### PR TITLE
docs: cross-platform onboarding (Windows, macOS, Linux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,16 @@ jobs:
 - **Path separators:** `totem.config.ts` uses forward slashes (`src/**/*.ts`) on all platforms. Do not use backslashes in glob patterns.
 - **Environment variables:** `totem init` writes your `OPENAI_API_KEY` to a `.env` file, so no need to set `export` or `$env:` manually.
 
+### Advanced: Pinning the MCP Server Version
+
+The default `npx -y @mmnto/mcp` setup always uses the latest version. For teams that need deterministic builds, you can pin the version by installing it as a dev dependency:
+
+```bash
+pnpm add -D @mmnto/mcp
+```
+
+Then remove the `-y` flag from your MCP config — `npx` will use the locally installed version instead of fetching from the registry.
+
 ### macOS / Linux
 
 - **Ollama:** If using Ollama for embeddings, ensure it is installed and running (`ollama serve`) before `totem sync`.


### PR DESCRIPTION
## Summary

- Add **Prerequisites** section with platform-agnostic install links (Node, pnpm, gh CLI)
- Split MCP server config (Section 4) into **macOS/Linux** vs **Windows** variants with explanation of the `cmd /c` wrapper requirement
- Add **Platform Notes** section covering git hooks, path separators, env vars (Windows) and Ollama setup (macOS)
- Update Shield GitHub Action example to use `@v0` tag (now auto-updated on publish)

Closes #12

## Test plan

- [x] All pre-push checks pass (format, lint, 330 tests)
- [x] Verified `totem init` already generates correct Windows MCP config via `buildNpxCommand`
- [x] README renders correctly in markdown preview
- [ ] Manual: copy-paste Windows MCP config into Claude Code on Windows to verify connectivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)