### PR TITLE
fix: compiler glob patterns — prompt constraints + brace expansion

### DIFF
--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -390,8 +390,14 @@
       "engine": "regex",
       "compiledAt": "2026-03-12T10:04:39.037Z",
       "fileGlobs": [
-        "scripts/**/*.{js,ts,mjs,cjs}",
-        "tools/**/*.{js,ts,mjs,cjs}",
+        "scripts/**/*.js",
+        "scripts/**/*.ts",
+        "scripts/**/*.mjs",
+        "scripts/**/*.cjs",
+        "tools/**/*.js",
+        "tools/**/*.ts",
+        "tools/**/*.mjs",
+        "tools/**/*.cjs",
         ".husky/**/*",
         "**/hooks/**/*"
       ],
@@ -439,10 +445,14 @@
       "engine": "regex",
       "compiledAt": "2026-03-12T10:06:52.646Z",
       "fileGlobs": [
-        "**/scripts/**/*.{ts,js}",
-        "**/tasks/**/*.{ts,js}",
-        "**/maintenance/**/*.{ts,js}",
-        "**/jobs/**/*.{ts,js}"
+        "**/scripts/**/*.ts",
+        "**/scripts/**/*.js",
+        "**/tasks/**/*.ts",
+        "**/tasks/**/*.js",
+        "**/maintenance/**/*.ts",
+        "**/maintenance/**/*.js",
+        "**/jobs/**/*.ts",
+        "**/jobs/**/*.js"
       ],
       "category": "style",
       "severity": "warning"
@@ -730,7 +740,17 @@
       "message": "Avoid writing directly to .git/hooks. Detect existing hook managers (like Husky or Lefthook) and provide manual guidance instead to prevent clobbering developer workflows.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:24:37.542Z",
-      "fileGlobs": ["**/*.{js,ts,sh,bash,py,rb,go}", "!**/*.test.ts", "!**/*.spec.ts"],
+      "fileGlobs": [
+        "**/*.js",
+        "**/*.ts",
+        "**/*.sh",
+        "**/*.bash",
+        "**/*.py",
+        "**/*.rb",
+        "**/*.go",
+        "!**/*.test.ts",
+        "!**/*.spec.ts"
+      ],
       "category": "architecture",
       "severity": "error"
     },
@@ -741,7 +761,16 @@
       "message": "When detecting Bun environments, check for both bun.lockb (legacy) and bun.lock (Bun >= 1.2) to ensure compatibility.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:26:00.387Z",
-      "fileGlobs": ["**/*.{js,ts,jsx,tsx,sh,yml,yaml}", "Dockerfile*"],
+      "fileGlobs": [
+        "**/*.js",
+        "**/*.ts",
+        "**/*.jsx",
+        "**/*.tsx",
+        "**/*.sh",
+        "**/*.yml",
+        "**/*.yaml",
+        "Dockerfile*"
+      ],
       "category": "architecture",
       "severity": "error"
     },
@@ -860,7 +889,16 @@
       "message": "Use semantic constraints (e.g., 'one to two short sentences') instead of numeric character/word limits. LLMs are poor at exact counting but respond effectively to qualitative boundaries.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:29:07.887Z",
-      "fileGlobs": ["**/*.{ts,tsx,js,jsx,py,md,yaml,yml}"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx",
+        "**/*.py",
+        "**/*.md",
+        "**/*.yaml",
+        "**/*.yml"
+      ],
       "category": "style",
       "severity": "warning"
     },
@@ -871,7 +909,16 @@
       "message": "Use granular assertions rather than snapshots when testing system prompts to avoid test fragility from non-functional prose changes.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:29:12.868Z",
-      "fileGlobs": ["**/*.test.{ts,js,tsx,jsx}", "**/*.spec.{ts,js,tsx,jsx}"],
+      "fileGlobs": [
+        "**/*.test.ts",
+        "**/*.test.js",
+        "**/*.test.tsx",
+        "**/*.test.jsx",
+        "**/*.spec.ts",
+        "**/*.spec.js",
+        "**/*.spec.tsx",
+        "**/*.spec.jsx"
+      ],
       "category": "architecture",
       "severity": "error"
     },
