### PR TITLE
fix: shield false positive — context enrichment + override mechanism

### DIFF
--- a/docs/active_work.md
+++ b/docs/active_work.md
@@ -1,204 +1,73 @@
 ### Active Work Summary
 
-The Data Layer Foundation is complete, and the project is currently at release `@mmnto/cli@1.5.6`. Recent focus has centered on:
+The project is at release `@mmnto/cli@1.5.7` with 922 lessons, 344 compiled rules, and 1,920 tests. The 1.6.0 milestone theme is **Pipeline Maturity** — improving rule quality, shield reliability, and bot review workflows.
 
-- **Orchestration & Workflows:**
-  - Deprecated legacy shield contexts and established formalized capability tiers.
-  - Implemented invisible sync hooks for smooth orchestration context updates.
-  - Integrated CodeRabbit configuration for automated PR reviews.
-  - Expanded the post-compaction hook with a capability manifest.
-  - Refactored agent instruction files (`CLAUDE.md`) to a lean root router pattern.
-  - Restructured workflow skills into a dedicated directory format.
-  - Enforced pre-push validation via pre-tool-use hooks.
-- **Security & Governance:**
-  - Hardened phase-gate hooks for stricter commit validation.
-  - Refined manifest attestation CI gates with dedicated separate workflows.
-  - Hardened ingestion with trust boundaries and an MCP authentication model.
-  - Implemented compile manifest signing to establish a provenance chain.
-  - Added Data Loss Prevention (DLP) secret masking middleware for outbound LLM calls.
-  - Executed codebase review fixes and targeted security hardening.
-  - Introduced phase-gate enforcement with preflight commit warnings.
-  - Backfilled body text for 125 foundational lessons and extracted operational knowledge from recent PRs.
-  - Consolidated near-duplicate rules and reverse-compiled curated enforcement patterns.
-  - Delivered a security hardening batch addressing capability limits and injection vulnerabilities.
-  - Upgraded the specification process to utilize a strict checklist format.
-  - Introduced a lesson file linter with a pre-compilation gate.
-- **Search & Infrastructure:**
-  - Implemented graceful AST query degradation to prevent execution failures during complex parsing.
-  - Remedied specification gaps with dependency injection for the core logger and CLI wiring fixes.
-  - Executed filesystem cleanup sweeps to replace legacy synchronization calls.
-  - Implemented parallel lesson compilation to optimize processing efficiency.
-  - Resolved functionality gaps across AST queries, process execution handling, and suppression metrics.
-  - Expanded critical test coverage and executed general codebase quality hardening.
-  - Configured AST query engines to fail-closed instead of swallowing exceptions.
-  - Added a CI wind tunnel SHA lock to ensure fixture integrity.
-  - Enhanced release workflow tag push resilience and updated dependency configurations.
-  - Introduced index partitions with alias resolution.
-  - Added a boundary parameter to the MCP search tool.
-  - Established a cross-platform CI matrix supporting multiple environments.
-  - Unified error domains and refactored the compiler architecture using a facade pattern.
-  - Delivered unified execution tracking following successful readiness audits.
-- **Documentation & DX:**
-  - Executed targeted continuous integration fixes and related capability tier updates.
-  - Extracted and integrated operational lessons from recent codebase quality sweeps.
-  - Required explicit confirmation before writing LLM-generated documentation.
-  - Configured documentation generation to actively strip marketing terminology.
-  - Regenerated project documentation alongside 5-lesson extraction.
-  - Fixed documentation generation to prevent persistence of stale issue references.
-  - Executed developer experience polish targeting onboarding flows and output brevity.
-  - Integrated launch metrics and a Docker test harness.
+Recent completed work (1.5.6–1.5.7):
 
