### PR TITLE
chore: 1.14.6 release changeset

### DIFF
--- a/.changeset/release-1-14-6-quality-sweep.md
+++ b/.changeset/release-1-14-6-quality-sweep.md
@@ -5,16 +5,20 @@
 Quality sweep Phase 1-2 and voice compliance fixes
 
 **Voice compliance (3 PRs):**
+
 - Reconcile lesson heading separator lint rules with parser flexibility (#1379, closes #1374). The compiler had produced a broken negative lookahead (`(?! .+[chars] .+)` instead of `(?! [chars] .+)`); hand-corrected.
 - Strip em dashes from `totem lint` verdict and violation output (#1382, closes #1373). Updated README code-fence examples to match.
 - Rename deprecated bare `totem extract` heading in cli-reference.md to canonical `totem lesson extract` (#1383, closes #1377).
 
 **Quality sweep Phase 1 (#1387, closes #1380, #1352, #1355):**
+
 - Archive 5 over-broad compiled rules and retire 1 duplicate lesson.
 
 **Quality sweep Phase 2:**
+
 - Escape glob wildcards (`*`) and underscores (`_`) in the export markdown renderer to prevent emphasis corruption in copilot/junie instruction files (#1388, closes #1386).
 - Archive 2 over-broad `throw $ERR` rules that need compound `inside: catch` ast-grep constraints (#1389, closes #1218). Tagged with `upgradeTarget: compound` per Proposal 226.
 
 **Postmerge (2 PRs):**
+
 - 31 new lessons extracted from the 1.14.3-1.14.5 afternoon marathon and voice scrub PRs (#1384, #1385). 3 rules compiled (1 kept, 2 archived for over-breadth).

--- a/.changeset/release-1-14-6-quality-sweep.md
+++ b/.changeset/release-1-14-6-quality-sweep.md
@@ -1,0 +1,20 @@
+---
+'@mmnto/totem': patch
+---
+
+Quality sweep Phase 1-2 and voice compliance fixes
+
+**Voice compliance (3 PRs):**
+- Reconcile lesson heading separator lint rules with parser flexibility (#1379, closes #1374). The compiler had produced a broken negative lookahead (`(?! .+[chars] .+)` instead of `(?! [chars] .+)`); hand-corrected.
+- Strip em dashes from `totem lint` verdict and violation output (#1382, closes #1373). Updated README code-fence examples to match.
+- Rename deprecated bare `totem extract` heading in cli-reference.md to canonical `totem lesson extract` (#1383, closes #1377).
+
+**Quality sweep Phase 1 (#1387, closes #1380, #1352, #1355):**
+- Archive 5 over-broad compiled rules and retire 1 duplicate lesson.
+
+**Quality sweep Phase 2:**
+- Escape glob wildcards (`*`) and underscores (`_`) in the export markdown renderer to prevent emphasis corruption in copilot/junie instruction files (#1388, closes #1386).
+- Archive 2 over-broad `throw $ERR` rules that need compound `inside: catch` ast-grep constraints (#1389, closes #1218). Tagged with `upgradeTarget: compound` per Proposal 226.
+
+**Postmerge (2 PRs):**
+- 31 new lessons extracted from the 1.14.3-1.14.5 afternoon marathon and voice scrub PRs (#1384, #1385). 3 rules compiled (1 kept, 2 archived for over-breadth).


### PR DESCRIPTION
## Summary

- Adds the changeset for 1.14.6 (patch bump for all three packages in the fixed group).
- Release content: voice compliance fixes (3 PRs), quality sweep Phase 1-2 (3 PRs), postmerge lessons (2 PRs), plus docs and strategy pointer bumps.
- Closes #1374, #1373, #1377, #1380, #1352, #1355, #1386, #1218

## What ships in 1.14.6

| PR | Summary |
|---|---|
| #1379 | Lesson heading separator rules reconciled with parser flexibility |
| #1382 | Em dashes stripped from `totem lint` output |
| #1383 | Deprecated bare `totem extract` heading renamed |
| #1384 | Postmerge: 25 lessons, 1 rule kept from afternoon marathon |
| #1385 | Postmerge: 6 lessons from voice scrub PRs |
| #1387 | Archive 5 over-broad rules, retire 1 duplicate lesson |
| #1388 | Export pipeline glob/emphasis escaping fix |
| #1389 | Archive 2 over-broad `throw $ERR` rules |

## Test plan

- [x] `pnpm run format:check` passes
- [x] 2766 tests pass
- [x] `totem lint` passes (388 active rules)
- [x] `totem verify-manifest` passes via pre-push hook
- [ ] CI passes on this PR
- [ ] Merge triggers changesets bot "Version Packages" PR
- [ ] Merge Version Packages PR triggers npm publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)