### PR TITLE
feat: generic OpenAI-compatible orchestrator (#285)

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -33,19 +33,24 @@
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.78.0",
     "@google/genai": "^1.44.0",
+    "openai": "^4.77.0",
     "@types/node": "^22.0.0",
     "typescript": "^5.7.0",
     "vitest": "^4.0.18"
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": ">=0.50.0",
-    "@google/genai": ">=1.0.0"
+    "@google/genai": ">=1.0.0",
+    "openai": ">=4.0.0"
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/sdk": {
       "optional": true
     },
     "@google/genai": {
+      "optional": true
+    },
+    "openai": {
       "optional": true
     }
   },

--- a/packages/cli/src/orchestrators/conformance.test.ts
+++ b/packages/cli/src/orchestrators/conformance.test.ts
@@ -9,9 +9,10 @@ import type { OrchestratorResult } from './orchestrator.js';
 
 // ─── Mock SDKs ──────────────────────────────────────
 
-const { mockGenerateContent, mockCreate } = vi.hoisted(() => ({
+const { mockGenerateContent, mockCreate, mockChatCreate } = vi.hoisted(() => ({
   mockGenerateContent: vi.fn(),
   mockCreate: vi.fn(),
+  mockChatCreate: vi.fn(),
 }));
 
 vi.mock('@google/genai', () => ({
@@ -23,6 +24,12 @@ vi.mock('@google/genai', () => ({
 vi.mock('@anthropic-ai/sdk', () => ({
   default: class {
     messages = { create: mockCreate };
+  },
+}));
+
+vi.mock('openai', () => ({
+  default: class {
+    chat = { completions: { create: mockChatCreate } };
   },
 }));
 
@@ -56,6 +63,7 @@ vi.mock('node:child_process', () => ({
 
 import { invokeAnthropicOrchestrator } from './anthropic-orchestrator.js';
 import { invokeGeminiOrchestrator } from './gemini-orchestrator.js';
+import { invokeOpenAIOrchestrator } from './openai-orchestrator.js';
 import { invokeShellOrchestrator } from './shell-orchestrator.js';
 
 // ─── Shared test opts ───────────────────────────────
@@ -133,6 +141,23 @@ const sdkFixtures: SdkFixture[] = [
       mockCreate.mockRejectedValueOnce(new Error('invalid_api_key'));
     },
     invoke: () => invokeAnthropicOrchestrator(baseOpts),
+  },
+  {
+    name: 'openai',
+    envKey: 'OPENAI_API_KEY',
+    setupHappy: () => {
+      mockChatCreate.mockResolvedValueOnce({
+        choices: [{ message: { content: 'conformance-ok' }, finish_reason: 'stop' }],
+        usage: { prompt_tokens: 10, completion_tokens: 5 },
+      });
+    },
+    setupQuota: () => {
+      mockChatCreate.mockRejectedValueOnce(Object.assign(new Error('rate limit'), { status: 429 }));
+    },
+    setupGenericError: () => {
+      mockChatCreate.mockRejectedValueOnce(new Error('invalid_api_key'));
+    },
+    invoke: () => invokeOpenAIOrchestrator(baseOpts),
   },
 ];
 

--- a/packages/cli/src/orchestrators/openai-orchestrator.test.ts
+++ b/packages/cli/src/orchestrators/openai-orchestrator.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { invokeOpenAIOrchestrator } from './openai-orchestrator.js';
+
+// ─── Mock SDK ───────────────────────────────────────
+
+const { mockCreate } = vi.hoisted(() => ({
+  mockCreate: vi.fn(),
+}));
+
+vi.mock('openai', () => ({
+  default: class {
+    chat = { completions: { create: mockCreate } };
+  },
+}));
+
+vi.mock('../ui.js', () => ({
+  log: { info: vi.fn(), success: vi.fn(), warn: vi.fn(), error: vi.fn(), dim: vi.fn() },
+}));
+
+// ─── Tests ──────────────────────────────────────────
+
+describe('invokeOpenAIOrchestrator', () => {
+  const baseOpts = {
+    prompt: 'test prompt',
+    model: 'gpt-4o',
+    cwd: '.',
+    tag: 'Test',
+    totemDir: '.totem',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env['OPENAI_API_KEY'] = 'test-key';
+  });
+
+  afterEach(() => {
+    delete process.env['OPENAI_API_KEY'];
+  });
+
+  it('returns structured result from OpenAI API', async () => {
+    mockCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: 'Hello from GPT' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 200, completion_tokens: 75 },
+    });
+
+    const result = await invokeOpenAIOrchestrator(baseOpts);
+
+    expect(result.content).toBe('Hello from GPT');
+    expect(result.inputTokens).toBe(200);
+    expect(result.outputTokens).toBe(75);
+    expect(result.finishReason).toBe('stop');
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('passes model and prompt to the SDK', async () => {
+    mockCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+    });
+
+    await invokeOpenAIOrchestrator(baseOpts);
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'test prompt' }],
+      }),
+    );
+  });
+
+  it('throws when no API key and no baseUrl', async () => {
+    delete process.env['OPENAI_API_KEY'];
+
+    await expect(invokeOpenAIOrchestrator(baseOpts)).rejects.toThrow('No OpenAI API key found');
+  });
+
+  it('uses dummy key for local servers with baseUrl', async () => {
+    delete process.env['OPENAI_API_KEY'];
+
+    mockCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: 'local response' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+    });
+
+    const result = await invokeOpenAIOrchestrator({
+      ...baseOpts,
+      model: 'llama3.1',
+      baseUrl: 'http://localhost:11434/v1',
+    });
+
+    expect(result.content).toBe('local response');
+  });
+
+  it('converts 429 errors to QuotaError', async () => {
+    const rateLimitErr = Object.assign(new Error('rate_limit_error'), { status: 429 });
+    mockCreate.mockRejectedValueOnce(rateLimitErr);
+
+    try {
+      await invokeOpenAIOrchestrator(baseOpts);
+      expect.fail('Should have thrown');
+    } catch (err) {
+      expect((err as Error).name).toBe('QuotaError');
+    }
+  });
+
+  it('wraps other API errors with [Totem Error] prefix', async () => {
+    mockCreate.mockRejectedValueOnce(new Error('invalid_api_key'));
+
+    await expect(invokeOpenAIOrchestrator(baseOpts)).rejects.toThrow(
+      '[Totem Error] OpenAI API call failed',
+    );
+  });
+
+  it('handles missing usage gracefully (local servers)', async () => {
+    mockCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: 'no usage' }, finish_reason: 'stop' }],
+      // No usage field — some local servers omit this
+    });
+
+    const result = await invokeOpenAIOrchestrator(baseOpts);
+
+    expect(result.content).toBe('no usage');
+    expect(result.inputTokens).toBeNull();
+    expect(result.outputTokens).toBeNull();
+  });
+
+  it('handles empty choices array', async () => {
+    mockCreate.mockResolvedValueOnce({
+      choices: [],
+      usage: { prompt_tokens: 10, completion_tokens: 0 },
+    });
+
+    const result = await invokeOpenAIOrchestrator(baseOpts);
+
+    expect(result.content).toBe('');
+    expect(result.finishReason).toBeUndefined();
+  });
+
+  it('handles null message content', async () => {
+    mockCreate.mockResolvedValueOnce({
+      choices: [{ message: { content: null }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+    });
+
+    const result = await invokeOpenAIOrchestrator(baseOpts);
+    expect(result.content).toBe('');
+  });
+});

