### PR TITLE
feat: Gate 1 — severity validation for compiled rules (Proposal 184)

### DIFF
--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -305,6 +305,12 @@ export async function compileCommand(options: CompileOptions): Promise<void> {
           continue;
         }
 
+        // ── Gate 1: Severity validation (Proposal 184) ──
+        // LLMs (especially Flash) frequently omit severity, producing rules
+        // that default to 'error' and break CI on advisory patterns.
+        // Default to 'warning' for new rules — they must be manually promoted.
+        const severity = parsed.severity ?? 'warning';
+
         const engine = parsed.engine ?? 'regex';
 
         // ── ast-grep engine ───────────────────────────
@@ -325,12 +331,16 @@ export async function compileCommand(options: CompileOptions): Promise<void> {
             message: parsed.message,
             engine: 'ast-grep',
             astGrepPattern: parsed.astGrepPattern,
+            severity,
             compiledAt: now,
             createdAt: existing?.createdAt ?? now,
             ...(sanitizedGlobs && sanitizedGlobs.length > 0 ? { fileGlobs: sanitizedGlobs } : {}),
           });
           compiled++;
-          log.success(TAG, `[${lesson.heading}] Compiled (ast-grep): ${parsed.astGrepPattern}`); // totem-ignore
+          log.success(
+            TAG,
+            `[${lesson.heading}] Compiled (ast-grep, ${severity}): ${parsed.astGrepPattern}`,
+          ); // totem-ignore
           continue;
         }
 
@@ -352,12 +362,13 @@ export async function compileCommand(options: CompileOptions): Promise<void> {
             message: parsed.message,
             engine: 'ast',
             astQuery: parsed.astQuery,
+            severity,
             compiledAt: now,
             createdAt: existing?.createdAt ?? now,
             ...(sanitizedGlobs && sanitizedGlobs.length > 0 ? { fileGlobs: sanitizedGlobs } : {}),
           });
           compiled++;
-          log.success(TAG, `[${lesson.heading}] Compiled (ast): ${parsed.astQuery}`); // totem-ignore
+          log.success(TAG, `[${lesson.heading}] Compiled (ast, ${severity}): ${parsed.astQuery}`); // totem-ignore
           continue;
         }
 
@@ -384,12 +395,13 @@ export async function compileCommand(options: CompileOptions): Promise<void> {
           pattern: parsed.pattern,
           message: parsed.message,
           engine: 'regex',
+          severity,
           compiledAt: now,
           createdAt: existing?.createdAt ?? now,
           ...(sanitizedGlobs && sanitizedGlobs.length > 0 ? { fileGlobs: sanitizedGlobs } : {}),
         });
         compiled++;
-        log.success(TAG, `[${lesson.heading}] Compiled: /${parsed.pattern}/`); // totem-ignore
+        log.success(TAG, `[${lesson.heading}] Compiled (regex, ${severity}): /${parsed.pattern}/`); // totem-ignore
       }
 
       if (!options.raw) {

--- a/packages/core/src/compiler-schema.ts
+++ b/packages/core/src/compiler-schema.ts
@@ -51,6 +51,7 @@ export const CompilerOutputSchema = z.object({
   engine: z.enum(['regex', 'ast', 'ast-grep']).optional(),
   astQuery: z.string().optional(),
   astGrepPattern: z.union([z.string(), z.record(z.unknown())]).optional(),
+  severity: z.enum(['error', 'warning']).optional(),
 });
 
 export type CompilerOutput = z.infer<typeof CompilerOutputSchema>;


### PR DESCRIPTION
## Summary

Implements Gate 1 of Proposal 184 (Compiled Rule Review Protocol). This is the surgical fix for the #1 compiler regression: Flash generating rules with `severity: NONE` that break CI.

### How it works
- LLM can now optionally return `severity` in the compiler output
- If omitted (which Flash always does), defaults to `'warning'` instead of undefined
- New rules start as warnings — they report violations but don't fail the build
- Rules must be manually promoted to `'error'` after validation

### Why this matters
Every compilation run since v1.0 has produced rules with missing severity. The existing `run-compiled-rules.ts` treats undefined severity as `'error'` (line 125: `v.rule.severity ?? 'error'`). This means untested LLM-generated rules immediately block pushes. Gate 1 breaks this cycle — new rules are advisory until a human promotes them.

### What this unblocks
- `totem compile --force` can now be run without reverting to the curated set
- Future compilation runs produce safe-by-default rules
- Gate 2 (self-test) and Gate 3 (contradiction check) can be built incrementally

Closes Proposal 184 Gate 1.

## Test plan
- [x] 1,014 tests pass
- [x] `totem lint` — 147 rules, 0 violations
- [x] Verified `run-compiled-rules.ts` respects severity field (warnings = PASS, errors = FAIL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)