### PR TITLE
docs: sync project docs and lessons via totem wrap

### DIFF
--- a/.totem/lessons.md
+++ b/.totem/lessons.md
@@ -866,3 +866,45 @@ Omit defensive XML escaping for prompt injection when processing trusted local d
 **Tags:** llm, code-review, prompting
 
 Deliberately excluding project context in "structural" review modes prevents the LLM from anchoring on developer intent, which can mask syntax-level bugs. Restricting the model's view to raw diffs forces it to identify logic errors and resource leaks that global project context might otherwise rationalize.
+
+## Lesson — Always generate sentinel markers even when the internal…
+
+**Tags:** idempotency, file-io, markdown
+
+Always generate sentinel markers even when the internal content is empty. Returning an empty string instead of empty markers causes the replacement logic to delete the markers from the target file, leading to redundant appends in subsequent runs.
+
+## Lesson — If a configuration file is a locally-authored script (e.g.,…
+
+**Tags:** security, configuration, trust-model
+
+If a configuration file is a locally-authored script (e.g., totem.config.ts) that the tool imports, the user already has arbitrary code execution. Validating individual path fields for traversal in this context adds no security value as the configuration itself is already a trusted input boundary.
+
+## Lesson — When performing string-slice replacements based on start…
+
+**Tags:** file-io, error-handling, robustness
+
+When performing string-slice replacements based on start and end markers, explicitly throw an error if the end marker appears before the start marker. Failing to check this relative ordering can result in incorrect slices that silently scramble or corrupt the target file's content.
+
+## Lesson — Runtime escaping and sanitization are unnecessary for…
+
+**Tags:** security, prompt-injection, workflow
+
+Runtime escaping and sanitization are unnecessary for content sourced from version-controlled files that undergo PR review. In these cases, the project's development workflow and human review process serve as the primary security boundary against malicious input like prompt injection or sentinel breakage.
+
+## Lesson — In local-first development tools, escaping XML tags in git…
+
+**Tags:** security, llm, git
+
+In local-first development tools, escaping XML tags in git diffs to prevent prompt injection is often unnecessary because the user already controls the input source. Avoiding redundant sanitization on trusted local data reduces prompt noise and prevents unnecessary token consumption.
+
+## Lesson — Resist merging similar orchestrator output handling and…
+
+**Tags:** design-decision, clean-code, architecture
+
+Resist merging similar orchestrator output handling and verdict parsing logic until at least three distinct modes exist. Keeping these paths separate during early feature development prevents premature coupling of specialized modes that might later diverge in requirements.
+
+## Lesson — Setting open-pull-requests-limit to 0 in dependabot.yml…
+
+**Tags:** dependabot, security, configuration
+
+Setting open-pull-requests-limit to 0 in dependabot.yml suppresses routine version bumps while still allowing critical security patches to trigger PRs via GitHub's repo-level security settings. This distinction allows for a security-only automated update policy that prevents noise and maintenance fatigue.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ By building our orchestrator as discrete, composable commands (`spec`, `shield`,
 
 This is a Turborepo monorepo consisting of:
 
