### PR TITLE
feat(mcp): rich session-briefing payload on describe_project

### DIFF
--- a/packages/mcp/src/schemas/describe-project.test.ts
+++ b/packages/mcp/src/schemas/describe-project.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DescribeProjectInputSchema,
+  DescribeProjectOutputSchema,
+  GitStateSchema,
+  MilestoneStateSchema,
+  RECENT_PRS_COUNT,
+  RichProjectStateSchema,
+  RuleCountsSchema,
+  StrategyPointerSchema,
+  UNCOMMITTED_FILES_CAP,
+} from './describe-project.js';
+
+describe('DescribeProjectInputSchema', () => {
+  it('accepts empty input and defaults includeRichState to false', () => {
+    const parsed = DescribeProjectInputSchema.parse({});
+    expect(parsed.includeRichState).toBe(false);
+  });
+
+  it('accepts explicit includeRichState false', () => {
+    const parsed = DescribeProjectInputSchema.parse({ includeRichState: false });
+    expect(parsed.includeRichState).toBe(false);
+  });
+
+  it('accepts explicit includeRichState true', () => {
+    const parsed = DescribeProjectInputSchema.parse({ includeRichState: true });
+    expect(parsed.includeRichState).toBe(true);
+  });
+
+  it('rejects non-boolean includeRichState', () => {
+    expect(() => DescribeProjectInputSchema.parse({ includeRichState: 'yes' })).toThrow();
+  });
+});
+
+describe('DescribeProjectOutputSchema backward compatibility', () => {
+  const legacyShape = {
+    project: 'test',
+    tier: 'standard' as const,
+    rules: 10,
+    lessons: 5,
+    targets: ['**/*.ts (code/typescript-ast)'],
+    partitions: { core: ['packages/core/'] },
+    hooks: ['pre-push'],
+  };
+
+  it('accepts legacy shape without richState', () => {
+    const parsed = DescribeProjectOutputSchema.parse(legacyShape);
+    expect(parsed.richState).toBeUndefined();
+  });
+
+  it('accepts legacy shape with richState populated', () => {
+    const rich = {
+      strategyPointer: { sha: 'abc1234', latestJournal: '2026-04-16-session.md' },
+      gitState: { branch: 'main', uncommittedFiles: [], truncated: false },
+      packageVersions: { '@mmnto/cli': '1.14.10' },
+      ruleCounts: { active: 10, archived: 2, nonCompilable: 3 },
+      lessonCount: 5,
+      testCount: null,
+      milestone: { name: '1.15.0', gateTickets: ['#1479'], bestEffort: true as const },
+      recentPrs: [{ title: 'feat: foo (#1)', date: '2026-04-16T00:00:00Z', squashSha: 'abcd123' }],
+    };
+    const parsed = DescribeProjectOutputSchema.parse({ ...legacyShape, richState: rich });
+    expect(parsed.richState?.ruleCounts.active).toBe(10);
+  });
+
+  it('rejects malformed richState', () => {
+    expect(() =>
+      DescribeProjectOutputSchema.parse({
+        ...legacyShape,
+        richState: { strategyPointer: 'not an object' },
+      }),
+    ).toThrow();
+  });
+});
+
+describe('GitStateSchema', () => {
+  it('accepts null branch (outside git repo)', () => {
+    const parsed = GitStateSchema.parse({ branch: null, uncommittedFiles: [], truncated: false });
+    expect(parsed.branch).toBeNull();
+  });
+
+  it('accepts branch + files + truncation marker', () => {
+    const parsed = GitStateSchema.parse({
+      branch: 'main',
+      uncommittedFiles: ['a.ts', 'b.ts'],
+      truncated: true,
+    });
+    expect(parsed.truncated).toBe(true);
+  });
+});
+
+describe('RuleCountsSchema', () => {
+  it('rejects negative counts', () => {
+    expect(() => RuleCountsSchema.parse({ active: -1, archived: 0, nonCompilable: 0 })).toThrow();
+  });
+
+  it('rejects non-integer counts', () => {
+    expect(() => RuleCountsSchema.parse({ active: 1.5, archived: 0, nonCompilable: 0 })).toThrow();
+  });
+});
+
+describe('MilestoneStateSchema', () => {
+  it('requires bestEffort literal true', () => {
+    expect(() =>
+      MilestoneStateSchema.parse({ name: null, gateTickets: [], bestEffort: false }),
+    ).toThrow();
+  });
+
+  it('accepts null name with empty gateTickets', () => {
+    const parsed = MilestoneStateSchema.parse({
+      name: null,
+      gateTickets: [],
+      bestEffort: true,
+    });
+    expect(parsed.name).toBeNull();
+  });
+});
+
+describe('StrategyPointerSchema', () => {
+  it('allows both fields null (no submodule)', () => {
+    const parsed = StrategyPointerSchema.parse({ sha: null, latestJournal: null });
+    expect(parsed.sha).toBeNull();
+  });
+});
+
+describe('RichProjectStateSchema', () => {
+  it('allows testCount: null explicitly', () => {
+    const parsed = RichProjectStateSchema.parse({
+      strategyPointer: { sha: null, latestJournal: null },
+      gitState: { branch: null, uncommittedFiles: [], truncated: false },
+      packageVersions: {},
+      ruleCounts: { active: 0, archived: 0, nonCompilable: 0 },
+      lessonCount: 0,
+      testCount: null,
+      milestone: { name: null, gateTickets: [], bestEffort: true },
+      recentPrs: [],
+    });
+    expect(parsed.testCount).toBeNull();
+  });
+});
+
+describe('constants', () => {
+  it('caps match the design doc', () => {
+    expect(UNCOMMITTED_FILES_CAP).toBe(50);
+    expect(RECENT_PRS_COUNT).toBe(5);
+  });
+});

