### PR TITLE
fix(pack): bump engines floor to ^1.26.0 (GCA HIGH on #1808)

### DIFF
--- a/.changeset/1808-engines-constraint-bump.md
+++ b/.changeset/1808-engines-constraint-bump.md
@@ -1,0 +1,12 @@
+---
+'@mmnto/pack-rust-architecture': patch
+'@mmnto/pack-agent-security': patch
+---
+
+**Fix `engines['@mmnto/totem']` constraint floor — `^1.25.0` → `^1.26.0`.**
+
+GCA HIGH catch on the auto-generated Version Packages PR (#1808). The engines-field reader (`pack-manifest-writer.ts:readEngineRange`) ships in `@mmnto/totem@1.26.0`. Engines pre-1.26.0 read `peerDependencies['@mmnto/totem']` and would silently treat these packs as `not-a-pack` (the engines field is invisible to them). Declaring compatibility with `^1.25.0` was technically incorrect — a 1.25.0 engine cannot satisfy these packs even though caret-semver would let it match.
+
+Tightening the floor to `^1.26.0` makes the constraint match actual runtime compatibility. Fixed-group co-versioning makes this a documentation / safety-rail correction in practice (consumers pinned to a 1.26.x pack pull in the matching 1.26.x engine via the cohort), but the declared range should reflect reality.
+
+No code change. Constraint-only tightening.

--- a/packages/pack-agent-security/package.json
+++ b/packages/pack-agent-security/package.json
@@ -28,7 +28,7 @@
     "test": "vitest run"
   },
   "engines": {
-    "@mmnto/totem": "^1.25.0"
+    "@mmnto/totem": "^1.26.0"
   },
   "devDependencies": {
     "@mmnto/totem": "workspace:*",

--- a/packages/pack-rust-architecture/package.json
+++ b/packages/pack-rust-architecture/package.json
@@ -32,7 +32,7 @@
     "test": "vitest run"
   },
   "engines": {
-    "@mmnto/totem": "^1.25.0"
+    "@mmnto/totem": "^1.26.0"
   },
   "peerDependencies": {
     "@ast-grep/napi": "^0.42.0"


### PR DESCRIPTION
## Summary

GCA HIGH catch on the auto-generated Version Packages PR #1808. The `engines['@mmnto/totem']` floor declared at `^1.25.0` in #1807 was technically incorrect — the engines-field reader (`pack-manifest-writer.ts:readEngineRange`) ships in `@mmnto/totem@1.26.0`. Engines pre-1.26.0 read `peerDependencies` and silently treat these packs as `not-a-pack` (the `engines` field is invisible to them). Caret-semver let `1.25.0` engines match the constraint, but they cannot actually satisfy the pack.

This tightens the floor to `^1.26.0` so the constraint matches actual runtime compatibility. Fixed-group co-versioning makes this a documentation / safety-rail correction in practice (consumers pinned to a 1.26.x pack pull in the matching 1.26.x engine via the cohort), but the declared range should reflect reality.

## What changed

| File | Change |
| --- | --- |
| `packages/pack-rust-architecture/package.json` | `engines.@mmnto/totem`: `^1.25.0` → `^1.26.0` |
| `packages/pack-agent-security/package.json` | `engines.@mmnto/totem`: `^1.25.0` → `^1.26.0` |
| `.changeset/1808-engines-constraint-bump.md` | Patch changeset for both packs |

## Cohort impact

Patch-level changeset rides into the same 1.26.0 release cohort as #1807. VP PR #1808 will regenerate to include the corrected constraint when this lands on main. No version inflation — both packs were already going to 1.26.0 from #1807's minor bump; the patch just adds the engines correction to the same cycle.

## Cross-link

- Refs #1808 (auto-generated Version Packages PR; will regenerate after this lands)
- Originating finding: GCA HIGH on `packages/cli/CHANGELOG.md:17` and `packages/core/CHANGELOG.md:17` of #1808
- Substrate fix from #1807 (closes #1803) is unchanged — this is a constraint-floor correction layered on top.

## Test plan

- [x] `pnpm --filter '@mmnto/cli' test` (1971 / 1971 pass)
- [x] `pnpm --filter '@mmnto/totem' test` (1762 / 1762 pass)
- [x] `pnpm --filter '@mmnto/pack-rust-architecture' test` (19 / 19 pass — includes the engines invariant from #1807)
- [x] `pnpm --filter '@mmnto/pack-agent-security' test` (58 / 58 pass — same)
- [x] `pnpm exec totem lint` PASS — 0 violations
- [x] `pnpm exec totem review` PASS — non-code fast-path skip on JSON-only diff
- [x] Pre-push gate: 3945 tests, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)