### PR TITLE
feat(cli): review --override stamps push-gate cache + --diff <range> flag

### DIFF
--- a/.changeset/1716-1717-review-override-and-diff-flag.md
+++ b/.changeset/1716-1717-review-override-and-diff-flag.md
@@ -1,0 +1,11 @@
+---
+'@mmnto/totem': patch
+'@mmnto/cli': patch
+'@mmnto/mcp': patch
+'@totem/pack-agent-security': patch
+---
+
+`totem review` operator-dogfood bundle: override stamps the push-gate cache, plus an explicit `--diff <ref-range>` flag.
+
+- **mmnto-ai/totem#1716** — `totem review --override <reason>` now writes `.totem/cache/.reviewed-content-hash` after recording the override, so the push-gate hook unblocks immediately. Closes the tribal-knowledge `git reset --soft HEAD~1 && totem review --staged` workaround used since the override flag was added. New `recordShieldOverride` helper bundles the trap-ledger write and content-hash stamp into a single call site exercised by both the V2 structured-verdict path and the V1 fallback.
+- **mmnto-ai/totem#1717** — adds `totem review --diff <ref-range>` for explicit diff scope (e.g. `--diff HEAD^..HEAD`, `--diff main...feature`). Bypasses the implicit working-tree → staged → branch-vs-base fallback. The chosen diff source is logged to stderr (`Diff source: explicit-range`, `staged`, `uncommitted`, or `branch-vs-base`) so the operator's mental model matches the actual git invocation. Diffs exceeding 50,000 chars now surface a fail-loud truncation warning at the resolution layer — before the LLM call — so the operator can re-run with a narrower range instead of paying for a degraded review. The flag is documented in `--help`'s "Diff resolution" section. New `getGitDiffRange(cwd, range)` core helper rejects flag-injection ranges (leading `-`) and empty values; arg-array `safeExec` invocation prevents shell-metachar interpretation.

