### PR TITLE
fix: audit compiled rules to reduce false positives

### DIFF
--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -8,12 +8,7 @@
       "message": "Do not use os.tmpdir() for agent-readable files; use workspace-local paths (e.g., '.totem/temp/') to satisfy MCP boundary restrictions.",
       "engine": "regex",
       "compiledAt": "2026-03-09T02:47:42.931Z",
-      "fileGlobs": [
-        "*.ts",
-        "*.js",
-        "!*.test.ts",
-        "!*.spec.ts"
-      ],
+      "fileGlobs": ["*.ts", "*.js", "!*.test.ts", "!*.spec.ts"],
       "category": "architecture",
       "severity": "error"
     },
@@ -24,10 +19,7 @@
       "message": "Use fs.openSync() instead of fs.createWriteStream() for spawn() stdio. WriteStream.fd is null until the 'open' event fires, which will cause spawn() to fail.",
       "engine": "regex",
       "compiledAt": "2026-03-09T02:50:03.081Z",
-      "fileGlobs": [
-        "packages/cli/**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["packages/cli/**/*.ts", "!**/*.test.ts"],
       "category": "style",
       "severity": "warning"
     },
@@ -48,10 +40,7 @@
       "message": "Anchor input regexes with '^' and include 'https?://' protocol to avoid substring matches in CLI input.",
       "engine": "regex",
       "compiledAt": "2026-03-09T02:53:05.481Z",
-      "fileGlobs": [
-        "packages/cli/**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["packages/cli/**/*.ts", "!**/*.test.ts"],
       "category": "architecture",
       "severity": "error"
     },
@@ -62,10 +51,7 @@
       "message": "Use backticks (`) for column identifiers in LanceDB filters; double quotes (\") cause silent failures in DataFusion.",
       "engine": "regex",
       "compiledAt": "2026-03-09T02:57:21.498Z",
-      "fileGlobs": [
-        "packages/core/**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["packages/core/**/*.ts", "!**/*.test.ts"],
       "category": "architecture",
       "severity": "error"
     },
@@ -76,9 +62,7 @@
       "message": "Use '@clack/prompts' instead of 'inquirer' for a more modern CLI UX (Issue #21)",
       "engine": "regex",
       "compiledAt": "2026-03-09T02:59:47.145Z",
-      "fileGlobs": [
-        "packages/cli/**/*.ts"
-      ],
+      "fileGlobs": ["packages/cli/**/*.ts"],
       "category": "style",
       "severity": "warning"
     },
@@ -89,10 +73,7 @@
       "message": "Decorative UI (branding tags, colors, banners) must be routed to stderr. Use the log.* helpers or console.error to reserve stdout for pipeable data.",
       "engine": "regex",
       "compiledAt": "2026-03-09T03:02:19.676Z",
-      "fileGlobs": [
-        "packages/cli/**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["packages/cli/**/*.ts", "!**/*.test.ts"],
       "category": "architecture",
       "severity": "error"
     },
@@ -103,10 +84,7 @@
       "message": "Use dynamic imports for heavy dependencies like 'ora' within the specific functions that require them to avoid startup performance tax.",
       "engine": "regex",
       "compiledAt": "2026-03-09T03:02:59.361Z",
-      "fileGlobs": [
-        "packages/cli/src/commands/**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["packages/cli/src/commands/**/*.ts", "!**/*.test.ts"],
       "category": "performance",
       "severity": "warning"
     },
@@ -127,10 +105,7 @@
       "message": "Route host hook output to stderr (console.error or console.warn) rather than stdout (console.log) to prevent AI tool pollution.",
       "engine": "regex",
       "compiledAt": "2026-03-09T03:03:48.432Z",
-      "fileGlobs": [
-        "packages/mcp/**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["packages/mcp/**/*.ts", "!**/*.test.ts"],
       "category": "architecture",
       "severity": "error"
     },
@@ -141,10 +116,7 @@
       "message": "MCP tool returns must be wrapped in XML tags (use formatXmlResponse) to prevent Indirect Prompt Injection from untrusted content.",
       "engine": "regex",
       "compiledAt": "2026-03-09T03:04:58.554Z",
-      "fileGlobs": [
-        "packages/mcp/**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["packages/mcp/**/*.ts", "!**/*.test.ts"],
       "category": "security",
       "severity": "error"
     },
@@ -155,12 +127,7 @@
       "message": "Potential command injection: AI-provided environment variables (like $TOOL_INPUT) must be handled safely (e.g., quoting or escaping) when used in shell commands.",
       "engine": "regex",
       "compiledAt": "2026-03-09T03:05:23.884Z",
-      "fileGlobs": [
-        "*.sh",
-        "*.bash",
-        "*.yml",
-        "*.yaml"
-      ],
+      "fileGlobs": ["*.sh", "*.bash", "*.yml", "*.yaml"],
       "category": "security",
       "severity": "error"
     },
@@ -171,10 +138,7 @@
       "message": "Do not sanitize or XML-wrap semi-trusted metadata like branch names or git file paths in prompts to avoid unnecessary clutter (Totem principle).",
       "engine": "regex",
       "compiledAt": "2026-03-09T03:09:49.306Z",
-      "fileGlobs": [
-        "packages/cli/**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["packages/cli/**/*.ts", "!**/*.test.ts"],
       "category": "security",
       "severity": "error"
     },
@@ -195,10 +159,7 @@
       "message": "Untrusted text (LLM/PR content) must be wrapped in `sanitize()` before display in CLI to prevent terminal injection.",
       "engine": "regex",
       "compiledAt": "2026-03-09T03:15:36.127Z",
-      "fileGlobs": [
-        "packages/cli/**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["packages/cli/**/*.ts", "!**/*.test.ts"],
       "category": "style",
       "severity": "warning"
     },
@@ -219,10 +180,7 @@
       "message": "Use exact count assertions (e.g., toBe(10)) for fixed asset collections instead of weak bounds.",
       "engine": "regex",
       "compiledAt": "2026-03-09T03:17:16.714Z",
-      "fileGlobs": [
-        "*.test.ts",
-        "*.spec.ts"
-      ],
+      "fileGlobs": ["*.test.ts", "*.spec.ts"],
       "category": "style",
       "severity": "warning"
     },
@@ -233,12 +191,7 @@
       "message": "Always use the '--' separator before positional arguments in git commands (e.g., 'git log -- <ref>') to protect against argument injection.",
       "engine": "regex",
       "compiledAt": "2026-03-09T03:20:47.247Z",
-      "fileGlobs": [
-        "*.sh",
-        "*.bash",
-        "packages/cli/**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["*.sh", "*.bash", "packages/cli/**/*.ts", "!**/*.test.ts"],
       "category": "security",
       "severity": "error"
     },
@@ -249,12 +202,7 @@
       "message": "Always quote shell variables (e.g., \"$VAR\") to prevent word-splitting and argument injection.",
       "engine": "regex",
       "compiledAt": "2026-03-09T03:13:51.536Z",
-      "fileGlobs": [
-        "*.sh",
-        "*.bash",
-        "*.yml",
-        "*.yaml"
-      ],
+      "fileGlobs": ["*.sh", "*.bash", "*.yml", "*.yaml"],
       "category": "security",
       "severity": "error"
     },
@@ -265,12 +213,7 @@
       "message": "Escape closing XML tags in prompts using backslash (e.g., <\\/tag>) to prevent injection.",
       "engine": "regex",
       "compiledAt": "2026-03-09T03:08:14.389Z",
-      "fileGlobs": [
-        "*.md",
-        "*.txt",
-        "*.html",
-        "*.xml"
-      ],
+      "fileGlobs": ["*.md", "*.txt", "*.html", "*.xml"],
       "category": "security",
       "severity": "error"
     },
@@ -281,12 +224,7 @@
       "message": "Use try-parse on stdout rather than string-matching the command for '-o json'. This handles edge cases and doesn't require config awareness.",
       "engine": "regex",
       "compiledAt": "2026-03-12T09:52:27.845Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.py",
-        "**/*.sh"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.py", "**/*.sh"],
       "category": "architecture",
       "severity": "error"
     },
