### PR TITLE
chore: cut 1.15.0 Pack Distribution

### DIFF
--- a/.changeset/1.15.0-pack-distribution.md
+++ b/.changeset/1.15.0-pack-distribution.md
@@ -1,0 +1,43 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+'@mmnto/mcp': minor
+'@totem/pack-agent-security': minor
+---
+
+1.15.0 ships Pack Distribution: the first shippable Totem pack, plus the compile-hardening and zero-trust substrate that makes packs safe to distribute.
+
+## Pack Distribution
+
+- `@totem/pack-agent-security` (ADR-089 flagship pack). 5 immutable security rules covering unauthorized process spawning, dynamic code evaluation with non-literal arguments, network exfiltration via hardcoded IPs or suspicious domains (API + shell-string variants), and obfuscated string assembly via byte-level primitives. Every rule ships `immutable: true` + `severity: error` + `category: security` with bad/good fixture pairs and 57 unit tests.
+- `totem install pack/<name>` command installs a published pack into the local manifest.
+- `pack-merge` primitive refuses downgrade of immutable rules to warning or archived; bypass attempts log to the Trap Ledger.
+- Content-hash substrate across TypeScript and bash (shield + sync + pre-push hook) so pack integrity verifies without relying on file timestamps.
+
+## Zero-trust default (ADR-089)
+
+- Pipeline 2 and Pipeline 3 LLM-generated rules now ship `unverified: true` unconditionally. Activation via the atomic `totem rule promote <hash>` CLI or the ADR-091 Stage 4 Codebase Verifier in 1.16.0.
+- Pipeline 1 (manual) keeps its conditional semantics; human-authored rules are self-evidencing.
+
+## Compile hardening (ADR-088 Phase 1)
+
+- Layer 3 verify-retry loop: rules that fail their own smoke test re-prompt once before the compiler rejects them.
+- Compile-time smoke gate runs both `badExample` and `goodExample`; rules that fire on both directions are rejected with reason code `matches-good-example` (closes the over-matching hole that drove the 2026-04-18 security-pack 10-of-10 archive rate).
+- `archivedAt` timestamp preserved across schema round-trips so the institutional first-archive-provenance ledger survives every compile cycle.
+- `unverified` flag and `nonCompilable` 4-tuple with 9-value reason-code enum replaces the opaque 2-tuples.
+- `totem doctor` stale-rule advisory (ADR-088 Phase 1) plus the grandfathered-rule advisory that surfaces the pre-zero-trust cohort categorized by `vintage-pre-1.13.0`, `no-badExample`, and `no-goodExample`.
+
+## Platform
+
+- Compound ast-grep rules (ADR-087, promoted from Proposal 226). `astGrepYamlRule` field on `CompiledRule` with mutual exclusion on `astGrepPattern`, structural combinators (all / any / not / inside / has / precedes / follows), and canonical-serialization hashing via `canonicalStringify`.
+- Windows shell-injection fix in `safeExec` via `cross-spawn.sync` (closes a three-week-latent vector).
+- Cross-Repo Context Mesh (`totem search` federation + `totem doctor` Linked Indexes health check).
+- Standalone binary distribution unblocked (darwin-arm64, linux-x64, win32-x64).
+
+## Positioning
+
+- **ADR-090 (Multi-Agent State Substrate).** Scopes Totem as the shared state, enforcement, and audit substrate for multi-agent development. Totem does not own agent routing, capability negotiation, session lifecycle, or live-edit conflict resolution. Future feature admission passes the Scope Decision Test.
+- **ADR-091 (Ingestion Pipeline Refinements).** Redefines the 1.16.0 ingestion pipeline as a 5-stage funnel: Extract → Classify → Compile → Verify-Against-Codebase → Activate. Renames the legacy `allowlist` terminology to `baseline`.
+- **ADR-085 (Pack Ecosystem).** Accepted with five deferred decisions resolved: Behavioral SemVer with refinement classification, array-order precedence plus `totem doctor` shadowing warning, Local Supreme Authority with ADR-089 immutable-severity carve-out, Sigstore + in-toto signing, native npm lifecycle with 72-hour unpublish constraint.
+
+Detailed patch-level changes: CHANGELOG.md entries 1.14.1 through 1.14.17.

