### PR TITLE
feat(cli): totem spec default-write to .totem/specs/<topic>.md (mmnto-ai/totem#1555)

### DIFF
--- a/.changeset/1555-spec-default-write.md
+++ b/.changeset/1555-spec-default-write.md
@@ -1,0 +1,18 @@
+---
+'@mmnto/cli': minor
+---
+
+`totem spec` now writes to `.totem/specs/<topic>.md` by default (`mmnto-ai/totem#1555`). Closes a tier-1 silent contract gap with the `/preflight` skill, which expected the spec file to materialize automatically — 6+ confirmed occurrences in the wild before this fix (preflight on totem#1441, two LC dogfood sessions, three claude-0008/0009 totem sessions).
+
+**Behavior:**
+
+- **Default (single-input):** writes `<gitRoot>/.totem/specs/<stem>.md`, where `<stem>` is the issue number (for issue/URL/`owner/repo#NNN` invocations) or the sanitized free-form topic. Sanitization replaces any character outside `[a-zA-Z0-9_-]` with a single dash, collapses runs, and trims leading/trailing dashes — `totem spec "migration plan"` writes `.totem/specs/migration-plan.md`. Logs `Spec saved to <relative-path>` to stderr on success.
+- **`--out <path>`:** unchanged; writes to the exact path provided.
+- **`--stdout` (new):** opt back into the legacy stdout-only behavior for piping (`totem spec 123 --stdout | grep ...`). Mutually exclusive with `--out` — passing both fails with a `TotemConfigError` before any LLM call.
+- **Multi-input fallback:** when more than one input is passed and neither `--out` nor `--stdout` is set, the command falls back to stdout with a stderr hint suggesting `--out <path>`. Single-shot multi-input piping still works without surprise.
+- **Path traversal guard:** topic strings like `../../etc/passwd` sanitize to `etc-passwd`, so the resolved path stays under `<gitRoot>/.totem/specs/`.
+- **Monorepo safety:** path resolution uses `resolveGitRoot` from `@mmnto/totem`, so running `totem spec` from a sub-package writes to the repo-root specs directory, not a stray `packages/cli/.totem/specs/`.
+
+**Naming convention.** Argument pass-through is the only shape that survives both numeric and free-form invocations without a normalization layer — `totem spec 1682` → `.totem/specs/1682.md`, `totem spec my-topic` → `.totem/specs/my-topic.md`. Slug-derived filenames add a stale-slug failure mode when issues get renamed; numeric-only would break free-form topics.
+
+**Migration.** The default behavior change is a bug-fix-with-additive-escape-hatch (precedent: `mmnto-ai/totem#1747` discriminated-union shape change). Stdout-piping consumers add `--stdout`; preflight-skill consumers gain the file write they always expected.

--- a/.totem/specs/1555.md
+++ b/.totem/specs/1555.md
@@ -1,0 +1,104 @@
+### Problem Statement
+
+The `totem spec <topic>` command currently outputs generated specifications to `stdout` by default, breaking automated preflight workflows that expect the file to automatically land in `.totem/specs/<topic>.md`. The command needs to default to saving to this disk location based on the Git repository root, introduce a `--stdout` flag for the legacy piping behavior, and log a success message to `stderr` when saving to disk.
+
+### Architectural Context
+
+- **Workflow Automation / Preflight Skill Gap**: Documented in the provided Totem Knowledge, AI agents (Claude) rely on the `/preflight <issue>` skill which explicitly expects `.totem/specs/<issue-number>.md` to exist after running `totem spec`. Failing to persist this file costs ~60s LLM round trips and breaks downstream phases.
+
+### Files to Examine
+
+1. `packages/cli/src/commands/spec.ts` — Contains `specCommand` and likely the `SpecOptions` interface. This is where the core output logic must be refactored.
+2. `packages/cli/src/index.ts` (or equivalent CLI router) — Where the `--stdout` flag needs to be registered for the commander/yargs CLI definition.
+3. `packages/cli/tests/commands/spec.test.ts` (or equivalent test file) — To add testing for the new default file output behavior and conflicting flag rejection.
+
+### Technical Approach & Contracts
+
+**Design Decision (Naming Convention):** Standardize strictly on `<sanitized-topic>.md`. Whatever the user passes as the topic (`1555`, `ticket-004`, or `login-bug`), sanitize it by replacing non-alphanumeric characters (excluding dashes/underscores) with dashes, and append `.md`. This requires zero inference and safely supports all observed workflows (issue numbers and slugs).
+
+**Contracts:**
+
+1. Update `SpecOptions` interface (likely in `packages/cli/src/commands/spec.ts` or a shared types file):
+
+```typescript
+export interface SpecOptions {
+  out?: string;
+  stdout?: boolean; // NEW: true to force stdout piping
+  // ... existing options
+}
+```
+
+**Sequence Logic:**
+
+1. Validate options: If `options.stdout` AND `options.out` are both truthy, throw an error.
+2. Generate the spec content via the existing embedding/LLM flow.
+3. Determine output destination:
+   - If `options.stdout === true`: write to `process.stdout.write(...)`.
+   - If `options.out` exists: use that exact path.
+   - Else (Default):
+     - Call shared helper `resolveGitRoot(process.cwd())`. Fallback to `process.cwd()` if `null`.
+     - Sanitize `inputs[0]` (the topic): `topic.replace(/[^a-zA-Z0-9-_]/g, '-')`.
+     - Target path = `path.join(gitRoot, '.totem', 'specs', `${sanitizedTopic}.md`)`.
+4. Disk Writing:
+   - Ensure directory exists: `fs.mkdirSync(path.dirname(targetPath), { recursive: true })`.
+   - Write file: `fs.writeFileSync(targetPath, content)`.
+   - Print status to stderr via existing UI helper: `log.success(\`Spec saved to ${path.relative(process.cwd(), targetPath)}\`)`.
+
+### Edge Cases & Traps
+
+- **Trap (Working Directory Context):** If a developer runs `totem spec` from deep within a monorepo (`e.g., packages/core`), writing to `./.totem/specs/` will create an orphaned specs folder. You MUST resolve the Git root first to ensure specs consolidate at `<repo-root>/.totem/specs/`.
+- **Trap (Conflicting Flags):** Providing both `--out custom.md` and `--stdout` makes no sense and indicates user confusion. This must be a hard error before making LLM calls.
+- **Trap (Path Traversal via Topic):** A user typing `totem spec ../../../etc/passwd` or `totem spec foo/bar` could traverse out of the `.totem/specs` directory or create accidental nested structures. Strict sanitization of the topic string is required.
+- **Trap (Missing `.totem/specs` directory):** The `.totem/specs` folder might not exist on fresh clones. `fs.mkdirSync` with `{ recursive: true }` is mandatory.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Add CLI Flags & Validation Logic**
+  - Update the CLI entry point (where `totem spec` flags are defined) to accept the `--stdout` boolean flag.
+  - Update `SpecOptions` interface to include `stdout?: boolean`.
+  - In `specCommand` (`packages/cli/src/commands/spec.ts`), immediately validate that `options.stdout` and `options.out` are not used together. Throw a user-friendly error if they are.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `rejects simultaneous use of --stdout and --out flags` in the spec command test file that proves this validation works before any LLM calls are made.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Path Resolution and Topic Sanitization**
+  - In `specCommand`, implement the output path resolution.
+  - Import and use the shared helper `resolveGitRoot`.
+  - Create a sanitizer function for the topic parameter that replaces any character other than `a-z`, `A-Z`, `0-9`, `-`, and `_` with a hyphen (`-`).
+  - Calculate the default target path: `${gitRoot || process.cwd()}/.totem/specs/${sanitizedTopic}.md`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `resolves default save path based on git root and sanitizes topic` testing the pure path resolution logic (mocking `process.cwd` and `resolveGitRoot` if necessary).
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Implement Output Routing and Disk Writing**
+  - In `specCommand`, modify the final output step.
+  - If `options.stdout` is true, write to `stdout` (current behavior).
+  - Otherwise, create the directory using `fs.mkdirSync(..., { recursive: true })` and write the spec using `fs.writeFileSync`.
+  - After saving to disk, use the `log` helper (imported from `../ui.js`) to output a success message to `stderr` containing the relative path from `process.cwd()` to the written file.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `writes spec to disk and logs to stderr by default` that verifies `fs.writeFileSync` is called with the correct path, and `process.stdout.write` is NOT called when no output flags are provided.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Conflicting Flags:** Execute `totem spec 123 --out custom.md --stdout`. Expect immediate CLI error with zero LLM API calls.
+- **Default Behavior:** Execute `totem spec "ticket/123!"`. Expect `.totem/specs/ticket-123-.md` to be created. Expect `stderr` to contain "Spec saved to ...". Expect `stdout` to be empty.
+- **Subdirectory Execution:** cd into `packages/cli` and run `totem spec 999`. Expect the file to be created at `<repo-root>/.totem/specs/999.md`, NOT `packages/cli/.totem/specs/999.md`.
+- **Legacy stdout pipe:** Execute `totem spec 123 --stdout`. Expect the spec markdown to print purely to `stdout` (meaning it can be safely piped like `totem spec 123 --stdout | grep ...`) with no `stderr` success logs breaking the pipe.

--- a/packages/cli/src/commands/spec.test.ts
+++ b/packages/cli/src/commands/spec.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import type { LanceStore, SearchResult } from '@mmnto/totem';
+import { type LanceStore, type SearchResult, TotemConfigError } from '@mmnto/totem';
 
+import type { StandardIssue } from '../adapters/issue-adapter.js';
 import { log } from '../ui.js';
 import type { RetrievedContext } from './spec.js';
 import {
@@ -9,8 +10,11 @@ import {
   expandSpecQuery,
   MAX_LESSON_CHARS,
   MAX_LESSONS,
+  resolveDefaultSpecPath,
   retrieveContext,
+  sanitizeSpecFilename,
   SPEC_SYSTEM_PROMPT,
+  validateOutputOptions,
 } from './spec.js';
 
 // ─── Helpers ─────────────────────────────────────────────
@@ -326,5 +330,157 @@ describe('expandSpecQuery', () => {
     expect(expandSpecQuery('add verification step')).toContain('rule-tester');
     expect(expandSpecQuery('load fixtures from disk')).toContain('rule-tester');
     expect(expandSpecQuery('provide examples for docs')).toContain('rule-tester');
+  });
+});
+
+// ─── validateOutputOptions (mmnto-ai/totem#1555) ─────────
+
+describe('validateOutputOptions', () => {
+  it('rejects simultaneous use of --stdout and --out flags', () => {
+    expect(() =>
+      validateOutputOptions({ out: 'file.md', stdout: true }, TotemConfigError),
+    ).toThrowError(/--stdout and --out cannot be used together/);
+  });
+
+  it('throws a TotemConfigError with CONFIG_INVALID code', () => {
+    expect(() =>
+      validateOutputOptions({ out: 'file.md', stdout: true }, TotemConfigError),
+    ).toThrowError(TotemConfigError);
+    let thrown: unknown;
+    try {
+      validateOutputOptions({ out: 'file.md', stdout: true }, TotemConfigError);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toMatchObject({ code: 'CONFIG_INVALID' });
+  });
+
+  it('accepts --out alone', () => {
+    expect(() => validateOutputOptions({ out: 'file.md' }, TotemConfigError)).not.toThrow();
+  });
+
+  it('accepts --stdout alone', () => {
+    expect(() => validateOutputOptions({ stdout: true }, TotemConfigError)).not.toThrow();
+  });
+
+  it('accepts neither flag set', () => {
+    expect(() => validateOutputOptions({}, TotemConfigError)).not.toThrow();
+  });
+});
+
+// ─── sanitizeSpecFilename ────────────────────────────────
+
+describe('sanitizeSpecFilename', () => {
+  it('passes alphanumeric inputs through unchanged', () => {
+    expect(sanitizeSpecFilename('1555')).toBe('1555');
+    expect(sanitizeSpecFilename('my-topic')).toBe('my-topic');
+    expect(sanitizeSpecFilename('migration_plan')).toBe('migration_plan');
+  });
+
+  it('replaces unsafe characters with dashes', () => {
+    expect(sanitizeSpecFilename('foo/bar')).toBe('foo-bar');
+    expect(sanitizeSpecFilename('hello world')).toBe('hello-world');
+    expect(sanitizeSpecFilename('a.b.c')).toBe('a-b-c');
+  });
+
+  it('blocks path traversal attempts', () => {
+    expect(sanitizeSpecFilename('../../etc/passwd')).toBe('etc-passwd');
+    expect(sanitizeSpecFilename('..\\windows\\system32')).toBe('windows-system32');
+  });
+
+  it('collapses runs of unsafe characters into a single dash', () => {
+    expect(sanitizeSpecFilename('a///b')).toBe('a-b');
+    expect(sanitizeSpecFilename('a   b')).toBe('a-b');
+  });
+
+  it('trims leading and trailing dashes', () => {
+    expect(sanitizeSpecFilename('---foo---')).toBe('foo');
+    expect(sanitizeSpecFilename('//path//')).toBe('path');
+  });
+
+  it('returns empty string for inputs that sanitize to nothing', () => {
+    expect(sanitizeSpecFilename('!!!')).toBe('');
+    expect(sanitizeSpecFilename('   ')).toBe('');
+  });
+});
+
+// ─── resolveDefaultSpecPath ──────────────────────────────
+
+function makeIssue(number: number): StandardIssue {
+  return {
+    number,
+    title: `Issue #${number}`,
+    body: 'body',
+    state: 'open',
+    labels: [],
+  };
+}
+
+describe('resolveDefaultSpecPath', () => {
+  const deps = {
+    resolveGitRoot: vi.fn(() => '/repo'),
+    pathJoin: (...parts: string[]) => parts.join('/'),
+  };
+
+  it('resolves single issue input to <gitRoot>/.totem/specs/<number>.md', () => {
+    const result = resolveDefaultSpecPath(
+      [{ issue: makeIssue(1555), freeText: null }],
+      '/repo/packages/cli',
+      deps,
+    );
+    expect(result).toBe('/repo/.totem/specs/1555.md');
+  });
+
+  it('resolves single free-text input to sanitized filename', () => {
+    const result = resolveDefaultSpecPath(
+      [{ issue: null, freeText: 'migration plan' }],
+      '/repo',
+      deps,
+    );
+    expect(result).toBe('/repo/.totem/specs/migration-plan.md');
+  });
+
+  it('falls back to cwd when git root is unavailable', () => {
+    const fallbackDeps = {
+      resolveGitRoot: vi.fn(() => null),
+      pathJoin: (...parts: string[]) => parts.join('/'),
+    };
+    const result = resolveDefaultSpecPath(
+      [{ issue: makeIssue(42), freeText: null }],
+      '/some/cwd',
+      fallbackDeps,
+    );
+    expect(result).toBe('/some/cwd/.totem/specs/42.md');
+  });
+
+  it('returns null for multi-input invocations', () => {
+    const result = resolveDefaultSpecPath(
+      [
+        { issue: makeIssue(1), freeText: null },
+        { issue: makeIssue(2), freeText: null },
+      ],
+      '/repo',
+      deps,
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null when free text sanitizes to empty', () => {
+    const result = resolveDefaultSpecPath([{ issue: null, freeText: '!!!' }], '/repo', deps);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when single input has neither issue nor free text', () => {
+    const result = resolveDefaultSpecPath([{ issue: null, freeText: null }], '/repo', deps);
+    expect(result).toBeNull();
+  });
+
+  it('uses git root over cwd for monorepo subpackages', () => {
+    const result = resolveDefaultSpecPath(
+      [{ issue: makeIssue(99), freeText: null }],
+      '/repo/packages/cli/src',
+      deps,
+    );
+    expect(result).toBe('/repo/.totem/specs/99.md');
   });
 });

--- a/packages/cli/src/commands/spec.ts
+++ b/packages/cli/src/commands/spec.ts
@@ -388,7 +388,7 @@ export async function specCommand(inputs: string[], options: SpecOptions): Promi
   });
   if (defaultPath) {
     writeOutput(content, defaultPath);
-    log.success(TAG, `Spec saved to ${path.relative(cwd, defaultPath)}`);
+    log.success(TAG, `Spec saved to ${sanitizeForTerminal(path.relative(cwd, defaultPath))}`);
   } else {
     log.dim(TAG, 'No default save path — writing to stdout. Use --out <path> to save.');
     writeOutput(content);

--- a/packages/cli/src/commands/spec.ts
+++ b/packages/cli/src/commands/spec.ts
@@ -237,6 +237,7 @@ export async function specCommand(inputs: string[], options: SpecOptions): Promi
     createEmbedder,
     LanceStore: LanceStoreImpl,
     resolveGitRoot,
+    sanitizeForTerminal,
     TotemConfigError,
   } = await import('@mmnto/totem');
   const { log } = await import('../ui.js');
@@ -378,7 +379,7 @@ export async function specCommand(inputs: string[], options: SpecOptions): Promi
   }
   if (options.out) {
     writeOutput(content, options.out);
-    log.success(TAG, `Written to ${options.out}`);
+    log.success(TAG, `Written to ${sanitizeForTerminal(options.out)}`);
     return;
   }
   const defaultPath = resolveDefaultSpecPath(parsed, cwd, {
@@ -389,7 +390,7 @@ export async function specCommand(inputs: string[], options: SpecOptions): Promi
     writeOutput(content, defaultPath);
     log.success(TAG, `Spec saved to ${path.relative(cwd, defaultPath)}`);
   } else {
-    log.dim(TAG, 'Multi-input — writing to stdout. Use --out <path> to save.');
+    log.dim(TAG, 'No default save path — writing to stdout. Use --out <path> to save.');
     writeOutput(content);
   }
 }

