### PR TITLE
fix(mcp): reopen LanceDB per query for stale-write resilience (#1418)

### DIFF
--- a/packages/core/src/store/lance-store.test.ts
+++ b/packages/core/src/store/lance-store.test.ts
@@ -320,6 +320,92 @@ describe('LanceStore', () => {
     });
   });
 
+  describe('stale-handle resilience (mmnto/totem#1418)', () => {
+    it('surfaces rows written by a separate instance without explicit reconnect', async () => {
+      // Reader connects to an empty directory first.
+      const readerDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lance-stale-'));
+      const readerEmbedder = new FakeEmbedder();
+      const reader = new LanceStore(readerDir, readerEmbedder, { absolutePathRoot: readerDir });
+      await reader.connect();
+
+      try {
+        // First query on an empty store: zero results, refresh counter ticks.
+        const initial = await reader.search({ query: 'alpha' });
+        expect(initial).toEqual([]);
+        const refreshAfterFirst = reader.readRefreshCount;
+        expect(refreshAfterFirst).toBeGreaterThan(0);
+
+        // A separate LanceStore (standing in for `totem sync` as an external
+        // process) writes rows into the SAME directory. The reader holds a
+        // stale view at this point in the timeline.
+        const writerEmbedder = new FakeEmbedder();
+        const writer = new LanceStore(readerDir, writerEmbedder, {
+          absolutePathRoot: readerDir,
+        });
+        await writer.connect();
+        await writer.insert([
+          makeChunk({ content: 'alpha fresh content from external writer', label: 'alpha-row' }),
+          makeChunk({ content: 'beta fresh content from external writer', label: 'beta-row' }),
+        ]);
+
+        // Reader queries again WITHOUT calling reconnect(). The fix reopens
+        // the LanceDB handle inside search(), so the externally-written rows
+        // become visible on this next call.
+        const refreshed = await reader.search({ query: 'alpha content' });
+        expect(refreshed.length).toBeGreaterThan(0);
+        expect(refreshed.some((r) => r.label === 'alpha-row')).toBe(true);
+
+        // Every search() call reopens. Confirms the reopen-per-query contract
+        // the fix relies on.
+        expect(reader.readRefreshCount).toBe(refreshAfterFirst + 1);
+      } finally {
+        cleanTmpDir(readerDir);
+      }
+    });
+
+    it('increments readRefreshCount on every search call', async () => {
+      await store.insert([makeChunk({ content: 'counter test content' })]);
+      const before = store.readRefreshCount;
+      await store.search({ query: 'counter' });
+      await store.search({ query: 'counter' });
+      await store.search({ query: 'counter' });
+      expect(store.readRefreshCount).toBe(before + 3);
+    });
+
+    it('increments readRefreshCount on searchFts call', async () => {
+      await store.insert([makeChunk({ content: 'fts counter content' })]);
+      await store.createFtsIndex();
+      const before = store.readRefreshCount;
+      await store.searchFts({ query: 'fts' });
+      expect(store.readRefreshCount).toBe(before + 1);
+    });
+
+    it('handles concurrent searches without one closing the other handle', async () => {
+      // Shield CRITICAL guard: the reopen-per-query strategy used to close
+      // `this.db` on every call, which would invalidate an in-flight query
+      // launched by a concurrent caller. Per-call snapshots scoped to each
+      // caller eliminate that race; this test keeps the contract locked in.
+      await store.insert([
+        makeChunk({ content: 'concurrent alpha content', label: 'alpha' }),
+        makeChunk({ content: 'concurrent beta content', label: 'beta' }),
+        makeChunk({ content: 'concurrent gamma content', label: 'gamma' }),
+      ]);
+
+      const before = store.readRefreshCount;
+      const results = await Promise.all([
+        store.search({ query: 'concurrent alpha' }),
+        store.search({ query: 'concurrent beta' }),
+        store.search({ query: 'concurrent gamma' }),
+      ]);
+
+      // Every call reopens; none fail from a sibling closing its connection.
+      expect(store.readRefreshCount).toBe(before + 3);
+      for (const r of results) {
+        expect(r.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
   describe('healthCheck', () => {
     it('returns healthy for a populated index', async () => {
       await store.insert([

--- a/packages/core/src/store/lance-store.ts
+++ b/packages/core/src/store/lance-store.ts
@@ -29,6 +29,44 @@ export function escapeSqlString(input: string): string {
   return input.replace(/'/g, "''");
 }
 
+/**
+ * Stateless FTS-index probe. Shared by the instance-level `detectFtsIndex`
+ * that maintains `this.hasFtsIndex` and by `openReadSnapshot()` which needs
+ * to compute the flag for a fresh per-call table handle without touching
+ * shared state (mmnto/totem#1418).
+ */
+async function detectFtsIndexOnTable(
+  table: lancedb.Table | null,
+  onWarn: (msg: string) => void,
+): Promise<boolean> {
+  if (!table) return false;
+  try {
+    const indices = await table.listIndices();
+    return indices.some((idx) => idx.indexType === 'FTS' || idx.name === 'content_idx');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    onWarn(`FTS index detection failed: ${msg}`);
+    return false;
+  }
+}
+
+/**
+ * Close a per-query LanceDB connection opened by `openReadSnapshot()`.
+ * `close()` can throw in some edge cases (e.g., the underlying directory
+ * was removed mid-query). Swallow and warn so a failed close never masks
+ * a successful search result (mmnto/totem#1418).
+ */
+function closeReadSnapshot(db: lancedb.Connection, onWarn: (msg: string) => void): void {
+  try {
+    if (db.isOpen()) {
+      db.close();
+    }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    onWarn(`LanceDB read-snapshot close failed: ${msg}`);
+  }
+}
+
 export class LanceStore {
   private db: lancedb.Connection | null = null;
   private table: lancedb.Table | null = null;
@@ -36,6 +74,12 @@ export class LanceStore {
   private embedder: Embedder;
   private hasFtsIndex = false;
   private onWarn: (msg: string) => void;
+  /**
+   * Instrumentation: number of times the read path has reopened the handle
+   * via `refreshReadHandle()`. Exposed via `readRefreshCount` so tests
+   * (mmnto/totem#1418) can assert the reopen fires on every search.
+   */
+  private readRefreshes = 0;
   /**
    * Source repo context injected at construction time. Primary stores use
    * `{ absolutePathRoot: projectRoot }` with no `sourceRepo`; linked stores
@@ -226,20 +270,7 @@ export class LanceStore {
 
   /** Check whether an FTS index exists on the table. */
   private async detectFtsIndex(): Promise<void> {
-    if (!this.table) {
-      this.hasFtsIndex = false;
-      return;
-    }
-    try {
-      const indices = await this.table.listIndices();
-      this.hasFtsIndex = indices.some(
-        (idx) => idx.indexType === 'FTS' || idx.name === 'content_idx',
-      );
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      this.onWarn(`FTS index detection failed: ${msg}`);
-      this.hasFtsIndex = false;
-    }
+    this.hasFtsIndex = await detectFtsIndexOnTable(this.table, this.onWarn);
   }
 
   /** Whether the FTS index is available for hybrid search. */
@@ -250,55 +281,71 @@ export class LanceStore {
   /**
    * Search with optional hybrid mode (vector + FTS with RRF reranking).
    * Falls back to vector-only if no FTS index exists.
+   *
+   * Opens a fresh LanceDB snapshot for this call (mmnto/totem#1418) so an
+   * external `totem sync` cannot leave this store reading a stale view,
+   * and so concurrent searches never invalidate each other's handle.
    */
   async search(options: SearchOptions): Promise<SearchResult[]> {
-    if (!this.table) return [];
+    const snapshot = await this.openReadSnapshot();
+    try {
+      if (!snapshot.table) return [];
 
-    const maxResults = options.maxResults ?? 5;
-    const boundary = options.boundary;
-    const useHybrid = (options.hybrid ?? true) && this.hasFtsIndex;
+      const maxResults = options.maxResults ?? 5;
+      const boundary = options.boundary;
+      const useHybrid = (options.hybrid ?? true) && snapshot.hasFtsIndex;
 
-    if (useHybrid) {
-      return runHybridSearch(
-        this.table,
+      if (useHybrid) {
+        return await runHybridSearch(
+          snapshot.table,
+          this.embedder,
+          this.onWarn,
+          options.query,
+          options.typeFilter as ContentType | undefined,
+          maxResults,
+          this.sourceContext,
+          boundary,
+        );
+      }
+
+      return await runVectorSearch(
+        snapshot.table,
         this.embedder,
-        this.onWarn,
         options.query,
         options.typeFilter as ContentType | undefined,
         maxResults,
         this.sourceContext,
         boundary,
       );
+    } finally {
+      closeReadSnapshot(snapshot.db, this.onWarn);
     }
-
-    return runVectorSearch(
-      this.table,
-      this.embedder,
-      options.query,
-      options.typeFilter as ContentType | undefined,
-      maxResults,
-      this.sourceContext,
-      boundary,
-    );
   }
 
   /**
-   * FTS-only search — no embedder required.
+   * FTS-only search. No embedder required.
    * Use when embedding is unavailable (offline, no API key, cold-start fallback).
    * Requires an FTS index to exist; returns empty if none available.
+   *
+   * Opens a fresh LanceDB snapshot for this call (mmnto/totem#1418).
    */
   async searchFts(options: SearchOptions): Promise<SearchResult[]> {
-    if (!this.table || !this.hasFtsIndex) return [];
+    const snapshot = await this.openReadSnapshot();
+    try {
+      if (!snapshot.table || !snapshot.hasFtsIndex) return [];
 
-    return runFtsSearch(
-      this.table,
-      this.onWarn,
-      options.query,
-      options.typeFilter as ContentType | undefined,
-      options.maxResults ?? 5,
-      this.sourceContext,
-      options.boundary,
-    );
+      return await runFtsSearch(
+        snapshot.table,
+        this.onWarn,
+        options.query,
+        options.typeFilter as ContentType | undefined,
+        options.maxResults ?? 5,
+        this.sourceContext,
+        options.boundary,
+      );
+    } finally {
+      closeReadSnapshot(snapshot.db, this.onWarn);
+    }
   }
 
   /** Delete all chunks from a specific file (for incremental re-index). */
@@ -326,6 +373,69 @@ export class LanceStore {
     this.table = null;
     this.hasFtsIndex = false;
     await this.connect();
+  }
+
+  /**
+   * Open a fresh read snapshot (connection + table + fts flag) for a single
+   * query. Scoped to the caller, NOT written onto `this.db` / `this.table`,
+   * so concurrent searches don't race each other's handle lifetime
+   * (mmnto/totem#1418 Shield CRITICAL follow-up).
+   *
+   * **Why unconditional reopen.** The MCP server holds LanceStore for the
+   * life of the process. When `totem sync` (a separate process) rewrites
+   * `.lancedb/` files underneath us, LanceDB's in-memory manifest keeps
+   * pointing at the pre-sync snapshot. Vector search against that stale
+   * view returns empty, which falls through to FTS-only via the hybrid
+   * path, producing uniform ~0.016 RRF scores instead of real similarity
+   * ranks. The corrupt path is silent because no exception fires.
+   *
+   * **Why not mtime-check.** A benchmark (see scripts/bench-lance-open.ts)
+   * measured connect+openTable at ~0.5-1.1ms per call against real indexes.
+   * That's well under the 10ms threshold where mtime gating starts to pay
+   * for its own complexity. Reopening every time is strictly simpler and
+   * eliminates a whole category of cache-invalidation bugs.
+   *
+   * **Why per-call snapshots.** Assigning the fresh connection to `this.db`
+   * and then closing the old one from a second concurrent caller would
+   * invalidate the first caller's in-flight query. Instead each call holds
+   * its own connection + table references through the query lifetime, and
+   * closes the connection in a finally block after the results return.
+   * The instance-level `this.db` / `this.table` fields are still maintained
+   * so write paths and existing consumers (healthCheck, stats, count) see
+   * an up-to-date view on the next non-read call via `connect()`.
+   *
+   * **Why not also refresh write paths.** `totem sync` owns the writer
+   * connection exclusively inside a single process. Write operations
+   * (insert, deleteByFile, reset) already hold a consistent view for
+   * their own workflow and a mid-sequence reopen would drop the in-flight
+   * table reference that `insert()` sets during first-table creation.
+   */
+  private async openReadSnapshot(): Promise<{
+    db: lancedb.Connection;
+    table: lancedb.Table | null;
+    hasFtsIndex: boolean;
+  }> {
+    const db = await lancedb.connect(this.dbPath);
+    const tableNames = await db.tableNames();
+
+    let table: lancedb.Table | null = null;
+    let hasFtsIndex = false;
+    if (tableNames.includes(TOTEM_TABLE_NAME)) {
+      table = await db.openTable(TOTEM_TABLE_NAME);
+      hasFtsIndex = await detectFtsIndexOnTable(table, this.onWarn);
+    }
+
+    this.readRefreshes += 1;
+    return { db, table, hasFtsIndex };
+  }
+
+  /**
+   * Test-seam instrumentation (mmnto/totem#1418): total count of read-path
+   * handle refreshes since this store was constructed. Asserted by the
+   * stale-handle regression test to confirm every search() call reopens.
+   */
+  get readRefreshCount(): number {
+    return this.readRefreshes;
   }
 
   /** Return true if the table doesn't exist or has zero rows. */

--- a/packages/core/src/store/lance-store.ts
+++ b/packages/core/src/store/lance-store.ts
@@ -416,17 +416,29 @@ export class LanceStore {
     hasFtsIndex: boolean;
   }> {
     const db = await lancedb.connect(this.dbPath);
-    const tableNames = await db.tableNames();
 
-    let table: lancedb.Table | null = null;
-    let hasFtsIndex = false;
-    if (tableNames.includes(TOTEM_TABLE_NAME)) {
-      table = await db.openTable(TOTEM_TABLE_NAME);
-      hasFtsIndex = await detectFtsIndexOnTable(table, this.onWarn);
+    // Shield WARN guard: `tableNames()` and `openTable()` can both throw.
+    // Without this try/catch the partially-opened `db` connection would
+    // leak if either step failed, because the caller's finally block that
+    // calls `closeReadSnapshot` only runs once the snapshot object is
+    // returned. Close the connection inline before rethrowing so the
+    // failure path is leak-free.
+    try {
+      const tableNames = await db.tableNames();
+
+      let table: lancedb.Table | null = null;
+      let hasFtsIndex = false;
+      if (tableNames.includes(TOTEM_TABLE_NAME)) {
+        table = await db.openTable(TOTEM_TABLE_NAME);
+        hasFtsIndex = await detectFtsIndexOnTable(table, this.onWarn);
+      }
+
+      this.readRefreshes += 1;
+      return { db, table, hasFtsIndex };
+    } catch (err) {
+      closeReadSnapshot(db, this.onWarn);
+      throw err;
     }
-
-    this.readRefreshes += 1;
-    return { db, table, hasFtsIndex };
   }
 
   /**

--- a/scripts/bench-lance-open.ts
+++ b/scripts/bench-lance-open.ts
@@ -1,0 +1,88 @@
+#!/usr/bin/env tsx
+/**
+ * Benchmark LanceDB connection open cost for mmnto/totem#1418.
+ *
+ * Drives the decision between reopen-per-query and mtime-check-and-reopen
+ * strategies for the MCP stale-handle fix. If per-open cost sits below ~10ms,
+ * reopening on every query is acceptable. If it runs above ~50ms, mtime
+ * gating wins. Numbers above 10ms but below 50ms are a tradeoff call.
+ *
+ * Usage:
+ *   pnpm tsx scripts/bench-lance-open.ts [path-to-lancedb]
+ *
+ * Default path: .strategy/.lancedb
+ */
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+import { performance } from 'node:perf_hooks';
+
+// Resolve @lancedb/lancedb through the `packages/core` package, since this
+// script lives at the repo root and the root has no direct dependency on
+// LanceDB (it's transitively held by @mmnto/totem).
+const localRequire = createRequire(path.resolve(process.cwd(), 'packages/core/package.json'));
+const lancedb = localRequire('@lancedb/lancedb') as typeof import('@lancedb/lancedb');
+
+const DEFAULT_PATH = path.resolve(process.cwd(), '.strategy/.lancedb');
+const TABLE_NAME = 'totem_chunks';
+
+async function main(): Promise<void> {
+  const dbPath = process.argv[2] ?? DEFAULT_PATH;
+  const iterations = Number(process.env.ITERATIONS ?? '100');
+
+  console.log(`[bench] dbPath=${dbPath} iterations=${iterations}`);
+
+  // Warm up — exclude the first few opens so the measurement reflects steady state.
+  for (let i = 0; i < 3; i += 1) {
+    const db = await lancedb.connect(dbPath);
+    await db.tableNames();
+    db.close();
+  }
+
+  const connectTimings: number[] = [];
+  const openTableTimings: number[] = [];
+  const totalTimings: number[] = [];
+
+  for (let i = 0; i < iterations; i += 1) {
+    const t0 = performance.now();
+    const db = await lancedb.connect(dbPath);
+    const t1 = performance.now();
+    const names = await db.tableNames();
+    let table = null;
+    if (names.includes(TABLE_NAME)) {
+      table = await db.openTable(TABLE_NAME);
+    }
+    const t2 = performance.now();
+    db.close();
+
+    connectTimings.push(t1 - t0);
+    openTableTimings.push(t2 - t1);
+    totalTimings.push(t2 - t0);
+
+    // Silence unused warning
+    void table;
+  }
+
+  printStats('lancedb.connect()', connectTimings);
+  printStats('tableNames() + openTable()', openTableTimings);
+  printStats('TOTAL (connect + open)', totalTimings);
+}
+
+function printStats(label: string, timings: number[]): void {
+  const sorted = [...timings].sort((a, b) => a - b);
+  const n = sorted.length;
+  const sum = sorted.reduce((a, b) => a + b, 0);
+  const avg = sum / n;
+  const median = sorted[Math.floor(n / 2)]!;
+  const p95 = sorted[Math.floor(n * 0.95)]!;
+  const min = sorted[0]!;
+  const max = sorted[n - 1]!;
+  console.log(`\n[${label}]`);
+  console.log(
+    `  n=${n}  avg=${avg.toFixed(2)}ms  median=${median.toFixed(2)}ms  p95=${p95.toFixed(2)}ms  min=${min.toFixed(2)}ms  max=${max.toFixed(2)}ms`,
+  );
+}
+
+main().catch((err) => {
+  console.error('[bench] failed:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Mechanical Root Cause

`LanceStore` opens a single LanceDB connection at MCP server startup and reuses it for every read. When `totem sync` (a separate CLI process) rewrites the on-disk `.lancedb/` files, the in-memory connection continues to point at the pre-sync view of the index. Subsequent `search()` / `searchFts()` calls return stale data, or fall through to FTS-fallback mode that produces uniform low scores masking the broken vector path.

Empirically reproduced on 2026-04-14 immediately after the strategy submodule reorg (#1417): `totem sync` rewrote `.strategy/.lancedb/` to disk; the MCP's `mcp__totem-strategy__search_knowledge` query for the exact title of `adr-087-compound-ast-grep-rules.md` returned ADR-086 + Strategy #73 with uniform `0.016` scores. ADR-087 is on disk and the file mtime was current; the MCP just couldn't see it.

## Fix Applied

**Open a fresh read snapshot per query.** Each `search()` / `searchFts()` call opens a scoped `{db, table, hasFtsIndex}` snapshot, runs the query, and closes the connection in a `finally` block. The snapshot lives on the stack, NOT on `this.db`, so concurrent searches never invalidate each other's in-flight handle.

**Why per-query and not mtime-check:** the benchmark (`scripts/bench-lance-open.ts`) measured connection open cost at **1.11ms avg / 1.35ms p95 on the primary `.lancedb/`** and **0.52ms / 0.66ms on the strategy `.lancedb/`** (n=100 each, 3-iter warmup). Under 1.5ms p95 across the board. The complexity of a stat-cache wrapper is not worth saving 1ms per query.

**Why scoped snapshots and not reopening `this.db`:** Shield review caught a CRITICAL race when the initial implementation reopened onto the shared `this.db`. Concurrent `search()` calls would invalidate each other's in-flight handle. The fix moved the connection ownership onto the local stack, so each query owns its own snapshot for the duration of the call. Locked by a 3-concurrent-search regression test.

## 4 commits, bisectable

1. **`54264ebe`** — `bench(mcp): measure LanceDB connection open cost for stale-handle fix`. Standalone script under `scripts/`. Drops the 1.11ms / 1.35ms p95 measurement that drove the reopen-per-query decision over mtime-caching.
2. **`6ccfacf1`** — `fix(mcp): open fresh LanceDB snapshot per read for stale-write resilience`. The core change. Per-call snapshots in `LanceStore.search()` and `searchFts()`.
3. **`85fd3a97`** — `test(mcp): regression test for stale LanceDB handle after external write`. 4 new tests under `describe('stale-handle resilience (mmnto/totem#1418)')` in `lance-store.test.ts`.
4. **`4ec5a813`** — `fix(mcp): close LanceDB connection on open failure in read snapshot`. Shield WARN follow-up: connection leak if open succeeded but table-fetch failed. Wrapped in a try/catch that closes the partial connection before rethrowing.

The 4-commit story is intentional: the Shield findings were caught and corrected pre-PR, with the correction landing as a separate commit instead of an amend (project rule). The review trail is visible in the commit history.

## Out of Scope

- mtime-cache implementation. Benchmark showed open cost is too low to justify the complexity.
- Filesystem watcher (chokidar etc.). Lazy read-driven reconnect is enough; a watcher would add a background process and signal handling for problems we don't have.
- Content-hash embedding cache (Proposal 230). Adjacent but distinct. That solves duplicate-compute across multi-checkout setups; this PR solves stale-read on the same checkout.

## Tests Added/Updated

- [x] 4 new regression tests in `lance-store.test.ts`:
  - External-write visibility (the primary regression)
  - `readRefreshCount` ticks on `search()`
  - `readRefreshCount` ticks on `searchFts()`
  - 3 concurrent `search()` calls succeed (the race-fix lock)

**Verification:**

- `pnpm -r test`: 2883 green (was 2879)
- `pnpm -r build`: clean
- `pnpm exec totem lint`: PASS, 23 warnings (pre-existing `.includes()` false-positives on the `tableNames` array), 0 errors
- `pnpm exec totem review`: PASS, no findings

## End-to-end verification (post-merge)

Restart Claude Code's MCP servers (exit Claude Code and re-launch, or send the disconnect/reconnect signal). After restart:

1. `cd /d/Dev/totem/.strategy && pnpm exec totem sync`
2. From the host repo, call `mcp__totem-strategy__search_knowledge` with `"compound ast-grep rule support compile pipeline"` (ADR-087 title).
3. ADR-087 should surface as the top hit with a varied vector-similarity score, NOT uniform 0.016.

After this restart, no further MCP restarts are needed for any subsequent `totem sync` runs; the per-query reopen handles freshness automatically.

## Related Tickets

Closes #1418

Required gate before #1421 (pre-1.15.0 deep review) can run with reliable strategy-knowledge searches. Pack Distribution (1.15.0) cannot ship a stale-handle bug in the federated query surface that packs will rely on.