### PR TITLE
feat: cross-platform CI matrix (ubuntu, windows, macos)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,11 @@ concurrency:
 jobs:
   build:
     name: Build & Lint
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- Adds `strategy: matrix` with `ubuntu-latest`, `windows-latest`, `macos-latest` to CI workflow
- Uses `fail-fast: false` so all platforms report independently
- Integration smoke tests (ci-integration.yml) remain Ubuntu-only (require API keys)

## Why
Totem uses native bindings (LanceDB Rust, ast-grep napi, Tree-sitter WASM) and heavy filesystem I/O. We already hit a Windows `.kill()` bug (#714). CI must catch platform-specific issues before they reach users. (ADR-062)

## Test plan
- [ ] Ubuntu CI green (existing baseline)
- [ ] Windows CI green (most likely to surface native binding issues)
- [ ] macOS CI green (ARM/x64 binary compatibility)

Closes #770

🤖 Generated with [Claude Code](https://claude.com/claude-code)