### PR TITLE
feat(cli): refactor totem handoff to deterministic journal scaffold (#1310)

### DIFF
--- a/packages/cli/src/commands/handoff.test.ts
+++ b/packages/cli/src/commands/handoff.test.ts
@@ -2,17 +2,14 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { HandoffCheckpointSchema } from '../schemas/handoff-checkpoint.js';
 import { cleanTmpDir } from '../test-utils.js';
 import {
-  buildLiteHandoff,
-  gatherDeterministicState,
-  parseSemanticFields,
+  buildJournalScaffold,
   readRecentLessons,
-  resolveCheckpointPath,
-  writeCheckpoint,
+  resolveJournalPath,
+  slugFromBranch,
 } from './handoff.js';
 
 describe('readRecentLessons', () => {
@@ -77,48 +74,90 @@ describe('readRecentLessons', () => {
   });
 });
 
-// ─── buildLiteHandoff ───────────────────────────────
+// ─── slugFromBranch ───────────────────────────────────
 
-describe('buildLiteHandoff', () => {
-  it('generates clean working tree snapshot', () => {
-    const output = buildLiteHandoff(
-      'main',
-      '',
-      '',
-      'abc1234 initial commit',
-      '## Lesson 1\nContent',
-    );
-    expect(output).toContain('main; clean working tree');
-    expect(output).toContain('Working tree is clean.');
-    expect(output).toContain('abc1234 initial commit');
-    expect(output).toContain('lines in lessons file'); // totem-ignore
+describe('slugFromBranch', () => {
+  it('returns session for main/master/HEAD', () => {
+    expect(slugFromBranch('main')).toBe('session');
+    expect(slugFromBranch('master')).toBe('session');
+    expect(slugFromBranch('HEAD')).toBe('session');
+    expect(slugFromBranch('')).toBe('session');
+    expect(slugFromBranch('(unknown)')).toBe('session');
   });
 
-  it('generates dirty working tree snapshot', () => {
-    const output = buildLiteHandoff(
+  it('strips common prefixes', () => {
+    expect(slugFromBranch('feat/add-logging')).toBe('add-logging');
+    expect(slugFromBranch('fix/null-pointer')).toBe('null-pointer');
+    expect(slugFromBranch('chore/cleanup-deps')).toBe('cleanup-deps');
+    expect(slugFromBranch('hotfix/1304-sweep')).toBe('1304-sweep');
+  });
+
+  it('sanitizes special characters', () => {
+    expect(slugFromBranch('feat/UPPER_case')).toBe('upper-case');
+    expect(slugFromBranch('feat/dots.and.slashes')).toBe('dots-and-slashes');
+  });
+
+  it('truncates long branch names to 60 chars', () => {
+    const long = 'feat/' + 'a'.repeat(100);
+    const slug = slugFromBranch(long);
+    expect(slug.length).toBeLessThanOrEqual(60);
+  });
+});
+
+// ─── resolveJournalPath ───────────────────────────────
+
+describe('resolveJournalPath', () => {
+  it('uses --out path when specified', () => {
+    const result = resolveJournalPath('/repo', '.totem', 'main', '/custom/path.md');
+    expect(result).toBe('/custom/path.md');
+  });
+
+  it('builds date-slug path under .totem/journal/', () => {
+    const result = resolveJournalPath('/repo', '.totem', 'feat/add-logging');
+    expect(result).toMatch(/\.totem[/\\]journal[/\\]\d{4}-\d{2}-\d{2}-add-logging\.md$/);
+  });
+
+  it('uses session slug for main branch', () => {
+    const result = resolveJournalPath('/repo', '.totem', 'main');
+    expect(result).toMatch(/\.totem[/\\]journal[/\\]\d{4}-\d{2}-\d{2}-session\.md$/);
+  });
+});
+
+// ─── buildJournalScaffold ─────────────────────────────
+
+describe('buildJournalScaffold', () => {
+  it('includes human-editable sections at the top', () => {
+    const output = buildJournalScaffold('main', '', '', 'abc1234 initial commit', '');
+    expect(output).toContain('## What Shipped');
+    expect(output).toContain('## Architectural Decisions');
+    expect(output).toContain('## Open Tickets');
+    expect(output).toContain('## Next Steps');
+  });
+
+  it('includes deterministic git state below the separator', () => {
+    const output = buildJournalScaffold(
       'feat/test',
-      ' M src/app.ts\n?? new-file.ts',
+      ' M src/app.ts',
       ' src/app.ts | 5 ++---',
-      'def5678 second commit\nabc1234 first commit',
+      'def5678 second commit',
       '',
     );
     expect(output).toContain('feat/test; dirty working tree');
     expect(output).toContain('M src/app.ts');
-    expect(output).toContain('new-file.ts');
     expect(output).toContain('5 ++---');
     expect(output).toContain('def5678 second commit');
-    expect(output).toContain('No lessons file found.');
   });
 
-  it('handles empty commits and lessons', () => {
-    const output = buildLiteHandoff('main', '', '', '', '');
+  it('shows clean working tree when status is empty', () => {
+    const output = buildJournalScaffold('main', '', '', '', '');
     expect(output).toContain('clean working tree');
+    expect(output).toContain('Working tree is clean.');
     expect(output).toContain('No commits found.');
     expect(output).toContain('No lessons file found.');
   });
 
   it('strips ANSI escape sequences from git output', () => {
-    const output = buildLiteHandoff(
+    const output = buildJournalScaffold(
       '\x1b[32mmain\x1b[0m',
       ' \x1b[31mM\x1b[0m src/app.ts',
       ' src/app.ts | 5 \x1b[32m++\x1b[31m---\x1b[0m',
@@ -126,335 +165,18 @@ describe('buildLiteHandoff', () => {
       '',
     );
     expect(output).not.toContain('\x1b[');
-    expect(output).toContain('main; dirty working tree');
-    expect(output).toContain('M src/app.ts');
+    expect(output).toContain('main');
     expect(output).toContain('abc1234 initial commit');
   });
-});
 
-// ─── gatherDeterministicState ───────────────────────
-
-vi.mock('../git.js', async (importOriginal) => {
-  const actual = (await importOriginal()) as Record<string, unknown>;
-  return {
-    ...actual,
-    getGitBranch: vi.fn().mockReturnValue('main'),
-    getGitStatus: vi.fn().mockReturnValue(''),
-  };
-});
-
-describe('gatherDeterministicState', () => {
-  let mockGetGitBranch: ReturnType<typeof vi.fn>;
-  let mockGetGitStatus: ReturnType<typeof vi.fn>;
-
-  beforeEach(async () => {
-    const git = await import('../git.js');
-    mockGetGitBranch = git.getGitBranch as unknown as ReturnType<typeof vi.fn>;
-    mockGetGitStatus = git.getGitStatus as unknown as ReturnType<typeof vi.fn>;
+  it('includes lesson line count when lessons exist', () => {
+    const output = buildJournalScaffold('main', '', '', '', 'Line 1\nLine 2\nLine 3');
+    expect(output).toContain('3 lines in lessons file');
   });
 
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it('extracts active files from git status safely handling detached HEAD', async () => {
-    mockGetGitBranch.mockImplementation(() => {
-      throw new Error('not a git repository');
-    });
-    mockGetGitStatus.mockReturnValue(' M src/foo.ts\n?? src/bar.ts\nA  src/baz.ts');
-
-    const result = await gatherDeterministicState('/tmp/test');
-
-    expect(result.branch).toBe('HEAD');
-    expect(result.active_files).toContain('src/foo.ts');
-    expect(result.active_files).toContain('src/bar.ts');
-    expect(result.active_files).toContain('src/baz.ts');
-    expect(result.active_files).toHaveLength(3);
-  });
-
-  it('extracts active files from normal branch', async () => {
-    mockGetGitBranch.mockReturnValue('feat/checkpoint');
-    mockGetGitStatus.mockReturnValue(' M src/app.ts\n?? README.md');
-
-    const result = await gatherDeterministicState('/tmp/test');
-
-    expect(result.branch).toBe('feat/checkpoint');
-    expect(result.active_files).toEqual(['README.md', 'src/app.ts']);
-  });
-
-  it('returns empty active_files when working tree is clean', async () => {
-    mockGetGitBranch.mockReturnValue('main');
-    mockGetGitStatus.mockReturnValue('');
-
-    const result = await gatherDeterministicState('/tmp/test');
-
-    expect(result.active_files).toEqual([]);
-  });
-
-  it('sets checkpoint_version to 1 and timestamp is valid ISO', async () => {
-    mockGetGitBranch.mockReturnValue('main');
-    mockGetGitStatus.mockReturnValue('');
-
-    const result = await gatherDeterministicState('/tmp/test');
-
-    expect(result.checkpoint_version).toBe(1);
-    const parsed = new Date(result.timestamp);
-    expect(parsed.toISOString()).toBe(result.timestamp);
-    expect(result.open_prs).toEqual([]);
-  });
-
-  it('strips C-style quotes from paths with spaces', async () => {
-    mockGetGitBranch.mockReturnValue('main');
-    mockGetGitStatus.mockReturnValue(' M "src/my file.ts"\n?? "docs/read me.md"');
-
-    const result = await gatherDeterministicState('/tmp/test');
-
-    expect(result.active_files).toEqual(['docs/read me.md', 'src/my file.ts']);
-  });
-
-  it('falls back to HEAD when getGitBranch returns empty string', async () => {
-    mockGetGitBranch.mockReturnValue('');
-    mockGetGitStatus.mockReturnValue('');
-
-    const result = await gatherDeterministicState('/tmp/test');
-
-    expect(result.branch).toBe('HEAD');
-  });
-
-  it('falls back to HEAD when getGitBranch returns (unknown)', async () => {
-    mockGetGitBranch.mockReturnValue('(unknown)');
-    mockGetGitStatus.mockReturnValue('');
-
-    const result = await gatherDeterministicState('/tmp/test');
-
-    expect(result.branch).toBe('HEAD');
-  });
-});
-
-// ─── parseSemanticFields (Task 3) ───────────────────
-
-describe('parseSemanticFields', () => {
-  it('extracts sections from markdown', () => {
-    const markdown = [
-      '### Branch & State',
-      'feat/test; dirty working tree.',
-      '',
-      '### What Was Done',
-      '- Implemented the schema validation',
-      '- Added unit tests for the parser',
-      '',
-      '### Uncommitted Changes',
-      '- Modified handoff.ts with new logic',
-      '',
-      '### Lessons & Traps',
-      '- Always validate with Zod before writing',
-      '- Watch out for Windows path separators',
-      '',
-      '### Next Steps',
-      '1. Wire up the atomic file writer',
-      '2. Add integration tests',
-      '3. Run the full test suite',
-    ].join('\n');
-
-    const result = parseSemanticFields(markdown);
-
-    expect(result.completed).toEqual([
-      'Implemented the schema validation',
-      'Added unit tests for the parser',
-    ]);
-    expect(result.remaining).toEqual([
-      'Wire up the atomic file writer',
-      'Add integration tests',
-      'Run the full test suite',
-    ]);
-    expect(result.context_hints).toEqual([
-      'Always validate with Zod before writing',
-      'Watch out for Windows path separators',
-    ]);
-    expect(result.pending_decisions).toEqual(['Modified handoff.ts with new logic']);
-  });
-
-  it('returns empty arrays for malformed input', () => {
-    const empty = parseSemanticFields('');
-    expect(empty.completed).toEqual([]);
-    expect(empty.remaining).toEqual([]);
-    expect(empty.pending_decisions).toEqual([]);
-    expect(empty.context_hints).toEqual([]);
-
-    const garbage = parseSemanticFields('foo bar baz\nno headings here\n!!!');
-    expect(garbage.completed).toEqual([]);
-    expect(garbage.remaining).toEqual([]);
-    expect(garbage.pending_decisions).toEqual([]);
-    expect(garbage.context_hints).toEqual([]);
-  });
-
-  it('handles ## headings as well as ###', () => {
-    const markdown = [
-      '## What Was Done',
-      '- Finished the feature',
-      '',
-      '## Next Steps',
-      '- Deploy to staging',
-    ].join('\n');
-
-    const result = parseSemanticFields(markdown);
-    expect(result.completed).toEqual(['Finished the feature']);
-    expect(result.remaining).toEqual(['Deploy to staging']);
-  });
-
-  it('handles non-bullet content lines', () => {
-    const markdown = ['### What Was Done', 'Implemented the schema.', 'Added tests.'].join('\n');
-
-    const result = parseSemanticFields(markdown);
-    expect(result.completed).toEqual(['Implemented the schema.', 'Added tests.']);
-  });
-});
-
-// ─── Lite mode checkpoint (Task 3) ──────────────────
-
-describe('lite mode checkpoint', () => {
-  it('bypasses LLM execution when lite flag is provided and returns empty semantic arrays', async () => {
-    const git = await import('../git.js');
-    const mockBranch = git.getGitBranch as unknown as ReturnType<typeof vi.fn>;
-    const mockStatus = git.getGitStatus as unknown as ReturnType<typeof vi.fn>;
-
-    mockBranch.mockReturnValue('feat/lite-test');
-    mockStatus.mockReturnValue(' M src/foo.ts');
-
-    const state = await gatherDeterministicState('/tmp/test');
-    const checkpoint = HandoffCheckpointSchema.parse(state);
-
-    expect(checkpoint.checkpoint_version).toBe(1);
-    expect(checkpoint.branch).toBe('feat/lite-test');
-    expect(checkpoint.active_files).toEqual(['src/foo.ts']);
-    expect(checkpoint.completed).toEqual([]);
-    expect(checkpoint.remaining).toEqual([]);
-    expect(checkpoint.pending_decisions).toEqual([]);
-    expect(checkpoint.context_hints).toEqual([]);
-  });
-});
-
-// ─── writeCheckpoint & resolveCheckpointPath (Task 4) ───
-
-describe('writeCheckpoint', () => {
-  let tmpDir: string;
-
-  beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-checkpoint-'));
-  });
-
-  afterEach(() => {
-    cleanTmpDir(tmpDir);
-  });
-
-  it('writes checkpoint json atomically alongside markdown', () => {
-    const mdPath = path.join(tmpDir, 'handoff.md');
-    const jsonPath = path.join(tmpDir, 'handoff.json');
-
-    fs.writeFileSync(mdPath, '### Branch & State\nmain; clean.', 'utf-8');
-
-    const checkpoint = HandoffCheckpointSchema.parse({
-      checkpoint_version: 1,
-      timestamp: new Date().toISOString(),
-      branch: 'main',
-      active_files: ['src/app.ts'],
-      completed: ['Implemented feature X'],
-      remaining: ['Add tests'],
-    });
-    writeCheckpoint(jsonPath, checkpoint);
-
-    expect(fs.existsSync(mdPath)).toBe(true);
-    expect(fs.existsSync(jsonPath)).toBe(true);
-
-    const raw = JSON.parse(fs.readFileSync(jsonPath, 'utf-8'));
-    const parsed = HandoffCheckpointSchema.parse(raw);
-    expect(parsed.branch).toBe('main');
-    expect(parsed.active_files).toEqual(['src/app.ts']);
-    expect(parsed.completed).toEqual(['Implemented feature X']);
-    expect(parsed.remaining).toEqual(['Add tests']);
-
-    expect(fs.existsSync(jsonPath + '.tmp')).toBe(false);
-  });
-
-  it('creates parent directories if they do not exist', () => {
-    const nested = path.join(tmpDir, 'deep', 'nested');
-    const jsonPath = path.join(nested, 'checkpoint.json');
-
-    const checkpoint = HandoffCheckpointSchema.parse({
-      checkpoint_version: 1,
-      timestamp: new Date().toISOString(),
-      branch: 'main',
-      active_files: [],
-    });
-    writeCheckpoint(jsonPath, checkpoint);
-
-    expect(fs.existsSync(jsonPath)).toBe(true);
-  });
-
-  it('writes checkpoint to .totem/handoff.json when no --out specified', () => {
-    const totemDir = path.join(tmpDir, '.totem');
-    fs.mkdirSync(totemDir, { recursive: true });
-
-    const jsonPath = resolveCheckpointPath(tmpDir, '.totem');
-    expect(jsonPath).toBe(path.join(tmpDir, '.totem', 'handoff.json'));
-
-    const checkpoint = HandoffCheckpointSchema.parse({
-      checkpoint_version: 1,
-      timestamp: new Date().toISOString(),
-      branch: 'feat/no-out',
-      active_files: ['src/index.ts'],
-      completed: ['Setup project'],
-    });
-    writeCheckpoint(jsonPath, checkpoint);
-
-    expect(fs.existsSync(jsonPath)).toBe(true);
-    const raw = JSON.parse(fs.readFileSync(jsonPath, 'utf-8'));
-    const parsed = HandoffCheckpointSchema.parse(raw);
-    expect(parsed.branch).toBe('feat/no-out');
-    expect(parsed.active_files).toEqual(['src/index.ts']);
-  });
-});
-
-// ─── resolveCheckpointPath ──────────────────────────
-
-describe('resolveCheckpointPath', () => {
-  let tmpDir: string;
-
-  beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-resolve-'));
-  });
-
-  afterEach(() => {
-    cleanTmpDir(tmpDir);
-  });
-
-  it('returns .json companion when --out has .md extension', () => {
-    const result = resolveCheckpointPath(tmpDir, '.totem', '/some/path/handoff.md');
-    expect(result).toBe('/some/path/handoff.json');
-  });
-
-  it('returns .json companion when --out has no extension', () => {
-    const result = resolveCheckpointPath(tmpDir, '.totem', '/some/path/handoff');
-    expect(result).toBe('/some/path/handoff.json');
-  });
-
-  it('returns totemDir/handoff.json when no --out', () => {
-    const result = resolveCheckpointPath(tmpDir, '.totem');
-    expect(result).toBe(path.join(tmpDir, '.totem', 'handoff.json'));
-  });
-
-  it('uses custom totemDir when configured', () => {
-    const result = resolveCheckpointPath(tmpDir, '.governance');
-    expect(result).toBe(path.join(tmpDir, '.governance', 'handoff.json'));
-  });
-
-  it('replaces .txt extension with .json', () => {
-    const result = resolveCheckpointPath(tmpDir, '.totem', '/output/report.txt');
-    expect(result).toBe('/output/report.json');
-  });
-
-  it('avoids collision when --out already ends in .json', () => {
-    const result = resolveCheckpointPath(tmpDir, '.totem', '/output/handoff.json');
-    expect(result).toBe('/output/handoff.checkpoint.json');
+  it('includes date in the title heading', () => {
+    const output = buildJournalScaffold('feat/test', '', '', '', '');
+    // Should start with # YYYY-MM-DD — feat/test
+    expect(output).toMatch(/^# \d{4}-\d{2}-\d{2} — feat\/test/);
   });
 });

--- a/packages/cli/src/commands/handoff.ts
+++ b/packages/cli/src/commands/handoff.ts
@@ -1,54 +1,16 @@
+import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import { readAllLessons } from '@mmnto/totem'; // totem-ignore
 
-import type { HandoffCheckpoint } from '../schemas/handoff-checkpoint.js';
-import { HandoffCheckpointSchema } from '../schemas/handoff-checkpoint.js';
-import { sanitize, wrapXml } from '../utils.js';
+import { sanitize } from '../utils.js';
 
 // ─── Constants ──────────────────────────────────────────
 
 const TAG = 'Handoff';
-const MAX_DIFF_CHARS = 50_000;
 const LESSONS_TAIL_LINES = 100;
-
-// ─── System prompt ──────────────────────────────────────
-
-const SYSTEM_PROMPT = `# Handoff System Prompt — End-of-Session State Transfer
-
-## Purpose
-Produce an end-of-session handoff snapshot that captures everything the next session (or the next developer) needs to resume work immediately.
-
-## Role
-You are writing a concise, tactical "End of Shift" handoff. You have access to the current git state, uncommitted changes, and lessons learned during this session. Your job is to synthesize this into a snapshot that lets the next session bootstrap instantly — no detective work required.
-
-## Rules
-- Be concrete and specific — file paths, branch names, issue numbers
-- Distinguish between what IS done vs what NEEDS to be done next
-- If there are uncommitted changes, describe what they represent and whether they look ready to commit
-- If the working tree is clean, say so and focus on what was accomplished and what's next
-- Capture any lessons or traps discovered during this session
-- Be concise — this is a tactical handoff, not a retrospective
-
-## Output Format
-Respond with ONLY the sections below. No preamble, no closing remarks.
-
-### Branch & State
-[Current branch, clean/dirty status, what the branch represents]
-
-### What Was Done
-[Summary of work completed this session based on the diff and git state. If no changes, say "No uncommitted changes — session may have been exploratory or changes were already committed."]
-
-### Uncommitted Changes
-[Description of what the uncommitted changes contain and their state (staged vs unstaged). If clean, say "Working tree is clean."]
-
-### Lessons & Traps
-[Lessons learned during this session from the memory file. If none, say "No new lessons recorded this session."]
-
-### Next Steps
-[Clear, ordered list of what the next session should do first. Be specific — not "continue working" but "finish implementing X in file Y, then run tests."]
-`;
+const RECENT_COMMITS_COUNT = 10;
 
 // ─── Lessons file reader ────────────────────────────────
 
@@ -66,243 +28,54 @@ export function readRecentLessons(cwd: string, totemDir: string): string {
   return lines.slice(-LESSONS_TAIL_LINES).join('\n').trim();
 }
 
-// ─── Prompt assembly ────────────────────────────────────
+// ─── Slug from branch ───────────────────────────────────
 
-function assemblePrompt(
+/**
+ * Derive a filesystem-safe slug from the git branch name.
+ * Falls back to 'session' for main, master, or detached HEAD.
+ */
+export function slugFromBranch(branch: string): string {
+  const generic = ['main', 'master', 'HEAD', '', '(unknown)'];
+  if (generic.includes(branch)) return 'session';
+
+  // Strip common prefixes (feat/, fix/, chore/, hotfix/, etc.)
+  const stripped = branch.replace(/^[a-z]+\//, '');
+  // Sanitize: lowercase, replace non-alphanumeric with hyphens, collapse runs, trim
+  return (
+    stripped
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '')
+      .slice(0, 60) || 'session'
+  );
+}
+
+// ─── Journal path resolution ────────────────────────────
+
+/**
+ * Build the journal file path: .totem/journal/YYYY-MM-DD-<slug>.md
+ * If --out is specified, use that path instead.
+ */
+export function resolveJournalPath(
+  cwd: string,
+  totemDir: string,
   branch: string,
-  status: string,
-  diff: string,
-  diffStat: string,
-  lessons: string,
-  systemPrompt: string,
+  outPath?: string,
 ): string {
-  const sections: string[] = [systemPrompt];
+  if (outPath) return outPath;
 
-  // Git state
-  sections.push('=== GIT STATE ===');
-  sections.push(`Branch: ${branch}`);
-  sections.push(`Status:\n${status ? wrapXml('git_status', status) : '(clean working tree)'}`);
-
-  // Diff
-  sections.push('\n=== DIFF ===');
-  if (!diff.trim()) {
-    sections.push('(no uncommitted changes)');
-  } else {
-    if (diffStat) {
-      sections.push(`Diff stat:\n${diffStat}`);
-      sections.push('');
-    }
-    if (diff.length > MAX_DIFF_CHARS) {
-      sections.push(
-        wrapXml(
-          'git_diff',
-          diff.slice(0, MAX_DIFF_CHARS) + `\n... [diff truncated at ${MAX_DIFF_CHARS} chars] ...`,
-        ),
-      );
-    } else {
-      sections.push(wrapXml('git_diff', diff));
-    }
-  }
-
-  // Lessons
-  sections.push('\n=== SESSION LESSONS ===');
-  sections.push(lessons || '(no lessons recorded)');
-
-  return sections.join('\n');
+  const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  const slug = slugFromBranch(branch);
+  return path.join(cwd, totemDir, 'journal', `${date}-${slug}.md`);
 }
 
-// ─── Main command ───────────────────────────────────────
-
-export interface HandoffOptions {
-  raw?: boolean;
-  out?: string;
-  model?: string;
-  fresh?: boolean;
-  lite?: boolean;
-}
-
-// ─── Deterministic checkpoint (ADR-039) ────────────────
-
-export interface DeterministicCheckpoint {
-  checkpoint_version: 1;
-  timestamp: string;
-  branch: string;
-  active_files: string[];
-  open_prs: number[];
-}
+// ─── Journal scaffold builder ───────────────────────────
 
 /**
- * Parse file paths from `git status --porcelain` output.
- * Handles standard two-char status codes: " M", "M ", "MM", "A ", "??", "D ", etc.
- * Also handles renames ("R  old -> new") by extracting the new path.
+ * Build the structured journal scaffold with human-editable sections
+ * at the top and deterministic git state at the bottom.
  */
-function parseStatusFiles(statusOutput: string): string[] {
-  if (!statusOutput.trim()) return [];
-
-  const files: string[] = [];
-  for (const line of statusOutput.split(/\r?\n/)) {
-    if (!line.trim()) continue;
-    // Porcelain format: XY <path> or XY <old> -> <new> for renames (R/C status)
-    const statusCode = line.slice(0, 2);
-    let filePart = line.slice(3); // skip 2-char status + space
-    if ((statusCode.includes('R') || statusCode.includes('C')) && filePart.includes(' -> ')) {
-      filePart = filePart.slice(filePart.indexOf(' -> ') + 4);
-    }
-    // Strip C-style quotes that git adds for paths with spaces/special chars
-    if (filePart.startsWith('"') && filePart.endsWith('"')) {
-      filePart = filePart.slice(1, -1);
-    }
-    files.push(filePart);
-  }
-  return files;
-}
-
-/**
- * Gathers deterministic (zero-LLM) state for the handoff checkpoint.
- * ADR-039: Git Metadata Primacy — these fields come from git, never the LLM.
- */
-export async function gatherDeterministicState(cwd: string): Promise<DeterministicCheckpoint> {
-  const { getGitBranch, getGitStatus } = await import('../git.js');
-
-  // 1. Get branch — handle detached HEAD gracefully
-  let branch: string;
-  try {
-    const raw = getGitBranch(cwd);
-    branch = raw && raw !== '(unknown)' ? raw : 'HEAD';
-  } catch {
-    branch = 'HEAD';
-  }
-
-  // 2. Get active files from git status --porcelain (covers staged, unstaged, and untracked)
-  const statusOutput = getGitStatus(cwd);
-  const active_files = parseStatusFiles(statusOutput).sort();
-
-  // 3. Return checkpoint with timestamp and empty open_prs (PR detection is future work)
-  return {
-    checkpoint_version: 1,
-    timestamp: new Date().toISOString(),
-    branch,
-    active_files,
-    open_prs: [],
-  };
-}
-
-// ─── Semantic field extraction (Task 3) ─────────────────
-
-/**
- * Known Markdown section headings and the semantic field they map to.
- * Headings are matched case-insensitively.
- */
-const SECTION_MAP: Record<string, keyof SemanticFields> = {
-  'what was done': 'completed',
-  'next steps': 'remaining',
-  'lessons & traps': 'context_hints',
-  lessons: 'context_hints',
-  'uncommitted changes': 'pending_decisions',
-};
-
-export interface SemanticFields {
-  completed: string[];
-  remaining: string[];
-  pending_decisions: string[];
-  context_hints: string[];
-}
-
-/**
- * Extract semantic fields from Markdown output by parsing section headings
- * and collecting bullet points / non-empty lines under each.
- *
- * Returns empty arrays for any sections not found or when input is malformed.
- */
-export function parseSemanticFields(markdown: string): SemanticFields {
-  const result: SemanticFields = {
-    completed: [],
-    remaining: [],
-    pending_decisions: [],
-    context_hints: [],
-  };
-
-  if (!markdown || !markdown.trim()) return result;
-
-  const lines = markdown.split(/\r?\n/);
-  let currentField: keyof SemanticFields | null = null;
-  let inCodeBlock = false;
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-
-    // Track fenced code blocks (``` or ~~~)
-    if (trimmed.startsWith('```') || trimmed.startsWith('~~~')) {
-      inCodeBlock = !inCodeBlock;
-      continue;
-    }
-    if (inCodeBlock) continue;
-
-    // Detect heading (### or ##)
-    const headingMatch = line.match(/^#{2,3}\s+(.+)$/);
-    if (headingMatch) {
-      const heading = headingMatch[1]!.trim().toLowerCase();
-      currentField = SECTION_MAP[heading] ?? null;
-      continue;
-    }
-
-    // Collect content lines under recognized sections
-    if (currentField) {
-      if (!trimmed) continue;
-      const bulletMatch = trimmed.match(/^[-*]\s+(.+)$/) ?? trimmed.match(/^\d+\.\s+(.+)$/);
-      if (bulletMatch) {
-        result[currentField].push(bulletMatch[1]!.trim());
-      } else if (!/^#{1,6}\s/.test(trimmed)) {
-        result[currentField].push(trimmed);
-      }
-    }
-  }
-
-  return result;
-}
-
-// ─── Atomic checkpoint writer (Task 4) ──────────────────
-
-/**
- * Write a JSON checkpoint file atomically: write to a .tmp file then rename.
- * Creates parent directories if needed.
- */
-export function writeCheckpoint(jsonPath: string, checkpoint: HandoffCheckpoint): void {
-  const dir = path.dirname(jsonPath);
-  if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
-  }
-
-  const tmpPath = jsonPath + '.tmp';
-  fs.writeFileSync(tmpPath, JSON.stringify(checkpoint, null, 2) + '\n', 'utf-8');
-  fs.renameSync(tmpPath, jsonPath);
-}
-
-/**
- * Determine the JSON checkpoint path given the --out option.
- * - If --out is specified: companion file with .json extension
- * - If --out is not specified: <cwd>/<totemDir>/handoff.json
- */
-export function resolveCheckpointPath(cwd: string, totemDir: string, outPath?: string): string {
-  if (outPath) {
-    const ext = path.extname(outPath);
-    if (ext === '.json') {
-      return outPath.slice(0, -ext.length) + '.checkpoint.json';
-    }
-    if (ext) {
-      return outPath.slice(0, -ext.length) + '.json';
-    }
-    return outPath + '.json';
-  }
-
-  return path.join(cwd, totemDir, 'handoff.json');
-}
-
-// ─── Lite handoff (zero LLM) ────────────────────────────
-
-const RECENT_COMMITS_COUNT = 10;
-
-export function buildLiteHandoff(
+export function buildJournalScaffold(
   branch: string,
   status: string,
   diffStat: string,
@@ -310,13 +83,33 @@ export function buildLiteHandoff(
   lessons: string,
 ): string {
   // Sanitize git-sourced fields to strip ANSI escapes / control chars
-  const sBranch = sanitize(branch); // totem-ignore — ANSI stripping for terminal output safety
+  const sBranch = sanitize(branch);
   const sStatus = sanitize(status);
   const sDiffStat = sanitize(diffStat);
   const sCommits = sanitize(recentCommits);
 
+  const date = new Date().toISOString().slice(0, 10);
   const lines: string[] = [];
 
+  // ── Human-editable section (top) ──
+  lines.push(`# ${date} — ${sBranch}`);
+  lines.push('');
+  lines.push('## What Shipped');
+  lines.push('<!-- What was accomplished this session? -->');
+  lines.push('');
+  lines.push('## Architectural Decisions');
+  lines.push('<!-- Any design choices worth recording? -->');
+  lines.push('');
+  lines.push('## Open Tickets');
+  lines.push('<!-- Tickets filed, referenced, or blocked? -->');
+  lines.push('');
+  lines.push('## Next Steps');
+  lines.push('<!-- What should the next session pick up? -->');
+  lines.push('');
+
+  // ── Deterministic git state (bottom) ──
+  lines.push('---');
+  lines.push('');
   lines.push('### Branch & State');
   lines.push(`${sBranch}; ${sStatus.trim() ? 'dirty working tree' : 'clean working tree'}.`);
   lines.push('');
@@ -355,17 +148,42 @@ export function buildLiteHandoff(
     lines.push('No lessons file found.');
   }
 
-  return lines.join('\n');
+  return lines.join('\n') + '\n';
+}
+
+// ─── Editor launcher ────────────────────────────────────
+
+/**
+ * Open a file in the user's editor. Uses $VISUAL, then $EDITOR, then vi.
+ * Returns true if the editor exited successfully.
+ */
+export function openInEditor(filePath: string): boolean {
+  const editor = process.env['VISUAL'] || process.env['EDITOR'] || 'vi';
+  // Split editor command in case it contains args (e.g. "code --wait")
+  const parts = editor.split(/\s+/);
+  const cmd = parts[0]!;
+  const args = [...parts.slice(1), filePath];
+
+  try {
+    execFileSync(cmd, args, { stdio: 'inherit' });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 // ─── Main command ───────────────────────────────────────
 
+export interface HandoffOptions {
+  noEdit?: boolean;
+  lite?: boolean;
+  out?: string;
+}
+
 export async function handoffCommand(options: HandoffOptions): Promise<void> {
-  const { getGitBranch, getGitDiff, getGitDiffStat, getGitLogSince, getGitStatus } =
-    await import('../git.js');
+  const { getGitBranch, getGitDiffStat, getGitLogSince, getGitStatus } = await import('../git.js');
   const { log } = await import('../ui.js');
-  const { getSystemPrompt, loadConfig, loadEnv, resolveConfigPath, runOrchestrator, writeOutput } =
-    await import('../utils.js');
+  const { loadConfig, loadEnv, resolveConfigPath } = await import('../utils.js');
 
   const cwd = process.cwd();
   const configPath = resolveConfigPath(cwd);
@@ -378,75 +196,43 @@ export async function handoffCommand(options: HandoffOptions): Promise<void> {
   const status = getGitStatus(cwd);
   log.info(TAG, `Branch: ${branch}`);
 
-  // Get diff
-  log.info(TAG, 'Getting uncommitted diff...');
-  const diff = getGitDiff('all', cwd);
-  const diffStat = diff.trim() ? getGitDiffStat(cwd) : '';
-
-  if (diff.trim()) {
-    log.info(TAG, `Diff: ${(diff.length / 1024).toFixed(0)}KB`);
-  } else {
-    log.dim(TAG, 'Working tree is clean.');
-  }
+  const diffStat = status.trim() ? getGitDiffStat(cwd) : '';
+  const recentCommits = getGitLogSince(cwd, undefined, RECENT_COMMITS_COUNT);
 
   // Read recent lessons
-  log.info(TAG, 'Reading recent lessons...');
   const lessons = readRecentLessons(cwd, config.totemDir);
-  log.info(TAG, `Lessons: ${lessons ? `${lessons.split('\n').length} lines` : 'none found'}`);
 
-  // Lite mode — deterministic, zero LLM
-  if (options.lite) {
-    // Snapshot git state BEFORE writing any files to avoid self-contamination
-    const deterministicState = await gatherDeterministicState(cwd);
+  // Build scaffold
+  const scaffold = buildJournalScaffold(branch, status, diffStat, recentCommits, lessons);
 
-    const recentCommits = getGitLogSince(cwd, undefined, RECENT_COMMITS_COUNT);
-    const output = buildLiteHandoff(branch, status, diffStat, recentCommits, lessons);
-    writeOutput(output, options.out);
-    if (options.out) log.success(TAG, `Written to ${options.out}`);
-
-    // Write checkpoint JSON with empty semantic fields (lite = no LLM)
-    try {
-      const checkpoint = HandoffCheckpointSchema.parse(deterministicState);
-      const jsonPath = resolveCheckpointPath(cwd, config.totemDir, options.out);
-      writeCheckpoint(jsonPath, checkpoint);
-      log.dim(TAG, `Checkpoint: ${jsonPath}`);
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      log.warn(TAG, `Checkpoint write failed (skipped): ${msg}`);
-    }
-
-    log.dim(TAG, 'Lite handoff complete (zero LLM).');
+  // --no-edit / --lite: print to stdout and exit
+  if (options.noEdit || options.lite) {
+    process.stdout.write(scaffold);
+    log.dim(TAG, 'Scaffold printed to stdout (--no-edit mode).');
     return;
   }
 
-  // Resolve system prompt (allow .totem/prompts/handoff.md override)
-  const systemPrompt = getSystemPrompt('handoff', SYSTEM_PROMPT, cwd, config.totemDir);
+  // Write scaffold to journal file
+  const journalPath = resolveJournalPath(cwd, config.totemDir, branch, options.out);
+  const journalDir = path.dirname(journalPath);
+  if (!fs.existsSync(journalDir)) {
+    fs.mkdirSync(journalDir, { recursive: true });
+  }
 
-  // Assemble prompt
-  const prompt = assemblePrompt(branch, status, diff, diffStat, lessons, systemPrompt);
-  log.dim(TAG, `Prompt: ${(prompt.length / 1024).toFixed(0)}KB`);
+  // If the file already exists, don't overwrite — open it for editing instead
+  if (!fs.existsSync(journalPath)) {
+    fs.writeFileSync(journalPath, scaffold, 'utf-8');
+    log.success(TAG, `Scaffold written to ${journalPath}`);
+  } else {
+    log.info(TAG, `Journal entry already exists: ${journalPath}`);
+  }
 
-  // Snapshot git state BEFORE writing any files to avoid self-contamination
-  const deterministicState = await gatherDeterministicState(cwd);
-
-  const content = await runOrchestrator({ prompt, tag: TAG, options, config, cwd });
-  if (content != null) {
-    writeOutput(content, options.out);
-    if (options.out) log.success(TAG, `Written to ${options.out}`);
-
-    // Build structured checkpoint: deterministic state + semantic fields from LLM output
-    const semanticFields = parseSemanticFields(content);
-    const merged = { ...deterministicState, ...semanticFields };
-
-    try {
-      const checkpoint = HandoffCheckpointSchema.parse(merged);
-      const jsonPath = resolveCheckpointPath(cwd, config.totemDir, options.out);
-      writeCheckpoint(jsonPath, checkpoint);
-      log.dim(TAG, `Checkpoint: ${jsonPath}`);
-    } catch (err) {
-      // Checkpoint is best-effort — never block the handoff on validation failure
-      const msg = err instanceof Error ? err.message : String(err);
-      log.warn(TAG, `Checkpoint validation failed (skipped): ${msg}`);
-    }
+  // Open in editor
+  log.info(TAG, 'Opening in editor...');
+  const ok = openInEditor(journalPath);
+  if (ok) {
+    log.success(TAG, 'Journal entry saved.');
+  } else {
+    log.warn(TAG, `Editor exited with error. Your journal entry is at: ${journalPath}`);
   }
 }

--- a/packages/cli/src/commands/handoff.ts
+++ b/packages/cli/src/commands/handoff.ts
@@ -205,10 +205,17 @@ export async function handoffCommand(options: HandoffOptions): Promise<void> {
   // Build scaffold
   const scaffold = buildJournalScaffold(branch, status, diffStat, recentCommits, lessons);
 
-  // --no-edit / --lite: print to stdout and exit
+  // --no-edit / --lite: write to --out if specified, otherwise print to stdout
   if (options.noEdit || options.lite) {
-    process.stdout.write(scaffold);
-    log.dim(TAG, 'Scaffold printed to stdout (--no-edit mode).');
+    if (options.out) {
+      const outDir = path.dirname(options.out);
+      if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+      fs.writeFileSync(options.out, scaffold, 'utf-8');
+      log.success(TAG, `Scaffold written to ${options.out}`);
+    } else {
+      process.stdout.write(scaffold);
+      log.dim(TAG, 'Scaffold printed to stdout (--no-edit mode).');
+    }
     return;
   }
 

--- a/packages/cli/src/commands/handoff.ts
+++ b/packages/cli/src/commands/handoff.ts
@@ -225,7 +225,7 @@ export async function handoffCommand(options: HandoffOptions): Promise<void> {
   // --no-edit / --lite: print to stdout
   if (options.noEdit || options.lite) {
     process.stdout.write(scaffold);
-    log.dim(TAG, 'Scaffold printed to stdout (--no-edit mode).');
+    log.dim(TAG, 'Scaffold printed to stdout.');
     return;
   }
 

--- a/packages/cli/src/commands/handoff.ts
+++ b/packages/cli/src/commands/handoff.ts
@@ -1,4 +1,3 @@
-import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -157,19 +156,16 @@ export function buildJournalScaffold(
  * Open a file in the user's editor. Uses $VISUAL, then $EDITOR, then vi.
  * Returns true if the editor exited successfully.
  */
-export function openInEditor(filePath: string): boolean {
+export async function openInEditor(filePath: string): Promise<boolean> {
+  const { spawnSync } = await import('node:child_process');
   const editor = process.env['VISUAL'] || process.env['EDITOR'] || 'vi';
   // Split editor command in case it contains args (e.g. "code --wait")
   const parts = editor.split(/\s+/);
   const cmd = parts[0]!;
   const args = [...parts.slice(1), filePath];
 
-  try {
-    execFileSync(cmd, args, { stdio: 'inherit' });
-    return true;
-  } catch {
-    return false;
-  }
+  const result = spawnSync(cmd, args, { stdio: 'inherit' });
+  return result.status === 0;
 }
 
 // ─── Main command ───────────────────────────────────────
@@ -236,7 +232,7 @@ export async function handoffCommand(options: HandoffOptions): Promise<void> {
 
   // Open in editor
   log.info(TAG, 'Opening in editor...');
-  const ok = openInEditor(journalPath);
+  const ok = await openInEditor(journalPath);
   if (ok) {
     log.success(TAG, 'Journal entry saved.');
   } else {

--- a/packages/cli/src/commands/handoff.ts
+++ b/packages/cli/src/commands/handoff.ts
@@ -212,26 +212,19 @@ export async function handoffCommand(options: HandoffOptions): Promise<void> {
   // Build scaffold
   const scaffold = buildJournalScaffold(branch, status, diffStat, recentCommits, lessons);
 
-  // --no-edit / --lite: write to --out if specified, otherwise print to stdout
-  if (options.noEdit || options.lite) {
-    if (options.out) {
-      const outDir = path.dirname(options.out);
-      if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
-      fs.writeFileSync(options.out, scaffold, 'utf-8');
-      log.success(TAG, `Scaffold written to ${options.out}`);
-    } else {
-      process.stdout.write(scaffold);
-      log.dim(TAG, 'Scaffold printed to stdout (--no-edit mode).');
-    }
-    return;
-  }
-
-  // --out without --no-edit: write to the specified path and exit (no editor)
+  // --out: write to the specified path and exit (no editor)
   if (options.out) {
     const outDir = path.dirname(options.out);
     if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
     fs.writeFileSync(options.out, scaffold, 'utf-8');
     log.success(TAG, `Scaffold written to ${options.out}`);
+    return;
+  }
+
+  // --no-edit / --lite: print to stdout
+  if (options.noEdit || options.lite) {
+    process.stdout.write(scaffold);
+    log.dim(TAG, 'Scaffold printed to stdout (--no-edit mode).');
     return;
   }
 

--- a/packages/cli/src/commands/handoff.ts
+++ b/packages/cli/src/commands/handoff.ts
@@ -170,12 +170,13 @@ export function buildJournalScaffold(
 export async function openInEditor(filePath: string): Promise<boolean> {
   const { spawnSync } = await import('node:child_process');
   const editor = process.env['VISUAL'] || process.env['EDITOR'] || 'vi';
-  // Split editor command in case it contains args (e.g. "code --wait")
-  const parts = editor.split(/\s+/);
-  const cmd = parts[0]!;
-  const args = [...parts.slice(1), filePath];
-
-  const result = spawnSync(cmd, args, { stdio: 'inherit', shell: process.platform === 'win32' });
+  // Use shell: true so the system shell parses the editor command (handles
+  // quoted paths like "/Applications/Visual Studio Code.app/.../code" --wait
+  // and Windows .cmd/.bat resolution).
+  const result = spawnSync(`${editor} "${filePath}"`, {
+    stdio: 'inherit',
+    shell: true,
+  });
   return result.status === 0;
 }
 

--- a/packages/cli/src/commands/handoff.ts
+++ b/packages/cli/src/commands/handoff.ts
@@ -1,7 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { readAllLessons } from '@mmnto/totem'; // totem-ignore
+import { readAllLessons } from '@mmnto/totem'; // totem-context: static import required — readRecentLessons is a sync exported helper used in tests
 
 import { sanitize } from '../utils.js';
 

--- a/packages/cli/src/commands/handoff.ts
+++ b/packages/cli/src/commands/handoff.ts
@@ -10,6 +10,17 @@ import { sanitize } from '../utils.js';
 const TAG = 'Handoff';
 const LESSONS_TAIL_LINES = 100;
 const RECENT_COMMITS_COUNT = 10;
+const MAX_SLUG_LENGTH = 60;
+
+/** Local calendar date as YYYY-MM-DD (avoids UTC off-by-one for evening users). */
+function currentLocalDate(): string {
+  const now = new Date();
+  return [
+    now.getFullYear(),
+    String(now.getMonth() + 1).padStart(2, '0'),
+    String(now.getDate()).padStart(2, '0'),
+  ].join('-');
+}
 
 // ─── Lessons file reader ────────────────────────────────
 
@@ -45,7 +56,7 @@ export function slugFromBranch(branch: string): string {
       .toLowerCase()
       .replace(/[^a-z0-9]+/g, '-')
       .replace(/^-|-$/g, '')
-      .slice(0, 60) || 'session'
+      .slice(0, MAX_SLUG_LENGTH) || 'session'
   );
 }
 
@@ -63,7 +74,7 @@ export function resolveJournalPath(
 ): string {
   if (outPath) return outPath;
 
-  const date = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  const date = currentLocalDate(); // YYYY-MM-DD
   const slug = slugFromBranch(branch);
   return path.join(cwd, totemDir, 'journal', `${date}-${slug}.md`);
 }
@@ -87,7 +98,7 @@ export function buildJournalScaffold(
   const sDiffStat = sanitize(diffStat);
   const sCommits = sanitize(recentCommits);
 
-  const date = new Date().toISOString().slice(0, 10);
+  const date = currentLocalDate();
   const lines: string[] = [];
 
   // ── Human-editable section (top) ──
@@ -164,7 +175,7 @@ export async function openInEditor(filePath: string): Promise<boolean> {
   const cmd = parts[0]!;
   const args = [...parts.slice(1), filePath];
 
-  const result = spawnSync(cmd, args, { stdio: 'inherit' });
+  const result = spawnSync(cmd, args, { stdio: 'inherit', shell: process.platform === 'win32' });
   return result.status === 0;
 }
 
@@ -215,8 +226,17 @@ export async function handoffCommand(options: HandoffOptions): Promise<void> {
     return;
   }
 
-  // Write scaffold to journal file
-  const journalPath = resolveJournalPath(cwd, config.totemDir, branch, options.out);
+  // --out without --no-edit: write to the specified path and exit (no editor)
+  if (options.out) {
+    const outDir = path.dirname(options.out);
+    if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+    fs.writeFileSync(options.out, scaffold, 'utf-8');
+    log.success(TAG, `Scaffold written to ${options.out}`);
+    return;
+  }
+
+  // Default: write scaffold to journal file and open in editor
+  const journalPath = resolveJournalPath(cwd, config.totemDir, branch);
   const journalDir = path.dirname(journalPath);
   if (!fs.existsSync(journalDir)) {
     fs.mkdirSync(journalDir, { recursive: true });

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -9,7 +9,6 @@ export interface CommandGroup {
 export const LLM_COMMANDS = new Set([
   'review',
   'spec',
-  'handoff',
   'docs',
   'check',
   'wrap',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -343,28 +343,18 @@ program
 
 program
   .command('handoff')
-  .description('Generate an end-of-session handoff snapshot for the next session')
-  .option('--lite', 'Zero-LLM deterministic snapshot (git state + lessons, no API key needed)')
-  .option('--raw', 'Output retrieved context without LLM synthesis')
-  .option('--out <path>', 'Write output to a file instead of stdout')
-  .option('--model <name>', 'Override the default model for the orchestrator')
-  .option('--fresh', 'Bypass cache and force a fresh LLM call (ignores cached responses)')
-  .action(
-    async (opts: {
-      lite?: boolean;
-      raw?: boolean;
-      out?: string;
-      model?: string;
-      fresh?: boolean;
-    }) => {
-      try {
-        const { handoffCommand } = await import('./commands/handoff.js');
-        await handoffCommand(opts);
-      } catch (err) {
-        handleError(err);
-      }
-    },
-  );
+  .description('Scaffold a structured journal entry for end-of-session handoff')
+  .option('--no-edit', 'Print scaffold to stdout instead of opening in $EDITOR')
+  .option('--lite', 'Alias for --no-edit (backward compat)')
+  .option('--out <path>', 'Write journal entry to a specific path')
+  .action(async (opts: { noEdit?: boolean; lite?: boolean; out?: string }) => {
+    try {
+      const { handoffCommand } = await import('./commands/handoff.js');
+      await handoffCommand(opts);
+    } catch (err) {
+      handleError(err);
+    }
+  });
 
 program
   .command('add-lesson [lesson]', { hidden: true })

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -368,7 +368,6 @@ const DEFAULT_TTLS: Record<string, number> = {
   spec: 3600, // 1 hour
   docs: 0, // No cache — each run should reflect latest state
   shield: 0,
-  handoff: 0,
   learn: 0,
 };
 


### PR DESCRIPTION
## Summary

Replace `totem handoff`'s LLM-powered zero-shot generation with a deterministic markdown scaffold that writes to `.totem/journal/YYYY-MM-DD-<slug>.md` and opens in `$EDITOR`.

**Implements Proposal 220 Phase A.** Also addresses the core of #1274 (configurable output destination, directory-based journal, markdown format).

### What changed

- **LLM path removed entirely** — no more orchestrator call, system prompt, semantic field parsing, or cache TTL entry. `handoff` is no longer in `LLM_COMMANDS`.
- **`handoff.json` deprecated** — no more JSON checkpoint writing. The markdown journal is the canonical state.
- **Scaffold structure**: human-editable sections at top (What Shipped, Architectural Decisions, Open Tickets, Next Steps) with HTML comment prompts, deterministic git state below the fold.
- **Slug from branch**: `feat/add-logging` → `add-logging`, `main`/`HEAD` → `session`.
- **`--no-edit`** (aliased as `--lite`): prints scaffold to stdout. Honors `--out` for file output without editor.
- **`--raw`, `--model`, `--fresh` removed** (no LLM to configure).
- **Net -504 lines** (208 added, 712 removed).

Closes #1310

## Test plan

- [x] 17 handoff tests pass (slug derivation, path resolution, scaffold content, ANSI stripping, lesson reading)
- [x] Full test suite passes (2722 tests)
- [x] `totem lint` — PASS (0 errors)
- [x] `totem review --no-auto-capture` — PASS
- [x] Build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)