### PR TITLE
chore: update default model IDs + add supported models doc

### DIFF
--- a/.changeset/bulletproof-ingestion-model-audit.md
+++ b/.changeset/bulletproof-ingestion-model-audit.md
@@ -1,0 +1,13 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+'@mmnto/mcp': patch
+---
+
+Adversarial ingestion scrubbing, eval harness, Bun support, and model audit
+
+- **Adversarial ingestion scrubbing:** `sanitizeForIngestion()` strips BiDi overrides (Trojan Source defense) from all content types and invisible Unicode from prose chunks. Suspicious patterns flagged via `onWarn` but never stripped. Detection regexes consolidated into core for DRY reuse. XML tag regex hardened against whitespace bypass.
+- **Adversarial evaluation harness:** Integration tests with planted architectural violations for model drift detection. Deterministic tests run without API keys; LLM tests gated behind `CI_INTEGRATION=true` for nightly runs against Gemini, Anthropic, and OpenAI.
+- **Bun support:** `detectTotemPrefix()` checks for both `bun.lockb` (legacy) and `bun.lock` (Bun >= 1.2). Priority: pnpm > yarn > bun > npx.
+- **Model audit:** Updated default orchestrator model IDs — Anthropic to `claude-sonnet-4-6`, OpenAI to `gpt-5.4`/`gpt-5-mini`.
+- **Supported models doc:** New `docs/supported-models.md` with provider model listing APIs and discovery scripts.

--- a/.totem/lessons.md
+++ b/.totem/lessons.md
@@ -1094,3 +1094,39 @@ Detect existing hook managers like Husky or Lefthook and provide manual integrat
 **Tags:** git, safety, automation
 
 Validate that an existing git hook is a shell script (e.g., by checking for a shebang) before attempting to append automated logic. This prevents the corruption of binary or specialized hooks that cannot handle string-based appends.
+
+## Lesson — Automated review tools often have stale knowledge of the
+
+**Tags:** llm, testing, integration
+
+Automated review tools often have stale knowledge of the latest or experimental model identifiers (e.g., `gemini-2.5-flash`). Prioritize model IDs proven to work in existing smoke tests over AI suggestions that flag them as typos.
+
+## Lesson — Avoid adding explicit runtime guards for conditions that
+
+**Tags:** typescript, refactoring
+
+Avoid adding explicit runtime guards for conditions that are already prohibited by strict TypeScript interfaces. Redundant checks for "cannot happen" states like `undefined` on a required property add clutter without improving safety when the design contract is already enforced.
+
+## Lesson — During data ingestion, strip high-risk security threats
+
+**Tags:** security, ingestion
+
+During data ingestion, strip high-risk security threats like BiDi overrides (Trojan Source) but only flag patterns like XML tags or Base64 via warnings. This prevents malicious injection while preserving the integrity of legitimate content that happens to use those formats.
+
+## Lesson — When detecting project environments, use a consistent
+
+**Tags:** bun, nodejs, devops
+
+When detecting project environments, use a consistent priority order (e.g., pnpm > yarn > bun > npx) to ensure specific lockfiles are honored. This includes checking for both legacy (`bun.lockb`) and modern (`bun.lock`) versions to maintain compatibility across tool versions.
+
+## Lesson — Implement an adversarial evaluation harness with planted
+
+**Tags:** testing, llm, quality-assurance
+
+Implement an adversarial evaluation harness with planted architectural violations to monitor LLM performance over time. Combining deterministic regex-based tests with gated LLM integration tests ensures that model drift is caught when reasoning fails to identify known traps.
+
+## Lesson — Moving security-sensitive regexes (like BiDi stripping or…
+
+**Tags:** security, regex, refactoring
+
+Moving security-sensitive regexes (like BiDi stripping or XML bypass defense) from CLI tools to core packages ensures consistent adversarial scrubbing across both ingestion pipelines and runtime shields. Hardening these patterns against whitespace bypasses (e.g., optional whitespace after closing slash in tags) prevents common prompt injection evasion techniques.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -88,7 +88,7 @@ Direct SDK calls using the standard OpenAI-compatible format. Ideal for official
 ```typescript
 orchestrator: {
   provider: 'openai',
-  defaultModel: 'gpt-4o',
+  defaultModel: 'gpt-5.4',
   // Supports custom endpoints via standard OpenAI configuration
 }
 ```
