### PR TITLE
chore: release v0.20.0

### DIFF
--- a/.changeset/release-v0.20.0-cli.md
+++ b/.changeset/release-v0.20.0-cli.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/cli': minor
+---
+
+Individual document targeting for `totem docs`, centralized `resolveOrchestrator()` with model name security validation, fix for truncated lesson extraction headings, cross-provider routing support, docs pipeline stability fixes, and relicense to Apache 2.0.

--- a/.changeset/release-v0.20.0-core.md
+++ b/.changeset/release-v0.20.0-core.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/totem': minor
+---
+
+Inline suppression directives (`totem-ignore` / `totem-ignore-next-line`) for deterministic shield, cross-provider `provider:model` routing with negated glob support, and relicense to Apache 2.0.

--- a/.changeset/release-v0.20.0-mcp.md
+++ b/.changeset/release-v0.20.0-mcp.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/mcp': patch
+---
+
+Relicense to Apache 2.0.


### PR DESCRIPTION
## Summary

- **Core (minor):** Inline suppression directives (`totem-ignore` / `totem-ignore-next-line`), cross-provider `provider:model` routing with negated glob support, Apache 2.0 relicense
- **CLI (minor):** Individual document targeting for `totem docs`, centralized `resolveOrchestrator()` with model name security validation, truncated lesson heading fix, cross-provider routing, docs pipeline stability fixes, Apache 2.0 relicense
- **MCP (patch):** Apache 2.0 relicense

## PRs included since v0.19.0

- #241 — `totem docs` individual doc targeting
- #246 — Cross-provider routing with negated glob support
- #255 — Inline suppression directives for deterministic shield
- #257 — `resolveOrchestrator()` centralization + truncated extract headings fix (Closes #248, Closes #253)
- #259 — MIT → Apache 2.0 relicense

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm test` passes
- [x] Pre-push hooks pass (format, lint, test)
- [ ] Changesets consumed by release workflow after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)