### PR TITLE
feat(core): STRATEGY_ROOT resolver + consumer ports (mmnto-ai/totem#1710)

### DIFF
--- a/.changeset/1710-strategy-root-consumers.md
+++ b/.changeset/1710-strategy-root-consumers.md
@@ -1,5 +1,5 @@
 ---
-'@mmnto/mcp': minor
+'@mmnto/mcp': major
 '@mmnto/cli': patch
 ---
 

--- a/.changeset/1710-strategy-root-consumers.md
+++ b/.changeset/1710-strategy-root-consumers.md
@@ -1,0 +1,47 @@
+---
+'@mmnto/mcp': minor
+'@mmnto/cli': patch
+---
+
+feat(consumers): port to `resolveStrategyRoot` (mmnto-ai/totem#1710)
+
+Builds on the `@mmnto/totem` resolver substrate. Each programmatic consumer
+of the strategy repo now reads through `resolveStrategyRoot` and degrades
+gracefully when the strategy root is unresolvable.
+
+**`@mmnto/mcp`:**
+
+- **Breaking:** `describe_project` rich-state `strategyPointer` payload
+  flips from `{ sha, latestJournal }` to a discriminated union:
+  `{ resolved: true, sha, latestJournal } | { resolved: false, reason }`.
+  Agents that read the rich-state pointer must check `resolved` before
+  reading `sha` / `latestJournal`. Only affects callers that opted in via
+  `includeRichState: true` — the legacy slim payload is byte-identical.
+- **Auto-injected strategy linkedIndex.** `initContext` consults
+  `resolveStrategyRoot` and prepends the resolved strategy path to the
+  linkedIndexes iteration with a stable link name `'strategy'`. Boundary
+  routing (`boundary: 'strategy'`) keeps working regardless of physical
+  source (sibling / submodule / env override). Init-time warnings surface
+  ONLY when the user explicitly signaled a strategy expectation (env or
+  config); zero-config projects without a strategy repo skip silently.
+
+**`@mmnto/cli`:**
+
+- `totem proposal new` / `totem adr new` use `resolveStrategyRoot` and
+  throw an actionable `TotemError` (ADR-088) with sibling-clone hint
+  when unresolved. Standalone strategy-repo case (cwd IS the strategy
+  repo) is detected before the resolver runs.
+- New `totem doctor` "Strategy Root" advisory diagnostic (`pass` /
+  `warn`, never `fail`).
+- Bench scripts (`scripts/benchmark-compile.ts`, `scripts/bench-lance-open.ts`)
+  hard-fail with actionable messages when the strategy root is unresolvable.
+
+**`totem.config.ts`:** the literal `linkedIndexes: ['.strategy']` is
+removed; the resolver is now the single source of truth for the strategy
+mesh path.
+
+**Documentation:** new `CONTRIBUTING.md` "Strategy Repo Expectations"
+section + `docs/architecture.md` update describing the configurable
+resolver.
+
+`.gitmodules` removal is a separate follow-up after this lands.

--- a/.changeset/1710-strategy-root-consumers.md
+++ b/.changeset/1710-strategy-root-consumers.md
@@ -28,9 +28,11 @@ gracefully when the strategy root is unresolvable.
 **`@mmnto/cli`:**
 
 - `totem proposal new` / `totem adr new` use `resolveStrategyRoot` and
-  throw an actionable `TotemError` (ADR-088) with sibling-clone hint
-  when unresolved. Standalone strategy-repo case (cwd IS the strategy
-  repo) is detected before the resolver runs.
+  throw an actionable `TotemError(CONFIG_MISSING)` with a sibling-clone
+  hint and `TOTEM_STRATEGY_ROOT` reference when unresolved (per the
+  ADR-088 design rationale on actionable error UX). Standalone
+  strategy-repo case (cwd IS the strategy repo) is detected before the
+  resolver runs.
 - New `totem doctor` "Strategy Root" advisory diagnostic (`pass` /
   `warn`, never `fail`).
 - Bench scripts (`scripts/benchmark-compile.ts`, `scripts/bench-lance-open.ts`)

--- a/.changeset/1710-strategy-root-resolver.md
+++ b/.changeset/1710-strategy-root-resolver.md
@@ -1,0 +1,26 @@
+---
+'@mmnto/totem': patch
+---
+
+feat(core): `resolveStrategyRoot` substrate (mmnto-ai/totem#1710)
+
+Adds a configurable strategy-root resolver to replace the hardcoded
+`.strategy/` submodule path. The resolver walks four precedence layers:
+
+1. `TOTEM_STRATEGY_ROOT` env var (with `STRATEGY_ROOT` accepted as a
+   legacy alias).
+2. `TotemConfig.strategyRoot` field (new optional config field).
+3. Sibling clone at `<gitRoot>/../totem-strategy/`.
+4. Legacy submodule at `<gitRoot>/.strategy/`.
+
+Each layer must resolve to a real directory (`fs.statSync(...).isDirectory()`)
+before it counts; misses fall through. Returns a `StrategyRootStatus`
+discriminated union so callers can pattern-match on `resolved` without a
+type assertion. Relative env / config values anchor at the git root, not at
+deep cwd.
+
+This PR ships the substrate only (resolver + types + config field +
+re-exports + 22 unit tests). Programmatic-consumer ports
+(`extractStrategyPointer`, `resolveGovernancePaths`, MCP `initContext`
+linkedIndexes, bench scripts) and the `StrategyPointerSchema` discriminated
+union land in the follow-up consumer-port PR.

--- a/.changeset/1710-strategy-root-resolver.md
+++ b/.changeset/1710-strategy-root-resolver.md
@@ -1,5 +1,5 @@
 ---
-'@mmnto/totem': patch
+'@mmnto/totem': minor
 ---
 
 feat(core): `resolveStrategyRoot` substrate (mmnto-ai/totem#1710)

--- a/.changeset/1710-strategy-root-resolver.md
+++ b/.changeset/1710-strategy-root-resolver.md
@@ -19,8 +19,9 @@ discriminated union so callers can pattern-match on `resolved` without a
 type assertion. Relative env / config values anchor at the git root, not at
 deep cwd.
 
-This PR ships the substrate only (resolver + types + config field +
-re-exports + 22 unit tests). Programmatic-consumer ports
+This entry covers the core substrate: resolver + types + config field +
+re-exports + unit tests. Programmatic-consumer ports
 (`extractStrategyPointer`, `resolveGovernancePaths`, MCP `initContext`
-linkedIndexes, bench scripts) and the `StrategyPointerSchema` discriminated
-union land in the follow-up consumer-port PR.
+linkedIndexes, bench scripts) and the `StrategyPointerSchema`
+discriminated union ship in the same PR via
+`1710-strategy-root-consumers.md`.

--- a/.totem/specs/1710.md
+++ b/.totem/specs/1710.md
@@ -1,0 +1,278 @@
+### Problem Statement
+
+The hardcoded `.strategy` git submodule creates unnecessary downstream CI costs and pull request noise for pure strategy repository updates. We need to replace it with a configurable `STRATEGY_ROOT` resolver that dynamically locates the strategy repository (prioritizing sibling directories and environment variables) while explicitly handling missing-strategy states with actionable errors across all programmatic consumers.
+
+### Architectural Context
+
+- **ADR-088 (Actionable Error UX):** Demands fail-loud, actionable error messages instead of silent omissions or raw stack traces when dependencies (like the strategy repo) are missing.
+- **Gemini Styleguide (Declined Patterns):** Mandates avoiding Zod schemas for small parsers or data structures (<10 fields). The MCP strategy extraction payload updates must use standard TS types rather than introducing new Zod schemas.
+
+### Files to Examine
+
+1. `packages/mcp/src/state-extractors.ts` — Currently hardcodes `.strategy` in `extractStrategyPointer`; must be updated to use the new resolver and return the new graceful-degrade payload.
+2. `packages/cli/src/utils/governance.ts` — Contains `resolveGovernancePaths`, which already scaffolds into `.strategy`; needs to flip its default and integrate the actionable fail-loud error.
+3. `totem.config.ts` — Contains the `linkedIndexes` array; needs to accept dynamic paths or gracefully skip missing ones.
+4. `scripts/benchmark-compile.ts` & `scripts/bench-lance-open.ts` — Need to be pointed to the new resolver instead of hardcoded paths.
+5. `docs/architecture.md` & `CONTRIBUTING.md` — Require documentation updates for the sibling-clone expectation.
+
+### Technical Approach & Contracts
+
+**1. The Resolver Function (`packages/core/src/strategy-resolver.ts`)**
+Create a central utility `resolveStrategyRoot(cwd: string): StrategyRootStatus` that checks paths in this strict order:
+
+1. `process.env.STRATEGY_ROOT` (resolved absolutely against `cwd`)
+2. `totem.config.ts` configured path (if present)
+3. Sibling path: `path.join(resolveGitRoot(cwd) || cwd, '../totem-strategy')`
+4. Submodule fallback: `path.join(resolveGitRoot(cwd) || cwd, '.strategy')`
+
+**Data Contracts:**
+
+```typescript
+export type StrategyRootStatus =
+  | { resolved: true; path: string; source: 'env' | 'config' | 'sibling' | 'submodule' }
+  | { resolved: false; reason: string };
+
+// Updated MCP Payload for describe_project
+export type StrategyPointer =
+  | { resolved: true; sha: string | null; latestJournal: string | null }
+  | { resolved: false; reason: string };
+```
+
+**2. Consumer Updates**
+
+- **MCP (`state-extractors.ts`):** Call `resolveStrategyRoot`. If `resolved: false`, return `{ resolved: false, reason: status.reason }`. Do not throw.
+- **Governance (`governance.ts`):** Call `resolveStrategyRoot`. If `resolved: false`, throw a `TotemError` with instructions to clone `totem-strategy` as a sibling directory.
+- **Doctor Command:** Add a diagnostic step that calls `resolveStrategyRoot` and yields a warning if unresolved.
+- **Federated Search / LanceDB Config:** If `resolveStrategyRoot` fails, emit a console warning and omit the strategy index from the array rather than crashing the search process.
+
+### Edge Cases & Traps
+
+- **Relative Path Resolution Context:** A sibling fallback `../totem-strategy` resolved against `cwd` will fail if the CLI is invoked deeply inside the repo (e.g., `cd packages/core && totem proposal new`). You _must_ resolve the sibling path against the repository root using the shared `resolveGitRoot(cwd)` helper.
+- **Path Exists but is a File:** Checking `fs.existsSync` is not enough. You must use `fs.statSync(path).isDirectory()` to prevent catastrophic failures when `STRATEGY_ROOT` accidentally points to a file.
+- **Missing `git` context:** If `resolveGitRoot` returns `null` (e.g., running from a non-git directory), the resolver must handle it gracefully (fallback to `cwd`).
+- **`totem.config.ts` schema constraints:** If adding a property to `totem.config.ts`, ensure its internal Zod schema (already existing) is updated to accept `strategyRoot?: string`.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Core Strategy Resolver**
+      Create `packages/core/src/strategy-resolver.ts` and export `resolveStrategyRoot`. Add `strategyRoot?: z.string().optional()` to the configuration schema if one exists.
+
+  > TOTEM INVARIANT (Reuse Shared Helpers): You MUST use `resolveGitRoot(cwd)` to determine the repository root before appending `../totem-strategy` or `.strategy`.
+  > TEST DIRECTIVE: Before implementing, write a failing test named `returns unresolved status when all target directories are missing or are files instead of directories` in `packages/core/test/strategy-resolver.test.ts`.
+  > write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Update MCP Extractors**
+      Modify `packages/mcp/src/state-extractors.ts` to use `resolveStrategyRoot`. Update the `StrategyPointer` TypeScript return type.
+
+  > TOTEM INVARIANT (Gemini Styleguide): Do not use Zod to validate the returned `StrategyPointer` object; rely purely on TypeScript types since it has <10 fields.
+  > TEST DIRECTIVE: Before implementing, write a failing test named `returns resolved false payload when strategy root is missing` in `packages/mcp/test/state-extractors.test.ts`.
+  > write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Update Governance Scaffolding**
+      Modify `packages/cli/src/utils/governance.ts` (`resolveGovernancePaths`). Replace the hardcoded dual-mode logic with `resolveStrategyRoot`.
+
+  > TOTEM INVARIANT (ADR-088): You MUST throw a `TotemError` with a clear, actionable message detailing the sibling clone instruction if the strategy root is unresolved. Do not let it throw a generic filesystem error.
+  > TEST DIRECTIVE: Before implementing, write a failing test named `throws TotemError with sibling-clone instructions when strategy root is unresolvable` in `packages/cli/test/governance.test.ts`.
+  > write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Update config and Federated Search**
+      Modify `totem.config.ts` logic that configures `linkedIndexes`. Map it to use the new resolver, filtering out the strategy index with a logged warning if unresolvable.
+
+  > TEST DIRECTIVE: Before implementing, write a failing test named `omits strategy index and warns when strategy root is unresolvable` in the relevant search configuration test suite.
+  > write test (or update existing) → verify fails → implement → verify passes → lint
+
+- [ ] **Task 5: Update Scripts & Totem Doctor**
+      Update `scripts/benchmark-compile.ts` and `scripts/bench-lance-open.ts` to use the resolver. Add a new diagnostic in `totem doctor` that warns about unresolved strategy paths.
+
+  > TEST DIRECTIVE: Before implementing, write a failing test named `reports unresolvable strategy root as an advisory warning not a hard failure` in `packages/cli/test/doctor.test.ts`.
+  > write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 6: Documentation Updates**
+      Update `CONTRIBUTING.md` to add the "Strategy repo expectations" section. Update `docs/architecture.md` to reflect the configurable nature of the strategy root.
+      write test (N/A) → verify fails (N/A) → implement → verify passes (N/A) → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Environment Override:** Set `STRATEGY_ROOT=/tmp/mock-strategy`, verify `resolveStrategyRoot` prioritizes it and returns `{ resolved: true, source: 'env' }`.
+- **Deep CWD Execution:** Execute `totem proposal new` from inside `packages/mcp/src/` with a sibling strategy repo. Verify it resolves to the git root's sibling, not `packages/mcp/src/../totem-strategy`.
+- **Missing Directory Handled Gracefully:** Remove the `.strategy` folder and sibling folder. Run `describe_project` via MCP and verify the payload contains `strategy: { resolved: false, reason: "..." }` rather than crashing.
+- **Doctor Diagnostic:** Run `totem doctor` with no strategy repo present. Verify it exits with code 0 but lists the missing strategy repo as a warning.
+
+---
+
+## Implementation Design
+
+### Scope
+
+**This PR ships:** `resolveStrategyRoot()` in `@mmnto/totem` core with a `StrategyRootStatus` discriminated-union return type, a new optional `TotemConfig.strategyRoot?: string` field, ports of all four programmatic consumers (state-extractors, governance, MCP linkedIndexes init, scripts) to the resolver, conversion of `StrategyPointerSchema` to a `z.discriminatedUnion('resolved', ...)`, a `totem doctor` strategy-root diagnostic, and a `CONTRIBUTING.md` "Strategy repo expectations" section.
+
+**This PR does NOT ship:** removal of `.gitmodules` / `.strategy` gitlink (separate follow-up after the resolver settles); pack-distribution of strategy artifacts (Proposal 247 / 1.16.0 territory); replacement of the `linkedIndexes` array with a multi-strategy-style federated mechanism (out of scope per the issue's "Out of scope" section).
+
+### Data model deltas
+
+**1. New type `StrategyRootStatus` (in `packages/core/src/strategy-resolver.ts`, re-exported from `@mmnto/totem`):**
+
+```typescript
+export type StrategyRootStatus =
+  | { resolved: true; path: string; source: 'env' | 'config' | 'sibling' | 'submodule' }
+  | { resolved: false; reason: string };
+```
+
+- **Holds:** Resolved absolute path + which precedence layer matched, OR a reason string.
+- **Writer:** `resolveStrategyRoot(cwd, options?)` — sole writer; pure function, no caching.
+- **Readers:** `extractStrategyPointer` (MCP), `resolveGovernancePaths` (CLI governance), MCP `initContext` (linkedIndexes), `totem doctor`, `scripts/benchmark-compile.ts`, `scripts/bench-lance-open.ts`.
+- **Invariants:** `path` is absolute (resolver normalizes via `path.resolve(<gitRoot>, raw)`). `source` is exhaustively one of four literals. When `resolved: false`, callers MUST NOT read `path` (TS discriminated union enforces).
+
+**2. New optional field `TotemConfig.strategyRoot` (in `packages/core/src/config-schema.ts:281`-region):**
+
+```typescript
+strategyRoot: z.string().optional(),
+```
+
+- Resolved against `<gitRoot>` (or `cwd` as last-ditch fallback if outside a git repo).
+- Read once during `loadConfig`; runtime is read-only.
+
+**3. `StrategyPointerSchema` shape change** (in `packages/mcp/src/schemas/describe-project.ts:42-48`):
+
+```typescript
+export const StrategyPointerSchema = z.discriminatedUnion('resolved', [
+  z.object({
+    resolved: z.literal(true),
+    sha: z.string().nullable(),
+    latestJournal: z.string().nullable(),
+  }),
+  z.object({
+    resolved: z.literal(false),
+    reason: z.string(),
+  }),
+]);
+```
+
+- **BREAKING change** to MCP `describe_project` rich-state payload. Consumers must inspect `strategyPointer.resolved` before reading `sha` / `latestJournal`. Documented in changeset and CHANGELOG.
+- Auto-spec proposed dropping Zod entirely; rejected — `StrategyPointerSchema` is embedded in `RichProjectStateSchema.strategyPointer` (line 92), which is the contract for the entire rich-state output. Discriminated-union is the canonical Zod tagged-union form and preserves the validation contract.
+
+**No new state containers (no maps, sets, module-level vars, singletons). No reserved keys / sentinels.**
+
+### State lifecycle
+
+**`StrategyRootStatus` (per-call value):** Scope per-request. Created at the call site by `resolveStrategyRoot`, returned as a value, GC'd after the consumer reads it. No mutation. No cross-boundary lifecycle.
+
+**`TotemConfig.strategyRoot` (loaded-config field):** Same lifetime as the loaded `TotemConfig` — server-lifetime in MCP, per-invocation in CLI commands. Read-only at runtime; user edits the file to change.
+
+**MCP `linkedStores` map (UNCHANGED — server-lifetime):** Existing behavior. The resolver is consulted ONCE per linkedIndex entry during `initContext` (`packages/mcp/src/context.ts:216`) when the entry's path matches the literal `'.strategy'` (or any path the resolver would produce). Init-time errors continue to land in `linkedStoreInitErrors` and surface on first query — no lifecycle change.
+
+No state crosses lifecycle boundaries.
+
+### Failure modes
+
+| Failure                                                                               | Category | Agent-facing surface                                                                                 | Recovery                                                                  |
+| ------------------------------------------------------------------------------------- | -------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
+| `STRATEGY_ROOT` env var points to a nonexistent path                                  | runtime  | `resolveStrategyRoot` returns `{resolved: false, reason}`; downstream consumers degrade per contract | Set env var to a real path or unset to fall through                       |
+| `STRATEGY_ROOT` env var points to a file (not a directory)                            | runtime  | Same — `fs.statSync(...).isDirectory()` guard                                                        | Same                                                                      |
+| `TotemConfig.strategyRoot` points to a nonexistent path                               | runtime  | Same                                                                                                 | Edit `totem.config.ts`                                                    |
+| Sibling `../totem-strategy` missing AND `.strategy/` missing                          | runtime  | `{resolved: false, reason: 'no strategy root found...'}`                                             | Clone sibling per `CONTRIBUTING.md`                                       |
+| `cwd` outside a git repo AND no env/config override                                   | runtime  | Unresolved status (resolver bails on `resolveGitRoot(cwd) === null`)                                 | Run from inside totem checkout, or set `STRATEGY_ROOT` env var explicitly |
+| `extractStrategyPointer` reads unresolved status                                      | runtime  | MCP rich-state returns `strategyPointer: {resolved: false, reason}` (visible to agent — Tenet 4)     | Agent surfaces "no strategy resolvable" instead of stale pointer          |
+| `resolveGovernancePaths` reads unresolved status                                      | runtime  | Throws `TotemError(CONFIG_MISSING)` with sibling-clone hint string                                   | User clones sibling, retries                                              |
+| `linkedIndexes: ['.strategy']` resolves unresolvable in MCP init                      | init     | Existing `linkedStoreInitErrors` map captures; per-query warning surfaces                            | Existing recovery (clone or remove from config)                           |
+| `totem doctor` runs without strategy root resolvable                                  | runtime  | New advisory `warn` diagnostic listing affected surfaces                                             | Actionable; not a hard fail (matches existing `checkLinkedIndexes` UX)    |
+| Resolver called from deep cwd (e.g., `packages/mcp/src/`)                             | runtime  | Resolver anchors at `resolveGitRoot(cwd)`, NOT literal cwd                                           | N/A — handled by anchoring at git root                                    |
+| `STRATEGY_ROOT` set globally in shell across multiple repos                           | runtime  | Resolver still respects the env var; consumer that touches it sees the precedence-1 hit              | Per-repo override via `totem.config.ts:strategyRoot`                      |
+| Bench scripts (`benchmark-compile.ts`, `bench-lance-open.ts`) called outside the repo | runtime  | Resolver returns `unresolved`; scripts log a clear error and exit non-zero                           | Run scripts from inside the totem checkout                                |
+
+All failure modes are init-time or runtime — none are silent-degradation. The MCP `strategyPointer.resolved: false` payload IS a signal to the agent (Tenet 4 fail-loud), not silence.
+
+### Invariants to lock in via tests
+
+**`resolveStrategyRoot` (`packages/core/src/strategy-resolver.test.ts`):**
+
+- Returns `{resolved: false}` when ALL of: env unset, config field unset, sibling missing, submodule missing.
+- Precedence is exactly env → config → sibling → submodule. Each layer short-circuits the rest. (Test 4 fixture pairs.)
+- Returns `{resolved: false, reason}` (not throws) when `cwd` is outside a git repo AND no env/config override is set.
+- Rejects (returns `unresolved`) a path that exists but is a FILE not a directory.
+- Resolves relative env-var values against `<gitRoot>`, not deep-cwd. (Run from `packages/mcp/src` with `STRATEGY_ROOT=../totem-strategy` → resolves to `<gitRoot>/../totem-strategy`.)
+- `path` is absolute on the `resolved: true` branch (resolver normalizes via `path.resolve`).
+
+**`extractStrategyPointer` (`packages/mcp/src/state-extractors.test.ts`):**
+
+- Returns `{resolved: false, reason}` when resolver returns unresolved.
+- Returns `{resolved: true, sha, latestJournal}` when resolver returns resolved (with `sha`/`latestJournal` nullable per existing graceful-degrade inside the strategy dir).
+
+**`resolveGovernancePaths` (`packages/cli/test/governance.test.ts`):**
+
+- Throws `TotemError(CONFIG_MISSING)` with sibling-clone instruction string when resolver returns unresolved.
+- Succeeds for both `submodule` and `sibling` source values without code-path divergence (the resolver hides the source).
+
+**MCP `initContext`** (existing test surface in `packages/mcp/src/context.test.ts` or `tools/search-knowledge.test.ts`):
+
+- Skips the strategy linkedIndex with a warning when the resolver returns unresolved (existing per-query warning path; no new surface needed).
+
+**`totem doctor` (`packages/cli/src/commands/doctor.test.ts`):**
+
+- New `Strategy Root` diagnostic returns `pass` when resolved, `warn` (NOT `fail`) when unresolved, surfacing affected consumers and remediation.
+
+**`StrategyPointerSchema` (`packages/mcp/src/schemas/describe-project.test.ts`):**
+
+- Discriminated union accepts both `{resolved: true, sha, latestJournal}` and `{resolved: false, reason}`.
+- Rejects malformed mixes (e.g., `{resolved: true, reason: 'x'}`, `{resolved: false, sha: null}`).
+
+### Open questions
+
+**Q1 — Env-var name: `STRATEGY_ROOT` (per ticket) or `TOTEM_STRATEGY_ROOT` (namespace hygiene)?**
+
+- **Options:** A) `STRATEGY_ROOT` (literal from issue). B) `TOTEM_STRATEGY_ROOT` (matches existing `TOTEM_TEST_*` convention; less likely to collide with arbitrary shell envs).
+- **Recommendation:** B with A as accepted alias. Read `process.env.TOTEM_STRATEGY_ROOT ?? process.env.STRATEGY_ROOT`. Document the canonical form as `TOTEM_STRATEGY_ROOT` in CONTRIBUTING.md; mention `STRATEGY_ROOT` works for backward-shorthand. Cheap to support both, prevents the namespace footgun.
+
+**Q2 — Multi-PR scope. Single PR or split?**
+
+- **Options:** A) Single PR (resolver + 4 consumers + schema flip + doctor + tests + docs). B) Two PRs: (1) substrate (resolver + `StrategyPointerSchema` discriminated union + tests), (2) consumer port (state-extractors + governance + MCP linkedIndexes init + scripts + doctor + CONTRIBUTING.md). C) Three+ PRs (more granular).
+- **Recommendation:** B. Substrate PR is small, deterministic, easy to review — and it ships the breaking schema change cleanly with one bot review cycle. Consumer-port PR has wider surface but each consumer is independently testable. Both qualify as "meaningful release candidates" per `feedback_bundle_locally_avoid_pr_churn.md`. C burns bot quota for marginal review-context gains; A risks a long bot-review tail on a single PR (the `StrategyPointerSchema` change is bot-bait).
+
+**Q3 — Submodule fallback in resolver from day one, or sibling-only with consumer-side legacy fallback?**
+
+- **Options:** A) Resolver supports `submodule` source (per spec). B) Resolver is sibling-only; legacy `.strategy/` access stays in consumers and is removed in the gitlink-removal PR.
+- **Recommendation:** A. The resolver IS the abstraction layer that lets us flip cleanly. With the submodule fallback in the resolver, the `.gitmodules` removal PR is a one-line change to drop the fallback case + delete `.gitmodules`. Option B forces consumers to know about both paths during transition, defeating the purpose of the resolver.
+
+**Q4 — `StrategyPointer` shape. Drop Zod (auto-spec recommendation) or convert to discriminated union?**
+
+- **Options:** A) Drop Zod, use TS-only types (auto-spec). Loosens `RichProjectStateSchema.strategyPointer` to `z.any()` or removes validation. B) Keep Zod, convert to `z.discriminatedUnion('resolved', [...])`.
+- **Recommendation:** B. The MCP rich-state output is a Zod-validated contract; loosening one field would regress the validation surface. Sixth recurrence of the auto-spec gap pattern (after `mmnto-ai/totem#1665` / `#1688` / `#1690` / `#1713` / `#1731`); design doc supersedes auto-spec per `feedback_auto_spec_gap.md`.
+
+**Q5 — `totem.config.ts:68` `linkedIndexes: ['.strategy']` literal: leave it, or replace with a resolver-aware mechanism in this PR?**
+
+- **Options:** A) Leave literal `'.strategy'`. The resolver kicks in inside `initContext` when iterating linkedIndexes — if the entry equals `'.strategy'`, the iterator consults the resolver to get the actual path, with graceful skip on unresolved. B) Replace the literal with a sentinel (e.g., `linkedIndexes: ['<strategy>']` or a config field `linkedStrategy: true`). C) Drop the entry and have the resolver auto-add the strategy index when resolvable.
+- **Recommendation:** C, with the literal removed from `totem.config.ts:68`. Cleanest separation of concerns: the resolver owns "where is strategy", and the federated-search machinery auto-includes strategy when resolvable. `linkedIndexes` array stays for genuinely-third-party indexes (none today, but the surface remains). This requires a small change in `initContext` to inject the resolved strategy path into the iteration loop, and the user no longer hand-edits `totem.config.ts` to wire the strategy mesh — the resolver does it.
+- **Alternative:** A is the defensive choice if you want zero behavior change to the linkedIndexes loop. Tradeoff: keeps a hardcoded `.strategy` literal in `totem.config.ts` that contradicts the "configurable resolver" goal.
+
+**Q6 — Bench scripts behavior on unresolved strategy root?**
+
+- **Options:** A) Hard error, exit non-zero (benchmarks need a real path). B) Soft warning + use a temp dir (writes the report somewhere even if strategy is missing). C) Skip the benchmark entirely.
+- **Recommendation:** A. Benchmarks are dev-tooling; running them without a strategy repo is operator error and a clear fail-loud message ("set STRATEGY_ROOT or clone sibling") is the right UX. Matches Tenet 4.
+
+---
+
+## Triage decision
+
+**Architectural — Phase 3 design doc drafted above.**
+
+Six open questions surfaced (Q1-Q6). Stopping at Phase 4 approval gate before any code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,31 @@ packages/
   mcp/    @mmnto/mcp     MCP server
 ```
 
+## Strategy Repo Expectations
+
+A handful of Totem surfaces consult a sibling **strategy repo** (`mmnto-ai/totem-strategy`) for ADRs, proposals, journals, and the federated knowledge index:
+
+- `totem proposal new` / `totem adr new` scaffolding
+- MCP `describe_project` rich-state pointer
+- Federated `search_knowledge` (the strategy linked-index is auto-injected when resolvable)
+- The `scripts/benchmark-compile.ts` and `scripts/bench-lance-open.ts` benchmarks
+
+The path is resolved by `resolveStrategyRoot` (see `packages/core/src/strategy-resolver.ts`) in this precedence order:
+
+1. `TOTEM_STRATEGY_ROOT` env var (`STRATEGY_ROOT` accepted as a legacy alias).
+2. `strategyRoot` field in `totem.config.ts`.
+3. Sibling clone at `../totem-strategy/` next to your totem checkout.
+4. Legacy `.strategy/` submodule at the totem checkout root.
+
+**Recommended setup for new contributors:** clone `mmnto-ai/totem-strategy` as a sibling directory:
+
+```bash
+cd <parent-of-totem>
+git clone https://github.com/mmnto-ai/totem-strategy.git
+```
+
+This gives you the full surface without the submodule ceremony. If the strategy repo isn't present, the affected commands degrade with actionable error messages — they don't silently fail. Run `totem doctor` to see which surfaces are affected.
+
 ## Contributor License Agreement (CLA)
 
 All contributors must sign our [Contributor License Agreement](.github/CLA.md) before their first Pull Request can be merged. This is a one-time requirement.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -249,9 +249,11 @@ The `.totem/lessons/` directory acts as an explicit version-controlled ledger of
 
 Users are offered an optional Universal Baseline during initialization. These foundational lessons feature audience tags and include fix guidance to resolve architectural violations. Language packs proactively provide baseline lessons tailored for specific programming environments. This solves the cold-start problem where a fresh install has no initial knowledge to retrieve.
 
-## The `.strategy/` Submodule
+## The Strategy Repo (Configurable Root)
 
-For secure collaboration, proprietary guidelines and sensitive orchestration instructions are isolated in a `.strategy/` directory. By managing it as a private git submodule, teams ensure confidential workflows remain access-controlled. It houses deep research and architecture analysis documents without encumbering the distributable core codebase. The strategy submodule operates its own instance to enforce rules specifically within its domain.
+For secure collaboration, proprietary guidelines and sensitive orchestration instructions are isolated in a sibling `totem-strategy` repository. It houses deep research, ADRs, proposals, and journal entries without encumbering the distributable core codebase. The strategy repo runs its own Totem instance to enforce rules specifically within its domain.
+
+Totem surfaces consult the strategy repo via `resolveStrategyRoot` (`packages/core/src/strategy-resolver.ts`) which walks four precedence layers: `TOTEM_STRATEGY_ROOT` env var (`STRATEGY_ROOT` accepted as a legacy alias) → `totem.config.ts:strategyRoot` field → sibling clone at `../totem-strategy/` → legacy `.strategy/` submodule. The first layer that resolves to a real directory wins. Each consumer surface (MCP `describe_project`, governance scaffolding, federated search, bench scripts, `totem doctor`) handles unresolvable state with actionable graceful degradation rather than silent failure. See `CONTRIBUTING.md` for the recommended sibling-clone setup.
 
 ## Scope & Limitations
 

--- a/packages/cli/src/commands/adr.test.ts
+++ b/packages/cli/src/commands/adr.test.ts
@@ -52,6 +52,7 @@ describe('adrNewCommand', () => {
     initGit(tmpDir);
     fs.mkdirSync(path.join(tmpDir, 'proposals', 'active'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, 'adr'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'templates'), { recursive: true });
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const { adrNewCommand } = await import('./adr.js');
@@ -73,6 +74,7 @@ describe('adrNewCommand', () => {
   it('respects gap numbering in adr/ directory', async () => {
     initGit(tmpDir);
     fs.mkdirSync(path.join(tmpDir, 'adr'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'templates'), { recursive: true });
     fs.writeFileSync(path.join(tmpDir, 'adr', '001-alpha.md'), '# a\n', 'utf-8');
     fs.writeFileSync(path.join(tmpDir, 'adr', '004-beta.md'), '# b\n', 'utf-8');
 

--- a/packages/cli/src/commands/adr.ts
+++ b/packages/cli/src/commands/adr.ts
@@ -21,7 +21,9 @@ export async function adrNewCommand(title: string, options: AdrNewOptions = {}):
   const { scaffoldGovernanceArtifact } = await import('../utils/governance.js');
 
   const cwd = options.cwd ?? process.cwd();
-  const result = scaffoldGovernanceArtifact({ type: 'adr', title, cwd });
+  const { loadGovernanceConfig } = await import('../utils/governance.js');
+  const config = await loadGovernanceConfig(cwd);
+  const result = scaffoldGovernanceArtifact({ type: 'adr', title, cwd, config });
 
   const relPath = path.relative(cwd, result.filePath);
   const dashboardSummary = result.dashboardRefreshed

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1378,8 +1378,12 @@ describe('checkStrategyRoot (mmnto-ai/totem#1710)', () => {
 
   afterEach(() => {
     cleanTmpDir(tmpDir);
-    if (prevEnvPrimary !== undefined) process.env.TOTEM_STRATEGY_ROOT = prevEnvPrimary;
-    if (prevEnvAlias !== undefined) process.env.STRATEGY_ROOT = prevEnvAlias;
+    // Symmetric restore: when prev was undefined, the env var was unset
+    // before this suite ran — DELETE rather than leak the test's value.
+    if (prevEnvPrimary === undefined) delete process.env.TOTEM_STRATEGY_ROOT;
+    else process.env.TOTEM_STRATEGY_ROOT = prevEnvPrimary;
+    if (prevEnvAlias === undefined) delete process.env.STRATEGY_ROOT;
+    else process.env.STRATEGY_ROOT = prevEnvAlias;
   });
 
   it('returns warn (NOT fail) when no strategy root resolves', async () => {

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -19,6 +19,7 @@ import {
   checkSecretLeaks,
   checkSecretsFileTracked,
   checkStaleRules,
+  checkStrategyRoot,
   checkUpgradeCandidates,
   doctorCommand,
   findLegacyGrandfatheredRules,
@@ -306,7 +307,7 @@ describe('doctorCommand', () => {
   it('runs without throwing', async () => {
     const results = await doctorCommand();
     expect(results).toBeDefined();
-    expect(results.length).toBe(11);
+    expect(results.length).toBe(12);
   });
 
   it('returns correct check names', async () => {
@@ -318,6 +319,7 @@ describe('doctorCommand', () => {
     expect(names).toContain('Embedding');
     expect(names).toContain('Index');
     expect(names).toContain('Linked Indexes');
+    expect(names).toContain('Strategy Root');
     expect(names).toContain('Secret Scan');
     expect(names).toContain('Secrets File Security');
     expect(names).toContain('Upgrade Candidates');
@@ -1356,6 +1358,46 @@ describe('checkLinkedIndexes (#1308)', () => {
     expect(result.status).toBe('warn');
     expect(result.name).toBe('Linked Indexes');
     expect(result.remediation).toContain('does not exist');
+  });
+});
+
+// ─── Strategy root (mmnto-ai/totem#1710) ──────────────────
+
+describe('checkStrategyRoot (mmnto-ai/totem#1710)', () => {
+  let tmpDir: string;
+  let prevEnvPrimary: string | undefined;
+  let prevEnvAlias: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    prevEnvPrimary = process.env.TOTEM_STRATEGY_ROOT;
+    prevEnvAlias = process.env.STRATEGY_ROOT;
+    delete process.env.TOTEM_STRATEGY_ROOT;
+    delete process.env.STRATEGY_ROOT;
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+    if (prevEnvPrimary !== undefined) process.env.TOTEM_STRATEGY_ROOT = prevEnvPrimary;
+    if (prevEnvAlias !== undefined) process.env.STRATEGY_ROOT = prevEnvAlias;
+  });
+
+  it('returns warn (NOT fail) when no strategy root resolves', async () => {
+    const result = await checkStrategyRoot(tmpDir);
+    expect(result.status).toBe('warn');
+    expect(result.name).toBe('Strategy Root');
+    expect(result.remediation).toMatch(/describe_project|proposal|federated/);
+  });
+
+  it('returns pass when TOTEM_STRATEGY_ROOT points to a real directory', async () => {
+    const target = path.join(tmpDir, 'elsewhere');
+    fs.mkdirSync(target, { recursive: true });
+    process.env.TOTEM_STRATEGY_ROOT = target;
+
+    const result = await checkStrategyRoot(tmpDir);
+    expect(result.status).toBe('pass');
+    expect(result.name).toBe('Strategy Root');
+    expect(result.message).toMatch(/^env →/);
   });
 });
 

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1403,6 +1403,21 @@ describe('checkStrategyRoot (mmnto-ai/totem#1710)', () => {
     expect(result.name).toBe('Strategy Root');
     expect(result.message).toMatch(/^env →/);
   });
+
+  it('strips ANSI/CR control bytes from diagnostic strings (R4 — terminal injection)', async () => {
+    // Hostile env value with embedded ANSI + CR. Without sanitization the
+    // unresolved-path diagnostic would echo these bytes through `log.warn`
+    // and rewind the cursor / spoof colors when `totem doctor` rendered it.
+    process.env.TOTEM_STRATEGY_ROOT = `${tmpDir}/missing\x1b[31mEVIL\x1b[0m\rOVERWRITE`;
+
+    const result = await checkStrategyRoot(tmpDir);
+    expect(result.status).toBe('warn');
+    // Message itself is the static string — the env value flows into
+    // `remediation` via `status.reason`.
+    expect(result.remediation).toBeDefined();
+    expect(result.remediation).not.toMatch(/\x1b\[/);
+    expect(result.remediation).not.toMatch(/\r/);
+  });
 });
 
 // ─── Stale rules (mmnto-ai/totem#1483) ──────────────────

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -1404,11 +1404,14 @@ describe('checkStrategyRoot (mmnto-ai/totem#1710)', () => {
     expect(result.message).toMatch(/^env →/);
   });
 
-  it('strips ANSI/CR control bytes from diagnostic strings (R4 — terminal injection)', async () => {
-    // Hostile env value with embedded ANSI + CR. Without sanitization the
-    // unresolved-path diagnostic would echo these bytes through `log.warn`
-    // and rewind the cursor / spoof colors when `totem doctor` rendered it.
-    process.env.TOTEM_STRATEGY_ROOT = `${tmpDir}/missing\x1b[31mEVIL\x1b[0m\rOVERWRITE`;
+  it('strips ANSI/CR/newline/tab control bytes from diagnostic strings (R4/R6 — terminal injection)', async () => {
+    // Hostile env value with embedded ANSI + CR + newlines + tabs.
+    // Without sanitization the unresolved-path diagnostic would echo
+    // these bytes through `log.warn` and rewind the cursor / spoof colors
+    // when `totem doctor` rendered it. R6 also flattens \n/\t to prevent
+    // forged extra log lines (`sanitizeForTerminal` deliberately preserves
+    // \n/\t for multi-line content; the doctor caller flattens).
+    process.env.TOTEM_STRATEGY_ROOT = `${tmpDir}/missing\x1b[31mEVIL\x1b[0m\r\n\n[fake] OK\tTAB`;
 
     const result = await checkStrategyRoot(tmpDir);
     expect(result.status).toBe('warn');
@@ -1417,6 +1420,8 @@ describe('checkStrategyRoot (mmnto-ai/totem#1710)', () => {
     expect(result.remediation).toBeDefined();
     expect(result.remediation).not.toMatch(/\x1b\[/);
     expect(result.remediation).not.toMatch(/\r/);
+    expect(result.remediation).not.toMatch(/\n/);
+    expect(result.remediation).not.toMatch(/\t/);
   });
 });
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -445,9 +445,12 @@ export function checkLinkedIndexes(cwd: string): DiagnosticResult {
  * graph (matches `checkSecretLeaks` and the rest of the diagnostics that
  * need core).
  */
-export async function checkStrategyRoot(cwd: string): Promise<DiagnosticResult> {
+export async function checkStrategyRoot(
+  cwd: string,
+  config?: { strategyRoot?: string },
+): Promise<DiagnosticResult> {
   const { resolveStrategyRoot } = await import('@mmnto/totem');
-  const status = resolveStrategyRoot(cwd);
+  const status = resolveStrategyRoot(cwd, { config });
   if (status.resolved) {
     const rel = path.relative(cwd, status.path) || '.';
     return {
@@ -1507,14 +1510,18 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<Diagno
 
   console.error(`${pc.cyan('[Totem]')} Running diagnostics...\n`);
 
-  // Resolve doctor thresholds from config when available. The default window
-  // (10) lines up with the schema default so missing config still gives the
-  // documented behavior.
+  // Resolve doctor thresholds + strategyRoot from config when available. The
+  // default window (10) lines up with the schema default so missing config
+  // still gives the documented behavior. mmnto-ai/totem#1710 R2: capture
+  // `strategyRoot` here too so `checkStrategyRoot` honors the precedence-2
+  // config layer.
   let doctorThresholds: { staleRuleWindow: number } | undefined;
+  let loadedConfig: { strategyRoot?: string } | undefined;
   try {
     const { loadConfig, resolveConfigPath } = await import('../utils.js');
     const configPath = resolveConfigPath(cwd);
     const config = await loadConfig(configPath);
+    loadedConfig = config;
     if (config.doctor) {
       doctorThresholds = { staleRuleWindow: config.doctor.staleRuleWindow };
     }
@@ -1537,7 +1544,7 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<Diagno
     checkEmbeddingConfig(cwd),
     checkIndex(cwd),
     checkLinkedIndexes(cwd),
-    await checkStrategyRoot(cwd),
+    await checkStrategyRoot(cwd, loadedConfig),
     await checkSecretLeaks(cwd),
     checkSecretsFileTracked(cwd),
     await checkUpgradeCandidates(cwd),

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -456,9 +456,19 @@ export async function checkStrategyRoot(
   // inputs (`TOTEM_STRATEGY_ROOT`, `STRATEGY_ROOT`, `TotemConfig.strategyRoot`).
   // A hostile env var with embedded ANSI/CR bytes would otherwise rewind the
   // cursor or spoof colors when `totem doctor` renders the diagnostic
-  // (mmnto-ai/totem#1710 R4 / CR R4 Major).
+  // (mmnto-ai/totem#1710 R4 / CR R4 Major). R6 (CR R6 Major):
+  // `sanitizeForTerminal` intentionally preserves `\n`/`\t` for
+  // multi-line content, but these single-line diagnostic strings must
+  // ALSO collapse those bytes — otherwise a value like
+  // `TOTEM_STRATEGY_ROOT=$'\n\n[fake] OK'` could forge an extra log
+  // line. `flatten` runs after the ANSI/CR strip.
+  const flatten = (s: string): string =>
+    s
+      .replace(/[\t\n]+/g, ' ')
+      .replace(/ {2,}/g, ' ')
+      .trim();
   if (status.resolved) {
-    const rel = sanitizeForTerminal(path.relative(cwd, status.path) || '.');
+    const rel = flatten(sanitizeForTerminal(path.relative(cwd, status.path) || '.'));
     return {
       name: 'Strategy Root',
       status: 'pass',
@@ -470,7 +480,7 @@ export async function checkStrategyRoot(
     name: 'Strategy Root',
     status: 'warn',
     message: 'unresolved',
-    remediation: `${sanitizeForTerminal(status.reason)} Affected: describe_project pointer, proposal/adr scaffolding, federated strategy search, bench scripts.`,
+    remediation: `${flatten(sanitizeForTerminal(status.reason))} Affected: describe_project pointer, proposal/adr scaffolding, federated strategy search, bench scripts.`,
   };
 }
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -429,6 +429,42 @@ export function checkLinkedIndexes(cwd: string): DiagnosticResult {
   };
 }
 
+/**
+ * Strategy-root resolver diagnostic (mmnto-ai/totem#1710).
+ *
+ * Runs `resolveStrategyRoot` and reports which precedence layer matched.
+ * Advisory only: `warn` (not `fail`) on unresolved so a freshly-cloned
+ * project without a strategy repo doesn't fail the doctor pass.
+ *
+ * Affected consumer surfaces if unresolved: MCP `describe_project`
+ * rich-state pointer, `totem proposal new` / `totem adr new`, federated
+ * search via the auto-injected strategy linkedIndex, the bench scripts
+ * under `scripts/`.
+ *
+ * Async + dynamic import to keep `@mmnto/totem` off the CLI cold-start
+ * graph (matches `checkSecretLeaks` and the rest of the diagnostics that
+ * need core).
+ */
+export async function checkStrategyRoot(cwd: string): Promise<DiagnosticResult> {
+  const { resolveStrategyRoot } = await import('@mmnto/totem');
+  const status = resolveStrategyRoot(cwd);
+  if (status.resolved) {
+    const rel = path.relative(cwd, status.path) || '.';
+    return {
+      name: 'Strategy Root',
+      status: 'pass',
+      message: `${status.source} → ${rel}`,
+    };
+  }
+
+  return {
+    name: 'Strategy Root',
+    status: 'warn',
+    message: 'unresolved',
+    remediation: `${status.reason} Affected: describe_project pointer, proposal/adr scaffolding, federated strategy search, bench scripts.`,
+  };
+}
+
 export async function checkSecretLeaks(
   cwd: string,
   totemDir = '.totem',
@@ -1501,6 +1537,7 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<Diagno
     checkEmbeddingConfig(cwd),
     checkIndex(cwd),
     checkLinkedIndexes(cwd),
+    await checkStrategyRoot(cwd),
     await checkSecretLeaks(cwd),
     checkSecretsFileTracked(cwd),
     await checkUpgradeCandidates(cwd),

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -450,9 +450,15 @@ export async function checkStrategyRoot(
   config?: { strategyRoot?: string },
 ): Promise<DiagnosticResult> {
   const { resolveStrategyRoot } = await import('@mmnto/totem');
+  const { sanitizeForTerminal } = await import('../terminal-sanitize.js');
   const status = resolveStrategyRoot(cwd, { config });
+  // `status.path` and `status.reason` are derived from env/config-controlled
+  // inputs (`TOTEM_STRATEGY_ROOT`, `STRATEGY_ROOT`, `TotemConfig.strategyRoot`).
+  // A hostile env var with embedded ANSI/CR bytes would otherwise rewind the
+  // cursor or spoof colors when `totem doctor` renders the diagnostic
+  // (mmnto-ai/totem#1710 R4 / CR R4 Major).
   if (status.resolved) {
-    const rel = path.relative(cwd, status.path) || '.';
+    const rel = sanitizeForTerminal(path.relative(cwd, status.path) || '.');
     return {
       name: 'Strategy Root',
       status: 'pass',
@@ -464,7 +470,7 @@ export async function checkStrategyRoot(
     name: 'Strategy Root',
     status: 'warn',
     message: 'unresolved',
-    remediation: `${status.reason} Affected: describe_project pointer, proposal/adr scaffolding, federated strategy search, bench scripts.`,
+    remediation: `${sanitizeForTerminal(status.reason)} Affected: describe_project pointer, proposal/adr scaffolding, federated strategy search, bench scripts.`,
   };
 }
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -1514,14 +1514,19 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<Diagno
   // default window (10) lines up with the schema default so missing config
   // still gives the documented behavior. mmnto-ai/totem#1710 R2: capture
   // `strategyRoot` here too so `checkStrategyRoot` honors the precedence-2
-  // config layer.
+  // config layer. R3 (CR): only use the config's `strategyRoot` when the
+  // resolved path is the repo-local file. A global `~/.totem/` profile is
+  // a personal default for tier/embedder choice and must NOT leak its
+  // strategyRoot across every repo on disk.
   let doctorThresholds: { staleRuleWindow: number } | undefined;
   let loadedConfig: { strategyRoot?: string } | undefined;
   try {
-    const { loadConfig, resolveConfigPath } = await import('../utils.js');
+    const { loadConfig, resolveConfigPath, isGlobalConfigPath } = await import('../utils.js');
     const configPath = resolveConfigPath(cwd);
     const config = await loadConfig(configPath);
-    loadedConfig = config;
+    if (!isGlobalConfigPath(configPath)) {
+      loadedConfig = config;
+    }
     if (config.doctor) {
       doctorThresholds = { staleRuleWindow: config.doctor.staleRuleWindow };
     }

--- a/packages/cli/src/commands/proposal.test.ts
+++ b/packages/cli/src/commands/proposal.test.ts
@@ -52,6 +52,7 @@ describe('proposalNewCommand', () => {
     initGit(tmpDir);
     fs.mkdirSync(path.join(tmpDir, 'proposals', 'active'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, 'adr'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'templates'), { recursive: true });
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const { proposalNewCommand } = await import('./proposal.js');

--- a/packages/cli/src/commands/proposal.ts
+++ b/packages/cli/src/commands/proposal.ts
@@ -24,7 +24,9 @@ export async function proposalNewCommand(
   const { scaffoldGovernanceArtifact } = await import('../utils/governance.js');
 
   const cwd = options.cwd ?? process.cwd();
-  const result = scaffoldGovernanceArtifact({ type: 'proposal', title, cwd });
+  const { loadGovernanceConfig } = await import('../utils/governance.js');
+  const config = await loadGovernanceConfig(cwd);
+  const result = scaffoldGovernanceArtifact({ type: 'proposal', title, cwd, config });
 
   const relPath = path.relative(cwd, result.filePath);
   const dashboardSummary = result.dashboardRefreshed

--- a/packages/cli/src/utils/governance.test.ts
+++ b/packages/cli/src/utils/governance.test.ts
@@ -87,6 +87,56 @@ describe('resolveGovernancePaths', () => {
     const { resolveGovernancePaths } = await import('./governance.js');
     expect(() => resolveGovernancePaths(tmpDir, 'proposal')).toThrow(/strategy/i);
   });
+
+  it('error message names the canonical sibling clone path and env var (mmnto-ai/totem#1710)', async () => {
+    initGit(tmpDir);
+    const { resolveGovernancePaths } = await import('./governance.js');
+    let caught: unknown;
+    try {
+      resolveGovernancePaths(tmpDir, 'proposal');
+    } catch (err) {
+      caught = err;
+    }
+    const totemErr = caught as { message?: string; recoveryHint?: string };
+    const combined = `${totemErr.message ?? ''}\n${totemErr.recoveryHint ?? ''}`;
+    expect(combined).toMatch(/totem-strategy/i);
+    expect(combined).toMatch(/TOTEM_STRATEGY_ROOT/);
+  });
+
+  it('resolves sibling strategy path via the resolver when ../totem-strategy exists (mmnto-ai/totem#1710)', async () => {
+    // Layout:
+    //   <parent>/repo/.git/   ← gitRoot (created via initGit)
+    //   <parent>/totem-strategy/proposals/active/
+    const repo = path.join(tmpDir, 'repo');
+    fs.mkdirSync(repo, { recursive: true });
+    initGit(repo);
+
+    const sibling = path.join(tmpDir, 'totem-strategy');
+    fs.mkdirSync(path.join(sibling, 'proposals', 'active'), { recursive: true });
+
+    const { resolveGovernancePaths } = await import('./governance.js');
+    const paths = resolveGovernancePaths(repo, 'proposal');
+
+    expect(paths.rootDir).toBe(path.normalize(sibling));
+    expect(paths.targetDir).toBe(path.normalize(path.join(sibling, 'proposals', 'active')));
+  });
+
+  it('resolves env-driven strategy path when TOTEM_STRATEGY_ROOT is set (mmnto-ai/totem#1710)', async () => {
+    initGit(tmpDir);
+    const elsewhere = path.join(tmpDir, 'elsewhere-strategy');
+    fs.mkdirSync(path.join(elsewhere, 'proposals', 'active'), { recursive: true });
+
+    const prev = process.env.TOTEM_STRATEGY_ROOT;
+    process.env.TOTEM_STRATEGY_ROOT = elsewhere;
+    try {
+      const { resolveGovernancePaths } = await import('./governance.js');
+      const paths = resolveGovernancePaths(tmpDir, 'proposal');
+      expect(paths.rootDir).toBe(path.normalize(elsewhere));
+    } finally {
+      if (prev === undefined) delete process.env.TOTEM_STRATEGY_ROOT;
+      else process.env.TOTEM_STRATEGY_ROOT = prev;
+    }
+  });
 });
 
 describe('getNextArtifactId', () => {

--- a/packages/cli/src/utils/governance.test.ts
+++ b/packages/cli/src/utils/governance.test.ts
@@ -730,3 +730,73 @@ describe('scaffoldGovernanceArtifact (orchestrator)', () => {
     expect(entries).toEqual([]);
   });
 });
+
+describe('loadGovernanceConfig (mmnto-ai/totem#1710 R3 — global config leak)', () => {
+  let tmpDir: string;
+  let homeDir: string;
+  let originalCwd: string;
+  let originalHomeEnv: string | undefined;
+  let originalUserprofile: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    homeDir = makeTmpDir('totem-home-');
+    originalCwd = process.cwd();
+    // os.homedir() reads HOME on POSIX and USERPROFILE on Windows; redirect
+    // both so the test runs cross-platform without leaking a real
+    // ~/.totem/ profile into the assertion.
+    originalHomeEnv = process.env['HOME'];
+    originalUserprofile = process.env['USERPROFILE'];
+    process.env['HOME'] = homeDir;
+    process.env['USERPROFILE'] = homeDir;
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    if (originalHomeEnv === undefined) {
+      delete process.env['HOME'];
+    } else {
+      process.env['HOME'] = originalHomeEnv;
+    }
+    if (originalUserprofile === undefined) {
+      delete process.env['USERPROFILE'];
+    } else {
+      process.env['USERPROFILE'] = originalUserprofile;
+    }
+    cleanTmpDir(tmpDir);
+    cleanTmpDir(homeDir);
+  });
+
+  it('returns undefined when the resolved config lives in the global ~/.totem/ profile', async () => {
+    // No local config in tmpDir — so resolveConfigPath walks up to the
+    // global ~/.totem/ profile. A user's personal global config
+    // typically encodes tier/embedder choices, NOT a strategy pointer
+    // for one specific repo. Loading it for governance scaffolding
+    // would let one user's strategyRoot leak across every repo on disk.
+    initGit(tmpDir);
+    const globalTotemDir = path.join(homeDir, '.totem');
+    fs.mkdirSync(globalTotemDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(globalTotemDir, 'totem.config.ts'),
+      "export default { targets: [{ glob: '**/*.ts', type: 'code', strategy: 'typescript-ast' }], strategyRoot: '/some/personal/strategy' };\n",
+      'utf-8',
+    );
+
+    const { loadGovernanceConfig } = await import('./governance.js');
+    const config = await loadGovernanceConfig(tmpDir);
+    expect(config).toBeUndefined();
+  });
+
+  it('returns the local config when one exists in cwd', async () => {
+    initGit(tmpDir);
+    fs.writeFileSync(
+      path.join(tmpDir, 'totem.config.ts'),
+      "export default { targets: [{ glob: '**/*.ts', type: 'code', strategy: 'typescript-ast' }], strategyRoot: '../totem-strategy' };\n",
+      'utf-8',
+    );
+
+    const { loadGovernanceConfig } = await import('./governance.js');
+    const config = await loadGovernanceConfig(tmpDir);
+    expect(config?.strategyRoot).toBe('../totem-strategy');
+  });
+});

--- a/packages/cli/src/utils/governance.test.ts
+++ b/packages/cli/src/utils/governance.test.ts
@@ -62,9 +62,12 @@ describe('resolveGovernancePaths', () => {
 
   it('resolves standalone strategy path when submodule prefix is missing', async () => {
     initGit(tmpDir);
-    // Standalone strategy repo — `proposals/active/` lives at the git root, no `.strategy/` prefix.
+    // Standalone strategy repo — `adr/` lives at the git root, no `.strategy/` prefix.
+    // `templates/` sentinel at the root distinguishes a real strategy repo from a
+    // consumer repo that happens to ship a top-level `adr/` docs folder.
     fs.mkdirSync(path.join(tmpDir, 'proposals', 'active'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, 'adr'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'templates'), { recursive: true });
 
     const { resolveGovernancePaths } = await import('./governance.js');
     const paths = resolveGovernancePaths(tmpDir, 'adr');
@@ -73,6 +76,17 @@ describe('resolveGovernancePaths', () => {
     expect(paths.targetDir).toBe(path.normalize(path.join(tmpDir, 'adr')));
     expect(paths.dashboardFile).toBe(path.normalize(path.join(tmpDir, 'README.md')));
     expect(paths.templatePath).toBe(path.normalize(path.join(tmpDir, 'templates', 'adr.md')));
+  });
+
+  it('rejects standalone false-positive when a consumer repo has only adr/ without templates/', async () => {
+    initGit(tmpDir);
+    // Consumer repo with a top-level `adr/` docs folder but NO `templates/`
+    // and NO sibling/submodule strategy. Pre-tightening, this would have
+    // false-positively scaffolded into the consumer's adr/ folder.
+    fs.mkdirSync(path.join(tmpDir, 'adr'), { recursive: true });
+
+    const { resolveGovernancePaths } = await import('./governance.js');
+    expect(() => resolveGovernancePaths(tmpDir, 'adr')).toThrow(/strategy/i);
   });
 
   it('throws TotemError when cwd is not inside a git repository', async () => {
@@ -514,6 +528,7 @@ describe('scaffoldGovernanceArtifact (orchestrator)', () => {
     initGit(tmpDir);
     fs.mkdirSync(path.join(tmpDir, 'proposals', 'active'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, 'adr'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'templates'), { recursive: true });
 
     const calls: Array<{ cmd: string; args: string[] }> = [];
     const exec = (cmd: string, args: string[]): void => {
@@ -549,6 +564,7 @@ describe('scaffoldGovernanceArtifact (orchestrator)', () => {
     initGit(tmpDir);
     fs.mkdirSync(path.join(tmpDir, 'proposals', 'active'), { recursive: true });
     fs.mkdirSync(path.join(tmpDir, 'adr'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'templates'), { recursive: true });
 
     const exec = (): void => {};
 
@@ -572,6 +588,7 @@ describe('scaffoldGovernanceArtifact (orchestrator)', () => {
     // template body see the cleaned form.
     initGit(tmpDir);
     fs.mkdirSync(path.join(tmpDir, 'proposals', 'active'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'templates'), { recursive: true });
 
     const exec = (): void => {};
 
@@ -604,6 +621,7 @@ describe('scaffoldGovernanceArtifact (orchestrator)', () => {
   it('creates file on disk even when docs:inject is missing', async () => {
     initGit(tmpDir);
     fs.mkdirSync(path.join(tmpDir, 'proposals', 'active'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'templates'), { recursive: true });
 
     const origWarn = console.error;
     console.error = () => {};
@@ -632,6 +650,7 @@ describe('scaffoldGovernanceArtifact (orchestrator)', () => {
     initGit(tmpDir);
     const target = path.join(tmpDir, 'proposals', 'active');
     fs.mkdirSync(target, { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'templates'), { recursive: true });
     fs.writeFileSync(path.join(target, '001-alpha.md'), '# a\n', 'utf-8');
     fs.writeFileSync(path.join(target, '003-beta.md'), '# b\n', 'utf-8');
 
@@ -649,6 +668,7 @@ describe('scaffoldGovernanceArtifact (orchestrator)', () => {
     initGit(tmpDir);
     const target = path.join(tmpDir, 'proposals', 'active');
     fs.mkdirSync(target, { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'templates'), { recursive: true });
     // Seed with the exact filename the scaffolder would generate for this title:
     // id=001 + slug='collide' ⇒ '001-collide.md'. We force this by ALSO seeding a
     // higher-numbered file so getNextArtifactId returns 002, then we seed 002-collide.md
@@ -688,6 +708,7 @@ describe('scaffoldGovernanceArtifact (orchestrator)', () => {
   it('throws TotemError BEFORE touching disk when title sanitizes to empty', async () => {
     initGit(tmpDir);
     fs.mkdirSync(path.join(tmpDir, 'proposals', 'active'), { recursive: true });
+    fs.mkdirSync(path.join(tmpDir, 'templates'), { recursive: true });
 
     const execCalls: string[] = [];
     const exec = (cmd: string): void => {

--- a/packages/cli/src/utils/governance.ts
+++ b/packages/cli/src/utils/governance.ts
@@ -47,9 +47,13 @@ export interface GovernancePaths {
 
 /**
  * Best-effort `TotemConfig` load for the governance commands. Returns
- * `undefined` when the config is missing or unparseable — both are
- * legitimate states for a freshly-cloned consumer repo, and the strategy-
- * root resolver still has env / sibling / submodule layers to fall back on.
+ * `undefined` when the config is missing, unparseable, OR resolves to the
+ * global `~/.totem/` profile — both missing and unparseable are legitimate
+ * states for a freshly-cloned consumer repo, and a global-profile config
+ * is intentionally NOT used as a repo-local `strategyRoot` source (that
+ * would let one user's personal pointer leak across every repo on disk).
+ * The strategy-root resolver still has env / sibling / submodule layers
+ * to fall back on (mmnto-ai/totem#1710 R3 — CR R3 global-config-leak fix).
  *
  * Shared by `proposalNewCommand` and `adrNewCommand` so the load idiom +
  * its `// totem-context: intentional best-effort` annotation live in one
@@ -59,8 +63,10 @@ export async function loadGovernanceConfig(
   cwd: string,
 ): Promise<StrategyResolverConfig | undefined> {
   try {
-    const { loadConfig, resolveConfigPath } = await import('../utils.js');
-    const config = (await loadConfig(resolveConfigPath(cwd))) as StrategyResolverConfig;
+    const { loadConfig, resolveConfigPath, isGlobalConfigPath } = await import('../utils.js');
+    const configPath = resolveConfigPath(cwd);
+    if (isGlobalConfigPath(configPath)) return undefined;
+    const config = (await loadConfig(configPath)) as StrategyResolverConfig;
     return config;
     // totem-context: intentional best-effort load — missing/unparseable config is a legitimate state for a freshly-cloned consumer repo; resolver's other layers (env / sibling / submodule) still apply.
   } catch {

--- a/packages/cli/src/utils/governance.ts
+++ b/packages/cli/src/utils/governance.ts
@@ -18,6 +18,7 @@ import {
   TotemError,
 } from '@mmnto/totem';
 
+import { sanitizeForTerminal } from '../terminal-sanitize.js';
 import { log } from '../ui.js';
 
 export type GovernanceType = 'proposal' | 'adr';
@@ -130,10 +131,19 @@ export function resolveGovernancePaths(
   } else {
     const status = resolveStrategyRoot(cwd, { gitRoot, config });
     if (!status.resolved) {
+      // Sanitize filesystem- and env-derived strings before they flow
+      // into the CLI-rendered TotemError. `cwd` and `gitRoot` are
+      // process inputs; `status.reason` carries env values
+      // (`TOTEM_STRATEGY_ROOT`, `STRATEGY_ROOT`) and config values
+      // verbatim. ANSI/CR bytes there would rewind the cursor when the
+      // error is rendered (mmnto-ai/totem#1710 R5 / CR R5 Major).
+      const safeCwd = sanitizeForTerminal(cwd);
+      const safeClonePath = sanitizeForTerminal(path.join(path.dirname(gitRoot), 'totem-strategy'));
+      const safeReason = sanitizeForTerminal(status.reason);
       throw new TotemError(
         'CONFIG_MISSING',
-        `No Totem-strategy layout found from ${cwd}.`,
-        `Clone the strategy repo as a sibling (e.g., \`git clone <strategy-url> ${path.join(path.dirname(gitRoot), 'totem-strategy')}\`), set the TOTEM_STRATEGY_ROOT env var, or initialize the legacy \`.strategy/\` submodule. Resolver detail: ${status.reason}`,
+        `No Totem-strategy layout found from ${safeCwd}.`,
+        `Clone the strategy repo as a sibling (e.g., \`git clone <strategy-url> ${safeClonePath}\`), set the TOTEM_STRATEGY_ROOT env var, or initialize the legacy \`.strategy/\` submodule. Resolver detail: ${safeReason}`,
       );
     }
     rootDir = status.path;

--- a/packages/cli/src/utils/governance.ts
+++ b/packages/cli/src/utils/governance.ts
@@ -110,9 +110,14 @@ export function resolveGovernancePaths(
 ): GovernancePaths {
   const gitRoot = resolveGitRoot(cwd);
   if (gitRoot === null) {
+    // Sanitize `cwd` here too — the sister branch already does this for
+    // the resolved-but-no-layout error (mmnto-ai/totem#1710 R5). A working
+    // directory name with embedded ANSI/CR bytes would otherwise hit the
+    // CLI raw on the not-in-git-repo path (mmnto-ai/totem#1710 R6 / CR R6
+    // outside-diff Major).
     throw new TotemError(
       'CONFIG_MISSING',
-      `Not inside a git repository: ${cwd}`,
+      `Not inside a git repository: ${sanitizeForTerminal(cwd)}`,
       'Run this command from inside a Totem or Totem-strategy repository checkout.',
     );
   }

--- a/packages/cli/src/utils/governance.ts
+++ b/packages/cli/src/utils/governance.ts
@@ -10,7 +10,13 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { resolveGitRoot, resolveStrategyRoot, safeExec, TotemError } from '@mmnto/totem';
+import {
+  resolveGitRoot,
+  resolveStrategyRoot,
+  safeExec,
+  type StrategyResolverConfig,
+  TotemError,
+} from '@mmnto/totem';
 
 import { log } from '../ui.js';
 
@@ -20,6 +26,12 @@ export interface ScaffoldOptions {
   type: GovernanceType;
   title: string;
   cwd: string;
+  /**
+   * Loaded `TotemConfig` (or any object with a `strategyRoot?: string` field).
+   * Forwarded to the strategy-root resolver so `TotemConfig.strategyRoot`
+   * wins precedence-2 over the sibling / submodule layers (mmnto-ai/totem#1710).
+   */
+  config?: StrategyResolverConfig;
 }
 
 export interface GovernancePaths {
@@ -31,6 +43,29 @@ export interface GovernancePaths {
   templatePath: string;
   /** Dashboard README refreshed by `docs:inject`. */
   dashboardFile: string;
+}
+
+/**
+ * Best-effort `TotemConfig` load for the governance commands. Returns
+ * `undefined` when the config is missing or unparseable — both are
+ * legitimate states for a freshly-cloned consumer repo, and the strategy-
+ * root resolver still has env / sibling / submodule layers to fall back on.
+ *
+ * Shared by `proposalNewCommand` and `adrNewCommand` so the load idiom +
+ * its `// totem-context: intentional best-effort` annotation live in one
+ * place (mmnto-ai/totem#1710 R2).
+ */
+export async function loadGovernanceConfig(
+  cwd: string,
+): Promise<StrategyResolverConfig | undefined> {
+  try {
+    const { loadConfig, resolveConfigPath } = await import('../utils.js');
+    const config = (await loadConfig(resolveConfigPath(cwd))) as StrategyResolverConfig;
+    return config;
+    // totem-context: intentional best-effort load — missing/unparseable config is a legitimate state for a freshly-cloned consumer repo; resolver's other layers (env / sibling / submodule) still apply.
+  } catch {
+    return undefined;
+  }
 }
 
 function targetSubpath(type: GovernanceType): string {
@@ -61,7 +96,11 @@ function templateFilename(type: GovernanceType): string {
  *
  * Also throws `TotemError` when cwd is not inside a git repo.
  */
-export function resolveGovernancePaths(cwd: string, type: GovernanceType): GovernancePaths {
+export function resolveGovernancePaths(
+  cwd: string,
+  type: GovernanceType,
+  config?: StrategyResolverConfig,
+): GovernancePaths {
   const gitRoot = resolveGitRoot(cwd);
   if (gitRoot === null) {
     throw new TotemError(
@@ -83,7 +122,7 @@ export function resolveGovernancePaths(cwd: string, type: GovernanceType): Gover
   if (standaloneHasTarget && standaloneHasTemplates) {
     rootDir = gitRoot;
   } else {
-    const status = resolveStrategyRoot(cwd, { gitRoot });
+    const status = resolveStrategyRoot(cwd, { gitRoot, config });
     if (!status.resolved) {
       throw new TotemError(
         'CONFIG_MISSING',
@@ -414,7 +453,7 @@ export function scaffoldGovernanceArtifact(
   options: ScaffoldOptions,
   internals: ScaffoldArtifactInternals = {},
 ): ScaffoldArtifactResult {
-  const paths = resolveGovernancePaths(options.cwd, options.type);
+  const paths = resolveGovernancePaths(options.cwd, options.type, options.config);
 
   // Sanitize once at the orchestrator entry. Both the filename slug and the
   // template body render against the cleaned form so a title carrying

--- a/packages/cli/src/utils/governance.ts
+++ b/packages/cli/src/utils/governance.ts
@@ -71,11 +71,16 @@ export function resolveGovernancePaths(cwd: string, type: GovernanceType): Gover
     );
   }
 
-  const standaloneHasProposals = fs.existsSync(path.join(gitRoot, 'proposals'));
-  const standaloneHasAdr = fs.existsSync(path.join(gitRoot, 'adr'));
+  // Standalone detection requires BOTH the type-specific target subdir AND
+  // a `templates/` folder at the repo root. The conjunction catches the
+  // canonical strategy-repo layout (proposals/active/ + adr/ + templates/)
+  // while avoiding false positives on consumer repos that happen to ship a
+  // top-level `adr/` docs folder without a strategy substrate.
+  const standaloneHasTarget = fs.existsSync(path.join(gitRoot, targetSubpath(type)));
+  const standaloneHasTemplates = fs.existsSync(path.join(gitRoot, 'templates'));
 
   let rootDir: string;
-  if (standaloneHasProposals || standaloneHasAdr) {
+  if (standaloneHasTarget && standaloneHasTemplates) {
     rootDir = gitRoot;
   } else {
     const status = resolveStrategyRoot(cwd, { gitRoot });

--- a/packages/cli/src/utils/governance.ts
+++ b/packages/cli/src/utils/governance.ts
@@ -10,7 +10,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { resolveGitRoot, safeExec, TotemError } from '@mmnto/totem';
+import { resolveGitRoot, resolveStrategyRoot, safeExec, TotemError } from '@mmnto/totem';
 
 import { log } from '../ui.js';
 
@@ -33,8 +33,6 @@ export interface GovernancePaths {
   dashboardFile: string;
 }
 
-const STRATEGY_SUBDIR = '.strategy';
-
 function targetSubpath(type: GovernanceType): string {
   return type === 'proposal' ? path.join('proposals', 'active') : 'adr';
 }
@@ -46,15 +44,22 @@ function templateFilename(type: GovernanceType): string {
 /**
  * Resolve governance paths for the current invocation.
  *
- * Two supported contexts:
- * 1. **Submodule case** — `<gitRoot>/.strategy/` exists. Used when Totem is
- *    the parent repo and `.strategy/` is a submodule/worktree.
- * 2. **Standalone case** — `<gitRoot>` itself is the strategy repo
- *    (`proposals/active/` sits at the repo root). Used when the CLI is run
- *    from inside the strategy repo directly.
+ * Two layout shapes supported:
  *
- * Throws `TotemError` when cwd is not inside a git repo, or when neither
- * layout can be detected.
+ * 1. **Standalone (cwd IS the strategy repo)** — `<gitRoot>` itself contains
+ *    `proposals/` or `adr/` at the top level. Used when the CLI runs from
+ *    inside the strategy repo directly. Detected here in the helper before
+ *    delegating to the resolver because the strategy-root resolver answers
+ *    "where IS the strategy repo from somewhere else", not "are we INSIDE
+ *    one already."
+ *
+ * 2. **Resolved (cwd is in a consuming repo)** — defer to
+ *    `resolveStrategyRoot` (mmnto-ai/totem#1710). The resolver walks env →
+ *    config → sibling → submodule precedence and returns an absolute path.
+ *    Throws an actionable `TotemError` (ADR-088) when none of the layers
+ *    resolve.
+ *
+ * Also throws `TotemError` when cwd is not inside a git repo.
  */
 export function resolveGovernancePaths(cwd: string, type: GovernanceType): GovernancePaths {
   const gitRoot = resolveGitRoot(cwd);
@@ -66,24 +71,22 @@ export function resolveGovernancePaths(cwd: string, type: GovernanceType): Gover
     );
   }
 
-  const submoduleRoot = path.join(gitRoot, STRATEGY_SUBDIR);
-  const submoduleHasProposals = fs.existsSync(path.join(submoduleRoot, 'proposals'));
-  const submoduleHasAdr = fs.existsSync(path.join(submoduleRoot, 'adr'));
-
   const standaloneHasProposals = fs.existsSync(path.join(gitRoot, 'proposals'));
   const standaloneHasAdr = fs.existsSync(path.join(gitRoot, 'adr'));
 
   let rootDir: string;
-  if (submoduleHasProposals || submoduleHasAdr) {
-    rootDir = submoduleRoot;
-  } else if (standaloneHasProposals || standaloneHasAdr) {
+  if (standaloneHasProposals || standaloneHasAdr) {
     rootDir = gitRoot;
   } else {
-    throw new TotemError(
-      'CONFIG_MISSING',
-      `No Totem-strategy layout found under ${gitRoot}.`,
-      'Expected either a `.strategy/` submodule or top-level `proposals/` and `adr/` directories. Clone or link the strategy repo first.',
-    );
+    const status = resolveStrategyRoot(cwd, { gitRoot });
+    if (!status.resolved) {
+      throw new TotemError(
+        'CONFIG_MISSING',
+        `No Totem-strategy layout found from ${cwd}.`,
+        `Clone the strategy repo as a sibling (e.g., \`git clone <strategy-url> ${path.join(path.dirname(gitRoot), 'totem-strategy')}\`), set the TOTEM_STRATEGY_ROOT env var, or initialize the legacy \`.strategy/\` submodule. Resolver detail: ${status.reason}`,
+      );
+    }
+    rootDir = status.path;
   }
 
   const targetDir = path.join(rootDir, targetSubpath(type));

--- a/packages/core/src/config-schema.test.ts
+++ b/packages/core/src/config-schema.test.ts
@@ -127,6 +127,23 @@ describe('TotemConfigSchema', () => {
       expect(result.data.strategyRoot).toBeUndefined();
     }
   });
+
+  it('rejects blank or whitespace-only strategyRoot (mmnto-ai/totem#1710 R3)', () => {
+    // The resolver already trims at runtime, but the schema must fail
+    // fast at config-parse time so a typo surfaces in `loadConfig` rather
+    // than silently falling through to the next precedence layer.
+    const blank = TotemConfigSchema.safeParse({
+      targets: BASE_TARGETS,
+      strategyRoot: '',
+    });
+    expect(blank.success).toBe(false);
+
+    const whitespace = TotemConfigSchema.safeParse({
+      targets: BASE_TARGETS,
+      strategyRoot: '   ',
+    });
+    expect(whitespace.success).toBe(false);
+  });
 });
 
 // ─── Orchestrator schema ─────────────────────────────

--- a/packages/core/src/config-schema.test.ts
+++ b/packages/core/src/config-schema.test.ts
@@ -108,6 +108,25 @@ describe('TotemConfigSchema', () => {
       expect(result.data.docs).toBeUndefined();
     }
   });
+
+  it('accepts strategyRoot as an optional string (mmnto-ai/totem#1710)', () => {
+    const result = TotemConfigSchema.safeParse({
+      targets: BASE_TARGETS,
+      strategyRoot: '../totem-strategy',
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.strategyRoot).toBe('../totem-strategy');
+    }
+  });
+
+  it('treats strategyRoot as undefined when omitted', () => {
+    const result = TotemConfigSchema.safeParse({ targets: BASE_TARGETS });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.strategyRoot).toBeUndefined();
+    }
+  });
 });
 
 // ─── Orchestrator schema ─────────────────────────────

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -280,6 +280,16 @@ export const TotemConfigSchema = z.object({
   /** Optional: paths to other totem-managed directories whose indexes should be queried alongside this one (e.g., ['.strategy', '../docs-repo']) */
   linkedIndexes: z.array(z.string()).optional(),
 
+  /**
+   * Optional: path override for the strategy repository (mmnto-ai/totem#1710).
+   *
+   * Resolved relative to the git root by `resolveStrategyRoot`, with the
+   * `TOTEM_STRATEGY_ROOT` (or legacy `STRATEGY_ROOT`) env var taking
+   * precedence. When unset, the resolver falls back to a sibling
+   * `../totem-strategy/` clone, then to the legacy `.strategy/` submodule.
+   */
+  strategyRoot: z.string().optional(),
+
   /** Optional: named partitions mapping logical aliases to file path prefixes for context isolation (e.g., { core: ['packages/core/'], mcp: ['packages/mcp/'] }) */
   partitions: z.record(z.array(z.string().min(1)).min(1)).optional(),
 

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -287,8 +287,12 @@ export const TotemConfigSchema = z.object({
    * `TOTEM_STRATEGY_ROOT` (or legacy `STRATEGY_ROOT`) env var taking
    * precedence. When unset, the resolver falls back to a sibling
    * `../totem-strategy/` clone, then to the legacy `.strategy/` submodule.
+   *
+   * Trimmed and required to be non-empty so a `strategyRoot: ''` typo
+   * fails fast at config-parse time instead of silently falling through
+   * to the next precedence layer (R3 — CR R3 nitpick).
    */
-  strategyRoot: z.string().optional(),
+  strategyRoot: z.string().trim().min(1).optional(),
 
   /** Optional: named partitions mapping logical aliases to file path prefixes for context isolation (e.g., { core: ['packages/core/'], mcp: ['packages/mcp/'] }) */
   partitions: z.record(z.array(z.string().min(1)).min(1)).optional(),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -378,6 +378,14 @@ export {
 // Filesystem helpers
 export { readJsonSafe } from './sys/fs.js';
 
+// Strategy-root resolver (mmnto-ai/totem#1710)
+export type {
+  StrategyResolverConfig,
+  StrategyResolverOptions,
+  StrategyRootStatus,
+} from './strategy-resolver.js';
+export { resolveStrategyRoot } from './strategy-resolver.js';
+
 // Semgrep adapter (Pipeline 4 — import rules from Semgrep YAML)
 export type { SemgrepImportResult } from './semgrep-adapter.js';
 export { parseSemgrepRules } from './semgrep-adapter.js';

--- a/packages/core/src/strategy-resolver.test.ts
+++ b/packages/core/src/strategy-resolver.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Tests for `resolveStrategyRoot` (mmnto-ai/totem#1710).
+ *
+ * The resolver is filesystem-driven, so tests construct real temp directories
+ * for the four precedence layers (env / config / sibling / submodule) and
+ * pass `gitRoot` via the test seam to avoid mocking `cross-spawn`. The seam
+ * mirrors `governance.ts`'s `ScaffoldArtifactInternals.exec` pattern:
+ * production callers omit `gitRoot` and the resolver invokes
+ * `resolveGitRoot(cwd)` internally; tests pass it explicitly.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { resolveStrategyRoot } from './strategy-resolver.js';
+import { cleanTmpDir } from './test-utils.js';
+
+let tmpRoot: string;
+let gitRoot: string;
+let cwd: string;
+let strategyParent: string;
+
+const ENV_KEYS = ['TOTEM_STRATEGY_ROOT', 'STRATEGY_ROOT'] as const;
+type EmptyEnv = Record<string, string | undefined>;
+
+function emptyEnv(): EmptyEnv {
+  return {};
+}
+
+function mkDir(p: string): string {
+  fs.mkdirSync(p, { recursive: true });
+  return p;
+}
+
+function mkFile(p: string, content = ''): string {
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, content, 'utf-8');
+  return p;
+}
+
+beforeEach(() => {
+  // Layout per test:
+  //   <tmpRoot>/
+  //     repo/             ← gitRoot + cwd
+  //     totem-strategy/   ← sibling target (created per-test as needed)
+  //     elsewhere/        ← env / config target (created per-test as needed)
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-strategy-resolver-'));
+  gitRoot = mkDir(path.join(tmpRoot, 'repo'));
+  cwd = gitRoot;
+  strategyParent = tmpRoot;
+});
+
+afterEach(() => {
+  cleanTmpDir(tmpRoot);
+  // Ensure no env leakage between tests — defensive even though tests pass
+  // an explicit `env` to the resolver.
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+// ─── Precedence ────────────────────────────────────────────────────────────
+
+describe('resolveStrategyRoot precedence', () => {
+  it('returns env source when TOTEM_STRATEGY_ROOT points to a directory', () => {
+    const target = mkDir(path.join(tmpRoot, 'elsewhere'));
+    const status = resolveStrategyRoot(cwd, {
+      gitRoot,
+      env: { TOTEM_STRATEGY_ROOT: target },
+    });
+    expect(status).toEqual({ resolved: true, path: path.normalize(target), source: 'env' });
+  });
+
+  it('accepts STRATEGY_ROOT as a fallback alias when TOTEM_STRATEGY_ROOT is unset', () => {
+    const target = mkDir(path.join(tmpRoot, 'elsewhere'));
+    const status = resolveStrategyRoot(cwd, {
+      gitRoot,
+      env: { STRATEGY_ROOT: target },
+    });
+    expect(status).toEqual({ resolved: true, path: path.normalize(target), source: 'env' });
+  });
+
+  it('prefers TOTEM_STRATEGY_ROOT over STRATEGY_ROOT when both are set', () => {
+    const preferred = mkDir(path.join(tmpRoot, 'preferred'));
+    const alias = mkDir(path.join(tmpRoot, 'alias'));
+    const status = resolveStrategyRoot(cwd, {
+      gitRoot,
+      env: { TOTEM_STRATEGY_ROOT: preferred, STRATEGY_ROOT: alias },
+    });
+    expect(status).toEqual({
+      resolved: true,
+      path: path.normalize(preferred),
+      source: 'env',
+    });
+  });
+
+  it('returns config source when env is unset and config.strategyRoot is set', () => {
+    const target = mkDir(path.join(tmpRoot, 'elsewhere'));
+    const status = resolveStrategyRoot(cwd, {
+      gitRoot,
+      env: emptyEnv(),
+      config: { strategyRoot: target },
+    });
+    expect(status).toEqual({
+      resolved: true,
+      path: path.normalize(target),
+      source: 'config',
+    });
+  });
+
+  it('returns sibling source when env+config unset and ../totem-strategy exists', () => {
+    const sibling = mkDir(path.join(strategyParent, 'totem-strategy'));
+    const status = resolveStrategyRoot(cwd, { gitRoot, env: emptyEnv() });
+    expect(status).toEqual({
+      resolved: true,
+      path: path.normalize(sibling),
+      source: 'sibling',
+    });
+  });
+
+  it('returns submodule source when env+config+sibling missing and .strategy exists', () => {
+    const submodule = mkDir(path.join(gitRoot, '.strategy'));
+    const status = resolveStrategyRoot(cwd, { gitRoot, env: emptyEnv() });
+    expect(status).toEqual({
+      resolved: true,
+      path: path.normalize(submodule),
+      source: 'submodule',
+    });
+  });
+
+  it('falls through to unresolved when all four layers fail', () => {
+    const status = resolveStrategyRoot(cwd, { gitRoot, env: emptyEnv() });
+    expect(status.resolved).toBe(false);
+    if (!status.resolved) {
+      expect(status.reason).not.toBe('');
+    }
+  });
+
+  it('short-circuits at env even when sibling and submodule both exist', () => {
+    mkDir(path.join(strategyParent, 'totem-strategy'));
+    mkDir(path.join(gitRoot, '.strategy'));
+    const target = mkDir(path.join(tmpRoot, 'elsewhere'));
+    const status = resolveStrategyRoot(cwd, {
+      gitRoot,
+      env: { TOTEM_STRATEGY_ROOT: target },
+    });
+    expect(status).toMatchObject({ resolved: true, source: 'env' });
+  });
+
+  it('short-circuits at sibling before falling through to submodule', () => {
+    const sibling = mkDir(path.join(strategyParent, 'totem-strategy'));
+    mkDir(path.join(gitRoot, '.strategy'));
+    const status = resolveStrategyRoot(cwd, { gitRoot, env: emptyEnv() });
+    expect(status).toEqual({
+      resolved: true,
+      path: path.normalize(sibling),
+      source: 'sibling',
+    });
+  });
+});
+
+// ─── isDirectory guard ─────────────────────────────────────────────────────
+
+describe('resolveStrategyRoot isDirectory guard', () => {
+  it('rejects env value pointing at a file (not a directory) and falls through', () => {
+    const file = mkFile(path.join(tmpRoot, 'not-a-dir'));
+    const sibling = mkDir(path.join(strategyParent, 'totem-strategy'));
+    const status = resolveStrategyRoot(cwd, {
+      gitRoot,
+      env: { TOTEM_STRATEGY_ROOT: file },
+    });
+    expect(status).toEqual({
+      resolved: true,
+      path: path.normalize(sibling),
+      source: 'sibling',
+    });
+  });
+
+  it('rejects config value pointing at a file and falls through', () => {
+    const file = mkFile(path.join(tmpRoot, 'not-a-dir'));
+    const submodule = mkDir(path.join(gitRoot, '.strategy'));
+    const status = resolveStrategyRoot(cwd, {
+      gitRoot,
+      env: emptyEnv(),
+      config: { strategyRoot: file },
+    });
+    expect(status).toEqual({
+      resolved: true,
+      path: path.normalize(submodule),
+      source: 'submodule',
+    });
+  });
+
+  it('rejects sibling that exists but is a file', () => {
+    mkFile(path.join(strategyParent, 'totem-strategy'));
+    const submodule = mkDir(path.join(gitRoot, '.strategy'));
+    const status = resolveStrategyRoot(cwd, { gitRoot, env: emptyEnv() });
+    expect(status).toEqual({
+      resolved: true,
+      path: path.normalize(submodule),
+      source: 'submodule',
+    });
+  });
+
+  it('rejects submodule that exists but is a file', () => {
+    mkFile(path.join(gitRoot, '.strategy'));
+    const status = resolveStrategyRoot(cwd, { gitRoot, env: emptyEnv() });
+    expect(status.resolved).toBe(false);
+  });
+});
+
+// ─── Git-root anchoring ───────────────────────────────────────────────────
+
+describe('resolveStrategyRoot git-root anchoring', () => {
+  it('anchors relative env values at gitRoot, not at deep cwd', () => {
+    const sibling = mkDir(path.join(strategyParent, 'totem-strategy'));
+    const deepCwd = mkDir(path.join(gitRoot, 'packages', 'mcp', 'src'));
+    const status = resolveStrategyRoot(deepCwd, {
+      gitRoot,
+      env: { TOTEM_STRATEGY_ROOT: '../totem-strategy' },
+    });
+    expect(status).toEqual({
+      resolved: true,
+      path: path.normalize(sibling),
+      source: 'env',
+    });
+  });
+
+  it('anchors relative config values at gitRoot', () => {
+    const sibling = mkDir(path.join(strategyParent, 'totem-strategy'));
+    const deepCwd = mkDir(path.join(gitRoot, 'packages', 'core', 'src'));
+    const status = resolveStrategyRoot(deepCwd, {
+      gitRoot,
+      env: emptyEnv(),
+      config: { strategyRoot: '../totem-strategy' },
+    });
+    expect(status).toEqual({
+      resolved: true,
+      path: path.normalize(sibling),
+      source: 'config',
+    });
+  });
+
+  it('returns unresolved when gitRoot is null and no env/config override is set', () => {
+    const status = resolveStrategyRoot(cwd, { gitRoot: null, env: emptyEnv() });
+    expect(status.resolved).toBe(false);
+    if (!status.resolved) {
+      expect(status.reason).toMatch(/git/i);
+    }
+  });
+
+  it('still resolves env when gitRoot is null but env is absolute', () => {
+    const target = mkDir(path.join(tmpRoot, 'elsewhere'));
+    const status = resolveStrategyRoot(cwd, {
+      gitRoot: null,
+      env: { TOTEM_STRATEGY_ROOT: target },
+    });
+    expect(status).toEqual({
+      resolved: true,
+      path: path.normalize(target),
+      source: 'env',
+    });
+  });
+
+  it('still resolves config when gitRoot is null but config value is absolute', () => {
+    const target = mkDir(path.join(tmpRoot, 'elsewhere'));
+    const status = resolveStrategyRoot(cwd, {
+      gitRoot: null,
+      env: emptyEnv(),
+      config: { strategyRoot: target },
+    });
+    expect(status).toEqual({
+      resolved: true,
+      path: path.normalize(target),
+      source: 'config',
+    });
+  });
+
+  it('returns unresolved when gitRoot is null and env value is relative', () => {
+    const status = resolveStrategyRoot(cwd, {
+      gitRoot: null,
+      env: { TOTEM_STRATEGY_ROOT: '../totem-strategy' },
+    });
+    expect(status.resolved).toBe(false);
+  });
+});
+
+// ─── Returned shape ────────────────────────────────────────────────────────
+
+describe('resolveStrategyRoot returned shape', () => {
+  it('returns an absolute path on the resolved branch', () => {
+    const sibling = mkDir(path.join(strategyParent, 'totem-strategy'));
+    const status = resolveStrategyRoot(cwd, { gitRoot, env: emptyEnv() });
+    expect(status).toMatchObject({ resolved: true, source: 'sibling' });
+    if (status.resolved) {
+      expect(path.isAbsolute(status.path)).toBe(true);
+      expect(status.path).toBe(path.normalize(sibling));
+    }
+  });
+
+  it('exposes a non-empty reason on the unresolved branch', () => {
+    const status = resolveStrategyRoot(cwd, { gitRoot, env: emptyEnv() });
+    expect(status.resolved).toBe(false);
+    if (!status.resolved) {
+      expect(status.reason).toMatch(/strategy/i);
+      expect(status.reason).toMatch(/sibling|submodule|env|config/i);
+    }
+  });
+
+  it('treats whitespace-only env values as unset (falls through)', () => {
+    const submodule = mkDir(path.join(gitRoot, '.strategy'));
+    const status = resolveStrategyRoot(cwd, {
+      gitRoot,
+      env: { TOTEM_STRATEGY_ROOT: '   ' },
+    });
+    expect(status).toEqual({
+      resolved: true,
+      path: path.normalize(submodule),
+      source: 'submodule',
+    });
+  });
+});

--- a/packages/core/src/strategy-resolver.test.ts
+++ b/packages/core/src/strategy-resolver.test.ts
@@ -242,11 +242,22 @@ describe('resolveStrategyRoot git-root anchoring', () => {
     });
   });
 
-  it('returns unresolved when gitRoot is null and no env/config override is set', () => {
+  it('falls back to cwd-anchored sibling/submodule when gitRoot is null', () => {
+    // <cwd>/../totem-strategy is the cwd-anchored sibling location.
+    const sibling = mkDir(path.join(cwd, '..', 'totem-strategy'));
+    const status = resolveStrategyRoot(cwd, { gitRoot: null, env: emptyEnv() });
+    expect(status).toEqual({
+      resolved: true,
+      path: path.normalize(sibling),
+      source: 'sibling',
+    });
+  });
+
+  it('returns unresolved when gitRoot is null AND no cwd-anchored layer matches', () => {
     const status = resolveStrategyRoot(cwd, { gitRoot: null, env: emptyEnv() });
     expect(status.resolved).toBe(false);
     if (!status.resolved) {
-      expect(status.reason).toMatch(/git/i);
+      expect(status.reason).toMatch(/strategy/i);
     }
   });
 
@@ -277,12 +288,17 @@ describe('resolveStrategyRoot git-root anchoring', () => {
     });
   });
 
-  it('returns unresolved when gitRoot is null and env value is relative', () => {
+  it('anchors relative env values at cwd when gitRoot is null', () => {
+    const sibling = mkDir(path.join(cwd, '..', 'totem-strategy'));
     const status = resolveStrategyRoot(cwd, {
       gitRoot: null,
       env: { TOTEM_STRATEGY_ROOT: '../totem-strategy' },
     });
-    expect(status.resolved).toBe(false);
+    expect(status).toEqual({
+      resolved: true,
+      path: path.normalize(sibling),
+      source: 'env',
+    });
   });
 });
 

--- a/packages/core/src/strategy-resolver.test.ts
+++ b/packages/core/src/strategy-resolver.test.ts
@@ -158,6 +158,23 @@ describe('resolveStrategyRoot precedence', () => {
       source: 'sibling',
     });
   });
+
+  it('treats a non-string config.strategyRoot as unset (R5 — type guard)', () => {
+    // The resolver is exported. A JS caller (or a TS caller using
+    // `as` casting) can pass a non-string — the resolver must treat
+    // that as "unset" instead of crashing in `.trim()`.
+    mkDir(path.join(strategyParent, 'totem-strategy'));
+    const status = resolveStrategyRoot(cwd, {
+      env: {},
+      gitRoot,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      config: { strategyRoot: 42 as any },
+    });
+    expect(status.resolved).toBe(true);
+    if (status.resolved) {
+      expect(status.source).toBe('sibling');
+    }
+  });
 });
 
 // ─── isDirectory guard ─────────────────────────────────────────────────────

--- a/packages/core/src/strategy-resolver.test.ts
+++ b/packages/core/src/strategy-resolver.test.ts
@@ -162,13 +162,16 @@ describe('resolveStrategyRoot precedence', () => {
   it('treats a non-string config.strategyRoot as unset (R5 — type guard)', () => {
     // The resolver is exported. A JS caller (or a TS caller using
     // `as` casting) can pass a non-string — the resolver must treat
-    // that as "unset" instead of crashing in `.trim()`.
+    // that as "unset" instead of crashing in `.trim()`. The
+    // `unknown` cast keeps the test honest (no eslint-disable
+    // suppression / no policy escape per CR R6) while still
+    // exercising the runtime guard.
     mkDir(path.join(strategyParent, 'totem-strategy'));
     const status = resolveStrategyRoot(cwd, {
       env: {},
       gitRoot,
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      config: { strategyRoot: 42 as any },
+      // totem-context: the cast is the SUBJECT of the test — we're proving the resolver's runtime guard catches non-string inputs that bypass TS, not skipping Zod validation.
+      config: { strategyRoot: 42 as unknown as string },
     });
     expect(status.resolved).toBe(true);
     if (status.resolved) {

--- a/packages/core/src/strategy-resolver.test.ts
+++ b/packages/core/src/strategy-resolver.test.ts
@@ -288,6 +288,26 @@ describe('resolveStrategyRoot git-root anchoring', () => {
     });
   });
 
+  it('honors absolute env values without probing gitRoot (lazy probe — CR R2)', () => {
+    // Simulate a real-world scenario: resolveGitRoot would throw (permission
+    // error, corrupt index), but the user has set TOTEM_STRATEGY_ROOT to an
+    // absolute path. The resolver MUST not short-circuit on the throw — the
+    // env override has to win precedence-1.
+    const target = mkDir(path.join(tmpRoot, 'absolute-target'));
+    // Pass the gitRoot option as undefined so the resolver attempts the
+    // probe; rely on the cwd being a real git-less tmpdir to ensure the
+    // probe path is exercised. When gitRoot probing fails or returns null,
+    // an absolute env value still wins.
+    const status = resolveStrategyRoot(cwd, {
+      env: { TOTEM_STRATEGY_ROOT: target },
+    });
+    expect(status).toEqual({
+      resolved: true,
+      path: path.normalize(target),
+      source: 'env',
+    });
+  });
+
   it('anchors relative env values at cwd when gitRoot is null', () => {
     const sibling = mkDir(path.join(cwd, '..', 'totem-strategy'));
     const status = resolveStrategyRoot(cwd, {

--- a/packages/core/src/strategy-resolver.ts
+++ b/packages/core/src/strategy-resolver.ts
@@ -154,8 +154,12 @@ export function resolveStrategyRoot(
     }
   }
 
-  // Layer 2 — config field. Same absolute-bypass behavior.
-  if (config?.strategyRoot !== undefined && config.strategyRoot.trim().length > 0) {
+  // Layer 2 — config field. Same absolute-bypass behavior. The
+  // `typeof string` guard is load-bearing: `resolveStrategyRoot` is
+  // exported, and a JS caller (or unsafe cast) could pass a non-string
+  // `strategyRoot` that would crash `.trim()` with `TypeError`. Treating
+  // a non-string as "unset" preserves the discriminated-union contract.
+  if (typeof config?.strategyRoot === 'string' && config.strategyRoot.trim().length > 0) {
     const resolved = resolveValue(config.strategyRoot, getAnchor);
     if (isDirectory(resolved)) {
       return { resolved: true, path: resolved, source: 'config' };

--- a/packages/core/src/strategy-resolver.ts
+++ b/packages/core/src/strategy-resolver.ts
@@ -1,0 +1,169 @@
+/**
+ * Strategy-root resolver (mmnto-ai/totem#1710).
+ *
+ * Single source of truth for "where is the strategy repo on disk." Replaces
+ * the hardcoded `.strategy/` submodule path with a configurable resolver that
+ * checks four precedence layers:
+ *
+ *   1. **env** — `TOTEM_STRATEGY_ROOT` (canonical) or `STRATEGY_ROOT` (alias).
+ *   2. **config** — `TotemConfig.strategyRoot`.
+ *   3. **sibling** — `<gitRoot>/../totem-strategy`.
+ *   4. **submodule** — `<gitRoot>/.strategy`.
+ *
+ * Each layer must resolve to a real directory (`fs.statSync(...).isDirectory()`)
+ * before it counts; a value that points at a file or a missing path falls
+ * through to the next layer. Returns a `StrategyRootStatus` discriminated
+ * union so callers can pattern-match on `resolved` without a TS-side type
+ * assertion.
+ *
+ * Anchors relative env / config values at `gitRoot`, not at the literal cwd —
+ * a deep cwd like `packages/mcp/src/` with `STRATEGY_ROOT=../totem-strategy`
+ * would otherwise resolve to `packages/mcp/totem-strategy`, which is wrong.
+ *
+ * Pure utility. No caching, no side effects, no logging. Each call walks the
+ * precedence chain from scratch so a process that mutates `process.env` mid-run
+ * sees the new value on the next call.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { resolveGitRoot } from './sys/git.js';
+
+/**
+ * Discriminated union. The `resolved: true` branch carries an absolute `path`
+ * and a `source` tag so callers can route per-layer (e.g., the `submodule`
+ * source is the legacy path that the gitlink-removal follow-up will retire).
+ * The `resolved: false` branch carries a `reason` string suitable for
+ * surfacing to agents and for the `totem doctor` advisory.
+ */
+export type StrategyRootStatus =
+  | {
+      resolved: true;
+      path: string;
+      source: 'env' | 'config' | 'sibling' | 'submodule';
+    }
+  | { resolved: false; reason: string };
+
+/**
+ * Minimal config shape consumed by the resolver. Avoids importing the full
+ * `TotemConfig` type to keep the resolver dependency-light and to let
+ * callers pass partial config objects (e.g., during init or in tests).
+ */
+export interface StrategyResolverConfig {
+  strategyRoot?: string;
+}
+
+export interface StrategyResolverOptions {
+  /** Test seam — production callers omit and the resolver invokes `resolveGitRoot(cwd)` itself. */
+  gitRoot?: string | null;
+  /** Test seam — production callers omit and the resolver reads `process.env`. */
+  env?: Record<string, string | undefined>;
+  /** Loaded `totem.config.ts` shape (only `strategyRoot` is read). */
+  config?: StrategyResolverConfig;
+}
+
+const ENV_PRIMARY = 'TOTEM_STRATEGY_ROOT';
+const ENV_ALIAS = 'STRATEGY_ROOT';
+const SIBLING_DIRNAME = 'totem-strategy';
+const SUBMODULE_DIRNAME = '.strategy';
+
+/**
+ * Read the canonical env var, falling back to the legacy alias. Whitespace-only
+ * values are treated as unset so a `STRATEGY_ROOT="   "` accident does not
+ * short-circuit the precedence chain.
+ */
+function readEnvValue(env: Record<string, string | undefined>): string | undefined {
+  const primary = env[ENV_PRIMARY];
+  if (typeof primary === 'string' && primary.trim().length > 0) return primary;
+  const alias = env[ENV_ALIAS];
+  if (typeof alias === 'string' && alias.trim().length > 0) return alias;
+  return undefined;
+}
+
+/**
+ * Resolve a raw value (env or config) to an absolute path. Relative values
+ * anchor at `gitRoot` when available; absolute values are returned as-is.
+ * Returns `null` when the value is relative AND `gitRoot` is null (the
+ * caller cannot anchor a relative path without a repo root).
+ */
+function resolveValue(raw: string, gitRoot: string | null): string | null {
+  const trimmed = raw.trim();
+  if (path.isAbsolute(trimmed)) return path.normalize(trimmed);
+  if (gitRoot === null) return null;
+  return path.normalize(path.resolve(gitRoot, trimmed));
+}
+
+/**
+ * `fs.statSync` raises on missing paths and on EACCES/ENOTDIR; treat any
+ * stat failure as "not a directory" and let the resolver fall through to
+ * the next layer.
+ */
+function isDirectory(p: string): boolean {
+  try {
+    return fs.statSync(p).isDirectory();
+    // totem-context: intentional fall-through — stat failures (ENOENT, EACCES, ENOTDIR) are the precedence-chain "miss" signal; rethrowing would force every consumer to wrap the resolver in try/catch for a routine outcome.
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Walk the four-layer precedence chain. Returns a `StrategyRootStatus`
+ * discriminated union.
+ */
+export function resolveStrategyRoot(
+  cwd: string,
+  options: StrategyResolverOptions = {},
+): StrategyRootStatus {
+  const env = options.env ?? process.env;
+  const gitRoot = options.gitRoot !== undefined ? options.gitRoot : resolveGitRoot(cwd);
+  const config = options.config;
+
+  // Layer 1 — env var
+  const envValue = readEnvValue(env);
+  if (envValue !== undefined) {
+    const resolved = resolveValue(envValue, gitRoot);
+    if (resolved !== null && isDirectory(resolved)) {
+      return { resolved: true, path: resolved, source: 'env' };
+    }
+  }
+
+  // Layer 2 — config field
+  if (config?.strategyRoot !== undefined && config.strategyRoot.trim().length > 0) {
+    const resolved = resolveValue(config.strategyRoot, gitRoot);
+    if (resolved !== null && isDirectory(resolved)) {
+      return { resolved: true, path: resolved, source: 'config' };
+    }
+  }
+
+  // Layers 3 + 4 require a known git root — sibling and submodule are both
+  // anchored at `<gitRoot>` and there is no useful fallback when we cannot
+  // find one. Surfacing the unresolved status here is the actionable signal:
+  // the agent gets back "no git root" instead of a stale-path footgun.
+  if (gitRoot === null) {
+    return {
+      resolved: false,
+      reason:
+        'No strategy root resolvable: cwd is outside a git repository and no absolute env / config override is set.',
+    };
+  }
+
+  // Layer 3 — sibling at <gitRoot>/../totem-strategy
+  const sibling = path.normalize(path.resolve(gitRoot, '..', SIBLING_DIRNAME));
+  if (isDirectory(sibling)) {
+    return { resolved: true, path: sibling, source: 'sibling' };
+  }
+
+  // Layer 4 — submodule at <gitRoot>/.strategy (legacy path; kept until
+  // the gitlink-removal follow-up retires `.gitmodules`).
+  const submodule = path.normalize(path.join(gitRoot, SUBMODULE_DIRNAME));
+  if (isDirectory(submodule)) {
+    return { resolved: true, path: submodule, source: 'submodule' };
+  }
+
+  return {
+    resolved: false,
+    reason: `No strategy root resolvable. Tried env (${ENV_PRIMARY} / ${ENV_ALIAS}), config.strategyRoot, sibling ${sibling}, and submodule ${submodule}. Clone the strategy repo as a sibling or set ${ENV_PRIMARY}.`,
+  };
+}

--- a/packages/core/src/strategy-resolver.ts
+++ b/packages/core/src/strategy-resolver.ts
@@ -82,16 +82,15 @@ function readEnvValue(env: Record<string, string | undefined>): string | undefin
 }
 
 /**
- * Resolve a raw value (env or config) to an absolute path. Relative values
- * anchor at `gitRoot` when available; absolute values are returned as-is.
- * Returns `null` when the value is relative AND `gitRoot` is null (the
- * caller cannot anchor a relative path without a repo root).
+ * Resolve a raw value (env or config) to an absolute path. Absolute values
+ * are returned as-is; relative values anchor at the supplied base
+ * (`gitRoot ?? cwd`) via `path.join` so that an absolute user-provided
+ * value doesn't override the anchor (which `path.resolve` would).
  */
-function resolveValue(raw: string, gitRoot: string | null): string | null {
+function resolveValue(raw: string, anchor: string): string {
   const trimmed = raw.trim();
   if (path.isAbsolute(trimmed)) return path.normalize(trimmed);
-  if (gitRoot === null) return null;
-  return path.normalize(path.resolve(gitRoot, trimmed));
+  return path.normalize(path.join(anchor, trimmed));
 }
 
 /**
@@ -119,45 +118,40 @@ export function resolveStrategyRoot(
   const env = options.env ?? process.env;
   const gitRoot = options.gitRoot !== undefined ? options.gitRoot : resolveGitRoot(cwd);
   const config = options.config;
+  // Unified anchor — gitRoot when available, cwd otherwise. The cwd fallback
+  // matches the design spec's "Missing git context" trap and lets relative
+  // env / config / sibling / submodule layers resolve in non-git contexts
+  // (e.g., a one-off script outside a checkout). Downstream consumers
+  // validate the resolved path and fail loudly if the cwd-anchored result
+  // isn't viable.
+  const anchor = gitRoot ?? cwd;
 
   // Layer 1 — env var
   const envValue = readEnvValue(env);
   if (envValue !== undefined) {
-    const resolved = resolveValue(envValue, gitRoot);
-    if (resolved !== null && isDirectory(resolved)) {
+    const resolved = resolveValue(envValue, anchor);
+    if (isDirectory(resolved)) {
       return { resolved: true, path: resolved, source: 'env' };
     }
   }
 
   // Layer 2 — config field
   if (config?.strategyRoot !== undefined && config.strategyRoot.trim().length > 0) {
-    const resolved = resolveValue(config.strategyRoot, gitRoot);
-    if (resolved !== null && isDirectory(resolved)) {
+    const resolved = resolveValue(config.strategyRoot, anchor);
+    if (isDirectory(resolved)) {
       return { resolved: true, path: resolved, source: 'config' };
     }
   }
 
-  // Layers 3 + 4 require a known git root — sibling and submodule are both
-  // anchored at `<gitRoot>` and there is no useful fallback when we cannot
-  // find one. Surfacing the unresolved status here is the actionable signal:
-  // the agent gets back "no git root" instead of a stale-path footgun.
-  if (gitRoot === null) {
-    return {
-      resolved: false,
-      reason:
-        'No strategy root resolvable: cwd is outside a git repository and no absolute env / config override is set.',
-    };
-  }
-
-  // Layer 3 — sibling at <gitRoot>/../totem-strategy
-  const sibling = path.normalize(path.resolve(gitRoot, '..', SIBLING_DIRNAME));
+  // Layer 3 — sibling at <anchor>/../totem-strategy
+  const sibling = path.normalize(path.join(anchor, '..', SIBLING_DIRNAME));
   if (isDirectory(sibling)) {
     return { resolved: true, path: sibling, source: 'sibling' };
   }
 
-  // Layer 4 — submodule at <gitRoot>/.strategy (legacy path; kept until
+  // Layer 4 — submodule at <anchor>/.strategy (legacy path; kept until
   // the gitlink-removal follow-up retires `.gitmodules`).
-  const submodule = path.normalize(path.join(gitRoot, SUBMODULE_DIRNAME));
+  const submodule = path.normalize(path.join(anchor, SUBMODULE_DIRNAME));
   if (isDirectory(submodule)) {
     return { resolved: true, path: submodule, source: 'submodule' };
   }

--- a/packages/core/src/strategy-resolver.ts
+++ b/packages/core/src/strategy-resolver.ts
@@ -83,14 +83,16 @@ function readEnvValue(env: Record<string, string | undefined>): string | undefin
 
 /**
  * Resolve a raw value (env or config) to an absolute path. Absolute values
- * are returned as-is; relative values anchor at the supplied base
- * (`gitRoot ?? cwd`) via `path.join` so that an absolute user-provided
- * value doesn't override the anchor (which `path.resolve` would).
+ * are returned as-is and bypass the anchor; relative values anchor at the
+ * lazily-evaluated base (`anchorThunk()`) via `path.join` so that an
+ * absolute user-provided value doesn't override the anchor (which
+ * `path.resolve` would). The thunk lets the resolver defer the
+ * `resolveGitRoot` probe until the relative path actually needs it.
  */
-function resolveValue(raw: string, anchor: string): string {
+function resolveValue(raw: string, anchorThunk: () => string): string {
   const trimmed = raw.trim();
   if (path.isAbsolute(trimmed)) return path.normalize(trimmed);
-  return path.normalize(path.join(anchor, trimmed));
+  return path.normalize(path.join(anchorThunk(), trimmed));
 }
 
 /**
@@ -110,38 +112,59 @@ function isDirectory(p: string): boolean {
 /**
  * Walk the four-layer precedence chain. Returns a `StrategyRootStatus`
  * discriminated union.
+ *
+ * The git-root probe is lazy. `resolveGitRoot` can throw `TotemGitError` on
+ * permission errors or a corrupted index; an eager probe would short-circuit
+ * an absolute env / config override that doesn't need git context at all.
+ * `getAnchor` defers the probe and swallows throws, so absolute overrides
+ * always get their precedence-1 / precedence-2 chance.
  */
 export function resolveStrategyRoot(
   cwd: string,
   options: StrategyResolverOptions = {},
 ): StrategyRootStatus {
   const env = options.env ?? process.env;
-  const gitRoot = options.gitRoot !== undefined ? options.gitRoot : resolveGitRoot(cwd);
   const config = options.config;
-  // Unified anchor — gitRoot when available, cwd otherwise. The cwd fallback
-  // matches the design spec's "Missing git context" trap and lets relative
-  // env / config / sibling / submodule layers resolve in non-git contexts
-  // (e.g., a one-off script outside a checkout). Downstream consumers
-  // validate the resolved path and fail loudly if the cwd-anchored result
-  // isn't viable.
-  const anchor = gitRoot ?? cwd;
 
-  // Layer 1 — env var
+  let cachedAnchor: string | undefined;
+  const getAnchor = (): string => {
+    if (cachedAnchor !== undefined) return cachedAnchor;
+    let gitRoot: string | null;
+    if (options.gitRoot !== undefined) {
+      gitRoot = options.gitRoot;
+    } else {
+      try {
+        gitRoot = resolveGitRoot(cwd);
+        // totem-context: intentional fall-through — resolveGitRoot throws on permission errors / corrupted index; fall back to cwd so absolute overrides and downstream consumers (governance throw, doctor warn, MCP unresolved payload) handle the wrong-path case explicitly.
+      } catch {
+        gitRoot = null;
+      }
+    }
+    cachedAnchor = gitRoot ?? cwd;
+    return cachedAnchor;
+  };
+
+  // Layer 1 — env var. Absolute values bypass the anchor probe entirely
+  // (resolveValue's `path.isAbsolute` short-circuits before calling the thunk).
   const envValue = readEnvValue(env);
   if (envValue !== undefined) {
-    const resolved = resolveValue(envValue, anchor);
+    const resolved = resolveValue(envValue, getAnchor);
     if (isDirectory(resolved)) {
       return { resolved: true, path: resolved, source: 'env' };
     }
   }
 
-  // Layer 2 — config field
+  // Layer 2 — config field. Same absolute-bypass behavior.
   if (config?.strategyRoot !== undefined && config.strategyRoot.trim().length > 0) {
-    const resolved = resolveValue(config.strategyRoot, anchor);
+    const resolved = resolveValue(config.strategyRoot, getAnchor);
     if (isDirectory(resolved)) {
       return { resolved: true, path: resolved, source: 'config' };
     }
   }
+
+  // Layers 3 + 4 require an anchor — sibling and submodule are both relative
+  // to the anchor by construction.
+  const anchor = getAnchor();
 
   // Layer 3 — sibling at <anchor>/../totem-strategy
   const sibling = path.normalize(path.join(anchor, '..', SIBLING_DIRNAME));

--- a/packages/mcp/src/context.test.ts
+++ b/packages/mcp/src/context.test.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ServerContext } from './context.js';
-import { _reconnectOnContext, loadEnv } from './context.js';
+import { _reconnectOnContext, dedupeEffectiveLinks, loadEnv } from './context.js';
 
 describe('loadEnv', () => {
   let tmpDir: string;
@@ -214,5 +214,57 @@ describe('_reconnectOnContext', () => {
     expect(broken).toHaveBeenCalledOnce();
     expect(okB).toHaveBeenCalledOnce();
     expect(ctx.linkedStoreInitErrors.size).toBe(0);
+  });
+});
+
+describe('dedupeEffectiveLinks (mmnto-ai/totem#1710 R2)', () => {
+  const projectRoot = path.resolve('/fake/project');
+
+  it('keeps a single entry untouched', () => {
+    const out = dedupeEffectiveLinks(projectRoot, [
+      { path: '/abs/path/strategy', nameOverride: 'strategy' },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.nameOverride).toBe('strategy');
+  });
+
+  it('drops a literal entry whose resolved path matches an earlier auto-injected entry', () => {
+    // Auto-inject (first) carries the override; literal '../totem-strategy'
+    // resolves to the same physical path. The dedup must keep the FIRST
+    // entry (with the stable 'strategy' name override) and drop the literal.
+    const siblingAbs = path.resolve(projectRoot, '..', 'totem-strategy');
+    const out = dedupeEffectiveLinks(projectRoot, [
+      { path: siblingAbs, nameOverride: 'strategy' },
+      { path: '../totem-strategy' },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.nameOverride).toBe('strategy');
+    expect(out[0]?.path).toBe(siblingAbs);
+  });
+
+  it('keeps two entries pointing at distinct paths', () => {
+    const out = dedupeEffectiveLinks(projectRoot, [
+      { path: '/abs/path/strategy', nameOverride: 'strategy' },
+      { path: '../sibling-other' },
+    ]);
+    expect(out).toHaveLength(2);
+  });
+
+  it('drops a duplicate caused by `.strategy` literal aliasing the same submodule path', () => {
+    const submoduleAbs = path.resolve(projectRoot, '.strategy');
+    const out = dedupeEffectiveLinks(projectRoot, [
+      { path: submoduleAbs, nameOverride: 'strategy' },
+      { path: '.strategy' },
+    ]);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.nameOverride).toBe('strategy');
+  });
+
+  it('treats different absolute paths as distinct even if basenames collide', () => {
+    const out = dedupeEffectiveLinks(projectRoot, [
+      { path: '/abs/repo-a/strategy', nameOverride: 'strategy' },
+      { path: '/abs/repo-b/strategy' },
+    ]);
+    expect(out).toHaveLength(2);
   });
 });

--- a/packages/mcp/src/context.ts
+++ b/packages/mcp/src/context.ts
@@ -288,15 +288,20 @@ async function initContext(): Promise<ServerContext> {
     // verbatim. The downstream consumer (`search-knowledge` Case 3)
     // wraps this string in `formatSystemWarning` → returns as text
     // content to the agent. An MCP client that renders the text in a
-    // terminal would interpret embedded ANSI/CR. Strip those bytes
-    // before persisting (mmnto-ai/totem#1710 R6 / CR R6 Major). Inline
-    // regex matches the canonical `terminal-sanitize.ts` strip in
-    // `packages/cli/src/`; mmnto-ai/totem#1744 consolidates the helper
-    // into `@mmnto/totem` so this duplication can be retired.
+    // terminal would interpret embedded ANSI/CR/newlines/tabs. Strip
+    // ANSI/CR + collapse \n/\t to single spaces before persisting
+    // (mmnto-ai/totem#1710 R6 / CR R6 Major + R7 / CR R7 Major). The
+    // ANSI/CR strip matches the canonical `terminal-sanitize.ts`
+    // regex in `packages/cli/src/`; the \n/\t flatten matches the
+    // doctor.ts pattern. mmnto-ai/totem#1744 consolidates both into
+    // a single shared helper in @mmnto/totem core.
     const safeReason = strategyStatus.reason
       // totem-context: inlined canonical `sanitizeForTerminal` regex — cross-package import deferred to mmnto-ai/totem#1744 (sanitizer consolidation into @mmnto/totem core).
       .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
-      .replace(/[\x00-\x08\x0b-\x0d\x0e-\x1f\x7f-\x9f]/g, ' ');
+      .replace(/[\x00-\x08\x0b-\x0d\x0e-\x1f\x7f-\x9f]/g, ' ')
+      .replace(/[\t\n]+/g, ' ')
+      .replace(/ {2,}/g, ' ')
+      .trim();
     linkedStoreInitErrors.set(
       'strategy',
       `Strategy root expected but not resolvable: ${safeReason}`,

--- a/packages/mcp/src/context.ts
+++ b/packages/mcp/src/context.ts
@@ -8,6 +8,7 @@ import {
   createEmbedder,
   LanceStore,
   requireEmbedding,
+  resolveStrategyRoot,
   TotemConfigError,
   TotemConfigSchema,
 } from '@mmnto/totem';
@@ -213,8 +214,36 @@ async function initContext(): Promise<ServerContext> {
   const linkedStores = new Map<string, LanceStore>();
   const linkedStoreInitErrors = new Map<string, string>();
 
+  // Auto-inject the strategy linkedIndex via the strategy-root resolver
+  // (mmnto-ai/totem#1710). Stable link name `'strategy'` regardless of
+  // physical source so `boundary: 'strategy'` queries route the same way
+  // whether the repo lives in `.strategy/`, `../totem-strategy/`, or
+  // wherever `TOTEM_STRATEGY_ROOT` points. Surface an init-time warning
+  // ONLY when the user explicitly signaled a strategy expectation (env or
+  // config); zero-config projects without a strategy repo skip silently.
+  // Read env via `Object.hasOwn` rather than `process.env.X !== undefined`
+  // per a project-local lint rule against the latter idiom.
+  const effectiveLinks: Array<{ path: string; nameOverride?: string }> = [];
+  const strategyExpected =
+    Object.hasOwn(process.env, 'TOTEM_STRATEGY_ROOT') ||
+    Object.hasOwn(process.env, 'STRATEGY_ROOT') ||
+    config.strategyRoot !== undefined;
+  const strategyStatus = resolveStrategyRoot(projectRoot, { config });
+  if (strategyStatus.resolved) {
+    effectiveLinks.push({ path: strategyStatus.path, nameOverride: 'strategy' });
+  } else if (strategyExpected) {
+    linkedStoreInitErrors.set(
+      'strategy',
+      `Strategy root expected but not resolvable: ${strategyStatus.reason}`,
+    );
+  }
+
   for (const linkedPath of config.linkedIndexes ?? []) {
-    const name = deriveLinkName(linkedPath, projectRoot);
+    effectiveLinks.push({ path: linkedPath });
+  }
+
+  for (const { path: linkedPath, nameOverride } of effectiveLinks) {
+    const name = nameOverride ?? deriveLinkName(linkedPath, projectRoot);
 
     // Collision detection — the first-wins so downstream lookups are stable.
     //

--- a/packages/mcp/src/context.ts
+++ b/packages/mcp/src/context.ts
@@ -139,6 +139,37 @@ function deriveLinkName(linkedPath: string, cwd: string): string {
   return base.replace(/^\./, '');
 }
 
+export interface EffectiveLinkCandidate {
+  path: string;
+  nameOverride?: string;
+}
+
+/**
+ * Dedupe a list of effective linkedIndex candidates by their RESOLVED
+ * absolute path. First-wins so the auto-injected strategy entry (with its
+ * stable `'strategy'` link name) takes precedence over a legacy literal in
+ * `config.linkedIndexes` pointing at the same physical store
+ * (mmnto-ai/totem#1710 R2 / CR R2).
+ *
+ * Pure function — exported so unit tests can exercise the dedup contract
+ * without standing up the full `initContext` pipeline (LanceStore +
+ * embedder + jiti config loader).
+ */
+export function dedupeEffectiveLinks(
+  projectRoot: string,
+  candidates: ReadonlyArray<EffectiveLinkCandidate>,
+): EffectiveLinkCandidate[] {
+  const seen = new Set<string>();
+  const out: EffectiveLinkCandidate[] = [];
+  for (const candidate of candidates) {
+    const resolvedAbs = path.resolve(projectRoot, candidate.path);
+    if (seen.has(resolvedAbs)) continue;
+    seen.add(resolvedAbs);
+    out.push(candidate);
+  }
+  return out;
+}
+
 /**
  * Load environment variables from .env file (does not override existing).
  */
@@ -223,24 +254,32 @@ async function initContext(): Promise<ServerContext> {
   // config); zero-config projects without a strategy repo skip silently.
   // Read env via `Object.hasOwn` rather than `process.env.X !== undefined`
   // per a project-local lint rule against the latter idiom.
-  const effectiveLinks: Array<{ path: string; nameOverride?: string }> = [];
+  //
+  // Dedupe by RESOLVED ABSOLUTE PATH (mmnto-ai/totem#1710 R2 / CR R2): if a
+  // legacy config still lists `'.strategy'` (or `'../totem-strategy'`) AND
+  // the resolver auto-injects the same physical store under name
+  // `'strategy'`, we must not queue the same LanceStore twice — federated
+  // search would return duplicate hits. The existing collision guard below
+  // catches name collisions but not path-via-different-name collisions, so
+  // we dedupe candidates upfront.
+  const candidates: EffectiveLinkCandidate[] = [];
   const strategyExpected =
     Object.hasOwn(process.env, 'TOTEM_STRATEGY_ROOT') ||
     Object.hasOwn(process.env, 'STRATEGY_ROOT') ||
     config.strategyRoot !== undefined;
   const strategyStatus = resolveStrategyRoot(projectRoot, { config });
   if (strategyStatus.resolved) {
-    effectiveLinks.push({ path: strategyStatus.path, nameOverride: 'strategy' });
+    candidates.push({ path: strategyStatus.path, nameOverride: 'strategy' });
   } else if (strategyExpected) {
     linkedStoreInitErrors.set(
       'strategy',
       `Strategy root expected but not resolvable: ${strategyStatus.reason}`,
     );
   }
-
   for (const linkedPath of config.linkedIndexes ?? []) {
-    effectiveLinks.push({ path: linkedPath });
+    candidates.push({ path: linkedPath });
   }
+  const effectiveLinks = dedupeEffectiveLinks(projectRoot, candidates);
 
   for (const { path: linkedPath, nameOverride } of effectiveLinks) {
     const name = nameOverride ?? deriveLinkName(linkedPath, projectRoot);

--- a/packages/mcp/src/context.ts
+++ b/packages/mcp/src/context.ts
@@ -263,10 +263,19 @@ async function initContext(): Promise<ServerContext> {
   // catches name collisions but not path-via-different-name collisions, so
   // we dedupe candidates upfront.
   const candidates: EffectiveLinkCandidate[] = [];
+  // Mirror `resolveStrategyRoot`'s whitespace-as-unset rule (R3 / CR R3):
+  // `TOTEM_STRATEGY_ROOT="   "` or `strategyRoot: ' '` would otherwise
+  // mark `strategyExpected=true` while the resolver sees nothing,
+  // surfacing a "Strategy root expected but not resolvable" warning that
+  // never goes away.
+  const envHas = (key: string): boolean => {
+    const v = process.env[key];
+    return typeof v === 'string' && v.trim().length > 0;
+  };
   const strategyExpected =
-    Object.hasOwn(process.env, 'TOTEM_STRATEGY_ROOT') ||
-    Object.hasOwn(process.env, 'STRATEGY_ROOT') ||
-    config.strategyRoot !== undefined;
+    envHas('TOTEM_STRATEGY_ROOT') ||
+    envHas('STRATEGY_ROOT') ||
+    (typeof config.strategyRoot === 'string' && config.strategyRoot.trim().length > 0);
   const strategyStatus = resolveStrategyRoot(projectRoot, { config });
   if (strategyStatus.resolved) {
     candidates.push({ path: strategyStatus.path, nameOverride: 'strategy' });

--- a/packages/mcp/src/context.ts
+++ b/packages/mcp/src/context.ts
@@ -252,8 +252,12 @@ async function initContext(): Promise<ServerContext> {
   // wherever `TOTEM_STRATEGY_ROOT` points. Surface an init-time warning
   // ONLY when the user explicitly signaled a strategy expectation (env or
   // config); zero-config projects without a strategy repo skip silently.
-  // Read env via `Object.hasOwn` rather than `process.env.X !== undefined`
-  // per a project-local lint rule against the latter idiom.
+  // Validate env values for non-whitespace content rather than testing
+  // for `!== undefined` — the project-local lint rule wants whitespace
+  // validation (`/\S/.test`) so a `TOTEM_STRATEGY_ROOT="   "` accident
+  // doesn't trigger the warning slot. `Object.hasOwn` was rejected in
+  // R4 because it adds no safety beyond the trim-and-length check and
+  // breaks Windows' case-insensitive env-var resolution.
   //
   // Dedupe by RESOLVED ABSOLUTE PATH (mmnto-ai/totem#1710 R2 / CR R2): if a
   // legacy config still lists `'.strategy'` (or `'../totem-strategy'`) AND

--- a/packages/mcp/src/context.ts
+++ b/packages/mcp/src/context.ts
@@ -284,9 +284,22 @@ async function initContext(): Promise<ServerContext> {
   if (strategyStatus.resolved) {
     candidates.push({ path: strategyStatus.path, nameOverride: 'strategy' });
   } else if (strategyExpected) {
+    // `strategyStatus.reason` carries env/config-derived path text
+    // verbatim. The downstream consumer (`search-knowledge` Case 3)
+    // wraps this string in `formatSystemWarning` → returns as text
+    // content to the agent. An MCP client that renders the text in a
+    // terminal would interpret embedded ANSI/CR. Strip those bytes
+    // before persisting (mmnto-ai/totem#1710 R6 / CR R6 Major). Inline
+    // regex matches the canonical `terminal-sanitize.ts` strip in
+    // `packages/cli/src/`; mmnto-ai/totem#1744 consolidates the helper
+    // into `@mmnto/totem` so this duplication can be retired.
+    const safeReason = strategyStatus.reason
+      // totem-context: inlined canonical `sanitizeForTerminal` regex — cross-package import deferred to mmnto-ai/totem#1744 (sanitizer consolidation into @mmnto/totem core).
+      .replace(/\x1b\[[0-?]*[ -/]*[@-~]/g, '')
+      .replace(/[\x00-\x08\x0b-\x0d\x0e-\x1f\x7f-\x9f]/g, ' ');
     linkedStoreInitErrors.set(
       'strategy',
-      `Strategy root expected but not resolvable: ${strategyStatus.reason}`,
+      `Strategy root expected but not resolvable: ${safeReason}`,
     );
   }
   for (const linkedPath of config.linkedIndexes ?? []) {

--- a/packages/mcp/src/schemas/describe-project.test.ts
+++ b/packages/mcp/src/schemas/describe-project.test.ts
@@ -51,7 +51,11 @@ describe('DescribeProjectOutputSchema backward compatibility', () => {
 
   it('accepts legacy shape with richState populated', () => {
     const rich = {
-      strategyPointer: { sha: 'abc1234', latestJournal: '2026-04-16-session.md' },
+      strategyPointer: {
+        resolved: true as const,
+        sha: 'abc1234',
+        latestJournal: '2026-04-16-session.md',
+      },
       gitState: { branch: 'main', uncommittedFiles: [], truncated: false },
       packageVersions: { '@mmnto/cli': '1.14.10' },
       ruleCounts: { active: 10, archived: 2, nonCompilable: 3 },
@@ -117,17 +121,67 @@ describe('MilestoneStateSchema', () => {
   });
 });
 
-describe('StrategyPointerSchema', () => {
-  it('allows both fields null (no submodule)', () => {
-    const parsed = StrategyPointerSchema.parse({ sha: null, latestJournal: null });
-    expect(parsed.sha).toBeNull();
+describe('StrategyPointerSchema (mmnto-ai/totem#1710)', () => {
+  it('accepts the resolved branch with both git fields null', () => {
+    const parsed = StrategyPointerSchema.parse({
+      resolved: true,
+      sha: null,
+      latestJournal: null,
+    });
+    if (parsed.resolved) {
+      expect(parsed.sha).toBeNull();
+      expect(parsed.latestJournal).toBeNull();
+    } else {
+      expect.fail('expected resolved branch');
+    }
+  });
+
+  it('accepts the resolved branch with non-null git fields', () => {
+    const parsed = StrategyPointerSchema.parse({
+      resolved: true,
+      sha: 'd387716',
+      latestJournal: 'claude-0006-pattern-history-overlay-1.17.1.md',
+    });
+    if (parsed.resolved) {
+      expect(parsed.sha).toBe('d387716');
+      expect(parsed.latestJournal).toBe('claude-0006-pattern-history-overlay-1.17.1.md');
+    }
+  });
+
+  it('accepts the unresolved branch with a reason string', () => {
+    const parsed = StrategyPointerSchema.parse({
+      resolved: false,
+      reason: 'No strategy root resolvable: cwd is outside a git repository.',
+    });
+    if (!parsed.resolved) {
+      expect(parsed.reason).toMatch(/strategy/);
+    } else {
+      expect.fail('expected unresolved branch');
+    }
+  });
+
+  it('rejects malformed mixes (resolved=true without sha)', () => {
+    const result = StrategyPointerSchema.safeParse({
+      resolved: true,
+      latestJournal: null,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects malformed mixes (resolved=false with sha)', () => {
+    const result = StrategyPointerSchema.safeParse({
+      resolved: false,
+      sha: 'abc1234',
+      latestJournal: null,
+    });
+    expect(result.success).toBe(false);
   });
 });
 
 describe('RichProjectStateSchema', () => {
   it('allows testCount: null explicitly', () => {
     const parsed = RichProjectStateSchema.parse({
-      strategyPointer: { sha: null, latestJournal: null },
+      strategyPointer: { resolved: true, sha: null, latestJournal: null },
       gitState: { branch: null, uncommittedFiles: [], truncated: false },
       packageVersions: {},
       ruleCounts: { active: 0, archived: 0, nonCompilable: 0 },
@@ -137,6 +191,22 @@ describe('RichProjectStateSchema', () => {
       recentPrs: [],
     });
     expect(parsed.testCount).toBeNull();
+  });
+
+  it('embeds the unresolved strategy-pointer branch (#1710)', () => {
+    const parsed = RichProjectStateSchema.parse({
+      strategyPointer: { resolved: false, reason: 'no sibling, no submodule' },
+      gitState: { branch: 'main', uncommittedFiles: [], truncated: false },
+      packageVersions: {},
+      ruleCounts: { active: 0, archived: 0, nonCompilable: 0 },
+      lessonCount: 0,
+      testCount: null,
+      milestone: { name: null, gateTickets: [], bestEffort: true },
+      recentPrs: [],
+    });
+    if (!parsed.strategyPointer.resolved) {
+      expect(parsed.strategyPointer.reason).toBe('no sibling, no submodule');
+    }
   });
 });
 

--- a/packages/mcp/src/schemas/describe-project.test.ts
+++ b/packages/mcp/src/schemas/describe-project.test.ts
@@ -176,6 +176,29 @@ describe('StrategyPointerSchema (mmnto-ai/totem#1710)', () => {
     });
     expect(result.success).toBe(false);
   });
+
+  it('rejects extra keys on the resolved branch (R3 — strict mode)', () => {
+    // Without .strict(), Zod silently strips unknown keys. .strict() makes
+    // the discriminated union catch a producer-side bug where the wrong
+    // branch fields leak into a payload (e.g., a `reason` accidentally
+    // emitted alongside a successful resolution).
+    const result = StrategyPointerSchema.safeParse({
+      resolved: true,
+      sha: 'abc1234',
+      latestJournal: null,
+      reason: 'should not appear',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects extra keys on the unresolved branch (R3 — strict mode)', () => {
+    const result = StrategyPointerSchema.safeParse({
+      resolved: false,
+      reason: 'No strategy root resolvable.',
+      latestJournal: 'should-not-appear.md',
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 describe('RichProjectStateSchema', () => {

--- a/packages/mcp/src/schemas/describe-project.ts
+++ b/packages/mcp/src/schemas/describe-project.ts
@@ -39,12 +39,32 @@ export type DescribeProjectInput = z.infer<typeof DescribeProjectInputSchema>;
 
 // ─── Rich state sub-schemas ────────────────────────────────────────────────
 
-export const StrategyPointerSchema = z.object({
-  /** Short-form 7-char SHA of the strategy submodule HEAD. Null when no submodule. */
-  sha: z.string().nullable(),
-  /** Filename of the most recent `.strategy/.journal/*.md` entry, no path. */
-  latestJournal: z.string().nullable(),
-});
+/**
+ * Strategy-pointer payload (mmnto-ai/totem#1710).
+ *
+ * Discriminated union on the `resolved` flag so consumers can pattern-match
+ * without inferring intent from null fields. The `resolved: false` branch
+ * surfaces the resolver's `reason` string so an agent reading the rich-state
+ * payload can render an actionable message instead of an empty pointer.
+ *
+ * Pre-1710 callers received `{ sha, latestJournal }` directly. The new shape
+ * is a breaking change to the MCP `describe_project` rich-state output;
+ * documented in CHANGELOG.
+ */
+export const StrategyPointerSchema = z.discriminatedUnion('resolved', [
+  z.object({
+    resolved: z.literal(true),
+    /** Short-form 7-char SHA of the resolved strategy HEAD. Null when git rev-parse fails inside the strategy dir. */
+    sha: z.string().nullable(),
+    /** Filename of the most recent `<strategyRoot>/.journal/*.md` entry, no path. Null when `.journal/` is missing or empty. */
+    latestJournal: z.string().nullable(),
+  }),
+  z.object({
+    resolved: z.literal(false),
+    /** Human-readable reason from the strategy-root resolver. */
+    reason: z.string(),
+  }),
+]);
 export type StrategyPointer = z.infer<typeof StrategyPointerSchema>;
 
 export const GitStateSchema = z.object({

--- a/packages/mcp/src/schemas/describe-project.ts
+++ b/packages/mcp/src/schemas/describe-project.ts
@@ -52,18 +52,22 @@ export type DescribeProjectInput = z.infer<typeof DescribeProjectInputSchema>;
  * documented in CHANGELOG.
  */
 export const StrategyPointerSchema = z.discriminatedUnion('resolved', [
-  z.object({
-    resolved: z.literal(true),
-    /** Short-form 7-char SHA of the resolved strategy HEAD. Null when git rev-parse fails inside the strategy dir. */
-    sha: z.string().nullable(),
-    /** Filename of the most recent `<strategyRoot>/.journal/*.md` entry, no path. Null when `.journal/` is missing or empty. */
-    latestJournal: z.string().nullable(),
-  }),
-  z.object({
-    resolved: z.literal(false),
-    /** Human-readable reason from the strategy-root resolver. */
-    reason: z.string(),
-  }),
+  z
+    .object({
+      resolved: z.literal(true),
+      /** Short-form 7-char SHA of the resolved strategy HEAD. Null when git rev-parse fails inside the strategy dir. */
+      sha: z.string().nullable(),
+      /** Filename of the most recent `<strategyRoot>/.journal/*.md` entry, no path. Null when `.journal/` is missing or empty. */
+      latestJournal: z.string().nullable(),
+    })
+    .strict(),
+  z
+    .object({
+      resolved: z.literal(false),
+      /** Human-readable reason from the strategy-root resolver. */
+      reason: z.string(),
+    })
+    .strict(),
 ]);
 export type StrategyPointer = z.infer<typeof StrategyPointerSchema>;
 

--- a/packages/mcp/src/state-extractors.test.ts
+++ b/packages/mcp/src/state-extractors.test.ts
@@ -49,25 +49,45 @@ describe('extractGitState', () => {
   });
 });
 
-describe('extractStrategyPointer', () => {
-  it('returns null/null when .strategy/ is absent', () => {
+describe('extractStrategyPointer (mmnto-ai/totem#1710)', () => {
+  let prevEnvPrimary: string | undefined;
+  let prevEnvAlias: string | undefined;
+  beforeEach(() => {
+    // Isolate the resolver from any developer-shell env override so the
+    // "absent strategy" test can reach the unresolved branch deterministically.
+    prevEnvPrimary = process.env.TOTEM_STRATEGY_ROOT;
+    prevEnvAlias = process.env.STRATEGY_ROOT;
+    delete process.env.TOTEM_STRATEGY_ROOT;
+    delete process.env.STRATEGY_ROOT;
+  });
+  afterEach(() => {
+    if (prevEnvPrimary !== undefined) process.env.TOTEM_STRATEGY_ROOT = prevEnvPrimary;
+    if (prevEnvAlias !== undefined) process.env.STRATEGY_ROOT = prevEnvAlias;
+  });
+
+  it('returns the unresolved branch when no strategy root is reachable', () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-mcp-nostrat-'));
     try {
       const ptr = extractStrategyPointer(tmp);
-      expect(ptr.sha).toBeNull();
-      expect(ptr.latestJournal).toBeNull();
+      expect(ptr.resolved).toBe(false);
+      if (!ptr.resolved) {
+        expect(ptr.reason).toMatch(/strategy/i);
+      }
     } finally {
       fs.rmSync(tmp, { recursive: true, force: true });
     }
   });
 
-  it('returns a 7-char SHA and a journal filename on the live repo', () => {
+  it('returns the resolved branch with a 7-char SHA and journal filename on the live repo', () => {
     const ptr = extractStrategyPointer(REPO_ROOT);
-    if (ptr.sha !== null) {
-      expect(ptr.sha).toMatch(/^[0-9a-f]{7}$/);
-    }
-    if (ptr.latestJournal !== null) {
-      expect(ptr.latestJournal).toMatch(/\.md$/);
+    expect(ptr.resolved).toBe(true);
+    if (ptr.resolved) {
+      if (ptr.sha !== null) {
+        expect(ptr.sha).toMatch(/^[0-9a-f]{7}$/);
+      }
+      if (ptr.latestJournal !== null) {
+        expect(ptr.latestJournal).toMatch(/\.md$/);
+      }
     }
   });
 });

--- a/packages/mcp/src/state-extractors.test.ts
+++ b/packages/mcp/src/state-extractors.test.ts
@@ -61,8 +61,12 @@ describe('extractStrategyPointer (mmnto-ai/totem#1710)', () => {
     delete process.env.STRATEGY_ROOT;
   });
   afterEach(() => {
-    if (prevEnvPrimary !== undefined) process.env.TOTEM_STRATEGY_ROOT = prevEnvPrimary;
-    if (prevEnvAlias !== undefined) process.env.STRATEGY_ROOT = prevEnvAlias;
+    // Symmetric restore: when prev was undefined, the env var was unset
+    // before this suite ran — DELETE rather than leak the test's value.
+    if (prevEnvPrimary === undefined) delete process.env.TOTEM_STRATEGY_ROOT;
+    else process.env.TOTEM_STRATEGY_ROOT = prevEnvPrimary;
+    if (prevEnvAlias === undefined) delete process.env.STRATEGY_ROOT;
+    else process.env.STRATEGY_ROOT = prevEnvAlias;
   });
 
   it('returns the unresolved branch when no strategy root is reachable', () => {

--- a/packages/mcp/src/state-extractors.ts
+++ b/packages/mcp/src/state-extractors.ts
@@ -19,6 +19,7 @@ import {
   resolveGitRoot,
   resolveStrategyRoot,
   safeExec,
+  type StrategyResolverConfig,
 } from '@mmnto/totem';
 
 import {
@@ -89,8 +90,11 @@ export function extractGitState(cwd: string): GitState {
  *   resolver's actionable reason instead of seeing an empty pointer that
  *   could be confused with a present-but-uninitialized submodule.
  */
-export function extractStrategyPointer(cwd: string): StrategyPointer {
-  const status = resolveStrategyRoot(cwd);
+export function extractStrategyPointer(
+  cwd: string,
+  config?: StrategyResolverConfig,
+): StrategyPointer {
+  const status = resolveStrategyRoot(cwd, { config });
   if (!status.resolved) {
     return { resolved: false, reason: status.reason };
   }

--- a/packages/mcp/src/state-extractors.ts
+++ b/packages/mcp/src/state-extractors.ts
@@ -13,7 +13,13 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { CompiledRulesFileSchema, readJsonSafe, resolveGitRoot, safeExec } from '@mmnto/totem';
+import {
+  CompiledRulesFileSchema,
+  readJsonSafe,
+  resolveGitRoot,
+  resolveStrategyRoot,
+  safeExec,
+} from '@mmnto/totem';
 
 import {
   type GitState,
@@ -68,19 +74,33 @@ export function extractGitState(cwd: string): GitState {
   return { branch, uncommittedFiles, truncated };
 }
 
-// ─── Strategy submodule pointer ────────────────────────────────────────────
+// ─── Strategy pointer ──────────────────────────────────────────────────────
 
+/**
+ * Resolve the strategy root via `resolveStrategyRoot` and return the rich-state
+ * pointer for the MCP `describe_project` payload (mmnto-ai/totem#1710).
+ *
+ * Two outcomes:
+ * - **Resolved:** `{ resolved: true, sha, latestJournal }`. `sha` and
+ *   `latestJournal` follow the existing graceful-degrade contract — null when
+ *   `git rev-parse` fails or `.journal/` is missing/empty inside the resolved
+ *   directory. The agent gets a real pointer when one exists.
+ * - **Unresolved:** `{ resolved: false, reason }`. The agent reads the
+ *   resolver's actionable reason instead of seeing an empty pointer that
+ *   could be confused with a present-but-uninitialized submodule.
+ */
 export function extractStrategyPointer(cwd: string): StrategyPointer {
-  const strategyDir = path.join(cwd, '.strategy');
-  if (!fs.existsSync(strategyDir)) {
-    return { sha: null, latestJournal: null };
+  const status = resolveStrategyRoot(cwd);
+  if (!status.resolved) {
+    return { resolved: false, reason: status.reason };
   }
 
+  const strategyDir = status.path;
   let sha: string | null = null;
   try {
     const full = safeExec('git', ['rev-parse', 'HEAD'], { cwd: strategyDir });
     sha = full.length >= 7 ? full.slice(0, 7) : null;
-    // totem-context: ADR-090 substrate graceful degradation — null sha on uninitialized submodule.
+    // totem-context: ADR-090 substrate graceful degradation — null sha on uninitialized strategy.
   } catch {
     sha = null;
   }
@@ -100,7 +120,7 @@ export function extractStrategyPointer(cwd: string): StrategyPointer {
     latestJournal = null;
   }
 
-  return { sha, latestJournal };
+  return { resolved: true, sha, latestJournal };
 }
 
 // ─── Package versions (fixed group only) ───────────────────────────────────

--- a/packages/mcp/src/tools/describe-project.test.ts
+++ b/packages/mcp/src/tools/describe-project.test.ts
@@ -30,6 +30,10 @@ vi.mock('@mmnto/totem', () => ({
   },
   // Stubs used by state-extractors (imported transitively via the tool).
   resolveGitRoot: () => null,
+  resolveStrategyRoot: () => ({
+    resolved: false,
+    reason: 'mock state-extractors test: no strategy root',
+  }),
   safeExec: () => '',
   readJsonSafe: () => {
     // Prefixed to match Totem's error convention so the lint rule does not

--- a/packages/mcp/src/tools/describe-project.ts
+++ b/packages/mcp/src/tools/describe-project.ts
@@ -10,7 +10,7 @@ import {
   TotemError,
 } from '@mmnto/totem';
 
-import { getContext } from '../context.js';
+import { getContext, loadEnv } from '../context.js';
 import { type DescribeProjectOutput, type RichProjectState } from '../schemas/describe-project.js';
 import {
   extractGitState,
@@ -58,6 +58,14 @@ async function getLegacyContext(): Promise<LegacyContext> {
   // Only .ts configs are supported here — jiti cannot parse YAML/TOML.
   // YAML/TOML users will have getContext() succeed since those configs
   // still define an embedding provider (Standard/Full tier).
+  //
+  // Load `.env` before reading config so env-derived fields (e.g.,
+  // `TOTEM_STRATEGY_ROOT` consumed by the strategy-root resolver inside
+  // `extractStrategyPointer`) match the main `getContext()` path. Without
+  // this, the Lite-tier `describe_project` payload could disagree with
+  // the rich-state path on the same repo (mmnto-ai/totem#1710 R3 / CR R3).
+  loadEnv(projectRoot);
+
   let configPath: string | null = null;
   for (const file of CONFIG_FILES) {
     const candidate = path.join(projectRoot, file);
@@ -116,10 +124,11 @@ export function registerDescribeProject(server: McpServer): void {
     {
       description:
         'Returns a structured JSON summary of the project governance scope: rules, lessons, config tier, partitions, targets, and hooks. Pass `includeRichState: true` to append a session-briefing payload (git state, strategy pointer, package versions, rule/lesson counts, milestone, recent PRs). Fast, deterministic, no LLM required.',
-      // totem-context: MCP SDK's registerTool accepts a Zod raw shape, not a
-      // JSON Schema object. This matches the convention already used in
-      // search-knowledge.ts and add-lesson.ts. The SDK converts the shape to
-      // JSON Schema internally before exposing the tool to clients.
+      // MCP SDK's registerTool accepts a Zod raw shape, not a JSON Schema
+      // object — same convention as search-knowledge.ts and add-lesson.ts.
+      // The SDK converts the shape to JSON Schema internally before
+      // exposing the tool to clients.
+      // totem-context: MCP SDK registerTool accepts a Zod raw shape, not a JSON Schema object.
       inputSchema: {
         includeRichState: z.boolean().optional(),
       },

--- a/packages/mcp/src/tools/describe-project.ts
+++ b/packages/mcp/src/tools/describe-project.ts
@@ -5,6 +5,7 @@ import {
   CONFIG_FILES,
   describeProject,
   type ProjectDescription,
+  type TotemConfig,
   TotemConfigSchema,
   TotemError,
 } from '@mmnto/totem';
@@ -26,6 +27,7 @@ interface LegacyContext {
   legacy: ProjectDescription;
   projectRoot: string;
   totemDir: string;
+  config: TotemConfig;
 }
 
 /**
@@ -46,6 +48,7 @@ async function getLegacyContext(): Promise<LegacyContext> {
       legacy: describeProject(ctx.config, ctx.projectRoot),
       projectRoot: ctx.projectRoot,
       totemDir: ctx.config.totemDir,
+      config: ctx.config,
     };
   } catch {
     // Expected on Lite tier — fall through to direct config load
@@ -86,12 +89,17 @@ async function getLegacyContext(): Promise<LegacyContext> {
     legacy: describeProject(config, configRoot),
     projectRoot: configRoot,
     totemDir: config.totemDir,
+    config,
   };
 }
 
-function buildRichState(projectRoot: string, totemDir: string): RichProjectState {
+function buildRichState(
+  projectRoot: string,
+  totemDir: string,
+  config: TotemConfig,
+): RichProjectState {
   return {
-    strategyPointer: extractStrategyPointer(projectRoot),
+    strategyPointer: extractStrategyPointer(projectRoot, config),
     gitState: extractGitState(projectRoot),
     packageVersions: extractPackageVersions(projectRoot),
     ruleCounts: extractRuleCounts(projectRoot, totemDir),
@@ -121,9 +129,9 @@ export function registerDescribeProject(server: McpServer): void {
     },
     async (args: { includeRichState?: boolean }) => {
       try {
-        const { legacy, projectRoot, totemDir } = await getLegacyContext();
+        const { legacy, projectRoot, totemDir, config } = await getLegacyContext();
         const output: DescribeProjectOutput = args.includeRichState
-          ? { ...legacy, richState: buildRichState(projectRoot, totemDir) }
+          ? { ...legacy, richState: buildRichState(projectRoot, totemDir, config) }
           : { ...legacy };
         return {
           content: [{ type: 'text' as const, text: JSON.stringify(output, null, 2) }],

--- a/scripts/bench-lance-open.ts
+++ b/scripts/bench-lance-open.ts
@@ -36,7 +36,7 @@ async function main(): Promise<void> {
     if (!strategyStatus.resolved) {
       console.error(`[bench] Cannot resolve default LanceDB path: ${strategyStatus.reason}`);
       console.error(
-        '[bench] Pass an explicit path (e.g., `pnpm tsx scripts/bench-lance-open.ts /path/to/.lancedb`), set TOTEM_STRATEGY_ROOT, or configure totem.config.ts:strategyRoot.',
+        '[bench] Pass an explicit path (e.g., `pnpm tsx scripts/bench-lance-open.ts /path/to/.lancedb`) or set TOTEM_STRATEGY_ROOT.',
       );
       process.exit(1);
     }

--- a/scripts/bench-lance-open.ts
+++ b/scripts/bench-lance-open.ts
@@ -10,7 +10,10 @@
  * Usage:
  *   pnpm tsx scripts/bench-lance-open.ts [path-to-lancedb]
  *
- * Default path: .strategy/.lancedb
+ * Default path: `<strategyRoot>/.lancedb` resolved via `resolveStrategyRoot`
+ * (mmnto-ai/totem#1710). When the strategy root is unresolvable, the script
+ * hard-fails with an actionable message; explicit positional arg always
+ * wins over the resolver default.
  */
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
@@ -22,11 +25,23 @@ import { performance } from 'node:perf_hooks';
 const localRequire = createRequire(path.resolve(process.cwd(), 'packages/core/package.json'));
 const lancedb = localRequire('@lancedb/lancedb') as typeof import('@lancedb/lancedb');
 
-const DEFAULT_PATH = path.resolve(process.cwd(), '.strategy/.lancedb');
+import { resolveStrategyRoot } from '../packages/core/src/strategy-resolver.js';
+
 const TABLE_NAME = 'totem_chunks';
 
 async function main(): Promise<void> {
-  const dbPath = process.argv[2] ?? DEFAULT_PATH;
+  let dbPath = process.argv[2];
+  if (dbPath === undefined) {
+    const strategyStatus = resolveStrategyRoot(process.cwd());
+    if (!strategyStatus.resolved) {
+      console.error(`[bench] Cannot resolve default LanceDB path: ${strategyStatus.reason}`);
+      console.error(
+        '[bench] Pass an explicit path (e.g., `pnpm tsx scripts/bench-lance-open.ts /path/to/.lancedb`), set TOTEM_STRATEGY_ROOT, or configure totem.config.ts:strategyRoot.',
+      );
+      process.exit(1);
+    }
+    dbPath = path.join(strategyStatus.path, '.lancedb');
+  }
   const iterations = Number(process.env.ITERATIONS ?? '100');
 
   console.log(`[bench] dbPath=${dbPath} iterations=${iterations}`);

--- a/scripts/benchmark-compile.ts
+++ b/scripts/benchmark-compile.ts
@@ -435,6 +435,19 @@ function scoreLesson(
 // ── Main ──
 
 async function runBenchmark() {
+  // Resolve the strategy root up-front so an unresolvable pointer fails
+  // fast — without this guard the script would burn the full benchmark
+  // loop (LLM calls + report assembly) before discovering it has nowhere
+  // to write the output (mmnto-ai/totem#1710 R4 / CR R4 Major).
+  const strategyStatus = resolveStrategyRoot(process.cwd());
+  if (!strategyStatus.resolved) {
+    console.error(`[bench] Cannot write report: ${strategyStatus.reason}`);
+    console.error(
+      '[bench] Set TOTEM_STRATEGY_ROOT, configure totem.config.ts:strategyRoot, or run from inside the totem checkout with a sibling totem-strategy clone.',
+    );
+    process.exit(1);
+  }
+
   COMPILER_PROMPT = (await import('../packages/cli/src/commands/compile-templates.js'))
     .COMPILER_SYSTEM_PROMPT;
 
@@ -618,15 +631,8 @@ async function runBenchmark() {
     }
   }
 
-  const strategyStatus = resolveStrategyRoot(process.cwd());
-  if (!strategyStatus.resolved) {
-    console.error(`[bench] Cannot write report: ${strategyStatus.reason}`);
-    console.error(
-      '[bench] Set TOTEM_STRATEGY_ROOT, configure totem.config.ts:strategyRoot, or run from inside the totem checkout with a sibling totem-strategy clone.',
-    );
-    process.exit(1);
-  }
-
+  // `strategyStatus` was validated at the top of `runBenchmark` — its
+  // `resolved: true` branch is guaranteed at this point.
   const report = lines.join('\n');
   const fs = await import('node:fs');
   const path = await import('node:path');

--- a/scripts/benchmark-compile.ts
+++ b/scripts/benchmark-compile.ts
@@ -4,10 +4,14 @@
  * Gemini Pro vs gemma4:26b head-to-head on 30 curated lessons.
  *
  * Usage: pnpm tsx scripts/benchmark-compile.ts
- * Output: .strategy/research/benchmark-compilation-quality-results.md
+ * Output: <strategyRoot>/research/benchmark-compilation-quality-results.md
+ *
+ * Strategy root is resolved via `resolveStrategyRoot` (mmnto-ai/totem#1710);
+ * hard-fails when unresolvable.
  */
 
 import { parseCompilerResponse, validateRegex } from '../packages/core/src/compiler.js';
+import { resolveStrategyRoot } from '../packages/core/src/strategy-resolver.js';
 
 const GEMINI_MODEL = 'gemini-3.1-pro-preview';
 const ANTHROPIC_MODEL = 'claude-sonnet-4-6';
@@ -614,17 +618,29 @@ async function runBenchmark() {
     }
   }
 
+  const strategyStatus = resolveStrategyRoot(process.cwd());
+  if (!strategyStatus.resolved) {
+    console.error(`[bench] Cannot write report: ${strategyStatus.reason}`);
+    console.error(
+      '[bench] Set TOTEM_STRATEGY_ROOT, configure totem.config.ts:strategyRoot, or run from inside the totem checkout with a sibling totem-strategy clone.',
+    );
+    process.exit(1);
+  }
+
   const report = lines.join('\n');
   const fs = await import('node:fs');
-  fs.writeFileSync('.strategy/research/benchmark-compilation-quality-results.md', report);
-  console.error(`\nReport written to .strategy/research/benchmark-compilation-quality-results.md`);
+  const path = await import('node:path');
+  const researchDir = path.join(strategyStatus.path, 'research');
+  fs.mkdirSync(researchDir, { recursive: true });
+
+  const reportPath = path.join(researchDir, 'benchmark-compilation-quality-results.md');
+  fs.writeFileSync(reportPath, report);
+  console.error(`\nReport written to ${reportPath}`);
 
   // Also write raw JSON for analysis
-  fs.writeFileSync(
-    '.strategy/research/benchmark-compilation-quality-raw.json',
-    JSON.stringify(results, null, 2),
-  );
-  console.error(`Raw data written to .strategy/research/benchmark-compilation-quality-raw.json`);
+  const rawPath = path.join(researchDir, 'benchmark-compilation-quality-raw.json');
+  fs.writeFileSync(rawPath, JSON.stringify(results, null, 2));
+  console.error(`Raw data written to ${rawPath}`);
 }
 
 runBenchmark().catch((err) => {

--- a/scripts/benchmark-compile.ts
+++ b/scripts/benchmark-compile.ts
@@ -443,7 +443,7 @@ async function runBenchmark() {
   if (!strategyStatus.resolved) {
     console.error(`[bench] Cannot write report: ${strategyStatus.reason}`);
     console.error(
-      '[bench] Set TOTEM_STRATEGY_ROOT, configure totem.config.ts:strategyRoot, or run from inside the totem checkout with a sibling totem-strategy clone.',
+      '[bench] Set TOTEM_STRATEGY_ROOT or run from inside the totem checkout with a sibling totem-strategy clone.',
     );
     process.exit(1);
   }

--- a/totem.config.ts
+++ b/totem.config.ts
@@ -65,7 +65,12 @@ const config: TotemConfig = {
 
   repositories: ['mmnto-ai/totem', 'mmnto-ai/totem-strategy'],
 
-  linkedIndexes: ['.strategy'],
+  // mmnto-ai/totem#1710: the strategy linkedIndex is auto-injected by the
+  // MCP context init via `resolveStrategyRoot`. Listing it here is no
+  // longer required — the resolver handles env / config / sibling /
+  // submodule precedence regardless of where the strategy repo sits.
+  // Keep `linkedIndexes` empty unless adding genuinely third-party indexes.
+  linkedIndexes: [],
 
   partitions: {
     core: ['packages/core/'],


### PR DESCRIPTION
## Summary

Replaces the hardcoded `.strategy/` submodule path with a configurable `resolveStrategyRoot` resolver. Each programmatic consumer now reads through the resolver and degrades gracefully when the strategy root is unresolvable.

- New `resolveStrategyRoot(cwd, options?)` in `@mmnto/totem` walks four precedence layers: `TOTEM_STRATEGY_ROOT` env (with `STRATEGY_ROOT` accepted as a legacy alias) → `TotemConfig.strategyRoot` → sibling `<gitRoot>/../totem-strategy/` → legacy submodule `<gitRoot>/.strategy/`. Returns a `StrategyRootStatus` discriminated union. `isDirectory()` guard on every layer; relative env / config values anchor at the git root, never at deep cwd.
- All four programmatic consumers ported: MCP `extractStrategyPointer` and the auto-injected strategy linkedIndex in `initContext`, CLI `resolveGovernancePaths` (proposal/adr scaffolding), and the bench scripts under `scripts/`.
- New `totem doctor` "Strategy Root" advisory diagnostic (`pass` / `warn`, never `fail`).
- `StrategyPointerSchema` flips to `z.discriminatedUnion('resolved', [...])` — breaking shape for MCP `describe_project` rich-state, opt-in only via `includeRichState: true`.
- `totem.config.ts:linkedIndexes: ['.strategy']` literal removed; the resolver is now the single source of truth.

Closes mmnto-ai/totem#1710.

## Open questions resolved (per Gemini review on the design doc)

- **Q1** Env-var name: `TOTEM_STRATEGY_ROOT` primary with `STRATEGY_ROOT` accepted as a legacy alias.
- **Q2** PR shape: bundled per `feedback_bundle_locally_avoid_pr_churn.md` — single PR with two commits (substrate + consumer port).
- **Q3** Submodule fallback is in the resolver from day one; `.gitmodules` removal is a separate follow-up after this lands.
- **Q4** Discriminated union over Zod-drop (sixth recurrence of the auto-spec gap; design doc supersedes auto-spec).
- **Q5** `linkedIndexes: ['.strategy']` literal dropped; resolver auto-injects with stable name `'strategy'` regardless of physical source.
- **Q6** Bench scripts hard-fail on unresolved with actionable messages.

Full Phase-3 design doc lives in `.totem/specs/1710.md`.

## Surfaces touched

| Surface | File | Behavior |
| --- | --- | --- |
| Core resolver | `packages/core/src/strategy-resolver.ts` | New module + 22 unit tests |
| Config schema | `packages/core/src/config-schema.ts` | New optional `strategyRoot?: string` |
| MCP rich-state | `packages/mcp/src/state-extractors.ts` | Returns discriminated union |
| MCP rich-state schema | `packages/mcp/src/schemas/describe-project.ts` | `StrategyPointerSchema` discriminated union |
| MCP linkedIndexes init | `packages/mcp/src/context.ts` | Auto-inject strategy with stable `'strategy'` link name |
| CLI governance | `packages/cli/src/utils/governance.ts` | Resolver-based with actionable `TotemError` |
| CLI doctor | `packages/cli/src/commands/doctor.ts` | New `checkStrategyRoot` advisory |
| Bench scripts | `scripts/benchmark-compile.ts`, `scripts/bench-lance-open.ts` | Resolver-based; hard-fail on unresolved |
| Workspace config | `totem.config.ts` | `linkedIndexes: ['.strategy']` literal removed |
| Contributor docs | `CONTRIBUTING.md`, `docs/architecture.md` | New "Strategy repo expectations" section |

## Out of scope (follow-ups)

- `.gitmodules` and `.strategy` gitlink removal — separate PR after the resolver settles in production.
- Pack-distribution of strategy artifacts (Proposal 247 / 1.16.x territory).
- Lint-rule false positives surfaced during pre-push: filed as `mmnto-ai/totem#1741` (`os.tmpdir()` test false-positive) and `mmnto-ai/totem#1742` (`.git/hooks` rule's regex bugged at `Pattern: //`).

## Test plan

- [x] `pnpm test` — full workspace pass: core 1553, cli 1941, mcp 128.
- [x] New tests: 22 resolver (precedence, isDirectory guard, git-root anchoring, returned shape, alias / primary env, whitespace-only env, null gitRoot fallthrough), 5 schema (discriminated union + embedded `RichProjectStateSchema` parse), 4 governance (sibling-driven + env-driven path resolution + actionable error string assertions), 2 doctor (pass/warn paths).
- [x] `pnpm run format` clean.
- [x] `totem lint --staged` PASS (0 errors, warnings all in the `Pattern: //` false-positive family — see #1741 / #1742).
- [x] `totem review --staged` (Sonnet) PASS, no findings.
- [x] `totem verify-manifest` PASS, 449 rules.
- [ ] Smoke: `pnpm exec totem doctor` reports "Strategy Root: pass" against the live checkout.
- [ ] Smoke: `pnpm exec totem search "<query>" --boundary strategy` routes to the auto-injected strategy index.
- [ ] CR + GCA bot review on this PR.

## Migration notes for `@mmnto/mcp` consumers (minor bump)

Callers that opt into rich state via `describe_project({ includeRichState: true })` must check `richState.strategyPointer.resolved` before reading `sha` / `latestJournal`:

```typescript
// Before
const sha = response.richState?.strategyPointer.sha;

// After
const ptr = response.richState?.strategyPointer;
if (ptr?.resolved) {
  const sha = ptr.sha;
} else if (ptr) {
  console.warn(ptr.reason);
}
```

The legacy slim payload (no `richState`) is byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)