### PR TITLE
fix(rules): reconcile lesson heading lint rules with parser flexibility

### DIFF
--- a/.totem/compile-manifest.json
+++ b/.totem/compile-manifest.json
@@ -1,7 +1,7 @@
 {
-  "compiled_at": "2026-04-11T23:02:52.705Z",
+  "compiled_at": "2026-04-12T15:37:04.404Z",
   "model": "gemini-3-flash-preview",
-  "input_hash": "afbfbe67de7c6681defa151c64ae50cfe29e82b81fd66b866a30b24029542c6b",
-  "output_hash": "b31fa3212d67bb42164038c66ac0fa564622b89b34563358ab06673f2021cd96",
+  "input_hash": "4a95fe8f4c1a8ad49327497bbe40a1af2dada5049de27e5b3df393988d932eb3",
+  "output_hash": "fb19cf9eed8189699b78a88a07980285d5a5bc800a600980fef283f026c77b1f",
   "rule_count": 399
 }

--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -2290,20 +2290,6 @@
       "severity": "warning"
     },
     {
-      "lessonHash": "c360340b1b8ff1c7",
-      "lessonHeading": "Manual lessons must use the '## Lesson — <Heading>'",
-      "pattern": "^##\\s+Lesson\\s*[^—]",
-      "message": "Manual lessons must use the '## Lesson — <Heading>' structure (with an em dash '—') to ensure compatibility with automated parsing and discovery tools.",
-      "engine": "regex",
-      "compiledAt": "2026-04-06T03:22:45.993Z",
-      "createdAt": "2026-04-06T03:22:45.993Z",
-      "fileGlobs": [
-        "**/*.md",
-        "**/*.mdx"
-      ],
-      "severity": "warning"
-    },
-    {
       "lessonHash": "f4b44468f7f5b46a",
       "lessonHeading": "Verify CLI availability in shared git hooks before execution",
       "pattern": "^[ \\t]*(?!(?:if|command|type|hash|\\[|&&|\\|\\|)\\b)\\s*(npx|pnpm|npm|yarn|eslint|prettier|lint-staged|tsc|vitest|jest|oxlint|biome|stylelint)\\b",
@@ -3580,19 +3566,6 @@
         "**/*.js",
         "**/*.tsx",
         "**/*.jsx"
-      ],
-      "severity": "warning"
-    },
-    {
-      "lessonHash": "e533191ba7c58614",
-      "lessonHeading": "Use a '## Lesson — <Heading>' format and 'Tags' field",
-      "pattern": "^## Lesson(?! —)",
-      "message": "Lesson headings must use the format '## Lesson — <Heading>' (with em dash and space)",
-      "engine": "regex",
-      "compiledAt": "2026-04-06T03:25:45.158Z",
-      "createdAt": "2026-04-06T03:25:45.158Z",
-      "fileGlobs": [
-        "**/*.md"
       ],
       "severity": "warning"
     },
@@ -6427,6 +6400,32 @@
       "severity": "warning",
       "status": "archived",
       "archivedReason": "Pattern `$STR.split('.')` fires on all dot splits: filename extension parsing (`filename.split('.')`), semantic version parsing (`'1.14.5'.split('.')`), dot-notation handling, and any arbitrary string manipulation with `.`. The underlying lesson was specific to splitting error messages containing code patterns with dots (the regression fixed in mmnto/totem#1349), but the rule is indiscriminate. Auto-compiled on the 2026-04-11 PM postmerge. Archived via the mmnto/totem#1345 filter. Kept in the ledger as the canonical example of 'the rule should have been narrower than the pattern the LLM chose'."
