### PR TITLE
fix(cli): flip --auto-capture to opt-in default on totem review

### DIFF
--- a/.changeset/1579-auto-capture-opt-in.md
+++ b/.changeset/1579-auto-capture-opt-in.md
@@ -1,0 +1,14 @@
+---
+'@mmnto/totem': patch
+'@mmnto/cli': patch
+'@mmnto/mcp': patch
+'@totem/pack-agent-security': patch
+---
+
+Flip Pipeline 5 auto-capture on `totem review` from opt-out to opt-in.
+
+`--no-auto-capture` is renamed to `--auto-capture`; the default is now OFF. Observation rules captured from review findings are context-less (regex drawn from the flagged line, message taken from the reviewer, `fileGlobs` scoped to the whole codebase) and routinely pollute `compiled-rules.json` with rules that fire on unrelated files. The Liquid City Session 6 audit measured an 8-rule wave across 5 review invocations producing 13 new warnings on the next `totem lint`, up from 0.
+
+To preserve the old behavior, pass `--auto-capture` explicitly. Auto-capture will resume as a default once ADR-091 Stage 2 Classifier + Stage 4 Codebase Verifier ship in 1.16.0 and the LLM-emitted rule loop has gates that prevent context-less emissions.
+
+Closes #1579.

--- a/docs/wiki/cli-reference.md
+++ b/docs/wiki/cli-reference.md
@@ -100,14 +100,14 @@ Manage rule exemptions for specific files or lines that deliberately bypass a st
 
 ### `totem review`
 
-The core of the Codebase Immune System. Reads your uncommitted diff and checks it against compiled rules and vector DB traps. Pipeline 5 automatically captures warnings from findings.
+The core of the Codebase Immune System. Reads your uncommitted diff and checks it against compiled rules and vector DB traps. Pipeline 5 observation auto-capture is off by default; opt in per invocation with `--auto-capture`.
 
 - **Flags:**
   - `--deterministic`: Runs lightning-fast zero-LLM checks using `compiled-rules.json` (sub-3 seconds).
   - `--format sarif`: Exports violations in SARIF 2.1.0 format.
   - `--format json`: Exports structured JSON including a unified `findings[]` array (ADR-071 Unified Findings Model) alongside raw `violations[]`.
   - `--learn`: Prompts you to extract a new lesson if a violation is found.
-  - `--no-auto-capture`: Disables Pipeline 5 observation auto-capture during the review.
+  - `--auto-capture`: Enables Pipeline 5 observation auto-capture during the review (off by default).
 
 ### `totem test`
 

--- a/docs/wiki/pipeline-engine.md
+++ b/docs/wiki/pipeline-engine.md
@@ -8,13 +8,13 @@ The Pipeline Engine is built around the **Create → Enforce Lifecycle**. It mov
 
 Totem supports five distinct pipelines for rule creation, from zero-LLM manual authoring to fully autonomous observation capture.
 
-| Pipeline | Name                     | LLM Required?        | Entry Point                                                                   |
-| -------- | ------------------------ | -------------------- | ----------------------------------------------------------------------------- |
-| **P1**   | Manual Rules             | No                   | `totem rule scaffold` → author lesson → `totem lesson compile`                |
-| **P2**   | LLM-Generated            | Yes                  | `totem lesson compile` (from extracted lessons)                               |
-| **P3**   | Example-Based            | Yes                  | `totem lesson compile` (from Bad/Good code snippets in `.totem/lessons/*.md`) |
-| **P4**   | Import                   | No                   | `totem import --from-eslint`, `totem import --from-semgrep`                   |
-| **P5**   | Observation Auto-Capture | No (at capture time) | Automatic during `totem review` (opt out with `--no-auto-capture`)            |
+| Pipeline | Name                     | LLM Required?        | Entry Point                                                                                                        |
+| -------- | ------------------------ | -------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| **P1**   | Manual Rules             | No                   | `totem rule scaffold` → author lesson → `totem lesson compile`                                                     |
+| **P2**   | LLM-Generated            | Yes                  | `totem lesson compile` (from extracted lessons)                                                                    |
+| **P3**   | Example-Based            | Yes                  | `totem lesson compile` (from Bad/Good code snippets in `.totem/lessons/*.md`)                                      |
+| **P4**   | Import                   | No                   | `totem import --from-eslint`, `totem import --from-semgrep`                                                        |
+| **P5**   | Observation Auto-Capture | No (at capture time) | Opt-in on `totem review` via `--auto-capture` (off by default; captured rules are context-less and apply globally) |
 
 ## Priority Order and Strategy
 
