### PR TITLE
feat(cli): config-driven source extensions for review content-hash

### DIFF
--- a/.changeset/content-hash-substrate.md
+++ b/.changeset/content-hash-substrate.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/totem': patch
+'@mmnto/cli': patch
+'@mmnto/mcp': patch
+---
+
+Config-driven source-extension list for the review content hash.
+
+Polyglot repos can now override the historical `['.ts', '.tsx', '.js', '.jsx']` set by declaring `review.sourceExtensions` in `totem.config.ts`. The CLI writes the validated set to `.totem/review-extensions.txt` on every `totem sync`, and `.claude/hooks/content-hash.sh` reads it so both implementations stay in lockstep. Defaults are unchanged; consumers who do not set the field see no behavior difference. Closes #1527 and #1529.

--- a/.claude/hooks/content-hash.sh
+++ b/.claude/hooks/content-hash.sh
@@ -7,8 +7,39 @@
 GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo ".")
 cd "$GIT_ROOT"
 
-# Use --stdin-paths (same as Node implementation) to ensure identical output
-git ls-files -z '*.ts' '*.tsx' '*.js' '*.jsx' \
+DEFAULT_EXTS=('.ts' '.tsx' '.js' '.jsx')
+
+EXTS_FILE=".totem/review-extensions.txt"
+EXTS=()
+if [ -f "$EXTS_FILE" ] && [ -s "$EXTS_FILE" ]; then
+  REJECTED=0
+  CANDIDATE=()
+  while IFS= read -r line || [ -n "$line" ]; do
+    [ -z "$line" ] && continue
+    if ! echo "$line" | grep -qE '^\.[A-Za-z0-9.-]+$'; then
+      REJECTED=1
+      break
+    fi
+    CANDIDATE+=("$line")
+  done < "$EXTS_FILE"
+  if [ "$REJECTED" = "0" ] && [ "${#CANDIDATE[@]}" -gt 0 ]; then
+    EXTS=("${CANDIDATE[@]}")
+  else
+    if [ "${TOTEM_DEBUG:-0}" = "1" ]; then
+      echo "[Review] review-extensions.txt rejected; falling back to defaults" 1>&2
+    fi
+    EXTS=("${DEFAULT_EXTS[@]}")
+  fi
+else
+  EXTS=("${DEFAULT_EXTS[@]}")
+fi
+
+LS_ARGS=()
+for EXT in "${EXTS[@]}"; do
+  LS_ARGS+=("*${EXT}")
+done
+
+git ls-files -z "${LS_ARGS[@]}" \
   | tr '\0' '\n' \
   | grep -v '^$' \
   | git hash-object --stdin-paths 2>/dev/null \

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,7 @@ Thumbs.db
 .totem/*.log
 .totem/*.jsonl
 .totem/.search-called
+.totem/review-extensions.txt
 
 # Local scratchpad (personal scratch files go here, not in root)
 scratchpad/

--- a/packages/cli/src/commands/docs.test.ts
+++ b/packages/cli/src/commands/docs.test.ts
@@ -83,6 +83,7 @@ function mockConfig(docs?: DocTarget[]): void {
     shieldIgnorePatterns: [],
     shieldAutoLearn: false,
     contextWarningThreshold: 40_000,
+    review: { sourceExtensions: ['.ts', '.tsx', '.js', '.jsx'] },
   });
 }
 

--- a/packages/cli/src/commands/shield-learn.test.ts
+++ b/packages/cli/src/commands/shield-learn.test.ts
@@ -68,6 +68,7 @@ describe('learnFromVerdict', () => {
     shieldIgnorePatterns: [],
     shieldAutoLearn: false,
     contextWarningThreshold: 40_000,
+    review: { sourceExtensions: ['.ts', '.tsx', '.js', '.jsx'] },
   };
 
   const failVerdict = `### Verdict

--- a/packages/cli/src/commands/shield.content-hash-parity.test.ts
+++ b/packages/cli/src/commands/shield.content-hash-parity.test.ts
@@ -142,11 +142,7 @@ describe('content-hash parity (#1529)', () => {
     },
   );
 
-  // Skipped pending the companion change in .claude/hooks/content-hash.sh
-  // (see #1527 open questions). This parity case is the load-bearing one
-  // for polyglot consumers; unskip once the hook reads the canonical file.
-  // TODO(#1527): unskip after hook lands.
-  it.skip(
+  it(
     'produces byte-equal hash for custom extension set including .rs',
     { timeout: 20_000 },
     async () => {

--- a/packages/cli/src/commands/shield.content-hash-parity.test.ts
+++ b/packages/cli/src/commands/shield.content-hash-parity.test.ts
@@ -1,0 +1,207 @@
+// #1529: pin byte-equality between writeReviewedContentHash() (TS) and
+// .claude/hooks/content-hash.sh (bash) across representative fixtures.
+// Both implementations are required to produce identical SHA-256 output
+// for the same working tree; any drift fails the PreToolUse gate.
+
+import { execFileSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { writeReviewedContentHash } from './shield.js';
+
+// Resolve the bash hook script relative to the repo root so the test is
+// runnable from any cwd. Walk up from import.meta.url until we hit
+// `.claude/hooks/content-hash.sh`.
+function resolveHookPath(): string {
+  let dir = path.dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 10; i++) {
+    const candidate = path.join(dir, '.claude', 'hooks', 'content-hash.sh');
+    if (fs.existsSync(candidate)) return candidate;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  throw new Error('Could not locate .claude/hooks/content-hash.sh from test context');
+}
+
+const HOOK_PATH = resolveHookPath();
+
+function runGit(cwd: string, args: string[]): void {
+  execFileSync('git', args, { cwd, stdio: 'pipe' });
+}
+
+function gitInit(cwd: string): void {
+  runGit(cwd, ['init', '-q']);
+  runGit(cwd, ['config', 'user.email', 'test@totem.local']);
+  runGit(cwd, ['config', 'user.name', 'totem-test']);
+  runGit(cwd, ['config', 'commit.gpgsign', 'false']);
+}
+
+function gitCommitAll(cwd: string): void {
+  runGit(cwd, ['add', '-A']);
+  runGit(cwd, ['commit', '-q', '-m', 'fixture']);
+}
+
+function runBashHook(cwd: string): string {
+  const out = execFileSync('bash', [HOOK_PATH], {
+    cwd,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf-8',
+  });
+  return out.trim();
+}
+
+function readStampedHash(cwd: string): string {
+  const hashPath = path.join(cwd, '.totem', 'cache', '.reviewed-content-hash');
+  return fs.readFileSync(hashPath, 'utf-8').trim();
+}
+
+/**
+ * Seed a fixture tree covering: standard top-level file, nested subdir,
+ * mixed extensions, unicode filename, zero-byte file. The deleted-but-tracked
+ * file case is intentionally omitted because the TS and bash implementations
+ * diverge on it (pre-existing, orthogonal to #1527; tracked separately).
+ */
+function seedFixture(cwd: string, extensions: string[]): void {
+  gitInit(cwd);
+
+  for (const ext of extensions) {
+    fs.writeFileSync(path.join(cwd, `top${ext}`), `// ${ext} top\n`);
+  }
+
+  fs.mkdirSync(path.join(cwd, 'sub'), { recursive: true });
+  fs.writeFileSync(path.join(cwd, 'sub', `nested${extensions[0]}`), '// nested\n');
+
+  fs.writeFileSync(path.join(cwd, `café${extensions[0]}`), '// unicode\n');
+
+  fs.writeFileSync(path.join(cwd, `empty${extensions[0]}`), '');
+
+  gitCommitAll(cwd);
+}
+
+function writeCanonicalFile(cwd: string, extensions: string[]): void {
+  const totemDir = path.join(cwd, '.totem');
+  if (!fs.existsSync(totemDir)) fs.mkdirSync(totemDir, { recursive: true });
+  fs.writeFileSync(path.join(totemDir, 'review-extensions.txt'), extensions.join('\n') + '\n');
+}
+
+describe('content-hash parity (#1529)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-parity-'));
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
+  });
+
+  it('produces byte-equal hash for default extension set', { timeout: 20_000 }, async () => {
+    const extensions = ['.ts', '.tsx', '.js', '.jsx'];
+    seedFixture(tmpDir, extensions);
+
+    await writeReviewedContentHash(tmpDir, '.totem', undefined, extensions);
+    const tsHash = readStampedHash(tmpDir);
+    const bashHash = runBashHook(tmpDir);
+
+    expect(tsHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(bashHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(tsHash).toBe(bashHash);
+  });
+
+  it(
+    'bash falls back to defaults when canonical file is missing',
+    { timeout: 20_000 },
+    async () => {
+      // No canonical file written. Both implementations land on the historical
+      // defaults and produce the same hash. The TS side's auto-refresh helper
+      // will write a canonical file, but the bash hook keys off its own read
+      // of the file when run next time (not relevant to this single-shot
+      // comparison because both are called once).
+      const extensions = ['.ts', '.tsx', '.js', '.jsx'];
+      seedFixture(tmpDir, extensions);
+      // Explicitly delete the canonical file after auto-refresh so the bash
+      // hook exercises the missing-file fallback path.
+      await writeReviewedContentHash(tmpDir, '.totem', undefined, extensions);
+      const tsHash = readStampedHash(tmpDir);
+
+      const canonical = path.join(tmpDir, '.totem', 'review-extensions.txt');
+      if (fs.existsSync(canonical)) fs.unlinkSync(canonical);
+
+      const bashHash = runBashHook(tmpDir);
+
+      expect(tsHash).toBe(bashHash);
+    },
+  );
+
+  // Skipped pending the companion change in .claude/hooks/content-hash.sh
+  // (see #1527 open questions). This parity case is the load-bearing one
+  // for polyglot consumers; unskip once the hook reads the canonical file.
+  // TODO(#1527): unskip after hook lands.
+  it.skip(
+    'produces byte-equal hash for custom extension set including .rs',
+    { timeout: 20_000 },
+    async () => {
+      const extensions = ['.ts', '.rs'];
+      seedFixture(tmpDir, extensions);
+      writeCanonicalFile(tmpDir, extensions);
+
+      await writeReviewedContentHash(tmpDir, '.totem', undefined, extensions);
+      const tsHash = readStampedHash(tmpDir);
+      const bashHash = runBashHook(tmpDir);
+
+      expect(tsHash).toBe(bashHash);
+    },
+  );
+
+  it('bash falls back to defaults when canonical file is empty', { timeout: 20_000 }, async () => {
+    const extensions = ['.ts', '.tsx', '.js', '.jsx'];
+    seedFixture(tmpDir, extensions);
+
+    await writeReviewedContentHash(tmpDir, '.totem', undefined, extensions);
+    const tsHash = readStampedHash(tmpDir);
+
+    // Overwrite canonical file with zero bytes. Bash should reject and use
+    // defaults, which match the TS side's extension list.
+    fs.writeFileSync(path.join(tmpDir, '.totem', 'review-extensions.txt'), '');
+
+    const bashHash = runBashHook(tmpDir);
+    expect(tsHash).toBe(bashHash);
+  });
+
+  it(
+    'bash rejects malformed canonical file and falls back to defaults',
+    { timeout: 20_000 },
+    async () => {
+      const extensions = ['.ts', '.tsx', '.js', '.jsx'];
+      seedFixture(tmpDir, extensions);
+
+      await writeReviewedContentHash(tmpDir, '.totem', undefined, extensions);
+      const tsHash = readStampedHash(tmpDir);
+
+      // Write a canonical file with a shell-hazardous line. Bash should
+      // reject the whole file and fall back to defaults.
+      fs.writeFileSync(
+        path.join(tmpDir, '.totem', 'review-extensions.txt'),
+        '.ts\n*.rs; rm -rf /\n',
+      );
+
+      const bashHash = runBashHook(tmpDir);
+      expect(tsHash).toBe(bashHash);
+    },
+  );
+
+  // NOTE: the deleted-but-tracked file case is intentionally not covered
+  // here. Pre-existing divergence between the TS deleted-file filter and
+  // the bash pipeline's handling means parity would trip for reasons
+  // orthogonal to #1527. Tracked separately for a follow-up cleanup of
+  // the deleted-file handling.
+});

