### PR TITLE
chore(core): archive 21 dynamic-import rules contradicting ADR-072 §3

### DIFF
--- a/.totem/compile-manifest.json
+++ b/.totem/compile-manifest.json
@@ -1,7 +1,7 @@
 {
-  "compiled_at": "2026-04-17T02:45:44.837Z",
+  "compiled_at": "2026-04-17T17:43:00.885Z",
   "model": "gemini-3-flash-preview",
   "input_hash": "67084674658ca8a20c375663ecfb60bae93deb09fa517b6312a9d4457974fdd5",
-  "output_hash": "d6075943925ae8e74c72c7c1367706e1f8bd3a0ffb66a2259e2aff2cd8a7f356",
-  "rule_count": 425
+  "output_hash": "575e8b8381c9a39ad49f92a4a28a1be9e1e041b8887daa12d4f3536b16507a78",
+  "rule_count": 428
 }

--- a/.totem/compile-manifest.json
+++ b/.totem/compile-manifest.json
@@ -1,7 +1,7 @@
 {
-  "compiled_at": "2026-04-17T17:43:00.885Z",
+  "compiled_at": "2026-04-17T18:12:19.742Z",
   "model": "gemini-3-flash-preview",
   "input_hash": "67084674658ca8a20c375663ecfb60bae93deb09fa517b6312a9d4457974fdd5",
-  "output_hash": "575e8b8381c9a39ad49f92a4a28a1be9e1e041b8887daa12d4f3536b16507a78",
-  "rule_count": 428
+  "output_hash": "58f450b1b4af8007e9cd46759f78139ef72dd21417941af511ae0cc957b75c56",
+  "rule_count": 429
 }

--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -7052,7 +7052,24 @@
       "fileGlobs": [
         "packages/cli/**/*.ts"
       ],
