### PR TITLE
fix(core): parseLessonsFile accepts em-dash, en-dash, and hyphen separators (#1263)

### DIFF
--- a/packages/core/src/drift-detector.test.ts
+++ b/packages/core/src/drift-detector.test.ts
@@ -96,6 +96,77 @@ Body text.
     expect(lessons[0]!.raw).toContain('## Lesson — Test');
     expect(lessons[0]!.raw).toContain('Body text.');
   });
+
+  it('accepts em-dash, en-dash, and hyphen separators (#1263)', () => {
+    // Users sometimes type a regular hyphen, or macOS auto-formats `--` to en-dash.
+    // The parser must accept all three so lessons aren't silently dropped.
+    // Regression test for the em-dash silent skip bug discovered on totem-playground.
+    const content = `# Header
+
+---
+
+## Lesson — Em-dash one
+
+**Tags:** a
+
+Body one.
+
+## Lesson - Hyphen two
+
+**Tags:** b
+
+Body two.
+
+## Lesson – En-dash three
+
+**Tags:** c
+
+Body three.
+`;
+
+    const lessons = parseLessonsFile(content);
+    expect(lessons).toHaveLength(3);
+    expect(lessons[0]!.heading).toBe('Em-dash one');
+    expect(lessons[1]!.heading).toBe('Hyphen two');
+    expect(lessons[2]!.heading).toBe('En-dash three');
+  });
+
+  it('preserves the actual separator byte-for-byte in lesson.raw (#1263)', () => {
+    // The raw field is used for content-hash drift detection. If the parser
+    // normalizes the separator to em-dash here, hash comparisons will think
+    // the file has been mutated when it hasn't. The write-side `rewriteLessonsFile`
+    // is allowed to normalize to canonical em-dash on rewrite — but the read-side
+    // `lesson.raw` MUST reflect the exact bytes on disk.
+    const content = `# Header
+
+---
+
+## Lesson — Canonical
+
+**Tags:** a
+
+Body one.
+
+## Lesson - Hyphen
+
+**Tags:** b
+
+Body two.
+
+## Lesson – En-dash
+
+**Tags:** c
+
+Body three.
+`;
+
+    const lessons = parseLessonsFile(content);
+    expect(lessons[0]!.raw).toContain('## Lesson — Canonical');
+    expect(lessons[1]!.raw).toContain('## Lesson - Hyphen');
+    expect(lessons[1]!.raw).not.toContain('## Lesson — Hyphen');
+    expect(lessons[2]!.raw).toContain('## Lesson – En-dash');
+    expect(lessons[2]!.raw).not.toContain('## Lesson — En-dash');
+  });
 });
 
 // ─── extractFileReferences ────────────────────────────

