### PR TITLE
fix: DX polish — onboarding dare, hide legacy, brief output (#674)

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1238,7 +1238,13 @@ export async function initCommand(options?: { bare?: boolean }): Promise<void> {
       console.error(brand('--------------------------'));
     }
 
-    log.success('Totem', 'Init complete. Run `totem sync` to index your project.');
+    log.success(
+      'Totem',
+      options?.bare
+        ? 'Init complete. 15 baseline rules are active.\n' +
+            '[Totem] Try it: write an empty `catch(e) {}` block and run `npx totem lint` — watch what happens.'
+        : 'Init complete. Run `totem sync` to index your project.',
+    );
   } finally {
     rl.close();
   }

--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -151,11 +151,14 @@ export async function runCompiledRules(
     const lines: string[] = [];
 
     if (errors.length === 0 && warnings.length === 0) {
-      lines.push('### Verdict');
-      lines.push(`**PASS** — All ${rules.length} rules passed.`);
-      lines.push('');
-      lines.push('### Details');
-      lines.push('No violations detected against compiled rules.');
+      // Clean pass — only emit verbose markdown when writing to file
+      if (outPath) {
+        lines.push('### Verdict');
+        lines.push(`**PASS** — All ${rules.length} rules passed.`);
+        lines.push('');
+        lines.push('### Details');
+        lines.push('No violations detected against compiled rules.');
+      }
     } else {
       lines.push('### Verdict');
       if (errors.length > 0) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -467,7 +467,7 @@ program
   );
 
 program
-  .command('migrate-lessons')
+  .command('migrate-lessons', { hidden: true })
   .description('Migrate .totem/lessons.md to .totem/lessons/ directory (one file per lesson)')
   .action(async () => {
     try {
@@ -504,7 +504,7 @@ program
   });
 
 program
-  .command('demo')
+  .command('demo', { hidden: true })
   .description('Show the Totem spinner with movie quotes')
   .option('--duration <seconds>', 'How long to run (default: 6)', '6')
   .action(async (opts: { duration: string }) => {
@@ -517,7 +517,7 @@ program
   });
 
 program
-  .command('install-hooks')
+  .command('install-hooks', { hidden: true })
   .description('Install git hooks interactively (legacy — prefer `totem hooks`)')
   .action(async () => {
     try {


### PR DESCRIPTION
## Summary

Pre-launch DX polish for the first-5-minutes experience.

### Changes
- **Post-init dare:** Lite/bare users now see "Try it: write an empty `catch(e) {}` block and run `npx totem lint` — watch what happens" instead of the broken "Run `totem sync`" path
- **Hidden commands:** `install-hooks` (legacy), `demo`, `migrate-lessons` removed from `--help` (still callable, just not cluttering the first impression)
- **Brief lint output:** Clean PASS skips the 6-line markdown block — verdict is one line: `PASS — 147 rules, 0 violations`

Closes #674

## Test plan
- [x] 1,014 tests pass
- [x] `totem lint` clean pass is now 1 verdict line (no verbose markdown)
- [x] Hidden commands still work when called directly
- [x] Post-init message branches correctly for bare vs full mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)