### PR TITLE
feat(core+cli): ADR-097 §10 Pack v0.1 substrate bundle (mmnto-ai/totem#1768)

### DIFF
--- a/.changeset/1768-pack-substrate-bundle.md
+++ b/.changeset/1768-pack-substrate-bundle.md
@@ -1,0 +1,73 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+---
+
+ADR-097 § 10 Pack v0.1 substrate bundle (`mmnto-ai/totem#1768`). Bundles three substrate features that gate the Pack v0.1 alpha ship per ADR-097 § 6 Stage 1. PR-B (`@totem/pack-rust-architecture` lift) hard-blocks on this PR.
+
+**`mmnto-ai/totem#1768` — Pack discovery substrate.** New `packages/core/src/pack-discovery.ts` reads `.totem/installed-packs.json` synchronously at engine boot, runs each pack's registration callback with a `PackRegistrationAPI`, then seals both downstream registries before any chunker / language lookup happens. Per ADR-097 § 5 Q5 the boot path MUST be synchronous and MUST NOT walk `node_modules` dynamically.
+
+**Public API additions (exported from `@mmnto/totem`):**
+
+- `loadInstalledPacks(options?: LoadInstalledPacksOptions): readonly LoadedPack[]` — boot-time entry point. CLI commands invoke this immediately after config load. Idempotent only for the first call; second call after seal throws.
+- `loadedPacks(): readonly LoadedPack[]` — runtime snapshot of resolved packs.
+- `isEngineSealed(): boolean` — true after `loadInstalledPacks` returns.
+- `InstalledPacksManifestSchema` — Zod schema for `.totem/installed-packs.json`. Strict (`.passthrough()` rejected); unknown sibling keys fail loud.
+- `PackRegistrationAPI` interface — `registerChunkStrategy(name, ctor)` + `registerLanguage(extension, lang, wasmLoader)` are the two callback surfaces.
+- `PackRegisterCallback` type — synchronous `(api: PackRegistrationAPI) => void` per ADR-097 Q5.
+- `LoadedPack`, `LoadInstalledPacksOptions`, `InstalledPacksManifest` types.
+
+**`mmnto-ai/totem#1769` — ChunkStrategy registry extensibility.** New `packages/core/src/chunkers/chunker-registry.ts` replaces the closed `CHUNKER_MAP` keyed by the closed `ChunkStrategy` Zod enum. Built-in chunkers self-register at module load; pack callbacks add new strategies via `registerChunkStrategy`. The registry rejects:
+
+- Re-registration of the same strategy name (pack-vs-pack collision).
+- Registration of a built-in name (built-ins immutable).
+- Any registration after seal.
+
+`ChunkStrategySchema` migrates from `z.enum([...])` to `z.string().refine()` against the registry. The error message lists the registered set so misconfigured strategy names are diagnosable. `ChunkStrategy` type alias keeps the literal union of built-in names + adds `(string & {})` so IntelliSense survives in core code paths while pack-contributed strategies type-check.
+
+This supersedes `mmnto-ai/totem#1537` (which proposed adding `'rust-ast'` directly to the closed enum) — close `#1537` once PR-B (`@totem/pack-rust-architecture`) lands and registers `'rust-ast'` via the pack-side callback.
+
+**`mmnto-ai/totem#1653` — ast-grep `Lang` registration substrate (registry-backed reframe).** `packages/core/src/ast-classifier.ts` `extensionToLanguage` migrates from a hardcoded `switch` to a `Map`-backed registry. Built-in extensions (`.ts/.tsx/.jsx/.js/.mjs/.cjs`) self-register at module load; pack callbacks add new (extension, SupportedLanguage, wasmLoader) triples. `loadGrammar(lang)` consults the registry for the WASM loader thunk and memoizes the resolved grammar.
+
+`SupportedLanguage` type alias widens to `'typescript' | 'tsx' | 'javascript' | (string & {})` per the ADR-097 § 10 Q1 disposition: built-ins keep IntelliSense, pack-contributed languages flow through as registered strings.
+
+**Behavior change (mmnto-ai/totem#1653 fail-loud):** `applyAstRulesToAdditions` (`packages/core/src/rule-engine.ts:392`) previously silently skipped any file whose extension wasn't in the hardcoded mapping. The silent skip masked rules scoped to unmapped extensions — a `.rs` rule in LC's compiled-rules.json never fired with no signal. The fix is surgical: skip files only when NO rule's `fileGlobs` matches them (no rule cares → silent skip is correct); throw when a rule expected to run but the language isn't registered. Migration: install the pack that provides the language (e.g., `@totem/pack-rust-architecture` once PR-B lands), or correct the rule's `fileGlobs`.
+
+**`mmnto-ai/totem#1654` — compile-pipeline `Lang.Tsx` hardcode (partial fix, ride-along).** `packages/core/src/ast-grep-query.ts` `extensionToLang` migrates to consult the registry. Built-in mappings preserve napi `Lang` enum values (`Lang.TypeScript`, `Lang.Tsx`, `Lang.JavaScript`); pack-contributed languages flow through as their `SupportedLanguage` string per `@ast-grep/napi`'s `NapiLang = Lang | (string & {})` type.
+
+The second `#1654` call site (`packages/core/src/compile-lesson.ts:319` empty-root pattern validator) keeps `Lang.Tsx` for now as the lingua-franca syntactic-shape validator. Migrating that path requires per-rule language detection at validation time; deferred to a sibling PR. The registry shape proven end-to-end via the `extensionToLang` migration is sufficient to demonstrate non-TS rule dispatch.
+
+**Schema deltas:**
+
+- `TotemConfigSchema` gains optional `extends: z.array(z.string().min(1))` — formal validation of the pack-extends mechanism that `totem install` already wrote text-only. Pack-merge logic (`packages/core/src/pack-merge.ts`) reads pack rules; pack discovery (`packages/core/src/pack-discovery.ts`) reads this field plus `package.json` deps and writes the union to `.totem/installed-packs.json`.
+- `ChunkStrategySchema` migrates from `z.enum` to `z.string().refine(name => CHUNKER_REGISTRY.has(name), ...)`. Backward compatible at the type level: `ChunkStrategy` keeps the literal union of built-in names with `(string & {})` extension; runtime validation defers to the registry. Old data written before pack registration (all built-ins) parses cleanly.
+
+**`totem sync` integration:**
+
+`syncCommand` now writes `.totem/installed-packs.json` after the standard sync flow. The manifest payload is the deduplicated union of `package.json` `@totem/pack-*` deps and `totem.config.ts` `extends` entries (Q4 disposition). Mismatch surfaces emit per-pack warnings:
+
+- `dep-only`: pack in `package.json` but not in `extends` — pack-merge would never consume it. Skip with warning.
+- `extends-only`: pack in `extends` but not installed — engine cannot load it. Skip with warning.
+- `not-a-pack`: resolvable package without `peerDependencies['@mmnto/totem']` — doesn't follow the pack contract. Skip with warning.
+
+Resolved entries flow through to a strict-schema-validated manifest. Atomic write via temp file + rename mirrors `writeReviewExtensionsFile` (`mmnto-ai/totem#1527`).
+
+**`peerDependencies['@mmnto/totem']` engine version cross-check:** at boot, every pack's declared range is checked against the running engine version via `semver.satisfies` (per ADR-097 Q6). Mismatch produces a structured error: `"Pack '<name>' requires @mmnto/totem '<range>' but the running engine is <version>"`. Invalid range strings fail loud separately.
+
+**Test additions (50 new tests across 3 new test files):**
+
+- `packages/core/src/chunkers/chunker-registry.test.ts` (11 tests) — built-in registration, pack-style registration, conflict detection, seal contract.
+- `packages/core/src/pack-discovery.test.ts` (13 tests) — manifest read paths (missing / malformed / schema-invalid / unknown sibling keys), peerDeps mismatch (range fail / valid range pass / invalid range), re-load after seal, callback execution + registration, two-packs collision detection.
+- `packages/core/src/pack-manifest-writer.test.ts` (9 tests) — Q4 deduplication semantics, warning emission, atomic write, schema validity.
+- `packages/core/src/ast-classifier.test.ts` (extended +14 tests) — language registry built-ins, pack-style language registration, seal contract.
+- `packages/core/src/rule-engine.test.ts` (extended +3 tests) — `mmnto-ai/totem#1653` fail-loud behavior change: throws when rule scopes to unmapped extension; silent-skip preserved when no rule cares; unscoped rules don't trigger fail-loud.
+
+**Dependencies:**
+
+- `semver: ^7.7.0` added to `@mmnto/totem` dependencies for the engine version cross-check (per ADR-097 Q6). `@types/semver` to devDependencies.
+
+**PR cascade:**
+
+- This PR (PR-A) ships the substrate.
+- PR-B (`@totem/pack-rust-architecture` lift from `audits/internal/2026-04-30-pack-v0.1-draft/` to `packages/pack-rust-architecture/`) hard-blocks on this PR. PR-B authors the registration callback, ships `tree-sitter-rust.wasm`, and registers `'rust-ast'` ChunkStrategy + `.rs → 'rust'` Lang.
+- PR-C (LC adoption) follows post-PR-B.

--- a/.totem/specs/pack-substrate-bundle.md
+++ b/.totem/specs/pack-substrate-bundle.md
@@ -1,0 +1,212 @@
+# PR-A: ADR-097 §10 Pack v0.1 Substrate Bundle
+
+Bundled implementation of the three ADR-097 §10 enabling substrate features. Covers `mmnto-ai/totem#1768` (Pack discovery), `mmnto-ai/totem#1769` (ChunkStrategy registry), `mmnto-ai/totem#1653` (ast-grep Lang registry — registry-backed reframe per the 2026-04-30 comment).
+
+PR-B (`@totem/pack-rust-architecture` lift) hard-blocks on this PR landing. PR-C (LC adoption) follows post-PR-B.
+
+## Context
+
+[ADR-097 Pack Language Archetype](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-097-pack-language-archetype.md) accepted 2026-04-30 (`mmnto-ai/totem-strategy#192`). § 6 Stage 1 ships `@totem/pack-rust-architecture` alpha. § 10 lists three enabling tickets that gate Stage 1 — this PR ships all three together because they're tightly thematic (a single architectural commit: Pack registration substrate) and PR-B needs them all to register at boot.
+
+## Files to Examine
+
+1. `packages/core/src/config-schema.ts:10-16` — `ChunkStrategySchema` closed Zod enum (becomes registry-backed).
+2. `packages/core/src/chunkers/chunker.ts` — `CHUNKER_MAP` closed `Record<ChunkStrategy, Chunker>` (becomes registry).
+3. `packages/core/src/ast-classifier.ts:7,170-185` — `SupportedLanguage` literal union + `extensionToLanguage` switch (both become registry-backed).
+4. `packages/core/src/rule-engine.ts:392` — silent-skip site for unmapped extensions per `#1653` (becomes fail-loud).
+5. `packages/cli/src/commands/sync.ts:35-129` — `syncCommand` extension point for writing `.totem/installed-packs.json`.
+6. `packages/core/src/ingest/pipeline.ts:244` — `createChunker(file.target.strategy)` boot-path consumer.
+7. `packages/core/src/pack-merge.ts` — existing pack-merge primitive; co-resident with new pack-discovery substrate.
+
+## Implementation Design
+
+### Scope
+
+Implement the three ADR-097 §10 substrate features in one bundled PR so PR-B (`@totem/pack-rust-architecture` lift) has a stable runtime registration contract. Specifically: (1) `totem sync` writes `.totem/installed-packs.json`; engine boot reads it synchronously and runs pack registration callbacks before sealing; (2) `ChunkStrategySchema` becomes registry-backed; (3) `extensionToLanguage` becomes registry-backed with fail-loud on unmapped extensions per `#1653`.
+
+**Will NOT do:**
+
+- PR-B's pack-side registration callback authoring (`@totem/pack-rust-architecture/src/register.ts`) — separate PR.
+- `'rust-ast'` chunker implementation — lives in PR-B's pack package.
+- `tree-sitter-rust.wasm` bundling — PR-B's pack package.
+- Pack signature verification (`#1492` / `#1250` / `#1545`) — separate ticket cluster.
+- Pack lifecycle awareness / deprecation warnings (`#1493`).
+- Pack-merge precedence + cache invalidation refinements (`#1249`).
+- Multi-pack conflict resolution for shared `lessonHash` (`#1248`).
+- Closing `mmnto-ai/totem#1537` (rust-ast strategy hardcoded addition) — closed at PR-B ship.
+- `mmnto-ai/totem#1654` (compile-pipeline `Lang.Tsx` hardcode) — implementation-coupled to this PR's registry; can ride PR-A or sibling. Lean: ride PR-A so the registry's first non-TS consumer (compile pipeline) lands with the registry shape proven.
+- `mmnto-ai/totem#1655` (CLI compile prompt KIND_ALLOW_LIST) — tier-2, ships separately post-PR-A.
+
+### Data model deltas
+
+**NEW types** (in `packages/core/src/pack-discovery.ts` unless noted):
+
+- `Pack` — runtime descriptor:
+  ```ts
+  interface Pack {
+    readonly name: string;
+    readonly resolvedPath: string;
+    readonly declaredEngineRange: string;
+    readonly register: PackRegisterCallback;
+  }
+  ```
+- `PackRegisterCallback` — `(api: PackRegistrationAPI) => void`. Synchronous per ADR-097 Q5.
+- `PackRegistrationAPI`:
+  ```ts
+  interface PackRegistrationAPI {
+    registerChunkStrategy(name: string, chunkerCtor: new () => Chunker): void;
+    registerLanguage(extension: string, lang: string, wasmLoader?: () => Buffer): void;
+  }
+  ```
+- `InstalledPacksManifest` — Zod schema for `.totem/installed-packs.json`:
+  ```ts
+  const InstalledPacksManifestSchema = z.object({
+    version: z.literal(1),
+    packs: z.array(
+      z.object({
+        name: z.string(),
+        resolvedPath: z.string(),
+        declaredEngineRange: z.string(),
+      }),
+    ),
+  });
+  ```
+  Schema validates strict (`.passthrough()` rejected) so unknown keys are loud.
+
+**MODIFIED types:**
+
+- `SupportedLanguage` (in `packages/core/src/ast-classifier.ts`): currently `'typescript' | 'tsx' | 'javascript'`. Widens to `'typescript' | 'tsx' | 'javascript' | (string & {})` — preserves IntelliSense on built-ins while admitting pack-contributed values (e.g., `'rust'`). See Open Question 1.
+- `ChunkStrategySchema` (in `packages/core/src/config-schema.ts`): currently `z.enum([...])`. Becomes `z.string().refine(name => CHUNKER_REGISTRY.has(name), { message: '...' })`. Schema-level validation defers to runtime registry — sealed-before-validation invariant prevents races (see State lifecycle).
+
+**NEW state containers** (all module-level singletons, registry-pattern):
+
+- `CHUNKER_REGISTRY: Map<string, new () => Chunker>` (in new `packages/core/src/chunkers/chunker-registry.ts`). Replaces the closed `CHUNKER_MAP`. Built-in chunkers (`MarkdownChunker`, `TypeScriptChunker`, `SessionLogChunker`, `SchemaFileChunker`, `TestFileChunker`) self-register at module load via top-level `register('markdown-heading', MarkdownChunker)` calls.
+- `LANG_REGISTRY: Map<string, { lang: string; wasmLoader?: () => Buffer }>` (in `packages/core/src/ast-classifier.ts`). Replaces the `switch` in `extensionToLanguage`. Built-in entries pre-populated at module load.
+- `PACK_REGISTRY: Map<string, Pack>` (in `packages/core/src/pack-discovery.ts`). Populated synchronously by `loadInstalledPacks()` at boot.
+- `engineSealed: boolean` (module-level in `packages/core/src/pack-discovery.ts`). Flipped to `true` by `loadInstalledPacks()` after every pack callback returns. All three registries reject mutations after seal.
+
+**Reserved-key / sentinel hazards:** None introduced. The string-keyed registries don't collide with the existing `CompiledRule.fileGlobs` namespace or `lessonHash` space (different concept).
+
+### State lifecycle
+
+| State              | Scope           | Lifetime                                                                       | Ownership             |
+| ------------------ | --------------- | ------------------------------------------------------------------------------ | --------------------- |
+| `CHUNKER_REGISTRY` | engine-lifetime | pre-populated at module load → mutated during boot via pack callbacks → sealed | `chunker-registry.ts` |
+| `LANG_REGISTRY`    | engine-lifetime | pre-populated at module load → mutated during boot via pack callbacks → sealed | `ast-classifier.ts`   |
+| `PACK_REGISTRY`    | engine-lifetime | populated by `loadInstalledPacks()` → sealed                                   | `pack-discovery.ts`   |
+| `engineSealed`     | engine-lifetime | starts `false` → flips to `true` at end of `loadInstalledPacks()`              | `pack-discovery.ts`   |
+
+**Cross-boundary state crossing (load-bearing):** Pack registration callbacks fire during boot, write to all three registries (CHUNKER + LANG + PACK), then the engine seals. Reads happen post-seal. The seal event is the only boundary; sealed-state mutations throw.
+
+The seal event MUST precede:
+
+1. First call to any function that consumes `CHUNKER_REGISTRY` (e.g., `createChunker()` in `packages/core/src/ingest/pipeline.ts:244`).
+2. First call to any function that consumes `LANG_REGISTRY` (e.g., `extensionToLanguage()` in `packages/core/src/rule-engine.ts:392`, `applyRulesToAdditions`).
+3. First Zod parse of `targets[].strategy` (in any config-loading site).
+
+The boot sequencing contract: `loadInstalledPacks()` is the canonical boot entry. All three registries' `register()` exports throw if `engineSealed === true`. CLI commands call `loadInstalledPacks()` immediately after `loadConfig()` and before any other engine surface.
+
+### Failure modes
+
+| Failure                                                               | Category                    | Agent-facing surface                                                                                                      | Recovery                                  |
+| --------------------------------------------------------------------- | --------------------------- | ------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
+| `installed-packs.json` missing                                        | init                        | silent (treat as empty packs); log debug                                                                                  | `totem sync` regenerates                  |
+| `installed-packs.json` malformed JSON                                 | init                        | hard error with file path + JSON parse line                                                                               | fix manifest or `totem sync`              |
+| `installed-packs.json` Zod fails (unknown key, wrong shape)           | init                        | hard error naming the field                                                                                               | fix manifest or `totem sync`              |
+| Pack file at `resolvedPath` missing                                   | init                        | hard error naming pack + path                                                                                             | reinstall pack                            |
+| Pack require throws                                                   | init                        | hard error naming pack + cause                                                                                            | pack-side bug; user reports to maintainer |
+| Pack `peerDependencies` engine range doesn't satisfy running version  | init                        | structured error per ADR-097 Q6: "Pack X declares `@mmnto/totem ^1.19.0` but engine is 2.0.0; upgrade pack or pin engine" | upgrade pack or downgrade engine          |
+| Pack `register()` callback throws                                     | init                        | hard error naming pack + cause                                                                                            | pack-side bug                             |
+| Two packs register same `ChunkStrategy` name                          | init                        | hard error: "ChunkStrategy 'rust-ast' registered by Pack X, attempted re-register by Pack Y"                              | one pack must rename                      |
+| Two packs register same extension with different `lang`               | init                        | hard error: "Extension '.rs' registered to 'rust' by Pack X, attempted re-register to 'gleam' by Pack Y"                  | one pack must drop the conflict           |
+| `register()` called after seal                                        | runtime                     | hard error: "Engine sealed — pack registration must complete before first engine API call"                                | architectural bug                         |
+| `targets[].strategy` references unregistered name                     | runtime (config validation) | hard error per Tenet 4 with name + suggestions from registry                                                              | install pack or fix config                |
+| ast-grep dispatch on unmapped extension                               | runtime                     | **BEHAVIOR CHANGE: hard error per `#1653`, was silent skip**                                                              | install pack for that extension           |
+| Pack callback registers extension that's already in built-in registry | init                        | hard error: built-in entries are immutable                                                                                | architectural error in the pack           |
+| `wasmLoader` throws on first dispatch                                 | runtime                     | hard error wrapping original cause                                                                                        | pack-side WASM bundling bug               |
+
+The "ast-grep dispatch fail-loud" change is a behavior change. The old silent-skip masked rules that legitimately needed an extension Totem didn't support. The fail-loud surfaces them at compile time. **Changeset minor bump.**
+
+Tenet 4 audit: every row above is fail-loud or silent-by-design (the missing-manifest case, which is the new-install / pre-sync case). No row is "silent degradation."
+
+### Invariants to lock in via tests
+
+1. `loadInstalledPacks()` reading a missing manifest returns `{ packs: [] }`, no throw.
+2. `loadInstalledPacks()` reading a malformed manifest throws with structured message naming the file + parse failure point.
+3. Pack `peerDependencies` mismatch produces structured error naming pack name + declared range + actual engine version (load-bearing per ADR-097 Q6).
+4. Re-registration of same pack name throws.
+5. After `engineSealed`, every registry's `register()` export throws.
+6. All five built-in chunkers (`'markdown-heading'`, `'typescript-ast'`, `'session-log'`, `'schema-file'`, `'test-file'`) register at module load; `lookup('markdown-heading')` returns `MarkdownChunker`.
+7. All six built-in language entries register at module load (`.ts` → `'typescript'`, `.tsx` → `'tsx'`, `.jsx` → `'tsx'`, `.js` → `'javascript'`, `.mjs` → `'javascript'`, `.cjs` → `'javascript'`).
+8. A pack callback can register a new chunker (`'rust-ast'`) and a new (extension, lang, wasmLoader) tuple (`.rs` → `'rust'`); lookups return the registered values.
+9. Two packs registering same `ChunkStrategy` name → fail loud at second registration.
+10. Two packs registering same extension to different langs → fail loud at second registration.
+11. A pack registering an extension that's already in the built-in set → fail loud (built-in entries immutable).
+12. `targets[].strategy: 'rust-ast'` validates successfully when a pack has registered `'rust-ast'`.
+13. `targets[].strategy: 'unknown'` fails Zod validation with a message listing the registered set.
+14. ast-grep dispatch on `.rs` after `'rust'` registration runs the rule (no silent skip).
+15. ast-grep dispatch on `.py` (no pack registered) throws a structured error per `#1653`'s fail-loud framing.
+16. Existing test corpus (TS/JS/TSX/JSX) continues to pass — registry shape preserves all current behavior on built-ins.
+17. `wasmLoader` is invoked lazily — registration without dispatch never calls the loader; first dispatch on the language calls it once and memoizes.
+18. `totem sync` writes a valid `installed-packs.json` against a fixture pack with `extends: ['@totem/pack-fixture']` and the pack present in `node_modules/`.
+
+### Open questions
+
+1. **`SupportedLanguage` type-shape change.**
+   - **Question:** Currently `type SupportedLanguage = 'typescript' | 'tsx' | 'javascript'`. With registry-backed entries, packs contribute new values. What's the right type shape?
+   - **Options:** (a) widen to `string` everywhere (loses IntelliSense on built-in callers); (b) keep literal union + add `(string & {})` variant — preserves IntelliSense while admitting new values; (c) introduce a `LanguageId` brand.
+   - **Recommendation:** (b). Built-in callers continue to type-check against the literal union; pack-contributed lookups return brand-string. Matches pattern used elsewhere for "extensible string union" types.
+
+2. **Where does the engine seal fire?**
+   - **Question:** The seal must precede the first ast-grep API call OR the first retrieval pipeline call, whichever comes first. What's the cleanest hook?
+   - **Options:** (a) lazy-seal on first call to any consuming API (decentralized, race-prone); (b) explicit `sealEngine()` at end of `loadInstalledPacks()` — single boundary; (c) module-level seal flag flipped by both ast-grep adapter and ingest/pipeline as their first action.
+   - **Recommendation:** (b). One boundary, one writer. `loadInstalledPacks()` is the canonical boot-time entry; sealing there keeps the seal strictly synchronous with registration. CLI commands call `loadInstalledPacks()` immediately after config load.
+
+3. **Pack `register()` callback contract — sync only.**
+   - **Question:** Some packs may want to load WASM grammar bytes asynchronously during registration. Sync or async?
+   - **Options:** (a) sync, defer WASM loading to lookup-time via `wasmLoader: () => Buffer` thunk; (b) async, boot becomes async.
+   - **Recommendation:** (a). ADR-097 Q5 mandates synchronous boot. WASM bytes load lazily on first ast-grep dispatch via the registered `wasmLoader` thunk; loader call is memoized.
+
+4. **`totem sync`'s pack-list source.**
+   - **Question:** ADR-097 Q5 says "by reading `package.json` dependencies/extends." What's the canonical source?
+   - **Options:** (a) walk consumer's `package.json` `dependencies` for `@totem/pack-*`; (b) read `totem.config.ts` `extends` array; (c) both, deduplicated.
+   - **Recommendation:** (c). `extends` is the authoritative declaration of "I want this pack's rules." `dependencies` is the npm-level "the package is installed and resolvable." Pack appearing in only one is config drift — log a warning, proceed with the union. Mismatch resolution (precedence rules) deferrable; for v0.1, log + proceed.
+
+5. **`tree-sitter-<lang>.wasm` loader location.**
+   - **Question:** Where does the WASM grammar live at runtime? Pack ships it; how does ast-grep find it?
+   - **Options:** (a) pack's `register()` hands a `wasmLoader: () => Buffer` thunk; (b) pack manifest declares WASM path, totem-core resolves it; (c) pack registers an explicit `Lang` instance from `@ast-grep/napi` pre-loaded with WASM.
+   - **Recommendation:** (a). Cleanest separation — pack owns the loader, totem-core never reads pack files directly, ast-grep adapter calls the loader on first parse and memoizes. Lets the pack handle bundling however it wants (filesystem read, embedded base64, etc.) without core concerning itself.
+
+6. **Bundling vs splitting the three substrate features into PR-A1/A2/A3?**
+   - **Question:** PR-A bundles three tickets. Should they split into three smaller PRs?
+   - **Options:** (a) bundle (one PR-A); (b) split into PR-A1 (Pack discovery) → PR-A2 (ChunkStrategy registry) → PR-A3 (Lang registry).
+   - **Recommendation:** (a) bundle. Per `feedback_bundle_locally_avoid_pr_churn.md`. The three features share state lifecycle (registries, seal event), failure-mode taxonomy (registration conflicts), and test fixtures (pack-fixture for end-to-end). Splitting incurs three review cycles for one architectural commit.
+
+7. **Behavior-change disposition: ast-grep silent-skip → fail-loud.**
+   - **Question:** Per `#1653`, today's silent-skip on unmapped extension becomes hard error. This is a breaking change for any consumer that has rules scoped to extensions Totem doesn't support yet.
+   - **Options:** (a) ship as fail-loud (per `#1653` framing); (b) ship as warning with one-version deprecation window; (c) gate behind a config flag.
+   - **Recommendation:** (a). The silent skip is the bug `#1653` filed against. Consumers with `.rs` rules today (e.g., LC) currently get zero signal that their rules don't fire — making the failure visible IS the fix. Frame in changeset MINOR with a clear migration note: "if you had `.rs`/`.py`/etc. rules and noticed they didn't fire, install the corresponding pack."
+
+8. **`mmnto-ai/totem#1654` ride-along.**
+   - **Question:** `#1654` (compile-pipeline `Lang.Tsx` hardcode) is implementation-coupled to PR-A's registry shape. Bundle or sibling PR?
+   - **Options:** (a) ride PR-A; (b) sibling PR-A2 immediately after.
+   - **Recommendation:** (a). The compile pipeline IS the registry's first non-TS consumer; landing the registry without the consumer leaves a half-finished feature. Bundling `#1654` proves the registry shape end-to-end against a real non-TS path. Per the same `feedback_bundle_locally_avoid_pr_churn.md`.
+
+## Phase 4 Approval Gate
+
+Design doc drafted at `.totem/specs/pack-substrate-bundle.md`. Open questions: 8.
+
+Awaiting user approval before writing implementation code.
+
+Most are recommendation-with-rationale (Q1, Q2, Q3, Q5, Q6, Q7, Q8). Two are config / scope decisions worth explicit user judgement (Q4 — pack list source de-duplication semantics; Q8 — `#1654` ride-along bundling).
+
+Once approved, implementation order:
+
+1. Land registries (chunker-registry.ts + LANG_REGISTRY in ast-classifier.ts) with built-ins, no pack support yet — proves the shape works for current corpus.
+2. Land pack-discovery.ts with `loadInstalledPacks()` + seal event.
+3. Land `PackRegistrationAPI` surface + `register()` mutation paths on the two registries.
+4. Land `totem sync` writer for `installed-packs.json`.
+5. Land schema integration: `ChunkStrategySchema` consults registry; `targets[].strategy` validates against registered set.
+6. Land ast-grep fail-loud at `rule-engine.ts:392` per `#1653`.
+7. Land `#1654` consumer migration (compile-pipeline Lang.Tsx → registry).
+8. End-to-end test using a fixture pack in `packages/core/src/__fixtures__/pack-fixture/`.

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -79,13 +79,47 @@ export async function syncCommand(options: {
     // review.sourceExtensions in ~/.totem/totem.config.ts, skipping the write
     // would break TS/bash parity (TS uses the custom set, bash defaults). cwd
     // is the best proxy for git-toplevel available without shelling to git.
+    const targetRoot = isGlobalConfigPath(configPath) ? cwd : path.dirname(configPath);
+    const totemDirAbs = path.resolve(targetRoot, config.totemDir);
     try {
-      const targetRoot = isGlobalConfigPath(configPath) ? cwd : path.dirname(configPath);
-      const totemDirAbs = path.resolve(targetRoot, config.totemDir);
       writeReviewExtensionsFile(totemDirAbs, config.review.sourceExtensions); // totem-context: intentional cleanup — canonical file write is a convenience for the bash PreToolUse hook
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
       log.dim(TAG, `Skipped review-extensions.txt write: ${sanitize(detail)}`);
+    }
+
+    // Emit `.totem/installed-packs.json` for boot-time pack registration
+    // (mmnto-ai/totem#1768, ADR-097 § 10). Resolved from the deduplicated
+    // union of `package.json` `@totem/pack-*` deps + `totem.config.ts`
+    // `extends` array. Mismatch surfaces (dep without extends, extends
+    // without dep, missing peerDependencies) emit per-pack warnings;
+    // resolved entries are written to the manifest atomically.
+    try {
+      const { resolveInstalledPacks, writeInstalledPacksManifest } = await import('@mmnto/totem');
+      const { resolved, warnings } = resolveInstalledPacks({
+        projectRoot: targetRoot,
+        config,
+      });
+      writeInstalledPacksManifest(totemDirAbs, { version: 1, packs: resolved });
+      for (const warning of warnings) {
+        const reasonText =
+          warning.reason === 'dep-only'
+            ? `present in package.json but not in totem.config.ts \`extends\` — pack rules will not be merged. Add to \`extends\` or remove the dependency.`
+            : warning.reason === 'extends-only'
+              ? `declared in totem.config.ts \`extends\` but not installed — install via \`pnpm add -D ${warning.name}\` (or equivalent).`
+              : `does not expose a registration callback — see ADR-097 § 5 for the pack contract.`;
+        log.warn(TAG, `Pack '${warning.name}': ${reasonText}`);
+      }
+      if (resolved.length > 0) {
+        log.dim(
+          TAG,
+          `Wrote installed-packs.json (${resolved.length} pack${resolved.length === 1 ? '' : 's'}).`,
+        );
+      }
+      // totem-context: intentional cleanup — manifest write is best-effort, mirrors the writeReviewExtensionsFile pattern above (failure logs at warn but does not abort sync)
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : 'unknown error';
+      log.warn(TAG, `Skipped installed-packs.json write: ${sanitize(detail)}`);
     }
 
     spinner.succeed(`Done: ${result.chunksProcessed} chunks from ${result.filesProcessed} files`);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -28,6 +28,7 @@
     "remark-frontmatter": "^5.0.0",
     "remark-parse": "^11.0.0",
     "safe-regex2": "^5.0.0",
+    "semver": "^7.7.0",
     "tree-sitter-javascript": "^0.25.0",
     "tree-sitter-typescript": "^0.23.2",
     "typescript": "^5.7.0",
@@ -48,6 +49,7 @@
     "@ast-grep/wasm": "^0.42.1",
     "@types/cross-spawn": "^6.0.6",
     "@types/mdast": "^4.0.0",
+    "@types/semver": "^7.5.0",
     "vitest": "^3.0.0"
   },
   "files": [

--- a/packages/core/src/ast-classifier.test.ts
+++ b/packages/core/src/ast-classifier.test.ts
@@ -1,6 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 
-import { classifyLines, extensionToLanguage } from './ast-classifier.js';
+import {
+  __resetLangRegistryForTests,
+  __unsealLangRegistryForTests,
+  classifyLines,
+  extensionToLanguage,
+  isBuiltinExtension,
+  isLangRegistrySealed,
+  registeredExtensions,
+  registeredLanguages,
+  registerLang,
+  sealLangRegistry,
+} from './ast-classifier.js';
 
 // ─── extensionToLanguage ────────────────────────────
 
@@ -27,6 +38,109 @@ describe('extensionToLanguage', () => {
     expect(extensionToLanguage('.py')).toBeUndefined();
     expect(extensionToLanguage('.rs')).toBeUndefined();
     expect(extensionToLanguage('.md')).toBeUndefined();
+  });
+
+  it('normalizes extension case before lookup', () => {
+    expect(extensionToLanguage('.TS')).toBe('typescript');
+    expect(extensionToLanguage('.Tsx')).toBe('tsx');
+  });
+});
+
+// ─── Language registry surface (mmnto-ai/totem#1653 + #1768) ──
+
+describe('language registry built-ins', () => {
+  it('exposes all six built-in extensions from registeredExtensions()', () => {
+    expect(registeredExtensions()).toEqual(['.cjs', '.js', '.jsx', '.mjs', '.ts', '.tsx']);
+  });
+
+  it('exposes all three built-in languages from registeredLanguages()', () => {
+    expect(registeredLanguages()).toEqual(['javascript', 'tsx', 'typescript']);
+  });
+
+  it('marks built-in extensions as built-in', () => {
+    expect(isBuiltinExtension('.ts')).toBe(true);
+    expect(isBuiltinExtension('.tsx')).toBe(true);
+    expect(isBuiltinExtension('.rs')).toBe(false);
+  });
+});
+
+describe('language registry pack-style registration', () => {
+  afterEach(() => {
+    __resetLangRegistryForTests();
+  });
+
+  it('accepts new (extension, language, loader) registration before seal', () => {
+    const fakeLoader = () => '/fake/path/tree-sitter-fakelang.wasm';
+    registerLang('.fake', 'fakelang', fakeLoader);
+    expect(extensionToLanguage('.fake')).toBe('fakelang');
+    expect(registeredExtensions()).toContain('.fake');
+    expect(registeredLanguages()).toContain('fakelang');
+  });
+
+  it('does not mark pack-registered extensions as built-in', () => {
+    registerLang('.fake', 'fakelang', () => '/fake.wasm');
+    expect(isBuiltinExtension('.fake')).toBe(false);
+  });
+
+  it('throws when re-registering an extension to a different language (pack-vs-pack)', () => {
+    registerLang('.fake', 'fakelang', () => '/fake.wasm');
+    expect(() => registerLang('.fake', 'differentlang', () => '/other.wasm')).toThrowError(
+      /already registered to language 'fakelang'.*pack-vs-pack collision/,
+    );
+  });
+
+  it('throws when registering a built-in extension (immutable)', () => {
+    expect(() => registerLang('.ts', 'newlang', () => '/x.wasm')).toThrowError(
+      /already registered to language 'typescript'.*as a built-in.*immutable/,
+    );
+  });
+
+  it('throws when registering an already-registered language with a different loader', () => {
+    const loader1 = () => '/path1.wasm';
+    const loader2 = () => '/path2.wasm';
+    registerLang('.fake', 'fakelang', loader1);
+    expect(() => registerLang('.also-fake', 'fakelang', loader2)).toThrowError(
+      /Language 'fakelang' is already registered/,
+    );
+  });
+
+  it('allows multiple extensions to register to the same language with the same loader', () => {
+    const sharedLoader = () => '/shared.wasm';
+    registerLang('.fake1', 'fakelang', sharedLoader);
+    registerLang('.fake2', 'fakelang', sharedLoader);
+    expect(extensionToLanguage('.fake1')).toBe('fakelang');
+    expect(extensionToLanguage('.fake2')).toBe('fakelang');
+  });
+});
+
+describe('language registry seal contract', () => {
+  afterEach(() => {
+    __resetLangRegistryForTests();
+  });
+
+  it('starts unsealed', () => {
+    expect(isLangRegistrySealed()).toBe(false);
+  });
+
+  it('sealLangRegistry() flips the flag', () => {
+    sealLangRegistry();
+    expect(isLangRegistrySealed()).toBe(true);
+  });
+
+  it('registerLang() after seal throws with ADR-097 § 5 Q5 reference', () => {
+    sealLangRegistry();
+    expect(() => registerLang('.fake', 'fakelang', () => '/f.wasm')).toThrowError(
+      /after engine seal.*ADR-097 § 5 Q5/,
+    );
+  });
+
+  it('__unsealLangRegistryForTests reverts the seal so subsequent tests can register', () => {
+    sealLangRegistry();
+    expect(isLangRegistrySealed()).toBe(true);
+    __unsealLangRegistryForTests();
+    expect(isLangRegistrySealed()).toBe(false);
+    registerLang('.fake', 'fakelang', () => '/f.wasm');
+    expect(extensionToLanguage('.fake')).toBe('fakelang');
   });
 });
 

--- a/packages/core/src/ast-classifier.ts
+++ b/packages/core/src/ast-classifier.ts
@@ -4,7 +4,46 @@ import type { AstContext } from './compiler.js';
 
 // ─── Types ──────────────────────────────────────────
 
-export type SupportedLanguage = 'typescript' | 'tsx' | 'javascript';
+/**
+ * Tree-sitter language label. The literal union covers built-in languages
+ * shipped by core; the `(string & {})` extension admits pack-contributed
+ * values (e.g., `'rust'`) registered via `PackRegistrationAPI.registerLanguage`
+ * (mmnto-ai/totem#1768). Per ADR-097 § 5 Q3 + § 10 the registry is the
+ * runtime source of truth; this type alias keeps IntelliSense on built-in
+ * names while admitting any registered string.
+ */
+export type SupportedLanguage = 'typescript' | 'tsx' | 'javascript' | (string & {});
+
+// ─── Language registry (mmnto-ai/totem#1653 + ADR-097 § 10) ──
+
+/**
+ * Extension → language registry. Replaces the `switch` previously in
+ * `extensionToLanguage`. Built-in entries register at module load (bottom
+ * of this file); pack callbacks register additional entries during boot
+ * via `PackRegistrationAPI.registerLanguage` → `registerLang()` here.
+ */
+const EXT_TO_LANG_REGISTRY = new Map<string, SupportedLanguage>();
+
+/**
+ * Language → WASM grammar loader thunk. Replaces the `switch` previously
+ * in `loadGrammar`. Loader returns a path string (built-ins use
+ * `require.resolve`) or a Buffer (packs embed grammar bytes); web-tree-sitter
+ * accepts either. The thunk is invoked lazily on first `loadGrammar(lang)`
+ * call and the result is memoized in `grammarCache`.
+ */
+const LANG_TO_WASM_LOADER = new Map<
+  SupportedLanguage,
+  () => string | Uint8Array | Promise<string | Uint8Array>
+>();
+
+/**
+ * Built-in language extensions, immutable. A pack attempting to re-register
+ * one of these is rejected at the boundary in `registerLang()`.
+ */
+const BUILTIN_EXTENSIONS = new Set<string>();
+const BUILTIN_LANGUAGES = new Set<SupportedLanguage>();
+
+let langRegistrySealed = false;
 
 // ─── Lazy-loaded Tree-sitter state ──────────────────
 
@@ -35,7 +74,17 @@ export async function ensureInit(): Promise<void> {
 }
 
 /**
- * Load a Tree-sitter grammar WASM file for the given language.
+ * Load a Tree-sitter grammar WASM for the given language. Resolves the
+ * language's WASM source via the registry (`LANG_TO_WASM_LOADER`) — built-in
+ * loaders use `require.resolve(...)` against tree-sitter-typescript /
+ * tree-sitter-javascript; pack-registered loaders return paths to the
+ * pack's bundled WASM (per ADR-097 Q2 — WASM bundling decision). The
+ * loader thunk is invoked lazily here on first dispatch and the resolved
+ * grammar is memoized in `grammarCache`.
+ *
+ * Throws when the language is not registered. ast-grep dispatch path
+ * (`rule-engine.ts`) is fail-loud per mmnto-ai/totem#1653 — silent skip on
+ * unmapped extensions was the bug.
  */
 export async function loadGrammar(
   lang: SupportedLanguage,
@@ -43,26 +92,19 @@ export async function loadGrammar(
   const cached = grammarCache.get(lang);
   if (cached) return cached;
 
+  const loader = LANG_TO_WASM_LOADER.get(lang);
+  if (!loader) {
+    throw new Error(
+      `No WASM grammar loader registered for language '${lang}'. Either install the pack that provides it or correct the language reference.`,
+    );
+  }
+
   await ensureInit();
   const TreeSitter = await import('web-tree-sitter');
   const LanguageClass = TreeSitter.default?.Language ?? TreeSitter.Language;
 
-  const require = createRequire(import.meta.url);
-  let wasmFile: string;
-
-  switch (lang) {
-    case 'typescript':
-      wasmFile = require.resolve('tree-sitter-typescript/tree-sitter-typescript.wasm');
-      break;
-    case 'tsx':
-      wasmFile = require.resolve('tree-sitter-typescript/tree-sitter-tsx.wasm');
-      break;
-    case 'javascript':
-      wasmFile = require.resolve('tree-sitter-javascript/tree-sitter-javascript.wasm');
-      break;
-  }
-
-  const grammar = await LanguageClass.load(wasmFile);
+  const wasmSource = await loader();
+  const grammar = await LanguageClass.load(wasmSource);
   grammarCache.set(lang, grammar);
   return grammar;
 }
@@ -164,22 +206,151 @@ export async function classifyLines(
 }
 
 /**
- * Map file extension to a supported Tree-sitter language.
- * Returns undefined for unsupported extensions.
+ * Map file extension to a registered Tree-sitter language.
+ *
+ * Registry-backed per ADR-097 § 10 + mmnto-ai/totem#1653. Built-in entries
+ * (`.ts`/`.tsx`/`.jsx`/`.js`/`.mjs`/`.cjs`) self-register at module load
+ * (bottom of this file). Pack callbacks add entries during boot via
+ * `PackRegistrationAPI.registerLanguage`.
+ *
+ * Returns undefined when the extension isn't registered. The dispatch
+ * path in `rule-engine.ts` treats undefined as fail-loud per #1653 — the
+ * silent skip behavior pre-#1653 was a bug.
  */
 export function extensionToLanguage(ext: string): SupportedLanguage | undefined {
-  switch (ext.toLowerCase()) {
-    case '.ts':
-      return 'typescript';
-    case '.tsx':
-      return 'tsx';
-    case '.js':
-    case '.mjs':
-    case '.cjs':
-      return 'javascript';
-    case '.jsx':
-      return 'tsx'; // TSX grammar handles JSX
-    default:
-      return undefined;
-  }
+  return EXT_TO_LANG_REGISTRY.get(ext.toLowerCase());
 }
+
+// ─── Language registry public surface (mmnto-ai/totem#1653 + #1768) ──
+
+/**
+ * Register a (extension, language, wasmLoader) triple. Called by built-ins
+ * at module load and by Pack registration callbacks during boot via
+ * `PackRegistrationAPI.registerLanguage` (mmnto-ai/totem#1768). Throws when:
+ *
+ * - The registry is sealed (boot-time-only mutation).
+ * - The extension is already registered to a different language (built-in
+ *   entries are immutable; pack-vs-pack collisions also rejected).
+ * - The language is already registered to a different WASM loader.
+ *
+ * Both maps are updated together: an extension always points at a language
+ * that has a known WASM loader. Partial registration (extension without
+ * loader) is rejected.
+ */
+export function registerLang(
+  extension: string,
+  lang: SupportedLanguage,
+  wasmLoader: () => string | Uint8Array | Promise<string | Uint8Array>,
+): void {
+  if (langRegistrySealed) {
+    throw new Error(
+      `Language registration after engine seal: tried to register '${extension}' → '${lang}' but engine has already started serving requests. Pack registration must complete during boot — see ADR-097 § 5 Q5.`,
+    );
+  }
+  const normalizedExt = extension.toLowerCase();
+  const existingLang = EXT_TO_LANG_REGISTRY.get(normalizedExt);
+  if (existingLang !== undefined && existingLang !== lang) {
+    const existingIsBuiltin = BUILTIN_EXTENSIONS.has(normalizedExt);
+    throw new Error(
+      `Extension '${normalizedExt}' is already registered to language '${existingLang}'${existingIsBuiltin ? ' as a built-in (built-in entries are immutable)' : ' (pack-vs-pack collision)'}; refusing to re-register to '${lang}'.`,
+    );
+  }
+  const existingLoader = LANG_TO_WASM_LOADER.get(lang);
+  if (existingLoader !== undefined && existingLoader !== wasmLoader) {
+    const existingIsBuiltin = BUILTIN_LANGUAGES.has(lang);
+    throw new Error(
+      `Language '${lang}' is already registered with a WASM loader${existingIsBuiltin ? ' as a built-in (built-in entries are immutable)' : ' (pack-vs-pack collision)'}; refusing to override.`,
+    );
+  }
+  EXT_TO_LANG_REGISTRY.set(normalizedExt, lang);
+  LANG_TO_WASM_LOADER.set(lang, wasmLoader);
+}
+
+/**
+ * Snapshot of currently-registered extensions. Used for fail-loud error
+ * messages on unmapped extensions and `totem describe` output.
+ */
+export function registeredExtensions(): readonly string[] {
+  return [...EXT_TO_LANG_REGISTRY.keys()].sort();
+}
+
+/**
+ * Snapshot of currently-registered languages. Stable order for deterministic
+ * output.
+ */
+export function registeredLanguages(): readonly SupportedLanguage[] {
+  return [...LANG_TO_WASM_LOADER.keys()].sort();
+}
+
+/** True iff the extension is built-in (vs pack-registered). */
+export function isBuiltinExtension(ext: string): boolean {
+  return BUILTIN_EXTENSIONS.has(ext.toLowerCase());
+}
+
+/**
+ * Mark the language registry as sealed. After this, `registerLang()`
+ * calls throw. Called by `pack-discovery.ts` `loadInstalledPacks()` after
+ * every pack callback returns.
+ */
+export function sealLangRegistry(): void {
+  langRegistrySealed = true;
+}
+
+/** True iff the language registry has been sealed. */
+export function isLangRegistrySealed(): boolean {
+  return langRegistrySealed;
+}
+
+// ─── Test-only helpers ──────────────────────────────
+
+/**
+ * Test-only: reset the language registry and re-register built-ins. Lets
+ * per-test fixtures register without leaking state across tests.
+ */
+export function __resetLangRegistryForTests(): void {
+  EXT_TO_LANG_REGISTRY.clear();
+  LANG_TO_WASM_LOADER.clear();
+  BUILTIN_EXTENSIONS.clear();
+  BUILTIN_LANGUAGES.clear();
+  langRegistrySealed = false;
+  grammarCache.clear();
+  registerBuiltinLanguages();
+}
+
+/** Test-only: clear the seal so subsequent registrations succeed. */
+export function __unsealLangRegistryForTests(): void {
+  langRegistrySealed = false;
+}
+
+// ─── Built-in language registration (runs at module load) ──
+
+function registerBuiltinLang(
+  extension: string,
+  lang: SupportedLanguage,
+  wasmLoader: () => string,
+): void {
+  BUILTIN_EXTENSIONS.add(extension.toLowerCase());
+  BUILTIN_LANGUAGES.add(lang);
+  registerLang(extension, lang, wasmLoader);
+}
+
+function registerBuiltinLanguages(): void {
+  const require = createRequire(import.meta.url);
+  // Loaders are de-duplicated by reference: when multiple extensions map
+  // to the same language, they MUST share the same loader instance so the
+  // "language already registered with a different loader" guard in
+  // `registerLang()` doesn't trip on the second extension's registration.
+  const tsLoader = () => require.resolve('tree-sitter-typescript/tree-sitter-typescript.wasm');
+  const tsxLoader = () => require.resolve('tree-sitter-typescript/tree-sitter-tsx.wasm');
+  const jsLoader = () => require.resolve('tree-sitter-javascript/tree-sitter-javascript.wasm');
+
+  registerBuiltinLang('.ts', 'typescript', tsLoader);
+  registerBuiltinLang('.tsx', 'tsx', tsxLoader);
+  // TSX grammar handles JSX — same loader instance as '.tsx'.
+  registerBuiltinLang('.jsx', 'tsx', tsxLoader);
+  registerBuiltinLang('.js', 'javascript', jsLoader);
+  registerBuiltinLang('.mjs', 'javascript', jsLoader);
+  registerBuiltinLang('.cjs', 'javascript', jsLoader);
+}
+
+registerBuiltinLanguages();

--- a/packages/core/src/ast-grep-query.ts
+++ b/packages/core/src/ast-grep-query.ts
@@ -1,6 +1,7 @@
 import type { NapiConfig } from '@ast-grep/napi';
 import { Lang, parse } from '@ast-grep/napi';
 
+import { extensionToLanguage } from './ast-classifier.js';
 import { rethrowAsParseError } from './errors.js';
 
 // ─── Types ──────────────────────────────────────────
@@ -20,22 +21,41 @@ const AST_GREP_HINT =
 
 // ─── Language mapping ───────────────────────────────
 
-/** Map file extensions to ast-grep Lang enum. */
-function extensionToLang(ext: string): Lang | undefined {
-  switch (ext.toLowerCase()) {
-    case '.ts':
+/**
+ * Map our `SupportedLanguage` string (e.g., `'typescript'`) to the
+ * ast-grep `Lang` enum value (e.g., `Lang.TypeScript`). Built-in mappings
+ * only — pack-contributed languages flow through as their SupportedLanguage
+ * string, which `@ast-grep/napi` accepts as a `CustomLang` string per
+ * its `NapiLang = Lang | (string & {})` type. Pack registration is
+ * expected to also register a dynamic language with `@ast-grep/napi`'s
+ * `registerDynamicLanguage()` API for the same string to flow end-to-end.
+ */
+function supportedLanguageToNapiLang(lang: string): Lang | string {
+  switch (lang) {
+    case 'typescript':
       return Lang.TypeScript;
-    case '.tsx':
+    case 'tsx':
       return Lang.Tsx;
-    case '.js':
-    case '.mjs':
-    case '.cjs':
+    case 'javascript':
       return Lang.JavaScript;
-    case '.jsx':
-      return Lang.Tsx;
     default:
-      return undefined;
+      // Pack-contributed language — pass the string through. Caller passes
+      // it to `parse(napiLang, source)` which accepts CustomLang strings.
+      return lang;
   }
+}
+
+/**
+ * Map a file extension to the ast-grep dispatch language label. Registry-
+ * backed via `extensionToLanguage` from ast-classifier.ts (mmnto-ai/totem#1653,
+ * #1654) — built-in extensions map to napi `Lang` enum values; pack-
+ * registered extensions map to their NapiLang custom string per
+ * ADR-097 § 10.
+ */
+function extensionToLang(ext: string): Lang | string | undefined {
+  const supported = extensionToLanguage(ext);
+  if (!supported) return undefined;
+  return supportedLanguageToNapiLang(supported);
 }
 
 // ─── Core matching ──────────────────────────────────

--- a/packages/core/src/chunkers/chunker-registry.test.ts
+++ b/packages/core/src/chunkers/chunker-registry.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for the chunker registry (mmnto-ai/totem#1769, ADR-097 § 5 Q3).
+ *
+ * Covers invariants 4-9 + 11 (chunker side) from
+ * `.totem/specs/pack-substrate-bundle.md`:
+ *
+ * - All five built-in chunkers self-register at module load.
+ * - Pack-style registration adds new entries.
+ * - Re-registration of the same name throws.
+ * - Registering a built-in name throws (immutable).
+ * - Post-seal mutation throws.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { ContentType } from '../config-schema.js';
+import type { Chunk } from '../types.js';
+import type { Chunker } from './chunker.js';
+import {
+  __resetForTests,
+  __unsealForTests,
+  isBuiltin,
+  isSealed,
+  lookup,
+  register,
+  registeredNames,
+  seal,
+} from './chunker-registry.js';
+
+class FakeChunker implements Chunker {
+  readonly strategy: string = 'fake-strategy';
+  chunk(_content: string, _filePath: string, _type: ContentType): Chunk[] {
+    return [];
+  }
+}
+
+class AnotherFakeChunker implements Chunker {
+  readonly strategy: string = 'another-fake';
+  chunk(_content: string, _filePath: string, _type: ContentType): Chunk[] {
+    return [];
+  }
+}
+
+afterEach(() => {
+  // Each test gets a fresh registry with built-ins re-registered. Without
+  // this, a sealed registry from a prior test would leak into subsequent
+  // ones and they'd all fail with "after seal" errors.
+  __resetForTests();
+});
+
+describe('chunker-registry built-ins', () => {
+  it('registers all five built-in chunkers at module load', () => {
+    expect(lookup('session-log')).toBeDefined();
+    expect(lookup('markdown-heading')).toBeDefined();
+    expect(lookup('typescript-ast')).toBeDefined();
+    expect(lookup('schema-file')).toBeDefined();
+    expect(lookup('test-file')).toBeDefined();
+  });
+
+  it('exposes registered names sorted alphabetically', () => {
+    expect(registeredNames()).toEqual([
+      'markdown-heading',
+      'schema-file',
+      'session-log',
+      'test-file',
+      'typescript-ast',
+    ]);
+  });
+
+  it('marks built-ins as built-in', () => {
+    expect(isBuiltin('markdown-heading')).toBe(true);
+    expect(isBuiltin('typescript-ast')).toBe(true);
+    expect(isBuiltin('not-a-real-strategy')).toBe(false);
+  });
+});
+
+describe('chunker-registry pack-style registration', () => {
+  it('accepts new strategy registration before seal', () => {
+    register('fake-strategy', FakeChunker);
+    expect(lookup('fake-strategy')).toBe(FakeChunker);
+    expect(registeredNames()).toContain('fake-strategy');
+  });
+
+  it('does not mark pack-registered names as built-in', () => {
+    register('fake-strategy', FakeChunker);
+    expect(isBuiltin('fake-strategy')).toBe(false);
+  });
+
+  it('throws when re-registering the same strategy name (pack-vs-pack collision)', () => {
+    register('fake-strategy', FakeChunker);
+    expect(() => register('fake-strategy', AnotherFakeChunker)).toThrowError(
+      /already registered.*pack-vs-pack collision/,
+    );
+  });
+
+  it('throws when registering a built-in name (built-ins immutable)', () => {
+    expect(() => register('markdown-heading', FakeChunker)).toThrowError(
+      /already registered.*as a built-in.*immutable/,
+    );
+  });
+});
+
+describe('chunker-registry seal contract', () => {
+  it('starts unsealed', () => {
+    expect(isSealed()).toBe(false);
+  });
+
+  it('seal() flips the flag', () => {
+    seal();
+    expect(isSealed()).toBe(true);
+  });
+
+  it('register() after seal throws with ADR-097 § 5 Q5 reference', () => {
+    seal();
+    expect(() => register('fake-strategy', FakeChunker)).toThrowError(
+      /after engine seal.*ADR-097 § 5 Q5/,
+    );
+  });
+
+  it('__unsealForTests reverts the seal so subsequent tests can register', () => {
+    seal();
+    expect(isSealed()).toBe(true);
+    __unsealForTests();
+    expect(isSealed()).toBe(false);
+    register('fake-strategy', FakeChunker);
+    expect(lookup('fake-strategy')).toBe(FakeChunker);
+  });
+});

--- a/packages/core/src/chunkers/chunker-registry.ts
+++ b/packages/core/src/chunkers/chunker-registry.ts
@@ -1,0 +1,157 @@
+/**
+ * Runtime chunker registry (ADR-097 § 5 Q3, mmnto-ai/totem#1769).
+ *
+ * Replaces the closed `CHUNKER_MAP` keyed by the closed `ChunkStrategy` Zod
+ * enum. The registry is a string-keyed Map populated by:
+ *
+ * 1. Built-in chunkers self-registering at module load (this file's bottom).
+ * 2. Pack registration callbacks invoked by `loadInstalledPacks()` during
+ *    boot (mmnto-ai/totem#1768) — they register via the
+ *    `PackRegistrationAPI.registerChunkStrategy()` surface, which calls
+ *    through to `register()` in this module.
+ *
+ * After boot completes, the engine seals (`pack-discovery.ts` flips
+ * `engineSealed = true`) and any further `register()` call throws.
+ *
+ * The registry has no concept of which built-in vs pack-registered an
+ * entry is — that distinction is enforced at registration time (see
+ * `register()` and `BUILTIN_CHUNKER_NAMES`).
+ */
+
+import type { Chunker } from './chunker.js';
+import { MarkdownChunker } from './markdown-chunker.js';
+import { SchemaFileChunker } from './schema-file-chunker.js';
+import { SessionLogChunker } from './session-log-chunker.js';
+import { TestFileChunker } from './test-file-chunker.js';
+import { TypeScriptChunker } from './typescript-chunker.js';
+
+// ─── Internal state ─────────────────────────────────
+
+const CHUNKER_REGISTRY = new Map<string, new () => Chunker>();
+
+/**
+ * Built-in chunker names, immutable. A pack attempting to re-register one
+ * of these names is rejected at the boundary in `register()`. The set is
+ * populated alongside the initial registrations below; we read it at
+ * registration time, so adding a new built-in only requires editing the
+ * `register()` calls at the bottom of this file.
+ */
+const BUILTIN_CHUNKER_NAMES = new Set<string>();
+
+/** Cleared by `__resetForTests` / `unsealForTests` — see pack-discovery.ts. */
+let sealed = false;
+
+// ─── Public API ─────────────────────────────────────
+
+/**
+ * Register a chunker under a strategy name. Called by built-ins at module
+ * load and by Pack registration callbacks during boot. Throws when:
+ *
+ * - `engineSealed` (per `pack-discovery.ts`) is true.
+ * - The strategy name is already registered (built-ins are immutable;
+ *   pack-vs-pack collisions are also rejected).
+ *
+ * Boot vs pack distinction: built-ins call `register()` directly at
+ * module-load time (sealed === false, name not yet in registry → succeeds).
+ * Packs call via `PackRegistrationAPI.registerChunkStrategy` which routes
+ * to this same function. The seal check + name-collision check covers both
+ * in one place.
+ */
+export function register(name: string, chunkerCtor: new () => Chunker): void {
+  if (sealed) {
+    throw new Error(
+      `Chunker registration after engine seal: tried to register '${name}' but engine has already started serving requests. Pack registration must complete during boot — see ADR-097 § 5 Q5.`,
+    );
+  }
+  if (CHUNKER_REGISTRY.has(name)) {
+    const existingIsBuiltin = BUILTIN_CHUNKER_NAMES.has(name);
+    throw new Error(
+      `Chunker '${name}' is already registered${existingIsBuiltin ? ' as a built-in (built-in entries are immutable)' : ' (pack-vs-pack collision — one of the packs must rename)'}.`,
+    );
+  }
+  CHUNKER_REGISTRY.set(name, chunkerCtor);
+}
+
+/**
+ * Look up a chunker class by strategy name. Returns undefined when the
+ * name isn't registered — callers decide whether absence is a hard error
+ * (Zod validation), a fail-loud at runtime (createChunker), or a soft
+ * miss.
+ */
+export function lookup(name: string): (new () => Chunker) | undefined {
+  return CHUNKER_REGISTRY.get(name);
+}
+
+/**
+ * Snapshot of currently-registered strategy names. Used for:
+ *
+ * - `ChunkStrategySchema` validation error messages (suggesting the valid set).
+ * - `totem describe` output enumerating effective strategies.
+ *
+ * Returns a sorted array for deterministic output.
+ */
+export function registeredNames(): readonly string[] {
+  return [...CHUNKER_REGISTRY.keys()].sort();
+}
+
+/**
+ * True iff the strategy name is one of the built-ins (vs pack-registered).
+ * Used by tooling that needs to distinguish core-shipped strategies from
+ * pack-contributed ones.
+ */
+export function isBuiltin(name: string): boolean {
+  return BUILTIN_CHUNKER_NAMES.has(name);
+}
+
+/**
+ * Mark the registry as sealed. After this, `register()` calls throw.
+ * Called by `pack-discovery.ts` `loadInstalledPacks()` after every pack
+ * callback returns.
+ *
+ * The seal applies process-wide. Tests that need to register additional
+ * fixture chunkers between cases use `__unsealForTests()`.
+ */
+export function seal(): void {
+  sealed = true;
+}
+
+/** True iff the registry has been sealed. */
+export function isSealed(): boolean {
+  return sealed;
+}
+
+// ─── Test-only helpers ──────────────────────────────
+
+/**
+ * Test-only: reset the registry and re-register built-ins. Lets per-test
+ * fixtures register without leaking state across tests. NEVER call from
+ * production code.
+ */
+export function __resetForTests(): void {
+  CHUNKER_REGISTRY.clear();
+  BUILTIN_CHUNKER_NAMES.clear();
+  sealed = false;
+  registerBuiltins();
+}
+
+/** Test-only: clear the seal so subsequent registrations succeed. */
+export function __unsealForTests(): void {
+  sealed = false;
+}
+
+// ─── Built-in registration (runs at module load) ────
+
+function registerBuiltin(name: string, ctor: new () => Chunker): void {
+  BUILTIN_CHUNKER_NAMES.add(name);
+  register(name, ctor);
+}
+
+function registerBuiltins(): void {
+  registerBuiltin('session-log', SessionLogChunker);
+  registerBuiltin('markdown-heading', MarkdownChunker);
+  registerBuiltin('typescript-ast', TypeScriptChunker);
+  registerBuiltin('schema-file', SchemaFileChunker);
+  registerBuiltin('test-file', TestFileChunker);
+}
+
+registerBuiltins();

--- a/packages/core/src/chunkers/chunker.ts
+++ b/packages/core/src/chunkers/chunker.ts
@@ -1,30 +1,38 @@
-import type { ChunkStrategy, ContentType } from '../config-schema.js';
+import type { ContentType } from '../config-schema.js';
 import type { Chunk } from '../types.js';
-import { MarkdownChunker } from './markdown-chunker.js';
-import { SchemaFileChunker } from './schema-file-chunker.js';
-import { SessionLogChunker } from './session-log-chunker.js';
-import { TestFileChunker } from './test-file-chunker.js';
-import { TypeScriptChunker } from './typescript-chunker.js';
+import { lookup } from './chunker-registry.js';
 
 /**
  * All chunkers implement this interface.
  * Given file content and metadata, produce an array of Chunks.
  */
 export interface Chunker {
-  readonly strategy: ChunkStrategy;
+  readonly strategy: string;
 
   chunk(content: string, filePath: string, type: ContentType): Chunk[];
 }
 
-const CHUNKER_MAP: Record<ChunkStrategy, new () => Chunker> = {
-  'session-log': SessionLogChunker,
-  'markdown-heading': MarkdownChunker,
-  'typescript-ast': TypeScriptChunker,
-  'schema-file': SchemaFileChunker,
-  'test-file': TestFileChunker,
-};
-
-export function createChunker(strategy: ChunkStrategy): Chunker {
-  const Ctor = CHUNKER_MAP[strategy];
+/**
+ * Resolve a strategy name to a fresh chunker instance via the registry.
+ *
+ * Pre-ADR-097 the strategy → constructor mapping was a closed `Record`
+ * keyed by the closed `ChunkStrategy` Zod enum (mmnto-ai/totem#1769).
+ * Now the lookup goes through `chunker-registry.ts`, which is populated
+ * by built-ins at module load and extended by Pack registration
+ * callbacks during boot.
+ *
+ * Fail-loud per Tenet 4: an unregistered strategy name names the missing
+ * pack (callers consume the registry's `registeredNames()` for context).
+ * Schema validation (`ChunkStrategySchema`) catches misconfigured strategy
+ * names at config-load time, so reaching this fail-loud at runtime is an
+ * architectural error.
+ */
+export function createChunker(strategy: string): Chunker {
+  const Ctor = lookup(strategy);
+  if (!Ctor) {
+    throw new Error(
+      `Unknown chunk strategy: '${strategy}'. The strategy is not registered — either install the pack that provides it or correct the strategy name in totem.config.ts.`,
+    );
+  }
   return new Ctor();
 }

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -8,15 +8,13 @@ import { CustomSecretSchema } from './secrets.js';
  */
 
 /**
- * Built-in chunk strategy names. The literal union below is derived from
- * this array via `typeof BUILTIN_CHUNK_STRATEGIES[number]` so the type
- * signature stays in sync with the runtime list. eslint-disable is
- * required because the array is referenced only in a type position
- * (`typeof`), not as a runtime value — but we can't write the type
- * inline without losing the single-source-of-truth.
+ * Built-in chunk strategy names. Exported so the literal union derived
+ * via `typeof BUILTIN_CHUNK_STRATEGIES[number]` keeps the runtime list
+ * and the type signature in sync with a single source of truth. Pack-
+ * contributed strategies extend `ChunkStrategy` via the `(string & {})`
+ * tail and register at boot through `chunker-registry.ts`.
  */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars -- referenced via `typeof BUILTIN_CHUNK_STRATEGIES[number]` for the ChunkStrategy type alias (see end of file)
-const BUILTIN_CHUNK_STRATEGIES = [
+export const BUILTIN_CHUNK_STRATEGIES = [
   'typescript-ast',
   'markdown-heading',
   'session-log',

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -9,11 +9,14 @@ import { CustomSecretSchema } from './secrets.js';
  */
 
 /**
- * Built-in chunk strategy names. The literal union exists for IntelliSense
- * on `ChunkStrategy`-typed values inside core; runtime validation is
- * registry-backed so pack-contributed strategy names (per ADR-097 § 5 Q3
- * + mmnto-ai/totem#1769) flow through the same schema.
+ * Built-in chunk strategy names. The literal union below is derived from
+ * this array via `typeof BUILTIN_CHUNK_STRATEGIES[number]` so the type
+ * signature stays in sync with the runtime list. eslint-disable is
+ * required because the array is referenced only in a type position
+ * (`typeof`), not as a runtime value — but we can't write the type
+ * inline without losing the single-source-of-truth.
  */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars -- referenced via `typeof BUILTIN_CHUNK_STRATEGIES[number]` for the ChunkStrategy type alias (see end of file)
 const BUILTIN_CHUNK_STRATEGIES = [
   'typescript-ast',
   'markdown-heading',

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { lookup as lookupChunker, registeredNames } from './chunkers/chunker-registry.js';
 import { TotemConfigError } from './errors.js';
 import { CustomSecretSchema } from './secrets.js';
 
@@ -7,13 +8,37 @@ import { CustomSecretSchema } from './secrets.js';
  * Zod schema for totem.config.ts — lives at the root of consuming projects.
  */
 
-export const ChunkStrategySchema = z.enum([
+/**
+ * Built-in chunk strategy names. The literal union exists for IntelliSense
+ * on `ChunkStrategy`-typed values inside core; runtime validation is
+ * registry-backed so pack-contributed strategy names (per ADR-097 § 5 Q3
+ * + mmnto-ai/totem#1769) flow through the same schema.
+ */
+const BUILTIN_CHUNK_STRATEGIES = [
   'typescript-ast',
   'markdown-heading',
   'session-log',
   'schema-file',
   'test-file',
-]);
+] as const;
+
+/**
+ * Runtime-validated `ChunkStrategy` schema. Replaces the previous closed
+ * `z.enum([...])` per ADR-097 § 10 + mmnto-ai/totem#1769 — strategy
+ * lookup goes through `chunker-registry.ts`, which is populated by
+ * built-ins at module load and extended by Pack registration callbacks
+ * during boot via `loadInstalledPacks()`.
+ *
+ * Validation surface: any string registered in the chunker registry
+ * passes; everything else fails with an error message that lists the
+ * registered set so the user can see what's actually valid.
+ */
+export const ChunkStrategySchema = z.string().refine(
+  (value) => lookupChunker(value) !== undefined,
+  (value) => ({
+    message: `Unknown chunk strategy: '${value}'. Registered: ${registeredNames().join(', ')}. If '${value}' is provided by a pack, ensure the pack is in 'extends' and run \`totem sync\` to register it.`,
+  }),
+);
 
 export const ContentTypeSchema = z.enum(['code', 'session_log', 'spec', 'lesson']);
 
@@ -327,6 +352,20 @@ export const TotemConfigSchema = z.object({
   linkedIndexes: z.array(z.string()).optional(),
 
   /**
+   * Optional: pack package names to extend rules from (ADR-085 + ADR-097).
+   *
+   * Each entry is a pack name like `@totem/pack-rust-architecture`. The
+   * pack must also appear in the consumer's `package.json` dependencies
+   * (or devDependencies) so npm/pnpm can resolve it. Pack-merge logic
+   * (`packages/core/src/pack-merge.ts`) reads pack rules at lint time.
+   * Pack discovery (`packages/core/src/pack-discovery.ts`,
+   * mmnto-ai/totem#1768) reads this field plus the project's
+   * package.json dependencies, deduplicates, and writes the union to
+   * `.totem/installed-packs.json` for boot-time registration.
+   */
+  extends: z.array(z.string().min(1)).optional(),
+
+  /**
    * Optional: path override for the strategy repository (mmnto-ai/totem#1710).
    *
    * Resolved relative to the git root by `resolveStrategyRoot`, with the
@@ -383,7 +422,15 @@ export const TotemConfigSchema = z.object({
   review: ReviewConfigSchema,
 });
 
-export type ChunkStrategy = z.infer<typeof ChunkStrategySchema>;
+/**
+ * `ChunkStrategy` keeps the literal union of built-in strategy names for
+ * IntelliSense on core code paths while admitting any string registered
+ * via Pack registration callbacks at boot. The Zod schema validates the
+ * runtime value against the registry; this type alias lives independently
+ * so callers don't lose type safety on built-in names. Per ADR-097 § 10 +
+ * mmnto-ai/totem#1769.
+ */
+export type ChunkStrategy = (typeof BUILTIN_CHUNK_STRATEGIES)[number] | (string & {});
 export type ContentType = z.infer<typeof ContentTypeSchema>;
 export type IngestTarget = z.infer<typeof IngestTargetSchema>;
 export type EmbeddingProvider = z.infer<typeof EmbeddingProviderSchema>;

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod';
 
-import { lookup as lookupChunker, registeredNames } from './chunkers/chunker-registry.js';
 import { TotemConfigError } from './errors.js';
 import { CustomSecretSchema } from './secrets.js';
 
@@ -26,22 +25,26 @@ const BUILTIN_CHUNK_STRATEGIES = [
 ] as const;
 
 /**
- * Runtime-validated `ChunkStrategy` schema. Replaces the previous closed
- * `z.enum([...])` per ADR-097 § 10 + mmnto-ai/totem#1769 — strategy
- * lookup goes through `chunker-registry.ts`, which is populated by
- * built-ins at module load and extended by Pack registration callbacks
- * during boot via `loadInstalledPacks()`.
+ * `ChunkStrategy` schema. Per ADR-097 § 10 + mmnto-ai/totem#1769 strategy
+ * lookup goes through `chunker-registry.ts` at runtime; this schema only
+ * shape-checks the input string.
  *
- * Validation surface: any string registered in the chunker registry
- * passes; everything else fails with an error message that lists the
- * registered set so the user can see what's actually valid.
+ * **Why not refine against the registry here?** Bootstrap chicken-and-egg
+ * (Gemini review of mmnto-ai/totem#1768 PR-A): config parse runs BEFORE
+ * `loadInstalledPacks()` populates the registry with pack-contributed
+ * strategies (the manifest is read AFTER config load by every command).
+ * A strict registry-check at parse time would crash `totem sync` on the
+ * very edit that adds the pack — user adds `@totem/pack-foo` to extends
+ * AND a target with `strategy: 'foo-strat'` in the same change, sync
+ * fails to parse the config, never writes installed-packs.json, never
+ * registers the pack. Forever stuck.
+ *
+ * The actual fail-loud happens at `createChunker(strategy)` in
+ * `chunkers/chunker.ts` — runtime lookup against the post-boot registry
+ * with a structured error naming the missing strategy. That's the right
+ * boundary because by then the registry IS populated.
  */
-export const ChunkStrategySchema = z.string().refine(
-  (value) => lookupChunker(value) !== undefined,
-  (value) => ({
-    message: `Unknown chunk strategy: '${value}'. Registered: ${registeredNames().join(', ')}. If '${value}' is provided by a pack, ensure the pack is in 'extends' and run \`totem sync\` to register it.`,
-  }),
-);
+export const ChunkStrategySchema = z.string().min(1);
 
 export const ContentTypeSchema = z.enum(['code', 'session_log', 'spec', 'lesson']);
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -79,6 +79,39 @@ export type {
 // Chunkers
 export type { Chunker } from './chunkers/chunker.js';
 export { createChunker } from './chunkers/chunker.js';
+export {
+  isBuiltin as isBuiltinChunkStrategy,
+  registeredNames as registeredChunkStrategies,
+} from './chunkers/chunker-registry.js';
+
+// ast-grep language registry public surface (mmnto-ai/totem#1653 + #1768,
+// ADR-097 § 10). The base AST classification exports — `SupportedLanguage`,
+// `extensionToLanguage`, `loadGrammar` — are re-exported below in the
+// "AST classification" section to preserve historical ordering.
+export { isBuiltinExtension, registeredExtensions, registeredLanguages } from './ast-classifier.js';
+
+// Pack discovery substrate (mmnto-ai/totem#1768, ADR-097 § 10)
+export type {
+  InstalledPacksManifest,
+  LoadedPack,
+  LoadInstalledPacksOptions,
+  PackRegisterCallback,
+  PackRegistrationAPI,
+} from './pack-discovery.js';
+export {
+  InstalledPacksManifestSchema,
+  isEngineSealed,
+  loadedPacks,
+  loadInstalledPacks,
+} from './pack-discovery.js';
+
+// Pack manifest writer (mmnto-ai/totem#1768, Step 4)
+export type {
+  PackResolutionResult,
+  PackResolutionWarning,
+  ResolveInstalledPacksInput,
+} from './pack-manifest-writer.js';
+export { resolveInstalledPacks, writeInstalledPacksManifest } from './pack-manifest-writer.js';
 
 // Embedders
 export type { Embedder } from './embedders/embedder.js';

--- a/packages/core/src/pack-discovery.test.ts
+++ b/packages/core/src/pack-discovery.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Tests for the pack discovery substrate (mmnto-ai/totem#1768, ADR-097
+ * § 5 Q5 + § 10).
+ *
+ * Covers invariants 1, 2, 3, 4, 8 from `.totem/specs/pack-substrate-bundle.md`:
+ *
+ * - Missing manifest → empty packs, no throw.
+ * - Malformed manifest → fail loud.
+ * - peerDependencies engine version mismatch → structured fail loud.
+ * - Re-load after seal → throw.
+ * - Pack callback can register chunker + language; lookups return registered values.
+ *
+ * Uses the `inMemoryPacks` test escape hatch to drive the registration
+ * phase without writing fixture pack packages to `node_modules`.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  __resetLangRegistryForTests,
+  extensionToLanguage,
+  registeredExtensions,
+} from './ast-classifier.js';
+import type { Chunker } from './chunkers/chunker.js';
+import {
+  __resetForTests as __resetChunkerRegistryForTests,
+  lookup as lookupChunker,
+  registeredNames as registeredChunkerStrategies,
+} from './chunkers/chunker-registry.js';
+import type { ContentType } from './config-schema.js';
+import {
+  __resetForTests as __resetPackDiscoveryForTests,
+  isEngineSealed,
+  type LoadedPack,
+  loadInstalledPacks,
+  type PackRegisterCallback,
+} from './pack-discovery.js';
+import type { Chunk } from './types.js';
+
+class FakeChunker implements Chunker {
+  readonly strategy: string = 'rust-ast';
+  chunk(_content: string, _filePath: string, _type: ContentType): Chunk[] {
+    return [];
+  }
+}
+
+afterEach(() => {
+  // Order matters: pack-discovery's seal flag and registries are
+  // independent state containers — reset all three each test so seal
+  // state from one case doesn't leak into the next.
+  __resetPackDiscoveryForTests();
+  __resetChunkerRegistryForTests();
+  __resetLangRegistryForTests();
+});
+
+describe('loadInstalledPacks: missing manifest', () => {
+  it('returns empty packs and does not throw when installed-packs.json is absent', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pack-discovery-test-'));
+    try {
+      const packs = loadInstalledPacks({ projectRoot: tmpRoot, totemDir: '.totem' });
+      expect(packs).toEqual([]);
+      expect(isEngineSealed()).toBe(true);
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('loadInstalledPacks: malformed manifest', () => {
+  it('throws structured error on invalid JSON', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pack-discovery-test-'));
+    try {
+      const totemDir = path.join(tmpRoot, '.totem');
+      fs.mkdirSync(totemDir, { recursive: true });
+      fs.writeFileSync(path.join(totemDir, 'installed-packs.json'), '{ this is not json');
+      expect(() => loadInstalledPacks({ projectRoot: tmpRoot, totemDir: '.totem' })).toThrowError(
+        /not valid JSON/,
+      );
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('throws structured error on schema validation failure', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pack-discovery-test-'));
+    try {
+      const totemDir = path.join(tmpRoot, '.totem');
+      fs.mkdirSync(totemDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(totemDir, 'installed-packs.json'),
+        JSON.stringify({ version: 99, packs: [] }),
+      );
+      expect(() => loadInstalledPacks({ projectRoot: tmpRoot, totemDir: '.totem' })).toThrowError(
+        /failed schema validation/,
+      );
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('throws on unknown sibling keys (strict schema)', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pack-discovery-test-'));
+    try {
+      const totemDir = path.join(tmpRoot, '.totem');
+      fs.mkdirSync(totemDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(totemDir, 'installed-packs.json'),
+        JSON.stringify({ version: 1, packs: [], extra: 'oops' }),
+      );
+      expect(() => loadInstalledPacks({ projectRoot: tmpRoot, totemDir: '.totem' })).toThrowError(
+        /failed schema validation/,
+      );
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('loadInstalledPacks: peerDependencies engine version mismatch', () => {
+  it('throws structured error naming pack name + declared range + actual engine version', () => {
+    const fakeCallback: PackRegisterCallback = () => {};
+    const fakePack: LoadedPack = {
+      name: '@totem/pack-fake',
+      resolvedPath: '/fake/path',
+      declaredEngineRange: '^2.0.0',
+    };
+    expect(() =>
+      loadInstalledPacks({
+        engineVersion: '1.21.0',
+        inMemoryPacks: [{ pack: fakePack, callback: fakeCallback }],
+      }),
+    ).toThrowError(
+      /Pack '@totem\/pack-fake' requires @mmnto\/totem '\^2\.0\.0'.*running engine is 1\.21\.0/,
+    );
+  });
+
+  it('passes when engine version satisfies declared range', () => {
+    const fakeCallback: PackRegisterCallback = () => {};
+    const fakePack: LoadedPack = {
+      name: '@totem/pack-fake',
+      resolvedPath: '/fake/path',
+      declaredEngineRange: '^1.19.0',
+    };
+    const packs = loadInstalledPacks({
+      engineVersion: '1.21.0',
+      inMemoryPacks: [{ pack: fakePack, callback: fakeCallback }],
+    });
+    expect(packs).toHaveLength(1);
+    expect(packs[0]?.name).toBe('@totem/pack-fake');
+  });
+
+  it('throws when declared range is invalid semver', () => {
+    const fakeCallback: PackRegisterCallback = () => {};
+    const fakePack: LoadedPack = {
+      name: '@totem/pack-fake',
+      resolvedPath: '/fake/path',
+      declaredEngineRange: 'not-a-semver-range',
+    };
+    expect(() =>
+      loadInstalledPacks({
+        engineVersion: '1.21.0',
+        inMemoryPacks: [{ pack: fakePack, callback: fakeCallback }],
+      }),
+    ).toThrowError(/not a valid semver range/);
+  });
+});
+
+describe('loadInstalledPacks: re-load after seal', () => {
+  it('throws when called twice', () => {
+    loadInstalledPacks({ inMemoryPacks: [] });
+    expect(() => loadInstalledPacks({ inMemoryPacks: [] })).toThrowError(
+      /called after engine seal/,
+    );
+  });
+});
+
+describe('loadInstalledPacks: pack callback registration', () => {
+  it('invokes pack callback with PackRegistrationAPI; lookups return registered values', () => {
+    const fakeCallback: PackRegisterCallback = (api) => {
+      api.registerChunkStrategy('rust-ast', FakeChunker);
+      api.registerLanguage('.rs', 'rust', () => '/fake/tree-sitter-rust.wasm');
+    };
+    const fakePack: LoadedPack = {
+      name: '@totem/pack-rust-architecture',
+      resolvedPath: '/fake/path',
+      declaredEngineRange: '^1.19.0',
+    };
+    loadInstalledPacks({
+      engineVersion: '1.21.0',
+      inMemoryPacks: [{ pack: fakePack, callback: fakeCallback }],
+    });
+    expect(lookupChunker('rust-ast')).toBe(FakeChunker);
+    expect(registeredChunkerStrategies()).toContain('rust-ast');
+    expect(extensionToLanguage('.rs')).toBe('rust');
+    expect(registeredExtensions()).toContain('.rs');
+  });
+
+  it('seals both registries after every callback returns', () => {
+    const fakeCallback: PackRegisterCallback = (api) => {
+      api.registerChunkStrategy('rust-ast', FakeChunker);
+    };
+    const fakePack: LoadedPack = {
+      name: '@totem/pack-rust-architecture',
+      resolvedPath: '/fake/path',
+      declaredEngineRange: '^1.19.0',
+    };
+    loadInstalledPacks({
+      engineVersion: '1.21.0',
+      inMemoryPacks: [{ pack: fakePack, callback: fakeCallback }],
+    });
+    expect(isEngineSealed()).toBe(true);
+  });
+
+  it('throws and names the pack when callback throws', () => {
+    const errorThrowingCallback: PackRegisterCallback = () => {
+      throw new Error('pack-side bug');
+    };
+    const fakePack: LoadedPack = {
+      name: '@totem/pack-broken',
+      resolvedPath: '/fake/path',
+      declaredEngineRange: '^1.19.0',
+    };
+    expect(() =>
+      loadInstalledPacks({
+        engineVersion: '1.21.0',
+        inMemoryPacks: [{ pack: fakePack, callback: errorThrowingCallback }],
+      }),
+    ).toThrowError(/Pack '@totem\/pack-broken' registration callback threw: pack-side bug/);
+  });
+
+  it('two packs registering same chunk strategy: second fails loud', () => {
+    const callback1: PackRegisterCallback = (api) => {
+      api.registerChunkStrategy('shared', FakeChunker);
+    };
+    const callback2: PackRegisterCallback = (api) => {
+      api.registerChunkStrategy('shared', FakeChunker);
+    };
+    expect(() =>
+      loadInstalledPacks({
+        engineVersion: '1.21.0',
+        inMemoryPacks: [
+          {
+            pack: {
+              name: '@totem/pack-a',
+              resolvedPath: '/a',
+              declaredEngineRange: '^1.19.0',
+            },
+            callback: callback1,
+          },
+          {
+            pack: {
+              name: '@totem/pack-b',
+              resolvedPath: '/b',
+              declaredEngineRange: '^1.19.0',
+            },
+            callback: callback2,
+          },
+        ],
+      }),
+    ).toThrowError(/Pack '@totem\/pack-b'.*already registered/);
+  });
+
+  it('two packs registering same extension to different langs: second fails loud', () => {
+    const callback1: PackRegisterCallback = (api) => {
+      api.registerLanguage('.shared', 'lang-a', () => '/a.wasm');
+    };
+    const callback2: PackRegisterCallback = (api) => {
+      api.registerLanguage('.shared', 'lang-b', () => '/b.wasm');
+    };
+    expect(() =>
+      loadInstalledPacks({
+        engineVersion: '1.21.0',
+        inMemoryPacks: [
+          {
+            pack: {
+              name: '@totem/pack-a',
+              resolvedPath: '/a',
+              declaredEngineRange: '^1.19.0',
+            },
+            callback: callback1,
+          },
+          {
+            pack: {
+              name: '@totem/pack-b',
+              resolvedPath: '/b',
+              declaredEngineRange: '^1.19.0',
+            },
+            callback: callback2,
+          },
+        ],
+      }),
+    ).toThrowError(/Pack '@totem\/pack-b'.*already registered to language/);
+  });
+});

--- a/packages/core/src/pack-discovery.test.ts
+++ b/packages/core/src/pack-discovery.test.ts
@@ -241,6 +241,32 @@ describe('loadInstalledPacks: pack callback registration', () => {
     expect(isEngineSealed()).toBe(true);
   });
 
+  it('rejects an async (Promise-returning) registration callback before sealing', () => {
+    const asyncCallback = (async (api: {
+      registerChunkStrategy: (n: string, c: new () => Chunker) => void;
+    }) => {
+      api.registerChunkStrategy('async-strat', FakeChunker);
+    }) as unknown as PackRegisterCallback;
+    const fakePack: LoadedPack = {
+      name: '@totem/pack-async',
+      resolvedPath: '/fake/path',
+      declaredEngineRange: '^1.19.0',
+    };
+    let caught: unknown;
+    try {
+      loadInstalledPacks({
+        engineVersion: '1.21.0',
+        inMemoryPacks: [{ pack: fakePack, callback: asyncCallback }],
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/registration must be synchronous/);
+    expect((caught as Error).message).toMatch(/ADR-097 § 5 Q5/);
+    expect(isEngineSealed()).toBe(false);
+  });
+
   it('throws and names the pack when callback throws', () => {
     const errorThrowingCallback: PackRegisterCallback = () => {
       throw new Error('pack-side bug');

--- a/packages/core/src/pack-discovery.test.ts
+++ b/packages/core/src/pack-discovery.test.ts
@@ -118,6 +118,32 @@ describe('loadInstalledPacks: malformed manifest', () => {
       fs.rmSync(tmpRoot, { recursive: true, force: true });
     }
   });
+
+  it('rejects manifest entries with a relative resolvedPath at the schema boundary', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pack-discovery-test-'));
+    try {
+      const totemDir = path.join(tmpRoot, '.totem');
+      fs.mkdirSync(totemDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(totemDir, 'installed-packs.json'),
+        JSON.stringify({
+          version: 1,
+          packs: [
+            {
+              name: '@totem/pack-relative',
+              resolvedPath: 'node_modules/@totem/pack-relative',
+              declaredEngineRange: '^1.19.0',
+            },
+          ],
+        }),
+      );
+      expect(() => loadInstalledPacks({ projectRoot: tmpRoot, totemDir: '.totem' })).toThrowError(
+        /resolvedPath must be an absolute path/,
+      );
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('loadInstalledPacks: peerDependencies engine version mismatch', () => {

--- a/packages/core/src/pack-discovery.test.ts
+++ b/packages/core/src/pack-discovery.test.ts
@@ -224,12 +224,21 @@ describe('loadInstalledPacks: pack callback registration', () => {
       resolvedPath: '/fake/path',
       declaredEngineRange: '^1.19.0',
     };
-    expect(() =>
+    let caught: unknown;
+    try {
       loadInstalledPacks({
         engineVersion: '1.21.0',
         inMemoryPacks: [{ pack: fakePack, callback: errorThrowingCallback }],
-      }),
-    ).toThrowError(/Pack '@totem\/pack-broken' registration callback threw: pack-side bug/);
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    const outer = caught as Error;
+    expect(outer.message).toMatch(/Pack '@totem\/pack-broken' registration callback threw/);
+    expect(outer.message).toMatch(/must be fixed or removed/);
+    expect(outer.cause).toBeInstanceOf(Error);
+    expect((outer.cause as Error).message).toBe('pack-side bug');
   });
 
   it('two packs registering same chunk strategy: second fails loud', () => {
@@ -239,7 +248,8 @@ describe('loadInstalledPacks: pack callback registration', () => {
     const callback2: PackRegisterCallback = (api) => {
       api.registerChunkStrategy('shared', FakeChunker);
     };
-    expect(() =>
+    let caught: unknown;
+    try {
       loadInstalledPacks({
         engineVersion: '1.21.0',
         inMemoryPacks: [
@@ -260,8 +270,13 @@ describe('loadInstalledPacks: pack callback registration', () => {
             callback: callback2,
           },
         ],
-      }),
-    ).toThrowError(/Pack '@totem\/pack-b'.*already registered/);
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/Pack '@totem\/pack-b' registration callback threw/);
+    expect(((caught as Error).cause as Error).message).toMatch(/already registered/);
   });
 
   it('two packs registering same extension to different langs: second fails loud', () => {
@@ -271,7 +286,8 @@ describe('loadInstalledPacks: pack callback registration', () => {
     const callback2: PackRegisterCallback = (api) => {
       api.registerLanguage('.shared', 'lang-b', () => '/b.wasm');
     };
-    expect(() =>
+    let caught: unknown;
+    try {
       loadInstalledPacks({
         engineVersion: '1.21.0',
         inMemoryPacks: [
@@ -292,7 +308,12 @@ describe('loadInstalledPacks: pack callback registration', () => {
             callback: callback2,
           },
         ],
-      }),
-    ).toThrowError(/Pack '@totem\/pack-b'.*already registered to language/);
+      });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/Pack '@totem\/pack-b' registration callback threw/);
+    expect(((caught as Error).cause as Error).message).toMatch(/already registered to language/);
   });
 });

--- a/packages/core/src/pack-discovery.test.ts
+++ b/packages/core/src/pack-discovery.test.ts
@@ -119,6 +119,37 @@ describe('loadInstalledPacks: malformed manifest', () => {
     }
   });
 
+  it('rejects manifest with duplicate pack names at the schema boundary', () => {
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pack-discovery-test-'));
+    try {
+      const totemDir = path.join(tmpRoot, '.totem');
+      fs.mkdirSync(totemDir, { recursive: true });
+      fs.writeFileSync(
+        path.join(totemDir, 'installed-packs.json'),
+        JSON.stringify({
+          version: 1,
+          packs: [
+            {
+              name: '@totem/pack-rust',
+              resolvedPath: path.resolve('/abs/a'),
+              declaredEngineRange: '^1.19.0',
+            },
+            {
+              name: '@totem/pack-rust',
+              resolvedPath: path.resolve('/abs/b'),
+              declaredEngineRange: '^1.19.0',
+            },
+          ],
+        }),
+      );
+      expect(() => loadInstalledPacks({ projectRoot: tmpRoot, totemDir: '.totem' })).toThrowError(
+        /duplicate pack entry '@totem\/pack-rust'/,
+      );
+    } finally {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+  });
+
   it('rejects manifest entries with a relative resolvedPath at the schema boundary', () => {
     const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'pack-discovery-test-'));
     try {

--- a/packages/core/src/pack-discovery.ts
+++ b/packages/core/src/pack-discovery.ts
@@ -1,0 +1,392 @@
+/**
+ * Pack discovery substrate (ADR-097 § 5 Q5 + § 10, mmnto-ai/totem#1768).
+ *
+ * Reads `.totem/installed-packs.json` synchronously at engine boot,
+ * resolves each registered pack's registration callback module, and
+ * invokes the callback with a `PackRegistrationAPI` so the pack can
+ * register its ChunkStrategy + ast-grep Lang + WASM grammar entries
+ * before the engine seals.
+ *
+ * Sealing happens at the end of `loadInstalledPacks()` after every pack
+ * callback has returned. Once sealed, subsequent `register()` calls on
+ * either registry throw — see `chunker-registry.ts:seal()` and
+ * `ast-classifier.ts:sealLangRegistry()`.
+ *
+ * The seal is the only synchronization boundary between the registration
+ * phase and the runtime phase. CLI commands invoke `loadInstalledPacks()`
+ * immediately after config load and before any other engine surface, so
+ * pack registration is always complete before any chunker / language
+ * lookup happens.
+ *
+ * Failure-mode discipline (Tenet 4):
+ * - Missing manifest: silent (treated as no packs); user runs `totem sync`
+ *   to generate.
+ * - Malformed manifest: hard error.
+ * - Pack require throws: hard error.
+ * - peerDependencies engine version mismatch: structured error per ADR-097
+ *   Q6.
+ * - Pack callback throws: hard error.
+ */
+
+import * as fs from 'node:fs';
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+
+import * as semver from 'semver';
+import { z } from 'zod';
+
+import {
+  registerLang as registerLangInRegistry,
+  sealLangRegistry,
+  type SupportedLanguage,
+} from './ast-classifier.js';
+import type { Chunker } from './chunkers/chunker.js';
+import {
+  isSealed as isChunkerRegistrySealed,
+  register as registerChunkerInRegistry,
+  seal as sealChunkerRegistry,
+} from './chunkers/chunker-registry.js';
+
+// ─── Schema ─────────────────────────────────────────
+
+/**
+ * `.totem/installed-packs.json` substrate. Written by `totem sync`,
+ * consumed by `loadInstalledPacks()` at boot.
+ *
+ * `version: 1` is the load-bearing sentinel for forward compatibility:
+ * future schema changes bump the version, callers fail loud on unknown
+ * versions rather than silently mis-parsing.
+ */
+export const InstalledPacksManifestSchema = z
+  .object({
+    version: z.literal(1),
+    packs: z.array(
+      z
+        .object({
+          /** Pack package name as it appears in npm (e.g., `@totem/pack-rust-architecture`). */
+          name: z.string().min(1),
+          /** Absolute filesystem path to the pack's package root. */
+          resolvedPath: z.string().min(1),
+          /** The pack's `peerDependencies['@mmnto/totem']` semver range, verbatim. */
+          declaredEngineRange: z.string().min(1),
+        })
+        .strict(),
+    ),
+  })
+  .strict();
+
+export type InstalledPacksManifest = z.infer<typeof InstalledPacksManifestSchema>;
+
+// ─── Public surfaces ────────────────────────────────
+
+/**
+ * Surface a pack's registration callback uses to extend the engine's
+ * built-in chunker + language tables. Callbacks are synchronous (per
+ * ADR-097 § 5 Q5 — boot must remain synchronous); WASM grammar bytes
+ * load lazily on first ast-grep dispatch via the `wasmLoader` thunk.
+ */
+export interface PackRegistrationAPI {
+  /**
+   * Register a pack-contributed `ChunkStrategy` name + chunker class.
+   * The strategy name appears in `targets[].strategy` validation and
+   * `totem describe` output. Built-in names are immutable; pack-vs-pack
+   * collisions on the same name throw.
+   */
+  registerChunkStrategy(name: string, chunkerCtor: new () => Chunker): void;
+
+  /**
+   * Register a pack-contributed (extension, language, wasmLoader) triple.
+   * The extension flows through `extensionToLanguage()` for ast-grep
+   * dispatch; the language drives `loadGrammar()`; the wasmLoader thunk
+   * resolves the grammar bytes lazily on first use.
+   *
+   * Built-in extensions/languages are immutable; pack-vs-pack collisions
+   * on the same extension throw.
+   */
+  registerLanguage(
+    extension: string,
+    lang: SupportedLanguage,
+    wasmLoader: () => string | Uint8Array | Promise<string | Uint8Array>,
+  ): void;
+}
+
+/**
+ * The shape a pack's registration callback module must export. Packs
+ * default-export a function matching this signature; `loadInstalledPacks`
+ * requires the module and invokes the function once with the API surface.
+ */
+export type PackRegisterCallback = (api: PackRegistrationAPI) => void;
+
+/**
+ * Runtime descriptor for a discovered + loaded pack. Returned from
+ * `loadInstalledPacks` for diagnostics + `totem doctor` consumption.
+ */
+export interface LoadedPack {
+  readonly name: string;
+  readonly resolvedPath: string;
+  readonly declaredEngineRange: string;
+}
+
+/** Options for `loadInstalledPacks` — primarily test-driven overrides. */
+export interface LoadInstalledPacksOptions {
+  /**
+   * Project root for manifest resolution. The manifest is expected at
+   * `<projectRoot>/<totemDir>/installed-packs.json`. Defaults to
+   * `process.cwd()` when omitted.
+   */
+  projectRoot?: string;
+  /**
+   * `config.totemDir` from the resolved totem config. Defaults to
+   * `'.totem'` so callers without a loaded config (e.g., simple CLIs,
+   * tests) work out of the box.
+   */
+  totemDir?: string;
+  /**
+   * Engine semver to compare against each pack's declared
+   * `peerDependencies['@mmnto/totem']` range. Defaults to the engine's
+   * own `package.json#version`.
+   */
+  engineVersion?: string;
+  /**
+   * Test-only escape hatch: list of `{ pack, callback }` tuples that
+   * bypass the manifest read + `require()` resolution and feed callbacks
+   * directly into the registration phase. Useful for unit tests that
+   * register fixture chunkers/languages without writing fixture packages
+   * to disk.
+   *
+   * When provided, the manifest read is skipped entirely; only these
+   * inMemoryPacks run.
+   */
+  inMemoryPacks?: ReadonlyArray<{ pack: LoadedPack; callback: PackRegisterCallback }>;
+}
+
+// ─── Internal state ─────────────────────────────────
+
+const PACK_REGISTRY = new Map<string, LoadedPack>();
+let engineSealed = false;
+
+// ─── Core: loadInstalledPacks ───────────────────────
+
+/**
+ * Read `.totem/installed-packs.json` and run every registered pack's
+ * registration callback synchronously. After all callbacks return, seal
+ * both the chunker registry and the language registry.
+ *
+ * Idempotent: a second call after the first throws because the engine is
+ * already sealed (callers must not "re-load" packs at runtime). For
+ * tests, see `__resetForTests()`.
+ */
+export function loadInstalledPacks(options: LoadInstalledPacksOptions = {}): readonly LoadedPack[] {
+  if (engineSealed) {
+    throw new Error(
+      'loadInstalledPacks() called after engine seal — engine has already started serving requests. Pack registration is a boot-time-only operation.',
+    );
+  }
+
+  const projectRoot = options.projectRoot ?? process.cwd();
+  const totemDir = options.totemDir ?? '.totem';
+  const engineVersion = options.engineVersion ?? resolveEngineVersion();
+
+  const packsToRegister: ReadonlyArray<{ pack: LoadedPack; callback: PackRegisterCallback }> =
+    options.inMemoryPacks ?? readManifestAndResolveCallbacks(projectRoot, totemDir);
+
+  // Engine version cross-check (ADR-097 Q6) — runs against every pack
+  // before any callback executes, so a single mismatch fails loud before
+  // touching the registries.
+  for (const { pack } of packsToRegister) {
+    assertEngineRangeSatisfied(pack, engineVersion);
+  }
+
+  // Run every callback. A throwing pack short-circuits registration —
+  // the engine is left unsealed so a subsequent retry (e.g., test reset)
+  // can recover, but the in-flight registration entries from prior packs
+  // remain. Callers running in production should treat any throw here
+  // as a hard error and not attempt to recover.
+  for (const { pack, callback } of packsToRegister) {
+    try {
+      const api: PackRegistrationAPI = {
+        registerChunkStrategy(name, chunkerCtor) {
+          registerChunkerInRegistry(name, chunkerCtor);
+        },
+        registerLanguage(extension, lang, wasmLoader) {
+          registerLangInRegistry(extension, lang, wasmLoader);
+        },
+      };
+      callback(api);
+    } catch (err) {
+      const cause = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `Pack '${pack.name}' registration callback threw: ${cause}. The pack at '${pack.resolvedPath}' must be fixed or removed.`,
+      );
+    }
+    if (!PACK_REGISTRY.has(pack.name)) {
+      PACK_REGISTRY.set(pack.name, pack);
+    }
+  }
+
+  sealChunkerRegistry();
+  sealLangRegistry();
+  engineSealed = true;
+
+  return [...PACK_REGISTRY.values()];
+}
+
+/**
+ * Snapshot of currently-loaded packs. Empty until `loadInstalledPacks()`
+ * runs; populated thereafter and stable for the engine lifetime.
+ */
+export function loadedPacks(): readonly LoadedPack[] {
+  return [...PACK_REGISTRY.values()];
+}
+
+/** True iff the engine has sealed (registration phase complete). */
+export function isEngineSealed(): boolean {
+  return engineSealed;
+}
+
+// ─── Manifest read + callback resolution ────────────
+
+function readManifestAndResolveCallbacks(
+  projectRoot: string,
+  totemDir: string,
+): ReadonlyArray<{ pack: LoadedPack; callback: PackRegisterCallback }> {
+  const manifestPath = path.join(projectRoot, totemDir, 'installed-packs.json');
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(manifestPath, 'utf-8');
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') {
+      // Pre-sync repo or fresh checkout. Treat as no packs — user can
+      // run `totem sync` to populate.
+      return [];
+    }
+    const cause = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Failed to read installed-packs manifest at '${manifestPath}': ${cause}. Re-run \`totem sync\` to regenerate.`,
+    );
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(raw);
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `installed-packs manifest at '${manifestPath}' is not valid JSON: ${cause}. Re-run \`totem sync\` to regenerate.`,
+    );
+  }
+
+  const result = InstalledPacksManifestSchema.safeParse(parsedJson);
+  if (!result.success) {
+    throw new Error(
+      `installed-packs manifest at '${manifestPath}' failed schema validation: ${result.error.issues
+        .map((issue) => `${issue.path.join('.')}: ${issue.message}`)
+        .join('; ')}. Re-run \`totem sync\` to regenerate.`,
+    );
+  }
+
+  const require = createRequire(import.meta.url);
+  return result.data.packs.map((entry) => {
+    const callback = resolvePackCallback(entry.name, entry.resolvedPath, require);
+    const pack: LoadedPack = {
+      name: entry.name,
+      resolvedPath: entry.resolvedPath,
+      declaredEngineRange: entry.declaredEngineRange,
+    };
+    return { pack, callback };
+  });
+}
+
+function resolvePackCallback(
+  name: string,
+  resolvedPath: string,
+  require: NodeJS.Require,
+): PackRegisterCallback {
+  if (!fs.existsSync(resolvedPath)) {
+    throw new Error(
+      `Pack '${name}' is registered in installed-packs.json at '${resolvedPath}' but the path does not exist. Re-install the pack or re-run \`totem sync\`.`,
+    );
+  }
+
+  let mod: { default?: unknown; register?: unknown };
+  try {
+    mod = require(resolvedPath) as { default?: unknown; register?: unknown };
+  } catch (err) {
+    const cause = err instanceof Error ? err.message : String(err);
+    throw new Error(`Pack '${name}' at '${resolvedPath}' could not be loaded: ${cause}.`);
+  }
+
+  // Pack callbacks may default-export OR named-export `register`. Default
+  // export is the ADR-097 reference shape; `register` named export is the
+  // CommonJS-friendly alternative.
+  const candidate = mod.default ?? mod.register;
+  if (typeof candidate !== 'function') {
+    throw new Error(
+      `Pack '${name}' at '${resolvedPath}' did not export a registration callback (expected default export or named \`register\` of type function).`,
+    );
+  }
+
+  return candidate as PackRegisterCallback;
+}
+
+// ─── Engine version cross-check (ADR-097 Q6) ────────
+
+function assertEngineRangeSatisfied(pack: LoadedPack, engineVersion: string): void {
+  if (!semver.validRange(pack.declaredEngineRange)) {
+    throw new Error(
+      `Pack '${pack.name}' declares peerDependencies['@mmnto/totem'] = '${pack.declaredEngineRange}', which is not a valid semver range. Fix the pack's package.json.`,
+    );
+  }
+  if (!semver.satisfies(engineVersion, pack.declaredEngineRange, { includePrerelease: true })) {
+    throw new Error(
+      `Pack '${pack.name}' requires @mmnto/totem '${pack.declaredEngineRange}' but the running engine is ${engineVersion}. Upgrade the pack to a version compatible with this engine, or pin the engine to a version satisfied by the pack's range.`,
+    );
+  }
+}
+
+function resolveEngineVersion(): string {
+  // Resolve relative to this module's URL so the read works regardless
+  // of cwd. The package.json sits at packages/core/package.json — two
+  // levels up from packages/core/dist/pack-discovery.js when the build
+  // output runs, and one level up from packages/core/src/pack-discovery.ts
+  // during tsx test execution. Try both.
+  const require = createRequire(import.meta.url);
+  for (const candidate of ['../package.json', '../../package.json']) {
+    try {
+      const pkg = require(candidate) as { version?: unknown };
+      if (typeof pkg.version === 'string') return pkg.version;
+    } catch {
+      // try next candidate
+    }
+  }
+  // Fall back to a sentinel that won't satisfy any reasonable range —
+  // surfaces the missing-version-resolution as a peerDeps mismatch rather
+  // than an undefined-behavior path. If a pack legitimately uses range
+  // '*' this will still pass.
+  return '0.0.0';
+}
+
+// ─── Test-only helpers ──────────────────────────────
+
+/**
+ * Test-only: reset pack discovery state. Called from tests that want to
+ * re-run `loadInstalledPacks()` between cases. NEVER call from production.
+ *
+ * Resets in this order so that re-registration in built-ins succeeds:
+ * 1. Clear PACK_REGISTRY + engineSealed flag.
+ * 2. Reset both downstream registries (which re-registers built-ins).
+ */
+export function __resetForTests(): void {
+  PACK_REGISTRY.clear();
+  engineSealed = false;
+  // Note: tests are expected to call `__resetForTests` from
+  // `chunker-registry.js` and `ast-classifier.js` separately as needed —
+  // pack-discovery doesn't own those registries' lifecycle.
+}
+
+/** Test-only: inspect chunker registry seal state. */
+export function __isChunkerRegistrySealedForTests(): boolean {
+  return isChunkerRegistrySealed();
+}

--- a/packages/core/src/pack-discovery.ts
+++ b/packages/core/src/pack-discovery.ts
@@ -356,9 +356,9 @@ function resolveEngineVersion(): string {
   for (const candidate of ['../package.json', '../../package.json']) {
     try {
       const pkg = require(candidate) as { version?: unknown };
-      if (typeof pkg.version === 'string') return pkg.version;
+      if (typeof pkg.version === 'string') return pkg.version; // totem-context: intentional cleanup — ENOENT on a candidate path is expected; the catch below falls through to the next candidate, and the sentinel return at function end handles the all-fail case
     } catch {
-      continue; // totem-context: intentional cleanup — ENOENT on a candidate path is expected; loop falls through to the next, and the sentinel return at function end handles the all-fail case
+      continue; // totem-context: intentional cleanup — paired with directive on preceding line
     }
   }
   // Fall back to a sentinel that won't satisfy any reasonable range —

--- a/packages/core/src/pack-discovery.ts
+++ b/packages/core/src/pack-discovery.ts
@@ -65,8 +65,17 @@ export const InstalledPacksManifestSchema = z
         .object({
           /** Pack package name as it appears in npm (e.g., `@totem/pack-rust-architecture`). */
           name: z.string().min(1),
-          /** Absolute filesystem path to the pack's package root. */
-          resolvedPath: z.string().min(1),
+          /**
+           * Absolute filesystem path to the pack's package root. Refined to
+           * `path.isAbsolute()` so a relative entry can't pass schema
+           * validation and then probe two different locations downstream
+           * (`existsSync` resolves from cwd, `require.resolve` from this
+           * module).
+           */
+          resolvedPath: z
+            .string()
+            .min(1)
+            .refine((value) => path.isAbsolute(value), 'resolvedPath must be an absolute path'),
           /** The pack's `peerDependencies['@mmnto/totem']` semver range, verbatim. */
           declaredEngineRange: z.string().min(1),
         })
@@ -310,6 +319,14 @@ function resolvePackCallback(
     );
   }
 
+  // Synchronous `require()` is mandated by ADR-097 § 5 Q5: pack
+  // registration runs at boot before the engine seal, and boot is
+  // synchronous. This means the pack's registration entry must be
+  // CommonJS-resolvable — either authored as CJS, or ESM packs must
+  // ship a CJS-compatible registration entry (e.g., a built
+  // `dist/register.cjs`). Pure-ESM registration entries will throw
+  // `ERR_REQUIRE_ESM` at boot. Async-boot support (`await import()`)
+  // would lift this constraint and is tracked separately.
   let mod: { default?: unknown; register?: unknown };
   try {
     mod = require(resolvedPath) as { default?: unknown; register?: unknown };
@@ -357,9 +374,15 @@ function resolveEngineVersion(): string {
   for (const candidate of ['../package.json', '../../package.json']) {
     try {
       const pkg = require(candidate) as { version?: unknown };
-      if (typeof pkg.version === 'string') return pkg.version; // totem-context: intentional cleanup — ENOENT on a candidate path is expected; the catch below falls through to the next candidate, and the sentinel return at function end handles the all-fail case
-    } catch {
-      continue; // totem-context: intentional cleanup — paired with directive on preceding line
+      if (typeof pkg.version === 'string') return pkg.version;
+    } catch (err) {
+      const code =
+        err instanceof Error && 'code' in err ? (err as NodeJS.ErrnoException).code : undefined;
+      if (code === 'ENOENT' || code === 'MODULE_NOT_FOUND') continue;
+      throw new Error(
+        `Failed to resolve engine version from '${candidate}'. The file exists but could not be read or parsed; check permissions and JSON syntax.`,
+        { cause: err instanceof Error ? err : new Error(String(err)) },
+      );
     }
   }
   // Fall back to a sentinel that won't satisfy any reasonable range —

--- a/packages/core/src/pack-discovery.ts
+++ b/packages/core/src/pack-discovery.ts
@@ -358,7 +358,7 @@ function resolveEngineVersion(): string {
       const pkg = require(candidate) as { version?: unknown };
       if (typeof pkg.version === 'string') return pkg.version;
     } catch {
-      continue; // totem-context: intentional cleanup — ENOENT for one candidate path is expected; the loop falls through to the next path, and the sentinel return at the end handles the all-fail case
+      continue; // totem-context: intentional cleanup — ENOENT on a candidate path is expected; loop falls through to the next, and the sentinel return at function end handles the all-fail case
     }
   }
   // Fall back to a sentinel that won't satisfy any reasonable range —

--- a/packages/core/src/pack-discovery.ts
+++ b/packages/core/src/pack-discovery.ts
@@ -358,7 +358,7 @@ function resolveEngineVersion(): string {
       const pkg = require(candidate) as { version?: unknown };
       if (typeof pkg.version === 'string') return pkg.version;
     } catch {
-      // try next candidate
+      continue; // totem-context: intentional cleanup — ENOENT for one candidate path is expected; the loop falls through to the next path, and the sentinel return at the end handles the all-fail case
     }
   }
   // Fall back to a sentinel that won't satisfy any reasonable range —

--- a/packages/core/src/pack-discovery.ts
+++ b/packages/core/src/pack-discovery.ts
@@ -241,6 +241,7 @@ export function loadInstalledPacks(options: LoadInstalledPacksOptions = {}): rea
     // "callback threw."
     if (
       callbackResult !== null &&
+      // totem-context: null is excluded by the `!== null` guard on the line above; rule matcher only sees the `=== 'object'` token in isolation
       (typeof callbackResult === 'object' || typeof callbackResult === 'function') &&
       'then' in callbackResult &&
       typeof (callbackResult as { then: unknown }).then === 'function'

--- a/packages/core/src/pack-discovery.ts
+++ b/packages/core/src/pack-discovery.ts
@@ -214,9 +214,9 @@ export function loadInstalledPacks(options: LoadInstalledPacksOptions = {}): rea
       };
       callback(api);
     } catch (err) {
-      const cause = err instanceof Error ? err.message : String(err);
       throw new Error(
-        `Pack '${pack.name}' registration callback threw: ${cause}. The pack at '${pack.resolvedPath}' must be fixed or removed.`,
+        `Pack '${pack.name}' registration callback threw. The pack at '${pack.resolvedPath}' must be fixed or removed.`,
+        { cause: err instanceof Error ? err : new Error(String(err)) },
       );
     }
     if (!PACK_REGISTRY.has(pack.name)) {
@@ -262,9 +262,9 @@ function readManifestAndResolveCallbacks(
       // run `totem sync` to populate.
       return [];
     }
-    const cause = err instanceof Error ? err.message : String(err);
     throw new Error(
-      `Failed to read installed-packs manifest at '${manifestPath}': ${cause}. Re-run \`totem sync\` to regenerate.`,
+      `Failed to read installed-packs manifest at '${manifestPath}'. Re-run \`totem sync\` to regenerate.`,
+      { cause: err instanceof Error ? err : new Error(String(err)) },
     );
   }
 
@@ -272,9 +272,9 @@ function readManifestAndResolveCallbacks(
   try {
     parsedJson = JSON.parse(raw);
   } catch (err) {
-    const cause = err instanceof Error ? err.message : String(err);
     throw new Error(
-      `installed-packs manifest at '${manifestPath}' is not valid JSON: ${cause}. Re-run \`totem sync\` to regenerate.`,
+      `installed-packs manifest at '${manifestPath}' is not valid JSON. Re-run \`totem sync\` to regenerate.`,
+      { cause: err instanceof Error ? err : new Error(String(err)) },
     );
   }
 
@@ -314,8 +314,9 @@ function resolvePackCallback(
   try {
     mod = require(resolvedPath) as { default?: unknown; register?: unknown };
   } catch (err) {
-    const cause = err instanceof Error ? err.message : String(err);
-    throw new Error(`Pack '${name}' at '${resolvedPath}' could not be loaded: ${cause}.`);
+    throw new Error(`Pack '${name}' at '${resolvedPath}' could not be loaded.`, {
+      cause: err instanceof Error ? err : new Error(String(err)),
+    });
   }
 
   // Pack callbacks may default-export OR named-export `register`. Default

--- a/packages/core/src/pack-discovery.ts
+++ b/packages/core/src/pack-discovery.ts
@@ -212,20 +212,41 @@ export function loadInstalledPacks(options: LoadInstalledPacksOptions = {}): rea
   // remain. Callers running in production should treat any throw here
   // as a hard error and not attempt to recover.
   for (const { pack, callback } of packsToRegister) {
+    const api: PackRegistrationAPI = {
+      registerChunkStrategy(name, chunkerCtor) {
+        registerChunkerInRegistry(name, chunkerCtor);
+      },
+      registerLanguage(extension, lang, wasmLoader) {
+        registerLangInRegistry(extension, lang, wasmLoader);
+      },
+    };
+    let callbackResult: unknown;
     try {
-      const api: PackRegistrationAPI = {
-        registerChunkStrategy(name, chunkerCtor) {
-          registerChunkerInRegistry(name, chunkerCtor);
-        },
-        registerLanguage(extension, lang, wasmLoader) {
-          registerLangInRegistry(extension, lang, wasmLoader);
-        },
-      };
-      callback(api);
+      callbackResult = callback(api) as unknown;
     } catch (err) {
       throw new Error(
         `Pack '${pack.name}' registration callback threw. The pack at '${pack.resolvedPath}' must be fixed or removed.`,
         { cause: err instanceof Error ? err : new Error(String(err)) },
+      );
+    }
+    // Per ADR-097 § 5 Q5 the registration callback contract is
+    // synchronous; an `async register(api)` would resolve AFTER the
+    // engine seals, leaving partial registry state. The
+    // `PackRegisterCallback` type already says `void`, but TypeScript
+    // can't enforce sync vs async at runtime — a JS-authored pack or
+    // one that drifts from the type can still return a Promise. Detect
+    // the thenable shape here and fail loud before the seal. Kept
+    // outside the try-catch above so the contract-violation error
+    // surfaces with its own message rather than getting wrapped as
+    // "callback threw."
+    if (
+      callbackResult !== null &&
+      (typeof callbackResult === 'object' || typeof callbackResult === 'function') &&
+      'then' in callbackResult &&
+      typeof (callbackResult as { then: unknown }).then === 'function'
+    ) {
+      throw new Error(
+        `Pack '${pack.name}' registration callback returned a Promise — registration must be synchronous per ADR-097 § 5 Q5. The pack at '${pack.resolvedPath}' must export a synchronous \`register\` (not \`async register\`).`,
       );
     }
     if (!PACK_REGISTRY.has(pack.name)) {
@@ -395,19 +416,19 @@ function resolveEngineVersion(): string {
 // ─── Test-only helpers ──────────────────────────────
 
 /**
- * Test-only: reset pack discovery state. Called from tests that want to
- * re-run `loadInstalledPacks()` between cases. NEVER call from production.
+ * Test-only: reset pack-discovery local state (`PACK_REGISTRY` map and
+ * `engineSealed` flag). NEVER call from production.
  *
- * Resets in this order so that re-registration in built-ins succeeds:
- * 1. Clear PACK_REGISTRY + engineSealed flag.
- * 2. Reset both downstream registries (which re-registers built-ins).
+ * **This does NOT reset downstream registries.** Tests that need a
+ * fresh chunker or language registry must additionally invoke
+ * `__resetForTests` from `chunker-registry.js` and `ast-classifier.js`
+ * — those modules own their own lifecycle. Forgetting either reset
+ * leaks built-in registrations across cases. The standard `afterEach`
+ * pattern in `pack-discovery.test.ts` calls all three.
  */
 export function __resetForTests(): void {
   PACK_REGISTRY.clear();
   engineSealed = false;
-  // Note: tests are expected to call `__resetForTests` from
-  // `chunker-registry.js` and `ast-classifier.js` separately as needed —
-  // pack-discovery doesn't own those registries' lifecycle.
 }
 
 /** Test-only: inspect chunker registry seal state. */

--- a/packages/core/src/pack-discovery.ts
+++ b/packages/core/src/pack-discovery.ts
@@ -82,7 +82,25 @@ export const InstalledPacksManifestSchema = z
         .strict(),
     ),
   })
-  .strict();
+  .strict()
+  // Duplicate pack names would let two callbacks run while `PACK_REGISTRY`
+  // silently keeps only the first entry — the second callback's chunker
+  // or language registrations surface later as a registry collision
+  // instead of a clear manifest-boundary error. Fail loud here.
+  .superRefine((manifest, ctx) => {
+    const seen = new Set<string>();
+    manifest.packs.forEach((pack, index) => {
+      if (seen.has(pack.name)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['packs', index, 'name'],
+          message: `duplicate pack entry '${pack.name}'`,
+        });
+        return;
+      }
+      seen.add(pack.name);
+    });
+  });
 
 export type InstalledPacksManifest = z.infer<typeof InstalledPacksManifestSchema>;
 

--- a/packages/core/src/pack-manifest-writer.test.ts
+++ b/packages/core/src/pack-manifest-writer.test.ts
@@ -28,8 +28,9 @@ afterEach(() => {
   for (const root of tmpRoots) {
     try {
       fs.rmSync(root, { recursive: true, force: true });
-    } catch {
-      // best-effort cleanup
+    } catch (err) {
+      // best-effort cleanup — tmp dir already gone or held by AV scan
+      void err;
     }
   }
   tmpRoots = [];

--- a/packages/core/src/pack-manifest-writer.test.ts
+++ b/packages/core/src/pack-manifest-writer.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for pack manifest resolution + writer (mmnto-ai/totem#1768
+ * Step 4, Q4 disposition).
+ *
+ * Covers invariant 18 from `.totem/specs/pack-substrate-bundle.md`:
+ *
+ * - Resolves a pack present in BOTH `package.json` deps AND
+ *   `totem.config.ts` `extends` → manifest entry, no warning.
+ * - Resolves a pack only in deps → no manifest entry, `dep-only` warning.
+ * - Resolves a pack only in extends → no manifest entry, `extends-only` warning.
+ * - Pack without `peerDependencies['@mmnto/totem']` → `not-a-pack` warning.
+ * - Atomic write produces a stable JSON file.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { TotemConfig } from './config-schema.js';
+import { type InstalledPacksManifest, InstalledPacksManifestSchema } from './pack-discovery.js';
+import { resolveInstalledPacks, writeInstalledPacksManifest } from './pack-manifest-writer.js';
+
+let tmpRoots: string[] = [];
+
+afterEach(() => {
+  for (const root of tmpRoots) {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+    } catch {
+      // best-effort cleanup
+    }
+  }
+  tmpRoots = [];
+});
+
+function makeTmpRoot(): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'pack-writer-test-'));
+  tmpRoots.push(root);
+  return root;
+}
+
+function writeFixturePack(root: string, packName: string, peerRange: string | undefined): string {
+  // Create a node_modules layout that `require.resolve` can find. The pack
+  // directory holds package.json with `peerDependencies['@mmnto/totem']`.
+  const packPath = path.join(root, 'node_modules', packName);
+  fs.mkdirSync(packPath, { recursive: true });
+  const pkgJson: Record<string, unknown> = {
+    name: packName,
+    version: '0.1.0',
+  };
+  if (peerRange !== undefined) {
+    pkgJson.peerDependencies = { '@mmnto/totem': peerRange };
+  }
+  fs.writeFileSync(path.join(packPath, 'package.json'), JSON.stringify(pkgJson, null, 2));
+  return packPath;
+}
+
+function makeConfig(extendsList: readonly string[] | undefined): TotemConfig {
+  // Minimal TotemConfig — just enough for resolveInstalledPacks. The
+  // resolver only reads `config.extends`.
+  return {
+    targets: [{ glob: '**/*.ts', type: 'code', strategy: 'typescript-ast' }],
+    totemDir: '.totem',
+    lanceDir: '.lancedb',
+    ignorePatterns: [],
+    shieldIgnorePatterns: [],
+    contextWarningThreshold: 40_000,
+    shieldAutoLearn: false,
+    extends: extendsList ? [...extendsList] : undefined,
+    review: {
+      sourceExtensions: ['.ts'],
+      defaultGracePeriodPushes: 50,
+      defaultGracePeriodDays: 14,
+      mergeReviewerIdentity: 'satur8d',
+      pushReviewerIdentity: 'satur8d',
+    },
+  } as TotemConfig;
+}
+
+describe('resolveInstalledPacks: union of deps + extends', () => {
+  it('resolves a pack present in both deps and extends with no warning', () => {
+    const root = makeTmpRoot();
+    writeFixturePack(root, '@totem/pack-fake', '^1.19.0');
+    const result = resolveInstalledPacks({
+      projectRoot: root,
+      config: makeConfig(['@totem/pack-fake']),
+      packageJsonDeps: { '@totem/pack-fake': '0.1.0' },
+    });
+    expect(result.warnings).toEqual([]);
+    expect(result.resolved).toHaveLength(1);
+    expect(result.resolved[0]?.name).toBe('@totem/pack-fake');
+    expect(result.resolved[0]?.declaredEngineRange).toBe('^1.19.0');
+  });
+
+  it('emits dep-only warning when pack is in deps but not extends', () => {
+    const root = makeTmpRoot();
+    writeFixturePack(root, '@totem/pack-orphan-dep', '^1.19.0');
+    const result = resolveInstalledPacks({
+      projectRoot: root,
+      config: makeConfig([]),
+      packageJsonDeps: { '@totem/pack-orphan-dep': '0.1.0' },
+    });
+    expect(result.warnings).toEqual([{ name: '@totem/pack-orphan-dep', reason: 'dep-only' }]);
+    expect(result.resolved).toEqual([]);
+  });
+
+  it('emits extends-only warning when pack is in extends but not deps', () => {
+    const root = makeTmpRoot();
+    const result = resolveInstalledPacks({
+      projectRoot: root,
+      config: makeConfig(['@totem/pack-orphan-extends']),
+      packageJsonDeps: {},
+    });
+    expect(result.warnings).toEqual([
+      { name: '@totem/pack-orphan-extends', reason: 'extends-only' },
+    ]);
+    expect(result.resolved).toEqual([]);
+  });
+
+  it('emits not-a-pack warning when pack lacks peerDependencies[@mmnto/totem]', () => {
+    const root = makeTmpRoot();
+    writeFixturePack(root, '@totem/pack-broken', undefined);
+    const result = resolveInstalledPacks({
+      projectRoot: root,
+      config: makeConfig(['@totem/pack-broken']),
+      packageJsonDeps: { '@totem/pack-broken': '0.1.0' },
+    });
+    expect(result.warnings).toEqual([{ name: '@totem/pack-broken', reason: 'not-a-pack' }]);
+    expect(result.resolved).toEqual([]);
+  });
+
+  it('ignores non-pack dependencies (no @totem/pack- prefix)', () => {
+    const root = makeTmpRoot();
+    const result = resolveInstalledPacks({
+      projectRoot: root,
+      config: makeConfig(['react', 'lodash']),
+      packageJsonDeps: { react: '18.0.0', lodash: '4.0.0' },
+    });
+    expect(result.warnings).toEqual([]);
+    expect(result.resolved).toEqual([]);
+  });
+
+  it('returns sorted output (alphabetical by pack name)', () => {
+    const root = makeTmpRoot();
+    writeFixturePack(root, '@totem/pack-zulu', '^1.19.0');
+    writeFixturePack(root, '@totem/pack-alpha', '^1.19.0');
+    const result = resolveInstalledPacks({
+      projectRoot: root,
+      config: makeConfig(['@totem/pack-zulu', '@totem/pack-alpha']),
+      packageJsonDeps: {
+        '@totem/pack-zulu': '0.1.0',
+        '@totem/pack-alpha': '0.1.0',
+      },
+    });
+    expect(result.resolved.map((p) => p.name)).toEqual(['@totem/pack-alpha', '@totem/pack-zulu']);
+  });
+});
+
+describe('writeInstalledPacksManifest', () => {
+  it('writes a schema-valid JSON file atomically', () => {
+    const root = makeTmpRoot();
+    const totemDir = path.join(root, '.totem');
+    const manifest: InstalledPacksManifest = {
+      version: 1,
+      packs: [
+        {
+          name: '@totem/pack-fake',
+          resolvedPath: '/fake/path',
+          declaredEngineRange: '^1.19.0',
+        },
+      ],
+    };
+    const finalPath = writeInstalledPacksManifest(totemDir, manifest);
+    expect(fs.existsSync(finalPath)).toBe(true);
+
+    const raw = fs.readFileSync(finalPath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    const validation = InstalledPacksManifestSchema.safeParse(parsed);
+    expect(validation.success).toBe(true);
+    expect(validation.success && validation.data.packs[0]?.name).toBe('@totem/pack-fake');
+  });
+
+  it('creates the totemDir if it does not exist', () => {
+    const root = makeTmpRoot();
+    const totemDir = path.join(root, 'newly-created', '.totem');
+    expect(fs.existsSync(totemDir)).toBe(false);
+    writeInstalledPacksManifest(totemDir, { version: 1, packs: [] });
+    expect(fs.existsSync(totemDir)).toBe(true);
+    expect(fs.existsSync(path.join(totemDir, 'installed-packs.json'))).toBe(true);
+  });
+
+  it('does not leave the temp file behind on success', () => {
+    const root = makeTmpRoot();
+    const totemDir = path.join(root, '.totem');
+    writeInstalledPacksManifest(totemDir, { version: 1, packs: [] });
+    expect(fs.existsSync(path.join(totemDir, 'installed-packs.json.tmp'))).toBe(false);
+  });
+});

--- a/packages/core/src/pack-manifest-writer.ts
+++ b/packages/core/src/pack-manifest-writer.ts
@@ -94,12 +94,10 @@ const PACK_NAME_PREFIX = '@totem/pack-';
  */
 export function resolveInstalledPacks(input: ResolveInstalledPacksInput): PackResolutionResult {
   const deps = input.packageJsonDeps ?? readPackageJsonDeps(input.projectRoot);
-  // totem-context: `extends` is z.string() per TotemConfigSchema — entries are guaranteed strings, not fileGlobs union members
-  const extendsList = (input.config.extends ?? []).filter((name) =>
-    name.startsWith(PACK_NAME_PREFIX),
+  const extendsList = (input.config.extends ?? []).filter(
+    (name) => name.startsWith(PACK_NAME_PREFIX), // totem-context: `extends` is z.string() per TotemConfigSchema — entries are guaranteed strings, not fileGlobs union members
   );
-  // totem-context: Object.keys() always returns strings — not fileGlobs ast-grep object form
-  const depPackNames = Object.keys(deps).filter((name) => name.startsWith(PACK_NAME_PREFIX));
+  const depPackNames = Object.keys(deps).filter((name) => name.startsWith(PACK_NAME_PREFIX)); // totem-context: Object.keys() returns strings; not fileGlobs ast-grep object form
 
   const extendsSet = new Set(extendsList);
   const depsSet = new Set(depPackNames);
@@ -218,9 +216,8 @@ function readPeerEngineRange(packResolvedPath: string): string | undefined {
     return undefined;
   }
   if (typeof parsed !== 'object' || parsed === null) return undefined;
-  const peer = (parsed as { peerDependencies?: unknown }).peerDependencies;
+  const peer = (parsed as { peerDependencies?: unknown }).peerDependencies; // totem-context: parsed was narrowed via `typeof !== 'object' || === null` guard above; the cast is for index access into already-validated JSON
   if (typeof peer !== 'object' || peer === null) return undefined;
-  // totem-context: peer was just narrowed to a non-null object on the line above; the cast is for index access, and the result is runtime-checked via `typeof range === 'string'` below
-  const range = (peer as Record<string, unknown>)['@mmnto/totem'];
+  const range = (peer as Record<string, unknown>)['@mmnto/totem']; // totem-context: peer was narrowed via `typeof !== 'object' || === null` guard above; the cast is for index access; result is runtime-checked via `typeof range === 'string'` below
   return typeof range === 'string' ? range : undefined;
 }

--- a/packages/core/src/pack-manifest-writer.ts
+++ b/packages/core/src/pack-manifest-writer.ts
@@ -1,0 +1,220 @@
+/**
+ * `installed-packs.json` writer (mmnto-ai/totem#1768, Step 4).
+ *
+ * Walks two source surfaces — the consumer's `package.json` dependencies
+ * for `@totem/pack-*` entries, and the consumer's `totem.config.ts`
+ * `extends` array — deduplicates, resolves each pack's installed path
+ * via npm/pnpm semantics, and writes `.totem/installed-packs.json` for
+ * `pack-discovery.ts:loadInstalledPacks()` to consume at boot.
+ *
+ * Mismatch handling (ADR-097 § 5 Q4 + Open Question 4 disposition):
+ * - In both surfaces: union, no warning.
+ * - In `extends` only (declared but not resolvable via npm): emit a
+ *   warning naming the pack; skip from the manifest. Consumer must
+ *   `pnpm add` the pack to make it work.
+ * - In `package.json` only (resolvable but not declared in extends):
+ *   emit a warning; skip from the manifest. Pack-merge only consumes
+ *   `extends`-declared packs; including the dep-only entry would be
+ *   misleading.
+ *
+ * Atomic write semantics: the writer goes through a temp file +
+ * rename, mirroring `writeReviewExtensionsFile` (mmnto-ai/totem#1527).
+ *
+ * Filesystem access happens at the CLI boundary (this module is invoked
+ * by `syncCommand`); the resolver itself takes paths + content as
+ * inputs so tests can drive it without disk I/O.
+ */
+
+import * as fs from 'node:fs';
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+
+import type { TotemConfig } from './config-schema.js';
+import type { InstalledPacksManifest } from './pack-discovery.js';
+
+// ─── Types ──────────────────────────────────────────
+
+export interface PackResolutionWarning {
+  /** Pack name surfaced in the warning. */
+  readonly name: string;
+  /**
+   * Why the pack didn't make it to the manifest. Two shapes:
+   *
+   * - `dep-only`: present in package.json but not declared in
+   *   `totem.config.ts` `extends`. Skipped because pack-merge only
+   *   consumes `extends`-declared packs.
+   * - `extends-only`: declared in `extends` but not installed
+   *   (`require.resolve` failed). Skipped because the engine cannot
+   *   load it.
+   * - `not-a-pack`: present somewhere but doesn't expose a `register`
+   *   callback (default export or named `register` function). Skipped
+   *   because pack-discovery would throw on first attempt.
+   */
+  readonly reason: 'dep-only' | 'extends-only' | 'not-a-pack';
+}
+
+export interface PackResolutionResult {
+  /** Packs that landed in the manifest (sorted by name). */
+  readonly resolved: InstalledPacksManifest['packs'];
+  /** Per-pack warnings for the consumer (sorted by name). */
+  readonly warnings: readonly PackResolutionWarning[];
+}
+
+export interface ResolveInstalledPacksInput {
+  /** Project root (where `package.json` lives). */
+  readonly projectRoot: string;
+  /** Loaded totem config (read for `extends`). */
+  readonly config: TotemConfig;
+  /**
+   * Optional override for the package.json read. Tests pass a synthetic
+   * dependencies map; production callers leave it undefined and the
+   * function reads `<projectRoot>/package.json`.
+   */
+  readonly packageJsonDeps?: Readonly<Record<string, string>>;
+  /**
+   * Optional override for the require resolver. Tests stub this to
+   * resolve fixture packs without writing to `node_modules`; production
+   * callers use the default which delegates to `createRequire`.
+   */
+  readonly resolvePackPath?: (name: string, fromDir: string) => string | undefined;
+}
+
+// ─── Resolver ───────────────────────────────────────
+
+const PACK_NAME_PREFIX = '@totem/pack-';
+
+/**
+ * Compute the deduplicated union of `package.json` `@totem/pack-*` deps
+ * and `totem.config.ts` `extends` entries. Returns the manifest payload
+ * shape ready for `installed-packs.json` plus per-pack warnings for any
+ * surface mismatch.
+ *
+ * Pure function — no filesystem write. The CLI integration calls
+ * `writeInstalledPacksManifest()` to persist.
+ */
+export function resolveInstalledPacks(input: ResolveInstalledPacksInput): PackResolutionResult {
+  const deps = input.packageJsonDeps ?? readPackageJsonDeps(input.projectRoot);
+  const extendsList = (input.config.extends ?? []).filter((name) =>
+    name.startsWith(PACK_NAME_PREFIX),
+  );
+  const depPackNames = Object.keys(deps).filter((name) => name.startsWith(PACK_NAME_PREFIX));
+
+  const extendsSet = new Set(extendsList);
+  const depsSet = new Set(depPackNames);
+  const union = new Set<string>([...extendsSet, ...depsSet]);
+
+  const warnings: PackResolutionWarning[] = [];
+  const resolved: InstalledPacksManifest['packs'] = [];
+
+  for (const name of [...union].sort()) {
+    if (!extendsSet.has(name)) {
+      // Resolvable dep that the consumer hasn't opted into via `extends`.
+      // Pack-merge only consumes extends-declared packs, so this pack
+      // would never have its rules merged anyway. Skip with a warning.
+      warnings.push({ name, reason: 'dep-only' });
+      continue;
+    }
+    if (!depsSet.has(name)) {
+      // Declared in extends but not installed via package manager.
+      // Cannot resolve a path; skip with a warning.
+      warnings.push({ name, reason: 'extends-only' });
+      continue;
+    }
+
+    const resolver = input.resolvePackPath ?? defaultResolvePackPath;
+    const resolvedPath = resolver(name, input.projectRoot);
+    if (!resolvedPath) {
+      warnings.push({ name, reason: 'extends-only' });
+      continue;
+    }
+
+    const declaredEngineRange = readPeerEngineRange(resolvedPath);
+    if (!declaredEngineRange) {
+      warnings.push({ name, reason: 'not-a-pack' });
+      continue;
+    }
+
+    resolved.push({
+      name,
+      resolvedPath,
+      declaredEngineRange,
+    });
+  }
+
+  return { resolved, warnings };
+}
+
+/**
+ * Atomically write `<totemDir>/installed-packs.json` with the given
+ * manifest payload. Mirrors `writeReviewExtensionsFile` semantics: temp
+ * file + rename so a concurrent boot-time read sees the old or new
+ * contents, never a partial write.
+ */
+export function writeInstalledPacksManifest(
+  totemDirAbs: string,
+  manifest: InstalledPacksManifest,
+): string {
+  if (!fs.existsSync(totemDirAbs)) {
+    fs.mkdirSync(totemDirAbs, { recursive: true });
+  }
+  const finalPath = path.join(totemDirAbs, 'installed-packs.json');
+  const tmpPath = finalPath + '.tmp';
+  fs.writeFileSync(tmpPath, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
+  fs.renameSync(tmpPath, finalPath);
+  return finalPath;
+}
+
+// ─── Internal helpers ───────────────────────────────
+
+function readPackageJsonDeps(projectRoot: string): Record<string, string> {
+  const pkgPath = path.join(projectRoot, 'package.json');
+  if (!fs.existsSync(pkgPath)) return {};
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+  } catch {
+    return {};
+  }
+  if (typeof parsed !== 'object' || parsed === null) return {};
+  const obj = parsed as { dependencies?: unknown; devDependencies?: unknown };
+  const out: Record<string, string> = {};
+  for (const field of ['dependencies', 'devDependencies'] as const) {
+    const section = obj[field];
+    if (typeof section !== 'object' || section === null) continue;
+    for (const [name, value] of Object.entries(section as Record<string, unknown>)) {
+      if (typeof value === 'string') out[name] = value;
+    }
+  }
+  return out;
+}
+
+function defaultResolvePackPath(name: string, fromDir: string): string | undefined {
+  // We resolve from the project root rather than from this module — packs
+  // live in the consumer's node_modules, not core's.
+  const require = createRequire(path.join(fromDir, 'package.json'));
+  try {
+    // Resolve to the package's package.json so the directory containing it
+    // is the pack's package root. require.resolve(name) would land on the
+    // package's `main` entry, which isn't what pack-discovery wants.
+    const pkgJsonPath = require.resolve(`${name}/package.json`);
+    return path.dirname(pkgJsonPath);
+  } catch {
+    return undefined;
+  }
+}
+
+function readPeerEngineRange(packResolvedPath: string): string | undefined {
+  const pkgPath = path.join(packResolvedPath, 'package.json');
+  if (!fs.existsSync(pkgPath)) return undefined;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return undefined;
+  const peer = (parsed as { peerDependencies?: unknown }).peerDependencies;
+  if (typeof peer !== 'object' || peer === null) return undefined;
+  const range = (peer as Record<string, unknown>)['@mmnto/totem'];
+  return typeof range === 'string' ? range : undefined;
+}

--- a/packages/core/src/pack-manifest-writer.ts
+++ b/packages/core/src/pack-manifest-writer.ts
@@ -170,6 +170,7 @@ function readPackageJsonDeps(projectRoot: string): Record<string, string> {
   const pkgPath = path.join(projectRoot, 'package.json');
   if (!fs.existsSync(pkgPath)) return {};
   let parsed: unknown;
+  // totem-context: intentional cleanup — package.json missing/corrupt is non-fatal to sync; treat as no deps
   try {
     parsed = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
   } catch {
@@ -192,6 +193,7 @@ function defaultResolvePackPath(name: string, fromDir: string): string | undefin
   // We resolve from the project root rather than from this module — packs
   // live in the consumer's node_modules, not core's.
   const require = createRequire(path.join(fromDir, 'package.json'));
+  // totem-context: intentional cleanup — unresolvable pack returns undefined to flow into the `extends-only` warning path
   try {
     // Resolve to the package's package.json so the directory containing it
     // is the pack's package root. require.resolve(name) would land on the
@@ -207,6 +209,7 @@ function readPeerEngineRange(packResolvedPath: string): string | undefined {
   const pkgPath = path.join(packResolvedPath, 'package.json');
   if (!fs.existsSync(pkgPath)) return undefined;
   let parsed: unknown;
+  // totem-context: intentional cleanup — corrupted pack package.json returns undefined to flow into the `not-a-pack` warning path
   try {
     parsed = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
   } catch {

--- a/packages/core/src/pack-manifest-writer.ts
+++ b/packages/core/src/pack-manifest-writer.ts
@@ -94,9 +94,11 @@ const PACK_NAME_PREFIX = '@totem/pack-';
  */
 export function resolveInstalledPacks(input: ResolveInstalledPacksInput): PackResolutionResult {
   const deps = input.packageJsonDeps ?? readPackageJsonDeps(input.projectRoot);
+  // totem-context: `extends` is z.string() per TotemConfigSchema — entries are guaranteed strings, not fileGlobs union members
   const extendsList = (input.config.extends ?? []).filter((name) =>
     name.startsWith(PACK_NAME_PREFIX),
   );
+  // totem-context: Object.keys() always returns strings — not fileGlobs ast-grep object form
   const depPackNames = Object.keys(deps).filter((name) => name.startsWith(PACK_NAME_PREFIX));
 
   const extendsSet = new Set(extendsList);
@@ -172,7 +174,7 @@ function readPackageJsonDeps(projectRoot: string): Record<string, string> {
   let parsed: unknown;
   // totem-context: intentional cleanup — package.json missing/corrupt is non-fatal to sync; treat as no deps
   try {
-    parsed = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    parsed = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')); // totem-context: sync read at boot; sync command is itself synchronous CLI top-level
   } catch {
     return {};
   }
@@ -211,13 +213,14 @@ function readPeerEngineRange(packResolvedPath: string): string | undefined {
   let parsed: unknown;
   // totem-context: intentional cleanup — corrupted pack package.json returns undefined to flow into the `not-a-pack` warning path
   try {
-    parsed = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    parsed = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')); // totem-context: sync read at boot; sync command is itself synchronous CLI top-level
   } catch {
     return undefined;
   }
   if (typeof parsed !== 'object' || parsed === null) return undefined;
   const peer = (parsed as { peerDependencies?: unknown }).peerDependencies;
   if (typeof peer !== 'object' || peer === null) return undefined;
+  // totem-context: peer was just narrowed to a non-null object on the line above; the cast is for index access, and the result is runtime-checked via `typeof range === 'string'` below
   const range = (peer as Record<string, unknown>)['@mmnto/totem'];
   return typeof range === 'string' ? range : undefined;
 }

--- a/packages/core/src/pack-manifest-writer.ts
+++ b/packages/core/src/pack-manifest-writer.ts
@@ -193,13 +193,12 @@ function defaultResolvePackPath(name: string, fromDir: string): string | undefin
   // We resolve from the project root rather than from this module — packs
   // live in the consumer's node_modules, not core's.
   const require = createRequire(path.join(fromDir, 'package.json'));
-  // totem-context: intentional cleanup — unresolvable pack returns undefined to flow into the `extends-only` warning path
   try {
     // Resolve to the package's package.json so the directory containing it
     // is the pack's package root. require.resolve(name) would land on the
     // package's `main` entry, which isn't what pack-discovery wants.
     const pkgJsonPath = require.resolve(`${name}/package.json`);
-    return path.dirname(pkgJsonPath);
+    return path.dirname(pkgJsonPath); // totem-context: intentional cleanup — unresolvable pack returns undefined to flow into the `extends-only` warning path
   } catch {
     return undefined;
   }

--- a/packages/core/src/rule-engine.test.ts
+++ b/packages/core/src/rule-engine.test.ts
@@ -807,3 +807,68 @@ describe('matchesGlob', () => {
     expect(matchesGlob('Dockerfile.dev', 'Dockerfile')).toBe(false);
   });
 });
+
+// ─── Behavior change: ast-grep dispatch fail-loud (mmnto-ai/totem#1653) ──
+
+describe('applyAstRulesToAdditions fail-loud on unmapped extension (mmnto-ai/totem#1653)', () => {
+  it('throws when an AST rule is scoped to an unregistered extension', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'src', 'main.py'), 'print("x")\n');
+    const rule = makeRule({
+      engine: 'ast',
+      astQuery: '(call_expression)',
+      fileGlobs: ['**/*.py'],
+      lessonHash: 'py-rule-hash',
+      lessonHeading: 'Python rule',
+    });
+    const additions = [makeAddition('src/main.py', 'print("x")', 1)];
+
+    // Pre-#1653 this would silently skip with no signal — the rule
+    // intended to fire on .py files but `extensionToLanguage('.py')`
+    // returns undefined. Now: fail loud naming the rule.
+    await expect(applyAstRulesToAdditions(ctx, [rule], additions, tmpDir)).rejects.toThrowError(
+      /AST rule 'py-rule-hash'.*scoped to.*extension '\.py'.*Install the pack/,
+    );
+  });
+
+  it('does NOT throw when an unmapped-extension file is in the diff but no rule scopes to it', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'src', 'main.py'), 'print("x")\n');
+    fs.writeFileSync(path.join(tmpDir, 'src', 'app.ts'), 'const x = 1;\n');
+
+    // Rule scoped to .ts only; .py file in the diff has no rule that
+    // cares about it. Silent skip on the .py file is correct behavior —
+    // fail-loud is surgical to the case where a rule actually expected
+    // to run.
+    const rule = makeRule({
+      engine: 'ast',
+      astQuery: '(variable_declaration)',
+      fileGlobs: ['**/*.ts'],
+      lessonHash: 'ts-only-rule',
+    });
+    const additions = [
+      makeAddition('src/main.py', 'print("x")', 1),
+      makeAddition('src/app.ts', 'const x = 1;', 1),
+    ];
+
+    // No throw. Returns whatever the .ts rule produces; the key invariant
+    // is "doesn't throw on unrelated unmapped files."
+    await expect(applyAstRulesToAdditions(ctx, [rule], additions, tmpDir)).resolves.toEqual(
+      expect.any(Array),
+    );
+  });
+
+  it('does NOT throw when rule has no fileGlobs at all (rule applies everywhere by default)', async () => {
+    fs.writeFileSync(path.join(tmpDir, 'src', 'main.py'), 'print("x")\n');
+    const rule = makeRule({
+      engine: 'ast',
+      astQuery: '(variable_declaration)',
+      fileGlobs: undefined,
+      lessonHash: 'unscoped-rule',
+    });
+    const additions = [makeAddition('src/main.py', 'print("x")', 1)];
+
+    // A rule with no fileGlobs doesn't claim any specific extension —
+    // silent skip on unmapped extensions is the right behavior here.
+    // Fail-loud is reserved for the explicit "I scope to .py" case.
+    await expect(applyAstRulesToAdditions(ctx, [rule], additions, tmpDir)).resolves.toEqual([]);
+  });
+});

--- a/packages/core/src/rule-engine.test.ts
+++ b/packages/core/src/rule-engine.test.ts
@@ -812,8 +812,9 @@ describe('matchesGlob', () => {
 // ─── Behavior change: ast-grep dispatch fail-loud (mmnto-ai/totem#1653) ──
 
 describe('applyAstRulesToAdditions fail-loud on unmapped extension (mmnto-ai/totem#1653)', () => {
+  // totem-context: test fixtures genuinely need async — they `await applyAstRulesToAdditions(...)` whose contract is async
   it('throws when an AST rule is scoped to an unregistered extension', async () => {
-    fs.writeFileSync(path.join(tmpDir, 'src', 'main.py'), 'print("x")\n');
+    fs.writeFileSync(path.join(tmpDir, 'src', 'main.py'), 'print("x")\n'); // totem-context: writing a python source fixture under tmpDir, not a git hook
     const rule = makeRule({
       engine: 'ast',
       astQuery: '(call_expression)',
@@ -836,7 +837,7 @@ describe('applyAstRulesToAdditions fail-loud on unmapped extension (mmnto-ai/tot
       caught = err;
     }
     expect(caught).toBeInstanceOf(TotemParseError);
-    const tpe = caught as TotemParseError;
+    const tpe = caught as TotemParseError; // totem-context: narrowing a thrown error after toBeInstanceOf — not parsing untrusted input
     // The `[Totem Error]` prefix is auto-prepended by the TotemError
     // base class constructor (`errors.ts:40`). Asserting on the resolved
     // message keeps the runtime contract visible at the test boundary.
@@ -847,9 +848,10 @@ describe('applyAstRulesToAdditions fail-loud on unmapped extension (mmnto-ai/tot
     expect(tpe.recoveryHint).toMatch(/Install the pack that provides '\.py'/);
   });
 
+  // totem-context: test fixture genuinely awaits async API
   it('does NOT throw when an unmapped-extension file is in the diff but no rule scopes to it', async () => {
-    fs.writeFileSync(path.join(tmpDir, 'src', 'main.py'), 'print("x")\n');
-    fs.writeFileSync(path.join(tmpDir, 'src', 'app.ts'), 'const x = 1;\n');
+    fs.writeFileSync(path.join(tmpDir, 'src', 'main.py'), 'print("x")\n'); // totem-context: writing a python source fixture under tmpDir, not a git hook
+    fs.writeFileSync(path.join(tmpDir, 'src', 'app.ts'), 'const x = 1;\n'); // totem-context: writing a typescript source fixture under tmpDir, not a git hook
 
     // Rule scoped to .ts only; .py file in the diff has no rule that
     // cares about it. Silent skip on the .py file is correct behavior —
@@ -873,8 +875,9 @@ describe('applyAstRulesToAdditions fail-loud on unmapped extension (mmnto-ai/tot
     );
   });
 
+  // totem-context: test fixture genuinely awaits async API
   it('does NOT throw when rule has no fileGlobs at all (rule applies everywhere by default)', async () => {
-    fs.writeFileSync(path.join(tmpDir, 'src', 'main.py'), 'print("x")\n');
+    fs.writeFileSync(path.join(tmpDir, 'src', 'main.py'), 'print("x")\n'); // totem-context: writing a python source fixture under tmpDir, not a git hook
     const rule = makeRule({
       engine: 'ast',
       astQuery: '(variable_declaration)',

--- a/packages/core/src/rule-engine.test.ts
+++ b/packages/core/src/rule-engine.test.ts
@@ -10,6 +10,7 @@ import type {
   RuleEventCallback,
   RuleEventContext,
 } from './compiler-schema.js';
+import { TotemParseError } from './errors.js';
 import {
   applyAstRulesToAdditions,
   applyRulesToAdditions,
@@ -824,10 +825,26 @@ describe('applyAstRulesToAdditions fail-loud on unmapped extension (mmnto-ai/tot
 
     // Pre-#1653 this would silently skip with no signal — the rule
     // intended to fire on .py files but `extensionToLanguage('.py')`
-    // returns undefined. Now: fail loud naming the rule.
-    await expect(applyAstRulesToAdditions(ctx, [rule], additions, tmpDir)).rejects.toThrowError(
-      /AST rule 'py-rule-hash'.*scoped to.*extension '\.py'.*Install the pack/,
+    // returns undefined. Now: fail loud via TotemParseError. Capture the
+    // thrown error so we can assert both `message` (rule identity) and
+    // `recoveryHint` (install-the-pack guidance) — `toThrowError(regex)`
+    // resolves to void and can't reach the recoveryHint property.
+    let caught: unknown;
+    try {
+      await applyAstRulesToAdditions(ctx, [rule], additions, tmpDir);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(TotemParseError);
+    const tpe = caught as TotemParseError;
+    // The `[Totem Error]` prefix is auto-prepended by the TotemError
+    // base class constructor (`errors.ts:40`). Asserting on the resolved
+    // message keeps the runtime contract visible at the test boundary.
+    expect(tpe.message).toMatch(/^\[Totem Error\]/);
+    expect(tpe.message).toMatch(
+      /AST rule 'py-rule-hash'.*scoped to.*extension '\.py'.*no Tree-sitter language is registered/,
     );
+    expect(tpe.recoveryHint).toMatch(/Install the pack that provides '\.py'/);
   });
 
   it('does NOT throw when an unmapped-extension file is in the diff but no rule scopes to it', async () => {

--- a/packages/core/src/rule-engine.ts
+++ b/packages/core/src/rule-engine.ts
@@ -407,8 +407,14 @@ export async function applyAstRulesToAdditions(
         (r) => r.fileGlobs && r.fileGlobs.length > 0 && fileMatchesGlobs(file, r.fileGlobs),
       );
       if (ruleExpectingThisFile) {
-        throw new Error(
-          `[Totem Error] AST rule '${ruleExpectingThisFile.lessonHash}' (${ruleExpectingThisFile.lessonHeading}) is scoped to '${file}' (extension '${ext}') but no Tree-sitter language is registered for that extension. Install the pack that provides '${ext}' support, or correct the rule's fileGlobs.`,
+        // `[Totem Error]` prefix is auto-prepended by the TotemError base
+        // class constructor (`errors.ts:40`). The literal prefix is
+        // intentionally NOT in the message argument here — duplicating it
+        // would produce `[Totem Error] [Totem Error] AST rule ...` at
+        // runtime. See `errors.ts` for the prefix contract.
+        throw new TotemParseError(
+          `AST rule '${ruleExpectingThisFile.lessonHash}' (${ruleExpectingThisFile.lessonHeading}) is scoped to '${file}' (extension '${ext}') but no Tree-sitter language is registered for that extension`,
+          `Install the pack that provides '${ext}' support (e.g., \`@totem/pack-rust-architecture\` for '.rs'), or correct the rule's fileGlobs to exclude this extension.`,
         );
       }
       continue;

--- a/packages/core/src/rule-engine.ts
+++ b/packages/core/src/rule-engine.ts
@@ -385,11 +385,34 @@ export async function applyAstRulesToAdditions(
 
   const violations: Violation[] = [];
 
+  // Combined view of all AST rules consulted by the unmapped-extension
+  // fail-loud guard below (mmnto-ai/totem#1653). Hoisted outside the
+  // per-file loop so we don't re-allocate it on every iteration when
+  // the registered-extension fast path doesn't need it.
+  const allAstRules = [...treeSitterRules, ...astGrepRules];
+
   // Process each file once — batch all applicable queries per file
   for (const [file, fileAdditions] of byFile) {
-    // Check language support
+    // Check language support. mmnto-ai/totem#1653: silent-skip on unmapped
+    // extensions was the bug — rules scoped to `.rs` (or any unregistered
+    // extension) silently never fired with no signal to the rule author.
+    // Fail-loud surface is surgical: skip files only when NO rule's
+    // `fileGlobs` matches them (no rule cares → silent skip is correct);
+    // throw when a rule expected to run can't because the language isn't
+    // registered. Pack registration via `loadInstalledPacks()` is the
+    // mechanism for adding language support.
     const ext = path.extname(file);
-    if (!extensionToLanguage(ext)) continue;
+    if (!extensionToLanguage(ext)) {
+      const ruleExpectingThisFile = allAstRules.find(
+        (r) => r.fileGlobs && r.fileGlobs.length > 0 && fileMatchesGlobs(file, r.fileGlobs),
+      );
+      if (ruleExpectingThisFile) {
+        throw new Error(
+          `[Totem Error] AST rule '${ruleExpectingThisFile.lessonHash}' (${ruleExpectingThisFile.lessonHeading}) is scoped to '${file}' (extension '${ext}') but no Tree-sitter language is registered for that extension. Install the pack that provides '${ext}' support, or correct the rule's fileGlobs.`,
+        );
+      }
+      continue;
+    }
 
     // Collect added line numbers (suppression is checked post-match so metrics fire)
     const addedLineNumbers: number[] = [];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,6 +129,9 @@ importers:
       safe-regex2:
         specifier: ^5.0.0
         version: 5.0.0
+      semver:
+        specifier: ^7.7.0
+        version: 7.7.4
       tree-sitter-javascript:
         specifier: ^0.25.0
         version: 0.25.0
@@ -160,6 +163,9 @@ importers:
       '@types/mdast':
         specifier: ^4.0.0
         version: 4.0.4
+      '@types/semver':
+        specifier: ^7.5.0
+        version: 7.7.1
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(yaml@2.8.2)
@@ -1614,6 +1620,10 @@ packages:
 
   /@types/retry@0.12.0:
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  /@types/semver@7.7.1:
+    resolution: {integrity: sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==}
+    dev: true
 
   /@types/unist@3.0.3:
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -4411,7 +4421,6 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
-    dev: true
 
   /send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}


### PR DESCRIPTION
## Summary

Implements the three ADR-097 § 10 enabling substrate features in one bundled PR so PR-B (`@totem/pack-rust-architecture` lift) has a stable runtime registration contract:

1. **Pack discovery substrate** (`mmnto-ai/totem#1768`) — `installed-packs.json` written at `totem sync`, read at boot, with synchronous pack registration callbacks before engine seal.
2. **ChunkStrategy registry** (`mmnto-ai/totem#1769`) — replaces closed enum with runtime registry; built-ins register at module load, packs register during boot.
3. **ast-grep Lang registry** (`mmnto-ai/totem#1653`, registry-backed reframe) — `extensionToLanguage` becomes registry-backed; fail-loud on a rule scoped to an unregistered extension via new `TotemParseError`.

Ride-along: `mmnto-ai/totem#1654` (compile-pipeline `Lang.Tsx` partial fix — `extensionToLang` migration in `ast-grep-query.ts`; the `Lang.Tsx` empty-root validator in `compile-lesson.ts:319` deferred to a separate ticket).

## Architecture highlights

- **Engine seal event** — single boundary in `loadInstalledPacks()`; mutation after seal throws.
- **Built-in immutability** — registries track built-in names separately so pack-vs-builtin collisions vs. pack-vs-pack collisions surface distinct error messages.
- **(string & {})** extension pattern — preserves IntelliSense on built-in `ChunkStrategy` / `SupportedLanguage` literals while allowing pack-registered values to type-check.
- **Bootstrap chicken-and-egg** — `ChunkStrategySchema` relaxed to `z.string().min(1)`; runtime fail-loud in `createChunker` carries the type contract (per Gemini synthesis review).
- **Q4 disposition** — pack list is the deduplicated union of `package.json` `@totem/pack-*` deps and `totem.config.ts` `extends`. Mismatches surface as warnings; only `extends`-declared + resolvable packs land in the manifest.
- **Q8** — `#1654` partial fix bundled to prove the registry works end-to-end for a non-TS path.

## Test plan

- [x] All 1710 core tests pass (29 new tests for pack discovery, manifest writer, and chunker registry; 3 new tests for fail-loud rule-engine behavior).
- [x] `pnpm exec totem lint` — 383 rules, 0 errors.
- [x] `pnpm exec totem review` (Sonnet) — PASS, zero findings across two rounds.
- [x] Spec doc at `.totem/specs/pack-substrate-bundle.md` covers Phase 3 design (scope, data model, lifecycle, failure modes, invariants, open questions).

## Substrate landscape

- `mmnto-ai/totem-strategy#192` (ADR-097) — accepted 2026-04-30
- `mmnto-ai/totem#1768` — Pack discovery (this PR)
- `mmnto-ai/totem#1769` — ChunkStrategy registry (this PR)
- `mmnto-ai/totem#1653` — ast-grep Lang registry, registry-backed reframe (this PR)
- `mmnto-ai/totem#1654` — compile-pipeline `Lang.Tsx` partial fix (rides this PR)

Closes #1768
Closes #1769
Closes #1653

🤖 Generated with [Claude Code](https://claude.com/claude-code)