### PR TITLE
feat(cli+docs): document ReDoS-safe module-path-tolerant regex patterns (#1657)

### DIFF
--- a/.totem/specs/1657.md
+++ b/.totem/specs/1657.md
@@ -20,24 +20,29 @@ This makes the gh issue's stated acceptance — "rule using `\b(?:[A-Za-z_]\w*::
 Both pass `safe-regex2@5.0.0` AND cover the module-path-tolerance intent (`crate::state::RunState`, `super::RunState`, bare `RunState`):
 
 **Form 1 — Suffix-anchor (generic identifier):**
+
 ```regex
 (?:::|\b)RunState\b
 ```
+
 - Star height: 1 (no nested quantifiers)
 - Matches: bare `RunState` (via `\b`), `crate::state::RunState` (via `::` at preceding `state::` boundary), `super::RunState`, `&mut RunState`, `&mut super::RunState`
 - Doesn't match: `MyRunState`, `RunStateExtra`
 - Use when the rule fires on the identifier regardless of its surrounding container.
 
 **Form 2 — Bounded wrapper (typed-container scoped):**
+
 ```regex
 \bResMut\s*<[^<>]{0,256}\bRunState\s*>
 ```
+
 - Star height: 1 (`{0,256}` is bounded; `[^<>]` has no nested quantifier)
 - Matches only when `RunState` appears inside `ResMut<...>` brackets, with bounded path content between
 - Tighter scope: doesn't fire on `RunState` references outside `ResMut<>`
 - Use when the rule fires specifically on a typed-container hardening intent (ADR-008 Rule 1's actual shape on liquid-city#77)
 
 **Generic recipes for the docs:**
+
 - Identifier match: `(?:::|\b)<IDENT>\b`
 - Wrapper match: `\b<WRAPPER>\s*<[^<>]{0,256}\b<IDENT>\s*>`
 
@@ -72,12 +77,12 @@ None. No new state.
 
 ### Failure modes
 
-| Failure | Category | Agent-facing surface | Recovery |
-|---|---|---|---|
-| Wiki page link broken (typo in cross-ref) | docs | renders broken in GitHub wiki | manual fix in follow-up |
-| Safe-regex2 behavior changes in a future bump | runtime | Form 1/2 tests would fail loudly in CI on dependency upgrade | tests pin behavior; intentional regression signal |
-| Compile prompt token-limit overflow | runtime | Sonnet refuses prompt or truncates | new section is ~12 lines / ~100 tokens, well within budget |
-| LLM ignores new section and emits unsafe form anyway | runtime | smoke gate rejects the rule (existing behavior) | rule rejected at compile, Sonnet retries; no new degradation |
+| Failure                                              | Category | Agent-facing surface                                         | Recovery                                                     |
+| ---------------------------------------------------- | -------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| Wiki page link broken (typo in cross-ref)            | docs     | renders broken in GitHub wiki                                | manual fix in follow-up                                      |
+| Safe-regex2 behavior changes in a future bump        | runtime  | Form 1/2 tests would fail loudly in CI on dependency upgrade | tests pin behavior; intentional regression signal            |
+| Compile prompt token-limit overflow                  | runtime  | Sonnet refuses prompt or truncates                           | new section is ~12 lines / ~100 tokens, well within budget   |
+| LLM ignores new section and emits unsafe form anyway | runtime  | smoke gate rejects the rule (existing behavior)              | rule rejected at compile, Sonnet retries; no new degradation |
 
 No new silent-degradation paths. The new wiki page documents existing behavior; if anyone follows the docs, they get gate-passing patterns. If they don't, the existing gate rejection still fires.
 
@@ -92,22 +97,26 @@ No new silent-degradation paths. The new wiki page documents existing behavior; 
 ### Open questions
 
 **Q1: Single recommended form vs. both forms in the docs.**
+
 - Options: (a) document only Form 1 (suffix-anchor) as the "default" recipe — simpler; (b) document Form 2 (bounded wrapper) only — narrower but more closely tracks the liquid-city use case; (c) document both with explicit "use this when…" guidance.
 - Tradeoff: (c) gives authors an actual choice and matches the two real intents (identifier-anywhere vs. typed-container scoped). (a) ships less prose but pushes typed-container authors toward over-broad rules. (b) ships less prose but doesn't help authors who want bare-identifier coverage.
 - Recommendation: **(c) document both.** Total addition is ~20 lines of prose + two pattern blocks; the choice is real.
 
 **Q2: Wiki-page home — new file vs. section in existing page.**
+
 - Options: (a) new file `docs/wiki/regex-authoring-guide.md`; (b) new section in `docs/wiki/pipeline-engine.md`; (c) new section in `docs/wiki/baseline-rules.md` (currently nearly empty); (d) section in `docs/wiki/cli-reference.md` under `totem lint`.
 - Tradeoff: (a) is most discoverable for the topic and lets future ReDoS / regex authoring guidance accumulate in one place. (b) is on-topic but the page is currently about Pipelines 1-5 (architecture) not authoring tactics. (c) co-locates with existing rule-authoring content. (d) co-locates with the lint-time gate that fires the rejection — visible to anyone debugging "why was my rule rejected."
 - Recommendation: **(a) new file `regex-authoring-guide.md`.** Topic-specific page. Future regex-authoring guidance (item 016 Option B's actionable rejection messages, or future safe-regex2 idioms) can extend it without polluting Pipeline architecture docs. Cross-link from `pipeline-engine.md` and `cli-reference.md` (`totem lint` section) to surface discoverability without duplicating prose.
 
 **Q3: Strategy item 016 amendment.**
+
 - Item 016 explicitly proposes the empirically-wrong safe form. Future readers of item 016 will hit the same dead end I just hit unless the file is corrected.
 - Options: (a) amend item 016 in place via a strategy PR — single source of truth, but rewrites a filed document; (b) leave item 016 as-is and add a cross-reference comment block at the top of the totem PR + `totem#1657` issue noting the correction; (c) file a NEW upstream-feedback item (019) documenting the correction.
 - Tradeoff: (a) keeps strategy clean for future readers; (b) preserves item 016's history but risks future repeats; (c) creates a paper trail but means items 016+019 are conceptually the same finding.
 - Recommendation: **(a) amend item 016 in place** as part of this PR's strategy-side change. One small commit on a strategy branch, with a "Note (2026-04-24): the originally proposed safe form does not pass safe-regex2; see PR #1657 for the corrected forms" preamble inserted ahead of the Proposal section.
 
 **Q4: Bundle the strategy item 016 amendment with the totem PR or split.**
+
 - Options: (a) one branch on each side, two PRs (totem + strategy), submodule pointer rides on the totem PR; (b) merge the strategy PR first, bump totem submodule, then totem PR.
 - Tradeoff: (a) easier to review (smaller diffs each); (b) totem PR's docs can cite the corrected item 016 location directly without "pending merge" caveats.
 - Recommendation: **(b)** — strategy first, then totem. Strategy item 016 amendment is ~15 lines, fast review.

--- a/.totem/specs/1657.md
+++ b/.totem/specs/1657.md
@@ -1,0 +1,120 @@
+# Spec: ReDoS-safe module-path-tolerant regex idiom — docs + prompt surface (#1657)
+
+Sourced from upstream-feedback item [016](../../.strategy/upstream-feedback/016-redos-gate-blocks-module-path-patterns.md). Originally framed as "document the canonical safe form `\b(?:[A-Za-z_]\w*::)*RunState\b` in the compile-prompt and authoring docs." Empirical verification during /preflight against the installed `safe-regex2@5.0.0` shows that proposed safe form is itself rejected by the gate. The actual deliverable is documenting an empirically-verified safe form (which is different from item 016's proposal).
+
+## Empirical correction to item 016 + the gh issue acceptance
+
+Item 016 and `totem#1657` both name `\b(?:[A-Za-z_]\w*::)*RunState\b` as the ReDoS-safe alternative to GCA's vulnerable form. Verification shows otherwise:
+
+```
+node> safeRegex(String.raw`\b(?:[A-Za-z_]\w*::)*RunState\b`)
+false
+```
+
+Why: `safe-regex2` uses a star-height heuristic — quantifier nested under quantifier (here `\w*` inside `(?:...)*`) is rejected regardless of whether the inner separator (`::`) is unambiguous. Same heuristic the original unsafe form failed on.
+
+This makes the gh issue's stated acceptance — "rule using `\b(?:[A-Za-z_]\w*::)*RunState\b` passes the ReDoS gate" — impossible to satisfy without weakening the gate or replacing safe-regex2. The actual user intent (express module-path tolerance under the gate) requires a different shape.
+
+## Empirically-verified safe forms
+
+Both pass `safe-regex2@5.0.0` AND cover the module-path-tolerance intent (`crate::state::RunState`, `super::RunState`, bare `RunState`):
+
+**Form 1 — Suffix-anchor (generic identifier):**
+```regex
+(?:::|\b)RunState\b
+```
+- Star height: 1 (no nested quantifiers)
+- Matches: bare `RunState` (via `\b`), `crate::state::RunState` (via `::` at preceding `state::` boundary), `super::RunState`, `&mut RunState`, `&mut super::RunState`
+- Doesn't match: `MyRunState`, `RunStateExtra`
+- Use when the rule fires on the identifier regardless of its surrounding container.
+
+**Form 2 — Bounded wrapper (typed-container scoped):**
+```regex
+\bResMut\s*<[^<>]{0,256}\bRunState\s*>
+```
+- Star height: 1 (`{0,256}` is bounded; `[^<>]` has no nested quantifier)
+- Matches only when `RunState` appears inside `ResMut<...>` brackets, with bounded path content between
+- Tighter scope: doesn't fire on `RunState` references outside `ResMut<>`
+- Use when the rule fires specifically on a typed-container hardening intent (ADR-008 Rule 1's actual shape on liquid-city#77)
+
+**Generic recipes for the docs:**
+- Identifier match: `(?:::|\b)<IDENT>\b`
+- Wrapper match: `\b<WRAPPER>\s*<[^<>]{0,256}\b<IDENT>\s*>`
+
+## Acceptance (deviates from gh issue body)
+
+The gh issue's `(?:[A-Za-z_]\w*::)*` acceptance criterion is replaced. The ticket scope is preserved (compile-prompt + authoring docs + regression tests); the recommended pattern is the empirically-verified Form 1 / Form 2 above.
+
+- [ ] `COMPILER_SYSTEM_PROMPT` (`packages/cli/src/commands/compile-templates.ts:49`) gains a "Module-path-tolerant regex" section showing Form 1 + Form 2 with rationale and at least one unsafe-form anti-example.
+- [ ] `PIPELINE3_COMPILER_PROMPT` (`packages/cli/src/commands/compile-templates.ts:507`) gains the same section (compile prompt parity per the existing pattern in #1626 / #1656).
+- [ ] User-facing wiki page documents Forms 1 + 2 with the same anti-example and a one-paragraph note on safe-regex2's star-height heuristic so the rationale is visible.
+- [ ] Regression test in `packages/core/src/compiler.test.ts`: Form 1 passes `validateRegex`, Form 2 passes, item 016's proposed form fails (locks in the empirical correction), the original unsafe form fails (no regression).
+- [ ] Comment on totem#1657 noting the acceptance-criterion correction with the verification snippet.
+- [ ] Comment or amendment on `.strategy/upstream-feedback/016-redos-gate-blocks-module-path-patterns.md` recording the corrected safe form (so future readers of item 016 don't repeat the dead end).
+
+---
+
+## Implementation Design
+
+### Scope
+
+**Will:** add a "Module-path-tolerant regex" section to both compile prompts (`COMPILER_SYSTEM_PROMPT` + `PIPELINE3_COMPILER_PROMPT`) showing Forms 1 + 2 + an unsafe-form anti-example; add a focused `regex-authoring-guide.md` wiki page (or section under an existing page) carrying the same content with the safe-regex2 star-height rationale; add `validateRegex` gate-behavior tests pinning Forms 1 + 2 as accepted and item 016's proposed form + the original unsafe form as rejected; comment on the gh issue + amend strategy item 016.
+
+**Will NOT:** modify the ReDoS gate's rejection message text (item 016's Option B, deferred to a follow-up ticket). Will NOT replace safe-regex2 or weaken the gate. Will NOT pre-author replacement rules for liquid-city's three declined-hardening cases (separate issue at the consumer's discretion). Will NOT add LLM autopromotion (item 016's Option C, deferred indefinitely).
+
+### Data model deltas
+
+None. This PR is documentation, prompt-text, and test-only. No exported types, schemas, or runtime data structures change.
+
+### State lifecycle
+
+None. No new state.
+
+### Failure modes
+
+| Failure | Category | Agent-facing surface | Recovery |
+|---|---|---|---|
+| Wiki page link broken (typo in cross-ref) | docs | renders broken in GitHub wiki | manual fix in follow-up |
+| Safe-regex2 behavior changes in a future bump | runtime | Form 1/2 tests would fail loudly in CI on dependency upgrade | tests pin behavior; intentional regression signal |
+| Compile prompt token-limit overflow | runtime | Sonnet refuses prompt or truncates | new section is ~12 lines / ~100 tokens, well within budget |
+| LLM ignores new section and emits unsafe form anyway | runtime | smoke gate rejects the rule (existing behavior) | rule rejected at compile, Sonnet retries; no new degradation |
+
+No new silent-degradation paths. The new wiki page documents existing behavior; if anyone follows the docs, they get gate-passing patterns. If they don't, the existing gate rejection still fires.
+
+### Invariants to lock in via tests
+
+- `validateRegex` accepts Form 1 (`(?:::|\b)RunState\b`) — locks the empirical claim that the suffix-anchor idiom passes the gate.
+- `validateRegex` accepts Form 2 (`\bResMut\s*<[^<>]{0,256}\bRunState\s*>`) — locks the bounded-wrapper idiom.
+- `validateRegex` rejects item 016's proposed form (`\b(?:[A-Za-z_]\w*::)*RunState\b`) — locks in the empirical correction so future docs PRs cannot accidentally re-document the impossible form.
+- `validateRegex` rejects the original unsafe form (`\bResMut\s*<\s*(?:[A-Za-z_][A-Za-z0-9_:]*::)?RunState\s*>`) — no regression on the gate's rejection of the GCA-suggested vulnerable shape.
+- Behavioral check: Form 1 matches `crate::state::RunState`, `super::RunState`, bare `RunState` and rejects `MyRunState` / `RunStateExtra`. Form 2 matches `ResMut<...>` wrappers and rejects bare `RunState` outside the wrapper.
+
+### Open questions
+
+**Q1: Single recommended form vs. both forms in the docs.**
+- Options: (a) document only Form 1 (suffix-anchor) as the "default" recipe — simpler; (b) document Form 2 (bounded wrapper) only — narrower but more closely tracks the liquid-city use case; (c) document both with explicit "use this when…" guidance.
+- Tradeoff: (c) gives authors an actual choice and matches the two real intents (identifier-anywhere vs. typed-container scoped). (a) ships less prose but pushes typed-container authors toward over-broad rules. (b) ships less prose but doesn't help authors who want bare-identifier coverage.
+- Recommendation: **(c) document both.** Total addition is ~20 lines of prose + two pattern blocks; the choice is real.
+
+**Q2: Wiki-page home — new file vs. section in existing page.**
+- Options: (a) new file `docs/wiki/regex-authoring-guide.md`; (b) new section in `docs/wiki/pipeline-engine.md`; (c) new section in `docs/wiki/baseline-rules.md` (currently nearly empty); (d) section in `docs/wiki/cli-reference.md` under `totem lint`.
+- Tradeoff: (a) is most discoverable for the topic and lets future ReDoS / regex authoring guidance accumulate in one place. (b) is on-topic but the page is currently about Pipelines 1-5 (architecture) not authoring tactics. (c) co-locates with existing rule-authoring content. (d) co-locates with the lint-time gate that fires the rejection — visible to anyone debugging "why was my rule rejected."
+- Recommendation: **(a) new file `regex-authoring-guide.md`.** Topic-specific page. Future regex-authoring guidance (item 016 Option B's actionable rejection messages, or future safe-regex2 idioms) can extend it without polluting Pipeline architecture docs. Cross-link from `pipeline-engine.md` and `cli-reference.md` (`totem lint` section) to surface discoverability without duplicating prose.
+
+**Q3: Strategy item 016 amendment.**
+- Item 016 explicitly proposes the empirically-wrong safe form. Future readers of item 016 will hit the same dead end I just hit unless the file is corrected.
+- Options: (a) amend item 016 in place via a strategy PR — single source of truth, but rewrites a filed document; (b) leave item 016 as-is and add a cross-reference comment block at the top of the totem PR + `totem#1657` issue noting the correction; (c) file a NEW upstream-feedback item (019) documenting the correction.
+- Tradeoff: (a) keeps strategy clean for future readers; (b) preserves item 016's history but risks future repeats; (c) creates a paper trail but means items 016+019 are conceptually the same finding.
+- Recommendation: **(a) amend item 016 in place** as part of this PR's strategy-side change. One small commit on a strategy branch, with a "Note (2026-04-24): the originally proposed safe form does not pass safe-regex2; see PR #1657 for the corrected forms" preamble inserted ahead of the Proposal section.
+
+**Q4: Bundle the strategy item 016 amendment with the totem PR or split.**
+- Options: (a) one branch on each side, two PRs (totem + strategy), submodule pointer rides on the totem PR; (b) merge the strategy PR first, bump totem submodule, then totem PR.
+- Tradeoff: (a) easier to review (smaller diffs each); (b) totem PR's docs can cite the corrected item 016 location directly without "pending merge" caveats.
+- Recommendation: **(b)** — strategy first, then totem. Strategy item 016 amendment is ~15 lines, fast review.
+
+### Verification plan during implementation
+
+- Phase 1: Write failing tests in `compiler.test.ts` for all four pattern shapes (Form 1 accept, Form 2 accept, item 016 proposed form reject, original unsafe form reject). Confirm RED.
+- Phase 2: Add the prompt section + wiki page. No code in `compiler.ts` changes — `validateRegex` already enforces the behavior the tests pin. Tests turn GREEN once they're written correctly against the existing gate.
+- Phase 3: Run `pnpm exec totem lint`, `pnpm exec totem review`. Address findings.
+- Phase 4: Strategy submodule — branch + amend item 016 + commit + push. Bump submodule pointer on the totem branch.

--- a/.totem/specs/1657.md
+++ b/.totem/specs/1657.md
@@ -6,7 +6,7 @@ Sourced from upstream-feedback item [016](../../.strategy/upstream-feedback/016-
 
 Item 016 and `totem#1657` both name `\b(?:[A-Za-z_]\w*::)*RunState\b` as the ReDoS-safe alternative to GCA's vulnerable form. Verification shows otherwise:
 
-```
+```text
 node> safeRegex(String.raw`\b(?:[A-Za-z_]\w*::)*RunState\b`)
 false
 ```

--- a/docs/wiki/cli-reference.md
+++ b/docs/wiki/cli-reference.md
@@ -71,6 +71,8 @@ Regex rules execute under a runtime timeout budget in a persistent worker thread
 
 Timeout outcomes land in `.totem/temp/telemetry.jsonl` tagged `type: 'regex-execution'` with repo-relative path redaction. This is distinct from the input-time ReDoS check on `totem add-secret --pattern` below — that rejects dangerous patterns at authoring time, while the lint-time budget enforces termination against any pattern that slips through.
 
+For authoring patterns that pass the input-time gate, see [Regex Safety](regex-safety.md), which documents two empirically-verified safe forms for module-path-tolerant identifier matching (a class the gate makes non-obvious).
+
 ### `totem rule list` / `totem rule scaffold`
 
 Manage your deterministic rules (Pipeline 1). `rule list` outputs active rules, and `rule scaffold` creates a template for manual rule authoring.

--- a/docs/wiki/regex-safety.md
+++ b/docs/wiki/regex-safety.md
@@ -1,0 +1,98 @@
+# Regex Safety
+
+Totem's compile pipeline rejects regex patterns that the `safe-regex2` static analyzer flags as ReDoS-prone (catastrophic backtracking under adversarial input). This page documents two empirically-verified pattern idioms for a common authoring case the gate makes non-obvious: matching an identifier with optional module-path qualification.
+
+## The gate
+
+`safe-regex2` uses a star-height heuristic. Any quantifier (`*`, `+`, `{n,}`) that wraps a sub-expression also containing a quantifier is rejected, regardless of whether the inner separator is unambiguous. Nested-quantifier shapes the gate rejects:
+
+- `(a+)+` — classic catastrophic backtracking
+- `([a-zA-Z]+)*` — character class with quantifier under outer quantifier
+- `(.*a){10}` — bounded outer quantifier still nests `*`
+- `\b(?:[A-Za-z_]\w*::)*Target\b` — identifier-class with `\w*` under `(?:...)*`
+
+The compile pipeline reports rejections as `Rejected regex: ReDoS vulnerability detected` and skips the rule.
+
+## The authoring trap
+
+A natural shape for "match `Target` with an optional module-path prefix" is `\b(?:[A-Za-z_]\w*::)*Target\b`. It looks safe (the `::` separator is unambiguous so the pattern is linear in practice), but `safe-regex2` rejects it because of the star-height heuristic.
+
+The shape `\bWrapper\s*<\s*(?:[A-Za-z_][A-Za-z0-9_:]*::)?Target\s*>` fails for the same family of reasons (the embedded `:` in the character class plus the literal `::` terminator is the canonical adversarial backtracking shape; `safe-regex2` flags it correctly).
+
+Two safe forms cover the same intent.
+
+## Form 1 — Suffix-anchor
+
+```regex
+(?:::|\b)Target\b
+```
+
+Star height 1 (no nested quantifiers).
+
+**Matches:**
+
+- `Target` (bare, anywhere — the leading `\b` matches at the word boundary)
+- `crate::state::Target` (the leading `::` matches at the `state::` boundary)
+- `super::Target`
+- `&mut Target`
+- `&mut super::Target`
+- `ResMut<crate::state::Target>` (matches inside the wrapper at the `state::` boundary)
+
+**Does not match:**
+
+- `MyTarget` (no `::` and no `\b` between `My` and `Target`)
+- `TargetExtra` (trailing `\b` blocks)
+
+**When to use:** the rule should fire on the identifier regardless of what container surrounds it.
+
+## Form 2 — Bounded wrapper
+
+```regex
+\bWrapper\s*<[^<>]{0,256}\bTarget\s*>
+```
+
+Star height 1 (`{0,256}` is a bounded quantifier; `[^<>]` has no nested quantifier).
+
+**Matches:**
+
+- `Wrapper<Target>`
+- `Wrapper<crate::state::Target>`
+- `Wrapper<super::Target>`
+- `fn foo(state: Wrapper<crate::director::state::Target>) {}` (path content is bounded by `[^<>]{0,256}`)
+
+**Does not match:**
+
+- `&mut Target` (no `Wrapper<...>` envelope)
+- `let x: Target = ...` (no `Wrapper<...>` envelope)
+- `Wrapper<TargetExtra>` (interior `\b` blocks the prefix collision)
+
+**When to use:** the rule should fire only when `Target` appears inside a specific typed container (e.g., `ResMut<Target>` for a Bevy ECS mutability hardening rule, `Box<Target>` for an ownership rule).
+
+## Anti-pattern
+
+Do not try to literally match an unbounded number of `<ident>::` segments via repetition. The gate will reject every shape that nests a quantifier under another quantifier. The two forms above match the same set of identifier forms without the gate-rejected shape.
+
+If a rule genuinely needs to walk an unbounded path of arbitrary depth, regex is the wrong tool. Use ast-grep with `kind:` and `inside:` combinators instead, which parse the source structurally and do not rely on regex backtracking. See [The Pipeline Engine](pipeline-engine.md) for ast-grep authoring guidance.
+
+## Verifying a pattern locally
+
+`safe-regex2` is the same package the compile gate uses. Verify a candidate pattern against it before authoring the lesson:
+
+```text
+node -e "console.log(require('safe-regex2')(String.raw\`<your-pattern>\`))"
+```
+
+A `true` result means the pattern passes the gate. A `false` result means it will be rejected at compile time.
+
+## Background
+
+The two safe forms emerged from a 2026-04-24 audit of an upstream-feedback item (`mmnto-ai/totem-strategy` item `016-redos-gate-blocks-module-path-patterns.md`) that originally proposed the trap shape above as canonical. The trap shape was caught at preflight verification. The full reasoning chain lives in:
+
+- `mmnto-ai/totem-strategy:upstream-feedback/016-redos-gate-blocks-module-path-patterns.md` (with the 🔴 CORRECTION preamble naming the empirical update)
+- `mmnto-ai/totem` issue [#1657](https://github.com/mmnto-ai/totem/issues/1657)
+- The `module-path-tolerant regex patterns (#1657)` test block in `packages/core/src/compiler.test.ts` pins both safe forms as accepted and the trap shapes as rejected.
+
+## Related
+
+- [The Pipeline Engine](pipeline-engine.md) — pipeline architecture for rule creation
+- [CLI Reference](cli-reference.md) — `totem lint --timeout-mode` for the runtime ReDoS budget that complements the input-time gate documented here

--- a/packages/cli/src/commands/compile-templates.test.ts
+++ b/packages/cli/src/commands/compile-templates.test.ts
@@ -223,6 +223,48 @@ describe('Declared Severity directive (mmnto-ai/totem#1656)', () => {
   });
 });
 
+// ─── Module-Path-Tolerant Regex Patterns (mmnto-ai/totem#1657) ──
+
+describe('Module-Path-Tolerant Regex Patterns (mmnto-ai/totem#1657)', () => {
+  describe('COMPILER_SYSTEM_PROMPT', () => {
+    it('declares the section with the #1657 issue reference', () => {
+      expect(COMPILER_SYSTEM_PROMPT).toContain('Module-Path-Tolerant Regex');
+      expect(COMPILER_SYSTEM_PROMPT).toContain('mmnto-ai/totem#1657');
+    });
+
+    it('documents Form 1 (suffix-anchor) verbatim', () => {
+      expect(COMPILER_SYSTEM_PROMPT).toContain('(?:::|\\b)Target\\b');
+    });
+
+    it('documents Form 2 (bounded wrapper) verbatim', () => {
+      expect(COMPILER_SYSTEM_PROMPT).toContain('\\bWrapper\\s*<[^<>]{0,256}\\bTarget\\s*>');
+    });
+
+    it('names the trap shape from item 016 so the LLM does not re-emit it', () => {
+      expect(COMPILER_SYSTEM_PROMPT).toContain('\\b(?:[A-Za-z_]\\w*::)*Target\\b');
+    });
+  });
+
+  describe('PIPELINE3_COMPILER_PROMPT', () => {
+    it('declares the section with the #1657 issue reference (parity with COMPILER_SYSTEM_PROMPT)', () => {
+      expect(PIPELINE3_COMPILER_PROMPT).toContain('Module-Path-Tolerant Regex');
+      expect(PIPELINE3_COMPILER_PROMPT).toContain('mmnto-ai/totem#1657');
+    });
+
+    it('documents Form 1 (suffix-anchor) verbatim', () => {
+      expect(PIPELINE3_COMPILER_PROMPT).toContain('(?:::|\\b)Target\\b');
+    });
+
+    it('documents Form 2 (bounded wrapper) verbatim', () => {
+      expect(PIPELINE3_COMPILER_PROMPT).toContain('\\bWrapper\\s*<[^<>]{0,256}\\bTarget\\s*>');
+    });
+
+    it('names the trap shape from item 016 so the LLM does not re-emit it', () => {
+      expect(PIPELINE3_COMPILER_PROMPT).toContain('\\b(?:[A-Za-z_]\\w*::)*Target\\b');
+    });
+  });
+});
+
 // ─── KIND_ALLOW_LIST ────────────────────────────────
 
 describe('KIND_ALLOW_LIST', () => {

--- a/packages/cli/src/commands/compile-templates.ts
+++ b/packages/cli/src/commands/compile-templates.ts
@@ -252,6 +252,30 @@ The compile pipeline applies a deterministic override after your output, so a mi
 
 **Anti-lazy guard:** do not classify "severity" language in free prose as a declaration. A lesson body that says "this prevents a severe error" or "a warning message appears" is NOT declaring severity. Only the structured \`Severity:\` key with a colon counts.
 
+### Module-Path-Tolerant Regex Patterns (mmnto-ai/totem#1657)
+
+Compile-time ReDoS validation rejects nested repetition. The naive shape \`\\b(?:[A-Za-z_]\\w*::)*Target\\b\` (an identifier-class with \`\\w*\` inside an outer \`(?:...)*\`) triggers safe-regex2's star-height heuristic regardless of whether the inner \`::\` separator is unambiguous. The shape \`\\bWrapper\\s*<\\s*(?:[A-Za-z_][A-Za-z0-9_:]*::)?Target\\s*>\` fails for the same reason (the embedded \`:\` in the character class plus the literal \`::\` terminator is the canonical adversarial backtracking shape).
+
+When a lesson asks for matches that tolerate optional module-path qualification (e.g., \`crate::state::RunState\`, \`super::RunState\`, bare \`RunState\`), use one of these two empirically-verified safe forms instead:
+
+**Form 1 — Suffix-anchor (identifier-anywhere intent):**
+
+\`\`\`regex
+(?:::|\\b)Target\\b
+\`\`\`
+
+Star height 1. Matches bare \`Target\`, \`crate::state::Target\`, \`super::Target\`, \`&mut Target\`. Does not over-match \`MyTarget\` or \`TargetExtra\` (trailing \`\\b\`). Use when the rule should fire on the identifier regardless of its surrounding container.
+
+**Form 2 — Bounded wrapper (typed-container scoped):**
+
+\`\`\`regex
+\\bWrapper\\s*<[^<>]{0,256}\\bTarget\\s*>
+\`\`\`
+
+Star height 1 (\`{0,256}\` is a bounded quantifier; \`[^<>]\` has no nested quantifier). Matches only when \`Target\` appears inside \`Wrapper<...>\` brackets with bounded path content between. Use when the rule should fire specifically on a typed-container hardening intent (e.g., \`ResMut<RunState>\` mutations).
+
+**Anti-lazy guard:** do NOT emit \`\\b(?:[A-Za-z_]\\w*::)*Target\\b\` or \`\\bWrapper\\s*<\\s*(?:[A-Za-z_][A-Za-z0-9_:]*::)?Target\\s*>\` — both fail safe-regex2's star-height check at compile time and the rule will be rejected with reason \`Rejected regex: ReDoS vulnerability detected\`.
+
 ## Examples
 
 Lesson: "Use \`err\` (never \`error\`) in catch blocks"
@@ -644,6 +668,30 @@ Read the lesson body for a \`Severity: <level>\` declaration and **honor it** in
 The compile pipeline applies a deterministic override after your output, so a mismatch is corrected silently. Honoring the declaration keeps your output self-consistent and avoids wasted telemetry records.
 
 **Anti-lazy guard:** do not classify "severity" language in free prose as a declaration. A lesson body that mentions "this prevents a severe error" or "a warning message appears" is NOT declaring severity. Only the structured \`Severity:\` key with a colon counts.
+
+### Module-Path-Tolerant Regex Patterns (mmnto-ai/totem#1657)
+
+Compile-time ReDoS validation rejects nested repetition. The naive shape \`\\b(?:[A-Za-z_]\\w*::)*Target\\b\` (an identifier-class with \`\\w*\` inside an outer \`(?:...)*\`) triggers safe-regex2's star-height heuristic regardless of whether the inner \`::\` separator is unambiguous. The shape \`\\bWrapper\\s*<\\s*(?:[A-Za-z_][A-Za-z0-9_:]*::)?Target\\s*>\` fails for the same reason.
+
+When the Bad-vs-Good distinction calls for matching an identifier with optional module-path qualification (e.g., \`crate::state::RunState\`, \`super::RunState\`, bare \`RunState\`), use one of these two empirically-verified safe forms instead:
+
+**Form 1 — Suffix-anchor (identifier-anywhere intent):**
+
+\`\`\`regex
+(?:::|\\b)Target\\b
+\`\`\`
+
+Star height 1. Matches bare \`Target\`, \`::-prefixed\` paths, and \`&mut\`-style references. Does not over-match \`MyTarget\` (trailing \`\\b\`).
+
+**Form 2 — Bounded wrapper (typed-container scoped):**
+
+\`\`\`regex
+\\bWrapper\\s*<[^<>]{0,256}\\bTarget\\s*>
+\`\`\`
+
+Star height 1 (bounded quantifier; \`[^<>]\` has no nested quantifier). Matches only when \`Target\` appears inside \`Wrapper<...>\` with bounded path content between.
+
+**Anti-lazy guard:** do NOT emit nested-quantifier shapes — they fail the gate at compile time.
 
 Every compilable rule MUST include non-empty \`badExample\` AND \`goodExample\` fields. The compile pipeline's schema parse rejects output that omits either one for \`ast-grep\` or \`regex\` engines, so the rule never reaches the smoke gate. The smoke gate then runs the rule against both snippets: the pattern MUST match \`badExample\` (zero matches here rejects with reason code \`pattern-zero-match\`) and MUST NOT match \`goodExample\` (any match here rejects with reason code \`matches-good-example\`).
 `;

--- a/packages/core/src/compiler.test.ts
+++ b/packages/core/src/compiler.test.ts
@@ -95,6 +95,98 @@ describe('validateRegex', () => {
   });
 });
 
+// ─── Module-path-tolerant regex idioms (mmnto-ai/totem#1657) ─────
+//
+// Pins the empirically-verified safe forms documented in the compile
+// prompts and `docs/wiki/regex-safety.md`. These tests intentionally
+// reference the literal pattern strings the docs cite so a docs change
+// to a different pattern is caught here.
+//
+// Authoring intent: catch references to a target identifier with
+// optional module-path qualification (`crate::state::RunState`,
+// `super::RunState`, bare `RunState`). The naive shape with nested
+// quantifiers — `\b(?:[A-Za-z_]\w*::)*RunState\b` — is rejected by
+// safe-regex2's star-height heuristic regardless of whether the inner
+// `::` separator is unambiguous, so the docs recommend two genuinely-
+// safe forms:
+//
+//  - Form 1 (suffix-anchor):     (?:::|\b)<IDENT>\b
+//  - Form 2 (bounded wrapper):   \b<WRAPPER>\s*<[^<>]{0,256}\b<IDENT>\s*>
+
+describe('module-path-tolerant regex patterns (#1657)', () => {
+  // Form 1 — suffix-anchor: identifier-anywhere intent.
+  const FORM_1 = String.raw`(?:::|\b)RunState\b`;
+
+  // Form 2 — bounded wrapper: typed-container-scoped intent
+  // (e.g., catching `ResMut<RunState>` mutations specifically).
+  const FORM_2 = String.raw`\bResMut\s*<[^<>]{0,256}\bRunState\s*>`;
+
+  // Item 016's originally-proposed safe form. Empirically rejected by
+  // safe-regex2 because `\w*` nests under `(?:...)*`. Pinning this
+  // rejection prevents a future docs PR from re-documenting the
+  // impossible shape.
+  const ITEM_016_PROPOSED = String.raw`\b(?:[A-Za-z_]\w*::)*RunState\b`;
+
+  // The original liquid-city#77 R2 unsafe form (the GCA-suggested
+  // shape that started this whole investigation). Pinning the
+  // rejection guards against safe-regex2 weakening in a future bump.
+  const ORIGINAL_UNSAFE = String.raw`\bResMut\s*<\s*(?:[A-Za-z_][A-Za-z0-9_:]*::)?RunState\s*>`;
+
+  it('Form 1 (suffix-anchor) passes the ReDoS gate', () => {
+    expect(validateRegex(FORM_1)).toEqual({ valid: true });
+  });
+
+  it('Form 2 (bounded wrapper) passes the ReDoS gate', () => {
+    expect(validateRegex(FORM_2)).toEqual({ valid: true });
+  });
+
+  it('item 016 proposed form is rejected (locks the empirical correction)', () => {
+    const result = validateRegex(ITEM_016_PROPOSED);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('ReDoS vulnerability detected');
+  });
+
+  it('original liquid-city#77 unsafe form is rejected (no regression)', () => {
+    const result = validateRegex(ORIGINAL_UNSAFE);
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe('ReDoS vulnerability detected');
+  });
+
+  it('Form 1 matches the intended cases (bare, ::-prefixed, &mut)', () => {
+    const re = new RegExp(FORM_1);
+    expect(re.test('ResMut<RunState>')).toBe(true);
+    expect(re.test('ResMut<crate::state::RunState>')).toBe(true);
+    expect(re.test('ResMut<super::RunState>')).toBe(true);
+    expect(re.test('&mut RunState')).toBe(true);
+    expect(re.test('&mut super::RunState')).toBe(true);
+  });
+
+  it('Form 1 does not over-match identifier-prefix collisions', () => {
+    const re = new RegExp(FORM_1);
+    expect(re.test('MyRunState')).toBe(false);
+    expect(re.test('RunStateExtra')).toBe(false);
+  });
+
+  it('Form 2 matches only inside ResMut<...> wrappers', () => {
+    const re = new RegExp(FORM_2);
+    expect(re.test('ResMut<RunState>')).toBe(true);
+    expect(re.test('ResMut<crate::state::RunState>')).toBe(true);
+    expect(re.test('ResMut<super::RunState>')).toBe(true);
+    expect(re.test('fn foo(state: ResMut<crate::director::state::RunState>) {}')).toBe(true);
+  });
+
+  it('Form 2 does not match RunState references outside ResMut<>', () => {
+    const re = new RegExp(FORM_2);
+    expect(re.test('&mut RunState')).toBe(false);
+    expect(re.test('let x: RunState = ...;')).toBe(false);
+  });
+
+  it('Form 2 does not over-match identifier-prefix collisions inside the wrapper', () => {
+    const re = new RegExp(FORM_2);
+    expect(re.test('ResMut<RunStateExtra>')).toBe(false);
+  });
+});
+
 // ─── extractAddedLines ──────────────────────────────
 
 describe('extractAddedLines', () => {


### PR DESCRIPTION
## Summary

The compile-time ReDoS gate (safe-regex2's star-height heuristic) correctly rejects module-path-tolerant regex shapes contributors naturally write when hardening against `crate::state::Target`-style bypass classes. Until now no safe alternative was documented. This PR ships two empirically-verified safe forms in both compile prompts and a dedicated wiki page.

- **Form 1 (suffix-anchor)**: `(?:::|\b)Target\b` — identifier-anywhere intent
- **Form 2 (bounded wrapper)**: `\bWrapper\s*<[^<>]{0,256}\bTarget\s*>` — typed-container scoped

Both have star height 1 (no nested quantifiers), pass `safe-regex2`, and cover the `mmnto-ai/liquid-city#77` `ResMut<RunState>` hardening intent including bare, `::`-prefixed (`crate::state::RunState`), and `super::`-prefixed identifier forms.

## Empirical scope correction

Item 016 + this issue's stated acceptance both named `\b(?:[A-Za-z_]\w*::)*Target\b` as the canonical safe form. Empirical verification during /preflight against `safe-regex2@5.0.0` showed that pattern itself is rejected (nested `*` quantifiers — same star-height heuristic the original unsafe form failed on):

```text
node> safeRegex(String.raw`\b(?:[A-Za-z_]\w*::)*RunState\b`)
false
```

Strategy-side correction merged via [`mmnto-ai/totem-strategy#129`](https://github.com/mmnto-ai/totem-strategy/pull/129) ahead of this PR; the wiki page and prompt sections cite the corrected forms. Methodology refinement to add an upstream-API verification step to /preflight Phase 1 filed as [#1661](https://github.com/mmnto-ai/totem/issues/1661).

## Changes

- `packages/cli/src/commands/compile-templates.ts`: new "Module-Path-Tolerant Regex Patterns (#1657)" section in both `COMPILER_SYSTEM_PROMPT` and `PIPELINE3_COMPILER_PROMPT`, parity per the established convention from #1626 + #1656.
- `packages/cli/src/commands/compile-templates.test.ts`: 8 new tests pinning section presence + verbatim Form 1 + Form 2 + trap-shape strings in both prompts (so a future docs PR cannot silently re-document the impossible shape on one prompt while fixing the other).
- `packages/core/src/compiler.test.ts`: 9 new tests pinning Form 1 accept, Form 2 accept, item 016 proposed form reject, original `liquid-city#77` unsafe form reject, plus behavioral matchers (`Form 1` vs `MyRunState` collision, `Form 2` scoping inside `ResMut` wrapper).
- `docs/wiki/regex-safety.md`: new focused page for regex-safety authoring guidance. Documents both safe forms with rationale, the gate's star-height heuristic, an anti-pattern note pointing to ast-grep for unbounded-depth path traversal, and a local verification snippet so contributors can check candidate patterns before submission.
- `docs/wiki/cli-reference.md`: cross-link from the `totem lint` section's existing ReDoS prose to the new page.
- `.strategy` submodule bump to `68740a6` (picks up the item 016 correction + the post-1.15.4 strategy commits).

## Out of scope

Per the design doc:

- ReDoS gate rejection-message improvements (item 016 Option B, deferred to a follow-up ticket).
- LLM autopromotion (item 016 Option C, deferred indefinitely).
- ast-grep / tree-sitter language-pack work for non-TS rules (parked at [`totem-strategy#128`](https://github.com/mmnto-ai/totem-strategy/pull/128) pending the four-option Proposal decision).

## Test plan

- [x] Core test suite: 1348 pass (+9 new in `compiler.test.ts`).
- [x] CLI test suite: 1827 pass (+8 new in `compile-templates.test.ts`).
- [x] `pnpm exec totem lint`: PASS, 82 warnings, 0 errors. All warnings are pre-existing over-broad rules firing on this PR's regex test fixtures (e.g., `re.test('&mut RunState')` triggering "use anchored regex for shell command matching" because the rule pattern is literal `//`); none are introduced by this change.
- [x] `pnpm exec totem review`: PASS, no findings.
- [x] Empirical verification of all four documented patterns against installed `safe-regex2@5.0.0` performed during preflight; the verification snippet from `docs/wiki/regex-safety.md` reproduces the result.

Closes #1657.

🤖 Generated with [Claude Code](https://claude.com/claude-code)