### PR TITLE
chore: CLA automation and CONTRIBUTING.md

### DIFF
--- a/.github/CLA.md
+++ b/.github/CLA.md
@@ -1,0 +1,46 @@
+# Totem Individual Contributor License Agreement (CLA)
+
+Thank you for your interest in contributing to **Totem** (the "Project"), maintained by **Matt Sutton / Memento AI (mmnto-ai)** (the "Maintainer"). This Contributor License Agreement ("Agreement") documents the rights granted by contributors to the Maintainer.
+
+By signing this Agreement, You accept and agree to the following terms and conditions for Your present and future Contributions submitted to the Project.
+
+## 1. Definitions
+
+- **"You" (or "Your")** means the individual who submits a Contribution to the Project.
+- **"Contribution"** means any original work of authorship, including any modifications or additions to an existing work, that is intentionally submitted by You to the Project for inclusion in the Project. "Submitted" means any form of communication sent to the Project (e.g., pull requests, issues, comments), but excluding communication conspicuously marked "Not a Contribution."
+- **"Project"** means the software and documentation maintained at [github.com/mmnto-ai/totem](https://github.com/mmnto-ai/totem).
+
+## 2. Grant of Copyright License
+
+You hereby grant to the Maintainer and to recipients of software distributed by the Maintainer a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
+
+## 3. Grant of Patent License
+
+You hereby grant to the Maintainer and to recipients of software distributed by the Maintainer a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Contribution, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contribution alone or by combination of Your Contribution with the Project to which the Contribution was submitted.
+
+## 4. Representations
+
+You represent that:
+
+- Each of Your Contributions is Your original creation.
+- You are legally entitled to grant the above licenses.
+- Your Contribution does not violate any third-party rights.
+- If Your employer has rights to intellectual property that You create, You represent that You have received permission to make Contributions on behalf of that employer, or that Your employer has waived such rights.
+
+## 5. Support and Warranty Disclaimer
+
+Your Contributions are provided on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of title, non-infringement, merchantability, or fitness for a particular purpose.
+
+You are not expected to provide support for Your Contributions, except to the extent You desire to provide support.
+
+## 6. Notification
+
+You agree to notify the Maintainer of any facts or circumstances of which You become aware that would make Your representations in this Agreement inaccurate in any respect.
+
+---
+
+**To sign this CLA**, reply to the CLA Assistant bot on your Pull Request with:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+This constitutes Your electronic signature to this Agreement.

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,38 @@
+name: CLA Assistant
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    if: |
+      (github.event_name == 'pull_request_target') ||
+      (github.event_name == 'issue_comment' && github.event.comment.body == 'recheck')
+    name: CLA Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_TOKEN }}
+        with:
+          path-to-signatures: signatures/cla.json
+          path-to-document: https://github.com/mmnto-ai/totem/blob/main/.github/CLA.md
+          branch: cla-signatures
+          allowlist: dependabot[bot],github-actions[bot],renovate[bot],mmnto-bot
+          custom-notsigned-prcomment: >-
+            Thank you for your contribution! Before we can merge this PR, we need you to sign our
+            [Contributor License Agreement]($CLA_DOCUMENT).
+            <br><br>
+            To sign, please reply to this comment with:<br>
+            `I have read the CLA Document and I hereby sign the CLA`
+          custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA

--- a/.totem/lessons.md
+++ b/.totem/lessons.md
@@ -812,3 +812,15 @@ Avoid adding explicit runtime checks or redundant error branches for logic paths
 **Tags:** llm, prompt-engineering, sanitization
 
 Requesting explicit metadata tokens (e.g., `Heading:`) from LLMs is more reliable than using heuristic truncation of the first line of output. Sanitize these explicit tokens to remove markdown artifacts and prefixes that LLMs frequently include despite instructions.
