### PR TITLE
fix: refresh docs for 1.10.1 and update stale model defaults

### DIFF
--- a/docs/active_work.md
+++ b/docs/active_work.md
@@ -1,19 +1,30 @@
 ### Active Work Summary
 
-The project is at release `@mmnto/cli@1.10.0` (pending changeset/publish) with ~2,502 tests across core, CLI, and MCP packages and 407 compiled rules. The Invisible Exoskeleton milestone shipped in full. The Import Engine is now current work.
+The project is at release `@mmnto/cli@1.10.1` (published 2026-04-04) with 2,506 tests across core, CLI, and MCP packages and 413 compiled rules. The Import Engine is the current milestone.
 
 ### Current: 1.11.0 — The Import Engine
 
 Theme: rule portability across tools and teams.
 
-- **#1138** — ESLint flat config import support
-- **#1139** — Totem-to-totem import (cross-repo rule sharing)
+**Phase 2 (next):**
+
+- **#1165** — Lesson retirement ledger (prevent re-extraction of removed rules)
 - **#1140** — ESLint `no-restricted-syntax`/`properties` handlers
+
+**Phase 3:**
+
+- **#1152** — Proactive language packs (tier-1 headline feature)
 - **#1131** — Rule refinement from false-positive scan alerts
 - **#1132** — Auto-detect string-content matches for AST upgrade
+
+**Phase 4 (1.11.0 minor):**
+
+- **#1138** — ESLint flat config import support
 - **#1059** — Pack distribution
-- **#1152** — Proactive language packs (moved from 1.10.0)
-- **#1158** — Exemption dedup bug fix
+- **#1139** — Totem-to-totem import (cross-repo rule sharing)
+
+**Strategy:**
+
 - Strategy **#50** — GHAS/SARIF extraction
 - Strategy **#51** — Lint warning extraction
 
@@ -34,6 +45,16 @@ Theme: internal quality, test infrastructure, and deferred refactors.
 - Strategy **#63** — Spec efficacy validation
 
 ### Recently Completed
+
+**1.10.1 — Phase 1 Bug Fixes (2026-04-04)**
+
+Bug fixes and rule hygiene shipped as a patch before the main Import Engine work.
+
+- ~~**#1158**~~ — Exemption dedup: added `!includes(message)` check in `recordFalsePositive()`
+- ~~**#1164**~~ — Narrowed process.exit() rule to exclude CLI entry points and command files
+- ~~**#1166**~~ — Rule conflict audit: deleted 5 lessons, scoped 1 (418 → 413 compiled rules)
+- ~~**#1168**~~ — POSIX compliance for monorepo shell hooks
+- Issues filed from GCA reviews: **#1175** (agent detection in TS), **#1177** (self-suppressing rule bug)
 
 **1.10.0 — The Invisible Exoskeleton (2026-04-02)**
 

--- a/docs/reference/supported-models.md
+++ b/docs/reference/supported-models.md
@@ -1,6 +1,6 @@
 # Supported Models & AI Tools Reference
 
-> **Last validated:** 2026-03-12
+> **Last validated:** 2026-04-04
 
 Totem supports four LLM provider families for orchestration, and exports project
 knowledge to all major AI coding tools. This document tracks model IDs, tool
@@ -14,27 +14,29 @@ Used by `totem review`, `totem spec`, `totem triage`, `totem extract`, etc.
 
 ### Google Gemini
 
-| Role                | Model ID                 | Notes                                            |
-| ------------------- | ------------------------ | ------------------------------------------------ |
-| Default (fast)      | `gemini-3-flash-preview` | Preview — current Totem default                  |
-| Pro (complex tasks) | `gemini-3.1-pro-preview` | Preview — used for spec/review/triage overrides  |
-| Stable fast         | `gemini-2.5-flash`       | GA release, used in smoke/eval tests             |
-| Stable pro          | `gemini-2.5-pro`         | GA release                                       |
-| Fast-lite (newest)  | `gemini-3.1-flash-lite`  | Released 2026-03-03, 2.5x faster TTFT than Flash |
-| Ultra-cheap         | `gemini-2.5-flash-lite`  | Minimal cost                                     |
+| Role                | Model ID                         | Notes                                        |
+| ------------------- | -------------------------------- | -------------------------------------------- |
+| Default (fast)      | `gemini-3-flash-preview`         | Preview — current Totem default              |
+| Pro (complex tasks) | `gemini-3.1-pro-preview`         | Replaced `gemini-3-pro-preview` (March 2026) |
+| Image generation    | `gemini-3.1-flash-image-preview` | Flash variant optimized for image tasks      |
+| Fast-lite (newest)  | `gemini-3.1-flash-lite`          | 2.5x faster TTFT than Flash, lowest cost     |
+| Stable fast         | `gemini-2.5-flash`               | GA — **deprecating June 17, 2026**           |
+| Stable pro          | `gemini-2.5-pro`                 | GA — **deprecating June 17, 2026**           |
 
 **Listing API:** `GET https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY`
 
 - Auth: API key as query parameter
 - Docs: https://ai.google.dev/api/models
