### PR TITLE
feat(cli): totem review --estimate (mmnto-ai/totem#1714)

### DIFF
--- a/.changeset/1714-review-estimate.md
+++ b/.changeset/1714-review-estimate.md
@@ -1,0 +1,11 @@
+---
+'@mmnto/cli': patch
+---
+
+`totem review --estimate` — pre-flight deterministic-rule estimator.
+
+Closes mmnto-ai/totem#1714. Adds `--estimate` to `totem review`: runs the same compiled-rule engine as `totem lint` against the diff resolved by `totem review`'s standard chain (`--diff` → `--staged` → working-tree → branch-vs-base) and returns immediately. No orchestrator, no embedder, no LanceDB — the entire LLM Verification Layer is structurally unreachable from this code path. Output is labeled `[Estimate]` (a new `ESTIMATE_DISPLAY_TAG` distinct from `[Review]`) so log lines unmistakably read as a forecast rather than a final verdict.
+
+Composes on top of mmnto-ai/totem#1715's `.totem/recurrence-stats.json` substrate as part of the bot-tax cluster (`#1713 totem retrospect`, `#1714 totem review --estimate`). The optional pattern-history overlay is filed separately as mmnto-ai/totem#1731.
+
+Mutually incompatible with `--learn`, `--auto-capture`, `--override`, `--suppress`, `--fresh`, `--mode`, and `--raw` — these only apply to the LLM path. The incompatibility guard fires before any other validation so the error message names the actual conflict (`--override is incompatible with --estimate`) rather than a misleading downstream constraint. Empty-diff runs do NOT stamp the `.reviewed-content-hash` push-gate cache: an estimate is a forecast, not a passing review.

--- a/.totem/specs/1714.md
+++ b/.totem/specs/1714.md
@@ -1,0 +1,176 @@
+### Problem Statement
+
+Contributors lack visibility into which automated review rules will fire on their PRs, leading to slow, multi-round bot reviews for predictable violations. The `totem review` command needs an `--estimate` pre-flight mode that deterministically cross-checks the local diff against the compiled rule corpus and outputs predicted findings without invoking the LLM verification layer.
+
+### Architectural Context
+
+- **Determinism Mandate (`feedback_axiom_mandate.md`):** Predicted findings must strictly rely on deterministic rule matches from `compiled-rules.json`, strictly avoiding LLM mediation.
+- **Implicit Diff Source Contract (`upstream-feedback/029`):** When the diff source is implicit (e.g., no explicit files or PR provided), the tool must surface this fact to the user to prevent false-positive escalation.
+- **Staged-vs-Working Drift (`upstream-feedback/025`):** The estimator must respect existing staging rules: it must evaluate staged changes if they exist, and only fall back to the working directory if the staging area is empty.
+- **Verification Layer Context Caching (Proposal 217):** Reminds us that standard `totem review` operations load the entire `compiled-rules.json` payload; the estimator intercepts this before the verification layer payload is ever constructed or transmitted.
+
+### Files to Examine
+
+1. `packages/cli/src/commands/review.ts` — Primary command entry point; needs the new `--estimate` flag and early-exit logic to bypass LLM invocation.
+2. `packages/cli/src/commands/run-compiled-rules.ts` — Prior art for how the CLI deterministically evaluates compiled rules.
+3. `.totem/compiled-rules.json` (in any local project) — To understand the expected structural contract of the compiled rule corpus.
+
+### Technical Approach & Contracts
+
+**Approach:**
+We will augment the `totem review` command with an `--estimate` flag. When present, the command resolves the diff source exactly as it currently does. If the diff source is implicit, it logs a prominent warning. It then fetches the diff using `getGitDiff`, extracts the changed files via the `extractChangedFiles` shared helper, and loads `.totem/compiled-rules.json` using `readJsonSafe`. By matching the changed files against the `appliesTo` paths/globs of the compiled rules, it predicts which rules the bot will evaluate. It prints these citations and exits cleanly (Code 0), entirely bypassing the LLM-based Verification Layer.
+
+**Data Contracts:**
+We will define Zod schemas to safely read the compiled rules payload:
+
+```typescript
+import { z } from 'zod';
+
+export const EstimatorCompiledRuleSchema = z.object({
+  id: z.string(),
+  severity: z.enum(['error', 'warning', 'info', 'critical']).catch('warning'),
+  description: z.string(),
+  appliesTo: z.array(z.string()).optional(),
+});
+
+// Using a fallback to array to handle both wrapped and unwrapped JSON structures
+export const CompiledRulesRegistrySchema = z.union([
+  z.object({ rules: z.array(EstimatorCompiledRuleSchema) }),
+  z.array(EstimatorCompiledRuleSchema),
+]);
+```
+
+**Trade-offs:**
+
+- _Full Regex Evaluation vs. Scope Matching:_ We could run the actual deterministic regexes embedded inside `compiled-rules.json` against the diff content, OR we can just match the file paths against the rule scopes (`appliesTo`).
+  _Recommendation:_ **Scope Matching**. Predicting that a rule _will be evaluated_ because the file changed perfectly satisfies the "visibility into what bot findings will likely fire" requirement without duplicating the heavy `runCompiledRules` regex logic or risking false negatives.
+
+### Edge Cases & Traps
+
+- **Staged vs. Working Drift (Trap):** Using `getGitDiff('all', cwd)` incorrectly merges staged and unstaged changes. If the user has explicitly staged files for a PR but has unrelated unstaged files, evaluating both causes false positives. You MUST check `getGitDiff('staged', cwd)` first. If empty, fallback to `getGitDiff('all', cwd)` ONLY when the diff source is implicit.
+- **LLM Trigger Regressions:** If the early return logic is placed too late, the CLI might accidentally initialize or call the Verification Layer API, violating the determinism mandate and wasting API credits.
+- **Missing Compilation:** Running `--estimate` before `totem compile` has ever run means `compiled-rules.json` doesn't exist. This must be caught gracefully by `readJsonSafe` (which throws a `TotemParseError`), translating it into a friendly prompt to run `totem compile`.
+- **Zero-Diff Execution:** If the extracted changed files array is empty, the estimator must exit 0 immediately with a "No changes detected" message rather than iterating over an empty list.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Add `--estimate` flag to Review Command**
+  - Modify `packages/cli/src/commands/review.ts` and its test file.
+  - Add `estimate?: boolean` to the `ReviewOptions` interface.
+  - Register the `--estimate` flag in the commander setup.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `parses estimate flag correctly and propagates to options`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Resolve Diff and Detect Implicit Source**
+  - Modify `packages/cli/src/commands/review.ts`.
+  - Intercept command flow if `options.estimate` is true.
+  - Resolve the diff using the shared helper `getGitDiff(mode, cwd)`. Fetch `'staged'` first; if empty, fetch `'all'`.
+    > TOTEM INVARIANT (upstream-feedback/029): The estimator surfaces implicit diff sources rather than producing silent low-confidence findings.
+  - If no explicit target (files/PR) was provided, emit a standard warning: `Implicit diff source detected: evaluating based on current local changes.`
+  - Extract file paths using the shared helper `extractChangedFiles(diff)`. Handle empty returns by logging "No changes detected" and exiting cleanly.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `surfaces implicit diff source warning when no explicit target provided`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Load Rules and Cross-Check Deterministically**
+  - Modify `packages/cli/src/commands/review.ts`.
+    > TOTEM INVARIANT (feedback_axiom_mandate.md): Predicted findings should be deterministic-substrate-grounded, not LLM-mediated.
+  - Define `CompiledRulesRegistrySchema` and load rules using the shared helper `readJsonSafe('.totem/compiled-rules.json', CompiledRulesRegistrySchema)`.
+  - Wrap in a `try/catch` to handle missing files, catching `TotemParseError` to output: `Error: No compiled rules found. Run 'totem compile' first.`
+  - Filter the loaded rules to identify which apply to the paths in the `extractChangedFiles` list (e.g., checking if the file paths match the rule's `appliesTo` scopes).
+    > TEST DIRECTIVE: Before implementing, write a failing test named `maps changed files to deterministic rule citations without invoking LLM`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Format Estimator Output and Bypass LLM**
+  - Modify `packages/cli/src/commands/review.ts`.
+  - Iterate over the matched rules. Output the predicted findings to the console citing the Rule ID, Severity, Description, and the specific changed files it applies to.
+  - Ensure the function explicitly `return`s immediately after printing, completely bypassing the downstream Verification Layer (LLM invocation).
+    > TEST DIRECTIVE: Before implementing, write a failing test named `exits cleanly with code 0 after printing estimates and bypasses LLM verification`.
+  - write test → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Staging precedence:** Create a staged change and an unstaged change. Run `totem review --estimate` implicitly. Assert that only the staged file is evaluated and logged.
+- **Empty diff source:** Run estimator on a clean git tree. Assert it exits 0 with "No changes detected".
+- **Implicit warning:** Run without explicit targets. Assert the console output contains the implicit diff source warning.
+- **LLM bypass validation:** Mock the LLM client or Verification layer. Run `--estimate`. Assert the mock is never called.
+- **Missing compiled-rules:** Delete `.totem/compiled-rules.json` in a test fixture. Run `--estimate`. Assert it fails gracefully with a message to run `totem compile`.
+
+---
+
+## Implementation Design
+
+### Scope (2 sentences)
+
+`totem review --estimate` runs the existing deterministic rule engine (`runCompiledRules`) against the diff resolved by `totem review`'s existing diff-source chain, prints `[Estimate]`-tagged predicted findings with file:line citations, and returns immediately without any LLM/orchestrator initialization. **Out of scope for this PR:** the optional pattern-history overlay (cross-checking `.totem/recurrence-stats.json` for clusters not yet covered by a compiled rule) per AC bullet 3 — file as a follow-up ticket.
+
+### Data model deltas
+
+| Addition                           | Holds               | Writes                    | Reads                             | Invariants                                                                                                                                                                                                                                                                                                          |
+| ---------------------------------- | ------------------- | ------------------------- | --------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ShieldOptions.estimate?: boolean` | flag from commander | `index.ts` action handler | `shieldCommand` early-exit branch | Optional, undefined ≡ false. Mutually compatible with `--diff`, `--staged`, `--out`. Mutually **incompatible** with `--learn`, `--auto-capture`, `--mode`, `--override`, `--suppress`, `--fresh`, `--raw` — these only mean things in the LLM path. CLI surfaces a `TotemConfigError` on incompatible combinations. |
+
+No new types in `@mmnto/totem`. No new fields on `CompiledRule`. No new module-level state. No new files in `core/`. New helper module `packages/cli/src/commands/shield-estimate.ts` (or inline branch in `shield.ts`, decision below) that wraps the diff-resolve → `runCompiledRules` → estimate-formatted output sequence.
+
+### State lifecycle
+
+No new state. The estimator is a pure pass-through: read `compiled-rules.json` (per-invocation, already cached behind `loadCompiledRules`), evaluate against in-memory diff additions, write stdout/file via existing `writeOutput`, return. Trap-ledger and rule-metrics writes from `runCompiledRules` (`appendLedgerEvent` on suppressions, `recordEvaluation` per rule) **continue to fire under `--estimate`** — this is desirable: the estimator dogfoods the same telemetry surface, so an estimator run looks identical to a real lint pass on the metrics side. Open question O2 below if Matt wants estimate runs excluded from metrics.
+
+### Failure modes
+
+| Failure                                                       | Category | Agent-facing surface                                                                            | Recovery                                             |
+| ------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `compiled-rules.json` missing                                 | init     | hard error (`TotemError` `NO_RULES`, identical to `totem lint`'s)                               | Run `totem compile` first.                           |
+| `compiled-rules.json` corrupt JSON                            | init     | hard error via existing `loadCompiledRules` parse path (Zod failure → `TotemParseError`)        | Re-run `totem compile` or restore from git.          |
+| Diff source empty (no changes anywhere in the fallback chain) | runtime  | `log.warn('No changes detected. Nothing to review.')` + return code 0                           | Make a change. Same surface as `totem review` today. |
+| Explicit `--diff <range>` produces empty diff                 | runtime  | `log.warn` + return 0 (already handled by `getDiffForReview`)                                   | Pass a non-empty range.                              |
+| Diff exceeds `REVIEW_DIFF_TRUNCATION_THRESHOLD` (50KB)        | runtime  | warning at resolution layer (already emitted by `getDiffForReview` since `mmnto-ai/totem#1717`) | Narrow `--diff <range>`.                             |
+| Regex rule has invalid pattern                                | runtime  | hard error via existing `applyRulesToAdditionsBounded` `TotemParseError` branch                 | Re-run `totem lesson compile` or archive the rule.   |
+| Regex timeout on a rule-file pair (strict mode)               | runtime  | warning + non-zero exit (existing `runCompiledRules` strict-mode contract)                      | Narrow scope or `--timeout-mode lenient`.            |
+| One or more violations found                                  | runtime  | non-zero exit via existing `SHIELD_FAILED` `TotemError` path                                    | Fix or `// totem-context:` suppress.                 |
+| Incompatible flags (`--estimate --learn`, etc.)               | init     | `TotemConfigError` `CONFIG_INVALID` at command entry                                            | Drop the incompatible flag.                          |
+
+Every failure mode reuses an existing surface. No new error classes, no new exit codes.
+
+### Invariants to lock in via tests
+
+- `--estimate` never imports / never instantiates the orchestrator, the embedding client, or the LanceDB store. Test asserts none of `runOrchestrator`, `requireEmbedding`, `LanceStore` constructors are called on the estimate path (mock + assert-not-called).
+- `--estimate` produces identical violation set as `totem lint` for the same diff input. Test fixtures: same diff, same `compiled-rules.json`; assert `violations` array shape-equals.
+- `--estimate` honors `getDiffForReview`'s full resolution chain: explicit `--diff` wins, then `--staged`, then working-tree, then branch-vs-base. One test per branch.
+- `--estimate` exit code matches `totem lint` semantics: 0 on PASS or warnings-only, non-zero on errors. The output verdict line is labeled `Estimate` (vs `Verdict`) so consumers don't conflate this with the LLM verdict.
+- `--estimate` is incompatible with `--learn`, `--auto-capture`, `--override`, `--suppress`, `--fresh`, `--mode`, `--raw` — each combination throws `TotemConfigError` before any work runs. Table-driven test.
+- Implicit-diff-source path emits a stderr `log.info` `Diff source: <chosen>` line (already done by `getDiffForReview`); `--estimate` doesn't suppress it. Existing `mmnto-ai/totem#1717` tests already cover this for `totem review`; we add coverage on the `--estimate` branch.
+
+### Open questions
+
+- **Q1: Inline branch in `shield.ts` vs new `shield-estimate.ts` module?**
+  - Options: (a) add a `if (options.estimate) { ... return; }` block early in `shieldCommand` after `getDiffForReview` resolves the diff, (b) extract a `runEstimate(options, config, cwd)` helper into `shield-estimate.ts` that `shieldCommand` delegates to.
+  - **Recommendation: (b).** `shield.ts` is already 1100+ lines; the estimate path is a self-contained branch with its own tests. New module keeps `shield.ts`'s LLM path uncluttered and parallels the `shield-classify`/`shield-hints`/`shield-templates` pattern.
+- **Q2: Should `--estimate` writes to `rule-metrics.json` and the trap ledger?**
+  - Options: (a) yes, transparent dogfood — estimator runs look identical to lint runs in metrics; (b) no, gate metric writes behind a `recordMetrics: boolean` option threaded into `runCompiledRules` and pass `false` for estimate.
+  - **Recommendation: (a).** Estimator runs ARE deterministic-rule evaluations against real diffs; recording them is honest. If we later want to distinguish, add a metrics-source field rather than silencing the write.
+- **Q3: Default output verdict label — `[Estimate] PASS` vs `[Review] PASS`?**
+  - Options: (a) reuse `[Review]` DISPLAY_TAG so muscle memory carries; (b) distinct `[Estimate]` tag so log lines are unambiguously a forecast.
+  - **Recommendation: (b).** The whole point is to make "this is a prediction, not a final verdict" unmistakable in stdout. Add `ESTIMATE_DISPLAY_TAG = 'Estimate'`.
+- **Q4: Pattern-history overlay scope — file follow-up ticket now or wait until after merge?**
+  - Options: (a) file follow-up `mmnto-ai/totem#NEXT` immediately so the AC bullet 3 has a tracking handle; (b) leave the AC bullet open, file later.
+  - **Recommendation: (a).** Follow-up ticket gives the bot-tax cluster (#1713 retrospect, #1714 estimate, future #NEXT pattern overlay) a clean shape. File during this PR's commit chain.

--- a/docs/wiki/cli-reference.md
+++ b/docs/wiki/cli-reference.md
@@ -117,6 +117,7 @@ The core of the Codebase Immune System. Reads your uncommitted diff and checks i
   - `--format json`: Exports structured JSON including a unified `findings[]` array (ADR-071 Unified Findings Model) alongside raw `violations[]`.
   - `--learn`: Prompts you to extract a new lesson if a violation is found.
   - `--auto-capture`: Enables Pipeline 5 observation auto-capture during the review (off by default).
+  - `--estimate`: Pre-flight deterministic-rule predictor (zero-LLM). Runs `compiled-rules.json` against the diff and prints predicted findings tagged `[Estimate]` so they are not conflated with an LLM verdict. Bypasses the entire Verification Layer — no orchestrator, no embedder, no LanceDB. Useful for predicting bot findings before opening a PR. Example: `totem review --estimate --diff main...HEAD`. Incompatible with `--learn`, `--auto-capture`, `--override`, `--suppress`, `--fresh`, `--mode`, and `--raw`.
 
 ### `totem test`
 

--- a/packages/cli/src/commands/shield-estimate.test.ts
+++ b/packages/cli/src/commands/shield-estimate.test.ts
@@ -1,0 +1,380 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TotemConfig } from '@mmnto/totem';
+
+import type { DiffForReviewSource } from '../git.js';
+import { cleanTmpDir } from '../test-utils.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ─── Mocks ──────────────────────────────────────────────
+//
+// `shield-estimate.ts` lazy-imports `../git.js`, `./run-compiled-rules.js`,
+// and `../ui.js` per the dynamic-imports-in-CLI policy (CR R1 on
+// `mmnto-ai/totem#1729`). vi.mock is hoisted, so these stubs are in place
+// before runEstimate's dynamic imports resolve.
+
+vi.mock('../git.js', async () => {
+  const actual = await vi.importActual<typeof import('../git.js')>('../git.js');
+  return {
+    ...actual,
+    getDiffForReview: vi.fn(),
+  };
+});
+
+vi.mock('./run-compiled-rules.js', () => ({
+  runCompiledRules: vi.fn(),
+}));
+
+vi.mock('../ui.js', () => ({
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    dim: vi.fn(),
+  },
+}));
+
+// Stub config loading so the second describe block (which exercises
+// shieldCommand directly) can run without scaffolding a real
+// totem.config.ts on disk. Same shape as `lint.test.ts`.
+vi.mock('../utils.js', async () => {
+  const actual = await vi.importActual<typeof import('../utils.js')>('../utils.js');
+  return {
+    ...actual,
+    resolveConfigPath: (cwd: string) => path.join(cwd, 'totem.config.ts'),
+    loadConfig: async () => ({
+      targets: [],
+      totemDir: '.totem',
+      ignorePatterns: [],
+    }),
+    loadEnv: () => {},
+  };
+});
+
+const gitModule = await import('../git.js');
+const rcrModule = await import('./run-compiled-rules.js');
+const uiModule = await import('../ui.js');
+const mockGetDiffForReview = vi.mocked(gitModule.getDiffForReview);
+const mockRunCompiledRules = vi.mocked(rcrModule.runCompiledRules);
+const mockLog = vi.mocked(uiModule.log);
+
+// ─── Helpers ────────────────────────────────────────────
+
+function makeConfig(): TotemConfig {
+  // Minimal TotemConfig surface that runEstimate touches: totemDir +
+  // ignorePatterns. The real schema has more fields but they are not
+  // read on the estimate path.
+  return {
+    totemDir: '.totem',
+    ignorePatterns: ['package-lock.json', '*.snap'],
+  } as unknown as TotemConfig;
+}
+
+const SAMPLE_DIFF =
+  'diff --git a/foo.ts b/foo.ts\n--- a/foo.ts\n+++ b/foo.ts\n@@ -1 +1,2 @@\n existing\n+new line\n';
+
+function diffResult(
+  overrides: Partial<{ diff: string; changedFiles: string[]; source: DiffForReviewSource }> = {},
+) {
+  return {
+    diff: SAMPLE_DIFF,
+    changedFiles: ['foo.ts'],
+    source: 'uncommitted' as DiffForReviewSource,
+    ...overrides,
+  };
+}
+
+function runCompiledRulesPassResult() {
+  return {
+    violations: [],
+    rules: [],
+    output: 'PASS',
+    findings: [],
+    regexTimeouts: [],
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────
+
+describe('runEstimate', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-estimate-'));
+    originalCwd = process.cwd();
+    mockGetDiffForReview.mockReset();
+    mockRunCompiledRules.mockReset();
+    for (const fn of Object.values(mockLog)) {
+      (fn as ReturnType<typeof vi.fn>).mockReset();
+    }
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    cleanTmpDir(tmpDir);
+  });
+
+  // ─── Empty-diff branch ────────────────────────────
+
+  it('returns clean and skips runCompiledRules when getDiffForReview returns null', async () => {
+    mockGetDiffForReview.mockResolvedValue(null);
+
+    const { runEstimate } = await import('./shield-estimate.js');
+    await expect(
+      runEstimate({ estimate: true }, makeConfig(), tmpDir, tmpDir),
+    ).resolves.toBeUndefined();
+
+    expect(mockRunCompiledRules).not.toHaveBeenCalled();
+
+    // Empty-diff branch logs the "No changes detected" line under the
+    // Estimate tag — never under Review.
+    const noChangesCall = mockLog.info.mock.calls.find((c) =>
+      String(c[1]).includes('No changes detected. Nothing to estimate.'),
+    );
+    expect(noChangesCall).toBeDefined();
+    expect(noChangesCall![0]).toBe('Estimate');
+  });
+
+  // ─── Tag invariant ────────────────────────────────
+
+  it('passes the Estimate tag (never Review) to getDiffForReview and runCompiledRules', async () => {
+    mockGetDiffForReview.mockResolvedValue(diffResult());
+    mockRunCompiledRules.mockResolvedValue(runCompiledRulesPassResult());
+
+    const { runEstimate } = await import('./shield-estimate.js');
+    await runEstimate({ estimate: true }, makeConfig(), tmpDir, tmpDir);
+
+    // getDiffForReview's 4th arg is the tag.
+    expect(mockGetDiffForReview).toHaveBeenCalledTimes(1);
+    expect(mockGetDiffForReview.mock.calls[0]![3]).toBe('Estimate');
+
+    // runCompiledRules.tag must be Estimate.
+    expect(mockRunCompiledRules).toHaveBeenCalledTimes(1);
+    const rcrArgs = mockRunCompiledRules.mock.calls[0]![0];
+    expect(rcrArgs.tag).toBe('Estimate');
+
+    // No log line on the estimate path may use the Review tag.
+    for (const call of mockLog.info.mock.calls) {
+      expect(call[0]).not.toBe('Review');
+    }
+  });
+
+  it('emits a [Estimate] preamble before delegating to getDiffForReview', async () => {
+    mockGetDiffForReview.mockResolvedValue(diffResult());
+    mockRunCompiledRules.mockResolvedValue(runCompiledRulesPassResult());
+
+    const { runEstimate } = await import('./shield-estimate.js');
+    await runEstimate({ estimate: true }, makeConfig(), tmpDir, tmpDir);
+
+    const preambleCall = mockLog.info.mock.calls.find((c) =>
+      String(c[1]).includes('Pre-flight prediction'),
+    );
+    expect(preambleCall).toBeDefined();
+    expect(preambleCall![0]).toBe('Estimate');
+  });
+
+  // ─── Diff pass-through ────────────────────────────
+
+  it('forwards the diff returned by getDiffForReview unchanged to runCompiledRules', async () => {
+    mockGetDiffForReview.mockResolvedValue(diffResult());
+    mockRunCompiledRules.mockResolvedValue(runCompiledRulesPassResult());
+
+    const { runEstimate } = await import('./shield-estimate.js');
+    await runEstimate({ estimate: true }, makeConfig(), tmpDir, tmpDir);
+
+    const rcrArgs = mockRunCompiledRules.mock.calls[0]![0];
+    expect(rcrArgs.diff).toBe(SAMPLE_DIFF);
+  });
+
+  it('forwards ignorePatterns from config into runCompiledRules', async () => {
+    mockGetDiffForReview.mockResolvedValue(diffResult());
+    mockRunCompiledRules.mockResolvedValue(runCompiledRulesPassResult());
+
+    const { runEstimate } = await import('./shield-estimate.js');
+    await runEstimate({ estimate: true }, makeConfig(), tmpDir, tmpDir);
+
+    const rcrArgs = mockRunCompiledRules.mock.calls[0]![0];
+    expect(rcrArgs.ignorePatterns).toEqual(['package-lock.json', '*.snap']);
+  });
+
+  it('forwards configRoot, totemDir, and isStaged into runCompiledRules', async () => {
+    mockGetDiffForReview.mockResolvedValue(diffResult({ source: 'staged' }));
+    mockRunCompiledRules.mockResolvedValue(runCompiledRulesPassResult());
+
+    const configRoot = path.join(tmpDir, 'sub-root');
+
+    const { runEstimate } = await import('./shield-estimate.js');
+    await runEstimate({ estimate: true, staged: true }, makeConfig(), tmpDir, configRoot);
+
+    const rcrArgs = mockRunCompiledRules.mock.calls[0]![0];
+    expect(rcrArgs.configRoot).toBe(configRoot);
+    expect(rcrArgs.totemDir).toBe('.totem');
+    expect(rcrArgs.isStaged).toBe(true);
+  });
+
+  it('forwards options.out as outPath into runCompiledRules', async () => {
+    mockGetDiffForReview.mockResolvedValue(diffResult());
+    mockRunCompiledRules.mockResolvedValue(runCompiledRulesPassResult());
+
+    const { runEstimate } = await import('./shield-estimate.js');
+    await runEstimate({ estimate: true, out: 'estimate.txt' }, makeConfig(), tmpDir, tmpDir);
+
+    const rcrArgs = mockRunCompiledRules.mock.calls[0]![0];
+    expect(rcrArgs.outPath).toBe('estimate.txt');
+    // Format is always 'text' on the estimate path — SARIF/JSON are
+    // lint's territory and `runReview` already rejects --format.
+    expect(rcrArgs.format).toBe('text');
+  });
+
+  // ─── Diff-source resolution branches ──────────────
+
+  it.each([
+    ['explicit-range', { estimate: true, diff: 'HEAD^..HEAD' }],
+    ['staged', { estimate: true, staged: true }],
+    ['uncommitted', { estimate: true }],
+    ['branch-vs-base', { estimate: true }],
+  ] as const)('honors getDiffForReview source resolution for %s', async (source, options) => {
+    mockGetDiffForReview.mockResolvedValue(diffResult({ source }));
+    mockRunCompiledRules.mockResolvedValue(runCompiledRulesPassResult());
+
+    const { runEstimate } = await import('./shield-estimate.js');
+    await runEstimate(options, makeConfig(), tmpDir, tmpDir);
+
+    // Whatever source getDiffForReview chose, the diff is the one
+    // passed to runCompiledRules.
+    expect(mockRunCompiledRules.mock.calls[0]![0].diff).toBe(SAMPLE_DIFF);
+    // And the options object is forwarded to getDiffForReview so it
+    // can do its own implicit-source label logging.
+    expect(mockGetDiffForReview).toHaveBeenCalledWith(
+      options,
+      expect.any(Object),
+      tmpDir,
+      'Estimate',
+    );
+  });
+
+  // ─── Exit code parity with lint ───────────────────
+
+  it('lets SHIELD_FAILED from runCompiledRules propagate (matches lint exit semantics)', async () => {
+    mockGetDiffForReview.mockResolvedValue(diffResult());
+    const { TotemError } = await import('@mmnto/totem');
+    mockRunCompiledRules.mockRejectedValue(
+      new TotemError('SHIELD_FAILED', 'Violations detected', 'Fix the violations above.'),
+    );
+
+    const { runEstimate } = await import('./shield-estimate.js');
+    await expect(
+      runEstimate({ estimate: true }, makeConfig(), tmpDir, tmpDir),
+    ).rejects.toMatchObject({ code: 'SHIELD_FAILED' });
+  });
+
+  it('completes without throwing on a clean pass (zero violations)', async () => {
+    mockGetDiffForReview.mockResolvedValue(diffResult());
+    mockRunCompiledRules.mockResolvedValue(runCompiledRulesPassResult());
+
+    const { runEstimate } = await import('./shield-estimate.js');
+    await expect(
+      runEstimate({ estimate: true }, makeConfig(), tmpDir, tmpDir),
+    ).resolves.toBeUndefined();
+  });
+
+  // ─── No-LLM invariant ─────────────────────────────
+
+  it('never imports the orchestrator or embedding modules from shield-estimate.ts', async () => {
+    // Static-source check: a regex-grep over the on-disk shield-estimate
+    // source asserts no LLM-path import exists. This catches a future
+    // drift where someone adds `runOrchestrator` or `requireEmbedding`
+    // to the estimator without going through code review. Pairs with
+    // the runtime tag-invariant tests above.
+    const estimatePath = path.join(__dirname, 'shield-estimate.ts');
+    const source = fs.readFileSync(estimatePath, 'utf-8');
+    // Forbidden symbols anywhere in the file — including `import`,
+    // re-exports, or string references. shield-templates.ts is a pure
+    // constants module so importing ESTIMATE_DISPLAY_TAG from it is
+    // safe; the ban is on the LLM/embedding/Lance surfaces.
+    expect(source).not.toMatch(/runOrchestrator/);
+    expect(source).not.toMatch(/requireEmbedding/);
+    expect(source).not.toMatch(/LanceStore/);
+    expect(source).not.toMatch(/createEmbedder/);
+    // ../utils.js exposes both runOrchestrator and orchestrator
+    // helpers; importing it would silently widen the surface even if
+    // none of those symbols are referenced. Block the import path
+    // outright.
+    expect(source).not.toMatch(/from ['"]\.\.\/utils\.js['"]/);
+  });
+});
+
+// ─── Incompatibility table — driven through shieldCommand ─
+
+describe('shieldCommand --estimate incompatibility guard', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-est-incompat-'));
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+    fs.writeFileSync(path.join(tmpDir, 'totem.config.ts'), 'export default {};', 'utf-8');
+    mockGetDiffForReview.mockReset();
+    mockRunCompiledRules.mockReset();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    cleanTmpDir(tmpDir);
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    ['learn', { learn: true }, '--learn'],
+    ['autoCapture', { autoCapture: true }, '--auto-capture'],
+    ['override', { override: 'this is a long enough reason' }, '--override'],
+    ['suppress', { suppress: ['some-label'] }, '--suppress'],
+    ['fresh', { fresh: true }, '--fresh'],
+    ['mode-standard', { mode: 'standard' as const }, '--mode'],
+    ['mode-structural', { mode: 'structural' as const }, '--mode'],
+    ['raw', { raw: true }, '--raw'],
+  ])(
+    'throws CONFIG_INVALID when --estimate is combined with %s',
+    async (_name, extra, expectedFlag) => {
+      const { shieldCommand } = await import('./shield.js');
+      const { TotemConfigError } = await import('@mmnto/totem');
+
+      const promise = shieldCommand({ estimate: true, ...extra });
+      await expect(promise).rejects.toBeInstanceOf(TotemConfigError);
+      await expect(promise).rejects.toMatchObject({ code: 'CONFIG_INVALID' });
+      await expect(promise).rejects.toThrow(
+        new RegExp(
+          `${expectedFlag.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&')} is incompatible with --estimate`,
+        ),
+      );
+    },
+  );
+
+  it('does NOT trip the --override length check when --estimate is set', async () => {
+    // Without --estimate, a 5-char --override would throw "must be at
+    // least 10 characters". With --estimate, the incompatibility guard
+    // fires first and the error names the actual conflict.
+    const { shieldCommand } = await import('./shield.js');
+    await expect(shieldCommand({ estimate: true, override: 'short' })).rejects.toThrow(
+      /--override is incompatible with --estimate/,
+    );
+  });
+
+  it('treats an empty --suppress array as compatible (commander accumulator default)', async () => {
+    // Commander seeds --suppress with `[]`. An empty array MUST NOT
+    // trigger the incompatibility error — only a non-empty array
+    // counts as the user actually passing --suppress.
+    mockGetDiffForReview.mockResolvedValue(null);
+    const { shieldCommand } = await import('./shield.js');
+    await expect(shieldCommand({ estimate: true, suppress: [] })).resolves.toBeUndefined();
+  });
+});

