### PR TITLE
feat(core): honor declared severity from lesson prose in compile output (#1656)

### DIFF
--- a/.totem/specs/1656.md
+++ b/.totem/specs/1656.md
@@ -1,0 +1,151 @@
+### Problem Statement
+
+The `totem lesson compile` command currently instructs the LLM to generate rules with a default `"warning"` severity, failing to honor lessons where authors explicitly declare `Severity: error` in the prose. We need to structurally parse the declared severity from the lesson markdown and explicitly pass it into the compilation prompt to force the LLM to emit the author's intended severity.
+
+### Architectural Context
+
+None found in provided context.
+
+### Files to Examine
+
+1. `packages/cli/src/commands/compile-templates.ts` — Contains the `COMPILER_SYSTEM_PROMPT` and the user prompt generation logic where structured inputs (tags/scope) are injected.
+2. `packages/cli/src/commands/compile.ts` — Houses `compileCommand`, iterating over lessons and calling the LLM; where the new parsing helper will be invoked.
+3. `packages/core/src/compile-lesson.ts` — Core logic orchestrating lesson compilation; check if prompt assembly happens here instead of `compile.ts`.
+
+### Technical Approach & Contracts
+
+**1. Prose Parsing (Option A):**
+Introduce a pure function `parseSeverityFromProse` in `@mmnto/totem` core. It will use a regex to tolerate case-insensitive variations, markdown bolding (`**`, `__`), italics (`*`, `_`), and trailing punctuation (e.g., `.**`).
+
+_Data Contract: Parse Utility_
+
+```typescript
+export function parseSeverityFromProse(body: string): 'error' | 'warning' | null;
+```
+
+**2. Prompt Injection:**
+Update the user prompt generator (likely `buildCompilerPrompt` or similar in `compile-templates.ts`) to accept `declaredSeverity` alongside `tags`/`scope`/`fileGlobs`. Add an explicit instruction to the LLM:
+`"Mandatory Directive: Emit \"severity\": \"${declaredSeverity ?? 'warning'}\" in your JSON output."`
+
+**3. Execution Integration:**
+Before dispatching a compilation request in `compileCommand` (or `compile-lesson.ts`), pass the `lesson.body` (or `lesson.content`) through `parseSeverityFromProse` and feed the result into the prompt builder.
+
+### Edge Cases & Traps
+
+- **Markdown Formatting Chaos:** The string could be `**Severity:** error`, `Severity: **error**`, `*Severity*: error.`, or even `**Severity: error**`. The regex must cleanly ignore markdown boundary markers.
+- **Multiple Declarations:** A lesson might mention "severity" multiple times (e.g., "This prevents an error"). Ensure the regex strictly matches `Severity:` as a key-value declaration, ideally at the start of a line or paragraph, and take the _first_ match.
+- **Prompt Injection Weakness:** The LLM might ignore soft suggestions. Use strong directive language in the prompt ("Mandatory Directive: You MUST emit...") to ensure the requested severity overrides its default behaviors.
+- **Silent Fallback:** If the regex fails to match, it must return `null`, allowing the system to fall back to the `'warning'` default exactly as it behaves today.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Implement Prose Severity Parser**
+      Modify `packages/core/src/utils/severity-parser.ts` (create if it doesn't exist) and export `parseSeverityFromProse(body: string)`. Use a robust regex matching `severity` followed by an optional colon and markdown, capturing `error` or `warning`.
+
+  > TEST DIRECTIVE: Before implementing, write a failing test named `returns error when severity is wrapped in bold markdown with a trailing period` that proves `**Severity:** error.` correctly extracts `'error'`. Add another test `returns null when no strict severity key is declared` to prove text like "this causes an error" doesn't falsely trigger.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Inject Structured Severity into Compile Prompt**
+      Modify `packages/cli/src/commands/compile-templates.ts`. Locate the function/template generating the user prompt (where `tags` and `scope` are passed). Add an optional `declaredSeverity: 'error' | 'warning' | null` parameter. Add a mandatory output directive for the severity field based on this parameter (defaulting to `'warning'`).
+
+  > TEST DIRECTIVE: Before implementing, write a failing test named `injects explicit error severity directive into compiler prompt` to ensure the prompt string contains the exact required constraint.
+  - update existing test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Plumb Parser into Compilation Loop**
+      Modify `packages/cli/src/commands/compile.ts` (or `packages/core/src/compile-lesson.ts` if the loop lives there). Locate where the lesson text is prepared for the LLM. Call `parseSeverityFromProse(lesson.body)` and pass the resulting value into the template/prompt builder.
+  > TEST DIRECTIVE: Before implementing, write a failing test named `passes parsed prose severity to compiler prompt builder` in the compile command test suite. Mock the LLM payload and ensure the instruction contains the extracted severity from a dummy lesson body.
+  - write test → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- Unit test `parseSeverityFromProse` against exactly:
+  - `**Severity:** error`
+  - `Severity: error.` (trailing period)
+  - `Severity: warning`
+  - `**Severity:** WARNING` (case insensitivity)
+  - `This lesson prevents a severe error.` (should return `null`)
+- End-to-End Compile test: Provide a mocked lesson with `**Severity:** error` in the prose to `totem lesson compile` and assert the compiled `compiled-rules.json` file contains `"severity": "error"` for that specific rule output. Ensure a secondary lesson with no severity marker compiles with `"severity": "warning"`.
+
+---
+
+## Implementation Design
+
+### Scope
+
+**Will do:** thread the existing-but-discarded `lesson.frontmatter.severity` through the compile pipeline so compiled rules emit the declared severity. Do this at two layers: (a) prompt directive so the LLM emits the right severity in its JSON response, (b) post-LLM override in `buildCompiledRule` as a deterministic safety net when the LLM drifts.
+
+**Will NOT do:** build a new prose parser. `extractField` + `buildFrontmatterFromLegacy` already do this and are battle-tested. Also will NOT add a first-class `severity:` YAML frontmatter field (Option B in the upstream write-up) — deferred to a future ticket. Also will NOT add a severity-mismatch warning surface in this PR — listed as Open Question 2 below.
+
+### Data model deltas
+
+No new types. Two existing-interface extensions:
+
+- **`CompileLessonDeps` (or `compileLesson` signature)** — gains access to `lesson.frontmatter.severity`. The call site in `compile.ts` already has `lesson.frontmatter` in scope (it constructed or loaded the lesson); the extension is "pass it through" rather than "re-parse it."
+- **`buildCompiledRule`'s `lesson` parameter** currently `{ hash: string; heading: string }`. Extension: `{ hash: string; heading: string; declaredSeverity?: 'error' | 'warning' }`. Declared severity stays optional; absence preserves the current `parsed.severity ?? 'warning'` fallback.
+
+No new state container. No new module variables.
+
+### State lifecycle
+
+Declared severity is per-compile-invocation, per-lesson. Derived at lesson-load time (already) and consumed at compile time. Lifetime is the duration of the compile call. No cross-lifecycle coupling.
+
+### Failure modes
+
+| Failure                                                                   | Category                                | Agent-facing surface                                                                                                                                                                         | Recovery                                                            |
+| ------------------------------------------------------------------------- | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| LLM ignores prompt directive and emits `warning` despite declared `error` | runtime                                 | silent — post-LLM override in `buildCompiledRule` replaces with declared severity                                                                                                            | Automatic; the override is deterministic. Telemetry event recorded. |
+| Lesson prose declares malformed severity (not `error` or `warning`)       | init                                    | silent — `buildFrontmatterFromLegacy` already returns `undefined` for anything else (line 103: `if (severity === 'error' \|\| severity === 'warning')`); compile falls back to LLM / default | This is existing behavior. No change.                               |
+| Lesson has YAML frontmatter with different severity than prose            | runtime                                 | frontmatter wins (prose-derived severity is only populated when YAML is absent per `lesson-io.ts:81,123`)                                                                                    | Existing architecture; no change required.                          |
+| Post-LLM override silently changes the LLM's severity                     | (new failure mode if we emit a warning) | Open Question 2 — see below                                                                                                                                                                  | Depends on OQ2 answer                                               |
+| `buildCompiledRule` caller passes wrong/no declared severity              | dev error                               | default `'warning'` ships; no visible signal at runtime                                                                                                                                      | Not user-facing; caught by tests                                    |
+
+### Invariants to lock in via tests
+
+- A lesson with prose `**Severity:** error` and LLM response `{"severity": "warning"}` compiles to a rule with `severity: 'error'`. The post-LLM override is authoritative.
+- A lesson with no severity prose and LLM response `{"severity": "warning"}` compiles to a rule with `severity: 'warning'`. No override fires.
+- A lesson with prose `**Severity:** error` and LLM response without a severity field compiles to `severity: 'error'`.
+- A lesson whose prose contains text like "this prevents a severe error" (no `Severity:` key) does NOT classify as declared `'error'`. `extractField`'s mandatory-colon invariant covers this; the test locks it in against future regressions.
+- Compile prompt contains an explicit directive to emit declared severity when the caller supplies one. Prompt text assertion mirrors #1626's pattern.
+- YAML-frontmatter severity wins over prose severity. Existing `lesson-io.ts:81,123` logic already does this; test confirms it survives the new plumbing.
+
+### Open questions
+
+- **Question 1:** Where does the override live — `buildCompiledRule` or the caller in `compile.ts`?
+  - **Options:**
+    - **A (in `buildCompiledRule`):** override happens inside core, applied uniformly to every compile path (Pipeline 2 LLM, Pipeline 3 LLM, cloud worker). One code-path touch; zero divergence between local + cloud paths. Signature change: `lesson` parameter gains `declaredSeverity`.
+    - **B (in `compile.ts` caller):** override applied after `buildCompiledRule` returns. No core-package signature change. But needs mirroring in the cloud-worker result handler, same divergence risk #1640 fought. Shorter diff if single-caller; risk if the mirroring is missed.
+  - **Recommendation:** **A.** Matches #1640's precedent of routing classification policy inside core, not CLI. Avoids local/cloud drift.
+
+- **Question 2:** Should a "severity mismatch between prose and LLM" warning emit when the override fires?
+  - **Options:**
+    - **A (silent override):** override quietly replaces `parsed.severity` with `lesson.frontmatter.severity`. User sees the right severity in `compiled-rules.json`; no log noise.
+    - **B (warn on mismatch):** log a `totem-context: LLM drift — overrode severity from X to Y` when the override actually changes anything. Observable signal that the prompt directive isn't holding.
+    - **C (telemetry only):** structured telemetry event `type: 'severity-override'` in `.totem/temp/telemetry.jsonl` (same sink as regex-safety), no user-visible log. Observable for debugging without noise.
+  - **Recommendation:** **C.** Keeps user output clean while preserving an audit signal for prompt-tuning feedback. If the override fires frequently, the telemetry shows it and the prompt can be strengthened in a follow-up.
+
+- **Question 3:** Add a prompt-level directive, a post-LLM override, or both?
+  - **Options:**
+    - **A (prompt only):** compile prompt gains a directive "when declared severity is provided, emit it." Depends on LLM compliance. If LLM drifts, the fix silently fails.
+    - **B (override only):** skip the prompt directive, do deterministic override in `buildCompiledRule`. LLM-output-agnostic; works even on legacy models or prompt-cache-staleness.
+    - **C (both):** prompt directive reduces the frequency of drift; override handles residual drift.
+  - **Recommendation:** **C.** Belt-and-suspenders. The prompt directive is cheap (one section in the templates file) and reduces wasted LLM work on drift. The override enforces the declared value even when the LLM does not.

--- a/packages/cli/src/commands/compile-templates.test.ts
+++ b/packages/cli/src/commands/compile-templates.test.ts
@@ -184,6 +184,45 @@ describe('Test-Contract Scope Classifier (mmnto-ai/totem#1626)', () => {
   });
 });
 