@@ -297,11 +235,7 @@
       "message": "Use getDefaultBranch() to dynamically detect the base branch instead of hardcoding 'main' or 'master' in diff strings (e.g., main...HEAD).",
       "engine": "regex",
       "compiledAt": "2026-03-12T09:53:08.340Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.sh"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.sh"],
       "category": "style",
       "severity": "warning"
     },
@@ -312,12 +246,7 @@
       "message": "Avoid hardcoded fallbacks like 'main' for environmental configuration; throw an explicit error if the value cannot be detected.",
       "engine": "regex",
       "compiledAt": "2026-03-12T09:53:26.715Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.tsx",
-        "**/*.jsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
       "category": "architecture",
       "severity": "error"
     },
@@ -328,14 +257,7 @@
       "message": "Error re-throw guards (checking for '[Totem Error]') should be centralized in the shared error handler, not duplicated at call sites.",
       "engine": "regex",
       "compiledAt": "2026-03-12T09:54:29.799Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.tsx",
-        "**/*.js",
-        "**/*.jsx",
-        "!**/error*.ts",
-        "!**/error*.js"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "!**/error*.ts", "!**/error*.js"],
       "category": "architecture",
       "severity": "error"
     },
@@ -346,10 +268,7 @@
       "message": "Do not strip ANSI escapes or control characters from MCP tool output. LLMs benefit from the full fidelity of formatting and snippets; terminal sanitization is a CLI concern, not an MCP payload concern.",
       "engine": "regex",
       "compiledAt": "2026-03-12T09:55:05.473Z",
-      "fileGlobs": [
-        "packages/mcp/**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["packages/mcp/**/*.ts", "!**/*.test.ts"],
       "category": "security",
       "severity": "error"
     },
@@ -360,13 +279,7 @@
       "message": "Do not port legacy technical implementations (Kafka, Kubernetes, Firestore) into Totem. Use local primitives like LanceDB or terminal execution instead.",
       "engine": "regex",
       "compiledAt": "2026-03-12T09:56:15.768Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "package.json",
-        "**/*.yaml",
-        "**/*.yml"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "package.json", "**/*.yaml", "**/*.yml"],
       "category": "style",
       "severity": "warning"
     },
@@ -377,11 +290,7 @@
       "message": "Keep 'triage' and 'learn' decoupled to maintain modularity. Do not invoke 'learn' from within 'triage' logic; use 'totem run <workflow>' for composition instead.",
       "engine": "regex",
       "compiledAt": "2026-03-12T09:57:13.318Z",
-      "fileGlobs": [
-        "**/triage/**",
-        "**/triage.*",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["**/triage/**", "**/triage.*", "!**/*.test.ts"],
       "category": "style",
       "severity": "warning"
     },
@@ -392,9 +301,7 @@
       "message": "Avoid embedding complex shell pipelines in JSON configuration; extract hook logic into a dedicated script file (e.g., .gemini/hooks/BeforeTool.js) for maintainability.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:00:01.065Z",
-      "fileGlobs": [
-        "*.json"
-      ],
+      "fileGlobs": ["*.json"],
       "category": "architecture",
       "severity": "error"
     },
@@ -422,12 +329,7 @@
       "message": "When matching or escaping closing XML tags, use a case-insensitive regex that accounts for optional internal whitespace (e.g., /<\\/\\s*tag\\s*>/i). Literal matches like '</tag>' or whitespace-rigid regexes are easily bypassed by LLMs/parsers and lead to prompt injection vulnerabilities.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:00:49.815Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "!**/*.test.ts",
-        "!**/*.tsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "!**/*.test.ts", "!**/*.tsx"],
       "category": "security",
       "severity": "error"
     },
@@ -438,11 +340,7 @@
       "message": "Use the .cjs extension for utility scripts and host integration hooks in ESM-first projects to ensure compatibility with external tools and prevent module resolution errors.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:01:52.623Z",
