### PR TITLE
fix(core+cli): honor source-declared Scope over LLM emission (#1665)

### DIFF
--- a/.changeset/1665-scope-derivation-override.md
+++ b/.changeset/1665-scope-derivation-override.md
@@ -1,0 +1,19 @@
+---
+'@mmnto/totem': patch
+'@mmnto/cli': patch
+'@mmnto/mcp': patch
+---
+
+fix(core+cli): honor source-declared `**Scope:**` over LLM emission on Pipeline 2/3 (#1665)
+
+Strategy item 023 substrate. Inverse of `mmnto-ai/totem#1626` (auto-ADD): the compile worker silently DROPPED test/spec exclusion globs (`!**/*.test.*`, `!**/*.spec.*`) that lessons declared in their `**Scope:**` line. Confirmed twice on `mmnto-ai/liquid-city#80` for rules `5bcc8aad9096c817` and `6c457c82d3945d15`.
+
+- New `parseDeclaredScope(body)` helper in `@mmnto/totem` that parses the lesson body's `**Scope:**` prose declaration into a glob list. Preserves `!`-prefixed exclusion entries verbatim and preserves authored order. Returns `undefined` for missing/empty/whitespace-only declarations.
+- New `isGlobSetEqual(a, b)` pure helper for set-of-strings comparison. Order-insensitive, duplicate-insensitive, sign-sensitive (`'!**/*.test.*'` does not equal `'**/*.test.*'`).
+- `extractManualPattern` (Pipeline 1) refactored to delegate Scope parsing to `parseDeclaredScope` so the manual flow shares a single source of truth with Pipeline 2/3.
+- `BuildCompiledRuleOptions.lessonBody?: string` opts callers into the override path. When supplied AND the body declares a `**Scope:**` line, the parsed source-Scope glob list takes precedence over `parsed.fileGlobs` regardless of LLM emission. Both lists pass through `sanitizeFileGlobs` for parity (shallow → recursive normalization).
+- `BuildRuleResult.scopeOverride?: { from: string[] | undefined; to: string[] }` reports the override event when the override actually changed the emitted globs. Threaded through rejection paths too. Mirrors `severityOverride` discipline from #1656.
+- New `onScopeOverride` callback on `CompileLessonCallbacks` wired to a `writeScopeOverrideTelemetry` closure in CLI `compile.ts` that records `type: 'scope-override'` entries to `.totem/temp/telemetry.jsonl`. Cloud-compile path also wired.
+- Author intent supreme: source-declared Scope overrides the LLM's emission AND the #1626 test-contract auto-include heuristic. The auto-include path stays active only when the lesson omits Scope.
+
+Compile pipeline failure mode shifts from "silent drop" to "deterministic override + telemetry on divergence." Strict-fail compile gate is deferred to a follow-up if telemetry reveals persistent LLM drift.

--- a/.totem/specs/1665.md
+++ b/.totem/specs/1665.md
@@ -1,0 +1,157 @@
+### Problem Statement
+
+The compile pipeline is silently dropping exclusion globs (e.g., `!**/*.test.*`) from a lesson's declared `Scope:` field when generating the compiled rule's `fileGlobs`. The validation smoke-gate currently uses a permissive superset check that allows these omissions to pass, requiring an update to strict set-of-strings equality to catch both dropped exclusions (this issue) and missing auto-inclusions (Issue #1626).
+
+### Architectural Context
+
+This is the inverse of Issue #1626 (shipped in 1.15.4, PR #1652 `3037591d`), which handled auto-_adding_ test inclusions for test-contract lessons. The pipeline currently enforces scope correctness via a smoke-gate check inside the compile stage. Moving to strict set-of-strings equality enforces determinism: the pipeline's derived expected scope MUST perfectly match the compiled `fileGlobs`—no missing exclusions, no hallucinated additions.
+
+### Files to Examine
+
+1. `packages/core/src/compile-lesson.ts` — Contains the compile smoke-gate validation and the `buildCompiledRule` function. This is where the superset check must be replaced and the dropping bug fixed.
+2. `packages/core/src/compile-lesson.test.ts` — Must be updated with fixtures proving the set equality gate works in both directions.
+3. `packages/cli/src/commands/compile-templates.ts` — (If prompt-based) To inspect if the compiler system prompt is actively omitting `!` prefixed strings.
+
+### Technical Approach & Contracts
+
+1. **Implement Set Equality Helper:** We need a deterministic `isGlobSetEqual(expected: string[], actual: string[]): boolean` helper that ignores array order and duplicate elements.
+2. **Update the Smoke-Gate Validation:** Locate the post-LLM validation phase in `compileLesson` or `buildCompiledRule`. It currently checks if the source-declared globs are a subset/superset of the compiled `fileGlobs`. Replace this with `isGlobSetEqual`.
+3. **Diagnose and Fix the Drop:**
+   - _If the drop is programmatic:_ Search `buildCompiledRule` for any `.filter()` or normalization logic stripping strings starting with `!`.
+   - _If the drop is LLM-induced:_ Do not rely purely on prompting. Instead, programmatically inject/merge the source's explicit exclusion globs (and the derived test inclusions from #1626) into `parsed.fileGlobs` before the equality check to guarantee architectural compliance.
+   - _Recommendation:_ Programmatic enforcement is strictly superior to prompt engineering. The pipeline should compute the `expectedGlobs` (Source Scope + Test Inclusions from #1626) and strictly overwrite or validate the LLM's `fileGlobs` against it.
+
+### Edge Cases & Traps
+
+- **Order Dependency Regression:** Glob arrays might be generated in different orders `['**/*.ts', '!**/*.spec.ts']` vs `['!**/*.spec.ts', '**/*.ts']`. The set-equality check MUST ignore order.
+- **Duplicate Globs:** `['**/*.ts', '**/*.ts']` must equal `['**/*.ts']`. Use `Set` internally.
+- **The #1626 Inverse Trap:** Issue #1626 _dynamically adds_ test globs based on the lesson payload. Your `expectedGlobs` calculation must account for these dynamic additions before performing the set-equality check against the final `fileGlobs`, otherwise legitimate test-contract rules will fail the strict gate.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Implement `isGlobSetEqual` Helper**
+  - Create a pure function `isGlobSetEqual(a: string[], b: string[])` in `packages/core/src/compile-lesson.ts` (or a dedicated util file if preferred).
+  - Convert both arrays to `Set`s. Return `false` if `Set.size` differs. Return `false` if any element in `Set A` is not in `Set B`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `isGlobSetEqual correctly identifies equivalent sets regardless of order and duplicates` in `compile-lesson.test.ts`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Upgrade Smoke-Gate to Strict Equality**
+  - Locate the validation step in `compileLesson` (or `buildCompiledRule`) that checks scope validity. It likely uses `.every()` or an `isSuperset` utility.
+  - Replace the permissive check with `isGlobSetEqual(derivedExpectedScope, compiledFileGlobs)`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `compile smoke-gate rejects output that drops exclusion globs` demonstrating that a missing `!**/*.test.*` glob now correctly throws a compile validation error.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Fix Exclusion Drop & Reconcile Dynamic Scope**
+  - Diagnose why exclusions drop. If the LLM omits them, ensure the pipeline's expected derived scope (which merges explicitly declared source exclusions + #1626 test inclusions) forcefully reconciles with `parsed.fileGlobs`.
+  - Ensure the pipeline explicitly assigns the correctly calculated explicit + derived globs to the final rule output so it passes the strict gate introduced in Task 2.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `compiles lesson with explicit test exclusions successfully` and `compiles test-contract lesson with auto-included test patterns successfully` (ensuring both directions of the #1626 / #1665 spec work flawlessly).
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+1. **The Dropped Exclusion Scenario (Issue #1665):** Compile a mocked lesson that specifies `Scope: ['**/*.ts', '!**/*.spec.ts']`. Verify the compiled rule's `fileGlobs` perfectly mirrors this array.
+2. **The Auto-Addition Scenario (Issue #1626):** Compile a mocked test-contract lesson (triggering the #1626 behavior). Verify the auto-added test globs exist in the output and the strict equality gate does _not_ throw a validation error.
+3. **Invalid Subset Rejection:** Mock LLM output that forgets an exclusion glob. Ensure the compilation throws the smoke-gate error and fails the build.
+
+## Implementation Design
+
+### Scope
+
+**Will:** Parse source `**Scope:**` from the lesson body programmatically (reusing `extractManualPattern`'s comma-split + filter-Boolean logic, exposed as a standalone helper). In `buildCompiledRule` (Pipeline 2/3), when the source declares Scope, use the source-derived list as authoritative `fileGlobs` and override the LLM's emission. Wire a `scopeOverride` marker on `BuildRuleResult` patterned after #1656's `severityOverride` so CLI telemetry records LLM divergence without blocking compile. Add an `isGlobSetEqual(a: string[], b: string[]): boolean` pure helper for set-of-strings comparison (used by the divergence detector, not as a gate).
+
+**Will NOT:** Flip compile to fail on divergence (too strict for incremental rollout — see Open Q1). Will NOT touch Pipeline 1 (`extractManualPattern` already handles Scope exclusions correctly). Will NOT re-architect #1626's test-contract classifier (orthogonal — that path applies when source omits Scope; this fix applies when source declares Scope). Will NOT change the compile-templates prompt in this PR.
+
+### Data model deltas
+
+| Item                                      | Type / shape                                                 | Holds                                     | Writer                       | Reader                               | Invariant                                                                                                                                                       |
+| ----------------------------------------- | ------------------------------------------------------------ | ----------------------------------------- | ---------------------------- | ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `parseDeclaredScope(body)`                | `(string) => string[] \| undefined`                          | Parsed source Scope: glob list            | —                            | `buildCompiledRule`                  | Returns `undefined` when no `**Scope:**` line OR empty value; returns non-empty `string[]` otherwise. Preserves order; preserves `!` exclusion entries verbatim |
+| `isGlobSetEqual(a, b)`                    | `(string[], string[]) => boolean`                            | Pure helper                               | —                            | `buildCompiledRule` divergence check | Set semantics: order-insensitive, duplicate-insensitive                                                                                                         |
+| `BuildRuleResult.scopeOverride?`          | `{ from: string[] \| undefined; to: string[] } \| undefined` | Telemetry marker                          | `buildCompiledRule`          | CLI telemetry callback               | Populated only when LLM emission differs from source-Scope set (mirrors `severityOverride` discipline from #1656)                                               |
+| `BuildCompiledRuleOptions.lessonBody?`    | `string \| undefined`                                        | Source lesson body for parseDeclaredScope | Caller (compile-lesson loop) | `buildCompiledRule`                  | Optional for backwards compat; when omitted, override path inactive                                                                                             |
+| `CompileLessonCallbacks.onScopeOverride?` | `(override) => void`                                         | Telemetry callback                        | —                            | CLI `writeScopeOverrideTelemetry`    | Mirrors `onSeverityOverride` shape from #1656                                                                                                                   |
+
+No new state containers. No reserved keys. `scopeOverride` marker fires only when override actually changed the outcome (skip-on-no-divergence parity with #1656).
+
+### State lifecycle
+
+- **`parseDeclaredScope` + `isGlobSetEqual`** — pure / stateless. No persistence.
+- **`scopeOverride` marker** — per-lesson-compile lifetime, bounded by `buildCompiledRule` return value. Caller observes; nothing accumulates.
+- **CLI telemetry append** — appends to `.totem/temp/telemetry.jsonl` with `type: 'scope-override'`, mirroring #1656's `type: 'severity-override'` pattern. Same write semantics, same path-redaction behavior.
+
+### Failure modes
+
+| Failure                                               | Category              | Agent-facing surface                                                                          | Recovery                                  |
+| ----------------------------------------------------- | --------------------- | --------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| Source `**Scope:**` malformed / empty value           | parse                 | Returns `undefined`; LLM emission used as-is (current behavior preserved)                     | Author fixes lesson; rerun compile        |
+| LLM emits `fileGlobs` that diverges from source-Scope | drift                 | Override applied + `scopeOverride` telemetry marker fires; final rule uses source-derived set | None needed — author's intent always wins |
+| Source has no `**Scope:**` line                       | n/a (legitimate path) | LLM emission used unchanged; #1626 test-contract auto-include path stays active               | n/a                                       |
+| `sanitizeFileGlobs` drops `'!'` alone                 | normalize             | Existing behavior — empty/whitespace entries filtered                                         | n/a                                       |
+| Caller forgets to pass `lessonBody` option            | runtime               | Override path inactive; LLM emission used (graceful degradation, current behavior)            | Caller wires `lessonBody`                 |
+
+No "silent degradation" rows. The override is the LOUD path — telemetry fires, marker visible to callers. The graceful-degradation case (caller forgets to wire `lessonBody`) preserves current behavior, not silently worse.
+
+### Invariants to lock in via tests
+
+- **`isGlobSetEqual` pure semantics:**
+  - Empty vs empty equal.
+  - `['a','b']` vs `['b','a']` equal (order-insensitive).
+  - `['a','a']` vs `['a']` equal (duplicate-insensitive).
+  - `['a']` vs `['a','b']` not equal.
+  - `['!**/*.test.*']` vs `['**/*.test.*']` not equal (sign matters; `!` is part of the string).
+- **`parseDeclaredScope` parser:**
+  - `**Scope:** A, B, !C` → `['A', 'B', '!C']` (preserves order + `!`).
+  - No `**Scope:**` line → `undefined`.
+  - `**Scope:**   ` (whitespace-only) → `undefined`.
+  - `**Scope:** A,,B` → `['A', 'B']` (filter Boolean drops empty entries).
+- **`buildCompiledRule` override behavior:**
+  - Source `[A, B, !C]` + LLM `[A, B]` → final `fileGlobs: [A, B, !C]`, marker `scopeOverride: { from: [A, B], to: [A, B, !C] }`.
+  - Source `[A, B, !C]` + LLM `[A, B, !C]` → final `fileGlobs: [A, B, !C]`, marker absent (no divergence).
+  - Source undefined + LLM `[A, B]` → final `fileGlobs: [A, B]`, marker absent (no override path).
+  - Source `[A]` + LLM undefined → final `fileGlobs: [A]`, marker `{ from: undefined, to: [A] }`.
+- **Pipeline 1 unaffected:** `extractManualPattern` regression test pins existing Scope-preservation behavior so the override path doesn't accidentally touch the manual flow.
+- **Telemetry callback fires once per override** with the correct `from`/`to` arrays. Path-redaction matches `severity-override` precedent.
+
+### Open questions
+
+1. **Question:** Override-and-log vs strict-fail on divergence?
+   - **Options:** (a) Override + telemetry — author intent always wins, no compile failures. (b) Strict equality gate — compile fails on divergence, forces LLM retry per spec recommendation.
+   - **Recommendation:** (a). The bug is "silent drop"; override fixes it deterministically. Strict-fail blocks legitimate edge cases (e.g., LLM legitimately omits an entry the author also forgot to declare and the gate would re-fire). Telemetry surfaces drift without breaking author flows. If telemetry shows persistent LLM drift after this lands, tighten to strict-fail in a follow-up.
+
+2. **Question:** `parseDeclaredScope` — new module or add to `lesson-pattern.ts`?
+   - **Options:** (a) Extract method into lesson-pattern.ts, export alongside `extractManualPattern`. (b) New module `packages/core/src/scope-derivation.ts`.
+   - **Recommendation:** (a). lesson-pattern.ts already owns the Scope-parsing logic inside `extractManualPattern`; pulling the comma-split + filter into a standalone helper is a refactor that also unblocks Pipeline 2/3. New module is premature.
+
+3. **Question:** Naming — `parseDeclaredScope` vs `parseSourceScope` vs `extractScopeGlobs`?
+   - **Options:** parseDeclaredScope (parity with #1656's parseDeclaredSeverity), parseSourceScope (descriptive), extractScopeGlobs (matches existing `extract*` family).
+   - **Recommendation:** `parseDeclaredScope`. Direct parity with `parseDeclaredSeverity` from #1656 + matching semantics ("the author's declaration in prose, parsed deterministically").
+
+4. **Question:** Should `scopeOverride` mirror `severityOverride`'s telemetry shape exactly, or use a different schema?
+   - **Options:** (a) Mirror — same `{ from, to }` shape, same callback discipline, same telemetry file. (b) Bespoke — perhaps include source-line info or rejection-reason category.
+   - **Recommendation:** (a). Mirror reduces cognitive load, reuses tested telemetry plumbing, lets future analysis treat both override classes uniformly. Add bespoke fields only if a concrete use case emerges.
+
+### Follow-up tickets to file at acceptance
+
+- **Compile-prompt Scope guidance refinement** — once telemetry shows the divergence rate, tighten the prompt instructions on `compile-templates.ts` to honor source `**Scope:**` more reliably. Tier-3.
+- **Strict-fail compile gate** (if telemetry indicates the override is masking authoring problems rather than LLM drift). Tier-3, dependent on telemetry data.
+- **Pipeline 1 audit** — verify no existing Pipeline 1 lesson silently drops exclusions during the manual flow (sanity check). Tier-3.

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -506,6 +506,51 @@ export async function compileCommand(
     }
   };
 
+  // mmnto-ai/totem#1665: scope-override telemetry, mirroring the
+  // severity-override helper above. Records lessons where author-declared
+  // **Scope:** in the lesson body diverged from the LLM's emitted fileGlobs.
+  // Frequent fires mean the LLM is dropping or hallucinating Scope entries
+  // and the prompt directive needs sharpening.
+  const writeScopeOverrideTelemetry = (
+    lesson: { heading: string; hash: string },
+    event: { from: string[] | undefined; to: string[] },
+  ): void => {
+    // totem-context: intentional cleanup — telemetry sink failures (disk full,
+    // permissions, concurrent writer) must not block compile correctness.
+    // Mirrors writeSeverityOverrideTelemetry's posture (mmnto-ai/totem#1656).
+    try {
+      const tempDir = path.join(totemDir, 'temp');
+      fs.mkdirSync(tempDir, { recursive: true });
+      const entry = {
+        type: 'scope-override' as const,
+        timestamp: new Date().toISOString(),
+        lessonHash: lesson.hash,
+        lessonHeading: lesson.heading,
+        from: event.from,
+        to: event.to,
+      };
+      fs.appendFileSync(
+        path.join(tempDir, 'telemetry.jsonl'),
+        JSON.stringify(entry) + '\n',
+        'utf-8',
+      );
+    } catch (err) {
+      log.warn(
+        TAG,
+        `Failed to write scope-override telemetry: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      // Best-effort sink: swallow expected IO failures (disk full, permissions,
+      // concurrent writer races) so telemetry never blocks compile. Unexpected
+      // errors propagate per Tenet 4 — silently swallowing TypeErrors or
+      // assertion failures would mask real bugs in the telemetry shape.
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      const expectedIoCodes = new Set(['ENOENT', 'EACCES', 'EPERM', 'ENOSPC', 'EBUSY', 'EROFS']);
+      if (!(err instanceof Error) || !code || !expectedIoCodes.has(code)) {
+        throw err;
+      }
+    }
+  };
+
   // ─── --refresh-manifest primitive (mmnto-ai/totem#1587) ─────────
   // No-LLM path that recomputes `output_hash` from current
   // `compiled-rules.json` state. Supports the postmerge inline-archive
@@ -1001,6 +1046,10 @@ export async function compileCommand(
           // other telemetry artifacts when compile runs from a sub-directory.
           // Best-effort — sink failures do not interfere with compile results.
           onSeverityOverride: writeSeverityOverrideTelemetry,
+          // mmnto-ai/totem#1665: append scope-override telemetry when the
+          // source-Scope override changes the emitted fileGlobs. Same
+          // best-effort discipline as severity above.
+          onScopeOverride: writeScopeOverrideTelemetry,
         },
       };
 
@@ -1162,14 +1211,23 @@ export async function compileCommand(
             // over the LLM's emission. Post-LLM override is deterministic;
             // the prompt directive reduces the frequency of mismatch but
             // the override guarantees correctness on the cloud path too.
+            // mmnto-ai/totem#1665: same posture for source-declared Scope —
+            // author intent overrides LLM emission on the cloud path too.
             const declaredSeverity = parseDeclaredSeverity(lesson.body);
             const ruleResult = buildCompiledRule(parsed, lesson, existingByHash, {
               declaredSeverityOverride: declaredSeverity,
+              lessonBody: lesson.body,
             });
             if (ruleResult.severityOverride) {
               writeSeverityOverrideTelemetry(
                 { heading: lesson.heading, hash: lesson.hash },
                 ruleResult.severityOverride,
+              );
+            }
+            if (ruleResult.scopeOverride) {
+              writeScopeOverrideTelemetry(
+                { heading: lesson.heading, hash: lesson.hash },
+                ruleResult.scopeOverride,
               );
             }
             if (ruleResult.rule) {

--- a/packages/core/src/compile-lesson.test.ts
+++ b/packages/core/src/compile-lesson.test.ts
@@ -511,6 +511,24 @@ describe('buildCompiledRule', () => {
     expect(result.rule!.fileGlobs).toEqual(['**/*.ts']);
     expect(result.scopeOverride).toBeUndefined();
   });
+
+  it('expands brace groups via sanitizeFileGlobs on the source-Scope path (CR PR #1674)', () => {
+    // Author writes brace-expansion form; parseDeclaredScope keeps it as a
+    // single token (top-level-only comma split) so sanitizeFileGlobs can
+    // expand it downstream. LLM emits the expanded form. After sanitization
+    // both reduce to identical sets, so no override fires.
+    const parsed: CompilerOutput = {
+      compilable: true,
+      pattern: 'test',
+      message: 'test',
+      engine: 'regex',
+      fileGlobs: ['**/*.ts', '**/*.tsx'],
+    };
+    const lessonBody = '**Scope:** **/*.{ts,tsx}';
+    const result = buildCompiledRule(parsed, lesson, existingByHash, { lessonBody });
+    expect(result.rule!.fileGlobs).toEqual(['**/*.ts', '**/*.tsx']);
+    expect(result.scopeOverride).toBeUndefined();
+  });
 });
 
 // ─── self-suppression guard (#1177) ────────────────

--- a/packages/core/src/compile-lesson.test.ts
+++ b/packages/core/src/compile-lesson.test.ts
@@ -352,6 +352,165 @@ describe('buildCompiledRule', () => {
     expect(result.rejectReason).toContain('Rejected regex');
     expect(result.severityOverride).toBeUndefined();
   });
+
+  // ─── scopeOverride (mmnto-ai/totem#1665) ──────────
+
+  it('overrides LLM-dropped exclusions when source declares Scope', () => {
+    // The exhibit case: lesson source declares test-exclusions but the LLM
+    // emits a stripped fileGlobs. Author intent always wins.
+    const parsed: CompilerOutput = {
+      compilable: true,
+      pattern: 'test',
+      message: 'test',
+      engine: 'regex',
+      fileGlobs: ['packages/zomboid-sim/src/**/*.rs'],
+    };
+    const lessonBody = '**Scope:** packages/zomboid-sim/src/**/*.rs, !**/*.test.*, !**/*.spec.*';
+    const result = buildCompiledRule(parsed, lesson, existingByHash, { lessonBody });
+    expect(result.rule!.fileGlobs).toEqual([
+      'packages/zomboid-sim/src/**/*.rs',
+      '!**/*.test.*',
+      '!**/*.spec.*',
+    ]);
+    expect(result.scopeOverride).toEqual({
+      from: ['packages/zomboid-sim/src/**/*.rs'],
+      to: ['packages/zomboid-sim/src/**/*.rs', '!**/*.test.*', '!**/*.spec.*'],
+    });
+  });
+
+  it('overrides LLM-hallucinated additions when source declares a different Scope', () => {
+    // Inverse direction: LLM auto-includes test patterns the author did not declare.
+    // #1626's auto-include heuristic is not honored when source declares Scope —
+    // author intent wins over heuristic.
+    const parsed: CompilerOutput = {
+      compilable: true,
+      pattern: 'test',
+      message: 'test',
+      engine: 'regex',
+      fileGlobs: ['packages/api/**/*.ts', '**/*.test.*', '**/*.spec.*'],
+    };
+    const lessonBody = '**Scope:** packages/api/**/*.ts';
+    const result = buildCompiledRule(parsed, lesson, existingByHash, { lessonBody });
+    expect(result.rule!.fileGlobs).toEqual(['packages/api/**/*.ts']);
+    expect(result.scopeOverride).toEqual({
+      from: ['packages/api/**/*.ts', '**/*.test.*', '**/*.spec.*'],
+      to: ['packages/api/**/*.ts'],
+    });
+  });
+
+  it('omits scopeOverride marker when LLM emission already matches source-Scope', () => {
+    const parsed: CompilerOutput = {
+      compilable: true,
+      pattern: 'test',
+      message: 'test',
+      engine: 'regex',
+      fileGlobs: ['packages/api/**/*.ts', '!**/*.test.*'],
+    };
+    const lessonBody = '**Scope:** packages/api/**/*.ts, !**/*.test.*';
+    const result = buildCompiledRule(parsed, lesson, existingByHash, { lessonBody });
+    expect(result.rule!.fileGlobs).toEqual(['packages/api/**/*.ts', '!**/*.test.*']);
+    expect(result.scopeOverride).toBeUndefined();
+  });
+
+  it('omits scopeOverride marker when set-equal but order differs', () => {
+    // Order-insensitive set equality: same entries different order = no override.
+    const parsed: CompilerOutput = {
+      compilable: true,
+      pattern: 'test',
+      message: 'test',
+      engine: 'regex',
+      fileGlobs: ['!**/*.test.*', 'packages/api/**/*.ts'],
+    };
+    const lessonBody = '**Scope:** packages/api/**/*.ts, !**/*.test.*';
+    const result = buildCompiledRule(parsed, lesson, existingByHash, { lessonBody });
+    expect(result.scopeOverride).toBeUndefined();
+  });
+
+  it('does not override when source omits Scope (preserves LLM emission, no marker)', () => {
+    // Backward-compat path: lessons without **Scope:** keep the LLM emission
+    // exactly as-is (including any #1626 test-contract auto-include).
+    const parsed: CompilerOutput = {
+      compilable: true,
+      pattern: 'test',
+      message: 'test',
+      engine: 'regex',
+      fileGlobs: ['**/*.test.*', '**/*.spec.*'],
+    };
+    const lessonBody = 'A test-contract lesson body with no Scope line.';
+    const result = buildCompiledRule(parsed, lesson, existingByHash, { lessonBody });
+    expect(result.rule!.fileGlobs).toEqual(['**/*.test.*', '**/*.spec.*']);
+    expect(result.scopeOverride).toBeUndefined();
+  });
+
+  it('does not override when lessonBody option is omitted (current-behavior preservation)', () => {
+    // Caller that does not opt into the override path (e.g., ad-hoc test
+    // harnesses) gets exactly today's behavior — no parsing, no marker.
+    const parsed: CompilerOutput = {
+      compilable: true,
+      pattern: 'test',
+      message: 'test',
+      engine: 'regex',
+      fileGlobs: ['**/*.ts'],
+    };
+    const result = buildCompiledRule(parsed, lesson, existingByHash);
+    expect(result.rule!.fileGlobs).toEqual(['**/*.ts']);
+    expect(result.scopeOverride).toBeUndefined();
+  });
+
+  it('overrides when source declares Scope but LLM emits nothing', () => {
+    const parsed: CompilerOutput = {
+      compilable: true,
+      pattern: 'test',
+      message: 'test',
+      engine: 'regex',
+      // fileGlobs deliberately undefined
+    };
+    const lessonBody = '**Scope:** packages/core/**/*.ts';
+    const result = buildCompiledRule(parsed, lesson, existingByHash, { lessonBody });
+    expect(result.rule!.fileGlobs).toEqual(['packages/core/**/*.ts']);
+    expect(result.scopeOverride).toEqual({
+      from: undefined,
+      to: ['packages/core/**/*.ts'],
+    });
+  });
+
+  it('preserves scopeOverride on rejection paths too', () => {
+    // Mirrors the severityOverride rejection-path test. If the LLM drifts on
+    // Scope AND emits an invalid pattern, the rejection still surfaces the
+    // marker so telemetry captures exactly the prompt-drift cases.
+    const parsed: CompilerOutput = {
+      compilable: true,
+      pattern: '(unclosed',
+      message: 'test',
+      engine: 'regex',
+      fileGlobs: ['**/*.ts'],
+    };
+    const lessonBody = '**Scope:** packages/core/**/*.ts, !**/*.test.*';
+    const result = buildCompiledRule(parsed, lesson, existingByHash, { lessonBody });
+    expect(result.rule).toBeNull();
+    expect(result.rejectReason).toContain('Rejected regex');
+    expect(result.scopeOverride).toEqual({
+      from: ['**/*.ts'],
+      to: ['packages/core/**/*.ts', '!**/*.test.*'],
+    });
+  });
+
+  it('normalizes shallow globs through sanitizeFileGlobs on the source-Scope path', () => {
+    // sanitizeFileGlobs converts shallow `*.ts` to recursive `**/*.ts`. Both
+    // source-derived and LLM-emitted lists pass through it, so an authored
+    // `*.ts` matches an LLM-emitted `**/*.ts` and no override fires.
+    const parsed: CompilerOutput = {
+      compilable: true,
+      pattern: 'test',
+      message: 'test',
+      engine: 'regex',
+      fileGlobs: ['**/*.ts'],
+    };
+    const lessonBody = '**Scope:** *.ts';
+    const result = buildCompiledRule(parsed, lesson, existingByHash, { lessonBody });
+    expect(result.rule!.fileGlobs).toEqual(['**/*.ts']);
+    expect(result.scopeOverride).toBeUndefined();
+  });
 });
 
 // ─── self-suppression guard (#1177) ────────────────

--- a/packages/core/src/compile-lesson.ts
+++ b/packages/core/src/compile-lesson.ts
@@ -14,6 +14,8 @@ import {
   extractBadGoodSnippets,
   extractManualPattern,
   extractRuleExamples,
+  isGlobSetEqual,
+  parseDeclaredScope,
   parseDeclaredSeverity,
 } from './lesson-pattern.js';
 import type { RuleTestResult } from './rule-tester.js';
@@ -102,6 +104,18 @@ export interface CompileLessonCallbacks {
   onSeverityOverride?: (
     lesson: { heading: string; hash: string },
     event: { from: 'error' | 'warning' | undefined; to: 'error' | 'warning' },
+  ) => void;
+  /**
+   * Fires when the declared-scope override (mmnto-ai/totem#1665) actually
+   * changed the emitted `fileGlobs`. CLI callers use this to write telemetry
+   * records tagged `type: 'scope-override'` for prompt-tuning feedback —
+   * frequent fires mean the LLM is drifting on Scope preservation. Absent =
+   * core runs without telemetry plumbing. Mirrors `onSeverityOverride`
+   * shape and discipline from #1656.
+   */
+  onScopeOverride?: (
+    lesson: { heading: string; hash: string },
+    event: { from: string[] | undefined; to: string[] },
   ) => void;
 }
 
@@ -351,6 +365,18 @@ export interface BuildCompiledRuleOptions {
    * callers can record telemetry for prompt-tuning feedback.
    */
   declaredSeverityOverride?: 'error' | 'warning';
+  /**
+   * Optional lesson body for declared-scope override (mmnto-ai/totem#1665).
+   * When supplied AND the body declares a `**Scope:**` line, the parsed
+   * source-Scope glob list takes precedence over `parsed.fileGlobs`
+   * regardless of LLM emission. Author-declared intent always wins; #1626's
+   * test-contract auto-include heuristic only applies when source omits Scope.
+   * `buildCompiledRule` reports the override event in
+   * `BuildRuleResult.scopeOverride` when the override actually changes the
+   * emitted globs, so CLI callers can record telemetry for prompt-tuning
+   * feedback (mirrors `declaredSeverityOverride` from #1656).
+   */
+  lessonBody?: string;
 }
 
 /**
@@ -413,21 +439,42 @@ export function buildCompiledRule(
       ? { from: emittedSeverity, to: declaredSeverity }
       : undefined;
 
-  // Thread `severityOverride` through rejection paths too (mmnto-ai/totem
-  // #1658 CR round-3 finding). If the LLM drifts on severity AND emits an
-  // invalid/missing pattern, the telemetry signal still fires — the
-  // rejection captures exactly the prompt-drift cases this signal is
-  // meant to detect, and dropping the marker on those paths would
-  // undercount drift measurement.
-  const reject = (rejectReason: string): BuildRuleResult =>
-    severityOverride
-      ? { rule: null, rejectReason, severityOverride }
-      : { rule: null, rejectReason };
+  // mmnto-ai/totem#1665: declared scope (parsed from the lesson body's
+  // `**Scope:**` prose convention) wins over the LLM's emission. Author
+  // intent is supreme; #1626's test-contract auto-include heuristic only
+  // applies when source omits Scope. The `scopeOverride` marker fires only
+  // when the override actually changed the outcome (mirrors `severityOverride`
+  // discipline from #1656).
+  //
+  // Both source-declared and LLM-emitted lists pass through `sanitizeFileGlobs`
+  // for parity (brace expansion, shallow → recursive normalization). Set-of-
+  // strings equality uses the post-sanitization values so an authored
+  // `**/*.{ts,js}` matches an LLM-emitted `['**/*.ts', '**/*.js']`.
+  const llmGlobsSanitized = parsed.fileGlobs ? sanitizeFileGlobs(parsed.fileGlobs) : undefined;
+  const declaredScope = options.lessonBody ? parseDeclaredScope(options.lessonBody) : undefined;
+  const declaredScopeSanitized = declaredScope ? sanitizeFileGlobs(declaredScope) : undefined;
+
+  const sanitizedGlobs = declaredScopeSanitized ?? llmGlobsSanitized;
+  const scopeOverride =
+    declaredScopeSanitized !== undefined &&
+    !isGlobSetEqual(declaredScopeSanitized, llmGlobsSanitized ?? [])
+      ? { from: llmGlobsSanitized, to: declaredScopeSanitized }
+      : undefined;
+
+  // Thread overrides through rejection paths too (mmnto-ai/totem#1658 CR
+  // round-3 finding). If the LLM drifts AND emits an invalid/missing
+  // pattern, the telemetry signal still fires — the rejection captures
+  // exactly the prompt-drift cases this signal is meant to detect.
+  const reject = (rejectReason: string): BuildRuleResult => {
+    const result: BuildRuleResult = { rule: null, rejectReason };
+    if (severityOverride) result.severityOverride = severityOverride;
+    if (scopeOverride) result.scopeOverride = scopeOverride;
+    return result;
+  };
 
   const engine = parsed.engine ?? 'regex';
   const now = new Date().toISOString();
   const existing = existingByHash.get(lesson.hash);
-  const sanitizedGlobs = parsed.fileGlobs ? sanitizeFileGlobs(parsed.fileGlobs) : undefined;
   const globsObj = sanitizedGlobs && sanitizedGlobs.length > 0 ? { fileGlobs: sanitizedGlobs } : {};
   // mmnto/totem#1408: the effective badExample is the override when present,
   // else whatever the LLM echoed back in CompilerOutput. Pipeline 1 and ad-hoc
@@ -597,7 +644,10 @@ export function buildCompiledRule(
     }
   }
 
-  return severityOverride ? { rule: candidate, severityOverride } : { rule: candidate };
+  const result: BuildRuleResult = { rule: candidate };
+  if (severityOverride) result.severityOverride = severityOverride;
+  if (scopeOverride) result.scopeOverride = scopeOverride;
+  return result;
 }
 
 // ─── Manual pattern builder ─────────────────────────
@@ -613,6 +663,15 @@ export interface BuildRuleResult {
    * the prompt directive is drifting and the LLM needs a stronger signal.
    */
   severityOverride?: { from: 'error' | 'warning' | undefined; to: 'error' | 'warning' };
+  /**
+   * Populated when source-declared `**Scope:**` actually changed the emitted
+   * `fileGlobs` (mmnto-ai/totem#1665). Absent when no `lessonBody` was
+   * supplied, when the body declared no Scope, or when the LLM emission
+   * already matched the source declaration. CLI callers use this as a
+   * telemetry signal for prompt-tuning feedback — frequent overrides mean
+   * the LLM is dropping or hallucinating Scope entries.
+   */
+  scopeOverride?: { from: string[] | undefined; to: string[] };
 }
 
 /**
@@ -967,6 +1026,7 @@ export async function compileLesson(
     const ruleResult = buildCompiledRule(parsed, lesson, existingByHash, {
       enforceSmokeGate: true,
       declaredSeverityOverride: declaredSeverity,
+      lessonBody: lesson.body,
       // Guard empty snippet arrays so they don't clobber parsed.badExample
       // or parsed.goodExample via ?? in buildCompiledRule. `[].join('\n')`
       // is the empty string, which is defined and would win over the LLM's
@@ -979,6 +1039,15 @@ export async function compileLesson(
       callbacks?.onSeverityOverride?.(
         { heading: lesson.heading, hash: lesson.hash },
         ruleResult.severityOverride,
+      );
+    }
+    if (ruleResult.scopeOverride) {
+      // totem-context: telemetry-only callback (mmnto-ai/totem#1665). Silent
+      // when omitted is the intended contract — drift telemetry is observability,
+      // not correctness. The override itself already applied in buildCompiledRule.
+      callbacks?.onScopeOverride?.(
+        { heading: lesson.heading, hash: lesson.hash },
+        ruleResult.scopeOverride,
       );
     }
     if (!ruleResult.rule) {
@@ -1144,11 +1213,21 @@ export async function compileLesson(
     const ruleResult = buildCompiledRule(parsed, lesson, existingByHash, {
       enforceSmokeGate: true,
       declaredSeverityOverride: declaredSeverity,
+      lessonBody: lesson.body,
     });
     if (ruleResult.severityOverride) {
       callbacks?.onSeverityOverride?.(
         { heading: lesson.heading, hash: lesson.hash },
         ruleResult.severityOverride,
+      );
+    }
+    if (ruleResult.scopeOverride) {
+      // totem-context: telemetry-only callback (mmnto-ai/totem#1665). Silent
+      // when omitted is the intended contract — drift telemetry is observability,
+      // not correctness. The override itself already applied in buildCompiledRule.
+      callbacks?.onScopeOverride?.(
+        { heading: lesson.heading, hash: lesson.hash },
+        ruleResult.scopeOverride,
       );
     }
 

--- a/packages/core/src/lesson-pattern.test.ts
+++ b/packages/core/src/lesson-pattern.test.ts
@@ -1044,6 +1044,39 @@ describe('parseDeclaredScope', () => {
     expect(manual?.fileGlobs).toEqual(parseDeclaredScope(body));
     expect(manual?.fileGlobs).toEqual(['packages/core/**/*.ts', '!**/*.test.*']);
   });
+
+  it('preserves commas inside brace groups (CR PR #1674 finding)', () => {
+    // `**/*.{ts,tsx}` is a single glob token — a naive comma-split would
+    // shatter it into '**/*.{ts' and 'tsx}'. Top-level-only splitting
+    // keeps the brace expression intact for sanitizeFileGlobs to expand
+    // downstream. Pre-fix, both Pipeline 1 (extractManualPattern) and
+    // Pipeline 2/3 (parseDeclaredScope override) silently mis-scoped these.
+    expect(parseDeclaredScope('**Scope:** **/*.{ts,tsx}')).toEqual(['**/*.{ts,tsx}']);
+  });
+
+  it('handles nested brace groups', () => {
+    // `!**/*.{test,spec}.{ts,tsx}` has two brace groups — both must stay
+    // intact in the single glob token.
+    expect(parseDeclaredScope('**Scope:** !**/*.{test,spec}.{ts,tsx}')).toEqual([
+      '!**/*.{test,spec}.{ts,tsx}',
+    ]);
+  });
+
+  it('still splits top-level commas alongside brace groups', () => {
+    // Mixed case: brace-expanded entry + comma-separated additional entries.
+    expect(parseDeclaredScope('**Scope:** **/*.{ts,tsx}, !**/*.test.*, !**/*.spec.*')).toEqual([
+      '**/*.{ts,tsx}',
+      '!**/*.test.*',
+      '!**/*.spec.*',
+    ]);
+  });
+
+  it('handles unbalanced closing brace defensively', () => {
+    // Authoring slip: extra `}` without an opening `{`. Should not crash;
+    // braceDepth saturates at 0 so a top-level comma after the rogue `}`
+    // still splits.
+    expect(parseDeclaredScope('**Scope:** foo}, bar')).toEqual(['foo}', 'bar']);
+  });
 });
 
 // ─── isGlobSetEqual (mmnto-ai/totem#1665) ──────────

--- a/packages/core/src/lesson-pattern.test.ts
+++ b/packages/core/src/lesson-pattern.test.ts
@@ -9,6 +9,8 @@ import {
   extractMultilineField,
   extractRuleExamples,
   extractYamlRuleAfterField,
+  isGlobSetEqual,
+  parseDeclaredScope,
   parseDeclaredSeverity,
   stripInlineCode,
 } from './lesson-pattern.js';
@@ -982,5 +984,111 @@ describe('parseDeclaredSeverity', () => {
       '**Severity:** warning',
     ].join('\n');
     expect(parseDeclaredSeverity(body)).toBe('error');
+  });
+});
+
+// ─── parseDeclaredScope (mmnto-ai/totem#1665) ──────────
+
+describe('parseDeclaredScope', () => {
+  it('parses a comma-separated Scope: declaration', () => {
+    expect(parseDeclaredScope('**Scope:** packages/core/**/*.ts')).toEqual([
+      'packages/core/**/*.ts',
+    ]);
+  });
+
+  it('preserves leading-! exclusion entries verbatim', () => {
+    expect(
+      parseDeclaredScope('**Scope:** packages/zomboid-sim/src/**/*.rs, !**/*.test.*, !**/*.spec.*'),
+    ).toEqual(['packages/zomboid-sim/src/**/*.rs', '!**/*.test.*', '!**/*.spec.*']);
+  });
+
+  it('preserves authored order', () => {
+    expect(parseDeclaredScope('**Scope:** !**/*.test.*, packages/core/**/*.ts')).toEqual([
+      '!**/*.test.*',
+      'packages/core/**/*.ts',
+    ]);
+  });
+
+  it('returns undefined when Scope: is missing', () => {
+    expect(parseDeclaredScope('Just a body with no Scope line.')).toBeUndefined();
+  });
+
+  it('returns undefined when Scope: value is empty', () => {
+    expect(parseDeclaredScope('**Scope:**')).toBeUndefined();
+  });
+
+  it('returns undefined when Scope: value is whitespace-only', () => {
+    expect(parseDeclaredScope('**Scope:**   ')).toBeUndefined();
+  });
+
+  it('filters empty entries from accidental double-commas', () => {
+    expect(parseDeclaredScope('**Scope:** A,,B,  ,C')).toEqual(['A', 'B', 'C']);
+  });
+
+  it('returns undefined when the entire value collapses to empty after split + filter', () => {
+    expect(parseDeclaredScope('**Scope:** ,,,')).toBeUndefined();
+  });
+
+  it('matches the same logic extractManualPattern uses (Pipeline 1 regression pin)', () => {
+    // After mmnto-ai/totem#1665, extractManualPattern delegates Scope parsing
+    // to parseDeclaredScope. This test pins that the manual-pattern path
+    // produces identical fileGlobs to a direct parseDeclaredScope call so
+    // the refactor doesn't drift the two surfaces.
+    const body = [
+      '**Pattern:** \\beval\\(',
+      '**Engine:** regex',
+      '**Scope:** packages/core/**/*.ts, !**/*.test.*',
+      '**Severity:** error',
+    ].join('\n');
+    const manual = extractManualPattern(body);
+    expect(manual?.fileGlobs).toEqual(parseDeclaredScope(body));
+    expect(manual?.fileGlobs).toEqual(['packages/core/**/*.ts', '!**/*.test.*']);
+  });
+});
+
+// ─── isGlobSetEqual (mmnto-ai/totem#1665) ──────────
+
+describe('isGlobSetEqual', () => {
+  it('returns true for two empty arrays', () => {
+    expect(isGlobSetEqual([], [])).toBe(true);
+  });
+
+  it('returns true for identical arrays', () => {
+    expect(isGlobSetEqual(['a', 'b'], ['a', 'b'])).toBe(true);
+  });
+
+  it('is order-insensitive', () => {
+    expect(isGlobSetEqual(['a', 'b'], ['b', 'a'])).toBe(true);
+  });
+
+  it('is duplicate-insensitive (set semantics)', () => {
+    expect(isGlobSetEqual(['a', 'a'], ['a'])).toBe(true);
+  });
+
+  it('returns false when sizes differ after dedup', () => {
+    expect(isGlobSetEqual(['a'], ['a', 'b'])).toBe(false);
+  });
+
+  it("treats '!' prefix as part of the string (sign matters)", () => {
+    expect(isGlobSetEqual(['!**/*.test.*'], ['**/*.test.*'])).toBe(false);
+  });
+
+  it('returns false when one side has an entry the other lacks', () => {
+    expect(isGlobSetEqual(['a', 'b', '!c'], ['a', 'b'])).toBe(false);
+  });
+
+  it('returns true on referential equality fast-path', () => {
+    const arr = ['a', 'b'];
+    expect(isGlobSetEqual(arr, arr)).toBe(true);
+  });
+
+  it('does not mutate inputs', () => {
+    const a = ['x', 'y'];
+    const b = ['y', 'x'];
+    const snapshotA = a.slice();
+    const snapshotB = b.slice();
+    isGlobSetEqual(a, b);
+    expect(a).toEqual(snapshotA);
+    expect(b).toEqual(snapshotB);
   });
 });

--- a/packages/core/src/lesson-pattern.ts
+++ b/packages/core/src/lesson-pattern.ts
@@ -322,19 +322,36 @@ export function extractYamlRuleAfterField(
 /**
  * Parse the lesson body's `**Scope:**` prose declaration into a glob list.
  *
- * Returns `undefined` when the field is absent OR the value is empty / whitespace-only.
- * Returns a non-empty `string[]` otherwise. Order is preserved as authored;
- * `!`-prefixed exclusion entries are kept verbatim. Used by both Pipeline 1
- * (`extractManualPattern`) and Pipeline 2/3 (`buildCompiledRule` override path
- * for mmnto-ai/totem#1665).
+ * Splits on TOP-LEVEL commas only — commas nested inside `{...}` brace groups
+ * are preserved as part of a single glob token, so brace-expanded patterns
+ * like `**\/*.{ts,tsx}` and `!**\/*.{test,spec}.{ts,tsx}` survive intact for
+ * `sanitizeFileGlobs` to expand downstream. Returns `undefined` when the field
+ * is absent OR the value is empty / whitespace-only. Returns a non-empty
+ * `string[]` otherwise; order is preserved as authored, `!`-prefixed
+ * exclusion entries are kept verbatim.
+ *
+ * Used by both Pipeline 1 (`extractManualPattern`) and Pipeline 2/3
+ * (`buildCompiledRule` override path for mmnto-ai/totem#1665).
  */
 export function parseDeclaredScope(body: string): string[] | undefined {
   const scopeRaw = extractField(body, 'Scope');
   if (!scopeRaw) return undefined;
-  const globs = scopeRaw
-    .split(',')
-    .map((g) => g.trim())
-    .filter(Boolean);
+  const globs: string[] = [];
+  let current = '';
+  let braceDepth = 0;
+  for (const ch of scopeRaw) {
+    if (ch === '{') braceDepth++;
+    else if (ch === '}') braceDepth = Math.max(0, braceDepth - 1);
+    if (ch === ',' && braceDepth === 0) {
+      const value = current.trim();
+      if (value) globs.push(value);
+      current = '';
+      continue;
+    }
+    current += ch;
+  }
+  const tail = current.trim();
+  if (tail) globs.push(tail);
   return globs.length > 0 ? globs : undefined;
 }
 

--- a/packages/core/src/lesson-pattern.ts
+++ b/packages/core/src/lesson-pattern.ts
@@ -320,6 +320,42 @@ export function extractYamlRuleAfterField(
 }
 
 /**
+ * Parse the lesson body's `**Scope:**` prose declaration into a glob list.
+ *
+ * Returns `undefined` when the field is absent OR the value is empty / whitespace-only.
+ * Returns a non-empty `string[]` otherwise. Order is preserved as authored;
+ * `!`-prefixed exclusion entries are kept verbatim. Used by both Pipeline 1
+ * (`extractManualPattern`) and Pipeline 2/3 (`buildCompiledRule` override path
+ * for mmnto-ai/totem#1665).
+ */
+export function parseDeclaredScope(body: string): string[] | undefined {
+  const scopeRaw = extractField(body, 'Scope');
+  if (!scopeRaw) return undefined;
+  const globs = scopeRaw
+    .split(',')
+    .map((g) => g.trim())
+    .filter(Boolean);
+  return globs.length > 0 ? globs : undefined;
+}
+
+/**
+ * Set-of-strings equality on glob arrays. Order-insensitive,
+ * duplicate-insensitive. Sign characters (`!` exclusion prefix) are part of
+ * the string and matter for equality — `'!**\/*.test.*'` does not equal
+ * `'**\/*.test.*'`. Used by mmnto-ai/totem#1665 divergence detection.
+ */
+export function isGlobSetEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a === b) return true;
+  const setA = new Set(a);
+  const setB = new Set(b);
+  if (setA.size !== setB.size) return false;
+  for (const entry of setA) {
+    if (!setB.has(entry)) return false;
+  }
+  return true;
+}
+
+/**
  * Try to extract manual pattern fields from a lesson body.
  * Returns null if the lesson doesn't contain a Pattern: field.
  */
@@ -328,13 +364,7 @@ export function extractManualPattern(body: string): ManualPattern | null {
   const engine: ManualPattern['engine'] =
     engineRaw === 'ast' ? 'ast' : engineRaw === 'ast-grep' ? 'ast-grep' : 'regex';
 
-  const scopeRaw = extractField(body, 'Scope');
-  const fileGlobs = scopeRaw
-    ? scopeRaw
-        .split(',')
-        .map((g) => g.trim())
-        .filter(Boolean)
-    : undefined;
+  const fileGlobs = parseDeclaredScope(body);
 
   const severityRaw = extractField(body, 'Severity')?.toLowerCase();
   const severity: ManualPattern['severity'] = severityRaw === 'error' ? 'error' : 'warning';


### PR DESCRIPTION
## Summary

Strategy item 023 substrate. Inverse of #1626 (auto-ADD): the compile worker silently DROPPED test/spec exclusion globs (`!**/*.test.*`, `!**/*.spec.*`) that lessons declared in their `**Scope:**` line. Confirmed twice on `mmnto-ai/liquid-city#80` for rules `5bcc8aad9096c817` (SystemParam) and `6c457c82d3945d15` (init_resource), where the source lesson `Scope:` line carried `packages/zomboid-sim/src/**/*.rs, !**/*.test.*, !**/*.spec.*` but compile output emitted only the positive glob.

This PR shifts the compile pipeline failure mode from "silent drop" to "deterministic override + telemetry on divergence." Author intent (declared `**Scope:**`) becomes supreme over LLM emission AND over #1626's test-contract auto-include heuristic. The auto-include path stays active only when the lesson omits Scope.

## Changes

- **`parseDeclaredScope(body)` helper** in `@mmnto/totem`. Parses `**Scope:**` prose declaration into a `string[]` glob list. Preserves `!`-prefixed exclusion entries verbatim and authored order. Returns `undefined` for missing / empty / whitespace-only declarations.
- **`isGlobSetEqual(a, b)` pure helper.** Order-insensitive, duplicate-insensitive set-of-strings comparison. Sign-sensitive (`'!**/*.test.*'` does NOT equal `'**/*.test.*'`).
- **Pipeline 1 refactor.** `extractManualPattern` now delegates Scope parsing to `parseDeclaredScope` so manual lessons share a single source of truth with Pipeline 2/3. Regression test pins behavior unchanged.
- **`BuildCompiledRuleOptions.lessonBody?: string`** opts callers into the override path. When supplied AND the body declares a `**Scope:**` line, the parsed source-Scope glob list takes precedence over `parsed.fileGlobs` regardless of LLM emission. Both lists pass through `sanitizeFileGlobs` for parity (shallow → recursive normalization handles author-`*.ts` vs LLM-`**/*.ts`).
- **`BuildRuleResult.scopeOverride?: { from: string[] | undefined; to: string[] }`** reports the override event when it actually changed the emitted globs. Threaded through rejection paths too. Mirrors `severityOverride` discipline from #1656.
- **`onScopeOverride` callback** on `CompileLessonCallbacks` wired to a `writeScopeOverrideTelemetry` closure in CLI `compile.ts` that records `type: 'scope-override'` entries to `.totem/temp/telemetry.jsonl`. Cloud-compile path also wired.
- **Selective-rethrow** in the telemetry catch block — expected IO error codes (ENOENT, EACCES, EPERM, ENOSPC, EBUSY, EROFS) are swallowed as best-effort sink failures; unexpected errors propagate per Tenet 4 (Fail Loud, Never Drift). Avoids the fully-swallow trap the lint rule `87aff037d7de47a7` surfaces.

## Why now

Item 023 was the second tier-1 item from the upstream-feedback batch (`mmnto-ai/totem-strategy#133`, merged 2026-04-25). Pairs cleanly with today's #1663 (`applies-to:` substrate, shipped in 1.15.5). Closes both tier-1 items in the batch in one session.

## Out of scope (deferred follow-ups at merge)

- **Strict-fail compile gate.** If `scope-override` telemetry shows persistent LLM drift, tighten the override path to fail compile on divergence rather than silently override. Tier-3, dependent on telemetry data.
- **Compile-prompt Scope guidance refinement.** Once telemetry reveals the divergence rate, sharpen the prompt instructions in `compile-templates.ts` to honor source `**Scope:**` more reliably. Tier-3.
- **Pipeline 1 audit.** Verify no existing Pipeline 1 lesson silently drops exclusions during the manual flow. Tier-3 sanity check.
- **Severity-helper rethrow hardening.** The existing `writeSeverityOverrideTelemetry` (#1656) has the fully-swallow shape this PR's `writeScopeOverrideTelemetry` rejected. Apply the selective-rethrow pattern there too. Tier-3 hygiene.

## Test plan

- [x] `pnpm --filter @mmnto/totem test` — 1,398 / 1,398 pass (+27 new tests: `parseDeclaredScope` 9 cases including the Pipeline 1 regression pin, `isGlobSetEqual` 9 cases, `buildCompiledRule` `scopeOverride` 9 scenarios covering the LC#80 exhibit, both inverse directions, no-divergence, no-override, no-lessonBody, undefined-LLM, rejection-path preservation, sanitizeFileGlobs normalization).
- [x] `pnpm --filter @mmnto/cli test` — 1,827 / 1,827 pass.
- [x] `pnpm exec totem lint` — PASS (7 warnings, all pre-existing rule-precision issues firing on patterns the code doesn't actually violate; selective-rethrow pattern resolved the fail-loud-catch error).
- [x] `pnpm exec totem review` — PASS, no findings.
- [x] `pnpm exec totem verify-manifest` — PASS.
- [x] LC#80 exhibit reproduced in test: source `[A, !B, !C]` + LLM `[A]` → output `[A, !B, !C]` with marker fired.
- [x] Inverse direction covered: source `[A]` + LLM `[A, **/*.test.*, **/*.spec.*]` (auto-include hallucination) → output `[A]` (author-explicit wins).
- [x] No-divergence case: matching emissions produce no marker.

Closes #1665

🤖 Generated with [Claude Code](https://claude.com/claude-code)