### PR TITLE
feat: compile manifest CI attestation gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,27 @@ jobs:
 
       - name: Verify wind tunnel SHA
         run: bash tools/update-wind-tunnel-sha.sh --verify
+
+  compile-manifest:
+    name: Compile Manifest Attestation
+    runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'pull_request' &&
+      !contains(github.event.pull_request.title, '[UPDATE-RULES]') &&
+      !contains(github.event.pull_request.body, '[UPDATE-RULES]')
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm build
+
+      - name: Verify compile manifest hashes
+        run: node packages/cli/dist/index.js verify-manifest


### PR DESCRIPTION
## Summary

Adds a CI job that runs `totem verify-manifest` on pull requests. If `compiled-rules.json` or `compile-manifest.json` hashes don't match, the PR fails — unless `[UPDATE-RULES]` is in the title or body.

Same pattern as Wind Tunnel SHA lock (ADR-069). Security boundary pushed to GitHub RBAC, preserving zero-config DX.

Closes #875

## Test plan

- [x] Existing `verify-manifest.test.ts` covers: missing manifest, forged output, changed lessons, valid state
- [x] CI job mirrors wind-tunnel-sha pattern exactly
- [x] `[UPDATE-RULES]` opt-out matches `[WIND-TUNNEL-UPDATE]` convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)