--- a/packages/cli/src/commands/shield-estimate.test.ts
+++ b/packages/cli/src/commands/shield-estimate.test.ts
@@ -220,6 +220,45 @@ describe('runEstimate', () => {
     expect(rcrArgs.isStaged).toBe(true);
   });
 
+  // mmnto-ai/totem#1732 CR R2 — `--diff` outranks `--staged` in
+  // `getDiffForReview`. `isStaged` must follow the resolved
+  // `DiffForReviewSource`, not the raw CLI flag, so the staged-index
+  // read strategy only kicks in for genuinely staged runs.
+  it('derives isStaged from diffResult.source, not options.staged, when both --diff and --staged are passed', async () => {
+    mockGetDiffForReview.mockResolvedValue(diffResult({ source: 'explicit-range' }));
+    mockRunCompiledRules.mockResolvedValue(runCompiledRulesPassResult());
+
+    const { runEstimate } = await import('./shield-estimate.js');
+    await runEstimate(
+      { estimate: true, staged: true, diff: 'main...HEAD' },
+      makeConfig(),
+      tmpDir,
+      tmpDir,
+    );
+
+    const rcrArgs = mockRunCompiledRules.mock.calls[0]![0];
+    expect(rcrArgs.isStaged).toBe(false);
+  });
+
+  it.each([
+    ['uncommitted', false] as const,
+    ['branch-vs-base', false] as const,
+    ['explicit-range', false] as const,
+    ['staged', true] as const,
+  ])(
+    'isStaged is true iff resolved source is "staged" (source=%s → isStaged=%s)',
+    async (source, expected) => {
+      mockGetDiffForReview.mockResolvedValue(diffResult({ source }));
+      mockRunCompiledRules.mockResolvedValue(runCompiledRulesPassResult());
+
+      const { runEstimate } = await import('./shield-estimate.js');
+      await runEstimate({ estimate: true }, makeConfig(), tmpDir, tmpDir);
+
+      const rcrArgs = mockRunCompiledRules.mock.calls[0]![0];
+      expect(rcrArgs.isStaged).toBe(expected);
+    },
+  );
+
   it('forwards options.out as outPath into runCompiledRules', async () => {
     mockGetDiffForReview.mockResolvedValue(diffResult());
     mockRunCompiledRules.mockResolvedValue(runCompiledRulesPassResult());

--- a/packages/cli/src/commands/shield-estimate.ts
+++ b/packages/cli/src/commands/shield-estimate.ts
@@ -55,6 +55,12 @@ export async function runEstimate(
     ignorePatterns: config.ignorePatterns,
     tag: ESTIMATE_DISPLAY_TAG,
     configRoot,
-    isStaged: !!options.staged,
+    // Source-of-truth for staged-mode is the resolved `DiffForReviewSource`,
+    // not the raw `options.staged` flag. `--diff` outranks `--staged` in
+    // `getDiffForReview` (mmnto-ai/totem#1717), so passing both flags must
+    // not cause `runCompiledRules` to use the staged-index read strategy
+    // when the diff actually came from an explicit range
+    // (mmnto-ai/totem#1732 CR R2).
+    isStaged: diffResult.source === 'staged',
   });
 }

