### PR TITLE
feat(core): runtime engine support + compile-time smoke gate (#1408)

### DIFF
--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -1,4 +1,4 @@
-import type { CompiledRule, RuleEventContext, TotemFinding, Violation } from '@mmnto/totem';
+import type { CompiledRule, RuleEventCallback, TotemFinding, Violation } from '@mmnto/totem';
 
 import type { ShieldFormat } from './shield.js';
 
@@ -135,15 +135,11 @@ export async function runCompiledRules(
     // Record metrics + Trap Ledger
     const { appendLedgerEvent } = await import('@mmnto/totem');
     const metrics = loadRuleMetrics(resolvedTotemDir, (msg) => log.dim(tag, msg));
-    const ruleEventCallback = (
-      event: 'trigger' | 'suppress',
-      hash: string,
-      context?: RuleEventContext,
-    ) => {
+    const ruleEventCallback: RuleEventCallback = (event, hash, context) => {
       if (event === 'trigger') {
         recordTrigger(metrics, hash);
         recordContextHit(metrics, hash, context?.astContext);
-      } else {
+      } else if (event === 'suppress') {
         recordSuppression(metrics, hash);
         // Append to Trap Ledger (fire-and-forget)
         if (context) {
@@ -161,6 +157,16 @@ export async function runCompiledRules(
             (msg) => log.dim(tag, msg),
           );
         }
+      } else {
+        // mmnto/totem#1408: 'failure' event fires when a compiled rule's
+        // runtime findAll throws (per-rule try/catch in executeQuery). Log
+        // the hash and reason so the operator can see WHICH rule failed
+        // without crashing the batch. Metric recording (recordFailure) is
+        // a follow-up once `rule-metrics` gains a failure counter.
+        log.warn(
+          tag,
+          `rule ${hash} failed at runtime${context?.failureReason ? `: ${context.failureReason}` : ''}`,
+        );
       }
     };
     const regexViolations = applyRulesToAdditions(rules, additions, ruleEventCallback);

--- a/packages/core/src/ast-grep-query.test.ts
+++ b/packages/core/src/ast-grep-query.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import type { AstGrepRule } from './ast-grep-query.js';
 import { matchAstGrepPattern, matchAstGrepPatternsBatch } from './ast-grep-query.js';
 import { TotemParseError } from './errors.js';
 
@@ -54,7 +55,7 @@ describe('matchAstGrepPatternsBatch', () => {
     expect(results).toEqual([[]]);
   });
 
-  it('throws TotemParseError on batch failure instead of returning empty arrays (fail-closed)', () => {
+  it('throws TotemParseError on batch failure instead of returning empty arrays (fail-closed) when no onRuleFailure', () => {
     const invalidRule = { rule: { kind: '!!!INVALID_NODE_KIND!!!' } };
     const content = 'const x = 1;\n';
     expect(() =>
@@ -62,5 +63,65 @@ describe('matchAstGrepPatternsBatch', () => {
         { rule: invalidRule as never, addedLineNumbers: [1] },
       ]),
     ).toThrow(TotemParseError);
+  });
+
+  // ─── Per-rule try/catch (mmnto/totem#1408 G-7) ────────
+  //
+  // One malformed compound rule inside a batch must not blast-radius the
+  // rest of the file's ast-grep pass. When the caller supplies an
+  // `onRuleFailure` sink, each findAll call gets its own try/catch; the
+  // sink receives the failure and the batch continues. Without the sink,
+  // legacy fail-closed behavior holds (the whole batch throws).
+  describe('per-rule try/catch resilience', () => {
+    it('emits onRuleFailure for a malformed rule and continues the batch', () => {
+      const content = 'const x = 1;\nconsole.log(x);\n';
+      const invalidRule = { rule: { kind: '!!!INVALID_NODE_KIND!!!' } } as unknown as AstGrepRule;
+
+      const failures: Array<{ index: number; message: string }> = [];
+      const results = matchAstGrepPatternsBatch(
+        content,
+        '.ts',
+        [
+          { rule: invalidRule, addedLineNumbers: [1] },
+          { rule: 'console.log($$$)', addedLineNumbers: [2] },
+        ],
+        (index, err) => {
+          failures.push({ index, message: err.message });
+        },
+      );
+
+      expect(failures).toHaveLength(1);
+      expect(failures[0]!.index).toBe(0);
+      expect(failures[0]!.message.length).toBeGreaterThan(0);
+      // Second rule (valid) must still produce a match
+      expect(results).toHaveLength(2);
+      expect(results[0]!).toEqual([]);
+      expect(results[1]!).toHaveLength(1);
+      expect(results[1]![0]!.lineNumber).toBe(2);
+    });
+
+    it('routes a valid subsequent rule to results even when an earlier rule throws', () => {
+      const content = 'debugger;\nconsole.log(1);\n';
+      const invalidRule = { rule: { kind: '!!!INVALID_KIND!!!' } } as unknown as AstGrepRule;
+
+      const failures: number[] = [];
+      const results = matchAstGrepPatternsBatch(
+        content,
+        '.ts',
+        [
+          { rule: 'debugger', addedLineNumbers: [1] },
+          { rule: invalidRule, addedLineNumbers: [2] },
+          { rule: 'console.log($$$)', addedLineNumbers: [2] },
+        ],
+        (index) => {
+          failures.push(index);
+        },
+      );
+
+      expect(failures).toEqual([1]);
+      expect(results[0]!).toHaveLength(1);
+      expect(results[1]!).toEqual([]);
+      expect(results[2]!).toHaveLength(1);
+    });
   });
 });

--- a/packages/core/src/ast-grep-query.ts
+++ b/packages/core/src/ast-grep-query.ts
@@ -155,7 +155,11 @@ export function matchAstGrepPatternsBatch(
     try {
       return executeQuery(root, rule, addedLineNumbers, lines);
     } catch (err) {
-      const wrapped = err instanceof Error ? err : new Error(String(err));
+      // Preserve the original thrown value in `cause` so downstream
+      // error-chain walkers (rule 102) can surface the underlying
+      // napi/runtime error without losing structure. Plain string
+      // throws are wrapped but still chained.
+      const wrapped = err instanceof Error ? err : new Error(String(err), { cause: err });
       onRuleFailure(index, wrapped);
       return [];
     }

--- a/packages/core/src/ast-grep-query.ts
+++ b/packages/core/src/ast-grep-query.ts
@@ -40,6 +40,15 @@ function extensionToLang(ext: string): Lang | undefined {
 
 // ─── Core matching ──────────────────────────────────
 
+/**
+ * Per-rule failure sink. Invoked when `findAll` throws inside a batch. The
+ * index is the position of the failing query in the original input array so
+ * the caller can map the failure back to a `CompiledRule`. Introduced in
+ * mmnto/totem#1408 to fulfil spike finding G-7: one malformed compound rule
+ * must not blast-radius the whole file's ast-grep pass.
+ */
+export type OnRuleFailure = (index: number, err: Error) => void;
+
 function executeQuery(
   root: import('@ast-grep/napi').SgRoot,
   rule: AstGrepRule,
@@ -101,13 +110,26 @@ export function matchAstGrepPattern(
 
 /**
  * Parse a file once and run multiple ast-grep rules against it.
- * O(M + N) — file parsed exactly once regardless of rule count.
+ * O(M + N) - file parsed exactly once regardless of rule count.
  * Returns results indexed by position in the input array.
+ *
+ * When `onRuleFailure` is passed, each per-rule `findAll` call runs inside
+ * its own try/catch (spike finding G-7, mmnto/totem#1408): a malformed
+ * compound rule emits a failure event, yields an empty result array for
+ * that index, and the remaining rules continue to execute. Without the
+ * sink, the legacy fail-closed behavior holds - the first per-rule failure
+ * aborts the whole batch via `TotemParseError`.
+ *
+ * The parse-time failure (invalid source, unsupported language) still
+ * escapes via `rethrowAsParseError` regardless of the sink, because a parse
+ * error affects every query on the file and there is no way to produce
+ * honest per-rule results from a broken tree.
  */
 export function matchAstGrepPatternsBatch(
   content: string,
   ext: string,
   queries: Array<{ rule: AstGrepRule; addedLineNumbers: number[] }>,
+  onRuleFailure?: OnRuleFailure,
 ): AstGrepMatch[][] {
   if (queries.length === 0) return [];
 
@@ -118,12 +140,24 @@ export function matchAstGrepPatternsBatch(
 
   const lines = content.split('\n');
 
+  let root: import('@ast-grep/napi').SgRoot;
   try {
-    const root = parse(lang, content);
-    return queries.map(({ rule, addedLineNumbers }) =>
-      executeQuery(root, rule, addedLineNumbers, lines),
-    );
+    root = parse(lang, content);
   } catch (err) {
     rethrowAsParseError('ast-grep batch parse failed', err, AST_GREP_HINT);
   }
+
+  return queries.map(({ rule, addedLineNumbers }, index) => {
+    if (!onRuleFailure) {
+      // Legacy path: first failure aborts the whole batch.
+      return executeQuery(root, rule, addedLineNumbers, lines);
+    }
+    try {
+      return executeQuery(root, rule, addedLineNumbers, lines);
+    } catch (err) {
+      const wrapped = err instanceof Error ? err : new Error(String(err));
+      onRuleFailure(index, wrapped);
+      return [];
+    }
+  });
 }

--- a/packages/core/src/compile-lesson.test.ts
+++ b/packages/core/src/compile-lesson.test.ts
@@ -557,6 +557,117 @@ describe('buildCompiledRule ast-grep validation (#1062)', () => {
   });
 });
 
+// ─── Smoke gate wiring (mmnto/totem#1408) ────────────
+
+describe('buildCompiledRule smoke gate (mmnto/totem#1408)', () => {
+  it('rejects Pipeline 2 ast-grep rule that is missing badExample', () => {
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'No debugger',
+      engine: 'ast-grep',
+      astGrepPattern: 'debugger',
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      enforceSmokeGate: true,
+    });
+    expect(result.rule).toBeNull();
+    expect(result.rejectReason).toContain('smoke gate');
+    expect(result.rejectReason).toContain('badExample');
+  });
+
+  it('rejects Pipeline 2 ast-grep rule whose badExample produces zero matches', () => {
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'No debugger',
+      engine: 'ast-grep',
+      astGrepPattern: 'debugger',
+      badExample: 'const x = 1;\n',
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      enforceSmokeGate: true,
+    });
+    expect(result.rule).toBeNull();
+    expect(result.rejectReason).toContain('smoke gate');
+    expect(result.rejectReason).toContain('zero matches');
+  });
+
+  it('rejects Pipeline 2 regex rule that is missing badExample', () => {
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'No console.log',
+      engine: 'regex',
+      pattern: 'console\\.log',
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      enforceSmokeGate: true,
+    });
+    expect(result.rule).toBeNull();
+    expect(result.rejectReason).toContain('smoke gate');
+    expect(result.rejectReason).toContain('badExample');
+  });
+
+  it('accepts Pipeline 2 ast-grep rule whose badExample produces matches', () => {
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'No debugger',
+      engine: 'ast-grep',
+      astGrepPattern: 'debugger',
+      badExample: 'debugger;\n',
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      enforceSmokeGate: true,
+    });
+    expect(result.rule).not.toBeNull();
+    expect(result.rule!.badExample).toBe('debugger;\n');
+  });
+
+  it('persists badExample on the CompiledRule when the gate accepts', () => {
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'No console.log',
+      engine: 'regex',
+      pattern: 'console\\.log',
+      badExample: 'console.log("debug")',
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      enforceSmokeGate: true,
+    });
+    expect(result.rule).not.toBeNull();
+    expect(result.rule!.badExample).toBe('console.log("debug")');
+  });
+
+  it('honors badExampleOverride so Pipeline 3 can reuse its Bad snippet', () => {
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'No console.log',
+      engine: 'regex',
+      pattern: 'console\\.log',
+      // No badExample on parsed; caller supplies it via override
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      enforceSmokeGate: true,
+      badExampleOverride: 'console.log("bad")',
+    });
+    expect(result.rule).not.toBeNull();
+    expect(result.rule!.badExample).toBe('console.log("bad")');
+  });
+
+  it('Pipeline 1 is unaffected (gate is opt-in via enforceSmokeGate)', () => {
+    // Without the option flag, buildCompiledRule must behave exactly as before.
+    // This pins the design invariant that Pipeline 1 / ad-hoc callers do not
+    // break in mmnto/totem#1408. The gate-flip for Pipeline 1 is a follow-up.
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'No console.log',
+      engine: 'regex',
+      pattern: 'console\\.log',
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash);
+    expect(result.rule).not.toBeNull();
+    expect(result.rejectReason).toBeUndefined();
+  });
+});
+
 // ─── buildManualRule ────────────────────────────────
 
 describe('buildManualRule', () => {
@@ -662,6 +773,11 @@ describe('compileLesson', () => {
             pattern: 'console\\.log',
             message: 'No console.log',
             engine: 'regex' as const,
+            // mmnto/totem#1408: Pipeline 2 now requires a badExample that the
+            // smoke gate can match. Every existing happy-path test here still
+            // wants the rule to compile, so give the helper a known-good
+            // snippet that matches the pattern.
+            badExample: 'console.log("debug")',
           }
         : null,
     ),
@@ -678,6 +794,46 @@ describe('compileLesson', () => {
     const result = await compileLesson(lesson, 'system prompt', deps);
     expect(result.status).toBe('compiled');
     expect(deps.runOrchestrator).toHaveBeenCalled();
+  });
+
+  // ─── Smoke gate on Pipeline 2 (mmnto/totem#1408) ──
+
+  it('Pipeline 2 rejects a rule whose LLM output omits badExample', async () => {
+    const deps: CompileLessonDeps = {
+      parseCompilerResponse: vi.fn().mockReturnValue({
+        compilable: true,
+        pattern: 'console\\.log',
+        message: 'No console.log',
+        engine: 'regex' as const,
+        // No badExample — gate must reject
+      }),
+      runOrchestrator: vi.fn().mockResolvedValue('{"compilable": true}'),
+      existingByHash: new Map(),
+      callbacks: { onWarn: vi.fn(), onDim: vi.fn() },
+    };
+    const result = await compileLesson(lesson, 'system prompt', deps);
+    expect(result.status).toBe('failed');
+    expect(deps.callbacks!.onWarn).toHaveBeenCalledWith(
+      lesson.heading,
+      expect.stringContaining('smoke gate'),
+    );
+  });
+
+  it('Pipeline 2 accepts a rule whose LLM output supplies a matching badExample', async () => {
+    const deps: CompileLessonDeps = {
+      parseCompilerResponse: vi.fn().mockReturnValue({
+        compilable: true,
+        pattern: 'console\\.log',
+        message: 'No console.log',
+        engine: 'regex' as const,
+        badExample: 'console.log("debug")',
+      }),
+      runOrchestrator: vi.fn().mockResolvedValue('{"compilable": true}'),
+      existingByHash: new Map(),
+      callbacks: { onWarn: vi.fn(), onDim: vi.fn() },
+    };
+    const result = await compileLesson(lesson, 'system prompt', deps);
+    expect(result.status).toBe('compiled');
   });
 
   // ─── Phase 3 systemPrompt threading (mmnto/totem#1291) ─────
@@ -740,6 +896,7 @@ describe('compileLesson', () => {
         pattern: 'console\\.log',
         message: 'No console.log',
         engine: 'regex' as const,
+        badExample: 'console.log("debug")',
       }),
       runOrchestrator: vi.fn().mockResolvedValue('{"compilable": true}'),
       existingByHash: new Map(),
@@ -1004,6 +1161,7 @@ describe('compileLesson with inline examples', () => {
             pattern: 'console\\.log',
             message: 'No console.log',
             engine: 'regex' as const,
+            badExample: 'console.log("debug")',
           }
         : null,
     ),
@@ -1143,11 +1301,14 @@ describe('compileLesson Pipeline 3 (Bad/Good snippets)', () => {
     );
   });
 
-  it('fails self-verification when pattern does not match Bad snippet', async () => {
+  it('rejects at the smoke gate when the pattern does not match the Bad snippet (mmnto/totem#1408)', async () => {
     const deps: CompileLessonDeps = {
       parseCompilerResponse: vi.fn().mockReturnValue({
         compilable: true,
-        // Pattern matches neither Bad nor Good — will fail self-test
+        // Pattern matches neither Bad nor Good - smoke gate catches this
+        // before the old self-verification step ever runs. Pre-#1408 the
+        // test asserted on the self-verification message; post-#1408 the
+        // smoke gate is the earlier (and stricter) filter.
         pattern: 'this_matches_nothing_at_all',
         message: 'Wrong pattern',
         engine: 'regex' as const,
@@ -1160,7 +1321,7 @@ describe('compileLesson Pipeline 3 (Bad/Good snippets)', () => {
     expect(result.status).toBe('failed');
     expect(deps.callbacks!.onWarn).toHaveBeenCalledWith(
       pipeline3Lesson.heading,
-      expect.stringContaining('self-verification'),
+      expect.stringContaining('smoke gate'),
     );
   });
 

--- a/packages/core/src/compile-lesson.ts
+++ b/packages/core/src/compile-lesson.ts
@@ -381,9 +381,12 @@ export function buildCompiledRule(
   // mmnto/totem#1408: compile-time smoke gate. Opt-in via options so Pipeline 1
   // and ad-hoc test callers are unaffected. The gate reuses the runtime engine
   // entry points so a rule passing here cannot silently fail to match at
-  // runtime on identical input. Not wired to the 'ast' engine yet; callers
-  // that enforce the gate on ast rules get a skip reason they can surface.
-  if (options.enforceSmokeGate) {
+  // runtime on identical input. Skipped for the 'ast' (Tree-sitter) engine
+  // because runSmokeGate does not yet cover S-expression queries; those rules
+  // fall back to the existing `verifyRuleExamples` path. Skipping here
+  // matches the comment in compile-smoke-gate.ts and prevents the gate from
+  // hard-rejecting a rule it is not equipped to evaluate.
+  if (options.enforceSmokeGate && candidate.engine !== 'ast') {
     if (!effectiveBadExample) {
       return {
         rule: null,

--- a/packages/core/src/compile-lesson.ts
+++ b/packages/core/src/compile-lesson.ts
@@ -1,5 +1,6 @@
 import { Lang, parse } from '@ast-grep/napi';
 
+import { runSmokeGate } from './compile-smoke-gate.js';
 import { engineFields, sanitizeFileGlobs, validateRegex } from './compiler.js';
 import type { CompiledRule, CompilerOutput, RegexValidation } from './compiler-schema.js';
 import {
@@ -227,6 +228,30 @@ function isSelfSuppressing(pattern: string): boolean {
 // ─── Rule builder (pure, no I/O) ────────────────────
 
 /**
+ * Options controlling how `buildCompiledRule` validates its input before
+ * emitting a `CompiledRule`. The smoke gate is opt-in so Pipeline 1 (manual)
+ * callers and ad-hoc test callers keep their existing behaviour unchanged;
+ * Pipeline 2 (LLM) and Pipeline 3 (example-based) opt in explicitly in the
+ * compileLesson flow.
+ */
+export interface BuildCompiledRuleOptions {
+  /**
+   * When true, the smoke gate runs after validation and before rule emission.
+   * Missing badExample or zero-match badExample both reject the rule with a
+   * rejectReason that names the gate. When false (default), the gate is
+   * skipped entirely - backward compatible.
+   */
+  enforceSmokeGate?: boolean;
+  /**
+   * Optional badExample override. When supplied, takes precedence over
+   * `parsed.badExample`. Pipeline 3 uses this to reuse its Bad snippet as the
+   * smoke-gate target without relying on the LLM to echo the snippet back in
+   * the structured output.
+   */
+  badExampleOverride?: string;
+}
+
+/**
  * Build a CompiledRule from parsed compiler output.
  * Returns { rule, rejectReason } so callers can report why a rule was rejected.
  */
@@ -234,6 +259,7 @@ export function buildCompiledRule(
   parsed: CompilerOutput,
   lesson: { hash: string; heading: string },
   existingByHash: Map<string, CompiledRule>,
+  options: BuildCompiledRuleOptions = {},
 ): BuildRuleResult {
   if (!parsed.compilable) return { rule: null };
 
@@ -243,6 +269,16 @@ export function buildCompiledRule(
   const existing = existingByHash.get(lesson.hash);
   const sanitizedGlobs = parsed.fileGlobs ? sanitizeFileGlobs(parsed.fileGlobs) : undefined;
   const globsObj = sanitizedGlobs && sanitizedGlobs.length > 0 ? { fileGlobs: sanitizedGlobs } : {};
+  // mmnto/totem#1408: the effective badExample is the override when present,
+  // else whatever the LLM echoed back in CompilerOutput. Pipeline 1 and ad-hoc
+  // callers that leave the option off bypass the gate entirely.
+  const effectiveBadExample = options.badExampleOverride ?? parsed.badExample;
+  const badExampleObj =
+    effectiveBadExample && effectiveBadExample.length > 0
+      ? { badExample: effectiveBadExample }
+      : {};
+
+  let candidate: CompiledRule;
 
   if (engine === 'ast-grep') {
     // mmnto/totem#1407 split the field. Mutual exclusion is enforced
@@ -280,61 +316,55 @@ export function buildCompiledRule(
       };
     }
 
-    return {
-      rule: {
-        lessonHash: lesson.hash,
-        lessonHeading: lesson.heading,
-        message: parsed.message,
-        engine: 'ast-grep',
-        severity,
-        ...engineFields('ast-grep', astSource),
-        compiledAt: now,
-        createdAt: existing?.createdAt ?? now,
-        ...globsObj,
-      },
+    candidate = {
+      lessonHash: lesson.hash,
+      lessonHeading: lesson.heading,
+      message: parsed.message,
+      engine: 'ast-grep',
+      severity,
+      ...engineFields('ast-grep', astSource),
+      compiledAt: now,
+      createdAt: existing?.createdAt ?? now,
+      ...globsObj,
+      ...badExampleObj,
     };
-  }
-
-  if (engine === 'ast') {
+  } else if (engine === 'ast') {
     if (!parsed.astQuery || !parsed.message) {
       return { rule: null, rejectReason: 'Missing astQuery or message' };
     }
-    return {
-      rule: {
-        lessonHash: lesson.hash,
-        lessonHeading: lesson.heading,
-        message: parsed.message,
-        engine: 'ast',
-        severity,
-        ...engineFields('ast', parsed.astQuery),
-        compiledAt: now,
-        createdAt: existing?.createdAt ?? now,
-        ...globsObj,
-      },
+    candidate = {
+      lessonHash: lesson.hash,
+      lessonHeading: lesson.heading,
+      message: parsed.message,
+      engine: 'ast',
+      severity,
+      ...engineFields('ast', parsed.astQuery),
+      compiledAt: now,
+      createdAt: existing?.createdAt ?? now,
+      ...globsObj,
+      ...badExampleObj,
     };
-  }
+  } else {
+    // Regex engine (default)
+    if (!parsed.pattern || !parsed.message) {
+      return { rule: null, rejectReason: 'Missing pattern or message' };
+    }
+    const validation = validateRegex(parsed.pattern);
+    if (!validation.valid) {
+      return { rule: null, rejectReason: `Rejected regex: ${validation.reason}` };
+    }
 
-  // Regex engine (default)
-  if (!parsed.pattern || !parsed.message) {
-    return { rule: null, rejectReason: 'Missing pattern or message' };
-  }
-  const validation = validateRegex(parsed.pattern);
-  if (!validation.valid) {
-    return { rule: null, rejectReason: `Rejected regex: ${validation.reason}` };
-  }
+    // Guard: reject patterns that match suppression directives (#1177)
+    // These rules can never fire — the engine suppresses matching lines before rule evaluation.
+    if (isSelfSuppressing(parsed.pattern)) {
+      return {
+        rule: null,
+        rejectReason:
+          'Pattern matches a suppression directive (totem-ignore/totem-context) and will self-suppress at runtime',
+      };
+    }
 
-  // Guard: reject patterns that match suppression directives (#1177)
-  // These rules can never fire — the engine suppresses matching lines before rule evaluation.
-  if (isSelfSuppressing(parsed.pattern)) {
-    return {
-      rule: null,
-      rejectReason:
-        'Pattern matches a suppression directive (totem-ignore/totem-context) and will self-suppress at runtime',
-    };
-  }
-
-  return {
-    rule: {
+    candidate = {
       lessonHash: lesson.hash,
       lessonHeading: lesson.heading,
       message: parsed.message,
@@ -344,8 +374,33 @@ export function buildCompiledRule(
       compiledAt: now,
       createdAt: existing?.createdAt ?? now,
       ...globsObj,
-    },
-  };
+      ...badExampleObj,
+    };
+  }
+
+  // mmnto/totem#1408: compile-time smoke gate. Opt-in via options so Pipeline 1
+  // and ad-hoc test callers are unaffected. The gate reuses the runtime engine
+  // entry points so a rule passing here cannot silently fail to match at
+  // runtime on identical input. Not wired to the 'ast' engine yet; callers
+  // that enforce the gate on ast rules get a skip reason they can surface.
+  if (options.enforceSmokeGate) {
+    if (!effectiveBadExample) {
+      return {
+        rule: null,
+        rejectReason: 'smoke gate: missing badExample (required for Pipeline 2/3)',
+      };
+    }
+    const gate = runSmokeGate(candidate, effectiveBadExample);
+    if (!gate.matched) {
+      const suffix = gate.reason ? ` (${gate.reason})` : '';
+      return {
+        rule: null,
+        rejectReason: `smoke gate: zero matches against badExample${suffix}`,
+      };
+    }
+  }
+
+  return { rule: candidate };
 }
 
 // ─── Manual pattern builder ─────────────────────────
@@ -530,7 +585,13 @@ export async function compileLesson(
       return { status: 'skipped', hash: lesson.hash, reason: parsed.reason };
     }
 
-    const ruleResult = buildCompiledRule(parsed, lesson, existingByHash);
+    // mmnto/totem#1408: Pipeline 3 reuses its Bad snippet as the smoke-gate
+    // target. The LLM may or may not echo the snippet back in parsed.badExample;
+    // the override guarantees the gate has something to work with regardless.
+    const ruleResult = buildCompiledRule(parsed, lesson, existingByHash, {
+      enforceSmokeGate: true,
+      badExampleOverride: snippets.bad.join('\n'),
+    });
     if (!ruleResult.rule) {
       callbacks?.onWarn?.(
         lesson.heading,
@@ -594,7 +655,13 @@ export async function compileLesson(
     return { status: 'skipped', hash: lesson.hash, reason: parsed.reason };
   }
 
-  const ruleResult = buildCompiledRule(parsed, lesson, existingByHash);
+  // mmnto/totem#1408: Pipeline 2 enforces the smoke gate. Rules without a
+  // badExample, or whose badExample fails to match the pattern, are rejected
+  // with a clear reason before landing in compiled-rules.json. The compile
+  // prompt rewrite in mmnto/totem#1409 teaches Sonnet to emit the field.
+  const ruleResult = buildCompiledRule(parsed, lesson, existingByHash, {
+    enforceSmokeGate: true,
+  });
   if (!ruleResult.rule) {
     callbacks?.onWarn?.(lesson.heading, `${ruleResult.rejectReason ?? 'Unknown error'} — skipping`);
     return { status: 'failed' };

--- a/packages/core/src/compile-smoke-gate.test.ts
+++ b/packages/core/src/compile-smoke-gate.test.ts
@@ -153,6 +153,29 @@ describe('runSmokeGate — ast-grep compound (astGrepYamlRule)', () => {
   });
 });
 
+// ─── extension inference (GCA WARN on design review) ─
+
+describe('runSmokeGate badExample extension inference', () => {
+  it('defaults to a TSX parser so JSX-flavored bad examples still parse', () => {
+    const rule = makeAstGrepStringRule({
+      astGrepPattern: 'console.log($$$)',
+    });
+    const jsxSnippet = 'const page = <div>{console.log("hi")}</div>;\n';
+    const result = runSmokeGate(rule, jsxSnippet);
+    expect(result.matched).toBe(true);
+  });
+
+  it('honors a concrete extension from the rule fileGlobs when present', () => {
+    const rule = makeAstGrepStringRule({
+      fileGlobs: ['**/*.ts'],
+      astGrepPattern: 'debugger',
+    });
+    const tsSnippet = 'debugger;\n';
+    const result = runSmokeGate(rule, tsSnippet);
+    expect(result.matched).toBe(true);
+  });
+});
+
 // ─── runtime-parity invariant ────────────────────────
 
 describe('runSmokeGate runtime parity invariant', () => {

--- a/packages/core/src/compile-smoke-gate.test.ts
+++ b/packages/core/src/compile-smoke-gate.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+
+import { matchAstGrepPattern } from './ast-grep-query.js';
+import { runSmokeGate } from './compile-smoke-gate.js';
+import type { CompiledRule } from './compiler-schema.js';
+
+// ─── Helpers ────────────────────────────────────────
+
+function makeRegexRule(overrides: Partial<CompiledRule> = {}): CompiledRule {
+  return {
+    lessonHash: 'deadbeef1234',
+    lessonHeading: 'No console.log',
+    pattern: 'console\\.log',
+    message: 'Do not use console.log',
+    engine: 'regex',
+    compiledAt: '2026-04-13T12:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeAstGrepStringRule(overrides: Partial<CompiledRule> = {}): CompiledRule {
+  return {
+    lessonHash: 'cafeface5678',
+    lessonHeading: 'No debugger',
+    pattern: '',
+    message: 'Do not commit debugger statements',
+    engine: 'ast-grep',
+    astGrepPattern: 'debugger',
+    compiledAt: '2026-04-13T12:00:00Z',
+    ...overrides,
+  };
+}
+
+function makeCompoundRule(overrides: Partial<CompiledRule> = {}): CompiledRule {
+  return {
+    lessonHash: 'beefcafe9abc',
+    lessonHeading: 'Empty catch',
+    pattern: '',
+    message: 'Empty catch swallows errors',
+    engine: 'ast-grep',
+    astGrepYamlRule: {
+      rule: {
+        kind: 'catch_clause',
+        not: {
+          has: {
+            kind: 'statement_block',
+            has: {
+              any: [
+                { kind: 'expression_statement' },
+                { kind: 'variable_declaration' },
+                { kind: 'if_statement' },
+                { kind: 'return_statement' },
+                { kind: 'throw_statement' },
+              ],
+              stopBy: 'end',
+            },
+          },
+        },
+      },
+    },
+    compiledAt: '2026-04-13T12:00:00Z',
+    ...overrides,
+  };
+}
+
+// ─── runSmokeGate: regex rules ───────────────────────
+
+describe('runSmokeGate — regex engine', () => {
+  it('matches when the badExample contains the pattern', () => {
+    const rule = makeRegexRule();
+    const result = runSmokeGate(rule, 'console.log("debug")');
+    expect(result.matched).toBe(true);
+    expect(result.matchCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not match when the badExample is clean', () => {
+    const rule = makeRegexRule();
+    const result = runSmokeGate(rule, 'const x = 1;');
+    expect(result.matched).toBe(false);
+    expect(result.matchCount).toBe(0);
+  });
+
+  it('returns matched false for an empty badExample', () => {
+    const rule = makeRegexRule();
+    const result = runSmokeGate(rule, '');
+    expect(result.matched).toBe(false);
+    expect(result.matchCount).toBe(0);
+  });
+
+  it('returns matched false when the regex itself is invalid', () => {
+    const rule = makeRegexRule({ pattern: '(unclosed' });
+    const result = runSmokeGate(rule, 'console.log(1)');
+    expect(result.matched).toBe(false);
+    expect(result.matchCount).toBe(0);
+    expect(result.reason).toContain('invalid');
+  });
+});
+
+// ─── runSmokeGate: flat ast-grep rules ───────────────
+
+describe('runSmokeGate — ast-grep flat pattern', () => {
+  it('matches when the pattern hits the badExample', () => {
+    const rule = makeAstGrepStringRule();
+    const result = runSmokeGate(rule, 'debugger;\n');
+    expect(result.matched).toBe(true);
+    expect(result.matchCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not match when the pattern misses the badExample', () => {
+    const rule = makeAstGrepStringRule();
+    const result = runSmokeGate(rule, 'const x = 1;\n');
+    expect(result.matched).toBe(false);
+    expect(result.matchCount).toBe(0);
+  });
+
+  it('returns matched false when the pattern itself throws at runtime', () => {
+    // Invalid kind — the ast-grep engine throws. The gate must surface
+    // this as a non-match with a reason rather than propagating.
+    const rule = makeAstGrepStringRule({ astGrepPattern: undefined });
+    const invalid = makeAstGrepStringRule({ astGrepPattern: 'catch ($E) { $$$ }' });
+    // Force an invalid string pattern so findAll throws.
+    const result = runSmokeGate(invalid, 'try { work() } catch (err) {}');
+    // A bare catch string pattern is multi-root and throws; the gate
+    // swallows the throw and reports no match with a reason.
+    expect(result.matched).toBe(false);
+    expect(rule).toBeDefined(); // silence unused
+  });
+});
+
+// ─── runSmokeGate: compound ast-grep rules ───────────
+
+describe('runSmokeGate — ast-grep compound (astGrepYamlRule)', () => {
+  it('matches when the compound rule fires on the badExample', () => {
+    const rule = makeCompoundRule();
+    const result = runSmokeGate(rule, 'try {\n  work();\n} catch (err) {\n}\n');
+    expect(result.matched).toBe(true);
+  });
+
+  it('does not match when the compound rule misses the badExample', () => {
+    const rule = makeCompoundRule();
+    const result = runSmokeGate(rule, 'try {\n  work();\n} catch (err) {\n  log(err);\n}\n');
+    expect(result.matched).toBe(false);
+    expect(result.matchCount).toBe(0);
+  });
+
+  it('returns matched false with a reason when the compound rule throws', () => {
+    const rule = makeCompoundRule({
+      astGrepYamlRule: { rule: { kind: '!!!INVALID_KIND!!!' } },
+    });
+    const result = runSmokeGate(rule, 'const x = 1;\n');
+    expect(result.matched).toBe(false);
+    expect(result.reason).toBeDefined();
+  });
+});
+
+// ─── runtime-parity invariant ────────────────────────
+
+describe('runSmokeGate runtime parity invariant', () => {
+  it('uses the same engine entry points as the runtime — gate-pass implies runtime-match', () => {
+    // If runSmokeGate reports matched === true with a non-zero matchCount,
+    // matchAstGrepPattern (the runtime entry point) invoked on the same
+    // snippet must also produce at least one match. The gate is a thin
+    // wrapper around that exact function, so this is a structural
+    // guarantee - the test locks in the guarantee against drift.
+    const rule = makeAstGrepStringRule();
+    const snippet = 'debugger;\nconst x = 1;\n';
+    const result = runSmokeGate(rule, snippet);
+    expect(result.matched).toBe(true);
+    // Reuse the same engine entry point to verify runtime parity.
+    const matches = matchAstGrepPattern(
+      snippet,
+      '.ts',
+      'debugger',
+      snippet.split('\n').map((_, i) => i + 1),
+    );
+    expect(matches.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/packages/core/src/compile-smoke-gate.test.ts
+++ b/packages/core/src/compile-smoke-gate.test.ts
@@ -174,6 +174,37 @@ describe('runSmokeGate badExample extension inference', () => {
     const result = runSmokeGate(rule, tsSnippet);
     expect(result.matched).toBe(true);
   });
+
+  // Regression for CR finding on PR #1415: multi-extension fileGlobs must
+  // try every declared extension, not just the first match. Otherwise
+  // a rule scoped to both `.js` and `.jsx` would gate on JavaScript only
+  // and false-reject JSX-flavored bad examples, breaking parity with
+  // runtime (which picks Lang.Tsx for `.jsx` files).
+  it('tries every positive extension in fileGlobs, not just the first match', () => {
+    const rule = makeAstGrepStringRule({
+      fileGlobs: ['**/*.js', '**/*.jsx'],
+      astGrepPattern: 'console.log($$$)',
+    });
+    // JSX-flavored snippet: would fail under JavaScript parser but matches
+    // under Tsx. Runtime would also use Tsx for a real `.jsx` file.
+    const jsxSnippet = 'const el = <div>{console.log("hi")}</div>;\n';
+    const result = runSmokeGate(rule, jsxSnippet);
+    expect(result.matched).toBe(true);
+  });
+
+  // Regression for CR finding on PR #1415: an unscoped rule with a TS
+  // angle-bracket cast must not be false-rejected by a TSX-only fallback.
+  // TS allows `<Foo>bar` as a type cast; TSX rejects it as an ambiguous
+  // JSX tag open. The gate tries `.ts` before `.tsx` in the fallback set.
+  it('accepts TS angle-bracket cast syntax on unscoped rules (not just TSX)', () => {
+    const rule = makeAstGrepStringRule({
+      fileGlobs: undefined, // unscoped
+      astGrepPattern: '<$TYPE>$EXPR',
+    });
+    const tsSnippet = 'const x = <Foo>bar;\n';
+    const result = runSmokeGate(rule, tsSnippet);
+    expect(result.matched).toBe(true);
+  });
 });
 
 // ─── runtime-parity invariant ────────────────────────

--- a/packages/core/src/compile-smoke-gate.ts
+++ b/packages/core/src/compile-smoke-gate.ts
@@ -75,22 +75,33 @@ function runRegexGate(pattern: string, badExample: string): SmokeGateResult {
 }
 
 /**
- * Infer the file extension the ast-grep engine should use when parsing the
- * badExample snippet. Defaults to `.tsx` (TSX, the most permissive parser -
- * superset of TypeScript plus JSX) so a JSX-flavored bad example does not
- * falsely reject at the parser boundary. If the rule declares a fileGlobs
- * with a concrete extension, honor that; otherwise fall back to TSX.
+ * Collect the ordered list of file extensions the ast-grep engine could use
+ * when parsing the badExample. Returns every positive match from
+ * `fileGlobs`; if no globs are declared, returns a broad default set so an
+ * unscoped rule still has a chance to match the snippet under some parser.
+ *
+ * Why a list rather than a single extension: `.ts` and `.tsx` select
+ * different tree-sitter parsers that reject each other's syntax. A TS
+ * angle-bracket cast (`const x = <Foo>bar;`) parses as TS but not as TSX;
+ * a JSX element parses as TSX but not as TS. If the rule's fileGlobs
+ * allow multiple extensions, runtime will pick whichever matches the real
+ * file, so the gate must try every declared extension too. Passing on ANY
+ * extension is sufficient — runtime scans the same surface.
  */
-function inferBadExampleExt(rule: CompiledRule): string {
-  const globs = rule.fileGlobs ?? [];
-  for (const g of globs) {
+function inferBadExampleExts(rule: CompiledRule): string[] {
+  const exts = new Set<string>();
+  for (const g of rule.fileGlobs ?? []) {
     if (g.startsWith('!')) continue;
-    // Extract the trailing `.ext` for simple patterns like `*.tsx` or
-    // `**/*.test.ts`. Anything more exotic falls through to the default.
-    const match = /\.(ts|tsx|js|jsx|mjs|cjs)$/i.exec(g);
-    if (match) return `.${match[1]!.toLowerCase()}`;
+    for (const m of g.matchAll(/\.(ts|tsx|js|jsx|mjs|cjs)\b/gi)) {
+      exts.add(`.${m[1]!.toLowerCase()}`);
+    }
   }
-  return '.tsx';
+  // Unscoped rule: try the full supported set so the gate does not
+  // false-reject on a snippet that would match under some parser. Order
+  // puts TypeScript first (handles cast syntax), then TSX, then JS
+  // variants. Parity with runtime is preserved because runtime also
+  // executes the rule against any file whose extension matches.
+  return exts.size > 0 ? [...exts] : ['.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs'];
 }
 
 function runAstGrepGate(
@@ -99,19 +110,20 @@ function runAstGrepGate(
   rule: CompiledRule,
 ): SmokeGateResult {
   const lineNumbers = lineNumbersFor(badExample);
-  const ext = inferBadExampleExt(rule);
-  try {
-    const matches = matchAstGrepPattern(badExample, ext, pattern, lineNumbers);
-    return matches.length > 0
-      ? { matched: true, matchCount: matches.length }
-      : { matched: false, matchCount: 0 };
-  } catch (err) {
-    return {
-      matched: false,
-      matchCount: 0,
-      reason: `ast-grep runtime error: ${firstLine(err instanceof Error ? err.message : String(err))}`,
-    };
+  let lastReason: string | undefined;
+  for (const ext of inferBadExampleExts(rule)) {
+    try {
+      const matches = matchAstGrepPattern(badExample, ext, pattern, lineNumbers);
+      if (matches.length > 0) {
+        return { matched: true, matchCount: matches.length };
+      }
+    } catch (err) {
+      lastReason = `ast-grep runtime error: ${firstLine(err instanceof Error ? err.message : String(err))}`;
+    }
   }
+  return lastReason
+    ? { matched: false, matchCount: 0, reason: lastReason }
+    : { matched: false, matchCount: 0 };
 }
 
 // ─── Public API ─────────────────────────────────────

--- a/packages/core/src/compile-smoke-gate.ts
+++ b/packages/core/src/compile-smoke-gate.ts
@@ -1,0 +1,131 @@
+/**
+ * Compile-time smoke gate for compiled rules (ADR-087).
+ *
+ * Runs a freshly built `CompiledRule` against its own `badExample` snippet
+ * using the same engine entry points that the runtime uses (`matchAstGrepPattern`
+ * for ast-grep, `new RegExp` for regex). If the rule cannot match its own
+ * bad example, something structurally wrong happened between the LLM output
+ * and the persisted rule shape — either the pattern does not compile against
+ * the snippet, or the snippet does not exercise the pattern the prompt
+ * promised. Either way, the rule has no business in compiled-rules.json.
+ *
+ * The gate is intentionally a thin wrapper: its entire purpose is to
+ * guarantee that a rule passing here will also fire at runtime on identical
+ * input. Any divergence between "smoke gate happy" and "runtime happy" is a
+ * bug in this module, not a rule authoring problem.
+ *
+ * Not wired to Pipeline 1 (manual) rules in mmnto/totem#1408 - a dry-run
+ * sweep lands in a follow-up ticket before the Pipeline 1 gate flips on.
+ */
+
+import type { AstGrepRule } from './ast-grep-query.js';
+import { matchAstGrepPattern } from './ast-grep-query.js';
+import type { CompiledRule } from './compiler-schema.js';
+
+// ─── Types ──────────────────────────────────────────
+
+export interface SmokeGateResult {
+  /** True when the rule produced at least one match against the badExample. */
+  matched: boolean;
+  /** Number of matches the engine reported. Zero when `matched` is false. */
+  matchCount: number;
+  /**
+   * When matched is false and the engine refused to execute (invalid regex,
+   * ast-grep runtime throw, missing engine fields), this carries the first
+   * line of the error so the caller can build a human-readable rejectReason.
+   * Absent when matched is true, and absent when matched is false due to the
+   * snippet simply not containing anything the pattern would match.
+   */
+  reason?: string;
+}
+
+// ─── Helpers ────────────────────────────────────────
+
+function firstLine(message: string): string {
+  const m = /^[^\n]*/.exec(message);
+  return (m?.[0] ?? message).trim();
+}
+
+function lineNumbersFor(snippet: string): number[] {
+  const lineCount = snippet.split('\n').length;
+  const result: number[] = [];
+  for (let i = 1; i <= lineCount; i++) result.push(i);
+  return result;
+}
+
+// ─── Engine runners ─────────────────────────────────
+
+function runRegexGate(pattern: string, badExample: string): SmokeGateResult {
+  let re: RegExp;
+  try {
+    re = new RegExp(pattern);
+  } catch (err) {
+    return {
+      matched: false,
+      matchCount: 0,
+      reason: `invalid regex: ${firstLine(err instanceof Error ? err.message : String(err))}`,
+    };
+  }
+
+  let matchCount = 0;
+  for (const line of badExample.split('\n')) {
+    if (re.test(line)) matchCount++;
+  }
+  return matchCount > 0 ? { matched: true, matchCount } : { matched: false, matchCount: 0 };
+}
+
+function runAstGrepGate(pattern: AstGrepRule, badExample: string): SmokeGateResult {
+  const lineNumbers = lineNumbersFor(badExample);
+  try {
+    const matches = matchAstGrepPattern(badExample, '.ts', pattern, lineNumbers);
+    return matches.length > 0
+      ? { matched: true, matchCount: matches.length }
+      : { matched: false, matchCount: 0 };
+  } catch (err) {
+    return {
+      matched: false,
+      matchCount: 0,
+      reason: `ast-grep runtime error: ${firstLine(err instanceof Error ? err.message : String(err))}`,
+    };
+  }
+}
+
+// ─── Public API ─────────────────────────────────────
+
+/**
+ * Run the smoke gate for a compiled rule. Returns a `SmokeGateResult` so the
+ * caller can decide whether to accept or reject the rule. The caller is
+ * responsible for the "zero matches means reject" decision; this function
+ * only reports what the engine says.
+ */
+export function runSmokeGate(rule: CompiledRule, badExample: string): SmokeGateResult {
+  if (!badExample || badExample.trim().length === 0) {
+    return { matched: false, matchCount: 0 };
+  }
+
+  if (rule.engine === 'regex') {
+    return runRegexGate(rule.pattern, badExample);
+  }
+
+  if (rule.engine === 'ast-grep') {
+    const source: AstGrepRule | undefined =
+      rule.astGrepPattern ?? (rule.astGrepYamlRule as AstGrepRule | undefined);
+    if (!source) {
+      return {
+        matched: false,
+        matchCount: 0,
+        reason: 'ast-grep rule missing both astGrepPattern and astGrepYamlRule',
+      };
+    }
+    return runAstGrepGate(source, badExample);
+  }
+
+  // Tree-sitter ast engine: not wired into the gate in mmnto/totem#1408.
+  // Callers should not pass 'ast' rules; surface a neutral skip so the
+  // caller can fall back to legacy verification.
+  return {
+    matched: false,
+    matchCount: 0,
+    reason: `smoke gate does not yet cover engine: ${rule.engine}`,
+  };
+}

--- a/packages/core/src/compile-smoke-gate.ts
+++ b/packages/core/src/compile-smoke-gate.ts
@@ -74,10 +74,34 @@ function runRegexGate(pattern: string, badExample: string): SmokeGateResult {
   return matchCount > 0 ? { matched: true, matchCount } : { matched: false, matchCount: 0 };
 }
 
-function runAstGrepGate(pattern: AstGrepRule, badExample: string): SmokeGateResult {
+/**
+ * Infer the file extension the ast-grep engine should use when parsing the
+ * badExample snippet. Defaults to `.tsx` (TSX, the most permissive parser -
+ * superset of TypeScript plus JSX) so a JSX-flavored bad example does not
+ * falsely reject at the parser boundary. If the rule declares a fileGlobs
+ * with a concrete extension, honor that; otherwise fall back to TSX.
+ */
+function inferBadExampleExt(rule: CompiledRule): string {
+  const globs = rule.fileGlobs ?? [];
+  for (const g of globs) {
+    if (g.startsWith('!')) continue;
+    // Extract the trailing `.ext` for simple patterns like `*.tsx` or
+    // `**/*.test.ts`. Anything more exotic falls through to the default.
+    const match = /\.(ts|tsx|js|jsx|mjs|cjs)$/i.exec(g);
+    if (match) return `.${match[1]!.toLowerCase()}`;
+  }
+  return '.tsx';
+}
+
+function runAstGrepGate(
+  pattern: AstGrepRule,
+  badExample: string,
+  rule: CompiledRule,
+): SmokeGateResult {
   const lineNumbers = lineNumbersFor(badExample);
+  const ext = inferBadExampleExt(rule);
   try {
-    const matches = matchAstGrepPattern(badExample, '.ts', pattern, lineNumbers);
+    const matches = matchAstGrepPattern(badExample, ext, pattern, lineNumbers);
     return matches.length > 0
       ? { matched: true, matchCount: matches.length }
       : { matched: false, matchCount: 0 };
@@ -117,7 +141,7 @@ export function runSmokeGate(rule: CompiledRule, badExample: string): SmokeGateR
         reason: 'ast-grep rule missing both astGrepPattern and astGrepYamlRule',
       };
     }
-    return runAstGrepGate(source, badExample);
+    return runAstGrepGate(source, badExample, rule);
   }
 
   // Tree-sitter ast engine: not wired into the gate in mmnto/totem#1408.

--- a/packages/core/src/compiler-schema.test.ts
+++ b/packages/core/src/compiler-schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import type { RuleEventCallback } from './compiler-schema.js';
 import {
   AstGrepYamlRuleSchema,
   CompiledRuleSchema,
@@ -174,5 +175,31 @@ describe('badExample optional field', () => {
       badExample: 'const foo = 1;',
     });
     expect(parsed.badExample).toBe('const foo = 1;');
+  });
+});
+
+// ─── RuleEventCallback discriminator (mmnto/totem#1408) ─────
+
+describe('RuleEventCallback discriminator', () => {
+  it('accepts the three distinct event variants without conflating them', () => {
+    const events: string[] = [];
+    const cb: RuleEventCallback = (event, hash, context) => {
+      events.push(`${event}:${hash}:${context?.failureReason ?? ''}`);
+    };
+
+    cb('trigger', 'h1');
+    cb('suppress', 'h2', { file: 'f', line: 1, justification: 'ok' });
+    cb('failure', 'h3', { file: 'f', line: 1, failureReason: 'napi panic' });
+
+    expect(events).toEqual(['trigger:h1:', 'suppress:h2:', 'failure:h3:napi panic']);
+  });
+
+  it('keeps suppress and failure as separate values per the #1412 postmerge GCA boundary', () => {
+    // The two discriminator values are not string-equal and must be handled on
+    // distinct code paths. This test locks that in at the type level so a
+    // future refactor that collapses them fails here loudly.
+    const suppress: 'trigger' | 'suppress' | 'failure' = 'suppress';
+    const failure: 'trigger' | 'suppress' | 'failure' = 'failure';
+    expect(suppress).not.toBe(failure);
   });
 });

--- a/packages/core/src/compiler-schema.ts
+++ b/packages/core/src/compiler-schema.ts
@@ -244,11 +244,27 @@ export interface RuleEventContext {
   justification?: string;
   /** AST context where the rule fired (code, string, comment, regex). */
   astContext?: AstContext;
+  /**
+   * Populated on `'failure'` events only. Holds the error message surfaced by
+   * the runtime engine (ast-grep `findAll`, regex `exec`, etc.) so `totem
+   * doctor` telemetry can aggregate rules that fail at execution time. Not
+   * used by `'trigger'` or `'suppress'` events. Kept as a string rather than
+   * the raw `unknown` so the callback interface stays cheap to consume.
+   */
+  failureReason?: string;
 }
 
-/** Callback for observability — invoked when a rule is suppressed or triggered. */
+/**
+ * Callback for observability - invoked when a rule is suppressed, triggered,
+ * or fails at runtime. The `'failure'` variant was added in mmnto/totem#1408
+ * alongside per-rule try/catch in `executeQuery`. It is intentionally distinct
+ * from `'suppress'`: suppression is a user-initiated directive (totem-ignore /
+ * totem-context), while failure is a runtime engine error on a rule that
+ * otherwise compiled. The #1412 postmerge GCA fix established this boundary,
+ * so the two values must NEVER be conflated in the Trap Ledger.
+ */
 export type RuleEventCallback = (
-  event: 'trigger' | 'suppress',
+  event: 'trigger' | 'suppress' | 'failure',
   lessonHash: string,
   context?: RuleEventContext,
 ) => void;

--- a/packages/core/src/lesson-pattern.test.ts
+++ b/packages/core/src/lesson-pattern.test.ts
@@ -79,6 +79,84 @@ describe('extractManualPattern', () => {
     expect(result?.pattern).toBe('process.kill($PID, 0)');
   });
 
+  // ─── Bad Example extraction (mmnto/totem#1408) ───────
+
+  it('extracts a Bad Example section into badExample when present', () => {
+    const body = [
+      '**Pattern:** console\\.log',
+      '**Engine:** regex',
+      '**Severity:** warning',
+      '',
+      '### Bad Example',
+      '',
+      '```ts',
+      'console.log("debug")',
+      'console.log(x)',
+      '```',
+    ].join('\n');
+    const result = extractManualPattern(body);
+    expect(result).not.toBeNull();
+    expect(result?.badExample).toBe('console.log("debug")\nconsole.log(x)');
+  });
+
+  it('returns badExample undefined when no Bad Example section is present', () => {
+    const body = '**Pattern:** console\\.log\n**Engine:** regex';
+    const result = extractManualPattern(body);
+    expect(result).not.toBeNull();
+    expect(result?.badExample).toBeUndefined();
+  });
+
+  it('treats an empty Bad Example block as absent', () => {
+    const body = [
+      '**Pattern:** foo',
+      '**Engine:** regex',
+      '',
+      '### Bad Example',
+      '',
+      '```ts',
+      '```',
+    ].join('\n');
+    const result = extractManualPattern(body);
+    expect(result?.badExample).toBeUndefined();
+  });
+
+  it('accepts ~~~ fences as well as ``` fences for the Bad Example block', () => {
+    const body = [
+      '**Pattern:** foo',
+      '**Engine:** regex',
+      '',
+      '### Bad Example',
+      '',
+      '~~~ts',
+      'foo()',
+      '~~~',
+    ].join('\n');
+    const result = extractManualPattern(body);
+    expect(result?.badExample).toBe('foo()');
+  });
+
+  it('stops the Bad Example capture at the next heading', () => {
+    const body = [
+      '**Pattern:** foo',
+      '**Engine:** regex',
+      '',
+      '### Bad Example',
+      '',
+      '```ts',
+      'foo()',
+      '```',
+      '',
+      '### Good Example',
+      '',
+      '```ts',
+      'bar()',
+      '```',
+    ].join('\n');
+    const result = extractManualPattern(body);
+    expect(result?.badExample).toBe('foo()');
+    expect(result?.badExample).not.toContain('bar()');
+  });
+
   it('extracts fields with no whitespace after the closing bold marker (#1282 GCA)', () => {
     // Pre-fix, extractField required \s+ which silently rejected **Pattern:**foo
     // (no space). The lesson would fall through to Pipeline 2 instead of taking

--- a/packages/core/src/lesson-pattern.ts
+++ b/packages/core/src/lesson-pattern.ts
@@ -17,6 +17,14 @@ export interface ManualPattern {
   severity: 'error' | 'warning';
   /** Optional rich message for the compiled rule. Falls back to lesson heading if absent. */
   message?: string;
+  /**
+   * Optional code snippet parsed from a `### Bad Example` markdown section in
+   * the lesson body. Used by the compile-time smoke gate (ADR-087 / mmnto/totem#1408)
+   * to verify the rule fires against its own bad example before landing in
+   * compiled-rules.json. Empty blocks are treated as absent. The gate is not
+   * required for Pipeline 1 rules in #1408 - a dry-run sweep precedes the flip.
+   */
+  badExample?: string;
 }
 
 export function extractField(body: string, field: string): string | undefined {
@@ -110,6 +118,39 @@ export function extractMultilineField(body: string, field: string): string | und
 }
 
 /**
+ * Extract the contents of a fenced code block that follows a `### Bad Example`
+ * heading in a lesson body. Used by the compile-time smoke gate
+ * (mmnto/totem#1408) to verify Pipeline 1 rules against their own bad
+ * example. Mirrors `extractBadGoodSnippets` for Pipeline 3 but targets a
+ * markdown heading rather than a bold field marker because Pipeline 1
+ * lessons conventionally use headings for worked examples.
+ *
+ * Returns `undefined` when:
+ *   - No `### Bad Example` heading is present
+ *   - The heading is present but no fenced code block follows before the
+ *     next heading or EOF
+ *   - The code block is empty
+ *
+ * Both ``` and ~~~ fence styles are accepted to stay aligned with
+ * `extractCodeBlock`.
+ */
+export function extractBadExample(body: string): string | undefined {
+  // Match `### Bad Example` through the first fenced block that follows.
+  // The heading-stop lookahead keeps the capture from sliding into a
+  // Good Example block when the Bad block is missing its fence.
+  const re = /(?:^|\n)#{2,6}\s*Bad\s+Example\s*\n([\s\S]*?)(?=\n#{2,6}\s|\n---\s*\n|$)/i;
+  const section = body.match(re);
+  if (!section) return undefined;
+
+  const slice = section[1] ?? '';
+  const fence = slice.match(/(?:^|\n)(```|~~~)[^\n]*\n([\s\S]*?)\n?\1/);
+  if (!fence) return undefined;
+
+  const content = (fence[2] ?? '').trim();
+  return content.length > 0 ? content : undefined;
+}
+
+/**
  * Try to extract manual pattern fields from a lesson body.
  * Returns null if the lesson doesn't contain a Pattern: field.
  */
@@ -137,7 +178,10 @@ export function extractManualPattern(body: string): ManualPattern | null {
   // when absent, and `buildManualRule` falls back to `lesson.heading` in that case.
   const message = extractMultilineField(body, 'Message');
 
-  return { pattern, engine, fileGlobs, severity, message };
+  // mmnto/totem#1408: optional Bad Example block for the compile-time smoke gate.
+  const badExample = extractBadExample(body);
+
+  return { pattern, engine, fileGlobs, severity, message, badExample };
 }
 
 /**

--- a/packages/core/src/rule-engine.test.ts
+++ b/packages/core/src/rule-engine.test.ts
@@ -10,7 +10,6 @@ import type {
   RuleEventCallback,
   RuleEventContext,
 } from './compiler-schema.js';
-import { TotemParseError } from './errors.js';
 import {
   applyAstRulesToAdditions,
   applyRulesToAdditions,
@@ -75,24 +74,149 @@ describe('applyAstRulesToAdditions', () => {
     expect(warnings[0]).toContain('AST query skipped');
   });
 
-  it('propagates ast-grep query errors instead of swallowing them (fail-closed)', async () => {
+  it('swallows ast-grep query errors on a single rule and emits a failure event (mmnto/totem#1408)', async () => {
     const filePath = path.join(tmpDir, 'src', 'app.ts');
     fs.writeFileSync(filePath, 'const x = 1;\n');
 
     // Runtime-invalid ast-grep string pattern. The pattern is a bare
-    // catch clause, which ast-grep rejects as multi-root. Post-#1407
-    // the string path is the only field rule-engine's filter sees;
-    // compound-rule runtime routing lands in mmnto/totem#1408.
+    // catch clause, which ast-grep rejects as multi-root. Pre-#1408 this
+    // threw TotemParseError and killed the whole batch; post-#1408 the
+    // per-rule try/catch isolates the failure to a single rule, emits a
+    // 'failure' event, and lets subsequent rules and files continue.
     const rule = makeRule({
       engine: 'ast-grep',
+      lessonHash: 'bad-rule-hash',
       astGrepPattern: 'catch ($ERR) { $$$BODY }',
     });
 
     const additions = [makeAddition('src/app.ts', 'const x = 1;', 1)];
+    const events: Array<{ event: string; hash: string; reason?: string }> = [];
 
-    await expect(applyAstRulesToAdditions([rule], additions, tmpDir)).rejects.toThrow(
-      TotemParseError,
+    const violations = await applyAstRulesToAdditions(
+      [rule],
+      additions,
+      tmpDir,
+      (event, hash, ctx) => {
+        events.push({ event, hash, reason: ctx?.failureReason });
+      },
     );
+
+    expect(violations).toEqual([]);
+    const failureEvent = events.find((e) => e.event === 'failure');
+    expect(failureEvent).toBeDefined();
+    expect(failureEvent!.hash).toBe('bad-rule-hash');
+    expect(failureEvent!.reason?.length ?? 0).toBeGreaterThan(0);
+  });
+
+  it('one malformed ast-grep rule does not prevent subsequent rules on the same file', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'src', 'app.ts'),
+      'debugger;\nconsole.log("hi");\nconst x = 1;\n',
+    );
+
+    const badRule = makeRule({
+      engine: 'ast-grep',
+      lessonHash: 'bad-rule',
+      astGrepPattern: 'catch ($ERR) { $$$BODY }', // multi-root, throws
+    });
+    const goodRule = makeRule({
+      engine: 'ast-grep',
+      lessonHash: 'good-rule',
+      astGrepPattern: 'console.log($$$)',
+    });
+
+    const additions = [
+      makeAddition('src/app.ts', 'debugger;', 1),
+      makeAddition('src/app.ts', 'console.log("hi");', 2),
+      makeAddition('src/app.ts', 'const x = 1;', 3),
+    ];
+
+    const events: Array<{ event: string; hash: string }> = [];
+    const violations = await applyAstRulesToAdditions(
+      [badRule, goodRule],
+      additions,
+      tmpDir,
+      (event, hash) => events.push({ event, hash }),
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]!.rule.lessonHash).toBe('good-rule');
+    expect(events.some((e) => e.event === 'failure' && e.hash === 'bad-rule')).toBe(true);
+  });
+
+  it('routes compound rules through NAPI object matcher and handles binding errors gracefully', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'src', 'app.ts'),
+      'try {\n  doWork();\n} catch (err) {\n}\n',
+    );
+
+    const compoundRule = makeRule({
+      engine: 'ast-grep',
+      lessonHash: 'compound-has',
+      // Empty catch — matches catch_clause nodes with no expression_statement descendants
+      astGrepPattern: undefined,
+      pattern: '',
+      astGrepYamlRule: {
+        rule: {
+          kind: 'catch_clause',
+          not: {
+            has: {
+              kind: 'statement_block',
+              has: {
+                any: [
+                  { kind: 'expression_statement' },
+                  { kind: 'variable_declaration' },
+                  { kind: 'if_statement' },
+                  { kind: 'return_statement' },
+                  { kind: 'throw_statement' },
+                ],
+                stopBy: 'end',
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const additions = [
+      makeAddition('src/app.ts', 'try {', 1),
+      makeAddition('src/app.ts', '  doWork();', 2),
+      makeAddition('src/app.ts', '} catch (err) {', 3),
+      makeAddition('src/app.ts', '}', 4),
+    ];
+
+    const violations = await applyAstRulesToAdditions([compoundRule], additions, tmpDir);
+    expect(violations.length).toBeGreaterThanOrEqual(1);
+    // The outer catch_clause spans lines 3-4; the first overlapping added
+    // line (3) is where the violation gets reported.
+    expect(violations[0]!.lineNumber).toBe(3);
+  });
+
+  it('compound rule with invalid NAPI config emits failure event without crashing', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'src', 'app.ts'), 'const x = 1;\n');
+
+    const compoundRule = makeRule({
+      engine: 'ast-grep',
+      lessonHash: 'compound-bad',
+      astGrepPattern: undefined,
+      pattern: '',
+      astGrepYamlRule: { rule: { kind: '!!!INVALID_KIND!!!' } },
+    });
+
+    const additions = [makeAddition('src/app.ts', 'const x = 1;', 1)];
+    const events: Array<{ event: string; hash: string; reason?: string }> = [];
+
+    const violations = await applyAstRulesToAdditions(
+      [compoundRule],
+      additions,
+      tmpDir,
+      (event, hash, ctx) => events.push({ event, hash, reason: ctx?.failureReason }),
+    );
+
+    expect(violations).toEqual([]);
+    const failure = events.find((e) => e.event === 'failure');
+    expect(failure).toBeDefined();
+    expect(failure!.hash).toBe('compound-bad');
   });
 
   it('still returns violations for valid AST rules (regression check)', async () => {

--- a/packages/core/src/rule-engine.ts
+++ b/packages/core/src/rule-engine.ts
@@ -277,7 +277,14 @@ export async function applyAstRulesToAdditions(
   readStrategy?: (filePath: string) => Promise<string | null>,
 ): Promise<Violation[]> {
   const treeSitterRules = rules.filter((r) => r.engine === 'ast' && r.astQuery);
-  const astGrepRules = rules.filter((r) => r.engine === 'ast-grep' && r.astGrepPattern);
+  // Widen to include compound rules (mmnto/totem#1408). A rule is runnable
+  // when EITHER `astGrepPattern` (string) or `astGrepYamlRule` (NapiConfig
+  // object) is populated. The mutual-exclusion superRefine on
+  // CompiledRuleSchema guarantees these do not coexist, so the per-rule
+  // dispatch below can safely use an if/else on presence alone.
+  const astGrepRules = rules.filter(
+    (r) => r.engine === 'ast-grep' && (r.astGrepPattern || r.astGrepYamlRule),
+  );
   if ((treeSitterRules.length === 0 && astGrepRules.length === 0) || additions.length === 0) {
     return [];
   }
@@ -408,14 +415,26 @@ export async function applyAstRulesToAdditions(
           // Fall through — content stays null for standard file read failures
         }
         if (content) {
-          // Batch: parse file once, run all patterns
-          const queries = applicableAstGrep
-            .filter((rule) => rule.astGrepPattern != null)
-            .map((rule) => ({
-              rule: rule.astGrepPattern as AstGrepRule,
-              addedLineNumbers,
-            }));
-          const batchResults = matchAstGrepPatternsBatch(content, ext, queries);
+          // Batch: parse file once, run all patterns.
+          // Each rule carries either astGrepPattern (string) or astGrepYamlRule
+          // (NapiConfig object); the batch helper polymorphically dispatches on
+          // type. Per-rule try/catch (mmnto/totem#1408 G-7) ensures one
+          // malformed rule does not kill the whole file pass: failures flow
+          // through the onRuleFailure sink, get mapped back to a lessonHash
+          // via the query index, and surface as 'failure' RuleEvent entries.
+          const queries = applicableAstGrep.map((rule) => ({
+            rule: (rule.astGrepPattern ?? rule.astGrepYamlRule) as AstGrepRule,
+            addedLineNumbers,
+          }));
+          const batchResults = matchAstGrepPatternsBatch(content, ext, queries, (index, err) => {
+            const failedRule = applicableAstGrep[index];
+            if (!failedRule) return;
+            onRuleEvent?.('failure', failedRule.lessonHash, {
+              file,
+              line: 0,
+              failureReason: err.message,
+            });
+          });
 
           for (let i = 0; i < applicableAstGrep.length; i++) {
             const rule = applicableAstGrep[i]!;

--- a/packages/core/src/rule-tester.test.ts
+++ b/packages/core/src/rule-tester.test.ts
@@ -242,4 +242,48 @@ describe('testRule', () => {
     expect(result.passed).toBe(false);
     expect(result.missedFails).toHaveLength(1);
   });
+
+  // ─── Compound (astGrepYamlRule) support — mmnto/totem#1408 ───
+  it('passes a compound astGrepYamlRule fixture with a known-good fail/pass set', () => {
+    const compoundRule: CompiledRule = {
+      lessonHash: 'compound-has-test',
+      lessonHeading: 'Empty catch block',
+      pattern: '',
+      message: 'Empty catch block swallows errors',
+      engine: 'ast-grep',
+      compiledAt: '2026-04-13T12:00:00Z',
+      astGrepYamlRule: {
+        rule: {
+          kind: 'catch_clause',
+          not: {
+            has: {
+              kind: 'statement_block',
+              has: {
+                any: [
+                  { kind: 'expression_statement' },
+                  { kind: 'variable_declaration' },
+                  { kind: 'if_statement' },
+                  { kind: 'return_statement' },
+                  { kind: 'throw_statement' },
+                ],
+                stopBy: 'end',
+              },
+            },
+          },
+        },
+      },
+    };
+
+    const result = testRule(compoundRule, {
+      ruleHash: 'compound-has-test',
+      filePath: 'src/app.ts',
+      failLines: ['try {', '  work();', '} catch (err) {', '}'],
+      passLines: ['try {', '  work();', '} catch (err) {', '  log(err);', '}'],
+      fixturePath: 'test.md',
+    });
+
+    expect(result.passed).toBe(true);
+    expect(result.missedFails).toHaveLength(0);
+    expect(result.falsePositives).toHaveLength(0);
+  });
 });

--- a/packages/core/src/rule-tester.ts
+++ b/packages/core/src/rule-tester.ts
@@ -160,11 +160,19 @@ export function testRule(rule: CompiledRule, fixture: RuleTestFixture): RuleTest
     passed: true,
   };
 
-  const isAstGrep = rule.engine === 'ast-grep' && rule.astGrepPattern;
+  // Either a flat astGrepPattern (string) or a compound astGrepYamlRule
+  // (NapiConfig object). Mutual exclusion is enforced by the schema
+  // superRefine; the test runner just picks whichever shape is present.
+  // mmnto/totem#1408 adds the compound path.
+  const astGrepRule: AstGrepRule | undefined =
+    rule.engine === 'ast-grep'
+      ? (rule.astGrepPattern ?? (rule.astGrepYamlRule as AstGrepRule | undefined))
+      : undefined;
+  const isAstGrep = astGrepRule !== undefined;
 
   if (isAstGrep) {
     const ext = path.extname(fixture.filePath) || '.ts';
-    const pattern = rule.astGrepPattern as AstGrepRule;
+    const pattern = astGrepRule as AstGrepRule;
 
     // Test fail block — parse all fail lines as one snippet; expect at least one match
     if (fixture.failLines.length > 0) {


### PR DESCRIPTION
## Mechanical Root Cause

ADR-087 Decision 3 locked the compile-time smoke gate ("the engine will instantly run the generated rule against this snippet and fail the compile if it returns zero matches") as the Defense-in-Depth layer for LLM-hallucinated rules. #1407 landed the schema (`astGrepYamlRule`, `badExample`); this PR wires the runtime engine to execute compound rules and lands the gate mechanism.

Also lands G-7 from the spike findings (per-rule try/catch in `executeQuery`) so one malformed rule cannot crash a whole file's lint pass.

## Fix Applied

10 bisectable commits on this branch:

1. **`2d72a398`** — add `'failure'` event variant to `RuleEventCallback`. Distinct from `'suppress'` per the #1412 postmerge GCA boundary (suppression is user-directive-only). `RuleEventContext.failureReason` carries the engine error message.
2. **`11e51901`** — per-rule try/catch in `executeQuery` so compound-rule napi throws do not blast-radius the batch.
3. **`9de9a69b`** — widen `applyAstRulesToAdditions` filter to include `astGrepYamlRule`; dispatch on whichever field is present.
4. **`3cf23a3c`** — `testRule` (in `rule-tester.ts`) routes compound rules through `matchAstGrepPattern` with flat-rule parity.
5. **`18345746`** — new `compile-smoke-gate.ts` module. `runSmokeGate(rule, badExample)` reuses runtime entry points (`matchAstGrepPattern` / `new RegExp`) so a gate-passing rule cannot silently fail at runtime.
6. **`ef9afc14`** — `extractManualPattern` captures a `### Bad Example` block from Pipeline 1 lesson bodies. Field is extracted but NOT required for Pipeline 1 yet (see follow-up).
7. **`f1a8178a`** — wire `runSmokeGate` into `buildCompiledRule` for Pipeline 2 (LLM) and Pipeline 3 (example-based). Missing or zero-matching `badExample` → rule rejected with a clear `rejectReason`. Pipeline 1 untouched.
8. **`62a9ceb6`** — review finding fix: infer `badExample` parse extension from `fileGlobs` (fall back to `.tsx` as the most permissive parser).
9. **`d44b00e6`** — review finding fix: skip smoke gate for `ast` (Tree-sitter) engine rules. Matches the comment in `compile-smoke-gate.ts`; prevents a Pipeline 2 LLM-emitted `ast` rule from being hard-rejected by a gate that doesn't cover it.
10. **`d4de4fdc`** — CLI type-widening. `'failure'` variant forced a contravariance refactor in `packages/cli/src/commands/run-compiled-rules.ts`. Uses the exported `RuleEventCallback` type directly; logs rule hash + `failureReason` via `log.warn` on failure.

## Out of Scope

- **Pipeline 1 smoke gate enforcement.** Dry-run measured **136 Pipeline 1 lessons** (out of 1041, 13%) that would fail the gate if flipped today. All 136 fail for the same reason: no `### Bad Example` block. Per the locked design decision, the gate is applied to Pipeline 2/3 only. Follow-up #1414 filed for the backfill + flip after a curation sweep.
- **Compiler prompt changes.** Teaching Sonnet to emit `astGrepYamlRule` and `badExample` is #1409.
- **Bulk recompile of `upgradeTarget: compound` archived queue.** Phase 4 on the epic, files after #1409.
- **`recordFailure` in `rule-metrics` / `totem doctor` surfacing.** The `'failure'` event is logged today; metric aggregation is a follow-up.
- **Object-walker for `isSelfSuppressing`.** Stringify path is correct per the #1407 design doc; regression-tested.

## Tests Added/Updated

- [x] 35 new tests (core: 1086 → 1121)
- [x] Compound rule end-to-end in `rule-engine.test.ts`
- [x] Per-rule try/catch isolation in `ast-grep-query.test.ts`
- [x] `compile-smoke-gate.test.ts` — new file, accept/reject invariants
- [x] `lesson-pattern.test.ts` — `### Bad Example` extraction
- [x] `rule-tester.test.ts` — compound rule fixture
- [x] `compiler-schema.test.ts` — `'failure'` vs `'suppress'` discriminator distinct and handleable

**Verification:**

- `pnpm -r test`: 1121 (core) + 1652 (cli) + 83 (mcp) all green
- `pnpm -r build`: clean (cli type-widening was caught and fixed)
- `pnpm exec totem lint`: PASS (69 warnings, 0 errors; warnings are pre-existing idiomatic patterns)
- `pnpm exec totem review`: PASS, no findings
- `pnpm exec totem verify-manifest`: PASS (411 rules, hashes match)

## Related Tickets

Closes #1408

Epic: mmnto-ai/totem-strategy#81
ADR: `.strategy/adr/adr-087-compound-ast-grep-rules.md`
Design doc: `.totem/specs/1408.md` (approved before code)

Blocks: #1409 (compiler prompt).
Follow-ups filed:
- #1414 — Pipeline 1 smoke gate backfill + flip (136 lessons need Bad Example blocks first)