### PR TITLE
fix: unify error domain with typed TotemError subclasses (#700)

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,14 +24,25 @@ function requireGhCli(): void {
 }
 
 function handleError(err: unknown): never {
+  const debug = process.env['TOTEM_DEBUG'] === '1' || process.argv.includes('--debug');
+
   if (err instanceof Error) {
     console.error(err.message);
     if ('recoveryHint' in err && typeof err.recoveryHint === 'string') {
       console.error(`  Fix: ${err.recoveryHint}`);
     }
+    if (debug && err.stack) {
+      console.error('\nStack trace:');
+      console.error(err.stack);
+    }
   } else {
     console.error('[Totem Error] An unknown error occurred:', err);
   }
+
+  if (!debug) {
+    console.error('  (Set TOTEM_DEBUG=1 for full stack trace)');
+  }
+
   process.exit(1);
 }
 

--- a/packages/core/src/embedders/embedder.ts
+++ b/packages/core/src/embedders/embedder.ts
@@ -1,4 +1,5 @@
 import type { EmbeddingProvider } from '../config-schema.js';
+import { TotemConfigError } from '../errors.js';
 import { OllamaEmbedder } from './ollama-embedder.js';
 
 /**
@@ -49,7 +50,11 @@ async function tryBuildEmbedder(config: EmbeddingProvider): Promise<Embedder> {
     const { GeminiEmbedder } = await import('./gemini-embedder.js');
     return new GeminiEmbedder(config.model, config.dimensions);
   }
-  throw new Error(`[Totem Error] Unknown embedding provider: ${config.provider}`);
+  throw new TotemConfigError(
+    `Unknown embedding provider: ${config.provider}`,
+    "Check totem.config.ts — valid providers: 'openai', 'gemini', 'ollama'.",
+    'CONFIG_INVALID',
+  );
 }
 
 /**
@@ -112,13 +117,10 @@ class LazyEmbedder implements Embedder {
 
       const available = await isOllamaAvailable();
       if (!available) {
-        throw new Error(
-          '[Totem Error] No embedding provider available.\n' +
-            'The configured provider failed and Ollama is not running.\n' +
-            'Either:\n' +
-            '  1. Install the SDK and set the API key for your configured provider\n' +
-            '  2. Install and start Ollama: https://ollama.com\n' +
-            "  3. Set provider: 'ollama' in totem.config.ts embedding config",
+        throw new TotemConfigError(
+          'No embedding provider available. The configured provider failed and Ollama is not running.',
+          "Either: (1) Install the SDK and set the API key for your configured provider, (2) Install and start Ollama: https://ollama.com, or (3) Set provider: 'ollama' in totem.config.ts.",
+          'CONFIG_MISSING',
         );
       }
 

--- a/packages/core/src/embedders/gemini-embedder.ts
+++ b/packages/core/src/embedders/gemini-embedder.ts
@@ -1,3 +1,4 @@
+import { TotemConfigError, TotemError } from '../errors.js';
 import type { Embedder } from './embedder.js';
 
 const DEFAULT_DIMENSIONS = 768;
@@ -50,10 +51,10 @@ async function importGeminiSdk(): Promise<{
     // Dynamic import — @google/genai is an optional peer dep
     return await import('@google/genai');
   } catch {
-    throw new Error(
-      '[Totem Error] Gemini SDK (@google/genai) is not installed.\n' +
-        'Install it with: pnpm add @google/genai\n' +
-        "Or use provider: 'openai' in your embedding config.",
+    throw new TotemConfigError(
+      'Gemini SDK (@google/genai) is not installed.',
+      "Install it with: pnpm add @google/genai — or use provider: 'openai' in your embedding config.",
+      'CONFIG_MISSING',
     );
   }
 }
@@ -73,9 +74,10 @@ export class GeminiEmbedder implements Embedder {
 
     const apiKey = process.env['GEMINI_API_KEY'] ?? process.env['GOOGLE_API_KEY'];
     if (!apiKey) {
-      throw new Error(
-        '[Totem Error] No Gemini API key found.\n' +
-          'Set GEMINI_API_KEY (or GOOGLE_API_KEY) in your .env file.',
+      throw new TotemConfigError(
+        'No Gemini API key found.',
+        'Set GEMINI_API_KEY (or GOOGLE_API_KEY) in your .env file.',
+        'CONFIG_MISSING',
       );
     }
 
@@ -114,13 +116,20 @@ export class GeminiEmbedder implements Embedder {
         });
 
         if (!response.embeddings || response.embeddings.length !== batch.length) {
-          throw new Error(
-            `[Totem Error] Expected ${batch.length} embeddings, got ${response.embeddings?.length ?? 0}`,
+          throw new TotemError(
+            'EMBEDDING_UNAVAILABLE',
+            `Expected ${batch.length} embeddings, got ${response.embeddings?.length ?? 0}`,
+            'This may be a transient Gemini API issue. Retry with `totem sync`.',
           );
         }
 
         return response.embeddings.map((e: { values?: number[] }) => {
-          if (!e.values) throw new Error('[Totem Error] Embedding response missing values');
+          if (!e.values)
+            throw new TotemError(
+              'EMBEDDING_UNAVAILABLE',
+              'Embedding response missing values',
+              'This may be a transient Gemini API issue. Retry with `totem sync`.',
+            );
           return e.values;
         });
       } catch (err) {
@@ -131,9 +140,11 @@ export class GeminiEmbedder implements Embedder {
       }
     }
 
-    const message = lastErr instanceof Error ? lastErr.message : String(lastErr);
-    throw new Error(
-      `[Totem Error] Gemini embedding failed after ${MAX_RETRIES + 1} attempts: ${message}`,
+    const detail = lastErr instanceof Error ? lastErr.message : String(lastErr);
+    throw new TotemError(
+      'EMBEDDING_UNAVAILABLE',
+      `Gemini embedding failed after ${MAX_RETRIES + 1} attempts: ${detail}`,
+      'Check your GEMINI_API_KEY and network connection, then retry with `totem sync`.',
     );
   }
 }

--- a/packages/core/src/embedders/openai-embedder.ts
+++ b/packages/core/src/embedders/openai-embedder.ts
@@ -1,5 +1,6 @@
 import OpenAI from 'openai';
 
+import { TotemConfigError, TotemError } from '../errors.js';
 import type { Embedder } from './embedder.js';
 
 const MAX_BATCH_SIZE = 2048;
@@ -18,9 +19,10 @@ export class OpenAIEmbedder implements Embedder {
 
     const apiKey = process.env['OPENAI_API_KEY'];
     if (!apiKey) {
-      throw new Error(
-        '[Totem Error] No embedding provider configured.\n' +
-          "Set OPENAI_API_KEY in your .env or configure 'ollama' in totem.config.ts.",
+      throw new TotemConfigError(
+        'No OpenAI API key found.',
+        "Set OPENAI_API_KEY in your .env or configure provider: 'ollama' in totem.config.ts.",
+        'CONFIG_MISSING',
       );
     }
 
@@ -64,9 +66,11 @@ export class OpenAIEmbedder implements Embedder {
         await new Promise((resolve) => setTimeout(resolve, delay));
       }
     }
-    const message = lastErr instanceof Error ? lastErr.message : String(lastErr);
-    throw new Error(
-      `[Totem Error] OpenAI embedding failed after ${MAX_RETRIES + 1} attempts: ${message}`,
+    const detail = lastErr instanceof Error ? lastErr.message : String(lastErr);
+    throw new TotemError(
+      'EMBEDDING_UNAVAILABLE',
+      `OpenAI embedding failed after ${MAX_RETRIES + 1} attempts: ${detail}`,
+      'Check your OPENAI_API_KEY and network connection, then retry with `totem sync`.',
     );
   }
 }

--- a/packages/core/src/exporter.ts
+++ b/packages/core/src/exporter.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import type { ParsedLesson } from './drift-detector.js';
+import { TotemParseError } from './errors.js';
 
 // ─── Constants ─────────────────────────────────────────
 
@@ -46,14 +47,16 @@ export function injectSentinelBlock(existingContent: string, generatedBlock: str
   const endIdx = existingContent.indexOf(SENTINEL_END);
 
   if (startIdx !== -1 && endIdx === -1) {
-    throw new Error(
-      `[Totem Error] Found ${SENTINEL_START} without matching ${SENTINEL_END}. Fix the target file manually.`,
+    throw new TotemParseError(
+      `Found ${SENTINEL_START} without matching ${SENTINEL_END}.`,
+      'Fix the target file manually — ensure both sentinel markers are present and correctly ordered.',
     );
   }
 
   if (startIdx !== -1 && endIdx !== -1 && endIdx < startIdx) {
-    throw new Error(
-      `[Totem Error] Found ${SENTINEL_END} before ${SENTINEL_START}. Fix the target file manually.`,
+    throw new TotemParseError(
+      `Found ${SENTINEL_END} before ${SENTINEL_START}.`,
+      'Fix the target file manually — ensure sentinel markers appear in the correct order.',
     );
   }
 

--- a/packages/core/src/lock.ts
+++ b/packages/core/src/lock.ts
@@ -9,6 +9,8 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { TotemError } from './errors.js';
+
 const LOCK_FILE = 'sync.lock';
 const STALE_THRESHOLD_MS = 120_000; // 2 minutes — sync can take 30-60s on large repos
 const MAX_RETRIES = 20;
@@ -155,9 +157,10 @@ export async function acquireLock(
     }
   }
 
-  throw new Error(
-    `[Totem Error] Could not acquire sync lock after ${MAX_RETRIES} attempts. ` +
-      `Another totem process may be running. Check ${file} or delete it manually.`,
+  throw new TotemError(
+    'SYNC_FAILED',
+    `Could not acquire sync lock after ${MAX_RETRIES} attempts.`,
+    `Another totem process may be running. Check ${file} or delete it manually.`,
   );
 }
 

--- a/packages/core/src/rule-engine.ts
+++ b/packages/core/src/rule-engine.ts
@@ -302,9 +302,14 @@ export async function applyAstRulesToAdditions(
 // ─── Convenience wrapper ────────────────────────────
 
 /**
- * Apply compiled rules against added lines from a diff.
- * Returns all violations found.
- * @param excludeFiles — file paths to skip (e.g., compiled-rules.json to avoid self-matches)
+ * Apply **regex-engine** compiled rules against added lines from a diff.
+ * This is a convenience wrapper that only handles 'regex' engine rules.
+ * For 'ast' and 'ast-grep' rules, call `applyAstRulesToAdditions` separately.
+ *
+ * @param rules — The full list of compiled rules. This function filters to regex rules.
+ * @param diff — The unified diff string.
+ * @param excludeFiles — File paths to skip (e.g., compiled-rules.json to avoid self-matches).
+ * @returns All regex-based violations found.
  */
 export function applyRules(
   rules: CompiledRule[],

--- a/packages/core/src/sarif.ts
+++ b/packages/core/src/sarif.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from 'node:crypto';
 
 import type { CompiledRule, Violation } from './compiler.js';
+import { TotemCompileError } from './errors.js';
 
 /** Default rule category when none is specified on the compiled rule. */
 export const DEFAULT_RULE_CATEGORY = 'architecture';
@@ -110,8 +111,9 @@ export function buildSarifLog(
   const results: SarifResult[] = violations.map((v) => {
     const idx = ruleIndexMap.get(v.rule.lessonHash);
     if (idx === undefined) {
-      throw new Error(
-        `[Totem Error] SARIF builder: no rule index for lessonHash ${v.rule.lessonHash}`,
+      throw new TotemCompileError(
+        `SARIF builder: no rule index for lessonHash ${v.rule.lessonHash}`,
+        'This is an internal error — the compiled rules may be corrupted. Run `totem compile --force`.',
       );
     }
     return {


### PR DESCRIPTION
## Summary

Replaces all raw `throw new Error()` calls with structured `TotemError` subclasses across the monorepo. Every error now includes a typed code, a clear message, and a recovery hint — no more wall-of-text stack traces for known failures.

### Changes
- **13 raw throws → typed errors:**
  - 8 in embedders → `TotemConfigError`, `TotemError('EMBEDDING_UNAVAILABLE')`
  - 2 in exporter → `TotemParseError`
  - 1 in lock → `TotemError('SYNC_FAILED')`
  - 1 in sarif → `TotemCompileError`
- **Debug mode:** Added `TOTEM_DEBUG=1` env var support to CLI error handler — shows full stack traces when troubleshooting
- **JSDoc:** Added docs on `applyRules` per GCA review on #710

### What was already clean
- Error hierarchy (6 subclasses) already existed
- CLI error handler already caught TotemError and suppressed stack traces
- Zero empty catch blocks — all had documented intent

Closes #700

## Test plan
- [x] 1,012 tests pass (382 core + 621 cli + 9 mcp)
- [x] `totem lint` — 147 rules, 0 violations
- [x] ESLint clean, Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)