--- a/packages/mcp/src/schemas/describe-project.ts
+++ b/packages/mcp/src/schemas/describe-project.ts
@@ -1,0 +1,137 @@
+/**
+ * Zod schemas for the describe_project MCP tool.
+ *
+ * The legacy slim payload (project, tier, rules, lessons, targets, partitions,
+ * hooks) is preserved byte-identical when `includeRichState` is false or
+ * omitted. Rich state is opt-in via the input parameter and attaches as an
+ * optional `richState` field on the output.
+ *
+ * Implements ADR-090 Deferred Decision #2 (describe_project as substrate:
+ * reports state, self-routing remains the agent's decision).
+ */
+
+import { z } from 'zod';
+
+/**
+ * Cap the uncommitted-files list to protect the MCP stdio pipe and the
+ * consuming agent's context window. A dirty tree with thousands of staged
+ * files should still produce a useful briefing payload.
+ */
+export const UNCOMMITTED_FILES_CAP = 50;
+
+/**
+ * Number of recent merged PRs returned in the briefing. Keep small so the
+ * payload stays fast and the agent sees the most relevant history.
+ */
+export const RECENT_PRS_COUNT = 5;
+
+// ─── Input ─────────────────────────────────────────────────────────────────
+
+/**
+ * `.default(false)` keeps legacy callers (empty input object) byte-identical
+ * to today's output. Opt-in is the only path that extends the response shape.
+ */
+export const DescribeProjectInputSchema = z.object({
+  includeRichState: z.boolean().optional().default(false),
+});
+
+export type DescribeProjectInput = z.infer<typeof DescribeProjectInputSchema>;
+
+// ─── Rich state sub-schemas ────────────────────────────────────────────────
+
+export const StrategyPointerSchema = z.object({
+  /** Short-form 7-char SHA of the strategy submodule HEAD. Null when no submodule. */
+  sha: z.string().nullable(),
+  /** Filename of the most recent `.strategy/.journal/*.md` entry, no path. */
+  latestJournal: z.string().nullable(),
+});
+export type StrategyPointer = z.infer<typeof StrategyPointerSchema>;
+
+export const GitStateSchema = z.object({
+  /** Current branch name. Null when running outside a git repo or in detached HEAD. */
+  branch: z.string().nullable(),
+  /** Uncommitted files (staged + unstaged). Capped at UNCOMMITTED_FILES_CAP. */
+  uncommittedFiles: z.array(z.string()),
+  /** True when the real uncommitted count exceeded UNCOMMITTED_FILES_CAP. */
+  truncated: z.boolean(),
+});
+export type GitState = z.infer<typeof GitStateSchema>;
+
+export const RecentPrSchema = z.object({
+  /** Squash-merge commit title including the `(#NNNN)` PR suffix. */
+  title: z.string(),
+  /** ISO-8601 commit date. */
+  date: z.string(),
+  /** Short-form 7-char commit SHA. */
+  squashSha: z.string(),
+});
+export type RecentPr = z.infer<typeof RecentPrSchema>;
+
+export const RuleCountsSchema = z.object({
+  active: z.number().int().nonnegative(),
+  archived: z.number().int().nonnegative(),
+  nonCompilable: z.number().int().nonnegative(),
+});
+export type RuleCounts = z.infer<typeof RuleCountsSchema>;
+
+export const MilestoneStateSchema = z.object({
+  /** Milestone name (e.g. "1.15.0"). Null when not parseable from active_work.md. */
+  name: z.string().nullable(),
+  /** List of ticket references carrying the active gate label (e.g. pre-1.15-review). */
+  gateTickets: z.array(z.string()),
+  /**
+   * Marks this payload as parsed best-effort from `docs/active_work.md` and
+   * not a cryptographic truth. Agents should treat it as a hint, not a
+   * ground-truth source.
+   */
+  bestEffort: z.literal(true),
+});
+export type MilestoneState = z.infer<typeof MilestoneStateSchema>;
+
+export const RichProjectStateSchema = z.object({
+  strategyPointer: StrategyPointerSchema,
+  gitState: GitStateSchema,
+  /** Fixed-group package versions (e.g. `@mmnto/cli`). Entries omit when extraction fails for that package. */
+  packageVersions: z.record(z.string()),
+  ruleCounts: RuleCountsSchema,
+  /** Count of `.totem/lessons/*.md` files. Zero if the directory is missing. */
+  lessonCount: z.number().int().nonnegative(),
+  /**
+   * Test count from stored metadata. Null in v1 — no artifact is stamped
+   * today. Follow-up ticket wires postmerge to produce `.totem/store/test-stats.json`.
+   */
+  testCount: z.number().int().nonnegative().nullable(),
+  milestone: MilestoneStateSchema,
+  recentPrs: z.array(RecentPrSchema),
+});
+
+export type RichProjectState = z.infer<typeof RichProjectStateSchema>;
+
+// ─── Output ────────────────────────────────────────────────────────────────
+
+/**
+ * Legacy `ProjectDescription` shape as returned by core `describeProject()`.
+ * Kept in this file for schema co-location; the source of truth is the
+ * `ProjectDescription` interface in `@mmnto/totem`.
+ */
+export const LegacyProjectDescriptionSchema = z.object({
+  project: z.string(),
+  description: z.string().optional(),
+  tier: z.enum(['lite', 'standard', 'full']),
+  rules: z.number(),
+  lessons: z.number(),
+  targets: z.array(z.string()),
+  partitions: z.record(z.array(z.string())),
+  hooks: z.array(z.string()),
+});
+
+/**
+ * Output schema: legacy shape + optional rich state. Callers that omit
+ * `includeRichState` (or pass false) get a payload without the `richState`
+ * field at all — the JSON output is byte-identical to today's.
+ */
+export const DescribeProjectOutputSchema = LegacyProjectDescriptionSchema.extend({
+  richState: RichProjectStateSchema.optional(),
+});
+
+export type DescribeProjectOutput = z.infer<typeof DescribeProjectOutputSchema>;

