### PR TITLE
chore: post-release sync — lessons, docs, roadmap after #226

### DIFF
--- a/.totem/lessons.md
+++ b/.totem/lessons.md
@@ -692,3 +692,27 @@ Synchronous `execSync` with piped stdio can cause the parent process to hang or 
 **Tags:** logging, ux, error-handling
 
 When catching and re-logging errors that originate from internal utilities with standardized prefixes (e.g., `[Totem Error]`), strip the redundant prefix from the message before outputting. This prevents cluttered logs like `[Docs] ... [Totem Error] ...` and maintains a clean user interface.
+
+## Lesson — Do not manually edit machine-generated artifacts like…
+
+**Tags:** architecture, devops, toolchain
+
+Do not manually edit machine-generated artifacts like `compiled-rules.json`; fixes must be applied to the source lessons or the compiler logic to ensure they persist and aren't overwritten during the next build cycle.
+
+## Lesson — The Git -- separator treats all subsequent arguments as…
+
+**Tags:** git, security, shell
+
+The Git `--` separator treats all subsequent arguments as file paths, meaning revision specifiers (like `branch...HEAD`) must appear before it to be correctly resolved rather than misinterpreted as filenames.
+
+## Lesson — Always fall back to resolving Git references against…
+
+**Tags:** git, ci, devops
+
+Always fall back to resolving Git references against `origin/<branch>` in CI environments, as local branch pointers are often missing or detached in the shallow clones typical of automated runners.
+
+## Lesson — Employ a two-layer validation model by running fast,…
+
+**Tags:** architecture, ci, design-decision
+
+Employ a two-layer validation model by running fast, deterministic regex-based checks in CI while reserving expensive or stochastic LLM reviews for local developer workflows to maintain rapid CI feedback loops without sacrificing deep analysis.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ By building our orchestrator as discrete, composable commands (`spec`, `shield`,
 
 This is a Turborepo monorepo consisting of:
 
-- **`@mmnto/totem`**: The core logic using **Tree-sitter for Universal AST Parsing**, syntax-aware chunking (with heading hierarchy breadcrumbs), and the LanceDB interface. Includes a deterministic lesson compiler (#213, #216).
+- **`@mmnto/totem`**: The core logic using **Tree-sitter for Universal AST Parsing**, syntax-aware chunking (with heading hierarchy breadcrumbs), and the LanceDB interface. Includes a deterministic lesson compiler (#213, #216) backed by compiled rules (#226).
 - **`@mmnto/cli`**: The executable interface (`totem init`, `totem sync`).
 - **`@mmnto/mcp`**: The standard I/O Model Context Protocol (MCP) server that exposes the `search_knowledge` and `add_lesson` tools to your AI.
 
@@ -164,7 +164,7 @@ orchestrator: {
 - **`briefing`**: Fetches your current git branch, uncommitted changes, open PRs, and recent session momentum to generate a startup briefing.
 - **`bridge`**: Assesses your current mid-task state and creates a lightweight breadcrumb file. Use this when your AI agent's context window gets too full.
 - **`spec <ids...>`**: Fetches GitHub Issues (supports URLs) and synthesizes a pre-work spec. The AI acts as a **Staff-Level Architect**, focusing on contracts and edge cases.
-- **`shield`**: Reads your uncommitted git diff, queries LanceDB for related traps, and performs a **hybrid zero-day + N-day architectural code review** (#98) before you push. Supports **zero-LLM shield mode** (#216) for lightning-fast deterministic checks.
+- **`shield`**: Reads your uncommitted git diff, queries LanceDB for related traps, and performs a **hybrid zero-day + N-day architectural code review** (#98) before you push. Supports **zero-LLM shield mode** (#216) for lightning-fast deterministic checks using compiled rules (#226).
 - **`triage`**: Fetches open GitHub issues and generates a prioritized roadmap (e.g., `docs/active_work.md`) for your next task.
 - **`add-lesson`**: Interactively document a context, symptom, and fix. Saves to `.totem/lessons.md` and triggers a background re-index.
 - **`docs`**: Automatically syncs project documentation (README, Roadmap) by analyzing git logs and closed issues since the last release (#190).
@@ -236,7 +236,7 @@ Then remove the `-y` flag from your MCP config — `npx` will use the locally in
 Totem is evolving from a memory database into a full Shift-Left orchestrator.
 
 - [x] **Foundations & Phase 1 (Onboarding):** Local vector DB, MCP interface, MVC Configuration Tiers (#187), "Universal Lessons" baseline (#128), and cross-platform docs (#210).
-- [x] **Phase 2 (Core Stability):** Tree-sitter Universal AST Parsing (#173), Shield GitHub Action (#180), Automated Doc Sync (#190), Drift Detection for self-cleaning memory (#177, #211), Deterministic Lesson Compiler / Zero-LLM Shield (#213, #216), and OpenAI embedding validation (#4).
+- [x] **Phase 2 (Core Stability):** Tree-sitter Universal AST Parsing (#173), Shield GitHub Action (#180), Automated Doc Sync (#190), Drift Detection for self-cleaning memory (#177, #211), Deterministic Lesson Compiler / Zero-LLM Shield (#213, #216) backed by regex ReDoS protection (#218), and OpenAI embedding validation (#4).
 - [ ] **Validation & Polish:** Internal dogfooding (#8) and interactive CLI tutorials (#129).
 - [ ] **Phase 3 (Workflow Expansion):** Custom Workflow Runner (#119), Agent-Optimized MCP (#176), and Cross-File Knowledge Graph (#183).
 

--- a/docs/active_work.md
+++ b/docs/active_work.md
@@ -1,6 +1,6 @@
 ### Active Work Summary
 
-Foundations, Phase 1 (Onboarding), and Phase 2 (Core Stability) are functionally complete, establishing the Turborepo architecture, syntax-aware chunking (now powered by Tree-sitter #173), and local data stores. Recent momentum has delivered the Shield GitHub Action (#180), Drift Detection (#177, #211), Automated Doc Sync (#190), MVC Configuration Tiers (#187), a "Universal Lessons" baseline (#128), Cross-Platform Onboarding (#210), OpenAI Embedding validation (#4), and a deterministic lesson compiler with zero-LLM shield mode (#213, #216) backed by regex ReDoS protection (#218). Focus is now on internal dogfooding (#8) before scaling Phase 3 workflow expansions.
+Foundations, Phase 1 (Onboarding), and Phase 2 (Core Stability) are functionally complete, establishing the Turborepo architecture, syntax-aware chunking (now powered by Tree-sitter #173), and local data stores. Recent momentum has delivered the Shield GitHub Action (#180), Drift Detection (#177, #211), Automated Doc Sync (#190), MVC Configuration Tiers (#187), a "Universal Lessons" baseline (#128), Cross-Platform Onboarding (#210), OpenAI Embedding validation (#4), and a deterministic lesson compiler with zero-LLM shield mode (#213, #216) backed by regex ReDoS protection (#218) and integrated into CI workflows (#222, #226). Focus is now on internal dogfooding (#8) before scaling Phase 3 workflow expansions.
 
 ### Prioritized Roadmap
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -41,6 +41,7 @@ The core embedded vector database, MCP server, and baseline CLI commands have be
 - [x] **#121 Bug: LanceDB `deleteByFile`** edge cases causing silent incremental sync failures.
 - [x] **#122 Core Tests:** Backfill unit and integration tests for `@mmnto/totem` core database and chunking logic.
 - [x] **#174 / #180 Shield GitHub Action:** `action.yml` composite action for CI/CD enforcement — pass/fail quality gate on PRs.
+- [x] **#222 / #226 CI Workflows:** Implement deterministic shield workflow, linting, tests, and compiled rules enforcement into the Totem repository CI pipeline.
 - [x] **#168 Interactive multi-select:** `totem extract` uses `@clack/prompts` multiselect for cherry-picking lessons.
 - [x] **#185 CLI command renames:** `learn` → `extract`, removed `anchor` alias (use `add-lesson`).
 - [x] **#131 Clean Ejection:** Build `totem eject` to safely remove git hooks, prompt injections, and database artifacts if a user uninstalls.


### PR DESCRIPTION
## Summary
- 4 lessons extracted from PR #226 (CI shield workflow)
- README, roadmap, active_work updated with #226 references
- `architecture.md` skipped (no architectural changes needed)

## Test plan
- [ ] Verify doc diffs are accurate
- [ ] CI passes (lint, format, deterministic shield)

🤖 Generated with [Claude Code](https://claude.com/claude-code)