### PR TITLE
feat: add native SessionStart hooks for dogfooding (#95)

### DIFF
--- a/docs/active_work.md
+++ b/docs/active_work.md
@@ -11,6 +11,66 @@ Our goal is to ensure that a user who installs Totem does not have to spend 20 m
 1. Upgrading `totem init` to auto-inject System Prompts into `CLAUDE.md`, `.gemini/gemini.md`, etc.
 2. Automating git hooks so `totem sync` runs in the background.
 
+## Dogfooding: Session Start Hooks
+
+We dogfood Totem inside this monorepo but **do not** run `totem init` here (it would overwrite development configs with production templates). Native execution hooks must be configured manually and kept in sync with the scaffolding logic in `packages/cli/src/commands/init.ts`.
+
+### Claude Code (`.claude/settings.local.json`)
+
+Add a `hooks` section alongside existing permissions:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node packages/cli/dist/index.js briefing",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+- `matcher: "startup"` fires only on new sessions (not resume/clear/compact)
+- Stdout is injected as context visible to Claude
+- Timeout is in seconds
+
+### Gemini CLI (`.gemini/settings.json`)
+
+Add a `hooks` section alongside existing MCP server config:
+
+```json
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "name": "totem-briefing",
+        "type": "command",
+        "command": "node packages/cli/dist/index.js briefing",
+        "timeout": 30000,
+        "description": "Load Totem session briefing on startup"
+      }
+    ]
+  }
+}
+```
+
+- Timeout is in milliseconds
+- Uses `GEMINI_PROJECT_DIR` env var for path resolution
+
+### Important Notes
+
+- Both configs are **gitignored** — they must be applied manually after a fresh clone.
+- The hooks point to compiled `dist/index.js` — run `pnpm build` in the CLI package before starting an agent session.
+- If the briefing command hangs (e.g., LLM API timeout), the agent startup may be delayed up to the configured timeout.
+
 ## Next Up
 
 After the Reflex Engine is robust, we will begin porting the workflow commands (`totem spec`, `totem shield`) for Epic #20 (The Workflow Orchestrator).


### PR DESCRIPTION
## Summary

- Configure native `SessionStart` hooks for Claude Code and Gemini CLI so `totem briefing` runs automatically on new sessions
- Both hook configs live in gitignored settings files (applied locally, not committable)
- Document the exact hook configurations in `docs/active_work.md` for manual sync after fresh clone

## Details

**Claude Code** (`.claude/settings.local.json`):
- Uses `SessionStart` event with `matcher: "startup"` (new sessions only, not resume/clear)
- Stdout is injected as context visible to Claude
- 30s timeout

**Gemini CLI** (`.gemini/settings.json`):
- Uses `SessionStart` event with `name: "totem-briefing"`
- 30000ms timeout (Gemini uses milliseconds)

**Documentation** (`docs/active_work.md`):
- Full JSON snippets for both tools
- Notes on gitignored files, build dependency, and timeout behavior

Closes #95

## Test plan

- [ ] Start a new Claude Code session in this repo — verify briefing output appears in initial context
- [ ] Start a new Gemini CLI session — verify briefing runs on startup
- [ ] Verify `--continue` / resume does NOT trigger the Claude hook (matcher = `startup` only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)