### PR TITLE
fix: standardize [Totem Error] tag across CLI logging

### DIFF
--- a/packages/cli/src/commands/add-lesson.ts
+++ b/packages/cli/src/commands/add-lesson.ts
@@ -66,7 +66,7 @@ export async function addLessonCommand(lessonArg?: string): Promise<void> {
   }
 
   if (!lessonText || !lessonText.trim()) {
-    log.error('Totem', 'Lesson text cannot be empty.');
+    log.error('Totem Error', 'Lesson text cannot be empty.');
     return;
   }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -27,7 +27,10 @@ function handleError(err: unknown): never {
   const debug = process.env['TOTEM_DEBUG'] === '1' || process.argv.includes('--debug');
 
   if (err instanceof Error) {
-    console.error(err.message);
+    const msg = err.message.startsWith('[Totem Error]')
+      ? err.message
+      : `[Totem Error] ${err.message}`;
+    console.error(msg);
     if ('recoveryHint' in err && typeof err.recoveryHint === 'string') {
       console.error(`  Fix: ${err.recoveryHint}`);
     }


### PR DESCRIPTION
## Summary

Standardizes error tagging in CLI output so all errors consistently use `[Totem Error]` prefix:

- `handleError` in `index.ts` now prefixes all `Error.message` output with `[Totem Error]`, with a guard to avoid double-prefixing for `TotemError` instances
- Standardized `log.error` tag from `'Totem'` to `'Totem Error'` in `add-lesson.ts`

Only 2 files changed — the scope was narrower than expected since most `log.error` calls already used the correct tag.

Closes #849

## Test plan

- [x] 948 CLI tests pass
- [x] Build clean
- [x] `totem lint` — PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)