### PR TITLE
fix(test): avoid shell metacharacters in safeExec timeout test (#1233)

### DIFF
--- a/packages/core/src/sys/exec.test.ts
+++ b/packages/core/src/sys/exec.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, it } from 'vitest';
 
 import { safeExec } from './exec.js';
 
+// Long-running interval used to ensure the child process outlives the
+// timeout window. Any value safely larger than TIMEOUT_MS works; 30s is
+// generous enough that a slow CI runner won't race the check.
+const LONG_RUNNING_INTERVAL_MS = 30_000;
+// Timeout for the test that asserts safeExec honors its timeout option.
+// Short enough to keep the suite fast.
+const TIMEOUT_TEST_MS = 100;
+
 describe('safeExec', () => {
   it('executes a command and returns trimmed output', () => {
     // Use single quotes inside the JS expression — cmd.exe strips double quotes
@@ -50,7 +58,9 @@ describe('safeExec', () => {
       // shell: true to resolve .cmd/.bat shims, and cmd.exe would parse
       // the `=>` token in an arrow function as `=` + `>` output redirection,
       // creating a stray file named `{}` in the cwd. See mmnto/totem#1233.
-      safeExec('node', ['-e', 'setInterval(Object, 30000)'], { timeout: 100 });
+      safeExec('node', ['-e', `setInterval(Object, ${LONG_RUNNING_INTERVAL_MS})`], {
+        timeout: TIMEOUT_TEST_MS,
+      });
       expect.unreachable('should have thrown');
     } catch (err) {
       expect(err).toBeInstanceOf(Error);

--- a/packages/core/src/sys/exec.test.ts
+++ b/packages/core/src/sys/exec.test.ts
@@ -45,7 +45,12 @@ describe('safeExec', () => {
 
   it('respects timeout option', () => {
     try {
-      safeExec('node', ['-e', 'setTimeout(() => {}, 30000)'], { timeout: 100 });
+      // Using setInterval(Object, ...) instead of setTimeout(() => {}, ...)
+      // avoids shell metacharacters. On Windows, safeExec runs with
+      // shell: true to resolve .cmd/.bat shims, and cmd.exe would parse
+      // the `=>` token in an arrow function as `=` + `>` output redirection,
+      // creating a stray file named `{}` in the cwd. See mmnto/totem#1233.
+      safeExec('node', ['-e', 'setInterval(Object, 30000)'], { timeout: 100 });
       expect.unreachable('should have thrown');
     } catch (err) {
       expect(err).toBeInstanceOf(Error);


### PR DESCRIPTION
## Summary

Closes #1233. Refs #1329.

The reproducible 0-byte `packages/core/{}` file that #1233 tracked is caused by `exec.test.ts` passing `setTimeout(() => {}, 30000)` as a `node -e` argument. On Windows, `safeExec` runs with `shell: true` (to resolve `.cmd`/`.bat` shims), so cmd.exe re-parses the command line and splits the `=>` token into `=` + `>` (output redirection) — then redirects stdout to a file literally named `{}` in the cwd.

This replaces the arrow-function body with `setInterval(Object, 30000)`, which is equivalent for the test's purpose (long-running to prove the timeout triggers) but contains no shell metacharacters. An inline comment documents the pitfall so the test isn't "fixed" back into the broken state by a well-meaning future refactor.

## Scope note

This fixes the **symptom** — the stray file stops appearing. The **architectural issue** — `safeExec` leaks unescaped args to cmd.exe whenever `shell: true` is active on Windows, which is a potential shell-injection vector and a cross-platform behavior divergence — is filed separately as #1329. Deliberately kept out of scope here because the `safeExec` fix has wider blast radius and deserves its own PR with proper alternatives discussion (cross-spawn vs. manual escaping vs. explicit `.cmd` detection).

## Verification

Before the fix:
```
$ rm -f packages/core/\{\}
$ pnpm exec vitest run src/sys/exec.test.ts
  ✓ src/sys/exec.test.ts (7 tests) 229ms
$ ls packages/core/\{\}
packages/core/{}   # ← 0-byte file created
```

After the fix:
```
$ rm -f packages/core/\{\}
$ pnpm exec vitest run src/sys/exec.test.ts
  ✓ src/sys/exec.test.ts (7 tests) 229ms
$ ls packages/core/\{\}
ls: cannot access 'packages/core/{}': No such file or directory  # ← gone
```

## Noted lint warning

Pre-push lint flagged one warning on line 53 (catch block fallback comment rule). It's a false positive — the catch block intentionally swallows the timeout error because that *is* what the test is asserting. Leaving as-is; happy to rephrase if reviewers want.

## Test plan

- [x] `exec.test.ts` still passes (7/7)
- [x] No stray `{}` file after test run (verified locally)
- [x] Pre-push hook passed (lint + 2725 tests + compiled rules)
- [ ] CI green on Windows runner (real test for this fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)