### PR TITLE
feat(cli): scaffold `totem proposal new` and `totem adr new` (#1288)

### DIFF
--- a/.totem/specs/1288.md
+++ b/.totem/specs/1288.md
@@ -1,0 +1,199 @@
+### Problem Statement
+
+The process of authoring new Totem proposals and Architecture Decision Records (ADRs) requires tribal knowledge regarding file naming conventions, boilerplate template structures, and post-creation dashboard updates. This feature introduces `totem proposal new` and `totem adr new` commands to automatically scaffold correctly numbered files, apply templates, and execute `docs:inject` to ensure dashboard indices never fall out of sync.
+
+### Architectural Context
+
+This enhancement follows the structural prevention pattern established in #1285 (wind tunnel SHA hook ordering): rather than catching stale dashboards after the fact (via pre-push hooks), the system enforces consistency by integrating the dashboard generation directly into the authoring workflow. It mirrors the existing `totem lesson add` workflow.
+
+### Files to Examine
+
+1. `packages/cli/src/commands/docs.ts` — Examine for existing command setup patterns and imports.
+2. `packages/cli/src/index.ts` (or equivalent CLI router) — To see where new top-level commands (`proposal`, `adr`) must be registered.
+
+### Technical Approach & Contracts
+
+1. **Directory Resolution**: The command must identify whether it is running in a main Totem repository (where files live in `.strategy/proposals/active` and `.strategy/adr`) or standalone in the strategy repository (`proposals/active` and `adr`). It will use the `resolveGitRoot` shared helper to anchor these checks.
+2. **Auto-Increment Logic**: Scan the resolved target directory for files matching `^(\d{3})-(.+)\.md$`. Parse the prefixes to integers, find the maximum, and add 1 (zero-padded to 3 digits). If no files exist, start at `001`.
+3. **Template Resolution**: Look for `.strategy/templates/proposal.md` (or `adr.md`). If missing, fall back to a hardcoded string template containing standard frontmatter (Status, Author, Date, Milestone) and structural headers.
+4. **Execution Sequence**:
+   - Resolve target path and next ID.
+   - Kebab-case the user-provided title to form the filename: `NNN-kebab-title.md`.
+   - Read template and inject standard variables (e.g., replace `{{TITLE}}` with the raw title, `{{DATE}}` with `YYYY-MM-DD`).
+   - Write the file.
+   - Run the injection script using `safeExec('npm', ['run', 'docs:inject'])` (or preferred package manager equivalent).
+   - Stage the newly created file and the updated dashboard files (typically `README.md`) using `safeExec('git', ['add', ...])`. Stop short of committing to fulfill the "not committed without user confirmation" AC.
+
+**Data Contracts:**
+
+```typescript
+interface ScaffoldOptions {
+  type: 'proposal' | 'adr';
+  title: string;
+  cwd: string;
+}
+
+interface GovernancePaths {
+  targetDir: string;
+  templatePath: string;
+}
+```
+
+### Edge Cases & Traps
+
+- **Missing `docs:inject` Script**: If the user's repository does not have a `docs:inject` script defined, `safeExec` will throw. The command must catch this specifically, emit a warning, but successfully complete the scaffolding.
+- **Gap Numbering**: If the directory contains `001-a.md` and `003-b.md`, the next number must be `004`, not `003`. Simply counting array length is a trap; explicit `Math.max` on parsed prefixes is required.
+- **Title Sanitization**: Titles with special characters (e.g., `LLM caching (v2) / Verifier`) must be safely transformed into valid git filenames (e.g., `llm-caching-v2-verifier`).
+- **Unstaged Working Tree**: Running `docs:inject` might modify `README.md`. When executing `git add`, only stage the exact generated proposal file and specifically `README.md` to avoid accidentally staging unrelated working tree changes.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Build Git Path & Directory Resolver**
+  - Create/Update `packages/cli/src/utils/governance.ts`.
+  - Implement a `resolveGovernancePaths(cwd: string, type: 'proposal' | 'adr')` utility using `resolveGitRoot`.
+  - Check for existence of the `.strategy/` prefix vs root-level structural folders to support both standalone and submodule contexts.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `resolves standalone strategy path when submodule prefix is missing` that proves context-aware path resolution works.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Implement Auto-Increment and Name Sanitization**
+  - Implement a `getNextArtifactId(targetDir: string)` utility that reads the directory and computes the next 3-digit padded number.
+  - Implement a `formatArtifactFilename(id: string, title: string)` utility.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `calculates correct next id when numerical gaps exist in directory` that proves gap-handling logic.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Template Generation Engine**
+  - Implement the template reader: check `templates/` dir first, falling back to a hardcoded minimal default markdown schema.
+  - Implement variable replacement for `{{TITLE}}`, `{{DATE}}`, and `{{AUTHOR}}`. (For MVP author, "Totem CLI" or an empty prompt is acceptable if git config lookup is complex).
+    > TEST DIRECTIVE: Before implementing, write a failing test named `generates fallback template when physical template file is missing`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Post-Scaffold Hook Orchestration**
+  - Create a runner utility for post-generation hooks using `safeExec`.
+  - Attempt to execute `npm run docs:inject` in the git root. Catch errors and warn gracefully instead of crashing.
+  - Execute `git add <new-file-path> README.md` to stage changes.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `stages artifact and readme without crashing if docs:inject fails`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 5: CLI Command Wiring**
+  - Create `packages/cli/src/commands/proposal.ts` and `packages/cli/src/commands/adr.ts`.
+  - Register `totem proposal new <title>` and `totem adr new <title>`.
+  - Wire them to invoke the orchestrator from Tasks 1-4.
+  - Add standard user-facing console output (e.g., "Scaffolded 219-title.md. Dashboard updated and staged.").
+  - write test → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Happy Path (Proposal):** Run `totem proposal new "Feature Branch Workflow"`. Assert that `proposals/active/001-feature-branch-workflow.md` is created, `docs:inject` is called, and the file is staged.
+- **Happy Path (ADR):** Run `totem adr new "Database Sharding"`. Assert `adr/001-database-sharding.md` is created.
+- **Gap Numbering:** Seed directory with `001-alpha.md` and `004-beta.md`. Run command. Assert `005-charlie.md` is created (verifying gap logic).
+- **Graceful Degradation:** Run command in a repository without `docs:inject` configured in `package.json`. Assert the markdown file is still successfully created, numbered, and staged, with a warning log emitted regarding the skipped hook.
+
+---
+
+## Implementation Design
+
+### Scope
+
+Ship `totem proposal new <title>` and `totem adr new <title>` scaffolding commands that write the next NNN-numbered artifact under `.strategy/proposals/active/` or `.strategy/adr/`, fill the template with Status/Date frontmatter matching ADR-091's convention, run `pnpm run docs:inject` to refresh the dashboard, and stage (not commit) the new file plus updated README.md.
+
+Does NOT cover: `list` / `status` / `promote` subcommands, PR-opening integration, `--from-outline` LLM-assisted drafting, or cross-repo discovery flags. All explicitly deferred per the ticket's own "Deferred to 1.15.0+" section.
+
+### Data model deltas
+
+Two new types in `packages/cli/src/utils/governance.ts` (new file):
+
+- **`ScaffoldOptions`** = `{ type: 'proposal' | 'adr'; title: string; cwd: string }`
+  - Holds: command invocation args.
+  - Written by: command entry point (`proposal.ts`, `adr.ts`).
+  - Read by: `scaffoldGovernanceArtifact()`.
+  - Invariants: `type` is one of two literals; `title` is a non-empty string; `cwd` is absolute (resolved from `process.cwd()`).
+
+- **`GovernancePaths`** = `{ rootDir: string; targetDir: string; templatePath: string; dashboardFile: string }`
+  - Holds: resolved filesystem paths for this invocation.
+  - Written by: `resolveGovernancePaths()`.
+  - Read by: scaffolding engine.
+  - Invariants: `rootDir` is either `<totem>/.strategy/` (submodule case) or `<cwd>` itself (standalone strategy repo case); `targetDir` is `<rootDir>/proposals/active` or `<rootDir>/adr`; `templatePath` may not exist on disk (fallback handled); `dashboardFile` is `<rootDir>/README.md`.
+
+No module-level state. No reserved keys or sentinel values. Template defaults are hardcoded exported string constants (`DEFAULT_PROPOSAL_TEMPLATE`, `DEFAULT_ADR_TEMPLATE`) to guarantee the heading convention matches ADR-091 (`# ADR NNN: Title` with a space separator, not a hyphen).
+
+### State lifecycle
+
+No persistent or long-lived state. Each command invocation:
+
+- Creates one markdown file.
+- Mutates `README.md` indirectly via `docs:inject`.
+- Mutates git index via `git add` on the two specific paths.
+- Owns all mutations within the command function; no shared module state.
+
+No state crosses lifecycle boundaries. One-shot, per-invocation scope throughout.
+
+### Failure modes
+
+| Failure                                                                               | Category  | Agent-facing surface                                                            | Recovery                         |
+| ------------------------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------- | -------------------------------- |
+| `cwd` not inside a git repo                                                           | init      | hard error (`TotemError` with hint)                                             | user navigates into a repo       |
+| Strategy dir not found (no `.strategy/` submodule AND no standalone `proposals/` dir) | init      | hard error with hint                                                            | user clones or links strategy    |
+| Target dir not writable                                                               | permanent | hard error                                                                      | user fixes permissions           |
+| Template file exists but malformed (missing `{{TITLE}}`)                              | runtime   | warning, continue with unreplaced variables visible in output file              | user fixes template              |
+| Directory has non-NNN-prefixed files mixed in                                         | runtime   | silent (regex-filtered)                                                         | none needed                      |
+| Next-number overflow (>999)                                                           | permanent | hard error "NNN-prefix format saturated"                                        | unreachable in practice          |
+| `docs:inject` script missing from `package.json`                                      | transient | warning "dashboard not refreshed; run manually" + exit 0                        | user runs `pnpm run docs:inject` |
+| `docs:inject` exits non-zero                                                          | runtime   | warning + stderr forwarded + exit 0 (file created)                              | user debugs script               |
+| `git add` fails                                                                       | runtime   | warning "file created but not staged" + exit 0                                  | user runs `git add` manually     |
+| Title sanitization produces empty slug (all-special-char title)                       | runtime   | hard error "title must contain at least one alphanumeric char" (loud, pre-disk) | user provides valid title        |
+| Exact filename collision (same title re-run)                                          | permanent | hard error "file already exists at <path>"                                      | user chooses different title     |
+
+Two "silent degradation" rows for `docs:inject` failure and `git add` failure, both justified against Tenet 4: the primary action (file creation) succeeded, so the scaffolded artifact is on disk and visible to the user; secondary regen/stage steps warn-loud via stderr so the user knows they need manual follow-up. Failing the whole command in that case would strand a file on disk with no feedback, which is a worse failure mode.
+
+### Invariants to lock in via tests
+
+- Next-ID computation respects gaps: `001-a.md` + `003-b.md` yields `004`, never `002` or `003`.
+- Filename kebab-case is deterministic: same title string produces same kebab slug across runs.
+- ADR heading emits as `# ADR NNN: Title` (space separator, matches ADR-091 exactly).
+- Proposal heading emits as `# Proposal NNN: Title`.
+- Status line defaults to `**Status:** Draft`.
+- Date line defaults to today in ISO `YYYY-MM-DD`.
+- `docs:inject` absence does not prevent file creation (warn-and-continue path).
+- `git add` failure does not prevent file creation.
+- `git add` stages only the new file plus README.md, never `-A` or `.` (per lesson-8067935e and lesson-4a01b498).
+- Strategy dir resolution covers both submodule case (`<totem>/.strategy/`) and standalone case (`<cwd>`).
+- Title with empty post-sanitization slug throws loud error BEFORE touching disk.
+- Exact filename collision on retry throws loud error without overwriting.
+
+### Open questions
+
+- **Question:** Package manager for `docs:inject` invocation — spec says `npm run docs:inject`, but CLAUDE.md mandates pnpm-only for this repo.
+  - **Options:** (a) hardcode `pnpm run docs:inject`; (b) detect `packageManager` field in strategy `package.json`; (c) universal `npm run` fallback.
+  - **Recommendation:** (a) hardcode `pnpm`. Matches CLAUDE.md. Strategy repo already uses pnpm (`pnpm-lock.yaml` present).
+
+- **Question:** Template variable set for MVP — just `{{TITLE}}` + `{{DATE}}`, or include `{{AUTHOR}}` / `{{MILESTONE}}`?
+  - **Options:** (a) MVP = `{{TITLE}}` + `{{DATE}}` only; (b) add `{{AUTHOR}}` via `git config user.name` lookup; (c) add `{{MILESTONE}}` interactive prompt.
+  - **Recommendation:** (a). Matches the ticket's "Minimum viable" framing. `{{AUTHOR}}` adds a git-config-missing failure path; `{{MILESTONE}}` is explicitly deferred in the ticket body.
+
+- **Question:** Collision behavior when the exact filename already exists (same title re-run).
+  - **Options:** (a) refuse with hard error (safest); (b) auto-bump to next NNN (already possible via gap logic but user intent is unclear); (c) support `--force` overwrite.
+  - **Recommendation:** (a). The auto-increment already handles "same title, next number" if the user actually wants a new artifact by re-running. Refusing collision protects against accidental overwrite of in-progress work. `--force` deferred to a later patch.
+
+- **Question:** Should the command support a `--no-stage` flag for users who want the file but not the git-index mutation?
+  - **Options:** (a) always stage (per spec); (b) add `--no-stage` for MVP; (c) defer the flag.
+  - **Recommendation:** (c) defer. The ticket AC is explicit: "New file is staged in git (but not committed without user confirmation)". If a user wants the file without staging, they can `git reset HEAD <file>` post-hoc. Keep MVP scope tight.

--- a/packages/cli/src/commands/adr.test.ts
+++ b/packages/cli/src/commands/adr.test.ts
@@ -7,9 +7,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanTmpDir } from '../test-utils.js';
 
 function makeTmpDir(): string {
-  // Canonicalize via realpathSync for macOS `/tmp -> /private/tmp` and
-  // Windows short-name parity with `git rev-parse --show-toplevel`.
-  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'totem-adr-')));
+  // `.native` expands Windows 8.3 short names; plain `realpathSync` does not.
+  // Required for parity with `git rev-parse --show-toplevel` on Windows CI.
+  return fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), 'totem-adr-')));
 }
 
 function initGit(dir: string): void {

--- a/packages/cli/src/commands/adr.test.ts
+++ b/packages/cli/src/commands/adr.test.ts
@@ -1,0 +1,86 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { cleanTmpDir } from '../test-utils.js';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'totem-adr-'));
+}
+
+function initGit(dir: string): void {
+  fs.mkdirSync(path.join(dir, '.git'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.git', 'HEAD'), 'ref: refs/heads/main\n', 'utf-8');
+  fs.writeFileSync(
+    path.join(dir, '.git', 'config'),
+    '[core]\n\trepositoryformatversion = 0\n',
+    'utf-8',
+  );
+  fs.mkdirSync(path.join(dir, '.git', 'objects'), { recursive: true });
+  fs.mkdirSync(path.join(dir, '.git', 'refs', 'heads'), { recursive: true });
+}
+
+/** Stub `safeExec` so the hooks run without spawning real subprocesses. */
+vi.mock('@mmnto/totem', async () => {
+  const actual = await vi.importActual<typeof import('@mmnto/totem')>('@mmnto/totem');
+  return {
+    ...actual,
+    safeExec: vi.fn((_cmd: string, _args: string[]) => ''),
+  };
+});
+
+describe('adrNewCommand', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    cleanTmpDir(tmpDir);
+    vi.restoreAllMocks();
+  });
+
+  it('creates 001-database-sharding.md with ADR-091 heading format', async () => {
+    initGit(tmpDir);
+    fs.mkdirSync(path.join(tmpDir, 'proposals', 'active'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'adr'), { recursive: true });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { adrNewCommand } = await import('./adr.js');
+    await adrNewCommand('Database Sharding', { cwd: tmpDir });
+
+    const filePath = path.join(tmpDir, 'adr', '001-database-sharding.md');
+    expect(fs.existsSync(filePath)).toBe(true);
+    const content = fs.readFileSync(filePath, 'utf-8');
+    // ADR-091: `# ADR NNN: Title` with SPACE separator, not a hyphen.
+    expect(content).toContain('# ADR 001: Database Sharding');
+    expect(content).not.toContain('# ADR-001');
+    expect(content).toContain('**Status:** Draft');
+
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(output).toContain('Scaffolded');
+    expect(output).toContain('001-database-sharding.md');
+  });
+
+  it('respects gap numbering in adr/ directory', async () => {
+    initGit(tmpDir);
+    fs.mkdirSync(path.join(tmpDir, 'adr'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, 'adr', '001-alpha.md'), '# a\n', 'utf-8');
+    fs.writeFileSync(path.join(tmpDir, 'adr', '004-beta.md'), '# b\n', 'utf-8');
+
+    const { adrNewCommand } = await import('./adr.js');
+    await adrNewCommand('Charlie', { cwd: tmpDir });
+
+    // Gap logic: max=4, next=005.
+    const filePath = path.join(tmpDir, 'adr', '005-charlie.md');
+    expect(fs.existsSync(filePath)).toBe(true);
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).toContain('# ADR 005: Charlie');
+  });
+});