-      "fileGlobs": [
-        "package.json",
-        "**/*.sh",
-        "Makefile"
-      ],
+      "fileGlobs": ["package.json", "**/*.sh", "Makefile"],
       "category": "architecture",
       "severity": "error"
     },
@@ -469,10 +367,7 @@
       "message": "Do not apply terminal sanitization (like stripAnsi) to data intended for LLM prompts. Terminal sanitization is a presentation-layer concern for CLI output, while LLMs need raw data (including code symbols) to maintain fidelity. Use prompt-specific sanitization (like XML escaping) instead.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:03:48.868Z",
-      "fileGlobs": [
-        "packages/mcp/**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["packages/mcp/**/*.ts", "!**/*.test.ts"],
       "category": "security",
       "severity": "error"
     },
@@ -505,10 +400,7 @@
       "message": "Directly expanding ${{ inputs.key }} in shell scripts is a command injection risk. Map to an environment variable in the 'env' section first and use the environment variable in your script.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:04:57.385Z",
-      "fileGlobs": [
-        ".github/workflows/*.yml",
-        ".github/workflows/*.yaml"
-      ],
+      "fileGlobs": [".github/workflows/*.yml", ".github/workflows/*.yaml"],
       "category": "security",
       "severity": "error"
     },
@@ -519,10 +411,7 @@
       "message": "Avoid generic headings like timestamps or 'Untitled'. Use descriptive, unique headings to ensure humans and AI can differentiate between knowledge chunks in search results.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:06:11.781Z",
-      "fileGlobs": [
-        "**/*.md",
-        "**/*.mdx"
-      ],
+      "fileGlobs": ["**/*.md", "**/*.mdx"],
       "category": "style",
       "severity": "warning"
     },
@@ -533,12 +422,7 @@
       "message": "Use exact count assertions (e.g., .toHaveLength() or .toBe()) instead of 'greater than' checks to detect accidental deletions in fixed sets.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:06:24.016Z",
-      "fileGlobs": [
-        "**/*.test.ts",
-        "**/*.test.js",
-        "**/*.spec.ts",
-        "**/*.spec.js"
-      ],
+      "fileGlobs": ["**/*.test.ts", "**/*.test.js", "**/*.spec.ts", "**/*.spec.js"],
       "category": "style",
       "severity": "warning"
     },
@@ -569,12 +453,7 @@
       "message": "Use named error objects (e.g., err.name = 'NoDocsConfiguredError') instead of string matching on err.message to handle expected conditions.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:07:06.920Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "!**/*.test.ts",
-        "!**/*.spec.ts"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "!**/*.test.ts", "!**/*.spec.ts"],
       "category": "style",
       "severity": "warning"
     },
@@ -585,12 +464,7 @@
       "message": "Sanitize ANSI escape sequences (e.g., using 'stripAnsi') before persisting text to Markdown or log files to prevent terminal injection vulnerabilities.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:07:57.552Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.tsx",
-        "**/*.jsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
       "category": "security",
       "severity": "error"
     },
@@ -601,12 +475,7 @@
       "message": "Do not reject a promise directly inside a setTimeout callback when timing out a child process. Call child.kill() and perform the rejection inside the 'close' event handler to ensure stdio streams are fully flushed.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:10:10.837Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.tsx",
-        "**/*.jsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
       "category": "architecture",
       "severity": "error"
     },
@@ -636,9 +505,7 @@
       "message": "Do not manually edit machine-generated artifacts like compiled-rules.json; fixes must be applied to the source lessons or compiler logic.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:11:35.833Z",
-      "fileGlobs": [
-        "compiled-rules.json"
-      ],
+      "fileGlobs": ["compiled-rules.json"],
       "category": "architecture",
       "severity": "error"
     },
@@ -669,12 +536,7 @@
       "message": "The @google/genai constructor requires an options object (e.g., { apiKey: '...' }) instead of a raw string.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:12:20.631Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.tsx",
-        "**/*.js",
-        "**/*.jsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
       "category": "style",
       "severity": "warning"
     },
@@ -702,12 +564,7 @@
       "message": "Avoid refactoring synchronous factory functions to async just to use dynamic import(). Node.js caches dynamic imports, so keep the factory synchronous to avoid unnecessary await boilerplate.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:12:55.785Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.tsx",
-        "**/*.jsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
       "category": "style",
       "severity": "warning"
     },
@@ -718,11 +575,7 @@
       "message": "Centralize error signature detection (e.g., 429 status or 'rate limit' strings) into a shared utility instead of hardcoding literals, ensuring consistent handling across SDKs and CLI paths.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:13:07.002Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.sh"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.sh"],
       "category": "style",
       "severity": "warning"
     },
@@ -733,12 +586,7 @@
       "message": "Use path.relative(process.cwd(), path.resolve(process.cwd(), input)) instead of string replacement for robust path normalization",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:13:43.629Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.tsx",
-        "**/*.js",
-        "**/*.jsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
       "category": "style",
       "severity": "warning"
     },
@@ -749,14 +597,7 @@
       "message": "Always use fully qualified identifiers (e.g., 'provider:model') for caching and telemetry to prevent cross-provider collisions.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:14:00.959Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.tsx",
-        "**/*.jsx",
-        "!**/*.test.ts",
-        "!**/*.test.js"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx", "!**/*.test.ts", "!**/*.test.js"],
       "category": "architecture",
       "severity": "error"
     },
@@ -767,11 +608,7 @@
       "message": "Avoid heuristic truncation of the first line (e.g., .split('\\n')[0]). Instead, request explicit metadata tokens from the LLM (like 'Heading:') and sanitize them to remove markdown artifacts or prefixes.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:15:51.107Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "!**/*.test.ts"],
       "category": "security",
       "severity": "error"
     },
@@ -782,12 +619,7 @@
       "message": "Prefer Vitest's expect().rejects.toHaveProperty() assertions over manual try/catch blocks with expect.fail()",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:15:59.165Z",
-      "fileGlobs": [
-        "**/*.test.ts",
-        "**/*.test.js",
-        "**/*.spec.ts",
-        "**/*.spec.js"
-      ],
+      "fileGlobs": ["**/*.test.ts", "**/*.test.js", "**/*.spec.ts", "**/*.spec.js"],
       "category": "style",
       "severity": "warning"
     },
