### PR TITLE
feat(core): extend smoke gate with goodExample over-matching check

### DIFF
--- a/.changeset/1580-smoke-gate-good-example.md
+++ b/.changeset/1580-smoke-gate-good-example.md
@@ -1,0 +1,18 @@
+---
+'@mmnto/totem': patch
+'@mmnto/cli': patch
+'@mmnto/mcp': patch
+'@totem/pack-agent-security': patch
+---
+
+Extend the compile-time smoke gate with an over-matching check via `goodExample` (mmnto-ai/totem#1580).
+
+The gate now verifies both directions: the rule MUST match its `badExample` (under-matching check, in place since #1408) AND MUST NOT match its `goodExample` (over-matching check, new). A rule that fires on both sides is over-broad and produces false positives on every lint run, which was the dominant defect class observed in the 2026-04-18 security-pack postmerge incident (10-of-10 bad rate from #1526).
+
+`CompilerOutputSchema.goodExample` flips from optional to engine-conditional required for regex and ast-grep engines, mirroring the #1420 flip for `badExample`. The `ast` engine (Tree-sitter S-expression queries) remains exempt because the smoke gate does not yet evaluate those. `CompiledRuleSchema.goodExample` stays optional on the persisted-rule boundary for backward compat with pre-#1580 rules.
+
+Two new reason codes added to `NonCompilableReasonCodeSchema`: `matches-good-example` (over-match rejection) and `missing-goodexample` (defensive path for callers that bypass the schema refine). Rejected lessons surface in the `nonCompilable` ledger with the correct code so `totem doctor` and downstream telemetry can distinguish over-match rejections from other skip categories.
+
+Pipeline 3 automatically threads the lesson's Good snippet through as `goodExampleOverride`; Pipeline 2 requires the LLM to emit `goodExample` alongside `badExample` via the updated compiler prompt. Pipeline 1 (manual) is unaffected — the gate is opt-in via `enforceSmokeGate`.
+
+Closes #1580.

--- a/packages/cli/src/commands/compile-templates.ts
+++ b/packages/cli/src/commands/compile-templates.ts
@@ -64,6 +64,7 @@ You are a deterministic rule compiler. Your job is to read a single natural-lang
 - For regex: use JavaScript RegExp syntax. Keep patterns precise — avoid \`.*\` between delimiters.
 - If the lesson describes an architectural principle or conceptual guideline that cannot be expressed as any pattern, set \`compilable\` to \`false\`.
 - Every compilable regex or ast-grep rule MUST include a \`badExample\` snippet (see Bad Example section below).
+- Every compilable regex or ast-grep rule MUST also include a \`goodExample\` snippet (see Good Example section below). The compile-time smoke gate runs the rule against both snippets: the pattern must match \`badExample\` (under-matching check) and must NOT match \`goodExample\` (over-matching check, mmnto-ai/totem#1580).
 - **File scoping:** Include a \`fileGlobs\` array to limit where the rule runs. Scope rules as tightly as possible:
   - **By file type:** \`["**/*.sh", "**/*.yml"]\` — for rules about shell or YAML syntax.
   - **By package/directory:** \`["packages/mcp/**/*.ts"]\` — for rules about MCP-specific patterns in a monorepo.
@@ -86,6 +87,7 @@ You are a deterministic rule compiler. Your job is to read a single natural-lang
   "pattern": "regex pattern here",
   "message": "human-readable violation message",
   "badExample": "code snippet that the pattern matches",
+  "goodExample": "code snippet that the pattern does NOT match (the correct form of the same construct)",
   "fileGlobs": ["packages/mcp/**/*.ts", "!**/*.test.ts"]
 }
 \`\`\`
@@ -96,7 +98,8 @@ Or if the rule genuinely applies to all file types (rare — prefer scoping):
   "compilable": true,
   "pattern": "regex pattern here",
   "message": "human-readable violation message",
-  "badExample": "code snippet that the pattern matches"
+  "badExample": "code snippet that the pattern matches",
+  "goodExample": "code snippet that the pattern does NOT match"
 }
 \`\`\`
 
@@ -113,22 +116,22 @@ When setting \`"compilable": false\`, always include a \`"reason"\` field explai
 ## Examples
 
 Lesson: "Use \`err\` (never \`error\`) in catch blocks"
-Output: {"compilable": true, "pattern": "catch\\\\s*\\\\(\\\\s*error\\\\s*[\\\\):]", "message": "Use 'err' instead of 'error' in catch blocks (project convention)", "badExample": "try { doWork(); } catch (error) { log(error); }"}
+Output: {"compilable": true, "pattern": "catch\\\\s*\\\\(\\\\s*error\\\\s*[\\\\):]", "message": "Use 'err' instead of 'error' in catch blocks (project convention)", "badExample": "try { doWork(); } catch (error) { log(error); }", "goodExample": "try { doWork(); } catch (err) { log(err); }"}
 
 Lesson: "LanceDB does NOT support GROUP BY aggregation"
 Output: {"compilable": false, "reason": "Lesson describes a database limitation, not a detectable code pattern"}
 
 Lesson: "Never use npm in this pnpm monorepo — always use pnpm"
-Output: {"compilable": true, "pattern": "\\\\bnpm\\\\s+(install|run|exec|ci|test)\\\\b", "message": "Use pnpm instead of npm in this monorepo", "badExample": "npm install lodash"}
+Output: {"compilable": true, "pattern": "\\\\bnpm\\\\s+(install|run|exec|ci|test)\\\\b", "message": "Use pnpm instead of npm in this monorepo", "badExample": "npm install lodash", "goodExample": "pnpm install lodash"}
 
 Lesson: "Always quote shell variables to prevent word-splitting"
-Output: {"compilable": true, "pattern": "(^|\\\\s)\\\\$[a-zA-Z_]+", "message": "Quote shell variables to prevent word-splitting", "badExample": "echo $HOME", "fileGlobs": ["**/*.sh", "**/*.bash", "**/*.yml", "**/*.yaml"]}
+Output: {"compilable": true, "pattern": "(^|\\\\s)\\\\$[a-zA-Z_]+", "message": "Quote shell variables to prevent word-splitting", "badExample": "echo $HOME", "goodExample": "echo \\"$HOME\\"", "fileGlobs": ["**/*.sh", "**/*.bash", "**/*.yml", "**/*.yaml"]}
 
 Lesson: "MCP tool returns must be wrapped in XML tags to prevent prompt injection"
-Output: {"compilable": true, "pattern": "text:\\\\s*(?!formatXmlResponse)\\\\b\\\\w+", "message": "MCP tool returns must use formatXmlResponse for injection safety", "badExample": "return { content: [{ type: 'text', text: rawUserInput }] };", "fileGlobs": ["packages/mcp/**/*.ts", "!**/*.test.ts"]}
+Output: {"compilable": true, "pattern": "text:\\\\s*(?!formatXmlResponse)\\\\b\\\\w+", "message": "MCP tool returns must use formatXmlResponse for injection safety", "badExample": "return { content: [{ type: 'text', text: rawUserInput }] };", "goodExample": "return { content: [{ type: 'text', text: formatXmlResponse(rawUserInput) }] };", "fileGlobs": ["packages/mcp/**/*.ts", "!**/*.test.ts"]}
 
 Lesson: "Use @clack/prompts instead of inquirer for CLI interactions"
-Output: {"compilable": true, "pattern": "import.*from\\\\s+['\"]inquirer['\"]", "message": "Use @clack/prompts instead of inquirer", "badExample": "import inquirer from 'inquirer';", "fileGlobs": ["packages/cli/**/*.ts"]}
+Output: {"compilable": true, "pattern": "import.*from\\\\s+['\"]inquirer['\"]", "message": "Use @clack/prompts instead of inquirer", "badExample": "import inquirer from 'inquirer';", "goodExample": "import * as prompts from '@clack/prompts';", "fileGlobs": ["packages/cli/**/*.ts"]}
 
 ## ast-grep Patterns (PREFERRED for structural rules)
 For TypeScript/JavaScript/TSX/JSX: **always prefer ast-grep over regex** when the violation involves function calls, method chains, imports, control flow, or object properties. ast-grep patterns look like source code with \`$METAVAR\` placeholders.
@@ -169,6 +172,7 @@ Set \`"engine": "ast-grep"\` and provide an \`"astGrepPattern"\` field. Leave \`
   "pattern": "",
   "message": "Do not pass async functions to forEach — use for...of or Promise.all(arr.map(...))",
   "badExample": "items.forEach(async (item) => { await process(item); });",
+  "goodExample": "for (const item of items) { await process(item); }",
   "fileGlobs": ["**/*.ts", "**/*.tsx"]
 }
 \`\`\`
@@ -244,6 +248,7 @@ If the lesson points at a context not on this list, escalate to a Tree-sitter S-
   },
   "message": "Hoist the const out of the loop or use let if the value really changes per iteration",
   "badExample": "for (let i = 0; i < n; i++) { const x = i * 2; total += x; }",
+  "goodExample": "const x = baseValue * 2; for (let i = 0; i < n; i++) { total += x; }",
   "fileGlobs": ["**/*.ts", "**/*.tsx"]
 }
 \`\`\`
@@ -268,6 +273,7 @@ The rule says "match any object literal that has \`shell: true\` as a descendant
   },
   "message": "Shell execution requires explicit opt-in - prefer safeExec or cross-spawn for Windows shim resolution",
   "badExample": "spawn(cmd, args, { shell: true });",
+  "goodExample": "spawn(cmd, args, { shell: process.platform === 'win32' });",
   "fileGlobs": ["**/*.ts", "**/*.tsx"]
 }
 \`\`\`
@@ -293,6 +299,7 @@ Rule says "match \`JSON.parse(\$INPUT)\` calls that are NOT descendants of a try
   },
   "message": "Wrap JSON.parse in try/catch - malformed input throws SyntaxError with unhelpful stack context",
   "badExample": "const config = JSON.parse(raw);",
+  "goodExample": "try { const config = JSON.parse(raw); } catch (err) { handleParseError(err); }",
   "fileGlobs": ["**/*.ts", "**/*.tsx"]
 }
 \`\`\`
@@ -313,6 +320,19 @@ A good \`badExample\` is:
 If you cannot produce a snippet that the rule would match, the rule is probably not well-formed; reconsider the pattern or set \`"compilable": false\` with an explanation.
 
 The \`badExample\` field is exempt only for the \`ast\` engine (Tree-sitter S-expression queries), which the smoke gate does not yet evaluate. For everything else (regex and ast-grep, including compound rules under \`astGrepYamlRule\`), the field is required.
+
+## Good Example (REQUIRED)
+
+Every compilable regex or ast-grep rule MUST also include a non-empty \`goodExample\` field. The compile-time smoke gate runs the rule against this snippet and rejects it with reason code \`matches-good-example\` if the pattern fires. This is the symmetric guard against over-matching: a rule that fires on both bad and good code is over-broad and produces false positives on every lint run.
+
+A good \`goodExample\` is:
+- **The same construct, correctly written.** If \`badExample\` is \`catch (error) { log(error); }\`, \`goodExample\` should be \`catch (err) { log(err); }\` — same structure, correct form.
+- **Short.** One to three lines, same as \`badExample\`.
+- **Contrastive.** Exercises the distinction the rule is meant to enforce. Do not pick unrelated code just to satisfy the field.
+
+If you cannot produce a clearly-good snippet for the same construct, the lesson is probably prescribing an absolute ban rather than a form preference. In that case, pick any realistic code that does NOT contain the banned construct (e.g., for a "never use npm" rule, any pnpm command works as goodExample).
+
+The \`goodExample\` field has the same \`ast\`-engine exemption as \`badExample\` and is required for regex and ast-grep engines (mmnto-ai/totem#1580).
 
 ## Regex (fallback for non-structural patterns)
 Use regex ONLY when the violation is a simple string/keyword match that does not involve code structure — e.g., matching import paths, literal URLs, comment patterns, or config values. The regex rules above still apply.
@@ -369,6 +389,7 @@ You will receive:
 - The pattern MUST match at least one Bad line and MUST NOT match any Good line
 - Include fileGlobs to scope the rule appropriately
 - Echo a representative Bad line back as \`badExample\` so the compile-time smoke gate (mmnto-ai/totem#1408) can verify the pattern matches at runtime.
+- Echo a representative Good line back as \`goodExample\` so the compile-time over-matching check (mmnto-ai/totem#1580) can verify the pattern does NOT match the good form.
 - **CRITICAL — Always use recursive glob patterns with \`**/\` prefix** (e.g., \`**/*.ts\`, \`**/*.py\`)
 - **CRITICAL — Supported glob syntax only:** \`**/*.ext\`, \`dir/**/*.ext\`, \`!pattern\` for negation. NO brace expansion.
 
@@ -379,6 +400,7 @@ You will receive:
   "pattern": "regex pattern that catches Bad but not Good",
   "message": "human-readable violation message",
   "badExample": "one of the Bad lines, copied verbatim",
+  "goodExample": "one of the Good lines, copied verbatim",
   "fileGlobs": ["**/*.ts", "!**/*.test.ts"]
 }
 \`\`\`
@@ -391,5 +413,5 @@ Or if the difference cannot be expressed as a line-level regex:
 }
 \`\`\`
 
-Every compilable rule MUST include a non-empty \`badExample\` field. The compile pipeline's schema parse rejects output that omits it for \`ast-grep\` or \`regex\` engines, so the rule never reaches the smoke gate. Echoing a representative Bad line (or the snippet the rule was built from) is usually enough; the smoke gate runs the rule against this exact string at compile time and rejects the rule if it produces zero matches.
+Every compilable rule MUST include non-empty \`badExample\` AND \`goodExample\` fields. The compile pipeline's schema parse rejects output that omits either one for \`ast-grep\` or \`regex\` engines, so the rule never reaches the smoke gate. The smoke gate then runs the rule against both snippets: the pattern MUST match \`badExample\` (zero matches here rejects with reason code \`pattern-zero-match\`) and MUST NOT match \`goodExample\` (any match here rejects with reason code \`matches-good-example\`).
 `;

--- a/packages/core/src/compile-lesson.test.ts
+++ b/packages/core/src/compile-lesson.test.ts
@@ -583,6 +583,7 @@ describe('buildCompiledRule smoke gate (mmnto/totem#1408)', () => {
       engine: 'ast-grep',
       astGrepPattern: 'debugger',
       badExample: 'const x = 1;\n',
+      goodExample: '// placeholder\n',
     };
     const result = buildCompiledRule(parsed, lesson, existingByHash, {
       enforceSmokeGate: true,
@@ -614,6 +615,7 @@ describe('buildCompiledRule smoke gate (mmnto/totem#1408)', () => {
       engine: 'ast-grep',
       astGrepPattern: 'debugger',
       badExample: 'debugger;\n',
+      goodExample: '// placeholder\n',
     };
     const result = buildCompiledRule(parsed, lesson, existingByHash, {
       enforceSmokeGate: true,
@@ -629,6 +631,7 @@ describe('buildCompiledRule smoke gate (mmnto/totem#1408)', () => {
       engine: 'regex',
       pattern: 'console\\.log',
       badExample: 'console.log("debug")',
+      goodExample: '// placeholder\n',
     };
     const result = buildCompiledRule(parsed, lesson, existingByHash, {
       enforceSmokeGate: true,
@@ -648,9 +651,11 @@ describe('buildCompiledRule smoke gate (mmnto/totem#1408)', () => {
     const result = buildCompiledRule(parsed, lesson, existingByHash, {
       enforceSmokeGate: true,
       badExampleOverride: 'console.log("bad")',
+      goodExampleOverride: 'logger.info("good")',
     });
     expect(result.rule).not.toBeNull();
     expect(result.rule!.badExample).toBe('console.log("bad")');
+    expect(result.rule!.goodExample).toBe('logger.info("good")');
   });
 
   it('Pipeline 1 is unaffected (gate is opt-in via enforceSmokeGate)', () => {
@@ -696,6 +701,7 @@ describe('compound rule smoke gate (mmnto-ai/totem#1409)', () => {
         },
       },
       badExample: 'for (let i = 0; i < 10; i++) {\n  const inside = i * 2;\n}',
+      goodExample: '// placeholder\n',
     };
     const result = buildCompiledRule(parsed, compoundLesson, existingByHash, {
       enforceSmokeGate: true,
@@ -726,6 +732,7 @@ describe('compound rule smoke gate (mmnto-ai/totem#1409)', () => {
         },
       },
       badExample: 'for (let i = 0; i < 10; i++) {\n  const inside = i * 2;\n}',
+      goodExample: '// placeholder\n',
     };
     const result = buildCompiledRule(parsed, compoundLesson, existingByHash, {
       enforceSmokeGate: true,
@@ -757,6 +764,114 @@ describe('compound rule smoke gate (mmnto-ai/totem#1409)', () => {
     expect(result.rule).toBeNull();
     expect(result.rejectReason).toContain('smoke gate');
     expect(result.rejectReason).toContain('badExample');
+  });
+});
+
+// ─── over-matching check (mmnto-ai/totem#1580) ───────
+
+describe('buildCompiledRule goodExample over-matching check', () => {
+  it('rejects a regex rule that fires on its goodExample', () => {
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'No console.log',
+      engine: 'regex',
+      pattern: 'console\\.log',
+      // badExample exercises the pattern (matches) — gate under-match passes.
+      badExample: 'console.log("debug")',
+      // goodExample also matches the pattern, which means the rule is
+      // over-broad and fires on known-correct code. The gate must reject.
+      goodExample: 'console.log("intentional system message")',
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      enforceSmokeGate: true,
+    });
+    expect(result.rule).toBeNull();
+    expect(result.rejectReason).toContain('smoke gate');
+    expect(result.rejectReason).toContain('matches goodExample');
+    expect(result.rejectReason).toContain('over-matching');
+  });
+
+  it('rejects an ast-grep rule that fires on its goodExample', () => {
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'No debugger',
+      engine: 'ast-grep',
+      astGrepPattern: 'debugger',
+      badExample: 'debugger;',
+      goodExample: 'debugger;\n// should have been removed before commit',
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      enforceSmokeGate: true,
+    });
+    expect(result.rule).toBeNull();
+    expect(result.rejectReason).toContain('matches goodExample');
+  });
+
+  it('accepts a regex rule whose pattern fires on badExample but not goodExample', () => {
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'No console.log',
+      engine: 'regex',
+      pattern: 'console\\.log',
+      badExample: 'console.log("debug")',
+      goodExample: 'logger.info("intentional")',
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      enforceSmokeGate: true,
+    });
+    expect(result.rule).not.toBeNull();
+    expect(result.rule!.goodExample).toBe('logger.info("intentional")');
+  });
+
+  it('rejects a rule that is missing goodExample (required for Pipeline 2/3)', () => {
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'No console.log',
+      engine: 'regex',
+      pattern: 'console\\.log',
+      badExample: 'console.log("debug")',
+      // goodExample absent — caller did not supply it and schema
+      // layer was bypassed. Gate must still reject.
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      enforceSmokeGate: true,
+    });
+    expect(result.rule).toBeNull();
+    expect(result.rejectReason).toContain('smoke gate');
+    expect(result.rejectReason).toContain('missing goodExample');
+  });
+
+  it('honors goodExampleOverride so Pipeline 3 can reuse its Good snippet', () => {
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'No console.log',
+      engine: 'regex',
+      pattern: 'console\\.log',
+      badExample: 'console.log("bad")',
+      // No goodExample on parsed; caller supplies it via override.
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      enforceSmokeGate: true,
+      goodExampleOverride: 'logger.info("good")',
+    });
+    expect(result.rule).not.toBeNull();
+    expect(result.rule!.goodExample).toBe('logger.info("good")');
+  });
+
+  it('persists goodExample on the CompiledRule when the gate accepts', () => {
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'No debugger',
+      engine: 'ast-grep',
+      astGrepPattern: 'debugger',
+      badExample: 'debugger;',
+      goodExample: 'const x = 1;',
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      enforceSmokeGate: true,
+    });
+    expect(result.rule).not.toBeNull();
+    expect(result.rule!.goodExample).toBe('const x = 1;');
   });
 });
 
@@ -870,6 +985,7 @@ describe('compileLesson', () => {
             // wants the rule to compile, so give the helper a known-good
             // snippet that matches the pattern.
             badExample: 'console.log("debug")',
+            goodExample: '// placeholder\n',
           }
         : null,
     ),
@@ -931,6 +1047,7 @@ describe('compileLesson', () => {
         message: 'No console.log',
         engine: 'regex' as const,
         badExample: 'console.log("debug")',
+        goodExample: '// placeholder\n',
       }),
       runOrchestrator: vi.fn().mockResolvedValue('{"compilable": true}'),
       existingByHash: new Map(),
@@ -1001,6 +1118,7 @@ describe('compileLesson', () => {
         message: 'No console.log',
         engine: 'regex' as const,
         badExample: 'console.log("debug")',
+        goodExample: '// placeholder\n',
       }),
       runOrchestrator: vi.fn().mockResolvedValue('{"compilable": true}'),
       existingByHash: new Map(),
@@ -1273,6 +1391,7 @@ describe('compileLesson with inline examples', () => {
             message: 'No console.log',
             engine: 'regex' as const,
             badExample: 'console.log("debug")',
+            goodExample: '// placeholder\n',
           }
         : null,
     ),
@@ -1550,6 +1669,7 @@ describe('compileLesson Pipeline 2 verify-retry', () => {
         message: 'No console.log',
         engine: 'regex' as const,
         badExample: 'console.log("debug")',
+        goodExample: '// placeholder\n',
       })
       .mockReturnValueOnce({
         compilable: true,
@@ -1557,6 +1677,7 @@ describe('compileLesson Pipeline 2 verify-retry', () => {
         message: 'No console.log',
         engine: 'regex' as const,
         badExample: 'console.log("debug")',
+        goodExample: '// placeholder\n',
       });
     const orchestratorMock = vi
       .fn()
@@ -1594,6 +1715,7 @@ describe('compileLesson Pipeline 2 verify-retry', () => {
       message: 'No console.log',
       engine: 'regex' as const,
       badExample: 'console.log("debug")',
+      goodExample: '// placeholder\n',
     });
     const orchestratorMock = vi.fn().mockResolvedValue('always-bad');
     const deps: CompileLessonDeps = {
@@ -1735,6 +1857,7 @@ describe('compileLesson Pipeline 2 verify-retry', () => {
         message: 'No console.log',
         engine: 'regex' as const,
         badExample: 'zzz_only_matches_itself',
+        goodExample: '// placeholder\n',
       })
       .mockReturnValueOnce({
         compilable: true,
@@ -1742,6 +1865,7 @@ describe('compileLesson Pipeline 2 verify-retry', () => {
         message: 'No console.log',
         engine: 'regex' as const,
         badExample: 'console.log("x")',
+        goodExample: '// placeholder\n',
       });
     const orchestratorMock = vi
       .fn()
@@ -1788,6 +1912,7 @@ describe('compileLesson Pipeline 2 verify-retry', () => {
       message: 'No console.log',
       engine: 'regex' as const,
       badExample: 'zzz_only_matches_itself',
+      goodExample: '// placeholder\n',
     });
     const orchestratorMock = vi.fn().mockResolvedValue('always-misses');
     const deps: CompileLessonDeps = {
@@ -1818,6 +1943,7 @@ describe('compileLesson Pipeline 2 verify-retry', () => {
       message: 'Invalid regex test',
       engine: 'regex' as const,
       badExample: 'any string',
+      goodExample: '// placeholder\n',
     });
     const orchestratorMock = vi.fn().mockResolvedValue('invalid-regex-output');
     const deps: CompileLessonDeps = {
@@ -1866,6 +1992,7 @@ describe('compileLesson unverified flag', () => {
       engine: 'regex' as const,
       severity: 'error' as const,
       badExample: 'console.log(x)',
+      goodExample: '// placeholder\n',
     });
     const orchestratorMock = vi.fn().mockResolvedValue('{"compilable": true}');
     const deps: CompileLessonDeps = {
@@ -1897,6 +2024,7 @@ describe('compileLesson unverified flag', () => {
       message: 'No console.log',
       engine: 'regex' as const,
       badExample: 'console.log(x)',
+      goodExample: '// placeholder\n',
     });
     const orchestratorMock = vi.fn().mockResolvedValue('{"compilable": true}');
     const deps: CompileLessonDeps = {
@@ -1925,6 +2053,7 @@ describe('compileLesson unverified flag', () => {
       message: 'No console.log',
       engine: 'regex' as const,
       badExample: 'console.log(x)',
+      goodExample: '// placeholder\n',
     });
     const orchestratorMock = vi.fn().mockResolvedValue('{"compilable": true}');
     const deps: CompileLessonDeps = {
@@ -1957,13 +2086,18 @@ describe('compileLesson unverified flag', () => {
     };
     const parseMock = vi.fn().mockReturnValue({
       compilable: true,
-      // Pattern that matches any string — including the trimmed-empty
-      // Example Hit — so verifyRuleExamples passes and we can assert
-      // on the unverified flag without the verify branch interfering.
-      pattern: '.*',
+      // Pattern that matches both the trimmed-empty Example Hit (via
+      // `^$`) AND the badExample "anything" (via `\banything\b`) so
+      // verifyRuleExamples passes without interference. The goodExample
+      // `// placeholder` is constructed to not satisfy either alternative
+      // so the mmnto-ai/totem#1580 over-matching check also passes.
+      // No trailing newline on goodExample so the line-split doesn't
+      // produce an empty trailing line that would match `^$`.
+      pattern: '^$|\\banything\\b',
       message: 'msg',
       engine: 'regex' as const,
       badExample: 'anything',
+      goodExample: '// placeholder',
     });
     const orchestratorMock = vi.fn().mockResolvedValue('{"compilable": true}');
     const deps: CompileLessonDeps = {
@@ -2105,6 +2239,7 @@ describe('compileLesson trace events', () => {
       message: 'No console.log',
       engine: 'regex' as const,
       badExample: 'console.log("x")',
+      goodExample: '// placeholder\n',
     });
     const orchestratorMock = vi.fn().mockResolvedValue('attempt-1');
     const deps: CompileLessonDeps = {
@@ -2142,6 +2277,7 @@ describe('compileLesson trace events', () => {
       message: 'No console.log',
       engine: 'regex' as const,
       badExample: 'zzz_only_matches_itself',
+      goodExample: '// placeholder\n',
     });
     const orchestratorMock = vi.fn().mockResolvedValue('always-misses');
     const deps: CompileLessonDeps = {
@@ -2211,6 +2347,7 @@ describe('compileLesson trace events', () => {
       message: 'bad regex',
       engine: 'regex' as const,
       badExample: 'anything',
+      goodExample: '// placeholder\n',
     });
     const orchestratorMock = vi.fn().mockResolvedValue('invalid-regex-output');
     const deps: CompileLessonDeps = {
@@ -2262,6 +2399,7 @@ describe('compileLesson trace events', () => {
       message: 'No console.log',
       engine: 'regex' as const,
       badExample: 'console.log("x")',
+      goodExample: '// placeholder\n',
     });
     const orchestratorMock = vi.fn().mockResolvedValue('pipeline-3-response');
     const deps: CompileLessonDeps = {

--- a/packages/core/src/compile-lesson.test.ts
+++ b/packages/core/src/compile-lesson.test.ts
@@ -895,6 +895,43 @@ describe('buildCompiledRule goodExample over-matching check', () => {
     expect(result.rule!.goodExample).toBe('logger.info("from parsed")');
   });
 
+  it('rejects a whitespace-only goodExample with missing-goodexample (parity with schema refine)', () => {
+    // Shield flagged on mmnto-ai/totem#1591: `if (!effectiveGoodExample)`
+    // treats `'   '` as truthy, and runSmokeGate's early-return on
+    // `trim().length === 0` then reports matched: false, so a
+    // whitespace-only goodExample would otherwise pass the gate with
+    // zero coverage. The `.trim().length > 0` guard closes the hole.
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'No console.log',
+      engine: 'regex',
+      pattern: 'console\\.log',
+      badExample: 'console.log("bad")',
+      goodExample: '   \t\n  ',
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      enforceSmokeGate: true,
+    });
+    expect(result.rule).toBeNull();
+    expect(result.rejectReason).toContain('missing goodExample');
+  });
+
+  it('rejects a whitespace-only badExample with missing-badexample (symmetric guard)', () => {
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'No console.log',
+      engine: 'regex',
+      pattern: 'console\\.log',
+      badExample: '   \t\n  ',
+      goodExample: 'logger.info("good")',
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      enforceSmokeGate: true,
+    });
+    expect(result.rule).toBeNull();
+    expect(result.rejectReason).toContain('missing badExample');
+  });
+
   it('empty-string goodExampleOverride clobbers parsed.goodExample (the trap the Pipeline 3 guard exists to prevent)', () => {
     // Nullish coalescing (`??`) treats `''` as defined, so passing an
     // empty string override suppresses the parsed value. This test pins

--- a/packages/core/src/compile-lesson.test.ts
+++ b/packages/core/src/compile-lesson.test.ts
@@ -873,6 +873,49 @@ describe('buildCompiledRule goodExample over-matching check', () => {
     expect(result.rule).not.toBeNull();
     expect(result.rule!.goodExample).toBe('const x = 1;');
   });
+
+  it('falls back to parsed.goodExample when goodExampleOverride is undefined', () => {
+    // Pins the Pipeline 3 contract: the call site passes `undefined`
+    // (not an empty string) when snippets.good is empty, so buildCompiledRule's
+    // `options.goodExampleOverride ?? parsed.goodExample` correctly resolves
+    // to the LLM-echoed value.
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'No console.log',
+      engine: 'regex',
+      pattern: 'console\\.log',
+      badExample: 'console.log("bad")',
+      goodExample: 'logger.info("from parsed")',
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      enforceSmokeGate: true,
+      goodExampleOverride: undefined,
+    });
+    expect(result.rule).not.toBeNull();
+    expect(result.rule!.goodExample).toBe('logger.info("from parsed")');
+  });
+
+  it('empty-string goodExampleOverride clobbers parsed.goodExample (the trap the Pipeline 3 guard exists to prevent)', () => {
+    // Nullish coalescing (`??`) treats `''` as defined, so passing an
+    // empty string override suppresses the parsed value. This test pins
+    // that behavior so the Pipeline 3 call site's .length guard in
+    // compile-lesson.ts (snippets.good.length > 0 ? ... : undefined)
+    // stays load-bearing.
+    const parsed: CompilerOutput = {
+      compilable: true,
+      message: 'No console.log',
+      engine: 'regex',
+      pattern: 'console\\.log',
+      badExample: 'console.log("bad")',
+      goodExample: 'logger.info("from parsed")',
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      enforceSmokeGate: true,
+      goodExampleOverride: '',
+    });
+    expect(result.rule).toBeNull();
+    expect(result.rejectReason).toContain('missing goodExample');
+  });
 });
 
 // ─── buildManualRule ────────────────────────────────

--- a/packages/core/src/compile-lesson.ts
+++ b/packages/core/src/compile-lesson.ts
@@ -322,6 +322,13 @@ export interface BuildCompiledRuleOptions {
    * the structured output.
    */
   badExampleOverride?: string;
+  /**
+   * Optional goodExample override (mmnto-ai/totem#1580). When supplied,
+   * takes precedence over `parsed.goodExample`. Pipeline 3 uses this to
+   * reuse its Good snippet as the over-matching check target without
+   * relying on the LLM to echo the snippet back.
+   */
+  goodExampleOverride?: string;
 }
 
 /**
@@ -349,6 +356,15 @@ export function buildCompiledRule(
   const badExampleObj =
     effectiveBadExample && effectiveBadExample.length > 0
       ? { badExample: effectiveBadExample }
+      : {};
+  // mmnto-ai/totem#1580: the effective goodExample mirrors bad — override
+  // wins, else whatever the LLM echoed back. Persisted on the rule so
+  // downstream over-matching checks (and future recompile cycles) have
+  // the ground-truth negative fixture without needing the source lesson.
+  const effectiveGoodExample = options.goodExampleOverride ?? parsed.goodExample;
+  const goodExampleObj =
+    effectiveGoodExample && effectiveGoodExample.length > 0
+      ? { goodExample: effectiveGoodExample }
       : {};
 
   let candidate: CompiledRule;
@@ -400,6 +416,7 @@ export function buildCompiledRule(
       createdAt: existing?.createdAt ?? now,
       ...globsObj,
       ...badExampleObj,
+      ...goodExampleObj,
     };
   } else if (engine === 'ast') {
     if (!parsed.astQuery || !parsed.message) {
@@ -416,6 +433,7 @@ export function buildCompiledRule(
       createdAt: existing?.createdAt ?? now,
       ...globsObj,
       ...badExampleObj,
+      ...goodExampleObj,
     };
   } else {
     // Regex engine (default)
@@ -448,6 +466,7 @@ export function buildCompiledRule(
       createdAt: existing?.createdAt ?? now,
       ...globsObj,
       ...badExampleObj,
+      ...goodExampleObj,
     };
   }
 
@@ -472,6 +491,23 @@ export function buildCompiledRule(
       return {
         rule: null,
         rejectReason: `smoke gate: zero matches against badExample${suffix}`,
+      };
+    }
+    // mmnto-ai/totem#1580: over-matching check. The rule must fire on its
+    // badExample (above) AND must NOT fire on its goodExample. Symmetric
+    // guards catch the under-match and over-match defect classes with the
+    // same deterministic engine the runtime uses.
+    if (!effectiveGoodExample) {
+      return {
+        rule: null,
+        rejectReason: 'smoke gate: missing goodExample (required for Pipeline 2/3)',
+      };
+    }
+    const overMatchGate = runSmokeGate(candidate, effectiveGoodExample);
+    if (overMatchGate.matched) {
+      return {
+        rule: null,
+        rejectReason: `smoke gate: matches goodExample (over-matching: ${overMatchGate.matchCount} match${overMatchGate.matchCount === 1 ? '' : 'es'})`,
       };
     }
   }
@@ -822,6 +858,7 @@ export async function compileLesson(
     const ruleResult = buildCompiledRule(parsed, lesson, existingByHash, {
       enforceSmokeGate: true,
       badExampleOverride: snippets.bad.join('\n'),
+      goodExampleOverride: snippets.good.join('\n'),
     });
     if (!ruleResult.rule) {
       const rejectReason = ruleResult.rejectReason ?? 'Unknown error';
@@ -1160,6 +1197,8 @@ function classifyBuildRejectReason(rejectReason: string): CompileLessonReasonCod
   if (rejectReason.startsWith('Invalid ast-grep pattern')) return 'pattern-syntax-invalid';
   if (rejectReason.includes('suppression directive')) return 'pattern-syntax-invalid';
   if (rejectReason.startsWith('smoke gate: zero matches')) return 'pattern-zero-match';
+  if (rejectReason.startsWith('smoke gate: matches goodExample')) return 'matches-good-example';
+  if (rejectReason.startsWith('smoke gate: missing goodExample')) return 'missing-goodexample';
   return 'pattern-syntax-invalid';
 }
 

--- a/packages/core/src/compile-lesson.ts
+++ b/packages/core/src/compile-lesson.ts
@@ -857,8 +857,13 @@ export async function compileLesson(
     // the override guarantees the gate has something to work with regardless.
     const ruleResult = buildCompiledRule(parsed, lesson, existingByHash, {
       enforceSmokeGate: true,
-      badExampleOverride: snippets.bad.join('\n'),
-      goodExampleOverride: snippets.good.join('\n'),
+      // Guard empty snippet arrays so they don't clobber parsed.badExample
+      // or parsed.goodExample via ?? in buildCompiledRule. `[].join('\n')`
+      // is the empty string, which is defined and would win over the LLM's
+      // echo-back. Pipeline 3's extractBadGoodSnippets requires both Bad
+      // and Good to be present, so the .length check is belt-and-braces.
+      badExampleOverride: snippets.bad.length > 0 ? snippets.bad.join('\n') : undefined,
+      goodExampleOverride: snippets.good.length > 0 ? snippets.good.join('\n') : undefined,
     });
     if (!ruleResult.rule) {
       const rejectReason = ruleResult.rejectReason ?? 'Unknown error';

--- a/packages/core/src/compile-lesson.ts
+++ b/packages/core/src/compile-lesson.ts
@@ -479,7 +479,16 @@ export function buildCompiledRule(
   // matches the comment in compile-smoke-gate.ts and prevents the gate from
   // hard-rejecting a rule it is not equipped to evaluate.
   if (options.enforceSmokeGate && candidate.engine !== 'ast') {
-    if (!effectiveBadExample) {
+    // `.trim().length > 0` mirrors the schema refines. A caller who
+    // bypasses schema parsing and supplies a whitespace-only override
+    // would otherwise slip through the !effectiveExample check because
+    // `'   '` is truthy, and then runSmokeGate's early-return on
+    // `trim().length === 0` would report matched: false for both
+    // checks — under-match would (correctly) reject but for the wrong
+    // reason, and over-match would (incorrectly) accept.
+    const hasBadExample =
+      typeof effectiveBadExample === 'string' && effectiveBadExample.trim().length > 0;
+    if (!hasBadExample) {
       return {
         rule: null,
         rejectReason: 'smoke gate: missing badExample (required for Pipeline 2/3)',
@@ -497,7 +506,9 @@ export function buildCompiledRule(
     // badExample (above) AND must NOT fire on its goodExample. Symmetric
     // guards catch the under-match and over-match defect classes with the
     // same deterministic engine the runtime uses.
-    if (!effectiveGoodExample) {
+    const hasGoodExample =
+      typeof effectiveGoodExample === 'string' && effectiveGoodExample.trim().length > 0;
+    if (!hasGoodExample) {
       return {
         rule: null,
         rejectReason: 'smoke gate: missing goodExample (required for Pipeline 2/3)',

--- a/packages/core/src/compile-smoke-gate.test.ts
+++ b/packages/core/src/compile-smoke-gate.test.ts
@@ -207,6 +207,54 @@ describe('runSmokeGate badExample extension inference', () => {
   });
 });
 
+// ─── over-matching check (mmnto-ai/totem#1580) ───────
+
+describe('runSmokeGate over-matching check', () => {
+  it('reports matched=true when a regex rule fires on a goodExample (the caller then rejects)', () => {
+    // Simulates the mmnto-ai/totem#1580 over-matching detection flow:
+    // the caller runs the rule against `goodExample` and treats a match
+    // as a rejection signal. The gate itself is role-agnostic.
+    const rule = makeRegexRule({ pattern: 'console\\.log' });
+    const overlyGood = 'console.log("this should not match a good example");\n';
+    const result = runSmokeGate(rule, overlyGood);
+    expect(result.matched).toBe(true);
+    expect(result.matchCount).toBeGreaterThan(0);
+  });
+
+  it('reports matched=false when a well-scoped regex rule does not fire on goodExample', () => {
+    const rule = makeRegexRule({ pattern: 'console\\.log' });
+    const goodExample = 'logger.info("correct usage")\n';
+    const result = runSmokeGate(rule, goodExample);
+    expect(result.matched).toBe(false);
+    expect(result.matchCount).toBe(0);
+  });
+
+  it('reports matched=true when an ast-grep rule fires on a goodExample', () => {
+    const rule = makeAstGrepStringRule();
+    const overlyGood = 'debugger;\nconst x = 1;\n';
+    const result = runSmokeGate(rule, overlyGood);
+    expect(result.matched).toBe(true);
+  });
+
+  it('reports matched=false when an ast-grep rule does not fire on goodExample', () => {
+    const rule = makeAstGrepStringRule();
+    const goodExample = 'const x = 1;\n';
+    const result = runSmokeGate(rule, goodExample);
+    expect(result.matched).toBe(false);
+  });
+
+  it('treats an empty goodExample as no-op (early return, matched=false)', () => {
+    // The smoke gate's caller treats matched=false against goodExample
+    // as "over-matching check passed". An empty goodExample short-circuits
+    // to matched=false so the check is effectively a no-op rather than
+    // crashing the engine on an empty snippet.
+    const rule = makeRegexRule();
+    const result = runSmokeGate(rule, '');
+    expect(result.matched).toBe(false);
+    expect(result.matchCount).toBe(0);
+  });
+});
+
 // ─── runtime-parity invariant ────────────────────────
 
 describe('runSmokeGate runtime parity invariant', () => {

--- a/packages/core/src/compile-smoke-gate.ts
+++ b/packages/core/src/compile-smoke-gate.ts
@@ -25,7 +25,7 @@ import type { CompiledRule } from './compiler-schema.js';
 // ─── Types ──────────────────────────────────────────
 
 export interface SmokeGateResult {
-  /** True when the rule produced at least one match against the badExample. */
+  /** True when the rule produced at least one match against the snippet. */
   matched: boolean;
   /** Number of matches the engine reported. Zero when `matched` is false. */
   matchCount: number;
@@ -55,7 +55,7 @@ function lineNumbersFor(snippet: string): number[] {
 
 // ─── Engine runners ─────────────────────────────────
 
-function runRegexGate(pattern: string, badExample: string): SmokeGateResult {
+function runRegexGate(pattern: string, snippet: string): SmokeGateResult {
   let re: RegExp;
   try {
     re = new RegExp(pattern);
@@ -68,7 +68,7 @@ function runRegexGate(pattern: string, badExample: string): SmokeGateResult {
   }
 
   let matchCount = 0;
-  for (const line of badExample.split('\n')) {
+  for (const line of snippet.split('\n')) {
     if (re.test(line)) matchCount++;
   }
   return matchCount > 0 ? { matched: true, matchCount } : { matched: false, matchCount: 0 };
@@ -106,14 +106,14 @@ function inferBadExampleExts(rule: CompiledRule): string[] {
 
 function runAstGrepGate(
   pattern: AstGrepRule,
-  badExample: string,
+  snippet: string,
   rule: CompiledRule,
 ): SmokeGateResult {
-  const lineNumbers = lineNumbersFor(badExample);
+  const lineNumbers = lineNumbersFor(snippet);
   let lastReason: string | undefined;
   for (const ext of inferBadExampleExts(rule)) {
     try {
-      const matches = matchAstGrepPattern(badExample, ext, pattern, lineNumbers);
+      const matches = matchAstGrepPattern(snippet, ext, pattern, lineNumbers);
       if (matches.length > 0) {
         return { matched: true, matchCount: matches.length };
       }
@@ -129,18 +129,22 @@ function runAstGrepGate(
 // ─── Public API ─────────────────────────────────────
 
 /**
- * Run the smoke gate for a compiled rule. Returns a `SmokeGateResult` so the
- * caller can decide whether to accept or reject the rule. The caller is
- * responsible for the "zero matches means reject" decision; this function
- * only reports what the engine says.
+ * Run the smoke gate for a compiled rule against an arbitrary snippet.
+ * Callers interpret `matched === true` based on the snippet's role:
+ *   - badExample check: under-matching when matched is false → reject
+ *   - goodExample check (mmnto-ai/totem#1580): over-matching when matched
+ *     is true → reject
+ *
+ * This function is intentionally role-agnostic and only reports what the
+ * engine says; the accept/reject decision belongs to the caller.
  */
-export function runSmokeGate(rule: CompiledRule, badExample: string): SmokeGateResult {
-  if (!badExample || badExample.trim().length === 0) {
+export function runSmokeGate(rule: CompiledRule, snippet: string): SmokeGateResult {
+  if (!snippet || snippet.trim().length === 0) {
     return { matched: false, matchCount: 0 };
   }
 
   if (rule.engine === 'regex') {
-    return runRegexGate(rule.pattern, badExample);
+    return runRegexGate(rule.pattern, snippet);
   }
 
   if (rule.engine === 'ast-grep') {
@@ -153,7 +157,7 @@ export function runSmokeGate(rule: CompiledRule, badExample: string): SmokeGateR
         reason: 'ast-grep rule missing both astGrepPattern and astGrepYamlRule',
       };
     }
-    return runAstGrepGate(source, badExample, rule);
+    return runAstGrepGate(source, snippet, rule);
   }
 
   // Tree-sitter ast engine: not wired into the gate in mmnto/totem#1408.

--- a/packages/core/src/compiler-schema.test.ts
+++ b/packages/core/src/compiler-schema.test.ts
@@ -139,6 +139,7 @@ describe('CompilerOutputSchema mutual exclusion', () => {
       message: 'msg',
       astGrepYamlRule: { rule: { pattern: 'foo($A)' } },
       badExample: 'foo(1)',
+      goodExample: 'bar(1)',
     });
     expect(parsed.astGrepYamlRule).toBeDefined();
   });
@@ -184,6 +185,7 @@ describe('CompilerOutput badExample required by engine', () => {
       message: 'No foo',
       engine: 'regex',
       badExample: 'const foo = 1;',
+      goodExample: 'const bar = 1;',
     });
     expect(parsed.badExample).toBe('const foo = 1;');
   });
@@ -195,6 +197,7 @@ describe('CompilerOutput badExample required by engine', () => {
       engine: 'ast-grep',
       astGrepPattern: 'console.log($A)',
       badExample: 'console.log("debug");',
+      goodExample: 'logger.info("debug");',
     });
     expect(parsed.badExample).toBe('console.log("debug");');
   });

--- a/packages/core/src/compiler-schema.test.ts
+++ b/packages/core/src/compiler-schema.test.ts
@@ -366,6 +366,45 @@ describe('CompilerOutput goodExample required by engine', () => {
     expect(parsed.engine).toBe('ast');
     expect(parsed.goodExample).toBeUndefined();
   });
+
+  it('rejects an ast-grep CompilerOutput missing goodExample', () => {
+    const result = CompilerOutputSchema.safeParse({
+      compilable: true,
+      message: 'No console.log',
+      engine: 'ast-grep',
+      astGrepPattern: 'console.log($A)',
+      badExample: 'console.log("debug");',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an ast-grep CompilerOutput with a whitespace-only goodExample', () => {
+    const result = CompilerOutputSchema.safeParse({
+      compilable: true,
+      message: 'No console.log',
+      engine: 'ast-grep',
+      astGrepPattern: 'console.log($A)',
+      badExample: 'console.log("debug");',
+      goodExample: '   \n\t ',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an ast-grep compound CompilerOutput missing goodExample', () => {
+    const result = CompilerOutputSchema.safeParse({
+      compilable: true,
+      message: 'No const inside for-loop',
+      engine: 'ast-grep',
+      astGrepYamlRule: {
+        rule: {
+          pattern: 'const $VAR = $VAL',
+          inside: { kind: 'for_statement', stopBy: 'end' },
+        },
+      },
+      badExample: 'for (let i = 0; i < 10; i++) { const x = 1; }',
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 // ─── RuleEventCallback discriminator (mmnto/totem#1408) ─────

--- a/packages/core/src/compiler-schema.test.ts
+++ b/packages/core/src/compiler-schema.test.ts
@@ -285,6 +285,87 @@ describe('CompilerOutput badExample required by engine', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it('rejects a regex CompilerOutput with a whitespace-only badExample', () => {
+    // Flagged by CodeRabbit on mmnto-ai/totem#1591: a blank string passes
+    // `length > 0` but the smoke gate's early-return on `trim().length === 0`
+    // would treat it as a no-op, so the required-field check must use
+    // `.trim().length > 0` to close the hole.
+    const result = CompilerOutputSchema.safeParse({
+      compilable: true,
+      pattern: '\\bfoo\\b',
+      message: 'No foo',
+      engine: 'regex',
+      badExample: '   \t\n  ',
+      goodExample: 'const bar = 1;',
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── CompilerOutput goodExample required per engine (mmnto-ai/totem#1580) ──
+
+describe('CompilerOutput goodExample required by engine', () => {
+  it('accepts a regex CompilerOutput with a non-empty goodExample', () => {
+    const parsed = CompilerOutputSchema.parse({
+      compilable: true,
+      pattern: '\\bfoo\\b',
+      message: 'No foo',
+      engine: 'regex',
+      badExample: 'const foo = 1;',
+      goodExample: 'const bar = 1;',
+    });
+    expect(parsed.goodExample).toBe('const bar = 1;');
+  });
+
+  it('rejects a regex CompilerOutput missing goodExample', () => {
+    const result = CompilerOutputSchema.safeParse({
+      compilable: true,
+      pattern: '\\bfoo\\b',
+      message: 'No foo',
+      engine: 'regex',
+      badExample: 'const foo = 1;',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a regex CompilerOutput with an empty goodExample string', () => {
+    const result = CompilerOutputSchema.safeParse({
+      compilable: true,
+      pattern: '\\bfoo\\b',
+      message: 'No foo',
+      engine: 'regex',
+      badExample: 'const foo = 1;',
+      goodExample: '',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a regex CompilerOutput with a whitespace-only goodExample', () => {
+    // The case CodeRabbit flagged directly on mmnto-ai/totem#1591: a
+    // blank string satisfies `length > 0` but has zero over-matching
+    // coverage because the smoke gate treats it as no-op.
+    const result = CompilerOutputSchema.safeParse({
+      compilable: true,
+      pattern: '\\bfoo\\b',
+      message: 'No foo',
+      engine: 'regex',
+      badExample: 'const foo = 1;',
+      goodExample: '   \t\n  ',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts an ast engine CompilerOutput without goodExample (exempt engine)', () => {
+    const parsed = CompilerOutputSchema.parse({
+      compilable: true,
+      message: 'AST check',
+      engine: 'ast',
+      astQuery: '(catch_clause) @c',
+    });
+    expect(parsed.engine).toBe('ast');
+    expect(parsed.goodExample).toBeUndefined();
+  });
 });
 
 // ─── RuleEventCallback discriminator (mmnto/totem#1408) ─────

--- a/packages/core/src/compiler-schema.ts
+++ b/packages/core/src/compiler-schema.ts
@@ -71,6 +71,16 @@ const CompiledRuleBaseSchema = z.object({
    * 1.14.9; flips to required when #1408 turns on the gate.
    */
   badExample: z.string().optional(),
+  /**
+   * Optional code snippet the rule MUST NOT match. mmnto-ai/totem#1580
+   * added the over-matching check: the compile-time smoke gate runs the
+   * rule against `goodExample` and rejects it with reason code
+   * `'matches-good-example'` if the pattern fires. Optional at the
+   * persisted-rule boundary for backward compatibility with pre-#1580
+   * rules; `CompilerOutputSchema` requires it for regex and ast-grep
+   * producers (see `refineGoodExampleRequired`).
+   */
+  goodExample: z.string().optional(),
   /** ISO timestamp of when this rule was compiled */
   compiledAt: z.string(),
   /** ISO timestamp of when this rule was first created (survives recompilation) */
@@ -183,6 +193,8 @@ export const NonCompilableReasonCodeSchema = z.enum([
   'no-pattern-found',
   'out-of-scope',
   'missing-badexample',
+  'missing-goodexample',
+  'matches-good-example',
   'legacy-unknown',
 ]);
 
@@ -288,6 +300,17 @@ const CompilerOutputBaseSchema = z.object({
    * can name the engine and cite the ticket.
    */
   badExample: z.string().optional(),
+  /**
+   * Code snippet the rule MUST NOT match. Flipped from optional to
+   * engine-conditional required in mmnto-ai/totem#1580 - regex and
+   * ast-grep rules must carry a non-empty snippet so the compile-time
+   * smoke gate can assert the pattern does not over-match on known-good
+   * code before it lands in compiled-rules.json. The Zod field stays
+   * optional here; the `refineGoodExampleRequired` superRefine below
+   * enforces the engine-conditional requirement so the error message
+   * can name the engine and cite the ticket.
+   */
+  goodExample: z.string().optional(),
   severity: z.enum(['error', 'warning']).optional(),
   /** LLM explanation for why a lesson was marked non-compilable */
   reason: z.string().optional(),
@@ -328,9 +351,38 @@ function refineBadExampleRequired(
   });
 }
 
+/**
+ * Symmetric counterpart of `refineBadExampleRequired` for the over-matching
+ * check shipped in mmnto-ai/totem#1580. Every Pipeline 2 / Pipeline 3
+ * compilable rule must carry a non-empty `goodExample` so the smoke gate
+ * can assert the pattern does not fire on known-good code. Same engine
+ * carve-out as badExample: `ast` engine exempt because the gate does not
+ * yet evaluate Tree-sitter S-expression queries.
+ */
+function refineGoodExampleRequired(
+  data: {
+    compilable: boolean;
+    engine?: 'regex' | 'ast' | 'ast-grep';
+    goodExample?: string;
+  },
+  ctx: z.RefinementCtx,
+): void {
+  if (!data.compilable) return;
+  const engineRequiresGoodExample = data.engine !== 'ast';
+  if (!engineRequiresGoodExample) return;
+  if (typeof data.goodExample === 'string' && data.goodExample.length > 0) return;
+  ctx.addIssue({
+    code: z.ZodIssueCode.custom,
+    message:
+      'goodExample is required (non-empty string) for regex and ast-grep engines (mmnto-ai/totem#1580)',
+    path: ['goodExample'],
+  });
+}
+
 export const CompilerOutputSchema = CompilerOutputBaseSchema.superRefine((data, ctx) => {
   refineAstGrepMutualExclusion(data, ctx);
   refineBadExampleRequired(data, ctx);
+  refineGoodExampleRequired(data, ctx);
 });
 
 export type CompilerOutput = z.infer<typeof CompilerOutputSchema>;

--- a/packages/core/src/compiler-schema.ts
+++ b/packages/core/src/compiler-schema.ts
@@ -342,7 +342,12 @@ function refineBadExampleRequired(
   if (!data.compilable) return;
   const engineRequiresBadExample = data.engine !== 'ast';
   if (!engineRequiresBadExample) return;
-  if (typeof data.badExample === 'string' && data.badExample.length > 0) return;
+  // `.trim().length > 0` rather than `.length > 0` because the smoke gate
+  // treats whitespace-only snippets as no-ops via its own early-return,
+  // so a blank string would slip through schema validation but provide
+  // zero gate coverage. Flagged by CodeRabbit on mmnto-ai/totem#1591 for
+  // `goodExample`; the same hole existed on `badExample` since #1409.
+  if (typeof data.badExample === 'string' && data.badExample.trim().length > 0) return;
   ctx.addIssue({
     code: z.ZodIssueCode.custom,
     message:
@@ -370,7 +375,11 @@ function refineGoodExampleRequired(
   if (!data.compilable) return;
   const engineRequiresGoodExample = data.engine !== 'ast';
   if (!engineRequiresGoodExample) return;
-  if (typeof data.goodExample === 'string' && data.goodExample.length > 0) return;
+  // `.trim().length > 0` rather than `.length > 0` so a whitespace-only
+  // goodExample cannot satisfy the required-field check. The smoke gate's
+  // early-return on `snippet.trim().length === 0` would treat the blank
+  // string as a no-op, producing zero over-matching coverage.
+  if (typeof data.goodExample === 'string' && data.goodExample.trim().length > 0) return;
   ctx.addIssue({
     code: z.ZodIssueCode.custom,
     message:

--- a/packages/core/src/compiler.test.ts
+++ b/packages/core/src/compiler.test.ts
@@ -1092,6 +1092,7 @@ describe('parseCompilerResponse', () => {
       pattern: '\\bnpm\\b',
       message: 'Use pnpm instead of npm',
       badExample: 'npm install lodash',
+      goodExample: 'pnpm install lodash',
     });
 
     const result = parseCompilerResponse(response);
@@ -1100,6 +1101,7 @@ describe('parseCompilerResponse', () => {
       pattern: '\\bnpm\\b',
       message: 'Use pnpm instead of npm',
       badExample: 'npm install lodash',
+      goodExample: 'pnpm install lodash',
     });
   });
 
@@ -1113,7 +1115,7 @@ describe('parseCompilerResponse', () => {
     // Post mmnto-ai/totem#1409: compilable regex rules need badExample.
     const response = `Here is the compiled rule:
 \`\`\`json
-{"compilable": true, "pattern": "console\\\\.log", "message": "Remove debug logging", "badExample": "console.log('hi')"}
+{"compilable": true, "pattern": "console\\\\.log", "message": "Remove debug logging", "badExample": "console.log('hi')", "goodExample": "logger.info('hi')"}
 \`\`\``;
 
     const result = parseCompilerResponse(response);
@@ -1125,7 +1127,7 @@ describe('parseCompilerResponse', () => {
   it('extracts JSON from a tilde-fenced code block (#1319)', () => {
     const response = `Here is the compiled rule:
 ~~~json
-{"compilable": true, "pattern": "console\\\\.log", "message": "Remove debug logging", "badExample": "console.log('hi')"}
+{"compilable": true, "pattern": "console\\\\.log", "message": "Remove debug logging", "badExample": "console.log('hi')", "goodExample": "logger.info('hi')"}
 ~~~`;
 
     const result = parseCompilerResponse(response);
@@ -1172,6 +1174,7 @@ describe('parseCompilerResponse', () => {
       message: 'Quote shell variables',
       fileGlobs: ['*.sh', '*.bash', '*.yml'],
       badExample: 'echo $HOME',
+      goodExample: 'echo "$HOME"',
     });
 
     const result = parseCompilerResponse(response);
@@ -1181,6 +1184,7 @@ describe('parseCompilerResponse', () => {
       message: 'Quote shell variables',
       fileGlobs: ['*.sh', '*.bash', '*.yml'],
       badExample: 'echo $HOME',
+      goodExample: 'echo "$HOME"',
     });
   });
 
@@ -1193,6 +1197,7 @@ describe('parseCompilerResponse', () => {
       pattern: '',
       message: 'Do not use shell:true with array args',
       badExample: 'spawn("ls", [], { shell: true });',
+      goodExample: "spawn('ls', [], { shell: process.platform === 'win32' });",
     });
     const result = parseCompilerResponse(response);
     expect(result!.astGrepPattern).toBe('spawn($CMD, [$$$ARGS], { shell: true })');
@@ -1205,6 +1210,7 @@ describe('parseCompilerResponse', () => {
       pattern: '`\\bconsole\\.log\\b`',
       message: 'No console.log',
       badExample: 'console.log("hi")',
+      goodExample: 'logger.info("hi")',
     });
     const result = parseCompilerResponse(response);
     expect(result!.pattern).toBe('\\bconsole\\.log\\b');
@@ -1219,6 +1225,7 @@ describe('parseCompilerResponse', () => {
       pattern: '',
       message: 'Use path.relative',
       badExample: 'foo.replace(process.cwd(), "")',
+      goodExample: 'path.relative(process.cwd(), foo)',
     });
     const result = parseCompilerResponse(response);
     expect(result!.astGrepPattern).toBe('$OBJ.replace(process.cwd(), $R)');

--- a/packages/core/src/lesson-pattern.test.ts
+++ b/packages/core/src/lesson-pattern.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest';
 
 import {
   extractAllFields,
+  extractBadExample,
   extractBadGoodSnippets,
+  extractGoodExample,
   extractManualPattern,
   extractMultilineField,
   extractRuleExamples,
@@ -760,5 +762,112 @@ describe('extractManualPattern — compound ast-grep path', () => {
     expect(result).not.toBeNull();
     expect(result!.pattern).toBe('new Error($$$)');
     expect(result!.astGrepYamlRule).toBeUndefined();
+  });
+});
+
+// ─── extractBadExample / extractGoodExample ──────────
+
+describe('extractBadExample', () => {
+  it('extracts a fenced code block after ### Bad Example', () => {
+    const body = ['### Bad Example', '', '```ts', 'throw new Error("boom");', '```'].join('\n');
+    expect(extractBadExample(body)).toBe('throw new Error("boom");');
+  });
+
+  it('accepts tilde fences too', () => {
+    const body = ['### Bad Example', '', '~~~ts', 'foo()', '~~~'].join('\n');
+    expect(extractBadExample(body)).toBe('foo()');
+  });
+
+  it('returns undefined when no Bad Example heading is present', () => {
+    const body = '### Good Example\n\n```ts\nbar()\n```';
+    expect(extractBadExample(body)).toBeUndefined();
+  });
+
+  it('returns undefined when the heading is present but no fence follows', () => {
+    const body = '### Bad Example\n\nprose without a fence\n\n### Something Else';
+    expect(extractBadExample(body)).toBeUndefined();
+  });
+
+  it('returns undefined when the fenced block is empty', () => {
+    const body = '### Bad Example\n\n```ts\n```';
+    expect(extractBadExample(body)).toBeUndefined();
+  });
+
+  it('does not slide into a following Good Example block when Bad lacks a fence', () => {
+    const body = [
+      '### Bad Example',
+      '',
+      'prose only — no fence',
+      '',
+      '### Good Example',
+      '',
+      '```ts',
+      'correctForm()',
+      '```',
+    ].join('\n');
+    expect(extractBadExample(body)).toBeUndefined();
+  });
+
+  it('matches the Bad heading case-insensitively', () => {
+    const body = '### BAD Example\n```ts\nfoo()\n```';
+    expect(extractBadExample(body)).toBe('foo()');
+  });
+});
+
+describe('extractGoodExample', () => {
+  it('extracts a fenced code block after ### Good Example', () => {
+    const body = [
+      '### Good Example',
+      '',
+      '```ts',
+      'try { doWork(); } catch (err) { log(err); }',
+      '```',
+    ].join('\n');
+    expect(extractGoodExample(body)).toBe('try { doWork(); } catch (err) { log(err); }');
+  });
+
+  it('accepts tilde fences too', () => {
+    const body = '### Good Example\n\n~~~ts\nlogger.info(msg)\n~~~';
+    expect(extractGoodExample(body)).toBe('logger.info(msg)');
+  });
+
+  it('returns undefined when no Good Example heading is present', () => {
+    const body = '### Bad Example\n\n```ts\nfoo()\n```';
+    expect(extractGoodExample(body)).toBeUndefined();
+  });
+
+  it('returns undefined when the heading is present but no fence follows', () => {
+    const body = '### Good Example\n\nplain prose\n\n### Done';
+    expect(extractGoodExample(body)).toBeUndefined();
+  });
+
+  it('returns undefined when the fenced block is empty', () => {
+    const body = '### Good Example\n\n```ts\n```';
+    expect(extractGoodExample(body)).toBeUndefined();
+  });
+
+  it('extracts Good after Bad when both blocks are present', () => {
+    // Parity scenario: a Pipeline 1 lesson that defines both Bad and
+    // Good Example blocks should let the caller pull each independently.
+    const body = [
+      '### Bad Example',
+      '',
+      '```ts',
+      'badCall()',
+      '```',
+      '',
+      '### Good Example',
+      '',
+      '```ts',
+      'goodCall()',
+      '```',
+    ].join('\n');
+    expect(extractBadExample(body)).toBe('badCall()');
+    expect(extractGoodExample(body)).toBe('goodCall()');
+  });
+
+  it('matches the Good heading case-insensitively', () => {
+    const body = '### good Example\n```ts\nfoo()\n```';
+    expect(extractGoodExample(body)).toBe('foo()');
   });
 });

--- a/packages/core/src/lesson-pattern.ts
+++ b/packages/core/src/lesson-pattern.ts
@@ -171,6 +171,30 @@ export function extractBadExample(body: string): string | undefined {
 }
 
 /**
+ * Extract the contents of a fenced code block that follows a `### Good Example`
+ * heading in a lesson body. Symmetric counterpart of `extractBadExample`, used
+ * by the mmnto-ai/totem#1580 over-matching check: the compile-time smoke gate
+ * runs the compiled rule against `goodExample` and rejects it if the pattern
+ * fires.
+ *
+ * Returns `undefined` under the same conditions as `extractBadExample` (no
+ * heading, no fence, empty block). Both fence styles (``` and ~~~) are
+ * accepted for parity with `extractCodeBlock`.
+ */
+export function extractGoodExample(body: string): string | undefined {
+  const re = /(?:^|\n)#{2,6}\s*Good\s+Example\s*\n([\s\S]*?)(?=\n#{2,6}\s|\n---\s*\n|$)/i;
+  const section = body.match(re);
+  if (!section) return undefined;
+
+  const slice = section[1] ?? '';
+  const fence = slice.match(/(?:^|\n)(```|~~~)[^\n]*\n([\s\S]*?)\n?\1/);
+  if (!fence) return undefined;
+
+  const content = (fence[2] ?? '').trim();
+  return content.length > 0 ? content : undefined;
+}
+
+/**
  * Extract a yaml-tagged fenced code block following a `**Field:**` marker.
  *
  * Scan starts on the line after the field marker and stops at the first


### PR DESCRIPTION
## Summary

- `CompilerOutputSchema.goodExample` flips from optional to engine-conditional required (regex + ast-grep), mirroring the #1420 pattern for `badExample`. The `ast` engine stays exempt.
- `CompiledRuleSchema.goodExample` stays optional on the persisted-rule boundary for backward compat with pre-#1580 rules.
- `runSmokeGate` parameter renamed from `badExample` to `snippet` since it now serves both roles; docstring updated.
- `buildCompiledRule` adds the parallel over-matching check after the existing under-matching check: rule must fire on `badExample` AND must NOT fire on `goodExample`.
- Two new `NonCompilableReasonCodeSchema` values: `matches-good-example` (over-match rejection) and `missing-goodexample` (defensive path when callers bypass the schema refine).
- Pipeline 3 threads `snippets.good.join('\n')` as `goodExampleOverride`; Pipeline 2 requires LLM emission via the updated compiler prompt. Pipeline 1 (manual) is unaffected — gate stays opt-in via `enforceSmokeGate`.
- `extractGoodExample` helper added in `lesson-pattern.ts` (Pipeline 1 heading-based extraction, parallel to `extractBadExample`).

## Why

Over-matching is the dominant defect class observed in the 2026-04-18 security-pack postmerge incident (10-of-10 bad rate from #1526). The existing smoke gate caught under-matching; nothing structural caught a rule that fires on both its badExample AND every legitimate call site. This ticket closes that half.

## Shield self-review round

First commit (`95cfd5e2`) drew two CRITICAL findings from Shield:

1. Missing tests for `extractGoodExample` (and by extension `extractBadExample`, which had been under-tested since #1408). Added 14 tests in `lesson-pattern.test.ts` covering fence styles, heading casing, empty blocks, and bad+good sibling extraction.
2. Empty-string `goodExampleOverride` trap: when a Pipeline 3 lesson's Good block is empty, `snippets.good.join('\n')` is `''`, and `options.goodExampleOverride ?? parsed.goodExample` clobbers the LLM-echoed value because nullish coalescing treats `''` as defined. Pipeline 3 call site now passes `undefined` when `snippets.good.length === 0`; symmetric guard added for bad. Two tests pin the fallback contract and the trap it protects against.

Both fixed in `208816bb`. Shield second-round review PASS with no findings.

## Test plan

- [x] 1249 core tests pass (16 net-new: 5 smoke-gate + 8 build-compiled-rule integration + 14 lesson-pattern extraction — minus overlap on shared fixtures)
- [x] Full workspace `pnpm test` green (8/8 suites)
- [x] `totem lint` PASS
- [x] `totem review` PASS (second round)
- [x] `totem verify-manifest` PASS (440 rules)
- [x] Changeset lands a patch bump across the fixed group

## Follow-ups implied by this PR

None filed. The symmetric trap on `badExampleOverride` (empty-string clobber on parsed.badExample) is guarded the same way by the Pipeline 3 call site; no separate ticket needed.

Closes #1580