--- a/packages/cli/src/orchestrators/openai-orchestrator.ts
+++ b/packages/cli/src/orchestrators/openai-orchestrator.ts
@@ -1,0 +1,87 @@
+import { log } from '../ui.js';
+import type { OrchestratorInvokeOptions, OrchestratorResult } from './orchestrator.js';
+import { detectPackageManager, isQuotaError } from './orchestrator.js';
+
+// ─── Constants ───────────────────────────────────────
+
+const DEFAULT_MAX_TOKENS = 16_384;
+
+/**
+ * Dummy API key for local OpenAI-compatible servers (Ollama, LM Studio)
+ * that don't require authentication but where the SDK mandates a key.
+ */
+const LOCAL_DUMMY_KEY = 'totem-local';
+
+// ─── SDK loader (BYOSD) ─────────────────────────────
+
+async function importOpenAISdk() {
+  try {
+    return (await import('openai')).default;
+  } catch {
+    throw new Error(
+      '[Totem Error] OpenAI SDK (openai) is not installed.\n' +
+        `Install it with: ${detectPackageManager()} add openai\n` +
+        "Or use provider: 'shell' in your orchestrator config.",
+    );
+  }
+}
+
+// ─── OpenAI-compatible API orchestrator ─────────────
+
+/**
+ * Invoke an OpenAI-compatible API via the `openai` SDK.
+ * Supports OpenAI, Ollama, LM Studio, Groq, OpenRouter, and any
+ * server implementing the `/v1/chat/completions` endpoint.
+ *
+ * @see https://github.com/mmnto-ai/totem/issues/285
+ */
+export async function invokeOpenAIOrchestrator(
+  opts: OrchestratorInvokeOptions & { baseUrl?: string },
+): Promise<OrchestratorResult> {
+  const { prompt, model, tag, baseUrl } = opts;
+
+  // For local servers, use a dummy key if none is set
+  const apiKey = process.env['OPENAI_API_KEY'] ?? (baseUrl ? LOCAL_DUMMY_KEY : undefined);
+  if (!apiKey) {
+    throw new Error(
+      '[Totem Error] No OpenAI API key found.\n' +
+        'Set OPENAI_API_KEY in your .env file, or add a baseUrl for local servers (Ollama, LM Studio).',
+    );
+  }
+
+  const OpenAI = await importOpenAISdk();
+  const client = new OpenAI({
+    apiKey,
+    ...(baseUrl && { baseURL: baseUrl }),
+  });
+
+  const serverLabel = baseUrl ? `OpenAI-compatible API (${baseUrl})` : 'OpenAI API';
+  log.info(tag, `Invoking ${serverLabel} (this may take 15-60 seconds)...`);
+  const startMs = Date.now();
+
+  try {
+    const response = await client.chat.completions.create({
+      model,
+      max_tokens: DEFAULT_MAX_TOKENS,
+      messages: [{ role: 'user' as const, content: prompt }],
+    });
+
+    const durationMs = Date.now() - startMs;
+    const choice = response.choices[0];
+
+    return {
+      content: choice?.message?.content ?? '',
+      inputTokens: response.usage?.prompt_tokens ?? null,
+      outputTokens: response.usage?.completion_tokens ?? null,
+      durationMs,
+      finishReason: choice?.finish_reason ?? undefined,
+    };
+  } catch (err) {
+    if (isQuotaError(err)) {
+      (err as Error).name = 'QuotaError';
+      throw err;
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`[Totem Error] OpenAI API call failed: ${msg}`);
+  }
+}

