### PR TITLE
fix: remove npm self-upgrade from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,6 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
-      - run: npm install -g npm@latest
-        name: Upgrade npm for OIDC support
-
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm build


### PR DESCRIPTION
## Summary

- Remove `npm install -g npm@latest` step from release workflow
- Node 22's bundled npm already supports OIDC provenance — the step was leftover from Node 18
- The self-upgrade crashes on Node 22.22.2 with `Cannot find module 'promise-retry'`

This is blocking the 1.10.0 release.

## Test plan

- [ ] Release workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)