### PR TITLE
fix(core): reject nonsense Pipeline 5 observation rules (#1279)

### DIFF
--- a/packages/core/src/pipeline-observation.test.ts
+++ b/packages/core/src/pipeline-observation.test.ts
@@ -154,7 +154,10 @@ describe('generateObservationRule', () => {
       '/* eslint-disable */',
       '   // indented comment',
       '# Python comment',
+      '#TODO no space after hash',
       '   # indented hash comment',
+      ' * JSDoc continuation line',
+      '   * indented JSDoc line',
     ];
 
     for (const content of cases) {

--- a/packages/core/src/pipeline-observation.test.ts
+++ b/packages/core/src/pipeline-observation.test.ts
@@ -125,6 +125,72 @@ describe('generateObservationRule', () => {
     expect(re.test('console.log(result);')).toBe(true);
   });
 
+  it('rejects pure-punctuation lines like } or */ (#1279)', () => {
+    const cases = [
+      { content: '}', desc: 'closing brace' },
+      { content: '*/', desc: 'block comment close' },
+      { content: '});', desc: 'closing brace + paren + semi' },
+      { content: '],', desc: 'closing bracket + comma' },
+      { content: '};', desc: 'closing brace + semi' },
+      { content: '  }  ', desc: 'indented closing brace' },
+    ];
+
+    for (const { content, desc } of cases) {
+      const input: ObservationInput = {
+        file: 'src/example.ts',
+        line: 1,
+        message: `Finding on ${desc}`,
+        fileContent: content,
+      };
+
+      expect(generateObservationRule(input)).toBeNull();
+    }
+  });
+
+  it('rejects comment-only lines (#1279)', () => {
+    const cases = [
+      '// TODO: fix this',
+      '// same response cache key.',
+      '/* eslint-disable */',
+      '   // indented comment',
+      '# Python comment',
+      '   # indented hash comment',
+    ];
+
+    for (const content of cases) {
+      const input: ObservationInput = {
+        file: 'src/example.ts',
+        line: 1,
+        message: 'Finding on comment line',
+        fileContent: content,
+      };
+
+      expect(generateObservationRule(input)).toBeNull();
+    }
+  });
+
+  it('accepts valid code lines despite containing punctuation (#1279)', () => {
+    const cases = [
+      'const result = foo(42);',
+      'import { foo } from "bar";',
+      'export default result;',
+      'console.log(result);',
+      'if (x > 0) {',
+      'return this.value;',
+    ];
+
+    for (const content of cases) {
+      const input: ObservationInput = {
+        file: 'src/example.ts',
+        line: 1,
+        message: 'Valid finding',
+        fileContent: content,
+      };
+
+      expect(generateObservationRule(input)).not.toBeNull();
+    }
+  });
+
   it('severity is always warning, never error', () => {
     const input: ObservationInput = {
       file: 'src/example.ts',

--- a/packages/core/src/pipeline-observation.test.ts
+++ b/packages/core/src/pipeline-observation.test.ts
@@ -180,6 +180,7 @@ describe('generateObservationRule', () => {
       'console.log(result);',
       'if (x > 0) {',
       'return this.value;',
+      '*args, **kwargs',
     ];
 
     for (const content of cases) {

--- a/packages/core/src/pipeline-observation.ts
+++ b/packages/core/src/pipeline-observation.ts
@@ -12,6 +12,11 @@ import { extname } from 'node:path';
 import type { CompiledRule } from './compiler-schema.js';
 import { codeToPattern } from './regex-utils.js';
 
+// ─── Constants ────────────────────────────────────
+
+/** Minimum alphanumeric characters a source line must contain to produce a rule. */
+const MIN_ALPHANUM_CHARS = 3;
+
 // ─── Input type ────────────────────────────────────
 
 /** Describes a single shield observation that should be turned into a rule. */
@@ -57,7 +62,7 @@ export function generateObservationRule(input: ObservationInput): CompiledRule |
   // that match thousands of lines across the codebase. (#1279)
   const trimmed = sourceLine.trim();
   const alphanumCount = (trimmed.match(/[a-zA-Z0-9]/g) ?? []).length;
-  if (alphanumCount < 3) {
+  if (alphanumCount < MIN_ALPHANUM_CHARS) {
     return null;
   }
 

--- a/packages/core/src/pipeline-observation.ts
+++ b/packages/core/src/pipeline-observation.ts
@@ -68,7 +68,13 @@ export function generateObservationRule(input: ObservationInput): CompiledRule |
 
   // Reject comment-only lines — patterns derived from comments match every
   // comment in the codebase and have no enforcement value. (#1279)
-  if (/^\s*\/\//.test(sourceLine) || /^\s*\/?\*/.test(sourceLine) || /^\s*#/.test(sourceLine)) {
+  if (
+    /^\s*\/\//.test(sourceLine) ||
+    /^\s*\/\*/.test(sourceLine) ||
+    /^\s*\*[\s/]/.test(sourceLine) ||
+    /^\s*\*$/.test(sourceLine) ||
+    /^\s*#/.test(sourceLine)
+  ) {
     return null;
   }
 

--- a/packages/core/src/pipeline-observation.ts
+++ b/packages/core/src/pipeline-observation.ts
@@ -63,7 +63,7 @@ export function generateObservationRule(input: ObservationInput): CompiledRule |
 
   // Reject comment-only lines — patterns derived from comments match every
   // comment in the codebase and have no enforcement value. (#1279)
-  if (/^\s*\/\//.test(sourceLine) || /^\s*\/\*/.test(sourceLine) || /^\s*#\s/.test(sourceLine)) {
+  if (/^\s*\/\//.test(sourceLine) || /^\s*\/?\*/.test(sourceLine) || /^\s*#/.test(sourceLine)) {
     return null;
   }
 

--- a/packages/core/src/pipeline-observation.ts
+++ b/packages/core/src/pipeline-observation.ts
@@ -52,6 +52,21 @@ export function generateObservationRule(input: ObservationInput): CompiledRule |
     return null;
   }
 
+  // Reject lines that are purely syntactic noise — closing braces, bracket/paren
+  // combos, block comment terminators. These produce patterns like `\}` or `\*/`
+  // that match thousands of lines across the codebase. (#1279)
+  const trimmed = sourceLine.trim();
+  const alphanumCount = (trimmed.match(/[a-zA-Z0-9]/g) ?? []).length;
+  if (alphanumCount < 3) {
+    return null;
+  }
+
+  // Reject comment-only lines — patterns derived from comments match every
+  // comment in the codebase and have no enforcement value. (#1279)
+  if (/^\s*\/\//.test(sourceLine) || /^\s*\/\*/.test(sourceLine) || /^\s*#\s/.test(sourceLine)) {
+    return null;
+  }
+
   const pattern = codeToPattern(sourceLine);
   if (pattern === '') {
     return null;


### PR DESCRIPTION
## Summary

- Pipeline 5 auto-capture was producing garbage regex rules from shield findings that pointed to syntactic noise (`}`, `*/`) or comment-only lines (`// TODO...`). Three consecutive reproductions on PRs #1278, #1282, #1292.
- Adds two validation gates in `generateObservationRule` before pattern generation: minimum alphanumeric content (≥3 chars) and comment-line rejection (`//`, `/*`, `*`, `#`).
- 15 new test inputs across 3 test cases covering rejection and acceptance.

Closes #1279

## Test plan

- [x] Pure-punctuation lines (`}`, `*/`, `});`, `],`, `};`) → rejected
- [x] Comment-only lines (`// TODO`, `/* eslint */`, `* JSDoc`, `# Python`, `#TODO`) → rejected
- [x] Valid code lines (`const x = ...`, `import ...`, `if (x > 0)`) → accepted
- [x] Full test suite passes (2727 tests, 0 failures)
- [x] `totem lint` passes (0 errors)
- [x] `totem review` passes (1 WARN addressed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)