### PR TITLE
fix(mcp): prevent double-heading when add_lesson body starts with canonical heading (#1284)

### DIFF
--- a/.changeset/pr-1284-mcp-double-heading.md
+++ b/.changeset/pr-1284-mcp-double-heading.md
@@ -1,0 +1,11 @@
+---
+'@mmnto/mcp': patch
+---
+
+Fix `add_lesson` MCP tool double-prepending `## Lesson — ` heading (#1284)
+
+When a caller passed a pre-formatted lesson to the `add_lesson` MCP tool whose body already started with a canonical `## Lesson — Foo` heading, the tool derived a title from the first line of the body — which included the literal `Lesson —` prefix — and produced a file with `## Lesson — Lesson — Foo` as the wrapper, with the original `## Lesson — Foo` still intact inside the body. The parser correctly read that as two separate lessons.
+
+The tool now detects a pre-existing canonical heading (em-dash, en-dash, or hyphen variants, consistent with the parser fix in #1278), extracts the title, and strips the heading line from the body before wrapping. Callers who pass plain body text with no leading heading see unchanged behavior.
+
+Closes #1284. Discovered during PR #1282 dogfooding.

--- a/.changeset/pr-1284-mcp-double-heading.md
+++ b/.changeset/pr-1284-mcp-double-heading.md
@@ -2,7 +2,7 @@
 '@mmnto/mcp': patch
 ---
 
-Fix `add_lesson` MCP tool double-prepending `## Lesson — ` heading (#1284)
+Fix `add_lesson` MCP tool double-prepending `## Lesson —` heading (#1284)
 
 When a caller passed a pre-formatted lesson to the `add_lesson` MCP tool whose body already started with a canonical `## Lesson — Foo` heading, the tool derived a title from the first line of the body — which included the literal `Lesson —` prefix — and produced a file with `## Lesson — Lesson — Foo` as the wrapper, with the original `## Lesson — Foo` still intact inside the body. The parser correctly read that as two separate lessons.
 

--- a/packages/mcp/src/tools/add-lesson.test.ts
+++ b/packages/mcp/src/tools/add-lesson.test.ts
@@ -196,3 +196,108 @@ describe('add_lesson auth model (#844)', () => {
     expect(typeof opts.shell).toBe('boolean');
   });
 });
+
+// ---------------------------------------------------------------------------
+// Double-heading bug (#1284)
+// ---------------------------------------------------------------------------
+
+describe('add_lesson double-heading guard (#1284)', () => {
+  let handle: (args: Record<string, unknown>) => Promise<unknown>;
+
+  beforeEach(() => {
+    _resetRateLimit();
+    lastWrittenEntry = '';
+    handle = setup();
+  });
+
+  /** Count occurrences of `## Lesson —` (all dash variants) in a string. */
+  function countLessonHeadings(entry: string): number {
+    const matches = entry.match(/^## Lesson[\s\u2014\u2013-]+/gm);
+    return matches ? matches.length : 0;
+  }
+
+  it('does not duplicate heading when body starts with canonical em-dash heading', async () => {
+    await handle({
+      lesson:
+        '## Lesson — Read-path schema changes break write-path invariants\n\nWhen modifying parsing logic that produces a data structure, also consider the writers.',
+      context_tags: ['architecture'],
+    });
+
+    expect(countLessonHeadings(lastWrittenEntry)).toBe(1);
+    expect(lastWrittenEntry).toContain(
+      '## Lesson — Read-path schema changes break write-path invariants',
+    );
+    // And the auto-generated duplicate must not appear
+    expect(lastWrittenEntry).not.toContain('## Lesson — Lesson —');
+  });
+
+  it('handles en-dash heading variant', async () => {
+    await handle({
+      lesson: '## Lesson – Use err in catch blocks\n\nDo not use error in catch blocks.',
+      context_tags: ['style'],
+    });
+
+    expect(countLessonHeadings(lastWrittenEntry)).toBe(1);
+  });
+
+  it('handles hyphen heading variant', async () => {
+    await handle({
+      lesson: '## Lesson - Plain hyphen variant\n\nBody text here.',
+      context_tags: ['test'],
+    });
+
+    expect(countLessonHeadings(lastWrittenEntry)).toBe(1);
+  });
+
+  it('preserves existing behavior when body does NOT start with a heading', async () => {
+    await handle({
+      lesson:
+        'Always validate input at trust boundaries. This is a plain lesson body with no heading.',
+      context_tags: ['security'],
+    });
+
+    // Exactly one heading should still be generated (by the auto-path)
+    expect(countLessonHeadings(lastWrittenEntry)).toBe(1);
+    expect(lastWrittenEntry).toContain('## Lesson — ');
+  });
+
+  it('strips the pre-existing heading from the body so it is not included twice in content', async () => {
+    await handle({
+      lesson: '## Lesson — First heading\n\nBody line one.\nBody line two.',
+      context_tags: ['test'],
+    });
+
+    // The body portion of the entry should contain "Body line one" and "Body line two"
+    // but should NOT contain the verbatim "## Lesson — First heading" line anywhere
+    // below the first line of the file.
+    const lines = lastWrittenEntry.split('\n');
+    const headingLineCount = lines.filter((l) => /^## Lesson[\s\u2014\u2013-]+/.test(l)).length;
+    expect(headingLineCount).toBe(1);
+    expect(lastWrittenEntry).toContain('Body line one.');
+    expect(lastWrittenEntry).toContain('Body line two.');
+  });
+
+  it('still applies tags and provenance when body has a pre-existing heading', async () => {
+    await handle({
+      lesson: '## Lesson — Heading here\n\nBody content.',
+      context_tags: ['tag-one', 'tag-two'],
+    });
+
+    expect(lastWrittenEntry).toContain('**Tags:** tag-one, tag-two');
+    expect(lastWrittenEntry).toContain('**Source:** mcp (added at ');
+  });
+
+  it('handles single-line lesson without trailing newline', async () => {
+    // Shield caught this edge case: if the caller sends just `## Lesson — Foo`
+    // with no body and no trailing newline, the earlier regex variant that
+    // required `\n+` at the end would fall through and produce a double heading.
+    await handle({
+      lesson: '## Lesson — Single line no body',
+      context_tags: ['edge-case'],
+    });
+
+    expect(countLessonHeadings(lastWrittenEntry)).toBe(1);
+    expect(lastWrittenEntry).toContain('## Lesson — Single line no body');
+    expect(lastWrittenEntry).not.toContain('## Lesson — Lesson');
+  });
+});

--- a/packages/mcp/src/tools/add-lesson.test.ts
+++ b/packages/mcp/src/tools/add-lesson.test.ts
@@ -300,4 +300,37 @@ describe('add_lesson double-heading guard (#1284)', () => {
     expect(lastWrittenEntry).toContain('## Lesson — Single line no body');
     expect(lastWrittenEntry).not.toContain('## Lesson — Lesson');
   });
+
+  it('handles pre-formatted lesson with leading blank lines or whitespace', async () => {
+    // Both GCA and CR flagged that a caller (especially an LLM) could emit
+    // a pre-formatted lesson prefixed by blank lines or leading whitespace.
+    // Without ^\s* the detection would miss it, fall through to the auto-title
+    // path, and reproduce the double-heading bug.
+    await handle({
+      lesson: '\n\n## Lesson — Leading whitespace variant\n\nBody content.',
+      context_tags: ['test'],
+    });
+
+    expect(countLessonHeadings(lastWrittenEntry)).toBe(1);
+    expect(lastWrittenEntry).toContain('## Lesson — Leading whitespace variant');
+    expect(lastWrittenEntry).not.toContain('## Lesson — Lesson');
+  });
+
+  it('does NOT treat lowercase "## lesson" as a canonical heading', async () => {
+    // Stay case-sensitive to match the parser's LESSON_HEADING_RE
+    // (`^## Lesson [—–-] ` with capital L) in core/drift-detector.ts.
+    // If we accepted lowercase here we would strip a line the parser would
+    // treat as body text, breaking round-trip semantics. The fallback path
+    // generates a title from the full body and the lowercase line is
+    // preserved verbatim inside the written entry.
+    await handle({
+      lesson: '## lesson — not canonical heading\nSome body.',
+      context_tags: ['test'],
+    });
+
+    // Exactly one canonical "## Lesson" line at the top — and the original
+    // lowercase line is preserved verbatim in the body (not stripped).
+    expect(countLessonHeadings(lastWrittenEntry)).toBe(1);
+    expect(lastWrittenEntry).toContain('## lesson — not canonical heading');
+  });
 });

--- a/packages/mcp/src/tools/add-lesson.ts
+++ b/packages/mcp/src/tools/add-lesson.ts
@@ -180,7 +180,34 @@ export function registerAddLesson(server: McpServer): void {
             .map((t) => sanitize(t).replace(/[\n,]/g, ' ').trim())
             .filter(Boolean)
             .join(', ') || 'untagged';
-        const rawHeading = generateLessonHeading(safeLesson);
+
+        // --- Double-heading guard (#1284) ---
+        // If the caller supplies a pre-formatted lesson whose body already
+        // starts with a canonical `## Lesson — Foo` heading, extract the
+        // heading and strip it from the body. Without this, `generateLessonHeading`
+        // would derive a title from the "Lesson — Foo" text and produce
+        // `## Lesson — Lesson — Foo`, and the original heading would remain
+        // inside the body — yielding two `## Lesson — ...` lines in one file
+        // that the parser then counts as two separate lessons.
+        // The separator class matches em-dash (\u2014), en-dash (\u2013), and
+        // hyphen, consistent with the parser's LESSON_HEADING_RE in #1278.
+        // The terminator allows either trailing newlines OR end-of-string so
+        // a single-line input like `## Lesson — Foo` (no body, no trailing
+        // newline) still gets normalized instead of slipping through.
+        // `matchAll` + iterator instead of `match` to satisfy the project-wide
+        // lint rule about iterating all regex matches — the `^` anchor ensures
+        // at most one match here regardless.
+        const LESSON_HEADING_RE = /^## Lesson[\s\u2014\u2013-]+(.+?)(?:\s*\n+|\s*$)/g;
+        const headingMatch = safeLesson.matchAll(LESSON_HEADING_RE).next().value;
+        let rawHeading: string;
+        let bodyContent: string;
+        if (headingMatch) {
+          rawHeading = headingMatch[1]!;
+          bodyContent = safeLesson.slice(headingMatch[0].length).trim();
+        } else {
+          rawHeading = generateLessonHeading(safeLesson);
+          bodyContent = safeLesson.trim();
+        }
         const heading = sanitizeHeading(rawHeading);
 
         // --- Source provenance (#844) ---
@@ -189,7 +216,7 @@ export function registerAddLesson(server: McpServer): void {
         const entry =
           `## Lesson — ${heading}\n\n` +
           `**Tags:** ${safeTags}\n\n` +
-          `${safeLesson.trim()}\n` +
+          `${bodyContent}\n` +
           provenance;
 
         // Acquire lock before writing lesson, release before spawning sync

--- a/packages/mcp/src/tools/add-lesson.ts
+++ b/packages/mcp/src/tools/add-lesson.ts
@@ -194,10 +194,16 @@ export function registerAddLesson(server: McpServer): void {
         // The terminator allows either trailing newlines OR end-of-string so
         // a single-line input like `## Lesson — Foo` (no body, no trailing
         // newline) still gets normalized instead of slipping through.
+        // Leading `\s*` absorbs blank lines or whitespace before the heading
+        // (LLM callers sometimes emit pre-formatted lessons with a leading
+        // newline). Case sensitivity intentionally matches the parser's
+        // canonical form in core/drift-detector.ts — if we accepted lowercase
+        // here we would strip a line the parser would still treat as body
+        // text, breaking round-trip semantics.
         // `matchAll` + iterator instead of `match` to satisfy the project-wide
         // lint rule about iterating all regex matches — the `^` anchor ensures
         // at most one match here regardless.
-        const LESSON_HEADING_RE = /^## Lesson[\s\u2014\u2013-]+(.+?)(?:\s*\n+|\s*$)/g;
+        const LESSON_HEADING_RE = /^\s*## Lesson[\s\u2014\u2013-]+(.+?)(?:\s*\n+|\s*$)/g;
         const headingMatch = safeLesson.matchAll(LESSON_HEADING_RE).next().value;
         let rawHeading: string;
         let bodyContent: string;


### PR DESCRIPTION
## Summary

Closes #1284.

When a caller passes a pre-formatted lesson to `add_lesson` whose body already starts with `## Lesson — Foo`, the tool was deriving a title from the first line of the body — which included the literal `Lesson —` prefix — and producing a file with `## Lesson — Lesson — Foo` as the wrapper heading, **with the original `## Lesson — Foo` still intact inside the body**. The parser then correctly counted that as two separate lessons.

## Fix

Detect a pre-existing canonical heading (em-dash, en-dash, or hyphen variants, consistent with the parser's `LESSON_HEADING_RE` in #1278), extract the title, and strip the heading line from the body before the wrap step. Callers who pass plain body text with no leading heading see unchanged behavior.

## Shield edge case caught and fixed inline

Shield caught that the initial regex required `\n+` at the end, which would fall through for a single-line input like `## Lesson — Foo` (no body, no trailing newline) and reproduce the bug. Added a test for that case and widened the terminator to `(?:\s*\n+|\s*$)`.

## `match` → `matchAll` refactor

Project-wide lint rule "use `matchAll()` instead of `match()` for security validations" flagged the initial use of `safeLesson.match(LESSON_HEADING_RE)`. The rule is defending against attackers shadowing malicious payloads with a safe prefix — not actually a hazard here because the regex is `^`-anchored (matches at position 0 only), but the rule is error-level. Refactored to `matchAll(...).next().value` to satisfy the rule without semantic changes. Inline comment documents that the `^` anchor already bounds this to one match.

## Test plan

- [x] New tests: 7/7 pass (`add-lesson.test.ts` — em-dash / en-dash / hyphen / no-heading / body-preservation / tags+provenance / single-line)
- [x] Full MCP test suite: 80/80 pass
- [x] Shield PASS (second run after fixing the single-line edge case)
- [x] Pre-push hook passed (20 unrelated warnings on pre-existing code, 0 errors)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)