### PR TITLE
fix: filter ignored patterns before branch-diff fallback (#695)

### DIFF
--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -12,34 +12,15 @@ export interface LintOptions {
 
 // ─── Command ────────────────────────────────────────
 
-/**
- * Filter a unified diff to exclude files matching shieldIgnorePatterns.
- * Splits on `diff --git` boundaries and removes sections for ignored files.
- * Uses the same matchesGlob from the core package for consistent behavior.
- */
-async function filterDiffByPatterns(diff: string, patterns: string[]): Promise<string> {
-  if (patterns.length === 0) return diff;
-
-  const { matchesGlob } = await import('@mmnto/totem');
-
-  const sections = diff.split(/^(?=diff --git )/m);
-  return sections
-    .filter((section) => {
-      // Extract destination path (b/) — handles renames correctly
-      const firstLine = section.substring(0, section.indexOf('\n'));
-      const quoted = firstLine.match(/^diff --git "a\/.*?" "b\/(.*?)"$/);
-      const unquoted = firstLine.match(/^diff --git a\/\S+ b\/(.+)$/);
-      const filePath = quoted?.[1] ?? unquoted?.[1];
-      if (!filePath) return true;
-      return !patterns.some((p) => matchesGlob(filePath, p));
-    })
-    .join(''); // totem-ignore (#669) — joining diff sections, not text fragments
-}
-
 export async function lintCommand(options: LintOptions): Promise<void> {
   const { loadConfig, loadEnv, resolveConfigPath } = await import('../utils.js');
-  const { extractChangedFiles, getDefaultBranch, getGitBranchDiff, getGitDiff } =
-    await import('../git.js');
+  const {
+    extractChangedFiles,
+    filterDiffByPatterns,
+    getDefaultBranch,
+    getGitBranchDiff,
+    getGitDiff,
+  } = await import('../git.js');
   const { log } = await import('../ui.js');
   const { runCompiledRules } = await import('./run-compiled-rules.js');
 
@@ -59,25 +40,23 @@ export async function lintCommand(options: LintOptions): Promise<void> {
   loadEnv(cwd);
   const config = await loadConfig(configPath);
 
-  // Get git diff
+  // Get git diff — filter ignored patterns before fallback check so that
+  // noise (e.g., .strategy submodule pointer) doesn't suppress the branch diff.
+  const allIgnore = [...config.ignorePatterns, ...(config.shieldIgnorePatterns ?? [])];
   const mode = options.staged ? 'staged' : 'all';
   log.info(TAG, `Getting ${mode === 'staged' ? 'staged' : 'uncommitted'} diff...`);
-  let diff = getGitDiff(mode, cwd);
+  let filteredDiff = await filterDiffByPatterns(getGitDiff(mode, cwd), allIgnore);
 
-  if (!diff.trim()) {
+  if (!filteredDiff.trim()) {
     const base = getDefaultBranch(cwd);
-    log.dim(TAG, `No uncommitted changes. Falling back to branch diff (${base}...HEAD)...`);
-    diff = getGitBranchDiff(cwd, base);
+    log.dim(TAG, `No relevant changes. Falling back to branch diff (${base}...HEAD)...`);
+    filteredDiff = await filterDiffByPatterns(getGitBranchDiff(cwd, base), allIgnore);
   }
 
-  if (!diff.trim()) {
+  if (!filteredDiff.trim()) {
     log.warn(TAG, 'No changes detected. Nothing to lint.');
     return;
   }
-
-  // Filter diff to exclude shieldIgnorePatterns (e.g., .strategy submodule)
-  const allIgnore = [...config.ignorePatterns, ...(config.shieldIgnorePatterns ?? [])];
-  const filteredDiff = await filterDiffByPatterns(diff, allIgnore);
 
   const changedFiles = extractChangedFiles(filteredDiff);
   log.info(TAG, `Changed files (${changedFiles.length}): ${changedFiles.join(', ')}`);

--- a/packages/cli/src/commands/shield.ts
+++ b/packages/cli/src/commands/shield.ts
@@ -3,7 +3,13 @@ import * as path from 'node:path';
 import type { ContentType, LanceStore, SearchResult } from '@mmnto/totem';
 import { TotemConfigError } from '@mmnto/totem';
 
-import { extractChangedFiles, getDefaultBranch, getGitBranchDiff, getGitDiff } from '../git.js';
+import {
+  extractChangedFiles,
+  filterDiffByPatterns,
+  getDefaultBranch,
+  getGitBranchDiff,
+  getGitDiff,
+} from '../git.js';
 import { bold, errorColor, log, success as successColor } from '../ui.js';
 import {
   formatLessonSection,
@@ -447,34 +453,23 @@ export async function shieldCommand(options: ShieldOptions): Promise<void> {
   loadEnv(cwd);
   const config = await loadConfig(configPath);
 
-  // Get git diff — try uncommitted/staged first, fall back to branch diff vs main
+  // Get git diff — filter ignored patterns before fallback check so that
+  // noise (e.g., .strategy submodule pointer) doesn't suppress the branch diff.
+  const allIgnore = [...config.ignorePatterns, ...(config.shieldIgnorePatterns ?? [])];
+
   const mode = options.staged ? 'staged' : 'all';
   log.info(TAG, `Getting ${mode === 'staged' ? 'staged' : 'uncommitted'} diff...`);
-  let diff = getGitDiff(mode, cwd);
+  let diff = await filterDiffByPatterns(getGitDiff(mode, cwd), allIgnore);
 
   if (!diff.trim()) {
     const base = getDefaultBranch(cwd);
-    log.dim(TAG, `No uncommitted changes. Falling back to branch diff (${base}...HEAD)...`);
-    diff = getGitBranchDiff(cwd, base);
+    log.dim(TAG, `No relevant changes. Falling back to branch diff (${base}...HEAD)...`);
+    diff = await filterDiffByPatterns(getGitBranchDiff(cwd, base), allIgnore);
   }
 
   if (!diff.trim()) {
     log.warn(TAG, 'No changes detected. Nothing to review.');
     return;
-  }
-
-  // Filter out shieldIgnorePatterns from diff (e.g., .strategy submodule)
-  const allIgnore = [...config.ignorePatterns, ...(config.shieldIgnorePatterns ?? [])];
-  if (allIgnore.length > 0) {
-    const { matchesGlob } = await import('@mmnto/totem');
-    const sections = diff.split(/^(?=diff --git )/m);
-    diff = sections
-      .filter((section) => {
-        const m = section.match(/^diff --git a\/\S+ b\/(.+)$/m);
-        if (!m) return true;
-        return !allIgnore.some((p) => matchesGlob(m[1]!, p));
-      })
-      .join(''); // totem-ignore (#669) — joining diff sections
   }
 
   const changedFiles = extractChangedFiles(diff);

--- a/packages/cli/src/git.test.ts
+++ b/packages/cli/src/git.test.ts
@@ -8,7 +8,13 @@ vi.mock('node:child_process', () => ({
   execSync: vi.fn(),
 }));
 
-import { getGitLogSince, getLatestTag, getTagDate, isFileDirty } from './git.js';
+import {
+  filterDiffByPatterns,
+  getGitLogSince,
+  getLatestTag,
+  getTagDate,
+  isFileDirty,
+} from './git.js';
 
 describe('getLatestTag', () => {
   beforeEach(() => vi.clearAllMocks());
@@ -76,6 +82,52 @@ describe('getGitLogSince', () => {
       throw new Error('not a git repo');
     });
     expect(getGitLogSince('/tmp')).toBe('');
+  });
+});
+
+describe('filterDiffByPatterns', () => {
+  const DIFF_WITH_STRATEGY = [
+    'diff --git a/.strategy b/.strategy',
+    'index abc1234..def5678 160000',
+    '--- a/.strategy',
+    '+++ b/.strategy',
+    '@@ -1 +1 @@',
+    '-Subproject commit aaa',
+    '+Subproject commit bbb',
+  ].join('\n');
+
+  const DIFF_WITH_CODE = [
+    'diff --git a/packages/cli/src/commands/lint.ts b/packages/cli/src/commands/lint.ts',
+    'index 1234567..abcdef0 100644',
+    '--- a/packages/cli/src/commands/lint.ts',
+    '+++ b/packages/cli/src/commands/lint.ts',
+    '@@ -1,3 +1,4 @@',
+    ' import { foo } from "bar";',
+    '+const x = 1;',
+  ].join('\n');
+
+  it('removes sections matching ignore patterns', async () => {
+    const combined = DIFF_WITH_STRATEGY + '\n' + DIFF_WITH_CODE;
+    const result = await filterDiffByPatterns(combined, ['.strategy']);
+    expect(result).not.toContain('.strategy');
+    expect(result).toContain('lint.ts');
+  });
+
+  it('returns full diff when no patterns match', async () => {
+    const result = await filterDiffByPatterns(DIFF_WITH_CODE, ['*.md']);
+    expect(result).toContain('lint.ts');
+  });
+
+  it('returns full diff when patterns array is empty', async () => {
+    const combined = DIFF_WITH_STRATEGY + '\n' + DIFF_WITH_CODE;
+    const result = await filterDiffByPatterns(combined, []);
+    expect(result).toContain('.strategy');
+    expect(result).toContain('lint.ts');
+  });
+
+  it('returns empty string when all sections are filtered out', async () => {
+    const result = await filterDiffByPatterns(DIFF_WITH_STRATEGY, ['.strategy']);
+    expect(result.trim()).toBe('');
   });
 });
 

--- a/packages/cli/src/git.ts
+++ b/packages/cli/src/git.ts
@@ -238,6 +238,30 @@ export function resolveGitRoot(cwd: string): string | null {
   }
 }
 
+/**
+ * Filter a unified diff to exclude files matching ignore patterns.
+ * Splits on `diff --git` boundaries and removes sections for ignored files.
+ * Uses matchesGlob from core for consistent glob behavior.
+ */
+export async function filterDiffByPatterns(diff: string, patterns: string[]): Promise<string> {
+  if (patterns.length === 0) return diff;
+
+  const { matchesGlob } = await import('@mmnto/totem');
+
+  const sections = diff.split(/^(?=diff --git )/m);
+  return sections
+    .filter((section) => {
+      // Extract destination path (b/) — handles renames correctly
+      const firstLine = section.substring(0, section.indexOf('\n'));
+      const quoted = firstLine.match(/^diff --git "a\/.*?" "b\/(.*?)"$/);
+      const unquoted = firstLine.match(/^diff --git a\/\S+ b\/(.+)$/);
+      const filePath = quoted?.[1] ?? unquoted?.[1];
+      if (!filePath) return true;
+      return !patterns.some((p) => matchesGlob(filePath, p));
+    })
+    .join(''); // totem-ignore (#669) — joining diff sections, not text fragments
+}
+
 export function extractChangedFiles(diff: string): string[] {
   const files: string[] = [];
   for (const line of diff.split('\n')) {


### PR DESCRIPTION
## Summary

Layer 3 validation (#695) uncovered a critical bug: the pre-push hook's Totem gate was a no-op.

Both `totem lint` and `totem shield` filtered `shieldIgnorePatterns` (e.g., `.strategy` submodule) **after** checking whether the diff was empty. When the only uncommitted change was an ignored file, the raw diff was non-empty, the branch-diff fallback never fired, and compiled rules scanned an empty (post-filter) diff — passing silently.

### Fix
- Filter ignored patterns **before** the emptiness check so the fallback to `main...HEAD` fires correctly
- Extracted `filterDiffByPatterns` to `git.ts` as a shared utility (was duplicated in `lint.ts` and `shield.ts`)
- Added 4 tests covering the filter function

### Validation
Deliberately injected a `${err}` violation (rule `e02e0640`), confirmed:
1. Pre-push hook now correctly falls back to branch diff and catches violations
2. Lint output includes file, line, pattern, and fix guidance — sufficient for agent self-correction in one cycle

### Also
- Updated local pre-push hook to use `totem lint` instead of deprecated `shield --deterministic`

Closes #695

## Test plan
- [x] 621 tests pass (617 existing + 4 new `filterDiffByPatterns` tests)
- [x] `totem lint` correctly falls back to branch diff when ignored patterns suppress uncommitted diff
- [x] `totem shield` uses shared `filterDiffByPatterns` from `git.ts`
- [x] Pre-push hook runs `totem lint` and scans compiled rules against branch diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)