### PR TITLE
fix: increase runOrchestrator test timeout for Windows CI

### DIFF
--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -692,7 +692,7 @@ function baseConfig(overrides?: Partial<TotemConfig>): TotemConfig {
   } as TotemConfig;
 }
 
-describe('runOrchestrator', () => {
+describe('runOrchestrator', { timeout: 15_000 }, () => {
   let tmpDir: string;
 
   beforeEach(() => {


### PR DESCRIPTION
## Summary

One-line fix: adds `{ timeout: 15_000 }` to the `runOrchestrator` describe block. The default 5000ms vitest timeout intermittently fails on Windows CI due to slow temp dir I/O.

Closes #1189

## Test plan

- [x] 1,558 tests pass
- [x] `totem lint` PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)