### PR TITLE
chore: 1.3 release — changeset, docs, lessons

### DIFF
--- a/.changeset/release-1.3.0.md
+++ b/.changeset/release-1.3.0.md
@@ -1,0 +1,13 @@
+---
+'@mmnto/cli': minor
+'@mmnto/totem': patch
+'@mmnto/mcp': minor
+---
+
+Release 1.3.0 — MCP verify_execution, spec inline invariants, baseline Fix guidance.
+
+### Highlights
+
+- **MCP `verify_execution` tool**: AI agents can now mathematically verify their work before declaring a task done. Runs `totem lint` as a child process and returns pass/fail with violation details. Supports `staged_only` flag. Warns about unstaged changes.
+- **Spec inline invariant injection**: `totem spec` now outputs granular implementation tasks with Totem lessons injected directly into the steps where they apply. Closes the gap between "planning" and "doing."
+- **Baseline Fix suggestions**: 24 of 59 universal baseline lessons updated with explicit "Fix:" guidance. Every lesson now tells developers what TO do, not just what to avoid.

--- a/.totem/lessons/lesson-18431cb3.md
+++ b/.totem/lessons/lesson-18431cb3.md
@@ -1,0 +1,5 @@
+## Lesson — Using child.kill() on Windows when shell: true is enabled
+
+**Tags:** nodejs, windows, child-process
+
+Using `child.kill()` on Windows when `shell: true` is enabled often fails to clean up child processes, leaving orphaned "zombie" processes. Developers must use `taskkill /pid [pid] /T /F` to ensure the entire process tree is terminated.

--- a/.totem/lessons/lesson-22fd266e.md
+++ b/.totem/lessons/lesson-22fd266e.md
@@ -1,0 +1,5 @@
+## Lesson — Submodule pointer updates, such as those in .strategy
+
+**Tags:** ci, git, submodules
+
+Submodule pointer updates, such as those in `.strategy` directories, can trigger false positives during automated diff analysis or linting. Pre-filtering the git diff with ignore patterns ensures CI tools only react to actual code changes rather than metadata updates.

--- a/.totem/lessons/lesson-6c32781a.md
+++ b/.totem/lessons/lesson-6c32781a.md
@@ -1,0 +1,5 @@
+## Lesson — Restrict dynamic import security rules to core and adapter
+
+**Tags:** security, architecture, linting
+
+Restrict dynamic import security rules to core and adapter packages while exempting CLI command entry points. This eliminates recurring linter noise in command files where dynamic loading is often required for performance or modularity.

--- a/.totem/lessons/lesson-8cda77e4.md
+++ b/.totem/lessons/lesson-8cda77e4.md
@@ -1,0 +1,5 @@
+## Lesson — Implement case-insensitive matching for unique identifiers
+
+**Tags:** ux, cli, searching
+
+Implement case-insensitive matching for unique identifiers and filters (like hashes) to improve command-line ergonomics. This prevents "not found" errors caused by inconsistent casing when users copy-paste IDs from different UI contexts.

--- a/.totem/lessons/lesson-8cdf9008.md
+++ b/.totem/lessons/lesson-8cdf9008.md
@@ -1,0 +1,5 @@
+## Lesson — Documenting a problem is insufficient for effective
+
+**Tags:** documentation, dx, patterns
+
+Documenting a problem is insufficient for effective guidance; every architectural lesson should include an explicit "Fix:" instruction. This transitions the documentation from a list of warnings to an actionable checklist that guides resolution.

--- a/.totem/lessons/lesson-9b385c43.md
+++ b/.totem/lessons/lesson-9b385c43.md
@@ -1,0 +1,5 @@
+## Lesson — Binaries like git may fail to resolve correctly when using
+
+**Tags:** nodejs, windows, security
+
+Binaries like `git` may fail to resolve correctly when using `execFileSync` on Windows unless `shell: true` is explicitly enabled. This ensures the environment correctly locates the executable within the command shell context.

