### PR TITLE
feat: --cwd flag for MCP server + strategy Totem init

### DIFF
--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -12,9 +12,17 @@ import { registerSearchKnowledge } from './tools/search-knowledge.js';
 
 // Support --cwd flag to run against a different project root
 const cwdFlagIdx = process.argv.indexOf('--cwd');
-if (cwdFlagIdx !== -1 && process.argv[cwdFlagIdx + 1]) {
-  const targetDir = path.resolve(process.argv[cwdFlagIdx + 1]);
-  process.chdir(targetDir);
+if (cwdFlagIdx !== -1) {
+  const cwdValue = process.argv[cwdFlagIdx + 1];
+  if (!cwdValue || cwdValue.startsWith('-')) {
+    throw new Error('[Totem Error] --cwd flag requires a directory path argument.');
+  }
+  try {
+    process.chdir(path.resolve(cwdValue));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    throw new Error(`[Totem Error] Failed to change directory to "${cwdValue}": ${message}`);
+  }
 }
 
 const require = createRequire(import.meta.url);


### PR DESCRIPTION
## Summary

- **MCP `--cwd` flag:** The MCP server entrypoint now accepts `--cwd <path>` to run against a different project root. Enables multi-domain knowledge architecture — one MCP server per knowledge domain.
- **Strategy Totem initialized:** 1,430 chunks from 100 files (30 ADRs, 9 proposals, 25 deep research docs, WWND ledgers, competitive analysis). Indexed and searchable via `totem-strategy` MCP server.
- **Submodule boundary:** Removed `.strategy/**/*.md` from public Totem targets. Strategy content is now exclusively indexed by the strategy Totem instance.

## Agent config (gitignored, local setup)

```json
"totem-strategy": {
  "command": "node",
  "args": ["./packages/mcp/dist/index.js", "--cwd", ".strategy"]
}
```

## Test plan

- [x] MCP server starts with `--cwd .strategy`
- [x] Strategy sync: 1,430 chunks from 100 files
- [x] Full test suite passes
- [x] Shield passes

Closes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)