### PR TITLE
chore: release 1.5.11 — incremental shield, status/check, docs staleness

### DIFF
--- a/.changeset/release-1-5-11.md
+++ b/.changeset/release-1-5-11.md
@@ -1,0 +1,14 @@
+---
+'@mmnto/cli': patch
+'@mmnto/totem': patch
+'@mmnto/mcp': patch
+---
+
+Incremental shield, totem status/check, docs staleness fix.
+
+- feat: incremental shield validation — delta-only re-check for small fixes (#1010)
+- feat: totem status + totem check commands (#951)
+- fix: totem docs staleness — aggressive rewrite of stale roadmap sections (#1024)
+- fix: mermaid lexer error in architecture diagram
+- chore: MCP add_lesson rate limit bumped to 25 per session
+- chore: 364 compiled rules, 966 lessons, 2,000 tests

--- a/.totem/compile-manifest.json
+++ b/.totem/compile-manifest.json
@@ -1,7 +1,7 @@
 {
-  "compiled_at": "2026-03-27T22:52:46.613Z",
+  "compiled_at": "2026-03-28T00:26:17.587Z",
   "model": "gemini-3-flash-preview",
-  "input_hash": "37a5ef86ca630c1d842f207692fbc285ab170f80debffed9f2aea191fe45462c",
-  "output_hash": "5bd110d746f91b962f14a3f774c110f5c85c6430292059e7a28c4b855677e0d8",
-  "rule_count": 357
+  "input_hash": "4588346d0798eece2ffe39b02e48461a9ef70f892aac09d5c282a35b42f19505",
+  "output_hash": "949bff1108e3a9cfcbc8445904f0b922ce6aff68125f027be66798b9efb0979b",
+  "rule_count": 364
 }

--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -5764,6 +5764,137 @@
         "packages/website/**/*.html"
       ],
       "severity": "warning"
+    },
+    {
+      "lessonHash": "78950a5239894249",
+      "lessonHeading": "Shared documentation and lessons should use portable",
+      "message": "Use portable commands like 'git rev-parse --show-toplevel' instead of hardcoded local file paths (e.g., /Users/..., /home/..., C:\\Users\\...).",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "(/Users/|/home/|[a-zA-Z]:\\\\Users\\\\)",
+      "compiledAt": "2026-03-28T00:21:11.118Z",
+      "createdAt": "2026-03-28T00:21:11.118Z",
+      "fileGlobs": [
+        "**/*.md",
+        "**/*.txt",
+        "**/*.markdown",
+        "**/*.lesson"
+      ]
+    },
+    {
+      "lessonHash": "a6aea3c165ceffde",
+      "lessonHeading": "Even when data is missing, wrap the fallback instructions",
+      "message": "Wrap fallback instructions or 'no context' notes in XML tags (e.g., <context_note>) to maintain a consistent schema for the LLM and reduce parsing ambiguity.",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "['\"](?!\\s*<)(?:No context|No data|No results|Information not found)",
+      "compiledAt": "2026-03-28T00:21:02.960Z",
+      "createdAt": "2026-03-28T00:21:02.960Z",
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.py",
+        "**/*.js",
+        "**/*.jsx",
+        "!**/*.test.ts",
+        "!**/*.test.js"
+      ]
+    },
+    {
+      "lessonHash": "09ee37252a814a09",
+      "lessonHeading": "Git commands used for programmatic parsing should be",
+      "message": "Git commands used for programmatic parsing should be prefixed with LC_ALL=C to ensure consistent, locale-independent output.",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "^(?!.*\\bLC_ALL=C.*\\bgit).*\\bgit\\s+(status|branch|log|diff|show|rev-parse|rev-list|ls-files|tag|describe|remote|config)\\b",
+      "compiledAt": "2026-03-28T00:22:51.687Z",
+      "createdAt": "2026-03-28T00:22:51.687Z",
+      "fileGlobs": [
+        "**/*.sh",
+        "**/*.bash",
+        "**/*.zsh",
+        "**/*.js",
+        "**/*.ts",
+        "**/*.py",
+        "**/*.yml",
+        "**/*.yaml"
+      ]
+    },
+    {
+      "lessonHash": "00c562ec01f93496",
+      "lessonHeading": "Wrap fallback instructions or meta-context in XML tags",
+      "message": "Wrap fallback instructions or meta-context in XML tags (e.g., <context_note>) to maintain structural consistency and reduce LLM ambiguity.",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "\\b(fallback|instructions?|meta[Cc]ontext|meta_context|meta-context)\\b\\s*[:=]\\s*['\"\\x60](?!\\s*<)",
+      "compiledAt": "2026-03-28T00:24:27.776Z",
+      "createdAt": "2026-03-28T00:24:27.776Z",
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.js",
+        "**/*.jsx",
+        "**/*.py",
+        "**/*.yaml",
+        "**/*.yml",
+        "!**/*.test.ts",
+        "!**/*.test.js",
+        "!**/*.spec.ts",
+        "!**/*.spec.js"
+      ]
+    },
+    {
+      "lessonHash": "b3e3e2b380a0b1be",
+      "lessonHeading": "Git output can vary by system locale, causing parsing logic",
+      "message": "Git output can vary by system locale; use 'LC_ALL=C git ...' to ensure consistent output format for parsing.",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "^(?!.*LC_ALL=C).*\\bgit\\s+(status|log|branch|diff|show|rev-parse|describe|tag|ls-files|remote)\\b",
+      "compiledAt": "2026-03-28T00:24:23.439Z",
+      "createdAt": "2026-03-28T00:24:23.439Z",
+      "fileGlobs": [
+        "**/*.sh",
+        "**/*.bash",
+        "**/*.yml",
+        "**/*.yaml",
+        "**/*.ts",
+        "**/*.js"
+      ]
+    },
+    {
+      "lessonHash": "22286088db9261b7",
+      "lessonHeading": "Hardcoding specific filenames like active_work.md",
+      "message": "Hardcoding 'active_work.md' limits flexibility; use configuration flags to define document targets.",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "active_work\\.md",
+      "compiledAt": "2026-03-28T00:24:47.706Z",
+      "createdAt": "2026-03-28T00:24:47.706Z",
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.py",
+        "**/*.go",
+        "!**/*.md"
+      ]
+    },
+    {
+      "lessonHash": "46da33204d5c663b",
+      "lessonHeading": "Git output parsing should account for localized strings",
+      "message": "Git output parsing should account for localized strings and special characters. Use --porcelain, --format, or -z for stable, machine-readable output.",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "\\bgit\\s+(status|branch|log|ls-files)\\b(?![^\"']*(--porcelain|--format|-z))",
+      "compiledAt": "2026-03-28T00:25:41.505Z",
+      "createdAt": "2026-03-28T00:25:41.505Z",
+      "fileGlobs": [
+        "**/*.ts",
+        "**/*.js",
+        "**/*.py",
+        "**/*.sh",
+        "**/*.bash",
+        "**/*.go"
+      ]
     }
   ],
   "nonCompilable": [
@@ -6352,6 +6483,25 @@
     "57e17f41422fa06c",
     "4c4bbb2c2adff887",
     "486a977cffc2714a",
-    "bc9d15fcc81e4641"
+    "bc9d15fcc81e4641",
+    "a1765b40647a004b",
+    "820cd0fea3e2ddd0",
+    "18fc834ab4100934",
+    "b7ce61eade36b111",
+    "9ba2353289ac32c2",
+    "de82a755b405ec23",
+    "bb8adbb0227798ca",
+    "daa7bc396597da5b",
+    "f4ad1455da1c2926",
+    "0d8a21dfb3096079",
+    "47c298e42782da0c",
+    "20f8d3f8f990b70f",
+    "2b93c12f23f38863",
+    "d9100b79110ace93",
+    "1558cf7daff10c10",
+    "c19ec3301c41979a",
+    "2e33398cc490aff2",
+    "cc4dbe96eb163590",
+    "1fabf989332b2192"
   ]
 }

