### PR TITLE
docs: post-1.3.17 README regen + lesson extraction

### DIFF
--- a/.totem/lessons/lesson-1febe282.md
+++ b/.totem/lessons/lesson-1febe282.md
@@ -1,0 +1,5 @@
+## Lesson — Move large imports, such as multi-line prompt templates,
+
+**Tags:** performance, cli, nodejs
+
+Move large imports, such as multi-line prompt templates, inside function bodies to prevent eager parsing at module load time. This improves CLI responsiveness by ensuring heavy strings are only processed when the specific command is actually invoked.

--- a/.totem/lessons/lesson-333eff48.md
+++ b/.totem/lessons/lesson-333eff48.md
@@ -1,0 +1,5 @@
+## Lesson — Structural patterns like spawn($CMD, [$$$ARGS]) often only
+
+**Tags:** ast-grep, linting, patterns
+
+Structural patterns like `spawn($CMD, [$$$ARGS])` often only match explicit array literals. To capture variable-based arguments, developers must use specific capture variables or combinators that account for references rather than just literal structures.

--- a/.totem/lessons/lesson-3428acae.md
+++ b/.totem/lessons/lesson-3428acae.md
@@ -1,0 +1,5 @@
+## Lesson — Core library modules should accept optional warning
+
+**Tags:** api-design, core-library, dx
+
+Core library modules should accept optional warning callbacks rather than requiring them as positional arguments. This prevents forcing specific logging contracts on consumers and maintains a flexible API surface for varied environments.

--- a/.totem/lessons/lesson-48536659.md
+++ b/.totem/lessons/lesson-48536659.md
@@ -1,0 +1,5 @@
+## Lesson — When delegating complex logic to new helper modules,
+
+**Tags:** testing, refactoring, maintenance
+
+When delegating complex logic to new helper modules, specific tests must assert that parameters are forwarded correctly to the new implementation. This prevents behavioral drift and ensures that filters or boundaries are not lost during the delegation jump.

--- a/.totem/lessons/lesson-b53cac12.md
+++ b/.totem/lessons/lesson-b53cac12.md
@@ -1,0 +1,5 @@
+## Lesson — Avoid re-exporting internal building blocks or heuristics
+
+**Tags:** architecture, api-design, semver
+
+Avoid re-exporting internal building blocks or heuristics from a package root as stable entry points. Exposing lower-level helpers makes future logic tuning semver-sensitive and complicates the public API maintenance.

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Your project gets immediate protection against the most common architectural tra
 > **Without MCP:** `totem lint`, `compile`, `extract`, `sync`, `explain`, and `stats` all work standalone. You get full deterministic enforcement and the complete CLI experience.
 > **With MCP:** Your AI agent gains live access to the knowledge index mid-session. It can `search_knowledge` before writing code and `add_lesson` when it discovers traps.
 
-Give your AI agent persistent project memory. `search_knowledge` retrieves traps, patterns, and architectural constraints with boundary parameters for scoped queries, while `add_lesson` captures new ones.
+Give your AI agent persistent project memory. `search_knowledge` retrieves traps, patterns, and architectural constraints with boundary parameters for scoped queries, while `add_lesson` captures new ones. Context is actively restored using explicit capability manifests during the session.
 
 **macOS / Linux:**
 
@@ -209,9 +209,9 @@ Cross-totem queries via `linkedIndexes` let the planner pull context from multip
 
 AI coding agents are brilliant but forgetful, often repeating architectural violations across sessions. Totem fixes this by creating a persistent memory layer that outlasts any single agent, model, or tool.
 
-- **Compile:** Your `.cursorrules` and `.mdc` files are plain English. Totem compiles them into deterministic AST and regex checks via the AST engine.
+- **Compile:** Your `.cursorrules` and `.mdc` files are plain English. Totem compiles them into deterministic AST and regex checks via the AST engine. A pre-compilation gate validates lessons before processing.
 - **Enforce:** `totem lint` is **100% deterministic** and runs compiled rules against your diff. It runs in ~2 seconds with zero API keys, and your CI passes or fails based purely on logic.
-- **Learn:** Run `totem extract` to compile new invariants from PR bugs, scaling your local index over time (the active CLI instance currently coordinates **419 embedded lessons**). When a violation happens, use `totem explain` to instantly retrieve the underlying lesson.
+- **Learn:** Run `totem extract` to compile new invariants from PR bugs, scaling your local index over time (the active CLI instance currently coordinates **436 embedded lessons**). When a violation happens, use `totem explain` to instantly retrieve the underlying lesson.
 - **Plan:** `totem spec` queries the knowledge index before your AI writes code, generating architectural invariants. The AI starts fully informed of past mistakes instead of starting blank.
 
 **Totem doesn't replace your AI. It gives your AI a memory.**
@@ -245,7 +245,7 @@ Totem is architected for high-compliance sectors (defense, finance, healthcare).
 - **Rule Architecture:**
 - **Curated Baselines:** Ships a curated **219-rule set** with mandatory verify steps for execution determinism. Includes reverse-compiled lessons with manual patterns for zero-LLM enforcement.
 - **Advanced AST Validation:** Empowers deterministic enforcement via tree-sitter and ast-grep classifications. The underlying engine is validated against an adversarial corpus to reduce false positives.
-- **Agent Automation:** Agent skills utilize lean root routers for streamlined instruction files. Context restoration utilizes explicit capability manifests after compacting.
+- **Agent Automation:** Agent skills utilize a streamlined directory format and root router pattern for clear instruction files. Context restoration uses explicit capability manifests to maintain agent focus.
 - **Severity Validation:** Compiled rules enforce strict severity levels. Errors actively block CI, while warnings inform without blocking.
 
 **What gets committed:** Your knowledge base (text files in `.totem/lessons/`) and the compiled artifact (`.totem/compiled-rules.json`). The `.lancedb/` vector index is a local-only cache, automatically rebuilt by `totem sync`. It is never committed to your repository.


### PR DESCRIPTION
## Summary
- Regenerate README with live metrics (219 rules, 23 baseline)
- Extract 5 lessons from PR 823
- Fix perf section revert (147 → 219)
- Remove leaked maintenance comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added five new instructional lessons covering CLI startup performance, structural pattern-matching for argument lists, optional warning handling in core modules, delegating logic to helper modules with tests, and avoiding re-exporting internal helpers as public API.
  * Updated README wording about persistent session knowledge, an explicit pre-compilation validation step, and clarified context restoration via capability manifests.
  * Expanded embedded lesson library from 419 to 436 lessons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->