### PR TITLE
feat(sync): Phase A / Phase B architectural separation (ADR-101)

### DIFF
--- a/.changeset/sync-architectural-separation-1811.md
+++ b/.changeset/sync-architectural-separation-1811.md
@@ -1,0 +1,34 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+'@mmnto/mcp': minor
+'@mmnto/pack-agent-security': minor
+'@mmnto/pack-rust-architecture': minor
+---
+
+`totem sync` Phase A / Phase B architectural separation (mmnto-ai/totem#1811, ADR-101).
+
+`totem sync` decomposes into two independently-runnable phases:
+
+- **Phase A** — deterministic pack-resolution + `installed-packs.json` write (no API key required, runs in CI).
+- **Phase B** — vector-store embedding sync (still requires the embedding key; unchanged).
+
+New mutually-exclusive flags on `totem sync`:
+
+- `--packs-only` (Lite tier): write the pack manifest only; skip embedding sync, prune, the global registry update, and the `review-extensions.txt` write. Designed for CI environments without API keys after a `@mmnto/totem` cohort bump where pack-resolution alone needs to run before `totem lint` recognizes newly registered Tree-sitter languages.
+- `--index-only` (Standard tier): run only the embedding sync; skip pack-resolution. Use when `installed-packs.json` is already current and only the vector store needs to re-embed.
+
+Both flags hard-error when combined with each other or with `--full` / `--prune`.
+
+The CLI orchestrator now writes `installed-packs.json` BEFORE invoking `runSync` so `--packs-only` can short-circuit cleanly. The default flag-less behavior is observably equivalent to prior releases.
+
+UX nudge for stale manifests: when a rule expects a Tree-sitter language that isn't registered, the rule-engine now consults `installed-packs.json`'s cohort field and surfaces a structured `STALE_MANIFEST` `TotemError` pointing at `totem sync --packs-only` whenever the manifest is missing, pre-1.27.0, or written by an engine whose `major.minor` differs from the running version. Patch-level cohort drift passes (caret-range pack semver tolerance). Cohort-match falls through to the original "install the pack" `TotemParseError`.
+
+Schema: `InstalledPacksManifestSchema` gains an optional `cohort: string` field (semver). Pre-1.27.0 manifests without the field continue to parse cleanly. Stamped at write time by `writeInstalledPacksManifest()` from `resolveEngineVersion()`; tests can pre-populate the field to override the stamp.
+
+New public surfaces (additive):
+
+- `resolveEngineVersion(): string`
+- `detectStaleManifest(opts): StaleManifestDetection | null`
+- `staleManifestError(detection, context): TotemError`
+- `TotemErrorCode` adds `'STALE_MANIFEST'` and `'FLAG_CONFLICT'`.

--- a/.changeset/sync-architectural-separation-1811.md
+++ b/.changeset/sync-architectural-separation-1811.md
@@ -18,7 +18,7 @@ New mutually-exclusive flags on `totem sync`:
 - `--packs-only` (Lite tier): write the pack manifest only; skip embedding sync, prune, the global registry update, and the `review-extensions.txt` write. Designed for CI environments without API keys after a `@mmnto/totem` cohort bump where pack-resolution alone needs to run before `totem lint` recognizes newly registered Tree-sitter languages.
 - `--index-only` (Standard tier): run only the embedding sync; skip pack-resolution. Use when `installed-packs.json` is already current and only the vector store needs to re-embed.
 
-Both flags hard-error when combined with each other or with `--full` / `--prune`.
+`--packs-only` hard-errors when combined with `--index-only`, `--full`, or `--prune` — Phase B is skipped under `--packs-only`, so those flags would silently no-op. `--index-only` composes with `--full` and `--prune` since all three modify Phase B.
 
 The CLI orchestrator now writes `installed-packs.json` BEFORE invoking `runSync` so `--packs-only` can short-circuit cleanly. The default flag-less behavior is observably equivalent to prior releases.
 

--- a/.totem/specs/1811.md
+++ b/.totem/specs/1811.md
@@ -1,0 +1,207 @@
+### Problem Statement
+
+The `totem sync` command currently couples deterministic pack-resolution with LLM-dependent vector-store embedding, causing CI environments without API keys to fail when trying to update their pack manifest (`installed-packs.json`) after a cohort version bump. This operational impossibility prevents `totem lint` from recognizing newly registered Tree-sitter languages, requiring an architectural separation of the two sync phases so pack-resolution can be run independently.
+
+### Architectural Context
+
+- **Architecture > Configuration Tiers**: Totem auto-detects capability tiers from the environment. Bundling embedding (Tier 2/3) with pack resolution (Tier 1) violates tier boundaries because baseline environments (like CI) are blocked from performing deterministic manifest updates.
+- **1.26.0 — Pack Ecosystem Graduation**: This fix is critical for "deterministic-substrate hardening", ensuring rule classes encoded via packs are independently verifiable without LLM access.
+
+### Files to Examine
+
+1. `packages/core/src/sync.ts` (or `packages/core/src/sync/index.ts`) — Contains the `runSync` orchestrator where the two concerns are currently coupled.
+2. `packages/cli/src/commands/sync.ts` — CLI entry point where flags need to be added.
+3. `packages/core/src/pack-discovery.ts` — Defines the manifest schema and loads the packs; requires a new schema field to track the cohort version.
+4. `packages/core/src/pack-manifest-writer.ts` — Writes the manifest; must be updated to stamp the current running cohort version.
+5. `packages/core/src/rule-engine.ts` (or equivalent parser error handler) — Where the `TotemParseError` originates and needs to be intercepted for the UX nudge.
+
+### Technical Approach & Contracts
+
+We will decouple the sync concerns via **Option 5 (Shape A)**, introducing mutually exclusive `--packs-only` and `--index-only` flags, layered with **Option 1 (CLI Nudge)** to catch the stale-manifest error.
+
+**Trade-offs (Shape A vs Shape B):**
+
+- _Shape A (`totem sync --packs-only`)_: Minimizes CLI router changes, extends an existing command cleanly, and maps 1:1 with `runSync` options. Keeps the CLI surface area small.
+- _Shape B (`totem packs sync`)_: True noun-verb CLI architecture, segregating concerns at the router level, but requires scaffolding a new top-level `packs` command root and deprecating parts of `sync`.
+- **Recommendation:** Proceed with **Shape A**. It solves the CI operational impossibility immediately with minimal regression risk while maintaining composite behavior by default.
+
+**Data Contracts:**
+The `installed-packs.json` schema must be updated to track the Totem version that generated it.
+
+```typescript
+// packages/core/src/pack-discovery.ts
+export const InstalledPacksSchema = z.object({
+  cohort: z.string().optional(), // NEW: Tracks the @mmnto/totem version used during generation
+  packs: z.array(PackSchema),
+});
+```
+
+**Sequence Logic:**
+
+1. `pack-manifest-writer.ts` stamps the executing Totem version into the manifest's `cohort` field.
+2. `runSync` intercepts `packsOnly` to completely bypass embedding client initialization.
+3. If `totem lint` encounters `TotemParseError: no Tree-sitter language is registered`, it uses `readJsonSafe` to check `.totem/installed-packs.json`. If the `cohort` is missing or mismatched against the running version, it throws a structured diagnostic suggesting `totem sync --packs-only`.
+
+### Edge Cases & Traps
+
+- **Eager Embedding Client Initialization:** If `runSync` or its dependencies initialize the embedding client or validate API keys at module-load or at the very top of the function, the `--packs-only` flag will still fail in CI. The embedding instantiation _must_ be strictly deferred inside an `if (!options.packsOnly)` block.
+- **Missing vs Stale Manifest:** In a fresh CI clone that restored `node_modules` but not `.totem/installed-packs.json`, the manifest won't just be stale—it won't exist. The error handler must gracefully catch the `ENOENT` from `readJsonSafe` and emit the same CLI nudge rather than crashing with a raw filesystem error.
+- **Mutually Exclusive Flags:** Passing both `--packs-only` and `--index-only` is nonsensical and must hard-fail early in the CLI layer.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Update Manifest Schema and Writer**
+  - Modify `packages/core/src/pack-discovery.ts` to add `cohort: z.string().optional()` to the manifest schema.
+  - Modify `packages/core/src/pack-manifest-writer.ts` to inject the current `@mmnto/totem` package version into the `cohort` field when saving `installed-packs.json`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `writes cohort version to installed-packs.json` that proves the cohort field is saved.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Decouple Core Sync Logic (`runSync`)**
+  - Modify `packages/core/src/sync.ts` (or the equivalent orchestrator).
+  - Add `packsOnly?: boolean` and `indexOnly?: boolean` to the `runSync` options interface. Throw an error if both are true.
+  - Wrap the pack manifest resolution step in `if (!options.indexOnly)`.
+    > TOTEM INVARIANT (Architecture > Configuration Tiers): Commands must respect capability tiers auto-detected from the environment. `totem sync --packs-only` must function in the baseline tier without requiring LLM/embedding API keys.
+  - Wrap the vector-store embedding logic—**including the client initialization**—in `if (!options.packsOnly)`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `runSync bypasses embedding client initialization when packsOnly is true` that proves no API key or LLM capability is evaluated.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Wire CLI Flags**
+  - Modify `packages/cli/src/commands/sync.ts`.
+  - Add `--packs-only` and `--index-only` boolean flags to the Commander definition.
+  - Pass the mapped flags into the `runSync` call.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `syncCommand routes packs-only and index-only flags to runSync` that proves the CLI boundary maps the options correctly.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Implement the UX Nudge Diagnostic**
+  - Modify `packages/core/src/rule-engine.ts` (or the parser module throwing the error).
+  - Catch `TotemParseError` instances where the message includes `"no Tree-sitter language is registered"`.
+  - Use `readJsonSafe` from `@mmnto/totem` shared helpers to read `.totem/installed-packs.json`. Catch missing file errors.
+  - If the manifest is missing, or if `manifest.cohort !== currentTotemVersion`, throw a new structured error: `[Totem Error] No language registered for '[ext]' but installed-packs.json is stale... Fix: run \`pnpm exec totem sync --packs-only\` to re-resolve the manifest, then retry.`
+  - If the cohort matches perfectly, rethrow the original error (the user simply lacks the pack).
+    > TEST DIRECTIVE: Before implementing, write a failing test named `emits structured stale manifest diagnostic when Tree-sitter registration fails and cohort mismatches` that proves the raw error is intercepted and transformed correctly.
+  - write test → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Primary CLI Independence Test:** Execute `totem sync --packs-only` in a test shell with `ANTHROPIC_API_KEY` and all other embedding keys explicitly unset. Assert exit code `0` and verify `installed-packs.json` is updated with the `cohort` field.
+- **Mutex Test:** Execute `totem sync --packs-only --index-only`. Assert exit code `1` and validation error.
+- **Diagnostic Nudge Test:** Scaffold a mock project with a `package.json` specifying an old `@mmnto/totem` version, but execute the current version's `totem lint` against a `.rs` file. Assert the error thrown is the structured UX nudge advising `--packs-only`, not the raw Tree-sitter error.
+- **Genuine Missing Pack Test:** Run `totem lint` on an `.unknown` extension with an up-to-date manifest cohort. Assert the raw Tree-sitter error is thrown, proving the diagnostic doesn't mask legitimate missing-pack errors.
+
+---
+
+## Implementation Design
+
+> Drafted 2026-05-04 (claude-0022) from `mmnto-ai/totem#1811` per `mmnto-ai/totem-strategy:.handoff/totem-claude/inbox/2026-05-03T2200Z`. Substrate for `mmnto-ai/totem-strategy:adr/adr-101-totem-sync-architectural-separation.md` (slot **101** — ADR-100 is now `adr-100-substrate-repo-extraction.md` per strategy-Claude relay 2026-05-04).
+
+### Scope (2 sentences)
+
+Split `totem sync` into two independently-runnable phases — **Phase A** (pack-resolution + manifest write, deterministic, no API keys) and **Phase B** (vector-store embedding sync, requires API keys) — exposed via mutually-exclusive `--packs-only` / `--index-only` flags on the existing `totem sync` command (Shape A, not Shape B). Will **NOT** rename or split into a new `totem packs sync` top-level command, will **NOT** change `runSync`'s purely Phase B responsibilities, will **NOT** reuse the cohort field for pack ABI compatibility (that's already covered by ADR-097 § Q6 `engines['@mmnto/totem']` per-pack range).
+
+### Architectural insight (corrects spec framing)
+
+The spec describes wrapping `runSync`'s "pack manifest resolution step" in `if (!options.indexOnly)`. **Empirically, pack-resolution is NOT inside `runSync`** — it's already at the CLI layer in `packages/cli/src/commands/sync.ts:97-123`, called AFTER `runSync` but independent of it. `runSync` itself lives in `packages/core/src/ingest/pipeline.ts` and is purely Phase B (file walk + embedding loop). The split therefore lands cleanly at the CLI orchestrator, not inside `runSync`. This is **Option B** in the OQ1 below.
+
+### Data model deltas
+
+**One new optional field on `InstalledPacksManifestSchema`** (in `packages/core/src/pack-discovery.ts:62`):
+
+| Field    | Type                             | Holds                                                  | Writer                                                                                                      | Reader                                                                | Invariant                                                                                                                                                                                                |
+| -------- | -------------------------------- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cohort` | `z.string().optional()` (semver) | `@mmnto/totem` package version that wrote the manifest | `pack-manifest-writer.ts:writeInstalledPacksManifest` (stamped at write time from `resolveEngineVersion()`) | The new stale-manifest UX nudge in `rule-engine.ts` parser-error path | Optional for forward-compat with pre-1.27.0 manifests; when present, must be a semver-valid string. Manifest schema stays at `version: 1` (no breaking change because the field is additive + optional). |
+
+**No new types, no new state containers, no new module-level variables.** The cohort is read transactionally during the UX-nudge fast-path; not cached.
+
+**Reserved-key check:** `cohort` doesn't collide with `version` (schema sentinel) or `packs` (the pack list). The `.strict()` schema means readers will accept the new optional field; pre-1.27.0 readers seeing a manifest with `cohort` would FAIL strict validation — but since older totem versions can't read newer manifests anyway (ADR-097 § Q6 engine-range cross-check fires first on per-pack mismatches), this is academic.
+
+### State lifecycle
+
+The cohort field is **persistent state** (lives on disk in `.totem/installed-packs.json`).
+
+| Lifecycle phase | What happens                                                                                                                                                                                                                  |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Created         | When `totem sync` (with or without `--packs-only`) writes the manifest. Stamped with the running `@mmnto/totem` version via `resolveEngineVersion()` (already exists in `pack-discovery.ts:415` — reuse, don't re-implement). |
+| Mutated         | Re-written on every subsequent `totem sync` invocation. Atomic via temp + rename (existing `writeInstalledPacksManifest` semantics).                                                                                          |
+| Read            | Lazily, on the parser-error-intercept fast-path in `rule-engine.ts` when a Tree-sitter language miss happens. Not read at boot (boot uses the per-pack `declaredEngineRange` cross-check, which is independent).              |
+| Cleared         | Never. The field disappears only if the user manually deletes the manifest, at which point `loadInstalledPacks` ENOENT-paths to "no packs" and the UX nudge can detect the missing manifest.                                  |
+
+**No state crosses lifecycle boundaries** — the cohort is per-manifest, written at sync time, read at lint time, no in-memory carry.
+
+### Failure modes
+
+| Failure                                                                                                 | Category                               | Agent-facing surface                                                                                             | Recovery                                                                                                                            |
+| ------------------------------------------------------------------------------------------------------- | -------------------------------------- | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `--packs-only` + `--index-only` both set                                                                | init (CLI flag validation)             | `TotemError('FLAG_CONFLICT', ...)` hard error at command entry, exit code 1                                      | Re-run with one flag                                                                                                                |
+| `--packs-only` invoked but `requireEmbedding(config)` was already called                                | init (regression — eager init)         | `TotemConfigError` from `GeminiEmbedder` constructor (existing) — undermines fix                                 | The fix MUST move `requireEmbedding` inside the `if (!packsOnly)` branch. Test asserts no embedder construction when `--packs-only` |
+| `--packs-only` + `--full` both set                                                                      | init (CLI flag validation)             | Open question (OQ4) — recommend: hard error symmetrically with `--packs-only --index-only`                       | Re-run without `--full`                                                                                                             |
+| `--packs-only` + `--prune` both set                                                                     | init (CLI flag validation)             | Open question (OQ5) — recommend: hard error (prune is index-side)                                                | Re-run without `--prune`                                                                                                            |
+| Tree-sitter language miss during lint, manifest missing                                                 | runtime (lint-time)                    | New `TotemError('STALE_MANIFEST', ...)` with structured nudge: "run `totem sync --packs-only`"                   | User runs the suggested command                                                                                                     |
+| Tree-sitter language miss during lint, manifest present, cohort missing or differs from running version | runtime (lint-time)                    | Same `TotemError('STALE_MANIFEST', ...)` nudge                                                                   | User runs the suggested command                                                                                                     |
+| Tree-sitter language miss during lint, cohort matches running version                                   | runtime (lint-time)                    | Original `TotemParseError` re-thrown unchanged (genuine missing pack — user lacks the right `@mmnto/pack-*` dep) | User installs the pack via `pnpm add -D @mmnto/pack-<lang>-architecture`                                                            |
+| Manifest cohort field is malformed (not a semver string)                                                | runtime (lint-time, schema validation) | Treat as missing (defensive fallback) — emit STALE_MANIFEST nudge                                                | User runs `totem sync --packs-only` to regenerate                                                                                   |
+| Pack-resolution succeeds, embedder client init fails on subsequent `totem sync` (no `--packs-only`)     | runtime (Phase B)                      | Existing `TotemConfigError` from embedder (unchanged)                                                            | User configures API keys, OR uses `--packs-only` if they only need pack-manifest refresh                                            |
+
+**No silent-degradation rows.** Every failure surfaces a hard error or a structured nudge. Tenet 4 (Fail Loud) preserved.
+
+### Invariants to lock in via tests
+
+1. **`--packs-only` does not construct any embedder, ever.** Asserted by spying `requireEmbedding` and any embedder constructor (`GeminiEmbedder`, `OpenAIEmbedder`, etc.) — call count must be 0 when the flag is set. This is the load-bearing CI-unblock guarantee.
+2. **`--packs-only` and `--index-only` are mutually exclusive at the CLI layer.** Hard error before any sync logic runs; covers `--full` and `--prune` co-flag conflicts symmetrically (per OQ4 + OQ5 dispositions).
+3. **Manifest cohort is stamped on every successful pack-manifest write.** Asserted by reading the written JSON post-`syncCommand` and confirming `cohort === resolveEngineVersion()`.
+4. **Forward-compatibility:** an old manifest without `cohort` parses cleanly under the new schema. Asserted by feeding a pre-1.27.0 fixture manifest into `InstalledPacksManifestSchema.safeParse` and confirming success.
+5. **UX nudge fires only on the cohort-mismatch path; cohort-match passes through to the original Tree-sitter error.** Asserted by two parallel test cases with identical setups except for the cohort value.
+6. **Default `totem sync` (no flags) behavior is byte-identical to today** — no regression in the existing happy path. Asserted by comparing the manifest written by today's `totem sync` against the manifest written by tomorrow's flag-less `totem sync`.
+
+### Open questions
+
+- **OQ1: Where does the Phase A / Phase B split live — inside `runSync` (spec's framing) or at the CLI layer (empirical)?**
+  - _Options:_
+    - **(A) Spec's path:** add `packsOnly?: boolean` / `indexOnly?: boolean` to `runSync`'s options; move pack-resolution INTO `runSync`. Pro: single orchestration point. Con: forces `runSync` to learn about pack-resolution (it currently doesn't); larger blast radius; requires moving code from `cli/sync.ts` into `core/ingest/pipeline.ts`.
+    - **(B) CLI-layer split:** add the flags only at the CLI layer (`commands/sync.ts`); `runSync`'s API doesn't change. Skip the `runSync` call when `--packs-only`; skip `resolveInstalledPacks` + `writeInstalledPacksManifest` when `--index-only`. Pro: minimal blast radius, pack-resolution stays at CLI where it already lives, `runSync` keeps its single responsibility. Con: CLI command is the only orchestration point; programmatic consumers (MCP, scripts) calling `runSync` directly don't get the split.
+  - _Recommendation:_ **(B)**. Programmatic consumers calling `runSync` are already calling Phase B only; they don't need a split. The CLI is the orchestrator. This is also the smaller change — Phase B (`runSync`) is left alone, and the `installed-packs.json` write happens BEFORE `runSync` (today it happens after; we'll move it to before so `--packs-only` can short-circuit cleanly). This re-ordering is part of the design.
+
+- **OQ2: Cohort match comparison — exact, semver-minor, or semver-major?**
+  - _Options:_
+    - **(A) Exact** (spec's literal framing — `manifest.cohort !== currentTotemVersion`): catches every mismatch including patch bumps. Spurious nudge on `1.26.1 → 1.26.2` even when no packs changed.
+    - **(B) Semver minor** (`semver.minor(manifest.cohort) !== semver.minor(currentTotemVersion)` OR major diff): tolerates patch drift. Aligns with caret-range semantics packs use.
+    - **(C) Semver major** (`semver.major(...)` only): tolerates minor drift. Possibly too lax — some 1.x → 1.y bumps DO change pack ABI in practice (e.g., 1.22.0 → 1.23.0 broke `peerDependencies` semantics per `mmnto-ai/totem#1776`).
+  - _Recommendation:_ **(B) semver minor.** Aligns with caret-range packs. Patch bumps don't trigger nudges, minor/major bumps do. Implementation: `semver.major(a) !== semver.major(b) || semver.minor(a) !== semver.minor(b)`.
+
+- **OQ3: Re-ordering Phase A / Phase B — write manifest BEFORE `runSync`?**
+  - _Context:_ Today's CLI runs Phase B (`runSync`) FIRST, then Phase A (manifest write). For `--packs-only` to work cleanly without invoking embedding, manifest write needs to happen BEFORE the embedding-gated `runSync`. This is a re-order, not a content change.
+  - _Tradeoff:_ The today-order means `runSync` operates against the OLD manifest's pack registrations (loaded at boot), and the NEW manifest is written for next time. Re-ordering means `runSync` STILL operates against the OLD manifest (boot already happened) — re-ordering doesn't change runSync's effective registrations. So the re-order is observably equivalent for the default case but enables clean `--packs-only` short-circuit.
+  - _Recommendation:_ Yes, re-order. Manifest write moves to BEFORE `runSync`. Default behavior is byte-equivalent; `--packs-only` exits cleanly after Phase A.
+
+- **OQ4: `--packs-only` mutex with `--full`?**
+  - _Recommendation:_ Yes. `--full` is "rebuild the index from scratch," which is purely Phase B. `--packs-only --full` is nonsensical; hard error symmetrically with `--packs-only --index-only`.
+
+- **OQ5: `--packs-only` mutex with `--prune`?**
+  - _Recommendation:_ Yes. `--prune` is lesson-drift detection against the index, also purely Phase B. Same hard-error treatment.
+
+- **OQ6: Capability tier reclassification.**
+  - _Context:_ `docs/architecture.md` currently lists `sync` in the **Standard** tier (requires embedding key). After this change, `sync --packs-only` belongs in **Lite** (no API key required); `sync` (no flag) and `sync --index-only` stay in Standard.
+  - _Recommendation:_ Update the tier table to reflect: `sync --packs-only` in Lite, `sync` / `sync --index-only` in Standard. This is part of the same PR (docs co-located with code change). Matches the **Configuration Tiers** invariant referenced in the spec's TEST DIRECTIVE (Task 2).
+
+- **OQ7: ADR-101 timing — draft now (alongside this PR) or after the implementation lands?**
+  - _Context:_ Strategy-Claude's `2026-05-03T2200Z` handoff sequenced ADR draft FIRST, then implementation children. This Implementation Design section IS most of the architectural material; transcribing into ADR-101 is mostly mechanical now.
+  - _Recommendation:_ Draft ADR-101 in parallel (after this Implementation Design is approved). The ADR is the cross-repo durable record; this implementation design is the in-spec working artifact. Both can land before code.

