### PR TITLE
feat(core): compound ast-grep schema + deterministic manifest hashing (#1407)

### DIFF
--- a/packages/cli/src/commands/run-compiled-rules.test.ts
+++ b/packages/cli/src/commands/run-compiled-rules.test.ts
@@ -1066,8 +1066,9 @@ describe('TOTEM_LITE graceful AST degradation', () => {
   it('skips AST rules with warning when TOTEM_LITE=1 and AST engine fails', async () => {
     process.env['TOTEM_LITE'] = '1';
 
-    const astRule = makeRule('console.log($$$)', 'no console', 'No console', {
+    const astRule = makeRule('', 'no console', 'No console', {
       engine: 'ast-grep',
+      astGrepPattern: 'console.log($$$)',
       fileGlobs: ['**/*.ts'],
     });
     saveCompiledRules(path.join(tmpDir, TOTEM_DIR, 'compiled-rules.json'), [astRule]);
@@ -1102,8 +1103,9 @@ describe('TOTEM_LITE graceful AST degradation', () => {
   it('re-throws AST errors when NOT in lite mode', async () => {
     delete process.env['TOTEM_LITE'];
 
-    const astRule = makeRule('console.log($$$)', 'no console', 'No console', {
+    const astRule = makeRule('', 'no console', 'No console', {
       engine: 'ast-grep',
+      astGrepPattern: 'console.log($$$)',
       fileGlobs: ['**/*.ts'],
     });
     saveCompiledRules(path.join(tmpDir, TOTEM_DIR, 'compiled-rules.json'), [astRule]);

--- a/packages/core/src/compile-lesson.test.ts
+++ b/packages/core/src/compile-lesson.test.ts
@@ -10,6 +10,7 @@ import {
   verifyRuleExamples,
 } from './compile-lesson.js';
 import type { CompiledRule, CompilerOutput } from './compiler-schema.js';
+import { CompilerOutputSchema } from './compiler-schema.js';
 
 // ─── Helpers ────────────────────────────────────────
 
@@ -241,11 +242,11 @@ describe('self-suppression guard (#1177)', () => {
     expect(result.rejectReason).toContain('self-suppress');
   });
 
-  it('rejects ast-grep object pattern containing totem-context', () => {
+  it('rejects ast-grep compound rule containing totem-context', () => {
     const result = buildCompiledRule(
       {
         compilable: true,
-        astGrepPattern: { rule: { pattern: 'totem-context: something' } },
+        astGrepYamlRule: { rule: { pattern: 'totem-context: something' } },
         message: 'test',
         engine: 'ast-grep',
       } as CompilerOutput,
@@ -481,17 +482,21 @@ describe('buildCompiledRule ast-grep validation (#1062)', () => {
     expect(result.rejectReason).toContain('top-level expressions');
   });
 
-  it('rejects ast-grep rule with object pattern missing rule key', () => {
-    const parsed: CompilerOutput = {
+  it('rejects ast-grep rule where Zod blocks a yaml rule missing the rule key', () => {
+    // The rule parameter is required by the Zod schema; construct the
+    // object as unknown to sidestep the type-narrowing and prove that
+    // parseCompilerResponse rejects it at the schema boundary rather
+    // than at buildCompiledRule. This is the invariant from the design
+    // doc: missing-rule-key is a parse-time failure, not a runtime one.
+    const malformed = {
       compilable: true,
       message: 'test',
       engine: 'ast-grep',
-      astGrepPattern: { pattern: 'console.log($A)' },
+      astGrepYamlRule: { pattern: 'console.log($A)' },
     };
-    const result = buildCompiledRule(parsed, lesson, existingByHash);
-    expect(result.rule).toBeNull();
-    expect(result.rejectReason).toContain('Invalid ast-grep pattern');
-    expect(result.rejectReason).toContain('rule');
+    // Parse with the authoritative schema to prove Zod rejects.
+    const parsed = CompilerOutputSchema.safeParse(malformed);
+    expect(parsed.success).toBe(false);
   });
 
   it('accepts valid ast-grep string pattern', () => {
@@ -506,16 +511,49 @@ describe('buildCompiledRule ast-grep validation (#1062)', () => {
     expect(result.rule!.engine).toBe('ast-grep');
   });
 
-  it('accepts valid ast-grep object pattern with rule key', () => {
+  it('accepts valid ast-grep compound rule via astGrepYamlRule', () => {
     const parsed: CompilerOutput = {
       compilable: true,
       message: 'No console.log',
       engine: 'ast-grep',
-      astGrepPattern: { rule: { pattern: 'console.log($A)' } },
+      astGrepYamlRule: { rule: { pattern: 'console.log($A)' } },
     };
     const result = buildCompiledRule(parsed, lesson, existingByHash);
     expect(result.rule).not.toBeNull();
     expect(result.rule!.engine).toBe('ast-grep');
+    expect(result.rule!.astGrepYamlRule).toEqual({ rule: { pattern: 'console.log($A)' } });
+    expect(result.rule!.astGrepPattern).toBeUndefined();
+  });
+
+  it('buildCompiledRule passes astGrepYamlRule to validateAstGrepPattern and propagates NAPI rejections', () => {
+    // Syntactically-valid Zod shape (has `rule` key) but the leaf kind
+    // is a node type ast-grep does not recognize. Zod lets it through;
+    // napi rejects it. That is the precise boundary this test pins.
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'nope',
+      engine: 'ast-grep',
+      astGrepYamlRule: { rule: { kind: '!!!NOT_A_REAL_NODE_KIND!!!' } },
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash);
+    expect(result.rule).toBeNull();
+    expect(result.rejectReason).toContain('Invalid ast-grep pattern');
+    // First-line napi error quoting per #1349
+    expect(result.rejectReason).toContain('ast-grep rejected pattern');
+  });
+
+  it('isSelfSuppressing still catches compound rules with deep totem-ignore leaves', () => {
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'nope',
+      engine: 'ast-grep',
+      astGrepYamlRule: {
+        rule: { all: [{ pattern: 'foo($A)' }, { pattern: 'totem-ignore marker' }] },
+      },
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash);
+    expect(result.rule).toBeNull();
+    expect(result.rejectReason).toContain('self-suppress');
   });
 });
 

--- a/packages/core/src/compile-lesson.ts
+++ b/packages/core/src/compile-lesson.ts
@@ -245,22 +245,33 @@ export function buildCompiledRule(
   const globsObj = sanitizedGlobs && sanitizedGlobs.length > 0 ? { fileGlobs: sanitizedGlobs } : {};
 
   if (engine === 'ast-grep') {
-    if (!parsed.astGrepPattern || !parsed.message) {
-      return { rule: null, rejectReason: 'Missing astGrepPattern or message' };
+    // mmnto/totem#1407 split the field. Mutual exclusion is enforced
+    // upstream by the schema superRefine; here we pick whichever the
+    // LLM emitted and route it to validation.
+    const astSource: string | Record<string, unknown> | undefined =
+      typeof parsed.astGrepPattern === 'string' && parsed.astGrepPattern.length > 0
+        ? parsed.astGrepPattern
+        : parsed.astGrepYamlRule;
+
+    if (!astSource || !parsed.message) {
+      return {
+        rule: null,
+        rejectReason: 'Missing astGrepPattern or astGrepYamlRule or message',
+      };
     }
 
-    // Validate ast-grep pattern at compile time (#1062)
-    const astValidation = validateAstGrepPattern(parsed.astGrepPattern);
+    // Validate ast-grep pattern at compile time (#1062, #1339, #1407)
+    const astValidation = validateAstGrepPattern(astSource);
     if (!astValidation.valid) {
       return { rule: null, rejectReason: `Invalid ast-grep pattern: ${astValidation.reason}` };
     }
 
-    // Guard: reject patterns that match suppression directives (#1177)
-    // These rules can never fire — the engine suppresses matching lines before rule evaluation.
-    const astPatternStr =
-      typeof parsed.astGrepPattern === 'string'
-        ? parsed.astGrepPattern
-        : JSON.stringify(parsed.astGrepPattern);
+    // Guard: reject patterns that match suppression directives (#1177).
+    // For compound rules, the existing stringify path walks the entire
+    // tree; any `totem-ignore` marker anywhere in the nested structure
+    // is caught. Deliberately no object walker here (design doc open
+    // question 2, resolved "keep existing stringify path").
+    const astPatternStr = typeof astSource === 'string' ? astSource : JSON.stringify(astSource);
     if (isSelfSuppressing(astPatternStr)) {
       return {
         rule: null,
@@ -276,7 +287,7 @@ export function buildCompiledRule(
         message: parsed.message,
         engine: 'ast-grep',
         severity,
-        ...engineFields('ast-grep', parsed.astGrepPattern),
+        ...engineFields('ast-grep', astSource),
         compiledAt: now,
         createdAt: existing?.createdAt ?? now,
         ...globsObj,

--- a/packages/core/src/compile-manifest.test.ts
+++ b/packages/core/src/compile-manifest.test.ts
@@ -1,3 +1,4 @@
+import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -112,6 +113,54 @@ describe('generateOutputHash', () => {
     fs.writeFileSync(pathB, JSON.stringify({ version: 1, rules: [ruleB] }, null, 2) + '\n');
 
     expect(generateOutputHash(pathA)).toBe(generateOutputHash(pathB));
+  });
+
+  it('does not switch to canonical path when the literal string appears only in a lesson message', () => {
+    // Regression for the substring false-positive flagged on #1412:
+    // a rule whose message body contains the bytes `"astGrepYamlRule"`
+    // (e.g., a lesson about when to use the new field) must NOT flip
+    // the hash computation path. Pre-#1407 CLIs would hash the raw
+    // byte stream; a false canonical path produces different bytes.
+    const pathByteStream = path.join(tmpDir, 'rules-bytes.json');
+    const pathWithStringInMessage = path.join(tmpDir, 'rules-msg.json');
+
+    const plainRule = {
+      lessonHash: 'plain',
+      lessonHeading: 'regex rule',
+      pattern: 'foo',
+      message: 'use foo instead of bar',
+      engine: 'regex',
+      compiledAt: '2026-04-13T00:00:00Z',
+    };
+    const trickyRule = {
+      lessonHash: 'tricky',
+      lessonHeading: 'mention the field',
+      pattern: 'foo',
+      // Literal bytes `"astGrepYamlRule"` inside a message (wrapping
+      // the name in single quotes in prose would still JSON-encode to
+      // a version that does NOT contain the double-quoted token —
+      // this test uses the token explicitly to force the worst case).
+      message: 'prefer astGrepPattern over "astGrepYamlRule" for flat patterns',
+      engine: 'regex',
+      compiledAt: '2026-04-13T00:00:00Z',
+    };
+
+    const plainJson = JSON.stringify({ version: 1, rules: [plainRule] }, null, 2) + '\n';
+    const trickyJson = JSON.stringify({ version: 1, rules: [trickyRule] }, null, 2) + '\n';
+
+    fs.writeFileSync(pathByteStream, plainJson);
+    fs.writeFileSync(pathWithStringInMessage, trickyJson);
+
+    // Hashes differ (different messages), but the tricky rule must
+    // have been hashed via the raw-byte-stream path, not canonical.
+    // Proof: the canonical path on tricky would produce a different
+    // hash than crypto over the raw bytes. Compare against the raw
+    // sha256 of the file contents.
+    const expectedTrickyHash = crypto
+      .createHash('sha256')
+      .update(trickyJson.replace(/\r\n/g, '\n'))
+      .digest('hex');
+    expect(generateOutputHash(pathWithStringInMessage)).toBe(expectedTrickyHash);
   });
 });
 

--- a/packages/core/src/compile-manifest.test.ts
+++ b/packages/core/src/compile-manifest.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import type { CompileManifest } from './compile-manifest.js';
 import {
+  canonicalStringify,
   generateInputHash,
   generateOutputHash,
   readCompileManifest,
@@ -73,6 +74,87 @@ describe('generateOutputHash', () => {
     fs.writeFileSync(pathCRLF, '{"rules": []}\r\n');
 
     expect(generateOutputHash(pathLF)).toBe(generateOutputHash(pathCRLF));
+  });
+
+  it('manifest hash generates identical hashes for astGrepYamlRule objects with differently ordered keys', () => {
+    const pathA = path.join(tmpDir, 'rules-a.json');
+    const pathB = path.join(tmpDir, 'rules-b.json');
+
+    const ruleA = {
+      lessonHash: 'abc',
+      lessonHeading: 'Test',
+      pattern: '',
+      message: 'm',
+      engine: 'ast-grep',
+      compiledAt: '2026-04-13T00:00:00Z',
+      astGrepYamlRule: {
+        rule: {
+          all: [{ pattern: 'foo($A)' }, { inside: { kind: 'function_declaration' } }],
+        },
+      },
+    };
+    // Same semantic rule, scrambled keys at every level.
+    const ruleB = {
+      engine: 'ast-grep',
+      astGrepYamlRule: {
+        rule: {
+          all: [{ pattern: 'foo($A)' }, { inside: { kind: 'function_declaration' } }],
+        },
+      },
+      pattern: '',
+      compiledAt: '2026-04-13T00:00:00Z',
+      lessonHash: 'abc',
+      message: 'm',
+      lessonHeading: 'Test',
+    };
+
+    fs.writeFileSync(pathA, JSON.stringify({ version: 1, rules: [ruleA] }, null, 2) + '\n');
+    fs.writeFileSync(pathB, JSON.stringify({ version: 1, rules: [ruleB] }, null, 2) + '\n');
+
+    expect(generateOutputHash(pathA)).toBe(generateOutputHash(pathB));
+  });
+});
+
+describe('canonicalStringify', () => {
+  it('sorts top-level object keys', () => {
+    expect(canonicalStringify({ b: 2, a: 1 })).toBe(canonicalStringify({ a: 1, b: 2 }));
+  });
+
+  it('sorts keys at every nesting depth', () => {
+    const a = { z: { y: { x: 1, w: 2 } }, a: 0 };
+    const b = { a: 0, z: { y: { w: 2, x: 1 } } };
+    expect(canonicalStringify(a)).toBe(canonicalStringify(b));
+  });
+
+  it('preserves array element order (arrays are ordered by contract)', () => {
+    expect(canonicalStringify([2, 1, 3])).not.toBe(canonicalStringify([1, 2, 3]));
+  });
+
+  it('handles nested arrays of objects with scrambled keys', () => {
+    const a = {
+      rule: {
+        all: [{ pattern: 'foo', kind: 'call' }, { inside: { stopBy: 'end', kind: 'function' } }],
+      },
+    };
+    const b = {
+      rule: {
+        all: [{ kind: 'call', pattern: 'foo' }, { inside: { kind: 'function', stopBy: 'end' } }],
+      },
+    };
+    expect(canonicalStringify(a)).toBe(canonicalStringify(b));
+  });
+
+  it('is stable for primitives', () => {
+    expect(canonicalStringify('hello')).toBe('"hello"');
+    expect(canonicalStringify(42)).toBe('42');
+    expect(canonicalStringify(true)).toBe('true');
+    expect(canonicalStringify(null)).toBe('null');
+  });
+
+  it('handles undefined by omitting the key (JSON.stringify parity)', () => {
+    const a = { a: 1, b: undefined };
+    const b = { a: 1 };
+    expect(canonicalStringify(a)).toBe(canonicalStringify(b));
   });
 });
 

--- a/packages/core/src/compile-manifest.test.ts
+++ b/packages/core/src/compile-manifest.test.ts
@@ -156,6 +156,14 @@ describe('canonicalStringify', () => {
     const b = { a: 1 };
     expect(canonicalStringify(a)).toBe(canonicalStringify(b));
   });
+
+  it('throws on a bare undefined input (contract violation)', () => {
+    // Undefined in record values is filtered out upstream; a bare
+    // undefined here means a caller bug, not malformed data on disk.
+    // Fail loud rather than silently produce the string "undefined"
+    // that would then hash to something no other input produces.
+    expect(() => canonicalStringify(undefined)).toThrow(/undefined is not a JSON value/);
+  });
 });
 
 describe('writeCompileManifest + readCompileManifest', () => {

--- a/packages/core/src/compile-manifest.ts
+++ b/packages/core/src/compile-manifest.ts
@@ -76,14 +76,85 @@ export function generateInputHash(lessonsDir: string): string {
 }
 
 /**
+ * Deterministic JSON stringify. Walks the input tree and sorts every
+ * object's keys alphabetically before serialising. Arrays keep their
+ * element order (arrays are ordered by contract). Primitives and
+ * `null` pass through unchanged.
+ *
+ * Used by `generateOutputHash` so that a compound ast-grep rule
+ * (`astGrepYamlRule`) produces the same output hash regardless of the
+ * JS engine's property insertion order. Without this, two compile
+ * runs could emit functionally-identical rules with different key
+ * orders and trip `verify-manifest` on an otherwise stable lesson
+ * set. The invariant is: structurally-equivalent inputs produce
+ * byte-identical outputs.
+ *
+ * Design notes:
+ *   - No cycle detection. Input is expected to be a finite tree
+ *     (NapiConfig + primitive scalars). Cyclic input would stack
+ *     overflow; that is a hard error, not a silent degradation.
+ *   - Undefined values are dropped, matching `JSON.stringify` parity.
+ *   - `Date` and other class instances are serialised via their
+ *     default `JSON.stringify` representation. In practice the hash
+ *     payload is plain JSON already, so this never fires.
+ */
+export function canonicalStringify(value: unknown): string {
+  if (value === null || typeof value !== 'object') {
+    return JSON.stringify(value);
+  }
+  if (Array.isArray(value)) {
+    return '[' + value.map((v) => canonicalStringify(v)).join(',') + ']';
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record)
+    .filter((k) => record[k] !== undefined)
+    .sort();
+  const parts: string[] = [];
+  for (const k of keys) {
+    parts.push(JSON.stringify(k) + ':' + canonicalStringify(record[k]));
+  }
+  return '{' + parts.join(',') + '}';
+}
+
+/**
  * Generate a deterministic SHA-256 hash of the compiled rules file.
  *
- * Line endings are normalized to `\n` before hashing.
+ * Line endings are normalized to `\n` before hashing. For files that
+ * contain at least one compound `astGrepYamlRule`, the payload is
+ * re-serialised through `canonicalStringify` so key-order variation
+ * inside the yaml object cannot shift the hash (mmnto/totem#1407).
+ * Files without any compound rule keep the byte-stream path for
+ * backward compatibility with manifests written by pre-#1407 CLIs:
+ * the old and new computation match byte-for-byte in that case, so
+ * every user's existing compile-manifest.json stays valid after
+ * upgrading without a forced recompile.
+ *
+ * A parse failure falls back to the raw content so verify-manifest
+ * can still catch tampering on partial writes; it does not mask the
+ * error.
  */
 export function generateOutputHash(rulesPath: string): string {
   try {
-    const content = fs.readFileSync(rulesPath, 'utf-8').replace(/\r\n/g, '\n');
-    return crypto.createHash('sha256').update(content).digest('hex');
+    const raw = fs.readFileSync(rulesPath, 'utf-8').replace(/\r\n/g, '\n');
+    let payload = raw;
+    // Only switch to canonical serialization when the file actually
+    // contains a compound rule. A simple substring check is safe
+    // here because JSON-stringified keys are quoted; a lesson body
+    // cannot produce the exact byte sequence without storing it in
+    // an astGrepYamlRule field.
+    if (raw.includes('"astGrepYamlRule"')) {
+      try {
+        const parsed: unknown = JSON.parse(raw);
+        if (typeof parsed === 'object' && parsed !== null) {
+          payload = canonicalStringify(parsed);
+        }
+      } catch {
+        // Malformed JSON: keep the raw byte stream so verify-manifest
+        // still surfaces the corruption via a mismatch rather than
+        // crashing here.
+      }
+    }
+    return crypto.createHash('sha256').update(payload).digest('hex');
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code === 'ENOENT') {

--- a/packages/core/src/compile-manifest.ts
+++ b/packages/core/src/compile-manifest.ts
@@ -99,6 +99,12 @@ export function generateInputHash(lessonsDir: string): string {
  *     payload is plain JSON already, so this never fires.
  */
 export function canonicalStringify(value: unknown): string {
+  if (value === undefined) {
+    throw new TotemParseError(
+      'canonicalStringify: undefined is not a JSON value',
+      'The manifest hash payload must be JSON-parseable. Undefined entries are filtered out of records before serialisation, so a direct undefined here indicates a caller bug rather than malformed data on disk.',
+    );
+  }
   if (value === null || typeof value !== 'object') {
     return JSON.stringify(value);
   }

--- a/packages/core/src/compile-manifest.ts
+++ b/packages/core/src/compile-manifest.ts
@@ -89,15 +89,41 @@ export function generateInputHash(lessonsDir: string): string {
  * set. The invariant is: structurally-equivalent inputs produce
  * byte-identical outputs.
  *
+ * **Contract:** `value` MUST be plain JSON — the output of
+ * `JSON.parse()` or a literal composed of `null`, booleans, numbers,
+ * strings, arrays, and plain object literals. Class instances
+ * (`Date`, `Map`, custom classes) are not supported and may produce
+ * output that diverges from `JSON.stringify`: a `Date` serialises to
+ * `{}` rather than its ISO string, `[undefined]` throws rather than
+ * becoming `[null]`. Callers in Totem always pass `JSON.parse()`
+ * output, so these cases are unreachable in practice; the contract
+ * is documented here so future callers do not reach for this
+ * function as a drop-in `JSON.stringify` replacement.
+ *
  * Design notes:
  *   - No cycle detection. Input is expected to be a finite tree
  *     (NapiConfig + primitive scalars). Cyclic input would stack
  *     overflow; that is a hard error, not a silent degradation.
- *   - Undefined values are dropped, matching `JSON.stringify` parity.
- *   - `Date` and other class instances are serialised via their
- *     default `JSON.stringify` representation. In practice the hash
- *     payload is plain JSON already, so this never fires.
+ *   - Undefined values inside records are dropped, matching
+ *     `JSON.stringify` parity. A bare `undefined` throws — it is
+ *     not a JSON value.
  */
+/**
+ * Detect whether a parsed compiled-rules file contains at least one
+ * rule with an `astGrepYamlRule` field. Walks only the `rules` array
+ * on the top-level object; does not recurse into nested rule bodies
+ * because compound rules live exactly one level deep in the payload.
+ */
+function hasCompoundRule(parsed: unknown): boolean {
+  if (typeof parsed !== 'object' || parsed === null) return false;
+  const rules = (parsed as { rules?: unknown }).rules;
+  if (!Array.isArray(rules)) return false;
+  for (const r of rules) {
+    if (r && typeof r === 'object' && 'astGrepYamlRule' in r) return true;
+  }
+  return false;
+}
+
 export function canonicalStringify(value: unknown): string {
   if (value === undefined) {
     throw new TotemParseError(
@@ -144,14 +170,16 @@ export function generateOutputHash(rulesPath: string): string {
     const raw = fs.readFileSync(rulesPath, 'utf-8').replace(/\r\n/g, '\n');
     let payload = raw;
     // Only switch to canonical serialization when the file actually
-    // contains a compound rule. A simple substring check is safe
-    // here because JSON-stringified keys are quoted; a lesson body
-    // cannot produce the exact byte sequence without storing it in
-    // an astGrepYamlRule field.
+    // contains a compound rule. We parse first and check the real
+    // field on every rule rather than substring-matching the raw
+    // bytes: a lesson message or heading could contain the literal
+    // string `"astGrepYamlRule"` and falsely flip the path,
+    // producing a different hash than pre-#1407 CLIs computed for
+    // the same manifest. Parsing is O(file size), same as hashing.
     if (raw.includes('"astGrepYamlRule"')) {
       try {
         const parsed: unknown = JSON.parse(raw);
-        if (typeof parsed === 'object' && parsed !== null) {
+        if (hasCompoundRule(parsed)) {
           payload = canonicalStringify(parsed);
         }
       } catch {

--- a/packages/core/src/compiler-schema.test.ts
+++ b/packages/core/src/compiler-schema.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AstGrepYamlRuleSchema,
+  CompiledRuleSchema,
+  CompilerOutputSchema,
+  NapiConfigSchema,
+} from './compiler-schema.js';
+
+// ─── NapiConfigSchema / AstGrepYamlRuleSchema ────────
+
+describe('NapiConfigSchema', () => {
+  it('accepts a minimal compound rule with a rule key', () => {
+    const parsed = NapiConfigSchema.parse({
+      rule: { pattern: 'foo($A)' },
+    });
+    expect(parsed.rule).toBeDefined();
+  });
+
+  it('accepts nested combinators (all / any / inside)', () => {
+    const parsed = NapiConfigSchema.parse({
+      rule: {
+        all: [{ pattern: 'foo($A)' }, { inside: { kind: 'function_declaration' } }],
+      },
+    });
+    expect(parsed.rule).toBeDefined();
+  });
+
+  it('rejects an object missing the rule key at parse time', () => {
+    expect(() => NapiConfigSchema.parse({ notRule: {} })).toThrow();
+  });
+
+  it('is exported as an alias under AstGrepYamlRuleSchema', () => {
+    const input = { rule: { pattern: 'foo($A)' } };
+    const viaNapi = NapiConfigSchema.parse(input);
+    const viaAlias = AstGrepYamlRuleSchema.parse(input);
+    expect(viaAlias).toEqual(viaNapi);
+  });
+});
+
+// ─── CompiledRuleSchema mutual exclusion ─────────────
+
+describe('CompiledRuleSchema mutual exclusion', () => {
+  const baseRule = {
+    lessonHash: 'abc123def456',
+    lessonHeading: 'Test rule',
+    pattern: '',
+    message: 'Use the right thing',
+    engine: 'ast-grep' as const,
+    compiledAt: '2026-04-13T12:00:00Z',
+  };
+
+  it('accepts ast-grep engine with only astGrepPattern', () => {
+    const parsed = CompiledRuleSchema.parse({
+      ...baseRule,
+      astGrepPattern: 'console.log($A)',
+    });
+    expect(parsed.astGrepPattern).toBe('console.log($A)');
+    expect(parsed.astGrepYamlRule).toBeUndefined();
+  });
+
+  it('accepts ast-grep engine with only astGrepYamlRule', () => {
+    const parsed = CompiledRuleSchema.parse({
+      ...baseRule,
+      astGrepYamlRule: { rule: { pattern: 'console.log($A)' } },
+    });
+    expect(parsed.astGrepYamlRule).toBeDefined();
+    expect(parsed.astGrepPattern).toBeUndefined();
+  });
+
+  it('CompiledRule rejects ast-grep engine with both pattern and yaml definitions', () => {
+    expect(() =>
+      CompiledRuleSchema.parse({
+        ...baseRule,
+        astGrepPattern: 'console.log($A)',
+        astGrepYamlRule: { rule: { pattern: 'console.log($A)' } },
+      }),
+    ).toThrow(/cannot define both astGrepPattern and astGrepYamlRule/);
+  });
+
+  it('CompiledRule rejects ast-grep engine with neither pattern nor yaml definitions', () => {
+    expect(() => CompiledRuleSchema.parse(baseRule)).toThrow(
+      /must define either astGrepPattern or astGrepYamlRule/,
+    );
+  });
+
+  it('treats empty-string astGrepPattern as "not present" for mutual exclusion', () => {
+    // Empty-string pattern + yaml object is the legit compound-rule shape because
+    // engineFields writes pattern: '' for ast-grep rules.
+    const parsed = CompiledRuleSchema.parse({
+      ...baseRule,
+      astGrepPattern: '',
+      astGrepYamlRule: { rule: { pattern: 'foo' } },
+    });
+    expect(parsed.astGrepYamlRule).toBeDefined();
+  });
+
+  it('accepts regex engine without either ast-grep field', () => {
+    const parsed = CompiledRuleSchema.parse({
+      ...baseRule,
+      engine: 'regex',
+      pattern: '\\bfoo\\b',
+    });
+    expect(parsed.engine).toBe('regex');
+  });
+
+  it('accepts ast engine without either ast-grep field', () => {
+    const parsed = CompiledRuleSchema.parse({
+      ...baseRule,
+      engine: 'ast',
+      astQuery: '(catch_clause) @c',
+    });
+    expect(parsed.engine).toBe('ast');
+  });
+});
+
+// ─── CompilerOutputSchema parallels ──────────────────
+
+describe('CompilerOutputSchema mutual exclusion', () => {
+  it('rejects compiler output with both ast-grep fields', () => {
+    expect(() =>
+      CompilerOutputSchema.parse({
+        compilable: true,
+        engine: 'ast-grep',
+        message: 'msg',
+        astGrepPattern: 'foo($A)',
+        astGrepYamlRule: { rule: { pattern: 'foo($A)' } },
+      }),
+    ).toThrow(/cannot define both astGrepPattern and astGrepYamlRule/);
+  });
+
+  it('accepts compiler output with only astGrepYamlRule', () => {
+    const parsed = CompilerOutputSchema.parse({
+      compilable: true,
+      engine: 'ast-grep',
+      message: 'msg',
+      astGrepYamlRule: { rule: { pattern: 'foo($A)' } },
+    });
+    expect(parsed.astGrepYamlRule).toBeDefined();
+  });
+});
+
+// ─── badExample optional field ───────────────────────
+
+describe('badExample optional field', () => {
+  const baseRule = {
+    lessonHash: 'abc123def456',
+    lessonHeading: 'Test rule',
+    pattern: '\\bfoo\\b',
+    message: 'No foo',
+    engine: 'regex' as const,
+    compiledAt: '2026-04-13T12:00:00Z',
+  };
+
+  it('accepts a CompiledRule with badExample set', () => {
+    const parsed = CompiledRuleSchema.parse({
+      ...baseRule,
+      badExample: 'const foo = 1;',
+    });
+    expect(parsed.badExample).toBe('const foo = 1;');
+  });
+
+  it('accepts a CompiledRule without badExample (optional)', () => {
+    const parsed = CompiledRuleSchema.parse(baseRule);
+    expect(parsed.badExample).toBeUndefined();
+  });
+
+  it('accepts CompilerOutput with badExample set', () => {
+    const parsed = CompilerOutputSchema.parse({
+      compilable: true,
+      pattern: '\\bfoo\\b',
+      message: 'No foo',
+      engine: 'regex',
+      badExample: 'const foo = 1;',
+    });
+    expect(parsed.badExample).toBe('const foo = 1;');
+  });
+});

--- a/packages/core/src/compiler-schema.ts
+++ b/packages/core/src/compiler-schema.ts
@@ -1,8 +1,43 @@
 import { z } from 'zod';
 
+// ─── NapiConfig / compound ast-grep rule schemas ────
+
+/**
+ * Schema mirroring `@ast-grep/napi`'s `NapiConfig` interface for compound
+ * structural rules. The `rule` key is required at the Zod layer so the
+ * parse-time failure is loud and readable; the inner tree shape is handed
+ * off to `@ast-grep/napi` at the engine boundary for the authoritative
+ * validity check (see `validateAstGrepPattern`). `passthrough()` lets
+ * future napi fields (e.g. `constraints`, `transform`) survive a parse
+ * without a schema bump.
+ *
+ * The rule body is a recursive structural tree (combinators like `all`,
+ * `any`, `not`, `inside`, `has`, `precedes`, `follows`). Rather than
+ * modelling the full recursive schema with `z.lazy()`, we accept any
+ * object shape here and lean on napi to reject malformed trees. That
+ * keeps the Zod layer cheap and the authoritative check centralized.
+ */
+export const NapiConfigSchema = z
+  .object({
+    rule: z.record(z.unknown()),
+  })
+  .passthrough();
+
+export type NapiConfig = z.infer<typeof NapiConfigSchema>;
+
+/**
+ * Named alias of `NapiConfigSchema` for grep-ability. The field on
+ * `CompiledRule` is named `astGrepYamlRule` (see ADR-087); the alias
+ * lets a reader search for `AstGrepYamlRuleSchema` and land on the
+ * right definition without first knowing it's a napi config.
+ */
+export const AstGrepYamlRuleSchema = NapiConfigSchema;
+
+export type AstGrepYamlRule = NapiConfig;
+
 // ─── Compiled rule schemas ──────────────────────────
 
-export const CompiledRuleSchema = z.object({
+const CompiledRuleBaseSchema = z.object({
   /** SHA-256 hash (first 16 hex chars) of heading + body — detects edits */
   lessonHash: z.string(),
   /** Human-readable heading from the lesson (for diagnostics) */
@@ -15,8 +50,27 @@ export const CompiledRuleSchema = z.object({
   engine: z.enum(['regex', 'ast', 'ast-grep']),
   /** Tree-sitter S-expression query (required when engine is 'ast') */
   astQuery: z.string().optional(),
-  /** ast-grep pattern — string for simple patterns, object for compound rules (has/inside/not) */
-  astGrepPattern: z.union([z.string(), z.record(z.unknown())]).optional(),
+  /**
+   * Flat ast-grep pattern source (a single JS/TS expression). Mutually
+   * exclusive with `astGrepYamlRule` when `engine === 'ast-grep'`; the
+   * superRefine below enforces that.
+   */
+  astGrepPattern: z.string().optional(),
+  /**
+   * Compound ast-grep rule (NapiConfig shape). Holds structural trees
+   * that cannot be expressed as a single source snippet (all / any /
+   * not / inside / has / precedes / follows combinators). Mutually
+   * exclusive with `astGrepPattern`; see the superRefine on this
+   * schema. Smoke-test wiring lands in mmnto/totem#1408.
+   */
+  astGrepYamlRule: AstGrepYamlRuleSchema.optional(),
+  /**
+   * Optional code snippet the rule is expected to match. Stored from
+   * compiler output so the smoke-test runner (wired in
+   * mmnto/totem#1408) can re-validate the rule offline. Optional in
+   * 1.14.9; flips to required when #1408 turns on the gate.
+   */
+  badExample: z.string().optional(),
   /** ISO timestamp of when this rule was compiled */
   compiledAt: z.string(),
   /** ISO timestamp of when this rule was first created (survives recompilation) */
@@ -45,6 +99,43 @@ export const CompiledRuleSchema = z.object({
    */
   manual: z.boolean().optional(),
 });
+
+/**
+ * Shared mutual-exclusion check between the flat `astGrepPattern` string
+ * and the structural `astGrepYamlRule` object. Used by both
+ * `CompiledRuleSchema` and `CompilerOutputSchema` so the gate fires at
+ * both the LLM-output boundary and the persisted-rule boundary. Empty
+ * strings count as "not present" because `engineFields` writes
+ * `pattern: ''` alongside every ast-grep rule.
+ */
+function refineAstGrepMutualExclusion(
+  data: {
+    engine?: 'regex' | 'ast' | 'ast-grep';
+    astGrepPattern?: string;
+    astGrepYamlRule?: unknown;
+  },
+  ctx: z.RefinementCtx,
+): void {
+  if (data.engine !== 'ast-grep') return;
+  const hasPattern = typeof data.astGrepPattern === 'string' && data.astGrepPattern.length > 0;
+  const hasYaml = data.astGrepYamlRule !== undefined;
+  if (hasPattern && hasYaml) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'ast-grep rule cannot define both astGrepPattern and astGrepYamlRule',
+      path: ['astGrepYamlRule'],
+    });
+  }
+  if (!hasPattern && !hasYaml) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'ast-grep rule must define either astGrepPattern or astGrepYamlRule',
+      path: ['astGrepPattern'],
+    });
+  }
+}
+
+export const CompiledRuleSchema = CompiledRuleBaseSchema.superRefine(refineAstGrepMutualExclusion);
 
 export type CompiledRule = z.infer<typeof CompiledRuleSchema>;
 
@@ -84,18 +175,30 @@ export type CompiledRulesFile = z.infer<typeof CompiledRulesFileSchema>;
 // ─── Compiler output schema ─────────────────────────
 
 /** Schema for the structured JSON the LLM returns when compiling a lesson. */
-export const CompilerOutputSchema = z.object({
+const CompilerOutputBaseSchema = z.object({
   compilable: z.boolean(),
   pattern: z.string().optional(),
   message: z.string().optional(),
   fileGlobs: z.array(z.string()).optional(),
   engine: z.enum(['regex', 'ast', 'ast-grep']).optional(),
   astQuery: z.string().optional(),
-  astGrepPattern: z.union([z.string(), z.record(z.unknown())]).optional(),
+  /** Flat ast-grep pattern source. Mutually exclusive with `astGrepYamlRule`. */
+  astGrepPattern: z.string().optional(),
+  /** Compound ast-grep rule (NapiConfig). Mutually exclusive with `astGrepPattern`. */
+  astGrepYamlRule: AstGrepYamlRuleSchema.optional(),
+  /**
+   * Optional code snippet the rule is expected to match. Optional in
+   * 1.14.9; gate wired in mmnto/totem#1408.
+   */
+  badExample: z.string().optional(),
   severity: z.enum(['error', 'warning']).optional(),
   /** LLM explanation for why a lesson was marked non-compilable */
   reason: z.string().optional(),
 });
+
+export const CompilerOutputSchema = CompilerOutputBaseSchema.superRefine(
+  refineAstGrepMutualExclusion,
+);
 
 export type CompilerOutput = z.infer<typeof CompilerOutputSchema>;
 

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -227,7 +227,38 @@ function normalizeShallowGlob(glob: string): string {
   return `${negated ? '!' : ''}**/${bare}`;
 }
 
-/** Build engine-specific fields for a compiled rule. */
+/**
+ * Build engine-specific fields for a compiled rule.
+ *
+ * Overloaded so only the `'ast-grep'` branch accepts a compound
+ * `Record<string, unknown>`; `'regex'` and `'ast'` are string-only.
+ * This prevents callers from passing a compound object to the regex
+ * engine and silently producing `"[object Object]"` via `String(pattern)`.
+ */
+export function engineFields(
+  engine: 'regex' | 'ast',
+  pattern: string,
+): { pattern: string; astQuery?: string };
+export function engineFields(
+  engine: 'ast-grep',
+  pattern: string | Record<string, unknown>,
+): { pattern: string; astGrepPattern?: string; astGrepYamlRule?: AstGrepYamlRule };
+// Wildcard overload for callers whose `engine` discriminator is the
+// union `'regex' | 'ast' | 'ast-grep'` and is resolved at runtime
+// (e.g., compile-lesson.ts:buildManualRule). TypeScript cannot narrow
+// the overload without the literal, so we expose the implementation
+// signature explicitly. The superRefine on `CompiledRuleSchema` is
+// the load-bearing gate; this wildcard merely keeps the type system
+// honest at call sites that legitimately forward the union.
+export function engineFields(
+  engine: 'regex' | 'ast' | 'ast-grep',
+  pattern: string | Record<string, unknown>,
+): {
+  pattern: string;
+  astGrepPattern?: string;
+  astGrepYamlRule?: AstGrepYamlRule;
+  astQuery?: string;
+};
 export function engineFields(
   engine: 'regex' | 'ast' | 'ast-grep',
   pattern: string | Record<string, unknown>,

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -15,6 +15,7 @@ import safeRegex from 'safe-regex2';
 import { z } from 'zod';
 
 import type {
+  AstGrepYamlRule,
   CompiledRule,
   CompiledRulesFile,
   CompilerOutput,
@@ -27,19 +28,23 @@ import { TotemParseError } from './errors.js';
 
 export type {
   AstContext,
+  AstGrepYamlRule,
   CompiledRule,
   CompiledRulesFile,
   CompilerOutput,
   DiffAddition,
+  NapiConfig,
   RegexValidation,
   RuleEventCallback,
   RuleEventContext,
   Violation,
 } from './compiler-schema.js';
 export {
+  AstGrepYamlRuleSchema,
   CompiledRuleSchema,
   CompiledRulesFileSchema,
   CompilerOutputSchema,
+  NapiConfigSchema,
 } from './compiler-schema.js';
 export { extractAddedLines } from './diff-parser.js';
 export {
@@ -226,12 +231,24 @@ function normalizeShallowGlob(glob: string): string {
 export function engineFields(
   engine: 'regex' | 'ast' | 'ast-grep',
   pattern: string | Record<string, unknown>,
-): { pattern: string; astGrepPattern?: string | Record<string, unknown>; astQuery?: string } {
+): {
+  pattern: string;
+  astGrepPattern?: string;
+  astGrepYamlRule?: AstGrepYamlRule;
+  astQuery?: string;
+} {
   switch (engine) {
     case 'regex':
       return { pattern: String(pattern) };
     case 'ast-grep':
-      return { pattern: '', astGrepPattern: pattern };
+      // Route strings to the flat field and objects to the compound field.
+      // mmnto/totem#1407 split the fields for explicit mutual exclusion; the
+      // caller is responsible for passing exactly one shape. The superRefine
+      // on CompiledRuleSchema gates the persisted rule.
+      if (typeof pattern === 'string') {
+        return { pattern: '', astGrepPattern: pattern };
+      }
+      return { pattern: '', astGrepYamlRule: pattern as AstGrepYamlRule };
     case 'ast':
       return { pattern: '', astQuery: String(pattern) };
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -122,10 +122,12 @@ export {
 // Compiler
 export type {
   AstContext,
+  AstGrepYamlRule,
   CompiledRule,
   CompiledRulesFile,
   CompilerOutput,
   DiffAddition,
+  NapiConfig,
   RuleEventCallback,
   RuleEventContext,
   Violation,
@@ -134,6 +136,7 @@ export {
   applyAstRulesToAdditions,
   applyRules,
   applyRulesToAdditions,
+  AstGrepYamlRuleSchema,
   CompiledRuleSchema,
   CompiledRulesFileSchema,
   CompilerOutputSchema,
@@ -145,6 +148,7 @@ export {
   loadCompiledRules,
   loadCompiledRulesFile,
   matchesGlob,
+  NapiConfigSchema,
   parseCompilerResponse,
   type RegexValidation,
   sanitizeFileGlobs,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -293,6 +293,7 @@ export {
 // Compile manifest (signing / provenance)
 export type { CompileManifest } from './compile-manifest.js';
 export {
+  canonicalStringify,
   CompileManifestSchema,
   generateInputHash,
   generateOutputHash,

--- a/packages/core/src/rule-engine.test.ts
+++ b/packages/core/src/rule-engine.test.ts
@@ -79,9 +79,13 @@ describe('applyAstRulesToAdditions', () => {
     const filePath = path.join(tmpDir, 'src', 'app.ts');
     fs.writeFileSync(filePath, 'const x = 1;\n');
 
+    // Runtime-invalid ast-grep string pattern. The pattern is a bare
+    // catch clause, which ast-grep rejects as multi-root. Post-#1407
+    // the string path is the only field rule-engine's filter sees;
+    // compound-rule runtime routing lands in mmnto/totem#1408.
     const rule = makeRule({
       engine: 'ast-grep',
-      astGrepPattern: { rule: { kind: '!!!INVALID_NODE_KIND!!!' } },
+      astGrepPattern: 'catch ($ERR) { $$$BODY }',
     });
 
     const additions = [makeAddition('src/app.ts', 'const x = 1;', 1)];


### PR DESCRIPTION
## Mechanical Root Cause

ADR-087 locked the architecture for compound ast-grep rule support. This PR lands the schema half: split `astGrepPattern` into a flat-string field and a new structural `astGrepYamlRule: NapiConfig` field with Zod-level mutual exclusion, route the new field through the existing `validateAstGrepPattern`, and add deterministic manifest hashing so two compile runs that emit the same compound rule with different key orders cannot trip `verify-manifest`. `badExample` fields are added to both compiler-output and compiled-rule schemas as optional for 1.14.9 (gate wired in #1408).

Design doc at `.totem/specs/1407.md` was approved before code was written. All three open questions resolved on (a), (b), (b).

## Fix Applied

Five bisectable commits on this branch:

1. **`acd6dd39`** — `feat(core): add NapiConfigSchema and schema-level mutual exclusion for ast-grep rules` — new `NapiConfigSchema`, `AstGrepYamlRuleSchema` alias, new `astGrepYamlRule` + optional `badExample` fields on both `CompiledRuleSchema` and `CompilerOutputSchema`, shared `superRefine` gating mutual exclusion and required-one-of. 16 new invariants in `compiler-schema.test.ts`.
2. **`66a06b89`** — `feat(core): route astGrepYamlRule through validateAstGrepPattern` — `buildCompiledRule` picks whichever ast-grep field the LLM emits, hands it to `validateAstGrepPattern`; `engineFields` routes strings to `astGrepPattern` and objects to `astGrepYamlRule`. `isSelfSuppressing` stringify path preserved and tested against deep-leaf `totem-ignore` per the design doc invariant.
3. **`baf02bc0`** — `feat(core): canonical JSON stringify for deterministic manifest hashing` — new pure `canonicalStringify` utility sorts keys at every depth; `generateOutputHash` only switches to canonical serialisation when the rules file contains `astGrepYamlRule`, so every existing user's `compile-manifest.json` stays valid after upgrading without a forced recompile.
4. **`54604c65`** — `test(cli): migrate run-compiled-rules fixtures to split ast-grep fields` — two TOTEM_LITE tests had to move their match source from `pattern` into `astGrepPattern` after the superRefine went live.
5. **`4dc05b25`** — `fix(core): canonicalStringify throws on bare undefined` — addresses the GCA INFO finding pre-emptively. Per Tenet 4 (Fail Loud, Never Drift): undefined is not a JSON value, so the contract throws rather than returns `undefined` as a string.

## Out of Scope

- **Engine runtime routing for compound rules.** `applyAstRulesToAdditions` at `rule-engine.ts:415` still filters on `r.astGrepPattern` only. A compound rule would never reach `findAll()` at runtime today. Scoped to #1408 per the design doc. One `rule-engine.test.ts` fail-closed test had to swap its compound fixture for a runtime-invalid string pattern because the compound path is unreachable; #1408 will restore the compound fixture.
- **Smoke-test runner for `badExample`.** The field is stored but not executed. Gate wired in #1408.
- **Compiler prompt changes.** Sonnet is not taught to emit `astGrepYamlRule` or `badExample` here. Lives in #1409.
- **`extractManualPattern` `badExample` extraction.** Pipeline 1 stays untouched per locked question 2.
- **Object-walker for `isSelfSuppressing`.** Design doc pinned the existing stringify path as correct; regression test locks that guarantee so a future walker refactor cannot regress it.
- **Auto-archive on napi upgrade.** Break-loud contract per #1345 stays intact. Locked question 3.

## Tests Added/Updated

- [x] 25 new tests (core: 1059 → 1084)
- [x] 16 invariants on schema mutual-exclusivity locked in `compiler-schema.test.ts`
- [x] `isSelfSuppressing` stringify path test for compound rules with deep `totem-ignore` leaves
- [x] `canonicalStringify` stability across 6 nesting patterns plus primitive handling plus `undefined` throw
- [x] `generateOutputHash` determinism across scrambled key orders for compound rules
- [x] Existing test migrations in `run-compiled-rules.test.ts` (fixture-only, no semantic change)

**Verification:**

- `pnpm -r test`: all 2819 green (was 2794)
- `pnpm exec totem lint`: PASS (21 warnings, all flat-rule false positives in comments/test strings, 0 errors)
- `pnpm exec totem review`: PASS (2 INFO findings, non-blocking — both are comment-accuracy nits on the guard logic which is itself correct)
- `pnpm exec totem verify-manifest`: PASS (410 rules, hashes match — backward compat path worked)
- `tsc --noEmit`: clean across all packages

## Related Tickets

Closes #1407

Epic: mmnto-ai/totem-strategy#81
ADR: `.strategy/adr/adr-087-compound-ast-grep-rules.md`
Spike findings: `packages/core/spikes/compound-ast-grep/findings.md` (merged in #1410)
Design doc: `.totem/specs/1407.md`

Blocks: #1408 (engine runtime + smoke gate + Pipeline 1 extractor). Unblocks phase 4 batch-recompile of the `upgradeTarget: compound` archived queue after #1408 and #1409 ship.