-- **`@mmnto/totem`**: The core logic using **Tree-sitter for Universal AST Parsing**, syntax-aware chunking (with heading hierarchy breadcrumbs), and the LanceDB interface. Includes a deterministic lesson compiler (#213, #216) backed by compiled rules (#226).
+- **`@mmnto/totem`**: The core logic using **Tree-sitter for Universal AST Parsing**, syntax-aware chunking (with heading hierarchy breadcrumbs), and the LanceDB interface. Includes a deterministic lesson compiler (#213, #216) backed by compiled rules (#226) and cross-model export targets (#269).
 - **`@mmnto/cli`**: The executable interface (`totem init`, `totem sync`).
 - **`@mmnto/mcp`**: The standard I/O Model Context Protocol (MCP) server that exposes the `search_knowledge` and `add_lesson` tools to your AI.
 
@@ -43,6 +43,7 @@ This is a Turborepo monorepo consisting of:
 
 - **100% Local Privacy:** Totem's vector database (`.lancedb/`) lives entirely within your local repository. Your codebase is never uploaded to a centralized SaaS platform or external memory service.
 - **Injection & ReDoS Hardening:** Totem actively sanitizes untrusted inputs (like PR comments fetched during `totem extract` and external GitHub issues), applies **ReDoS protection to compiled regex rules** (#218), and **XML-delimits MCP responses** (#149) to mitigate indirect prompt injection and terminal injection attacks.
+- **Continuous Auditing:** The repository utilizes Dependabot for automated security vulnerability scanning (#267, #272) to ensure dependencies remain secure.
 
 ## Prerequisites
 
@@ -174,12 +175,13 @@ orchestrator: {
 - **`briefing`**: Fetches your current git branch, uncommitted changes, open PRs, and recent session momentum to generate a startup briefing.
 - **`bridge`**: Assesses your current mid-task state and creates a lightweight breadcrumb file. Use this when your AI agent's context window gets too full.
 - **`spec <ids...>`**: Fetches GitHub Issues (supports URLs) and synthesizes a pre-work spec. The AI acts as a **Staff-Level Architect**, focusing on contracts and edge cases.
-- **`shield`**: Reads your uncommitted git diff, queries LanceDB for related traps, and performs a **hybrid zero-day + N-day architectural code review** (#98) before you push. Supports **zero-LLM shield mode** (#216) for lightning-fast deterministic checks using compiled rules (#226), false-positive mitigation for non-code contexts (#251), and inline suppression directives (#255).
+- **`shield`**: Reads your uncommitted git diff, queries LanceDB for related traps, and performs a **hybrid zero-day + N-day architectural code review** (#98) before you push. Supports **zero-LLM shield mode** (#216) for lightning-fast deterministic checks using compiled rules (#226), false-positive mitigation for non-code contexts (#251), inline suppression directives (#255), and **context-blind structural review** (`--mode=structural` #270).
 - **`triage`**: Fetches open GitHub issues and generates a prioritized roadmap (e.g., `docs/active_work.md`) for your next task.
+- **`compile`**: Compiles `.totem/lessons.md` into deterministic regex/AST rules for zero-LLM checks. Supports **cross-model lesson export** (`--export`) to enforce architectural constraints across different agent environments and external tools (#264, #269).
 - **`add-lesson`**: Interactively document a context, symptom, and fix. Saves to `.totem/lessons.md` and triggers a background re-index.
 - **`docs`**: Automatically syncs project documentation (README, Roadmap) by analyzing git logs and closed issues since the last release (#190). Supports targeting individual files (e.g., `totem docs README.md`) with path fixes and strict state preservation to prevent hallucination (#238, #241, #249).
 - **`wrap`**: A post-merge workflow chain that runs `extract`, syncs the database, generates a roadmap, and updates docs in one command (#143, #242).
-- **`extract <ids...>`**: Fetches merged PRs, reads comments, and extracts systemic architectural traps with **descriptive headings** (#203, #253). Supports interactive multi-select pruning.
+- **`extract <ids...>`**: Fetches merged PRs, reads comments, and extracts systemic architectural traps with **descriptive headings** (#203, #253). Supports interactive multi-select pruning and the `--pick` flag for selective lesson acceptance (#265).
 - **`handoff`**: Captures uncommitted changes and lessons learned today, synthesizing a tactical snapshot for your next session.
 - **`eject`**: Safely removes all Totem git hooks, configuration files, AI agent prompt injections, and the local `.lancedb/` index (#131).
 
@@ -243,11 +245,15 @@ Then remove the `-y` flag from your MCP config — `npx` will use the locally in
 Totem is evolving from a memory database into a full Shift-Left orchestrator.
 
 - [x] **Foundations & Phase 1 (Onboarding):** Local vector DB, MCP interface, MVC Configuration Tiers (#187), "Universal Lessons" baseline (#128), and cross-platform docs (#210).
-- [x] **Phase 2 (Core Stability):** Tree-sitter Universal AST Parsing (#173), Shield GitHub Action (#180), Automated Doc Sync with XML sentinels, individual document targeting, and stability/hallucination fixes (#190, #206, #224, #228, #238, #241, #249, #250), Drift Detection for self-cleaning memory (#177, #211), Deterministic Lesson Compiler / Zero-LLM Shield (#213, #216) backed by regex ReDoS protection (#218), false-positive mitigation (#251), and inline suppression directives (#255), Native API Orchestrators for Gemini and Anthropic (#229) with BYOSD package manager auto-detection (#236), cross-provider routing with negated glob support (#243, #246), and OpenAI embedding validation (#4).
+- [x] **Phase 2 (Core Stability):** Tree-sitter Universal AST Parsing (#173), Shield GitHub Action (#180), Automated Doc Sync with XML sentinels, individual document targeting, and stability/hallucination fixes (#190, #206, #224, #228, #238, #241, #249, #250), Drift Detection for self-cleaning memory (#177, #211), Deterministic Lesson Compiler / Zero-LLM Shield (#213, #216) backed by regex ReDoS protection (#218), false-positive mitigation (#251), inline suppression directives (#255), structural context-blind review (#270), cross-model lesson export targets (#264, #269), selective lesson acceptance (#265), Native API Orchestrators for Gemini and Anthropic (#229) with BYOSD package manager auto-detection (#236), centralized orchestrator resolution (#248), cross-provider routing with negated glob support (#243, #246), Provider Conformance test suites (#244, #263), and OpenAI embedding validation (#4).
 - [x] **Validation:** Internal dogfooding (#8) across multiple real-world repositories.
 - [ ] **Phase 3 (Workflow Expansion):** Interactive CLI tutorials (#129), Custom Workflow Runner (#119), Agent-Optimized MCP (#176), and Cross-File Knowledge Graph (#183).
 
 For a deeper dive into the system design, see `docs/architecture.md`.
+
+## Contributing
+
+We welcome community contributions! Please review our `CONTRIBUTING.md` guidelines. Note that all external contributions require signing our automated Contributor License Agreement (CLA) (#258, #266).
 
 ## License
 

--- a/docs/active_work.md
+++ b/docs/active_work.md
@@ -1,20 +1,14 @@
 ### Active Work Summary
 
-Foundations, Phase 1 (Onboarding), and Phase 2 (Core Stability) are functionally complete, establishing the Turborepo architecture, syntax-aware chunking (now powered by Tree-sitter #173), and local data stores. Recent momentum has delivered the Shield GitHub Action (#180), Drift Detection (#177, #211), Automated Doc Sync (#190), MVC Configuration Tiers (#187), a "Universal Lessons" baseline (#128), Cross-Platform Onboarding (#210), OpenAI Embedding validation (#4), a deterministic lesson compiler with zero-LLM shield mode (#213, #216) backed by regex ReDoS protection (#218), integrated into CI workflows (#222, #226), and expanded with inline suppression directives and false-positive resolution (#251, #255), XML sentinels for automated doc sync (#228), native API orchestrators (#229) for Gemini and Anthropic with BYOSD optional peer dependencies and package manager auto-detection (#236), cross-provider routing in orchestrator overrides with negated glob support (#243, #246), individual document targeting with hallucination and stability fixes for the `totem docs` pipeline (#206, #224, #238, #241, #249, #250), centralized orchestrator resolution logic (#248), and fixes for truncated lesson extraction headings (#253). Additionally, the project has been relicensed to Apache 2.0. Internal dogfooding (#8) is validated. Focus is now on orchestrator stabilization and Phase 3 workflow expansions.
+Foundations, Phase 1 (Onboarding), and Phase 2 (Core Stability) are functionally complete, establishing the Turborepo architecture, syntax-aware chunking (now powered by Tree-sitter #173), and local data stores. Recent momentum has delivered the Shield GitHub Action (#180), Drift Detection (#177, #211), Automated Doc Sync (#190), MVC Configuration Tiers (#187), a "Universal Lessons" baseline (#128), Cross-Platform Onboarding (#210), OpenAI Embedding validation (#4), a deterministic lesson compiler with zero-LLM shield mode (#213, #216) backed by regex ReDoS protection (#218), integrated into CI workflows (#222, #226), and expanded with inline suppression directives and false-positive resolution (#251, #255), XML sentinels for automated doc sync (#228), native API orchestrators (#229) for Gemini and Anthropic with BYOSD optional peer dependencies and package manager auto-detection (#236), cross-provider routing in orchestrator overrides with negated glob support (#243, #246), individual document targeting with hallucination and stability fixes for the `totem docs` pipeline (#206, #224, #238, #241, #249, #250), centralized orchestrator resolution logic (#248), fixes for truncated lesson extraction headings (#253), provider conformance suites and nightly smoke tests (#244, #245, #263), selective lesson acceptance (#265), cross-model lesson export targets (#264, #269), structural context-blind reviews (#270), multi-agent code review analysis (#247), and repository hygiene including CLA automation and Dependabot configuration (#258, #266, #267, #272). Additionally, the project has been relicensed to Apache 2.0. Internal dogfooding (#8) is validated. With orchestrator stabilization achieved, focus is now on Phase 3 workflow expansions and shift-left CI integration.
 
 ### Prioritized Roadmap
 
-**Do Next (Orchestrator Stabilization)**
-
-- #244 — test: Provider Conformance Suite for orchestrator implementations — Essential validation gate to ensure all new and existing models behave consistently before expanding features.
-- #245 — test: Nightly integration smoke tests for orchestrator providers — Automates the conformance suite against live APIs to catch upstream provider drift immediately.
-
-**Up Next (Shift-Left & CI Integration)**
+**Do Next (Shift-Left & CI Integration)**
 
 - #195 — Epic: Model Compatibility & Auditing Strategy — Directly aligns with the shift toward orchestration by defining how models are audited for compatibility.
 - #196 — Build Adversarial Evaluation Harness for CI (Model Drift Mitigation) — Establishes the CI drift gate, pushing AI verification shift-left.
 - #214 — Feature: CI Drift Gate (Structural Integrity Check) — Provides the infrastructure to run the adversarial harness in standard CI pipelines.
-- #247 — Analysis: Multi-Agent Code Review & The Three-Lens Model — Research necessary to define the next generation of automated PR review workflows.
 
 **Backlog (Exploratory, Epics, & Phase 4)**
 
@@ -24,11 +18,11 @@ Foundations, Phase 1 (Onboarding), and Phase 2 (Core Stability) are functionally
 
 ### Next Issue (User Story & Scope)
 
-**#244 — test: Provider Conformance Suite for orchestrator implementations**
+**#195 — Epic: Model Compatibility & Auditing Strategy**
 
-- **User Story:** As a maintainer, I want a standard conformance test suite for all API orchestrators so that we can verify consistent behavior across different LLM providers (Anthropic, Gemini, etc.) and prevent regressions when updating models.
-- **Scope:** Build a shared testing suite that validates the core orchestrator interface (request formatting, XML parsing, error handling) using mocked responses. Apply it to the current Anthropic and Gemini orchestrators.
-- **Why Next:** With orchestrator resolution successfully centralized (#248), we must ensure existing models behave consistently before introducing nightly smoke tests (#245) or new providers.
+- **User Story:** As a maintainer, I want a defined model compatibility and auditing strategy so that we can systematically verify how different models are supported and audited following the shift to centralized orchestration.
+- **Scope:** Define how models are audited for compatibility, providing the strategic foundation needed before implementing the adversarial evaluation harness in CI.
+- **Why Next:** With orchestrator providers stabilized through the conformance suite and nightly smoke tests (#244, #245), the foundation is ready to formalize the model compatibility strategy as we move toward shift-left CI integrations.
 
 ### Blocked / Needs Input
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,17 +19,21 @@ Totem is designed as a **Shared Brain** and **Orchestrator** for a team of auton
 - `totem init` / `totem eject`: Scaffolds or safely removes `totem.config.ts`, git hooks, and AI memory reflexes.
 - `totem sync`: Crawls target directories defined in `totem.config.ts`, chunks, embeds, and updates the LanceDB index.
 - `totem search`: Direct debug query interface.
-- `totem spec` / `totem shield` / `totem triage`: Standardized workflow orchestration commands (spec planning, pre-push review, issue prioritization).
+- `totem spec` / `totem shield` / `totem triage`: Standardized workflow orchestration commands (spec planning, pre-push review, issue prioritization). `totem shield` includes options like `--mode=structural` for context-blind architectural review.
 - `totem briefing` / `totem handoff`: Session start/end context snapshots.
-- `totem extract`: Batch lesson extraction from PR review threads with interactive multi-select curation.
+- `totem extract`: Batch lesson extraction from PR review threads with interactive multi-select curation (supported by the `--pick` flag for selective lesson acceptance). Generated lessons use highly descriptive, content-derived headings.
 - `totem add-lesson`: Inline lesson capture (also exposed as MCP tool `add_lesson`).
-- `totem compile`: Translates natural-language lessons into deterministic regex rules via constrained LLM prompt at compile-time.
+- `totem compile`: Translates natural-language lessons into deterministic regex rules via constrained LLM prompt at compile-time. Supports an `--export` flag for cross-model lesson export targets.
 - `totem docs`: Automated per-document LLM passes to keep project documentation in sync with the codebase. Supports targeting individual documents via explicit path arguments (with automatic path fixes) for precision updates (safeguarded by XML sentinels for reliable output extraction).
 - `totem bridge` / `totem wrap`: Mid-session context resets and end-of-task workflow automation.
 
 ### 3. Deterministic Compiler & Zero-LLM Shield
 
-`totem compile` reads `.totem/lessons.md` and translates each lesson into a regex rule (or marks it as non-compilable). Rules are stored in `.totem/compiled-rules.json` (with support for `fileGlobs` scoping to target specific files) and validated at compile-time with both syntax checking and ReDoS static analysis (`safe-regex2`). Developers can bypass specific false positives using **inline suppression directives** (`totem-ignore` / `totem-ignore-next-line`), and `fileGlobs` support negated patterns (e.g., `!*.test.ts`) to exclude file types. Vulnerable patterns (nested quantifiers, star height > 1) are rejected, leaving them to be handled by the standard LLM-based shield. `totem shield --deterministic` applies these rules against `git diff` additions with zero LLM calls — ideal for CI enforcement without API keys or quota.
+`totem compile` reads `.totem/lessons.md` and translates each lesson into a regex rule (or marks it as non-compilable). Rules are stored in `.totem/compiled-rules.json` (with support for `fileGlobs` scoping to target specific files) and validated at compile-time with both syntax checking and ReDoS static analysis (`safe-regex2`). The compilation process is context-aware to prevent false positives within string literals and non-code contexts.
+
+Developers can further bypass specific false positives using **inline suppression directives** (`totem-ignore` / `totem-ignore-next-line`), and `fileGlobs` support negated patterns (e.g., `!*.test.ts`) to exclude file types. Vulnerable patterns (nested quantifiers, star height > 1) are rejected, leaving them to be handled by the standard LLM-based shield.
+
+`totem shield --deterministic` applies these compiled rules against `git diff` additions with zero LLM calls — ideal for CI enforcement without API keys or quota. Compiled rules can also be adapted to external systems via `totem compile --export` for cross-model lesson enforcement.
 
 ### 4. Shield GitHub Action (`action.yml`)
 
@@ -43,7 +47,7 @@ A stdio-based server for LLM integration. Provides two tools:
 
 - `search_knowledge(query)`: Semantic retrieval of codebase context and lessons.
 - `add_lesson(lesson, tags)`: Appends human-readable architectural lessons to `.totem/lessons.md` with descriptive content-derived headings.
-- **Security:** XML-delimits all MCP responses (#149) and sanitizes persisted content to mitigate prompt injection and terminal injection attacks.
+- **Security:** XML-delimits all MCP responses and sanitizes persisted content to mitigate prompt injection and terminal injection attacks.
 
 ## Configuration Tiers
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -35,6 +35,7 @@ The core embedded vector database, MCP server, and baseline CLI commands have be
 
 **Goal:** Before ingesting enterprise databases, the local vector index and LLM prompts must be bulletproof across all environments.
 
+- [x] **#267 / #272 Security:** Configure Dependabot for automated security vulnerability scanning.
 - [x] **#218 Security:** Add ReDoS protection to compiled regex rules.
 - [x] **#206 / #224 Robustness:** Refactor orchestrator from `execSync` to async `spawn` and fix `node-fetch` aborts on large files like `architecture.md` via Gemini CLI.
 - [x] **#173 Epic: Universal AST Parsing:** Implement Tree-sitter for robust, language-agnostic code chunking.
@@ -42,7 +43,7 @@ The core embedded vector database, MCP server, and baseline CLI commands have be
 - [x] **#122 Core Tests:** Backfill unit and integration tests for `@mmnto/totem` core database and chunking logic.
 - [x] **#174 / #180 Shield GitHub Action:** `action.yml` composite action for CI/CD enforcement — pass/fail quality gate on PRs.
 - [x] **#222 / #226 CI Workflows:** Implement deterministic shield workflow, linting, tests, and compiled rules enforcement into the Totem repository CI pipeline.
-- [x] **#168 Interactive multi-select:** `totem extract` uses `@clack/prompts` multiselect for cherry-picking lessons.
+- [x] **#168 / #265 Interactive multi-select:** `totem extract` uses `@clack/prompts` multiselect for cherry-picking lessons and supports selective acceptance via the `--pick` flag.
 - [x] **#185 CLI command renames:** `learn` → `extract`, removed `anchor` alias (use `add-lesson`).
 - [x] **#131 Clean Ejection:** Build `totem eject` to safely remove git hooks, prompt injections, and database artifacts if a user uninstalls.
 - [x] **#127 Core:** Add heading hierarchy breadcrumbs to MarkdownChunker labels.
@@ -84,14 +85,15 @@ The core embedded vector database, MCP server, and baseline CLI commands have be
 - [ ] **#23 Automated Memory Consolidation:** Command (`totem consolidate`) to clean up and merge old lessons.
 - [x] **#187 Minimum Viable Configuration:** Tiered config (Lite/Standard/Full) with auto-detection. Embedding is optional; Lite tier works with zero API keys.
 - [x] **#190 / #228 / #238 / #241 Automated Doc Sync (#249, #250):** `totem docs` command to keep project docs updated via per-doc LLM passes, now supporting individual doc targeting, path fixes, hallucination fixes, and XML sentinels. Integrated into `totem wrap` as Step 4/4 (#143).
-- [x] **#213 / #216 / #255 Zero-LLM Shield Mode (#251):** Deterministic lesson compiler, zero-LLM shield mode, false-positive resolution, and inline suppression directives.
+- [x] **#213 / #216 / #255 Zero-LLM Shield Mode (#251, #270):** Deterministic lesson compiler, zero-LLM shield mode (including `--mode=structural` context-blind review), false-positive resolution, and inline suppression directives.
 - [x] **#229 Epic: Native API Orchestrator (#230–#234, #236, #237):** Replace CLI shell-spawning with direct SDK calls to Gemini (`@google/genai`) and Anthropic (`@anthropic-ai/sdk`). BYOSD pattern with optional peer dependencies, discriminated union config, and package manager auto-detection for install prompts.
 - [x] **#243 / #246 Multi-Model Orchestration (#235):** Enable cross-provider routing in orchestrator overrides using `provider:model` syntax with negated glob support.
 - [x] **#248 Orchestrator Refactoring:** Extract `resolveOrchestrator()` helper to deduplicate model resolution.
 - [x] **#144 Epic: AI PR Review Posture & Noise Reduction:** Refine AI PR review posture to reduce noise.
-- [ ] **#244 / #245 Provider Conformance Suite:** Build conformance suite and nightly integration smoke tests to ensure all orchestrator models behave consistently.
+- [x] **#264 / #269 Cross-Model Enforcement:** Enable cross-model lesson export via `totem compile --export`.
+- [x] **#244 / #245 Provider Conformance Suite (#263):** Build conformance suite and nightly integration smoke tests to ensure all orchestrator models behave consistently.
 - [ ] **#195 / #196 / #214 Epic: Shift-Left AI Verification:** Define model compatibility strategy, build adversarial evaluation harness for CI (Model Drift Mitigation), and implement CI Drift Gate.
-- [ ] **#247 Analysis: Multi-Agent Code Review:** Research multi-agent code review and the Three-Lens Model for automated PR review workflows.
+- [x] **#247 Analysis: Multi-Agent Code Review:** Research multi-agent code review and the Three-Lens Model for automated PR review workflows.
 - [ ] **#176 Agent-Optimized MCP:** Dynamic token budgeting and write access for deeper agent-to-agent interactions.
 - [ ] **#183 Cross-File Knowledge Graph (Blocked):** Implement symbol resolution to enable multi-file architectural reasoning.
 
@@ -109,3 +111,4 @@ The core embedded vector database, MCP server, and baseline CLI commands have be
 - [ ] **#198 RFC: Open Core & Defensive Licensing Strategy (Blocked):** Evaluate MIT vs. Fair Source licensing strategy.
 - [x] Implement Changesets and npm publishing (Issue #5 / #46)
 - [x] Chore: Relicense project from MIT to Apache 2.0
+- [x] **#258 / #266 Governance:** Implement Contributor License Agreement (CLA) automation and CONTRIBUTING.md.


### PR DESCRIPTION
## Summary
- Auto-generated via `totem wrap 269 270 272` — full end-of-cycle doc sync
- README, roadmap, active_work, and architecture docs updated to reflect PRs #269, #270, #272
- 7 new lessons extracted and indexed

## Changes
- **README.md**: Reflects `compile --export`, `shield --mode=structural`, Dependabot, CLA
- **docs/roadmap.md**: Checks off #247, #258, #264, #265, #267, #270
- **docs/active_work.md**: Updates priorities post-Phase 2 completion
- **docs/architecture.md**: Integrates export and structural shield flows
- **.totem/lessons.md**: 7 new lessons from PR review feedback

## Test plan
- [x] Gemini reviewed all doc diffs — no hallucinations, checkboxes correct, priorities aligned
- [x] All tests pass, formatting clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)