### PR TITLE
docs(skill): replace postmerge SKILL.md step 4 revert with inline archive workflow

### DIFF
--- a/.claude/skills/postmerge/SKILL.md
+++ b/.claude/skills/postmerge/SKILL.md
@@ -70,13 +70,18 @@ with the merged PR numbers (space-separated, e.g. `1345 1347 1348`).
    `pnpm run format`
 
 7. Stage only the artifacts we keep: new lessons, the mutated rules
-   file, the refreshed manifest, the regenerated exports, and any
-   curation scripts preserved for institutional memory. Do NOT stage
-   `docs/active_work.md`, `docs/roadmap.md`, or
+   file, the refreshed manifest, and the regenerated exports. Do NOT
+   stage `docs/active_work.md`, `docs/roadmap.md`, or
    `docs/architecture.md` unless you hand-edited them deliberately
    (those are `totem docs` targets and a postmerge run should not
    rewrite them):
    `git add .totem/lessons/ .totem/compiled-rules.json .totem/compile-manifest.json .github/copilot-instructions.md .junie/skills/totem-rules/rules.md`
+
+   If you wrote a one-off curation script during step 4 (as was done
+   on mmnto-ai/totem#1366 with `scripts/archive-bad-postmerge-rules.cjs`),
+   stage it explicitly so the institutional memory lands with the
+   commit:
+   `git add scripts/archive-bad-postmerge-rules.cjs  # or whatever you named yours`
 
 8. Commit:
    `git commit -m "chore: totem postmerge lessons for $ARGUMENTS"`

--- a/.claude/skills/postmerge/SKILL.md
+++ b/.claude/skills/postmerge/SKILL.md
@@ -22,29 +22,69 @@ with the merged PR numbers (space-separated, e.g. `1345 1347 1348`).
    mmnto-ai/totem#1221. Local compile routes to Sonnet 4.6:
    `pnpm exec totem lesson compile --export`
 
-4. Revert `compiled-rules.json` to the curated set. Compile will
-   produce new rules from the extracted lessons, but the curated set
-   in main is the source of truth. The new rules should be reviewed
-   and cherry-picked by hand rather than auto-merged (empirically
-   4/6 auto-compiled rules from the 1.14.1 postmerge were bad, and
-   mmnto-ai/totem#1349 now catches the syntactic-invalid cases but
-   not the over-broad ones):
-   `git checkout HEAD -- .totem/compiled-rules.json`
+4. Review the newly compiled rules. Step 3's output prints a count
+   like `N/M (100%) ... X compiled, Y skipped, Z failed`. For each
+   of the X newly compiled rules, inspect them in
+   `.totem/compiled-rules.json` and verify:
+   - The `astGrepPattern` or `pattern` is not over-broad (does it
+     fire on legitimate code the rule is not trying to flag?)
+   - The pattern does not reference hallucinated package names, type
+     names, or file paths that do not exist in the repo
+   - The `lessonHeading` accurately describes the rule's behavior
 
-5. Format everything wrap might have touched:
+   For any rule that fails these checks, mutate
+   `.totem/compiled-rules.json` to add `status: 'archived'` and a
+   detailed `archivedReason` explaining the specific failure mode.
+   The mmnto-ai/totem#1345 archive filter in `loadCompiledRules`
+   silences archived rules at lint time while preserving them in the
+   ledger for future compile-worker prompt regression analysis. See
+   `scripts/archive-bad-postmerge-rules.cjs` (committed on
+   mmnto-ai/totem#1366) for the canonical mutation script shape.
+   Match target rules by `lessonHash`, not `lessonHeading` (headings
+   are auto-truncated to 60 chars and are not guaranteed unique).
+
+   **Do NOT** use `git checkout HEAD -- .totem/compiled-rules.json`
+   to revert the entire rules file. Reverting rules while keeping
+   the new lessons on disk creates a manifest inconsistency
+   (manifest.input_hash reflects the new lessons, output_hash
+   reflects the reverted rules, verify-manifest fails on push). This
+   is the symmetric counterpart of the mmnto-ai/totem#1337 bug.
+   Archive-in-place is the intended curation surface; reverting is
+   not.
+
+   Empirical baseline: approximately 2 of every 6 auto-compiled
+   rules are bad (1.14.1 postmerge), and the 2026-04-11 PM postmerge
+   hit 4 of 5. The compile-worker prompt rewrite conversation lives
+   under Strategy #73 and Strategy #62. Every archivedReason is
+   feedback that informs that rewrite.
+
+5. Refresh the manifest and exports. After any mutation to
+   `compiled-rules.json`, re-run step 3's compile command. It will
+   detect the rules file drift via mmnto-ai/totem#1348's no-op
+   refresh path, update `compile-manifest.json` hashes, and
+   regenerate the copilot and junie exports so they filter the
+   newly archived rules out of the exported markdown:
+   `pnpm exec totem lesson compile --export`
+
+6. Format everything compile touched:
    `pnpm run format`
 
-6. Stage only the artifacts we keep (lessons, exports, docs if they
-   were intentionally updated — NOT `docs/active_work.md`,
-   `docs/roadmap.md`, or `docs/architecture.md` unless you hand-edited
-   them deliberately):
-   `git add .totem/lessons/ .github/copilot-instructions.md .junie/skills/totem-rules/rules.md`
+7. Stage only the artifacts we keep: new lessons, the mutated rules
+   file, the refreshed manifest, the regenerated exports, and any
+   curation scripts preserved for institutional memory. Do NOT stage
+   `docs/active_work.md`, `docs/roadmap.md`, or
+   `docs/architecture.md` unless you hand-edited them deliberately
+   (those are `totem docs` targets and a postmerge run should not
+   rewrite them):
+   `git add .totem/lessons/ .totem/compiled-rules.json .totem/compile-manifest.json .github/copilot-instructions.md .junie/skills/totem-rules/rules.md`
 
-7. Commit:
+8. Commit:
    `git commit -m "chore: totem postmerge lessons for $ARGUMENTS"`
 
-8. Report: how many lessons extracted, which rules compiled and were
-   reverted, whether any over-broad rules warrant follow-up tickets.
+9. Report: how many lessons extracted, how many rules compiled, how
+   many were archived inline with reasons, and whether any new
+   tickets were filed for rules that need source-lesson refinement
+   before they can be re-compiled cleanly.
 
 The retirement error from `totem wrap` produces this same workaround
 text at runtime, so if you forget the sequence, just run


### PR DESCRIPTION
Closes #1367

## Summary

- Replace `.claude/skills/postmerge/SKILL.md` step 4 (revert `compiled-rules.json`) with an inline-archive workflow that uses the `#1345` archive filter as the intended curation surface.
- Add a new step 5 that re-runs `totem lesson compile --export` after the archive mutation to refresh the manifest via `#1348`'s no-op refresh path and regenerate the copilot/junie exports.
- Renumber steps 5-8 to 6-9 and expand the staging command in step 7 to include `compiled-rules.json` + `compile-manifest.json`.
- Add an explicit "Do NOT revert" callout naming the manifest inconsistency failure mode and the symmetric relationship to `#1337`.

## Why

Surfaced empirically while running the 2026-04-11 PM postmerge on `#1366` (the first production run of the manual sequence after `totem wrap` retirement on `#1362`). The old step 4 said to revert `compiled-rules.json` via `git checkout HEAD -- .totem/compiled-rules.json`, but reverting the rules file while keeping the new lessons on disk creates a manifest inconsistency:

- `manifest.input_hash` reflects the new lesson set
- `output_hash` reflects the reverted rules
- `verify-manifest` fails on push

This is the symmetric counterpart of the `#1337` bug we fixed this morning (`#1337` was "lessons deleted but manifest stays stale"; the revert path creates "rules reverted but lessons still present"). The old skill instruction led users directly into a state that cannot be committed cleanly without surgical intervention.

The `#1334` precedent already deviated from the revert instruction in practice, and `#1366` extended the curation approach by using the `#1345` archive filter for Day Zero silencing of bad auto-compile output. This PR codifies that precedent into the skill so the next person running `/postmerge` does not re-discover the bug the hard way.

## The three validation checks in the new step 4

The new step 4 tells the user to inspect each newly compiled rule against three concrete checks:

1. The `astGrepPattern` or `pattern` is not over-broad (does it fire on legitimate code the rule is not trying to flag?)
2. The pattern does not reference hallucinated package names, type names, or file paths that do not exist in the repo
3. The `lessonHeading` accurately describes the rule's behavior

All three checks were used on `#1366` to identify the 4 rules that got archived. The failure modes they caught map directly to the archivedReason fields we wrote: over-broad split rule (check 1), hallucinated `@mcp-b/core` package (check 2), over-broad dynamic import pattern (check 1), over-broad dot-split (check 1).

## The archive mutation pattern

Step 4 cites `scripts/archive-bad-postmerge-rules.cjs` (committed on `#1366`) as the canonical mutation script shape. That script was hardened during the `#1366` bot review round to match target rules by `lessonHash` instead of `lessonHeading` (per CodeRabbit's finding that headings are auto-truncated and collision-prone). The SKILL.md incorporates that learning inline so future scripts do not repeat the mistake.

## The new step 5

After any mutation to `compiled-rules.json`, re-run `totem lesson compile --export`. This triggers the `#1348` no-op refresh path to:

- Update `compile-manifest.json` hashes to match the mutated rules file
- Regenerate `.github/copilot-instructions.md` and `.junie/skills/totem-rules/rules.md` so they filter the newly archived rules out of the exported markdown

Previously this refresh was implicit in step 3 of the 1.14.1-era skill, but when the step pattern changed to "compile once, then curate, then refresh," the refresh became a distinct operation that deserved its own step.

## What the skill still does

- Still uses `totem lesson extract` and `totem lesson compile --export` (canonical noun-verb forms from `#1362` / `#1366` bot rounds)
- Still says to not pass `--cloud` per the `#1221` cloud compile restriction
- Still explicitly names the three doc targets that should NOT be staged unless hand-edited (`docs/active_work.md`, `docs/roadmap.md`, `docs/architecture.md`) because those are `totem docs` rewrite targets
- Still cites the `totem wrap` retirement (`#1361`) so future users understand why the manual sequence exists

## Test plan

- [ ] CI green on the branch (docs-only, should be fast)
- [ ] `totem review` fast-paths (no code changes)
- [ ] `totem lint` reports no changes detected (`.claude/` is in ignorePatterns)
- [ ] The next `/postmerge` invocation produces a cleaner run than #1366 did, because the workflow bug has been codified out

🤖 Generated with [Claude Code](https://claude.com/claude-code)