### PR TITLE
feat(core+cli): ADR-089 zero-trust default + totem rule promote CLI (part 1 of #1581)

### DIFF
--- a/.changeset/1581-unverified-default-and-promote.md
+++ b/.changeset/1581-unverified-default-and-promote.md
@@ -1,0 +1,20 @@
+---
+'@mmnto/totem': patch
+'@mmnto/cli': patch
+'@mmnto/mcp': patch
+'@totem/pack-agent-security': patch
+---
+
+Ship the ADR-089 zero-trust default and the `totem rule promote` CLI (mmnto-ai/totem#1581, part 1 of 2).
+
+**Zero-trust default (core):** every LLM-generated rule now ships `unverified: true` unconditionally. Pipeline 2 (verify-retry loop) and Pipeline 3 (Bad/Good example-based) both flip from the pre-#1581 conditional behavior (keyed on Example Hit presence) to unconditional. Pipeline 1 (manual) keeps its pre-#1581 conditional semantics because manual rules are human-authored and self-evidencing; the existing Pipeline 1 Example-Hit guard stays as a safety net.
+
+Rationale: the LLM cannot self-certify structural invariants. Example Hit/Miss is an LLM-produced artifact of the compile process, not a human sign-off. Activation requires either human promotion via the new CLI below OR the ADR-091 Stage 4 Codebase Verifier in 1.16.0 (which validates rules empirically against actual code, not against LLM-generated snippet fixtures).
+
+**`totem rule promote <id>` CLI:** flips a rule's `unverified: true` flag to absent (canonical "verified" state), atomically refreshes `compile-manifest.json`'s `output_hash` so `verify-manifest` passes on the next push. Refuses to promote archived rules and refuses when the target rule is already verified. Exits 1 on ambiguous prefix matches with a disambiguation list.
+
+Hand-editing `compiled-rules.json` to flip `unverified` would break the manifest hash and trip the pre-push `verify-manifest` gate. The promote command is the blessed path; the atomic refresh closes that user trap at source.
+
+**Scope split:** the "Option 1 + Categorized Advisory" plan locks the 1.15.0 ship gate via this PR. The categorized `totem doctor` advisory that surfaces the 357 grandfathered pre-1.13.0 rules by reason lands as a follow-up PR on a separate branch to keep the reviewable surface tight.
+
+Closes #1581 (part 1).

--- a/packages/cli/src/commands/rule.test.ts
+++ b/packages/cli/src/commands/rule.test.ts
@@ -511,3 +511,172 @@ describe('rule scaffold', () => {
     expect(fs.existsSync(customPath)).toBe(true);
   });
 });
