### PR TITLE
fix: correct PostCompact hook format

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,8 +2,13 @@
   "hooks": {
     "PostCompact": [
       {
-        "type": "command",
-        "command": "bash .claude/hooks/post-compact.sh"
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/post-compact.sh"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
Hook was using wrong structure. Claude Code requires matcher + hooks array. Verified with /doctor.