-Post-merge sequence was aligned during a multi-agent planning session (Claude + Gemini, 2026-03-13) informed by Deep Research Brief 24 (Competitive Moat Analysis). See `.strategy/deep-research/24-competitive-moat-analysis/` for the full adversarial analysis.
+- **Agent Governance (ADR-076 / Proposal 195):**
+  - Rule unit testing — inline `**Example Hit:**`/`**Example Miss:**` verification at compile time (#1012)
+  - Forbidden native module rules — enforce safeExec, readJsonSafe, GitAdapter usage (#1004)
+  - New `core/src/sys/` standard library: `safeExec()`, `readJsonSafe()`, git adapter (13 functions)
+- **Codebase Audit Remediation:**
+  - Error cause chains (ES2022) across TotemError hierarchy
+  - CoreLogger DI — injectable logger replaces `console.warn` in core
+  - Phase-gate hooks hardened — `fix/*` exemption removed, warning upgraded to block
+  - CRLF fixed with `.gitattributes` + prettier `endOfLine: "lf"`
+- **Self-Healing Loop:**
+  - Trap Ledger — `.totem/ledger/events.ndjson` append-only telemetry
+  - `totem doctor --pr` — autonomous rule downgrading for noisy rules
+  - Triage UX Phase 1 — categorized inbox with severity mapping
+  - Review-learn — extract lessons from resolved bot findings
+- **Ecosystem:**
+  - Unified findings model — `TotemFinding` interface, `deduplicateFindings()`
+  - User-defined secrets with DLP at every LLM boundary
+  - Language packs — Python, Rust, Go baseline lessons
+  - Strategy submodule now runs its own Totem instance
 
 ### Prioritized Roadmap
 
-**Next Up (Post-0.35.0 Sequence)**
+**Bug Fixes (next patch: 1.5.8)**
 
-The following sequence was determined by cross-referencing the competitive moat analysis (Brief 24) with current product pain points. Ordered by effort/impact ratio:
+- #992 — Shield false positive when diff references symbols from unchanged code (tier-1)
+- #1006 — safeExec result.trim() crashes if stdio overridden to non-pipe mode
+- #1005 — gh-utils error unwrapping doesn't match safeExec error chain structure
+- #1007 — github-cli-pr.ts missing GH_PROMPT_DISABLED on direct gh invocation
+- #989 — Resolve .spec-completed path relative to git root, not cwd
+- #991 — Use jq for JSON parsing in pre-push-check.sh hook
 
-1. **#434 — Adversarial trap corpus** — Synthetic violations to measure precision/recall of deterministic engine.
-2. **#433 — Lesson Packs prototype** — Mine 1 OSS project as proof of concept for distributable rule sets.
-3. **#432 — Dynamic imports for CLI startup perf** — GCA Rule 51 follow-up. Convert static `@mmnto/totem` imports to dynamic `await import()` in command files.
-4. **#92 — `totem stats` enhancement (Staff Architect visibility)** — Reframed from "telemetry dashboard" to local CLI metrics: violation history from git log, lesson coverage, rule fire counts from local JSONL. No cloud, no TUI — terminal output only for v1.0.
-5. **AST Compilation Design (scope within #314)** — Driven by data from the testing harness. Design task, not immediate implementation. Transitions compilation from regex-only to AST-aware rules (Tree-sitter/ast-grep) for the cases where regex is provably insufficient.
+**Pipeline Integrity (Proposal 195, continued)**
 
-**Tier-1 Core & Shift-Left Foundation**
+- #1013 — Lesson logic linter — semantic validation for scope/severity/exclusions (tier-1)
+- #1010 — Incremental shield validation — diff-only re-check after minor fixes (tier-1)
+- #984 — triage-pr and review-learn skip CodeRabbit "outside diff range" findings (tier-1)
 
-- #314 — Epic: The Codebase Immune System — Adaptive Agent Governance. Now explicitly scoped to include AST compilation design (item 5 above).
-- #124 — Epic: Frictionless 10-Minute Init (totem init).
-- #430 — Document authority modes for `totem docs` (generated vs. assisted). Fixes the workflow vulnerability where `totem docs` overwrites human-curated strategic decisions.
-- #435 — Auto-extract lessons from PR review comments (`totem extract --from-pr`).
+**Triage Phases 2–4**
 
-**Tier-1 UX & Documentation**
+- #957 — Phase 2: Agent Dispatch Integration — atomic triage fixes (tier-1)
+- #958 — Phase 3: Interactive CLI — Clack prompts for PR triage
+- #959 — Phase 4: Lesson Extraction Pipeline — bot to lesson loop (blocked)
 
-- #283 — Epic: v1.0 Documentation Site & README Minimization.
-- #385 — Export compiled rules to Semgrep YAML and ESLint configs — Deferred until core governance (#314) is finalized.
+**Enforcement & DX**
 
-**Backlog (Tier-2 / Tier-3)**
+- #917 — Exemption engine — unified false positive tracking
+- #951 — `totem check` + `totem status` — unified enforcement commands
+- #931 — Auto-ticket deferred bot review items
 
-- #392 — feat: `totem review` — full codebase review powered by repomix + vectordb lessons.
-- #79 — Epic: Documentation Ingestion Pipeline & Adapters — Phase 4.
+### Completed (1.6.0 milestone)
 
-### Completed
+- #1012 — Rule unit testing (PR #1018)
+- #1004 — Forbidden native module lessons (PR #1011)
+- #1001 — Error cause chains (PR #1003)
+- #995, #996, #998 — safeExec, readJsonSafe, GitAdapter to core (PR #1003)
+- #986 — Phase-gate hardening (PR #990)
+- #981, #993 — CoreLogger DI, test coverage (PR #985)
+- #971, #978, #994 — CI fix, rmSync sweep, dynamic import scoping (PR #982)
+- #960, #961 — Trap Ledger + self-healing (PRs #962, #968)
+- #956 — Triage Phase 1 (PR #967)
+- #955 — Safe-regex validation (PR #977)
+- #954 — Dynamic imports in non-command files (PR #977)
+- #952 — shield-context deprecation (PR #982)
+- #963 — Strip "works cited" during ingest (PR #977)
+- #1002 — Test audit global state (PR #1003)
 
-- **Search & Data Layer:**
-  - Implemented index partitions with alias resolution to enhance vector search capabilities.
-  - Added test coverage for cross-repository linked index queries and stabilized the AI-powered `totem shield` CI pipeline.
-  - Implemented cross-repository query support via the linked indexes configuration.
-  - Enhanced dimension mismatch detection utilizing index metadata.
-  - Implemented Data Loss Prevention (DLP) secret masking middleware to securely strip secrets before embedding.
-  - Delivered the Data Layer Foundation with hybrid search and Gemini embeddings.
-  - Switched default embedder to `gemini-embedding-2-preview` and implemented graceful degradation to Ollama fallbacks.
-  - Upgraded LanceDB to 0.26.x and resolved FTS pivot posting panics.
-  - Implemented auto-healing DB migrations for version bumps and dimension mismatches.
-  - Migrated lessons directory to dual-read/single-write and added startup health checks for LanceStore indexes.
-  - Automated full sync triggering following embedder configuration changes.
-- **Core & Shift-Left Foundation:**
-  - Hardened phase-gate hooks and implemented graceful AST query degradation to prevent execution failures.
-  - Remedied specification gaps via core logger dependency injection, temporary directory cleanup helpers, and CLI wiring updates.
-  - Deprecated legacy shield contexts in favor of standardized capability tiers.
-  - Executed continuous integration fixes and swept the codebase to remove legacy filesystem synchronization calls.
-  - Implemented parallel lesson compilation utilizing a concurrency flag to optimize processing output.
-  - Expanded critical test coverage and executed codebase quality hardening cleanups.
-  - Resolved execution functionality gaps involving AST queries, process termination handling, and suppression metrics.
-  - Refined the manifest attestation CI gate with isolated workflows and adjusted triggers.
-  - Hardened ingestion by establishing trust boundaries and an MCP authentication model.
-  - Implemented compile manifest signing to ensure a secure provenance chain.
-  - Configured AST query engines to fail-closed, preventing swallowed exceptions during execution.
-  - Secured testing infrastructure with a CI wind tunnel SHA lock for fixture integrity.
-  - Improved release workflow tag push resilience.
-  - Executed security hardening based on codebase review findings and extracted corresponding operational lessons.
-  - Implemented phase-gate enforcement to actively warn users on commits lacking preflight validation.
-  - Extracted operational lessons from recent orchestration and enforcement efforts.
-  - Expanded the enforcement baseline by backfilling body text for 125 foundational lessons and extracting recent operational lessons.
-  - Consolidated near-duplicate rules to streamline the active baseline and improve enforcement precision.
-  - Established a cross-platform CI matrix supporting Ubuntu, Windows, and macOS environments.
-  - Upgraded the specification process to utilize a strict checklist format for improved validation.
-  - Introduced a lesson file linter with a pre-compilation gate to validate lessons before processing.
-  - Introduced foundational manual patterns in lessons and reverse-compiled curated rules to strengthen the enforcement baseline.
-  - Extracted the compiler helper and refined logging interception for improved reliability.
-  - Delivered a security hardening batch addressing capability limits, taskkill injection vulnerabilities, and heading truncations.
-  - Implemented launch metrics and a Docker test harness to improve deployment reliability and evaluation.
-  - Unified the error domain with typed subclasses and refactored the compiler architecture using a facade pattern.
-  - Reverted to a curated 147-rule set with mandatory verify steps, and fixed branch-diff fallbacks to pre-filter ignored patterns.
-  - Delivered sprint capabilities including verified execution tracking, specification invariants, and enhanced baseline fix guidance.
-  - Introduced the explain command allowing users to look up the specific lesson behind a violation.
-  - Shipped the Tier 2 AST engine and introduced the minimal initialization scaffolding option.
-  - Implemented guardrail rules to enforce strict compliance on task completion states.
-  - Executed a portability audit for readiness and addressed conditions from the joint code review.
-  - Resolved launch testing findings and audited compiled rules to further reduce false positives.
-  - Implemented filesystem concurrency locks to safely manage concurrent sync operations and state mutations.
-  - Released cross-repository link functionality to smoothly share and sync knowledge lessons across local projects.
-  - Shipped the Universal Baseline, providing 60 battle-tested lessons automatically during initialization scaffolding.
-  - Introduced the error class hierarchy equipped with actionable recovery hints for improved error state handling.
-  - Demoted three overly-aggressive AI-powered `totem shield` rules to warnings and explicitly prefixed error logs to reduce false positives.
-  - Fixed compiler generation of unsupported glob patterns, addressing brace expansion and nested constraints.
-  - Converted compilation top-level imports to dynamic imports to improve CLI startup performance.
-  - Executed a review blitz to address dynamic imports, warning callbacks, and AI-powered `totem shield` false positives.
-  - Configured initialization embedding detection to explicitly prioritize Gemini over OpenAI.
-  - Conducted a Rule Invariant Audit focusing heavily on execution determinism.
-  - Bumped CodeQL action to v4 to ensure up-to-date security scanning during CI.
-  - Automated the ingestion of cursor rules and prompt configurations directly during the initialization scaffolding phase.
-  - Optimized compilation performance by caching non-compilable lessons to skip redundant recompilation.
-  - Refined file path processing to strictly enforce specified directory boundaries, fixing broad execution overreaches.
-  - Delivered Organizational Trap Ledger (Phase 1) featuring tracking extensions and enhanced statistics.
-  - Extracted shared execution logic to unify deterministic `totem lint` and AI-powered `totem shield`. Extended standard format support to deterministic linting.
-  - Introduced severity levels (error vs warning) for AI-powered `totem shield` reviews.
-  - Ingested existing agent configuration files into compiled rules. Completed an expanded audit of 137 rules categorized by invariant, style, and security.
-  - Validated extracted lessons strictly prior to disk writes and integrated core metrics into local tracking.
-  - Delivered compiled rule testing harness to provide empirical rule failure data.
-  - Shipped standard format output tracking, enabling external security scanning integration.
-  - Split deterministic `totem lint` from AI-powered `totem shield` and scoped rules to accurate file boundaries to minimize false positives.
-  - Scoped the dynamic-import AI shield rule explicitly to command files to reduce false positives.
-  - Delivered Semantic Rule Observability (Phase 1) to enhance rule telemetry and tracking.
-  - Researched involuntary enforcement strategy paths.
-  - Completed a bug blitz addressing AST gate file reading, glob matching, and orchestrator process leaks.
-  - Reinstated agent hooks and audited suppressions.
-  - Applied recency patterns to agent instruction files and enforced length limits.
-  - Delivered Universal Lessons baseline and refined ignore patterns for frictionless initialization.
-  - Tuned matching patterns and literal file path rules to reduce false positives on docs and config lessons.
-- **Orchestration & Integrations:**
-  - Added Data Loss Prevention (DLP) secret masking middleware for outbound LLM calls.
-  - Implemented invisible sync hooks for smooth orchestration context updates.
-  - Integrated CodeRabbit configuration for automated PR reviews.
-  - Expanded the post-compaction hook with a capability manifest to enhance agent context during active work.
-  - Refactored agent instruction files to utilize a lean root router pattern.
-  - Added a boundary parameter to the search tool to enhance context scoping and extracted corresponding operational lessons.
-  - Delivered workflow automation enhancements, restructuring skills into a dedicated directory format and removing stale commands.
-  - Refined agent hooks by enforcing pre-push validation via pre-tool-use hooks and correcting post-compaction formatting.
-  - Updated reference hooks to utilize deterministic `totem lint` instead of AI-powered `totem shield` for rapid, predictable pre-push validation.
-  - Integrated Claude Code hooks for preflight specification and AI-powered `totem shield` pre-push validation.
-  - Implemented tools that equip agents to self-correct during active work.
-  - Integrated health checks with initial query gates and resolved race conditions in lesson debouncing.
-  - Added search logging and resolved Gemini embedder dimension mismatches.
-  - Resolved auto-handoff on lifecycle events, integrated JetBrains Junie, and fixed connection failures and zombie processes.
-  - Fixed environment loading quote stripping and corrected default Gemini model configuration schemas.
-  - Shipped graceful degradation for orchestrator providers with SDK-to-CLI fallback capabilities.
-  - Configured issue sources to support triage and extraction across multiple repositories.
-  - Added Copilot and Junie to initialization scaffolding and corrected health check CLI flags.
-  - Resolved server connection failures for development and strategy environments.
-  - Validated Gemini CLI compliance regarding search calls with lean configurations.
-- **Documentation & DX:**
-  - Extracted and integrated new enforcement lessons from recent codebase quality sweeps.
-  - Required explicit confirmation before writing LLM-generated documentation.
-  - Configured documentation generation to actively strip marketing terminology.
-  - Regenerated post-1.3.17 README and performed 47-lesson extraction.
-  - Fixed documentation generation to prevent persistence of stale issue references.
-  - Executed Developer Experience (DX) polish to streamline onboarding flows, hide legacy commands, and condense standard output.
-  - Regenerated project documentation to integrate launch metrics and reflect the latest context.
-  - Updated the README to prominently feature the new 60-lesson Universal Baseline shipped alongside initialization.
-  - Added a dedicated Scope & Limitations section to the architecture documentation.
-  - Finalized product tagline positioning and updated the core document framework.
-  - Finalized the full documentation rewrite, positioning the tool according to the established framework.
-  - Hardened documentation generation against hallucinations by actively stripping known-not-shipped issue references from its context.
-  - Migrated README to a dev wiki covering environments, testing, releases, and CLI guides.
-  - Executed a multi-agent code review blitz and refreshed stale prompts for initialization and documentation glossaries.
-  - Updated the README to explicitly highlight the air-gapped security doctrine.
-  - Updated the styleguide to proactively suppress recurring review nits.
-  - Established an Agent Memory Architecture guide and documented the consumer scaffolding pipeline.
-  - Released consumer playground and a multi-project knowledge domains index repository.
-  - Standardized CLI help output and expanded compiled rules with telemetry fields.
-  - Completed post-release documentation sync, introduced new lessons, and closed stale tickets.
-  - Audited all suppression directives and corrected stale lesson references across documentation.
-
-<!-- No blocked items. Prior tickets were closed or superseded. Do not re-add. -->
+<!-- No blocked items except #959 (Phase 4), which depends on Phases 2-3. -->

--- a/packages/cli/src/commands/shield-templates.ts
+++ b/packages/cli/src/commands/shield-templates.ts
@@ -10,6 +10,8 @@ export const MAX_SPEC_RESULTS = 3;
 export const MAX_LESSONS = 10;
 export const MAX_SESSION_RESULTS = 5;
 export const MAX_CODE_RESULTS = 5;
+export const MAX_FILE_CONTEXT_CHARS = 20_000;
+export const MAX_FILE_LINES = 300;
 
 // ─── Zod schemas (V2 structured output) ─────────────────
 
@@ -122,6 +124,7 @@ Do NOT include any text before or after the tags. No preamble, no closing remark
 - Use Totem knowledge when it directly applies (cite session/spec in the message).
 - If no issues found, return an empty findings array with a summary of what the diff does.
 - DO NOT emit findings about documentation, formatting, or non-code files.
+- If a FILE CONTEXT section is provided, use it to verify that referenced symbols (variables, parameters, imports) actually exist in the file before flagging them as undefined or unused.
 `;
 
 // ─── Structural system prompt ────────────────────────────
@@ -225,6 +228,7 @@ Do NOT include any text before or after the tags. No preamble, no closing remark
 - Only comment on code that is actually changing. Reference specific files and hunks.
 - If no issues found, return an empty findings array with a summary of what the diff does.
 - DO NOT emit findings about documentation, formatting, or non-code files.
+- If a FILE CONTEXT section is provided, use it to verify that referenced symbols (variables, parameters, imports) actually exist in the file before flagging them as undefined or unused.
 `;
 
 // ─── Shield Learn system prompt ──────────────────────

--- a/packages/cli/src/commands/shield.test.ts
+++ b/packages/cli/src/commands/shield.test.ts
@@ -10,6 +10,7 @@ import { cleanTmpDir } from '../test-utils.js';
 import {
   assemblePrompt,
   assembleStructuralPrompt,
+  buildFileContext,
   computeVerdict,
   extractStructuredVerdict,
   formatVerdictForDisplay,
@@ -634,6 +635,131 @@ describe('formatVerdictForDisplay', () => {
     const output = formatVerdictForDisplay(verdict, true);
     // Should have the finding line without any file path before the dash
     expect(output).toContain('INFO [0.5] — General observation');
+  });
+});
+
+// ─── buildFileContext ─────────────────────────────────
+
+describe('buildFileContext', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shield-ctx-'));
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  it('includes small files under the line limit', async () => {
+    const filePath = 'small-file.ts';
+    fs.writeFileSync(path.join(tmpDir, filePath), 'const x = 1;\nconst y = 2;\n');
+
+    const result = await buildFileContext([filePath], tmpDir, 300, 20000);
+    expect(result).toContain('FILE CONTEXT');
+    expect(result).toContain('const x = 1');
+  });
+
+  it('excludes files over the line limit', async () => {
+    const filePath = 'large-file.ts';
+    const lines = Array.from({ length: 500 }, (_, i) => `const x${i} = ${i};`).join('\n');
+    fs.writeFileSync(path.join(tmpDir, filePath), lines);
+
+    const result = await buildFileContext([filePath], tmpDir, 300, 20000);
+    expect(result).toBe('');
+  });
+
+  it('skips nonexistent files gracefully', async () => {
+    const result = await buildFileContext(['does-not-exist.ts'], tmpDir, 300, 20000);
+    expect(result).toBe('');
+  });
+
+  it('respects character budget', async () => {
+    for (let i = 0; i < 5; i++) {
+      fs.writeFileSync(path.join(tmpDir, `file${i}.ts`), 'x'.repeat(100) + '\n');
+    }
+
+    const result = await buildFileContext(
+      ['file0.ts', 'file1.ts', 'file2.ts', 'file3.ts', 'file4.ts'],
+      tmpDir,
+      300,
+      250,
+    );
+    expect(result.length).toBeLessThan(500);
+  });
+
+  it('returns empty string when no files qualify', async () => {
+    const result = await buildFileContext([], tmpDir, 300, 20000);
+    expect(result).toBe('');
+  });
+
+  it('skips non-code files', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'readme.md'), '# Hello\n');
+    const result = await buildFileContext(['readme.md'], tmpDir, 300, 20000);
+    expect(result).toBe('');
+  });
+});
+
+// ─── assemblePrompt with fileContext ─────────────────
+
+describe('assemblePrompt fileContext integration', () => {
+  const sampleDiff = 'diff --git a/foo.ts b/foo.ts\n+const x = 1;\n';
+  const changedFiles = ['foo.ts'];
+  const emptyContext = { specs: [], sessions: [], code: [], lessons: [] };
+
+  it('includes file context in assembled prompt', () => {
+    const fc =
+      '\n=== FILE CONTEXT (unchanged code for reference) ===\n--- foo.ts ---\nconst x = 1;\n';
+    const prompt = assemblePrompt(sampleDiff, changedFiles, emptyContext, 'SYS', undefined, fc);
+    expect(prompt).toContain('FILE CONTEXT');
+    expect(prompt).toContain('unchanged code for reference');
+  });
+
+  it('omits file context when empty', () => {
+    const prompt = assemblePrompt(sampleDiff, changedFiles, emptyContext, 'SYS', undefined, '');
+    expect(prompt).not.toContain('FILE CONTEXT');
+  });
+});
+
+describe('assembleStructuralPrompt fileContext integration', () => {
+  const sampleDiff = 'diff --git a/foo.ts b/foo.ts\n+const x = 1;\n';
+  const changedFiles = ['foo.ts'];
+
+  it('includes file context in structural prompt', () => {
+    const fc =
+      '\n=== FILE CONTEXT (unchanged code for reference) ===\n--- foo.ts ---\nconst x = 1;\n';
+    const prompt = assembleStructuralPrompt(sampleDiff, changedFiles, 'SYS', undefined, fc);
+    expect(prompt).toContain('FILE CONTEXT');
+  });
+
+  it('omits file context when undefined', () => {
+    const prompt = assembleStructuralPrompt(sampleDiff, changedFiles, 'SYS');
+    expect(prompt).not.toContain('FILE CONTEXT');
+  });
+});
+
+// ─── shield override validation ──────────────────────
+
+describe('shield override validation', () => {
+  it('rejects override reason under 10 characters', async () => {
+    const { TotemConfigError } = await import('@mmnto/totem');
+    const reason = 'short';
+    expect(reason.length).toBeLessThan(10);
+    // Mirrors the validation in shieldCommand
+    expect(() => {
+      if (reason.length < 10) {
+        throw new TotemConfigError(
+          `--override reason must be at least 10 characters (got ${reason.length}).`,
+          'Provide a meaningful justification',
+          'CONFIG_INVALID',
+        );
+      }
+    }).toThrow(/at least 10 characters/);
+  });
+
+  it('accepts override reason of 10+ characters', () => {
+    const reason = 'False positive: onWarn is defined at line 273';
+    expect(reason.length).toBeGreaterThanOrEqual(10);
   });
 });
 

