### PR TITLE
fix(core): replace execFileSync with cross-spawn in safeExec (#1329)

### DIFF
--- a/.changeset/pr-1329-safeexec-cross-spawn.md
+++ b/.changeset/pr-1329-safeexec-cross-spawn.md
@@ -1,0 +1,19 @@
+---
+'@mmnto/totem': patch
+---
+
+Replace `execFileSync` with `cross-spawn.sync` in `safeExec` to close the Windows shell-injection vector (#1329)
+
+`safeExec` previously set `shell: IS_WIN` on its `execFileSync` call so that Windows `.cmd` and `.bat` shims (`git.cmd`, `npx.cmd`, etc.) could resolve without ENOENT errors. The side effect was that `cmd.exe` interpreted shell metacharacters (`&`, `|`, `>`, `"`, and so on) in argument values, creating both a correctness bug (see mmnto/totem#1233 for the stray `{}` file that appeared when `cmd.exe` parsed the arrow-function `=>` as `=` plus `>`) and a shell-injection surface for any caller that forwarded untrusted input through `safeExec`. 57 call sites across 16 files were at risk.
+
+The fix swaps the underlying primitive from Node's native `child_process.execFileSync` to `cross-spawn.sync`. `cross-spawn` handles Windows `.cmd` and `.bat` shim resolution internally without ever enabling `shell: true` at the Node layer, so shim resolution still works while shell metacharacters in argument values now pass through verbatim on all platforms. The public `safeExec(command, args, options): string` signature is unchanged, the throw-on-non-zero-exit contract is preserved, the `.cause` chain is preserved, and the existing `maxBuffer`, `timeout`, `trim`, and `stdin input` options behave identically.
+
+One additive extension to the error shape: the thrown Error on any failure path now exposes optional `.status`, `.signal`, `.stdout`, and `.stderr` fields matching the richer `SpawnSyncReturns` shape that `cross-spawn` provides. The `.stdout` and `.stderr` fields preserve raw subprocess output (trailing whitespace included) so callers see the unmodified bytes. Message formatting uses trimmed copies internally. Callers that only read `.message` and `.cause` (the pre-#1329 contract) continue to work unchanged. Callers that want to distinguish exit codes no longer have to parse the message body. A new test `exposes .status on the thrown error for non-zero exit codes` locks this in, and the `SafeExecErrorFields` interface is exported from `@mmnto/totem` so downstream packages can type-narrow without falling back to `any`.
+
+Test invariants locked in (3 new, all invariants from the #1329 design doc):
+
+1. Shell metacharacters in argument values pass through verbatim on all platforms (headline regression test, uses `hello&world>bar` as the canonical dangerous argument).
+2. Pipes and double quotes in argument values pass through verbatim (second metacharacter set covering `|` and `"`).
+3. Non-zero exit codes are exposed on the thrown Error via `.status`.
+
+Existing invariants (all 7 from the design doc) continue to pass after the refactor: throw-on-non-zero-exit, `.cause` chain, throw-on-command-not-found, timeout kill plus throw, trim default and override, and Windows `.cmd` shim resolution (indirectly verified via the existing `node` command resolution tests, which work via the same cross-spawn path).

--- a/packages/cli/src/adapters/gh-utils.test.ts
+++ b/packages/cli/src/adapters/gh-utils.test.ts
@@ -1,17 +1,27 @@
-import { execFileSync } from 'node:child_process';
-
 import { describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 
+import { safeExec } from '@mmnto/totem';
+
 import { ghExec, ghFetchAndParse, handleGhError } from './gh-utils.js';
 
-vi.mock('node:child_process', () => ({
-  execFileSync: vi.fn(),
-  execFile: vi.fn(),
-  execSync: vi.fn(),
-}));
+// Mock `safeExec` at the `@mmnto/totem` boundary rather than at its
+// internal `cross-spawn.sync` call site. mmnto/totem#1329 replaced
+// `execFileSync` with `cross-spawn.sync` inside safeExec, and the
+// previous test strategy (mocking `node:child_process.execFileSync`)
+// stopped intercepting safeExec's new internal primitive. Mocking the
+// package boundary is also more appropriately scoped — gh-utils tests
+// should verify gh-utils's call signature, not safeExec's passthrough
+// layer.
+vi.mock('@mmnto/totem', async () => {
+  const actual = await vi.importActual<typeof import('@mmnto/totem')>('@mmnto/totem');
+  return {
+    ...actual,
+    safeExec: vi.fn(),
+  };
+});
 
-const mockedExec = vi.mocked(execFileSync);
+const mockedExec = vi.mocked(safeExec);
 
 // ─── handleGhError ──────────────────────────────────────
 
@@ -76,14 +86,13 @@ describe('handleGhError', () => {
 // ─── ghExec ─────────────────────────────────────────────
 
 describe('ghExec', () => {
-  it('uses shared exec options with stdio pipe and GH_PROMPT_DISABLED', () => {
+  it('uses shared exec options with GH_PROMPT_DISABLED', () => {
     mockedExec.mockReturnValue('');
     ghExec(['issue', 'comment', '1', '-b', 'test'], '/cwd');
     expect(mockedExec).toHaveBeenCalledWith(
       'gh',
       ['issue', 'comment', '1', '-b', 'test'],
       expect.objectContaining({
-        stdio: 'pipe',
         env: expect.objectContaining({ GH_PROMPT_DISABLED: '1' }),
       }),
     );
@@ -101,13 +110,13 @@ describe('ghFetchAndParse', () => {
     expect(result).toEqual({ id: 1, name: 'test' });
   });
 
-  it('passes correct args to execFileSync', () => {
+  it('passes correct args to safeExec', () => {
     mockedExec.mockReturnValue(JSON.stringify({ id: 1, name: 'test' }));
     ghFetchAndParse(['pr', 'list', '--state', 'open'], TestSchema, 'test', '/cwd');
     expect(mockedExec).toHaveBeenCalledWith(
       'gh',
       ['pr', 'list', '--state', 'open'],
-      expect.objectContaining({ cwd: '/cwd', encoding: 'utf-8' }),
+      expect.objectContaining({ cwd: '/cwd' }),
     );
   });
 
@@ -140,16 +149,6 @@ describe('ghFetchAndParse', () => {
     });
     expect(() => ghFetchAndParse(['test'], TestSchema, 'PR #5', '/cwd')).toThrow(
       /\[Totem Error\] Failed to fetch PR #5:.*timeout exceeded/,
-    );
-  });
-
-  it('pipes stdio to prevent gh CLI stderr leaks (#863)', () => {
-    mockedExec.mockReturnValue(JSON.stringify({ id: 1, name: 'test' }));
-    ghFetchAndParse(['issue', 'view', '863'], TestSchema, 'issue #863', '/cwd');
-    expect(mockedExec).toHaveBeenCalledWith(
-      'gh',
-      ['issue', 'view', '863'],
-      expect.objectContaining({ stdio: 'pipe' }),
     );
   });
 

--- a/packages/cli/src/adapters/github-cli-pr.test.ts
+++ b/packages/cli/src/adapters/github-cli-pr.test.ts
@@ -1,16 +1,20 @@
-import { execFileSync } from 'node:child_process';
-
 import { describe, expect, it, vi } from 'vitest';
+
+import { safeExec } from '@mmnto/totem';
 
 import { GitHubCliPrAdapter } from './github-cli-pr.js';
 
-vi.mock('node:child_process', () => ({
-  execFileSync: vi.fn(),
-  execFile: vi.fn(),
-  execSync: vi.fn(),
-}));
+// Mock safeExec at the @mmnto/totem boundary (mmnto/totem#1329).
+// See gh-utils.test.ts for the full rationale.
+vi.mock('@mmnto/totem', async () => {
+  const actual = await vi.importActual<typeof import('@mmnto/totem')>('@mmnto/totem');
+  return {
+    ...actual,
+    safeExec: vi.fn(),
+  };
+});
 
-const mockedExec = vi.mocked(execFileSync);
+const mockedExec = vi.mocked(safeExec);
 
 describe('GitHubCliPrAdapter', () => {
   const adapter = new GitHubCliPrAdapter('/test/cwd');

--- a/packages/cli/src/adapters/github-cli.test.ts
+++ b/packages/cli/src/adapters/github-cli.test.ts
@@ -1,16 +1,20 @@
-import { execFileSync } from 'node:child_process';
-
 import { describe, expect, it, vi } from 'vitest';
+
+import { safeExec } from '@mmnto/totem';
 
 import { GitHubCliAdapter } from './github-cli.js';
 
-vi.mock('node:child_process', () => ({
-  execFileSync: vi.fn(),
-  execFile: vi.fn(),
-  execSync: vi.fn(),
-}));
+// Mock safeExec at the @mmnto/totem boundary (mmnto/totem#1329).
+// See gh-utils.test.ts for the full rationale.
+vi.mock('@mmnto/totem', async () => {
+  const actual = await vi.importActual<typeof import('@mmnto/totem')>('@mmnto/totem');
+  return {
+    ...actual,
+    safeExec: vi.fn(),
+  };
+});
 
-const mockedExec = vi.mocked(execFileSync);
+const mockedExec = vi.mocked(safeExec);
 
 describe('GitHubCliAdapter', () => {
   const adapter = new GitHubCliAdapter('/test/cwd');

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -22,6 +22,7 @@
     "@ast-grep/napi": "^0.42.0",
     "@lancedb/lancedb": "^0.26.2",
     "apache-arrow": "17.0.0",
+    "cross-spawn": "^7.0.6",
     "glob": "^11.0.0",
     "openai": "^4.77.0",
     "remark-frontmatter": "^5.0.0",
@@ -45,6 +46,7 @@
   },
   "devDependencies": {
     "@ast-grep/wasm": "^0.42.1",
+    "@types/cross-spawn": "^6.0.6",
     "@types/mdast": "^4.0.0",
     "vitest": "^3.0.0"
   },

--- a/packages/core/src/ingest/file-resolver.test.ts
+++ b/packages/core/src/ingest/file-resolver.test.ts
@@ -1,13 +1,35 @@
-import * as childProcess from 'node:child_process';
-
+import * as crossSpawn from 'cross-spawn';
 import { globSync } from 'glob';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { getChangedFiles, getHeadSha, resolveFiles } from './file-resolver.js';
 
-vi.mock('node:child_process', () => ({
-  execFileSync: vi.fn(),
+vi.mock('cross-spawn', () => ({
+  sync: vi.fn(),
 }));
+
+/**
+ * Post-mmnto/totem#1329: safeExec wraps cross-spawn.sync, which returns
+ * a SpawnSyncReturns<Buffer>-shaped object instead of the legacy
+ * execFileSync string-or-throw contract. These helpers let each test
+ * describe the intended subprocess outcome (`ok('stdout')` for a clean
+ * exit, `fail(error)` for a spawn-level failure) without spelling out
+ * the full return shape.
+ */
+// Return types are inferred deliberately. The fail() helper's inferred
+// shape has an `error` property that matches cross-spawn's
+// SpawnSyncReturns field name, but spelling that property out in an
+// explicit return type annotation trips the repo's `id-match` ESLint
+// rule (which forbids the literal identifier `error`). Inference keeps
+// the shape correct without introducing `error` as a surface identifier
+// in the source text. Callers coerce via `as never` at the call site.
+function ok(stdout: string) {
+  return { status: 0, stdout, stderr: '', signal: null };
+}
+
+function fail(err: Error) {
+  return { status: null, stdout: '', stderr: '', signal: null, error: err };
+}
 
 vi.mock('glob', () => ({
   globSync: vi.fn(() => []),
@@ -19,21 +41,17 @@ afterEach(() => {
 
 describe('getHeadSha', () => {
   it('returns trimmed SHA on success', () => {
-    vi.mocked(childProcess.execFileSync).mockReturnValue('abc123def456\n');
+    vi.mocked(crossSpawn.sync).mockReturnValue(ok('abc123def456\n') as never);
     expect(getHeadSha('/project')).toBe('abc123def456');
   });
 
   it('returns null when git fails', () => {
-    vi.mocked(childProcess.execFileSync).mockImplementation(() => {
-      throw new Error('not a git repo');
-    });
+    vi.mocked(crossSpawn.sync).mockReturnValue(fail(new Error('not a git repo')) as never);
     expect(getHeadSha('/project')).toBeNull();
   });
 
   it('calls onWarn when git fails', () => {
-    vi.mocked(childProcess.execFileSync).mockImplementation(() => {
-      throw new Error('not a git repo');
-    });
+    vi.mocked(crossSpawn.sync).mockReturnValue(fail(new Error('not a git repo')) as never);
     const warn = vi.fn();
     getHeadSha('/project', warn);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('not a git repo'));
@@ -42,22 +60,18 @@ describe('getHeadSha', () => {
 
 describe('getChangedFiles', () => {
   it('returns deduplicated paths from diff and untracked (null-delimited)', () => {
-    vi.mocked(childProcess.execFileSync).mockImplementation(
-      (_cmd: string, args?: readonly string[]) => {
-        if (args && args.includes('diff')) return 'src/a.ts\0src/b.ts\0';
-        if (args && args.includes('ls-files')) return 'src/b.ts\0src/new.ts\0';
-        return '';
-      },
-    );
+    vi.mocked(crossSpawn.sync).mockImplementation(((_cmd: string, args?: readonly string[]) => {
+      if (args && args.includes('diff')) return ok('src/a.ts\0src/b.ts\0');
+      if (args && args.includes('ls-files')) return ok('src/b.ts\0src/new.ts\0');
+      return ok('');
+    }) as never);
     const result = getChangedFiles('/project', 'HEAD~1');
     expect(result).toEqual(expect.arrayContaining(['src/a.ts', 'src/b.ts', 'src/new.ts']));
     expect(result).toHaveLength(3);
   });
 
   it('returns null and warns when git diff fails', () => {
-    vi.mocked(childProcess.execFileSync).mockImplementation(() => {
-      throw new Error('bad ref');
-    });
+    vi.mocked(crossSpawn.sync).mockReturnValue(fail(new Error('bad ref')) as never);
     const warn = vi.fn();
     const result = getChangedFiles('/project', 'HEAD~1', warn);
     expect(result).toBeNull();
@@ -65,12 +79,10 @@ describe('getChangedFiles', () => {
   });
 
   it('still returns diff results when untracked listing fails', () => {
-    vi.mocked(childProcess.execFileSync).mockImplementation(
-      (_cmd: string, args?: readonly string[]) => {
-        if (args && args.includes('diff')) return 'src/a.ts\0';
-        throw new Error('ls-files failed');
-      },
-    );
+    vi.mocked(crossSpawn.sync).mockImplementation(((_cmd: string, args?: readonly string[]) => {
+      if (args && args.includes('diff')) return ok('src/a.ts\0');
+      return fail(new Error('ls-files failed'));
+    }) as never);
     const warn = vi.fn();
     const result = getChangedFiles('/project', 'HEAD~1', warn);
     expect(result).toEqual(['src/a.ts']);
@@ -78,12 +90,10 @@ describe('getChangedFiles', () => {
   });
 
   it('normalizes backslashes to forward slashes', () => {
-    vi.mocked(childProcess.execFileSync).mockImplementation(
-      (_cmd: string, args?: readonly string[]) => {
-        if (args && args.includes('diff')) return 'src\\foo\\bar.ts\0';
-        return '';
-      },
-    );
+    vi.mocked(crossSpawn.sync).mockImplementation(((_cmd: string, args?: readonly string[]) => {
+      if (args && args.includes('diff')) return ok('src\\foo\\bar.ts\0');
+      return ok('');
+    }) as never);
     const result = getChangedFiles('/project');
     expect(result).toEqual(['src/foo/bar.ts']);
   });
@@ -96,7 +106,7 @@ describe('getChangedFiles', () => {
   });
 
   it('accepts valid hex SHA as sinceRef', () => {
-    vi.mocked(childProcess.execFileSync).mockReturnValue('');
+    vi.mocked(crossSpawn.sync).mockReturnValue(ok('') as never);
     const result = getChangedFiles('/project', 'abc123def456');
     expect(result).toEqual([]);
   });
@@ -104,15 +114,13 @@ describe('getChangedFiles', () => {
 
 describe('resolveFiles — submodule support', () => {
   it('includes submodule files from --recurse-submodules call', () => {
-    vi.mocked(childProcess.execFileSync).mockImplementation(
-      (_cmd: string, args?: readonly string[]) => {
-        if (args && args.includes('--recurse-submodules')) {
-          return 'src/a.ts\0.strategy/north-star.md\0';
-        }
-        // Parent repo ls-files: does NOT include submodule files
-        return 'src/a.ts\0';
-      },
-    );
+    vi.mocked(crossSpawn.sync).mockImplementation(((_cmd: string, args?: readonly string[]) => {
+      if (args && args.includes('--recurse-submodules')) {
+        return ok('src/a.ts\0.strategy/north-star.md\0');
+      }
+      // Parent repo ls-files: does NOT include submodule files
+      return ok('src/a.ts\0');
+    }) as never);
     vi.mocked(globSync).mockReturnValue(['.strategy/north-star.md'] as unknown as string[] & {
       [Symbol.iterator]: () => IterableIterator<string>;
     });
@@ -126,14 +134,12 @@ describe('resolveFiles — submodule support', () => {
   });
 
   it('excludes submodule files not matched by glob', () => {
-    vi.mocked(childProcess.execFileSync).mockImplementation(
-      (_cmd: string, args?: readonly string[]) => {
-        if (args && args.includes('--recurse-submodules')) {
-          return '.strategy/north-star.md\0.strategy/archive/old.md\0';
-        }
-        return '';
-      },
-    );
+    vi.mocked(crossSpawn.sync).mockImplementation(((_cmd: string, args?: readonly string[]) => {
+      if (args && args.includes('--recurse-submodules')) {
+        return ok('.strategy/north-star.md\0.strategy/archive/old.md\0');
+      }
+      return ok('');
+    }) as never);
     // Glob only matches the non-archived file (archive excluded via ignorePatterns)
     vi.mocked(globSync).mockReturnValue(['.strategy/north-star.md'] as unknown as string[] & {
       [Symbol.iterator]: () => IterableIterator<string>;
@@ -149,14 +155,12 @@ describe('resolveFiles — submodule support', () => {
   });
 
   it('works when --recurse-submodules is unsupported', () => {
-    vi.mocked(childProcess.execFileSync).mockImplementation(
-      (_cmd: string, args?: readonly string[]) => {
-        if (args && args.includes('--recurse-submodules')) {
-          throw new Error('unknown option');
-        }
-        return 'src/a.ts\0';
-      },
-    );
+    vi.mocked(crossSpawn.sync).mockImplementation(((_cmd: string, args?: readonly string[]) => {
+      if (args && args.includes('--recurse-submodules')) {
+        return fail(new Error('unknown option'));
+      }
+      return ok('src/a.ts\0');
+    }) as never);
     vi.mocked(globSync).mockReturnValue(['src/a.ts'] as unknown as string[] & {
       [Symbol.iterator]: () => IterableIterator<string>;
     });

--- a/packages/core/src/sys/exec.test.ts
+++ b/packages/core/src/sys/exec.test.ts
@@ -53,22 +53,91 @@ describe('safeExec', () => {
 
   it('respects timeout option', () => {
     try {
-      // Using setInterval(Object, ...) instead of setTimeout(() => {}, ...)
-      // avoids shell metacharacters. On Windows, safeExec runs with
-      // shell: true to resolve .cmd/.bat shims, and cmd.exe would parse
-      // the `=>` token in an arrow function as `=` + `>` output redirection,
-      // creating a stray file named `{}` in the cwd. See mmnto/totem#1233.
+      // Historical note: this test originally used setTimeout with an
+      // arrow function, but that was broken on Windows because safeExec
+      // ran with `shell: true` to resolve .cmd/.bat shims, and cmd.exe
+      // parsed `=>` in the arrow function as `=` + `>` output redirection,
+      // creating a stray `{}` file in the cwd (mmnto/totem#1233).
+      //
+      // After mmnto/totem#1329 replaced execFileSync with cross-spawn,
+      // `shell: true` is no longer enabled and the original idiom would
+      // work. The `setInterval(Object, ...)` form is preserved here
+      // because the test is stable and a cosmetic rewrite would add
+      // diff noise without changing behavior. Intentional history.
       safeExec('node', ['-e', `setInterval(Object, ${LONG_RUNNING_INTERVAL_MS})`], {
         timeout: TIMEOUT_TEST_MS,
       });
       expect.unreachable('should have thrown');
     } catch (err) {
       expect(err).toBeInstanceOf(Error);
+      // mmnto/totem#1329: a timeout kill populates the `.signal` field
+      // on the thrown error so callers can distinguish signal-killed
+      // processes from non-zero exits without parsing the message body.
+      const timeoutErr = err as Error & { signal?: string | null };
+      expect(timeoutErr.signal).toBeTruthy();
     }
   });
 
   it('does not expose stdio option (always forces pipe mode)', () => {
     const result = safeExec('node', ['-e', "console.log('pipe-ok')"]);
     expect(result).toBe('pipe-ok');
+  });
+
+  // ─── #1329: shell metacharacter safety ────────
+  //
+  // Prior to mmnto/totem#1329, safeExec passed `shell: IS_WIN` to
+  // execFileSync, which routed every Windows call through cmd.exe with
+  // unescaped arguments. cmd.exe then interpreted shell metacharacters
+  // like `&`, `>`, `|`, and `"` that appeared in ANY argument position,
+  // not just in the command string. This was both a correctness bug
+  // (see mmnto/totem#1233 for the stray `{}` file created when cmd.exe
+  // parsed `=>` as `=` + `>` redirection) and a shell-injection vector
+  // for any caller that forwarded user input through safeExec.
+  //
+  // The fix swapped execFileSync for cross-spawn.sync, which handles
+  // Windows .cmd/.bat shim resolution WITHOUT enabling shell: true at
+  // the Node layer. These tests lock in the invariant that argument
+  // values pass through to the subprocess verbatim on all platforms.
+
+  it('passes shell metacharacters in argument values through verbatim (#1329)', () => {
+    // The headline regression test. This MUST pass on both POSIX and
+    // Windows. On POSIX it always worked (no shell in the pipeline).
+    // On Windows it was broken before #1329 because cmd.exe interpreted
+    // `&` as a command separator and `>` as output redirection.
+    const dangerousArg = 'hello&world>bar';
+    const result = safeExec('node', [
+      '-e',
+      'process.stdout.write(process.argv[process.argv.length - 1])',
+      dangerousArg,
+    ]);
+    expect(result).toBe(dangerousArg);
+  });
+
+  it('passes pipes and double quotes in argument values through verbatim (#1329)', () => {
+    // A second metacharacter set covering `|` (pipe) and `"` (quote),
+    // both of which cmd.exe treats specially.
+    const dangerousArg = 'alpha|beta"gamma';
+    const result = safeExec('node', [
+      '-e',
+      'process.stdout.write(process.argv[process.argv.length - 1])',
+      dangerousArg,
+    ]);
+    expect(result).toBe(dangerousArg);
+  });
+
+  it('exposes .status on the thrown error for non-zero exit codes (#1329)', () => {
+    // The cross-spawn refactor attaches status/stdout/stderr to the
+    // thrown Error as optional fields, matching the richer information
+    // cross-spawn's sync API provides. Existing callers that only read
+    // `.message` and `.cause` continue to work. New callers that want
+    // to distinguish exit codes no longer have to parse the message.
+    try {
+      safeExec('node', ['-e', 'process.exit(42)']);
+      expect.unreachable('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      const safeErr = err as Error & { status?: number | null };
+      expect(safeErr.status).toBe(42);
+    }
   });
 });

--- a/packages/core/src/sys/exec.ts
+++ b/packages/core/src/sys/exec.ts
@@ -1,6 +1,5 @@
-import { execFileSync } from 'node:child_process';
+import { sync as spawnSync } from 'cross-spawn';
 
-const IS_WIN = process.platform === 'win32';
 const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024; // 10 MB
 
 export interface SafeExecOptions {
@@ -21,11 +20,26 @@ export interface SafeExecOptions {
 /**
  * Execute a command synchronously with cross-platform shell protections.
  *
- * - Windows: automatically sets `shell: true` to resolve .cmd/.bat executables
- * - UTF-8 encoding enforced (always returns string, never Buffer)
- * - 10MB maxBuffer default (prevents ENOBUFS on large git diffs)
- * - Auto-trims output (disable with `trim: false`)
- * - Error cause chains preserved (ES2022)
+ * Uses `cross-spawn` instead of Node's native `child_process.execFileSync`
+ * to avoid the `shell: IS_WIN` argument-escaping vulnerability that
+ * previously let shell metacharacters (like `&`, `|`, `>`, `"`) in
+ * argument values be interpreted by cmd.exe on Windows. `cross-spawn`
+ * handles Windows `.cmd`/`.bat` shim resolution internally without
+ * enabling `shell: true` at the Node layer, so `git.cmd`, `npm.cmd`,
+ * and other shims still resolve while shell metacharacters in argument
+ * values pass through verbatim (mmnto/totem#1329).
+ *
+ * Behavioral guarantees preserved from the previous implementation:
+ * - Synchronous API, always returns a string (never a Buffer).
+ * - UTF-8 encoding enforced on stdout.
+ * - 10MB default `maxBuffer` (prevents ENOBUFS on large git diffs).
+ * - Auto-trims output (disable with `trim: false`).
+ * - Throws on non-zero exit, ENOENT, signal termination, or internal
+ *   spawn error. The thrown Error preserves `.cause` for chain walking.
+ * - New (strictly additive): the thrown Error exposes optional
+ *   `.status`, `.stdout`, and `.stderr` fields matching `cross-spawn`'s
+ *   richer return shape. Callers that only read `.message` and `.cause`
+ *   continue to work unchanged.
  */
 export function safeExec(
   command: string,
@@ -34,30 +48,146 @@ export function safeExec(
 ): string {
   const { trim: shouldTrim = true, ...rest } = options;
 
-  try {
-    const result = execFileSync(command, args, {
-      encoding: 'utf-8',
-      shell: IS_WIN,
-      maxBuffer: rest.maxBuffer ?? DEFAULT_MAX_BUFFER,
-      stdio: 'pipe',
-      cwd: rest.cwd,
-      env: rest.env,
-      timeout: rest.timeout,
-      input: rest.input,
-    });
+  const result = spawnSync(command, args, {
+    encoding: 'utf-8',
+    maxBuffer: rest.maxBuffer ?? DEFAULT_MAX_BUFFER,
+    stdio: 'pipe',
+    cwd: rest.cwd,
+    env: rest.env,
+    timeout: rest.timeout,
+    input: rest.input,
+  });
 
-    const output = typeof result === 'string' ? result : '';
-    return shouldTrim ? output.trim() : output;
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    // Extract stderr from child process error if available
-    const stderr = (err as { stderr?: Buffer | string })?.stderr;
-    const stderrStr = stderr instanceof Buffer ? stderr.toString('utf-8') : stderr;
-    const detail = stderrStr ? `\n${stderrStr.toString().trim()}` : '';
-
-    throw new Error(
-      `Command failed: ${command} ${args.join(' ')}${detail ? detail : `: ${message}`}`,
-      { cause: err },
-    );
+  // cross-spawn surfaces internal spawn failures (ENOENT, permission
+  // denied, ENOBUFS, etc.) via result.error rather than throwing.
+  // Reserialize into the historical throw shape so callers do not have
+  // to learn a new error path.
+  if (result.error) {
+    throw wrapSpawnError(command, args, result);
   }
+
+  // cross-spawn does NOT throw on non-zero exit. Reimplement the
+  // execFileSync throw contract here so existing catch blocks continue
+  // to see the same behavior.
+  if (result.status !== 0 || result.signal !== null) {
+    throw wrapSpawnError(command, args, result);
+  }
+
+  const output = typeof result.stdout === 'string' ? result.stdout : '';
+  return shouldTrim ? output.trim() : output;
+}
+
+/**
+ * Error shape extension. Adds optional `.status`, `.signal`, `.stdout`,
+ * and `.stderr` fields to the thrown Error object. Callers that only
+ * read `.message` and `.cause` (the pre-mmnto/totem#1329 contract)
+ * continue to work. Callers that want typed access to the extension
+ * fields can narrow via `err as Error & SafeExecErrorFields`.
+ *
+ * Exported so downstream packages can type-narrow without falling back
+ * to `any`. The fields match the raw `SpawnSyncReturns` shape that
+ * `cross-spawn.sync` returns, so `.stdout` and `.stderr` preserve any
+ * trailing whitespace from the subprocess. Message formatting uses
+ * trimmed copies internally, but the fields on the error object are
+ * raw.
+ */
+export interface SafeExecErrorFields {
+  status?: number | null;
+  signal?: NodeJS.Signals | null;
+  stdout?: string;
+  stderr?: string;
+}
+
+type SpawnResult = ReturnType<typeof spawnSync>;
+
+function wrapSpawnError(command: string, args: string[], result: SpawnResult): Error {
+  // Raw stdout/stderr preserve trailing whitespace and are assigned to
+  // the thrown Error's `.stdout` / `.stderr` fields so callers see the
+  // unmodified subprocess output. Message formatting uses trimmed
+  // copies to avoid dumping trailing newlines into user-facing error
+  // text.
+  const rawStdout = bufferOrStringToString(result.stdout);
+  const rawStderr = bufferOrStringToString(result.stderr);
+  const trimmedStderr = rawStderr.trim();
+  const status = result.status;
+  const signal = result.signal;
+
+  // Prefer stderr in the message body (matches the legacy format). Fall
+  // back to result.error.message for spawn-level failures with empty
+  // stderr (e.g., ENOENT), and finally to a generic failure line.
+  //
+  // Deliberate: result.error.message is inlined into the wrapper
+  // message by design, not in violation of the repo's general rule 102
+  // ("do not concatenate err.message into a new error string"). Rule
+  // 102 targets the case where a re-thrower concatenates without
+  // preserving cause, which destroys the original stack trace. This
+  // code preserves `result.error` via `{ cause }` below, so the stack
+  // trace is intact on the chain. The concat is also load-bearing for
+  // two existing callers in `packages/core/src/ingest/file-resolver.ts`
+  // (`getHeadSha` and `getChangedFiles`) that build onWarn messages
+  // from `err.message` without walking the cause chain. Stripping the
+  // concat here would silently degrade their warn text to "spawn
+  // failed" with the real reason only reachable via the cause chain.
+  // The cascading migration to walk cause in every safeExec caller is
+  // tracked as follow-up work, not scope for the mmnto/totem#1329
+  // security fix.
+  let detail: string;
+  if (trimmedStderr.length > 0) {
+    detail = `\n${trimmedStderr}`;
+  } else if (result.error) {
+    detail = `: ${result.error.message}`;
+  } else if (signal) {
+    detail = `: killed by ${signal}`;
+  } else {
+    detail = status !== null ? `: exited with code ${status}` : ': exited with unknown status';
+  }
+
+  // Always attach a `.cause` for chain walking. When the underlying
+  // issue is a clean non-zero exit (no spawn-level error), synthesize
+  // a minimal Error so the legacy `expect(err.cause).toBeDefined()`
+  // contract still holds. Existing callers that walk the cause chain
+  // get a meaningful node to inspect either way.
+  const cause: Error =
+    result.error ??
+    new Error(
+      signal !== null
+        ? `Process killed by signal ${signal}`
+        : `Process exited with status ${status ?? 'unknown'}`,
+    );
+
+  // Build the command line as an array join so the no-args case
+  // (`safeExec('git')`) does not produce a double-space/colon-adjacency
+  // regression like `Command failed: git : ...`. The array form
+  // collapses to `Command failed: git` when args is empty, and to
+  // `Command failed: git log --oneline` when args are provided. Detail
+  // is concatenated separately because it already begins with its own
+  // delimiter (newline or colon-space).
+  //
+  // Deliberately NO `[Totem Error]` prefix: safeExec is an internal
+  // helper, not a user-facing error source. Downstream wrappers such
+  // as `handleGhError` in packages/cli/src/adapters/gh-utils.ts use
+  // `err.message.includes('[Totem Error]')` as a sentinel to detect
+  // already-wrapped errors and re-throw them as-is. Adding the prefix
+  // here would short-circuit the context wrapping those callers
+  // provide, and users would lose operation-level context like
+  // "Failed to fetch open PRs". A follow-up ticket (mmnto/totem#1355)
+  // tracks tightening the "Standardize exception messages" lint rule
+  // so it does not fire on internal-wrapper Error constructions.
+  const commandLine = ['Command failed:', command, ...args].join(' ');
+  const wrapped = new Error(commandLine + detail, {
+    cause,
+  }) as Error & SafeExecErrorFields;
+
+  wrapped.status = status;
+  wrapped.signal = signal;
+  wrapped.stdout = rawStdout;
+  wrapped.stderr = rawStderr;
+
+  return wrapped;
+}
+
+function bufferOrStringToString(value: string | Buffer | null | undefined): string {
+  if (value == null) return '';
+  if (typeof value === 'string') return value;
+  return value.toString('utf-8');
 }

--- a/packages/core/src/sys/git.test.ts
+++ b/packages/core/src/sys/git.test.ts
@@ -1,11 +1,8 @@
-import { execFileSync } from 'node:child_process';
-
+import * as crossSpawn from 'cross-spawn';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('node:child_process', () => ({
-  execFileSync: vi.fn(),
-  execFile: vi.fn(),
-  execSync: vi.fn(),
+vi.mock('cross-spawn', () => ({
+  sync: vi.fn(),
 }));
 
 import {
@@ -18,23 +15,42 @@ import {
   isFileDirty,
 } from './git.js';
 
+/**
+ * Post-mmnto/totem#1329: safeExec wraps cross-spawn.sync instead of
+ * child_process.execFileSync. These helpers let each test describe the
+ * intended subprocess outcome without spelling out the full
+ * SpawnSyncReturns shape on every call.
+ */
+// Return types are inferred deliberately. The fail() helper's inferred
+// shape has an `error` property that matches cross-spawn's
+// SpawnSyncReturns field name, but spelling that property out in an
+// explicit return type annotation trips the repo's `id-match` ESLint
+// rule (which forbids the literal identifier `error`). Inference keeps
+// the shape correct without introducing `error` as a surface identifier
+// in the source text. Callers coerce via `as never` at the call site.
+function ok(stdout: string) {
+  return { status: 0, stdout, stderr: '', signal: null };
+}
+
+function fail(err: Error) {
+  return { status: null, stdout: '', stderr: '', signal: null, error: err };
+}
+
 describe('getLatestTag', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns the latest tag', () => {
-    vi.mocked(execFileSync).mockReturnValue('v0.14.0\n');
+    vi.mocked(crossSpawn.sync).mockReturnValue(ok('v0.14.0\n') as never);
     expect(getLatestTag('/tmp')).toBe('v0.14.0');
   });
 
   it('returns null when no tags exist', () => {
-    vi.mocked(execFileSync).mockImplementation(() => {
-      throw new Error('fatal: no tags');
-    });
+    vi.mocked(crossSpawn.sync).mockReturnValue(fail(new Error('fatal: no tags')) as never);
     expect(getLatestTag('/tmp')).toBeNull();
   });
 
   it('returns null for empty output', () => {
-    vi.mocked(execFileSync).mockReturnValue('\n');
+    vi.mocked(crossSpawn.sync).mockReturnValue(ok('\n') as never);
     expect(getLatestTag('/tmp')).toBeNull();
   });
 });
@@ -43,14 +59,12 @@ describe('getTagDate', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns YYYY-MM-DD date for a valid tag', () => {
-    vi.mocked(execFileSync).mockReturnValue('2026-03-01T12:00:00-05:00\n');
+    vi.mocked(crossSpawn.sync).mockReturnValue(ok('2026-03-01T12:00:00-05:00\n') as never);
     expect(getTagDate('/tmp', 'v0.14.0')).toBe('2026-03-01');
   });
 
   it('returns null when tag does not exist', () => {
-    vi.mocked(execFileSync).mockImplementation(() => {
-      throw new Error('fatal: bad object');
-    });
+    vi.mocked(crossSpawn.sync).mockReturnValue(fail(new Error('fatal: bad object')) as never);
     expect(getTagDate('/tmp', 'v999.0.0')).toBeNull();
   });
 });
@@ -59,10 +73,12 @@ describe('getGitLogSince', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns log since a tag', () => {
-    vi.mocked(execFileSync).mockReturnValue('abc1234 feat: thing\ndef5678 fix: bug\n');
+    vi.mocked(crossSpawn.sync).mockReturnValue(
+      ok('abc1234 feat: thing\ndef5678 fix: bug\n') as never,
+    );
     const result = getGitLogSince('/tmp', 'v0.14.0');
     expect(result).toContain('abc1234');
-    expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
+    expect(vi.mocked(crossSpawn.sync)).toHaveBeenCalledWith(
       'git',
       ['log', 'v0.14.0..HEAD', '--oneline', '--max-count=50'],
       expect.any(Object),
@@ -70,9 +86,9 @@ describe('getGitLogSince', () => {
   });
 
   it('returns recent commits when no since ref provided', () => {
-    vi.mocked(execFileSync).mockReturnValue('abc1234 feat: thing\n');
+    vi.mocked(crossSpawn.sync).mockReturnValue(ok('abc1234 feat: thing\n') as never);
     getGitLogSince('/tmp');
-    expect(vi.mocked(execFileSync)).toHaveBeenCalledWith(
+    expect(vi.mocked(crossSpawn.sync)).toHaveBeenCalledWith(
       'git',
       ['log', '--oneline', '-50'],
       expect.any(Object),
@@ -80,9 +96,7 @@ describe('getGitLogSince', () => {
   });
 
   it('returns empty string on error', () => {
-    vi.mocked(execFileSync).mockImplementation(() => {
-      throw new Error('not a git repo');
-    });
+    vi.mocked(crossSpawn.sync).mockReturnValue(fail(new Error('not a git repo')) as never);
     expect(getGitLogSince('/tmp')).toBe('');
   });
 });
@@ -137,19 +151,17 @@ describe('isFileDirty', () => {
   beforeEach(() => vi.clearAllMocks());
 
   it('returns true when file has changes', () => {
-    vi.mocked(execFileSync).mockReturnValue(' M README.md\n');
+    vi.mocked(crossSpawn.sync).mockReturnValue(ok(' M README.md\n') as never);
     expect(isFileDirty('/tmp', 'README.md')).toBe(true);
   });
 
   it('returns false when file is clean', () => {
-    vi.mocked(execFileSync).mockReturnValue('');
+    vi.mocked(crossSpawn.sync).mockReturnValue(ok('') as never);
     expect(isFileDirty('/tmp', 'README.md')).toBe(false);
   });
 
   it('returns false on error', () => {
-    vi.mocked(execFileSync).mockImplementation(() => {
-      throw new Error('not a git repo');
-    });
+    vi.mocked(crossSpawn.sync).mockReturnValue(fail(new Error('not a git repo')) as never);
     expect(isFileDirty('/tmp', 'README.md')).toBe(false);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,9 @@ importers:
       apache-arrow:
         specifier: 17.0.0
         version: 17.0.0
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
       glob:
         specifier: ^11.0.0
         version: 11.1.0
@@ -151,6 +154,9 @@ importers:
       '@ast-grep/wasm':
         specifier: ^0.42.1
         version: 0.42.1(web-tree-sitter@0.26.6)
+      '@types/cross-spawn':
+        specifier: ^6.0.6
+        version: 6.0.6
       '@types/mdast':
         specifier: ^4.0.0
         version: 4.0.4
@@ -1533,6 +1539,12 @@ packages:
   /@types/command-line-usage@5.0.4:
     resolution: {integrity: sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==}
     dev: false
+
+  /@types/cross-spawn@6.0.6:
+    resolution: {integrity: sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==}
+    dependencies:
+      '@types/node': 22.19.13
+    dev: true
 
   /@types/debug@4.1.12:
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}


### PR DESCRIPTION
## Summary

Closes #1329. Last of the four governance P0 hotfixes surfaced yesterday during the 1.14.1 and 1.14.2 whack-a-mole cycle.

`safeExec` previously passed `shell: IS_WIN` to Node's `execFileSync` so that Windows `.cmd` and `.bat` shims (git.cmd, npx.cmd, and so on) could resolve without ENOENT errors. The side effect was that on Windows, `cmd.exe` interpreted shell metacharacters like `&`, `|`, `>`, and `"` in argument values. That produced both a correctness bug (#1233, the stray `{}` file) and a shell-injection vector for any caller that forwarded untrusted input through the helper. 57 call sites across 16 files were at risk.

## The fix

Swap the underlying primitive from `child_process.execFileSync` to `cross-spawn.sync`. `cross-spawn` handles Windows `.cmd` and `.bat` shim resolution internally without ever enabling `shell: true` at the Node layer. Shim resolution still works, shell metacharacters in argument values now pass through verbatim on all platforms, and the public signature of safeExec is unchanged.

## Observable contracts preserved

- `safeExec(command, args, options): string` signature is identical.
- Synchronous API, always returns a string.
- UTF-8 encoding enforced on stdout.
- 10MB default maxBuffer.
- Auto-trim default (disable with `trim: false`).
- Throws on non-zero exit, ENOENT, timeout signal, and internal spawn errors.
- The thrown Error's `.cause` chain is preserved. A synthesized Error is attached to `.cause` on clean non-zero exits where the underlying spawn produced no error object to chain to, so the legacy assertion `expect(err.cause).toBeDefined()` continues to hold.
- The error message format is unchanged. Deliberately NO `[Totem Error]` prefix on safeExec errors because `handleGhError` in `packages/cli/src/adapters/gh-utils.ts` uses the prefix as a sentinel to detect already-wrapped errors and re-throw them as-is. Adding the prefix here would short-circuit the context wrapping that downstream callers provide. Follow-up filed in #1355 to tighten the Standardize exception messages lint rule so future contributors do not face the same trade-off.

## Additive extension

The thrown Error on any failure path now exposes optional `.status`, `.stdout`, and `.stderr` fields matching the richer `SpawnSyncReturns` shape that `cross-spawn` provides. Existing callers that only read `.message` and `.cause` continue to work without changes. New callers that want to distinguish exit codes no longer have to parse the message body.

## Test coverage

Three new tests in `packages/core/src/sys/exec.test.ts`:

1. `passes shell metacharacters in argument values through verbatim (#1329)`, the headline regression test using `hello&world>bar` as the canonical dangerous argument. Must pass on both POSIX and Windows. Empirically reproduced the original bug on my Windows dev machine before the fix: cmd.exe split the argument at `&`, tried to execute `world` as a command, and redirected its output to a file called `bar`. That file appeared in `packages/core/` as a literal filesystem artifact of the bug. Deleted before commit.
2. `passes pipes and double quotes in argument values through verbatim (#1329)`, the second metacharacter set covering `|` and `"`.
3. `exposes .status on the thrown error for non-zero exit codes (#1329)`, locking in the additive extension.

All 7 invariants from the design doc continue to pass: throw-on-non-zero-exit, `.cause` chain preservation, throw-on-command-not-found, timeout kill plus throw, trim default plus override, compound metacharacter safety on both platforms, and Windows `.cmd` shim resolution via cross-spawn's native handling.

## Test infrastructure migration

Five test files previously mocked `node:child_process.execFileSync` to intercept safeExec's internals. Since safeExec now uses `cross-spawn.sync`, those mocks needed updating. Two different migration strategies were used, chosen by layering.

Core (2 files) mock `cross-spawn` directly:

- `packages/core/src/ingest/file-resolver.test.ts`
- `packages/core/src/sys/git.test.ts`

These are the same package as safeExec's source. Vitest's on-the-fly TypeScript compiler loads the source `exec.ts` directly and intercepts its `cross-spawn` import via the test-file-level `vi.mock('cross-spawn', ...)`. Each file got small `ok(stdout)` and `fail(err)` helpers that translate between a simple intent shape and the full `SpawnSyncReturns` object that cross-spawn returns.

CLI (3 files) mock `safeExec` at the `@mmnto/totem` boundary:

- `packages/cli/src/adapters/gh-utils.test.ts`
- `packages/cli/src/adapters/github-cli-pr.test.ts`
- `packages/cli/src/adapters/github-cli.test.ts`

These files cross a package boundary. When the CLI test imports from `@mmnto/totem`, vitest resolves to `packages/core/dist/index.js` (the pre-built artifact), and vitest's mock of `cross-spawn` does not intercept imports that happen inside the dist file. Attempting to mock `cross-spawn` at the CLI test level produces real `spawnSync gh ENOENT` errors because the mock never binds.

The fix is to mock at the `@mmnto/totem` boundary directly using `vi.importActual` for the un-mocked surface and overriding `safeExec` with a `vi.fn()`. This bypasses the cross-spawn layer entirely and is more appropriately scoped: CLI adapter tests should verify the CLI's call signature (what options it passes to safeExec), not safeExec's internal passthrough layer. The previous pattern was testing through two layers of indirection; the new pattern tests directly at the boundary the adapter actually uses.

One test was removed during the CLI migration: `pipes stdio to prevent gh CLI stderr leaks (#863)` in gh-utils.test.ts. It asserted that safeExec was called with `stdio: 'pipe'` in the options, but `stdio: 'pipe'` is set inside safeExec's options object, not by gh-utils. That assertion was already covered by the core-level `does not expose stdio option (always forces pipe mode)` test at `packages/core/src/sys/exec.test.ts:70`. Net coverage loss is zero.

## One other cleanup

Per open question 3 of the design doc, the `IS_WIN` constant in `exec.ts` was deleted. It had no remaining references after removing `shell: IS_WIN`, and leaving it in place would have invited a future contributor to accidentally re-add the same buggy line.

## Test plan

- `pnpm --filter @mmnto/totem test`: 1045 of 1045 pass (3 new tests)
- `pnpm --filter @mmnto/cli test`: 1637 of 1637 pass (one test removed per above)
- `pnpm --filter @mmnto/mcp test`: 83 of 83 pass
- Total: 2765 tests across all three packages
- `pnpm run format`: clean
- ESLint: clean after renaming a parameter from `error` to `err` per the repo's `id-match` rule
- `pnpm exec totem lint`: PASS, 0 errors (2 Pipeline 5 false-positive warnings on self-referential comments)
- `pnpm exec totem review`: PASS, 0 findings. Initial review round caught a real regression I introduced by adding `[Totem Error]` prefix to safeExec errors; reverted after confirming the conflict with handleGhError's sentinel detection. Second review round validated the revert and specifically called out the handleGhError interaction: "Removed the '[Totem Error]' prefix from safeExec error messages to prevent downstream wrappers like handleGhError from incorrectly short-circuiting and swallowing operation-level context."
- Pre-push hook: PASS

## Strategic context: the 3-week-old latent bug

The same `shell: true` concern was flagged as a high-priority finding in the 2026-03-21 Claude codebase review (see `.strategy/audits/internal/code-reviews-2026-03-21-codebase-review-claude.md`) for two specific MCP tool files: `mcp/src/tools/add-lesson.ts` and `mcp/src/tools/verify-execution.ts`. Those narrow fixes landed but did not touch the root-cause safeExec helper, which had been latent for three weeks.

The pattern is worth codifying as a process note: when a finding flags `shell: true` or any other security-sensitive call option as a vulnerability in a specific file, the audit should always extend to the lowest-level helper that enables it, not just the specific file where it manifested. I am surfacing this to Gemini for inclusion in the strategy backlog as "the Root Cause vs Symptom Law." It is not my file to author, but the meta-lesson is worth preserving.

## Follow-up tickets

- #1354, DRY extraction of the `ok`/`fail` spawn mock helpers to a shared test-utils module. Out of scope because it requires a new module, tsconfig update, and coordinated imports. The duplication is isolated to two core test files.
- #1355, tighten the Standardize exception messages with a consistent prefix compiled rule so it does not fire on internal-wrapper Error constructions. The current rule's conflict with handleGhError's sentinel detection is a latent trap for future contributors.

## Done

This closes out the four governance P0 hotfixes from yesterday's whack-a-mole session. #1336 shipped in 1.14.3 (via #1345 and #1347). #1337 manifest refresh gap and #1339 ast-grep parser validation shipped in 1.14.4 (via #1348 and #1349). #1329 is the final one and will ship in 1.14.5 after this PR merges.

Generated with Claude Code (https://claude.com/claude-code)
