### PR TITLE
fix: release workflow tag push resilience

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,9 @@ jobs:
 
       - run: pnpm build
 
+      - name: Allow tag overwrites for republish resilience
+        run: git config --global push.followTags false
+
       - name: Create Release PR or Publish
         id: changesets
         uses: changesets/action@v1
@@ -41,8 +44,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
-      - name: Update Action v0 Tag
+      - name: Push release tags
         if: steps.changesets.outputs.published == 'true'
         run: |
+          git push origin --tags --force
           git tag -f v0
           git push origin refs/tags/v0 --force

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ dev-cheatsheet.txt
 
 # Review artifacts
 review-output.md
+totem-audit.zip
 .code-review/
 2026-*
 .totem/cache/.shield-passed


### PR DESCRIPTION
## Summary
Fixes the release CI failure where changesets action double-pushes tags that already exist on the remote, causing `! [rejected] @mmnto/totem@1.3.19 -> @mmnto/totem@1.3.19 (already exists)`.

- Disables `push.followTags` before changesets action runs (prevents auto-push during internal git ops)
- Pushes tags explicitly with `--force` in a separate step that tolerates pre-existing tags

## Test plan
- [ ] CI passes
- [ ] Next release workflow should push tags without failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to improve version tag management and reliability during publication, reducing release inconsistencies.
  * Updated repository ignore rules to exclude a generated audit archive so it is no longer tracked in version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->