### PR TITLE
chore(rules): archive rule 7e511801 (over-broad diff-header regex)

### DIFF
--- a/.totem/compile-manifest.json
+++ b/.totem/compile-manifest.json
@@ -2,6 +2,6 @@
   "compiled_at": "2026-04-11T05:28:26.417Z",
   "model": "gemini-3-flash-preview",
   "input_hash": "22224cfa711642a21d2921bc292f05636cfd5823f1197722ce899e291a423143",
-  "output_hash": "2f97358cdd72c5434e91953daa9e0e1c9e1dcfe3b1724e366d964777d7944270",
+  "output_hash": "5bfe2cd089b8bb92c094da7a3dacf4f6d6ac267882c46c083395d7928fbb82b9",
   "rule_count": 394
 }

--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -5306,7 +5306,9 @@
         "**/*.go",
         "**/*.rs"
       ],
-      "severity": "error"
+      "severity": "error",
+      "status": "archived",
+      "archivedReason": "Over-broad regex. The pattern matches any string literal containing \"+++ b/\" or \"--- a/\" regardless of whether the file path actually contains spaces, so it fires on every legitimate git-diff test fixture in core/cli/mcp test files. Multiple test files across the repo already have this pattern unchallenged because they predate the rule — only new test code trips it. Archived via the mmnto/totem#1345 loadCompiledRules filter after the self-healing loop was unlocked. Superseded by the broader ast-grep validation work tracked in mmnto/totem#1339. Kept in the manifest (not deleted) so telemetry on its historical triggers stays intact."
     },
     {
       "lessonHash": "541a56213e186fa9",


### PR DESCRIPTION
## Summary

Uses the new mmnto/totem#1345 `loadCompiledRules` archive filter to silence rule `7e51180103c25af5` ("Git diff headers wrap file paths containing spaces"). First use of the just-landed self-healing superpower.

## The rule is broken

The regex `(['\"\/])\^?\+\+\+\s+b\\?\/` was supposed to catch git diff headers where file paths contain spaces and therefore need quoting — e.g., `'+++ "b/path with spaces.ts"'`. Instead it fires on **any** string literal containing `'+++ b/` regardless of whether the path actually has a space in it.

Every legitimate diff-fixture test file across core + cli + mcp already tripped this — they only stopped biting because they predated the rule and weren't in any diff since. When PR #1345 added a new integration test that needed a literal `'+++ b/src/sample.ts'` line (no space in the path) to seed a diff for `applyRules`, lint failed with this rule even though the path is a plain `src/sample.ts`. I worked around it on #1345 by constructing the `+++` prefix dynamically (`'+'.repeat(3)`), but that's ugly and every future diff-fixture test author will hit the same wall.

## Why archive instead of delete

Archiving (not deleting) per ADR-074 Trap Ledger lifecycle: the rule stays in `compiled-rules.json` so historical trigger/suppression telemetry is preserved. `loadCompiledRules` now filters it out of the lint execution path. The rule's source lesson can still be reopened and recompiled later if someone wants to make a tighter version that actually checks for spaces in the path.

## End-to-end proof of life for #1345

```
$ pnpm exec totem verify-manifest
[Verify] PASS — Manifest verified: 394 rules, hashes match.

$ pnpm exec totem lint
[Lint] Running 393 rules (zero LLM)...
[Lint] Verdict: PASS — 393 rules, 0 violations
```

The manifest still carries 394 (total, including archived), `verify-manifest` is happy because the output hash was refreshed, and lint only runs 393 (one silenced). This is the fix from #1345 doing its job on a real rule for the first time.

## What this unblocks

- Future diff-fixture test authors no longer need the `'+'.repeat(3)` workaround.
- Empirically validates the #1345 filter against a production-quality rule file (not just a unit test fixture).
- Superseded by the broader ast-grep pattern validation tracked in #1339 when that lands — until then, archiving is the right hammer for this class of "compiled but over-broad" rule.

## Test plan

- [x] `pnpm exec totem verify-manifest` — PASS (394 rules, hashes match)
- [x] `pnpm exec totem lint` — PASS (393 rules running, archived rule silenced)
- [x] Pre-push hook — PASS

## Files

- `.totem/compiled-rules.json` — one rule mutated: `status: 'archived'` + `archivedReason` added
- `.totem/compile-manifest.json` — `output_hash` refreshed to match the new rules file bytes

No source code changes, no changeset (data-only edit, no publishable package affected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)