+- Note: `gemini-3-pro-preview` was discontinued March 26, 2026. Use `gemini-3.1-pro-preview`.
 
 ### Anthropic (Claude)
 
 | Role              | Model ID            | Dated Snapshot               |
 | ----------------- | ------------------- | ---------------------------- |
-| Flagship          | `claude-opus-4-6`   | Latest Opus                  |
+| Flagship          | `claude-opus-4-6`   | Latest Opus (1M context)     |
 | Fast/balanced     | `claude-sonnet-4-6` | Latest Sonnet                |
 | Cheapest          | `claude-haiku-4-5`  | `claude-haiku-4-5-20251001`  |
+| Previous Opus     | `claude-opus-4-5`   | Still available              |
 | Legacy Sonnet 4.5 | `claude-sonnet-4-5` | `claude-sonnet-4-5-20250929` |
 | Legacy Sonnet 4   | `claude-sonnet-4-0` | `claude-sonnet-4-20250514`   |
 
@@ -46,32 +48,34 @@ Used by `totem review`, `totem spec`, `totem triage`, `totem extract`, etc.
 
 ### OpenAI
 
-| Role                 | Model ID                  | Notes                    |
-| -------------------- | ------------------------- | ------------------------ |
-| Flagship             | `gpt-5.4`                 | Latest                   |
-| Pro (higher compute) | `gpt-5.4-pro`             | Higher token limits      |
-| Fast/cheap           | `gpt-5-mini`              | Cost-optimized           |
-| Ultra-cheap          | `gpt-5-nano`              | Smallest                 |
-| Reasoning (best)     | `o3-pro`                  | Slow but powerful        |
-| Reasoning (fast)     | `o4-mini`                 | Cost-efficient reasoning |
-| Previous gen         | `gpt-4o`, `gpt-4o-mini`   | Legacy, still available  |
-| Previous gen         | `gpt-4.1`, `gpt-4.1-mini` | Still available          |
+| Role                 | Model ID                  | Notes                                 |
+| -------------------- | ------------------------- | ------------------------------------- |
+| Flagship             | `gpt-5.4`                 | Latest                                |
+| Pro (higher compute) | `gpt-5.4-pro`             | Higher token limits                   |
+| Fast/cheap           | `gpt-5.4-mini`            | Cost-optimized (succeeded gpt-5-mini) |
+| Ultra-cheap          | `gpt-5.4-nano`            | Smallest (succeeded gpt-5-nano)       |
+| Reasoning (best)     | `o3-pro`                  | API only — retired from ChatGPT       |
+| Reasoning (fast)     | `o4-mini`                 | API only — retired from ChatGPT       |
+| Previous gen         | `gpt-4.1`, `gpt-4.1-mini` | Legacy, still available in API        |
 
 **Listing API:** `GET https://api.openai.com/v1/models`
 
 - Auth: `Authorization: Bearer $OPENAI_API_KEY`
 - Docs: https://platform.openai.com/docs/models
