### PR TITLE
fix: remove duplicate match/exec rule causing false positives

### DIFF
--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -876,17 +876,6 @@
       "severity": "error"
     },
     {
-      "lessonHash": "b2d2d79023432eb9",
-      "lessonHeading": "Always iterate through all regex matches (e.g.,",
-      "pattern": "\\.(match|exec)\\(",
-      "message": "Use matchAll() to iterate through all regex matches. Relying on match() or exec() can allow 'shadowing' attacks where a safe first match hides a malicious payload later in the string.",
-      "engine": "regex",
-      "compiledAt": "2026-03-12T10:29:36.148Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
-      "category": "architecture",
-      "severity": "error"
-    },
-    {
       "lessonHash": "5decef91ba5a7b52",
       "lessonHeading": "Include a space or delimiter when concatenating disjoint",
       "pattern": "(\\$\\{[^}]+\\}\\$\\{[^}]+\\}|\\.join\\(['\"]{2}\\))",


### PR DESCRIPTION
## Summary

Root cause of #584 was NOT a glob matching bug. `matchesGlob()` works correctly.

The issue: `totem compile` generated two rules for the same match/exec concept:
- `064f3540` — scoped to `cli/adapters` + `mcp` (correct)
- `b2d2d790` — scoped to `**/*.ts` (catches everything)

The broad duplicate caused false positives on `packages/core/` files. Removed the duplicate. Real fix is dedup detection in `totem compile` (#569).

## Test plan
- [x] `totem lint` passes (136 rules, 0 violations)
- [x] 978 tests pass

Closes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)