### PR TITLE
fix(ci): use `pnpm run version` to invoke changeset script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,8 @@ jobs:
       - name: Create Release PR or Publish
         uses: changesets/action@v1
         with:
-          version: pnpm version
-          publish: pnpm release
+          version: pnpm run version
+          publish: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Change `pnpm version` → `pnpm run version` and `pnpm release` → `pnpm run release` in the Release workflow
- `pnpm version` resolves to pnpm's built-in version command, not the `"version": "changeset version"` script in package.json — so the changeset was never consumed and no version bump PR was created

Follow-up to #63.

## Test plan

- [ ] Merge → Release workflow creates a "Version Packages" PR that bumps all 3 packages from `0.1.0` → `0.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)