--- a/.totem/specs/1717.md
+++ b/.totem/specs/1717.md
@@ -1,0 +1,110 @@
+# Spec — totem#1717 totem review --diff <ref-range>
+
+_Generated 2026-04-28; gemini-3.1-pro-preview spec captured + design doc appended._
+
+## Problem Statement
+
+`totem review` falls back to a branch-vs-base diff when uncommitted is empty, hits a 50KB truncation cliff inside the prompt assembler, and emits "diff is truncated" CRITICALs that look indistinguishable from genuine LLM-quality issues. The fallback path is implicit, has no operator-visible signal saying "I'm using fallback X," and the truncation is silent at the resolution layer (only the prompt assembler knows it truncated).
+
+## Acceptance criteria (from issue body)
+
+- Add `--diff <ref-range>` flag that passes the exact range to `git diff`, bypassing working-tree inference
+- Document fallback resolution rules in `--help`
+- Log fallback resolution to stderr so operator's mental model matches CLI execution path
+- Flag truncation explicitly when diff exceeds threshold
+
+## Existing surface
+
+- `packages/cli/src/git.ts:112` — `getDiffForReview` is the centralized resolver; already does staged/all → branch-fallback. Already logs fallback via `log.dim` (which goes to stderr through the UI channel).
+- `packages/cli/src/commands/shield.ts:490` — `ShieldOptions` interface; `--staged` already exists.
+- `packages/cli/src/commands/shield-templates.ts:39` — `MAX_DIFF_CHARS = 50_000` (character count, not bytes).
+- `packages/cli/src/commands/shield.ts:147,212,537` — three prompt-assembler sites where truncation happens silently.
+- `packages/core/src/sys/git.ts` — `getGitBranchDiff(cwd, base)` is the existing core helper for ref-range diffs (uses `safeExec` with `${ref}...HEAD`).
+
+## Knowledge-base context
+
+- Lesson 2026-03-03T01:52:20.000Z: branch-diff fallback is load-bearing — must throw not silently return on detection failure.
+- Lesson `lesson-76228ccb`: filter lockfiles before source selection — already handled by `filterDiffByPatterns`.
+- ADR-083 Actor-Aware Enforcement: the diff is the input to the content-hash review; explicit ranges are still subject to the same enforcement.
+
+## Implementation Design
+
+### Scope (2 sentences)
+
+Adds `--diff <ref-range>` flag to `totem review` that bypasses the implicit working-tree → staged → branch-vs-base fallback chain by executing the exact ref range via git, surfaces resolution + truncation signals to stderr, and documents the fallback chain in `--help`. Will NOT change the truncation threshold itself (`MAX_DIFF_CHARS = 50_000` stays), will NOT add a `--no-truncate` escape hatch (separate ticket if requested), will NOT alter the structural / standard mode dispatch.
+
+### Data model deltas
+
+**`ShieldOptions.diff?: string`** in `packages/cli/src/commands/shield.ts:490`.
+
+- **Holds:** explicit ref range as user-supplied string (e.g., `HEAD^..HEAD`, `main...feature`).
+- **Writer:** Commander option parser at command-registration time.
+- **Reader:** `shieldCommand` → `getDiffForReview` (passed through).
+- **Invariants:** optional; when present, must not start with `-` (flag injection guard); `safeExec` arg-array form prevents shell metachar injection.
+
+**`DiffForReviewOptions.diff?: string`** in `packages/cli/src/git.ts:90`.
+
+- **Holds:** same value, plumbed from `ShieldOptions.diff`.
+- **Writer:** `shieldCommand` callsite.
+- **Reader:** `getDiffForReview`.
+- **Invariants:** same as above; checked at the `getDiffForReview` entry point.
+
+**`DiffSource` discriminated string** (NEW, internal — not exported on `DiffForReviewResult`):
+
+- Values: `'explicit-range' | 'staged' | 'uncommitted' | 'branch-vs-base'`.
+- **Writer:** `getDiffForReview` — set as the resolution path is chosen.
+- **Reader:** stderr logging within `getDiffForReview`; truncation warning emission.
+- **Invariant:** exactly one source per call; bounded by the four enum values.
+
+No new state containers. No persistent state. No reserved-key sentinels.
+
+### State lifecycle
+
+All new state is per-invocation (per-CLI-call). Created at flag-parsing time, lives for the duration of the `shieldCommand` call, destroyed at process exit. No state crosses lifecycle boundaries.
+
+### Failure modes
+
+| Failure                                                       | Category | Agent-facing surface                                                                                                   | Recovery                                                                  |
+| ------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `--diff` value starts with `-`                                | runtime  | hard error: `TotemConfigError` with `CONFIG_INVALID` code                                                              | user supplies a non-flag-prefixed range                                   |
+| `--diff` range invalid (git error)                            | runtime  | hard error: re-throw of `safeExec` failure with context                                                                | user fixes range or fetches missing refs                                  |
+| `--diff` range produces empty output                          | runtime  | hard error: "explicit range produced no diff — nothing to review"                                                      | user supplies a range with actual changes                                 |
+| `getGitBranchDiff` already throws on missing base — preserved | runtime  | hard error: `TotemGitError` (existing)                                                                                 | user runs `git fetch origin <base>`                                       |
+| Diff exceeds `MAX_DIFF_CHARS`                                 | runtime  | warning to stderr: `Diff exceeds 50000 chars; LLM review will see truncated content. Consider --diff <smaller-range>.` | user retries with narrower range, OR proceeds knowing truncation happened |
+| Resolution path unknown after fallback chain                  | runtime  | warning then null-return (existing behavior preserved)                                                                 | nothing to review — exit 0                                                |
+
+No silent degradations. The truncation warning is a fail-loud upgrade of the previously-silent behavior — Tenet 4 satisfied.
+
+### Invariants to lock in via tests
+
+- `--diff` value beginning with `-` is rejected before any git execution
+- `--diff` value beginning with `--` is rejected
+- Explicit `--diff` skips the staged/uncommitted/branch-fallback chain entirely (only one git invocation, and it's the explicit range)
+- Explicit `--diff` still applies `filterDiffByPatterns` (ignore-pattern filter is global hygiene, not source-specific)
+- Resolution path is logged exactly once per call, to stderr, with the chosen source enum string
+- Truncation warning fires when and only when `diff.length > MAX_DIFF_CHARS` (parity with the prompt-assembler truncation site)
+- Truncation warning routes to stderr, never stdout (preserve `--json` mode's clean stdout)
+- Explicit `--diff` that resolves to an empty git output throws (not falls back) — explicit means explicit
+- `--help` output includes the fallback resolution chain explicitly
+
+### Open questions
+
+- **Q1.** Where does the explicit-range execution live: new `getGitDiffRange(cwd, range)` core helper, or inline `safeExec('git', ['diff', '--', range])` in `getDiffForReview`?
+  - **Options:** (a) new core helper for symmetry with `getGitBranchDiff`; (b) inline in cli/git.ts since this is a CLI-specific concern.
+  - **Recommendation:** **(a) — new `getGitDiffRange` core helper.** Matches the existing pattern, gets `safeExec` + `GIT_COMMAND_TIMEOUT_MS` + `GIT_DIFF_MAX_BUFFER` for free, and stays consumable by future MCP / API surfaces.
+
+- **Q2.** Should `--diff` apply `filterDiffByPatterns`?
+  - **Options:** (a) yes — ignore patterns are hygiene that always applies; (b) no — explicit means explicit, ignore patterns mute the user's chosen scope.
+  - **Recommendation:** **(a) — yes.** Ignore patterns are repo-policy (lockfiles, generated files, vendor/), not diff-source policy. Muting them on `--diff` would mean the user has to re-add `:!package-lock.json` style exclusions to every `--diff` invocation. The explicit-range escape is for diff _source_, not for ignore _scope_ — there's no use case I can see for "I want to review the lockfile churn explicitly."
+
+- **Q3.** Truncation warning emission point: at resolution (`getDiffForReview`) or at prompt assembly (3 sites in `shield.ts`)?
+  - **Options:** (a) emit once at resolution — operator sees it before any LLM call cost is incurred; (b) emit at each prompt assembly site — closer to the truncation reality.
+  - **Recommendation:** **(a) — emit once at resolution.** The threshold is fixed (`MAX_DIFF_CHARS`), the resolution layer knows the diff size, and a pre-LLM-call warning gives the operator a chance to abort and supply a narrower `--diff`. Three emission points = three places to drift if the threshold changes.
+
+- **Q4.** Flag-injection guard depth: reject leading `-`, or also strip/reject shell metacharacters?
+  - **Options:** (a) reject leading `-` only — `safeExec` arg-array form already prevents shell metachar interpretation; (b) also reject `;|&$\`` to be paranoid.
+  - **Recommendation:** **(a) — leading `-` only.** `safeExec` uses `cross-spawn.sync` with explicit arg arrays — shell metacharacters in arg values aren't interpreted. The leading-`-` check is the only real flag-injection vector. Adding a metachar denylist is defense-in-depth that just trips on legitimate ranges containing `^` / `$`. Users can still write `git diff` syntax like `HEAD^^..HEAD` and `@{u}..HEAD`, which would fail an over-strict denylist.
+
+- **Q5.** Threshold measurement: stay with `diff.length` (char count, parity with `MAX_DIFF_CHARS`) or move to `Buffer.byteLength` per gemini-spec?
+  - **Options:** (a) stay with char count — internal alignment with the truncation site; (b) move to byte length — more accurate for token-budget reasoning.
+  - **Recommendation:** **(a) — stay with char count.** The actual truncation site uses `diff.length`, so the warning predicate must use the same measurement or it'll fire spuriously / silently miss. If we want byte-length elsewhere, that's a separate refactor (`MAX_DIFF_CHARS` → `MAX_DIFF_BYTES`) and not in scope for this ticket.

--- a/packages/cli/src/commands/shield.test.ts
+++ b/packages/cli/src/commands/shield.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -27,6 +28,7 @@ import {
   formatVerdictForDisplay,
   MAX_DIFF_CHARS,
   parseVerdict,
+  recordShieldOverride,
   SHIELD_LEARN_SYSTEM_PROMPT,
   STRUCTURAL_SYSTEM_PROMPT,
   writeReviewedContentHash,
@@ -407,6 +409,86 @@ describe('writeReviewedContentHash', () => {
       expect(content).toMatch(/^[a-f0-9]{64}$/);
     },
   );
+});
+
+// ─── recordShieldOverride (#1716) ─────────────────────
+
+describe('recordShieldOverride (#1716)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-override-stamp-'));
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  function gitInit(cwd: string): void {
+    execFileSync('git', ['init', '-q'], { cwd, stdio: 'pipe' });
+    execFileSync('git', ['config', 'user.email', 'test@totem.local'], { cwd, stdio: 'pipe' });
+    execFileSync('git', ['config', 'user.name', 'totem-test'], { cwd, stdio: 'pipe' });
+    execFileSync('git', ['config', 'commit.gpgsign', 'false'], { cwd, stdio: 'pipe' });
+  }
+
+  function gitCommitAll(cwd: string): void {
+    execFileSync('git', ['add', '-A'], { cwd, stdio: 'pipe' });
+    execFileSync('git', ['commit', '-q', '-m', 'fixture'], { cwd, stdio: 'pipe' });
+  }
+
+  it(
+    'writes the override event to the trap ledger and stamps reviewed-content-hash',
+    { timeout: 15_000 },
+    async () => {
+      gitInit(tmpDir);
+      fs.writeFileSync(path.join(tmpDir, 'index.ts'), 'export const x = 1;\n');
+      gitCommitAll(tmpDir);
+
+      await recordShieldOverride({
+        override: 'False positive: signature is type-safe',
+        cwd: tmpDir,
+        totemDir: '.totem',
+      });
+
+      const eventsPath = path.join(tmpDir, '.totem', 'ledger', 'events.ndjson');
+      expect(fs.existsSync(eventsPath)).toBe(true);
+      const events = fs
+        .readFileSync(eventsPath, 'utf-8')
+        .trim()
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => JSON.parse(line));
+      expect(events).toHaveLength(1);
+      expect(events[0].type).toBe('override');
+      expect(events[0].ruleId).toBe('shield-override');
+      expect(events[0].justification).toBe('False positive: signature is type-safe');
+      expect(events[0].source).toBe('shield');
+
+      const flagPath = path.join(tmpDir, '.totem', 'cache', '.reviewed-content-hash');
+      expect(fs.existsSync(flagPath)).toBe(true);
+      expect(fs.readFileSync(flagPath, 'utf-8').trim()).toMatch(/^[a-f0-9]{64}$/);
+    },
+  );
+
+  it('honors configRoot when stamping the cache and writing the ledger', async () => {
+    gitInit(tmpDir);
+    const sub = path.join(tmpDir, 'subproject');
+    fs.mkdirSync(sub);
+    fs.writeFileSync(path.join(sub, 'index.ts'), 'export const y = 2;\n');
+    gitCommitAll(tmpDir);
+
+    await recordShieldOverride({
+      override: 'Documented exemption — see ADR-083',
+      cwd: sub,
+      totemDir: '.totem',
+      configRoot: tmpDir,
+    });
+
+    expect(fs.existsSync(path.join(tmpDir, '.totem', 'ledger', 'events.ndjson'))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, '.totem', 'cache', '.reviewed-content-hash'))).toBe(
+      true,
+    );
+  });
 });
 
 // ─── extractStructuredVerdict ─────────────────────────

