### PR TITLE
fix(core): thread RuleEngineContext through rule engine, remove module state

### DIFF
--- a/.changeset/rule-engine-context.md
+++ b/.changeset/rule-engine-context.md
@@ -1,0 +1,11 @@
+---
+'@mmnto/totem': patch
+'@mmnto/cli': patch
+'@mmnto/mcp': patch
+---
+
+core: thread per-invocation `RuleEngineContext` through the rule engine
+
+Removes the module-level `let coreLogger` / `let shieldContextDeprecationWarned` state from `rule-engine.ts` and replaces the hidden DI setter (`setCoreLogger` / `resetShieldContextWarning`) with a required `RuleEngineContext` parameter on `applyRulesToAdditions`, `applyAstRulesToAdditions`, `applyRules`, and `extractJustification`. Concurrent or federated rule evaluations cannot bleed logger wiring or deprecation-warning latching across each other. Closes mmnto-ai/totem#1441.
+
+**Breaking:** `setCoreLogger` and `resetShieldContextWarning` are removed from `@mmnto/totem`. Callers must build a `RuleEngineContext` once per linting invocation and pass it as the first argument to the affected functions. See the README or the `RuleEngineContext` JSDoc for the shape.

--- a/.totem/specs/1441.md
+++ b/.totem/specs/1441.md
@@ -1,0 +1,173 @@
+### Problem Statement
+
+The `packages/core/src/rule-engine.ts` module uses top-level mutable variables (`coreLogger`, `shieldContextDeprecationWarned`) to track logging configuration and deprecation warnings. This breaks functional isolation during concurrent rule evaluations or federated searches, causing race conditions where one rule's execution state bleeds into another.
+
+### Architectural Context
+
+This fix addresses a Tier-1 bug surfaced during the pre-1.15-review Gemini audit (Finding #3). As Totem moves towards the 1.15.0 "Distribution Pipeline" and Pack Ecosystem, functional isolation of the AST linting phase is paramount. Federated packs running through the same engine must not share state, as cross-pack state leakage is a structural trust violation.
+
+### Files to Examine
+
+1. `packages/core/src/rule-engine.ts` — Contains the mutable module-level state (`let coreLogger`, `let shieldContextDeprecationWarned`) and the configuration exports to remove.
+2. `packages/core/src/__tests__/rule-engine.test.ts` — Will contain tests relying on `setCoreLogger` and `resetShieldContextWarning` that need to be rewritten.
+
+### Technical Approach & Contracts
+
+We will remove module-scoped mutable state and replace it with a per-call execution context.
+
+**Contract Changes:**
+Introduce a new interface for execution context in `packages/core/src/rule-engine.ts`:
+
+```typescript
+export interface CoreLogger {
+  warn: (msg: string) => void;
+  // ... any other existing methods
+}
+
+export interface RuleEngineContext {
+  logger: CoreLogger;
+  state: {
+    hasWarnedShieldContext: boolean;
+  };
+}
+```
+
+**Implementation Steps:**
+
+1. Delete `let shieldContextDeprecationWarned`, `let coreLogger`, `export function setCoreLogger`, and `export function resetShieldContextWarning`.
+2. Update the signature of `applyAstRulesToAdditions` (and any other entry points) to accept `RuleEngineContext` as an explicit, required parameter.
+3. Update internal helper functions like `warnShieldContextDeprecation` to accept `RuleEngineContext` and use `ctx.state.hasWarnedShieldContext` to prevent duplicate warnings _per execution_, rather than globally.
+4. Refactor all calling code (in tests and potentially in the CLI package) to instantiate and pass down the `RuleEngineContext` object instead of calling `setCoreLogger`.
+
+### Edge Cases & Traps
+
+- **Cross-Package Breaking Changes:** Removing `setCoreLogger` is an internal API break. You must search the entire monorepo (`packages/cli`, `packages/mcp`) for `setCoreLogger` and update them to pass the logger via the new context parameter.
+- **Optional Parameter Trap:** Do _not_ make `RuleEngineContext` optional with a fallback to `console`. By making it strictly required, TypeScript will force you to update all call sites, guaranteeing no blind spots are left.
+- **Test Setup Bleed:** Existing tests likely rely on `resetShieldContextWarning()` in `afterEach` blocks. These hooks should be removed, and tests should instantiate fresh mock loggers and contexts per test case.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Define RuleEngineContext and Remove Global State**
+  - **Files:** `packages/core/src/rule-engine.ts`, `packages/core/src/__tests__/rule-engine.test.ts`
+    > TEST DIRECTIVE: Before implementing, write a failing test named `isolates warning state across distinct rule engine executions` in `rule-engine.test.ts` that provides two separate context objects to two sequential calls, asserting that the logger's `warn` method is invoked on _both_ mock loggers (proving the state is no longer globally shared).
+  - Define the `RuleEngineContext` interface.
+  - Delete `shieldContextDeprecationWarned`, `coreLogger`, `setCoreLogger`, and `resetShieldContextWarning` from `rule-engine.ts`.
+  - Update `warnShieldContextDeprecation` to accept `ctx: RuleEngineContext`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Inject Context into Entry Points**
+  - **Files:** `packages/core/src/rule-engine.ts`
+  - Modify `applyAstRulesToAdditions` (and any other exported linting entry points in this file) to require a `ctx: RuleEngineContext` parameter.
+  - Plumb the `ctx` object through to `warnShieldContextDeprecation` and any logger invocations.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Refactor Core Tests**
+  - **Files:** `packages/core/src/__tests__/rule-engine.test.ts` (and any other core test file that fails to compile)
+  - Remove all `beforeEach`/`afterEach` calls to `setCoreLogger` and `resetShieldContextWarning`.
+  - Update all calls to `applyAstRulesToAdditions` in tests to inline a mock `RuleEngineContext`: `{ logger: mockLogger, state: { hasWarnedShieldContext: false } }`.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Fix Cross-Package Consumers**
+  - **Files:** Grep for `setCoreLogger` across `packages/cli` and `packages/mcp`
+  - Update CLI/MCP commands that previously called `setCoreLogger(logger)`.
+  - Have them pass `{ logger, state: { hasWarnedShieldContext: false } }` down into `applyAstRulesToAdditions`.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Concurrency Isolation Test:** Trigger two instances of rule evaluations sequentially (or concurrently via `Promise.all`) using distinct `RuleEngineContext` objects containing different mock loggers. Assert that both mock loggers receive the deprecated warning exactly once.
+- **Type Safety Validation:** Ensure running `tsc --noEmit` across the monorepo passes, proving no rogue calls to `setCoreLogger` or missing context arguments exist in `packages/cli` or `packages/mcp`.
+
+---
+
+## Implementation Design
+
+### Scope (2 sentences)
+
+Replace module-level `coreLogger` and `shieldContextDeprecationWarned` state in `rule-engine.ts` with a required `RuleEngineContext` threaded through every public entry point that can reach the legacy `shield-context:` deprecation path. Does NOT change violation detection semantics, rule-event observability, the `CoreLogger` interface shape, or the warning message text — this is a plumbing change, not a feature.
+
+### Data model deltas
+
+**New type — `RuleEngineContext`** (exported from `rule-engine.ts`):
+
+```typescript
+export interface RuleEngineContext {
+  logger: CoreLogger;
+  state: { hasWarnedShieldContext: boolean };
+}
+```
+
+- **Holds:** the logger to call on deprecation + a single mutable flag.
+- **Written by:** `warnShieldContextDeprecation(ctx)` flips the flag on first call within a ctx lifetime.
+- **Read by:** `warnShieldContextDeprecation(ctx)` gates on the flag.
+- **Invariant:** callers own ctx lifetime. Within one ctx, `logger.warn` for the legacy directive fires at most once. Across distinct ctx instances, warnings are independent.
+- **No reserved keys / sentinels.** Two named fields, both required.
+
+**Removed surface (breaking):**
+
+- `export function setCoreLogger(logger: CoreLogger): void` — gone.
+- `export function resetShieldContextWarning(): void` — gone (was `@internal`).
+- Module-level `let coreLogger`, `let shieldContextDeprecationWarned` — gone.
+
+**Modified signatures (breaking; all require `ctx: RuleEngineContext` as first param — TS1016 forbids required-after-optional, and several signatures end with `onRuleEvent?`):**
+
+| Function                                                        | Status                          |
+| --------------------------------------------------------------- | ------------------------------- |
+| `applyRulesToAdditions(ctx, rules, additions, onRuleEvent?)`    | exported, regex path            |
+| `applyAstRulesToAdditions(ctx, rules, additions, onRuleEvent?)` | exported, ast path              |
+| `applyRules(ctx, rules, diff, excludeFiles?)`                   | exported, convenience wrapper   |
+| `extractJustification(ctx, line, precedingLine)`                | exported, reachable legacy path |
+
+Internal helpers (`hasContextDirective`, `matchContextDirective`, `warnShieldContextDeprecation`, `isSuppressed`) also take `ctx` but stay private — not part of the public break.
+
+### State lifecycle
+
+- **Scope:** per-call. Caller instantiates `{ logger, state: { hasWarnedShieldContext: false } }` once per linting invocation.
+- **Lifetime:** created before the first `applyRules*` / `extractJustification` call, mutated in place as the engine processes additions, discarded when the linting invocation returns.
+- **Ownership:** `run-compiled-rules.ts` owns ctx creation in the CLI path; tests own ctx creation per `it` block.
+- **No cross-boundary leak.** ctx never escapes the stack of the public entry point.
+
+### Failure modes
+
+| Failure                                                | Category | Agent-facing surface                                                                                                        | Recovery                           |
+| ------------------------------------------------------ | -------- | --------------------------------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| Caller forgets `ctx` arg                               | init     | hard TypeScript compile error                                                                                               | fix callsite                       |
+| Caller passes shared ctx across concurrent invocations | runtime  | warning suppression behaves per-ctx (degraded but not wrong — flag still flips atomically in JS single-threaded event loop) | document: one ctx per invocation   |
+| Logger throws inside `warn`                            | runtime  | exception propagates out of `applyRules*`                                                                                   | caller wraps; no change from today |
+| Legacy `shield-context:` directive appears             | runtime  | one warning per ctx, flag latches                                                                                           | by design                          |
+
+No silent-degradation rows. Every failure surface is hard-fail.
+
+### Invariants to lock in via tests
+
+1. Two distinct ctx instances threaded through sequential `applyRulesToAdditions` calls each observe their own deprecation warning exactly once (concurrency isolation — the headline invariant from the ticket).
+2. One ctx reused across two sequential legacy-directive hits emits `logger.warn` exactly once (flag-latching semantics preserved from pre-refactor behavior).
+3. `extractJustification(..., ctx)` with a legacy directive flips `ctx.state.hasWarnedShieldContext` and calls `ctx.logger.warn`.
+4. Deleting `setCoreLogger` / `resetShieldContextWarning` from `index.ts` + `compiler.ts` barrel exports does not orphan any other caller (monorepo-wide `tsc --noEmit` clean).
+5. `run-compiled-rules.ts` no longer calls `setCoreLogger`; it constructs ctx once and threads it into `applyRules` / `applyAstRulesToAdditions`.
+
+### Resolved questions
+
+- **Position of `ctx`:** **First param** across all four signatures. TypeScript forbids required-after-optional (TS1016), and `applyRulesToAdditions` + `applyAstRulesToAdditions` already end with `onRuleEvent?`. Options-object ceremony would add weight for a single extra required field. DI-style first-position context injection wins.
+- **`applyRules` `excludeFiles?`:** Stays optional. Out of scope.
+- **Barrel re-exports:** Yes — `RuleEngineContext` re-exported from `compiler.ts` and `index.ts`, matching the existing `CoreLogger` pattern.

--- a/packages/cli/src/commands/run-compiled-rules.test.ts
+++ b/packages/cli/src/commands/run-compiled-rules.test.ts
@@ -484,10 +484,10 @@ describe('runCompiledRules', () => {
     expect(events[0]!.source).toBe('lint');
   });
 
-  // ─── setCoreLogger wiring ──────────────────────────
+  // ─── RuleEngineContext wiring (mmnto/totem#1441) ────
 
-  it('calls setCoreLogger with a warn method during execution', async () => {
-    const spy = vi.spyOn(totem, 'setCoreLogger');
+  it('threads a RuleEngineContext with a working warn logger into applyRulesToAdditions', async () => {
+    const spy = vi.spyOn(totem, 'applyRulesToAdditions');
     try {
       const rules = [makeRule('neverMatchXYZ123', 'No match', 'No match rule')];
       writeRules(tmpDir, rules);
@@ -502,11 +502,13 @@ describe('runCompiledRules', () => {
         tag: 'Test',
       });
 
-      // setCoreLogger is called once to wire the logger, once in finally to reset
+      // First positional arg is the RuleEngineContext — verify it carries a
+      // callable warn method and a fresh hasWarnedShieldContext flag.
       expect(spy).toHaveBeenCalled();
-      const firstCall = spy.mock.calls[0]![0];
-      expect(firstCall).toHaveProperty('warn');
-      expect(typeof firstCall.warn).toBe('function');
+      const ctxArg = spy.mock.calls[0]![0];
+      expect(ctxArg).toHaveProperty('logger');
+      expect(typeof ctxArg.logger.warn).toBe('function');
+      expect(ctxArg.state.hasWarnedShieldContext).toBe(false);
     } finally {
       spy.mockRestore();
     }
@@ -934,7 +936,7 @@ describe('runCompiledRules', () => {
       expect(violations).toHaveLength(1);
       expect(spyAst).toHaveBeenCalled();
       // Check that workingDirectory passed to applyAstRulesToAdditions is tmpDir (repo root), not subDir
-      expect(spyAst.mock.calls[0]![2]).toBe(tmpDir);
+      expect(spyAst.mock.calls[0]![3]).toBe(tmpDir);
       mockResolveGitRoot.mockRestore();
       mockExec.mockRestore();
       spyAst.mockRestore();
@@ -992,7 +994,7 @@ describe('runCompiledRules', () => {
       expect(violations).toHaveLength(1);
       expect(spyAst).toHaveBeenCalled();
       // Non-staged path must also resolve against repo root, not subDir
-      expect(spyAst.mock.calls[0]![2]).toBe(tmpDir);
+      expect(spyAst.mock.calls[0]![3]).toBe(tmpDir);
       mockResolveGitRoot.mockRestore();
       spyAst.mockRestore();
     });

--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -58,379 +58,385 @@ export async function runCompiledRules(
     resolveGitRoot,
     safeExec,
     saveRuleMetrics,
-    setCoreLogger,
     TotemError,
   } = await import('@mmnto/totem');
+  type RuleEngineContext = import('@mmnto/totem').RuleEngineContext;
 
   const { diff, cwd, totemDir, format, outPath, exportPaths, ignorePatterns, tag, isStaged } =
     options;
 
-  // Wire core logger to CLI UI (ADR-071: core must not use console.warn directly)
-  setCoreLogger({ warn: (msg) => log.warn(tag, msg) });
+  // Per-invocation rule-engine context (ADR-071 + mmnto/totem#1441): logger
+  // threads into the engine as a parameter rather than a module-level setter,
+  // so concurrent / federated runs cannot clobber each other's wiring.
+  const ruleCtx: RuleEngineContext = {
+    logger: { warn: (msg: string) => log.warn(tag, msg) },
+    state: { hasWarnedShieldContext: false },
+  };
+  const resolvedTotemDir = path.join(options.configRoot ?? cwd, totemDir);
+
+  // Load compiled rules
+  const rulesPath = path.join(resolvedTotemDir, COMPILED_RULES_FILE);
+  const rules = loadCompiledRules(rulesPath);
+
+  if (rules.length === 0) {
+    throw new TotemError(
+      'NO_RULES',
+      `No compiled rules found at ${totemDir}/${COMPILED_RULES_FILE}.`,
+      "Run 'totem compile' to generate rules.",
+    );
+  }
+
+  log.info(tag, `Running ${rules.length} rules (zero LLM)...`);
+
+  // Extract additions, exclude compiled rules file, export targets, and binary files
+  const BINARY_EXTENSIONS = new Set([
+    '.png',
+    '.jpg',
+    '.jpeg',
+    '.gif',
+    '.mp4',
+    '.pdf',
+    '.zip',
+    '.tar',
+    '.gz',
+    '.woff',
+    '.woff2',
+    '.eot',
+    '.ttf',
+    '.mp3',
+    '.wav',
+    '.ico',
+    '.bin',
+  ]);
+  const rulesRelPath = path.join(totemDir, COMPILED_RULES_FILE).replace(/\\/g, '/');
+  const excluded = new Set([rulesRelPath]);
+  if (exportPaths) {
+    for (const ep of exportPaths) {
+      excluded.add(ep.replace(/\\/g, '/'));
+    }
+  }
+  const additions = extractAddedLines(diff)
+    .filter((a) => !excluded.has(a.file))
+    .filter((a) => !BINARY_EXTENSIONS.has(path.extname(a.file).toLowerCase()))
+    .filter(
+      (a) => !ignorePatterns || !ignorePatterns.some((pattern) => matchesGlob(a.file, pattern)),
+    );
+
+  // Resolve repo root once — git diff paths are always repo-root-relative,
+  // so both staged and non-staged paths need the repo root for file resolution.
+  const repoRoot = resolveGitRoot(cwd);
+
+  // Enrich with AST context
   try {
-    const resolvedTotemDir = path.join(options.configRoot ?? cwd, totemDir);
-
-    // Load compiled rules
-    const rulesPath = path.join(resolvedTotemDir, COMPILED_RULES_FILE);
-    const rules = loadCompiledRules(rulesPath);
-
-    if (rules.length === 0) {
-      throw new TotemError(
-        'NO_RULES',
-        `No compiled rules found at ${totemDir}/${COMPILED_RULES_FILE}.`,
-        "Run 'totem compile' to generate rules.",
-      );
+    await enrichWithAstContext(additions, { cwd: repoRoot ?? cwd });
+    const classified = additions.filter((a) => a.astContext !== undefined).length;
+    if (classified > 0) {
+      log.dim(tag, `AST classified ${classified}/${additions.length} additions`);
     }
+    // totem-context: intentional graceful degradation — AST enrichment is best-effort
+  } catch {
+    log.dim(tag, 'AST classification unavailable, falling back to raw matching');
+  }
 
-    log.info(tag, `Running ${rules.length} rules (zero LLM)...`);
-
-    // Extract additions, exclude compiled rules file, export targets, and binary files
-    const BINARY_EXTENSIONS = new Set([
-      '.png',
-      '.jpg',
-      '.jpeg',
-      '.gif',
-      '.mp4',
-      '.pdf',
-      '.zip',
-      '.tar',
-      '.gz',
-      '.woff',
-      '.woff2',
-      '.eot',
-      '.ttf',
-      '.mp3',
-      '.wav',
-      '.ico',
-      '.bin',
-    ]);
-    const rulesRelPath = path.join(totemDir, COMPILED_RULES_FILE).replace(/\\/g, '/');
-    const excluded = new Set([rulesRelPath]);
-    if (exportPaths) {
-      for (const ep of exportPaths) {
-        excluded.add(ep.replace(/\\/g, '/'));
-      }
-    }
-    const additions = extractAddedLines(diff)
-      .filter((a) => !excluded.has(a.file))
-      .filter((a) => !BINARY_EXTENSIONS.has(path.extname(a.file).toLowerCase()))
-      .filter(
-        (a) => !ignorePatterns || !ignorePatterns.some((pattern) => matchesGlob(a.file, pattern)),
-      );
-
-    // Resolve repo root once — git diff paths are always repo-root-relative,
-    // so both staged and non-staged paths need the repo root for file resolution.
-    const repoRoot = resolveGitRoot(cwd);
-
-    // Enrich with AST context
-    try {
-      await enrichWithAstContext(additions, { cwd: repoRoot ?? cwd });
-      const classified = additions.filter((a) => a.astContext !== undefined).length;
-      if (classified > 0) {
-        log.dim(tag, `AST classified ${classified}/${additions.length} additions`);
-      }
-    } catch {
-      log.dim(tag, 'AST classification unavailable, falling back to raw matching');
-    }
-
-    // Record metrics + Trap Ledger
-    const { appendLedgerEvent } = await import('@mmnto/totem');
-    const metrics = loadRuleMetrics(resolvedTotemDir, (msg) => log.dim(tag, msg));
-    const ruleEventCallback: RuleEventCallback = (event, hash, context) => {
-      if (event === 'trigger') {
-        recordTrigger(metrics, hash);
-        recordContextHit(metrics, hash, context?.astContext);
-      } else if (event === 'suppress') {
-        recordSuppression(metrics, hash);
-        // Append to Trap Ledger (fire-and-forget). When the suppressed rule
-        // was shipped by a pack with immutable: true (ADR-089,
-        // mmnto-ai/totem#1485), the event carries the flag so auditors can
-        // surface every attempt to silence an enforced security rule via
-        // `jq 'select(.immutable == true)'` over events.ndjson.
-        if (context) {
-          appendLedgerEvent(
-            resolvedTotemDir,
-            {
-              timestamp: new Date().toISOString(),
-              type: context.justification ? 'override' : 'suppress',
-              ruleId: hash,
-              file: context.file,
-              line: context.line,
-              justification: context.justification ?? '',
-              source: 'lint',
-              ...(context.immutable === true ? { immutable: true } : {}),
-            },
-            (msg) => log.dim(tag, msg),
-          );
-        }
-      } else {
-        // mmnto/totem#1408: 'failure' event fires when a compiled rule's
-        // runtime findAll throws (per-rule try/catch in executeQuery). Log
-        // the hash and reason so the operator can see WHICH rule failed
-        // without crashing the batch. Metric recording (recordFailure) is
-        // a follow-up once `rule-metrics` gains a failure counter.
-        log.warn(
-          tag,
-          `rule ${hash} failed at runtime${context?.failureReason ? `: ${context.failureReason}` : ''}`,
+  // Record metrics + Trap Ledger
+  const { appendLedgerEvent } = await import('@mmnto/totem');
+  const metrics = loadRuleMetrics(resolvedTotemDir, (msg) => log.dim(tag, msg));
+  const ruleEventCallback: RuleEventCallback = (event, hash, context) => {
+    if (event === 'trigger') {
+      recordTrigger(metrics, hash);
+      recordContextHit(metrics, hash, context?.astContext);
+    } else if (event === 'suppress') {
+      recordSuppression(metrics, hash);
+      // Append to Trap Ledger (fire-and-forget). When the suppressed rule
+      // was shipped by a pack with immutable: true (ADR-089,
+      // mmnto-ai/totem#1485), the event carries the flag so auditors can
+      // surface every attempt to silence an enforced security rule via
+      // `jq 'select(.immutable == true)'` over events.ndjson.
+      if (context) {
+        appendLedgerEvent(
+          resolvedTotemDir,
+          {
+            timestamp: new Date().toISOString(),
+            type: context.justification ? 'override' : 'suppress',
+            ruleId: hash,
+            file: context.file,
+            line: context.line,
+            justification: context.justification ?? '',
+            source: 'lint',
+            ...(context.immutable === true ? { immutable: true } : {}),
+          },
+          (msg) => log.dim(tag, msg),
         );
       }
-    };
-    const regexViolations = applyRulesToAdditions(rules, additions, ruleEventCallback);
-
-    // Run AST rules (async — reads files and runs Tree-sitter/ast-grep queries)
-    const astRules = rules.filter((r) => r.engine === 'ast' || r.engine === 'ast-grep');
-    let astViolations: Violation[] = [];
-    if (astRules.length > 0) {
-      log.dim(tag, `Running ${astRules.length} AST rule(s)...`);
-      try {
-        const workingDirectory = repoRoot ?? cwd;
-        let readStrategy: ((filePath: string) => Promise<string | null>) | undefined = undefined;
-
-        if (isStaged) {
-          if (repoRoot) {
-            readStrategy = async (filePath: string) => {
-              try {
-                // 1. Detect symlinks explicitly (git ls-files -s returns mode 120000).
-                //    The `--` separator prevents filePath values starting with `-` from
-                //    being interpreted as git options.
-                const lsOutput = safeExec(
-                  'git',
-                  ['ls-files', '--recurse-submodules', '-s', '--', filePath],
-                  { cwd: repoRoot, env: { ...process.env, LC_ALL: 'C' } },
-                );
-                if (lsOutput.startsWith('120000 ')) {
-                  return null; // Explicitly exclude symlinks from AST checks
-                }
-
-                // 2. Read staged content
-                const content = safeExec('git', ['show', `:${filePath}`], {
-                  cwd: repoRoot,
-                  trim: false,
-                  env: { ...process.env, LC_ALL: 'C' },
-                });
-
-                // 3. Normalize CRLF to LF specifically for the staged callback
-                // Disk-read callback preserves existing behavior per Invariant #4.
-                return content.replace(/\r\n/g, '\n');
-              } catch (err) {
-                // Explicit throw per Failure Mode 1 decision
-                throw new TotemError(
-                  'STAGED_READ_FAILED',
-                  `Failed to read staged content for ${filePath}`,
-                  `git show :${filePath} failed. The file may not exist in the index or may be staged for deletion. Ensure --staged is used correctly.`,
-                  { cause: err },
-                );
-              }
-            };
-          }
-        }
-
-        astViolations = await applyAstRulesToAdditions(
-          rules,
-          additions,
-          workingDirectory,
-          ruleEventCallback,
-          (msg) => log.warn(tag, msg),
-          readStrategy,
-        );
-      } catch (err) {
-        // STAGED_READ_FAILED must propagate — the pre-commit guarantee depends
-        // on surfacing staged-read failures rather than silently falling back.
-        if (err instanceof TotemError && err.code === 'STAGED_READ_FAILED') {
-          throw err;
-        }
-        const msg = err instanceof Error ? err.message : String(err);
-        const isWasmFailure = /not initialized|wasm|web-tree-sitter/i.test(msg);
-        if (process.env['TOTEM_LITE'] === '1' && isWasmFailure) {
-          // In the lite binary, WASM init may fail under Node.js (works in Bun).
-          // Degrade gracefully: skip AST rules, warn, continue with regex results.
-          log.warn(tag, `AST rules skipped (WASM engine unavailable): ${msg}`);
-        } else {
-          throw err;
-        }
-      }
-    }
-
-    const violations = [...regexViolations, ...astViolations];
-
-    // ── Zero-match rule detection (#1061) ────────────
-    // Count rules whose fileGlobs matched none of the files in this diff.
-    const diffFiles = [...new Set(additions.map((a) => a.file))];
-    const zeroMatchRules: CompiledRule[] = [];
-    for (const rule of rules) {
-      if (rule.fileGlobs && rule.fileGlobs.length > 0) {
-        const positive = rule.fileGlobs.filter((g) => typeof g === 'string' && !g.startsWith('!'));
-        const negative = rule.fileGlobs
-          .filter((g): g is string => typeof g === 'string' && g.startsWith('!'))
-          .map((g) => g.slice(1));
-        const hasMatch = diffFiles.some((file) => {
-          const positiveMatch = positive.length === 0 || positive.some((g) => matchesGlob(file, g));
-          const negativeMatch = negative.some((g) => matchesGlob(file, g));
-          return positiveMatch && !negativeMatch;
-        });
-        if (!hasMatch) zeroMatchRules.push(rule);
-      }
-    }
-    if (zeroMatchRules.length > 0) {
-      log.dim(tag, `${zeroMatchRules.length} rule(s) matched no files in this diff`);
-    }
-
-    // mmnto-ai/totem#1483: tick evaluationCount once per rule per lint run.
-    // Invariant: one run loads the rule set, evaluates each rule against the
-    // diff additions, and increments the counter here exactly once per
-    // lessonHash. Multiple matches on a rule within one run still produce a
-    // single increment. This counter is the "was this rule exercised" signal
-    // the doctor stale-rule check reads to distinguish a dormant rule from a
-    // rule that has genuinely sat through N lint cycles without firing.
-    for (const rule of rules) {
-      recordEvaluation(metrics, rule.lessonHash);
-    }
-
-    try {
-      saveRuleMetrics(resolvedTotemDir, metrics);
-    } catch (err) {
+    } else {
+      // mmnto/totem#1408: 'failure' event fires when a compiled rule's
+      // runtime findAll throws (per-rule try/catch in executeQuery). Log
+      // the hash and reason so the operator can see WHICH rule failed
+      // without crashing the batch. Metric recording (recordFailure) is
+      // a follow-up once `rule-metrics` gains a failure counter.
       log.warn(
         tag,
-        `Could not save rule metrics: ${err instanceof Error ? err.message : String(err)}`,
+        `rule ${hash} failed at runtime${context?.failureReason ? `: ${context.failureReason}` : ''}`,
       );
     }
+  };
+  const regexViolations = applyRulesToAdditions(ruleCtx, rules, additions, ruleEventCallback);
 
-    // Classify violations by severity (computed once, reused across all output formats)
-    const errors = violations.filter((v) => (v.rule.severity ?? 'error') === 'error');
-    const warnings = violations.filter((v) => (v.rule.severity ?? 'error') === 'warning');
+  // Run AST rules (async — reads files and runs Tree-sitter/ast-grep queries)
+  const astRules = rules.filter((r) => r.engine === 'ast' || r.engine === 'ast-grep');
+  let astViolations: Violation[] = [];
+  if (astRules.length > 0) {
+    log.dim(tag, `Running ${astRules.length} AST rule(s)...`);
+    try {
+      const workingDirectory = repoRoot ?? cwd;
+      let readStrategy: ((filePath: string) => Promise<string | null>) | undefined = undefined;
 
-    // Convert to unified findings model once (ADR-071)
-    const { violationToFinding } = await import('@mmnto/totem');
-    const findings = violations.map(violationToFinding);
+      if (isStaged) {
+        if (repoRoot) {
+          readStrategy = async (filePath: string) => {
+            try {
+              // totem-ignore-next-line — false positive: comment mentions `git ls-files`; actual call below uses --recurse-submodules
+              // 1. Detect symlinks explicitly (git ls-files -s returns mode 120000).
+              //    The `--` separator prevents filePath values starting with `-` from
+              //    being interpreted as git options.
+              const lsOutput = safeExec(
+                'git',
+                ['ls-files', '--recurse-submodules', '-s', '--', filePath],
+                { cwd: repoRoot, env: { ...process.env, LC_ALL: 'C' } },
+              );
+              if (lsOutput.startsWith('120000 ')) {
+                return null; // Explicitly exclude symlinks from AST checks
+              }
 
-    // Build output
-    let output: string;
+              // 2. Read staged content
+              const content = safeExec('git', ['show', `:${filePath}`], {
+                cwd: repoRoot,
+                trim: false,
+                env: { ...process.env, LC_ALL: 'C' },
+              });
 
-    if (format === 'sarif') {
-      const { buildSarifLog, getHeadSha } = await import('@mmnto/totem');
-      const { createRequire } = await import('node:module');
-      const req = createRequire(import.meta.url);
-      const version = (req('../../package.json') as { version: string }).version;
-      const commitHash = getHeadSha(cwd) ?? undefined;
-      // SARIF is a strict channel for error-severity findings only.
-      // Warnings are probationary (Rule Nursery) and stay as local telemetry
-      // to prevent alert fatigue in the PR UI (Proposal 190).
-      const sarif = buildSarifLog(errors, rules, { version, commitHash });
-
-      // Surface warning count as a single note so users know they exist
-      if (warnings.length > 0) {
-        const summaryRuleIdx = sarif.runs[0].tool.driver.rules.length;
-        sarif.runs[0].tool.driver.rules.push({
-          id: 'totem/warning-summary',
-          shortDescription: {
-            text: 'Probationary warnings detected — run `totem lint` locally to review',
-          },
-        });
-        sarif.runs[0].results.push({
-          ruleId: 'totem/warning-summary',
-          ruleIndex: summaryRuleIdx,
-          level: 'note',
-          message: {
-            text: `${warnings.length} warning-severity finding(s) detected. Warnings are probationary and not shown in PR reviews. Run \`totem lint\` locally to review.`,
-          },
-          locations: [
-            {
-              physicalLocation: {
-                artifactLocation: { uri: '.totem/compiled-rules.json' },
-                region: { startLine: 1 },
-              },
-            },
-          ],
-        });
+              // 3. Normalize CRLF to LF specifically for the staged callback
+              // totem-context: Invariant #4 refers to an internal invariant number, not an issue ref
+              // Disk-read callback preserves existing behavior per Invariant #4.
+              return content.replace(/\r\n/g, '\n');
+            } catch (err) {
+              // Explicit throw per Failure Mode 1 decision
+              throw new TotemError(
+                'STAGED_READ_FAILED',
+                `Failed to read staged content for ${filePath}`,
+                `git show :${filePath} failed. The file may not exist in the index or may be staged for deletion. Ensure --staged is used correctly.`,
+                { cause: err },
+              );
+            }
+          };
+        }
       }
 
-      output = JSON.stringify(sarif, null, 2);
-    } else if (format === 'json') {
-      output = JSON.stringify(
-        {
-          pass: errors.length === 0,
-          rules: rules.length,
-          errors: errors.length,
-          warnings: warnings.length,
-          findings,
-          violations,
-        },
-        null,
-        2,
+      astViolations = await applyAstRulesToAdditions(
+        ruleCtx,
+        rules,
+        additions,
+        workingDirectory,
+        ruleEventCallback,
+        (msg) => log.warn(tag, msg),
+        readStrategy,
       );
-    } else {
-      const lines: string[] = [];
-
-      if (errors.length === 0 && warnings.length === 0) {
-        // Clean pass — only emit verbose markdown when writing to file
-        if (outPath) {
-          lines.push('### Verdict');
-          lines.push(`**PASS** - All ${rules.length} rules passed.`);
-          lines.push('');
-          lines.push('### Details');
-          lines.push('No violations detected against compiled rules.');
-        }
+    } catch (err) {
+      // STAGED_READ_FAILED must propagate — the pre-commit guarantee depends
+      // on surfacing staged-read failures rather than silently falling back.
+      if (err instanceof TotemError && err.code === 'STAGED_READ_FAILED') {
+        throw err;
+      }
+      const msg = err instanceof Error ? err.message : String(err);
+      const isWasmFailure = /not initialized|wasm|web-tree-sitter/i.test(msg);
+      if (process.env['TOTEM_LITE'] === '1' && isWasmFailure) {
+        // In the lite binary, WASM init may fail under Node.js (works in Bun).
+        // Degrade gracefully: skip AST rules, warn, continue with regex results.
+        log.warn(tag, `AST rules skipped (WASM engine unavailable): ${msg}`);
       } else {
+        throw err;
+      }
+    }
+  }
+
+  const violations = [...regexViolations, ...astViolations];
+
+  // ── Zero-match rule detection (mmnto-ai/totem#1061) ────────────
+  // Count rules whose fileGlobs matched none of the files in this diff.
+  const diffFiles = [...new Set(additions.map((a) => a.file))];
+  const zeroMatchRules: CompiledRule[] = [];
+  for (const rule of rules) {
+    if (rule.fileGlobs && rule.fileGlobs.length > 0) {
+      const positive = rule.fileGlobs.filter((g) => typeof g === 'string' && !g.startsWith('!'));
+      const negative = rule.fileGlobs
+        .filter((g): g is string => typeof g === 'string' && g.startsWith('!'))
+        .map((g) => g.slice(1));
+      const hasMatch = diffFiles.some((file) => {
+        const positiveMatch = positive.length === 0 || positive.some((g) => matchesGlob(file, g));
+        const negativeMatch = negative.some((g) => matchesGlob(file, g));
+        return positiveMatch && !negativeMatch;
+      });
+      if (!hasMatch) zeroMatchRules.push(rule);
+    }
+  }
+  if (zeroMatchRules.length > 0) {
+    log.dim(tag, `${zeroMatchRules.length} rule(s) matched no files in this diff`);
+  }
+
+  // mmnto-ai/totem#1483: tick evaluationCount once per rule per lint run.
+  // Invariant: one run loads the rule set, evaluates each rule against the
+  // diff additions, and increments the counter here exactly once per
+  // lessonHash. Multiple matches on a rule within one run still produce a
+  // single increment. This counter is the "was this rule exercised" signal
+  // the doctor stale-rule check reads to distinguish a dormant rule from a
+  // rule that has genuinely sat through N lint cycles without firing.
+  for (const rule of rules) {
+    recordEvaluation(metrics, rule.lessonHash);
+  }
+
+  try {
+    saveRuleMetrics(resolvedTotemDir, metrics);
+    // totem-context: intentional graceful degradation — metric save is best-effort
+  } catch (err) {
+    log.warn(
+      tag,
+      `Could not save rule metrics: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  // Classify violations by severity (computed once, reused across all output formats)
+  const errors = violations.filter((v) => (v.rule.severity ?? 'error') === 'error');
+  const warnings = violations.filter((v) => (v.rule.severity ?? 'error') === 'warning');
+
+  // Convert to unified findings model once (ADR-071)
+  const { violationToFinding } = await import('@mmnto/totem');
+  const findings = violations.map(violationToFinding);
+
+  // Build output
+  let output: string;
+
+  if (format === 'sarif') {
+    const { buildSarifLog, getHeadSha } = await import('@mmnto/totem');
+    const { createRequire } = await import('node:module');
+    const req = createRequire(import.meta.url);
+    const version = (req('../../package.json') as { version: string }).version;
+    const commitHash = getHeadSha(cwd) ?? undefined;
+    // SARIF is a strict channel for error-severity findings only.
+    // Warnings are probationary (Rule Nursery) and stay as local telemetry
+    // to prevent alert fatigue in the PR UI (Proposal 190).
+    const sarif = buildSarifLog(errors, rules, { version, commitHash });
+
+    // Surface warning count as a single note so users know they exist
+    if (warnings.length > 0) {
+      const summaryRuleIdx = sarif.runs[0].tool.driver.rules.length;
+      sarif.runs[0].tool.driver.rules.push({
+        id: 'totem/warning-summary',
+        shortDescription: {
+          text: 'Probationary warnings detected — run `totem lint` locally to review',
+        },
+      });
+      sarif.runs[0].results.push({
+        ruleId: 'totem/warning-summary',
+        ruleIndex: summaryRuleIdx,
+        level: 'note',
+        message: {
+          text: `${warnings.length} warning-severity finding(s) detected. Warnings are probationary and not shown in PR reviews. Run \`totem lint\` locally to review.`,
+        },
+        locations: [
+          {
+            physicalLocation: {
+              artifactLocation: { uri: '.totem/compiled-rules.json' },
+              region: { startLine: 1 },
+            },
+          },
+        ],
+      });
+    }
+
+    output = JSON.stringify(sarif, null, 2);
+  } else if (format === 'json') {
+    output = JSON.stringify(
+      {
+        pass: errors.length === 0,
+        rules: rules.length,
+        errors: errors.length,
+        warnings: warnings.length,
+        findings,
+        violations,
+      },
+      null,
+      2,
+    );
+  } else {
+    const lines: string[] = [];
+
+    if (errors.length === 0 && warnings.length === 0) {
+      // Clean pass — only emit verbose markdown when writing to file
+      if (outPath) {
         lines.push('### Verdict');
-        if (errors.length > 0) {
-          lines.push(
-            `**FAIL** - ${errors.length} error(s)${warnings.length > 0 ? `, ${warnings.length} warning(s)` : ''} across ${rules.length} rules.`,
-          );
-        } else {
-          lines.push(
-            `**PASS** - ${warnings.length} warning(s), 0 errors across ${rules.length} rules.`,
-          );
-        }
+        lines.push(`**PASS** - All ${rules.length} rules passed.`);
+        lines.push('');
+        lines.push('### Details');
+        lines.push('No violations detected against compiled rules.');
+      }
+    } else {
+      lines.push('### Verdict');
+      if (errors.length > 0) {
+        lines.push(
+          `**FAIL** - ${errors.length} error(s)${warnings.length > 0 ? `, ${warnings.length} warning(s)` : ''} across ${rules.length} rules.`,
+        );
+      } else {
+        lines.push(
+          `**PASS** - ${warnings.length} warning(s), 0 errors across ${rules.length} rules.`,
+        );
+      }
 
-        if (errors.length > 0) {
+      if (errors.length > 0) {
+        lines.push('');
+        lines.push('### Errors');
+        for (const v of errors) {
+          lines.push(`- **${v.file}:${v.lineNumber}** - ${v.rule.message}`);
+          lines.push(`  Pattern: \`/${v.rule.pattern}/\``);
+          lines.push(`  Lesson: "${v.rule.lessonHeading}"`);
+          lines.push(`  Line: \`${v.line.trim()}\``);
           lines.push('');
-          lines.push('### Errors');
-          for (const v of errors) {
-            lines.push(`- **${v.file}:${v.lineNumber}** - ${v.rule.message}`);
-            lines.push(`  Pattern: \`/${v.rule.pattern}/\``);
-            lines.push(`  Lesson: "${v.rule.lessonHeading}"`);
-            lines.push(`  Line: \`${v.line.trim()}\``);
-            lines.push('');
-          }
-        }
-
-        if (warnings.length > 0) {
-          lines.push('');
-          lines.push('### Warnings');
-          for (const v of warnings) {
-            lines.push(`- **${v.file}:${v.lineNumber}** - ${v.rule.message}`);
-            lines.push(`  Pattern: \`/${v.rule.pattern}/\``);
-            lines.push(`  Lesson: "${v.rule.lessonHeading}"`);
-            lines.push(`  Line: \`${v.line.trim()}\``);
-            lines.push('');
-          }
         }
       }
-      output = lines.join('\n');
+
+      if (warnings.length > 0) {
+        lines.push('');
+        lines.push('### Warnings');
+        for (const v of warnings) {
+          lines.push(`- **${v.file}:${v.lineNumber}** - ${v.rule.message}`);
+          lines.push(`  Pattern: \`/${v.rule.pattern}/\``);
+          lines.push(`  Lesson: "${v.rule.lessonHeading}"`);
+          lines.push(`  Line: \`${v.line.trim()}\``);
+          lines.push('');
+        }
+      }
     }
-
-    writeOutput(output, outPath);
-    if (outPath) log.success(tag, `Written to ${outPath}`);
-
-    if (errors.length > 0) {
-      const verdictLabel = errorColor(bold('FAIL'));
-      const warnSuffix = warnings.length > 0 ? `, ${warnings.length} warning(s)` : '';
-      log.info(tag, `Verdict: ${verdictLabel} - ${errors.length} error(s)${warnSuffix}`);
-      throw new TotemError(
-        'SHIELD_FAILED',
-        'Violations detected',
-        'Fix the violations above or use totem explain <hash> for details.',
-      );
-    } else if (warnings.length > 0) {
-      const verdictLabel = successColor(bold('PASS'));
-      log.info(tag, `Verdict: ${verdictLabel} - ${warnings.length} warning(s), 0 errors`);
-    } else {
-      const verdictLabel = successColor(bold('PASS'));
-      log.info(tag, `Verdict: ${verdictLabel} - ${rules.length} rules, 0 violations`);
-    }
-
-    return { violations, findings, rules, output };
-  } finally {
-    setCoreLogger({ warn: () => {} });
+    output = lines.join('\n');
   }
+
+  writeOutput(output, outPath);
+  if (outPath) log.success(tag, `Written to ${outPath}`);
+
+  if (errors.length > 0) {
+    const verdictLabel = errorColor(bold('FAIL'));
+    const warnSuffix = warnings.length > 0 ? `, ${warnings.length} warning(s)` : '';
+    log.info(tag, `Verdict: ${verdictLabel} - ${errors.length} error(s)${warnSuffix}`);
+    throw new TotemError(
+      'SHIELD_FAILED',
+      'Violations detected',
+      'Fix the violations above or use totem explain <hash> for details.',
+    );
+  } else if (warnings.length > 0) {
+    const verdictLabel = successColor(bold('PASS'));
+    log.info(tag, `Verdict: ${verdictLabel} - ${warnings.length} warning(s), 0 errors`);
+  } else {
+    const verdictLabel = successColor(bold('PASS'));
+    log.info(tag, `Verdict: ${verdictLabel} - ${rules.length} rules, 0 violations`);
+  }
+
+  return { violations, findings, rules, output };
 }

--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -195,7 +195,7 @@ export async function runCompiledRules(
         if (repoRoot) {
           readStrategy = async (filePath: string) => {
             try {
-              // totem-ignore-next-line — false positive: comment mentions `git ls-files`; actual call below uses --recurse-submodules
+              // totem-context: false positive — comment mentions `git ls-files`; the actual call below already uses --recurse-submodules
               // 1. Detect symlinks explicitly (git ls-files -s returns mode 120000).
               //    The `--` separator prevents filePath values starting with `-` from
               //    being interpreted as git options.

--- a/packages/cli/src/commands/shield-eval.integration.test.ts
+++ b/packages/cli/src/commands/shield-eval.integration.test.ts
@@ -28,9 +28,15 @@ import {
   type CompiledRulesFile,
   extractAddedLines,
   hashLesson,
+  type RuleEngineContext,
 } from '@mmnto/totem';
 
-import { cleanTmpDir } from '../test-utils.js';
+import { cleanTmpDir, makeRuleEngineCtx } from '../test-utils.js';
+
+let ctx: RuleEngineContext;
+beforeEach(() => {
+  ctx = makeRuleEngineCtx();
+});
 import { parseVerdict } from './shield.js';
 
 // ─── Adversarial Fixtures ────────────────────────────
@@ -188,7 +194,7 @@ function scaffoldAdversarialRepo(tmpDir: string): void {
 
 describe('Adversarial Eval — Deterministic', () => {
   it('catches all 4 planted traps via compiled rules against expected diff', () => {
-    const violations = applyRules(TRAP_RULES, EXPECTED_DIFF);
+    const violations = applyRules(ctx, TRAP_RULES, EXPECTED_DIFF);
 
     expect(violations.length).toBeGreaterThanOrEqual(4); // totem-ignore
 
@@ -201,7 +207,7 @@ describe('Adversarial Eval — Deterministic', () => {
 
   it('catches all traps with AST-aware additions pipeline', () => {
     const additions = extractAddedLines(EXPECTED_DIFF);
-    const violations = applyRulesToAdditions(TRAP_RULES, additions);
+    const violations = applyRulesToAdditions(ctx, TRAP_RULES, additions);
 
     // extractAddedLines only processes + lines, so we should still catch violations
     const headings = new Set(violations.map((v) => v.rule.lessonHeading));
@@ -221,7 +227,7 @@ describe('Adversarial Eval — Deterministic', () => {
 +  return \`Hello, \${name}!\`;
  }
 `;
-    const violations = applyRules(TRAP_RULES, cleanDiff);
+    const violations = applyRules(ctx, TRAP_RULES, cleanDiff);
     expect(violations).toHaveLength(0);
   });
 
@@ -238,7 +244,7 @@ describe('Adversarial Eval — Deterministic', () => {
       expect(diff).toContain('catch (error)');
 
       // Run compiled rules against the real diff
-      const violations = applyRules(TRAP_RULES, diff);
+      const violations = applyRules(ctx, TRAP_RULES, diff);
       expect(violations.length).toBeGreaterThanOrEqual(4); // totem-ignore
     } finally {
       cleanTmpDir(tmpDir);

--- a/packages/cli/src/commands/shield.test.ts
+++ b/packages/cli/src/commands/shield.test.ts
@@ -4,9 +4,20 @@ import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { applyRules, type CompiledRule, loadCompiledRules, saveCompiledRules } from '@mmnto/totem';
+import {
+  applyRules,
+  type CompiledRule,
+  loadCompiledRules,
+  type RuleEngineContext,
+  saveCompiledRules,
+} from '@mmnto/totem';
 
-import { cleanTmpDir } from '../test-utils.js';
+import { cleanTmpDir, makeRuleEngineCtx } from '../test-utils.js';
+
+let ctx: RuleEngineContext;
+beforeEach(() => {
+  ctx = makeRuleEngineCtx();
+});
 import {
   assemblePrompt,
   assembleStructuralPrompt,
@@ -195,7 +206,7 @@ describe('compiled rules engine', () => {
 +}
 `;
 
-    const violations = applyRules(rules, diff);
+    const violations = applyRules(ctx, rules, diff);
     expect(violations).toHaveLength(1);
     expect(violations[0]!.rule.message).toBe('Use err, not error, in catch blocks');
     expect(violations[0]!.file).toBe('src/handler.ts');
@@ -215,7 +226,7 @@ describe('compiled rules engine', () => {
  export default foo;
 `;
 
-    const violations = applyRules(rules, diff);
+    const violations = applyRules(ctx, rules, diff);
     expect(violations).toHaveLength(0);
   });
 

--- a/packages/cli/src/test-utils.ts
+++ b/packages/cli/src/test-utils.ts
@@ -1,5 +1,7 @@
 import * as fs from 'node:fs';
 
+import type { RuleEngineContext } from '@mmnto/totem';
+
 /**
  * Remove a temporary directory with retry semantics for Windows ENOTEMPTY flakes.
  * Safe to call with falsy paths (no-op).
@@ -7,4 +9,17 @@ import * as fs from 'node:fs';
 export function cleanTmpDir(dir: string | undefined): void {
   if (!dir) return;
   fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+}
+
+/**
+ * Build a fresh `RuleEngineContext` for a CLI test. Warnings are captured on
+ * the returned `warnings` array so tests can assert without setting up spies.
+ */
+export function makeRuleEngineCtx(): RuleEngineContext & { warnings: string[] } {
+  const warnings: string[] = [];
+  return {
+    logger: { warn: (msg: string) => warnings.push(msg) },
+    state: { hasWarnedShieldContext: false },
+    warnings,
+  };
 }

--- a/packages/core/src/adversarial.test.ts
+++ b/packages/core/src/adversarial.test.ts
@@ -1,11 +1,18 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 import {
   applyRules,
   applyRulesToAdditions,
   type CompiledRule,
   type DiffAddition,
+  type RuleEngineContext,
 } from './compiler.js';
+import { makeRuleEngineCtx } from './test-utils.js';
+
+let ctx: RuleEngineContext;
+beforeEach(() => {
+  ctx = makeRuleEngineCtx();
+});
 
 // ─── Adversarial Evaluation Harness ─────────────────
 //
@@ -77,7 +84,7 @@ describe('adversarial evaluation harness', () => {
 +      - run: npm run test
        - run: pnpm build
 `;
-    const violations = applyRules(ADVERSARIAL_RULES, diff);
+    const violations = applyRules(ctx, ADVERSARIAL_RULES, diff);
     expect(violations.length).toBeGreaterThan(0); // totem-ignore
     expect(violations.some((v) => v.rule.lessonHeading === 'Never use npm')).toBe(true);
   });
@@ -93,7 +100,7 @@ describe('adversarial evaluation harness', () => {
 +    console.error(error);
    }
 `;
-    const violations = applyRules(ADVERSARIAL_RULES, diff);
+    const violations = applyRules(ctx, ADVERSARIAL_RULES, diff);
     expect(violations.some((v) => v.rule.lessonHeading === 'Use err not error')).toBe(true);
   });
 
@@ -108,7 +115,7 @@ describe('adversarial evaluation harness', () => {
 +  debugger;
    return res.json();
 `;
-    const violations = applyRules(ADVERSARIAL_RULES, diff);
+    const violations = applyRules(ctx, ADVERSARIAL_RULES, diff);
     const debugViolations = violations.filter(
       (v) => v.rule.lessonHeading === 'No debugger in production',
     );
@@ -125,7 +132,7 @@ describe('adversarial evaluation harness', () => {
 +  return fetchData().catch(() => {})
  }
 `;
-    const violations = applyRules(ADVERSARIAL_RULES, diff);
+    const violations = applyRules(ctx, ADVERSARIAL_RULES, diff);
     expect(violations.some((v) => v.rule.lessonHeading === 'No empty catch blocks')).toBe(true);
   });
 
@@ -139,7 +146,7 @@ describe('adversarial evaluation harness', () => {
 +  // FIXME: this is a temporary hack
    return validateToken(token);
 `;
-    const violations = applyRules(ADVERSARIAL_RULES, diff);
+    const violations = applyRules(ctx, ADVERSARIAL_RULES, diff);
     const todoViolations = violations.filter(
       (v) => v.rule.lessonHeading === 'No TODO in production',
     );
@@ -156,7 +163,7 @@ describe('adversarial evaluation harness', () => {
 +  password: 'hunter2',
  };
 `;
-    const violations = applyRules(ADVERSARIAL_RULES, diff);
+    const violations = applyRules(ctx, ADVERSARIAL_RULES, diff);
     expect(violations.some((v) => v.rule.lessonHeading === 'No hardcoded secrets')).toBe(true);
   });
 
@@ -170,7 +177,7 @@ describe('adversarial evaluation harness', () => {
 +  metadata: any;
  }
 `;
-    const violations = applyRules(ADVERSARIAL_RULES, diff);
+    const violations = applyRules(ctx, ADVERSARIAL_RULES, diff);
     expect(violations.some((v) => v.rule.lessonHeading === 'No any types')).toBe(true);
   });
 
@@ -184,7 +191,7 @@ describe('adversarial evaluation harness', () => {
 +  return \`Hello, \${name}!\`;
  }
 `;
-    const violations = applyRules(ADVERSARIAL_RULES, diff);
+    const violations = applyRules(ctx, ADVERSARIAL_RULES, diff);
     expect(violations).toHaveLength(0);
   });
 
@@ -197,7 +204,7 @@ describe('adversarial evaluation harness', () => {
 +  debugger; // totem-ignore
    run();
 `;
-    const violations = applyRules(ADVERSARIAL_RULES, diff);
+    const violations = applyRules(ctx, ADVERSARIAL_RULES, diff);
     const debugViolations = violations.filter(
       (v) => v.rule.lessonHeading === 'No debugger in production',
     );
@@ -220,7 +227,7 @@ describe('adversarial evaluation harness', () => {
 +  const data: any = fetch('/api');
  }
 `;
-    const violations = applyRules(ADVERSARIAL_RULES, diff);
+    const violations = applyRules(ctx, ADVERSARIAL_RULES, diff);
     // Should catch: debugger, TODO, error (not err), any
     expect(violations.length).toBeGreaterThanOrEqual(4); // totem-ignore
 
@@ -264,7 +271,7 @@ describe('AST gating suppresses false positives', () => {
       },
     ];
 
-    const violations = applyRulesToAdditions(rules, additions);
+    const violations = applyRulesToAdditions(ctx, rules, additions);
     expect(violations).toHaveLength(0);
   });
 
@@ -281,7 +288,7 @@ describe('AST gating suppresses false positives', () => {
       },
     ];
 
-    const violations = applyRulesToAdditions(rules, additions);
+    const violations = applyRulesToAdditions(ctx, rules, additions);
     expect(violations).toHaveLength(0);
   });
 
@@ -298,7 +305,7 @@ describe('AST gating suppresses false positives', () => {
       },
     ];
 
-    const violations = applyRulesToAdditions(rules, additions);
+    const violations = applyRulesToAdditions(ctx, rules, additions);
     expect(violations.length).toBeGreaterThan(0); // totem-ignore
     expect(violations.some((v) => v.rule.lessonHeading === 'No debugger in production')).toBe(true);
   });
@@ -317,7 +324,7 @@ describe('AST gating suppresses false positives', () => {
       },
     ];
 
-    const violations = applyRulesToAdditions(rules, additions);
+    const violations = applyRulesToAdditions(ctx, rules, additions);
     expect(violations.length).toBeGreaterThan(0); // totem-ignore
   });
 });

--- a/packages/core/src/compiler.test.ts
+++ b/packages/core/src/compiler.test.ts
@@ -13,13 +13,19 @@ import {
   loadCompiledRules,
   loadCompiledRulesFile,
   parseCompilerResponse,
+  type RuleEngineContext,
   sanitizeFileGlobs,
   saveCompiledRules,
   saveCompiledRulesFile,
   validateRegex,
 } from './compiler.js';
 import { CompiledRuleSchema } from './compiler-schema.js';
-import { cleanTmpDir } from './test-utils.js';
+import { cleanTmpDir, makeRuleEngineCtx } from './test-utils.js';
+
+let ctx: RuleEngineContext;
+beforeEach(() => {
+  ctx = makeRuleEngineCtx();
+});
 
 // ─── hashLesson ──────────────────────────────────────
 
@@ -216,7 +222,7 @@ describe('applyRules', () => {
 
   it('detects a simple pattern violation', () => {
     const rules = [makeRule('\\bnpm\\.install\\b', 'Do not call npm.install directly')];
-    const violations = applyRules(rules, diff);
+    const violations = applyRules(ctx, rules, diff);
     expect(violations).toHaveLength(1);
     expect(violations[0]!.rule.message).toBe('Do not call npm.install directly');
     expect(violations[0]!.file).toBe('src/app.ts');
@@ -224,7 +230,7 @@ describe('applyRules', () => {
 
   it('returns no violations when patterns do not match', () => {
     const rules = [makeRule('\\byarn\\b', 'Do not use yarn')];
-    const violations = applyRules(rules, diff);
+    const violations = applyRules(ctx, rules, diff);
     expect(violations).toHaveLength(0);
   });
 
@@ -233,33 +239,33 @@ describe('applyRules', () => {
       makeRule('\\bnpm\\b', 'Do not use npm'),
       makeRule('\\berror\\b', 'Use err, not error'),
     ];
-    const violations = applyRules(rules, diff);
+    const violations = applyRules(ctx, rules, diff);
     expect(violations).toHaveLength(2);
   });
 
   it('throws on rules with invalid regex patterns (mmnto/totem#1442 — no silent-compliance footgun)', () => {
     const rules = [makeRule('[invalid', 'Bad pattern')];
-    expect(() => applyRules(rules, diff)).toThrow(/invalid regex pattern/);
+    expect(() => applyRules(ctx, rules, diff)).toThrow(/invalid regex pattern/);
   });
 
   it('returns empty for empty diff', () => {
     const rules = [makeRule('anything', 'test')];
-    expect(applyRules(rules, '')).toEqual([]);
+    expect(applyRules(ctx, rules, '')).toEqual([]);
   });
 
   it('returns empty for empty rules', () => {
-    expect(applyRules([], diff)).toEqual([]);
+    expect(applyRules(ctx, [], diff)).toEqual([]);
   });
 
   it('excludes files listed in excludeFiles', () => {
     const rules = [makeRule('\\bnpm\\.install\\b', 'Do not call npm.install directly')];
-    const violations = applyRules(rules, diff, ['src/app.ts']);
+    const violations = applyRules(ctx, rules, diff, ['src/app.ts']);
     expect(violations).toHaveLength(0);
   });
 
   it('still detects violations in non-excluded files', () => {
     const rules = [makeRule('\\bnpm\\.install\\b', 'Do not call npm.install directly')];
-    const violations = applyRules(rules, diff, ['other-file.ts']);
+    const violations = applyRules(ctx, rules, diff, ['other-file.ts']);
     expect(violations).toHaveLength(1);
   });
 
@@ -286,7 +292,7 @@ describe('applyRules', () => {
 
   it('applies rule to all files when fileGlobs is absent', () => {
     const rules = [makeRule('\\$\\w+', 'Found a dollar-sign variable')];
-    const violations = applyRules(rules, multiFileDiff);
+    const violations = applyRules(ctx, rules, multiFileDiff);
     expect(violations).toHaveLength(2); // matches in both .sh and .ts
   });
 
@@ -297,7 +303,7 @@ describe('applyRules', () => {
         fileGlobs: ['*.sh', '*.bash'],
       },
     ];
-    const violations = applyRules(rules, multiFileDiff);
+    const violations = applyRules(ctx, rules, multiFileDiff);
     expect(violations).toHaveLength(1);
     expect(violations[0]!.file).toBe('deploy.sh');
   });
@@ -309,7 +315,7 @@ describe('applyRules', () => {
         fileGlobs: ['*.py'],
       },
     ];
-    const violations = applyRules(rules, multiFileDiff);
+    const violations = applyRules(ctx, rules, multiFileDiff);
     expect(violations).toHaveLength(0);
   });
 
@@ -320,7 +326,7 @@ describe('applyRules', () => {
         fileGlobs: ['**/*.ts'],
       },
     ];
-    const violations = applyRules(rules, multiFileDiff);
+    const violations = applyRules(ctx, rules, multiFileDiff);
     expect(violations).toHaveLength(1);
     expect(violations[0]!.file).toBe('src/utils.ts');
   });
@@ -332,7 +338,7 @@ describe('applyRules', () => {
         fileGlobs: [],
       },
     ];
-    const violations = applyRules(rules, multiFileDiff);
+    const violations = applyRules(ctx, rules, multiFileDiff);
     expect(violations).toHaveLength(2);
   });
 
@@ -343,7 +349,7 @@ describe('applyRules', () => {
         fileGlobs: ['*.sh', '*.ts', '!*.sh'],
       },
     ];
-    const violations = applyRules(rules, multiFileDiff);
+    const violations = applyRules(ctx, rules, multiFileDiff);
     expect(violations).toHaveLength(1);
     expect(violations[0]!.file).toBe('src/utils.ts');
   });
@@ -381,7 +387,7 @@ describe('applyRules', () => {
         fileGlobs: ['packages/mcp/**/*.ts'],
       },
     ];
-    const violations = applyRules(rules, monorepoMultiFileDiff);
+    const violations = applyRules(ctx, rules, monorepoMultiFileDiff);
     expect(violations).toHaveLength(2); // server.ts + tools.test.ts
     expect(violations.every((v) => v.file!.startsWith('packages/mcp/'))).toBe(true);
   });
@@ -393,7 +399,7 @@ describe('applyRules', () => {
         fileGlobs: ['packages/mcp/**/*.ts', '!**/*.test.ts'],
       },
     ];
-    const violations = applyRules(rules, monorepoMultiFileDiff);
+    const violations = applyRules(ctx, rules, monorepoMultiFileDiff);
     expect(violations).toHaveLength(1);
     expect(violations[0]!.file).toBe('packages/mcp/src/server.ts');
   });
@@ -405,7 +411,7 @@ describe('applyRules', () => {
         fileGlobs: ['packages/cli/**/*.ts'],
       },
     ];
-    const violations = applyRules(rules, monorepoMultiFileDiff);
+    const violations = applyRules(ctx, rules, monorepoMultiFileDiff);
     expect(violations).toHaveLength(0);
   });
 
@@ -423,7 +429,7 @@ describe('applyRules', () => {
     ].join('\n');
 
     const rules = [makeRule('\\bnpm\\.install\\b', 'Do not call npm.install directly')];
-    const violations = applyRules(rules, suppressedDiff);
+    const violations = applyRules(ctx, rules, suppressedDiff);
     expect(violations).toHaveLength(0);
   });
 
@@ -440,7 +446,7 @@ describe('applyRules', () => {
     ].join('\n');
 
     const rules = [makeRule('\\bnpm\\.install\\b', 'Do not call npm.install directly')];
-    const violations = applyRules(rules, suppressedDiff);
+    const violations = applyRules(ctx, rules, suppressedDiff);
     expect(violations).toHaveLength(0);
   });
 
@@ -459,7 +465,7 @@ describe('applyRules', () => {
     ].join('\n');
 
     const rules = [makeRule('\\bnpm\\.install\\b', 'Do not call npm.install directly')];
-    const violations = applyRules(rules, suppressedDiff);
+    const violations = applyRules(ctx, rules, suppressedDiff);
     expect(violations).toHaveLength(0);
   });
 
@@ -475,7 +481,7 @@ describe('applyRules', () => {
     ].join('\n');
 
     const rules = [makeRule('\\bnpm\\.install\\b', 'Do not call npm.install directly')];
-    const violations = applyRules(rules, plainDiff);
+    const violations = applyRules(ctx, rules, plainDiff);
     expect(violations).toHaveLength(1);
   });
 
@@ -492,7 +498,7 @@ describe('applyRules', () => {
     ].join('\n');
 
     const rules = [makeRule('\\$[A-Z_]+', 'Quote shell variables')];
-    const violations = applyRules(rules, suppressedDiff);
+    const violations = applyRules(ctx, rules, suppressedDiff);
     expect(violations).toHaveLength(0);
   });
 
@@ -508,7 +514,7 @@ describe('applyRules', () => {
     ].join('\n');
 
     const rules = [makeRule('\\bnpm\\.install\\b', 'Do not call npm.install')];
-    const violations = applyRules(rules, suppressedDiff);
+    const violations = applyRules(ctx, rules, suppressedDiff);
     expect(violations).toHaveLength(0);
   });
 
@@ -527,7 +533,7 @@ describe('applyRules', () => {
       makeRule('\\bnpm\\.install\\b', 'Do not call npm.install'),
       makeRule('\\berror\\b', 'Use err, not error'),
     ];
-    const violations = applyRules(rules, suppressedDiff);
+    const violations = applyRules(ctx, rules, suppressedDiff);
     expect(violations).toHaveLength(0);
   });
 
@@ -543,7 +549,7 @@ describe('applyRules', () => {
     ].join('\n');
 
     const rules = [makeRule('\\bnpm\\.install\\b', 'Do not call npm.install')];
-    const violations = applyRules(rules, suppressedDiff);
+    const violations = applyRules(ctx, rules, suppressedDiff);
     expect(violations).toHaveLength(0);
   });
 
@@ -571,7 +577,7 @@ describe('applyRules', () => {
         fileGlobs: ['*.ts', '!*.test.ts', '!*.spec.ts'],
       },
     ];
-    const violations = applyRules(rules, testFileDiff);
+    const violations = applyRules(ctx, rules, testFileDiff);
     expect(violations).toHaveLength(1);
     expect(violations[0]!.file).toBe('src/utils.ts');
   });
