### PR TITLE
fix: Enforce npm provenance for OIDC publishing

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -72,6 +72,7 @@
     "url": "https://github.com/mmnto-ai/totem/issues"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,6 +62,7 @@
     "url": "https://github.com/mmnto-ai/totem/issues"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -48,6 +48,7 @@
     "url": "https://github.com/mmnto-ai/totem/issues"
   },
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "provenance": true
   }
 }


### PR DESCRIPTION
Updates all three packages to explicitly require provenance via \publishConfig\. This resolves the E404 publishing error on GitHub Actions when relying on OIDC tokens without an NPM_TOKEN fallback.