### PR TITLE
fix(rules): archive over-broad throw $ERR rules (upgradeTarget: compound)

### DIFF
--- a/.totem/compile-manifest.json
+++ b/.totem/compile-manifest.json
@@ -1,7 +1,7 @@
 {
-  "compiled_at": "2026-04-13T03:28:17.703Z",
+  "compiled_at": "2026-04-13T03:46:43.226Z",
   "model": "gemini-3-flash-preview",
   "input_hash": "f8d6affddb086b6c96d60e2a6f95e0505f18c2fa3fe277edde2665f3d7594f4e",
-  "output_hash": "f1fdb0ae1e3a59a8ca1ecf2f623d49d6b843b53b9f5ffddcba480b5d30c0e586",
+  "output_hash": "4a2dc5db7a6d8ac015df27b330ae8a63bb7a8d252c4a29e590ad7ede9806a078",
   "rule_count": 403
 }

--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -2291,7 +2291,9 @@
         "!**/*.test.*",
         "!**/*.spec.*"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Over-broad: throw $ERR matches every throw statement. The intent is to flag re-throws in CLI handlers, but the pattern cannot distinguish re-throws from intentional error construction. upgradeTarget: compound (needs inside: catch constraint per Proposal 226). See #1218."
     },
     {
       "lessonHash": "f4b44468f7f5b46a",
@@ -5386,7 +5388,9 @@
         "packages/cli/src/commands/**/*.ts",
         "!**/*.test.*"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Duplicate of 95e66fb1 (same throw $ERR pattern, narrower scope). Both over-broad. upgradeTarget: compound. See #1218."
     },
     {
       "lessonHash": "128c55f185c04c6a",


### PR DESCRIPTION
## Summary

- Archived 2 rules with pattern `throw $ERR` that match every throw statement instead of only re-throws inside catch blocks
- The intent (prefer exit codes over re-throws in CLI handlers) requires a compound ast-grep rule with `inside: catch` constraint that flat patterns cannot express
- Marked with `upgradeTarget: compound` per Proposal 226 convention
- Left the structurally-scoped variant (`function $NAME(): void { ...; throw $ERR; }`) active since it has enough context to be useful

403 total rules (388 active, 15 archived).

## Test plan

- [x] `totem lint` passes (0 violations, 388 active rules)
- [x] `totem verify-manifest` passes
- [x] Pre-push hook passes (format, lint, 2766 tests)

Closes #1218

🤖 Generated with [Claude Code](https://claude.com/claude-code)