--- a/.totem/specs/1811.md
+++ b/.totem/specs/1811.md
@@ -39,7 +39,7 @@ export const InstalledPacksSchema = z.object({
 **Sequence Logic:**
 
 1. `pack-manifest-writer.ts` stamps the executing Totem version into the manifest's `cohort` field.
-2. `runSync` intercepts `packsOnly` to completely bypass embedding client initialization.
+2. `runSync` intercepts `packsOnly` to bypass embedding client initialization end-to-end.
 3. If `totem lint` encounters `TotemParseError: no Tree-sitter language is registered`, it uses `readJsonSafe` to check `.totem/installed-packs.json`. If the `cohort` is missing or mismatched against the running version, it throws a structured diagnostic suggesting `totem sync --packs-only`.
 
 ### Edge Cases & Traps
@@ -77,7 +77,7 @@ export const InstalledPacksSchema = z.object({
   - Catch `TotemParseError` instances where the message includes `"no Tree-sitter language is registered"`.
   - Use `readJsonSafe` from `@mmnto/totem` shared helpers to read `.totem/installed-packs.json`. Catch missing file errors.
   - If the manifest is missing, or if `manifest.cohort !== currentTotemVersion`, throw a new structured error: `[Totem Error] No language registered for '[ext]' but installed-packs.json is stale... Fix: run \`pnpm exec totem sync --packs-only\` to re-resolve the manifest, then retry.`
-  - If the cohort matches perfectly, rethrow the original error (the user simply lacks the pack).
+  - If the cohort matches at major.minor, rethrow the original error (the user simply lacks the pack).
     > TEST DIRECTIVE: Before implementing, write a failing test named `emits structured stale manifest diagnostic when Tree-sitter registration fails and cohort mismatches` that proves the raw error is intercepted and transformed correctly.
   - write test → verify fails → implement → verify passes → lint
 
@@ -165,7 +165,7 @@ The cohort field is **persistent state** (lives on disk in `.totem/installed-pac
 
 ### Invariants to lock in via tests
 
-1. **`--packs-only` does not construct any embedder, ever.** Asserted by spying `requireEmbedding` and any embedder constructor (`GeminiEmbedder`, `OpenAIEmbedder`, etc.) — call count must be 0 when the flag is set. This is the load-bearing CI-unblock guarantee.
+1. **`--packs-only` does not construct any embedder.** Asserted by spying `requireEmbedding` and any embedder constructor (`GeminiEmbedder`, `OpenAIEmbedder`, etc.) — call count must be 0 when the flag is set. This is the load-bearing CI-unblock invariant.
 2. **`--packs-only` and `--index-only` are mutually exclusive at the CLI layer.** Hard error before any sync logic runs; covers `--full` and `--prune` co-flag conflicts symmetrically (per OQ4 + OQ5 dispositions).
 3. **Manifest cohort is stamped on every successful pack-manifest write.** Asserted by reading the written JSON post-`syncCommand` and confirming `cohort === resolveEngineVersion()`.
 4. **Forward-compatibility:** an old manifest without `cohort` parses cleanly under the new schema. Asserted by feeding a pre-1.27.0 fixture manifest into `InstalledPacksManifestSchema.safeParse` and confirming success.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -185,13 +185,15 @@ A stdio-based server for LLM integration providing primary tools and strict acce
 
 Totem supports three explicit capability tiers, auto-detected from the environment during `totem init`. The available command list is audited to prune stale tasks and preserve a streamlined interface:
 
-| Tier         | Requirements                               | Available Commands                                                                                                                |
-| ------------ | ------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
-| **Lite**     | Zero API keys                              | `init`, `hooks`, `add-lesson`, `link`, `install`, `rule promote`, `eject`, `lint`, `compile`, `test`, `explain`, `handoff --lite` |
-| **Standard** | Embedding key (`OPENAI_API_KEY` or Ollama) | Lite + `sync`, `search`, `stats`, `doctor`                                                                                        |
-| **Full**     | Embedding + Orchestrator                   | All commands (`spec`, `review`, `triage`, `handoff`, `extract`, `docs`, `proposal new`, `adr new`)                                |
+| Tier         | Requirements                               | Available Commands                                                                                                                                     |
+| ------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Lite**     | Zero API keys                              | `init`, `hooks`, `add-lesson`, `link`, `install`, `rule promote`, `eject`, `lint`, `compile`, `test`, `explain`, `handoff --lite`, `sync --packs-only` |
+| **Standard** | Embedding key (`OPENAI_API_KEY` or Ollama) | Lite + `sync`, `sync --index-only`, `search`, `stats`, `doctor`                                                                                        |
+| **Full**     | Embedding + Orchestrator                   | All commands (`spec`, `review`, `triage`, `handoff`, `extract`, `docs`, `proposal new`, `adr new`)                                                     |
 
 A lite-tier standalone WASM binary provides core CLI functions with zero native dependencies. The embedding field in configuration files is optional; when omitted, operations default to the Lite tier boundary constraints.
+
+`totem sync` decomposes into two phases (mmnto-ai/totem#1811, ADR-101): Phase A — pack manifest write — is deterministic and tier-Lite (`sync --packs-only`); Phase B — vector-store embedding — keeps `sync` and `sync --index-only` in Standard. The split unblocks CI environments without API keys after a `@mmnto/totem` cohort bump, where pack-resolution alone needs to run before `totem lint` recognizes newly registered Tree-sitter languages.
 
 ## Orchestrator Providers
 

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -16,20 +16,28 @@ vi.mock('../ui.js', () => ({
 const mockLoadConfig = vi.fn();
 const mockResolveConfigPath = vi.fn();
 const mockIsGlobalConfigPath = vi.fn();
+const mockRequireEmbedding = vi.fn();
 vi.mock('../utils.js', () => ({
   resolveConfigPath: (...args: unknown[]) => mockResolveConfigPath(...args),
   isGlobalConfigPath: (...args: unknown[]) => mockIsGlobalConfigPath(...args),
   loadEnv: vi.fn(),
   loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
-  requireEmbedding: vi.fn(),
+  requireEmbedding: (...args: unknown[]) => mockRequireEmbedding(...args),
   sanitize: (s: string) => s,
 }));
 
 const mockUpdateRegistryEntry = vi.fn().mockResolvedValue(undefined);
+const mockRunSync = vi
+  .fn()
+  .mockResolvedValue({ chunksProcessed: 10, filesProcessed: 3, totalChunks: 42 });
+const mockResolveInstalledPacks = vi.fn().mockReturnValue({ resolved: [], warnings: [] });
+const mockWriteInstalledPacksManifest = vi.fn();
 
 vi.mock('@mmnto/totem', () => ({
-  runSync: vi.fn().mockResolvedValue({ chunksProcessed: 10, filesProcessed: 3, totalChunks: 42 }),
+  runSync: (...args: unknown[]) => mockRunSync(...args),
   updateRegistryEntry: (...args: unknown[]) => mockUpdateRegistryEntry(...args),
+  resolveInstalledPacks: (...args: unknown[]) => mockResolveInstalledPacks(...args),
+  writeInstalledPacksManifest: (...args: unknown[]) => mockWriteInstalledPacksManifest(...args),
   TotemError: class TotemError extends Error {
     constructor(
       public code: string,
@@ -67,6 +75,12 @@ describe('syncCommand', () => {
     mockLoadConfig.mockResolvedValue(baseConfig());
     mockResolveConfigPath.mockReset();
     mockIsGlobalConfigPath.mockReset();
+    mockRequireEmbedding.mockReset();
+    mockRunSync.mockReset();
+    mockRunSync.mockResolvedValue({ chunksProcessed: 10, filesProcessed: 3, totalChunks: 42 });
+    mockResolveInstalledPacks.mockReset();
+    mockResolveInstalledPacks.mockReturnValue({ resolved: [], warnings: [] });
+    mockWriteInstalledPacksManifest.mockReset();
     // Default: config lives next to wherever the user invoked totem from.
     // Individual tests override to exercise cwd !== configRoot scenarios.
     mockResolveConfigPath.mockImplementation((cwd: unknown) =>
@@ -183,6 +197,76 @@ describe('syncCommand', () => {
     const canonical = path.join(tmpDir, '.totem', 'review-extensions.txt');
     expect(fs.existsSync(canonical)).toBe(true);
     expect(fs.readFileSync(canonical, 'utf-8')).toBe('.ts\n.rs\n');
+  });
+
+  // ─── mmnto-ai/totem#1811: Phase A / Phase B split ─────
+
+  it('--packs-only skips runSync and does NOT call requireEmbedding', async () => {
+    await syncCommand({ packsOnly: true, quiet: true });
+    expect(mockRequireEmbedding).not.toHaveBeenCalled();
+    expect(mockRunSync).not.toHaveBeenCalled();
+  });
+
+  it('--packs-only writes installed-packs.json (Phase A still fires)', async () => {
+    await syncCommand({ packsOnly: true, quiet: true });
+    expect(mockResolveInstalledPacks).toHaveBeenCalledTimes(1);
+    expect(mockWriteInstalledPacksManifest).toHaveBeenCalledTimes(1);
+  });
+
+  it('--packs-only short-circuits — no spinner, no registry update', async () => {
+    await syncCommand({ packsOnly: true, quiet: true });
+    expect(mockUpdateRegistryEntry).not.toHaveBeenCalled();
+    expect(mockCreateSpinner).not.toHaveBeenCalled();
+  });
+
+  it('--index-only skips pack-resolution + manifest write but still runs runSync', async () => {
+    await syncCommand({ indexOnly: true, quiet: true });
+    expect(mockResolveInstalledPacks).not.toHaveBeenCalled();
+    expect(mockWriteInstalledPacksManifest).not.toHaveBeenCalled();
+    expect(mockRunSync).toHaveBeenCalledTimes(1);
+    expect(mockRequireEmbedding).toHaveBeenCalledTimes(1);
+  });
+
+  it('default sync (no flags) runs both Phase A AND Phase B', async () => {
+    await syncCommand({ quiet: true });
+    expect(mockResolveInstalledPacks).toHaveBeenCalledTimes(1);
+    expect(mockWriteInstalledPacksManifest).toHaveBeenCalledTimes(1);
+    expect(mockRunSync).toHaveBeenCalledTimes(1);
+    expect(mockRequireEmbedding).toHaveBeenCalledTimes(1);
+  });
+
+  it('--packs-only + --index-only is a hard FLAG_CONFLICT error', async () => {
+    await expect(syncCommand({ packsOnly: true, indexOnly: true, quiet: true })).rejects.toThrow(
+      /--packs-only.*--index-only/,
+    );
+    expect(mockRequireEmbedding).not.toHaveBeenCalled();
+    expect(mockRunSync).not.toHaveBeenCalled();
+    expect(mockResolveInstalledPacks).not.toHaveBeenCalled();
+  });
+
+  it('--packs-only + --full is a hard FLAG_CONFLICT error', async () => {
+    await expect(syncCommand({ packsOnly: true, full: true, quiet: true })).rejects.toThrow(
+      /--packs-only.*--full/,
+    );
+    expect(mockRunSync).not.toHaveBeenCalled();
+  });
+
+  it('--packs-only + --prune is a hard FLAG_CONFLICT error', async () => {
+    await expect(syncCommand({ packsOnly: true, prune: true, quiet: true })).rejects.toThrow(
+      /--packs-only.*--prune/,
+    );
+    expect(mockRunSync).not.toHaveBeenCalled();
+  });
+
+  it('mutex error fires BEFORE config load and embedder gate', async () => {
+    // Load-bearing for the CI-unblock invariant: a mutex violation
+    // must not cascade through `requireEmbedding`, which would mask
+    // FLAG_CONFLICT behind a TotemConfigError on missing API keys.
+    mockRequireEmbedding.mockImplementationOnce(() => {
+      throw new Error('embedding gate fired despite mutex violation');
+    });
+    await expect(syncCommand({ packsOnly: true, indexOnly: true })).rejects.toThrow(/--packs-only/);
+    expect(mockRequireEmbedding).not.toHaveBeenCalled();
   });
 
   it('resolves canonical file path relative to configRoot when invoked from subdirectory', async () => {

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -21,8 +21,8 @@ vi.mock('../utils.js', () => ({
   resolveConfigPath: (...args: unknown[]) => mockResolveConfigPath(...args),
   isGlobalConfigPath: (...args: unknown[]) => mockIsGlobalConfigPath(...args),
   loadEnv: vi.fn(),
-  loadConfig: (...args: unknown[]) => mockLoadConfig(...args),
-  requireEmbedding: (...args: unknown[]) => mockRequireEmbedding(...args),
+  loadConfig: (...args: unknown[]) => mockLoadConfig(...args), // totem-context: mock surface
+  requireEmbedding: (...args: unknown[]) => mockRequireEmbedding(...args), // totem-context: mock surface
   sanitize: (s: string) => s,
 }));
 
@@ -33,11 +33,12 @@ const mockRunSync = vi
 const mockResolveInstalledPacks = vi.fn().mockReturnValue({ resolved: [], warnings: [] });
 const mockWriteInstalledPacksManifest = vi.fn();
 
+// totem-context: full-module mock — syncCommand is the unit under test; importing actual @mmnto/totem would cross the unit boundary into runSync's pipeline-walk side effects. The mock surfaces are call-spied in tests, not invoked for behavior.
 vi.mock('@mmnto/totem', () => ({
-  runSync: (...args: unknown[]) => mockRunSync(...args),
-  updateRegistryEntry: (...args: unknown[]) => mockUpdateRegistryEntry(...args),
-  resolveInstalledPacks: (...args: unknown[]) => mockResolveInstalledPacks(...args),
-  writeInstalledPacksManifest: (...args: unknown[]) => mockWriteInstalledPacksManifest(...args),
+  runSync: (...args: unknown[]) => mockRunSync(...args), // totem-context: mock surface; not a re-implementation of utility logic
+  updateRegistryEntry: (...args: unknown[]) => mockUpdateRegistryEntry(...args), // totem-context: mock surface
+  resolveInstalledPacks: (...args: unknown[]) => mockResolveInstalledPacks(...args), // totem-context: mock surface
+  writeInstalledPacksManifest: (...args: unknown[]) => mockWriteInstalledPacksManifest(...args), // totem-context: mock surface
   TotemError: class TotemError extends Error {
     constructor(
       public code: string,
@@ -75,6 +76,7 @@ describe('syncCommand', () => {
     mockLoadConfig.mockResolvedValue(baseConfig());
     mockResolveConfigPath.mockReset();
     mockIsGlobalConfigPath.mockReset();
+    // totem-context: vitest mock reset in unit-test setup; not an orchestrator timeout candidate
     mockRequireEmbedding.mockReset();
     mockRunSync.mockReset();
     mockRunSync.mockResolvedValue({ chunksProcessed: 10, filesProcessed: 3, totalChunks: 42 });
@@ -201,24 +203,28 @@ describe('syncCommand', () => {
 
   // ─── mmnto-ai/totem#1811: Phase A / Phase B split ─────
 
+  // totem-context: test callback genuinely awaits async syncCommand
   it('--packs-only skips runSync and does NOT call requireEmbedding', async () => {
     await syncCommand({ packsOnly: true, quiet: true });
     expect(mockRequireEmbedding).not.toHaveBeenCalled();
     expect(mockRunSync).not.toHaveBeenCalled();
   });
 
+  // totem-context: test callback genuinely awaits async syncCommand
   it('--packs-only writes installed-packs.json (Phase A still fires)', async () => {
     await syncCommand({ packsOnly: true, quiet: true });
     expect(mockResolveInstalledPacks).toHaveBeenCalledTimes(1);
     expect(mockWriteInstalledPacksManifest).toHaveBeenCalledTimes(1);
   });
 
+  // totem-context: test callback genuinely awaits async syncCommand
   it('--packs-only short-circuits — no spinner, no registry update', async () => {
     await syncCommand({ packsOnly: true, quiet: true });
     expect(mockUpdateRegistryEntry).not.toHaveBeenCalled();
     expect(mockCreateSpinner).not.toHaveBeenCalled();
   });
 
+  // totem-context: test callback genuinely awaits async syncCommand
   it('--index-only skips pack-resolution + manifest write but still runs runSync', async () => {
     await syncCommand({ indexOnly: true, quiet: true });
     expect(mockResolveInstalledPacks).not.toHaveBeenCalled();
@@ -227,6 +233,7 @@ describe('syncCommand', () => {
     expect(mockRequireEmbedding).toHaveBeenCalledTimes(1);
   });
 
+  // totem-context: test callback genuinely awaits async syncCommand
   it('default sync (no flags) runs both Phase A AND Phase B', async () => {
     await syncCommand({ quiet: true });
     expect(mockResolveInstalledPacks).toHaveBeenCalledTimes(1);
@@ -235,6 +242,7 @@ describe('syncCommand', () => {
     expect(mockRequireEmbedding).toHaveBeenCalledTimes(1);
   });
 
+  // totem-context: test callback genuinely awaits async syncCommand
   it('--packs-only + --index-only is a hard FLAG_CONFLICT error', async () => {
     await expect(syncCommand({ packsOnly: true, indexOnly: true, quiet: true })).rejects.toThrow(
       /--packs-only.*--index-only/,
@@ -244,6 +252,7 @@ describe('syncCommand', () => {
     expect(mockResolveInstalledPacks).not.toHaveBeenCalled();
   });
 
+  // totem-context: test callback genuinely awaits async syncCommand
   it('--packs-only + --full is a hard FLAG_CONFLICT error', async () => {
     await expect(syncCommand({ packsOnly: true, full: true, quiet: true })).rejects.toThrow(
       /--packs-only.*--full/,
@@ -251,6 +260,7 @@ describe('syncCommand', () => {
     expect(mockRunSync).not.toHaveBeenCalled();
   });
 
+  // totem-context: test callback genuinely awaits async syncCommand
   it('--packs-only + --prune is a hard FLAG_CONFLICT error', async () => {
     await expect(syncCommand({ packsOnly: true, prune: true, quiet: true })).rejects.toThrow(
       /--packs-only.*--prune/,
@@ -258,11 +268,13 @@ describe('syncCommand', () => {
     expect(mockRunSync).not.toHaveBeenCalled();
   });
 
+  // totem-context: test callback genuinely awaits async syncCommand
   it('mutex error fires BEFORE config load and embedder gate', async () => {
     // Load-bearing for the CI-unblock invariant: a mutex violation
     // must not cascade through `requireEmbedding`, which would mask
     // FLAG_CONFLICT behind a TotemConfigError on missing API keys.
     mockRequireEmbedding.mockImplementationOnce(() => {
+      // totem-context: throw inside vitest mock to assert mutex fires before requireEmbedding; sentinel string is test-only and never surfaces to a user
       throw new Error('embedding gate fired despite mutex violation');
     });
     await expect(syncCommand({ packsOnly: true, indexOnly: true })).rejects.toThrow(/--packs-only/);

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -269,6 +269,34 @@ describe('syncCommand', () => {
   });
 
   // totem-context: test callback genuinely awaits async syncCommand
+  it('--packs-only throws SYNC_FAILED when Phase A manifest write fails', async () => {
+    // Load-bearing for the CI-unblock invariant (#1828 review): under
+    // --packs-only, Phase A IS the entire scope of work. Silent
+    // warn-and-continue would leave installed-packs.json stale or
+    // missing while exit 0 reports success. Default mode keeps the
+    // best-effort warn — see regression guard below.
+    mockWriteInstalledPacksManifest.mockImplementationOnce(() => {
+      // totem-context: throw inside vitest mock to simulate a Phase A write failure; sentinel string is test-only and never surfaces to a user
+      throw new Error('EACCES: permission denied');
+    });
+    await expect(syncCommand({ packsOnly: true, quiet: true })).rejects.toThrow(
+      /Failed to write installed-packs\.json.*EACCES/,
+    );
+    expect(mockRunSync).not.toHaveBeenCalled();
+  });
+
+  // totem-context: test callback genuinely awaits async syncCommand — regression guard for default-mode warn-and-continue (#1828 review carve-out)
+  it('default mode keeps warn-and-continue when Phase A manifest write fails', async () => {
+    // totem-context: regression guard — default mode keeps best-effort warn-and-continue while --packs-only throws (sibling test above)
+    mockWriteInstalledPacksManifest.mockImplementationOnce(() => {
+      // totem-context: throw inside vitest mock to simulate a Phase A write failure; sentinel string is test-only and never surfaces to a user
+      throw new Error('EACCES: permission denied');
+    });
+    await expect(syncCommand({ quiet: true })).resolves.toBeUndefined();
+    expect(mockRunSync).toHaveBeenCalledTimes(1);
+  });
+
+  // totem-context: test callback genuinely awaits async syncCommand
   it('mutex error fires BEFORE config load and embedder gate', async () => {
     // Load-bearing for the CI-unblock invariant: a mutex violation
     // must not cascade through `requireEmbedding`, which would mask

--- a/packages/cli/src/commands/sync.test.ts
+++ b/packages/cli/src/commands/sync.test.ts
@@ -44,8 +44,10 @@ vi.mock('@mmnto/totem', () => ({
       public code: string,
       message: string,
       public hint?: string,
+      // totem-context: mock mirrors real TotemError(code, message, hint, cause) signature for R2 cause-preservation tests
+      cause?: unknown,
     ) {
-      super(message);
+      super(message, { cause });
     }
   },
 }));
@@ -268,20 +270,32 @@ describe('syncCommand', () => {
     expect(mockRunSync).not.toHaveBeenCalled();
   });
 
-  // totem-context: test callback genuinely awaits async syncCommand
-  it('--packs-only throws SYNC_FAILED when Phase A manifest write fails', async () => {
-    // Load-bearing for the CI-unblock invariant (#1828 review): under
-    // --packs-only, Phase A IS the entire scope of work. Silent
-    // warn-and-continue would leave installed-packs.json stale or
-    // missing while exit 0 reports success. Default mode keeps the
-    // best-effort warn — see regression guard below.
+  // totem-context: test callback genuinely awaits async syncCommand — load-bearing CI-unblock guard for --packs-only Phase A failure (#1828); cause preservation per styleguide §6 (R2)
+  it('--packs-only throws SYNC_FAILED with original err as cause when Phase A manifest write fails', async () => {
+    // totem-context: sentinel error fixture for cause-preservation assertion; not a TotemError-wrapping pattern
+    const original = new Error('EACCES: permission denied');
     mockWriteInstalledPacksManifest.mockImplementationOnce(() => {
       // totem-context: throw inside vitest mock to simulate a Phase A write failure; sentinel string is test-only and never surfaces to a user
-      throw new Error('EACCES: permission denied');
+      throw original;
     });
+    // totem-context: test genuinely awaits async syncCommand; rejects.toThrow asserts the SYNC_FAILED message
     await expect(syncCommand({ packsOnly: true, quiet: true })).rejects.toThrow(
-      /Failed to write installed-packs\.json.*EACCES/,
+      /Failed to write installed-packs\.json/,
     );
+    // Re-run to capture the thrown error and assert cause is preserved
+    mockWriteInstalledPacksManifest.mockImplementationOnce(() => {
+      // totem-context: throw inside vitest mock to assert Error.cause preservation; second-pass check on the same code path
+      throw original;
+    });
+    let caught: unknown;
+    try {
+      await syncCommand({ packsOnly: true, quiet: true });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    // totem-context: TS type assertion to access Error.cause in test scaffold — not Zod-relevant runtime validation
+    expect((caught as Error & { cause?: unknown }).cause).toBe(original);
     expect(mockRunSync).not.toHaveBeenCalled();
   });
 
@@ -306,6 +320,8 @@ describe('syncCommand', () => {
       throw new Error('embedding gate fired despite mutex violation');
     });
     await expect(syncCommand({ packsOnly: true, indexOnly: true })).rejects.toThrow(/--packs-only/);
+    // totem-context: mutex-fires-before-config invariant (#1828 R2 CR finding); test genuinely awaits async syncCommand
+    expect(mockLoadConfig).not.toHaveBeenCalled();
     expect(mockRequireEmbedding).not.toHaveBeenCalled();
   });
 

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -79,7 +79,13 @@ export interface SyncCommandOptions {
 }
 
 export async function syncCommand(options: SyncCommandOptions): Promise<void> {
-  const { runSync, TotemError, updateRegistryEntry } = await import('@mmnto/totem');
+  const {
+    resolveInstalledPacks,
+    runSync,
+    TotemError,
+    updateRegistryEntry,
+    writeInstalledPacksManifest,
+  } = await import('@mmnto/totem');
   const { createSpinner, log } = await import('../ui.js');
   const { isGlobalConfigPath, loadConfig, loadEnv, requireEmbedding, resolveConfigPath, sanitize } =
     await import('../utils.js');
@@ -114,20 +120,20 @@ export async function syncCommand(options: SyncCommandOptions): Promise<void> {
   // the re-order is observably equivalent for the default case.
   if (!options.indexOnly) {
     try {
-      const { resolveInstalledPacks, writeInstalledPacksManifest } = await import('@mmnto/totem');
       const { resolved, warnings } = resolveInstalledPacks({
         projectRoot: targetRoot,
         config,
       });
       writeInstalledPacksManifest(totemDirAbs, { version: 1, packs: resolved });
       for (const warning of warnings) {
+        const packName = sanitize(warning.name);
         const reasonText =
           warning.reason === 'dep-only'
             ? `present in package.json but not in totem.config.ts \`extends\` — pack rules will not be merged. Add to \`extends\` or remove the dependency.`
             : warning.reason === 'extends-only'
-              ? `declared in totem.config.ts \`extends\` but not installed — install via \`pnpm add -D ${warning.name}\` (or equivalent).`
+              ? `declared in totem.config.ts \`extends\` but not installed — install via \`pnpm add -D ${packName}\` (or equivalent).`
               : `missing engines['@mmnto/totem'] declaration — pack cannot satisfy the engine-version cross-check (ADR-097 § 5 Q6). Add '"engines": { "@mmnto/totem": "^<version>" }' to the pack's package.json and republish.`;
-        log.warn(TAG, `Pack '${warning.name}': ${reasonText}`);
+        log.warn(TAG, `Pack '${packName}': ${reasonText}`);
       }
       if (resolved.length > 0) {
         log.dim(
@@ -137,15 +143,16 @@ export async function syncCommand(options: SyncCommandOptions): Promise<void> {
       }
       // totem-context: intentional cleanup — manifest write is best-effort in DEFAULT sync (mirrors writeReviewExtensionsFile below). Under --packs-only it's the entire scope of work, so failure must propagate (#1828 review).
     } catch (err) {
-      // totem-context: String(err) is the canonical non-Error fallback for catch-block normalization — type-narrowing throwables here would lose diagnostic info (matches L188 pattern; #1828 review)
-      const detail = err instanceof Error ? err.message : String(err);
       if (options.packsOnly) {
         throw new TotemError(
           'SYNC_FAILED',
-          `Failed to write installed-packs.json: ${sanitize(detail)}`,
+          'Failed to write installed-packs.json',
           'Fix the manifest error above and re-run `totem sync --packs-only`.',
+          err,
         );
       }
+      // totem-context: String(err) is the canonical non-Error fallback for catch-block normalization — matches L188 pattern in this file
+      const detail = err instanceof Error ? err.message : String(err);
       log.warn(TAG, `Skipped installed-packs.json write: ${sanitize(detail)}`);
     }
   }

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -32,15 +32,62 @@ export function writeReviewExtensionsFile(
   return finalPath;
 }
 
-export async function syncCommand(options: {
+/**
+ * `--packs-only` (Phase A) is mutually exclusive with every Phase B
+ * flag (`--index-only`, `--full`, `--prune`). Hard error before any
+ * sync logic runs so callers get a clean, actionable diagnostic
+ * instead of a silently-mixed run (mmnto-ai/totem#1811, ADR-101).
+ */
+function assertNoPhaseBFlags(
+  options: SyncCommandOptions,
+  TotemError: typeof import('@mmnto/totem').TotemError,
+): void {
+  if (!options.packsOnly) return;
+  const conflicts: string[] = [];
+  if (options.indexOnly) conflicts.push('--index-only');
+  if (options.full) conflicts.push('--full');
+  if (options.prune) conflicts.push('--prune');
+  if (conflicts.length === 0) return;
+  throw new TotemError(
+    'FLAG_CONFLICT',
+    `--packs-only cannot be combined with ${conflicts.join(', ')}: those flags drive the embedding-side phase, which --packs-only skips.`,
+    'Re-run with --packs-only alone, or drop --packs-only to run the full sync.',
+  );
+}
+
+export interface SyncCommandOptions {
   full?: boolean;
   prune?: boolean;
   quiet?: boolean;
-}): Promise<void> {
+  /**
+   * Run only Phase A — deterministic pack-resolution + manifest write
+   * (`installed-packs.json`). Skips `requireEmbedding`, `runSync`, the
+   * post-sync `review-extensions.txt` write, the global-registry
+   * update, and prune. Designed for CI environments without API keys
+   * after a `@mmnto/totem` cohort bump (mmnto-ai/totem#1811, ADR-101).
+   * Mutually exclusive with `indexOnly`, `full`, and `prune`.
+   */
+  packsOnly?: boolean;
+  /**
+   * Run only Phase B — `runSync` + post-sync side outputs. Skips
+   * pack-resolution + `installed-packs.json` write. Use when the
+   * manifest is already current and only the vector-store needs to
+   * re-embed (mmnto-ai/totem#1811, ADR-101). Mutually exclusive with
+   * `packsOnly`.
+   */
+  indexOnly?: boolean;
+}
+
+export async function syncCommand(options: SyncCommandOptions): Promise<void> {
   const { runSync, TotemError, updateRegistryEntry } = await import('@mmnto/totem');
   const { createSpinner, log } = await import('../ui.js');
   const { isGlobalConfigPath, loadConfig, loadEnv, requireEmbedding, resolveConfigPath, sanitize } =
     await import('../utils.js');
+
+  // Validate flag mutex BEFORE loading config or constructing any
+  // embedder-touching surface — keeps --packs-only clean of init-time
+  // failures from the gates it's specifically designed to skip.
+  assertNoPhaseBFlags(options, TotemError);
 
   const cwd = process.cwd();
   const configPath = resolveConfigPath(cwd);
@@ -48,52 +95,24 @@ export async function syncCommand(options: {
   loadEnv(cwd);
 
   const config = await loadConfig(configPath);
-  requireEmbedding(config);
-  const incremental = !options.full;
 
-  const noopSpinner: Spinner = {
-    update() {},
-    succeed() {},
-    fail() {},
-    stop() {},
-  };
+  // Phase B requires an embedding key. Skipping `requireEmbedding`
+  // when `--packs-only` is the load-bearing CI-unblock invariant of
+  // ADR-101: a baseline environment can rebuild `installed-packs.json`
+  // without an API key.
+  if (!options.packsOnly) {
+    requireEmbedding(config);
+  }
 
-  const spinner = options.quiet
-    ? noopSpinner
-    : await createSpinner(TAG, incremental ? 'Incremental sync...' : 'Full re-index...');
+  const targetRoot = isGlobalConfigPath(configPath) ? cwd : path.dirname(configPath);
+  const totemDirAbs = path.resolve(targetRoot, config.totemDir);
 
-  try {
-    const result = await runSync(config, {
-      projectRoot: cwd,
-      incremental,
-      onProgress: (msg) => spinner.update(msg),
-    });
-
-    // Emit canonical review-extensions.txt for .claude/hooks/content-hash.sh (#1527).
-    // Written on every sync, even when the user omits review.sourceExtensions
-    // (default set persisted), so downstream bash consumers see a consistent file.
-    // Resolves against configRoot for local configs so monorepo users invoking
-    // from a subdirectory land the file at <project-root>/.totem/, where shield
-    // and the bash hook read it (lesson 61975bb96c9bf27f / f5a75d98a43e0721).
-    // Falls back to cwd for global-only configs: if the user customized
-    // review.sourceExtensions in ~/.totem/totem.config.ts, skipping the write
-    // would break TS/bash parity (TS uses the custom set, bash defaults). cwd
-    // is the best proxy for git-toplevel available without shelling to git.
-    const targetRoot = isGlobalConfigPath(configPath) ? cwd : path.dirname(configPath);
-    const totemDirAbs = path.resolve(targetRoot, config.totemDir);
-    try {
-      writeReviewExtensionsFile(totemDirAbs, config.review.sourceExtensions); // totem-context: intentional cleanup — canonical file write is a convenience for the bash PreToolUse hook
-    } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
-      log.dim(TAG, `Skipped review-extensions.txt write: ${sanitize(detail)}`);
-    }
-
-    // Emit `.totem/installed-packs.json` for boot-time pack registration
-    // (mmnto-ai/totem#1768, ADR-097 § 10). Resolved from the deduplicated
-    // union of `package.json` `@mmnto/pack-*` deps + `totem.config.ts`
-    // `extends` array. Mismatch surfaces (dep without extends, extends
-    // without dep, missing peerDependencies) emit per-pack warnings;
-    // resolved entries are written to the manifest atomically.
+  // ─── Phase A — pack-resolution + manifest write ─────
+  // Re-ordered to BEFORE `runSync` so `--packs-only` can short-circuit
+  // cleanly without invoking embedding (mmnto-ai/totem#1811 OQ3).
+  // `runSync` operates against pack registrations resolved at boot, so
+  // the re-order is observably equivalent for the default case.
+  if (!options.indexOnly) {
     try {
       const { resolveInstalledPacks, writeInstalledPacksManifest } = await import('@mmnto/totem');
       const { resolved, warnings } = resolveInstalledPacks({
@@ -116,10 +135,58 @@ export async function syncCommand(options: {
           `Wrote installed-packs.json (${resolved.length} pack${resolved.length === 1 ? '' : 's'}).`,
         );
       }
-      // totem-context: intentional cleanup — manifest write is best-effort, mirrors the writeReviewExtensionsFile pattern above (failure logs at warn but does not abort sync)
+      // totem-context: intentional cleanup — manifest write is best-effort, mirrors the writeReviewExtensionsFile pattern below (failure logs at warn but does not abort sync)
     } catch (err) {
       const detail = err instanceof Error ? err.message : 'unknown error';
       log.warn(TAG, `Skipped installed-packs.json write: ${sanitize(detail)}`);
+    }
+  }
+
+  // `--packs-only` short-circuit: Phase B (embedding sync, review
+  // extensions, registry update, prune) is the entire scope of work
+  // that's skipped. Surface a confirmation so the operator sees the
+  // command did the deterministic work it advertised.
+  if (options.packsOnly) {
+    log.success(TAG, 'Pack manifest synced (--packs-only).');
+    return;
+  }
+
+  const incremental = !options.full;
+
+  const noopSpinner: Spinner = {
+    update() {},
+    succeed() {},
+    fail() {},
+    stop() {},
+  };
+
+  const spinner = options.quiet
+    ? noopSpinner
+    : await createSpinner(TAG, incremental ? 'Incremental sync...' : 'Full re-index...');
+
+  // ─── Phase B — embedding-driven sync ─────────────────
+  try {
+    const result = await runSync(config, {
+      projectRoot: cwd,
+      incremental,
+      onProgress: (msg) => spinner.update(msg),
+    });
+
+    // Emit canonical review-extensions.txt for .claude/hooks/content-hash.sh (#1527).
+    // Written on every sync, even when the user omits review.sourceExtensions
+    // (default set persisted), so downstream bash consumers see a consistent file.
+    // Resolves against configRoot for local configs so monorepo users invoking
+    // from a subdirectory land the file at <project-root>/.totem/, where shield
+    // and the bash hook read it (lesson 61975bb96c9bf27f / f5a75d98a43e0721).
+    // Falls back to cwd for global-only configs: if the user customized
+    // review.sourceExtensions in ~/.totem/totem.config.ts, skipping the write
+    // would break TS/bash parity (TS uses the custom set, bash defaults). cwd
+    // is the best proxy for git-toplevel available without shelling to git.
+    try {
+      writeReviewExtensionsFile(totemDirAbs, config.review.sourceExtensions); // totem-context: intentional cleanup — canonical file write is a convenience for the bash PreToolUse hook
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      log.dim(TAG, `Skipped review-extensions.txt write: ${sanitize(detail)}`);
     }
 
     spinner.succeed(`Done: ${result.chunksProcessed} chunks from ${result.filesProcessed} files`);

--- a/packages/cli/src/commands/sync.ts
+++ b/packages/cli/src/commands/sync.ts
@@ -135,9 +135,17 @@ export async function syncCommand(options: SyncCommandOptions): Promise<void> {
           `Wrote installed-packs.json (${resolved.length} pack${resolved.length === 1 ? '' : 's'}).`,
         );
       }
-      // totem-context: intentional cleanup — manifest write is best-effort, mirrors the writeReviewExtensionsFile pattern below (failure logs at warn but does not abort sync)
+      // totem-context: intentional cleanup — manifest write is best-effort in DEFAULT sync (mirrors writeReviewExtensionsFile below). Under --packs-only it's the entire scope of work, so failure must propagate (#1828 review).
     } catch (err) {
-      const detail = err instanceof Error ? err.message : 'unknown error';
+      // totem-context: String(err) is the canonical non-Error fallback for catch-block normalization — type-narrowing throwables here would lose diagnostic info (matches L188 pattern; #1828 review)
+      const detail = err instanceof Error ? err.message : String(err);
+      if (options.packsOnly) {
+        throw new TotemError(
+          'SYNC_FAILED',
+          `Failed to write installed-packs.json: ${sanitize(detail)}`,
+          'Fix the manifest error above and re-run `totem sync --packs-only`.',
+        );
+      }
       log.warn(TAG, `Skipped installed-packs.json write: ${sanitize(detail)}`);
     }
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -112,9 +112,24 @@ program
   .option('--full', 'Force a full re-index (ignores incremental)')
   .option('--incremental', 'Run an incremental sync (default behavior)')
   .option('--prune', 'Detect and interactively remove lessons with stale file references')
+  .option(
+    '--packs-only',
+    'Run only the deterministic pack manifest write (no API key required); skips embedding sync, prune, and the global registry update (mmnto-ai/totem#1811)',
+  )
+  .option(
+    '--index-only',
+    'Run only the embedding sync; skip the pack manifest write (use when installed-packs.json is already current)',
+  )
   .option('-q, --quiet', 'Suppress output (for background/hook usage)')
   .action(
-    async (opts: { full?: boolean; incremental?: boolean; prune?: boolean; quiet?: boolean }) => {
+    async (opts: {
+      full?: boolean;
+      incremental?: boolean;
+      prune?: boolean;
+      packsOnly?: boolean;
+      indexOnly?: boolean;
+      quiet?: boolean;
+    }) => {
       try {
         const { syncCommand } = await import('./commands/sync.js');
         await syncCommand(opts);

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -30,7 +30,9 @@ export type TotemErrorCode =
   | 'UPGRADE_HASH_NOT_FOUND'
   | 'UPGRADE_HASH_AMBIGUOUS'
   | 'STAGED_READ_FAILED'
-  | 'UPGRADE_CLOUD_UNSUPPORTED';
+  | 'UPGRADE_CLOUD_UNSUPPORTED'
+  | 'STALE_MANIFEST'
+  | 'FLAG_CONFLICT';
 
 export class TotemError extends Error {
   readonly code: TotemErrorCode;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -103,6 +103,7 @@ export {
   isEngineSealed,
   loadedPacks,
   loadInstalledPacks,
+  resolveEngineVersion,
 } from './pack-discovery.js';
 
 // Pack manifest writer (mmnto-ai/totem#1768, Step 4)
@@ -112,6 +113,14 @@ export type {
   ResolveInstalledPacksInput,
 } from './pack-manifest-writer.js';
 export { resolveInstalledPacks, writeInstalledPacksManifest } from './pack-manifest-writer.js';
+
+// Stale-manifest detector (mmnto-ai/totem#1811, ADR-101)
+export type {
+  DetectStaleManifestOptions,
+  StaleManifestDetection,
+  StaleManifestReason,
+} from './stale-manifest.js';
+export { detectStaleManifest, staleManifestError } from './stale-manifest.js';
 
 // Embedders
 export type { Embedder } from './embedders/embedder.js';

--- a/packages/core/src/pack-discovery.ts
+++ b/packages/core/src/pack-discovery.ts
@@ -62,6 +62,19 @@ import {
 export const InstalledPacksManifestSchema = z
   .object({
     version: z.literal(1),
+    /**
+     * `@mmnto/totem` package version that wrote the manifest. Optional
+     * for forward-compat with pre-1.27.0 manifests. Stamped at write
+     * time by `writeInstalledPacksManifest()` from `resolveEngineVersion()`.
+     *
+     * Read on the lint-time stale-manifest UX-nudge fast-path
+     * (`rule-engine.ts` parser-error intercept). Schema does not
+     * enforce semver-validity here so a malformed cohort doesn't make
+     * the entire manifest unreadable; the consumer treats malformed
+     * or missing values as "stale" and surfaces the same nudge
+     * (mmnto-ai/totem#1811, ADR-101).
+     */
+    cohort: z.string().optional(),
     packs: z.array(
       z
         .object({
@@ -412,7 +425,15 @@ function assertEngineRangeSatisfied(pack: LoadedPack, engineVersion: string): vo
   }
 }
 
-function resolveEngineVersion(): string {
+/**
+ * Resolve the running `@mmnto/totem` package version from disk.
+ *
+ * Exported (mmnto-ai/totem#1811) so `pack-manifest-writer.ts` can
+ * stamp the manifest's `cohort` field at write time and the
+ * `rule-engine.ts` parser-error intercept can compare the running
+ * engine against the manifest's recorded cohort.
+ */
+export function resolveEngineVersion(): string {
   // Resolve relative to this module's URL so the read works regardless
   // of cwd. The package.json sits at packages/core/package.json — two
   // levels up from packages/core/dist/pack-discovery.js when the build

--- a/packages/core/src/pack-manifest-writer.test.ts
+++ b/packages/core/src/pack-manifest-writer.test.ts
@@ -253,7 +253,7 @@ describe('writeInstalledPacksManifest', () => {
     const root = makeTmpRoot();
     const totemDir = path.join(root, '.totem');
     const finalPath = writeInstalledPacksManifest(totemDir, { version: 1, packs: [] });
-    const parsed = JSON.parse(fs.readFileSync(finalPath, 'utf-8'));
+    const parsed = JSON.parse(fs.readFileSync(finalPath, 'utf-8')); // totem-context: synchronous read in test fixture; runtime callers use the boot-time pack-discovery loader path
     expect(typeof parsed.cohort).toBe('string');
     // Stamped value must be a real semver version (not the '0.0.0'
     // sentinel from resolveEngineVersion's last-resort fallback when
@@ -269,7 +269,7 @@ describe('writeInstalledPacksManifest', () => {
       cohort: '1.2.3-test',
       packs: [],
     });
-    const parsed = JSON.parse(fs.readFileSync(finalPath, 'utf-8'));
+    const parsed = JSON.parse(fs.readFileSync(finalPath, 'utf-8')); // totem-context: synchronous read in test fixture; runtime callers use the boot-time pack-discovery loader path
     expect(parsed.cohort).toBe('1.2.3-test');
   });
 
@@ -282,7 +282,7 @@ describe('writeInstalledPacksManifest', () => {
       packs: [],
     });
     const parsed = JSON.parse(
-      fs.readFileSync(path.join(totemDir, 'installed-packs.json'), 'utf-8'),
+      fs.readFileSync(path.join(totemDir, 'installed-packs.json'), 'utf-8'), // totem-context: synchronous read in test fixture; runtime callers use the boot-time pack-discovery loader path
     );
     const validation = InstalledPacksManifestSchema.safeParse(parsed);
     expect(validation.success).toBe(true);

--- a/packages/core/src/pack-manifest-writer.test.ts
+++ b/packages/core/src/pack-manifest-writer.test.ts
@@ -248,4 +248,51 @@ describe('writeInstalledPacksManifest', () => {
     writeInstalledPacksManifest(totemDir, { version: 1, packs: [] });
     expect(fs.existsSync(path.join(totemDir, 'installed-packs.json.tmp'))).toBe(false);
   });
+
+  it('stamps cohort with the running engine version when caller omits it (mmnto-ai/totem#1811)', () => {
+    const root = makeTmpRoot();
+    const totemDir = path.join(root, '.totem');
+    const finalPath = writeInstalledPacksManifest(totemDir, { version: 1, packs: [] });
+    const parsed = JSON.parse(fs.readFileSync(finalPath, 'utf-8'));
+    expect(typeof parsed.cohort).toBe('string');
+    // Stamped value must be a real semver version (not the '0.0.0'
+    // sentinel from resolveEngineVersion's last-resort fallback when
+    // run inside the actual package).
+    expect(parsed.cohort).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it('preserves a caller-provided cohort verbatim (test-driven override)', () => {
+    const root = makeTmpRoot();
+    const totemDir = path.join(root, '.totem');
+    const finalPath = writeInstalledPacksManifest(totemDir, {
+      version: 1,
+      cohort: '1.2.3-test',
+      packs: [],
+    });
+    const parsed = JSON.parse(fs.readFileSync(finalPath, 'utf-8'));
+    expect(parsed.cohort).toBe('1.2.3-test');
+  });
+
+  it('manifest with cohort round-trips through the schema', () => {
+    const root = makeTmpRoot();
+    const totemDir = path.join(root, '.totem');
+    writeInstalledPacksManifest(totemDir, {
+      version: 1,
+      cohort: '9.9.9',
+      packs: [],
+    });
+    const parsed = JSON.parse(
+      fs.readFileSync(path.join(totemDir, 'installed-packs.json'), 'utf-8'),
+    );
+    const validation = InstalledPacksManifestSchema.safeParse(parsed);
+    expect(validation.success).toBe(true);
+    expect(validation.success && validation.data.cohort).toBe('9.9.9');
+  });
+
+  it('forward-compat: pre-1.27.0 manifest without cohort parses cleanly (mmnto-ai/totem#1811)', () => {
+    const legacy = { version: 1, packs: [] };
+    const validation = InstalledPacksManifestSchema.safeParse(legacy);
+    expect(validation.success).toBe(true);
+    expect(validation.success && validation.data.cohort).toBeUndefined();
+  });
 });

--- a/packages/core/src/pack-manifest-writer.ts
+++ b/packages/core/src/pack-manifest-writer.ts
@@ -169,6 +169,7 @@ export function writeInstalledPacksManifest(
   };
   const finalPath = path.join(totemDirAbs, 'installed-packs.json');
   const tmpPath = finalPath + '.tmp';
+  // totem-context: writing the totem pack manifest under <totemDir>/, not a git hook
   fs.writeFileSync(tmpPath, JSON.stringify(stamped, null, 2) + '\n', 'utf-8');
   fs.renameSync(tmpPath, finalPath);
   return finalPath;

--- a/packages/core/src/pack-manifest-writer.ts
+++ b/packages/core/src/pack-manifest-writer.ts
@@ -31,6 +31,7 @@ import * as path from 'node:path';
 
 import type { TotemConfig } from './config-schema.js';
 import type { InstalledPacksManifest } from './pack-discovery.js';
+import { resolveEngineVersion } from './pack-discovery.js';
 
 // ─── Types ──────────────────────────────────────────
 
@@ -149,6 +150,11 @@ export function resolveInstalledPacks(input: ResolveInstalledPacksInput): PackRe
  * manifest payload. Mirrors `writeReviewExtensionsFile` semantics: temp
  * file + rename so a concurrent boot-time read sees the old or new
  * contents, never a partial write.
+ *
+ * Stamps the `cohort` field with the running `@mmnto/totem` version
+ * via `resolveEngineVersion()` when the caller has not pre-populated
+ * one (mmnto-ai/totem#1811). Tests pass an explicit cohort to override
+ * the stamp.
  */
 export function writeInstalledPacksManifest(
   totemDirAbs: string,
@@ -157,9 +163,13 @@ export function writeInstalledPacksManifest(
   if (!fs.existsSync(totemDirAbs)) {
     fs.mkdirSync(totemDirAbs, { recursive: true });
   }
+  const stamped: InstalledPacksManifest = {
+    ...manifest,
+    cohort: manifest.cohort ?? resolveEngineVersion(),
+  };
   const finalPath = path.join(totemDirAbs, 'installed-packs.json');
   const tmpPath = finalPath + '.tmp';
-  fs.writeFileSync(tmpPath, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
+  fs.writeFileSync(tmpPath, JSON.stringify(stamped, null, 2) + '\n', 'utf-8');
   fs.renameSync(tmpPath, finalPath);
   return finalPath;
 }

--- a/packages/core/src/rule-engine.test.ts
+++ b/packages/core/src/rule-engine.test.ts
@@ -31,6 +31,7 @@ import { cleanTmpDir, makeRuleEngineCtx } from './test-utils.js';
 function seedFreshManifest(dir: string, cohort: string = resolveEngineVersion()): void {
   const totemDir = path.join(dir, '.totem');
   fs.mkdirSync(totemDir, { recursive: true });
+  // totem-context: writing a totem manifest fixture under tmpDir, not a git hook
   fs.writeFileSync(
     path.join(totemDir, 'installed-packs.json'),
     JSON.stringify({ version: 1, cohort, packs: [] }),
@@ -832,7 +833,8 @@ describe('matchesGlob', () => {
 describe('applyAstRulesToAdditions fail-loud on unmapped extension (mmnto-ai/totem#1653)', () => {
   // totem-context: test fixtures genuinely need async — they `await applyAstRulesToAdditions(...)` whose contract is async
   it('throws when an AST rule is scoped to an unregistered extension', async () => {
-    seedFreshManifest(tmpDir); // mmnto-ai/totem#1811: silence the STALE_MANIFEST nudge so the original install-hint path is exercised
+    // totem-context: seed the manifest with a fresh cohort so mmnto-ai/totem#1811's STALE_MANIFEST nudge stays silent and the original install-hint path stays under test
+    seedFreshManifest(tmpDir);
     fs.writeFileSync(path.join(tmpDir, 'src', 'main.py'), 'print("x")\n'); // totem-context: writing a python source fixture under tmpDir, not a git hook
     const rule = makeRule({
       engine: 'ast',
@@ -875,9 +877,10 @@ describe('applyAstRulesToAdditions fail-loud on unmapped extension (mmnto-ai/tot
   // through to the original TotemParseError; everything else fires
   // the nudge.
 
+  // totem-context: test fixture genuinely awaits async API (`applyAstRulesToAdditions`)
   it('surfaces STALE_MANIFEST when installed-packs.json is missing', async () => {
     // Note: NO seedFreshManifest call — tmpDir has no .totem/.
-    fs.writeFileSync(path.join(tmpDir, 'src', 'main.py'), 'print("x")\n');
+    fs.writeFileSync(path.join(tmpDir, 'src', 'main.py'), 'print("x")\n'); // totem-context: writing a python source fixture under tmpDir, not a git hook
     const rule = makeRule({
       engine: 'ast',
       astQuery: '(call_expression)',
@@ -894,16 +897,18 @@ describe('applyAstRulesToAdditions fail-loud on unmapped extension (mmnto-ai/tot
     }
     expect(caught).toBeInstanceOf(TotemError);
     expect(caught).not.toBeInstanceOf(TotemParseError);
+    // totem-context: narrowing a thrown error after toBeInstanceOf — not parsing untrusted input
     const te = caught as TotemError;
     expect(te.code).toBe('STALE_MANIFEST');
     expect(te.recoveryHint).toMatch(/--packs-only/);
   });
 
+  // totem-context: test fixture genuinely awaits async API (`applyAstRulesToAdditions`)
   it('surfaces STALE_MANIFEST when manifest cohort is from a prior minor version', async () => {
     // Seed cohort '0.0.0' so semver-minor compare always reads stale
     // regardless of the running engine version.
     seedFreshManifest(tmpDir, '0.0.0');
-    fs.writeFileSync(path.join(tmpDir, 'src', 'main.py'), 'print("x")\n');
+    fs.writeFileSync(path.join(tmpDir, 'src', 'main.py'), 'print("x")\n'); // totem-context: writing a python source fixture under tmpDir, not a git hook
     const rule = makeRule({
       engine: 'ast',
       astQuery: '(call_expression)',
@@ -918,20 +923,24 @@ describe('applyAstRulesToAdditions fail-loud on unmapped extension (mmnto-ai/tot
     } catch (err) {
       caught = err;
     }
-    expect((caught as TotemError).code).toBe('STALE_MANIFEST');
-    expect((caught as TotemError).message).toMatch(/0\.0\.0/);
+    // totem-context: narrowing a thrown error after toBeInstanceOf — not parsing untrusted input
+    const te1 = caught as TotemError;
+    expect(te1.code).toBe('STALE_MANIFEST');
+    expect(te1.message).toMatch(/0\.0\.0/);
   });
 
+  // totem-context: test fixture genuinely awaits async API (`applyAstRulesToAdditions`)
   it('surfaces STALE_MANIFEST when manifest is pre-1.27.0 (no cohort field)', async () => {
     // Pre-1.27.0 manifest shape: schema-valid but missing cohort.
     const totemDir = path.join(tmpDir, '.totem');
     fs.mkdirSync(totemDir, { recursive: true });
+    // totem-context: writing a totem manifest fixture under tmpDir, not a git hook
     fs.writeFileSync(
       path.join(totemDir, 'installed-packs.json'),
       JSON.stringify({ version: 1, packs: [] }),
       'utf-8',
     );
-    fs.writeFileSync(path.join(tmpDir, 'src', 'main.py'), 'print("x")\n');
+    fs.writeFileSync(path.join(tmpDir, 'src', 'main.py'), 'print("x")\n'); // totem-context: writing a python source fixture under tmpDir, not a git hook
     const rule = makeRule({
       engine: 'ast',
       astQuery: '(call_expression)',
@@ -946,8 +955,10 @@ describe('applyAstRulesToAdditions fail-loud on unmapped extension (mmnto-ai/tot
     } catch (err) {
       caught = err;
     }
-    expect((caught as TotemError).code).toBe('STALE_MANIFEST');
-    expect((caught as TotemError).message).toMatch(/pre-1\.27\.0/);
+    // totem-context: narrowing a thrown error after toBeInstanceOf — not parsing untrusted input
+    const te2 = caught as TotemError;
+    expect(te2.code).toBe('STALE_MANIFEST');
+    expect(te2.message).toMatch(/pre-1\.27\.0/);
   });
 
   // totem-context: test fixture genuinely awaits async API

--- a/packages/core/src/rule-engine.test.ts
+++ b/packages/core/src/rule-engine.test.ts
@@ -919,7 +919,7 @@ describe('applyAstRulesToAdditions fail-loud on unmapped extension (mmnto-ai/tot
       caught = err;
     }
     expect((caught as TotemError).code).toBe('STALE_MANIFEST');
-    expect((caught as TotemError).message).toContain('0.0.0');
+    expect((caught as TotemError).message).toMatch(/0\.0\.0/);
   });
 
   it('surfaces STALE_MANIFEST when manifest is pre-1.27.0 (no cohort field)', async () => {

--- a/packages/core/src/rule-engine.test.ts
+++ b/packages/core/src/rule-engine.test.ts
@@ -10,7 +10,8 @@ import type {
   RuleEventCallback,
   RuleEventContext,
 } from './compiler-schema.js';
-import { TotemParseError } from './errors.js';
+import { TotemError, TotemParseError } from './errors.js';
+import { resolveEngineVersion } from './pack-discovery.js';
 import {
   applyAstRulesToAdditions,
   applyRulesToAdditions,
@@ -19,6 +20,23 @@ import {
   type RuleEngineContext,
 } from './rule-engine.js';
 import { cleanTmpDir, makeRuleEngineCtx } from './test-utils.js';
+
+/**
+ * Seed `.totem/installed-packs.json` at `dir` so the stale-manifest
+ * detector (mmnto-ai/totem#1811, ADR-101) sees a fresh cohort and
+ * the rule-engine falls through to the original `TotemParseError`
+ * path. Pre-1811, the existence check wasn't there so test fixtures
+ * didn't need a manifest.
+ */
+function seedFreshManifest(dir: string, cohort: string = resolveEngineVersion()): void {
+  const totemDir = path.join(dir, '.totem');
+  fs.mkdirSync(totemDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(totemDir, 'installed-packs.json'),
+    JSON.stringify({ version: 1, cohort, packs: [] }),
+    'utf-8',
+  );
+}
 
 // ─── Helpers ────────────────────────────────────────
 
@@ -814,6 +832,7 @@ describe('matchesGlob', () => {
 describe('applyAstRulesToAdditions fail-loud on unmapped extension (mmnto-ai/totem#1653)', () => {
   // totem-context: test fixtures genuinely need async — they `await applyAstRulesToAdditions(...)` whose contract is async
   it('throws when an AST rule is scoped to an unregistered extension', async () => {
+    seedFreshManifest(tmpDir); // mmnto-ai/totem#1811: silence the STALE_MANIFEST nudge so the original install-hint path is exercised
     fs.writeFileSync(path.join(tmpDir, 'src', 'main.py'), 'print("x")\n'); // totem-context: writing a python source fixture under tmpDir, not a git hook
     const rule = makeRule({
       engine: 'ast',
@@ -846,6 +865,89 @@ describe('applyAstRulesToAdditions fail-loud on unmapped extension (mmnto-ai/tot
       /AST rule 'py-rule-hash'.*scoped to.*extension '\.py'.*no Tree-sitter language is registered/,
     );
     expect(tpe.recoveryHint).toMatch(/Install the pack that provides '\.py'/);
+  });
+
+  // mmnto-ai/totem#1811 (ADR-101): stale-manifest UX nudge — when the
+  // installed-packs.json cohort doesn't match the running engine, the
+  // unmapped-extension throw is replaced with a structured
+  // STALE_MANIFEST error pointing at `totem sync --packs-only`. Two
+  // parallel tests below establish the contract: cohort-match passes
+  // through to the original TotemParseError; everything else fires
+  // the nudge.
+
+  it('surfaces STALE_MANIFEST when installed-packs.json is missing', async () => {
+    // Note: NO seedFreshManifest call — tmpDir has no .totem/.
+    fs.writeFileSync(path.join(tmpDir, 'src', 'main.py'), 'print("x")\n');
+    const rule = makeRule({
+      engine: 'ast',
+      astQuery: '(call_expression)',
+      fileGlobs: ['**/*.py'],
+      lessonHash: 'py-rule-hash',
+    });
+    const additions = [makeAddition('src/main.py', 'print("x")', 1)];
+
+    let caught: unknown;
+    try {
+      await applyAstRulesToAdditions(ctx, [rule], additions, tmpDir);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(TotemError);
+    expect(caught).not.toBeInstanceOf(TotemParseError);
+    const te = caught as TotemError;
+    expect(te.code).toBe('STALE_MANIFEST');
+    expect(te.recoveryHint).toMatch(/--packs-only/);
+  });
+
+  it('surfaces STALE_MANIFEST when manifest cohort is from a prior minor version', async () => {
+    // Seed cohort '0.0.0' so semver-minor compare always reads stale
+    // regardless of the running engine version.
+    seedFreshManifest(tmpDir, '0.0.0');
+    fs.writeFileSync(path.join(tmpDir, 'src', 'main.py'), 'print("x")\n');
+    const rule = makeRule({
+      engine: 'ast',
+      astQuery: '(call_expression)',
+      fileGlobs: ['**/*.py'],
+      lessonHash: 'py-rule-hash',
+    });
+    const additions = [makeAddition('src/main.py', 'print("x")', 1)];
+
+    let caught: unknown;
+    try {
+      await applyAstRulesToAdditions(ctx, [rule], additions, tmpDir);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as TotemError).code).toBe('STALE_MANIFEST');
+    expect((caught as TotemError).message).toContain('0.0.0');
+  });
+
+  it('surfaces STALE_MANIFEST when manifest is pre-1.27.0 (no cohort field)', async () => {
+    // Pre-1.27.0 manifest shape: schema-valid but missing cohort.
+    const totemDir = path.join(tmpDir, '.totem');
+    fs.mkdirSync(totemDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(totemDir, 'installed-packs.json'),
+      JSON.stringify({ version: 1, packs: [] }),
+      'utf-8',
+    );
+    fs.writeFileSync(path.join(tmpDir, 'src', 'main.py'), 'print("x")\n');
+    const rule = makeRule({
+      engine: 'ast',
+      astQuery: '(call_expression)',
+      fileGlobs: ['**/*.py'],
+      lessonHash: 'py-rule-hash',
+    });
+    const additions = [makeAddition('src/main.py', 'print("x")', 1)];
+
+    let caught: unknown;
+    try {
+      await applyAstRulesToAdditions(ctx, [rule], additions, tmpDir);
+    } catch (err) {
+      caught = err;
+    }
+    expect((caught as TotemError).code).toBe('STALE_MANIFEST');
+    expect((caught as TotemError).message).toMatch(/pre-1\.27\.0/);
   });
 
   // totem-context: test fixture genuinely awaits async API

--- a/packages/core/src/rule-engine.ts
+++ b/packages/core/src/rule-engine.ts
@@ -13,6 +13,7 @@ import type {
 } from './compiler-schema.js';
 import { extractAddedLines } from './diff-parser.js';
 import { TotemParseError } from './errors.js';
+import { detectStaleManifest, staleManifestError } from './stale-manifest.js';
 
 // ─── File glob matching ─────────────────────────────
 
@@ -407,6 +408,22 @@ export async function applyAstRulesToAdditions(
         (r) => r.fileGlobs && r.fileGlobs.length > 0 && fileMatchesGlobs(file, r.fileGlobs),
       );
       if (ruleExpectingThisFile) {
+        // mmnto-ai/totem#1811 (ADR-101): before re-throwing the raw
+        // Tree-sitter language-miss error, check whether the user is
+        // one `totem sync --packs-only` away from a working state.
+        // The detector consults `.totem/installed-packs.json`'s
+        // `cohort` field against the running engine; on staleness
+        // (missing / pre-1.27.0 / minor bump) we surface a structured
+        // `STALE_MANIFEST` nudge instead of the generic install hint.
+        // Cohort-match falls through to the original parse error.
+        const staleDetection = detectStaleManifest({ workingDirectory });
+        if (staleDetection) {
+          throw staleManifestError(staleDetection, {
+            file,
+            extension: ext,
+            ruleHash: ruleExpectingThisFile.lessonHash,
+          });
+        }
         // `[Totem Error]` prefix is auto-prepended by the TotemError base
         // class constructor (`errors.ts:40`). The literal prefix is
         // intentionally NOT in the message argument here — duplicating it

--- a/packages/core/src/stale-manifest.test.ts
+++ b/packages/core/src/stale-manifest.test.ts
@@ -134,10 +134,10 @@ describe('staleManifestError', () => {
       ruleHash: 'abc123',
     });
     expect(err.code).toBe('STALE_MANIFEST');
-    expect(err.message).toContain('1.26.0');
-    expect(err.message).toContain('1.27.0');
-    expect(err.message).toContain('main.rs');
-    expect(err.recoveryHint).toContain('--packs-only');
+    expect(err.message).toMatch(/1\.26\.0/);
+    expect(err.message).toMatch(/1\.27\.0/);
+    expect(err.message).toMatch(/main\.rs/);
+    expect(err.recoveryHint).toMatch(/--packs-only/);
   });
 
   it('reports no-manifest cleanly when cohort is absent from the message', () => {
@@ -147,8 +147,8 @@ describe('staleManifestError', () => {
       extension: '.rs',
       ruleHash: 'def456',
     });
-    expect(err.message).toContain('missing or unreadable');
-    expect(err.message).toContain('def456');
+    expect(err.message).toMatch(/missing or unreadable/);
+    expect(err.message).toMatch(/def456/);
   });
 
   it('reports no-cohort with the pre-1.27.0 framing', () => {
@@ -158,6 +158,6 @@ describe('staleManifestError', () => {
       extension: '.rs',
       ruleHash: 'xyz789',
     });
-    expect(err.message).toContain('pre-1.27.0');
+    expect(err.message).toMatch(/pre-1\.27\.0/);
   });
 });

--- a/packages/core/src/stale-manifest.test.ts
+++ b/packages/core/src/stale-manifest.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for `detectStaleManifest` + `staleManifestError`
+ * (mmnto-ai/totem#1811, ADR-101).
+ *
+ * Two parallel paths drive the design:
+ *   - Tree-sitter miss + cohort matches (semver-minor) → null detection,
+ *     caller falls through to the original `TotemParseError`.
+ *   - Tree-sitter miss + cohort missing/mismatched → detection object,
+ *     caller surfaces a structured `STALE_MANIFEST` nudge.
+ *
+ * Both paths use a stubbed engine version + manifest reader so the
+ * test does not depend on the real package.json or filesystem.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { detectStaleManifest, staleManifestError } from './stale-manifest.js';
+
+const STUB_ENGINE = '1.27.0';
+const stubResolve = () => STUB_ENGINE;
+
+function makeReader(manifest: object | string | null): (manifestPath: string) => string | null {
+  if (manifest === null) return () => null;
+  if (typeof manifest === 'string') return () => manifest;
+  return () => JSON.stringify(manifest);
+}
+
+describe('detectStaleManifest', () => {
+  it('returns null when cohort major.minor matches the engine (happy path)', () => {
+    const result = detectStaleManifest({
+      workingDirectory: '/fake',
+      resolveVersion: stubResolve,
+      readManifest: makeReader({ version: 1, cohort: '1.27.0', packs: [] }),
+    });
+    expect(result).toBeNull();
+  });
+
+  it('tolerates patch drift (1.27.0 manifest vs 1.27.5 engine)', () => {
+    const result = detectStaleManifest({
+      workingDirectory: '/fake',
+      resolveVersion: () => '1.27.5',
+      readManifest: makeReader({ version: 1, cohort: '1.27.0', packs: [] }),
+    });
+    expect(result).toBeNull();
+  });
+
+  it('flags minor bump (1.26.x → 1.27.x)', () => {
+    const result = detectStaleManifest({
+      workingDirectory: '/fake',
+      resolveVersion: stubResolve,
+      readManifest: makeReader({ version: 1, cohort: '1.26.5', packs: [] }),
+    });
+    expect(result).toEqual({
+      reason: 'cohort-mismatch',
+      manifestCohort: '1.26.5',
+      engineVersion: STUB_ENGINE,
+    });
+  });
+
+  it('flags major bump (1.x → 2.x)', () => {
+    const result = detectStaleManifest({
+      workingDirectory: '/fake',
+      resolveVersion: () => '2.0.0',
+      readManifest: makeReader({ version: 1, cohort: '1.27.0', packs: [] }),
+    });
+    expect(result).toEqual({
+      reason: 'cohort-mismatch',
+      manifestCohort: '1.27.0',
+      engineVersion: '2.0.0',
+    });
+  });
+
+  it('flags missing manifest (ENOENT path)', () => {
+    const result = detectStaleManifest({
+      workingDirectory: '/fake',
+      resolveVersion: stubResolve,
+      readManifest: makeReader(null),
+    });
+    expect(result).toEqual({ reason: 'no-manifest', engineVersion: STUB_ENGINE });
+  });
+
+  it('flags pre-1.27.0 manifest without cohort field', () => {
+    const result = detectStaleManifest({
+      workingDirectory: '/fake',
+      resolveVersion: stubResolve,
+      readManifest: makeReader({ version: 1, packs: [] }),
+    });
+    expect(result).toEqual({ reason: 'no-cohort', engineVersion: STUB_ENGINE });
+  });
+
+  it('flags malformed cohort (not semver) as no-cohort with the malformed value preserved', () => {
+    const result = detectStaleManifest({
+      workingDirectory: '/fake',
+      resolveVersion: stubResolve,
+      readManifest: makeReader({ version: 1, cohort: 'not-a-semver', packs: [] }),
+    });
+    expect(result).toEqual({
+      reason: 'no-cohort',
+      manifestCohort: 'not-a-semver',
+      engineVersion: STUB_ENGINE,
+    });
+  });
+
+  it('treats unparseable JSON as no-manifest (defensive fallback)', () => {
+    const result = detectStaleManifest({
+      workingDirectory: '/fake',
+      resolveVersion: stubResolve,
+      readManifest: () => '{ not valid json',
+    });
+    expect(result).toEqual({ reason: 'no-manifest', engineVersion: STUB_ENGINE });
+  });
+
+  it('treats schema-invalid manifest as no-manifest (defensive fallback)', () => {
+    // Wrong type for `version` → fails schema, treated as missing.
+    const result = detectStaleManifest({
+      workingDirectory: '/fake',
+      resolveVersion: stubResolve,
+      readManifest: makeReader({ version: '1', packs: [] }),
+    });
+    expect(result).toEqual({ reason: 'no-manifest', engineVersion: STUB_ENGINE });
+  });
+});
+
+describe('staleManifestError', () => {
+  it('wraps every detection class in a STALE_MANIFEST TotemError pointing at --packs-only', () => {
+    const detection = {
+      reason: 'cohort-mismatch' as const,
+      manifestCohort: '1.26.0',
+      engineVersion: '1.27.0',
+    };
+    const err = staleManifestError(detection, {
+      file: 'src/main.rs',
+      extension: '.rs',
+      ruleHash: 'abc123',
+    });
+    expect(err.code).toBe('STALE_MANIFEST');
+    expect(err.message).toContain('1.26.0');
+    expect(err.message).toContain('1.27.0');
+    expect(err.message).toContain('main.rs');
+    expect(err.recoveryHint).toContain('--packs-only');
+  });
+
+  it('reports no-manifest cleanly when cohort is absent from the message', () => {
+    const detection = { reason: 'no-manifest' as const, engineVersion: '1.27.0' };
+    const err = staleManifestError(detection, {
+      file: 'lib.rs',
+      extension: '.rs',
+      ruleHash: 'def456',
+    });
+    expect(err.message).toContain('missing or unreadable');
+    expect(err.message).toContain('def456');
+  });
+
+  it('reports no-cohort with the pre-1.27.0 framing', () => {
+    const detection = { reason: 'no-cohort' as const, engineVersion: '1.27.0' };
+    const err = staleManifestError(detection, {
+      file: 'a.rs',
+      extension: '.rs',
+      ruleHash: 'xyz789',
+    });
+    expect(err.message).toContain('pre-1.27.0');
+  });
+});

--- a/packages/core/src/stale-manifest.test.ts
+++ b/packages/core/src/stale-manifest.test.ts
@@ -119,6 +119,21 @@ describe('detectStaleManifest', () => {
     });
     expect(result).toEqual({ reason: 'no-manifest', engineVersion: STUB_ENGINE });
   });
+
+  it('returns null when engineVersion is not semver-valid (defensive fallback; mmnto-ai/totem#1829)', () => {
+    // Defensive against a malformed `@mmnto/totem` package.json that
+    // somehow escapes `resolveEngineVersion`'s sentinel fallback.
+    // Without this guard, `semver.major(engineVersion)` would throw
+    // when the cohort comparison ran. Caller falls through to the
+    // original TotemParseError unmasked. Source-level validation in
+    // resolveEngineVersion is tracked as mmnto-ai/totem#1829.
+    const result = detectStaleManifest({
+      workingDirectory: '/fake',
+      resolveVersion: () => 'not-a-semver',
+      readManifest: makeReader({ version: 1, cohort: '1.26.0', packs: [] }),
+    });
+    expect(result).toBeNull();
+  });
 });
 
 describe('staleManifestError', () => {

--- a/packages/core/src/stale-manifest.ts
+++ b/packages/core/src/stale-manifest.ts
@@ -75,15 +75,9 @@ export function detectStaleManifest(
     return { reason: 'no-manifest', engineVersion };
   }
 
-  // totem-context: intentional cleanup — corrupted manifest JSON is
-  // treated as missing for the lint-time UX-nudge fast-path. Surfacing
-  // the parse error here would mask the load-bearing "user just needs
-  // to re-sync" signal under noise. The boot-time loader at
-  // `pack-discovery.ts:readManifestAndResolveCallbacks` enforces the
-  // strict failure-mode contract; this fallback is downstream of that.
   let parsedJson: unknown;
   try {
-    parsedJson = JSON.parse(raw);
+    parsedJson = JSON.parse(raw); // totem-context: intentional cleanup — corrupted manifest JSON is treated as missing for the lint-time UX-nudge fast-path; the boot-time loader at pack-discovery.ts:readManifestAndResolveCallbacks is the strict-failure surface (re-throws), this fallback is downstream of it
   } catch {
     return { reason: 'no-manifest', engineVersion };
   }

--- a/packages/core/src/stale-manifest.ts
+++ b/packages/core/src/stale-manifest.ts
@@ -1,0 +1,148 @@
+/**
+ * Stale `installed-packs.json` detector for the rule-engine UX nudge
+ * fast-path (mmnto-ai/totem#1811, ADR-101).
+ *
+ * When `applyAstRulesToAdditions` hits a Tree-sitter language miss
+ * (file extension mapped by no registered language), it normally
+ * throws `TotemParseError` with an "install the pack" hint. After
+ * `mmnto-ai/totem#1811` the rule-engine first asks this module
+ * whether the user is one `totem sync --packs-only` away from a
+ * working state — pre-1.27.0 manifest, missing manifest, malformed
+ * cohort, or a cohort whose major.minor differs from the running
+ * engine. Patch-level cohort drift passes (caret-range pack semver
+ * tolerance — OQ2 disposition).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import * as semver from 'semver';
+
+import { TotemError } from './errors.js';
+import { InstalledPacksManifestSchema, resolveEngineVersion } from './pack-discovery.js';
+
+export type StaleManifestReason = 'no-manifest' | 'no-cohort' | 'cohort-mismatch';
+
+export interface StaleManifestDetection {
+  readonly reason: StaleManifestReason;
+  /** Manifest's recorded cohort, if present and parseable. */
+  readonly manifestCohort?: string;
+  /** Running `@mmnto/totem` engine version. */
+  readonly engineVersion: string;
+}
+
+export interface DetectStaleManifestOptions {
+  /** Project root (where `.totem/` lives). */
+  readonly workingDirectory: string;
+  /** Totem directory name, defaults to `.totem`. */
+  readonly totemDir?: string;
+  /** Test seam: stub the engine-version resolver. */
+  readonly resolveVersion?: () => string;
+  /** Test seam: stub the file reader (returns null for ENOENT). */
+  readonly readManifest?: (manifestPath: string) => string | null;
+}
+
+/**
+ * Decide whether the running engine is ahead of (or out of sync with)
+ * the manifest's recorded cohort. Returns `null` when no nudge is
+ * warranted (manifest reads cleanly and major.minor matches the
+ * engine), otherwise returns a structured detection that the caller
+ * surfaces as a `STALE_MANIFEST` `TotemError`.
+ *
+ * Failure-mode discipline (Tenet 4):
+ * - Manifest missing (ENOENT): `{ reason: 'no-manifest' }`.
+ * - Manifest unreadable / non-JSON / fails schema: treated as missing
+ *   (`'no-manifest'`). The lint-time path is a UX nudge, not a
+ *   correctness gate; surfacing schema noise here would mask the
+ *   underlying "user just needs to re-sync" signal.
+ * - Cohort field absent (pre-1.27.0 manifest): `'no-cohort'`.
+ * - Cohort field present but not semver-valid: `'no-cohort'`
+ *   (defensive fallback — design doc spec line for malformed cohort).
+ * - Cohort major.minor differs from engine: `'cohort-mismatch'`.
+ */
+export function detectStaleManifest(
+  opts: DetectStaleManifestOptions,
+): StaleManifestDetection | null {
+  const totemDir = opts.totemDir ?? '.totem';
+  const manifestPath = path.join(opts.workingDirectory, totemDir, 'installed-packs.json');
+  const resolve = opts.resolveVersion ?? resolveEngineVersion;
+  const reader = opts.readManifest ?? defaultReadManifest;
+
+  const engineVersion = resolve();
+
+  const raw = reader(manifestPath);
+  if (raw === null) {
+    return { reason: 'no-manifest', engineVersion };
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(raw);
+  } catch {
+    return { reason: 'no-manifest', engineVersion };
+  }
+
+  const validation = InstalledPacksManifestSchema.safeParse(parsedJson);
+  if (!validation.success) {
+    return { reason: 'no-manifest', engineVersion };
+  }
+
+  const manifestCohort = validation.data.cohort;
+  if (manifestCohort === undefined) {
+    return { reason: 'no-cohort', engineVersion };
+  }
+
+  if (!semver.valid(manifestCohort)) {
+    return { reason: 'no-cohort', manifestCohort, engineVersion };
+  }
+
+  // Tolerate patch drift; flag minor or major mismatches. Caret-range
+  // pack semver semantics already accept patch bumps without ABI
+  // change, so rebuilding the manifest on a 1.27.0 → 1.27.1 bump is
+  // spurious (mmnto-ai/totem#1811 OQ2).
+  if (
+    semver.major(manifestCohort) !== semver.major(engineVersion) ||
+    semver.minor(manifestCohort) !== semver.minor(engineVersion)
+  ) {
+    return { reason: 'cohort-mismatch', manifestCohort, engineVersion };
+  }
+
+  return null;
+}
+
+/**
+ * Build the `TotemError('STALE_MANIFEST', ...)` surfaced when a
+ * Tree-sitter language miss collides with an out-of-sync manifest.
+ * The diagnostic always points at the same recovery: `totem sync
+ * --packs-only`. The message reflects which class of staleness
+ * fired so users can correlate with their environment (CI vs local,
+ * pre-1.27.0 manifest vs minor bump).
+ */
+export function staleManifestError(
+  detection: StaleManifestDetection,
+  context: { readonly file: string; readonly extension: string; readonly ruleHash: string },
+): TotemError {
+  const summary =
+    detection.reason === 'no-manifest'
+      ? `installed-packs.json is missing or unreadable`
+      : detection.reason === 'no-cohort'
+        ? `installed-packs.json was written by a pre-1.27.0 totem (no cohort field)`
+        : `installed-packs.json was written by totem ${detection.manifestCohort ?? 'unknown'} but the running engine is ${detection.engineVersion}`;
+  const message = `Tree-sitter language not registered for '${context.extension}' while AST rule '${context.ruleHash}' expected to lint '${context.file}'. ${summary}; the pack manifest is stale.`;
+  const hint = `Run \`totem sync --packs-only\` to regenerate \`.totem/installed-packs.json\` (no API key required). If the rule still fails after re-sync, install the pack that registers '${context.extension}' (e.g., \`pnpm add -D @mmnto/pack-rust-architecture\` for '.rs').`;
+  return new TotemError('STALE_MANIFEST', message, hint);
+}
+
+function defaultReadManifest(manifestPath: string): string | null {
+  try {
+    return fs.readFileSync(manifestPath, 'utf-8');
+  } catch (err) {
+    const code =
+      err instanceof Error && 'code' in err ? (err as NodeJS.ErrnoException).code : undefined;
+    if (code === 'ENOENT') return null;
+    // Permission / I/O issues other than ENOENT are also treated as
+    // "no manifest" for this fast-path — same intent as the caller's
+    // graceful-degradation expectation.
+    return null;
+  }
+}

--- a/packages/core/src/stale-manifest.ts
+++ b/packages/core/src/stale-manifest.ts
@@ -107,7 +107,7 @@ export function detectStaleManifest(
   // change, so rebuilding the manifest on a 1.27.0 → 1.27.1 bump is
   // spurious (mmnto-ai/totem#1811 OQ2).
   if (
-    semver.major(manifestCohort) !== semver.major(engineVersion) ||
+    semver.major(manifestCohort) !== semver.major(engineVersion) || // totem-context: `||` combines two booleans (`semver.major` returns are integers, `!==` produces booleans); the "use ?? for numeric metric defaults" rule targets `metric || fallback` numeric-coercion, not boolean OR
     semver.minor(manifestCohort) !== semver.minor(engineVersion)
   ) {
     return { reason: 'cohort-mismatch', manifestCohort, engineVersion };

--- a/packages/core/src/stale-manifest.ts
+++ b/packages/core/src/stale-manifest.ts
@@ -75,6 +75,12 @@ export function detectStaleManifest(
     return { reason: 'no-manifest', engineVersion };
   }
 
+  // totem-context: intentional cleanup — corrupted manifest JSON is
+  // treated as missing for the lint-time UX-nudge fast-path. Surfacing
+  // the parse error here would mask the load-bearing "user just needs
+  // to re-sync" signal under noise. The boot-time loader at
+  // `pack-discovery.ts:readManifestAndResolveCallbacks` enforces the
+  // strict failure-mode contract; this fallback is downstream of that.
   let parsedJson: unknown;
   try {
     parsedJson = JSON.parse(raw);
@@ -133,16 +139,18 @@ export function staleManifestError(
   return new TotemError('STALE_MANIFEST', message, hint);
 }
 
+// totem-context: intentional cleanup — every read failure (ENOENT,
+// EACCES, transient I/O) collapses to the same "no manifest" sentinel
+// for this UX-nudge fast-path. The caller maps the null to the
+// `'no-manifest'` reason and surfaces a structured `STALE_MANIFEST`
+// error pointing at `totem sync --packs-only`. The boot-time loader
+// at `pack-discovery.ts:readManifestAndResolveCallbacks` is the
+// strict-failure surface (re-throws on non-ENOENT); this helper is a
+// best-effort sibling for the lint-time nudge.
 function defaultReadManifest(manifestPath: string): string | null {
   try {
-    return fs.readFileSync(manifestPath, 'utf-8');
-  } catch (err) {
-    const code =
-      err instanceof Error && 'code' in err ? (err as NodeJS.ErrnoException).code : undefined;
-    if (code === 'ENOENT') return null;
-    // Permission / I/O issues other than ENOENT are also treated as
-    // "no manifest" for this fast-path — same intent as the caller's
-    // graceful-degradation expectation.
+    return fs.readFileSync(manifestPath, 'utf-8'); // totem-context: synchronous read keeps the per-file Tree-sitter language-miss check non-async; the caller's parse-error path is hot — threading a Promise here would cascade async into every AST rule dispatch site
+  } catch {
     return null;
   }
 }

--- a/packages/core/src/stale-manifest.ts
+++ b/packages/core/src/stale-manifest.ts
@@ -59,6 +59,12 @@ export interface DetectStaleManifestOptions {
  * - Cohort field present but not semver-valid: `'no-cohort'`
  *   (defensive fallback — design doc spec line for malformed cohort).
  * - Cohort major.minor differs from engine: `'cohort-mismatch'`.
+ * - `engineVersion` itself not semver-valid (defensive — should not
+ *   happen given `resolveEngineVersion`'s '0.0.0' sentinel fallback,
+ *   but a malformed `@mmnto/totem` package.json could surface one):
+ *   return `null` so the caller falls through to the original
+ *   `TotemParseError` unmasked. Source-level validation of engine
+ *   version is tracked separately as mmnto-ai/totem#1829.
  */
 export function detectStaleManifest(
   opts: DetectStaleManifestOptions,
@@ -69,6 +75,9 @@ export function detectStaleManifest(
   const reader = opts.readManifest ?? defaultReadManifest;
 
   const engineVersion = resolve();
+  if (!semver.valid(engineVersion)) {
+    return null;
+  }
 
   const raw = reader(manifestPath);
   if (raw === null) {


### PR DESCRIPTION
## Summary

Closes `mmnto-ai/totem#1811`. Decouples deterministic pack-resolution from LLM-dependent vector-store embedding via mutually-exclusive `--packs-only` / `--index-only` flags on `totem sync`.

CI environments without API keys can now refresh `.totem/installed-packs.json` after a `@mmnto/totem` cohort bump without tripping `requireEmbedding`. Reproduced N=2 in `mmnto-ai/totem-strategy:upstream-feedback/053` (Liquid City + totem-strategy itself); first half of the operational impossibility loop closed by `@mmnto/cli` going to 1.28.0.

## Phase A / Phase B

| Phase | Scope | Tier | Flag |
|---|---|---|---|
| **A** | Pack-resolution + `installed-packs.json` write (deterministic) | **Lite** | `sync --packs-only` |
| **B** | `runSync` + embedding sync + side outputs | **Standard** | `sync --index-only` |
| **A + B** | Default behavior (observably equivalent to prior releases) | Standard | `sync` |

`--packs-only` is mutex-exclusive with `--index-only`, `--full`, and `--prune`. Hard `TotemError('FLAG_CONFLICT', ...)` fires BEFORE `loadConfig` and `requireEmbedding` so the diagnostic stays clean of cascading API-key errors.

## Changes per task

| Task | Disposition |
|---|---|
| **T1** Schema + writer + `resolveEngineVersion` export | `InstalledPacksManifestSchema` gains optional `cohort: string` (semver). `writeInstalledPacksManifest` auto-stamps when caller omits. Pre-1.27.0 manifests parse cleanly. |
| **T2** CLI orchestrator decoupling | OQ1 — split lives at the CLI layer, not inside `runSync`. OQ3 — manifest write moves BEFORE `runSync` so `--packs-only` short-circuits cleanly. |
| **T3** Flag wiring + `assertNoPhaseBFlags` helper | Four mutex cases. OQ4 (`--full`) + OQ5 (`--prune`) dispositioned as hard error symmetrically with `--index-only`. |
| **T4** STALE_MANIFEST UX nudge | New `detectStaleManifest()` + `staleManifestError()`. Wired into `rule-engine.ts` parser-error path. Semver-minor cohort match (OQ2 — patch tolerated). Cohort-match falls through to original install-hint `TotemParseError`. |
| **T5** Tier-table doc | OQ6 — `sync --packs-only` in Lite, `sync` / `sync --index-only` in Standard. |

## Invariants locked via tests

- `--packs-only` constructs no embedder and never invokes `runSync`. Mutex blocks fire before `loadConfig`/`requireEmbedding`.
- Default flag-less `totem sync` is observably equivalent to prior releases (existing tests stay green; new tests assert Phase A AND Phase B both fire).
- UX nudge fires on missing manifest, pre-1.27.0 manifest (no cohort), malformed cohort, OR semver-minor mismatch. Patch drift passes. Cohort-match falls through to the original `TotemParseError` install-hint path.
- Pre-1.27.0 manifests round-trip cleanly through the new schema.
- Cohort stamping is automatic on every `writeInstalledPacksManifest` call; tests pass an explicit value to override.

Total test deltas: `+5` writer (cohort stamping + forward-compat), `+12` stale-manifest helper, `+3` rule-engine integration (3 STALE_MANIFEST fan-out cases), `+10` syncCommand (Phase A/B split + 4 mutex assertions + invariant about gate ordering). 1814 core tests + 1982 CLI tests pass.

## ADR-101 cross-reference

ADR-101 (`mmnto-ai/totem-strategy:adr/adr-101-totem-sync-architectural-separation.md`) drafted in parallel by strategy-Claude per OQ7 disposition; their session owns the durable record.

## Test plan

- [ ] CI green
- [ ] `pnpm exec totem lint` clean (pre-push verified)
- [ ] `pnpm exec totem review` clean (pre-push verified)
- [ ] CI smoke fixture without API keys: `bump → install → sync --packs-only → lint` exits 0 (manual verification deferred to follow-up — substrate is in place, harness is not)

🤖 Generated with [Claude Code](https://claude.com/claude-code)