### PR TITLE
docs(readme): restore SARIF + CI/CD and air-gapped coverage (#1344)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,23 @@ Totem is a set of CLI tools, not a framework. Building blocks you wire into what
 
 The built-in MCP server exposes the knowledge base to any compatible agent — same index, no extra setup.
 
+## CI/CD and GitHub Integration
+
+Because `totem lint` is deterministic and runs in under two seconds, it drops cleanly into a CI pipeline. It supports three output formats — `text` (default), `json` for scripting, and `sarif` for security dashboards:
+
+```bash
+totem lint --format sarif --out totem.sarif
+```
+
+Pipe the SARIF file into GitHub Code Scanning (via the standard `github/codeql-action/upload-sarif` action) or any SARIF-compliant tool, and Totem's tripwires show up as inline PR annotations right where the developer wrote the code that violated a rule. The stream is deliberately scoped to error-severity findings so PR reviews don't drown in probationary warnings — warnings stay as local telemetry until a rule has enough signal to graduate.
+
+The same `--format sarif` flag works on the standalone `totem-lite` binary for CI environments without Node.js. See [CI/CD Integration](https://github.com/mmnto-ai/totem/blob/main/docs/wiki/ci-integration.md) for pipeline recipes.
+
 ## What Works and What Doesn't
 
 Totem has three layers, and I want to be honest about where each one stands:
 
-1. **The enforcement layer works.** Compiled rules, Git hooks, the pre-push lint gate — they catch violations mechanically, offline, in under 2 seconds. This is the load-bearing floor that everything else stands on.
+1. **The enforcement layer works.** Compiled rules, Git hooks, the pre-push lint gate — they catch violations mechanically, offline, in under 2 seconds. This is the load-bearing floor that everything else stands on. And because nothing on that floor touches the network, it runs natively in air-gapped environments — no source code leaves your machine.
 2. **The planning layer works too, to my surprise.** Before the agent writes any code, `totem spec` pulls the GitHub issue body, queries the knowledge base for relevant lessons and ADRs, and dumps a structured implementation spec to `.totem/specs/<issue>.md` — architectural context, files to examine, edge cases the issue description missed, and task-by-task TDD directives with retrieved lessons injected inline as invariants. None of this is a hard tripwire — the agent could write a vague spec and ignore the retrieved context — but in practice the structured prompt reliably catches "I'm about to reinvent a helper that already exists" before the agent commits to an approach, not after. A meaningful chunk of the velocity and architectural consistency I've been hitting comes from this upstream gate, more than I expected when I first added it.
 3. **The memory layer is real infrastructure** — the index exists, it's queryable, and it's portable across agents and repos. But whether an agent _consistently acts_ on the context it retrieves is an open question I'm actively working through. Availability is deterministic. The agent's discipline is not.
 


### PR DESCRIPTION
## Summary

Closes #1344.

The multi-PR voice refresh cycle (#1320 → #1341 → #1343) over-corrected when stripping marketing speak and role-assignment metaphors — two load-bearing feature surfaces got dropped along with the fluff: (a) the SARIF output format and its CI integration story, and (b) the offline / air-gapped invariant. This PR restores both in the pragmatic-builder voice the rest of the doc now uses.

## Strategic framing (from Gemini, executed by me)

1. **No diff archaeology.** The pre-#1320 copy was infected with the "Governance OS / Flight Controller" voice we deliberately killed. Reaching back into old wording risks letting corporate nouns bleed back in. Wrote fresh instead.
2. **Surgical placement, not a restructure.** Two edits only — one new short section and one sentence appended to an existing bullet — so this doesn't re-litigate what #1341 and #1343 just settled.
3. **Feature coverage is non-negotiable, but voice is also non-negotiable.** Both restored facts are stated as mechanical truths (WWND voice) rather than marketing claims.

## The two edits

### 1. New "CI/CD and GitHub Integration" section

Placed immediately after the "What's in the Box" table, before "What Works and What Doesn't". Full text:

> ## CI/CD and GitHub Integration
>
> Because `totem lint` is deterministic and runs in under two seconds, it drops cleanly into a CI pipeline. It supports three output formats — `text` (default), `json` for scripting, and `sarif` for security dashboards:
>
> ```bash
> totem lint --format sarif --out totem.sarif
> ```
>
> Pipe the SARIF file into GitHub Code Scanning (via the standard `github/codeql-action/upload-sarif` action) or any SARIF-compliant tool, and Totem's tripwires show up as inline PR annotations right where the developer wrote the code that violated a rule. The stream is deliberately scoped to error-severity findings so PR reviews don't drown in probationary warnings — warnings stay as local telemetry until a rule has enough signal to graduate.
>
> The same `--format sarif` flag works on the standalone `totem-lite` binary for CI environments without Node.js. See [CI/CD Integration](https://github.com/mmnto-ai/totem/blob/main/docs/wiki/ci-integration.md) for pipeline recipes.

Three honest-assessment moves in this copy:
- **Concrete command up front.** One code block, the actual flag, no hand-waving.
- **Names the external integration target.** `github/codeql-action/upload-sarif` is the canonical way to pipe SARIF into GitHub Code Scanning; readers who want to wire it in can find it immediately.
- **Calls out the error-only scope as a deliberate design choice.** This is Proposal 190 / Rule Nursery behavior. Not a limitation — it's a design choice that prevents alert fatigue in PR reviews. Tenet 5 (Honest Assessment) says always separate mechanical guarantees from probabilistic experiments; the error/warning split is exactly that split.

### 2. Extended "What Works and What Doesn't" Layer 1

The existing bullet ended at *"the load-bearing floor that everything else stands on."* Added one sentence:

> And because nothing on that floor touches the network, it runs natively in air-gapped environments — no source code leaves your machine.

Three mechanical-truth beats in 28 words: (a) the invariant (*"nothing on that floor touches the network"*), (b) the concrete consequence (*"runs natively in air-gapped environments"*), (c) the user-facing guarantee stated as a fact rather than a promise (*"no source code leaves your machine"*).

## Factual correction to the upstream draft

The upstream draft concept claimed *"Every CLI command supports `--format json`, but `totem lint` also natively outputs SARIF."* That's wrong — `--format` is scoped to `totem lint` specifically (`packages/cli/src/index.ts:277` explicitly rejects `--format` on `totem review`). Other commands use `--json` for scripting output (see the existing "Every command supports `--json` for scripting" line already in "What's in the Box"). Consolidated the accurate version into a single clause: *"It supports three output formats — `text` (default), `json` for scripting, and `sarif` for security dashboards"*.

## Voice compliance audit (against `.strategy/voice-tuning-dataset.md`)

- ✅ **Humility and Curiosity** — no "definitive" / "premier" / "battle-tested"
- ✅ **Non-Declarative Phrasing** — "Because X is Y, it drops cleanly into Z" rather than "Totem's enterprise-grade CI integration"
- ✅ **Mechanical Truth (WWND)** — names the exact command, exact GH action, exact flag, exact severity cap
- ✅ **Honest Assessment** — calls out the error-only scope as a deliberate design, not a limitation
- ✅ **Harmonize Memory and Enforcement** — uses "tripwires" consistent with existing README vocabulary
- ✅ **No Role-Assignment Metaphors** — no sensors, no flight controllers, no actuators
- ✅ **Problem-Focused** — opens with the problem ("drops cleanly into a CI pipeline") rather than a feature brag

## Test plan

- [x] Rendered locally, both edits sit where expected (`CI/CD and GitHub Integration` is between "What's in the Box" and "What Works and What Doesn't"; Layer 1 extension lives in the existing numbered list without disturbing the flow into Layer 2)
- [x] `pnpm exec totem lint` — skipped markdown (relevant-files filter — no code rules apply to `.md`)
- [x] `pnpm exec totem review` — same (no code changes to review)
- [x] Pre-push hook — 2763 tests still pass; no code regressions even though this is docs-only
- [x] Both claims fact-checked against actual CLI code: `totem lint --format sarif` works, SARIF is error-only per `run-compiled-rules.ts:292`, Lite binary supports the same flag per `index-lite.ts:127`

## Out of scope

No other features. Gemini and I both agreed the MEMORY entry's "SARIF + offline/CI-integration" covered the full restoration scope. If we discover additional load-bearing copy that got cut during the voice refresh, it's cheaper to file a follow-up ticket than to widen this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)