### PR TITLE
feat(core): pack-merge primitive + immutable enforcement (#1485)

### DIFF
--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -141,7 +141,11 @@ export async function runCompiledRules(
         recordContextHit(metrics, hash, context?.astContext);
       } else if (event === 'suppress') {
         recordSuppression(metrics, hash);
-        // Append to Trap Ledger (fire-and-forget)
+        // Append to Trap Ledger (fire-and-forget). When the suppressed rule
+        // was shipped by a pack with immutable: true (ADR-089,
+        // mmnto-ai/totem#1485), the event carries the flag so auditors can
+        // surface every attempt to silence an enforced security rule via
+        // `jq 'select(.immutable == true)'` over events.ndjson.
         if (context) {
           appendLedgerEvent(
             resolvedTotemDir,
@@ -153,6 +157,7 @@ export async function runCompiledRules(
               line: context.line,
               justification: context.justification ?? '',
               source: 'lint',
+              ...(context.immutable === true ? { immutable: true } : {}),
             },
             (msg) => log.dim(tag, msg),
           );

--- a/packages/core/src/compiler-schema.ts
+++ b/packages/core/src/compiler-schema.ts
@@ -301,6 +301,13 @@ export interface RuleEventContext {
    * the raw `unknown` so the callback interface stays cheap to consume.
    */
   failureReason?: string;
+  /**
+   * True when the rule that fired this event was shipped by a pack with
+   * `immutable: true`. Threaded through so downstream ledger writers can
+   * flag immutable-rule bypass events for pack enforcement audit (ADR-089,
+   * mmnto-ai/totem#1485). Absent on events from non-immutable rules.
+   */
+  immutable?: boolean;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -313,6 +313,10 @@ export { CustomSecretSchema, loadCustomSecrets, SecretsFileSchema } from './secr
 export type { LedgerEvent } from './ledger.js';
 export { appendLedgerEvent, LedgerEventSchema, readLedgerEvents } from './ledger.js';
 
+// Pack rule merge primitive (ADR-085 + ADR-089, mmnto-ai/totem#1485)
+export type { ImmutableOverrideBlock, MergeRulesResult } from './pack-merge.js';
+export { mergeRules } from './pack-merge.js';
+
 // Shell execution (cross-platform safe wrapper)
 export type { SafeExecOptions } from './sys/exec.js';
 export { describeSafeExecError, safeExec } from './sys/exec.js';

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -20,6 +20,14 @@ export const LedgerEventSchema = z.object({
   justification: z.string().default(''),
   /** Source of the event */
   source: z.enum(['lint', 'shield', 'bot']),
+  /**
+   * True when the bypassed rule was shipped by a pack with
+   * `immutable: true`. Audit consumers can filter
+   * `events.ndjson | jq 'select(.immutable == true)'` to surface every
+   * attempt to silence an enforced security rule (ADR-089,
+   * mmnto-ai/totem#1485). Absent on events from non-immutable rules.
+   */
+  immutable: z.boolean().optional(),
 });
 
 export type LedgerEvent = z.infer<typeof LedgerEventSchema>;

--- a/packages/core/src/pack-merge.test.ts
+++ b/packages/core/src/pack-merge.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CompiledRule } from './compiler-schema.js';
+import { mergeRules } from './pack-merge.js';
+
+// ─── Helpers ────────────────────────────────────────
+
+const baseRule = (
+  overrides: Partial<CompiledRule> & Pick<CompiledRule, 'lessonHash'>,
+): CompiledRule =>
+  ({
+    lessonHeading: 'test-rule',
+    message: 'test message',
+    pattern: 'pattern-x',
+    engine: 'regex',
+    compiledAt: '2026-04-17T00:00:00Z',
+    ...overrides,
+  }) as CompiledRule;
+
+// ─── Tests ──────────────────────────────────────────
+
+describe('mergeRules', () => {
+  it('emits pack-only rules unchanged', () => {
+    const packRule = baseRule({ lessonHash: 'pack-only' });
+    const { rules, blocks } = mergeRules([], [packRule]);
+    expect(rules).toEqual([packRule]);
+    expect(blocks).toEqual([]);
+  });
+
+  it('emits local-only rules unchanged', () => {
+    const localRule = baseRule({ lessonHash: 'local-only' });
+    const { rules, blocks } = mergeRules([localRule], []);
+    expect(rules).toEqual([localRule]);
+    expect(blocks).toEqual([]);
+  });
+
+  it('returns empty result on empty inputs', () => {
+    const { rules, blocks } = mergeRules([], []);
+    expect(rules).toEqual([]);
+    expect(blocks).toEqual([]);
+  });
+
+  it('local rule overrides pack rule when pack is not immutable (ADR-085 default)', () => {
+    const packRule = baseRule({
+      lessonHash: 'shared',
+      severity: 'error',
+      message: 'pack message',
+    });
+    const localRule = baseRule({
+      lessonHash: 'shared',
+      severity: 'warning',
+      message: 'local message',
+    });
+    const { rules, blocks } = mergeRules([localRule], [packRule]);
+    expect(rules).toEqual([localRule]);
+    expect(blocks).toEqual([]);
+  });
+
+  it('forces pack severity when local downgrades an immutable+error pack rule', () => {
+    const packRule = baseRule({
+      lessonHash: 'immut',
+      immutable: true,
+      severity: 'error',
+      message: 'pack enforcement',
+    });
+    const localRule = baseRule({
+      lessonHash: 'immut',
+      severity: 'warning',
+      message: 'local tries to downgrade',
+    });
+    const { rules, blocks } = mergeRules([localRule], [packRule]);
+
+    expect(rules).toHaveLength(1);
+    expect(rules[0]!.severity).toBe('error');
+    expect(rules[0]!.immutable).toBe(true);
+    // Pattern / message bodies come from the local rule — immutable
+    // protects the enforcement knob, not the rule content.
+    expect(rules[0]!.message).toBe('local tries to downgrade');
+    expect(blocks).toEqual([
+      {
+        lessonHash: 'immut',
+        lessonHeading: 'test-rule',
+        attemptedChange: 'severity-downgrade',
+        attemptedSeverity: 'warning',
+        enforcedSeverity: 'error',
+      },
+    ]);
+  });
+
+  it('blocks archive attempt on an immutable+error pack rule and restores active status', () => {
+    const packRule = baseRule({
+      lessonHash: 'immut-archive',
+      immutable: true,
+      severity: 'error',
+    });
+    const localRule = baseRule({
+      lessonHash: 'immut-archive',
+      severity: 'error',
+      status: 'archived',
+      archivedReason: 'local tried to archive a security rule',
+    });
+    const { rules, blocks } = mergeRules([localRule], [packRule]);
+
+    expect(rules).toHaveLength(1);
+    expect(rules[0]!.severity).toBe('error');
+    expect(rules[0]!.status).toBe('active');
+    expect(rules[0]!.archivedReason).toBeUndefined();
+    expect(blocks).toEqual([
+      {
+        lessonHash: 'immut-archive',
+        lessonHeading: 'test-rule',
+        attemptedChange: 'archive',
+        enforcedSeverity: 'error',
+      },
+    ]);
+  });
+
+  it('blocks combined downgrade + archive attempt with attemptedChange: both', () => {
+    const packRule = baseRule({
+      lessonHash: 'immut-both',
+      immutable: true,
+      severity: 'error',
+    });
+    const localRule = baseRule({
+      lessonHash: 'immut-both',
+      severity: 'warning',
+      status: 'archived',
+      archivedReason: 'double override attempt',
+    });
+    const { rules, blocks } = mergeRules([localRule], [packRule]);
+
+    expect(rules).toHaveLength(1);
+    expect(rules[0]!.severity).toBe('error');
+    expect(rules[0]!.status).toBe('active');
+    expect(rules[0]!.archivedReason).toBeUndefined();
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0]!.attemptedChange).toBe('both');
+    expect(blocks[0]!.attemptedSeverity).toBe('warning');
+  });
+
+  it('does not force severity when pack is immutable but severity is not error', () => {
+    // Immutable currently protects error-level rules only. A pack that
+    // declares immutable: true + severity: 'warning' communicates intent
+    // but the merge falls back to local precedence — no block reported.
+    const packRule = baseRule({
+      lessonHash: 'immut-warn',
+      immutable: true,
+      severity: 'warning',
+    });
+    const localRule = baseRule({
+      lessonHash: 'immut-warn',
+      severity: 'warning',
+      status: 'archived',
+    });
+    const { rules, blocks } = mergeRules([localRule], [packRule]);
+    expect(rules).toEqual([localRule]);
+    expect(blocks).toEqual([]);
+  });
+
+  it('emits no block when the local rule does not attempt to downgrade or archive', () => {
+    const packRule = baseRule({
+      lessonHash: 'immut-noop',
+      immutable: true,
+      severity: 'error',
+    });
+    const localRule = baseRule({
+      lessonHash: 'immut-noop',
+      severity: 'error',
+      message: 'local refines message but keeps severity',
+    });
+    const { rules, blocks } = mergeRules([localRule], [packRule]);
+    expect(rules).toHaveLength(1);
+    expect(rules[0]!.severity).toBe('error');
+    expect(rules[0]!.message).toBe('local refines message but keeps severity');
+    expect(rules[0]!.immutable).toBe(true);
+    expect(blocks).toEqual([]);
+  });
+
+  it('preserves deterministic ordering: pack rules first, then local-only rules', () => {
+    const pack1 = baseRule({ lessonHash: 'p1' });
+    const pack2 = baseRule({ lessonHash: 'p2' });
+    const localOverlap = baseRule({ lessonHash: 'p1', message: 'overrides pack1' });
+    const localOnly1 = baseRule({ lessonHash: 'l1' });
+    const localOnly2 = baseRule({ lessonHash: 'l2' });
+
+    const { rules } = mergeRules([localOverlap, localOnly1, localOnly2], [pack1, pack2]);
+    const hashes = rules.map((r) => r.lessonHash);
+    expect(hashes).toEqual(['p1', 'p2', 'l1', 'l2']);
+    expect(rules[0]!.message).toBe('overrides pack1');
+  });
+
+  it('is a pure function — inputs are not mutated', () => {
+    const packRule = baseRule({
+      lessonHash: 'immut',
+      immutable: true,
+      severity: 'error',
+    });
+    const localRule = baseRule({
+      lessonHash: 'immut',
+      severity: 'warning',
+      status: 'archived',
+      archivedReason: 'audit',
+    });
+    const packSnapshot = JSON.stringify(packRule);
+    const localSnapshot = JSON.stringify(localRule);
+
+    mergeRules([localRule], [packRule]);
+
+    expect(JSON.stringify(packRule)).toBe(packSnapshot);
+    expect(JSON.stringify(localRule)).toBe(localSnapshot);
+  });
+
+  it('handles multiple immutable pack rules with mixed override attempts', () => {
+    const p1 = baseRule({
+      lessonHash: 'p1',
+      immutable: true,
+      severity: 'error',
+    });
+    const p2 = baseRule({
+      lessonHash: 'p2',
+      immutable: true,
+      severity: 'error',
+    });
+    const p3 = baseRule({
+      lessonHash: 'p3',
+      immutable: true,
+      severity: 'error',
+    });
+    const l1 = baseRule({ lessonHash: 'p1', severity: 'warning' });
+    const l2 = baseRule({ lessonHash: 'p2', status: 'archived' });
+    // p3 has no local override — no block, emits pack rule as-is.
+
+    const { rules, blocks } = mergeRules([l1, l2], [p1, p2, p3]);
+    expect(rules).toHaveLength(3);
+    expect(rules.every((r) => r.severity === 'error')).toBe(true);
+    expect(rules.every((r) => r.status !== 'archived')).toBe(true);
+    expect(blocks).toHaveLength(2);
+    expect(blocks.map((b) => b.lessonHash).sort()).toEqual(['p1', 'p2']);
+  });
+});

--- a/packages/core/src/pack-merge.test.ts
+++ b/packages/core/src/pack-merge.test.ts
@@ -157,6 +157,31 @@ describe('mergeRules', () => {
     expect(blocks).toEqual([]);
   });
 
+  it('does not treat an omitted local severity as a downgrade attempt', () => {
+    // CR finding on #1515: defaulting omitted localRule.severity to
+    // 'warning' records bogus blocks for local overrides that simply
+    // don't opine on severity. Runtime consumers disagree on the default
+    // (finding.ts uses 'error', compile-lesson.ts uses 'warning'), so
+    // absence is ambiguous — only an explicit 'warning' counts as a
+    // downgrade. The merged rule still gets the pack's 'error' forced.
+    const packRule = baseRule({
+      lessonHash: 'immut-implicit',
+      immutable: true,
+      severity: 'error',
+    });
+    const localRule = baseRule({
+      lessonHash: 'immut-implicit',
+      // severity intentionally omitted — local has no opinion
+      message: 'local refines message only',
+    });
+    const { rules, blocks } = mergeRules([localRule], [packRule]);
+    expect(rules).toHaveLength(1);
+    expect(rules[0]!.severity).toBe('error');
+    expect(rules[0]!.immutable).toBe(true);
+    expect(rules[0]!.message).toBe('local refines message only');
+    expect(blocks).toEqual([]);
+  });
+
   it('emits no block when the local rule does not attempt to downgrade or archive', () => {
     const packRule = baseRule({
       lessonHash: 'immut-noop',

--- a/packages/core/src/pack-merge.ts
+++ b/packages/core/src/pack-merge.ts
@@ -1,0 +1,161 @@
+/**
+ * Pack rule merge primitive (ADR-085 + ADR-089, mmnto-ai/totem#1485).
+ *
+ * The default pack-merge semantic from ADR-085 Resolved Decision 3 is
+ * "Local Supreme Authority": when a repo's local `compiled-rules.json`
+ * declares the same `lessonHash` as an inherited pack rule, the local
+ * entry wins. This preserves the "my repo, my rules" principle.
+ *
+ * ADR-089 carves out a narrow exception: rules shipped by a pack with
+ * `immutable: true` AND `severity: 'error'` cannot be locally downgraded
+ * or archived. Security packs like `@totem/pack-agent-security` rely on
+ * this contract to guarantee that enforcement cannot be silently weakened
+ * by a motivated local override.
+ *
+ * This module is the pure primitive that encodes both rules. It does
+ * NOT know about pack install paths, config resolution, or the filesystem —
+ * callers hand it two arrays and receive the merged array back. Phase C
+ * will wire a consumer (`totem install` + pack-config resolution) around
+ * this primitive. Until then the logic is fully unit-tested in memory so
+ * the enforcement contract is ready the day pack distribution lands.
+ */
+
+import type { CompiledRule } from './compiler-schema.js';
+
+// ─── Types ──────────────────────────────────────────
+
+/**
+ * Explains why a local override was refused. Accumulated into the merge
+ * result so callers can surface every blocked attempt without swallowing
+ * the detail. Useful for `totem install` diagnostics and for the Trap
+ * Ledger snapshot a future pack-build flow may capture.
+ */
+export interface ImmutableOverrideBlock {
+  /** The lessonHash of the immutable pack rule whose local override was rejected. */
+  lessonHash: string;
+  /** Human-readable name for log output. */
+  lessonHeading: string;
+  /** Which aspect of the local rule the merge refused to honor. */
+  attemptedChange: 'severity-downgrade' | 'archive' | 'both';
+  /** The severity the local rule tried to set. Absent for archive-only overrides. */
+  attemptedSeverity?: 'warning' | 'error';
+  /** The severity the pack enforces. Always 'error' — immutable is currently error-only. */
+  enforcedSeverity: 'error';
+}
+
+export interface MergeRulesResult {
+  /** The merged rule array. One entry per unique `lessonHash`. */
+  rules: CompiledRule[];
+  /**
+   * Immutable overrides the merge blocked. Empty when no local rule tried
+   * to downgrade or archive an immutable pack rule. Callers that want a
+   * hard error on any blocked override can check `blocks.length > 0`.
+   */
+  blocks: ImmutableOverrideBlock[];
+}
+
+// ─── Merge ──────────────────────────────────────────
+
+/**
+ * Merge local and pack rule arrays according to ADR-085 + ADR-089 semantics.
+ *
+ * Precedence:
+ *   - When a `lessonHash` appears in both arrays, local wins (ADR-085
+ *     Local Supreme Authority)
+ *   - EXCEPT when the pack rule carries `immutable: true` AND
+ *     `severity: 'error'`: the pack's severity is preserved and any local
+ *     `status: 'archived'` is cleared back to active. The rest of the
+ *     local rule's shape (pattern, message, fileGlobs, badExample) is
+ *     still honored — immutable protects the enforcement knob, not the
+ *     rule body. A pack author that needs to freeze the pattern as well
+ *     should simply ship the rule without a matching local entry.
+ *
+ * Non-immutable pack rules follow pure local precedence: the local entry
+ * replaces the pack entry byte-for-byte.
+ *
+ * Rules that appear only in `packRules` are appended as-is. Rules that
+ * appear only in `localRules` are emitted as-is. Pure function — does
+ * not mutate its inputs.
+ */
+export function mergeRules(
+  localRules: readonly CompiledRule[],
+  packRules: readonly CompiledRule[],
+): MergeRulesResult {
+  const localByHash = new Map<string, CompiledRule>();
+  for (const rule of localRules) {
+    localByHash.set(rule.lessonHash, rule);
+  }
+
+  const merged: CompiledRule[] = [];
+  const blocks: ImmutableOverrideBlock[] = [];
+  const consumedLocalHashes = new Set<string>();
+
+  for (const packRule of packRules) {
+    const localRule = localByHash.get(packRule.lessonHash);
+    if (!localRule) {
+      // No local override — pack rule lands as-is.
+      merged.push(packRule);
+      continue;
+    }
+
+    consumedLocalHashes.add(packRule.lessonHash);
+
+    const isEnforcedImmutable =
+      packRule.immutable === true && (packRule.severity ?? 'warning') === 'error';
+
+    if (!isEnforcedImmutable) {
+      // ADR-085 default: local overrides pack byte-for-byte.
+      merged.push(localRule);
+      continue;
+    }
+
+    // Immutable carve-out (ADR-089). Start from the local rule, then
+    // force severity and clear archive status if the local attempted
+    // either of those.
+    const attemptedSeverityDowngrade = (localRule.severity ?? 'warning') !== 'error';
+    const attemptedArchive = localRule.status === 'archived';
+
+    if (attemptedSeverityDowngrade || attemptedArchive) {
+      const attemptedChange: ImmutableOverrideBlock['attemptedChange'] =
+        attemptedSeverityDowngrade && attemptedArchive
+          ? 'both'
+          : attemptedSeverityDowngrade
+            ? 'severity-downgrade'
+            : 'archive';
+      const block: ImmutableOverrideBlock = {
+        lessonHash: packRule.lessonHash,
+        lessonHeading: packRule.lessonHeading,
+        attemptedChange,
+        enforcedSeverity: 'error',
+      };
+      if (attemptedSeverityDowngrade) {
+        block.attemptedSeverity = (localRule.severity ?? 'warning') as 'warning' | 'error';
+      }
+      blocks.push(block);
+    }
+
+    // Build the enforced rule. Preserve the local rule's pattern / body
+    // (immutable protects severity, not code content), but force the
+    // pack's severity and clear any archive flag. Preserve local
+    // `archivedReason` removal by not copying the field forward.
+    const enforced: CompiledRule = {
+      ...localRule,
+      severity: 'error',
+      immutable: true,
+    };
+    if (enforced.status === 'archived') {
+      enforced.status = 'active';
+      delete enforced.archivedReason;
+    }
+    merged.push(enforced);
+  }
+
+  // Emit local-only rules that no pack rule claimed.
+  for (const rule of localRules) {
+    if (!consumedLocalHashes.has(rule.lessonHash)) {
+      merged.push(rule);
+    }
+  }
+
+  return { rules: merged, blocks };
+}

--- a/packages/core/src/pack-merge.ts
+++ b/packages/core/src/pack-merge.ts
@@ -111,8 +111,14 @@ export function mergeRules(
 
     // Immutable carve-out (ADR-089). Start from the local rule, then
     // force severity and clear archive status if the local attempted
-    // either of those.
-    const attemptedSeverityDowngrade = (localRule.severity ?? 'warning') !== 'error';
+    // either of those. An omitted `localRule.severity` is NOT treated as
+    // a downgrade attempt — the local override is opting out of
+    // opinionating on severity, not declaring a lower one. Only an
+    // explicit `'warning'` counts. (Runtime severity defaults vary
+    // across consumers; finding.ts defaults to 'error' while
+    // compile-lesson.ts defaults to 'warning', so inferring a downgrade
+    // from absence would produce bogus blocks.)
+    const attemptedSeverityDowngrade = localRule.severity === 'warning';
     const attemptedArchive = localRule.status === 'archived';
 
     if (attemptedSeverityDowngrade || attemptedArchive) {
@@ -129,7 +135,7 @@ export function mergeRules(
         enforcedSeverity: 'error',
       };
       if (attemptedSeverityDowngrade) {
-        block.attemptedSeverity = (localRule.severity ?? 'warning') as 'warning' | 'error';
+        block.attemptedSeverity = 'warning';
       }
       blocks.push(block);
     }

--- a/packages/core/src/rule-engine.test.ts
+++ b/packages/core/src/rule-engine.test.ts
@@ -421,6 +421,39 @@ describe('applyRulesToAdditions — event context', () => {
     });
   });
 
+  it('threads rule.immutable into the suppress event context for pack enforcement audit', () => {
+    // ADR-089 / mmnto-ai/totem#1485 — when a pack-shipped immutable rule
+    // is bypassed by an inline totem-ignore directive, the suppress event
+    // must carry `immutable: true` so the Trap Ledger writer can flag it
+    // for pack enforcement audit.
+    const rule = makeRule({
+      engine: 'regex',
+      pattern: 'dangerous\\.call',
+      lessonHash: 'immut-suppress-test',
+      immutable: true,
+      severity: 'error',
+    });
+
+    const additions: DiffAddition[] = [
+      {
+        file: 'src/attack.ts',
+        line: 'dangerous.call(); // totem-ignore',
+        lineNumber: 10,
+        precedingLine: null,
+      },
+    ];
+
+    const events: Array<{ event: string; hash: string; context?: RuleEventContext }> = [];
+    const onRuleEvent: RuleEventCallback = (event, hash, context) => {
+      events.push({ event, hash, context });
+    };
+
+    applyRulesToAdditions([rule], additions, onRuleEvent);
+    expect(events).toHaveLength(1);
+    expect(events[0]!.event).toBe('suppress');
+    expect(events[0]!.context?.immutable).toBe(true);
+  });
+
   it('onRuleEvent callback receives file and line context on trigger', () => {
     const rule = makeRule({
       engine: 'regex',

--- a/packages/core/src/rule-engine.ts
+++ b/packages/core/src/rule-engine.ts
@@ -243,6 +243,7 @@ export function applyRulesToAdditions(
             file: addition.file,
             line: addition.lineNumber,
             justification: extractJustification(addition.line, addition.precedingLine),
+            immutable: rule.immutable,
           });
         }
         continue;
@@ -375,6 +376,7 @@ export async function applyAstRulesToAdditions(
                 file,
                 line: match.lineNumber,
                 justification: extractJustification(addition.line, addition.precedingLine),
+                immutable: rule.immutable,
               });
               continue;
             }
@@ -461,6 +463,7 @@ export async function applyAstRulesToAdditions(
                   justification: addition
                     ? extractJustification(addition.line, addition.precedingLine)
                     : '',
+                  immutable: rule.immutable,
                 });
                 continue;
               }


### PR DESCRIPTION
## Summary

Implements ADR-089 immutable enforcement via a pure pack-merge primitive and threads the \`immutable\` flag end-to-end through rule-engine events and the Trap Ledger. Covers AC 1 (schema, shipped as #1510), AC 2 (pack-merge enforcement), AC 3 (Trap Ledger audit), and AC 4 (unit tests) of #1485. AC 5 (e2e integration) deferred to #1514 pending #1491 \`totem install\`.

Per the Option 3 plan agreed with Gemini: ship the enforcement policy now so the contract is ready when pack distribution lands in Phase C. The primitive is fully unit-tested in memory; plugging the pipes together when #1491 arrives is a one-line wiring change.

## Changes

### \`packages/core/src/pack-merge.ts\`

New pure primitive \`mergeRules(localRules, packRules) -> { rules, blocks }\`:

- **Default:** local rules override pack rules byte-for-byte (ADR-085 Local Supreme Authority).
- **Exception:** when a pack rule carries \`immutable: true\` AND \`severity: 'error'\`, the merge forces \`severity: 'error'\` and clears \`status: 'archived'\` on the merged rule. Immutable protects the enforcement knob, not the rule body — pattern / message / fileGlobs still come from the local override.
- **Blocks array:** every refused downgrade or archive attempt accumulates an \`ImmutableOverrideBlock\` with \`lessonHash\`, \`attemptedChange\` (\`'severity-downgrade' | 'archive' | 'both'\`), \`attemptedSeverity\`, and \`enforcedSeverity\`. Callers can hard-fail on non-empty blocks or surface as warnings.

### Trap Ledger audit (AC 3)

- \`RuleEventContext.immutable?: boolean\` threaded from the rule-engine's three \`'suppress'\` event sites (regex, tree-sitter, ast-grep). Set from \`rule.immutable\`.
- \`LedgerEventSchema\` extended with optional \`immutable\` flag.
- \`run-compiled-rules\` suppress handler propagates \`context.immutable\` into the ledger event, gated on \`=== true\` so non-immutable rules do not pollute the field.

Auditors can now filter \`events.ndjson | jq 'select(.immutable == true)'\` to surface every attempt to silence an enforced security rule.

## Tests

- **\`pack-merge.test.ts\`** (12 tests): pack-only / local-only / empty inputs, ADR-085 default precedence, severity-downgrade block, archive block, combined both-block, non-error immutable no-op, no-downgrade no-block, deterministic ordering, input immutability, multi-rule mixed override.
- **\`rule-engine.test.ts\`** (1 new test): immutable rule suppressed via inline \`totem-ignore\` fires \`onRuleEvent\` with \`context.immutable === true\`.

## Out of scope (tracked)

- **#1514** — AC 5 e2e integration test (pack install → local override → confirm block). Blocked on #1491 \`totem install\`.
- Actual pack-build CLI wiring around \`mergeRules\`. Phase C territory.

## Test plan

- [x] \`pnpm test\` — all 8 packages green
- [x] \`totem review\` — PASS
- [x] \`totem lint\` — PASS (7 warnings, 0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)