### PR TITLE
feat: add Copilot and Junie to totem init (#448)

### DIFF
--- a/.changeset/init-copilot-junie.md
+++ b/.changeset/init-copilot-junie.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/cli': minor
+---
+
+Add Copilot and Junie to totem init agent detection.
+
+- **Init:** Auto-detect JetBrains Junie (`.junie/`) and GitHub Copilot (`.github/copilot-instructions.md`)
+- **Init:** Correct Junie MCP path to `.junie/mcp/mcp.json` (was incorrectly using `.mcp.json`)
+- **Init:** Copilot gets reflex injection only (no MCP — Copilot doesn't support it)

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -77,7 +77,7 @@ interface DetectedProject {
   hasSessions: boolean;
 }
 
-type AiTool = 'Claude Code' | 'Gemini CLI' | 'Cursor';
+type AiTool = 'Claude Code' | 'Gemini CLI' | 'Cursor' | 'JetBrains Junie' | 'GitHub Copilot';
 
 export interface HookInstallerResult {
   file: string;
@@ -87,9 +87,9 @@ export interface HookInstallerResult {
 
 interface AiToolInfo {
   name: AiTool;
-  mcpPath: string;
+  mcpPath: string | null;
   reflexFile: string | null;
-  serverEntry: Record<string, unknown>;
+  serverEntry: Record<string, unknown> | null;
   hookInstaller?: (cwd: string) => Promise<HookInstallerResult[]>;
 }
 
@@ -370,6 +370,18 @@ const AI_TOOLS: AiToolInfo[] = [
     reflexFile: '.cursorrules',
     serverEntry: { type: 'stdio', command: npxCmd, args: npxArgs },
   },
+  {
+    name: 'JetBrains Junie',
+    mcpPath: '.junie/mcp/mcp.json',
+    reflexFile: '.junie/guidelines.md',
+    serverEntry: { command: npxCmd, args: npxArgs },
+  },
+  {
+    name: 'GitHub Copilot',
+    mcpPath: null,
+    reflexFile: '.github/copilot-instructions.md',
+    serverEntry: null,
+  },
 ];
 
 function detectAiTools(cwd: string): AiToolInfo[] {
@@ -384,6 +396,12 @@ function detectAiTools(cwd: string): AiToolInfo[] {
   }
   if (exists('.cursorrules') || exists('.cursor/mcp.json')) {
     detected.push(AI_TOOLS.find((t) => t.name === 'Cursor')!);
+  }
+  if (exists('.junie') || exists('.junie/guidelines.md')) {
+    detected.push(AI_TOOLS.find((t) => t.name === 'JetBrains Junie')!);
+  }
+  if (exists('.github/copilot-instructions.md')) {
+    detected.push(AI_TOOLS.find((t) => t.name === 'GitHub Copilot')!);
   }
 
   return detected;
@@ -907,6 +925,7 @@ export async function initCommand(): Promise<void> {
 
       // --- MCP scaffolding for selected tools ---
       for (const tool of selectedTools) {
+        if (!tool.mcpPath || !tool.serverEntry) continue;
         const filePath = path.join(cwd, tool.mcpPath);
         const result = scaffoldMcpConfig(filePath, tool.serverEntry);
 


### PR DESCRIPTION
## Summary

Adds JetBrains Junie and GitHub Copilot to `totem init` auto-detection:

- **Junie:** Detects `.junie/`, scaffolds MCP at `.junie/mcp/mcp.json` (correct path), injects reflexes into `.junie/guidelines.md`
- **Copilot:** Detects `.github/copilot-instructions.md`, injects reflexes only (Copilot has no MCP support)
- Guards MCP scaffolding against null paths (Copilot)

The full adapter pattern refactor (ADR-026) is deferred — this PR adds the agents to the existing `AI_TOOLS` array.

## Test plan

- [x] Full test suite passes
- [x] Shield passes
- [ ] GCA review

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)