### PR TITLE
chore: add PR template (mechanical root cause + out-of-scope)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,7 +14,8 @@
 
 <!-- Describe the test coverage added to mechanically verify this fix. A change is incomplete without verification logic. -->
 
-- [ ]
+- [ ] Added/updated automated tests covering the root-cause mechanism
+- [ ] N/A (explain why verification logic is not applicable)
 
 ## Related Tickets
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Mechanical Root Cause
+
+<!-- What is the fundamental, deterministic reason this bug existed or this feature was needed? (Do not describe symptoms; describe the mechanism.) -->
+
+## Fix Applied
+
+<!-- Describe the specific architectural change or implementation details that resolve the root cause. -->
+
+## Out of Scope
+
+<!-- What related changes were intentionally excluded from this PR to keep the diff bisectable and focused? -->
+
+## Tests Added/Updated
+
+<!-- Describe the test coverage added to mechanically verify this fix. A change is incomplete without verification logic. -->
+
+- [ ]
+
+## Related Tickets
+
+<!-- Use "Closes #123" to automatically close the tracking issue when merged. -->
+
+Closes #


### PR DESCRIPTION
## Mechanical Root Cause

PR descriptions across the 1.14.x cycle had inconsistent structure. The changesets bot consumed PR bodies as CHANGELOG source material, CR/GCA extracted context from them for review, and humans read them to understand intent — but without a template, each author reinvented the format. This led to drift like the #1397 release where the "Postmerge" count line in the changeset went stale after downstream edits.

## Fix Applied

Adds `.github/pull_request_template.md` with four required sections:

- **Mechanical Root Cause** — force authors to describe the mechanism, not just the symptom
- **Fix Applied** — architectural change or implementation detail
- **Out of Scope** — explicit negative scope (prevents scope creep during review, mirrors our Phase 3 design-doc discipline)
- **Tests Added/Updated** — checkbox forcing verification coverage
- **Related Tickets** — `Closes #NNN` for auto-close

The template is the first thing every PR author sees when they open the compose form. GitHub auto-loads it.

## Out of Scope

- YAML issue forms for bug reports — deferred until external contributors appear (YAGNI)
- Active Q&A routing to GitHub Discussions — that's a policy commitment, not a configuration file
- Backfilling prior PRs to match the template — only applies to new PRs from merge forward

## Tests Added/Updated

- [ ] N/A — this is a template file, not code

## Related Tickets

No tracking issue. Strategy followup from today's board audit discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)