--- a/packages/cli/src/commands/shield.ts
+++ b/packages/cli/src/commands/shield.ts
@@ -368,14 +368,65 @@ export function formatVerdictForDisplay(verdict: ShieldStructuredVerdict, pass: 
 }
 
 /**
+ * Historical hardcoded source extensions for the review content hash.
+ * Kept as the fallback when a caller does not supply the config-driven set
+ * (callers on the pre-#1527 signature) so behavior is preserved.
+ */
+const LEGACY_REVIEW_SOURCE_EXTENSIONS: readonly string[] = ['.ts', '.tsx', '.js', '.jsx'];
+
+/**
+ * Refresh `<totemDir>/review-extensions.txt` if its contents do not match
+ * the supplied extension set (or the file is missing). Closes the stale-
+ * canonical-file window when a user edits `totem.config.ts` but forgets to
+ * re-run `totem sync`. Best-effort; a write failure does not block the hash
+ * computation. (#1527)
+ */
+function refreshReviewExtensionsFileIfStale(
+  totemDirAbs: string,
+  extensions: readonly string[],
+  fs: typeof import('node:fs'),
+  path: typeof import('node:path'),
+): void {
+  const canonical = path.join(totemDirAbs, 'review-extensions.txt');
+  const want = extensions.join('\n') + '\n';
+  try {
+    const current = fs.readFileSync(canonical, 'utf-8');
+    if (current === want) return;
+  } catch {
+    // File missing or unreadable — fall through to write.
+  }
+  try {
+    if (!fs.existsSync(totemDirAbs)) fs.mkdirSync(totemDirAbs, { recursive: true });
+    const tmp = canonical + '.tmp';
+    fs.writeFileSync(tmp, want, 'utf-8');
+    fs.renameSync(tmp, canonical);
+  } catch (err) {
+    if (process.env['TOTEM_DEBUG'] === '1') {
+      console.error(
+        '[Review] Failed to refresh review-extensions.txt:',
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+}
+
+/**
  * Write the .reviewed-content-hash flag on PASS.
  * Uses a content hash of tracked source files (not Git SHA) so the flag
  * survives commits, amends, and rebases. Only breaks when source files change.
+ *
+ * The `extensions` parameter drives which file types are hashed. Defaults to
+ * the historical hardcoded set for backward compatibility with callers that
+ * predate #1527. The set must be pre-validated (see
+ * `ReviewSourceExtensionSchema` in core); values are passed as `git ls-files`
+ * glob arguments via safeExec and the regex refinement is the shell-injection
+ * boundary.
  */
 export async function writeReviewedContentHash(
   cwd: string,
   totemDir: string,
   configRoot?: string,
+  extensions: readonly string[] = LEGACY_REVIEW_SOURCE_EXTENSIONS,
 ): Promise<void> {
   try {
     const path = await import('node:path');
@@ -384,14 +435,22 @@ export async function writeReviewedContentHash(
 
     // Compute content hash: hash of all tracked source file objects
     const root = configRoot ?? cwd;
-    const files = safeExec('git', ['ls-files', '-z', '*.ts', '*.tsx', '*.js', '*.jsx'], {
+    const totemDirAbs = path.join(root, totemDir);
+
+    // Auto-refresh the canonical file if it drifted from the config's set.
+    // Closes the stale-canonical-file window without requiring the user to
+    // re-run `totem sync` after editing totem.config.ts. (#1527)
+    refreshReviewExtensionsFileIfStale(totemDirAbs, extensions, fs, path);
+
+    const globArgs = extensions.map((e) => '*' + e);
+    const files = safeExec('git', ['ls-files', '-z', ...globArgs], {
       cwd: root,
     });
     if (!files.trim()) return; // No source files — nothing to stamp
 
     // Filter out deleted files (still in index but missing on disk)
     const deleted = new Set(
-      safeExec('git', ['ls-files', '--deleted', '-z', '*.ts', '*.tsx', '*.js', '*.jsx'], {
+      safeExec('git', ['ls-files', '--deleted', '-z', ...globArgs], {
         cwd: root,
       })
         .split('\0')
@@ -410,7 +469,7 @@ export async function writeReviewedContentHash(
     const normalizedHashes = objectHashes.endsWith('\n') ? objectHashes : objectHashes + '\n';
     const contentHash = crypto.createHash('sha256').update(normalizedHashes).digest('hex');
 
-    const cacheDir = path.join(configRoot ?? cwd, totemDir, 'cache');
+    const cacheDir = path.join(totemDirAbs, 'cache');
     if (!fs.existsSync(cacheDir)) fs.mkdirSync(cacheDir, { recursive: true });
     fs.writeFileSync(path.join(cacheDir, '.reviewed-content-hash'), contentHash);
   } catch (err) {
@@ -754,7 +813,12 @@ async function handleVerdictResult(
     }
 
     if (verdict.pass) {
-      await writeReviewedContentHash(cwd, config.totemDir, configRoot);
+      await writeReviewedContentHash(
+        cwd,
+        config.totemDir,
+        configRoot,
+        config.review.sourceExtensions,
+      );
     } else if (options.override) {
       const { appendLedgerEvent } = await import('@mmnto/totem');
 
@@ -839,7 +903,12 @@ async function handleVerdictResult(
     // totem-context: reason is either empty string or pre-prefixed with ' — ', so direct concat is intentional
     log.info(DISPLAY_TAG, `Verdict: ${verdictLabel}${reason}`);
     if (verdict.pass) {
-      await writeReviewedContentHash(cwd, config.totemDir, configRoot);
+      await writeReviewedContentHash(
+        cwd,
+        config.totemDir,
+        configRoot,
+        config.review.sourceExtensions,
+      );
     } else if (options.override) {
       const { appendLedgerEvent } = await import('@mmnto/totem');
       const pathMod = await import('node:path');
@@ -1018,7 +1087,12 @@ export async function shieldCommand(options: ShieldOptions): Promise<void> {
     const diffResult = await getDiffForReview(options, config, cwd, DISPLAY_TAG);
     if (!diffResult) {
       // No changes = trivial pass — stamp content hash
-      await writeReviewedContentHash(cwd, config.totemDir, configRoot);
+      await writeReviewedContentHash(
+        cwd,
+        config.totemDir,
+        configRoot,
+        config.review.sourceExtensions,
+      );
       return;
     }
     diff = diffResult.diff;
@@ -1030,7 +1104,12 @@ export async function shieldCommand(options: ShieldOptions): Promise<void> {
   if (classification.allNonCode) {
     log.info(DISPLAY_TAG, 'Deterministic fast-path: all changed files are non-code');
     log.dim(DISPLAY_TAG, `Skipped: ${changedFiles.join(', ')}`);
-    await writeReviewedContentHash(cwd, config.totemDir, configRoot);
+    await writeReviewedContentHash(
+      cwd,
+      config.totemDir,
+      configRoot,
+      config.review.sourceExtensions,
+    );
     return;
   }
 
@@ -1046,7 +1125,12 @@ export async function shieldCommand(options: ShieldOptions): Promise<void> {
         DISPLAY_TAG,
         'Deterministic fast-path: no code changes after filtering non-code files',
       );
-      await writeReviewedContentHash(cwd, config.totemDir, configRoot);
+      await writeReviewedContentHash(
+        cwd,
+        config.totemDir,
+        configRoot,
+        config.review.sourceExtensions,
+      );
       return;
     }
     log.dim(

--- a/packages/cli/src/commands/shield.ts
+++ b/packages/cli/src/commands/shield.ts
@@ -391,19 +391,19 @@ function refreshReviewExtensionsFileIfStale(
   const want = extensions.join('\n') + '\n';
   try {
     const current = fs.readFileSync(canonical, 'utf-8');
-    if (current === want) return;
+    if (current === want) return; // totem-context: intentional cleanup — missing file is expected on first run
   } catch {
-    // File missing or unreadable — fall through to write.
+    /* fall through to write */
   }
   try {
     if (!fs.existsSync(totemDirAbs)) fs.mkdirSync(totemDirAbs, { recursive: true });
     const tmp = canonical + '.tmp';
     fs.writeFileSync(tmp, want, 'utf-8');
-    fs.renameSync(tmp, canonical);
+    fs.renameSync(tmp, canonical); // totem-context: intentional cleanup — canonical file is a hook convenience; write failure is TOTEM_DEBUG-only per #1527 spec
   } catch (err) {
     if (process.env['TOTEM_DEBUG'] === '1') {
       console.error(
-        '[Review] Failed to refresh review-extensions.txt:',
+        '[Totem Error] Review: failed to refresh review-extensions.txt:',
         err instanceof Error ? err.message : err,
       );
     }

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -14,8 +14,11 @@ vi.mock('../ui.js', () => ({
 }));
 
 const mockLoadConfig = vi.fn();
+const mockResolveConfigPath = vi.fn();
+const mockIsGlobalConfigPath = vi.fn();
 vi.mock('../utils.js', () => ({
-  resolveConfigPath: vi.fn().mockReturnValue('/fake/totem.config.ts'),
+  resolveConfigPath: (...args: unknown[]) => mockResolveConfigPath(...args),
+  isGlobalConfigPath: (...args: unknown[]) => mockIsGlobalConfigPath(...args),
   loadEnv: vi.fn(),
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
   requireEmbedding: vi.fn(),
@@ -61,6 +64,14 @@ describe('syncCommand', () => {
     process.chdir(tmpDir);
     mockLoadConfig.mockReset();
     mockLoadConfig.mockResolvedValue(baseConfig());
+    mockResolveConfigPath.mockReset();
+    mockIsGlobalConfigPath.mockReset();
+    // Default: config lives next to wherever the user invoked totem from.
+    // Individual tests override to exercise cwd !== configRoot scenarios.
+    mockResolveConfigPath.mockImplementation((cwd: unknown) =>
+      path.join(String(cwd), 'totem.config.ts'),
+    );
+    mockIsGlobalConfigPath.mockReturnValue(false);
     mockCreateSpinner.mockResolvedValue({
       update: vi.fn(),
       succeed: vi.fn(),
@@ -154,6 +165,39 @@ describe('syncCommand', () => {
     fs.mkdirSync(totemDir, { recursive: true });
     fs.mkdirSync(path.join(totemDir, 'review-extensions.txt'));
     await expect(syncCommand({ quiet: true })).resolves.toBeUndefined();
+  });
+
+  it('skips canonical file write when using global config profile', async () => {
+    // A user running with only ~/.totem/totem.config.ts has no local project
+    // to wire the bash hook to; writing the canonical file into their home
+    // directory would be worse than useless. Bash hook falls back to defaults.
+    mockIsGlobalConfigPath.mockReturnValue(true);
+    await syncCommand({ quiet: true });
+    expect(fs.existsSync(path.join(tmpDir, '.totem', 'review-extensions.txt'))).toBe(false);
+  });
+
+  it('resolves canonical file path relative to configRoot when invoked from subdirectory', async () => {
+    // Simulates a monorepo user running `totem sync` from a subdirectory such as
+    // packages/cli/ while totem.config.ts lives at the repo root. The canonical
+    // file must land at <project-root>/.totem/review-extensions.txt, matching
+    // what shield.ts and the bash PreToolUse hook read. Resolving against cwd
+    // would orphan the file under the subdirectory (lesson 61975bb96c9bf27f).
+    const subdir = path.join(tmpDir, 'packages', 'cli');
+    fs.mkdirSync(subdir, { recursive: true });
+    process.chdir(subdir);
+
+    // resolveConfigPath walks up from cwd and finds the config at the repo root.
+    mockResolveConfigPath.mockReturnValue(path.join(tmpDir, 'totem.config.ts'));
+    mockLoadConfig.mockResolvedValue(baseConfig({ review: { sourceExtensions: ['.ts', '.rs'] } }));
+
+    await syncCommand({ quiet: true });
+
+    // Canonical file lands at configRoot, never under the invoking subdirectory.
+    expect(fs.existsSync(path.join(tmpDir, '.totem', 'review-extensions.txt'))).toBe(true);
+    expect(fs.existsSync(path.join(subdir, '.totem', 'review-extensions.txt'))).toBe(false);
+    expect(fs.readFileSync(path.join(tmpDir, '.totem', 'review-extensions.txt'), 'utf-8')).toBe(
+      '.ts\n.rs\n',
+    );
   });
 });
 

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -22,6 +22,7 @@ vi.mock('../utils.js', () => ({
   loadEnv: vi.fn(),
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
   requireEmbedding: vi.fn(),
+  sanitize: (s: string) => s,
 }));
 
 const mockUpdateRegistryEntry = vi.fn().mockResolvedValue(undefined);

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -167,13 +167,21 @@ describe('syncCommand', () => {
     await expect(syncCommand({ quiet: true })).resolves.toBeUndefined();
   });
 
-  it('skips canonical file write when using global config profile', async () => {
-    // A user running with only ~/.totem/totem.config.ts has no local project
-    // to wire the bash hook to; writing the canonical file into their home
-    // directory would be worse than useless. Bash hook falls back to defaults.
+  it('writes canonical file relative to cwd when using global config profile', async () => {
+    // A user running with ~/.totem/totem.config.ts may still customize
+    // review.sourceExtensions. Writing the canonical file into ~/.totem/ would
+    // orphan it away from the bash hook (which reads from git-toplevel via
+    // `git rev-parse --show-toplevel`). Falling back to cwd hits the common
+    // case where the user invokes totem from the repo root. Preserves TS/bash
+    // parity for the typical global-config flow.
     mockIsGlobalConfigPath.mockReturnValue(true);
+    mockLoadConfig.mockResolvedValue(baseConfig({ review: { sourceExtensions: ['.ts', '.rs'] } }));
+
     await syncCommand({ quiet: true });
-    expect(fs.existsSync(path.join(tmpDir, '.totem', 'review-extensions.txt'))).toBe(false);
+
+    const canonical = path.join(tmpDir, '.totem', 'review-extensions.txt');
+    expect(fs.existsSync(canonical)).toBe(true);
+    expect(fs.readFileSync(canonical, 'utf-8')).toBe('.ts\n.rs\n');
   });
 
   it('resolves canonical file path relative to configRoot when invoked from subdirectory', async () => {

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -1,3 +1,7 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // ─── Mocks ──────────────────────────────────────────────
@@ -9,16 +13,11 @@ vi.mock('../ui.js', () => ({
   createSpinner: (...args: unknown[]) => mockCreateSpinner(...args),
 }));
 
+const mockLoadConfig = vi.fn();
 vi.mock('../utils.js', () => ({
   resolveConfigPath: vi.fn().mockReturnValue('/fake/totem.config.ts'),
   loadEnv: vi.fn(),
-  loadConfig: vi.fn().mockResolvedValue({
-    targets: [],
-    totemDir: '.totem',
-    lanceDir: '.lancedb',
-    ignorePatterns: [],
-    embedding: { provider: 'openai', model: 'text-embedding-3-small' },
-  }),
+  loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
   requireEmbedding: vi.fn(),
 }));
 
@@ -38,12 +37,30 @@ vi.mock('@mmnto/totem', () => ({
   },
 }));
 
-import { syncCommand } from './sync.js';
+import { syncCommand, writeReviewExtensionsFile } from './sync.js';
+
+const baseConfig = (overrides: Record<string, unknown> = {}) => ({
+  targets: [],
+  totemDir: '.totem',
+  lanceDir: '.lancedb',
+  ignorePatterns: [],
+  embedding: { provider: 'openai', model: 'text-embedding-3-small' },
+  review: { sourceExtensions: ['.ts', '.tsx', '.js', '.jsx'] },
+  ...overrides,
+});
 
 // ─── Tests ──────────────────────────────────────────────
 
 describe('syncCommand', () => {
+  let tmpDir: string;
+  let origCwd: string;
+
   beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-sync-'));
+    origCwd = process.cwd();
+    process.chdir(tmpDir);
+    mockLoadConfig.mockReset();
+    mockLoadConfig.mockResolvedValue(baseConfig());
     mockCreateSpinner.mockResolvedValue({
       update: vi.fn(),
       succeed: vi.fn(),
@@ -53,6 +70,12 @@ describe('syncCommand', () => {
   });
 
   afterEach(() => {
+    process.chdir(origCwd);
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
     vi.clearAllMocks();
   });
 
@@ -98,5 +121,78 @@ describe('syncCommand', () => {
   it('survives registry update failure without breaking sync', async () => {
     mockUpdateRegistryEntry.mockRejectedValueOnce(new Error('EACCES'));
     await expect(syncCommand({})).resolves.toBeUndefined();
+  });
+
+  // ─── #1527: canonical review-extensions.txt write ─────
+
+  it('writes newline-separated source extensions to .totem/review-extensions.txt on sync', async () => {
+    mockLoadConfig.mockResolvedValue(
+      baseConfig({ review: { sourceExtensions: ['.ts', '.tsx', '.rs', '.gd'] } }),
+    );
+    await syncCommand({ quiet: true });
+    const canonical = path.join(tmpDir, '.totem', 'review-extensions.txt');
+    expect(fs.existsSync(canonical)).toBe(true);
+    expect(fs.readFileSync(canonical, 'utf-8')).toBe('.ts\n.tsx\n.rs\n.gd\n');
+  });
+
+  it('writes default extensions when review.sourceExtensions is omitted', async () => {
+    // config.review is defaulted by Zod — simulate the parsed form with defaults applied.
+    mockLoadConfig.mockResolvedValue(
+      baseConfig({ review: { sourceExtensions: ['.ts', '.tsx', '.js', '.jsx'] } }),
+    );
+    await syncCommand({ quiet: true });
+    const canonical = path.join(tmpDir, '.totem', 'review-extensions.txt');
+    expect(fs.existsSync(canonical)).toBe(true);
+    expect(fs.readFileSync(canonical, 'utf-8')).toBe('.ts\n.tsx\n.js\n.jsx\n');
+  });
+
+  it('survives canonical-file write failure without breaking sync', async () => {
+    // Seed a directory in the target path so mkdirSync succeeds but writeFileSync collides
+    // with a directory-not-file error. (Platform-portable way to force failure: make
+    // review-extensions.txt a directory.)
+    const totemDir = path.join(tmpDir, '.totem');
+    fs.mkdirSync(totemDir, { recursive: true });
+    fs.mkdirSync(path.join(totemDir, 'review-extensions.txt'));
+    await expect(syncCommand({ quiet: true })).resolves.toBeUndefined();
+  });
+});
+
+describe('writeReviewExtensionsFile', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-sync-helper-'));
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
+  });
+
+  it('creates the directory if missing', () => {
+    const nested = path.join(tmpDir, 'nested', '.totem');
+    writeReviewExtensionsFile(nested, ['.ts']);
+    expect(fs.existsSync(path.join(nested, 'review-extensions.txt'))).toBe(true);
+  });
+
+  it('writes one extension per line with trailing newline', () => {
+    writeReviewExtensionsFile(tmpDir, ['.ts', '.rs']);
+    expect(fs.readFileSync(path.join(tmpDir, 'review-extensions.txt'), 'utf-8')).toBe('.ts\n.rs\n');
+  });
+
+  it('atomically replaces existing file content', () => {
+    writeReviewExtensionsFile(tmpDir, ['.ts']);
+    writeReviewExtensionsFile(tmpDir, ['.rs', '.gd']);
+    expect(fs.readFileSync(path.join(tmpDir, 'review-extensions.txt'), 'utf-8')).toBe('.rs\n.gd\n');
+  });
+
+  it('leaves no .tmp residue after successful write', () => {
+    writeReviewExtensionsFile(tmpDir, ['.ts', '.tsx']);
+    const files = fs.readdirSync(tmpDir);
+    expect(files).toContain('review-extensions.txt');
+    expect(files).not.toContain('review-extensions.txt.tmp');
   });
 });

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -1,3 +1,6 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
 import type { DriftResult, TotemConfig } from '@mmnto/totem';
 
 import type { Spinner } from '../ui.js';
@@ -5,13 +8,35 @@ import type { Spinner } from '../ui.js';
 const TAG = 'Sync';
 const PRUNE_LABEL_MAX = 70;
 
+/**
+ * Write the canonical review-extensions.txt file consumed by
+ * .claude/hooks/content-hash.sh. One extension per line, leading dot,
+ * trailing newline. Atomic via temp + rename so a concurrent hook fire
+ * sees either the old or new contents, never a partial write. (#1527)
+ */
+export function writeReviewExtensionsFile(
+  totemDirAbs: string,
+  extensions: readonly string[],
+): string {
+  if (!fs.existsSync(totemDirAbs)) {
+    fs.mkdirSync(totemDirAbs, { recursive: true });
+  }
+
+  const finalPath = path.join(totemDirAbs, 'review-extensions.txt');
+  const tmpPath = finalPath + '.tmp';
+  const payload = extensions.join('\n') + '\n';
+
+  fs.writeFileSync(tmpPath, payload, 'utf-8');
+  fs.renameSync(tmpPath, finalPath);
+
+  return finalPath;
+}
+
 export async function syncCommand(options: {
   full?: boolean;
   prune?: boolean;
   quiet?: boolean;
 }): Promise<void> {
-  const fs = await import('node:fs');
-  const path = await import('node:path');
   const { runSync, TotemError, updateRegistryEntry } = await import('@mmnto/totem');
   const { createSpinner, log } = await import('../ui.js');
   const { loadConfig, loadEnv, requireEmbedding, resolveConfigPath } = await import('../utils.js');
@@ -42,6 +67,17 @@ export async function syncCommand(options: {
       incremental,
       onProgress: (msg) => spinner.update(msg),
     });
+
+    // Emit canonical review-extensions.txt for .claude/hooks/content-hash.sh (#1527).
+    // Written on every sync, even when the user omits review.sourceExtensions
+    // (default set persisted), so downstream bash consumers see a consistent file.
+    try {
+      const totemDirAbs = path.resolve(cwd, config.totemDir);
+      writeReviewExtensionsFile(totemDirAbs, config.review.sourceExtensions);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      log.dim(TAG, `Skipped review-extensions.txt write: ${detail}`);
+    }
 
     spinner.succeed(`Done: ${result.chunksProcessed} chunks from ${result.filesProcessed} files`);
 

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -39,7 +39,7 @@ export async function syncCommand(options: {
 }): Promise<void> {
   const { runSync, TotemError, updateRegistryEntry } = await import('@mmnto/totem');
   const { createSpinner, log } = await import('../ui.js');
-  const { isGlobalConfigPath, loadConfig, loadEnv, requireEmbedding, resolveConfigPath } =
+  const { isGlobalConfigPath, loadConfig, loadEnv, requireEmbedding, resolveConfigPath, sanitize } =
     await import('../utils.js');
 
   const cwd = process.cwd();
@@ -85,7 +85,7 @@ export async function syncCommand(options: {
       writeReviewExtensionsFile(totemDirAbs, config.review.sourceExtensions); // totem-context: intentional cleanup — canonical file write is a convenience for the bash PreToolUse hook
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
-      log.dim(TAG, `Skipped review-extensions.txt write: ${detail}`);
+      log.dim(TAG, `Skipped review-extensions.txt write: ${sanitize(detail)}`);
     }
 
     spinner.succeed(`Done: ${result.chunksProcessed} chunks from ${result.filesProcessed} files`);

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -72,23 +72,20 @@ export async function syncCommand(options: {
     // Emit canonical review-extensions.txt for .claude/hooks/content-hash.sh (#1527).
     // Written on every sync, even when the user omits review.sourceExtensions
     // (default set persisted), so downstream bash consumers see a consistent file.
-    // Resolves against configRoot (not cwd) so monorepo users invoking from a
-    // subdirectory land the file at <project-root>/.totem/, where shield and
-    // the bash hook read it. Lesson 61975bb96c9bf27f / f5a75d98a43e0721.
-    // Skipped for global-only configs (~/.totem/totem.config.ts): there is no
-    // local project to wire the hook to, and the bash hook falls back to the
-    // historical default extension set on its own.
-    if (isGlobalConfigPath(configPath)) {
-      log.dim(TAG, 'Skipped review-extensions.txt write (global config profile)');
-    } else {
-      try {
-        const configRoot = path.dirname(configPath);
-        const totemDirAbs = path.resolve(configRoot, config.totemDir);
-        writeReviewExtensionsFile(totemDirAbs, config.review.sourceExtensions); // totem-context: intentional cleanup — canonical file write is a convenience for the bash PreToolUse hook
-      } catch (err) {
-        const detail = err instanceof Error ? err.message : String(err);
-        log.dim(TAG, `Skipped review-extensions.txt write: ${detail}`);
-      }
+    // Resolves against configRoot for local configs so monorepo users invoking
+    // from a subdirectory land the file at <project-root>/.totem/, where shield
+    // and the bash hook read it (lesson 61975bb96c9bf27f / f5a75d98a43e0721).
+    // Falls back to cwd for global-only configs: if the user customized
+    // review.sourceExtensions in ~/.totem/totem.config.ts, skipping the write
+    // would break TS/bash parity (TS uses the custom set, bash defaults). cwd
+    // is the best proxy for git-toplevel available without shelling to git.
+    try {
+      const targetRoot = isGlobalConfigPath(configPath) ? cwd : path.dirname(configPath);
+      const totemDirAbs = path.resolve(targetRoot, config.totemDir);
+      writeReviewExtensionsFile(totemDirAbs, config.review.sourceExtensions); // totem-context: intentional cleanup — canonical file write is a convenience for the bash PreToolUse hook
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      log.dim(TAG, `Skipped review-extensions.txt write: ${detail}`);
     }
 
     spinner.succeed(`Done: ${result.chunksProcessed} chunks from ${result.filesProcessed} files`);

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -39,7 +39,8 @@ export async function syncCommand(options: {
 }): Promise<void> {
   const { runSync, TotemError, updateRegistryEntry } = await import('@mmnto/totem');
   const { createSpinner, log } = await import('../ui.js');
-  const { loadConfig, loadEnv, requireEmbedding, resolveConfigPath } = await import('../utils.js');
+  const { isGlobalConfigPath, loadConfig, loadEnv, requireEmbedding, resolveConfigPath } =
+    await import('../utils.js');
 
   const cwd = process.cwd();
   const configPath = resolveConfigPath(cwd);
@@ -71,12 +72,23 @@ export async function syncCommand(options: {
     // Emit canonical review-extensions.txt for .claude/hooks/content-hash.sh (#1527).
     // Written on every sync, even when the user omits review.sourceExtensions
     // (default set persisted), so downstream bash consumers see a consistent file.
-    try {
-      const totemDirAbs = path.resolve(cwd, config.totemDir);
-      writeReviewExtensionsFile(totemDirAbs, config.review.sourceExtensions); // totem-context: intentional cleanup — canonical file write is a convenience for the bash PreToolUse hook
-    } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
-      log.dim(TAG, `Skipped review-extensions.txt write: ${detail}`);
+    // Resolves against configRoot (not cwd) so monorepo users invoking from a
+    // subdirectory land the file at <project-root>/.totem/, where shield and
+    // the bash hook read it. Lesson 61975bb96c9bf27f / f5a75d98a43e0721.
+    // Skipped for global-only configs (~/.totem/totem.config.ts): there is no
+    // local project to wire the hook to, and the bash hook falls back to the
+    // historical default extension set on its own.
+    if (isGlobalConfigPath(configPath)) {
+      log.dim(TAG, 'Skipped review-extensions.txt write (global config profile)');
+    } else {
+      try {
+        const configRoot = path.dirname(configPath);
+        const totemDirAbs = path.resolve(configRoot, config.totemDir);
+        writeReviewExtensionsFile(totemDirAbs, config.review.sourceExtensions); // totem-context: intentional cleanup — canonical file write is a convenience for the bash PreToolUse hook
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        log.dim(TAG, `Skipped review-extensions.txt write: ${detail}`);
+      }
     }
 
     spinner.succeed(`Done: ${result.chunksProcessed} chunks from ${result.filesProcessed} files`);

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -73,7 +73,7 @@ export async function syncCommand(options: {
     // (default set persisted), so downstream bash consumers see a consistent file.
     try {
       const totemDirAbs = path.resolve(cwd, config.totemDir);
-      writeReviewExtensionsFile(totemDirAbs, config.review.sourceExtensions);
+      writeReviewExtensionsFile(totemDirAbs, config.review.sourceExtensions); // totem-context: intentional cleanup — canonical file write is a convenience for the bash PreToolUse hook
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
       log.dim(TAG, `Skipped review-extensions.txt write: ${detail}`);

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -541,6 +541,7 @@ describe('requireEmbedding', () => {
     shieldIgnorePatterns: [],
     shieldAutoLearn: false,
     contextWarningThreshold: 40_000,
+    review: { sourceExtensions: ['.ts', '.tsx', '.js', '.jsx'] },
   };
 
   it('returns embedding provider when configured', () => {

--- a/packages/cli/src/utils/pilot.test.ts
+++ b/packages/cli/src/utils/pilot.test.ts
@@ -25,6 +25,7 @@ function makeConfig(pilot?: TotemConfig['pilot']): TotemConfig {
     shieldIgnorePatterns: [],
     contextWarningThreshold: 40_000,
     shieldAutoLearn: false,
+    review: { sourceExtensions: ['.ts', '.tsx', '.js', '.jsx'] },
     pilot,
   } as TotemConfig;
 }

--- a/packages/core/src/config-schema.test.ts
+++ b/packages/core/src/config-schema.test.ts
@@ -540,6 +540,102 @@ describe('requireEmbedding', () => {
 
 // ─── Garbage collection config ──────────────────────
 
+// ─── Review source extensions (mmnto/totem#1527) ──────
+
+describe('review.sourceExtensions', () => {
+  it('normalizes missing dots and rejects shell-unsafe characters', () => {
+    // Accepts both "ts" and ".ts", normalizes to leading-dot form.
+    const ok = TotemConfigSchema.safeParse({
+      targets: BASE_TARGETS,
+      review: { sourceExtensions: ['ts', '.rs'] },
+    });
+    expect(ok.success).toBe(true);
+    if (ok.success) {
+      expect(ok.data.review.sourceExtensions).toEqual(['.ts', '.rs']);
+    }
+
+    // Shell-unsafe inputs rejected.
+    const hazards = ['*.ts', 'ts; rm -rf /', '', 'ts js', '.ts`whoami`', '.ts"', ".ts'"];
+    for (const bad of hazards) {
+      const result = TotemConfigSchema.safeParse({
+        targets: BASE_TARGETS,
+        review: { sourceExtensions: [bad] },
+      });
+      expect(result.success, `extension "${bad}" should be rejected`).toBe(false);
+    }
+  });
+
+  it('defaults to historical hardcoded set when field is absent', () => {
+    const result = TotemConfigSchema.safeParse({ targets: BASE_TARGETS });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.review.sourceExtensions).toEqual(['.ts', '.tsx', '.js', '.jsx']);
+    }
+  });
+
+  it('defaults to historical hardcoded set when review object is empty', () => {
+    const result = TotemConfigSchema.safeParse({
+      targets: BASE_TARGETS,
+      review: {},
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.review.sourceExtensions).toEqual(['.ts', '.tsx', '.js', '.jsx']);
+    }
+  });
+
+  it('rejects explicit empty array', () => {
+    const result = TotemConfigSchema.safeParse({
+      targets: BASE_TARGETS,
+      review: { sourceExtensions: [] },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const paths = result.error.issues.map((i) => i.path.join('.'));
+      expect(paths.some((p) => p.includes('sourceExtensions'))).toBe(true);
+    }
+  });
+
+  it('accepts compound extensions like .d.ts via internal dots', () => {
+    const result = TotemConfigSchema.safeParse({
+      targets: BASE_TARGETS,
+      review: { sourceExtensions: ['.d.ts'] },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.review.sourceExtensions).toEqual(['.d.ts']);
+    }
+  });
+
+  it('normalizes "ts" and ".ts" to the same stored form', () => {
+    const a = TotemConfigSchema.parse({
+      targets: BASE_TARGETS,
+      review: { sourceExtensions: ['ts'] },
+    });
+    const b = TotemConfigSchema.parse({
+      targets: BASE_TARGETS,
+      review: { sourceExtensions: ['.ts'] },
+    });
+    expect(a.review.sourceExtensions).toEqual(b.review.sourceExtensions);
+  });
+
+  it('passthrough tolerates unknown future review fields', () => {
+    const result = TotemConfigSchema.safeParse({
+      targets: BASE_TARGETS,
+      review: {
+        sourceExtensions: ['.ts'],
+        futureUnknownField: { nested: 'value' },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // passthrough preserves the unknown field on the parsed object
+      const asRecord = result.data.review as Record<string, unknown>;
+      expect(asRecord['futureUnknownField']).toEqual({ nested: 'value' });
+    }
+  });
+});
+
 describe('GarbageCollectionSchema', () => {
   it('rejects garbage collection config with negative minAgeDays', () => {
     const result = GarbageCollectionSchema.safeParse({ minAgeDays: -1 });

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -57,6 +57,7 @@ export const DEFAULT_IGNORE_PATTERNS = [
   '**/*.test.tsx',
   '**/*.spec.ts',
   '**/*.spec.tsx',
+  '**/.totem/review-extensions.txt',
 ];
 
 // ─── Orchestrator schemas ────────────────────────────
@@ -180,6 +181,39 @@ export const DocTargetSchema = z.object({
 export const ConfigTierSchema = z.enum(['lite', 'standard', 'full']);
 export type ConfigTier = z.infer<typeof ConfigTierSchema>;
 
+/**
+ * Default source extensions used when computing the review content hash.
+ * Historical hardcoded set, preserved for backward compatibility with
+ * pre-#1527 consumers. Polyglot repos override via `review.sourceExtensions`.
+ */
+export const DEFAULT_REVIEW_SOURCE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx'] as const;
+
+/**
+ * Per-extension schema for `review.sourceExtensions`. Accepts either `"ts"`
+ * or `".ts"` (normalizes to leading-dot form). The `.refine()` regex is the
+ * shell-injection boundary: these strings are later passed as `git ls-files`
+ * glob arguments on both the TS side (via safeExec) and the bash side
+ * (via shell globs). The regex rejects `*`, `;`, quotes, backticks, spaces,
+ * newlines, and any other character that could break out of a glob arg.
+ */
+export const ReviewSourceExtensionSchema = z
+  .string()
+  .transform((s) => (s.startsWith('.') ? s : '.' + s))
+  .refine(
+    (s) => /^\.[a-z0-9][a-z0-9.-]*$/i.test(s),
+    'must match /\\.[A-Za-z0-9.-]+/ after normalization',
+  );
+
+export const ReviewConfigSchema = z
+  .object({
+    sourceExtensions: z
+      .array(ReviewSourceExtensionSchema)
+      .min(1, 'review.sourceExtensions must contain at least one extension')
+      .default([...DEFAULT_REVIEW_SOURCE_EXTENSIONS]),
+  })
+  .passthrough()
+  .default({});
+
 export const TotemConfigSchema = z.object({
   /** Glob patterns and chunking strategies for each ingest target */
   targets: z.array(IngestTargetSchema).min(1),
@@ -258,6 +292,12 @@ export const TotemConfigSchema = z.object({
       tier: z.enum(['strict', 'standard']).default('standard'),
     })
     .optional(),
+
+  /** Review gate configuration. `sourceExtensions` drives the content-hash
+   *  computation in `writeReviewedContentHash()` and `.claude/hooks/content-hash.sh`.
+   *  Polyglot repos extend the default `['.ts', '.tsx', '.js', '.jsx']` to cover
+   *  additional source languages (e.g., `['.rs', '.gd']` for Rust + Godot). */
+  review: ReviewConfigSchema,
 });
 
 export type ChunkStrategy = z.infer<typeof ChunkStrategySchema>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export {
   ConfigTierSchema,
   ContentTypeSchema,
   DEFAULT_IGNORE_PATTERNS,
+  DEFAULT_REVIEW_SOURCE_EXTENSIONS,
   DocTargetSchema,
   EmbeddingProviderSchema,
   GarbageCollectionSchema,
@@ -46,6 +47,8 @@ export {
   OpenAIProviderSchema,
   OrchestratorSchema,
   requireEmbedding,
+  ReviewConfigSchema,
+  ReviewSourceExtensionSchema,
   ShellOrchestratorSchema,
   TotemConfigSchema,
 } from './config-schema.js';


### PR DESCRIPTION
## Summary

- Adds `review.sourceExtensions: string[]` to `TotemConfig`. Both `writeReviewedContentHash()` and `.claude/hooks/content-hash.sh` honor it. Polyglot consumers (Rust / Godot / Python / any other language) set the config and the hook plus stamp agree.
- `totem sync` writes `.totem/review-extensions.txt` as the canonical file. `totem review` auto-refreshes the file before stamping when the config has drifted since last sync.
- Parity test pins byte-equal output between the TypeScript and bash implementations across five scenarios: default set, custom set including `.rs`, missing canonical file, empty canonical file, malformed canonical file.

## Why

Liquid City (polyglot downstream consumer) is currently blocked because the two hash implementations drift the moment their repo contains non-`.ts/.tsx/.js/.jsx` source. They authorized one `--no-verify` push while this ships as 1.14.11.

## Dogfood source

Liquid City session, 2026-04-18. Proposal 233 Gap 5 is the adjacent retrieval-layer instance of the same classifier-before-artifact pattern; out of scope here, tracked separately.

## Test plan

- [x] `pnpm run format` clean
- [x] `pnpm exec totem lint` PASS (0 errors, 84 pre-existing warnings)
- [x] `pnpm exec totem review` PASS (no findings)
- [x] `pnpm exec totem verify-manifest` PASS (438 rules)
- [x] `pnpm -r build` PASS (strict tsc)
- [x] `pnpm -r test` PASS (3100 tests across core, mcp, pack-agent-security, cli)
- [x] Parity test (5 scenarios) passes
- [ ] CR + GCA review cycle clean
- [ ] Liquid City upgrades to 1.14.11, sets `review.sourceExtensions` in their config, confirms hook and stamp agree

## Closes

Closes #1527
Closes #1529

## Notes for reviewers

- Bash hook's regex-validation fallback emits a warning only under `TOTEM_DEBUG=1`. The hook fires on every PreToolUse; unconditional stderr would pollute agent context.
- Deleted-file filter divergence between `shield.ts` and `content-hash.sh` is pre-existing and intentionally out of scope. Parity test avoids exercising it. If it surfaces as a real issue, follow-up ticket.
- `.claude/hooks/` distribution to downstream consumers is manual for this PR. Liquid City copies the updated script alongside their config. Auto-install lands separately if adoption friction emerges (#1528 territory).
- `writeReviewedContentHash` signature gains `extensions?: readonly string[]` as an optional 4th param that defaults to the historical hardcoded set. Preserves public-API backward compat while all internal callsites pass `config.review.sourceExtensions`.
- The companion docs/doctor ticket #1530 covers the adjacent PreToolUse compound-command race (`content-hash.sh > stamp && git push` fails under agent sequencing). Surfaced by Liquid City alongside this work.