### PR TITLE
chore(hooks): narrow review-gate.sh to Bash(git push*) via if-scope

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -28,6 +28,7 @@
         "hooks": [
           {
             "type": "command",
+            "if": "Bash(git push*)",
             "command": "bash .claude/hooks/review-gate.sh"
           }
         ]


### PR DESCRIPTION
## Mechanical Root Cause

The `review-gate.sh` PreToolUse hook was configured with only `"matcher": "Bash"`, so it fired on every Bash invocation. For each non-push call (`ls`, `git status`, `pnpm build`, etc.), the hook:

1. Spawned a `bash` subshell.
2. Read the tool input via stdin.
3. Called `jq` or a `grep | sed` fallback to extract `.command` from the JSON payload.
4. Ran a regex to decide if the command was `git push`.
5. Exited 0 when it wasn't, allowing the call to proceed.

On a grind cycle that runs hundreds of Bash calls per session (the upcoming 24-ticket pre-1.15-review pass is exactly this shape), the aggregate cost of that startup-and-exit pattern is measurable. It also adds latency to every tool call, which compounds across long sessions.

Claude Code v2.1.85 shipped an `if` field on hooks that lets the harness do the filtering before the hook process is ever spawned. This PR adopts it for `review-gate.sh`.

## Fix Applied

One line added to the inner hook entry in `.claude/settings.json`:

```json
"PreToolUse": [
  {
    "matcher": "Bash",
    "hooks": [
      {
        "type": "command",
        "if": "Bash(git push*)",
        "command": "bash .claude/hooks/review-gate.sh"
      }
    ]
  }
]
```

The `if` field goes on the inner hook entry (sibling of `type` and `command`), with the permission-rule-style value `Bash(git push*)`. It refines within the existing `matcher: "Bash"` rather than replacing it. Syntax verified against Claude Code docs via the in-repo claude-code-guide agent before landing.

The hook script's own internal `git push` regex guard stays in place as defense-in-depth. If the `if`-scope is ever accidentally dropped from settings or a Claude Code version downgrade removes `if` support, the internal guard still prevents the hook from gating non-push commands. Cost of defense-in-depth is the cost already paid today; once `if` is active, the internal guard becomes a fallback that never executes during normal operation.

## Out of Scope

- **Consumer init template parity.** `CLAUDE_PRETOOLUSE_ENTRY` in `packages/cli/src/commands/init-templates.ts` scaffolds a completely different consumer-facing hook (`node .totem/hooks/shield-gate.cjs`), not `review-gate.sh`. If we want to apply the same optimization to the consumer shield-gate, that is a separate ticket with its own scope (consumer init templates are load-bearing for every new Totem installation).
- **Removal of the internal `git push` regex guard in `review-gate.sh`.** Left intact on purpose as defense-in-depth. If a future PR has a strong reason to remove it (e.g., cleanup after we gain confidence in the `if` field), it belongs in its own commit with explicit rationale.
- **Behavioral verification in this PR.** See below.

## Tests Added/Updated

- [x] N/A. The spec generator suggested a new test file asserting the `if` field exists, but that would be a tautology against the committed config and has no behavioral outcome to exercise without a Claude Code runtime. The change is visible in the commit diff and small enough to inspect directly.

**Behavioral verification** requires a `git push` through Claude Code after this merges, to confirm the hook still fires on push and no longer fires on non-push Bash. That verification happens on the next push after merge.

## Related Tickets

Closes #1462

Context:

- Part of Proposal 232 Tier 1 workflow-setup phase, executed before the 24-ticket pre-1.15-review grind starts.
- Sibling tickets: #1460 (PreCompact hook), #1461 (`/autofix-pr` trial).
- Preflight executed per CLAUDE.md formal workflow.