--- a/packages/cli/src/commands/adr.test.ts
+++ b/packages/cli/src/commands/adr.test.ts
@@ -7,7 +7,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanTmpDir } from '../test-utils.js';
 
 function makeTmpDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), 'totem-adr-'));
+  // Canonicalize via realpathSync for macOS `/tmp -> /private/tmp` and
+  // Windows short-name parity with `git rev-parse --show-toplevel`.
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'totem-adr-')));
 }
 
 function initGit(dir: string): void {

--- a/packages/cli/src/commands/adr.ts
+++ b/packages/cli/src/commands/adr.ts
@@ -1,0 +1,33 @@
+/**
+ * `totem adr new <title>` — scaffolding entry point (mmnto/totem#1288).
+ *
+ * Resolves the strategy repo layout (submodule or standalone), writes the
+ * next NNN-prefixed ADR under `adr/`, refreshes the dashboard via
+ * `pnpm run docs:inject`, and stages the two mutated paths. All
+ * orchestration logic lives in `../utils/governance.ts`; this file is the
+ * thin CLI adapter that prints the user-facing summary.
+ */
+
+const TAG = 'ADR';
+
+export interface AdrNewOptions {
+  /** Override the cwd (test seam). Defaults to `process.cwd()`. */
+  cwd?: string;
+}
+
+export async function adrNewCommand(title: string, options: AdrNewOptions = {}): Promise<void> {
+  const path = await import('node:path');
+  const { log, bold } = await import('../ui.js');
+  const { scaffoldGovernanceArtifact } = await import('../utils/governance.js');
+
+  const cwd = options.cwd ?? process.cwd();
+  const result = scaffoldGovernanceArtifact({ type: 'adr', title, cwd });
+
+  const relPath = path.relative(cwd, result.filePath);
+  const dashboardSummary = result.dashboardRefreshed
+    ? 'dashboard refreshed'
+    : 'dashboard refresh skipped (manual required)';
+  const stagedSummary = result.staged ? 'staged' : 'not staged (manual git add required)';
+
+  log.success(TAG, `Scaffolded ${bold(relPath)}; ${dashboardSummary}; ${stagedSummary}.`);
+}

--- a/packages/cli/src/commands/proposal.test.ts
+++ b/packages/cli/src/commands/proposal.test.ts
@@ -7,9 +7,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanTmpDir } from '../test-utils.js';
 
 function makeTmpDir(): string {
-  // Canonicalize via realpathSync for macOS `/tmp -> /private/tmp` and
-  // Windows short-name parity with `git rev-parse --show-toplevel`.
-  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'totem-proposal-')));
+  // `.native` expands Windows 8.3 short names; plain `realpathSync` does not.
+  // Required for parity with `git rev-parse --show-toplevel` on Windows CI.
+  return fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), 'totem-proposal-')));
 }
 
 function initGit(dir: string): void {

--- a/packages/cli/src/commands/proposal.test.ts
+++ b/packages/cli/src/commands/proposal.test.ts
@@ -7,7 +7,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanTmpDir } from '../test-utils.js';
 
 function makeTmpDir(): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), 'totem-proposal-'));
