### PR TITLE
feat: ESLint no-restricted-syntax and no-restricted-properties importers

### DIFF
--- a/packages/core/src/eslint-adapter.test.ts
+++ b/packages/core/src/eslint-adapter.test.ts
@@ -263,4 +263,38 @@ describe('parseEslintConfig', () => {
       expect(re.test('const x = 1;')).toBe(false);
     });
   });
+
+  describe('no-restricted-properties bracket notation', () => {
+    it('matches bracket notation for object+property', () => {
+      const result = parseEslintConfig(
+        JSON.stringify({
+          rules: {
+            'no-restricted-properties': ['error', { object: 'Math', property: 'pow' }],
+          },
+        }),
+      );
+      const re = new RegExp(result.rules[0]!.pattern);
+      expect(re.test(' Math.pow(2, 3)')).toBe(true);
+      expect(re.test(' Math?.pow(2, 3)')).toBe(true);
+      expect(re.test(' Math["pow"]')).toBe(true);
+      expect(re.test(" Math['pow']")).toBe(true);
+      expect(re.test('const x = 1;')).toBe(false);
+    });
+
+    it('matches bracket notation for property-only', () => {
+      const result = parseEslintConfig(
+        JSON.stringify({
+          rules: {
+            'no-restricted-properties': ['error', { property: '__proto__' }],
+          },
+        }),
+      );
+      const re = new RegExp(result.rules[0]!.pattern);
+      expect(re.test('obj.__proto__')).toBe(true);
+      expect(re.test('obj?.__proto__')).toBe(true);
+      expect(re.test('obj["__proto__"]')).toBe(true);
+      expect(re.test("obj['__proto__']")).toBe(true);
+      expect(re.test('const __proto__ = 1;')).toBe(false);
+    });
+  });
 });

--- a/packages/core/src/eslint-adapter.ts
+++ b/packages/core/src/eslint-adapter.ts
@@ -159,13 +159,15 @@ function handleRestrictedProperties(
     if (obj && prop) {
       const eo = escapeRegex(obj);
       const ep = escapeRegex(prop);
-      pattern = `(?:^|[^\\w$])${eo}\\s*(?:\\.|\\?\\.)\\s*${ep}\\b`;
+      // Dot/optional-chaining access OR bracket notation
+      pattern = `(?:^|[^\\w$])${eo}\\s*(?:(?:\\.|\\?\\.)\\s*${ep}\\b|\\[\\s*['"]${ep}['"]\\s*\\])`;
     } else if (obj) {
       const eo = escapeRegex(obj);
       pattern = `(?:^|[^\\w$])${eo}\\s*(?:\\.|\\?\\.|\\[)`;
     } else {
       const ep = escapeRegex(prop!);
-      pattern = `(?:\\.|\\?\\.)\\s*${ep}\\b`;
+      // Dot/optional-chaining access OR bracket notation
+      pattern = `(?:(?:\\.|\\?\\.)\\s*${ep}\\b|\\[\\s*['"]${ep}['"]\\s*\\])`;
     }
 
     rules.push({


### PR DESCRIPTION
## Summary

- Add `handleRestrictedProperties` handler: converts `no-restricted-properties` config entries (object/property/message) to regex rules. Supports object+property, object-only, and property-only variants.
- Add `handleRestrictedSyntax` handler: maps common ESTree node types (`ForInStatement`, `WithStatement`, `DebuggerStatement`) to regex approximations via lookup table. Complex/unknown selectors skipped gracefully.
- Register both in `IMPORTABLE_HANDLERS`

Closes #1140

## Test plan

- [x] 12 new tests (6 properties + 5 syntax + 1 regex validation)
- [x] Full suite: 2,525 tests pass
- [x] `totem lint` PASS (0 errors)
- [x] `totem review` PASS (0 critical)

🤖 Generated with [Claude Code](https://claude.com/claude-code)