### PR TITLE
chore: 1.14.7 tactical cleanup (#1391, #1350, #1354, #1357)

### DIFF
--- a/.claude/docs/contributing.md
+++ b/.claude/docs/contributing.md
@@ -6,10 +6,25 @@
 - Use `Closes #NNN` in PR descriptions to auto-close issues.
 - Squash merge to main (user preference).
 
-## GCA (Gemini Code Assist)
+## PR Review Bot Protocol
 
-- ONE consolidated `@gemini-code-assist` comment per PR (not per finding).
-- GCA decline: add lesson with `review-guidance` tag + update `.gemini/styleguide.md` §6.
+Two bots review PRs. Their interaction models are completely different -- confusing them causes missed feedback or duplicate noise.
+
+### CodeRabbit (CR)
+
+- Reply inline to any CR comment thread freely.
+- CR reads every reply in its thread automatically -- no tagging needed.
+- Supports `@coderabbitai fix` commands to trigger automated fixes.
+- One reply per finding is fine; multiple back-and-forth exchanges are normal.
+
+### Gemini Code Assist (GCA)
+
+- ONE batched top-level PR comment per PR. Never reply inline to individual GCA comment threads.
+- Every GCA reply MUST contain `@gemini-code-assist` -- GCA only sees messages that tag it explicitly.
+- Batch all findings into a single numbered-list response: address each finding in order.
+- GCA decline: add a lesson with `review-guidance` tag + update `.gemini/styleguide.md` §6.
+
+> **WARNING:** Do not apply CR habits to GCA. Inline thread replies to GCA threads are invisible to GCA and will be silently ignored. Always compose one top-level comment with `@gemini-code-assist` and the full response.
 
 ## Publishing
 

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -101,7 +101,16 @@ All overrides are recorded in the Trap Ledger (`.totem/ledger/events.ndjson`) fo
 - Library code (`@mmnto/totem` core) uses `onWarn` callbacks, never direct `console.warn`.
 - **Error cause chains (ES2022):** When re-throwing errors in `catch` blocks, always pass the original error as the `cause` property: `throw new TotemError('...', '...', err)`. NEVER concatenate `err.message` into a new error string — this destroys the original stack trace. The `handleError` debug logger traverses `.cause` chains automatically.
 
-## 10. Hash Conventions (Do Not Flag as Mismatches)
+## 10. PR Review Reply Protocol
+
+Responses to GCA findings follow a batched model by design, not because of a limitation.
+
+- You will receive ONE top-level comment per PR that addresses all findings. It will be a numbered list, one item per finding, in the order you raised them.
+- This is the established protocol. Do not flag the absence of inline replies to individual threads as missing responses.
+- Inline thread replies from this project's agents are directed at CodeRabbit (CR), which uses a different interaction model. CR and GCA coexist on the same PRs but receive replies through separate channels.
+- If a finding is declined, you will see a `review-guidance` tagged lesson added and this styleguide updated in §6.
+
+## 11. Hash Conventions (Do Not Flag as Mismatches)
 
 Totem uses **two independent hash functions** for lessons, computed over different
 inputs. They are NOT supposed to match — this is the established convention since

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ After >15 turns of code changes: run `totem status`, re-query strategy ADRs for 
 
 ## Detailed Docs (read when relevant)
 
-- [Contributing rules](.claude/docs/contributing.md) — GCA replies, AI_PROMPT_BLOCK, changesets
+- [Contributing rules](.claude/docs/contributing.md) — PR bot protocol (CR/GCA), AI_PROMPT_BLOCK, changesets
 - [Architecture context](.claude/docs/architecture.md) — partitions, boundary parameter, linked indexes
 - [Agent workflow](.claude/docs/agent-workflow.md) — dispatch templates, delegation rules
 - Strategy ADRs: query `mcp__totem-strategy__search_knowledge`

--- a/packages/cli/src/adapters/gh-utils.ts
+++ b/packages/cli/src/adapters/gh-utils.ts
@@ -2,7 +2,13 @@
 
 import { z } from 'zod';
 
-import { safeExec, TotemConfigError, TotemError, TotemParseError } from '@mmnto/totem';
+import {
+  describeSafeExecError,
+  safeExec,
+  TotemConfigError,
+  TotemError,
+  TotemParseError,
+} from '@mmnto/totem';
 
 import { GH_TIMEOUT_MS } from '../utils.js';
 
@@ -35,10 +41,10 @@ export function handleGhError(err: unknown, context: string): never {
     );
   }
   // safeExec wraps child-process errors: message includes stderr, cause is the original.
