### PR TITLE
fix(cli): retire totem wrap pending fix for destructive docs overwrite of active_work.md

### DIFF
--- a/.claude/skills/postmerge/SKILL.md
+++ b/.claude/skills/postmerge/SKILL.md
@@ -1,13 +1,51 @@
 ---
 name: postmerge
-description: Post-merge workflow — extract lessons and wrap
+description: Post-merge workflow — extract lessons and compile rules (manual sequence, wrap is retired)
 ---
 
-After merging PRs, run the post-merge workflow:
+`totem wrap` is retired pending mmnto-ai/totem#1361 (it silently
+overwrites hand-crafted committed docs via the `totem docs` step).
+Run the post-merge steps directly instead.
 
-1. Run `pnpm exec totem wrap $ARGUMENTS --yes` (pass PR numbers as arguments)
-2. Revert compiled rules to curated set: `git checkout HEAD -- .totem/compiled-rules.json`
-3. Format wrap output: `pnpm run format`
-4. Stage lessons, docs, and exports: `git add .totem/lessons/ README.md docs/ .github/copilot-instructions.md .junie/skills/totem-rules/rules.md`
-5. Commit: `git commit -m "chore: totem wrap for PRs $ARGUMENTS"`
-6. Report: how many lessons extracted, any doc failures, rule compilation stats (note: new compiled rules were reverted)
+After merging PRs, run the following sequence. Replace `$ARGUMENTS`
+with the merged PR numbers (space-separated, e.g. `1345 1347 1348`).
+
+1. Extract lessons from the merged PR(s):
+   `pnpm exec totem extract $ARGUMENTS --yes`
+
+2. Sync the semantic index (usually already handled by the post-merge
+   git hook, but running it explicitly is cheap and safe):
+   `pnpm exec totem sync`
+
+3. Compile new rules locally and export to AI tool configs. Do NOT
+   pass `--cloud`; the cloud worker is still Gemini-only per
+   mmnto-ai/totem#1221. Local compile routes to Sonnet 4.6:
+   `pnpm exec totem compile --export`
+
+4. Revert `compiled-rules.json` to the curated set. Compile will
+   produce new rules from the extracted lessons, but the curated set
+   in main is the source of truth. The new rules should be reviewed
+   and cherry-picked by hand rather than auto-merged (empirically
+   4/6 auto-compiled rules from the 1.14.1 postmerge were bad, and
+   mmnto-ai/totem#1349 now catches the syntactic-invalid cases but
+   not the over-broad ones):
+   `git checkout HEAD -- .totem/compiled-rules.json`
+
+5. Format everything wrap might have touched:
+   `pnpm run format`
+
+6. Stage only the artifacts we keep (lessons, exports, docs if they
+   were intentionally updated — NOT `docs/active_work.md`,
+   `docs/roadmap.md`, or `docs/architecture.md` unless you hand-edited
+   them deliberately):
+   `git add .totem/lessons/ .github/copilot-instructions.md .junie/skills/totem-rules/rules.md`
+
+7. Commit:
+   `git commit -m "chore: totem postmerge lessons for $ARGUMENTS"`
+
+8. Report: how many lessons extracted, which rules compiled and were
+   reverted, whether any over-broad rules warrant follow-up tickets.
+
+The retirement error from `totem wrap` produces this same workaround
+text at runtime, so if you forget the sequence, just run
+`pnpm exec totem wrap <prs>` and copy the hint.

--- a/.claude/skills/postmerge/SKILL.md
+++ b/.claude/skills/postmerge/SKILL.md
@@ -11,7 +11,7 @@ After merging PRs, run the following sequence. Replace `$ARGUMENTS`
 with the merged PR numbers (space-separated, e.g. `1345 1347 1348`).
 
 1. Extract lessons from the merged PR(s):
-   `pnpm exec totem extract $ARGUMENTS --yes`
+   `pnpm exec totem lesson extract $ARGUMENTS --yes`
 
 2. Sync the semantic index (usually already handled by the post-merge
    git hook, but running it explicitly is cheap and safe):
@@ -20,7 +20,7 @@ with the merged PR numbers (space-separated, e.g. `1345 1347 1348`).
 3. Compile new rules locally and export to AI tool configs. Do NOT
    pass `--cloud`; the cloud worker is still Gemini-only per
    mmnto-ai/totem#1221. Local compile routes to Sonnet 4.6:
