### PR TITLE
security: add ReDoS protection to compiled regex rules

### DIFF
--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -173,8 +173,9 @@ export async function compileCommand(options: CompileOptions): Promise<void> {
       continue;
     }
 
-    if (!validateRegex(parsed.pattern)) {
-      log.warn(TAG, `[${lesson.heading}] Invalid regex: ${parsed.pattern} — skipping`);
+    const validation = validateRegex(parsed.pattern);
+    if (!validation.valid) {
+      log.warn(TAG, `[${lesson.heading}] Rejected regex: ${validation.reason} — skipping`);
       failed++;
       continue;
     }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
     "openai": "^4.77.0",
     "remark-frontmatter": "^5.0.0",
     "remark-parse": "^11.0.0",
+    "safe-regex2": "^5.0.0",
     "typescript": "^5.7.0",
     "unified": "^11.0.0",
     "yaml": "^2.4.0",

--- a/packages/core/src/compiler.test.ts
+++ b/packages/core/src/compiler.test.ts
@@ -40,19 +40,46 @@ describe('hashLesson', () => {
 
 describe('validateRegex', () => {
   it('accepts a valid regex', () => {
-    expect(validateRegex('\\bfoo\\b')).toBe(true);
+    expect(validateRegex('\\bfoo\\b')).toEqual({ valid: true });
   });
 
   it('accepts a simple string pattern', () => {
-    expect(validateRegex('console.log')).toBe(true);
+    expect(validateRegex('console.log')).toEqual({ valid: true });
+  });
+
+  it('accepts a complex but safe pattern', () => {
+    // Anchored API key format — complex but not vulnerable
+    expect(validateRegex('^[A-Za-z0-9]{32,}$')).toEqual({ valid: true });
   });
 
   it('rejects an invalid regex', () => {
-    expect(validateRegex('[invalid')).toBe(false);
+    const result = validateRegex('[invalid');
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('invalid syntax');
   });
 
   it('rejects unbalanced parentheses', () => {
-    expect(validateRegex('(unclosed')).toBe(false);
+    const result = validateRegex('(unclosed');
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('invalid syntax');
+  });
+
+  it('rejects ReDoS pattern: nested quantifiers (a+)+', () => {
+    const result = validateRegex('(a+)+$');
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('ReDoS vulnerability detected');
+  });
+
+  it('rejects ReDoS pattern: nested character class quantifiers ([a-zA-Z]+)*', () => {
+    const result = validateRegex('([a-zA-Z]+)*');
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('ReDoS vulnerability detected');
+  });
+
+  it('rejects ReDoS pattern: nested repetition (.*a){10}', () => {
+    const result = validateRegex('(.*a){10}');
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('ReDoS vulnerability detected');
   });
 });
 

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -1,6 +1,7 @@
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 
+import safeRegex from 'safe-regex2';
 import { z } from 'zod';
 
 // ─── Schemas ─────────────────────────────────────────
@@ -57,14 +58,27 @@ export function hashLesson(heading: string, body: string): string {
 
 // ─── Regex validation ────────────────────────────────
 
-/** Validate that a pattern string is a syntactically valid RegExp. */
-export function validateRegex(pattern: string): boolean {
+export interface RegexValidation {
+  valid: boolean;
+  reason?: string;
+}
+
+/**
+ * Validate that a pattern string is a syntactically valid RegExp
+ * and is not vulnerable to ReDoS (catastrophic backtracking).
+ */
+export function validateRegex(pattern: string): RegexValidation {
   try {
     new RegExp(pattern);
-    return true;
   } catch {
-    return false;
+    return { valid: false, reason: 'invalid syntax' };
   }
+
+  if (!safeRegex(pattern)) {
+    return { valid: false, reason: 'ReDoS vulnerability detected' };
+  }
+
+  return { valid: true };
 }
 
 // ─── Diff parsing ────────────────────────────────────

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -72,6 +72,7 @@ export {
   hashLesson,
   loadCompiledRules,
   parseCompilerResponse,
+  type RegexValidation,
   saveCompiledRules,
   validateRegex,
 } from './compiler.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,6 +87,9 @@ importers:
       remark-parse:
         specifier: ^11.0.0
         version: 11.0.0
+      safe-regex2:
+        specifier: ^5.0.0
+        version: 5.0.0
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -3298,6 +3301,11 @@ packages:
       signal-exit: 4.1.0
     dev: false
 
+  /ret@0.5.0:
+    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
+    engines: {node: '>=10'}
+    dev: false
+
   /reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -3356,6 +3364,12 @@ packages:
     dependencies:
       queue-microtask: 1.2.3
     dev: true
+
+  /safe-regex2@5.0.0:
+    resolution: {integrity: sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==}
+    dependencies:
+      ret: 0.5.0
+    dev: false
 
   /safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}


### PR DESCRIPTION
## Summary
- Integrate `safe-regex2` for compile-time static analysis of LLM-generated regex patterns
- Vulnerable patterns (nested quantifiers, star height > 1) are rejected at compile time and marked as non-compilable, gracefully falling back to LLM evaluation
- `validateRegex` now returns `{ valid: boolean, reason?: string }` for better diagnostics in compilation logs
- 4 new ReDoS-specific tests added to compiler test suite

## Changes
- `packages/core/src/compiler.ts` — Import `safe-regex2`, update `validateRegex` return type + ReDoS check
- `packages/core/src/compiler.test.ts` — Tests for `(a+)+$`, `([a-zA-Z]+)*`, `(.*a){10}` rejection + safe pattern acceptance
- `packages/core/src/index.ts` — Export `RegexValidation` type
- `packages/cli/src/commands/compile.ts` — Update caller to use `validation.valid` and log `validation.reason`
- `packages/core/package.json` + `pnpm-lock.yaml` — Add `safe-regex2` dependency

## Test plan
- [x] Known ReDoS patterns rejected with descriptive reason
- [x] Safe patterns (anchored, simple quantifiers) still accepted
- [x] Invalid syntax still caught before ReDoS check
- [x] All 390 tests pass (155 core + 235 CLI)

Closes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)