### PR TITLE
feat(core): add immutable flag to CompiledRule schema for #1485

### DIFF
--- a/packages/core/src/compiler-schema.ts
+++ b/packages/core/src/compiler-schema.ts
@@ -98,6 +98,13 @@ const CompiledRuleBaseSchema = z.object({
    * compiled-rules.json files; the legacy heuristic stays as a fallback.
    */
   manual: z.boolean().optional(),
+  /**
+   * Schema marker for ADR-089 Zero-Trust enforcement.
+   * Readers:
+   * - #1485 pack-merge path refuses downgrade to warning/archived locally.
+   * - #1479 Layer 3 security branch rejects outright on verify failure.
+   */
+  immutable: z.boolean().optional(),
 });
 
 /**


### PR DESCRIPTION
This PR adds the \immutable: z.boolean().optional()\ field to \CompiledRuleSchema\ to unblock #1479 and the rest of #1485. 

It is kept strictly optional to prevent breaking inference for the 30+ existing tests and adapter fixtures that mock legacy rules. Pack-merge logic will handle the default \alse\ behavior at runtime.