### PR TITLE
fix(cli): prune stale nonCompilable entries on no-op compile runs (#1281)

### DIFF
--- a/.changeset/pr-1281-compile-prune-noop.md
+++ b/.changeset/pr-1281-compile-prune-noop.md
@@ -1,0 +1,11 @@
+---
+'@mmnto/cli': patch
+---
+
+Prune stale `nonCompilable` entries on no-op compile runs (#1281)
+
+`totem lesson compile` was only draining stale entries from the `nonCompilable` cache when there was actual compile work to do. On a no-op run (all lessons already compiled), stale entries — left over from lessons that had been edited or removed in a previous run — survived forever until some future run happened to have real work.
+
+The prune logic is now extracted into a pure helper (`pruneStaleNonCompilable`) and called from both branches. The no-op path only rewrites `compiled-rules.json` when there's actually something to drain, so genuinely idle runs still don't touch the file.
+
+Closes #1281. Discovered during the #1264 E2E reproduction.

--- a/packages/cli/src/commands/compile-prune.test.ts
+++ b/packages/cli/src/commands/compile-prune.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { pruneStaleNonCompilable } from './compile.js';
+
+describe('pruneStaleNonCompilable', () => {
+  it('returns empty result when the map is empty', () => {
+    const result = pruneStaleNonCompilable(new Map(), new Set(['abc', 'def']));
+    expect(result.fresh).toEqual([]);
+    expect(result.drained).toBe(0);
+  });
+
+  it('returns all entries when every hash is still current', () => {
+    const map = new Map<string, string>([
+      ['abc', 'First lesson'],
+      ['def', 'Second lesson'],
+    ]);
+    const current = new Set(['abc', 'def']);
+
+    const result = pruneStaleNonCompilable(map, current);
+
+    expect(result.fresh).toEqual([
+      { hash: 'abc', title: 'First lesson' },
+      { hash: 'def', title: 'Second lesson' },
+    ]);
+    expect(result.drained).toBe(0);
+  });
+
+  it('drops entries whose hashes are no longer present in current lessons', () => {
+    const map = new Map<string, string>([
+      ['abc', 'Kept lesson'],
+      ['stale1', 'Removed lesson A'],
+      ['stale2', 'Removed lesson B'],
+    ]);
+    const current = new Set(['abc']);
+
+    const result = pruneStaleNonCompilable(map, current);
+
+    expect(result.fresh).toEqual([{ hash: 'abc', title: 'Kept lesson' }]);
+    expect(result.drained).toBe(2);
+  });
+
+  it('drains everything when no hashes are current', () => {
+    const map = new Map<string, string>([
+      ['stale1', 'Removed A'],
+      ['stale2', 'Removed B'],
+    ]);
+    const current = new Set<string>();
+
+    const result = pruneStaleNonCompilable(map, current);
+
+    expect(result.fresh).toEqual([]);
+    expect(result.drained).toBe(2);
+  });
+
+  it('preserves tuple shape including titles from legacy-normalized entries', () => {
+    // Legacy string-form entries get normalized to {hash, title: '(legacy entry)'}
+    // by the schema transform. The prune helper must preserve that title verbatim.
+    const map = new Map<string, string>([['legacy-hash', '(legacy entry)']]);
+    const current = new Set(['legacy-hash']);
+
+    const result = pruneStaleNonCompilable(map, current);
+
+    expect(result.fresh).toEqual([{ hash: 'legacy-hash', title: '(legacy entry)' }]);
+    expect(result.drained).toBe(0);
+  });
+
+  it('does not mutate the input map', () => {
+    const map = new Map<string, string>([
+      ['abc', 'Kept'],
+      ['stale', 'Removed'],
+    ]);
+    const current = new Set(['abc']);
+
+    pruneStaleNonCompilable(map, current);
+
+    // Input map is unchanged — caller decides whether to mutate
+    expect(map.size).toBe(2);
+    expect(map.has('stale')).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/compile-prune.test.ts
+++ b/packages/cli/src/commands/compile-prune.test.ts
@@ -1,6 +1,21 @@
 import { describe, expect, it } from 'vitest';
 
-import { pruneStaleNonCompilable } from './compile.js';
+import type { CompiledRule } from '@mmnto/totem';
+
+import { pruneStaleNonCompilable, pruneStaleRules } from './compile.js';
+
+// ─── Test helpers ────────────────────────────────────
+
+function makeRule(lessonHash: string, heading = `Heading for ${lessonHash}`): CompiledRule {
+  return {
+    lessonHash,
+    lessonHeading: heading,
+    pattern: 'dummy',
+    message: heading,
+    engine: 'regex',
+    compiledAt: '2026-04-10T00:00:00Z',
+  };
+}
 
 describe('pruneStaleNonCompilable', () => {
   it('returns empty result when the map is empty', () => {
@@ -76,5 +91,57 @@ describe('pruneStaleNonCompilable', () => {
     // Input map is unchanged — caller decides whether to mutate
     expect(map.size).toBe(2);
     expect(map.has('stale')).toBe(true);
+  });
+});
+
+describe('pruneStaleRules', () => {
+  it('returns an empty result when the input rules array is empty', () => {
+    const result = pruneStaleRules([], new Set(['abc']));
+    expect(result.fresh).toEqual([]);
+    expect(result.pruned).toBe(0);
+  });
+
+  it('keeps all rules when every lessonHash is still current', () => {
+    const rules = [makeRule('abc'), makeRule('def')];
+    const result = pruneStaleRules(rules, new Set(['abc', 'def']));
+
+    expect(result.fresh).toHaveLength(2);
+    expect(result.fresh.map((r) => r.lessonHash)).toEqual(['abc', 'def']);
+    expect(result.pruned).toBe(0);
+  });
+
+  it('drops rules whose source lesson has been removed', () => {
+    const rules = [makeRule('abc'), makeRule('removed-1'), makeRule('removed-2')];
+    const result = pruneStaleRules(rules, new Set(['abc']));
+
+    expect(result.fresh.map((r) => r.lessonHash)).toEqual(['abc']);
+    expect(result.pruned).toBe(2);
+  });
+
+  it('drains everything when no lessonHash matches', () => {
+    const rules = [makeRule('stale-1'), makeRule('stale-2')];
+    const result = pruneStaleRules(rules, new Set<string>());
+
+    expect(result.fresh).toEqual([]);
+    expect(result.pruned).toBe(2);
+  });
+
+  it('preserves rule identity and field order for kept rules', () => {
+    const ruleA = makeRule('abc', 'Heading A');
+    const ruleB = makeRule('def', 'Heading B');
+    const result = pruneStaleRules([ruleA, ruleB], new Set(['abc', 'def']));
+
+    // Kept rules are the same object references, so metadata (compiledAt,
+    // createdAt, etc.) is preserved verbatim — important for audit lineage.
+    expect(result.fresh[0]).toBe(ruleA);
+    expect(result.fresh[1]).toBe(ruleB);
+  });
+
+  it('does not mutate the input array', () => {
+    const rules = [makeRule('abc'), makeRule('stale')];
+    pruneStaleRules(rules, new Set(['abc']));
+
+    expect(rules).toHaveLength(2);
+    expect(rules[1]!.lessonHash).toBe('stale');
   });
 });

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -81,6 +81,41 @@ export function buildTelemetryPrefix(contextCounts: {
   ].join(' ');
 }
 
+// ─── Non-compilable cache helpers ───────────────────
+
+/**
+ * Non-compilable entry as it lives on disk after the schema transform in
+ * `@mmnto/totem` normalizes legacy `string[]` entries to `{hash, title}` tuples.
+ */
+export interface NonCompilableTuple {
+  hash: string;
+  title: string;
+}
+
+/**
+ * Filter stale entries from a non-compilable map against the current set of
+ * lesson hashes. Returns the fresh tuple-form list and a count of how many
+ * entries were drained.
+ *
+ * Extracted for mmnto/totem#1281 so the no-op compile path can drain stale
+ * entries too — previously the prune only ran when `toCompile.length > 0`,
+ * leaving stale entries stranded on no-op runs (e.g. after a lesson was
+ * removed or after a parser-bug fix invalidated old non-compilable hashes).
+ * Pure function; does not mutate the input map.
+ */
+export function pruneStaleNonCompilable(
+  nonCompilableMap: Map<string, string>,
+  currentHashes: Set<string>,
+): { fresh: NonCompilableTuple[]; drained: number } {
+  const fresh: NonCompilableTuple[] = [];
+  for (const [hash, title] of nonCompilableMap) {
+    if (currentHashes.has(hash)) {
+      fresh.push({ hash, title });
+    }
+  }
+  return { fresh, drained: nonCompilableMap.size - fresh.length };
+}
+
 // ─── Logging helpers ────────────────────────────────
 
 function logCompiledRule(
@@ -424,9 +459,30 @@ export async function compileCommand(options: CompileOptions): Promise<UpgradeOu
     }
 
     if (toCompile.length === 0) {
+      // mmnto/totem#1281: even with no lessons to compile, stale non-compilable
+      // entries from lessons that were edited or removed in a previous run still
+      // need to be drained. Without this, stale entries survive forever until
+      // some future compile run happens to have real work to do.
+      let reportedNonCompilable = nonCompilableMap.size;
+      if (!options.raw) {
+        const currentHashes = new Set(lessons.map((l) => hashLesson(l.heading, l.body)));
+        const { fresh, drained } = pruneStaleNonCompilable(nonCompilableMap, currentHashes);
+        if (drained > 0) {
+          saveCompiledRulesFile(rulesPath, {
+            version: 1,
+            rules: existingRules,
+            nonCompilable: fresh,
+          });
+          log.dim(
+            TAG,
+            `Pruned ${drained} stale non-compilable entr${drained === 1 ? 'y' : 'ies'} (lessons edited or removed)`,
+          ); // totem-ignore
+          reportedNonCompilable = fresh.length;
+        }
+      }
       log.success(
         TAG,
-        `All ${lessonsInScope.length} lesson(s) in scope already processed (${existingRules.length} compiled, ${nonCompilableMap.size} non-compilable). Use --force to recompile.`,
+        `All ${lessonsInScope.length} lesson(s) in scope already processed (${existingRules.length} compiled, ${reportedNonCompilable} non-compilable). Use --force to recompile.`,
       ); // totem-ignore
     } else {
       const { createSpinner } = await import('../ui.js');
@@ -748,9 +804,11 @@ export async function compileCommand(options: CompileOptions): Promise<UpgradeOu
       if (!options.raw) {
         // mmnto/totem#1280: Prune stale non-compilable entries (lesson was edited or removed)
         // and write the result as {hash, title} tuples for observability.
-        const freshNonCompilable = [...nonCompilableMap.entries()]
-          .filter(([h]) => currentHashes.has(h))
-          .map(([hash, title]) => ({ hash, title }));
+        // The helper also covers the no-op path via mmnto/totem#1281.
+        const { fresh: freshNonCompilable } = pruneStaleNonCompilable(
+          nonCompilableMap,
+          currentHashes,
+        );
         saveCompiledRulesFile(rulesPath, {
           version: 1,
           rules: newRules,

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -116,6 +116,24 @@ export function pruneStaleNonCompilable(
   return { fresh, drained: nonCompilableMap.size - fresh.length };
 }
 
+/**
+ * Filter stale compiled rules whose source lesson has been removed from the
+ * project. Returns the fresh rule list (same object references preserved to
+ * keep audit lineage intact) and a count of how many rules were dropped.
+ *
+ * Symmetrical counterpart to `pruneStaleNonCompilable` — both helpers are
+ * used by the no-op compile path (mmnto/totem#1281) so lesson removals drain
+ * the compiled rule AND any stale non-compilable entry in the same run.
+ * Pure function; does not mutate the input array.
+ */
+export function pruneStaleRules(
+  rules: readonly CompiledRule[],
+  currentHashes: Set<string>,
+): { fresh: CompiledRule[]; pruned: number } {
+  const fresh = rules.filter((r) => currentHashes.has(r.lessonHash));
+  return { fresh, pruned: rules.length - fresh.length };
+}
+
 // ─── Logging helpers ────────────────────────────────
 
 function logCompiledRule(
@@ -459,31 +477,72 @@ export async function compileCommand(options: CompileOptions): Promise<UpgradeOu
     }
 
     if (toCompile.length === 0) {
-      // mmnto/totem#1281: even with no lessons to compile, stale non-compilable
-      // entries from lessons that were edited or removed in a previous run still
-      // need to be drained. Without this, stale entries survive forever until
-      // some future compile run happens to have real work to do.
+      // mmnto/totem#1281: even with no lessons to compile, stale entries left
+      // over from a previous run still need to be drained. Two cases share
+      // this no-op stall:
+      //  1. Stale `nonCompilable` entries from lessons that were edited or
+      //     removed (the original ticket scope).
+      //  2. Stale compiled rules whose source lesson has been removed
+      //     entirely — pointed out by GCA on PR #1331 review. Same
+      //     inconsistency vs. the active-compile branch, same fix.
+      // Without this, stale entries survive forever until some future compile
+      // run happens to have real work to do. Both counts flow into the
+      // success log so the reported state matches disk state.
       let reportedNonCompilable = nonCompilableMap.size;
+      let reportedCompiled = existingRules.length;
       if (!options.raw) {
         const currentHashes = new Set(lessons.map((l) => hashLesson(l.heading, l.body)));
-        const { fresh, drained } = pruneStaleNonCompilable(nonCompilableMap, currentHashes);
-        if (drained > 0) {
+        const { fresh: freshRules, pruned: rulesPruned } = pruneStaleRules(
+          existingRules,
+          currentHashes,
+        );
+        const { fresh: freshNonCompilable, drained } = pruneStaleNonCompilable(
+          nonCompilableMap,
+          currentHashes,
+        );
+        if (rulesPruned > 0 || drained > 0) {
           saveCompiledRulesFile(rulesPath, {
             version: 1,
-            rules: existingRules,
-            nonCompilable: fresh,
+            rules: freshRules,
+            nonCompilable: freshNonCompilable,
           });
-          log.dim(
-            TAG,
-            `Pruned ${drained} stale non-compilable entr${drained === 1 ? 'y' : 'ies'} (lessons edited or removed)`,
-          ); // totem-ignore
-          reportedNonCompilable = fresh.length;
+          if (rulesPruned > 0) {
+            log.dim(
+              TAG,
+              `Pruned ${rulesPruned} stale rule${rulesPruned === 1 ? '' : 's'} (lessons removed)`,
+            ); // totem-context: log only fires when actual draining happens
+          }
+          if (drained > 0) {
+            log.dim(
+              TAG,
+              `Pruned ${drained} stale non-compilable entr${drained === 1 ? 'y' : 'ies'} (lessons edited or removed)`,
+            ); // totem-context: log only fires when actual draining happens
+          }
+          // CR finding on PR #1331: refresh the compile manifest so its
+          // output hash and rule_count match the rewritten on-disk state.
+          // Without this, provenance/attestation flows desync silently.
+          const { generateInputHash, generateOutputHash, writeCompileManifest } =
+            await import('@mmnto/totem');
+          const lessonsDir = path.join(totemDir, 'lessons');
+          const manifestPath = path.join(totemDir, 'compile-manifest.json');
+          const inputHash = generateInputHash(lessonsDir);
+          const outputHash = generateOutputHash(rulesPath);
+          writeCompileManifest(manifestPath, {
+            compiled_at: new Date().toISOString(),
+            model: options.model ?? config.orchestrator?.defaultModel ?? 'unknown',
+            input_hash: inputHash,
+            output_hash: outputHash,
+            rule_count: freshRules.length,
+          });
+          log.dim(TAG, `Manifest: ${inputHash.slice(0, 8)}…→${outputHash.slice(0, 8)}…`); // totem-context: provenance trace matches active-compile branch
+          reportedNonCompilable = freshNonCompilable.length;
+          reportedCompiled = freshRules.length;
         }
       }
       log.success(
         TAG,
-        `All ${lessonsInScope.length} lesson(s) in scope already processed (${existingRules.length} compiled, ${reportedNonCompilable} non-compilable). Use --force to recompile.`,
-      ); // totem-ignore
+        `All ${lessonsInScope.length} lesson(s) in scope already processed (${reportedCompiled} compiled, ${reportedNonCompilable} non-compilable). Use --force to recompile.`,
+      ); // totem-context: success log reports post-prune counts
     } else {
       const { createSpinner } = await import('../ui.js');
       const spinner = await createSpinner(TAG, 'Compiling...');
@@ -805,10 +864,16 @@ export async function compileCommand(options: CompileOptions): Promise<UpgradeOu
         // mmnto/totem#1280: Prune stale non-compilable entries (lesson was edited or removed)
         // and write the result as {hash, title} tuples for observability.
         // The helper also covers the no-op path via mmnto/totem#1281.
-        const { fresh: freshNonCompilable } = pruneStaleNonCompilable(
-          nonCompilableMap,
-          currentHashes,
-        );
+        const { fresh: freshNonCompilable, drained: nonCompilableDrained } =
+          pruneStaleNonCompilable(nonCompilableMap, currentHashes);
+        if (nonCompilableDrained > 0) {
+          // GCA finding on PR #1331: log drained entries here for parity with
+          // the no-op branch, so telemetry traces are symmetric.
+          log.dim(
+            TAG,
+            `Pruned ${nonCompilableDrained} stale non-compilable entr${nonCompilableDrained === 1 ? 'y' : 'ies'} (lessons edited or removed)`,
+          ); // totem-context: log only fires when actual draining happens
+        }
         saveCompiledRulesFile(rulesPath, {
           version: 1,
           rules: newRules,


### PR DESCRIPTION
## Summary

Closes #1281.

`totem lesson compile` was only draining stale entries from the `nonCompilable` cache when `toCompile.length > 0`. On a no-op run (all lessons already compiled), stale entries left over from lessons that had been edited or removed in a previous run survived forever until some future run happened to have real work to do.

## Fix

Extract the prune logic into a pure helper `pruneStaleNonCompilable` and call it from both branches:

- **No-op branch** (`toCompile.length === 0`) now prunes and rewrites `compiled-rules.json` *only* if something was actually drained. A genuinely idle run (no lesson changes, no stale entries) still does not touch the file, matching the acceptance criterion in the ticket.
- **Active-compile branch** uses the same helper instead of its previous inline prune, keeping both code paths in lockstep.

The helper is pure and non-mutating — the six unit tests cover empty map, all-current, all-stale, partial drain, legacy title preservation, and explicit non-mutation of the input map.

## Shield finding addressed inline

Shield caught that the success log message was using `nonCompilableMap.size` (the pre-prune size), so it would report the stale count even after draining entries. Fixed by computing `reportedNonCompilable` after the prune and threading it through to the log line.

## Test plan

- [x] New unit tests: 6/6 pass (`compile-prune.test.ts`)
- [x] Full cli test suite: 1627/1627 pass
- [x] Shield PASS (second run after fixing the log-count finding)
- [x] Pre-push hook passed (format, lint, tests, compiled rules)
- [ ] CI green

## Noted lint warning

Pre-push lint flagged one warning: `orchestrator test suites should set an explicit 15s timeout`. This is a false positive — the test suite is for a pure synchronous function with no orchestrator involvement. Leaving as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)