### PR TITLE
feat: totem rule subcommands (list, inspect, test)

### DIFF
--- a/packages/cli/src/commands/rule.test.ts
+++ b/packages/cli/src/commands/rule.test.ts
@@ -1,0 +1,385 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { cleanTmpDir } from '../test-utils.js';
+
+// ─── Mock utils to bypass real config loading ───────────
+
+vi.mock('../utils.js', async () => {
+  const actual = await vi.importActual<typeof import('../utils.js')>('../utils.js');
+  return {
+    ...actual,
+    resolveConfigPath: (cwd: string) => path.join(cwd, 'totem.config.ts'),
+    loadConfig: async () => ({
+      targets: [],
+      totemDir: '.totem',
+      ignorePatterns: [],
+    }),
+  };
+});
+
+// ─── Helpers ────────────────────────────────────────────
+
+/** Strip ANSI escape codes for assertion matching. */
+function stripAnsi(str: string): string {
+  return str.replace(/\x1b\[[0-9;]*m/g, ''); // totem-context: ANSI regex — not user input
+}
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'totem-rule-'));
+}
+
+/** Write a minimal compiled-rules.json with the given rules. */
+function writeRules(totemDir: string, rules: Record<string, unknown>[]): void {
+  const rulesPath = path.join(totemDir, 'compiled-rules.json');
+  fs.writeFileSync(rulesPath, JSON.stringify({ version: 1, rules }), 'utf-8');
+}
+
+/** Scaffold a .totem directory with config, lessons dir, and optional rules. */
+function scaffold(cwd: string, rules?: Record<string, unknown>[]) {
+  const totemDir = path.join(cwd, '.totem');
+  const lessonsDir = path.join(totemDir, 'lessons');
+  fs.mkdirSync(lessonsDir, { recursive: true });
+  fs.writeFileSync(path.join(cwd, 'totem.config.ts'), 'export default {};', 'utf-8');
+
+  if (rules) {
+    writeRules(totemDir, rules);
+  }
+  return { totemDir, lessonsDir };
+}
+
+/**
+ * Compute the hash a rule would get after parseLessonsFile processes it.
+ * parseLessonsFile strips the **Tags:** line from the body before hashing,
+ * so we replicate that here to get a matching hash.
+ */
+async function computeLessonHash(heading: string, bodyAfterTags: string): Promise<string> {
+  const { hashLesson } = await import('@mmnto/totem');
+  return hashLesson(heading, bodyAfterTags);
+}
+
+const SAMPLE_RULES = [
+  {
+    lessonHash: 'abcd1234abcd1234',
+    lessonHeading: 'Always use strict equality',
+    pattern: '===?\\s',
+    message: 'Use === instead of ==',
+    engine: 'regex',
+    severity: 'error',
+    compiledAt: '2026-01-01T00:00:00.000Z',
+    createdAt: '2025-12-01T00:00:00.000Z',
+    fileGlobs: ['**/*.ts', '**/*.js'],
+  },
+  {
+    lessonHash: 'efgh5678efgh5678',
+    lessonHeading: 'Avoid console.log in production code that ships to users',
+    pattern: 'console\\.log',
+    message: 'Remove console.log statements',
+    engine: 'regex',
+    severity: 'warning',
+    compiledAt: '2026-01-02T00:00:00.000Z',
+    fileGlobs: ['**/*.ts'],
+  },
+  {
+    lessonHash: 'abcd9999abcd9999',
+    lessonHeading: 'No var declarations',
+    pattern: '\\bvar\\b',
+    message: 'Use const or let instead of var',
+    engine: 'regex',
+    severity: 'warning',
+    compiledAt: '2026-01-03T00:00:00.000Z',
+  },
+];
+
+// ─── Tests ──────────────────────────────────────────────
+
+describe('rule list', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    cleanTmpDir(tmpDir);
+    vi.restoreAllMocks();
+  });
+
+  it('outputs correct count and table format', async () => {
+    scaffold(tmpDir, SAMPLE_RULES);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { ruleListCommand } = await import('./rule.js');
+    await ruleListCommand();
+
+    const output = stripAnsi(consoleSpy.mock.calls.map((c) => String(c[0])).join('\n'));
+    expect(output).toContain('3 rule(s) total');
+    expect(output).toContain('abcd1234');
+    expect(output).toContain('efgh5678');
+    expect(output).toContain('regex');
+    expect(output).toContain('error');
+    expect(output).toContain('warning');
+  });
+
+  it('truncates long headings', async () => {
+    scaffold(tmpDir, [
+      {
+        ...SAMPLE_RULES[0],
+        lessonHeading:
+          'This is a very long heading that exceeds fifty characters and should be truncated properly',
+      },
+    ]);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { ruleListCommand } = await import('./rule.js');
+    await ruleListCommand();
+
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    // Should be truncated with ellipsis
+    expect(output).toContain('\u2026');
+    // Should NOT contain the full heading
+    expect(output).not.toContain('truncated properly');
+  });
+
+  it('shows error when no compiled-rules.json exists', async () => {
+    scaffold(tmpDir); // no rules
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { ruleListCommand } = await import('./rule.js');
+    await ruleListCommand();
+
+    const output = stripAnsi(consoleSpy.mock.calls.map((c) => String(c[0])).join('\n'));
+    expect(output).toContain('No compiled rules found');
+    expect(output).toContain('totem compile');
+  });
+});
+
+describe('rule inspect', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    cleanTmpDir(tmpDir);
+    vi.restoreAllMocks();
+  });
+
+  it('finds rule by full hash', async () => {
+    scaffold(tmpDir, SAMPLE_RULES);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { ruleInspectCommand } = await import('./rule.js');
+    await ruleInspectCommand('abcd1234abcd1234');
+
+    const output = stripAnsi(consoleSpy.mock.calls.map((c) => String(c[0])).join('\n'));
+    expect(output).toContain('abcd1234abcd1234');
+    expect(output).toContain('Always use strict equality');
+    expect(output).toContain('regex');
+    expect(output).toContain('error');
+    expect(output).toContain('**/*.ts');
+  });
+
+  it('finds rule by prefix', async () => {
+    scaffold(tmpDir, SAMPLE_RULES);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { ruleInspectCommand } = await import('./rule.js');
+    await ruleInspectCommand('efgh');
+
+    const output = stripAnsi(consoleSpy.mock.calls.map((c) => String(c[0])).join('\n'));
+    expect(output).toContain('efgh5678efgh5678');
+    expect(output).toContain('console.log');
+  });
+
+  it('errors on no match', async () => {
+    scaffold(tmpDir, SAMPLE_RULES);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { ruleInspectCommand } = await import('./rule.js');
+    await ruleInspectCommand('zzzz');
+
+    const output = stripAnsi(consoleSpy.mock.calls.map((c) => String(c[0])).join('\n'));
+    expect(output).toContain("No rule found matching 'zzzz'");
+  });
+
+  it('reports ambiguous prefix', async () => {
+    scaffold(tmpDir, SAMPLE_RULES);
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    // 'abcd' matches both abcd1234... and abcd9999...
+    const { ruleInspectCommand } = await import('./rule.js');
+    await ruleInspectCommand('abcd');
+
+    const output = stripAnsi(consoleSpy.mock.calls.map((c) => String(c[0])).join('\n'));
+    expect(output).toContain('Ambiguous prefix');
+    expect(output).toContain('abcd1234abcd1234');
+    expect(output).toContain('abcd9999abcd9999');
+  });
+});
+
+describe('rule test', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    cleanTmpDir(tmpDir);
+    vi.restoreAllMocks();
+  });
+
+  it('passes when examples match correctly', async () => {
+    const heading = 'Catch console log usage';
+    // Body as parseLessonsFile would produce it (tags stripped)
+    const bodyAfterTags = [
+      'Do not use console.log in production.',
+      '',
+      '**Pattern:** `console\\.log`',
+      '**Example Hit:** `console.log("debug")`',
+      '**Example Miss:** `logger.info("debug")`',
+    ].join('\n');
+
+    const realHash = await computeLessonHash(heading, bodyAfterTags);
+
+    const rule = {
+      lessonHash: realHash,
+      lessonHeading: heading,
+      pattern: 'console\\.log',
+      message: 'Remove console.log statements',
+      engine: 'regex' as const,
+      severity: 'error' as const,
+      compiledAt: '2026-01-01T00:00:00.000Z',
+    };
+
+    const { lessonsDir } = scaffold(tmpDir, [rule]);
+
+    // Write the lesson file — parseLessonsFile will extract heading and body
+    const lessonContent = [
+      `## Lesson \u2014 ${heading}`,
+      '',
+      '**Tags:** best-practice',
+      '',
+      bodyAfterTags,
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(lessonsDir, 'lesson-test.md'), lessonContent, 'utf-8');
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { ruleTestCommand } = await import('./rule.js');
+    await ruleTestCommand(realHash);
+
+    const output = stripAnsi(consoleSpy.mock.calls.map((c) => String(c[0])).join('\n'));
+    expect(output).toContain('PASS');
+  });
+
+  it('reports failure when examples do not match', async () => {
+    const heading = 'Catch console log';
+    const bodyAfterTags = [
+      'Remove console.log statements.',
+      '',
+      '**Pattern:** `console\\.log`',
+      '**Example Hit:** `console.log("test")`',
+      '**Example Miss:** `logger.info("test")`',
+    ].join('\n');
+
+    const realHash = await computeLessonHash(heading, bodyAfterTags);
+
+    // Deliberately wrong pattern so the example hit will NOT match
+    const rule = {
+      lessonHash: realHash,
+      lessonHeading: heading,
+      pattern: 'NOMATCH_PATTERN_XYZZY',
+      message: 'Remove console.log',
+      engine: 'regex' as const,
+      severity: 'warning' as const,
+      compiledAt: '2026-01-01T00:00:00.000Z',
+    };
+
+    const { lessonsDir } = scaffold(tmpDir, [rule]);
+
+    const lessonContent = [
+      `## Lesson \u2014 ${heading}`,
+      '',
+      '**Tags:** lint',
+      '',
+      bodyAfterTags,
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(lessonsDir, 'lesson-test.md'), lessonContent, 'utf-8');
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { ruleTestCommand } = await import('./rule.js');
+    await ruleTestCommand(realHash);
+
+    const output = stripAnsi(consoleSpy.mock.calls.map((c) => String(c[0])).join('\n'));
+    expect(output).toContain('FAIL');
+  });
+
+  it('reports when no examples exist in lesson', async () => {
+    const heading = 'No examples lesson';
+    const bodyAfterTags = 'This lesson has no Example Hit/Miss lines.';
+
+    const realHash = await computeLessonHash(heading, bodyAfterTags);
+
+    const rule = {
+      lessonHash: realHash,
+      lessonHeading: heading,
+      pattern: 'something',
+      message: 'Some rule',
+      engine: 'regex' as const,
+      severity: 'warning' as const,
+      compiledAt: '2026-01-01T00:00:00.000Z',
+    };
+
+    const { lessonsDir } = scaffold(tmpDir, [rule]);
+
+    const lessonContent = [
+      `## Lesson \u2014 ${heading}`,
+      '',
+      '**Tags:** misc',
+      '',
+      bodyAfterTags,
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(lessonsDir, 'lesson-test.md'), lessonContent, 'utf-8');
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { ruleTestCommand } = await import('./rule.js');
+    await ruleTestCommand(realHash);
+
+    const output = stripAnsi(consoleSpy.mock.calls.map((c) => String(c[0])).join('\n'));
+    expect(output).toContain('No Example Hit/Miss');
+  });
+
+  it('shows error when no compiled-rules.json exists', async () => {
+    scaffold(tmpDir); // no rules
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { ruleTestCommand } = await import('./rule.js');
+    await ruleTestCommand('abcd');
+
+    const output = stripAnsi(consoleSpy.mock.calls.map((c) => String(c[0])).join('\n'));
+    expect(output).toContain('No compiled rules found');
+  });
+});

