### PR TITLE
chore: switch embedder to Gemini (gemini-embedding-2-preview)

### DIFF
--- a/totem.config.ts
+++ b/totem.config.ts
@@ -14,7 +14,7 @@ const config: TotemConfig = {
     { glob: '.totem/lessons.md', type: 'lesson', strategy: 'markdown-heading' },
   ],
 
-  embedding: { provider: 'openai', model: 'text-embedding-3-small' },
+  embedding: { provider: 'gemini', model: 'gemini-embedding-2-preview', dimensions: 768 },
 
   orchestrator: {
     provider: 'gemini',


### PR DESCRIPTION
## Summary
- Switch embedding provider from OpenAI `text-embedding-3-small` (1536d) to Gemini `gemini-embedding-2-preview` (768d)
- Task-type aware embeddings for better retrieval quality on code/docs
- Requires `totem sync --full` after merge to rebuild the index

Closes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)