### PR TITLE
fix(ci): add registry-url and upgrade npm for OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,8 +21,12 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - run: npm install -g npm@latest
+        name: Upgrade npm for OIDC support
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

- Restore `registry-url` in `setup-node` — required for OIDC token negotiation
- Add `npm install -g npm@latest` step — OIDC requires npm >= 11.5.1
- Bump to Node 22 for a more recent npm baseline

Follow-up to #66 (ENEEDAUTH failure).

## Test plan

- [ ] Merge → Release workflow publishes `0.2.0` to npm via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)