--- a/packages/cli/src/commands/shield-estimate.ts
+++ b/packages/cli/src/commands/shield-estimate.ts
@@ -1,0 +1,62 @@
+import type { TotemConfig } from '@mmnto/totem';
+
+import type { ShieldOptions } from './shield.js';
+// totem-context: shield-templates is a pure constants module — static
+// import is correct and the dynamic-imports-in-CLI lint rule is a false
+// positive here. Same pattern as shield.ts's DISPLAY_TAG import.
+import { ESTIMATE_DISPLAY_TAG } from './shield-templates.js';
+
+/**
+ * Pre-flight deterministic-rule estimator for `totem review --estimate`
+ * (mmnto-ai/totem#1714). Runs the same compiled-rule engine as
+ * `totem lint` against the diff resolved by `totem review`'s standard
+ * resolution chain (explicit `--diff` → `--staged` → working-tree →
+ * branch-vs-base) and returns immediately. No orchestrator, no
+ * embedder, no LanceDB — the entire LLM Verification Layer is
+ * structurally unreachable from this module.
+ *
+ * Output is labeled `[Estimate]` (`ESTIMATE_DISPLAY_TAG`) on every log
+ * line so consumers cannot conflate this with an LLM verdict; the
+ * verdict line and `SHIELD_FAILED` exit semantics are inherited from
+ * `runCompiledRules` unchanged so a passing estimate looks identical to
+ * a passing `totem lint` run on the metrics + trap-ledger surface.
+ *
+ * Empty-diff handling intentionally does NOT stamp the
+ * `.reviewed-content-hash` push-gate cache: an estimate is a forecast,
+ * not a passing review, and stamping the cache would let the push-gate
+ * unblock without ever running the LLM review.
+ */
+export async function runEstimate(
+  options: ShieldOptions,
+  config: TotemConfig,
+  cwd: string,
+  configRoot: string,
+): Promise<void> {
+  const { log } = await import('../ui.js');
+  const { getDiffForReview } = await import('../git.js');
+  const { runCompiledRules } = await import('./run-compiled-rules.js');
+
+  log.info(ESTIMATE_DISPLAY_TAG, 'Pre-flight prediction (deterministic, zero-LLM):');
+
+  const diffResult = await getDiffForReview(options, config, cwd, ESTIMATE_DISPLAY_TAG);
+  if (!diffResult) {
+    // Distinct from the `totem review` no-diff branch: the LLM path
+    // stamps the push-gate content hash because an empty diff is a
+    // trivial pass; an estimate is a forecast and explicitly does NOT
+    // stamp the cache. (Q2 in `.totem/specs/1714.md`.)
+    log.info(ESTIMATE_DISPLAY_TAG, 'No changes detected. Nothing to estimate.');
+    return;
+  }
+
+  await runCompiledRules({
+    diff: diffResult.diff,
+    cwd,
+    totemDir: config.totemDir,
+    format: 'text',
+    outPath: options.out,
+    ignorePatterns: config.ignorePatterns,
+    tag: ESTIMATE_DISPLAY_TAG,
+    configRoot,
+    isStaged: !!options.staged,
+  });
+}