@@ -798,11 +630,7 @@
       "message": "Omit defensive XML escaping for trusted local data (like git diffs) in CLI tools to reduce prompt clutter and token usage",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:16:52.434Z",
-      "fileGlobs": [
-        "packages/cli/**/*.ts",
-        "apps/cli/**/*.ts",
-        "**/cli/**/*.ts"
-      ],
+      "fileGlobs": ["packages/cli/**/*.ts", "apps/cli/**/*.ts", "**/cli/**/*.ts"],
       "category": "security",
       "severity": "error"
     },
@@ -813,10 +641,7 @@
       "message": "Always generate sentinel markers even when the internal content is empty. Returning an empty string instead of empty markers causes the replacement logic to delete the markers from the target file, leading to redundant appends.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:17:34.832Z",
-      "fileGlobs": [
-        "packages/mcp/**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["packages/mcp/**/*.ts", "!**/*.test.ts"],
       "category": "style",
       "severity": "warning"
     },
@@ -827,9 +652,7 @@
       "message": "Set open-pull-requests-limit to 0 in dependabot.yml to suppress routine version bumps while allowing security patches.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:18:14.963Z",
-      "fileGlobs": [
-        ".github/dependabot.yml"
-      ],
+      "fileGlobs": [".github/dependabot.yml"],
       "category": "architecture",
       "severity": "error"
     },
@@ -840,12 +663,7 @@
       "message": "Hoisting .split('\\n') outside of loops prevents quadratic O(N^2) complexity. Avoid splitting the same string repeatedly to access lines by index.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:18:31.586Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.tsx",
-        "**/*.js",
-        "**/*.jsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
       "category": "architecture",
       "severity": "error"
     },
@@ -856,12 +674,7 @@
       "message": "Synchronous file operations (e.g. readFileSync) are preferred in CLI tools for simplicity, as blocking the event loop is acceptable in short-lived processes.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:18:53.786Z",
-      "fileGlobs": [
-        "packages/cli/**/*.ts",
-        "packages/cli/**/*.js",
-        "bin/**/*.ts",
-        "bin/**/*.js"
-      ],
+      "fileGlobs": ["packages/cli/**/*.ts", "packages/cli/**/*.js", "bin/**/*.ts", "bin/**/*.js"],
       "category": "performance",
       "severity": "warning"
     },
@@ -872,13 +685,7 @@
       "message": "Provide a dummy fallback API key (e.g., || 'local-only') when using environment variables to ensure local OpenAI-compatible endpoints bypass SDK validation.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:20:16.907Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.tsx",
-        "**/*.js",
-        "**/*.jsx",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "!**/*.test.ts"],
       "category": "architecture",
       "severity": "error"
     },
@@ -889,10 +696,7 @@
       "message": "Casting an object literal to an Error type does not satisfy 'instanceof Error' checks at runtime. Use 'Object.assign(new Error(message), properties)' instead.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:23:23.974Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.tsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.tsx"],
       "category": "style",
       "severity": "warning"
     },
@@ -903,12 +707,7 @@
       "message": "Avoid Zod's .url() validator as it requires a protocol prefix (e.g., http://) and fails on bare hostnames or host:port configurations.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:23:30.349Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.tsx",
-        "**/*.jsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
       "category": "architecture",
       "severity": "error"
     },
@@ -919,11 +718,7 @@
       "message": "Avoid using 'exit 0' in git hooks as it prevents hook chaining. Wrap logic in if/fi blocks instead to allow subsequent hooks to execute.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:24:15.797Z",
-      "fileGlobs": [
-        ".husky/**/*",
-        "scripts/hooks/**/*",
-        "*.sh"
-      ],
+      "fileGlobs": [".husky/**/*", "scripts/hooks/**/*", "*.sh"],
       "category": "architecture",
       "severity": "error"
     },
@@ -975,12 +770,7 @@
       "message": "Model name validation regexes must explicitly allow dots (.) to accommodate naming schemes like gpt-5.4",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:26:15.087Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.tsx",
-        "**/*.jsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
       "category": "style",
       "severity": "warning"
     },
@@ -991,13 +781,7 @@
       "message": "Use 'pnpm exec' instead of 'pnpm bin' to reliably handle workspace package resolution in the monorepo.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:26:22.357Z",
-      "fileGlobs": [
-        "*.sh",
-        "*.bash",
-        "*.yml",
-        "*.yaml",
-        "package.json"
-      ],
+      "fileGlobs": ["*.sh", "*.bash", "*.yml", "*.yaml", "package.json"],
       "category": "style",
       "severity": "warning"
     },
@@ -1024,14 +808,7 @@
       "message": "Always resolve the git repository root via 'git rev-parse --show-toplevel' instead of checking for a .git directory. This ensures compatibility with monorepos, submodules, and worktrees.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:27:11.859Z",
-      "fileGlobs": [
-        "**/*.sh",
-        "**/*.bash",
-        "**/*.js",
-        "**/*.ts",
-        "**/*.yml",
-        "**/*.yaml"
-      ],
+      "fileGlobs": ["**/*.sh", "**/*.bash", "**/*.js", "**/*.ts", "**/*.yml", "**/*.yaml"],
       "category": "style",
       "severity": "warning"
     },
@@ -1042,12 +819,7 @@
       "message": "Use { shell: true } or { shell: IS_WIN } when calling the 'git' binary with execFileSync to ensure it resolves correctly on Windows.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:27:25.049Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.tsx",
-        "**/*.jsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
       "category": "architecture",
       "severity": "warning"
     },
@@ -1058,15 +830,7 @@
       "message": "LLMs are poor at character counting; use semantic constraints (e.g., 'one to two short sentences') instead of numeric limits.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:27:33.745Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.tsx",
-        "**/*.js",
-        "**/*.jsx",
-        "**/*.py",
-        "**/*.md",
-        "**/*.txt"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.py", "**/*.md", "**/*.txt"],
       "category": "style",
       "severity": "warning"
     },