-  // Check both the wrapper and the cause so detection (ENOENT, rate-limit) works regardless.
+  // describeSafeExecError unrolls the cause chain so detection (ENOENT, rate-limit) works
+  // regardless of where the relevant text lives in the chain.
   const wrapperMsg = err instanceof Error ? err.message : String(err);
-  const causeMsg = err instanceof Error && err.cause instanceof Error ? err.cause.message : '';
-  const msg = `${wrapperMsg}\n${causeMsg}`;
+  const msg = describeSafeExecError(err);
   if (msg.includes('ENOENT')) {
     throw new TotemConfigError(
       'GitHub CLI (gh) is required but was not found.',

--- a/packages/cli/src/commands/compile-noop-refresh.test.ts
+++ b/packages/cli/src/commands/compile-noop-refresh.test.ts
@@ -321,3 +321,97 @@ describe('compileCommand no-op manifest refresh (#1337)', () => {
     expect(fs.readFileSync(manifestPath, 'utf-8')).toBe(malformed);
   });
 });
+
+// ─── ensureLessonsDir guard (#1350) ──────────────────
+//
+// The NO_LESSONS_DIR guard fires in the no-op branch when lessonsDir is
+// absent or is not a directory at the time generateInputHash is called.
+// The realistic trigger is a workspace that populates lessons from the
+// legacy .totem/lessons.md file so readAllLessons returns non-empty, but
+// has no .totem/lessons/ directory for generateInputHash to hash.
+//
+// The helper that writes the legacy file and config but skips lessons/:
+
+function setupWorkspaceLegacyLessons(tmpDir: string, lessonMarkdownContent: string): void {
+  fs.writeFileSync(
+    path.join(tmpDir, 'totem.config.ts'),
+    [
+      'export default {',
+      '  targets: [{ glob: "**/*.ts", type: "code", strategy: "typescript-ast" }],',
+      '  totemDir: ".totem",',
+      '  orchestrator: {',
+      '    provider: "shell",',
+      '    command: "echo should-never-run",',
+      '    defaultModel: "test-model",',
+      '  },',
+      '};',
+      '',
+    ].join('\n'),
+    'utf-8',
+  );
+
+  const totemDir = path.join(tmpDir, '.totem');
+  fs.mkdirSync(totemDir, { recursive: true });
+
+  // Write lessons via the legacy .totem/lessons.md path so readAllLessons
+  // returns non-empty without a lessons/ directory being present.
+  fs.writeFileSync(path.join(totemDir, 'lessons.md'), lessonMarkdownContent, 'utf-8');
+
+  // Pre-populate compiled-rules.json so every lesson is already "compiled"
+  // (no actual compilation runs) and the no-op branch is entered.
+  const now = '2026-04-13T00:00:00Z';
+  fs.writeFileSync(
+    path.join(totemDir, 'compiled-rules.json'),
+    JSON.stringify(
+      {
+        version: 1,
+        rules: [],
+        nonCompilable: [],
+      },
+      null,
+      2,
+    ) + '\n',
+    'utf-8',
+  );
+
+  // No compile-manifest.json and no lessons/ directory - the guard should
+  // fire before generateInputHash attempts to hash a non-existent directory.
+}
+
+describe('ensureLessonsDir guard (#1350)', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-lessons-dir-guard-'));
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    cleanTmpDir(tmpDir);
+  });
+
+  it('throws NO_LESSONS_DIR when lessons directory is missing during no-op compile', async () => {
+    // Lessons come from the legacy lessons.md so readAllLessons returns
+    // non-empty and the NO_LESSONS check is bypassed. The no-op branch is
+    // entered (toCompile.length === 0 since all rules are pre-populated or
+    // there are none to add). generateInputHash(lessonsDir) then hits the
+    // ensureLessonsDir guard because .totem/lessons/ was never created.
+    const heading = 'Use err in catch';
+    const body = 'Do not use the identifier "error" in catch blocks.';
+    const lessonContent = `## Lesson - ${heading}\n\n**Tags:** test\n\n${body}\n`;
+
+    setupWorkspaceLegacyLessons(tmpDir, lessonContent);
+
+    // No .totem/lessons/ directory exists - guard must fire.
+    const totemDir = path.join(tmpDir, '.totem');
+    expect(fs.existsSync(path.join(totemDir, 'lessons'))).toBe(false);
+
+    await expect(compileCommand({})).rejects.toMatchObject({
+      code: 'NO_LESSONS_DIR',
+      message: expect.stringContaining('Lessons directory not found'),
+    });
+  });
+});

