### PR TITLE
fix(ci): add root agent-instruction files to turbo test inputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -10,7 +10,18 @@
       "persistent": true
     },
     "test": {
-      "dependsOn": ["build"]
+      "dependsOn": ["build"],
+      "inputs": [
+        "$TURBO_ROOT/CLAUDE.md",
+        "$TURBO_ROOT/GEMINI.md",
+        "$TURBO_ROOT/.junie/guidelines.md",
+        "$TURBO_ROOT/.gemini/**",
+        "$TURBO_ROOT/tools/pre-commit",
+        "$TURBO_ROOT/tools/pre-push",
+        "$TURBO_ROOT/tools/post-merge",
+        "$TURBO_ROOT/.claude/hooks/**",
+        "**"
+      ]
     },
     "lint": {},
     "clean": {


### PR DESCRIPTION
## Mechanical Root Cause

The \`test\` task in \`turbo.json\` had no \`inputs\` array:

\`\`\`json
"test": {
  "dependsOn": ["build"]
}
\`\`\`

Turbo defaults to hashing only files within each package workspace. But \`config-drift.test.ts\` and \`pre-compact-hook.test.ts\` in the cli package read root-level files via \`readRoot()\` (CLAUDE.md, GEMINI.md, .junie/guidelines.md, .gemini/*, tools/pre-*, .claude/hooks/*). Changes to those root files did not bust the turbo cache for cli:test.

Observed on PR #1466: CLAUDE.md grew to 3204 characters (over the 3000-char FR-C01 cap). Local pre-push served a stale turbo cache hit on cli:test and reported green. CI ran clean (no cache) and caught the overflow. The user saw "all tests pass" from pre-push but got a CI failure on all three platforms.

## Fix Applied

Added an explicit \`inputs\` array to the \`test\` task:

\`\`\`json
"test": {
  "dependsOn": ["build"],
  "inputs": [
    "$TURBO_ROOT/CLAUDE.md",
    "$TURBO_ROOT/GEMINI.md",
    "$TURBO_ROOT/.junie/guidelines.md",
    "$TURBO_ROOT/.gemini/**",
    "$TURBO_ROOT/tools/pre-commit",
    "$TURBO_ROOT/tools/pre-push",
    "$TURBO_ROOT/tools/post-merge",
    "$TURBO_ROOT/.claude/hooks/**",
    "**"
  ]
}
\`\`\`

The trailing \`**\` preserves the default package-scope file hashing. The \`$TURBO_ROOT/\` prefix (turbo v2+) resolves paths relative to the monorepo root.

The array applies to all three packages' test tasks. core:test and mcp:test do not currently read these root files, so they pick up a few extra cache misses when root files change. The cost is trivial (seconds of re-execution) vs the alternative of per-package task overrides with ongoing maintenance burden.

## Out of Scope

- \`packages/mcp/package.json\` is read cross-package by \`config-drift.test.ts\` in cli. This is a separate turbo input gap but lower-risk; any mcp package.json change already busts mcp:test and mcp:build, and the cross-package read is a single \`main\` entrypoint assertion. Tracked if it surfaces.
- \`globalDependencies\` was considered and rejected; it invalidates ALL tasks (build + test + lint) on any listed file change, which is unnecessarily broad for files that only affect tests.

## Tests Added/Updated

- [x] N/A. Config-only change. \`turbo run test --dry\` validates turbo accepts the new input set (641 files considered, up from package-only scope). CI will exercise the real cache behavior.

## Related Tickets

Closes #1467