### PR TITLE
fix: skip compile manifest attestation on docs-only PRs

### DIFF
--- a/.github/workflows/compile-manifest.yml
+++ b/.github/workflows/compile-manifest.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened, edited]
+    paths:
+      - '.totem/compiled-rules.json'
+      - '.totem/compile-manifest.json'
+      - '.totem/lessons/**'
+      - 'packages/core/src/compiler*'
+      - 'packages/cli/src/commands/compile.ts'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Add paths filter so the workflow only triggers when compiled rules, lessons, or compiler source files change. Prevents false failures on documentation and non-code PRs.