--- a/packages/cli/src/commands/shield.ts
+++ b/packages/cli/src/commands/shield.ts
@@ -483,6 +483,46 @@ export async function writeReviewedContentHash(
   }
 }
 
+/**
+ * Record a shield override: append the override event to the Trap Ledger
+ * AND stamp the reviewed-content-hash so the push-gate hook unblocks.
+ *
+ * mmnto-ai/totem#1716: prior to this helper the override branch only wrote the ledger
+ * entry; the missing stamp left the contributor stuck behind the push-gate
+ * with a tribal-knowledge `git reset --soft HEAD~1 && totem review --staged`
+ * workaround. Override is a legitimate completion path (with logged
+ * justification) and must produce the same cache state as a passing review.
+ */
+export async function recordShieldOverride(params: {
+  override: string;
+  cwd: string;
+  totemDir: string;
+  configRoot?: string;
+  sourceExtensions?: readonly string[];
+}): Promise<void> {
+  const path = await import('node:path');
+  const { appendLedgerEvent } = await import('@mmnto/totem');
+  const resolvedTotemDir = path.join(params.configRoot ?? params.cwd, params.totemDir);
+  appendLedgerEvent(
+    resolvedTotemDir,
+    {
+      timestamp: new Date().toISOString(),
+      type: 'override',
+      ruleId: 'shield-override',
+      file: '(shield)',
+      justification: params.override,
+      source: 'shield',
+    },
+    (msg) => log.dim(DISPLAY_TAG, msg),
+  );
+  await writeReviewedContentHash(
+    params.cwd,
+    params.totemDir,
+    params.configRoot,
+    params.sourceExtensions,
+  );
+}
+
 // ─── Main command ───────────────────────────────────────
 
 export type ShieldFormat = 'text' | 'sarif' | 'json';