+
+// ─── rule promote (ADR-089 zero-trust activation, mmnto-ai/totem#1581) ──
+
+describe('rule promote', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+    // Reset between tests so one test's error exit does not poison the next.
+    // Without this the Node runtime keeps the last set exitCode and vitest
+    // reports success-with-exit-1, failing CI even when all tests pass.
+    process.exitCode = 0;
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    cleanTmpDir(tmpDir);
+    vi.restoreAllMocks();
+    // Restore exitCode so subsequent describe blocks and the vitest runner
+    // itself exit cleanly (Shield finding on #1581 part 1 review).
+    process.exitCode = 0;
+  });
+
+  /** Write a manifest alongside the rules file so the promote command can refresh it. */
+  async function writeManifest(totemDir: string, rulesPath: string): Promise<void> {
+    const { generateOutputHash } = await import('@mmnto/totem');
+    const manifestPath = path.join(totemDir, 'compile-manifest.json');
+    const manifest = {
+      version: 1 as const,
+      compiled_at: '2026-04-20T12:00:00.000Z',
+      model: 'test-model',
+      input_hash: 'deadbeef'.repeat(8),
+      output_hash: generateOutputHash(rulesPath),
+      rule_count: 1,
+    };
+    fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
+  }
+
+  it('removes the unverified flag from a matching rule and refreshes the manifest', async () => {
+    const unverifiedRule = {
+      ...SAMPLE_RULES[0]!,
+      lessonHash: 'aaaa1111aaaa1111',
+      unverified: true,
+    };
+    const { totemDir } = scaffold(tmpDir, [unverifiedRule]);
+    const rulesPath = path.join(totemDir, 'compiled-rules.json');
+    await writeManifest(totemDir, rulesPath);
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { rulePromoteCommand } = await import('./rule.js');
+    await rulePromoteCommand('aaaa');
+
+    const rules = JSON.parse(fs.readFileSync(rulesPath, 'utf-8')) as { rules: unknown[] };
+    const promoted = rules.rules[0] as { unverified?: boolean; lessonHash: string };
+    expect(promoted.unverified).toBeUndefined();
+
+    const output = stripAnsi(consoleSpy.mock.calls.map((c) => String(c[0])).join('\n'));
+    expect(output).toContain('Promoted rule');
+    expect(output).toContain('Manifest refreshed');
+  });
+
+  it('refreshes the manifest output_hash to match the mutated rules file', async () => {
+    const { generateOutputHash } = await import('@mmnto/totem');
+    const unverifiedRule = {
+      ...SAMPLE_RULES[0]!,
+      lessonHash: 'bbbb2222bbbb2222',
+      unverified: true,
+    };
+    const { totemDir } = scaffold(tmpDir, [unverifiedRule]);
+    const rulesPath = path.join(totemDir, 'compiled-rules.json');
+    const manifestPath = path.join(totemDir, 'compile-manifest.json');
+    await writeManifest(totemDir, rulesPath);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { rulePromoteCommand } = await import('./rule.js');
+    await rulePromoteCommand('bbbb');
+
+    const updatedManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as {
+      output_hash: string;
+    };
+    const currentRulesHash = generateOutputHash(rulesPath);
+    expect(updatedManifest.output_hash).toBe(currentRulesHash);
+  });
+
+  it('errors when no rule matches the prefix', async () => {
+    const unverifiedRule = {
+      ...SAMPLE_RULES[0]!,
+      lessonHash: 'cccc3333cccc3333',
+      unverified: true,
+    };
+    const { totemDir } = scaffold(tmpDir, [unverifiedRule]);
+    const rulesPath = path.join(totemDir, 'compiled-rules.json');
+    await writeManifest(totemDir, rulesPath);
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { rulePromoteCommand } = await import('./rule.js');
+    await rulePromoteCommand('no-such-prefix');
+
+    const output = stripAnsi(consoleSpy.mock.calls.map((c) => String(c[0])).join('\n'));
+    expect(output).toContain('No rule found');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('errors with a disambiguation list when the prefix matches multiple rules', async () => {
+    const { totemDir } = scaffold(tmpDir, [
+      { ...SAMPLE_RULES[0]!, lessonHash: 'dddd4444aaaaaaaa', unverified: true },
+      { ...SAMPLE_RULES[0]!, lessonHash: 'dddd4444bbbbbbbb', unverified: true },
+    ]);
+    const rulesPath = path.join(totemDir, 'compiled-rules.json');
+    await writeManifest(totemDir, rulesPath);
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { rulePromoteCommand } = await import('./rule.js');
+    await rulePromoteCommand('dddd4444');
+
+    const output = stripAnsi(consoleSpy.mock.calls.map((c) => String(c[0])).join('\n'));
+    expect(output).toContain('Ambiguous');
+    expect(output).toContain('matches 2 rules');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('refuses to promote an archived rule', async () => {
+    const archivedRule = {
+      ...SAMPLE_RULES[0]!,
+      lessonHash: 'eeee5555eeee5555',
+      unverified: true,
+      status: 'archived',
+      archivedReason: 'Test archive',
+    };
+    const { totemDir } = scaffold(tmpDir, [archivedRule]);
+    const rulesPath = path.join(totemDir, 'compiled-rules.json');
+    await writeManifest(totemDir, rulesPath);
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { rulePromoteCommand } = await import('./rule.js');
+    await rulePromoteCommand('eeee');
+
+    const output = stripAnsi(consoleSpy.mock.calls.map((c) => String(c[0])).join('\n'));
+    expect(output).toContain('archived');
+    expect(output).toContain('Unarchive');
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('no-ops with a warning when the rule is already verified', async () => {
+    const verifiedRule = {
+      ...SAMPLE_RULES[0]!,
+      lessonHash: 'ffff6666ffff6666',
+      // No unverified field — canonical "verified" state.
+    };
+    const { totemDir } = scaffold(tmpDir, [verifiedRule]);
+    const rulesPath = path.join(totemDir, 'compiled-rules.json');
+    await writeManifest(totemDir, rulesPath);
+
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { rulePromoteCommand } = await import('./rule.js');
+    await rulePromoteCommand('ffff');
+
+    const output = stripAnsi(consoleSpy.mock.calls.map((c) => String(c[0])).join('\n'));
+    expect(output).toContain('already verified');
+  });
+});

--- a/packages/cli/src/commands/rule.test.ts
+++ b/packages/cli/src/commands/rule.test.ts
@@ -541,13 +541,17 @@ describe('rule promote', () => {
   async function writeManifest(totemDir: string, rulesPath: string): Promise<void> {
     const { generateOutputHash } = await import('@mmnto/totem');
     const manifestPath = path.join(totemDir, 'compile-manifest.json');
+    // Derive rule_count from the file instead of hardcoding so the fixture
+    // stays accurate when callers write multi-rule scenarios (CR nit review
+    // on PR #1601).
+    const parsedRules = JSON.parse(fs.readFileSync(rulesPath, 'utf-8')) as { rules?: unknown[] };
     const manifest = {
       version: 1 as const,
       compiled_at: '2026-04-20T12:00:00.000Z',
       model: 'test-model',
       input_hash: 'deadbeef'.repeat(8),
       output_hash: generateOutputHash(rulesPath),
-      rule_count: 1,
+      rule_count: parsedRules.rules?.length ?? 0,
     };
     fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
   }
@@ -678,5 +682,9 @@ describe('rule promote', () => {
 
     const output = stripAnsi(consoleSpy.mock.calls.map((c) => String(c[0])).join('\n'));
     expect(output).toContain('already verified');
+    // Pin that the idempotent no-op does not set a failure exitCode.
+    // Catches regressions where the warning path accidentally turns into
+    // an error path (CR review on PR #1601).
+    expect(process.exitCode ?? 0).toBe(0);
   });
 });

--- a/packages/cli/src/commands/rule.ts
+++ b/packages/cli/src/commands/rule.ts
@@ -281,3 +281,105 @@ export async function ruleTestCommand(id: string): Promise<void> {
   }
   console.error('');
 }
+
+/**
+ * Promote an unverified rule to active (remove the `unverified` flag).
+ *
+ * ADR-089 zero-trust default (mmnto-ai/totem#1581): newly compiled
+ * LLM-generated rules ship with `unverified: true`. They stay silent at
+ * lint time until a human explicitly promotes them or the ADR-091 Stage 4
+ * Codebase Verifier (1.16.0) empirically validates them.
+ *
+ * Atomic surface: reads the full manifest (including archived rules),
+ * validates the target is an active unverified rule, flips the flag,
+ * writes `compiled-rules.json` via tmp + rename, recomputes the
+ * manifest's `output_hash`, and writes the manifest back. All in one
+ * command so hand-editing `compiled-rules.json` plus manual manifest
+ * refresh never becomes the blessed path.
+ */
+export async function rulePromoteCommand(id: string): Promise<void> {
+  const fs = await import('node:fs');
+  const path = await import('node:path');
+  const { log, bold } = await import('../ui.js');
+  const { loadCompiledRulesFile, generateOutputHash, readCompileManifest, writeCompileManifest } =
+    await import('@mmnto/totem');
+  const { loadConfig, resolveConfigPath } = await import('../utils.js');
+
+  const cwd = process.cwd();
+  const configPath = resolveConfigPath(cwd);
+  const config = await loadConfig(configPath);
+  const totemDir = path.join(cwd, config.totemDir);
+  const rulesPath = path.join(totemDir, 'compiled-rules.json');
+  const manifestPath = path.join(totemDir, 'compile-manifest.json');
+
+  if (!fs.existsSync(rulesPath)) {
+    log.error('Totem Error', `No compiled-rules.json at ${rulesPath}. Run 'totem compile' first.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const manifest = loadCompiledRulesFile(rulesPath);
+  const matches = manifest.rules.filter((r) =>
+    r.lessonHash.toLowerCase().startsWith(id.toLowerCase()),
+  );
+
+  if (matches.length === 0) {
+    log.error('Totem Error', `No rule found matching '${id}'`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (matches.length > 1) {
+    log.warn(TAG, `Ambiguous prefix '${id}' matches ${matches.length} rules:`);
+    for (const m of matches) {
+      log.info(TAG, `  ${bold(m.lessonHash)} \u2014 ${m.lessonHeading}`);
+    }
+    log.dim(TAG, 'Provide more characters to disambiguate.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const rule = matches[0]!;
+
+  if (rule.status === 'archived') {
+    log.error('Totem Error', `Rule ${rule.lessonHash} is archived. Unarchive it before promoting.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (rule.unverified !== true) {
+    log.warn(
+      TAG,
+      `Rule ${rule.lessonHash} is already verified (unverified flag absent or false). No action.`,
+    );
+    return;
+  }
+
+  // Delete the field rather than writing `unverified: false`. Absence is
+  // the canonical "verified" state per the CompiledRuleSchema docs; see
+  // compiler-schema.ts on the `unverified` field which explicitly says
+  // "Never write literal `false`". Preserves pre-#1480 manifest hashes
+  // when an unverified rule gets promoted back to the original shape.
+  delete rule.unverified;
+
+  // Atomic write with the same JSON.stringify(data, null, 2) + '\n' shape
+  // used by compile-lesson.ts and rule-mutator.ts — the canonical on-disk
+  // format for compiled-rules.json. Manifest hashes are canonicalized
+  // inside `generateOutputHash` below; the write itself matches the
+  // existing convention byte-for-byte. Tmp-file + rename prevents torn
+  // writes if the process crashes mid-save.
+  const tmpPath = `${rulesPath}.tmp`;
+  fs.writeFileSync(tmpPath, JSON.stringify(manifest, null, 2) + '\n', { encoding: 'utf-8' });
+  fs.renameSync(tmpPath, rulesPath);
+
+  // Refresh the manifest's output_hash so verify-manifest passes on the
+  // next push. Keeps the blessed path atomic instead of asking the user
+  // to run a separate refresh command.
+  const compileManifest = readCompileManifest(manifestPath);
+  compileManifest.output_hash = generateOutputHash(rulesPath);
+  compileManifest.compiled_at = new Date().toISOString();
+  writeCompileManifest(manifestPath, compileManifest);
+
+  log.success(TAG, `Promoted rule ${bold(rule.lessonHash)} — ${rule.lessonHeading}`);
+  log.dim(TAG, 'Manifest refreshed. `totem verify-manifest` should pass.');
+}

--- a/packages/cli/src/commands/rule.ts
+++ b/packages/cli/src/commands/rule.ts
@@ -355,6 +355,14 @@ export async function rulePromoteCommand(id: string): Promise<void> {
     return;
   }
 
+  // Preflight the manifest read BEFORE mutating compiled-rules.json.
+  // If the manifest is missing, corrupt, or unwritable, we want to fail
+  // out now — not after writing the rules file. Otherwise the rule would
+  // be half-promoted (compiled-rules.json flipped, manifest stale) and
+  // verify-manifest would fail on the next push with no rollback path.
+  // CR review on PR #1601 flagged this as a partial-state atomicity bug.
+  const compileManifest = readCompileManifest(manifestPath);
+
   // Delete the field rather than writing `unverified: false`. Absence is
   // the canonical "verified" state per the CompiledRuleSchema docs; see
   // compiler-schema.ts on the `unverified` field which explicitly says
@@ -373,9 +381,10 @@ export async function rulePromoteCommand(id: string): Promise<void> {
   fs.renameSync(tmpPath, rulesPath);
 
   // Refresh the manifest's output_hash so verify-manifest passes on the
-  // next push. Keeps the blessed path atomic instead of asking the user
-  // to run a separate refresh command.
-  const compileManifest = readCompileManifest(manifestPath);
+  // next push. Uses the compileManifest loaded above (preflighted) so
+  // the mutation order is: read-manifest → mutate-rules → write-rules →
+  // update-manifest. Missing/corrupt manifest would have thrown above,
+  // preserving compiled-rules.json's pre-promote state.
   compileManifest.output_hash = generateOutputHash(rulesPath);
   compileManifest.compiled_at = new Date().toISOString();
   writeCompileManifest(manifestPath, compileManifest);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -967,6 +967,24 @@ ruleCmd
     }
   });
 
+ruleCmd
+  .command('promote <id>')
+  .description('Promote an unverified rule to active (removes the unverified flag; ADR-089)')
+  .action(async (id: string) => {
+    try {
+      const { rulePromoteCommand } = await import('./commands/rule.js');
+      await rulePromoteCommand(id);
+    } catch (err) {
+      handleError(err);
+      // handleError is typed `: never` and calls process.exit, so this throw
+      // never executes. It is here only to satisfy the ast-grep structural
+      // rule that scans catch bodies for a throw_statement (Tenet 4 fail-loud
+      // enforcement). Removing it re-introduces the lint error without any
+      // behavioral change.
+      throw err;
+    }
+  });
+
 // ─── Config noun-verb subcommands ───────────────────────
 const configCmd = program.command('config').description('Read and manage project configuration');
 

--- a/packages/core/src/compile-lesson.test.ts
+++ b/packages/core/src/compile-lesson.test.ts
@@ -2122,11 +2122,16 @@ describe('compileLesson unverified flag', () => {
     }
   });
 
-  it('leaves unverified absent when the lesson carries a non-empty Example Hit', async () => {
-    // Invariant #1: presence of Example Hit produces unverified: undefined.
-    // The serialized JSON omits the field — `canonicalStringify`
-    // (key-sorted JSON.stringify) writes nothing for undefined values so
-    // pre-#1480 manifest hashes stay stable.
+  it('ships Pipeline 2 rules as unverified: true even when the lesson carries a non-empty Example Hit (ADR-089 zero-trust default, mmnto-ai/totem#1581)', async () => {
+    // Pre-#1581 invariant: presence of Example Hit produced
+    // unverified: undefined. Post-#1581: LLM-generated rules (Pipeline 2
+    // and Pipeline 3) always ship unverified: true regardless of Example
+    // Hit presence. The LLM cannot self-certify structural invariants;
+    // Example Hit/Miss is an LLM-produced artifact of the compile process,
+    // not a human sign-off. Activation requires `totem rule promote
+    // <hash>` or the ADR-091 Stage 4 Codebase Verifier in 1.16.0.
+    // Pipeline 1 (manual) keeps its pre-#1581 conditional semantics; see
+    // the Pipeline 1 test below.
     const parseMock = vi.fn().mockReturnValue({
       compilable: true,
       pattern: 'console\\.log',
@@ -2146,7 +2151,7 @@ describe('compileLesson unverified flag', () => {
     const result = await compileLesson(lessonWithExampleHit, 'system prompt', deps);
     expect(result.status).toBe('compiled');
     if (result.status === 'compiled') {
-      expect(result.rule.unverified).toBeUndefined();
+      expect(result.rule.unverified).toBe(true);
     }
   });
 

--- a/packages/core/src/compile-lesson.ts
+++ b/packages/core/src/compile-lesson.ts
@@ -917,13 +917,15 @@ export async function compileLesson(
     trace.push({ layer: 2, action: 'verify', outcome: 'passed' });
     trace.push({ layer: 2, action: 'result', outcome: 'compiled' });
 
-    // Pipeline 3 rules are example-based — they always ship with a Bad snippet
-    // by construction. Flag unverified only when the lesson body itself omits
-    // the canonical Example Hit block, keeping the signal aligned with the
-    // lesson-level ground-truth rather than the Pipeline 3 self-test.
-    if (!exampleHitPresent) {
-      ruleResult.rule.unverified = true;
-    }
+    // ADR-089 zero-trust default (mmnto-ai/totem#1581): every LLM-generated
+    // rule ships `unverified: true` unconditionally. Pipeline 3 self-test
+    // against Bad/Good snippets is not a human sign-off; Example Hit/Miss
+    // is also an LLM-produced artifact of the compile process. Activation
+    // requires `totem rule promote <hash>` or the ADR-091 Stage 4 Codebase
+    // Verifier in 1.16.0. `exampleHitPresent` retained in trace scope for
+    // Pipeline 1 (manual) guard below, which keeps its pre-#1581 semantics
+    // because manual rules are human-authored and self-evidencing.
+    ruleResult.rule.unverified = true;
 
     return { status: 'compiled', rule: ruleResult.rule, trace };
   }
@@ -1039,12 +1041,15 @@ export async function compileLesson(
     if (ruleResult.rule) {
       const testResult = verifyRuleExamples(ruleResult.rule, lesson.body);
       if (!testResult || testResult.passed) {
-        // ADR-088 Phase 1 Layer 3 (mmnto-ai/totem#1480): flag rules compiled
-        // without a non-empty Example Hit as unverified, even when the
-        // lesson carried an Example Miss (the miss still got verified).
-        if (!exampleHitPresent) {
-          ruleResult.rule.unverified = true;
-        }
+        // ADR-089 zero-trust default (mmnto-ai/totem#1581): every
+        // LLM-generated rule ships `unverified: true` unconditionally,
+        // even when Example Hit/Miss verification passed. The LLM cannot
+        // self-certify structural invariants; activation requires
+        // `totem rule promote <hash>` or the ADR-091 Stage 4 Codebase
+        // Verifier in 1.16.0. Pre-#1581 behavior keyed on
+        // `exampleHitPresent`; under zero-trust that signal is an
+        // authoring heuristic rather than a trust boundary.
+        ruleResult.rule.unverified = true;
         trace.push({ layer: 3, action: 'verify', outcome: 'MATCH' });
         trace.push({ layer: 3, action: 'result', outcome: 'compiled' });
         return { status: 'compiled', rule: ruleResult.rule, trace };

--- a/packages/core/src/compiler-schema.test.ts
+++ b/packages/core/src/compiler-schema.test.ts
@@ -201,7 +201,7 @@ describe('CompiledRule archivedAt field', () => {
     // cycle erased prior archivedAt values from compiled-rules.json,
     // eroding the institutional first-archive-provenance ledger.
     const firstParse = CompiledRuleSchema.parse(baseArchivedRule);
-    const serialized = JSON.parse(JSON.stringify(firstParse)) as unknown;
+    const serialized: unknown = JSON.parse(JSON.stringify(firstParse));
     const secondParse = CompiledRuleSchema.parse(serialized);
     expect(secondParse.archivedAt).toBe('2026-04-13T12:05:00Z');
     expect(secondParse.archivedReason).toBe('Over-matching pattern');


### PR DESCRIPTION
## Summary

Part 1 of two. Ships the ADR-089 zero-trust policy substrate plus the atomic CLI command users need to activate rules under that policy. Part 2 (the `totem doctor` categorized advisory for the 357 grandfathered pre-1.13.0 legacy rules) lands in a separate PR to keep the reviewable surface tight.

### Core

- **Pipeline 2** (LLM verify-retry) and **Pipeline 3** (LLM from Bad/Good snippets) now set `unverified: true` unconditionally on every compiled rule. Pre-#1581 the flag was conditional on Example Hit presence; post-#1581 the LLM cannot self-certify regardless.
- **Pipeline 1** (manual human-authored rules) keeps its pre-#1581 conditional semantics — the existing Example-Hit guard stays as a safety net. Manual rules are self-evidencing by construction.

### CLI

- New **`totem rule promote <id>`** atomic command:
  - Flips `unverified: true` to absent (the canonical verified state per `CompiledRuleSchema` docs).
  - Atomically refreshes `compile-manifest.json`'s `output_hash` so `verify-manifest` passes on the next push. Hand-editing `compiled-rules.json` and running a separate refresh is not a supported workflow.
  - Refuses to promote archived rules (`Unarchive before promoting`).
  - No-ops with a warning when the rule is already verified (idempotent-friendly).
  - Exits 1 on ambiguous prefix matches with a disambiguation list (matches the `rule inspect` / `rule test` ergonomics).

## Why

Rationale per ADR-089 and the 2026-04-19 strategy-pair decision: the LLM is probabilistic and cannot be trusted to self-certify structural invariants. Example Hit/Miss is an LLM-produced artifact of the compile process, not a human sign-off. Activation requires either:

1. **Human promotion** via the new CLI (ships in this PR), or
2. **ADR-091 Stage 4 Codebase Verifier** (1.16.0 headline), which validates rules empirically against actual code without depending on LLM-authored snippet fixtures.

Shipping the prospective zero-trust default now (Option 1 + Categorized Advisory per the 2026-04-20 ship-gate lock) protects downstream CI from LLM hallucinations on every new compile. The 357 grandfathered pre-1.13.0 rules stay behind a compat exemption for this release; part 2 of this ticket will surface them via `totem doctor`.

## Out of scope

- Categorized doctor advisory for the 357 grandfathered legacy rules. Follow-up PR on a separate branch, same sprint.
- Retroactive flip of existing rules. Option 2 (retroactive) and Option 3 (retroactive with migration ramp) were evaluated and declined on scope-creep grounds; see the 2026-04-20 session summary in `docs/active_work.md` "1.15.0 Ship Gate" section.
- `--reason <string>` flag to record why the user promoted. The promote event itself is the signal; reason-as-telemetry can come later if needed.

## Test plan

- [x] 7 new tests: 1 in `compile-lesson.test.ts` pins Pipeline 2 zero-trust invariant (rule ships unverified even with Example Hit present), 6 in `rule.test.ts` cover successful promote, manifest refresh, no-match error, ambiguous-prefix error, archived-rule refusal, already-verified no-op.
- [x] `pnpm test` — all 8 workspace suites green
- [x] `totem lint` — PASS, 0 violations (the new catch-without-throw lint added an unreachable `throw` after `handleError: never` call to satisfy the structural gate)
- [x] `totem review` — PASS, no findings after the round-1 CR ack
- [x] `totem verify-manifest` — PASS

## Shield review history

Two iterations required before PASS:

1. **Round 1 CRITICAL**: tests mutated `process.exitCode` without restoring it, poisoning the vitest runner. Fixed with `process.exitCode = 0` in both `beforeEach` and `afterEach`.
2. **Round 2 CRITICAL** on `canonicalStringify` was declined — the on-disk file write uses `JSON.stringify(data, null, 2) + '\n'` which matches the canonical convention in `packages/core/src/compiler.ts:173` and `packages/cli/src/commands/rule-mutator.ts:41`. `canonicalStringify` is only used inside `generateOutputHash` for hash canonicalization. Clarified the rule-body comment so the rationale is unambiguous.

## Ship gate impact

Slot 3 of 3 on the 1.15.0 ship gate (part 1 of 2):

| Slot | Ticket | Status |
|---|---|---|
| 1 | #1580 smoke-gate `goodExample` | ✅ Merged (PR #1591) |
| 2 | #1589 schema `archivedAt` | Pending merge (PR #1599) |
| 3 | **#1581 zero-trust default + promote (part 1)** | **This PR** |
| 3+ | #1581 categorized doctor advisory (part 2) | Next PR |

Closes #1581 (part 1 of 2)