@@ -1064,7 +1111,7 @@
       "message": "Local LLM 500 errors often indicate VRAM or context exhaustion. Include specific guidance to adjust hardware-steering parameters like 'numCtx' in the error message to help users resolve failures immediately.",
       "engine": "regex",
       "compiledAt": "2026-03-12T11:39:36.248Z",
-      "fileGlobs": ["**/{llm,providers}/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": ["**/llm/**/*.ts", "**/providers/**/*.ts", "!**/*.test.ts"],
       "category": "architecture",
       "severity": "error"
     },
@@ -1119,7 +1166,16 @@
       "message": "Manually suppress 'unused export' errors in styleguide files (e.g., using // eslint-disable-line) as these are consumed by AI tools and not internal imports.",
       "engine": "regex",
       "compiledAt": "2026-03-12T11:48:26.594Z",
-      "fileGlobs": ["**/styleguide/**/*.{ts,tsx,js,jsx}", "**/*.styleguide.{ts,tsx,js,jsx}"],
+      "fileGlobs": [
+        "**/styleguide/**/*.ts",
+        "**/styleguide/**/*.tsx",
+        "**/styleguide/**/*.js",
+        "**/styleguide/**/*.jsx",
+        "**/*.styleguide.ts",
+        "**/*.styleguide.tsx",
+        "**/*.styleguide.js",
+        "**/*.styleguide.jsx"
+      ],
       "category": "style",
       "severity": "warning"
     },
@@ -1323,7 +1379,11 @@
       "compiledAt": "2026-03-16T03:01:20.857Z",
       "createdAt": "2026-03-16T03:01:20.857Z",
       "fileGlobs": [
-        "**/*.{json,yaml,yml,md,sh}",
+        "**/*.json",
+        "**/*.yaml",
+        "**/*.yml",
+        "**/*.md",
+        "**/*.sh",
         ".gemini/**/*",
         ".junie/**/*",
         ".github/workflows/**/*"
@@ -1514,7 +1574,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T03:08:29.013Z",
       "createdAt": "2026-03-16T03:08:29.013Z",
-      "fileGlobs": ["scripts/**/*.{js,ts}", "tools/**/*.{js,ts}"],
+      "fileGlobs": ["scripts/**/*.js", "scripts/**/*.ts", "tools/**/*.js", "tools/**/*.ts"],
       "category": "style",
       "severity": "warning"
     },