+    },
+    {
+      "lessonHash": "7e3eefeaa85403d0",
+      "lessonHeading": "Manual lessons must use the '## Lesson <separator> <Heading>' structure",
+      "message": "Manual lessons must use '## Lesson <separator> <Heading>' structure where separator is an em-dash (—), en-dash (–), or hyphen (-)",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "^## Lesson(?! [—–-] .+)",
+      "compiledAt": "2026-04-12T15:37:03.920Z",
+      "createdAt": "2026-04-12T15:37:03.920Z",
+      "fileGlobs": [
+        "**/*.md"
+      ]
+    },
+    {
+      "lessonHash": "6e8a7d02136381a2",
+      "lessonHeading": "Use a '## Lesson <separator> <Heading>' format and 'Tags' field",
+      "message": "Lesson headings must use the format '## Lesson <separator> <Heading>' where separator is an em-dash (—), en-dash (–), or hyphen (-)",
+      "engine": "regex",
+      "severity": "warning",
+      "pattern": "^## Lesson(?! [—–-] .+)",
+      "compiledAt": "2026-04-12T15:37:04.023Z",
+      "createdAt": "2026-04-12T15:37:04.023Z",
+      "fileGlobs": [
+        "**/*.md"
+      ]
     }
   ],
   "nonCompilable": [

--- a/.totem/lessons/lesson-4822027f.md
+++ b/.totem/lessons/lesson-4822027f.md
@@ -1,5 +1,5 @@
-## Lesson — Manual lessons must use the '## Lesson — <Heading>'
+## Lesson — Manual lessons must use the '## Lesson <separator> <Heading>' structure
 
 **Tags:** documentation, tooling
 
-Manual lessons must use the '## Lesson — <Heading>' structure and include a 'Tags' field to ensure compatibility with automated parsing and discovery tools.
+Manual lessons must use a `## Lesson <separator> <Heading>` structure (where `<separator>` is an em-dash, en-dash, or hyphen) and include a `Tags` field to ensure compatibility with automated parsing and discovery tools. The parser accepts all three separator forms equivalently.

--- a/.totem/lessons/lesson-874db909.md
+++ b/.totem/lessons/lesson-874db909.md
@@ -1,5 +1,5 @@
-## Lesson — Use a '## Lesson — <Heading>' format and 'Tags' field
+## Lesson — Use a '## Lesson <separator> <Heading>' format and 'Tags' field
 
 **Tags:** documentation, dx
 
-Use a '## Lesson — <Heading>' format and 'Tags' field in lesson files to ensure consistency with auto-generated content and improve parsing.
+Use a `## Lesson <separator> <Heading>` format (where `<separator>` is an em-dash, en-dash, or hyphen) and include a `Tags` field in lesson files to ensure consistency with auto-generated content and improve parsing. The parser accepts all three separator characters equivalently.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Totem turns a plain-English markdown lesson into a physical constraint that a lo
 **Input:** (`.totem/lessons/no-child-process.md`)
 
 ```markdown
-## Lesson — Never use native child_process
+## Lesson - Never use native child_process
 
 Tags: architecture
 Direct use of `node:child_process` is forbidden outside `core/src/sys/`. Use the `safeExec` shared helper instead.

--- a/docs/wiki/it-never-happens-again.md
+++ b/docs/wiki/it-never-happens-again.md
@@ -19,7 +19,7 @@ Totem reads the review comments, identifies the architectural pattern, and write
 _Example output:_
 
 ```markdown
-## Lesson — Lazy load CLI commands
+## Lesson - Lazy load CLI commands
 
 Tags: architecture, cli
 Never use static imports (e.g., `import fs from 'fs'`) at the top level of CLI command files. Always use dynamic imports (`await import('fs')`) inside the command handler to preserve startup latency.

--- a/docs/wiki/pipeline-engine.md
+++ b/docs/wiki/pipeline-engine.md
@@ -54,7 +54,7 @@ Then, author the lesson markdown and run `totem lesson compile` to generate the 
 Given a lesson (`.totem/lessons/db-access.md`) with explicit blocks:
 
 ````markdown
-## Lesson — Direct DB access is forbidden in UI components
+## Lesson - Direct DB access is forbidden in UI components
 
 **Wrong:**
 


### PR DESCRIPTION
## Summary

- Updated two lesson source files to reflect that `parseLessonsFile` accepts em-dash, en-dash, and hyphen separators (since #1263)
- Recompiled rules with corrected regex `^## Lesson(?! [—–-] .+)` -- the LLM-generated pattern `(?! .+[—–-] .+)` was wrong (the `.+` before the dash class consumed the separator, causing the rule to fire on all headings including valid ones)
- Swapped the three doc code-fence examples from em-dash to hyphen: README.md, it-never-happens-again.md, pipeline-engine.md

## Test plan

- [x] Node regex test confirms old pattern fires on valid headings, fixed pattern does not
- [x] `totem lint` passes with 0 violations (394 active rules)
- [x] `totem verify-manifest` passes (hash matches)
- [x] Full test suite passes (2765 tests)
- [x] Pre-push hook passes (format, lint, tests, manifest)

Closes #1374

🤖 Generated with [Claude Code](https://claude.com/claude-code)