### PR TITLE
chore: queue drain — Shield branding, preflight doc-scope, dual-hash styleguide (#1298, #1299, #1302)

### DIFF
--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -39,9 +39,25 @@ If `totem spec` fails, report the error and stop — do not proceed to Phase 2.
   (hard error → warning, sync → async, blocking → non-blocking)
 - Crosses architectural boundaries (core → cli, cli → mcp, etc.)
 - Touches >3 files OR introduces a new cross-cutting concern
+- Documents a new config field, new public API method, or new
+  agent-facing tool surface (regardless of whether the doc is in the
+  same PR as the implementation, and regardless of whether the
+  implementation is yours or someone else's)
 
 When in doubt, draft the doc. The cost of 10 minutes of design writing
 is always lower than the cost of a multi-round bot review cycle.
+
+**Why docs-that-describe-features count as architectural.** A wiki page
+that describes a new config field has the same data-model verification
+requirement as the code that implements it — you can write incorrect
+documentation about a real feature surface just as easily as you can
+write incorrect code. If you're authoring docs for a feature you didn't
+just build (or built more than a session ago), READ THE SCHEMA before
+the prose. The Phase 3 data-model section will force you to enumerate
+the config fields, which is exactly the work that catches "I remember
+this feature as automatic but the schema says opt-in" errors before
+they ship to users. The mmnto-ai/totem#1297 docs PR cycle is the
+load-bearing example.
 
 State your triage decision explicitly: "Tactical — skipping Phase 3"
 or "Architectural — drafting design doc."

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -117,7 +117,7 @@ the project shipped, not drift.
 ### `lessonHash` (in `compiled-rules.json` and the compile manifest)
 
 - Defined in `packages/core/src/compiler.ts:60-66`
-- Formula: `sha256(`${heading}\n${body}`).slice(0, 16)`
+- Formula: `sha256(heading + '\n' + body).slice(0, 16)`
 - 16 characters
 - Hashes ONLY `heading + '\n' + body` — explicitly excludes frontmatter
 - Used as the canonical content hash for the compile manifest, rule loader,
@@ -126,7 +126,7 @@ the project shipped, not drift.
 ### Why they're independent
 
 1. The two hashes are computed over different input strings (full file vs
-   heading+body only). They cannot agree even by coincidence — one includes
+   heading+body only). They are not expected to match because one includes
    frontmatter content the other excludes.
 2. The slice lengths differ (8 vs 16 chars). Even if both were SHA-256 of
    identical inputs, the 8-char filename hash would only match the FIRST 8

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -68,7 +68,7 @@ The following suggestions have been repeatedly declined during code review. Do n
 - **Lesson heading truncation.** Do not suggest expanding lesson headings beyond 60 characters. The `HEADING_MAX_CHARS` limit is enforced by `lesson-format.ts`. Headings serve as SARIF identifiers and vector search labels, not prose. Truncation is by design.
 - **Redundant "Lesson:" prefix in lesson headings.** Do not flag `## Lesson — Lesson: ...` as a style issue on auto-generated lesson files. This is a known `sanitizeHeading` improvement tracked separately.
 - **Timestamps appearing as "future dates."** The project is actively developed in 2026. Do not flag `compiledAt` or `createdAt` timestamps as errors or bugs.
-- **Confusing `totem lint` and `totem shield`.** `totem lint` = compiled rules, zero LLM, fast, Lite tier. `totem shield` = AI-powered code review, Full tier. Never describe shield as "deterministic" or lint as "AI-powered." Issue #515 (Claude Code hooks) was closed and NOT shipped — do not reference it as a live feature.
+- **Confusing `totem lint` and `totem review`.** `totem lint` = compiled rules, zero LLM, fast, Lite tier. `totem review` = AI-powered code review, Full tier. Never describe review as "deterministic" or lint as "AI-powered." The old `totem shield` command is a deprecated alias for `totem review` — do not use the old name in suggestions. Issue #515 (Claude Code hooks) was closed and NOT shipped — do not reference it as a live feature.
 - **Alphabetical sorting of command lists.** Do not suggest alphabetically sorting command lists in documentation tables. Commands are grouped by function (init → hooks → enforcement → workflow), which is more useful than alphabetical order.
 
 ## 7. Tone & Voice (The Solo Dev Litmus Test)
@@ -100,3 +100,47 @@ All overrides are recorded in the Trap Ledger (`.totem/ledger/events.ndjson`) fo
 - Defense-in-depth guards in batch processing loops should use `log.warn()` + counter increments, NOT `throw`. The design intent is resilient continuation, not fail-fast. Only suggest `throw` for guards that should halt the entire operation.
 - Library code (`@mmnto/totem` core) uses `onWarn` callbacks, never direct `console.warn`.
 - **Error cause chains (ES2022):** When re-throwing errors in `catch` blocks, always pass the original error as the `cause` property: `throw new TotemError('...', '...', err)`. NEVER concatenate `err.message` into a new error string — this destroys the original stack trace. The `handleError` debug logger traverses `.cause` chains automatically.
+
+## 10. Hash Conventions (Do Not Flag as Mismatches)
+
+Totem uses **two independent hash functions** for lessons, computed over different
+inputs. They are NOT supposed to match — this is the established convention since
+the project shipped, not drift.
+
+### Filename hash (`lesson-XXXXXXXX.md`)
+
+- Defined in `packages/core/src/lesson-io.ts:14-17`
+- Formula: `sha256(full_file_content).substring(0, 8)`
+- 8 characters
+- Hashes the **full file content** including frontmatter (`**Tags:**`, `**Scope:**`)
+
+### `lessonHash` (in `compiled-rules.json` and the compile manifest)
+
+- Defined in `packages/core/src/compiler.ts:60-66`
+- Formula: `sha256(`${heading}\n${body}`).slice(0, 16)`
+- 16 characters
+- Hashes ONLY `heading + '\n' + body` — explicitly excludes frontmatter
+- Used as the canonical content hash for the compile manifest, rule loader,
+  doctor diagnostic, and `totem compile --upgrade <hash>` CLI flag
+
+### Why they're independent
+
+1. The two hashes are computed over different input strings (full file vs
+   heading+body only). They cannot agree even by coincidence — one includes
+   frontmatter content the other excludes.
+2. The slice lengths differ (8 vs 16 chars). Even if both were SHA-256 of
+   identical inputs, the 8-char filename hash would only match the FIRST 8
+   chars of the 16-char `lessonHash`, and the inputs are not identical.
+3. ALL existing 393+ compiled rules from 1.13.0 and earlier exhibit this
+   convention. Verifiable by sampling: pick any rule, look at its `lessonHash`,
+   then look at the corresponding `.totem/lessons/lesson-*.md` file's
+   filename — they will not match. They were never designed to match.
+
+### Do not flag
+
+When reviewing PRs that touch `.totem/compiled-rules.json` or
+`.totem/lessons/lesson-*.md`, do not flag mismatches between the 16-char
+`lessonHash` field and the 8-char filename hash. They are independent
+identifiers by design. If a future change unifies them under a single scheme,
+that will be discussed in a strategy proposal under `.strategy/proposals/`,
+not as a code review finding.

--- a/packages/cli/src/commands/shield.test.ts
+++ b/packages/cli/src/commands/shield.test.ts
@@ -595,7 +595,7 @@ describe('formatVerdictForDisplay', () => {
   it('formats empty findings as clean pass', () => {
     const verdict = { findings: [], summary: 'All good' };
     const output = formatVerdictForDisplay(verdict, true);
-    expect(output).toContain('Shield Review');
+    expect(output).toContain('Review');
     expect(output).toContain('PASS');
     expect(output).toContain('Summary: All good');
     expect(output).toContain('No issues found');

--- a/packages/cli/src/commands/shield.ts
+++ b/packages/cli/src/commands/shield.ts
@@ -334,7 +334,7 @@ export function formatVerdictForDisplay(verdict: ShieldStructuredVerdict, pass: 
 
   // Header
   const verdictLabel = pass ? successColor(bold('PASS')) : errorColor(bold('FAIL'));
-  lines.push(`Shield Review — ${verdictLabel}`);
+  lines.push(`Review — ${verdictLabel}`);
   lines.push('');
 
   // Summary
@@ -415,7 +415,7 @@ export async function writeReviewedContentHash(
     // Non-fatal — flag is a convenience for PreToolUse hooks
     if (process.env['TOTEM_DEBUG'] === '1') {
       console.error(
-        '[Shield] Failed to write .reviewed-content-hash:',
+        '[Review] Failed to write .reviewed-content-hash:',
         err instanceof Error ? err.message : err,
       );
     }

--- a/packages/cli/src/index-lite.ts
+++ b/packages/cli/src/index-lite.ts
@@ -102,7 +102,7 @@ program
     'Initialize without package manager checks or Git hooks (ideal for notes/docs repos)',
   )
   .option('--pilot', 'Enable pilot mode — hooks warn instead of block during initial adoption')
-  .option('--strict', 'Use strict enforcement tier (spec-required + shield gate for agents)')
+  .option('--strict', 'Use strict enforcement tier (spec-required + review gate for agents)')
   .option('--global', 'Create a personal profile in ~/.totem/ for use across all projects')
   .action(
     async (options: { bare?: boolean; pilot?: boolean; strict?: boolean; global?: boolean }) => {
@@ -162,7 +162,7 @@ program
   .description('Install git hooks (pre-commit, pre-push, post-merge) non-interactively')
   .option('--check', 'Verify hooks are installed (exit 1 if missing)')
   .option('-f, --force', 'Force overwrite existing hooks')
-  .option('--strict', 'Use strict enforcement tier (spec-required + shield gate)')
+  .option('--strict', 'Use strict enforcement tier (spec-required + review gate)')
   .option('--standard', 'Use standard enforcement tier (default)')
   .action(
     async (opts: { check?: boolean; force?: boolean; strict?: boolean; standard?: boolean }) => {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -83,7 +83,7 @@ program
     'Initialize without package manager checks or Git hooks (ideal for notes/docs repos)',
   )
   .option('--pilot', 'Enable pilot mode — hooks warn instead of block during initial adoption')
-  .option('--strict', 'Use strict enforcement tier (spec-required + shield gate for agents)')
+  .option('--strict', 'Use strict enforcement tier (spec-required + review gate for agents)')
   .option('--global', 'Create a personal profile in ~/.totem/ for use across all projects')
   .action(
     async (options: { bare?: boolean; pilot?: boolean; strict?: boolean; global?: boolean }) => {
@@ -213,7 +213,7 @@ program
     },
   );
 
-// ─── Review options shared between `review` (primary) and `shield` (deprecated alias) ───
+// ─── Review options shared between `review` (primary) and the deprecated `shield` alias ───
 const reviewOptions = (cmd: Command) =>
   cmd
     .option('--raw', 'Output retrieved context without LLM synthesis')
@@ -698,7 +698,7 @@ program
   .description('Install git hooks (pre-commit, pre-push, post-merge) non-interactively')
   .option('--check', 'Verify hooks are installed (exit 1 if missing)')
   .option('-f, --force', 'Force overwrite existing hooks')
-  .option('--strict', 'Use strict enforcement tier (spec-required + shield gate)')
+  .option('--strict', 'Use strict enforcement tier (spec-required + review gate)')
   .option('--standard', 'Use standard enforcement tier (default)')
   .action(
     async (opts: { check?: boolean; force?: boolean; strict?: boolean; standard?: boolean }) => {
@@ -726,7 +726,7 @@ program
 
 program
   .command('status')
-  .description('Show current project health (manifest, shield, rules)')
+  .description('Show current project health (manifest, review, rules)')
   .action(async () => {
     try {
       const { statusCommand } = await import('./commands/status.js');


### PR DESCRIPTION
## Summary

Bundled queue drain for three tier-2 tickets in the 1.14.0 milestone:

- **#1298** — Replace user-visible "Shield Review" verdict with "Review" and `[Shield]` log tags with `[Review]`. Update `--strict` option descriptions and `totem status` description to use "review gate" instead of "shield gate". Covers both `index.ts` and `index-lite.ts`.
- **#1299** — Expand `/preflight` v2 Phase 3 trigger to include docs that describe new feature surfaces (config fields, public APIs, agent tools). Adds rationale paragraph explaining the #1297 docs PR failure case.
- **#1302** — Add section 10 (Hash Conventions) to `.gemini/styleguide.md` documenting the dual-hash convention (8-char filename hash vs 16-char `lessonHash`) so GCA stops flagging it as a mismatch. Also fixes stale `totem shield` → `totem review` reference in section 6.

Closes #1298, closes #1299, closes #1302

## Test plan

- [x] 2735 tests pass (pre-push gate)
- [x] `totem lint` — PASS (0 errors, 11 warnings all pre-existing)
- [x] `totem review --no-auto-capture` — PASS
- [x] `review-alias.test.ts` still passes (deprecated `totem shield` alias unchanged)
- [x] `formatVerdictForDisplay` test updated to assert `Review` instead of `Shield Review`
- [ ] Verify `totem review` output shows `Review — PASS` (not `Shield Review — PASS`)
- [ ] Next PR touching `compiled-rules.json` should not trigger GCA hash-mismatch finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)