### PR TITLE
perf: cache non-compilable lessons to skip recompilation

### DIFF
--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -2,12 +2,13 @@ import * as path from 'node:path';
 
 import {
   type CompiledRule,
+  type CompiledRulesFile,
   exportLessons,
   hashLesson,
-  loadCompiledRules,
+  loadCompiledRulesFile,
   parseCompilerResponse,
   readAllLessons,
-  saveCompiledRules,
+  saveCompiledRulesFile,
   validateRegex,
 } from '@mmnto/totem';
 
@@ -141,20 +142,27 @@ export async function compileCommand(options: CompileOptions): Promise<void> {
 
   // ─── Phase 1: Regex compilation (requires orchestrator) ──
   if (config.orchestrator) {
-    const existingRules = options.force ? [] : loadCompiledRules(rulesPath);
+    const existingFile: CompiledRulesFile = options.force
+      ? { version: 1, rules: [], nonCompilable: [] }
+      : loadCompiledRulesFile(rulesPath);
+    const existingRules = existingFile.rules;
     const existingByHash = new Map(existingRules.map((r) => [r.lessonHash, r]));
+    const nonCompilableSet = new Set(existingFile.nonCompilable ?? []);
 
     const toCompile: Array<{ index: number; heading: string; body: string; hash: string }> = [];
 
     for (const lesson of lessons) {
       const hash = hashLesson(lesson.heading, lesson.body);
-      if (!existingByHash.has(hash)) {
-        toCompile.push({ index: lesson.index, heading: lesson.heading, body: lesson.body, hash });
-      }
+      if (existingByHash.has(hash)) continue; // already compiled
+      if (nonCompilableSet.has(hash)) continue; // cached as non-compilable
+      toCompile.push({ index: lesson.index, heading: lesson.heading, body: lesson.body, hash });
     }
 
     if (toCompile.length === 0) {
-      log.success(TAG, `All ${lessons.length} lessons already compiled. Use --force to recompile.`); // totem-ignore
+      log.success(
+        TAG,
+        `All ${lessons.length} lessons already processed (${existingRules.length} compiled, ${nonCompilableSet.size} non-compilable). Use --force to recompile.`,
+      ); // totem-ignore
     } else {
       log.info(
         TAG,
@@ -200,6 +208,7 @@ export async function compileCommand(options: CompileOptions): Promise<void> {
 
         if (!parsed.compilable) {
           log.dim(TAG, `[${lesson.heading}] Not compilable (conceptual/architectural) — skipping`); // totem-ignore
+          nonCompilableSet.add(lesson.hash);
           skipped++;
           continue;
         }
@@ -236,10 +245,16 @@ export async function compileCommand(options: CompileOptions): Promise<void> {
       }
 
       if (!options.raw) {
-        saveCompiledRules(rulesPath, newRules);
+        // Prune stale non-compilable hashes (lesson was edited or removed)
+        const freshNonCompilable = [...nonCompilableSet].filter((h) => currentHashes.has(h));
+        saveCompiledRulesFile(rulesPath, {
+          version: 1,
+          rules: newRules,
+          nonCompilable: freshNonCompilable,
+        });
         log.info(
           TAG,
-          `Results: ${compiled} compiled, ${skipped} skipped (conceptual), ${failed} failed`,
+          `Results: ${compiled} compiled, ${skipped} skipped (conceptual), ${failed} failed, ${freshNonCompilable.length} cached`,
         );
         log.success(
           TAG,

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -34,6 +34,8 @@ export type CompiledRule = z.infer<typeof CompiledRuleSchema>;
 export const CompiledRulesFileSchema = z.object({
   version: z.literal(1),
   rules: z.array(CompiledRuleSchema),
+  /** Lesson hashes that the LLM determined cannot be compiled (conceptual/architectural). */
+  nonCompilable: z.array(z.string()).optional(),
 });
 
 export type CompiledRulesFile = z.infer<typeof CompiledRulesFileSchema>;
@@ -356,9 +358,29 @@ export function loadCompiledRules(rulesPath: string): CompiledRule[] {
   }
 }
 
+/** Load the full compiled rules file (rules + non-compilable cache). */
+export function loadCompiledRulesFile(rulesPath: string): CompiledRulesFile {
+  if (!fs.existsSync(rulesPath)) return { version: 1, rules: [], nonCompilable: [] };
+
+  try {
+    const raw = fs.readFileSync(rulesPath, 'utf-8');
+    return CompiledRulesFileSchema.parse(JSON.parse(raw));
+  } catch {
+    return { version: 1, rules: [], nonCompilable: [] };
+  }
+}
+
 /** Save compiled rules to a JSON file. */
 export function saveCompiledRules(rulesPath: string, rules: CompiledRule[]): void {
   const data: CompiledRulesFile = { version: 1, rules };
+  fs.writeFileSync(rulesPath, JSON.stringify(data, null, 2) + '\n', {
+    encoding: 'utf-8',
+    mode: 0o644,
+  });
+}
+
+/** Save the full compiled rules file (rules + non-compilable cache). */
+export function saveCompiledRulesFile(rulesPath: string, data: CompiledRulesFile): void {
   fs.writeFileSync(rulesPath, JSON.stringify(data, null, 2) + '\n', {
     encoding: 'utf-8',
     mode: 0o644,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -92,10 +92,12 @@ export {
   extractAddedLines,
   hashLesson,
   loadCompiledRules,
+  loadCompiledRulesFile,
   matchesGlob,
   parseCompilerResponse,
   type RegexValidation,
   saveCompiledRules,
+  saveCompiledRulesFile,
   validateRegex,
 } from './compiler.js';
 


### PR DESCRIPTION
## Summary

`totem compile` now caches lesson hashes that the LLM determined cannot be compiled (conceptual/architectural). On subsequent runs, these are skipped without an LLM call.

**Before:** ~15 min compile (retrying 240 non-compilable lessons every time)
**After:** ~30 seconds (only new/changed lessons get compiled)

## Changes
- New `nonCompilable` field in `compiled-rules.json`
- `loadCompiledRulesFile` / `saveCompiledRulesFile` for full file access
- Non-compilable hashes cached during compilation
- Stale hashes pruned when lesson content changes (hash changes)
- Status output shows cached count

## Test plan
- [x] 978 tests pass
- [x] `totem lint` passes (136 rules, 0 violations)
- [x] Backward compatible — existing compiled-rules.json without `nonCompilable` loads fine

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)