### PR TITLE
feat: compile progress spinner and updated rules [UPDATE-RULES]

### DIFF
--- a/.totem/compile-manifest.json
+++ b/.totem/compile-manifest.json
@@ -1,7 +1,7 @@
 {
-  "compiled_at": "2026-03-23T17:27:41.890Z",
+  "compiled_at": "2026-03-23T21:40:48.763Z",
   "model": "gemini-3-flash-preview",
-  "input_hash": "ff6f4eb9fa33b85e857fe0d4d1bccd80f89b62334d2f704db67b88f06a390124",
-  "output_hash": "5ece895f04e35c04d81a866bce98be8721da3d4d85db04e920b96fd698d6eb75",
-  "rule_count": 247
+  "input_hash": "d7ef7bb4492e73e595286100b5c821db2d3e0638d06b31b4a4e91f7eee296ed3",
+  "output_hash": "2c0b1112a1be52bac033b92ae859dd4edc47fb9a78f2bbae7a7a46ec917c0a82",
+  "rule_count": 266
 }

--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -9,7 +9,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T06:36:05.566Z",
       "createdAt": "2026-03-21T06:36:05.566Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -20,7 +25,14 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T06:36:57.866Z",
       "createdAt": "2026-03-21T06:36:57.866Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.go", "**/*.py", "!**/*.test.*", "!**/*_test.go"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.go",
