### PR TITLE
chore: post-release sync — lessons, docs, roadmap after v0.17.0

### DIFF
--- a/.totem/lessons.md
+++ b/.totem/lessons.md
@@ -620,3 +620,27 @@ Avoid over-engineering cosmetic log summaries, such as using frequency maps for 
 **Tags:** security, terminal-injection, cli
 
 Sanitize ANSI escape sequences from user-provided text before persisting it to local Markdown files or logs (like `lessons.md`). This prevents terminal injection vulnerabilities where viewing the file with tools like `cat` could execute malicious or disruptive control sequences in the user's terminal environment.
+
+## Lesson — Sanitize all strings extracted from files before displaying…
+
+**Tags:** security, terminal, cli
+
+Sanitize all strings extracted from files before displaying them in terminal outputs or interactive prompts. This prevents terminal injection attacks where malicious ANSI escape sequences in the source file could be used to spoof the UI or trick the user.
+
+## Lesson — When extracting patterns like file paths from Markdown…
+
+**Tags:** regex, markdown, parsing, trap
+
+When extracting patterns like file paths from Markdown content, explicitly filter out triple-backtick code blocks before running the extraction logic. This prevents false positives by ensuring the parser does not mistake code examples or documentation within the body for active file references.
+
+## Lesson — For machine-generated files with a strictly controlled…
+
+**Tags:** parsing, architecture, design-decision
+
+For machine-generated files with a strictly controlled schema, prefer strict positional parsing over global scanning. Strict parsing is more resilient than "fuzzy" scanning because it avoids accidental matches of keywords (like "Tags:") that may legitimately appear inside the body text of a lesson.
+
+## Lesson — When re-throwing errors in a CLI orchestrator, always…
+
+**Tags:** error-handling, style-guide
+
+When re-throwing errors in a CLI orchestrator, always include the project's standard error prefix (e.g., `[Totem Error]`) in the message. This ensures a consistent user experience and allows the system to clearly distinguish between internal application errors and raw system/library failures.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ When you're three levels deep in a debugging session, you need to know if the co
 - **Local-First & Git-Native:** Memory shouldn't be locked in a cloud SaaS. Totem compiles an embedded LanceDB vector index right inside your project (`.lancedb/`). The actual knowledge is stored in a human-readable, version-controlled `.totem/lessons.md` file. Review your AI's memory in your PRs.
 - **The Reflex Engine:** Totem doesn't just give your AI a database; it gives them _reflexes_. `totem init` auto-injects behavioral triggers and **Defensive Context Management Reflexes** (#160) into your AI's system prompts (`CLAUDE.md`, `.cursorrules`), forcing them to autonomously document traps, query architecture, and issue warnings before they write code.
 - **Multi-Agent Orchestration:** Use Claude to write code, Gemini to review PRs, and a local DeepSeek model for fast checks. Totem acts as the "Shared Brain" and workflow orchestrator (via `totem spec`) for your entire AI org chart.