--- a/packages/cli/src/commands/shield-estimate.ts
+++ b/packages/cli/src/commands/shield-estimate.ts
@@ -1,9 +1,7 @@
 import type { TotemConfig } from '@mmnto/totem';
 
 import type { ShieldOptions } from './shield.js';
-// totem-context: shield-templates is a pure constants module — static
-// import is correct and the dynamic-imports-in-CLI lint rule is a false
-// positive here. Same pattern as shield.ts's DISPLAY_TAG import.
+// totem-context: shield-templates is a pure constants + types module with no runtime logic; static import matches the established shield.ts:19 DISPLAY_TAG pattern and the lazy-import lint rule is a false positive here
 import { ESTIMATE_DISPLAY_TAG } from './shield-templates.js';
 
 /**

--- a/packages/cli/src/commands/shield-templates.ts
+++ b/packages/cli/src/commands/shield-templates.ts
@@ -36,6 +36,17 @@ export const TAG = 'Shield';
  * config-key lookup (e.g. `runOrchestrator({ tag: TAG })`).
  */
 export const DISPLAY_TAG = 'Review';
+
+/**
+ * User-visible log prefix for the `totem review --estimate` pre-flight
+ * deterministic-rule run (mmnto-ai/totem#1714). Distinct from
+ * `DISPLAY_TAG` so estimator output is unmistakably labeled as a
+ * forecast rather than a final LLM verdict. Every `log.info` /
+ * `log.dim` / `log.warn` call emitted from the estimate code path
+ * (`shield-estimate.ts`) MUST use this constant, never `DISPLAY_TAG`.
+ */
+export const ESTIMATE_DISPLAY_TAG = 'Estimate';
+
 export const MAX_DIFF_CHARS = 50_000;
 export const QUERY_DIFF_TRUNCATE = 2_000;
 export const SPEC_SEARCH_POOL = 15;

