### PR TITLE
feat: archive-in-place durability and totem lesson archive (#1587)

### DIFF
--- a/.claude/skills/postmerge/SKILL.md
+++ b/.claude/skills/postmerge/SKILL.md
@@ -32,16 +32,26 @@ with the merged PR numbers (space-separated, e.g. `1345 1347 1348`).
      names, or file paths that do not exist in the repo
    - The `lessonHeading` accurately describes the rule's behavior
 
-   For any rule that fails these checks, mutate
-   `.totem/compiled-rules.json` to add `status: 'archived'` and a
-   detailed `archivedReason` explaining the specific failure mode.
-   The mmnto-ai/totem#1345 archive filter in `loadCompiledRules`
-   silences archived rules at lint time while preserving them in the
-   ledger for future compile-worker prompt regression analysis. See
-   `scripts/archive-bad-postmerge-rules.cjs` (committed on
-   mmnto-ai/totem#1366) for the canonical mutation script shape.
-   Match target rules by `lessonHash`, not `lessonHeading` (headings
-   are auto-truncated to 60 chars and are not guaranteed unique).
+   For any rule that fails these checks, archive it with the atomic
+   `totem lesson archive <hash> --reason "<specific failure mode>"`
+   command (mmnto-ai/totem#1587). The command flips the rule's
+   `status` to `archived`, stamps `archivedAt` on first transition,
+   refreshes `compile-manifest.json`'s `output_hash`, and regenerates
+   the copilot and junie exports so the archived rule stops flowing
+   into downstream AI tool configs — all in one invocation.
+
+   ```bash
+   pnpm exec totem lesson archive 8dbddb67 --reason "Pattern fires on every throw-in-catch; lesson's real scope is post-scaffold hooks only"
+   ```
+
+   Use as many characters of the hash as needed to unambiguously
+   match one rule. The command matches on `lessonHash` prefix;
+   ambiguous prefixes print the candidates and exit non-zero with
+   no mutation. Idempotent on rerun — `archivedReason` refreshes,
+   `archivedAt` is preserved. The mmnto-ai/totem#1345 archive filter
+   in `loadCompiledRules` silences archived rules at lint time while
+   preserving them in the ledger for future compile-worker prompt
+   regression analysis.
 
    **Do NOT** use `git checkout HEAD -- .totem/compiled-rules.json`
    to revert the entire rules file. Reverting rules while keeping
@@ -49,8 +59,8 @@ with the merged PR numbers (space-separated, e.g. `1345 1347 1348`).
    (manifest.input_hash reflects the new lessons, output_hash
    reflects the reverted rules, verify-manifest fails on push). This
    is the symmetric counterpart of the mmnto-ai/totem#1337 bug.
-   Archive-in-place is the intended curation surface; reverting is
-   not.
+   Archive-in-place via `totem lesson archive` is the intended
+   curation surface; reverting is not.
 
    Empirical baseline: approximately 2 of every 6 auto-compiled
    rules are bad (1.14.1 postmerge), and the 2026-04-11 PM postmerge
@@ -58,18 +68,10 @@ with the merged PR numbers (space-separated, e.g. `1345 1347 1348`).
    under Strategy #73 and Strategy #62. Every archivedReason is
    feedback that informs that rewrite.
 
-5. Refresh the manifest and exports. After any mutation to
-   `compiled-rules.json`, re-run step 3's compile command. It will
-   detect the rules file drift via mmnto-ai/totem#1348's no-op
-   refresh path, update `compile-manifest.json` hashes, and
-   regenerate the copilot and junie exports so they filter the
-   newly archived rules out of the exported markdown:
-   `pnpm exec totem lesson compile --export`
-
-6. Format everything compile touched:
+5. Format everything compile and archive touched:
    `pnpm run format`
 
-7. Stage only the artifacts we keep: new lessons, the mutated rules
+6. Stage only the artifacts we keep: new lessons, the mutated rules
    file, the refreshed manifest, and the regenerated exports. Do NOT
    stage `docs/active_work.md`, `docs/roadmap.md`, or
    `docs/architecture.md` unless you hand-edited them deliberately
@@ -77,19 +79,30 @@ with the merged PR numbers (space-separated, e.g. `1345 1347 1348`).
    rewrite them):
    `git add .totem/lessons/ .totem/compiled-rules.json .totem/compile-manifest.json .github/copilot-instructions.md .junie/skills/totem-rules/rules.md`
 
-   If you wrote a one-off curation script during step 4 (as was done
-   on mmnto-ai/totem#1366 with `scripts/archive-bad-postmerge-rules.cjs`),
-   stage it explicitly so the institutional memory lands with the
-   commit:
-   `git add scripts/archive-bad-postmerge-rules.cjs  # or whatever you named yours`
-
-8. Commit:
+7. Commit:
    `git commit -m "chore: totem postmerge lessons for $ARGUMENTS"`
 
-9. Report: how many lessons extracted, how many rules compiled, how
-   many were archived inline with reasons, and whether any new
-   tickets were filed for rules that need source-lesson refinement
-   before they can be re-compiled cleanly.
+8. Report: how many lessons extracted, how many rules compiled, how
+   many were archived with `totem lesson archive` and their reasons,
+   and whether any new tickets were filed for rules that need source-
+   lesson refinement before they can be re-compiled cleanly.
+
+**Historical note.** Postmerge curation scripts at
+`scripts/archive-bad-postmerge-*.cjs` (first introduced on
+mmnto-ai/totem#1366, last used on mmnto-ai/totem#1625) are retired.
+Those scripts hand-mutated `compiled-rules.json` and relied on a
+subsequent `totem lesson compile --export` call to refresh the
+manifest, but that no-op path only detected input-hash drift — not
+output-hash drift from inline mutations (the exact gap
+mmnto-ai/totem#1587 closed). `totem lesson archive` replaces them
+with one atomic call that handles the mutation + manifest refresh +
+export regeneration in a single step. Existing scripts stay in
+history for audit but should not be invoked in new postmerge cycles.
+
+For an output-hash-only refresh without archiving (e.g., after
+manual edits to compiled-rules.json for other lifecycle reasons),
+use `pnpm exec totem lesson compile --refresh-manifest` — the
+no-LLM primitive that backs the atomic archive command.
 
 The retirement error from `totem wrap` produces this same workaround
 text at runtime, so if you forget the sequence, just run

--- a/.totem/specs/1587.md
+++ b/.totem/specs/1587.md
@@ -1,0 +1,185 @@
+### Problem Statement
+
+The `totem lesson compile` command currently overwrites lifecycle fields (`status`, `archivedReason`, `archivedAt`) during `--force` regeneration and lacks a mechanism to detect output-hash drift after manual or inline archiving. A new `--refresh-manifest` flag, an additive merge pass for lifecycle fields during recompilation, and a first-class `totem lesson archive <hash>` command must be implemented to support durable inline archiving without breaking `totem verify-manifest`.
+
+### Architectural Context
+
+This fix addresses three converging issues identified in #1587 and LC Claude Session (Items 7 and 8). It builds upon the input-hash drift precedent from #1348 and #1337. The atomic operation matches the primitive shape of `totem rules promote` added in #1581 (zero-trust workflow). Archive fields are considered part of the canonical rules subset and must continue to be included in the manifest hash to maintain integrity guarantees.
+
+### Files to Examine
+
+1. `packages/cli/src/commands/compile.ts` — Location of the compile command logic, where `--refresh-manifest` flag and `--force` lifecycle merging must be injected.
+2. `packages/cli/src/commands/rule.ts` — Contains `rulePromoteCommand` which exports domain utilities (`loadCompiledRulesFile`, `generateOutputHash`, `readCompileManifest`, `writeCompileManifest`) that must be reused for the archive and refresh functions.
+3. `packages/cli/src/commands/lesson.ts` — Location to register the new `totem lesson archive` atomic command.
+4. `.claude/skills/postmerge/SKILL.md` — The workflow documentation that currently prescribes an unsupported hand-rolled script pattern which must be updated.
+
+### Technical Approach & Contracts
+
+1. **Compile Output Lifecycle Merge (`--force` fix):** Before writing the newly compiled rules to `compiled-rules.json`, the compile pipeline must read the existing `compiled-rules.json` (using `loadCompiledRulesFile`). For any rule hash/ID that still exists in the newly compiled output, map over the `status`, `archivedReason`, and `archivedAt` properties from the old state to the new state.
+2. **Refresh Manifest Flag:** Add a boolean `--refresh-manifest` argument to the compile command. If true, bypass LLM compilation. Load `compiled-rules.json`, run `generateOutputHash()`, read `compile-manifest.json` via `readCompileManifest()`, update its `output_hash` and `compiled_at`, and save via `writeCompileManifest()`.
+3. **Atomic Archive Command:** Implement `totem lesson archive <hash> [--reason <string>]`. This command will:
+   - Use `loadCompiledRulesFile()` or `readJsonSafe()` to load current rules.
+   - Find the rule by hash. If missing, fail fast.
+   - Set `status: 'archived'`, `archivedReason: reason || 'Archived via CLI'`, and `archivedAt: new Date().toISOString()`.
+   - Write back to `compiled-rules.json`.
+   - Invoke the same `generateOutputHash` / `writeCompileManifest` logic used by the refresh flag.
+   - Trigger the export regenerator.
+
+**Data Contracts:**
+
+```typescript
+interface ArchiveCommandArgs {
+  hash: string;
+  reason?: string;
+}
+
+// Ensure the compiled rule type allows for lifecycle fields
+interface CompiledRule {
+  // ... existing fields ...
+  status?: 'active' | 'archived';
+  archivedReason?: string;
+  archivedAt?: string;
+}
+```
+
+### Edge Cases & Traps
+
+- **Race conditions in Archive:** Modifying the JSON file manually outside the CLI while the `archive` command is running could result in lost data. Ensure read-modify-write happens synchronously or with file locks if available in the CLI context.
+- **Dangling archives:** When merging lifecycle fields during `--force`, do NOT re-add archived rules whose underlying lessons have been deleted from `.totem/lessons.md`. Only apply the lifecycle fields to rules that survived the current `--force` compilation pass.
+- **Manifest refresh bypassing:** If `--refresh-manifest` is used alongside regular compile flags (like `--force`), the CLI should prioritize the explicit explicit refresh action and exit, or enforce exclusivity. Strict exclusivity (error if combining with `--force`) is the safest architectural trap prevention.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Implement `compile --refresh-manifest` flag**
+  - Files to modify: `packages/cli/src/commands/compile.ts`
+  - Update the CLI command builder to accept a boolean `--refresh-manifest` flag.
+  - Implement the early exit branch: If `--refresh-manifest` is true, call `loadCompiledRulesFile`, `generateOutputHash`, update the manifest via `writeCompileManifest`, and exit 0.
+    > TOTEM INVARIANT (CLI Primitive Contract): The `--refresh-manifest` flag must recompute `output_hash` without invoking the LLM or touching any lessons. It must be non-destructive.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `updates manifest output_hash without invoking compilation when --refresh-manifest is passed` proving the manifest hash syncs with a manually mutated rules file.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Preserve lifecycle fields during `--force` compile**
+  - Files to modify: `packages/cli/src/commands/compile.ts` or the core compile orchestrator.
+  - Inject a merge step right before the new `compiled-rules.json` is written.
+  - Load the _existing_ compiled rules. Map the previous `status`, `archivedReason`, and `archivedAt` values onto the newly generated rules by matching their rule hash/ID.
+    > TOTEM INVARIANT (Additive Lifecycle): `--force` must preserve `status`, `archivedReason`, and `archivedAt` additively. It must merge forward, not regenerate.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `preserves status and archived fields when compiling with force flag` ensuring existing archived rules stay archived after a `--force` recompile.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Create `totem lesson archive` command**
+  - Files to modify: `packages/cli/src/commands/lesson.ts` (or `archive.ts`)
+  - Create the command handler for `totem lesson archive <hash> [--reason]`.
+  - Load rules, find the target rule, mutate `status: 'archived'` along with timestamp and reason.
+  - Write rules, refresh manifest (using the same domain logic as Task 1), and trigger export regeneration.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `archives a lesson rule, updates output hash, and regenerates exports` proving that the atomic command correctly mutates all required downstream artifacts.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Update postmerge workflow documentation**
+  - Files to modify: `.claude/skills/postmerge/SKILL.md`
+  - Update Step 5. Remove instructions regarding `scripts/archive-bad-postmerge-*.cjs`.
+  - Instruct the model/user to run `totem lesson archive <hash> --reason "..."` directly.
+  - write test (N/A for markdown docs) → verify fails (N/A) → implement → verify passes (N/A) → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Manifest Refresh Scenario:** Mutate an existing `compiled-rules.json` rule manually to simulate drift. Run `totem verify-manifest` to assert failure. Run `totem lesson compile --refresh-manifest`. Run `totem verify-manifest` again to assert success.
+- **Force Merge Scenario:** Archive a rule. Run a full `totem lesson compile --force`. Assert that the rule still contains `status: 'archived'` and the correct `archivedReason` in the resulting output.
+- **Atomic Archive Scenario:** Run `totem lesson archive <hash> --reason "testing"`. Assert that the target rule is updated, `compile-manifest.json` `output_hash` is correctly updated, and exports are regenerated seamlessly without drift errors.
+- **Invalid Archive Scenario:** Run `totem lesson archive invalid-hash`. Assert that the CLI fails fast with a descriptive error and does not touch the manifest or exports.
+
+## Implementation Design
+
+### Scope
+
+Implements the four-part fix for #1587: (1) `totem lesson compile --refresh-manifest` flag that recomputes `output_hash` without LLM invocation; (2) lifecycle-merge pass during `totem lesson compile --force` that preserves `status` / `archivedReason` / `archivedAt` on rules that survive the recompile; (3) new `totem lesson archive <hash> [--reason <string>]` atomic command matching the `rulePromoteCommand` (rule.ts:300-394) pattern; (4) `.claude/skills/postmerge/SKILL.md` step 5 rewrite to use the atomic command and retire the `scripts/archive-bad-postmerge-*.cjs` pattern.
+
+Explicitly NOT in scope: changes to `nonCompilable` lifecycle semantics (tracked in #1627); unarchive / `totem lesson unarchive` command (future ticket); cross-bump of existing archived-at-null rules backfill (one-off, not load-bearing); modification to any non-CLI consumer of `compiled-rules.json`.
+
+### Data model deltas
+
+No new types. `CompiledRule` already carries `status`, `archivedReason`, `archivedAt` per the schema in `packages/core/src/compiler-schema.ts`. `archivedAt` preservation on schema round-trip shipped via #1589 (1.14.16).
+
+No new required fields. The atomic archive command treats `archivedAt` as owned by the first archive transition (consistent with the #1625 archive-script fix): set on first archive, preserved on reruns. `archivedReason` refreshes on every invocation with the new reason.
+
+No new state containers. All state flows through the existing `compiled-rules.json` + `compile-manifest.json` pair.
+
+No reserved keys or sentinels introduced.
+
+### State lifecycle
+
+All state touched is **persistent** (on-disk JSON) with **command-scoped** mutation:
+
+- **`compiled-rules.json`** — mutation owned by compile.ts (write paths: fresh compile, no-op refresh on input drift, --force regenerate, --refresh-manifest no-op) and the new lesson.ts archive command (write path: lifecycle field flip). Read by lint, review, verify-manifest, exports. Atomic writes via tmp + rename per `rulePromoteCommand` precedent.
+- **`compile-manifest.json`** — mutation owned by compile.ts (four write paths above, plus the new --refresh-manifest primitive). Read by verify-manifest and the pre-push hook. Preflight-read-before-mutate pattern mandatory per #1601 CR finding.
+
+No session-level or cross-request state. No state crossing lifecycle boundaries.
+
+### Failure modes
+
+| Failure                                                                                         | Category | Agent-facing surface                                                                                                       | Recovery                                                                |
+| ----------------------------------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `--refresh-manifest` combined with `--force` or other compile flags                             | runtime  | hard error `[Totem Error] --refresh-manifest is a no-LLM primitive and cannot combine with --force or other compile flags` | user drops the conflicting flag                                         |
+| `--refresh-manifest` finds manifest already fresh                                               | runtime  | info log `Manifest already fresh — no changes` + exit 0                                                                    | none needed; no-op is success                                           |
+| `totem lesson archive <hash>` — hash not found                                                  | runtime  | hard error `[Totem Error] No rule found matching '<id>'`                                                                   | user re-runs with correct hash                                          |
+| `totem lesson archive <hash>` — ambiguous prefix                                                | runtime  | hard error `Ambiguous prefix 'X' matches N rules:` + list                                                                  | user provides more chars                                                |
+| `totem lesson archive <hash>` — rule already archived                                           | runtime  | idempotent refresh (updates `archivedReason` to new value; preserves original `archivedAt`) + info log                     | none needed; idempotency is the point                                   |
+| `totem lesson archive` — manifest read fails mid-command                                        | init     | hard error `[Totem Error] Cannot read compile-manifest.json` BEFORE any write to rules.json                                | compiled-rules.json preserved in pre-archive state; user fixes manifest |
+| `--force` lifecycle merge — rule deleted between old and new compile (lesson removed from disk) | runtime  | silent skip (rule not in new output → no lifecycle to preserve)                                                            | none; intentional per dangling-archive trap                             |
+| `--force` merge — corrupt existing compiled-rules.json                                          | init     | hard error `[Totem Error] Cannot parse existing compiled-rules.json` before LLM invocation                                 | user fixes JSON or runs fresh compile                                   |
+
+No silent-degradation paths. Tenet 4 compliant.
+
+### Invariants to lock in via tests
+
+- `--refresh-manifest` recomputes `output_hash` from current `compiled-rules.json` without invoking the LLM; manually-archived rule's manifest drift clears after one call.
+- `--refresh-manifest` with a fresh manifest is a no-op (no file write, no `compiled_at` bump).
+- `--refresh-manifest` + `--force` exits with a hard error and touches no files.
+- `--force` recompile preserves `status: 'archived'`, `archivedReason`, and `archivedAt` for rules whose `lessonHash` survives to the new output.
+- `--force` recompile does NOT resurrect lifecycle fields onto rules whose source lesson was deleted (dangling-archive guard).
+- `totem lesson archive <hash> --reason "X"` on a fresh rule: flips `status` to `archived`, sets `archivedReason` to `X`, sets `archivedAt` to now, refreshes manifest `output_hash`, regenerates copilot + junie exports.
+- `totem lesson archive <hash> --reason "Y"` on already-archived rule: refreshes `archivedReason` to `Y`, preserves original `archivedAt` timestamp untouched.
+- `totem lesson archive <unknown-hash>` exits non-zero and touches no files.
+- After `totem lesson archive`, `totem verify-manifest` passes and `git push` pre-push hook clears.
+
+### Open questions
+
+- **Question:** Should `--refresh-manifest` and `--export` combine? (`--refresh-manifest --export` would refresh manifest AND regenerate copilot/junie exports.)
+- **Options:**
+  - (a) Allow the combination. `--refresh-manifest` stays a no-LLM primitive; `--export` is an independent output step that reads the rules file and emits markdown. Composable.
+  - (b) Make `--refresh-manifest` always regenerate exports too (implicit). Matches `totem lesson archive`'s behavior, where exports regenerate as part of the atomic command.
+  - (c) Make `--refresh-manifest` strictly refresh-only. Users who also want exports run `--export` on a separate call.
+- **Recommendation:** (a). Keeps each flag's semantics crisp: `--refresh-manifest` touches only the manifest; `--export` touches exports. `totem lesson archive` bundles both because it's a workflow-atomic verb, not a primitive. This matches `rulePromoteCommand`'s shape (which doesn't touch exports; exports refresh via the next `--export` call).
+
+- **Question:** Should the `totem lesson archive` command also run a lint or review pass after mutation to catch malformed rule state?
+- **Options:**
+  - (a) Yes, always. Archive command becomes longer-running (~2s lint); never ships a broken state.
+  - (b) No, trust schema validation on load + the atomic write pattern.
+  - (c) Optional `--verify` flag, off by default.
+- **Recommendation:** (b). The atomic command doesn't introduce pattern validity changes — it only flips lifecycle fields. Lint already runs at push time. Adding it here duplicates work.
+
+- **Question:** Should this all land as one PR or split into 2-3?
+- **Options:**
+  - (a) One PR (all 4 tasks). Largest diff but most atomic; skill doc can cite the new commands directly.
+  - (b) Split: PR-1 (refresh-manifest + --force merge, core+compile), PR-2 (archive command + skill doc).
+  - (c) Split 3: PR-1 (refresh-manifest), PR-2 (--force merge), PR-3 (archive command + skill doc).
+- **Recommendation:** (a). All four tasks are tightly coupled (the archive command uses the refresh primitive; the skill doc references the archive command; --force merge shares the dangling-archive invariant with the archive command's idempotency contract). Splitting adds rebase / cross-ref overhead without reducing review burden per piece.

--- a/packages/cli/src/commands/compile-prune.test.ts
+++ b/packages/cli/src/commands/compile-prune.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import type { CompiledRule } from '@mmnto/totem';
 
 import type { NonCompilableMapValue } from './compile.js';
-import { pruneStaleNonCompilable, pruneStaleRules } from './compile.js';
+import { pruneStaleNonCompilable, pruneStaleRules, upsertRule } from './compile.js';
 
 // ─── 4-tuple helpers (mmnto-ai/totem#1481) ───────────
 
@@ -167,5 +167,47 @@ describe('pruneStaleRules', () => {
 
     expect(rules).toHaveLength(2);
     expect(rules[1]!.lessonHash).toBe('stale');
+  });
+});
+
+// ─── upsertRule (mmnto-ai/totem#1587) ────────────────
+
+describe('upsertRule', () => {
+  it('appends when no entry with the same lessonHash exists', () => {
+    const rules = [makeRule('abc'), makeRule('def')];
+    const fresh = makeRule('ghi', 'New rule');
+    upsertRule(rules, fresh);
+
+    expect(rules).toHaveLength(3);
+    expect(rules[2]).toBe(fresh);
+  });
+
+  it('replaces in-place when an entry with the same lessonHash exists', () => {
+    // Order preservation is load-bearing: re-compiling a mid-array rule
+    // under --force must NOT move it to the end. Appending instead of
+    // replacing causes diff churn in compiled-rules.json on every force
+    // run (CR finding on PR mmnto-ai/totem#1629).
+    const ruleA = makeRule('abc', 'Old A');
+    const ruleB = makeRule('def', 'B');
+    const ruleC = makeRule('ghi', 'C');
+    const rules = [ruleA, ruleB, ruleC];
+    const replacement = makeRule('abc', 'New A');
+    upsertRule(rules, replacement);
+
+    expect(rules).toHaveLength(3);
+    expect(rules[0]).toBe(replacement);
+    expect(rules[0]!.lessonHeading).toBe('New A');
+    expect(rules[1]).toBe(ruleB);
+    expect(rules[2]).toBe(ruleC);
+  });
+
+  it('is idempotent when called twice with the same rule object', () => {
+    const rules = [makeRule('abc', 'Original')];
+    const replacement = makeRule('abc', 'Updated');
+    upsertRule(rules, replacement);
+    upsertRule(rules, replacement);
+
+    expect(rules).toHaveLength(1);
+    expect(rules[0]).toBe(replacement);
   });
 });

--- a/packages/cli/src/commands/compile-prune.test.ts
+++ b/packages/cli/src/commands/compile-prune.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it } from 'vitest';
 import type { CompiledRule } from '@mmnto/totem';
 
 import type { NonCompilableMapValue } from './compile.js';
-import { pruneStaleNonCompilable, pruneStaleRules, upsertRule } from './compile.js';
+import {
+  pruneStaleNonCompilable,
+  pruneStaleRules,
+  removeRuleByHash,
+  upsertRule,
+} from './compile.js';
 
 // ─── 4-tuple helpers (mmnto-ai/totem#1481) ───────────
 
@@ -209,5 +214,30 @@ describe('upsertRule', () => {
 
     expect(rules).toHaveLength(1);
     expect(rules[0]).toBe(replacement);
+  });
+});
+
+// ─── removeRuleByHash (mmnto-ai/totem#1587 + mmnto-ai/totem#1629 cloud parity) ──
+
+describe('removeRuleByHash', () => {
+  it('removes the matching rule in place and preserves order of the rest', () => {
+    const ruleA = makeRule('abc', 'A');
+    const ruleB = makeRule('def', 'B');
+    const ruleC = makeRule('ghi', 'C');
+    const rules = [ruleA, ruleB, ruleC];
+    removeRuleByHash(rules, 'def');
+
+    expect(rules).toHaveLength(2);
+    expect(rules[0]).toBe(ruleA);
+    expect(rules[1]).toBe(ruleC);
+  });
+
+  it('is a no-op when the hash does not match any rule', () => {
+    const rules = [makeRule('abc'), makeRule('def')];
+    removeRuleByHash(rules, 'missing');
+
+    expect(rules).toHaveLength(2);
+    expect(rules[0]!.lessonHash).toBe('abc');
+    expect(rules[1]!.lessonHash).toBe('def');
   });
 });

--- a/packages/cli/src/commands/compile-refresh-manifest.test.ts
+++ b/packages/cli/src/commands/compile-refresh-manifest.test.ts
@@ -1,0 +1,223 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { generateOutputHash, hashLesson, readCompileManifest } from '@mmnto/totem';
+
+import { cleanTmpDir } from '../test-utils.js';
+import { compileCommand } from './compile.js';
+
+// ─── Helpers ─────────────────────────────────────────
+//
+// These tests exercise the `--refresh-manifest` primitive (mmnto-ai/totem#1587).
+// The flag must recompute output_hash from the current compiled-rules.json
+// state without invoking the LLM or touching any lessons. It is the non-LLM
+// complement to #1348's input-hash drift refresh, covering the postmerge
+// inline-archive workflow where a rule's `status: 'archived'` field is set
+// directly by a curation script.
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'totem-refresh-manifest-'));
+}
+
+function lessonMarkdown(heading: string, body: string): string {
+  return `## Lesson — ${heading}\n\n**Tags:** test\n\n${body}\n`;
+}
+
+interface WorkspaceOptions {
+  lessons: Record<string, string>;
+  rules: Array<{ lessonHash: string; lessonHeading: string; status?: 'archived' }>;
+}
+
+function setupWorkspace(tmpDir: string, options: WorkspaceOptions): void {
+  fs.writeFileSync(
+    path.join(tmpDir, 'totem.config.ts'),
+    [
+      'export default {',
+      '  targets: [{ glob: "**/*.ts", type: "code", strategy: "typescript-ast" }],',
+      '  totemDir: ".totem",',
+      '  orchestrator: {',
+      '    provider: "shell",',
+      '    command: "echo should-never-run",',
+      '    defaultModel: "test-model",',
+      '  },',
+      '};',
+      '',
+    ].join('\n'),
+    'utf-8',
+  );
+
+  const totemDir = path.join(tmpDir, '.totem');
+  const lessonsDir = path.join(totemDir, 'lessons');
+  fs.mkdirSync(lessonsDir, { recursive: true });
+  for (const [name, body] of Object.entries(options.lessons)) {
+    fs.writeFileSync(path.join(lessonsDir, name), body, 'utf-8');
+  }
+
+  const rulesPath = path.join(totemDir, 'compiled-rules.json');
+  const now = '2026-04-22T00:00:00Z';
+  fs.writeFileSync(
+    rulesPath,
+    JSON.stringify(
+      {
+        version: 1,
+        rules: options.rules.map((r) => ({
+          lessonHash: r.lessonHash,
+          lessonHeading: r.lessonHeading,
+          pattern: 'dummy-never-matches',
+          message: r.lessonHeading,
+          engine: 'regex',
+          compiledAt: now,
+          ...(r.status ? { status: r.status } : {}),
+        })),
+        nonCompilable: [],
+      },
+      null,
+      2,
+    ) + '\n',
+    'utf-8',
+  );
+
+  // Write manifest with an output_hash that matches the rules file as written.
+  // Tests that want drift will mutate the rules file AFTER setupWorkspace.
+  const manifestPath = path.join(totemDir, 'compile-manifest.json');
+  fs.writeFileSync(
+    manifestPath,
+    JSON.stringify(
+      {
+        compiled_at: now,
+        model: 'test-model',
+        input_hash: '0000000000000000000000000000000000000000000000000000000000000000',
+        output_hash: generateOutputHash(rulesPath),
+        rule_count: options.rules.length,
+      },
+      null,
+      2,
+    ) + '\n',
+    'utf-8',
+  );
+}
+
+describe('compileCommand --refresh-manifest (#1587)', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    cleanTmpDir(tmpDir);
+  });
+
+  it('updates manifest output_hash without invoking compilation when --refresh-manifest is passed', async () => {
+    // Scenario: a postmerge archive script mutates compiled-rules.json in
+    // place (flipping status to 'archived'). The output_hash in the manifest
+    // is now stale. `--refresh-manifest` must recompute it without running
+    // the LLM or touching lessons.
+    const heading = 'Use err in catch';
+    const body = 'Do not use the identifier "error" in catch blocks.';
+    const lessonHash = hashLesson(heading, body);
+
+    setupWorkspace(tmpDir, {
+      lessons: { 'use-err.md': lessonMarkdown(heading, body) },
+      rules: [{ lessonHash, lessonHeading: heading }],
+    });
+
+    const totemDir = path.join(tmpDir, '.totem');
+    const rulesPath = path.join(totemDir, 'compiled-rules.json');
+    const manifestPath = path.join(totemDir, 'compile-manifest.json');
+
+    const manifestBefore = readCompileManifest(manifestPath);
+    const hashBefore = manifestBefore.output_hash;
+
+    // Simulate the postmerge archive-in-place: mutate compiled-rules.json
+    // directly (flip status to 'archived' on the only rule).
+    const rulesJson = JSON.parse(fs.readFileSync(rulesPath, 'utf-8'));
+    rulesJson.rules[0].status = 'archived';
+    rulesJson.rules[0].archivedReason = 'test archive';
+    rulesJson.rules[0].archivedAt = '2026-04-23T00:00:00Z';
+    fs.writeFileSync(rulesPath, JSON.stringify(rulesJson, null, 2) + '\n', 'utf-8');
+
+    const rulesFileHashAfterMutation = generateOutputHash(rulesPath);
+    expect(rulesFileHashAfterMutation).not.toBe(hashBefore);
+
+    await compileCommand({ refreshManifest: true });
+
+    const manifestAfter = readCompileManifest(manifestPath);
+    expect(manifestAfter.output_hash).toBe(rulesFileHashAfterMutation);
+  });
+
+  it('is a no-op when the manifest is already fresh', async () => {
+    // Baseline: rules and manifest agree. `--refresh-manifest` must not
+    // write the manifest back (no compiled_at bump, no byte change).
+    const heading = 'Use err in catch';
+    const body = 'Do not use the identifier "error" in catch blocks.';
+    const lessonHash = hashLesson(heading, body);
+
+    setupWorkspace(tmpDir, {
+      lessons: { 'use-err.md': lessonMarkdown(heading, body) },
+      rules: [{ lessonHash, lessonHeading: heading }],
+    });
+
+    const totemDir = path.join(tmpDir, '.totem');
+    const manifestPath = path.join(totemDir, 'compile-manifest.json');
+    const manifestBytesBefore = fs.readFileSync(manifestPath, 'utf-8');
+
+    await compileCommand({ refreshManifest: true });
+
+    const manifestBytesAfter = fs.readFileSync(manifestPath, 'utf-8');
+    expect(manifestBytesAfter).toBe(manifestBytesBefore);
+  });
+
+  it('throws TotemConfigError when combined with --force', async () => {
+    // Strict exclusivity: --refresh-manifest is a no-LLM primitive and
+    // cannot combine with --force (an LLM-invoking regenerate). The combo
+    // is incoherent; fail loud rather than pick a silent resolution.
+    const heading = 'Use err in catch';
+    const body = 'Do not use the identifier "error" in catch blocks.';
+    const lessonHash = hashLesson(heading, body);
+
+    setupWorkspace(tmpDir, {
+      lessons: { 'use-err.md': lessonMarkdown(heading, body) },
+      rules: [{ lessonHash, lessonHeading: heading }],
+    });
+
+    await expect(compileCommand({ refreshManifest: true, force: true })).rejects.toMatchObject({
+      code: 'CONFIG_INVALID',
+    });
+  });
+
+  it('leaves the rules file untouched on a successful refresh', async () => {
+    // The primitive must be read-only w.r.t. compiled-rules.json. Only the
+    // manifest is written. Byte-for-byte equality is the strictest check.
+    const heading = 'Use err in catch';
+    const body = 'Do not use the identifier "error" in catch blocks.';
+    const lessonHash = hashLesson(heading, body);
+
+    setupWorkspace(tmpDir, {
+      lessons: { 'use-err.md': lessonMarkdown(heading, body) },
+      rules: [{ lessonHash, lessonHeading: heading, status: 'archived' }],
+    });
+
+    const totemDir = path.join(tmpDir, '.totem');
+    const rulesPath = path.join(totemDir, 'compiled-rules.json');
+
+    // Mutate the rules file so there is drift to refresh against.
+    const rulesJson = JSON.parse(fs.readFileSync(rulesPath, 'utf-8'));
+    rulesJson.rules[0].archivedReason = 'test archive drift';
+    fs.writeFileSync(rulesPath, JSON.stringify(rulesJson, null, 2) + '\n', 'utf-8');
+
+    const rulesBytesBefore = fs.readFileSync(rulesPath, 'utf-8');
+
+    await compileCommand({ refreshManifest: true });
+
+    const rulesBytesAfter = fs.readFileSync(rulesPath, 'utf-8');
+    expect(rulesBytesAfter).toBe(rulesBytesBefore);
+  });
+});

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -182,6 +182,25 @@ export function pruneStaleRules(
   return { fresh, pruned: rules.length - fresh.length };
 }
 
