### PR TITLE
fix: auto-healing DB — dimension mismatch + version recovery

### DIFF
--- a/packages/core/src/store/lance-store.ts
+++ b/packages/core/src/store/lance-store.ts
@@ -76,19 +76,15 @@ export class LanceStore {
   /** Check if the stored vector dimensions differ from the current embedder. */
   private async hasDimensionMismatch(): Promise<boolean> {
     if (!this.table) return false;
-    try {
-      const sample = await this.table.query().limit(1).toArray();
-      if (sample.length === 0) return false;
-      const row = sample[0] as Record<string, unknown>;
-      const vec = row['vector'];
-      if (Array.isArray(vec)) {
-        return vec.length !== this.embedder.dimensions;
-      }
-      return false;
-    } catch {
-      // Can't check — not a mismatch, might be empty or corrupted
-      return false;
+    // Let query errors bubble up to connect()'s catch block for auto-healing
+    const sample = await this.table.query().limit(1).toArray();
+    if (sample.length === 0) return false;
+    const row = sample[0] as Record<string, unknown>;
+    const vec = row['vector'];
+    if (Array.isArray(vec)) {
+      return vec.length !== this.embedder.dimensions;
     }
+    return false;
   }
 
   /** Detect errors that warrant auto-healing (nuke + rebuild). */
@@ -113,7 +109,7 @@ export class LanceStore {
     this.hasFtsIndex = false;
 
     try {
-      fs.rmSync(this.dbPath, { recursive: true, force: true });
+      await fs.promises.rm(this.dbPath, { recursive: true, force: true });
     } catch (err) {
       // OS-level file locks may prevent deletion — warn but don't crash
       const detail = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Summary

`LanceStore.connect()` now auto-heals in two scenarios:

1. **Embedder dimension mismatch** (#548): Samples a stored vector, compares to current embedder. If different, nukes `.lancedb/` and reconnects empty.
2. **Version/corruption** (#500): Catches LanceDB errors on `openTable`. Deletes index and reconnects. Fails gracefully on OS file locks.

Both warn via `onWarn` callback and leave the DB ready for `totem sync --full`.

## Why

Users switching embedders (OpenAI → Gemini) or upgrading LanceDB versions get silent failures. This turns a cryptic dimension mismatch error into an automatic recovery.

## Test plan
- [x] 973 tests pass
- [x] `totem lint` passes (137 rules, 0 violations)

Closes #500, Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)