### PR TITLE
fix(pack): #1803 Option C — engines field migration

### DIFF
--- a/.changeset/1803-engines-field-migration.md
+++ b/.changeset/1803-engines-field-migration.md
@@ -1,0 +1,24 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+'@mmnto/pack-rust-architecture': minor
+'@mmnto/pack-agent-security': minor
+---
+
+**ADR-097 § Q6 amended — engine-version constraint moves from `peerDependencies` to `engines` (closes #1803).**
+
+Pack manifest resolver (`pack-manifest-writer.ts:readEngineRange`, formerly `readPeerEngineRange`) now reads `engines['@mmnto/totem']` from the resolved pack's `package.json` instead of `peerDependencies['@mmnto/totem']`. The boot-time engine-version cross-check (`pack-discovery.ts:assertEngineRangeSatisfied`) reads the same value via `installed-packs.json#packs[].declaredEngineRange` and continues to fail loud on semver mismatch.
+
+**Why the move:**
+
+- `engines` is npm-canonical for engine-version constraints. `peerDependencies` is for actual peer packages the consumer must install (e.g., `@ast-grep/napi`). Mechanism mapping is now correct.
+- Symmetry across the cohort. Internal and future external packs declare `engines.@mmnto/totem` consistently; `peerDependencies` is uniformly for actual peer packages only.
+- Closes the structural collision with `mmnto-ai/totem#1777` (the `1.22.0 → 2.0.0` wiggle root cause): a fixed-group sibling pack cannot peer-dep `@mmnto/totem` without triggering a changesets MAJOR cascade. The `engines` field is not touched by changesets fixed-group auto-bump, so the wiggle stays prevented even with a declared engine constraint.
+
+**Migration shape:**
+
+- `@mmnto/pack-rust-architecture` and `@mmnto/pack-agent-security` now declare `"engines": { "@mmnto/totem": "^1.25.0" }`. Neither declares `@mmnto/totem` in `peerDependencies` (locked by `structure.test.ts` invariants in both packs).
+- The `not-a-pack` warning in `totem sync` was reworded to point at the actual gap: `"missing engines['@mmnto/totem'] declaration — pack cannot satisfy the engine-version cross-check (ADR-097 § 5 Q6). Add '"engines": { "@mmnto/totem": "^<version>" }' to the pack's package.json and republish."` Pre-#1803 text was misleading per `mmnto-ai/totem#1803`'s reproducer (it claimed the registration callback was missing when the callback was correctly exported).
+- No fallback to the legacy `peerDependencies['@mmnto/totem']` slot. Pre-1.26.0 packs that declared the engine constraint via peerDeps (none known to exist outside the `@mmnto/*` cohort, all of which are migrated in this cohort) must republish with `engines` declared.
+
+Closes #1803.

--- a/docs/active_work.md
+++ b/docs/active_work.md
@@ -53,10 +53,11 @@ The strategic frame is "publishing without runtime-wiring is incomplete; ship ga
 
 #### Headline work — Pack v0.1 graduation
 
+- [ ] **`mmnto-ai/totem#1803` Option C — engines field migration.** Move the pack engine-version constraint from `peerDependencies['@mmnto/totem']` to `engines['@mmnto/totem']` per ADR-097 § Q6 amendment. Closes the structural collision with `mmnto-ai/totem#1777` (fixed-group sibling cannot peer-dep `@mmnto/totem` without triggering a MAJOR cascade) while preserving real semver cross-check at boot. Resolver mod + schema cascade across `pack-rust-architecture` and `pack-agent-security` + warning-text fix in `totem sync`. Unblocks Pack v0.1 alpha-pilot Leg 3 (external consumer adoption / LC un-quarantine).
 - [ ] **Bot-pack publish.** Lift `pack-staging/pack-bot-coderabbit-v0.1/` and `pack-staging/pack-bot-gemini-code-assist-v0.1/` to `@mmnto/pack-bot-coderabbit@1.x` and `@mmnto/pack-bot-gemini-code-assist@1.x` on npm. Publishing pipeline is proven; low risk.
 - [ ] **Bot-pack wire-into-hooks.** Session-start hooks for Claude Code and Gemini CLI consult the bot packs alongside the existing `totem describe` orientation pass. Same shape as the language-pack `extends` mechanism.
 - [ ] **Memory refactor.** Thin or remove the ~11 bot-specific rules in strategy-Claude memory that duplicate pack content; replace with one pointer rule directing future sessions to `@mmnto/pack-bot-coderabbit/workflows/*` and `@mmnto/pack-bot-gemini-code-assist/workflows/*` as the canonical source. Memory keeps session-incident receipts; pack holds the canonical operational rules.
-- [ ] **LC un-quarantine validation.** Pattern-quality review per `mmnto-ai/totem#1793` BEFORE un-quarantining the 4-rule `.rs` cohort (3 from upstream-014, 1 from upstream-048). End-to-end validation that PR #1795's substrate-wiring fix unblocks the LC PR-C cascade is the load-bearing signal that closes the alpha-pilot gate.
+- [ ] **LC un-quarantine validation.** Pattern-quality review per `mmnto-ai/totem#1793` BEFORE un-quarantining the 4-rule `.rs` cohort (3 from upstream-014, 1 from upstream-048). End-to-end validation that PR #1795's substrate-wiring fix + #1803's engines-field migration unblock the LC PR-C cascade is the load-bearing signal that closes the alpha-pilot gate.
 
 #### Headline work — Substrate hardening (Tenet 15)
 

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -107,7 +107,7 @@ export async function syncCommand(options: {
             ? `present in package.json but not in totem.config.ts \`extends\` — pack rules will not be merged. Add to \`extends\` or remove the dependency.`
             : warning.reason === 'extends-only'
               ? `declared in totem.config.ts \`extends\` but not installed — install via \`pnpm add -D ${warning.name}\` (or equivalent).`
-              : `does not expose a registration callback — see ADR-097 § 5 for the pack contract.`;
+              : `missing engines['@mmnto/totem'] declaration — pack cannot satisfy the engine-version cross-check (ADR-097 § 5 Q6). Add '"engines": { "@mmnto/totem": "^<version>" }' to the pack's package.json and republish.`;
         log.warn(TAG, `Pack '${warning.name}': ${reasonText}`);
       }
       if (resolved.length > 0) {

--- a/packages/core/src/pack-discovery.test.ts
+++ b/packages/core/src/pack-discovery.test.ts
@@ -177,7 +177,7 @@ describe('loadInstalledPacks: malformed manifest', () => {
   });
 });
 
-describe('loadInstalledPacks: peerDependencies engine version mismatch', () => {
+describe('loadInstalledPacks: engines[@mmnto/totem] version mismatch', () => {
   it('throws structured error naming pack name + declared range + actual engine version', () => {
     const fakeCallback: PackRegisterCallback = () => {};
     const fakePack: LoadedPack = {

--- a/packages/core/src/pack-discovery.ts
+++ b/packages/core/src/pack-discovery.ts
@@ -23,8 +23,10 @@
  *   to generate.
  * - Malformed manifest: hard error.
  * - Pack require throws: hard error.
- * - peerDependencies engine version mismatch: structured error per ADR-097
- *   Q6.
+ * - engines['@mmnto/totem'] version mismatch: structured error per ADR-097
+ *   Q6 (amended 2026-05-03 — moved from peerDependencies to engines field
+ *   per mmnto-ai/totem#1803 to avoid changesets `fixed` group sibling
+ *   peer-dep collision; see #1776 / #1777).
  * - Pack callback throws: hard error.
  */
 
@@ -76,7 +78,13 @@ export const InstalledPacksManifestSchema = z
             .string()
             .min(1)
             .refine((value) => path.isAbsolute(value), 'resolvedPath must be an absolute path'),
-          /** The pack's `peerDependencies['@mmnto/totem']` semver range, verbatim. */
+          /**
+           * The pack's `engines['@mmnto/totem']` semver range, verbatim.
+           * (Pre-1.26.0 packs used `peerDependencies['@mmnto/totem']`;
+           * mmnto-ai/totem#1803 moved the constraint to the `engines`
+           * field to free `peerDependencies` for actual peer packages
+           * and avoid changesets fixed-group sibling collisions.)
+           */
           declaredEngineRange: z.string().min(1),
         })
         .strict(),
@@ -170,7 +178,7 @@ export interface LoadInstalledPacksOptions {
   totemDir?: string;
   /**
    * Engine semver to compare against each pack's declared
-   * `peerDependencies['@mmnto/totem']` range. Defaults to the engine's
+   * `engines['@mmnto/totem']` range. Defaults to the engine's
    * own `package.json#version`.
    */
   engineVersion?: string;
@@ -394,7 +402,7 @@ function resolvePackCallback(
 function assertEngineRangeSatisfied(pack: LoadedPack, engineVersion: string): void {
   if (!semver.validRange(pack.declaredEngineRange)) {
     throw new Error(
-      `Pack '${pack.name}' declares peerDependencies['@mmnto/totem'] = '${pack.declaredEngineRange}', which is not a valid semver range. Fix the pack's package.json.`,
+      `Pack '${pack.name}' declares engines['@mmnto/totem'] = '${pack.declaredEngineRange}', which is not a valid semver range. Fix the pack's package.json.`,
     );
   }
   if (!semver.satisfies(engineVersion, pack.declaredEngineRange, { includePrerelease: true })) {

--- a/packages/core/src/pack-manifest-writer.test.ts
+++ b/packages/core/src/pack-manifest-writer.test.ts
@@ -1,6 +1,8 @@
 /**
  * Tests for pack manifest resolution + writer (mmnto-ai/totem#1768
- * Step 4, Q4 disposition).
+ * Step 4, Q4 disposition; ADR-097 § Q6 amended 2026-05-03 via
+ * mmnto-ai/totem#1803 — engine constraint moved from peerDependencies
+ * to the `engines` field).
  *
  * Covers invariant 18 from `.totem/specs/pack-substrate-bundle.md`:
  *
@@ -8,7 +10,10 @@
  *   `totem.config.ts` `extends` → manifest entry, no warning.
  * - Resolves a pack only in deps → no manifest entry, `dep-only` warning.
  * - Resolves a pack only in extends → no manifest entry, `extends-only` warning.
- * - Pack without `peerDependencies['@mmnto/totem']` → `not-a-pack` warning.
+ * - Pack without `engines['@mmnto/totem']` → `not-a-pack` warning.
+ * - Pack with engine constraint declared in legacy `peerDependencies`
+ *   slot but missing from `engines` → still `not-a-pack` (no fallback
+ *   read; the migration is hard, not graceful).
  * - Atomic write produces a stable JSON file.
  */
 
@@ -42,17 +47,36 @@ function makeTmpRoot(): string {
   return root;
 }
 
-function writeFixturePack(root: string, packName: string, peerRange: string | undefined): string {
+interface FixturePackOptions {
+  /** Engine semver range for `engines['@mmnto/totem']`. Omitted → not-a-pack. */
+  readonly engineRange?: string;
+  /**
+   * Legacy peerDependencies['@mmnto/totem'] value, for tests that
+   * verify the resolver no longer falls back to peer-dep reads after the
+   * #1803 migration. Default: not declared.
+   */
+  readonly legacyPeerRange?: string;
+}
+
+function writeFixturePack(
+  root: string,
+  packName: string,
+  options: FixturePackOptions = {},
+): string {
   // Create a node_modules layout that `require.resolve` can find. The pack
-  // directory holds package.json with `peerDependencies['@mmnto/totem']`.
+  // directory holds package.json with `engines['@mmnto/totem']` per ADR-097
+  // § Q6 (post-#1803).
   const packPath = path.join(root, 'node_modules', packName);
   fs.mkdirSync(packPath, { recursive: true });
   const pkgJson: Record<string, unknown> = {
     name: packName,
     version: '0.1.0',
   };
-  if (peerRange !== undefined) {
-    pkgJson.peerDependencies = { '@mmnto/totem': peerRange };
+  if (options.engineRange !== undefined) {
+    pkgJson.engines = { '@mmnto/totem': options.engineRange };
+  }
+  if (options.legacyPeerRange !== undefined) {
+    pkgJson.peerDependencies = { '@mmnto/totem': options.legacyPeerRange };
   }
   fs.writeFileSync(path.join(packPath, 'package.json'), JSON.stringify(pkgJson, null, 2));
   return packPath;
@@ -83,7 +107,7 @@ function makeConfig(extendsList: readonly string[] | undefined): TotemConfig {
 describe('resolveInstalledPacks: union of deps + extends', () => {
   it('resolves a pack present in both deps and extends with no warning', () => {
     const root = makeTmpRoot();
-    writeFixturePack(root, '@mmnto/pack-fake', '^1.19.0');
+    writeFixturePack(root, '@mmnto/pack-fake', { engineRange: '^1.19.0' });
     const result = resolveInstalledPacks({
       projectRoot: root,
       config: makeConfig(['@mmnto/pack-fake']),
@@ -97,7 +121,7 @@ describe('resolveInstalledPacks: union of deps + extends', () => {
 
   it('emits dep-only warning when pack is in deps but not extends', () => {
     const root = makeTmpRoot();
-    writeFixturePack(root, '@mmnto/pack-orphan-dep', '^1.19.0');
+    writeFixturePack(root, '@mmnto/pack-orphan-dep', { engineRange: '^1.19.0' });
     const result = resolveInstalledPacks({
       projectRoot: root,
       config: makeConfig([]),
@@ -120,9 +144,9 @@ describe('resolveInstalledPacks: union of deps + extends', () => {
     expect(result.resolved).toEqual([]);
   });
 
-  it('emits not-a-pack warning when pack lacks peerDependencies[@mmnto/totem]', () => {
+  it('emits not-a-pack warning when pack lacks engines[@mmnto/totem]', () => {
     const root = makeTmpRoot();
-    writeFixturePack(root, '@mmnto/pack-broken', undefined);
+    writeFixturePack(root, '@mmnto/pack-broken', {});
     const result = resolveInstalledPacks({
       projectRoot: root,
       config: makeConfig(['@mmnto/pack-broken']),
@@ -130,6 +154,32 @@ describe('resolveInstalledPacks: union of deps + extends', () => {
     });
     expect(result.warnings).toEqual([{ name: '@mmnto/pack-broken', reason: 'not-a-pack' }]);
     expect(result.resolved).toEqual([]);
+  });
+
+  it('emits not-a-pack warning for a legacy pack that declares only peerDependencies[@mmnto/totem] (no engines fallback)', () => {
+    // Migration is hard, not graceful: a pre-#1803 pack that didn't add the
+    // engines field is not silently accepted via a peerDeps fallback. The
+    // resolver reads engines only; pack must republish with engines declared.
+    const root = makeTmpRoot();
+    writeFixturePack(root, '@mmnto/pack-legacy', { legacyPeerRange: '^1.25.0' });
+    const result = resolveInstalledPacks({
+      projectRoot: root,
+      config: makeConfig(['@mmnto/pack-legacy']),
+      packageJsonDeps: { '@mmnto/pack-legacy': '0.1.0' },
+    });
+    expect(result.warnings).toEqual([{ name: '@mmnto/pack-legacy', reason: 'not-a-pack' }]);
+    expect(result.resolved).toEqual([]);
+  });
+
+  it('reads engines[@mmnto/totem] verbatim into declaredEngineRange (preserves caret/tilde/etc.)', () => {
+    const root = makeTmpRoot();
+    writeFixturePack(root, '@mmnto/pack-tilde-range', { engineRange: '~1.25.0' });
+    const result = resolveInstalledPacks({
+      projectRoot: root,
+      config: makeConfig(['@mmnto/pack-tilde-range']),
+      packageJsonDeps: { '@mmnto/pack-tilde-range': '0.1.0' },
+    });
+    expect(result.resolved[0]?.declaredEngineRange).toBe('~1.25.0');
   });
 
   it('ignores non-pack dependencies (no @mmnto/pack- prefix)', () => {
@@ -145,8 +195,8 @@ describe('resolveInstalledPacks: union of deps + extends', () => {
 
   it('returns sorted output (alphabetical by pack name)', () => {
     const root = makeTmpRoot();
-    writeFixturePack(root, '@mmnto/pack-zulu', '^1.19.0');
-    writeFixturePack(root, '@mmnto/pack-alpha', '^1.19.0');
+    writeFixturePack(root, '@mmnto/pack-zulu', { engineRange: '^1.19.0' });
+    writeFixturePack(root, '@mmnto/pack-alpha', { engineRange: '^1.19.0' });
     const result = resolveInstalledPacks({
       projectRoot: root,
       config: makeConfig(['@mmnto/pack-zulu', '@mmnto/pack-alpha']),

--- a/packages/core/src/pack-manifest-writer.ts
+++ b/packages/core/src/pack-manifest-writer.ts
@@ -222,7 +222,7 @@ function readEngineRange(packResolvedPath: string): string | undefined {
     return undefined;
   }
   if (typeof parsed !== 'object' || parsed === null) return undefined;
-  const engines = (parsed as { engines?: unknown }).engines; // totem-context: parsed was narrowed via `typeof !== 'object' || === null` guard above; the cast is for index access into already-validated JSON
+  const engines = (parsed as { engines?: unknown }).engines; // totem-context: SAFETY INVARIANT — `parsed` confirmed non-null object by the `typeof !== 'object' || === null` guard immediately above. Cast is for index access into runtime-narrowed JSON; no formal schema validation, but `engines` is itself runtime-checked on the next line before use.
   if (typeof engines !== 'object' || engines === null) return undefined;
   const range = (engines as Record<string, unknown>)['@mmnto/totem']; // totem-context: engines was narrowed via `typeof !== 'object' || === null` guard above; the cast is for index access; result is runtime-checked via `typeof range === 'string'` below
   return typeof range === 'string' ? range : undefined;

--- a/packages/core/src/pack-manifest-writer.ts
+++ b/packages/core/src/pack-manifest-writer.ts
@@ -128,7 +128,7 @@ export function resolveInstalledPacks(input: ResolveInstalledPacksInput): PackRe
       continue;
     }
 
-    const declaredEngineRange = readPeerEngineRange(resolvedPath);
+    const declaredEngineRange = readEngineRange(resolvedPath);
     if (!declaredEngineRange) {
       warnings.push({ name, reason: 'not-a-pack' });
       continue;
@@ -204,7 +204,14 @@ function defaultResolvePackPath(name: string, fromDir: string): string | undefin
   }
 }
 
-function readPeerEngineRange(packResolvedPath: string): string | undefined {
+function readEngineRange(packResolvedPath: string): string | undefined {
+  // ADR-097 § Q6 (amended 2026-05-03 via mmnto-ai/totem#1803): pack engine
+  // version constraint lives in `engines['@mmnto/totem']`, NOT
+  // `peerDependencies`. The `peerDependencies` slot is reserved for actual
+  // peer packages the consumer must install (e.g., `@ast-grep/napi`).
+  // Rationale: changesets `fixed` group siblings cannot peer-dep one
+  // another (mmnto-ai/totem#1776 / #1777 wiggle); engines field is
+  // architecturally correct + immune to fixed-group auto-bump.
   const pkgPath = path.join(packResolvedPath, 'package.json');
   if (!fs.existsSync(pkgPath)) return undefined;
   let parsed: unknown;
@@ -215,8 +222,8 @@ function readPeerEngineRange(packResolvedPath: string): string | undefined {
     return undefined;
   }
   if (typeof parsed !== 'object' || parsed === null) return undefined;
-  const peer = (parsed as { peerDependencies?: unknown }).peerDependencies; // totem-context: parsed was narrowed via `typeof !== 'object' || === null` guard above; the cast is for index access into already-validated JSON
-  if (typeof peer !== 'object' || peer === null) return undefined;
-  const range = (peer as Record<string, unknown>)['@mmnto/totem']; // totem-context: peer was narrowed via `typeof !== 'object' || === null` guard above; the cast is for index access; result is runtime-checked via `typeof range === 'string'` below
+  const engines = (parsed as { engines?: unknown }).engines; // totem-context: parsed was narrowed via `typeof !== 'object' || === null` guard above; the cast is for index access into already-validated JSON
+  if (typeof engines !== 'object' || engines === null) return undefined;
+  const range = (engines as Record<string, unknown>)['@mmnto/totem']; // totem-context: engines was narrowed via `typeof !== 'object' || === null` guard above; the cast is for index access; result is runtime-checked via `typeof range === 'string'` below
   return typeof range === 'string' ? range : undefined;
 }

--- a/packages/pack-agent-security/package.json
+++ b/packages/pack-agent-security/package.json
@@ -27,6 +27,9 @@
     "build": "echo '[pack-agent-security] no build step (data-only pack)'",
     "test": "vitest run"
   },
+  "engines": {
+    "@mmnto/totem": "^1.25.0"
+  },
   "devDependencies": {
     "@mmnto/totem": "workspace:*",
     "vitest": "^3.0.0"

--- a/packages/pack-agent-security/test/structure.test.ts
+++ b/packages/pack-agent-security/test/structure.test.ts
@@ -68,4 +68,18 @@ describe('@mmnto/pack-agent-security structure', () => {
     const deps = pkg.dependencies ?? {};
     expect(Object.keys(deps)).toEqual([]);
   });
+
+  it('package.json engines declares @mmnto/totem with a non-empty semver range (ADR-097 § Q6)', () => {
+    const pkg = readJsonSafe<{ engines?: Record<string, string> }>(
+      path.join(PACK_ROOT, 'package.json'),
+    );
+    // ADR-097 § Q6 (amended 2026-05-03 via mmnto-ai/totem#1803): pack engine
+    // version constraint MUST live in `engines['@mmnto/totem']` for parity
+    // with public packs even though pack-agent-security is private. The
+    // resolver-vs-peer separation is consistent across the pack cohort.
+    expect(pkg.engines).toBeDefined();
+    const range = pkg.engines?.['@mmnto/totem'];
+    expect(typeof range).toBe('string');
+    expect(range).not.toBe('');
+  });
 });

--- a/packages/pack-rust-architecture/package.json
+++ b/packages/pack-rust-architecture/package.json
@@ -31,6 +31,9 @@
     "prepare": "node scripts/copy-wasm.cjs",
     "test": "vitest run"
   },
+  "engines": {
+    "@mmnto/totem": "^1.25.0"
+  },
   "peerDependencies": {
     "@ast-grep/napi": "^0.42.0"
   },

--- a/packages/pack-rust-architecture/test/structure.test.ts
+++ b/packages/pack-rust-architecture/test/structure.test.ts
@@ -84,13 +84,9 @@ describe('@mmnto/pack-rust-architecture structure', () => {
     // v0.1 side-channel registration in register.cjs (mmnto-ai/totem#1774).
     // No other runtime deps are admitted: peerDep covers @ast-grep/napi
     // (external); devDeps cover @mmnto/totem (workspace), @vscode/tree-sitter-wasm
-    // (build-time WASM source), and vitest. @mmnto/totem is intentionally NOT
-    // a peerDep — pack-rust-architecture lives in the changesets `fixed`
-    // group with @mmnto/totem (and the rest of the @mmnto/* cohort), so
-    // version harmony is guaranteed at publish time. Declaring
-    // @mmnto/totem as a peerDep AS WELL as a fixed-group member would create
-    // a circular constraint on every minor bump, pre-empting the cluster to
-    // a major bump (mmnto-ai/totem#1776 wiggle on PR #1775's first auto-cut).
+    // (build-time WASM source), and vitest. The @mmnto/totem engine version
+    // constraint lives in the `engines` field per ADR-097 § Q6 (amended
+    // 2026-05-03 via mmnto-ai/totem#1803) — see the engines invariant below.
     expect(Object.keys(deps).sort()).toEqual(['@ast-grep/lang-rust']);
   });
 
@@ -98,11 +94,35 @@ describe('@mmnto/pack-rust-architecture structure', () => {
     const pkg = readJsonSafe<{ peerDependencies?: Record<string, string> }>(
       path.join(PACK_ROOT, 'package.json'),
     );
-    // Exact-key equality: @mmnto/totem MUST NOT appear here (fixed-group
-    // member; see test above for rationale). Only the external napi engine
-    // is pinned via peerDep.
+    // Exact-key equality: @mmnto/totem MUST NOT appear here. The engine
+    // version constraint is declared via the `engines` field instead
+    // (mmnto-ai/totem#1803). Rationale: pack-rust-architecture lives in the
+    // changesets `fixed` group with @mmnto/totem and the rest of the
+    // @mmnto/* cohort; declaring @mmnto/totem as a peerDep on a fixed-group
+    // sibling creates a circular constraint on every minor bump that
+    // pre-empts the cluster to a major (#1776 wiggle on #1775's first
+    // auto-cut). The `engines` field is npm-canonical for engine-version
+    // constraints, isn't touched by changesets fixed-group auto-bump, and
+    // makes the resolver-vs-peer separation explicit. Only the external
+    // napi engine is pinned via peerDep.
     expect(Object.keys(pkg.peerDependencies ?? {}).sort()).toEqual(['@ast-grep/napi']);
     expect(pkg.peerDependencies?.['@ast-grep/napi']).toBe('^0.42.0');
+  });
+
+  it('package.json engines declares @mmnto/totem with a non-empty semver range (ADR-097 § Q6)', () => {
+    const pkg = readJsonSafe<{ engines?: Record<string, string> }>(
+      path.join(PACK_ROOT, 'package.json'),
+    );
+    // ADR-097 § Q6 (amended 2026-05-03 via mmnto-ai/totem#1803): pack engine
+    // version constraint MUST live in `engines['@mmnto/totem']`. The
+    // resolver (`pack-manifest-writer.ts:readEngineRange`) reads this field
+    // to populate `installed-packs.json#packs[].declaredEngineRange`; the
+    // boot path (`pack-discovery.ts:assertEngineRangeSatisfied`) cross-checks
+    // it against the running engine version via semver.satisfies.
+    expect(pkg.engines).toBeDefined();
+    const range = pkg.engines?.['@mmnto/totem'];
+    expect(typeof range).toBe('string');
+    expect(range).not.toBe('');
   });
 
   it('tree-sitter-rust.wasm is present and non-empty', () => {


### PR DESCRIPTION
## Summary

- Closes #1803. Moves pack engine-version cross-check from `peerDependencies['@mmnto/totem']` to `engines['@mmnto/totem']` per ADR-097 § Q6 amended decision (Option C, routed by strategy-Claude `2026-05-03T0145Z`).
- Resolves the structural collision with #1777: a fixed-group sibling pack cannot peer-dep `@mmnto/totem` without triggering a changesets MAJOR cascade (root cause of the 1.22.0 → 2.0.0 wiggle on #1776). The `engines` field is npm-canonical for engine-version constraints AND immune to changesets fixed-group auto-bump.
- Schema cascade: `@mmnto/pack-rust-architecture` and `@mmnto/pack-agent-security` declare `"engines": { "@mmnto/totem": "^1.25.0" }`. Cohort cuts as 1.26.0 under `Pack Ecosystem Graduation`.

## What changed

| File | Change |
| --- | --- |
| `packages/core/src/pack-manifest-writer.ts` | `readPeerEngineRange` → `readEngineRange`; reads `engines['@mmnto/totem']` instead of `peerDependencies['@mmnto/totem']`. |
| `packages/core/src/pack-discovery.ts` | Schema field comment, options doc, and `assertEngineRangeSatisfied` error message reference the `engines` field. Boot-time semver work unchanged in behavior. |
| `packages/cli/src/commands/sync.ts` | `not-a-pack` warning text rewords to point at the actual gap (missing `engines['@mmnto/totem']`) instead of the misleading "does not expose a registration callback" text from #1803's reproducer. |
| `packages/pack-rust-architecture/package.json` | Adds `engines['@mmnto/totem']`. peerDeps unchanged (locked at `@ast-grep/napi` only). |
| `packages/pack-agent-security/package.json` | Adds `engines['@mmnto/totem']` for cohort parity (private pack, but resolver-vs-peer separation should be uniform). |
| `packages/pack-rust-architecture/test/structure.test.ts` | New `engines` invariant; existing peerDeps comment updated to reference engines as the engine-constraint canonical location. |
| `packages/pack-agent-security/test/structure.test.ts` | Parity engines invariant. |
| `packages/core/src/pack-manifest-writer.test.ts` | Fixture builder accepts `engineRange` + `legacyPeerRange` options. Two new cases: legacy peerDeps-only pack still warns `not-a-pack` (no fallback); engines value preserved verbatim. |
| `packages/core/src/pack-discovery.test.ts` | Describe block renamed peerDependencies → engines. |
| `docs/active_work.md` | Threads #1803 into 1.26.0 Pack Ecosystem Graduation bullets. |

## Decision context (Option C vs A vs B)

Strategy-Claude routed three options after I surfaced the #1777 / claude-0011 invariant collision:

- **Option A (resolver-side special-casing for fixed-group siblings)** — REJECTED. Hidden coupling between core and changesets-specific config; consumers may use different release tools.
- **Option B (`*` peerDep + engines field)** — REJECTED. `*` peerDep is a code smell; asymmetry between internal and external packs; test invariant relaxes to encode the band-aid.
- **Option C (engines field replaces peerDep gate)** — ADOPTED. Architectural separation correct (`engines` is npm-canonical for engine-version constraints); symmetry across cohort; no `*`-as-sentinel; changesets-friendly; semver work happens at the right layer.

Full decision rationale in `.handoff/totem-claude/processed/2026-05-03T0145Z-strategy-claude.md` (totem-strategy repo).

## No graceful fallback

The migration is hard, not graceful. A pre-1.26.0 pack that declared the engine constraint via `peerDependencies['@mmnto/totem']` (no known external consumers exist; all `@mmnto/*` cohort packs are migrated in this PR) will warn `not-a-pack` until it republishes with `engines` declared. Justification: graceful fallback would create silent dual-reading paths the resolver's behavior depends on, defeating the point of the architectural split.

## Strategy-side follow-up

ADR-097 § Q6 prose at `mmnto-ai/totem-strategy/adr/adr-097-pack-language-archetype.md` still says `peerDependencies` — that update is for strategy-Claude's bundle (will land via the chore/docs-sync-routing branch's eventual strategy PR alongside the journal entry for this session).

## Test plan

- [x] `pnpm --filter '@mmnto/totem' test` (1762 / 1762 pass)
- [x] `pnpm --filter '@mmnto/cli' test` (1971 / 1971 pass)
- [x] `pnpm --filter '@mmnto/pack-rust-architecture' test` (19 / 19 pass)
- [x] `pnpm --filter '@mmnto/pack-agent-security' test` (58 / 58 pass)
- [x] `pnpm exec totem lint` PASS — 0 violations
- [x] `pnpm exec totem review` PASS — 0 findings (Gemini 3.1 Pro)
- [x] `pnpm exec totem verify-manifest` PASS — 458 rules, hashes match
- [x] Pre-push gate: 3945 tests pass, format + lint clean
- [ ] LC un-quarantine validation post-merge (1.26.0 publish + LC bump): 4-rule `.rs` cohort un-quarantines, `feat/heatmap-toggle-and-iter` (16 commits held) bumps + un-quarantines, lint passes against `.rs` files in `packages/zomboid-sim/**`. Closes Pack v0.1 alpha-pilot Leg 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)