-   `pnpm exec totem compile --export`
+   `pnpm exec totem lesson compile --export`
 
 4. Revert `compiled-rules.json` to the curated set. Compile will
    produce new rules from the extracted lessons, but the curated set

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,7 +164,7 @@ Totem supports three explicit capability tiers, auto-detected from the environme
 | ------------ | ------------------------------------------ | ---------------------------------------------------------------------------------------------------------------- |
 | **Lite**     | Zero API keys                              | `init`, `hooks`, `add-lesson`, `link`, `bridge`, `eject`, `lint`, `compile`, `test`, `explain`, `handoff --lite` |
 | **Standard** | Embedding key (`OPENAI_API_KEY` or Ollama) | Lite + `sync`, `search`, `stats`, `doctor`                                                                       |
-| **Full**     | Embedding + Orchestrator                   | All commands (`spec`, `review`, `triage`, `audit`, `briefing`, `handoff`, `extract`, `wrap`, `docs`)             |
+| **Full**     | Embedding + Orchestrator                   | All commands (`spec`, `review`, `triage`, `audit`, `briefing`, `handoff`, `extract`, `docs`)                     |
 
 A lite-tier standalone WASM binary provides core CLI functions with zero native dependencies. The embedding field in configuration files is optional; when omitted, operations default to the Lite tier boundary constraints.
 

--- a/docs/reference/supported-models.md
+++ b/docs/reference/supported-models.md
@@ -132,8 +132,7 @@ When a provider releases new stable models, update these locations:
 
 ## AI Coding Tools (Export Targets)
 
-Totem exports compiled lessons to AI coding tool config files via `totem compile --export`
-(also runs automatically as Step 5 of `totem wrap`). Each tool reads its own file on startup.
+Totem exports compiled lessons to AI coding tool config files via `totem compile --export`. Each tool reads its own file on startup.
 
 | Tool                   | Config File                       | Export Key | Totem Support           |
 | ---------------------- | --------------------------------- | ---------- | ----------------------- |

--- a/docs/reference/workflow-automation.md
+++ b/docs/reference/workflow-automation.md
@@ -48,9 +48,10 @@ The agent optimizes for speed over process, skipping steps like `totem spec` and
 
 ### Phase 6: After PR Merge
 
-**What should happen:** Extract lessons from the PR, wrap.
-**Commands:** `totem wrap <pr-numbers> --yes`
+**What should happen:** Extract lessons from the merged PR(s), re-sync the index, compile new rules locally, review the resulting rules by hand.
+**Commands:** `totem extract <prs> --yes`, `totem sync`, `totem compile --export`, `git checkout HEAD -- .totem/compiled-rules.json`
 **Skill:** `/postmerge <pr-numbers>`
