### PR TITLE
feat: totem demo — spinner showcase command

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -425,6 +425,19 @@ program
   });
 
 program
+  .command('demo')
+  .description('Show the Totem spinner with movie quotes')
+  .option('--duration <seconds>', 'How long to run (default: 6)', '6')
+  .action(async (opts: { duration: string }) => {
+    const { createSpinner } = await import('./ui.js');
+    const seconds = Math.max(1, Math.min(60, parseInt(opts.duration, 10) || 6));
+    const spinner = await createSpinner('Totem');
+    setTimeout(() => {
+      spinner.succeed(`Done — ${seconds}s of vibes`);
+    }, seconds * 1000);
+  });
+
+program
   .command('install-hooks')
   .description('Install git hooks interactively (legacy — prefer `totem hooks`)')
   .action(async () => {


### PR DESCRIPTION
## Summary

Adds `totem demo` — shows the Inception-themed spinner with cycling movie quotes. Useful for demos, onboarding, and verifying the CLI is installed correctly.

```bash
totem demo              # 6 seconds (default)
totem demo --duration 10  # 10 seconds
```

## Test plan

- [x] Command runs and shows spinner with quotes
- [x] Full test suite passes
- [x] Shield passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)