### PR TITLE
fix: scope manual content injection to README only (#672)

### DIFF
--- a/packages/cli/src/commands/docs.ts
+++ b/packages/cli/src/commands/docs.ts
@@ -144,7 +144,7 @@ function assemblePrompt(
   }
 
   // Manual content — only inject into user-facing docs (README), not internal docs
-  const isUserFacing = doc.path === 'README.md' || doc.path.includes('README');
+  const isUserFacing = path.basename(doc.path).toLowerCase() === 'readme.md';
   if (isUserFacing) {
     try {
       const manualPath = path.resolve('docs', 'manual');


### PR DESCRIPTION
## Summary

`totem docs` was injecting `docs/manual/*.md` content into ALL 4 configured docs (README, roadmap, active_work, architecture). This caused duplicate troubleshooting sections to appear in every doc on every regeneration.

### Fix
Only inject manual content when the doc path is `README.md`. Internal docs are no longer polluted.

### Why this kept happening
The `assemblePrompt` function reads `docs/manual/` for every doc target indiscriminately. The LLM then dutifully includes the troubleshooting content wherever it fits. We trimmed it manually twice (#650, #671) before fixing the root cause.

## Test plan
- [x] 1,008 tests pass
- [x] Build clean

Closes #672