--- a/packages/cli/src/orchestrators/orchestrator.test.ts
+++ b/packages/cli/src/orchestrators/orchestrator.test.ts
@@ -30,6 +30,15 @@ vi.mock('./anthropic-orchestrator.js', () => ({
   }),
 }));
 
+vi.mock('./openai-orchestrator.js', () => ({
+  invokeOpenAIOrchestrator: vi.fn().mockResolvedValue({
+    content: 'openai result',
+    inputTokens: 150,
+    outputTokens: 60,
+    durationMs: 1500,
+  }),
+}));
+
 // ─── Tests ──────────────────────────────────────────
 
 describe('createOrchestrator', () => {
@@ -86,6 +95,29 @@ describe('createOrchestrator', () => {
     });
     expect(result.content).toBe('anthropic result');
     expect(result.inputTokens).toBe(200);
+  });
+
+  it('returns a function for openai provider', () => {
+    const config: OrchestratorConfig = {
+      provider: 'openai',
+      defaultModel: 'gpt-4o',
+    };
+    const invoke = createOrchestrator(config);
+    expect(typeof invoke).toBe('function');
+  });
+
+  it('openai invoker dispatches to openai-orchestrator module', async () => {
+    const config: OrchestratorConfig = { provider: 'openai' };
+    const invoke = createOrchestrator(config);
+    const result = await invoke({
+      prompt: 'test',
+      model: 'gpt-4o',
+      cwd: '.',
+      tag: 'Test',
+      totemDir: '.totem',
+    });
+    expect(result.content).toBe('openai result');
+    expect(result.inputTokens).toBe(150);
   });
 });
 
@@ -235,6 +267,13 @@ describe('parseModelString', () => {
     expect(parseModelString('gemini:gemini-3.1-pro-preview', 'anthropic')).toEqual({
       provider: 'gemini',
       model: 'gemini-3.1-pro-preview',
+    });
+  });
+
+  it('parses openai:model into provider and model', () => {
+    expect(parseModelString('openai:gpt-4o', 'gemini')).toEqual({
+      provider: 'openai',
+      model: 'gpt-4o',
     });
   });
 

