### PR TITLE
refactor(core): migrate safeField.replace sites to escapeRegex helper

### DIFF
--- a/packages/core/src/lesson-pattern.ts
+++ b/packages/core/src/lesson-pattern.ts
@@ -13,6 +13,7 @@
 import YAML from 'yaml';
 
 import { TotemParseError } from './errors.js';
+import { escapeRegex } from './regex-utils.js';
 
 export interface ManualPattern {
   /**
@@ -66,7 +67,7 @@ export function extractField(body: string, field: string): string | undefined {
   // silently rejecting `**Pattern:**foo` (no space) and `**Pattern:**` (empty value).
   // Caught by gemini-code-assist on PR #1282 as another instance of the
   // cross-helper-consistency cascade pattern documented in lesson-400fed87.
-  const safeField = field.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const safeField = escapeRegex(field);
   const re = new RegExp(`^(?:\\*{2})?${safeField}(?:\\*{2})?:(?:\\*{2})?[ \\t]*(.*)$`, 'im');
   const match = body.match(re);
   // Trim and treat empty as "no value" so callers' `if (!value)` checks fire correctly.
@@ -90,7 +91,7 @@ export function extractField(body: string, field: string): string | undefined {
  * Returns the trimmed value, or `undefined` if the field is absent.
  */
 export function extractMultilineField(body: string, field: string): string | undefined {
-  const safeField = field.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const safeField = escapeRegex(field);
   // Match the field's first line. Supports four common forms:
   //   **Field:**  ← canonical totem (asterisks both sides of colon)
   //   **Field**:  ← alternative markdown convention (asterisks before colon)
@@ -194,11 +195,7 @@ export function extractYamlRuleAfterField(
   body: string,
   field: string,
 ): Record<string, unknown> | null {
-  // Replacer function — `'\\$&'` would still parse correctly because `$&`
-  // expanding to the matched char is exactly the intent, but the function
-  // form is the safer idiom in substitution-sensitive contexts (matches the
-  // broader repo convention, GCA catch on mmnto/totem#1454).
-  const safeField = field.replace(/[.*+?^${}()|[\]\\]/g, (ch) => '\\' + ch);
+  const safeField = escapeRegex(field);
   const startRe = new RegExp(`^(?:\\*{2})?${safeField}(?:\\*{2})?:(?:\\*{2})?.*$`, 'i');
   // Section terminator — any bold field marker OR any markdown heading stops
   // the YAML scan. CR catch on mmnto/totem#1454: without the heading guard,
@@ -328,7 +325,7 @@ export function extractManualPattern(body: string): ManualPattern | null {
  * `**Field**:`, `**Field:`, and plain `Field:`.
  */
 export function extractAllFields(body: string, field: string): string[] {
-  const safeField = field.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const safeField = escapeRegex(field);
   const re = new RegExp(`^(?:\\*{2})?${safeField}(?:\\*{2})?:(?:\\*{2})?[ \\t]*(.*)$`, 'gim');
   return Array.from(body.matchAll(re), (m) => m[1]!.trim());
 }
@@ -366,7 +363,7 @@ export interface BadGoodSnippets {
  * Used internally by extractBadGoodSnippets.
  */
 function extractCodeBlock(body: string, field: string): string[] | null {
-  const safeField = field.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const safeField = escapeRegex(field);
   // Try fenced code block after **Field:** or **Field**: (colon required, inside or outside bold)
   const fencedRe = new RegExp(
     `(?:^|\\n)\\*{0,2}${safeField}\\*{0,2}\\s*:[^\\n]*\\n(?:\\s*\\n)*(\`\`\`|~~~)[^\\n]*\\n([\\s\\S]*?)\\1`,

--- a/packages/core/src/regex-utils.test.ts
+++ b/packages/core/src/regex-utils.test.ts
@@ -4,11 +4,25 @@ import { codeToPattern, escapeRegex } from './regex-utils.js';
 
 describe('escapeRegex', () => {
   it('escapes all regex metacharacters', () => {
-    const metacharacters = '.*+?^${}()|[]\\';
+    const metacharacters = '.*+?^${}()|[]\\-';
     const escaped = escapeRegex(metacharacters);
-    expect(escaped).toBe('\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\');
+    expect(escaped).toBe('\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\\\-');
     // The escaped string should be safe to use in a RegExp
     expect(() => new RegExp(escaped)).not.toThrow();
+  });
+
+  it('escapes hyphen so output is safe inside a character class', () => {
+    // A caller that interpolates escapeRegex output into `[...]` would
+    // otherwise get a range expression by accident. GCA catch on #1501.
+    const escaped = escapeRegex('a-z');
+    expect(escaped).toBe('a\\-z');
+    const re = new RegExp(`[${escaped}]`);
+    // The character class contains `a`, `\-`, `z` as literals. `m` is
+    // not in the set and must not match.
+    expect(re.test('-')).toBe(true);
+    expect(re.test('a')).toBe(true);
+    expect(re.test('z')).toBe(true);
+    expect(re.test('m')).toBe(false);
   });
 
   it('leaves alphanumeric strings unchanged', () => {

--- a/packages/core/src/regex-utils.ts
+++ b/packages/core/src/regex-utils.ts
@@ -8,9 +8,14 @@
 /**
  * Escape all regex special characters in a string so it can be used
  * as a literal match inside a `RegExp`.
+ *
+ * Uses a replacer function (not a `'\\$&'` string replacement) to
+ * match the repo convention set by `shell-orchestrator.ts` and the
+ * GCA catches on PR #1454 / #1458. Functionally equivalent but safer
+ * as a default in substitution-sensitive contexts.
  */
 export function escapeRegex(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return s.replace(/[.*+?^${}()|[\]\\]/g, (ch) => '\\' + ch);
 }
 
 /**

--- a/packages/core/src/regex-utils.ts
+++ b/packages/core/src/regex-utils.ts
@@ -15,7 +15,7 @@
  * as a default in substitution-sensitive contexts.
  */
 export function escapeRegex(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, (ch) => '\\' + ch);
+  return s.replace(/[.*+?^${}()|[\]\\-]/g, (ch) => '\\' + ch);
 }
 
 /**


### PR DESCRIPTION
## Mechanical Root Cause

`packages/core/src/regex-utils.ts` already exports `escapeRegex(s)`, whose docstring says it replaces "the scattered `string.replace(/[.*+?^${}()|[\]\]/g, '\$&')` pattern found across the codebase." Five sites in `packages/core/src/lesson-pattern.ts` had not migrated. The pre-existing inline idiom also uses the string-back-reference form (`'\$&'`), which GCA flagged on PR #1454 as inferior to the replacer-function form for substitution-sensitive contexts.

A follow-on GCA catch on this PR identified that `escapeRegex` also omitted hyphen from its escape set, which is unsafe when the output is interpolated into a character class (`[...]`).

## Fix Applied

**Commit `c209fccb`:**
- `escapeRegex` in `regex-utils.ts` switched from `'\$&'` to `(ch) => '\' + ch`. Byte-identical output for this commit.
- Five call sites in `lesson-pattern.ts` now import and call `escapeRegex` instead of inlining the regex-escape expression:
  - `extractField` (was inline string replacer)
  - `extractMultilineField` (was inline string replacer)
  - `extractAllFields` (was inline string replacer)
  - `extractCodeBlock` (was inline string replacer)
  - `extractYamlRuleAfterField` (was inline function replacer from #1454)

**Commit `eb029b1c` (in response to GCA review):**
- Hyphen `-` added to the escape set (`/[.*+?^${}()|[\]\-]/g`). Matches MDN's canonical escape set.
- Behavior change: inputs containing hyphens now produce escaped output (e.g., `a-z` returns `a\-z` instead of `a-z`). Functionally equivalent inside a regex because `\-` is a literal hyphen everywhere in JavaScript regex, but output bytes differ for hyphenated inputs.
- New test locks in the hyphen-escape behavior and proves the escaped output is safe to interpolate into `[...]`.

Single source of truth; all five callers get the canonical implementation in one place.

## Out of Scope

- Renaming `escapeRegex` to `escapeRegExp`. The existing name is already used by `eslint-adapter.ts` and re-exported from `packages/core/src/index.ts`; rename would be unnecessary churn.
- Auditing for other copies of the same idiom outside `packages/core`. Quick grep confirmed the remaining uses in `shell-orchestrator.ts` already use the function form.
- Changeset. This is a refactor with a minor defensive-output change for hyphen inputs. No current caller is affected (no current caller interpolates `escapeRegex` output into a character class). Happy to add a `patch` changeset if the CI changesets check requires one.

## Tests Added/Updated

- [x] Added/updated automated tests covering the root-cause mechanism

- Existing metacharacter test extended to include hyphen in the input string and expected output.
- New test: `escapes hyphen so output is safe inside a character class` — verifies `escapeRegex('a-z')` returns `a\-z`, then interpolates the result into a character class and asserts the set contains the three literal characters without inadvertent range behavior.

Full suite: 2,931 tests across 6 packages green. `totem review` deterministic fast-path returned zero findings on both commits.

## Related Tickets

Closes #1458