--- a/.totem/lessons/lesson-10bc7d30.md
+++ b/.totem/lessons/lesson-10bc7d30.md
@@ -1,0 +1,5 @@
+## Lesson — Shared documentation and lessons should use portable
+
+**Tags:** documentation, dx
+
+Shared documentation and lessons should use portable commands like 'git rev-parse --show-toplevel' instead of hardcoded local file paths to ensure instructions work for all contributors.

--- a/.totem/lessons/lesson-117be5de.md
+++ b/.totem/lessons/lesson-117be5de.md
@@ -1,0 +1,5 @@
+## Lesson — Even when data is missing, wrap the fallback instructions
+
+**Tags:** prompt-engineering, llm, structure
+
+Even when data is missing, wrap the fallback instructions or 'no context' notes in XML tags (e.g., <context_note>) to maintain a consistent schema for the LLM and reduce parsing ambiguity.

--- a/.totem/lessons/lesson-1af10ec5.md
+++ b/.totem/lessons/lesson-1af10ec5.md
@@ -1,0 +1,5 @@
+## Lesson — High-level system prompt rules must strictly align
+
+**Tags:** llm, dx, prompt-engineering
+
+High-level system prompt rules must strictly align with the logic used in prompt assembly to prevent the LLM from receiving contradictory or confusing instructions.