--- a/packages/cli/src/commands/rule.ts
+++ b/packages/cli/src/commands/rule.ts
@@ -1,0 +1,205 @@
+import type { CompiledRule } from '@mmnto/totem';
+
+const TAG = 'Rule';
+
+// ─── Helpers ───────────────────────────────────────────
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? text.slice(0, max - 1) + '\u2026' : text;
+}
+
+/**
+ * Resolve the rules path and load rules, with a user-friendly error
+ * when no compiled-rules.json exists.
+ */
+async function loadRulesOrExit(): Promise<{
+  rules: CompiledRule[];
+  totemDir: string;
+  cwd: string;
+}> {
+  const path = await import('node:path');
+  const { loadCompiledRules } = await import('@mmnto/totem');
+  const { loadConfig, resolveConfigPath } = await import('../utils.js');
+
+  const cwd = process.cwd();
+  const configPath = resolveConfigPath(cwd);
+  const config = await loadConfig(configPath);
+  const totemDir = path.join(cwd, config.totemDir);
+  const rulesPath = path.join(totemDir, 'compiled-rules.json');
+
+  const rules = loadCompiledRules(rulesPath);
+
+  return { rules, totemDir, cwd };
+}
+
+/**
+ * Find rules matching a hash prefix. Returns the match(es) and handles
+ * ambiguous / not-found cases with user output.
+ */
+function resolveRuleByPrefix(
+  rules: CompiledRule[],
+  id: string,
+  log: (typeof import('../ui.js'))['log'],
+  bold: (typeof import('../ui.js'))['bold'],
+): CompiledRule | null {
+  const lower = id.toLowerCase();
+  const matches = rules.filter((r) => r.lessonHash.toLowerCase().startsWith(lower));
+
+  if (matches.length === 0) {
+    log.error('Totem Error', `No rule found matching '${id}'`);
+    return null;
+  }
+
+  if (matches.length > 1) {
+    log.warn(TAG, `Ambiguous prefix '${id}' matches ${matches.length} rules:`);
+    for (const m of matches) {
+      log.info(TAG, `  ${bold(m.lessonHash)} \u2014 ${m.lessonHeading}`);
+    }
+    log.dim(TAG, 'Provide more characters to disambiguate.');
+    return null;
+  }
+
+  return matches[0]!;
+}
+
+// ─── Subcommands ───────────────────────────────────────
+
+export async function ruleListCommand(): Promise<void> {
+  const { log, dim, bold } = await import('../ui.js');
+  const { rules } = await loadRulesOrExit();
+
+  if (rules.length === 0) {
+    log.error('Totem Error', 'No compiled rules found. Run `totem compile` first.');
+    return;
+  }
+
+  // Table header
+  const hashW = 10;
+  const engineW = 10;
+  const sevW = 9;
+  const globW = 7;
+  const headingW = 50;
+
+  console.error(
+    dim(
+      `  ${'HASH'.padEnd(hashW)}${'ENGINE'.padEnd(engineW)}${'SEVERITY'.padEnd(sevW)}${'GLOBS'.padEnd(globW)}HEADING`,
+    ),
+  );
+  console.error(dim('  ' + '\u2500'.repeat(hashW + engineW + sevW + globW + headingW)));
+
+  for (const rule of rules) {
+    const hash = rule.lessonHash.slice(0, 8).padEnd(hashW);
+    const engine = (rule.engine ?? 'regex').padEnd(engineW);
+    const severity = (rule.severity ?? 'warning').padEnd(sevW);
+    const globs = String(rule.fileGlobs?.length ?? 0).padEnd(globW);
+    const heading = truncate(rule.lessonHeading, headingW);
+
+    console.error(`  ${hash}${engine}${severity}${globs}${heading}`);
+  }
+
+  console.error('');
+  log.info(TAG, `${bold(String(rules.length))} rule(s) total`);
+}
+
+export async function ruleInspectCommand(id: string): Promise<void> {
+  const { log, bold, dim } = await import('../ui.js');
+  const { rules } = await loadRulesOrExit();
+
+  if (rules.length === 0) {
+    log.error('Totem Error', 'No compiled rules found. Run `totem compile` first.');
+    return;
+  }
+
+  const rule = resolveRuleByPrefix(rules, id, log, bold);
+  if (!rule) return;
+
+  console.error('');
+  log.info(TAG, `${bold('Hash:')}       ${rule.lessonHash}`);
+  log.info(TAG, `${bold('Heading:')}    ${rule.lessonHeading}`);
+  log.info(TAG, `${bold('Engine:')}     ${rule.engine}`);
+  log.info(TAG, `${bold('Severity:')}   ${rule.severity ?? 'warning'}`);
+  log.info(TAG, `${bold('Message:')}    ${rule.message}`);
+
+  if (rule.pattern) {
+    log.info(TAG, `${bold('Pattern:')}    ${dim(rule.pattern)}`);
+  }
+  if (rule.astQuery) {
+    log.info(TAG, `${bold('AST Query:')}  ${dim(rule.astQuery)}`);
+  }
+  if (rule.astGrepPattern) {
+    const display =
+      typeof rule.astGrepPattern === 'string'
+        ? rule.astGrepPattern
+        : JSON.stringify(rule.astGrepPattern);
+    log.info(TAG, `${bold('AST Grep:')}   ${dim(display)}`);
+  }
+  if (rule.fileGlobs && rule.fileGlobs.length > 0) {
+    log.info(TAG, `${bold('File Globs:')} ${rule.fileGlobs.join(', ')}`);
+  }
+  if (rule.compiledAt) {
+    log.info(TAG, `${bold('Compiled:')}   ${rule.compiledAt}`);
+  }
+  if (rule.createdAt) {
+    log.info(TAG, `${bold('Created:')}    ${rule.createdAt}`);
+  }
+  console.error('');
+}
+
+export async function ruleTestCommand(id: string): Promise<void> {
+  const { log, bold, errorColor, success: successColor } = await import('../ui.js');
+  const {
+    hashLesson,
+    readAllLessons,
+    extractRuleExamples,
+    verifyRuleExamples,
+    formatExampleFailure,
+  } = await import('@mmnto/totem');
+
+  const { rules, totemDir } = await loadRulesOrExit();
+
+  if (rules.length === 0) {
+    log.error('Totem Error', 'No compiled rules found. Run `totem compile` first.');
+    return;
+  }
+
+  const rule = resolveRuleByPrefix(rules, id, log, bold);
+  if (!rule) return;
+
+  // Find source lesson — search all lessons for one whose hash matches the rule's lessonHash
+  const lessons = readAllLessons(totemDir);
+  const lesson = lessons.find((l) => hashLesson(l.heading, l.body) === rule.lessonHash);
+
+  if (!lesson) {
+    log.warn(TAG, `Source lesson for rule ${bold(rule.lessonHash)} not found in .totem/lessons/`);
+    log.dim(TAG, 'The lesson may have been removed or the hash may have changed.');
+    return;
+  }
+
+  // Check for Example Hit/Miss
+  const examples = extractRuleExamples(lesson.body);
+  if (!examples) {
+    log.warn(TAG, 'No Example Hit/Miss found in lesson for this rule. Add examples to test.');
+    return;
+  }
+
+  // Run verification using the same logic as compile
+  const result = verifyRuleExamples(rule, lesson.body);
+
+  if (!result) {
+    // verifyRuleExamples returns null for non-regex engines with no examples
+    log.warn(TAG, `Engine '${rule.engine}' does not support inline example testing.`);
+    return;
+  }
+
+  console.error('');
+  if (result.passed) {
+    const label = successColor(bold('PASS'));
+    log.info(TAG, `${label} \u2014 ${rule.lessonHeading}`);
+    log.dim(TAG, `${examples.hits.length} hit(s), ${examples.misses.length} miss(es) verified`);
+  } else {
+    const label = errorColor(bold('FAIL'));
+    log.info(TAG, `${label} \u2014 ${rule.lessonHeading}`);
+    log.warn(TAG, formatExampleFailure(result));
+  }
+  console.error('');
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -665,6 +665,45 @@ program
     }
   });
 
