### PR TITLE
chore: v1.3.5 release — knowledge quality + security

### DIFF
--- a/.changeset/v1-3-5-quality.md
+++ b/.changeset/v1-3-5-quality.md
@@ -1,0 +1,10 @@
+---
+'@mmnto/cli': patch
+'@mmnto/totem': patch
+---
+
+### Knowledge Quality & Security
+
+- All 59 universal baseline lessons now include actionable Fix guidance — agents know HOW to resolve violations, not just WHAT is wrong (#642)
+- Path traversal containment check using path.relative prevents reads outside the project directory (#738)
+- Traversal skip now logs a warning via onWarn callback for visibility (#739)

--- a/.totem/lessons/lesson-37640ec3.md
+++ b/.totem/lessons/lesson-37640ec3.md
@@ -1,0 +1,5 @@
+## Lesson — Every architectural lesson should include actionable "Fix"
+
+**Tags:** ai-agents, linting, knowledge-management
+
+Every architectural lesson should include actionable "Fix" guidance to complete the self-correction loop for AI agents. This allows the agent to move from violation detection to resolution in one cycle without needing to guess the correct pattern.

--- a/.totem/lessons/lesson-59fb63ef.md
+++ b/.totem/lessons/lesson-59fb63ef.md
@@ -1,0 +1,5 @@
+## Lesson — When using advanced git commands like reset to stage demo
+
+**Tags:** docs, git, onboarding, dx
+
+When using advanced git commands like `reset` to stage demo violations, include inline comments to explain the intent. This prevents user confusion while maintaining a seamless copy-paste experience for the "60-second superpower" onboarding goal.

--- a/.totem/lessons/lesson-84852a06.md
+++ b/.totem/lessons/lesson-84852a06.md
@@ -1,0 +1,5 @@
+## Lesson — Refactor rule engines to surface warnings via callbacks
+
+**Tags:** rule-engine, debugging, observability
+
+Refactor rule engines to surface warnings via callbacks when files are skipped because they reside outside the project directory. This improves transparency by preventing silent failures when rules are unexpectedly not applied to target files.

--- a/.totem/lessons/lesson-9164973a.md
+++ b/.totem/lessons/lesson-9164973a.md
@@ -1,0 +1,5 @@
+## Lesson — Silent skipping of files during path traversal containment
+
+**Tags:** security, logging, path-traversal
+
+Silent skipping of files during path traversal containment checks causes confusion and hides configuration issues. Providing an optional warning callback ensures visibility into excluded files without coupling library logic to specific logging frameworks.


### PR DESCRIPTION
## Summary

Changeset for 1.3.5. Merge → Version Packages PR → merge → published.

### What's in 1.3.5
- All 59 baseline lessons have Fix guidance (Closes #642)
- Path traversal containment check with path.relative (Closes #738)
- Traversal skip warning via onWarn callback (Closes #739)
- 4 lessons extracted from PRs 735/738/740/741
- Docs updated (README, active_work, architecture)

🤖 Generated with [Claude Code](https://claude.com/claude-code)