### PR TITLE
security(cli): reject shell-injecting {model} tokens in shell orchestrator

### DIFF
--- a/.changeset/security-1-14-10-shell-orchestrator-model-injection.md
+++ b/.changeset/security-1-14-10-shell-orchestrator-model-injection.md
@@ -8,8 +8,8 @@ The shell orchestrator used to interpolate `orchestrator.defaultModel` (and per-
 
 **Fix is defense in depth:**
 
-1. **Allow-list at the boundary.** Model names must match `^[a-zA-Z0-9][a-zA-Z0-9._:/_-]*$`. Anything outside this set throws loud before spawn is called. Covers every model name used in practice (providers, dashes, dots, colons for provider-qualified names, slashes for ns/model, underscores for ollama quantized tags).
-2. **Shell-quoting at interpolation.** Even after the allow-list passes, the model token is wrapped in shell-safe quotes (single on Unix, double on Windows) — same treatment the `{file}` token has always had. A future regression that drops the allow-list cannot re-open the hole alone.
+1. **Shared allow-list at the boundary.** The shell orchestrator now imports `MODEL_NAME_RE` from `orchestrator.ts` and applies the same leading-dash + allow-list check that `resolveOrchestrator` has always used. Single source of truth for model-name validation, symmetric across all orchestrators, no chance of one gate rejecting what another accepts. Validation errors throw `TotemConfigError` matching the sibling validator.
+2. **Shell-quoting at interpolation.** Even after the allow-list passes, the model token is wrapped in shell-safe quotes (single-quote on Unix, MSVCRT-style `\"` escape on Windows) — same treatment the `{file}` token has always had. A future regression that drops the allow-list cannot re-open the hole alone.
 
 **Regression tests added:** 12 exploit cases (semicolon, backtick, dollar-subshell, pipe, redirect, newline, ampersand, space, quote, dquote, paren, leading-dash) all rejected before `spawn()` is called. 8 benign model shapes accepted including underscore-containing ollama quantized tags. 1 defense-in-depth assertion that the model is quoted on the spawn command.
 

--- a/.changeset/security-1-14-10-shell-orchestrator-model-injection.md
+++ b/.changeset/security-1-14-10-shell-orchestrator-model-injection.md
@@ -1,0 +1,24 @@
+---
+'@mmnto/totem': patch
+---
+
+Security: Reject shell-injecting `{model}` tokens in the shell orchestrator
+
+The shell orchestrator used to interpolate `orchestrator.defaultModel` (and per-command overrides) directly into a command string that was then executed with `shell: true`. A poisoned config value like `"gemini-1.5; rm -rf /"` would run as shell. The `{file}` token was already shell-quoted; the `{model}` token was not.
+
+**Fix is defense in depth:**
+
+1. **Allow-list at the boundary.** Model names must match `^[a-zA-Z0-9][a-zA-Z0-9._:/_-]*$`. Anything outside this set throws loud before spawn is called. Covers every model name used in practice (providers, dashes, dots, colons for provider-qualified names, slashes for ns/model, underscores for ollama quantized tags).
+2. **Shell-quoting at interpolation.** Even after the allow-list passes, the model token is wrapped in shell-safe quotes (single on Unix, double on Windows) — same treatment the `{file}` token has always had. A future regression that drops the allow-list cannot re-open the hole alone.
+
+**Regression tests added:** 12 exploit cases (semicolon, backtick, dollar-subshell, pipe, redirect, newline, ampersand, space, quote, dquote, paren, leading-dash) all rejected before `spawn()` is called. 8 benign model shapes accepted including underscore-containing ollama quantized tags. 1 defense-in-depth assertion that the model is quoted on the spawn command.
+
+**Exposure assessment:**
+
+Exploitable only when a user runs any `totem` command that reaches the shell orchestrator AND a poisoned `totem.config.ts` is present. Realistic vector: cloning a malicious repo and running `totem review` / `totem compile` / `totem spec` against it. Trusted-config users (single-developer, audited-config repos) were never at risk.
+
+**Minor backward-compat note:**
+
+Users whose `orchestrator.command` string manually wrapped `{model}` in quotes (e.g., `"--model=\"{model}\""`) will see the token double-quoted after this patch. The shell strips the outer quotes, so the final argv is identical, but if anyone has a custom command that depends on the raw unquoted substitution, they should drop the manual quotes from their template. Most users followed the existing `{file}` pattern (no manual quotes — Totem quotes for you), so this affects a narrow slice.
+
+Thanks to Gemini for catching this in the pre-1.15.0 deep review.

--- a/.totem/compile-manifest.json
+++ b/.totem/compile-manifest.json
@@ -1,7 +1,7 @@
 {
-  "compiled_at": "2026-04-15T00:21:20.771Z",
+  "compiled_at": "2026-04-15T06:01:05.919Z",
   "model": "gemini-3-flash-preview",
   "input_hash": "6768a0151660dce316e7e916463fdf86d60c4d70f13ef4937c9ed0e5325c2732",
-  "output_hash": "827b2b68320c471328af64ea23ded9b1f06626b04490b412ad0ccaccc33f8fdd",
+  "output_hash": "3ce48ec48ee5c630ed64ae8bf926d0329124ec38cc166a29b8d5d885dd8d0555",
   "rule_count": 411
 }

--- a/.totem/compile-manifest.json
+++ b/.totem/compile-manifest.json
@@ -2,6 +2,6 @@
   "compiled_at": "2026-04-15T00:21:20.771Z",
   "model": "gemini-3-flash-preview",
   "input_hash": "6768a0151660dce316e7e916463fdf86d60c4d70f13ef4937c9ed0e5325c2732",
-  "output_hash": "ad75642fecc6796d3d99c48a35e1b9dc9c2cd8a9b501c79bf70efc7d81a6e082",
+  "output_hash": "827b2b68320c471328af64ea23ded9b1f06626b04490b412ad0ccaccc33f8fdd",
   "rule_count": 411
 }

