### PR TITLE
docs: update README, roadmap, and lessons for v0.7.0

### DIFF
--- a/.totem/lessons.md
+++ b/.totem/lessons.md
@@ -99,7 +99,7 @@ For rough diagnostic summaries or progress indicators, `string.length` is often 
 
 **Tags:** architecture, adapter-pattern, issue-tracker, pivot
 
-The IssueAdapter interface lives at `packages/cli/src/adapters/issue-adapter.ts` with `StandardIssue` and `StandardIssueListItem` types. The GitHub implementation is `GitHubCliAdapter` at `packages/cli/src/adapters/github-cli.ts`. Future issue tracker adapters (Jira, Linear) should implement the same interface. PR-related gh calls (briefing.ts, learn.ts) are NOT yet abstracted — they would need a separate PrAdapter interface.
+The IssueAdapter interface lives at `packages/cli/src/adapters/issue-adapter.ts` with `StandardIssue` and `StandardIssueListItem` types. The GitHub implementation is `GitHubCliAdapter` at `packages/cli/src/adapters/github-cli.ts`. PR-related functionality is similarly abstracted via `PrAdapter` at `packages/cli/src/adapters/pr-adapter.ts`. Future issue tracker adapters (Jira, Linear) should implement the same interface.
 
 ## Lesson — 2026-03-05T03:16:17.884Z
 
@@ -124,18 +124,6 @@ When adding error re-throw guards (like checking for `[Totem Error]` prefix befo
 **Tags:** regex, input-validation, trap
 
 When writing regex to parse user input (like GitHub URLs), always anchor with `^` and include the protocol (`https?://`). Unanchored regexes match substrings embedded in other text, which is almost never the intent for CLI input parsing.
-
-## Lesson — 2026-03-05T04:05:21.566Z
-
-**Tags:** detection, init, false-positive, trap
-
-When detecting tool presence via filesystem checks in `totem init`, use specific marker files (like `.cursorrules`, `.cursor/mcp.json`) — not bare directory existence checks (like `.cursor/`). Generic directory names cause false positives.
-
-## Lesson — 2026-03-05T04:11:55.046Z
-
-**Tags:** security, input-validation, env-injection, init, trap
-
-Any CLI command that writes user input to a file (.env, config, etc.) must sanitize at the boundary: strip newlines/carriage returns, validate format with a regex, and quote values. This is especially critical for .env files where newline injection creates arbitrary environment variables. Always treat interactive CLI input as untrusted, same as HTTP input.
 
 ## Lesson — 2026-03-05T04:32:16.597Z
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Totem is actively evolving from a memory database into a full Shift-Left orchest
 
 - [x] **Pillar 1: The Memory Layer** - Local vector DB, syntax-aware chunking, and MCP interface.
 - [x] **Pillar 2: The Reflex Engine** - Auto-injection of AI prompts, proactive learning triggers, and background git hooks. (See [Epic #19](https://github.com/mmnto-ai/totem/issues/19))
-- [ ] **Pillar 3: The Workflow Orchestrator** - Native CLI commands (`totem spec`, `totem shield`) for pre-work briefings and local PR reviews. (See [Epic #20](https://github.com/mmnto-ai/totem/issues/20))
-- [ ] **Pillar 4: Polish** - Automated memory consolidation and CLI UI/UX polish.
+- [x] **Pillar 3: The Workflow Orchestrator** - Native CLI commands (`totem spec`, `totem shield`, `totem triage`) for pre-work briefings and local PR reviews. (See [Epic #20](https://github.com/mmnto-ai/totem/issues/20))
+- [ ] **Pillar 4: Polish** - Automated memory consolidation, comprehensive test coverage, robust GitHub API handling, and CLI UI/UX polish.
 
 For a deeper dive into the system design, see `docs/architecture.md`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -22,7 +22,7 @@ The core embedded vector database, MCP server, and baseline CLI commands have be
 **Goal:** If users can't install Totem easily and don't trust what it does, advanced features won't matter. Make onboarding frictionless and the CLI feel premium.
 
 - [x] **#87 Auto-configure AI tools:** `totem init` scaffolds `.gemini/settings.json`, `CLAUDE.md`, and `.cursorrules` automatically.
-- [ ] **#89 UX Polish for `totem init`:** Fix double-prompting and print clean success summaries so developers trust the onboarding.
+- [x] **#89 UX Polish for `totem init`:** Fix double-prompting and print clean success summaries so developers trust the onboarding.
 - [ ] **#86 Seamless Host Integration:** Build the `SessionStart` hooks, Claude custom commands, and `Totem Architect` skills that #87 installs.
 - [ ] **#21 CLI UI/UX Polish:** Swap generic `console.log` for `@clack/prompts` and `ora` spinners.
 - [ ] **#12 Cross-platform onboarding:** Ensure docs and installers work flawlessly across Windows (PowerShell) and macOS.
@@ -32,9 +32,9 @@ The core embedded vector database, MCP server, and baseline CLI commands have be
 **Goal:** Before ingesting enterprise databases, the local vector index and LLM prompts must be bulletproof across all environments.
 
 - [x] **#80 Security: Add XML delimiting:** Close the prompt injection gap in orchestrator commands.
-- [ ] **#91 Normalize LanceDB paths:** Fix Windows backslash issues before users share `.lancedb` folders across OS boundaries.
-- [ ] **#90 Refactor to `IssueAdapter`:** Extract `gh` CLI logic into an interface to decouple from GitHub.
-- [ ] **#77 Test audit:** Backfill CLI unit tests using the newly added Vitest infrastructure.
+- [x] **#91 Normalize LanceDB paths:** Fix Windows backslash issues before users share `.lancedb` folders across OS boundaries.
+- [x] **#90 Refactor to `IssueAdapter` / `PrAdapter`:** Extract `gh` CLI logic into interfaces to decouple from GitHub.
+- [x] **#77 Test audit:** Backfill CLI unit tests using the newly added Vitest infrastructure. (103+ tests passing)
 - [ ] **#78 Shell escaping edge cases:** Validate `execSync` safety with PowerShell as default shell.
 
 ## Phase 3: Workflow Expansion (Power User Tools)
@@ -44,7 +44,7 @@ The core embedded vector database, MCP server, and baseline CLI commands have be
 - [ ] **#44 `totem bridge`:** Build a mid-session context compaction tool to clear token windows without losing place.
 - [ ] **#74 `totem oracle`:** Add a frictionless Q&A command to query LanceDB without strict personas.
 - [ ] **#92 Telemetry Logging & Dashboard:** Persist token stats to `.totem/telemetry.jsonl` and build `totem stats` to track API quota usage.
-- [ ] **#83 Support GitHub issue URLs:** Allow users to paste full URLs in addition to issue numbers for `totem spec` and `triage`.
+- [x] **#83 Support GitHub issue URLs:** Allow users to paste full URLs in addition to issue numbers for `totem spec` and `triage`.
 - [ ] **#23 Automated Memory Consolidation:** Command (`totem consolidate`) to clean up and merge old lessons.
 
 ## Phase 4: Enterprise Expansion


### PR DESCRIPTION
## Summary
- Mark Pillar 3 complete in README, update Pillar 4 description
- Check off completed roadmap items (#89, #91, #90, #77, #83)
- Update adapter lesson to reflect PrAdapter, prune stale lessons