### PR TITLE
fix(mcp): use synchronous FD for background sync log in add_lesson

### DIFF
--- a/packages/mcp/src/tools/add-lesson.ts
+++ b/packages/mcp/src/tools/add-lesson.ts
@@ -64,15 +64,18 @@ export function registerAddLesson(server: McpServer): void {
           const { cmd, args } = detectSyncCommand(projectRoot);
           const logPath = path.join(totemDir, 'mcp-sync.log');
           const logFd = fs.openSync(logPath, 'a');
-          const child = spawn(cmd, args, {
-            cwd: projectRoot,
-            detached: true,
-            stdio: ['ignore', logFd, logFd],
-            shell: true,
-            windowsHide: true,
-          });
-          child.unref();
-          fs.closeSync(logFd);
+          try {
+            const child = spawn(cmd, args, {
+              cwd: projectRoot,
+              detached: true,
+              stdio: ['ignore', logFd, logFd],
+              shell: true,
+              windowsHide: true,
+            });
+            child.unref();
+          } finally {
+            fs.closeSync(logFd);
+          }
 
           // Reconnect the store after the sync has had time to finish,
           // so the next search_knowledge call sees the new data.


### PR DESCRIPTION
## Summary

- `fs.createWriteStream` opens files asynchronously — its `fd` is `null` until the `'open'` event fires
- `spawn()` needs a valid FD immediately for the `stdio` option, causing a crash: `"The argument 'stdio' is invalid. Received WriteStream { fd: null ... }"`
- Replace with `fs.openSync()` to get a numeric FD synchronously, then `fs.closeSync()` in the parent after spawning (Node duplicates the FD for the child)

Fixes #57

## Test plan

- [x] `pnpm build` — clean
- [x] Called `add_lesson` via MCP — no crash, lesson persisted to `.totem/lessons.md`
- [x] Background sync triggered successfully
- [x] Pre-push hooks (format, lint, test) all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)