### PR TITLE
fix(cli): write temp files to .totem/temp/ instead of os.tmpdir()

### DIFF
--- a/packages/cli/src/commands/shield.ts
+++ b/packages/cli/src/commands/shield.ts
@@ -245,7 +245,14 @@ export async function shieldCommand(options: ShieldOptions): Promise<void> {
   }
   console.error(`[${TAG}] Model: ${model}`);
 
-  const result = invokeShellOrchestrator(prompt, config.orchestrator.command, model, cwd, TAG);
+  const result = invokeShellOrchestrator(
+    prompt,
+    config.orchestrator.command,
+    model,
+    cwd,
+    TAG,
+    config.totemDir,
+  );
   writeOutput(result, options.out);
 
   if (options.out) {

--- a/packages/cli/src/commands/spec.ts
+++ b/packages/cli/src/commands/spec.ts
@@ -256,7 +256,14 @@ export async function specCommand(input: string, options: SpecOptions): Promise<
   }
   console.error(`[${TAG}] Model: ${model}`);
 
-  const result = invokeShellOrchestrator(prompt, config.orchestrator.command, model, cwd, TAG);
+  const result = invokeShellOrchestrator(
+    prompt,
+    config.orchestrator.command,
+    model,
+    cwd,
+    TAG,
+    config.totemDir,
+  );
   writeOutput(result, options.out);
 
   if (options.out) {

--- a/packages/cli/src/commands/triage.ts
+++ b/packages/cli/src/commands/triage.ts
@@ -247,7 +247,14 @@ export async function triageCommand(options: TriageOptions): Promise<void> {
   }
   console.error(`[${TAG}] Model: ${model}`);
 
-  const result = invokeShellOrchestrator(prompt, config.orchestrator.command, model, cwd, TAG);
+  const result = invokeShellOrchestrator(
+    prompt,
+    config.orchestrator.command,
+    model,
+    cwd,
+    TAG,
+    config.totemDir,
+  );
   writeOutput(result, options.out);
 
   if (options.out) {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -62,9 +62,10 @@ export function invokeShellOrchestrator(
   model: string,
   cwd: string,
   tag: string,
+  totemDir: string,
 ): string {
   const tmpName = `totem-${tag.toLowerCase()}-${crypto.randomBytes(TEMP_ID_BYTES).toString('hex')}.md`;
-  const tempDir = path.join(cwd, '.totem', 'temp');
+  const tempDir = path.join(cwd, totemDir, 'temp');
   fs.mkdirSync(tempDir, { recursive: true });
   const tempPath = path.join(tempDir, tmpName);
 


### PR DESCRIPTION
## Summary
- Gemini CLI's workspace security boundary blocks file reads from `os.tmpdir()`, causing `totem spec`, `totem shield`, and `totem triage` to fail when the orchestrator tries to read the prompt file
- Changed all three commands to write temp files to `cwd/.totem/temp/` (inside the consumer's working directory) so they stay within the allowed workspace
- Removed unused `node:os` import from all three files

## Test plan
- [x] `pnpm build` — clean compilation
- [x] `pnpm test` — all pass
- [x] `pnpm run format` — no changes needed
- [x] Pre-push hooks (format, lint, test) all green
- [ ] Run `totem spec 643` from satur8d repo to verify Gemini can now read the prompt file

🤖 Generated with [Claude Code](https://claude.com/claude-code)