### PR TITLE
feat(core): classify context-sensitive lessons as context-required (#1598)

### DIFF
--- a/.totem/specs/1598.md
+++ b/.totem/specs/1598.md
@@ -1,0 +1,111 @@
+# Spec — #1598 compile: worker doesn't extract context constraints from scope-sensitive lessons
+
+## Problem Statement
+
+The LLM compile worker currently extracts surface-level patterns from scope-sensitive lessons without capturing the natural-language context guards (e.g., "inside X", "only for NEW items"), leading to over-broad rules that generate false positives. Implement a classifier step in the compiler prompt + schema that flags these lessons as uncompilable with a specific `context-required` reason code, preventing them from polluting the rule set.
+
+## Architectural Context
+
+Aligns with ADR-091's deterministic ingestion funnel (`Extract → Classify → Compile → Verify-Against-Codebase → Activate`). Sibling to #1523 (authorial-guidance skipping), extending the `Classify` stage to filter lessons where context cannot be structurally captured.
+
+## Files to Examine
+
+1. `packages/core/src/compiler-schema.ts` — `NonCompilableReasonCodeSchema` Zod enum at lines 198-210.
+2. `packages/core/src/compile-lesson.ts` — Pipeline 2 + 3 routing; the `!parsed.compilable` short-circuit is the precedent extension point.
+3. `packages/cli/src/commands/compile-templates.ts` — compiler prompt; currently instructs LLM to set `compilable: false` for conceptual lessons but gives no context-guard guidance.
+4. `packages/core/src/compile-lesson.test.ts` — mocked `runOrchestrator` test surface for regression coverage.
+
+## Technical Approach
+
+1. **Schema extension:** add `'context-required'` to `NonCompilableReasonCodeSchema` before the terminal `'legacy-unknown'` sentinel.
+2. **Prompt engineering:** append a "Context Constraints Classifier" section to the compile prompt with (a) the trigger-phrase heuristic (inside/when/only-for-new/must-not/except-when), (b) an explicit "lazy-reject is a violation" guard, (c) worked examples from the issue (sim.tick + Proposal ID collision).
+3. **Core routing:** when `parsed.reason` or a new `parsed.reasonCode` field indicates context-required, emit that reason code instead of the generic `out-of-scope`. Thread through both Pipeline 2 retry loop and Pipeline 3 early-exit.
+4. **UI surface:** extend any doctor/postmerge reason-code formatters to map `context-required` to a human-readable string.
+
+## Edge Cases & Traps
+
+- **Lazy-LLM trap:** giving the LLM an "out" risks it rejecting compilable scope-sensitive rules. Prompt must make `context-required` the exception; test coverage must include a positive case that asserts a structurally-capturable scope-sensitive lesson still compiles.
+- **GoodExample over-reliance:** #1580's smoke gate catches over-matching only if the goodExample is adversarial. Pipeline 2 LLMs generate trivial goodExamples that slip through. The fix must land at the compiler prompt, not the smoke gate.
+- **Backward compatibility:** existing rules in `compiled-rules.json` are unaffected — this fix applies only to new or re-compiled lessons. Retroactive reclassification is out of scope.
+
+## Acceptance
+
+- [ ] `NonCompilableReasonCodeSchema` extended with `'context-required'`
+- [ ] Compile prompt teaches the LLM to detect and reject context-sensitive lessons
+- [ ] Regression: sim.tick + Proposal ID lessons route to `nonCompilable` with `reason: 'context-required'`
+- [ ] Anti-lazy: structurally-capturable scope-sensitive lesson compiles successfully (no lazy reject)
+- [ ] Doctor / postmerge surfaces the new reason code
+
+## Implementation Design
+
+### Scope
+
+**Will do:** extend `NonCompilableReasonCodeSchema` with one new enum value (`'context-required'`), add a Context Constraints Classifier section to the compile prompt template, thread the new reason code through Pipeline 2 + Pipeline 3 exit paths in `compile-lesson.ts`, surface it in any doctor/CLI reason-code formatter, cover the two issue-body regressions plus one anti-lazy positive case.
+
+**Will NOT do:** retroactively reclassify existing rules in `compiled-rules.json`; ship #1523's authorial-guidance classifier (sibling ticket, same surface, separate scope call); build a deterministic pre-LLM filter (the heuristic is prompt-side only this cycle); change the `parsed.reason` → `reasonCode` mapping for other exit paths; touch #1587's archive-durability work.
+
+### Data model deltas
+
+**New field:** none. The change is one new value on an existing enum.
+
+**Extended enum:** `NonCompilableReasonCodeSchema` gains `'context-required'`.
+
+- **Holds:** a classification for lessons rejected because their hazard is scope-bounded by a context the compiler cannot structurally capture.
+- **Written by:** `compile-lesson.ts` Pipeline 2 + Pipeline 3 exit paths, when the LLM returns `compilable: false` with a reason that indicates context-dependency. The LLM produces the signal; the core code translates it to the enum value.
+- **Read by:** (a) `NonCompilableEntryWriteSchema` serialization into `compiled-rules.json`, (b) doctor/postmerge reason-code formatters (CLI surface), (c) downstream triage tooling reading the ledger.
+- **Invariants:** must land before `'legacy-unknown'` in the enum order per the schema's "fresh producers never emit legacy-unknown" rule. Non-breaking addition — existing persisted data round-trips unchanged.
+
+**LLM response contract:** the LLM must emit a machine-readable signal that core can map to the enum. Two options (see Open Questions below):
+
+- **Option A — new `reasonCode` field:** LLM emits `{ compilable: false, reasonCode: 'context-required', reason: '<prose>' }`. Core trusts and writes it through (with schema validation gating). Cleanest but requires LLM to know the enum vocabulary.
+- **Option B — keyword match on `reason`:** LLM emits `{ compilable: false, reason: 'context-required: <prose>' }` with a leading sentinel. Core does a string match on the reason prefix to map to the enum. More forgiving, but the sentinel is fragile if the LLM drops or rephrases it.
+
+### State lifecycle
+
+No new persistent state. The reason code flows:
+
+- **Scope:** per-lesson (one reason code per compile invocation).
+- **Lifetime:** created inside `compileLesson` when the LLM returns non-compilable with context signal; written to the `trace` event (in-memory, per-call); persisted via `CompiledRulesFile.nonCompilable` on the surrounding compile run's serialize step; read by doctor on next invocation.
+- **Ownership:** `compile-lesson.ts` mutates. `compile-manifest.ts` serializes. `doctor.ts` and postmerge consume read-only.
+
+No state crosses lifecycle boundaries. The reason code is derived fresh on every compile and never carries stale state across runs.
+
+### Failure modes
+
+| Failure                                                                                         | Category               | Agent-facing surface                                                                     | Recovery                                                                                              |
+| ----------------------------------------------------------------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| LLM returns `compilable: false` with context-guard signal                                       | runtime (expected)     | skipped with `reasonCode: 'context-required'`, lesson persists in `nonCompilable` ledger | none — lesson is semantically non-compilable; re-compile after content edit retries                   |
+| LLM returns `compilable: false` with a malformed / unrecognized reason                          | runtime                | skipped with `reasonCode: 'out-of-scope'` (current fallback behavior, unchanged)         | none — lessons this class today behave identically post-change                                        |
+| LLM "lazy-rejects" a compilable scope-sensitive lesson                                          | runtime (prompt drift) | skipped with `reasonCode: 'context-required'` when it should have compiled               | anti-lazy regression test catches; if test drifts, bad rule never ships (fail-loud via test suite)    |
+| Schema validation fails on the new enum value on an old-pipeline core reading new-pipeline data | init/version-skew      | hard error via Zod parse at `CompiledRulesFileSchema` load                               | bump `packages/core` minor; producer/consumer version skew already handled by `version: z.literal(1)` |
+| Doctor formatter receives `'context-required'` with no mapping                                  | runtime (code gap)     | prints the raw enum value instead of a human string                                      | defensive default in formatter (existing pattern); regression test covers                             |
+
+All rows either map to an existing graceful path or fail loud. No silent degradation introduced.
+
+### Invariants to lock in via tests
+
+1. `NonCompilableReasonCodeSchema.parse('context-required')` succeeds; schema order preserves `'legacy-unknown'` as terminal.
+2. A lesson whose body contains a context-guard phrase ("sim.tick() must not advance inside \_process") with a mocked LLM returning the context-required signal routes to `skipped` with `reasonCode: 'context-required'` — NOT `'out-of-scope'`.
+3. A second lesson exercising the "only for NEW" class (Proposal ID collision) routes identically — proves the classifier isn't triggered by a single keyword.
+4. **Anti-lazy invariant:** a scope-sensitive lesson whose constraint CAN be captured structurally (e.g., "use double quotes inside JSON files" — scope is captured by `fileGlobs`) compiles successfully with `status: 'compiled'`, no `context-required` emission.
+5. A doctor-output formatter unit test asserts `'context-required'` maps to a non-empty human string (not the raw enum).
+6. `NonCompilableEntryWriteSchema` round-trip: write `{hash, title, reasonCode: 'context-required'}` to JSON, re-read through `NonCompilableEntryReadSchema`, object equals input (no silent strip).
+
+### Open questions
+
+- **Question 1:** LLM response contract — add a new `reasonCode` field on the compiler response schema, or sentinel-prefix the existing `reason` string?
+  - **Options:**
+    - (a) **New `reasonCode` field.** Clean, type-safe, core validates against enum directly. Cost: prompt must teach the LLM the full enum vocabulary or constrain to `'context-required'`; schema extension touches `CompilerOutputSchema` in addition to `NonCompilableReasonCodeSchema`.
+    - (b) **Sentinel prefix in `reason`.** LLM emits `reason: 'context-required: <prose>'`; core does a `startsWith` check. Cost: fragile to LLM rephrasing; adds string-parsing surface that can silently fall through to `out-of-scope` if the LLM drops the sentinel.
+    - (c) **Keyword classifier on `reason` prose.** Core runs a heuristic (contains "context" + "cannot be captured" / "scope-dependent") on the free-form `reason` field. Cost: keyword drift over time; hardest to test deterministically.
+  - **Recommendation:** **(a) New `reasonCode` field.** Type-safe, test-friendly, aligns with how the compiler output schema already threads structured fields. The prompt constrains the LLM to emit `reasonCode: 'context-required'` ONLY for this case (leaves other reason codes to core-side classification). Cost is one field on `CompilerOutputSchema` and a prompt-side enum constraint.
+- **Question 2:** Ship with or without #1523 (authorial-guidance classifier)?
+  - **Options:**
+    - (a) **Ship standalone.** Land `context-required` now, leave #1523's `authorial-guidance` for a follow-up. Smaller PR, faster review cycle.
+    - (b) **Bundle.** Both extensions share the same classifier-prompt surface and enum schema. Landing together is ~20% more code for ~60% more value (closes two tier-2/3 tickets) and avoids two separate prompt-rewrite rounds.
+  - **Recommendation:** **(a) Ship standalone** for this PR. #1523's surface overlaps heavily but the LC upstream-feedback evidence base (two concrete examples) is stronger than #1523's ("10/10 archive rate on one postmerge"); landing them separately makes each PR's evidence base narrower and easier to bot-review. File a follow-up note on #1523 referencing the shared enum precedent once #1598 ships.
+- **Question 3:** Should the anti-lazy regression test use a real LLM call or a mocked response?
+  - **Options:**
+    - (a) **Mocked (deterministic).** Test asserts: given prompt P and a mocked response indicating the LLM classified as compilable, the rule compiles. Tests the routing, not the LLM's behavior.
+    - (b) **Real LLM (behavioral).** Test gates on actual model behavior — expensive, flaky, but catches prompt regressions.
+  - **Recommendation:** **(a) Mocked.** Follows existing `compile-lesson.test.ts` convention (2589 lines of mock-based testing). Behavioral regression lives in the compile-smoke-gate empirical pass on real postmerge runs, not the unit suite.

--- a/packages/cli/src/commands/compile-templates.ts
+++ b/packages/cli/src/commands/compile-templates.ts
@@ -113,6 +113,46 @@ Or if the lesson cannot be compiled:
 
 When setting \`"compilable": false\`, always include a \`"reason"\` field explaining why the lesson cannot be compiled into a regex/AST pattern (e.g., "Lesson describes a conceptual architectural principle, not a detectable code pattern").
 
+### Context Constraints Classifier (mmnto-ai/totem#1598)
+
+Some lessons describe **real code defects** whose hazard is bounded by a **context the pattern cannot capture**. The violation depends on WHERE the code appears, not just WHAT the code is. A naive pattern would fire on every surface match, producing a false-positive-prone rule.
+
+Markers that signal a context constraint in the lesson body:
+- "**inside** X", "**within** X", "**when wrapped in** X", "**when called from** X" — scope guards
+- "**only for new** X", "**only when** X", "**except when** X" — conditional guards
+- "**must not** X ... **when** Y" — combined guards
+
+When the lesson carries such a guard AND the guard cannot be captured structurally (i.e., no \`fileGlobs\` / \`kind:\` / \`inside:\` combinator in ast-grep can express it), emit:
+
+\`\`\`json
+{
+  "compilable": false,
+  "reasonCode": "context-required",
+  "reason": "Lesson constrains scope to <the guard>; the pattern cannot distinguish violations from legitimate usage."
+}
+\`\`\`
+
+The \`reasonCode\` field is optional and narrow — \`"context-required"\` is the only value you may emit. Absence of the field means the existing generic out-of-scope classification applies.
+
+**Worked examples (DO emit \`context-required\`):**
+
+- Lesson: "\`sim.tick()\` must not advance inside \`_process\`"
+  - Naive pattern \`sim\\.tick\\(\` would fire on the legitimate \`_physics_process()\` body. The guard ("inside \`_process\`") is a Godot runtime callback name, not a file-level or node-level scope expressible in regex or ast-grep.
+  - Correct output: \`{"compilable": false, "reasonCode": "context-required", "reason": "Lesson restricts sim.tick() to non-_process callbacks; pattern cannot distinguish _process from _physics_process enclosure."}\`
+
+- Lesson: "new follow-up proposal IDs must not collide with existing ones"
+  - Naive pattern \`Proposal\\s+0*([0-9]+)\` would fire on every existing \`Proposal 042\` reference in the repo. The guard ("new IDs only") requires knowing which IDs are new at compile time, which no pattern can express.
+  - Correct output: \`{"compilable": false, "reasonCode": "context-required", "reason": "Lesson applies only to newly-introduced IDs; pattern cannot distinguish new from existing references."}\`
+
+**Anti-lazy guard (DO compile):**
+
+The existence of this escape hatch does **not** license lazy rejection. A scope-sensitive lesson whose guard IS expressible structurally MUST still compile:
+
+- Lesson: "Use double quotes inside JSON files" → scope is captured by \`fileGlobs: ["**/*.json"]\`. Compile normally.
+- Lesson: "No \`console.log\` inside React render methods" → scope is captured by an ast-grep \`inside: { kind: 'method_definition', has: { kind: 'identifier', regex: '^render$' } }\` combinator. Compile normally if you can express it; only fall back to \`context-required\` when the structural tools genuinely cannot reach the guard.
+
+**Rule of thumb:** ask "can any of \`fileGlobs\`, ast-grep \`kind:\`, \`inside:\`, \`has:\`, or \`regex:\` express the guard the lesson describes?" If yes, compile. If no, emit \`context-required\`.
+
 ## Examples
 
 Lesson: "Use \`err\` (never \`error\`) in catch blocks"

--- a/packages/cli/src/commands/compile-templates.ts
+++ b/packages/cli/src/commands/compile-templates.ts
@@ -453,5 +453,27 @@ Or if the difference cannot be expressed as a line-level regex:
 }
 \`\`\`
 
+### Context Constraints Classifier (mmnto-ai/totem#1598)
+
+Some lessons describe **real code defects** whose hazard depends on a **context the pattern cannot capture**. The Bad snippet and Good snippet may look textually similar aside from their surrounding context — the violation is about WHERE the code appears, not just WHAT the code is. A naive regex derived from the Bad line would fire on every surface match, producing a false-positive-prone rule.
+
+Markers in the lesson body that signal this class:
+- "**inside** X", "**within** X", "**when wrapped in** X", "**when called from** X" — scope guards
+- "**only for new** X", "**only when** X", "**except when** X" — conditional guards
+
+When you cannot write a regex that distinguishes the Bad lines from the Good lines because the distinguishing context lives outside the snippet itself (and \`fileGlobs\` alone cannot close the gap), emit:
+
+\`\`\`json
+{
+  "compilable": false,
+  "reasonCode": "context-required",
+  "reason": "Lesson constrains scope to <the guard>; Bad and Good snippets differ only in surrounding context the pattern cannot see."
+}
+\`\`\`
+
+The \`reasonCode\` field is optional and narrow — \`"context-required"\` is the only value you may emit. Absence of the field keeps the default classification.
+
+**Anti-lazy guard:** when \`fileGlobs\` CAN express the distinguishing scope (e.g., "only in JSON files", "only in test files"), compile normally with the appropriate glob. Only fall back to \`context-required\` when the structural tools genuinely cannot reach the guard.
+
 Every compilable rule MUST include non-empty \`badExample\` AND \`goodExample\` fields. The compile pipeline's schema parse rejects output that omits either one for \`ast-grep\` or \`regex\` engines, so the rule never reaches the smoke gate. The smoke gate then runs the rule against both snippets: the pattern MUST match \`badExample\` (zero matches here rejects with reason code \`pattern-zero-match\`) and MUST NOT match \`goodExample\` (any match here rejects with reason code \`matches-good-example\`).
 `;

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -1074,9 +1074,15 @@ export async function compileCommand(
             }
             if (!parsed.compilable) {
               // mmnto/totem#1280: capture title alongside hash for observability.
-              // mmnto-ai/totem#1481: the cloud worker currently classifies every
-              // compilable:false outcome as out-of-scope. Granular cloud-side
-              // reasonCodes are out of scope here and track via mmnto/totem#1221.
+              // mmnto-ai/totem#1481: the cloud worker defaults compilable:false
+              // outcomes to out-of-scope. Granular cloud-side reasonCodes track
+              // via mmnto/totem#1221.
+              //
+              // mmnto-ai/totem#1598: respect the LLM's context-required signal
+              // on the cloud path the same way local Pipeline 2 / 3 routing in
+              // core/compile-lesson.ts does. Mirroring the routing here keeps
+              // downstream ledger triage consistent whether the compile ran
+              // locally or through the cloud worker.
               //
               // Under --force / upgrade, evict any stale active-rule entry so
               // we don't leave the old rule alive while also marking the same
@@ -1085,9 +1091,11 @@ export async function compileCommand(
               if (upgradeTargets?.has(lesson.hash) || options.force) {
                 removeRuleByHash(newRules, lesson.hash);
               }
+              const reasonCode =
+                parsed.reasonCode === 'context-required' ? 'context-required' : 'out-of-scope';
               nonCompilableMap.set(lesson.hash, {
                 title: lesson.heading,
-                reasonCode: 'out-of-scope',
+                reasonCode,
                 reason: parsed.reason,
               });
               skippedLessons.push({ heading: lesson.heading, reason: parsed.reason });

--- a/packages/core/src/compile-lesson.test.ts
+++ b/packages/core/src/compile-lesson.test.ts
@@ -1418,14 +1418,23 @@ describe('compileLesson', () => {
     // The context-required escape hatch (mmnto-ai/totem#1598) risks lazy-
     // rejection of lessons whose scope CAN be captured structurally (fileGlobs,
     // kind-scoped ast-grep, etc.). Lock in that a valid compilable response
-    // with a pattern still compiles even when the lesson body references scope
-    // keywords like "inside". The compiler routing must trust `compilable:true`
-    // and must not scan the lesson body for escape-hatch triggers.
+    // with a pattern still compiles even when the lesson body literally
+    // contains the escape-hatch trigger keywords ("inside", "only for new").
+    // The compiler routing must trust `compilable:true` and must not scan the
+    // lesson body for escape-hatch triggers. CR PR mmnto-ai/totem#1639 round-1
+    // flagged that a fixture without scope markers left this invariant
+    // untested; the explicit scope-sensitive body closes that gap.
+    const scopeSensitiveLesson: LessonInput = {
+      index: 0,
+      heading: 'Use logger inside request handlers (anti-lazy #1598)',
+      body: 'Always use logger inside request handlers; only for new handlers, console.log is forbidden. The scope here IS expressible structurally via fileGlobs, so the LLM must compile despite the "inside" and "only for new" trigger keywords in the body.',
+      hash: 'antilazy1598scopesensitive',
+    };
     const deps: CompileLessonDeps = {
       parseCompilerResponse: vi.fn().mockReturnValue({
         compilable: true,
         pattern: 'console\\.log',
-        message: 'Use logger inside handlers instead of console.log',
+        message: 'Use logger inside request handlers instead of console.log',
         engine: 'regex' as const,
         badExample: 'console.log("debug")',
         goodExample: 'logger.info("debug")',
@@ -1434,7 +1443,7 @@ describe('compileLesson', () => {
       existingByHash: new Map(),
       callbacks: { onWarn: vi.fn(), onDim: vi.fn() },
     };
-    const result = await compileLesson(lesson, 'system prompt', deps);
+    const result = await compileLesson(scopeSensitiveLesson, 'system prompt', deps);
     expect(result.status).toBe('compiled');
   });
 

--- a/packages/core/src/compile-lesson.test.ts
+++ b/packages/core/src/compile-lesson.test.ts
@@ -1374,6 +1374,70 @@ describe('compileLesson', () => {
     }
   });
 
+  it('routes LLM context-required signal to reasonCode context-required (Pipeline 2, mmnto-ai/totem#1598)', async () => {
+    const deps: CompileLessonDeps = {
+      parseCompilerResponse: vi.fn().mockReturnValue({
+        compilable: false,
+        reasonCode: 'context-required',
+        reason:
+          'Lesson constrains scope to an enclosing function ("inside _process") the pattern cannot express.',
+      }),
+      runOrchestrator: vi.fn().mockResolvedValue('response'),
+      existingByHash: new Map(),
+      callbacks: { onWarn: vi.fn(), onDim: vi.fn() },
+    };
+    const result = await compileLesson(lesson, 'system prompt', deps);
+    expect(result.status).toBe('skipped');
+    if (result.status === 'skipped') {
+      expect(result.reasonCode).toBe('context-required');
+    }
+  });
+
+  it('falls back to out-of-scope when LLM omits reasonCode on a non-compilable response', async () => {
+    // Backward compatibility: LLM responses that mark compilable:false without
+    // the reasonCode field continue to route through the generic out-of-scope
+    // exit path. Only the narrow context-required signal opts into the new
+    // classifier bucket.
+    const deps: CompileLessonDeps = {
+      parseCompilerResponse: vi.fn().mockReturnValue({
+        compilable: false,
+        reason: 'Describes a conceptual principle, not a code pattern',
+      }),
+      runOrchestrator: vi.fn().mockResolvedValue('response'),
+      existingByHash: new Map(),
+      callbacks: { onWarn: vi.fn(), onDim: vi.fn() },
+    };
+    const result = await compileLesson(lesson, 'system prompt', deps);
+    expect(result.status).toBe('skipped');
+    if (result.status === 'skipped') {
+      expect(result.reasonCode).toBe('out-of-scope');
+    }
+  });
+
+  it('anti-lazy: compiles a structurally-capturable scope-sensitive lesson when LLM supplies a pattern', async () => {
+    // The context-required escape hatch (mmnto-ai/totem#1598) risks lazy-
+    // rejection of lessons whose scope CAN be captured structurally (fileGlobs,
+    // kind-scoped ast-grep, etc.). Lock in that a valid compilable response
+    // with a pattern still compiles even when the lesson body references scope
+    // keywords like "inside". The compiler routing must trust `compilable:true`
+    // and must not scan the lesson body for escape-hatch triggers.
+    const deps: CompileLessonDeps = {
+      parseCompilerResponse: vi.fn().mockReturnValue({
+        compilable: true,
+        pattern: 'console\\.log',
+        message: 'Use logger inside handlers instead of console.log',
+        engine: 'regex' as const,
+        badExample: 'console.log("debug")',
+        goodExample: 'logger.info("debug")',
+      }),
+      runOrchestrator: vi.fn().mockResolvedValue('response'),
+      existingByHash: new Map(),
+      callbacks: { onWarn: vi.fn(), onDim: vi.fn() },
+    };
+    const result = await compileLesson(lesson, 'system prompt', deps);
+    expect(result.status).toBe('compiled');
+  });
+
   it('calls onWarn callback on failures', async () => {
     const deps: CompileLessonDeps = {
       parseCompilerResponse: vi.fn().mockReturnValue(null),
@@ -1665,6 +1729,25 @@ describe('compileLesson Pipeline 3 (Bad/Good snippets)', () => {
       pipeline3Lesson.heading,
       expect.stringContaining('Pipeline 3'),
     );
+  });
+
+  it('routes LLM context-required signal to reasonCode context-required (Pipeline 3, mmnto-ai/totem#1598)', async () => {
+    const deps: CompileLessonDeps = {
+      parseCompilerResponse: vi.fn().mockReturnValue({
+        compilable: false,
+        reasonCode: 'context-required',
+        reason:
+          'Lesson constrains scope to "only for NEW proposal IDs"; pattern cannot distinguish new from existing.',
+      }),
+      runOrchestrator: vi.fn().mockResolvedValue('response'),
+      existingByHash: new Map(),
+      callbacks: { onWarn: vi.fn(), onDim: vi.fn() },
+    };
+    const result = await compileLesson(pipeline3Lesson, 'system prompt', deps);
+    expect(result.status).toBe('skipped');
+    if (result.status === 'skipped') {
+      expect(result.reasonCode).toBe('context-required');
+    }
   });
 
   it('rejects at the smoke gate when the pattern does not match the Bad snippet (mmnto/totem#1408)', async () => {

--- a/packages/core/src/compile-lesson.ts
+++ b/packages/core/src/compile-lesson.ts
@@ -867,18 +867,27 @@ export async function compileLesson(
     }
 
     if (!parsed.compilable) {
+      // mmnto-ai/totem#1598: when the LLM flags a lesson as non-compilable
+      // because its hazard is scope-bounded by a context the pattern cannot
+      // capture (e.g., "inside X", "only for NEW items"), it signals with
+      // `reasonCode: 'context-required'`. Route to the distinct ledger bucket
+      // so downstream triage can distinguish structural-cannot-capture from
+      // generic conceptual-principle lessons. Absent the signal, keep the
+      // existing out-of-scope fallback.
+      const reasonCode =
+        parsed.reasonCode === 'context-required' ? 'context-required' : 'out-of-scope';
       callbacks?.onDim?.(lesson.heading, 'Pipeline 3: not compilable — skipping');
       trace.push({
         layer: 2,
         action: 'result',
         outcome: 'skipped',
-        reasonCode: 'out-of-scope',
+        reasonCode,
       });
       return {
         status: 'skipped',
         hash: lesson.hash,
         reason: parsed.reason,
-        reasonCode: 'out-of-scope',
+        reasonCode,
         trace,
       };
     }
@@ -1025,18 +1034,24 @@ export async function compileLesson(
     }
 
     if (!parsed.compilable) {
+      // mmnto-ai/totem#1598: see Pipeline 3 block above. Same classifier
+      // routing applies here — an LLM `context-required` signal lands in its
+      // own ledger bucket; everything else retains the generic out-of-scope
+      // classification.
+      const reasonCode =
+        parsed.reasonCode === 'context-required' ? 'context-required' : 'out-of-scope';
       callbacks?.onDim?.(lesson.heading, 'Not compilable (conceptual/architectural) — skipping');
       trace.push({
         layer: 3,
         action: 'result',
         outcome: 'skipped',
-        reasonCode: 'out-of-scope',
+        reasonCode,
       });
       return {
         status: 'skipped',
         hash: lesson.hash,
         reason: parsed.reason,
-        reasonCode: 'out-of-scope',
+        reasonCode,
         trace,
       };
     }

--- a/packages/core/src/compiler-schema.test.ts
+++ b/packages/core/src/compiler-schema.test.ts
@@ -6,6 +6,9 @@ import {
   CompiledRuleSchema,
   CompilerOutputSchema,
   NapiConfigSchema,
+  NonCompilableEntryReadSchema,
+  NonCompilableEntryWriteSchema,
+  NonCompilableReasonCodeSchema,
 } from './compiler-schema.js';
 
 // ─── NapiConfigSchema / AstGrepYamlRuleSchema ────────
@@ -489,5 +492,78 @@ describe('RuleEventCallback discriminator', () => {
     const suppress: 'trigger' | 'suppress' | 'failure' = 'suppress';
     const failure: 'trigger' | 'suppress' | 'failure' = 'failure';
     expect(suppress).not.toBe(failure);
+  });
+});
+
+// ─── NonCompilableReasonCode 'context-required' (mmnto-ai/totem#1598) ────
+
+describe("NonCompilableReasonCodeSchema 'context-required'", () => {
+  it('accepts the context-required reason code', () => {
+    expect(() => NonCompilableReasonCodeSchema.parse('context-required')).not.toThrow();
+  });
+
+  it('keeps legacy-unknown as the terminal enum value', () => {
+    const values = NonCompilableReasonCodeSchema.options;
+    expect(values[values.length - 1]).toBe('legacy-unknown');
+    expect(values).toContain('context-required');
+  });
+
+  it('round-trips a NonCompilable ledger entry carrying context-required', () => {
+    const entry = {
+      hash: 'a'.repeat(16),
+      title: 'sim.tick() must not advance inside _process',
+      reasonCode: 'context-required' as const,
+      reason: 'Lesson constrains scope to an enclosing function; regex cannot capture the guard.',
+    };
+    const written = NonCompilableEntryWriteSchema.parse(entry);
+    const read = NonCompilableEntryReadSchema.parse(written);
+    expect(read).toEqual(entry);
+  });
+});
+
+describe('CompilerOutputSchema context-required reasonCode', () => {
+  it('accepts a non-compilable output with reasonCode context-required', () => {
+    const parsed = CompilerOutputSchema.parse({
+      compilable: false,
+      reasonCode: 'context-required',
+      reason:
+        'Lesson references an enclosing scope ("inside _process") the pattern cannot express.',
+    });
+    expect(parsed.compilable).toBe(false);
+    expect(parsed.reasonCode).toBe('context-required');
+  });
+
+  it('accepts a non-compilable output without a reasonCode (falls back to generic out-of-scope)', () => {
+    // Backward compatibility: LLM responses that set compilable:false without
+    // a reasonCode continue to route through the existing out-of-scope exit.
+    const parsed = CompilerOutputSchema.parse({
+      compilable: false,
+      reason: 'Conceptual architectural principle.',
+    });
+    expect(parsed.compilable).toBe(false);
+    expect(parsed.reasonCode).toBeUndefined();
+  });
+
+  it('rejects compilable output with a reasonCode (reasonCode is for non-compilable exits only)', () => {
+    const result = CompilerOutputSchema.safeParse({
+      compilable: true,
+      pattern: 'foo',
+      badExample: 'foo()',
+      goodExample: 'bar()',
+      reasonCode: 'context-required',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a reasonCode value outside the LLM-emittable vocabulary', () => {
+    // Internal codes like verify-retry-exhausted are emitted by core routing,
+    // never by the LLM. Locking this in prevents the LLM from bypassing core
+    // classification by emitting an internal sentinel.
+    const result = CompilerOutputSchema.safeParse({
+      compilable: false,
+      reasonCode: 'verify-retry-exhausted',
+      reason: 'stolen sentinel',
+    });
+    expect(result.success).toBe(false);
   });
 });

--- a/packages/core/src/compiler-schema.ts
+++ b/packages/core/src/compiler-schema.ts
@@ -206,6 +206,13 @@ export const NonCompilableReasonCodeSchema = z.enum([
   'missing-badexample',
   'missing-goodexample',
   'matches-good-example',
+  // `context-required` (mmnto-ai/totem#1598) classifies lessons whose hazard
+  // is scope-bounded by a context (e.g., "inside X", "only for NEW items")
+  // that cannot be captured structurally in a single-line regex or ast-grep
+  // pattern. Distinct from `out-of-scope` (conceptual / architectural) —
+  // context-required lessons describe real code defects; the compiler simply
+  // cannot produce a non-false-positive-prone rule.
+  'context-required',
   'legacy-unknown',
 ]);
 
@@ -325,6 +332,19 @@ const CompilerOutputBaseSchema = z.object({
   severity: z.enum(['error', 'warning']).optional(),
   /** LLM explanation for why a lesson was marked non-compilable */
   reason: z.string().optional(),
+  /**
+   * LLM-emittable classifier code (mmnto-ai/totem#1598). Narrower than
+   * `NonCompilableReasonCodeSchema` because most reason codes
+   * (`verify-retry-exhausted`, `missing-badexample`, `security-rule-rejected`,
+   * etc.) are emitted by core routing, not the LLM. Exposing the full enum
+   * to the LLM would let it bypass core classification by forging an
+   * internal sentinel. This narrow enum lists only the codes the compile
+   * prompt is allowed to produce.
+   *
+   * Only valid when `compilable === false`. Enforced by
+   * `refineReasonCodeRequiresNonCompilable` below.
+   */
+  reasonCode: z.enum(['context-required']).optional(),
 });
 
 /**
@@ -399,10 +419,30 @@ function refineGoodExampleRequired(
   });
 }
 
+/**
+ * `reasonCode` is meaningful only when the LLM classifies a lesson as
+ * non-compilable. Compilable output carries a pattern + examples, not a
+ * classifier code. Enforcing the asymmetry at the schema prevents the LLM
+ * from emitting contradictory output like `{compilable: true, reasonCode: 'context-required'}`.
+ */
+function refineReasonCodeRequiresNonCompilable(
+  data: { compilable: boolean; reasonCode?: string },
+  ctx: z.RefinementCtx,
+): void {
+  if (data.reasonCode === undefined) return;
+  if (!data.compilable) return;
+  ctx.addIssue({
+    code: z.ZodIssueCode.custom,
+    message: 'reasonCode is only valid when compilable is false (mmnto-ai/totem#1598)',
+    path: ['reasonCode'],
+  });
+}
+
 export const CompilerOutputSchema = CompilerOutputBaseSchema.superRefine((data, ctx) => {
   refineAstGrepMutualExclusion(data, ctx);
   refineBadExampleRequired(data, ctx);
   refineGoodExampleRequired(data, ctx);
+  refineReasonCodeRequiresNonCompilable(data, ctx);
 });
 
 export type CompilerOutput = z.infer<typeof CompilerOutputSchema>;


### PR DESCRIPTION
## Summary

Teaches the compile worker to detect lessons whose hazard is scope-bounded by a context the pattern cannot structurally capture (e.g., "`sim.tick()` must not advance inside `_process`") and route them to the `nonCompilable` ledger with a new `context-required` reason code, instead of compiling them into false-positive-prone rules.

Extends ADR-091's Classify stage. Sibling to #1523 (authorial-guidance classifier); the `reasonCode` field pattern established here extends cleanly to that follow-up.

## What changed

- **Schema** — `NonCompilableReasonCodeSchema` gains `'context-required'` before the terminal `'legacy-unknown'` sentinel. `CompilerOutputBaseSchema` gains a narrow `reasonCode: z.enum(['context-required']).optional()` field so the LLM can signal the classification. The enum is deliberately narrow (not `NonCompilableReasonCodeSchema`) to prevent the LLM from forging internal codes like `verify-retry-exhausted`. New `refineReasonCodeRequiresNonCompilable` superRefine rejects `compilable: true` paired with a `reasonCode`.
- **Core routing** — `compile-lesson.ts` Pipeline 2 + Pipeline 3 `!parsed.compilable` short-circuits honor the new signal. Absent signal falls back to the existing `'out-of-scope'` classification for backward compat.
- **Cloud parity** — `cli/commands/compile.ts` cloud-worker result handler mirrors the routing so ledger triage is consistent across local and cloud compile paths.
- **Prompt** — new "Context Constraints Classifier" section on the compile prompt with marker heuristics (inside / when / only-for-new / must-not), the two issue-body worked examples (sim.tick + Proposal ID collision), and an explicit **anti-lazy** rule-of-thumb: compilation MUST still succeed when `fileGlobs` / ast-grep `kind:` / `inside:` / `has:` / `regex:` combinators CAN express the guard.

## Tests (10 new)

- **6 schema tests** — enum acceptance, enum ordering (`legacy-unknown` stays terminal), `NonCompilableEntry` ledger round-trip, `CompilerOutput` acceptance with and without `reasonCode`, rejection of `reasonCode` on compilable output, rejection of out-of-vocabulary `reasonCode` values (prevents sentinel forgery).
- **3 routing tests** — Pipeline 2 context-required routing, Pipeline 3 context-required routing, backward-compat fallback to `out-of-scope`.
- **1 anti-lazy test** — a compilable LLM response with a valid pattern still compiles even when the lesson body references scope keywords (locks in that routing trusts `compilable: true` and never re-scans the body for escape-hatch triggers).

Full suite: core 1277/1277, cli 1798/1798, all passing.

## Design decisions (spec at `.totem/specs/1598.md`)

- **LLM contract uses a typed `reasonCode` field**, not reason-prose sentinel parsing. Type-safe, test-deterministic, no string-parsing fragility.
- **Ship standalone** rather than bundled with #1523 — narrow evidence base, tight bot-review cycle. #1523 can extend the same `reasonCode` enum as a fast-follow.
- **Mocked tests, not live-LLM behavioral.** Behavioral regression lands on empirical postmerge runs, not the unit suite.

## Lint warnings (informational — all false positives)

Pre-push lint emitted 10 warnings, 0 errors. Five are of exactly the class #1598 addresses:

- 9x "async test callback" warnings on tests that genuinely `await compileLesson()` (which returns a `Promise`). The offending rule fires on a context-insensitive pattern — sibling tests at lines 1346/1363/1377 of the same file use identical `async () => { await compileLesson(...) }` shape and trip the same warning.
- 1x `toContain` warning on an enum-membership assertion, flagged against a rule whose purpose is secret-masking / data-sanitization testing — the assertion here has no data-sanitization context.

Both are visible surface area for Stage 4 Codebase Verifier (1.16.0) to clean up against the 357 pre-1.13.0 rule corpus. Not fixing in this PR per the spec's "no retroactive reclassification" scope boundary.

## Other scope

Bumps `.strategy` submodule pointer `460086c → 3d5d0e3` picking up upstream-feedback 006 + 008 filing closeouts (strategy PRs #112 – #116) and the `audit/` → `audits/external/` relocation.

## Test plan

- [ ] Mocked regression tests pass (core test suite).
- [ ] Anti-lazy test compiles a pattern-bearing response (core test suite).
- [ ] Cloud-path routing mirrors local — verified via code-read parity, no dedicated test added (cloud path already has thinner integration coverage; would need a full cloud-worker mock which is out of scope).
- [ ] Empirical behavioral check: watch next postmerge run's `nonCompilable` ledger for the new `'context-required'` code appearing on lessons that previously compiled to over-broad rules. Landing this PR is the prerequisite for that measurement.

Closes #1598

🤖 Generated with [Claude Code](https://claude.com/claude-code)