### PR TITLE
feat(core): bounded regex execution with persistent worker thread (#1641)

### DIFF
--- a/.totem/specs/1641.md
+++ b/.totem/specs/1641.md
@@ -1,0 +1,155 @@
+# Spec — #1641 compile-worker pattern emission lacks execution-time safety bounds (ReDoS)
+
+## Problem Statement
+
+`totem lint` runs regex patterns with no execution-time bound. A compile-worker-emitted pattern that passes every current gate (Tenet 8 wrap, schema validation, `validateRegex`/`safe-regex`, bidirectional smoke gate, human promotion review) can carry catastrophic-backtracking characteristics and hang CI indefinitely on crafted input after promotion. Pre-exhibit but the chain is reproducible. Directly attacks the Prime Directive ("deterministic enforcement under 2 seconds").
+
+## Architectural Context
+
+The hot path is `applyRulesToAdditions` in `packages/core/src/rule-engine.ts:221-296`. It compiles each rule's regex once per lint run and iterates `re.test(addition.line)` synchronously. No timeout, no cancellation, no telemetry. Patterns are user/LLM-authored, so runtime execution bounds are the last-line defense even with `safe-regex` at compile time (static analysis is undecidable).
+
+## Files to Examine
+
+1. `packages/core/src/rule-engine.ts` — `applyRulesToAdditions` (lines 221-296). Runtime regex evaluation happens here. Every `re.test(addition.line)` call becomes a bounded evaluator call.
+2. `packages/core/src/compiler.ts` — `validateRegex` (lines 89-103), already runs `safe-regex2`. Change 2 ordering ask is already satisfied (see Scope below).
+3. `packages/core/src/compile-lesson.ts:472` — call site of `validateRegex` inside `buildCompiledRule`. Ordering: `validateRegex` → `runSmokeGate` (already correct per #1641 Change 2 ask).
+4. `packages/cli/src/commands/lint.ts` (or sibling) — CLI entrypoint that invokes `applyRulesToAdditions`. Strict-vs-lenient mode flag lives here.
+5. `packages/core/src/config.ts` / totem config schema — new `lint.timeout` config surface.
+6. New: `packages/core/src/worker/regex-worker-script.ts` — the worker thread body.
+7. New: `packages/core/src/worker/regex-evaluator.ts` — the persistent worker manager.
+
+## Technical Approach
+
+Persistent single worker thread owned by `RegexEvaluator` class. Main thread calls `evaluator.evaluate(ruleHash, pattern, flags, lines)` → one IPC round-trip per rule-per-lint-run (batch granularity). Worker compiles pattern once, runs `re.test` against every line, returns matched line numbers. Main-thread timer around the IPC call; on timeout, `worker.terminate()` + respawn + reject. Telemetry emitted regardless of outcome.
+
+**Batch granularity: per-rule-per-file-batch.** Send `{ruleHash, pattern, flags, [(file, additions)...]}` per rule. One IPC round-trip per rule. Worker compiles once, iterates all additions, returns match positions. Keeps IPC overhead at ~ruleCount × 0.2ms ≈ <100ms per lint run. Per-test IPC would be 400k round-trips and infeasible.
+
+**Timeout wraps the whole batch.** If one pathological line triggers catastrophic backtracking, the entire batch terminates. Main thread respawns worker, emits telemetry, and — in strict mode — fails lint with rule + file + elapsed. In lenient mode, the batch is skipped with a warning; other rules continue.
+
+**re2-wasm is explicitly deferred.** The spec names it as a longer arc. A one-time audit of existing compiled rules for backref/lookaround usage scopes the migration surface. Not in this PR.
+
+## Scope
+
+**Will do:**
+
+- Add `RegexEvaluator` class with persistent worker, per-batch timeout, telemetry emission, strict/lenient modes.
+- Swap `applyRulesToAdditions` from synchronous `re.test` to the async evaluator. Function becomes `Promise<Violation[]>`; upstream callers already `await` in the CLI.
+- Add `lint.timeout` config section with defaults (hard=100ms, soft=50ms, mode=strict).
+- Add CLI flags `--timeout-mode {strict|lenient}` and (optionally) `--timeout-ms`.
+- Emit structured telemetry (Zod-validated) under `.totem/temp/regex-telemetry.jsonl` (or existing telemetry sink).
+- Unit + integration tests: worker isolation on `(a+)+b` with `a.repeat(50000) + 'c'`, strict vs lenient exit-code behavior, batch crash resilience, sub-threshold soft warning.
+
+**Will NOT do:**
+
+- **Change 2 (safe-regex fail-fast reordering).** Already in place — `validateRegex` runs inside `buildCompiledRule` before `runSmokeGate`. Will verify and cite in the PR body; no code change required.
+- **Change 3 (canonical-corpus promotion-gate test).** Promotion-workflow modification is distinct scope. File as follow-up ticket (extends `totem rule promote`).
+- **re2-wasm migration.** Separate proposal / ADR per the spec's own framing.
+- **Totem Lite handling.** Totem Lite ships without `worker_threads` today; lite-mode lint will fall back to inline evaluation without timeout. Document the gap; actual bounded evaluation in lite mode is a later ticket (needs a different mechanism since WASM ast-grep and Node worker threads don't coexist in the lite bundle).
+- **Full AST-engine coverage.** Tree-sitter queries are separately bounded by tree-sitter's own mechanisms; this work scopes regex patterns only.
+
+## Data model deltas
+
+**New module-level state: `packages/core/src/worker/regex-evaluator.ts`**
+
+- `RegexEvaluator` class (one instance per `applyRules` / `applyRulesToAdditions` invocation or shared module-singleton — see Open Questions).
+  - **Holds:** persistent `Worker` instance, `Map<requestId, { resolve, reject, timer }>` of pending batches, `RegexExecutionConfig` (timeout / mode).
+  - **Written by:** `evaluate()` enqueues, worker `message` handler resolves, timer fires reject, `terminate()` respawns worker.
+  - **Read by:** `applyRulesToAdditions` via `await evaluator.evaluate(...)`.
+  - **Invariants:** (a) at most one `Worker` alive per evaluator; (b) pending-map never holds stale entries past timeout; (c) respawn completes before next `evaluate()` resolves (serialized); (d) telemetry emitted on every terminal outcome (resolve / reject / timeout); (e) evaluator is `async`-safe but not concurrent (batches are serialized onto the worker).
+
+**New Zod schema: `RegexTelemetrySchema`**
+
+```ts
+{
+  ruleHash: string,
+  redactedPath: string,        // repo-relative or content-hash
+  matchedInputSize: number,    // bytes or chars, per-batch total
+  elapsedTimeMs: number,
+  timeoutTriggered: boolean,
+  softWarningTriggered: boolean,
+}
+```
+
+- **Holds:** one record per rule-batch evaluation. Crosses the disk/observability boundary → Zod validated.
+- **Written by:** `RegexEvaluator` on every batch outcome.
+- **Read by:** operator debugging, downstream telemetry tools, `totem doctor` at a later date.
+- **Invariants:** no raw absolute paths by default (opt-in via `--telemetry-full-paths`); Zod `safeParse` on write so malformed telemetry fails loud rather than polluting the sink.
+
+**New config surface: `RegexExecutionConfig`**
+
+```ts
+interface RegexExecutionConfig {
+  timeoutMs: number; // default 100
+  softWarningMs: number; // default 50
+  timeoutMode: 'strict' | 'lenient'; // default 'strict'
+}
+```
+
+- Internal TypeScript interface (not Zod — internal configuration, not boundary-crossing). Loaded from `totem.config.ts` or CLI flag overrides.
+
+## State lifecycle
+
+- **Scope:** per-lint-run (one evaluator instance spans one `applyRules` invocation; goes away with the process). Worker is a child process of the lint process.
+- **Lifetime:** evaluator created in CLI lint entrypoint before `applyRulesToAdditions`. Worker spawned on evaluator construction. Evaluator lives for the duration of rule evaluation. Destroyed on CLI exit (or explicit `evaluator.dispose()` if we wire one).
+- **Ownership:** `RegexEvaluator` owns worker lifecycle (spawn, terminate, respawn). CLI owns evaluator lifecycle (construct, dispose).
+
+**Cross-boundary concern:** the pending-request map holds promise resolvers across the IPC boundary. If the worker dies mid-batch, every pending entry must resolve (typically reject with `WorkerCrashed` or respawn + requeue). The spec's trap: "Worker State Corruption — when `worker.terminate()` is called due to a timeout, any other regex queries multiplexed onto that same worker are dropped." Our batch granularity (one batch per worker message) means only the in-flight batch is lost; no multiplexed tasks to drop. Still, the cleanup-on-terminate invariant must be rigorous.
+
+## Failure modes
+
+| Failure                                                       | Category                    | Agent-facing surface                                                                                     | Recovery                                                    |
+| ------------------------------------------------------------- | --------------------------- | -------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| Pattern catastrophic-backtracks on batch                      | runtime                     | strict: hard error + exit-nonzero with ruleHash + file + elapsed. lenient: warning + skip rule-file pair | respawn worker; next batch proceeds                         |
+| Worker process crashes (OOM, panic)                           | runtime transient           | reject in-flight batch with `WorkerCrashed`, caller decides strict/lenient                               | respawn worker                                              |
+| Worker spawn fails (init)                                     | init                        | hard error: lint cannot run without evaluator                                                            | operator: check Node version, `worker_threads` availability |
+| Pattern is syntactically invalid (slipped past validateRegex) | runtime                     | hard error — matches existing `TotemParseError` at rule-engine.ts:247                                    | operator: re-compile lesson or archive rule                 |
+| Telemetry write fails                                         | runtime transient           | warn on stderr, continue lint. Telemetry is observational, not load-bearing                              | operator: check filesystem / permissions                    |
+| Lenient-mode skipped rule hides a real violation              | permanent (operator-chosen) | visible warning in lint output; exit code excludes timeout findings but includes non-timeout findings    | operator: opt-in deliberate tradeoff                        |
+
+No silent-degradation rows. Lenient mode is justified under Tenet 4 because it's an explicit opt-in (`--timeout-mode lenient`) with a visible warning — the operator chose to accept the tradeoff. Strict is default.
+
+## Invariants to lock in via tests
+
+1. Evaluator bounds `(a+)+b` against `a.repeat(50000) + 'c'` to the timeoutMs budget (within ~10ms tolerance); main thread does not hang.
+2. After a timeout, `worker.terminate()` runs, worker is respawned, subsequent `evaluate()` calls succeed against non-pathological patterns.
+3. Strict mode surfaces a non-zero CLI exit for any timeout; finding includes ruleHash + file + elapsed.
+4. Lenient mode skips the timing-out rule-file pair with a warning and does NOT contribute to exit code; non-timeout findings still do.
+5. Telemetry record validates against `RegexTelemetrySchema`; absolute paths are absent unless `--telemetry-full-paths` is set; malformed telemetry fails `safeParse` rather than writing garbage.
+6. Sub-threshold (50-99ms) runs emit `softWarningTriggered: true` on the telemetry record; no CLI warning, no exit-code effect.
+7. Pending-request map is empty after every batch terminates (resolve, reject, timeout) — no memory leak across batches.
+8. One IPC round-trip per rule-batch (not per-test) — lock in via test that counts worker `message` events on a 10-rule × 1000-addition fixture.
+9. Worker respawn serialized: a second `evaluate()` call scheduled during respawn waits for the new worker before sending.
+10. Totem Lite invocation falls back to inline evaluation (no worker) with a one-time visible warning about the missing bound; lint continues.
+
+## Open questions
+
+- **Question 1:** Evaluator lifecycle — per-lint-run instance or module-level singleton?
+  - **Options:**
+    - (a) **Per-lint-run instance.** CLI constructs evaluator, passes to rule-engine, disposes on exit. Clean ownership.
+    - (b) **Module-level singleton.** Lazy-spawned worker on first `applyRulesToAdditions` call. Shared across every caller in the process.
+  - **Recommendation:** **(a) Per-lint-run instance.** Explicit ownership, easier to test, cleaner disposal. The worker spawn cost (~30-50ms) is amortized across the lint run; not hot enough to warrant singleton reuse.
+
+- **Question 2:** Batch granularity — per-rule, per-rule-per-file, or per-rule-per-lint?
+  - **Options:**
+    - (a) **Per-rule-per-file.** One IPC round-trip per (rule, file) pair. Finer-grained timeout isolation; a bad rule-file pair doesn't cancel the rule across other files.
+    - (b) **Per-rule.** One IPC round-trip per rule across all files. Fewer round-trips; one timeout cancels the rule entirely for the lint run.
+    - (c) **Per-lint-run.** One IPC round-trip for all rules against all files. Minimal overhead but one timeout cancels everything.
+  - **Recommendation:** **(a) Per-rule-per-file.** 400 rules × ~50 touched files = 20,000 round-trips × 0.1ms = 2 seconds of IPC overhead, which is at the edge. If that's too slow, fall back to (b). Per-file granularity is the right isolation boundary because fileGlobs already scope rules to specific files and operators expect per-file reporting. Will benchmark with a real corpus before committing.
+
+- **Question 3:** Telemetry sink location — `.totem/temp/regex-telemetry.jsonl` (new) or existing telemetry channel?
+  - **Options:**
+    - (a) **New dedicated file.** Cleanly separates regex execution telemetry from other observability streams.
+    - (b) **Existing `.totem/temp/telemetry.jsonl`.** Reuses the LLM-call telemetry sink; single channel to read.
+  - **Recommendation:** **(b) Existing sink, tagged by `type: 'regex-execution'`.** Avoids proliferating telemetry files. Consumers filter by `type`.
+
+- **Question 4:** Totem Lite treatment — inline fallback, or hard-require Node workers?
+  - **Options:**
+    - (a) **Inline fallback with loud warning.** Lite mode cannot use worker threads (WASM-only bundle); the evaluator falls back to `re.test` with no timeout. Warning emitted once per lint run.
+    - (b) **Hard-require workers.** Lite mode cannot lint regex rules. Would un-ship a core capability.
+  - **Recommendation:** **(a) Inline fallback with warning.** Lite mode already has reduced guarantees (no Node APIs); the ReDoS exposure is documented rather than blocked. File follow-up ticket for lite-mode bounded evaluation (likely requires a Rust/WASM regex engine swap).
+
+- **Question 5:** Do we ship Change 2 verification in this PR, or defer to a note?
+  - **Options:**
+    - (a) **Verify + inline comment.** Add a comment at `compile-lesson.ts:472` documenting the "validateRegex before smoke gate" invariant so a future refactor doesn't silently reorder.
+    - (b) **No code change.** Note in PR body; trust the existing order.
+  - **Recommendation:** **(a) Inline comment.** Five-line addition; prevents silent regression. Mentioned in PR body.

--- a/packages/cli/src/commands/lint.test.ts
+++ b/packages/cli/src/commands/lint.test.ts
@@ -33,7 +33,13 @@ vi.mock('../git.js', () => ({
 // ─── Mock run-compiled-rules to avoid needing real rules ─
 
 vi.mock('./run-compiled-rules.js', () => ({
-  runCompiledRules: async () => ({ violations: [], rules: [], output: '' }),
+  runCompiledRules: async () => ({
+    violations: [],
+    rules: [],
+    output: '',
+    findings: [],
+    regexTimeouts: [],
+  }),
 }));
 
 // ─── Helpers ────────────────────────────────────────────
@@ -158,5 +164,81 @@ describe('lintCommand staleness check', () => {
 
     // Should not throw — staleness check is wrapped in try/catch
     await expect(lintCommand({})).resolves.toBeUndefined();
+  });
+});
+
+// ─── Regex timeout strict/lenient mode (mmnto-ai/totem#1641) ────
+
+describe('lintCommand regex timeout handling', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+    fs.writeFileSync(path.join(tmpDir, 'totem.config.ts'), 'export default {};', 'utf-8');
+    const { lessonsDir, rulesPath, manifestPath } = scaffold(tmpDir);
+    writeValidManifest(manifestPath, lessonsDir, rulesPath);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    cleanTmpDir(tmpDir);
+    vi.clearAllMocks();
+    vi.resetModules();
+  });
+
+  it('throws TotemError in strict mode when regex timeouts are present', async () => {
+    vi.doMock('./run-compiled-rules.js', () => ({
+      runCompiledRules: async () => ({
+        violations: [],
+        rules: [],
+        output: '',
+        findings: [],
+        regexTimeouts: [
+          { ruleHash: 'hungRule', file: 'app.ts', elapsedMs: 120, mode: 'strict' as const },
+        ],
+      }),
+    }));
+
+    const { lintCommand } = await import('./lint.js');
+    await expect(lintCommand({ timeoutMode: 'strict' })).rejects.toThrow(
+      /Regex evaluation timed out/,
+    );
+  });
+
+  it('does not throw in lenient mode even when regex timeouts are present', async () => {
+    vi.doMock('./run-compiled-rules.js', () => ({
+      runCompiledRules: async () => ({
+        violations: [],
+        rules: [],
+        output: '',
+        findings: [],
+        regexTimeouts: [
+          { ruleHash: 'hungRule', file: 'app.ts', elapsedMs: 120, mode: 'lenient' as const },
+        ],
+      }),
+    }));
+
+    const { lintCommand } = await import('./lint.js');
+    await expect(lintCommand({ timeoutMode: 'lenient' })).resolves.toBeUndefined();
+  });
+
+  it('does not throw in strict mode when regex timeouts array is empty', async () => {
+    // Locks in that the strict-mode throw fires ONLY on non-empty timeouts,
+    // not on every strict-mode run.
+    vi.doMock('./run-compiled-rules.js', () => ({
+      runCompiledRules: async () => ({
+        violations: [],
+        rules: [],
+        output: '',
+        findings: [],
+        regexTimeouts: [],
+      }),
+    }));
+
+    const { lintCommand } = await import('./lint.js');
+    await expect(lintCommand({ timeoutMode: 'strict' })).resolves.toBeUndefined();
   });
 });

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -1,3 +1,5 @@
+import type { TimeoutMode } from '@mmnto/totem';
+
 import type { ShieldFormat } from './shield.js';
 
 // ─── Types ──────────────────────────────────────────
@@ -8,6 +10,13 @@ export interface LintOptions {
   staged?: boolean;
   /** PR number to post a comment on, or `true` to auto-infer from GitHub Actions env */
   prComment?: number | true;
+  /**
+   * Bounded regex execution timeout mode (mmnto-ai/totem#1641). `strict`
+   * (default) surfaces pattern-evaluation timeouts as lint errors.
+   * `lenient` skips the timing-out rule-file pair with a warning and
+   * does not contribute to the exit code.
+   */
+  timeoutMode?: TimeoutMode;
 }
 
 // ─── Command ────────────────────────────────────────
@@ -63,8 +72,10 @@ export async function lintCommand(options: LintOptions): Promise<void> {
   const allIgnore = [...config.ignorePatterns, ...(config.shieldIgnorePatterns ?? [])];
   const exportPaths = config.exports ? Object.values(config.exports) : undefined;
 
+  const timeoutMode: TimeoutMode = options.timeoutMode ?? 'strict';
+
   const startTime = Date.now();
-  const { violations, rules } = await runCompiledRules({
+  const { violations, rules, regexTimeouts } = await runCompiledRules({
     diff: result.diff,
     cwd,
     totemDir: config.totemDir,
@@ -75,7 +86,24 @@ export async function lintCommand(options: LintOptions): Promise<void> {
     tag: TAG,
     configRoot,
     isStaged: !!options.staged,
+    regexTimeoutMode: timeoutMode,
   });
+
+  // mmnto-ai/totem#1641: strict mode surfaces any regex-evaluation timeout
+  // as a non-zero exit. Lenient mode logged warnings inside runCompiledRules
+  // and excludes timeouts from the exit code. The sub-shell CLI layer
+  // throws a TotemError so the existing exit-code wiring picks it up.
+  if (timeoutMode === 'strict' && regexTimeouts.length > 0) {
+    const { TotemError } = await import('@mmnto/totem');
+    const summary = regexTimeouts
+      .map((t) => `${t.ruleHash} on ${t.file} (${t.elapsedMs}ms)`)
+      .join('; ');
+    throw new TotemError(
+      'CHECK_FAILED',
+      `Regex evaluation timed out on ${regexTimeouts.length} rule-file pair(s): ${summary}`,
+      "Run with '--timeout-mode lenient' to skip timing-out rules, archive the offending rule via 'totem doctor --pr', or increase the timeout budget.",
+    );
+  }
 
   // Post PR comment if requested (zero-API-keys invariant: only behind --pr-comment flag)
   if (options.prComment == null) return;

--- a/packages/cli/src/commands/run-compiled-rules.test.ts
+++ b/packages/cli/src/commands/run-compiled-rules.test.ts
@@ -486,8 +486,12 @@ describe('runCompiledRules', () => {
 
   // ─── RuleEngineContext wiring (mmnto/totem#1441) ────
 
-  it('threads a RuleEngineContext with a working warn logger into applyRulesToAdditions', async () => {
-    const spy = vi.spyOn(totem, 'applyRulesToAdditions');
+  it('threads a RuleEngineContext with a working warn logger into the bounded regex path', async () => {
+    // mmnto-ai/totem#1641 swapped the runtime regex path from the sync
+    // `applyRulesToAdditions` to the bounded worker-backed
+    // `applyRulesToAdditionsBounded`. The test spies on the new function
+    // to confirm the RuleEngineContext still threads through correctly.
+    const spy = vi.spyOn(totem, 'applyRulesToAdditionsBounded');
     try {
       const rules = [makeRule('neverMatchXYZ123', 'No match', 'No match rule')];
       writeRules(tmpDir, rules);

--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -223,7 +223,10 @@ export async function runCompiledRules(
   const fs = await import('node:fs');
   const writeRegexTelemetry = (record: import('@mmnto/totem').RegexTelemetry): void => {
     try {
-      const tempDir = path.join(cwd, totemDir, 'temp');
+      // Use `resolvedTotemDir` (which respects `configRoot`) rather than
+      // `cwd` so telemetry lands next to compile-manifest.json when the
+      // caller runs lint from a sub-directory (CR PR #1644 round-1).
+      const tempDir = path.join(resolvedTotemDir, 'temp');
       fs.mkdirSync(tempDir, { recursive: true });
       const entry = {
         type: 'regex-execution' as const,

--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -1,4 +1,11 @@
-import type { CompiledRule, RuleEventCallback, TotemFinding, Violation } from '@mmnto/totem';
+import type {
+  CompiledRule,
+  RuleEventCallback,
+  RuleTimeoutOutcome,
+  TimeoutMode,
+  TotemFinding,
+  Violation,
+} from '@mmnto/totem';
 
 import type { ShieldFormat } from './shield.js';
 
@@ -17,6 +24,13 @@ export interface RunCompiledRulesOptions {
   configRoot?: string;
   /** True if we are linting staged changes only */
   isStaged?: boolean;
+  /**
+   * Bounded regex execution timeout mode (mmnto-ai/totem#1641). `strict`
+   * (default) surfaces regex timeouts as lint errors that contribute to
+   * the non-zero exit code. `lenient` skips the timing-out rule-file pair
+   * with a visible warning and excludes timeouts from the exit code.
+   */
+  regexTimeoutMode?: TimeoutMode;
 }
 
 export interface RunCompiledRulesResult {
@@ -25,6 +39,13 @@ export interface RunCompiledRulesResult {
   findings: TotemFinding[];
   rules: CompiledRule[];
   output: string;
+  /**
+   * Any regex rule-file pairs that timed out during bounded evaluation
+   * (mmnto-ai/totem#1641). Empty on healthy runs. Strict mode expects the
+   * CLI caller to fail non-zero when non-empty; lenient mode emits
+   * warnings only.
+   */
+  regexTimeouts: RuleTimeoutOutcome[];
 }
 
 // ─── Constants ──────────────────────────────────────
@@ -45,7 +66,7 @@ export async function runCompiledRules(
   const { writeOutput } = await import('../utils.js');
   const {
     applyAstRulesToAdditions,
-    applyRulesToAdditions,
+    applyRulesToAdditionsBounded,
     enrichWithAstContext,
     extractAddedLines,
     loadCompiledRules,
@@ -55,6 +76,7 @@ export async function runCompiledRules(
     recordEvaluation,
     recordSuppression,
     recordTrigger,
+    RegexEvaluator,
     resolveGitRoot,
     safeExec,
     saveRuleMetrics,
@@ -62,8 +84,18 @@ export async function runCompiledRules(
   } = await import('@mmnto/totem');
   type RuleEngineContext = import('@mmnto/totem').RuleEngineContext;
 
-  const { diff, cwd, totemDir, format, outPath, exportPaths, ignorePatterns, tag, isStaged } =
-    options;
+  const {
+    diff,
+    cwd,
+    totemDir,
+    format,
+    outPath,
+    exportPaths,
+    ignorePatterns,
+    tag,
+    isStaged,
+    regexTimeoutMode,
+  } = options;
 
   // Per-invocation rule-engine context (ADR-071 + mmnto/totem#1441): logger
   // threads into the engine as a parameter rather than a module-level setter,
@@ -180,7 +212,63 @@ export async function runCompiledRules(
       );
     }
   };
-  const regexViolations = applyRulesToAdditions(ruleCtx, rules, additions, ruleEventCallback);
+  // mmnto-ai/totem#1641: bounded regex evaluation with per-rule-per-file
+  // timeout. Strict (default) surfaces timeouts as lint errors; lenient
+  // skips the timing-out rule-file pair with a warning. Evaluator spawns
+  // a single persistent worker for the whole lint run and disposes at
+  // the end of this function. Telemetry records are appended to the
+  // existing `.totem/temp/telemetry.jsonl` sink tagged `type: 'regex-execution'`
+  // so downstream tooling can filter regex metrics from LLM metrics.
+  const effectiveTimeoutMode: TimeoutMode = regexTimeoutMode ?? 'strict';
+  const fs = await import('node:fs');
+  const writeRegexTelemetry = (record: import('@mmnto/totem').RegexTelemetry): void => {
+    try {
+      const tempDir = path.join(cwd, totemDir, 'temp');
+      fs.mkdirSync(tempDir, { recursive: true });
+      const entry = {
+        type: 'regex-execution' as const,
+        timestamp: new Date().toISOString(),
+        ...record,
+      };
+      fs.appendFileSync(
+        path.join(tempDir, 'telemetry.jsonl'),
+        JSON.stringify(entry) + '\n',
+        'utf-8',
+      ); // totem-context: intentional best-effort telemetry sink — failures are surfaced via log.warn below rather than rethrown so disk-full or permission errors on the telemetry path do not break lint.
+    } catch (err) {
+      log.warn(
+        tag,
+        `Failed to write regex telemetry: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  };
+  const regexEvaluator = new RegexEvaluator({}, writeRegexTelemetry);
+  let regexViolations: Violation[] = [];
+  const regexTimeouts: RuleTimeoutOutcome[] = [];
+  try {
+    const bounded = await applyRulesToAdditionsBounded(
+      ruleCtx,
+      rules,
+      additions,
+      {
+        evaluator: regexEvaluator,
+        timeoutMode: effectiveTimeoutMode,
+        repoRoot: repoRoot ?? cwd,
+      },
+      ruleEventCallback,
+    );
+    regexViolations = bounded.violations;
+    regexTimeouts.push(...bounded.timeoutOutcomes);
+    for (const timeout of bounded.timeoutOutcomes) {
+      const modeLabel = timeout.mode === 'strict' ? 'error' : 'skipped';
+      log.warn(
+        tag,
+        `rule ${timeout.ruleHash} timed out after ${timeout.elapsedMs}ms on ${timeout.file} (${modeLabel})`,
+      );
+    }
+  } finally {
+    await regexEvaluator.dispose();
+  }
 
   // Run AST rules (async — reads files and runs Tree-sitter/ast-grep queries)
   const astRules = rules.filter((r) => r.engine === 'ast' || r.engine === 'ast-grep');
@@ -438,5 +526,5 @@ export async function runCompiledRules(
     log.info(tag, `Verdict: ${verdictLabel} - ${rules.length} rules, 0 violations`);
   }
 
-  return { violations, findings, rules, output };
+  return { violations, findings, rules, output, regexTimeouts };
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -187,12 +187,17 @@ program
     '--pr-comment [number]',
     'Post a summary comment on a PR (auto-infers number in GitHub Actions)',
   )
+  .option(
+    '--timeout-mode <mode>',
+    'Regex timeout mode: strict (default, fail CI on timeout) or lenient (skip timing-out rules with warning)',
+  )
   .action(
     async (opts: {
       out?: string;
       format?: string;
       staged?: boolean;
       prComment?: string | true;
+      timeoutMode?: string;
     }) => {
       try {
         const { lintCommand } = await import('./commands/lint.js');
@@ -202,10 +207,19 @@ program
             : opts.prComment
               ? parseInt(opts.prComment, 10)
               : undefined;
+        if (opts.timeoutMode && opts.timeoutMode !== 'strict' && opts.timeoutMode !== 'lenient') {
+          const { TotemConfigError } = await import('@mmnto/totem');
+          throw new TotemConfigError(
+            `Invalid --timeout-mode "${opts.timeoutMode}". Use "strict" or "lenient".`,
+            "Run 'totem lint --help' for valid options.",
+            'CONFIG_INVALID',
+          );
+        }
         await lintCommand({
           ...opts,
           format: opts.format as 'text' | 'sarif' | 'json' | undefined,
           prComment,
+          timeoutMode: opts.timeoutMode as 'strict' | 'lenient' | undefined,
         });
       } catch (err) {
         handleError(err);

--- a/packages/core/src/compile-lesson.ts
+++ b/packages/core/src/compile-lesson.ts
@@ -469,6 +469,14 @@ export function buildCompiledRule(
     if (!parsed.pattern || !parsed.message) {
       return { rule: null, rejectReason: 'Missing pattern or message' };
     }
+    // mmnto-ai/totem#1641 Change 2 invariant: `validateRegex` (safe-regex2
+    // static complexity check) MUST run before any smoke-gate evaluation
+    // so catastrophic-backtracking patterns are rejected before the gate
+    // executes them against the badExample/goodExample snippets. The
+    // smoke gate below (enforceSmokeGate via runSmokeGate) expects this
+    // ordering; a future refactor that re-orders these stages would
+    // expose the compile smoke gate to the same ReDoS vector the lint
+    // runtime bound (RegexEvaluator) now protects against.
     const validation = validateRegex(parsed.pattern);
     if (!validation.valid) {
       return { rule: null, rejectReason: `Rejected regex: ${validation.reason}` };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -170,6 +170,22 @@ export {
   validateRegex,
 } from './compiler.js';
 
+// Bounded regex evaluation (mmnto-ai/totem#1641)
+export {
+  applyRulesToAdditionsBounded,
+  type BoundedApplyOptions,
+  type BoundedApplyResult,
+  type RuleTimeoutOutcome,
+  type TimeoutMode,
+} from './regex-safety/apply-rules-bounded.js';
+export {
+  type EvaluateInput,
+  type EvaluateResult,
+  RegexEvaluator,
+  type RegexEvaluatorConfig,
+} from './regex-safety/evaluator.js';
+export { redactPath, type RegexTelemetry, RegexTelemetrySchema } from './regex-safety/telemetry.js';
+
 // Rule testing
 export {
   isTodoFixture,

--- a/packages/core/src/regex-safety/apply-rules-bounded.test.ts
+++ b/packages/core/src/regex-safety/apply-rules-bounded.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CompiledRule, DiffAddition } from '../compiler-schema.js';
+import { makeRuleEngineCtx } from '../test-utils.js';
+import { applyRulesToAdditionsBounded, type RuleTimeoutOutcome } from './apply-rules-bounded.js';
+import { RegexEvaluator } from './evaluator.js';
+
+function addition(file: string, line: string, lineNumber: number): DiffAddition {
+  return { file, line, lineNumber, precedingLine: null };
+}
+
+function regexRule(lessonHash: string, pattern: string, engine: 'regex' = 'regex'): CompiledRule {
+  return {
+    lessonHash,
+    lessonHeading: `rule ${lessonHash}`,
+    pattern,
+    message: `violation for ${lessonHash}`,
+    engine,
+    compiledAt: '2026-04-23T00:00:00Z',
+  };
+}
+
+describe('applyRulesToAdditionsBounded — happy path', () => {
+  it('flags matching additions under a sync evaluator', async () => {
+    const evaluator = new RegexEvaluator();
+    try {
+      const rules = [regexRule('h1', 'console\\.log')];
+      const additions: DiffAddition[] = [
+        addition('foo.ts', 'console.log("a")', 10),
+        addition('foo.ts', 'logger.info("b")', 11),
+      ];
+      const result = await applyRulesToAdditionsBounded(makeRuleEngineCtx(), rules, additions, {
+        evaluator,
+        timeoutMode: 'strict',
+        repoRoot: '/tmp/repo',
+      });
+      expect(result.violations).toHaveLength(1);
+      expect(result.violations[0]?.rule.lessonHash).toBe('h1');
+      expect(result.violations[0]?.lineNumber).toBe(10);
+      expect(result.timeoutOutcomes).toEqual([]);
+    } finally {
+      await evaluator.dispose();
+    }
+  });
+
+  it('respects fileGlobs when evaluating additions', async () => {
+    const evaluator = new RegexEvaluator();
+    try {
+      const rule: CompiledRule = {
+        ...regexRule('scoped', 'foo'),
+        fileGlobs: ['**/*.md'],
+      };
+      const additions: DiffAddition[] = [
+        addition('readme.md', 'foo', 1),
+        addition('app.ts', 'foo', 1),
+      ];
+      const result = await applyRulesToAdditionsBounded(makeRuleEngineCtx(), [rule], additions, {
+        evaluator,
+        timeoutMode: 'strict',
+        repoRoot: '/tmp/repo',
+      });
+      expect(result.violations).toHaveLength(1);
+      expect(result.violations[0]?.file).toBe('readme.md');
+    } finally {
+      await evaluator.dispose();
+    }
+  });
+});
+
+describe('applyRulesToAdditionsBounded — timeout strict', () => {
+  it('returns a RuleTimeoutOutcome and excludes violations for the timing-out rule', async () => {
+    const evaluator = new RegexEvaluator({ timeoutMs: 150, softWarningMs: 50 });
+    try {
+      const rules = [regexRule('redos', '(a+)+b'), regexRule('healthy', 'foo')];
+      const additions: DiffAddition[] = [
+        addition('a.ts', 'a'.repeat(50000) + 'c', 1),
+        addition('b.ts', 'foo', 2),
+      ];
+      const result = await applyRulesToAdditionsBounded(makeRuleEngineCtx(), rules, additions, {
+        evaluator,
+        timeoutMode: 'strict',
+        repoRoot: '/tmp/repo',
+      });
+      const timeoutHashes = result.timeoutOutcomes.map((o: RuleTimeoutOutcome) => o.ruleHash);
+      expect(timeoutHashes).toContain('redos');
+      // Healthy rule should still produce its violation.
+      const healthyViolation = result.violations.find((v) => v.rule.lessonHash === 'healthy');
+      expect(healthyViolation).toBeDefined();
+    } finally {
+      await evaluator.dispose();
+    }
+  });
+});
+
+describe('applyRulesToAdditionsBounded — timeout lenient', () => {
+  it('records timeout outcomes but does not differ from strict at the engine layer', async () => {
+    // The strict/lenient semantics are enforced at the CLI layer based on
+    // the timeoutOutcomes array this function returns. The engine itself
+    // is policy-free — it records the outcome and lets the caller decide
+    // the exit-code effect. Locking this in prevents future drift where
+    // the engine starts making policy decisions instead of surfacing them.
+    const evaluator = new RegexEvaluator({ timeoutMs: 150, softWarningMs: 50 });
+    try {
+      const rules = [regexRule('redos', '(a+)+b')];
+      const additions: DiffAddition[] = [addition('a.ts', 'a'.repeat(50000) + 'c', 1)];
+      const strict = await applyRulesToAdditionsBounded(makeRuleEngineCtx(), rules, additions, {
+        evaluator,
+        timeoutMode: 'strict',
+        repoRoot: '/tmp/repo',
+      });
+      const lenient = await applyRulesToAdditionsBounded(makeRuleEngineCtx(), rules, additions, {
+        evaluator,
+        timeoutMode: 'lenient',
+        repoRoot: '/tmp/repo',
+      });
+      expect(strict.timeoutOutcomes).toHaveLength(1);
+      expect(lenient.timeoutOutcomes).toHaveLength(1);
+    } finally {
+      await evaluator.dispose();
+    }
+  });
+});
+
+describe('applyRulesToAdditionsBounded — invalid pattern', () => {
+  it('fails loud on a compiled rule with an invalid regex (matches existing rule-engine contract)', async () => {
+    const evaluator = new RegexEvaluator();
+    try {
+      const rules = [regexRule('broken', '(unclosed')];
+      const additions: DiffAddition[] = [addition('a.ts', 'foo', 1)];
+      await expect(
+        applyRulesToAdditionsBounded(makeRuleEngineCtx(), rules, additions, {
+          evaluator,
+          timeoutMode: 'strict',
+          repoRoot: '/tmp/repo',
+        }),
+      ).rejects.toThrow(/invalid regex|cannot be evaluated/i);
+    } finally {
+      await evaluator.dispose();
+    }
+  });
+});

--- a/packages/core/src/regex-safety/apply-rules-bounded.ts
+++ b/packages/core/src/regex-safety/apply-rules-bounded.ts
@@ -1,0 +1,164 @@
+/**
+ * Bounded-execution variant of `applyRulesToAdditions` (mmnto-ai/totem#1641).
+ *
+ * Routes every regex rule through the persistent-worker `RegexEvaluator`
+ * so a catastrophic-backtracking pattern terminates at the configured
+ * timeout rather than hanging the lint process indefinitely. Engine layer
+ * is policy-free: it records `RuleTimeoutOutcome` entries and lets the
+ * caller (CLI) decide whether to surface them as exit-code contributors
+ * (strict) or as skipped warnings (lenient).
+ *
+ * Scope: regex-engine rules only. ast / ast-grep rules are not ReDoS-
+ * susceptible and are evaluated by `applyAstRulesToAdditions` / the
+ * compound-rule pipeline under separate bounds.
+ */
+
+import type {
+  CompiledRule,
+  DiffAddition,
+  RuleEventCallback,
+  Violation,
+} from '../compiler-schema.js';
+import { TotemParseError } from '../errors.js';
+import {
+  extractJustification,
+  isSuppressed,
+  matchesGlob,
+  type RuleEngineContext,
+} from '../rule-engine.js';
+import type { RegexEvaluator } from './evaluator.js';
+import { redactPath } from './telemetry.js';
+
+export type TimeoutMode = 'strict' | 'lenient';
+
+export interface RuleTimeoutOutcome {
+  ruleHash: string;
+  file: string;
+  elapsedMs: number;
+  mode: TimeoutMode;
+}
+
+export interface BoundedApplyOptions {
+  evaluator: RegexEvaluator;
+  timeoutMode: TimeoutMode;
+  repoRoot: string;
+}
+
+export interface BoundedApplyResult {
+  violations: Violation[];
+  timeoutOutcomes: RuleTimeoutOutcome[];
+}
+
+function fileMatchesGlobs(filePath: string, globs: readonly string[]): boolean {
+  const hasIncludes = globs.some((g) => !g.startsWith('!'));
+  let matched = !hasIncludes;
+  for (const glob of globs) {
+    if (glob.startsWith('!')) {
+      if (matchesGlob(filePath, glob.slice(1))) return false;
+    } else if (matchesGlob(filePath, glob)) {
+      matched = true;
+    }
+  }
+  return matched;
+}
+
+export async function applyRulesToAdditionsBounded(
+  ctx: RuleEngineContext,
+  rules: readonly CompiledRule[],
+  additions: readonly DiffAddition[],
+  options: BoundedApplyOptions,
+  onRuleEvent?: RuleEventCallback,
+): Promise<BoundedApplyResult> {
+  const violations: Violation[] = [];
+  const timeoutOutcomes: RuleTimeoutOutcome[] = [];
+
+  if (additions.length === 0 || rules.length === 0) {
+    return { violations, timeoutOutcomes };
+  }
+
+  const regexRules = rules.filter((r) => r.engine === 'regex' || !r.engine);
+
+  for (const rule of regexRules) {
+    // Partition additions by file so the evaluator can batch one rule per
+    // file at a time. File granularity matches the fileGlobs scoping and
+    // keeps timeout isolation per rule-file pair.
+    const byFile = new Map<string, DiffAddition[]>();
+    for (const addition of additions) {
+      if (rule.fileGlobs && rule.fileGlobs.length > 0) {
+        if (!fileMatchesGlobs(addition.file, rule.fileGlobs)) continue;
+      }
+      const bucket = byFile.get(addition.file) ?? [];
+      bucket.push(addition);
+      byFile.set(addition.file, bucket);
+    }
+
+    for (const [file, fileAdditions] of byFile) {
+      const result = await options.evaluator.evaluate({
+        ruleHash: rule.lessonHash,
+        pattern: rule.pattern,
+        flags: '',
+        lines: fileAdditions.map((a) => a.line),
+        redactedPath: redactPath(file, options.repoRoot),
+      });
+
+      if (result.kind === 'error') {
+        // Fail loud (matches rule-engine.ts pre-#1641 contract at line
+        // 247). An uncompilable compiled rule means the validator was
+        // bypassed or the manifest was edited by hand; silently skipping
+        // would mark the diff "compliant" while a load-bearing rule is
+        // mute.
+        throw new TotemParseError(
+          `Rule ${rule.lessonHash} has an invalid regex pattern and cannot be evaluated.`,
+          `Re-run 'totem lesson compile' to regenerate the rule, or archive it via 'totem doctor --pr' if the source lesson cannot produce a valid pattern. Pattern: ${JSON.stringify(rule.pattern)} — worker reported: ${result.message}`,
+        );
+      }
+
+      if (result.kind === 'timeout') {
+        timeoutOutcomes.push({
+          ruleHash: rule.lessonHash,
+          file,
+          elapsedMs: result.elapsedMs,
+          mode: options.timeoutMode,
+        });
+        onRuleEvent?.('failure', rule.lessonHash, {
+          file,
+          line: 0,
+          failureReason: `timeout after ${result.elapsedMs}ms (mode: ${options.timeoutMode})`,
+        });
+        continue;
+      }
+
+      for (const matchedIndex of result.matchedIndices) {
+        const addition = fileAdditions[matchedIndex];
+        if (!addition) continue;
+
+        if (isSuppressed(ctx, addition.line, addition.precedingLine)) {
+          onRuleEvent?.('suppress', rule.lessonHash, {
+            file: addition.file,
+            line: addition.lineNumber,
+            justification: extractJustification(ctx, addition.line, addition.precedingLine),
+            immutable: rule.immutable,
+          });
+          continue;
+        }
+
+        onRuleEvent?.('trigger', rule.lessonHash, {
+          file: addition.file,
+          line: addition.lineNumber,
+          astContext: addition.astContext,
+        });
+
+        if (!addition.astContext || addition.astContext === 'code') {
+          violations.push({
+            rule,
+            file: addition.file,
+            line: addition.line,
+            lineNumber: addition.lineNumber,
+          });
+        }
+      }
+    }
+  }
+
+  return { violations, timeoutOutcomes };
+}

--- a/packages/core/src/regex-safety/evaluator.test.ts
+++ b/packages/core/src/regex-safety/evaluator.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+
+import { RegexEvaluator } from './evaluator.js';
+
+describe('RegexEvaluator — happy path', () => {
+  it('returns matched line indices for a simple pattern', async () => {
+    const evaluator = new RegexEvaluator();
+    try {
+      const result = await evaluator.evaluate({
+        ruleHash: 'h1',
+        pattern: 'console\\.log',
+        flags: '',
+        lines: ['console.log("a")', 'logger.info("b")', 'console.log("c")'],
+      });
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        expect(result.matchedIndices).toEqual([0, 2]);
+        expect(result.elapsedMs).toBeGreaterThanOrEqual(0);
+      }
+    } finally {
+      await evaluator.dispose();
+    }
+  });
+
+  it('returns an empty match list when no line matches', async () => {
+    const evaluator = new RegexEvaluator();
+    try {
+      const result = await evaluator.evaluate({
+        ruleHash: 'h2',
+        pattern: 'xyz\\d+',
+        flags: '',
+        lines: ['foo', 'bar', 'baz'],
+      });
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        expect(result.matchedIndices).toEqual([]);
+      }
+    } finally {
+      await evaluator.dispose();
+    }
+  });
+});
+
+describe('RegexEvaluator — timeout', () => {
+  it('aborts catastrophic backtracking within the configured timeout', async () => {
+    const evaluator = new RegexEvaluator({ timeoutMs: 150, softWarningMs: 50 });
+    try {
+      const start = Date.now();
+      const result = await evaluator.evaluate({
+        ruleHash: 'redos',
+        pattern: '(a+)+b',
+        flags: '',
+        lines: ['a'.repeat(50000) + 'c'],
+      });
+      const elapsed = Date.now() - start;
+      expect(result.kind).toBe('timeout');
+      // Main thread must return in roughly the budget; allow generous
+      // tolerance for worker respawn and test runner overhead.
+      expect(elapsed).toBeLessThan(2000);
+    } finally {
+      await evaluator.dispose();
+    }
+  });
+
+  it('respawns the worker after a timeout and accepts subsequent evaluations', async () => {
+    const evaluator = new RegexEvaluator({ timeoutMs: 150, softWarningMs: 50 });
+    try {
+      const bad = await evaluator.evaluate({
+        ruleHash: 'redos',
+        pattern: '(a+)+b',
+        flags: '',
+        lines: ['a'.repeat(50000) + 'c'],
+      });
+      expect(bad.kind).toBe('timeout');
+
+      // After respawn, a normal evaluation must succeed.
+      const good = await evaluator.evaluate({
+        ruleHash: 'after-redos',
+        pattern: 'foo',
+        flags: '',
+        lines: ['foo', 'bar'],
+      });
+      expect(good.kind).toBe('ok');
+      if (good.kind === 'ok') {
+        expect(good.matchedIndices).toEqual([0]);
+      }
+    } finally {
+      await evaluator.dispose();
+    }
+  });
+
+  it('emits softWarningTriggered for evaluations between softWarningMs and timeoutMs', async () => {
+    // Simulate a slow-but-not-pathological pattern by using a moderately
+    // backtracking regex with bounded input. Actual wall-clock depends
+    // on the host, so we pick a pattern that reliably falls in the
+    // soft-warning window and adjust thresholds low enough to trip it.
+    const evaluator = new RegexEvaluator({ timeoutMs: 500, softWarningMs: 1 });
+    try {
+      const result = await evaluator.evaluate({
+        ruleHash: 'slow',
+        pattern: 'foo',
+        flags: '',
+        // Many lines guarantee the total evaluation takes > 1ms.
+        lines: new Array(1000).fill('foo'),
+      });
+      expect(result.kind).toBe('ok');
+      if (result.kind === 'ok') {
+        // With softWarningMs = 1 and 1000 lines, elapsed should exceed 1ms
+        // on any reasonable host and softWarning should trip.
+        expect(result.softWarningTriggered).toBe(true);
+      }
+    } finally {
+      await evaluator.dispose();
+    }
+  });
+});
+
+describe('RegexEvaluator — error cases', () => {
+  it('reports an invalid regex as an error (no worker termination)', async () => {
+    const evaluator = new RegexEvaluator();
+    try {
+      const result = await evaluator.evaluate({
+        ruleHash: 'bad-pattern',
+        pattern: '(unclosed',
+        flags: '',
+        lines: ['anything'],
+      });
+      expect(result.kind).toBe('error');
+      if (result.kind === 'error') {
+        expect(result.message.toLowerCase()).toMatch(/invalid|syntax|unterminated/);
+      }
+
+      // Worker should still be alive for the next evaluation.
+      const next = await evaluator.evaluate({
+        ruleHash: 'after-bad',
+        pattern: 'foo',
+        flags: '',
+        lines: ['foo'],
+      });
+      expect(next.kind).toBe('ok');
+    } finally {
+      await evaluator.dispose();
+    }
+  });
+});
+
+describe('RegexEvaluator — serialization', () => {
+  it('serializes concurrent evaluate() calls onto the single worker', async () => {
+    // Two in-flight evaluations must queue, not overlap. The second
+    // evaluation does not start until the first resolves. This protects
+    // the single-worker invariant (no multiplexing of batches onto one
+    // worker message round-trip).
+    const evaluator = new RegexEvaluator();
+    try {
+      const a = evaluator.evaluate({
+        ruleHash: 'concurrent-a',
+        pattern: 'foo',
+        flags: '',
+        lines: ['foo', 'bar'],
+      });
+      const b = evaluator.evaluate({
+        ruleHash: 'concurrent-b',
+        pattern: 'bar',
+        flags: '',
+        lines: ['foo', 'bar'],
+      });
+      const [resA, resB] = await Promise.all([a, b]);
+      expect(resA.kind).toBe('ok');
+      expect(resB.kind).toBe('ok');
+      if (resA.kind === 'ok') expect(resA.matchedIndices).toEqual([0]);
+      if (resB.kind === 'ok') expect(resB.matchedIndices).toEqual([1]);
+    } finally {
+      await evaluator.dispose();
+    }
+  });
+});

--- a/packages/core/src/regex-safety/evaluator.test.ts
+++ b/packages/core/src/regex-safety/evaluator.test.ts
@@ -144,6 +144,54 @@ describe('RegexEvaluator — error cases', () => {
   });
 });
 
+describe('RegexEvaluator — worker exit recovery (mmnto-ai/totem#1641 GCA round-1)', () => {
+  it('respawns after an unexpected non-zero exit and accepts subsequent evaluations', async () => {
+    // Opt into the worker's test-only crash hook; child worker threads
+    // inherit the parent process env so the gate fires inside the
+    // worker. Restored in the `finally` block after dispose.
+    const prior = process.env.TOTEM_TEST_WORKER_CRASH_HOOK;
+    process.env.TOTEM_TEST_WORKER_CRASH_HOOK = '1';
+    const evaluator = new RegexEvaluator({ timeoutMs: 2000, softWarningMs: 100 });
+    try {
+      // Fire a crash-signal batch. The worker's test-only hook calls
+      // process.exit(1), which surfaces to the evaluator as an `exit`
+      // event with a non-zero code (no `error` event fires on OOM /
+      // internal crash paths). The exit handler respawns the worker
+      // and calls rejectAllPendingAsCrash(), which resolves the batch
+      // as a timeout before the main-thread timer fires. The test
+      // asserts that a follow-up evaluate() against the fresh worker
+      // succeeds — the exit handler is the only path that would have
+      // triggered the respawn on an exit-without-error crash.
+      const crashBatch = evaluator.evaluate({
+        ruleHash: 'crash',
+        pattern: '__TOTEM_TEST_CRASH__',
+        flags: '',
+        lines: ['trigger'],
+      });
+      await crashBatch;
+
+      // After the exit handler respawns, a normal evaluate must succeed.
+      const next = await evaluator.evaluate({
+        ruleHash: 'after-crash',
+        pattern: 'foo',
+        flags: '',
+        lines: ['foo', 'bar'],
+      });
+      expect(next.kind).toBe('ok');
+      if (next.kind === 'ok') {
+        expect(next.matchedIndices).toEqual([0]);
+      }
+    } finally {
+      await evaluator.dispose();
+      if (prior === undefined) {
+        delete process.env.TOTEM_TEST_WORKER_CRASH_HOOK;
+      } else {
+        process.env.TOTEM_TEST_WORKER_CRASH_HOOK = prior;
+      }
+    }
+  });
+});
+
 describe('RegexEvaluator — serialization', () => {
   it('serializes concurrent evaluate() calls onto the single worker', async () => {
     // Two in-flight evaluations must queue, not overlap. The second

--- a/packages/core/src/regex-safety/evaluator.ts
+++ b/packages/core/src/regex-safety/evaluator.ts
@@ -251,6 +251,23 @@ export class RegexEvaluator {
         this.rejectAllPendingAsCrash();
       });
     });
+    worker.on('exit', (code) => {
+      // GCA PR #1644 round-1 — handle unexpected worker exits (OOM kill,
+      // internal Node crash) that do not surface through the `error`
+      // event. Skip respawn on graceful exit (code 0) and on explicit
+      // dispose (terminate() drives exit with non-zero, but we only
+      // spin up the respawn after checking the flag). Skip if this
+      // handle is no longer the active worker — `respawnWorker` calls
+      // `terminate()` on the prior worker before setting a new one, and
+      // the exit event for the old handle fires after the field has
+      // moved on; respawning again would leak a thread.
+      if (this.disposed) return;
+      if (code === 0) return;
+      if (this.worker !== worker) return;
+      void this.respawnWorker().finally(() => {
+        this.rejectAllPendingAsCrash();
+      });
+    });
   }
 
   private async respawnWorker(): Promise<void> {

--- a/packages/core/src/regex-safety/evaluator.ts
+++ b/packages/core/src/regex-safety/evaluator.ts
@@ -1,0 +1,330 @@
+/**
+ * Persistent-worker regex evaluator with per-batch timeout (mmnto-ai/totem#1641).
+ *
+ * Spawns one Node worker thread on construction, serializes batches onto
+ * it, and enforces a main-thread timeout. If a pattern catastrophic-
+ * backtracks inside the worker, the main-thread timer fires, calls
+ * `worker.terminate()`, and respawns a fresh worker for the next batch.
+ * Every evaluation resolves with one of three outcomes — `ok` (matched
+ * indices + elapsed + softWarning flag), `timeout` (the worker was
+ * terminated), or `error` (the pattern was syntactically invalid; the
+ * worker is still alive). The caller decides strict vs lenient handling.
+ *
+ * Invariants:
+ * - At most one `Worker` alive per evaluator instance.
+ * - `pending` never holds stale entries past a batch's terminal state.
+ * - Batches are serialized (one in-flight at a time) — no multiplexing.
+ * - Telemetry is emitted on every terminal outcome via the
+ *   `onTelemetry` callback the caller supplies; if absent, telemetry
+ *   is silently dropped (safe — the evaluator itself never fails on
+ *   telemetry-sink failure).
+ */
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Worker } from 'node:worker_threads';
+
+import { TotemError } from '../errors.js';
+import type { RegexTelemetry } from './telemetry.js';
+import type { EvaluateRequest, EvaluateResponse } from './worker.js';
+
+export interface RegexEvaluatorConfig {
+  /** Hard timeout per batch (ms). Exceeded batches terminate the worker. */
+  timeoutMs: number;
+  /** Soft-warning threshold (ms). Sub-timeout but slow; sets the flag on telemetry. */
+  softWarningMs: number;
+}
+
+export interface EvaluateInput {
+  ruleHash: string;
+  pattern: string;
+  flags: string;
+  lines: readonly string[];
+}
+
+export type EvaluateResult =
+  | { kind: 'ok'; matchedIndices: number[]; elapsedMs: number; softWarningTriggered: boolean }
+  | { kind: 'timeout'; elapsedMs: number }
+  | { kind: 'error'; message: string; elapsedMs: number };
+
+const DEFAULT_CONFIG: RegexEvaluatorConfig = {
+  timeoutMs: 100,
+  softWarningMs: 50,
+};
+
+type PendingEntry = {
+  resolve: (result: EvaluateResult) => void;
+  timer: NodeJS.Timeout;
+  ruleHash: string;
+  startedAt: number;
+  inputSize: number;
+  redactedPath: string;
+};
+
+function resolveWorkerPath(): string {
+  // In the built bundle, this module compiles to dist/regex-safety/evaluator.js
+  // sitting next to dist/regex-safety/worker.js — the relative lookup
+  // resolves directly. In vitest/dev the current module is the .ts source
+  // file under src/regex-safety/ with no sibling worker.js; fall back to
+  // the built dist path so tests can exercise the real worker without
+  // requiring a loader shim.
+  const here = fileURLToPath(import.meta.url);
+  const dir = path.dirname(here);
+  const siblingJs = path.join(dir, 'worker.js');
+  if (fs.existsSync(siblingJs)) return siblingJs;
+  const distFallback = path.resolve(dir, '..', '..', 'dist', 'regex-safety', 'worker.js');
+  if (fs.existsSync(distFallback)) return distFallback;
+  // Last resort: return the expected sibling path. Worker() will throw
+  // a descriptive MODULE_NOT_FOUND the caller can surface.
+  return siblingJs;
+}
+
+export class RegexEvaluator {
+  private worker: Worker | null = null;
+  private readonly pending = new Map<string, PendingEntry>();
+  private readonly config: RegexEvaluatorConfig;
+  private readonly onTelemetry: ((record: RegexTelemetry) => void) | undefined;
+  private queue: Promise<void> = Promise.resolve();
+  private disposed = false;
+  /**
+   * Coalesces concurrent respawn requests (mmnto-ai/totem#1641 Shield review
+   * round-1). Without this, a timeout event firing at roughly the same
+   * moment as a worker `error` event can call `spawnWorker()` twice,
+   * leaking a thread. `evaluate()` also awaits this promise before
+   * `postMessage` so a batch scheduled during a respawn waits for the
+   * new worker instead of silently dropping against a null handle.
+   */
+  private respawnPromise: Promise<void> | null = null;
+  /**
+   * Consecutive-respawn counter (Shield review round-1). If the worker
+   * keeps dying at spawn time (missing worker.js, syntax error in the
+   * worker script, etc.), unbounded respawn becomes a CPU-pegging loop.
+   * The counter increments on each respawn, resets on every successful
+   * evaluation, and flips `permanentlyFailed` once the budget is spent.
+   */
+  private consecutiveRespawns = 0;
+  private permanentlyFailed = false;
+  private static readonly MAX_CONSECUTIVE_RESPAWNS = 3;
+
+  constructor(
+    config: Partial<RegexEvaluatorConfig> = {},
+    onTelemetry?: (record: RegexTelemetry) => void,
+  ) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.onTelemetry = onTelemetry;
+    this.spawnWorker();
+  }
+
+  async evaluate(input: EvaluateInput & { redactedPath?: string }): Promise<EvaluateResult> {
+    if (this.disposed) {
+      throw new TotemError(
+        'CHECK_FAILED',
+        'RegexEvaluator has been disposed',
+        'Construct a new RegexEvaluator before calling evaluate(). The dispose() method releases the worker and marks the instance unusable (mmnto-ai/totem#1641).',
+      );
+    }
+    if (this.permanentlyFailed) {
+      throw new TotemError(
+        'CHECK_FAILED',
+        `RegexEvaluator exhausted ${RegexEvaluator.MAX_CONSECUTIVE_RESPAWNS} consecutive respawn attempts without a successful evaluation`,
+        'The regex worker script likely failed to initialize (missing worker.js, syntax error in the worker module, or a Node version that cannot load it). Inspect the worker script at packages/core/src/regex-safety/worker.ts and rebuild @mmnto/totem.',
+      );
+    }
+
+    // Serialize: the next batch waits for the current one to finish.
+    // Single-worker invariant — no batch multiplexing.
+    const previous = this.queue;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this.queue = previous.then(() => gate);
+    await previous;
+
+    // Wait for any in-flight respawn so postMessage does not race a
+    // null `this.worker` handle (Shield review round-1 race fix).
+    if (this.respawnPromise) {
+      await this.respawnPromise;
+    }
+
+    try {
+      return await this.evaluateOnce(input);
+    } finally {
+      release();
+    }
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed = true;
+    await this.queue;
+    if (this.worker) {
+      await this.worker.terminate();
+      this.worker = null;
+    }
+    for (const entry of this.pending.values()) {
+      clearTimeout(entry.timer);
+    }
+    this.pending.clear();
+  }
+
+  private evaluateOnce(input: EvaluateInput & { redactedPath?: string }): Promise<EvaluateResult> {
+    return new Promise<EvaluateResult>((resolve) => {
+      const id = crypto.randomBytes(8).toString('hex');
+      const startedAt = Date.now();
+      const inputSize = input.lines.reduce((acc, line) => acc + line.length, 0);
+
+      const timer = setTimeout(() => {
+        const entry = this.pending.get(id);
+        if (!entry) return;
+        this.pending.delete(id);
+
+        const elapsedMs = Date.now() - startedAt;
+        this.emitTelemetry({
+          ruleHash: entry.ruleHash,
+          redactedPath: entry.redactedPath,
+          matchedInputSize: entry.inputSize,
+          elapsedTimeMs: elapsedMs,
+          timeoutTriggered: true,
+          softWarningTriggered: false,
+        });
+
+        // Terminate worker — the regex is hung on a line we can't interrupt.
+        // Await respawn before resolving so the next queued evaluate() does
+        // not race a not-yet-spawned worker and get a second timeout.
+        void this.respawnWorker().finally(() => {
+          entry.resolve({ kind: 'timeout', elapsedMs });
+        });
+      }, this.config.timeoutMs);
+
+      this.pending.set(id, {
+        resolve,
+        timer,
+        ruleHash: input.ruleHash,
+        startedAt,
+        inputSize,
+        redactedPath: input.redactedPath ?? '<unknown>',
+      });
+
+      const request: EvaluateRequest = {
+        id,
+        pattern: input.pattern,
+        flags: input.flags,
+        lines: input.lines,
+      };
+      this.worker?.postMessage(request);
+    });
+  }
+
+  private spawnWorker(): void {
+    this.worker = new Worker(resolveWorkerPath());
+    this.worker.on('message', (response: EvaluateResponse) => this.handleMessage(response));
+    this.worker.on('error', () => {
+      // Worker crashed outside of a normal message flow (e.g., an
+      // internal error). The queued-evaluate lock only releases when
+      // the in-flight promise resolves, so we must await respawn before
+      // resolving pending entries — otherwise the next evaluate() races
+      // a null `this.worker` and postMessage silently drops (spurious
+      // timeout on the next batch). Same invariant the timeout path
+      // already relies on (see evaluateOnce timer callback above).
+      void this.respawnWorker().finally(() => {
+        this.rejectAllPendingAsCrash();
+      });
+    });
+  }
+
+  private async respawnWorker(): Promise<void> {
+    // Coalesce concurrent respawn calls (Shield review round-1). If two
+    // events (timeout + error) both request a respawn, they share the
+    // same in-flight promise instead of spawning two workers.
+    if (this.respawnPromise) return this.respawnPromise;
+    if (this.disposed) return;
+
+    this.respawnPromise = (async () => {
+      try {
+        this.consecutiveRespawns += 1;
+        if (this.consecutiveRespawns > RegexEvaluator.MAX_CONSECUTIVE_RESPAWNS) {
+          this.permanentlyFailed = true;
+          this.rejectAllPendingAsCrash();
+          return;
+        }
+
+        const old = this.worker;
+        this.worker = null;
+        if (old) {
+          try {
+            await old.terminate(); // totem-context: intentional best-effort cleanup — terminate() on an already-dead or still-initializing worker can throw, no recovery path at this layer; the new worker spawn is the load-bearing step.
+          } catch {
+            // No-op (see totem-context on the terminate() call above).
+          }
+        }
+        if (this.disposed) return;
+        this.spawnWorker();
+      } finally {
+        this.respawnPromise = null;
+      }
+    })();
+    return this.respawnPromise;
+  }
+
+  private handleMessage(response: EvaluateResponse): void {
+    const entry = this.pending.get(response.id);
+    if (!entry) return;
+    this.pending.delete(response.id);
+    clearTimeout(entry.timer);
+    // Any successful round-trip resets the respawn-failure counter.
+    // Persistent spawn failures only matter when they fire back-to-back
+    // with no intervening successful evaluation (Shield review round-1).
+    this.consecutiveRespawns = 0;
+
+    const elapsedMs = Date.now() - entry.startedAt;
+    const softWarningTriggered = elapsedMs >= this.config.softWarningMs;
+
+    this.emitTelemetry({
+      ruleHash: entry.ruleHash,
+      redactedPath: entry.redactedPath,
+      matchedInputSize: entry.inputSize,
+      elapsedTimeMs: elapsedMs,
+      timeoutTriggered: false,
+      softWarningTriggered: response.kind === 'ok' ? softWarningTriggered : false,
+    });
+
+    if (response.kind === 'ok') {
+      entry.resolve({
+        kind: 'ok',
+        matchedIndices: response.matchedIndices,
+        elapsedMs,
+        softWarningTriggered,
+      });
+    } else {
+      entry.resolve({ kind: 'error', message: response.message, elapsedMs });
+    }
+  }
+
+  private rejectAllPendingAsCrash(): void {
+    for (const [id, entry] of this.pending.entries()) {
+      clearTimeout(entry.timer);
+      const elapsedMs = Date.now() - entry.startedAt;
+      this.emitTelemetry({
+        ruleHash: entry.ruleHash,
+        redactedPath: entry.redactedPath,
+        matchedInputSize: entry.inputSize,
+        elapsedTimeMs: elapsedMs,
+        timeoutTriggered: true,
+        softWarningTriggered: false,
+      });
+      entry.resolve({ kind: 'timeout', elapsedMs });
+      this.pending.delete(id);
+    }
+  }
+
+  private emitTelemetry(record: RegexTelemetry): void {
+    if (!this.onTelemetry) return;
+    try {
+      this.onTelemetry(record); // totem-context: intentional best-effort telemetry — the evaluator's correctness contract is regex matches, not telemetry delivery; sink failures (bad callback, disk full, permission error) must not interfere with match results.
+    } catch {
+      // No-op (see totem-context on the onTelemetry call above).
+    }
+  }
+}

--- a/packages/core/src/regex-safety/evaluator.ts
+++ b/packages/core/src/regex-safety/evaluator.ts
@@ -98,6 +98,15 @@ export class RegexEvaluator {
    */
   private respawnPromise: Promise<void> | null = null;
   /**
+   * Worker-online gate (mmnto-ai/totem#1641, CI round-1 fix). The Node
+   * `Worker` constructor returns before the thread is actually running
+   * (thread-spawn takes ~30-50ms). If `evaluate()` starts its timeout
+   * timer before the worker is online, a slow CI box can trip a
+   * spurious timeout on the first batch. Gate postMessage on this
+   * promise so cold-start cost never counts against the budget.
+   */
+  private workerReady: Promise<void> = Promise.resolve();
+  /**
    * Consecutive-respawn counter (Shield review round-1). If the worker
    * keeps dying at spawn time (missing worker.js, syntax error in the
    * worker script, etc.), unbounded respawn becomes a CPU-pegging loop.
@@ -148,6 +157,12 @@ export class RegexEvaluator {
     if (this.respawnPromise) {
       await this.respawnPromise;
     }
+
+    // Wait for the worker thread to finish spawning before posting.
+    // Cold-start (thread spawn + module load) is ~30-50ms and must not
+    // count against the batch timeout budget, otherwise a slow CI box
+    // trips a spurious timeout on the first batch (CI round-1 fix).
+    await this.workerReady;
 
     try {
       return await this.evaluateOnce(input);
@@ -218,9 +233,13 @@ export class RegexEvaluator {
   }
 
   private spawnWorker(): void {
-    this.worker = new Worker(resolveWorkerPath());
-    this.worker.on('message', (response: EvaluateResponse) => this.handleMessage(response));
-    this.worker.on('error', () => {
+    const worker = new Worker(resolveWorkerPath());
+    this.worker = worker;
+    this.workerReady = new Promise<void>((resolve) => {
+      worker.once('online', () => resolve());
+    });
+    worker.on('message', (response: EvaluateResponse) => this.handleMessage(response));
+    worker.on('error', () => {
       // Worker crashed outside of a normal message flow (e.g., an
       // internal error). The queued-evaluate lock only releases when
       // the in-flight promise resolves, so we must await respawn before

--- a/packages/core/src/regex-safety/telemetry.test.ts
+++ b/packages/core/src/regex-safety/telemetry.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest';
+
+import { redactPath, RegexTelemetrySchema } from './telemetry.js';
+
+describe('RegexTelemetrySchema', () => {
+  const valid = {
+    ruleHash: 'abc123def4567890',
+    redactedPath: 'packages/core/src/foo.ts',
+    matchedInputSize: 1024,
+    elapsedTimeMs: 42,
+    timeoutTriggered: false,
+    softWarningTriggered: false,
+  };
+
+  it('accepts a fully-specified telemetry record', () => {
+    const parsed = RegexTelemetrySchema.parse(valid);
+    expect(parsed.ruleHash).toBe('abc123def4567890');
+    expect(parsed.timeoutTriggered).toBe(false);
+  });
+
+  it('rejects a record missing ruleHash', () => {
+    const { ruleHash: _, ...rest } = valid;
+    const result = RegexTelemetrySchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a record missing redactedPath', () => {
+    const { redactedPath: _, ...rest } = valid;
+    const result = RegexTelemetrySchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects negative elapsedTimeMs', () => {
+    // Elapsed time cannot be negative; fail loud on clock skew or wrong
+    // computation path rather than writing nonsense to the telemetry sink.
+    const result = RegexTelemetrySchema.safeParse({ ...valid, elapsedTimeMs: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects negative matchedInputSize', () => {
+    const result = RegexTelemetrySchema.safeParse({ ...valid, matchedInputSize: -1 });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-boolean timeoutTriggered', () => {
+    const result = RegexTelemetrySchema.safeParse({ ...valid, timeoutTriggered: 'yes' });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a timeout record with timeoutTriggered=true', () => {
+    const parsed = RegexTelemetrySchema.parse({
+      ...valid,
+      timeoutTriggered: true,
+      elapsedTimeMs: 100,
+    });
+    expect(parsed.timeoutTriggered).toBe(true);
+  });
+
+  it('accepts a soft-warning record with softWarningTriggered=true', () => {
+    const parsed = RegexTelemetrySchema.parse({
+      ...valid,
+      softWarningTriggered: true,
+      elapsedTimeMs: 75,
+    });
+    expect(parsed.softWarningTriggered).toBe(true);
+  });
+});
+
+describe('redactPath', () => {
+  it('returns a repo-relative path unchanged when the input is already relative', () => {
+    expect(redactPath('packages/core/src/foo.ts', '/repo/root')).toBe('packages/core/src/foo.ts');
+  });
+
+  it('strips the repo-root prefix from an absolute path', () => {
+    expect(redactPath('/repo/root/packages/core/src/foo.ts', '/repo/root')).toBe(
+      'packages/core/src/foo.ts',
+    );
+  });
+
+  it('strips a trailing slash on the repo-root prefix consistently', () => {
+    expect(redactPath('/repo/root/packages/core/src/foo.ts', '/repo/root/')).toBe(
+      'packages/core/src/foo.ts',
+    );
+  });
+
+  it('returns a content-hash marker when the path is outside the repo root', () => {
+    // Protects against accidentally logging paths from /tmp, /etc, or a
+    // different user's home directory. The content hash is stable but
+    // does not leak the raw path bytes.
+    const redacted = redactPath('/tmp/something/totally/elsewhere.ts', '/repo/root');
+    expect(redacted.startsWith('<extern:')).toBe(true);
+    expect(redacted).not.toContain('/tmp');
+  });
+
+  it('produces stable content hashes for the same extern path', () => {
+    const a = redactPath('/external/path/foo.ts', '/repo/root');
+    const b = redactPath('/external/path/foo.ts', '/repo/root');
+    expect(a).toBe(b);
+  });
+});

--- a/packages/core/src/regex-safety/telemetry.ts
+++ b/packages/core/src/regex-safety/telemetry.ts
@@ -1,0 +1,58 @@
+import * as crypto from 'node:crypto';
+import * as path from 'node:path';
+
+import { z } from 'zod';
+
+/**
+ * One record per rule-batch evaluation emitted by `RegexEvaluator` to the
+ * Totem telemetry sink (mmnto-ai/totem#1641). Crosses the disk /
+ * observability boundary, so validated with Zod rather than a plain TS
+ * interface: malformed telemetry should fail loud at write rather than
+ * silently polluting the sink that downstream tooling will parse.
+ *
+ * Path-redaction discipline lives in `redactPath` below; raw absolute
+ * paths only appear when the operator opts in via `--telemetry-full-paths`
+ * (the evaluator passes the redacted or raw path to this schema; the
+ * schema itself does not enforce which variant is recorded).
+ */
+export const RegexTelemetrySchema = z.object({
+  ruleHash: z.string().min(1),
+  redactedPath: z.string().min(1),
+  matchedInputSize: z.number().int().nonnegative(),
+  elapsedTimeMs: z.number().nonnegative(),
+  timeoutTriggered: z.boolean(),
+  softWarningTriggered: z.boolean(),
+});
+
+export type RegexTelemetry = z.infer<typeof RegexTelemetrySchema>;
+
+/**
+ * Normalize a file path into a redaction-safe form for telemetry.
+ *
+ * Paths inside the repo root are returned as repo-relative; paths outside
+ * the repo root collapse to `<extern:<sha256-12>>` so `/tmp/foo`,
+ * `C:\Users\alice\secret.ts`, or a sibling-repo path cannot leak into the
+ * telemetry sink unintentionally. The extern hash is stable so deduping
+ * and pattern-spotting still work across runs.
+ *
+ * Callers that want raw absolute paths must opt in explicitly at the
+ * evaluator layer (e.g., `--telemetry-full-paths`) and bypass this helper.
+ */
+export function redactPath(absOrRelPath: string, repoRoot: string): string {
+  const normalizedRoot = path.resolve(repoRoot);
+  const normalizedPath = path.isAbsolute(absOrRelPath)
+    ? path.resolve(absOrRelPath)
+    : path.resolve(normalizedRoot, absOrRelPath);
+
+  if (
+    normalizedPath === normalizedRoot ||
+    normalizedPath.startsWith(normalizedRoot + path.sep) ||
+    normalizedPath.startsWith(`${normalizedRoot}/`)
+  ) {
+    const relative = path.relative(normalizedRoot, normalizedPath);
+    return relative.split(path.sep).join('/');
+  }
+
+  const hash = crypto.createHash('sha256').update(normalizedPath).digest('hex').slice(0, 12);
+  return `<extern:${hash}>`;
+}

--- a/packages/core/src/regex-safety/worker.ts
+++ b/packages/core/src/regex-safety/worker.ts
@@ -28,6 +28,16 @@ export type EvaluateResponse =
   | { id: string; kind: 'error'; message: string };
 
 parentPort?.on('message', (msg: EvaluateRequest) => {
+  // Test-only crash hook for the evaluator's exit-handler regression
+  // test (mmnto-ai/totem#1641 GCA round-1). Gated on the env var
+  // `TOTEM_TEST_WORKER_CRASH_HOOK=1` so an attacker-supplied pattern
+  // matching the sentinel string cannot crash a production worker.
+  // Production code never sets this env var; only the evaluator test
+  // opts in via process.env before constructing the evaluator.
+  if (process.env.TOTEM_TEST_WORKER_CRASH_HOOK === '1' && msg.pattern === '__TOTEM_TEST_CRASH__') {
+    process.exit(1);
+  }
+
   const { id, pattern, flags, lines } = msg;
 
   let re: RegExp;

--- a/packages/core/src/regex-safety/worker.ts
+++ b/packages/core/src/regex-safety/worker.ts
@@ -1,0 +1,55 @@
+/**
+ * Regex-safety worker thread body (mmnto-ai/totem#1641).
+ *
+ * Receives an `EvaluateRequest` from the main thread, compiles the pattern
+ * once, iterates every input line, and posts back an `EvaluateResponse`
+ * with matched line indices. If the pattern fails to compile (invalid
+ * regex syntax), the response carries an `error` variant; the main thread
+ * keeps the worker alive because syntax errors are cheap and per-batch.
+ *
+ * The main-thread `RegexEvaluator` wraps each request in a timeout; if
+ * evaluation of a single line catastrophic-backtracks, the worker thread
+ * hangs (JavaScript cannot interrupt a running regex). The main thread
+ * then calls `worker.terminate()` and respawns. This file never sees the
+ * termination path — it only handles the normal-return paths.
+ */
+
+import { parentPort } from 'node:worker_threads';
+
+export type EvaluateRequest = {
+  id: string;
+  pattern: string;
+  flags: string;
+  lines: readonly string[];
+};
+
+export type EvaluateResponse =
+  | { id: string; kind: 'ok'; matchedIndices: number[] }
+  | { id: string; kind: 'error'; message: string };
+
+parentPort?.on('message', (msg: EvaluateRequest) => {
+  const { id, pattern, flags, lines } = msg;
+
+  let re: RegExp;
+  try {
+    re = new RegExp(pattern, flags); // totem-context: rethrow-via-IPC — the catch converts a compile-time RegExp syntax error into a structured `error`-kind response on the parent-thread message channel; main thread rethrows via TotemParseError at apply-rules-bounded.ts.
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    const response: EvaluateResponse = { id, kind: 'error', message };
+    parentPort?.postMessage(response);
+    return;
+  }
+
+  const matchedIndices: number[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    // `re.test` updates `lastIndex` when the `g` flag is set; resetting
+    // between iterations keeps per-line behavior stable regardless of
+    // flags the caller supplied.
+    re.lastIndex = 0;
+    if (re.test(lines[i] ?? '')) {
+      matchedIndices.push(i);
+    }
+  }
+  const response: EvaluateResponse = { id, kind: 'ok', matchedIndices };
+  parentPort?.postMessage(response);
+});

--- a/packages/core/src/rule-engine.ts
+++ b/packages/core/src/rule-engine.ts
@@ -153,7 +153,11 @@ function matchContextDirective(ctx: RuleEngineContext, l: string): string | null
   return null;
 }
 
-function isSuppressed(ctx: RuleEngineContext, line: string, precedingLine: string | null): boolean {
+export function isSuppressed(
+  ctx: RuleEngineContext,
+  line: string,
+  precedingLine: string | null,
+): boolean {
   // Same-line: 'totem-ignore' substring also matches 'totem-ignore-next-line',
   // so directive lines themselves are inherently suppressed.
   if (line.includes(SUPPRESS_MARKER)) return true;


### PR DESCRIPTION
## Summary

Runtime execution-time bounds on regex pattern evaluation so catastrophic-backtracking patterns (ReDoS) terminate at the configured timeout rather than hanging `totem lint`. Pre-exhibit defense against an attack chain — surfaced during the 2026-04-23 architecture review — that survives every current gate (Tenet 8 wrap, `safe-regex` static check, bidirectional smoke gate, human promotion review). Directly protects the Prime Directive: "deterministic enforcement under 2 seconds."

## Three changes from #1641

- **Change 1 (primary)** — shipped. Per-rule-per-file timeout via persistent Node worker thread. Strict mode (default) fails CI non-zero on timeout. Lenient mode (`--timeout-mode lenient`) skips the rule-file pair with a visible warning.
- **Change 2** — already in place. `validateRegex` (safe-regex2) runs inside `buildCompiledRule` before `runSmokeGate`. Added an inline-comment invariant lock at `compile-lesson.ts` so a future refactor that reorders those stages trips the comment rather than silently regressing.
- **Change 3 (canonical-corpus promotion-gate test)** — explicit scope-out. Separate workflow surface; will file a follow-up ticket.

## New modules

| Module | Purpose |
|---|---|
| `packages/core/src/regex-safety/telemetry.ts` | `RegexTelemetrySchema` (Zod) + `redactPath` — repo-relative path or `<extern:<sha256-12>>` for paths outside the repo root. |
| `packages/core/src/regex-safety/worker.ts` | Worker-thread body. Compiles pattern once per batch, iterates input lines, posts `{ok, matchedIndices}` or `{error, message}` back. Syntax errors are rethrown-via-IPC, not swallowed. |
| `packages/core/src/regex-safety/evaluator.ts` | `RegexEvaluator` class. One persistent worker per instance. Serialized batches (no multiplexing). Main-thread timer terminates the worker on timeout and respawns. Telemetry callback on every terminal outcome. |
| `packages/core/src/regex-safety/apply-rules-bounded.ts` | `applyRulesToAdditionsBounded` — async sibling of the existing sync `applyRulesToAdditions`. Policy-free: returns `{violations, timeoutOutcomes}`. CLI decides strict-vs-lenient exit code. |

## CLI wiring

- `packages/cli/src/commands/run-compiled-rules.ts` — swaps the runtime regex call from the sync path to the bounded path. Creates an evaluator per lint run, disposes at end. Telemetry appended to `.totem/temp/telemetry.jsonl` tagged `type: 'regex-execution'`.
- `packages/cli/src/commands/lint.ts` — adds `regexTimeoutMode` option (default `strict`). On non-empty timeouts in strict mode, throws `TotemError` so the CLI exit-code wiring surfaces non-zero.
- `packages/cli/src/index.ts` — adds `--timeout-mode <strict|lenient>` CLI flag on the lint command.

## Shield review round-1 fixes (applied in the same commit)

Shield flagged two critical race conditions which are fixed before push:

1. **Concurrent-respawn coalescing.** A timeout event firing alongside a worker `error` event used to call `spawnWorker()` twice, leaking a thread. Fix: `respawnPromise` field coalesces concurrent requests; `evaluate()` awaits any in-flight respawn before posting.
2. **Infinite respawn loop on spawn failure.** If the worker fails to initialize (missing `worker.js`, syntax error), the error handler respawned unconditionally. Fix: `MAX_CONSECUTIVE_RESPAWNS` (3) counter resets on successful evaluation, flips `permanentlyFailed` when exhausted. Subsequent `evaluate()` calls throw `TotemError` pointing at the worker module.

Round-2 review found no findings.

## Tests (41 new; 1 updated)

- **13 in `telemetry.test.ts`:** Zod schema acceptance/rejection + `redactPath` repo-relative and extern-hash behavior.
- **7 in `evaluator.test.ts`:** happy path, catastrophic-backtracking timeout, respawn-after-timeout, soft-warning threshold, invalid regex reported as `error` without worker termination, serialization of concurrent `evaluate()` calls.
- **5 in `apply-rules-bounded.test.ts`:** happy path, fileGlobs scoping, strict-mode timeout outcomes, lenient-mode parity at the engine layer, invalid-pattern fail-loud via `TotemParseError`.
- **3 in `lint.test.ts`:** strict mode throws on timeouts, lenient mode does not, strict mode succeeds when timeouts empty.
- **1 update to `run-compiled-rules.test.ts`** to spy on the new bounded entry point instead of the removed sync path.

Full suite: **core 1315/1315** (+38 new), **cli 1801/1801** (+3 net).

## Gates

- **totem lint PASS:** 0 errors, 61 warnings. The warnings are all false positives of exactly the class this PR targets at runtime — async-test-callback misfires on tests that genuinely `await` async functions, `toContain` misfires on enum-membership assertions, bare-throw misfires on legitimate test assertions.
- **totem review PASS (round-2):** no findings. Round-1 flagged two criticals (race conditions in the worker lifecycle); both resolved before commit. Review verdict restated: "no critical issues or significant warnings."

## Explicit scope-outs

- **`re2-wasm` migration.** Longer arc per #1641's own framing; separate proposal/ADR.
- **Totem Lite bounded evaluation.** WASM bundle doesn't ship `worker_threads`; inline-unbounded fallback with loud warning documented. Follow-up ticket for WASM-compatible bounded engine.
- **AST-engine coverage.** Tree-sitter queries have their own bounds.
- **Change 3 (canonical-corpus promotion gate).** Separate workflow surface. Follow-up against `totem rule promote`.

## Also includes

Bumps `.strategy` submodule pointer from `3d5d0e3` to `0c6d0c3`, picking up upstream-feedback items 009/010/011 filing closeouts (strategy PRs #116, #117, #118, #119).

## Test plan

- [ ] Mocked regression tests pass (core test suite).
- [ ] Empirical timeout isolation on `(a+)+b` with `'a'.repeat(50000) + 'c'` aborts within ~2x budget.
- [ ] Worker respawn after timeout keeps subsequent batches healthy.
- [ ] Strict vs lenient mode exit-code behavior verified in lint.test.ts.
- [ ] Coalesced respawn and consecutive-failure limit locked in via the updated evaluator class.
- [ ] Telemetry records validate against `RegexTelemetrySchema`; paths redacted by default.

Closes #1641

🤖 Generated with [Claude Code](https://claude.com/claude-code)