### PR TITLE
docs: replace tagline — stop repeating yourself to your AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Totem
 
-**Git for AI. Rule your context.**
+**Stop repeating yourself to your AI.**
 
-A CLI that compiles your `.cursorrules` into deterministic CI guardrails. Stop repeating yourself to your AI.
+A CLI that compiles your `.cursorrules` into deterministic CI guardrails.
 
 Totem is not a framework. It's not a library. It's a **drop-in CLI and MCP Server** that gives Cursor, Copilot, Claude Code, and Gemini deterministic guardrails — in 60 seconds.
 


### PR DESCRIPTION
## Summary

- Replace **"Git for AI. Rule your context."** with **"Stop repeating yourself to your AI."**
- "Git for AI" implies version control, which is misleading
- The new tagline names the exact pain point every Cursor/Copilot user feels

One-line diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)