### PR TITLE
feat(cli): mesh completion - search federation + doctor health check (#1307, #1308)

### DIFF
--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -14,6 +14,7 @@ import {
   checkEmbeddingConfig,
   checkGitHooks,
   checkIndex,
+  checkLinkedIndexes,
   checkSecretLeaks,
   checkSecretsFileTracked,
   checkUpgradeCandidates,
@@ -300,7 +301,7 @@ describe('doctorCommand', () => {
   it('runs without throwing', async () => {
     const results = await doctorCommand();
     expect(results).toBeDefined();
-    expect(results.length).toBe(8);
+    expect(results.length).toBe(9);
   });
 
   it('returns correct check names', async () => {
@@ -311,6 +312,7 @@ describe('doctorCommand', () => {
     expect(names).toContain('Git Hooks');
     expect(names).toContain('Embedding');
     expect(names).toContain('Index');
+    expect(names).toContain('Linked Indexes');
     expect(names).toContain('Secret Scan');
     expect(names).toContain('Secrets File Security');
     expect(names).toContain('Upgrade Candidates');
@@ -354,6 +356,7 @@ describe('doctorCommand output', () => {
     expect(output).toContain('Git Hooks');
     expect(output).toContain('Embedding');
     expect(output).toContain('Index');
+    expect(output).toContain('Linked Indexes');
     expect(output).toContain('Secret Scan');
     expect(output).toContain('Secrets File Security');
     expect(output).toContain('Upgrade Candidates');
@@ -1246,5 +1249,104 @@ describe('runSelfHealing', () => {
     const committedRules = JSON.parse(showResult.stdout ?? '');
     expect(committedRules.rules[0].status).toBe('archived');
     expect(committedRules.rules[0].archivedReason).toMatch(/after \d+ days/);
+  });
+});
+
+// ─── Linked indexes health check (#1308) ────────────────
+
+describe('checkLinkedIndexes (#1308)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  it('returns skip when no linkedIndexes configured', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'totem.config.ts'),
+      `export default {
+  targets: [{ glob: '**/*.ts', type: 'code', strategy: 'typescript-ast' }],
+  totemDir: '.totem',
+  embedding: { provider: 'gemini', model: 'gemini-embedding-2-preview', dimensions: 768 },
+};`,
+    );
+    const result = checkLinkedIndexes(tmpDir);
+    expect(result.status).toBe('skip');
+    expect(result.name).toBe('Linked Indexes');
+  });
+
+  it('returns skip when host has no embedding provider', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'totem.config.ts'),
+      `export default {
+  targets: [{ glob: '**/*.ts', type: 'code', strategy: 'typescript-ast' }],
+  totemDir: '.totem',
+  linkedIndexes: ['../other-repo'],
+};`,
+    );
+    const result = checkLinkedIndexes(tmpDir);
+    expect(result.status).toBe('skip');
+    expect(result.message).toContain('Lite tier');
+  });
+
+  it('returns pass when linked index is reachable', () => {
+    const linkedDir = makeTmpDir();
+    try {
+      // Set up the linked repo with a config and .lancedb
+      fs.writeFileSync(
+        path.join(linkedDir, 'totem.config.ts'),
+        `export default {
+  targets: [{ glob: '**/*.ts', type: 'code', strategy: 'typescript-ast' }],
+  totemDir: '.totem',
+  embedding: { provider: 'gemini', model: 'gemini-embedding-2-preview', dimensions: 768 },
+};`,
+      );
+      const lanceDir = path.join(linkedDir, '.lancedb');
+      fs.mkdirSync(lanceDir, { recursive: true });
+      fs.writeFileSync(path.join(lanceDir, 'data.lance'), 'placeholder');
+
+      // Escape backslashes for Windows paths in the config template
+      const escapedPath = linkedDir.replace(/\\/g, '\\\\');
+      fs.writeFileSync(
+        path.join(tmpDir, 'totem.config.ts'),
+        `export default {
+  targets: [{ glob: '**/*.ts', type: 'code', strategy: 'typescript-ast' }],
+  totemDir: '.totem',
+  embedding: { provider: 'gemini', model: 'gemini-embedding-2-preview', dimensions: 768 },
+  linkedIndexes: ['${escapedPath}'],
+};`,
+      );
+
+      const result = checkLinkedIndexes(tmpDir);
+      expect(result.status).toBe('pass');
+      expect(result.name).toBe('Linked Indexes');
+      expect(result.message).toContain('1 configured');
+      expect(result.message).toContain('1 reachable');
+    } finally {
+      cleanTmpDir(linkedDir);
+    }
+  });
+
+  it('returns warn when linked index path does not exist', () => {
+    const nonExistentPath = path.join(tmpDir, 'no-such-repo');
+    const escapedPath = nonExistentPath.replace(/\\/g, '\\\\');
+    fs.writeFileSync(
+      path.join(tmpDir, 'totem.config.ts'),
+      `export default {
+  targets: [{ glob: '**/*.ts', type: 'code', strategy: 'typescript-ast' }],
+  totemDir: '.totem',
+  embedding: { provider: 'gemini', model: 'gemini-embedding-2-preview', dimensions: 768 },
+  linkedIndexes: ['${escapedPath}'],
+};`,
+    );
+
+    const result = checkLinkedIndexes(tmpDir);
+    expect(result.status).toBe('warn');
+    expect(result.name).toBe('Linked Indexes');
+    expect(result.remediation).toContain('does not exist');
   });
 });

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -319,6 +319,116 @@ export function checkIndex(cwd: string, lanceDir = '.lancedb'): DiagnosticResult
   };
 }
 
