### PR TITLE
docs(wiki): rename deprecated bare totem extract to canonical form

### DIFF
--- a/docs/wiki/cli-reference.md
+++ b/docs/wiki/cli-reference.md
@@ -157,7 +157,7 @@ Compiles `.totem/lessons.md` into deterministic regex/AST rules for zero-LLM che
   - `--from-cursor`: Ingests `.cursorrules`, `.windsurfrules`, and `.cursor/rules/*.mdc` files as lessons.
   - `--upgrade <hash>`: Targets one rule by hash (full or short prefix), evicts only that rule from the cache (preserves `createdAt` metadata), recompiles through Sonnet with a telemetry-driven directive, and replaces the rule. Rejects `--cloud` (not supported) and `--force` (scoped eviction makes force redundant and dangerous).
 
-### `totem extract <pr-ids...>`
+### `totem lesson extract <pr-ids...>`
 
 Fetches merged PRs, reads comments, and extracts systemic architectural traps. Automatically infers scope from PR changed files.
 


### PR DESCRIPTION
## Summary

- Renamed the `cli-reference.md` section heading from `totem extract <pr-ids...>` to `totem lesson extract <pr-ids...>` to match the CLI's canonical noun-verb taxonomy
- The `totem lesson compile` heading was already correct (line 149)
- The bare `totem extract` form is deprecated per `lesson.test.ts:214`

Note: `docs/reference/` files also use bare forms (architecture-diagram.md, llm-parameters.md, supported-models.md, workflow-automation.md) but those are outside the scope of this ticket, which targets `cli-reference.md` specifically.

## Test plan

- [x] `totem lint` passes (0 violations)
- [x] `totem verify-manifest` passes
- [x] Pre-push hook passes (format, lint, 2765 tests)

Closes #1377

🤖 Generated with [Claude Code](https://claude.com/claude-code)