### PR TITLE
chore: changeset for 1.7.2 — rule GC + compile progress

### DIFF
--- a/.changeset/rule-gc-and-compile-progress.md
+++ b/.changeset/rule-gc-and-compile-progress.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/cli': patch
+'@mmnto/totem': patch
+---
+
+feat: rule garbage collection and compile progress indicator (#1040, #894)
+
+- `totem doctor --pr` now archives stale compiled rules (zero triggers after configurable minAgeDays). Opt-in via `garbageCollection` config block. Security-category rules are exempt.
+- `totem compile` now shows elapsed time and ETA with throughput-based estimation. Rate-limited LLM calls (429) are automatically retried with jittered exponential backoff.


### PR DESCRIPTION
## Summary
- Changeset for 1.7.2 patch release
- `@mmnto/cli` + `@mmnto/totem` both patch bumped
- Features: rule garbage collection (#1040), compile progress with ETA (#894)

🤖 Generated with [Claude Code](https://claude.com/claude-code)