### PR TITLE
fix: review blitz 2 — dynamic imports, onWarn, rule demotions

### DIFF
--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -1200,8 +1200,8 @@
       "compiledAt": "2026-03-16T02:46:32.222Z",
       "createdAt": "2026-03-16T02:46:32.222Z",
       "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
-      "category": "architecture",
-      "severity": "error"
+      "category": "style",
+      "severity": "warning"
     },
     {
       "lessonHash": "64f919558d8ad756",
@@ -1782,7 +1782,9 @@
         "!**/bin/**/*.ts",
         "!**/bin/**/*.jsx",
         "!**/bin/**/*.tsx"
-      ]
+      ],
+      "severity": "warning",
+      "category": "style"
     },
     {
       "lessonHash": "e383aa297e35d91d",

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -1,19 +1,4 @@
-import * as path from 'node:path';
-
-import {
-  type CompiledRule,
-  type CompiledRulesFile,
-  exportLessons,
-  hashLesson,
-  loadCompiledRulesFile,
-  parseCompilerResponse,
-  readAllLessons,
-  saveCompiledRulesFile,
-  validateRegex,
-} from '@mmnto/totem';
-
-import { log } from '../ui.js';
-import { loadConfig, loadEnv, resolveConfigPath, runOrchestrator } from '../utils.js';
+import type { CompiledRule, CompiledRulesFile } from '@mmnto/totem';
 
 // ─── Constants ──────────────────────────────────────
 
@@ -133,6 +118,19 @@ export interface CompileOptions {
 }
 
 export async function compileCommand(options: CompileOptions): Promise<void> {
+  const path = await import('node:path');
+  const { log } = await import('../ui.js');
+  const { loadConfig, loadEnv, resolveConfigPath, runOrchestrator } = await import('../utils.js');
+  const {
+    exportLessons,
+    hashLesson,
+    loadCompiledRulesFile,
+    parseCompilerResponse,
+    readAllLessons,
+    saveCompiledRulesFile,
+    validateRegex,
+  } = await import('@mmnto/totem');
+
   const cwd = process.cwd();
   const configPath = resolveConfigPath(cwd);
   loadEnv(cwd);

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -346,26 +346,38 @@ export function applyRules(
 // ─── File I/O ────────────────────────────────────────
 
 /** Load compiled rules from a JSON file. Returns empty array if file missing or invalid. */
-export function loadCompiledRules(rulesPath: string): CompiledRule[] {
+export function loadCompiledRules(
+  rulesPath: string,
+  onWarn?: (msg: string) => void,
+): CompiledRule[] {
   if (!fs.existsSync(rulesPath)) return [];
 
   try {
     const raw = fs.readFileSync(rulesPath, 'utf-8');
     const parsed = CompiledRulesFileSchema.parse(JSON.parse(raw));
     return parsed.rules;
-  } catch {
+  } catch (err) {
+    if (err instanceof Error && (err as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    onWarn?.(`Could not load compiled rules: ${err instanceof Error ? err.message : String(err)}`);
     return [];
   }
 }
 
 /** Load the full compiled rules file (rules + non-compilable cache). */
-export function loadCompiledRulesFile(rulesPath: string): CompiledRulesFile {
+export function loadCompiledRulesFile(
+  rulesPath: string,
+  onWarn?: (msg: string) => void,
+): CompiledRulesFile {
   if (!fs.existsSync(rulesPath)) return { version: 1, rules: [], nonCompilable: [] };
 
   try {
     const raw = fs.readFileSync(rulesPath, 'utf-8');
     return CompiledRulesFileSchema.parse(JSON.parse(raw));
-  } catch {
+  } catch (err) {
+    if (err instanceof Error && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { version: 1, rules: [], nonCompilable: [] };
+    }
+    onWarn?.(`Could not load compiled rules: ${err instanceof Error ? err.message : String(err)}`);
     return { version: 1, rules: [], nonCompilable: [] };
   }
 }


### PR DESCRIPTION
## Summary

Three code review findings + two rule demotions:

1. **#594**: compile.ts top-level imports converted to dynamic inside function body
2. **#595**: loadCompiledRules/loadCompiledRulesFile accept onWarn callback, distinguish ENOENT from corruption
3. **#575**: err.message rule demoted to warning (false positive on onWarn strings)
4. Conflicting dynamic-import rule demoted to warning (contradicts the "use dynamic imports in commands" rule)

## Test plan
- [x] 978 tests pass
- [x] `totem lint` passes (0 errors, 7 warnings)

Closes #575, Closes #594, Closes #595

🤖 Generated with [Claude Code](https://claude.com/claude-code)