### PR TITLE
chore(changeset): downgrade #1710 @mmnto/mcp bump major → minor

### DIFF
--- a/.changeset/1710-strategy-root-consumers.md
+++ b/.changeset/1710-strategy-root-consumers.md
@@ -1,5 +1,5 @@
 ---
-'@mmnto/mcp': major
+'@mmnto/mcp': minor
 '@mmnto/cli': patch
 ---
 
@@ -11,12 +11,27 @@ gracefully when the strategy root is unresolvable.
 
 **`@mmnto/mcp`:**
 
-- **Breaking:** `describe_project` rich-state `strategyPointer` payload
-  flips from `{ sha, latestJournal }` to a discriminated union:
+- **Schema shape change (treated as minor — see rationale below):**
+  `describe_project` rich-state `strategyPointer` payload flips from
+  `{ sha, latestJournal }` to a discriminated union:
   `{ resolved: true, sha, latestJournal } | { resolved: false, reason }`.
   Agents that read the rich-state pointer must check `resolved` before
   reading `sha` / `latestJournal`. Only affects callers that opted in via
   `includeRichState: true` — the legacy slim payload is byte-identical.
+
+  **Rationale for minor (not major):** (a) success-path is additive —
+  the resolved branch preserves both `sha` and `latestJournal` fields;
+  the failure-path now structures what was previously a pair of `null`s
+  into a `{ resolved: false, reason }` envelope. (b) No known
+  programmatic JSON consumers — the field is consumed across the totem
+  ecosystem (mmnto-ai/totem, mmnto-ai/totem-strategy,
+  mmnto-ai/totem-playground) exclusively as agent-rendered text via
+  SessionStart hooks. (c) No queued cluster of breaking changes to ride
+  alongside in a 2.0.0 bundle. The deferred-breaking-changes ledger
+  (mmnto-ai/totem#1746) records this decision so the precedent stays
+  visible; when that ledger reaches 2-3 substantive items, that bundle
+  becomes 2.0.0.
+
 - **Auto-injected strategy linkedIndex.** `initContext` consults
   `resolveStrategyRoot` and prepends the resolved strategy path to the
   linkedIndexes iteration with a stable link name `'strategy'`. Boundary


### PR DESCRIPTION
## Summary

- Downgrade `@mmnto/mcp` from `major` to `minor` in `1710-strategy-root-consumers.md`
- Replaces stale Version Packages PR `mmnto-ai/totem#1745` (cut to 2.0.0)
- Filed `mmnto-ai/totem#1746` as the deferred-breaking-changes ledger (precedent-protection mechanism)

## Why

PR `mmnto-ai/totem#1743` shipped a discriminated-union shape change to `describe_project` rich-state `strategyPointer`. The R2 round set the bump to `major` on the strict-semver argument that any programmatic JSON consumer reading `strategyPointer.sha` directly would now need to check `.resolved` first. With `fixed-grouping` in changesets, that cascaded all four packages to 2.0.0 in `mmnto-ai/totem#1745`.

Reframing as `minor` because:

1. **Success path is additive.** The resolved branch preserves both `sha` and `latestJournal` fields. The failure path now structures what was previously a pair of nulls into a `{ resolved: false, reason }` envelope.
2. **No known programmatic JSON consumers.** Across the ecosystem (mmnto-ai/totem, mmnto-ai/totem-strategy, mmnto-ai/totem-playground), the field is consumed exclusively as agent-rendered text via SessionStart hooks — never as parsed JSON in user code.
3. **No queued cluster of breaking changes.** Shipping 2.0.0 alone for one schema flip would devalue the major signal.

The deferred-major ledger (`mmnto-ai/totem#1746`) records this wiggle so the precedent-protection cost stays visible. When the ledger reaches 2-3 substantive items, that bundle becomes 2.0.0.

## Effect

- Closes/replaces stale Version Packages PR `mmnto-ai/totem#1745` — the changesets bot will re-cut a fresh PR targeting **1.18.0** for all four packages once this lands on main.
- No code change. Just the bump-level edit + an in-body rationale note in the changeset.

## Test plan

- [x] `totem lint --staged` PASS
- [x] No code changes; CI build/test/lint paths unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)