### PR TITLE
fix: isolate flaky tests from real filesystem state

### DIFF
--- a/packages/cli/src/commands/review-alias.test.ts
+++ b/packages/cli/src/commands/review-alias.test.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import * as path from 'node:path';
 
 import { describe, expect, it } from 'vitest';
@@ -11,19 +11,14 @@ describe('review command alias', () => {
   const distEntry = path.resolve(process.cwd(), 'dist/index.js');
 
   const cli = (args: string): { stdout: string; stderr: string } => {
-    try {
-      // totem-context: test helper — args are hardcoded test strings, not user input
-      const stdout = execSync(`node "${distEntry}" ${args}`, {
-        cwd: process.cwd(),
-        encoding: 'utf-8',
-        timeout: 10_000,
-        env: { ...process.env, NODE_NO_WARNINGS: '1' },
-      });
-      return { stdout, stderr: '' };
-    } catch (err: unknown) {
-      const e = err as { stdout?: string; stderr?: string };
-      return { stdout: e.stdout ?? '', stderr: e.stderr ?? '' };
-    }
+    // totem-context: test helper — args are hardcoded test strings, not user input
+    const result = spawnSync('node', [distEntry, ...args.split(' ')], {
+      cwd: process.cwd(),
+      encoding: 'utf-8',
+      timeout: 10_000,
+      env: { ...process.env, NODE_NO_WARNINGS: '1' },
+    });
+    return { stdout: result.stdout ?? '', stderr: result.stderr ?? '' };
   };
 
   it('registers review as a visible command in --help', () => {

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -241,7 +241,12 @@ describe('resolveConfigPath', () => {
   });
 
   it('throws when no config file exists', () => {
-    expect(() => resolveConfigPath(tmpDir)).toThrow('No Totem configuration found');
+    const fakeHome = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-home-'));
+    try {
+      expect(() => resolveConfigPath(tmpDir, fakeHome)).toThrow('No Totem configuration found');
+    } finally {
+      cleanTmpDir(fakeHome);
+    }
   });
 
   it('resolves totem.yaml when totem.config.ts is missing', () => {


### PR DESCRIPTION
## Summary
- **resolveConfigPath**: pass fake `homeDir` to prevent test from finding real `~/.totem/` global profile (introduced by the global profile feature in 1.10.0)
- **review-alias**: switch `execSync` → `spawnSync` to capture stderr even when the command exits 0 (deprecation warning was invisible on success)

Both tests were flaky only on machines with a global totem profile installed.

## Test plan
- [x] `pnpm --filter @mmnto/cli test` — 1,548/1,548 passing (was 1,546)
- [x] Full suite: 2,505 tests passing
- [x] `totem lint` PASS, `totem review` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)