### PR TITLE
feat(cli): compiler prompt + badExample required flip (#1409)

### DIFF
--- a/packages/cli/src/commands/compile-templates.test.ts
+++ b/packages/cli/src/commands/compile-templates.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { COMPILER_SYSTEM_PROMPT, PIPELINE3_COMPILER_PROMPT } from './compile-templates.js';
+import {
+  COMPILER_SYSTEM_PROMPT,
+  KIND_ALLOW_LIST,
+  PIPELINE3_COMPILER_PROMPT,
+} from './compile-templates.js';
 
 describe('COMPILER_SYSTEM_PROMPT', () => {
   it('includes Identity and Rules sections', () => {
@@ -54,5 +58,43 @@ describe('PIPELINE3_COMPILER_PROMPT', () => {
 
   it('identifies itself as Pipeline 3', () => {
     expect(PIPELINE3_COMPILER_PROMPT).toContain('Pipeline 3');
+  });
+});
+
+// ─── KIND_ALLOW_LIST ────────────────────────────────
+
+describe('KIND_ALLOW_LIST', () => {
+  it('is a non-empty readonly array of strings', () => {
+    expect(Array.isArray(KIND_ALLOW_LIST)).toBe(true);
+    expect(KIND_ALLOW_LIST.length).toBeGreaterThan(0);
+    for (const entry of KIND_ALLOW_LIST) {
+      expect(typeof entry).toBe('string');
+      expect(entry.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('contains the kinds from the compound spike allow-list (findings.md G-3)', () => {
+    // Lock the spike-derived minimum set so a future edit cannot silently
+    // drop one of the empirically-validated kinds. Spike reference:
+    // packages/core/spikes/compound-ast-grep/findings.md gap G-3.
+    const spikeMinimum = [
+      'for_statement',
+      'while_statement',
+      'try_statement',
+      'catch_clause',
+      'function_declaration',
+      'class_declaration',
+      'method_definition',
+      'import_statement',
+      'export_statement',
+    ];
+    for (const kind of spikeMinimum) {
+      expect(KIND_ALLOW_LIST).toContain(kind);
+    }
+  });
+
+  it('has no duplicate entries', () => {
+    const seen = new Set(KIND_ALLOW_LIST);
+    expect(seen.size).toBe(KIND_ALLOW_LIST.length);
   });
 });

--- a/packages/cli/src/commands/compile-templates.test.ts
+++ b/packages/cli/src/commands/compile-templates.test.ts
@@ -20,6 +20,58 @@ describe('COMPILER_SYSTEM_PROMPT', () => {
     expect(COMPILER_SYSTEM_PROMPT).toContain('**/');
     expect(COMPILER_SYSTEM_PROMPT).toContain('Supported glob syntax only');
   });
+
+  // ─── Compound rules (mmnto-ai/totem#1409) ──────────
+
+  it('contains a Compound rules section with structural combinators', () => {
+    expect(COMPILER_SYSTEM_PROMPT).toContain('Compound rules');
+    expect(COMPILER_SYSTEM_PROMPT).toContain('inside');
+    expect(COMPILER_SYSTEM_PROMPT).toContain('has');
+    expect(COMPILER_SYSTEM_PROMPT).toContain('not');
+    expect(COMPILER_SYSTEM_PROMPT).toContain('kind:');
+  });
+
+  it('renames the misleading Compound patterns heading to Flat patterns', () => {
+    // The pre-#1409 prompt had a section titled "Compound patterns (method
+    // calls with specific arguments)" whose examples were actually flat
+    // single-node patterns using $$$ captures. That mislabel taught the
+    // LLM to call flat rules "compound" and blurred the boundary. The
+    // rewrite uses the Flat patterns heading for those examples and
+    // reserves "Compound rules" for true structural combinators.
+    expect(COMPILER_SYSTEM_PROMPT).not.toContain(
+      'Compound patterns (method calls with specific arguments)',
+    );
+    expect(COMPILER_SYSTEM_PROMPT).toContain('Flat patterns');
+  });
+
+  it('interpolates at least three KIND_ALLOW_LIST entries verbatim', () => {
+    let hits = 0;
+    for (const kind of KIND_ALLOW_LIST) {
+      if (COMPILER_SYSTEM_PROMPT.includes(kind)) hits++;
+    }
+    expect(hits).toBeGreaterThanOrEqual(3);
+  });
+
+  it('forbids the inside-pattern sharp edge from the spike findings (G-3)', () => {
+    // The for-loop inside-pattern shape silently matches zero per
+    // compound.spike.test.ts:247. The prompt must steer Sonnet away.
+    expect(COMPILER_SYSTEM_PROMPT).toMatch(/for \(\$[A-Z]+; \$[A-Z]+; \$[A-Z]+\)/);
+  });
+
+  it('has a Bad Example section that flags the field as required', () => {
+    expect(COMPILER_SYSTEM_PROMPT).toContain('Bad Example (REQUIRED)');
+    expect(COMPILER_SYSTEM_PROMPT).toContain('badExample');
+  });
+
+  it('shows badExample in the ast-grep output schema example', () => {
+    // The LLM leans heavily on the literal output schema block, so the
+    // JSON template must visibly carry badExample for the field to land
+    // in real responses. Count occurrences of the literal "badExample"
+    // key in triple-quoted code blocks as a proxy for "shows up in the
+    // example JSON".
+    const occurrences = COMPILER_SYSTEM_PROMPT.match(/"badExample":/g) ?? [];
+    expect(occurrences.length).toBeGreaterThanOrEqual(3);
+  });
 });
 
 describe('PIPELINE3_COMPILER_PROMPT', () => {
@@ -58,6 +110,12 @@ describe('PIPELINE3_COMPILER_PROMPT', () => {
 
   it('identifies itself as Pipeline 3', () => {
     expect(PIPELINE3_COMPILER_PROMPT).toContain('Pipeline 3');
+  });
+
+  // ─── badExample requirement (mmnto-ai/totem#1409) ──
+
+  it('teaches Pipeline 3 to emit a badExample field', () => {
+    expect(PIPELINE3_COMPILER_PROMPT).toContain('badExample');
   });
 });
 

--- a/packages/cli/src/commands/compile-templates.ts
+++ b/packages/cli/src/commands/compile-templates.ts
@@ -1,3 +1,48 @@
+// ─── Compound rule outer-combinator allow-list ──────
+
+/**
+ * Tree-sitter node kinds that are safe to use as the outer target of an
+ * `inside:` / `has:` / `not:` combinator in a compound ast-grep rule.
+ *
+ * Why a named export: the allow-list has independent value beyond the
+ * compiler prompt. `totem doctor` will lint existing compiled rules for
+ * illegal `kind:` targets, and future rule-tester hints can surface the
+ * same list. Interpolating it into the prompt keeps the two consumers in
+ * sync — a single source of truth.
+ *
+ * Why these kinds: they cover the structural contexts that show up in
+ * real lessons (control flow, function and class bodies, module-level
+ * imports and exports). Sourced from the compound ast-grep spike
+ * findings at packages/core/spikes/compound-ast-grep/findings.md (gap
+ * G-3) plus the ADR-087 / Proposal 226 design doc.
+ *
+ * Why not `pattern:` as the outer target: the spike harness test 8
+ * pinned the empirical finding that an outer `inside: { pattern: 'for
+ * ($INIT; $COND; $STEP) { $$$ }' }` silently matches zero. The
+ * combinator target must be a single-node kind match for the match
+ * engine to pin the scope reliably. The prompt (below) forbids the
+ * pattern: shape for outer targets; this list enumerates the accepted
+ * kinds.
+ */
+export const KIND_ALLOW_LIST = [
+  'for_statement',
+  'while_statement',
+  'do_statement',
+  'try_statement',
+  'catch_clause',
+  'function_declaration',
+  'method_definition',
+  'arrow_function',
+  'class_declaration',
+  'class_body',
+  'import_statement',
+  'export_statement',
+  'if_statement',
+  'switch_statement',
+] as const;
+
+export type KindAllowListEntry = (typeof KIND_ALLOW_LIST)[number];
+
 // ─── Compiler prompt ────────────────────────────────
 
 export const COMPILER_SYSTEM_PROMPT = `# Lesson Compiler — Rule Extraction

--- a/packages/cli/src/commands/compile-templates.ts
+++ b/packages/cli/src/commands/compile-templates.ts
@@ -62,6 +62,7 @@ You are a deterministic rule compiler. Your job is to read a single natural-lang
 - Patterns should catch **violations** (code that breaks the lesson's rule), NOT conformance.
 - For regex: use JavaScript RegExp syntax. Keep patterns precise — avoid \`.*\` between delimiters.
 - If the lesson describes an architectural principle or conceptual guideline that cannot be expressed as any pattern, set \`compilable\` to \`false\`.
+- Every compilable regex or ast-grep rule MUST include a \`badExample\` snippet (see Bad Example section below).
 - **File scoping:** Include a \`fileGlobs\` array to limit where the rule runs. Scope rules as tightly as possible:
   - **By file type:** \`["**/*.sh", "**/*.yml"]\` — for rules about shell or YAML syntax.
   - **By package/directory:** \`["packages/mcp/**/*.ts"]\` — for rules about MCP-specific patterns in a monorepo.
@@ -83,6 +84,7 @@ You are a deterministic rule compiler. Your job is to read a single natural-lang
   "compilable": true,
   "pattern": "regex pattern here",
   "message": "human-readable violation message",
+  "badExample": "code snippet that the pattern matches",
   "fileGlobs": ["packages/mcp/**/*.ts", "!**/*.test.ts"]
 }
 \`\`\`
@@ -92,7 +94,8 @@ Or if the rule genuinely applies to all file types (rare — prefer scoping):
 {
   "compilable": true,
   "pattern": "regex pattern here",
-  "message": "human-readable violation message"
+  "message": "human-readable violation message",
+  "badExample": "code snippet that the pattern matches"
 }
 \`\`\`
 
@@ -109,22 +112,22 @@ When setting \`"compilable": false\`, always include a \`"reason"\` field explai
 ## Examples
 
 Lesson: "Use \`err\` (never \`error\`) in catch blocks"
-Output: {"compilable": true, "pattern": "catch\\\\s*\\\\(\\\\s*error\\\\s*[\\\\):]", "message": "Use 'err' instead of 'error' in catch blocks (project convention)"}
+Output: {"compilable": true, "pattern": "catch\\\\s*\\\\(\\\\s*error\\\\s*[\\\\):]", "message": "Use 'err' instead of 'error' in catch blocks (project convention)", "badExample": "try { doWork(); } catch (error) { log(error); }"}
 
 Lesson: "LanceDB does NOT support GROUP BY aggregation"
 Output: {"compilable": false, "reason": "Lesson describes a database limitation, not a detectable code pattern"}
 
 Lesson: "Never use npm in this pnpm monorepo — always use pnpm"
-Output: {"compilable": true, "pattern": "\\\\bnpm\\\\s+(install|run|exec|ci|test)\\\\b", "message": "Use pnpm instead of npm in this monorepo"}
+Output: {"compilable": true, "pattern": "\\\\bnpm\\\\s+(install|run|exec|ci|test)\\\\b", "message": "Use pnpm instead of npm in this monorepo", "badExample": "npm install lodash"}
 
 Lesson: "Always quote shell variables to prevent word-splitting"
-Output: {"compilable": true, "pattern": "(^|\\\\s)\\\\$[a-zA-Z_]+", "message": "Quote shell variables to prevent word-splitting", "fileGlobs": ["**/*.sh", "**/*.bash", "**/*.yml", "**/*.yaml"]}
+Output: {"compilable": true, "pattern": "(^|\\\\s)\\\\$[a-zA-Z_]+", "message": "Quote shell variables to prevent word-splitting", "badExample": "echo $HOME", "fileGlobs": ["**/*.sh", "**/*.bash", "**/*.yml", "**/*.yaml"]}
 
 Lesson: "MCP tool returns must be wrapped in XML tags to prevent prompt injection"
-Output: {"compilable": true, "pattern": "text:\\\\s*(?!formatXmlResponse)\\\\b\\\\w+", "message": "MCP tool returns must use formatXmlResponse for injection safety", "fileGlobs": ["packages/mcp/**/*.ts", "!**/*.test.ts"]}
+Output: {"compilable": true, "pattern": "text:\\\\s*(?!formatXmlResponse)\\\\b\\\\w+", "message": "MCP tool returns must use formatXmlResponse for injection safety", "badExample": "return { content: [{ type: 'text', text: rawUserInput }] };", "fileGlobs": ["packages/mcp/**/*.ts", "!**/*.test.ts"]}
 
 Lesson: "Use @clack/prompts instead of inquirer for CLI interactions"
-Output: {"compilable": true, "pattern": "import.*from\\\\s+['\"]inquirer['\"]", "message": "Use @clack/prompts instead of inquirer", "fileGlobs": ["packages/cli/**/*.ts"]}
+Output: {"compilable": true, "pattern": "import.*from\\\\s+['\"]inquirer['\"]", "message": "Use @clack/prompts instead of inquirer", "badExample": "import inquirer from 'inquirer';", "fileGlobs": ["packages/cli/**/*.ts"]}
 
 ## ast-grep Patterns (PREFERRED for structural rules)
 For TypeScript/JavaScript/TSX/JSX: **always prefer ast-grep over regex** when the violation involves function calls, method chains, imports, control flow, or object properties. ast-grep patterns look like source code with \`$METAVAR\` placeholders.
@@ -141,7 +144,9 @@ For TypeScript/JavaScript/TSX/JSX: **always prefer ast-grep over regex** when th
 - \`JSON.parse($INPUT) as $TYPE\` — unsafe type assertion on parsed JSON
 - \`eval($CODE)\` — any eval call
 
-### Compound patterns (method calls with specific arguments)
+### Flat patterns with \`$$$\` captures
+These are still single-node patterns; the \`$$$\` captures absorb variable-length argument lists or nested statements within one syntactic node. Reach for compound rules (next section) when the rule needs to look outside the matched node.
+
 - \`$OBJ.replace(process.cwd(), $REPLACEMENT)\` — string replace on cwd instead of path.relative
 - \`new RegExp($SRC, $FLAGS + 'g')\` — blindly appending regex flags
 - \`$ARR.forEach(async ($ITEM) => { $$$BODY })\` — async callback in forEach (drops promises)
@@ -162,11 +167,156 @@ Set \`"engine": "ast-grep"\` and provide an \`"astGrepPattern"\` field. Leave \`
   "astGrepPattern": "$ARR.forEach(async ($ITEM) => { $$$BODY })",
   "pattern": "",
   "message": "Do not pass async functions to forEach — use for...of or Promise.all(arr.map(...))",
+  "badExample": "items.forEach(async (item) => { await process(item); });",
   "fileGlobs": ["**/*.ts", "**/*.tsx"]
 }
 \`\`\`
 
 IMPORTANT: ast-grep patterns must be single valid AST nodes. Only use for TypeScript/JavaScript/TSX/JSX files.
+
+## Compound rules (structural combinators: \`inside\`, \`has\`, \`not\`)
+
+Compound rules go beyond a single matched node. Reach for them when the lesson talks about *structural context*:
+- "inside a loop" / "inside a try block"
+- "empty catch" or "function with no return"
+- "spawn calls outside of import statements"
+
+Compound rules use the \`astGrepYamlRule\` field instead of \`astGrepPattern\`. The shape mirrors the ast-grep YAML rule format:
+
+\`\`\`json
+{
+  "engine": "ast-grep",
+  "astGrepYamlRule": {
+    "rule": {
+      "pattern": "matched-node-source",
+      "inside": { "kind": "outer-context-kind", "stopBy": "end" }
+    }
+  }
+}
+\`\`\`
+
+### Outer combinator targets MUST use \`kind:\`
+
+For the outer side of an \`inside\` / \`has\` / \`not\` combinator, target a single tree-sitter node \`kind\`. Pattern-shaped outer targets that span multiple statements (declaration, condition, update) silently match zero in the current ast-grep release.
+
+**FORBIDDEN sharp edge** (matches zero, never warns):
+\`\`\`json
+{
+  "rule": {
+    "pattern": "const $VAR = $VAL",
+    "inside": { "pattern": "for ($A; $B; $C) { $$$ }", "stopBy": "end" }
+  }
+}
+\`\`\`
+
+**Use instead:**
+\`\`\`json
+{
+  "rule": {
+    "pattern": "const $VAR = $VAL",
+    "inside": { "kind": "for_statement", "stopBy": "end" }
+  }
+}
+\`\`\`
+
+The matched node (the part that gets flagged) can still use \`pattern:\`. The combinator target is the part that needs \`kind:\`.
+
+### Allowed outer kinds
+
+Use one of these tree-sitter node kinds when targeting the outer side of a combinator. Other kinds may work but were not validated in the spike, so prefer this list:
+${KIND_ALLOW_LIST.map((k) => `- \`${k}\``).join('\n')}
+
+If the lesson points at a context not on this list, escalate to a Tree-sitter S-expression query (engine \`ast\`) instead of guessing a kind.
+
+### Compound example A: const declaration nested inside a for-loop
+
+\`\`\`json
+{
+  "compilable": true,
+  "engine": "ast-grep",
+  "pattern": "",
+  "astGrepYamlRule": {
+    "rule": {
+      "pattern": "const $VAR = $VAL",
+      "inside": { "kind": "for_statement", "stopBy": "end" }
+    }
+  },
+  "message": "Hoist the const out of the loop or use let if the value really changes per iteration",
+  "badExample": "for (let i = 0; i < n; i++) { const x = i * 2; total += x; }",
+  "fileGlobs": ["**/*.ts", "**/*.tsx"]
+}
+\`\`\`
+
+### Compound example B: empty catch block (uses \`has\` and \`not\`)
+
+The rule says "the catch_clause does NOT have a statement_block that has any real statement inside". Both \`has\` and \`not\` combine to express the absence of a body.
+
+\`\`\`json
+{
+  "compilable": true,
+  "engine": "ast-grep",
+  "pattern": "",
+  "astGrepYamlRule": {
+    "rule": {
+      "kind": "catch_clause",
+      "not": {
+        "has": {
+          "kind": "statement_block",
+          "has": {
+            "any": [
+              { "kind": "expression_statement" },
+              { "kind": "variable_declaration" },
+              { "kind": "if_statement" },
+              { "kind": "return_statement" },
+              { "kind": "throw_statement" }
+            ],
+            "stopBy": "end"
+          }
+        }
+      }
+    }
+  },
+  "message": "Catch block is empty - either rethrow, log, or handle the error",
+  "badExample": "try { doWork(); } catch (err) {\\n}",
+  "fileGlobs": ["**/*.ts", "**/*.tsx"]
+}
+\`\`\`
+
+### Compound example C: spawn() calls that are NOT inside an import statement
+
+\`\`\`json
+{
+  "compilable": true,
+  "engine": "ast-grep",
+  "pattern": "",
+  "astGrepYamlRule": {
+    "rule": {
+      "pattern": "spawn($CMD, $OPTS)",
+      "not": {
+        "inside": { "kind": "import_statement", "stopBy": "end" }
+      }
+    }
+  },
+  "message": "Use safeExec instead of raw spawn for runtime command execution",
+  "badExample": "spawn('rm', { shell: true });",
+  "fileGlobs": ["**/*.ts", "**/*.tsx"]
+}
+\`\`\`
+
+When emitting a compound rule, set \`"astGrepPattern"\` and \`"pattern"\` to the empty string and put the structural tree under \`"astGrepYamlRule"\`. The two ast-grep fields are mutually exclusive: one or the other, never both.
+
+## Bad Example (REQUIRED)
+
+Every compilable regex or ast-grep rule MUST include a non-empty \`badExample\` field. The compile-time smoke gate runs the rule against this snippet using the same engine entry points the runtime uses; rules that fail to match their own bad example are rejected before they land in \`compiled-rules.json\`.
+
+A good \`badExample\` is:
+- **Short.** One to three lines is plenty. Multi-line is fine when the rule needs structural context (e.g., a try/catch for an empty-catch rule).
+- **Realistic.** Looks like code a developer might actually write, not a synthetic test fixture.
+- **Targeted.** Exercises exactly the violation the rule is meant to catch. Do not pad it with unrelated lines.
+
+If you cannot produce a snippet that the rule would match, the rule is probably not well-formed; reconsider the pattern or set \`"compilable": false\` with an explanation.
+
+The \`badExample\` field is exempt only for the \`ast\` engine (Tree-sitter S-expression queries), which the smoke gate does not yet evaluate. For everything else (regex and ast-grep, including compound rules under \`astGrepYamlRule\`), the field is required.
 
 ## Regex (fallback for non-structural patterns)
 Use regex ONLY when the violation is a simple string/keyword match that does not involve code structure — e.g., matching import paths, literal URLs, comment patterns, or config values. The regex rules above still apply.
@@ -222,6 +372,7 @@ You will receive:
 - The regex must use JavaScript RegExp syntax
 - The pattern MUST match at least one Bad line and MUST NOT match any Good line
 - Include fileGlobs to scope the rule appropriately
+- Echo a representative Bad line back as \`badExample\` so the compile-time smoke gate (mmnto-ai/totem#1408) can verify the pattern matches at runtime.
 - **CRITICAL — Always use recursive glob patterns with \`**/\` prefix** (e.g., \`**/*.ts\`, \`**/*.py\`)
 - **CRITICAL — Supported glob syntax only:** \`**/*.ext\`, \`dir/**/*.ext\`, \`!pattern\` for negation. NO brace expansion.
 
@@ -231,6 +382,7 @@ You will receive:
   "compilable": true,
   "pattern": "regex pattern that catches Bad but not Good",
   "message": "human-readable violation message",
+  "badExample": "one of the Bad lines, copied verbatim",
   "fileGlobs": ["**/*.ts", "!**/*.test.ts"]
 }
 \`\`\`
@@ -242,4 +394,6 @@ Or if the difference cannot be expressed as a line-level regex:
   "reason": "Explanation of why a regex cannot distinguish these snippets"
 }
 \`\`\`
+
+The compile pipeline supplies the Bad snippet to the smoke gate as a fallback, so a missing \`badExample\` will not block compilation. Including it anyway gives the gate a tighter target and helps downstream telemetry.
 `;

--- a/packages/cli/src/commands/compile-templates.ts
+++ b/packages/cli/src/commands/compile-templates.ts
@@ -26,6 +26,7 @@
  */
 export const KIND_ALLOW_LIST = [
   'for_statement',
+  'for_in_statement',
   'while_statement',
   'do_statement',
   'try_statement',
@@ -273,7 +274,9 @@ The rule says "match any object literal that has \`shell: true\` as a descendant
 
 Note: do NOT try to express "empty catch block" via \`not: { has: { any: [...kind list...] } }\`. The inverse-of-allow-list shape produces false positives for any statement kind you forgot to enumerate (TypeScript has ~15 statement kinds, including \`for_statement\`, \`while_statement\`, \`switch_statement\`, \`try_statement\`, \`class_declaration\`, etc.). If you need to detect an empty block, use \`nthChild\` or a \`pattern:\` match on literal braces instead, and verify the rule against a badExample that exercises the common non-empty shapes.
 
-### Compound example C: spawn() calls that are NOT inside an import statement
+### Compound example C: JSON.parse() that is NOT wrapped in a try block
+
+Rule says "match \`JSON.parse(\$INPUT)\` calls that are NOT descendants of a try_statement". The negative combinator is meaningful here because call expressions can legitimately appear both inside and outside a \`try\` block; flagging only the unwrapped calls catches the real anti-pattern.
 
 \`\`\`json
 {
@@ -282,17 +285,19 @@ Note: do NOT try to express "empty catch block" via \`not: { has: { any: [...kin
   "pattern": "",
   "astGrepYamlRule": {
     "rule": {
-      "pattern": "spawn($CMD, $OPTS)",
+      "pattern": "JSON.parse($INPUT)",
       "not": {
-        "inside": { "kind": "import_statement", "stopBy": "end" }
+        "inside": { "kind": "try_statement", "stopBy": "end" }
       }
     }
   },
-  "message": "Use safeExec instead of raw spawn for runtime command execution",
-  "badExample": "spawn('rm', { shell: true });",
+  "message": "Wrap JSON.parse in try/catch - malformed input throws SyntaxError with unhelpful stack context",
+  "badExample": "const config = JSON.parse(raw);",
   "fileGlobs": ["**/*.ts", "**/*.tsx"]
 }
 \`\`\`
+
+Note: the \`not: inside:\` combinator is only meaningful when the matched node (the \`pattern:\` side) can actually appear as a descendant of the outer target. Matching a call_expression with \`not: inside: import_statement\` is vacuous because call_expressions cannot structurally live inside imports (imports only carry specifiers and identifiers). Check the tree-sitter grammar before reaching for \`not:\` to avoid teaching no-op filters.
 
 When emitting a compound rule, set \`"astGrepPattern"\` and \`"pattern"\` to the empty string and put the structural tree under \`"astGrepYamlRule"\`. The two ast-grep fields are mutually exclusive: one or the other, never both.
 

--- a/packages/cli/src/commands/compile-templates.ts
+++ b/packages/cli/src/commands/compile-templates.ts
@@ -395,5 +395,5 @@ Or if the difference cannot be expressed as a line-level regex:
 }
 \`\`\`
 
-The compile pipeline supplies the Bad snippet to the smoke gate as a fallback, so a missing \`badExample\` will not block compilation. Including it anyway gives the gate a tighter target and helps downstream telemetry.
+Every compilable rule MUST include a non-empty \`badExample\` field. The compile pipeline's schema parse rejects output that omits it for \`ast-grep\` or \`regex\` engines, so the rule never reaches the smoke gate. Echoing a representative Bad line (or the snippet the rule was built from) is usually enough; the smoke gate runs the rule against this exact string at compile time and rejects the rule if it produces zero matches.
 `;

--- a/packages/cli/src/commands/compile-templates.ts
+++ b/packages/cli/src/commands/compile-templates.ts
@@ -247,9 +247,9 @@ If the lesson points at a context not on this list, escalate to a Tree-sitter S-
 }
 \`\`\`
 
-### Compound example B: empty catch block (uses \`has\` and \`not\`)
+### Compound example B: object literal containing \`shell: true\` (uses \`has\`)
 
-The rule says "the catch_clause does NOT have a statement_block that has any real statement inside". Both \`has\` and \`not\` combine to express the absence of a body.
+The rule says "match any object literal that has \`shell: true\` as a descendant property". The \`has\` combinator expresses the containment relationship cleanly, and \`stopBy: end\` walks the full subtree rather than stopping at the immediate neighbor.
 
 \`\`\`json
 {
@@ -258,29 +258,20 @@ The rule says "the catch_clause does NOT have a statement_block that has any rea
   "pattern": "",
   "astGrepYamlRule": {
     "rule": {
-      "kind": "catch_clause",
-      "not": {
-        "has": {
-          "kind": "statement_block",
-          "has": {
-            "any": [
-              { "kind": "expression_statement" },
-              { "kind": "variable_declaration" },
-              { "kind": "if_statement" },
-              { "kind": "return_statement" },
-              { "kind": "throw_statement" }
-            ],
-            "stopBy": "end"
-          }
-        }
+      "kind": "object",
+      "has": {
+        "pattern": "shell: true",
+        "stopBy": "end"
       }
     }
   },
-  "message": "Catch block is empty - either rethrow, log, or handle the error",
-  "badExample": "try { doWork(); } catch (err) {\\n}",
+  "message": "Shell execution requires explicit opt-in - prefer safeExec or cross-spawn for Windows shim resolution",
+  "badExample": "spawn(cmd, args, { shell: true });",
   "fileGlobs": ["**/*.ts", "**/*.tsx"]
 }
 \`\`\`
+
+Note: do NOT try to express "empty catch block" via \`not: { has: { any: [...kind list...] } }\`. The inverse-of-allow-list shape produces false positives for any statement kind you forgot to enumerate (TypeScript has ~15 statement kinds, including \`for_statement\`, \`while_statement\`, \`switch_statement\`, \`try_statement\`, \`class_declaration\`, etc.). If you need to detect an empty block, use \`nthChild\` or a \`pattern:\` match on literal braces instead, and verify the rule against a badExample that exercises the common non-empty shapes.
 
 ### Compound example C: spawn() calls that are NOT inside an import statement
 

--- a/packages/core/src/compile-lesson.test.ts
+++ b/packages/core/src/compile-lesson.test.ts
@@ -668,6 +668,97 @@ describe('buildCompiledRule smoke gate (mmnto/totem#1408)', () => {
   });
 });
 
+// ─── Compound rule + smoke gate invariants (mmnto-ai/totem#1409) ────
+
+describe('compound rule smoke gate (mmnto-ai/totem#1409)', () => {
+  const compoundLesson: LessonInput = {
+    index: 0,
+    heading: 'No const declarations inside for loops',
+    body: 'Hoist the const out of the loop or use let.',
+    hash: 'compound-1409',
+  };
+
+  it('accepts a compound rule with inside: { kind: for_statement } against a matching badExample', () => {
+    // Happy path from the spike harness test 1: kind-based outer target
+    // is the supported way to express "inside a for-loop". The smoke
+    // gate must accept this when the badExample contains a for-loop
+    // body; that pins the canonical compound shape against silent
+    // regression.
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'No const inside for-loop',
+      engine: 'ast-grep',
+      astGrepYamlRule: {
+        rule: {
+          pattern: 'const $VAR = $VAL',
+          inside: { kind: 'for_statement', stopBy: 'end' },
+        },
+      },
+      badExample: 'for (let i = 0; i < 10; i++) {\n  const inside = i * 2;\n}',
+    };
+    const result = buildCompiledRule(parsed, compoundLesson, existingByHash, {
+      enforceSmokeGate: true,
+    });
+    expect(result.rule).not.toBeNull();
+    expect(result.rule!.engine).toBe('ast-grep');
+    expect(result.rule!.astGrepYamlRule).toBeDefined();
+  });
+
+  it('rejects the inside: { pattern: for ($A; $B; $C) { $$$ } } sharp edge at the smoke gate', () => {
+    // Spike harness test 8 (compound.spike.test.ts:247) pins that
+    // pattern-shaped outer targets silently match zero in 0.42.0. The
+    // prompt forbids this shape; the smoke gate is the backstop. This
+    // test holds the gate honest: feed it the forbidden shape against
+    // the same snippet that the kind-based version matches, and the
+    // gate must reject because the runtime returns zero matches.
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'No const inside for-loop',
+      engine: 'ast-grep',
+      astGrepYamlRule: {
+        rule: {
+          pattern: 'const $VAR = $VAL',
+          inside: {
+            pattern: 'for ($INIT; $COND; $STEP) { $$$ }',
+            stopBy: 'end',
+          },
+        },
+      },
+      badExample: 'for (let i = 0; i < 10; i++) {\n  const inside = i * 2;\n}',
+    };
+    const result = buildCompiledRule(parsed, compoundLesson, existingByHash, {
+      enforceSmokeGate: true,
+    });
+    expect(result.rule).toBeNull();
+    expect(result.rejectReason).toContain('smoke gate');
+  });
+
+  it('rejects a compound rule with no badExample at all (schema-shaped CompilerOutput, gate-shaped test)', () => {
+    // Test the buildCompiledRule layer directly - the schema layer is
+    // covered in compiler-schema.test.ts. Here we prove the smoke-gate
+    // path also rejects a compound rule that arrives with no
+    // badExample, so callers that bypass the schema (e.g., the
+    // upgrade flow) still get the gate's protection.
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'No const inside for-loop',
+      engine: 'ast-grep',
+      astGrepYamlRule: {
+        rule: {
+          pattern: 'const $VAR = $VAL',
+          inside: { kind: 'for_statement', stopBy: 'end' },
+        },
+      },
+    };
+    const result = buildCompiledRule(parsed, compoundLesson, existingByHash, {
+      enforceSmokeGate: true,
+    });
+    expect(result.rule).toBeNull();
+    expect(result.rejectReason).toContain('smoke gate');
+    expect(result.rejectReason).toContain('badExample');
+  });
+});
+
 // ─── buildManualRule ────────────────────────────────
 
 describe('buildManualRule', () => {

--- a/packages/core/src/compiler-schema.test.ts
+++ b/packages/core/src/compiler-schema.test.ts
@@ -131,19 +131,22 @@ describe('CompilerOutputSchema mutual exclusion', () => {
   });
 
   it('accepts compiler output with only astGrepYamlRule', () => {
+    // Post mmnto-ai/totem#1409: every compilable ast-grep output must
+    // carry a non-empty badExample, so the happy path here includes one.
     const parsed = CompilerOutputSchema.parse({
       compilable: true,
       engine: 'ast-grep',
       message: 'msg',
       astGrepYamlRule: { rule: { pattern: 'foo($A)' } },
+      badExample: 'foo(1)',
     });
     expect(parsed.astGrepYamlRule).toBeDefined();
   });
 });
 
-// ─── badExample optional field ───────────────────────
+// ─── CompiledRule badExample optional field ──────────
 
-describe('badExample optional field', () => {
+describe('CompiledRule badExample field', () => {
   const baseRule = {
     lessonHash: 'abc123def456',
     lessonHeading: 'Test rule',
@@ -161,12 +164,20 @@ describe('badExample optional field', () => {
     expect(parsed.badExample).toBe('const foo = 1;');
   });
 
-  it('accepts a CompiledRule without badExample (optional)', () => {
+  it('accepts a CompiledRule without badExample (optional on the persisted shape)', () => {
+    // CompiledRule stays optional because Pipeline 1 (manual) rules
+    // have not yet been taught to emit badExample — that work is
+    // deferred to mmnto-ai/totem#1414. Only CompilerOutput (the LLM
+    // gate) flips to required in mmnto-ai/totem#1409.
     const parsed = CompiledRuleSchema.parse(baseRule);
     expect(parsed.badExample).toBeUndefined();
   });
+});
 
-  it('accepts CompilerOutput with badExample set', () => {
+// ─── CompilerOutput badExample required per engine (mmnto-ai/totem#1409) ──
+
+describe('CompilerOutput badExample required by engine', () => {
+  it('accepts a regex CompilerOutput with a non-empty badExample', () => {
     const parsed = CompilerOutputSchema.parse({
       compilable: true,
       pattern: '\\bfoo\\b',
@@ -175,6 +186,101 @@ describe('badExample optional field', () => {
       badExample: 'const foo = 1;',
     });
     expect(parsed.badExample).toBe('const foo = 1;');
+  });
+
+  it('accepts an ast-grep CompilerOutput with a non-empty badExample', () => {
+    const parsed = CompilerOutputSchema.parse({
+      compilable: true,
+      message: 'No console.log',
+      engine: 'ast-grep',
+      astGrepPattern: 'console.log($A)',
+      badExample: 'console.log("debug");',
+    });
+    expect(parsed.badExample).toBe('console.log("debug");');
+  });
+
+  it('rejects a regex CompilerOutput missing badExample', () => {
+    const result = CompilerOutputSchema.safeParse({
+      compilable: true,
+      pattern: '\\bfoo\\b',
+      message: 'No foo',
+      engine: 'regex',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a regex CompilerOutput with an empty badExample string', () => {
+    const result = CompilerOutputSchema.safeParse({
+      compilable: true,
+      pattern: '\\bfoo\\b',
+      message: 'No foo',
+      engine: 'regex',
+      badExample: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an ast-grep CompilerOutput missing badExample', () => {
+    const result = CompilerOutputSchema.safeParse({
+      compilable: true,
+      message: 'No console.log',
+      engine: 'ast-grep',
+      astGrepPattern: 'console.log($A)',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an ast-grep compound CompilerOutput missing badExample', () => {
+    const result = CompilerOutputSchema.safeParse({
+      compilable: true,
+      message: 'No const inside for-loop',
+      engine: 'ast-grep',
+      astGrepYamlRule: {
+        rule: {
+          pattern: 'const $VAR = $VAL',
+          inside: { kind: 'for_statement', stopBy: 'end' },
+        },
+      },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts an ast engine CompilerOutput without badExample (exempt engine)', () => {
+    // Tree-sitter S-expression rules are not covered by the smoke gate
+    // in mmnto-ai/totem#1408, so the schema does not force a badExample
+    // on them. The exemption is load-bearing: removing it would reject
+    // every ast-engine rule the LLM emits today.
+    const parsed = CompilerOutputSchema.parse({
+      compilable: true,
+      message: 'AST check',
+      engine: 'ast',
+      astQuery: '(catch_clause) @c',
+    });
+    expect(parsed.engine).toBe('ast');
+    expect(parsed.badExample).toBeUndefined();
+  });
+
+  it('accepts a non-compilable CompilerOutput without badExample', () => {
+    // When compilable is false, there is no rule to smoke-test, so
+    // badExample stays optional. The reason field is what matters.
+    const parsed = CompilerOutputSchema.parse({
+      compilable: false,
+      reason: 'Conceptual architectural principle',
+    });
+    expect(parsed.compilable).toBe(false);
+  });
+
+  it('rejects a CompilerOutput with no engine field but no badExample (defaults to regex)', () => {
+    // buildCompiledRule defaults a missing engine to regex, so the
+    // schema treats the absent case the same way for gate purposes.
+    // This closes the back door where the LLM could omit engine to
+    // skip the required badExample.
+    const result = CompilerOutputSchema.safeParse({
+      compilable: true,
+      pattern: '\\bnpm\\b',
+      message: 'Use pnpm instead of npm',
+    });
+    expect(result.success).toBe(false);
   });
 });
 

--- a/packages/core/src/compiler-schema.ts
+++ b/packages/core/src/compiler-schema.ts
@@ -187,8 +187,14 @@ const CompilerOutputBaseSchema = z.object({
   /** Compound ast-grep rule (NapiConfig). Mutually exclusive with `astGrepPattern`. */
   astGrepYamlRule: AstGrepYamlRuleSchema.optional(),
   /**
-   * Optional code snippet the rule is expected to match. Optional in
-   * 1.14.9; gate wired in mmnto/totem#1408.
+   * Code snippet the rule is expected to match. Flipped from optional to
+   * engine-conditional required in mmnto-ai/totem#1409 - regex and
+   * ast-grep rules must carry a non-empty snippet so the compile-time
+   * smoke gate (#1408) can execute the rule against known-bad code
+   * before it lands in compiled-rules.json. The Zod field stays
+   * optional here; the `refineBadExampleRequired` superRefine below
+   * enforces the engine-conditional requirement so the error message
+   * can name the engine and cite the ticket.
    */
   badExample: z.string().optional(),
   severity: z.enum(['error', 'warning']).optional(),
@@ -196,9 +202,45 @@ const CompilerOutputBaseSchema = z.object({
   reason: z.string().optional(),
 });
 
-export const CompilerOutputSchema = CompilerOutputBaseSchema.superRefine(
-  refineAstGrepMutualExclusion,
-);
+/**
+ * Enforce that Pipeline 2 / Pipeline 3 LLM output carries a non-empty
+ * `badExample` for every rule whose engine is covered by the compile-time
+ * smoke gate (regex and ast-grep, per mmnto-ai/totem#1408). The `ast`
+ * engine (Tree-sitter S-expression queries) is exempt because the smoke
+ * gate does not yet evaluate those rules - forcing `badExample` there
+ * would reject every ast-engine rule the LLM emits today.
+ *
+ * An absent `engine` field counts as `regex` because `buildCompiledRule`
+ * defaults a missing engine to regex. Without that equivalence the LLM
+ * could omit `engine` and bypass the gate silently.
+ *
+ * Applies only to compilable rules. Non-compilable output carries
+ * `reason` instead of a rule and has nothing for the gate to execute.
+ */
+function refineBadExampleRequired(
+  data: {
+    compilable: boolean;
+    engine?: 'regex' | 'ast' | 'ast-grep';
+    badExample?: string;
+  },
+  ctx: z.RefinementCtx,
+): void {
+  if (!data.compilable) return;
+  const engineRequiresBadExample = data.engine !== 'ast';
+  if (!engineRequiresBadExample) return;
+  if (typeof data.badExample === 'string' && data.badExample.length > 0) return;
+  ctx.addIssue({
+    code: z.ZodIssueCode.custom,
+    message:
+      'badExample is required (non-empty string) for regex and ast-grep engines (mmnto-ai/totem#1409)',
+    path: ['badExample'],
+  });
+}
+
+export const CompilerOutputSchema = CompilerOutputBaseSchema.superRefine((data, ctx) => {
+  refineAstGrepMutualExclusion(data, ctx);
+  refineBadExampleRequired(data, ctx);
+});
 
 export type CompilerOutput = z.infer<typeof CompilerOutputSchema>;
 

--- a/packages/core/src/compiler.test.ts
+++ b/packages/core/src/compiler.test.ts
@@ -922,10 +922,14 @@ describe('CompiledRuleSchema status field', () => {
 
 describe('parseCompilerResponse', () => {
   it('parses a valid compilable response', () => {
+    // Post mmnto-ai/totem#1409: regex and ast-grep compilable responses
+    // must carry a non-empty badExample. Adding one here is the
+    // realistic happy-path shape and keeps the expect-equal tight.
     const response = JSON.stringify({
       compilable: true,
       pattern: '\\bnpm\\b',
       message: 'Use pnpm instead of npm',
+      badExample: 'npm install lodash',
     });
 
     const result = parseCompilerResponse(response);
@@ -933,6 +937,7 @@ describe('parseCompilerResponse', () => {
       compilable: true,
       pattern: '\\bnpm\\b',
       message: 'Use pnpm instead of npm',
+      badExample: 'npm install lodash',
     });
   });
 
@@ -943,9 +948,10 @@ describe('parseCompilerResponse', () => {
   });
 
   it('extracts JSON from a code fence', () => {
+    // Post mmnto-ai/totem#1409: compilable regex rules need badExample.
     const response = `Here is the compiled rule:
 \`\`\`json
-{"compilable": true, "pattern": "console\\\\.log", "message": "Remove debug logging"}
+{"compilable": true, "pattern": "console\\\\.log", "message": "Remove debug logging", "badExample": "console.log('hi')"}
 \`\`\``;
 
     const result = parseCompilerResponse(response);
@@ -957,7 +963,7 @@ describe('parseCompilerResponse', () => {
   it('extracts JSON from a tilde-fenced code block (#1319)', () => {
     const response = `Here is the compiled rule:
 ~~~json
-{"compilable": true, "pattern": "console\\\\.log", "message": "Remove debug logging"}
+{"compilable": true, "pattern": "console\\\\.log", "message": "Remove debug logging", "badExample": "console.log('hi')"}
 ~~~`;
 
     const result = parseCompilerResponse(response);
@@ -997,11 +1003,13 @@ describe('parseCompilerResponse', () => {
   });
 
   it('parses a response with fileGlobs', () => {
+    // Post mmnto-ai/totem#1409: compilable regex rules need badExample.
     const response = JSON.stringify({
       compilable: true,
       pattern: '\\$[a-zA-Z_]+',
       message: 'Quote shell variables',
       fileGlobs: ['*.sh', '*.bash', '*.yml'],
+      badExample: 'echo $HOME',
     });
 
     const result = parseCompilerResponse(response);
@@ -1010,38 +1018,45 @@ describe('parseCompilerResponse', () => {
       pattern: '\\$[a-zA-Z_]+',
       message: 'Quote shell variables',
       fileGlobs: ['*.sh', '*.bash', '*.yml'],
+      badExample: 'echo $HOME',
     });
   });
 
   it('strips single backtick wrappers from pattern fields', () => {
+    // Post mmnto-ai/totem#1409: compilable ast-grep rules need badExample.
     const response = JSON.stringify({
       compilable: true,
       engine: 'ast-grep',
       astGrepPattern: '`spawn($CMD, [$$$ARGS], { shell: true })`',
       pattern: '',
       message: 'Do not use shell:true with array args',
+      badExample: 'spawn("ls", [], { shell: true });',
     });
     const result = parseCompilerResponse(response);
     expect(result!.astGrepPattern).toBe('spawn($CMD, [$$$ARGS], { shell: true })');
   });
 
   it('strips single backtick wrappers from regex pattern', () => {
+    // Post mmnto-ai/totem#1409: compilable regex rules need badExample.
     const response = JSON.stringify({
       compilable: true,
       pattern: '`\\bconsole\\.log\\b`',
       message: 'No console.log',
+      badExample: 'console.log("hi")',
     });
     const result = parseCompilerResponse(response);
     expect(result!.pattern).toBe('\\bconsole\\.log\\b');
   });
 
   it('leaves patterns without backtick wrappers unchanged', () => {
+    // Post mmnto-ai/totem#1409: compilable ast-grep rules need badExample.
     const response = JSON.stringify({
       compilable: true,
       engine: 'ast-grep',
       astGrepPattern: '$OBJ.replace(process.cwd(), $R)',
       pattern: '',
       message: 'Use path.relative',
+      badExample: 'foo.replace(process.cwd(), "")',
     });
     const result = parseCompilerResponse(response);
     expect(result!.astGrepPattern).toBe('$OBJ.replace(process.cwd(), $R)');


### PR DESCRIPTION
## Mechanical Root Cause

ADR-087 Decision 2 and Decision 3 locked two pieces that this ticket lands together: teach the Pipeline 2 (LLM-from-prose) and Pipeline 3 (example-based) compiler to emit compound ast-grep rules with `kind:` for outer combinator targets, and teach it to emit a `badExample` snippet alongside every rule so the #1408 smoke gate has something to run against. The PR 1416 postmerge empirically validated that without these changes, Pipeline 2 compile throughput drops to zero — the gate rejects rules without a `badExample`, and until Sonnet is taught to emit one, no new rules land.

## Fix Applied

4 bisectable commits:

1. **`b19a2c93`** — new `KIND_ALLOW_LIST` named export. 14 tree-sitter kinds covering the common outer-combinator surfaces (for/while/do statements, try/catch, function/class declarations, if/switch, import/export). Single source of truth — the prompt interpolates it so we never drift.
2. **`dbe67700`** — flip `CompilerOutputSchema.badExample` from optional to required for ast-grep AND regex engines via `superRefine`. `ast` engine stays exempt (smoke gate does not cover it per #1408). Existing tests that emitted ast-grep/regex rules without `badExample` got realistic fixtures added (8 in total, listed below).
3. **`73cc310c`** — rewrite `COMPILER_SYSTEM_PROMPT` in `packages/cli/src/commands/compile-templates.ts`. Renames the misleading "Compound patterns" section (those were flat with `$$$` captures, not structural) to "Flat patterns with $$$ captures". Adds a new section "Compound rules (structural combinators: inside, has, not)" with the `kind:` preference, the `inside: { pattern: ... }` forbid citing spike #1406 findings G-3, and 3 compound examples each carrying a `badExample`. Adds a new "Bad Example (REQUIRED)" section. Updates the final JSON output template. Prompt delta: +210 lines. Anthropic prompt caching amortizes on the second call within a 5-minute TTL.
4. **`9fb39cb7`** — regression tests for every invariant listed in the design doc. 25 new tests across `compiler-schema.test.ts` (+10), `compile-templates.test.ts` (+10), `compile-lesson.test.ts` (+3). The sharp-edge regression test pins the spike finding: a rule using `inside: { pattern: 'for ($A; $B; $C) { $$$ }' }` fails the smoke gate (silent zero-match), while the same rule using `inside: { kind: 'for_statement' }` passes.

## Out of Scope

- Benchmark script for compound rule emission. Deferred to phase 4 per the locked open question 2.
- Bulk recompile of archived `upgradeTarget: compound` rules. Phase 4 on the epic.
- Pipeline 1 `badExample` extraction or gate flip. Deferred to #1414.
- `ruleFormat: 'flat' | 'compound'` enum. Redundant — the shape of `astGrepPattern` vs `astGrepYamlRule` already discriminates.

## Tests Added/Updated

- [x] 25 new tests locking every invariant from the design doc
- [x] 8 existing test fixtures updated with realistic `badExample` snippets: 7 in `packages/core/src/compiler.test.ts` (every `parseCompilerResponse` happy path with regex or ast-grep) and 1 in `compiler-schema.test.ts`

**Verification:**

- `pnpm -r test`: 1134 (core) + 1662 (cli) + 83 (mcp) = 2879 green (+25 from baseline)
- `pnpm -r build`: clean
- `pnpm exec totem lint`: PASS (34 warnings, 0 errors — warnings are pre-existing idiomatic patterns)
- `pnpm exec totem review`: PASS, no findings
- `pnpm exec totem verify-manifest`: not affected, no compiled rules changed

## Related Tickets

Closes #1409

Epic: mmnto-ai/totem-strategy#81
ADR: `.strategy/adr/adr-087-compound-ast-grep-rules.md` (locked)
Design doc: `.totem/specs/1409.md` (approved)

Unblocks: phase 4 bulk recompile of the `upgradeTarget: compound` archived queue. Once this merges, the next `totem lesson compile` run will exercise the new prompt against fresh lessons AND the existing archived queue on demand.

With #1406, #1407, #1408, #1409 all landed, the 1.14.9 Precision Engine story is structurally complete. #1414 remains as the Pipeline 1 backfill cleanup follow-up.