@@ -123,7 +123,7 @@ Direct SDK calls via `@anthropic-ai/sdk`. Requires `ANTHROPIC_API_KEY`:
 ```typescript
 orchestrator: {
   provider: 'anthropic',
-  defaultModel: 'claude-sonnet-4-5-20250514',
+  defaultModel: 'claude-sonnet-4-6',
 }
 ```
 

--- a/docs/supported-models.md
+++ b/docs/supported-models.md
@@ -1,0 +1,139 @@
+# Supported Models Reference
+
+> **Last validated:** 2026-03-10
+
+Totem supports four AI provider families. This document tracks the current
+recommended model IDs for each and how to programmatically discover new ones.
+
+---
+
+## Orchestrator Models (LLM Calls)
+
+Used by `totem shield`, `totem spec`, `totem triage`, `totem extract`, etc.
+
+### Google Gemini
+
+| Role                | Model ID                 | Notes                                           |
+| ------------------- | ------------------------ | ----------------------------------------------- |
+| Default (fast)      | `gemini-3-flash-preview` | Preview — current Totem default                 |
+| Pro (complex tasks) | `gemini-3.1-pro-preview` | Preview — used for spec/shield/triage overrides |
+| Stable fast         | `gemini-2.5-flash`       | GA release, used in smoke/eval tests            |
+| Stable pro          | `gemini-2.5-pro`         | GA release                                      |
+| Ultra-cheap         | `gemini-2.5-flash-lite`  | Minimal cost                                    |
+
+**Listing API:** `GET https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY`
+
+- Auth: API key as query parameter
+- Docs: https://ai.google.dev/api/models
+
+### Anthropic (Claude)
+
+| Role              | Model ID            | Dated Snapshot               |
+| ----------------- | ------------------- | ---------------------------- |
+| Flagship          | `claude-opus-4-6`   | Latest Opus                  |
+| Fast/balanced     | `claude-sonnet-4-6` | Latest Sonnet                |
+| Cheapest          | `claude-haiku-4-5`  | `claude-haiku-4-5-20251001`  |
+| Legacy Sonnet 4.5 | `claude-sonnet-4-5` | `claude-sonnet-4-5-20250929` |
+| Legacy Sonnet 4   | `claude-sonnet-4-0` | `claude-sonnet-4-20250514`   |
+
+**Listing API:** `GET https://api.anthropic.com/v1/models`
+
+- Auth: `X-Api-Key` header + `anthropic-version: 2023-06-01`
+- Docs: https://docs.anthropic.com/en/docs/about-claude/models
+- Note: Anthropic does **not** offer an embedding model.
+
+### OpenAI
+
+| Role                 | Model ID                  | Notes                    |
+| -------------------- | ------------------------- | ------------------------ |
+| Flagship             | `gpt-5.4`                 | Latest                   |
+| Pro (higher compute) | `gpt-5.4-pro`             | Higher token limits      |
+| Fast/cheap           | `gpt-5-mini`              | Cost-optimized           |
+| Ultra-cheap          | `gpt-5-nano`              | Smallest                 |
+| Reasoning (best)     | `o3-pro`                  | Slow but powerful        |
+| Reasoning (fast)     | `o4-mini`                 | Cost-efficient reasoning |
+| Previous gen         | `gpt-4o`, `gpt-4o-mini`   | Legacy, still available  |
+| Previous gen         | `gpt-4.1`, `gpt-4.1-mini` | Still available          |
+
+**Listing API:** `GET https://api.openai.com/v1/models`
+
+- Auth: `Authorization: Bearer $OPENAI_API_KEY`
+- Docs: https://platform.openai.com/docs/models
+
+### Ollama (Local)
+
+Ollama runs models locally. Any model from the [Ollama library](https://ollama.com/search)
+can be used as an orchestrator. Popular choices:
+
+| Model           | Parameters  | Notes                  |
+| --------------- | ----------- | ---------------------- |
+| `llama3.1`      | 8B/70B/405B | Meta's flagship        |
+| `qwen2.5-coder` | 7B/32B      | Code-specialized       |
+| `phi3`          | 3.8B/14B    | Microsoft, lightweight |
+
+**Listing API (local):** `GET http://localhost:11434/api/tags`
+
+- Auth: None (local server)
+- Lists only downloaded models. Browse full library at https://ollama.com/search
+- Docs: https://github.com/ollama/ollama/blob/main/docs/api.md
+
+---
+
+## Embedding Models (Vector Search)
+
+Used by `totem sync` for indexing chunks into LanceDB.
+
+| Provider             | Model ID                 | Dimensions | Notes                          |
+| -------------------- | ------------------------ | ---------- | ------------------------------ |
+| **OpenAI** (default) | `text-embedding-3-small` | 1536       | Lowest onboarding friction     |
+| OpenAI (large)       | `text-embedding-3-large` | 3072       | Higher quality, higher cost    |
+| **Ollama** (offline) | `nomic-embed-text`       | 768        | 56M+ pulls, most popular local |
+| Ollama               | `mxbai-embed-large`      | 1024       | BERT-large class SOTA          |
+| Ollama               | `qwen3-embedding`        | varies     | Newest, fast-growing           |
+| Gemini               | `gemini-embedding-001`   | —          | Not yet supported in Totem     |
+
+---
+
+## Totem Defaults
+
+Current defaults configured in `totem.config.ts` and `packages/cli/src/commands/init.ts`:
+
+```
+Embedding:    OpenAI text-embedding-3-small  (or Ollama nomic-embed-text)
+Orchestrator: Gemini gemini-3-flash-preview  (overrides: gemini-3.1-pro-preview for spec/shield/triage)
+```
+
+### Updating Defaults
+
+When a provider releases new stable models, update these locations:
+
+1. `packages/core/src/config-schema.ts` — Zod schema defaults (embeddings only)
+2. `packages/core/src/embedders/openai-embedder.ts` — constructor default
+3. `packages/core/src/embedders/ollama-embedder.ts` — constructor default
+4. `packages/cli/src/commands/init.ts` — config generation templates
+5. `docs/architecture.md` — documentation examples
+6. `totem.config.ts` — project root config (this repo's own config)
+7. Test files — smoke, integration, and unit tests referencing specific model IDs
+
+---
+
+## Model Discovery Scripts
+
+Quick one-liners to check available models from each provider:
+
+```bash
+# Gemini — list all models
+curl -s "https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY" | jq '.models[].name'
+
+# Anthropic — list all models
+curl -s https://api.anthropic.com/v1/models \
+  -H "X-Api-Key: $ANTHROPIC_API_KEY" \
+  -H "anthropic-version: 2023-06-01" | jq '.data[].id'
+
+# OpenAI — list all models
+curl -s https://api.openai.com/v1/models \
+  -H "Authorization: Bearer $OPENAI_API_KEY" | jq '.data[].id' | sort
+
+# Ollama — list locally downloaded models
+curl -s http://localhost:11434/api/tags | jq '.models[].name'
+```

--- a/packages/cli/src/commands/shield-eval.integration.test.ts
+++ b/packages/cli/src/commands/shield-eval.integration.test.ts
@@ -379,7 +379,7 @@ describe.runIf(process.env['CI_INTEGRATION'] === 'true')(
             targets: [{ glob: 'src/**/*.ts', type: 'code', strategy: 'typescript-ast' }],
             totemDir: '.totem',
             lanceDir: '.lancedb',
-            orchestrator: { provider: 'openai', model: 'gpt-4o-mini' },
+            orchestrator: { provider: 'openai', model: 'gpt-5-mini' },
           };
         `;
         fs.writeFileSync(path.join(tmpDir, 'totem.config.ts'), config);

--- a/packages/cli/src/orchestrators/anthropic-orchestrator.test.ts
+++ b/packages/cli/src/orchestrators/anthropic-orchestrator.test.ts
@@ -23,7 +23,7 @@ vi.mock('../ui.js', () => ({
 describe('invokeAnthropicOrchestrator', () => {
   const baseOpts = {
     prompt: 'test prompt',
-    model: 'claude-sonnet-4-5-20250514',
+    model: 'claude-sonnet-4-6',
     cwd: '.',
     tag: 'Test',
     totemDir: '.totem',
@@ -65,7 +65,7 @@ describe('invokeAnthropicOrchestrator', () => {
 
     expect(mockCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        model: 'claude-sonnet-4-5-20250514',
+        model: 'claude-sonnet-4-6',
         messages: [{ role: 'user', content: 'test prompt' }],
       }),
     );

--- a/packages/cli/src/orchestrators/openai-orchestrator.test.ts
+++ b/packages/cli/src/orchestrators/openai-orchestrator.test.ts
@@ -23,7 +23,7 @@ vi.mock('../ui.js', () => ({
 describe('invokeOpenAIOrchestrator', () => {
   const baseOpts = {
     prompt: 'test prompt',
-    model: 'gpt-4o',
+    model: 'gpt-5.4',
     cwd: '.',
     tag: 'Test',
     totemDir: '.totem',
@@ -63,7 +63,7 @@ describe('invokeOpenAIOrchestrator', () => {
 
     expect(mockCreate).toHaveBeenCalledWith(
       expect.objectContaining({
-        model: 'gpt-4o',
+        model: 'gpt-5.4',
         messages: [{ role: 'user', content: 'test prompt' }],
       }),
     );

--- a/packages/cli/src/orchestrators/orchestrator.test.ts
+++ b/packages/cli/src/orchestrators/orchestrator.test.ts
@@ -63,7 +63,7 @@ describe('createOrchestrator', () => {
   it('returns a function for anthropic provider', () => {
     const config: OrchestratorConfig = {
       provider: 'anthropic',
-      defaultModel: 'claude-sonnet-4-5-20250514',
+      defaultModel: 'claude-sonnet-4-6',
     };
     const invoke = createOrchestrator(config);
     expect(typeof invoke).toBe('function');
@@ -88,7 +88,7 @@ describe('createOrchestrator', () => {
     const invoke = createOrchestrator(config);
     const result = await invoke({
       prompt: 'test',
-      model: 'claude-sonnet-4-5-20250514',
+      model: 'claude-sonnet-4-6',
       cwd: '.',
       tag: 'Test',
       totemDir: '.totem',
@@ -100,7 +100,7 @@ describe('createOrchestrator', () => {
   it('returns a function for openai provider', () => {
     const config: OrchestratorConfig = {
       provider: 'openai',
-      defaultModel: 'gpt-4o',
+      defaultModel: 'gpt-5.4',
     };
     const invoke = createOrchestrator(config);
     expect(typeof invoke).toBe('function');
@@ -111,7 +111,7 @@ describe('createOrchestrator', () => {
     const invoke = createOrchestrator(config);
     const result = await invoke({
       prompt: 'test',
-      model: 'gpt-4o',
+      model: 'gpt-5.4',
       cwd: '.',
       tag: 'Test',
       totemDir: '.totem',
@@ -271,9 +271,9 @@ describe('parseModelString', () => {
   });
 
   it('parses openai:model into provider and model', () => {
-    expect(parseModelString('openai:gpt-4o', 'gemini')).toEqual({
+    expect(parseModelString('openai:gpt-5.4', 'gemini')).toEqual({
       provider: 'openai',
-      model: 'gpt-4o',
+      model: 'gpt-5.4',
     });
   });
 

--- a/packages/core/src/config-schema.test.ts
+++ b/packages/core/src/config-schema.test.ts
@@ -28,7 +28,7 @@ const GEMINI_ORCHESTRATOR = {
 
 const ANTHROPIC_ORCHESTRATOR = {
   provider: 'anthropic' as const,
-  defaultModel: 'claude-sonnet-4-5-20250514',
+  defaultModel: 'claude-sonnet-4-6',
 };
 
 describe('TotemConfigSchema', () => {


### PR DESCRIPTION
## Summary

- **Model audit:** Updated outdated orchestrator defaults across tests and docs — Anthropic `claude-sonnet-4-5-20250514` → `claude-sonnet-4-6`, OpenAI `gpt-4o` → `gpt-5.4`, `gpt-4o-mini` → `gpt-5-mini`
- **Supported models doc:** New `docs/supported-models.md` with current model IDs for all providers, listing API endpoints, discovery scripts, and update checklist
- **Changeset:** Covers both #323 (adversarial scrubbing) and this PR for 0.25.0 release

Note: `config-schema.ts`, `init.ts`, and `totem.config.ts` were audited and confirmed to have no Anthropic/OpenAI orchestrator defaults — they only reference Gemini models. Embedding defaults (`text-embedding-3-small`, `nomic-embed-text`) are current and unchanged.

Closes #324, Closes #325

## Test plan

- [x] Full test suite passes (443 tests across 26 files)
- [x] `MODEL_NAME_RE` already supports dots — `gpt-5.4` passes validation
- [x] Prettier format clean
- [x] Pre-push hooks passed (format, lint, tests, deterministic shield)

🤖 Generated with [Claude Code](https://claude.com/claude-code)