### PR TITLE
fix: mermaid diagram rendering in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,23 +20,22 @@ Totem operates as a continuous, self-healing loop that converts institutional kn
 
 ```mermaid
 graph LR
-    %% Styles
     classDef observe fill:#4b3a75,stroke:#9b72cf,stroke-width:2px,color:#fff
     classDef learn fill:#5e3a24,stroke:#e67c3b,stroke-width:2px,color:#fff
     classDef enforce fill:#1a4d2e,stroke:#34a853,stroke-width:2px,color:#fff
     classDef core fill:#2d2d2d,stroke:#888,stroke-width:1px,color:#fff
 
-    Observe[1. The Eye <br> Observe]:::observe
-    Learn[2. The Brain <br> Learn]:::learn
-    Enforce[3. The Hand <br> Enforce]:::enforce
-    Ledger[(Trap Ledger)]:::core
+    Observe["1. The Eye — Observe"]:::observe
+    Learn["2. The Brain — Learn"]:::learn
+    Enforce["3. The Hand — Enforce"]:::enforce
+    Ledger[("Trap Ledger")]:::core
 
-    Observe -->|PR Reviews<br/>Bot Nits| Learn
-    Learn -->|totem compile<br/>Generate Rule| Enforce
-    Enforce -->|totem lint<br/>pre-push hook| Observe
+    Observe -->|"PR Reviews / Bot Nits"| Learn
+    Learn -->|"totem compile"| Enforce
+    Enforce -->|"totem lint / pre-push"| Observe
 
-    Enforce -.->|Developer Bypass| Ledger
-    Ledger -.->|Self-Healing Loop| Learn
+    Enforce -.->|"Developer Bypass"| Ledger
+    Ledger -.->|"Self-Healing Loop"| Learn
 ```
 
 1. **The Eye (Observe):** `totem review` (our optional reference implementation) and your CI bots watch the code. What went wrong?


### PR DESCRIPTION
## Summary

- GitHub's mermaid renderer was showing "Unable to render rich display" for the Pipeline Engine diagram
- Root cause: `<br>` and `<br/>` HTML tags in node labels and edge labels are not reliably supported
- Fix: replaced with quoted labels using `—` separators and `/` for multi-line edge text

## Test plan

- [x] Verify diagram renders on the PR preview page

Closes #1207 if filed, otherwise standalone fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)