+// ─── Declared Severity directive (mmnto-ai/totem#1656) ──
+
+describe('Declared Severity directive (mmnto-ai/totem#1656)', () => {
+  describe('COMPILER_SYSTEM_PROMPT', () => {
+    it('declares the directive section with the #1656 issue reference', () => {
+      expect(COMPILER_SYSTEM_PROMPT).toContain('Declared Severity');
+      expect(COMPILER_SYSTEM_PROMPT).toContain('mmnto-ai/totem#1656');
+    });
+
+    it('references the Severity prose convention used by lesson authors', () => {
+      expect(COMPILER_SYSTEM_PROMPT).toMatch(/`?Severity:\s*(error|warning)`?/i);
+    });
+
+    it('names both valid severity values for emission', () => {
+      expect(COMPILER_SYSTEM_PROMPT).toContain("'error'");
+      expect(COMPILER_SYSTEM_PROMPT).toContain("'warning'");
+    });
+
+    it('instructs the LLM to honor the declared severity when present', () => {
+      expect(COMPILER_SYSTEM_PROMPT).toMatch(/honor|honour|emit.*declared|match.*declared/i);
+    });
+  });
+
+  describe('PIPELINE3_COMPILER_PROMPT', () => {
+    it('declares the directive section with the #1656 issue reference', () => {
+      expect(PIPELINE3_COMPILER_PROMPT).toContain('Declared Severity');
+      expect(PIPELINE3_COMPILER_PROMPT).toContain('mmnto-ai/totem#1656');
+    });
+
+    it('references the Severity prose convention used by lesson authors', () => {
+      expect(PIPELINE3_COMPILER_PROMPT).toMatch(/`?Severity:\s*(error|warning)`?/i);
+    });
+
+    it('instructs the LLM to honor the declared severity when present', () => {
+      expect(PIPELINE3_COMPILER_PROMPT).toMatch(/honor|honour|emit.*declared|match.*declared/i);
+    });
+  });
+});
+
 // ─── KIND_ALLOW_LIST ────────────────────────────────
 
 describe('KIND_ALLOW_LIST', () => {

--- a/packages/cli/src/commands/compile-templates.ts
+++ b/packages/cli/src/commands/compile-templates.ts
@@ -236,6 +236,20 @@ If the lesson clearly targets a narrower test directory (e.g., "only for e2e tes
 
 **Rule of thumb:** ask "does the hazard this lesson describes actually HAPPEN inside test code?" If yes, emit test-inclusive fileGlobs. If the lesson is about production code that has nothing to do with tests, keep the standard exclusion pattern.
 
+### Declared Severity (mmnto-ai/totem#1656)
+
+Lessons sometimes declare their intended severity in prose, using the convention \`**Severity:** error\` or \`Severity: warning\` on its own line (tolerant of bold or italic markdown). The severity carries load-bearing semantics: totem's CI integration treats \`'error'\` as blocking and \`'warning'\` as advisory.
+
+Read the lesson body for a \`Severity: <level>\` declaration and **honor it** in your \`"severity"\` output:
+
+- Prose says \`Severity: error\` → emit \`"severity": "error"\`.
+- Prose says \`Severity: warning\` → emit \`"severity": "warning"\`.
+- No \`Severity:\` line → fall back to the default \`"severity": "warning"\`.
+
+The compile pipeline applies a deterministic override after your output, so a mismatch between your emission and the declared severity is corrected silently. But honoring the declaration the first time saves a round-trip and keeps your output self-consistent.
+
+**Anti-lazy guard:** do not classify "severity" language in free prose as a declaration. A lesson body that says "this prevents a severe error" or "a warning message appears" is NOT declaring severity. Only the structured \`Severity:\` key with a colon counts.
+
 ## Examples
 
 Lesson: "Use \`err\` (never \`error\`) in catch blocks"
@@ -613,6 +627,20 @@ If the lesson clearly targets a narrower test directory (e.g., "only for e2e tes
   - Output: application-scope fileGlobs with the usual test exclusion, e.g., \`["packages/api/**/*.ts", "!**/*.test.*"]\`.
 
 **Rule of thumb:** ask "does the hazard this lesson describes actually HAPPEN inside test code?" If yes, emit test-inclusive fileGlobs. If the lesson is about production code, keep the standard exclusion pattern.
+
+### Declared Severity (mmnto-ai/totem#1656)
+
+Lessons sometimes declare their intended severity in prose, using the convention \`**Severity:** error\` or \`Severity: warning\` on its own line (tolerant of bold or italic markdown). Totem's CI integration treats \`'error'\` as blocking and \`'warning'\` as advisory, so the declaration is load-bearing.
+
+Read the lesson body for a \`Severity: <level>\` declaration and **honor it** in your \`"severity"\` output:
+
+- Prose says \`Severity: error\` → emit \`"severity": "error"\`.
+- Prose says \`Severity: warning\` → emit \`"severity": "warning"\`.
+- No \`Severity:\` line → fall back to the default \`"severity": "warning"\`.
+
+The compile pipeline applies a deterministic override after your output, so a mismatch is corrected silently. Honoring the declaration keeps your output self-consistent and avoids wasted telemetry records.
+
+**Anti-lazy guard:** do not classify "severity" language in free prose as a declaration. A lesson body that mentions "this prevents a severe error" or "a warning message appears" is NOT declaring severity. Only the structured \`Severity:\` key with a colon counts.
 
 Every compilable rule MUST include non-empty \`badExample\` AND \`goodExample\` fields. The compile pipeline's schema parse rejects output that omits either one for \`ast-grep\` or \`regex\` engines, so the rule never reaches the smoke gate. The smoke gate then runs the rule against both snippets: the pattern MUST match \`badExample\` (zero matches here rejects with reason code \`pattern-zero-match\`) and MUST NOT match \`goodExample\` (any match here rejects with reason code \`matches-good-example\`).
 `;

--- a/packages/cli/src/commands/compile-templates.ts
+++ b/packages/cli/src/commands/compile-templates.ts
@@ -255,22 +255,22 @@ The compile pipeline applies a deterministic override after your output, so a mi
 ## Examples
 
 Lesson: "Use \`err\` (never \`error\`) in catch blocks"
-Output: {"compilable": true, "pattern": "catch\\\\s*\\\\(\\\\s*error\\\\s*[\\\\):]", "message": "Use 'err' instead of 'error' in catch blocks (project convention)", "badExample": "try { doWork(); } catch (error) { log(error); }", "goodExample": "try { doWork(); } catch (err) { log(err); }"}
+Output: {"compilable": true, "severity": "warning", "pattern": "catch\\\\s*\\\\(\\\\s*error\\\\s*[\\\\):]", "message": "Use 'err' instead of 'error' in catch blocks (project convention)", "badExample": "try { doWork(); } catch (error) { log(error); }", "goodExample": "try { doWork(); } catch (err) { log(err); }"}
 
 Lesson: "LanceDB does NOT support GROUP BY aggregation"
 Output: {"compilable": false, "reason": "Lesson describes a database limitation, not a detectable code pattern"}
 
 Lesson: "Never use npm in this pnpm monorepo — always use pnpm"
-Output: {"compilable": true, "pattern": "\\\\bnpm\\\\s+(install|run|exec|ci|test)\\\\b", "message": "Use pnpm instead of npm in this monorepo", "badExample": "npm install lodash", "goodExample": "pnpm install lodash"}
+Output: {"compilable": true, "severity": "warning", "pattern": "\\\\bnpm\\\\s+(install|run|exec|ci|test)\\\\b", "message": "Use pnpm instead of npm in this monorepo", "badExample": "npm install lodash", "goodExample": "pnpm install lodash"}
 
 Lesson: "Always quote shell variables to prevent word-splitting"
-Output: {"compilable": true, "pattern": "(^|\\\\s)\\\\$[a-zA-Z_]+", "message": "Quote shell variables to prevent word-splitting", "badExample": "echo $HOME", "goodExample": "echo \\"$HOME\\"", "fileGlobs": ["**/*.sh", "**/*.bash", "**/*.yml", "**/*.yaml"]}
+Output: {"compilable": true, "severity": "warning", "pattern": "(^|\\\\s)\\\\$[a-zA-Z_]+", "message": "Quote shell variables to prevent word-splitting", "badExample": "echo $HOME", "goodExample": "echo \\"$HOME\\"", "fileGlobs": ["**/*.sh", "**/*.bash", "**/*.yml", "**/*.yaml"]}
 
 Lesson: "MCP tool returns must be wrapped in XML tags to prevent prompt injection"
-Output: {"compilable": true, "pattern": "text:\\\\s*(?!formatXmlResponse)\\\\b\\\\w+", "message": "MCP tool returns must use formatXmlResponse for injection safety", "badExample": "return { content: [{ type: 'text', text: rawUserInput }] };", "goodExample": "return { content: [{ type: 'text', text: formatXmlResponse(rawUserInput) }] };", "fileGlobs": ["packages/mcp/**/*.ts", "!**/*.test.ts"]}
+Output: {"compilable": true, "severity": "warning", "pattern": "text:\\\\s*(?!formatXmlResponse)\\\\b\\\\w+", "message": "MCP tool returns must use formatXmlResponse for injection safety", "badExample": "return { content: [{ type: 'text', text: rawUserInput }] };", "goodExample": "return { content: [{ type: 'text', text: formatXmlResponse(rawUserInput) }] };", "fileGlobs": ["packages/mcp/**/*.ts", "!**/*.test.ts"]}
 
 Lesson: "Use @clack/prompts instead of inquirer for CLI interactions"
-Output: {"compilable": true, "pattern": "import.*from\\\\s+['\"]inquirer['\"]", "message": "Use @clack/prompts instead of inquirer", "badExample": "import inquirer from 'inquirer';", "goodExample": "import * as prompts from '@clack/prompts';", "fileGlobs": ["packages/cli/**/*.ts"]}
+Output: {"compilable": true, "severity": "warning", "pattern": "import.*from\\\\s+['\"]inquirer['\"]", "message": "Use @clack/prompts instead of inquirer", "badExample": "import inquirer from 'inquirer';", "goodExample": "import * as prompts from '@clack/prompts';", "fileGlobs": ["packages/cli/**/*.ts"]}
 
 ## ast-grep Patterns (PREFERRED for structural rules)
 For TypeScript/JavaScript/TSX/JSX: **always prefer ast-grep over regex** when the violation involves function calls, method chains, imports, control flow, or object properties. ast-grep patterns look like source code with \`$METAVAR\` placeholders.

--- a/packages/cli/src/commands/compile-templates.ts
+++ b/packages/cli/src/commands/compile-templates.ts
@@ -84,6 +84,7 @@ You are a deterministic rule compiler. Your job is to read a single natural-lang
 \`\`\`json
 {
   "compilable": true,
+  "severity": "warning",
   "pattern": "regex pattern here",
   "message": "human-readable violation message",
   "badExample": "code snippet that the pattern matches",
@@ -96,6 +97,7 @@ Or if the rule genuinely applies to all file types (rare — prefer scoping):
 \`\`\`json
 {
   "compilable": true,
+  "severity": "warning",
   "pattern": "regex pattern here",
   "message": "human-readable violation message",
   "badExample": "code snippet that the pattern matches",
@@ -534,6 +536,7 @@ You will receive:
 \`\`\`json
 {
   "compilable": true,
+  "severity": "warning",
   "pattern": "regex pattern that catches Bad but not Good",
   "message": "human-readable violation message",
   "badExample": "one of the Bad lines, copied verbatim",

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -431,6 +431,7 @@ export async function compileCommand(
     LEDGER_RETRY_PENDING_CODES,
     loadCompiledRulesFile,
     parseCompilerResponse,
+    parseDeclaredSeverity,
     readAllLessons,
     readCompileManifest,
     saveCompiledRulesFile,
@@ -469,6 +470,41 @@ export async function compileCommand(
 
   const totemDir = path.join(cwd, config.totemDir);
   const rulesPath = path.join(totemDir, COMPILED_RULES_FILE);
+
+  // mmnto-ai/totem#1656: shared helper for severity-override telemetry.
+  // Closes over the per-invocation `totemDir` (cwd-aware) so records land
+  // next to the other telemetry artifacts when compile runs from a
+  // sub-directory (sibling of mmnto-ai/totem#1645). Called from both the
+  // local compile path (via the `onSeverityOverride` callback on
+  // CompileLessonDeps) and the cloud compile path (inline when
+  // buildCompiledRule reports a severityOverride on the cloud result).
+  const writeSeverityOverrideTelemetry = (
+    lesson: { heading: string; hash: string },
+    event: { from: 'error' | 'warning' | undefined; to: 'error' | 'warning' },
+  ): void => {
+    try {
+      const tempDir = path.join(totemDir, 'temp');
+      fs.mkdirSync(tempDir, { recursive: true });
+      const entry = {
+        type: 'severity-override' as const,
+        timestamp: new Date().toISOString(),
+        lessonHash: lesson.hash,
+        lessonHeading: lesson.heading,
+        from: event.from,
+        to: event.to,
+      };
+      fs.appendFileSync(
+        path.join(tempDir, 'telemetry.jsonl'),
+        JSON.stringify(entry) + '\n',
+        'utf-8',
+      ); // totem-context: intentional best-effort telemetry sink — severity-override records are a prompt-tuning signal, not correctness-critical. Sink failures (disk full, permissions, concurrent writer) must not interfere with compile results (mmnto-ai/totem#1656).
+    } catch (err) {
+      log.warn(
+        TAG,
+        `Failed to write severity-override telemetry: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  };
 
   // ─── --refresh-manifest primitive (mmnto-ai/totem#1587) ─────────
   // No-LLM path that recomputes `output_hash` from current
@@ -959,6 +995,12 @@ export async function compileCommand(
         callbacks: {
           onWarn: (heading: string, msg: string) => log.warn(TAG, `[${heading}] ${msg}`),
           onDim: (heading: string, msg: string) => log.dim(TAG, `[${heading}] ${msg}`),
+          // mmnto-ai/totem#1656: append severity-override telemetry when the
+          // post-LLM override in buildCompiledRule changes the emitted
+          // severity. Uses totemDir (cwd-aware) so records land next to
+          // other telemetry artifacts when compile runs from a sub-directory.
+          // Best-effort — sink failures do not interfere with compile results.
+          onSeverityOverride: writeSeverityOverrideTelemetry,
         },
       };
 
@@ -1116,7 +1158,20 @@ export async function compileCommand(
               continue;
             }
 
-            const ruleResult = buildCompiledRule(parsed, lesson, existingByHash);
+            // mmnto-ai/totem#1656: declared severity from lesson prose wins
+            // over the LLM's emission. Post-LLM override is deterministic;
+            // the prompt directive reduces the frequency of mismatch but
+            // the override guarantees correctness on the cloud path too.
+            const declaredSeverity = parseDeclaredSeverity(lesson.body);
+            const ruleResult = buildCompiledRule(parsed, lesson, existingByHash, {
+              declaredSeverityOverride: declaredSeverity,
+            });
+            if (ruleResult.severityOverride) {
+              writeSeverityOverrideTelemetry(
+                { heading: lesson.heading, hash: lesson.hash },
+                ruleResult.severityOverride,
+              );
+            }
             if (ruleResult.rule) {
               // Verify rule against inline Example Hit/Miss lines
               const testResult = verifyRuleExamples(ruleResult.rule, lesson.body);

--- a/packages/core/src/compile-lesson.test.ts
+++ b/packages/core/src/compile-lesson.test.ts
@@ -235,6 +235,84 @@ describe('buildCompiledRule', () => {
     const result = buildCompiledRule(parsed, lesson, existingByHash);
     expect(result.rule!.severity).toBe('warning');
   });
+
+  // ─── Declared severity override (mmnto-ai/totem#1656) ──
+
+  it('honors declaredSeverityOverride when LLM emits a different severity', () => {
+    const parsed: CompilerOutput = {
+      compilable: true,
+      pattern: 'test',
+      message: 'test',
+      engine: 'regex',
+      severity: 'warning',
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      declaredSeverityOverride: 'error',
+    });
+    expect(result.rule!.severity).toBe('error');
+    expect(result.severityOverride).toEqual({ from: 'warning', to: 'error' });
+  });
+
+  it('honors declaredSeverityOverride when LLM emits no severity', () => {
+    const parsed: CompilerOutput = {
+      compilable: true,
+      pattern: 'test',
+      message: 'test',
+      engine: 'regex',
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      declaredSeverityOverride: 'error',
+    });
+    expect(result.rule!.severity).toBe('error');
+    expect(result.severityOverride).toEqual({ from: undefined, to: 'error' });
+  });
+
+  it('omits severityOverride marker when declared severity matches LLM output', () => {
+    const parsed: CompilerOutput = {
+      compilable: true,
+      pattern: 'test',
+      message: 'test',
+      engine: 'regex',
+      severity: 'error',
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      declaredSeverityOverride: 'error',
+    });
+    expect(result.rule!.severity).toBe('error');
+    expect(result.severityOverride).toBeUndefined();
+  });
+
+  it('omits severityOverride marker when no declared severity provided', () => {
+    const parsed: CompilerOutput = {
+      compilable: true,
+      pattern: 'test',
+      message: 'test',
+      engine: 'regex',
+      severity: 'warning',
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash);
+    expect(result.rule!.severity).toBe('warning');
+    expect(result.severityOverride).toBeUndefined();
+  });
+
+  it('omits severityOverride marker when declared warning matches the default fallback', () => {
+    // LLM emits no severity AND declared is 'warning'. The emitted severity
+    // would have defaulted to 'warning' anyway, so the override changes
+    // nothing in the final rule. Marker must not fire — it would be
+    // telemetry noise on every lesson that declares its severity as warning.
+    const parsed: CompilerOutput = {
+      compilable: true,
+      pattern: 'test',
+      message: 'test',
+      engine: 'regex',
+      // severity deliberately omitted (undefined)
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      declaredSeverityOverride: 'warning',
+    });
+    expect(result.rule!.severity).toBe('warning');
+    expect(result.severityOverride).toBeUndefined();
+  });
 });
 
 // ─── self-suppression guard (#1177) ────────────────

