### PR TITLE
fix: set exit code 1 when --yes mode drops all suspicious lessons

### DIFF
--- a/packages/cli/src/commands/extract-shared.ts
+++ b/packages/cli/src/commands/extract-shared.ts
@@ -407,6 +407,9 @@ export async function sharedPipeline(
 
   if (selected.length === 0) {
     log.dim(TAG, 'No lessons selected — nothing written.');
+    if (options.yes && suspiciousCount > 0) {
+      process.exitCode = 1;
+    }
     return;
   }
 


### PR DESCRIPTION
## Summary

Closes #1161

One-line fix: when `totem extract --yes` drops all lessons as suspicious, `process.exitCode = 1` is now set before the early return. Previously CI saw success despite every lesson being rejected.

## Test plan

- [x] All 1,548 tests pass
- [x] `totem review` — PASS
- [x] One push, zero fixup commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)