--- a/packages/cli/src/orchestrators/orchestrator.ts
+++ b/packages/cli/src/orchestrators/orchestrator.ts
@@ -59,7 +59,7 @@ export function isQuotaError(err: unknown): boolean {
 
 // ─── Model string parsing (#243) ─────────────────────
 
-const KNOWN_PROVIDERS = ['gemini', 'anthropic', 'shell'] as const;
+const KNOWN_PROVIDERS = ['gemini', 'anthropic', 'openai', 'shell'] as const;
 
 /**
  * Parse a `provider:model` string into its components.
@@ -151,6 +151,11 @@ export function createOrchestrator(config: OrchestratorConfig): InvokeOrchestrat
       return async (opts) => {
         const { invokeAnthropicOrchestrator } = await import('./anthropic-orchestrator.js');
         return invokeAnthropicOrchestrator(opts);
+      };
+    case 'openai':
+      return async (opts) => {
+        const { invokeOpenAIOrchestrator } = await import('./openai-orchestrator.js');
+        return invokeOpenAIOrchestrator({ ...opts, baseUrl: config.baseUrl });
       };
   }
 }

--- a/packages/core/src/config-schema.test.ts
+++ b/packages/core/src/config-schema.test.ts
@@ -126,8 +126,22 @@ describe('OrchestratorSchema', () => {
     }
   });
 
-  it('rejects unknown provider', () => {
+  it('accepts openai provider', () => {
     const result = OrchestratorSchema.safeParse({ provider: 'openai' });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts openai provider with baseUrl', () => {
+    const result = OrchestratorSchema.safeParse({
+      provider: 'openai',
+      baseUrl: 'http://localhost:11434/v1',
+      defaultModel: 'llama3.1',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects unknown provider', () => {
+    const result = OrchestratorSchema.safeParse({ provider: 'cohere' });
     expect(result.success).toBe(false);
   });
 

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -71,10 +71,18 @@ export const AnthropicOrchestratorSchema = z.object({
   ...BaseOrchestratorFields,
 });
 
+export const OpenAIOrchestratorSchema = z.object({
+  provider: z.literal('openai'),
+  /** Optional base URL for OpenAI-compatible servers (Ollama, LM Studio, etc.) */
+  baseUrl: z.string().url().optional(),
+  ...BaseOrchestratorFields,
+});
+
 export const OrchestratorSchema = z.discriminatedUnion('provider', [
   ShellOrchestratorSchema,
   GeminiOrchestratorSchema,
   AnthropicOrchestratorSchema,
+  OpenAIOrchestratorSchema,
 ]);
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.13
+      openai:
+        specifier: ^4.77.0
+        version: 4.104.0(zod@3.25.76)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -1181,7 +1184,6 @@ packages:
     dependencies:
       '@types/node': 22.19.13
       form-data: 4.0.5
-    dev: false
 
   /@types/node@12.20.55:
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -1191,7 +1193,6 @@ packages:
     resolution: {integrity: sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==}
     dependencies:
       undici-types: 5.26.5
-    dev: false
 
   /@types/node@20.19.35:
     resolution: {integrity: sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==}
@@ -1479,7 +1480,6 @@ packages:
     engines: {node: '>=6.5'}
     dependencies:
       event-target-shim: 5.0.1
-    dev: false
 
   /accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
@@ -1513,7 +1513,6 @@ packages:
     engines: {node: '>= 8.0.0'}
     dependencies:
       humanize-ms: 1.2.1
-    dev: false
 
   /ajv-formats@3.0.1(ajv@8.18.0):
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -1616,7 +1615,6 @@ packages:
 
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    dev: false
 
   /bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -1701,7 +1699,6 @@ packages:
     dependencies:
       es-errors: 1.3.0
       function-bind: 1.1.2
-    dev: false
 
   /call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
@@ -1791,7 +1788,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
-    dev: false
 
   /command-line-args@5.2.1:
     resolution: {integrity: sha512-H4UfQhZyakIjC74I9d34fGYDwk3XpSr17QhEd0Q3I9Xq1CETHo4Hcuo87WyWHpAF1aSLjLRf5lD9ZGX2qStUvg==}
@@ -1888,7 +1884,6 @@ packages:
   /delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
-    dev: false
 
   /depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -1925,7 +1920,6 @@ packages:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
-    dev: false
 
   /eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -1965,12 +1959,10 @@ packages:
   /es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
-    dev: false
 
   /es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
