### PR TITLE
fix: shell: bash for Compile with Bun step (windows PowerShell parser)

### DIFF
--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -100,6 +100,12 @@ jobs:
           fi
 
       - name: Compile with Bun
+        # shell: bash is required — the multi-line command uses backslash line
+        # continuations, which PowerShell (the default on windows-latest) parses
+        # as a ParserError. This was a latent bug from PR #1200 masked by matrix
+        # fail-fast for 3 releases; exposed when fail-fast was disabled in #1266
+        # and windows finally reached this step. See strategy proposal 214.
+        shell: bash
         run: |
           bun build --compile \
             --target=${{ matrix.bun-target }} \


### PR DESCRIPTION
## Summary

Final hotfix to unblock the 1.13.0 binary backfill. The per-platform caps from #1266 were correctly calibrated — the first run after merge proved it:

| Platform | Cap | Measured | Result |
|---|---|---|---|
| darwin-arm64 | 75 / 90 MB | 68 MB | **PASS** |
| linux-x64 | 120 / 140 MB | 110 MB | **PASS** |
| win32-x64 | 120 / 140 MB | *never reached* | PowerShell ParserError |

All three platforms finally ran to completion because `fail-fast: false` landed in #1266. Windows got as far as the `Compile with Bun` step before hitting a PowerShell parser error on bash-style line continuations.

## Root cause

The `Compile with Bun` step uses backslash line continuations:
```yaml
run: |
  bun build --compile \
    --target=${{ matrix.bun-target }} \
    packages/cli/dist/lite/totem-lite.mjs \
    --outfile packages/cli/dist/lite/bin/${{ matrix.artifact }}
```

The step doesn't specify `shell:`, so on `windows-latest` it defaults to PowerShell 7 (`pwsh.EXE`). PowerShell uses **backtick** for line continuation, not backslash — so `--target=bun-windows-x64 \` is parsed as `--target=bun-windows-x64` followed by a stray backslash token, producing:

```
ParserError: D:\a\_temp\...ps1:3
Line |
   3 |    --target=bun-windows-x64 \
```

**This has been broken since PR #1200** (1.12.0). It was masked by matrix fail-fast for three releases — linux-x64 (or darwin-arm64 before the 1.13.0 cap recalibration) always failed the size gate first and cancelled windows before it reached the Compile step. Disabling fail-fast in #1266 is what finally exposed it.

## Fix

One-line: add `shell: bash` to the step. Matches the pattern already used by the other bash-specific steps in the same workflow (granular gate, final-binary size gate, smoke test).

```yaml
- name: Compile with Bun
  shell: bash   # ← added
  run: |
    bun build --compile \
      ...
```

This forces Git Bash on `windows-latest` (which ships with the runner image via Git for Windows).

## Expected post-merge behavior

After merge + `workflow_dispatch` against `@mmnto/cli@1.13.0`:
- darwin-arm64: PASS (already proven)
- linux-x64: PASS (already proven)
- win32-x64: first real measurement — binary size TBD, will show up in the logs
- attach-to-release: **finally runs** instead of skipping, and the 1.13.0 release assets get populated

## Follow-up if needed

If the windows binary exceeds the provisional 140 MB cap, we'll have a measured data point to either (a) tighten the cap downward if it's meaningfully smaller, or (b) raise it if windows is surprisingly heavier than linux. Either way, it's a trivial matrix tweak and we finally have real data.

## Local verification

- `pnpm exec totem lint` — PASS (393 rules, 0 violations)
- Pre-push hook: 2606 tests pass, totem lint PASS
- Change is tiny and isolated — no meaningful blast radius

## Test plan

- [x] Local quality checks green
- [ ] CI green on PR
- [ ] Post-merge `workflow_dispatch` against `@mmnto/cli@1.13.0` finally succeeds on all 3 platforms
- [ ] Binaries visible via `gh release view @mmnto/cli@1.13.0 --json assets`

🤖 Generated with [Claude Code](https://claude.com/claude-code)