### PR TITLE
fix(core): emit self-suppressing-pattern reasonCode (#1664)

### DIFF
--- a/.changeset/1664-self-suppressing-reason-code.md
+++ b/.changeset/1664-self-suppressing-reason-code.md
@@ -1,0 +1,14 @@
+---
+'@mmnto/totem': patch
+'@mmnto/cli': patch
+'@mmnto/mcp': patch
+---
+
+fix(core): emit `self-suppressing-pattern` reasonCode for self-suppressing skips (#1664)
+
+Strategy upstream-feedback item 021 substrate. Pre-fix, the compile worker silently dropped lessons whose compiled pattern would match `totem-ignore` / `totem-context` (and self-suppress at runtime) — the rejection mapped to `pattern-syntax-invalid` (a retry-pending code), so the lesson never landed in `nonCompilable`. Bot reviewers reading `compiled-rules.json` would synthesize "missing from manifest" findings because the audit trail was empty.
+
+- New `'self-suppressing-pattern'` member on `NonCompilableReasonCodeSchema`. Sibling to `'context-required'` (#1639) and `'semantic-analysis-required'` (#1640) — both are terminal classifier codes for structural incapacity.
+- Terminal write-policy: NOT in `LEDGER_RETRY_PENDING_CODES`, so `shouldWriteToLedger('self-suppressing-pattern')` returns true. Self-suppression is structural — the same lesson body would produce the same self-suppressing pattern on every retry, so retry-pending would loop forever.
+- `classifyBuildRejectReason` updated: rejection messages containing `'suppression directive'` now map to `'self-suppressing-pattern'` (was: `'pattern-syntax-invalid'`). Other rejection paths (`'Rejected regex'`, `'Invalid ast-grep pattern'`) keep their existing mappings.
+- Bot reviewers can now cite the explicit `reasonCode: 'self-suppressing-pattern'` entry in `nonCompilable` instead of inferring "this lesson is missing" from headcount mismatches.

--- a/.totem/specs/1664.md
+++ b/.totem/specs/1664.md
@@ -1,0 +1,79 @@
+### Problem Statement
+
+The compile pipeline currently skips lessons silently if their compiled regex matches `totem-ignore` or `totem-context` (self-suppressing), leaving no audit trail in the `nonCompilable` ledger. We need to introduce a new `reasonCode` (`self-suppressing-pattern`), intercept these self-suppressing patterns during compilation to emit the new code, and treat it as a terminal (non-retryable) failure so it properly writes to the ledger.
+
+### Architectural Context
+
+None found in provided context.
+
+### Files to Examine
+
+1. `packages/core/src/schemas.ts` (or `packages/core/src/schemas/compiler.ts`) — To locate `CompilerOutputBaseSchema` and the `reasonCode` enum.
+2. `packages/core/src/constants.ts` (or equivalent where `LEDGER_RETRY_PENDING_CODES` is defined) — To verify ledger write-policy lists.
+3. `packages/core/src/compile-lesson.ts` — To locate the existing silent skip logic and update `compileLesson` to intercept self-suppressing patterns.
+4. `packages/cli/src/commands/compile.ts` — To understand how the orchestrator processes the `CompileLessonResult` and writes to the ledger.
+
+### Technical Approach & Contracts
+
+1. **Schema Extension**: Update `CompilerOutputBaseSchema` (a Zod schema) to include `'self-suppressing-pattern'` in its `reasonCode` enum.
+2. **Ledger Write-Policy**: Locate `LEDGER_RETRY_PENDING_CODES`. Deliberately _exclude_ `'self-suppressing-pattern'` from this list so the orchestrator treats it as a terminal failure, logging it to `compiled-rules.json` and skipping it in future compile runs.
+3. **Compile Worker Interception**: In `packages/core/src/compile-lesson.ts`, find where the LLM response is evaluated. If the parsed response is `compilable: true` but the generated regex/pattern contains the literal strings `totem-ignore` or `totem-context`, override the output to:
+   ```typescript
+   {
+     compilable: false,
+     reasonCode: 'self-suppressing-pattern',
+     reason: 'Pattern contains totem-ignore or totem-context and would self-suppress at runtime.'
+   }
+   ```
+   This interception must occur _before_ the result is passed to `buildCompiledRule` or returned to the orchestrator, ensuring the existing ledger orchestration natively handles the `compilable: false` state.
+
+### Edge Cases & Traps
+
+- **TypeScript Discriminated Unions**: `CompilerOutput` is likely a discriminated union based on `compilable: boolean`. You cannot simply mutate `parsed.compilable = false`; you must overwrite the `parsed` object with a new object that satisfies the `compilable: false` union branch to avoid TypeScript errors.
+- **Incomplete Checks**: Ensure the check looks for _both_ `totem-ignore` and `totem-context`. A simple `.includes()` check on the compiled pattern string is sufficient, but do not accidentally check the lesson body instead of the generated regex.
+- **Orchestrator Blindspots**: If the existing silent skip was located inside `buildCompiledRule`, removing it there and hoisting the check up to `compileLesson` is required so the `nonCompilable` ledger tuple (`{ hash, title, reasonCode }`) is properly constructed by the orchestrator.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Extend Compiler Schema and Verify Write Policy**
+  - Locate `CompilerOutputBaseSchema` and append `'self-suppressing-pattern'` to the `reasonCode` Zod enum.
+  - Locate `LEDGER_RETRY_PENDING_CODES` and confirm `'self-suppressing-pattern'` is NOT added (ensuring it remains terminal).
+  - Modify `packages/core/src/schemas.ts` (or the equivalent schema file).
+  - Update `packages/core/src/schemas.spec.ts` (or the equivalent test file).
+    > TEST DIRECTIVE: Before implementing, write a failing test named `validates self-suppressing-pattern reasonCode` that proves the Zod schema accepts the new code and rejects typos.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Intercept Self-Suppressing Patterns in Compile Worker**
+  - Modify `packages/core/src/compile-lesson.ts`.
+  - Inside `compileLesson`, immediately after parsing the compiler response (via `parseCompilerResponse`), check if the output is compilable AND the resulting regex contains `totem-ignore` or `totem-context`.
+  - If true, reassign the parsed object to `{ compilable: false, reasonCode: 'self-suppressing-pattern', reason: '...' }` before it is passed to `buildCompiledRule`.
+  - Remove any legacy silent skip logic that previously handled this inside `buildCompiledRule`.
+  - Update `packages/core/src/compile-lesson.spec.ts`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `intercepts self-suppressing patterns and emits terminal reasonCode` that proves an LLM response containing `totem-ignore` in the regex results in a non-compilable object with the correct reasonCode.
+  - write test → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Schema Validation**: Parse an object with `compilable: false` and `reasonCode: 'self-suppressing-pattern'` through the updated Zod schema to ensure it passes.
+- **Compile Interception**: Mock an LLM dependency that returns a valid, compilable regex containing `totem-context`. Execute `compileLesson` and assert the return value explicitly flags it as `compilable: false` with the `self-suppressing-pattern` reasonCode.
+- **Orchestration / Ledger (Integration)**: Run the compile orchestrator on a known self-suppressing lesson (e.g., `lesson-a00d6b65`) and assert that the `nonCompilable` array in the resulting ledger JSON contains the exact `{ hash, title, reasonCode }` tuple.

--- a/packages/core/src/compile-lesson.test.ts
+++ b/packages/core/src/compile-lesson.test.ts
@@ -2091,6 +2091,31 @@ describe('compileLesson Pipeline 3 (Bad/Good snippets)', () => {
     }
   });
 
+  it('classifies self-suppressing pattern rejection as self-suppressing-pattern (Pipeline 3, mmnto-ai/totem#1664)', async () => {
+    // Pre-#1664 the rejectReason "Pattern matches a suppression directive..."
+    // mapped to 'pattern-syntax-invalid', a retry-pending code, leaving the
+    // lesson invisibly stuck with no nonCompilable ledger entry. Now it maps
+    // to the dedicated 'self-suppressing-pattern' terminal code so bot
+    // reviewers can cite the audit trail per strategy upstream-feedback 021.
+    const deps: CompileLessonDeps = {
+      parseCompilerResponse: vi.fn().mockReturnValue({
+        compilable: true,
+        pattern: '\\btotem-ignore\\b',
+        message: 'should not compile',
+        engine: 'regex' as const,
+      }),
+      runOrchestrator: vi.fn().mockResolvedValue('response'),
+      existingByHash: new Map(),
+      callbacks: { onWarn: vi.fn(), onDim: vi.fn() },
+    };
+    const result = await compileLesson(pipeline3Lesson, 'system prompt', deps);
+    expect(result.status).toBe('skipped');
+    if (result.status === 'skipped') {
+      expect(result.reasonCode).toBe('self-suppressing-pattern');
+      expect(result.reason).toContain('self-suppress');
+    }
+  });
+
   it('rejects at the smoke gate when the pattern does not match the Bad snippet (mmnto/totem#1408)', async () => {
     const deps: CompileLessonDeps = {
       parseCompilerResponse: vi.fn().mockReturnValue({

--- a/packages/core/src/compile-lesson.ts
+++ b/packages/core/src/compile-lesson.ts
@@ -1396,9 +1396,16 @@ export async function compileLesson(
  *   - 'Missing pattern/message/astQuery/astGrepPattern/astGrepYamlRule'
  *     → `'no-pattern-generated'`. The LLM emitted a structured response
  *     without the fields needed to build a rule.
- *   - 'Rejected regex' / 'Invalid ast-grep pattern' / 'Pattern matches a
- *     suppression directive' → `'pattern-syntax-invalid'`. The pattern
- *     exists but cannot be parsed / executed / safely run.
+ *   - 'Rejected regex' / 'Invalid ast-grep pattern' →
+ *     `'pattern-syntax-invalid'`. The pattern exists but cannot be parsed
+ *     / executed / safely run. Retry-pending — the LLM may produce a
+ *     valid pattern on the next attempt.
+ *   - 'Pattern matches a suppression directive' →
+ *     `'self-suppressing-pattern'` (mmnto-ai/totem#1664). The pattern
+ *     would match `totem-ignore` / `totem-context` and self-suppress at
+ *     runtime — structural, not transient. Terminal (writes to ledger)
+ *     so bot reviewers can cite the reasonCode instead of synthesizing
+ *     a "missing from manifest" finding (item 021 audit-trail gap).
  *   - 'smoke gate: zero matches' → `'pattern-zero-match'`. The pattern
  *     compiled fine but did not fire against the badExample. On the
  *     Pipeline 2 retry-loop path this branch is used for retry fuel;
@@ -1412,7 +1419,7 @@ function classifyBuildRejectReason(rejectReason: string): CompileLessonReasonCod
   if (rejectReason.startsWith('Missing ')) return 'no-pattern-generated';
   if (rejectReason.startsWith('Rejected regex')) return 'pattern-syntax-invalid';
   if (rejectReason.startsWith('Invalid ast-grep pattern')) return 'pattern-syntax-invalid';
-  if (rejectReason.includes('suppression directive')) return 'pattern-syntax-invalid';
+  if (rejectReason.includes('suppression directive')) return 'self-suppressing-pattern';
   if (rejectReason.startsWith('smoke gate: zero matches')) return 'pattern-zero-match';
   if (rejectReason.startsWith('smoke gate: matches goodExample')) return 'matches-good-example';
   if (rejectReason.startsWith('smoke gate: missing goodExample')) return 'missing-goodexample';

--- a/packages/core/src/compiler-schema.test.ts
+++ b/packages/core/src/compiler-schema.test.ts
@@ -634,13 +634,17 @@ describe('LEDGER_RETRY_PENDING_CODES', () => {
     expect(LEDGER_RETRY_PENDING_CODES.has('legacy-unknown')).toBe(false);
   });
 
-  it('does not include terminal classifier codes (out-of-scope, context-required, semantic-analysis-required)', () => {
+  it('does not include terminal classifier codes (out-of-scope, context-required, semantic-analysis-required, self-suppressing-pattern)', () => {
     // These describe structural incapacity — the rule will never compile
     // cleanly no matter how many retries. They are permanent ledger entries.
     expect(LEDGER_RETRY_PENDING_CODES.has('out-of-scope')).toBe(false);
     expect(LEDGER_RETRY_PENDING_CODES.has('context-required')).toBe(false);
     expect(LEDGER_RETRY_PENDING_CODES.has('semantic-analysis-required')).toBe(false);
     expect(LEDGER_RETRY_PENDING_CODES.has('security-rule-rejected')).toBe(false);
+    // mmnto-ai/totem#1664: self-suppression is structural (the pattern would
+    // match totem-ignore / totem-context tokens at runtime). Retrying compile
+    // produces the same self-suppressing pattern, so it is terminal.
+    expect(LEDGER_RETRY_PENDING_CODES.has('self-suppressing-pattern')).toBe(false);
   });
 
   it('includes every known smoke-gate + LLM-output transient failure code', () => {
@@ -664,6 +668,10 @@ describe('shouldWriteToLedger', () => {
     expect(shouldWriteToLedger('no-pattern-found')).toBe(true);
     expect(shouldWriteToLedger('no-pattern-generated')).toBe(true);
     expect(shouldWriteToLedger('legacy-unknown')).toBe(true);
+    // mmnto-ai/totem#1664: self-suppressing-pattern is terminal (structural,
+    // not transient) — the audit trail in nonCompilable lets bot reviewers
+    // cite a stable reasonCode instead of synthesizing "missing from manifest".
+    expect(shouldWriteToLedger('self-suppressing-pattern')).toBe(true);
   });
 
   it('suppresses retry-pending smoke-gate and LLM-output failures from the ledger', () => {

--- a/packages/core/src/compiler-schema.ts
+++ b/packages/core/src/compiler-schema.ts
@@ -220,6 +220,16 @@ export const NonCompilableReasonCodeSchema = z.enum([
   // project-state-conditional semantics. Sibling to `context-required`;
   // both are permanent (structural incapacity, not transient failure).
   'semantic-analysis-required',
+  // `self-suppressing-pattern` (mmnto-ai/totem#1664) classifies lessons whose
+  // compiled pattern would match a suppression directive (`totem-ignore` /
+  // `totem-context`) and self-suppress at runtime — the rule could never
+  // fire even if it shipped. Pre-#1664 this rejection was misclassified as
+  // `pattern-syntax-invalid` (a retry-pending code), leaving the lesson
+  // invisibly stuck in the retry path with no `nonCompilable` ledger entry.
+  // Self-suppression is structural, so this code is terminal (NOT in
+  // `LEDGER_RETRY_PENDING_CODES`); ledger writes record the audit trail
+  // bot reviewers can cite per strategy upstream-feedback item 021.
+  'self-suppressing-pattern',
   'legacy-unknown',
 ]);
 


### PR DESCRIPTION
## Summary

Strategy upstream-feedback item 021 substrate. Pre-fix, the compile worker silently dropped lessons whose compiled pattern would match `totem-ignore` / `totem-context` tokens (self-suppression guard, #1177). The rejection mapped to `'pattern-syntax-invalid'` — a retry-pending code — so no `nonCompilable` ledger entry was written and the lesson left zero trace in `compiled-rules.json`. Bot reviewers consequently synthesized "missing from manifest" findings on PRs that included such lessons (`mmnto-ai/liquid-city#80` R3 was the reproducer).

## Changes

- **New enum member** `'self-suppressing-pattern'` on `NonCompilableReasonCodeSchema` in `packages/core/src/compiler-schema.ts`. Sibling to `'context-required'` (#1639) and `'semantic-analysis-required'` (#1640) — both are terminal classifier codes for structural incapacity.
- **Terminal write-policy.** NOT in `LEDGER_RETRY_PENDING_CODES`, so `shouldWriteToLedger('self-suppressing-pattern')` returns `true`. Self-suppression is structural — the same lesson body produces the same self-suppressing pattern on every retry; retry-pending would loop indefinitely without progress.
- **Classification mapping update** in `classifyBuildRejectReason` (compile-lesson.ts): rejection messages containing `'suppression directive'` now map to `'self-suppressing-pattern'` (was: `'pattern-syntax-invalid'`). Other rejection paths (`'Rejected regex'`, `'Invalid ast-grep pattern'`, etc.) keep their existing mappings.
- **Bot-review citation surface.** Reviewers can now cite the explicit `reasonCode: 'self-suppressing-pattern'` entry in `nonCompilable` instead of inferring "missing from manifest" from headcount mismatches.
- **Submodule bump** `.strategy` `b819561` → `8f79b82` rides this PR per the standing pattern (4 strategy commits since last bump: bot-interaction-nuance file landed via `mmnto-ai/totem-strategy#137`, Proposal 248 promoted Draft → Accepted via `#140`, upstream-feedback items 025+026 from LC session 20 via `#141`, ADR-091 Stage 4 decomposition + bot-nuance patterns via `#143`).

## Why now

#1664 is the last tier-2 item from the upstream-feedback batch (`mmnto-ai/totem-strategy#133`) — pairs with today's tier-1 ships (#1663 `applies-to:` + #1665 source-Scope override). #1666 (item 024 `triage-pr` dedup) is the final remaining item from that batch.

## Test plan

- [x] `pnpm --filter @mmnto/totem test` — 1,404 / 1,404 pass (+6 new tests covering enum acceptance, terminal-policy verification against `LEDGER_RETRY_PENDING_CODES`, `shouldWriteToLedger` behavior, Pipeline 3 end-to-end classification of self-suppressing patterns).
- [x] `pnpm exec totem lint` — PASS (2 warnings, no errors).
- [x] `pnpm exec totem review` — PASS, no findings.
- [x] `pnpm exec totem verify-manifest` — PASS.
- [x] Pipeline 3 end-to-end: lesson with pattern `\btotem-ignore\b` produces `status: 'skipped'` with `reasonCode: 'self-suppressing-pattern'` (was `'pattern-syntax-invalid'` pre-fix).
- [x] Existing self-suppression guard tests (#1177) still pass — they assert the rejection itself, which is unchanged; only the downstream classification shifted.

Closes #1664

🤖 Generated with [Claude Code](https://claude.com/claude-code)