-    dev: false
 
   /es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -1981,7 +1973,6 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       es-errors: 1.3.0
-    dev: false
 
   /es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
@@ -1991,7 +1982,6 @@ packages:
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
       hasown: 2.0.2
-    dev: false
 
   /esbuild@0.27.3:
     resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
@@ -2175,7 +2165,6 @@ packages:
   /event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
-    dev: false
 
   /eventsource-parser@3.0.6:
     resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
@@ -2381,7 +2370,6 @@ packages:
 
   /form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
-    dev: false
 
   /form-data@4.0.5:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
@@ -2392,7 +2380,6 @@ packages:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
-    dev: false
 
   /format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
@@ -2405,7 +2392,6 @@ packages:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 4.0.0-beta.3
-    dev: false
 
   /formdata-polyfill@4.0.10:
     resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
@@ -2452,7 +2438,6 @@ packages:
 
   /function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-    dev: false
 
   /gaxios@7.1.3:
     resolution: {integrity: sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==}
@@ -2496,7 +2481,6 @@ packages:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
-    dev: false
 
   /get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -2504,7 +2488,6 @@ packages:
     dependencies:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
-    dev: false
 
   /glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -2581,7 +2564,6 @@ packages:
   /gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
-    dev: false
 
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -2595,21 +2577,18 @@ packages:
   /has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
     engines: {node: '>= 0.4'}
-    dev: false
 
   /has-tostringtag@1.0.2:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-symbols: 1.1.0
-    dev: false
 
   /hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
-    dev: false
 
   /hono@4.12.3:
     resolution: {integrity: sha512-SFsVSjp8sj5UumXOOFlkZOG6XS9SJDKw0TbwFeV+AJ8xlST8kxK5Z/5EYa111UY8732lK2S/xB653ceuaoGwpg==}
@@ -2646,7 +2625,6 @@ packages:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
     dependencies:
       ms: 2.1.3
-    dev: false
 
   /iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -2915,7 +2893,6 @@ packages:
   /math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
-    dev: false
 
   /mdast-util-from-markdown@2.0.3:
     resolution: {integrity: sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==}
@@ -3186,7 +3163,6 @@ packages:
   /mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
-    dev: false
 
   /mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
@@ -3198,7 +3174,6 @@ packages:
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
-    dev: false
 
   /mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
@@ -3272,7 +3247,6 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
-    dev: false
 
   /node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
@@ -3344,7 +3318,6 @@ packages:
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding
-    dev: false
 
   /optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -4007,7 +3980,6 @@ packages:
 
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: false
 
   /tree-sitter-javascript@0.23.1:
     resolution: {integrity: sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==}
@@ -4180,7 +4152,6 @@ packages:
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-    dev: false
 
   /undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -4530,7 +4501,6 @@ packages:
   /web-streams-polyfill@4.0.0-beta.3:
     resolution: {integrity: sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==}
     engines: {node: '>= 14'}
-    dev: false
 
   /web-tree-sitter@0.26.6:
     resolution: {integrity: sha512-fSPR7VBW/fZQdUSp/bXTDLT+i/9dwtbnqgEBMzowrM4U3DzeCwDbY3MKo0584uQxID4m/1xpLflrlT/rLIRPew==}
@@ -4538,14 +4508,12 @@ packages:
 
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-    dev: false
 
   /whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-    dev: false
 
   /which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}


### PR DESCRIPTION
## Summary
- Add `openai` provider to orchestrator config, enabling OpenAI, Ollama, LM Studio, Groq, OpenRouter, and any `/v1/chat/completions`-compatible server
- BYOSD pattern: `openai` is an optional peer dep, lazily loaded at runtime
- Dummy API key fallback (`totem-local`) for local servers that don't require auth
- Defensive handling for servers that omit `usage` stats in responses
- Config: `provider: 'openai'` with optional `baseUrl` for local endpoints

## Test plan
- [x] All 358 tests pass (6/6 turbo tasks)
- [x] 9 new unit tests for `openai-orchestrator.ts` (happy path, local baseUrl, missing key, quota errors, missing usage, empty choices, null content)
- [x] Conformance suite extended with 5 OpenAI parity tests (same contract as Gemini/Anthropic)
- [x] `createOrchestrator` factory tests for openai provider
- [x] `parseModelString` test for `openai:model` prefix
- [x] Config schema tests for openai provider + baseUrl validation
- [x] `totem shield --deterministic` passes (24 rules, 0 violations)

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)