+export function checkLinkedIndexes(cwd: string): DiagnosticResult {
+  const configResult = readConfigFile(cwd);
+  if (!configResult) {
+    return {
+      name: 'Linked Indexes',
+      status: 'skip',
+      message: 'No config (skipped)',
+    };
+  }
+
+  const [, content] = configResult;
+
+  if (!/linkedIndexes:\s*\[/.test(content)) {
+    return {
+      name: 'Linked Indexes',
+      status: 'skip',
+      message: '0 configured',
+    };
+  }
+
+  if (!hasEmbeddingProvider(content)) {
+    return {
+      name: 'Linked Indexes',
+      status: 'skip',
+      message: 'Lite tier (no embedding)',
+    };
+  }
+
+  // Extract linked paths from the config array
+  const arrayMatch = /linkedIndexes:\s*\[([\s\S]*?)\]/.exec(content);
+  const linkedPaths: string[] = [];
+  if (arrayMatch) {
+    const arrayContent = arrayMatch[1];
+    let m: RegExpExecArray | null;
+    const strRe = /['"]([^'"]+)['"]/g;
+    while ((m = strRe.exec(arrayContent)) !== null) {
+      linkedPaths.push(m[1]);
+    }
+  }
+
+  if (linkedPaths.length === 0) {
+    return {
+      name: 'Linked Indexes',
+      status: 'skip',
+      message: '0 configured',
+    };
+  }
+
+  const issues: string[] = [];
+  const seenNames = new Set<string>();
+  let reachable = 0;
+
+  for (const linkedPath of linkedPaths) {
+    const resolvedPath = path.resolve(cwd, linkedPath);
+    const linkName = path.basename(resolvedPath).replace(/^\./, '');
+    let entryOk = true;
+
+    if (seenNames.has(linkName)) {
+      issues.push(`name collision on '${linkName}'`);
+      entryOk = false;
+    } else {
+      seenNames.add(linkName);
+    }
+
+    if (!fs.existsSync(resolvedPath)) {
+      issues.push(`'${linkName}' path does not exist (${resolvedPath})`);
+      continue;
+    }
+
+    const lanceDbPath = path.join(resolvedPath, '.lancedb');
+    if (!fs.existsSync(lanceDbPath)) {
+      issues.push(`'${linkName}' has no .lancedb index (run totem sync in ${resolvedPath})`);
+      entryOk = false;
+    }
+
+    const linkedConfig = readConfigFile(resolvedPath);
+    if (!linkedConfig) {
+      issues.push(`'${linkName}' has no totem config`);
+      entryOk = false;
+    } else {
+      const [, linkedContent] = linkedConfig;
+      if (!hasEmbeddingProvider(linkedContent)) {
+        issues.push(`'${linkName}' has no embedding provider (dimension mismatch risk)`);
+        entryOk = false;
+      }
+    }
+
+    if (entryOk) {
+      reachable++;
+    }
+  }
+
+  const n = linkedPaths.length;
+
+  if (issues.length === 0) {
+    return {
+      name: 'Linked Indexes',
+      status: 'pass',
+      message: `${n} configured, ${reachable} reachable`,
+    };
+  }
+
+  return {
+    name: 'Linked Indexes',
+    status: 'warn',
+    message: `${n} configured, ${reachable} reachable, ${issues.length} issue(s)`,
+    remediation: issues.join('; '),
+  };
+}
+
 export async function checkSecretLeaks(
   cwd: string,
   totemDir = '.totem',
@@ -1011,6 +1121,7 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<Diagno
     checkGitHooks(cwd),
     checkEmbeddingConfig(cwd),
     checkIndex(cwd),
+    checkLinkedIndexes(cwd),
     await checkSecretLeaks(cwd),
     checkSecretsFileTracked(cwd),
     await checkUpgradeCandidates(cwd),

--- a/packages/cli/src/commands/search.test.ts
+++ b/packages/cli/src/commands/search.test.ts
@@ -1,0 +1,44 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// We can't easily test the full searchCommand because it requires
+// real LanceDB + embedder. Instead, test the federation path by
+// verifying that the linked index init code handles errors gracefully.
+
+describe('searchCommand federation (#1307)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('linked index connection failures are caught and warned, not thrown', () => {
+    // The federation code in search.ts catches errors per-link and
+    // calls log.warn instead of throwing. This is locked in by the
+    // try/catch at line ~51 of search.ts. Verify the structural
+    // contract by reading the source and checking the expected error-handling pattern.
+    const source = fs.readFileSync(path.join(process.cwd(), 'src/commands/search.ts'), 'utf-8');
+
+    // Federation block must exist
+    expect(source).toContain('linkedIndexes');
+    expect(source).toContain('config.linkedIndexes.length > 0');
+
+    // Error handling must use log.warn, not throw
+    expect(source).toContain('Could not connect to linked index');
+    expect(source).toContain('log.warn');
+
+    // Linked search failures must also be caught
+    expect(source).toContain('Linked search failed for');
+
+    // Results must be merged and sorted by score
+    expect(source).toContain('.sort((a, b) => b.result.score - a.result.score)');
+  });
+
+  it('linked results include repo tag prefix in output', () => {
+    const source = fs.readFileSync(path.join(process.cwd(), 'src/commands/search.ts'), 'utf-8');
+
+    // The [linkName] prefix must appear in the output formatting
+    expect(source).toContain('repoTag');
+    expect(source).toMatch(/linkName.*\?.*\[/);
+  });
+});

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -42,6 +42,13 @@ export async function searchCommand(
           continue;
         }
         const linkedEmbedder = createEmbedder(linkedEmbedding);