@@ -1077,12 +841,7 @@
       "message": "Use granular assertions rather than snapshots for testing system prompts to avoid brittle tests caused by minor prose changes",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:27:41.274Z",
-      "fileGlobs": [
-        "**/*.test.ts",
-        "**/*.test.js",
-        "**/*.spec.ts",
-        "**/*.spec.js"
-      ],
+      "fileGlobs": ["**/*.test.ts", "**/*.test.js", "**/*.spec.ts", "**/*.spec.js"],
       "category": "style",
       "severity": "warning"
     },
@@ -1108,12 +867,7 @@
       "message": "Check for the presence of the 'g' flag before appending it; re-adding a global flag to a pattern that already includes it causes a runtime SyntaxError.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:28:37.997Z",
-      "fileGlobs": [
-        "**/*.js",
-        "**/*.ts",
-        "**/*.jsx",
-        "**/*.tsx"
-      ],
+      "fileGlobs": ["**/*.js", "**/*.ts", "**/*.jsx", "**/*.tsx"],
       "category": "architecture",
       "severity": "error"
     },
@@ -1164,12 +918,7 @@
       "message": "Include a space or delimiter when concatenating disjoint text fragments to prevent 'keyword synthesis' and security filter bypass.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:29:45.168Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.tsx",
-        "**/*.jsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
       "category": "architecture",
       "severity": "error"
     },
@@ -1180,12 +929,7 @@
       "message": "Do not append the 'g' flag to existing RegExp flags without checking for its presence; duplicate flags cause a runtime SyntaxError in JavaScript.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:30:04.191Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.tsx",
-        "**/*.js",
-        "**/*.jsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
       "category": "architecture",
       "severity": "error"
     },
@@ -1196,10 +940,7 @@
       "message": "When implementing glob matching for '**', ensure the index check excludes the start of the string (index 0). Use 'indexOf(...) > 0' to avoid misinterpreting repo-relative paths as root-anchored.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:31:03.838Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js"],
       "category": "architecture",
       "severity": "error"
     },
@@ -1210,9 +951,7 @@
       "message": "In core packages, prefer a small custom implementation over external libraries like 'micromatch' to keep the dependency graph lean.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:31:15.221Z",
-      "fileGlobs": [
-        "packages/core/**/*"
-      ],
+      "fileGlobs": ["packages/core/**/*"],
       "category": "style",
       "severity": "warning"
     },
@@ -1223,14 +962,7 @@
       "message": "Use the --recurse-submodules flag with git ls-files to ensure submodule files are included in scans.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:32:33.520Z",
-      "fileGlobs": [
-        "**/*.sh",
-        "**/*.bash",
-        "**/*.js",
-        "**/*.ts",
-        "**/*.yml",
-        "**/*.yaml"
-      ],
+      "fileGlobs": ["**/*.sh", "**/*.bash", "**/*.js", "**/*.ts", "**/*.yml", "**/*.yaml"],
       "category": "architecture",
       "severity": "error"
     },
@@ -1258,9 +990,7 @@
       "message": "The MCP spec lacks session lifecycle hooks (session.start, session.end, or beforeDisconnect). Do not attempt to build auto-handoff via MCP code; use agent system prompts as a workaround (see #383).",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:33:29.060Z",
-      "fileGlobs": [
-        "packages/mcp/**/*.ts"
-      ],
+      "fileGlobs": ["packages/mcp/**/*.ts"],
       "category": "architecture",
       "severity": "error"
     },
@@ -1271,13 +1001,7 @@
       "message": "Use --body-file instead of --body to prevent shell injection and escaping issues with LLM-generated text.",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:33:45.083Z",
-      "fileGlobs": [
-        "*.sh",
-        "*.bash",
-        "*.yml",
-        "*.yaml",
-        "packages/cli/**/*.ts"
-      ],
+      "fileGlobs": ["*.sh", "*.bash", "*.yml", "*.yaml", "packages/cli/**/*.ts"],
       "category": "security",
       "severity": "error"
     },
@@ -1288,10 +1012,7 @@
       "message": "Potential shell injection: Never use github.event or inputs directly in 'run' blocks. Map them to environment variables first and reference them as \"$VAR\".",
       "engine": "regex",
       "compiledAt": "2026-03-12T10:36:00.971Z",
-      "fileGlobs": [
-        ".github/workflows/*.yml",
-        ".github/workflows/*.yaml"
-      ],
+      "fileGlobs": [".github/workflows/*.yml", ".github/workflows/*.yaml"],
       "category": "security",
       "severity": "error"
     },
@@ -1302,12 +1023,7 @@
       "message": "Extract the shared exec → JSON.parse → schema.validate pattern into a private helper method to avoid duplicating boilerplate in CLI adapters.",
       "engine": "regex",
       "compiledAt": "2026-03-12T11:24:12.010Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "!**/*.test.ts",
-        "!**/*.spec.ts"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "!**/*.test.ts", "!**/*.spec.ts"],
       "category": "architecture",
       "severity": "error"
     },
@@ -1318,11 +1034,7 @@
       "message": "Strictly enforce 'Fail Fast' for multi-input orchestrator commands. Use Promise.all instead of Promise.allSettled; partial context assembly (e.g., missing one of several PRs) can lead to LLM hallucinations based on incomplete information.",
       "engine": "regex",
       "compiledAt": "2026-03-12T11:26:16.241Z",
-      "fileGlobs": [
-        "**/cli/**/*.ts",
-        "**/totem/**/*.ts",
-        "**/orchestrator/**/*.ts"
-      ],
+      "fileGlobs": ["**/cli/**/*.ts", "**/totem/**/*.ts", "**/orchestrator/**/*.ts"],
       "category": "style",
       "severity": "warning"
     },
@@ -1333,11 +1045,7 @@
       "message": "Custom .env parsers must not override existing process.env keys (use ??= or ||=). Ensure you also strip CRLF (\\r) and surrounding quotes from values.",
       "engine": "regex",
       "compiledAt": "2026-03-12T11:30:21.712Z",
