### PR TITLE
docs: README polish from external product teardown

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Auto-detects your environment (Cursor, Copilot, Junie) and sets up `totem.config
 
 Your project gets immediate protection against the most common architectural traps on Day 1. Already have `.cursorrules` or `.mdc` files? `totem init` auto-ingests them and compiles your instructions into deterministic rules.
 
-### 2. Connect the MCP Server *(optional)*
+### 2. Connect the MCP Server _(optional)_
 
 > **Without MCP:** `totem lint`, `compile`, `extract`, `sync`, and `stats` all work standalone. You get full deterministic enforcement.
 > **With MCP:** Your AI agent can search project knowledge and add lessons mid-session — no copy-paste, no context loss.


### PR DESCRIPTION
## Summary

Addresses feedback from an external product teardown (Claude Sonnet 4.6 evaluating Totem as a prospective user):

- **Remove "Early Alpha" warning** — own it or fix it, don't apologize for it in the README
- **Drop "zero-config" claim** — honest about what `init` generates
- **Mark MCP as optional** — clear callout explaining what works without it vs with it
- **Document hook installation** — explains it's a standard `.git/hooks/` shell script, Husky-safe, verifiable with `totem hooks --check`
- **Strip internal issue refs** — outsiders don't care about `#614` or `#616`

## Related issues

- #626 — Backlog cleanup (target <15 open issues before 1.0)
- #627 — Zero-config init (convention over configuration)
- #628 — MCP clarity in quickstart

## Test plan
- [x] Pre-push hooks pass
- [ ] Visual review of README rendering on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)