### PR TITLE
fix(ci): switch to npm trusted publishing via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 
@@ -22,7 +23,6 @@ jobs:
         with:
           node-version: 20
           cache: pnpm
-          registry-url: https://registry.npmjs.org
 
       - run: pnpm install --frozen-lockfile
 
@@ -35,5 +35,3 @@ jobs:
           publish: pnpm run release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `id-token: write` permission to enable OIDC authentication with npm
- Remove `NPM_TOKEN`, `NODE_AUTH_TOKEN` env vars and `registry-url` — no longer needed with trusted publishing
- Trusted publishers configured on npmjs.com for `@mmnto/totem`, `@mmnto/cli`, `@mmnto/mcp`

Follow-up to #63 and #64. After merge, re-run the Release workflow to publish `0.2.0`.

## Test plan

- [ ] Merge → re-run Release workflow → all 3 packages publish `0.2.0` to npm via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)