@@ -493,6 +533,8 @@ export interface ShieldOptions {
   model?: string;
   fresh?: boolean;
   staged?: boolean;
+  /** Explicit ref range for `git diff` (mmnto-ai/totem#1717). Bypasses implicit fallback chain. */
+  diff?: string;
   mode?: 'standard' | 'structural';
   learn?: boolean;
   yes?: boolean;
@@ -820,8 +862,6 @@ async function handleVerdictResult(
         config.review.sourceExtensions,
       );
     } else if (options.override) {
-      const { appendLedgerEvent } = await import('@mmnto/totem');
-
       const criticalFindings = filtered.filter((f) => f.severity === 'CRITICAL');
 
       log.warn(DISPLAY_TAG, `SHIELD OVERRIDE APPLIED: ${options.override}`);
@@ -829,24 +869,20 @@ async function handleVerdictResult(
         log.warn(DISPLAY_TAG, `  [overridden] ${finding.message}`);
       }
 
-      appendLedgerEvent(
-        resolvedTotemDir,
-        {
-          timestamp: new Date().toISOString(),
-          type: 'override',
-          ruleId: 'shield-override',
-          file: '(shield)',
-          justification: options.override,
-          source: 'shield',
-        },
-        (msg) => log.dim(DISPLAY_TAG, msg),
-      );
+      await recordShieldOverride({
+        override: options.override,
+        cwd,
+        totemDir: config.totemDir,
+        configRoot,
+        sourceExtensions: config.review.sourceExtensions,
+      });
 
       // Track overridden findings for exemption engine (only non-exempted findings)
       const { readLocalExemptions, writeLocalExemptions } =
         await import('../exemptions/exemption-store.js');
       const { trackFalsePositives } = await import('../exemptions/exemption-engine.js');
       const { PROMOTION_THRESHOLD } = await import('../exemptions/exemption-schema.js');
+      const { appendLedgerEvent } = await import('@mmnto/totem');
 
       const localExemptions = readLocalExemptions(cacheDir, (msg) => log.dim(DISPLAY_TAG, msg));
       const tracked = trackFalsePositives(criticalFindings, 'shield', localExemptions, shared);
@@ -910,24 +946,15 @@ async function handleVerdictResult(
         config.review.sourceExtensions,
       );
     } else if (options.override) {
-      const { appendLedgerEvent } = await import('@mmnto/totem');
-      const pathMod = await import('node:path');
-      const resolvedTotemDir = pathMod.join(configRoot ?? cwd, config.totemDir);
-
       log.warn(DISPLAY_TAG, `SHIELD OVERRIDE APPLIED: ${options.override}`);
 
-      appendLedgerEvent(
-        resolvedTotemDir,
-        {
-          timestamp: new Date().toISOString(),
-          type: 'override',
-          ruleId: 'shield-override',
-          file: '(shield)',
-          justification: options.override,
-          source: 'shield',
-        },
-        (msg) => log.dim(DISPLAY_TAG, msg),
-      );
+      await recordShieldOverride({
+        override: options.override,
+        cwd,
+        totemDir: config.totemDir,
+        configRoot,
+        sourceExtensions: config.review.sourceExtensions,
+      });
     } else {
       if (options.learn || config.shieldAutoLearn)
         await learnFromVerdict(content, diff, options, config, cwd, configRoot);

--- a/packages/cli/src/git.test.ts
+++ b/packages/cli/src/git.test.ts
@@ -9,6 +9,7 @@ import {
   getGitBranch,
   getGitBranchDiff,
   getGitDiff,
+  getGitDiffRange,
   getGitDiffStat,
   getGitLogSince,
   getGitStatus,
@@ -30,6 +31,7 @@ describe('git re-exports', () => {
     expect(typeof getGitBranch).toBe('function');
     expect(typeof getGitBranchDiff).toBe('function');
     expect(typeof getGitDiff).toBe('function');
+    expect(typeof getGitDiffRange).toBe('function');
     expect(typeof getGitDiffStat).toBe('function');
     expect(typeof getGitLogSince).toBe('function');
     expect(typeof getGitStatus).toBe('function');

--- a/packages/cli/src/git.test.ts
+++ b/packages/cli/src/git.test.ts
@@ -65,12 +65,13 @@ vi.mock('@mmnto/totem', async () => {
   };
 });
 
-// Must import after mock setup — vitest hoists vi.mock
-const { safeExec, getGitDiff, getGitBranchDiff, getGitDiffRange } = await import('@mmnto/totem');
-const mockSafeExec = vi.mocked(safeExec);
-const mockGetGitDiff = vi.mocked(getGitDiff);
-const mockGetGitBranchDiff = vi.mocked(getGitBranchDiff);
-const mockGetGitDiffRange = vi.mocked(getGitDiffRange);
+// Must import after mock setup — vitest hoists vi.mock.
+// Aliased so the imports don't shadow the top-of-file re-export checks.
+const totemMod = await import('@mmnto/totem');
+const mockSafeExec = vi.mocked(totemMod.safeExec);
+const mockGetGitDiff = vi.mocked(totemMod.getGitDiff);
+const mockGetGitBranchDiff = vi.mocked(totemMod.getGitBranchDiff);
+const mockGetGitDiffRange = vi.mocked(totemMod.getGitDiffRange);
 
 describe('isAncestor', () => {
   it('returns true for direct ancestor', () => {

--- a/packages/cli/src/git.test.ts
+++ b/packages/cli/src/git.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   extractChangedFiles,
@@ -58,12 +58,19 @@ vi.mock('@mmnto/totem', async () => {
   return {
     ...actual,
     safeExec: vi.fn(),
+    getGitDiff: vi.fn(),
+    getGitBranchDiff: vi.fn(),
+    getGitDiffRange: vi.fn(),
+    getDefaultBranch: vi.fn(() => 'main'),
   };
 });
 
 // Must import after mock setup — vitest hoists vi.mock
-const { safeExec } = await import('@mmnto/totem');
+const { safeExec, getGitDiff, getGitBranchDiff, getGitDiffRange } = await import('@mmnto/totem');
 const mockSafeExec = vi.mocked(safeExec);
+const mockGetGitDiff = vi.mocked(getGitDiff);
+const mockGetGitBranchDiff = vi.mocked(getGitBranchDiff);
+const mockGetGitDiffRange = vi.mocked(getGitDiffRange);
 
 describe('isAncestor', () => {
   it('returns true for direct ancestor', () => {
@@ -161,5 +168,76 @@ describe('getDiffBetween', () => {
       throw new Error('git error');
     });
     expect(getDiffBetween('/tmp', 'abc123')).toBe('');
+  });
+});
+
+// ─── getDiffForReview --diff (#1717) ─────────────────
+
+describe('getDiffForReview --diff (#1717)', () => {
+  const config = { ignorePatterns: [] as string[] };
+  const sampleDiff = 'diff --git a/foo.ts b/foo.ts\n+++ b/foo.ts\n@@ -1 +1 @@\n+x';
+
+  beforeEach(() => {
+    mockGetGitDiffRange.mockReset();
+    mockGetGitDiff.mockReset();
+    mockGetGitBranchDiff.mockReset();
+  });
+
+  it('uses the explicit-range path and reports source: explicit-range', async () => {
+    mockGetGitDiffRange.mockReturnValue(sampleDiff);
+    const result = await getDiffForReview({ diff: 'HEAD^..HEAD' }, config, '/tmp', 'Review');
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe('explicit-range');
+    expect(mockGetGitDiffRange).toHaveBeenCalledWith('/tmp', 'HEAD^..HEAD');
+  });
+
+  it('skips the staged/working/branch fallback chain when --diff is set', async () => {
+    mockGetGitDiffRange.mockReturnValue(sampleDiff);
+    await getDiffForReview({ diff: 'main...feature' }, config, '/tmp', 'Review');
+    expect(mockGetGitDiffRange).toHaveBeenCalledTimes(1);
+    expect(mockGetGitDiff).not.toHaveBeenCalled();
+    expect(mockGetGitBranchDiff).not.toHaveBeenCalled();
+  });
+
+  it('returns null when explicit range produces an empty diff', async () => {
+    mockGetGitDiffRange.mockReturnValue('');
+    const result = await getDiffForReview({ diff: 'HEAD..HEAD' }, config, '/tmp', 'Review');
+    expect(result).toBeNull();
+  });
+
+  it('still applies ignore patterns to the explicit-range diff', async () => {
+    const lockfileDiff = [
+      'diff --git a/package-lock.json b/package-lock.json',
+      '--- a/package-lock.json',
+      '+++ b/package-lock.json',
+      '@@ -1 +1 @@',
+      '-{"v":1}',
+      '+{"v":2}',
+      '',
+    ].join('\n');
+    mockGetGitDiffRange.mockReturnValue(lockfileDiff);
+    const result = await getDiffForReview(
+      { diff: 'HEAD^..HEAD' },
+      { ignorePatterns: ['package-lock.json'] },
+      '/tmp',
+      'Review',
+    );
+    expect(result).toBeNull();
+  });
+
+  it('reports source: branch-vs-base when the working-tree diff is empty', async () => {
+    mockGetGitDiff.mockReturnValue('');
+    mockGetGitBranchDiff.mockReturnValue(sampleDiff);
+    const result = await getDiffForReview({}, config, '/tmp', 'Review');
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe('branch-vs-base');
+  });
+
+  it('reports source: staged when --staged is set and produces a diff', async () => {
+    mockGetGitDiff.mockReturnValue(sampleDiff);
+    const result = await getDiffForReview({ staged: true }, config, '/tmp', 'Review');
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe('staged');
+    expect(mockGetGitDiff).toHaveBeenCalledWith('staged', '/tmp');
   });
 });

--- a/packages/cli/src/git.ts
+++ b/packages/cli/src/git.ts
@@ -6,6 +6,7 @@ export {
   getGitBranch,
   getGitBranchDiff,
   getGitDiff,
+  getGitDiffRange,
   getGitDiffStat,
   getGitLogSince,
   getGitStatus,
@@ -87,8 +88,12 @@ export function getDiffBetween(cwd: string, base: string, head?: string): string
 
 // ─── Diff-for-review helper (CLI-only — uses log from ui.js) ─────
 
+export type DiffForReviewSource = 'explicit-range' | 'staged' | 'uncommitted' | 'branch-vs-base';
+
 export interface DiffForReviewOptions {
   staged?: boolean;
+  /** Explicit ref range (mmnto-ai/totem#1717). When set, bypasses the implicit fallback chain. */
+  diff?: string;
 }
 
 export interface DiffForReviewConfig {
@@ -99,13 +104,34 @@ export interface DiffForReviewConfig {
 export interface DiffForReviewResult {
   diff: string;
   changedFiles: string[];
+  /** Which path produced the diff (mmnto-ai/totem#1717 — surfaced for operator-visible logging). */
+  source: DiffForReviewSource;
 }
+
+/**
+ * Maximum diff size (in characters) before the prompt assembler truncates.
+ * Mirrored from `shield-templates.MAX_DIFF_CHARS` so the resolution-layer
+ * warning fires on the same threshold as the actual truncation site.
+ *
+ * Kept as a separate constant here rather than imported from
+ * `commands/shield-templates.ts` to avoid a circular CLI dependency
+ * (`git.ts` is intended to be substrate for many commands, not just review).
+ */
+export const REVIEW_DIFF_TRUNCATION_THRESHOLD = 50_000;
 
 /**
  * Shared diff-fetching logic used by both `shield` and `lint` commands.
  *
- * Merges ignore patterns, gets staged/all diff, filters by patterns,
- * falls back to branch diff, and extracts changed files.
+ * Resolution order:
+ *   1. `--diff <range>` (explicit, no fallback)
+ *   2. `--staged` (staged-only) or working-tree (`all`) diff
+ *   3. Branch-vs-base diff (`<default>...HEAD`) when 2 yields nothing
+ *
+ * The chosen resolution path is logged to stderr (mmnto-ai/totem#1717) so the operator's
+ * mental model matches the actual git invocation. Diffs exceeding
+ * `REVIEW_DIFF_TRUNCATION_THRESHOLD` chars surface a warning here, before
+ * the LLM call is made, so the operator can re-run with a narrower
+ * `--diff <range>` instead of paying for a degraded review.
  *
  * Returns `null` when no changes are detected.
  */
@@ -122,26 +148,53 @@ export async function getDiffForReview(
     getDefaultBranch,
     getGitBranchDiff,
     getGitDiff,
+    getGitDiffRange,
   } = await import('@mmnto/totem');
 
   const allIgnore = [...config.ignorePatterns, ...(config.shieldIgnorePatterns ?? [])];
-  const mode = options.staged ? 'staged' : 'all';
-  log.info(tag, `Getting ${mode === 'staged' ? 'staged' : 'uncommitted'} diff...`);
-  let diff = filterDiffByPatterns(getGitDiff(mode, cwd), allIgnore);
 
-  if (!diff.trim()) {
-    const base = getDefaultBranch(cwd);
-    log.dim(tag, `No relevant changes. Falling back to branch diff (${base}...HEAD)...`);
-    diff = filterDiffByPatterns(getGitBranchDiff(cwd, base), allIgnore);
+  let diff: string;
+  let source: DiffForReviewSource;
+
+  if (options.diff !== undefined) {
+    // Explicit-range path — no fallback. getGitDiffRange rejects flag-injection
+    // (leading `-`) and empty values; ignore patterns still apply per repo policy.
+    log.info(tag, `Diff source: explicit range (${options.diff})`);
+    diff = filterDiffByPatterns(getGitDiffRange(cwd, options.diff), allIgnore);
+    source = 'explicit-range';
+    if (!diff.trim()) {
+      log.warn(tag, `Explicit range '${options.diff}' produced no diff. Nothing to review.`);
+      return null;
+    }
+  } else {
+    const mode: 'staged' | 'all' = options.staged ? 'staged' : 'all';
+    const sourceLabel: DiffForReviewSource = options.staged ? 'staged' : 'uncommitted';
+    log.info(tag, `Diff source: ${sourceLabel}`);
+    diff = filterDiffByPatterns(getGitDiff(mode, cwd), allIgnore);
+    source = sourceLabel;
+
+    if (!diff.trim()) {
+      const base = getDefaultBranch(cwd);
+      log.info(tag, `Diff source: branch-vs-base (${base}...HEAD)`);
+      diff = filterDiffByPatterns(getGitBranchDiff(cwd, base), allIgnore);
+      source = 'branch-vs-base';
+    }
+
+    if (!diff.trim()) {
+      log.warn(tag, 'No changes detected. Nothing to review.');
+      return null;
+    }
   }
 
-  if (!diff.trim()) {
-    log.warn(tag, 'No changes detected. Nothing to review.');
-    return null;
+  if (diff.length > REVIEW_DIFF_TRUNCATION_THRESHOLD) {
+    log.warn(
+      tag,
+      `Diff exceeds ${REVIEW_DIFF_TRUNCATION_THRESHOLD} chars (${diff.length}). LLM review will see truncated content; re-run with a narrower --diff <range> to avoid degraded findings.`,
+    );
   }
 
   const changedFiles = extractChangedFiles(diff);
   log.info(tag, `Changed files (${changedFiles.length}): ${changedFiles.join(', ')}`);
 
-  return { diff, changedFiles };
+  return { diff, changedFiles, source };
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -235,6 +235,10 @@ const reviewOptions = (cmd: Command) =>
     .option('--model <name>', 'Override the default model for the orchestrator')
     .option('--fresh', 'Bypass cache and force a fresh LLM call (ignores cached responses)')
     .option('--staged', 'Review only staged changes (default: all uncommitted)')
+    .option(
+      '--diff <ref-range>',
+      'Review an explicit git diff range (e.g. "HEAD^..HEAD" or "main...feature"). Bypasses the implicit working-tree → staged → branch-vs-base fallback.',
+    )
     .option('--deterministic', 'REMOVED — use `totem lint` instead', false)
     .option('--format <format>', 'REMOVED — use `totem lint --format` instead')
     .option(
@@ -256,6 +260,19 @@ const reviewOptions = (cmd: Command) =>
     .option(
       '--auto-capture',
       'Enable Pipeline 5 auto-capture of observation rules from findings (off by default; captured rules are context-less and apply globally)',
+    )
+    .addHelpText(
+      'after',
+      [
+        '',
+        'Diff resolution (when --diff is omitted):',
+        '  1. --staged          → staged-only diff',
+        '  2. (default)         → working-tree diff (all uncommitted)',
+        '  3. (fallback)        → branch-vs-base diff when 1/2 produce nothing',
+        'The chosen path is logged to stderr; large diffs (>50000 chars)',
+        'trigger an explicit truncation warning before the LLM call.',
+        '',
+      ].join('\n'),
     );
 
 async function runReview(opts: {
@@ -264,6 +281,7 @@ async function runReview(opts: {
   model?: string;
   fresh?: boolean;
   staged?: boolean;
+  diff?: string;
   deterministic?: boolean;
   format?: string;
   mode?: string;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -7,6 +7,7 @@ import { Command } from 'commander';
 import { z } from 'zod';
 
 import { initCommand } from './commands/init.js';
+import { REVIEW_DIFF_TRUNCATION_THRESHOLD } from './git.js';
 import { TotemHelp } from './help.js';
 import { reapOrphanedTempFiles } from './utils.js';
 
@@ -269,7 +270,7 @@ const reviewOptions = (cmd: Command) =>
         '  1. --staged          → staged-only diff',
         '  2. (default)         → working-tree diff (all uncommitted)',
         '  3. (fallback)        → branch-vs-base diff when 1/2 produce nothing',
-        'The chosen path is logged to stderr; large diffs (>50000 chars)',
+        `The chosen path is logged to stderr; large diffs (>${REVIEW_DIFF_TRUNCATION_THRESHOLD} chars)`,
         'trigger an explicit truncation warning before the LLM call.',
         '',
       ].join('\n'),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -364,6 +364,7 @@ export {
   getGitBranch,
   getGitBranchDiff,
   getGitDiff,
+  getGitDiffRange,
   getGitDiffStat,
   getGitLogSince,
   getGitStatus,

--- a/packages/core/src/sys/git.test.ts
+++ b/packages/core/src/sys/git.test.ts
@@ -11,6 +11,7 @@ import { fail, ok } from '../test-utils.js';
 import {
   extractChangedFiles,
   filterDiffByPatterns,
+  getGitDiffRange,
   getGitLogSince,
   getLatestTag,
   getTagDate,
@@ -49,6 +50,54 @@ describe('getTagDate', () => {
   it('returns null when tag does not exist', () => {
     vi.mocked(crossSpawn.sync).mockReturnValue(fail(new Error('fatal: bad object')) as never);
     expect(getTagDate('/tmp', 'v999.0.0')).toBeNull();
+  });
+});
+
+describe('getGitDiffRange (#1717)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns diff output for a valid ref range', () => {
+    vi.mocked(crossSpawn.sync).mockReturnValue(
+      ok('diff --git a/foo.ts b/foo.ts\n+const x = 1;\n') as never,
+    );
+    const result = getGitDiffRange('/tmp', 'HEAD^..HEAD');
+    expect(result).toContain('+const x = 1;');
+    expect(vi.mocked(crossSpawn.sync)).toHaveBeenCalledWith(
+      'git',
+      ['diff', 'HEAD^..HEAD'],
+      expect.any(Object),
+    );
+  });
+
+  it('trims whitespace before invoking git', () => {
+    vi.mocked(crossSpawn.sync).mockReturnValue(ok('') as never);
+    getGitDiffRange('/tmp', '  main...feature  ');
+    expect(vi.mocked(crossSpawn.sync)).toHaveBeenCalledWith(
+      'git',
+      ['diff', 'main...feature'],
+      expect.any(Object),
+    );
+  });
+
+  it('rejects empty ranges before invoking git', () => {
+    expect(() => getGitDiffRange('/tmp', '')).toThrow(/Empty ref range/);
+    expect(() => getGitDiffRange('/tmp', '   ')).toThrow(/Empty ref range/);
+    expect(vi.mocked(crossSpawn.sync)).not.toHaveBeenCalled();
+  });
+
+  it('rejects ranges starting with a dash to defuse git-flag injection', () => {
+    expect(() => getGitDiffRange('/tmp', '--no-index')).toThrow(/may not start with '-'/);
+    expect(() => getGitDiffRange('/tmp', '-p')).toThrow(/may not start with '-'/);
+    expect(vi.mocked(crossSpawn.sync)).not.toHaveBeenCalled();
+  });
+
+  it('wraps git failures in a TotemGitError with actionable hint', () => {
+    vi.mocked(crossSpawn.sync).mockReturnValue(
+      fail(new Error("fatal: bad revision 'nope..nope'")) as never,
+    );
+    expect(() => getGitDiffRange('/tmp', 'nope..nope')).toThrow(
+      /Failed to compute diff for range 'nope..nope'/,
+    );
   });
 });
 

--- a/packages/core/src/sys/git.ts
+++ b/packages/core/src/sys/git.ts
@@ -145,6 +145,46 @@ export function getGitBranchDiff(cwd: string, base?: string): string {
 }
 
 /**
+ * Run `git diff <range>` for an explicitly supplied ref range (e.g.
+ * `HEAD^..HEAD`, `main...feature`). Used by `totem review --diff` to
+ * bypass the implicit working-tree → staged → branch-vs-base fallback chain.
+ *
+ * Rejects ranges starting with `-` to defuse git-flag injection (e.g.
+ * `--diff --no-index`); `safeExec`'s arg-array form already prevents shell
+ * metacharacter expansion on the range itself.
+ */
+export function getGitDiffRange(cwd: string, range: string): string {
+  const trimmed = range.trim();
+  if (trimmed.length === 0) {
+    throw new TotemGitError(
+      'Empty ref range supplied to --diff.',
+      'Provide a non-empty range, e.g. --diff "HEAD^..HEAD" or --diff "main...feature".',
+    );
+  }
+  if (trimmed.startsWith('-')) {
+    throw new TotemGitError(
+      `Invalid ref range: ${trimmed}. Ranges may not start with '-' (git-flag injection guard).`,
+      'Provide a positional ref range such as "HEAD^..HEAD" without leading dashes.',
+    );
+  }
+  try {
+    return safeExec('git', ['diff', trimmed], {
+      cwd,
+      timeout: GIT_COMMAND_TIMEOUT_MS,
+      maxBuffer: GIT_DIFF_MAX_BUFFER,
+    });
+  } catch (err) {
+    throwIfGitMissing(err);
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new TotemGitError(
+      `Failed to compute diff for range '${trimmed}': ${msg}`,
+      `Verify the range is valid. Try 'git diff ${trimmed}' to confirm git accepts it; missing refs may need 'git fetch origin'.`,
+      err,
+    );
+  }
+}
+
+/**
  * Get the author date of a tag in YYYY-MM-DD format.
  * Returns null if tag doesn't exist or lookup fails.
  */

--- a/packages/core/src/sys/git.ts
+++ b/packages/core/src/sys/git.ts
@@ -175,9 +175,8 @@ export function getGitDiffRange(cwd: string, range: string): string {
     });
   } catch (err) {
     throwIfGitMissing(err);
-    const msg = err instanceof Error ? err.message : String(err);
     throw new TotemGitError(
-      `Failed to compute diff for range '${trimmed}': ${msg}`,
+      `Failed to compute diff for range '${trimmed}'.`,
       `Verify the range is valid. Try 'git diff ${trimmed}' to confirm git accepts it; missing refs may need 'git fetch origin'.`,
       err,
     );


### PR DESCRIPTION
## Mechanical Root Cause

**`mmnto-ai/totem#1716`** — `totem review --override <reason>` recorded the override in the trap ledger but did not call `writeReviewedContentHash`. Every other completion path (verdict.pass, no-changes, all-non-code, after-filter-empty) stamped `.totem/cache/.reviewed-content-hash`; the override branch was missed in both the V2 structured-verdict and V1 fallback flows. The push-gate hook compares the cached hash against the current source-content hash, so an override-completed review left the contributor stuck behind the gate with the tribal-knowledge `git reset --soft HEAD~1 && totem review --staged` workaround documented in `upstream-feedback/027`.

**`mmnto-ai/totem#1717`** — `totem review`'s diff resolution was implicit: working-tree → branch-vs-base fallback fired silently when uncommitted was empty, hit the `MAX_DIFF_CHARS = 50_000` truncation cliff inside the prompt assembler, and emitted "diff is truncated" CRITICALs that looked indistinguishable from genuine LLM-quality findings. The fallback path was invisible in `--help` and the truncation was silent at the resolution layer.

## Fix Applied

### `mmnto-ai/totem#1716` — override now stamps the cache

- New `recordShieldOverride(params)` helper at `packages/cli/src/commands/shield.ts:496` bundles the trap-ledger write and `writeReviewedContentHash` stamp into one call.
- Both the V2 structured-verdict override branch and the V1 fallback override branch route through the helper, so the cache state after override matches the cache state after a passing review (per ADR-083 — override is a legitimate completion path with logged justification).
- Helper is exported and tested directly (`packages/cli/src/commands/shield.test.ts`); the 2-test block exercises the success path and the configRoot-relative path with real git fixtures.

### `mmnto-ai/totem#1717` — explicit `--diff <ref-range>` flag

- New `--diff <ref-range>` Commander option on `totem review` (e.g. `--diff HEAD^..HEAD`, `--diff main...feature`). Bypasses the implicit fallback chain entirely.
- New `getGitDiffRange(cwd, range)` core helper at `packages/core/src/sys/git.ts:154` mirrors `getGitBranchDiff`'s pattern (`safeExec` + `GIT_COMMAND_TIMEOUT_MS` + `GIT_DIFF_MAX_BUFFER`). Rejects ranges starting with `-` (git-flag-injection guard, e.g. `--diff --no-index`) and rejects empty/whitespace input. `safeExec`'s arg-array form prevents shell-metachar interpretation on the range itself.
- `getDiffForReview` now reports a `source: 'explicit-range' | 'staged' | 'uncommitted' | 'branch-vs-base'` discriminator and logs the chosen path to stderr (`Diff source: explicit-range (HEAD^..HEAD)`, etc.) so the operator's mental model matches the actual git invocation.
- Diffs exceeding `REVIEW_DIFF_TRUNCATION_THRESHOLD = 50_000` chars now surface a fail-loud warning at the resolution layer — **before** the LLM call — so the operator can re-run with a narrower `--diff <range>` instead of paying for a degraded review. Threshold mirrors `MAX_DIFF_CHARS` exactly to keep the warning predicate aligned with the actual truncation site.
- `--help` now documents the fallback chain via Commander's `addHelpText('after', ...)`.
- Ignore patterns (`filterDiffByPatterns`) still apply to the explicit-range diff — repo policy (lockfiles, generated files, vendor) is global hygiene, not source-specific.

### Bonus dogfood

The override path's content-hash stamp dogfooded itself during this PR's pre-push review: gemini surfaced a false-positive CRITICAL about `log` being out of scope inside `recordShieldOverride` (it's actually statically imported at `shield.ts:3`), the override flag was used to ship the citation-based decline, and the `recordShieldOverride` helper itself stamped the cache so the second push attempt cleared the gate without intervention. End-to-end loop verified.

## Out of Scope

- No change to `MAX_DIFF_CHARS` itself — separate ticket if the threshold needs tuning.
- No `--no-truncate` escape hatch — separate ticket if requested.
- No change to the structural / standard mode dispatch.
- `lint` command's diff-source surface is unchanged — `--diff` is opt-in for `review` only this cycle; lint can opt in later if needed (the `DiffForReviewOptions.diff` field is already optional).
- No agent-facing MCP surface for `--diff` — this is a CLI-only flag for operator dogfood.
- Submodule pointer not bumped per `feedback_no_auto_strategy_submodule_bump.md`; rides next release cut.

## Tests Added/Updated

- [x] Added/updated automated tests covering the root-cause mechanism

**`packages/core/src/sys/git.test.ts`** — 5 new tests for `getGitDiffRange`:
- returns diff output for a valid ref range
- trims whitespace before invoking git
- rejects empty ranges before invoking git
- rejects ranges starting with `-` to defuse git-flag injection (covers leading single `-` and `--` cases)
- wraps git failures in a `TotemGitError` with actionable hint

**`packages/cli/src/git.test.ts`** — 6 new tests for `getDiffForReview --diff`:
- uses the explicit-range path and reports `source: explicit-range`
- skips the staged/working/branch fallback chain when `--diff` is set (one git invocation, no fallbacks)
- returns `null` when explicit range produces an empty diff
- still applies ignore patterns to the explicit-range diff
- reports `source: branch-vs-base` when the working-tree diff is empty (existing fallback, now with discriminator coverage)
- reports `source: staged` when `--staged` is set and produces a diff

**`packages/cli/src/commands/shield.test.ts`** — 2 new tests for `recordShieldOverride`:
- writes the override event to the trap ledger AND stamps `.reviewed-content-hash`
- honors `configRoot` when stamping the cache and writing the ledger

**Suite totals:** core 1411 ✓ (+5), cli 1842 ✓ (+8). Lint PASS, 0 errors.

## Related Tickets

Closes mmnto-ai/totem#1716
Closes mmnto-ai/totem#1717

## AI_PROMPT_BLOCK

Reviewing bots: please verify (a) `recordShieldOverride` is called from BOTH override branches in `shield.ts` (the V2 structured-verdict path AND the V1 fallback parser), (b) `getGitDiffRange`'s flag-injection guard fires before any `safeExec` invocation, (c) the truncation warning predicate (`diff.length > REVIEW_DIFF_TRUNCATION_THRESHOLD`) matches the actual truncation site (`diff.length > MAX_DIFF_CHARS` in `shield.ts`), and (d) `--diff` still applies `filterDiffByPatterns` (ignore patterns are global hygiene; this is intentional per the design doc at `.totem/specs/1717.md`).