### PR TITLE
fix(ci): use RELEASE_TOKEN PAT for changesets action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,6 @@ jobs:
           version: pnpm version
           publish: pnpm release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Use `RELEASE_TOKEN` (fine-grained PAT) instead of `GITHUB_TOKEN` in the Release workflow
- The `mmnto-ai` org policy blocks `GITHUB_TOKEN` from creating PRs, which caused the `changesets/action` step to fail on every merge to `main`

Fixes the Release workflow failure from #61.

## Test plan

- [ ] Merge this PR → Release workflow should successfully create the "Version Packages" PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)