### PR TITLE
fix(cli): triage-pr dedup by deterministic rootCommentId (#1666)

### DIFF
--- a/.changeset/1666-triage-dedup-by-comment-id.md
+++ b/.changeset/1666-triage-dedup-by-comment-id.md
@@ -1,0 +1,19 @@
+---
+'@mmnto/totem': patch
+'@mmnto/cli': patch
+'@mmnto/mcp': patch
+---
+
+fix(cli): switch triage-pr dedup identity to deterministic rootCommentId (#1666)
+
+Strategy upstream-feedback item 024 substrate. The previous `deduplicateFindings` used a `(file, line, body keyword Jaccard ≥ 0.3, line proximity ≤ 3)` fuzzy-merge heuristic. On `mmnto-ai/liquid-city#80` R3, GCA emitted six distinct high-severity findings on the same `(file, line)` anchor (all six anchored at the same rule-section start line because GitHub's pull-request inline-comment API requires a `line` field and GCA chose the rule-section header). The fuzzy merge collapsed all six into one entry, hiding five GCA-high findings from the triage summary.
+
+- **Strict-by-id dedup.** `deduplicateFindings` now uses `rootCommentId` as the primary dedup primitive. Two findings with different `rootCommentId` are ALWAYS distinct, even when bodies are byte-identical and they anchor at the same `(file, line)`.
+- **Body-hash fallback** for synthesized review-body findings (`extractReviewBodyFindings` emits these with `file === '(review body)'` and no `rootCommentId`). Map key is `(file, body)` directly — bounded length, no crypto cost, V8 handles long string keys natively.
+- **Cross-bot independence is now a feature.** When CR and GCA independently flag the same `(file, line)`, both findings surface so consumers can read the agreement as elevated-confidence signal (per the strategy bot-nuance file's "Cross-bot agreement = elevated finding confidence" pattern). The previous fuzzy merge silently masked that signal.
+- **`mergedWith` field stays on the schema, undefined in output.** Backward-compat shim so downstream display consumers don't need a coordinated rewrite.
+- **`extractKeywords` and `jaccardSimilarity` helpers retained as exports** for the deferred `--no-dedup` debug flag (#TBD-follow-up) and ad-hoc analysis scripts. No longer called by core dedup logic.
+
+Compile-pipeline failure mode shifts from "silent collapse of distinct findings" to "deterministic distinctness when API IDs differ." The 14 prior fuzzy-merge tests are rewritten to match the new semantics; the LC#80 R3 exhibit (6 distinct rootCommentIds on the same file:line) is pinned as a regression test.
+
+Closes the strategy upstream-feedback batch from `mmnto-ai/totem-strategy#133` — items 020 (#1663), 021 (#1664), 022 (Proposal 248), 023 (#1665), 024 (#1666) all complete.

--- a/.totem/specs/1666.md
+++ b/.totem/specs/1666.md
@@ -1,0 +1,164 @@
+### Problem Statement
+
+The `totem triage-pr` command incorrectly deduplicates findings based on a `(path, line, author)` tuple, which causes distinct findings on the same line (e.g., multiple GCA high-severity issues) to collapse into a single item, hiding critical summary data. The deduplication identity must be updated to use the deterministic API `comment_id` as the primary key, with a body-hash fallback exclusively for synthesized review-body findings that lack a comment ID.
+
+### Architectural Context
+
+None found in provided context. (Strictly adhering to Strategy upstream-feedback item 024 from the issue description).
+
+### Files to Examine
+
+1. `packages/cli/src/commands/triage-pr.ts` — Contains the `normalizeBotFindings` and `formatTriageOutput` functions where the deduplication pass currently resides.
+2. `packages/cli/src/adapters/github-cli-pr.ts` (if available) — To verify how `id` / `comment_id` is parsed from the GitHub CLI/API response.
+3. `packages/cli/src/commands/triage-pr.test.ts` (or equivalent test file) — To implement the necessary TDD fixtures.
+
+### Technical Approach & Contracts
+
+To correctly handle deduplication without data loss, we must implement a **Two-Pass Hybrid Deduplication Strategy**. This prevents order-of-processing bugs where a synthesized review-body finding might be evaluated before its inline counterpart.
+
+**Data Contracts:**
+The internal `CategorizedFinding` (and the input `CommentThread` interface if necessary) must be explicitly typed to include:
+
+```typescript
+{
+  commentId?: string; // thread_id for inline, comment id for top-level, undefined for synthesized
+  // ... existing fields (body, path, line, author, etc.)
+}
+```
+
+**Two-Pass Deduplication Logic in `normalizeBotFindings`:**
+
+1. **Pass 1 (Primary - Deterministic IDs):** Iterate through all findings that _have_ a `commentId`.
+   - Keep them all.
+   - Track their IDs in `seenCommentIds = new Set<string>()` (to catch API duplication anomalies).
+   - Compute a SHA-256 hash of their _normalized_ body: `const hash = createHash('sha256').update(stripHtmlWrappers(finding.body)).digest('hex')`.
+   - Add this hash to `seenBodyHashes = new Set<string>()`.
+2. **Pass 2 (Fallback - Synthesized Findings):** Iterate through findings that _lack_ a `commentId`.
+   - Compute their body hash using the exact same normalization.
+   - If `seenBodyHashes.has(hash)`, **DROP** the finding (it collapses into the inline version).
+   - If `!seenBodyHashes.has(hash)`, **KEEP** the finding, and add its hash to `seenBodyHashes` (to deduplicate identical synthesized findings against each other).
+3. **Re-assemble:** Combine the results of Pass 1 and Pass 2, sorting them to maintain the original expected output order (typically by path/line or chronologically).
+
+### Edge Cases & Traps
+
+- **Order-of-Operations Trap:** If you process a single pass and a synthesized finding appears in the array before its inline counterpart, the synthesized one is kept, and the inline one (which has a unique ID) is _also_ kept, failing the deduplication requirement. You **must** do a two-pass approach or explicitly sort inline findings before synthesized ones.
+- **Normalization Trap:** Hashing the raw `.body` will cause deduplication to fail if inline comments have different HTML wrapper artifacts than synthesized comments. You must hash the output of the existing `stripHtmlWrappers(html)` helper.
+- **Generic Lint Trap (Data Loss):** Never apply the `body-hash` deduplication to findings that _do_ have a `commentId`. Doing so will silently drop identical generic lint errors that legitimately occur on different lines. The `body-hash` drop rule ONLY applies to findings lacking a `commentId`.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Define Contracts & Write Failing Tests**
+  - Update types in `packages/cli/src/commands/triage-pr.ts` (or the respective types file) to include `commentId?: string` on findings.
+  - Locate `packages/cli/src/commands/triage-pr.test.ts`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `retains distinct findings on the same line` that mocks two findings sharing the same `(path, line, author)` but possessing unique `commentId`s.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `collapses synthesized review-body finding when identical inline finding exists` that mocks an inline finding (with `commentId`) and a synthesized finding (without `commentId`) sharing the same body.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Extract `commentId` in Adapter / Mapping**
+  - Modify the logic that maps raw GitHub `CommentThread` items into findings inside `normalizeBotFindings` (or prior to it).
+  - Ensure the GitHub `id` or `node_id` is correctly mapped to the `commentId` property. Synthesized `(review body)` findings should leave this explicitly `undefined`.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Implement Two-Pass Deduplication**
+  - In `packages/cli/src/commands/triage-pr.ts`, locate the deduplication loop inside `normalizeBotFindings`.
+  - Remove the old `const dedupKey = ${path}:${line}:${author}` logic.
+  - Implement the Pass 1 / Pass 2 logic using `crypto.createHash('sha256')` and `stripHtmlWrappers(body)`.
+  - Ensure the final array maintains proper sorting.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Same-Line Unique Findings:** Provide 2 mocked GCA finding objects. `path="foo.ts"`, `line=10`, `author="gca"`. Give them different `commentId`s and different bodies. Assert that `normalizeBotFindings` returns length 2.
+- **Synthesized vs Inline Collapse:** Provide 1 inline finding (`commentId="123"`, `body="Fix typo"`) and 1 review-body finding (`commentId=undefined`, `body="Fix typo"`). Assert `normalizeBotFindings` returns length 1, and the kept finding is the one with `commentId="123"`.
+- **Generic Lint Duplication (Negative Test):** Provide 2 inline findings with identical bodies (`body="Missing semicolon"`) but different lines (`line=5`, `line=10`) and different `commentId`s. Assert `normalizeBotFindings` returns length 2.
+
+## Implementation Design
+
+### Scope
+
+**Will:** Replace `deduplicateFindings` in `packages/cli/src/parsers/triage-dedup.ts` so the dedup primary key is `rootCommentId` for inline review-thread findings. Two findings with different `rootCommentId` are ALWAYS distinct, even if their bodies are byte-identical and they anchor at the same `(file, line)`. For findings without `rootCommentId` (synthesized review-body findings — `file === '(review body)'`), fall back to `(file, body-hash)` as the dedup primitive. Update the existing 14 dedup tests to match the new semantics (some will assert distinct findings where they previously asserted merged).
+
+**Will NOT:** Add a `--no-dedup` / `--raw` CLI flag (deferred — separate UX concern). Will NOT update the summary line to surface "dedup collapsed N findings" (deferred). Will NOT update `triage-pr --help` docs (deferred — same follow-up). Will NOT touch `bot-review-parser.ts` — `rootCommentId` is already populated correctly at every producer site.
+
+### Data model deltas
+
+| Item                          | Type / shape              | Holds          | Writer                | Reader                   | Invariant                                                                                                                                                                                                                                                   |
+| ----------------------------- | ------------------------- | -------------- | --------------------- | ------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `CategorizedFinding.dedupKey` | `string` (existing field) | Dedup identity | `deduplicateFindings` | Downstream display layer | After this PR: prefixed with `'id:'` for `rootCommentId` keys, `'body-hash:'` for body-hash fallback keys, `'review-body:'` for the legacy `(file, body)` synthesized path. Uniqueness invariant: two distinct findings always produce distinct dedup keys. |
+| (no new types)                | —                         | —              | —                     | —                        | —                                                                                                                                                                                                                                                           |
+
+No new state containers. No new module-level vars. The `mergedWith` field on `CategorizedFinding` becomes a no-op output (always undefined or empty) under strict-by-id semantics — keeping the field for backward compat avoids forcing every downstream consumer into a coordinated update.
+
+The `dedupKey` prefix is non-load-bearing for correctness — it's a debugging aid so a reader of the output can tell which dedup path produced a given key. The uniqueness invariant lives on the unprefixed core (`rootCommentId` itself, or `${file}|${body-hash}` for fallback).
+
+### State lifecycle
+
+- `deduplicateFindings` is a pure function — input array in, output array out. No persisted state, no module vars.
+- `dedupKey` lives on the returned `CategorizedFinding[]`; lifetime tied to the caller's display loop. Same as today.
+- `Set<string>` of seen keys is per-invocation, garbage-collected when the function returns. Not a state container in the design-doc sense.
+
+### Failure modes
+
+| Failure                                                                                                    | Category       | Agent-facing surface                                     | Recovery                                                                                                                                                                     |
+| ---------------------------------------------------------------------------------------------------------- | -------------- | -------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `rootCommentId` is `undefined` for an inline finding (shouldn't happen — bot-review-parser always sets it) | runtime        | Falls back to body-hash path, treated as synthesized     | Bot-review-parser fix (out of scope; doesn't currently happen)                                                                                                               |
+| Two findings with same `rootCommentId` (shouldn't happen — IDs are GitHub-assigned)                        | runtime        | Second one dropped (existing-key collision) — first wins | n/a; would indicate upstream API bug                                                                                                                                         |
+| Body-hash collision between two distinct review-body findings                                              | runtime / rare | Second one dropped silently                              | Body-hash collision rate is negligible; fallback is per-(file, body) so collisions limited to identical-body findings on the same `(review body)` pseudo-path. Not blocking. |
+| Empty input array                                                                                          | runtime        | Returns `[]`                                             | n/a                                                                                                                                                                          |
+| All findings have `triageCategory` resolution failures                                                     | runtime        | Categorization is unchanged from today's behavior        | Existing path                                                                                                                                                                |
+
+No "silent degradation" rows. Body-hash collisions are theoretically possible but the input space (synthesized review-body findings only) is small enough that a collision implies the bot literally posted two identical review-body lines — which is itself a duplicate.
+
+### Invariants to lock in via tests
+
+- **The LC#80 R3 exhibit reproduction:** 6 GCA findings on `compiled-rules.json:598`, distinct `rootCommentId`s, identical or near-identical bodies. Result must be 6 distinct entries (was: 1 after fuzzy merge).
+- **Strict-by-id distinctness:** Two findings with different `rootCommentId` are NEVER merged, regardless of file/line/body similarity.
+- **Body-hash fallback invariant:** Two synthesized review-body findings (`file === '(review body)'`, both lacking `rootCommentId`) with identical body collapse to one. With distinct bodies, stay distinct.
+- **No-id × has-id mixed case:** A synthesized finding (no id) and an inline finding (has id) with the same body do NOT merge — the id-keyed finding wins on its own track.
+- **Order independence:** dedup output order matches input order (first-seen wins on collision); sorting stability preserved.
+- **Categorization unchanged:** `triageCategory` mapping for each surviving finding matches today's behavior — only the merge step is rewritten.
+- **`mergedWith` field invariant under strict-id mode:** Empty / undefined for all output. Backward-compat shim to avoid breaking downstream consumers that read it.
+
+### Open questions
+
+1. **Question:** Should `mergedWith` be removed entirely, kept as undefined-only for backward compat, or kept and populated (as a "would have been merged under fuzzy semantics" debug surface)?
+   - **Options:** (a) Remove from `CategorizedFinding` schema. (b) Keep as undefined/empty everywhere — no producer writes it, downstream readers naturally skip it. (c) Keep and populate as fuzzy-merge audit trail for the deferred `--raw` flag's debug output.
+   - **Recommendation:** (b). Removing breaks downstream readers (every consumer of `CategorizedFinding` would need updating). Populating creates two parallel truths. Leaving it inert is the smallest possible change that lands the fix.
+
+2. **Question:** Cross-bot dedup — should a CR finding and a GCA finding with similar bodies on the same line ever merge?
+   - **Options:** (a) Never merge across bots — `rootCommentId` is sufficient. (b) Keep the today's cross-bot Jaccard merge as a separate optional layer.
+   - **Recommendation:** (a). Cross-bot independent agreement is now the _signal we want to surface_ (per strategy bot-nuance pattern 1: "Cross-bot agreement = elevated finding confidence"). Merging them across bots would mask exactly the high-confidence pattern strategy Claude documented. Today's fuzzy-merge collapses them silently — that's the opposite of the desired behavior.
+
+3. **Question:** Body-hash function — full SHA-256, truncated SHA-256 (first 12 chars), or just the body string itself as the map key?
+   - **Options:** (a) Full SHA-256. (b) Truncated SHA-256 (12 hex). (c) Use the body string directly.
+   - **Recommendation:** (c). Bodies are bounded (review comments are typically <2KB), JS Map handles string keys natively, no crypto cost. Hashing is unnecessary unless we need the key to be compact for telemetry — and we don't (the key is per-invocation, never persisted).
+
+4. **Question:** Defer `--no-dedup` / `--raw` flag and summary-line update to follow-ups, or include them in this PR?
+   - **Options:** (a) Defer (smallest PR). (b) Include — they're related to the same UX fix.
+   - **Recommendation:** (a). The primary fix is the correctness change; the flag is a debugging convenience. Smaller PR = faster bot review = clean session cap. File a follow-up at merge.
+
+### Follow-up tickets to file at acceptance
+
+- **`--no-dedup` / `--raw` flag** for `triage-pr` to bypass dedup entirely. Tier-3 UX.
+- **Summary-line dedup-count surface** ("dedup collapsed N findings — see --raw"). Tier-3 UX, depends on the flag.
+- **`triage-pr --help` doc** that explains the dedup primitive. Tier-3 docs.

--- a/packages/cli/src/parsers/triage-dedup.test.ts
+++ b/packages/cli/src/parsers/triage-dedup.test.ts
@@ -197,6 +197,28 @@ describe('deduplicateFindings', () => {
     expect(result).toHaveLength(2);
   });
 
+  it('preserves cross-bot independence on the body-hash fallback path (CR + GCA same body → distinct)', () => {
+    // Body-hash key includes `tool` so two synthesized findings from
+    // different bots with identical bodies stay distinct. Symmetry with
+    // the strict-by-id path's cross-bot independence for inline findings
+    // (CR R1 review finding on PR #1690 — fixed in this round).
+    const findings: NormalizedBotFinding[] = [
+      makeFinding({
+        tool: 'coderabbit',
+        file: '(review body)',
+        body: 'Identical synthesized finding text',
+      }),
+      makeFinding({
+        tool: 'gca',
+        file: '(review body)',
+        body: 'Identical synthesized finding text',
+      }),
+    ];
+    const result = deduplicateFindings(findings);
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.tool).sort()).toEqual(['coderabbit', 'gca']);
+  });
+
   it('does not merge a synthesized finding with an inline finding even when bodies match', () => {
     // No-id × has-id mixed case: the inline path is keyed by id, the
     // synthesized path is keyed by (file, body). Their key spaces don't

--- a/packages/cli/src/parsers/triage-dedup.test.ts
+++ b/packages/cli/src/parsers/triage-dedup.test.ts
@@ -60,178 +60,221 @@ describe('jaccardSimilarity', () => {
   });
 });
 
-// ─── deduplicateFindings ─────────────────────────────
+// ─── deduplicateFindings (mmnto-ai/totem#1666 — strict-by-id) ──────────
 
 describe('deduplicateFindings', () => {
-  it('merges findings from different bots on same file+line with same category', () => {
+  // ─── Strict-by-id semantics ─────────────────────────
+
+  it('reproduces the LC#80 R3 exhibit: 6 distinct rootCommentIds on the same file:line surface as 6 entries', () => {
+    // Pre-#1666 the proximity + Jaccard fuzzy merge collapsed all 6 into
+    // one entry. Strict-by-id keeps them distinct because each comment
+    // carries a unique GitHub-assigned ID, regardless of how similar
+    // the bodies look or how identical the (file, line) anchor is.
+    const findings: NormalizedBotFinding[] = [
+      {
+        tool: 'gca',
+        severity: 'high',
+        file: '.totem/compiled-rules.json',
+        line: 598,
+        body: 'SystemParam rule severity should be `error` not `warning`',
+        rootCommentId: 1001,
+      },
+      {
+        tool: 'gca',
+        severity: 'high',
+        file: '.totem/compiled-rules.json',
+        line: 598,
+        body: 'SystemParam rule fileGlobs missing test/spec exclusions',
+        rootCommentId: 1002,
+      },
+      {
+        tool: 'gca',
+        severity: 'high',
+        file: '.totem/compiled-rules.json',
+        line: 598,
+        body: 'init_resource rule fileGlobs missing test/spec exclusions',
+        rootCommentId: 1003,
+      },
+      {
+        tool: 'gca',
+        severity: 'high',
+        file: '.totem/compiled-rules.json',
+        line: 598,
+        body: 'SystemParam rule goodExample non-compilable Rust lifetimes',
+        rootCommentId: 1004,
+      },
+      {
+        tool: 'gca',
+        severity: 'high',
+        file: '.totem/compiled-rules.json',
+        line: 598,
+        body: 'archivedReason `\\b` JSON-escape typo',
+        rootCommentId: 1005,
+      },
+      {
+        tool: 'gca',
+        severity: 'high',
+        file: '.totem/compiled-rules.json',
+        line: 598,
+        body: 'lesson-a00d6b65 missing from compiled-rules.json',
+        rootCommentId: 1006,
+      },
+    ];
+
+    const result = deduplicateFindings(findings);
+    expect(result).toHaveLength(6);
+    expect(result.map((r) => r.rootCommentId)).toEqual([1001, 1002, 1003, 1004, 1005, 1006]);
+  });
+
+  it('keeps findings with distinct rootCommentIds even when bodies are byte-identical', () => {
+    const findings: NormalizedBotFinding[] = [
+      makeFinding({ file: 'src/auth.ts', line: 10, body: 'Missing semicolon', rootCommentId: 200 }),
+      makeFinding({ file: 'src/auth.ts', line: 10, body: 'Missing semicolon', rootCommentId: 201 }),
+    ];
+    const result = deduplicateFindings(findings);
+    expect(result).toHaveLength(2);
+  });
+
+  it('drops the second finding when two share the same rootCommentId (API duplicate)', () => {
+    const findings: NormalizedBotFinding[] = [
+      makeFinding({ body: 'first', rootCommentId: 999 }),
+      makeFinding({ body: 'second (duplicate id)', rootCommentId: 999 }),
+    ];
+    const result = deduplicateFindings(findings);
+    expect(result).toHaveLength(1);
+    expect(result[0]!.body).toBe('first'); // first-seen wins
+  });
+
+  // ─── Cross-bot independence (strategy bot-nuance pattern 1) ──────
+
+  it('keeps cross-bot findings distinct on the same file:line — agreement is signal, not noise', () => {
+    // Pre-#1666 the fuzzy merge collapsed CR + GCA findings on similar
+    // bodies into one entry, masking exactly the cross-bot agreement
+    // signal the strategy bot-nuance file documents as elevated-
+    // confidence. Strict-by-id surfaces both so the triage agent reads
+    // the convergence.
     const findings: NormalizedBotFinding[] = [
       makeFinding({
         tool: 'coderabbit',
         file: 'src/auth.ts',
         line: 10,
         body: 'SQL injection risk in query builder',
+        rootCommentId: 300,
       }),
       makeFinding({
         tool: 'gca',
         file: 'src/auth.ts',
         line: 10,
         body: 'Potential injection vulnerability in SQL query',
+        rootCommentId: 301,
       }),
     ];
-
     const result = deduplicateFindings(findings);
-    expect(result).toHaveLength(1);
-    expect(result[0]!.mergedWith).toHaveLength(1);
-    expect(result[0]!.mergedWith![0]!.tool).toBe('gca');
-  });
-
-  it('refuses to merge findings on the same line if triageCategory differs', () => {
-    const findings: NormalizedBotFinding[] = [
-      makeFinding({
-        file: 'src/foo.ts',
-        line: 10,
-        body: 'SQL injection risk via exec call',
-      }),
-      makeFinding({
-        file: 'src/foo.ts',
-        line: 10,
-        body: 'Trailing whitespace on this line is a typo',
-      }),
-    ];
-
-    const result = deduplicateFindings(findings);
-    // security vs nit — should NOT merge
     expect(result).toHaveLength(2);
-    expect(result[0]!.mergedWith).toBeUndefined();
-    expect(result[1]!.mergedWith).toBeUndefined();
+    expect(result.map((r) => r.tool).sort()).toEqual(['coderabbit', 'gca']);
   });
 
-  it('merges findings within +/-3 line proximity', () => {
-    const findings: NormalizedBotFinding[] = [
-      makeFinding({
-        file: 'src/auth.ts',
-        line: 10,
-        body: 'Credential leak risk in secret handling code',
-      }),
-      makeFinding({
-        file: 'src/auth.ts',
-        line: 13,
-        body: 'Secret credential leak risk detected in code',
-      }),
-    ];
+  // ─── Body-hash fallback (synthesized review-body findings) ──────
 
+  it('dedupes review-body findings with identical (file, body) when rootCommentId is absent', () => {
+    // extractReviewBodyFindings emits findings with file === '(review body)'
+    // and no rootCommentId. The fallback path uses (file, body) as the
+    // dedup primitive.
+    const findings: NormalizedBotFinding[] = [
+      makeFinding({ file: '(review body)', body: 'Outside-diff finding text' }),
+      makeFinding({ file: '(review body)', body: 'Outside-diff finding text' }),
+    ];
     const result = deduplicateFindings(findings);
     expect(result).toHaveLength(1);
-    expect(result[0]!.mergedWith).toHaveLength(1);
   });
 
-  it('does not merge findings more than 3 lines apart', () => {
+  it('keeps review-body findings distinct when bodies differ', () => {
     const findings: NormalizedBotFinding[] = [
-      makeFinding({
-        file: 'src/auth.ts',
-        line: 10,
-        body: 'Credential leak risk in this function',
-      }),
-      makeFinding({
-        file: 'src/auth.ts',
-        line: 14,
-        body: 'Secret credential exposed in this block',
-      }),
+      makeFinding({ file: '(review body)', body: 'First synthesized finding' }),
+      makeFinding({ file: '(review body)', body: 'Second synthesized finding' }),
     ];
-
     const result = deduplicateFindings(findings);
     expect(result).toHaveLength(2);
   });
 
-  it('does not merge findings in different files', () => {
+  it('does not merge a synthesized finding with an inline finding even when bodies match', () => {
+    // No-id × has-id mixed case: the inline path is keyed by id, the
+    // synthesized path is keyed by (file, body). Their key spaces don't
+    // overlap, so they can't collide.
     const findings: NormalizedBotFinding[] = [
-      makeFinding({
-        file: 'src/auth.ts',
-        line: 10,
-        body: 'SQL injection risk via exec call',
-      }),
-      makeFinding({
-        file: 'src/db.ts',
-        line: 10,
-        body: 'SQL injection risk via exec call',
-      }),
+      makeFinding({ file: 'src/auth.ts', line: 10, body: 'Missing semicolon', rootCommentId: 400 }),
+      makeFinding({ file: '(review body)', body: 'Missing semicolon' }),
     ];
-
     const result = deduplicateFindings(findings);
     expect(result).toHaveLength(2);
   });
 
-  it('handles file-level comments (no line) with high body similarity', () => {
+  // ─── Trivial pass-through cases ─────────────────────
+
+  it('preserves all findings when every rootCommentId is distinct', () => {
     const findings: NormalizedBotFinding[] = [
-      makeFinding({
-        file: 'src/auth.ts',
-        line: undefined,
-        body: 'This module has security vulnerabilities in the authentication flow',
-      }),
-      makeFinding({
-        file: 'src/auth.ts',
-        line: undefined,
-        body: 'Security vulnerabilities detected in the authentication flow of this module',
-      }),
+      makeFinding({ file: 'src/auth.ts', line: 10, rootCommentId: 1 }),
+      makeFinding({ file: 'src/utils.ts', line: 50, rootCommentId: 2 }),
+      makeFinding({ file: 'src/config.ts', line: 5, rootCommentId: 3 }),
     ];
-
-    const result = deduplicateFindings(findings);
-    expect(result).toHaveLength(1);
-    expect(result[0]!.mergedWith).toHaveLength(1);
-  });
-
-  it('preserves all findings when no duplicates exist', () => {
-    const findings: NormalizedBotFinding[] = [
-      makeFinding({
-        file: 'src/auth.ts',
-        line: 10,
-        body: 'SQL injection risk via exec call',
-      }),
-      makeFinding({
-        file: 'src/utils.ts',
-        line: 50,
-        body: 'Trailing whitespace is a cosmetic nit',
-      }),
-      makeFinding({
-        file: 'src/config.ts',
-        line: 5,
-        body: 'Missing null check on boundary parameter',
-      }),
-    ];
-
     const result = deduplicateFindings(findings);
     expect(result).toHaveLength(3);
+  });
+
+  it('does not merge findings in different files (sanity check)', () => {
+    const findings: NormalizedBotFinding[] = [
+      makeFinding({ file: 'src/auth.ts', line: 10, body: 'identical', rootCommentId: 10 }),
+      makeFinding({ file: 'src/db.ts', line: 10, body: 'identical', rootCommentId: 11 }),
+    ];
+    const result = deduplicateFindings(findings);
+    expect(result).toHaveLength(2);
+  });
+
+  it('handles empty input', () => {
+    expect(deduplicateFindings([])).toEqual([]);
+  });
+
+  // ─── Output schema invariants ───────────────────────
+
+  it('leaves mergedWith undefined under strict-by-id semantics', () => {
+    // mergedWith was the fuzzy-merge audit field. Under strict-by-id
+    // it never gets populated; the field stays on the schema for
+    // backward-compat with downstream display consumers (per design
+    // doc Q1).
+    const findings: NormalizedBotFinding[] = [
+      makeFinding({ rootCommentId: 50 }),
+      makeFinding({ rootCommentId: 51 }),
+    ];
+    const result = deduplicateFindings(findings);
     for (const r of result) {
       expect(r.mergedWith).toBeUndefined();
     }
   });
 
-  it('populates mergedWith on the primary finding', () => {
+  it('prefixes dedupKey with `id:` for inline findings and `body:` for fallback findings', () => {
     const findings: NormalizedBotFinding[] = [
-      makeFinding({
-        tool: 'coderabbit',
-        file: 'src/auth.ts',
-        line: 10,
-        body: 'Credential leak risk in secret handling',
-      }),
-      makeFinding({
-        tool: 'gca',
-        file: 'src/auth.ts',
-        line: 11,
-        body: 'Secret credential leak detected here',
-      }),
-      makeFinding({
-        tool: 'unknown',
-        file: 'src/auth.ts',
-        line: 12,
-        body: 'Credential secret leak in this block',
-      }),
+      makeFinding({ file: 'src/auth.ts', body: 'inline', rootCommentId: 700 }),
+      makeFinding({ file: '(review body)', body: 'synthesized' }),
     ];
-
     const result = deduplicateFindings(findings);
-    expect(result).toHaveLength(1);
-    expect(result[0]!.tool).toBe('coderabbit'); // primary is the first one
-    expect(result[0]!.mergedWith).toHaveLength(2);
-    expect(result[0]!.dedupKey).toContain('merged:');
+    expect(result[0]!.dedupKey).toBe('id:700');
+    expect(result[1]!.dedupKey.startsWith('body:')).toBe(true);
+    expect(result[1]!.dedupKey).toContain('synthesized');
+  });
+
+  it('preserves input order (first-seen wins on collision)', () => {
+    const findings: NormalizedBotFinding[] = [
+      makeFinding({ tool: 'coderabbit', body: 'first', rootCommentId: 1 }),
+      makeFinding({ tool: 'gca', body: 'second', rootCommentId: 2 }),
+      makeFinding({ tool: 'coderabbit', body: 'third', rootCommentId: 3 }),
+    ];
+    const result = deduplicateFindings(findings);
+    expect(result.map((r) => r.body)).toEqual(['first', 'second', 'third']);
+  });
+
+  it('attaches triageCategory on every output finding', () => {
+    const findings: NormalizedBotFinding[] = [makeFinding({ rootCommentId: 1 })];
+    const result = deduplicateFindings(findings);
+    expect(result[0]!.triageCategory).toBeDefined();
   });
 });

--- a/packages/cli/src/parsers/triage-dedup.ts
+++ b/packages/cli/src/parsers/triage-dedup.ts
@@ -2,9 +2,6 @@ import type { NormalizedBotFinding } from './bot-review-parser.js';
 import { mapToTriageCategory } from './triage-severity-mapper.js';
 import type { CategorizedFinding } from './triage-types.js';
 
-const PROXIMITY_THRESHOLD = 3; // lines
-const KEYWORD_OVERLAP_THRESHOLD = 0.3; // 30% Jaccard similarity
-
 const STOPWORDS = new Set([
   'the',
   'a',
@@ -60,7 +57,13 @@ const STOPWORDS = new Set([
   'no',
 ]);
 
-/** Extract significant words from text (strip stopwords, lowercase) */
+/**
+ * Extract significant words from text (strip stopwords, lowercase).
+ *
+ * Retained as a public helper for downstream tooling (e.g., the deferred
+ * `--no-dedup` debug flag, ad-hoc analysis scripts) even though
+ * `deduplicateFindings` no longer uses it after mmnto-ai/totem#1666.
+ */
 export function extractKeywords(text: string): Set<string> {
   return new Set(
     text
@@ -71,7 +74,12 @@ export function extractKeywords(text: string): Set<string> {
   );
 }
 
-/** Jaccard similarity between two keyword sets */
+/**
+ * Jaccard similarity between two keyword sets.
+ *
+ * Retained alongside `extractKeywords` for the same reason — see that
+ * function's note.
+ */
 export function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
   if (a.size === 0 && b.size === 0) return 0;
   const intersection = new Set([...a].filter((x) => b.has(x)));
@@ -79,65 +87,68 @@ export function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
   return intersection.size / union.size;
 }
 
+/**
+ * Deduplicate bot findings using deterministic comment-id identity
+ * (mmnto-ai/totem#1666; strategy upstream-feedback item 024).
+ *
+ * Two findings with different `rootCommentId` are ALWAYS distinct, even
+ * when their bodies are byte-identical and they anchor at the same
+ * `(file, line)`. This forecloses the LC#80 R3 failure mode where six
+ * GCA findings on `compiled-rules.json:598` (each anchored at the rule-
+ * section start line) collapsed into one entry under the prior
+ * proximity + Jaccard fuzzy-merge semantics.
+ *
+ * Cross-bot independence is now a feature, not a bug: when CR and GCA
+ * independently flag the same `(file, line)`, both findings surface so
+ * the consumer can read the cross-bot agreement as elevated-confidence
+ * signal (per the strategy bot-nuance pattern). Today's previous
+ * cross-bot merge silently masked exactly that signal.
+ *
+ * Synthesized review-body findings (`file === '(review body)'`, no
+ * `rootCommentId`) fall back to a `(file, body)` Map key. Body-hash
+ * collisions are negligible at this scale: the input space is per-
+ * review-body line items only, and identical-body findings on that
+ * pseudo-path are themselves duplicates.
+ *
+ * The `mergedWith` field on the output is left undefined under strict-
+ * by-id semantics. Keeping the field on the schema (rather than
+ * removing it) avoids forcing downstream display consumers into a
+ * coordinated update; readers naturally skip the empty/undefined
+ * surface.
+ */
 export function deduplicateFindings(findings: NormalizedBotFinding[]): CategorizedFinding[] {
-  // First, categorize all findings
-  const categorized: CategorizedFinding[] = findings.map((f, i) => ({
-    ...f,
-    triageCategory: mapToTriageCategory(f),
-    dedupKey: `${f.file}:${f.line ?? 'file'}:${i}`,
-  }));
+  const result: CategorizedFinding[] = [];
+  const seenIds = new Set<number>();
+  const seenBodyKeys = new Set<string>();
 
-  const merged: CategorizedFinding[] = [];
-  const consumed = new Set<number>();
-
-  for (let i = 0; i < categorized.length; i++) {
-    if (consumed.has(i)) continue;
-
-    const primary = categorized[i]!;
-    const primaryKw = extractKeywords(primary.body);
-    const group: NormalizedBotFinding[] = [];
-
-    for (let j = i + 1; j < categorized.length; j++) {
-      if (consumed.has(j)) continue;
-      const candidate = categorized[j]!;
-
-      // Must be same category
-      if (candidate.triageCategory !== primary.triageCategory) continue;
-
-      // Must be same file
-      if (candidate.file !== primary.file) continue;
-
-      // Check line proximity
-      if (primary.line != null && candidate.line != null) {
-        if (Math.abs(primary.line - candidate.line) > PROXIMITY_THRESHOLD) continue;
-      } else if (primary.line == null && candidate.line == null) {
-        // Both file-level — require high similarity to merge
-        const sim = jaccardSimilarity(primaryKw, extractKeywords(candidate.body));
-        if (sim < 0.8) continue;
-      } else {
-        // One has a line, one doesn't — require high similarity
-        const sim = jaccardSimilarity(primaryKw, extractKeywords(candidate.body));
-        if (sim < 0.8) continue;
-      }
-
-      // Check keyword overlap
-      const candidateKw = extractKeywords(candidate.body);
-      const similarity = jaccardSimilarity(primaryKw, candidateKw);
-      if (similarity < KEYWORD_OVERLAP_THRESHOLD) continue;
-
-      // Merge
-      group.push(candidate);
-      consumed.add(j);
+  for (const finding of findings) {
+    let dedupKey: string;
+    if (finding.rootCommentId !== undefined) {
+      // Strict-by-id path: GitHub-assigned comment IDs are unique per
+      // inline review comment. Two findings with different IDs are always
+      // distinct, regardless of file/line/body similarity or which bot
+      // emitted them.
+      if (seenIds.has(finding.rootCommentId)) continue;
+      seenIds.add(finding.rootCommentId);
+      dedupKey = `id:${finding.rootCommentId}`;
+    } else {
+      // Body-hash fallback for synthesized findings without an upstream
+      // comment ID (today: extractReviewBodyFindings produces these with
+      // `file: '(review body)'`). Map key is the body string itself —
+      // bounded length, no crypto cost, V8 handles long string keys
+      // natively.
+      const key = `${finding.file}|${finding.body}`;
+      if (seenBodyKeys.has(key)) continue;
+      seenBodyKeys.add(key);
+      dedupKey = `body:${finding.file}|${finding.body}`;
     }
 
-    if (group.length > 0) {
-      primary.mergedWith = group;
-      // Update dedupKey to reflect the merge
-      primary.dedupKey = `merged:${primary.file}:${primary.line ?? 'file'}:${primary.triageCategory}`;
-    }
-
-    merged.push(primary);
+    result.push({
+      ...finding,
+      triageCategory: mapToTriageCategory(finding),
+      dedupKey,
+    });
   }
 
-  return merged;
+  return result;
 }

--- a/packages/cli/src/parsers/triage-dedup.ts
+++ b/packages/cli/src/parsers/triage-dedup.ts
@@ -134,13 +134,14 @@ export function deduplicateFindings(findings: NormalizedBotFinding[]): Categoriz
     } else {
       // Body-hash fallback for synthesized findings without an upstream
       // comment ID (today: extractReviewBodyFindings produces these with
-      // `file: '(review body)'`). Map key is the body string itself —
-      // bounded length, no crypto cost, V8 handles long string keys
-      // natively.
-      const key = `${finding.file}|${finding.body}`;
+      // `file: '(review body)'`). Map key includes `tool` so two
+      // synthesized findings from different bots with identical bodies
+      // stay distinct — preserves the cross-bot-independence symmetry
+      // the strict-by-id path provides for inline findings.
+      const key = `${finding.tool}|${finding.file}|${finding.body}`;
       if (seenBodyKeys.has(key)) continue;
       seenBodyKeys.add(key);
-      dedupKey = `body:${finding.file}|${finding.body}`;
+      dedupKey = `body:${finding.tool}|${finding.file}|${finding.body}`;
     }
 
     result.push({


### PR DESCRIPTION
## Summary

Strategy upstream-feedback item 024 substrate. The previous `deduplicateFindings` used a fuzzy `(file, line, body keyword Jaccard ≥ 0.3, line proximity ≤ 3)` merge. On `mmnto-ai/liquid-city#80` R3, GCA emitted six distinct high-severity findings all anchored at `compiled-rules.json:598` (the rule-section start line — GitHub's inline-comment API requires a `line` field, and GCA chose the section header for all six). The fuzzy merge collapsed five of them into one entry, hiding ~10 minutes of triage-agent recovery work behind a silent miss.

This PR replaces the fuzzy merge with deterministic `rootCommentId`-keyed dedup + body-hash fallback for synthesized findings.

## Changes

- **Strict-by-id dedup.** `deduplicateFindings` now uses `rootCommentId` as the primary dedup primitive. Two findings with different `rootCommentId` are ALWAYS distinct, even when bodies are byte-identical and they share the same `(file, line)` anchor.
- **Body-hash fallback** for synthesized review-body findings (`extractReviewBodyFindings` emits these with `file === '(review body)'` and no `rootCommentId`). Map key is `(file, body)` directly — bounded length, no crypto cost, V8 handles long string keys natively (per design doc Q3 rec).
- **Cross-bot independence is now a feature, not a bug.** When CR and GCA independently flag the same `(file, line)`, both findings surface. The triage agent reads the convergence as the elevated-confidence signal documented in the strategy bot-nuance file's "Cross-bot agreement = elevated finding confidence" pattern. Today's fuzzy merge silently masked exactly that signal — opposite of the desired UX.
- **`mergedWith` field stays on the schema, undefined in output** (per design doc Q1 rec). Backward-compat shim so downstream display consumers don't need a coordinated rewrite.
- **`extractKeywords` and `jaccardSimilarity` helpers retained as exports** for the deferred `--no-dedup` debug flag (#TBD) and ad-hoc analysis scripts. No longer called by core dedup logic.
- **Submodule bump** `.strategy` `8f79b82` → `f33823b` picks up strategy PR #144 roadmap refresh.

## Why now — closes the upstream-feedback batch

This PR completes every item from `mmnto-ai/totem-strategy#133`:

- ✅ Item 020 → #1663 (`applies-to:` lesson frontmatter)
- ✅ Item 021 → #1664 (`self-suppressing-pattern` reasonCode)
- ✅ Item 022 → `mmnto-ai/totem-strategy#136` (Proposal 248 Bot Operations Packs)
- ✅ Item 023 → #1665 (source-Scope override)
- ✅ Item 024 → #1666 (this PR)

Five-for-five.

## Out of scope (deferred follow-ups at merge)

- **`--no-dedup` / `--raw` flag** for `triage-pr` to bypass dedup entirely. Tier-3 UX.
- **Summary-line dedup-count surface** ("dedup collapsed N findings — see --raw"). Tier-3 UX, depends on the flag.
- **`triage-pr --help` doc** explaining the dedup primitive. Tier-3 docs.

## Test plan

- [x] `pnpm --filter @mmnto/cli test` — 1,833 / 1,833 pass.
- [x] `pnpm --filter @mmnto/cli test -- --run triage-dedup` — 20 / 20 pass (6 helper tests + 14 dedup tests, mix of rewritten and new).
- [x] **LC#80 R3 exhibit pinned as regression test:** 6 distinct rootCommentIds on `compiled-rules.json:598` produce 6 entries (was: 1 after fuzzy merge).
- [x] Strict-by-id distinctness with byte-identical bodies.
- [x] API duplicate (same rootCommentId twice) drops the second; first-seen wins.
- [x] Cross-bot independence preserved (CR + GCA distinct ids → both kept).
- [x] Body-hash fallback dedupes review-body findings with identical `(file, body)`.
- [x] Body-hash fallback keeps review-body findings with distinct bodies separate.
- [x] No-id × has-id mixed case: synthesized + inline with same body → both kept (different key spaces).
- [x] `mergedWith` undefined for all output.
- [x] `dedupKey` prefix verified (`id:` for inline, `body:` for fallback).
- [x] Input order preserved in output.
- [x] `pnpm exec totem lint` — PASS, 0 errors.
- [x] `pnpm exec totem review` — PASS, no findings.
- [x] `pnpm exec totem verify-manifest` — PASS.

Closes #1666

🤖 Generated with [Claude Code](https://claude.com/claude-code)