### PR TITLE
fix: manifest attestation gate uses live PR title [UPDATE-RULES]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,27 +53,3 @@ jobs:
 
       - name: Verify wind tunnel SHA
         run: bash tools/update-wind-tunnel-sha.sh --verify
-
-  compile-manifest:
-    name: Compile Manifest Attestation
-    runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'pull_request' &&
-      !contains(github.event.pull_request.title, '[UPDATE-RULES]') &&
-      !contains(github.event.pull_request.body, '[UPDATE-RULES]')
-    steps:
-      - uses: actions/checkout@v6
-
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
-
-      - run: pnpm build
-
-      - name: Verify compile manifest hashes
-        run: node packages/cli/dist/index.js verify-manifest

--- a/.github/workflows/compile-manifest.yml
+++ b/.github/workflows/compile-manifest.yml
@@ -1,0 +1,51 @@
+name: Compile Manifest Attestation
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, edited]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Compile Manifest Attestation
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check for [UPDATE-RULES] bypass
+        id: bypass
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }} # totem-ignore — #875: env mapping IS the safe pattern
+          PR_BODY: ${{ github.event.pull_request.body }} # totem-ignore — #875: env mapping IS the safe pattern
+        run: |
+          if [[ "$PR_TITLE $PR_BODY" == *"[UPDATE-RULES]"* ]]; then # totem-ignore — #875: vars are env-mapped above
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "✅ [UPDATE-RULES] found — skipping manifest verification"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v6
+        if: steps.bypass.outputs.skip != 'true'
+
+      - uses: pnpm/action-setup@v4
+        if: steps.bypass.outputs.skip != 'true'
+
+      - uses: actions/setup-node@v6
+        if: steps.bypass.outputs.skip != 'true'
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+        if: steps.bypass.outputs.skip != 'true'
+
+      - run: pnpm build
+        if: steps.bypass.outputs.skip != 'true'
+
+      - name: Verify compile manifest hashes
+        if: steps.bypass.outputs.skip != 'true'
+        run: node packages/cli/dist/index.js verify-manifest

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ totem-audit.zip
 skills-lock.json
 .claude/skills/autofix/
 .claude/skills/code-review/
+cloc-results.json

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ dist/
 pnpm-lock.yaml
 # Lesson files contain regex patterns and glob syntax that prettier mangles
 .totem/lessons/
+cloc-results.json


### PR DESCRIPTION
## Summary

The manifest attestation CI gate from #882 used a job-level `if:` that freezes `github.event.pull_request.title` at trigger time. Adding `[UPDATE-RULES]` after triggering doesn't retrigger the workflow.

Fix: split the manifest attestation into its own workflow (`compile-manifest.yml`) with:
- `edited` in PR trigger types — editing the title/body fires a **new** workflow run with updated context
- `cancel-in-progress` concurrency — prevents pile-ups from rapid edits
- `timeout-minutes: 10` — prevents hung builds from draining CI minutes
- Bypass check runs first (no checkout/build needed) — cheap skip when `[UPDATE-RULES]` is present
- Job always runs (no job-level `if:`) — branch protection never gets stuck on "pending"
- Template expressions mapped to env vars to satisfy shell injection rules

**Note:** Manual re-runs of an existing workflow still use the original event payload. The `edited` trigger ensures that editing the PR title/body creates a fresh run with updated context, which is sufficient for the bypass use case.

Also adds `cloc-results.json` to `.gitignore` and `.prettierignore` — a corrupt binary file was silently breaking Prettier format checks.

## Test plan

- [x] `totem lint` passes (0 violations)
- [x] `totem shield` run — addressed shell injection, runner waste, status deadlock findings
- [x] `pnpm format:check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)