### PR TITLE
feat(core+cli): ADR-091 pack pending-verification install→lint promotion (closes #1684)

### DIFF
--- a/.changeset/1684-pack-pending-verification.md
+++ b/.changeset/1684-pack-pending-verification.md
@@ -1,0 +1,30 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+'@mmnto/mcp': minor
+'@mmnto/pack-rust-architecture': minor
+'@mmnto/pack-agent-security': minor
+---
+
+**ADR-091 § Bootstrap Semantics: pack pending-verification install→lint promotion (#1684)**
+
+Closes the cloud-compile bootstrap gap that ADR-091 § Bootstrap Semantics defined: pack rules cannot be trusted to fire on the consumer's codebase until Stage 4 verifies them locally, so they now enter the consumer's manifest as `'pending-verification'` and the next `totem lint` runs the verifier and promotes them per outcome.
+
+**`CompiledRule.status` enum extended** with a fourth lifecycle value `'pending-verification'` alongside `'active' | 'archived' | 'untested-against-codebase'`. The lint-execution path (`loadCompiledRules`) treats it as inert exactly like `'archived'` and `'untested-against-codebase'`; the admin path (`loadCompiledRulesFile`) returns it unfiltered so the promotion interceptor can find pending entries.
+
+**`totem install pack/<name>`** now stamps every pack rule `'pending-verification'` regardless of the status the pack shipped with. The pack's authoring environment cannot have run Stage 4 against the consumer's codebase, so the cloud-compile status is meaningless on the consumer side. The install command appends `Run \`totem lint\` to activate pack rules` to its output as the activation hint.
+
+**`.totem/verification-outcomes.json`** is the new committable side-table that memoizes Stage 4 outcomes across runs. The first lint run after install reads pending rules from the manifest, invokes the Stage 4 verifier on each, maps the outcome to one of the four terminal lifecycle values per Invariant #3, atomically writes the outcomes file with canonical-key-order serialization (Invariant #11 — byte-stable across runs so consumer repos see no phantom diffs), and saves the mutated manifest. Subsequent lint runs read the recorded outcome from the file and skip re-verification (Invariant #4); a pack content update produces a new `lessonHash` which has no recorded outcome, so the verifier runs again (Invariant #5).
+
+**Per-rule verifier-throw isolation** (Invariant #7): one failing rule's verifier-throw does not abort the lint pass; that rule remains `'pending-verification'` and the next lint retries.
+
+**Empty-pending fast path** (Invariant #9): the common-case lint pass with zero pending rules pays no verification cost and skips the outcomes-file read entirely.
+
+**New public API** in `@mmnto/totem`:
+
+- `promotePendingRules(rules, deps)` and `applyOutcomeToRule(rule, entry)` — the core interceptor.
+- `readVerificationOutcomes(filePath, onWarn?)` and `writeVerificationOutcomes(filePath, outcomes)` — the persistence layer.
+- `VerificationOutcomeEntrySchema`, `VerificationOutcomesFileSchema`, `Stage4OutcomeStored` — Zod schemas.
+- `VerificationOutcomesStore`, `VerificationOutcomesFile`, `VerificationOutcomeEntry`, `Stage4OutcomeStoredValue`, `PromotePendingRulesDeps`, `PromotePendingRulesResult` — types.
+
+**Naming-collision context (option B):** the original ADR-091 draft specified `.totem/rule-metrics.json` for the verification-outcomes file, but `packages/core/src/rule-metrics.ts` already exists as a per-machine telemetry-cache module (`triggerCount`, `suppressCount`, `evaluationCount`) with a gitignored `.totem/cache/rule-metrics.json` lifetime. ADR-091 § 65 was amended to specify `.totem/verification-outcomes.json` instead — separate filename for the new committable verification state, separate module name (`verification-outcomes.ts`) for the new schemas + persistence layer.

--- a/.totem/specs/1684.md
+++ b/.totem/specs/1684.md
@@ -1,0 +1,267 @@
+### Problem Statement
+Pack rules installed from the cloud lack codebase context, meaning they cannot be trusted to fire safely until empirically verified against the consumer's repository. This feature introduces a `pending-verification` state during installation and leverages the first `totem lint` or `totem review` run to silently execute the Stage 4 verifier, promoting or demoting the rules based on the outcome while persisting results to `.totem/verification-outcomes.json`.
+
+### Architectural Context
+This work operationalizes the "Bootstrap Semantics" defined in ADR-091 and enforces the zero-trust default from ADR-089. From the provided Totem context, this interacts directly with the newly established compile pipeline (via `#1682` Stage 4 verifier, referenced in `applyStage4` logic from `packages/core/src/compile-lesson.ts`). Verification-outcomes persistence provides the memoization layer ensuring we only pay the verification cost once per rule-hash.
+
+### Files to Examine
+1. `packages/core/src/types.ts` (or equivalent schema definition file) — To update the `RuleStatus` enum and define the verification-outcomes Zod schemas.
+2. `packages/core/src/compile-lesson.ts` — To observe the existing `applyStage4` verifier footprint.
+3. `packages/cli/src/commands/install.ts` (or equivalent pack install logic) — To inject the `pending-verification` stamp and activation message.
+4. `packages/core/src/linter.ts` (or engine orchestrator) — To intercept pending rules, trigger verification, and ensure unpromoted rules remain inert.
+
+### Technical Approach & Contracts
+We will implement an interceptor-based promotion flow during lint initialization, backed by a persistent metrics store.
+
+**1. Data Contracts:**
+Update the `CompiledRule` core schema:
+```typescript
+const RuleStatusSchema = z.enum(['active', 'archived', 'pending-verification']);
+```
+
+Create the `.totem/verification-outcomes.json` schema:
+```typescript
+const RuleVerificationOutcomeSchema = z.enum([
+  'no-match', 
+  'stage4-out-of-scope-match', 
+  'in-scope-bad-example', 
+  'in-scope-non-bad-example'
+]);
+
+const VerificationOutcomeEntrySchema = z.object({
+  hash: z.string(),
+  verifiedAt: z.string().datetime(),
+  outcome: RuleVerificationOutcomeSchema,
+  baselineMatchPaths: z.array(z.string()).optional(),
+});
+
+export const VerificationOutcomesStoreSchema = z.record(z.string(), VerificationOutcomeEntrySchema);
+// Key: Rule hash
+```
+
+**2. Approach & Trade-offs:**
+* *Approach A (In-memory evaluation only)*: Re-run verification every time. Rejected, violates acceptance criteria and scales poorly.
+* *Approach B (Manifest rewrite + metrics file)*: Update the `status` in the local manifest (`compiled-rules.json`) upon promotion AND write to `.totem/verification-outcomes.json`. Subsequent runs check the local manifest. Re-verification triggers if the hash in the manifest differs from the metrics file. **(Recommended)**. This maintains a single source of truth for the rule's local state while memoizing the historical outcome.
+
+**Execution Sequence:**
+1. `totem install pack/<name>` writes to local manifest with `status: 'pending-verification'`.
+2. `totem lint` starts, loads the local manifest.
+3. Linter identifies rules with `status === 'pending-verification'` (or where `metrics.hash !== rule.hash`).
+4. Linter invokes Stage 4 verifier for each identified rule.
+5. Verifier outcomes map directly to manifest mutations (e.g., `archived` + `reasonCode`, or `active` + `confidence/severity`).
+6. Linter persists the local manifest AND writes to `.totem/verification-outcomes.json`.
+7. Linter drops any rules from the active pipeline that failed verification or threw errors, keeping them inert.
+
+### Edge Cases & Traps
+* **Concurrent CI Writes (Race Condition):** When multiple lint processes run in CI simultaneously, they will race to write `.totem/verification-outcomes.json`. Writing must be atomic (write to a temporary file, then `fs.renameSync`) to avoid file corruption.
+* **Hash Desync Trap:** If a pack author updates a rule (changing its hash) and a consumer updates the pack, the rule must drop back to `pending-verification`. The interceptor must explicitly compare the rule's current hash against the hash recorded in the metrics file.
+* **Verifier Failure Inertness:** If the Stage 4 verifier throws an exception (e.g., network timeout during AST parsing), the rule MUST remain `pending-verification` and MUST NOT be fed to the engine. It must remain inert.
+* **Missing Totem Directory:** The `.totem` directory might not exist yet during a CI run. The metrics writer must use `fs.mkdirSync(dir, { recursive: true })`.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Define Contracts and Schemas**
+  - Update the rule status schema in `packages/core/src/types.ts` to include `pending-verification`.
+  - Add literal options for `confidence` (`untested-against-codebase`) and `reasonCode` (`stage4-out-of-scope-match`).
+  - Create the `VerificationOutcomesStoreSchema` using Zod.
+  > TEST DIRECTIVE: Before implementing, write a failing test named `rejects invalid verification-outcomes schema payloads` that proves malformed JSON is caught by Zod.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Implement Verification-Outcomes Persistence**
+  - Create `packages/core/src/verification-outcomes.ts`.
+  - Implement `readVerificationOutcomes()` using the shared `readJsonSafe<Record<string, VerificationOutcomeEntry>>('.totem/verification-outcomes.json', VerificationOutcomesStoreSchema)`. Catch `ENOENT` / TotemParseError and return an empty object `{}`, do not crash.
+  - Implement `writeVerificationOutcomes()` with atomic file writing (`fs.writeFileSync` to a `.tmp` file, then `fs.renameSync`) to handle CI race conditions. Ensure `.totem` directory creation.
+  > TEST DIRECTIVE: Before implementing, write a failing test named `writes metrics atomically and creates missing directories` to prevent CI file corruption.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Pack Installer Status Stamping**
+  - Modify the install logic in `packages/cli/src/commands/install.ts` (or respective file).
+  - Force imported rules into `status: 'pending-verification'`.
+  - Output to stdout: "Run \`totem lint\` to activate pack rules".
+  > TEST DIRECTIVE: Before implementing, write a failing test named `forces installed pack rules to pending-verification status and prints activation message`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Engine Execution Inertness Enforcement**
+  - Modify rule filtering in the lint/review engine `packages/core/src/linter.ts`.
+  - Strip out any rules with `status === 'pending-verification'` before they are handed to the execution engine.
+  > TEST DIRECTIVE: Before implementing, write a failing test named `prevents pending-verification rules from firing during lint execution` to ensure inertness.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 5: First-Lint Promotion Interceptor**
+  - In the linter setup phase, before execution filtering, scan for rules requiring verification (`status === 'pending-verification'` OR `rule.hash !== metrics[rule.hash]`).
+  - For each matching rule, invoke the Stage 4 verifier.
+  - Apply the four outcomes directly to the rule object in memory (`active`/`archived`, updating `confidence`, `severity`, and `reasonCode`).
+  - If a verifier throws an error, catch it, log a warning, and leave the rule as `pending-verification`.
+  - Accumulate outcomes, then call `writeVerificationOutcomes()`.
+  - Save the updated local manifest (`compiled-rules.json`).
+  > TEST DIRECTIVE: Before implementing, write a failing test named `promotes pending rules to active with candidate debt on in-scope non-bad-example match`.
+  - write test → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+Every implementation MUST end with these steps:
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+- **Installer Stamping:** Verify `totem install pack/test-pack` correctly modifies the local manifest to `pending-verification` and does not default to `active`.
+- **Inertness:** Provide a codebase containing a known violation of a `pending-verification` rule. Verify `totem lint` ignores it and returns clean.
+- **Promotion to Debt:** Provide a baseline violation of a `pending-verification` rule (non-badExample shape). Verify `totem lint` triggers promotion, changes status to `active` with `severity: warning`, and outputs the Candidate Debt.
+- **Demotion to Archived:** Provide an out-of-scope baseline violation. Verify rule transitions to `archived` with `reasonCode='stage4-out-of-scope-match'` and no engine execution occurs for it.
+- **Memoization:** Verify the second `totem lint` run does not invoke the Stage 4 verifier again by stubbing the verifier and asserting it is called 0 times.
+- **Hash Invalidation:** Manually alter the rule hash in the local manifest. Verify `totem lint` re-invokes the verifier.
+
+---
+
+## Implementation Design
+
+### Scope
+
+This implementation adds a `pending-verification` rule status, the install→lint promotion machinery that runs the **existing** Stage 4 verifier (shipped via `mmnto-ai/totem#1682` / `#1683` / `#1766`) on first-touch of pack-installed rules, and the `.totem/verification-outcomes.json` persistence layer that memoizes outcomes across runs. Out of scope: any `totem doctor` UX surfaces (`mmnto-ai/totem#1685`), Stage 4 perf hardening (`mmnto-ai/totem#1686`), Sigstore signing (`mmnto-ai/totem#1492`), or modifications to the verifier itself (callers only — the verifier API is frozen as `verifyAgainstCodebase` + `resolveStage4Baseline`).
+
+### Data model deltas
+
+**1. `CompiledRule.status` enum extension** (`packages/core/src/compiler-schema.ts:117`)
+
+- Current (post-#1682): `z.enum(['active', 'archived', 'untested-against-codebase']).optional()`
+- New: `z.enum(['active', 'archived', 'untested-against-codebase', 'pending-verification']).optional()`
+- Semantic: rule is in the local manifest but the Stage 4 verifier has never run against the consumer's codebase. Inert at lint time exactly the way `'archived'` and `'untested-against-codebase'` are.
+- **Writer:** `installCommand` in `packages/cli/src/commands/install.ts` — stamps every rule from a pack manifest at install time, **before** `mergeRules` writes to `.totem/compiled-rules.json`.
+- **Reader:** the existing inertness filter at `packages/core/src/compiler.ts:132` (`loadCompiledRules` archived-filter) gets extended to also drop `pending-verification` rules from the engine pipeline. Plus the new first-lint promotion interceptor.
+- **Invariant:** a rule MUST NOT remain `pending-verification` after the Stage 4 verifier has run successfully on it — exactly one of the four outcome statuses replaces it. If the verifier throws on that rule, the status stays `pending-verification` and the next lint retries.
+
+> **Spec correction note:** Gemini's auto-generated spec above proposed `RuleStatusSchema = z.enum(['active', 'archived', 'pending-verification'])` — that drops the existing `'untested-against-codebase'` value shipped by #1682. The actual delta is an EXTENSION of the existing enum, not a replacement. The implementation follows the existing schema's vocabulary verbatim.
+
+**2. `VerificationOutcomesStore` schema** (new file `packages/core/src/verification-outcomes.ts`)
+
+```typescript
+import { z } from 'zod';
+
+// Mirrors Stage4Outcome from stage4-verifier.ts EXACTLY (same string literals).
+// Keeping storage vocabulary aligned with the runtime type avoids a translation
+// layer that would drift.
+export const Stage4OutcomeStored = z.enum([
+  'no-matches',
+  'out-of-scope',
+  'in-scope-bad-example',
+  'candidate-debt',
+]);
+
+export const VerificationOutcomeEntrySchema = z.object({
+  ruleHash: z.string().min(1),
+  verifiedAt: z.string().datetime(),
+  outcome: Stage4OutcomeStored,
+  baselineMatches: z.array(z.string()).default([]),
+  inScopeMatches: z.array(z.string()).default([]),
+  candidateDebtLines: z.array(z.string()).default([]),
+});
+
+export const VerificationOutcomesFileSchema = z.object({
+  version: z.literal(1).default(1),
+  outcomes: z.record(z.string(), VerificationOutcomeEntrySchema),
+});
+export type VerificationOutcomeEntry = z.infer<typeof VerificationOutcomeEntrySchema>;
+export type VerificationOutcomesFile = z.infer<typeof VerificationOutcomesFileSchema>;
+```
+
+- **Writer:** first-lint promotion interceptor — single atomic write per lint pass that touched ≥1 pending rule.
+- **Reader:** lint startup — loads metrics to skip re-verification on rules whose `ruleHash` matches the current rule.
+- **Invariant:** when `metrics[ruleHash]` exists and `rule.lessonHash === ruleHash`, no re-verification is invoked.
+- **No reserved keys.** Direct `record<hash, entry>` shape. The `version` field is the forward-compat handle.
+- **Schema-version bump policy:** structural changes to `VerificationOutcomeEntrySchema` increment `version` and the loader treats older versions as "no metrics" (re-verify everything). No silent migration in v1.
+- **Vocabulary alignment with Gemini's spec:** Gemini proposed outcome literals `'no-match' | 'stage4-out-of-scope-match' | 'in-scope-bad-example' | 'in-scope-non-bad-example'` — those don't match the actual `Stage4Outcome` type (`'no-matches' | 'out-of-scope' | 'in-scope-bad-example' | 'candidate-debt'`). The implementation uses the actual type's literals to avoid a redundant translation layer.
+
+**3. Activation message** (`packages/cli/src/commands/install.ts`)
+
+Plain stdout addition after the existing `Installed ${packName}.` success line: `Run \`totem lint\` to activate pack rules`. Not a data type — but locked in via test (Invariant #8).
+
+### State lifecycle
+
+| State piece | Scope | Lifetime | Owner |
+|---|---|---|---|
+| `pending-verification` on rule | Persistent (`.totem/compiled-rules.json`) | Created at install; cleared on first successful Stage 4 outcome; persists across sessions; survives pack reinstall (re-stamped) | `installCommand` (creates); `firstLintPromote` (clears, one per outcome) |
+| `.totem/verification-outcomes.json` | Persistent (per-repo, **committable** per ADR-091 § Bootstrap CI-first) | Created on first lint with pending rules; mutated on every lint pass that runs the verifier; never auto-deleted (`mmnto-ai/totem#1685` will surface 30-day-stale warnings) | `firstLintPromote` (writes); `loadVerificationOutcomes` (reads) |
+| In-memory verification result | Per-process (per lint invocation) | Created during interceptor; consumed for status mutation + atomic write; discarded at process exit | `firstLintPromote` only |
+
+**Crossing-boundary call-out:** install-time status stamps on `compiled-rules.json` are consumed by a later separate process (`totem lint`). This is the canonical Totem lifecycle pattern (already used by `'archived'` flagging) — no new pattern introduced. The two state files (`compiled-rules.json` + `verification-outcomes.json`) are linked by `lessonHash`; never co-mutated in the same write transaction (each has its own atomic write).
+
+### Failure modes
+
+| Failure | Category | Agent-facing surface | Recovery |
+|---|---|---|---|
+| `installCommand` cannot write `.totem/compiled-rules.json` (perm/disk) | runtime | hard error via `TotemError` (existing path, unchanged) | manual fix; pack stays uninstalled |
+| Concurrent CI writes to `.totem/verification-outcomes.json` | runtime (race) | rare; corruption hazard | atomic write: `fs.writeFileSync('.tmp')` then `fs.renameSync(.tmp, final)`; corrupt-read → re-verify all pending |
+| `verifyAgainstCodebase` throws on a single rule | runtime (transient) | `log.warn` + leave rule as `pending-verification` | next `totem lint` retries; per-rule try/catch isolates the failure; lint pass MUST complete |
+| `.totem/` directory missing in fresh CI checkout | runtime (init) | silent `fs.mkdirSync(dir, { recursive: true })` before write | idempotent |
+| `verification-outcomes.json` schema validation fails on read (corrupt / older version / hand-edit) | permanent file state | `log.warn` + treat as empty store; re-verify all pending rules; OVERWRITE on next successful write | self-healing on next lint pass |
+| Pack-installed rule hash differs from `metrics[hash]` (pack updated) | runtime | rule re-enters verification path; old `metrics[oldHash]` becomes orphan | orphan-prune is a `totem doctor` concern (`#1685`), not in this PR |
+| Lint pass with zero pending rules | runtime (common case) | no-op fast path | n/a |
+| `.totem/verification-outcomes.json` exists but `metrics[ruleHash]` is missing for a rule still marked `pending-verification` | runtime | re-verify the rule (treat as fresh) | normal operation |
+
+All silent-degradation rows justified vs Tenet 4: corrupt `verification-outcomes.json` is recoverable per-machine cache state (re-verify is cheap and produces identical outcomes); verifier-throw is recoverable (next lint retries); rule status itself is **never** silently degraded — every status mutation is explicit and deterministic.
+
+### Invariants to lock in via tests
+
+1. **Install-time stamping**: `installCommand` on a pack containing N rules produces exactly N entries in the consumer's `compiled-rules.json` with `status === 'pending-verification'`. No rule slips through with `'active'` or undefined status.
+2. **Inertness**: `loadCompiledRules` filters out `pending-verification` rules the same way it filters `'archived'`. The engine never sees them.
+3. **Four-outcome status mutation** — each Stage 4 outcome maps deterministically:
+   - `'no-matches'` → `status: 'untested-against-codebase'` (existing T1 semantic)
+   - `'out-of-scope'` → `status: 'archived'` + `archivedReason: 'stage4-out-of-scope-match'` + `archivedAt: <iso>`
+   - `'in-scope-bad-example'` → `status: 'active'` + `confidence: 'high'`
+   - `'candidate-debt'` → `status: 'active'` + `severity: 'warning'` (force-override regardless of authored severity)
+4. **Memoization across runs**: second `totem lint` after a successful first-lint promotion invokes `verifyAgainstCodebase` ZERO times; outcomes pulled from `verification-outcomes.json` exclusively.
+5. **Hash-invalidation re-verify**: when `metrics[ruleHash]` is absent for a `pending-verification` rule, the verifier IS invoked. (Pack-content change → new `lessonHash` → metrics absent → re-verify.)
+6. **Atomic write**: `writeVerificationOutcomes` writes via temp+rename; simulated mid-write interrupt does not corrupt the prior valid file.
+7. **Verifier-throw isolation**: when one rule's verifier throws, other rules' verification proceeds; the thrown rule remains `pending-verification`; the lint pass completes cleanly (no process exit).
+8. **Activation message exact-match**: `totem install pack/<name>` stdout contains the literal string `Run \`totem lint\` to activate pack rules`. Locked in via exact-substring assertion.
+9. **Empty-pending fast path**: `totem lint` with zero `pending-verification` rules in the manifest does NOT read `.totem/verification-outcomes.json` (file-read penalty avoided in the common case).
+10. **Corrupt-metrics resilience**: load with deliberately-malformed `verification-outcomes.json` produces `log.warn` + empty store + re-verifies all pending; subsequent lint write overwrites the corrupted file with valid v1 content.
+11. **Byte-stable serialization across runs** (strategy-Claude observation, 2026-05-01): a second `totem lint` immediately after a successful first-lint promotion produces a **byte-identical** `.totem/verification-outcomes.json`. Achieved via canonical-key-order JSON serialization on write. Locks the committable-file-without-phantom-diff property at the file level so consumer repos don't see noise diffs on every CI run.
+
+### Open questions
+
+- **Q1 — Where does the first-lint promotion interceptor module live?**
+  - **Options:**
+    - (a) `packages/core/src/rule-engine.ts` — colocate with `applyRulesToAdditions`. Already imports verifier; smaller import graph delta.
+    - (b) New file `packages/core/src/first-lint-promote.ts` exporting a single `promotePendingRules(deps)` entry point. Clean module boundary, easier unit testing, separable failure modes from the rule-engine hot path.
+    - (c) Inside the CLI lint command (`packages/cli/src/commands/lint.ts`). Couples promotion semantics to CLI.
+  - **Recommendation:** (b). The promotion logic owns its own state (verification-outcomes IO), its own failure modes (verifier-throw isolation + atomic write), and its own tests. Keeping it in core means MCP / `totem review` / future test runners can reuse the promotion path. (c) is wrong because it ties lifecycle policy to a CLI command. (a) bloats `rule-engine.ts`.
+
+- **Q2 — Which baseline does the interceptor pass to `verifyAgainstCodebase` for pack-installed rules?**
+  - **Options:**
+    - (a) Consumer's `review.stage4Baseline` config (resolver from `#1683` already covers this).
+    - (b) Pack-author-supplied baseline metadata (would require pack manifest extension).
+  - **Recommendation:** (a). The whole point of pending-verification is that verification happens **against the consumer's codebase** — so the consumer's baseline is the right one. The existing `resolveStage4Baseline(config, lesson)` already takes `(config, lesson)` and produces the right baseline; pack rules are just compiled lessons and reuse this surface unchanged. (b) would re-introduce the cloud-compile bootstrap gap that ADR-091 § Bootstrap Semantics solves.
+
+- **Q3 — Should `verification-outcomes.json` be `.gitignore`'d or committable?**
+  - **Options:**
+    - (a) `.gitignore`'d — per-machine state; CI re-verifies fresh.
+    - (b) Committable — ticket says "the file is committable so subsequent CI runs and local runs share the verification result."
+  - **Recommendation:** (b). Per the ticket and ADR-091 § Bootstrap CI-first explicit text. Documenting in `docs/wiki/cli-reference.md` install section is in scope; updating `.gitignore` to NOT-ignore the file is the deliverable.
+
+- **Q4 — `installCommand` currently merges pack rules into the consumer manifest before any status manipulation. Where is the cleanest seam to inject the `pending-verification` stamp?**
+  - **Options:**
+    - (a) Mutate the pack-rules array in-memory pre-`mergeRules` call (`installCommand` in `install.ts`). Two-line change; the pack's manifest on disk is unchanged.
+    - (b) Push the stamp into `mergeRules` itself with a flag (e.g., `mergeRules(target, source, { stampPending: true })`). Keeps the install-flow simple but bloats core API.
+    - (c) Stamp post-merge in the consumer manifest. Requires a second pass over the merged result.
+  - **Recommendation:** (a). Lowest surface-area change. The pack's on-disk manifest is read-only from the installer's perspective; mutating the in-memory copy before merge is local, testable, and doesn't change `mergeRules` semantics for non-install consumers.
+
+- **Q5 — Test coverage for the lint integration: should the first-lint interceptor be unit-tested in core (with mocked verifier), or end-to-end via a real CLI lint pass?**
+  - **Options:**
+    - (a) Core unit tests with mocked `Stage4VerifierDeps` (the existing pattern from `stage4-verifier.test.ts`). Fast, deterministic, low friction.
+    - (b) Full CLI integration test that installs a fake pack, runs `totem lint`, asserts verification-outcomes output. High fidelity, slow.
+    - (c) Both — unit for the four-outcome mutation + atomic write semantics; one end-to-end smoke test for the full pipeline.
+  - **Recommendation:** (c). Same pattern as the existing Stage 4 substrate (`mmnto-ai/totem#1757`).
+
+Five open questions, none blocking — all carry a recommendation.

--- a/.totem/specs/1684.md
+++ b/.totem/specs/1684.md
@@ -1,31 +1,37 @@
 ### Problem Statement
+
 Pack rules installed from the cloud lack codebase context, meaning they cannot be trusted to fire safely until empirically verified against the consumer's repository. This feature introduces a `pending-verification` state during installation and leverages the first `totem lint` or `totem review` run to silently execute the Stage 4 verifier, promoting or demoting the rules based on the outcome while persisting results to `.totem/verification-outcomes.json`.
 
 ### Architectural Context
+
 This work operationalizes the "Bootstrap Semantics" defined in ADR-091 and enforces the zero-trust default from ADR-089. From the provided Totem context, this interacts directly with the newly established compile pipeline (via `#1682` Stage 4 verifier, referenced in `applyStage4` logic from `packages/core/src/compile-lesson.ts`). Verification-outcomes persistence provides the memoization layer ensuring we only pay the verification cost once per rule-hash.
 
 ### Files to Examine
+
 1. `packages/core/src/types.ts` (or equivalent schema definition file) — To update the `RuleStatus` enum and define the verification-outcomes Zod schemas.
 2. `packages/core/src/compile-lesson.ts` — To observe the existing `applyStage4` verifier footprint.
 3. `packages/cli/src/commands/install.ts` (or equivalent pack install logic) — To inject the `pending-verification` stamp and activation message.
 4. `packages/core/src/linter.ts` (or engine orchestrator) — To intercept pending rules, trigger verification, and ensure unpromoted rules remain inert.
 
 ### Technical Approach & Contracts
+
 We will implement an interceptor-based promotion flow during lint initialization, backed by a persistent metrics store.
 
 **1. Data Contracts:**
 Update the `CompiledRule` core schema:
+
 ```typescript
 const RuleStatusSchema = z.enum(['active', 'archived', 'pending-verification']);
 ```
 
 Create the `.totem/verification-outcomes.json` schema:
+
 ```typescript
 const RuleVerificationOutcomeSchema = z.enum([
-  'no-match', 
-  'stage4-out-of-scope-match', 
-  'in-scope-bad-example', 
-  'in-scope-non-bad-example'
+  'no-match',
+  'stage4-out-of-scope-match',
+  'in-scope-bad-example',
+  'in-scope-non-bad-example',
 ]);
 
 const VerificationOutcomeEntrySchema = z.object({
@@ -40,10 +46,12 @@ export const VerificationOutcomesStoreSchema = z.record(z.string(), Verification
 ```
 
 **2. Approach & Trade-offs:**
-* *Approach A (In-memory evaluation only)*: Re-run verification every time. Rejected, violates acceptance criteria and scales poorly.
-* *Approach B (Manifest rewrite + metrics file)*: Update the `status` in the local manifest (`compiled-rules.json`) upon promotion AND write to `.totem/verification-outcomes.json`. Subsequent runs check the local manifest. Re-verification triggers if the hash in the manifest differs from the metrics file. **(Recommended)**. This maintains a single source of truth for the rule's local state while memoizing the historical outcome.
+
+- _Approach A (In-memory evaluation only)_: Re-run verification every time. Rejected, violates acceptance criteria and scales poorly.
+- _Approach B (Manifest rewrite + metrics file)_: Update the `status` in the local manifest (`compiled-rules.json`) upon promotion AND write to `.totem/verification-outcomes.json`. Subsequent runs check the local manifest. Re-verification triggers if the hash in the manifest differs from the metrics file. **(Recommended)**. This maintains a single source of truth for the rule's local state while memoizing the historical outcome.
 
 **Execution Sequence:**
+
 1. `totem install pack/<name>` writes to local manifest with `status: 'pending-verification'`.
 2. `totem lint` starts, loads the local manifest.
 3. Linter identifies rules with `status === 'pending-verification'` (or where `metrics.hash !== rule.hash`).
@@ -53,10 +61,11 @@ export const VerificationOutcomesStoreSchema = z.record(z.string(), Verification
 7. Linter drops any rules from the active pipeline that failed verification or threw errors, keeping them inert.
 
 ### Edge Cases & Traps
-* **Concurrent CI Writes (Race Condition):** When multiple lint processes run in CI simultaneously, they will race to write `.totem/verification-outcomes.json`. Writing must be atomic (write to a temporary file, then `fs.renameSync`) to avoid file corruption.
-* **Hash Desync Trap:** If a pack author updates a rule (changing its hash) and a consumer updates the pack, the rule must drop back to `pending-verification`. The interceptor must explicitly compare the rule's current hash against the hash recorded in the metrics file.
-* **Verifier Failure Inertness:** If the Stage 4 verifier throws an exception (e.g., network timeout during AST parsing), the rule MUST remain `pending-verification` and MUST NOT be fed to the engine. It must remain inert.
-* **Missing Totem Directory:** The `.totem` directory might not exist yet during a CI run. The metrics writer must use `fs.mkdirSync(dir, { recursive: true })`.
+
+- **Concurrent CI Writes (Race Condition):** When multiple lint processes run in CI simultaneously, they will race to write `.totem/verification-outcomes.json`. Writing must be atomic (write to a temporary file, then `fs.renameSync`) to avoid file corruption.
+- **Hash Desync Trap:** If a pack author updates a rule (changing its hash) and a consumer updates the pack, the rule must drop back to `pending-verification`. The interceptor must explicitly compare the rule's current hash against the hash recorded in the metrics file.
+- **Verifier Failure Inertness:** If the Stage 4 verifier throws an exception (e.g., network timeout during AST parsing), the rule MUST remain `pending-verification` and MUST NOT be fed to the engine. It must remain inert.
+- **Missing Totem Directory:** The `.totem` directory might not exist yet during a CI run. The metrics writer must use `fs.mkdirSync(dir, { recursive: true })`.
 
 ### Implementation Tasks
 
@@ -64,27 +73,27 @@ export const VerificationOutcomesStoreSchema = z.record(z.string(), Verification
   - Update the rule status schema in `packages/core/src/types.ts` to include `pending-verification`.
   - Add literal options for `confidence` (`untested-against-codebase`) and `reasonCode` (`stage4-out-of-scope-match`).
   - Create the `VerificationOutcomesStoreSchema` using Zod.
-  > TEST DIRECTIVE: Before implementing, write a failing test named `rejects invalid verification-outcomes schema payloads` that proves malformed JSON is caught by Zod.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `rejects invalid verification-outcomes schema payloads` that proves malformed JSON is caught by Zod.
   - write test → verify fails → implement → verify passes → lint
 
 - [ ] **Task 2: Implement Verification-Outcomes Persistence**
   - Create `packages/core/src/verification-outcomes.ts`.
   - Implement `readVerificationOutcomes()` using the shared `readJsonSafe<Record<string, VerificationOutcomeEntry>>('.totem/verification-outcomes.json', VerificationOutcomesStoreSchema)`. Catch `ENOENT` / TotemParseError and return an empty object `{}`, do not crash.
   - Implement `writeVerificationOutcomes()` with atomic file writing (`fs.writeFileSync` to a `.tmp` file, then `fs.renameSync`) to handle CI race conditions. Ensure `.totem` directory creation.
-  > TEST DIRECTIVE: Before implementing, write a failing test named `writes metrics atomically and creates missing directories` to prevent CI file corruption.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `writes metrics atomically and creates missing directories` to prevent CI file corruption.
   - write test → verify fails → implement → verify passes → lint
 
 - [ ] **Task 3: Pack Installer Status Stamping**
   - Modify the install logic in `packages/cli/src/commands/install.ts` (or respective file).
   - Force imported rules into `status: 'pending-verification'`.
   - Output to stdout: "Run \`totem lint\` to activate pack rules".
-  > TEST DIRECTIVE: Before implementing, write a failing test named `forces installed pack rules to pending-verification status and prints activation message`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `forces installed pack rules to pending-verification status and prints activation message`.
   - write test → verify fails → implement → verify passes → lint
 
 - [ ] **Task 4: Engine Execution Inertness Enforcement**
   - Modify rule filtering in the lint/review engine `packages/core/src/linter.ts`.
   - Strip out any rules with `status === 'pending-verification'` before they are handed to the execution engine.
-  > TEST DIRECTIVE: Before implementing, write a failing test named `prevents pending-verification rules from firing during lint execution` to ensure inertness.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `prevents pending-verification rules from firing during lint execution` to ensure inertness.
   - write test → verify fails → implement → verify passes → lint
 
 - [ ] **Task 5: First-Lint Promotion Interceptor**
@@ -94,10 +103,11 @@ export const VerificationOutcomesStoreSchema = z.record(z.string(), Verification
   - If a verifier throws an error, catch it, log a warning, and leave the rule as `pending-verification`.
   - Accumulate outcomes, then call `writeVerificationOutcomes()`.
   - Save the updated local manifest (`compiled-rules.json`).
-  > TEST DIRECTIVE: Before implementing, write a failing test named `promotes pending rules to active with candidate debt on in-scope non-bad-example match`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `promotes pending rules to active with candidate debt on in-scope non-bad-example match`.
   - write test → verify fails → implement → verify passes → lint
 
 ### Execution Flow (structural constraint)
+
 ```dot
 digraph workflow {
   spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
@@ -109,12 +119,15 @@ digraph workflow {
 ```
 
 ### Verification (MANDATORY — do not skip)
+
 Every implementation MUST end with these steps:
+
 1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
 2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
 3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
 
 ### Test Plan
+
 - **Installer Stamping:** Verify `totem install pack/test-pack` correctly modifies the local manifest to `pending-verification` and does not default to `active`.
 - **Inertness:** Provide a codebase containing a known violation of a `pending-verification` rule. Verify `totem lint` ignores it and returns clean.
 - **Promotion to Debt:** Provide a baseline violation of a `pending-verification` rule (non-badExample shape). Verify `totem lint` triggers promotion, changes status to `active` with `severity: warning`, and outputs the Candidate Debt.
@@ -188,26 +201,26 @@ Plain stdout addition after the existing `Installed ${packName}.` success line: 
 
 ### State lifecycle
 
-| State piece | Scope | Lifetime | Owner |
-|---|---|---|---|
-| `pending-verification` on rule | Persistent (`.totem/compiled-rules.json`) | Created at install; cleared on first successful Stage 4 outcome; persists across sessions; survives pack reinstall (re-stamped) | `installCommand` (creates); `firstLintPromote` (clears, one per outcome) |
-| `.totem/verification-outcomes.json` | Persistent (per-repo, **committable** per ADR-091 § Bootstrap CI-first) | Created on first lint with pending rules; mutated on every lint pass that runs the verifier; never auto-deleted (`mmnto-ai/totem#1685` will surface 30-day-stale warnings) | `firstLintPromote` (writes); `loadVerificationOutcomes` (reads) |
-| In-memory verification result | Per-process (per lint invocation) | Created during interceptor; consumed for status mutation + atomic write; discarded at process exit | `firstLintPromote` only |
+| State piece                         | Scope                                                                   | Lifetime                                                                                                                                                                   | Owner                                                                    |
+| ----------------------------------- | ----------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `pending-verification` on rule      | Persistent (`.totem/compiled-rules.json`)                               | Created at install; cleared on first successful Stage 4 outcome; persists across sessions; survives pack reinstall (re-stamped)                                            | `installCommand` (creates); `firstLintPromote` (clears, one per outcome) |
+| `.totem/verification-outcomes.json` | Persistent (per-repo, **committable** per ADR-091 § Bootstrap CI-first) | Created on first lint with pending rules; mutated on every lint pass that runs the verifier; never auto-deleted (`mmnto-ai/totem#1685` will surface 30-day-stale warnings) | `firstLintPromote` (writes); `loadVerificationOutcomes` (reads)          |
+| In-memory verification result       | Per-process (per lint invocation)                                       | Created during interceptor; consumed for status mutation + atomic write; discarded at process exit                                                                         | `firstLintPromote` only                                                  |
 
 **Crossing-boundary call-out:** install-time status stamps on `compiled-rules.json` are consumed by a later separate process (`totem lint`). This is the canonical Totem lifecycle pattern (already used by `'archived'` flagging) — no new pattern introduced. The two state files (`compiled-rules.json` + `verification-outcomes.json`) are linked by `lessonHash`; never co-mutated in the same write transaction (each has its own atomic write).
 
 ### Failure modes
 
-| Failure | Category | Agent-facing surface | Recovery |
-|---|---|---|---|
-| `installCommand` cannot write `.totem/compiled-rules.json` (perm/disk) | runtime | hard error via `TotemError` (existing path, unchanged) | manual fix; pack stays uninstalled |
-| Concurrent CI writes to `.totem/verification-outcomes.json` | runtime (race) | rare; corruption hazard | atomic write: `fs.writeFileSync('.tmp')` then `fs.renameSync(.tmp, final)`; corrupt-read → re-verify all pending |
-| `verifyAgainstCodebase` throws on a single rule | runtime (transient) | `log.warn` + leave rule as `pending-verification` | next `totem lint` retries; per-rule try/catch isolates the failure; lint pass MUST complete |
-| `.totem/` directory missing in fresh CI checkout | runtime (init) | silent `fs.mkdirSync(dir, { recursive: true })` before write | idempotent |
-| `verification-outcomes.json` schema validation fails on read (corrupt / older version / hand-edit) | permanent file state | `log.warn` + treat as empty store; re-verify all pending rules; OVERWRITE on next successful write | self-healing on next lint pass |
-| Pack-installed rule hash differs from `metrics[hash]` (pack updated) | runtime | rule re-enters verification path; old `metrics[oldHash]` becomes orphan | orphan-prune is a `totem doctor` concern (`#1685`), not in this PR |
-| Lint pass with zero pending rules | runtime (common case) | no-op fast path | n/a |
-| `.totem/verification-outcomes.json` exists but `metrics[ruleHash]` is missing for a rule still marked `pending-verification` | runtime | re-verify the rule (treat as fresh) | normal operation |
+| Failure                                                                                                                      | Category              | Agent-facing surface                                                                               | Recovery                                                                                                         |
+| ---------------------------------------------------------------------------------------------------------------------------- | --------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `installCommand` cannot write `.totem/compiled-rules.json` (perm/disk)                                                       | runtime               | hard error via `TotemError` (existing path, unchanged)                                             | manual fix; pack stays uninstalled                                                                               |
+| Concurrent CI writes to `.totem/verification-outcomes.json`                                                                  | runtime (race)        | rare; corruption hazard                                                                            | atomic write: `fs.writeFileSync('.tmp')` then `fs.renameSync(.tmp, final)`; corrupt-read → re-verify all pending |
+| `verifyAgainstCodebase` throws on a single rule                                                                              | runtime (transient)   | `log.warn` + leave rule as `pending-verification`                                                  | next `totem lint` retries; per-rule try/catch isolates the failure; lint pass MUST complete                      |
+| `.totem/` directory missing in fresh CI checkout                                                                             | runtime (init)        | silent `fs.mkdirSync(dir, { recursive: true })` before write                                       | idempotent                                                                                                       |
+| `verification-outcomes.json` schema validation fails on read (corrupt / older version / hand-edit)                           | permanent file state  | `log.warn` + treat as empty store; re-verify all pending rules; OVERWRITE on next successful write | self-healing on next lint pass                                                                                   |
+| Pack-installed rule hash differs from `metrics[hash]` (pack updated)                                                         | runtime               | rule re-enters verification path; old `metrics[oldHash]` becomes orphan                            | orphan-prune is a `totem doctor` concern (`#1685`), not in this PR                                               |
+| Lint pass with zero pending rules                                                                                            | runtime (common case) | no-op fast path                                                                                    | n/a                                                                                                              |
+| `.totem/verification-outcomes.json` exists but `metrics[ruleHash]` is missing for a rule still marked `pending-verification` | runtime               | re-verify the rule (treat as fresh)                                                                | normal operation                                                                                                 |
 
 All silent-degradation rows justified vs Tenet 4: corrupt `verification-outcomes.json` is recoverable per-machine cache state (re-verify is cheap and produces identical outcomes); verifier-throw is recoverable (next lint retries); rule status itself is **never** silently degraded — every status mutation is explicit and deterministic.
 

--- a/docs/wiki/cli-reference.md
+++ b/docs/wiki/cli-reference.md
@@ -77,6 +77,14 @@ For authoring patterns that pass the input-time gate, see [Regex Safety](regex-s
 
 Manage your deterministic rules (Pipeline 1). `rule list` outputs active rules, and `rule scaffold` creates a template for manual rule authoring.
 
+### `totem install pack/<name>`
+
+Installs a Totem pack from npm and merges its rules into your local manifest. Pack rules enter as `pending-verification` status and stay inert at lint time until the next `totem lint` runs the Stage 4 codebase verifier on each — only after that pass do rules promote to `active`, `archived`, or `untested-against-codebase` per their per-rule outcome. Verification outcomes are recorded in `.totem/verification-outcomes.json` (committable) so subsequent CI and local runs share the result and skip re-verification.
+
+- **Flags:**
+  - `--yes`: Auto-append the pack's `.totemignore` entries without showing the diff preview. Required in non-interactive contexts (CI).
+- **Output:** After a successful install, the command prints `Run \`totem lint\` to activate pack rules` as a reminder that pack rules are inert until the first lint pass promotes them.
+
 ### `totem import`
 
 Imports rules from existing tools into the Totem engine (Pipeline 4).

--- a/packages/cli/src/commands/first-lint-promote-runner.ts
+++ b/packages/cli/src/commands/first-lint-promote-runner.ts
@@ -64,15 +64,25 @@ export async function runFirstLintPromote(options: RunFirstLintPromoteOptions): 
   const hasPending = manifest.rules.some((r) => r.status === 'pending-verification');
   if (!hasPending) return;
 
-  // Per-process caches mirror the compile-side wiring in compile.ts:668.
-  // We resolve the repo root + file list once and reuse them across rules.
-  let repoRootCache: string | undefined;
-  let filesCache: readonly string[] | undefined;
+  // Resolve the repo root eagerly (only after we know there's pending work)
+  // so the .totemignore + manifest-exclusion paths can be computed relative
+  // to it. Monorepo subpackages run lint with `cwd` and `configRoot` inside
+  // the package, but `git ls-files` returns paths relative to the actual
+  // repo root — so the manifest-exclusion set must use the same base or
+  // the manifest entry won't match and Stage 4 will end up scanning the
+  // compiled-rules file (false-positive matches against rules' own
+  // `badExample` text).
+  const repoRoot: string = safeExec('git', ['rev-parse', '--show-toplevel'], {
+    cwd,
+    env: { ...process.env, LC_ALL: 'C' },
+  });
 
-  const activeManifestPath = path.join(config.totemDir, COMPILED_RULES_FILE).replace(/\\/g, '/');
+  const activeManifestPath = path.relative(repoRoot, manifestPath).replace(/\\/g, '/');
   const manifestExclusionSet = new Set<string>([...STAGE4_MANIFEST_EXCLUSIONS, activeManifestPath]);
 
-  const ignorePath = path.join(cwd, '.totemignore');
+  // `.totemignore` lives at the repo root by convention (matches compile.ts:708).
+  // Resolving from `cwd` would miss the file when totem is run from a subpackage.
+  const ignorePath = path.join(repoRoot, '.totemignore');
   let ignoreContent = '';
   try {
     ignoreContent = await fs.promises.readFile(ignorePath, 'utf-8'); // totem-context: best-effort optional file; ENOENT means no directives — see the catch
@@ -88,16 +98,10 @@ export async function runFirstLintPromote(options: RunFirstLintPromoteOptions): 
     configExclude: configOverrides?.exclude,
   });
 
+  let filesCache: readonly string[] | undefined;
   const readFileCache = new Map<string, Promise<string>>();
 
   const verifier = async (rule: import('@mmnto/totem').CompiledRule) => {
-    if (repoRootCache === undefined) {
-      repoRootCache = safeExec('git', ['rev-parse', '--show-toplevel'], {
-        cwd,
-        env: { ...process.env, LC_ALL: 'C' },
-      });
-    }
-    const repoRoot = repoRootCache;
     if (filesCache === undefined) {
       const lsOutput: string = safeExec('git', ['ls-files', '-z', '--recurse-submodules'], {
         cwd: repoRoot,

--- a/packages/cli/src/commands/first-lint-promote-runner.ts
+++ b/packages/cli/src/commands/first-lint-promote-runner.ts
@@ -34,6 +34,7 @@ export async function runFirstLintPromote(options: RunFirstLintPromoteOptions): 
     promotePendingRules,
     resolveStage4Baseline,
     safeExec,
+    sanitizeForTerminal,
     saveCompiledRulesFile,
     STAGE4_MANIFEST_EXCLUSIONS,
     verifyAgainstCodebase,
@@ -72,13 +73,36 @@ export async function runFirstLintPromote(options: RunFirstLintPromoteOptions): 
   // the manifest entry won't match and Stage 4 will end up scanning the
   // compiled-rules file (false-positive matches against rules' own
   // `badExample` text).
-  const repoRoot: string = safeExec('git', ['rev-parse', '--show-toplevel'], {
-    cwd,
-    env: { ...process.env, LC_ALL: 'C' },
-  });
+  // totem-context: log+exitCode rather than throw per `.gemini/styleguide.md`
+  // CLI-failure-signal rule (GCA mmnto-ai/totem#1787 R1) — git missing or
+  // running outside a repo should not surface a stack trace.
+  let repoRoot: string;
+  try {
+    repoRoot = safeExec('git', ['rev-parse', '--show-toplevel'], {
+      cwd,
+      env: { ...process.env, LC_ALL: 'C' },
+    }); // totem-context: intentional cleanup — CLI rejects throw at top-level per `.gemini/styleguide.md`; log+exitCode is the documented signal path
+  } catch (err) {
+    log.error(
+      'Totem Error',
+      `Failed to resolve git root: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
 
+  // `.totem/verification-outcomes.json` is committable, so once tracked it
+  // surfaces in the tracked-files enumeration. Without an exclusion entry,
+  // a pending rule would Stage-4 match against serialized outcome JSON
+  // instead of consumer source files. Same class as the manifest-exclusion
+  // (CR mmnto-ai/totem#1787 R1).
   const activeManifestPath = path.relative(repoRoot, manifestPath).replace(/\\/g, '/');
-  const manifestExclusionSet = new Set<string>([...STAGE4_MANIFEST_EXCLUSIONS, activeManifestPath]);
+  const activeOutcomesPath = path.relative(repoRoot, outcomesPath).replace(/\\/g, '/');
+  const manifestExclusionSet = new Set<string>([
+    ...STAGE4_MANIFEST_EXCLUSIONS,
+    activeManifestPath,
+    activeOutcomesPath,
+  ]);
 
   // `.totemignore` lives at the repo root by convention (matches compile.ts:708).
   // Resolving from `cwd` would miss the file when totem is run from a subpackage.
@@ -129,7 +153,10 @@ export async function runFirstLintPromote(options: RunFirstLintPromoteOptions): 
   const result = await promotePendingRules(manifest.rules, {
     outcomesPath,
     verifier,
-    onWarn: (msg: string) => log.warn(tag, msg),
+    // totem-context: msg composed from untrusted lessonHeading + verifier
+    // error text in first-lint-promote.ts; sanitize before terminal write
+    // (CR mmnto-ai/totem#1787 R1, terminal-injection guideline).
+    onWarn: (msg: string) => log.warn(tag, sanitizeForTerminal(msg)),
   });
 
   if (result.changed) {

--- a/packages/cli/src/commands/first-lint-promote-runner.ts
+++ b/packages/cli/src/commands/first-lint-promote-runner.ts
@@ -1,0 +1,140 @@
+/**
+ * CLI runner for the first-lint promotion interceptor (mmnto-ai/totem#1684 T5).
+ *
+ * Wires the Stage 4 verifier deps that core's `promotePendingRules` cannot
+ * build itself — git ls-files enumeration, baseline resolution from the
+ * consumer's `totem.config.ts` plus `.totemignore` directives, and the
+ * fs-backed reader. Mutates `.totem/compiled-rules.json` in place when any
+ * pending rule is promoted, and atomically writes
+ * `.totem/verification-outcomes.json` for memoization across runs.
+ *
+ * Empty-pending fast path: when the manifest has zero `'pending-verification'`
+ * rules, the function returns immediately without invoking git or reading
+ * the outcomes file. The common-case lint pass pays no cost.
+ */
+
+import type { TotemConfig } from '@mmnto/totem';
+
+const COMPILED_RULES_FILE = 'compiled-rules.json';
+const VERIFICATION_OUTCOMES_FILE = 'verification-outcomes.json';
+
+export interface RunFirstLintPromoteOptions {
+  readonly cwd: string;
+  readonly configRoot: string;
+  readonly config: TotemConfig;
+  readonly tag: string;
+}
+
+export async function runFirstLintPromote(options: RunFirstLintPromoteOptions): Promise<void> {
+  const fs = await import('node:fs');
+  const path = await import('node:path');
+  const {
+    loadCompiledRulesFile,
+    parseStage4BaselineDirectives,
+    promotePendingRules,
+    resolveStage4Baseline,
+    safeExec,
+    saveCompiledRulesFile,
+    STAGE4_MANIFEST_EXCLUSIONS,
+    verifyAgainstCodebase,
+  } = await import('@mmnto/totem');
+  const { log } = await import('../ui.js');
+
+  const { cwd, configRoot, config, tag } = options;
+  const totemDirAbs = path.join(configRoot, config.totemDir);
+  const manifestPath = path.join(totemDirAbs, COMPILED_RULES_FILE);
+  const outcomesPath = path.join(totemDirAbs, VERIFICATION_OUTCOMES_FILE);
+
+  if (!fs.existsSync(manifestPath)) return;
+
+  // Read the unfiltered manifest so the interceptor can see pending rules.
+  // `loadCompiledRules` (the lint-execution path) filters them out per
+  // `compiler.ts:140`, so reading via the admin path is required.
+  // A malformed manifest is not our concern to surface — the existing
+  // runCompiledRules path will report it via loadCompiledRules's TotemParseError
+  // immediately after this returns. Returning early here means a corrupt
+  // manifest fails loud through the canonical lint error rather than a
+  // confusing pre-lint stack trace.
+  let manifest: import('@mmnto/totem').CompiledRulesFile;
+  try {
+    manifest = loadCompiledRulesFile(manifestPath); // totem-context: defer manifest-parse error to runCompiledRules's loadCompiledRules so the canonical lint error surfaces, not a pre-lint stack trace
+  } catch {
+    return;
+  }
+  const hasPending = manifest.rules.some((r) => r.status === 'pending-verification');
+  if (!hasPending) return;
+
+  // Per-process caches mirror the compile-side wiring in compile.ts:668.
+  // We resolve the repo root + file list once and reuse them across rules.
+  let repoRootCache: string | undefined;
+  let filesCache: readonly string[] | undefined;
+
+  const activeManifestPath = path.join(config.totemDir, COMPILED_RULES_FILE).replace(/\\/g, '/');
+  const manifestExclusionSet = new Set<string>([...STAGE4_MANIFEST_EXCLUSIONS, activeManifestPath]);
+
+  const ignorePath = path.join(cwd, '.totemignore');
+  let ignoreContent = '';
+  try {
+    ignoreContent = await fs.promises.readFile(ignorePath, 'utf-8'); // totem-context: best-effort optional file; ENOENT means no directives — see the catch
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== 'ENOENT') throw err;
+  }
+  const ignoreDirectives = parseStage4BaselineDirectives(ignoreContent);
+  const configOverrides = config.review?.stage4Baseline;
+  const baseline = resolveStage4Baseline({
+    ignoreDirectives,
+    configExtend: configOverrides?.extend,
+    configExclude: configOverrides?.exclude,
+  });
+
+  const readFileCache = new Map<string, Promise<string>>();
+
+  const verifier = async (rule: import('@mmnto/totem').CompiledRule) => {
+    if (repoRootCache === undefined) {
+      repoRootCache = safeExec('git', ['rev-parse', '--show-toplevel'], {
+        cwd,
+        env: { ...process.env, LC_ALL: 'C' },
+      });
+    }
+    const repoRoot = repoRootCache;
+    if (filesCache === undefined) {
+      const lsOutput: string = safeExec('git', ['ls-files', '-z', '--recurse-submodules'], {
+        cwd: repoRoot,
+        env: { ...process.env, LC_ALL: 'C' },
+      });
+      filesCache = lsOutput
+        .split('\0')
+        .filter((line) => line.length > 0 && !manifestExclusionSet.has(line));
+    }
+    return verifyAgainstCodebase(rule, baseline, {
+      listFiles: async () => filesCache!,
+      readFile: (file: string) => {
+        let pending = readFileCache.get(file);
+        if (!pending) {
+          pending = fs.promises.readFile(path.join(repoRoot, file), 'utf-8');
+          readFileCache.set(file, pending);
+        }
+        return pending;
+      },
+      workingDirectory: repoRoot,
+    });
+  };
+
+  log.info(tag, 'Pack rules pending verification — running Stage 4 against your codebase...');
+  const result = await promotePendingRules(manifest.rules, {
+    outcomesPath,
+    verifier,
+    onWarn: (msg: string) => log.warn(tag, msg),
+  });
+
+  if (result.changed) {
+    saveCompiledRulesFile(manifestPath, { ...manifest, rules: result.mutatedRules });
+  }
+
+  const summary =
+    `Promoted ${result.promoted} pack rule(s) ` +
+    `(${result.verifierInvocations} verified this pass, ` +
+    `${result.verifierFailures} retried next time).`;
+  log.success(tag, summary);
+}

--- a/packages/cli/src/commands/install.test.ts
+++ b/packages/cli/src/commands/install.test.ts
@@ -3,14 +3,18 @@ import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import type { CompiledRule } from '@mmnto/totem';
+
 import { cleanTmpDir } from '../test-utils.js';
 import {
   buildTotemignoreDiff,
   detectPackageManager,
   isInExtends,
   isValidTarget,
+  PACK_INSTALL_ACTIVATION_MESSAGE,
   resolveCompiledRulesExport,
   resolvePackName,
+  stampPackRulesAsPending,
 } from './install.js';
 
 describe('resolvePackName', () => {
@@ -240,5 +244,63 @@ describe('detectPackageManager', () => {
 
   it('falls back to npm when no lockfile is present', () => {
     expect(detectPackageManager(fs, path, tmpDir)).toBe('npm');
+  });
+});
+
+// ─── Pack pending-verification (mmnto-ai/totem#1684 T3) ──────
+
+describe('stampPackRulesAsPending', () => {
+  function makeRule(overrides: Partial<CompiledRule> = {}): CompiledRule {
+    return {
+      lessonHash: 'abc123',
+      lessonHeading: 'No console log',
+      pattern: 'console\\.log',
+      message: 'no console.log',
+      engine: 'regex' as const,
+      compiledAt: '2026-05-01T12:00:00.000Z',
+      ...overrides,
+    };
+  }
+
+  it('forces installed pack rules to pending-verification status and prints activation message', () => {
+    const inputRules: CompiledRule[] = [
+      makeRule({ lessonHash: 'a' }),
+      makeRule({ lessonHash: 'b', status: 'active' }),
+      makeRule({ lessonHash: 'c', status: 'untested-against-codebase' }),
+    ];
+    const stamped = stampPackRulesAsPending(inputRules);
+    expect(stamped).toHaveLength(3);
+    for (const rule of stamped) {
+      expect(rule.status).toBe('pending-verification');
+    }
+    expect(PACK_INSTALL_ACTIVATION_MESSAGE).toBe('Run `totem lint` to activate pack rules');
+  });
+
+  it('does not mutate the input rules', () => {
+    const original = makeRule({ lessonHash: 'a', status: 'active' });
+    const stamped = stampPackRulesAsPending([original]);
+    expect(original.status).toBe('active');
+    expect(stamped[0]?.status).toBe('pending-verification');
+    expect(stamped[0]).not.toBe(original);
+  });
+
+  it('preserves all other rule fields', () => {
+    const original = makeRule({
+      lessonHash: 'a',
+      pattern: 'foo',
+      message: 'No foo',
+      severity: 'warning',
+      category: 'style',
+    });
+    const [stamped] = stampPackRulesAsPending([original]);
+    expect(stamped?.lessonHash).toBe('a');
+    expect(stamped?.pattern).toBe('foo');
+    expect(stamped?.message).toBe('No foo');
+    expect(stamped?.severity).toBe('warning');
+    expect(stamped?.category).toBe('style');
+  });
+
+  it('returns an empty array unchanged for an empty pack', () => {
+    expect(stampPackRulesAsPending([])).toEqual([]);
   });
 });

--- a/packages/cli/src/commands/install.ts
+++ b/packages/cli/src/commands/install.ts
@@ -23,6 +23,32 @@
 
 import type { CompiledRule, CompiledRulesFile } from '@mmnto/totem';
 
+// ─── Pack pending-verification (mmnto-ai/totem#1684) ──────────
+
+/**
+ * The activation hint printed after a successful `totem install` so the user
+ * knows pack rules are inert until the first `totem lint` invokes the Stage 4
+ * verifier on their codebase. Exported as a named constant so tests can lock
+ * the string byte-exactly per #1684 design-doc Invariant #8.
+ */
+export const PACK_INSTALL_ACTIVATION_MESSAGE = 'Run `totem lint` to activate pack rules';
+
+/**
+ * Force every pack-supplied rule into `status: 'pending-verification'` for
+ * the duration of the install. The pack's authoring environment (cloud
+ * compile in particular) cannot have run Stage 4 against the consumer's
+ * codebase, so any status it shipped is meaningless on the consumer side.
+ * The first-lint promotion interceptor (mmnto-ai/totem#1684 T5) replaces
+ * this status on first encounter; subsequent runs read the recorded
+ * outcome from `.totem/verification-outcomes.json`.
+ *
+ * Returns a new array with new rule objects — never mutates the input.
+ * Pure so it can be unit-tested without staging the full install flow.
+ */
+export function stampPackRulesAsPending(rules: readonly CompiledRule[]): CompiledRule[] {
+  return rules.map((rule) => ({ ...rule, status: 'pending-verification' as const }));
+}
+
 // ─── Pure helpers (exported for unit tests) ─────────
 
 export function detectPackageManager(
@@ -388,7 +414,16 @@ export async function installCommand(target: string, options: InstallOptions = {
   }
 
   // ── 6. Merge rules into .totem/compiled-rules.json ──
-  mergeLocalRules(fs, totemDir, path.join(totemDir, 'compiled-rules.json'), packRulesFile, {
+  // Stamp pack rules as `pending-verification` BEFORE mergeRules sees them
+  // (mmnto-ai/totem#1684). The cloud-compile bootstrap path cannot have
+  // verified the pack's rules against the consumer's codebase, so the
+  // first `totem lint` runs the Stage 4 verifier and promotes each rule
+  // per its outcome. Until then they are inert at lint time.
+  const stampedPackRulesFile: CompiledRulesFile = {
+    ...packRulesFile,
+    rules: stampPackRulesAsPending(packRulesFile.rules),
+  };
+  mergeLocalRules(fs, totemDir, path.join(totemDir, 'compiled-rules.json'), stampedPackRulesFile, {
     mergeRules,
     CompiledRulesFileSchema,
     saveCompiledRulesFile,
@@ -413,6 +448,7 @@ export async function installCommand(target: string, options: InstallOptions = {
   }
 
   log.success(TAG, `Installed ${packName}.`);
+  log.info(TAG, PACK_INSTALL_ACTIVATION_MESSAGE);
 }
 
 // ─── Internal helpers (not exported) ────────────────

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -66,6 +66,13 @@ export async function lintCommand(options: LintOptions): Promise<void> {
     // Never crash lint due to staleness check — silently ignore errors
   }
 
+  // First-lint promotion (mmnto-ai/totem#1684): scan the manifest for pack
+  // rules in `'pending-verification'` state and run the Stage 4 verifier on
+  // each, mutating compiled-rules.json + writing verification-outcomes.json.
+  // No-op fast path returns immediately when nothing is pending.
+  const { runFirstLintPromote } = await import('./first-lint-promote-runner.js');
+  await runFirstLintPromote({ cwd, configRoot, config, tag: TAG });
+
   const result = await getDiffForReview(options, config, cwd, TAG);
   if (!result) return;
 

--- a/packages/core/src/compile-manifest.test.ts
+++ b/packages/core/src/compile-manifest.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import type { CompileManifest } from './compile-manifest.js';
 import {
+  canonicalizeKeys,
   canonicalStringify,
   generateInputHash,
   generateOutputHash,
@@ -212,6 +213,47 @@ describe('canonicalStringify', () => {
     // Fail loud rather than silently produce the string "undefined"
     // that would then hash to something no other input produces.
     expect(() => canonicalStringify(undefined)).toThrow(/undefined is not a JSON value/);
+  });
+
+  it('produces pretty-printed output when given an indent argument', () => {
+    // The optional indent param routes through JSON.stringify so committable
+    // artefacts (verification-outcomes.json, etc.) stay diff-friendly while
+    // still using the canonical key order that minified hash payloads use.
+    const out = canonicalStringify({ b: 2, a: 1 }, 2);
+    expect(out).toBe('{\n  "a": 1,\n  "b": 2\n}');
+  });
+
+  it('agrees with the minified form when indent is omitted', () => {
+    const v = { z: 1, a: { c: 3, b: 2 } };
+    expect(canonicalStringify(v)).toBe('{"a":{"b":2,"c":3},"z":1}');
+  });
+});
+
+describe('canonicalizeKeys', () => {
+  it('sorts object keys recursively without serializing', () => {
+    const out = canonicalizeKeys({ z: { y: 1, x: 2 }, a: 0 }) as Record<string, unknown>;
+    expect(Object.keys(out)).toEqual(['a', 'z']);
+    expect(Object.keys(out.z as object)).toEqual(['x', 'y']);
+  });
+
+  it('preserves array order while sorting nested object keys', () => {
+    const out = canonicalizeKeys([{ b: 1, a: 2 }, 3, { d: 4, c: 5 }]) as Array<unknown>;
+    expect(out).toHaveLength(3);
+    expect(Object.keys(out[0] as object)).toEqual(['a', 'b']);
+    expect(out[1]).toBe(3);
+    expect(Object.keys(out[2] as object)).toEqual(['c', 'd']);
+  });
+
+  it('returns primitives unchanged', () => {
+    expect(canonicalizeKeys('s')).toBe('s');
+    expect(canonicalizeKeys(7)).toBe(7);
+    expect(canonicalizeKeys(null)).toBe(null);
+    expect(canonicalizeKeys(true)).toBe(true);
+  });
+
+  it('drops undefined-valued properties (JSON.stringify parity)', () => {
+    const out = canonicalizeKeys({ a: 1, b: undefined, c: 3 }) as Record<string, unknown>;
+    expect(Object.keys(out)).toEqual(['a', 'c']);
   });
 });
 

--- a/packages/core/src/compile-manifest.ts
+++ b/packages/core/src/compile-manifest.ts
@@ -124,12 +124,39 @@ function hasCompoundRule(parsed: unknown): boolean {
   return false;
 }
 
-export function canonicalStringify(value: unknown): string {
+/**
+ * Recursively shape an object tree so every nested record's keys are sorted
+ * lexicographically and `undefined` properties are dropped. Pure data
+ * transform — caller chooses how to serialize the result (minified for hash
+ * payloads, pretty-printed for committable files).
+ */
+export function canonicalizeKeys(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(canonicalizeKeys);
+  const record = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const k of Object.keys(record).sort()) {
+    if (record[k] === undefined) continue;
+    out[k] = canonicalizeKeys(record[k]);
+  }
+  return out;
+}
+
+/**
+ * Stringify a value with deterministic key order. The 1-arg form returns
+ * minified JSON (the manifest-hash payload form per mmnto/totem#1407). Pass
+ * `indent` to produce pretty-printed canonical JSON (used for committable
+ * artefacts like `.totem/verification-outcomes.json` per mmnto-ai/totem#1684).
+ */
+export function canonicalStringify(value: unknown, indent?: number): string {
   if (value === undefined) {
     throw new TotemParseError(
       'canonicalStringify: undefined is not a JSON value',
       'The manifest hash payload must be JSON-parseable. Undefined entries are filtered out of records before serialisation, so a direct undefined here indicates a caller bug rather than malformed data on disk.',
     );
+  }
+  if (indent !== undefined) {
+    return JSON.stringify(canonicalizeKeys(value), null, indent);
   }
   if (value === null || typeof value !== 'object') {
     return JSON.stringify(value);

--- a/packages/core/src/compiler-schema.test.ts
+++ b/packages/core/src/compiler-schema.test.ts
@@ -265,8 +265,34 @@ describe('CompiledRule status field — Stage 4 untested-against-codebase value'
   });
 
   it('rejects an unknown status value', () => {
-    const bogus = { ...stage4UntestedRule, status: 'pending-verification' };
+    const bogus = { ...stage4UntestedRule, status: 'unknown-status' };
     expect(() => CompiledRuleSchema.parse(bogus)).toThrow();
+  });
+});
+
+// ─── Stage 4 pack pending-verification value (mmnto-ai/totem#1684) ─────
+
+describe("CompiledRule status field — pack 'pending-verification' value", () => {
+  const pendingRule = {
+    lessonHash: 'def456abc789',
+    lessonHeading: 'Pack pending rule',
+    pattern: '\\bbar\\b',
+    message: 'No bar',
+    engine: 'regex' as const,
+    compiledAt: '2026-05-01T12:00:00Z',
+    status: 'pending-verification' as const,
+  };
+
+  it("accepts a CompiledRule with status 'pending-verification'", () => {
+    const parsed = CompiledRuleSchema.parse(pendingRule);
+    expect(parsed.status).toBe('pending-verification');
+  });
+
+  it("preserves status: 'pending-verification' across round-trip", () => {
+    const firstParse = CompiledRuleSchema.parse(pendingRule);
+    const serialized: unknown = JSON.parse(JSON.stringify(firstParse));
+    const secondParse = CompiledRuleSchema.parse(serialized);
+    expect(secondParse.status).toBe('pending-verification');
   });
 });
 

--- a/packages/core/src/compiler-schema.ts
+++ b/packages/core/src/compiler-schema.ts
@@ -92,11 +92,11 @@ const CompiledRuleBaseSchema = z.object({
   /** Severity level — error blocks CI, warning reports but doesn't fail */
   severity: z.enum(['error', 'warning']).optional(),
   /**
-   * Lifecycle status. Three values:
+   * Lifecycle status. Four values:
    *   - `'active'`         — rule is enforced by `totem lint`/`totem review`.
    *   - `'archived'`       — rule is preserved on disk (telemetry continuity)
    *                          but skipped at lint time. `loadCompiledRules`
-   *                          filters these out (`compiler.ts:132`).
+   *                          filters these out (`compiler.ts:140`).
    *   - `'untested-against-codebase'` — Stage 4 verifier (mmnto-ai/totem#1682)
    *                          ran against the consumer's codebase but found
    *                          zero matches. The rule's runtime behavior on
@@ -105,6 +105,20 @@ const CompiledRuleBaseSchema = z.object({
    *                          distinct lifecycle semantic so a subsequent
    *                          compile cycle in a populated repo can re-run
    *                          Stage 4 and promote to `'active'`.
+   *   - `'pending-verification'` — pack rule installed via `totem install` in
+   *                          the cloud-compile bootstrap path
+   *                          (mmnto-ai/totem#1684). Stage 4 verifier has
+   *                          never run against the consumer's codebase. Inert
+   *                          at lint time exactly like `'archived'` and
+   *                          `'untested-against-codebase'`. The first-lint
+   *                          promotion interceptor invokes Stage 4 against
+   *                          the consumer's codebase on first encounter and
+   *                          replaces the status with one of the three
+   *                          terminal lifecycle values per Stage4Outcome →
+   *                          status mapping (see `first-lint-promote.ts`).
+   *                          Lifecycle is one-shot: a rule is `'pending-verification'`
+   *                          at most once per `lessonHash` per consumer
+   *                          repository (memoized in `verification-outcomes.json`).
    *
    * Distinct from the boolean `unverified` flag below: `unverified` is set
    * by ADR-089 zero-trust default on every LLM-generated rule (post-Layer-3
@@ -114,7 +128,9 @@ const CompiledRuleBaseSchema = z.object({
    * simultaneously — they answer different questions (author-trust vs
    * empirical-firing).
    */
-  status: z.enum(['active', 'archived', 'untested-against-codebase']).optional(),
+  status: z
+    .enum(['active', 'archived', 'untested-against-codebase', 'pending-verification'])
+    .optional(),
   /**
    * Stage 4 confidence (mmnto-ai/totem#1682). Set to `'high'` when Stage 4's
    * codebase walk found in-scope matches that are structurally equivalent

--- a/packages/core/src/compiler.test.ts
+++ b/packages/core/src/compiler.test.ts
@@ -856,6 +856,46 @@ describe('compiled rules file I/O', () => {
       expect(manifest.rules.some((r) => r.status === 'untested-against-codebase')).toBe(true);
     });
 
+    it('prevents pending-verification rules from firing during lint execution (mmnto-ai/totem#1684)', () => {
+      // Pack rules installed via `totem install` enter the manifest as
+      // `'pending-verification'` because the cloud-compile bootstrap path
+      // cannot have run Stage 4 against the consumer's codebase. They must
+      // stay inert until the first-lint promotion interceptor invokes the
+      // verifier and replaces the status with one of the three terminal
+      // lifecycle values. The interceptor reads the unfiltered manifest
+      // via {@link loadCompiledRulesFile}, so it sees pending rules even
+      // though `loadCompiledRules` (the lint-execution path) skips them.
+      const pendingRule: CompiledRule = {
+        lessonHash: 'eeeeeeeeeeeeeeee',
+        lessonHeading: 'Pack pending rule',
+        pattern: '\\bpending\\b',
+        message: 'pending',
+        engine: 'regex',
+        status: 'pending-verification',
+        compiledAt: '2026-05-01T00:00:00Z',
+      };
+      const rulesPath = path.join(tmpDir, 'compiled-rules.json');
+      saveCompiledRulesFile(rulesPath, {
+        version: 1,
+        rules: [activeRule, legacyRule, archivedRule, pendingRule],
+        nonCompilable: [],
+      });
+
+      const loaded = loadCompiledRules(rulesPath);
+      expect(loaded).toHaveLength(2);
+      expect(loaded.map((r) => r.lessonHash).sort()).toEqual(
+        [activeRule.lessonHash, legacyRule.lessonHash].sort(),
+      );
+      expect(loaded.some((r) => r.status === 'pending-verification')).toBe(false);
+
+      // The full manifest still preserves the pending entry so the
+      // first-lint promotion interceptor (T5) can find it and run the
+      // Stage 4 verifier against the consumer's codebase.
+      const manifest = loadCompiledRulesFile(rulesPath);
+      expect(manifest.rules).toHaveLength(4);
+      expect(manifest.rules.some((r) => r.status === 'pending-verification')).toBe(true);
+    });
+
     it('archived rules do not fire while a sibling active rule still triggers on the same diff', () => {
       // Integration proof: an active rule matching one added line and an
       // archived rule matching a second added line must resolve to exactly

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -110,13 +110,20 @@ export function validateRegex(pattern: string): RegexValidation {
  *
  * Filters out rules with inert lifecycle status so the lint execution path,
  * rule tester, and every other consumer that enforces rules treats them as
- * silenced (#1336 — "The Archive Lie"). Two inert states qualify:
+ * silenced (#1336 — "The Archive Lie"). Three inert states qualify:
  *   - `'archived'` — explicitly silenced via curation (#1336).
  *   - `'untested-against-codebase'` — Stage 4 (mmnto-ai/totem#1682) ran
  *     against the consumer's codebase and produced zero matches. The
  *     rule's runtime behavior is unknown; the schema docstring at
  *     `compiler-schema.ts:100-107` commits to inert-like-archived
  *     semantics, and this filter is what enforces that contract.
+ *   - `'pending-verification'` — pack rule installed via `totem install`
+ *     in the cloud-compile bootstrap path (mmnto-ai/totem#1684). Stage 4
+ *     has not yet run on the consumer's codebase. The rule stays inert
+ *     until the first-lint promotion interceptor runs the verifier and
+ *     replaces the status with one of the three terminal lifecycle
+ *     values. The interceptor itself runs BEFORE this filter and reads
+ *     from the unfiltered manifest via {@link loadCompiledRulesFile}.
  *
  * Rules without a `status` field (legacy manifests compiled before the
  * lifecycle state was added) are treated as active.
@@ -138,7 +145,10 @@ export function loadCompiledRules(
     const json = JSON.parse(raw) as unknown;
     const parsed = CompiledRulesFileSchema.parse(json);
     return parsed.rules.filter(
-      (r) => r.status !== 'archived' && r.status !== 'untested-against-codebase',
+      (r) =>
+        r.status !== 'archived' &&
+        r.status !== 'untested-against-codebase' &&
+        r.status !== 'pending-verification',
     );
   } catch (err) {
     if (err instanceof Error && (err as NodeJS.ErrnoException).code === 'ENOENT') return [];

--- a/packages/core/src/first-lint-promote.test.ts
+++ b/packages/core/src/first-lint-promote.test.ts
@@ -266,7 +266,10 @@ describe('promotePendingRules', () => {
       [ruleA, ruleB],
       deps({ verifier, onWarn: (m) => warnings.push(m) }),
     );
-    expect(result.verifierInvocations).toBe(1);
+    // Both invocations are counted, including the throwing one — the metric
+    // reports verifier work attempted, not work succeeded
+    // (CR mmnto-ai/totem#1787 R1).
+    expect(result.verifierInvocations).toBe(2);
     expect(result.verifierFailures).toBe(1);
     expect(result.promoted).toBe(1);
     expect(result.mutatedRules.find((r) => r.lessonHash === 'fails')?.status).toBe(

--- a/packages/core/src/first-lint-promote.test.ts
+++ b/packages/core/src/first-lint-promote.test.ts
@@ -1,0 +1,314 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CompiledRule } from './compiler-schema.js';
+import {
+  applyOutcomeToRule,
+  promotePendingRules,
+  type PromotePendingRulesDeps,
+} from './first-lint-promote.js';
+import type { Stage4VerificationResult } from './stage4-verifier.js';
+import { cleanTmpDir } from './test-utils.js';
+import {
+  readVerificationOutcomes,
+  type VerificationOutcomeEntry,
+  writeVerificationOutcomes,
+} from './verification-outcomes.js';
+
+// ─── Helpers ────────────────────────────────────────
+
+function makeRule(overrides: Partial<CompiledRule> = {}): CompiledRule {
+  return {
+    lessonHash: 'abc123',
+    lessonHeading: 'No console log',
+    pattern: 'console\\.log',
+    message: 'no console.log',
+    engine: 'regex' as const,
+    compiledAt: '2026-05-01T12:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeStage4Result(
+  outcome: Stage4VerificationResult['outcome'],
+  overrides: Partial<Stage4VerificationResult> = {},
+): Stage4VerificationResult {
+  return {
+    outcome,
+    baselineMatches: [],
+    inScopeMatches: [],
+    candidateDebtLines: [],
+    ...overrides,
+  };
+}
+
+const FROZEN_NOW = new Date('2026-05-01T13:00:00.000Z');
+
+// ─── applyOutcomeToRule (Invariant #3) ──────────────
+
+describe('applyOutcomeToRule', () => {
+  const baseRule = makeRule({ lessonHash: 'h1', status: 'pending-verification' });
+
+  function entry(
+    outcome: Stage4VerificationResult['outcome'],
+    extras: Partial<VerificationOutcomeEntry> = {},
+  ): VerificationOutcomeEntry {
+    return {
+      ruleHash: 'h1',
+      verifiedAt: FROZEN_NOW.toISOString(),
+      outcome,
+      baselineMatches: [],
+      inScopeMatches: [],
+      candidateDebtLines: [],
+      ...extras,
+    };
+  }
+
+  it("maps 'no-matches' to status: 'untested-against-codebase'", () => {
+    const out = applyOutcomeToRule(baseRule, entry('no-matches'));
+    expect(out.status).toBe('untested-against-codebase');
+  });
+
+  it("maps 'out-of-scope' to archived with reason and timestamp", () => {
+    const out = applyOutcomeToRule(baseRule, entry('out-of-scope'));
+    expect(out.status).toBe('archived');
+    expect(out.archivedReason).toBe('stage4-out-of-scope-match');
+    expect(out.archivedAt).toBe(FROZEN_NOW.toISOString());
+  });
+
+  it('preserves prior archivedAt on out-of-scope re-archive', () => {
+    const earlier = '2026-04-01T00:00:00.000Z';
+    const ruleWithPrior = makeRule({ lessonHash: 'h1', archivedAt: earlier });
+    const out = applyOutcomeToRule(ruleWithPrior, entry('out-of-scope'));
+    expect(out.archivedAt).toBe(earlier);
+  });
+
+  it("maps 'in-scope-bad-example' to active with confidence high", () => {
+    const out = applyOutcomeToRule(baseRule, entry('in-scope-bad-example'));
+    expect(out.status).toBe('active');
+    expect(out.confidence).toBe('high');
+  });
+
+  it("maps 'candidate-debt' to active with severity warning, overriding authored severity", () => {
+    const ruleWithError = makeRule({ lessonHash: 'h1', severity: 'error' });
+    const out = applyOutcomeToRule(ruleWithError, entry('candidate-debt'));
+    expect(out.status).toBe('active');
+    expect(out.severity).toBe('warning');
+  });
+
+  it('does not mutate the input rule object', () => {
+    const original = makeRule({ lessonHash: 'h1', status: 'pending-verification' });
+    applyOutcomeToRule(original, entry('no-matches'));
+    expect(original.status).toBe('pending-verification');
+  });
+});
+
+// ─── promotePendingRules ────────────────────────────
+
+describe('promotePendingRules', () => {
+  let tmpDir!: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-flp-'));
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  function deps(
+    overrides: Partial<PromotePendingRulesDeps> & {
+      verifier: PromotePendingRulesDeps['verifier'];
+    },
+  ): PromotePendingRulesDeps {
+    return {
+      outcomesPath: path.join(tmpDir, 'verification-outcomes.json'),
+      now: () => FROZEN_NOW,
+      onWarn: () => {},
+      ...overrides,
+    };
+  }
+
+  // ── Empty-pending fast path (Invariant #9) ────
+
+  it('returns the rules array unchanged and skips file reads when no rules are pending', async () => {
+    const verifier = vi.fn();
+    const onWarn = vi.fn();
+    const rules: CompiledRule[] = [
+      makeRule({ lessonHash: 'a', status: 'active' }),
+      makeRule({ lessonHash: 'b' }),
+    ];
+    const result = await promotePendingRules(
+      rules,
+      deps({ verifier, onWarn, outcomesPath: path.join(tmpDir, 'absent.json') }),
+    );
+    expect(result.changed).toBe(false);
+    expect(result.verifierInvocations).toBe(0);
+    expect(result.promoted).toBe(0);
+    expect(verifier).not.toHaveBeenCalled();
+    expect(onWarn).not.toHaveBeenCalled();
+    expect(result.mutatedRules).toEqual(rules);
+    // No outcomes file should have been created.
+    expect(fs.existsSync(path.join(tmpDir, 'absent.json'))).toBe(false);
+  });
+
+  // ── Promotion to active with candidate debt ───
+
+  it('promotes pending rules to active with candidate debt on in-scope non-bad-example match', async () => {
+    const pending = makeRule({
+      lessonHash: 'p1',
+      status: 'pending-verification',
+      severity: 'error',
+    });
+    const verifier = vi.fn(async () =>
+      makeStage4Result('candidate-debt', {
+        inScopeMatches: ['src/foo.ts'],
+        candidateDebtLines: ['src/foo.ts:10:something'],
+      }),
+    );
+    const result = await promotePendingRules([pending], deps({ verifier }));
+    expect(result.changed).toBe(true);
+    expect(result.promoted).toBe(1);
+    expect(result.verifierInvocations).toBe(1);
+    expect(result.mutatedRules[0]?.status).toBe('active');
+    expect(result.mutatedRules[0]?.severity).toBe('warning');
+  });
+
+  // ── All four outcome mappings round-trip via verifier ─
+
+  it('maps each Stage 4 outcome to the correct terminal status (Invariant #3)', async () => {
+    const rules: CompiledRule[] = [
+      makeRule({ lessonHash: 'no-match-rule', status: 'pending-verification' }),
+      makeRule({ lessonHash: 'oos-rule', status: 'pending-verification' }),
+      makeRule({ lessonHash: 'isb-rule', status: 'pending-verification' }),
+      makeRule({ lessonHash: 'cd-rule', status: 'pending-verification' }),
+    ];
+    const outcomesByHash: Record<string, Stage4VerificationResult['outcome']> = {
+      'no-match-rule': 'no-matches',
+      'oos-rule': 'out-of-scope',
+      'isb-rule': 'in-scope-bad-example',
+      'cd-rule': 'candidate-debt',
+    };
+    const verifier = vi.fn(async (rule: CompiledRule) =>
+      makeStage4Result(outcomesByHash[rule.lessonHash]!),
+    );
+    const result = await promotePendingRules(rules, deps({ verifier }));
+    expect(result.promoted).toBe(4);
+    expect(result.verifierInvocations).toBe(4);
+    expect(result.mutatedRules.find((r) => r.lessonHash === 'no-match-rule')?.status).toBe(
+      'untested-against-codebase',
+    );
+    expect(result.mutatedRules.find((r) => r.lessonHash === 'oos-rule')?.status).toBe('archived');
+    expect(result.mutatedRules.find((r) => r.lessonHash === 'isb-rule')?.confidence).toBe('high');
+    expect(result.mutatedRules.find((r) => r.lessonHash === 'cd-rule')?.severity).toBe('warning');
+  });
+
+  // ── Memoization across runs (Invariant #4) ────
+
+  it('skips the verifier on a second pass when an outcome is already recorded for the rule', async () => {
+    const pending = makeRule({ lessonHash: 'memo', status: 'pending-verification' });
+    const verifier = vi.fn(async () => makeStage4Result('in-scope-bad-example'));
+    const sharedDeps = deps({ verifier });
+
+    // First pass: writes outcomes to disk.
+    await promotePendingRules([pending], sharedDeps);
+    expect(verifier).toHaveBeenCalledTimes(1);
+
+    // Second pass: rule is still pending in the manifest (caller hadn't
+    // written the mutated manifest back yet, simulating the ungraceful-exit
+    // recovery case). The verifier MUST NOT run again.
+    verifier.mockClear();
+    const second = await promotePendingRules([pending], sharedDeps);
+    expect(verifier).not.toHaveBeenCalled();
+    expect(second.verifierInvocations).toBe(0);
+    expect(second.promoted).toBe(1);
+    expect(second.mutatedRules[0]?.status).toBe('active');
+    expect(second.mutatedRules[0]?.confidence).toBe('high');
+  });
+
+  // ── Hash-invalidation re-verify (Invariant #5) ─
+
+  it('re-invokes the verifier when the rule lessonHash differs from the recorded outcome', async () => {
+    const outcomesPath = path.join(tmpDir, 'verification-outcomes.json');
+    // Seed the outcomes file with an entry under an OLD hash. The current
+    // rule has a different lessonHash, simulating a pack content change.
+    writeVerificationOutcomes(outcomesPath, {
+      'old-hash': {
+        ruleHash: 'old-hash',
+        verifiedAt: '2026-04-01T00:00:00.000Z',
+        outcome: 'in-scope-bad-example',
+        baselineMatches: [],
+        inScopeMatches: [],
+        candidateDebtLines: [],
+      },
+    });
+    const verifier = vi.fn(async () => makeStage4Result('no-matches'));
+    const pending = makeRule({ lessonHash: 'new-hash', status: 'pending-verification' });
+    const result = await promotePendingRules([pending], deps({ verifier, outcomesPath }));
+    expect(verifier).toHaveBeenCalledOnce();
+    expect(result.mutatedRules[0]?.status).toBe('untested-against-codebase');
+  });
+
+  // ── Verifier-throw isolation (Invariant #7) ────
+
+  it('isolates per-rule verifier failures and leaves other rules to verify', async () => {
+    const ruleA = makeRule({ lessonHash: 'fails', status: 'pending-verification' });
+    const ruleB = makeRule({ lessonHash: 'passes', status: 'pending-verification' });
+    const warnings: string[] = [];
+    const verifier = vi.fn(async (rule: CompiledRule) => {
+      if (rule.lessonHash === 'fails') throw new Error('transient fs failure');
+      return makeStage4Result('in-scope-bad-example');
+    });
+    const result = await promotePendingRules(
+      [ruleA, ruleB],
+      deps({ verifier, onWarn: (m) => warnings.push(m) }),
+    );
+    expect(result.verifierInvocations).toBe(1);
+    expect(result.verifierFailures).toBe(1);
+    expect(result.promoted).toBe(1);
+    expect(result.mutatedRules.find((r) => r.lessonHash === 'fails')?.status).toBe(
+      'pending-verification',
+    );
+    expect(result.mutatedRules.find((r) => r.lessonHash === 'passes')?.status).toBe('active');
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toMatch(/transient fs failure/);
+  });
+
+  // ── Outcomes file is written atomically ────────
+
+  it('writes the outcomes file with a record per verified rule', async () => {
+    const outcomesPath = path.join(tmpDir, 'verification-outcomes.json');
+    const pending = makeRule({ lessonHash: 'p1', status: 'pending-verification' });
+    const verifier = vi.fn(async () =>
+      makeStage4Result('out-of-scope', { baselineMatches: ['tests/foo.test.ts'] }),
+    );
+    await promotePendingRules([pending], deps({ verifier, outcomesPath }));
+    const persisted = readVerificationOutcomes(outcomesPath);
+    expect(persisted['p1']?.outcome).toBe('out-of-scope');
+    expect(persisted['p1']?.baselineMatches).toEqual(['tests/foo.test.ts']);
+    expect(persisted['p1']?.verifiedAt).toBe(FROZEN_NOW.toISOString());
+  });
+
+  // ── No write when nothing changed ─────────────
+
+  it('does not touch the outcomes file when only memoized hits run', async () => {
+    const outcomesPath = path.join(tmpDir, 'verification-outcomes.json');
+    const pending = makeRule({ lessonHash: 'memo2', status: 'pending-verification' });
+    const verifier = vi.fn(async () => makeStage4Result('in-scope-bad-example'));
+
+    await promotePendingRules([pending], deps({ verifier, outcomesPath }));
+    const firstMtime = fs.statSync(outcomesPath).mtimeMs;
+
+    // Wait at least 1ms so a re-write would surface in mtime comparison.
+    await new Promise((resolve) => setTimeout(resolve, 5));
+    verifier.mockClear();
+    await promotePendingRules([pending], deps({ verifier, outcomesPath }));
+
+    const secondMtime = fs.statSync(outcomesPath).mtimeMs;
+    expect(secondMtime).toBe(firstMtime);
+    expect(verifier).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/first-lint-promote.ts
+++ b/packages/core/src/first-lint-promote.ts
@@ -105,8 +105,9 @@ export async function promotePendingRules(
   }
 
   // Empty-pending fast path (Invariant #9): skip the outcomes-file read
-  // when there's nothing to verify. Returns the original array unchanged
-  // — callers can shallow-equal compare to detect no-op.
+  // when there's nothing to verify. The returned array is a shallow copy
+  // of the input — `changed: false` is the no-op signal callers should use
+  // to skip manifest writes, not array-identity.
   if (pendingIndices.length === 0) {
     return { mutatedRules: [...rules], ...NOOP_RESULT_TEMPLATE };
   }

--- a/packages/core/src/first-lint-promote.ts
+++ b/packages/core/src/first-lint-promote.ts
@@ -57,7 +57,9 @@ export interface PromotePendingRulesDeps {
   readonly now?: () => Date;
   /**
    * Optional logger for verifier failures and self-healing diagnostics.
-   * Defaults to `console.warn` when omitted.
+   * Defaults to a no-op when omitted — pass an explicit logger to surface
+   * corrupt-cache and verifier-failure diagnostics. The CLI runner wires
+   * this to `log.warn` after sanitization (see `first-lint-promote-runner.ts`).
    */
   readonly onWarn?: (msg: string) => void;
 }
@@ -69,7 +71,11 @@ export interface PromotePendingRulesResult {
    * Callers persist this to `.totem/compiled-rules.json`.
    */
   readonly mutatedRules: CompiledRule[];
-  /** Count of rules that invoked the verifier this pass (excludes memoized hits). */
+  /**
+   * Count of verifier calls this pass (excludes memoized hits). Includes
+   * calls that threw, since the metric reports work attempted rather than
+   * work succeeded — pair with `verifierFailures` to derive the success count.
+   */
   readonly verifierInvocations: number;
   /** Count of rules whose status was replaced with a terminal lifecycle value. */
   readonly promoted: number;
@@ -133,8 +139,8 @@ export async function promotePendingRules(
       // No memoized outcome (or hash mismatch on a stale entry). Invoke the
       // verifier. Per-rule try/catch isolates failures (Invariant #7).
       try {
-        const result = await deps.verifier(rule);
         verifierInvocations += 1;
+        const result = await deps.verifier(rule);
         outcomeEntry = {
           ruleHash: rule.lessonHash,
           verifiedAt: now().toISOString(),

--- a/packages/core/src/first-lint-promote.ts
+++ b/packages/core/src/first-lint-promote.ts
@@ -1,0 +1,201 @@
+import type { CompiledRule } from './compiler-schema.js';
+import type { Stage4VerificationResult } from './stage4-verifier.js';
+import {
+  readVerificationOutcomes,
+  type VerificationOutcomeEntry,
+  type VerificationOutcomesStore,
+  writeVerificationOutcomes,
+} from './verification-outcomes.js';
+
+/**
+ * The first-lint promotion interceptor (mmnto-ai/totem#1684 T5).
+ *
+ * Pack rules installed via `totem install` enter the consumer's manifest with
+ * `status: 'pending-verification'` because the cloud-compile bootstrap path
+ * cannot have run Stage 4 against the consumer's codebase. On the first
+ * `totem lint` run after install, this module sweeps the manifest for those
+ * pending entries, invokes the Stage 4 verifier on each, and replaces the
+ * status with one of the four terminal lifecycle values per Invariant #3:
+ *
+ *   - `'no-matches'`        → `status: 'untested-against-codebase'`
+ *   - `'out-of-scope'`      → `status: 'archived'` + `archivedReason`
+ *   - `'in-scope-bad-example'` → `status: 'active'` + `confidence: 'high'`
+ *   - `'candidate-debt'`    → `status: 'active'` + `severity: 'warning'`
+ *
+ * Outcomes are written to `.totem/verification-outcomes.json` so subsequent
+ * runs skip re-verification on rules whose `lessonHash` matches a recorded
+ * outcome (Invariant #4). A pack content update produces a new `lessonHash`
+ * which has no recorded outcome → verifier runs again (Invariant #5).
+ *
+ * Empty-pending fast path: when the manifest has zero `'pending-verification'`
+ * rules, the function returns immediately without reading the outcomes file
+ * (Invariant #9) — the common-case lint pass pays no verification cost.
+ *
+ * Per-rule try/catch isolates verifier-throws (Invariant #7): one rule's
+ * failure does not abort the pass; that rule remains `'pending-verification'`
+ * and the next lint retries.
+ */
+
+export interface PromotePendingRulesDeps {
+  /**
+   * Filesystem path to `.totem/verification-outcomes.json`. The interceptor
+   * reads existing outcomes for memoization and atomically rewrites the
+   * file when new outcomes are recorded.
+   */
+  readonly outcomesPath: string;
+  /**
+   * Pre-wired Stage 4 verifier — typically a closure that builds the
+   * `Stage4VerifierDeps` once (git ls-files, baseline resolution) and then
+   * invokes `verifyAgainstCodebase` per rule. Throws on transient I/O
+   * errors; the interceptor catches and isolates per-rule failures.
+   */
+  readonly verifier: (rule: CompiledRule) => Promise<Stage4VerificationResult>;
+  /**
+   * ISO-now provider for `verifiedAt` timestamps. Injected so tests can
+   * produce deterministic outcomes; production code passes `() => new Date()`.
+   */
+  readonly now?: () => Date;
+  /**
+   * Optional logger for verifier failures and self-healing diagnostics.
+   * Defaults to `console.warn` when omitted.
+   */
+  readonly onWarn?: (msg: string) => void;
+}
+
+export interface PromotePendingRulesResult {
+  /**
+   * The mutated rule list. Statuses on `'pending-verification'` rules are
+   * replaced per Invariant #3; rules whose verifier threw are unchanged.
+   * Callers persist this to `.totem/compiled-rules.json`.
+   */
+  readonly mutatedRules: CompiledRule[];
+  /** Count of rules that invoked the verifier this pass (excludes memoized hits). */
+  readonly verifierInvocations: number;
+  /** Count of rules whose status was replaced with a terminal lifecycle value. */
+  readonly promoted: number;
+  /** Count of rules whose verifier threw and stayed `'pending-verification'`. */
+  readonly verifierFailures: number;
+  /**
+   * Whether any rule status mutation occurred. Callers can skip manifest
+   * writes when this is `false` to avoid touching the file on no-op passes.
+   */
+  readonly changed: boolean;
+}
+
+const NOOP_RESULT_TEMPLATE = {
+  verifierInvocations: 0,
+  promoted: 0,
+  verifierFailures: 0,
+  changed: false,
+} as const;
+
+export async function promotePendingRules(
+  rules: readonly CompiledRule[],
+  deps: PromotePendingRulesDeps,
+): Promise<PromotePendingRulesResult> {
+  const pendingIndices: number[] = [];
+  for (let i = 0; i < rules.length; i++) {
+    if (rules[i]?.status === 'pending-verification') pendingIndices.push(i);
+  }
+
+  // Empty-pending fast path (Invariant #9): skip the outcomes-file read
+  // when there's nothing to verify. Returns the original array unchanged
+  // — callers can shallow-equal compare to detect no-op.
+  if (pendingIndices.length === 0) {
+    return { mutatedRules: [...rules], ...NOOP_RESULT_TEMPLATE };
+  }
+
+  const onWarn = deps.onWarn ?? (() => {});
+  const now = deps.now ?? (() => new Date());
+
+  const existingOutcomes = readVerificationOutcomes(deps.outcomesPath, onWarn);
+  const updatedOutcomes: VerificationOutcomesStore = { ...existingOutcomes };
+
+  const mutatedRules: CompiledRule[] = [...rules];
+  let verifierInvocations = 0;
+  let promoted = 0;
+  let verifierFailures = 0;
+  let outcomesChanged = false;
+
+  for (const idx of pendingIndices) {
+    const rule = mutatedRules[idx]!;
+    const memoized = existingOutcomes[rule.lessonHash];
+
+    let outcomeEntry: VerificationOutcomeEntry | null = null;
+
+    if (memoized && memoized.ruleHash === rule.lessonHash) {
+      // Memoization hit: reuse the recorded outcome. The status was either
+      // never written back to the manifest (interrupted prior pass) or the
+      // rule was re-stamped pending by a reinstall — either way, the
+      // recorded outcome is still authoritative.
+      outcomeEntry = memoized;
+    } else {
+      // No memoized outcome (or hash mismatch on a stale entry). Invoke the
+      // verifier. Per-rule try/catch isolates failures (Invariant #7).
+      try {
+        const result = await deps.verifier(rule);
+        verifierInvocations += 1;
+        outcomeEntry = {
+          ruleHash: rule.lessonHash,
+          verifiedAt: now().toISOString(),
+          outcome: result.outcome,
+          baselineMatches: [...result.baselineMatches],
+          inScopeMatches: [...result.inScopeMatches],
+          candidateDebtLines: [...result.candidateDebtLines],
+        };
+        updatedOutcomes[rule.lessonHash] = outcomeEntry;
+        outcomesChanged = true; // totem-context: per-rule verifier-throw isolation per Invariant #7 of #1684 — one failing rule must not abort the lint pass; the rule stays 'pending-verification' and next lint retries
+      } catch (err) {
+        verifierFailures += 1;
+        onWarn(
+          `Stage 4 verifier failed for rule ${rule.lessonHash} (${rule.lessonHeading}); ` +
+            `leaving as 'pending-verification' for next lint retry. ` +
+            `Cause: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        continue;
+      }
+    }
+
+    mutatedRules[idx] = applyOutcomeToRule(rule, outcomeEntry);
+    promoted += 1;
+  }
+
+  if (outcomesChanged) {
+    writeVerificationOutcomes(deps.outcomesPath, updatedOutcomes);
+  }
+
+  return {
+    mutatedRules,
+    verifierInvocations,
+    promoted,
+    verifierFailures,
+    changed: promoted > 0,
+  };
+}
+
+/**
+ * Map a Stage 4 outcome to the rule's terminal lifecycle status per
+ * Invariant #3. Pure function so the four-way mapping can be unit-tested
+ * without staging the full interceptor flow. Returns a new rule object;
+ * never mutates the input.
+ */
+export function applyOutcomeToRule(
+  rule: CompiledRule,
+  entry: VerificationOutcomeEntry,
+): CompiledRule {
+  switch (entry.outcome) {
+    case 'no-matches':
+      return { ...rule, status: 'untested-against-codebase' };
+    case 'out-of-scope':
+      return {
+        ...rule,
+        status: 'archived',
+        archivedReason: 'stage4-out-of-scope-match',
+        archivedAt: rule.archivedAt ?? entry.verifiedAt,
+      };
+    case 'in-scope-bad-example':
+      return { ...rule, status: 'active', confidence: 'high' };
+    case 'candidate-debt':
+      return { ...rule, status: 'active', severity: 'warning' };
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -376,6 +376,23 @@ export {
   verifyAgainstCodebase,
 } from './stage4-verifier.js';
 
+// Pack pending-verification install→lint promotion (mmnto-ai/totem#1684)
+export type { PromotePendingRulesDeps, PromotePendingRulesResult } from './first-lint-promote.js';
+export { applyOutcomeToRule, promotePendingRules } from './first-lint-promote.js';
+export type {
+  Stage4OutcomeStoredValue,
+  VerificationOutcomeEntry,
+  VerificationOutcomesFile,
+  VerificationOutcomesStore,
+} from './verification-outcomes.js';
+export {
+  readVerificationOutcomes,
+  Stage4OutcomeStored,
+  VerificationOutcomeEntrySchema,
+  VerificationOutcomesFileSchema,
+  writeVerificationOutcomes,
+} from './verification-outcomes.js';
+
 // Compile manifest (signing / provenance)
 export type { CompileManifest } from './compile-manifest.js';
 export {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -396,6 +396,7 @@ export {
 // Compile manifest (signing / provenance)
 export type { CompileManifest } from './compile-manifest.js';
 export {
+  canonicalizeKeys,
   canonicalStringify,
   CompileManifestSchema,
   generateInputHash,

--- a/packages/core/src/verification-outcomes.test.ts
+++ b/packages/core/src/verification-outcomes.test.ts
@@ -237,4 +237,42 @@ describe('readVerificationOutcomes / writeVerificationOutcomes', () => {
     writeVerificationOutcomes(filePath, sampleStore);
     expect(readVerificationOutcomes(filePath)).toEqual(sampleStore);
   });
+
+  it('drops entries whose key does not match their stored ruleHash', () => {
+    // Defense in depth: schema validates each entry's shape but not that the
+    // file-level key matches the stored ruleHash. A tampered or hand-edited
+    // file could memoize an outcome under the wrong hash; the loader filters
+    // those out with a warn (CR mmnto-ai/totem#1787 R1).
+    const filePath = tmpFile();
+    const tampered = {
+      version: 1,
+      outcomes: {
+        // Key "abc123" but entry.ruleHash is "different-hash" — mismatch.
+        abc123: {
+          ruleHash: 'different-hash',
+          verifiedAt: '2026-05-02T00:00:00.000Z',
+          outcome: 'in-scope-bad-example' as const,
+          baselineMatches: [],
+          inScopeMatches: [],
+          candidateDebtLines: [],
+        },
+        // Aligned entry — key matches ruleHash.
+        aligned: {
+          ruleHash: 'aligned',
+          verifiedAt: '2026-05-02T00:00:00.000Z',
+          outcome: 'no-matches' as const,
+          baselineMatches: [],
+          inScopeMatches: [],
+          candidateDebtLines: [],
+        },
+      },
+    };
+    fs.writeFileSync(filePath, JSON.stringify(tampered), 'utf-8');
+    const warnings: string[] = [];
+    const store = readVerificationOutcomes(filePath, (m) => warnings.push(m));
+    expect(Object.keys(store)).toEqual(['aligned']);
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toMatch(/Key\/hash mismatch/);
+    expect(warnings[0]).toMatch(/abc123/);
+  });
 });

--- a/packages/core/src/verification-outcomes.test.ts
+++ b/packages/core/src/verification-outcomes.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  Stage4OutcomeStored,
+  VerificationOutcomeEntrySchema,
+  VerificationOutcomesFileSchema,
+} from './verification-outcomes.js';
+
+// ─── Stage4OutcomeStored ───────────────────────────
+
+describe('Stage4OutcomeStored', () => {
+  it('accepts each Stage4Outcome literal', () => {
+    for (const outcome of [
+      'no-matches',
+      'out-of-scope',
+      'in-scope-bad-example',
+      'candidate-debt',
+    ] as const) {
+      expect(Stage4OutcomeStored.parse(outcome)).toBe(outcome);
+    }
+  });
+
+  it('rejects an unknown literal', () => {
+    expect(() => Stage4OutcomeStored.parse('promoted')).toThrow();
+  });
+});
+
+// ─── VerificationOutcomeEntrySchema ────────────────
+
+describe('VerificationOutcomeEntrySchema', () => {
+  const validEntry = {
+    ruleHash: 'abc123',
+    verifiedAt: '2026-05-01T12:34:56.000Z',
+    outcome: 'in-scope-bad-example' as const,
+    baselineMatches: [],
+    inScopeMatches: ['src/foo.ts'],
+    candidateDebtLines: [],
+  };
+
+  it('accepts a fully-populated valid entry', () => {
+    const parsed = VerificationOutcomeEntrySchema.parse(validEntry);
+    expect(parsed.ruleHash).toBe('abc123');
+    expect(parsed.outcome).toBe('in-scope-bad-example');
+    expect(parsed.inScopeMatches).toEqual(['src/foo.ts']);
+  });
+
+  it('defaults match arrays to empty when omitted', () => {
+    const parsed = VerificationOutcomeEntrySchema.parse({
+      ruleHash: 'abc123',
+      verifiedAt: '2026-05-01T12:34:56.000Z',
+      outcome: 'no-matches',
+    });
+    expect(parsed.baselineMatches).toEqual([]);
+    expect(parsed.inScopeMatches).toEqual([]);
+    expect(parsed.candidateDebtLines).toEqual([]);
+  });
+
+  it('rejects invalid verification-outcomes schema payloads', () => {
+    expect(() => VerificationOutcomeEntrySchema.parse({ ...validEntry, ruleHash: '' })).toThrow();
+    expect(() => VerificationOutcomeEntrySchema.parse({ ...validEntry, ruleHash: 42 })).toThrow();
+    expect(() =>
+      VerificationOutcomeEntrySchema.parse({ ...validEntry, verifiedAt: 'not-a-date' }),
+    ).toThrow();
+    expect(() =>
+      VerificationOutcomeEntrySchema.parse({ ...validEntry, outcome: 'promoted' }),
+    ).toThrow();
+    expect(() =>
+      VerificationOutcomeEntrySchema.parse({ ...validEntry, ruleHash: '   ' }),
+    ).toThrow();
+    expect(() =>
+      VerificationOutcomeEntrySchema.parse({ ...validEntry, inScopeMatches: [''] }),
+    ).toThrow();
+    const { ruleHash: _omit, ...missingHash } = validEntry;
+    void _omit;
+    expect(() => VerificationOutcomeEntrySchema.parse(missingHash)).toThrow();
+  });
+
+  it('trims surrounding whitespace from ruleHash', () => {
+    const parsed = VerificationOutcomeEntrySchema.parse({ ...validEntry, ruleHash: '  abc123  ' });
+    expect(parsed.ruleHash).toBe('abc123');
+  });
+});
+
+// ─── VerificationOutcomesFileSchema ────────────────
+
+describe('VerificationOutcomesFileSchema', () => {
+  const validEntry = {
+    ruleHash: 'abc123',
+    verifiedAt: '2026-05-01T12:34:56.000Z',
+    outcome: 'in-scope-bad-example' as const,
+    baselineMatches: [],
+    inScopeMatches: [],
+    candidateDebtLines: [],
+  };
+
+  it('accepts an empty outcomes record with default version', () => {
+    const parsed = VerificationOutcomesFileSchema.parse({ outcomes: {} });
+    expect(parsed.version).toBe(1);
+    expect(parsed.outcomes).toEqual({});
+  });
+
+  it('accepts a populated outcomes record', () => {
+    const parsed = VerificationOutcomesFileSchema.parse({
+      version: 1,
+      outcomes: { abc123: validEntry },
+    });
+    expect(parsed.outcomes['abc123']?.outcome).toBe('in-scope-bad-example');
+  });
+
+  it('rejects a future schema version', () => {
+    expect(() =>
+      VerificationOutcomesFileSchema.parse({
+        version: 2,
+        outcomes: { abc123: validEntry },
+      }),
+    ).toThrow();
+  });
+
+  it('rejects a malformed nested entry', () => {
+    expect(() =>
+      VerificationOutcomesFileSchema.parse({
+        version: 1,
+        outcomes: { abc123: { ...validEntry, outcome: 'promoted' } },
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/core/src/verification-outcomes.test.ts
+++ b/packages/core/src/verification-outcomes.test.ts
@@ -1,9 +1,17 @@
-import { describe, expect, it } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { cleanTmpDir } from './test-utils.js';
 import {
+  readVerificationOutcomes,
   Stage4OutcomeStored,
   VerificationOutcomeEntrySchema,
   VerificationOutcomesFileSchema,
+  type VerificationOutcomesStore,
+  writeVerificationOutcomes,
 } from './verification-outcomes.js';
 
 // ─── Stage4OutcomeStored ───────────────────────────
@@ -123,5 +131,110 @@ describe('VerificationOutcomesFileSchema', () => {
         outcomes: { abc123: { ...validEntry, outcome: 'promoted' } },
       }),
     ).toThrow();
+  });
+});
+
+// ─── Persistence (mmnto-ai/totem#1684 T2) ───────────
+
+describe('readVerificationOutcomes / writeVerificationOutcomes', () => {
+  let tmpDir!: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-vouts-'));
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  function tmpFile(name = 'verification-outcomes.json'): string {
+    return path.join(tmpDir, name);
+  }
+
+  const sampleStore: VerificationOutcomesStore = {
+    abc123: {
+      ruleHash: 'abc123',
+      verifiedAt: '2026-05-01T12:34:56.000Z',
+      outcome: 'in-scope-bad-example',
+      baselineMatches: [],
+      inScopeMatches: ['src/foo.ts', 'src/bar.ts'],
+      candidateDebtLines: [],
+    },
+    def456: {
+      ruleHash: 'def456',
+      verifiedAt: '2026-05-01T12:35:00.000Z',
+      outcome: 'candidate-debt',
+      baselineMatches: [],
+      inScopeMatches: ['src/baz.ts'],
+      candidateDebtLines: ['src/baz.ts:10:something'],
+    },
+  };
+
+  it('returns an empty store when the file does not exist', () => {
+    const warnings: string[] = [];
+    const store = readVerificationOutcomes(tmpFile('absent.json'), (m) => warnings.push(m));
+    expect(store).toEqual({});
+    expect(warnings).toEqual([]);
+  });
+
+  it('writes verification outcomes atomically and creates missing directories', () => {
+    const filePath = path.join(tmpFile('nested'), 'deep', 'verification-outcomes.json');
+    expect(fs.existsSync(path.dirname(filePath))).toBe(false);
+    writeVerificationOutcomes(filePath, sampleStore);
+    expect(fs.existsSync(filePath)).toBe(true);
+    expect(fs.existsSync(`${filePath}.tmp`)).toBe(false);
+    const roundTripped = readVerificationOutcomes(filePath);
+    expect(roundTripped).toEqual(sampleStore);
+  });
+
+  it('round-trips the sample store byte-stably', () => {
+    const filePath = tmpFile();
+    writeVerificationOutcomes(filePath, sampleStore);
+    const firstBytes = fs.readFileSync(filePath, 'utf-8');
+    writeVerificationOutcomes(filePath, sampleStore);
+    const secondBytes = fs.readFileSync(filePath, 'utf-8');
+    expect(secondBytes).toBe(firstBytes);
+  });
+
+  it('canonicalizes object key order regardless of insertion order', () => {
+    const filePath = tmpFile();
+    writeVerificationOutcomes(filePath, sampleStore);
+    const firstBytes = fs.readFileSync(filePath, 'utf-8');
+
+    const reordered: VerificationOutcomesStore = {
+      def456: sampleStore['def456']!,
+      abc123: sampleStore['abc123']!,
+    };
+    writeVerificationOutcomes(filePath, reordered);
+    const secondBytes = fs.readFileSync(filePath, 'utf-8');
+    expect(secondBytes).toBe(firstBytes);
+  });
+
+  it('returns an empty store and warns on malformed JSON', () => {
+    const filePath = tmpFile();
+    fs.writeFileSync(filePath, '{ this is : not json,', 'utf-8');
+    const warnings: string[] = [];
+    const store = readVerificationOutcomes(filePath, (m) => warnings.push(m));
+    expect(store).toEqual({});
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toMatch(/Malformed JSON/);
+  });
+
+  it('returns an empty store and warns on schema mismatch', () => {
+    const filePath = tmpFile();
+    fs.writeFileSync(filePath, JSON.stringify({ version: 2, outcomes: {} }), 'utf-8');
+    const warnings: string[] = [];
+    const store = readVerificationOutcomes(filePath, (m) => warnings.push(m));
+    expect(store).toEqual({});
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toMatch(/Schema validation failed/);
+  });
+
+  it('overwrites a prior corrupt file on next write', () => {
+    const filePath = tmpFile();
+    fs.writeFileSync(filePath, 'garbage{', 'utf-8');
+    expect(readVerificationOutcomes(filePath, () => {})).toEqual({});
+    writeVerificationOutcomes(filePath, sampleStore);
+    expect(readVerificationOutcomes(filePath)).toEqual(sampleStore);
   });
 });

--- a/packages/core/src/verification-outcomes.ts
+++ b/packages/core/src/verification-outcomes.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 
 import { z } from 'zod';
 
+import { canonicalStringify } from './compile-manifest.js';
 import type { Stage4Outcome } from './stage4-verifier.js';
 
 /**
@@ -136,7 +137,22 @@ export function readVerificationOutcomes(
     );
     return {};
   }
-  return result.data.outcomes;
+  // totem-context: defense-in-depth — schema validates each entry's shape but
+  // not that the file-level record key matches the entry's stored ruleHash.
+  // A tampered or hand-edited file could memoize an outcome under the wrong
+  // hash. Drop those entries (with a warn) so memoization never satisfies a
+  // mismatched lookup.
+  const aligned: VerificationOutcomesStore = {};
+  for (const [key, entry] of Object.entries(result.data.outcomes)) {
+    if (entry.ruleHash !== key) {
+      onWarn?.(
+        `Key/hash mismatch in ${filePath}: key=${key}, entry.ruleHash=${entry.ruleHash}. Ignoring entry.`,
+      );
+      continue;
+    }
+    aligned[key] = entry;
+  }
+  return aligned;
 }
 
 /**
@@ -158,22 +174,16 @@ export function writeVerificationOutcomes(
   fs.mkdirSync(dir, { recursive: true });
 
   const file: VerificationOutcomesFile = { version: 1, outcomes };
-  const json = `${JSON.stringify(canonicalizeForSerialization(file), null, 2)}\n`;
+  const json = `${canonicalStringify(file, 2)}\n`;
 
-  const tmpPath = `${filePath}.tmp`;
-  fs.writeFileSync(tmpPath, json, 'utf-8');
-  fs.renameSync(tmpPath, filePath);
-}
-
-function canonicalizeForSerialization(value: unknown): unknown {
-  if (Array.isArray(value)) return value.map(canonicalizeForSerialization);
-  if (typeof value === 'object' && value !== null) {
-    const record = value as Record<string, unknown>;
-    const out: Record<string, unknown> = {};
-    for (const key of Object.keys(record).sort()) {
-      out[key] = canonicalizeForSerialization(record[key]);
-    }
-    return out;
+  // totem-context: per-write unique temp filename so two concurrent lint
+  // processes can't clobber each other's in-flight write and trigger a
+  // hard rename failure mid-pass (CR mmnto-ai/totem#1787 R1).
+  const tmpPath = `${filePath}.${process.pid}.${Date.now().toString(36)}.tmp`;
+  try {
+    fs.writeFileSync(tmpPath, json, 'utf-8');
+    fs.renameSync(tmpPath, filePath);
+  } finally {
+    if (fs.existsSync(tmpPath)) fs.rmSync(tmpPath, { force: true });
   }
-  return value;
 }

--- a/packages/core/src/verification-outcomes.ts
+++ b/packages/core/src/verification-outcomes.ts
@@ -1,0 +1,87 @@
+import { z } from 'zod';
+
+import type { Stage4Outcome } from './stage4-verifier.js';
+
+/**
+ * Stage 4 outcome literals serialized into `.totem/verification-outcomes.json`
+ * (mmnto-ai/totem#1684, ADR-091 § Bootstrap CI-first). Mirrors the
+ * `Stage4Outcome` type from `stage4-verifier.ts` exactly so the storage
+ * vocabulary matches the runtime type and we avoid a translation layer that
+ * would drift on Stage 4 evolution.
+ *
+ * The `_OutcomeAlignment` type below enforces the mirror at compile time —
+ * if either side adds, drops, or renames a literal, the assertion below
+ * fails the build before drift can land in the corpus.
+ */
+export const Stage4OutcomeStored = z.enum([
+  'no-matches',
+  'out-of-scope',
+  'in-scope-bad-example',
+  'candidate-debt',
+]);
+
+type _OutcomeAlignment =
+  z.infer<typeof Stage4OutcomeStored> extends Stage4Outcome
+    ? Stage4Outcome extends z.infer<typeof Stage4OutcomeStored>
+      ? true
+      : false
+    : false;
+
+const _stage4OutcomeAlignment: _OutcomeAlignment = true;
+void _stage4OutcomeAlignment;
+
+/**
+ * One verification record per pack-installed rule (keyed by `lessonHash` in
+ * the file-level record). Persisted across lint runs so subsequent passes
+ * skip re-verification when the rule's content hash matches a recorded
+ * outcome.
+ */
+export const VerificationOutcomeEntrySchema = z.object({
+  /**
+   * `lessonHash` of the rule the outcome was recorded against. Persisted
+   * inside the entry as well as serving as the file-level record key so a
+   * tampered key (key/value mismatch) can be detected on read.
+   */
+  ruleHash: z.string().trim().min(1),
+  /** ISO-8601 timestamp of when the verifier produced the outcome. */
+  verifiedAt: z.string().datetime(),
+  /** The terminal Stage 4 outcome that was recorded. */
+  outcome: Stage4OutcomeStored,
+  /** Repo-relative paths of baseline-scoped files where the rule fired. */
+  baselineMatches: z.array(z.string().trim().min(1)).default([]),
+  /** Repo-relative paths of in-scope files where the rule fired. */
+  inScopeMatches: z.array(z.string().trim().min(1)).default([]),
+  /**
+   * In-scope match lines that did not match the `badExample` shape — the
+   * Candidate Debt evidence carried forward to the `totem doctor` UX
+   * surface in mmnto-ai/totem#1685. Empty unless `outcome === 'candidate-debt'`.
+   */
+  candidateDebtLines: z.array(z.string().trim().min(1)).default([]),
+});
+
+/**
+ * The on-disk shape of `.totem/verification-outcomes.json`. Wraps the
+ * per-rule record in a versioned envelope so structural changes can break
+ * the file forward without silent migration: a loader that sees an unknown
+ * `version` treats the file as empty and re-verifies, instead of risking a
+ * partial parse against a newer schema.
+ */
+export const VerificationOutcomesFileSchema = z.object({
+  version: z.literal(1).default(1),
+  outcomes: z.record(z.string(), VerificationOutcomeEntrySchema),
+});
+
+export type Stage4OutcomeStoredValue = z.infer<typeof Stage4OutcomeStored>;
+export type VerificationOutcomeEntry = z.infer<typeof VerificationOutcomeEntrySchema>;
+export type VerificationOutcomesFile = z.infer<typeof VerificationOutcomesFileSchema>;
+
+/**
+ * Convenience alias for the in-memory mapping of `lessonHash` to its recorded
+ * verification outcome. The file-level wrapper holds the same record under
+ * `outcomes`; this alias exists so call sites that operate on the mapping
+ * directly (the first-lint promotion interceptor in particular) can carry
+ * a focused type without re-derivation. Reserved by mmnto-ai/totem#1684 §
+ * "Vocabulary alignment" — `VerificationOutcomesStore` is the canonical name
+ * for the in-memory mapping.
+ */
+export type VerificationOutcomesStore = VerificationOutcomesFile['outcomes'];

--- a/packages/core/src/verification-outcomes.ts
+++ b/packages/core/src/verification-outcomes.ts
@@ -1,3 +1,6 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
 import { z } from 'zod';
 
 import type { Stage4Outcome } from './stage4-verifier.js';
@@ -85,3 +88,92 @@ export type VerificationOutcomesFile = z.infer<typeof VerificationOutcomesFileSc
  * for the in-memory mapping.
  */
 export type VerificationOutcomesStore = VerificationOutcomesFile['outcomes'];
+
+// ─── Persistence (mmnto-ai/totem#1684 T2) ───────────
+
+/**
+ * Load the per-rule verification outcomes from a `verification-outcomes.json`
+ * file. Returns an empty store when the file is missing, contains malformed
+ * JSON, or fails schema validation — the corpus self-heals on the next
+ * write. The interceptor that wrote the corrupt file (or a future pass with
+ * a refreshed schema) will overwrite it on the next promotion run, so the
+ * cache state cannot wedge.
+ *
+ * Invariant: schema-version mismatch is treated as "no outcomes recorded"
+ * rather than attempted migration. A v2 file read by a v1 loader returns
+ * an empty store and warns; the next write produces a valid v1 file.
+ */
+export function readVerificationOutcomes(
+  filePath: string,
+  onWarn?: (msg: string) => void,
+): VerificationOutcomesStore {
+  if (!fs.existsSync(filePath)) return {};
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf-8'); // totem-context: self-healing on transient read errors per Invariant #10 of #1684 — verification-outcomes.json is per-machine cache; corruption is recoverable on next write
+  } catch (err) {
+    onWarn?.(
+      // totem-context: see preceding try — corrupt cache state self-heals; next write overwrites
+      `Could not read ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return {};
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw); // totem-context: self-healing on malformed JSON per Invariant #10 of #1684 — corrupt cache state self-heals; next write overwrites
+  } catch (err) {
+    onWarn?.(
+      // totem-context: see preceding try — corrupt cache state self-heals; next write overwrites
+      `Malformed JSON in ${filePath}: ${err instanceof Error ? err.message : String(err)}. Treating as empty; next write will overwrite.`,
+    );
+    return {};
+  }
+  const result = VerificationOutcomesFileSchema.safeParse(parsed);
+  if (!result.success) {
+    const issues = result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+    onWarn?.(
+      `Schema validation failed for ${filePath}: ${issues}. Treating as empty; next write will overwrite.`,
+    );
+    return {};
+  }
+  return result.data.outcomes;
+}
+
+/**
+ * Persist the per-rule verification outcomes to disk via temp-file +
+ * atomic rename, so a concurrent CI lint pass that interrupts mid-write
+ * leaves the prior valid file intact rather than producing a truncated
+ * partial-write that the next loader would reject.
+ *
+ * Output is canonicalized (recursive object-key sort) before serialization
+ * so two lint passes that produce the same outcomes write byte-identical
+ * files — Invariant #11 in the design doc, which keeps consumer repos
+ * from seeing phantom diffs on every CI run.
+ */
+export function writeVerificationOutcomes(
+  filePath: string,
+  outcomes: VerificationOutcomesStore,
+): void {
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true });
+
+  const file: VerificationOutcomesFile = { version: 1, outcomes };
+  const json = `${JSON.stringify(canonicalizeForSerialization(file), null, 2)}\n`;
+
+  const tmpPath = `${filePath}.tmp`;
+  fs.writeFileSync(tmpPath, json, 'utf-8');
+  fs.renameSync(tmpPath, filePath);
+}
+
+function canonicalizeForSerialization(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalizeForSerialization);
+  if (typeof value === 'object' && value !== null) {
+    const record = value as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(record).sort()) {
+      out[key] = canonicalizeForSerialization(record[key]);
+    }
+    return out;
+  }
+  return value;
+}


### PR DESCRIPTION
## Summary

Closes the cloud-compile bootstrap gap that ADR-091 § Bootstrap Semantics defined. Pack rules installed via `totem install` cannot be trusted to fire on the consumer's codebase until Stage 4 verifies them locally — so they now enter the manifest as `'pending-verification'` and the next `totem lint` runs the verifier and promotes them per outcome.

Six commits split along the spec's task plan (T1–T6 in `.totem/specs/1684.md`):

- **T1** `020f1291` — `CompiledRule.status` enum extended with `'pending-verification'` (alongside `'active' | 'archived' | 'untested-against-codebase'`); `verification-outcomes.ts` defines Zod schemas for the new committable side-table with a compile-time alignment guard against `Stage4Outcome` drift.
- **T2** `4e7f75dc` — `readVerificationOutcomes` / `writeVerificationOutcomes` persistence with self-healing on corrupt-read (Invariant #10), atomic temp+rename writes, and recursive object-key sort for byte-stable serialization (Invariant #11).
- **T3** `f319147d` — `installCommand` force-stamps every pack rule `'pending-verification'` regardless of the status the pack shipped with, and prints `Run \`totem lint\` to activate pack rules` after the install-success line (Invariant #8 exact-match locked via constant + test).
- **T4** `8e0fd6e1` — `loadCompiledRules` filter (lint-execution path) extended to also drop `'pending-verification'` rules; `loadCompiledRulesFile` (admin path) keeps them visible so the interceptor can find them.
- **T5** `08dd8823` — `first-lint-promote.ts` exports `promotePendingRules(rules, deps)` with per-rule verifier-throw isolation (Invariant #7), empty-pending fast path (Invariant #9), and memoization across runs (Invariant #4) keyed on `lessonHash` (Invariant #5 hash-invalidation re-verify). CLI runner at `first-lint-promote-runner.ts` builds Stage 4 deps and wires into `lintCommand` before `getDiffForReview`.
- **T6** `6159046c` — Changeset (minor bump on the fixed group of `@mmnto/{totem,cli,mcp,pack-rust-architecture,pack-agent-security}`), wiki entry for `totem install`, and monorepo path correctness (resolve `repoRoot` eagerly so `.totemignore` and the manifest-exclusion entry use repo-relative paths instead of mis-joining against `configRoot` in monorepo subpackages — addresses two findings from the first `totem review` pass).

## Naming-collision context

The original ADR-091 draft specified `.totem/rule-metrics.json`, but `packages/core/src/rule-metrics.ts` already exists as a per-machine telemetry-cache module (`triggerCount`, `suppressCount`, `evaluationCount`) with a gitignored `.totem/cache/rule-metrics.json` lifetime. Multi-agent decision (option B): rename the new committable verification state to `.totem/verification-outcomes.json` + new `verification-outcomes.ts` module. ADR-091 § 65 was amended in `mmnto-ai/totem-strategy` main to match.

## Test plan

- [x] **`@mmnto/totem`**: 1753/1753 tests pass (was 1719; +34 new — schema validation, persistence round-trips, byte-stable serialization, four Stage4Outcome mappings, memoization-skip, hash-invalidation re-verify, verifier-throw isolation, empty-pending fast path, filter regression).
- [x] **`@mmnto/cli`**: 1962/1962 tests pass (was 1958; +4 new — stamper purity, activation-message exact-substring lock-in, install-flow regression).
- [x] `totem lint` PASS (0 errors, 3 warnings — substrate-rule false positives in the spec doc + test code, tier-3 follow-up).
- [x] `totem review` PASS via `gemini-3.1-pro-preview` against the full branch diff.

## Known follow-ups

1. Substrate-rule false positives on internal scaffolding (`os.tmpdir()` / `fs.readFileSync` in tests; "absolute claims" rule firing on RFC-2119 prose in `.totem/specs/`) — file as tier-3.
2. The same monorepo-subpackage manifest-exclusion path issue exists in `compile.ts:663`. T6 fixed it on my code; mirror to `compile.ts` as tier-3.
3. `totem doctor` Stage 4 UX surfaces (`mmnto-ai/totem#1685`) and Stage 4 perf hardening (`mmnto-ai/totem#1686`) remain — tracked in their own tickets.

Closes #1684.

🤖 Generated with [Claude Code](https://claude.com/claude-code)