+**Note:** `totem wrap` is retired pending [mmnto-ai/totem#1361](https://github.com/mmnto-ai/totem/issues/1361) because its `totem docs` step silently overwrote hand-crafted committed documentation. Run the individual commands directly.
 
 ### Phase 7: Before Release
 
@@ -81,7 +82,7 @@ Exempt branches (commit gate only): `main`, `master`, `hotfix/*`, `docs/*`, deta
 | -------------------- | ------------------------ | --------------------------------------------------------------- |
 | `/preflight <issue>` | Before starting a ticket | `totem spec` → `search_knowledge`                               |
 | `/prepush`           | Before pushing code      | `format` → `totem lint` → `totem review`                        |
-| `/postmerge <prs>`   | After merging PRs        | `totem wrap`                                                    |
+| `/postmerge <prs>`   | After merging PRs        | `totem extract` → `totem sync` → `totem compile --export`       |
 | `/triage`            | Pick next work           | `totem triage --fresh`                                          |
 | `/release-prep`      | Before cutting a release | `totem extract` → changeset → `pnpm run version` → `totem docs` |
 | `/signoff`           | End of session           | update memory → journal                                         |

--- a/docs/reference/workflow-automation.md
+++ b/docs/reference/workflow-automation.md
@@ -49,7 +49,7 @@ The agent optimizes for speed over process, skipping steps like `totem spec` and
 ### Phase 6: After PR Merge
 
 **What should happen:** Extract lessons from the merged PR(s), re-sync the index, compile new rules locally, review the resulting rules by hand.
-**Commands:** `totem extract <prs> --yes`, `totem sync`, `totem compile --export`, `git checkout HEAD -- .totem/compiled-rules.json`
+**Commands:** `totem lesson extract <prs> --yes`, `totem sync`, `totem lesson compile --export`, `git checkout HEAD -- .totem/compiled-rules.json`
 **Skill:** `/postmerge <pr-numbers>`
 **Note:** `totem wrap` is retired pending [mmnto-ai/totem#1361](https://github.com/mmnto-ai/totem/issues/1361) because its `totem docs` step silently overwrote hand-crafted committed documentation. Run the individual commands directly.
 

--- a/docs/wiki/agent-gemini-code-assist.md
+++ b/docs/wiki/agent-gemini-code-assist.md
@@ -15,7 +15,7 @@ GCA's `.gemini/config.yaml` can be as large as necessary since it acts as a conf
 
 ## 3. Totem Integration
 
-Totem influences GCA primarily through compiled architectural rules exported during `totem wrap` or `totem review`, which can inform the `.gemini/styleguide.md`. GCA does not use the `search_knowledge` MCP tool, as it cannot run local MCP servers.
+Totem influences GCA primarily through compiled architectural rules exported during `totem compile --export` or `totem review`, which can inform the `.gemini/styleguide.md`. GCA does not use the `search_knowledge` MCP tool, as it cannot run local MCP servers.
 
 ## 4. Common Pitfalls
 

--- a/docs/wiki/cli-reference.md
+++ b/docs/wiki/cli-reference.md
@@ -202,9 +202,21 @@ Captures uncommitted changes and lessons learned today for your next session.
 - **Flags:**
   - `--lite`: An ANSI-sanitized, zero-LLM snapshot (fast).
 
-### `totem wrap`
+### `totem wrap` (RETIRED)
 
-A post-merge workflow chain. Runs `extract`, syncs the database, generates a roadmap, and updates docs in one command.
+Previously a 6-step post-merge workflow chain. Retired pending [mmnto-ai/totem#1361](https://github.com/mmnto-ai/totem/issues/1361) because the `totem docs` step silently overwrote hand-crafted committed documentation. Running the command now prints a hard error with the manual workaround sequence. Use the individual commands directly:
+
+```bash
+pnpm exec totem extract <pr-numbers> --yes
+pnpm exec totem sync
+pnpm exec totem compile --export
+git checkout HEAD -- .totem/compiled-rules.json
+pnpm run format
+git add .totem/lessons/ .github/copilot-instructions.md .junie/skills/totem-rules/rules.md
+git commit -m "chore: totem postmerge lessons for <prs>"
+```
+
+Three return conditions must ship before `totem wrap` comes back: a `--skip-docs` flag on wrap, a 24-hour git-author-date freshness guard on `totem docs`, and an end-to-end regression test that seeds a hand-crafted `active_work.md` and asserts the file survives the pipeline unmodified.
 
 ### `totem add-secret <value>`
 

--- a/docs/wiki/cli-reference.md
+++ b/docs/wiki/cli-reference.md
@@ -207,9 +207,9 @@ Captures uncommitted changes and lessons learned today for your next session.
 Previously a 6-step post-merge workflow chain. Retired pending [mmnto-ai/totem#1361](https://github.com/mmnto-ai/totem/issues/1361) because the `totem docs` step silently overwrote hand-crafted committed documentation. Running the command now prints a hard error with the manual workaround sequence. Use the individual commands directly:
 
 ```bash
-pnpm exec totem extract <pr-numbers> --yes
+pnpm exec totem lesson extract <pr-numbers> --yes
 pnpm exec totem sync
-pnpm exec totem compile --export
+pnpm exec totem lesson compile --export
 git checkout HEAD -- .totem/compiled-rules.json
 pnpm run format
 git add .totem/lessons/ .github/copilot-instructions.md .junie/skills/totem-rules/rules.md

--- a/packages/cli/src/commands/wrap.test.ts
+++ b/packages/cli/src/commands/wrap.test.ts
@@ -47,16 +47,19 @@ describe('wrapCommand (retired)', () => {
     }
   });
 
-  it('lists the manual workaround sequence in the recovery hint', async () => {
+  it('lists the manual workaround sequence in the recovery hint using canonical noun-verb commands', async () => {
     try {
       await wrapCommand(['142'], {});
       expect.unreachable('wrapCommand should have thrown');
     } catch (err) {
       expect(err).toBeInstanceOf(TotemError);
       const hint = (err as TotemError).recoveryHint;
-      expect(hint).toContain('totem extract');
+      // Canonical noun-verb forms (`totem lesson extract`, `totem lesson compile`)
+      // per packages/cli/src/index.ts. The top-level `totem extract` and
+      // `totem compile` aliases are `{ hidden: true }` deprecated shims.
+      expect(hint).toContain('totem lesson extract');
       expect(hint).toContain('totem sync');
-      expect(hint).toContain('totem compile --export');
+      expect(hint).toContain('totem lesson compile --export');
       expect(hint).toContain('git checkout HEAD -- .totem/compiled-rules.json');
     }
   });

--- a/packages/cli/src/commands/wrap.test.ts
+++ b/packages/cli/src/commands/wrap.test.ts
@@ -1,127 +1,63 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-vi.mock('./extract.js', () => ({
-  extractCommand: vi.fn().mockResolvedValue(undefined),
-}));
-vi.mock('./sync.js', () => ({
-  syncCommand: vi.fn().mockResolvedValue(undefined),
-}));
-vi.mock('./triage.js', () => ({
-  triageCommand: vi.fn().mockResolvedValue(undefined),
-}));
-vi.mock('./docs.js', () => ({
-  docsCommand: vi.fn().mockResolvedValue(undefined),
-}));
-vi.mock('./compile.js', () => ({
-  compileCommand: vi.fn().mockResolvedValue(undefined),
-}));
-vi.mock('node:child_process', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:child_process')>();
-  return { ...actual, execSync: vi.fn() };
-});
+import { TotemError } from '@mmnto/totem';
 
-import { TotemConfigError } from '@mmnto/totem';
-
-import { compileCommand } from './compile.js';
-import { docsCommand } from './docs.js';
-import { extractCommand } from './extract.js';
-import { syncCommand } from './sync.js';
-import { triageCommand } from './triage.js';
 import { wrapCommand } from './wrap.js';
 
-describe('wrapCommand', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+// ─── Retirement tests (mmnto-ai/totem#1361) ──────────────
+//
+// `totem wrap` is retired pending a fix for the destructive
+// `totem docs` overwrite of hand-crafted committed documentation.
+// The function body is intentionally a hard error so the command
+// cannot be invoked out of habit. These tests lock the retirement
+// contract so future refactors cannot silently re-enable the
+// command without also removing the retirement shim.
+//
+// When wrap is un-retired, delete these tests and restore the
+// original orchestration assertions from git history.
+
+describe('wrapCommand (retired)', () => {
+  it('throws a TotemError regardless of arguments', async () => {
+    await expect(wrapCommand([], {})).rejects.toBeInstanceOf(TotemError);
+    await expect(wrapCommand(['142'], {})).rejects.toBeInstanceOf(TotemError);
+    await expect(
+      wrapCommand(['100', '101'], { model: 'gemini-3-flash', fresh: true, yes: true }),
+    ).rejects.toBeInstanceOf(TotemError);
   });
 
-  it('calls extract, sync, triage, docs, and compile in sequence', async () => {
-    const callOrder: string[] = [];
-    vi.mocked(extractCommand).mockImplementation(async () => {
-      callOrder.push('extract');
-    });
-    vi.mocked(syncCommand).mockImplementation(async () => {
-      callOrder.push('sync');
-    });
-    vi.mocked(triageCommand).mockImplementation(async () => {
-      callOrder.push('triage');
-    });
-    vi.mocked(docsCommand).mockImplementation(async () => {
-      callOrder.push('docs');
-    });
-    vi.mocked(compileCommand).mockImplementation(async () => {
-      callOrder.push('compile');
-    });
-
-    await wrapCommand(['142'], {});
-
-    expect(callOrder).toEqual(['extract', 'sync', 'triage', 'docs', 'compile']);
-    // docs:inject (execSync) should also have been called
-    const { execSync } = await import('node:child_process');
-    expect(execSync).toHaveBeenCalledWith('pnpm run docs:inject', expect.any(Object));
-    expect(extractCommand).toHaveBeenCalledWith(['142'], {
-      model: undefined,
-      fresh: undefined,
-      yes: undefined,
-    });
-    expect(syncCommand).toHaveBeenCalledWith({ full: false });
-    expect(triageCommand).toHaveBeenCalledWith({
-      model: undefined,
-      fresh: undefined,
-    });
-    expect(docsCommand).toHaveBeenCalledWith([], {
-      model: undefined,
-      fresh: undefined,
-      yes: undefined,
-    });
+  it('names the retirement reason in the error message', async () => {
+    try {
+      await wrapCommand(['142'], {});
+      expect.unreachable('wrapCommand should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TotemError);
+      expect((err as Error).message).toContain('retired');
+      expect((err as Error).message).toContain('totem docs');
+    }
   });
 
-  it('passes model and fresh options through', async () => {
-    await wrapCommand(['100', '101'], { model: 'gemini-3-flash', fresh: true, yes: true });
-
-    expect(extractCommand).toHaveBeenCalledWith(['100', '101'], {
-      model: 'gemini-3-flash',
-      fresh: true,
-      yes: true,
-    });
-    expect(triageCommand).toHaveBeenCalledWith({
-      model: 'gemini-3-flash',
-      fresh: true,
-    });
-    expect(docsCommand).toHaveBeenCalledWith([], {
-      model: 'gemini-3-flash',
-      fresh: true,
-      yes: true,
-    });
-    expect(compileCommand).toHaveBeenCalledWith({
-      model: 'gemini-3-flash',
-      fresh: true,
-      export: true,
-    });
+  it('points at the tracking ticket in the recovery hint', async () => {
+    try {
+      await wrapCommand(['142'], {});
+      expect.unreachable('wrapCommand should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TotemError);
+      const hint = (err as TotemError).recoveryHint;
+      expect(hint).toContain('mmnto-ai/totem#1361');
+    }
   });
 
-  it('gracefully skips docs step when no docs configured', async () => {
-    const err = new TotemConfigError(
-      'No docs configured.',
-      'Add docs to config.',
-      'CONFIG_MISSING',
-    );
-    vi.mocked(docsCommand).mockRejectedValueOnce(err);
-
-    await wrapCommand(['142'], {});
-
-    expect(extractCommand).toHaveBeenCalled();
-    expect(syncCommand).toHaveBeenCalled();
-    expect(triageCommand).toHaveBeenCalled();
-    expect(docsCommand).toHaveBeenCalled();
-    expect(compileCommand).toHaveBeenCalled();
-  });
-
-  it('aborts chain if extract throws', async () => {
-    vi.mocked(extractCommand).mockRejectedValueOnce(new Error('User aborted'));
-
-    await expect(wrapCommand(['142'], {})).rejects.toThrow('User aborted');
-    expect(syncCommand).not.toHaveBeenCalled();
-    expect(triageCommand).not.toHaveBeenCalled();
-    expect(docsCommand).not.toHaveBeenCalled();
+  it('lists the manual workaround sequence in the recovery hint', async () => {
+    try {
+      await wrapCommand(['142'], {});
+      expect.unreachable('wrapCommand should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TotemError);
+      const hint = (err as TotemError).recoveryHint;
+      expect(hint).toContain('totem extract');
+      expect(hint).toContain('totem sync');
+      expect(hint).toContain('totem compile --export');
+      expect(hint).toContain('git checkout HEAD -- .totem/compiled-rules.json');
+    }
   });
 });

--- a/packages/cli/src/commands/wrap.ts
+++ b/packages/cli/src/commands/wrap.ts
@@ -1,8 +1,10 @@
+import { TotemError } from '@mmnto/totem';
+
 // ─── Constants ──────────────────────────────────────────
 
 const TAG = 'Wrap';
 
-// ─── Main command ───────────────────────────────────────
+// ─── Options ────────────────────────────────────────────
 
 export interface WrapOptions {
   model?: string;
@@ -10,91 +12,56 @@ export interface WrapOptions {
   yes?: boolean;
 }
 
-export async function wrapCommand(prNumbers: string[], options: WrapOptions): Promise<void> {
-  const { log } = await import('../ui.js');
-  const { TotemError } = await import('@mmnto/totem');
+// ─── Main command ───────────────────────────────────────
 
-  // Step 1: Learn from PR(s)
-  log.info(TAG, `Step 1/6 — Extracting from PR ${prNumbers.join(', ')}...`);
-  const { extractCommand } = await import('./extract.js');
-  await extractCommand(prNumbers, {
-    model: options.model,
-    fresh: options.fresh,
-    yes: options.yes,
-  });
-
-  // Step 2: Sync index
-  log.info(TAG, 'Step 2/6 — Syncing index...');
-  const { syncCommand } = await import('./sync.js');
-  await syncCommand({ full: false });
-
-  // Step 3: Triage
-  log.info(TAG, 'Step 3/6 — Generating triage roadmap...');
-  const { triageCommand } = await import('./triage.js');
-  await triageCommand({
-    model: options.model,
-    fresh: options.fresh,
-  });
-
-  // Step 4: Update project docs (if configured)
-  log.info(TAG, 'Step 4/6 — Updating project docs...');
-  try {
-    const { docsCommand } = await import('./docs.js');
-    await docsCommand([], {
-      model: options.model,
-      fresh: options.fresh,
-      yes: options.yes,
-    });
-  } catch (err) {
-    // Don't fail wrap if docs aren't configured — it's optional
-    if (err instanceof TotemError && err.code === 'CONFIG_MISSING') {
-      log.dim(TAG, 'No docs configured — skipping doc sync.');
-    } else {
-      throw err;
-    }
-  }
-
-  // Step 5: Deterministic doc injection (markdown-magic)
-  log.info(TAG, 'Step 5/6 — Injecting dynamic doc values...');
-  try {
-    const { execSync } = await import('node:child_process');
-    execSync('pnpm run docs:inject', { cwd: process.cwd(), stdio: 'pipe' });
-    log.success(TAG, 'Doc values injected.');
-  } catch (err) {
-    // execSync errors may carry details in stdout/stderr buffers
-    const msg = [
-      err instanceof Error ? err.message : String(err),
-      err && typeof err === 'object' && 'stdout' in err ? String(err.stdout) : '',
-      err && typeof err === 'object' && 'stderr' in err ? String(err.stderr) : '',
-    ].join(' ');
-    if (msg.includes('Missing script') || msg.includes('not found')) {
-      log.dim(TAG, 'docs:inject not configured — skipping.');
-    } else {
-      log.error('Totem Error', `docs:inject failed: ${msg.slice(0, 200)}`);
-      throw err;
-    }
-  }
-
-  // Step 6: Compile rules and export to AI tool configs (if configured)
-  log.info(TAG, 'Step 6/6 — Compiling rules and exporting...');
-  try {
-    const { compileCommand } = await import('./compile.js');
-    await compileCommand({
-      model: options.model,
-      fresh: options.fresh,
-      export: true,
-    });
-  } catch (err) {
-    // Don't fail wrap if compile has nothing to do
-    if (err instanceof TotemError && err.code === 'NO_LESSONS') {
-      log.dim(TAG, 'Nothing to compile — skipping.');
-    } else {
-      throw err;
-    }
-  }
-
-  log.success(
-    TAG,
-    'Wrap complete — lessons extracted, index synced, roadmap updated, docs synced, values injected, rules exported.',
+/**
+ * RETIRED as of mmnto-ai/totem#1361.
+ *
+ * `totem wrap` previously orchestrated a 6-step post-merge workflow
+ * (extract lessons, sync index, triage, update project docs, inject
+ * doc values, compile and export rules). Step 4 (`totem docs`) iterates
+ * every target in `config.docs` and runs an LLM rewrite pass. The
+ * dirty-file guard at `docs.ts:450` catches uncommitted changes but
+ * does nothing for recent committed edits, so any hand-crafted refresh
+ * of `docs/active_work.md`, `docs/roadmap.md`, or `docs/architecture.md`
+ * gets silently overwritten on the next wrap invocation.
+ *
+ * This is a Tenet 5 ("Sensors Not Actuators") violation. The command is
+ * blocked behind a hard error until three return conditions ship:
+ *
+ *   1. `--skip-docs` flag exists on wrap
+ *   2. `totem docs` has a freshness guard (skip targets whose git
+ *      author date is within the last 24 hours without `--force-regen`)
+ *   3. End-to-end regression test for wrap locks the invariant that
+ *      hand-crafted docs survive the pipeline
+ *
+ * The function signature, options interface, and test scaffolding
+ * are preserved below for institutional memory. See
+ * mmnto-ai/totem#1361 for the tracking ticket. Git log has the
+ * original 6-step implementation (most recent version in commit
+ * bd638103's parent tree).
+ */
+// eslint-disable-next-line @typescript-eslint/require-await
+export async function wrapCommand(_prNumbers: string[], _options: WrapOptions): Promise<void> {
+  throw new TotemError(
+    'CONFIG_INVALID',
+    'totem wrap is retired. It silently overwrites hand-crafted docs via the totem docs step.',
+    [
+      'Run the individual steps manually:',
+      '',
+      '  pnpm exec totem extract <pr-numbers> --yes',
+      '  pnpm exec totem sync',
+      '  pnpm exec totem compile --export',
+      '  git checkout HEAD -- .totem/compiled-rules.json',
+      '  pnpm run format',
+      '  git add .totem/lessons/ .github/copilot-instructions.md .junie/skills/totem-rules/rules.md',
+      "  git commit -m 'chore: totem postmerge lessons for <prs>'",
+      '',
+      'Tracking: mmnto-ai/totem#1361',
+    ].join('\n'),
   );
 }
+
+// TAG is kept as a named export anchor so future non-retired implementations
+// can restore their log prefix without re-deriving the token.
+export { TAG };

--- a/packages/cli/src/commands/wrap.ts
+++ b/packages/cli/src/commands/wrap.ts
@@ -1,5 +1,3 @@
-import { TotemError } from '@mmnto/totem';
-
 // ─── Constants ──────────────────────────────────────────
 
 const TAG = 'Wrap';
@@ -41,17 +39,23 @@ export interface WrapOptions {
  * original 6-step implementation (most recent version in commit
  * bd638103's parent tree).
  */
-// eslint-disable-next-line @typescript-eslint/require-await
 export async function wrapCommand(_prNumbers: string[], _options: WrapOptions): Promise<void> {
+  // Dynamic import matches the CLI lazy-load convention used by every
+  // other command in this package (see compile.ts, check.ts, drift.ts).
+  // The original pre-retirement wrap also imported TotemError this way;
+  // preserving the pattern here keeps the un-retirement PR a clean
+  // restoration of the 6-step body.
+  const { TotemError } = await import('@mmnto/totem');
+
   throw new TotemError(
     'CONFIG_INVALID',
     'totem wrap is retired. It silently overwrites hand-crafted docs via the totem docs step.',
     [
       'Run the individual steps manually:',
       '',
-      '  pnpm exec totem extract <pr-numbers> --yes',
+      '  pnpm exec totem lesson extract <pr-numbers> --yes',
       '  pnpm exec totem sync',
-      '  pnpm exec totem compile --export',
+      '  pnpm exec totem lesson compile --export',
       '  git checkout HEAD -- .totem/compiled-rules.json',
       '  pnpm run format',
       '  git add .totem/lessons/ .github/copilot-instructions.md .junie/skills/totem-rules/rules.md',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -598,14 +598,18 @@ program
     }
   });
 
+// `totem wrap` is retired pending mmnto-ai/totem#1361. The command is
+// hidden from --help but still wired so invocation produces the
+// retirement error with the manual workaround sequence. Do NOT remove
+// the registration — deleting it would silently mask the error with
+// commander's "unknown command" path and lose the workaround hint.
 program
-  .command('wrap <pr-numbers...>')
-  .description('Post-merge workflow: learn from PR(s), sync index, then triage')
+  .command('wrap <pr-numbers...>', { hidden: true })
+  .description('RETIRED (mmnto-ai/totem#1361) — post-merge workflow')
   .option('--model <name>', 'Override the default model for the orchestrator')
   .option('--fresh', 'Bypass cache and force fresh LLM calls')
   .option('--yes', 'Skip confirmation prompt for lesson extraction')
   .action(async (prNumbers: string[], opts: { model?: string; fresh?: boolean; yes?: boolean }) => {
-    requireGhCli();
     try {
       const { wrapCommand } = await import('./commands/wrap.js');
       await wrapCommand(prNumbers, opts);


### PR DESCRIPTION
Closes #1361

## Summary

- Retire `totem wrap` via a hard `TotemError` throw. Surfaced during the 2026-04-11 PM `/signoff` session: step 4 (`totem docs`) silently overwrites hand-crafted committed documentation because the dirty-file guard at `docs.ts:450` only catches uncommitted changes, not recent committed edits. This is a Tenet 5 ("Sensors Not Actuators") violation.
- Keep the command wired behind `{ hidden: true }` so invocation fires the error instead of commander's "unknown command" fallback. The error's `recoveryHint` lists the full manual workaround sequence so users are not blocked.
- Rewrite `.claude/skills/postmerge/SKILL.md` to run the individual steps directly (`totem extract` → `totem sync` → `totem compile --export` → revert compiled-rules.json → format → stage → commit).
- Update all user-facing doc references: `docs/wiki/cli-reference.md`, `docs/wiki/agent-gemini-code-assist.md`, `docs/architecture.md`, `docs/reference/workflow-automation.md`, `docs/reference/supported-models.md`.

## Context

The signoff session on 2026-04-11 hand-crafted a 1.14.5 refresh in `docs/active_work.md`. Before running `/postmerge` for the six marathon PRs, I checked what `totem wrap` would actually do and found:

1. `totem wrap <prs>` runs 6 steps. Step 4 is `totem docs` iterating every target in `config.docs`.
2. `totem.config.ts:42-50` registers `docs/active_work.md`, `docs/roadmap.md`, and `docs/architecture.md` as doc targets.
3. `packages/cli/src/commands/docs.ts:450-458` has a dirty-file guard, but it only catches uncommitted changes.
4. The LLM prompt at `docs.ts:38-42` explicitly tells the model to "aggressively rewrite forward-looking sections (roadmaps, active work, upcoming features) to match the Ground Truth."
5. Result: the signoff refresh would have been silently destroyed on the first postmerge wrap run.

Per the `/signoff` conversation (Claude + Gemini agreement), Option C was chosen: hard error, not deprecation warning. A command that actively corrupts committed work deserves an honest "this is turned off" signal.

## Return conditions (tracked in #1361)

Before `totem wrap` comes back, all three must ship:

1. `--skip-docs` flag on wrap so post-release refresh workflows can opt out of Step 4 entirely.
2. Freshness guard on `totem docs`: skip targets whose git author date is within the last 24 hours without `--force-regen`.
3. End-to-end regression test for wrap that seeds a hand-crafted `active_work.md`, runs wrap, and asserts the file survives the pipeline unmodified.

## What is NOT changed

- `wrap.ts` source is preserved (only the body of `wrapCommand` is replaced with the throw). Function signature, `WrapOptions` interface, and `TAG` constant all stay as named exports so the un-retirement PR can restore the original 6-step implementation without re-deriving the shape.
- The original orchestration tests in `wrap.test.ts` are not preserved inline but they are in git history (look at the parent of this commit). The un-retirement PR should restore them alongside the new regression test for the freshness guard.
- `packages/cli/src/commands/docs.ts` is untouched. The underlying `totem docs` drift is a separate fix that lands as part of return condition #2.

## Test plan

- [ ] CI green on the branch
- [ ] `totem wrap 1234` from the command line prints the retirement error and the manual workaround (verify locally)
- [ ] `totem --help` does not show `wrap` in the command list
- [ ] `pnpm exec vitest run packages/cli/src/commands/wrap.test.ts` passes the four new retirement-contract assertions
- [ ] `docs/wiki/cli-reference.md` rendered preview shows the "RETIRED" marker and the workaround sequence
- [ ] `.claude/skills/postmerge/SKILL.md` no longer references `totem wrap`

🤖 Generated with [Claude Code](https://claude.com/claude-code)