### PR TITLE
fix: add missing link command to README command table

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The AI helps you **write** rules. The rules enforce themselves.
 | `verify-manifest` | Verify compiled-rules.json matches the compile manifest (CI gate)                |
 | `test`            | Run test fixtures against compiled rules (TDD for governance rules)              |
 | `extract`         | Extract lessons from PR review(s) into .totem/lessons/ (interactive cherry-pick) |
+| `link`            | Link a neighboring repo into this project                                        |
 | `eject`           | Remove all Totem hooks, config, and data from this project                       |
 | `wrap`            | Post-merge workflow: learn from PR(s), sync index, then triage                   |
 | `docs`            | Auto-update registered project docs using LLM synthesis                          |

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -353,7 +353,7 @@ program
 
 program
   .command('link <path>')
-  .description("Link a neighboring repo's lessons into this project")
+  .description('Link a neighboring repo into this project')
   .option('--unlink', 'Remove a previously linked repo')
   .option('-y, --yes', 'Skip the security confirmation prompt')
   .action(async (targetPath: string, opts: { unlink?: boolean; yes?: boolean }) => {


### PR DESCRIPTION
## Summary
The `totem link` command was missing from the README command table. Root cause: the description string used double quotes with an apostrophe (`"repo's"`), which broke the `docs-transforms.cjs` regex parser (`[^'"]+` stops at the `'`).

Fix: simplified the description to avoid the apostrophe.

## Test plan
- [x] `pnpm run docs:inject` — `link` now appears in generated table
- [x] `pnpm run test:docs` — 9/9 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)