### PR TITLE
fix(pack): remove @mmnto/totem peerDep — closes #1776 Version Packages 2.0.0 wiggle

### DIFF
--- a/.changeset/1776-vp-wiggle-pack-peerdep.md
+++ b/.changeset/1776-vp-wiggle-pack-peerdep.md
@@ -1,0 +1,13 @@
+---
+'@totem/pack-rust-architecture': patch
+---
+
+**Fix #1776 wiggle — remove `@mmnto/totem` peerDep from `@totem/pack-rust-architecture`.**
+
+The first Version Packages auto-cut after PR #1775 pre-empted `1.22.0 → 2.0.0` instead of `1.22.0 → 1.23.0` despite all changesets being declared `minor`. Root cause: `@totem/pack-rust-architecture` declared `peerDependencies['@mmnto/totem']: ^1.22.0`, which combined with the changesets `fixed` group creates a circular constraint — the pack's peerDep range update on a totem minor bump triggers a MAJOR cascade per the changesets peerDep-update policy, and the cascade lifts every fixed-group member to a major bump.
+
+Fix mirrors the pattern in `@totem/pack-agent-security`: fixed-group packs do not declare `@mmnto/totem` as a peerDep — version harmony is guaranteed at publish time by the fixed group itself, not by peerDep range pinning. `@ast-grep/napi` (external, not in the fixed group) remains a peerDep as expected.
+
+Test `structure.test.ts` updated to assert the exact-key equality of `peerDependencies` so a regression in this rule is caught at unit-test time, not at next Version Packages auto-cut.
+
+No runtime behavior change. Pack still registers Rust into both engine paths via `register.cjs`.

--- a/packages/pack-rust-architecture/package.json
+++ b/packages/pack-rust-architecture/package.json
@@ -32,7 +32,6 @@
     "test": "vitest run"
   },
   "peerDependencies": {
-    "@mmnto/totem": "^1.22.0",
     "@ast-grep/napi": "^0.42.0"
   },
   "dependencies": {

--- a/packages/pack-rust-architecture/test/structure.test.ts
+++ b/packages/pack-rust-architecture/test/structure.test.ts
@@ -82,24 +82,26 @@ describe('@totem/pack-rust-architecture structure', () => {
     const deps = pkg.dependencies ?? {};
     // @ast-grep/lang-rust is the napi-side parser binding required by the
     // v0.1 side-channel registration in register.cjs (mmnto-ai/totem#1774).
-    // No other runtime deps are admitted: peerDeps cover @mmnto/totem and
-    // @ast-grep/napi; devDeps cover @vscode/tree-sitter-wasm (build-time
-    // WASM source) and vitest.
+    // No other runtime deps are admitted: peerDep covers @ast-grep/napi
+    // (external); devDeps cover @mmnto/totem (workspace), @vscode/tree-sitter-wasm
+    // (build-time WASM source), and vitest. @mmnto/totem is intentionally NOT
+    // a peerDep — pack-rust-architecture lives in the changesets `fixed`
+    // group with @mmnto/totem (and the rest of the @mmnto/* + @totem/*
+    // cohort), so version harmony is guaranteed at publish time. Declaring
+    // @mmnto/totem as a peerDep AS WELL as a fixed-group member would create
+    // a circular constraint on every minor bump, pre-empting the cluster to
+    // a major bump (mmnto-ai/totem#1776 wiggle on PR #1775's first auto-cut).
     expect(Object.keys(deps).sort()).toEqual(['@ast-grep/lang-rust']);
   });
 
-  it('package.json peerDependencies pin both engine surfaces (totem + ast-grep napi)', () => {
+  it('package.json peerDependencies pin only the external @ast-grep/napi engine', () => {
     const pkg = readJsonSafe<{ peerDependencies?: Record<string, string> }>(
       path.join(PACK_ROOT, 'package.json'),
     );
-    expect(pkg.peerDependencies?.['@ast-grep/napi']).toBe('^0.42.0');
-  });
-
-  it('package.json peerDependencies pins @mmnto/totem to ^1.22.0 (Pack v0.1 substrate version)', () => {
-    const pkg = readJsonSafe<{ peerDependencies?: Record<string, string> }>(
-      path.join(PACK_ROOT, 'package.json'),
-    );
-    expect(pkg.peerDependencies?.['@mmnto/totem']).toBe('^1.22.0');
+    // Exact-key equality: @mmnto/totem MUST NOT appear here (fixed-group
+    // member; see test above for rationale). Only the external napi engine
+    // is pinned via peerDep.
+    expect(Object.keys(pkg.peerDependencies ?? {}).sort()).toEqual(['@ast-grep/napi']);
     expect(pkg.peerDependencies?.['@ast-grep/napi']).toBe('^0.42.0');
   });
 


### PR DESCRIPTION
## Summary

- Removes `peerDependencies['@mmnto/totem']` from `@totem/pack-rust-architecture/package.json`. The pack lives in the changesets `fixed` group with `@mmnto/totem`; declaring it as a peerDep AS WELL creates a circular constraint that pre-empts every minor bump to a major bump per changesets policy.
- Updates `test/structure.test.ts` to enforce the inverse invariant — `@mmnto/totem` MUST NOT appear in peerDeps — so a future regression of this rule is caught at unit-test time, not on the next Version Packages auto-cut.

## Root cause of #1776

After PR #1775 merged, the changesets bot opened auto-cut PR #1776 and pre-empted `1.22.0 → 2.0.0` despite my changeset being all-minor. Test failure across all 3 platforms:

```
FAIL test/structure.test.ts > package.json peerDependencies pins @mmnto/totem to ^1.22.0
AssertionError: expected '^2.0.0' to be '^1.22.0'
```

Tracing back from the failed assertion: changesets bumped my pack's `peerDependencies['@mmnto/totem']` from `^1.22.0` to `^2.0.0`. Per [changesets default policy](https://github.com/changesets/changesets/blob/main/docs/dependents-options.md), a peerDep range update is a **MAJOR-bump trigger on the dependent**. Combined with the `fixed` group cohort behavior, this cascade lifted every fixed-group member (`@mmnto/totem`, `@mmnto/cli`, `@mmnto/mcp`, `@totem/pack-agent-security`, `@totem/pack-rust-architecture`) to 2.0.0 — even though the underlying changeset was minor for everyone.

## Why this is the right shape

`@totem/pack-agent-security` is the precedent: it declares `@mmnto/totem` only as a `devDependencies: { "@mmnto/totem": "workspace:*" }`, never as a peerDep. Version harmony in the fixed-group cohort is guaranteed at publish time — every member of the group always shares the same version. peerDep pinning is redundant AND it triggers the wiggle.

`@ast-grep/napi` correctly stays a peerDep on this pack (external, not in the fixed group).

## Effect on PR #1776

After this PR merges, the changesets bot regenerates the auto-cut PR. With the peerDep removed, the next auto-cut should land at the intended **`1.22.0 → 1.23.0` minor bump** for the cohort.

## Test plan

- [x] `pnpm --filter @totem/pack-rust-architecture test` → 18/18 pass (one test consolidated)
- [x] `pnpm --filter @mmnto/totem test` → 1719/1719 still green
- [x] `pnpm -w run format` — clean
- [x] `pnpm exec totem lint` — PASS, 0 violations
- [x] `pnpm exec totem review` — Sonnet PASS, no findings

Closes #1776 (the wiggle, not the PR — the PR auto-regenerates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)