+        "**/*.py",
+        "!**/*.test.*",
+        "!**/*_test.go"
+      ],
       "severity": "warning"
     },
     {
@@ -31,7 +43,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T06:38:51.398Z",
       "createdAt": "2026-03-21T06:38:51.398Z",
-      "fileGlobs": ["packages/cli/src/git.ts"],
+      "fileGlobs": [
+        "packages/cli/src/git.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -42,7 +56,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T06:39:26.739Z",
       "createdAt": "2026-03-21T06:39:26.739Z",
-      "fileGlobs": ["**/compiled-rules.json"],
+      "fileGlobs": [
+        "**/compiled-rules.json"
+      ],
       "severity": "warning"
     },
     {
@@ -53,7 +69,15 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T06:39:37.213Z",
       "createdAt": "2026-03-21T06:39:37.213Z",
-      "fileGlobs": ["*.sh", "*.bash", "*.zsh", "*.yml", "*.yaml", "Makefile", "package.json"],
+      "fileGlobs": [
+        "*.sh",
+        "*.bash",
+        "*.zsh",
+        "*.yml",
+        "*.yaml",
+        "Makefile",
+        "package.json"
+      ],
       "severity": "warning"
     },
     {
@@ -64,7 +88,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T06:40:23.231Z",
       "createdAt": "2026-03-21T06:40:23.231Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -75,7 +104,14 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T06:41:24.154Z",
       "createdAt": "2026-03-21T06:41:24.154Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "!**/*.test.ts", "!**/*.spec.ts"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx",
+        "!**/*.test.ts",
+        "!**/*.spec.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -87,7 +123,12 @@
       "astGrepPattern": "$OBJ.replace(process.cwd(), $REPLACEMENT)",
       "compiledAt": "2026-03-21T06:41:58.539Z",
       "createdAt": "2026-03-21T06:41:58.539Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -98,7 +139,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T06:42:10.970Z",
       "createdAt": "2026-03-21T06:42:10.970Z",
-      "fileGlobs": ["packages/cli/src/orchestrators/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/cli/src/orchestrators/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -151,7 +195,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T06:46:10.910Z",
       "createdAt": "2026-03-21T06:46:10.910Z",
-      "fileGlobs": ["**/.github/dependabot.yml"],
+      "fileGlobs": [
+        "**/.github/dependabot.yml"
+      ],
       "severity": "warning"
     },
     {
@@ -180,7 +226,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T06:48:15.815Z",
       "createdAt": "2026-03-21T06:48:15.815Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -191,7 +242,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T06:48:36.799Z",
       "createdAt": "2026-03-21T06:48:36.799Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -217,7 +273,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T06:52:30.714Z",
       "createdAt": "2026-03-21T06:52:30.714Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx"
+      ],
       "severity": "warning"
     },
     {
@@ -228,7 +287,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T06:52:43.493Z",
       "createdAt": "2026-03-21T06:52:43.493Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -239,7 +303,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T06:56:12.331Z",
       "createdAt": "2026-03-21T06:56:12.331Z",
-      "fileGlobs": ["packages/cli/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/cli/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -250,7 +317,13 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T06:56:50.893Z",
       "createdAt": "2026-03-21T06:56:50.893Z",
-      "fileGlobs": ["*.ts", "*.js", "*.sh", "*.yml", "*.yaml"],
+      "fileGlobs": [
+        "*.ts",
+        "*.js",
+        "*.sh",
+        "*.yml",
+        "*.yaml"
+      ],
       "severity": "warning"
     },
     {
@@ -261,7 +334,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T06:57:03.648Z",
       "createdAt": "2026-03-21T06:57:03.648Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -272,7 +350,13 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T06:57:11.663Z",
       "createdAt": "2026-03-21T06:57:11.663Z",
-      "fileGlobs": ["package.json", "*.sh", "*.bash", "*.yml", "*.yaml"],
+      "fileGlobs": [
+        "package.json",
+        "*.sh",
+        "*.bash",
+        "*.yml",
+        "*.yaml"
+      ],
       "severity": "warning"
     },
     {
@@ -301,7 +385,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T06:58:42.266Z",
       "createdAt": "2026-03-21T06:58:42.266Z",
-      "fileGlobs": ["packages/cli/src/git.ts"],
+      "fileGlobs": [
+        "packages/cli/src/git.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -312,7 +398,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T06:58:56.946Z",
       "createdAt": "2026-03-21T06:58:56.946Z",
-      "fileGlobs": ["packages/cli/src/git.ts"],
+      "fileGlobs": [
+        "packages/cli/src/git.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -323,7 +411,14 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T06:59:15.315Z",
       "createdAt": "2026-03-21T06:59:15.315Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.py", "**/*.md"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx",
+        "**/*.py",
+        "**/*.md"
+      ],
       "severity": "warning"
     },
     {
@@ -370,7 +465,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:02:28.769Z",
       "createdAt": "2026-03-21T07:02:28.769Z",
-      "fileGlobs": ["**/*.js", "**/*.ts", "**/*.jsx", "**/*.tsx"],
+      "fileGlobs": [
+        "**/*.js",
+        "**/*.ts",
+        "**/*.jsx",
+        "**/*.tsx"
+      ],
       "severity": "warning"
     },
     {
@@ -381,7 +481,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:02:46.313Z",
       "createdAt": "2026-03-21T07:02:46.313Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -392,7 +497,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:03:43.442Z",
       "createdAt": "2026-03-21T07:03:43.442Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -419,7 +529,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:04:27.660Z",
       "createdAt": "2026-03-21T07:04:27.660Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -430,7 +545,15 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:04:58.487Z",
       "createdAt": "2026-03-21T07:04:58.487Z",
-      "fileGlobs": ["*.sh", "*.bash", "*.yml", "*.yaml", "**/*.ts", "**/*.js", "Makefile"],
+      "fileGlobs": [
+        "*.sh",
+        "*.bash",
+        "*.yml",
+        "*.yaml",
+        "**/*.ts",
+        "**/*.js",
+        "Makefile"
+      ],
       "severity": "warning"
     },
     {
@@ -441,7 +564,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:05:59.724Z",
       "createdAt": "2026-03-21T07:05:59.724Z",
-      "fileGlobs": [".github/workflows/*.yml", ".github/workflows/*.yaml", "**/*.sh", "**/*.bash"],
+      "fileGlobs": [
+        ".github/workflows/*.yml",
+        ".github/workflows/*.yaml",
+        "**/*.sh",
+        "**/*.bash"
+      ],
       "severity": "warning"
     },
     {
@@ -452,7 +580,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:06:08.004Z",
       "createdAt": "2026-03-21T07:06:08.004Z",
-      "fileGlobs": ["packages/mcp/**/*.ts"],
+      "fileGlobs": [
+        "packages/mcp/**/*.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -463,7 +593,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:07:24.082Z",
       "createdAt": "2026-03-21T07:07:24.082Z",
-      "fileGlobs": ["**/*.test.ts", "**/*.test.js", "**/*.spec.ts", "**/*.spec.js"],
+      "fileGlobs": [
+        "**/*.test.ts",
+        "**/*.test.js",
+        "**/*.spec.ts",
+        "**/*.spec.js"
+      ],
       "severity": "warning"
     },
     {
@@ -475,7 +610,12 @@
       "astGrepPattern": "$A[$A.indexOf($B) + 1]",
       "compiledAt": "2026-03-21T07:10:02.103Z",
       "createdAt": "2026-03-21T07:10:02.103Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "!**/*.test.ts", "!**/*.spec.ts"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "!**/*.test.ts",
+        "!**/*.spec.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -486,7 +626,13 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:10:13.697Z",
       "createdAt": "2026-03-21T07:10:13.697Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "!**/*.test.ts"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx",
+        "!**/*.test.ts"
+      ],
       "severity": "error"
     },
     {
@@ -513,7 +659,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:10:50.885Z",
       "createdAt": "2026-03-21T07:10:50.885Z",
-      "fileGlobs": ["*.md", "*.mdx"],
+      "fileGlobs": [
+        "*.md",
+        "*.mdx"
+      ],
       "severity": "warning"
     },
     {
@@ -524,7 +673,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:11:06.839Z",
       "createdAt": "2026-03-21T07:11:06.839Z",
-      "fileGlobs": [".gemini/**"],
+      "fileGlobs": [
+        ".gemini/**"
+      ],
       "severity": "warning"
     },
     {
@@ -535,7 +686,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:12:25.923Z",
       "createdAt": "2026-03-21T07:12:25.923Z",
-      "fileGlobs": ["skills/**/*.md", "!**/SKILL.md"],
+      "fileGlobs": [
+        "skills/**/*.md",
+        "!**/SKILL.md"
+      ],
       "severity": "warning"
     },
     {
@@ -546,7 +700,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:12:49.401Z",
       "createdAt": "2026-03-21T07:12:49.401Z",
-      "fileGlobs": [".github/workflows/*.yml", ".github/workflows/*.yaml"],
+      "fileGlobs": [
+        ".github/workflows/*.yml",
+        ".github/workflows/*.yaml"
+      ],
       "severity": "warning"
     },
     {
@@ -557,7 +714,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:13:30.152Z",
       "createdAt": "2026-03-21T07:13:30.152Z",
-      "fileGlobs": [".claude/hooks/**", "packages/cli/src/commands/install-hooks.ts"],
+      "fileGlobs": [
+        ".claude/hooks/**",
+        "packages/cli/src/commands/install-hooks.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -568,7 +728,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:13:30.153Z",
       "createdAt": "2026-03-21T07:13:30.153Z",
-      "fileGlobs": ["**/*.ts", "**/*.js"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js"
+      ],
       "severity": "error"
     },
     {
@@ -619,7 +782,11 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:13:51.813Z",
       "createdAt": "2026-03-21T07:13:51.813Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.sh"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.sh"
+      ],
       "severity": "warning"
     },
     {
@@ -647,7 +814,11 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:14:55.956Z",
       "createdAt": "2026-03-21T07:14:55.956Z",
-      "fileGlobs": ["**/llm/**/*.ts", "**/providers/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "**/llm/**/*.ts",
+        "**/providers/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "error"
     },
     {
@@ -658,7 +829,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:16:09.671Z",
       "createdAt": "2026-03-21T07:16:09.671Z",
-      "fileGlobs": ["packages/core/src/config-schema.ts", "packages/core/src/compiler-schema.ts"],
+      "fileGlobs": [
+        "packages/core/src/config-schema.ts",
+        "packages/core/src/compiler-schema.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -685,7 +859,13 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:16:12.378Z",
       "createdAt": "2026-03-21T07:16:12.378Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.py", "**/*.sh", ".env*"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.py",
+        "**/*.sh",
+        ".env*"
+      ],
       "severity": "error"
     },
     {
@@ -696,7 +876,13 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:16:31.597Z",
       "createdAt": "2026-03-21T07:16:31.597Z",
-      "fileGlobs": [".husky/**", "package.json", "scripts/**", "*.sh", "*.bash"],
+      "fileGlobs": [
+        ".husky/**",
+        "package.json",
+        "scripts/**",
+        "*.sh",
+        "*.bash"
+      ],
       "severity": "warning"
     },
     {
@@ -727,7 +913,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:16:38.736Z",
       "createdAt": "2026-03-21T07:16:38.736Z",
-      "fileGlobs": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"],
+      "fileGlobs": [
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.spec.ts",
+        "**/*.spec.tsx"
+      ],
       "severity": "warning"
     },
     {
@@ -738,7 +929,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:16:42.876Z",
       "createdAt": "2026-03-21T07:16:42.876Z",
-      "fileGlobs": ["**/*config*.*", "**/*cache*.*"],
+      "fileGlobs": [
+        "**/*config*.*",
+        "**/*cache*.*"
+      ],
       "severity": "warning"
     },
     {
@@ -749,7 +943,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:16:45.395Z",
       "createdAt": "2026-03-21T07:16:45.395Z",
-      "fileGlobs": ["**/*.md"],
+      "fileGlobs": [
+        "**/*.md"
+      ],
       "severity": "error"
     },
     {
@@ -760,7 +956,13 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:16:51.528Z",
       "createdAt": "2026-03-21T07:16:51.528Z",
-      "fileGlobs": ["*.sh", "*.bash", "*.zsh", "*.yml", "*.yaml"],
+      "fileGlobs": [
+        "*.sh",
+        "*.bash",
+        "*.zsh",
+        "*.yml",
+        "*.yaml"
+      ],
       "severity": "warning"
     },
     {
@@ -771,7 +973,11 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:17:09.503Z",
       "createdAt": "2026-03-21T07:17:09.503Z",
-      "fileGlobs": ["packages/mcp/**/*.ts", "packages/mcp/**/*.js", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/mcp/**/*.ts",
+        "packages/mcp/**/*.js",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -797,7 +1003,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:17:09.504Z",
       "createdAt": "2026-03-21T07:17:09.504Z",
-      "fileGlobs": [".totem/lessons/**", ".totem/lessons.md"],
+      "fileGlobs": [
+        ".totem/lessons/**",
+        ".totem/lessons.md"
+      ],
       "severity": "warning"
     },
     {
@@ -808,7 +1017,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:17:31.605Z",
       "createdAt": "2026-03-21T07:17:31.605Z",
-      "fileGlobs": ["packages/cli/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/cli/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -819,7 +1031,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:17:43.617Z",
       "createdAt": "2026-03-21T07:17:43.617Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "error"
     },
     {
@@ -830,7 +1047,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:17:43.617Z",
       "createdAt": "2026-03-21T07:17:43.617Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -841,7 +1063,11 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:18:18.494Z",
       "createdAt": "2026-03-21T07:18:18.494Z",
-      "fileGlobs": [".husky/**/*", "scripts/hooks/**/*", "*.sh"],
+      "fileGlobs": [
+        ".husky/**/*",
+        "scripts/hooks/**/*",
+        "*.sh"
+      ],
       "severity": "error"
     },
     {
@@ -853,7 +1079,11 @@
       "astGrepPattern": "import($PATH)",
       "compiledAt": "2026-03-21T07:18:34.475Z",
       "createdAt": "2026-03-21T07:18:34.475Z",
-      "fileGlobs": ["packages/cli/src/**/*.ts", "!packages/cli/src/commands/**", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/cli/src/**/*.ts",
+        "!packages/cli/src/commands/**",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -883,7 +1113,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:19:47.719Z",
       "createdAt": "2026-03-21T07:19:47.719Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -894,7 +1129,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:20:10.770Z",
       "createdAt": "2026-03-21T07:20:10.770Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -905,7 +1145,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:20:36.676Z",
       "createdAt": "2026-03-21T07:20:36.676Z",
-      "fileGlobs": ["**/*.md", "**/*.ts", "**/*.js", "**/*.txt"],
+      "fileGlobs": [
+        "**/*.md",
+        "**/*.ts",
+        "**/*.js",
+        "**/*.txt"
+      ],
       "severity": "warning"
     },
     {
@@ -916,7 +1161,14 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:20:48.796Z",
       "createdAt": "2026-03-21T07:20:48.796Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx", "!**/*.test.ts", "!**/*.test.js"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx",
+        "!**/*.test.ts",
+        "!**/*.test.js"
+      ],
       "severity": "error"
     },
     {
@@ -927,7 +1179,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:20:48.796Z",
       "createdAt": "2026-03-21T07:20:48.796Z",
-      "fileGlobs": ["packages/core/**/*"],
+      "fileGlobs": [
+        "packages/core/**/*"
+      ],
       "severity": "warning"
     },
     {
@@ -954,7 +1208,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:21:24.094Z",
       "createdAt": "2026-03-21T07:21:24.094Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -965,7 +1224,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:21:49.612Z",
       "createdAt": "2026-03-21T07:21:49.612Z",
-      "fileGlobs": ["packages/cli/src/orchestrators/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/cli/src/orchestrators/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -976,7 +1238,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:21:58.029Z",
       "createdAt": "2026-03-21T07:21:58.029Z",
-      "fileGlobs": ["*.md", "*.mdx"],
+      "fileGlobs": [
+        "*.md",
+        "*.mdx"
+      ],
       "severity": "warning"
     },
     {
@@ -987,7 +1252,11 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:21:58.029Z",
       "createdAt": "2026-03-21T07:21:58.029Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "!**/*.test.ts"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "!**/*.test.ts"
+      ],
       "severity": "error"
     },
     {
@@ -998,7 +1267,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:21:58.029Z",
       "createdAt": "2026-03-21T07:21:58.029Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "error"
     },
     {
@@ -1009,7 +1283,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:22:45.347Z",
       "createdAt": "2026-03-21T07:22:45.347Z",
-      "fileGlobs": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "fileGlobs": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -1020,7 +1299,14 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:22:45.347Z",
       "createdAt": "2026-03-21T07:22:45.347Z",
-      "fileGlobs": ["**/*.sh", "**/*.bash", "**/*.js", "**/*.ts", "**/*.yml", "**/*.yaml"],
+      "fileGlobs": [
+        "**/*.sh",
+        "**/*.bash",
+        "**/*.js",
+        "**/*.ts",
+        "**/*.yml",
+        "**/*.yaml"
+      ],
       "severity": "error"
     },
     {
@@ -1031,7 +1317,14 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:22:45.347Z",
       "createdAt": "2026-03-21T07:22:45.347Z",
-      "fileGlobs": ["**/*.sh", "**/*.bash", "**/*.js", "**/*.ts", "**/*.yml", "**/*.yaml"],
+      "fileGlobs": [
+        "**/*.sh",
+        "**/*.bash",
+        "**/*.js",
+        "**/*.ts",
+        "**/*.yml",
+        "**/*.yaml"
+      ],
       "severity": "warning"
     },
     {
@@ -1042,7 +1335,11 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:22:59.892Z",
       "createdAt": "2026-03-21T07:22:59.892Z",
-      "fileGlobs": ["*.md", "*.markdown", "*.txt"],
+      "fileGlobs": [
+        "*.md",
+        "*.markdown",
+        "*.txt"
+      ],
       "severity": "warning"
     },
     {
@@ -1053,7 +1350,11 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:22:59.892Z",
       "createdAt": "2026-03-21T07:22:59.892Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "!**/*.test.ts"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "!**/*.test.ts"
+      ],
       "severity": "error"
     },
     {
@@ -1064,7 +1365,13 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:23:30.778Z",
       "createdAt": "2026-03-21T07:23:30.778Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx", "**/*.py"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx",
+        "**/*.py"
+      ],
       "severity": "warning"
     },
     {
@@ -1075,7 +1382,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:24:32.504Z",
       "createdAt": "2026-03-21T07:24:32.504Z",
-      "fileGlobs": ["**/*.md", "**/*.ts", "**/*.js", "**/package.json"],
+      "fileGlobs": [
+        "**/*.md",
+        "**/*.ts",
+        "**/*.js",
+        "**/package.json"
+      ],
       "severity": "warning"
     },
     {
@@ -1086,7 +1398,13 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:24:32.505Z",
       "createdAt": "2026-03-21T07:24:32.505Z",
-      "fileGlobs": [".husky/**/*", ".githooks/**/*", "scripts/hooks/**/*", "**/*.sh", "**/*.bash"],
+      "fileGlobs": [
+        ".husky/**/*",
+        ".githooks/**/*",
+        "scripts/hooks/**/*",
+        "**/*.sh",
+        "**/*.bash"
+      ],
       "severity": "error"
     },
     {
@@ -1097,7 +1415,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:24:32.505Z",
       "createdAt": "2026-03-21T07:24:32.505Z",
-      "fileGlobs": ["packages/core/src/rule-engine.ts", "packages/core/src/compiler.ts"],
+      "fileGlobs": [
+        "packages/core/src/rule-engine.ts",
+        "packages/core/src/compiler.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -1108,7 +1429,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:24:48.956Z",
       "createdAt": "2026-03-21T07:24:48.956Z",
-      "fileGlobs": ["**/*.mcp.json", "**/settings.json"],
+      "fileGlobs": [
+        "**/*.mcp.json",
+        "**/settings.json"
+      ],
       "severity": "warning"
     },
     {
@@ -1134,7 +1458,11 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:25:02.487Z",
       "createdAt": "2026-03-21T07:25:02.487Z",
-      "fileGlobs": ["**/orchestrator/**/*.ts", "**/totem/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "**/orchestrator/**/*.ts",
+        "**/totem/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -1145,7 +1473,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:25:02.487Z",
       "createdAt": "2026-03-21T07:25:02.487Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -1156,7 +1489,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:26:18.826Z",
       "createdAt": "2026-03-21T07:26:18.826Z",
-      "fileGlobs": ["packages/cli/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/cli/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -1167,7 +1503,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:27:14.295Z",
       "createdAt": "2026-03-21T07:27:14.295Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -1178,7 +1519,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:28:06.154Z",
       "createdAt": "2026-03-21T07:28:06.154Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -1189,7 +1535,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:29:29.447Z",
       "createdAt": "2026-03-21T07:29:29.447Z",
-      "fileGlobs": ["packages/cli/src/commands/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/cli/src/commands/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -1200,7 +1549,14 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:30:15.396Z",
       "createdAt": "2026-03-21T07:30:15.396Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx", "**/*.py", "**/*.sql"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx",
+        "**/*.py",
+        "**/*.sql"
+      ],
       "severity": "warning"
     },
     {
@@ -1211,7 +1567,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:30:19.276Z",
       "createdAt": "2026-03-21T07:30:19.276Z",
-      "fileGlobs": ["**/*sarif*/**/*.ts", "**/sarif/**/*.ts"],
+      "fileGlobs": [
+        "**/*sarif*/**/*.ts",
+        "**/sarif/**/*.ts"
+      ],
       "severity": "error"
     },
     {
@@ -1222,7 +1581,13 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:30:22.609Z",
       "createdAt": "2026-03-21T07:30:22.609Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx", "!**/*.test.ts"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -1233,7 +1598,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:30:58.693Z",
       "createdAt": "2026-03-21T07:30:58.693Z",
-      "fileGlobs": ["**/*.ts", "**/*.js"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js"
+      ],
       "severity": "warning"
     },
     {
@@ -1244,7 +1612,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:30:58.694Z",
       "createdAt": "2026-03-21T07:30:58.694Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -1273,7 +1646,14 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:32:05.130Z",
       "createdAt": "2026-03-21T07:32:05.130Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.py", "**/*.go", "**/*.rb", "**/*.rs"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.py",
+        "**/*.go",
+        "**/*.rb",
+        "**/*.rs"
+      ],
       "severity": "warning"
     },
     {
@@ -1284,7 +1664,13 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:32:33.084Z",
       "createdAt": "2026-03-21T07:32:33.084Z",
-      "fileGlobs": ["**/*.md", "**/*.sh", "**/*.bash", "**/*.yml", "**/*.yaml"],
+      "fileGlobs": [
+        "**/*.md",
+        "**/*.sh",
+        "**/*.bash",
+        "**/*.yml",
+        "**/*.yaml"
+      ],
       "severity": "warning"
     },
     {
@@ -1295,7 +1681,14 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:32:50.877Z",
       "createdAt": "2026-03-21T07:32:50.877Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx",
+        "**/*.mjs",
+        "**/*.cjs"
+      ],
       "severity": "warning"
     },
     {
@@ -1306,7 +1699,11 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:33:52.271Z",
       "createdAt": "2026-03-21T07:33:52.271Z",
-      "fileGlobs": ["**/cli/**/*.ts", "**/cli/**/*.js", "!**/*.test.ts"],
+      "fileGlobs": [
+        "**/cli/**/*.ts",
+        "**/cli/**/*.js",
+        "!**/*.test.ts"
+      ],
       "severity": "error"
     },
     {
@@ -1317,7 +1714,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:35:28.869Z",
       "createdAt": "2026-03-21T07:35:28.869Z",
-      "fileGlobs": ["packages/cli/src/commands/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/cli/src/commands/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -1346,7 +1746,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:36:18.501Z",
       "createdAt": "2026-03-21T07:36:18.501Z",
-      "fileGlobs": ["*.md"],
+      "fileGlobs": [
+        "*.md"
+      ],
       "severity": "warning"
     },
     {
@@ -1357,7 +1759,14 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:36:18.501Z",
       "createdAt": "2026-03-21T07:36:18.501Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.py", "**/*.env", "**/*.yaml", "**/*.yml"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.py",
+        "**/*.env",
+        "**/*.yaml",
+        "**/*.yml"
+      ],
       "severity": "error"
     },
     {
@@ -1368,7 +1777,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:37:15.024Z",
       "createdAt": "2026-03-21T07:37:15.024Z",
-      "fileGlobs": ["**/*.ts", "**/*.js"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js"
+      ],
       "severity": "warning"
     },
     {
@@ -1379,7 +1791,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:37:44.336Z",
       "createdAt": "2026-03-21T07:37:44.336Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -1390,7 +1807,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:38:41.084Z",
       "createdAt": "2026-03-21T07:38:41.084Z",
-      "fileGlobs": ["packages/core/src/rule-engine.ts"],
+      "fileGlobs": [
+        "packages/core/src/rule-engine.ts"
+      ],
       "severity": "error"
     },
     {
@@ -1420,7 +1839,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:39:45.935Z",
       "createdAt": "2026-03-21T07:39:45.935Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -1447,7 +1871,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:40:30.271Z",
       "createdAt": "2026-03-21T07:40:30.271Z",
-      "fileGlobs": ["**/*.md"],
+      "fileGlobs": [
+        "**/*.md"
+      ],
       "severity": "warning"
     },
     {
@@ -1493,7 +1919,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:40:33.420Z",
       "createdAt": "2026-03-21T07:40:33.420Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ],
       "severity": "error"
     },
     {
@@ -1504,7 +1935,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:40:53.001Z",
       "createdAt": "2026-03-21T07:40:53.001Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "error"
     },
     {
@@ -1515,7 +1951,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:41:43.357Z",
       "createdAt": "2026-03-21T07:41:43.357Z",
-      "fileGlobs": ["packages/cli/src/index.ts"],
+      "fileGlobs": [
+        "packages/cli/src/index.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -1526,7 +1964,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:42:46.567Z",
       "createdAt": "2026-03-21T07:42:46.567Z",
-      "fileGlobs": ["*.md"],
+      "fileGlobs": [
+        "*.md"
+      ],
       "severity": "warning"
     },
     {
@@ -1537,7 +1977,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:43:01.961Z",
       "createdAt": "2026-03-21T07:43:01.961Z",
-      "fileGlobs": ["**/*.md"],
+      "fileGlobs": [
+        "**/*.md"
+      ],
       "severity": "warning"
     },
     {
@@ -1549,7 +1991,12 @@
       "astQuery": "(catch_clause body: (statement_block) @body (#eq? @body \"{}\")) @violation",
       "compiledAt": "2026-03-21T07:43:17.117Z",
       "createdAt": "2026-03-21T07:43:17.117Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -1560,7 +2007,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:43:26.366Z",
       "createdAt": "2026-03-21T07:43:26.366Z",
-      "fileGlobs": ["packages/cli/**/*.ts"],
+      "fileGlobs": [
+        "packages/cli/**/*.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -1571,7 +2020,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:43:43.680Z",
       "createdAt": "2026-03-21T07:43:43.680Z",
-      "fileGlobs": ["packages/cli/src/git.ts"],
+      "fileGlobs": [
+        "packages/cli/src/git.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -1582,7 +2033,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:44:29.835Z",
       "createdAt": "2026-03-21T07:44:29.835Z",
-      "fileGlobs": ["**/*.md"],
+      "fileGlobs": [
+        "**/*.md"
+      ],
       "severity": "warning"
     },
     {
@@ -1593,7 +2046,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:45:50.468Z",
       "createdAt": "2026-03-21T07:45:50.468Z",
-      "fileGlobs": [".github/workflows/*.yml", ".github/workflows/*.yaml"],
+      "fileGlobs": [
+        ".github/workflows/*.yml",
+        ".github/workflows/*.yaml"
+      ],
       "severity": "error"
     },
     {
@@ -1604,7 +2060,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:46:01.049Z",
       "createdAt": "2026-03-21T07:46:01.049Z",
-      "fileGlobs": [".github/dependabot.yml"],
+      "fileGlobs": [
+        ".github/dependabot.yml"
+      ],
       "severity": "error"
     },
     {
@@ -1615,7 +2073,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:46:44.719Z",
       "createdAt": "2026-03-21T07:46:44.719Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -1626,7 +2089,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:47:08.710Z",
       "createdAt": "2026-03-21T07:47:08.710Z",
-      "fileGlobs": ["packages/core/src/rule-engine.ts", "packages/core/src/compiler.ts"],
+      "fileGlobs": [
+        "packages/core/src/rule-engine.ts",
+        "packages/core/src/compiler.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -1637,7 +2103,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:48:10.171Z",
       "createdAt": "2026-03-21T07:48:10.171Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ],
       "severity": "error"
     },
     {
@@ -1648,7 +2119,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:48:35.030Z",
       "createdAt": "2026-03-21T07:48:35.030Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.mjs", "**/*.cjs"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.mjs",
+        "**/*.cjs"
+      ],
       "severity": "warning"
     },
     {
@@ -1659,7 +2135,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:49:27.518Z",
       "createdAt": "2026-03-21T07:49:27.518Z",
-      "fileGlobs": ["packages/cli/src/git.ts"],
+      "fileGlobs": [
+        "packages/cli/src/git.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -1670,7 +2148,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:50:19.353Z",
       "createdAt": "2026-03-21T07:50:19.353Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx"
+      ],
       "severity": "warning"
     },
     {
@@ -1681,7 +2162,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:51:39.296Z",
       "createdAt": "2026-03-21T07:51:39.296Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -1709,7 +2195,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:52:51.896Z",
       "createdAt": "2026-03-21T07:52:51.896Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx"
+      ],
       "severity": "warning"
     },
     {
@@ -1720,7 +2209,11 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:52:51.896Z",
       "createdAt": "2026-03-21T07:52:51.896Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "!**/*.test.ts"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "!**/*.test.ts"
+      ],
       "severity": "error"
     },
     {
@@ -1746,7 +2239,13 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:52:51.896Z",
       "createdAt": "2026-03-21T07:52:51.896Z",
-      "fileGlobs": ["*.sh", "*.bash", "*.yml", "*.yaml", "packages/cli/**/*.ts"],
+      "fileGlobs": [
+        "*.sh",
+        "*.bash",
+        "*.yml",
+        "*.yaml",
+        "packages/cli/**/*.ts"
+      ],
       "severity": "error"
     },
     {
@@ -1757,7 +2256,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:53:04.001Z",
       "createdAt": "2026-03-21T07:53:04.001Z",
-      "fileGlobs": ["packages/mcp/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/mcp/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -1768,7 +2270,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:53:09.583Z",
       "createdAt": "2026-03-21T07:53:09.583Z",
-      "fileGlobs": ["*.sh", "*.yml", "*.yaml", "package.json"],
+      "fileGlobs": [
+        "*.sh",
+        "*.yml",
+        "*.yaml",
+        "package.json"
+      ],
       "severity": "warning"
     },
     {
@@ -1779,7 +2286,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:53:48.413Z",
       "createdAt": "2026-03-21T07:53:48.413Z",
-      "fileGlobs": ["lib/**/*.ts", "packages/core/**/*.ts", "src/lib/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "lib/**/*.ts",
+        "packages/core/**/*.ts",
+        "src/lib/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -1790,7 +2302,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:53:48.413Z",
       "createdAt": "2026-03-21T07:53:48.413Z",
-      "fileGlobs": ["packages/cli/src/git.ts"],
+      "fileGlobs": [
+        "packages/cli/src/git.ts"
+      ],
       "severity": "error"
     },
     {
@@ -1801,7 +2315,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:54:01.977Z",
       "createdAt": "2026-03-21T07:54:01.977Z",
-      "fileGlobs": [".claude/hooks/**", "packages/cli/src/commands/install-hooks.ts"],
+      "fileGlobs": [
+        ".claude/hooks/**",
+        "packages/cli/src/commands/install-hooks.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -1812,7 +2329,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:54:12.750Z",
       "createdAt": "2026-03-21T07:54:12.750Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -1855,7 +2377,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:55:35.205Z",
       "createdAt": "2026-03-21T07:55:35.205Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -1866,7 +2393,14 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:55:35.205Z",
       "createdAt": "2026-03-21T07:55:35.205Z",
-      "fileGlobs": ["**/*.md", "**/*.sh", "**/*.yml", "**/*.yaml", "package.json", "**/*.txt"],
+      "fileGlobs": [
+        "**/*.md",
+        "**/*.sh",
+        "**/*.yml",
+        "**/*.yaml",
+        "package.json",
+        "**/*.txt"
+      ],
       "severity": "error"
     },
     {
@@ -1877,7 +2411,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:55:35.205Z",
       "createdAt": "2026-03-21T07:55:35.205Z",
-      "fileGlobs": ["packages/cli/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/cli/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -1888,7 +2425,13 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:56:01.571Z",
       "createdAt": "2026-03-21T07:56:01.571Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx", "**/*.py"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx",
+        "**/*.py"
+      ],
       "severity": "warning"
     },
     {
@@ -1899,7 +2442,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:56:26.881Z",
       "createdAt": "2026-03-21T07:56:26.881Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "error"
     },
     {
@@ -1910,7 +2458,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:57:17.223Z",
       "createdAt": "2026-03-21T07:57:17.223Z",
-      "fileGlobs": ["packages/cli/src/commands/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/cli/src/commands/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -1921,7 +2472,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:57:17.223Z",
       "createdAt": "2026-03-21T07:57:17.223Z",
-      "fileGlobs": ["README.md"],
+      "fileGlobs": [
+        "README.md"
+      ],
       "severity": "error"
     },
     {
@@ -1951,7 +2504,11 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:57:26.805Z",
       "createdAt": "2026-03-21T07:57:26.805Z",
-      "fileGlobs": ["**/*.mcp.json", "**/settings.json", "**/.vscode/settings.json"],
+      "fileGlobs": [
+        "**/*.mcp.json",
+        "**/settings.json",
+        "**/.vscode/settings.json"
+      ],
       "severity": "error"
     },
     {
@@ -1962,7 +2519,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:57:51.074Z",
       "createdAt": "2026-03-21T07:57:51.074Z",
-      "fileGlobs": ["packages/cli/**/*.ts", "packages/cli/**/*.js"],
+      "fileGlobs": [
+        "packages/cli/**/*.ts",
+        "packages/cli/**/*.js"
+      ],
       "severity": "warning"
     },
     {
@@ -1973,7 +2533,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:58:00.308Z",
       "createdAt": "2026-03-21T07:58:00.308Z",
-      "fileGlobs": ["packages/cli/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/cli/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -1984,7 +2547,11 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:58:09.939Z",
       "createdAt": "2026-03-21T07:58:09.939Z",
-      "fileGlobs": ["packages/core/**/*.ts", "libs/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/core/**/*.ts",
+        "libs/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -1995,7 +2562,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:58:17.482Z",
       "createdAt": "2026-03-21T07:58:17.482Z",
-      "fileGlobs": ["**/*.md", "**/*.mdx", "docs/**/*", "guides/**/*"],
+      "fileGlobs": [
+        "**/*.md",
+        "**/*.mdx",
+        "docs/**/*",
+        "guides/**/*"
+      ],
       "severity": "warning"
     },
     {
@@ -2006,7 +2578,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:59:11.752Z",
       "createdAt": "2026-03-21T07:59:11.752Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -2017,7 +2594,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:59:11.752Z",
       "createdAt": "2026-03-21T07:59:11.752Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -2028,7 +2610,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:59:11.752Z",
       "createdAt": "2026-03-21T07:59:11.752Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx"
+      ],
       "severity": "warning"
     },
     {
@@ -2039,7 +2624,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T07:59:35.585Z",
       "createdAt": "2026-03-21T07:59:35.585Z",
-      "fileGlobs": ["**/*.test.ts", "**/*.test.js", "**/*.spec.ts", "**/*.spec.js"],
+      "fileGlobs": [
+        "**/*.test.ts",
+        "**/*.test.js",
+        "**/*.spec.ts",
+        "**/*.spec.js"
+      ],
       "severity": "warning"
     },
     {
@@ -2074,7 +2664,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:01:18.700Z",
       "createdAt": "2026-03-21T08:01:18.700Z",
-      "fileGlobs": ["packages/core/src/compiler.ts", "packages/core/src/rule-engine.ts"],
+      "fileGlobs": [
+        "packages/core/src/compiler.ts",
+        "packages/core/src/rule-engine.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -2085,7 +2678,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:01:52.877Z",
       "createdAt": "2026-03-21T08:01:52.877Z",
-      "fileGlobs": ["**/compiled-rules.json"],
+      "fileGlobs": [
+        "**/compiled-rules.json"
+      ],
       "severity": "error"
     },
     {
@@ -2115,7 +2710,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:02:57.599Z",
       "createdAt": "2026-03-21T08:02:57.599Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -2126,7 +2726,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:03:26.315Z",
       "createdAt": "2026-03-21T08:03:26.315Z",
-      "fileGlobs": ["package.json"],
+      "fileGlobs": [
+        "package.json"
+      ],
       "severity": "warning"
     },
     {
@@ -2157,7 +2759,11 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:03:51.698Z",
       "createdAt": "2026-03-21T08:03:51.698Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "!**/*.test.ts"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "!**/*.test.ts"
+      ],
       "severity": "error"
     },
     {
@@ -2168,7 +2774,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:03:51.699Z",
       "createdAt": "2026-03-21T08:03:51.699Z",
-      "fileGlobs": ["packages/cli/src/commands/install-hooks.ts"],
+      "fileGlobs": [
+        "packages/cli/src/commands/install-hooks.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -2179,7 +2787,13 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:04:24.196Z",
       "createdAt": "2026-03-21T08:04:24.196Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx", "**/*.sql"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx",
+        "**/*.sql"
+      ],
       "severity": "warning"
     },
     {
@@ -2190,7 +2804,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:04:24.196Z",
       "createdAt": "2026-03-21T08:04:24.196Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -2201,7 +2820,14 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:04:41.670Z",
       "createdAt": "2026-03-21T08:04:41.670Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "!**/*.test.ts", "!**/*.spec.ts"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx",
+        "!**/*.test.ts",
+        "!**/*.spec.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -2213,7 +2839,12 @@
       "astGrepPattern": "try { $$$A; execSync($$$B, { $$$C, stdio: 'inherit', $$$D }); $$$E; } catch ($$$F) { $$$G; }",
       "compiledAt": "2026-03-21T08:05:17.304Z",
       "createdAt": "2026-03-21T08:05:17.304Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -2224,7 +2855,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:05:50.608Z",
       "createdAt": "2026-03-21T08:05:50.608Z",
-      "fileGlobs": ["**/prompts/**/*", "**/ai/**/*", "**/llm/**/*", "**/*prompt*"],
+      "fileGlobs": [
+        "**/prompts/**/*",
+        "**/ai/**/*",
+        "**/llm/**/*",
+        "**/*prompt*"
+      ],
       "severity": "error"
     },
     {
@@ -2235,7 +2871,14 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:06:06.626Z",
       "createdAt": "2026-03-21T08:06:06.626Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.py", "**/*.sh", "**/*.go", "**/*.rs"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.py",
+        "**/*.sh",
+        "**/*.go",
+        "**/*.rs"
+      ],
       "severity": "error"
     },
     {
@@ -2246,7 +2889,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:06:06.626Z",
       "createdAt": "2026-03-21T08:06:06.626Z",
-      "fileGlobs": ["packages/cli/**/*.ts", "packages/cli/**/*.js", "bin/**/*.ts", "bin/**/*.js"],
+      "fileGlobs": [
+        "packages/cli/**/*.ts",
+        "packages/cli/**/*.js",
+        "bin/**/*.ts",
+        "bin/**/*.js"
+      ],
       "severity": "warning"
     },
     {
@@ -2289,7 +2937,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:06:49.594Z",
       "createdAt": "2026-03-21T08:06:49.594Z",
-      "fileGlobs": ["packages/mcp/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/mcp/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "error"
     },
     {
@@ -2300,7 +2951,13 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:06:49.594Z",
       "createdAt": "2026-03-21T08:06:49.594Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx", "!**/*.test.ts"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx",
+        "!**/*.test.ts"
+      ],
       "severity": "error"
     },
     {
@@ -2328,7 +2985,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:08:30.265Z",
       "createdAt": "2026-03-21T08:08:30.265Z",
-      "fileGlobs": ["packages/cli/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/cli/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -2339,7 +2999,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:08:56.078Z",
       "createdAt": "2026-03-21T08:08:56.078Z",
-      "fileGlobs": ["packages/cli/src/commands/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/cli/src/commands/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -2350,7 +3013,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:09:06.753Z",
       "createdAt": "2026-03-21T08:09:06.753Z",
-      "fileGlobs": ["packages/mcp/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/mcp/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -2362,7 +3028,10 @@
       "astGrepPattern": "console.$METHOD($$$ARGS)",
       "compiledAt": "2026-03-21T08:09:19.775Z",
       "createdAt": "2026-03-21T08:09:19.775Z",
-      "fileGlobs": ["packages/core/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/core/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -2393,7 +3062,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:09:55.445Z",
       "createdAt": "2026-03-21T08:09:55.445Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx"
+      ],
       "severity": "warning"
     },
     {
@@ -2404,7 +3076,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:10:08.688Z",
       "createdAt": "2026-03-21T08:10:08.688Z",
-      "fileGlobs": ["packages/cli/**/*.ts", "packages/cli/**/*.js", "bin/**/*.ts", "bin/**/*.js"],
+      "fileGlobs": [
+        "packages/cli/**/*.ts",
+        "packages/cli/**/*.js",
+        "bin/**/*.ts",
+        "bin/**/*.js"
+      ],
       "severity": "warning"
     },
     {
@@ -2433,7 +3110,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:11:01.170Z",
       "createdAt": "2026-03-21T08:11:01.170Z",
-      "fileGlobs": [".husky/*", ".git/hooks/*"],
+      "fileGlobs": [
+        ".husky/*",
+        ".git/hooks/*"
+      ],
       "severity": "warning"
     },
     {
@@ -2444,7 +3124,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:11:01.170Z",
       "createdAt": "2026-03-21T08:11:01.170Z",
-      "fileGlobs": ["packages/mcp/**/*.ts"],
+      "fileGlobs": [
+        "packages/mcp/**/*.ts"
+      ],
       "severity": "error"
     },
     {
@@ -2455,7 +3137,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T08:11:06.736Z",
       "createdAt": "2026-03-21T08:11:06.736Z",
-      "fileGlobs": ["**/*.md", "**/*.mdx"],
+      "fileGlobs": [
+        "**/*.md",
+        "**/*.mdx"
+      ],
       "severity": "warning"
     },
     {
@@ -2483,7 +3168,13 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T22:15:32.541Z",
       "createdAt": "2026-03-21T22:15:32.541Z",
-      "fileGlobs": ["*.sh", "*.bash", "*.yml", "*.yaml", "package.json"],
+      "fileGlobs": [
+        "*.sh",
+        "*.bash",
+        "*.yml",
+        "*.yaml",
+        "package.json"
+      ],
       "severity": "warning"
     },
     {
@@ -2494,7 +3185,9 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T22:16:30.127Z",
       "createdAt": "2026-03-21T22:16:30.127Z",
-      "fileGlobs": ["packages/cli/**/*.ts"],
+      "fileGlobs": [
+        "packages/cli/**/*.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -2521,7 +3214,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T22:18:55.305Z",
       "createdAt": "2026-03-21T22:18:55.305Z",
-      "fileGlobs": ["*.yml", "*.yaml"],
+      "fileGlobs": [
+        "*.yml",
+        "*.yaml"
+      ],
       "severity": "warning"
     },
     {
@@ -2533,7 +3229,10 @@
       "astGrepPattern": "import $SPECIFIERS from '@mmnto/totem'",
       "compiledAt": "2026-03-21T22:19:10.791Z",
       "createdAt": "2026-03-21T22:19:10.791Z",
-      "fileGlobs": ["packages/cli/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/cli/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -2544,7 +3243,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T22:20:39.927Z",
       "createdAt": "2026-03-21T22:20:39.927Z",
-      "fileGlobs": ["README.md", "docs/**/*.md"],
+      "fileGlobs": [
+        "README.md",
+        "docs/**/*.md"
+      ],
       "severity": "warning"
     },
     {
@@ -2555,7 +3257,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T22:20:56.000Z",
       "createdAt": "2026-03-21T22:20:56.000Z",
-      "fileGlobs": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "fileGlobs": [
+        "*.ts",
+        "*.tsx",
+        "*.js",
+        "*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -2566,7 +3273,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-21T22:22:15.562Z",
       "createdAt": "2026-03-21T22:22:15.562Z",
-      "fileGlobs": ["packages/core/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/core/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -2596,7 +3306,11 @@
       "engine": "regex",
       "compiledAt": "2026-03-22T00:36:46.241Z",
       "createdAt": "2026-03-22T00:36:46.241Z",
-      "fileGlobs": ["**/*.md", "**/*.txt", "docs/**"],
+      "fileGlobs": [
+        "**/*.md",
+        "**/*.txt",
+        "docs/**"
+      ],
       "severity": "warning"
     },
     {
@@ -2640,7 +3354,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-22T17:36:26.161Z",
       "createdAt": "2026-03-22T17:36:26.161Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -2670,7 +3389,10 @@
       "astGrepPattern": "try { $$$PRE; expect.fail($$$ARGS); $$$POST } catch ($ERR) { $$$CATCH }",
       "compiledAt": "2026-03-22T17:37:13.018Z",
       "createdAt": "2026-03-22T17:37:13.018Z",
-      "fileGlobs": ["**/*.test.ts", "**/*.spec.ts"],
+      "fileGlobs": [
+        "**/*.test.ts",
+        "**/*.spec.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -2682,7 +3404,12 @@
       "astQuery": "(required_parameter pattern: (identifier) @id (#match? @id \"^(warn|warning)$\")) @violation",
       "compiledAt": "2026-03-22T17:37:48.379Z",
       "createdAt": "2026-03-22T17:37:48.379Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "!**/*.test.ts", "!**/*.spec.ts"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "!**/*.test.ts",
+        "!**/*.spec.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -2713,7 +3440,10 @@
       "astGrepPattern": "spawn($CMD, [$$$ARGS], { $$$BEFORE, shell: true, $$$AFTER })",
       "compiledAt": "2026-03-22T17:38:40.852Z",
       "createdAt": "2026-03-22T17:38:40.852Z",
-      "fileGlobs": ["**/*.ts", "**/*.js"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js"
+      ],
       "severity": "warning"
     },
     {
@@ -2725,7 +3455,10 @@
       "astGrepPattern": "process.kill($PID, 0)",
       "compiledAt": "2026-03-22T17:38:40.852Z",
       "createdAt": "2026-03-22T17:38:40.852Z",
-      "fileGlobs": ["**/*.ts", "**/*.js"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js"
+      ],
       "severity": "warning"
     },
     {
@@ -2737,7 +3470,11 @@
       "astGrepPattern": "new RegExp($SRC, $FLAGS + 'g')",
       "compiledAt": "2026-03-22T17:38:40.853Z",
       "createdAt": "2026-03-22T17:38:40.853Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "!**/*.test.ts"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -2749,7 +3486,10 @@
       "astGrepPattern": "$OBJ.replace(process.cwd(), $REPLACEMENT)",
       "compiledAt": "2026-03-22T17:38:40.853Z",
       "createdAt": "2026-03-22T17:38:40.853Z",
-      "fileGlobs": ["**/*.ts", "**/*.js"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js"
+      ],
       "severity": "warning"
     },
     {
@@ -2761,7 +3501,10 @@
       "astGrepPattern": "JSON.parse($A) as $B",
       "compiledAt": "2026-03-22T17:38:52.601Z",
       "createdAt": "2026-03-22T17:38:52.601Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx"
+      ],
       "severity": "warning"
     },
     {
@@ -2773,7 +3516,12 @@
       "astQuery": "(catch_clause body: (statement_block) @body (#eq? @body \"{}\")) @violation",
       "compiledAt": "2026-03-22T17:39:21.564Z",
       "createdAt": "2026-03-22T17:39:21.564Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -2785,7 +3533,11 @@
       "astGrepPattern": "$A[$A.indexOf($B) + 1]",
       "compiledAt": "2026-03-22T17:40:18.643Z",
       "createdAt": "2026-03-22T17:40:18.643Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "!**/*.test.ts"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -2797,7 +3549,10 @@
       "astGrepPattern": "$NODE.findAll(typeof $X === 'string' ? $Y : $Z)",
       "compiledAt": "2026-03-22T17:40:18.643Z",
       "createdAt": "2026-03-22T17:40:18.643Z",
-      "fileGlobs": ["**/*.ts", "**/*.js"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js"
+      ],
       "severity": "warning"
     },
     {
@@ -2808,7 +3563,13 @@
       "engine": "regex",
       "compiledAt": "2026-03-22T17:41:25.546Z",
       "createdAt": "2026-03-22T17:41:25.546Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx", "!**/*.test.ts"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -2820,7 +3581,14 @@
       "astQuery": "(catch_clause body: (statement_block) @body (#eq? @body \"{}\")) @violation",
       "compiledAt": "2026-03-22T17:42:09.151Z",
       "createdAt": "2026-03-22T17:42:09.151Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "!**/*.test.ts", "!**/*.spec.ts"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx",
+        "!**/*.test.ts",
+        "!**/*.spec.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -2831,7 +3599,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-22T17:42:42.238Z",
       "createdAt": "2026-03-22T17:42:42.238Z",
-      "fileGlobs": ["**/*.js", "**/*.ts", "**/*.jsx", "**/*.tsx"],
+      "fileGlobs": [
+        "**/*.js",
+        "**/*.ts",
+        "**/*.jsx",
+        "**/*.tsx"
+      ],
       "severity": "warning"
     },
     {
@@ -2842,7 +3615,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-22T17:43:30.348Z",
       "createdAt": "2026-03-22T17:43:30.348Z",
-      "fileGlobs": ["packages/cli/**/*.ts", "!**/*.test.ts"],
+      "fileGlobs": [
+        "packages/cli/**/*.ts",
+        "!**/*.test.ts"
+      ],
       "severity": "warning"
     },
     {
@@ -2874,7 +3650,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-23T04:25:13.392Z",
       "createdAt": "2026-03-23T04:25:13.392Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -2886,7 +3667,10 @@
       "astGrepPattern": "function $NAME($$$ARGS) { throw $ERR }",
       "compiledAt": "2026-03-23T04:26:34.759Z",
       "createdAt": "2026-03-23T04:26:34.759Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx"
+      ],
       "severity": "warning"
     },
     {
@@ -2959,7 +3743,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-23T04:28:42.554Z",
       "createdAt": "2026-03-23T04:28:42.554Z",
-      "fileGlobs": ["*.sh", "*.bash", "*.yml", "*.yaml"],
+      "fileGlobs": [
+        "*.sh",
+        "*.bash",
+        "*.yml",
+        "*.yaml"
+      ],
       "severity": "warning"
     },
     {
@@ -2970,7 +3759,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-23T04:29:00.016Z",
       "createdAt": "2026-03-23T04:29:00.016Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -2981,7 +3775,15 @@
       "engine": "regex",
       "compiledAt": "2026-03-23T04:29:24.343Z",
       "createdAt": "2026-03-23T04:29:24.343Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx", "**/*.py", "**/*.go", "!**/*.md"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx",
+        "**/*.py",
+        "**/*.go",
+        "!**/*.md"
+      ],
       "severity": "warning"
     },
     {
@@ -2992,7 +3794,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-23T04:30:00.759Z",
       "createdAt": "2026-03-23T04:30:00.759Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -3003,7 +3810,12 @@
       "engine": "regex",
       "compiledAt": "2026-03-23T04:30:42.749Z",
       "createdAt": "2026-03-23T04:30:42.749Z",
-      "fileGlobs": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -3014,7 +3826,13 @@
       "engine": "regex",
       "compiledAt": "2026-03-23T04:32:25.729Z",
       "createdAt": "2026-03-23T04:32:25.729Z",
-      "fileGlobs": ["*.sh", "*.bash", "*.yml", "*.yaml", "package.json"],
+      "fileGlobs": [
+        "*.sh",
+        "*.bash",
+        "*.yml",
+        "*.yaml",
+        "package.json"
+      ],
       "severity": "warning"
     },
     {
@@ -3025,7 +3843,14 @@
       "engine": "regex",
       "compiledAt": "2026-03-23T04:32:42.918Z",
       "createdAt": "2026-03-23T04:32:42.918Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx", "!**/*.test.ts", "!**/*.test.js"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx",
+        "!**/*.test.ts",
+        "!**/*.test.js"
+      ],
       "severity": "warning"
     },
     {
@@ -3036,7 +3861,10 @@
       "engine": "regex",
       "compiledAt": "2026-03-23T04:33:05.619Z",
       "createdAt": "2026-03-23T04:33:05.619Z",
-      "fileGlobs": [".github/workflows/*.yml", ".github/workflows/*.yaml"],
+      "fileGlobs": [
+        ".github/workflows/*.yml",
+        ".github/workflows/*.yaml"
+      ],
       "severity": "warning"
     },
     {
@@ -3048,7 +3876,12 @@
       "astQuery": "(catch_clause body: (statement_block (throw_statement (new_expression constructor: (identifier) @ctor (#eq? @ctor \"Error\") arguments: (arguments (string)))))) @violation",
       "compiledAt": "2026-03-23T04:33:41.616Z",
       "createdAt": "2026-03-23T04:33:41.616Z",
-      "fileGlobs": ["**/*.ts", "**/*.js", "**/*.tsx", "**/*.jsx"],
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx"
+      ],
       "severity": "warning"
     },
     {
@@ -3059,7 +3892,13 @@
       "engine": "regex",
       "compiledAt": "2026-03-23T04:33:45.150Z",
       "createdAt": "2026-03-23T04:33:45.150Z",
-      "fileGlobs": ["*.sh", "*.bash", "*.zsh", "*.yml", "*.yaml"],
+      "fileGlobs": [
+        "*.sh",
+        "*.bash",
+        "*.zsh",
+        "*.yml",
+        "*.yaml"
+      ],
       "severity": "warning"
     },
     {
@@ -3070,8 +3909,324 @@
       "engine": "regex",
       "compiledAt": "2026-03-23T04:34:15.705Z",
       "createdAt": "2026-03-23T04:34:15.705Z",
-      "fileGlobs": ["*.sh", "*.bash", ".husky/**", "package.json", ".lintstagedrc*"],
+      "fileGlobs": [
+        "*.sh",
+        "*.bash",
+        ".husky/**",
+        "package.json",
+        ".lintstagedrc*"
+      ],
       "severity": "warning"
+    },
+    {
+      "lessonHash": "2f8553af87aee751",
+      "lessonHeading": "Adding 'edited' to pull_request trigger types ensures",
+      "message": "GitHub Action pull_request triggers should include the 'edited' type to ensure workflows rerun when the PR title changes (e.g., to detect bypass strings like [UPDATE-RULES]).",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "types:\\s*\\[(?![^\\]]*\\bedited\\b)[^\\]]*\\]",
+      "compiledAt": "2026-03-23T21:36:37.757Z",
+      "createdAt": "2026-03-23T21:36:37.757Z",
+      "fileGlobs": [
+        ".github/workflows/*.yml",
+        ".github/workflows/*.yaml"
+      ]
+    },
+    {
+      "lessonHash": "da5e4b2ad9052b52",
+      "lessonHeading": "MCP tools should return plain-text for error paths",
+      "message": "MCP tools should return plain-text for error paths. Do not use XML wrapping (like formatXmlResponse) when isError is true to ensure client compatibility.",
+      "engine": "ast-grep",
+      "severity": "warning",
+      "pattern": "",
+      "astGrepPattern": "{ $$$ , content: [ { $$$ , text: formatXmlResponse($$$) , $$$ } ] , $$$ , isError: true , $$$ }",
+      "compiledAt": "2026-03-23T21:37:47.161Z",
+      "createdAt": "2026-03-23T21:37:47.161Z",
+      "fileGlobs": [
+        "packages/mcp/**/*.ts",
+        "!**/*.test.ts"
+      ]
+    },
+    {
+      "lessonHash": "9255d609df5aef76",
+      "lessonHeading": "Implementing a trap for EXIT, INT, and TERM signals ensures",
+      "message": "When implementing a cleanup trap, ensure you catch EXIT, INT, and TERM signals together to reliably handle interruptions and temporary file cleanup.",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "\\btrap\\s+(['\"].*?['\"]|\\S+)\\s+(?=.*\\b(EXIT|INT|TERM)\\b)(?!(?=.*\\bEXIT\\b)(?=.*\\bINT\\b)(?=.*\\bTERM\\b)).*",
+      "compiledAt": "2026-03-23T21:38:01.067Z",
+      "createdAt": "2026-03-23T21:38:01.067Z",
+      "fileGlobs": [
+        "*.sh",
+        "*.bash",
+        "*.zsh",
+        "*.yml",
+        "*.yaml"
+      ]
+    },
+    {
+      "lessonHash": "52b5414764184f25",
+      "lessonHeading": "When redacting tokens like sk-proj- and sk-, the longest",
+      "message": "Longest patterns must be evaluated first during redaction. Ensure 'sk-proj-' is handled before 'sk-' to prevent partial matching and sensitive data exposure.",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "\\bsk-(?!proj-).+sk-proj-",
+      "compiledAt": "2026-03-23T21:38:51.342Z",
+      "createdAt": "2026-03-23T21:38:51.342Z",
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx",
+        "**/*.py",
+        "**/*.go"
+      ]
+    },
+    {
+      "lessonHash": "2377d2fa9d1cfa6d",
+      "lessonHeading": "Map PR metadata to env vars for secure shells",
+      "message": "Map PR metadata to environment variables instead of using 'gh api' to prevent shell injection and avoid unnecessary 'pull-requests: read' permissions.",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "\\bgh\\s+api\\s+.*\\/pulls\\/",
+      "compiledAt": "2026-03-23T21:38:09.422Z",
+      "createdAt": "2026-03-23T21:38:09.422Z",
+      "fileGlobs": [
+        "*.sh",
+        ".github/workflows/*.yml",
+        ".github/workflows/*.yaml"
+      ]
+    },
+    {
+      "lessonHash": "8cc714c0c10fbd39",
+      "lessonHeading": "Use dynamic await import() inside CLI command handlers",
+      "message": "Use dynamic await import() inside CLI command handlers for internal packages instead of top-level static imports to ensure fast startup performance.",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "import\\s+.*from\\s+['\"](@|\\.\\./)",
+      "compiledAt": "2026-03-23T21:38:26.361Z",
+      "createdAt": "2026-03-23T21:38:26.361Z",
+      "fileGlobs": [
+        "packages/cli/**/*.ts"
+      ]
+    },
+    {
+      "lessonHash": "358177469f11c272",
+      "lessonHeading": "Relying on error name strings for matching is fragile",
+      "message": "Relying on error name strings for matching is fragile. Use 'instanceof' or specific error codes for robust, type-safe error handling.",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "\\b(err|e|error|exception)\\.name(\\s*[!=]=+\\s*['\"]|\\.(includes|startsWith|endsWith))",
+      "compiledAt": "2026-03-23T21:39:19.106Z",
+      "createdAt": "2026-03-23T21:39:19.106Z",
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ]
+    },
+    {
+      "lessonHash": "5c5fe9d9060bcb6d",
+      "lessonHeading": "Core library modules should use optional callbacks",
+      "message": "Use optional callbacks (e.g., onWarn) instead of hardcoded console methods in core library modules to remain environment-agnostic.",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "\\bconsole\\.(log|warn|error|info|debug|trace)\\s*\\(",
+      "compiledAt": "2026-03-23T21:39:12.701Z",
+      "createdAt": "2026-03-23T21:39:12.701Z",
+      "fileGlobs": [
+        "packages/core/**/*.ts",
+        "packages/core/**/*.js",
+        "lib/**/*.ts",
+        "lib/**/*.js",
+        "src/lib/**/*.ts",
+        "!**/*.test.ts",
+        "!**/*.test.js"
+      ]
+    },
+    {
+      "lessonHash": "7abdd08cc9aea21c",
+      "lessonHeading": "Sanitize untrusted PR content by escaping closing tags",
+      "message": "Sanitize untrusted PR content by escaping closing tags (e.g., .replace(/<\\//g, '<\\\\/')) to prevent attackers from breaking out of XML envelopes and injecting malicious instructions.",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "<(\\w+)>.*\\$\\{(?!.*(escape|sanitize|encode|format|replace))\\s*(?:pr|payload|pullRequest|issue|comment)\\.[^}]+\\}.*<\\/\\1>",
+      "compiledAt": "2026-03-23T21:39:24.636Z",
+      "createdAt": "2026-03-23T21:39:24.636Z",
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx",
+        "!**/*.test.ts",
+        "!**/*.test.js"
+      ]
+    },
+    {
+      "lessonHash": "18999ece8c37d886",
+      "lessonHeading": "Using input strings as Map keys in batch processing",
+      "message": "Using input strings as Map keys in batch processing causes data loss when duplicate inputs are provided. Returning an array of results mapped to input indices ensures every call is uniquely handled and preserved.",
+      "engine": "ast-grep",
+      "severity": "warning",
+      "pattern": "",
+      "astGrepPattern": "new Map($ARR.map($$FUNC))",
+      "compiledAt": "2026-03-23T21:39:46.534Z",
+      "createdAt": "2026-03-23T21:39:46.534Z",
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ]
+    },
+    {
+      "lessonHash": "c802b8588ec9d911",
+      "lessonHeading": "Reject non-positive PIDs and infinite timestamps",
+      "message": "Reject non-positive PIDs and infinite timestamps in lockfiles to prevent accidental signaling of process groups (via kill(0)) and broken staleness math.",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "process\\.kill\\(\\s*0\\s*\\)|\\b(pid|PID)\\s*[:=]\\s*(0|-[1-9]\\d*)\\b|\\btimestamp\\s*[:=]\\s*(Infinity|Number\\.POSITIVE_INFINITY)",
+      "compiledAt": "2026-03-23T21:39:59.029Z",
+      "createdAt": "2026-03-23T21:39:59.029Z",
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "!**/*.test.ts",
+        "!**/*.test.js"
+      ]
+    },
+    {
+      "lessonHash": "e56d56efd671f07e",
+      "lessonHeading": "Simple string lookups like indexOf('[{') fail to detect",
+      "message": "Simple string lookups like indexOf('[{') fail to detect pretty-printed JSON; use a regex search for /\\[\\s*{/ instead to correctly identify the start of an array regardless of whitespace.",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "\\.(indexOf|includes|startsWith|match)\\s*\\(\\s*['\"]\\s*\\[\\{\\s*['\"]\\s*\\)",
+      "compiledAt": "2026-03-23T21:39:44.406Z",
+      "createdAt": "2026-03-23T21:39:44.406Z",
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ]
+    },
+    {
+      "lessonHash": "25e28b9f51d1c060",
+      "lessonHeading": "Replacing direct process.exit(1) calls with thrown custom",
+      "message": "Avoid direct process.exit() calls; throw custom errors instead to keep logic composable and centralize exit handling at the application boundary.",
+      "engine": "ast-grep",
+      "severity": "warning",
+      "pattern": "",
+      "astGrepPattern": "process.exit($$$)",
+      "compiledAt": "2026-03-23T21:39:35.112Z",
+      "createdAt": "2026-03-23T21:39:35.112Z",
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.tsx",
+        "**/*.jsx",
+        "!**/*.test.ts",
+        "!**/*.test.js",
+        "!**/*.spec.ts",
+        "!**/*.spec.js"
+      ]
+    },
+    {
+      "lessonHash": "7a47e69b5ea86122",
+      "lessonHeading": "Using parseInt() allows malformed strings like '5foo' to be",
+      "message": "Use Number() or explicit validation instead of parseInt() to prevent parsing malformed strings (e.g., '5foo')",
+      "engine": "ast-grep",
+      "severity": "warning",
+      "pattern": "",
+      "astGrepPattern": "parseInt($$$ARGS)",
+      "compiledAt": "2026-03-23T21:39:29.275Z",
+      "createdAt": "2026-03-23T21:39:29.275Z",
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ]
+    },
+    {
+      "lessonHash": "14cbc205f8c86d3d",
+      "lessonHeading": "Confine dynamic imports to CLI command handlers to maintain",
+      "message": "Dynamic imports must be confined to CLI command handlers to maintain a clean dependency graph and pass security scans.",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "\\bimport\\s*\\(",
+      "compiledAt": "2026-03-23T21:40:11.466Z",
+      "createdAt": "2026-03-23T21:40:11.466Z",
+      "fileGlobs": [
+        "packages/cli/**/*.ts",
+        "packages/cli/**/*.js",
+        "!packages/cli/src/commands/**/*.ts",
+        "!packages/cli/src/commands/**/*.js",
+        "!**/*.test.ts"
+      ]
+    },
+    {
+      "lessonHash": "78c3bbbdf6659ff4",
+      "lessonHeading": "The github.event.pull_request context is immutable",
+      "message": "The github.event.pull_request context is immutable for a specific workflow run. Manual re-runs will not reflect title or body edits made after the initial trigger. Fetch the latest PR data via the GitHub API if current values are required.",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "github\\.event\\.pull_request\\.(title|body)",
+      "compiledAt": "2026-03-23T21:40:06.136Z",
+      "createdAt": "2026-03-23T21:40:06.136Z",
+      "fileGlobs": [
+        ".github/workflows/*.yml",
+        ".github/workflows/*.yaml"
+      ]
+    },
+    {
+      "lessonHash": "4668d0b7c2436f09",
+      "lessonHeading": "In the DataFusion SQL dialect, backslashes are treated",
+      "message": "In DataFusion SQL, backslashes are treated as literal characters. Use doubled single quotes ('') instead of '\\'' to escape single quotes within string literals.",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "\\\\'",
+      "compiledAt": "2026-03-23T21:40:17.553Z",
+      "createdAt": "2026-03-23T21:40:17.553Z",
+      "fileGlobs": [
+        "**/*.sql"
+      ]
+    },
+    {
+      "lessonHash": "db517157e7186b1b",
+      "lessonHeading": "Calling .test() on a global regex increments the lastIndex",
+      "message": "Calling .test() on a global regex increments lastIndex, which can cause subsequent replacements or tests to skip characters. Use a non-global regex instead.",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "(\\/[^/]+\\/[a-z]*g[a-z]*|new\\s+RegExp\\s*\\([^)]+['\"][^'\"]*g[^'\"]*['\"]\\s*\\))\\.test\\(",
+      "compiledAt": "2026-03-23T21:40:40.156Z",
+      "createdAt": "2026-03-23T21:40:40.156Z",
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx"
+      ]
+    },
+    {
+      "lessonHash": "f202f65f8a198f18",
+      "lessonHeading": "When testing expected failures, assert the specific error",
+      "message": "When testing expected failures, assert the specific error message or violation count instead of just checking if an error was thrown to prevent false positives.",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "\\.(toThrow|toThrowError)\\(\\s*\\)",
+      "compiledAt": "2026-03-23T21:40:48.747Z",
+      "createdAt": "2026-03-23T21:40:48.747Z",
+      "fileGlobs": [
+        "**/*.test.ts",
+        "**/*.test.js",
+        "**/*.spec.ts",
+        "**/*.spec.js",
+        "**/*.test.tsx",
+        "**/*.test.jsx"
+      ]
     }
   ],
   "nonCompilable": [
@@ -3554,6 +4709,19 @@
     "f3d453f9876e156d",
     "610215977c44a021",
     "70bf4a90c02ec975",
-    "7b8bc6dc9dc15010"
+    "7b8bc6dc9dc15010",
+    "ece957c3e31f56f0",
+    "6376712252dd4c9d",
+    "ddf5e24d248c9df1",
+    "a39492de8bd30047",
+    "c6608242141cfe77",
+    "f656f682e04d9359",
+    "829bd9c624ad9cce",
+    "ebf08344db275331",
+    "9f2f55719676a144",
+    "238fc21c856fb54d",
+    "c5170761107ec71c",
+    "9ec0e320821292ea",
+    "e5f79d0298620e19"
   ]
 }

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -390,14 +390,14 @@ export async function compileCommand(options: CompileOptions): Promise<void> {
         `All ${lessons.length} lessons already processed (${existingRules.length} compiled, ${nonCompilableSet.size} non-compilable). Use --force to recompile.`,
       ); // totem-ignore
     } else {
-      log.info(
-        TAG,
-        `${toCompile.length} lessons need compilation (${existingRules.length} already compiled)`,
-      );
+      const { createSpinner } = await import('../ui.js');
+      const spinner = await createSpinner(TAG);
 
       let compiled = 0;
       let skipped = 0;
       let failed = 0;
+      let processed = 0;
+      const total = toCompile.length;
       const newRules: CompiledRule[] = [...existingRules];
 
       const currentHashes = new Set(lessons.map((l) => hashLesson(l.heading, l.body)));
@@ -442,6 +442,9 @@ export async function compileCommand(options: CompileOptions): Promise<void> {
               }),
           ),
         );
