### PR TITLE
fix: 1.14.1 Hotfix Sweep (#1304, #1305, #1306, #1309)

### DIFF
--- a/docs/active_work.md
+++ b/docs/active_work.md
@@ -1,36 +1,33 @@
 ### Active Work Summary
 
-The project is at release `@mmnto/cli@1.13.0` (published 2026-04-07, "The Refinement Engine") with **2,722 tests** across core, CLI, and MCP packages and **394 compiled rules** (up from 393 after the 1.14.0 lesson extraction + Sonnet compile). **1.14.0 is scope-locked and in release prep** — Cross-Repo Context Mesh as the headline feature plus LLM Context Caching machinery shipping as opt-in preview. Theme renamed to "The Nervous System Foundation" to reflect what actually landed (previously locked as "The Distribution Pipeline," which now slides to 1.15.0).
+The project is at release `@mmnto/cli@1.14.0` (published 2026-04-09, "The Nervous System Foundation") with **2,722 tests** across core, CLI, and MCP packages and **394 compiled rules**.
 
-### Current: 1.14.0 — The Nervous System Foundation (release prep)
+### Current: 1.14.1 — Hotfix Sweep & Queue Drain
 
-Theme: Cross-repo federated context (active default) plus opt-in preview of persistent LLM context caching — two halves of the same nervous system, shipping at different maturity levels in 1.14.0 (mesh active, caching opt-in preview pending default activation in 1.15.0 per mmnto/totem#1291).
+Theme: Draining the technical debt queue before opening new architectural surface.
 
-- **Cross-Repo Context Mesh (shipped, active default):**
-  - ~~**#1295**~~ — Phases 1-3 of Proposal 215. `linkedIndexes: []` config, required `SourceContext` on `SearchResult`, federated search with cross-store RRF merge, per-query runtime warnings (not session-persistent), collision-safe failure log, targeted boundary routing (Case 2 isError on full failure, Case 3 for broken-init links), dimension-mismatch diagnostic that persists until the index is fixed, one-shot flags consumed only after successful work, empirical smoke test
-  - 9 bot review rounds, ~27 findings resolved across 9 fix commits — see PR body for the full architectural journey
+- **#1304** — `applyAstRulesToAdditions` staged content + cwd resolution bug.
+- **#1305** — `lance-search` SQL backtick over-escape cleanup.
+- **#1306** — AST engine test coverage audit (locking in #1304 and #1305).
+- **#1309** — `totem doctor` upgrade-candidate hint + stale-manifest warning emit deprecated compile.
 
-- **LLM Context Caching — Opt-In Preview (shipped, default off):**
-  - ~~**#1292**~~ — Phases 1-3 of Proposal 217. Anthropic `cache_control` wired through orchestrator middleware for compile + review paths. Sliding TTL configurable via `cacheTTL` (constrained to Anthropic's two supported values: `300` default or `3600` extended); resets on every cache hit, so bulk recompile runs stay warm end-to-end **when enabled**. Defaults to off in 1.14.0 — opt-in via `enableContextCaching: true` in `totem.config.ts` to avoid surprising existing users mid-cycle with a token-usage profile shift. Default activation tracked for 1.15.0 in mmnto/totem#1291. Anthropic-only in 1.14.0; Gemini `CachedContent` tracked for 1.16.0+. The full machinery (orchestrator middleware, schema field, TTL-literal validation, per-call cache metric tracking) ships in 1.14.0 — only the default-on behavior is deferred.
+_Note: #1304 introduces a new callback injection for the read strategy and requires a `/preflight` v2 design-doc gate._
 
-- **Workflow governance (shipped):**
-  - ~~**#1296**~~ — `/preflight` skill v2. Adds triage-gated design-doc phase between `totem spec` and code for architectural changes. Six-subsection template (scope, data model, state lifecycle, failure modes table, invariants, open questions) + explicit approval gate. Direct response to the #1295 review cycle — ~70-80% of the ~27 findings would have been caught by a 1-page design doc before any code was written. Tactical changes skip Phase 3 via explicit triage checklist
+- **#1299** — Expand `/preflight` v2 to docs that document feature surfaces (single-file edit to SKILL.md).
+- **#1302** — Document dual-hash convention in `.gemini/styleguide.md`.
+- **#1298** — Shield branding cleanup.
+- **#1301** — Audit `nonCompilable` lesson bodies for implementation contradictions.
 
-- **Governance + cleanup (shipped this branch):**
-  - ~~**chore**~~ — Extract 19 lessons from the 1.14.0 PR arc (#1292, #1295, #1296)
-  - ~~**chore**~~ — Compile 1 new rule from those lessons via local Sonnet (394 total, up from 393). 18 lessons skipped as architectural/conceptual — they become `nonCompilable` tuples for doctor triage. (Initial pass produced a `process.exit($CODE)` ast-grep rule + a malformed delimiter pattern; the delimiter lesson was reframed as architectural after both bots flagged the broken pattern, so it now ships as documentation only.)
+### Next: 1.15.0 — The Distribution Pipeline
 
-- **Pre-release checklist:**
-  - [x] Update `docs/active_work.md`
-  - [ ] Update `docs/roadmap.md` (handled by `totem docs` generation; not hand-edited)
-  - [ ] Update README + wiki (hand off to Gemini)
-  - [x] Add changeset (minor for `@mmnto/cli` + `@mmnto/totem` + `@mmnto/mcp`)
-  - [ ] File totem-playground tickets for playground refresh (validate mesh federation from playground)
-  - [ ] Rebuild standalone binary for linux-x64, darwin-arm64, win32-x64
-  - [x] Push branch + open release prep PR (mmnto/totem#1300)
-  - [ ] Merge release PR + Version Packages PR to publish 1.14.0
+Theme: The Totem Pack Ecosystem. 1.14.0 proved the Nervous System (federated context + cached tokens); 1.15.0 lets teams bundle and share compiled rules across repositories via the npm registry. Headline work: #1059 + Strategy #35 + ADR-085 Totem Pack Ecosystem. Cleanup tickets bundled as operational chores along the way (see "Deferred to 1.15.0" below).
 
-- **Deferred to 1.15.0 — The Distribution Pipeline** (slid from 1.14.0 when the mesh + caching arc shipped first):
+_New queued features for 1.15.x:_
+
+- **#1307** — CLI `totem search` silently ignores `linkedIndexes`.
+- **#1308** — `totem doctor` has no Linked Indexes health check.
+
+- **Deferred to 1.15.0:**
   - **#1059** — Rule pack distribution (headline)
   - Strategy **#35** — Distributing compiled rules (headline)
   - **#1221** — Cloud compile worker Sonnet routing (critical for cloud distribution)
@@ -40,26 +37,23 @@ Theme: Cross-repo federated context (active default) plus opt-in preview of pers
   - **#1218** — Broad `throw $ERR` ast-grep pattern needs refinement
   - **#1219** — Lazy-load compiler prompt templates
 
-- **Deferred to 1.16.0 — The Ingestion Pipeline** (slid from 1.15.0):
+### After Next: 1.16.0 — The Ingestion Pipeline
+
+Theme: Source Diversity and the Self-Healing Loop. Convert external signals (GHAS alerts, lint warnings) into Totem lessons. Headline work: Strategy #50 + #51 + ADR-086 External Alert Ingestion.
+
+- **Deferred to 1.16.0:**
   - Strategy **#50** — GHAS / SARIF alert extraction (headline)
   - Strategy **#51** — Lint warning extraction (headline)
   - **#1226** — SARIF upload hex escape fix (load-bearing for SARIF ingestion)
   - **#1279** — Pipeline 5 hallucination bug (sand before ingestion ships; escalated from 1.14.0 post-evidence)
   - Strategy **#17** — Governance eval harness (validate ingested inputs)
 
-- **Backlog (Horizon 3+):**
-  - Strategy **#6** — Adversarial trap corpus
-  - Strategy **#62** — Model-specific prompt adapters (partially addressed by #1220 rewrite)
-  - Strategy **#64** — Model Routing Matrix (partially addressed by #73 benchmark)
-  - **#1236** — Revisit 6 silenced upgrade-target lessons (1.13.0 cleanup)
+### Backlog (Horizon 3+)
 
-### Next: 1.15.0 — The Distribution Pipeline
-
-Theme: The Totem Pack Ecosystem. 1.14.0 proved the Nervous System (federated context + cached tokens); 1.15.0 lets teams bundle and share compiled rules across repositories via the npm registry. Headline work: #1059 + Strategy #35 + ADR-085 Totem Pack Ecosystem. Cleanup tickets bundled as operational chores along the way (see "Deferred to 1.15.0" above).
-
-### After Next: 1.16.0 — The Ingestion Pipeline
-
-Theme: Source Diversity and the Self-Healing Loop. Convert external signals (GHAS alerts, lint warnings) into Totem lessons. Headline work: Strategy #50 + #51 + ADR-086 External Alert Ingestion.
+- Strategy **#6** — Adversarial trap corpus
+- Strategy **#62** — Model-specific prompt adapters (partially addressed by #1220 rewrite)
+- Strategy **#64** — Model Routing Matrix (partially addressed by #73 benchmark)
+- **#1236** — Revisit 6 silenced upgrade-target lessons (1.13.0 cleanup)
 
 ### Recently Completed
 

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -633,7 +633,7 @@ describe('checkUpgradeCandidates', () => {
     expect(result.status).toBe('warn');
     expect(result.message).toContain('noisy-rule');
     expect(result.message).toContain('40%');
-    expect(result.remediation).toContain('totem compile --upgrade noisy-rule');
+    expect(result.remediation).toContain('totem lesson compile --upgrade noisy-rule');
   });
 
   it('does NOT flag a rule at exactly 20% non-code (strict greater-than)', async () => {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -515,7 +515,7 @@ export async function findUpgradeCandidates(
 /**
  * Find regex/ast rules whose telemetry shows >NON_CODE_THRESHOLD of matches landing
  * in non-code contexts (strings, comments, regex literals). These are good candidates
- * for being upgraded to structural ast-grep patterns via `totem compile --upgrade`.
+ * for being upgraded to structural ast-grep patterns via `totem lesson compile --upgrade`.
  */
 export async function checkUpgradeCandidates(
   cwd: string,
@@ -559,7 +559,7 @@ export async function checkUpgradeCandidates(
     name: 'Upgrade Candidates',
     status: 'warn',
     message: `${candidates.length} rule(s) firing in non-code contexts: ${summary}`,
-    remediation: `Run \`totem compile --upgrade ${firstHash}\` to re-compile through Claude Sonnet with telemetry guidance.`,
+    remediation: `Run \`totem lesson compile --upgrade ${firstHash}\` to re-compile through Claude Sonnet with telemetry guidance.`,
   };
 }
 

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -49,7 +49,7 @@ export async function lintCommand(options: LintOptions): Promise<void> {
       if (currentInputHash !== manifest.input_hash) {
         uiLog.warn(
           TAG,
-          "Compile manifest is stale — lessons changed since last compile. Run 'totem compile' to update.",
+          "Compile manifest is stale — lessons changed since last compile. Run 'totem lesson compile' to update.",
         );
       }
     }
@@ -74,6 +74,7 @@ export async function lintCommand(options: LintOptions): Promise<void> {
     ignorePatterns: allIgnore,
     tag: TAG,
     configRoot,
+    isStaged: !!options.staged,
   });
 
   // Post PR comment if requested (zero-API-keys invariant: only behind --pr-comment flag)

--- a/packages/cli/src/commands/run-compiled-rules.test.ts
+++ b/packages/cli/src/commands/run-compiled-rules.test.ts
@@ -346,6 +346,29 @@ describe('runCompiledRules', () => {
     expect(result.violations).toHaveLength(0);
   });
 
+  it('excludes binary files from scanning', async () => {
+    const rules = [
+      makeRule('console\\.log\\("foo"\\)', 'No foo log', 'No foo log', {
+        engine: 'ast-grep',
+        astGrepPattern: 'console.log("foo")',
+      }),
+    ];
+    writeRules(tmpDir, rules);
+
+    // Diff that changes a binary file (.png)
+    const diff = makeDiff('assets/logo.png', '  console.log("foo");');
+
+    const result = await runCompiledRules({
+      diff,
+      cwd: tmpDir,
+      totemDir: TOTEM_DIR,
+      format: 'json',
+      tag: 'Test',
+    });
+
+    expect(result.violations).toHaveLength(0);
+  });
+
   // ─── Ignore patterns ────────────────────────────────
 
   // ─── SARIF output ──────────────────────────────────
@@ -605,6 +628,368 @@ describe('runCompiledRules', () => {
     expect(events[0]!.file).toBe('src/app.ts');
     expect(events[0]!.justification).toBe('needed for monitoring');
     expect(events[0]!.source).toBe('lint');
+  });
+
+  // ─── readStrategy / isStaged ────────────────────────
+
+  describe('readStrategy / isStaged', () => {
+    it('constructs readStrategy and reads staged content via the underlying staged read when isStaged is true', async () => {
+      const rules = [
+        makeRule('console\\.log\\("foo"\\)', 'No foo log', 'No foo log', {
+          engine: 'ast-grep',
+          astGrepPattern: 'console.log("foo")',
+        }),
+      ];
+      writeRules(tmpDir, rules);
+
+      const diff = makeDiff('src/app.ts', '  console.log("foo");');
+
+      const mockResolveGitRoot = vi.spyOn(totem, 'resolveGitRoot').mockReturnValue(tmpDir);
+
+      const mockExec = vi
+        .spyOn(totem, 'safeExec')
+        .mockImplementation((cmd: string, args?: string[]) => {
+          if (!args) return '';
+          if (args[0] === 'ls-files' && args[1] === '--recurse-submodules' && args[2] === '-s') {
+            return '100644 hash 0\tsrc/app.ts\n';
+          }
+          if (args[0] === 'show') {
+            return '// context\n  console.log("foo");\n// context\n';
+          }
+          return '';
+        });
+
+      let violations: unknown[] = [];
+      try {
+        const result = await runCompiledRules({
+          diff,
+          cwd: tmpDir,
+          totemDir: TOTEM_DIR,
+          format: 'json',
+          tag: 'Test',
+          isStaged: true,
+        });
+        violations = result.violations;
+      } catch (err: unknown) {
+        if (
+          err instanceof Error &&
+          err.name === 'TotemError' &&
+          err.message.includes('Violations detected')
+        ) {
+          violations = [1]; // We just need to know it matched
+        } else {
+          throw err;
+        }
+      }
+
+      expect(violations).toHaveLength(1);
+      mockResolveGitRoot.mockRestore();
+      mockExec.mockRestore();
+    });
+
+    it('filters symlinks via the underlying index check mode 120000', async () => {
+      const rules = [
+        makeRule('console\\.log\\("foo"\\)', 'No foo log', 'No foo log', {
+          engine: 'ast-grep',
+          astGrepPattern: 'console.log("foo")',
+        }),
+      ];
+      writeRules(tmpDir, rules);
+
+      const diff = makeDiff('src/app.ts', '  console.log("foo");');
+
+      const mockResolveGitRoot = vi.spyOn(totem, 'resolveGitRoot').mockReturnValue(tmpDir);
+
+      const mockExec = vi
+        .spyOn(totem, 'safeExec')
+        .mockImplementation((cmd: string, args?: string[]) => {
+          if (!args) return '';
+          if (args[0] === 'ls-files' && args[1] === '--recurse-submodules' && args[2] === '-s') {
+            return '120000 hash 0\tsrc/app.ts\n'; // Symlink
+          }
+          if (args[0] === 'show') {
+            return 'console.log("foo");\n'; // Should not be called
+          }
+          return '';
+        });
+
+      try {
+        const result = await runCompiledRules({
+          diff,
+          cwd: tmpDir,
+          totemDir: TOTEM_DIR,
+          format: 'json',
+          tag: 'Test',
+          isStaged: true,
+        });
+
+        expect(result.violations).toHaveLength(0);
+      } finally {
+        mockResolveGitRoot.mockRestore();
+        mockExec.mockRestore();
+      }
+    });
+
+    it('normalizes CRLF to LF in staged content', async () => {
+      const rules = [
+        makeRule('console\\.log\\("foo"\\)', 'No foo log', 'No foo log', {
+          engine: 'ast-grep',
+          astGrepPattern: 'console.log("foo")',
+        }),
+      ];
+      writeRules(tmpDir, rules);
+
+      const diff = makeDiff('src/app.ts', '  console.log("foo");');
+
+      const mockResolveGitRoot = vi.spyOn(totem, 'resolveGitRoot').mockReturnValue(tmpDir);
+
+      const mockExec = vi
+        .spyOn(totem, 'safeExec')
+        .mockImplementation((cmd: string, args?: string[]) => {
+          if (!args) return '';
+          if (args[0] === 'ls-files' && args[1] === '--recurse-submodules' && args[2] === '-s') {
+            return '100644 hash 0\tsrc/app.ts\n';
+          }
+          if (args[0] === 'show') {
+            return '// context\r\n  console.log("foo");\r\n// context\r\n';
+          }
+          return '';
+        });
+
+      let violations: unknown[] = [];
+      try {
+        const result = await runCompiledRules({
+          diff,
+          cwd: tmpDir,
+          totemDir: TOTEM_DIR,
+          format: 'json',
+          tag: 'Test',
+          isStaged: true,
+        });
+        violations = result.violations;
+      } catch (err: unknown) {
+        if (
+          err instanceof Error &&
+          err.name === 'TotemError' &&
+          err.message.includes('Violations detected')
+        ) {
+          violations = [1];
+        } else {
+          throw err;
+        }
+      }
+
+      expect(violations).toHaveLength(1);
+      mockResolveGitRoot.mockRestore();
+      mockExec.mockRestore();
+    });
+
+    it('throws STAGED_READ_FAILED when the underlying staged read fails', async () => {
+      const rules = [
+        makeRule('console\\.log\\("foo"\\)', 'No foo log', 'No foo log', {
+          engine: 'ast-grep',
+          astGrepPattern: 'console.log("foo")',
+        }),
+      ];
+      writeRules(tmpDir, rules);
+
+      const diff = makeDiff('src/app.ts', '  console.log("foo");');
+
+      const mockResolveGitRoot = vi.spyOn(totem, 'resolveGitRoot').mockReturnValue(tmpDir);
+
+      const mockExec = vi
+        .spyOn(totem, 'safeExec')
+        .mockImplementation((cmd: string, args?: string[]) => {
+          if (!args) return '';
+          if (args[0] === 'ls-files' && args[1] === '--recurse-submodules' && args[2] === '-s') {
+            return '100644 hash 0\tsrc/app.ts\n';
+          }
+          if (args[0] === 'show') {
+            throw new Error('[Totem Error] Command failed: show :src/app.ts');
+          }
+          return '';
+        });
+
+      try {
+        await expect(
+          runCompiledRules({
+            diff,
+            cwd: tmpDir,
+            totemDir: TOTEM_DIR,
+            format: 'json',
+            tag: 'Test',
+            isStaged: true,
+          }),
+        ).rejects.toThrow('Failed to read staged content');
+      } finally {
+        mockResolveGitRoot.mockRestore();
+        mockExec.mockRestore();
+      }
+    });
+
+    it('does not construct readStrategy when isStaged is false', async () => {
+      const rules = [
+        makeRule('console\\.log\\("foo"\\)', 'No foo log', 'No foo log', {
+          engine: 'ast-grep',
+          astGrepPattern: 'console.log("foo")',
+        }),
+      ];
+      writeRules(tmpDir, rules);
+
+      fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, 'src', 'app.ts'),
+        '// context\n  console.log("foo");\n// context\n',
+      );
+
+      const diff = makeDiff('src/app.ts', '  console.log("foo");');
+
+      const mockExec = vi.spyOn(totem, 'safeExec').mockImplementation(() => {
+        throw new Error('[Totem Error] Should not be called');
+      });
+
+      let violations: unknown[] = [];
+      try {
+        const result = await runCompiledRules({
+          diff,
+          cwd: tmpDir,
+          totemDir: TOTEM_DIR,
+          format: 'json',
+          tag: 'Test',
+          isStaged: false,
+        });
+        violations = result.violations;
+      } catch (err: unknown) {
+        if (
+          err instanceof Error &&
+          err.name === 'TotemError' &&
+          err.message.includes('Violations detected')
+        ) {
+          violations = [1];
+        } else {
+          throw err;
+        }
+      }
+
+      // AST engine runs with disk-read fallback
+      expect(violations).toHaveLength(1);
+      mockExec.mockRestore();
+    });
+
+    it('uses repo root as workingDirectory when cwd is a subdirectory', async () => {
+      const rules = [
+        makeRule('console\\.log\\("foo"\\)', 'No foo log', 'No foo log', {
+          engine: 'ast-grep',
+          astGrepPattern: 'console.log("foo")',
+        }),
+      ];
+      writeRules(tmpDir, rules);
+
+      const diff = makeDiff('src/app.ts', '  console.log("foo");');
+
+      const subDir = path.join(tmpDir, 'sub', 'dir');
+      fs.mkdirSync(subDir, { recursive: true });
+
+      const mockResolveGitRoot = vi.spyOn(totem, 'resolveGitRoot').mockReturnValue(tmpDir);
+
+      const mockExec = vi
+        .spyOn(totem, 'safeExec')
+        .mockImplementation((cmd: string, args?: string[]) => {
+          if (!args) return '';
+          if (args[0] === 'ls-files' && args[1] === '--recurse-submodules' && args[2] === '-s') {
+            return '100644 hash 0\tsrc/app.ts\n';
+          }
+          if (args[0] === 'show') {
+            return '// context\n  console.log("foo");\n// context\n';
+          }
+          return '';
+        });
+
+      const spyAst = vi.spyOn(totem, 'applyAstRulesToAdditions');
+
+      let violations: unknown[] = [];
+      try {
+        const result = await runCompiledRules({
+          diff,
+          cwd: subDir,
+          totemDir: TOTEM_DIR,
+          format: 'json',
+          tag: 'Test',
+          isStaged: true,
+          configRoot: tmpDir,
+        });
+        violations = result.violations;
+      } catch (err: unknown) {
+        if (
+          err instanceof Error &&
+          err.name === 'TotemError' &&
+          err.message.includes('Violations detected')
+        ) {
+          violations = [1];
+        } else {
+          throw err;
+        }
+      }
+
+      expect(violations).toHaveLength(1);
+      expect(spyAst).toHaveBeenCalled();
+      // Check that workingDirectory passed to applyAstRulesToAdditions is tmpDir (repo root), not subDir
+      expect(spyAst.mock.calls[0]![2]).toBe(tmpDir);
+      mockResolveGitRoot.mockRestore();
+      mockExec.mockRestore();
+      spyAst.mockRestore();
+    });
+
+    it('falls back to original cwd when not in a git repo (resolveGitRoot returns null)', async () => {
+      const rules = [
+        makeRule('console\\.log\\("foo"\\)', 'No foo log', 'No foo log', {
+          engine: 'ast-grep',
+          astGrepPattern: 'console.log("foo")',
+        }),
+      ];
+      writeRules(tmpDir, rules);
+
+      fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, 'src', 'app.ts'),
+        '// context\n  console.log("foo");\n// context\n',
+      );
+
+      const diff = makeDiff('src/app.ts', '  console.log("foo");');
+
+      const mockResolveGitRoot = vi.spyOn(totem, 'resolveGitRoot').mockReturnValue(null);
+      const mockExec = vi.spyOn(totem, 'safeExec').mockImplementation(() => {
+        throw new Error('[Totem Error] Should not be called');
+      });
+
+      let violations: unknown[] = [];
+      try {
+        const result = await runCompiledRules({
+          diff,
+          cwd: tmpDir,
+          totemDir: TOTEM_DIR,
+          format: 'json',
+          tag: 'Test',
+          isStaged: true,
+        });
+        violations = result.violations;
+      } catch (err: unknown) {
+        if (
+          err instanceof Error &&
+          err.name === 'TotemError' &&
+          err.message.includes('Violations detected')
+        ) {
+          violations = [1];
+        } else {
+          throw err;
+        }
+      }
+
+      // Should gracefully fallback to disk read and process rules
+      expect(violations).toHaveLength(1);
+      mockResolveGitRoot.mockRestore();
+      mockExec.mockRestore();
+    });
   });
 });
 

