### PR TITLE
docs: harden README against Staff Engineer red team

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ _AI coding agents are brilliant goldfish. Totem gives them a memory._
 
 A zero-config CLI and MCP Server that compiles your project's architectural rules into deterministic CI guardrails. It creates a persistent, model-agnostic context layer that outlasts any single AI session — so Claude, Cursor, Gemini, and Copilot all enforce the same rules without being told twice.
 
-Totem doesn't ship with your app. It lives in your workflow.
+Totem doesn't ship with your app. It lives in your workflow. It also works on non-code repositories — docs, ADRs, infrastructure configs, personal notes — via `totem init --bare`.
 
 ## The 10-Second Workflow
 


### PR DESCRIPTION
## Summary

Five surgical additions addressing attack vectors from a simulated FAANG Staff Engineer red team:

1. **"100% deterministic"** — `totem lint` does not call an LLM. No temperature, no inference. Logic, not vibes.
2. **"Fully air-gappable"** — With Ollama, the entire pipeline runs without a single external API call.
3. **".lancedb is never committed"** — It's a local cache, rebuilt by sync. Only lessons and compiled-rules.json are versioned.
4. **"Executable ADRs"** — Lessons aren't just documentation. They're enforced in every commit.
5. **Non-code use case** — `totem init --bare` works on docs, ADRs, notes, infrastructure configs.

## Why
A skeptical Staff Engineer would attack three claims: "local" (but you send to OpenAI), "deterministic" (but you use an LLM), and "lightweight" (but you commit a vector DB). All three are false — but the README didn't say so clearly enough.