--- a/.totem/lessons/lesson-1beaaf91.md
+++ b/.totem/lessons/lesson-1beaaf91.md
@@ -1,0 +1,5 @@
+## Lesson — Treat active work context as the ground truth for roadmaps,
+
+**Tags:** llm, documentation
+
+Treat active work context as the ground truth for roadmaps, aggressively pruning items not present in the current context to prevent documentation rot.

--- a/.totem/lessons/lesson-2b3b26cb.md
+++ b/.totem/lessons/lesson-2b3b26cb.md
@@ -1,0 +1,5 @@
+## Lesson — High-level system prompt rules must precisely match
+
+**Tags:** prompt-engineering, reliability
+
+High-level system prompt rules must precisely match the specific instructions injected by the code during prompt assembly to avoid providing the LLM with conflicting behavioral guidance.

--- a/.totem/lessons/lesson-411c5a4f.md
+++ b/.totem/lessons/lesson-411c5a4f.md
@@ -1,0 +1,5 @@
+## Lesson — Implement a 'Staleness Protocol' where the active work
+
+**Tags:** prompt-engineering, documentation
+
+Implement a 'Staleness Protocol' where the active work context is the absolute authority for roadmaps; items not present in the context should be aggressively removed or marked completed to prevent documentation rot.

--- a/.totem/lessons/lesson-429edee0.md
+++ b/.totem/lessons/lesson-429edee0.md
@@ -1,0 +1,5 @@
+## Lesson — Incremental validation is only reliable if the current head
+
+**Tags:** git, security, architecture
+
+Incremental validation is only reliable if the current head is a direct descendant of a previously verified commit. This prevents logic gaps and security bypasses when switching between unrelated branches or working with non-linear history.

--- a/.totem/lessons/lesson-503222e9.md
+++ b/.totem/lessons/lesson-503222e9.md
@@ -1,0 +1,5 @@
+## Lesson — When active work context is unavailable, documentation
+
+**Tags:** documentation, resilience
+
+When active work context is unavailable, documentation tools should append staleness warnings to existing roadmap sections rather than deleting them to handle missing initialization data gracefully.

--- a/.totem/lessons/lesson-63aa9504.md
+++ b/.totem/lessons/lesson-63aa9504.md
@@ -1,0 +1,5 @@
+## Lesson — Optimization paths that process file deltas must still
+
+**Tags:** git, cli, logic
+
+Optimization paths that process file deltas must still apply the project's ignore patterns to avoid analyzing sensitive or irrelevant files like lockfiles. Bypassing these filters during incremental reviews can lead to false positives or processing of vendored code.