-      "fileGlobs": [
-        "**/cli/**/*.ts",
-        "**/cli/**/*.js",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["**/cli/**/*.ts", "**/cli/**/*.js", "!**/*.test.ts"],
       "category": "architecture",
       "severity": "error"
     },
@@ -1348,9 +1056,7 @@
       "message": "Include the '[Totem Error]' prefix in re-thrown error messages to maintain consistent CLI reporting.",
       "engine": "regex",
       "compiledAt": "2026-03-12T11:31:03.928Z",
-      "fileGlobs": [
-        "packages/cli/**/*.ts"
-      ],
+      "fileGlobs": ["packages/cli/**/*.ts"],
       "category": "style",
       "severity": "warning"
     },
@@ -1361,14 +1067,7 @@
       "message": "Git diff headers wrap paths with spaces in quotes (e.g., +++ \"b/path\"). Update logic to handle optional quotes before the 'b/' prefix to ensure files with spaces are processed correctly.",
       "engine": "regex",
       "compiledAt": "2026-03-12T11:31:45.504Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.py",
-        "**/*.sh",
-        "**/*.go",
-        "**/*.rs"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.py", "**/*.sh", "**/*.go", "**/*.rs"],
       "category": "architecture",
       "severity": "error"
     },
@@ -1379,12 +1078,7 @@
       "message": "User-controlled fields (like PR descriptions or comments) must be wrapped in XML tags explicitly labeled as 'untrusted content' to prevent prompt injection.",
       "engine": "regex",
       "compiledAt": "2026-03-12T11:37:34.822Z",
-      "fileGlobs": [
-        "**/prompts/**/*",
-        "**/ai/**/*",
-        "**/llm/**/*",
-        "**/*prompt*"
-      ],
+      "fileGlobs": ["**/prompts/**/*", "**/ai/**/*", "**/llm/**/*", "**/*prompt*"],
       "category": "security",
       "severity": "error"
     },
@@ -1395,12 +1089,7 @@
       "message": "Sanitize git-sourced metadata (branch, status, diff) to remove ANSI escape sequences and control characters.",
       "engine": "regex",
       "compiledAt": "2026-03-12T11:37:51.849Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.sh",
-        "**/*.bash"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.sh", "**/*.bash"],
       "category": "security",
       "severity": "error"
     },
@@ -1411,11 +1100,7 @@
       "message": "Local LLM 500 errors often indicate VRAM or context exhaustion. Include specific guidance to adjust hardware-steering parameters like 'numCtx' in the error message to help users resolve failures immediately.",
       "engine": "regex",
       "compiledAt": "2026-03-12T11:39:36.248Z",
-      "fileGlobs": [
-        "**/llm/**/*.ts",
-        "**/providers/**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["**/llm/**/*.ts", "**/providers/**/*.ts", "!**/*.test.ts"],
       "category": "architecture",
       "severity": "error"
     },
@@ -1426,13 +1111,7 @@
       "message": "Verify CLI availability (e.g., using 'command -v' or 'tool --version') before execution in git hooks to prevent brittle CI failures.",
       "engine": "regex",
       "compiledAt": "2026-03-12T11:42:55.298Z",
-      "fileGlobs": [
-        ".husky/**/*",
-        ".githooks/**/*",
-        "scripts/hooks/**/*",
-        "**/*.sh",
-        "**/*.bash"
-      ],
+      "fileGlobs": [".husky/**/*", ".githooks/**/*", "scripts/hooks/**/*", "**/*.sh", "**/*.bash"],
       "category": "architecture",
       "severity": "error"
     },
@@ -1443,14 +1122,7 @@
       "message": "Include a space or delimiter between concatenated fragments (e.g., '${a} ${b}') to prevent 'keyword synthesis' and bypass security filters.",
       "engine": "regex",
       "compiledAt": "2026-03-12T11:43:36.197Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.tsx",
-        "**/*.jsx",
-        "**/*.sh",
-        "**/*.bash"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx", "**/*.sh", "**/*.bash"],
       "category": "architecture",
       "severity": "error"
     },
@@ -1461,12 +1133,7 @@
       "message": "ESM intra-module mocks require re-binding: spreading vi.importActual() retains closure references to real exports. Re-bind callers to use the mocked factory instead.",
       "engine": "regex",
       "compiledAt": "2026-03-12T11:46:14.525Z",
-      "fileGlobs": [
-        "**/*.test.ts",
-        "**/*.test.tsx",
-        "**/*.spec.ts",
-        "**/*.spec.tsx"
-      ],
+      "fileGlobs": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"],
       "category": "style",
       "severity": "warning"
     },
@@ -1477,10 +1144,7 @@
       "message": "Avoid using literal file paths in lessons (e.g., 'src/config.ts'). Use conceptual descriptions instead (e.g., 'the configuration file') to prevent drift detector errors when files are moved or renamed.",
       "engine": "regex",
       "compiledAt": "2026-03-12T11:46:43.434Z",
-      "fileGlobs": [
-        ".totem/lessons/**",
-        ".totem/lessons.md"
-      ],
+      "fileGlobs": [".totem/lessons/**", ".totem/lessons.md"],
       "category": "style",
       "severity": "warning"
     },
@@ -1512,12 +1176,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T02:42:50.515Z",
       "createdAt": "2026-03-16T02:42:50.515Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.tsx",
-        "**/*.jsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
       "category": "security",
       "severity": "error"
     },
@@ -1529,12 +1188,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T02:46:32.222Z",
       "createdAt": "2026-03-16T02:46:32.222Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.tsx",
-        "**/*.jsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
       "category": "style",
       "severity": "warning"
     },
@@ -1546,14 +1200,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T02:48:07.575Z",
       "createdAt": "2026-03-16T02:48:07.575Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.tsx",
-        "**/*.jsx",
-        "**/*.mjs",
-        "**/*.cjs"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx", "**/*.mjs", "**/*.cjs"],
       "category": "style",
       "severity": "warning"
     },
@@ -1565,12 +1212,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T02:49:39.467Z",
       "createdAt": "2026-03-16T02:49:39.467Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.tsx",
-        "**/*.jsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
       "category": "security",
       "severity": "error"
     },