-- **Built for Enterprise Scale:** The ingestion pipeline streams chunks in batches directly to the local vector store (#104), maintaining a flat memory footprint regardless of how massive your monorepo gets. Features like **Drift Detection** (#177) ensure your memory stays self-cleaning and relevant as the codebase evolves.
+- **Built for Enterprise Scale:** The ingestion pipeline streams chunks in batches directly to the local vector store (#104), maintaining a flat memory footprint regardless of how massive your monorepo gets. Features like **Drift Detection** (#177, #211) ensure your memory stays self-cleaning and relevant as the codebase evolves.
 
 ## Philosophy: The Unix Approach to AI
 
@@ -50,7 +50,7 @@ This is a Turborepo monorepo consisting of:
 - **pnpm** _(recommended)_ — `corepack enable` or see other methods at [pnpm.io/installation](https://pnpm.io/installation)
 - **GitHub CLI (`gh`)** _(optional, for orchestrator commands)_ — [cli.github.com](https://cli.github.com/)
 
-Totem works on **Windows**, **macOS**, and **Linux**. On Windows, Git Bash (bundled with [Git for Windows](https://gitforwindows.org/)) is recommended but not required — PowerShell and CMD work too.
+Totem works on **Windows**, **macOS**, and **Linux** (#210). On Windows, Git Bash (bundled with [Git for Windows](https://gitforwindows.org/)) is recommended but not required — PowerShell and CMD work too.
 
 ## Getting Started
 
@@ -94,7 +94,7 @@ _(Note: If you accepted the git hook installation during `init`, Totem will auto
 
 #### Drift Detection (Self-Cleaning Memory)
 
-Over time, lessons in `.totem/lessons.md` can reference files or paths that no longer exist. Use `--prune` to detect and interactively remove stale lessons:
+Over time, lessons in `.totem/lessons.md` can reference files or paths that no longer exist. Use `--prune` to detect and interactively remove stale lessons (#211):
 
 ```bash
 npx @mmnto/cli sync --prune
@@ -235,9 +235,9 @@ Then remove the `-y` flag from your MCP config — `npx` will use the locally in
 
 Totem is evolving from a memory database into a full Shift-Left orchestrator.
 
-- [x] **Pillar 1: The Memory Layer** - Local vector DB, tree-sitter syntax-aware chunking, and MCP interface.
-- [x] **Pillar 2: The Reflex Engine** - Auto-injection of AI prompts, proactive learning triggers, and background git hooks.
-- [x] **Pillar 3: The Workflow Orchestrator** - Native CLI commands (`spec`, `shield`, `triage`, `docs`, `wrap`) for pre-work briefings and local PR reviews.
-- [ ] **Pillar 4: Polish** - OpenAI embedding validation (#4), interactive tutorials (#129), cross-platform stability (Windows/macOS), and automated memory consolidation. Drift Detection (`sync --prune`) for self-cleaning memory (#181).
+- [x] **Foundations & Phase 1 (Onboarding):** Local vector DB, MCP interface, MVC Configuration Tiers (#187), "Universal Lessons" baseline (#128), and cross-platform docs (#210).
+- [x] **Phase 2 (Core Stability):** Tree-sitter Universal AST Parsing (#173), Shield GitHub Action (#180), Automated Doc Sync (#190), and Drift Detection for self-cleaning memory (#177, #211).
+- [ ] **Validation & Polish:** OpenAI embedding validation (#4), internal dogfooding (#8), and interactive CLI tutorials (#129).
+- [ ] **Phase 3 (Workflow Expansion):** Custom Workflow Runner (#119), Agent-Optimized MCP (#176), and Cross-File Knowledge Graph (#183).
 
 For a deeper dive into the system design, see `docs/architecture.md`.

--- a/docs/active_work.md
+++ b/docs/active_work.md
@@ -1,6 +1,6 @@
 ### Active Work Summary
 
-Foundations, Phase 1 (Onboarding), and Phase 2 (Core Stability) are functionally complete, establishing the Turborepo architecture, syntax-aware chunking (now powered by Tree-sitter #173), and local data stores. Recent momentum has delivered the Shield GitHub Action (#180), Drift Detection (#177), Automated Doc Sync (#190), MVC Configuration Tiers (#187), and a "Universal Lessons" baseline (#128). Focus is now shifting toward validating the core OpenAI embedding pipeline (#4) to enable internal dogfooding (#8) and completing interactive onboarding polish before scaling Phase 3 workflow expansions.
+Foundations, Phase 1 (Onboarding), and Phase 2 (Core Stability) are functionally complete, establishing the Turborepo architecture, syntax-aware chunking (now powered by Tree-sitter #173), and local data stores. Recent momentum has delivered the Shield GitHub Action (#180), Drift Detection (#177, #211), Automated Doc Sync (#190), MVC Configuration Tiers (#187), a "Universal Lessons" baseline (#128), and Cross-Platform Onboarding (#210). Focus is now shifting toward validating the core OpenAI embedding pipeline (#4) to enable internal dogfooding (#8) and completing interactive onboarding polish before scaling Phase 3 workflow expansions.
 
 ### Prioritized Roadmap
 
@@ -12,7 +12,6 @@ Foundations, Phase 1 (Onboarding), and Phase 2 (Core Stability) are functionally
 **Up Next (Adoption & Polish)**
 
 - #129 — Epic: Interactive CLI Tutorial & Conversational Onboarding — Specifically flagged in the active work roadmap to finish Phase 1 polish.
-- #12 — Cross-platform onboarding: support Windows (PowerShell) & macOS in all docs — Removes immediate setup friction for new users.
 
 **Backlog (Phase 3 Workflow Expansion)**
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,7 +28,7 @@ The core embedded vector database, MCP server, and baseline CLI commands have be
 - [ ] **#125 Epic: Invisible Orchestration:** Audit AI model hooks and Git hooks to trigger `shield`, `sync`, and `handoff` automagically, achieving a "run `init` and forget" workflow.
 - [x] **#86 Seamless Host Integration:** Build the `SessionStart` hooks, Claude custom commands, and `Totem Architect` skills that #87 installs.
 - [x] **#21 CLI UI/UX Polish:** Branded colors (picocolors), ora spinners, ASCII banner. @clack/prompts multiselect shipped in v0.13.0 (#168).
-- [ ] **#12 Cross-platform onboarding:** Ensure docs and installers work flawlessly across Windows (PowerShell) and macOS.
+- [x] **#12 Cross-platform onboarding:** Ensure docs and installers work flawlessly across Windows (PowerShell), macOS, and Linux.
 
 ## Phase 2: Core Stability & Data Safety (Functionally Complete)
 


### PR DESCRIPTION
## Summary\n\n- 4 new lessons extracted from PR #211 (sanitization, code fence handling, strict parsing, error prefix)\n- README, roadmap, and active_work updated by `totem docs`\n\nRoutine post-release sync — no code changes.