--- a/.totem/compile-manifest.json
+++ b/.totem/compile-manifest.json
@@ -1,7 +1,7 @@
 {
-  "compiled_at": "2026-04-15T06:01:05.919Z",
+  "compiled_at": "2026-04-15T06:18:22.942Z",
   "model": "gemini-3-flash-preview",
   "input_hash": "6768a0151660dce316e7e916463fdf86d60c4d70f13ef4937c9ed0e5325c2732",
-  "output_hash": "3ce48ec48ee5c630ed64ae8bf926d0329124ec38cc166a29b8d5d885dd8d0555",
+  "output_hash": "09c351fed0e73e60a38eca340b14eee338cfd134febe27047c23832d4fb92933",
   "rule_count": 411
 }

--- a/.totem/compile-manifest.json
+++ b/.totem/compile-manifest.json
@@ -2,6 +2,6 @@
   "compiled_at": "2026-04-15T00:21:20.771Z",
   "model": "gemini-3-flash-preview",
   "input_hash": "6768a0151660dce316e7e916463fdf86d60c4d70f13ef4937c9ed0e5325c2732",
-  "output_hash": "09c351fed0e73e60a38eca340b14eee338cfd134febe27047c23832d4fb92933",
+  "output_hash": "ad75642fecc6796d3d99c48a35e1b9dc9c2cd8a9b501c79bf70efc7d81a6e082",
   "rule_count": 411
 }