--- a/packages/core/src/drift-detector.ts
+++ b/packages/core/src/drift-detector.ts
@@ -6,7 +6,7 @@ import type { LessonFrontmatter } from './types.js';
 // ─── Types ─────────────────────────────────────────────
 
 export interface ParsedLesson {
-  /** Heading text after "## Lesson — " */
+  /** Heading text after "## Lesson [—|–|-] " (em-dash, en-dash, or hyphen) */
   heading: string;
   /** Extracted tags from the **Tags:** line */
   tags: string[];
@@ -71,24 +71,46 @@ const FILE_EXTENSIONS = new Set([
 
 // ─── Lesson parser ─────────────────────────────────────
 
-const LESSON_HEADING_RE = /^## Lesson — /m;
+/**
+ * Heading delimiter regex — accepts em-dash (—), en-dash (–), or hyphen (-) (#1263).
+ *
+ * Em-dash is the canonical totem convention, but users typing by hand often use a
+ * regular hyphen, and macOS auto-formats `--` to en-dash. Pre-#1263 this regex was
+ * em-dash-only and silently dropped any lesson file using a different separator.
+ *
+ * Uses a character class (NOT a capture group) — `String.prototype.split()` injects
+ * captured matches into the result array, which would break the parts[i] index math.
+ */
+const LESSON_HEADING_RE = /^## Lesson [—–-] /m;
+
+/** Global, capturing variant of LESSON_HEADING_RE for parallel separator extraction. */
+const LESSON_HEADING_SEP_RE = /^## Lesson ([—–-]) /gm;
 
 /**
  * Parse a lessons.md file into individual lesson entries.
- * Splits on `## Lesson —` headings and extracts tags + body.
+ * Splits on `## Lesson [—|–|-]` headings and extracts tags + body.
+ *
+ * The `lesson.raw` field preserves the user's actual separator byte-for-byte from
+ * disk — content-hash drift detection depends on this invariant. Write-side
+ * normalization to canonical em-dash happens separately in `rewriteLessonsFile`.
  */
 export function parseLessonsFile(content: string): ParsedLesson[] {
   const lessons: ParsedLesson[] = [];
 
-  // Split on lesson headings, keeping the delimiter
+  // Split on lesson headings (delimiter consumed)
   const parts = content.split(LESSON_HEADING_RE);
+
+  // Extract the actual separator used in each heading via a parallel matchAll.
+  // Length === parts.length - 1 in well-formed input; the `?? '—'` fallback below
+  // defends against any unexpected divergence by defaulting to canonical em-dash.
+  const separators = [...content.matchAll(LESSON_HEADING_SEP_RE)].map((m) => m[1]!);
 
   // parts[0] is the file header (before the first lesson)
   for (let i = 1; i < parts.length; i++) {
     const part = parts[i]!;
     const lines = part.split('\n');
 
-    // First line is the heading (rest of the ## Lesson — line)
+    // First line is the heading text (rest of the `## Lesson <sep> ` line)
     const heading = (lines[0] ?? '').trim();
 
     // Find tags line: **Tags:** ...
@@ -112,7 +134,9 @@ export function parseLessonsFile(content: string): ParsedLesson[] {
     }
 
     const body = lines.slice(bodyStartIdx).join('\n').trim();
-    const raw = `## Lesson — ${part}`;
+    // Preserve the actual separator from disk (byte-for-byte) for content-hash stability.
+    const sep = separators[i - 1] ?? '—';
+    const raw = `## Lesson ${sep} ${part}`;
 
     lessons.push({ heading, tags, body, raw, index: i - 1 });
   }

--- a/packages/core/src/lesson-io.test.ts
+++ b/packages/core/src/lesson-io.test.ts
@@ -85,6 +85,37 @@ describe('writeLessonFile', () => {
     const content = fs.readFileSync(filePath, 'utf-8');
     expect(content).toContain(`## Lesson — ${shortHeading}`);
   });
+
+  it('truncates and canonicalizes hyphen/en-dash heading separators on write (#1263)', () => {
+    // After #1263 widened the parser to accept hyphen and en-dash, the heading
+    // limit on write must also recognize all three separators AND normalize to
+    // canonical em-dash on output. Otherwise, hyphen-formatted entries silently
+    // bypass the 60-character limit, and the file persists a non-canonical
+    // separator on disk. Mirrors the write-side normalization in rewriteLessonsFile.
+    const lessonsDir = path.join(tmpDir, 'lessons');
+    const longHeading =
+      'This is a very long lesson heading that definitely exceeds the sixty character limit we enforce';
+
+    // Hyphen input → canonical em-dash output, heading truncated
+    const hyphenEntry = `## Lesson - ${longHeading}\n\n**Tags:** t\n\nBody.\n`;
+    const hyphenPath = writeLessonFile(lessonsDir, hyphenEntry);
+    const hyphenContent = fs.readFileSync(hyphenPath, 'utf-8');
+    expect(hyphenContent).toMatch(/^## Lesson — /m);
+    expect(hyphenContent).not.toMatch(/^## Lesson - /m);
+    const hyphenHeadingMatch = hyphenContent.match(/^## Lesson — (.+)$/m);
+    expect(hyphenHeadingMatch).toBeTruthy();
+    expect(hyphenHeadingMatch![1]!.length).toBeLessThanOrEqual(60);
+
+    // En-dash input → canonical em-dash output, heading truncated
+    const enDashEntry = `## Lesson – ${longHeading}\n\n**Tags:** t\n\nBody.\n`;
+    const enDashPath = writeLessonFile(lessonsDir, enDashEntry);
+    const enDashContent = fs.readFileSync(enDashPath, 'utf-8');
+    expect(enDashContent).toMatch(/^## Lesson — /m);
+    expect(enDashContent).not.toMatch(/^## Lesson – /m);
+    const enDashHeadingMatch = enDashContent.match(/^## Lesson — (.+)$/m);
+    expect(enDashHeadingMatch).toBeTruthy();
+    expect(enDashHeadingMatch![1]!.length).toBeLessThanOrEqual(60);
+  });
 });
 
 describe('writeLessonFileAsync', () => {
@@ -208,6 +239,37 @@ describe('readAllLessons', () => {
     const lessons = readAllLessons(tmpDir);
     expect(lessons[0]!.heading).toBe('A');
     expect(lessons[1]!.heading).toBe('Z');
+  });
+
+  it('emits a warning when a lesson file in the directory parses to zero lessons (#1263)', () => {
+    // A .md file with no `## Lesson` heading (e.g., a draft, a misnamed file,
+    // or a file using an unsupported separator) should warn the author instead
+    // of being silently dropped. Pre-#1263, this was the silent failure mode
+    // that ate hyphen-formatted lessons on totem-playground for weeks.
+    const lessonsDir = path.join(tmpDir, 'lessons');
+    fs.mkdirSync(lessonsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(lessonsDir, 'lesson-empty.md'),
+      '# Just a header, no lesson heading\n\nThis file has no `## Lesson` markers.\n',
+      'utf-8',
+    );
+    const warnings: string[] = [];
+    const lessons = readAllLessons(tmpDir, (msg) => warnings.push(msg));
+    expect(lessons).toHaveLength(0);
+    expect(warnings.some((w) => w.includes('lesson-empty.md'))).toBe(true);
+    expect(warnings.some((w) => w.includes('## Lesson'))).toBe(true);
+  });
+
+  it('emits a warning when legacy lessons.md parses to zero lessons (#1263)', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'lessons.md'),
+      '# Totem Lessons\n\nNo lesson entries yet.\n',
+      'utf-8',
+    );
+    const warnings: string[] = [];
+    const lessons = readAllLessons(tmpDir, (msg) => warnings.push(msg));
+    expect(lessons).toHaveLength(0);
+    expect(warnings.some((w) => w.includes('lessons.md'))).toBe(true);
   });
 });
 

--- a/packages/core/src/lesson-io.ts
+++ b/packages/core/src/lesson-io.ts
@@ -18,11 +18,16 @@ export function lessonFileName(content: string): string {
 
 /**
  * Enforce heading length limit on a lesson entry string.
- * Applies truncateHeading() to any `## Lesson — ...` heading that exceeds the limit.
+ * Applies truncateHeading() to any `## Lesson [—|–|-] ...` heading that exceeds the limit.
+ *
+ * Accepts em-dash, en-dash, and hyphen separators (matching the parser as of #1263)
+ * AND normalizes the output to canonical em-dash on write — entries written through
+ * this function persist to disk in canonical form regardless of the input separator.
+ * This mirrors the write-side normalization in `rewriteLessonsFile`.
  */
 function enforceHeadingLimit(entry: string): string {
-  return entry.replace(/^(## Lesson — )(.+)$/m, (_match, prefix: string, heading: string) => {
-    return `${prefix}${truncateHeading(heading) || 'Lesson'}`; // totem-ignore — prefix ends with "— " delimiter
+  return entry.replace(/^## Lesson [—–-] (.+)$/m, (_match, heading: string) => {
+    return `## Lesson — ${truncateHeading(heading) || 'Lesson'}`; // canonical em-dash on write
   });
 }
 
@@ -77,6 +82,12 @@ export function readAllLessons(totemDir: string, onWarn?: (msg: string) => void)
       lesson.sourcePath = legacyPath;
     }
     allLessons.push(...lessons);
+
+    // #1263: warn if a non-empty file produced zero parsed lessons (e.g. unsupported
+    // separator, malformed heading, missing `## Lesson` markers entirely).
+    if (onWarn && lessons.length === 0 && content.trim().length > 0) {
+      onWarn(`${legacyPath}: no '## Lesson [—|–|-] ' headings found — file was skipped`);
+    }
   }
 
   // 2. Read .totem/lessons/*.md (sorted, skip non-.md)
@@ -89,6 +100,7 @@ export function readAllLessons(totemDir: string, onWarn?: (msg: string) => void)
     for (const file of files) {
       const filePath = path.join(lessonsDir, file);
       const content = fs.readFileSync(filePath, 'utf-8');
+      const lessonsBefore = allLessons.length;
 
       // ADR-070: detect YAML frontmatter for individual lesson files
       const warn = onWarn ? (msg: string) => onWarn(`${filePath}: ${msg}`) : undefined;
@@ -112,6 +124,14 @@ export function readAllLessons(totemDir: string, onWarn?: (msg: string) => void)
           lesson.sourcePath = filePath;
         }
         allLessons.push(...lessons);
+      }
+
+      // #1263: warn if a non-empty file produced zero parsed lessons (e.g. unsupported
+      // separator, malformed heading, missing `## Lesson` markers entirely). Pre-#1263
+      // these files were silently dropped — totem-playground discovered hyphen-formatted
+      // lessons had been ignored for weeks before the bug was caught.
+      if (onWarn && allLessons.length === lessonsBefore && content.trim().length > 0) {
+        onWarn(`${filePath}: no '## Lesson [—|–|-] ' headings found — file was skipped`);
       }
     }
   }


### PR DESCRIPTION
## Summary

Closes #1263. Pre-fix, `LESSON_HEADING_RE` matched em-dash only (`/^## Lesson — /m`). Lesson files using a regular hyphen — or macOS-autoformatted en-dash from `--` — were silently parsed as containing zero lessons. No warning, no compilation, no rule produced. Discovered on totem-playground while investigating why 4 of 6 `pg-*` lessons weren't in the rule set: they had been silently dropped for weeks.

## What changed

### Read path — `drift-detector.ts`
- `LESSON_HEADING_RE` widened to `/^## Lesson [—–-] /m` (em-dash, en-dash, hyphen)
- Uses a **character class**, not a capture group — `String.prototype.split()` injects captured matches into the parts array, which would shift indices and break the parser. The spec for #1263 explicitly called this out as the trap.
- New `LESSON_HEADING_SEP_RE = /^## Lesson ([—–-]) /gm` capturing variant for parallel separator extraction via `matchAll`.
- `parseLessonsFile` now reconstructs `lesson.raw` with the **actual** separator from disk, not a hardcoded em-dash. This is **load-bearing**: `lesson.raw` is used for content-hash drift detection — if the parser normalized the separator on read, hash comparisons would think the file had been mutated when it hadn't. (Caught by Gemini during review of the proposed fix.)

### Write path — `lesson-io.ts`
- `enforceHeadingLimit` regex widened to match all three separators **AND normalize to canonical em-dash on output**. Pre-fix, hyphen-formatted entries flowed through `prepareLessonForWrite` and silently bypassed the 60-character heading limit because the em-dash-only regex didn't match. Mirrors the existing write-side normalization in `rewriteLessonsFile`. (Caught by Shield AI in `totem review` as a follow-on consequence of the read-path widening.)
- `readAllLessons` now emits the existing `onWarn` callback when a non-empty `.md` file in `.totem/lessons/` (or the legacy `.totem/lessons.md`) parses to zero lessons. Pre-fix, these were silently dropped — discoverable only by counting expected vs. actual rule output.

## Architectural principle (write canonical, read accurate)

This PR codifies an asymmetry that totem already practices implicitly:

| Side | Behavior | Why |
|---|---|---|
| **Read** | `lesson.raw` reflects exact bytes on disk | Content-hash drift detection requires byte-level fidelity |
| **Write** | Always normalize to canonical em-dash | Totem is an enforcement engine — quietly correct sloppy separators rather than build a state-tracker just to preserve a typo |

`rewriteLessonsFile` was already canonicalizing on the prune path; this PR brings `enforceHeadingLimit` into alignment with the same principle.

## Tests added (5)

| Test | What it locks in |
|---|---|
| `parseLessonsFile > accepts em-dash, en-dash, and hyphen separators (#1263)` | 3-lesson regression, all separators in one file |
| `parseLessonsFile > preserves the actual separator byte-for-byte in lesson.raw (#1263)` | Content-hash invariant — `raw` must match disk |
| `readAllLessons > emits a warning when a lesson file in the directory parses to zero lessons (#1263)` | Silent-drop prevention for `.totem/lessons/*.md` |
| `readAllLessons > emits a warning when legacy lessons.md parses to zero lessons (#1263)` | Same, for the legacy path |
| `writeLessonFile > truncates and canonicalizes hyphen/en-dash heading separators on write (#1263)` | Heading-limit enforcement + normalization for non-canonical inputs |

## Verification

| Check | Result |
|---|---|
| `pnpm --filter @mmnto/totem test` (core) | **974/974 pass** |
| Full suite (core + cli + mcp via `pnpm -r test`) | **2611/2611 pass** |
| `pnpm run format` | clean |
| `pnpm totem lint` | PASS, 20 warnings, **0 errors** |
| `pnpm totem review` (Shield AI) | **PASS, 0 findings** (final pass) |
| `mcp__totem-dev__verify_execution` | PASS |

## Two notable observations from the self-governance flywheel

### 1. Shield AI caught a cascading consequence in real time

The first run of `totem review` flagged `enforceHeadingLimit` as a follow-on issue created by the read-path change: now that hyphen-formatted lessons can exist in the corpus, the write-side heading limit silently wouldn't fire on them. **This was the exact cascading architectural consequence the shield was designed to catch.** I did not see it in my preflight; the shield did. Per Gemini's strategic call, the fix went into this PR rather than a follow-up because reconciling read+write invariants is structural integrity, not scope creep.

### 2. The lint warnings are noise — flagged for the Refinement Engine, not manual suppression

The PR adds **20 lint warnings, 0 errors**. Of those, 18 are noisy false positives concentrated in two test files:

- **`lesson-io.test.ts:228, 229, 241`** — 6 different lessons all firing on `expect(warnings.some((w) => w.includes('lesson-empty.md')))` test assertions. Lessons cover advice like "use `path.basename()` to identify target files", "check for null author fields from third-party metadata", "use line-start regex to detect markers in user-authored files". **None of these apply to test code asserting that a warning string contains an expected substring.**
- **`lesson-io.test.ts:220`** — `fs.writeFileSync(path.join(lessonsDir, 'lesson-empty.md'), ...)` flagged by a lesson titled "Detect existing hook managers and provide manual guidance". The lesson is about not writing directly to `.git/hooks`. The test is writing a `.totem/lessons/` test fixture. **Wildly off-target match.**
- **`drift-detector.test.ts:164, 165`** — `expect(lessons[1]!.raw).toContain('## Lesson - Hyphen')` flagged by a lesson titled "Avoid using partial matchers like toContain when testing" — the actual lesson is about secret-masking assertions, not generic `toContain` use. **False-positive on lesson scope.**

**These are exactly the upgrade candidates that `totem doctor --pr` is designed to flag** — every one of these matches lands in a non-code context (test assertions, test fixture setup). Per the 1.13.0 Refinement Engine philosophy, the right move is to let the telemetry accumulate and let `doctor` flag these lessons for compile-upgrade, not to manually refactor my test code to satisfy noisy rules. Filing a follow-up observation: at least 6 lessons in the corpus need precision-targeted refinement after they collect a few more non-code hits.

(I considered using `expect(...).toMatch(/regex/)` in place of `.includes()` in the assertions, but that would:
- Hide a legitimate signal that the corpus needs tuning
- Set a precedent that test code should be contorted to satisfy production-targeted lessons
- Defeat the purpose of the Refinement Engine, which exists precisely so we don't have to do that)

## Out of scope (deliberately not touched)

- `rewriteLessonHeadings` in `lesson-format.ts` uses its own `/^(## Lesson — )(.+)$/gm` regex for a separate format-rewrite concern. Could benefit from the same widening as a future cleanup, but it's not on the fix path for #1263.
- The auto-captured "Pipeline 5: observation from shield" rule that the first `totem review` run wrote into `.totem/compiled-rules.json` — its compiled pattern was `\*/` against `**/*.ts`, which is meaningless (matches the end of every block comment). Excluded from staging. Worth a separate ticket: "Pipeline 5 observation capture produces nonsense regex from shield findings".
- The `packages/core/{}` stray file from #1233 — known issue, separate ticket.

## Test plan

- [x] Unit tests for parser multi-separator support
- [x] Unit tests for byte-for-byte `lesson.raw` preservation
- [x] Unit tests for zero-lesson warnings (both legacy and per-file paths)
- [x] Unit test for write-side normalization + heading limit enforcement
- [x] Full suite green (2611 tests)
- [x] Format clean
- [x] Lint pass
- [x] Shield AI review zero findings
- [x] `mcp verify_execution` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