--- a/packages/core/src/compile-lesson.test.ts
+++ b/packages/core/src/compile-lesson.test.ts
@@ -313,6 +313,45 @@ describe('buildCompiledRule', () => {
     expect(result.rule!.severity).toBe('warning');
     expect(result.severityOverride).toBeUndefined();
   });
+
+  it('preserves severityOverride on rejection paths too', () => {
+    // CR round-3 finding on mmnto-ai/totem#1658: if the LLM drifts on
+    // severity AND emits an invalid pattern, the rejection path must still
+    // surface severityOverride so telemetry captures exactly the
+    // prompt-drift cases this signal is meant to detect.
+    const parsed: CompilerOutput = {
+      compilable: true,
+      pattern: '(unclosed',
+      message: 'test',
+      engine: 'regex',
+      severity: 'warning',
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      declaredSeverityOverride: 'error',
+    });
+    expect(result.rule).toBeNull();
+    expect(result.rejectReason).toContain('Rejected regex');
+    expect(result.severityOverride).toEqual({ from: 'warning', to: 'error' });
+  });
+
+  it('does not fabricate severityOverride on rejection paths when declared severity matches', () => {
+    // Inverse of the above: rejection path + no actual drift = no marker.
+    // The rejection is still reported; only the severity-override signal
+    // stays absent.
+    const parsed: CompilerOutput = {
+      compilable: true,
+      pattern: '(unclosed',
+      message: 'test',
+      engine: 'regex',
+      severity: 'error',
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash, {
+      declaredSeverityOverride: 'error',
+    });
+    expect(result.rule).toBeNull();
+    expect(result.rejectReason).toContain('Rejected regex');
+    expect(result.severityOverride).toBeUndefined();
+  });
 });
 
 // ─── self-suppression guard (#1177) ────────────────