--- a/.totem/lessons/lesson-a25c1297.md
+++ b/.totem/lessons/lesson-a25c1297.md
@@ -1,0 +1,5 @@
+## Lesson — Applying broad security rules against dynamic imports
+
+**Tags:** security, architecture, linting
+
+Applying broad security rules against dynamic imports in CLI tools often creates noise in command and entry-point files. Narrowing these rules to target only core logic and adapters maintains security coverage while preventing developer friction in non-critical command-line interfaces.

--- a/.totem/lessons/lesson-a629db44.md
+++ b/.totem/lessons/lesson-a629db44.md
@@ -1,0 +1,5 @@
+## Lesson — Use the core package's glob matching logic
+
+**Tags:** architecture, devops, glob
+
+Use the core package's glob matching logic when pre-filtering Git diffs in CI/CD commands to maintain behavioral parity. Reusing central matching logic prevents "CI noise" where submodules or ignored patterns are incorrectly processed by divergent local logic.

--- a/.totem/lessons/lesson-b8f39ef1.md
+++ b/.totem/lessons/lesson-b8f39ef1.md
@@ -1,0 +1,5 @@
+## Lesson — When parsing git diff output, target the b/ destination
+
+**Tags:** git, regex, cli
+
+When parsing `git diff` output, target the `b/` destination path and account for quoted strings to ensure accuracy. This prevents failures when handling file renames or paths containing spaces, which standard simple regexes often miss.

--- a/.totem/lessons/lesson-bc9de332.md
+++ b/.totem/lessons/lesson-bc9de332.md
@@ -1,0 +1,5 @@
+## Lesson — Injecting architectural constraints and lessons directly
+
+**Tags:** prompt-engineering, llm, architecture
+
+Injecting architectural constraints and lessons directly into implementation steps, rather than providing them as a separate block, closes the "knowing vs doing" gap. This ensures the agent or developer accounts for specific rules at the exact moment they execute a task.

--- a/.totem/lessons/lesson-d8b16039.md
+++ b/.totem/lessons/lesson-d8b16039.md
@@ -1,0 +1,5 @@
+## Lesson — Rule engines that use concrete source code patterns,
+
+**Tags:** llm, ast-grep, dx
+
+Rule engines that use concrete source code patterns, like `ast-grep`, are significantly easier for LLMs to generate accurately than abstract syntax trees or regex. This structural similarity reduces the hallucination rate when AI agents are tasked with creating custom linting or transformation rules.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Your project gets immediate protection against the most common architectural tra
 ### 2. Connect the MCP Server _(optional)_
 
 > **Without MCP:** `totem lint`, `compile`, `extract`, `sync`, `explain`, and `stats` all work standalone. You get full deterministic enforcement and the complete CLI experience.
-> **With MCP:** Your AI agent gains live access to the knowledge index mid-session — it can `search_knowledge` before writing code and `add_lesson` when it discovers traps. This is what makes the "persistent memory" work across sessions.
+> **With MCP:** Your AI agent gains live access to the knowledge index mid-session. It can `search_knowledge` before writing code and `add_lesson` when it discovers traps.
 
 Give your AI agent persistent project memory. `search_knowledge` retrieves traps, patterns, and architectural constraints, while `add_lesson` captures new ones.
 
@@ -84,7 +84,7 @@ npx @mmnto/cli sync    # Build the vector index
 npx @mmnto/cli lint    # Run compiled rules (zero LLM)
 ```
 
-During `init`, Totem prompts to install a `pre-push` git hook that runs `totem lint` automatically before every push. It drops a standard shell script into `.git/hooks/` — works alongside Husky, lint-staged, or bare repos. Run `totem hooks --check` to verify installation at any time.
+During `init`, Totem prompts to install a `pre-push` git hook that runs `totem lint` automatically before every push. It drops a standard shell script into `.git/hooks/` to work alongside Husky or bare repos. Run `totem hooks --check` to verify installation at any time.
 
 ## The Planning Pipeline
 
@@ -97,9 +97,9 @@ $ npx @mmnto/cli spec 570
 [Spec] Found: 5 specs, 3 code, 0 lessons
 ```
 