@@ -1582,13 +1224,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T02:50:11.470Z",
       "createdAt": "2026-03-16T02:50:11.470Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.tsx",
-        "**/*.jsx",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx", "!**/*.test.ts"],
       "category": "security",
       "severity": "error"
     },
@@ -1600,13 +1236,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T02:50:44.927Z",
       "createdAt": "2026-03-16T02:50:44.927Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.py",
-        "**/*.sh",
-        ".env*"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.py", "**/*.sh", ".env*"],
       "category": "architecture",
       "severity": "error"
     },
@@ -1618,10 +1248,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T02:52:52.036Z",
       "createdAt": "2026-03-16T02:52:52.036Z",
-      "fileGlobs": [
-        ".husky/*",
-        ".git/hooks/*"
-      ],
+      "fileGlobs": [".husky/*", ".git/hooks/*"],
       "category": "performance",
       "severity": "warning"
     },
@@ -1633,11 +1260,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T02:56:34.988Z",
       "createdAt": "2026-03-16T02:56:34.988Z",
-      "fileGlobs": [
-        "**/orchestrator/**/*.ts",
-        "**/totem/**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["**/orchestrator/**/*.ts", "**/totem/**/*.ts", "!**/*.test.ts"],
       "category": "style",
       "severity": "warning"
     },
@@ -1649,10 +1272,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T02:58:53.041Z",
       "createdAt": "2026-03-16T02:58:53.041Z",
-      "fileGlobs": [
-        "packages/cli/src/commands/**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["packages/cli/src/commands/**/*.ts", "!**/*.test.ts"],
       "category": "performance",
       "severity": "warning"
     },
@@ -1664,12 +1284,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T02:59:35.089Z",
       "createdAt": "2026-03-16T02:59:35.089Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.mjs",
-        "**/*.cjs"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.mjs", "**/*.cjs"],
       "category": "architecture",
       "severity": "error"
     },
@@ -1699,12 +1314,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T02:59:59.949Z",
       "createdAt": "2026-03-16T02:59:59.949Z",
-      "fileGlobs": [
-        "**/*.md",
-        "**/*.mdx",
-        "docs/**/*",
-        "guides/**/*"
-      ],
+      "fileGlobs": ["**/*.md", "**/*.mdx", "docs/**/*", "guides/**/*"],
       "category": "style",
       "severity": "warning"
     },
@@ -1716,14 +1326,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T03:00:18.456Z",
       "createdAt": "2026-03-16T03:00:18.456Z",
-      "fileGlobs": [
-        "**/*.md",
-        "**/*.sh",
-        "**/*.yml",
-        "**/*.yaml",
-        "package.json",
-        "**/*.txt"
-      ],
+      "fileGlobs": ["**/*.md", "**/*.sh", "**/*.yml", "**/*.yaml", "package.json", "**/*.txt"],
       "category": "architecture",
       "severity": "error"
     },
@@ -1735,14 +1338,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T03:00:35.755Z",
       "createdAt": "2026-03-16T03:00:35.755Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.py",
-        "**/*.env",
-        "**/*.yaml",
-        "**/*.yml"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.py", "**/*.env", "**/*.yaml", "**/*.yml"],
       "category": "architecture",
       "severity": "error"
     },
@@ -1809,11 +1405,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T03:02:18.906Z",
       "createdAt": "2026-03-16T03:02:18.906Z",
-      "fileGlobs": [
-        "**/*.mcp.json",
-        "**/settings.json",
-        "**/.vscode/settings.json"
-      ],
+      "fileGlobs": ["**/*.mcp.json", "**/settings.json", "**/.vscode/settings.json"],
       "category": "security",
       "severity": "error"
     },
@@ -1825,10 +1417,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T03:03:10.761Z",
       "createdAt": "2026-03-16T03:03:10.761Z",
-      "fileGlobs": [
-        "**/*sarif*/**/*.ts",
-        "**/sarif/**/*.ts"
-      ],
+      "fileGlobs": ["**/*sarif*/**/*.ts", "**/sarif/**/*.ts"],
       "category": "architecture",
       "severity": "error"
     },
@@ -1858,10 +1447,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T03:03:48.822Z",
       "createdAt": "2026-03-16T03:03:48.822Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["**/*.ts", "!**/*.test.ts"],
       "category": "style",
       "severity": "warning"
     },
@@ -1910,9 +1496,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T03:06:12.659Z",
       "createdAt": "2026-03-16T03:06:12.659Z",
-      "fileGlobs": [
-        "**/*.md"
-      ],
+      "fileGlobs": ["**/*.md"],
       "category": "security",
       "severity": "error"
     },
@@ -1924,11 +1508,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T03:06:36.995Z",
       "createdAt": "2026-03-16T03:06:36.995Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "!**/*.test.ts"],
       "category": "architecture",
       "severity": "error"
     },
@@ -1959,10 +1539,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T03:07:11.081Z",
       "createdAt": "2026-03-16T03:07:11.081Z",
-      "fileGlobs": [
-        "packages/cli/**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["packages/cli/**/*.ts", "!**/*.test.ts"],
       "category": "style",
       "severity": "warning"
     },
@@ -1974,11 +1551,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T03:07:29.611Z",
       "createdAt": "2026-03-16T03:07:29.611Z",
-      "fileGlobs": [
-        "packages/cli/**/*.ts",
-        "apps/cli/**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["packages/cli/**/*.ts", "apps/cli/**/*.ts", "!**/*.test.ts"],
       "category": "architecture",
       "severity": "error"
     },
@@ -1990,12 +1563,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T03:08:29.013Z",
       "createdAt": "2026-03-16T03:08:29.013Z",
-      "fileGlobs": [
-        "scripts/**/*.js",
-        "scripts/**/*.ts",
-        "tools/**/*.js",
-        "tools/**/*.ts"
-      ],
+      "fileGlobs": ["scripts/**/*.js", "scripts/**/*.ts", "tools/**/*.js", "tools/**/*.ts"],
       "category": "style",
       "severity": "warning"
     },