--- a/packages/cli/src/commands/compile-noop-refresh.test.ts
+++ b/packages/cli/src/commands/compile-noop-refresh.test.ts
@@ -359,7 +359,6 @@ function setupWorkspaceLegacyLessons(tmpDir: string, lessonMarkdownContent: stri
 
   // Pre-populate compiled-rules.json so every lesson is already "compiled"
   // (no actual compilation runs) and the no-op branch is entered.
-  const now = '2026-04-13T00:00:00Z';
   fs.writeFileSync(
     path.join(totemDir, 'compiled-rules.json'),
     JSON.stringify(

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -267,6 +267,20 @@ export async function compileCommand(options: CompileOptions): Promise<UpgradeOu
     writeCompileManifest,
   } = await import('@mmnto/totem');
 
+  // Guard: throw a specific NO_LESSONS_DIR error instead of a generic
+  // TotemParseError when lessonsDir is absent or is not a directory.
+  // Called before both generateInputHash sites so both branches get the
+  // same explicit error with the same recovery hint.
+  const ensureLessonsDir = (dir: string): void => {
+    if (!fs.existsSync(dir) || !fs.statSync(dir).isDirectory()) {
+      throw new TotemError(
+        'NO_LESSONS_DIR',
+        `Lessons directory not found: ${dir}`,
+        'Run `totem extract <pr>` to create lessons, or create .totem/lessons/ manually.',
+      );
+    }
+  };
+
   const cwd = process.cwd();
   const configPath = resolveConfigPath(cwd);
   if (isGlobalConfigPath(configPath)) {
@@ -522,6 +536,7 @@ export async function compileCommand(options: CompileOptions): Promise<UpgradeOu
         // that invalidates mtime-based caches downstream.
         const lessonsDir = path.join(totemDir, 'lessons');
         const manifestPath = path.join(totemDir, 'compile-manifest.json');
+        ensureLessonsDir(lessonsDir);
         const currentInputHash = generateInputHash(lessonsDir);
         let existingManifestInputHash: string | null = null;
         try {
@@ -944,6 +959,7 @@ export async function compileCommand(options: CompileOptions): Promise<UpgradeOu
         // re-import needed here.
         const lessonsDir = path.join(totemDir, 'lessons');
         const manifestPath = path.join(totemDir, 'compile-manifest.json');
+        ensureLessonsDir(lessonsDir);
         const inputHash = generateInputHash(lessonsDir);
         const outputHash = generateOutputHash(rulesPath);
         writeCompileManifest(manifestPath, {

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -276,7 +276,7 @@ export async function compileCommand(options: CompileOptions): Promise<UpgradeOu
       throw new TotemError(
         'NO_LESSONS_DIR',
         `Lessons directory not found: ${dir}`,
-        'Run `totem extract <pr>` to create lessons, or create .totem/lessons/ manually.',
+        'Run `totem lesson extract <pr>` to create lessons, or create .totem/lessons/ manually.',
       );
     }
   };

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -19,6 +19,7 @@ export type TotemErrorCode =
   | 'SYNC_FAILED'
   | 'GIT_FAILED'
   | 'NO_LESSONS'
+  | 'NO_LESSONS_DIR'
   | 'NO_RULES'
   | 'SHIELD_FAILED'
   | 'LINT_LESSONS_FAILED'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -310,7 +310,7 @@ export { appendLedgerEvent, LedgerEventSchema, readLedgerEvents } from './ledger
 
 // Shell execution (cross-platform safe wrapper)
 export type { SafeExecOptions } from './sys/exec.js';
-export { safeExec } from './sys/exec.js';
+export { describeSafeExecError, safeExec } from './sys/exec.js';
 
 // Git utilities (pure helpers — no CLI dependencies)
 export {

--- a/packages/core/src/ingest/file-resolver.test.ts
+++ b/packages/core/src/ingest/file-resolver.test.ts
@@ -2,34 +2,12 @@ import * as crossSpawn from 'cross-spawn';
 import { globSync } from 'glob';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { fail, ok } from '../test-utils.js';
 import { getChangedFiles, getHeadSha, resolveFiles } from './file-resolver.js';
 
 vi.mock('cross-spawn', () => ({
   sync: vi.fn(),
 }));
-
-/**
- * Post-mmnto/totem#1329: safeExec wraps cross-spawn.sync, which returns
- * a SpawnSyncReturns<Buffer>-shaped object instead of the legacy
- * execFileSync string-or-throw contract. These helpers let each test
- * describe the intended subprocess outcome (`ok('stdout')` for a clean
- * exit, `fail(error)` for a spawn-level failure) without spelling out
- * the full return shape.
- */
-// Return types are inferred deliberately. The fail() helper's inferred
-// shape has an `error` property that matches cross-spawn's
-// SpawnSyncReturns field name, but spelling that property out in an
-// explicit return type annotation trips the repo's `id-match` ESLint
-// rule (which forbids the literal identifier `error`). Inference keeps
-// the shape correct without introducing `error` as a surface identifier
-// in the source text. Callers coerce via `as never` at the call site.
-function ok(stdout: string) {
-  return { status: 0, stdout, stderr: '', signal: null };
-}
-
-function fail(err: Error) {
-  return { status: null, stdout: '', stderr: '', signal: null, error: err };
-}
 
 vi.mock('glob', () => ({
   globSync: vi.fn(() => []),

--- a/packages/core/src/ingest/file-resolver.ts
+++ b/packages/core/src/ingest/file-resolver.ts
@@ -4,7 +4,7 @@ import { globSync } from 'glob';
 
 import type { IngestTarget } from '../config-schema.js';
 import { DEFAULT_IGNORE_PATTERNS } from '../config-schema.js';
-import { safeExec } from '../sys/exec.js';
+import { describeSafeExecError, safeExec } from '../sys/exec.js';
 
 export interface ResolvedFile {
   absolutePath: string;
@@ -59,7 +59,7 @@ function getGitNonIgnoredFiles(
 
     return files;
   } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : String(err);
+    const errorMsg = describeSafeExecError(err);
     const msg =
       errorMsg.includes('ENOENT') || errorMsg.includes('not found')
         ? `Command 'git' not found. Cannot use .gitignore for filtering. Falling back to ignorePatterns only.`
@@ -139,9 +139,7 @@ export function getChangedFiles(
       });
     } catch (err) {
       if (onWarn) {
-        onWarn(
-          `Failed to list untracked files: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        onWarn(`Failed to list untracked files: ${describeSafeExecError(err)}`);
       }
     }
 
@@ -154,7 +152,7 @@ export function getChangedFiles(
 
     return [...paths];
   } catch (err) {
-    const msg = `Failed to get changed files from git. Error: ${err instanceof Error ? err.message : String(err)}`;
+    const msg = `Failed to get changed files from git. Error: ${describeSafeExecError(err)}`;
     if (onWarn) {
       onWarn(msg);
     }
@@ -172,7 +170,7 @@ export function getHeadSha(projectRoot: string, onWarn?: (msg: string) => void):
     });
   } catch (err) {
     if (onWarn) {
-      onWarn(`Failed to read HEAD SHA: ${err instanceof Error ? err.message : String(err)}`);
+      onWarn(`Failed to read HEAD SHA: ${describeSafeExecError(err)}`);
     }
     return null;
   }

--- a/packages/core/src/sys/exec.test.ts
+++ b/packages/core/src/sys/exec.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { safeExec } from './exec.js';
+import { describeSafeExecError, safeExec } from './exec.js';
 
 // Long-running interval used to ensure the child process outlives the
 // timeout window. Any value safely larger than TIMEOUT_MS works; 30s is
@@ -9,6 +9,30 @@ const LONG_RUNNING_INTERVAL_MS = 30_000;
 // Timeout for the test that asserts safeExec honors its timeout option.
 // Short enough to keep the suite fast.
 const TIMEOUT_TEST_MS = 100;
+
+describe('describeSafeExecError', () => {
+  it('returns the raw string for non-Error input', () => {
+    expect(describeSafeExecError('raw string error')).toBe('raw string error');
+    expect(describeSafeExecError(42)).toBe('42');
+  });
+
+  it('returns wrapper message when there is no cause', () => {
+    const err = new Error('spawn failed');
+    expect(describeSafeExecError(err)).toBe('spawn failed');
+  });
+
+  it('appends cause message in parentheses when cause exists', () => {
+    const cause = new Error('spawn gh ENOENT');
+    const wrapper = new Error('Command failed: gh', { cause });
+    expect(describeSafeExecError(wrapper)).toBe('Command failed: gh (spawn gh ENOENT)');
+  });
+
+  it('deduplicates when cause message is already in wrapper', () => {
+    const cause = new Error('spawn gh ENOENT');
+    const wrapper = new Error('Command failed: gh: spawn gh ENOENT', { cause });
+    expect(describeSafeExecError(wrapper)).toBe('Command failed: gh: spawn gh ENOENT');
+  });
+});
 
 describe('safeExec', () => {
   it('executes a command and returns trimmed output', () => {

--- a/packages/core/src/sys/exec.ts
+++ b/packages/core/src/sys/exec.ts
@@ -112,30 +112,13 @@ function wrapSpawnError(command: string, args: string[], result: SpawnResult): E
   const status = result.status;
   const signal = result.signal;
 
-  // Prefer stderr in the message body (matches the legacy format). Fall
-  // back to result.error.message for spawn-level failures with empty
-  // stderr (e.g., ENOENT), and finally to a generic failure line.
-  //
-  // Deliberate: result.error.message is inlined into the wrapper
-  // message by design, not in violation of the repo's general rule 102
-  // ("do not concatenate err.message into a new error string"). Rule
-  // 102 targets the case where a re-thrower concatenates without
-  // preserving cause, which destroys the original stack trace. This
-  // code preserves `result.error` via `{ cause }` below, so the stack
-  // trace is intact on the chain. The concat is also load-bearing for
-  // two existing callers in `packages/core/src/ingest/file-resolver.ts`
-  // (`getHeadSha` and `getChangedFiles`) that build onWarn messages
-  // from `err.message` without walking the cause chain. Stripping the
-  // concat here would silently degrade their warn text to "spawn
-  // failed" with the real reason only reachable via the cause chain.
-  // The cascading migration to walk cause in every safeExec caller is
-  // tracked as follow-up work, not scope for the mmnto/totem#1329
-  // security fix.
+  // mmnto/totem#1357: cause message no longer inlined. Callers use
+  // describeSafeExecError() to unroll the chain when needed.
   let detail: string;
   if (trimmedStderr.length > 0) {
     detail = `\n${trimmedStderr}`;
   } else if (result.error) {
-    detail = `: ${result.error.message}`;
+    detail = ': spawn failed';
   } else if (signal) {
     detail = `: killed by ${signal}`;
   } else {
@@ -190,4 +173,22 @@ function bufferOrStringToString(value: string | Buffer | null | undefined): stri
   if (value == null) return '';
   if (typeof value === 'string') return value;
   return value.toString('utf-8');
+}
+
+/**
+ * Build a human-readable description from a safeExec error, unrolling
+ * the cause chain so callers don't need to walk it manually.
+ *
+ * Deduplicates: if the cause message is already embedded in the wrapper
+ * (the pre-migration concat behavior), it is not appended again.
+ */
+export function describeSafeExecError(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  const wrapperMsg = err.message;
+  if (!(err.cause instanceof Error)) return wrapperMsg;
+  const causeMsg = err.cause.message;
+  // Deduplicate: if wrapper already contains the cause (pre-migration),
+  // don't double-print.
+  if (wrapperMsg.includes(causeMsg)) return wrapperMsg;
+  return `${wrapperMsg} (${causeMsg})`;
 }

--- a/packages/core/src/sys/git.test.ts
+++ b/packages/core/src/sys/git.test.ts
@@ -5,6 +5,7 @@ vi.mock('cross-spawn', () => ({
   sync: vi.fn(),
 }));
 
+import { fail, ok } from '../test-utils.js';
 import {
   extractChangedFiles,
   filterDiffByPatterns,
@@ -14,27 +15,6 @@ import {
   inferScopeFromFiles,
   isFileDirty,
 } from './git.js';
-
-/**
- * Post-mmnto/totem#1329: safeExec wraps cross-spawn.sync instead of
- * child_process.execFileSync. These helpers let each test describe the
- * intended subprocess outcome without spelling out the full
- * SpawnSyncReturns shape on every call.
- */
-// Return types are inferred deliberately. The fail() helper's inferred
-// shape has an `error` property that matches cross-spawn's
-// SpawnSyncReturns field name, but spelling that property out in an
-// explicit return type annotation trips the repo's `id-match` ESLint
-// rule (which forbids the literal identifier `error`). Inference keeps
-// the shape correct without introducing `error` as a surface identifier
-// in the source text. Callers coerce via `as never` at the call site.
-function ok(stdout: string) {
-  return { status: 0, stdout, stderr: '', signal: null };
-}
-
-function fail(err: Error) {
-  return { status: null, stdout: '', stderr: '', signal: null, error: err };
-}
 
 describe('getLatestTag', () => {
   beforeEach(() => vi.clearAllMocks());

--- a/packages/core/src/test-utils.ts
+++ b/packages/core/src/test-utils.ts
@@ -8,3 +8,21 @@ export function cleanTmpDir(dir: string | undefined): void {
   if (!dir) return;
   fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
 }
+
+// ---- cross-spawn mock helpers ----
+//
+// Shared mock return values for cross-spawn.sync. The `fail` return
+// shape has an `error` property that matches cross-spawn's
+// SpawnSyncReturns field name, but spelling that property out in an
+// explicit return type annotation trips the repo's `id-match` ESLint
+// rule (which forbids the literal identifier `error`). Inference keeps
+// the shape correct without introducing `error` as a surface identifier
+// in the source text. Callers coerce via `as never` at the call site.
+
+export function ok(stdout: string) {
+  return { status: 0, stdout, stderr: '', signal: null };
+}
+
+export function fail(err: Error) {
+  return { status: null, stdout: '', stderr: '', signal: null, error: err };
+}


### PR DESCRIPTION
## Summary

Bundled tactical cleanup for the 1.14.7 milestone. Four independent fixes:

- **#1391** - Codify PR review bot reply protocol (CR vs GCA) in contributing docs, gemini styleguide, and CLAUDE.md pointers
- **#1350** - Add `NO_LESSONS_DIR` guard before both `generateInputHash` calls in compile command, with test
- **#1354** - Extract duplicated `ok()`/`fail()` spawn mock helpers from two test files into shared `test-utils.ts`
- **#1357** - Add `describeSafeExecError` helper, migrate 4 file-resolver callers + gh-utils to use it, remove message concatenation from `wrapSpawnError` (rule 102 compliance)

Closes #1391
Closes #1350
Closes #1354
Closes #1357

## Test plan

- [x] 2771 tests pass (5 new: 1 for NO_LESSONS_DIR guard, 4 for describeSafeExecError)
- [x] `totem lint` passes (388 rules, 0 errors)
- [x] `totem review` passes (0 findings)
- [x] `pnpm run format:check` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)