### PR TITLE
fix(core): resolve non-staged AST paths against repo root, not cwd (#1312)

### DIFF
--- a/packages/cli/src/commands/run-compiled-rules.test.ts
+++ b/packages/cli/src/commands/run-compiled-rules.test.ts
@@ -940,6 +940,63 @@ describe('runCompiledRules', () => {
       spyAst.mockRestore();
     });
 
+    it('uses repo root as workingDirectory for non-staged path from a subdirectory (#1312)', async () => {
+      const rules = [
+        makeRule('console\\.log\\("foo"\\)', 'No foo log', 'No foo log', {
+          engine: 'ast-grep',
+          astGrepPattern: 'console.log("foo")',
+        }),
+      ];
+      writeRules(tmpDir, rules);
+
+      // Write the file at repo root so AST can read it
+      fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+      fs.writeFileSync(
+        path.join(tmpDir, 'src', 'app.ts'),
+        '// context\n  console.log("foo");\n// context\n',
+      );
+
+      const diff = makeDiff('src/app.ts', '  console.log("foo");');
+
+      const subDir = path.join(tmpDir, 'sub', 'dir');
+      fs.mkdirSync(subDir, { recursive: true });
+
+      const mockResolveGitRoot = vi.spyOn(totem, 'resolveGitRoot').mockReturnValue(tmpDir);
+
+      const spyAst = vi.spyOn(totem, 'applyAstRulesToAdditions');
+
+      let violations: unknown[] = [];
+      try {
+        const result = await runCompiledRules({
+          diff,
+          cwd: subDir,
+          totemDir: TOTEM_DIR,
+          format: 'json',
+          tag: 'Test',
+          isStaged: false,
+          configRoot: tmpDir,
+        });
+        violations = result.violations;
+      } catch (err: unknown) {
+        if (
+          err instanceof Error &&
+          err.name === 'TotemError' &&
+          err.message.includes('Violations detected')
+        ) {
+          violations = [1];
+        } else {
+          throw err;
+        }
+      }
+
+      expect(violations).toHaveLength(1);
+      expect(spyAst).toHaveBeenCalled();
+      // Non-staged path must also resolve against repo root, not subDir
+      expect(spyAst.mock.calls[0]![2]).toBe(tmpDir);
+      mockResolveGitRoot.mockRestore();
+      spyAst.mockRestore();
+    });
+
     it('falls back to original cwd when not in a git repo (resolveGitRoot returns null)', async () => {
       const rules = [
         makeRule('console\\.log\\("foo"\\)', 'No foo log', 'No foo log', {

--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -117,9 +117,13 @@ export async function runCompiledRules(
         (a) => !ignorePatterns || !ignorePatterns.some((pattern) => matchesGlob(a.file, pattern)),
       );
 
+    // Resolve repo root once — git diff paths are always repo-root-relative,
+    // so both staged and non-staged paths need the repo root for file resolution.
+    const repoRoot = resolveGitRoot(cwd);
+
     // Enrich with AST context
     try {
-      await enrichWithAstContext(additions, { cwd });
+      await enrichWithAstContext(additions, { cwd: repoRoot ?? cwd });
       const classified = additions.filter((a) => a.astContext !== undefined).length;
       if (classified > 0) {
         log.dim(tag, `AST classified ${classified}/${additions.length} additions`);
@@ -167,14 +171,11 @@ export async function runCompiledRules(
     if (astRules.length > 0) {
       log.dim(tag, `Running ${astRules.length} AST rule(s)...`);
       try {
-        let workingDirectory = cwd;
+        const workingDirectory = repoRoot ?? cwd;
         let readStrategy: ((filePath: string) => Promise<string | null>) | undefined = undefined;
 
         if (isStaged) {
-          const repoRoot = resolveGitRoot(cwd);
           if (repoRoot) {
-            workingDirectory = repoRoot;
-
             readStrategy = async (filePath: string) => {
               try {
                 // 1. Detect symlinks explicitly (git ls-files -s returns mode 120000).


### PR DESCRIPTION
## Summary

When `totem lint` runs from a subdirectory without `--staged`, AST rules silently produce zero violations. Git diff paths are repo-root-relative, but the non-staged code path resolves them against `process.cwd()` instead of the repo root.

Example: running `totem lint` from `packages/cli/` with a diff path `packages/core/src/rule-engine.ts` resolves to `packages/cli/packages/core/src/rule-engine.ts` — file not found, AST rule skipped, no error shown.

The #1304 fix (PR #1311) only fixed the staged path. This hoists `resolveGitRoot()` out of the `if (isStaged)` block so both paths resolve correctly. Also fixes `enrichWithAstContext` which had the same cwd issue.

Closes #1312

## Changes

- `run-compiled-rules.ts`: Hoist `resolveGitRoot(cwd)` before the `if (isStaged)` block. `workingDirectory` is now `repoRoot ?? cwd` unconditionally. `enrichWithAstContext` also uses `repoRoot ?? cwd`.
- `run-compiled-rules.test.ts`: New test `'uses repo root as workingDirectory for non-staged path from a subdirectory (#1312)'` — mirrors the existing staged-path test but with `isStaged: false`.

## Test plan

- [x] 2736 tests pass (pre-push gate, +1 new test)
- [x] `totem lint` — PASS (0 errors)
- [x] `totem review --no-auto-capture` — PASS
- [x] Existing staged subdirectory test still passes
- [x] New non-staged subdirectory test verifies `workingDirectory` is repo root, not subdir

🤖 Generated with [Claude Code](https://claude.com/claude-code)