+- Note: `gpt-4o`, `gpt-4o-mini`, `o4-mini` retired from ChatGPT (Feb 2026) but still in API.
 
 ### Ollama (Local)
 
 Ollama runs models locally. Any model from the [Ollama library](https://ollama.com/search)
 can be used as an orchestrator. Popular choices:
 
-| Model           | Parameters  | Notes                  |
-| --------------- | ----------- | ---------------------- |
-| `llama3.1`      | 8B/70B/405B | Meta's flagship        |
-| `qwen2.5-coder` | 7B/32B      | Code-specialized       |
-| `phi3`          | 3.8B/14B    | Microsoft, lightweight |
+| Model           | Parameters      | Notes                            |
+| --------------- | --------------- | -------------------------------- |
+| `gemma4`        | e2b/e4b/26b/31b | Google, multimodal, 128-256K ctx |
+| `qwen3`         | 0.6B–235B (MoE) | Alibaba, strong reasoning        |
+| `llama3.2`      | 1B/3B/11B/90B   | Meta, vision variants available  |
+| `qwen2.5-coder` | 7B/32B          | Code-specialized                 |
+| `phi3`          | 3.8B/14B        | Microsoft, lightweight           |
 
 **Listing API (local):** `GET http://localhost:11434/api/tags`
 
@@ -91,9 +95,11 @@ Used by `totem sync` for indexing chunks into LanceDB.
 | Gemini               | `gemini-embedding-001`       | 768        | Stable, text-only                     |
 | OpenAI               | `text-embedding-3-small`     | 1536       | Lowest onboarding friction            |
 | OpenAI (large)       | `text-embedding-3-large`     | 3072       | Higher quality, higher cost           |
-| **Ollama** (offline) | `nomic-embed-text`           | 768        | 56M+ pulls, most popular local        |
+| **Ollama** (offline) | `nomic-embed-text`           | 768        | Most popular local embed model        |
+| Ollama               | `nomic-embed-text-v2-moe`    | 768        | Multilingual MoE variant              |
 | Ollama               | `mxbai-embed-large`          | 1024       | BERT-large class SOTA                 |
-| Ollama               | `qwen3-embedding`            | varies     | Newest, fast-growing                  |
+| Ollama               | `embeddinggemma`             | 768        | 300M params, from Gemma 3, 100+ langs |
+| Ollama               | `qwen3-embedding`            | varies     | 0.6B–8B, 100+ languages               |
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -17,7 +17,7 @@ Totem is a **standard library for codebase governance** — deterministic primit
 - [ ] **AST Upgrade Detection (#1132):** Auto-detect string-content matches eligible for AST patterns.
 - [ ] **Pack Distribution (#1059):** Shareable rule bundles.
 - [ ] **Proactive Language Packs (#1152):** Thick TypeScript/Shell/Node.js baseline rules from established best practices (moved from 1.10.0).
-- [ ] **Exemption Dedup Fix (#1158):** Fix duplicate sampleMessages in auto-promotion.
+- [ ] **Lesson Retirement Ledger (#1165):** Prevent re-extraction of intentionally removed rules.
 - [ ] **GHAS/SARIF Extraction (Strategy #50):** Import rules from GitHub Advanced Security alerts.
 - [ ] **Lint Warning Extraction (Strategy #51):** Convert lint warnings into totem lessons.
 
@@ -42,6 +42,15 @@ Totem is a **standard library for codebase governance** — deterministic primit
 ---
 
 ## Shipped Milestones
+
+### 1.10.1 — Phase 1 Bug Fixes (2026-04-04)
+
+**Theme:** Rule hygiene and release pipeline hardening before the Import Engine.
+
+- [x] **Exemption Dedup (#1158):** Added `!includes(message)` check in `recordFalsePositive()`.
+- [x] **Exit Scope (#1164):** Narrowed process.exit() rule to exclude CLI entry points and command files.
+- [x] **Rule Conflict Audit (#1166):** Deleted 5 lessons, scoped 1 (418 → 413 compiled rules).
+- [x] **POSIX Compliance (#1168):** Multi-line if/then/fi in agent detection, hardened hook parser.
 
 ### 1.10.0 — The Invisible Exoskeleton (2026-04-02)
 

--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -15,7 +15,7 @@ _Rule portability — bring governance from external tools and other totem insta
 - **AST Upgrade Detection (#1132):** Auto-detect string-content matches for AST patterns.
 - **Pack Distribution (#1059):** Shareable rule bundles.
 - **Proactive Language Packs (#1152):** Thick TypeScript/Shell/Node.js baseline rules from established best practices.
-- **Exemption Dedup Fix (#1158):** Fix duplicate sampleMessages in auto-promotion.
+- **Lesson Retirement Ledger (#1165):** Prevent re-extraction of intentionally removed rules.
 - **GHAS/SARIF Extraction (Strategy #50):** Import from GitHub Advanced Security alerts.
 - **Lint Warning Extraction (Strategy #51):** Convert lint warnings into totem lessons.
 
@@ -40,6 +40,15 @@ _Internal quality, research validation, and platform hardening._
 ---
 
 ## Shipped
+
+### 1.10.1 — Phase 1 Bug Fixes (2026-04-04)
+
+_Rule hygiene and release pipeline hardening before the Import Engine._
+
+- **Exemption Dedup (#1158):** Added `!includes(message)` check in `recordFalsePositive()`.
+- **Exit Scope (#1164):** Narrowed process.exit() rule to exclude CLI entry points and command files.
+- **Rule Conflict Audit (#1166):** Deleted 5 lessons, scoped 1 (418 → 413 compiled rules).
+- **POSIX Compliance (#1168):** Multi-line if/then/fi in agent detection, hardened hook parser.
 
 ### 1.10.0 — The Invisible Exoskeleton (2026-04-02)
 

--- a/packages/cli/src/commands/init-detect.ts
+++ b/packages/cli/src/commands/init-detect.ts
@@ -294,23 +294,23 @@ export function detectOrchestrator(cwd: string): DetectedOrchestrator | null {
   }
 
   if (hasKey(envContent, 'ANTHROPIC_API_KEY')) {
-    const config = { provider: 'anthropic', defaultModel: 'claude-sonnet-4-20250514' };
+    const config = { provider: 'anthropic', defaultModel: 'claude-sonnet-4-6' };
     return {
       config,
       block: `  orchestrator: {
     provider: 'anthropic',
-    defaultModel: 'claude-sonnet-4-20250514',
+    defaultModel: 'claude-sonnet-4-6',
   },`,
     };
   }
 
   if (hasKey(envContent, 'OPENAI_API_KEY')) {
-    const config = { provider: 'openai', defaultModel: 'gpt-4.1-mini' };
+    const config = { provider: 'openai', defaultModel: 'gpt-5.4-mini' };
     return {
       config,
       block: `  orchestrator: {
     provider: 'openai',
-    defaultModel: 'gpt-4.1-mini',
+    defaultModel: 'gpt-5.4-mini',
   },`,
     };
   }

--- a/packages/cli/src/orchestrators/orchestrator.test.ts
+++ b/packages/cli/src/orchestrators/orchestrator.test.ts
@@ -253,10 +253,10 @@ describe('resolveOrchestrator', () => {
   });
 
   it('creates new invoker for cross-provider resolution', () => {
-    const result = resolveOrchestrator('anthropic:claude-sonnet-4-20250514', 'gemini', mockInvoke);
+    const result = resolveOrchestrator('anthropic:claude-sonnet-4-6', 'gemini', mockInvoke);
     expect(result.invoke).not.toBe(mockInvoke);
-    expect(result.parsed).toEqual({ provider: 'anthropic', model: 'claude-sonnet-4-20250514' });
-    expect(result.qualifiedModel).toBe('anthropic:claude-sonnet-4-20250514');
+    expect(result.parsed).toEqual({ provider: 'anthropic', model: 'claude-sonnet-4-6' });
+    expect(result.qualifiedModel).toBe('anthropic:claude-sonnet-4-6');
   });
 
   it('throws on empty model string (provider:)', () => {
@@ -302,9 +302,9 @@ describe('resolveOrchestrator', () => {
 
 describe('parseModelString', () => {
   it('parses anthropic:model into provider and model', () => {
-    expect(parseModelString('anthropic:claude-sonnet-4-20250514', 'gemini')).toEqual({
+    expect(parseModelString('anthropic:claude-sonnet-4-6', 'gemini')).toEqual({
       provider: 'anthropic',
-      model: 'claude-sonnet-4-20250514',
+      model: 'claude-sonnet-4-6',
     });
   });
 

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -779,7 +779,7 @@ describe('runOrchestrator', () => {
       orchestrator: {
         provider: 'gemini',
         defaultModel: 'gemini-3-flash-preview',
-        overrides: { shield: 'anthropic:claude-sonnet-4-20250514' },
+        overrides: { shield: 'anthropic:claude-sonnet-4-6' },
       },
     });
 


### PR DESCRIPTION
## Summary

- Sync docs to 1.10.1 release state (version, test count 2,506, rule count 413)
- Add 1.10.1 as shipped milestone in roadmap + wiki
- Reorganize 1.11.0 active_work into phased plan (Phase 2–4)
- Refresh `supported-models.md` (validated 2026-04-04): Gemini 2.5 deprecation warning, OpenAI 5.4 renames, gemma4/qwen3 for Ollama, new embedding models
- Update init-detect defaults: `claude-sonnet-4-20250514` → `claude-sonnet-4-6`, `gpt-4.1-mini` → `gpt-5.4-mini`

Closes #1185

## Test plan

- [x] 125 affected tests pass (orchestrator + utils)
- [x] Full suite: 2,506 tests pass
- [x] `totem lint` clean
- [x] `totem review` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)