--- a/packages/cli/src/commands/shield.ts
+++ b/packages/cli/src/commands/shield.ts
@@ -18,6 +18,8 @@ import {
 import {
   MAX_CODE_RESULTS,
   MAX_DIFF_CHARS,
+  MAX_FILE_CONTEXT_CHARS,
+  MAX_FILE_LINES,
   MAX_LESSONS,
   MAX_SESSION_RESULTS,
   MAX_SPEC_RESULTS,
@@ -70,6 +72,57 @@ async function buildSearchQuery(changedFiles: string[], diff: string): Promise<s
   return `${fileNames} ${diffSnippet}`.trim();
 }
 
+// ─── File context for false-positive reduction ──────────
+
+export async function buildFileContext(
+  changedFiles: string[],
+  cwd: string,
+  maxLines: number,
+  maxChars: number,
+): Promise<string> {
+  const fs = await import('node:fs');
+  const path = await import('node:path');
+  const { classifyFile } = await import('./shield-classify.js');
+
+  const entries: string[] = [];
+  let totalChars = 0;
+
+  for (const file of changedFiles) {
+    if (totalChars >= maxChars) break;
+
+    // Skip non-code files
+    if (classifyFile(file) === 'NON_CODE') continue;
+
+    const fullPath = path.join(cwd, file);
+
+    // Skip deleted files
+    if (!fs.existsSync(fullPath)) continue;
+
+    let content: string;
+    try {
+      content = fs.readFileSync(fullPath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    // Skip binary files (null byte check)
+    if (content.includes('\0')) continue;
+
+    // Skip large files
+    const lines = content.split('\n');
+    if (lines.length > maxLines) continue;
+
+    const entry = `--- ${file} ---\n${content}`;
+    if (totalChars + entry.length > maxChars) continue;
+
+    entries.push(entry);
+    totalChars += entry.length;
+  }
+
+  if (entries.length === 0) return '';
+  return `\n=== FILE CONTEXT (unchanged code for reference) ===\n${entries.join('\n\n')}`;
+}
+
 // ─── Prompt assembly ────────────────────────────────────
 
 export function assemblePrompt(
@@ -78,6 +131,7 @@ export function assemblePrompt(
   context: RetrievedContext,
   systemPrompt: string,
   smartHints?: string[],
+  fileContext?: string,
 ): string {
   const sections: string[] = [systemPrompt];
 
@@ -94,6 +148,11 @@ export function assemblePrompt(
     );
   } else {
     sections.push(wrapXml('git_diff', diff));
+  }
+
+  // File context — full source for small changed files
+  if (fileContext) {
+    sections.push(fileContext);
   }
 
   // Totem knowledge
@@ -136,6 +195,7 @@ export function assembleStructuralPrompt(
   changedFiles: string[],
   systemPrompt: string,
   smartHints?: string[],
+  fileContext?: string,
 ): string {
   const sections: string[] = [systemPrompt];
 
@@ -153,6 +213,11 @@ export function assembleStructuralPrompt(
     );
   } else {
     sections.push(wrapXml('git_diff', diff));
+  }
+
+  // File context — full source for small changed files
+  if (fileContext) {
+    sections.push(fileContext);
   }
 
   // Smart review hints — auto-detected context to reduce false positives
@@ -338,6 +403,7 @@ export interface ShieldOptions {
   mode?: 'standard' | 'structural';
   learn?: boolean;
   yes?: boolean;
+  override?: string;
 }
 
 // ─── Deterministic mode (delegates to shared engine) ─
@@ -512,6 +578,32 @@ async function handleVerdictResult(
 
     if (verdict.pass) {
       await writeShieldPassedFlag(cwd, config.totemDir, configRoot);
+    } else if (options.override) {
+      const { appendLedgerEvent } = await import('@mmnto/totem');
+      const pathMod = await import('node:path');
+      const resolvedTotemDir = pathMod.join(configRoot ?? cwd, config.totemDir);
+
+      log.warn(TAG, `SHIELD OVERRIDE APPLIED: ${options.override}`);
+      for (const finding of structured.findings.filter(
+        (f: { severity: string }) => f.severity === 'CRITICAL',
+      )) {
+        log.warn(TAG, `  [overridden] ${finding.message}`);
+      }
+
+      appendLedgerEvent(
+        resolvedTotemDir,
+        {
+          timestamp: new Date().toISOString(),
+          type: 'override',
+          ruleId: 'shield-override',
+          file: '(shield)',
+          justification: options.override,
+          source: 'shield',
+        },
+        (msg) => log.dim(TAG, msg),
+      );
+
+      await writeShieldPassedFlag(cwd, config.totemDir, configRoot);
     } else {
       if (options.learn) {
         await learnFromVerdict(
@@ -539,6 +631,27 @@ async function handleVerdictResult(
     const reason = verdict.reason ? ` — ${verdict.reason}` : '';
     log.info(TAG, `Verdict: ${verdictLabel}${reason}`);
     if (verdict.pass) {
+      await writeShieldPassedFlag(cwd, config.totemDir, configRoot);
+    } else if (options.override) {
+      const { appendLedgerEvent } = await import('@mmnto/totem');
+      const pathMod = await import('node:path');
+      const resolvedTotemDir = pathMod.join(configRoot ?? cwd, config.totemDir);
+
+      log.warn(TAG, `SHIELD OVERRIDE APPLIED: ${options.override}`);
+
+      appendLedgerEvent(
+        resolvedTotemDir,
+        {
+          timestamp: new Date().toISOString(),
+          type: 'override',
+          ruleId: 'shield-override',
+          file: '(shield)',
+          justification: options.override,
+          source: 'shield',
+        },
+        (msg) => log.dim(TAG, msg),
+      );
+
       await writeShieldPassedFlag(cwd, config.totemDir, configRoot);
     } else {
       if (options.learn) await learnFromVerdict(content, diff, options, config, cwd, configRoot);
@@ -570,6 +683,13 @@ export async function shieldCommand(options: ShieldOptions): Promise<void> {
     throw new TotemConfigError(
       `Invalid --mode "${options.mode}". Use "standard" or "structural".`,
       'Check `totem shield --help` for valid options.',
+      'CONFIG_INVALID',
+    );
+  }
+  if (options.override !== undefined && options.override.length < 10) {
+    throw new TotemConfigError(
+      `--override reason must be at least 10 characters (got ${options.override.length}).`,
+      'Provide a meaningful justification, e.g., --override "False positive: onWarn param visible at line 273"',
       'CONFIG_INVALID',
     );
   }
@@ -645,6 +765,17 @@ export async function shieldCommand(options: ShieldOptions): Promise<void> {
     log.dim(TAG, `${annotations.length} annotation(s) recorded in Trap Ledger`);
   }
 
+  // Build full-file context for small changed files (reduces false positives)
+  const fileContext = await buildFileContext(
+    filteredFiles.length > 0 ? filteredFiles : changedFiles,
+    cwd,
+    MAX_FILE_LINES,
+    MAX_FILE_CONTEXT_CHARS,
+  );
+  if (fileContext) {
+    log.dim(TAG, `File context: ${(fileContext.length / 1024).toFixed(0)}KB`);
+  }
+
   // Structural mode — context-blind LLM review, no embeddings, no Totem knowledge
   if (options.mode === 'structural') {
     log.info(TAG, 'Running structural review (context-blind, no Totem knowledge)...');
@@ -655,7 +786,13 @@ export async function shieldCommand(options: ShieldOptions): Promise<void> {
       cwd,
       config.totemDir,
     );
-    const prompt = assembleStructuralPrompt(filteredDiff, filteredFiles, systemPrompt, smartHints);
+    const prompt = assembleStructuralPrompt(
+      filteredDiff,
+      filteredFiles,
+      systemPrompt,
+      smartHints,
+      fileContext,
+    );
     log.dim(TAG, `Prompt: ${(prompt.length / 1024).toFixed(0)}KB`);
 
     const content = await runOrchestrator({
@@ -703,7 +840,14 @@ export async function shieldCommand(options: ShieldOptions): Promise<void> {
   const systemPrompt = getSystemPrompt('shield', SYSTEM_PROMPT_V2, cwd, config.totemDir);
 
   // Assemble prompt — use filtered diff/files for LLM review
-  const prompt = assemblePrompt(filteredDiff, filteredFiles, context, systemPrompt, smartHints);
+  const prompt = assemblePrompt(
+    filteredDiff,
+    filteredFiles,
+    context,
+    systemPrompt,
+    smartHints,
+    fileContext,
+  );
   log.dim(TAG, `Prompt: ${(prompt.length / 1024).toFixed(0)}KB`);
 
   const content = await runOrchestrator({

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -209,6 +209,10 @@ program
   )
   .option('--learn', 'Extract lessons from failed verdicts into .totem/lessons/')
   .option('--yes', 'Auto-accept extracted lessons (for CI; suspicious lessons are dropped)')
+  .option(
+    '--override <reason>',
+    'Override shield FAIL with a reason (min 10 chars, logged to trap ledger)',
+  )
   .action(
     async (opts: {
       raw?: boolean;
@@ -221,6 +225,7 @@ program
       mode?: string;
       learn?: boolean;
       yes?: boolean;
+      override?: string;
     }) => {
       try {
         // Redirect removed --deterministic flag to totem lint


### PR DESCRIPTION
## Summary
- **Context enrichment**: Include full file content for small changed files (<300 lines, 20KB budget) in the shield prompt, giving the LLM visibility into unchanged symbols (function signatures, imports) that diff hunks alone don't show
- **Override mechanism**: `--override <reason>` flag (min 10 chars) downgrades CRITICAL findings to warnings, logs to trap ledger, exits 0
- Updates `docs/active_work.md` with current 1.6.0 roadmap

Closes #992

## Files changed
- `packages/cli/src/commands/shield.ts` — `buildFileContext()`, `assemblePrompt()` signature, override logic in verdict processing
- `packages/cli/src/commands/shield-templates.ts` — `MAX_FILE_CONTEXT_CHARS`, `MAX_FILE_LINES` constants, system prompt update
- `packages/cli/src/index.ts` — `--override <reason>` option
- `packages/cli/src/commands/shield.test.ts` — 12 new tests
- `docs/active_work.md` — Rewritten with current state

## Test plan
- [x] 1,932 tests passing (12 new)
- [x] totem lint: 344 rules, 0 errors
- [x] totem shield: PASS (0 critical) — **shield used its own file context feature** (15KB)
- [x] format:check passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)