@@ -2007,13 +1575,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T03:09:06.578Z",
       "createdAt": "2026-03-16T03:09:06.578Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.tsx",
-        "**/*.jsx",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx", "!**/*.test.ts"],
       "category": "style",
       "severity": "warning"
     },
@@ -2025,11 +1587,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T03:10:02.298Z",
       "createdAt": "2026-03-16T03:10:02.298Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "!**/*.test.ts"],
       "category": "architecture",
       "severity": "error"
     },
@@ -2041,10 +1599,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T03:10:47.000Z",
       "createdAt": "2026-03-16T03:10:47.000Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js"],
       "category": "architecture",
       "severity": "error"
     },
@@ -2056,12 +1611,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T03:12:24.084Z",
       "createdAt": "2026-03-16T03:12:24.084Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.tsx",
-        "**/*.jsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
       "category": "style",
       "severity": "warning"
     },
@@ -2073,10 +1623,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T03:12:55.911Z",
       "createdAt": "2026-03-16T03:12:55.911Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.tsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.tsx"],
       "category": "style",
       "severity": "warning"
     },
@@ -2088,11 +1635,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T03:13:41.467Z",
       "createdAt": "2026-03-16T03:13:41.467Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "!**/*.test.ts"],
       "category": "architecture",
       "severity": "error"
     },
@@ -2104,14 +1647,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T03:14:07.972Z",
       "createdAt": "2026-03-16T03:14:07.972Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.tsx",
-        "**/*.js",
-        "**/*.jsx",
-        "**/*.py",
-        "**/*.go"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.py", "**/*.go"],
       "category": "style",
       "severity": "warning"
     },
@@ -2123,11 +1659,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T03:14:19.583Z",
       "createdAt": "2026-03-16T03:14:19.583Z",
-      "fileGlobs": [
-        "packages/core/**/*.ts",
-        "libs/**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["packages/core/**/*.ts", "libs/**/*.ts", "!**/*.test.ts"],
       "category": "style",
       "severity": "warning"
     },
@@ -2176,10 +1708,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T18:26:19.306Z",
       "createdAt": "2026-03-16T18:26:19.306Z",
-      "fileGlobs": [
-        "**/*config*.*",
-        "**/*cache*.*"
-      ],
+      "fileGlobs": ["**/*config*.*", "**/*cache*.*"],
       "severity": "warning"
     },
     {
@@ -2190,11 +1719,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T18:26:53.992Z",
       "createdAt": "2026-03-16T18:26:53.992Z",
-      "fileGlobs": [
-        "**/core/**/*.ts",
-        "**/core/**/*.js",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["**/core/**/*.ts", "**/core/**/*.js", "!**/*.test.ts"],
       "severity": "warning"
     },
     {
@@ -2205,12 +1730,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T18:28:10.471Z",
       "createdAt": "2026-03-16T18:28:10.471Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.js",
-        "**/*.tsx",
-        "**/*.jsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
       "severity": "warning"
     },
     {
@@ -2221,12 +1741,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T18:28:19.310Z",
       "createdAt": "2026-03-16T18:28:19.310Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.tsx",
-        "**/*.js",
-        "**/*.jsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
       "severity": "warning"
     },
     {
@@ -2237,12 +1752,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T18:28:42.664Z",
       "createdAt": "2026-03-16T18:28:42.664Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.tsx",
-        "**/*.js",
-        "**/*.jsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
       "severity": "warning"
     },
     {
@@ -2278,10 +1788,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T18:31:06.232Z",
       "createdAt": "2026-03-16T18:31:06.232Z",
-      "fileGlobs": [
-        "packages/cli/src/commands/**/*.ts",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["packages/cli/src/commands/**/*.ts", "!**/*.test.ts"],
       "severity": "warning",
       "category": "performance"
     },
@@ -2293,11 +1800,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T18:31:28.577Z",
       "createdAt": "2026-03-16T18:31:28.577Z",
-      "fileGlobs": [
-        "**/*.md",
-        "**/*.mdx",
-        "**/*.txt"
-      ],
+      "fileGlobs": ["**/*.md", "**/*.mdx", "**/*.txt"],
       "severity": "warning"
     },
     {
@@ -2308,10 +1811,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T18:32:34.014Z",
       "createdAt": "2026-03-16T18:32:34.014Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.tsx"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.tsx"],
       "severity": "warning"
     },
     {
@@ -2322,9 +1822,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T18:33:55.501Z",
       "createdAt": "2026-03-16T18:33:55.501Z",
-      "fileGlobs": [
-        "**/compiled-rules.json"
-      ],
+      "fileGlobs": ["**/compiled-rules.json"],
       "severity": "warning"
     },
     {
@@ -2335,11 +1833,7 @@
       "engine": "regex",
       "compiledAt": "2026-03-16T18:34:35.156Z",
       "createdAt": "2026-03-16T18:34:35.156Z",
-      "fileGlobs": [
-        "**/*.ts",
-        "**/*.tsx",
-        "!**/*.test.ts"
-      ],
+      "fileGlobs": ["**/*.ts", "**/*.tsx", "!**/*.test.ts"],
       "severity": "warning"
     },
     {


### PR DESCRIPTION
## Summary

Audits all 148 compiled rules to reduce noise from false positives that were blocking PRs and cluttering code scanning alerts.

### Changes
- **DELETE rule #33**: Broad `\bimport` matcher flagged stdlib imports like `node:child_process` — redundant with rules #105 and #142 which cover the specific cases
- **FIX #105**: `@mmnto/totem` static import check now excludes `import type` (was false-positive on type-only imports)
- **FIX #123**: `throw new Error` check now excludes `TotemError` variants — the clean error pattern was being flagged as the problem it solves
- **FIX #140**: Updated for TotemError hierarchy, set severity to warning
- **Set severity on 9 rules**: All had `undefined` severity, now set to `warning`

### Result
- 148 → 147 rules
- 0 undefined severity
- False positives on TotemError, type imports, and stdlib imports eliminated

## Test plan
- [x] All 999 tests pass
- [x] `totem lint` — 0 errors, 0 false positives
- [x] Build passes