### PR TITLE
fix: strip backtick wrappers from LLM-generated pattern fields [UPDATE-RULES]

### DIFF
--- a/.totem/compile-manifest.json
+++ b/.totem/compile-manifest.json
@@ -1,7 +1,7 @@
 {
-  "compiled_at": "2026-04-06T00:40:46.246Z",
+  "compiled_at": "2026-04-06T01:29:08.243Z",
   "model": "gemini-3-flash-preview",
   "input_hash": "da5fb64ebe3fbfbf72e2cc841ed4b5550eab3f39df8107be622dda6982a876cf",
-  "output_hash": "ba841f768ea1194b0cf7dc2bf99cd93f0b319d5c63efb631ae49cff1a25d04ea",
+  "output_hash": "4e1424cbc932e3789cb4ba35bde6ff7a1d1c6d6e25f432a09fd18507a420895a",
   "rule_count": 438
 }

--- a/packages/core/src/compiler.test.ts
+++ b/packages/core/src/compiler.test.ts
@@ -745,6 +745,40 @@ describe('parseCompilerResponse', () => {
       fileGlobs: ['*.sh', '*.bash', '*.yml'],
     });
   });
+
+  it('strips single backtick wrappers from pattern fields', () => {
+    const response = JSON.stringify({
+      compilable: true,
+      engine: 'ast-grep',
+      astGrepPattern: '`spawn($CMD, [$$$ARGS], { shell: true })`',
+      pattern: '',
+      message: 'Do not use shell:true with array args',
+    });
+    const result = parseCompilerResponse(response);
+    expect(result!.astGrepPattern).toBe('spawn($CMD, [$$$ARGS], { shell: true })');
+  });
+
+  it('strips single backtick wrappers from regex pattern', () => {
+    const response = JSON.stringify({
+      compilable: true,
+      pattern: '`\\bconsole\\.log\\b`',
+      message: 'No console.log',
+    });
+    const result = parseCompilerResponse(response);
+    expect(result!.pattern).toBe('\\bconsole\\.log\\b');
+  });
+
+  it('leaves patterns without backtick wrappers unchanged', () => {
+    const response = JSON.stringify({
+      compilable: true,
+      engine: 'ast-grep',
+      astGrepPattern: '$OBJ.replace(process.cwd(), $R)',
+      pattern: '',
+      message: 'Use path.relative',
+    });
+    const result = parseCompilerResponse(response);
+    expect(result!.astGrepPattern).toBe('$OBJ.replace(process.cwd(), $R)');
+  });
 });
 
 // ─── sanitizeFileGlobs ─────────────────────────────

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -225,10 +225,20 @@ export function engineFields(
 
 // ─── LLM response parsing ──────────────────────────
 
-/**
- * Parse the LLM's compilation response. Extracts JSON from the response text,
- * validates it, and returns the structured output or null if unparseable.
- */
+/** Strip leading/trailing backtick wrappers (e.g., `` `pattern` ``, `` ```regex\npattern\n``` ``). */
+function stripBacktickWrap(value: string): string {
+  const s = value.trim();
+  // Multi-line code fence: ```lang\n...\n```
+  const fenceMatch = s.match(/^```[^\n]*\n([\s\S]*?)\n?```$/);
+  if (fenceMatch) return fenceMatch[1]!.trim();
+  // Single backtick wrap: `pattern` — only strip if content doesn't contain backticks
+  if (s.startsWith('`') && s.endsWith('`') && s.length > 2) {
+    const inner = s.slice(1, -1);
+    if (!inner.includes('`')) return inner.trim();
+  }
+  return s;
+}
+
 export function parseCompilerResponse(response: string): CompilerOutput | null {
   // Try to extract JSON from the response (LLMs often wrap in ```json blocks)
   const jsonMatch = response.match(/```(?:json)?\s*\n?([\s\S]*?)\n?```/);
@@ -238,7 +248,22 @@ export function parseCompilerResponse(response: string): CompilerOutput | null {
     const parsed = JSON.parse(jsonStr);
     const result = CompilerOutputSchema.safeParse(parsed);
     if (!result.success) return null;
-    return result.data;
+
+    const data = result.data;
+    // Strip backtick formatting hallucinations from pattern fields
+    if (typeof data.pattern === 'string' && data.pattern) {
+      data.pattern = stripBacktickWrap(data.pattern);
+    }
+    if (typeof data.astGrepPattern === 'string' && data.astGrepPattern) {
+      data.astGrepPattern = stripBacktickWrap(data.astGrepPattern);
+    }
+    if (typeof data.astQuery === 'string' && data.astQuery) {
+      data.astQuery = stripBacktickWrap(data.astQuery);
+    }
+    if (data.fileGlobs) {
+      data.fileGlobs = data.fileGlobs.map(stripBacktickWrap);
+    }
+    return data;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
- `parseCompilerResponse` now strips leading/trailing backtick wrappers from `pattern`, `astGrepPattern`, and `astQuery` fields
- Handles both single backtick (`` `pattern` ``) and code fence (` ```regex\npattern\n``` `) wrappers
- Discovered during the Sonnet bulk recompile: 10 ast-grep patterns came out wrapped in backticks, causing silent failures in the rule engine

This must merge **before** the bulk recompile PR (#1224) so the recompile produces clean patterns natively.

## Test plan
- [x] 3 new tests: backtick stripping on ast-grep, backtick stripping on regex, no-op on clean patterns
- [x] 78 compiler tests pass
- [x] Full suite passes
- [x] Totem review passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>