+
+## Lesson — Prefer Vitest's expect().rejects.toHaveProperty()…
+
+**Tags:** testing, vitest, patterns
+
+Prefer Vitest's `expect().rejects.toHaveProperty()` assertions over manual `try/catch` blocks with `expect.fail()`. This pattern is more concise and prevents tests from accidentally passing if the code fails to throw as expected.
+
+## Lesson — Ensure all thrown errors, including those for missing…
+
+**Tags:** error-handling, style-guide, consistency
+
+Ensure all thrown errors, including those for missing environment variables or configuration, strictly include the `[Totem Error]` prefix. Maintaining this prefix even in low-level setup code ensures consistent error reporting for users and automated monitoring.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,58 @@
+# Contributing to Totem
+
+Thanks for your interest in contributing to Totem! This guide covers everything you need to get started.
+
+## Getting Started
+
+1. **Fork** the repository and clone your fork
+2. Install dependencies: `pnpm install`
+3. Build all packages: `pnpm build`
+4. Run tests: `pnpm test`
+
+## Development Workflow
+
+1. Create a feature branch from `main`
+2. Make your changes
+3. Ensure tests pass: `pnpm test`
+4. Ensure code is formatted: `pnpm format:check` (fix with `pnpm run format`)
+5. Ensure linting passes: `pnpm lint`
+6. Open a Pull Request against `main`
+
+## Code Style
+
+- TypeScript strict mode
+- `kebab-case.ts` for files
+- Use `err` (never `error`) in catch blocks
+- No empty catch blocks
+- Extract magic numbers into named constants
+
+## Package Structure
+
+```
+packages/
+  core/   @mmnto/totem   Core library (LanceDB, chunking, compiler)
+  cli/    @mmnto/cli     CLI commands
+  mcp/    @mmnto/mcp     MCP server
+```
+
+## Contributor License Agreement (CLA)
+
+All contributors must sign our [Contributor License Agreement](.github/CLA.md) before their first Pull Request can be merged. This is a one-time requirement.
+
+**Why?** The CLA ensures that the project maintainers have the necessary rights to distribute and relicense contributions. This is standard practice for Apache 2.0 licensed projects that may offer additional licensing options in the future.
+
+**How?** When you open your first PR, the CLA Assistant bot will post a comment asking you to sign. Simply reply with:
+
+> I have read the CLA Document and I hereby sign the CLA
+
+Once signed, the bot remembers your signature for all future PRs.
+
+## Reporting Issues
+
+- Use [GitHub Issues](https://github.com/mmnto-ai/totem/issues) for bugs and feature requests
+- Check existing issues before creating a new one
+- Include reproduction steps for bugs
+
+## Questions?
+
+Open a [Discussion](https://github.com/mmnto-ai/totem/discussions) or reach out in an issue.


### PR DESCRIPTION
## Summary
- Add **Contributor License Agreement** (`.github/CLA.md`) based on Apache CLA template, granting copyright + patent licenses to the project
- Add **CLA Assistant workflow** (`.github/workflows/cla.yml`) using `contributor-assistant/github-action@v2.6.1` — runs entirely in our Actions runners, no third-party OAuth
- Add **CONTRIBUTING.md** with development setup, code style, and CLA signing instructions
- Signatures stored in `signatures/cla.json` on a dedicated `cla-signatures` branch
- Bot accounts (dependabot, github-actions, renovate, mmnto-bot) are allowlisted to bypass the CLA check

## Post-Merge Manual Steps
- [ ] Add `CLA_TOKEN` secret (PAT with `contents:write` + `pull-requests:write` for the signatures branch)
- [ ] Add "CLA Assistant" as a required status check in `main` branch protection rules

## Test plan
- [ ] Open a test PR from a non-org account — verify CLA bot comments with signing instructions
- [ ] Reply with signature phrase — verify bot updates status check to passing
- [ ] Open a second PR from same account — verify auto-pass without re-signing
- [ ] Verify Dependabot PRs bypass the CLA check

Closes #258

🤖 Generated with [Claude Code](https://claude.com/claude-code)