+/**
+ * Replace-by-lessonHash if an entry with the same hash is already in the
+ * array; otherwise append. Preserves array order for existing entries so
+ * the compile loop's output stays stable across runs.
+ *
+ * Used by the --force durability path (mmnto-ai/totem#1587) and the
+ * non-force add-new-rule path: all success-side pushes go through this
+ * helper so transient compile failures leave old rules intact and
+ * repeated successes do not double-insert.
+ */
+export function upsertRule(rules: CompiledRule[], rule: CompiledRule): void {
+  const idx = rules.findIndex((r) => r.lessonHash === rule.lessonHash);
+  if (idx >= 0) {
+    rules[idx] = rule;
+  } else {
+    rules.push(rule);
+  }
+}
+
 // ─── Verbose trace renderer (mmnto-ai/totem#1482) ──
 
 /**
@@ -459,6 +478,13 @@ export async function compileCommand(
         "Run 'totem lesson compile' first to generate the rules file.",
       );
     }
+    // Validate compiled-rules.json by parsing it through the schema
+    // BEFORE refreshing the manifest. Without this, a corrupt rules file
+    // gets its new byte-level hash written to the manifest and
+    // verify-manifest stops surfacing the corruption — silent drift.
+    // loadCompiledRulesFile throws TotemParseError on malformed JSON or
+    // schema violations (CR finding on PR mmnto-ai/totem#1629).
+    const compiledRulesFile = loadCompiledRulesFile(rulesPath);
     const compileManifest = readCompileManifest(manifestPath);
     const freshOutputHash = generateOutputHash(rulesPath);
     if (compileManifest.output_hash === freshOutputHash) {
@@ -467,6 +493,7 @@ export async function compileCommand(
     }
     compileManifest.output_hash = freshOutputHash;
     compileManifest.compiled_at = new Date().toISOString();
+    compileManifest.rule_count = compiledRulesFile.rules.length;
     writeCompileManifest(manifestPath, compileManifest);
     log.success(TAG, `Manifest refreshed: output_hash ${freshOutputHash.slice(0, 8)}…`);
     return;
@@ -872,14 +899,14 @@ export async function compileCommand(
       let skipped = 0;
       let failed = 0;
       const skippedLessons: { heading: string; reason?: string }[] = [];
-      // Under --force, start fresh: every lesson re-enters the compile
-      // loop and produces a new rule, with lifecycle fields preserved via
-      // existingByHash -> buildCompiledRule. Initializing from
-      // existingRules would double-count each re-compiled rule
-      // (mmnto-ai/totem#1587). The dangling-archive guard is implicit:
-      // rules whose source lesson was deleted are never re-compiled under
-      // --force so they drop naturally.
-      const newRules: CompiledRule[] = options.force ? [] : [...existingRules];
+      // Always initialize newRules from existingRules so transient compile
+      // failures (network/rate-limit/manual reject/example-verification/
+      // cloud parse) under --force do NOT silently drop rules. Each push
+      // site uses upsertRule below to replace-by-lessonHash on successful
+      // compile, so the old rule survives when a new rule fails to
+      // produce (CR finding on PR mmnto-ai/totem#1629). Dangling-archive guard still
+      // runs via the currentHashes filter below.
+      const newRules: CompiledRule[] = [...existingRules];
 
       const currentHashes = new Set(lessons.map((l) => hashLesson(l.heading, l.body)));
       const freshRules = newRules.filter((r) => currentHashes.has(r.lessonHash));
@@ -946,7 +973,7 @@ export async function compileCommand(
                 );
               }
             }
-            newRules.push(manualResult.rule);
+            upsertRule(newRules, manualResult.rule);
             compiled++;
             logCompiledRule(log, lesson, manualResult.rule);
           } else if (manualResult.rejectReason) {
@@ -1056,7 +1083,7 @@ export async function compileCommand(
                 failed++;
                 continue;
               }
-              newRules.push(ruleResult.rule);
+              upsertRule(newRules, ruleResult.rule);
               compiled++;
               logCompiledRule(log, lesson, ruleResult.rule);
             } else {
@@ -1132,15 +1159,20 @@ export async function compileCommand(
               process.stdout.write(block + '\n');
             }
 
-            // Upgrade targets: remove the stale copy from newRules for any
-            // terminal outcome where the rule's state CHANGES (compiled -> new
-            // pattern replaces old; skipped -> rule moves to nonCompilable and
-            // must no longer appear as an active rule). For `failed`
-            // (transient error) and `noop` (no change), leave the old rule
-            // intact so a flaky network / rate-limit doesn't silently delete
-            // work (mmnto/totem#1234 GCA finding).
+            // Upgrade and --force: remove the stale copy from newRules for
+            // any terminal outcome where the rule's state CHANGES (compiled
+            // -> new pattern replaces old via upsertRule below; skipped ->
+            // rule moves to nonCompilable and must no longer appear as an
+            // active rule). For `failed` (transient error) and `noop` (no
+            // change), leave the old rule intact so a flaky network /
+            // rate-limit doesn't silently delete work (mmnto/totem#1234
+            // GCA finding; mmnto-ai/totem#1587 extension to cover --force).
+            //
+            // The `compiled` case is redundant with upsertRule's replace-
+            // by-hash semantics, but the splice still matters for `skipped`
+            // where no rule is pushed back.
             if (
-              upgradeTargets?.has(lesson.hash) &&
+              (upgradeTargets?.has(lesson.hash) || options.force) &&
               (result.status === 'compiled' || result.status === 'skipped')
             ) {
               const staleIdx = newRules.findIndex((r) => r.lessonHash === lesson.hash);
@@ -1190,7 +1222,7 @@ export async function compileCommand(
                 if (upgradeTargets?.has(lesson.hash)) {
                   nonCompilableMap.delete(lesson.hash);
                 }
-                newRules.push(result.rule);
+                upsertRule(newRules, result.rule);
                 compiled++;
                 logCompiledRule(log, lesson, result.rule);
                 break;

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -72,6 +72,16 @@ export interface CompileOptions {
     /** Telemetry directive to inject into the Pipeline 2 prompt for this lesson. */
     telemetryPrefix?: string;
   }>;
