### PR TITLE
feat(cli): test-contract scope classifier in compile prompt (#1626)

### DIFF
--- a/.totem/specs/1626.md
+++ b/.totem/specs/1626.md
@@ -1,0 +1,159 @@
+### Problem Statement
+
+The `compile-worker` automatically derives a default applicability scope for new rules, but incorrectly assumes all lessons target standard application code (`!**/*.test.*`). This causes test-specific lessons (e.g., assertion rules, mocking contracts) to be explicitly excluded from the test files they are meant to govern.
+
+### Architectural Context
+
+This is a sibling to issue #1598 (context-sensitive lesson extraction gap). Both represent pattern-derivation failure modes in the compile worker. While #1598 addressed context guards in lesson prose, this issue addresses scope inversion.
+
+### Files to Examine
+
+1. `packages/core/src/compile-lesson.ts` — Core logic where the default scope heuristic currently lives and needs to be overridden.
+2. `packages/cli/src/compile-templates.ts` — The compiler system prompts; determines if the LLM is explicitly instructed on how to handle test scopes.
+3. `packages/cli/src/commands/compile.ts` — The orchestration layer for the compile worker.
+4. `packages/cli/src/commands/wrap.ts` — Existing CLI command structure, useful as a reference for adding the new `rescope` command.
+
+### Technical Approach & Contracts
+
+1. **Scope Heuristic Utility:** Introduce a deterministic function `detectTestContract(lesson: LessonInput): boolean` to classify test lessons.
+   - **Tags Signal:** Returns `true` if `lesson.tags` includes `testing`.
+   - **Code Signal:** Returns `true` if `lesson.body` matches testing patterns (`/describe\(|it\(|test\(|expect\(/`).
+   - **Keyword Signal:** Returns `true` if `lesson.title` contains `test`, `spec`, `assertion`, or `contract` (subject to edge-case mitigation).
+2. **Compiler Injection:** Update `compileLesson` to apply the heuristic. If `detectTestContract` is `true`, alter the baseline scope from standard app code to test-inclusive: `**/*.test.ts, **/*.spec.ts, **/tests/**/*.ts, **/__tests__/**/*.ts`. Pass this signal explicitly to the prompt in `compile-templates.ts`.
+3. **Rescope Command:** Create a `totem rule rescope` command. It will scan the compiled JSON corpus using `readJsonSafe` (from Shared Helpers), apply the heuristic, and surgically update the scope strings for mis-scoped test rules, avoiding a full recompile.
+
+**Data Contracts:**
+
+```typescript
+interface ScopeHeuristicResult {
+  isTestContract: boolean;
+  suggestedScope: string;
+}
+```
+
+### Edge Cases & Traps
+
+- **The "Contract" False Positive:** The issue requests checking the title for the word "contract". However, lessons about "API Contracts" or "Data Contracts" will be incorrectly scoped to test files if triggered solely by this keyword. The heuristic _must_ pair the word "contract" with another signal (like test code patterns) or weight it lower than explicit `testing` tags.
+- **LLM Specificity Loss:** If the LLM correctly infers a highly specific test scope (e.g., `packages/e2e/**/*.spec.ts`), blindly overwriting it with a generic `**/*.test.*` default will destroy that specificity. The heuristic should only invert the _default exclusions_ (`!**/*.test.*`), not wholesale replace custom inclusions.
+- **Test Helpers Exclusion:** A scope of `**/*.test.*` misses test helper and fixture files. The injected scope must include directories conventionally used for testing (e.g., `**/test-utils/**`).
+- **File Parsing Risks:** Manually parsing the rule corpus JSON files using `fs.readFileSync` combined with `JSON.parse` is unsafe. You must use the shared `readJsonSafe` helper.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Implement the Test Scope Heuristic**
+  - Create `packages/core/src/scope-heuristic.ts` and `packages/core/src/scope-heuristic.test.ts`.
+  - Implement `detectTestContract(lesson: LessonInput): ScopeHeuristicResult`.
+  - > TEST DIRECTIVE: Before implementing, write a failing test named `rejects false-positive test classification for generic API contract lessons` that proves lessons containing the word "contract" but lacking test-code patterns are NOT classified as test contracts.
+  - Implement the regex and tag checking logic based on the candidate signals in the issue.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Integrate Heuristic into Compile Worker**
+  - Modify `packages/core/src/compile-lesson.ts` and its corresponding test file.
+  - Call `detectTestContract` before invoking `runOrchestrator` or `parseCompilerResponse`.
+  - If a test contract is detected, adjust the fallback scope passed to the compiler to `**/*.test.ts, **/*.spec.ts, **/tests/**/*.ts`.
+  - Update `packages/cli/src/compile-templates.ts` to instruct the LLM: "If the lesson is a testing contract, ensure the scope INCLUDES test files and EXCLUDES standard application code."
+  - > TEST DIRECTIVE: Before implementing, write a failing test named `flips default scope exclusions to inclusions when test contract is detected` to ensure test files are no longer negated.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Create the `rule rescope` Command**
+  - Create `packages/cli/src/commands/rule-rescope.ts` (and register it in the CLI entrypoint).
+  - Implement a command that finds all compiled rule JSON artifacts in the local target (e.g., `.junie/skills/totem-rules/` or equivalent).
+  - Use `readJsonSafe` from `@mmnto/totem` to read each rule JSON file. Do not use `JSON.parse`.
+  - For each rule, re-evaluate its source lesson against `detectTestContract`. If it is a test contract _and_ its scope contains `!**/*.test.*`, rewrite the scope string and save.
+  - > TEST DIRECTIVE: Before implementing, write a failing test named `updates mis-scoped test exclusions to inclusions without wiping custom rule paths` to ensure targeted scope fixes.
+  - write test → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Heuristic Accuracy:** Ensure "Normalize temp paths for cross-platform equality" (from the issue) successfully triggers the test-contract flag based on code examples (`expect`, `test`), even if the title lacks keywords.
+- **False-Positive Prevention:** Ensure a lesson titled "Define strict API Data Contracts" with no test tags or test code patterns generates a standard application scope (`!**/*.test.ts`).
+- **Rescope CLI Mutation:** Create a mock `.junie/skills/totem-rules/rules.json` file with a test-contract lesson mapped to a `!**/*.test.ts` scope. Run `totem rule rescope` and assert the file is modified to `**/*.test.ts` via `readJsonSafe`.
+
+---
+
+## Implementation Design
+
+### Scope
+
+**Will do:** teach the compile-worker to emit test-inclusive `fileGlobs` when a lesson is a test-contract (behavior the lesson intends to govern inside test files). The fix surface is the compile prompt plus (pending open-question resolution) an optional deterministic post-emission validator.
+
+**Will NOT do:** build a new `totem rule rescope` CLI command. Existing corpus repair uses `totem compile --upgrade <hash>` per affected rule. Also will not introduce a standalone `scope-heuristic.ts` module unless the user picks Option B below.
+
+### Data model deltas
+
+**Option A (prompt-only).** Zero deltas. `fileGlobs` schema unchanged. LLM emits test-inclusive globs when the prompt teaches it to.
+
+**Option B (prompt + deterministic validator).** One new module:
+
+- `packages/core/src/scope-heuristic.ts` — pure function `detectTestContract(input: LessonClassifierInput): { isTestContract: boolean; signals: string[] }`.
+  - Holds: classification logic + signal provenance (for audit/logging).
+  - Written by: the function body; stateless.
+  - Read by: `compile-lesson.ts` post-LLM-response hook.
+  - Invariants: deterministic; no side effects; no I/O; signal strings are stable for logging.
+
+No new fields on `CompilerOutputSchema`, `CompiledRule`, or `NonCompilableEntry`. `fileGlobs` continues to carry scope as today.
+
+### State lifecycle
+
+**Option A:** no new state.
+
+**Option B:** `detectTestContract` is pure / stateless. Called once per `compileLesson` invocation; result is consumed in the same call and discarded. No persistence. No cross-lifecycle coupling.
+
+### Failure modes
+
+| Failure                                                                                      | Category               | Agent-facing surface                                                                                                                        | Recovery                                                                                                                                                                  |
+| -------------------------------------------------------------------------------------------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| LLM emits non-test globs despite test-contract lesson (Option A)                             | runtime                | silent degradation — rule ships with `!**/*.test.*`                                                                                         | Manual `totem compile --upgrade <hash>` after detection. Same as status quo for other LLM drift.                                                                          |
+| LLM emits non-test globs despite test-contract lesson (Option B)                             | runtime                | warning — post-emission validator logs "scope inversion detected: lesson X classified as test-contract but emitted fileGlobs exclude tests" | Operator runs `totem compile --upgrade <hash>` with updated prompt. Validator emits a reasonCode for ledger traceability (no schema change; reuses prose `reason`).       |
+| `detectTestContract` false-positive on "API Contracts" / "Data Contracts" lessons (Option B) | runtime                | warning (noisy) — misclassifies app-code lesson as test-contract                                                                            | Heuristic tuning: require tag OR code-signal alongside keyword. Unit tests lock this in (see Invariants below).                                                           |
+| Prompt guidance not picked up by LLM                                                         | transient              | silent degradation identical to current state                                                                                               | Temperature variance; fix is prompt re-tuning + regression tests on mocked LLM responses.                                                                                 |
+| Existing corpus rules remain mis-scoped after prompt fix                                     | permanent until action | no surface; rules continue to silently not fire                                                                                             | One-shot `totem compile --upgrade <hash>` per affected rule (two known exhibits: "Normalize temp paths" + "Spy on logger contracts"). Filed as follow-up task in PR body. |
+
+### Invariants to lock in via tests
+
+- **Test-code signal is necessary for test-contract classification** when the title contains ambiguous words like "contract". A lesson titled "Define strict API Data Contracts" with no test tags, no describe/it/test/expect in examples, and no test fileGlobs MUST NOT be classified as test-contract.
+- **Test-code signal is sufficient** when paired with any glob-compatible scope. A lesson whose `goodExample`/`badExample` contains `expect(` or `describe(` patterns MUST be classified as test-contract regardless of title.
+- **Test-contract classification inverts exclusions, not inclusions.** If the LLM emits `packages/e2e/**/*.spec.ts` (a narrow test scope), the validator MUST NOT blanket-replace it with `**/*.test.*, **/*.spec.*, **/tests/**/*.*, **/__tests__/**/*.*`. Only `!**/*.test.*`-style exclusions get flipped; narrow test globs pass through untouched.
+- **`testing` tag is a short-circuit positive signal.** Tag presence alone classifies as test-contract; no further code-pattern check required.
+- **Known exhibits compile with test-inclusive scope.** Mocked compile of "Normalize temp paths for cross-platform equality" and "Spy on logger contracts in tests" both emit fileGlobs that include `**/*.test.*`-style patterns.
+- **Prompt does not bias toward inversion.** Compile-templates.ts fileGlobs examples MUST include at least one `**/*.test.*`-inclusive example for the classifier to learn from.
+
+### Open questions
+
+- **Question 1:** Option A (prompt-only fix) vs Option B (prompt + deterministic post-emission validator)?
+  - **Options:**
+    - **A (prompt-only):** smallest surface, 2 files touched (compile-templates.ts + its test). Matches #1598's scope exactly. Risk: LLM drift — a future model or temperature run could regress without a deterministic guard. Regression tests mock the LLM response and test only the prompt-text invariants (e.g., "classifier section present, test-inclusive example present").
+    - **B (prompt + validator):** catches LLM drift deterministically. Adds `packages/core/src/scope-heuristic.ts` + integration in `compile-lesson.ts`. ~4 files touched. Validator logs a warning and MAY override the LLM's fileGlobs. Robustness win; new audit-point cost.
+  - **Recommendation:** **Option A.** Matches #1598 precedent, keeps PR size tight, easier bot-review round. Defer Option B to a follow-up if drift is observed empirically. The PR body enumerates Option B's rationale so the user can file a tier-3 follow-up ticket if they want the guard.
+
+- **Question 2:** Retriage strategy for the two known mis-scoped rules ("Normalize temp paths", "Spy on logger contracts in tests")?
+  - **Options:**
+    - **Defer to follow-up PR** (recommended). The two exhibits are called out in the PR body; land the prompt fix first, then `totem compile --upgrade <hash>` for each affected rule in a separate PR. Keeps this PR scoped to the prevention fix.
+    - **Bundle in this PR.** Run upgrade, commit the resulting `compiled-rules.json` diff, run pre-push review. Adds data-churn noise to the PR.
+  - **Recommendation:** Defer. Prevention and cure are different concerns; bundling increases review scope without benefit.
+
+- **Question 3:** Test-helper directories (`test-utils/`, `__tests__/`) in the default test-inclusive globs?
+  - **Options:**
+    - **Include by default:** `**/*.test.*, **/*.spec.*, **/tests/**/*.*, **/__tests__/**/*.*`. Covers monorepo test layouts without case-by-case tuning.
+    - **Minimal default:** `**/*.test.*, **/*.spec.*`. Simpler; catches conventional file-suffix naming. Operators needing test-utils scope author the glob manually.
+  - **Recommendation:** Include the broader set. Memory lesson `lesson-4ecb26b7` flagged that broad `!**/test/**` exclusions miss nested-package test directories; by symmetry, broad inclusion avoids the inverse miss.

--- a/packages/cli/src/commands/compile-templates.test.ts
+++ b/packages/cli/src/commands/compile-templates.test.ts
@@ -119,6 +119,71 @@ describe('PIPELINE3_COMPILER_PROMPT', () => {
   });
 });
 
