### PR TITLE
Version Packages — v0.14.0

### DIFF
--- a/.changeset/mvc-config-tiers.md
+++ b/.changeset/mvc-config-tiers.md
@@ -1,7 +1,0 @@
----
-'@mmnto/totem': minor
-'@mmnto/cli': minor
-'@mmnto/mcp': minor
----
-
-Minimum viable configuration tiers (Lite/Standard/Full). Embedding is now optional — Lite tier works with zero API keys. Auto-detects OPENAI_API_KEY during `totem init`.

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @mmnto/cli
 
+## 0.14.0
+
+### Minor Changes
+
+- 171a810: Minimum viable configuration tiers (Lite/Standard/Full). Embedding is now optional — Lite tier works with zero API keys. Auto-detects OPENAI_API_KEY during `totem init`.
+
+### Patch Changes
+
+- Updated dependencies [171a810]
+  - @mmnto/totem@0.14.0
+
 ## 0.13.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmnto/cli",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "CLI for Totem — AI persistent memory and context layer",
   "type": "module",
   "bin": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @mmnto/totem
 
+## 0.14.0
+
+### Minor Changes
+
+- 171a810: Minimum viable configuration tiers (Lite/Standard/Full). Embedding is now optional — Lite tier works with zero API keys. Auto-detects OPENAI_API_KEY during `totem init`.
+
 ## 0.13.0
 
 ## 0.12.0

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmnto/totem",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "Persistent memory and context layer for AI agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @mmnto/mcp
 
+## 0.14.0
+
+### Minor Changes
+
+- 171a810: Minimum viable configuration tiers (Lite/Standard/Full). Embedding is now optional — Lite tier works with zero API keys. Auto-detects OPENAI_API_KEY during `totem init`.
+
+### Patch Changes
+
+- Updated dependencies [171a810]
+  - @mmnto/totem@0.14.0
+
 ## 0.13.0
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmnto/mcp",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "MCP server for Totem — AI persistent memory and context layer",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Bumps all three packages to `0.14.0`:
- `@mmnto/totem` — minor (config tiers, `requireEmbedding` guard)
- `@mmnto/cli` — minor (auto-detect embedding tier, Ollama prompt, Lite tier support)
- `@mmnto/mcp` — minor (uses centralized `requireEmbedding` from core)

## What's New

Minimum viable configuration tiers (Lite/Standard/Full). Embedding is now optional — Lite tier works with zero API keys. Auto-detects `OPENAI_API_KEY` during `totem init`.