+  /**
+   * Recompute `compile-manifest.json`'s `output_hash` from the current
+   * `compiled-rules.json` state without invoking the LLM or touching any
+   * lessons (mmnto-ai/totem#1587). Exists to support the postmerge
+   * inline-archive workflow where a curation script mutates
+   * `status: 'archived'` on a rule directly; `--refresh-manifest` is the
+   * blessed way to re-sync the manifest afterwards. Cannot combine with
+   * `--force`.
+   */
+  refreshManifest?: boolean;
 }
 
 // ─── Telemetry directive (mmnto/totem#1131) ────────────────────
@@ -426,6 +436,42 @@ export async function compileCommand(
   const totemDir = path.join(cwd, config.totemDir);
   const rulesPath = path.join(totemDir, COMPILED_RULES_FILE);
 
+  // ─── --refresh-manifest primitive (mmnto-ai/totem#1587) ─────────
+  // No-LLM path that recomputes `output_hash` from current
+  // `compiled-rules.json` state. Supports the postmerge inline-archive
+  // workflow where a curation script mutates `status: 'archived'` on a
+  // rule directly. Preflights the manifest read before any write
+  // (mmnto-ai/totem#1601 CR pattern): missing/corrupt manifest fails
+  // loud without side effects.
+  if (options.refreshManifest) {
+    if (options.force) {
+      throw new TotemConfigError(
+        '--refresh-manifest cannot be combined with --force.',
+        '--refresh-manifest is a no-LLM primitive that only recomputes output_hash. Use one or the other, not both.',
+        'CONFIG_INVALID',
+      );
+    }
+    const manifestPath = path.join(totemDir, 'compile-manifest.json');
+    if (!fs.existsSync(rulesPath)) {
+      throw new TotemError(
+        'NO_RULES',
+        `No compiled-rules.json at ${rulesPath}.`,
+        "Run 'totem lesson compile' first to generate the rules file.",
+      );
+    }
+    const compileManifest = readCompileManifest(manifestPath);
+    const freshOutputHash = generateOutputHash(rulesPath);
+    if (compileManifest.output_hash === freshOutputHash) {
+      log.info(TAG, 'Manifest already fresh — no changes.');
+      return;
+    }
+    compileManifest.output_hash = freshOutputHash;
+    compileManifest.compiled_at = new Date().toISOString();
+    writeCompileManifest(manifestPath, compileManifest);
+    log.success(TAG, `Manifest refreshed: output_hash ${freshOutputHash.slice(0, 8)}…`);
+    return;
+  }
+
   const lessons = readAllLessons(totemDir);
 
   // Ingest cursor instructions if --from-cursor
@@ -643,9 +689,13 @@ export async function compileCommand(
 
   // ─── Phase 1: Regex compilation (requires orchestrator) ──
   if (config.orchestrator) {
-    const existingFile: CompiledRulesFile = options.force
-      ? { version: 1, rules: [], nonCompilable: [] }
-      : loadCompiledRulesFile(rulesPath);
+    // Always load the existing file so lifecycle fields (status,
+    // archivedReason, archivedAt) survive --force recompile (mmnto-ai/
+    // totem#1587). The cache-skip logic below gates on !options.force so
+    // every lesson still goes through the compile loop under --force;
+    // buildCompiledRule then pulls the lifecycle fields from `existing`
+    // onto the new rule via preserveLifecycleFields.
+    const existingFile: CompiledRulesFile = loadCompiledRulesFile(rulesPath);
     const existingRules = existingFile.rules;
     const existingByHash = new Map(existingRules.map((r) => [r.lessonHash, r]));
     // mmnto/totem#1280 + mmnto-ai/totem#1481: in-memory nonCompilable is
@@ -654,11 +704,17 @@ export async function compileCommand(
     // strings and 2-tuples to the 4-tuple shape (reasonCode:
     // 'legacy-unknown') before we reach this block, so existingFile.
     // nonCompilable is always 4-tuple-shaped here.
+    //
+    // --force resets the nonCompilable ledger so previously-failed
+    // lessons get re-attempted with whatever prompt improvements landed.
+    // Failures that happen this pass re-populate the map.
     const nonCompilableMap = new Map<string, NonCompilableMapValue>(
-      (existingFile.nonCompilable ?? []).map((entry) => [
-        entry.hash,
-        { title: entry.title, reasonCode: entry.reasonCode, reason: entry.reason },
-      ]),
+      options.force
+        ? []
+        : (existingFile.nonCompilable ?? []).map((entry) => [
+            entry.hash,
+            { title: entry.title, reasonCode: entry.reasonCode, reason: entry.reason },
+          ]),
     );
 
     // Note: we do NOT delete the --upgrade target from existingByHash here.
@@ -677,8 +733,12 @@ export async function compileCommand(
     for (const lesson of lessonsInScope) {
       const hash = hashLesson(lesson.heading, lesson.body);
       if (!upgradeTargets?.has(hash)) {
-        if (existingByHash.has(hash)) continue; // already compiled
-        if (nonCompilableMap.has(hash)) continue; // cached as non-compilable
+        // --force bypasses both caches: every lesson re-enters the
+        // compile loop so pattern regenerates, while buildCompiledRule
+        // pulls lifecycle fields forward from the existingByHash lookup
+        // (mmnto-ai/totem#1587).
+        if (!options.force && existingByHash.has(hash)) continue; // already compiled
+        if (!options.force && nonCompilableMap.has(hash)) continue; // cached as non-compilable
       }
       toCompile.push({ index: lesson.index, heading: lesson.heading, body: lesson.body, hash });
     }
@@ -812,7 +872,14 @@ export async function compileCommand(
       let skipped = 0;
       let failed = 0;
       const skippedLessons: { heading: string; reason?: string }[] = [];
-      const newRules: CompiledRule[] = [...existingRules];
+      // Under --force, start fresh: every lesson re-enters the compile
+      // loop and produces a new rule, with lifecycle fields preserved via
+      // existingByHash -> buildCompiledRule. Initializing from
+      // existingRules would double-count each re-compiled rule
+      // (mmnto-ai/totem#1587). The dangling-archive guard is implicit:
+      // rules whose source lesson was deleted are never re-compiled under
+      // --force so they drop naturally.
+      const newRules: CompiledRule[] = options.force ? [] : [...existingRules];
 
       const currentHashes = new Set(lessons.map((l) => hashLesson(l.heading, l.body)));
       const freshRules = newRules.filter((r) => currentHashes.has(r.lessonHash));

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -201,6 +201,19 @@ export function upsertRule(rules: CompiledRule[], rule: CompiledRule): void {
   }
 }
 
+/**
+ * Remove the first rule matching `lessonHash` from `rules`, in place.
+ * No-op when no match. Used on the `--force` / upgrade skipped paths in
+ * both local and cloud workers: when a lesson transitions to
+ * non-compilable, any pre-existing rule for the same hash must be evicted
+ * from the active set, otherwise --force leaves the old rule alive while
+ * also marking the hash non-compilable (mmnto-ai/totem#1629 CR finding).
+ */
+export function removeRuleByHash(rules: CompiledRule[], lessonHash: string): void {
+  const idx = rules.findIndex((r) => r.lessonHash === lessonHash);
+  if (idx >= 0) rules.splice(idx, 1);
+}
+
 // ─── Verbose trace renderer (mmnto-ai/totem#1482) ──
 
 /**
@@ -1064,6 +1077,14 @@ export async function compileCommand(
               // mmnto-ai/totem#1481: the cloud worker currently classifies every
               // compilable:false outcome as out-of-scope. Granular cloud-side
               // reasonCodes are out of scope here and track via mmnto/totem#1221.
+              //
+              // Under --force / upgrade, evict any stale active-rule entry so
+              // we don't leave the old rule alive while also marking the same
+              // hash non-compilable (mmnto-ai/totem#1629 CR finding — symmetry
+              // with the local skipped path).
+              if (upgradeTargets?.has(lesson.hash) || options.force) {
+                removeRuleByHash(newRules, lesson.hash);
+              }
               nonCompilableMap.set(lesson.hash, {
                 title: lesson.heading,
                 reasonCode: 'out-of-scope',
@@ -1173,8 +1194,7 @@ export async function compileCommand(
               (upgradeTargets?.has(lesson.hash) || options.force) &&
               result.status === 'skipped'
             ) {
-              const staleIdx = newRules.findIndex((r) => r.lessonHash === lesson.hash);
-              if (staleIdx >= 0) newRules.splice(staleIdx, 1);
+              removeRuleByHash(newRules, lesson.hash);
             }
 
             // Record the terminal outcome for each upgrade target. Used by

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -1159,21 +1159,19 @@ export async function compileCommand(
               process.stdout.write(block + '\n');
             }
 
-            // Upgrade and --force: remove the stale copy from newRules for
-            // any terminal outcome where the rule's state CHANGES (compiled
-            // -> new pattern replaces old via upsertRule below; skipped ->
-            // rule moves to nonCompilable and must no longer appear as an
-            // active rule). For `failed` (transient error) and `noop` (no
-            // change), leave the old rule intact so a flaky network /
-            // rate-limit doesn't silently delete work (mmnto/totem#1234
-            // GCA finding; mmnto-ai/totem#1587 extension to cover --force).
-            //
-            // The `compiled` case is redundant with upsertRule's replace-
-            // by-hash semantics, but the splice still matters for `skipped`
-            // where no rule is pushed back.
+            // Upgrade and --force: remove the stale copy from newRules when
+            // the rule moves to nonCompilable (status === 'skipped') and
+            // must no longer appear as an active rule. The `compiled` case
+            // is handled by upsertRule below (replace-by-lessonHash in
+            // place, preserving array order — splicing here would defeat
+            // that by forcing upsertRule to append). For `failed`
+            // (transient error) and `noop` (no change), leave the old rule
+            // intact so a flaky network / rate-limit doesn't silently
+            // delete work (mmnto/totem#1234 GCA finding; mmnto-ai/totem#1587
+            // extension to cover --force).
             if (
               (upgradeTargets?.has(lesson.hash) || options.force) &&
-              (result.status === 'compiled' || result.status === 'skipped')
+              result.status === 'skipped'
             ) {
               const staleIdx = newRules.findIndex((r) => r.lessonHash === lesson.hash);
               if (staleIdx >= 0) newRules.splice(staleIdx, 1);

--- a/packages/cli/src/commands/lesson-archive.test.ts
+++ b/packages/cli/src/commands/lesson-archive.test.ts
@@ -1,0 +1,234 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { generateOutputHash, readCompileManifest } from '@mmnto/totem';
+
+import { cleanTmpDir } from '../test-utils.js';
+import { lessonArchiveCommand } from './lesson.js';
+
+// ─── Helpers ─────────────────────────────────────────
+//
+// Exercise `totem lesson archive <hash> [--reason <string>]` — the atomic
+// archive verb from mmnto-ai/totem#1587 Task 3. The command mirrors
+// `rulePromoteCommand` (rule.ts:300-394) in shape: preflight manifest read,
+// atomic tmp+rename write of rules.json, refresh manifest output_hash.
+// Idempotent on rerun: archivedReason refreshes, archivedAt is preserved
+// across invocations.
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'totem-lesson-archive-'));
+}
+
+interface RuleSeed {
+  lessonHash: string;
+  lessonHeading: string;
+  status?: 'archived';
+  archivedReason?: string;
+  archivedAt?: string;
+}
+
+function setupWorkspace(tmpDir: string, rules: RuleSeed[]): void {
+  fs.writeFileSync(
+    path.join(tmpDir, 'totem.config.ts'),
+    [
+      'export default {',
+      '  targets: [{ glob: "**/*.ts", type: "code", strategy: "typescript-ast" }],',
+      '  totemDir: ".totem",',
+      '};',
+      '',
+    ].join('\n'),
+    'utf-8',
+  );
+
+  const totemDir = path.join(tmpDir, '.totem');
+  fs.mkdirSync(totemDir, { recursive: true });
+
+  const rulesPath = path.join(totemDir, 'compiled-rules.json');
+  const now = '2026-04-22T00:00:00Z';
+  fs.writeFileSync(
+    rulesPath,
+    JSON.stringify(
+      {
+        version: 1,
+        rules: rules.map((r) => ({
+          lessonHash: r.lessonHash,
+          lessonHeading: r.lessonHeading,
+          pattern: 'dummy-never-matches',
+          message: r.lessonHeading,
+          engine: 'regex',
+          severity: 'warning',
+          compiledAt: now,
+          ...(r.status ? { status: r.status } : {}),
+          ...(r.archivedReason ? { archivedReason: r.archivedReason } : {}),
+          ...(r.archivedAt ? { archivedAt: r.archivedAt } : {}),
+        })),
+        nonCompilable: [],
+      },
+      null,
+      2,
+    ) + '\n',
+    'utf-8',
+  );
+
+  const manifestPath = path.join(totemDir, 'compile-manifest.json');
+  fs.writeFileSync(
+    manifestPath,
+    JSON.stringify(
+      {
+        compiled_at: now,
+        model: 'test-model',
+        input_hash: '0000000000000000000000000000000000000000000000000000000000000000',
+        output_hash: generateOutputHash(rulesPath),
+        rule_count: rules.length,
+      },
+      null,
+      2,
+    ) + '\n',
+    'utf-8',
+  );
+}
+
+describe('lessonArchiveCommand (#1587)', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    cleanTmpDir(tmpDir);
+  });
+
+  it('archives the target rule, refreshes manifest output_hash, and stamps archivedAt', async () => {
+    setupWorkspace(tmpDir, [{ lessonHash: 'abc123def456abcd', lessonHeading: 'Use err in catch' }]);
+
+    const totemDir = path.join(tmpDir, '.totem');
+    const rulesPath = path.join(totemDir, 'compiled-rules.json');
+    const manifestPath = path.join(totemDir, 'compile-manifest.json');
+
+    await lessonArchiveCommand('abc123def456abcd', { reason: 'Over-broad in test contexts' });
+
+    const rulesAfter = JSON.parse(fs.readFileSync(rulesPath, 'utf-8'));
+    const rule = rulesAfter.rules.find(
+      (r: { lessonHash: string }) => r.lessonHash === 'abc123def456abcd',
+    );
+    expect(rule.status).toBe('archived');
+    expect(rule.archivedReason).toBe('Over-broad in test contexts');
+    expect(typeof rule.archivedAt).toBe('string');
+    expect(rule.archivedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    const manifestAfter = readCompileManifest(manifestPath);
+    expect(manifestAfter.output_hash).toBe(generateOutputHash(rulesPath));
+  });
+
+  it('is idempotent on rerun: archivedReason refreshes, archivedAt is preserved', async () => {
+    const originalArchivedAt = '2026-04-15T00:00:00.000Z';
+    setupWorkspace(tmpDir, [
+      {
+        lessonHash: 'abc123def456abcd',
+        lessonHeading: 'Use err in catch',
+        status: 'archived',
+        archivedReason: 'Original reason',
+        archivedAt: originalArchivedAt,
+      },
+    ]);
+
+    const totemDir = path.join(tmpDir, '.totem');
+    const rulesPath = path.join(totemDir, 'compiled-rules.json');
+
+    await lessonArchiveCommand('abc123def456abcd', { reason: 'Updated reason' });
+
+    const rulesAfter = JSON.parse(fs.readFileSync(rulesPath, 'utf-8'));
+    const rule = rulesAfter.rules.find(
+      (r: { lessonHash: string }) => r.lessonHash === 'abc123def456abcd',
+    );
+    expect(rule.status).toBe('archived');
+    expect(rule.archivedReason).toBe('Updated reason');
+    expect(rule.archivedAt).toBe(originalArchivedAt);
+  });
+
+  it('accepts a hash prefix and resolves unambiguously', async () => {
+    setupWorkspace(tmpDir, [
+      { lessonHash: 'abc123def456abcd', lessonHeading: 'Rule A' },
+      { lessonHash: 'def789ghi012efgh', lessonHeading: 'Rule B' },
+    ]);
+
+    const totemDir = path.join(tmpDir, '.totem');
+    const rulesPath = path.join(totemDir, 'compiled-rules.json');
+
+    await lessonArchiveCommand('abc12', { reason: 'prefix match' });
+
+    const rulesAfter = JSON.parse(fs.readFileSync(rulesPath, 'utf-8'));
+    const ruleA = rulesAfter.rules.find(
+      (r: { lessonHash: string }) => r.lessonHash === 'abc123def456abcd',
+    );
+    const ruleB = rulesAfter.rules.find(
+      (r: { lessonHash: string }) => r.lessonHash === 'def789ghi012efgh',
+    );
+    expect(ruleA.status).toBe('archived');
+    expect(ruleB.status).toBeUndefined();
+  });
+
+  it('fails fast on unknown hash without mutating any files', async () => {
+    setupWorkspace(tmpDir, [{ lessonHash: 'abc123def456abcd', lessonHeading: 'Use err in catch' }]);
+
+    const totemDir = path.join(tmpDir, '.totem');
+    const rulesPath = path.join(totemDir, 'compiled-rules.json');
+    const manifestPath = path.join(totemDir, 'compile-manifest.json');
+    const rulesBefore = fs.readFileSync(rulesPath, 'utf-8');
+    const manifestBefore = fs.readFileSync(manifestPath, 'utf-8');
+
+    await lessonArchiveCommand('ffff', { reason: 'not matching anything' });
+
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0;
+
+    expect(fs.readFileSync(rulesPath, 'utf-8')).toBe(rulesBefore);
+    expect(fs.readFileSync(manifestPath, 'utf-8')).toBe(manifestBefore);
+  });
+
+  it('fails fast on ambiguous prefix without mutating any files', async () => {
+    setupWorkspace(tmpDir, [
+      { lessonHash: 'abc123def456abcd', lessonHeading: 'Rule A' },
+      { lessonHash: 'abc999ghi012efgh', lessonHeading: 'Rule B' },
+    ]);
+
+    const totemDir = path.join(tmpDir, '.totem');
+    const rulesPath = path.join(totemDir, 'compiled-rules.json');
+    const manifestPath = path.join(totemDir, 'compile-manifest.json');
+    const rulesBefore = fs.readFileSync(rulesPath, 'utf-8');
+    const manifestBefore = fs.readFileSync(manifestPath, 'utf-8');
+
+    await lessonArchiveCommand('abc', { reason: 'ambiguous' });
+
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0;
+
+    expect(fs.readFileSync(rulesPath, 'utf-8')).toBe(rulesBefore);
+    expect(fs.readFileSync(manifestPath, 'utf-8')).toBe(manifestBefore);
+  });
+
+  it('uses a default reason when --reason is omitted', async () => {
+    setupWorkspace(tmpDir, [{ lessonHash: 'abc123def456abcd', lessonHeading: 'Use err in catch' }]);
+
+    const totemDir = path.join(tmpDir, '.totem');
+    const rulesPath = path.join(totemDir, 'compiled-rules.json');
+
+    await lessonArchiveCommand('abc123def456abcd', {});
+
+    const rulesAfter = JSON.parse(fs.readFileSync(rulesPath, 'utf-8'));
+    const rule = rulesAfter.rules.find(
+      (r: { lessonHash: string }) => r.lessonHash === 'abc123def456abcd',
+    );
+    expect(rule.status).toBe('archived');
+    expect(typeof rule.archivedReason).toBe('string');
+    expect(rule.archivedReason.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/cli/src/commands/lesson-archive.test.ts
+++ b/packages/cli/src/commands/lesson-archive.test.ts
@@ -215,6 +215,54 @@ describe('lessonArchiveCommand (#1587)', () => {
     expect(fs.readFileSync(manifestPath, 'utf-8')).toBe(manifestBefore);
   });
 
+  it('fails before mutating compiled-rules.json when compile-manifest.json is corrupt', async () => {
+    // Load-bearing atomicity contract (CR finding on PR #1629): the
+    // preflight manifest read must fail out BEFORE any write to
+    // compiled-rules.json. A corrupt manifest must not leave the rules
+    // file half-archived.
+    setupWorkspace(tmpDir, [{ lessonHash: 'abc123def456abcd', lessonHeading: 'Use err in catch' }]);
+
+    const totemDir = path.join(tmpDir, '.totem');
+    const rulesPath = path.join(totemDir, 'compiled-rules.json');
+    const manifestPath = path.join(totemDir, 'compile-manifest.json');
+
+    fs.writeFileSync(manifestPath, '{ this is: not valid json }', 'utf-8');
+    const rulesBefore = fs.readFileSync(rulesPath, 'utf-8'); // totem-ignore — test-fixture read, not static-analysis path
+
+    await expect(
+      lessonArchiveCommand('abc123def456abcd', { reason: 'should not apply' }),
+    ).rejects.toMatchObject({ code: 'PARSE_FAILED' });
+
+    // compiled-rules.json must be untouched.
+    expect(fs.readFileSync(rulesPath, 'utf-8')).toBe(rulesBefore); // totem-ignore — test-fixture read, not static-analysis path
+  });
+
+  it('fails before mutating compiled-rules.json when compiled-rules.json itself has duplicate hashes', async () => {
+    // Data-corruption surface (CR finding on PR mmnto-ai/totem#1629): duplicate full
+    // hashes are not prefix ambiguity; fail fast with a distinct signal.
+    setupWorkspace(tmpDir, [{ lessonHash: 'abc123def456abcd', lessonHeading: 'Rule A' }]);
+
+    const totemDir = path.join(tmpDir, '.totem');
+    const rulesPath = path.join(totemDir, 'compiled-rules.json');
+    const manifestPath = path.join(totemDir, 'compile-manifest.json');
+
+    // Rewrite the rules file with two entries carrying the SAME lessonHash.
+    const rulesJson = JSON.parse(fs.readFileSync(rulesPath, 'utf-8')); // totem-ignore — test-fixture read, not static-analysis path
+    rulesJson.rules.push({ ...rulesJson.rules[0], lessonHeading: 'Rule A duplicate' });
+    fs.writeFileSync(rulesPath, JSON.stringify(rulesJson, null, 2) + '\n', 'utf-8');
+
+    const rulesBefore = fs.readFileSync(rulesPath, 'utf-8'); // totem-ignore — test-fixture read, not static-analysis path
+    const manifestBefore = fs.readFileSync(manifestPath, 'utf-8'); // totem-ignore — test-fixture read, not static-analysis path
+
+    await lessonArchiveCommand('abc123def456abcd', { reason: 'duplicate' });
+
+    expect(process.exitCode).toBe(1);
+    process.exitCode = 0;
+
+    expect(fs.readFileSync(rulesPath, 'utf-8')).toBe(rulesBefore);
+    expect(fs.readFileSync(manifestPath, 'utf-8')).toBe(manifestBefore);
+  });
+
   it('uses a default reason when --reason is omitted', async () => {
     setupWorkspace(tmpDir, [{ lessonHash: 'abc123def456abcd', lessonHeading: 'Use err in catch' }]);
 

--- a/packages/cli/src/commands/lesson.ts
+++ b/packages/cli/src/commands/lesson.ts
@@ -154,12 +154,41 @@ export async function lessonArchiveCommand(id: string, opts: { reason?: string }
   const manifestPath = path.join(totemDir, 'compile-manifest.json');
 
   if (!fs.existsSync(rulesPath)) {
-    log.error('Totem Error', `No compiled-rules.json at ${rulesPath}. Run 'totem compile' first.`);
+    log.error(
+      'Totem Error',
+      `No compiled-rules.json at ${rulesPath}. Run 'totem lesson compile' first.`,
+    );
     process.exitCode = 1;
     return;
   }
 
   const rulesFile = loadCompiledRulesFile(rulesPath);
+
+  // Pre-index pass with duplicate-collision abort (CR finding on PR mmnto-ai/totem#1629).
+  // Duplicate full hashes in compiled-rules.json are data corruption, not
+  // prefix ambiguity; the "provide more characters to disambiguate" hint
+  // is impossible to satisfy when the full hash itself collides. Surface
+  // this as a distinct failure mode before prefix resolution runs.
+  const byHash = new Map<string, CompiledRule>();
+  const duplicates = new Set<string>();
+  for (const r of rulesFile.rules) {
+    const key = r.lessonHash.toLowerCase();
+    if (byHash.has(key)) {
+      duplicates.add(key);
+    } else {
+      byHash.set(key, r);
+    }
+  }
+  if (duplicates.size > 0) {
+    log.error(
+      'Totem Error',
+      `compiled-rules.json contains duplicate lessonHash entries: ${[...duplicates].join(', ')}`,
+    );
+    log.dim(TAG, 'This is data corruption. Run `totem verify-manifest` and investigate.');
+    process.exitCode = 1;
+    return;
+  }
+
   const matches = rulesFile.rules.filter((r: CompiledRule) =>
     r.lessonHash.toLowerCase().startsWith(id.toLowerCase()),
   );

--- a/packages/cli/src/commands/lesson.ts
+++ b/packages/cli/src/commands/lesson.ts
@@ -1,3 +1,5 @@
+import type { CompiledRule } from '@mmnto/totem';
+
 const TAG = 'Lesson';
 
 // ─── Helpers ───────────────────────────────────────────
@@ -107,4 +109,132 @@ export async function lessonAddCommand(text: string): Promise<void> {
     const message = err instanceof Error ? err.message : String(err);
     log.warn(TAG, `Failed to trigger background sync: ${message}`);
   }
+}
+
+/**
+ * Archive a compiled rule by flipping its `status` to `'archived'`, setting
+ * the `archivedReason`, stamping `archivedAt` on first transition, and
+ * refreshing the compile manifest so `totem verify-manifest` passes on the
+ * next push (mmnto-ai/totem#1587).
+ *
+ * Atomic surface matches `rulePromoteCommand` (rule.ts:300-394): preflight
+ * the manifest read BEFORE mutating compiled-rules.json so a missing or
+ * corrupt manifest fails loud without leaving the rules file half-written.
+ * Tmp-file + rename on the rules write prevents torn writes if the process
+ * crashes mid-save.
+ *
+ * Idempotent on rerun. First archive transition owns `archivedAt`;
+ * subsequent invocations refresh `archivedReason` only. Matches the
+ * canonical archive-script pattern standardized in mmnto-ai/totem#1625.
+ *
+ * Supersedes the hand-rolled `scripts/archive-bad-postmerge-*.cjs` pattern
+ * for postmerge curation; the `/postmerge` skill calls this command
+ * directly after Task 4 of mmnto-ai/totem#1587 ships.
+ */
+export async function lessonArchiveCommand(id: string, opts: { reason?: string }): Promise<void> {
+  const fs = await import('node:fs');
+  const path = await import('node:path');
+  const { log, bold } = await import('../ui.js');
+  const {
+    exportLessons,
+    generateOutputHash,
+    hashLesson,
+    loadCompiledRulesFile,
+    readAllLessons,
+    readCompileManifest,
+    writeCompileManifest,
+  } = await import('@mmnto/totem');
+  const { loadConfig, resolveConfigPath } = await import('../utils.js');
+
+  const cwd = process.cwd();
+  const configPath = resolveConfigPath(cwd);
+  const config = await loadConfig(configPath);
+  const totemDir = path.join(cwd, config.totemDir);
+  const rulesPath = path.join(totemDir, 'compiled-rules.json');
+  const manifestPath = path.join(totemDir, 'compile-manifest.json');
+
+  if (!fs.existsSync(rulesPath)) {
+    log.error('Totem Error', `No compiled-rules.json at ${rulesPath}. Run 'totem compile' first.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const rulesFile = loadCompiledRulesFile(rulesPath);
+  const matches = rulesFile.rules.filter((r: CompiledRule) =>
+    r.lessonHash.toLowerCase().startsWith(id.toLowerCase()),
+  );
+
+  if (matches.length === 0) {
+    log.error('Totem Error', `No rule found matching '${id}'`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (matches.length > 1) {
+    log.warn(TAG, `Ambiguous prefix '${id}' matches ${matches.length} rules:`);
+    for (const m of matches) {
+      log.info(TAG, `  ${bold(m.lessonHash)} — ${m.lessonHeading}`);
+    }
+    log.dim(TAG, 'Provide more characters to disambiguate.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const rule = matches[0]!;
+
+  // Preflight the manifest read BEFORE mutating rules.json (mmnto-ai/
+  // totem#1601 CR pattern on rulePromoteCommand). Missing / corrupt /
+  // unwritable manifest must fail out before any side effects on the
+  // rules file.
+  const compileManifest = readCompileManifest(manifestPath);
+
+  // Idempotent lifecycle transition: first archive owns archivedAt;
+  // reruns refresh archivedReason but leave archivedAt untouched. Matches
+  // the canonical archive-script shape standardized in mmnto-ai/totem#1625.
+  const wasAlreadyArchived = rule.status === 'archived';
+  rule.status = 'archived';
+  rule.archivedReason = opts.reason ?? 'Archived via `totem lesson archive`';
+  if (!rule.archivedAt) {
+    rule.archivedAt = new Date().toISOString();
+  }
+
+  // Atomic tmp+rename write matching the canonical on-disk format used
+  // by compile-lesson.ts, rule-mutator.ts, and rulePromoteCommand.
+  const tmpPath = `${rulesPath}.tmp`;
+  fs.writeFileSync(tmpPath, JSON.stringify(rulesFile, null, 2) + '\n', { encoding: 'utf-8' });
+  fs.renameSync(tmpPath, rulesPath);
+
+  // Refresh the manifest's output_hash so verify-manifest passes on the
+  // next push. Uses the compileManifest loaded above (preflighted) so the
+  // mutation order is: read-manifest -> mutate-rules -> write-rules ->
+  // update-manifest.
+  compileManifest.output_hash = generateOutputHash(rulesPath);
+  compileManifest.compiled_at = new Date().toISOString();
+  writeCompileManifest(manifestPath, compileManifest);
+
+  // Regenerate exports so the archived rule gets filtered out of
+  // copilot-instructions.md and junie rules.md (mirrors the compile.ts
+  // mmnto-ai/totem#1345 export-path filter). No-op if no exports are
+  // configured.
+  if (config.exports && Object.keys(config.exports).length > 0) {
+    const lessons = readAllLessons(totemDir);
+    const archivedHashes = new Set(
+      rulesFile.rules
+        .filter((r: CompiledRule) => r.status === 'archived')
+        .map((r: CompiledRule) => r.lessonHash.toLowerCase()),
+    );
+    const lessonsForExport =
+      archivedHashes.size === 0
+        ? lessons
+        : lessons.filter((l) => !archivedHashes.has(hashLesson(l.heading, l.body).toLowerCase()));
+    for (const [name, filePath] of Object.entries(config.exports)) {
+      const absPath = path.join(cwd, filePath);
+      exportLessons(lessonsForExport, absPath);
+      log.dim(TAG, `Exported ${lessonsForExport.length} rules to ${filePath} (${name})`);
+    }
+  }
+
+  const verb = wasAlreadyArchived ? 'Refreshed archive' : 'Archived';
+  log.success(TAG, `${verb} for rule ${bold(rule.lessonHash)} — ${rule.lessonHeading}`);
+  log.dim(TAG, 'Manifest refreshed. `totem verify-manifest` should pass.');
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -784,6 +784,20 @@ lessonCmd
   });
 
 lessonCmd
+  .command('archive <hash>')
+  .description('Archive a compiled rule (flip status, refresh manifest, regenerate exports)')
+  .option('--reason <string>', 'Reason for archiving (recorded in archivedReason)')
+  .action(async (hash: string, opts: { reason?: string }) => {
+    try {
+      const { lessonArchiveCommand } = await import('./commands/lesson.js');
+      await lessonArchiveCommand(hash, opts);
+    } catch (err) {
+      handleError(err); // handleError returns `never`; unreachable throw below satisfies the fail-loud check
+      throw err;
+    }
+  });
+
+lessonCmd
   .command('compile')
   .description('Compile lessons into deterministic regex rules')
   .option('--raw', 'Output compiler prompts without LLM synthesis')
@@ -803,6 +817,10 @@ lessonCmd
     '--upgrade <hash>',
     'Re-compile a single rule with telemetry-driven ast-grep guidance (mmnto/totem#1131)',
   )
+  .option(
+    '--refresh-manifest',
+    'Recompute compile-manifest.json output_hash from current compiled-rules.json (no LLM; mmnto-ai/totem#1587)',
+  )
   .action(
     async (opts: {
       raw?: boolean;
@@ -816,6 +834,7 @@ lessonCmd
       cloud?: string;
       verbose?: boolean;
       upgrade?: string;
+      refreshManifest?: boolean;
     }) => {
       try {
         const { compileCommand } = await import('./commands/compile.js');

--- a/packages/core/src/compile-lesson.test.ts
+++ b/packages/core/src/compile-lesson.test.ts
@@ -158,6 +158,62 @@ describe('buildCompiledRule', () => {
     expect(result.rule!.createdAt).toBe('2025-01-01T00:00:00.000Z');
   });
 
+  it('preserves archive lifecycle fields (status, archivedReason, archivedAt) from existing rule (#1587)', () => {
+    // When --force recompiles a rule that was previously archived by a
+    // postmerge curation script, the archive lifecycle fields must carry
+    // forward. Otherwise `--force` silently un-archives every archived
+    // rule in the corpus — the exact bug LC Claude identified.
+    const existing = new Map<string, CompiledRule>();
+    existing.set('abc123', {
+      lessonHash: 'abc123',
+      lessonHeading: 'old',
+      pattern: 'old',
+      message: 'old',
+      engine: 'regex',
+      compiledAt: '2026-01-01T00:00:00.000Z',
+      createdAt: '2025-01-01T00:00:00.000Z',
+      status: 'archived',
+      archivedReason: 'Over-broad in test contexts',
+      archivedAt: '2026-04-15T00:00:00.000Z',
+    });
+    const parsed: CompilerOutput = {
+      compilable: true,
+      pattern: 'console\\.log',
+      message: 'No console.log',
+      engine: 'regex',
+    };
+    const result = buildCompiledRule(parsed, lesson, existing);
+    expect(result.rule!.status).toBe('archived');
+    expect(result.rule!.archivedReason).toBe('Over-broad in test contexts');
+    expect(result.rule!.archivedAt).toBe('2026-04-15T00:00:00.000Z');
+  });
+
+  it('does not set lifecycle fields when existing rule has none (#1587)', () => {
+    // Non-archived existing rule: lifecycle fields stay absent on the new
+    // rule. Zod strips undefined; explicit absence is the canonical
+    // "active" state per CompiledRuleSchema.
+    const existing = new Map<string, CompiledRule>();
+    existing.set('abc123', {
+      lessonHash: 'abc123',
+      lessonHeading: 'old',
+      pattern: 'old',
+      message: 'old',
+      engine: 'regex',
+      compiledAt: '2026-01-01T00:00:00.000Z',
+      createdAt: '2025-01-01T00:00:00.000Z',
+    });
+    const parsed: CompilerOutput = {
+      compilable: true,
+      pattern: 'console\\.log',
+      message: 'No console.log',
+      engine: 'regex',
+    };
+    const result = buildCompiledRule(parsed, lesson, existing);
+    expect(result.rule!.status).toBeUndefined();
+    expect(result.rule!.archivedReason).toBeUndefined();
+    expect(result.rule!.archivedAt).toBeUndefined();
+  });
+
   it('includes sanitized fileGlobs when provided', () => {
     const parsed: CompilerOutput = {
       compilable: true,

--- a/packages/core/src/compile-lesson.ts
+++ b/packages/core/src/compile-lesson.ts
@@ -332,6 +332,27 @@ export interface BuildCompiledRuleOptions {
 }
 
 /**
+ * Extract archive lifecycle fields from an existing compiled rule so they
+ * carry forward during `--force` recompile (mmnto-ai/totem#1587). Lifecycle
+ * fields are additive state owned by `totem lesson archive` and the
+ * postmerge curation scripts; `--force` regenerates the pattern but must
+ * not silently un-archive. `createdAt` is preserved separately at each
+ * engine site because its fallback is `now` rather than absent.
+ *
+ * The dangling-archive guard is implicit: a lesson whose source was
+ * deleted is not in `toCompile`, so buildCompiledRule is never called
+ * for it, so its lifecycle fields are never resurrected onto new output.
+ */
+function preserveLifecycleFields(existing: CompiledRule | undefined): Partial<CompiledRule> {
+  if (!existing) return {};
+  const preserved: Partial<CompiledRule> = {};
+  if (existing.status !== undefined) preserved.status = existing.status;
+  if (existing.archivedReason !== undefined) preserved.archivedReason = existing.archivedReason;
+  if (existing.archivedAt !== undefined) preserved.archivedAt = existing.archivedAt;
+  return preserved;
+}
+
+/**
  * Build a CompiledRule from parsed compiler output.
  * Returns { rule, rejectReason } so callers can report why a rule was rejected.
  */
@@ -414,6 +435,7 @@ export function buildCompiledRule(
       ...engineFields('ast-grep', astSource),
       compiledAt: now,
       createdAt: existing?.createdAt ?? now,
+      ...preserveLifecycleFields(existing),
       ...globsObj,
       ...badExampleObj,
       ...goodExampleObj,
@@ -431,6 +453,7 @@ export function buildCompiledRule(
       ...engineFields('ast', parsed.astQuery),
       compiledAt: now,
       createdAt: existing?.createdAt ?? now,
+      ...preserveLifecycleFields(existing),
       ...globsObj,
       ...badExampleObj,
       ...goodExampleObj,
@@ -464,6 +487,7 @@ export function buildCompiledRule(
       ...engineFields('regex', parsed.pattern),
       compiledAt: now,
       createdAt: existing?.createdAt ?? now,
+      ...preserveLifecycleFields(existing),
       ...globsObj,
       ...badExampleObj,
       ...goodExampleObj,
@@ -657,6 +681,7 @@ export function buildManualRule(
       ...engineFields(manual.engine, engineFieldArgs),
       compiledAt: now,
       createdAt: existing?.createdAt ?? now,
+      ...preserveLifecycleFields(existing),
       ...(sanitizedGlobs && sanitizedGlobs.length > 0 ? { fileGlobs: sanitizedGlobs } : {}),
     },
   };

--- a/packages/core/src/compile-lesson.ts
+++ b/packages/core/src/compile-lesson.ts
@@ -347,8 +347,14 @@ function preserveLifecycleFields(existing: CompiledRule | undefined): Partial<Co
   if (!existing) return {};
   const preserved: Partial<CompiledRule> = {};
   if (existing.status !== undefined) preserved.status = existing.status;
-  if (existing.archivedReason !== undefined) preserved.archivedReason = existing.archivedReason;
-  if (existing.archivedAt !== undefined) preserved.archivedAt = existing.archivedAt;
+  // archivedReason and archivedAt are only meaningful when status is
+  // 'archived'. Copying them onto an active rule (or one with absent
+  // status) would leave the rule in a half-archived state that later
+  // lesson-archive idempotency logic cannot safely untangle.
+  if (existing.status === 'archived') {
+    if (existing.archivedReason !== undefined) preserved.archivedReason = existing.archivedReason;
+    if (existing.archivedAt !== undefined) preserved.archivedAt = existing.archivedAt;
+  }
   return preserved;
 }
 


### PR DESCRIPTION
## Summary

Closes #1587. Four-part fix closing the three convergent failure modes flagged in the ticket body (original #1587 scope + LC session-7 item 7 + LC session-7 item 8).

- **Task 1 — `totem lesson compile --refresh-manifest` (new flag).** No-LLM primitive that recomputes `compile-manifest.json` output_hash from the current `compiled-rules.json` state. Closes the postmerge inline-archive gap where the no-op compile path only detected input-hash drift. Strict exclusivity with `--force`.
- **Task 2 — `--force` lifecycle merge.** `buildCompiledRule` and `buildManualRule` in core now preserve `status` / `archivedReason` / `archivedAt` additively from the existing rule (new `preserveLifecycleFields` helper). `compile.ts` always loads the existing file under `--force` and gates cache skip on `!options.force` so every lesson re-enters the compile loop while lifecycle fields carry forward. Dangling-archive guard is implicit.
- **Task 3 — `totem lesson archive <hash> [--reason <string>]`.** New atomic verb mirroring `rulePromoteCommand` (rule.ts:300-394). Preflight manifest read before mutating rules.json (mmnto-ai/totem#1601 CR pattern), tmp+rename atomic write, refreshes manifest, regenerates copilot + junie exports. Idempotent on rerun (archivedReason refreshes; archivedAt preserved).
- **Task 4 — `/postmerge` skill doc rewrite.** Step 5 now calls `totem lesson archive` directly, retiring the hand-rolled `scripts/archive-bad-postmerge-*.cjs` pattern. Historical scripts stay in git for audit.

## Design approval

Phase 3 implementation design doc at `.totem/specs/1587.md` (scope, data-model deltas, state lifecycle, failure-mode table, test invariants, three open questions). Gemini pre-approved via totem-strategy consult before implementation started; alignment on all three open questions (`--refresh-manifest --export` composable ✓, no lint-after-archive ✓, single bundled PR ✓).

## Tests

13 new tests, all passing:

- **Core** (`packages/core/src/compile-lesson.test.ts`) — 2 new unit tests: `buildCompiledRule` preserves `status` / `archivedReason` / `archivedAt` from existing rule; absence on non-archived existing rule.
- **CLI `compile-refresh-manifest.test.ts`** — 4 new tests: updates output_hash on drift; no-op on fresh manifest; hard-errors on `--force` combine; rules file untouched on refresh.
- **CLI `lesson-archive.test.ts`** — 6 new tests: first archive stamps timestamp; idempotent rerun (archivedReason refreshes, archivedAt preserved); prefix resolution; unknown-hash fail-fast; ambiguous-prefix fail-fast; default reason when `--reason` omitted.

Full suite green: core 1266, cli 1791, mcp 119, pack 57 (total 3233).

## Test plan

- [x] `pnpm run format`
- [x] `pnpm run test` (3233/3233 pass)
- [x] `pnpm exec totem lint` (0 errors, 13 warnings — all false positives on new-diff mirroring of `rulePromoteCommand` patterns)
- [x] `pnpm exec totem review` (PASS)
- [x] Pre-push hook (PASS, lint + verify-manifest)
- [ ] Bot review (CR + GCA)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)