+// ─── Test-Contract Scope Classifier (mmnto-ai/totem#1626) ──
+
+describe('Test-Contract Scope Classifier (mmnto-ai/totem#1626)', () => {
+  describe('COMPILER_SYSTEM_PROMPT', () => {
+    it('declares the classifier section with the #1626 issue reference', () => {
+      expect(COMPILER_SYSTEM_PROMPT).toContain('Test-Contract Scope Classifier');
+      expect(COMPILER_SYSTEM_PROMPT).toContain('mmnto-ai/totem#1626');
+    });
+
+    it('names the testing tag as a positive classifier signal', () => {
+      expect(COMPILER_SYSTEM_PROMPT).toMatch(/`testing`\s+tag/);
+    });
+
+    it('enumerates the broad test-inclusive glob set so monorepo layouts are covered', () => {
+      expect(COMPILER_SYSTEM_PROMPT).toContain('**/*.test.*');
+      expect(COMPILER_SYSTEM_PROMPT).toContain('**/*.spec.*');
+      expect(COMPILER_SYSTEM_PROMPT).toContain('**/tests/**');
+      expect(COMPILER_SYSTEM_PROMPT).toContain('**/__tests__/**');
+    });
+
+    it('warns against the API Contracts / Data Contracts false-positive trap', () => {
+      expect(COMPILER_SYSTEM_PROMPT).toMatch(/API Contracts|Data Contracts/);
+    });
+
+    it('teaches the classifier to preserve narrow test globs instead of blanket-replacing', () => {
+      expect(COMPILER_SYSTEM_PROMPT).toMatch(/narrow|preserve|do not overwrite/i);
+    });
+
+    it('includes at least one fileGlobs example with a test-inclusive glob (not just exclusion)', () => {
+      const inclusivePattern = /"fileGlobs":\s*\[[^\]]*"\*\*\/\*\.test\.\*"/;
+      const inclusiveAltPattern = /"fileGlobs":\s*\[[^\]]*"\*\*\/\*\.spec\.\*"/;
+      const hasInclusive =
+        inclusivePattern.test(COMPILER_SYSTEM_PROMPT) ||
+        inclusiveAltPattern.test(COMPILER_SYSTEM_PROMPT);
+      expect(hasInclusive).toBe(true);
+    });
+  });
+
+  describe('PIPELINE3_COMPILER_PROMPT', () => {
+    it('declares the classifier section with the #1626 issue reference', () => {
+      expect(PIPELINE3_COMPILER_PROMPT).toContain('Test-Contract Scope Classifier');
+      expect(PIPELINE3_COMPILER_PROMPT).toContain('mmnto-ai/totem#1626');
+    });
+
+    it('names the testing tag as a positive classifier signal', () => {
+      expect(PIPELINE3_COMPILER_PROMPT).toMatch(/`testing`\s+tag/);
+    });
+
+    it('enumerates the broad test-inclusive glob set so monorepo layouts are covered', () => {
+      expect(PIPELINE3_COMPILER_PROMPT).toContain('**/*.test.*');
+      expect(PIPELINE3_COMPILER_PROMPT).toContain('**/*.spec.*');
+      expect(PIPELINE3_COMPILER_PROMPT).toContain('**/tests/**');
+      expect(PIPELINE3_COMPILER_PROMPT).toContain('**/__tests__/**');
+    });
+
+    it('warns against the API Contracts / Data Contracts false-positive trap', () => {
+      expect(PIPELINE3_COMPILER_PROMPT).toMatch(/API Contracts|Data Contracts/);
+    });
+
+    it('teaches the classifier to preserve narrow test globs instead of blanket-replacing', () => {
+      expect(PIPELINE3_COMPILER_PROMPT).toMatch(/narrow|preserve|do not overwrite/i);
+    });
+  });
+});
+
 // ─── KIND_ALLOW_LIST ────────────────────────────────
 
 describe('KIND_ALLOW_LIST', () => {

--- a/packages/cli/src/commands/compile-templates.ts
+++ b/packages/cli/src/commands/compile-templates.ts
@@ -202,6 +202,40 @@ Only fall back to \`semantic-analysis-required\` when the analysis the lesson de
 
 **Rule of thumb:** ask "does detecting the hazard require analyzing code the pattern cannot see (other files, closure bodies, sibling parameters, project state)?" If yes, emit \`semantic-analysis-required\`. If no, compile — or fall back to \`context-required\` if the guard is local but structurally inexpressible.
 
+### Test-Contract Scope Classifier (mmnto-ai/totem#1626)
+
+Some lessons describe **behavior that executes inside test files**: assertion conventions, spy or mock contracts, test-fixture hygiene. The default \`fileGlobs\` guidance above excludes test files (\`!**/*.test.*\`), which inverts the intent for this class. The rule ships with tests excluded from scope and never fires where it is meant to govern.
+
+Positive signals (any one alone is enough to classify):
+- The lesson carries the \`testing\` tag.
+- \`badExample\` or \`goodExample\` contains test-framework calls: \`describe(\`, \`it(\`, \`test(\`, \`expect(\`, \`vi.mock(\`, \`jest.mock(\`, \`beforeEach(\`, \`afterEach(\`, \`vi.spyOn(\`, \`jest.spyOn(\`.
+- Lesson body describes behavior specific to test execution (assertion patterns, spy contracts, test fixtures, mocked-dependency setup).
+
+When a lesson is a test-contract, emit \`fileGlobs\` that INCLUDE test files. The conventional broad set covers typical monorepo test layouts:
+
+\`\`\`json
+{"fileGlobs": ["**/*.test.*", "**/*.spec.*", "**/tests/**/*.*", "**/__tests__/**/*.*"]}
+\`\`\`
+
+If the lesson clearly targets a narrower test directory (e.g., "only for e2e tests in \`packages/e2e\`"), preserve that narrow glob rather than blanket-replacing it with the broad default. Specificity beats the default when the lesson carries it.
+
+**False-positive trap.** The word "contract" alone does NOT make a lesson test-scoped. Lessons titled "Define strict API Data Contracts" or "Versioning contracts for REST endpoints" describe application-surface invariants, not test conventions. Require the \`testing\` tag OR test-framework code in the examples alongside any keyword match before classifying as test-contract.
+
+**Worked examples (emit test-inclusive fileGlobs):**
+
+- Lesson: "Normalize temp paths for cross-platform equality" with \`goodExample\` using \`expect(actual).toBe(normalizePath(expected))\`.
+  - Output: \`{"compilable": true, "pattern": "...", "message": "...", "badExample": "...", "goodExample": "...", "fileGlobs": ["**/*.test.*", "**/*.spec.*", "**/tests/**/*.*", "**/__tests__/**/*.*"]}\`
+
+- Lesson: "Spy on logger contracts in tests" tagged \`testing\`, with examples using \`vi.spyOn(logger, 'error')\`.
+  - Output: same test-inclusive fileGlobs set.
+
+**Anti-lazy guard (do NOT emit test-inclusive fileGlobs):**
+
+- Lesson: "Define strict API Data Contracts" with REST handler examples, no \`expect\`, no \`describe\`, no \`testing\` tag.
+  - Output: application-scope fileGlobs with the usual test exclusion, e.g., \`["packages/api/**/*.ts", "!**/*.test.*"]\`.
+
+**Rule of thumb:** ask "does the hazard this lesson describes actually HAPPEN inside test code?" If yes, emit test-inclusive fileGlobs. If the lesson is about production code that has nothing to do with tests, keep the standard exclusion pattern.
+
 ## Examples
 
 Lesson: "Use \`err\` (never \`error\`) in catch blocks"
@@ -546,6 +580,39 @@ When the snippet pair cannot be distinguished by any single-line pattern because
 The \`reasonCode\` field is narrow — \`"context-required"\` and \`"semantic-analysis-required"\` are the only values you may emit. Use \`semantic-analysis-required\` when the required analysis exceeds the compiler's capability; use \`context-required\` when a structural guard exists but the pattern vocabulary cannot express it.
 
 **Anti-lazy guard:** compile normally when the distinguishing difference is on the Bad/Good lines themselves or when \`fileGlobs\` can scope the rule. Only emit \`semantic-analysis-required\` when no pattern can discriminate the snippet pair regardless of vocabulary.
+
+### Test-Contract Scope Classifier (mmnto-ai/totem#1626)
+
+Some lessons describe **behavior that executes inside test files**: assertion conventions, spy or mock contracts, test-fixture hygiene. A default \`fileGlobs\` of \`"!**/*.test.*"\` inverts the intent for this class, shipping a rule that can never fire on the code it is meant to govern.
+
+Positive signals (any one alone is enough to classify):
+- The lesson carries the \`testing\` tag.
+- The Bad or Good snippet contains test-framework calls: \`describe(\`, \`it(\`, \`test(\`, \`expect(\`, \`vi.mock(\`, \`jest.mock(\`, \`beforeEach(\`, \`afterEach(\`, \`vi.spyOn(\`, \`jest.spyOn(\`.
+- Lesson body describes behavior specific to test execution (assertion patterns, spy contracts, test fixtures, mocked-dependency setup).
+
+When the lesson is a test-contract, emit \`fileGlobs\` that INCLUDE test files. The conventional broad set covers typical monorepo test layouts:
+
+\`\`\`json
+{"fileGlobs": ["**/*.test.*", "**/*.spec.*", "**/tests/**/*.*", "**/__tests__/**/*.*"]}
+\`\`\`
+
+If the lesson clearly targets a narrower test directory (e.g., "only for e2e tests in \`packages/e2e\`"), preserve that narrow glob rather than blanket-replacing it with the broad default.
+
+**False-positive trap.** The word "contract" alone does NOT make a lesson test-scoped. Lessons titled "Define strict API Data Contracts" or "Versioning contracts for REST endpoints" describe application-surface invariants. Require the \`testing\` tag OR test-framework code in the examples alongside any keyword match before classifying as test-contract.
+
+**Worked examples (emit test-inclusive fileGlobs):**
+
+- Lesson: "Normalize temp paths for cross-platform equality" with Good snippet \`expect(actual).toBe(normalizePath(expected))\`.
+  - Output: test-inclusive fileGlobs from the conventional broad set.
+- Lesson: "Spy on logger contracts in tests" tagged \`testing\`, with examples using \`vi.spyOn(logger, 'error')\`.
+  - Output: test-inclusive fileGlobs from the conventional broad set.
+
+**Anti-lazy guard (do NOT emit test-inclusive fileGlobs):**
+
+- Lesson: "Define strict API Data Contracts" with REST handler snippets, no \`expect\`, no \`describe\`, no \`testing\` tag.
+  - Output: application-scope fileGlobs with the usual test exclusion, e.g., \`["packages/api/**/*.ts", "!**/*.test.*"]\`.
+
+**Rule of thumb:** ask "does the hazard this lesson describes actually HAPPEN inside test code?" If yes, emit test-inclusive fileGlobs. If the lesson is about production code, keep the standard exclusion pattern.
 
 Every compilable rule MUST include non-empty \`badExample\` AND \`goodExample\` fields. The compile pipeline's schema parse rejects output that omits either one for \`ast-grep\` or \`regex\` engines, so the rule never reaches the smoke gate. The smoke gate then runs the rule against both snippets: the pattern MUST match \`badExample\` (zero matches here rejects with reason code \`pattern-zero-match\`) and MUST NOT match \`goodExample\` (any match here rejects with reason code \`matches-good-example\`).
 `;


### PR DESCRIPTION
## Summary

Teaches the compile-worker to recognize lessons whose hazard is **behavior inside test files** (assertion conventions, spy/mock contracts, test-fixture hygiene) and emit test-inclusive `fileGlobs` instead of the default `!**/*.test.*` exclusion. Prevents the silent scope inversion that ships test-contract rules with scopes that structurally exclude the code they are meant to govern.

Third prompt classifier after #1598 (context-required) and #1634 (semantic-analysis-required). Same structural surface on both `COMPILER_SYSTEM_PROMPT` and `PIPELINE3_COMPILER_PROMPT`.

## LC impact

Two known-mis-scoped rules from `liquid-city` exports will retriage correctly on next `totem compile --upgrade <hash>`:

- `Normalize temp paths for cross-platform equality`
- `Spy on logger contracts in tests`

Both currently ship with scopes that exclude tests, silently failing to govern the code they target. Retriage lands in a follow-up chore PR after this prompt fix merges (prevention vs cure separation per the preflight design gate).

## What changed

- **`packages/cli/src/commands/compile-templates.ts`** — new `### Test-Contract Scope Classifier (mmnto-ai/totem#1626)` section appended after the Semantic Analysis Classifier in both prompt templates. Enumerates three positive signals (`testing` tag, test-framework calls in examples, test-execution-specific lesson body), the broad test-inclusive glob set, narrow-glob preservation guidance, a false-positive trap against "API Contracts" / "Data Contracts" keyword matches, worked examples for the two known exhibits, and an anti-lazy guard preserving application-scope rules when test signals are absent.
- **`packages/cli/src/commands/compile-templates.test.ts`** — 9 new regression tests. Lock in classifier section presence on both prompts, `testing`-tag signal, the broad glob set (`**/*.test.*`, `**/*.spec.*`, `**/tests/**/*.*`, `**/__tests__/**/*.*`), API/Data Contracts false-positive trap warning, narrow-glob preservation guidance, and (COMPILER_SYSTEM_PROMPT only) at least one `fileGlobs` example block using a test-inclusive glob rather than exclusion-only.
- **`.totem/specs/1626.md`** — preflight spec + Implementation Design from the `/preflight 1626` ritual. Option A (prompt-only) shipped per approved design; Option B (deterministic post-emission validator) deferred as a follow-up if LLM drift is observed empirically.
- **`.strategy`** submodule bump `0c6d0c3` → `9e38d44`. Picks up strategy PRs #120 (2026-04-23 evening journal) and #121 (`@mmnto/*` version bump to `^1.15.3` + upstream-feedback items 012 and 013).

## Design decisions (spec at `.totem/specs/1626.md`)

1. **Option A (prompt-only) over Option B (deterministic validator).** Matches #1598 precedent exactly. Tight PR scope. Defer drift resistance to a follow-up if empirically needed.
2. **Retriage deferred to follow-up PR.** Prevention and cure are distinct concerns. Bundling would add corpus-diff noise without benefit.
3. **Broad test-inclusive glob set** (`**/*.test.*`, `**/*.spec.*`, `**/tests/**/*.*`, `**/__tests__/**/*.*`). Symmetric to `lesson-4ecb26b7` which flagged that broad `!**/test/**` exclusions miss nested-package test directories.

## Lint warnings (informational — all false positives)

Pre-push lint emitted 23 warnings, 0 errors. Five are of exactly the class this PR addresses:

- "Use anchored regex for shell command matching" fires on JavaScript `RegExp.prototype.test()` calls in test code. That rule was compiled from a shell-command lesson but scoped without test exclusion, and now fires on every `.test(` call in the regex-testing tests.
- "async test callback" warnings on tests that genuinely `await` async functions, same rule-scope inversion pattern as flagged on #1598 + #1640 + #1644.

These are visible surface area for the retriage follow-up PR to silence via `totem compile --upgrade <hash>` once this prompt fix lands.

## Test plan

- [x] 9 new regression tests lock in classifier presence on both prompts.
- [x] CLI suite green: **1,812 / 1,812** tests pass.
- [x] `pnpm run format`
- [x] `pnpm exec totem lint` PASS (0 errors, 23 warnings — all the false positives this PR targets)
- [x] `pnpm exec totem review` PASS (Shield, no findings)
- [x] `pnpm exec totem verify-manifest` PASS (443 rules)
- [x] Pre-push hook (PASS)
- [ ] Bot review (CR + GCA)
- [ ] CI green
- [ ] Follow-up chore PR retriages the two known mis-scoped rules via `totem compile --upgrade <hash>`.

Closes #1626

🤖 Generated with [Claude Code](https://claude.com/claude-code)