+// ─── Rule noun-verb subcommands ──────────────────────────
+const ruleCmd = program.command('rule').description('Manage compiled rules');
+
+ruleCmd
+  .command('list')
+  .description('List all compiled rules')
+  .action(async () => {
+    try {
+      const { ruleListCommand } = await import('./commands/rule.js');
+      await ruleListCommand();
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+ruleCmd
+  .command('inspect <id>')
+  .description('Show rule details by hash (supports prefix matching)')
+  .action(async (id: string) => {
+    try {
+      const { ruleInspectCommand } = await import('./commands/rule.js');
+      await ruleInspectCommand(id);
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+ruleCmd
+  .command('test <id>')
+  .description('Test rule against inline Example Hit/Miss')
+  .action(async (id: string) => {
+    try {
+      const { ruleTestCommand } = await import('./commands/rule.js');
+      await ruleTestCommand(id);
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
 program
   .command('check')
   .description('Run lint + review sequentially')
@@ -716,7 +755,7 @@ program.addHelpText(
   'after',
   `
 Commands by tier:
-  Core (no API keys):    init, sync, lint, compile, test, verify-manifest, hooks, link, stats, drift, doctor, status
+  Core (no API keys):    init, sync, lint, compile, test, verify-manifest, hooks, link, stats, drift, doctor, status, rule
   AI-Powered (needs LLM): review, spec, handoff, docs, compile (with LLM), check
   GitHub Workflows:      extract, review-learn, triage, triage-pr, wrap
   Utilities:             add-lesson, add-secret, list-secrets, remove-secret, explain, eject


### PR DESCRIPTION
## Summary
Adds `totem rule` noun-verb subcommands per Proposal 205 (CLI Taxonomy Redesign):

- `totem rule list` — formatted table of all compiled rules (hash, engine, severity, heading, globs)
- `totem rule inspect <id>` — pretty-print full rule details with prefix matching
- `totem rule test <id>` — run rule against Example Hit/Miss fixtures from source lesson

Reuses existing core verification logic (`verifyRuleExamples`, `extractRuleExamples`).

## Test plan
- [x] 11 new tests covering all subcommands + edge cases
- [x] Full test suite green
- [x] Review passes — no findings
- [x] Lint — 0 errors
- [x] Format clean

Closes #1072

🤖 Generated with [Claude Code](https://claude.com/claude-code)