### PR TITLE
chore: backfill changesets for 1.14.1

### DIFF
--- a/.changeset/pr-1311-hotfix-sweep.md
+++ b/.changeset/pr-1311-hotfix-sweep.md
@@ -1,0 +1,13 @@
+---
+'@mmnto/cli': patch
+'@mmnto/totem': patch
+---
+
+1.14.1 — Hotfix sweep (#1311)
+
+Bundled fixes for four post-1.14.0 regressions surfaced during the first day of 1.14.0 in production:
+
+- **#1304** — `totem review` and `totem lint` were running rules against on-disk content instead of staged content when files had unstaged modifications. The rule engine now loads staged blob content via `git show :path` when a path is in the index, falling back to filesystem read only for unstaged paths. Path containment is also hardened to reject symlinks that escape the repo root.
+- **#1305** — `lance-search` predicates were failing on any field name containing a SQL keyword or dash (`source-repo`, `file-type`) because the generated `WHERE` clause lacked backtick quoting. Field identifiers are now backtick-wrapped consistently.
+- **#1306** — AST engine test coverage audit found an uncovered branch in `ast-query` that silently returned an empty result set for malformed tree-sitter query strings. It now throws a descriptive error so `totem compile` can surface the broken rule instead of silently dropping it.
+- **#1309** — `totem doctor` and `totem lint` were still printing the legacy `totem review --fix` hint after that flag was removed in 1.12. Updated to the current `totem review --apply` form.

--- a/.changeset/pr-1311-hotfix-sweep.md
+++ b/.changeset/pr-1311-hotfix-sweep.md
@@ -7,7 +7,7 @@
 
 Bundled fixes for four post-1.14.0 regressions surfaced during the first day of 1.14.0 in production:
 
-- **#1304** — `totem review` and `totem lint` were running rules against on-disk content instead of staged content when files had unstaged modifications. The rule engine now loads staged blob content via `git show :path` when a path is in the index, falling back to filesystem read only for unstaged paths. Path containment is also hardened to reject symlinks that escape the repo root.
+- **#1304** — `totem review` and `totem lint` were running rules against on-disk content instead of staged content when files had unstaged modifications. The rule engine now loads staged blob content via `git show :path` when a path is in the index, and reads from the filesystem only when the path is unstaged. Path containment is also hardened to reject symlinks that escape the repo root.
 - **#1305** — `lance-search` predicates were failing on any field name containing a SQL keyword or dash (`source-repo`, `file-type`) because the generated `WHERE` clause lacked backtick quoting. Field identifiers are now backtick-wrapped consistently.
 - **#1306** — AST engine test coverage audit found an uncovered branch in `ast-query` that silently returned an empty result set for malformed tree-sitter query strings. It now throws a descriptive error so `totem compile` can surface the broken rule instead of silently dropping it.
 - **#1309** — `totem doctor` and `totem lint` were still printing the legacy `totem review --fix` hint after that flag was removed in 1.12. Updated to the current `totem review --apply` form.

--- a/.changeset/pr-1313-queue-drain.md
+++ b/.changeset/pr-1313-queue-drain.md
@@ -1,0 +1,11 @@
+---
+'@mmnto/cli': patch
+---
+
+Queue drain: Shield branding consistency (#1313)
+
+Three small queue-drain items bundled into one PR (#1298, #1299, #1302):
+
+- **#1298** — `totem shield` output and `totem --help` entries now consistently use "Shield" branding instead of the legacy "AI Shield" and "shield" mix that had crept in over several releases.
+- **#1299** — `/preflight` skill doc-scope expanded to cover the cases where preflight was routinely producing "draft from memory" outputs instead of searching the knowledge base first.
+- **#1302** — Dual-hash convention documented in `.gemini/styleguide.md` so cross-agent review produces consistent pattern/content hash formatting.

--- a/.changeset/pr-1314-ast-path-resolution.md
+++ b/.changeset/pr-1314-ast-path-resolution.md
@@ -1,0 +1,7 @@
+---
+'@mmnto/cli': patch
+---
+
+Resolve non-staged AST paths against repo root, not cwd (#1314)
+
+`totem review` was resolving AST engine file paths relative to the current working directory instead of the repo root when evaluating non-staged files, causing false misses for any invocation from a subdirectory. The resolver now consistently anchors against the repo root for both staged and non-staged paths. Fixes #1312.

--- a/.changeset/pr-1316-handoff-scaffold.md
+++ b/.changeset/pr-1316-handoff-scaffold.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/cli': patch
+---
+
+Refactor `totem handoff` to a deterministic journal scaffold (#1316)
+
+`totem handoff` previously generated its output via an LLM call, which made the command slow, non-reproducible, and gated on provider availability. It's now a deterministic scaffold: the command reads git state, recent commits, and the active journal directory, then writes a pre-filled template the user (or an agent) can flesh out.
+
+Closes #1310. Also removes ~500 lines of dead orchestration code that was only used by the old LLM path.

--- a/.changeset/pr-1324-pipeline5-gate.md
+++ b/.changeset/pr-1324-pipeline5-gate.md
@@ -1,0 +1,11 @@
+---
+'@mmnto/totem': patch
+---
+
+Reject nonsense Pipeline 5 observation rules (#1324)
+
+Pipeline 5 (auto-capture from Shield findings) was faithfully converting every source line Shield flagged into an observation rule, including lines that were pure syntactic noise (`}`, `*/`, bare braces) or comment-only. The result was a steady drip of garbage rules that users had to clean up via `git checkout -- .totem/compiled-rules.json` after every `totem review`.
+
+`generateObservationRule()` now rejects source lines with fewer than 3 alphanumeric characters and lines that are entirely comments (JSDoc, block-comment continuation, line comments, bare hash). The check is deliberately minimal — the goal is to drop obvious noise, not to second-guess Shield's judgment on real code.
+
+Closes #1279. Three consecutive reproductions (`*/`, `}`, and PR #1292's own cascade-fix commits) blocked on this gate in testing.

--- a/.changeset/pr-1325-stdout-rename.md
+++ b/.changeset/pr-1325-stdout-rename.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/cli': patch
+---
+
+Rename `totem handoff --no-edit` to `--stdout` (#1325)
+
+**User-visible CLI change.** The `--no-edit` flag on `totem handoff` never worked: Commander.js interpreted it as a boolean negation of a nonexistent `--edit` option, so passing `--no-edit` silently set an unrelated field to `false` and the command still tried to open `$EDITOR`. The flag has been renamed to `--stdout` (with `--lite` kept as an alias) which unambiguously prints the scaffold to stdout.
+
+Anyone who was passing `--no-edit` was getting the default behavior anyway, so there is no functional regression — just a rename to something that actually works. Fixes #1317. Also deletes the orphaned `handoff-checkpoint` schema files that were stranded when #1316 removed the LLM-path code that referenced them (#1318).

--- a/.changeset/pr-1326-tilde-fence.md
+++ b/.changeset/pr-1326-tilde-fence.md
@@ -6,4 +6,4 @@ Support tilde-fenced code blocks in lessons and compiler output (#1326)
 
 CommonMark allows `~~~` as an alternate code-fence delimiter. Totem's lesson parser, compiler-response parser, drift detector, lesson linter, and suspicious-lesson detector were all hard-coded to recognize only triple-backtick fences, so any lesson authored with tilde fences silently lost its code blocks during extraction and compilation.
 
-Seven files updated to match both fence styles. Every regex uses a capture group + backreference (`(```|~~~)...\1`) so opening and closing delimiters must match — mixing fence styles in a single block won't cross-match and produce garbage captures.
+Seven files updated to match both fence styles. Every regex uses a capture group plus backreference for the opening delimiter, so opening and closing fences must match — mixing fence styles in a single block won't cross-match and produce garbage captures.

--- a/.changeset/pr-1326-tilde-fence.md
+++ b/.changeset/pr-1326-tilde-fence.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/totem': patch
+---
+
+Support tilde-fenced code blocks in lessons and compiler output (#1326)
+
+CommonMark allows `~~~` as an alternate code-fence delimiter. Totem's lesson parser, compiler-response parser, drift detector, lesson linter, and suspicious-lesson detector were all hard-coded to recognize only triple-backtick fences, so any lesson authored with tilde fences silently lost its code blocks during extraction and compilation.
+
+Seven files updated to match both fence styles. Every regex uses a capture group + backreference (`(```|~~~)...\1`) so opening and closing delimiters must match — mixing fence styles in a single block won't cross-match and produce garbage captures.


### PR DESCRIPTION
## Summary

Backfills the seven missing changesets for code-bearing PRs merged to main since `@mmnto/*@1.14.0`. Prepares the ground for the 1.14.1 Version Packages PR once the remaining Phase 1 papercuts land.

**Changesets written** (all patch bumps per the incremental-release rule):

| PR | Scope | Title |
|---|---|---|
| #1311 | core + cli | 1.14.1 Hotfix Sweep |
| #1313 | cli | Queue drain: Shield branding + preflight + styleguide |
| #1314 | cli | Resolve non-staged AST paths against repo root |
| #1316 | cli | `totem handoff` deterministic scaffold refactor |
| #1324 | core | Pipeline 5 sanity gate |
| #1325 | cli | `--no-edit` → `--stdout` rename |
| #1326 | core | Tilde-fence support |

Four PRs are docs-only and do not ship to npm, so no changesets needed: #1315 (dropped lesson files), #1320 (README), #1322 (wiki), #1323 (wiki).

## Verification

`changeset status` confirms all three packages will bump to **1.14.1**:

```
info Packages to be bumped at patch:
- @mmnto/cli
- @mmnto/totem
- @mmnto/mcp
```

The `fixed` group in `.changeset/config.json` pulls `@mmnto/mcp` along even though no changeset names it directly.

## Noted lint warning

Pre-push lint flagged one warning on `.changeset/pr-1325-stdout-rename.md:7` for the phrase "never worked" — the rule fires on "never" as an absolute claim, but this is a factual statement about a flag that was broken by Commander.js's `--no-*` negation convention. Leaving as-is since the phrasing is accurate; happy to rephrase if reviewers disagree.

## Test plan

- [x] `changeset status` shows expected bumps
- [x] Pre-push hook passes (lint + tests + compiled rules)
- [ ] CI green
- [ ] Version Packages PR opens automatically and shows the expected 1.14.1 bump once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)