### PR TITLE
fix(rules): Phase 1 quality sweep - archive 5 over-broad rules, retire 1 duplicate lesson

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1234,7 +1234,6 @@ Windows requires shell:true for git binary resolution. _(architecture, curated)_
 
 - **Git's porcelain output uses C-style escaping for paths** — Git's porcelain output uses C-style escaping for paths containing special characters or quotes. These must be explicitly decoded (e.g., handling backslashes and quotes) to obtain the actual filesystem path. _(git, parsing)_
 - **When outputting text sourced from external files, PR** — When outputting text sourced from external files, PR content, or LLMs to the terminal, use sanitization functions to prevent terminal injection attacks. This prevents malicious content from executing escaped sequences that could manipulate the terminal state or compromise the user's environment. _(security, cli, terminal)_
-- **Use a '## Lesson <separator> <Heading>' format and 'Tags' field** — Use a `## Lesson <separator> <Heading>` format (where `<separator>` is an em-dash, en-dash, or hyphen) and include a `Tags` field in lesson files to ensure consistency with auto-generated content and improve parsing. The parser accepts all three separator characters equivalently. _(documentation, dx)_
 - **2026-03-05T04:05:14.473Z** — **Pattern:** JSON\.parse\(._(exec|spawn|stdout|stderr)
   **Engine:** regex
   **Scope:** \*\*/_.ts, **/\*.js, !**/_.test.ts, !\*\*/_.spec.ts

--- a/.junie/skills/totem-rules/rules.md
+++ b/.junie/skills/totem-rules/rules.md
@@ -1234,7 +1234,6 @@ Windows requires shell:true for git binary resolution. _(architecture, curated)_
 
 - **Git's porcelain output uses C-style escaping for paths** — Git's porcelain output uses C-style escaping for paths containing special characters or quotes. These must be explicitly decoded (e.g., handling backslashes and quotes) to obtain the actual filesystem path. _(git, parsing)_
 - **When outputting text sourced from external files, PR** — When outputting text sourced from external files, PR content, or LLMs to the terminal, use sanitization functions to prevent terminal injection attacks. This prevents malicious content from executing escaped sequences that could manipulate the terminal state or compromise the user's environment. _(security, cli, terminal)_
-- **Use a '## Lesson <separator> <Heading>' format and 'Tags' field** — Use a `## Lesson <separator> <Heading>` format (where `<separator>` is an em-dash, en-dash, or hyphen) and include a `Tags` field in lesson files to ensure consistency with auto-generated content and improve parsing. The parser accepts all three separator characters equivalently. _(documentation, dx)_
 - **2026-03-05T04:05:14.473Z** — **Pattern:** JSON\.parse\(._(exec|spawn|stdout|stderr)
   **Engine:** regex
   **Scope:** \*\*/_.ts, **/\*.js, !**/_.test.ts, !\*\*/_.spec.ts

--- a/.totem/compile-manifest.json
+++ b/.totem/compile-manifest.json
@@ -1,7 +1,7 @@
 {
-  "compiled_at": "2026-04-12T23:44:27.938Z",
+  "compiled_at": "2026-04-13T02:17:27.733Z",
   "model": "gemini-3-flash-preview",
-  "input_hash": "962e6edf7093b58e93885d82758d01ab988e82c7f8fda675f6c965792ba27ffb",
-  "output_hash": "238b736995609472772a3feef060c9a6650c4091bf2635b3467b707a80100de7",
-  "rule_count": 402
+  "input_hash": "f8d6affddb086b6c96d60e2a6f95e0505f18c2fa3fe277edde2665f3d7594f4e",
+  "output_hash": "26cc98d4fb192880a4367b65eb867559a9c34e7074de2436e7ea5526abcc4544",
+  "rule_count": 401
 }

--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -482,7 +482,9 @@
         "**/*.js",
         "**/*.jsx"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Over-broad: fires on any .split('\\n') regardless of loop context. Blocks legitimate one-shot first-line extraction in catch blocks (#1349). See #1352."
     },
     {
       "lessonHash": "3cbe6d5f6544532c",
@@ -2012,7 +2014,9 @@
         "**/*.js",
         "!**/*.test.ts"
       ],
-      "severity": "error"
+      "severity": "error",
+      "status": "archived",
+      "archivedReason": "Over-broad: fires on any .split('\\n')[0] regardless of context. The lesson is about LLM metadata parsing, not general string splitting. Blocks legitimate error-message first-line extraction. See #1352."
     },
     {
       "lessonHash": "ef230abe26dbdb31",
@@ -3839,7 +3843,9 @@
         "**/*.js",
         "**/*.jsx"
       ],
-      "severity": "error"
+      "severity": "error",
+      "status": "archived",
+      "archivedReason": "Duplicate of dc656c9238a0f80e (same lesson, regex variant). Both fire on any .split('\\n') without loop context. See #1352."
     },
     {
       "lessonHash": "c802b8588ec9d911",
@@ -4150,7 +4156,9 @@
         "**/*.js",
         "!**/*.test.ts"
       ],