-      "badExample": "client.messages.create({ model: 'claude-opus-4-7', temperature: 0.7, messages: [] });"
+      "badExample": "client.messages.create({ model: 'claude-opus-4-7', temperature: 0.7, messages: [] });",
+      "status": "archived",
+      "archivedReason": "Incomplete pattern (CodeRabbit finding on #1520): astGrepPattern `client.messages.create({ $$$ARGS, temperature: $VAL, $$$REST })` matches only calls that pass temperature, but the rule message says Opus 4.7 rejects all three of temperature, top_p, and top_k. Calls passing only top_p or top_k slip through. Archived rather than shipped incomplete; full coverage requires a compound rule authored in the source lesson."
+    },
+    {
+      "lessonHash": "263c3b88dc975aa3",
+      "lessonHeading": "Pipeline 5: observation from shield",
+      "pattern": "badExample:\\s+parsed\\.badExample\\s+\\?\\?\\s+'\\(no\\s+badExample\\s+emitted\\)',",
+      "message": "When retrying due to an Example Hit/Miss verification failure, the `badExample` passed to `previousFailure` is still `parsed.badExample` (the smoke gate snippet, which the pattern successfully matched). The retry directive prompt says '**Code snippet the pattern had to match:**' followed by this smoke gate snippet, which might slightly confuse the LLM since the actual failure was on the Example Hit snippet (detailed in the `Failure reason`). Consider passing the actual failed Example Hit snippet if the failure originated from `verifyRuleExamples`.",
+      "engine": "regex",
+      "severity": "warning",
+      "fileGlobs": [
+        "**/*.ts"
+      ],
+      "compiledAt": "2026-04-17T04:17:14.891Z",
+      "createdAt": "2026-04-17T04:17:14.891Z",
+      "status": "archived",
+      "archivedReason": "Orphan: no source lesson file exists in .totem/lessons/ for this hash. The rule was compiled at 2026-04-17T04:17:14.891Z but the parent manifest on main was generated at 2026-04-17T02:45:44 (off-by-one drift: manifest rule_count 425 vs actual 426). totem lesson compile drain step caught the orphan during #1517 refresh. Preserved in archived state for hash telemetry continuity per project convention; cannot be recompiled without re-authoring the lesson."
     }
   ],
   "nonCompilable": [

--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -171,7 +171,9 @@
         "packages/cli/**/*.ts",
         "packages/cli/**/*.js"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Pattern-message mismatch: astGrepPattern `import($MODULE)` fires on every dynamic import in the CLI, but the message tells developers to prefer dynamic imports. Every canonical lazy-load line trips a warning to do what it already does. Archived via #1517 + ADR-072 §3 (lazy-load via await import() established in PR #945, shipped 1.5.3)."
     },
     {
       "lessonHash": "2d364f952af19014",
@@ -383,7 +385,9 @@
         "**/*.tsx",
         "**/*.jsx"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Over-broad: astGrepPattern `async function $NAME($$$PARAMS) { $$$BODY }` matches every async function in the entire codebase across **/*.ts, **/*.js, **/*.tsx, **/*.jsx. Cannot distinguish factory functions hoisting dynamic imports from any other async function. Archived via #1517."
     },
     {
       "lessonHash": "b9e4125e6a31f2cf",
@@ -1271,7 +1275,9 @@
         "!**/*.test.ts",
         "!**/*.spec.ts"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Over-broad: astGrepPattern `import $NAME from '$MODULE'` matches every top-level default import in packages/cli/src/commands/** regardless of whether the module is heavy. Source of the 100+ warning storm on PR #1516. ADR-072 §3 reserves lazy-loading for heavy dependencies. Archived via #1517 + ADR-072 §3 (lazy-load via await import() established in PR #945, shipped 1.5.3)."
     },
     {
       "lessonHash": "427481b534fe3392",
@@ -2198,7 +2204,9 @@
         "!**/*.test.ts",
         "!**/*.spec.ts"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Over-broad: astGrepPattern `import $NAME from '$MODULE'` matches every top-level default import in packages/cli/src/commands/**. Contributes to the PR #1516 warning storm. Archived via #1517 + ADR-072 §3 (lazy-load via await import() established in PR #945, shipped 1.5.3)."
     },
     {
       "lessonHash": "d940b2c9ffe92e99",
@@ -2326,7 +2334,9 @@
         "!**/*.test.ts",
         "!**/*.spec.ts"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Hallucinated scope: pattern references '@core/' npm scope, which does not exist in this repository. No package.json declares it; no source file imports from it. Same failure mode as already-archived 0d0bbae4392c0255 ('@mcp-b/core'). Rule will never fire on real code. Archived via #1517."
     },
     {
       "lessonHash": "6d53d5fd241365d5",
@@ -2488,7 +2498,9 @@
         "packages/cli/**/*.ts",
         "packages/cli/**/*.js"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Message forbids dynamic import() inside command function bodies, which is the canonical lazy-load pattern for all 25 CLI commands. Contradicts #1517 + ADR-072 §3 (lazy-load via await import() established in PR #945, shipped 1.5.3)."
     },
     {
       "lessonHash": "dd4542e69ec3d5a1",
@@ -2695,7 +2707,9 @@
         "!**/*.test.ts",
         "!**/*.spec.ts"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Globs target packages/cli/src/commands/** but the message says \"avoid dynamic imports in shared utility modules\". Pattern fires on every canonical await import() in command handlers. Archived via #1517 + ADR-072 §3 (lazy-load via await import() established in PR #945, shipped 1.5.3)."
     },
     {
       "lessonHash": "fd5d891750fca994",
@@ -2772,7 +2786,9 @@
         "packages/cli/src/commands/**/*.ts",
         "!packages/cli/src/commands/index.ts"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Globs include packages/cli/src/commands/** (only index.ts excluded), but the message flags dynamic imports \"detected outside CLI command entry points\". Globs contradict intent and fire on every canonical lazy-load line. Archived via #1517 + ADR-072 §3 (lazy-load via await import() established in PR #945, shipped 1.5.3)."
     },
     {
       "lessonHash": "d4b86f844e149484",
@@ -2924,7 +2940,9 @@
         "!**/*.test.ts",
         "!**/*.spec.ts"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Over-broad: astGrepPattern `import $NAME from '$PKG'` matches every top-level default import in packages/cli/src/commands/** with no way to distinguish heavy internal packages from cheap built-ins. Archived via #1517 + ADR-072 §3 (lazy-load via await import() established in PR #945, shipped 1.5.3)."
     },
     {
       "lessonHash": "b93bd44e6c1d2d59",
@@ -2989,7 +3007,9 @@
         "!**/*.test.ts",
         "!**/*.spec.ts"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Globs `packages/cli/src/**/*.ts, !packages/cli/src/commands/**/*.ts` are over-broad: they match the CLI root entry files packages/cli/src/index.ts and index-lite.ts, which is precisely where ADR-072 §3 (PR #945) places lazy-loads of command handlers. Rule fires on every canonical `const { cmd } = await import('./commands/foo.js')` line in the two CLI bin entry files. Canonical utility-layer coverage retained via rules a1fd35ee696110b0 (utils/adapters/lib) and f6739f9ad356067a (utils/lib/helpers), which use correctly narrow globs. Archived via #1517."
     },
     {
       "lessonHash": "cccd9363ba696d53",
@@ -3622,7 +3642,9 @@
         "!**/*.test.ts",
         "!**/*.test.js"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Over-broad: astGrepPattern `import $NAME from '$MODULE'` fires on every top-level default import across packages/cli/**. Archived via #1517 + ADR-072 §3 (lazy-load via await import() established in PR #945, shipped 1.5.3)."
     },
     {
       "lessonHash": "cb854652a786c5d7",
@@ -3653,7 +3675,9 @@
         "!**/*.test.ts",
         "!**/*.spec.ts"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Globs `packages/cli/src/**/*.ts, !packages/cli/src/commands/**/*.ts` are over-broad: they match the CLI root entry files packages/cli/src/index.ts and index-lite.ts, which is precisely where ADR-072 §3 (PR #945) places lazy-loads of command handlers. Rule fires on every canonical `const { cmd } = await import('./commands/foo.js')` line in the two CLI bin entry files. Canonical utility-layer coverage retained via rules a1fd35ee696110b0 (utils/adapters/lib) and f6739f9ad356067a (utils/lib/helpers), which use correctly narrow globs. Archived via #1517."
     },
     {
       "lessonHash": "9f266a455f97fe37",
@@ -3814,7 +3838,9 @@
         "!**/*.test.ts",
         "!**/*.spec.ts"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Noise rule: astGrepPattern `import($MODULE)` fires on every canonical dynamic import in command handlers with a message saying the pattern is \"required\". No action for the developer. Archived via #1517 + ADR-072 §3 (lazy-load via await import() established in PR #945, shipped 1.5.3)."
     },
     {
       "lessonHash": "b38ceed379b48068",
@@ -4044,7 +4070,9 @@
         "!**/*.test.ts",
         "!**/*.spec.ts"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Over-broad: astGrepPattern `import $NAME from '$MODULE'` fires on every top-level default import in packages/cli/src/commands/**. Archived via #1517 + ADR-072 §3 (lazy-load via await import() established in PR #945, shipped 1.5.3)."
     },
     {
       "lessonHash": "c962ead45bcec3a0",
@@ -4243,7 +4271,9 @@
         "!**/*.test.ts",
         "!**/*.spec.ts"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Globs `packages/cli/src/**/*.ts, !packages/cli/src/commands/**/*.ts` are over-broad: they match the CLI root entry files packages/cli/src/index.ts and index-lite.ts, which is precisely where ADR-072 §3 (PR #945) places lazy-loads of command handlers. Rule fires on every canonical `const { cmd } = await import('./commands/foo.js')` line in the two CLI bin entry files. Canonical utility-layer coverage retained via rules a1fd35ee696110b0 (utils/adapters/lib) and f6739f9ad356067a (utils/lib/helpers), which use correctly narrow globs. Archived via #1517."
     },
     {
       "lessonHash": "2b570f4ebf0982cd",
@@ -4957,7 +4987,9 @@
         "!**/*.test.ts",
         "!**/*.spec.ts"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Globs `packages/cli/src/**/*.ts, !packages/cli/src/commands/**/*.ts` are over-broad: they match the CLI root entry files packages/cli/src/index.ts and index-lite.ts, which is precisely where ADR-072 §3 (PR #945) places lazy-loads of command handlers. Rule fires on every canonical `const { cmd } = await import('./commands/foo.js')` line in the two CLI bin entry files. Canonical utility-layer coverage retained via rules a1fd35ee696110b0 (utils/adapters/lib) and f6739f9ad356067a (utils/lib/helpers), which use correctly narrow globs. Archived via #1517."
     },
     {
       "lessonHash": "939ae83ed3bf28bb",
@@ -4988,7 +5020,9 @@
         "!**/*.test.ts",
         "!**/*.spec.ts"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Over-broad: astGrepPattern `import $NAME from '$MODULE'` fires on every top-level default import in packages/cli/src/commands/**. Archived via #1517 + ADR-072 §3 (lazy-load via await import() established in PR #945, shipped 1.5.3)."
     },
     {
       "lessonHash": "916e2117b749ce03",
@@ -5677,7 +5711,9 @@
         "!**/*.test.ts",
         "!**/*.spec.ts"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Over-broad: astGrepPattern `import $NAME from '$MODULE'` fires on every top-level default import in packages/cli/src/commands/** with no way to identify \"heavy logic or detection modules\". Archived via #1517 + ADR-072 §3 (lazy-load via await import() established in PR #945, shipped 1.5.3)."
     },
     {
       "lessonHash": "60c2e674222dc4e5",
@@ -5781,7 +5817,9 @@
         "packages/cli/**/commands/**/*.ts",
         "packages/cli/**/commands/**/*.js"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Over-broad: astGrepPattern `import { $$$IMPORTS } from '$MODULE'` fires on every top-level destructured import in packages/cli/**/commands/**. Cannot distinguish heavy schemas from cheap built-ins. Archived via #1517 + ADR-072 §3 (lazy-load via await import() established in PR #945, shipped 1.5.3)."
     },
     {
       "lessonHash": "f202f65f8a198f18",
@@ -6000,7 +6038,9 @@
         "!**/*.test.ts",
         "!**/*.spec.ts"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Over-broad: astGrepPattern `import $NAME from '$MODULE'` fires on every top-level default import in packages/cli/src/commands/**. Archived via #1517 + ADR-072 §3 (lazy-load via await import() established in PR #945, shipped 1.5.3)."
     },
     {
       "lessonHash": "4a408d868a972f5f",
@@ -6967,17 +7007,52 @@
       "severity": "warning"
     },
     {
-      "lessonHash": "263c3b88dc975aa3",
-      "lessonHeading": "Pipeline 5: observation from shield",
-      "pattern": "badExample:\\s+parsed\\.badExample\\s+\\?\\?\\s+'\\(no\\s+badExample\\s+emitted\\)',",
-      "message": "When retrying due to an Example Hit/Miss verification failure, the `badExample` passed to `previousFailure` is still `parsed.badExample` (the smoke gate snippet, which the pattern successfully matched). The retry directive prompt says '**Code snippet the pattern had to match:**' followed by this smoke gate snippet, which might slightly confuse the LLM since the actual failure was on the Example Hit snippet (detailed in the `Failure reason`). Consider passing the actual failed Example Hit snippet if the failure originated from `verifyRuleExamples`.",
+      "lessonHash": "600edf2e1c782b77",
+      "lessonHeading": "Initialize manifests with schema wrappers",
+      "message": "Initialize rule manifests as '{ \"version\": 1, \"rules\": [] }' instead of a bare array for schema-aware loader compatibility.",
+      "engine": "ast-grep",
+      "severity": "warning",
+      "pattern": "",
+      "astGrepPattern": "const $VAR = []",
+      "compiledAt": "2026-04-17T17:41:50.379Z",
+      "createdAt": "2026-04-17T17:41:50.379Z",
+      "fileGlobs": [
+        "packages/pack-agent-security/**/*.ts",
+        "packages/pack-agent-security/**/*.js"
+      ],
+      "badExample": "const manifest = [];",
+      "status": "archived",
+      "archivedReason": "Over-broad: astGrepPattern `const $VAR = []` fires on every empty-array declaration in packages/pack-agent-security/**, not only on manifest initializers. Cannot distinguish \"const manifest = []\" (the intended target) from \"const violations = []\" or any other transient empty-array. Same failure mode as the dynamic-import rules archived under #1517."
+    },
+    {
+      "lessonHash": "28cc46c09bd5820f",
+      "lessonHeading": "Allow null branches for detached HEADs",
+      "message": "currentBranch must allow null (string | null) to handle detached HEAD states in CI. Do not hardcode a non-null branch string in test fixtures.",
       "engine": "regex",
       "severity": "warning",
+      "pattern": "currentBranch:\\s*['\"][^'\"]+['\"]",
+      "compiledAt": "2026-04-17T17:41:49.160Z",
+      "createdAt": "2026-04-17T17:41:49.160Z",
       "fileGlobs": [
-        "**/*.ts"
+        "packages/mcp/src/**/*.test.ts",
+        "packages/mcp/src/**/*.test.tsx"
       ],
-      "compiledAt": "2026-04-17T04:17:14.891Z",
-      "createdAt": "2026-04-17T04:17:14.891Z"
+      "badExample": "const gitState = { currentBranch: 'main', commits: [] };"
+    },
+    {
+      "lessonHash": "854ee1ad7fe80c40",
+      "lessonHeading": "Claude Opus 4.7 rejects sampling parameters",
+      "message": "Claude Opus 4.7 rejects temperature, top_p, and top_k sampling parameters — strip them before calling the Messages API",
+      "engine": "ast-grep",
+      "severity": "warning",
+      "pattern": "",
+      "astGrepPattern": "client.messages.create({ $$$ARGS, temperature: $VAL, $$$REST })",
+      "compiledAt": "2026-04-17T17:42:07.419Z",
+      "createdAt": "2026-04-17T17:42:07.419Z",
+      "fileGlobs": [
+        "packages/cli/**/*.ts"
+      ],
+      "badExample": "client.messages.create({ model: 'claude-opus-4-7', temperature: 0.7, messages: [] });"
     }
   ],
   "nonCompilable": [

--- a/packages/cli/src/index-lite.ts
+++ b/packages/cli/src/index-lite.ts
@@ -258,7 +258,7 @@ program
   .option('--yes', 'Auto-approve .totemignore merge (required for non-interactive CI)')
   .action(async (target: string, options: { yes?: boolean }) => {
     try {
-      const { installCommand } = await import('./commands/install.js'); // totem-context: lazy import is the canonical CLI entry-point pattern (ADR-063)
+      const { installCommand } = await import('./commands/install.js');
       await installCommand(target, { yes: options.yes }); // totem-context: intentional cleanup — handleError is never-typed and calls process.exit(1)
     } catch (err) {
       handleError(err);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -484,7 +484,7 @@ program
   .option('--yes', 'Auto-approve .totemignore merge (required for non-interactive CI)')
   .action(async (target: string, options: { yes?: boolean }) => {
     try {
-      const { installCommand } = await import('./commands/install.js'); // totem-context: lazy import is the canonical CLI entry-point pattern (ADR-063)
+      const { installCommand } = await import('./commands/install.js');
       await installCommand(target, { yes: options.yes }); // totem-context: intentional cleanup — handleError is never-typed and calls process.exit(1)
     } catch (err) {
       handleError(err);


### PR DESCRIPTION
## Summary

Archives 21 compiled rules in `.totem/compiled-rules.json` that fired on the canonical CLI lazy-load pattern with contradictory intent. PR #1516 had to ship two narrow `totem-context:` suppressions as a workaround; this PR removes the root cause so future CLI command PRs don't pay the same tax.

## What's in the diff

**Archive bucket (21 rules):**
- 5 direct contradictions that forbade `await import()` inside command function bodies, which ADR-072 §3 (PR #945, 1.5.3) makes canonical for all 25 CLI commands.
- 9 over-broad variants that fired on every top-level static import in `packages/cli/src/commands/**` regardless of whether the module was heavy. Source of the 100+ warning storm on PR #1516.
- 4 duplicates with over-broad globs (`packages/cli/src/**/*.ts, !packages/cli/src/commands/**`) that caught the two CLI bin entry files (`index.ts`, `index-lite.ts`), precisely where ADR-072 §3 places lazy-loads.
- 1 rule targeting a hallucinated `@core/` npm scope (no such package in this repo).
- 1 rule whose pattern `async function $NAME` fired on every async function across all file types.
- 1 straggler caught during compile refresh: `600edf2e1c782b77`, pattern `const $VAR = []` in pack-agent-security, same over-broad failure mode.

**Keep bucket (retained narrowly-scoped rules):**
- `a1fd35ee696110b0` and `f6739f9ad356067a` — utility-layer guards with correctly narrow globs (`utils/**`, `adapters/**`, `lib/**`, `helpers/**`). Don't catch entry files.
- `b8763e4bd93c7314` (ora-specific), `9cede77f72fe608b` (tree-sitter WASM), `1408ec626c931051` (@mmnto/totem static-imports-in-commands), and others with narrow targets.

**Suppression cleanup:**
- Stripped the two `totem-context:` markers from commit `1cb11edc` on PR #1516 in `packages/cli/src/index.ts:487` and `packages/cli/src/index-lite.ts:261`.

**Along for the ride:**
- Strategy submodule pointer bump `44951cc → 5321472` for last session's Phase B grind journal.
- Two net-new active rules surfaced from compile catch-up on drifted lessons: `28cc46c09bd5820f` (detached-HEAD branch typing in mcp tests) and `854ee1ad7fe80c40` (Opus 4.7 sampling-parameter rejection in anthropic orchestrator). Both narrow.

## Why ADR-072 §3 and not ADR-063

The #1517 ticket body cited ADR-063, but that ADR is about context engineering principles. The actual canonical reference for the lazy-load convention is **ADR-072 §3**: "The 25 CLI commands already use `await import()` (shipped in 1.5.3, PR #945)." All `archivedReason` fields cite the corrected reference.

## Test plan

- [x] `totem lint` on the modified entry files passes with 0 violations (was 11 warnings before archive).
- [x] `totem verify-manifest` passes (428 rules, hashes match).
- [x] `pnpm run format` reports no changes.
- [x] Pre-push hooks pass (3030 tests, lint, manifest).
- [ ] CI pass on PR.

## Follow-up

Filed #1519 for source-lesson refinement. The archive filter (#1345) silences these rules operationally, but the underlying lesson files in `.totem/lessons/` could regenerate similar patterns on a future compile. That's separate body of work from this archive pass.

Closes #1517

🤖 Generated with [Claude Code](https://claude.com/claude-code)