+        if (linkedEmbedder.dimensions !== embedder.dimensions) {
+          log.warn(
+            TAG,
+            `Linked index at ${linkedPath} produces ${linkedEmbedder.dimensions}-dim embeddings; expected ${embedder.dimensions} - skipping.`,
+          );
+          continue;
+        }
         const linkName = path.basename(resolvedPath).replace(/^\./, '');
         const linkedStore = new LanceStore(
           path.join(resolvedPath, linkedConfig.lanceDir),
@@ -106,7 +113,9 @@ export async function searchCommand(
   const allResults = [
     ...results.map((r) => ({ result: r, linkName: undefined as string | undefined })),
     ...linkedResults,
-  ].sort((a, b) => b.result.score - a.result.score);
+  ]
+    .sort((a, b) => b.result.score - a.result.score)
+    .slice(0, maxResults);
 
   if (allResults.length === 0) {
     console.log('[Totem] No results found.');

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -9,6 +9,9 @@ export async function searchCommand(
     await import('@mmnto/totem');
   const { loadConfig, loadEnv, requireEmbedding, resolveConfigPath, sanitize } =
     await import('../utils.js');
+  const { log } = await import('../ui.js');
+
+  const TAG = 'Search';
 
   const cwd = process.cwd();
   const configPath = resolveConfigPath(cwd);
@@ -23,6 +26,37 @@ export async function searchCommand(
   });
   await store.connect();
 
+  const maxResults = options.maxResults ? parseInt(options.maxResults, 10) || 5 : 5;
+
+  // Federation: connect to linked indexes (cross-repo mesh)
+  const linkedStores: Array<{ store: InstanceType<typeof LanceStore>; linkName: string }> = [];
+  if (config.linkedIndexes && config.linkedIndexes.length > 0) {
+    for (const linkedPath of config.linkedIndexes) {
+      try {
+        const resolvedPath = path.resolve(cwd, linkedPath);
+        const linkedConfigPath = resolveConfigPath(resolvedPath);
+        const linkedConfig = await loadConfig(linkedConfigPath);
+        const linkedEmbedding = linkedConfig.embedding;
+        if (!linkedEmbedding) continue;
+        const linkedEmbedder = createEmbedder(linkedEmbedding);
+        const linkName = path.basename(resolvedPath).replace(/^\./, '');
+        const linkedStore = new LanceStore(
+          path.join(resolvedPath, linkedConfig.lanceDir),
+          linkedEmbedder,
+          { sourceRepo: linkName, absolutePathRoot: resolvedPath },
+        );
+        await linkedStore.connect();
+        linkedStores.push({ store: linkedStore, linkName });
+        log.dim(TAG, `Linked index: ${linkedPath}`);
+      } catch (err) {
+        log.warn(
+          TAG,
+          `Could not connect to linked index at ${linkedPath} - skipping. ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  }
+
   const VALID_TYPES = ContentTypeSchema.options;
   if (options.type && !VALID_TYPES.includes(options.type as ContentType)) {
     throw new TotemConfigError(
@@ -35,16 +69,51 @@ export async function searchCommand(
   const results = await store.search({
     query,
     typeFilter: options.type as ContentType | undefined,
-    maxResults: options.maxResults ? parseInt(options.maxResults, 10) || 5 : 5,
+    maxResults,
   });
 
-  if (results.length === 0) {
+  // Query linked stores in parallel
+  const linkedResults: Array<{
+    result: (typeof results)[number];
+    linkName: string;
+  }> = [];
+  if (linkedStores.length > 0) {
+    const linkedSearches = await Promise.all(
+      linkedStores.map(async ({ store: ls, linkName }) => {
+        try {
+          const r = await ls.search({
+            query,
+            typeFilter: options.type as ContentType | undefined,
+            maxResults,
+          });
+          return r.map((result) => ({ result, linkName }));
+        } catch (err) {
+          log.warn(
+            TAG,
+            `Linked search failed for ${linkName} - skipping. ${err instanceof Error ? err.message : String(err)}`,
+          );
+          return [];
+        }
+      }),
+    );
+    linkedResults.push(...linkedSearches.flat());
+  }
+
+  // Merge primary and linked results, sort by score descending
+  const allResults = [
+    ...results.map((r) => ({ result: r, linkName: undefined as string | undefined })),
+    ...linkedResults,
+  ].sort((a, b) => b.result.score - a.result.score);
+
+  if (allResults.length === 0) {
     console.log('[Totem] No results found.');
     return;
   }
 
-  for (const result of results) {
-    console.log(`\n--- ${sanitize(result.label).replace(/\n/g, ' ')} (${result.type}) ---`);
+  for (const { result, linkName } of allResults) {
+    const repoTag = linkName ? `[${linkName}] ` : '';
+    const label = repoTag + sanitize(result.label).replace(/\n/g, ' ');
+    console.log(`\n--- ${label} (${result.type}) ---`);
     console.log(
       `File: ${sanitize(result.filePath).replace(/\n/g, ' ')} | Score: ${result.score.toFixed(3)}`,
     );

--- a/packages/cli/src/commands/search.ts
+++ b/packages/cli/src/commands/search.ts
@@ -37,7 +37,10 @@ export async function searchCommand(
         const linkedConfigPath = resolveConfigPath(resolvedPath);
         const linkedConfig = await loadConfig(linkedConfigPath);
         const linkedEmbedding = linkedConfig.embedding;
-        if (!linkedEmbedding) continue;
+        if (!linkedEmbedding) {
+          log.warn(TAG, `Linked index at ${linkedPath} has no embedding provider - skipping.`);
+          continue;
+        }
         const linkedEmbedder = createEmbedder(linkedEmbedding);
         const linkName = path.basename(resolvedPath).replace(/^\./, '');
         const linkedStore = new LanceStore(
@@ -115,7 +118,7 @@ export async function searchCommand(
     const label = repoTag + sanitize(result.label).replace(/\n/g, ' ');
     console.log(`\n--- ${label} (${result.type}) ---`);
     console.log(
-      `File: ${sanitize(result.filePath).replace(/\n/g, ' ')} | Score: ${result.score.toFixed(3)}`,
+      `File: ${sanitize(linkName ? result.absoluteFilePath : result.filePath).replace(/\n/g, ' ')} | Score: ${result.score.toFixed(3)}`,
     );
     const snippet = result.content.slice(0, 200) + (result.content.length > 200 ? '...' : '');
     console.log(sanitize(snippet));


### PR DESCRIPTION
## Summary

Completes the 1.14.x Nervous System arc with the two remaining mesh features:

- **#1307** - `totem search` now federates across `linkedIndexes`. Linked stores are initialized using the same pattern as `totem spec`, results are merged by score, and linked results are tagged with `[linkName]` prefix. Connection failures degrade gracefully with `log.warn`.
- **#1308** - `totem doctor` gains a "Linked Indexes" health check. Validates each configured linked index: path exists, `.lancedb` present, config present, embedding provider present, no name collisions. Reports reachable count and per-link issues.

Closes #1307
Closes #1308

## Test plan

- [x] 2777 tests pass (6 new: 4 for doctor linked check, 2 for search federation contracts)
- [x] `totem lint` passes (391 rules, 0 violations)
- [x] `totem review` passes (1 warning about global maxResults truncation on federated results, acceptable for parity with MCP behavior)
- [x] `pnpm run format:check` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)