@@ -752,7 +758,7 @@ describe('compiled rules file I/O', () => {
         '+const second = "the archived rule must not fire here";',
       ].join('\n');
 
-      const violations = applyRules(rules, diff);
+      const violations = applyRules(ctx, rules, diff);
       expect(violations).toHaveLength(1);
       expect(violations[0]!.rule.lessonHash).toBe(activeRule.lessonHash);
       expect(violations.some((v) => v.rule.lessonHash === archivedRule.lessonHash)).toBe(false);

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -64,7 +64,7 @@ export {
   type CoreLogger,
   extractJustification,
   matchesGlob,
-  setCoreLogger,
+  type RuleEngineContext,
 } from './rule-engine.js';
 
 // ─── Hashing ────────────────────────────────────────

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -161,10 +161,10 @@ export {
   NonCompilableReasonCodeSchema,
   parseCompilerResponse,
   type RegexValidation,
+  type RuleEngineContext,
   sanitizeFileGlobs,
   saveCompiledRules,
   saveCompiledRulesFile,
-  setCoreLogger,
   validateRegex,
 } from './compiler.js';
 

--- a/packages/core/src/rule-engine.test.ts
+++ b/packages/core/src/rule-engine.test.ts
@@ -15,23 +15,23 @@ import {
   applyRulesToAdditions,
   extractJustification,
   matchesGlob,
-  resetShieldContextWarning,
-  setCoreLogger,
+  type RuleEngineContext,
 } from './rule-engine.js';
-import { cleanTmpDir } from './test-utils.js';
+import { cleanTmpDir, makeRuleEngineCtx } from './test-utils.js';
 
 // ─── Helpers ────────────────────────────────────────
 
 let tmpDir: string;
+let ctx: RuleEngineContext & { warnings: string[] };
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-rule-engine-'));
   fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+  ctx = makeRuleEngineCtx();
 });
 
 afterEach(() => {
   cleanTmpDir(tmpDir);
-  resetShieldContextWarning();
 });
 
 function makeRule(overrides: Partial<CompiledRule>): CompiledRule {
@@ -66,8 +66,13 @@ describe('applyAstRulesToAdditions', () => {
     // Bad queries return empty results with a warning — prevents TS-specific node names
     // from crashing lint when run against JS files (#988)
     const warnings: string[] = [];
-    const violations = await applyAstRulesToAdditions([rule], additions, tmpDir, undefined, (msg) =>
-      warnings.push(msg),
+    const violations = await applyAstRulesToAdditions(
+      ctx,
+      [rule],
+      additions,
+      tmpDir,
+      undefined,
+      (msg) => warnings.push(msg),
     );
     expect(violations).toEqual([]);
     expect(warnings.length).toBeGreaterThan(0);
@@ -93,6 +98,7 @@ describe('applyAstRulesToAdditions', () => {
     const events: Array<{ event: string; hash: string; reason?: string }> = [];
 
     const violations = await applyAstRulesToAdditions(
+      ctx,
       [rule],
       additions,
       tmpDir,
@@ -133,6 +139,7 @@ describe('applyAstRulesToAdditions', () => {
 
     const events: Array<{ event: string; hash: string }> = [];
     const violations = await applyAstRulesToAdditions(
+      ctx,
       [badRule, goodRule],
       additions,
       tmpDir,
@@ -185,7 +192,7 @@ describe('applyAstRulesToAdditions', () => {
       makeAddition('src/app.ts', '}', 4),
     ];
 
-    const violations = await applyAstRulesToAdditions([compoundRule], additions, tmpDir);
+    const violations = await applyAstRulesToAdditions(ctx, [compoundRule], additions, tmpDir);
     expect(violations.length).toBeGreaterThanOrEqual(1);
     // The outer catch_clause spans lines 3-4; the first overlapping added
     // line (3) is where the violation gets reported.
@@ -207,6 +214,7 @@ describe('applyAstRulesToAdditions', () => {
     const events: Array<{ event: string; hash: string; reason?: string }> = [];
 
     const violations = await applyAstRulesToAdditions(
+      ctx,
       [compoundRule],
       additions,
       tmpDir,
@@ -229,7 +237,7 @@ describe('applyAstRulesToAdditions', () => {
 
     const additions = [makeAddition('src/app.ts', 'console.log("hello");', 1)];
 
-    const violations = await applyAstRulesToAdditions([rule], additions, tmpDir);
+    const violations = await applyAstRulesToAdditions(ctx, [rule], additions, tmpDir);
     expect(violations).toHaveLength(1);
     expect(violations[0]!.lineNumber).toBe(1);
   });
@@ -252,6 +260,7 @@ describe('applyAstRulesToAdditions', () => {
     };
 
     const violations = await applyAstRulesToAdditions(
+      ctx,
       [rule],
       additions,
       tmpDir,
@@ -277,6 +286,7 @@ describe('applyAstRulesToAdditions', () => {
     const mockReadStrategyReturningNull = async () => null;
 
     const violations = await applyAstRulesToAdditions(
+      ctx,
       [rule],
       additions,
       tmpDir,
@@ -298,7 +308,7 @@ describe('applyAstRulesToAdditions', () => {
     const additions = [makeAddition('src/app.ts', 'console.log("disk content");', 1)];
 
     // No readStrategy argument passed
-    const violations = await applyAstRulesToAdditions([rule], additions, tmpDir);
+    const violations = await applyAstRulesToAdditions(ctx, [rule], additions, tmpDir);
     expect(violations).toHaveLength(1);
     expect(violations[0]!.line).toBe('console.log("disk content");');
   });
@@ -318,7 +328,7 @@ describe('applyAstRulesToAdditions', () => {
     const additions = [makeAddition('src/app.ts', 'console.log("hello");', 1)];
 
     // We pass repoRoot as the workingDirectory. If it uses something else (like process.cwd()), it will fail to read the file.
-    const violations = await applyAstRulesToAdditions([rule], additions, repoRoot);
+    const violations = await applyAstRulesToAdditions(ctx, [rule], additions, repoRoot);
     expect(violations).toHaveLength(1);
   });
 
@@ -348,7 +358,7 @@ describe('applyAstRulesToAdditions', () => {
       events.push({ event, hash });
     };
 
-    const violations = await applyAstRulesToAdditions([rule], additions, tmpDir, onRuleEvent);
+    const violations = await applyAstRulesToAdditions(ctx, [rule], additions, tmpDir, onRuleEvent);
     expect(violations).toHaveLength(0);
     expect(events).toEqual([{ event: 'suppress', hash: 'suppress-ast-grep-test' }]);
   });
@@ -379,7 +389,7 @@ describe('applyAstRulesToAdditions', () => {
       events.push({ event, hash });
     };
 
-    const violations = await applyAstRulesToAdditions([rule], additions, tmpDir, onRuleEvent);
+    const violations = await applyAstRulesToAdditions(ctx, [rule], additions, tmpDir, onRuleEvent);
     expect(violations).toHaveLength(0);
     expect(events).toEqual([{ event: 'suppress', hash: 'suppress-tree-sitter-test' }]);
   });
@@ -409,7 +419,7 @@ describe('applyRulesToAdditions — event context', () => {
       events.push({ event, hash, context });
     };
 
-    const violations = applyRulesToAdditions([rule], additions, onRuleEvent);
+    const violations = applyRulesToAdditions(ctx, [rule], additions, onRuleEvent);
     expect(violations).toHaveLength(0);
     expect(events).toHaveLength(1);
     expect(events[0]!.event).toBe('suppress');
@@ -448,7 +458,7 @@ describe('applyRulesToAdditions — event context', () => {
       events.push({ event, hash, context });
     };
 
-    applyRulesToAdditions([rule], additions, onRuleEvent);
+    applyRulesToAdditions(ctx, [rule], additions, onRuleEvent);
     expect(events).toHaveLength(1);
     expect(events[0]!.event).toBe('suppress');
     expect(events[0]!.context?.immutable).toBe(true);
@@ -475,7 +485,7 @@ describe('applyRulesToAdditions — event context', () => {
       events.push({ event, hash, context });
     };
 
-    const violations = applyRulesToAdditions([rule], additions, onRuleEvent);
+    const violations = applyRulesToAdditions(ctx, [rule], additions, onRuleEvent);
     expect(violations).toHaveLength(1);
     expect(events).toHaveLength(1);
     expect(events[0]!.event).toBe('trigger');
@@ -506,7 +516,7 @@ describe('applyRulesToAdditions — event context', () => {
       events.push({ event, hash, context });
     };
 
-    const violations = applyRulesToAdditions([rule], additions, onRuleEvent);
+    const violations = applyRulesToAdditions(ctx, [rule], additions, onRuleEvent);
     expect(violations).toHaveLength(0);
     expect(events).toHaveLength(1);
     expect(events[0]!.event).toBe('suppress');
@@ -538,7 +548,7 @@ describe('applyRulesToAdditions — event context', () => {
       events.push({ event, hash, context });
     };
 
-    const violations = applyRulesToAdditions([rule], additions, onRuleEvent);
+    const violations = applyRulesToAdditions(ctx, [rule], additions, onRuleEvent);
     expect(violations).toHaveLength(0);
     expect(events).toHaveLength(1);
     expect(events[0]!.event).toBe('suppress');
@@ -550,10 +560,6 @@ describe('applyRulesToAdditions — event context', () => {
   });
 
   it('shield-context: legacy alias suppresses rule with deprecation warning', () => {
-    resetShieldContextWarning();
-    const warnings: string[] = [];
-    setCoreLogger({ warn: (msg) => warnings.push(msg) });
-
     const rule = makeRule({
       engine: 'regex',
       pattern: 'console\\.log',
@@ -569,19 +575,13 @@ describe('applyRulesToAdditions — event context', () => {
       },
     ];
 
-    const violations = applyRulesToAdditions([rule], additions);
+    const violations = applyRulesToAdditions(ctx, [rule], additions);
     expect(violations).toHaveLength(0);
-    expect(warnings).toHaveLength(1);
-    expect(warnings[0]).toContain('shield-context');
-
-    resetShieldContextWarning();
+    expect(ctx.warnings).toHaveLength(1);
+    expect(ctx.warnings[0]).toContain('shield-context');
   });
 
   it('shield-context: on preceding line suppresses with deprecation warning', () => {
-    resetShieldContextWarning();
-    const warnings: string[] = [];
-    setCoreLogger({ warn: (msg) => warnings.push(msg) });
-
     const rule = makeRule({
       engine: 'regex',
       pattern: 'console\\.log',
@@ -597,11 +597,64 @@ describe('applyRulesToAdditions — event context', () => {
       },
     ];
 
-    const violations = applyRulesToAdditions([rule], additions);
+    const violations = applyRulesToAdditions(ctx, [rule], additions);
     expect(violations).toHaveLength(0);
-    expect(warnings).toHaveLength(1);
+    expect(ctx.warnings).toHaveLength(1);
+  });
 
-    resetShieldContextWarning();
+  it('isolates deprecation-warning state across distinct ctx instances (mmnto/totem#1441)', () => {
+    // Concurrency-isolation invariant: two sequential applyRulesToAdditions
+    // calls with distinct ctx objects each see their own one-shot deprecation
+    // warning. Pre-#1441, module-level `shieldContextDeprecationWarned` would
+    // latch after the first call and silently swallow the second.
+    const rule = makeRule({
+      engine: 'regex',
+      pattern: 'console\\.log',
+      lessonHash: 'isolation-test',
+    });
+    const additions: DiffAddition[] = [
+      {
+        file: 'src/app.ts',
+        line: 'console.log("hi"); // shield-context: reason',
+        lineNumber: 1,
+        precedingLine: null,
+      },
+    ];
+
+    const ctxA = makeRuleEngineCtx();
+    const ctxB = makeRuleEngineCtx();
+    applyRulesToAdditions(ctxA, [rule], additions);
+    applyRulesToAdditions(ctxB, [rule], additions);
+
+    expect(ctxA.warnings).toHaveLength(1);
+    expect(ctxB.warnings).toHaveLength(1);
+    expect(ctxA.state.hasWarnedShieldContext).toBe(true);
+    expect(ctxB.state.hasWarnedShieldContext).toBe(true);
+  });
+
+  it('latches deprecation warning per ctx (repeat hits on same ctx warn once)', () => {
+    const rule = makeRule({
+      engine: 'regex',
+      pattern: 'console\\.log',
+      lessonHash: 'latch-test',
+    });
+    const additions: DiffAddition[] = [
+      {
+        file: 'src/app.ts',
+        line: 'console.log("a"); // shield-context: one',
+        lineNumber: 1,
+        precedingLine: null,
+      },
+      {
+        file: 'src/app.ts',
+        line: 'console.log("b"); // shield-context: two',
+        lineNumber: 2,
+        precedingLine: null,
+      },
+    ];
+
+    applyRulesToAdditions(ctx, [rule], additions);
+    expect(ctx.warnings).toHaveLength(1);
   });
 });
 
@@ -609,22 +662,25 @@ describe('applyRulesToAdditions — event context', () => {
 
 describe('extractJustification', () => {
   it('returns empty string for plain totem-ignore', () => {
-    expect(extractJustification('code(); // totem-ignore', null)).toBe('');
+    expect(extractJustification(ctx, 'code(); // totem-ignore', null)).toBe('');
   });
 
   it('extracts justification from same-line totem-context:', () => {
-    expect(extractJustification('code(); // totem-context: needed for DLP', null)).toBe(
+    expect(extractJustification(ctx, 'code(); // totem-context: needed for DLP', null)).toBe(
       'needed for DLP',
     );
   });
 
   it('extracts justification from preceding line totem-context:', () => {
-    expect(extractJustification('code();', '// totem-context: audit trail')).toBe('audit trail');
+    expect(extractJustification(ctx, 'code();', '// totem-context: audit trail')).toBe(
+      'audit trail',
+    );
   });
 
   it('prefers same-line over preceding line', () => {
     expect(
       extractJustification(
+        ctx,
         'code(); // totem-context: same-line reason',
         '// totem-context: preceding reason',
       ),
@@ -632,40 +688,36 @@ describe('extractJustification', () => {
   });
 
   it('trims whitespace from justification', () => {
-    expect(extractJustification('code(); // totem-context:   extra spaces  ', null)).toBe(
+    expect(extractJustification(ctx, 'code(); // totem-context:   extra spaces  ', null)).toBe(
       'extra spaces',
     );
   });
 
   it('extracts justification from same-line shield-context: (legacy)', () => {
-    resetShieldContextWarning();
-    const warnings: string[] = [];
-    setCoreLogger({ warn: (msg) => warnings.push(msg) });
-    expect(extractJustification('code(); // shield-context: legacy DLP', null)).toBe('legacy DLP');
-    expect(warnings).toHaveLength(1);
-    resetShieldContextWarning();
+    expect(extractJustification(ctx, 'code(); // shield-context: legacy DLP', null)).toBe(
+      'legacy DLP',
+    );
+    expect(ctx.warnings).toHaveLength(1);
   });
 
   it('extracts justification from preceding line shield-context: (legacy)', () => {
-    resetShieldContextWarning();
-    const warnings: string[] = [];
-    setCoreLogger({ warn: (msg) => warnings.push(msg) });
-    expect(extractJustification('code();', '// shield-context: legacy audit')).toBe('legacy audit');
-    expect(warnings).toHaveLength(1);
-    resetShieldContextWarning();
+    expect(extractJustification(ctx, 'code();', '// shield-context: legacy audit')).toBe(
+      'legacy audit',
+    );
+    expect(ctx.warnings).toHaveLength(1);
   });
 
   it('prefers totem-context: over shield-context: (precedence)', () => {
-    resetShieldContextWarning();
-    const warnings: string[] = [];
-    setCoreLogger({ warn: (msg) => warnings.push(msg) });
     // Same-line totem-context wins over preceding-line shield-context
     expect(
-      extractJustification('code(); // totem-context: new reason', '// shield-context: old reason'),
+      extractJustification(
+        ctx,
+        'code(); // totem-context: new reason',
+        '// shield-context: old reason',
+      ),
     ).toBe('new reason');
     // totem-context matched first — shield-context deprecation warning should NOT fire
-    expect(warnings).toHaveLength(0);
-    resetShieldContextWarning();
+    expect(ctx.warnings).toHaveLength(0);
   });
 });
 

--- a/packages/core/src/rule-engine.ts
+++ b/packages/core/src/rule-engine.ts
@@ -174,6 +174,14 @@ function isSuppressed(ctx: RuleEngineContext, line: string, precedingLine: strin
  * Extract justification text from totem-context: directives.
  * Checks both the current line and the preceding line.
  * Returns empty string for plain totem-ignore (no justification).
+ *
+ * @param ctx - Per-invocation rule engine context. Required so that the legacy
+ *   `shield-context:` deprecation path (reached via `matchContextDirective`)
+ *   uses the caller's logger and per-ctx latch instead of module state.
+ * @param line - The line being evaluated.
+ * @param precedingLine - The line immediately before, or null at start of file.
+ * @returns The justification text, or empty string if the line carries a plain
+ *   `totem-ignore` or no directive at all.
  */
 export function extractJustification(
   ctx: RuleEngineContext,
@@ -197,9 +205,18 @@ export function extractJustification(
 // ─── Regex rule execution ───────────────────────────
 
 /**
- * Apply compiled rules against pre-extracted diff additions.
+ * Apply compiled regex-engine rules against pre-extracted diff additions.
  * Skips additions with non-code AST context (strings, comments, regex).
- * Optional `onRuleEvent` callback enables observability metrics collection.
+ *
+ * @param ctx - Per-invocation rule engine context. Replaces the module-level
+ *   logger / deprecation-warning latch that existed pre-#1441. Callers build
+ *   one ctx per linting invocation: `{ logger, state: { hasWarnedShieldContext: false } }`.
+ * @param rules - The full rule list. This function filters to regex-engine
+ *   rules internally.
+ * @param additions - The diff additions to evaluate.
+ * @param onRuleEvent - Optional observability callback for metrics collection
+ *   on trigger / suppress / failure events.
+ * @returns All regex-based violations found.
  */
 export function applyRulesToAdditions(
   ctx: RuleEngineContext,
@@ -284,6 +301,21 @@ export function applyRulesToAdditions(
  * Handles both Tree-sitter S-expression ('ast') and ast-grep ('ast-grep') engines.
  * Async because it reads files and runs Tree-sitter queries.
  * Handles fileGlobs filtering and suppression same as regex rules.
+ *
+ * @param ctx - Per-invocation rule engine context (see {@link RuleEngineContext}).
+ * @param rules - The full rule list. This function filters to ast / ast-grep
+ *   rules internally.
+ * @param additions - The diff additions to evaluate.
+ * @param workingDirectory - Absolute path used to resolve file reads. Callers
+ *   must pass the repo root, not `process.cwd()` (#1304).
+ * @param onRuleEvent - Optional observability callback for trigger / suppress
+ *   / failure events.
+ * @param onWarn - Optional AST-path warning sink ("AST query skipped",
+ *   "Skipped file outside project", etc.). Follow-up #1552 tracks consolidating
+ *   this into `ctx.logger.warn`.
+ * @param readStrategy - Optional async reader for staged / virtual file
+ *   content. When omitted, reads from disk.
+ * @returns All AST-based violations found.
  */
 export async function applyAstRulesToAdditions(
   ctx: RuleEngineContext,
@@ -500,9 +532,10 @@ export async function applyAstRulesToAdditions(
  * This is a convenience wrapper that only handles 'regex' engine rules.
  * For 'ast' and 'ast-grep' rules, call `applyAstRulesToAdditions` separately.
  *
- * @param rules — The full list of compiled rules. This function filters to regex rules.
- * @param diff — The unified diff string.
- * @param excludeFiles — File paths to skip (e.g., compiled-rules.json to avoid self-matches).
+ * @param ctx - Per-invocation rule engine context (see {@link RuleEngineContext}).
+ * @param rules - The full list of compiled rules. This function filters to regex rules.
+ * @param diff - The unified diff string.
+ * @param excludeFiles - File paths to skip (e.g., compiled-rules.json to avoid self-matches).
  * @returns All regex-based violations found.
  */
 export function applyRules(

--- a/packages/core/src/rule-engine.ts
+++ b/packages/core/src/rule-engine.ts
@@ -100,27 +100,26 @@ export interface CoreLogger {
   warn(message: string): void;
 }
 
-let shieldContextDeprecationWarned = false;
-let coreLogger: CoreLogger = { warn: () => {} }; // no-op default — CLI must wire its own logger
+/**
+ * Per-invocation execution context for the rule engine (mmnto/totem#1441).
+ * Replaces module-level `coreLogger` + `shieldContextDeprecationWarned` state
+ * so concurrent / federated rule evaluations cannot bleed logger configuration
+ * or deprecation-warning latching across each other. Callers instantiate one
+ * ctx per linting invocation; the engine threads it through every helper that
+ * can reach the legacy `shield-context:` directive path.
+ */
+export interface RuleEngineContext {
+  logger: CoreLogger;
+  state: { hasWarnedShieldContext: boolean };
+}
 
-function warnShieldContextDeprecation(): void {
-  if (!shieldContextDeprecationWarned) {
-    shieldContextDeprecationWarned = true;
-    coreLogger.warn(
+function warnShieldContextDeprecation(ctx: RuleEngineContext): void {
+  if (!ctx.state.hasWarnedShieldContext) {
+    ctx.state.hasWarnedShieldContext = true;
+    ctx.logger.warn(
       '⚠ Deprecation: "// shield-context:" is deprecated. Use "// totem-context:" instead. (See ADR-071)',
     );
   }
-}
-
-/** Set the logger for core diagnostics. CLI should call this at startup. */
-export function setCoreLogger(logger: CoreLogger): void {
-  coreLogger = logger;
-}
-
-/** @internal — exposed for testing only */
-export function resetShieldContextWarning(): void {
-  shieldContextDeprecationWarned = false;
-  coreLogger = { warn: () => {} };
 }
 
 /**
@@ -133,40 +132,40 @@ export function resetShieldContextWarning(): void {
  * Syntax-agnostic: works with any comment style (//, #, HTML comments, block comments).
  */
 /** Check if a line contains a context directive (totem-context or legacy shield-context). */
-function hasContextDirective(l: string): boolean {
+function hasContextDirective(ctx: RuleEngineContext, l: string): boolean {
   if (l.includes(CONTEXT_MARKER)) return true;
   if (l.includes(LEGACY_CONTEXT_MARKER)) {
-    warnShieldContextDeprecation();
+    warnShieldContextDeprecation(ctx);
     return true;
   }
   return false;
 }
 
 /** Extract justification from a context directive on a single line, or null if none. */
-function matchContextDirective(l: string): string | null {
+function matchContextDirective(ctx: RuleEngineContext, l: string): string | null {
   const primary = l.match(CONTEXT_RE);
   if (primary) return primary[1]!.trim();
   const legacy = l.match(LEGACY_CONTEXT_RE);
   if (legacy) {
-    warnShieldContextDeprecation();
+    warnShieldContextDeprecation(ctx);
     return legacy[1]!.trim();
   }
   return null;
 }
 
-function isSuppressed(line: string, precedingLine: string | null): boolean {
+function isSuppressed(ctx: RuleEngineContext, line: string, precedingLine: string | null): boolean {
   // Same-line: 'totem-ignore' substring also matches 'totem-ignore-next-line',
   // so directive lines themselves are inherently suppressed.
   if (line.includes(SUPPRESS_MARKER)) return true;
 
   // Same-line: totem-context: or shield-context: (legacy)
-  if (hasContextDirective(line)) return true;
+  if (hasContextDirective(ctx, line)) return true;
 
   // Next-line: preceding line contains the next-line directive
   if (precedingLine != null && precedingLine.includes(SUPPRESS_NEXT_LINE_MARKER)) return true;
 
   // Next-line: preceding line contains a context directive
-  if (precedingLine != null && hasContextDirective(precedingLine)) return true;
+  if (precedingLine != null && hasContextDirective(ctx, precedingLine)) return true;
 
   return false;
 }
@@ -176,14 +175,18 @@ function isSuppressed(line: string, precedingLine: string | null): boolean {
  * Checks both the current line and the preceding line.
  * Returns empty string for plain totem-ignore (no justification).
  */
-export function extractJustification(line: string, precedingLine: string | null): string {
+export function extractJustification(
+  ctx: RuleEngineContext,
+  line: string,
+  precedingLine: string | null,
+): string {
   // Check current line for context directive
-  const sameLine = matchContextDirective(line);
+  const sameLine = matchContextDirective(ctx, line);
   if (sameLine) return sameLine;
 
   // Check preceding line for context directive
   if (precedingLine) {
-    const prevLine = matchContextDirective(precedingLine);
+    const prevLine = matchContextDirective(ctx, precedingLine);
     if (prevLine) return prevLine;
   }
 
@@ -199,6 +202,7 @@ export function extractJustification(line: string, precedingLine: string | null)
  * Optional `onRuleEvent` callback enables observability metrics collection.
  */
 export function applyRulesToAdditions(
+  ctx: RuleEngineContext,
   rules: CompiledRule[],
   additions: DiffAddition[],
   onRuleEvent?: RuleEventCallback,
@@ -237,12 +241,12 @@ export function applyRulesToAdditions(
       }
 
       // Skip if suppressed via inline directive
-      if (isSuppressed(addition.line, addition.precedingLine)) {
+      if (isSuppressed(ctx, addition.line, addition.precedingLine)) {
         if (re.test(addition.line)) {
           onRuleEvent?.('suppress', rule.lessonHash, {
             file: addition.file,
             line: addition.lineNumber,
-            justification: extractJustification(addition.line, addition.precedingLine),
+            justification: extractJustification(ctx, addition.line, addition.precedingLine),
             immutable: rule.immutable,
           });
         }
@@ -282,6 +286,7 @@ export function applyRulesToAdditions(
  * Handles fileGlobs filtering and suppression same as regex rules.
  */
 export async function applyAstRulesToAdditions(
+  ctx: RuleEngineContext,
   rules: CompiledRule[],
   additions: DiffAddition[],
   workingDirectory: string,
@@ -371,11 +376,11 @@ export async function applyAstRulesToAdditions(
 
           for (const match of matches) {
             const addition = fileAdditions.find((a) => a.lineNumber === match.lineNumber);
-            if (addition && isSuppressed(addition.line, addition.precedingLine)) {
+            if (addition && isSuppressed(ctx, addition.line, addition.precedingLine)) {
               onRuleEvent?.('suppress', rule.lessonHash, {
                 file,
                 line: match.lineNumber,
-                justification: extractJustification(addition.line, addition.precedingLine),
+                justification: extractJustification(ctx, addition.line, addition.precedingLine),
                 immutable: rule.immutable,
               });
               continue;
@@ -456,12 +461,12 @@ export async function applyAstRulesToAdditions(
 
             for (const match of matches) {
               const addition = fileAdditions.find((a) => a.lineNumber === match.lineNumber);
-              if (addition && isSuppressed(addition.line, addition.precedingLine)) {
+              if (addition && isSuppressed(ctx, addition.line, addition.precedingLine)) {
                 onRuleEvent?.('suppress', rule.lessonHash, {
                   file,
                   line: match.lineNumber,
                   justification: addition
-                    ? extractJustification(addition.line, addition.precedingLine)
+                    ? extractJustification(ctx, addition.line, addition.precedingLine)
                     : '',
                   immutable: rule.immutable,
                 });
@@ -501,6 +506,7 @@ export async function applyAstRulesToAdditions(
  * @returns All regex-based violations found.
  */
 export function applyRules(
+  ctx: RuleEngineContext,
   rules: CompiledRule[],
   diff: string,
   excludeFiles?: string[],
@@ -513,5 +519,5 @@ export function applyRules(
     additions = additions.filter((a) => !excluded.has(a.file));
   }
 
-  return applyRulesToAdditions(rules, additions);
+  return applyRulesToAdditions(ctx, rules, additions);
 }

--- a/packages/core/src/rule-tester.ts
+++ b/packages/core/src/rule-tester.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 
 import type { AstGrepRule } from './ast-grep-query.js';
 import { matchAstGrepPattern } from './ast-grep-query.js';
-import type { CompiledRule, DiffAddition } from './compiler.js';
+import type { CompiledRule, DiffAddition, RuleEngineContext } from './compiler.js';
 import { applyRulesToAdditions, loadCompiledRules } from './compiler.js';
 import { getErrorMessage } from './errors.js';
 
@@ -202,10 +202,16 @@ export function testRule(rule: CompiledRule, fixture: RuleTestFixture): RuleTest
       }
     }
   } else {
-    // Regex-engine rules — test line by line
+    // Regex-engine rules — test line by line. Fixture runs are synthetic;
+    // any shield-context: deprecation that slips through goes to a no-op
+    // logger to keep fixture semantics isolated from production warnings.
+    const ctx: RuleEngineContext = {
+      logger: { warn: () => {} },
+      state: { hasWarnedShieldContext: false },
+    };
     for (const line of fixture.failLines) {
       const additions = linesToAdditions([line], fixture.filePath);
-      const violations = applyRulesToAdditions([rule], additions);
+      const violations = applyRulesToAdditions(ctx, [rule], additions);
       if (violations.length === 0) {
         result.missedFails.push(line);
       }
@@ -213,7 +219,7 @@ export function testRule(rule: CompiledRule, fixture: RuleTestFixture): RuleTest
 
     for (const line of fixture.passLines) {
       const additions = linesToAdditions([line], fixture.filePath);
-      const violations = applyRulesToAdditions([rule], additions);
+      const violations = applyRulesToAdditions(ctx, [rule], additions);
       if (violations.length > 0) {
         result.falsePositives.push(line);
       }

--- a/packages/core/src/test-utils.ts
+++ b/packages/core/src/test-utils.ts
@@ -1,5 +1,7 @@
 import * as fs from 'node:fs';
 
+import type { RuleEngineContext } from './rule-engine.js';
+
 /**
  * Remove a temporary directory with retry semantics for Windows ENOTEMPTY flakes.
  * Safe to call with falsy paths (no-op).
@@ -7,6 +9,20 @@ import * as fs from 'node:fs';
 export function cleanTmpDir(dir: string | undefined): void {
   if (!dir) return;
   fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+}
+
+/**
+ * Build a fresh `RuleEngineContext` for a test. Captures warnings into the
+ * returned `warnings` array so assertions can introspect logger output
+ * without setting up module-level spies.
+ */
+export function makeRuleEngineCtx(): RuleEngineContext & { warnings: string[] } {
+  const warnings: string[] = [];
+  return {
+    logger: { warn: (msg: string) => warnings.push(msg) },
+    state: { hasWarnedShieldContext: false },
+    warnings,
+  };
 }
 
 // ---- cross-spawn mock helpers ----


### PR DESCRIPTION
## Summary

Replaces module-level `let coreLogger` / `let shieldContextDeprecationWarned` in `packages/core/src/rule-engine.ts` with a required `RuleEngineContext` parameter threaded through `applyRulesToAdditions`, `applyAstRulesToAdditions`, `applyRules`, and `extractJustification`. Concurrent / federated rule evaluations no longer bleed logger wiring or deprecation-warning latching across each other.

### Breaking

- `setCoreLogger` and `resetShieldContextWarning` are removed from the `@mmnto/totem` public surface.
- The four affected functions now require `ctx: RuleEngineContext` as the **first** argument (TS1016 prevents required-after-optional, which forbids a trailing-param approach given existing `onRuleEvent?`).
- Callers build one ctx per linting invocation: `{ logger, state: { hasWarnedShieldContext: false } }`. See the `RuleEngineContext` JSDoc for the shape.

### Why first-arg, not options object

Every callsite already has to change (the signature is breaking), so arg-order change has zero marginal cost. An options object adds ceremony for a single extra required field without semantic payoff. First-position context injection matches conventional DI patterns.

### Wider scope than the original spec

Gemini's original spec missed that `extractJustification` (exported) reaches the `shield-context:` deprecation path via `matchContextDirective`. Adding ctx to it was necessary for full isolation — otherwise module-level state would survive in that path.

## Test plan

- [x] `tsc --noEmit` clean across core + cli + mcp
- [x] 3,162 tests pass (core: 1222, cli: 1764, mcp: 119, pack: 57) — includes **2 new invariant tests** in `rule-engine.test.ts`:
  - `isolates deprecation-warning state across distinct ctx instances` — concurrency-isolation headline invariant
  - `latches deprecation warning per ctx (repeat hits on same ctx warn once)` — preserves pre-refactor behavior within a single ctx
- [x] `totem lint` — PASS (0 errors, 40 warnings — mostly pre-existing rules surfaced into diff scope by the `run-compiled-rules.ts` dedent)
- [x] `totem review` — PASS (1 WARN noted below)

## Known follow-up

`totem review` flagged (0.9 confidence) that `applyAstRulesToAdditions` takes both `ctx` (with logger) and a separate `onWarn` callback — legitimate DRY concern. Filed as mmnto-ai/totem#1552 for consolidation in a follow-on PR. Out of scope for this ticket to keep the blast radius tight.

Closes #1441

🤖 Generated with [Claude Code](https://claude.com/claude-code)