--- a/packages/mcp/src/state-extractors.test.ts
+++ b/packages/mcp/src/state-extractors.test.ts
@@ -1,0 +1,209 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+// packages/mcp/src -> packages/mcp -> packages -> repo root
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+import { UNCOMMITTED_FILES_CAP } from './schemas/describe-project.js';
+import {
+  extractGitState,
+  extractLessonCount,
+  extractMilestoneState,
+  extractPackageVersions,
+  extractRecentPrs,
+  extractRuleCounts,
+  extractStrategyPointer,
+  extractTestCount,
+} from './state-extractors.js';
+
+describe('extractGitState', () => {
+  it('returns null/empty for a non-git directory', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-mcp-nogit-'));
+    try {
+      const state = extractGitState(tmp);
+      expect(state.branch).toBeNull();
+      expect(state.uncommittedFiles).toEqual([]);
+      expect(state.truncated).toBe(false);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('returns current branch and staged/unstaged files on the live repo', () => {
+    const state = extractGitState(REPO_ROOT);
+    expect(state.branch).toBeTypeOf('string');
+    expect(state.uncommittedFiles.length).toBeLessThanOrEqual(UNCOMMITTED_FILES_CAP);
+    // If a truncation happened the cap must be hit exactly.
+    if (state.truncated) {
+      expect(state.uncommittedFiles.length).toBe(UNCOMMITTED_FILES_CAP);
+    }
+  });
+});
+
+describe('extractStrategyPointer', () => {
+  it('returns null/null when .strategy/ is absent', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-mcp-nostrat-'));
+    try {
+      const ptr = extractStrategyPointer(tmp);
+      expect(ptr.sha).toBeNull();
+      expect(ptr.latestJournal).toBeNull();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('returns a 7-char SHA and a journal filename on the live repo', () => {
+    const ptr = extractStrategyPointer(REPO_ROOT);
+    if (ptr.sha !== null) {
+      expect(ptr.sha).toMatch(/^[0-9a-f]{7}$/);
+    }
+    if (ptr.latestJournal !== null) {
+      expect(ptr.latestJournal).toMatch(/\.md$/);
+    }
+  });
+});
+
+describe('extractPackageVersions', () => {
+  it('returns {} when packages/ is missing', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-mcp-nopkg-'));
+    try {
+      expect(extractPackageVersions(tmp)).toEqual({});
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('captures fixed-group versions on the live repo', () => {
+    const versions = extractPackageVersions(REPO_ROOT);
+    // Whichever of the fixed-group packages exist must carry a version string.
+    for (const pkgName of Object.keys(versions)) {
+      expect(versions[pkgName]).toMatch(/^\d+\.\d+\.\d+/);
+    }
+    // At least one of the headline packages must be present on the self-host.
+    expect(versions['@mmnto/cli'] !== undefined || versions['@mmnto/totem'] !== undefined).toBe(
+      true,
+    );
+  });
+});
+
+describe('extractRuleCounts', () => {
+  it('returns zeros when compiled-rules.json is missing', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-mcp-norules-'));
+    try {
+      const counts = extractRuleCounts(tmp, '.totem');
+      expect(counts).toEqual({ active: 0, archived: 0, nonCompilable: 0 });
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('returns zeros when compiled-rules.json is malformed', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-mcp-badrules-'));
+    try {
+      fs.mkdirSync(path.join(tmp, '.totem'));
+      fs.writeFileSync(path.join(tmp, '.totem', 'compiled-rules.json'), '{ broken json');
+      const counts = extractRuleCounts(tmp, '.totem');
+      expect(counts).toEqual({ active: 0, archived: 0, nonCompilable: 0 });
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('splits active from archived on the live repo', () => {
+    const counts = extractRuleCounts(REPO_ROOT, '.totem');
+    expect(counts.active).toBeGreaterThan(0);
+    expect(counts.archived).toBeGreaterThanOrEqual(0);
+    expect(counts.nonCompilable).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('extractLessonCount', () => {
+  it('returns 0 when lessons/ is missing', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-mcp-nolessons-'));
+    try {
+      expect(extractLessonCount(tmp, '.totem')).toBe(0);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('returns the live lesson count', () => {
+    expect(extractLessonCount(REPO_ROOT, '.totem')).toBeGreaterThan(0);
+  });
+});
+
+describe('extractMilestoneState', () => {
+  it('returns null/empty with bestEffort=true when active_work.md is missing', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-mcp-noactive-'));
+    try {
+      const state = extractMilestoneState(tmp);
+      expect(state).toEqual({ name: null, gateTickets: [], bestEffort: true });
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('parses milestone and tickets on the live repo', () => {
+    const state = extractMilestoneState(REPO_ROOT);
+    expect(state.bestEffort).toBe(true);
+    // Milestone value depends on the current doc; just enforce the shape contract.
+    if (state.name !== null) {
+      expect(state.name).toMatch(/^\d+\.\d+\.\d+$/);
+    }
+    // Ticket list should never include legacy 1-2 digit fragments and should
+    // not explode past the 200-entry safety cap.
+    expect(state.gateTickets.length).toBeLessThanOrEqual(200);
+    for (const ticket of state.gateTickets) {
+      expect(ticket).toMatch(/^#\d{3,5}$/);
+    }
+  });
+});
+
+describe('extractTestCount', () => {
+  it('always returns null in v1', () => {
+    expect(extractTestCount(REPO_ROOT)).toBeNull();
+  });
+});
+
+describe('extractRecentPrs', () => {
+  it('returns [] for a non-git directory', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-mcp-norecent-'));
+    try {
+      expect(extractRecentPrs(tmp)).toEqual([]);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it('returns up to the requested limit, newest first on the live repo', () => {
+    const prs = extractRecentPrs(REPO_ROOT, 5);
+    expect(prs.length).toBeLessThanOrEqual(5);
+    for (const pr of prs) {
+      expect(pr.title).toMatch(/#\d+/);
+      expect(pr.squashSha).toMatch(/^[0-9a-f]{7,12}$/);
+      expect(() => new Date(pr.date).toISOString()).not.toThrow();
+    }
+    if (prs.length >= 2) {
+      const t0 = new Date(prs[0]!.date).getTime();
+      const t1 = new Date(prs[1]!.date).getTime();
+      expect(t0).toBeGreaterThanOrEqual(t1);
+    }
+  });
+});
+
+describe('temp dir cleanup safety', () => {
+  // Smoke test: verify rmSync pattern from earlier tests does not leak.
+  let tmp: string;
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-mcp-cleanup-'));
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+  it('temp dir exists inside the test', () => {
+    expect(fs.existsSync(tmp)).toBe(true);
+  });
+});

--- a/packages/mcp/src/state-extractors.test.ts
+++ b/packages/mcp/src/state-extractors.test.ts
@@ -32,9 +32,15 @@ describe('extractGitState', () => {
     }
   });
 
-  it('returns current branch and staged/unstaged files on the live repo', () => {
+  it('returns branch (or null on detached HEAD) and staged/unstaged files on the live repo', () => {
     const state = extractGitState(REPO_ROOT);
-    expect(state.branch).toBeTypeOf('string');
+    // GitHub Actions checks out the merge commit in detached HEAD, so branch
+    // legitimately resolves to null there. Locally it is a string. Either is
+    // valid; the important invariant is that the call does not throw.
+    if (state.branch !== null) {
+      expect(state.branch).toBeTypeOf('string');
+      expect(state.branch.length).toBeGreaterThan(0);
+    }
     expect(state.uncommittedFiles.length).toBeLessThanOrEqual(UNCOMMITTED_FILES_CAP);
     // If a truncation happened the cap must be hit exactly.
     if (state.truncated) {

--- a/packages/mcp/src/state-extractors.ts
+++ b/packages/mcp/src/state-extractors.ts
@@ -154,7 +154,7 @@ export function extractRuleCounts(cwd: string, totemDir: string): RuleCounts {
     let active = 0;
     let archived = 0;
     for (const rule of parsed.rules) {
-      if ((rule as { status?: string }).status === 'archived') archived += 1;
+      if (rule.status === 'archived') archived += 1;
       else active += 1;
     }
     return {

--- a/packages/mcp/src/state-extractors.ts
+++ b/packages/mcp/src/state-extractors.ts
@@ -121,10 +121,14 @@ export function extractPackageVersions(cwd: string): Record<string, string> {
   for (const subdir of subdirs) {
     const pkgJson = path.join(packagesDir, subdir, 'package.json');
     try {
-      const parsed = readJsonSafe<{ name?: string; version?: string }>(pkgJson);
+      const parsed = readJsonSafe<{ name?: unknown; version?: unknown }>(pkgJson);
+      // readJsonSafe types the shape but does not enforce runtime invariants.
+      // A hand-edited package.json with a numeric version or non-string name
+      // would otherwise leak a malformed value into the response (CR catch on
+      // #1506).
       if (
-        parsed.name !== undefined &&
-        parsed.version !== undefined &&
+        typeof parsed.name === 'string' &&
+        typeof parsed.version === 'string' &&
         (FIXED_GROUP_PACKAGES as readonly string[]).includes(parsed.name)
       ) {
         result[parsed.name] = parsed.version;
@@ -245,11 +249,21 @@ export function extractTestCount(_cwd: string): number | null {
 export function extractRecentPrs(cwd: string, limit = RECENT_PRS_COUNT): RecentPr[] {
   if (resolveGitRoot(cwd) === null) return [];
 
+  // Unit separator (0x1f) is ASCII-reserved for field delimiting and never
+  // appears in commit subjects, unlike `|` which GCA flagged on #1506 as a
+  // correctness risk since commit messages routinely contain pipes.
+  const FIELD_SEP = '\x1f';
   let raw: string;
   try {
     raw = safeExec(
       'git',
-      ['log', `-n`, String(limit * 3), '--grep=#[0-9]\\+', '--format=%s|%cI|%h'],
+      [
+        'log',
+        '-n',
+        String(limit * 3),
+        '--grep=#[0-9]\\+',
+        `--format=%s${FIELD_SEP}%cI${FIELD_SEP}%h`,
+      ],
       { cwd },
     );
     // totem-context: ADR-090 substrate graceful degradation — empty list on git-log failure.
@@ -260,7 +274,7 @@ export function extractRecentPrs(cwd: string, limit = RECENT_PRS_COUNT): RecentP
 
   const results: RecentPr[] = [];
   for (const line of raw.split(/\r?\n/)) {
-    const [title, date, squashSha] = line.split('|');
+    const [title, date, squashSha] = line.split(FIELD_SEP);
     if (
       title === undefined ||
       date === undefined ||

--- a/packages/mcp/src/state-extractors.ts
+++ b/packages/mcp/src/state-extractors.ts
@@ -41,16 +41,15 @@ export function extractGitState(cwd: string): GitState {
   }
 
   let branch: string | null = null;
-  // totem-context: ADR-090 substrate graceful degradation — partial payload over crash.
   try {
     const out = safeExec('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd });
     branch = out === 'HEAD' ? null : out;
+    // totem-context: ADR-090 substrate graceful degradation — partial payload over crash.
   } catch {
     branch = null;
   }
 
   let allFiles: string[] = [];
-  // totem-context: ADR-090 substrate graceful degradation — empty file list on git-status failure.
   try {
     const porcelain = safeExec('git', ['status', '--porcelain'], { cwd });
     if (porcelain.length > 0) {
@@ -59,6 +58,7 @@ export function extractGitState(cwd: string): GitState {
         .map((line) => line.slice(3).trim())
         .filter((name) => name.length > 0);
     }
+    // totem-context: ADR-090 substrate graceful degradation — empty file list on git-status failure.
   } catch {
     allFiles = [];
   }
@@ -77,16 +77,15 @@ export function extractStrategyPointer(cwd: string): StrategyPointer {
   }
 
   let sha: string | null = null;
-  // totem-context: ADR-090 substrate graceful degradation — null sha on uninitialized submodule.
   try {
     const full = safeExec('git', ['rev-parse', 'HEAD'], { cwd: strategyDir });
     sha = full.length >= 7 ? full.slice(0, 7) : null;
+    // totem-context: ADR-090 substrate graceful degradation — null sha on uninitialized submodule.
   } catch {
     sha = null;
   }
 
   let latestJournal: string | null = null;
-  // totem-context: ADR-090 substrate graceful degradation — null when .journal/ unreachable.
   try {
     const journalDir = path.join(strategyDir, '.journal');
     if (fs.existsSync(journalDir)) {
@@ -96,6 +95,7 @@ export function extractStrategyPointer(cwd: string): StrategyPointer {
         .sort();
       latestJournal = entries.length > 0 ? entries[entries.length - 1]! : null;
     }
+    // totem-context: ADR-090 substrate graceful degradation — null when .journal/ unreachable.
   } catch {
     latestJournal = null;
   }
@@ -111,16 +111,15 @@ export function extractPackageVersions(cwd: string): Record<string, string> {
   if (!fs.existsSync(packagesDir)) return result;
 
   let subdirs: string[];
-  // totem-context: ADR-090 substrate graceful degradation — empty map on unreadable packages/.
   try {
     subdirs = fs.readdirSync(packagesDir);
+    // totem-context: ADR-090 substrate graceful degradation — empty map on unreadable packages/.
   } catch {
     return result;
   }
 
   for (const subdir of subdirs) {
     const pkgJson = path.join(packagesDir, subdir, 'package.json');
-    // totem-context: ADR-090 substrate graceful degradation — per-package skip on parse failure.
     try {
       const parsed = readJsonSafe<{ name?: string; version?: string }>(pkgJson);
       if (
@@ -130,6 +129,7 @@ export function extractPackageVersions(cwd: string): Record<string, string> {
       ) {
         result[parsed.name] = parsed.version;
       }
+      // totem-context: ADR-090 substrate graceful degradation — per-package skip on parse failure.
     } catch {
       // Missing / unparseable package.json is a non-fatal skip.
     }
@@ -145,7 +145,6 @@ export function extractRuleCounts(cwd: string, totemDir: string): RuleCounts {
     return { active: 0, archived: 0, nonCompilable: 0 };
   }
 
-  // totem-context: ADR-090 substrate graceful degradation — zero counts on malformed manifest.
   try {
     const parsed = readJsonSafe(rulesPath, CompiledRulesFileSchema);
     let active = 0;
@@ -159,6 +158,7 @@ export function extractRuleCounts(cwd: string, totemDir: string): RuleCounts {
       archived,
       nonCompilable: parsed.nonCompilable?.length ?? 0,
     };
+    // totem-context: ADR-090 substrate graceful degradation — zero counts on malformed manifest.
   } catch {
     return { active: 0, archived: 0, nonCompilable: 0 };
   }
@@ -169,9 +169,9 @@ export function extractRuleCounts(cwd: string, totemDir: string): RuleCounts {
 export function extractLessonCount(cwd: string, totemDir: string): number {
   const lessonsDir = path.join(cwd, totemDir, 'lessons');
   if (!fs.existsSync(lessonsDir)) return 0;
-  // totem-context: ADR-090 substrate graceful degradation — zero count on unreadable lessons/.
   try {
     return fs.readdirSync(lessonsDir).filter((f) => f.endsWith('.md')).length;
+    // totem-context: ADR-090 substrate graceful degradation — zero count on unreadable lessons/.
   } catch {
     return 0;
   }
@@ -193,9 +193,9 @@ export function extractMilestoneState(cwd: string): MilestoneState {
   }
 
   let content: string;
-  // totem-context: ADR-090 substrate graceful degradation + intentional unstaged-disk read.
   try {
     content = fs.readFileSync(activeWorkPath, 'utf-8');
+    // totem-context: ADR-090 substrate graceful degradation + intentional unstaged-disk read.
   } catch {
     return { name: null, gateTickets: [], bestEffort: true };
   }
@@ -246,13 +246,13 @@ export function extractRecentPrs(cwd: string, limit = RECENT_PRS_COUNT): RecentP
   if (resolveGitRoot(cwd) === null) return [];
 
   let raw: string;
-  // totem-context: ADR-090 substrate graceful degradation — empty list on git-log failure.
   try {
     raw = safeExec(
       'git',
       ['log', `-n`, String(limit * 3), '--grep=#[0-9]\\+', '--format=%s|%cI|%h'],
       { cwd },
     );
+    // totem-context: ADR-090 substrate graceful degradation — empty list on git-log failure.
   } catch {
     return [];
   }

--- a/packages/mcp/src/state-extractors.ts
+++ b/packages/mcp/src/state-extractors.ts
@@ -41,8 +41,7 @@ export function extractGitState(cwd: string): GitState {
   }
 
   let branch: string | null = null;
-  // totem-context: substrate graceful degradation per ADR-090 — if git fails we
-  // still want to return a partial payload instead of crashing the MCP server.
+  // totem-context: ADR-090 substrate graceful degradation — partial payload over crash.
   try {
     const out = safeExec('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd });
     branch = out === 'HEAD' ? null : out;
@@ -51,8 +50,7 @@ export function extractGitState(cwd: string): GitState {
   }
 
   let allFiles: string[] = [];
-  // totem-context: substrate graceful degradation per ADR-090 — git status
-  // failure yields an empty file list, not an exception.
+  // totem-context: ADR-090 substrate graceful degradation — empty file list on git-status failure.
   try {
     const porcelain = safeExec('git', ['status', '--porcelain'], { cwd });
     if (porcelain.length > 0) {
@@ -79,8 +77,7 @@ export function extractStrategyPointer(cwd: string): StrategyPointer {
   }
 
   let sha: string | null = null;
-  // totem-context: substrate graceful degradation per ADR-090 — submodule may
-  // be uninitialized; null pointer is a valid payload shape.
+  // totem-context: ADR-090 substrate graceful degradation — null sha on uninitialized submodule.
   try {
     const full = safeExec('git', ['rev-parse', 'HEAD'], { cwd: strategyDir });
     sha = full.length >= 7 ? full.slice(0, 7) : null;
@@ -89,8 +86,7 @@ export function extractStrategyPointer(cwd: string): StrategyPointer {
   }
 
   let latestJournal: string | null = null;
-  // totem-context: substrate graceful degradation per ADR-090 — a missing
-  // .journal/ directory is non-fatal; null is the documented fallback.
+  // totem-context: ADR-090 substrate graceful degradation — null when .journal/ unreachable.
   try {
     const journalDir = path.join(strategyDir, '.journal');
     if (fs.existsSync(journalDir)) {
@@ -115,8 +111,7 @@ export function extractPackageVersions(cwd: string): Record<string, string> {
   if (!fs.existsSync(packagesDir)) return result;
 
   let subdirs: string[];
-  // totem-context: substrate graceful degradation per ADR-090 — unreadable
-  // packages/ yields an empty version map, not a crash.
+  // totem-context: ADR-090 substrate graceful degradation — empty map on unreadable packages/.
   try {
     subdirs = fs.readdirSync(packagesDir);
   } catch {
@@ -125,8 +120,7 @@ export function extractPackageVersions(cwd: string): Record<string, string> {
 
   for (const subdir of subdirs) {
     const pkgJson = path.join(packagesDir, subdir, 'package.json');
-    // totem-context: substrate graceful degradation per ADR-090 — per-package
-    // parse failures skip that one package, the rest still report.
+    // totem-context: ADR-090 substrate graceful degradation — per-package skip on parse failure.
     try {
       const parsed = readJsonSafe<{ name?: string; version?: string }>(pkgJson);
       if (
@@ -151,8 +145,7 @@ export function extractRuleCounts(cwd: string, totemDir: string): RuleCounts {
     return { active: 0, archived: 0, nonCompilable: 0 };
   }
 
-  // totem-context: substrate graceful degradation per ADR-090 — malformed or
-  // missing compile-rules manifest yields zero counts rather than a crash.
+  // totem-context: ADR-090 substrate graceful degradation — zero counts on malformed manifest.
   try {
     const parsed = readJsonSafe(rulesPath, CompiledRulesFileSchema);
     let active = 0;
@@ -176,8 +169,7 @@ export function extractRuleCounts(cwd: string, totemDir: string): RuleCounts {
 export function extractLessonCount(cwd: string, totemDir: string): number {
   const lessonsDir = path.join(cwd, totemDir, 'lessons');
   if (!fs.existsSync(lessonsDir)) return 0;
-  // totem-context: substrate graceful degradation per ADR-090 — unreadable
-  // lessons directory returns zero; agents see the missing signal explicitly.
+  // totem-context: ADR-090 substrate graceful degradation — zero count on unreadable lessons/.
   try {
     return fs.readdirSync(lessonsDir).filter((f) => f.endsWith('.md')).length;
   } catch {
@@ -194,28 +186,23 @@ export function extractLessonCount(cwd: string, totemDir: string): number {
  * ground-truth source.
  */
 export function extractMilestoneState(cwd: string): MilestoneState {
-  // totem-context: `docs/active_work.md` is the canonical briefing-source path
-  // documented in ADR-090 and the #1497 spec; hardcoding is intentional, not
-  // a config omission.
+  // totem-context: ADR-090 + #1497 canonical briefing-source path, not a config omission.
   const activeWorkPath = path.join(cwd, 'docs', 'active_work.md');
   if (!fs.existsSync(activeWorkPath)) {
     return { name: null, gateTickets: [], bestEffort: true };
   }
 
   let content: string;
-  // totem-context: substrate graceful degradation per ADR-090 — and substrate
-  // reads the unstaged disk version on purpose (the briefing reports the
-  // current working-copy state of the doc, not the git-indexed version).
+  // totem-context: ADR-090 substrate graceful degradation + intentional unstaged-disk read.
   try {
     content = fs.readFileSync(activeWorkPath, 'utf-8');
   } catch {
     return { name: null, gateTickets: [], bestEffort: true };
   }
 
-  // Milestone: first "### Current: X.Y.Z" heading (e.g. "### Current: 1.15.0 — The Distribution Pipeline").
-  // totem-context: single-match by design — the doc has exactly one Current heading;
-  // matchAll would obscure that invariant.
+  // Milestone: first "### Current: X.Y.Z" heading (the doc has exactly one).
   let name: string | null = null;
+  // totem-context: single-match by design — one Current heading; matchAll would obscure intent.
   const currentMatch = content.match(/^###\s+Current:\s*(\d+\.\d+\.\d+)/m);
   if (currentMatch?.[1] !== undefined) name = currentMatch[1];
 
@@ -259,8 +246,7 @@ export function extractRecentPrs(cwd: string, limit = RECENT_PRS_COUNT): RecentP
   if (resolveGitRoot(cwd) === null) return [];
 
   let raw: string;
-  // totem-context: substrate graceful degradation per ADR-090 — git log
-  // failure (no history, permission) yields an empty recent-PRs list.
+  // totem-context: ADR-090 substrate graceful degradation — empty list on git-log failure.
   try {
     raw = safeExec(
       'git',

--- a/packages/mcp/src/state-extractors.ts
+++ b/packages/mcp/src/state-extractors.ts
@@ -41,6 +41,8 @@ export function extractGitState(cwd: string): GitState {
   }
 
   let branch: string | null = null;
+  // totem-context: substrate graceful degradation per ADR-090 — if git fails we
+  // still want to return a partial payload instead of crashing the MCP server.
   try {
     const out = safeExec('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd });
     branch = out === 'HEAD' ? null : out;
@@ -49,6 +51,8 @@ export function extractGitState(cwd: string): GitState {
   }
 
   let allFiles: string[] = [];
+  // totem-context: substrate graceful degradation per ADR-090 — git status
+  // failure yields an empty file list, not an exception.
   try {
     const porcelain = safeExec('git', ['status', '--porcelain'], { cwd });
     if (porcelain.length > 0) {
@@ -75,6 +79,8 @@ export function extractStrategyPointer(cwd: string): StrategyPointer {
   }
 
   let sha: string | null = null;
+  // totem-context: substrate graceful degradation per ADR-090 — submodule may
+  // be uninitialized; null pointer is a valid payload shape.
   try {
     const full = safeExec('git', ['rev-parse', 'HEAD'], { cwd: strategyDir });
     sha = full.length >= 7 ? full.slice(0, 7) : null;
@@ -83,6 +89,8 @@ export function extractStrategyPointer(cwd: string): StrategyPointer {
   }
 
   let latestJournal: string | null = null;
+  // totem-context: substrate graceful degradation per ADR-090 — a missing
+  // .journal/ directory is non-fatal; null is the documented fallback.
   try {
     const journalDir = path.join(strategyDir, '.journal');
     if (fs.existsSync(journalDir)) {
@@ -107,6 +115,8 @@ export function extractPackageVersions(cwd: string): Record<string, string> {
   if (!fs.existsSync(packagesDir)) return result;
 
   let subdirs: string[];
+  // totem-context: substrate graceful degradation per ADR-090 — unreadable
+  // packages/ yields an empty version map, not a crash.
   try {
     subdirs = fs.readdirSync(packagesDir);
   } catch {
@@ -115,6 +125,8 @@ export function extractPackageVersions(cwd: string): Record<string, string> {
 
   for (const subdir of subdirs) {
     const pkgJson = path.join(packagesDir, subdir, 'package.json');
+    // totem-context: substrate graceful degradation per ADR-090 — per-package
+    // parse failures skip that one package, the rest still report.
     try {
       const parsed = readJsonSafe<{ name?: string; version?: string }>(pkgJson);
       if (
@@ -139,6 +151,8 @@ export function extractRuleCounts(cwd: string, totemDir: string): RuleCounts {
     return { active: 0, archived: 0, nonCompilable: 0 };
   }
 
+  // totem-context: substrate graceful degradation per ADR-090 — malformed or
+  // missing compile-rules manifest yields zero counts rather than a crash.
   try {
     const parsed = readJsonSafe(rulesPath, CompiledRulesFileSchema);
     let active = 0;
@@ -162,6 +176,8 @@ export function extractRuleCounts(cwd: string, totemDir: string): RuleCounts {
 export function extractLessonCount(cwd: string, totemDir: string): number {
   const lessonsDir = path.join(cwd, totemDir, 'lessons');
   if (!fs.existsSync(lessonsDir)) return 0;
+  // totem-context: substrate graceful degradation per ADR-090 — unreadable
+  // lessons directory returns zero; agents see the missing signal explicitly.
   try {
     return fs.readdirSync(lessonsDir).filter((f) => f.endsWith('.md')).length;
   } catch {
@@ -178,12 +194,18 @@ export function extractLessonCount(cwd: string, totemDir: string): number {
  * ground-truth source.
  */
 export function extractMilestoneState(cwd: string): MilestoneState {
+  // totem-context: `docs/active_work.md` is the canonical briefing-source path
+  // documented in ADR-090 and the #1497 spec; hardcoding is intentional, not
+  // a config omission.
   const activeWorkPath = path.join(cwd, 'docs', 'active_work.md');
   if (!fs.existsSync(activeWorkPath)) {
     return { name: null, gateTickets: [], bestEffort: true };
   }
 
   let content: string;
+  // totem-context: substrate graceful degradation per ADR-090 — and substrate
+  // reads the unstaged disk version on purpose (the briefing reports the
+  // current working-copy state of the doc, not the git-indexed version).
   try {
     content = fs.readFileSync(activeWorkPath, 'utf-8');
   } catch {
@@ -191,6 +213,8 @@ export function extractMilestoneState(cwd: string): MilestoneState {
   }
 
   // Milestone: first "### Current: X.Y.Z" heading (e.g. "### Current: 1.15.0 — The Distribution Pipeline").
+  // totem-context: single-match by design — the doc has exactly one Current heading;
+  // matchAll would obscure that invariant.
   let name: string | null = null;
   const currentMatch = content.match(/^###\s+Current:\s*(\d+\.\d+\.\d+)/m);
   if (currentMatch?.[1] !== undefined) name = currentMatch[1];
@@ -235,6 +259,8 @@ export function extractRecentPrs(cwd: string, limit = RECENT_PRS_COUNT): RecentP
   if (resolveGitRoot(cwd) === null) return [];
 
   let raw: string;
+  // totem-context: substrate graceful degradation per ADR-090 — git log
+  // failure (no history, permission) yields an empty recent-PRs list.
   try {
     raw = safeExec(
       'git',

--- a/packages/mcp/src/state-extractors.ts
+++ b/packages/mcp/src/state-extractors.ts
@@ -1,0 +1,264 @@
+/**
+ * State extractors for the rich `describe_project` payload.
+ *
+ * Each extractor reads from local git, filesystem, or stored-state files and
+ * returns its schema shape. On missing source files or non-zero git exit,
+ * extractors degrade gracefully (null / 0 / []) rather than throwing, so the
+ * MCP handler can compose a partial payload instead of crashing.
+ *
+ * ADR-090 substrate invariant: no LLM calls, no live npm/github registry
+ * calls. Every function reads only from disk or local git state.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { CompiledRulesFileSchema, readJsonSafe, resolveGitRoot, safeExec } from '@mmnto/totem';
+
+import {
+  type GitState,
+  type MilestoneState,
+  RECENT_PRS_COUNT,
+  type RecentPr,
+  type RuleCounts,
+  type StrategyPointer,
+  UNCOMMITTED_FILES_CAP,
+} from './schemas/describe-project.js';
+
+/** Fixed-group package names whose versions show in the briefing. */
+const FIXED_GROUP_PACKAGES = [
+  '@mmnto/totem',
+  '@mmnto/cli',
+  '@mmnto/mcp',
+  '@totem/pack-agent-security',
+] as const;
+
+// ─── Git state ─────────────────────────────────────────────────────────────
+
+export function extractGitState(cwd: string): GitState {
+  if (resolveGitRoot(cwd) === null) {
+    return { branch: null, uncommittedFiles: [], truncated: false };
+  }
+
+  let branch: string | null = null;
+  try {
+    const out = safeExec('git', ['rev-parse', '--abbrev-ref', 'HEAD'], { cwd });
+    branch = out === 'HEAD' ? null : out;
+  } catch {
+    branch = null;
+  }
+
+  let allFiles: string[] = [];
+  try {
+    const porcelain = safeExec('git', ['status', '--porcelain'], { cwd });
+    if (porcelain.length > 0) {
+      allFiles = porcelain
+        .split(/\r?\n/)
+        .map((line) => line.slice(3).trim())
+        .filter((name) => name.length > 0);
+    }
+  } catch {
+    allFiles = [];
+  }
+
+  const truncated = allFiles.length > UNCOMMITTED_FILES_CAP;
+  const uncommittedFiles = truncated ? allFiles.slice(0, UNCOMMITTED_FILES_CAP) : allFiles;
+  return { branch, uncommittedFiles, truncated };
+}
+
+// ─── Strategy submodule pointer ────────────────────────────────────────────
+
+export function extractStrategyPointer(cwd: string): StrategyPointer {
+  const strategyDir = path.join(cwd, '.strategy');
+  if (!fs.existsSync(strategyDir)) {
+    return { sha: null, latestJournal: null };
+  }
+
+  let sha: string | null = null;
+  try {
+    const full = safeExec('git', ['rev-parse', 'HEAD'], { cwd: strategyDir });
+    sha = full.length >= 7 ? full.slice(0, 7) : null;
+  } catch {
+    sha = null;
+  }
+
+  let latestJournal: string | null = null;
+  try {
+    const journalDir = path.join(strategyDir, '.journal');
+    if (fs.existsSync(journalDir)) {
+      const entries = fs
+        .readdirSync(journalDir)
+        .filter((f) => f.endsWith('.md'))
+        .sort();
+      latestJournal = entries.length > 0 ? entries[entries.length - 1]! : null;
+    }
+  } catch {
+    latestJournal = null;
+  }
+
+  return { sha, latestJournal };
+}
+
+// ─── Package versions (fixed group only) ───────────────────────────────────
+
+export function extractPackageVersions(cwd: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  const packagesDir = path.join(cwd, 'packages');
+  if (!fs.existsSync(packagesDir)) return result;
+
+  let subdirs: string[];
+  try {
+    subdirs = fs.readdirSync(packagesDir);
+  } catch {
+    return result;
+  }
+
+  for (const subdir of subdirs) {
+    const pkgJson = path.join(packagesDir, subdir, 'package.json');
+    try {
+      const parsed = readJsonSafe<{ name?: string; version?: string }>(pkgJson);
+      if (
+        parsed.name !== undefined &&
+        parsed.version !== undefined &&
+        (FIXED_GROUP_PACKAGES as readonly string[]).includes(parsed.name)
+      ) {
+        result[parsed.name] = parsed.version;
+      }
+    } catch {
+      // Missing / unparseable package.json is a non-fatal skip.
+    }
+  }
+  return result;
+}
+
+// ─── Rule counts from .totem/compiled-rules.json ───────────────────────────
+
+export function extractRuleCounts(cwd: string, totemDir: string): RuleCounts {
+  const rulesPath = path.join(cwd, totemDir, 'compiled-rules.json');
+  if (!fs.existsSync(rulesPath)) {
+    return { active: 0, archived: 0, nonCompilable: 0 };
+  }
+
+  try {
+    const parsed = readJsonSafe(rulesPath, CompiledRulesFileSchema);
+    let active = 0;
+    let archived = 0;
+    for (const rule of parsed.rules) {
+      if ((rule as { status?: string }).status === 'archived') archived += 1;
+      else active += 1;
+    }
+    return {
+      active,
+      archived,
+      nonCompilable: parsed.nonCompilable?.length ?? 0,
+    };
+  } catch {
+    return { active: 0, archived: 0, nonCompilable: 0 };
+  }
+}
+
+// ─── Lesson count ──────────────────────────────────────────────────────────
+
+export function extractLessonCount(cwd: string, totemDir: string): number {
+  const lessonsDir = path.join(cwd, totemDir, 'lessons');
+  if (!fs.existsSync(lessonsDir)) return 0;
+  try {
+    return fs.readdirSync(lessonsDir).filter((f) => f.endsWith('.md')).length;
+  } catch {
+    return 0;
+  }
+}
+
+// ─── Milestone + gate tickets from docs/active_work.md ─────────────────────
+
+/**
+ * Regex-parse the milestone name and gate-ticket list from active_work.md.
+ * This is explicitly best-effort — the markdown format can drift.
+ * `bestEffort: true` signals to agents that the values are a hint, not a
+ * ground-truth source.
+ */
+export function extractMilestoneState(cwd: string): MilestoneState {
+  const activeWorkPath = path.join(cwd, 'docs', 'active_work.md');
+  if (!fs.existsSync(activeWorkPath)) {
+    return { name: null, gateTickets: [], bestEffort: true };
+  }
+
+  let content: string;
+  try {
+    content = fs.readFileSync(activeWorkPath, 'utf-8');
+  } catch {
+    return { name: null, gateTickets: [], bestEffort: true };
+  }
+
+  // Milestone: first "### Current: X.Y.Z" heading (e.g. "### Current: 1.15.0 — The Distribution Pipeline").
+  let name: string | null = null;
+  const currentMatch = content.match(/^###\s+Current:\s*(\d+\.\d+\.\d+)/m);
+  if (currentMatch?.[1] !== undefined) name = currentMatch[1];
+
+  // Gate tickets: unique `#NNNN` refs inside code spans across the doc body.
+  // The lint-rule registry carries lesson hashes with similar `#` prefixes, so
+  // require 3-5 digits and cap at 200 entries to keep the payload tight.
+  const tickets = new Set<string>();
+  const ticketRe = /#(\d{3,5})\b/g;
+  for (const match of content.matchAll(ticketRe)) {
+    tickets.add(`#${match[1]}`);
+    if (tickets.size >= 200) break;
+  }
+
+  return {
+    name,
+    gateTickets: Array.from(tickets),
+    bestEffort: true,
+  };
+}
+
+// ─── Test count (v1: always null) ──────────────────────────────────────────
+
+/**
+ * Stored test-count artifact does not exist in v1. Follow-up ticket wires
+ * postmerge to stamp `.totem/store/test-stats.json` after `pnpm test` runs;
+ * until then the endpoint reports null honestly rather than fabricate a
+ * number.
+ */
+export function extractTestCount(_cwd: string): number | null {
+  return null;
+}
+
+// ─── Recent merged PRs from git log ────────────────────────────────────────
+
+/**
+ * Capture squash-merge commits whose subject references a PR number
+ * (`... (#NNNN)`). Skips commits whose message lacks a PR tag so we do not
+ * include non-PR merges like the Version Packages auto-commit in some flows.
+ */
+export function extractRecentPrs(cwd: string, limit = RECENT_PRS_COUNT): RecentPr[] {
+  if (resolveGitRoot(cwd) === null) return [];
+
+  let raw: string;
+  try {
+    raw = safeExec(
+      'git',
+      ['log', `-n`, String(limit * 3), '--grep=#[0-9]\\+', '--format=%s|%cI|%h'],
+      { cwd },
+    );
+  } catch {
+    return [];
+  }
+  if (raw.length === 0) return [];
+
+  const results: RecentPr[] = [];
+  for (const line of raw.split(/\r?\n/)) {
+    const [title, date, squashSha] = line.split('|');
+    if (
+      title === undefined ||
+      date === undefined ||
+      squashSha === undefined ||
+      !/#\d+/.test(title)
+    ) {
+      continue;
+    }
+    results.push({ title, date, squashSha });
+    if (results.length >= limit) break;
+  }
+  return results;
+}

--- a/packages/mcp/src/tools/describe-project.test.ts
+++ b/packages/mcp/src/tools/describe-project.test.ts
@@ -28,6 +28,13 @@ vi.mock('@mmnto/totem', () => ({
   TotemError: class extends Error {
     recoveryHint?: string;
   },
+  // Stubs used by state-extractors (imported transitively via the tool).
+  resolveGitRoot: () => null,
+  safeExec: () => '',
+  readJsonSafe: () => {
+    throw new Error('mock readJsonSafe: no file in test context');
+  },
+  CompiledRulesFileSchema: { parse: (v: unknown) => v },
 }));
 
 let contextError: Error | null = null;
@@ -114,5 +121,62 @@ describe('describe_project MCP tool', () => {
     } finally {
       process.cwd = originalCwd;
     }
+  });
+
+  it('omits richState when includeRichState is false (default)', async () => {
+    const server = fakeServer();
+    registerDescribeProject(server as never);
+
+    const result = (await capturedHandler({})) as { content: { text: string }[] };
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed.richState).toBeUndefined();
+    // Legacy shape preserved byte-by-byte when richState is absent.
+    expect(parsed).toEqual({
+      project: 'test-project',
+      description: 'A test project',
+      tier: 'standard',
+      rules: 10,
+      lessons: 5,
+      targets: ['**/*.ts (code/typescript-ast)'],
+      partitions: { core: ['packages/core/'] },
+      hooks: ['pre-push'],
+    });
+  });
+
+  it('omits richState when includeRichState is explicitly false', async () => {
+    const server = fakeServer();
+    registerDescribeProject(server as never);
+
+    const result = (await capturedHandler({ includeRichState: false })) as {
+      content: { text: string }[];
+    };
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed.richState).toBeUndefined();
+  });
+
+  it('attaches richState when includeRichState is true', async () => {
+    const server = fakeServer();
+    registerDescribeProject(server as never);
+
+    const result = (await capturedHandler({ includeRichState: true })) as {
+      content: { text: string }[];
+    };
+    const parsed = JSON.parse(result.content[0]!.text);
+    expect(parsed.richState).toBeDefined();
+    // Legacy fields remain attached alongside richState.
+    expect(parsed.project).toBe('test-project');
+    // Rich-state contract: every documented section is present (even if null/zero/empty).
+    expect(parsed.richState).toHaveProperty('strategyPointer');
+    expect(parsed.richState).toHaveProperty('gitState');
+    expect(parsed.richState).toHaveProperty('packageVersions');
+    expect(parsed.richState).toHaveProperty('ruleCounts');
+    expect(parsed.richState).toHaveProperty('lessonCount');
+    expect(parsed.richState).toHaveProperty('testCount');
+    expect(parsed.richState).toHaveProperty('milestone');
+    expect(parsed.richState).toHaveProperty('recentPrs');
+    // testCount pinned to null for v1.
+    expect(parsed.richState.testCount).toBeNull();
+    // milestone.bestEffort pinned to true.
+    expect(parsed.richState.milestone.bestEffort).toBe(true);
   });
 });

--- a/packages/mcp/src/tools/describe-project.test.ts
+++ b/packages/mcp/src/tools/describe-project.test.ts
@@ -32,7 +32,9 @@ vi.mock('@mmnto/totem', () => ({
   resolveGitRoot: () => null,
   safeExec: () => '',
   readJsonSafe: () => {
-    throw new Error('mock readJsonSafe: no file in test context');
+    // Prefixed to match Totem's error convention so the lint rule does not
+    // flag this mock throw.
+    throw new Error('[Totem Error] mock readJsonSafe: no file in test context');
   },
   CompiledRulesFileSchema: { parse: (v: unknown) => v },
 }));

--- a/packages/mcp/src/tools/describe-project.ts
+++ b/packages/mcp/src/tools/describe-project.ts
@@ -1,14 +1,38 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
 
-import { CONFIG_FILES, describeProject, TotemConfigSchema, TotemError } from '@mmnto/totem';
+import {
+  CONFIG_FILES,
+  describeProject,
+  type ProjectDescription,
+  TotemConfigSchema,
+  TotemError,
+} from '@mmnto/totem';
 
 import { getContext } from '../context.js';
+import { type DescribeProjectOutput, type RichProjectState } from '../schemas/describe-project.js';
+import {
+  extractGitState,
+  extractLessonCount,
+  extractMilestoneState,
+  extractPackageVersions,
+  extractRecentPrs,
+  extractRuleCounts,
+  extractStrategyPointer,
+  extractTestCount,
+} from '../state-extractors.js';
+
+interface LegacyContext {
+  legacy: ProjectDescription;
+  projectRoot: string;
+  totemDir: string;
+}
 
 /**
  * Lightweight config loader for describe — avoids requiring embedder.
  * Falls back to getContext() if available, otherwise loads config directly.
  */
-async function getDescriptionFromContext() {
+async function getLegacyContext(): Promise<LegacyContext> {
   const path = await import('node:path');
   const fs = await import('node:fs');
   const projectRoot = process.cwd();
@@ -18,7 +42,11 @@ async function getDescriptionFromContext() {
   // we intentionally swallow the error and fall back to direct config load.
   try {
     const ctx = await getContext();
-    return describeProject(ctx.config, ctx.projectRoot);
+    return {
+      legacy: describeProject(ctx.config, ctx.projectRoot),
+      projectRoot: ctx.projectRoot,
+      totemDir: ctx.config.totemDir,
+    };
   } catch {
     // Expected on Lite tier — fall through to direct config load
   }
@@ -52,8 +80,26 @@ async function getDescriptionFromContext() {
   const mod = (await jiti.import(configPath)) as Record<string, unknown>;
   const raw = mod['default'] ?? mod;
   const config = TotemConfigSchema.parse(raw);
+  const configRoot = path.dirname(configPath);
 
-  return describeProject(config, path.dirname(configPath));
+  return {
+    legacy: describeProject(config, configRoot),
+    projectRoot: configRoot,
+    totemDir: config.totemDir,
+  };
+}
+
+function buildRichState(projectRoot: string, totemDir: string): RichProjectState {
+  return {
+    strategyPointer: extractStrategyPointer(projectRoot),
+    gitState: extractGitState(projectRoot),
+    packageVersions: extractPackageVersions(projectRoot),
+    ruleCounts: extractRuleCounts(projectRoot, totemDir),
+    lessonCount: extractLessonCount(projectRoot, totemDir),
+    testCount: extractTestCount(projectRoot),
+    milestone: extractMilestoneState(projectRoot),
+    recentPrs: extractRecentPrs(projectRoot),
+  };
 }
 
 export function registerDescribeProject(server: McpServer): void {
@@ -61,17 +107,26 @@ export function registerDescribeProject(server: McpServer): void {
     'describe_project',
     {
       description:
-        'Returns a structured JSON summary of the project governance scope: rules, lessons, config tier, partitions, targets, and hooks. Fast, deterministic, no LLM required.',
-      inputSchema: {},
+        'Returns a structured JSON summary of the project governance scope: rules, lessons, config tier, partitions, targets, and hooks. Pass `includeRichState: true` to append a session-briefing payload (git state, strategy pointer, package versions, rule/lesson counts, milestone, recent PRs). Fast, deterministic, no LLM required.',
+      // totem-context: MCP SDK's registerTool accepts a Zod raw shape, not a
+      // JSON Schema object. This matches the convention already used in
+      // search-knowledge.ts and add-lesson.ts. The SDK converts the shape to
+      // JSON Schema internally before exposing the tool to clients.
+      inputSchema: {
+        includeRichState: z.boolean().optional(),
+      },
       annotations: {
         readOnlyHint: true,
       },
     },
-    async () => {
+    async (args: { includeRichState?: boolean }) => {
       try {
-        const result = await getDescriptionFromContext();
+        const { legacy, projectRoot, totemDir } = await getLegacyContext();
+        const output: DescribeProjectOutput = args.includeRichState
+          ? { ...legacy, richState: buildRichState(projectRoot, totemDir) }
+          : { ...legacy };
         return {
-          content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }],
+          content: [{ type: 'text' as const, text: JSON.stringify(output, null, 2) }],
         };
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
## Mechanical Root Cause

`mcp__totem-dev__describe_project()` returned a slim shape (project, tier, rules, lessons, targets, partitions, hooks) that forced every incoming agent to reconstruct the rest of the briefing from separate tool calls and file reads. A typical session-start briefing costs ~5 tool calls (`MEMORY.md`, `docs/active_work.md`, latest journal, `git status`, `git log`). Across every agent session that cost compounds into the "handoff fatigue" discussed during the 2026-04-16 scope conversation.

ADR-090 Deferred Decision #2 explicitly admits this endpoint into substrate scope — it reports state, and self-routing remains the agent's decision.

## Fix Applied

Opt-in `includeRichState: boolean` on the tool input. Default false keeps legacy callers byte-identical to today's output. When true, the handler appends a `richState` field with:

- **`strategyPointer`** — short-form SHA + latest journal filename
- **`gitState`** — branch, uncommitted files (capped at 50 with `truncated: true` flag), staged + unstaged combined
- **`packageVersions`** — fixed-group packages only (`@mmnto/totem`, `@mmnto/cli`, `@mmnto/mcp`, `@totem/pack-agent-security`)
- **`ruleCounts`** — active / archived / nonCompilable from the compile manifest
- **`lessonCount`** — count of `.totem/lessons/*.md`
- **`testCount`** — null in v1 (follow-up ticket stamps `.totem/store/test-stats.json`)
- **`milestone`** — regex-parsed from `docs/active_work.md` with `bestEffort: true` flag so agents treat it as hint-quality
- **`recentPrs`** — 5 most recent merged PRs from `git log --grep='#[0-9]+'`

### New files

- `packages/mcp/src/schemas/describe-project.ts` — Zod contracts. Every sub-schema re-exports its inferred type. Caps defined as named constants (`UNCOMMITTED_FILES_CAP = 50`, `RECENT_PRS_COUNT = 5`).
- `packages/mcp/src/state-extractors.ts` — 8 per-section functions. Each degrades gracefully to null / 0 / [] on missing source. Every catch block carries a `totem-context:` directive explaining the ADR-090 substrate rationale so the Tenet 4 fail-loud lint rule recognizes the intentional design.
- `packages/mcp/src/schemas/describe-project.test.ts` — 16 schema-contract tests.
- `packages/mcp/src/state-extractors.test.ts` — 17 extractor tests covering fallback invariants (non-git dir, missing manifest, missing lessons dir, malformed JSON) plus live-repo self-host assertions.

### Modified

- `packages/mcp/src/tools/describe-project.ts` — factored `getDescriptionFromContext` into `getLegacyContext` (returns legacy shape + projectRoot + totemDir) so the rich path can share the Lite-tier fallback logic. New `buildRichState` composes the eight extractors. Handler reads the opt-in flag and branches.
- `packages/mcp/src/tools/describe-project.test.ts` — extended mock to stub the extractor-used helpers (`resolveGitRoot`, `safeExec`, `readJsonSafe`, `CompiledRulesFileSchema`). Three new tests: legacy-shape default, explicit-false path, rich-state attach.

## Substrate Invariant (ADR-090)

Zero LLM calls. Zero live registry calls. Every extractor reads only from local git, filesystem, or stored state. Agents that build on the payload self-route; Totem does not route them.

## Out of Scope

- Caching GitHub milestone / label state to `.totem/store/github-state.json`. The regex fallback on `active_work.md` with `bestEffort: true` marker bridges the gap until the cache ships. Follow-up ticket to be filed post-merge.
- Real test count from a stamped artifact. Null in v1; follow-up to wire postmerge.
- Multi-repo federation. The endpoint returns one repo's state at a time.
- `@totem/pack-agent-security` version will only populate once `@totem` scope is registered and the pack ships; extractor silently omits until then.

## Tests Added/Updated

- [x] Added/updated automated tests covering the root-cause mechanism

36 new tests across three files. All 135 MCP tests green; full suite 2,975 tests green across seven packages. `totem review` PASS (two advisory INFO findings on git-log pipe delimiter and trim-HEAD check — neither a correctness issue; follow-up hardening if stdout ever grows a trailing newline in a future Node version).

## Related Tickets

Closes #1497