### PR TITLE
chore(claude-md): add Tool Patterns section (Monitor + /loop)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,11 @@ After >15 turns of code changes: run `totem status`, re-query strategy ADRs for 
 
 - **Controller, not implementer.** Delegate code+test tasks to background agents. Keep this thread for decisions.
 
+## Tool Patterns
+
+- **Prefer Monitor over Bash `sleep` loops when waiting for a signal.** Kick the long-running process to the background and Monitor it. `sleep; check; sleep; check` patterns burn cache context every iteration; Monitor streams events only when they happen. Example: launch `pnpm test --watch` in the background and Monitor it, rather than writing a shell poll loop.
+- **Use `/loop` self-paced when reacting to a future state change.** `/loop` without an interval lets the model decide when to check back. Pairs with Monitor for long watches. Example: `/loop watch the CI on this branch, react when green`.
+
 ## Detailed Docs (read when relevant)
 
 - [Contributing rules](.claude/docs/contributing.md) — PR bot protocol (CR/GCA), AI_PROMPT_BLOCK, changesets

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,8 +43,8 @@ After >15 turns of code changes: run `totem status`, re-query strategy ADRs for 
 
 ## Tool Patterns
 
-- **Prefer Monitor over Bash `sleep` loops when waiting for a signal.** Kick the long-running process to the background and Monitor it. `sleep; check; sleep; check` patterns burn cache context every iteration; Monitor streams events only when they happen. Example: launch `pnpm test --watch` in the background and Monitor it, rather than writing a shell poll loop.
-- **Use `/loop` self-paced when reacting to a future state change.** `/loop` without an interval lets the model decide when to check back. Pairs with Monitor for long watches. Example: `/loop watch the CI on this branch, react when green`.
+- **Prefer Monitor over Bash `sleep` loops.** Background long-running processes and Monitor them. `sleep; check` burns cache every iteration; Monitor only fires on events.
+- **`/loop` self-paced for poll-and-react.** `/loop <prompt>` without an interval lets the model self-cadence. Example: `/loop watch CI, react when green`.
 
 ## Detailed Docs (read when relevant)
 


### PR DESCRIPTION
## Mechanical Root Cause

Two recurrence patterns were about to dominate the upcoming 24-ticket pre-1.15-review grind:

1. Bash `sleep; check; sleep; check` loops for waiting on signals. These burn cache context every iteration.
2. Manual "check state, react if changed" workflows (watching CI, waiting for a ticket status to flip) that put the cadence decision on the agent instead of using the harness's built-in scheduling.

Both have better alternatives in Claude Code as of w15: Monitor tool (v2.1.98) streams events only when they happen, and `/loop` self-paced lets the model decide cadence via internal scheduling. CLAUDE.md did not mention either surface, leaving agents to reinvent the shell-loop pattern they had before these tools existed.

## Fix Applied

Five added lines in CLAUDE.md, a new `## Tool Patterns` section inserted between Agent Discipline and Detailed Docs:

- "Prefer Monitor over Bash `sleep` loops when waiting for a signal." Directive plus one concrete example (`pnpm test --watch` backgrounded and Monitored rather than a shell poll loop).
- "Use `/loop` self-paced when reacting to a future state change." Directive plus one concrete example (`/loop watch the CI on this branch, react when green`).

Held to 5 added lines deliberately. Lesson `lesson-60fdfe9d` (CLAUDE.md compliance experiment, 2026-03-14) established that verbose CLAUDE.md (325 lines observed) suppresses MCP tool usage entirely; lean (~40 lines) works reliably. File grew from 49 to 54 lines, well inside the lean zone.

## Out of Scope

Other Proposal 232 Tier 2 and Tier 3 items deferred by the 2026-04-15 strategy-pair audit:

- `TaskCreated` hook (Tier 2): policy unresolved (when is a subagent spawn allowed?), blast radius on mid-turn `Agent()` rejection unknown per Proposal 232's own open questions. Defer pending post-grind retrospective.
- `/insights` one-shot (Tier 2): retrospective value only. Run once at milestone close as a separate exercise.
- Ultraplan trial documentation (Tier 3): designed for strategic design work; the grind is tactical execution. Revisit post-Pack-Distribution.

Tier 1 items tracked separately: #1460 (PreCompact hook), #1462 (review-gate `if`-scope), #1461 (`/autofix-pr` trial).

## Tests Added/Updated

- [x] N/A. Documentation-only change. Pre-push validated 2922 tests and 392 lint rules, format clean. Spec's structural assertion (Tool Patterns between Agent Discipline and Detailed Docs) verified locally with the one-line node check from the acceptance criteria.

## Related Tickets

Closes #1465

Context:

- Proposal 232 stays active as reference through the cycle; will be archived after all Tier-1 items close.
- Preflight executed per CLAUDE.md formal workflow, eating our own dogfood.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal development guidance documentation with new tool pattern recommendations for monitoring and scheduling operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->