### PR TITLE
fix(core): auto-heal incremental sync when DB is empty

### DIFF
--- a/packages/core/src/ingest/pipeline.ts
+++ b/packages/core/src/ingest/pipeline.ts
@@ -15,7 +15,8 @@ export async function runSync(
   config: TotemConfig,
   options: SyncOptions,
 ): Promise<{ chunksProcessed: number; filesProcessed: number }> {
-  const { projectRoot, incremental, onProgress } = options;
+  const { projectRoot, onProgress } = options;
+  let incremental = options.incremental;
   const log = onProgress ?? (() => {});
 
   // 1. Create embedder
@@ -26,6 +27,12 @@ export async function runSync(
   const storePath = path.join(projectRoot, config.lanceDir);
   const store = new LanceStore(storePath, embedder);
   await store.connect();
+
+  // 2b. Auto-heal: force full sync when incremental is requested but DB is empty
+  if (incremental && (await store.isEmpty())) {
+    log('Empty database detected. Forcing full sync...');
+    incremental = false;
+  }
 
   // 3. Resolve files to process
   const allFiles = resolveFiles(config.targets, projectRoot, config.ignorePatterns, log);

--- a/packages/core/src/store/lance-store.ts
+++ b/packages/core/src/store/lance-store.ts
@@ -111,6 +111,12 @@ export class LanceStore {
     await this.connect();
   }
 
+  /** Return true if the table doesn't exist or has zero rows. */
+  async isEmpty(): Promise<boolean> {
+    if (!this.table) return true;
+    return (await this.table.countRows()) === 0;
+  }
+
   /** Return stats about the current index. */
   async stats(): Promise<{ totalChunks: number; byType: Record<string, number> }> {
     if (!this.table) return { totalChunks: 0, byType: {} };


### PR DESCRIPTION
## Summary
- When `.lancedb` is deleted and `totem sync` runs incrementally, the empty DB now triggers an automatic fallback to full sync instead of silently producing an empty index
- Adds `isEmpty()` helper to `LanceStore` that checks table existence and row count

Closes #40

## Test plan
- [x] `pnpm build` — clean
- [x] `pnpm run format` — clean
- [x] `pnpm test` — passing
- [x] Pre-push hooks (format, lint, test) — all green
- [x] `totem shield` — passed, no critical issues or warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)