### PR TITLE
docs(readme): point version badge at @mmnto/totem (core) for project-level version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Totem
 
-[![npm version](https://img.shields.io/npm/v/@mmnto/cli.svg)](https://www.npmjs.com/package/@mmnto/cli)
+[![npm version](https://img.shields.io/npm/v/@mmnto/totem.svg)](https://www.npmjs.com/package/@mmnto/totem)
 [![CI](https://github.com/mmnto-ai/totem/actions/workflows/ci.yml/badge.svg)](https://github.com/mmnto-ai/totem/actions/workflows/ci.yml)
 
 _AI coding agents are brilliant goldfish. Totem is their persistent, cross-repo memory._


### PR DESCRIPTION
## Summary

Swap the README npm version badge from \`@mmnto/cli\` to \`@mmnto/totem\` so the displayed version number reads as "the version of Totem" rather than "the version of the CLI subpackage."

The three published packages are versioned in lockstep via a changesets fixed group:

\`\`\`json
"fixed": [["@mmnto/totem", "@mmnto/cli", "@mmnto/mcp"]]
\`\`\`

Current state of all three: \`1.14.5\`. Changesets guarantees they always share the same version, so this is a semantic relabel, not a functional change. The displayed number stays identical on every release.

## Why

Surfaced in chat during #1376 signoff: a reader of the README sees "npm version 1.14.5" attached to \`@mmnto/cli\` and may reasonably wonder which version applies to \`@mmnto/core\` or \`@mmnto/mcp\`. The lockstep guarantee is an internal invariant that isn't visible from the badge. Pointing the badge at the project-named package (\`@mmnto/totem\`) makes the project-level version explicit without adding badge clutter.

## What does not change

- Install instructions in the Quickstart section still reference \`pnpm dlx @mmnto/cli init\` because the CLI is the user-facing entry point.
- The lockstep guarantee (the three packages always share one version) is unchanged.
- The number displayed on the badge is unchanged (1.14.5 on both cli and totem right now).

## Test plan

- [x] \`totem lint\` passed (pre-push hook)
- [ ] CI green
- [ ] Verify the shields.io badge resolves for \`@mmnto/totem\` after merge (should already work since the package is published)

🤖 Generated with [Claude Code](https://claude.com/claude-code)