### PR TITLE
feat(cli): totem stats --pattern-recurrence (mmnto-ai/totem#1715)

### DIFF
--- a/.changeset/1715-stats-pattern-recurrence.md
+++ b/.changeset/1715-stats-pattern-recurrence.md
@@ -1,0 +1,14 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+'@mmnto/mcp': minor
+'@totem/pack-agent-security': minor
+---
+
+`totem stats --pattern-recurrence` — cross-PR recurrence clustering substrate.
+
+Closes mmnto-ai/totem#1715. Fetches bot-review findings (CodeRabbit + Gemini Code Assist) across the most recent merged PRs (`--history-depth`, default 50, capped at 200), folds in trap-ledger `override` events as co-equal signals, clusters them by a normalized signature (paths + line numbers + code-fence content stripped), filters out clusters covered by an existing compiled rule via Jaccard ≥ 0.6 keyword-overlap on the rule's `message`, and writes the surviving patterns at-or-above `--threshold` (default 5) to `.totem/recurrence-stats.json`. The console summary shows the top 5 by occurrence count.
+
+This is the substrate of truth for the upcoming `totem retrospect <pr>` (mmnto-ai/totem#1713 bot-tax circuit breaker) and `totem review --estimate` (mmnto-ai/totem#1714 pre-flight estimator) — patterns from those features will read this file rather than re-scan PR history per invocation.
+
+Output shape is versioned (`version: 1`), stable, and Zod-validated; consumers can parse against `RecurrenceStatsSchema` exported from `@mmnto/totem`. Atomic writes via temp + rename keep concurrent invocations safe.

--- a/.totem/specs/1715.md
+++ b/.totem/specs/1715.md
@@ -1,0 +1,148 @@
+# Spec — totem#1715 totem stats --pattern-recurrence
+
+_Generated 2026-04-28; gemini-3.1-pro-preview spec captured + design doc appended._
+
+## Problem Statement
+
+The same class of finding can recur 5+ times across PRs without ever being codified into a deterministic rule. Currently invisible — nobody is counting. The recurrence IS the signal that a rule should exist; we lose it by treating each PR's findings as PR-local. This is the "signal 2" instrumentation gap from the four-honest-signals framework — same-class-mistake frequency is unmeasurable without it.
+
+This feature is also the substrate of truth for the bot-tax circuit breaker (`mmnto-ai/totem#1713`) and the pre-flight estimator (`mmnto-ai/totem#1714`). Build order matters — this one first, then the other two compose.
+
+## Acceptance criteria (from issue body)
+
+- `totem stats --pattern-recurrence` runs against bot-review history + trap-ledger
+- Recurrence threshold configurable; sensible default
+- Output identifies patterns lacking corresponding compiled rules
+- Output suggests the shape of a lesson/rule that would catch the recurrence (heuristic — can be follow-up)
+- Stats schema lives at the right abstraction layer (NOT inside `compiled-rules.json` — sibling file)
+- Documented in `--help` and workflow doc
+
+## Existing surface
+
+- `packages/cli/src/commands/stats.ts` — current `statsCommand()` reads `compiled-rules.json` + rule-metrics + trap-ledger. Add the new mode here.
+- `packages/cli/src/index.ts:137` — Commander registration; need new option + extended description.
+- `packages/cli/src/adapters/github-cli-pr.ts` — `GitHubCliPrAdapter.fetchPr(num)` and `.fetchReviewComments(num)` are the established history-fetching path.
+- `packages/cli/src/parsers/bot-review-parser.ts` — `isBotComment`, `detectBot`, `parseCRSeverity`, `parseGCASeverity`, `extractReviewBodyFindings`, `stripHtmlWrappers`, `extractSuggestion`.
+- `packages/cli/src/parsers/triage-dedup.ts` — `deduplicateFindings` (per-PR dedup pattern; we need a separate cross-PR clustering layer).
+- `packages/cli/src/commands/triage-pr.ts` — full per-PR ingestion pipeline; reusable as a per-PR fetcher.
+- `packages/cli/src/commands/review-learn.ts:201` — `extractResolvedBotFindings` (resolved-thread filter — only resolved findings count as "real"; useful for noise reduction).
+- `packages/core/src/ledger.ts` — `readLedgerEvents(totemDir)` returns parsed `LedgerEvent[]`; the override + suppress events are signal sources.
+- `packages/core/src/sys/fs.ts` — `readJsonSafe` for the output file's safe IO.
+- `compiled-rules.json` — the `lessonHash` + `message` + `fileGlobs` fields for the existing-rule-coverage filter.
+
+## Knowledge-base context
+
+- **Lesson `lesson-89e4c802`** — when surfacing findings from review bodies, dedup against inline comments to prevent redundant reporting.
+- **Lesson `lesson-ee7825f9`** — DRY duplicated review-parsing logic immediately. Any extraction shared with `triage-pr.ts` / `review-learn.ts` belongs in `bot-review-parser.ts`.
+- **Trap Ledger** at `.totem/ledger/events.ndjson` — `override` events carry the user's pattern signal; `suppress` events too.
+- **`upstream-feedback/032`** (convergence-trigger discipline) — the canonical exhibit: `mmnto-ai/liquid-city#97` 26-round bot-review marathon. Recurrence stats inform the convergence threshold #1713 will use.
+- **Trap Ledger triggers nursery auto-tuning** (Proposal 198 §4): "10 identical override events for Rule #42 → doctor opens a PR downgrading severity." This feature is the *cross-PR* analogue — patterns NOT YET ruled.
+
+## Implementation Design
+
+### Scope (2 sentences)
+
+Adds `totem stats --pattern-recurrence` which fetches bot-review findings across the most recent N merged PRs (configurable depth, default 50) plus local trap-ledger overrides, clusters them into patterns by a normalized signature, filters out patterns already covered by `compiled-rules.json`, and writes the surviving patterns at threshold or above to `.totem/recurrence-stats.json` plus a stdout summary. Will NOT (a) author lessons or rules — purely descriptive output for human/LLM downstream; (b) make GitHub API writes; (c) run continuously / be invoked from hooks; (d) implement the synthesis-mode `review-learn` consumer (separate ticket).
+
+### Data model deltas
+
+**`RecurrencePatternSchema`** — new Zod schema (export from `packages/core/src/recurrence-stats.ts`):
+
+| Field | Type | Holds |
+|---|---|---|
+| `signature` | `string` | Stable hash of the normalized pattern body — used as cluster key |
+| `tool` | `'coderabbit' \| 'gca' \| 'sarif' \| 'override' \| 'mixed'` | Source classification (`mixed` when one signature has finding-tool clusters from multiple bots) |
+| `severityBucket` | `'critical' \| 'high' \| 'medium' \| 'low' \| 'nit'` | Normalized severity across CR/GCA's different severity vocabularies |
+| `occurrences` | `number` (≥ 1) | Total finding count for this signature |
+| `prs` | `string[]` (deduped, sorted ascending numerically) | PR numbers where this pattern fired |
+| `sampleBodies` | `string[]` (length ≤ 3) | First 3 raw bodies seen — for human triage |
+| `firstSeen` | ISO datetime | Earliest finding's `created_at` |
+| `lastSeen` | ISO datetime | Latest finding's `created_at` |
+| `paths` | `string[]` (deduped, ≤ 10) | File paths where the pattern fired (substrate for rule-fileGlobs synthesis) |
+| `coveredByRule` | `boolean` | `true` if signature heuristically maps to an existing compiled rule (filtered out of headline output but kept in JSON for transparency) |
+
+**`RecurrenceStatsSchema`** — top-level output:
+
+| Field | Type | Holds |
+|---|---|---|
+| `version` | `1` (literal) | Schema version for forward-compat |
+| `lastUpdated` | ISO datetime | When this run wrote the file |
+| `thresholdApplied` | `number` (≥ 1) | The `--threshold` value used; informs reproducibility |
+| `historyDepth` | `number` | Number of PRs scanned |
+| `prsScanned` | `string[]` | PR numbers actually fetched (post-filter) |
+| `patterns` | `RecurrencePattern[]` | Patterns at-or-above threshold; sorted by `occurrences` descending |
+| `coveredPatterns` | `RecurrencePattern[]` | Patterns that DID hit existing rules — separate array so rule-coverage rate is observable |
+
+Persisted at `.totem/recurrence-stats.json`. Atomic write via temp file + rename.
+
+**No new state containers.** Each invocation is stateless — read inputs, compute, write output, exit.
+
+### State lifecycle
+
+All new state is per-invocation:
+
+- **Bot-finding cache** (`Map<prNumber, NormalizedBotFinding[]>`) — built fresh per call, lives only for the duration of `statsCommand`. No persistence.
+- **Pattern cluster map** (`Map<signature, RecurrencePattern>`) — built during clustering, serialized to JSON, discarded.
+- **Output file** (`.totem/recurrence-stats.json`) — overwritten atomically per invocation. No accumulation; each run gives a fresh snapshot keyed on the historyDepth window.
+
+No state crosses lifecycle boundaries. The output file is consumed read-only by future `#1713` / `#1714` commands (via a separate read helper).
+
+### Failure modes
+
+| Failure | Category | Agent-facing surface | Recovery |
+|---|---|---|---|
+| `gh` CLI missing or unauthenticated | init | hard error: `TotemConfigError` with `requireGhCli`-style hint | install `gh`, run `gh auth login` |
+| GitHub rate limit hit mid-fetch | runtime | warning to stderr per-PR, continue with partial data; final report flags `prsScanned < historyDepth` | wait for quota; the partial run still writes JSON for the PRs we got |
+| `compiled-rules.json` missing | runtime | warning; treat existing rules as empty (rule-coverage check returns `false` for all patterns) | run `totem sync` or `totem compile` to materialize the file |
+| `compiled-rules.json` malformed | runtime | hard error: `TotemParseError` | fix or regenerate the manifest |
+| `events.ndjson` missing | runtime | silent (treated as zero override events) | normal pre-first-override state — not a failure |
+| `events.ndjson` partially malformed | runtime | warning per bad line, skip the line, continue | `readLedgerEvents` already enforces this; we inherit the contract |
+| Output write fails (disk full, permission) | runtime | hard error: `TotemError` with `WRITE_FAILED` | resolve disk/permission issue and retry |
+| Output already exists with newer `lastUpdated` | runtime | warning, prompt-or-overwrite based on `--yes` flag | use `--yes` to confirm overwrite in CI |
+| Concurrent invocations race on the output file | runtime | atomic rename serializes; loser's data is lost but no corruption | invoke serially (CI single-shot); future ticket if multi-host coordination needed |
+| `--history-depth` > 200 | init | warning; capped at 200 to defuse rate-limit blowups | use `--threshold` filtering instead, or run multiple shorter windows |
+
+No silent degradations. Tenet 4 satisfied.
+
+### Invariants to lock in via tests
+
+- A pattern's `signature` is stable across runs given the same input bodies (deterministic normalization)
+- Two findings differing only in file path / line number / code-fenced snippet content collapse to ONE signature
+- Two findings with the same signature from different bots produce ONE pattern with `tool: 'mixed'`
+- `occurrences` equals the count of distinct findings (NOT distinct PRs) — repeated occurrences within one PR count
+- `prs` is deduplicated and sorted ascending numerically
+- Patterns with `occurrences < threshold` are excluded from `patterns` (still appear in `coveredPatterns` if they matched a rule? — see Q1)
+- Patterns hitting an existing rule (per coverage heuristic) are routed to `coveredPatterns`, not `patterns`
+- Output file is written atomically (temp + rename); a crash mid-write leaves the previous file intact
+- A missing `compiled-rules.json` does not throw — patterns just aren't routed to `coveredPatterns`
+- The summary printed to stdout matches the JSON contents (no drift)
+
+### Open questions
+
+- **Q1.** How aggressive should the existing-rule coverage heuristic be in v0?
+  - **Options:** (a) skip entirely — every pattern lands in `patterns`, `coveredByRule` always `false`; (b) simple keyword-overlap on rule `message` ≥ 0.6 Jaccard; (c) embedding-based semantic match against the lance store; (d) string-equality on the normalized signature.
+  - **Recommendation:** **(b) — keyword-overlap on message text.** Catches the obvious cases without false-positive rate of (c). Embedding-match is the right long-term answer but lance-store coupling makes the command heavyweight; defer to a `--use-embeddings` flag in a follow-up.
+
+- **Q2.** Default `--history-depth`?
+  - **Options:** (a) 20 (last sprint or two); (b) 50 (~2 months at typical totem cadence); (c) 100 (deeper context, more API calls).
+  - **Recommendation:** **(b) 50.** Matches the spec's suggestion. Configurable per-repo via a future `totem.config.ts` field if needed.
+
+- **Q3.** Subcommand or flag?
+  - **Options:** (a) flag — `totem stats --pattern-recurrence` (existing `statsCommand` extended); (b) subcommand — `totem stats pattern-recurrence` or `totem stats recurrence`; (c) standalone — `totem recurrence-stats`.
+  - **Recommendation:** **(a) flag.** Spec is explicit on `totem stats --pattern-recurrence`. The existing `statsCommand` already aggregates rule-metrics + ledger; extending it keeps the "stats reporting" surface coherent. Subcommand explosion is a known UX hazard (cf. ADR-094 grammar work in flight).
+
+- **Q4.** Trap-ledger overrides — co-equal data source or bot-review-only?
+  - **Options:** (a) co-equal — every `override` event becomes a finding-with-no-bot, signature-clustered alongside bot findings; (b) supplemental — overrides only count when they map to an EXISTING bot finding signature (boost the count); (c) bot-only — ignore the ledger for v0.
+  - **Recommendation:** **(a) co-equal.** Override-without-rule IS a recurrence signal. Tool tag becomes `'override'`. Trap-ledger source-of-truth aligns with Proposal 198's nursery auto-tuning thesis; treating overrides as first-class avoids the pattern where users rely on `// totem-context:` to silence undocumented patterns and the cross-PR signal stays invisible.
+
+- **Q5.** Signature normalization — what exactly is stripped?
+  - **Options:** (a) minimal — strip leading/trailing whitespace and collapse internal whitespace; (b) standard — also strip file paths, line numbers, code fences, backtick spans, URLs, leading severity prefixes; (c) aggressive — also stem-normalize identifier-like tokens (e.g. `myVar` → `<ident>`).
+  - **Recommendation:** **(b) standard.** Matches the spec's "strip file paths, line numbers, and backtick-enclosed code snippets." Aggressive stemming risks over-clustering ("missing import for X" and "missing import for Y" should arguably stay distinct if X/Y are different module classes). Ship standard; refine if false-positive rate is high.
+
+- **Q6.** Suggested-lesson-shape generation — v0 scope?
+  - **Options:** (a) leave empty / undefined; (b) heuristic skeleton (template with file globs from `paths`, severity from bucket, body from sample); (c) defer to LLM call inside the command (heavyweight).
+  - **Recommendation:** **(a) leave empty.** Spec acceptance criterion says "heuristic — can be follow-up." Suggested-shape generation is squarely in `review-learn --synthesis-mode` territory; this command is the *substrate*. File a follow-up tier-3 ticket.
+
+- **Q7.** Output ergonomics — JSON-only, or JSON + Markdown sidecar?
+  - **Options:** (a) JSON only at `.totem/recurrence-stats.json` — agent-friendly, parsable; (b) JSON + Markdown summary at `.totem/recurrence-stats.md` — human-readable; (c) JSON + `--out <path>` flag for adhoc.
+  - **Recommendation:** **(a) JSON only + stdout console summary** (the existing `statsCommand` pattern). Markdown sidecar is consumer-driven, not substrate-driven; if `#1714` review-estimate wants formatted output it can render its own.

--- a/.totem/specs/1715.md
+++ b/.totem/specs/1715.md
@@ -36,7 +36,7 @@ This feature is also the substrate of truth for the bot-tax circuit breaker (`mm
 - **Lesson `lesson-ee7825f9`** — DRY duplicated review-parsing logic immediately. Any extraction shared with `triage-pr.ts` / `review-learn.ts` belongs in `bot-review-parser.ts`.
 - **Trap Ledger** at `.totem/ledger/events.ndjson` — `override` events carry the user's pattern signal; `suppress` events too.
 - **`upstream-feedback/032`** (convergence-trigger discipline) — the canonical exhibit: `mmnto-ai/liquid-city#97` 26-round bot-review marathon. Recurrence stats inform the convergence threshold #1713 will use.
-- **Trap Ledger triggers nursery auto-tuning** (Proposal 198 §4): "10 identical override events for Rule #42 → doctor opens a PR downgrading severity." This feature is the *cross-PR* analogue — patterns NOT YET ruled.
+- **Trap Ledger triggers nursery auto-tuning** (Proposal 198 §4): "10 identical override events for Rule #42 → doctor opens a PR downgrading severity." This feature is the _cross-PR_ analogue — patterns NOT YET ruled.
 
 ## Implementation Design
 
@@ -48,30 +48,30 @@ Adds `totem stats --pattern-recurrence` which fetches bot-review findings across
 
 **`RecurrencePatternSchema`** — new Zod schema (export from `packages/core/src/recurrence-stats.ts`):
 
-| Field | Type | Holds |
-|---|---|---|
-| `signature` | `string` | Stable hash of the normalized pattern body — used as cluster key |
-| `tool` | `'coderabbit' \| 'gca' \| 'sarif' \| 'override' \| 'mixed'` | Source classification (`mixed` when one signature has finding-tool clusters from multiple bots) |
-| `severityBucket` | `'critical' \| 'high' \| 'medium' \| 'low' \| 'nit'` | Normalized severity across CR/GCA's different severity vocabularies |
-| `occurrences` | `number` (≥ 1) | Total finding count for this signature |
-| `prs` | `string[]` (deduped, sorted ascending numerically) | PR numbers where this pattern fired |
-| `sampleBodies` | `string[]` (length ≤ 3) | First 3 raw bodies seen — for human triage |
-| `firstSeen` | ISO datetime | Earliest finding's `created_at` |
-| `lastSeen` | ISO datetime | Latest finding's `created_at` |
-| `paths` | `string[]` (deduped, ≤ 10) | File paths where the pattern fired (substrate for rule-fileGlobs synthesis) |
-| `coveredByRule` | `boolean` | `true` if signature heuristically maps to an existing compiled rule (filtered out of headline output but kept in JSON for transparency) |
+| Field            | Type                                                        | Holds                                                                                                                                   |
+| ---------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `signature`      | `string`                                                    | Stable hash of the normalized pattern body — used as cluster key                                                                        |
+| `tool`           | `'coderabbit' \| 'gca' \| 'sarif' \| 'override' \| 'mixed'` | Source classification (`mixed` when one signature has finding-tool clusters from multiple bots)                                         |
+| `severityBucket` | `'critical' \| 'high' \| 'medium' \| 'low' \| 'nit'`        | Normalized severity across CR/GCA's different severity vocabularies                                                                     |
+| `occurrences`    | `number` (≥ 1)                                              | Total finding count for this signature                                                                                                  |
+| `prs`            | `string[]` (deduped, sorted ascending numerically)          | PR numbers where this pattern fired                                                                                                     |
+| `sampleBodies`   | `string[]` (length ≤ 3)                                     | First 3 raw bodies seen — for human triage                                                                                              |
+| `firstSeen`      | ISO datetime                                                | Earliest finding's `created_at`                                                                                                         |
+| `lastSeen`       | ISO datetime                                                | Latest finding's `created_at`                                                                                                           |
+| `paths`          | `string[]` (deduped, ≤ 10)                                  | File paths where the pattern fired (substrate for rule-fileGlobs synthesis)                                                             |
+| `coveredByRule`  | `boolean`                                                   | `true` if signature heuristically maps to an existing compiled rule (filtered out of headline output but kept in JSON for transparency) |
 
 **`RecurrenceStatsSchema`** — top-level output:
 
-| Field | Type | Holds |
-|---|---|---|
-| `version` | `1` (literal) | Schema version for forward-compat |
-| `lastUpdated` | ISO datetime | When this run wrote the file |
-| `thresholdApplied` | `number` (≥ 1) | The `--threshold` value used; informs reproducibility |
-| `historyDepth` | `number` | Number of PRs scanned |
-| `prsScanned` | `string[]` | PR numbers actually fetched (post-filter) |
-| `patterns` | `RecurrencePattern[]` | Patterns at-or-above threshold; sorted by `occurrences` descending |
-| `coveredPatterns` | `RecurrencePattern[]` | Patterns that DID hit existing rules — separate array so rule-coverage rate is observable |
+| Field              | Type                  | Holds                                                                                     |
+| ------------------ | --------------------- | ----------------------------------------------------------------------------------------- |
+| `version`          | `1` (literal)         | Schema version for forward-compat                                                         |
+| `lastUpdated`      | ISO datetime          | When this run wrote the file                                                              |
+| `thresholdApplied` | `number` (≥ 1)        | The `--threshold` value used; informs reproducibility                                     |
+| `historyDepth`     | `number`              | Number of PRs scanned                                                                     |
+| `prsScanned`       | `string[]`            | PR numbers actually fetched (post-filter)                                                 |
+| `patterns`         | `RecurrencePattern[]` | Patterns at-or-above threshold; sorted by `occurrences` descending                        |
+| `coveredPatterns`  | `RecurrencePattern[]` | Patterns that DID hit existing rules — separate array so rule-coverage rate is observable |
 
 Persisted at `.totem/recurrence-stats.json`. Atomic write via temp file + rename.
 
@@ -89,18 +89,18 @@ No state crosses lifecycle boundaries. The output file is consumed read-only by 
 
 ### Failure modes
 
-| Failure | Category | Agent-facing surface | Recovery |
-|---|---|---|---|
-| `gh` CLI missing or unauthenticated | init | hard error: `TotemConfigError` with `requireGhCli`-style hint | install `gh`, run `gh auth login` |
-| GitHub rate limit hit mid-fetch | runtime | warning to stderr per-PR, continue with partial data; final report flags `prsScanned < historyDepth` | wait for quota; the partial run still writes JSON for the PRs we got |
-| `compiled-rules.json` missing | runtime | warning; treat existing rules as empty (rule-coverage check returns `false` for all patterns) | run `totem sync` or `totem compile` to materialize the file |
-| `compiled-rules.json` malformed | runtime | hard error: `TotemParseError` | fix or regenerate the manifest |
-| `events.ndjson` missing | runtime | silent (treated as zero override events) | normal pre-first-override state — not a failure |
-| `events.ndjson` partially malformed | runtime | warning per bad line, skip the line, continue | `readLedgerEvents` already enforces this; we inherit the contract |
-| Output write fails (disk full, permission) | runtime | hard error: `TotemError` with `WRITE_FAILED` | resolve disk/permission issue and retry |
-| Output already exists with newer `lastUpdated` | runtime | warning, prompt-or-overwrite based on `--yes` flag | use `--yes` to confirm overwrite in CI |
-| Concurrent invocations race on the output file | runtime | atomic rename serializes; loser's data is lost but no corruption | invoke serially (CI single-shot); future ticket if multi-host coordination needed |
-| `--history-depth` > 200 | init | warning; capped at 200 to defuse rate-limit blowups | use `--threshold` filtering instead, or run multiple shorter windows |
+| Failure                                        | Category | Agent-facing surface                                                                                 | Recovery                                                                          |
+| ---------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `gh` CLI missing or unauthenticated            | init     | hard error: `TotemConfigError` with `requireGhCli`-style hint                                        | install `gh`, run `gh auth login`                                                 |
+| GitHub rate limit hit mid-fetch                | runtime  | warning to stderr per-PR, continue with partial data; final report flags `prsScanned < historyDepth` | wait for quota; the partial run still writes JSON for the PRs we got              |
+| `compiled-rules.json` missing                  | runtime  | warning; treat existing rules as empty (rule-coverage check returns `false` for all patterns)        | run `totem sync` or `totem compile` to materialize the file                       |
+| `compiled-rules.json` malformed                | runtime  | hard error: `TotemParseError`                                                                        | fix or regenerate the manifest                                                    |
+| `events.ndjson` missing                        | runtime  | silent (treated as zero override events)                                                             | normal pre-first-override state — not a failure                                   |
+| `events.ndjson` partially malformed            | runtime  | warning per bad line, skip the line, continue                                                        | `readLedgerEvents` already enforces this; we inherit the contract                 |
+| Output write fails (disk full, permission)     | runtime  | hard error: `TotemError` with `WRITE_FAILED`                                                         | resolve disk/permission issue and retry                                           |
+| Output already exists with newer `lastUpdated` | runtime  | warning, prompt-or-overwrite based on `--yes` flag                                                   | use `--yes` to confirm overwrite in CI                                            |
+| Concurrent invocations race on the output file | runtime  | atomic rename serializes; loser's data is lost but no corruption                                     | invoke serially (CI single-shot); future ticket if multi-host coordination needed |
+| `--history-depth` > 200                        | init     | warning; capped at 200 to defuse rate-limit blowups                                                  | use `--threshold` filtering instead, or run multiple shorter windows              |
 
 No silent degradations. Tenet 4 satisfied.
 
@@ -141,7 +141,7 @@ No silent degradations. Tenet 4 satisfied.
 
 - **Q6.** Suggested-lesson-shape generation — v0 scope?
   - **Options:** (a) leave empty / undefined; (b) heuristic skeleton (template with file globs from `paths`, severity from bucket, body from sample); (c) defer to LLM call inside the command (heavyweight).
-  - **Recommendation:** **(a) leave empty.** Spec acceptance criterion says "heuristic — can be follow-up." Suggested-shape generation is squarely in `review-learn --synthesis-mode` territory; this command is the *substrate*. File a follow-up tier-3 ticket.
+  - **Recommendation:** **(a) leave empty.** Spec acceptance criterion says "heuristic — can be follow-up." Suggested-shape generation is squarely in `review-learn --synthesis-mode` territory; this command is the _substrate_. File a follow-up tier-3 ticket.
 
 - **Q7.** Output ergonomics — JSON-only, or JSON + Markdown sidecar?
   - **Options:** (a) JSON only at `.totem/recurrence-stats.json` — agent-friendly, parsable; (b) JSON + Markdown summary at `.totem/recurrence-stats.md` — human-readable; (c) JSON + `--out <path>` flag for adhoc.

--- a/packages/cli/src/commands/recurrence-stats.test.ts
+++ b/packages/cli/src/commands/recurrence-stats.test.ts
@@ -1,0 +1,423 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock @clack/prompts confirm to a no-op returning false.
+vi.mock('@clack/prompts', () => ({
+  confirm: vi.fn().mockResolvedValue(false),
+  isCancel: vi.fn().mockReturnValue(false),
+}));
+
+// Mock the GitHubCliPrAdapter and gh-utils used by recurrence-stats.
+const mockFetchPr = vi.fn();
+const mockFetchReviewComments = vi.fn();
+const mockGhFetchAndParse = vi.fn();
+
+vi.mock('../adapters/github-cli-pr.js', () => ({
+  // Use a real class so `new GitHubCliPrAdapter(...)` is a valid construct.
+  GitHubCliPrAdapter: class GitHubCliPrAdapter {
+    fetchPr(num: number) {
+      return mockFetchPr(num);
+    }
+    fetchReviewComments(num: number) {
+      return mockFetchReviewComments(num);
+    }
+  },
+}));
+
+vi.mock('../adapters/gh-utils.js', () => ({
+  ghFetchAndParse: (...args: unknown[]) => mockGhFetchAndParse(...args),
+  handleGhError: (err: unknown) => {
+    throw err;
+  },
+}));
+
+// Mock loadConfig + resolveConfigPath to a tmp totemDir.
+let tmpDir: string;
+let totemDir: string;
+
+vi.mock('../utils.js', () => ({
+  loadConfig: vi.fn().mockImplementation(async () => ({ totemDir: '.totem' })),
+  resolveConfigPath: vi.fn().mockReturnValue(''),
+}));
+
+import { runRecurrenceStats } from './recurrence-stats.js';
+
+// ─── Test setup ────────────────────────────────────────
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'recurrence-stats-'));
+  totemDir = path.join(tmpDir, '.totem');
+  fs.mkdirSync(totemDir, { recursive: true });
+
+  // Run from tmpDir so totemDir resolves under it.
+  process.chdir(tmpDir);
+
+  mockFetchPr.mockReset();
+  mockFetchReviewComments.mockReset();
+  mockGhFetchAndParse.mockReset();
+});
+
+afterEach(() => {
+  // Restore cwd to a known location so test cleanup can rm tmpDir.
+  process.chdir(os.tmpdir());
+  fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+});
+
+// ─── Test data factories ───────────────────────────────
+
+function makeReviewComment(overrides: {
+  id: number;
+  prAuthor?: string;
+  filePath?: string;
+  line?: number;
+  body: string;
+}) {
+  return {
+    id: overrides.id,
+    author: overrides.prAuthor ?? 'coderabbitai[bot]',
+    body: overrides.body,
+    path: overrides.filePath ?? 'src/handler.ts',
+    diffHunk: `@@ -1,3 +${overrides.line ?? 42},3 @@`,
+    inReplyToId: undefined,
+    createdAt: '2026-04-01T00:00:00.000Z',
+  };
+}
+
+interface PatternShape {
+  signature: string;
+  tool: string;
+  occurrences: number;
+  prs: string[];
+  paths: string[];
+  coveredByRule: boolean;
+}
+
+function loadStats(): {
+  version: 1;
+  thresholdApplied: number;
+  patterns: PatternShape[];
+  coveredPatterns: PatternShape[];
+  prsScanned: string[];
+} {
+  const raw = fs.readFileSync(path.join(totemDir, 'recurrence-stats.json'), 'utf-8');
+  return JSON.parse(raw);
+}
+
+// ─── Tests ─────────────────────────────────────────────
+
+describe('runRecurrenceStats', () => {
+  it('collapses path/line variants of the same finding to one signature', async () => {
+    mockGhFetchAndParse.mockReturnValue([
+      { number: 100, mergedAt: '2026-04-01T00:00:00.000Z' },
+      { number: 101, mergedAt: '2026-04-02T00:00:00.000Z' },
+      { number: 102, mergedAt: '2026-04-03T00:00:00.000Z' },
+    ]);
+
+    // Same finding text, different files / lines / fenced code blocks
+    mockFetchPr.mockImplementation((num: number) => ({
+      number: num,
+      title: `PR ${num}`,
+      body: '',
+      state: 'merged',
+      comments: [],
+      reviews: [],
+    }));
+    mockFetchReviewComments.mockImplementation((num: number) => {
+      const variants = [
+        'Avoid using `any` in packages/cli/src/foo.ts:42 — prefer `unknown`.',
+        'Avoid using `any` in packages/core/src/bar.ts:99 — prefer `unknown`.',
+        'Avoid using `any` in src/baz.ts:7 — prefer `unknown`.',
+      ];
+      const idx = num - 100;
+      return [makeReviewComment({ id: 1000 + num, body: variants[idx]!, line: 42 + idx })];
+    });
+
+    await runRecurrenceStats({ threshold: 1, historyDepth: 5, yes: true });
+
+    const stats = loadStats();
+    // Threshold 1 → all clusters surface; should be exactly one cluster
+    const allPatterns = [...stats.patterns, ...stats.coveredPatterns];
+    expect(allPatterns.length).toBe(1);
+    expect(allPatterns[0]!.occurrences).toBe(3);
+  });
+
+  it('marks cluster as `mixed` when same signature spans multiple bots', async () => {
+    mockGhFetchAndParse.mockReturnValue([{ number: 200, mergedAt: '2026-04-01T00:00:00.000Z' }]);
+    mockFetchPr.mockReturnValue({
+      number: 200,
+      title: 't',
+      body: '',
+      state: 'merged',
+      comments: [],
+      reviews: [],
+    });
+    mockFetchReviewComments.mockReturnValue([
+      makeReviewComment({
+        id: 1,
+        prAuthor: 'coderabbitai[bot]',
+        body: 'Avoid using `any` — prefer `unknown`.',
+      }),
+      makeReviewComment({
+        id: 2,
+        prAuthor: 'gemini-code-assist[bot]',
+        body: 'Avoid using `any` — prefer `unknown`.',
+      }),
+    ]);
+
+    await runRecurrenceStats({ threshold: 1, historyDepth: 5, yes: true });
+
+    const stats = loadStats();
+    const allPatterns = [...stats.patterns, ...stats.coveredPatterns];
+    expect(allPatterns.length).toBe(1);
+    expect(allPatterns[0]!.tool).toBe('mixed');
+    // Two distinct findings with same signature
+    expect(allPatterns[0]!.occurrences).toBe(2);
+  });
+
+  it('counts occurrences across distinct findings, not distinct PRs', async () => {
+    mockGhFetchAndParse.mockReturnValue([
+      { number: 300, mergedAt: '2026-04-01T00:00:00.000Z' },
+      { number: 301, mergedAt: '2026-04-02T00:00:00.000Z' },
+    ]);
+    mockFetchPr.mockReturnValue({
+      number: 0,
+      title: 't',
+      body: '',
+      state: 'merged',
+      comments: [],
+      reviews: [],
+    });
+    // PR 300 has 3 distinct findings with the same body, PR 301 has 1.
+    // Total occurrences: 4. Distinct PRs: 2.
+    mockFetchReviewComments.mockImplementation((num: number) => {
+      if (num === 300) {
+        return [
+          makeReviewComment({ id: 1, body: 'Empty catch block.', filePath: 'a.ts', line: 1 }),
+          makeReviewComment({ id: 2, body: 'Empty catch block.', filePath: 'b.ts', line: 2 }),
+          makeReviewComment({ id: 3, body: 'Empty catch block.', filePath: 'c.ts', line: 3 }),
+        ];
+      }
+      return [makeReviewComment({ id: 4, body: 'Empty catch block.', filePath: 'd.ts', line: 4 })];
+    });
+
+    await runRecurrenceStats({ threshold: 1, historyDepth: 5, yes: true });
+
+    const stats = loadStats();
+    const allPatterns = [...stats.patterns, ...stats.coveredPatterns];
+    expect(allPatterns.length).toBe(1);
+    expect(allPatterns[0]!.occurrences).toBe(4);
+    expect(allPatterns[0]!.prs).toEqual(['300', '301']);
+  });
+
+  it('dedupes + sorts prs ascending numerically', async () => {
+    mockGhFetchAndParse.mockReturnValue([
+      { number: 1500, mergedAt: '2026-04-03T00:00:00.000Z' },
+      { number: 200, mergedAt: '2026-04-02T00:00:00.000Z' },
+      { number: 80, mergedAt: '2026-04-01T00:00:00.000Z' },
+    ]);
+    mockFetchPr.mockReturnValue({
+      number: 0,
+      title: 't',
+      body: '',
+      state: 'merged',
+      comments: [],
+      reviews: [],
+    });
+    mockFetchReviewComments.mockImplementation((num: number) => [
+      makeReviewComment({ id: num, body: 'Same finding text everywhere.', filePath: 'x.ts' }),
+    ]);
+
+    await runRecurrenceStats({ threshold: 1, historyDepth: 5, yes: true });
+
+    const stats = loadStats();
+    const allPatterns = [...stats.patterns, ...stats.coveredPatterns];
+    expect(allPatterns.length).toBe(1);
+    // 80 < 200 < 1500 numerically (NOT lexically — '1500' < '200' < '80' lex)
+    expect(allPatterns[0]!.prs).toEqual(['80', '200', '1500']);
+  });
+
+  it('excludes patterns below threshold from headline patterns', async () => {
+    mockGhFetchAndParse.mockReturnValue([
+      { number: 400, mergedAt: '2026-04-01T00:00:00.000Z' },
+      { number: 401, mergedAt: '2026-04-02T00:00:00.000Z' },
+    ]);
+    mockFetchPr.mockReturnValue({
+      number: 0,
+      title: 't',
+      body: '',
+      state: 'merged',
+      comments: [],
+      reviews: [],
+    });
+    mockFetchReviewComments.mockImplementation((num: number) => [
+      makeReviewComment({ id: num, body: `Distinct issue ${num}.`, filePath: 'x.ts' }),
+    ]);
+
+    // threshold=5 — neither cluster has enough occurrences (each is 1)
+    await runRecurrenceStats({ threshold: 5, historyDepth: 5, yes: true });
+    const stats = loadStats();
+    expect(stats.patterns.length).toBe(0);
+  });
+
+  it('routes patterns matching an existing rule to coveredPatterns', async () => {
+    // Seed compiled-rules.json with a rule whose message overlaps the
+    // finding text well enough to clear Jaccard >= 0.6.
+    const rule = {
+      lessonHash: 'abc123',
+      lessonHeading: 'Avoid any',
+      message: 'Avoid using any type — prefer unknown',
+      pattern: 'any',
+      engine: 'regex' as const,
+      severity: 'warning' as const,
+      category: 'style' as const,
+      fileGlobs: ['**/*.ts'],
+      status: 'active' as const,
+      compiledAt: '2026-04-01T00:00:00.000Z',
+    };
+    fs.writeFileSync(
+      path.join(totemDir, 'compiled-rules.json'),
+      JSON.stringify({ version: 1, rules: [rule], nonCompilable: [] }),
+    );
+
+    mockGhFetchAndParse.mockReturnValue([{ number: 500, mergedAt: '2026-04-01T00:00:00.000Z' }]);
+    mockFetchPr.mockReturnValue({
+      number: 500,
+      title: 't',
+      body: '',
+      state: 'merged',
+      comments: [],
+      reviews: [],
+    });
+    mockFetchReviewComments.mockReturnValue([
+      makeReviewComment({
+        id: 5001,
+        body: 'Avoid using any type — prefer unknown.',
+      }),
+    ]);
+
+    await runRecurrenceStats({ threshold: 1, historyDepth: 5, yes: true });
+
+    const stats = loadStats();
+    expect(stats.patterns.length).toBe(0);
+    expect(stats.coveredPatterns.length).toBe(1);
+    expect(stats.coveredPatterns[0]!.tool).toBe('coderabbit');
+  });
+
+  it('atomic write — temp file is cleaned up after rename', async () => {
+    mockGhFetchAndParse.mockReturnValue([{ number: 600, mergedAt: '2026-04-01T00:00:00.000Z' }]);
+    mockFetchPr.mockReturnValue({
+      number: 600,
+      title: 't',
+      body: '',
+      state: 'merged',
+      comments: [],
+      reviews: [],
+    });
+    mockFetchReviewComments.mockReturnValue([makeReviewComment({ id: 6001, body: 'A finding.' })]);
+
+    await runRecurrenceStats({ threshold: 1, historyDepth: 5, yes: true });
+
+    expect(fs.existsSync(path.join(totemDir, 'recurrence-stats.json'))).toBe(true);
+    expect(fs.existsSync(path.join(totemDir, 'recurrence-stats.json.tmp'))).toBe(false);
+  });
+
+  it('does not throw when compiled-rules.json is missing', async () => {
+    // Make sure rules file does not exist
+    const rulesPath = path.join(totemDir, 'compiled-rules.json');
+    if (fs.existsSync(rulesPath)) fs.unlinkSync(rulesPath);
+
+    mockGhFetchAndParse.mockReturnValue([{ number: 700, mergedAt: '2026-04-01T00:00:00.000Z' }]);
+    mockFetchPr.mockReturnValue({
+      number: 700,
+      title: 't',
+      body: '',
+      state: 'merged',
+      comments: [],
+      reviews: [],
+    });
+    mockFetchReviewComments.mockReturnValue([
+      makeReviewComment({ id: 7001, body: 'Some finding.' }),
+    ]);
+
+    await expect(
+      runRecurrenceStats({ threshold: 1, historyDepth: 5, yes: true }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('folds trap-ledger override events as co-equal findings', async () => {
+    // Seed events.ndjson with one override event
+    const ledgerDir = path.join(totemDir, 'ledger');
+    fs.mkdirSync(ledgerDir, { recursive: true });
+    const event = {
+      timestamp: '2026-04-01T00:00:00.000Z',
+      type: 'override',
+      ruleId: 'rule-xyz',
+      file: 'src/legacy.ts',
+      line: 10,
+      justification: 'Legacy code we will refactor later.',
+      source: 'shield',
+    };
+    fs.writeFileSync(path.join(ledgerDir, 'events.ndjson'), JSON.stringify(event) + '\n');
+
+    mockGhFetchAndParse.mockReturnValue([]);
+    mockFetchPr.mockReturnValue({
+      number: 0,
+      title: 't',
+      body: '',
+      state: 'merged',
+      comments: [],
+      reviews: [],
+    });
+    mockFetchReviewComments.mockReturnValue([]);
+
+    await runRecurrenceStats({ threshold: 1, historyDepth: 5, yes: true });
+
+    const stats = loadStats();
+    const allPatterns = [...stats.patterns, ...stats.coveredPatterns];
+    expect(allPatterns.length).toBe(1);
+    expect(allPatterns[0]!.tool).toBe('override');
+    // Override events are not tied to a PR
+    expect(allPatterns[0]!.prs).toEqual([]);
+  });
+
+  it('marks cluster as `mixed` when override + bot finding share a signature', async () => {
+    const ledgerDir = path.join(totemDir, 'ledger');
+    fs.mkdirSync(ledgerDir, { recursive: true });
+    // Use a justification that, after normalization, matches the bot finding
+    const event = {
+      timestamp: '2026-04-01T00:00:00.000Z',
+      type: 'override',
+      ruleId: 'rule-xyz',
+      file: 'src/handler.ts',
+      line: 10,
+      justification: 'Avoid using any type prefer unknown.',
+      source: 'shield',
+    };
+    fs.writeFileSync(path.join(ledgerDir, 'events.ndjson'), JSON.stringify(event) + '\n');
+
+    mockGhFetchAndParse.mockReturnValue([{ number: 800, mergedAt: '2026-04-01T00:00:00.000Z' }]);
+    mockFetchPr.mockReturnValue({
+      number: 800,
+      title: 't',
+      body: '',
+      state: 'merged',
+      comments: [],
+      reviews: [],
+    });
+    mockFetchReviewComments.mockReturnValue([
+      makeReviewComment({ id: 8001, body: 'Avoid using any type prefer unknown.' }),
+    ]);
+
+    await runRecurrenceStats({ threshold: 1, historyDepth: 5, yes: true });
+
+    const stats = loadStats();
+    const allPatterns = [...stats.patterns, ...stats.coveredPatterns];
+    expect(allPatterns.length).toBe(1);
+    expect(allPatterns[0]!.tool).toBe('mixed');
+    expect(allPatterns[0]!.occurrences).toBe(2);
+    expect(allPatterns[0]!.prs).toEqual(['800']);
+  });
+});

--- a/packages/cli/src/commands/recurrence-stats.test.ts
+++ b/packages/cli/src/commands/recurrence-stats.test.ts
@@ -321,7 +321,40 @@ describe('runRecurrenceStats', () => {
     await runRecurrenceStats({ threshold: 1, historyDepth: 5, yes: true });
 
     expect(fs.existsSync(path.join(totemDir, 'recurrence-stats.json'))).toBe(true);
-    expect(fs.existsSync(path.join(totemDir, 'recurrence-stats.json.tmp'))).toBe(false);
+    // No .tmp residue under any name (covers the legacy fixed-name path
+    // AND the unique PID+timestamp form introduced for mmnto-ai/totem#1729 CR R1).
+    const residue = fs.readdirSync(totemDir).filter((f) => f.endsWith('.tmp'));
+    expect(residue).toEqual([]);
+  });
+
+  it('survives concurrent invocations without temp-file collision', async () => {
+    mockGhFetchAndParse.mockReturnValue([{ number: 650, mergedAt: '2026-04-01T00:00:00.000Z' }]);
+    mockFetchPr.mockReturnValue({
+      number: 650,
+      title: 't',
+      body: '',
+      state: 'merged',
+      comments: [],
+      reviews: [],
+    });
+    mockFetchReviewComments.mockReturnValue([
+      makeReviewComment({ id: 6501, body: 'Concurrent invocation test finding.' }),
+    ]);
+
+    // Two parallel invocations would collide on a fixed `.tmp` path; the
+    // PID+epochMs suffix introduced for mmnto-ai/totem#1729 CR R1 keeps
+    // them disjoint. Both must resolve and the final file must be valid.
+    await Promise.all([
+      runRecurrenceStats({ threshold: 1, historyDepth: 5, yes: true }),
+      runRecurrenceStats({ threshold: 1, historyDepth: 5, yes: true }),
+    ]);
+
+    expect(fs.existsSync(path.join(totemDir, 'recurrence-stats.json'))).toBe(true);
+    const stats = loadStats();
+    expect(stats.version).toBe(1);
+    // No .tmp residue under any name
+    const residue = fs.readdirSync(totemDir).filter((f) => f.endsWith('.tmp'));
+    expect(residue).toEqual([]);
   });
 
   it('does not throw when compiled-rules.json is missing', async () => {

--- a/packages/cli/src/commands/recurrence-stats.ts
+++ b/packages/cli/src/commands/recurrence-stats.ts
@@ -385,7 +385,7 @@ export async function runRecurrenceStats(options: RunRecurrenceStatsOptions = {}
 
   // 10. Overwrite confirmation if file exists with newer lastUpdated
   if (fs.existsSync(outputPath)) {
-    const existingNewer = await isExistingOutputNewer(outputPath, lastUpdated, log);
+    const existingNewer = isExistingOutputNewer(outputPath, lastUpdated, log);
     if (existingNewer) {
       const proceed = await confirmOverwrite(outputPath, options.yes ?? false, log);
       if (!proceed) {
@@ -484,11 +484,11 @@ function pickDominantSeverity(buckets: SeverityBucket[]): SeverityBucket {
   return 'nit';
 }
 
-async function isExistingOutputNewer(
+function isExistingOutputNewer(
   outputPath: string,
   prospectiveTimestamp: string,
   log: { warn: (tag: string, msg: string) => void },
-): Promise<boolean> {
+): boolean {
   try {
     const raw = fs.readFileSync(outputPath, 'utf-8');
     const parsed = JSON.parse(raw) as { lastUpdated?: unknown };

--- a/packages/cli/src/commands/recurrence-stats.ts
+++ b/packages/cli/src/commands/recurrence-stats.ts
@@ -11,12 +11,12 @@
  * No LLM. No GitHub API writes. Stateless per invocation.
  */
 
-import * as fs from 'node:fs';
-import * as path from 'node:path';
-
-import { z } from 'zod';
-
 import type { NormalizedBotFinding } from '../parsers/bot-review-parser.js';
+
+// totem-context: type-only imports above are erased at compile time and don't
+// violate the lazy-import command policy (mmnto-ai/totem#1729 CR R1). All
+// runtime imports (node:fs, node:path, zod, @mmnto/totem, helpers, adapters)
+// are dynamic — see runRecurrenceStats body.
 
 // ─── Constants ───────────────────────────────────────
 
@@ -42,13 +42,6 @@ interface AnnotatedFinding {
   prNumber: string | undefined;
   observedAt: string;
 }
-
-// ─── gh PR list schema ──────────────────────────────
-
-const GhMergedPrListItemSchema = z.object({
-  number: z.number(),
-  mergedAt: z.string().nullable().optional(),
-});
 
 // ─── Severity bucket mapping ────────────────────────
 
@@ -83,6 +76,11 @@ function toSeverityBucket(
 // ─── Main entrypoint ────────────────────────────────
 
 export async function runRecurrenceStats(options: RunRecurrenceStatsOptions = {}): Promise<void> {
+  // Dynamic imports per `packages/cli/src/commands/**` lazy-import policy
+  // (mmnto-ai/totem#1729 CR R1).
+  const fs = await import('node:fs');
+  const path = await import('node:path');
+  const { z } = await import('zod');
   const { GitHubCliPrAdapter } = await import('../adapters/github-cli-pr.js');
   const { handleGhError, ghFetchAndParse } = await import('../adapters/gh-utils.js');
   const { log } = await import('../ui.js');
@@ -104,6 +102,12 @@ export async function runRecurrenceStats(options: RunRecurrenceStatsOptions = {}
     tokenizeForJaccard,
   } = await import('@mmnto/totem');
   const { loadConfig, resolveConfigPath } = await import('../utils.js');
+
+  // Schema is local to the run path so the zod import stays lazy.
+  const GhMergedPrListItemSchema = z.object({
+    number: z.number(),
+    mergedAt: z.string().nullable().optional(),
+  });
 
   const cwd = process.cwd();
 
@@ -388,7 +392,18 @@ export async function runRecurrenceStats(options: RunRecurrenceStatsOptions = {}
 
   // 10. Overwrite confirmation if file exists with newer lastUpdated
   if (fs.existsSync(outputPath)) {
-    const existingNewer = isExistingOutputNewer(outputPath, lastUpdated, log);
+    let existingNewer = false;
+    try {
+      const raw = fs.readFileSync(outputPath, 'utf-8');
+      const parsed = JSON.parse(raw) as { lastUpdated?: unknown };
+      if (typeof parsed.lastUpdated === 'string') {
+        existingNewer = parsed.lastUpdated > lastUpdated;
+      }
+      // totem-context: best-effort read — an unparseable existing file is treated as "not newer" so the overwrite path proceeds rather than erroring. Atomic temp+rename below protects user data; log.warn surfaces parse failures for diagnostics.
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.warn(TAG, `Could not read existing recurrence-stats.json: ${msg}`);
+    }
     if (existingNewer) {
       const proceed = await confirmOverwrite(outputPath, options.yes ?? false, log);
       if (!proceed) {
@@ -398,11 +413,21 @@ export async function runRecurrenceStats(options: RunRecurrenceStatsOptions = {}
     }
   }
 
-  // 11. Atomic write
+  // 11. Atomic write — unique temp filename (PID + epoch ms + random) so
+  //     concurrent invocations don't race on the same .tmp path
+  //     (mmnto-ai/totem#1729 CR R1 + R2). PID alone is identical across
+  //     in-process awaits and Date.now() can collide on the same ms; the
+  //     random suffix closes both gaps deterministically.
   fs.mkdirSync(totemDir, { recursive: true });
-  const tmp = outputPath + '.tmp';
-  fs.writeFileSync(tmp, JSON.stringify(stats, null, 2) + '\n', 'utf-8');
-  fs.renameSync(tmp, outputPath);
+  const crypto = await import('node:crypto');
+  const tmp = `${outputPath}.${process.pid}.${Date.now()}.${crypto.randomUUID()}.tmp`;
+  try {
+    fs.writeFileSync(tmp, JSON.stringify(stats, null, 2) + '\n', 'utf-8');
+    fs.renameSync(tmp, outputPath);
+  } finally {
+    // Defensive cleanup if rename failed mid-flight.
+    if (fs.existsSync(tmp)) fs.rmSync(tmp, { force: true });
+  }
 
   // 12. Stdout summary (via log → stderr; mirrors statsCommand voice)
   log.info(TAG, `Wrote ${outputPath}`);
@@ -485,24 +510,6 @@ function pickDominantSeverity(buckets: SeverityBucket[]): SeverityBucket {
     if (buckets.includes(candidate)) return candidate;
   }
   return 'nit';
-}
-
-function isExistingOutputNewer(
-  outputPath: string,
-  prospectiveTimestamp: string,
-  log: { warn: (tag: string, msg: string) => void },
-): boolean {
-  try {
-    const raw = fs.readFileSync(outputPath, 'utf-8');
-    const parsed = JSON.parse(raw) as { lastUpdated?: unknown };
-    if (typeof parsed.lastUpdated !== 'string') return false;
-    return parsed.lastUpdated > prospectiveTimestamp;
-    // totem-context: best-effort read — an unparseable existing file is treated as "not newer" so the overwrite path proceeds rather than erroring. Atomic temp+rename in the caller protects user data; log.warn surfaces the parse failure for diagnostics.
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    log.warn(TAG, `Could not read existing recurrence-stats.json: ${msg}`);
-    return false;
-  }
 }
 
 async function confirmOverwrite(

--- a/packages/cli/src/commands/recurrence-stats.ts
+++ b/packages/cli/src/commands/recurrence-stats.ts
@@ -154,10 +154,6 @@ export async function runRecurrenceStats(options: RunRecurrenceStatsOptions = {}
 
   for (const pr of prList) {
     const prNum = pr.number;
-    // totem-context: per-PR resilience — log + continue with partial data per the
-    // mmnto-ai/totem#1715 design (rate-limit / transient adapter failures must
-    // not abort the whole scan; the final report flags partial coverage via
-    // prsScanned < historyDepth).
     try {
       const prData = adapter.fetchPr(prNum);
       const reviewComments = adapter.fetchReviewComments(prNum);
@@ -213,6 +209,7 @@ export async function runRecurrenceStats(options: RunRecurrenceStatsOptions = {}
       }
 
       prsScanned.push(String(prNum));
+      // totem-context: per-PR catch swallows transient errors by design — log + continue with partial data per the mmnto-ai/totem#1715 failure-mode table; the scan must not abort on rate-limit / adapter failures, and prsScanned < historyDepth surfaces partial coverage in the final report.
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       log.warn(TAG, `PR #${prNum}: skipped (${msg})`);
@@ -309,12 +306,9 @@ export async function runRecurrenceStats(options: RunRecurrenceStatsOptions = {}
   // 6. Coverage filter against compiled rules
   const rulesPath = path.join(totemDir, 'compiled-rules.json');
   let compiledRules: Array<{ message: string }> = [];
-  // totem-context: intentional fallback — per the mmnto-ai/totem#1715 design,
-  // a missing or malformed compiled-rules.json must not abort the recurrence
-  // scan; coverage routing is just disabled and every cluster lands in
-  // headline `patterns` with `coveredByRule: false`.
   try {
     compiledRules = loadCompiledRules(rulesPath) as Array<{ message: string }>;
+    // totem-context: missing/malformed compiled-rules.json disables coverage routing only — every cluster lands in headline `patterns` with `coveredByRule: false` per the mmnto-ai/totem#1715 failure-mode table. The scan must not abort on a missing manifest.
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     log.warn(TAG, `Could not load compiled rules: ${msg} — coverage check disabled.`);
@@ -498,15 +492,12 @@ function isExistingOutputNewer(
   prospectiveTimestamp: string,
   log: { warn: (tag: string, msg: string) => void },
 ): boolean {
-  // totem-context: best-effort read — an unparseable existing file is
-  // treated as "not newer" so the overwrite path proceeds rather than
-  // erroring. The user's data isn't lost (atomic temp+rename), and the
-  // log.warn surfaces the parse failure for diagnostics.
   try {
     const raw = fs.readFileSync(outputPath, 'utf-8');
     const parsed = JSON.parse(raw) as { lastUpdated?: unknown };
     if (typeof parsed.lastUpdated !== 'string') return false;
     return parsed.lastUpdated > prospectiveTimestamp;
+    // totem-context: best-effort read — an unparseable existing file is treated as "not newer" so the overwrite path proceeds rather than erroring. Atomic temp+rename in the caller protects user data; log.warn surfaces the parse failure for diagnostics.
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     log.warn(TAG, `Could not read existing recurrence-stats.json: ${msg}`);

--- a/packages/cli/src/commands/recurrence-stats.ts
+++ b/packages/cli/src/commands/recurrence-stats.ts
@@ -1,0 +1,524 @@
+/**
+ * `totem stats --pattern-recurrence` — cross-PR recurrence clustering.
+ *
+ * Substrate of mmnto-ai/totem#1715. Fetches bot-review findings across
+ * the most recent N merged PRs (configurable via --history-depth, default
+ * 50, capped at 200), folds in trap-ledger override events as co-equal
+ * findings, clusters by normalized signature, filters out clusters
+ * already covered by an existing compiled rule, and writes the survivors
+ * at `.totem/recurrence-stats.json` plus a stdout summary.
+ *
+ * No LLM. No GitHub API writes. Stateless per invocation.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { z } from 'zod';
+
+import type { NormalizedBotFinding } from '../parsers/bot-review-parser.js';
+
+// ─── Constants ───────────────────────────────────────
+
+const TAG = 'Recurrence';
+const DEFAULT_THRESHOLD = 5;
+const DEFAULT_HISTORY_DEPTH = 50;
+const MAX_HISTORY_DEPTH = 200;
+const MAX_SAMPLE_BODIES = 3;
+const MAX_PATHS = 10;
+const COVERAGE_JACCARD_THRESHOLD = 0.6;
+
+// ─── Types ───────────────────────────────────────────
+
+export interface RunRecurrenceStatsOptions {
+  threshold?: number;
+  historyDepth?: number;
+  yes?: boolean;
+}
+
+/** Internal: a finding plus its source PR + observed timestamp. */
+interface AnnotatedFinding {
+  finding: NormalizedBotFinding;
+  prNumber: string | undefined;
+  observedAt: string;
+}
+
+// ─── gh PR list schema ──────────────────────────────
+
+const GhMergedPrListItemSchema = z.object({
+  number: z.number(),
+  mergedAt: z.string().nullable().optional(),
+});
+
+// ─── Severity bucket mapping ────────────────────────
+
+type SeverityBucket = 'critical' | 'high' | 'medium' | 'low' | 'nit';
+
+function toSeverityBucket(
+  tool: NormalizedBotFinding['tool'] | 'override',
+  severity: string,
+): SeverityBucket {
+  const s = severity.toLowerCase();
+  if (tool === 'override') return 'medium';
+  if (tool === 'coderabbit') {
+    if (s === 'critical') return 'critical';
+    if (s === 'major') return 'high';
+    if (s === 'minor') return 'medium';
+    return 'low';
+  }
+  if (tool === 'gca') {
+    if (s === 'high') return 'high';
+    if (s === 'medium') return 'medium';
+    if (s === 'low') return 'low';
+    return 'low';
+  }
+  // unknown tool / synthesized review-body
+  if (s === 'critical') return 'critical';
+  if (s === 'high' || s === 'major') return 'high';
+  if (s === 'medium' || s === 'minor' || s === 'warning') return 'medium';
+  if (s === 'low' || s === 'info') return 'low';
+  return 'nit';
+}
+
+// ─── Main entrypoint ────────────────────────────────
+
+export async function runRecurrenceStats(options: RunRecurrenceStatsOptions = {}): Promise<void> {
+  const { GitHubCliPrAdapter } = await import('../adapters/github-cli-pr.js');
+  const { handleGhError, ghFetchAndParse } = await import('../adapters/gh-utils.js');
+  const { log } = await import('../ui.js');
+  const {
+    isBotComment,
+    detectBot,
+    parseCRSeverity,
+    parseGCASeverity,
+    stripHtmlWrappers,
+    extractSuggestion,
+    extractReviewBodyFindings,
+  } = await import('../parsers/bot-review-parser.js');
+  const {
+    computeSignature,
+    jaccard,
+    loadCompiledRules,
+    normalizeFindingBody,
+    readLedgerEvents,
+    tokenizeForJaccard,
+  } = await import('@mmnto/totem');
+  const { loadConfig, resolveConfigPath } = await import('../utils.js');
+
+  const cwd = process.cwd();
+
+  // 1. Validate + clamp options
+  const threshold = clampThreshold(options.threshold);
+  let historyDepth = clampHistoryDepth(options.historyDepth);
+  if (options.historyDepth !== undefined && options.historyDepth > MAX_HISTORY_DEPTH) {
+    log.warn(
+      TAG,
+      `--history-depth ${options.historyDepth} exceeds cap of ${MAX_HISTORY_DEPTH}; using ${MAX_HISTORY_DEPTH} instead.`,
+    );
+    historyDepth = MAX_HISTORY_DEPTH;
+  }
+
+  log.info(TAG, `Scanning up to ${historyDepth} merged PR(s); threshold=${threshold}.`);
+
+  // 2. Fetch the most recent merged PRs via gh
+  let prList: Array<{ number: number; mergedAt?: string | null }> = [];
+  try {
+    prList = ghFetchAndParse(
+      [
+        'pr',
+        'list',
+        '--state',
+        'merged',
+        '--limit',
+        String(historyDepth),
+        '--json',
+        'number,mergedAt',
+      ],
+      z.array(GhMergedPrListItemSchema),
+      'merged PR list',
+      cwd,
+    );
+  } catch (err) {
+    // ghFetchAndParse already wraps via handleGhError on its own throw path,
+    // but if anything slipped through wrap it here for the same hint surface.
+    handleGhError(err, 'merged PR list');
+  }
+
+  log.info(TAG, `Found ${prList.length} merged PR(s).`);
+
+  // 3. Per-PR fetch + finding extraction
+  const adapter = new GitHubCliPrAdapter(cwd);
+  const annotated: AnnotatedFinding[] = [];
+  const prsScanned: string[] = [];
+
+  for (const pr of prList) {
+    const prNum = pr.number;
+    try {
+      const prData = adapter.fetchPr(prNum);
+      const reviewComments = adapter.fetchReviewComments(prNum);
+
+      // Group threads by root id
+      const threads = groupThreadsByRoot(reviewComments);
+      const botThreads = threads.filter(
+        (t) => t.comments.length > 0 && isBotComment(t.comments[0]!.author),
+      );
+
+      // Inline bot findings
+      const inlineFindings: NormalizedBotFinding[] = [];
+      for (const thread of botThreads) {
+        const botComment = thread.comments[0];
+        if (!botComment) continue;
+        const tool = detectBot(botComment.author);
+        const severity =
+          tool === 'coderabbit'
+            ? parseCRSeverity(botComment.body)
+            : tool === 'gca'
+              ? parseGCASeverity(botComment.body)
+              : 'info';
+
+        const body = stripHtmlWrappers(botComment.body);
+        const suggestion = extractSuggestion(botComment.body);
+        const hunkMatch = thread.diffHunk.match(/@@ .+?\+(\d+)/);
+        const line = hunkMatch ? parseInt(hunkMatch[1]!, 10) : undefined;
+
+        inlineFindings.push({
+          tool,
+          severity,
+          file: thread.path,
+          line,
+          body,
+          suggestion,
+          resolutionSignal: 'none',
+          rootCommentId: botComment.id,
+        });
+      }
+
+      // Review-body findings (CR outside-diff + nits)
+      const reviewBodyFindings = extractReviewBodyFindings(prData.reviews);
+
+      const allFindings = [...inlineFindings, ...reviewBodyFindings];
+      // Use the PR's mergedAt as observation timestamp (best available).
+      const observedAt = pr.mergedAt ?? new Date().toISOString();
+      for (const f of allFindings) {
+        annotated.push({
+          finding: f,
+          prNumber: String(prNum),
+          observedAt,
+        });
+      }
+
+      prsScanned.push(String(prNum));
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.warn(TAG, `PR #${prNum}: skipped (${msg})`);
+      continue;
+    }
+  }
+
+  log.info(
+    TAG,
+    `Scanned ${prsScanned.length}/${prList.length} PR(s); collected ${annotated.length} bot finding(s).`,
+  );
+
+  // 4. Trap-ledger overrides as co-equal findings (Q4)
+  const config = await loadConfig(resolveConfigPath(cwd));
+  const totemDir = path.join(cwd, config.totemDir);
+  const ledgerEvents = readLedgerEvents(totemDir, (msg) => log.warn(TAG, msg));
+  const overrideEvents = ledgerEvents.filter((e) => e.type === 'override');
+  for (const event of overrideEvents) {
+    const synthetic: NormalizedBotFinding = {
+      tool: 'unknown',
+      severity: 'medium',
+      file: event.file,
+      line: event.line,
+      body: event.justification,
+      resolutionSignal: 'none',
+    };
+    annotated.push({
+      finding: synthetic,
+      prNumber: undefined,
+      observedAt: event.timestamp,
+    });
+  }
+  if (overrideEvents.length > 0) {
+    log.info(TAG, `Folded in ${overrideEvents.length} trap-ledger override event(s).`);
+  }
+
+  // 5. Cluster by signature
+  interface MutableCluster {
+    signature: string;
+    tools: Set<'coderabbit' | 'gca' | 'sarif' | 'override' | 'unknown'>;
+    severityBuckets: SeverityBucket[];
+    occurrences: number;
+    prs: Set<string>;
+    sampleBodies: string[];
+    firstSeen: string;
+    lastSeen: string;
+    paths: Set<string>;
+    normalizedBody: string;
+  }
+
+  const clusters = new Map<string, MutableCluster>();
+
+  for (const a of annotated) {
+    const isOverride = a.prNumber === undefined;
+    const tool = isOverride ? ('override' as const) : a.finding.tool;
+
+    const normalized = normalizeFindingBody(a.finding.body);
+    if (normalized.length === 0) continue;
+    const signature = computeSignature(normalized);
+
+    const bucket = toSeverityBucket(tool, a.finding.severity);
+
+    let cluster = clusters.get(signature);
+    if (!cluster) {
+      cluster = {
+        signature,
+        tools: new Set(),
+        severityBuckets: [],
+        occurrences: 0,
+        prs: new Set(),
+        sampleBodies: [],
+        firstSeen: a.observedAt,
+        lastSeen: a.observedAt,
+        paths: new Set(),
+        normalizedBody: normalized,
+      };
+      clusters.set(signature, cluster);
+    }
+
+    cluster.tools.add(tool);
+    cluster.severityBuckets.push(bucket);
+    cluster.occurrences += 1;
+    if (a.prNumber !== undefined) cluster.prs.add(a.prNumber);
+    if (cluster.sampleBodies.length < MAX_SAMPLE_BODIES) {
+      cluster.sampleBodies.push(a.finding.body);
+    }
+    if (a.observedAt < cluster.firstSeen) cluster.firstSeen = a.observedAt;
+    if (a.observedAt > cluster.lastSeen) cluster.lastSeen = a.observedAt;
+    if (a.finding.file && a.finding.file !== '(review body)') {
+      if (cluster.paths.size < MAX_PATHS) cluster.paths.add(a.finding.file);
+    }
+  }
+
+  // 6. Coverage filter against compiled rules
+  const rulesPath = path.join(totemDir, 'compiled-rules.json');
+  let compiledRules: Array<{ message: string }> = [];
+  try {
+    compiledRules = loadCompiledRules(rulesPath) as Array<{ message: string }>;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warn(TAG, `Could not load compiled rules: ${msg} — coverage check disabled.`);
+    compiledRules = [];
+  }
+
+  // Pre-tokenize rule messages once.
+  const ruleTokenSets = compiledRules.map((r) => tokenizeForJaccard(r.message ?? ''));
+
+  // 7. Materialize patterns
+  const allPatterns: Array<{
+    signature: string;
+    tool: 'coderabbit' | 'gca' | 'sarif' | 'override' | 'mixed' | 'unknown';
+    severityBucket: SeverityBucket;
+    occurrences: number;
+    prs: string[];
+    sampleBodies: string[];
+    firstSeen: string;
+    lastSeen: string;
+    paths: string[];
+    coveredByRule: boolean;
+  }> = [];
+
+  for (const cluster of clusters.values()) {
+    const tools = [...cluster.tools];
+    const tool = tools.length > 1 ? 'mixed' : (tools[0] ?? 'unknown');
+    const severityBucket = pickDominantSeverity(cluster.severityBuckets);
+
+    // Coverage heuristic: max Jaccard across all rule messages ≥ 0.6
+    const findingTokens = tokenizeForJaccard(cluster.normalizedBody);
+    let maxJaccard = 0;
+    for (const ruleTokens of ruleTokenSets) {
+      const v = jaccard(findingTokens, ruleTokens);
+      if (v > maxJaccard) maxJaccard = v;
+    }
+    const coveredByRule = maxJaccard >= COVERAGE_JACCARD_THRESHOLD;
+
+    const prs = [...cluster.prs].sort((a, b) => Number(a) - Number(b));
+    const paths = [...cluster.paths].sort((a, b) => a.localeCompare(b));
+
+    allPatterns.push({
+      signature: cluster.signature,
+      tool,
+      severityBucket,
+      occurrences: cluster.occurrences,
+      prs,
+      sampleBodies: cluster.sampleBodies,
+      firstSeen: cluster.firstSeen,
+      lastSeen: cluster.lastSeen,
+      paths,
+      coveredByRule,
+    });
+  }
+
+  // 8. Split into headline + covered, apply threshold to headline only
+  const headlinePatterns = allPatterns
+    .filter((p) => !p.coveredByRule)
+    .filter((p) => p.occurrences >= threshold)
+    .sort((a, b) => b.occurrences - a.occurrences);
+
+  const coveredPatterns = allPatterns
+    .filter((p) => p.coveredByRule)
+    .sort((a, b) => b.occurrences - a.occurrences);
+
+  // 9. Output preparation
+  const outputPath = path.join(totemDir, 'recurrence-stats.json');
+  const lastUpdated = new Date().toISOString();
+  const stats = {
+    version: 1 as const,
+    lastUpdated,
+    thresholdApplied: threshold,
+    historyDepth,
+    prsScanned,
+    patterns: headlinePatterns,
+    coveredPatterns,
+  };
+
+  // 10. Overwrite confirmation if file exists with newer lastUpdated
+  if (fs.existsSync(outputPath)) {
+    const existingNewer = await isExistingOutputNewer(outputPath, lastUpdated, log);
+    if (existingNewer) {
+      const proceed = await confirmOverwrite(outputPath, options.yes ?? false, log);
+      if (!proceed) {
+        log.warn(TAG, 'Overwrite declined; not writing recurrence-stats.json.');
+        return;
+      }
+    }
+  }
+
+  // 11. Atomic write
+  fs.mkdirSync(totemDir, { recursive: true });
+  const tmp = outputPath + '.tmp';
+  fs.writeFileSync(tmp, JSON.stringify(stats, null, 2) + '\n', 'utf-8');
+  fs.renameSync(tmp, outputPath);
+
+  // 12. Stdout summary (via log → stderr; mirrors statsCommand voice)
+  log.info(TAG, `Wrote ${outputPath}`);
+  log.info(
+    TAG,
+    `Patterns at-or-above threshold ${threshold}: ${headlinePatterns.length} (covered: ${coveredPatterns.length}, scanned PRs: ${prsScanned.length}/${historyDepth}).`,
+  );
+
+  if (headlinePatterns.length > 0) {
+    log.info(TAG, 'Top recurrences:');
+    for (const p of headlinePatterns.slice(0, 5)) {
+      const snippet = (p.sampleBodies[0] ?? '').replace(/\s+/g, ' ').slice(0, 80);
+      log.dim(TAG, `  [${p.signature}] ${p.occurrences}x across ${p.prs.length} PR(s): ${snippet}`);
+    }
+  } else {
+    log.dim(TAG, '  (none — all clusters below threshold or covered by existing rules)');
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────
+
+interface MinimalThread {
+  path: string;
+  diffHunk: string;
+  comments: { id?: number; author: string; body: string }[];
+}
+
+function groupThreadsByRoot(
+  comments: Array<{
+    id: number;
+    author: string;
+    body: string;
+    path: string;
+    diffHunk: string;
+    inReplyToId?: number;
+    createdAt?: string;
+  }>,
+): MinimalThread[] {
+  const byId = new Map<number, (typeof comments)[number]>();
+  for (const c of comments) byId.set(c.id, c);
+
+  const threadMap = new Map<number, (typeof comments)[number][]>();
+  for (const c of comments) {
+    const rootId = c.inReplyToId ?? c.id;
+    const thread = threadMap.get(rootId) ?? [];
+    thread.push(c);
+    threadMap.set(rootId, thread);
+  }
+
+  const threads: MinimalThread[] = [];
+  for (const [rootId, threadComments] of threadMap) {
+    threadComments.sort((a, b) => {
+      if (!a.createdAt || !b.createdAt) return 0;
+      return a.createdAt.localeCompare(b.createdAt);
+    });
+    const root = byId.get(rootId) ?? threadComments[0]!;
+    threads.push({
+      path: root.path,
+      diffHunk: root.diffHunk,
+      comments: threadComments.map((c) => ({ id: c.id, author: c.author, body: c.body })),
+    });
+  }
+  return threads;
+}
+
+function clampThreshold(input: number | undefined): number {
+  if (input === undefined || !Number.isFinite(input) || input < 1) return DEFAULT_THRESHOLD;
+  return Math.floor(input);
+}
+
+function clampHistoryDepth(input: number | undefined): number {
+  if (input === undefined || !Number.isFinite(input) || input < 1) return DEFAULT_HISTORY_DEPTH;
+  return Math.min(MAX_HISTORY_DEPTH, Math.floor(input));
+}
+
+/** Pick the highest-severity bucket present in the cluster. */
+function pickDominantSeverity(buckets: SeverityBucket[]): SeverityBucket {
+  const order: SeverityBucket[] = ['critical', 'high', 'medium', 'low', 'nit'];
+  for (const candidate of order) {
+    if (buckets.includes(candidate)) return candidate;
+  }
+  return 'nit';
+}
+
+async function isExistingOutputNewer(
+  outputPath: string,
+  prospectiveTimestamp: string,
+  log: { warn: (tag: string, msg: string) => void },
+): Promise<boolean> {
+  try {
+    const raw = fs.readFileSync(outputPath, 'utf-8');
+    const parsed = JSON.parse(raw) as { lastUpdated?: unknown };
+    if (typeof parsed.lastUpdated !== 'string') return false;
+    return parsed.lastUpdated > prospectiveTimestamp;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.warn(TAG, `Could not read existing recurrence-stats.json: ${msg}`);
+    return false;
+  }
+}
+
+async function confirmOverwrite(
+  outputPath: string,
+  yesFlag: boolean,
+  log: { warn: (tag: string, msg: string) => void },
+): Promise<boolean> {
+  if (yesFlag) return true;
+  if (!process.stdin.isTTY) {
+    log.warn(
+      TAG,
+      `Existing ${outputPath} is newer; pass --yes to overwrite in non-interactive mode.`,
+    );
+    return false;
+  }
+  const { confirm, isCancel } = await import('@clack/prompts');
+  const ans = await confirm({
+    message: `Existing ${outputPath} is newer. Overwrite?`,
+    initialValue: false,
+  });
+  if (isCancel(ans)) return false;
+  return ans === true;
+}

--- a/packages/cli/src/commands/recurrence-stats.ts
+++ b/packages/cli/src/commands/recurrence-stats.ts
@@ -142,6 +142,7 @@ export async function runRecurrenceStats(options: RunRecurrenceStatsOptions = {}
     // ghFetchAndParse already wraps via handleGhError on its own throw path,
     // but if anything slipped through wrap it here for the same hint surface.
     handleGhError(err, 'merged PR list');
+    throw err;
   }
 
   log.info(TAG, `Found ${prList.length} merged PR(s).`);
@@ -153,6 +154,10 @@ export async function runRecurrenceStats(options: RunRecurrenceStatsOptions = {}
 
   for (const pr of prList) {
     const prNum = pr.number;
+    // totem-context: per-PR resilience — log + continue with partial data per the
+    // mmnto-ai/totem#1715 design (rate-limit / transient adapter failures must
+    // not abort the whole scan; the final report flags partial coverage via
+    // prsScanned < historyDepth).
     try {
       const prData = adapter.fetchPr(prNum);
       const reviewComments = adapter.fetchReviewComments(prNum);
@@ -304,6 +309,10 @@ export async function runRecurrenceStats(options: RunRecurrenceStatsOptions = {}
   // 6. Coverage filter against compiled rules
   const rulesPath = path.join(totemDir, 'compiled-rules.json');
   let compiledRules: Array<{ message: string }> = [];
+  // totem-context: intentional fallback — per the mmnto-ai/totem#1715 design,
+  // a missing or malformed compiled-rules.json must not abort the recurrence
+  // scan; coverage routing is just disabled and every cluster lands in
+  // headline `patterns` with `coveredByRule: false`.
   try {
     compiledRules = loadCompiledRules(rulesPath) as Array<{ message: string }>;
   } catch (err) {
@@ -489,6 +498,10 @@ function isExistingOutputNewer(
   prospectiveTimestamp: string,
   log: { warn: (tag: string, msg: string) => void },
 ): boolean {
+  // totem-context: best-effort read — an unparseable existing file is
+  // treated as "not newer" so the overwrite path proceeds rather than
+  // erroring. The user's data isn't lost (atomic temp+rename), and the
+  // log.warn surfaces the parse failure for diagnostics.
   try {
     const raw = fs.readFileSync(outputPath, 'utf-8');
     const parsed = JSON.parse(raw) as { lastUpdated?: unknown };

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -1,4 +1,21 @@
-export async function statsCommand(): Promise<void> {
+export interface StatsOptions {
+  patternRecurrence?: boolean;
+  threshold?: number;
+  historyDepth?: number;
+  yes?: boolean;
+}
+
+export async function statsCommand(options: StatsOptions = {}): Promise<void> {
+  if (options.patternRecurrence) {
+    const { runRecurrenceStats } = await import('./recurrence-stats.js');
+    await runRecurrenceStats({
+      threshold: options.threshold,
+      historyDepth: options.historyDepth,
+      yes: options.yes,
+    });
+    return;
+  }
+
   const path = await import('node:path');
   const { createEmbedder, LanceStore } = await import('@mmnto/totem');
   const { loadConfig, loadEnv, requireEmbedding, resolveConfigPath } = await import('../utils.js');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -136,14 +136,64 @@ program
 program
   .command('stats')
   .description('Show index statistics')
-  .action(async () => {
-    try {
-      const { statsCommand } = await import('./commands/stats.js');
-      await statsCommand();
-    } catch (err) {
-      handleError(err);
-    }
-  });
+  .option(
+    '--pattern-recurrence',
+    'Cluster bot-review findings + trap-ledger overrides across the most recent merged PRs and write .totem/recurrence-stats.json (mmnto-ai/totem#1715)',
+  )
+  .option(
+    '--threshold <n>',
+    'Recurrence mode: minimum occurrences for a pattern to land in the headline output (default: 5)',
+    '5',
+  )
+  .option(
+    '--history-depth <n>',
+    'Recurrence mode: number of recent merged PRs to scan (default: 50, capped at 200)',
+    '50',
+  )
+  .option(
+    '--yes',
+    'Recurrence mode: auto-confirm overwrite when an existing recurrence-stats.json is newer',
+  )
+  .addHelpText(
+    'after',
+    [
+      '',
+      'Recurrence mode (--pattern-recurrence):',
+      '  Fetches bot-review findings across the most recent merged PRs (default 50,',
+      '  capped at 200 via --history-depth) plus trap-ledger override events,',
+      '  clusters them by a normalized signature, filters out clusters covered by',
+      '  existing compiled rules (Jaccard >= 0.6 on rule message), and writes the',
+      '  surviving patterns at-or-above --threshold to .totem/recurrence-stats.json.',
+      '  Requires the GitHub CLI (`gh`) authenticated against the current repo.',
+      '',
+    ].join('\n'),
+  )
+  .action(
+    async (opts: {
+      patternRecurrence?: boolean;
+      threshold?: string;
+      historyDepth?: string;
+      yes?: boolean;
+    }) => {
+      try {
+        const threshold = opts.threshold ? parseInt(opts.threshold, 10) : undefined;
+        const historyDepth = opts.historyDepth ? parseInt(opts.historyDepth, 10) : undefined;
+        if (opts.patternRecurrence) {
+          requireGhCli();
+        }
+        const { statsCommand } = await import('./commands/stats.js');
+        await statsCommand({
+          patternRecurrence: opts.patternRecurrence,
+          threshold,
+          historyDepth,
+          yes: opts.yes,
+        });
+      } catch (err) {
+        handleError(err); // handleError returns `never`; unreachable throw below satisfies the fail-loud check
+        throw err;
+      }
+    },
+  );
 
 program
   .command('explain <hash>')

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -396,3 +396,21 @@ export { codeToPattern, escapeRegex } from './regex-utils.js';
 // Pipeline 5 — observation-based auto-capture from shield findings
 export type { ObservationInput } from './pipeline-observation.js';
 export { deduplicateObservations, generateObservationRule } from './pipeline-observation.js';
+
+// Recurrence-stats schemas + helpers (mmnto-ai/totem#1715)
+export type {
+  RecurrencePattern,
+  RecurrenceSeverityBucket,
+  RecurrenceStats,
+  RecurrenceTool,
+} from './recurrence-stats.js';
+export {
+  computeSignature,
+  jaccard,
+  normalizeFindingBody,
+  RecurrencePatternSchema,
+  RecurrenceSeverityBucketSchema,
+  RecurrenceStatsSchema,
+  RecurrenceToolSchema,
+  tokenizeForJaccard,
+} from './recurrence-stats.js';

--- a/packages/core/src/recurrence-stats.test.ts
+++ b/packages/core/src/recurrence-stats.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeSignature,
+  jaccard,
+  normalizeFindingBody,
+  RecurrencePatternSchema,
+  RecurrenceStatsSchema,
+  tokenizeForJaccard,
+} from './recurrence-stats.js';
+
+// ─── RecurrencePatternSchema ───────────────────────────
+
+describe('RecurrencePatternSchema', () => {
+  it('parses a well-formed pattern', () => {
+    const result = RecurrencePatternSchema.safeParse({
+      signature: 'abc123def4567890',
+      tool: 'coderabbit',
+      severityBucket: 'medium',
+      occurrences: 7,
+      prs: ['101', '102'],
+      sampleBodies: ['avoid using any type here', 'avoid using any type'],
+      firstSeen: '2026-01-01T00:00:00.000Z',
+      lastSeen: '2026-01-15T00:00:00.000Z',
+      paths: ['src/a.ts', 'src/b.ts'],
+      coveredByRule: false,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects malformed pattern (missing fields)', () => {
+    const result = RecurrencePatternSchema.safeParse({
+      signature: 'abc',
+      tool: 'coderabbit',
+      // missing other fields
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects unknown tool', () => {
+    const result = RecurrencePatternSchema.safeParse({
+      signature: 'abc',
+      tool: 'sonarqube',
+      severityBucket: 'low',
+      occurrences: 1,
+      prs: [],
+      sampleBodies: [],
+      firstSeen: 'x',
+      lastSeen: 'y',
+      paths: [],
+      coveredByRule: false,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects sampleBodies > 3', () => {
+    const result = RecurrencePatternSchema.safeParse({
+      signature: 'abc',
+      tool: 'gca',
+      severityBucket: 'low',
+      occurrences: 4,
+      prs: ['1'],
+      sampleBodies: ['a', 'b', 'c', 'd'],
+      firstSeen: 'x',
+      lastSeen: 'y',
+      paths: [],
+      coveredByRule: false,
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe('RecurrenceStatsSchema', () => {
+  it('parses an empty stats document', () => {
+    const result = RecurrenceStatsSchema.safeParse({
+      version: 1,
+      lastUpdated: '2026-04-28T00:00:00.000Z',
+      thresholdApplied: 5,
+      historyDepth: 50,
+      prsScanned: [],
+      patterns: [],
+      coveredPatterns: [],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects non-1 version', () => {
+    const result = RecurrenceStatsSchema.safeParse({
+      version: 2,
+      lastUpdated: 'x',
+      thresholdApplied: 5,
+      historyDepth: 50,
+      prsScanned: [],
+      patterns: [],
+      coveredPatterns: [],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── normalizeFindingBody ──────────────────────────────
+
+describe('normalizeFindingBody', () => {
+  it('strips file paths with line:col suffix', () => {
+    const body = 'Avoid using `any` in packages/cli/src/foo.ts:42:7 and src/bar.ts:10';
+    const out = normalizeFindingBody(body);
+    expect(out).not.toContain('packages/cli/src/foo.ts');
+    expect(out).not.toContain('src/bar.ts');
+    expect(out).not.toMatch(/:42/);
+    expect(out).not.toMatch(/:10\b/);
+  });
+
+  it('strips standalone line references', () => {
+    const out = normalizeFindingBody('See line 42 and Line: 100 below');
+    expect(out).not.toContain('line 42');
+    expect(out).not.toContain('line: 100');
+    expect(out).not.toMatch(/\bline\b/);
+  });
+
+  it('strips triple-backtick fenced code', () => {
+    const body = 'Wrap this:\n```ts\nconst x: any = 1;\n```\nUse a real type.';
+    const out = normalizeFindingBody(body);
+    expect(out).not.toContain('const x');
+    expect(out).not.toContain('```');
+    expect(out).toContain('use a real type');
+  });
+
+  it('strips backtick-spans', () => {
+    const out = normalizeFindingBody('Avoid `any` here, prefer `unknown`.');
+    expect(out).not.toContain('`');
+    expect(out).toContain('avoid');
+    expect(out).toContain('prefer');
+  });
+
+  it('strips URLs', () => {
+    const out = normalizeFindingBody(
+      'See https://github.com/mmnto-ai/totem/issues/1715 for context.',
+    );
+    expect(out).not.toContain('https://');
+    expect(out).not.toContain('github.com');
+  });
+
+  it('strips leading severity prefix `CRITICAL: `', () => {
+    const out = normalizeFindingBody('CRITICAL: shell injection risk in handler.');
+    expect(out.startsWith('shell')).toBe(true);
+  });
+
+  it('strips leading bold severity prefix `**Critical**`', () => {
+    const out = normalizeFindingBody('**Critical** shell injection risk.');
+    expect(out.startsWith('shell')).toBe(true);
+  });
+
+  it('lowercases and collapses internal whitespace', () => {
+    const out = normalizeFindingBody('Avoid    USING\n\n  ANY    TYPE');
+    expect(out).toBe('avoid using any type');
+  });
+
+  it('produces the same normalized output for path/line variants', () => {
+    const a = normalizeFindingBody(
+      'Avoid using `any` in packages/cli/src/foo.ts:42 — prefer unknown.',
+    );
+    const b = normalizeFindingBody(
+      'Avoid using `any` in packages/core/src/bar.ts:99 — prefer unknown.',
+    );
+    expect(a).toBe(b);
+  });
+});
+
+// ─── computeSignature ──────────────────────────────────
+
+describe('computeSignature', () => {
+  it('is deterministic for the same input', () => {
+    const sig1 = computeSignature('avoid using any type');
+    const sig2 = computeSignature('avoid using any type');
+    expect(sig1).toBe(sig2);
+  });
+
+  it('produces a 16-char hex string', () => {
+    const sig = computeSignature('hello world');
+    expect(sig).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('differs for distinct inputs', () => {
+    const a = computeSignature('avoid using any type');
+    const b = computeSignature('avoid using let');
+    expect(a).not.toBe(b);
+  });
+});
+
+// ─── tokenizeForJaccard ────────────────────────────────
+
+describe('tokenizeForJaccard', () => {
+  it('drops tokens of length <= 2', () => {
+    const toks = tokenizeForJaccard('a bb ccc dddd');
+    expect(toks.has('a')).toBe(false);
+    expect(toks.has('bb')).toBe(false);
+    expect(toks.has('ccc')).toBe(true);
+    expect(toks.has('dddd')).toBe(true);
+  });
+
+  it('drops stopwords', () => {
+    const toks = tokenizeForJaccard('the use of any using');
+    expect(toks.has('the')).toBe(false);
+    expect(toks.has('use')).toBe(false);
+    expect(toks.has('using')).toBe(false);
+    expect(toks.has('any')).toBe(true);
+  });
+
+  it('lowercases tokens', () => {
+    const toks = tokenizeForJaccard('Avoid USING ANY TYPE');
+    expect(toks.has('avoid')).toBe(true);
+    expect(toks.has('any')).toBe(true);
+    expect(toks.has('type')).toBe(true);
+  });
+
+  it('splits on non-alphanumeric characters', () => {
+    const toks = tokenizeForJaccard('avoid-using/any.type');
+    expect(toks.has('avoid')).toBe(true);
+    expect(toks.has('any')).toBe(true);
+    expect(toks.has('type')).toBe(true);
+  });
+});
+
+// ─── jaccard ───────────────────────────────────────────
+
+describe('jaccard', () => {
+  it('returns 1.0 for identical non-empty sets', () => {
+    const a = new Set(['avoid', 'any', 'type']);
+    const b = new Set(['avoid', 'any', 'type']);
+    expect(jaccard(a, b)).toBe(1);
+  });
+
+  it('returns 0.0 for disjoint sets', () => {
+    const a = new Set(['foo', 'bar']);
+    const b = new Set(['baz', 'qux']);
+    expect(jaccard(a, b)).toBe(0);
+  });
+
+  it('returns 0.0 for two empty sets', () => {
+    const a = new Set<string>();
+    const b = new Set<string>();
+    expect(jaccard(a, b)).toBe(0);
+  });
+
+  it('is symmetric', () => {
+    const a = new Set(['avoid', 'any', 'type', 'unknown']);
+    const b = new Set(['avoid', 'any', 'prefer']);
+    expect(jaccard(a, b)).toBe(jaccard(b, a));
+  });
+
+  it('returns a value strictly between 0 and 1 for partial overlap', () => {
+    const a = new Set(['avoid', 'any', 'type']);
+    const b = new Set(['avoid', 'any', 'prefer']);
+    const v = jaccard(a, b);
+    expect(v).toBeGreaterThan(0);
+    expect(v).toBeLessThan(1);
+    // |intersection| = 2, |union| = 4 → 0.5
+    expect(v).toBeCloseTo(0.5, 5);
+  });
+});

--- a/packages/core/src/recurrence-stats.ts
+++ b/packages/core/src/recurrence-stats.ts
@@ -1,0 +1,215 @@
+/**
+ * Recurrence-stats schemas + pure helpers for `totem stats --pattern-recurrence`
+ * (mmnto-ai/totem#1715).
+ *
+ * Substrate of the four-honest-signals "signal 2" instrumentation
+ * (same-class-mistake frequency). The data model is consumed by the
+ * recurrence-stats command and downstream by the bot-tax circuit
+ * breaker (mmnto-ai/totem#1713) and the pre-flight estimator
+ * (mmnto-ai/totem#1714).
+ *
+ * Everything in this file is pure: Zod schemas + deterministic string
+ * helpers. No I/O, no command logic — that lives in the cli package.
+ */
+
+import { createHash } from 'node:crypto';
+
+import { z } from 'zod';
+
+// ─── Zod schemas ────────────────────────────────────
+
+/** Source classification of a clustered pattern. */
+export const RecurrenceToolSchema = z.enum([
+  'coderabbit',
+  'gca',
+  'sarif',
+  'override',
+  'mixed',
+  'unknown',
+]);
+
+export type RecurrenceTool = z.infer<typeof RecurrenceToolSchema>;
+
+/** Normalized severity bucket across CR/GCA/override sources. */
+export const RecurrenceSeverityBucketSchema = z.enum(['critical', 'high', 'medium', 'low', 'nit']);
+
+export type RecurrenceSeverityBucket = z.infer<typeof RecurrenceSeverityBucketSchema>;
+
+/** A single cross-PR cluster of bot/override findings sharing one signature. */
+export const RecurrencePatternSchema = z.object({
+  /** Stable hash of the normalized pattern body — used as cluster key */
+  signature: z.string().min(1),
+  /** Source classification (`mixed` when one signature spans bots/overrides) */
+  tool: RecurrenceToolSchema,
+  /** Normalized severity across CR/GCA's different severity vocabularies */
+  severityBucket: RecurrenceSeverityBucketSchema,
+  /** Total finding count for this signature (>= 1) */
+  occurrences: z.number().int().min(1),
+  /** PR numbers where this pattern fired (deduped, sorted ascending numerically) */
+  prs: z.array(z.string()),
+  /** First 3 raw bodies seen — for human triage */
+  sampleBodies: z.array(z.string()).max(3),
+  /** Earliest finding timestamp (ISO 8601) */
+  firstSeen: z.string(),
+  /** Latest finding timestamp (ISO 8601) */
+  lastSeen: z.string(),
+  /** File paths where the pattern fired (deduped, ≤ 10) */
+  paths: z.array(z.string()).max(10),
+  /** True if signature heuristically maps to an existing compiled rule */
+  coveredByRule: z.boolean(),
+});
+
+export type RecurrencePattern = z.infer<typeof RecurrencePatternSchema>;
+
+/** Top-level shape persisted at `.totem/recurrence-stats.json`. */
+export const RecurrenceStatsSchema = z.object({
+  /** Schema version for forward-compat */
+  version: z.literal(1),
+  /** When this run wrote the file (ISO 8601) */
+  lastUpdated: z.string(),
+  /** The `--threshold` value used; informs reproducibility */
+  thresholdApplied: z.number().int().min(1),
+  /** Number of PRs requested via `--history-depth` */
+  historyDepth: z.number().int().min(0),
+  /** PR numbers actually fetched (post-filter) */
+  prsScanned: z.array(z.string()),
+  /** Patterns at-or-above threshold; sorted by occurrences descending */
+  patterns: z.array(RecurrencePatternSchema),
+  /** Patterns that hit existing rules — separate so coverage rate is observable */
+  coveredPatterns: z.array(RecurrencePatternSchema),
+});
+
+export type RecurrenceStats = z.infer<typeof RecurrenceStatsSchema>;
+
+// ─── Pure helpers — signature normalization ─────────
+
+/**
+ * Q5 normalization pipeline for finding bodies before signature hashing.
+ *
+ * Strips, in order:
+ * - Triple-backtick code fences (```…```)
+ * - URLs (http(s)://…)
+ * - Backtick-spans (`code`)
+ * - File paths with optional :line / :line:col suffix
+ *   (e.g. `packages/cli/src/foo.ts:42`, `src/x.ts:42:7`)
+ * - Standalone line references (`line 42`, `line: 42`, ` :42`)
+ * - Leading severity prefixes (`CRITICAL: `, `**Critical**`, etc.)
+ *
+ * Then lowercases and collapses internal whitespace.
+ */
+export function normalizeFindingBody(body: string): string {
+  let out = body;
+
+  // 1. Strip triple-backtick fenced blocks (with or without language hint).
+  out = out.replace(/```[\s\S]*?```/g, ' ');
+
+  // 2. Strip URLs.
+  out = out.replace(/https?:\/\/\S+/g, ' ');
+
+  // 3. Strip leading severity prefixes — `**Critical**`, `CRITICAL: `, etc.
+  //    Run BEFORE backtick-span stripping so wrapped severity tokens are
+  //    captured by the bracket-aware patterns.
+  out = out.replace(
+    /^\s*(?:\*\*|`)?\s*(?:critical|high|major|medium|minor|low|nit|nitpick|info|warning|error)\s*(?:\*\*|`)?\s*[:.\-—]\s*/i,
+    '',
+  );
+  // Also handle a leading "**Critical**" with no trailing punctuation.
+  out = out.replace(
+    /^\s*\*\*\s*(?:critical|high|major|medium|minor|low|nit|nitpick|info|warning|error)\s*\*\*\s*/i,
+    '',
+  );
+
+  // 4. Strip backtick spans, keeping surrounding whitespace.
+  out = out.replace(/`[^`]*`/g, ' ');
+
+  // 5. Strip file paths with optional :line / :line:col suffix.
+  //    Matches things like `packages/cli/src/foo.ts:42`, `src/x.ts:42:7`,
+  //    `./foo.ts`, `../bar/baz.tsx`. A path here is a sequence of
+  //    non-space, non-quote tokens containing at least one `/` or `\`
+  //    AND ending in a recognized code/text extension.
+  out = out.replace(
+    /(?:[A-Za-z]:[\\/])?(?:\.{0,2}[\\/])?(?:[\w.\-]+[\\/])+[\w.\-]+\.[A-Za-z0-9]{1,8}(?::\d+(?::\d+)?)?/g,
+    ' ',
+  );
+
+  // 6. Strip standalone line references — `line 42`, `line: 42`, ` :42`.
+  out = out.replace(/\bline\s*[:\-]?\s*\d+\b/gi, ' ');
+  out = out.replace(/(?<=\s):\d+\b/g, ' ');
+
+  // 7. Lowercase + collapse whitespace.
+  out = out.toLowerCase().replace(/\s+/g, ' ').trim();
+
+  return out;
+}
+
+/**
+ * Compute a 16-char hex SHA-256 prefix of the normalized text.
+ * Stable + deterministic; collision probability negligible at this
+ * input scale (per-repo PR history).
+ */
+export function computeSignature(normalized: string): string {
+  return createHash('sha256').update(normalized, 'utf-8').digest('hex').slice(0, 16);
+}
+
+// ─── Pure helpers — Jaccard coverage heuristic ──────
+
+const STOPWORDS = new Set([
+  'the',
+  'a',
+  'an',
+  'is',
+  'of',
+  'to',
+  'in',
+  'and',
+  'or',
+  'for',
+  'on',
+  'this',
+  'that',
+  'it',
+  'be',
+  'as',
+  'at',
+  'by',
+  'if',
+  'not',
+  'but',
+  'use',
+  'using',
+]);
+
+/**
+ * Tokenize text for Jaccard similarity:
+ * - Split on whitespace + non-alphanumerics
+ * - Lowercase
+ * - Drop tokens of length ≤ 2
+ * - Drop a small stopword list
+ */
+export function tokenizeForJaccard(text: string): Set<string> {
+  const lowered = text.toLowerCase();
+  const raw = lowered.split(/[^a-z0-9]+/);
+  const out = new Set<string>();
+  for (const tok of raw) {
+    if (tok.length <= 2) continue;
+    if (STOPWORDS.has(tok)) continue;
+    out.add(tok);
+  }
+  return out;
+}
+
+/**
+ * Jaccard similarity |A ∩ B| / |A ∪ B|. Returns 1.0 on identical sets,
+ * 0.0 on disjoint sets, undefined-protected against the empty/empty case
+ * (treated as 0 — they're not "the same pattern", they're both empty).
+ */
+export function jaccard(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 0;
+  let intersection = 0;
+  for (const tok of a) {
+    if (b.has(tok)) intersection += 1;
+  }
+  const union = a.size + b.size - intersection;
+  if (union === 0) return 0;
+  return intersection / union;
+}


### PR DESCRIPTION
## Mechanical Root Cause

The same class of bot-review finding can recur 5+ times across PRs without ever being codified into `compiled-rules.json`. Today nobody is counting — each PR's findings are treated as PR-local. The recurrence IS the signal that a rule should exist, and we're losing it. This is the "signal 2" instrumentation gap from the four-honest-signals framework: same-class-mistake frequency is unmeasurable without it.

This feature is the **substrate of truth** for the upcoming bot-tax circuit breaker (`mmnto-ai/totem#1713`) and pre-flight estimator (`mmnto-ai/totem#1714`). Build order: `mmnto-ai/totem#1715` first, then `mmnto-ai/totem#1713` and `mmnto-ai/totem#1714` compose on the recurrence-stats schema rather than re-scanning PR history per invocation.

## Fix Applied

### `totem stats --pattern-recurrence` mode (new flag on existing `stats` command)

- Fetches the most recent merged PRs via `gh pr list` (configurable `--history-depth`, default 50, capped at 200 with a warning).
- Per-PR pipeline reuses the established `triage-pr` adapter pattern: `GitHubCliPrAdapter.fetchPr() + .fetchReviewComments()`, then `isBotComment` / `detectBot` / `parseCRSeverity` / `parseGCASeverity` / `extractReviewBodyFindings` from `bot-review-parser.ts`.
- Folds in trap-ledger `override` events as **co-equal** signals (Q4) — `tool: 'override'`; same-signature override + bot finding produces a `'mixed'` cluster.
- Clusters by a normalized signature: stripped paths, line refs, code fences, backtick spans, URLs, leading severity prefixes; lowercased + whitespace-collapsed; SHA-256 hex prefix as the cluster key.
- Coverage filter: tokenize-and-jaccard against each compiled-rule's `message`. Patterns hitting Jaccard ≥ 0.6 route to `coveredPatterns` (visible in JSON for coverage-rate observability), not the headline `patterns` array.
- Threshold filter: only patterns with `occurrences >= --threshold` (default 5) land in headline `patterns`. `coveredPatterns` keeps all matched regardless of threshold.
- Atomic write to `.totem/recurrence-stats.json` (temp + rename). Stdout summary mirrors `statsCommand` voice via `log.info` / `log.dim`.
- `requireGhCli()` gate before any `gh` call. Per-PR catch swallows transient errors with `log.warn` and continues (rate-limit resilience per the design's failure-mode table); final report flags partial coverage via `prsScanned < historyDepth`.

### Schema substrate (new core surface)

- `RecurrencePatternSchema` and `RecurrenceStatsSchema` in `packages/core/src/recurrence-stats.ts`, exported via `@mmnto/totem`.
- Pure helpers: `normalizeFindingBody`, `computeSignature`, `tokenizeForJaccard`, `jaccard`. No I/O. Deterministic.
- `version: 1` literal on the top-level schema for forward-compat.

### Approved decisions (Q1-Q7 from `.totem/specs/1715.md`, confirmed by Gemini)

- **Q1 — coverage heuristic:** Jaccard ≥ 0.6 keyword-overlap on rule message. No embeddings; no LanceDB coupling on a stats command.
- **Q2 — `--history-depth`:** default 50, cap 200 with warn.
- **Q3 — surface:** flag on existing `totem stats`, not a subcommand (ADR-094 grammar work in flight).
- **Q4 — trap-ledger:** co-equal data source.
- **Q5 — signature normalization:** standard (paths, line refs, code fences, backticks, URLs, leading severity prefixes).
- **Q6 — `suggestedLessonShape`:** deferred to `review-learn --synthesis-mode` (separate ticket).
- **Q7 — output:** JSON only at `.totem/recurrence-stats.json` + stdout summary.

### Dogfood note

The `mmnto-ai/totem#1716` override-stamp-cache fix (just shipped in `@mmnto/cli@1.15.10` today) worked end-to-end during this PR's review cycle. Round-1 `totem review` flagged a false-positive CRITICAL on `requireGhCli` (claimed missing import; actually defined locally in `index.ts:17` and called at lines 401/418/628). The override path stamped the push-gate cache automatically — first push attempt succeeded after the override, no `git reset --soft HEAD~1` workaround needed. That's the dogfood loop closing on itself within hours of the substrate landing.

## Out of Scope

- No LLM call from inside the command — this is the deterministic substrate. `review-learn --synthesis-mode` is the LLM consumer (separate ticket).
- No agent-facing MCP surface — pure CLI for now; if `mmnto-ai/totem#1497` (rich `describe_project`) wants to surface recurrence-stats, that's a follow-up.
- No automatic rule synthesis — we identify candidate patterns, the human / LLM authors the lesson.
- No GitHub API writes — read-only.
- No continuous-mode invocation — this is a manual / CI-snapshot tool.
- Submodule pointer not bumped per `feedback_no_auto_strategy_submodule_bump.md`.

## Tests Added/Updated

- [x] Added/updated automated tests covering the root-cause mechanism

**`packages/core/src/recurrence-stats.test.ts`** — 27 new tests:
- `RecurrencePatternSchema` / `RecurrenceStatsSchema` Zod parse + reject malformed
- `normalizeFindingBody` strips paths (`packages/cli/src/foo.ts:42`), line refs (`line 42`, `:42`), triple-backtick code fences, backtick spans, URLs, leading severity prefixes; lowercase + whitespace collapse
- `computeSignature` is stable + deterministic; 16-char hex prefix
- `jaccard` is symmetric; returns 1.0 on identical sets, 0.0 on disjoint, 0.0 on empty/empty
- `tokenizeForJaccard` drops stopwords + ≤2-char tokens

**`packages/cli/src/commands/recurrence-stats.test.ts`** — 10 new tests covering every design-doc invariant:
- Path/line/code-fence variants of one finding collapse to one signature
- Cross-bot same-signature → `tool: 'mixed'`
- `occurrences` counts distinct findings, not distinct PRs
- `prs[]` deduped + sorted **ascending numerically** (80 < 200 < 1500, NOT lexical)
- `occurrences < threshold` excluded from headline `patterns`
- Jaccard ≥ 0.6 routes to `coveredPatterns`, not `patterns`
- Atomic write — temp file cleaned up after rename
- Missing `compiled-rules.json` does not throw (coverage check disabled)
- Override events flow through with `tool: 'override'`, `prs: []`
- Override + bot finding sharing a signature → `tool: 'mixed'`

**Suite totals:** core 1438 ✓ (+27), cli 1852 ✓ (+10). Lint PASS, 0 errors.

## Related Tickets

Closes mmnto-ai/totem#1715
Unblocks mmnto-ai/totem#1713 (totem retrospect — bot-tax circuit breaker)
Unblocks mmnto-ai/totem#1714 (totem review --estimate — pre-flight estimator)

## AI_PROMPT_BLOCK

Reviewing bots: please verify (a) `requireGhCli` is imported / in module scope before `--pattern-recurrence` flow runs (note: it's defined locally at `packages/cli/src/index.ts:17` and called at the existing 401/418/628 sites — same pattern); (b) the per-PR catch + continue is intentional resilience documented via `// totem-context:` adjacent to each catch (not a Tenet 4 violation — see the design doc's failure-mode table); (c) the override path's `prs: []` stays empty (override events don't have a PR association); (d) the `'mixed'` tool tag fires when AND only when one signature collects findings from multiple distinct sources (cross-bot, or bot+override).