### PR TITLE
chore: sync lessons and triage after v0.15.0 release

### DIFF
--- a/.totem/lessons.md
+++ b/.totem/lessons.md
@@ -538,3 +538,63 @@ Verify fixed collections of assets with exact count assertions (e.g., `toBe(10)`
 **Tags:** clean-code, design-decision
 
 For static, small sets of string comparisons (like 'y/n' prompt responses), explicit boolean `OR` checks are often more idiomatic and readable than `[].includes()` patterns. Avoid over-engineering simple branching logic if the set of possible values is not expected to grow.
+
+## Lesson — 2026-03-08T02:39:04.901Z
+
+**Tags:** scaffolding, error-handling, architecture
+
+Prefer graceful degradation with a warning over halting for non-critical scaffolding tasks during initialization. Unlike core orchestrator commands where partial failure is risky, setup steps should be resilient to recoverable environment issues like file permissions to ensure a smooth onboarding experience.
+
+## Lesson — 2026-03-08T02:39:04.901Z
+
+**Tags:** search, indexing, documentation
+
+Avoid generic headings for knowledge chunks as they result in indistinguishable labels in search results and UI components. Use descriptive, unique headings to ensure both humans and AI can differentiate between related lessons during context assembly.
+
+## Lesson — 2026-03-08T02:39:04.901Z
+
+**Tags:** testing, quality-assurance
+
+Use exact count assertions rather than "greater than" checks when verifying fixed sets of assets or features. Precise assertions detect accidental deletions that range-based checks would miss, ensuring the integrity of curated content.
+
+## Lesson — 2026-03-08T02:39:04.901Z
+
+**Tags:** windows, shell, performance
+
+Use temporary files instead of CLI arguments or environment variables when passing large data (like prompts) to sub-processes on Windows to avoid "argument list too long" errors.
+
+## Lesson — 2026-03-08T02:39:04.901Z
+
+**Tags:** async, performance, error-handling
+
+For background maintenance tasks with small expected workloads (e.g., cleaning 0-5 files), prefer sequential `for...of` loops over `Promise.all`. Sequential processing simplifies error isolation, allowing you to "swallow and continue" on a per-item basis without the complexity of `Promise.allSettled`.
+
+## Lesson — 2026-03-08T02:39:04.901Z
+
+**Tags:** architecture, configuration, cli
+
+Avoid introducing asynchronous configuration loading or complex resolution logic into non-critical fire-and-forget utilities if those parameters are not yet user-configurable. Keeping background tasks hardcoded and "best-effort" prevents over-engineering and ensures the CLI startup path remains lean and fast.
+
+## Lesson — 2026-03-08T02:39:04.901Z
+
+**Tags:** security, git, trap
+
+Always use the `--` separator before positional arguments in git commands (e.g., `git log -- <ref>`) to protect against argument injection. This ensures that potentially untrusted strings, such as branch or tag names, are never interpreted as command-line flags.
+
+## Lesson — 2026-03-08T02:39:04.901Z
+
+**Tags:** error-handling, architecture, design-decision
+
+Use named error objects (e.g., `err.name = 'NoDocsConfiguredError'`) instead of string matching to handle expected "graceful skip" conditions in orchestrators. This creates a stable contract between modules that remains robust even if the user-facing error message is updated for better readability.
+
+## Lesson — 2026-03-08T02:39:04.901Z
+
+**Tags:** architecture, consistency, design-decision
+
+Prioritize codebase-wide consistency for established utility patterns (like `shell: IS_WIN` for Windows execution) over local "fixes" in a single PR. Core architectural or security shifts should be handled as dedicated global refactors to avoid fragmented and confusing helper implementations across the codebase.
+
+## Lesson — 2026-03-08T02:39:04.901Z
+
+**Tags:** pragmatism, design-decision, logging
+
+Avoid over-engineering cosmetic log summaries, such as using frequency maps for a simple `+N/-M` line-change count, if basic `Set`-based logic provides sufficient visual feedback. Prioritize simplicity and functional correctness over perfect accuracy for non-critical console output.

--- a/docs/active_work.md
+++ b/docs/active_work.md
@@ -1,61 +1,34 @@
 ### Active Work Summary
 
-Totem has completed Phase 2 (Core Stability), Minimum Viable Configuration tiers (#187), Universal Baselines (#128), temp file cleanup (#108), and automated doc sync (#190). The project is now in Phase 3 (Workflow Expansion), focused on power-user tools and usability improvements. A v0.15.0 release is imminent, bundling all three recent features.
+Foundations, Phase 1 (Onboarding), and Phase 2 (Core Stability) are functionally complete, establishing the Turborepo architecture, syntax-aware chunking, and local data stores. Recent momentum has shifted toward validating the core embedding pipeline (OpenAI) to enable internal dogfooding and wrapping up remaining interactive onboarding tasks before moving into Phase 3 workflow expansions.
 
 ### Prioritized Roadmap
 
-**Do Next (Phase 1: Onboarding & Polish — remaining items)**
+**Do Next (Critical Path & Validation)**
 
-- #129 — Epic: Interactive CLI Tutorial & Conversational Onboarding — Crucial next step for guiding users through the initial learning curve to build trust.
-- #126 — Epic: Invisible Orchestration & Auto-Triggering (The 'Init and Forget' Protocol) — Automates the core value loop immediately after onboarding.
-- #12 — Cross-platform onboarding: support Windows (PowerShell) & macOS in all docs — Ensures the onboarding process is seamless regardless of the user's OS.
+- #4 — Validate OpenAI Embedding Provider (Happy Path) — P1 validation required to ensure core embedding functionality is actually working for end users.
+- #8 — Validate dogfood sync with OpenAI embeddings — P1 dogfooding necessary to prove out the system's core value proposition and ingestion stability.
 
-**Up Next (Phase 3: Core Workflows & Usability)**
+**Up Next (Adoption & Polish)**
 
-- #181 — Feature: Drift Detection (Self-Cleaning Memory) — Detects and prunes stale lessons automatically to maintain memory quality.
-- #178 — Epic: Clipboard/Export UI for "Freemium Hoppers" — Broadens accessibility for users who aren't ready to fully integrate MCP.
-- #179 — Epic: Markdown/Document-Only Mode — Expands the addressable market to non-code, documentation-only use cases.
-- #110 — Enhancement: Make markdown chunker MAX_SPLIT_DEPTH configurable — A straightforward configurability win for core functionality.
-- #130 — Epic: Database Observability & Management (`totem inspect`) — Visualizing index health to build trust in the embedded vector database.
-- #119 — Epic: Custom Workflow Runner (`totem run <workflow>`) — Introduces an AI task runner for user-defined markdown workflows.
-- #92 — Feature: Telemetry Logging and Local Dashboard (`totem stats`) — Tracks API quota usage locally.
-- #74 — Feature: Add `totem oracle` command for general knowledge querying — Frictionless Q&A against the vector database.
-- #23 — Feature: Automated Memory Consolidation (`totem consolidate`) — Provides a command to clean up and merge old lessons.
+- #129 — Epic: Interactive CLI Tutorial & Conversational Onboarding — Specifically flagged in the active work roadmap to finish Phase 1 polish.
+- #12 — Cross-platform onboarding: support Windows (PowerShell) & macOS in all docs — Removes immediate setup friction for new users.
 
-**Backlog (Phase 4: Enterprise Expansion & Advanced Architecture)**
+**Backlog (Phase 3 Workflow Expansion)**
 
-- #198 — RFC: Open Core & Defensive Licensing Strategy (MIT vs. Fair Source) — Strategic foundation for open-source and enterprise scaling.
-- #195 — Epic: Model Compatibility & Auditing Strategy — Framework for supporting diverse AI models and tracking their performance.
-- #196 — Build Adversarial Evaluation Harness for CI (Model Drift Mitigation) — Advanced CI workflow for testing model stability.
-- #193 — Epic: Agent-to-Agent Handoff Patterns (The Synthesis Artifact) — Advanced agent workflow orchestration patterns.
-- #183 — RFC: Cross-File Knowledge Graph (Symbol Resolution) — Complex architectural enhancement for deeper AI context.
-- #182 — RFC: Tree-sitter Multi-Language Support (Python/Rust) — Language expansion slated for enterprise deployment.
-- #176 — Epic: Agent-Optimized MCP (Dynamic Token Budgeting & Write Access) — Advanced MCP capabilities for autonomous agents.
-- #175 — Epic: Multiplayer Cache Syncing — Collaborative features dependent on federated architecture.
-- #154 — epic: Sandbox Compatibility & Path Normalization (Stream Crossing) — Platform stability and stream management for diverse environments.
-- #144 — epic: Refine AI PR Review Posture & Noise Reduction — Improved review loop tuning and signal-to-noise ratio.
-- #124 — Epic: Automated Onboarding Protocols (`totem onboard`) — Tailored Day 1 briefings for new developers joining a team.
-- #123 — Epic: Federated Memory (Mothership Pattern) — Allows inheriting meta-lessons or team-wide policies from upstream indexes.
-- #84 — Epic: Issue Tracking System Adapters (Jira, Linear, etc.) — Enterprise integrations for linking lessons directly to tickets.
-- #79 — Epic: Documentation Ingestion Pipeline & Adapters — Ingesting internal wikis like Notion and Confluence.
-- #42 — Epic: Solve Universal AI DevEx Friction (Hallucinations, Scope Creep, Testing) — Evolving init guardrails for universal best practices.
-- #34 — Feature: Configurable Governance and Traction Points (AI Review Loops) — Enterprise governance configurations for controlling AI autonomy.
+- #119 — Epic: Custom Workflow Runner (`totem run <workflow>`) — Sets the foundation for power-user capabilities.
+- #176 — Epic: Agent-Optimized MCP (Dynamic Token Budgeting & Write Access) — Crucial for deepening agent-to-agent interactions.
+- #183 — RFC: Cross-File Knowledge Graph (Symbol Resolution) — The next major architectural leap for codebase comprehension.
 
 ### Next Issue (User Story & Scope)
 
-**#129 — Epic: Interactive CLI Tutorial & Conversational Onboarding**
+**#4 — Validate OpenAI Embedding Provider (Happy Path)**
 
-**User Story:** As a new user installing Totem, I want an interactive, animated CLI tutorial so that I can immediately understand the core workflows and how to ask contextual questions without needing to read external documentation.
-
-**Scope Boundaries:**
-
-- **DO:** Build an interactive, step-by-step CLI tutorial (`totem tutorial`).
-- **DO:** Allow users to pause the walkthrough, ask the LLM contextual questions about their codebase, and resume seamlessly.
-- **DO NOT:** Introduce any new core CLI commands or concepts that aren't already part of the Phase 1 MVP.
-- **DO NOT:** Build any web-based or graphical UI components; this must be entirely terminal-driven.
-- **Why Next:** With "Universal Baselines" shipped, the interactive tutorial is the critical missing piece of the "Magic" onboarding experience. It bridges the gap between installation and confident daily use, ensuring users don't abandon the tool immediately after `totem init`.
+- **User Story:** As an end user, I want the default OpenAI embedding provider to work flawlessly upon initial setup so that my codebase is successfully ingested and searchable without silent failures.
+- **Scope:** Strictly test and fix the happy-path execution of the existing `openai-embedder.ts`. Ensure environment variables are read correctly, payload requests succeed, and vectors are returned properly to the chunker. DO NOT add support for new models, DO NOT refactor the LanceDB storage layer, and DO NOT build advanced retry mechanisms yet.
+- **Why Next:** Core embedding stability is a prerequisite for all advanced features and internal dogfooding. We cannot proceed to Phase 3 if the foundational pipeline is unverified.
 
 ### Blocked / Needs Input
 
-- #4 — Validate OpenAI Embedding Provider (Happy Path) — Pending validation steps for OpenAI embedding integration.
-- #8 — Validate dogfood sync with OpenAI embeddings — Pending validation steps, heavily dependent on the completion of #4.
+- #198 — RFC: Open Core & Defensive Licensing Strategy (MIT vs. Fair Source) — Requires strategic business and legal decisions before any actionable work can begin.
+- #183 — RFC: Cross-File Knowledge Graph (Symbol Resolution) — Needs architectural consensus on the symbol resolution strategy before technical implementation.


### PR DESCRIPTION
## Summary

- Extract 10 lessons from PRs #197, #199, #200
- Regenerate triage roadmap in `docs/active_work.md`

Post-release housekeeping — no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)