### PR TITLE
fix: stale prompts — docs glossary, init model, reflex block

### DIFF
--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -50,6 +50,11 @@ Updated content here...
 </updated_document>
 \`\`\`
 
+## Command Glossary (DO NOT confuse these)
+- **\`totem lint\`**: Runs compiled AST/regex rules against a diff. Zero LLM. Fast (~2s). No API keys needed. Used in pre-push hooks and CI. Lives in the Lite configuration tier.
+- **\`totem shield\`**: AI-powered code review. Queries LanceDB for context, sends diff + knowledge to an LLM. Slow (~18s). Requires API keys. Used before opening PRs. Lives in the Full configuration tier.
+- These are DIFFERENT commands with DIFFERENT purposes. Never describe \`shield\` as "deterministic" or \`lint\` as "AI-powered."
+
 ## Formatting Rules
 - **Sub-Bullet Threshold:** When a feature list exceeds 3 items, use nested sub-bullets instead of comma-separated inline lists. Group related items into named categories (e.g., "Security:", "DX:", "Orchestration:").
 - **Completed Phase Summary:** Phases marked \`[x]\` should be summarized in 1-2 sentences max. Do NOT expand completed phases with every PR number — use categorized sub-bullets for the key capability areas only.

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -16,7 +16,7 @@ import { installEnforcementHooks, installPostMergeHook } from './install-hooks.j
 // Bump REFLEX_VERSION whenever the AI_PROMPT_BLOCK content changes materially.
 // This allows `totem init` to detect stale blocks and offer upgrades.
 
-export const REFLEX_VERSION = 2;
+export const REFLEX_VERSION = 3;
 const REFLEX_START = '<!-- totem:reflexes:start -->';
 const REFLEX_END = '<!-- totem:reflexes:end -->';
 const REFLEX_VERSION_RE = /<!-- totem:reflexes:version:(\d+) -->/;
@@ -43,7 +43,7 @@ Lessons are automatically re-indexed in the background after each \`add_lesson\`
 
 ### Memory Classification
 When deciding where to store information or rules, use this decision tree:
-- If forgetting this causes a mistake on an UNRELATED task (Core Safety): Store in your root agent memory file (e.g., CLAUDE.md or .gemini/gemini.md).
+- If forgetting this causes a mistake on an UNRELATED task (Core Safety): Store in your root agent memory file (e.g., CLAUDE.md or GEMINI.md).
 - If it's a stable, project-wide workflow rule: Store in project config (e.g., CLAUDE.md).
 - If it's a stable syntax/style pattern: Store in the project's styleguide or linter rules.
 - If it's domain knowledge, an edge case, or a past trap: You MUST use the Totem \`add_lesson\` tool to anchor it into the project's LanceDB.
@@ -53,7 +53,7 @@ When deciding where to store information or rules, use this decision tree:
 Totem provides CLI commands that map to your development lifecycle. Use them at these moments:
 1. **Start of Session:** Run \`totem briefing\` to get oriented with current branch state, open PRs, and recent context. Run \`totem triage\` if you need to pick a new task.
 2. **Before Implementation:** Run \`totem spec <issue-url-or-topic>\` to generate an architectural plan and review related context before writing code.
-3. **Before PR/Push:** Run \`totem shield\` to analyze uncommitted changes against project knowledge — catches architectural drift and pattern violations.
+3. **Before Push:** Run \`totem lint\` for a fast compiled-rules check (zero LLM, ~2s). **Before PR:** Run \`totem shield\` for a full AI-powered code review against project knowledge (~18s).
 4. **End of Session:** Run \`totem handoff\` to generate a snapshot for the next agent session with current progress and open threads.
 
 ### Cloud / PR Review Bots
@@ -567,7 +567,7 @@ export async function generateConfig(
       embeddingBlock = `  embedding: { provider: 'ollama', model: 'nomic-embed-text', baseUrl: 'http://localhost:11434' },`;
       break;
     case 'gemini':
-      embeddingBlock = `  embedding: { provider: 'gemini', model: 'text-embedding-004' },`;
+      embeddingBlock = `  embedding: { provider: 'gemini', model: 'gemini-embedding-2-preview', dimensions: 768 },`;
       break;
     case 'none':
       embeddingBlock = `  // embedding: { provider: 'openai', model: 'text-embedding-3-small' },\n  // Lite tier — set OPENAI_API_KEY and re-run \`totem init\` to enable sync/search.`;


### PR DESCRIPTION
## Summary
Prompt audit found 4 issues across 2 files:

1. **docs.ts**: Added command glossary to system prompt — prevents the LLM docs generator from confusing `totem lint` (deterministic) with `totem shield` (AI-powered). This has caused incorrect docs in 3 consecutive releases.
2. **init.ts**: Fixed Gemini embedder model from `text-embedding-004` (unavailable) to `gemini-embedding-2-preview`
3. **init.ts**: AI_PROMPT_BLOCK now distinguishes "Before Push → `totem lint`" from "Before PR → `totem shield`"
4. **init.ts**: Fixed stale `.gemini/gemini.md` reference → `GEMINI.md`
5. **REFLEX_VERSION** bumped to 3 (material prompt change)

## Why
The docs generator has confused lint and shield in every release since the split. The command glossary injection is the permanent fix. The init model name was wrong and would fail for new Gemini users.

## Test plan
- [x] 614 CLI tests pass
- [x] `totem lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)