### PR TITLE
chore: align dependabot labels with existing repo labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,5 +19,5 @@ updates:
       day: monday
     open-pull-requests-limit: 5
     labels:
-      - dependencies
-      - ci
+      - 'type: chore'
+      - 'scope: ci'


### PR DESCRIPTION
## Summary
- Replace nonexistent \`dependencies\` and \`ci\` labels with actual \`type: chore\` and \`scope: ci\` labels
- Unblocks label application on open dependabot PRs (#1228, #1229)

The dependabot config was referencing labels that don't exist in this repo, so labels weren't being applied to incoming PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>