### PR TITLE
fix: guard pre-push shield gate against missing CLI in CI

### DIFF
--- a/tools/pre-push
+++ b/tools/pre-push
@@ -26,8 +26,8 @@ fi
 
 echo "[totem] ✅ All pre-push checks passed."
 
-# Deterministic shield gate — only runs when compiled rules exist.
-if [ -f ".totem/compiled-rules.json" ]; then
+# Deterministic shield gate — only runs when compiled rules exist AND CLI is available.
+if [ -f ".totem/compiled-rules.json" ] && pnpm exec totem --version > /dev/null 2>&1; then
   echo "[totem] Running deterministic shield..."
   pnpm exec totem shield --deterministic
   if [ $? -ne 0 ]; then


### PR DESCRIPTION
## Summary

- Pre-push hook now checks CLI availability before running deterministic shield
- Fixes Release workflow failure where `pnpm exec totem` wasn't available after Changesets publish

One-line change: `if [ -f ".totem/compiled-rules.json" ]` → `if [ -f ".totem/compiled-rules.json" ] && pnpm exec totem --version > /dev/null 2>&1`

## Test plan

- [x] Pre-push hook still runs shield locally (CLI is available)
- [x] CI environments without built CLI skip shield gracefully
- [x] Deterministic shield passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)