### PR TITLE
Version Packages v0.18.0

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @mmnto/cli
 
+## 0.18.0
+
+### Minor Changes
+
+- feat: async orchestrator and ReDoS protection
+  - Refactored shell orchestrator from `execSync` to async `spawn` with streaming stdout/stderr, 50MB safety cap, and proper timeout handling (#206)
+  - Added compile-time ReDoS static analysis via `safe-regex2` — vulnerable regex patterns are rejected during `totem compile` with diagnostic reasons (#218)
+  - Graceful per-doc error handling in `totem docs` — a single doc failure no longer aborts the entire batch
+
+### Patch Changes
+
+- Updated dependencies
+  - @mmnto/totem@0.18.0
+
 ## 0.17.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmnto/cli",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "CLI for Totem — AI persistent memory and context layer",
   "type": "module",
   "bin": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @mmnto/totem
 
+## 0.18.0
+
+### Minor Changes
+
+- feat: async orchestrator and ReDoS protection
+  - Refactored shell orchestrator from `execSync` to async `spawn` with streaming stdout/stderr, 50MB safety cap, and proper timeout handling (#206)
+  - Added compile-time ReDoS static analysis via `safe-regex2` — vulnerable regex patterns are rejected during `totem compile` with diagnostic reasons (#218)
+  - Graceful per-doc error handling in `totem docs` — a single doc failure no longer aborts the entire batch
+
 ## 0.17.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmnto/totem",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "Persistent memory and context layer for AI agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @mmnto/mcp
 
+## 0.18.0
+
+### Minor Changes
+
+- feat: async orchestrator and ReDoS protection
+  - Refactored shell orchestrator from `execSync` to async `spawn` with streaming stdout/stderr, 50MB safety cap, and proper timeout handling (#206)
+  - Added compile-time ReDoS static analysis via `safe-regex2` — vulnerable regex patterns are rejected during `totem compile` with diagnostic reasons (#218)
+  - Graceful per-doc error handling in `totem docs` — a single doc failure no longer aborts the entire batch
+
+### Patch Changes
+
+- Updated dependencies
+  - @mmnto/totem@0.18.0
+
 ## 0.17.0
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmnto/mcp",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "MCP server for Totem — AI persistent memory and context layer",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bump `@mmnto/totem`, `@mmnto/cli`, `@mmnto/mcp` to **0.18.0**
- Async orchestrator refactor — `spawn` replaces `execSync` with streaming, 50MB safety cap, proper timeout handling (#206)
- ReDoS protection for compiled regex rules via `safe-regex2` static analysis (#218)
- Graceful per-doc error handling in `totem docs`

## Test plan
- [ ] Merge and verify GitHub Actions publish workflow triggers
- [ ] Confirm all 3 packages appear on npm at 0.18.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)