+  // Canonicalize via realpathSync for macOS `/tmp -> /private/tmp` and
+  // Windows short-name parity with `git rev-parse --show-toplevel`.
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'totem-proposal-')));
 }
 
 function initGit(dir: string): void {

--- a/packages/cli/src/commands/proposal.test.ts
+++ b/packages/cli/src/commands/proposal.test.ts
@@ -1,0 +1,82 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { cleanTmpDir } from '../test-utils.js';
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'totem-proposal-'));
+}
+
+function initGit(dir: string): void {
+  fs.mkdirSync(path.join(dir, '.git'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.git', 'HEAD'), 'ref: refs/heads/main\n', 'utf-8');
+  fs.writeFileSync(
+    path.join(dir, '.git', 'config'),
+    '[core]\n\trepositoryformatversion = 0\n',
+    'utf-8',
+  );
+  fs.mkdirSync(path.join(dir, '.git', 'objects'), { recursive: true });
+  fs.mkdirSync(path.join(dir, '.git', 'refs', 'heads'), { recursive: true });
+}
+
+/** Stub `safeExec` so the hooks run without spawning real subprocesses. */
+vi.mock('@mmnto/totem', async () => {
+  const actual = await vi.importActual<typeof import('@mmnto/totem')>('@mmnto/totem');
+  return {
+    ...actual,
+    safeExec: vi.fn((_cmd: string, _args: string[]) => ''),
+  };
+});
+
+describe('proposalNewCommand', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    cleanTmpDir(tmpDir);
+    vi.restoreAllMocks();
+  });
+
+  it('creates 001-feature-branch-workflow.md for standalone strategy repo', async () => {
+    initGit(tmpDir);
+    fs.mkdirSync(path.join(tmpDir, 'proposals', 'active'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'adr'), { recursive: true });
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { proposalNewCommand } = await import('./proposal.js');
+    await proposalNewCommand('Feature Branch Workflow', { cwd: tmpDir });
+
+    const filePath = path.join(tmpDir, 'proposals', 'active', '001-feature-branch-workflow.md');
+    expect(fs.existsSync(filePath)).toBe(true);
+    const content = fs.readFileSync(filePath, 'utf-8');
+    expect(content).toContain('# Proposal 001: Feature Branch Workflow');
+    expect(content).toContain('**Status:** Draft');
+
+    // Summary line surfaced via stderr log.success.
+    const output = consoleSpy.mock.calls.map((c) => String(c[0])).join('\n');
+    expect(output).toContain('Scaffolded');
+    expect(output).toContain('001-feature-branch-workflow.md');
+  });
+
+  it('creates file under submodule .strategy/ when present', async () => {
+    initGit(tmpDir);
+    const strategyDir = path.join(tmpDir, '.strategy');
+    fs.mkdirSync(path.join(strategyDir, 'proposals', 'active'), { recursive: true });
+    fs.mkdirSync(path.join(strategyDir, 'adr'), { recursive: true });
+
+    const { proposalNewCommand } = await import('./proposal.js');
+    await proposalNewCommand('Ingestion Pipeline', { cwd: tmpDir });
+
+    const filePath = path.join(strategyDir, 'proposals', 'active', '001-ingestion-pipeline.md');
+    expect(fs.existsSync(filePath)).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/proposal.ts
+++ b/packages/cli/src/commands/proposal.ts
@@ -1,0 +1,36 @@
+/**
+ * `totem proposal new <title>` — scaffolding entry point (mmnto/totem#1288).
+ *
+ * Resolves the strategy repo layout (submodule or standalone), writes the
+ * next NNN-prefixed proposal under `proposals/active/`, refreshes the
+ * dashboard via `pnpm run docs:inject`, and stages the two mutated paths.
+ * All orchestration logic lives in `../utils/governance.ts`; this file is
+ * the thin CLI adapter that prints the user-facing summary.
+ */
+
+const TAG = 'Proposal';
+
+export interface ProposalNewOptions {
+  /** Override the cwd (test seam). Defaults to `process.cwd()`. */
+  cwd?: string;
+}
+
+export async function proposalNewCommand(
+  title: string,
+  options: ProposalNewOptions = {},
+): Promise<void> {
+  const path = await import('node:path');
+  const { log, bold } = await import('../ui.js');
+  const { scaffoldGovernanceArtifact } = await import('../utils/governance.js');
+
+  const cwd = options.cwd ?? process.cwd();
+  const result = scaffoldGovernanceArtifact({ type: 'proposal', title, cwd });
+
+  const relPath = path.relative(cwd, result.filePath);
+  const dashboardSummary = result.dashboardRefreshed
+    ? 'dashboard refreshed'
+    : 'dashboard refresh skipped (manual required)';
+  const stagedSummary = result.staged ? 'staged' : 'not staged (manual git add required)';
+
+  log.success(TAG, `Scaffolded ${bold(relPath)}; ${dashboardSummary}; ${stagedSummary}.`);
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -985,6 +985,38 @@ ruleCmd
     }
   });
 
+// ─── Proposal noun-verb subcommands ─────────────────────
+// mmnto/totem#1288: scaffold NNN-prefixed proposals in <strategy>/proposals/active/.
+const proposalCmd = program.command('proposal').description('Manage governance proposals');
+
+proposalCmd
+  .command('new <title>')
+  .description('Scaffold a new NNN-prefixed proposal under proposals/active/')
+  .action(async (title: string) => {
+    try {
+      const { proposalNewCommand } = await import('./commands/proposal.js');
+      await proposalNewCommand(title); // totem-context: handleError (catch below) is terminal — declared `: never` and exits via process.exit.
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+// ─── ADR noun-verb subcommands ──────────────────────────
+// mmnto/totem#1288: scaffold NNN-prefixed ADRs in <strategy>/adr/ per ADR-091 heading convention.
+const adrCmd = program.command('adr').description('Manage Architecture Decision Records');
+
+adrCmd
+  .command('new <title>')
+  .description('Scaffold a new NNN-prefixed ADR under adr/ (heading: `# ADR NNN: Title`)')
+  .action(async (title: string) => {
+    try {
+      const { adrNewCommand } = await import('./commands/adr.js');
+      await adrNewCommand(title); // totem-context: handleError (catch below) is terminal — declared `: never` and exits via process.exit.
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
 // ─── Config noun-verb subcommands ───────────────────────
 const configCmd = program.command('config').description('Read and manage project configuration');
 

--- a/packages/cli/src/utils/governance.test.ts
+++ b/packages/cli/src/utils/governance.test.ts
@@ -169,6 +169,34 @@ describe('formatArtifactFilename', () => {
   });
 });
 
+describe('sanitizeArtifactTitle', () => {
+  it('replaces newlines, tabs, and other C0 control characters with spaces', async () => {
+    const { sanitizeArtifactTitle } = await import('./governance.js');
+    expect(sanitizeArtifactTitle('Fix\n## Fake Heading')).toBe('Fix ## Fake Heading');
+    expect(sanitizeArtifactTitle('Multi\tline\rtext')).toBe('Multi line text');
+    expect(sanitizeArtifactTitle('bellecho')).toBe('bell echo');
+  });
+
+  it('strips DEL (0x7F)', async () => {
+    const { sanitizeArtifactTitle } = await import('./governance.js');
+    expect(sanitizeArtifactTitle('helloworld')).toBe('hello world');
+  });
+
+  it('collapses runs of whitespace and trims edges', async () => {
+    const { sanitizeArtifactTitle } = await import('./governance.js');
+    expect(sanitizeArtifactTitle('   multiple    spaces    ')).toBe('multiple spaces');
+  });
+
+  it('preserves `#` and other markdown-meaningful characters that stay single-line-safe', async () => {
+    const { sanitizeArtifactTitle } = await import('./governance.js');
+    // `#` inside a single-line heading is still part of the h1, so we don't strip it.
+    expect(sanitizeArtifactTitle('Add # char support')).toBe('Add # char support');
+    // Same for `$`, `{`, `}` — the template renderer uses a keyed replacer so
+    // these cannot inject further substitutions.
+    expect(sanitizeArtifactTitle('Handle $foo and {{X}}')).toBe('Handle $foo and {{X}}');
+  });
+});
+
 describe('renderArtifactTemplate', () => {
   let tmpDir: string;
 
@@ -351,8 +379,8 @@ describe('runPostScaffoldHooks', () => {
 
   it('stages artifact and readme without crashing if docs:inject fails', async () => {
     const warnings: string[] = [];
-    const origWarn = console.warn;
-    console.warn = (msg: unknown) => {
+    const origWarn = console.error;
+    console.error = (msg: unknown) => {
       warnings.push(String(msg));
     };
 
@@ -383,14 +411,14 @@ describe('runPostScaffoldHooks', () => {
       const combined = warnings.join('\n');
       expect(combined).toMatch(/docs:inject/i);
     } finally {
-      console.warn = origWarn;
+      console.error = origWarn;
     }
   });
 
   it('reports staged:false when git add fails but does not throw', async () => {
     const warnings: string[] = [];
-    const origWarn = console.warn;
-    console.warn = (msg: unknown) => {
+    const origWarn = console.error;
+    console.error = (msg: unknown) => {
       warnings.push(String(msg));
     };
 
@@ -413,7 +441,7 @@ describe('runPostScaffoldHooks', () => {
       expect(result.staged).toBe(false);
       expect(warnings.join('\n')).toMatch(/stage|git add/i);
     } finally {
-      console.warn = origWarn;
+      console.error = origWarn;
     }
   });
 });
@@ -487,12 +515,48 @@ describe('scaffoldGovernanceArtifact (orchestrator)', () => {
     expect(written).not.toContain('# ADR-001');
   });
 
+  it('sanitizes titles carrying newlines or control characters before templating', async () => {
+    // Caught by CodeRabbit on PR #1615. A title with embedded newlines
+    // would otherwise inject fresh markdown blocks into the scaffolded
+    // artifact. Orchestrator sanitizes at the entry so both filename and
+    // template body see the cleaned form.
+    initGit(tmpDir);
+    fs.mkdirSync(path.join(tmpDir, 'proposals', 'active'), { recursive: true });
+
+    const exec = (): void => {};
+
+    const { scaffoldGovernanceArtifact } = await import('./governance.js');
+    const result = scaffoldGovernanceArtifact(
+      {
+        type: 'proposal',
+        title: 'Fix the thing\n## Injected Fake Heading\n- Not a real list',
+        cwd: tmpDir,
+      },
+      { exec, date: '2026-04-22' },
+    );
+
+    const written = fs.readFileSync(result.filePath, 'utf-8');
+    // Heading is a single line; no injected newline-bounded blocks.
+    const lines = written.split('\n');
+    expect(lines[0]).toBe(
+      '# Proposal 001: Fix the thing ## Injected Fake Heading - Not a real list',
+    );
+    // Ensure no fresh `##` heading or `-` list item appears at line-start
+    // anywhere in the body above the template's own `## Problem Statement`.
+    const bodyLines = lines.slice(
+      0,
+      lines.findIndex((l) => l === '## Problem Statement'),
+    );
+    const injectedHeading = bodyLines.find((l, i) => i > 0 && l.startsWith('## '));
+    expect(injectedHeading).toBeUndefined();
+  });
+
   it('creates file on disk even when docs:inject is missing', async () => {
     initGit(tmpDir);
     fs.mkdirSync(path.join(tmpDir, 'proposals', 'active'), { recursive: true });
 
-    const origWarn = console.warn;
-    console.warn = () => {};
+    const origWarn = console.error;
+    console.error = () => {};
     try {
       const exec = (cmd: string, args: string[]): void => {
         if (cmd === 'pnpm' && args.includes('docs:inject')) {
@@ -510,7 +574,7 @@ describe('scaffoldGovernanceArtifact (orchestrator)', () => {
       // File must still be on disk despite docs:inject failing.
       expect(fs.existsSync(result.filePath)).toBe(true);
     } finally {
-      console.warn = origWarn;
+      console.error = origWarn;
     }
   });
 

--- a/packages/cli/src/utils/governance.test.ts
+++ b/packages/cli/src/utils/governance.test.ts
@@ -7,7 +7,12 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { cleanTmpDir } from '../test-utils.js';
 
 function makeTmpDir(prefix = 'totem-gov-'): string {
-  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  // Canonicalize via realpathSync so `/tmp -> /private/tmp` on macOS and
+  // Windows short-name `RUNNER~1` paths both collapse to the same form
+  // `git rev-parse --show-toplevel` returns. Without this, path-equality
+  // assertions fail on macos-latest and windows-latest CI runners while
+  // passing on ubuntu.
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
 }
 
 function initGit(dir: string): void {

--- a/packages/cli/src/utils/governance.test.ts
+++ b/packages/cli/src/utils/governance.test.ts
@@ -281,6 +281,30 @@ describe('renderArtifactTemplate', () => {
 
     expect(rendered).toBe('# Fix $foo and $& and $1 in ledger\n');
   });
+
+  it('resists template-token injection from user-provided title (single-pass)', async () => {
+    // A naive sequential-replace implementation substitutes `{{DATE}}` from
+    // the title in pass 1, then the pass-2 DATE regex matches the freshly-
+    // inserted `{{DATE}}` and swaps in the date value. GCA caught this on
+    // PR #1615. Single-pass regex with keyed lookup eliminates the class.
+    const tplDir = path.join(tmpDir, 'templates');
+    fs.mkdirSync(tplDir, { recursive: true });
+    const tplPath = path.join(tplDir, 'adr.md');
+    fs.writeFileSync(tplPath, '{{TITLE}} / {{DATE}}\n', 'utf-8');
+
+    const { renderArtifactTemplate } = await import('./governance.js');
+    const rendered = renderArtifactTemplate({
+      type: 'adr',
+      id: '001',
+      title: '{{DATE}}',
+      templatePath: tplPath,
+      date: '2026-04-22',
+    });
+
+    // Title stays literal. The `{{DATE}}` in the template body resolves;
+    // the `{{DATE}}` inside the title does NOT.
+    expect(rendered).toBe('{{DATE}} / 2026-04-22\n');
+  });
 });
 
 describe('runPostScaffoldHooks', () => {

--- a/packages/cli/src/utils/governance.test.ts
+++ b/packages/cli/src/utils/governance.test.ts
@@ -7,12 +7,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { cleanTmpDir } from '../test-utils.js';
 
 function makeTmpDir(prefix = 'totem-gov-'): string {
-  // Canonicalize via realpathSync so `/tmp -> /private/tmp` on macOS and
-  // Windows short-name `RUNNER~1` paths both collapse to the same form
-  // `git rev-parse --show-toplevel` returns. Without this, path-equality
-  // assertions fail on macos-latest and windows-latest CI runners while
-  // passing on ubuntu.
-  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
+  // Canonicalize via `realpathSync.native` so the tmp path collapses to the
+  // same form `git rev-parse --show-toplevel` returns. `.native` is required
+  // because plain `realpathSync` resolves POSIX symlinks (macOS `/tmp ->
+  // /private/tmp`) but NOT Windows 8.3 short names (`C:\Users\RUNNER~1\...`
+  // → `C:\Users\runneradmin\...`). Without `.native`, path-equality
+  // assertions fail on windows-latest CI while passing on macos and ubuntu.
+  return fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), prefix)));
 }
 
 function initGit(dir: string): void {

--- a/packages/cli/src/utils/governance.test.ts
+++ b/packages/cli/src/utils/governance.test.ts
@@ -1,0 +1,544 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { cleanTmpDir } from '../test-utils.js';
+
+function makeTmpDir(prefix = 'totem-gov-'): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function initGit(dir: string): void {
+  // Minimal git scaffold to satisfy `git rev-parse --show-toplevel`.
+  fs.mkdirSync(path.join(dir, '.git'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.git', 'HEAD'), 'ref: refs/heads/main\n', 'utf-8');
+  fs.writeFileSync(
+    path.join(dir, '.git', 'config'),
+    '[core]\n\trepositoryformatversion = 0\n',
+    'utf-8',
+  );
+  fs.mkdirSync(path.join(dir, '.git', 'objects'), { recursive: true });
+  fs.mkdirSync(path.join(dir, '.git', 'refs', 'heads'), { recursive: true });
+}
+
+describe('resolveGovernancePaths', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    cleanTmpDir(tmpDir);
+  });
+
+  it('resolves submodule strategy path when `.strategy/` exists alongside cwd', async () => {
+    initGit(tmpDir);
+    const strategyDir = path.join(tmpDir, '.strategy');
+    fs.mkdirSync(path.join(strategyDir, 'proposals', 'active'), { recursive: true });
+    fs.mkdirSync(path.join(strategyDir, 'adr'), { recursive: true });
+
+    const { resolveGovernancePaths } = await import('./governance.js');
+    const paths = resolveGovernancePaths(tmpDir, 'proposal');
+
+    expect(paths.rootDir).toBe(path.normalize(strategyDir));
+    expect(paths.targetDir).toBe(path.normalize(path.join(strategyDir, 'proposals', 'active')));
+    expect(paths.dashboardFile).toBe(path.normalize(path.join(strategyDir, 'README.md')));
+    expect(paths.templatePath).toBe(
+      path.normalize(path.join(strategyDir, 'templates', 'proposal.md')),
+    );
+  });
+
+  it('resolves standalone strategy path when submodule prefix is missing', async () => {
+    initGit(tmpDir);
+    // Standalone strategy repo — `proposals/active/` lives at the git root, no `.strategy/` prefix.
+    fs.mkdirSync(path.join(tmpDir, 'proposals', 'active'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'adr'), { recursive: true });
+
+    const { resolveGovernancePaths } = await import('./governance.js');
+    const paths = resolveGovernancePaths(tmpDir, 'adr');
+
+    expect(paths.rootDir).toBe(path.normalize(tmpDir));
+    expect(paths.targetDir).toBe(path.normalize(path.join(tmpDir, 'adr')));
+    expect(paths.dashboardFile).toBe(path.normalize(path.join(tmpDir, 'README.md')));
+    expect(paths.templatePath).toBe(path.normalize(path.join(tmpDir, 'templates', 'adr.md')));
+  });
+
+  it('throws TotemError when cwd is not inside a git repository', async () => {
+    // tmpDir has no `.git/`; resolveGitRoot returns null.
+    const { resolveGovernancePaths } = await import('./governance.js');
+    expect(() => resolveGovernancePaths(tmpDir, 'proposal')).toThrow(/not inside a git repo/i);
+  });
+
+  it('throws TotemError when no strategy layout is found', async () => {
+    initGit(tmpDir);
+    // Neither `.strategy/proposals/` nor top-level `proposals/`.
+    const { resolveGovernancePaths } = await import('./governance.js');
+    expect(() => resolveGovernancePaths(tmpDir, 'proposal')).toThrow(/strategy/i);
+  });
+});
+
+describe('getNextArtifactId', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir('totem-gov-id-');
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  it('returns 001 when target directory is empty', async () => {
+    const { getNextArtifactId } = await import('./governance.js');
+    expect(getNextArtifactId(tmpDir)).toBe('001');
+  });
+
+  it('returns 001 when target directory does not exist', async () => {
+    const missing = path.join(tmpDir, 'never-created');
+    const { getNextArtifactId } = await import('./governance.js');
+    expect(getNextArtifactId(missing)).toBe('001');
+  });
+
+  it('calculates correct next id when numerical gaps exist in directory', async () => {
+    // Seed with 001 and 003 — next must be 004, NOT 002 (gap logic).
+    fs.writeFileSync(path.join(tmpDir, '001-a.md'), '# A\n', 'utf-8');
+    fs.writeFileSync(path.join(tmpDir, '003-b.md'), '# B\n', 'utf-8');
+    const { getNextArtifactId } = await import('./governance.js');
+    expect(getNextArtifactId(tmpDir)).toBe('004');
+  });
+
+  it('ignores files that do not match the NNN-title.md pattern', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'README.md'), '# R\n', 'utf-8');
+    fs.writeFileSync(path.join(tmpDir, 'notes.txt'), 'x', 'utf-8');
+    fs.writeFileSync(path.join(tmpDir, '42-not-padded.md'), '# x\n', 'utf-8');
+    fs.writeFileSync(path.join(tmpDir, '010-valid.md'), '# v\n', 'utf-8');
+    const { getNextArtifactId } = await import('./governance.js');
+    expect(getNextArtifactId(tmpDir)).toBe('011');
+  });
+
+  it('throws when NNN-prefix space is saturated (>999)', async () => {
+    fs.writeFileSync(path.join(tmpDir, '999-final.md'), '# x\n', 'utf-8');
+    const { getNextArtifactId } = await import('./governance.js');
+    expect(() => getNextArtifactId(tmpDir)).toThrow(/saturated|overflow|999/i);
+  });
+});
+
+describe('formatArtifactFilename', () => {
+  it('produces kebab-case with NNN- prefix', async () => {
+    const { formatArtifactFilename } = await import('./governance.js');
+    expect(formatArtifactFilename('001', 'Feature Branch Workflow')).toBe(
+      '001-feature-branch-workflow.md',
+    );
+  });
+
+  it('sanitizes special characters into hyphens', async () => {
+    const { formatArtifactFilename } = await import('./governance.js');
+    expect(formatArtifactFilename('042', 'LLM caching (v2) / Verifier')).toBe(
+      '042-llm-caching-v2-verifier.md',
+    );
+  });
+
+  it('is deterministic across runs for the same title', async () => {
+    const { formatArtifactFilename } = await import('./governance.js');
+    const a = formatArtifactFilename('007', 'Totem Ingestion Pipeline');
+    const b = formatArtifactFilename('007', 'Totem Ingestion Pipeline');
+    expect(a).toBe(b);
+    expect(a).toBe('007-totem-ingestion-pipeline.md');
+  });
+
+  it('throws when title sanitization produces an empty slug', async () => {
+    const { formatArtifactFilename } = await import('./governance.js');
+    expect(() => formatArtifactFilename('001', '!!!---???')).toThrow(/empty slug/i);
+  });
+
+  it('collapses runs of hyphens and trims leading/trailing hyphens', async () => {
+    const { formatArtifactFilename } = await import('./governance.js');
+    expect(formatArtifactFilename('050', '  ---Alpha   Beta---  ')).toBe('050-alpha-beta.md');
+  });
+});
+
+describe('renderArtifactTemplate', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir('totem-gov-tpl-');
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  it('generates fallback template when physical template file is missing', async () => {
+    const missingTemplate = path.join(tmpDir, 'templates', 'proposal.md');
+    const { renderArtifactTemplate } = await import('./governance.js');
+    const rendered = renderArtifactTemplate({
+      type: 'proposal',
+      id: '005',
+      title: 'Ingestion Pipeline',
+      templatePath: missingTemplate,
+      date: '2026-04-21',
+    });
+
+    // Exact heading form for Proposals per ADR-091 — space separator.
+    expect(rendered).toContain('# Proposal 005: Ingestion Pipeline');
+    expect(rendered).toContain('**Status:** Draft');
+    expect(rendered).toContain('**Date:** 2026-04-21');
+  });
+
+  it('emits `# ADR NNN: Title` heading with space separator for adr type', async () => {
+    const { renderArtifactTemplate } = await import('./governance.js');
+    const rendered = renderArtifactTemplate({
+      type: 'adr',
+      id: '091',
+      title: 'Five-Stage Ingestion',
+      templatePath: path.join(tmpDir, 'nonexistent.md'),
+      date: '2026-04-21',
+    });
+
+    expect(rendered).toContain('# ADR 091: Five-Stage Ingestion');
+    // Defensive: must NOT use a hyphen separator (common GPT-style slip).
+    expect(rendered).not.toContain('# ADR-091');
+    expect(rendered).not.toContain('# ADR 091 -');
+    expect(rendered).toContain('**Status:** Draft');
+    expect(rendered).toContain('**Date:** 2026-04-21');
+  });
+
+  it('reads from disk and substitutes {{TITLE}} and {{DATE}} when template exists', async () => {
+    const tplDir = path.join(tmpDir, 'templates');
+    fs.mkdirSync(tplDir, { recursive: true });
+    const tplPath = path.join(tplDir, 'proposal.md');
+    fs.writeFileSync(
+      tplPath,
+      '# Proposal: {{TITLE}}\n\n**Date:** {{DATE}}\n\nBody here.\n',
+      'utf-8',
+    );
+
+    const { renderArtifactTemplate } = await import('./governance.js');
+    const rendered = renderArtifactTemplate({
+      type: 'proposal',
+      id: '012',
+      title: 'Example',
+      templatePath: tplPath,
+      date: '2026-04-21',
+    });
+
+    expect(rendered).toContain('# Proposal: Example');
+    expect(rendered).toContain('**Date:** 2026-04-21');
+    expect(rendered).not.toContain('{{TITLE}}');
+    expect(rendered).not.toContain('{{DATE}}');
+  });
+
+  it('replaces ALL occurrences of template variables', async () => {
+    const tplDir = path.join(tmpDir, 'templates');
+    fs.mkdirSync(tplDir, { recursive: true });
+    const tplPath = path.join(tplDir, 'adr.md');
+    fs.writeFileSync(tplPath, '{{TITLE}} / {{TITLE}} / {{DATE}} / {{DATE}}\n', 'utf-8');
+
+    const { renderArtifactTemplate } = await import('./governance.js');
+    const rendered = renderArtifactTemplate({
+      type: 'adr',
+      id: '001',
+      title: 'X',
+      templatePath: tplPath,
+      date: '2026-04-21',
+    });
+
+    // Both occurrences of each variable should be substituted.
+    expect(rendered).toBe('X / X / 2026-04-21 / 2026-04-21\n');
+  });
+});
+
+describe('runPostScaffoldHooks', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir('totem-gov-hooks-');
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  it('runs docs:inject then git add on the two target paths', async () => {
+    const calls: Array<{ cmd: string; args: string[]; cwd?: string }> = [];
+    const exec = (cmd: string, args: string[], cwdArg?: string): void => {
+      calls.push({ cmd, args, cwd: cwdArg });
+    };
+
+    const { runPostScaffoldHooks } = await import('./governance.js');
+    const result = runPostScaffoldHooks({
+      rootDir: tmpDir,
+      newFilePath: path.join(tmpDir, 'proposals', 'active', '001-x.md'),
+      dashboardFile: path.join(tmpDir, 'README.md'),
+      exec,
+    });
+
+    expect(result.dashboardRefreshed).toBe(true);
+    expect(result.staged).toBe(true);
+    expect(calls).toHaveLength(2);
+    expect(calls[0]!.cmd).toBe('pnpm');
+    expect(calls[0]!.args).toEqual(['run', 'docs:inject']);
+    expect(calls[0]!.cwd).toBe(tmpDir);
+    expect(calls[1]!.cmd).toBe('git');
+    // git add must stage ONLY the two specific paths, never `-A` or `.`.
+    expect(calls[1]!.args[0]).toBe('add');
+    expect(calls[1]!.args.slice(1)).toEqual([
+      path.join(tmpDir, 'proposals', 'active', '001-x.md'),
+      path.join(tmpDir, 'README.md'),
+    ]);
+    expect(calls[1]!.args).not.toContain('-A');
+    expect(calls[1]!.args).not.toContain('.');
+  });
+
+  it('stages artifact and readme without crashing if docs:inject fails', async () => {
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (msg: unknown) => {
+      warnings.push(String(msg));
+    };
+
+    try {
+      const calls: Array<{ cmd: string; args: string[] }> = [];
+      const exec = (cmd: string, args: string[]): void => {
+        calls.push({ cmd, args });
+        if (cmd === 'pnpm' && args.includes('docs:inject')) {
+          throw new Error('Command failed: pnpm run docs:inject\nMissing script: docs:inject');
+        }
+      };
+
+      const { runPostScaffoldHooks } = await import('./governance.js');
+      const result = runPostScaffoldHooks({
+        rootDir: tmpDir,
+        newFilePath: path.join(tmpDir, 'proposals', 'active', '001-x.md'),
+        dashboardFile: path.join(tmpDir, 'README.md'),
+        exec,
+      });
+
+      expect(result.dashboardRefreshed).toBe(false);
+      // git add still ran despite docs:inject failure (the artifact exists).
+      expect(result.staged).toBe(true);
+      const gitCall = calls.find((c) => c.cmd === 'git');
+      expect(gitCall).toBeDefined();
+      expect(gitCall!.args[0]).toBe('add');
+      // A warning surfaced about the missing script.
+      const combined = warnings.join('\n');
+      expect(combined).toMatch(/docs:inject/i);
+    } finally {
+      console.warn = origWarn;
+    }
+  });
+
+  it('reports staged:false when git add fails but does not throw', async () => {
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (msg: unknown) => {
+      warnings.push(String(msg));
+    };
+
+    try {
+      const exec = (cmd: string, args: string[]): void => {
+        if (cmd === 'git' && args[0] === 'add') {
+          throw new Error('fatal: pathspec did not match any files');
+        }
+      };
+
+      const { runPostScaffoldHooks } = await import('./governance.js');
+      const result = runPostScaffoldHooks({
+        rootDir: tmpDir,
+        newFilePath: path.join(tmpDir, 'proposals', 'active', '001-x.md'),
+        dashboardFile: path.join(tmpDir, 'README.md'),
+        exec,
+      });
+
+      expect(result.dashboardRefreshed).toBe(true);
+      expect(result.staged).toBe(false);
+      expect(warnings.join('\n')).toMatch(/stage|git add/i);
+    } finally {
+      console.warn = origWarn;
+    }
+  });
+});
+
+describe('scaffoldGovernanceArtifact (orchestrator)', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir('totem-gov-orch-');
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    cleanTmpDir(tmpDir);
+  });
+
+  it('creates file on disk with proposal heading and default Status/Date', async () => {
+    initGit(tmpDir);
+    fs.mkdirSync(path.join(tmpDir, 'proposals', 'active'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'adr'), { recursive: true });
+
+    const calls: Array<{ cmd: string; args: string[] }> = [];
+    const exec = (cmd: string, args: string[]): void => {
+      calls.push({ cmd, args });
+    };
+
+    const { scaffoldGovernanceArtifact } = await import('./governance.js');
+    const result = scaffoldGovernanceArtifact(
+      {
+        type: 'proposal',
+        title: 'Feature Branch Workflow',
+        cwd: tmpDir,
+      },
+      { exec, date: '2026-04-21' },
+    );
+
+    expect(result.filename).toBe('001-feature-branch-workflow.md');
+    expect(result.id).toBe('001');
+    expect(result.dashboardRefreshed).toBe(true);
+    expect(result.staged).toBe(true);
+
+    const written = fs.readFileSync(result.filePath, 'utf-8');
+    expect(written).toContain('# Proposal 001: Feature Branch Workflow');
+    expect(written).toContain('**Status:** Draft');
+    expect(written).toContain('**Date:** 2026-04-21');
+
+    // git add ran with exactly the two paths.
+    const gitCall = calls.find((c) => c.cmd === 'git');
+    expect(gitCall!.args).toEqual(['add', result.filePath, path.join(tmpDir, 'README.md')]);
+  });
+
+  it('creates file on disk with adr heading (space separator)', async () => {
+    initGit(tmpDir);
+    fs.mkdirSync(path.join(tmpDir, 'proposals', 'active'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'adr'), { recursive: true });
+
+    const exec = (): void => {};
+
+    const { scaffoldGovernanceArtifact } = await import('./governance.js');
+    const result = scaffoldGovernanceArtifact(
+      { type: 'adr', title: 'Database Sharding', cwd: tmpDir },
+      { exec, date: '2026-04-21' },
+    );
+
+    expect(result.filename).toBe('001-database-sharding.md');
+    const written = fs.readFileSync(result.filePath, 'utf-8');
+    // ADR-091 heading form with SPACE separator.
+    expect(written).toContain('# ADR 001: Database Sharding');
+    expect(written).not.toContain('# ADR-001');
+  });
+
+  it('creates file on disk even when docs:inject is missing', async () => {
+    initGit(tmpDir);
+    fs.mkdirSync(path.join(tmpDir, 'proposals', 'active'), { recursive: true });
+
+    const origWarn = console.warn;
+    console.warn = () => {};
+    try {
+      const exec = (cmd: string, args: string[]): void => {
+        if (cmd === 'pnpm' && args.includes('docs:inject')) {
+          throw new Error('Missing script: "docs:inject"');
+        }
+      };
+
+      const { scaffoldGovernanceArtifact } = await import('./governance.js');
+      const result = scaffoldGovernanceArtifact(
+        { type: 'proposal', title: 'Test', cwd: tmpDir },
+        { exec, date: '2026-04-21' },
+      );
+
+      expect(result.dashboardRefreshed).toBe(false);
+      // File must still be on disk despite docs:inject failing.
+      expect(fs.existsSync(result.filePath)).toBe(true);
+    } finally {
+      console.warn = origWarn;
+    }
+  });
+
+  it('respects gap numbering when seeding 001 + 003 (next is 004)', async () => {
+    initGit(tmpDir);
+    const target = path.join(tmpDir, 'proposals', 'active');
+    fs.mkdirSync(target, { recursive: true });
+    fs.writeFileSync(path.join(target, '001-alpha.md'), '# a\n', 'utf-8');
+    fs.writeFileSync(path.join(target, '003-beta.md'), '# b\n', 'utf-8');
+
+    const { scaffoldGovernanceArtifact } = await import('./governance.js');
+    const result = scaffoldGovernanceArtifact(
+      { type: 'proposal', title: 'Gamma', cwd: tmpDir },
+      { exec: () => {}, date: '2026-04-21' },
+    );
+
+    expect(result.id).toBe('004');
+    expect(result.filename).toBe('004-gamma.md');
+  });
+
+  it('throws TotemError on exact filename collision without overwriting', async () => {
+    initGit(tmpDir);
+    const target = path.join(tmpDir, 'proposals', 'active');
+    fs.mkdirSync(target, { recursive: true });
+    // Seed with the exact filename the scaffolder would generate for this title:
+    // id=001 + slug='collide' ⇒ '001-collide.md'. We force this by ALSO seeding a
+    // higher-numbered file so getNextArtifactId returns 002, then we seed 002-collide.md
+    // so the collision path fires. Simpler: seed 001-keep-slot.md then 002-collide.md
+    // and ask for title 'Collide' — next id is 003, no collision. To force one, we
+    // patch the target so 001 is empty-of-slug but we put a pre-existing file at
+    // the exact next path:
+    const existingPath = path.join(target, '001-collide.md');
+    fs.writeFileSync(existingPath, 'ORIGINAL CONTENT — DO NOT OVERWRITE\n', 'utf-8');
+    // Drop a higher-numbered file so `getNextArtifactId` yields 002, NOT 001.
+    // Wait — this test is about EXACT collision. Reset: we want the computed
+    // filename to equal an existing file. The way to force that is to mock
+    // `getNextArtifactId` — but we don't have DI there. Instead, we seed:
+    //   001-collide.md  (existing, will collide)
+    // and DELETE other files so next id would also be 001? No — next id is
+    // always max+1. So for exact collision we need the slug AND id to match
+    // a pre-existing file. Since id is always new, collision only happens if
+    // a NNN-slug.md with the same slug as our title already exists at the
+    // computed id. That can't happen via getNextArtifactId alone — UNLESS
+    // we allow the test to reach in via the `forceId` seam (test-only).
+    //
+    // Expose an optional `forceId` injection for deterministic collision tests.
+    fs.writeFileSync(path.join(target, '002-other.md'), '# other\n', 'utf-8');
+
+    const { scaffoldGovernanceArtifact } = await import('./governance.js');
+    expect(() =>
+      scaffoldGovernanceArtifact(
+        { type: 'proposal', title: 'Collide', cwd: tmpDir },
+        { exec: () => {}, date: '2026-04-21', forceId: '001' },
+      ),
+    ).toThrow(/already exists/i);
+
+    // Original content preserved.
+    expect(fs.readFileSync(existingPath, 'utf-8')).toBe('ORIGINAL CONTENT — DO NOT OVERWRITE\n');
+  });
+
+  it('throws TotemError BEFORE touching disk when title sanitizes to empty', async () => {
+    initGit(tmpDir);
+    fs.mkdirSync(path.join(tmpDir, 'proposals', 'active'), { recursive: true });
+
+    const execCalls: string[] = [];
+    const exec = (cmd: string): void => {
+      execCalls.push(cmd);
+    };
+
+    const { scaffoldGovernanceArtifact } = await import('./governance.js');
+    expect(() =>
+      scaffoldGovernanceArtifact(
+        { type: 'proposal', title: '???', cwd: tmpDir },
+        { exec, date: '2026-04-21' },
+      ),
+    ).toThrow(/empty slug/i);
+
+    // No hooks ran — failure fired before exec seam was reached.
+    expect(execCalls).toEqual([]);
+    // No files written.
+    const entries = fs.readdirSync(path.join(tmpDir, 'proposals', 'active'));
+    expect(entries).toEqual([]);
+  });
+});

--- a/packages/cli/src/utils/governance.test.ts
+++ b/packages/cli/src/utils/governance.test.ts
@@ -252,6 +252,29 @@ describe('renderArtifactTemplate', () => {
     // Both occurrences of each variable should be substituted.
     expect(rendered).toBe('X / X / 2026-04-21 / 2026-04-21\n');
   });
+
+  it('renders titles containing `$` characters literally (no back-reference interpretation)', async () => {
+    // `String.prototype.replace` interprets `$&`, `$1`, etc. in the
+    // replacement string as back-references. Titles can legitimately
+    // contain `$` (prices, shell variable names, etc.) and must not be
+    // mangled. The implementation uses a replacer-function form to dodge
+    // this trap; see PR #1429 for the canonical bug class.
+    const tplDir = path.join(tmpDir, 'templates');
+    fs.mkdirSync(tplDir, { recursive: true });
+    const tplPath = path.join(tplDir, 'proposal.md');
+    fs.writeFileSync(tplPath, '# {{TITLE}}\n', 'utf-8');
+
+    const { renderArtifactTemplate } = await import('./governance.js');
+    const rendered = renderArtifactTemplate({
+      type: 'proposal',
+      id: '001',
+      title: 'Fix $foo and $& and $1 in ledger',
+      templatePath: tplPath,
+      date: '2026-04-22',
+    });
+
+    expect(rendered).toBe('# Fix $foo and $& and $1 in ledger\n');
+  });
 });
 
 describe('runPostScaffoldHooks', () => {

--- a/packages/cli/src/utils/governance.ts
+++ b/packages/cli/src/utils/governance.ts
@@ -418,7 +418,12 @@ export function scaffoldGovernanceArtifact(
   const filename = formatArtifactFilename(id, cleanTitle);
   const filePath = path.join(paths.targetDir, filename);
 
-  // Collision guard — hard error per spec (no --force, no auto-bump).
+  // Collision pre-check gives a clean user-facing error on the common path.
+  // The authoritative collision guard is the `flag: 'wx'` on `writeFileSync`
+  // below, which closes the TOCTOU race between the pre-check and the write
+  // (a concurrent scaffolder could slip in between the two). Keeping both
+  // gives a nice error when the file already exists AND safety against the
+  // narrow race window.
   if (fs.existsSync(filePath)) {
     throw new TotemError(
       'CONFIG_INVALID',
@@ -439,7 +444,20 @@ export function scaffoldGovernanceArtifact(
   // Ensure parent dir exists (it should, from resolveGovernancePaths, but
   // cheap to defend against a manually-pruned target).
   fs.mkdirSync(paths.targetDir, { recursive: true });
-  fs.writeFileSync(filePath, rendered, 'utf-8');
+  try {
+    // `flag: 'wx'` = write exclusive. Atomic fail with EEXIST if the file
+    // was created between the pre-check and now. Closes the TOCTOU race.
+    fs.writeFileSync(filePath, rendered, { encoding: 'utf-8', flag: 'wx' });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+      throw new TotemError(
+        'CONFIG_INVALID',
+        `Artifact already exists at ${filePath}.`,
+        'A concurrent scaffolder created this file between the pre-check and the write. Re-run the command to pick up a fresh NNN.',
+      );
+    }
+    throw err;
+  }
 
   const hookResult = runPostScaffoldHooks({
     rootDir: paths.rootDir,

--- a/packages/cli/src/utils/governance.ts
+++ b/packages/cli/src/utils/governance.ts
@@ -12,6 +12,8 @@ import * as path from 'node:path';
 
 import { resolveGitRoot, safeExec, TotemError } from '@mmnto/totem';
 
+import { log } from '../ui.js';
+
 export type GovernanceType = 'proposal' | 'adr';
 
 export interface ScaffoldOptions {
@@ -163,6 +165,28 @@ export function formatArtifactFilename(id: string, title: string): string {
   return `${id}-${slug}.md`;
 }
 
+/**
+ * Sanitize a raw title for safe inclusion in the scaffolded markdown body.
+ *
+ * Strips C0 control characters and `DEL` (0x00-0x1F, 0x7F) — most notably
+ * newlines, carriage returns, and tabs — then collapses any remaining run
+ * of whitespace to a single space and trims the edges. Without this pass,
+ * a title like `Fix\n## Fake Heading` would inject a fresh markdown block
+ * into the scaffolded artifact, shifting document structure out of the
+ * scaffolder's control. The `#` character itself is allowed through on
+ * purpose: a single-line heading that contains `#` characters stays a
+ * single h1 heading in markdown.
+ */
+export function sanitizeArtifactTitle(title: string): string {
+  return (
+    title
+      // eslint-disable-next-line no-control-regex -- intentional: strip ASCII C0 controls + DEL
+      .replace(/[\x00-\x1F\x7F]+/g, ' ')
+      .replace(/\s+/g, ' ')
+      .trim()
+  );
+}
+
 // ─── Template engine ────────────────────────────────────
 
 /**
@@ -308,9 +332,9 @@ export function runPostScaffoldHooks(opts: PostScaffoldHookOptions): PostScaffol
     dashboardRefreshed = true; // totem-context: intentional warn-and-continue per spec 1288 — dashboard refresh failure must not strand the scaffolded artifact on disk.
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    // eslint-disable-next-line no-console -- intentional stderr warning per spec
-    console.warn(
-      `[Totem Warning] docs:inject did not run cleanly (${msg}). Dashboard not refreshed; run 'pnpm run docs:inject' manually.`,
+    log.warn(
+      'Totem',
+      `docs:inject did not run cleanly (${msg}). Dashboard not refreshed; run 'pnpm run docs:inject' manually.`,
     );
   }
 
@@ -320,9 +344,9 @@ export function runPostScaffoldHooks(opts: PostScaffoldHookOptions): PostScaffol
     staged = true; // totem-context: intentional warn-and-continue per spec 1288 — git add failure must not strand the scaffolded artifact on disk.
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    // eslint-disable-next-line no-console -- intentional stderr warning per spec
-    console.warn(
-      `[Totem Warning] git add failed (${msg}). File created but not staged; run 'git add' manually.`,
+    log.warn(
+      'Totem',
+      `git add failed (${msg}). File created but not staged; run 'git add' manually.`,
     );
   }
 
@@ -384,8 +408,14 @@ export function scaffoldGovernanceArtifact(
 ): ScaffoldArtifactResult {
   const paths = resolveGovernancePaths(options.cwd, options.type);
 
+  // Sanitize once at the orchestrator entry. Both the filename slug and the
+  // template body render against the cleaned form so a title carrying
+  // newlines, tabs, or control characters cannot inject markdown blocks
+  // into the scaffolded artifact.
+  const cleanTitle = sanitizeArtifactTitle(options.title);
+
   const id = internals.forceId ?? getNextArtifactId(paths.targetDir);
-  const filename = formatArtifactFilename(id, options.title);
+  const filename = formatArtifactFilename(id, cleanTitle);
   const filePath = path.join(paths.targetDir, filename);
 
   // Collision guard — hard error per spec (no --force, no auto-bump).
@@ -401,7 +431,7 @@ export function scaffoldGovernanceArtifact(
   const rendered = renderArtifactTemplate({
     type: options.type,
     id,
-    title: options.title,
+    title: cleanTitle,
     templatePath: paths.templatePath,
     date,
   });

--- a/packages/cli/src/utils/governance.ts
+++ b/packages/cli/src/utils/governance.ts
@@ -244,13 +244,16 @@ export function renderArtifactTemplate(opts: RenderTemplateOptions): string {
     template = type === 'proposal' ? DEFAULT_PROPOSAL_TEMPLATE : DEFAULT_ADR_TEMPLATE;
   }
 
-  // Replacer-function form avoids the `$&` / `$1` back-reference trap in
-  // `String.prototype.replace`'s string-replacement mode. A title like
-  // `Fix $foo bug` would otherwise mis-render. See PR #1429 review cycle.
-  return template
-    .replace(/\{\{TITLE\}\}/g, () => title)
-    .replace(/\{\{DATE\}\}/g, () => date)
-    .replace(/\{\{ID\}\}/g, () => id);
+  // Single-pass regex + keyed replacer function. Two reasons:
+  //   1. Sequential `.replace()` calls allow template injection (a title of
+  //      `{{DATE}}` would be substituted into the template and then picked
+  //      up by the next pass as an actual DATE token). One pass eliminates
+  //      that class of bug.
+  //   2. The replacer-function form avoids `$&` / `$1` back-reference
+  //      interpretation in the replacement string (see PR #1429 review
+  //      cycle). A title like `Fix $foo bug` mis-renders otherwise.
+  const replacements: Record<string, string> = { TITLE: title, DATE: date, ID: id };
+  return template.replace(/\{\{(TITLE|DATE|ID)\}\}/g, (_match, key) => replacements[key]!);
 }
 
 // ─── Post-scaffold hooks ────────────────────────────────

--- a/packages/cli/src/utils/governance.ts
+++ b/packages/cli/src/utils/governance.ts
@@ -1,0 +1,423 @@
+/**
+ * Governance-artifact scaffolding utilities (mmnto/totem#1288).
+ *
+ * Shared helpers for the `totem proposal new` and `totem adr new` commands.
+ * Nothing in this module carries module-level state — every helper takes
+ * its context via arguments so the tests can exercise both the submodule
+ * (`<totem>/.strategy/`) and the standalone (strategy-repo root) cases.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { resolveGitRoot, safeExec, TotemError } from '@mmnto/totem';
+
+export type GovernanceType = 'proposal' | 'adr';
+
+export interface ScaffoldOptions {
+  type: GovernanceType;
+  title: string;
+  cwd: string;
+}
+
+export interface GovernancePaths {
+  /** Directory that anchors the governance layout (strategy repo root or submodule root). */
+  rootDir: string;
+  /** Directory that holds the NNN-prefixed artifact files. */
+  targetDir: string;
+  /** On-disk template path. May not exist; caller falls back to the hardcoded default. */
+  templatePath: string;
+  /** Dashboard README refreshed by `docs:inject`. */
+  dashboardFile: string;
+}
+
+const STRATEGY_SUBDIR = '.strategy';
+
+function targetSubpath(type: GovernanceType): string {
+  return type === 'proposal' ? path.join('proposals', 'active') : 'adr';
+}
+
+function templateFilename(type: GovernanceType): string {
+  return type === 'proposal' ? 'proposal.md' : 'adr.md';
+}
+
+/**
+ * Resolve governance paths for the current invocation.
+ *
+ * Two supported contexts:
+ * 1. **Submodule case** — `<gitRoot>/.strategy/` exists. Used when Totem is
+ *    the parent repo and `.strategy/` is a submodule/worktree.
+ * 2. **Standalone case** — `<gitRoot>` itself is the strategy repo
+ *    (`proposals/active/` sits at the repo root). Used when the CLI is run
+ *    from inside the strategy repo directly.
+ *
+ * Throws `TotemError` when cwd is not inside a git repo, or when neither
+ * layout can be detected.
+ */
+export function resolveGovernancePaths(cwd: string, type: GovernanceType): GovernancePaths {
+  const gitRoot = resolveGitRoot(cwd);
+  if (gitRoot === null) {
+    throw new TotemError(
+      'CONFIG_MISSING',
+      `Not inside a git repository: ${cwd}`,
+      'Run this command from inside a Totem or Totem-strategy repository checkout.',
+    );
+  }
+
+  const submoduleRoot = path.join(gitRoot, STRATEGY_SUBDIR);
+  const submoduleHasProposals = fs.existsSync(path.join(submoduleRoot, 'proposals'));
+  const submoduleHasAdr = fs.existsSync(path.join(submoduleRoot, 'adr'));
+
+  const standaloneHasProposals = fs.existsSync(path.join(gitRoot, 'proposals'));
+  const standaloneHasAdr = fs.existsSync(path.join(gitRoot, 'adr'));
+
+  let rootDir: string;
+  if (submoduleHasProposals || submoduleHasAdr) {
+    rootDir = submoduleRoot;
+  } else if (standaloneHasProposals || standaloneHasAdr) {
+    rootDir = gitRoot;
+  } else {
+    throw new TotemError(
+      'CONFIG_MISSING',
+      `No Totem-strategy layout found under ${gitRoot}.`,
+      'Expected either a `.strategy/` submodule or top-level `proposals/` and `adr/` directories. Clone or link the strategy repo first.',
+    );
+  }
+
+  const targetDir = path.join(rootDir, targetSubpath(type));
+  const templatePath = path.join(rootDir, 'templates', templateFilename(type));
+  const dashboardFile = path.join(rootDir, 'README.md');
+
+  return {
+    rootDir: path.normalize(rootDir),
+    targetDir: path.normalize(targetDir),
+    templatePath: path.normalize(templatePath),
+    dashboardFile: path.normalize(dashboardFile),
+  };
+}
+
+// ─── Auto-increment + filename sanitization ─────────────
+
+const ARTIFACT_FILENAME_RE = /^(\d{3})-(.+)\.md$/;
+const MAX_ARTIFACT_ID = 999;
+
+/**
+ * Scan `targetDir` for `NNN-slug.md` files, parse the prefix to an int,
+ * and return `(max + 1)` zero-padded to three digits.
+ *
+ * Returns `'001'` when the directory is missing or contains no matching
+ * files. Files that do not match `^(\d{3})-(.+)\.md$` are ignored so
+ * README.md or non-padded prefixes (e.g. `42-x.md`) do not pollute the
+ * count. Throws `TotemError` when the next id would exceed 999.
+ */
+export function getNextArtifactId(targetDir: string): string {
+  if (!fs.existsSync(targetDir)) {
+    return '001';
+  }
+
+  let highest = 0;
+  const entries = fs.readdirSync(targetDir);
+  for (const entry of entries) {
+    const match = ARTIFACT_FILENAME_RE.exec(entry);
+    if (!match) continue;
+    const parsed = parseInt(match[1]!, 10);
+    if (Number.isFinite(parsed) && parsed > highest) {
+      highest = parsed;
+    }
+  }
+
+  const next = highest + 1;
+  if (next > MAX_ARTIFACT_ID) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `NNN-prefix format saturated at ${targetDir} (highest id is ${highest}).`,
+      'Archive older artifacts or extend the numbering scheme before adding more.',
+    );
+  }
+
+  return String(next).padStart(3, '0');
+}
+
+/**
+ * Build the final artifact filename from a numeric id and a raw title.
+ *
+ * Sanitization: lowercase, any non-alphanumeric run becomes a single hyphen,
+ * leading/trailing hyphens are stripped. Throws `TotemError` when the
+ * sanitized slug is empty — the error fires BEFORE any filesystem write so
+ * the caller never strands a half-written artifact.
+ */
+export function formatArtifactFilename(id: string, title: string): string {
+  const slug = title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  if (slug.length === 0) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `Title "${title}" produces an empty slug.`,
+      'Titles must contain at least one alphanumeric character.',
+    );
+  }
+
+  return `${id}-${slug}.md`;
+}
+
+// ─── Template engine ────────────────────────────────────
+
+/**
+ * Default proposal template. Exported so tests and callers can inspect the
+ * baseline shape without re-deriving it. Uses ADR-091's exact heading form
+ * (`# Proposal NNN: Title` with a SPACE separator, not a hyphen). Keep in
+ * sync with `DEFAULT_ADR_TEMPLATE` below.
+ */
+export const DEFAULT_PROPOSAL_TEMPLATE = `# Proposal {{ID}}: {{TITLE}}
+
+**Status:** Draft
+**Date:** {{DATE}}
+
+## Problem Statement
+
+_Describe the problem this proposal addresses._
+
+## Proposal
+
+_Describe the proposed change._
+
+## Alternatives Considered
+
+_List alternatives and why they were rejected._
+
+## Impact
+
+_Who / what does this affect?_
+`;
+
+/**
+ * Default ADR template. Mirrors `DEFAULT_PROPOSAL_TEMPLATE` but with the
+ * `# ADR NNN: Title` heading form required by ADR-091.
+ */
+export const DEFAULT_ADR_TEMPLATE = `# ADR {{ID}}: {{TITLE}}
+
+**Status:** Draft
+**Date:** {{DATE}}
+
+## Context
+
+_Describe the architectural context and forces at play._
+
+## Decision
+
+_State the decision._
+
+## Consequences
+
+_List the consequences. Note what improves and what regresses._
+`;
+
+export interface RenderTemplateOptions {
+  type: GovernanceType;
+  id: string;
+  title: string;
+  templatePath: string;
+  date: string;
+}
+
+/**
+ * Render the artifact template with variable substitution.
+ *
+ * If `templatePath` exists on disk, its contents are used; otherwise the
+ * hardcoded `DEFAULT_PROPOSAL_TEMPLATE` / `DEFAULT_ADR_TEMPLATE` string is
+ * used. Substitutes `{{TITLE}}`, `{{DATE}}`, and `{{ID}}` globally.
+ *
+ * MVP variable set per spec #1288: only `{{TITLE}}` and `{{DATE}}` are
+ * user-facing; `{{ID}}` is internal to the default templates so the NNN
+ * number lands in the heading without the caller having to splice it.
+ */
+export function renderArtifactTemplate(opts: RenderTemplateOptions): string {
+  const { type, id, title, templatePath, date } = opts;
+
+  let template: string;
+  if (fs.existsSync(templatePath)) {
+    template = fs.readFileSync(templatePath, 'utf-8');
+  } else {
+    template = type === 'proposal' ? DEFAULT_PROPOSAL_TEMPLATE : DEFAULT_ADR_TEMPLATE;
+  }
+
+  return template
+    .replace(/\{\{TITLE\}\}/g, title)
+    .replace(/\{\{DATE\}\}/g, date)
+    .replace(/\{\{ID\}\}/g, id);
+}
+
+// ─── Post-scaffold hooks ────────────────────────────────
+
+/**
+ * Thin injection seam so tests can verify exact argv without spawning a
+ * real subprocess. Production callers omit the `exec` field and we default
+ * to `safeExec`.
+ */
+export type ExecFn = (cmd: string, args: string[], cwd?: string) => void;
+
+export interface PostScaffoldHookOptions {
+  rootDir: string;
+  newFilePath: string;
+  dashboardFile: string;
+  /** Override the exec function (test seam). Defaults to `safeExec`. */
+  exec?: ExecFn;
+}
+
+export interface PostScaffoldHookResult {
+  /** True if `pnpm run docs:inject` exited 0. False when the script is missing or failed. */
+  dashboardRefreshed: boolean;
+  /** True if `git add` staged the two paths. False if git returned non-zero. */
+  staged: boolean;
+}
+
+const defaultExec: ExecFn = (cmd, args, cwd) => {
+  safeExec(cmd, args, { cwd });
+};
+
+/**
+ * Run the two post-scaffold side-effects in sequence:
+ *
+ * 1. `pnpm run docs:inject` (refresh the dashboard index). On non-zero exit
+ *    or missing script, warn to stderr and continue — the scaffolded file
+ *    already exists on disk, so a dashboard refresh failure should not
+ *    strand the artifact.
+ * 2. `git add <newFilePath> <dashboardFile>`. Stages ONLY those two paths;
+ *    never `-A` or `.` (per lesson-8067935e / lesson-4a01b498). On failure,
+ *    warn and return `staged: false` so the caller can surface the stage
+ *    state in its user-facing summary.
+ *
+ * Neither step throws; both failures degrade gracefully so the user always
+ * walks away with the new artifact on disk.
+ */
+export function runPostScaffoldHooks(opts: PostScaffoldHookOptions): PostScaffoldHookResult {
+  const { rootDir, newFilePath, dashboardFile, exec = defaultExec } = opts;
+
+  let dashboardRefreshed = false;
+  try {
+    exec('pnpm', ['run', 'docs:inject'], rootDir);
+    dashboardRefreshed = true; // totem-context: intentional warn-and-continue per spec 1288 — dashboard refresh failure must not strand the scaffolded artifact on disk.
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // eslint-disable-next-line no-console -- intentional stderr warning per spec
+    console.warn(
+      `[Totem Warning] docs:inject did not run cleanly (${msg}). Dashboard not refreshed; run 'pnpm run docs:inject' manually.`,
+    );
+  }
+
+  let staged = false;
+  try {
+    exec('git', ['add', newFilePath, dashboardFile], rootDir);
+    staged = true; // totem-context: intentional warn-and-continue per spec 1288 — git add failure must not strand the scaffolded artifact on disk.
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    // eslint-disable-next-line no-console -- intentional stderr warning per spec
+    console.warn(
+      `[Totem Warning] git add failed (${msg}). File created but not staged; run 'git add' manually.`,
+    );
+  }
+
+  return { dashboardRefreshed, staged };
+}
+
+// ─── Orchestrator ───────────────────────────────────────
+
+export interface ScaffoldArtifactResult {
+  /** Zero-padded NNN id chosen for the artifact. */
+  id: string;
+  /** Basename of the new file (`NNN-kebab-title.md`). */
+  filename: string;
+  /** Absolute path the file was written to. */
+  filePath: string;
+  /** Absolute path to the dashboard README that `docs:inject` refreshes. */
+  dashboardFile: string;
+  /** True if `pnpm run docs:inject` succeeded. */
+  dashboardRefreshed: boolean;
+  /** True if `git add` staged the two paths. */
+  staged: boolean;
+}
+
+export interface ScaffoldArtifactInternals {
+  /** Override the exec function (test seam). Defaults to `safeExec`. */
+  exec?: ExecFn;
+  /** Override the date string (test seam). Defaults to today in `YYYY-MM-DD`. */
+  date?: string;
+  /**
+   * Force a specific NNN id instead of calling `getNextArtifactId`. Test-only
+   * seam for deterministic collision scenarios; production callers must not
+   * pass this (the auto-increment is the spec behavior).
+   */
+  forceId?: string;
+}
+
+function todayIso(): string {
+  const now = new Date();
+  const y = now.getUTCFullYear();
+  const m = String(now.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(now.getUTCDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * Full scaffolding pipeline, invoked by both `totem proposal new` and
+ * `totem adr new`:
+ *
+ *   resolve paths → compute id → sanitize filename → render template →
+ *   collision guard → write file → run docs:inject + git add
+ *
+ * Pre-disk validation (path resolution, id computation, slug sanitization,
+ * collision check) happens BEFORE the filesystem is touched so a bad input
+ * never strands a half-written artifact.
+ */
+export function scaffoldGovernanceArtifact(
+  options: ScaffoldOptions,
+  internals: ScaffoldArtifactInternals = {},
+): ScaffoldArtifactResult {
+  const paths = resolveGovernancePaths(options.cwd, options.type);
+
+  const id = internals.forceId ?? getNextArtifactId(paths.targetDir);
+  const filename = formatArtifactFilename(id, options.title);
+  const filePath = path.join(paths.targetDir, filename);
+
+  // Collision guard — hard error per spec (no --force, no auto-bump).
+  if (fs.existsSync(filePath)) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `Artifact already exists at ${filePath}.`,
+      'Choose a different title, or remove the existing file before re-scaffolding.',
+    );
+  }
+
+  const date = internals.date ?? todayIso();
+  const rendered = renderArtifactTemplate({
+    type: options.type,
+    id,
+    title: options.title,
+    templatePath: paths.templatePath,
+    date,
+  });
+
+  // Ensure parent dir exists (it should, from resolveGovernancePaths, but
+  // cheap to defend against a manually-pruned target).
+  fs.mkdirSync(paths.targetDir, { recursive: true });
+  fs.writeFileSync(filePath, rendered, 'utf-8');
+
+  const hookResult = runPostScaffoldHooks({
+    rootDir: paths.rootDir,
+    newFilePath: filePath,
+    dashboardFile: paths.dashboardFile,
+    exec: internals.exec,
+  });
+
+  return {
+    id,
+    filename,
+    filePath,
+    dashboardFile: paths.dashboardFile,
+    dashboardRefreshed: hookResult.dashboardRefreshed,
+    staged: hookResult.staged,
+  };
+}

--- a/packages/cli/src/utils/governance.ts
+++ b/packages/cli/src/utils/governance.ts
@@ -244,10 +244,13 @@ export function renderArtifactTemplate(opts: RenderTemplateOptions): string {
     template = type === 'proposal' ? DEFAULT_PROPOSAL_TEMPLATE : DEFAULT_ADR_TEMPLATE;
   }
 
+  // Replacer-function form avoids the `$&` / `$1` back-reference trap in
+  // `String.prototype.replace`'s string-replacement mode. A title like
+  // `Fix $foo bug` would otherwise mis-render. See PR #1429 review cycle.
   return template
-    .replace(/\{\{TITLE\}\}/g, title)
-    .replace(/\{\{DATE\}\}/g, date)
-    .replace(/\{\{ID\}\}/g, id);
+    .replace(/\{\{TITLE\}\}/g, () => title)
+    .replace(/\{\{DATE\}\}/g, () => date)
+    .replace(/\{\{ID\}\}/g, () => id);
 }
 
 // ─── Post-scaffold hooks ────────────────────────────────

--- a/packages/pack-agent-security/test/repo-sweep.test.ts
+++ b/packages/pack-agent-security/test/repo-sweep.test.ts
@@ -274,6 +274,13 @@ const ALLOWLIST: AllowEntry[] = [
   },
   {
     hash: 'c2c09301bb56a02b',
+    file: 'packages/cli/src/utils/governance.ts',
+    expectedCount: 2,
+    reason:
+      '`totem proposal new` and `totem adr new` scaffolding orchestrator (#1288). Calls `pnpm run docs:inject` and `git add <file> <dashboard>` via safeExec (imported as `exec`). Literal binary names, structured argv. User-provided title is sanitized to `[a-z0-9-]+` before reaching the argv surface, so no shell-injection vector.',
+  },
+  {
+    hash: 'c2c09301bb56a02b',
     file: 'packages/mcp/src/tools/add-lesson.ts',
     expectedCount: 2,
     reason: 'Same Windows taskkill cleanup pattern as shell-orchestrator.ts.',


### PR DESCRIPTION
## Summary

- `totem proposal new <title>` and `totem adr new <title>` scaffold NNN-prefixed artifacts under the strategy repo layout, fill a template matching ADR-091's heading convention (`# ADR NNN: Title` with space separator), refresh the dashboard via `pnpm run docs:inject`, and stage the two mutated paths.
- Auto-increment respects numbering gaps (`001-a.md` + `003-b.md` yields `004-c.md`); slug sanitization strips non-alphanumerics; empty-slug titles throw loud before any disk write; exact-filename collisions throw without overwriting.
- Supports both the submodule case (`<totem>/.strategy/`) and the standalone case (cwd is the strategy repo itself).
- Warn-and-continue on `docs:inject` and `git add` failures so a scaffolded artifact never gets stranded without feedback.
- Default template carries `Status: Draft` + `Date: YYYY-MM-DD` frontmatter, matching the ADR-091 convention surfaced during this session's manual ADR-092 promotion cycle.

## Scope

MVP only per the ticket's "Minimum viable" section. Deferred: `list` / `status` / `promote` subcommands, `--from-outline` LLM-assisted drafting, PR-opening integration, `--force`, `--no-stage`, cross-repo discovery flags. The `promote` state transition (Draft → Accepted + file move) is the obvious next lap once the MVP settles.

## Design doc

`.totem/specs/1288.md` carries the preflight spec plus the Implementation Design section (scope, data model deltas, state lifecycle, failure modes table, invariants locked via tests, open questions). The four open questions were resolved per user direction before coding started.

## Follow-up ticket

**#1614** filed for refining the `lesson-fail-open-catch-ban` ast-grep rule so it recognizes terminal handlers like `handleError` (declared `: never`) without needing a per-site `// totem-context:` annotation. Every new CLI command added to `index.ts` hits this false positive today. Workaround is in place (trailing comment on the try body's last statement) but the rule itself should learn the pattern.

## Verification

- `totem lint`: PASS (0 errors, 223 warnings; all either test-fixture patterns or rule false-positives on production code)
- `totem review`: PASS (0 findings after one revision round that caught a real `$&` back-reference bug in the template renderer, fixed + regression test)
- `totem verify-manifest`: PASS (440 rules, hashes match)
- Test suite: full monorepo green, including `@totem/pack-agent-security` repo-sweep with the new governance.ts spawn sites allowlisted

## Test plan

- [x] Unit: `governance.test.ts` — 28 tests covering path resolution (submodule + standalone), auto-increment with gap, filename sanitization + collision + empty-slug, template variable substitution including `$&` back-reference safety, post-scaffold hook argv, docs:inject/git-add failure resilience, and orchestrator end-to-end
- [x] Unit: `proposal.test.ts` + `adr.test.ts` — 4 tests covering CLI adapter happy path in both submodule and standalone contexts plus gap numbering and ADR-091 heading form
- [x] Pack sweep: `packages/pack-agent-security/test/repo-sweep.test.ts` allowlist entry for `governance.ts` spawn sites (expected count 2)
- [ ] Manual: run `totem proposal new "Test"` against the strategy submodule and confirm the generated file matches the ADR-091 heading convention byte-for-byte
- [ ] Manual: run `totem adr new "Test"` and confirm the same

Closes #1288.

🤖 Generated with [Claude Code](https://claude.com/claude-code)