### PR TITLE
chore: release 1.5.7 — codebase audit hardening

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @mmnto/cli
 
+## 1.5.7
+
+### Patch Changes
+
+- Codebase audit remediation and foundation hardening
+  - New `core/src/sys/` standard library: `safeExec()`, `readJsonSafe()`, git adapter (13 functions moved from CLI to core)
+  - Error cause chains (ES2022): TotemError hierarchy accepts `cause`, 22 catch blocks updated
+  - Forbidden native module rules: 3 compiled rules enforce shared helper usage
+  - Phase-gate hooks hardened: `fix/*` exemption removed, warning upgraded to block
+  - CoreLogger DI: `setCoreLogger()` replaces `console.warn` in core
+  - CRLF fixed: `.gitattributes` forces LF, prettier `endOfLine: "lf"`
+  - Shield flag verify-not-consume: push no longer deletes the flag
+  - AST query graceful degradation: tree-sitter failures no longer crash compilation
+  - Spec gap remediation: `cleanTmpDir` helper, CLI wiring fixes
+
+- Updated dependencies
+  - @mmnto/totem@1.5.7
+
 ## 1.5.6
 
 ### Patch Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmnto/cli",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "CLI for Totem — AI persistent memory and context layer",
   "type": "module",
   "bin": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,20 @@
 # @mmnto/totem
 
+## 1.5.7
+
+### Patch Changes
+
+- Codebase audit remediation and foundation hardening
+  - New `core/src/sys/` standard library: `safeExec()`, `readJsonSafe()`, git adapter (13 functions moved from CLI to core)
+  - Error cause chains (ES2022): TotemError hierarchy accepts `cause`, 22 catch blocks updated
+  - Forbidden native module rules: 3 compiled rules enforce shared helper usage
+  - Phase-gate hooks hardened: `fix/*` exemption removed, warning upgraded to block
+  - CoreLogger DI: `setCoreLogger()` replaces `console.warn` in core
+  - CRLF fixed: `.gitattributes` forces LF, prettier `endOfLine: "lf"`
+  - Shield flag verify-not-consume: push no longer deletes the flag
+  - AST query graceful degradation: tree-sitter failures no longer crash compilation
+  - Spec gap remediation: `cleanTmpDir` helper, CLI wiring fixes
+
 ## 1.5.6
 
 ### Patch Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmnto/totem",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "Persistent memory and context layer for AI agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @mmnto/mcp
 
+## 1.5.7
+
+### Patch Changes
+
+- Codebase audit remediation and foundation hardening
+  - New `core/src/sys/` standard library: `safeExec()`, `readJsonSafe()`, git adapter (13 functions moved from CLI to core)
+  - Error cause chains (ES2022): TotemError hierarchy accepts `cause`, 22 catch blocks updated
+  - Forbidden native module rules: 3 compiled rules enforce shared helper usage
+  - Phase-gate hooks hardened: `fix/*` exemption removed, warning upgraded to block
+  - CoreLogger DI: `setCoreLogger()` replaces `console.warn` in core
+  - CRLF fixed: `.gitattributes` forces LF, prettier `endOfLine: "lf"`
+  - Shield flag verify-not-consume: push no longer deletes the flag
+  - AST query graceful degradation: tree-sitter failures no longer crash compilation
+  - Spec gap remediation: `cleanTmpDir` helper, CLI wiring fixes
+
+- Updated dependencies
+  - @mmnto/totem@1.5.7
+
 ## 1.5.6
 
 ### Patch Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmnto/mcp",
-  "version": "1.5.6",
+  "version": "1.5.7",
   "description": "MCP server for Totem — AI persistent memory and context layer",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- New `core/src/sys/` standard library: `safeExec()`, `readJsonSafe()`, git adapter (13 functions moved from CLI to core)
- Error cause chains (ES2022): TotemError hierarchy accepts `cause`, 22 catch blocks updated
- Forbidden native module rules: 3 compiled rules enforce shared helper usage
- Phase-gate hooks hardened: `fix/*` exemption removed, warning upgraded to block
- CoreLogger DI, CRLF fix, shield flag verify-not-consume, AST graceful degradation

Closes #971, #978, #950, #952, #981, #983, #986, #988, #994, #1001, #995, #996, #998, #1002, #993, #1004

## PRs included
- #982 — Quick wins bundle
- #985 — Spec gap remediation
- #990 — Phase-gate hardening + AST graceful degradation
- #1003 — Codebase audit remediation
- #1009 — Postmerge wrap + lesson scope fix + CRLF fix
- #1011 — Forbidden native module lessons

## Test plan
- [x] 1,893 tests passing
- [x] totem lint: 311 rules, 0 violations
- [x] totem shield: fast-path (non-code changes only in this PR)
- [x] format:check passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)