### PR TITLE
chore: add changeset for 0.27.0

### DIFF
--- a/.changeset/shield-fileglobs-saga-validator.md
+++ b/.changeset/shield-fileglobs-saga-validator.md
@@ -1,7 +1,7 @@
 ---
-"@mmnto/totem": minor
-"@mmnto/cli": minor
-"@mmnto/mcp": minor
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+'@mmnto/mcp': minor
 ---
 
 feat: saga validator for `totem docs` — deterministic post-update validation catches LLM hallucinations (checkbox mutations, sentinel corruption, frontmatter deletion, excessive content loss) before writing to disk (#356)


### PR DESCRIPTION
## Summary
- Adds changeset for 0.27.0 release (minor bump for all 3 packages)
- Covers #356 (saga validator) and #357 (shield fileGlobs scoping)

Once merged, the changesets bot will open a "Version Packages" PR to bump versions and update CHANGELOGs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)