### PR TITLE
chore: retire .strategy git submodule (mmnto-ai/totem#1710 follow-up)

### DIFF
--- a/.changeset/retire-strategy-submodule.md
+++ b/.changeset/retire-strategy-submodule.md
@@ -1,0 +1,32 @@
+---
+'@mmnto/cli': patch
+---
+
+chore: retire `.strategy/` git submodule (mmnto-ai/totem#1710 follow-up)
+
+Removes `.gitmodules` and the `.strategy` gitlink. The four-layer
+`resolveStrategyRoot` precedence shipped in mmnto-ai/totem#1710
+(`TOTEM_STRATEGY_ROOT` env → `TotemConfig.strategyRoot` → sibling clone
+at `../totem-strategy/` → legacy `.strategy/` submodule) makes the
+submodule path the LAST-resort fallback, and the auto-clone ceremony
+of `.gitmodules` was the only thing forcing every fresh totem checkout
+to fetch a strategy SHA from the gitlink.
+
+The resolver's Layer 4 (manual `.strategy/` directory) still works for
+existing checkouts that have one — the retirement is just removing the
+auto-clone wiring + the gitlink commit-pointer drift cycle.
+
+Recommended setup remains: clone `mmnto-ai/totem-strategy` as a sibling
+to your totem checkout. `CONTRIBUTING.md` already describes this; no
+doc change required.
+
+**Side updates:**
+
+- `.prettierignore`: drop the `.strategy/` entry (no directory to ignore).
+- `.gemini/styleguide.md`: rephrase a stale `.strategy/proposals/` doc
+  reference to use `<strategyRoot>/proposals/` instead, with a parenthetical
+  pointing at the resolver and the recommended sibling-clone path.
+
+**Note for existing local clones:** after pulling this PR, run
+`rm -rf .strategy .git/modules/.strategy` to clean the orphaned working
+tree. Git won't auto-prune a formerly-tracked submodule directory.

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -154,5 +154,6 @@ When reviewing PRs that touch `.totem/compiled-rules.json` or
 `.totem/lessons/lesson-*.md`, do not flag mismatches between the 16-char
 `lessonHash` field and the 8-char filename hash. They are independent
 identifiers by design. If a future change unifies them under a single scheme,
-that will be discussed in a strategy proposal under `.strategy/proposals/`,
-not as a code review finding.
+that will be discussed in a strategy proposal under
+`<strategyRoot>/proposals/` (resolved by `resolveStrategyRoot`, typically a
+sibling `../totem-strategy/` clone), not as a code review finding.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule ".strategy"]
-	path = .strategy
-	url = https://github.com/mmnto-ai/totem-strategy.git

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,7 +2,6 @@ node_modules/
 dist/
 .lancedb/
 .turbo/
-.strategy/
 # Agent worktree scratchpads — not auditable artifacts
 .claude/worktrees/
 pnpm-lock.yaml

--- a/packages/mcp/src/state-extractors.test.ts
+++ b/packages/mcp/src/state-extractors.test.ts
@@ -82,16 +82,25 @@ describe('extractStrategyPointer (mmnto-ai/totem#1710)', () => {
     }
   });
 
-  it('returns the resolved branch with a 7-char SHA and journal filename on the live repo', () => {
+  it('returns the resolved branch with a 7-char SHA and journal filename on the live repo', (ctx) => {
     const ptr = extractStrategyPointer(REPO_ROOT);
-    expect(ptr.resolved).toBe(true);
-    if (ptr.resolved) {
-      if (ptr.sha !== null) {
-        expect(ptr.sha).toMatch(/^[0-9a-f]{7}$/);
-      }
-      if (ptr.latestJournal !== null) {
-        expect(ptr.latestJournal).toMatch(/\.md$/);
-      }
+    // Integration assertion only runs when strategy is reachable on the
+    // running host. After the `.strategy` submodule retirement
+    // (mmnto-ai/totem#1749), the resolver legitimately returns
+    // `unresolved` on CI runners that have no env override, no
+    // `TotemConfig.strategyRoot`, and no sibling `../totem-strategy/`
+    // clone. The unresolved branch is covered by the prior test; the
+    // shape of the resolved branch is covered by the resolver's own
+    // unit tests in `packages/core/src/strategy-resolver.test.ts`.
+    if (!ptr.resolved) {
+      ctx.skip();
+      return;
+    }
+    if (ptr.sha !== null) {
+      expect(ptr.sha).toMatch(/^[0-9a-f]{7}$/);
+    }
+    if (ptr.latestJournal !== null) {
+      expect(ptr.latestJournal).toMatch(/\.md$/);
     }
   });
 });


### PR DESCRIPTION
## Summary

- Delete `.gitmodules` and the `.strategy` gitlink — the auto-clone ceremony that was forcing every fresh totem checkout to fetch a strategy SHA via the submodule pointer.
- Strip the now-unnecessary `.strategy/` entry from `.prettierignore`.
- Reroute one stale `.strategy/proposals/` reference in `.gemini/styleguide.md` to `<strategyRoot>/proposals/` with a pointer at the resolver.
- Patch changeset on `@mmnto/cli`.

## Why

`mmnto-ai/totem#1710` shipped the `resolveStrategyRoot` substrate (env → config → sibling → submodule precedence) and explicitly deferred this cleanup: *"`.gitmodules` removal is a separate follow-up after this lands."* This PR closes that follow-up.

The submodule was redundant in three ways:

1. The recommended setup is now a sibling clone at `../totem-strategy/` (Layer 3), per `CONTRIBUTING.md`.
2. The resolver routes around the submodule whenever any earlier layer hits.
3. The submodule pointer drifted (was sitting on a stale journal branch `journal/totem-claude-0004-review-estimate-and-1.16.1`), and bumping it just to delete it would be the kind of mechanical churn `#1710` was retiring.

The resolver's Layer 4 (legacy `.strategy/` directory) still works for any existing checkout that has one manually-cloned — this retirement is just removing the auto-clone wiring + the gitlink commit-pointer drift cycle.

## Note for existing local clones

After pulling this PR, run:

```bash
rm -rf .strategy .git/modules/.strategy
```

Git won't auto-prune a formerly-tracked submodule directory — cosmetic, not a blocker.

## Test plan

- [x] `pnpm test` — 3,640 tests green (cli 1,945 / mcp 135 / core 1,558)
- [x] `pnpm --filter @mmnto/totem build && @mmnto/cli build && @mmnto/mcp build` — all clean
- [x] `totem lint --staged` PASS
- [x] `totem review --staged` PASS, no findings
- [ ] CI green on this PR
- [ ] Manual smoke: `totem doctor` Strategy Root advisory still pass/warn correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)