### PR TITLE
fix(changeset): downgrade ADR-088 Phase 1 bump from minor to patch

### DIFF
--- a/.changeset/adr-088-unverified-and-reason-codes.md
+++ b/.changeset/adr-088-unverified-and-reason-codes.md
@@ -1,7 +1,7 @@
 ---
-'@mmnto/totem': minor
-'@mmnto/cli': minor
-'@mmnto/mcp': minor
+'@mmnto/totem': patch
+'@mmnto/cli': patch
+'@mmnto/mcp': patch
 ---
 
 ADR-088 Phase 1 Layers 3 and 4 substrate: unverified flag and reason codes.


### PR DESCRIPTION
## Mechanical Root Cause

PR #1544 shipped with a changeset declaring `minor` on all three published packages. The changesets GitHub Action generated Version Packages PR #1547 proposing 1.14.11 → **1.15.0**. 1.15.0 is milestone-locked to Pack Distribution per ADR-075 / ADR-085, and Phase B still has roughly seven tickets to drain (#1482, #1483, #1486-#1490, #1492, #1493). Allowing the minor bump through would publish 1.15.0 as "ADR-088 Phase 1 substrate" and slide the Pack Distribution headline to 1.16.0.

## Fix Applied

Rewrote the changeset frontmatter from `minor` to `patch` on all three packages. Body unchanged. When this merges, the changesets Action regenerates PR #1547 as 1.14.11 → **1.14.12**, matching the rest of the Phase B grind which has been shipping as patches under 1.14.x.

## Out of Scope

- Closing #1547 directly. The bot updates it automatically when this merges.
- Any logic change. Changeset-only.

## Tests Added/Updated

- [x] N/A (changeset metadata only; no code path touched).

## Related Tickets

No tracking ticket. Followup-to PR #1544.