-      "severity": "error"
+      "severity": "error",
+      "status": "archived",
+      "archivedReason": "Conflicts with internal error wrapper pattern: bare Error in helpers (safeExec, handleGhError) is intentional because TotemError handles prefixing automatically. The regex cannot distinguish user-facing from internal errors, and forces workarounds (#1329 string concatenation bypass). See #1355."
     },
     {
       "lessonHash": "ba29c80ef7b13c15",
@@ -6411,19 +6419,6 @@
       "engine": "regex",
       "compiledAt": "2026-04-12T15:37:03.920Z",
       "createdAt": "2026-04-12T15:37:03.920Z",
-      "fileGlobs": [
-        "**/*.md"
-      ],
-      "severity": "warning"
-    },
-    {
-      "lessonHash": "6e8a7d02136381a2",
-      "lessonHeading": "Use a '## Lesson <separator> <Heading>' format and 'Tags' field",
-      "pattern": "^## Lesson(?! [—–-] .+)",
-      "message": "Lesson headings must use the format '## Lesson <separator> <Heading>' where separator is an em-dash (—), en-dash (–), or hyphen (-)",
-      "engine": "regex",
-      "compiledAt": "2026-04-12T15:37:04.023Z",
-      "createdAt": "2026-04-12T15:37:04.023Z",
       "fileGlobs": [
         "**/*.md"
       ],

--- a/.totem/lessons/lesson-874db909.md
+++ b/.totem/lessons/lesson-874db909.md
@@ -1,5 +1,0 @@
-## Lesson — Use a '## Lesson <separator> <Heading>' format and 'Tags' field
-
-**Tags:** documentation, dx
-
-Use a `## Lesson <separator> <Heading>` format (where `<separator>` is an em-dash, en-dash, or hyphen) and include a `Tags` field in lesson files to ensure consistency with auto-generated content and improve parsing. The parser accepts all three separator characters equivalently.


### PR DESCRIPTION
## Summary

Bundles three rule-quality tickets from the 1.14.6 quality sweep:

- **#1380**: Retired duplicate lesson `lesson-874db909.md` and archived its compiled rule. The surviving rule (`7e3eefeaa85403d0`) covers the same heading-separator check.
- **#1352**: Archived 3 over-broad Pipeline 5 `split()` rules that blocked legitimate first-line extraction in catch blocks. All three fire on any `.split('\n')` without loop context.
- **#1355**: Archived the "Standardize exception messages" rule. Conflicts with intentional internal error wrappers (`safeExec`, `handleGhError`) where bare `Error` is correct and `TotemError` handles prefixing automatically.

401 total rules (389 active, 12 archived).

## Test plan

- [x] `totem lint` passes (0 violations, 389 active rules)
- [x] `totem verify-manifest` passes
- [x] Pre-push hook passes (format, lint, 2765 tests)

Closes #1380
Closes #1352
Closes #1355

🤖 Generated with [Claude Code](https://claude.com/claude-code)