### PR TITLE
chore: bump strategy pointer, drop stale --cloud, lock 1.15.0 plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Not mechanically enforced. Follow these because they reduce PR bot noise.
 
 - **Before coding:** Run `/preflight <issue>`. Create a feature branch.
 - **Before pushing:** `pnpm run format` → `totem lint` → `totem review` → verify compile manifest is current.
-- **After merging:** `totem lesson extract <prs>` → `totem lesson compile --cloud <url>` (6+ lessons).
+- **After merging:** `totem lesson extract <prs>` → `totem lesson compile` (6+ lessons). The `--cloud` flag is off-path until #1221 migrates the cloud worker to Sonnet; local compile is the golden path.
 - **NEVER** use `git push --no-verify`, `totem-ignore`, or `eslint-disable` without a ticket.
 - Git pre-push hook runs `totem lint` + `totem verify-manifest` (stateless, no LLM).
 

--- a/docs/active_work.md
+++ b/docs/active_work.md
@@ -1,10 +1,18 @@
 ### Active Work Summary
 
-The project is at release `@mmnto/cli@1.14.8` (published 2026-04-14) with **1.14.9 — Precision Engine** feature-complete on `main` and pending release. Test counts: **2,879 across core, CLI, and MCP packages**. **411 compiled rules** in the rules array (389 active, 22 archived). The `nonCompilable` ledger separately tracks 889 lessons the LLM declined to convert into rules; that array is sibling to `rules` and not counted toward `rule_count`. The next release ships compound ast-grep rule support, a compile-time smoke gate, and the `badExample` requirement that closes the LLM-hallucination loop.
+The project is at release `@mmnto/cli@1.14.10` (published 2026-04-15). Test counts: **2,922 across core, CLI, and MCP packages**. **414 compiled rules** in the rules array (392 active, 22 archived). The `nonCompilable` ledger separately tracks 889 lessons the LLM declined to convert into rules; that array is sibling to `rules` and not counted toward `rule_count`. 1.15.0 Pack Distribution is blocked by the pre-1.15.0 deep review gate (#1421); the 2026-04-15 joint planning pass (Ultraplan + strategy-repo pair) locked a three-phase sequence of workflow setup, gated grind, and pack delivery before the first 1.15.0 implementation ticket moves.
 
 ### Recently Shipped
 
-**1.14.9** (feature-complete on `main`, release pending) -- The Precision Engine. Compound ast-grep rule support + compile-time smoke gate. Closes the loop on rule quality before Pack Distribution starts.
+**1.14.10** (2026-04-15) -- The Bundle Release. Three PRs:
+
+- **#1429** -- shell-orchestrator `{model}` token RCE fix. Three rounds of GCA + Shield review: `MODEL_NAME_RE` unification, Windows MSVCRT escape, `TotemConfigError`, replacer-function interpolation to dodge `$&` back-reference regressions.
+- **#1454** -- Pipeline 1 compound rule authoring. Four rounds of CR + GCA review. Shared `assertValidModelName` helper, `TotemParseError` for regex failures, narrow-false pattern on `isFileDirty` and `resolveGitRoot`, markdown-heading terminator on YAML scan, `totem-context:` migration on `sys/git.ts`. Three inaugural compound rules shipped (rule count 411 → 414).
+- **#1455** -- Version Packages auto-PR. Three CHANGELOG.md nits fixed inline: `MODEL_SAFE_RE` → `MODEL_NAME_RE`, `TotemError(CHECK_FAILED)` → `TotemParseError`, broken fence formatting rewritten.
+
+Follow-ups filed from this sweep: #1456 (Repomix audit commit + submodule bump), #1457 (totem-ignore → totem-context: migration), #1458 (replace back-reference idiom in lesson-pattern.ts), #1459 (fill 61 scaffolded-but-TODO fixture files).
+
+**1.14.9** (2026-04-15) -- The Precision Engine. Compound ast-grep rule support + compile-time smoke gate. Closes the loop on rule quality before Pack Distribution starts.
 
 - **#1410** (closes #1406) -- spike: `@ast-grep/napi` compound YAML rule validation. ADR promotion gate for Proposal 226. Empirically proved the runtime accepts NapiConfig polymorphically; identified the `inside: { pattern: ... }` silent-zero-match sharp edge that drove the `kind:` allow-list in #1409.
 - **#1412** (closes #1407) -- feat(core): `astGrepYamlRule` field on `CompiledRule` schema with mutual exclusion via `superRefine`. Optional `badExample` field added (flipped to required in #1420). Deterministic manifest hashing via `canonicalStringify` so key-order variation in compound rules cannot trip `verify-manifest`. Backward-compat guard preserves existing manifests byte-for-byte.
@@ -55,36 +63,75 @@ All filed from bot review findings during the marathon; all deferred with tracke
 
 ### Current: 1.15.0 — The Distribution Pipeline
 
-**Blocked by the pre-1.15.0 deep review gate (#1421).** All 1.15.0 implementation tickets are paused until the foundation review passes. Rationale: Pack Distribution is the first release where rules leave the repo, so foundation bugs would distribute to every downstream consumer. Catching at the foundation layer is orders of magnitude cheaper than retro-fixing every pack consumer.
+**Blocked by the pre-1.15.0 deep review gate (#1421).** 24 tickets carry the `pre-1.15-review` label (12 tier-1 bugs, 9 tier-2 cleanup, 3 untiered), plus follow-ups #1456-#1459 from the 2026-04-15 PR sweep. All 1.15.0 implementation tickets are paused until the foundation review passes. Pack Distribution is the first release where rules leave the repo, so foundation bugs would distribute to every downstream consumer. Catching at the foundation layer is orders of magnitude cheaper than retro-fixing every pack consumer.
 
-Once #1421 closes, 1.15.0 implementation work begins. Phase 2 (mesh completion) can proceed without tripping over the same governance-engine rakes that surfaced during the 1.14.2 rename PR.
+The 2026-04-15 joint planning pass (Ultraplan cloud session + strategy-repo pair audit) locked a three-phase sequence of workflow improvements, gated grind, and pack delivery. Phases run in order; each phase has an explicit checkpoint before the next starts.
 
-**Phase 2 — Mesh completion (wraps up the 1.14.0 "Nervous System Foundation" story arc):**
+**Phase A: Workflow setup before the grind.** Cut bot-review-cycle cost before running it 24 times.
 
-- **#1307** — CLI `totem search` silently ignores `linkedIndexes`.
-- **#1308** — `totem doctor` has no Linked Indexes health check.
+- **Preflight v2 skill:** already shipped via #1296 (1.14.0) and #1299 (1.14.1). Proposal archived to `proposals/archive/` on 2026-04-15 after both planning passes tripped on the unarchived file.
+- **Tier-2 docs promotion:** Monitor tool and `/loop` self-paced examples into CLAUDE.md. Proposal 232 Tier 2 items promoted based on recurrence during the grind.
+- **#1460:** PreCompact hook. Highest blast radius of the workflow items; test in throwaway session with manual `/compact` before enabling globally.
+- **#1462:** if-scope `review-gate.sh`. One-line settings change narrowing from every Bash call to `Bash(git push*)`. Verify on a throwaway PR.
+- **#1461:** `/autofix-pr` trial. Run on the first Phase B bundle PR (concurrent, not prerequisite) for real bot-review pressure on the round-count comparison.
 
-**Phase 3 — Pack MVP (headline 1.15.0 work):**
+**Phase A.5: Architectural gates before the grind.** Strategy-pair audit surfaced two proposals that gate 1.15.0 foundations:
 
-- **#1059** — Rule pack distribution (headline)
-- Strategy **#35** — Distributing compiled rules (headline)
-- **#1243** — Pack schema (reads Gemini's Proposal 223 in `.strategy/proposals/active/223-pack-distribution.md`)
+- **Proposal 202:** Stacked Compilation Architecture. Promote to ADR and ticket as `pre-1.15-review`. Without a layered AST → template → LLM+verify → explicit-fail fallback, packs ship the 0/6 usable-rule failure mode from the 1.6.0 stress test. Load-bearing.
+- **Proposal 228:** Zero-Trust Agent Governance. Promote to ADR and commit `@totem/pack-agent-security` to 1.15.0 as the flagship pack (first production consumer of the pack infrastructure).
 
-**Bundled cleanup:**
+**Phase B: Pre-1.15-review grind.** 24 tickets ordered for minimum cross-PR interference:
 
-- **#1221** — Cloud compile worker Sonnet routing (critical for cloud distribution)
-- **#1232** — Thread explicit `cwd` through `compileCommand` (#1234 follow-up)
-- **#1235** — Batch `--upgrade` hashes in `runSelfHealing`
-- **#1218** — Broad `throw $ERR` ast-grep pattern needs refinement
-- **#1219** — Lazy-load compiler prompt templates
-- **#1350**, **#1352**, **#1354**, **#1355**, **#1357** — Follow-ups from the 2026-04-11 four-P0 sweep
+1. **#1279 first.** Pipeline 5 over-narrow captures. De-noising step for the whole grind; workaround fired four times on the 1.14.10 branch alone.
+2. **Tactical cleanup batch:** #1456, #1457, #1458, #1459 as four small PRs. First real exercise of the Preflight v2 tactical triage posture.
+3. **Tier-1 bundles grouped by `scope:` label:** mcp, cli, compiler, orchestrator, store. One bundle per PR; within each bundle, deepest architectural layer first so cascade fixes land before surface fixes.
+4. **Tier-2 cleanup** after tier-1 closes.
+5. **Re-tier the 3 untiered** during the Phase A planning window. Any that resolve to tier-3 or post-1.0 lose the `pre-1.15-review` label per ADR-075.
 
-**1.14.9 follow-ups (unmilestoned, unblock between cycles):**
+**Phase C: Pack Distribution headline work.** Gated on ADR-085 promotion from Proposed to Accepted.
 
-- **#1414** — Pipeline 1 smoke gate flip after 136-lesson Bad Example backfill. Mechanism shipped in #1415; hard enforcement deferred until the curation sweep.
-- **#1418** — MCP server holds a stale LanceDB handle after `totem sync` rebuilds embeddings. Surfaced empirically while syncing the strategy submodule reorg. 1.14.x patch or 1.15.0 pre-distribution hardening; Pack Distribution cannot ship a stale-handle bug in the federated query surface.
-- **#1419** — Cryptographic attestation for the Trap Ledger (SOX compliance gap). Filed at tier-3 by Gemini. Closes the gap in Proposal 225's enterprise pitch where the ledger was claimed as "cryptographically logged" but is currently a flat append-only file.
-- **#1421** — Pre-1.15.0 deep code review gate. Four-surface independent pass on `main` between 1.14.9 release and the first 1.15.0 ticket.
+- **#1421 meta-gate closes.**
+- **Promote ADR-085 (Totem Pack Ecosystem) to Accepted** with the five deferred decisions resolved: SemVer mapping, local-overrides-pack merge rule, conflict resolution, pack lifecycle, signing.
+- **Decompose ADR-085 into tickets:** pack resolver in `totem.config.ts` `extends` array, pack fetcher, signature verification, hash-stable compilation (#1232 is a prerequisite), pack lifecycle commands (`totem pack publish`, `totem pack verify`).
+- **Build `@totem/pack-agent-security`** as the flagship pack (Proposal 228).
+- **Wire Proposal 229 TBench spot-check** as the pack-release gate. Full harness stays Horizon 3; the spot-check is the 1.15.0-scoped subset.
+- **Decide ADR-086 (External Alert Ingestion) fate:** defer to 1.15.1 or 1.16.0. Recommend defer; Ingestion is wide and should not ride with Distribution.
+
+**Proposal dispositions from the 2026-04-15 audit.**
+
+- **Archive (already shipped):** `preflight-v2.md` (done 2026-04-15).
+- **Promote to ADR this cycle:** 202 (Stacked Compilation, `pre-1.15-review`), 228 (Zero-Trust, 1.15.0 flagship pack).
+- **Lock at 1.16.0:** Proposal 217 (LLM context caching).
+- **Lock at 1.17.0 with open-question iteration first:** Proposal 230 (content-hash embedding cache; three open questions on `library_version` keying, eviction policy, hit-ratio telemetry).
+- **Decompose as tickets now:** Proposal 191 vectors A+B (JIT bot prompts, trap-ledger pruning). Vector C (semantic LSP) stays Horizon 3+.
+- **Split into two tickets:** Proposal 229 (TBench spot-check 1.15.0, full harness Horizon 3).
+- **Formalize decision gate before further work:** Proposal 227 (multi-axis platform strategy; architectural roadmap vs decision-framing doc is unresolved).
+- **Stay parked:** 218 (governance fine-tuning, Horizon 3), 231 (P2P Iroh, Horizon 3+).
+- **Active reference through the cycle:** 232 (archive after Tier-1 items close).
+
+**Undecomposed ADR backfill candidates.** Strategy-pair audit identified 22 Accepted ADRs with zero ticket citations; 16 are buildable. Five highest-leverage for near-term pickup (all touch pack + ingestion paths):
+
+- **ADR-004:** AST-Aware Git Diff Analysis (Tree-sitter line-mapping + scope field on compiled rules).
+- **ADR-015:** Zero-Config Architectural Detection (5-stage fingerprinting).
+- **ADR-017:** Vector Cache Invalidation & Data Drift (hash-based staleness for LanceDB).
+- **ADR-025:** `totem doctor` Diagnostic Architecture.
+- **ADR-039:** Deterministic Briefing & Handoff.
+
+Backfill these as the 24-ticket grind drains.
+
+**Milestone guidance.** Per ADR-075, the 1.15.0 GitHub milestone stays thematically locked to Pack Distribution. The 24 `pre-1.15-review` tickets track via the label filter rather than attaching to the milestone. A dedicated "Pre-1.15.0 Gate" milestone is optional; the label filter suffices.
+
+**Watch-outs.**
+
+- **Phase A:** PreCompact hook (#1460) exit-2 blocks compaction indefinitely; recoverable only by hand-editing settings.json. Test in throwaway session first.
+- **Phase B:** Scope interleaving in PRs multiplies bot-review findings. One bundle per PR; do not mix `scope: mcp` and `scope: cli` in the same diff.
+- **Phase C:** Do not change compile-pipeline substrate (Proposals 217, 230) in the same release as the pack-distribution feature on top of it. Both are quarantined to 1.16.0+.
+
+**Other pending work (unmilestoned, unblock between cycles):**
+
+- **#1414:** Pipeline 1 smoke gate flip after 136-lesson Bad Example backfill. Mechanism shipped in #1415; hard enforcement deferred until the curation sweep.
+- **#1419:** Cryptographic attestation for the Trap Ledger (SOX compliance gap). Filed at tier-3 by Gemini. Closes the gap in Proposal 225's enterprise pitch where the ledger was claimed as "cryptographically logged" but is currently a flat append-only file.
+- **#1421:** Pre-1.15.0 deep code review gate (the meta-gate for the Phase B grind).
 
 ### After Next: 1.16.0 — The Ingestion Pipeline
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -6,54 +6,26 @@ Totem is a standard library for codebase governance — deterministic primitives
 
 ---
 
-## 1.13.0 — The Refinement Engine (Active — release prep)
+## 1.15.0: The Distribution Pipeline (Active)
 
-**Theme:** Telemetry-driven rule refinement, compilation routing, and structural pattern upgrades.
+**Theme:** The Totem Pack Ecosystem. 1.13.0 proved the engine can generate high-fidelity ast-grep rules. The 1.14.x cycle wired the nervous system foundation: cross-repo context mesh, LLM context caching preview, `/preflight` v2 design-doc gate, compound ast-grep rule support, compile-time smoke gate, precision engine. 1.15.0 is where proven rules leave the repo and teams bundle and share them across repositories via the npm registry.
 
-- **Compilation Routing:**
-  - [x] **Sonnet Routing:** Compile pipeline routes through Claude Sonnet 4.6 (90% correctness vs Gemini Pro's 73%, 2.4s vs 19.6s avg). Validated by Strategy #73 benchmark across 30 lessons in 4 difficulty tiers.
-  - [x] **Bulk Recompile:** All 1156 lessons recompiled through Sonnet — 438 → 393 rules, 102 regex→ast-grep upgrades, 143 noisy Gemini-hallucinated rules purged. Quality > quantity.
-  - [x] **Prompt Rewrite:** Compiler system prompt rewritten with explicit ast-grep preference, syntax cheat sheet, and 6 compound pattern examples mined from benchmark failures.
-  - [x] **Parser Hardening:** Backtick wrapper stripping in both Pipeline 1 (manual `**Pattern:**` extraction) and Pipeline 2 (LLM JSON output) so generated patterns no longer ship with code-fence artifacts.
+Blocked by the pre-1.15.0 deep review gate (#1421). 24 tickets carry the `pre-1.15-review` label. The 2026-04-15 joint planning pass (Ultraplan cloud session + strategy-repo pair audit) locked a three-phase sequence. See `docs/active_work.md` for the full phase breakdown, ticket sequencing, and proposal dispositions.
 
-- **Telemetry-Driven Refinement:**
-  - [x] **Context Telemetry:** `RuleMetric` now tracks the per-context match distribution (code, string, comment, regex, unknown). Match-context comes from the rule runner's `astContext` field; historical hits are seeded into the `unknown` bucket so older metrics remain interpretable.
-  - [x] **`totem doctor` Diagnostic:** New `checkUpgradeCandidates` flags regex rules whose telemetry shows >20% of matches landing in non-code contexts (excluding `unknown` from the ratio, with a 5-event minimum-confidence floor).
-  - [x] **`totem compile --upgrade <hash>`:** Re-compile a single targeted rule through Claude Sonnet with a telemetry-driven directive prompt. Scoped cache eviction preserves the rule's original `createdAt` metadata; failure paths leave the old rule intact (fail-safe) while replacement paths handle both `compiled` and `skipped` outcomes consistently.
-  - [x] **Self-Healing Integration:** `totem doctor --pr` upgrade phase calls `compileCommand` in-process, bundles results into the existing branch + commit + PR flow, reports only actual replacements (not noop/skipped/failed) in the auto-heal PR body, and stages `compile-manifest.json` alongside the rules file.
-  - [x] **AST Empty Catch:** 8 empty-catch rules upgraded from the legacy `ast` (Tree-sitter `#eq?`) engine to `ast-grep` structural matching, correctly handling parameterless catch blocks and multi-line empty bodies.
+- **Phase A: Workflow setup before the grind.** Cut bot-review-cycle cost before running it across 24 tickets. Monitor tool and `/loop` self-paced examples into CLAUDE.md (Proposal 232 Tier 2), PreCompact hook (#1460), review-gate `if`-scope (#1462), `/autofix-pr` trial on first Phase B bundle PR (#1461). `/preflight` v2 already shipped via #1296 + #1299; the proposal was archived 2026-04-15 once both planning passes tripped on the unarchived file.
+- **Phase A.5: Architectural gates.** Promote Proposal 202 (Stacked Compilation Architecture) and Proposal 228 (Zero-Trust Agent Governance) to ADR. Proposal 202 tickets land with `pre-1.15-review` because without a layered AST → template → LLM+verify → explicit-fail fallback, packs ship the 0/6 usable-rule failure mode from the 1.6.0 stress test. Proposal 228 becomes the 1.15.0 flagship pack `@totem/pack-agent-security`, the first production consumer of the pack infrastructure.
+- **Phase B: Pre-1.15-review grind.** 24 tickets ordered to minimize cross-PR interference. #1279 ships first as the de-noising step (Pipeline 5 over-narrow captures fired four times on the 1.14.10 branch alone). Tactical cleanup batch #1456-#1459 next. Tier-1 bundles grouped by `scope:` label (mcp, cli, compiler, orchestrator, store); one bundle per PR; deepest architectural layer first within each bundle. Tier-2 cleanup after tier-1 closes.
+- **Phase C: Pack Distribution headline.** Promote ADR-085 (Totem Pack Ecosystem) to Accepted with its five deferred decisions resolved (SemVer mapping, local-overrides-pack merge rule, conflict resolution, pack lifecycle, signing). Decompose into tickets for pack resolver, pack fetcher, signature verification, hash-stable compilation, pack lifecycle commands. Ship `@totem/pack-agent-security`. Wire Proposal 229 TBench spot-check as the pack-release gate (full harness stays Horizon 3).
 
-- **Pipeline Hygiene:**
-  - [x] **Wind Tunnel:** Skip auto-scaffolded TODO fixtures so empty placeholder fixtures don't dilute the gate signal.
-  - [x] **Extract Dedup:** Heading-level exact-match deduplication runs before embedding similarity to short-circuit duplicate ingestion at zero cost.
-  - [x] **Config Drift Test:** Replaced the line-count limit on instructional files with a token-aware character + directive count limit.
-
-- **Governance (eat your own dogfood):**
-  - [x] **Lesson Protection Rule:** A near-miss almost deleted `.totem/lessons.md` (which sources 41+ functional ast-grep rules) under the mistaken assumption it was legacy cruft. Encoded the constraint as a Pipeline 1 lint rule with severity `error` that flags the destructive shell-removal command targeting the load-bearing lessons file, at the point of intent, across all script and documentation files. Demonstrates the totem thesis: when an agent makes a mistake, write a deterministic constraint, not a sticky note.
+Quarantined out of 1.15.0: Proposal 217 (LLM context caching, 1.16.0) and Proposal 230 (content-hash embedding cache, 1.17.0). Both touch compile pipeline substrate; changing substrate and the feature built on top of it in the same release is a silent-regression risk.
 
 ---
 
-## 1.14.0 — The Distribution Pipeline (Next)
+## 1.16.0: The Ingestion Pipeline
 
-**Theme:** The Totem Pack Ecosystem. We spent 1.13.0 proving the engine can generate high-fidelity ast-grep rules — the bulk Sonnet recompile produced 393 precise rules and the refinement diagnostic closes the loop on noisy ones. 1.14.0 is about letting teams **bundle and share** those proven rules across repositories via the npm registry.
+**Theme:** Source Diversity and the Self-Healing Loop. Expand the extraction pipeline to automatically convert external signals (GitHub Advanced Security alerts and standard repository lint warnings) into deterministic Totem lessons. Where 1.13.0 refined rules from internal telemetry and 1.14.x + 1.15.0 ship the nervous system and the distribution pipeline, 1.16.0 is about where the _inputs_ come from.
 
-- **Headline Work:**
-  - [ ] **Rule Pack Distribution:** Standardized bundles for reusable rule distribution (#1059). Teams should be able to publish a versioned pack of compiled rules to npm and consume them in other projects under the same governance contract that locally-compiled rules satisfy.
-  - [ ] **Distributing Compiled Rules:** Strategy #35 research — mechanisms, versioning model, trust anchors, and integrity verification for cross-team rule sharing.
-
-- **Bundled Cleanup (operational chores on the way):**
-  - [ ] **Cloud Compile → Sonnet:** Update the cloud compile worker to route through Claude Sonnet (#1221) — critical prerequisite for cloud distribution, since packs compiled through the cloud need to meet the same quality bar as local Sonnet compile.
-  - [ ] **`cwd` Threading:** Thread explicit `cwd` through `compileCommand` so packs can be compiled from arbitrary working directories (#1232, #1234 follow-up).
-  - [ ] **Build Artifact:** Investigate and fix the stray `packages/core/{}` file produced by `pnpm build` (#1233).
-  - [ ] **Batch `--upgrade`:** Refactor `compileCommand` to accept an array of hashes so `runSelfHealing` doesn't reload config + lessons + rules + manifest per candidate (#1235).
-  - [ ] **Broad `throw $ERR` Pattern:** Refine the overly-broad ast-grep pattern (#1218).
-  - [ ] **Lazy Compile Templates:** Lazy-load compiler prompt templates to reduce CLI startup cost (#1219).
-
----
-
-## 1.15.0 — The Ingestion Pipeline
-
-**Theme:** Source Diversity and the Self-Healing Loop. Expand the extraction pipeline to automatically convert external signals — GitHub Advanced Security (GHAS) alerts and standard repository lint warnings — into deterministic Totem lessons. Where 1.13.0 refined rules from internal telemetry and 1.14.0 distributes them across teams, 1.15.0 is about where the _inputs_ come from.
+Also lands Proposal 217 (LLM context caching, quarantined out of 1.15.0 because it touches compile pipeline substrate).
 
 - **Headline Work:**
   - [ ] **GHAS / SARIF Extraction:** Convert GitHub Advanced Security alerts into Totem lessons (Strategy #50). This is the original #1131 scope we pivoted away from when telemetry-driven refinement won — now the right time, because 1.14.0 distribution gives us a way to ship the resulting rules back out.
@@ -77,6 +49,33 @@ Strategic research not currently scoped to 1.14.0 or 1.15.0:
 ---
 
 ## Shipped Milestones
+
+### 1.14.x: The Nervous System Foundation + Hotfix Cycle (2026-04-09 to 2026-04-15)
+
+Eleven releases over six days. Headline foundation work in 1.14.0, a four-P0 governance sweep across 1.14.3 through 1.14.5, quality sweep + capstone in 1.14.6 and 1.14.7, perf follow-up in 1.14.8, precision + bundle release on 2026-04-15.
+
+- **1.14.0** (2026-04-09): Cross-Repo Context Mesh (#1295), LLM Context Caching opt-in preview (#1292), `/preflight` v2 design-doc gate (#1296).
+- **1.14.1** (2026-04-11): Hotfix Sweep and Phase 1 Papercuts. Nine PRs including Pipeline 5 sanity gate, compile prune no-op fix, tilde-fence support.
+- **1.14.2** (2026-04-11): `DISPLAY_TAG = 'Review'` cosmetic split; `TAG = 'Shield'` internal routing key preserved (coordinated rename tracked in #1335).
+- **1.14.3** (2026-04-11): Archive Lie filter (#1345). `loadCompiledRules` now filters out archived status; self-healing loop is no longer a placebo.
+- **1.14.4** (2026-04-11): Compile manifest drift refresh (#1348) + parser-based ast-grep validation (#1349).
+- **1.14.5** (2026-04-11): `safeExec` rewrite on `cross-spawn.sync` (#1356), closing a latent Windows shell-injection vector that had been open for three weeks.
+- **1.14.6** (2026-04-13): Quality Sweep Phase 1-2 and Voice Compliance. 7 over-broad rules archived; voice-scrub follow-ups (#1379, #1382, #1383).
+- **1.14.7** (2026-04-13): Nervous System Capstone. Mesh completion (#1396), bot reply protocol docs (#1395), cause-chain migration (#1357).
+- **1.14.8** (2026-04-14): Perf Follow-up. `cwd` threading (#1401), batch upgrade hashes (#1401), PR template enforcement (#1402).
+- **1.14.9** (2026-04-15): The Precision Engine. Compound ast-grep rule support (#1410, #1412, #1415), compile-time smoke gate, `badExample` requirement (#1420) closing the LLM-hallucination loop.
+- **1.14.10** (2026-04-15): The Bundle Release. Shell-orchestrator `{model}` token RCE fix (#1429), Pipeline 1 compound rule authoring + fail-loud fixes in git.ts and rule-engine.ts (#1454).
+
+### 1.13.0: The Refinement Engine (2026-04-07)
+
+**Theme:** Telemetry-driven rule refinement, compilation routing, and structural pattern upgrades.
+
+- **Compilation Routing:** Compile pipeline routes through Claude Sonnet 4.6 (90% correctness vs Gemini Pro's 73%, 2.4s vs 19.6s avg per Strategy #73 benchmark). Bulk recompile of 1156 lessons dropped 438 rules to 393 after purging 143 noisy Gemini-hallucinated rules and upgrading 102 regex rules to ast-grep structural matching.
+- **Telemetry-Driven Refinement:** `RuleMetric.contextCounts` tracks per-context match distribution (code, string, comment, regex, unknown). `totem doctor checkUpgradeCandidates` flags regex rules with >20% non-code-context matches. `totem compile --upgrade <hash>` re-compiles a single rule with a telemetry-driven directive prompt. Self-healing `totem doctor --pr` calls `compileCommand` in-process.
+- **Pipeline Hygiene:** Wind tunnel skips auto-scaffolded TODO fixtures. Extract pipeline dedups at heading level before embedding similarity. Config drift test uses token-aware character + directive count limit.
+- **AST Coverage:** 8 empty-catch rules upgraded from the legacy Tree-sitter `#eq?` engine to ast-grep structural matching. Backtick wrapper stripping hardened in both Pipeline 1 (manual `**Pattern:**` extraction) and Pipeline 2 (LLM JSON output).
+- **Governance:** Lesson Protection Rule (Pipeline 1 lint rule, severity error) blocks destructive shell removal of `.totem/lessons.md` at the point of intent. Added after a 41-rule near-miss. Self-governance: use totem to govern totem.
+- **Standalone Binaries:** Real binaries shipped on darwin-arm64 (68 MB), linux-x64 (111 MB), win32-x64 (125 MB) via the #1241 arc (4 PRs: #1260, #1261, #1266, #1267). Original 50 MB cap was aspirational; actual Bun 1.2.x runtime baseline is 60-104 MB depending on platform.
 
 ### 1.12.0 — The Umpire & The Router (2026-04-05)
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -50,9 +50,9 @@ Strategic research not currently scoped to 1.14.0 or 1.15.0:
 
 ## Shipped Milestones
 
-### 1.14.x: The Nervous System Foundation + Hotfix Cycle (2026-04-09 to 2026-04-15)
+### 1.14.x: Nervous System Foundation + Hotfix Cycle
 
-Eleven releases over six days. Headline foundation work in 1.14.0, a four-P0 governance sweep across 1.14.3 through 1.14.5, quality sweep + capstone in 1.14.6 and 1.14.7, perf follow-up in 1.14.8, precision + bundle release on 2026-04-15.
+Eleven releases over six days (2026-04-09 to 2026-04-15). Headline foundation work in 1.14.0, a four-P0 governance sweep across 1.14.3 through 1.14.5, quality sweep + capstone in 1.14.6 and 1.14.7, perf follow-up in 1.14.8, precision + bundle release on 2026-04-15.
 
 - **1.14.0** (2026-04-09): Cross-Repo Context Mesh (#1295), LLM Context Caching opt-in preview (#1292), `/preflight` v2 design-doc gate (#1296).
 - **1.14.1** (2026-04-11): Hotfix Sweep and Phase 1 Papercuts. Nine PRs including Pipeline 5 sanity gate, compile prune no-op fix, tilde-fence support.


### PR DESCRIPTION
## Mechanical Root Cause

Three overlapping staleness conditions landed during the 2026-04-15 planning cycle:

1. The `.strategy` submodule pointer on main was last bumped on 2026-04-11 (`87138d2`). Since then, strategy main has advanced through the 2026-04-15 journals (handoff + precision-engine), proposals 228-231, the PR #83 external-consumer migration, and the `temp/` triage-run cleanup.
2. `CLAUDE.md` line 25 instructed agents to run `totem lesson compile --cloud <url>` as part of the postmerge workflow. The cloud worker still routes through Gemini (not Sonnet) until #1221 closes. The 1.13.0 bulk Sonnet recompile purged 143 noisy Gemini-produced rules as evidence of the quality gap; running `--cloud` against the 2026-04-15 backlog would have reintroduced the same class of noise.
3. `docs/active_work.md` and `docs/roadmap.md` both predated the 2026-04-15 planning pass that locked the 1.15.0 three-phase sequence. The roadmap still showed 1.13.0 as "Active" (shipped 2026-04-07) and the 1.14.0 theme on the wrong release.

During the execution of (1), a fourth staleness condition surfaced: `proposals/active/preflight-v2.md` described a skill update that had already shipped via #1296 (1.14.0) and been enhanced by #1299 (1.14.1). Both the 2026-04-15 Ultraplan pass and the strategy-repo pair audit recommended shipping it without checking the target file. The proposal was never archived post-ship, which fooled both planning passes. Ticket #1463 was filed for the already-shipped work, caught during preflight Phase 1 before any code was written, and closed with a link to #1296 + #1299.

## Fix Applied

Five commits on this branch:

- `34b47d33` -- `.strategy` pointer bump to `2532fad` for proposals 228-232 and both 2026-04-15 journals.
- `ad08212a` -- `.strategy` pointer re-bump to `1be1ee5` for the `preflight-v2.md` archive commit that surfaced during the staleness catch.
- `9b9d136d` -- `CLAUDE.md` line 25 dropped the `--cloud` flag and added a note that it is off-path until #1221 ships.
- `84690a00` -- `docs/active_work.md` header refreshed to 1.14.10 shipped (2922 tests, 414 rules / 392 active / 22 archived). 1.14.10 entry added with the three PRs (#1429, #1454, #1455) and four follow-ups (#1456-#1459). 1.14.9 flipped from "feature-complete, release pending" to shipped. The "Current: 1.15.0" section replaced with the locked three-phase plan (workflow setup, architectural gates, grind, pack distribution headline) plus proposal dispositions and the five highest-leverage undecomposed ADR backfill candidates. `docs/roadmap.md` 1.13.0 Active + 1.14.0 Next sections replaced with 1.15.0 Active; old 1.15.0 Ingestion renumbered to 1.16.0 with a Proposal 217 note; 1.14.x and 1.13.0 added to Shipped Milestones.
- `4b26973b` -- Follow-up shortening one 82-char shipped-milestone heading to clear a 60-char lint warning.

Side effects completed outside this branch:

- Ticket #1463 closed with a full explanation linking to #1296 and #1299.
- Strategy repo `main` advanced to `1be1ee5` with the `preflight-v2.md` archive move.

## Out of Scope

- Proposal 202 and Proposal 228 promotion to ADR. Strategy-repo pair territory; flagged in `active_work.md` locked plan but not executed here.
- ADR-004 / 015 / 017 / 025 / 039 ticket decomposition. Listed as backfill candidates, deferred.
- #1460 / #1462 / #1461 implementation. Next PRs following this one.
- Other potential staleness in `CLAUDE.md` beyond line 25. Only the operator-flagged line was addressed.
- The 60-char lesson-heading rule fired on one shipped-milestone heading and was worked around by restructuring. The rule itself may be over-broad for non-lesson markdown; not in scope here.

## Tests Added/Updated

- [x] N/A. All changes are docs + config. Pre-push ran 2922 tests green and 392 lint rules with 0 violations.

## Related Tickets

No single ticket closes with this PR. Related:

- #1421 -- pre-1.15.0 deep code review gate (this PR locks the plan that feeds the gate)
- #1463 -- closed separately (Preflight v2 was already shipped via #1296 + #1299)
- #1221 -- cited in `CLAUDE.md` for the `--cloud` deferral
- `mmnto-ai/totem-strategy` journal entries for 2026-04-15 (both captured via the pointer bump)