--- a/packages/cli/src/commands/shield.ts
+++ b/packages/cli/src/commands/shield.ts
@@ -541,6 +541,19 @@ export interface ShieldOptions {
   override?: string;
   suppress?: string[];
   autoCapture?: boolean;
+  /**
+   * Pre-flight deterministic-rule estimator (mmnto-ai/totem#1714). When
+   * true, `shieldCommand` short-circuits to `runEstimate` in
+   * `shield-estimate.ts`: same diff-resolution chain as the LLM review
+   * path, then `runCompiledRules` against `compiled-rules.json`, then
+   * return — no orchestrator, no embedder, no LanceDB. Output is labeled
+   * `[Estimate]` (`ESTIMATE_DISPLAY_TAG`) instead of `[Review]` so log
+   * lines unmistakably read as a forecast. Mutually incompatible with
+   * `--learn`, `--auto-capture`, `--override`, `--suppress`, `--fresh`,
+   * `--mode`, and `--raw` — these only apply to the LLM path; combining
+   * them throws `TotemConfigError CONFIG_INVALID`.
+   */
+  estimate?: boolean;
 }
 
 // ─── Deterministic mode (delegates to shared engine) ─
@@ -1063,6 +1076,44 @@ export async function shieldCommand(options: ShieldOptions): Promise<void> {
   const { filterDiffByPatterns, getDiffForReview } = await import('../git.js');
   const { classifyChangedFiles } = await import('./shield-classify.js');
   const { extractShieldContextAnnotations, extractShieldHints } = await import('./shield-hints.js');
+
+  // mmnto-ai/totem#1714: --estimate is the deterministic-rule pre-flight
+  // path. Reject incompatible flag combinations BEFORE any other
+  // validation (e.g. the --override length check below) so the user-
+  // facing error names the actual conflict (`--override is incompatible
+  // with --estimate`) instead of a misleading downstream constraint.
+  if (options.estimate) {
+    type IncompatibleFlag = readonly [keyof ShieldOptions, string];
+    const incompatible: readonly IncompatibleFlag[] = [
+      ['learn', '--learn'],
+      ['autoCapture', '--auto-capture'],
+      ['override', '--override'],
+      ['suppress', '--suppress'],
+      ['fresh', '--fresh'],
+      ['mode', '--mode'],
+      ['raw', '--raw'],
+    ];
+    for (const [key, flag] of incompatible) {
+      const value = options[key];
+      // totem-context: boolean OR in a presence-test, not a numeric-metric default — `??` would change "absent or explicitly-disabled" to "absent" and let `--fresh=false` slip through
+      if (value === undefined || value === false) continue;
+      if (Array.isArray(value) && value.length === 0) continue;
+      throw new TotemConfigError(
+        `${flag} is incompatible with --estimate.`,
+        'Drop the incompatible flag, or run without --estimate.',
+        'CONFIG_INVALID',
+      );
+    }
+
+    const cwd = process.cwd();
+    const configPath = resolveConfigPath(cwd);
+    const configRoot = path.dirname(configPath);
+    loadEnv(cwd);
+    const config = await loadConfig(configPath);
+    const { runEstimate } = await import('./shield-estimate.js');
+    await runEstimate(options, config, cwd, configRoot);
+    return;
+  }
 
   if (options.mode && options.mode !== 'standard' && options.mode !== 'structural') {
     throw new TotemConfigError(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -312,6 +312,10 @@ const reviewOptions = (cmd: Command) =>
       '--auto-capture',
       'Enable Pipeline 5 auto-capture of observation rules from findings (off by default; captured rules are context-less and apply globally)',
     )
+    .option(
+      '--estimate',
+      'Pre-flight deterministic-rule estimator (zero-LLM). Runs compiled-rules.json against the diff and prints predicted findings tagged [Estimate]. Bypasses the LLM Verification Layer entirely. Incompatible with --learn, --auto-capture, --override, --suppress, --fresh, --mode, and --raw.',
+    )
     .addHelpText(
       'after',
       [
@@ -322,6 +326,15 @@ const reviewOptions = (cmd: Command) =>
         '  3. (fallback)        → branch-vs-base diff when 1/2 produce nothing',
         `The chosen path is logged to stderr; large diffs (>${REVIEW_DIFF_TRUNCATION_THRESHOLD} chars)`,
         'trigger an explicit truncation warning before the LLM call.',
+        '',
+        'Pre-flight estimator (--estimate):',
+        '  Runs the same deterministic engine as `totem lint` against the diff',
+        '  resolved by the chain above and returns immediately — no orchestrator,',
+        '  no embedding, no LanceDB. Output is labeled [Estimate] (not [Review])',
+        '  so log lines unmistakably read as a forecast. Use this to predict bot',
+        '  findings before opening a PR. Example:',
+        // totem-context: documented git-range example in --help text for users of --diff, not a hardcoded base-branch reference in product code
+        '    totem review --estimate --diff main...HEAD',
         '',
       ].join('\n'),
     );
@@ -341,6 +354,7 @@ async function runReview(opts: {
   override?: string;
   suppress?: string[];
   autoCapture?: boolean;
+  estimate?: boolean;
 }): Promise<void> {
   // Redirect removed --deterministic flag to totem lint
   if (opts.deterministic) {


### PR DESCRIPTION
## Mechanical Root Cause

Contributors open PRs without visibility into which compiled rules will fire on their diff. Rounds 1-N of bot review become "discover the rule corpus" rather than "ship the substantive change." Most of those findings are predictable from `compiled-rules.json` already on disk — the operator just has no command surface to ask the question before pushing.

This is the second feature in the bot-tax cluster. `mmnto-ai/totem#1715` shipped the substrate yesterday (cross-PR recurrence stats); this PR ships the pre-flight predictor that consumers will run on every PR before pushing. `mmnto-ai/totem#1713` (retrospect) is the third; both this and that one read the same substrate.

## Fix Applied

### `totem review --estimate` (new flag)

- New `--estimate` flag on `totem review`. When set, `shieldCommand` short-circuits to `runEstimate` in the new `shield-estimate.ts` module before any orchestrator / embedder / LanceDB code path is reachable.
- Diff resolution reuses the existing `getDiffForReview` chain from `mmnto-ai/totem#1717`: `--diff <range>` → `--staged` → working-tree → branch-vs-base, with the truncation warning and implicit-source logging inherited unchanged.
- Rule evaluation reuses `runCompiledRules` (the same engine `totem lint` uses): regex via the bounded worker, AST via Tree-sitter / ast-grep, full trap-ledger + rule-metrics writes (Q2 — estimator runs are valid evaluations and dogfood the same telemetry surface).
- Output is labeled `[Estimate]` (new `ESTIMATE_DISPLAY_TAG` distinct from `[Review]`) so log lines unmistakably read as a forecast rather than a final LLM verdict (Q3).
- Empty-diff runs do NOT stamp the `.reviewed-content-hash` push-gate cache. An estimate is a forecast, not a passing review; stamping the cache would let a future `totem review` push-gate skip the LLM verification.

### Approved decisions (Q1-Q4 from `.totem/specs/1714.md`, confirmed by Gemini)

- **Q1 — new module:** `shield-estimate.ts` rather than inlining in 1100-line `shield.ts`. Parallels the `shield-classify` / `shield-hints` / `shield-templates` pattern.
- **Q2 — metrics dogfood:** estimator runs write `rule-metrics.json` and trap-ledger entries transparently. Same behavior as `totem lint`.
- **Q3 — distinct tag:** `[Estimate]` not `[Review]`. The whole point is to make "this is a prediction" unmistakable in stdout.
- **Q4 — follow-up overlay:** `mmnto-ai/totem#1731` filed for the optional pattern-history layer (cross-checking `.totem/recurrence-stats.json` for clusters not yet covered by a compiled rule). Out of scope here; in scope for that ticket.

### Spec deviation worth flagging

The Gemini auto-spec at the top of `.totem/specs/1714.md` recommended **scope matching** ("rules whose globs match changed files") instead of running the engine. I rejected that recommendation in the appended Implementation Design section — the AC asks for "predicted findings, severity, anchored citations" with file:line, which scope matching cannot produce. The implementation runs the actual engine; the design doc captures the pushback for posterity.

### Incompatible flag combinations

`--estimate` is mutually incompatible with `--learn`, `--auto-capture`, `--override`, `--suppress`, `--fresh`, `--mode`, `--raw` — these only mean things in the LLM path. The incompatibility guard fires **before** the existing `--mode` and `--override` length validation so the user-facing error names the actual conflict (`--override is incompatible with --estimate`) rather than a misleading downstream constraint. Table-driven test covers all 7 combinations.

### Dogfood note

`pnpm exec totem review --estimate --staged` was used as a sanity check during this PR's pre-push cycle. Output: `[Estimate] Verdict: PASS - 52 warning(s), 0 errors`, identical to `pnpm exec totem lint --staged`. The tag is correctly `[Estimate]` on every log line; no `[Review]` leakage. The 52 warnings are all on the new test file (`shield-estimate.test.ts`) firing legitimate test-pattern rules whose globs don't exclude `*.test.ts` properly — out of scope for this PR.

The `mmnto-ai/totem#1727` override-stamp-cache fix (shipped yesterday in `@mmnto/cli@1.15.10`) worked end-to-end on this PR's pre-push cycle. Round-1 `totem review --staged` flagged a false-positive CRITICAL on `loadConfig`/`loadEnv`/`resolveConfigPath` (claimed missing imports; actually statically imported at `shield.ts:8,9,12` and used identically at line 1140 in the pre-existing LLM path). The override path stamped the push-gate cache automatically.

## Out of Scope

- Pattern-history overlay (cross-checking `recurrence-stats.json`) — filed as `mmnto-ai/totem#1731`.
- LLM-mediated synthesis — this is the deterministic-substrate path; the AI verdict path stays exactly as-is for non-`--estimate` invocations.
- Agent-facing MCP surface — pure CLI for now.
- Pre-existing test-glob noise (52 warnings on `shield-estimate.test.ts`) — separate cleanup.
- Submodule pointer not bumped per `feedback_no_auto_strategy_submodule_bump.md`.

## Tests Added/Updated

- [x] Added/updated automated tests covering the root-cause mechanism

**`packages/cli/src/commands/shield-estimate.test.ts`** — 24 new tests covering every design-doc invariant:

- **No-LLM-import assertion** (defense-in-depth): static-source regex check that `shield-estimate.ts` does not import `runOrchestrator` / `requireEmbedding` / `LanceStore` / any orchestrator-side surface, paired with runtime mocking that catches accidental imports if execution happens to traverse them.
- **Diff-source resolution:** four `it.each` rows covering explicit `--diff`, `--staged`, working-tree, branch-vs-base. Verifies the right `getDiffForReview` source label flows through and that the diff fed to `runCompiledRules` matches what the resolver returned.
- **Empty-diff branch:** `getDiffForReview` returns `null` → `[Estimate] No changes detected. Nothing to estimate.` line + clean return + no `runCompiledRules` call + no content-hash stamp.
- **Tag invariant:** every log line uses `ESTIMATE_DISPLAY_TAG`, never `DISPLAY_TAG`. Asserted across PASS / no-diff / FAIL paths.
- **Verdict propagation:** PASS run completes without throwing; `SHIELD_FAILED` `TotemError` from `runCompiledRules` propagates unchanged.
- **Incompatibility guard table:** `describe.each` covering all 7 incompatible flags + the `--mode-standard` / `--mode-structural` symmetry case + the `suppress: []` no-conflict case + ordering check (the new guard fires before the existing `--override` length check so the error names the actual conflict).
- **Preamble emission:** `[Estimate] Pre-flight prediction (deterministic, zero-LLM):` is logged before any work runs.

CLI suite: 1853 → 1877 (+24). Core suite unchanged (no core changes).

## Test Plan

- [x] `pnpm run format` clean
- [x] `pnpm --filter @mmnto/cli build` clean (typecheck via tsc)
- [x] `pnpm --filter @mmnto/totem build` clean
- [x] `pnpm --filter @mmnto/cli test` 1877/1877 pass
- [x] `pnpm --filter @mmnto/totem test` 1438/1438 pass
- [x] `pnpm exec totem lint` 0 errors (52 warnings — test-glob noise, out of scope)
- [x] `pnpm exec totem review --staged` PASS via override (false positive on statically-imported utilities; overridden with citation)
- [x] Dogfood `pnpm exec totem review --estimate --staged` matches `pnpm exec totem lint --staged` line-for-line on warnings
- [x] Pre-push hook (`totem lint` + `totem verify-manifest`) PASS

Closes mmnto-ai/totem#1714