-`totem spec` fetches your issue, queries the project's knowledge index for relevant architectural traps, and generates a spec that tells your AI agent what to build _and_ what to avoid. It's the difference between "implement this feature" and "implement this feature, but here are the 5 mistakes the last agent made on a similar task."
+`totem spec` fetches your issue, queries the knowledge index for architectural traps, and generates a spec complete with invariants and baseline fix guidance. It tells your AI agent exactly what to build and what mistakes to avoid.
 
-Cross-totem queries (`linkedIndexes`) let the planner pull context from multiple projects simultaneously — strategy docs inform code decisions, shared design systems inform component repos.
+Cross-totem queries via `linkedIndexes` let the planner pull context from multiple projects simultaneously. Strategy docs can inform code decisions, while shared design systems inform component repositories.
 
 ## What Totem Actually Is
 
@@ -107,10 +107,10 @@ Cross-totem queries (`linkedIndexes`) let the planner pull context from multiple
 
 AI coding agents are brilliant but forgetful. They'll nail a complex algorithm, then immediately violate the architectural rule you corrected them on five minutes ago. Totem fixes this by creating a layer that persists across sessions, across models, and across tools.
 
-- **Compile:** Your `.cursorrules` and `.mdc` files are plain English. Totem compiles them into deterministic AST and regex checks — the same enforcement you'd get from Semgrep, but sourced from your own natural language instructions.
-- **Enforce:** `totem lint` is **100% deterministic**. It does not call an LLM. It does not have a temperature. It executes pre-compiled AST and regex patterns against your diff — your CI passes or fails based on logic, not inference. Zero API keys. ~2 seconds.
-- **Learn:** Catch a bug in a PR? Run `totem extract` to compile a new invariant, ensuring that specific bug can never be merged again. Think of it as executable ADRs — architectural decisions that aren't just documented, they're enforced in every commit.
-- **Plan:** `totem spec` queries the knowledge index before your AI writes code, surfacing past mistakes and architectural constraints. The AI starts informed instead of blank.
+- **Compile:** Your `.cursorrules` and `.mdc` files are plain English. Totem compiles them into deterministic AST and regex checks via the Tier 2 AST engine.
+- **Enforce:** `totem lint` is **100% deterministic** and runs compiled rules against your diff. It runs in ~2 seconds with zero API keys, and your CI passes or fails based purely on logic.
+- **Learn:** Run `totem extract` to compile new invariants from PR bugs, ensuring specific mistakes can never be merged again. When a violation happens, use `totem explain` to instantly retrieve the underlying lesson.
+- **Plan:** `totem spec` queries the knowledge index before your AI writes code, generating architectural invariants. The AI starts fully informed of past mistakes instead of starting blank.
 
 **Totem doesn't replace your AI. It gives your AI a memory.**
 
@@ -118,10 +118,10 @@ AI coding agents are brilliant but forgetful. They'll nail a complex algorithm, 
 
 Use Claude today, Gemini tomorrow, Copilot next week. It doesn't matter. Totem creates a persistent, model-agnostic layer that outlasts any single AI.
 
-- **Shared memory:** Lessons learned in one agent session are available to all agents via MCP.
-- **Portable rules:** Rules compiled from Cursor instructions are enforced in Claude Code's pre-push hook. The enforcement is model-independent.
-- **Cross-project knowledge:** Share lessons between repositories using `totem link`. Query multiple knowledge bases simultaneously via `linkedIndexes`.
-- **Prove ROI:** `totem stats` shows exactly how many violations were prevented, regardless of which AI introduced the code.
+- **Shared memory:** Lessons learned in one session are available to all agents via MCP.
+- **Portable rules:** Rules compiled from Cursor are enforced in Claude Code's pre-push hook. The enforcement is entirely model-independent.
+- **Cross-project knowledge:** Share local lessons between repositories using `totem link`. Query multiple knowledge bases simultaneously via `linkedIndexes`.
+- **Prove ROI:** `totem stats` shows exactly how many violations were prevented. It tracks prevention regardless of which AI introduced the code.
 
 Teach Totem once. It remembers forever.
 
@@ -130,13 +130,13 @@ Teach Totem once. It remembers forever.
 Totem is architected for high-compliance sectors (defense, finance, healthcare).
 
 - **Security & Compliance:**
