### PR TITLE
chore: release 1.5.1

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmnto/cli",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "CLI for Totem — AI persistent memory and context layer",
   "type": "module",
   "bin": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmnto/totem",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Persistent memory and context layer for AI agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmnto/mcp",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "MCP server for Totem — AI persistent memory and context layer",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Version bump to 1.5.1 for npm publish. Tag + publish after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)