@@ -1710,9 +1770,18 @@
       "compiledAt": "2026-03-16T18:29:04.072Z",
       "createdAt": "2026-03-16T18:29:04.072Z",
       "fileGlobs": [
-        "**/*.{js,ts,jsx,tsx}",
-        "!**/commands/**/*.{js,ts,jsx,tsx}",
-        "!**/bin/**/*.{js,ts,jsx,tsx}"
+        "**/*.js",
+        "**/*.ts",
+        "**/*.jsx",
+        "**/*.tsx",
+        "!**/commands/**/*.js",
+        "!**/commands/**/*.ts",
+        "!**/commands/**/*.jsx",
+        "!**/commands/**/*.tsx",
+        "!**/bin/**/*.js",
+        "!**/bin/**/*.ts",
+        "!**/bin/**/*.jsx",
+        "!**/bin/**/*.tsx"
       ]
     },
     {
@@ -1773,7 +1842,16 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T18:36:05.648Z",
       "createdAt": "2026-03-16T18:36:05.648Z",
-      "fileGlobs": ["**/*.{js,ts,json,md,sh,yml,yaml}", ".gitignore"]
+      "fileGlobs": [
+        "**/*.js",
+        "**/*.ts",
+        "**/*.json",
+        "**/*.md",
+        "**/*.sh",
+        "**/*.yml",
+        "**/*.yaml",
+        ".gitignore"
+      ]
     }
   ],
   "nonCompilable": [

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -39,6 +39,14 @@ You are a deterministic rule compiler. Your job is to read a single natural-lang
   - **By package/directory:** \`["packages/mcp/**/*.ts"]\` — for rules about MCP-specific patterns in a monorepo.
   - **By exclusion:** \`["packages/cli/**/*.ts", "!**/*.test.ts"]\` — exclude test files that legitimately use the flagged pattern.
   - **Infer scope from context:** If a lesson mentions "MCP tool returns", "CLI output", "LanceDB filters", or a specific package, scope to that package. Only omit \`fileGlobs\` if the rule genuinely applies to ALL files (e.g., universal TypeScript style rules).
+  - **CRITICAL — Supported glob syntax only:**
+    - \`*.ext\` — match extension anywhere
+    - \`dir/**/*.ext\` — directory + recursive + extension
+    - \`dir/**\` — everything under directory
+    - \`dir/*.ext\` — direct children only
+    - \`!pattern\` — negation prefix
+    - **DO NOT use** brace expansion \`{a,b}\`, nested globstars \`**/dir/**\`, or regex-style patterns.
+    - **DO NOT use** \`**/*.{ts,js}\`. Instead use separate entries: \`["**/*.ts", "**/*.js"]\`.
 
 ## Output Schema
 \`\`\`json
@@ -86,6 +94,31 @@ Output: {"compilable": true, "pattern": "text:\\\\s*(?!formatXmlResponse)\\\\b\\
 Lesson: "Use @clack/prompts instead of inquirer for CLI interactions"
 Output: {"compilable": true, "pattern": "import.*from\\\\s+['\"]inquirer['\"]", "message": "Use @clack/prompts instead of inquirer", "fileGlobs": ["packages/cli/**/*.ts"]}
 `;
+
+// ─── Glob sanitization ─────────────────────────────
+
+/**
+ * Expand brace patterns and strip unsupported glob syntax.
+ * e.g., "**\/*.{ts,js}" → ["**\/*.ts", "**\/*.js"]
+ */
+function sanitizeFileGlobs(globs: string[]): string[] {
+  const result: string[] = [];
+  for (const glob of globs) {
+    // Expand brace patterns: **/*.{ts,js} → **/*.ts, **/*.js
+    const braceMatch = /^(.*)\{([^}]+)\}(.*)$/.exec(glob);
+    if (braceMatch) {
+      const prefix = braceMatch[1]!;
+      const alternatives = braceMatch[2]!.split(',').map((s) => s.trim());
+      const suffix = braceMatch[3]!;
+      for (const alt of alternatives) {
+        result.push(prefix + alt + suffix);
+      }
+      continue;
+    }
+    result.push(glob);
+  }
+  return result;
+}
 
 // ─── Main command ───────────────────────────────────
 
@@ -228,6 +261,7 @@ export async function compileCommand(options: CompileOptions): Promise<void> {
 
         const now = new Date().toISOString();
         const existing = existingByHash.get(lesson.hash);
+        const sanitizedGlobs = parsed.fileGlobs ? sanitizeFileGlobs(parsed.fileGlobs) : undefined;
         newRules.push({
           lessonHash: lesson.hash,
           lessonHeading: lesson.heading,
@@ -236,9 +270,7 @@ export async function compileCommand(options: CompileOptions): Promise<void> {
           engine: 'regex',
           compiledAt: now,
           createdAt: existing?.createdAt ?? now,
-          ...(parsed.fileGlobs && parsed.fileGlobs.length > 0
-            ? { fileGlobs: parsed.fileGlobs }
-            : {}),
+          ...(sanitizedGlobs && sanitizedGlobs.length > 0 ? { fileGlobs: sanitizedGlobs } : {}),
         });
         compiled++;
         log.success(TAG, `[${lesson.heading}] Compiled: /${parsed.pattern}/`); // totem-ignore


### PR DESCRIPTION
## Summary

Fixes the compiler generating unsupported glob patterns:

1. **Prompt constraints** — explicitly lists supported glob syntax, forbids `{a,b}` and nested `**/`
2. **Post-compile sanitizer** — `sanitizeFileGlobs()` expands brace patterns into separate entries
3. **Fixed 12 existing rules** with brace expansion in compiled-rules.json

Before: `**/*.{ts,js}` → silently matches nothing
After: `["**/*.ts", "**/*.js"]` → works correctly

## Test plan
- [x] 978 tests pass
- [x] `totem lint` passes (148 rules, 0 violations — 12 more rules now active)

Closes #602

🤖 Generated with [Claude Code](https://claude.com/claude-code)