--- a/.changeset/1.15.0-pack-distribution.md
+++ b/.changeset/1.15.0-pack-distribution.md
@@ -12,7 +12,7 @@
 - `@totem/pack-agent-security` (ADR-089 flagship pack). 5 immutable security rules covering unauthorized process spawning, dynamic code evaluation with non-literal arguments, network exfiltration via hardcoded IPs or suspicious domains (API + shell-string variants), and obfuscated string assembly via byte-level primitives. Every rule ships `immutable: true` + `severity: error` + `category: security` with bad/good fixture pairs and 57 unit tests.
 - `totem install pack/<name>` command installs a published pack into the local manifest.
 - `pack-merge` primitive refuses downgrade of immutable rules to warning or archived; bypass attempts log to the Trap Ledger.
-- Content-hash substrate across TypeScript and bash (shield + sync + pre-push hook) so pack integrity verifies without relying on file timestamps.
+- Content-hash substrate across TypeScript and bash (review + sync + pre-push hook) so pack integrity verifies without relying on file timestamps.
 
 ## Zero-trust default (ADR-089)
 


### PR DESCRIPTION
## Summary

- Minor-level changeset that bumps the fixed group (`@mmnto/totem`, `@mmnto/cli`, `@mmnto/mcp`, `@totem/pack-agent-security`) from 1.14.17 to 1.15.0.
- Theme: Pack Distribution. First shippable Totem pack (`@totem/pack-agent-security`) plus the compile-hardening and zero-trust substrate that makes packs safe to distribute downstream.
- No code changes. Release-notes body only.

## Ship-gate verification

All four 1.15.0 ship-gate criteria from `docs/active_work.md` are met:

- [x] #1580 goodExample smoke gate (1.14.15)
- [x] #1589 archivedAt schema preservation (1.14.16)
- [x] #1581 part 1 zero-trust default + `totem rule promote` CLI (1.14.16)
- [x] #1581 part 2 grandfathered-rule advisory (1.14.17)
- [x] `@totem/pack-agent-security` has 5 immutable rules with fixture-backed tests (57 unit tests: 5 structure, 5 parity, 43 rules, 1 monorepo, 3 repo-sweep)

## What 1.15.0 ships vs 1.14.0

Release-notes body lives in the changeset at `.changeset/1.15.0-pack-distribution.md`. Summary:

- **Pack Distribution**: `@totem/pack-agent-security` flagship pack, `totem install pack/<name>`, `pack-merge` immutable-downgrade refusal, content-hash substrate.
- **Zero-trust default (ADR-089)**: Pipeline 2 + Pipeline 3 LLM rules ship `unverified: true` unconditionally; `totem rule promote <hash>` atomic activation CLI.
- **Compile hardening (ADR-088 Phase 1)**: Layer 3 verify-retry, bidirectional smoke gate (`badExample` + `goodExample`), `archivedAt` round-trip preservation, 9-value reason-code enum, two new `totem doctor` advisories.
- **Platform**: Compound ast-grep rules (ADR-087), Windows `safeExec` shell-injection fix, Cross-Repo Context Mesh, standalone binaries.
- **Positioning**: ADR-090 (Multi-Agent State Substrate), ADR-091 (5-stage ingestion funnel), ADR-085 (Pack Ecosystem, five deferred decisions resolved).

Detailed patch-level changes: CHANGELOG.md entries 1.14.1 through 1.14.17.

## Test plan

- [x] `pnpm dlx @changesets/cli status` confirms all 4 packages bump at minor (1.14.17 → 1.15.0)
- [x] Pack-agent-security verification: 5 immutable rules, 5 bad/good fixture pairs, 57 tests pass
- [x] Doctor grandfathered-rule advisory verified against real corpus (378 grandfathered rules categorized)
- [ ] After merge: Version Packages auto-PR lands 1.15.0 on npm via the release workflow

Closes the 1.15.0 ship-gate tracking in `docs/active_work.md`. Post-merge signoff will update `active_work.md` and `MEMORY.md` to reflect the cut.