### PR TITLE
feat(cli): totem doctor grandfathered-rule advisory (part 2 of #1581)

### DIFF
--- a/.changeset/1603-doctor-grandfathered-advisory.md
+++ b/.changeset/1603-doctor-grandfathered-advisory.md
@@ -1,0 +1,17 @@
+---
+'@mmnto/cli': patch
+---
+
+Add `totem doctor` Grandfathered Rules advisory (mmnto-ai/totem#1603, part 2 of #1581).
+
+Surfaces the pre-zero-trust cohort (active rules without the ADR-089 `unverified` flag) categorized by reason code:
+
+- `vintage-pre-1.13.0` — rule compiled before the 1.13.0 ship date
+- `no-badExample` — absent or empty `badExample` substrate field
+- `no-goodExample` — absent or empty `goodExample` substrate field
+
+On the current corpus the advisory reports 378 grandfathered rules (358 vintage-pre-1.13.0, 371 no-badExample, 378 no-goodExample). This is the mechanically true state; categorization gives users a triage-able surface.
+
+Advisory-only (`status: 'warn'`). ADR-091 Stage 4 Codebase Verifier (1.16.0, mmnto-ai/totem#1504) is the empirical audit path — that verifier runs rules against actual code and does not depend on the substrate snippet fields the legacy cohort lacks. The `doctor` advisory holds the position until Stage 4 ships.
+
+Final item of the 1.15.0 compile-hardening ship gate.

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -13,6 +13,7 @@ import {
   checkConfig,
   checkEmbeddingConfig,
   checkGitHooks,
+  checkGrandfatheredRules,
   checkIndex,
   checkLinkedIndexes,
   checkSecretLeaks,
@@ -20,11 +21,13 @@ import {
   checkStaleRules,
   checkUpgradeCandidates,
   doctorCommand,
+  findLegacyGrandfatheredRules,
   findStaleRules,
   MIN_CONTEXT_EVENTS,
   MIN_EVENTS,
   NON_CODE_THRESHOLD,
   runSelfHealing,
+  V_1_13_0_SHIP_DATE_ISO,
 } from './doctor.js';
 
 // ─── Helpers ────────────────────────────────────────────
@@ -303,7 +306,7 @@ describe('doctorCommand', () => {
   it('runs without throwing', async () => {
     const results = await doctorCommand();
     expect(results).toBeDefined();
-    expect(results.length).toBe(10);
+    expect(results.length).toBe(11);
   });
 
   it('returns correct check names', async () => {
@@ -319,6 +322,7 @@ describe('doctorCommand', () => {
     expect(names).toContain('Secrets File Security');
     expect(names).toContain('Upgrade Candidates');
     expect(names).toContain('Stale Rules');
+    expect(names).toContain('Grandfathered Rules');
   });
 });
 
@@ -1736,5 +1740,324 @@ describe('findStaleRules + checkStaleRules', () => {
   it('checkStaleRules returns skip when compiled-rules.json is missing', async () => {
     const result = await checkStaleRules(tmpDir);
     expect(result.status).toBe('skip');
+  });
+});
+
+// ─── Grandfathered rules (mmnto-ai/totem#1603) ──────────
+
+describe('findLegacyGrandfatheredRules + checkGrandfatheredRules', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  function writeRules(tmpDir: string, rules: unknown[]): void {
+    const totemDir = path.join(tmpDir, '.totem');
+    fs.mkdirSync(totemDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(totemDir, 'compiled-rules.json'),
+      JSON.stringify({ version: 1, rules, nonCompilable: [] }),
+    );
+  }
+
+  // Post-1.13.0 timestamp used to neutralize the vintage reason in tests
+  // that target a single reason code in isolation.
+  const POST_1_13_0 = '2026-04-08T00:00:00.000Z';
+  const PRE_1_13_0 = '2026-02-01T00:00:00.000Z';
+
+  it('returns null when compiled-rules.json is missing', async () => {
+    const result = await findLegacyGrandfatheredRules(tmpDir);
+    expect(result).toBeNull();
+  });
+
+  it('flags a rule for vintage-pre-1.13.0 in isolation', async () => {
+    writeRules(tmpDir, [
+      {
+        lessonHash: 'rule-vintage',
+        lessonHeading: 'vintage only',
+        pattern: 'x',
+        message: 'x',
+        engine: 'regex',
+        compiledAt: PRE_1_13_0,
+        createdAt: PRE_1_13_0,
+        badExample: 'bad snippet',
+        goodExample: 'good snippet',
+      },
+    ]);
+    const result = await findLegacyGrandfatheredRules(tmpDir);
+    expect(result).toEqual([
+      expect.objectContaining({
+        lessonHash: 'rule-vintage',
+        reasons: ['vintage-pre-1.13.0'],
+      }),
+    ]);
+  });
+
+  it('flags a rule for no-badExample in isolation', async () => {
+    writeRules(tmpDir, [
+      {
+        lessonHash: 'rule-no-bad',
+        lessonHeading: 'missing bad',
+        pattern: 'x',
+        message: 'x',
+        engine: 'regex',
+        compiledAt: POST_1_13_0,
+        createdAt: POST_1_13_0,
+        goodExample: 'good snippet',
+      },
+    ]);
+    const result = await findLegacyGrandfatheredRules(tmpDir);
+    expect(result).toEqual([
+      expect.objectContaining({
+        lessonHash: 'rule-no-bad',
+        reasons: ['no-badExample'],
+      }),
+    ]);
+  });
+
+  it('flags a rule for no-goodExample in isolation', async () => {
+    writeRules(tmpDir, [
+      {
+        lessonHash: 'rule-no-good',
+        lessonHeading: 'missing good',
+        pattern: 'x',
+        message: 'x',
+        engine: 'regex',
+        compiledAt: POST_1_13_0,
+        createdAt: POST_1_13_0,
+        badExample: 'bad snippet',
+      },
+    ]);
+    const result = await findLegacyGrandfatheredRules(tmpDir);
+    expect(result).toEqual([
+      expect.objectContaining({
+        lessonHash: 'rule-no-good',
+        reasons: ['no-goodExample'],
+      }),
+    ]);
+  });
+
+  it('treats whitespace-only substrate snippets as absent', async () => {
+    writeRules(tmpDir, [
+      {
+        lessonHash: 'rule-whitespace',
+        lessonHeading: 'whitespace snippets',
+        pattern: 'x',
+        message: 'x',
+        engine: 'regex',
+        compiledAt: POST_1_13_0,
+        createdAt: POST_1_13_0,
+        badExample: '   ',
+        goodExample: '\n\t',
+      },
+    ]);
+    const result = await findLegacyGrandfatheredRules(tmpDir);
+    expect(result!.length).toBe(1);
+    expect(result![0]!.reasons.sort()).toEqual(['no-badExample', 'no-goodExample']);
+  });
+
+  it('aggregates multiple reasons on a single rule', async () => {
+    writeRules(tmpDir, [
+      {
+        lessonHash: 'rule-all-three',
+        lessonHeading: 'full legacy',
+        pattern: 'x',
+        message: 'x',
+        engine: 'regex',
+        compiledAt: PRE_1_13_0,
+        createdAt: PRE_1_13_0,
+      },
+    ]);
+    const result = await findLegacyGrandfatheredRules(tmpDir);
+    expect(result!.length).toBe(1);
+    expect(result![0]!.reasons).toEqual(['vintage-pre-1.13.0', 'no-badExample', 'no-goodExample']);
+  });
+
+  it('skips archived rules', async () => {
+    writeRules(tmpDir, [
+      {
+        lessonHash: 'rule-archived',
+        lessonHeading: 'archived legacy',
+        pattern: 'x',
+        message: 'x',
+        engine: 'regex',
+        compiledAt: PRE_1_13_0,
+        createdAt: PRE_1_13_0,
+        status: 'archived',
+      },
+    ]);
+    const result = await findLegacyGrandfatheredRules(tmpDir);
+    expect(result).toEqual([]);
+  });
+
+  it('skips rules with unverified: true (post zero-trust cohort)', async () => {
+    writeRules(tmpDir, [
+      {
+        lessonHash: 'rule-unverified',
+        lessonHeading: 'zero-trust marker present',
+        pattern: 'x',
+        message: 'x',
+        engine: 'regex',
+        compiledAt: PRE_1_13_0,
+        createdAt: PRE_1_13_0,
+        unverified: true,
+      },
+    ]);
+    const result = await findLegacyGrandfatheredRules(tmpDir);
+    expect(result).toEqual([]);
+  });
+
+  it('omits rules that satisfy all three substrate checks', async () => {
+    writeRules(tmpDir, [
+      {
+        lessonHash: 'rule-substrate-complete',
+        lessonHeading: 'fully verified',
+        pattern: 'x',
+        message: 'x',
+        engine: 'regex',
+        compiledAt: POST_1_13_0,
+        createdAt: POST_1_13_0,
+        badExample: 'bad',
+        goodExample: 'good',
+      },
+    ]);
+    const result = await findLegacyGrandfatheredRules(tmpDir);
+    expect(result).toEqual([]);
+  });
+
+  it('treats vintage at the exact 1.13.0 ship date as NOT pre-1.13.0', async () => {
+    // Boundary test: `<` semantics, not `<=`. A rule whose createdAt equals
+    // V_1_13_0_SHIP_DATE_ISO shipped with 1.13.0 and carries the substrate
+    // expectation forward, so it does not count as vintage.
+    writeRules(tmpDir, [
+      {
+        lessonHash: 'rule-at-boundary',
+        lessonHeading: 'boundary',
+        pattern: 'x',
+        message: 'x',
+        engine: 'regex',
+        compiledAt: V_1_13_0_SHIP_DATE_ISO,
+        createdAt: V_1_13_0_SHIP_DATE_ISO,
+        badExample: 'bad',
+        goodExample: 'good',
+      },
+    ]);
+    const result = await findLegacyGrandfatheredRules(tmpDir);
+    expect(result).toEqual([]);
+  });
+
+  it('falls back to compiledAt when createdAt is absent', async () => {
+    writeRules(tmpDir, [
+      {
+        lessonHash: 'rule-no-createdat',
+        lessonHeading: 'no createdAt',
+        pattern: 'x',
+        message: 'x',
+        engine: 'regex',
+        compiledAt: PRE_1_13_0,
+        badExample: 'bad',
+        goodExample: 'good',
+      },
+    ]);
+    const result = await findLegacyGrandfatheredRules(tmpDir);
+    expect(result!.length).toBe(1);
+    expect(result![0]!.reasons).toEqual(['vintage-pre-1.13.0']);
+    expect(result![0]!.vintage).toBe(PRE_1_13_0);
+  });
+
+  it('sorts worst-off first, then oldest vintage first', async () => {
+    writeRules(tmpDir, [
+      {
+        lessonHash: 'rule-one-reason-new',
+        lessonHeading: 'one reason, newer vintage',
+        pattern: 'x',
+        message: 'x',
+        engine: 'regex',
+        compiledAt: POST_1_13_0,
+        createdAt: POST_1_13_0,
+        badExample: 'bad',
+      },
+      {
+        lessonHash: 'rule-all-three-newer',
+        lessonHeading: 'three reasons, newer vintage',
+        pattern: 'x',
+        message: 'x',
+        engine: 'regex',
+        compiledAt: '2026-03-15T00:00:00.000Z',
+        createdAt: '2026-03-15T00:00:00.000Z',
+      },
+      {
+        lessonHash: 'rule-all-three-older',
+        lessonHeading: 'three reasons, older vintage',
+        pattern: 'x',
+        message: 'x',
+        engine: 'regex',
+        compiledAt: '2026-01-01T00:00:00.000Z',
+        createdAt: '2026-01-01T00:00:00.000Z',
+      },
+    ]);
+    const result = await findLegacyGrandfatheredRules(tmpDir);
+    const hashes = result!.map((c) => c.lessonHash);
+    expect(hashes).toEqual(['rule-all-three-older', 'rule-all-three-newer', 'rule-one-reason-new']);
+  });
+
+  it('checkGrandfatheredRules returns skip when compiled-rules.json is missing', async () => {
+    const result = await checkGrandfatheredRules(tmpDir);
+    expect(result.status).toBe('skip');
+  });
+
+  it('checkGrandfatheredRules returns pass when no rules are grandfathered', async () => {
+    writeRules(tmpDir, [
+      {
+        lessonHash: 'rule-verified',
+        lessonHeading: 'verified',
+        pattern: 'x',
+        message: 'x',
+        engine: 'regex',
+        compiledAt: POST_1_13_0,
+        createdAt: POST_1_13_0,
+        badExample: 'bad',
+        goodExample: 'good',
+      },
+    ]);
+    const result = await checkGrandfatheredRules(tmpDir);
+    expect(result.status).toBe('pass');
+  });
+
+  it('checkGrandfatheredRules returns warn with per-reason counts and ADR-091 remediation', async () => {
+    writeRules(tmpDir, [
+      {
+        lessonHash: 'rule-a',
+        lessonHeading: 'A',
+        pattern: 'x',
+        message: 'x',
+        engine: 'regex',
+        compiledAt: PRE_1_13_0,
+        createdAt: PRE_1_13_0,
+      },
+      {
+        lessonHash: 'rule-b',
+        lessonHeading: 'B',
+        pattern: 'x',
+        message: 'x',
+        engine: 'regex',
+        compiledAt: POST_1_13_0,
+        createdAt: POST_1_13_0,
+        badExample: 'bad',
+      },
+    ]);
+    const result = await checkGrandfatheredRules(tmpDir);
+    expect(result.status).toBe('warn');
+    expect(result.message).toMatch(/2 grandfathered rule\(s\)/);
+    expect(result.message).toMatch(/1 vintage-pre-1\.13\.0/);
+    expect(result.message).toMatch(/1 no-badExample/);
+    expect(result.message).toMatch(/2 no-goodExample/);
+    expect(result.remediation).toContain('ADR-091 Stage 4');
+    expect(result.remediation).toContain('mmnto-ai/totem#1504');
   });
 });

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -905,6 +905,167 @@ export async function checkStaleRules(
   };
 }
 
+// ─── Grandfathered-rule advisory (mmnto-ai/totem#1603) ─
+
+/**
+ * ISO timestamp for the 1.13.0 ship date. Rules whose vintage timestamp
+ * precedes this never saw the ADR-088 Phase 1 substrate fields
+ * (`badExample`, `goodExample`, `unverified`) during their compile. Used
+ * by `findLegacyGrandfatheredRules` to categorize the pre-zero-trust
+ * cohort the 2026-04-20 audit measured at 357 of 378 active rules.
+ */
+export const V_1_13_0_SHIP_DATE_ISO = '2026-04-07T00:00:00.000Z';
+
+export type GrandfatheredReasonCode = 'vintage-pre-1.13.0' | 'no-badExample' | 'no-goodExample';
+
+export interface GrandfatheredRuleCandidate {
+  lessonHash: string;
+  heading: string;
+  /** Non-empty: rules with zero applicable reasons are not returned. */
+  reasons: GrandfatheredReasonCode[];
+  /** `createdAt` when present, `compiledAt` otherwise; used for the vintage check. */
+  vintage: string;
+}
+
+/**
+ * Pure helper: scan compiled rules and return the grandfathered
+ * pre-zero-trust cohort categorized by reason. A rule is a candidate
+ * when it is active (`status !== 'archived'`) and lacks the `unverified`
+ * flag from ADR-089 part 1 (mmnto-ai/totem#1581). Each candidate gets
+ * every reason that applies:
+ *
+ *   - `vintage-pre-1.13.0`: vintage timestamp precedes the 1.13.0 ship date.
+ *   - `no-badExample`: empty or absent `badExample` field.
+ *   - `no-goodExample`: empty or absent `goodExample` field.
+ *
+ * Rules with at least one reason are returned; rules that satisfy all
+ * three substrate checks are omitted.
+ *
+ * Returns `null` when `compiled-rules.json` is missing or unreadable,
+ * matching the fallback convention used by `findStaleRules` so the
+ * caller can render a `skip` diagnostic rather than fail the pipeline.
+ */
+export async function findLegacyGrandfatheredRules(
+  cwd: string,
+  totemDir = '.totem',
+): Promise<GrandfatheredRuleCandidate[] | null> {
+  const rulesPath = path.join(cwd, totemDir, 'compiled-rules.json');
+  if (!fs.existsSync(rulesPath)) return null;
+
+  try {
+    const { loadCompiledRulesFile } = await import('@mmnto/totem');
+    const rulesFile = loadCompiledRulesFile(rulesPath);
+
+    const candidates: GrandfatheredRuleCandidate[] = [];
+    for (const rule of rulesFile.rules) {
+      if (rule.status === 'archived') continue;
+      if (rule.unverified === true) continue;
+
+      const vintage = rule.createdAt ?? rule.compiledAt;
+      const reasons: GrandfatheredReasonCode[] = [];
+      if (vintage < V_1_13_0_SHIP_DATE_ISO) reasons.push('vintage-pre-1.13.0');
+      if (!rule.badExample || rule.badExample.trim().length === 0) {
+        reasons.push('no-badExample');
+      }
+      if (!rule.goodExample || rule.goodExample.trim().length === 0) {
+        reasons.push('no-goodExample');
+      }
+
+      if (reasons.length === 0) continue;
+
+      candidates.push({
+        lessonHash: rule.lessonHash,
+        heading: rule.lessonHeading,
+        reasons,
+        vintage,
+      });
+    }
+
+    // Sort by reason count desc (worst-off first), then vintage asc
+    // (oldest first) so the leader line surfaces the most affected rule.
+    return candidates.sort((a, b) => {
+      if (a.reasons.length !== b.reasons.length) return b.reasons.length - a.reasons.length;
+      return a.vintage.localeCompare(b.vintage);
+    });
+  } catch (err) {
+    // Matches `findStaleRules` fallback: corrupt or unreadable rules file
+    // degrades to "no data" so one bad read cannot crash the diagnostic
+    // pipeline. Defective Error objects (empty message) still propagate.
+    if (err instanceof Error && err.message.length === 0) {
+      throw err;
+    }
+    return null;
+  }
+}
+
+/**
+ * Grandfathered-rule advisory diagnostic. Summarizes the pre-zero-trust
+ * cohort by reason code. Advisory-only (`warn`): ADR-091 Stage 4
+ * Codebase Verifier (1.16.0, mmnto-ai/totem#1504) is the empirical
+ * audit path; this check gives users a triage-able surface until that
+ * ships.
+ */
+export async function checkGrandfatheredRules(
+  cwd: string,
+  totemDir = '.totem',
+): Promise<DiagnosticResult> {
+  const rulesPath = path.join(cwd, totemDir, 'compiled-rules.json');
+  if (!fs.existsSync(rulesPath)) {
+    return {
+      name: 'Grandfathered Rules',
+      status: 'skip',
+      message: 'compiled-rules.json missing',
+    };
+  }
+
+  const candidates = await findLegacyGrandfatheredRules(cwd, totemDir);
+  if (candidates === null) {
+    return {
+      name: 'Grandfathered Rules',
+      status: 'skip',
+      message: 'Could not analyze rules',
+    };
+  }
+
+  if (candidates.length === 0) {
+    return {
+      name: 'Grandfathered Rules',
+      status: 'pass',
+      message: 'All active rules carry the ADR-089 zero-trust substrate',
+    };
+  }
+
+  const reasonCounts: Record<GrandfatheredReasonCode, number> = {
+    'vintage-pre-1.13.0': 0,
+    'no-badExample': 0,
+    'no-goodExample': 0,
+  };
+  for (const candidate of candidates) {
+    for (const reason of candidate.reasons) {
+      reasonCounts[reason]++;
+    }
+  }
+
+  const summaryParts: string[] = [];
+  if (reasonCounts['vintage-pre-1.13.0'] > 0) {
+    summaryParts.push(`${reasonCounts['vintage-pre-1.13.0']} vintage-pre-1.13.0`);
+  }
+  if (reasonCounts['no-badExample'] > 0) {
+    summaryParts.push(`${reasonCounts['no-badExample']} no-badExample`);
+  }
+  if (reasonCounts['no-goodExample'] > 0) {
+    summaryParts.push(`${reasonCounts['no-goodExample']} no-goodExample`);
+  }
+
+  return {
+    name: 'Grandfathered Rules',
+    status: 'warn',
+    message: `${candidates.length} grandfathered rule(s): ${summaryParts.join(', ')}`,
+    remediation:
+      'Pre-zero-trust cohort. ADR-091 Stage 4 Codebase Verifier (1.16.0) will empirically validate these against real code; see mmnto-ai/totem#1504.',
+  };
+}
+
 // ─── Types ──────────────────────────────────────────────
 
 export interface DoctorOptions {
@@ -1344,6 +1505,7 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<Diagno
     checkSecretsFileTracked(cwd),
     await checkUpgradeCandidates(cwd),
     await checkStaleRules(cwd, '.totem', doctorThresholds),
+    await checkGrandfatheredRules(cwd),
   ];
 
   for (const result of results) {


### PR DESCRIPTION
## Summary

- Adds a categorized `totem doctor` advisory for the pre-zero-trust cohort (active rules lacking the ADR-089 `unverified` flag), grouped by reason code: `vintage-pre-1.13.0`, `no-badExample`, `no-goodExample`.
- Final item of the 1.15.0 compile-hardening ship gate. After this merges, 1.15.0 can ship pending pack-agent-security verification criterion (≥5 immutable rules with test fixtures).
- Closes #1603. Completes #1581.

## What lands

`findLegacyGrandfatheredRules` — pure filter over `compiled-rules.json` returning structured candidates; every grandfathered rule carries every reason that applies, and rules with zero reasons are omitted. `checkGrandfatheredRules` wires it into the doctor pipeline and renders a `DiagnosticResult` (skip / pass / warn). Advisory-only severity: `warn` does not fail CI. Sort order is reason-count desc then vintage asc so the leader line surfaces the most affected rule.

Follows the `findStaleRules` / `checkStaleRules` pattern at `doctor.ts:781+` including the "empty-error-message sentinel propagates, all other reads fall back to null" convention so one bad rules file cannot crash the diagnostic pipeline.

## Why now

2026-04-20 empirical check measured 357 of 378 active rules (94%) as pre-1.13.0 with zero `badExample` / `goodExample` / `unverified` substrate coverage. #1504's Phase 1 gates assume those fields, so 70% of its audit surface would no-op on the legacy cohort — #1504 moved to 1.16.0 behind ADR-091 Stage 4 Codebase Verifier (which validates empirically against real code, not against LLM-generated snippet fixtures).

In the meantime, users deserve a triage-able surface over the grandfathered corpus rather than a mass unverified flip. Retroactive `unverified: true` (Option 2) would break every downstream consumer's lint overnight; Option 3 (retroactive with migration ramp) pulled scope into migration tooling. Option 1 (prospective-only, shipped in 1.14.16 via #1601) + categorized advisory (this PR) locks the ship gate cleanly.

## Real-corpus output

```
! Grandfathered Rules  378 grandfathered rule(s): 358 vintage-pre-1.13.0, 371 no-badExample, 378 no-goodExample
  → Pre-zero-trust cohort. ADR-091 Stage 4 Codebase Verifier (1.16.0) will empirically validate these against real code; see mmnto-ai/totem#1504.
```

## Commits

- `a5e3d1c1` — `feat(cli):` doctor advisory, tests, changeset
- `da7d5676` — `chore:` bump `.strategy` pointer to `3047662` (2026-04-20 ship-gate trio journal)

## Test plan

- [x] 14 new unit tests cover every reason in isolation, whitespace-only snippet handling, multi-reason aggregation, archived-rule skipping, `unverified: true` post-zero-trust skipping, full-substrate omission, 1.13.0 boundary semantic, `createdAt`-absent fallback to `compiledAt`, sort ordering, and all three `DiagnosticResult` paths (skip / pass / warn).
- [x] Existing `doctorCommand` diagnostic-count assertion updated from 10 to 11.
- [x] 1,743 CLI tests pass.
- [x] `pnpm totem lint` PASS (25 warnings — pre-existing-pattern false positives on `||` vs `??` for string guards and `async () =>` on async test bodies).
- [x] `pnpm totem verify-manifest` PASS — 440 rules, hashes match.
- [x] `pnpm totem review` PASS — Shield surfaced zero findings.
- [x] `pnpm totem doctor` on the real repo — reports the 378/358/371/378 cohort as designed.

Closes #1603. Completes #1581.