@@ -27,7 +27,7 @@ When establishing rules, prefer pipelines in the following order: **P1 > P3 > P2
 3. **P2 (LLM/Sonnet):** Fallback. Generates rules from prose explanations in extracted lessons. Powered by Claude Sonnet 4.6. Highly capable but requires well-written lessons.
    - _Use when:_ Rules are derived from PR review feedback where strict examples weren't provided.
 4. **P4 (Import):** The bootstrapping pipeline. Use this on Day 1 to suck in your existing `eslint-plugin-no-restricted-syntax` configurations into the fast Totem engine.
-5. **P5 (Observation Capture):** The auto-pilot. P5 listens to `totem review` outputs. When a bot flags a specific line, P5 deterministically extracts that line into a `severity: warning` rule so the team is alerted next time it happens.
+5. **P5 (Observation Capture):** Opt-in auto-capture. When invoked with `totem review --auto-capture`, P5 extracts the flagged line into a `severity: warning` rule. Default is off because captured rules are context-less and apply globally; enable per-invocation only when you want to seed rules from the current review pass.
 
 ## Usage Examples
 
@@ -97,10 +97,10 @@ The Semgrep adapter (`--from-semgrep`) imports pattern-based YAML rules.
 
 ### Pipeline 5: Auto-Capture
 
-Run your standard review. If the PR contains violations, P5 will automatically stage the offending lines as warnings in your rule list.
+Run review with `--auto-capture` to stage flagged lines as warnings in your rule list. Default is off.
 
 ```bash
-totem review --deterministic
+totem review --auto-capture
 ```
 
-_(To skip capture in CI or final push workflows, use `totem review --deterministic --no-auto-capture`)_
+_(Auto-capture will resume as a default once ADR-091 Stage 2 Classifier and Stage 4 Codebase Verifier ship in 1.16.0 and the LLM-emitted rule loop has gates that prevent context-less emissions.)_

--- a/packages/cli/src/commands/shield.ts
+++ b/packages/cli/src/commands/shield.ts
@@ -808,7 +808,7 @@ async function handleVerdictResult(
     console.error(display);
 
     // ─── Pipeline 5: auto-capture observation rules ──
-    if (options.autoCapture !== false) {
+    if (options.autoCapture === true) {
       await captureObservationRules(filtered, cwd, config, configRoot);
     }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -240,8 +240,8 @@ const reviewOptions = (cmd: Command) =>
       [] as string[], // totem-context: Commander accumulator default — not untrusted input
     )
     .option(
-      '--no-auto-capture',
-      'Disable Pipeline 5 auto-capture of observation rules from findings',
+      '--auto-capture',
+      'Enable Pipeline 5 auto-capture of observation rules from findings (off by default; captured rules are context-less and apply globally)',
     );
 
 async function runReview(opts: {


### PR DESCRIPTION
## Summary

- Renames `--no-auto-capture` to `--auto-capture` on `totem review`, default OFF.
- Gate in `shield.ts` flipped from `options.autoCapture !== false` to `options.autoCapture === true`.
- Docs updated: `pipeline-engine.md` (P5 table row, strategy section, usage example), `cli-reference.md` (review section, flag list).
- Changeset: patch bump across the fixed group (`@mmnto/totem`, `@mmnto/cli`, `@mmnto/mcp`, `@totem/pack-agent-security`).

## Why

Pipeline 5 observation capture writes context-less rules (regex from the flagged line, message from the reviewer, `fileGlobs` scoped to the whole codebase) that routinely pollute `compiled-rules.json` with rules that fire on unrelated files. Liquid City Session 6 audit measured an 8-rule wave across 5 review invocations producing 13 new warnings on the next `totem lint`, up from 0.

Strategic call: 1.15.0 ships with human-authored packs only. Auto-capture resumes as a default once ADR-091 Stage 2 Classifier + Stage 4 Codebase Verifier ship in 1.16.0 and the LLM-emitted rule loop has gates that prevent context-less emissions.

## Out of scope

- Gate-level integration tests. No existing `runShield` harness to extend, and the gate is a trivial `if`. Existing `captureObservationRules` unit suite (5 tests) covers the function behavior. Happy to refactor into a `shouldAutoCapture(options)` helper if bots push back.
- `--auto-capture` removal of the old `--no-auto-capture` flag is a breaking change for anyone who had it in scripts. Commander will now error on the unknown flag. The workaround is removing the flag (new default matches old opt-out behavior).

## Test plan

- [x] `pnpm test` — 1722/1722 CLI tests pass
- [x] `totem lint` — PASS, 0 violations
- [x] `totem review` — PASS, no findings
- [x] `totem verify-manifest` — PASS (439 rules)
- [x] `totem review --help` shows `--auto-capture` (not `--no-auto-capture`) with the opt-in description
- [x] `totem review` (no flag) skips the capture branch; `totem review --auto-capture` hits it (verified via code-path trace)

Closes #1579