--- a/.totem/lessons/lesson-67a69e22.md
+++ b/.totem/lessons/lesson-67a69e22.md
@@ -1,0 +1,5 @@
+## Lesson — Decoupling fast, deterministic state readers from slower
+
+**Tags:** architecture, cli, performance
+
+Decoupling fast, deterministic state readers from slower validation wrappers improves CLI responsiveness. This allows users to verify system state without triggering expensive linting or LLM processes.

--- a/.totem/lessons/lesson-6ab2f937.md
+++ b/.totem/lessons/lesson-6ab2f937.md
@@ -1,0 +1,5 @@
+## Lesson — Git commands used for programmatic parsing should be
+
+**Tags:** git, i18n, parsing
+
+Git commands used for programmatic parsing should be prefixed with `LC_ALL=C` to ensure consistent, locale-independent output. This prevents parsing failures when the user's environment uses a non-English language.

--- a/.totem/lessons/lesson-7f003e71.md
+++ b/.totem/lessons/lesson-7f003e71.md
@@ -1,0 +1,5 @@
+## Lesson — Incremental logic must apply the same ignore patterns
+
+**Tags:** architecture, git, performance
+
+Incremental logic must apply the same ignore patterns as full-scan paths to prevent processing excluded files like lockfiles or vendored code. This ensures consistency between fast-path and standard review cycles.

--- a/.totem/lessons/lesson-92f6e8e4.md
+++ b/.totem/lessons/lesson-92f6e8e4.md
@@ -1,0 +1,5 @@
+## Lesson — Wrap fallback instructions or meta-commentary in XML tags
+
+**Tags:** llm, prompt-engineering, xml
+
+Wrap fallback instructions or meta-commentary in XML tags like <context_note> to maintain structural consistency with other data blocks and reduce LLM parsing ambiguity.

--- a/.totem/lessons/lesson-9bd1e54f.md
+++ b/.totem/lessons/lesson-9bd1e54f.md
@@ -1,0 +1,5 @@
+## Lesson — When a required context source is empty, use a safety
+
+**Tags:** llm, resilience, documentation
+
+When a required context source is empty, use a safety fallback that preserves existing data with a staleness warning rather than performing destructive deletions.

--- a/.totem/lessons/lesson-9d049935.md
+++ b/.totem/lessons/lesson-9d049935.md
@@ -1,0 +1,5 @@
+## Lesson — Wrap fallback instructions or meta-context in XML tags
+
+**Tags:** llm, prompt-engineering
+
+Wrap fallback instructions or meta-context in XML tags like `<context_note>` to maintain structural consistency and reduce LLM ambiguity when mixing data and instructions.

--- a/.totem/lessons/lesson-a1bdf4e9.md
+++ b/.totem/lessons/lesson-a1bdf4e9.md
@@ -1,0 +1,5 @@
+## Lesson — Incremental validation must confirm the previous commit
+
+**Tags:** git, validation, performance
+
+Incremental validation must confirm the previous commit is a direct ancestor before evaluating deltas. This prevents applying partial reviews to divergent branches where the base state is unverified.

--- a/.totem/lessons/lesson-ae6be998.md
+++ b/.totem/lessons/lesson-ae6be998.md
@@ -1,0 +1,5 @@
+## Lesson — Git output can vary by system locale, causing parsing logic
+
+**Tags:** git, i18n, parsing
+
+Git output can vary by system locale, causing parsing logic to fail. Forcing a neutral locale like `LC_ALL=C` ensures consistent output format across different environments.

--- a/.totem/lessons/lesson-c36f141a.md
+++ b/.totem/lessons/lesson-c36f141a.md
@@ -1,0 +1,5 @@
+## Lesson — Treat active work context as the absolute ground truth
+
+**Tags:** llm, documentation, prompt-engineering
+
+Treat active work context as the absolute ground truth for forward-looking sections; if an item is missing from the context, it should be aggressively rewritten as completed or removed.

