### PR TITLE
feat(core): ADR-088 Layer 3 verify-retry loop on Pipeline 2 compile

### DIFF
--- a/.totem/compile-manifest.json
+++ b/.totem/compile-manifest.json
@@ -2,6 +2,6 @@
   "compiled_at": "2026-04-17T02:45:44.837Z",
   "model": "gemini-3-flash-preview",
   "input_hash": "67084674658ca8a20c375663ecfb60bae93deb09fa517b6312a9d4457974fdd5",
-  "output_hash": "7c2402acc7e4a2d1b3c805678256b0583986681acb79927e8a9e71041ce393bd",
+  "output_hash": "d6075943925ae8e74c72c7c1367706e1f8bd3a0ffb66a2259e2aff2cd8a7f356",
   "rule_count": 425
 }

--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -6965,6 +6965,19 @@
         "!**/*.spec.*"
       ],
       "severity": "warning"
+    },
+    {
+      "lessonHash": "263c3b88dc975aa3",
+      "lessonHeading": "Pipeline 5: observation from shield",
+      "pattern": "badExample:\\s+parsed\\.badExample\\s+\\?\\?\\s+'\\(no\\s+badExample\\s+emitted\\)',",
+      "message": "When retrying due to an Example Hit/Miss verification failure, the `badExample` passed to `previousFailure` is still `parsed.badExample` (the smoke gate snippet, which the pattern successfully matched). The retry directive prompt says '**Code snippet the pattern had to match:**' followed by this smoke gate snippet, which might slightly confuse the LLM since the actual failure was on the Example Hit snippet (detailed in the `Failure reason`). Consider passing the actual failed Example Hit snippet if the failure originated from `verifyRuleExamples`.",
+      "engine": "regex",
+      "severity": "warning",
+      "fileGlobs": [
+        "**/*.ts"
+      ],
+      "compiledAt": "2026-04-17T04:17:14.891Z",
+      "createdAt": "2026-04-17T04:17:14.891Z"
     }
   ],
   "nonCompilable": [

--- a/packages/core/src/compile-lesson.test.ts
+++ b/packages/core/src/compile-lesson.test.ts
@@ -890,6 +890,13 @@ describe('compileLesson', () => {
   // ─── Smoke gate on Pipeline 2 (mmnto/totem#1408) ──
 
   it('Pipeline 2 rejects a rule whose LLM output omits badExample', async () => {
+    // Post-ADR-088 (mmnto-ai/totem#1479): missing badExample short-circuits
+    // to `status: 'skipped'` with reasonCode `'missing-badexample'` rather
+    // than `'failed'`. The Layer 4 explicit-failure contract requires every
+    // skipped lesson to carry a machine-readable reason; emitting `'failed'`
+    // would drop the entry without a trace. No retry because the compiler
+    // system prompt already requires the field (mmnto-ai/totem#1409) and
+    // retrying won't teach the LLM to emit a field it just omitted.
     const deps: CompileLessonDeps = {
       parseCompilerResponse: vi.fn().mockReturnValue({
         compilable: true,
@@ -903,7 +910,12 @@ describe('compileLesson', () => {
       callbacks: { onWarn: vi.fn(), onDim: vi.fn() },
     };
     const result = await compileLesson(lesson, 'system prompt', deps);
-    expect(result.status).toBe('failed');
+    expect(result.status).toBe('skipped');
+    if (result.status === 'skipped') {
+      expect(result.reasonCode).toBe('missing-badexample');
+      expect(result.reason).toContain('missing badExample');
+    }
+    expect(deps.runOrchestrator).toHaveBeenCalledTimes(1);
     expect(deps.callbacks!.onWarn).toHaveBeenCalledWith(
       lesson.heading,
       expect.stringContaining('smoke gate'),
@@ -1493,5 +1505,176 @@ describe('compileLesson Pipeline 3 (Bad/Good snippets)', () => {
       pipeline3Lesson.heading,
       expect.stringContaining('Pipeline 3'),
     );
+  });
+});
+
+// ─── Pipeline 2 Layer 3 verify-retry loop (ADR-088, mmnto-ai/totem#1479) ──
+
+describe('compileLesson Pipeline 2 verify-retry', () => {
+  const lesson: LessonInput = {
+    index: 0,
+    heading: 'No console.log in production code',
+    body: 'Do not use console.log in production.',
+    hash: 'h-retry',
+  };
+
+  it('retries after smoke-gate zero-match and succeeds when a later attempt produces a matching pattern', async () => {
+    // Attempt 1 returns a pattern that does not match the badExample.
+    // Attempt 2 returns a pattern that does. Expected outcome: compiled,
+    // two orchestrator calls, retry feedback threaded into attempt 2.
+    const parseMock = vi
+      .fn()
+      .mockReturnValueOnce({
+        compilable: true,
+        pattern: 'never_matches_xyz',
+        message: 'No console.log',
+        engine: 'regex' as const,
+        badExample: 'console.log("debug")',
+      })
+      .mockReturnValueOnce({
+        compilable: true,
+        pattern: 'console\\.log',
+        message: 'No console.log',
+        engine: 'regex' as const,
+        badExample: 'console.log("debug")',
+      });
+    const orchestratorMock = vi
+      .fn()
+      .mockResolvedValueOnce('attempt-1')
+      .mockResolvedValueOnce('attempt-2');
+    const deps: CompileLessonDeps = {
+      parseCompilerResponse: parseMock,
+      runOrchestrator: orchestratorMock,
+      existingByHash: new Map(),
+      callbacks: { onWarn: vi.fn(), onDim: vi.fn() },
+    };
+
+    const result = await compileLesson(lesson, 'system prompt', deps);
+    expect(result.status).toBe('compiled');
+    expect(orchestratorMock).toHaveBeenCalledTimes(2);
+
+    // The retry-directive must appear in the user prompt of attempt 2 and
+    // must not appear in attempt 1. The directive carries the failed
+    // pattern and the badExample so the LLM can correct its output.
+    const userPrompt1 = orchestratorMock.mock.calls[0]![0] as string;
+    const userPrompt2 = orchestratorMock.mock.calls[1]![0] as string;
+    expect(userPrompt1).not.toContain('Previous Attempt Failed Verification');
+    expect(userPrompt2).toContain('Previous Attempt Failed Verification');
+    expect(userPrompt2).toContain('never_matches_xyz');
+    expect(userPrompt2).toContain('console.log("debug")');
+  });
+
+  it('returns skipped with reasonCode verify-retry-exhausted after MAX_VERIFY_ATTEMPTS failures', async () => {
+    // Every attempt returns a pattern that does not match the badExample.
+    // Expected outcome: skipped, reasonCode 'verify-retry-exhausted',
+    // exactly 3 orchestrator calls.
+    const parseMock = vi.fn().mockReturnValue({
+      compilable: true,
+      pattern: 'never_matches_xyz',
+      message: 'No console.log',
+      engine: 'regex' as const,
+      badExample: 'console.log("debug")',
+    });
+    const orchestratorMock = vi.fn().mockResolvedValue('always-bad');
+    const deps: CompileLessonDeps = {
+      parseCompilerResponse: parseMock,
+      runOrchestrator: orchestratorMock,
+      existingByHash: new Map(),
+      callbacks: { onWarn: vi.fn(), onDim: vi.fn() },
+    };
+
+    const result = await compileLesson(lesson, 'system prompt', deps);
+    expect(result.status).toBe('skipped');
+    if (result.status === 'skipped') {
+      expect(result.reasonCode).toBe('verify-retry-exhausted');
+      expect(result.reason).toContain('Verify retry exhausted after 3 attempts');
+    }
+    expect(orchestratorMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('rejects a security-context rule without retry when verify fails', async () => {
+    // securityContext: true + zero-match on attempt 1. Zero tolerance per
+    // ADR-088 Decision 3 means no retry. Expected outcome: skipped,
+    // reasonCode 'security-verify-rejected', exactly 1 orchestrator call.
+    const parseMock = vi.fn().mockReturnValue({
+      compilable: true,
+      pattern: 'never_matches_xyz',
+      message: 'Security rule that failed to verify',
+      engine: 'regex' as const,
+      badExample: 'spawn("sh", ["-c", userInput])',
+    });
+    const orchestratorMock = vi.fn().mockResolvedValue('security-bad');
+    const deps: CompileLessonDeps = {
+      parseCompilerResponse: parseMock,
+      runOrchestrator: orchestratorMock,
+      existingByHash: new Map(),
+      callbacks: { onWarn: vi.fn(), onDim: vi.fn() },
+      securityContext: true,
+    };
+
+    const result = await compileLesson(lesson, 'system prompt', deps);
+    expect(result.status).toBe('skipped');
+    if (result.status === 'skipped') {
+      expect(result.reasonCode).toBe('security-verify-rejected');
+      expect(result.reason).toContain('zero matches');
+    }
+    expect(orchestratorMock).toHaveBeenCalledTimes(1);
+    expect(deps.callbacks!.onWarn).toHaveBeenCalledWith(
+      lesson.heading,
+      expect.stringContaining('Security rule rejected on verify failure'),
+    );
+  });
+
+  it('does not retry when the smoke-gate rejection is missing badExample (short-circuit to skipped)', async () => {
+    // Missing badExample is a structural-output failure. Retrying cannot
+    // teach the LLM to emit a field it just omitted. Expected outcome:
+    // skipped, reasonCode 'missing-badexample', exactly 1 orchestrator
+    // call. Same contract exercised by the pre-retry test above but
+    // explicitly scoped to the retry-loop branch.
+    const parseMock = vi.fn().mockReturnValue({
+      compilable: true,
+      pattern: 'console\\.log',
+      message: 'No console.log',
+      engine: 'regex' as const,
+      // no badExample
+    });
+    const orchestratorMock = vi.fn().mockResolvedValue('no-badexample');
+    const deps: CompileLessonDeps = {
+      parseCompilerResponse: parseMock,
+      runOrchestrator: orchestratorMock,
+      existingByHash: new Map(),
+      callbacks: { onWarn: vi.fn(), onDim: vi.fn() },
+    };
+
+    const result = await compileLesson(lesson, 'system prompt', deps);
+    expect(result.status).toBe('skipped');
+    if (result.status === 'skipped') {
+      expect(result.reasonCode).toBe('missing-badexample');
+    }
+    expect(orchestratorMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates non-compilable LLM verdict with reasonCode non-compilable', async () => {
+    // Conceptual/architectural lessons that the LLM classifies as
+    // non-compilable. ADR-088 Layer 4 requires a machine-readable reason.
+    const parseMock = vi.fn().mockReturnValue({
+      compilable: false,
+      reason: 'Architectural principle, not a pattern.',
+    });
+    const orchestratorMock = vi.fn().mockResolvedValue('{"compilable": false}');
+    const deps: CompileLessonDeps = {
+      parseCompilerResponse: parseMock,
+      runOrchestrator: orchestratorMock,
+      existingByHash: new Map(),
+      callbacks: { onWarn: vi.fn(), onDim: vi.fn() },
+    };
+
+    const result = await compileLesson(lesson, 'system prompt', deps);
+    expect(result.status).toBe('skipped');
+    if (result.status === 'skipped') {
+      expect(result.reasonCode).toBe('non-compilable');
+      expect(result.reason).toBe('Architectural principle, not a pattern.');
+    }
+    expect(orchestratorMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/compile-lesson.test.ts
+++ b/packages/core/src/compile-lesson.test.ts
@@ -1677,4 +1677,120 @@ describe('compileLesson Pipeline 2 verify-retry', () => {
     }
     expect(orchestratorMock).toHaveBeenCalledTimes(1);
   });
+
+  it('retries when Example Hit/Miss verification fails and succeeds on a later attempt', async () => {
+    // ADR-088 AC (mmnto-ai/totem#1479): "verifies every LLM-generated pattern
+    // against the lesson's Example Hit block. Zero-match triggers a retry."
+    // Attempt 1 produces a pattern that passes the smoke gate (matches its
+    // own badExample) but does NOT match the lesson's Example Hit.
+    // verifyRuleExamples fails; the retry path fires. Attempt 2 returns a
+    // pattern that matches both the badExample and the Example Hit.
+    const lessonWithExample: LessonInput = {
+      index: 0,
+      heading: 'No console.log in production',
+      body: 'Do not use console.log in production.\n**Example Hit:** console.log(x)',
+      hash: 'h-retry-verify',
+    };
+    const parseMock = vi
+      .fn()
+      .mockReturnValueOnce({
+        compilable: true,
+        pattern: 'zzz_only_matches_itself',
+        message: 'No console.log',
+        engine: 'regex' as const,
+        badExample: 'zzz_only_matches_itself',
+      })
+      .mockReturnValueOnce({
+        compilable: true,
+        pattern: 'console\\.log',
+        message: 'No console.log',
+        engine: 'regex' as const,
+        badExample: 'console.log("x")',
+      });
+    const orchestratorMock = vi
+      .fn()
+      .mockResolvedValueOnce('attempt-1')
+      .mockResolvedValueOnce('attempt-2');
+    const deps: CompileLessonDeps = {
+      parseCompilerResponse: parseMock,
+      runOrchestrator: orchestratorMock,
+      existingByHash: new Map(),
+      callbacks: { onWarn: vi.fn(), onDim: vi.fn() },
+    };
+
+    const result = await compileLesson(lessonWithExample, 'system prompt', deps);
+    expect(result.status).toBe('compiled');
+    expect(orchestratorMock).toHaveBeenCalledTimes(2);
+
+    // The retry directive must reflect the Example Hit failure (generic
+    // wording so it can serve both smoke-gate and verify failures), it
+    // must carry the prior pattern so the LLM sees what it produced, and
+    // — when the failure source is verifyRuleExamples — the "Code
+    // snippet the pattern had to match" field must show the missed
+    // Example Hit line, not the LLM's own badExample (which the pattern
+    // did match, since the smoke gate passed).
+    const userPrompt2 = orchestratorMock.mock.calls[1]![0] as string;
+    expect(userPrompt2).toContain('Previous Attempt Failed Verification');
+    expect(userPrompt2).toContain('zzz_only_matches_itself'); // pattern field
+    expect(userPrompt2).toContain('console.log(x)'); // missed Example Hit
+  });
+
+  it('exhausts retries when Example Hit/Miss verification fails on every attempt', async () => {
+    // Same Example Hit lesson as above, but the LLM never produces a
+    // pattern that matches the lesson's Example Hit. Three attempts, each
+    // passing the smoke gate but failing verifyRuleExamples. Expected
+    // outcome: skipped, reasonCode 'verify-retry-exhausted'.
+    const lessonWithExample: LessonInput = {
+      index: 0,
+      heading: 'No console.log in production',
+      body: 'Do not use console.log in production.\n**Example Hit:** console.log(x)',
+      hash: 'h-verify-exhaust',
+    };
+    const parseMock = vi.fn().mockReturnValue({
+      compilable: true,
+      pattern: 'zzz_only_matches_itself',
+      message: 'No console.log',
+      engine: 'regex' as const,
+      badExample: 'zzz_only_matches_itself',
+    });
+    const orchestratorMock = vi.fn().mockResolvedValue('always-misses');
+    const deps: CompileLessonDeps = {
+      parseCompilerResponse: parseMock,
+      runOrchestrator: orchestratorMock,
+      existingByHash: new Map(),
+      callbacks: { onWarn: vi.fn(), onDim: vi.fn() },
+    };
+
+    const result = await compileLesson(lessonWithExample, 'system prompt', deps);
+    expect(result.status).toBe('skipped');
+    if (result.status === 'skipped') {
+      expect(result.reasonCode).toBe('verify-retry-exhausted');
+    }
+    expect(orchestratorMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('returns failed without retry when the LLM emits an invalid regex (validator rejection)', async () => {
+    // Validator-level rejection (ADR-088 + CR review on #1479). Retrying
+    // an invalid regex produces more invalid regexes and masks real LLM
+    // output quality issues. Return 'failed' so the lesson stays pending
+    // for a future recompile rather than landing in nonCompilable.
+    const parseMock = vi.fn().mockReturnValue({
+      compilable: true,
+      pattern: '[unclosed-bracket-class',
+      message: 'Invalid regex test',
+      engine: 'regex' as const,
+      badExample: 'any string',
+    });
+    const orchestratorMock = vi.fn().mockResolvedValue('invalid-regex-output');
+    const deps: CompileLessonDeps = {
+      parseCompilerResponse: parseMock,
+      runOrchestrator: orchestratorMock,
+      existingByHash: new Map(),
+      callbacks: { onWarn: vi.fn(), onDim: vi.fn() },
+    };
+
+    const result = await compileLesson(lesson, 'system prompt', deps);
+    expect(result.status).toBe('failed');
+    expect(orchestratorMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/core/src/compile-lesson.ts
+++ b/packages/core/src/compile-lesson.ts
@@ -34,7 +34,7 @@ export type CompileLessonReasonCode =
 
 export type CompileLessonResult =
   | { status: 'compiled'; rule: CompiledRule }
-  | { status: 'skipped'; hash: string; reason?: string; reasonCode?: CompileLessonReasonCode }
+  | { status: 'skipped'; hash: string; reason?: string; reasonCode: CompileLessonReasonCode }
   | { status: 'failed' }
   | { status: 'noop' };
 
@@ -629,7 +629,12 @@ export async function compileLesson(
 
     if (!parsed.compilable) {
       callbacks?.onDim?.(lesson.heading, 'Pipeline 3: not compilable — skipping');
-      return { status: 'skipped', hash: lesson.hash, reason: parsed.reason };
+      return {
+        status: 'skipped',
+        hash: lesson.hash,
+        reason: parsed.reason,
+        reasonCode: 'non-compilable',
+      };
     }
 
     // mmnto/totem#1408: Pipeline 3 reuses its Bad snippet as the smoke-gate
@@ -694,7 +699,7 @@ export async function compileLesson(
   //     with a machine-readable reason so totem doctor and downstream
   //     tooling can distinguish this from 'non-compilable'.
   const MAX_VERIFY_ATTEMPTS = 3;
-  let previousFailure: { pattern: string; badExample: string; reason: string } | null = null;
+  let previousFailure: { pattern: string; snippet: string; reason: string } | null = null;
 
   for (let attempt = 1; attempt <= MAX_VERIFY_ATTEMPTS; attempt++) {
     const userPromptParts: string[] = [];
@@ -731,48 +736,87 @@ export async function compileLesson(
 
     // Smoke gate enforcement lives in buildCompiledRule (mmnto-ai/totem#1408).
     // Rules without a badExample, or whose badExample fails to match the
-    // pattern, come back with rule === null and a rejectReason we can retry on.
+    // pattern, come back with rule === null and a rejectReason. Classify the
+    // outcome into one of four buckets:
+    //   success          — rule built AND Example Hit/Miss verify passed
+    //   retry-eligible   — smoke-gate zero-match OR verifyRuleExamples failure
+    //   missing-badexample — LLM omitted a required field (structural)
+    //   validator-failure  — invalid regex / ast-grep parse error / self-
+    //                        suppression guard; retrying would produce more
+    //                        invalid patterns, so the lesson stays pending
     const ruleResult = buildCompiledRule(parsed, lesson, existingByHash, {
       enforceSmokeGate: true,
     });
 
+    let retryReason: string;
+    let retrySnippet: string;
+
     if (ruleResult.rule) {
       const testResult = verifyRuleExamples(ruleResult.rule, lesson.body);
-      if (testResult && !testResult.passed) {
-        callbacks?.onWarn?.(lesson.heading, formatExampleFailure(testResult));
+      if (!testResult || testResult.passed) {
+        return { status: 'compiled', rule: ruleResult.rule };
+      }
+      // Example Hit/Miss verification failed against the lesson's ground
+      // truth. ADR-088 AC: "verifies every LLM-generated pattern against
+      // the lesson's Example Hit block. Zero-match triggers a retry."
+      retryReason = formatExampleFailure(testResult);
+      // The snippet the retry directive should show is the Example Hit
+      // line the pattern missed, not the LLM's own badExample (which the
+      // pattern did match, since the smoke gate passed). If missedFails
+      // is empty but the test still failed (false-positive-only case),
+      // fall back to the badExample so the directive has something
+      // concrete to anchor on.
+      retrySnippet =
+        testResult.missedFails.length > 0
+          ? testResult.missedFails.join('\n')
+          : (parsed.badExample ?? '(no snippet available)');
+    } else {
+      const rejectReason = ruleResult.rejectReason ?? 'Unknown error';
+
+      // Missing-badExample is a structural-output failure. Retrying won't
+      // teach the LLM to emit a field it just omitted — the compiler
+      // system prompt already requires it (mmnto-ai/totem#1409).
+      // Short-circuit to skipped with a distinct reasonCode.
+      if (rejectReason.includes('missing badExample')) {
+        callbacks?.onWarn?.(lesson.heading, `${rejectReason} — skipping`);
+        return {
+          status: 'skipped',
+          hash: lesson.hash,
+          reason: rejectReason,
+          reasonCode: 'missing-badexample',
+        };
+      }
+
+      // Only smoke-gate zero-match against the LLM's own badExample is
+      // retry-eligible. Validator-level rejections — invalid regex,
+      // ast-grep parse errors, self-suppression guards — are terminal.
+      // Retrying them produces more invalid patterns and wastes tokens.
+      // 'failed' keeps the rule pending for a future recompile rather
+      // than marking it permanently nonCompilable.
+      const isZeroMatch = rejectReason.startsWith('smoke gate: zero matches');
+      if (!isZeroMatch) {
+        callbacks?.onWarn?.(lesson.heading, `${rejectReason} — failing`);
         return { status: 'failed' };
       }
-      return { status: 'compiled', rule: ruleResult.rule };
+
+      retryReason = rejectReason;
+      retrySnippet = parsed.badExample ?? '(no badExample emitted)';
     }
 
-    const rejectReason = ruleResult.rejectReason ?? 'Unknown error';
-
-    // Missing-badExample is a structural-output failure, not a
-    // pattern-quality failure. Retrying won't teach the LLM to emit a
-    // field it just omitted — the compiler system prompt already asks
-    // for it (mmnto-ai/totem#1409). Short-circuit to skipped with a
-    // distinct reasonCode so the caller gets an explicit ADR-088 Layer 4
-    // failure instead of a silent nonCompilable.
-    if (rejectReason.includes('missing badExample')) {
-      callbacks?.onWarn?.(lesson.heading, `${rejectReason} — skipping`);
-      return {
-        status: 'skipped',
-        hash: lesson.hash,
-        reason: rejectReason,
-        reasonCode: 'missing-badexample',
-      };
-    }
+    // Shared retry path. Triggered by smoke-gate zero-match OR by
+    // Example Hit/Miss verify failure. Both carry a retryReason that
+    // threads back into the next LLM attempt's user prompt.
 
     // ADR-088 Decision 3: security rules zero-tolerance. No retry.
     if (deps.securityContext === true) {
       callbacks?.onWarn?.(
         lesson.heading,
-        `Security rule rejected on verify failure (no retry): ${rejectReason}`,
+        `Security rule rejected on verify failure (no retry): ${retryReason}`,
       );
       return {
         status: 'skipped',
         hash: lesson.hash,
-        reason: rejectReason,
+        reason: retryReason,
         reasonCode: 'security-verify-rejected',
       };
     }
@@ -780,12 +824,12 @@ export async function compileLesson(
     if (attempt < MAX_VERIFY_ATTEMPTS) {
       previousFailure = {
         pattern: extractPatternString(parsed),
-        badExample: parsed.badExample ?? '(no badExample emitted)',
-        reason: rejectReason,
+        snippet: retrySnippet,
+        reason: retryReason,
       };
       callbacks?.onDim?.(
         lesson.heading,
-        `Verify failed (attempt ${attempt}/${MAX_VERIFY_ATTEMPTS}): ${rejectReason} — retrying`,
+        `Verify failed (attempt ${attempt}/${MAX_VERIFY_ATTEMPTS}): ${retryReason} — retrying`,
       );
       continue;
     }
@@ -793,12 +837,12 @@ export async function compileLesson(
     // Attempts exhausted → Layer 4 fallthrough per ADR-088.
     callbacks?.onWarn?.(
       lesson.heading,
-      `Verify retry exhausted after ${MAX_VERIFY_ATTEMPTS} attempts: ${rejectReason} — skipping`,
+      `Verify retry exhausted after ${MAX_VERIFY_ATTEMPTS} attempts: ${retryReason} — skipping`,
     );
     return {
       status: 'skipped',
       hash: lesson.hash,
-      reason: `Verify retry exhausted after ${MAX_VERIFY_ATTEMPTS} attempts: ${rejectReason}`,
+      reason: `Verify retry exhausted after ${MAX_VERIFY_ATTEMPTS} attempts: ${retryReason}`,
       reasonCode: 'verify-retry-exhausted',
     };
   }
@@ -831,25 +875,25 @@ function extractPatternString(parsed: CompilerOutput): string {
  * the LLM so it can correct its output.
  */
 function buildRetryDirective(
-  failure: { pattern: string; badExample: string; reason: string },
+  failure: { pattern: string; snippet: string; reason: string },
   attempt: number,
   maxAttempts: number,
 ): string {
   return [
-    `This is attempt ${attempt} of ${maxAttempts}. The previous attempt produced a pattern that failed the compile-time smoke gate.`,
+    `This is attempt ${attempt} of ${maxAttempts}. The previous attempt produced a pattern that failed verification.`,
     '',
     '**Previous pattern:**',
     '```',
     failure.pattern,
     '```',
     '',
-    '**badExample the pattern had to match:**',
+    '**Code snippet the pattern had to match:**',
     '```',
-    failure.badExample,
+    failure.snippet,
     '```',
     '',
-    `**Gate reason:** ${failure.reason}`,
+    `**Failure reason:** ${failure.reason}`,
     '',
-    'Generate a corrected pattern that DOES match the badExample above. Keep the lesson intent unchanged; only fix the pattern so it triggers on the provided snippet.',
+    'Generate a corrected pattern that satisfies the requirements. Keep the lesson intent unchanged; only fix the pattern so it triggers correctly.',
   ].join('\n');
 }

--- a/packages/core/src/compile-lesson.ts
+++ b/packages/core/src/compile-lesson.ts
@@ -20,9 +20,21 @@ export interface LessonInput {
   hash: string;
 }
 
+/**
+ * Machine-readable skip reasons. Threaded through `CompileLessonResult` so
+ * downstream consumers (totem doctor, Layer 4 fallthrough reporting per ADR-088)
+ * can distinguish why a lesson produced no rule without string-matching
+ * human-readable messages.
+ */
+export type CompileLessonReasonCode =
+  | 'non-compilable' // LLM classified the lesson as conceptual/architectural
+  | 'missing-badexample' // LLM output omitted badExample; structural failure, no retry
+  | 'verify-retry-exhausted' // Layer 3 retry loop ran to cap without producing a matching pattern
+  | 'security-verify-rejected'; // Layer 3 security rule failed verify; no retry per zero-tolerance
+
 export type CompileLessonResult =
   | { status: 'compiled'; rule: CompiledRule }
-  | { status: 'skipped'; hash: string; reason?: string }
+  | { status: 'skipped'; hash: string; reason?: string; reasonCode?: CompileLessonReasonCode }
   | { status: 'failed' }
   | { status: 'noop' };
 
@@ -62,6 +74,17 @@ export interface CompileLessonDeps {
    * system prompt would invalidate the cache on every --upgrade call.
    */
   telemetryPrefix?: string;
+  /**
+   * Assert that this compile is producing a security rule. Per ADR-088
+   * Decision 3 (Layer 3 zero-tolerance), security rules that fail the smoke
+   * gate are rejected outright with no retry. Reserved for callers that know
+   * the source pack context (e.g., compiling lessons from a pack scoped
+   * `@totem/pack-agent-security` or any pack whose manifest carries an
+   * immutable severity contract). Today's `totem lesson compile` at repo
+   * level does not set this; a future pack-build command will. Defaults to
+   * false; security zero-tolerance is gated on an affirmative caller assertion.
+   */
+  securityContext?: boolean;
 }
 
 // ─── ast-grep pattern validation ───────────────────
@@ -648,53 +671,185 @@ export async function compileLesson(
     return { status: 'compiled', rule: ruleResult.rule };
   }
 
-  // ── Pipeline 2: LLM compilation ──────────────────
-  // The compilerPrompt (ast-grep manual + few-shot examples, ~50KB) is the
-  // persistent system context — same bytes across every Pipeline 2 call within
-  // a session. Pass it as systemPrompt so the orchestrator can cache it
-  // (mmnto/totem#1291 Phase 3). The user prompt carries only the per-lesson
-  // body and the optional telemetry directive (which is per-rule, not cacheable).
+  // ── Pipeline 2 / Layer 3: LLM compilation with verify-retry loop ──
+  // ADR-088 Phase 1 (mmnto-ai/totem#1479). The compilerPrompt (ast-grep
+  // manual + few-shot examples, ~50KB) is the persistent system context —
+  // same bytes across every call within a session. Pass it as systemPrompt
+  // so the orchestrator can cache it (mmnto/totem#1291 Phase 3). The user
+  // prompt carries only the per-lesson body, the optional telemetry
+  // directive (per --upgrade target, not cacheable), and on retries the
+  // prior-attempt feedback block.
   //
-  // Optional telemetry directive (mmnto/totem#1131) — nudges Sonnet toward ast-grep
-  // when the existing rule is firing in strings/comments instead of code. Lives
-  // in the user prompt because it varies per --upgrade target.
-  const userPromptParts: string[] = [];
-  if (deps.telemetryPrefix) {
-    userPromptParts.push('## Telemetry-Driven Refinement Directive', deps.telemetryPrefix);
-  }
-  userPromptParts.push('## Lesson to Compile', `Heading: ${lesson.heading}`, lesson.body);
-  const userPrompt = userPromptParts.join('\n\n');
-  const response = await runOrchestrator(userPrompt, compilerPrompt);
+  // Retry semantics:
+  //   - On smoke-gate zero-match, rebuild the user prompt with a
+  //     "Previous Attempt Failed Verification" section that names the
+  //     failed pattern and the badExample it could not match, then call
+  //     the LLM again. Up to MAX_VERIFY_ATTEMPTS total attempts.
+  //   - Security context (deps.securityContext === true) disables retry:
+  //     a failing verify rejects outright with reasonCode
+  //     'security-verify-rejected' per ADR-088 Decision 3 (zero
+  //     tolerance).
+  //   - On attempt exhaustion, fall through to Layer 4 with reasonCode
+  //     'verify-retry-exhausted'. The lesson is recorded as skipped
+  //     with a machine-readable reason so totem doctor and downstream
+  //     tooling can distinguish this from 'non-compilable'.
+  const MAX_VERIFY_ATTEMPTS = 3;
+  let previousFailure: { pattern: string; badExample: string; reason: string } | null = null;
 
-  if (response == null) return { status: 'noop' };
+  for (let attempt = 1; attempt <= MAX_VERIFY_ATTEMPTS; attempt++) {
+    const userPromptParts: string[] = [];
+    if (deps.telemetryPrefix) {
+      userPromptParts.push('## Telemetry-Driven Refinement Directive', deps.telemetryPrefix);
+    }
+    if (previousFailure) {
+      userPromptParts.push(
+        '## Previous Attempt Failed Verification',
+        buildRetryDirective(previousFailure, attempt, MAX_VERIFY_ATTEMPTS),
+      );
+    }
+    userPromptParts.push('## Lesson to Compile', `Heading: ${lesson.heading}`, lesson.body);
+    const userPrompt = userPromptParts.join('\n\n');
+    const response = await runOrchestrator(userPrompt, compilerPrompt);
 
-  const parsed = parseCompilerResponse(response);
-  if (!parsed) {
-    callbacks?.onWarn?.(lesson.heading, 'Failed to parse LLM response — skipping');
-    return { status: 'failed' };
+    if (response == null) return { status: 'noop' };
+
+    const parsed = parseCompilerResponse(response);
+    if (!parsed) {
+      callbacks?.onWarn?.(lesson.heading, 'Failed to parse LLM response — skipping');
+      return { status: 'failed' };
+    }
+
+    if (!parsed.compilable) {
+      callbacks?.onDim?.(lesson.heading, 'Not compilable (conceptual/architectural) — skipping');
+      return {
+        status: 'skipped',
+        hash: lesson.hash,
+        reason: parsed.reason,
+        reasonCode: 'non-compilable',
+      };
+    }
+
+    // Smoke gate enforcement lives in buildCompiledRule (mmnto-ai/totem#1408).
+    // Rules without a badExample, or whose badExample fails to match the
+    // pattern, come back with rule === null and a rejectReason we can retry on.
+    const ruleResult = buildCompiledRule(parsed, lesson, existingByHash, {
+      enforceSmokeGate: true,
+    });
+
+    if (ruleResult.rule) {
+      const testResult = verifyRuleExamples(ruleResult.rule, lesson.body);
+      if (testResult && !testResult.passed) {
+        callbacks?.onWarn?.(lesson.heading, formatExampleFailure(testResult));
+        return { status: 'failed' };
+      }
+      return { status: 'compiled', rule: ruleResult.rule };
+    }
+
+    const rejectReason = ruleResult.rejectReason ?? 'Unknown error';
+
+    // Missing-badExample is a structural-output failure, not a
+    // pattern-quality failure. Retrying won't teach the LLM to emit a
+    // field it just omitted — the compiler system prompt already asks
+    // for it (mmnto-ai/totem#1409). Short-circuit to skipped with a
+    // distinct reasonCode so the caller gets an explicit ADR-088 Layer 4
+    // failure instead of a silent nonCompilable.
+    if (rejectReason.includes('missing badExample')) {
+      callbacks?.onWarn?.(lesson.heading, `${rejectReason} — skipping`);
+      return {
+        status: 'skipped',
+        hash: lesson.hash,
+        reason: rejectReason,
+        reasonCode: 'missing-badexample',
+      };
+    }
+
+    // ADR-088 Decision 3: security rules zero-tolerance. No retry.
+    if (deps.securityContext === true) {
+      callbacks?.onWarn?.(
+        lesson.heading,
+        `Security rule rejected on verify failure (no retry): ${rejectReason}`,
+      );
+      return {
+        status: 'skipped',
+        hash: lesson.hash,
+        reason: rejectReason,
+        reasonCode: 'security-verify-rejected',
+      };
+    }
+
+    if (attempt < MAX_VERIFY_ATTEMPTS) {
+      previousFailure = {
+        pattern: extractPatternString(parsed),
+        badExample: parsed.badExample ?? '(no badExample emitted)',
+        reason: rejectReason,
+      };
+      callbacks?.onDim?.(
+        lesson.heading,
+        `Verify failed (attempt ${attempt}/${MAX_VERIFY_ATTEMPTS}): ${rejectReason} — retrying`,
+      );
+      continue;
+    }
+
+    // Attempts exhausted → Layer 4 fallthrough per ADR-088.
+    callbacks?.onWarn?.(
+      lesson.heading,
+      `Verify retry exhausted after ${MAX_VERIFY_ATTEMPTS} attempts: ${rejectReason} — skipping`,
+    );
+    return {
+      status: 'skipped',
+      hash: lesson.hash,
+      reason: `Verify retry exhausted after ${MAX_VERIFY_ATTEMPTS} attempts: ${rejectReason}`,
+      reasonCode: 'verify-retry-exhausted',
+    };
   }
 
-  if (!parsed.compilable) {
-    callbacks?.onDim?.(lesson.heading, 'Not compilable (conceptual/architectural) — skipping');
-    return { status: 'skipped', hash: lesson.hash, reason: parsed.reason };
-  }
+  // Unreachable: every path inside the loop returns. Kept to satisfy the
+  // return-type checker without using a non-null assertion dance.
+  return { status: 'failed' };
+}
 
-  // mmnto/totem#1408: Pipeline 2 enforces the smoke gate. Rules without a
-  // badExample, or whose badExample fails to match the pattern, are rejected
-  // with a clear reason before landing in compiled-rules.json. The compile
-  // prompt rewrite in mmnto/totem#1409 teaches Sonnet to emit the field.
-  const ruleResult = buildCompiledRule(parsed, lesson, existingByHash, {
-    enforceSmokeGate: true,
-  });
-  if (!ruleResult.rule) {
-    callbacks?.onWarn?.(lesson.heading, `${ruleResult.rejectReason ?? 'Unknown error'} — skipping`);
-    return { status: 'failed' };
-  }
+// ─── Retry loop helpers (ADR-088 Layer 3) ──────────
 
-  const testResult = verifyRuleExamples(ruleResult.rule, lesson.body);
-  if (testResult && !testResult.passed) {
-    callbacks?.onWarn?.(lesson.heading, formatExampleFailure(testResult));
-    return { status: 'failed' };
+/**
+ * Render the parsed LLM output's pattern as a printable string for the
+ * retry-directive prompt. regex and astGrepPattern are string-native; a
+ * compound ast-grep rule is JSON-serialized so the LLM can see the
+ * structure that produced zero matches.
+ */
+function extractPatternString(parsed: CompilerOutput): string {
+  if (typeof parsed.pattern === 'string' && parsed.pattern.length > 0) return parsed.pattern;
+  if (typeof parsed.astGrepPattern === 'string' && parsed.astGrepPattern.length > 0) {
+    return parsed.astGrepPattern;
   }
-  return { status: 'compiled', rule: ruleResult.rule };
+  if (parsed.astGrepYamlRule) return JSON.stringify(parsed.astGrepYamlRule, null, 2);
+  return '(pattern unavailable)';
+}
+
+/**
+ * Build the "Previous Attempt Failed Verification" user-prompt block that
+ * threads the prior-attempt pattern, badExample, and reject reason back to
+ * the LLM so it can correct its output.
+ */
+function buildRetryDirective(
+  failure: { pattern: string; badExample: string; reason: string },
+  attempt: number,
+  maxAttempts: number,
+): string {
+  return [
+    `This is attempt ${attempt} of ${maxAttempts}. The previous attempt produced a pattern that failed the compile-time smoke gate.`,
+    '',
+    '**Previous pattern:**',
+    '```',
+    failure.pattern,
+    '```',
+    '',
+    '**badExample the pattern had to match:**',
+    '```',
+    failure.badExample,
+    '```',
+    '',
+    `**Gate reason:** ${failure.reason}`,
+    '',
+    'Generate a corrected pattern that DOES match the badExample above. Keep the lesson intent unchanged; only fix the pattern so it triggers on the provided snippet.',
+  ].join('\n');
 }


### PR DESCRIPTION
## Summary

Implements ADR-088 Phase 1 hardening of the LLM free-form compilation path (Pipeline 2 → Layer 3). Pre-change, a smoke-gate zero-match produced a silent \`nonCompilable\` entry with no retry; ADR-088 Decision 3 specifies up to 3 attempts with the failed pattern + badExample fed back into the prompt, plus security-rule zero tolerance and explicit Layer 4 fallthrough with a machine-readable reason code.

## Changes

- \`compileLesson\` wraps Pipeline 2 in a \`MAX_VERIFY_ATTEMPTS=3\` retry loop. On smoke-gate rejection the user prompt gains a \"Previous Attempt Failed Verification\" block carrying the failed pattern, the badExample it had to match, and the gate reason.
- New \`CompileLessonReasonCode\` union on the \`skipped\` variant of \`CompileLessonResult\`: \`non-compilable\` | \`missing-badexample\` | \`verify-retry-exhausted\` | \`security-verify-rejected\`. Every terminal skip path now carries a machine-readable code so \`totem doctor\` and downstream Layer 4 reporting can distinguish failure modes without string-matching human messages.
- Security zero-tolerance is gated on an affirmative \`deps.securityContext\` caller assertion. Today no caller sets it; a future pack-build command will flip it on when compiling lessons from a security-scoped pack. Implemented as a contract so #1479 can land without threading pack context through \`totem lesson compile\`.
- \`missing-badExample\` short-circuits to skipped without retry. Retrying cannot teach the LLM to emit a field it just omitted.

## Tests

Added 5 new unit tests under \`describe('compileLesson Pipeline 2 verify-retry')\`:

- Zero-match on attempt 1, match on attempt 2 → compiled; retry directive present in attempt-2 prompt and absent from attempt-1.
- Three zero-matches → skipped with \`reasonCode: 'verify-retry-exhausted'\` and exactly 3 orchestrator calls.
- \`securityContext: true\` + zero-match → skipped with \`reasonCode: 'security-verify-rejected'\` and exactly 1 orchestrator call.
- \`missing-badExample\` → skipped with \`reasonCode: 'missing-badexample'\` and exactly 1 orchestrator call.
- Non-compilable LLM verdict → skipped with \`reasonCode: 'non-compilable'\`.

Updated the pre-retry \"rejects a rule whose LLM output omits badExample\" test to assert the new ADR-088 contract (\`skipped\` + \`reasonCode\`) instead of the prior \`failed\` semantic. Layer 4's explicit-failure contract requires every skipped lesson to carry a machine-readable reason so the entry lands in \`nonCompilable\` rather than dropping silently.

## Out of scope (tracked)

- **#1511** — playground stress-test corpus integration against real LLM. Belongs as a spike; mocked integration would be redundant with the unit tests here.
- **#1512** — thread \`securityContext\` from a pack-build flow into \`compileLesson\`. Blocked on #1491 pack install/build.
- **Ticket B per ADR-088** — rules without Example Hit/Miss are not subject to this gate; unverified flagging is separate work.

## Test plan

- [x] \`pnpm test\` — all 8 packages green (1695 CLI + 103 compile-lesson core tests)
- [x] \`totem review\` — PASS
- [x] \`totem lint\` — PASS (2 false-positive warnings on \`.includes()\` usage against an error-reason string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)