### PR TITLE
fix(core): enable ast-grep verification in verifyRuleExamples (mmnto-ai/totem#1699)

### DIFF
--- a/.changeset/1699-ast-grep-verify-rule-examples.md
+++ b/.changeset/1699-ast-grep-verify-rule-examples.md
@@ -1,0 +1,17 @@
+---
+'@mmnto/totem': patch
+'@mmnto/cli': patch
+'@mmnto/mcp': patch
+---
+
+fix(core): enable ast-grep verification in `verifyRuleExamples` (mmnto-ai/totem#1699)
+
+AI Studio corpus audit ([mmnto-ai/totem-strategy#150](https://github.com/mmnto-ai/totem-strategy/pull/150), B-Q4.1 / Q5 P2-1) finding. `verifyRuleExamples` short-circuited every non-regex rule via `if (rule.engine !== 'regex') return null;`, so ast-grep rules were never verified against their inline `**Example Hit:**` / `**Example Miss:**` blocks during compilation or via `totem rule test`. The downstream tester (`packages/core/src/rule-tester.ts`) already supports ast-grep through its `isAstGrep` branch — the entry point upstream of it was dropping the rule before the existing path could run.
+
+Real cases were slipping through this gap. Archived rule `e2341ed9229f9a60` shipped with pattern `new $ERROR($$$ARGS)`, matching every error class instantiation; the smoke-gate's bidirectional check (mmnto-ai/totem#1591) would have caught it at compile time if `verifyRuleExamples` had not blocked the engine.
+
+- **Guard narrowed.** Changed `if (rule.engine !== 'regex') return null;` to `if (rule.engine !== 'regex' && rule.engine !== 'ast-grep') return null;`. Tree-sitter (`engine: 'ast'`) stays skipped because `testRule`'s non-`ast-grep` branch routes through `applyRulesToAdditions`, which is the regex pipeline and does not handle S-expression queries.
+- **Tests.** Added two regression cases pinning the new behavior: ast-grep PASS on a matching badExample / non-matching goodExample, and ast-grep FAIL on the over-broad `new $ERROR($$$ARGS)` shape (the `e2341ed9229f9a60` exhibit class). The pre-existing test that asserted ast-grep returns null is rewritten to cover the Tree-sitter `'ast'` engine, which still legitimately short-circuits.
+- **No CLI surface change required.** `totem rule test <ast-grep-hash>` now returns PASS / FAIL against inline examples instead of warning "Engine 'ast-grep' does not support inline example testing." The compile-pipeline smoke gate (`compile-smoke-gate.ts`) inherits ast-grep coverage through the same entry point.
+
+Closes mmnto-ai/totem#1699.

--- a/packages/core/src/compile-lesson.test.ts
+++ b/packages/core/src/compile-lesson.test.ts
@@ -1791,18 +1791,55 @@ describe('verifyRuleExamples', () => {
     expect(result).toBeNull();
   });
 
-  it('returns null for non-regex engine', () => {
+  it('returns null for the Tree-sitter `ast` engine (testRule cannot run S-expression queries)', () => {
     const rule: CompiledRule = {
       lessonHash: 'h2',
       lessonHeading: 'test',
-      message: 'ast rule',
-      engine: 'ast-grep',
-      astGrepPattern: 'console.log($A)',
+      message: 'tree-sitter rule',
+      engine: 'ast',
+      astQuery: '(call_expression (identifier) @console)',
       pattern: '',
       compiledAt: new Date().toISOString(),
     };
     const body = '**Example Hit:** console.log(x)';
     expect(verifyRuleExamples(rule, body)).toBeNull();
+  });
+
+  it('runs verification for ast-grep engine and PASSes on a matching badExample (mmnto-ai/totem#1699)', () => {
+    const rule: CompiledRule = {
+      lessonHash: 'h2-astgrep-pass',
+      lessonHeading: 'test',
+      message: 'no console.log via ast-grep',
+      engine: 'ast-grep',
+      astGrepPattern: 'console.log($A)',
+      pattern: '',
+      compiledAt: new Date().toISOString(),
+    };
+    const body = '**Example Hit:** console.log("test")\n**Example Miss:** logger.info("test")';
+    const result = verifyRuleExamples(rule, body);
+    expect(result).not.toBeNull();
+    expect(result!.passed).toBe(true);
+  });
+
+  it('runs verification for ast-grep engine and FAILs when the pattern also matches the goodExample (mmnto-ai/totem#1699)', () => {
+    // Over-broad pattern: matches every `new $ERROR($$$ARGS)` — the kind of
+    // shape that shipped pre-#1699 because verifyRuleExamples short-circuited
+    // ast-grep. With the guard narrowed, this rule is caught.
+    const rule: CompiledRule = {
+      lessonHash: 'h2-astgrep-overbroad',
+      lessonHeading: 'test',
+      message: 'over-broad ast-grep',
+      engine: 'ast-grep',
+      astGrepPattern: 'new $ERROR($$$ARGS)',
+      pattern: '',
+      compiledAt: new Date().toISOString(),
+    };
+    const body =
+      '**Example Hit:** const err = new TotemError("boom")\n**Example Miss:** const widget = new Widget(opts)';
+    const result = verifyRuleExamples(rule, body);
+    expect(result).not.toBeNull();
+    expect(result!.passed).toBe(false);
+    expect(result!.falsePositives.length).toBeGreaterThan(0);
   });
 
   it('passes when hits match and misses do not', () => {

--- a/packages/core/src/compile-lesson.ts
+++ b/packages/core/src/compile-lesson.ts
@@ -696,13 +696,17 @@ export function deriveVirtualFilePath(rule: CompiledRule): string {
 
 /**
  * Verify a compiled rule against inline Example Hit/Miss lines.
- * Returns null if no examples exist or engine is not regex.
+ * Returns null if no examples exist or engine is `'ast'` (Tree-sitter).
+ * Tree-sitter rules are skipped because `testRule`'s non-`ast-grep` branch
+ * runs the regex pipeline (`applyRulesToAdditions`), which does not handle
+ * S-expression queries. Regex and ast-grep rules both flow through to
+ * `testRule`. mmnto-ai/totem#1699.
  * Returns RuleTestResult if verification was run.
  */
 export function verifyRuleExamples(rule: CompiledRule, body: string): RuleTestResult | null {
   const examples = extractRuleExamples(body);
   if (!examples) return null;
-  if (rule.engine !== 'regex') return null;
+  if (rule.engine !== 'regex' && rule.engine !== 'ast-grep') return null;
 
   const fixture = {
     ruleHash: rule.lessonHash,


### PR DESCRIPTION
## Summary
- Narrows the engine guard in `verifyRuleExamples` from `!== 'regex'` to `!== 'regex' && !== 'ast-grep'`, enabling ast-grep rules to run through the existing `testRule` verification path.
- `testRule` already supported ast-grep via its `isAstGrep` branch (`packages/core/src/rule-tester.ts`); the upstream guard was the only thing blocking it.
- Tree-sitter (`engine: 'ast'`) stays skipped because `testRule`'s non-ast-grep else branch routes through `applyRulesToAdditions` (the regex pipeline), which does not handle S-expression queries.
- Two new regression tests + one rewritten test (the old "non-regex returns null" case now covers Tree-sitter only, where the short-circuit is still legitimate).
- Audit citation: AI Studio corpus audit ([mmnto-ai/totem-strategy#150](https://github.com/mmnto-ai/totem-strategy/pull/150), B-Q4.1 / Q5 P2-1). Real-world impact: archived rule `e2341ed9229f9a60` shipped with pattern `new $ERROR($$$ARGS)` matching every error class instantiation; the bidirectional smoke gate (mmnto-ai/totem#1591) would have caught it at compile time if `verifyRuleExamples` had not blocked the engine.

Closes mmnto-ai/totem#1699.

## Test plan
- [x] `pnpm --filter @mmnto/totem test` — 1406 pass (1404 baseline + 2 new ast-grep cases)
- [x] `pnpm --filter @mmnto/cli test` — 1834 pass (no downstream regression)
- [x] `pnpm run format` clean
- [x] `pnpm exec totem lint` 0 errors (3 warnings consistent with line 1836's pre-existing `toBeGreaterThan(0)` convention in the same describe block)
- [x] `pnpm exec totem review` PASS, no findings
- [x] `pnpm exec totem verify-manifest` PASS
- [x] Pre-push hook all green

## Out of scope
- The other 10 audit-derived issues (mmnto-ai/totem#1695-#1698, mmnto-ai/totem#1700-#1705) — sequenced separately.
- The 12th cross-cutting `totem memory audit` coordination ticket — gated on the strategy-side issue landing first.
- Retroactive sweep of existing ast-grep rules to surface latent over-matching the gate would now catch — separate retriage chore once this lands.