--- a/packages/core/src/compile-lesson.ts
+++ b/packages/core/src/compile-lesson.ts
@@ -14,6 +14,7 @@ import {
   extractBadGoodSnippets,
   extractManualPattern,
   extractRuleExamples,
+  parseDeclaredSeverity,
 } from './lesson-pattern.js';
 import type { RuleTestResult } from './rule-tester.js';
 import { testRule } from './rule-tester.js';
@@ -91,6 +92,17 @@ function hashPattern(pattern: string): string {
 export interface CompileLessonCallbacks {
   onWarn?: (heading: string, message: string) => void;
   onDim?: (heading: string, message: string) => void;
+  /**
+   * Fires when the declared-severity override (mmnto-ai/totem#1656) actually
+   * changed the emitted severity. CLI callers use this to write telemetry
+   * records tagged `type: 'severity-override'` for prompt-tuning feedback —
+   * frequent fires mean the prompt directive is drifting. Absent = core runs
+   * without telemetry plumbing.
+   */
+  onSeverityOverride?: (
+    lesson: { heading: string; hash: string },
+    event: { from: 'error' | 'warning' | undefined; to: 'error' | 'warning' },
+  ) => void;
 }
 
 export interface CompileLessonDeps {
@@ -329,6 +341,16 @@ export interface BuildCompiledRuleOptions {
    * relying on the LLM to echo the snippet back.
    */
   goodExampleOverride?: string;
+  /**
+   * Optional declared-severity override (mmnto-ai/totem#1656). When
+   * supplied, takes precedence over `parsed.severity` regardless of
+   * LLM emission. Sourced from the lesson body's `**Severity:** error`
+   * / `Severity: warning` prose convention. `buildCompiledRule`
+   * reports the override event in `BuildRuleResult.severityOverride`
+   * when the override actually changes the emitted severity, so CLI
+   * callers can record telemetry for prompt-tuning feedback.
+   */
+  declaredSeverityOverride?: 'error' | 'warning';
 }
 
 /**
@@ -370,7 +392,27 @@ export function buildCompiledRule(
 ): BuildRuleResult {
   if (!parsed.compilable) return { rule: null };
 
-  const severity = parsed.severity ?? 'warning';
+  // mmnto-ai/totem#1656: declared severity (parsed from the lesson body's
+  // `**Severity:** error` / `Severity: warning` prose convention) wins over
+  // the LLM's emission. Post-LLM override is the deterministic safety net
+  // for prompt-directive drift. The `severityOverride` marker is populated
+  // only when the override actually changed the outcome, so CLI callers
+  // can emit telemetry for prompt-tuning feedback without noise.
+  //
+  // Marker fires when the declared value differs from what the final rule
+  // WOULD HAVE SHIPPED without the override (i.e., `emittedSeverity ??
+  // 'warning'`). If the LLM emits nothing and the declaration is 'warning',
+  // the final severity is 'warning' both ways and the marker stays absent
+  // (Shield finding on initial PR round).
+  const declaredSeverity = options.declaredSeverityOverride;
+  const emittedSeverity = parsed.severity;
+  const severity: 'error' | 'warning' = declaredSeverity ?? emittedSeverity ?? 'warning';
+  const wouldHaveShipped = emittedSeverity ?? 'warning';
+  const severityOverride =
+    declaredSeverity !== undefined && declaredSeverity !== wouldHaveShipped
+      ? { from: emittedSeverity, to: declaredSeverity }
+      : undefined;
+
   const engine = parsed.engine ?? 'regex';
   const now = new Date().toISOString();
   const existing = existingByHash.get(lesson.hash);
@@ -561,7 +603,7 @@ export function buildCompiledRule(
     }
   }
 
-  return { rule: candidate };
+  return severityOverride ? { rule: candidate, severityOverride } : { rule: candidate };
 }
 
 // ─── Manual pattern builder ─────────────────────────
@@ -569,6 +611,14 @@ export function buildCompiledRule(
 export interface BuildRuleResult {
   rule: CompiledRule | null;
   rejectReason?: string;
+  /**
+   * Populated when `declaredSeverityOverride` actually changed the emitted
+   * severity (mmnto-ai/totem#1656). Absent when no override was supplied, or
+   * when the override matched the LLM's emission. CLI callers use this as a
+   * telemetry signal for prompt-tuning feedback — frequent overrides mean
+   * the prompt directive is drifting and the LLM needs a stronger signal.
+   */
+  severityOverride?: { from: 'error' | 'warning' | undefined; to: 'error' | 'warning' };
 }
 
 /**
@@ -752,6 +802,13 @@ export async function compileLesson(
   const { parseCompilerResponse, runOrchestrator, existingByHash, callbacks } = deps;
   const exampleHitPresent = hasExampleHits(lesson.body);
 
+  // mmnto-ai/totem#1656: extract the declared severity from the lesson body
+  // via the shared `parseDeclaredSeverity` helper (same parser surface as
+  // `buildFrontmatterFromLegacy`). Threaded into every `buildCompiledRule`
+  // call below so the post-LLM override is authoritative regardless of
+  // whether the prompt directive holds.
+  const declaredSeverity = parseDeclaredSeverity(lesson.body);
+
   // Trace buffer (mmnto-ai/totem#1482). Populated unconditionally across all
   // three pipelines so the CLI can choose to render it under --verbose
   // without a per-call gate. Cost of empty-or-small arrays per lesson is
@@ -915,6 +972,7 @@ export async function compileLesson(
     // the override guarantees the gate has something to work with regardless.
     const ruleResult = buildCompiledRule(parsed, lesson, existingByHash, {
       enforceSmokeGate: true,
+      declaredSeverityOverride: declaredSeverity,
       // Guard empty snippet arrays so they don't clobber parsed.badExample
       // or parsed.goodExample via ?? in buildCompiledRule. `[].join('\n')`
       // is the empty string, which is defined and would win over the LLM's
@@ -923,6 +981,12 @@ export async function compileLesson(
       badExampleOverride: snippets.bad.length > 0 ? snippets.bad.join('\n') : undefined,
       goodExampleOverride: snippets.good.length > 0 ? snippets.good.join('\n') : undefined,
     });
+    if (ruleResult.severityOverride) {
+      callbacks?.onSeverityOverride?.(
+        { heading: lesson.heading, hash: lesson.hash },
+        ruleResult.severityOverride,
+      );
+    }
     if (!ruleResult.rule) {
       const rejectReason = ruleResult.rejectReason ?? 'Unknown error';
       callbacks?.onWarn?.(lesson.heading, `Pipeline 3: ${rejectReason} — skipping`);
@@ -1085,7 +1149,14 @@ export async function compileLesson(
     //                        invalid patterns, so the lesson stays pending
     const ruleResult = buildCompiledRule(parsed, lesson, existingByHash, {
       enforceSmokeGate: true,
+      declaredSeverityOverride: declaredSeverity,
     });
+    if (ruleResult.severityOverride) {
+      callbacks?.onSeverityOverride?.(
+        { heading: lesson.heading, hash: lesson.hash },
+        ruleResult.severityOverride,
+      );
+    }
 
     let retryReason: string;
     let retrySnippet: string;

--- a/packages/core/src/compile-lesson.ts
+++ b/packages/core/src/compile-lesson.ts
@@ -413,6 +413,17 @@ export function buildCompiledRule(
       ? { from: emittedSeverity, to: declaredSeverity }
       : undefined;
 
+  // Thread `severityOverride` through rejection paths too (mmnto-ai/totem
+  // #1658 CR round-3 finding). If the LLM drifts on severity AND emits an
+  // invalid/missing pattern, the telemetry signal still fires — the
+  // rejection captures exactly the prompt-drift cases this signal is
+  // meant to detect, and dropping the marker on those paths would
+  // undercount drift measurement.
+  const reject = (rejectReason: string): BuildRuleResult =>
+    severityOverride
+      ? { rule: null, rejectReason, severityOverride }
+      : { rule: null, rejectReason };
+
   const engine = parsed.engine ?? 'regex';
   const now = new Date().toISOString();
   const existing = existingByHash.get(lesson.hash);
@@ -448,16 +459,13 @@ export function buildCompiledRule(
         : parsed.astGrepYamlRule;
 
     if (!astSource || !parsed.message) {
-      return {
-        rule: null,
-        rejectReason: 'Missing astGrepPattern or astGrepYamlRule or message',
-      };
+      return reject('Missing astGrepPattern or astGrepYamlRule or message');
     }
 
     // Validate ast-grep pattern at compile time (#1062, #1339, #1407)
     const astValidation = validateAstGrepPattern(astSource);
     if (!astValidation.valid) {
-      return { rule: null, rejectReason: `Invalid ast-grep pattern: ${astValidation.reason}` };
+      return reject(`Invalid ast-grep pattern: ${astValidation.reason}`);
     }
 
     // Guard: reject patterns that match suppression directives (#1177).
@@ -467,11 +475,9 @@ export function buildCompiledRule(
     // question 2, resolved "keep existing stringify path").
     const astPatternStr = typeof astSource === 'string' ? astSource : JSON.stringify(astSource);
     if (isSelfSuppressing(astPatternStr)) {
-      return {
-        rule: null,
-        rejectReason:
-          'Pattern matches a suppression directive (totem-ignore/totem-context) and will self-suppress at runtime',
-      };
+      return reject(
+        'Pattern matches a suppression directive (totem-ignore/totem-context) and will self-suppress at runtime',
+      );
     }
 
     candidate = {
@@ -490,7 +496,7 @@ export function buildCompiledRule(
     };
   } else if (engine === 'ast') {
     if (!parsed.astQuery || !parsed.message) {
-      return { rule: null, rejectReason: 'Missing astQuery or message' };
+      return reject('Missing astQuery or message');
     }
     candidate = {
       lessonHash: lesson.hash,
@@ -509,7 +515,7 @@ export function buildCompiledRule(
   } else {
     // Regex engine (default)
     if (!parsed.pattern || !parsed.message) {
-      return { rule: null, rejectReason: 'Missing pattern or message' };
+      return reject('Missing pattern or message');
     }
     // mmnto-ai/totem#1641 Change 2 invariant: `validateRegex` (safe-regex2
     // static complexity check) MUST run before any smoke-gate evaluation
@@ -521,17 +527,15 @@ export function buildCompiledRule(
     // runtime bound (RegexEvaluator) now protects against.
     const validation = validateRegex(parsed.pattern);
     if (!validation.valid) {
-      return { rule: null, rejectReason: `Rejected regex: ${validation.reason}` };
+      return reject(`Rejected regex: ${validation.reason}`);
     }
 
     // Guard: reject patterns that match suppression directives (#1177)
     // These rules can never fire — the engine suppresses matching lines before rule evaluation.
     if (isSelfSuppressing(parsed.pattern)) {
-      return {
-        rule: null,
-        rejectReason:
-          'Pattern matches a suppression directive (totem-ignore/totem-context) and will self-suppress at runtime',
-      };
+      return reject(
+        'Pattern matches a suppression directive (totem-ignore/totem-context) and will self-suppress at runtime',
+      );
     }
 
     candidate = {
@@ -569,18 +573,12 @@ export function buildCompiledRule(
     const hasBadExample =
       typeof effectiveBadExample === 'string' && effectiveBadExample.trim().length > 0;
     if (!hasBadExample) {
-      return {
-        rule: null,
-        rejectReason: 'smoke gate: missing badExample (required for Pipeline 2/3)',
-      };
+      return reject('smoke gate: missing badExample (required for Pipeline 2/3)');
     }
     const gate = runSmokeGate(candidate, effectiveBadExample);
     if (!gate.matched) {
       const suffix = gate.reason ? ` (${gate.reason})` : '';
-      return {
-        rule: null,
-        rejectReason: `smoke gate: zero matches against badExample${suffix}`,
-      };
+      return reject(`smoke gate: zero matches against badExample${suffix}`);
     }
     // mmnto-ai/totem#1580: over-matching check. The rule must fire on its
     // badExample (above) AND must NOT fire on its goodExample. Symmetric
@@ -589,17 +587,13 @@ export function buildCompiledRule(
     const hasGoodExample =
       typeof effectiveGoodExample === 'string' && effectiveGoodExample.trim().length > 0;
     if (!hasGoodExample) {
-      return {
-        rule: null,
-        rejectReason: 'smoke gate: missing goodExample (required for Pipeline 2/3)',
-      };
+      return reject('smoke gate: missing goodExample (required for Pipeline 2/3)');
     }
     const overMatchGate = runSmokeGate(candidate, effectiveGoodExample);
     if (overMatchGate.matched) {
-      return {
-        rule: null,
-        rejectReason: `smoke gate: matches goodExample (over-matching: ${overMatchGate.matchCount} match${overMatchGate.matchCount === 1 ? '' : 'es'})`,
-      };
+      return reject(
+        `smoke gate: matches goodExample (over-matching: ${overMatchGate.matchCount} match${overMatchGate.matchCount === 1 ? '' : 'es'})`,
+      );
     }
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -251,6 +251,7 @@ export {
   extractField,
   extractManualPattern,
   extractRuleExamples,
+  parseDeclaredSeverity,
   stripInlineCode,
 } from './lesson-pattern.js';
 export type { IngestionSanitizeOptions } from './sanitize.js';

--- a/packages/core/src/lesson-pattern.test.ts
+++ b/packages/core/src/lesson-pattern.test.ts
@@ -932,6 +932,17 @@ describe('parseDeclaredSeverity', () => {
     expect(parseDeclaredSeverity('Severity: **warning**,')).toBe('warning');
   });
 
+  it('tolerates backtick-wrapped values with bold markers or trailing punctuation', () => {
+    // Order-of-operations matters: `stripInlineCode` only matches when
+    // backticks are at absolute string edges. Running markdown/punctuation
+    // strip first isolates the core value; then `stripInlineCode` removes
+    // the backticks around it. GCA round-3 finding on
+    // mmnto-ai/totem#1658.
+    expect(parseDeclaredSeverity('Severity: **`error`**')).toBe('error');
+    expect(parseDeclaredSeverity('Severity: `error`.')).toBe('error');
+    expect(parseDeclaredSeverity('Severity: **`warning`**.')).toBe('warning');
+  });
+
   it('tolerates comma or semicolon after the severity value', () => {
     expect(parseDeclaredSeverity('Severity: error,')).toBe('error');
     expect(parseDeclaredSeverity('Severity: warning;')).toBe('warning');

--- a/packages/core/src/lesson-pattern.test.ts
+++ b/packages/core/src/lesson-pattern.test.ts
@@ -9,6 +9,7 @@ import {
   extractMultilineField,
   extractRuleExamples,
   extractYamlRuleAfterField,
+  parseDeclaredSeverity,
   stripInlineCode,
 } from './lesson-pattern.js';
 
@@ -869,5 +870,81 @@ describe('extractGoodExample', () => {
   it('matches the Good heading case-insensitively', () => {
     const body = '### good Example\n```ts\nfoo()\n```';
     expect(extractGoodExample(body)).toBe('foo()');
+  });
+});
+
+// ─── parseDeclaredSeverity (mmnto-ai/totem#1656) ─────
+
+describe('parseDeclaredSeverity', () => {
+  it('extracts error from canonical **Severity:** error prose', () => {
+    expect(parseDeclaredSeverity('**Severity:** error')).toBe('error');
+  });
+
+  it('extracts warning from canonical **Severity:** warning prose', () => {
+    expect(parseDeclaredSeverity('**Severity:** warning')).toBe('warning');
+  });
+
+  it('normalizes uppercase to lowercase', () => {
+    expect(parseDeclaredSeverity('**Severity:** ERROR')).toBe('error');
+    expect(parseDeclaredSeverity('**Severity:** Warning')).toBe('warning');
+  });
+
+  it('accepts the alt markdown form **Severity**: error', () => {
+    expect(parseDeclaredSeverity('**Severity**: error')).toBe('error');
+  });
+
+  it('accepts plain Severity: warning without bold markers', () => {
+    expect(parseDeclaredSeverity('Severity: warning')).toBe('warning');
+  });
+
+  it('tolerates trailing period after the severity value', () => {
+    // lesson-ef0ba0d7 on liquid-city uses "**Severity: error.**" shape; the
+    // extractField helper captures the whole value including trailing
+    // punctuation, so the exact prose shape drives the match behavior.
+    // The current helper returns the raw extracted value; a trailing period
+    // makes the normalized value "error." which does not match the enum,
+    // so the helper returns undefined. If/when extractField is taught to
+    // strip trailing punctuation this test locks in the expected behavior
+    // change. For now, the LC exhibit's prose needs the period outside the
+    // bold marker (`**Severity: error.**` -> value captured as `error.**`)
+    // which is handled by parseDeclaredSeverity returning undefined, and
+    // the LLM's fallback emission survives. Document the boundary here.
+    expect(parseDeclaredSeverity('Severity: error.')).toBeUndefined();
+  });
+
+  it('returns undefined when no Severity field is present', () => {
+    expect(parseDeclaredSeverity('This lesson describes an important invariant.')).toBeUndefined();
+  });
+
+  it('returns undefined for free-prose mentions without the Severity: key', () => {
+    // Mandatory-colon guard from lesson-28a41450 — "this prevents a severe
+    // error" must not match as a severity declaration.
+    expect(
+      parseDeclaredSeverity('This lesson prevents a severe error in production code.'),
+    ).toBeUndefined();
+    expect(parseDeclaredSeverity('A warning message appears during compile.')).toBeUndefined();
+  });
+
+  it('returns undefined for an out-of-vocabulary severity level', () => {
+    // The helper only produces the two canonical values that the
+    // `CompiledRule.severity` field accepts. Prose declaring "info" or
+    // "fatal" or any other string returns undefined, preserving the
+    // compile-pipeline's default fallback.
+    expect(parseDeclaredSeverity('**Severity:** info')).toBeUndefined();
+    expect(parseDeclaredSeverity('**Severity:** critical')).toBeUndefined();
+  });
+
+  it('matches the first Severity: declaration when multiple appear', () => {
+    // extractField returns the first match on the case-insensitive,
+    // line-anchored regex. Lock in that a lesson body with a second
+    // **Severity:** line lower down does not override the first.
+    const body = [
+      '**Severity:** error',
+      '',
+      'Some discussion of the invariant.',
+      '',
+      '**Severity:** warning',
+    ].join('\n');
+    expect(parseDeclaredSeverity(body)).toBe('error');
   });
 });

--- a/packages/core/src/lesson-pattern.test.ts
+++ b/packages/core/src/lesson-pattern.test.ts
@@ -898,18 +898,43 @@ describe('parseDeclaredSeverity', () => {
   });
 
   it('tolerates trailing period after the severity value', () => {
-    // lesson-ef0ba0d7 on liquid-city uses "**Severity: error.**" shape; the
-    // extractField helper captures the whole value including trailing
-    // punctuation, so the exact prose shape drives the match behavior.
-    // The current helper returns the raw extracted value; a trailing period
-    // makes the normalized value "error." which does not match the enum,
-    // so the helper returns undefined. If/when extractField is taught to
-    // strip trailing punctuation this test locks in the expected behavior
-    // change. For now, the LC exhibit's prose needs the period outside the
-    // bold marker (`**Severity: error.**` -> value captured as `error.**`)
-    // which is handled by parseDeclaredSeverity returning undefined, and
-    // the LLM's fallback emission survives. Document the boundary here.
-    expect(parseDeclaredSeverity('Severity: error.')).toBeUndefined();
+    // Matches the liquid-city ADR-008 exhibits where lesson prose ends the
+    // severity line with a period (`**Severity:** error.`). The helper
+    // strips trailing sentence punctuation so the author's intent survives.
+    // mmnto-ai/totem#1658 R1 GCA + CR finding.
+    expect(parseDeclaredSeverity('Severity: error.')).toBe('error');
+    expect(parseDeclaredSeverity('**Severity:** error.')).toBe('error');
+  });
+
+  it('tolerates full-line bold markdown wrapping severity and value', () => {
+    // Shape `**Severity: error**` is common in author prose. extractField
+    // captures `error**`; the trailing-markdown strip normalizes to `error`.
+    expect(parseDeclaredSeverity('**Severity: error**')).toBe('error');
+    expect(parseDeclaredSeverity('**Severity: warning**')).toBe('warning');
+  });
+
+  it('tolerates backtick-wrapped values', () => {
+    expect(parseDeclaredSeverity('**Severity:** `error`')).toBe('error');
+    expect(parseDeclaredSeverity('Severity: `warning`')).toBe('warning');
+  });
+
+  it('tolerates leading markdown markers on the value', () => {
+    // Shape `Severity: **error**` — leading `**` must strip alongside
+    // trailing. Shield round-2 finding on mmnto-ai/totem#1658.
+    expect(parseDeclaredSeverity('Severity: **error**')).toBe('error');
+    expect(parseDeclaredSeverity('Severity: **warning**')).toBe('warning');
+  });
+
+  it('tolerates combined bold-then-punctuation shape like error**.', () => {
+    // Punctuation outside the markdown markers. Both sets must strip to
+    // reach the bare `error` / `warning` token.
+    expect(parseDeclaredSeverity('Severity: **error**.')).toBe('error');
+    expect(parseDeclaredSeverity('Severity: **warning**,')).toBe('warning');
+  });
+
+  it('tolerates comma or semicolon after the severity value', () => {
+    expect(parseDeclaredSeverity('Severity: error,')).toBe('error');
+    expect(parseDeclaredSeverity('Severity: warning;')).toBe('warning');
   });
 
   it('returns undefined when no Severity field is present', () => {

--- a/packages/core/src/lesson-pattern.ts
+++ b/packages/core/src/lesson-pattern.ts
@@ -53,14 +53,34 @@ export interface ManualPattern {
  * normalized `'error' | 'warning'` value if declared, otherwise `undefined`.
  *
  * Reuses `extractField` for the prose-extraction rules (markdown-bold
- * tolerance, mandatory colon, case-insensitive match, line-anchored). Added
- * as a shared helper so the compile pipeline's declared-severity override
- * (in `compile-lesson.ts::compileLesson`) and the CLI's cloud-path override
- * (in `compile.ts`) normalize from a single source of truth.
+ * tolerance, mandatory colon, case-insensitive match, line-anchored). Then
+ * strips trailing markdown boundary markers and sentence punctuation so
+ * common shapes like `**Severity: error.**` (full-line bold with period),
+ * `**Severity:** error.` (trailing period on the value), and
+ * `**Severity:** \`error\`` (backtick-wrapped value) all normalize to the
+ * same token. Strict equality follows the strip so out-of-vocabulary tokens
+ * (`info`, `critical`) still return `undefined` and preserve the
+ * compile-pipeline's default fallback to `'warning'`.
+ *
+ * Added as a shared helper so the compile pipeline's declared-severity
+ * override (in `compile-lesson.ts::compileLesson`) and the CLI's cloud-path
+ * override (in `compile.ts`) normalize from a single source of truth.
  */
 export function parseDeclaredSeverity(body: string): 'error' | 'warning' | undefined {
-  const raw = extractField(body, 'Severity')?.toLowerCase();
-  return raw === 'error' || raw === 'warning' ? raw : undefined;
+  const raw = extractField(body, 'Severity');
+  if (!raw) return undefined;
+  // Strip backtick wrappers first (e.g. `error`), then leading and trailing
+  // markdown boundary markers (`*`, `_`) and trailing sentence punctuation
+  // (`.`, `,`, `;`, `:`, `!`, `?`). Single pass covers both ends: leading
+  // strip handles `Severity: **error**`-shape; trailing strip handles
+  // `Severity: error.`, `**Severity: error**`, and the combined
+  // `**error**.` shape. Tolerates GCA and CR review findings on
+  // mmnto-ai/totem#1658 (bot review rounds 1 + 2, 2026-04-24).
+  const normalized = stripInlineCode(raw.trim())
+    .replace(/^[*_]+|[*_.,;:!?]+$/g, '')
+    .trim()
+    .toLowerCase();
+  return normalized === 'error' || normalized === 'warning' ? normalized : undefined;
 }
 
 export function extractField(body: string, field: string): string | undefined {

--- a/packages/core/src/lesson-pattern.ts
+++ b/packages/core/src/lesson-pattern.ts
@@ -47,6 +47,22 @@ export interface ManualPattern {
   astGrepYamlRule?: Record<string, unknown>;
 }
 
+/**
+ * Parse the declared severity from a lesson body's `**Severity:** error` /
+ * `Severity: warning` prose convention (mmnto-ai/totem#1656). Returns the
+ * normalized `'error' | 'warning'` value if declared, otherwise `undefined`.
+ *
+ * Reuses `extractField` for the prose-extraction rules (markdown-bold
+ * tolerance, mandatory colon, case-insensitive match, line-anchored). Added
+ * as a shared helper so the compile pipeline's declared-severity override
+ * (in `compile-lesson.ts::compileLesson`) and the CLI's cloud-path override
+ * (in `compile.ts`) normalize from a single source of truth.
+ */
+export function parseDeclaredSeverity(body: string): 'error' | 'warning' | undefined {
+  const raw = extractField(body, 'Severity')?.toLowerCase();
+  return raw === 'error' || raw === 'warning' ? raw : undefined;
+}
+
 export function extractField(body: string, field: string): string | undefined {
   // Match all common bold/colon variants (#1282 — caught by Shield AI as a
   // partial-fix consequence of extending extractMultilineField):

--- a/packages/core/src/lesson-pattern.ts
+++ b/packages/core/src/lesson-pattern.ts
@@ -69,17 +69,19 @@ export interface ManualPattern {
 export function parseDeclaredSeverity(body: string): 'error' | 'warning' | undefined {
   const raw = extractField(body, 'Severity');
   if (!raw) return undefined;
-  // Strip backtick wrappers first (e.g. `error`), then leading and trailing
-  // markdown boundary markers (`*`, `_`) and trailing sentence punctuation
-  // (`.`, `,`, `;`, `:`, `!`, `?`). Single pass covers both ends: leading
-  // strip handles `Severity: **error**`-shape; trailing strip handles
-  // `Severity: error.`, `**Severity: error**`, and the combined
-  // `**error**.` shape. Tolerates GCA and CR review findings on
-  // mmnto-ai/totem#1658 (bot review rounds 1 + 2, 2026-04-24).
-  const normalized = stripInlineCode(raw.trim())
-    .replace(/^[*_]+|[*_.,;:!?]+$/g, '')
+  // Strip markdown boundary markers (`*`, `_`) and trailing sentence
+  // punctuation (`.`, `,`, `;`, `:`, `!`, `?`) FIRST, then strip backtick
+  // wrappers. Order is load-bearing: `stripInlineCode` only matches when
+  // backticks are at the absolute string edges, so running it first leaves
+  // backticks in place on shapes like `**\`error\`**` (bold-wrapped
+  // backticks) or `` `error`. `` (backticks followed by punctuation). The
+  // outer strip pass isolates the core value; stripInlineCode then removes
+  // the backticks around it. GCA round-3 finding on mmnto-ai/totem#1658.
+  const stripped = raw
     .trim()
-    .toLowerCase();
+    .replace(/^[*_]+|[*_.,;:!?]+$/g, '')
+    .trim();
+  const normalized = stripInlineCode(stripped).toLowerCase();
   return normalized === 'error' || normalized === 'warning' ? normalized : undefined;
 }
 


### PR DESCRIPTION
## Summary

Close the gap between the already-parsed severity in `lesson.frontmatter` and the compiled rule's emitted severity. The prose-severity parser has been in the codebase since the legacy frontmatter shim (`buildFrontmatterFromLegacy`); the compile pipeline was reading `parsed.severity` from the LLM output and discarding the authoritative declaration. This PR plumbs the declared value through at two layers.

## LC impact

Five ADR-008 rules on `mmnto-ai/liquid-city#77` burned ~10 manual severity-edit commits across R2 + R3 rounds because the compile pipeline emitted `"severity": "warning"` despite the lesson prose declaring `Severity: error`. After this PR merges, the next `totem lesson compile` cycle on liquid-city emits declared severity directly — the archive-in-place severity-edit loop goes away.

## Fix surfaces (two layers)

- **Compile prompt directive.** Both `COMPILER_SYSTEM_PROMPT` and `PIPELINE3_COMPILER_PROMPT` gain a `### Declared Severity (mmnto-ai/totem#1656)` section instructing the LLM to honor `**Severity:** error` / `Severity: warning` prose declarations in the emitted JSON. Reduces the frequency of drift at source.
- **Post-LLM override in `buildCompiledRule`.** Deterministic safety net that replaces `parsed.severity` with the declared value when they differ. LLM compliance is belt-and-suspenders, not load-bearing.

## Telemetry for prompt-tuning feedback

When the override actually changes the final severity, a record tagged `type: 'severity-override'` appends to `.totem/temp/telemetry.jsonl` via the new `onSeverityOverride` callback on `CompileLessonCallbacks`. CLI `compile.ts` wires the sink closure over the cwd-aware `totemDir` (matches the `mmnto-ai/totem#1645` pattern). 

**Marker-fire logic** (Shield finding from the review round): fires only when `declaredSeverity` differs from `emittedSeverity ?? 'warning'`, NOT from `emittedSeverity` alone. Prevents telemetry noise when a lesson declares `'warning'` and the LLM omits severity entirely (both resolve to the default; nothing changed).

## What changed

- **`packages/core/src/lesson-pattern.ts`** — new `parseDeclaredSeverity(body)` helper. Reuses `extractField` for prose extraction. Returns normalized `'error' | 'warning' | undefined`.
- **`packages/core/src/compile-lesson.ts`** — `BuildCompiledRuleOptions.declaredSeverityOverride`, `BuildRuleResult.severityOverride`, `CompileLessonCallbacks.onSeverityOverride`. `compileLesson` extracts once near the top and threads into both internal `buildCompiledRule` calls (Pipeline 2 and Pipeline 3).
- **`packages/cli/src/commands/compile.ts`** — `writeSeverityOverrideTelemetry` closure near `compileCommand` init. Wired as `onSeverityOverride` for the local path; called inline on the cloud path after `buildCompiledRule` returns.
- **`packages/cli/src/commands/compile-templates.ts`** — Declared Severity section appended to both prompts after the Test-Contract Scope Classifier.
- **`packages/core/src/index.ts`** — `parseDeclaredSeverity` re-export.
- **`.totem/specs/1656.md`** — preflight spec + Implementation Design. Captures the architectural insight that the parser already existed; the ticket was plumbing, not authoring.
- **`.strategy` submodule bump** `9e38d44` → `113179c`. Picks up strategy PR #122 (upstream-feedback 012/013 filed frontmatter) and strategy PR #125 (items 015 + 016 from liquid-city session-17).

## Tests (11 new, all passing)

- **5 in `compile-lesson.test.ts`** — `buildCompiledRule` with / without `declaredSeverityOverride` across the matrix (LLM emits different / same / none / warning-matches-default).
- **9 in `lesson-pattern.test.ts`** — `parseDeclaredSeverity` edge cases (canonical, case, alt markdown, bare, multi-declaration, out-of-vocab, trailing-punctuation boundary, free-prose anti-trigger).
- **7 in `compile-templates.test.ts`** — "Declared Severity" directive present on both prompts, issue reference, testing-tag signal, severity values emitted.

Full suites: core **1,331 / 1,331**, cli **1,819 / 1,819**.

## Gates

- [x] `pnpm run format`
- [x] `pnpm exec totem lint` PASS (0 errors, 8 warnings — all #1626-class false positives pending retriage)
- [x] `pnpm exec totem review` PASS (0 findings after DRY refactor + logic fix)
- [x] `pnpm exec totem verify-manifest` PASS (443 rules)
- [x] Pre-push hook PASS
- [ ] Bot review (CR + GCA)
- [ ] CI green
- [ ] Follow-up chore PR retriages LC's five ADR-008 rules via `totem compile --upgrade <hash>`

Closes #1656

🤖 Generated with [Claude Code](https://claude.com/claude-code)