### PR TITLE
fix: spy on log.warn instead of console.error in spec tests (#745)

### DIFF
--- a/packages/cli/src/commands/spec.test.ts
+++ b/packages/cli/src/commands/spec.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import type { LanceStore, SearchResult } from '@mmnto/totem';
 
+import { log } from '../ui.js';
 import type { RetrievedContext } from './spec.js';
 import {
   assemblePrompt,
@@ -225,7 +226,7 @@ describe('retrieveContext — cross-totem linked stores', () => {
   });
 
   it('config error in linked store logs warning and continues', async () => {
-    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const warnSpy = vi.spyOn(log, 'warn').mockImplementation(() => {});
     const primary = mockStore([makeSpec({ label: 'primary', score: 0.5 })]);
     const broken = mockFailingStore(new Error('Invalid config: dimension mismatch'));
 


### PR DESCRIPTION
Decouples the config error test from `log.warn`'s internal implementation. Spies on `log.warn` directly instead of `console.error`.

1,019 tests pass.

Closes #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)