+
+        processed += batch.length;
+        spinner.update(`${processed}/${total} lessons (${Math.round((processed / total) * 100)}%)`);
 
         for (const { lesson, result } of results) {
           switch (result.status) {
@@ -500,13 +503,8 @@ export async function compileCommand(options: CompileOptions): Promise<void> {
         });
         log.dim(TAG, `Manifest: ${inputHash.slice(0, 8)}…→${outputHash.slice(0, 8)}…`);
 
-        log.info(
-          TAG,
-          `Results: ${compiled} compiled, ${skipped} skipped (conceptual), ${failed} failed, ${freshNonCompilable.length} cached`,
-        );
-        log.success(
-          TAG,
-          `${newRules.length} total rules saved to ${config.totemDir}/${COMPILED_RULES_FILE}`,
+        spinner.succeed(
+          `${newRules.length} rules — ${compiled} compiled, ${skipped} skipped, ${failed} failed`,
         );
       }
     }

--- a/packages/cli/src/ui.ts
+++ b/packages/cli/src/ui.ts
@@ -88,12 +88,12 @@ export async function createSpinner(tag: string, text?: string): Promise<Spinner
 
   let quoteInterval: NodeJS.Timeout | null = null;
 
-  // Cycle quotes every 4 seconds if we are in quote mode
+  // Cycle quotes every 45 seconds if we are in quote mode — let them breathe
   if (isQuoteMode) {
     quoteInterval = setInterval(() => {
       currentText = getRandomSpinnerQuote();
       spinner.text = `${prefix(tag)} ${currentText}`;
-    }, 4000);
+    }, 45_000);
   }
 
   const cleanup = () => {


### PR DESCRIPTION
## Summary

- Compile progress spinner: shows `35/730 lessons (6%)` during compilation with movie quote rotation
- Quote rotation interval increased from 4s to 45s
- Incremental compile: 19 new rules from quality sweep lesson extractions (266 total)
- Manifest verified, wind tunnel 9/9 passes

## Test plan

- [x] 1,322 tests passing
- [x] `totem verify-manifest` passes
- [x] `totem test` — 9/9 wind tunnel fixtures pass
- [x] Lint clean (266 rules, 0 violations)
- [x] Progress spinner tested live during compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)