--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -15,6 +15,8 @@ export interface RunCompiledRulesOptions {
   tag: string;
   /** Absolute path to config root — used for cache paths instead of cwd */
   configRoot?: string;
+  /** True if we are linting staged changes only */
+  isStaged?: boolean;
 }
 
 export interface RunCompiledRulesResult {
@@ -52,12 +54,15 @@ export async function runCompiledRules(
     recordContextHit,
     recordSuppression,
     recordTrigger,
+    resolveGitRoot,
+    safeExec,
     saveRuleMetrics,
     setCoreLogger,
     TotemError,
   } = await import('@mmnto/totem');
 
-  const { diff, cwd, totemDir, format, outPath, exportPaths, ignorePatterns, tag } = options;
+  const { diff, cwd, totemDir, format, outPath, exportPaths, ignorePatterns, tag, isStaged } =
+    options;
 
   // Wire core logger to CLI UI (ADR-071: core must not use console.warn directly)
   setCoreLogger({ warn: (msg) => log.warn(tag, msg) });
@@ -78,7 +83,26 @@ export async function runCompiledRules(
 
     log.info(tag, `Running ${rules.length} rules (zero LLM)...`);
 
-    // Extract additions, exclude compiled rules file and export targets
+    // Extract additions, exclude compiled rules file, export targets, and binary files
+    const BINARY_EXTENSIONS = new Set([
+      '.png',
+      '.jpg',
+      '.jpeg',
+      '.gif',
+      '.mp4',
+      '.pdf',
+      '.zip',
+      '.tar',
+      '.gz',
+      '.woff',
+      '.woff2',
+      '.eot',
+      '.ttf',
+      '.mp3',
+      '.wav',
+      '.ico',
+      '.bin',
+    ]);
     const rulesRelPath = path.join(totemDir, COMPILED_RULES_FILE).replace(/\\/g, '/');
     const excluded = new Set([rulesRelPath]);
     if (exportPaths) {
@@ -88,6 +112,7 @@ export async function runCompiledRules(
     }
     const additions = extractAddedLines(diff)
       .filter((a) => !excluded.has(a.file))
+      .filter((a) => !BINARY_EXTENSIONS.has(path.extname(a.file).toLowerCase()))
       .filter(
         (a) => !ignorePatterns || !ignorePatterns.some((pattern) => matchesGlob(a.file, pattern)),
       );
@@ -142,14 +167,65 @@ export async function runCompiledRules(
     if (astRules.length > 0) {
       log.dim(tag, `Running ${astRules.length} AST rule(s)...`);
       try {
+        let workingDirectory = cwd;
+        let readStrategy: ((filePath: string) => Promise<string | null>) | undefined = undefined;
+
+        if (isStaged) {
+          const repoRoot = resolveGitRoot(cwd);
+          if (repoRoot) {
+            workingDirectory = repoRoot;
+
+            readStrategy = async (filePath: string) => {
+              try {
+                // 1. Detect symlinks explicitly (git ls-files -s returns mode 120000).
+                //    The `--` separator prevents filePath values starting with `-` from
+                //    being interpreted as git options.
+                const lsOutput = safeExec(
+                  'git',
+                  ['ls-files', '--recurse-submodules', '-s', '--', filePath],
+                  { cwd: repoRoot, env: { ...process.env, LC_ALL: 'C' } },
+                );
+                if (lsOutput.startsWith('120000 ')) {
+                  return null; // Explicitly exclude symlinks from AST checks
+                }
+
+                // 2. Read staged content
+                const content = safeExec('git', ['show', `:${filePath}`], {
+                  cwd: repoRoot,
+                  trim: false,
+                  env: { ...process.env, LC_ALL: 'C' },
+                });
+
+                // 3. Normalize CRLF to LF specifically for the staged callback
+                // Disk-read callback preserves existing behavior per Invariant #4.
+                return content.replace(/\r\n/g, '\n');
+              } catch (err) {
+                // Explicit throw per Failure Mode 1 decision
+                throw new TotemError(
+                  'STAGED_READ_FAILED',
+                  `Failed to read staged content for ${filePath}`,
+                  `git show :${filePath} failed. The file may not exist in the index or may be staged for deletion. Ensure --staged is used correctly.`,
+                  { cause: err },
+                );
+              }
+            };
+          }
+        }
+
         astViolations = await applyAstRulesToAdditions(
           rules,
           additions,
-          cwd,
+          workingDirectory,
           ruleEventCallback,
           (msg) => log.warn(tag, msg),
+          readStrategy,
         );
       } catch (err) {
+        // STAGED_READ_FAILED must propagate — the pre-commit guarantee depends
+        // on surfacing staged-read failures rather than silently falling back.
+        if (err instanceof TotemError && err.code === 'STAGED_READ_FAILED') {
+          throw err;
+        }
         const msg = err instanceof Error ? err.message : String(err);
         const isWasmFailure = /not initialized|wasm|web-tree-sitter/i.test(msg);
         if (process.env['TOTEM_LITE'] === '1' && isWasmFailure) {

--- a/packages/core/src/ast-query.ts
+++ b/packages/core/src/ast-query.ts
@@ -173,8 +173,9 @@ export async function matchAstQuery(
 export async function matchAstQueriesBatch(
   filePath: string,
   queries: Array<{ astQuery: string; addedLineNumbers: number[] }>,
-  cwd: string,
+  workingDirectory: string,
   onWarn: (msg: string) => void = console.warn, // totem-context: fallback ensures query failures are never silently swallowed
+  readStrategy?: (filePath: string) => Promise<string | null>,
 ): Promise<AstMatch[][]> {
   if (queries.length === 0) return [];
 
@@ -184,7 +185,20 @@ export async function matchAstQueriesBatch(
     return queries.map(() => []);
   }
 
-  const content = await readFileContent(filePath, cwd);
+  let content: string | null = null;
+  if (readStrategy) {
+    content = await readStrategy(filePath);
+  } else {
+    // Default disk read fallback
+    try {
+      const fullPath = path.resolve(workingDirectory, filePath);
+      const fs = await import('node:fs/promises');
+      content = await fs.readFile(fullPath, 'utf-8');
+    } catch {
+      content = null;
+    }
+  }
+
   if (!content) {
     return queries.map(() => []);
   }

--- a/packages/core/src/ast-query.ts
+++ b/packages/core/src/ast-query.ts
@@ -189,11 +189,15 @@ export async function matchAstQueriesBatch(
   if (readStrategy) {
     content = await readStrategy(filePath);
   } else {
-    // Default disk read fallback
+    // Default disk read fallback with path containment check
     try {
-      const fullPath = path.resolve(workingDirectory, filePath);
-      const fs = await import('node:fs/promises');
-      content = await fs.readFile(fullPath, 'utf-8');
+      const normalizedBase = path.resolve(workingDirectory);
+      const fullPath = path.join(normalizedBase, filePath);
+      if (!fullPath.startsWith(normalizedBase)) {
+        content = null;
+      } else {
+        content = await fs.readFile(fullPath, 'utf-8');
+      }
     } catch {
       content = null;
     }

--- a/packages/core/src/ast-query.ts
+++ b/packages/core/src/ast-query.ts
@@ -189,11 +189,14 @@ export async function matchAstQueriesBatch(
   if (readStrategy) {
     content = await readStrategy(filePath);
   } else {
-    // Default disk read fallback with path containment check
+    // Default disk read fallback with path containment check.
+    // Uses path.relative() instead of startsWith() to avoid sibling-directory bypass
+    // (e.g., /app-secrets bypassing a /app base).
     try {
       const normalizedBase = path.resolve(workingDirectory);
       const fullPath = path.join(normalizedBase, filePath);
-      if (!fullPath.startsWith(normalizedBase)) {
+      const relative = path.relative(normalizedBase, fullPath);
+      if (relative.startsWith('..') || path.isAbsolute(relative)) {
         content = null;
       } else {
         content = await fs.readFile(fullPath, 'utf-8');

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -28,6 +28,7 @@ export type TotemErrorCode =
   | 'MCP_ERROR'
   | 'UPGRADE_HASH_NOT_FOUND'
   | 'UPGRADE_HASH_AMBIGUOUS'
+  | 'STAGED_READ_FAILED'
   | 'UPGRADE_CLOUD_UNSUPPORTED';
 
 export class TotemError extends Error {

--- a/packages/core/src/rule-engine.test.ts
+++ b/packages/core/src/rule-engine.test.ts
@@ -106,6 +106,94 @@ describe('applyAstRulesToAdditions', () => {
     expect(violations[0]!.lineNumber).toBe(1);
   });
 
+  it('supports injected readStrategy for staged content', async () => {
+    // The file doesn't exist on disk, or has different content on disk
+    fs.writeFileSync(path.join(tmpDir, 'src', 'app.ts'), 'console.log("disk content");\n');
+
+    const rule = makeRule({
+      engine: 'ast-grep',
+      astGrepPattern: 'console.log("staged content")',
+    });
+
+    const additions = [makeAddition('src/app.ts', 'console.log("staged content");', 1)];
+
+    // Inject a readStrategy that returns staged content
+    const mockReadStrategy = async (filePath: string) => {
+      if (filePath === 'src/app.ts') return 'console.log("staged content");\n';
+      return null;
+    };
+
+    const violations = await applyAstRulesToAdditions(
+      [rule],
+      additions,
+      tmpDir,
+      undefined,
+      undefined,
+      mockReadStrategy,
+    );
+    expect(violations).toHaveLength(1);
+    expect(violations[0]!.line).toBe('console.log("staged content");');
+  });
+
+  it('skips file when readStrategy returns null', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'src', 'app.ts'), 'console.log("disk content");\n');
+
+    const rule = makeRule({
+      engine: 'ast-grep',
+      astGrepPattern: 'console.log("disk content")',
+    });
+
+    const additions = [makeAddition('src/app.ts', 'console.log("disk content");', 1)];
+
+    // readStrategy returns null (simulating a symlink or unreadable file)
+    const mockReadStrategyReturningNull = async () => null;
+
+    const violations = await applyAstRulesToAdditions(
+      [rule],
+      additions,
+      tmpDir,
+      undefined,
+      undefined,
+      mockReadStrategyReturningNull,
+    );
+    expect(violations).toHaveLength(0); // Violation from disk content is ignored because readStrategy returned null
+  });
+
+  it('uses disk read when no readStrategy provided (Invariant #4 backward compat)', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'src', 'app.ts'), 'console.log("disk content");\n');
+
+    const rule = makeRule({
+      engine: 'ast-grep',
+      astGrepPattern: 'console.log("disk content")',
+    });
+
+    const additions = [makeAddition('src/app.ts', 'console.log("disk content");', 1)];
+
+    // No readStrategy argument passed
+    const violations = await applyAstRulesToAdditions([rule], additions, tmpDir);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]!.line).toBe('console.log("disk content");');
+  });
+
+  it('respects workingDirectory explicitly rather than cwd', async () => {
+    // The bug (#1304) was that applyAstRulesToAdditions used process.cwd() instead of the repo root
+    // To simulate this, we pass a workingDirectory that is different from cwd
+    const repoRoot = path.join(tmpDir, 'repo-root');
+    fs.mkdirSync(path.join(repoRoot, 'src'), { recursive: true });
+    fs.writeFileSync(path.join(repoRoot, 'src', 'app.ts'), 'console.log("hello");\n');
+
+    const rule = makeRule({
+      engine: 'ast-grep',
+      astGrepPattern: 'console.log($$$)',
+    });
+
+    const additions = [makeAddition('src/app.ts', 'console.log("hello");', 1)];
+
+    // We pass repoRoot as the workingDirectory. If it uses something else (like process.cwd()), it will fail to read the file.
+    const violations = await applyAstRulesToAdditions([rule], additions, repoRoot);
+    expect(violations).toHaveLength(1);
+  });
+
   it('emits suppress event for ast-grep rules on totem-ignore lines', async () => {
     fs.writeFileSync(
       path.join(tmpDir, 'src', 'app.ts'),

--- a/packages/core/src/rule-engine.ts
+++ b/packages/core/src/rule-engine.ts
@@ -319,6 +319,14 @@ export async function applyAstRulesToAdditions(
       });
 
       if (applicableTreeSitter.length > 0) {
+        // Path containment check — prevent traversal outside the project
+        const normalizedBase = path.resolve(workingDirectory);
+        const fullPath = path.join(normalizedBase, file);
+        if (!fullPath.startsWith(normalizedBase)) {
+          onWarn?.(`Skipped file outside project: ${file}`);
+          continue;
+        }
+
         // Batch: parse file once, run all queries against the cached tree
         const queries = applicableTreeSitter.map((rule) => ({
           astQuery: rule.astQuery!,

--- a/packages/core/src/rule-engine.ts
+++ b/packages/core/src/rule-engine.ts
@@ -271,9 +271,10 @@ export function applyRulesToAdditions(
 export async function applyAstRulesToAdditions(
   rules: CompiledRule[],
   additions: DiffAddition[],
-  cwd: string,
+  workingDirectory: string,
   onRuleEvent?: RuleEventCallback,
   onWarn?: (msg: string) => void,
+  readStrategy?: (filePath: string) => Promise<string | null>,
 ): Promise<Violation[]> {
   const treeSitterRules = rules.filter((r) => r.engine === 'ast' && r.astQuery);
   const astGrepRules = rules.filter((r) => r.engine === 'ast-grep' && r.astGrepPattern);
@@ -324,7 +325,13 @@ export async function applyAstRulesToAdditions(
           addedLineNumbers,
         }));
 
-        const batchResults = await matchAstQueriesBatch(file, queries, cwd, onWarn);
+        const batchResults = await matchAstQueriesBatch(
+          file,
+          queries,
+          workingDirectory,
+          onWarn,
+          readStrategy,
+        );
 
         // Map results back to violations
         for (let i = 0; i < applicableTreeSitter.length; i++) {
@@ -370,18 +377,25 @@ export async function applyAstRulesToAdditions(
         // Read file content once for all ast-grep rules on this file
         let content: string | null = null;
         try {
-          const fullPath = path.resolve(cwd, file);
+          const fullPath = path.resolve(workingDirectory, file);
           // Path containment check — prevent traversal outside the project
-          const relative = path.relative(path.resolve(cwd), fullPath);
+          const relative = path.relative(path.resolve(workingDirectory), fullPath);
           if (relative.startsWith('..') || path.isAbsolute(relative)) {
             onWarn?.(`Skipped file outside project: ${file} (resolved to ${fullPath})`);
             continue;
           }
-          content = await fs.promises.readFile(fullPath, 'utf-8');
-        } catch {
-          // Fall through — content stays null
+          if (readStrategy) {
+            content = await readStrategy(file);
+          } else {
+            content = await fs.promises.readFile(fullPath, 'utf-8');
+          }
+        } catch (err: unknown) {
+          // Explicitly propagate readStrategy errors. Disk reads fall back to null, but staged reads shouldn't.
+          if (readStrategy) {
+            throw err;
+          }
+          // Fall through — content stays null for standard file read failures
         }
-
         if (content) {
           // Batch: parse file once, run all patterns
           const queries = applicableAstGrep

--- a/packages/core/src/rule-engine.ts
+++ b/packages/core/src/rule-engine.ts
@@ -319,10 +319,13 @@ export async function applyAstRulesToAdditions(
       });
 
       if (applicableTreeSitter.length > 0) {
-        // Path containment check — prevent traversal outside the project
+        // Path containment check — prevent traversal outside the project.
+        // Uses path.relative() instead of startsWith() to avoid sibling-directory bypass
+        // (e.g., /app-secrets bypassing a /app base).
         const normalizedBase = path.resolve(workingDirectory);
         const fullPath = path.join(normalizedBase, file);
-        if (!fullPath.startsWith(normalizedBase)) {
+        const relative = path.relative(normalizedBase, fullPath);
+        if (relative.startsWith('..') || path.isAbsolute(relative)) {
           onWarn?.(`Skipped file outside project: ${file}`);
           continue;
         }

--- a/packages/core/src/store/lance-search.test.ts
+++ b/packages/core/src/store/lance-search.test.ts
@@ -203,6 +203,23 @@ describe('runVectorSearch', () => {
     expect(clause).not.toContain('\\\\');
   });
 
+  it('does not escape backticks in boundary prefixes (not required for single-quoted literals)', async () => {
+    const table = mockTable({ vectorRows: [] });
+    await runVectorSearch(
+      table as never,
+      mockEmbedder(),
+      'query',
+      undefined,
+      5,
+      DEFAULT_CTX,
+      'src/my`path',
+    );
+
+    const clause = table._vectorBuilder.where.mock.calls[0]![0] as string;
+    expect(clause).toContain('src/my`path');
+    expect(clause).not.toContain('src/my\\`path');
+  });
+
   it('escapes single quotes in boundary prefixes', async () => {
     const table = mockTable({ vectorRows: [] });
     await runVectorSearch(

--- a/packages/core/src/store/lance-search.ts
+++ b/packages/core/src/store/lance-search.ts
@@ -145,12 +145,8 @@ async function runFtsLeg(
 function escapeBoundaryPrefix(raw: string): string {
   // Normalize Windows backslashes to forward slashes
   const normalized = raw.replace(/\\/g, '/');
-  // Escape SQL LIKE wildcards (%, _), backticks, and single quotes
-  return normalized
-    .replace(/`/g, '\\`')
-    .replace(/%/g, '\\%')
-    .replace(/_/g, '\\_')
-    .replace(/'/g, "''");
+  // Escape SQL LIKE wildcards (%, _) and single quotes
+  return normalized.replace(/%/g, '\\%').replace(/_/g, '\\_').replace(/'/g, "''");
 }
 
 /** Build a SQL WHERE clause from optional type and boundary filters. */
@@ -160,7 +156,7 @@ function buildWhereClause(
 ): string | undefined {
   const conditions: string[] = [];
   if (typeFilter) {
-    const safeType = typeFilter.replace(/`/g, '\\`').replace(/'/g, "''");
+    const safeType = typeFilter.replace(/'/g, "''");
     conditions.push(`\`type\` = '${safeType}'`);
   }
   // Normalize boundary to array


### PR DESCRIPTION
This PR completes the 1.14.1 hotfix sweep.

Closes #1304
Closes #1305
Closes #1306
Closes #1309

## Scope

- **#1304**: Rule-engine reads working tree instead of staged content + cwd resolution bug. Includes /preflight v2 design doc. Injects `readStrategy` into `applyAstRulesToAdditions`, resolves paths against repo root via `resolveGitRoot`, normalizes CRLF to LF in staged callback (Invariant #4 preserved), excludes symlinks via `git ls-files -s` mode 120000, throws `STAGED_READ_FAILED` on git show failure. Uses pre-existing `safeExec` helper from `sys/exec.ts`.
- **#1305**: lance-search over-escapes backticks in SQL string literals (single-quoted literals don't need backtick escaping).
- **#1306**: AST engine test coverage audit — 13 new tests covering all failure modes and invariants from the #1304 design doc: symlink filter (mode 120000), CRLF normalization, STAGED_READ_FAILED throw, backward-compat disk read, subdirectory-to-repo-root resolution, git-less fallback, binary file exclusion, readStrategy-returns-null skip, disk read when no readStrategy provided.
- **#1309**: `totem doctor` upgrade-candidate hint + `totem lint` stale-manifest warning both emit deprecated `totem compile --upgrade` — updated to `totem lesson compile --upgrade`.

## Commits (5)

1. `docs(core): /preflight v2 design doc for #1304 staged-content rule-engine fix` — submodule pointer bump
2. `fix(core): rule-engine reads working tree instead of staged content (#1304)` — core implementation with STAGED_READ_FAILED error code, defensive `--` separator in git ls-files, explicit rethrow guard for staged-read errors
3. `test(core): audit AST engine test coverage (#1306)` — 13 new tests in `rule-engine.test.ts` + `run-compiled-rules.test.ts`
4. `fix(core): lance-search over-escapes backticks and doctor hint deprecated compile (#1305, #1309)` — removes unnecessary backtick escaping, updates doctor + lint hint strings
5. `docs: refresh active_work for 1.14.1 hotfix sweep` — post-1.14.0 state + 1.14.1 punchlist

## Test plan

- [x] `@mmnto/totem` — 1024 tests passing
- [x] `@mmnto/cli` — 1637 tests passing
- [x] `@mmnto/mcp` — 74 tests passing
- [x] **Total: 2735 tests** (up from 2722, +13 net)
- [x] Pre-push: format check, lint, totem lint (86 warnings / 0 errors), all passing
- [x] `totem review` Shield pass — zero findings

## Binary file handling

Binary files (e.g., `.png`, `.jpg`) are excluded from AST scanning via the `BINARY_EXTENSIONS` set in `run-compiled-rules.ts`. Verified with test `"excludes binary files from scanning"`.

## Cross-agent note

Implementation by Gemini Pro (core fix + initial tests), cross-agent review + test checklist + cleanup by Claude Opus (debug log removal, Pipeline 5 cleanup, defensive rethrow guard, git ls-files `--` hardening, active_work commit). Shield caught 2 debug log leftovers and 1 STAGED_READ_FAILED propagation concern that led to the defensive rethrow guard.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>