### PR TITLE
fix: use npm (not pnpm) for OIDC trusted publishing

### DIFF
--- a/tools/publish-oidc.js
+++ b/tools/publish-oidc.js
@@ -1,13 +1,35 @@
 #!/usr/bin/env node
 /**
- * Publish workspace packages via pnpm with OIDC provenance.
+ * Publish workspace packages via npm with OIDC trusted publishing.
+ *
+ * Uses pnpm pack (resolves workspace: protocols) then npm publish (OIDC auth).
+ * pnpm publish doesn't support OIDC (pnpm/pnpm#9812), and npm publish
+ * doesn't resolve workspace: protocols — so we need both.
+ *
+ * Publishes in topological order: core before cli/mcp.
  * Skips already-published versions for idempotent CI retries.
  */
 const { spawnSync } = require('node:child_process');
 const fs = require('node:fs');
 const path = require('node:path');
 
-const pkgDirs = fs.readdirSync('packages').map((d) => path.join('packages', d));
+// Topological order: core has no workspace deps, cli and mcp depend on core.
+const pkgOrder = ['core', 'cli', 'mcp'];
+const pkgDirs = pkgOrder.map((d) => path.join('packages', d));
+
+// Safety check: fail if a new package was added but not listed here
+const discovered = fs
+  .readdirSync('packages')
+  .filter((d) => fs.existsSync(path.join('packages', d, 'package.json')));
+const missing = discovered.filter((d) => !pkgOrder.includes(d));
+if (missing.length > 0) {
+  console.error(
+    `[Totem Error] Packages not in pkgOrder: ${missing.join(', ')}. Update tools/publish-oidc.js`,
+  );
+  process.exitCode = 1;
+  process.exit();
+}
+
 let published = 0;
 let skipped = 0;
 
@@ -28,15 +50,40 @@ for (const dir of pkgDirs) {
     continue;
   }
 
+  // Pack with pnpm to resolve workspace: protocols into real version ranges
+  console.log(`Packing ${pkg.name}@${pkg.version}...`);
+  const pack = spawnSync('pnpm', ['pack'], {
+    cwd: dir,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  if (pack.status !== 0) {
+    console.error(`[Totem Error] Failed to pack ${pkg.name} (exit ${pack.status})`);
+    console.error(pack.stderr);
+    process.exitCode = 1;
+    break;
+  }
+  const tarball = pack.stdout.trim().split('\n').pop();
+  if (!tarball || !fs.existsSync(path.join(dir, tarball))) {
+    console.error(`[Totem Error] Failed to identify tarball for ${pkg.name}`);
+    process.exitCode = 1;
+    break;
+  }
+
+  // Publish the tarball with npm for OIDC auth + provenance
   console.log(`Publishing ${pkg.name}@${pkg.version}...`);
-  const result = spawnSync(
-    'pnpm',
-    ['publish', '--access', 'public', '--no-git-checks', '--provenance'],
-    {
-      cwd: dir,
-      stdio: 'inherit',
-    },
-  );
+  const result = spawnSync('npm', ['publish', tarball, '--access', 'public', '--provenance'], {
+    cwd: dir,
+    stdio: 'inherit',
+  });
+
+  // Clean up tarball
+  try {
+    fs.unlinkSync(path.join(dir, tarball));
+  } catch (_err) {
+    // best-effort cleanup — tarball left behind is harmless
+  }
+
   if (result.status !== 0) {
     console.error(
       `[Totem Error] Failed to publish ${pkg.name}@${pkg.version} (exit ${result.status})`,


### PR DESCRIPTION
## Summary
pnpm doesn't support OIDC trusted publishing ([pnpm/pnpm#9812](https://github.com/pnpm/pnpm/issues/9812)). Previous attempts failed with ENEEDAUTH because `pnpm publish` can't negotiate OIDC tokens.

Switches `publish-oidc.js` from `pnpm publish` to `npm publish --provenance`. npm 11.5.1+ on Node 22+ handles OIDC natively in GitHub Actions — no `registry-url`, no `NODE_AUTH_TOKEN`, no `.npmrc` needed.

## Test plan
- [x] Merge and verify 1.10.1 publishes to npm via OIDC

🤖 Generated with [Claude Code](https://claude.com/claude-code)