### PR TITLE
docs: fix rule counts in active_work.md

### DIFF
--- a/docs/active_work.md
+++ b/docs/active_work.md
@@ -1,6 +1,6 @@
 ### Active Work Summary
 
-The project is at release `@mmnto/cli@1.14.7` (publishing 2026-04-13) with **2,777 tests** across core, CLI, and MCP packages and **406 compiled rules** (390 active, 16 archived).
+The project is at release `@mmnto/cli@1.14.7` (publishing 2026-04-13) with **2,777 tests** across core, CLI, and MCP packages and **406 compiled rules** (388 active, 18 archived).
 
 ### Recently Shipped (2026-04-13)
 


### PR DESCRIPTION
## Summary

Fixes stale rule counts in `docs/active_work.md`. The 1.14.7 release PR (#1397) squash-merged before the count correction commit landed on the branch.

Corrects: 406 total (390 active, 16 archived) to 406 total (388 active, 18 archived). The 3 postmerge rules were all archived after bot review.

## Test plan

- [x] Docs-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)