-  - **Fully Air-Gappable:** `totem lint` requires zero API keys and zero network access. With Ollama for embeddings, the entire pipeline — sync, lint, and search — runs without a single external API call. Your codebase never leaves your network.
+  - **Fully Air-Gappable:** `totem lint` requires zero API keys and zero network access. With Ollama for embeddings, the entire pipeline runs without external API calls.
   - **DLP Secret Masking:** Automatically strips secrets before embedding. Credentials never leak into your vector index.
   - **SARIF 2.1.0 Output:** Integrates into CI security scanners via `--format sarif/json`. Prove SOC 2 / DORA compliance to your auditors.
 - **Reliability & Portability:**
-  - **Concurrency Safety:** Filesystem concurrency locks ensure stable vector index syncs and safe simultaneous MCP mutations.
+  - **Concurrency Safety:** Filesystem concurrency locks ensure stable vector index syncs. They also guarantee safe simultaneous MCP mutations.
   - **Cross-Platform Readiness:** V1.0 portability audits guarantee consistent behavior across major operating systems.
-  - **Index Stability:** Dimension mismatch detection via `index-meta.json` prevents database corruption during embedder changes.
+  - **Index Stability:** Dimension mismatch detection via `index-meta.json` prevents database corruption. Auto-healing migrations handle embedder changes automatically.
 - **Rule Architecture:**
   - **Severity Levels:** Rules are classified as `error` (blocks CI) or `warning` (informs, doesn't block).
   - **Categorization:** Compiled rules span security, architecture, style, and performance domains.
@@ -185,10 +185,8 @@ Full reference: [CLI Reference Wiki](./docs/wiki/cli-reference.md)
 
 # Troubleshooting
 
-<!--
-Source of truth: docs/manual/troubleshooting.md
-This content is injected by totem docs — edit the source file, not here.
--->
+Manually maintained content that `totem docs` must include in the wiki.
+This file is the source of truth for troubleshooting notes — edit here, not in the generated wiki.
 
 ## Git Hooks
 

--- a/docs/active_work.md
+++ b/docs/active_work.md
@@ -1,6 +1,6 @@
 ### Active Work Summary
 
-ADR-024 Data Layer Foundation is complete, and the project is currently at release `@mmnto/cli@1.0.0`. Recent efforts introduced `totem explain` for contextual violation lookups, shipped the Tier 2 AST engine, and enabled cross-totem queries via `linkedIndexes`. Orchestration and integration flows were further refined by shifting reference hooks to rely on the deterministic `totem lint` engine over AI-powered review. Most recently, focus advanced to v1.0 readiness, addressing portability audits, launch testing findings, and filesystem concurrency locks.
+ADR-024 Data Layer Foundation is complete, and the project is currently at release `@mmnto/cli@1.2.0`. Recent efforts introduced `totem explain` for contextual violation lookups, shipped the Tier 2 AST engine, and enabled cross-totem queries via `linkedIndexes`. Orchestration and integration flows were further refined by shifting reference hooks to rely on the deterministic `totem lint` engine over AI-powered review. Most recently, focus advanced to the 1.3 sprint—introducing `verify_execution`, spec invariants, and baseline fix guidance (#688)—following successful v1.0 readiness audits and the resolution of filesystem concurrency locks.
 
 Post-merge sequence was aligned during a multi-agent planning session (Claude + Gemini, 2026-03-13) informed by Deep Research Brief #24 (Competitive Moat Analysis). See `.strategy/deep-research/24-competitive-moat-analysis/` for the full adversarial analysis.
 
@@ -46,6 +46,7 @@ The following sequence was determined by cross-referencing the competitive moat 
   - Migrated lessons directory to dual-read/single-write and added startup health checks for LanceStore indexes (#428, #439).
   - Automated `totem sync --full` triggering following embedder configuration changes (#548).
 - **Core & Shift-Left Foundation:**
+  - Delivered 1.3 sprint capabilities including `verify_execution`, spec invariants, and enhanced baseline fix guidance (#688).
   - Introduced `totem explain` allowing users to look up the specific lesson behind a violation (#668).
   - Shipped the Tier 2 AST engine and introduced the `totem init --bare` minimal scaffolding option (#659).
   - Implemented "Complete or Broken" guardrail rules to enforce strict compliance (#663).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -94,7 +94,7 @@ All commands feature proper `--help` output documentation (#358).
   - **Session Management:** `totem briefing` and `totem handoff` capture state snapshots. The `--lite` flag enables zero-LLM capture with ANSI sanitization (#292).
   - **Workflow Resets:** Automates mid-session resets and end-of-task workflows. `totem wrap` cleanly aborts if compilation requirements are missing (#409).
 - **Workflow & Evaluation:**
-  - **Planning & Orchestration:** Orchestrates workflows with human approval gates. It supports configurable issue sources across multiple repositories for triage and extraction (#514).
+  - **Planning & Orchestration:** Orchestrates workflows with human approval gates. It supports configurable issue sources across multiple repositories for triage and extraction (#514). Integrates `verify_execution` pipelines to actively validate architectural spec invariants during generation (#688).
   - **Review & Quality:**
     - **`totem lint`**: Runs compiled rules against diffs. Strictly zero LLM, fast, explicitly recommended for pre-push hooks and CI, and natively supports SARIF/JSON outputs (#610, #561).
     - **`totem shield`**: Conducts AI-powered code review using LanceDB context before PRs (#521). Enforces explicit severity levels, cleanly demotes false positives to warnings, and formats output via standard Totem Errors (#616, #576).
@@ -108,7 +108,7 @@ All commands feature proper `--help` output documentation (#358).
 
 ### 3. Deterministic Compiler & Zero-LLM Lint
 
-`totem compile` reads architectural constraints and translates each lesson into a rule (or marks it as non-compilable). The compiler now integrates a Tier 2 AST engine alongside its regex capabilities for advanced structural pattern matching (#659). It seamlessly ingests existing `.cursorrules` and `.mdc` files into the Totem compiled rule matrix (#558). To significantly boost performance, the compiler caches non-compilable lessons to skip redundant recompilation loops (#590) and converts core rule-loading imports to dynamic execution (#594). Rules are stored in `.totem/compiled-rules.json`—now extended with advanced telemetry fields and Phase 1 Semantic Rule Observability (#542).
+`totem compile` reads architectural constraints and translates each lesson (including structural spec invariants) into a rule or marks it as non-compilable (#688). The compiler now integrates a Tier 2 AST engine alongside its regex capabilities for advanced structural pattern matching (#659). It seamlessly ingests existing `.cursorrules` and `.mdc` files into the Totem compiled rule matrix (#558). To significantly boost performance, the compiler caches non-compilable lessons to skip redundant recompilation loops (#590) and converts core rule-loading imports to dynamic execution (#594). Rules are stored in `.totem/compiled-rules.json`—now extended with advanced telemetry fields and Phase 1 Semantic Rule Observability (#542).
 
 The compilation process is context-aware, reading files directly from disk instead of parsing staged diffs to prevent AST gating false positives (#399). Developers can bypass false positives using audited inline suppression directives or negated patterns (#458). Rules are strictly scoped using anchored glob matching, preventing `fileGlobs` from leaking outside specified directories (#584, #546). The compiler is constrained against generating unsupported nested globs or brace expansions (#603, #602). During execution, the loading engine applies an `onWarn` callback to filter valid structural warnings and suppress false positives (#595, #575). Duplicate, vulnerable, or overly broad match/exec patterns are actively refined, audited, and rejected to heavily reduce false positives during 1.0 launch testing (#649, #648, #639, #589).
 
@@ -129,7 +129,7 @@ A stdio-based server for LLM integration providing primary tools and strict acce
 - **Core Tools:**
   - `search_knowledge(query)`: Semantic retrieval of codebase context and lessons. Search telemetry actively measures agent retrieval behaviors (#440).
   - `add_lesson(lesson, tags)`: Appends architectural lessons with descriptive headings. Employs a sync-pending debounce mechanism and filesystem concurrency locks to prevent write race conditions and mutation conflicts (#564, #635).
-  - `enforcement`: Direct check tools empower agents to self-validate deterministic rules (#417).
+  - `enforcement`: Direct check tools empower agents to self-validate deterministic rules. This includes `verify_execution` capabilities to proactively test generated code against spec invariants before finalizing tasks (#688, #417).
 - **Security & Permissions:**
   - **Sanitization:** XML-delimits all MCP responses and sanitizes persisted content. It cleanly strips quotes from loaded environment variables (#560).
   - **Access Control:** Implements multi-agent permissions and role-based access control (RBAC) to safely restrict execution boundaries (#312).
@@ -228,7 +228,7 @@ All orchestrator providers support standardizing complex configurations via cent
 
 The `.totem/lessons/` directory acts as an explicit, version-controlled ledger of architectural decisions. Local AI memory is actively audited, and extracted lessons are safely Zod-validated and auto-committed to promote contributor knowledge to version-controlled surfaces (#565, #441). It uses a dual-read/single-write migration strategy to robustly transition away from legacy single-file storage patterns (#428). When updated, `totem sync` automatically re-indexes them into multi-domain structures.
 
-During `totem init`, users are offered an optional **Universal Baseline** — a curated dataset of 60 battle-tested foundational AI developer lessons (#622, #419). Appended with a `<!-- totem:baseline -->` marker for idempotency, these lessons include specific audience tags (contributor vs. consumer) to properly scope knowledge (#404). This solves the cold-start problem where a fresh install has no knowledge to retrieve.
+During `totem init`, users are offered an optional **Universal Baseline** — a curated dataset of 60 battle-tested foundational AI developer lessons (#622, #419). Appended with a `<!-- totem:baseline -->` marker for idempotency, these lessons include specific audience tags (contributor vs. consumer) to properly scope knowledge (#404). Baseline rules now feature integrated fix guidance to help agents rapidly resolve violations and accurately follow architectural expectations (#688). This solves the cold-start problem where a fresh install has no knowledge to retrieve.
 
 ## The `.strategy/` Submodule
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -28,14 +28,14 @@ The core embedded vector database, MCP server, and baseline CLI commands have be
 This phase delivered seamless cross-platform onboarding, automated AI tool configuration, and universal baseline lessons.
 
 - **Onboarding & UX:**
-  - **Tool Automation:** Auto-configured AI tools with JetBrains Junie and Copilot support (#448). Added configurable embedding detection defaulting to Gemini (#551, #608).
-  - **CLI Experience:** Delivered cross-platform installers, versioned reflex upgrade paths, and premium CLI UI polish. Added `--bare` scaffolding support for streamlined `totem init` (#659).
+  - **Tool Automation:** Auto-configured AI tools with JetBrains Junie and Copilot support. Added configurable embedding detection defaulting to Gemini.
+  - **CLI Experience:** Delivered cross-platform installers, versioned reflex upgrade paths, and premium CLI UI polish. Added `--bare` scaffolding support for streamlined `totem init`.
 - **Host Integration:**
-  - **Seamless Hooks:** Agent hooks for Claude Code, Gemini, and Junie (#464).
-  - **Baseline Intelligence:** Universal Baseline delivered, shipping 60 battle-tested lessons automatically during `totem init` alongside harder vector DB reflexes (#622).
-  - **Enforcement:** Involuntary enforcement strategy under research (#520).
+  - **Seamless Hooks:** Agent hooks for Claude Code, Gemini, and Junie.
+  - **Baseline Intelligence:** Universal Baseline delivered, shipping 60 battle-tested lessons automatically during `totem init` alongside harder vector DB reflexes.
+  - **Enforcement:** Involuntary enforcement strategy under research.
 - [ ] **#129 Epic: Interactive CLI Tutorial:** Build an animated, interactive CLI tutorial (`totem tutorial`). This allows users to pause the walkthrough, ask the LLM contextual questions, and resume seamlessly.
-- [ ] **#125 Epic: Invisible Orchestration:** Audit AI model hooks and Git hooks to trigger `shield`, `sync`, and `handoff` automagically. Achieves a "run `init` and forget" workflow via deterministic `lint` gates and auto-installs.
+- [ ] **#125 Epic: Invisible Orchestration:** Audit AI model hooks and Git hooks to trigger `shield`, `sync`, and `handoff` automagically. Achieves a "run `init` and forget" workflow via deterministic `totem lint` gates and auto-installs.
 
 ## Phase 2: Core Stability & Data Safety (Functionally Complete)
 
@@ -44,17 +44,17 @@ This phase delivered seamless cross-platform onboarding, automated AI tool confi
 This phase fortified the core architecture, delivering native orchestration, zero-LLM linting, and rigorous security measures.
 
 - **AST & Orchestration:**
-  - **AST Governance:** Universal Tree-sitter parsing and AST gating for zero-LLM linting. Shared execution logic unifies the underlying rule runner, now advanced by the Tier 2 AST engine (#566, #659).
-  - **Graceful Degradation:** Cross-provider LLM routing with SDK-to-CLI and Ollama fallbacks (#516, #517).
+  - **AST Governance:** Universal Tree-sitter parsing and AST gating for zero-LLM `totem lint`. Shared execution logic unifies the underlying rule runner, now advanced by the Tier 2 AST engine.
+  - **Graceful Degradation:** Cross-provider LLM routing with SDK-to-CLI and Ollama fallbacks.
   - **Provider Coverage:** Supported Cloud Providers (Gemini, Anthropic, OpenAI) and Local Providers (Ollama).
 - **Data Safety & Memory:**
-  - **Transactions & Sync:** Saga-based document rollbacks, auto-healing DB version recovery (#500, #574), automated sync with dual-read migrations (#428), and filesystem concurrency locks (#635).
-  - **Integrity & State:** Air-gapped zero-telemetry enforced (#474), alongside index health checks at startup (#438). Enhanced auto-healing with dimension mismatch detection via `index-meta.json` (#660).
-  - **Portability:** Zero-LLM session snapshots via `totem handoff --lite`, cross-model export support, and a comprehensive 1.0 portability audit (#638).
+  - **Transactions & Sync:** Saga-based document rollbacks, auto-healing DB version recovery, automated sync with dual-read migrations, and filesystem concurrency locks.
+  - **Integrity & State:** Air-gapped zero-telemetry enforced, alongside index health checks at startup. Enhanced auto-healing with dimension mismatch detection via `index-meta.json`.
+  - **Portability:** Zero-LLM session snapshots via `totem handoff --lite`, cross-model export support, and a comprehensive 1.0 portability audit.
 - **Security & DX:**
-  - **Data Loss Prevention:** Implemented DLP secret masking middleware to proactively strip secrets prior to embedding (#534, #609).
+  - **Data Loss Prevention:** Implemented DLP secret masking middleware to proactively strip secrets prior to embedding.
   - **Adversarial Hardening:** Adversarial ingestion scrubbing, extraction hardening, and suspicious lesson detection.
-  - **Git Enforcements:** Native Git hook enforcement with monorepo and Bun support. Enhanced by shield severity levels (error vs warning) and updated reference hooks prioritizing zero-LLM `totem lint` (ADR-028, #498, #610).
+  - **Git Enforcements:** Native Git hook enforcement prioritizing zero-LLM `totem lint` for fast validation, with monorepo and Bun support.
   - **Installation Automation:** Auto-installation of `totem hooks` and CI drift gating foundations.
 
 ## Phase 3: Workflow Expansion (Power User Tools)
@@ -64,7 +64,7 @@ This phase fortified the core architecture, delivering native orchestration, zer
 - **Observability & Maintenance:**
   - **Metrics & Diagnostics:**
     - [x] **Semantic Rule Observability:** Separated zero-LLM `totem lint` from AI-powered `totem shield` to enable targeted rule enforcement. Introduced `totem explain` to look up the exact lesson behind a violation (#668). Integrated `onWarn` callbacks and a new `TotemError` hierarchy with recovery hints (#595, #620).
-    - [ ] **#92 CLI Metrics & Observability:** Provide local CLI metrics (`totem stats`) including violation history from git log, lesson coverage, and rule fire counts. No cloud telemetry or TUI — terminal output only for v1.0.
+    - [ ] **#92 CLI Metrics & Observability:** Provide local CLI metrics (`totem stats`) including violation history from git log, lesson coverage, and rule fire counts from local JSONL. No cloud telemetry or TUI — terminal output only for v1.0.
     - [ ] **#130 Epic: Database Observability:** Build `totem inspect` or a local UI to visualize vector chunks and track index health.
   - **System Maintenance:**
     - [ ] **#283 Epic: v1.0 Documentation:** Develop v1.0 docs and extensive wiki migrations covering dev environments and release processes (#450, #477). Includes the 1.0 tagline, Holy Grail positioning, and architecture limitations (ADR-049, #586, #606).
@@ -90,17 +90,17 @@ This phase fortified the core architecture, delivering native orchestration, zer
 - **Shift-Left & Advanced Intelligence:**
   - **Governance & Verification:**
     - [ ] **#195 / #196 Epic: Shift-Left AI Verification:** Define model compatibility and auditing strategy to systematically verify models.
-    - [ ] **#314 Epic: Adaptive Agent Governance:** Establish the Codebase Immune System, incorporating AST compilation design. This transitions `totem compile` to support Tree-sitter for cases where regex is insufficient.
+    - [ ] **#314 Epic: Adaptive Agent Governance:** Establish the Codebase Immune System, explicitly scoped to include AST compilation design. This transitions `totem compile` from regex-only to AST-aware rules (Tree-sitter/ast-grep) for cases where regex is provably insufficient.
     - [x] **#422 Rule Testing Harness:** Implemented a compiled rule testing harness to identify regex false-positives and drive AST requirements.
     - [ ] **#434 Adversarial Trap Corpus:** Develop synthetic violations to measure precision and recall of the deterministic engine.
     - [x] **Quality Control:** Addressed joint 1.0 code review conditions and launch testing findings to ensure stability (#639, #648).
   - **Rules & Standards:**
     - [x] **#387 SARIF Output:** Standardized output for CI/CD integration, enhanced with organizational trap ledgers and linting support (#418, #561).
     - [x] **External Rule Ingestion:** Built support to automatically ingest `.cursorrules`, `.mdc` files, and prompt templates into compiled rules during `totem init` (#558, #578, #596).
-    - **Rule Invariant Audit:** Categorized over 130 compiled rules by invariant, style, and security to establish strict baseline severity (#559, #577). Audited compiled rules to significantly reduce false positives and introduced Complete or Broken guardrail rules (#649, #663).
+    - **Rule Invariant Audit:** Categorized over 130 compiled rules by invariant, style, and security to establish strict baseline severity (#559, #577). Audited compiled rules to significantly reduce false positives, introduced Complete or Broken guardrail rules, and added baseline Fix guidance for spec invariants (#649, #663, #688).
     - [x] **Compilation Optimization:** Cached non-compilable lessons and removed duplicate match/exec rules to optimize performance and accuracy (#589, #590). Refined compiler glob patterns to support prompt constraints and strict boundaries (#584, #602, #603).
     - [ ] **#385 Rule Exports:** Export compiled rules to Semgrep YAML and ESLint configurations. Deferred until core governance (#314) is finalized.
-    - [ ] **#433 Lesson Packs Prototype:** Mine OSS projects as a proof of concept for distributable rule sets.
+    - [ ] **#433 Lesson Packs Prototype:** Mine 1 OSS project as a proof of concept for distributable rule sets.
   - **Data Architecture & Agents:**
     - [x] **#176 Agent-Optimized MCP:** Implemented MCP enforcement tools enabling active self-correction and heartbeat zombie harvesting (#417, #503).
     - [x] **#364 VectorDB Structure:** Defined multi-type schemas, delivered health checks, and integrated Gemini embeddings (#439, #539).


### PR DESCRIPTION
## Summary

Release prep for 1.3.0.

- Changeset for minor bump (cli + mcp) / patch (core)
- Docs regenerated via `totem wrap` — README, roadmap, active_work, architecture
- 11 new lessons extracted from PRs #683-688
- Tagline and hero section preserved (verified)
- No troubleshooting leaks into internal docs (verified)

Merge → Version Packages PR → merge that → 1.3.0 ships.