--- a/packages/cli/src/commands/spec.ts
+++ b/packages/cli/src/commands/spec.ts
@@ -379,7 +379,8 @@ export async function specCommand(inputs: string[], options: SpecOptions): Promi
   }
   if (options.out) {
     writeOutput(content, options.out);
-    log.success(TAG, `Written to ${sanitizeForTerminal(options.out)}`);
+    const safeOut = sanitizeForTerminal(options.out).replace(/[\n\t]+/g, ' ');
+    log.success(TAG, `Written to ${safeOut}`);
     return;
   }
   const defaultPath = resolveDefaultSpecPath(parsed, cwd, {
@@ -388,7 +389,11 @@ export async function specCommand(inputs: string[], options: SpecOptions): Promi
   });
   if (defaultPath) {
     writeOutput(content, defaultPath);
-    log.success(TAG, `Spec saved to ${sanitizeForTerminal(path.relative(cwd, defaultPath))}`);
+    const safeRelativePath = sanitizeForTerminal(path.relative(cwd, defaultPath)).replace(
+      /[\n\t]+/g,
+      ' ',
+    );
+    log.success(TAG, `Spec saved to ${safeRelativePath}`);
   } else {
     log.dim(TAG, 'No default save path — writing to stdout. Use --out <path> to save.');
     writeOutput(content);

--- a/packages/cli/src/commands/spec.ts
+++ b/packages/cli/src/commands/spec.ts
@@ -1,4 +1,9 @@
-import type { ContentType, LanceStore, SearchResult } from '@mmnto/totem';
+import type {
+  ContentType,
+  LanceStore,
+  SearchResult,
+  TotemConfigError as TotemConfigErrorClass,
+} from '@mmnto/totem';
 
 import type { StandardIssue } from '../adapters/issue-adapter.js';
 import { SYSTEM_PROMPT } from './spec-templates.js';
@@ -99,7 +104,7 @@ export function expandSpecQuery(query: string): string {
 
 // ─── Input types ────────────────────────────────────────
 
-interface ParsedInput {
+export interface ParsedInput {
   issue: StandardIssue | null;
   freeText: string | null;
 }
@@ -157,20 +162,81 @@ export async function assemblePrompt(
   return sections.join('\n');
 }
 
-// ─── Main command ───────────────────────────────────────
+// ─── Output routing (mmnto-ai/totem#1555) ──────────────
 
 export interface SpecOptions {
   raw?: boolean;
   out?: string;
+  stdout?: boolean;
   model?: string;
   fresh?: boolean;
 }
+
+/**
+ * mmnto-ai/totem#1555: validate that --stdout and --out are not used together.
+ * Run before any LLM call so a user-error surfaces in <50ms with no API cost.
+ */
+export function validateOutputOptions(
+  options: Pick<SpecOptions, 'out' | 'stdout'>,
+  TotemConfigErrorCtor: typeof TotemConfigErrorClass,
+): void {
+  if (options.stdout && options.out) {
+    throw new TotemConfigErrorCtor(
+      '--stdout and --out cannot be used together.',
+      'Pick one: --out <path> writes to a specific file; --stdout writes to standard output.',
+      'CONFIG_INVALID',
+    );
+  }
+}
+
+/**
+ * Sanitize a free-form topic string for use as a filename stem. Replaces any
+ * character outside `[a-zA-Z0-9_-]` with a single dash, collapses runs, and
+ * trims leading/trailing dashes. Returns `''` for inputs that sanitize to
+ * nothing — caller decides the fallback.
+ */
+export function sanitizeSpecFilename(input: string): string {
+  return input.replace(/[^a-zA-Z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
+}
+
+export interface ResolveSpecPathDeps {
+  resolveGitRoot: (cwd: string) => string | null;
+  pathJoin: (...parts: string[]) => string;
+}
+
+/**
+ * Derive the default spec output path under `<gitRoot>/.totem/specs/<stem>.md`.
+ * Returns `null` for ambiguous cases (multi-input, empty topic) — the caller
+ * falls back to stdout with a hint.
+ */
+export function resolveDefaultSpecPath(
+  parsedInputs: ParsedInput[],
+  cwd: string,
+  deps: ResolveSpecPathDeps,
+): string | null {
+  if (parsedInputs.length !== 1) return null;
+  const first = parsedInputs[0]!;
+  let stem: string;
+  if (first.issue) {
+    stem = String(first.issue.number);
+  } else if (first.freeText) {
+    stem = sanitizeSpecFilename(first.freeText);
+    if (!stem) return null;
+  } else {
+    return null;
+  }
+  const root = deps.resolveGitRoot(cwd) ?? cwd;
+  return deps.pathJoin(root, '.totem', 'specs', `${stem}.md`);
+}
+
+// ─── Main command ───────────────────────────────────────
 
 export async function specCommand(inputs: string[], options: SpecOptions): Promise<void> {
   const path = await import('node:path');
   const {
     createEmbedder,
     LanceStore: LanceStoreImpl,
+    resolveGitRoot,
     TotemConfigError,
   } = await import('@mmnto/totem');
   const { log } = await import('../ui.js');
@@ -183,6 +249,8 @@ export async function specCommand(inputs: string[], options: SpecOptions): Promi
     runOrchestrator,
     writeOutput,
   } = await import('../utils.js');
+
+  validateOutputOptions(options, TotemConfigError);
 
   const unique = [...new Set(inputs)];
   if (unique.length > MAX_INPUTS) {
@@ -302,8 +370,26 @@ export async function specCommand(inputs: string[], options: SpecOptions): Promi
   log.dim(TAG, `Prompt: ${(prompt.length / 1024).toFixed(0)}KB`);
 
   const content = await runOrchestrator({ prompt, tag: TAG, options, config, cwd, totalResults });
-  if (content != null) {
+  if (content == null) return;
+
+  if (options.stdout) {
+    writeOutput(content);
+    return;
+  }
+  if (options.out) {
     writeOutput(content, options.out);
-    if (options.out) log.success(TAG, `Written to ${options.out}`);
+    log.success(TAG, `Written to ${options.out}`);
+    return;
+  }
+  const defaultPath = resolveDefaultSpecPath(parsed, cwd, {
+    resolveGitRoot,
+    pathJoin: path.join,
+  });
+  if (defaultPath) {
+    writeOutput(content, defaultPath);
+    log.success(TAG, `Spec saved to ${path.relative(cwd, defaultPath)}`);
+  } else {
+    log.dim(TAG, 'Multi-input — writing to stdout. Use --out <path> to save.');
+    writeOutput(content);
   }
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -216,13 +216,20 @@ program
   .command('spec <inputs...>')
   .description('Generate a pre-work spec briefing for GitHub issue(s) or topic(s)')
   .option('--raw', 'Output retrieved context without LLM synthesis')
-  .option('--out <path>', 'Write output to a file instead of stdout')
+  .option(
+    '--out <path>',
+    'Write output to a specific file (overrides default .totem/specs/<topic>.md)',
+  )
+  .option(
+    '--stdout',
+    'Print to stdout instead of saving to .totem/specs/<topic>.md (mutually exclusive with --out)',
+  )
   .option('--model <name>', 'Override the default model for the orchestrator')
   .option('--fresh', 'Bypass cache and force a fresh LLM call (ignores cached responses)')
   .action(
     async (
       inputs: string[],
-      opts: { raw?: boolean; out?: string; model?: string; fresh?: boolean },
+      opts: { raw?: boolean; out?: string; stdout?: boolean; model?: string; fresh?: boolean },
     ) => {
       try {
         const { specCommand } = await import('./commands/spec.js');


### PR DESCRIPTION
## Summary

Closes the tier-1 silent contract gap between `totem spec` and the `/preflight` skill ([`mmnto-ai/totem#1555`](https://github.com/mmnto-ai/totem/issues/1555)). 6+ confirmed occurrences before this fix (2 LC sessions + totem#1441 in the original ticket body, plus #1744 / #1752 / #1682 from the last three claude sessions).

- **Default behavior (single-input):** writes `<gitRoot>/.totem/specs/<stem>.md`, where `<stem>` is the issue number (issue/URL/`owner/repo#NNN` forms) or sanitized free-form topic. Sanitization replaces any character outside `[a-zA-Z0-9_-]` with a single dash, collapses runs, trims leading/trailing dashes. Path traversal attempts (`../../etc/passwd` → `etc-passwd`) stay under the specs directory. Logs `Spec saved to <relative>` to stderr.
- **`--stdout` (new):** opt back into the legacy stdout-only behavior for piping (`totem spec 123 --stdout | grep ...`). Mutually exclusive with `--out`; passing both fails with a `TotemConfigError` before any LLM call.
- **Multi-input fallback:** falls back to stdout with a stderr hint. Single-shot multi-input piping continues working without surprise.
- **Monorepo safety:** uses `resolveGitRoot` from `@mmnto/totem` so a sub-package invocation lands in the repo-root specs directory.

Three pure exported helpers (`validateOutputOptions`, `sanitizeSpecFilename`, `resolveDefaultSpecPath`) carry the new logic with 21 dedicated tests.

## Naming convention

Argument pass-through. `totem spec 1682` → `.totem/specs/1682.md`; `totem spec my-topic` → `.totem/specs/my-topic.md`. Slug-derived filenames add a stale-slug failure mode for renamed issues; numeric-only would break free-form topics. Pass-through is the only shape that survives both invocation forms without a normalization layer. Documented in the [`#1555` comment thread](https://github.com/mmnto-ai/totem/issues/1555#issuecomment-4355006196).

## Migration

Bug-fix-with-additive-escape-hatch (precedent: `mmnto-ai/totem#1747` discriminated-union shape change). Stdout-piping consumers add `--stdout`; preflight-skill consumers gain the file write they always expected. Minor bump on `@mmnto/cli`.

## Bot-review tail

Sonnet pre-push flagged a CRITICAL false positive: *"`resolveGitRoot` is incorrectly imported from `@mmnto/totem`; it is actually located in `../utils.js`."* Verified false: grep returns zero matches in `packages/cli/src/utils.ts`, the export is at `packages/core/src/index.ts:388`, and a runtime probe (`node --input-type=module -e "import('@mmnto/totem')..."` from `packages/cli/`) returns `function | result: D:\Dev\totem`. Override applied with citation defense logged to trap ledger.

Re-review surfaced a CRITICAL ENOENT-on-missing-`.totem/specs/` claim; also false — `writeOutput` already calls `fs.mkdirSync(dir, { recursive: true })` (`packages/cli/src/utils.ts:251-254`).

## Test plan

- [x] `pnpm --filter @mmnto/cli test` — 1958/1958 pass (24 existing spec tests + 21 new).
- [x] `pnpm --filter @mmnto/cli build` — clean.
- [x] Smoke: `pnpm exec totem spec 1 --stdout --out foo.md` → `[Totem Error] --stdout and --out cannot be used together.` (validation rejects before LLM call).
- [x] `pnpm exec totem lint` — PASS (5 warnings, all false positives on regex matches).
- [x] `pnpm run format` — clean.
- [ ] CR + GCA review on this PR.
- [ ] Manual smoke after merge: run `pnpm exec totem spec 1555` from a totem checkout, verify `.totem/specs/1555.md` materializes (this PR's own spec file already verifies the explicit `--out` path).

Closes #1555