### PR TITLE
chore: release 1.6.1 — Pipeline DX

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @mmnto/cli
 
+## 1.6.1
+
+### Patch Changes
+
+- fix: pipeline fixes, compiler DX improvements, and shield auto-refresh
+  - Shield flag auto-refresh on pre-push — no more stale flag after every commit (#1045)
+  - Bot source enum in LedgerEvent for accurate exemption tracking (#1048)
+  - Thread context propagation for reliable PR comment replies (#1051)
+  - Shield false positive fix on synchronous adapter methods (#1058)
+  - Compiler transparency — `totem compile --verbose` shows why lessons are skipped (#1060)
+  - Zero-match rule detection in lint output (#1061)
+  - Compile-time validation for ast-grep patterns (#1062)
+  - Hardened hook upgrade tests (#1068)
+
+- Updated dependencies
+  - @mmnto/totem@1.6.1
+
 ## 1.6.0
 
 ### Minor Changes

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmnto/cli",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "CLI for Totem — AI persistent memory and context layer",
   "type": "module",
   "bin": {

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,19 @@
 # @mmnto/totem
 
+## 1.6.1
+
+### Patch Changes
+
+- fix: pipeline fixes, compiler DX improvements, and shield auto-refresh
+  - Shield flag auto-refresh on pre-push — no more stale flag after every commit (#1045)
+  - Bot source enum in LedgerEvent for accurate exemption tracking (#1048)
+  - Thread context propagation for reliable PR comment replies (#1051)
+  - Shield false positive fix on synchronous adapter methods (#1058)
+  - Compiler transparency — `totem compile --verbose` shows why lessons are skipped (#1060)
+  - Zero-match rule detection in lint output (#1061)
+  - Compile-time validation for ast-grep patterns (#1062)
+  - Hardened hook upgrade tests (#1068)
+
 ## 1.6.0
 
 ### Minor Changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmnto/totem",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Persistent memory and context layer for AI agents",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp/CHANGELOG.md
+++ b/packages/mcp/CHANGELOG.md
@@ -1,5 +1,22 @@
 # @mmnto/mcp
 
+## 1.6.1
+
+### Patch Changes
+
+- fix: pipeline fixes, compiler DX improvements, and shield auto-refresh
+  - Shield flag auto-refresh on pre-push — no more stale flag after every commit (#1045)
+  - Bot source enum in LedgerEvent for accurate exemption tracking (#1048)
+  - Thread context propagation for reliable PR comment replies (#1051)
+  - Shield false positive fix on synchronous adapter methods (#1058)
+  - Compiler transparency — `totem compile --verbose` shows why lessons are skipped (#1060)
+  - Zero-match rule detection in lint output (#1061)
+  - Compile-time validation for ast-grep patterns (#1062)
+  - Hardened hook upgrade tests (#1068)
+
+- Updated dependencies
+  - @mmnto/totem@1.6.1
+
 ## 1.6.0
 
 ### Minor Changes

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mmnto/mcp",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "MCP server for Totem — AI persistent memory and context layer",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
Version bump to 1.6.1 across all packages.

## What's in 1.6.1
- **#1045** — Shield flag auto-refresh on pre-push
- **#1048** — Bot source enum in LedgerEvent
- **#1051** — Thread context propagation for PR replies
- **#1058** — Shield false positive fix on sync adapter methods
- **#1060** — Compiler transparency (`--verbose` flag)
- **#1061** — Zero-match rule detection in lint output
- **#1062** — Compile-time ast-grep pattern validation
- **#1068** — Hardened hook upgrade tests

## Test plan
- [x] All tests pass
- [x] Lint pass — 379 rules, 0 violations
- [x] Changeset applied, versions bumped

🤖 Generated with [Claude Code](https://claude.com/claude-code)