--- a/.totem/lessons/lesson-c644161b.md
+++ b/.totem/lessons/lesson-c644161b.md
@@ -1,0 +1,5 @@
+## Lesson — When required context is missing, instruct the LLM
+
+**Tags:** llm, resilience
+
+When required context is missing, instruct the LLM to preserve existing data with a staleness note rather than deleting it to ensure resilience against missing files.

--- a/.totem/lessons/lesson-c9f8d0f7.md
+++ b/.totem/lessons/lesson-c9f8d0f7.md
@@ -1,0 +1,5 @@
+## Lesson — Performance-optimized paths that analyze diff deltas
+
+**Tags:** architecture, git
+
+Performance-optimized paths that analyze diff deltas must still apply global ignore patterns to prevent the inadvertent processing of excluded files like lockfiles.

--- a/.totem/lessons/lesson-daf7210c.md
+++ b/.totem/lessons/lesson-daf7210c.md
@@ -1,0 +1,5 @@
+## Lesson — Hardcoding specific filenames like active_work.md
+
+**Tags:** architecture, clean-code, configuration
+
+Hardcoding specific filenames like active_work.md in document-processing logic limits flexibility; use configuration flags to define behavior for different document targets.

--- a/.totem/lessons/lesson-de8d34f8.md
+++ b/.totem/lessons/lesson-de8d34f8.md
@@ -1,0 +1,5 @@
+## Lesson — README files and curated wiki pages must be human-authored
+
+**Tags:** documentation, policy, llm
+
+README files and curated wiki pages must be human-authored to ensure accuracy and maintain a high-quality source of truth. LLM-generated prose in these files can introduce subtle hallucinations that mislead contributors.

--- a/.totem/lessons/lesson-df57b94f.md
+++ b/.totem/lessons/lesson-df57b94f.md
@@ -1,0 +1,5 @@
+## Lesson — Git output parsing should account for localized strings
+
+**Tags:** git, cli
+
+Git output parsing should account for localized strings and special characters in filenames to ensure the tool remains reliable across different developer environments.

--- a/.totem/lessons/lesson-e05a8c28.md
+++ b/.totem/lessons/lesson-e05a8c28.md
@@ -1,0 +1,5 @@
+## Lesson — The project has transitioned from a 5-tier product model
+
+**Tags:** architecture, strategy
+
+The project has transitioned from a 5-tier product model to a 3-tier capability model (Lite, Standard, Full), which defines the official architectural and feature boundaries.

--- a/.totem/lessons/lesson-eb315e66.md
+++ b/.totem/lessons/lesson-eb315e66.md
@@ -1,0 +1,5 @@
+## Lesson — Limiting incremental validation to small modifications (<
+
+**Tags:** performance, validation, shield
+
+Limiting incremental validation to small modifications (< 15 lines) prevents the loss of necessary context. This maintains review quality while optimizing for minor changes.

--- a/.totem/lessons/lesson-f1798d12.md
+++ b/.totem/lessons/lesson-f1798d12.md
@@ -1,0 +1,5 @@
+## Lesson — Limiting incremental fast-paths to small changes (e.g., <
+
+**Tags:** llm, architecture, performance
+
+Limiting incremental fast-paths to small changes (e.g., < 15 lines) ensures the model maintains high precision without losing context. Larger changes or new files should trigger a full-context review to catch cross-functional regressions.


### PR DESCRIPTION
## Summary
Release 1.5.11 bundles:

- **#1010**: Incremental shield validation (delta-only re-check)
- **#951**: `totem status` + `totem check` commands
- **#1024**: Docs staleness fix (aggressive rewrite of stale sections)
- MCP rate limit bumped to 25/session
- Mermaid lexer fix in architecture diagram
- 9 lessons extracted from PRs #1032 + #1036
- 364 compiled rules, 966 lessons, 2,000 tests

## Test plan
- [x] 2,000 tests passing
- [x] `totem lint`: PASS (364 rules, 0 errors)
- [x] `pnpm run format:check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)