### PR TITLE
docs(wiki): refresh 1.14.0 feature pages to Pragmatic Builder voice

### DIFF
--- a/docs/wiki/context-caching.md
+++ b/docs/wiki/context-caching.md
@@ -1,6 +1,6 @@
 # Context Caching
 
-When running bulk operations like `totem compile` across dozens of lessons, the token cost and latency of sending the massive system prompt on every API call became prohibitive. Context Caching leverages LLM prompt caching to solve this friction.
+When running bulk operations like `totem compile` across dozens of lessons, the token cost and latency of sending the massive system prompt on every API call can become prohibitive. Context Caching leverages LLM prompt caching to solve this friction.
 
 Context Caching is supported on the **Anthropic** provider (`anthropic:` prefix). Totem uses Anthropic's `cache_control` markers to cache the static portions of your prompts; cache savings appear automatically once the provider returns prompt-cache usage metrics on the response.
 

--- a/docs/wiki/context-caching.md
+++ b/docs/wiki/context-caching.md
@@ -1,6 +1,6 @@
 # Context Caching
 
-Totem can leverage LLM prompt caching to significantly reduce the token cost and latency of governing your codebase, particularly for bulk operations like recompiling many lessons in a single session.
+When running bulk operations like `totem compile` across dozens of lessons, the token cost and latency of sending the massive system prompt on every API call became prohibitive. Context Caching leverages LLM prompt caching to solve this friction.
 
 Context Caching is supported on the **Anthropic** provider (`anthropic:` prefix). Totem uses Anthropic's `cache_control` markers to cache the static portions of your prompts; cache savings appear automatically once the provider returns prompt-cache usage metrics on the response.
 

--- a/docs/wiki/cross-repo-mesh.md
+++ b/docs/wiki/cross-repo-mesh.md
@@ -1,6 +1,6 @@
 # Cross-Repo Mesh (Federation)
 
-Most governance tools operate in isolation per repository. Totem lets you connect multiple repositories into a shared semantic knowledge mesh, allowing your agents to federate context across repository boundaries.
+When working across multiple repositories, I found that AI agents kept hallucinating context because they couldn't see the architectural decisions made in sibling repos. The Cross-Repo Mesh fixes this by connecting multiple `.lancedb` indexes into a shared semantic knowledge base, allowing your agents to federate context across repository boundaries.
 
 ## Two ways to share lessons across repositories
 

--- a/docs/wiki/cross-repo-mesh.md
+++ b/docs/wiki/cross-repo-mesh.md
@@ -1,6 +1,6 @@
 # Cross-Repo Mesh (Federation)
 
-When working across multiple repositories, I found that AI agents kept hallucinating context because they couldn't see the architectural decisions made in sibling repos. The Cross-Repo Mesh fixes this by connecting multiple `.lancedb` indexes into a shared semantic knowledge base, allowing your agents to federate context across repository boundaries.
+When working across multiple repositories, AI agents often hallucinate context because they cannot see the architectural decisions made in sibling repos. The Cross-Repo Mesh fixes this by connecting multiple `.lancedb` indexes into a shared semantic knowledge base, allowing agents to federate context across repository boundaries.
 
 ## Two ways to share lessons across repositories
 

--- a/docs/wiki/enforcement-model.md
+++ b/docs/wiki/enforcement-model.md
@@ -2,17 +2,17 @@
 
 Your AI doesn't have to be obedient. It just has to push code.
 
-## Sensors, Not Actuators
+## A Platform of Primitives
 
-Totem provides **sensors** — the knowledge index, compiled rules, lint results, content hashes, review verdicts. These measure and report the state of your codebase.
+Totem provides the **primitives** — the knowledge index, the compiler, the compiled AST rules, the lint results, and the review verdicts. These are the building blocks that measure and report the state of your codebase.
 
-Totem does **not** provide **actuators** — it doesn't decide when to block, inject, or enforce. You (the Flight Controller) wire sensors to actuators via your IDE hooks, CI config, or git hooks. Totem ships reference wiring, not mandatory policy.
+Totem does **not** force a specific workflow — it doesn't dictate when to block, inject, or enforce. You decide how to wire these primitives into your own Git hooks, CI config, or IDE plugins. Totem ships reference wiring, not a mandatory policy.
 
-| Layer             | What Totem Provides (Sensor)            | What You Wire (Actuator)     |
-| ----------------- | --------------------------------------- | ---------------------------- |
-| **Deterministic** | `totem lint` — compiled rules, zero LLM | Git pre-push hook            |
-| **Knowledge**     | `search_knowledge` — vector index       | SessionStart hook, MCP tools |
-| **Review**        | `totem review` — LLM-powered analysis   | PreToolUse hook (optional)   |
+| Layer             | What Totem Provides                       | Where You Wire It            |
+| ----------------- | ----------------------------------------- | ---------------------------- |
+| **Deterministic** | `totem lint` (compiled rules, zero LLM)   | Git pre-push hook            |
+| **Knowledge**     | `search_knowledge` (vector index)         | SessionStart hook, MCP tools |
+| **Review**        | `totem review` (LLM-powered analysis)     | PreToolUse hook (optional)   |
 
 ### The Git Hook (Product — All Users)
 
@@ -27,7 +27,7 @@ No flag files. No LLM calls. No workflow opinions. Works air-gapped.
 
 For teams using AI agents, Totem provides a reference `PreToolUse` hook that uses **content hashing** to verify the agent reviewed the code before pushing. This is actor-aware — it only fires for the AI agent, never for the human developer.
 
-This is a reference implementation. You can use it as-is, adapt it, or build your own enforcement using Totem's sensors.
+This is a reference implementation. You can use it as-is, adapt it, or build your own enforcement using Totem's primitives.
 
 ## Handling False Positives
 

--- a/docs/wiki/enforcement-model.md
+++ b/docs/wiki/enforcement-model.md
@@ -8,11 +8,11 @@ Totem provides the **primitives** — the knowledge index, the compiler, the com
 
 Totem does **not** force a specific workflow — it doesn't dictate when to block, inject, or enforce. You decide how to wire these primitives into your own Git hooks, CI config, or IDE plugins. Totem ships reference wiring, not a mandatory policy.
 
-| Layer             | What Totem Provides                       | Where You Wire It            |
-| ----------------- | ----------------------------------------- | ---------------------------- |
-| **Deterministic** | `totem lint` (compiled rules, zero LLM)   | Git pre-push hook            |
-| **Knowledge**     | `search_knowledge` (vector index)         | SessionStart hook, MCP tools |
-| **Review**        | `totem review` (LLM-powered analysis)     | PreToolUse hook (optional)   |
+| Layer             | What Totem Provides                     | Where You Wire It            |
+| ----------------- | --------------------------------------- | ---------------------------- |
+| **Deterministic** | `totem lint` (compiled rules, zero LLM) | Git pre-push hook            |
+| **Knowledge**     | `search_knowledge` (vector index)       | SessionStart hook, MCP tools |
+| **Review**        | `totem review` (LLM-powered analysis)   | PreToolUse hook (optional)   |
 
 ### The Git Hook (Product — All Users)
 


### PR DESCRIPTION
Refactors the 1.14.0 feature documentation (Cross-Repo Mesh, Context Caching) and the Enforcement Model page to align with the new 'Pragmatic Builder' voice established in PR #1320.

- Scrubs 'Governance OS', 'Sensors/Actuators', and 'Flight Controller' metaphors.
- Frames new features as solutions to observed engineering friction (hallucinating context, prohibitive API costs) rather than declarative marketing claims.