--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -6644,43 +6644,17 @@
       "archivedReason": "Over-broad: pattern JSON.stringify($OBJ) matches any single-argument JSON.stringify call in compile-manifest.ts, including the legitimate primitive-serialization call inside canonicalStringify itself (line 103). The lesson intent is specifically about the canonicalStringify function, not all JSON.stringify calls in the file. upgradeTarget: compound (Proposal 226) — a compound rule with inside: function canonicalStringify(...) { $$$ } could constrain the pattern to calls that bypass canonicalStringify, catching the real anti-pattern without firing on the helper's own implementation. Phase 4 recompile candidate once #1408 and #1409 ship."
     },
     {
-      "lessonHash": "20aa11df474faf48",
+      "lessonHash": "85bca8dcad2b19cb",
       "lessonHeading": "Pipeline 5: observation from shield",
-      "pattern": "if\\s+\\(model\\.startsWith\\('-'\\)\\s+\\|\\|\\s+!MODEL_NAME_RE\\.test\\(model\\)\\)\\s+\\{",
-      "message": "`TotemParseError` is used for a configuration validation error. Consider using `TotemConfigError` (as used in `resolveOrchestrator` for the exact same validation) to maintain consistent error semantics and avoid stylistic drift.",
-      "engine": "regex",
-      "compiledAt": "2026-04-15T05:37:10.108Z",
-      "createdAt": "2026-04-15T05:37:10.108Z",
-      "fileGlobs": [
-        "**/*.ts"
-      ],
-      "severity": "warning"
-    },
-    {
-      "lessonHash": "7616deb08fb0bb7b",
-      "lessonHeading": "Pipeline 5: observation from shield",
-      "pattern": "const\\s+resolvedCmd\\s+=\\s+command",
-      "message": "Missing test for the bug fix regarding string replacement back-references (`$&`, etc.) in `invokeShellOrchestrator`. Bug fixes require corresponding `.test.ts` updates to prevent regressions.",
-      "engine": "regex",
-      "compiledAt": "2026-04-15T05:42:00.153Z",
-      "createdAt": "2026-04-15T05:42:00.153Z",
-      "fileGlobs": [
-        "**/*.ts"
-      ],
-      "severity": "warning"
-    },
-    {
-      "lessonHash": "cbda3b118183c615",
-      "lessonHeading": "Pipeline 5: observation from shield",
-      "pattern": "const\\s+quotedModel\\s+=\\s+quoteShellArg\\(model\\);",
-      "message": "Missing test for bug fix: The fix to prevent regex back-references (like `$&`) in `quotedPath` or `quotedModel` from corrupting shell command interpolation requires a corresponding test case to prevent regressions.",
+      "pattern": "systemPrompt\\s+!==\\s+undefined\\s+&&\\s+systemPrompt\\.length\\s+>\\s+0\\s+\\?\\s+`\\$\\{systemPrompt\\}\\\\n\\\\n\\$\\{prompt\\}`\\s+:\\s+prompt;",
+      "message": "Calling `assertValidModelName(model)` in `invokeShellOrchestrator` introduces a double-parsing bug. `resolveOrchestrator` already strips the provider prefix and passes `parsed.model` to the invoke function. Because `assertValidModelName` applies Gate 3 (`parseModelString`), it will re-parse the already-stripped model string. This falsely rejects valid models containing colons (e.g., `shell:foo:-bar` becomes `foo:-bar`, which Gate 3 splits again, rejecting `-bar` for starting with `-`). Gate 3 is a lookahead check only needed in `resolveOrchestrator` to ensure the post-strip string doesn't start with `-`. `invokeShellOrchestrator` should revert to only checking Gate 1 and 2.",
       "engine": "regex",
       "severity": "warning",
       "fileGlobs": [
         "**/*.ts"
       ],
-      "compiledAt": "2026-04-15T05:42:20.623Z",
-      "createdAt": "2026-04-15T05:42:20.623Z"
+      "compiledAt": "2026-04-15T06:04:25.951Z",
+      "createdAt": "2026-04-15T06:04:25.951Z"
     }
   ],
   "nonCompilable": [

--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -6642,19 +6642,6 @@
       "severity": "warning",
       "status": "archived",
       "archivedReason": "Over-broad: pattern JSON.stringify($OBJ) matches any single-argument JSON.stringify call in compile-manifest.ts, including the legitimate primitive-serialization call inside canonicalStringify itself (line 103). The lesson intent is specifically about the canonicalStringify function, not all JSON.stringify calls in the file. upgradeTarget: compound (Proposal 226) — a compound rule with inside: function canonicalStringify(...) { $$$ } could constrain the pattern to calls that bypass canonicalStringify, catching the real anti-pattern without firing on the helper's own implementation. Phase 4 recompile candidate once #1408 and #1409 ship."
-    },
-    {
-      "lessonHash": "85bca8dcad2b19cb",
-      "lessonHeading": "Pipeline 5: observation from shield",
-      "pattern": "systemPrompt\\s+!==\\s+undefined\\s+&&\\s+systemPrompt\\.length\\s+>\\s+0\\s+\\?\\s+`\\$\\{systemPrompt\\}\\\\n\\\\n\\$\\{prompt\\}`\\s+:\\s+prompt;",
-      "message": "Calling `assertValidModelName(model)` in `invokeShellOrchestrator` introduces a double-parsing bug. `resolveOrchestrator` already strips the provider prefix and passes `parsed.model` to the invoke function. Because `assertValidModelName` applies Gate 3 (`parseModelString`), it will re-parse the already-stripped model string. This falsely rejects valid models containing colons (e.g., `shell:foo:-bar` becomes `foo:-bar`, which Gate 3 splits again, rejecting `-bar` for starting with `-`). Gate 3 is a lookahead check only needed in `resolveOrchestrator` to ensure the post-strip string doesn't start with `-`. `invokeShellOrchestrator` should revert to only checking Gate 1 and 2.",
-      "engine": "regex",
-      "severity": "warning",
-      "fileGlobs": [
-        "**/*.ts"
-      ],
-      "compiledAt": "2026-04-15T06:04:25.951Z",
-      "createdAt": "2026-04-15T06:04:25.951Z"
     }
   ],
   "nonCompilable": [

--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -6642,6 +6642,19 @@
       "severity": "warning",
       "status": "archived",
       "archivedReason": "Over-broad: pattern JSON.stringify($OBJ) matches any single-argument JSON.stringify call in compile-manifest.ts, including the legitimate primitive-serialization call inside canonicalStringify itself (line 103). The lesson intent is specifically about the canonicalStringify function, not all JSON.stringify calls in the file. upgradeTarget: compound (Proposal 226) — a compound rule with inside: function canonicalStringify(...) { $$$ } could constrain the pattern to calls that bypass canonicalStringify, catching the real anti-pattern without firing on the helper's own implementation. Phase 4 recompile candidate once #1408 and #1409 ship."
+    },
+    {
+      "lessonHash": "20aa11df474faf48",
+      "lessonHeading": "Pipeline 5: observation from shield",
+      "pattern": "if\\s+\\(model\\.startsWith\\('-'\\)\\s+\\|\\|\\s+!MODEL_NAME_RE\\.test\\(model\\)\\)\\s+\\{",
+      "message": "`TotemParseError` is used for a configuration validation error. Consider using `TotemConfigError` (as used in `resolveOrchestrator` for the exact same validation) to maintain consistent error semantics and avoid stylistic drift.",
+      "engine": "regex",
+      "severity": "warning",
+      "fileGlobs": [
+        "**/*.ts"
+      ],
+      "compiledAt": "2026-04-15T05:37:10.108Z",
+      "createdAt": "2026-04-15T05:37:10.108Z"
     }
   ],
   "nonCompilable": [

--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -6649,12 +6649,38 @@
       "pattern": "if\\s+\\(model\\.startsWith\\('-'\\)\\s+\\|\\|\\s+!MODEL_NAME_RE\\.test\\(model\\)\\)\\s+\\{",
       "message": "`TotemParseError` is used for a configuration validation error. Consider using `TotemConfigError` (as used in `resolveOrchestrator` for the exact same validation) to maintain consistent error semantics and avoid stylistic drift.",
       "engine": "regex",
+      "compiledAt": "2026-04-15T05:37:10.108Z",
+      "createdAt": "2026-04-15T05:37:10.108Z",
+      "fileGlobs": [
+        "**/*.ts"
+      ],
+      "severity": "warning"
+    },
+    {
+      "lessonHash": "7616deb08fb0bb7b",
+      "lessonHeading": "Pipeline 5: observation from shield",
+      "pattern": "const\\s+resolvedCmd\\s+=\\s+command",
+      "message": "Missing test for the bug fix regarding string replacement back-references (`$&`, etc.) in `invokeShellOrchestrator`. Bug fixes require corresponding `.test.ts` updates to prevent regressions.",
+      "engine": "regex",
+      "compiledAt": "2026-04-15T05:42:00.153Z",
+      "createdAt": "2026-04-15T05:42:00.153Z",
+      "fileGlobs": [
+        "**/*.ts"
+      ],
+      "severity": "warning"
+    },
+    {
+      "lessonHash": "cbda3b118183c615",
+      "lessonHeading": "Pipeline 5: observation from shield",
+      "pattern": "const\\s+quotedModel\\s+=\\s+quoteShellArg\\(model\\);",
+      "message": "Missing test for bug fix: The fix to prevent regex back-references (like `$&`) in `quotedPath` or `quotedModel` from corrupting shell command interpolation requires a corresponding test case to prevent regressions.",
+      "engine": "regex",
       "severity": "warning",
       "fileGlobs": [
         "**/*.ts"
       ],
-      "compiledAt": "2026-04-15T05:37:10.108Z",
-      "createdAt": "2026-04-15T05:37:10.108Z"
+      "compiledAt": "2026-04-15T05:42:20.623Z",
+      "createdAt": "2026-04-15T05:42:20.623Z"
     }
   ],
   "nonCompilable": [

--- a/packages/cli/src/orchestrators/orchestrator.ts
+++ b/packages/cli/src/orchestrators/orchestrator.ts
@@ -123,15 +123,43 @@ export function parseModelString(
 
 // ─── Centralized model resolution (#248) ────────────
 
+/** Characters allowed in model names — restricts shell metacharacters. */
+const MODEL_NAME_RE = /^[\w./:_-]+$/;
+
 /**
- * Characters allowed in model names — restricts shell metacharacters.
+ * Validate a model name string against shell-safety gates. Single source of
+ * truth for both `resolveOrchestrator` (config-load, raw provider:model
+ * input) and `invokeShellOrchestrator` (shell-interpolation, post-parse
+ * stripped model input).
  *
- * Exported as the single source of truth so orchestrators that perform
- * shell interpolation (`shell-orchestrator.ts`) can gate on the exact
- * same surface as `resolveOrchestrator`. Any divergence would re-open
- * the class of config-driven shell-injection mmnto/totem#1429 fixes.
+ * Two gates applied to the input string as-is:
+ *   1. **Leading-dash reject.** Blocks shell-option tricks like `--exec`.
+ *   2. **Allow-list regex.** `MODEL_NAME_RE` restricts to word chars,
+ *      dots, slashes, colons, underscores, and hyphens — covers every
+ *      model identifier used in practice (provider-qualified, namespace/
+ *      model, ollama quantized tags).
+ *
+ * Gates 1 + 2 are safe to apply at ANY stage — raw `provider:model` strings
+ * and stripped model-portions both pass the same allow-list. The post-parse
+ * "model-portion not empty and not dash-prefixed" check (Gate 3) lives
+ * inline in `resolveOrchestrator` where the split happens, NOT in this
+ * shared helper — applying it to an already-stripped model causes a
+ * double-parse that falsely rejects valid names like `foo:-bar` that were
+ * safe pre-split (Shield catch on mmnto/totem#1429 GCA round 2).
+ *
+ * CR catch on mmnto/totem#1429 round 1: exporting only the regex created
+ * a drift vector where the shell path could diverge from the config path.
+ * This helper closes that vector for the checks that BOTH paths need.
  */
-export const MODEL_NAME_RE = /^[\w./:_-]+$/;
+export function assertValidModelName(rawModel: string): void {
+  if (rawModel.startsWith('-') || !MODEL_NAME_RE.test(rawModel)) {
+    throw new TotemConfigError(
+      `Invalid model name '${rawModel}'. Model names may only contain word characters, dots, slashes, colons, underscores, and hyphens, and must not start with a dash.`,
+      'Check your orchestrator.model config value and remove any invalid characters.',
+      'CONFIG_INVALID',
+    );
+  }
+}
 
 export interface ResolvedOrchestrator {
   parsed: { provider: string; model: string };
@@ -149,13 +177,10 @@ export function resolveOrchestrator(
   baseProvider: string,
   baseInvoke: InvokeOrchestrator,
 ): ResolvedOrchestrator {
-  if (rawModel.startsWith('-') || !MODEL_NAME_RE.test(rawModel)) {
-    throw new TotemConfigError(
-      `Invalid model name '${rawModel}'. Model names may only contain word characters, dots, slashes, colons, underscores, and hyphens.`,
-      'Check your orchestrator.model config value and remove any invalid characters.',
-      'CONFIG_INVALID',
-    );
-  }
+  // Shared gates 1 + 2 (regex + leading-dash). Symmetric with the check in
+  // `invokeShellOrchestrator` so any model accepted by one path is accepted
+  // by the other.
+  assertValidModelName(rawModel);
 
   const parsed = parseModelString(rawModel, baseProvider);
 
@@ -167,6 +192,12 @@ export function resolveOrchestrator(
     );
   }
 
+  // Gate 3 — post-parse model-portion check. Applied only here, not in the
+  // shared helper, because the helper is also called from the shell-invoke
+  // path where the model has already been through parseModelString once.
+  // Double-parsing an already-stripped model splits on any embedded `:` a
+  // second time and falsely rejects inputs that were safe pre-strip (Shield
+  // catch on mmnto/totem#1429).
   if (!parsed.model || parsed.model.startsWith('-')) {
     throw new TotemConfigError(
       `Invalid model name in '${rawModel}'. The model portion must not be empty or start with a hyphen.`,

--- a/packages/cli/src/orchestrators/orchestrator.ts
+++ b/packages/cli/src/orchestrators/orchestrator.ts
@@ -123,8 +123,15 @@ export function parseModelString(
 
 // ─── Centralized model resolution (#248) ────────────
 
-/** Characters allowed in model names — restricts shell metacharacters. */
-const MODEL_NAME_RE = /^[\w./:_-]+$/;
+/**
+ * Characters allowed in model names — restricts shell metacharacters.
+ *
+ * Exported as the single source of truth so orchestrators that perform
+ * shell interpolation (`shell-orchestrator.ts`) can gate on the exact
+ * same surface as `resolveOrchestrator`. Any divergence would re-open
+ * the class of config-driven shell-injection mmnto/totem#1429 fixes.
+ */
+export const MODEL_NAME_RE = /^[\w./:_-]+$/;
 
 export interface ResolvedOrchestrator {
   parsed: { provider: string; model: string };

--- a/packages/cli/src/orchestrators/shell-orchestrator.test.ts
+++ b/packages/cli/src/orchestrators/shell-orchestrator.test.ts
@@ -330,6 +330,28 @@ describe('invokeShellOrchestrator', () => {
       const quoted = cmd.includes("'gemini-2.5-pro'") || cmd.includes('"gemini-2.5-pro"');
       expect(quoted).toBe(true);
     });
+
+    it('preserves `$&` and similar back-reference sequences in the resolved command (Shield catch, regression)', async () => {
+      // `String.prototype.replace` with a STRING replacement interprets `$&`,
+      // `$'`, `$`` , and `$1` as back-reference specials. A directory with `$&`
+      // in its name would silently corrupt the interpolated command. We use
+      // replacer FUNCTIONS to bypass that special-casing. This test pins the
+      // fix by creating a tempDir whose path contains `$&` and asserting the
+      // literal sequence appears in the resolved spawn command.
+      const weirdDir = path.join(tmpDir, 'project$&cwd');
+      fs.mkdirSync(path.join(weirdDir, totemDir, 'temp'), { recursive: true });
+      emitSuccess('ok');
+      await invokeShellOrchestrator({
+        prompt: 'prompt',
+        command: 'llm --model {model} < {file}',
+        model: 'gemini-2.5-pro',
+        cwd: weirdDir,
+        tag: 'Test',
+        totemDir,
+      });
+      const cmd = mockedSpawn.mock.calls[0]![0] as string;
+      expect(cmd).toContain('project$&cwd');
+    });
   });
 
   // ─── systemPrompt threading (mmnto/totem#1291 Phase 3 cascade fix) ──

--- a/packages/cli/src/orchestrators/shell-orchestrator.test.ts
+++ b/packages/cli/src/orchestrators/shell-orchestrator.test.ts
@@ -242,6 +242,95 @@ describe('invokeShellOrchestrator', () => {
     vi.useRealTimers();
   });
 
+  // ─── Model sanitization (shell-injection defense) ──
+  //
+  // Regression tests for the RCE found during the pre-1.15.0 deep review:
+  // the `{model}` token was interpolated raw into a string executed with
+  // `shell: true`, so a poisoned config value could run arbitrary shell
+  // commands. Fix is two layers: (1) allow-list MODEL_SAFE_RE rejects
+  // metacharacters at the boundary, (2) defense-in-depth shell-quoting of
+  // the token at interpolation.
+
+  describe('model sanitization', () => {
+    const EXPLOITS = [
+      ['semicolon', 'gemini; echo pwned'],
+      ['backtick', 'gemini`echo pwned`'],
+      ['dollar-subshell', 'gemini$(echo pwned)'],
+      ['pipe', 'gemini | echo pwned'],
+      ['redirect', 'gemini > /tmp/pwned'],
+      ['newline', 'gemini\necho pwned'],
+      ['ampersand', 'gemini && echo pwned'],
+      ['space', 'gemini pwned'],
+      ['quote', "gemini'"],
+      ['dquote', 'gemini"'],
+      ['paren', 'gemini()'],
+      ['leading-dash', '-rf'],
+    ] as const;
+
+    for (const [label, badModel] of EXPLOITS) {
+      it(`rejects model with ${label} and never spawns`, async () => {
+        await expect(
+          invokeShellOrchestrator({
+            prompt: 'prompt',
+            command: 'llm --model {model} < {file}',
+            model: badModel,
+            cwd: tmpDir,
+            tag: 'Test',
+            totemDir,
+          }),
+        ).rejects.toThrow(/refuses model/);
+        // Critical invariant: spawn MUST NOT have been called. The allow-list
+        // fires before we ever reach shell execution.
+        expect(mockedSpawn).not.toHaveBeenCalled();
+      });
+    }
+
+    const BENIGN = [
+      ['simple', 'gemini-2.5-pro'],
+      ['provider-qualified', 'anthropic:claude-sonnet-4-6'],
+      ['namespaced-slash', 'ollama/gemma4'],
+      ['dotted', 'claude.sonnet.4.6'],
+      ['ollama-tag', 'gemma4:e4b'],
+      ['alphanumeric-only', 'gpt5'],
+      ['ollama-quantized', 'llama2:13b-chat-q4_0'],
+      ['underscore', 'my_model_v2'],
+    ] as const;
+
+    for (const [label, goodModel] of BENIGN) {
+      it(`accepts benign model (${label})`, async () => {
+        emitSuccess('ok');
+        await invokeShellOrchestrator({
+          prompt: 'prompt',
+          command: 'llm --model {model} < {file}',
+          model: goodModel,
+          cwd: tmpDir,
+          tag: 'Test',
+          totemDir,
+        });
+        expect(mockedSpawn).toHaveBeenCalledOnce();
+      });
+    }
+
+    it('shell-quotes the model token even after allow-list passes (defense in depth)', async () => {
+      emitSuccess('ok');
+      await invokeShellOrchestrator({
+        prompt: 'prompt',
+        command: 'llm --model {model} < {file}',
+        model: 'gemini-2.5-pro',
+        cwd: tmpDir,
+        tag: 'Test',
+        totemDir,
+      });
+      const cmd = mockedSpawn.mock.calls[0]![0] as string;
+      // Expect the model to appear inside quotes (either ' on Unix or " on
+      // Windows). This prevents a future regression that removes the
+      // allow-list but leaves interpolation unquoted from re-opening the
+      // RCE hole.
+      const quoted = cmd.includes("'gemini-2.5-pro'") || cmd.includes('"gemini-2.5-pro"');
+      expect(quoted).toBe(true);
+    });
+  });
+
   // ─── systemPrompt threading (mmnto/totem#1291 Phase 3 cascade fix) ──
 
   describe('systemPrompt threading', { timeout: 15000 }, () => {

--- a/packages/cli/src/orchestrators/shell-orchestrator.test.ts
+++ b/packages/cli/src/orchestrators/shell-orchestrator.test.ts
@@ -247,9 +247,10 @@ describe('invokeShellOrchestrator', () => {
   // Regression tests for the RCE found during the pre-1.15.0 deep review:
   // the `{model}` token was interpolated raw into a string executed with
   // `shell: true`, so a poisoned config value could run arbitrary shell
-  // commands. Fix is two layers: (1) allow-list MODEL_SAFE_RE rejects
-  // metacharacters at the boundary, (2) defense-in-depth shell-quoting of
-  // the token at interpolation.
+  // commands. Fix is two layers: (1) the shared `MODEL_NAME_RE` allow-list
+  // (plus an explicit leading-dash reject) mirrors `resolveOrchestrator`
+  // exactly so validation is symmetric across all orchestrators, and
+  // (2) defense-in-depth shell-quoting of the token at interpolation.
 
   describe('model sanitization', () => {
     const EXPLOITS = [

--- a/packages/cli/src/orchestrators/shell-orchestrator.test.ts
+++ b/packages/cli/src/orchestrators/shell-orchestrator.test.ts
@@ -279,7 +279,7 @@ describe('invokeShellOrchestrator', () => {
             tag: 'Test',
             totemDir,
           }),
-        ).rejects.toThrow(/refuses model/);
+        ).rejects.toThrow(/Invalid model name/);
         // Critical invariant: spawn MUST NOT have been called. The allow-list
         // fires before we ever reach shell execution.
         expect(mockedSpawn).not.toHaveBeenCalled();

--- a/packages/cli/src/orchestrators/shell-orchestrator.ts
+++ b/packages/cli/src/orchestrators/shell-orchestrator.ts
@@ -5,11 +5,9 @@ import * as path from 'node:path';
 
 import { z } from 'zod';
 
-import { TotemConfigError } from '@mmnto/totem';
-
 import { log } from '../ui.js';
 import type { OrchestratorInvokeOptions, OrchestratorResult } from './orchestrator.js';
-import { isQuotaError, MODEL_NAME_RE } from './orchestrator.js';
+import { assertValidModelName, isQuotaError } from './orchestrator.js';
 
 // ─── Constants ───────────────────────────────────────
 
@@ -102,18 +100,13 @@ export async function invokeShellOrchestrator(
   // The {model} token used to be substituted raw, which turned a config-supplied
   // string into a shell-injection sink. A malicious totem.config.ts could set
   // `defaultModel: "gemini-1.5; rm -rf /"` and ride `shell: true` straight to
-  // arbitrary code execution. The gate mirrors `resolveOrchestrator` exactly —
-  // leading-dash rejection (blocks shell-option tricks like `--exec`) plus the
-  // shared `MODEL_NAME_RE` allow-list. Using the same predicate on both surfaces
-  // keeps the validation symmetric so a model accepted upstream cannot be
-  // rejected here (and vice versa). GCA catch on mmnto/totem#1429.
-  if (model.startsWith('-') || !MODEL_NAME_RE.test(model)) {
-    throw new TotemConfigError(
-      `Shell orchestrator refuses model ${JSON.stringify(model)}. Model names may only contain word characters, dots, slashes, colons, underscores, and hyphens, and must not start with a dash. This guards against shell injection via the {model} token in orchestrator.command.`,
-      'Set orchestrator.defaultModel / overrides to a plain model identifier (e.g., "claude-sonnet-4-6", "anthropic:claude-sonnet-4-6", "gpt-5.4-mini").',
-      'CONFIG_INVALID',
-    );
-  }
+  // arbitrary code execution. `assertValidModelName` is the single shared gate
+  // used here and in `resolveOrchestrator` so any model accepted by one path
+  // is accepted by the other (and vice versa). Covers regex allow-list +
+  // leading-dash reject + post-parse model-portion check (catches `gemini:`
+  // and `anthropic:-foo` which pass the flat regex but are unsafe). CR catch
+  // on mmnto/totem#1429.
+  assertValidModelName(model);
 
   const fullPrompt =
     systemPrompt !== undefined && systemPrompt.length > 0 ? `${systemPrompt}\n\n${prompt}` : prompt;

--- a/packages/cli/src/orchestrators/shell-orchestrator.ts
+++ b/packages/cli/src/orchestrators/shell-orchestrator.ts
@@ -5,9 +5,11 @@ import * as path from 'node:path';
 
 import { z } from 'zod';
 
+import { TotemConfigError } from '@mmnto/totem';
+
 import { log } from '../ui.js';
 import type { OrchestratorInvokeOptions, OrchestratorResult } from './orchestrator.js';
-import { isQuotaError } from './orchestrator.js';
+import { isQuotaError, MODEL_NAME_RE } from './orchestrator.js';
 
 // ─── Constants ───────────────────────────────────────
 
@@ -18,22 +20,19 @@ const TEMP_ID_BYTES = 4;
 /** execFileSync on Windows can't resolve executables without `shell: true`. */
 const IS_WIN = process.platform === 'win32';
 
-/**
- * Model names the shell orchestrator is willing to interpolate into a shell
- * command. Intentionally restrictive: alphanumeric, plus dot, underscore,
- * dash, colon, slash. Colon allows provider-qualified names like
- * `anthropic:claude-sonnet-4-6`. Slash allows `ns/model` style. Underscore
- * covers ollama quantized tags like `llama2:13b-chat-q4_0`. First char
- * must be alphanumeric to reject leading-dash shell-option tricks.
- *
- * Rejecting anything outside this set guards against a poisoned
- * `orchestrator.defaultModel` / overrides value executing shell commands
- * via the `{model}` token.
- */
-const MODEL_SAFE_RE = /^[a-zA-Z0-9][\w.:/-]*$/;
-
 function quoteShellArg(value: string): string {
-  return IS_WIN ? `"${value.replace(/"/g, '""')}"` : `'${value.replace(/'/g, "'\\''")}'`;
+  // Windows quoting is genuinely ambiguous — `cmd.exe` has no universal
+  // quote-escape; `""` (doubling) works inside cmd's own quote state and
+  // `\"` works for the Microsoft C-runtime argv parser used by most target
+  // binaries. Neither is safe when an unchecked string contains BOTH `"`
+  // and shell metacharacters. The real defense is the upstream allow-list
+  // (`MODEL_NAME_RE` below, which rejects `"` outright). We emit `\"` here
+  // so the quoted output at least parses correctly under MSVCRT rules for
+  // the well-known tools we pipe to (gemini, claude, ollama). If a future
+  // caller passes an unchecked path, the right fix is to pre-validate or
+  // to stop using `shell: true` — not to defeat shell quoting entirely in
+  // this helper. See GCA + Shield discussion on mmnto/totem#1429.
+  return IS_WIN ? `"${value.replace(/"/g, '\\"')}"` : `'${value.replace(/'/g, "'\\''")}'`;
 }
 
 // ─── Gemini CLI JSON parsing ─────────────────────────
@@ -103,12 +102,16 @@ export async function invokeShellOrchestrator(
   // The {model} token used to be substituted raw, which turned a config-supplied
   // string into a shell-injection sink. A malicious totem.config.ts could set
   // `defaultModel: "gemini-1.5; rm -rf /"` and ride `shell: true` straight to
-  // arbitrary code execution. The allow-list covers every model name used in
-  // practice (providers, dashes, dots, colons for provider-qualified names,
-  // slashes for ns/model) and rejects everything else loud and early.
-  if (!MODEL_SAFE_RE.test(model)) {
-    throw new Error(
-      `[Totem Error] Shell orchestrator refuses model ${JSON.stringify(model)}: contains characters outside the safe set [a-zA-Z0-9._:/-]. This guards against shell injection via the {model} token in orchestrator.command.`,
+  // arbitrary code execution. The gate mirrors `resolveOrchestrator` exactly —
+  // leading-dash rejection (blocks shell-option tricks like `--exec`) plus the
+  // shared `MODEL_NAME_RE` allow-list. Using the same predicate on both surfaces
+  // keeps the validation symmetric so a model accepted upstream cannot be
+  // rejected here (and vice versa). GCA catch on mmnto/totem#1429.
+  if (model.startsWith('-') || !MODEL_NAME_RE.test(model)) {
+    throw new TotemConfigError(
+      `Shell orchestrator refuses model ${JSON.stringify(model)}. Model names may only contain word characters, dots, slashes, colons, underscores, and hyphens, and must not start with a dash. This guards against shell injection via the {model} token in orchestrator.command.`,
+      'Set orchestrator.defaultModel / overrides to a plain model identifier (e.g., "claude-sonnet-4-6", "anthropic:claude-sonnet-4-6", "gpt-5.4-mini").',
+      'CONFIG_INVALID',
     );
   }
 

--- a/packages/cli/src/orchestrators/shell-orchestrator.ts
+++ b/packages/cli/src/orchestrators/shell-orchestrator.ts
@@ -18,6 +18,24 @@ const TEMP_ID_BYTES = 4;
 /** execFileSync on Windows can't resolve executables without `shell: true`. */
 const IS_WIN = process.platform === 'win32';
 
+/**
+ * Model names the shell orchestrator is willing to interpolate into a shell
+ * command. Intentionally restrictive: alphanumeric, plus dot, underscore,
+ * dash, colon, slash. Colon allows provider-qualified names like
+ * `anthropic:claude-sonnet-4-6`. Slash allows `ns/model` style. Underscore
+ * covers ollama quantized tags like `llama2:13b-chat-q4_0`. First char
+ * must be alphanumeric to reject leading-dash shell-option tricks.
+ *
+ * Rejecting anything outside this set guards against a poisoned
+ * `orchestrator.defaultModel` / overrides value executing shell commands
+ * via the `{model}` token.
+ */
+const MODEL_SAFE_RE = /^[a-zA-Z0-9][\w.:/-]*$/;
+
+function quoteShellArg(value: string): string {
+  return IS_WIN ? `"${value.replace(/"/g, '""')}"` : `'${value.replace(/'/g, "'\\''")}'`;
+}
+
 // ─── Gemini CLI JSON parsing ─────────────────────────
 
 const GeminiModelStatsSchema = z.object({
@@ -80,6 +98,20 @@ export async function invokeShellOrchestrator(
   // shell CLI fallback. Caught by Shield AI on the first push attempt as
   // part of the same cascade as the Gemini/OpenAI/Ollama fixes.
   const { prompt, systemPrompt, command, model, cwd, tag, totemDir } = opts;
+
+  // Reject poisoned model names BEFORE we ever interpolate into a shell string.
+  // The {model} token used to be substituted raw, which turned a config-supplied
+  // string into a shell-injection sink. A malicious totem.config.ts could set
+  // `defaultModel: "gemini-1.5; rm -rf /"` and ride `shell: true` straight to
+  // arbitrary code execution. The allow-list covers every model name used in
+  // practice (providers, dashes, dots, colons for provider-qualified names,
+  // slashes for ns/model) and rejects everything else loud and early.
+  if (!MODEL_SAFE_RE.test(model)) {
+    throw new Error(
+      `[Totem Error] Shell orchestrator refuses model ${JSON.stringify(model)}: contains characters outside the safe set [a-zA-Z0-9._:/-]. This guards against shell injection via the {model} token in orchestrator.command.`,
+    );
+  }
+
   const fullPrompt =
     systemPrompt !== undefined && systemPrompt.length > 0 ? `${systemPrompt}\n\n${prompt}` : prompt;
   const tmpName = `totem-${tag.toLowerCase()}-${crypto.randomBytes(TEMP_ID_BYTES).toString('hex')}.md`;
@@ -89,10 +121,12 @@ export async function invokeShellOrchestrator(
 
   fs.writeFileSync(tempPath, fullPrompt, { encoding: 'utf-8', mode: 0o600 });
 
-  const quotedPath = IS_WIN
-    ? `"${tempPath.replace(/"/g, '""')}"`
-    : `'${tempPath.replace(/'/g, "'\\''")}'`;
-  const resolvedCmd = command.replace(/\{file\}/g, quotedPath).replace(/\{model\}/g, model);
+  // Defense in depth: even after the allow-list above rejects shell metacharacters,
+  // we still shell-quote the model token at interpolation. Matches the treatment
+  // {file} has always had. Two layers: validate, then escape.
+  const quotedPath = quoteShellArg(tempPath);
+  const quotedModel = quoteShellArg(model);
+  const resolvedCmd = command.replace(/\{file\}/g, quotedPath).replace(/\{model\}/g, quotedModel);
 
   log.info(tag, 'Invoking orchestrator (this may take 15-60 seconds)...');
 

--- a/packages/cli/src/orchestrators/shell-orchestrator.ts
+++ b/packages/cli/src/orchestrators/shell-orchestrator.ts
@@ -127,9 +127,18 @@ export async function invokeShellOrchestrator(
   // Defense in depth: even after the allow-list above rejects shell metacharacters,
   // we still shell-quote the model token at interpolation. Matches the treatment
   // {file} has always had. Two layers: validate, then escape.
+  //
+  // Use replacer FUNCTIONS instead of string replacements. `String.prototype.replace`
+  // interprets `$&`, `$'`, `$n`, etc. in a replacement STRING as back-references, so
+  // a `cwd` that happens to contain `$&` (e.g., a directory named `project$&`) would
+  // splice the regex match back in and corrupt the interpolated command. The
+  // function form bypasses that special-casing entirely. Shield catch on
+  // mmnto/totem#1429 GCA follow-up.
   const quotedPath = quoteShellArg(tempPath);
   const quotedModel = quoteShellArg(model);
-  const resolvedCmd = command.replace(/\{file\}/g, quotedPath).replace(/\{model\}/g, quotedModel);
+  const resolvedCmd = command
+    .replace(/\{file\}/g, () => quotedPath)
+    .replace(/\{model\}/g, () => quotedModel);
 
   log.info(tag, 'Invoking orchestrator (this may take 15-60 seconds)...');
 


### PR DESCRIPTION
## Mechanical Root Cause

`packages/cli/src/orchestrators/shell-orchestrator.ts` substituted the `{model}` token directly into a command string executed with `shell: true`. A poisoned `totem.config.ts` value like `orchestrator.defaultModel = "gemini; rm -rf /"` ran as shell. The `{file}` token in the same function was already shell-quoted; the `{model}` token was not.

## How Discovered

Gemini caught this during the pre-1.15.0 deep architectural review (#1421). Captured at `.strategy/audits/internal/2026-04-14-repomix-architectural-teardown.md` under Critical Finding #1.

## Exposure

Exploitable only via a poisoned `totem.config.ts`. Realistic attack vector: user clones a malicious repo and runs `totem review` / `totem compile` / `totem spec` against it. Trusted-config users (single-dev, audited-config workflows) were never at risk. No known production exploitation.

## Fix Applied — Defense in Depth

**Layer 1 — Allow-list at the boundary** (`MODEL_SAFE_RE` in `shell-orchestrator.ts:34`). Model names must match `^[a-zA-Z0-9][\w.:/-]*$`: alphanumeric, dot, colon, slash, dash, underscore. First char must be alphanumeric (rejects leading-dash tricks like `-rf`). Covers every real model name in use:
- `gemini-2.5-pro`, `claude-sonnet-4-6`
- `anthropic:claude-sonnet-4-6` (provider-qualified)
- `ollama/gemma4` (ns/model)
- `gemma4:e4b`, `llama2:13b-chat-q4_0` (ollama quantized tags — underscore + colon + digits)

Shell metacharacters (`;`, backtick, `$`, `|`, `>`, `\n`, `&`, space, quote, paren, leading `-`) are rejected **before** `spawn()` is ever called.

**Layer 2 — Shell-quoting at interpolation** (`quoteShellArg` helper). Even after the allow-list passes, the model token is wrapped in shell-safe quotes (single on Unix, double on Windows). A future regression that drops the allow-list cannot re-open the RCE alone.

## Tests Added

19 new regression tests in `shell-orchestrator.test.ts` — all now 38 pass:

- **12 exploit cases**: semicolon, backtick, dollar-subshell, pipe, redirect, newline, ampersand, space, quote, dquote, paren, leading-dash. Each asserts the error is thrown AND `spawn()` is never called (critical invariant: we don't degrade to "try and maybe it fails safely").
- **8 benign shapes**: simple, provider-qualified, namespaced-slash, dotted, ollama-tag, alphanumeric-only, ollama-quantized (the underscore case), plain-underscore.
- **1 defense-in-depth**: verifies the model arg is shell-quoted on the spawn command even for a benign input, locking in the two-layer guarantee.

## Backward Compatibility

Users who manually wrapped `{model}` in their `orchestrator.command` template (e.g., `"--model=\"{model}\""`) will see double-quoting. After shell parsing the final argv is identical, so no behavior change reaches the orchestrator binary. If anyone has a custom template that depends on raw unquoted substitution, they should drop the manual quotes. Most users followed the existing `{file}` pattern (no manual quotes — Totem quotes for you), so this affects a narrow slice.

## Release

Ships as **1.14.10** standalone security patch. Not bundled with any other work. Changeset included.

## Out of Scope

- Removing `shell: true` entirely. That's a bigger refactor (shell redirections like `< {file}` break without it). Tracked for 1.15.x hardening if we decide to deprecate shell-mode orchestrators.
- Schema-level validation of `orchestrator.defaultModel` at config load time. The runtime check is cheap and closer to the injection sink. Config-time validation is a nice-to-have.
- Compound ast-grep rule banning `spawn(..., { shell: true })` across the repo. That's one of Gemini's proposed compound rules — filed as a separate ticket so this PR stays focused.

## Verification

- [x] `pnpm -r test`: full suite passes (19 new tests)
- [x] `pnpm exec totem review`: PASS (1 WARN on regex dedupe, 1 INFO on backward-compat — both addressed)
- [x] `pnpm run format`: clean
- [x] `pnpm exec totem lint`: clean