### PR TITLE
fix(cli): activeManifestPath repo-relative (GCA HIGH on #1814)

### DIFF
--- a/.changeset/1814-active-manifest-path-repo-relative.md
+++ b/.changeset/1814-active-manifest-path-repo-relative.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/cli': patch
+---
+
+Compute Stage 4 manifest exclusion path against `repoRoot`, not `config.totemDir`.
+
+Follow-up to PR #1812 (closes #1796) catching GCA HIGH on the auto-VP PR #1814. The `activeManifestPath` exclusion key in `compile.ts` is compared against `git ls-files` output, which is repo-root-relative. Joining `config.totemDir` alone produced the wrong key when `cwd != configRoot != repoRoot` (monorepo subpackage invocation): the exclusion failed to match the repo-relative `git ls-files` line, so `compiled-rules.json` slipped into the Stage 4 scan corpus and self-matched against rules' own `badExample` text.
+
+Resolution: defer the `activeManifestPath` computation into the verifier closure (after `repoRoot` is resolved) and use `path.relative(repoRoot, path.join(totemDir, 'compiled-rules.json'))`. Mirrors the canonical pattern at `first-lint-promote-runner.ts:99`. Pre-existing tech debt tracked in MEMORY.md from claude-0014; PR #1796's surgical scope (lessons / rules / fixtures resolution) didn't touch it. GCA's review on the VP PR was the natural moment to close it.

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -671,11 +671,17 @@ export async function compileCommand(
   // (e.g. `.my-totem`) put their manifest at `<totemDir>/compiled-rules.json`,
   // which doesn't match the default — so we ALSO add the active manifest
   // path computed from config. CR mmnto-ai/totem#1766 R1 catch.
-  const activeManifestPath = path.join(config.totemDir, 'compiled-rules.json').replace(/\\/g, '/');
-  const stage4ManifestExclusionSet = new Set<string>([
-    ...STAGE4_MANIFEST_EXCLUSIONS,
-    activeManifestPath,
-  ]);
+  //
+  // mmnto-ai/totem#1814 (GCA HIGH on auto-VP PR for mmnto-ai/totem#1796): the
+  // comparison is against the manifest scan output (line 705), which is
+  // repo-root-relative. When `cwd != configRoot != repoRoot` (monorepo
+  // subpackage invocation), joining `config.totemDir` alone produces e.g.
+  // `.totem/compiled-rules.json` while the scan returns
+  // `packages/sub/.totem/compiled-rules.json`. Resolution: compute
+  // `activeManifestPath` lazily AFTER `repoRoot` is resolved, then use
+  // `path.relative(repoRoot, …)` so the exclusion key matches the
+  // repo-relative paths from the scan. Mirrors the canonical pattern at
+  // `first-lint-promote-runner.ts:99`.
   const buildStage4Verifier = () => {
     return async (rule: import('@mmnto/totem').CompiledRule) => {
       if (stage4RepoRootCache === undefined) {
@@ -691,6 +697,17 @@ export async function compileCommand(
       }
       const repoRoot = stage4RepoRootCache;
       if (stage4FilesCache === undefined) {
+        // Compute repo-relative manifest path now that `repoRoot` is
+        // resolved (mmnto-ai/totem#1814). The exclusion set is built
+        // once per compile run alongside `stage4FilesCache`; subsequent
+        // rule invocations reuse the cached file list.
+        const activeManifestPath = path
+          .relative(repoRoot, path.join(totemDir, COMPILED_RULES_FILE))
+          .replace(/\\/g, '/');
+        const stage4ManifestExclusionSet = new Set<string>([
+          ...STAGE4_MANIFEST_EXCLUSIONS,
+          activeManifestPath,
+        ]);
         // Single git invocation per compile run; reused across all rules
         // in the batch. `LC_ALL=C` keeps output stable across locales.
         // Fail-loud if git is unavailable — this gate is the ADR-091


### PR DESCRIPTION
## Summary

Follow-up to PR #1812 (closes #1796). GCA flagged HIGH on the auto-VP PR #1814:

> The path harmonization for `.totem/` resolution introduced in `c857383` (fixing #1796) contains a logic error regarding manifest exclusions for the Stage 4 verifier in `compile.ts`. While `totemDir` is correctly resolved against `configRoot`, the `activeManifestPath` (line 674 in `compile.ts`) is computed using `config.totemDir` directly. In monorepo setups where the config is in a subpackage but `.totem/` is at the root, this results in a path that does not match the repo-relative paths returned by the manifest scan. Consequently, the manifest is not excluded from the scan, leading to false-positive matches against the rules' own `badExample` text. This should be resolved relative to the `repoRoot`, mirroring the correct implementation found in `first-lint-promote-runner.ts:99`.

GCA's architectural finding is correct; their attribution is partially off — the `activeManifestPath:674` issue is **pre-existing tech debt**, not introduced by `c857383f`. Strategy memory from claude-0014 already had this filed as a tier-3 follow-up (the comment block on the equivalent fix in `first-lint-promote-runner.ts` from PR #1787 explicitly notes the same issue still existed in `compile.ts`). PR #1796's surgical scope (lessons / rules / fixtures resolution) didn't touch the Stage 4 manifest exclusion code path. GCA's review on the VP PR is the natural moment to close it.

## Resolution

`activeManifestPath` was previously computed eagerly at function entry, before `repoRoot` was known. Move the computation inside the `if (stage4FilesCache === undefined)` block in `buildStage4Verifier`, where `repoRoot` is already resolved. Use `path.relative(repoRoot, path.join(totemDir, COMPILED_RULES_FILE))` — exactly the canonical shape at `packages/cli/src/commands/first-lint-promote-runner.ts:99`.

`totemDir` (resolved at line 487 against `configRoot` via PR #1796) and `COMPILED_RULES_FILE` (module-level constant at line 13) are both in scope via closure capture from the enclosing `compileCommand` function.

## Changes

- `packages/cli/src/commands/compile.ts` — moved the exclusion-set construction into the Stage 4 verifier closure with `path.relative(repoRoot, ...)` resolution.
- `.changeset/1814-active-manifest-path-repo-relative.md` — patch bump.

## Test plan

- [x] `pnpm --filter @mmnto/cli test` — 1973/1973 pass (no regression; existing compile tests exercise the closure path).
- [x] `pnpm exec totem lint` — 0 violations.
- [x] `pnpm exec totem review` — one false-positive CRITICAL on outer-scope vars (`totemDir` line 487 + `COMPILED_RULES_FILE` line 13 ARE in scope via closure capture); overridden with empirical evidence per the project's `--override` escape valve. The reviewer LLM lacked outer-scope context in its diff window.
- [x] `pnpm -w exec tsc --noEmit -p packages/cli/tsconfig.json` — clean (would have caught the alleged ReferenceError).
- [x] Pre-push hook lint — passed (1 warning on changeset prose; no errors).

## After merge

VP PR #1814 will auto-regenerate to include this fix in the 1.26.1 cohort bump. Then it can merge clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)