### PR TITLE
fix(core): index-manifest writer Tenet 14 + identity-branch fix-forward

### DIFF
--- a/.changeset/index-manifest-writer.md
+++ b/.changeset/index-manifest-writer.md
@@ -1,0 +1,17 @@
+---
+'@mmnto/totem': minor
+---
+
+`totem sync` now writes `.totem/index-manifest.json` for downstream consumers (e.g., the
+`totem-status` Visor TUI), avoiding the need for those consumers to pull massive
+LanceDB CGO/Rust bindings just to enumerate indexed-document metadata.
+
+The manifest schema is `totem-index-manifest-v0.2`. Each `documents[]` entry exposes
+`sourceFile`, `origin` (derived structurally from `node_modules/<pkg>` paths, otherwise
+`local`), `rowCount`, and `lastSynced`. When the project is a git checkout, an optional
+`gitCommit: 'git:<sha>'` field records provenance; the field is omitted when no git
+SHA is available (no synthesized fake-presence values).
+
+New public API: `buildIndexManifest`, `INDEX_MANIFEST_SCHEMA`, `IndexManifest`,
+`ManifestDocument`, and `LanceStore.manifestDocuments()`. The manifest file is
+gitignored.

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ packages/pack-rust-architecture/tree-sitter-rust.wasm
 .totem/.search-called
 .totem/review-extensions.txt
 .totem/installed-packs.json
+.totem/index-manifest.json
 
 # Local scratchpad (personal scratch files go here, not in root)
 scratchpad/

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -131,10 +131,12 @@ export { TOTEM_TABLE_NAME } from './store/lance-schema.js';
 export { LanceStore } from './store/lance-store.js';
 
 // Pipeline
-export type { ResolvedFile } from './ingest/sync.js';
+export type { IndexManifest, ManifestDocument, ResolvedFile } from './ingest/sync.js';
 export {
+  buildIndexManifest,
   getChangedFiles,
   getHeadSha,
+  INDEX_MANIFEST_SCHEMA,
   resolveFiles,
   runSync,
   verifyIndexMeta,

--- a/packages/core/src/ingest/pipeline.test.ts
+++ b/packages/core/src/ingest/pipeline.test.ts
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { TotemConfig } from '../config-schema.js';
 import { TotemConfigSchema } from '../config-schema.js';
 import { cleanTmpDir } from '../test-utils.js';
-import { runSync } from './pipeline.js';
+import { buildIndexManifest, INDEX_MANIFEST_SCHEMA, runSync } from './pipeline.js';
 
 // Import the internal helpers via a workaround — we test the state file contract
 // since readSyncState/writeSyncState are not exported directly.
@@ -114,5 +114,62 @@ describe('runSync embedding guard', () => {
     await expect(runSync(config, { projectRoot: os.tmpdir(), incremental: false })).rejects.toThrow(
       'No embedding provider configured',
     );
+  });
+});
+
+describe('buildIndexManifest', () => {
+  const writtenAt = new Date('2026-05-07T00:00:00.000Z');
+  const docs = [
+    {
+      sourceFile: 'src/a.ts',
+      origin: 'local',
+      rowCount: 3,
+      lastSynced: '2026-05-07T00:00:00.000Z',
+    },
+  ];
+
+  it('writes the v0.2 schema identifier', () => {
+    const m = buildIndexManifest({ documents: docs, headSha: 'abc123', writtenAt });
+    expect(m.schema).toBe('totem-index-manifest-v0.2');
+    expect(INDEX_MANIFEST_SCHEMA).toBe('totem-index-manifest-v0.2');
+  });
+
+  it('includes documents array verbatim', () => {
+    const m = buildIndexManifest({ documents: docs, headSha: 'abc123', writtenAt });
+    expect(m.documents).toEqual(docs);
+  });
+
+  it('serializes writtenAt as an ISO timestamp', () => {
+    const m = buildIndexManifest({ documents: docs, headSha: 'abc123', writtenAt });
+    expect(m.writtenAt).toBe('2026-05-07T00:00:00.000Z');
+  });
+
+  it('emits gitCommit with git: prefix when headSha is provided', () => {
+    const m = buildIndexManifest({ documents: docs, headSha: 'abc123def456', writtenAt });
+    expect(m.gitCommit).toBe('git:abc123def456');
+  });
+
+  it('OMITS gitCommit field when headSha is null', () => {
+    const m = buildIndexManifest({ documents: docs, headSha: null, writtenAt });
+    expect(m.gitCommit).toBeUndefined();
+    expect('gitCommit' in m).toBe(false);
+  });
+
+  it('OMITS gitCommit field when headSha is empty string', () => {
+    const m = buildIndexManifest({ documents: docs, headSha: '', writtenAt });
+    expect('gitCommit' in m).toBe(false);
+  });
+
+  it('does not synthesize a fake hash URI on no-git (Tenet 14: honest absence)', () => {
+    const m = buildIndexManifest({ documents: docs, headSha: undefined, writtenAt });
+    const serialized = JSON.stringify(m);
+    expect(serialized).not.toMatch(/sha\d+:unknown/);
+    expect(serialized).not.toMatch(/sha1:/);
+    expect(serialized).not.toMatch(/sha256:/);
+  });
+
+  it('does not label the git commit as indexHash (Tenet 14: identity ≠ content hash)', () => {
+    const m = buildIndexManifest({ documents: docs, headSha: 'abc123', writtenAt });
+    expect('indexHash' in m).toBe(false);
   });
 });

--- a/packages/core/src/ingest/pipeline.ts
+++ b/packages/core/src/ingest/pipeline.ts
@@ -118,6 +118,38 @@ function writeSyncState(totemDir: string, state: SyncState): void {
   fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + '\n', 'utf-8');
 }
 
+export interface ManifestDocument {
+  sourceFile: string;
+  origin: string;
+  rowCount: number;
+  lastSynced: string;
+}
+
+export interface IndexManifest {
+  schema: string;
+  writtenAt: string;
+  documents: ManifestDocument[];
+  gitCommit?: string;
+}
+
+export const INDEX_MANIFEST_SCHEMA = 'totem-index-manifest-v0.2';
+
+export function buildIndexManifest(input: {
+  documents: ManifestDocument[];
+  headSha: string | null | undefined;
+  writtenAt: Date;
+}): IndexManifest {
+  const manifest: IndexManifest = {
+    schema: INDEX_MANIFEST_SCHEMA,
+    writtenAt: input.writtenAt.toISOString(),
+    documents: input.documents,
+  };
+  if (input.headSha) {
+    manifest.gitCommit = `git:${input.headSha}`;
+  }
+  return manifest;
+}
+
 export async function runSync(
   config: TotemConfig,
   options: SyncOptions,
@@ -314,17 +346,11 @@ async function runSyncInner(
   // Persist index manifest for downstream consumers (e.g. totem-status Visor)
   try {
     const docs = await store.manifestDocuments();
-    const manifest = {
-      schema: 'totem-index-manifest-v0.1',
-      writtenAt: new Date().toISOString(),
-      indexHash: headSha ? `sha1:${headSha}` : 'sha1:unknown',
-      documents: docs,
-    };
+    const manifest = buildIndexManifest({ documents: docs, headSha, writtenAt: new Date() });
     const manifestPath = path.join(totemDir, 'index-manifest.json');
     const tmpManifestPath = manifestPath + '.tmp';
-    // totem-ignore
     fs.writeFileSync(tmpManifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');
-    fs.renameSync(tmpManifestPath, manifestPath); // totem-context: intentional cleanup
+    fs.renameSync(tmpManifestPath, manifestPath);
   } catch (err) {
     const detail =
       err instanceof Error ? err.message : typeof err === 'string' ? err : 'unknown error';

--- a/packages/core/src/ingest/pipeline.ts
+++ b/packages/core/src/ingest/pipeline.ts
@@ -386,8 +386,11 @@ async function runSyncInner(
 
   // Persist index manifest for downstream consumers (e.g. totem-status Visor)
   try {
-    const docs = await store.manifestDocuments();
-    const manifest = buildIndexManifest({ documents: docs, headSha, writtenAt: new Date() });
+    // Single timestamp threaded through both manifestDocuments() and buildIndexManifest
+    // so documents[].lastSynced == manifest.writtenAt, per the v0.2 contract.
+    const writtenAt = new Date();
+    const docs = await store.manifestDocuments(writtenAt);
+    const manifest = buildIndexManifest({ documents: docs, headSha, writtenAt });
     const manifestPath = path.join(totemDir, 'index-manifest.json');
     const tmpManifestPath = manifestPath + '.tmp';
     fs.writeFileSync(tmpManifestPath, JSON.stringify(manifest, null, 2) + '\n', 'utf-8');

--- a/packages/core/src/ingest/pipeline.ts
+++ b/packages/core/src/ingest/pipeline.ts
@@ -118,13 +118,40 @@ function writeSyncState(totemDir: string, state: SyncState): void {
   fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + '\n', 'utf-8');
 }
 
+/**
+ * One entry in the index-manifest `documents[]` array.
+ *
+ * `lastSynced` is the time the manifest itself was written, not a per-document
+ * sync timestamp — LanceDB rows do not currently carry per-row sync timestamps,
+ * so every document in a single manifest carries the same `lastSynced` value
+ * (equal to `IndexManifest.writtenAt`). Treat it as a manifest-level signal,
+ * not as per-document staleness data.
+ */
 export interface ManifestDocument {
   sourceFile: string;
+  /**
+   * Pack name (`@scope/pkg` or `pkg`) when the source file lives under
+   * `node_modules/`; otherwise `local`. Derived from path structure only;
+   * never from filename- or path-identity matches.
+   */
   origin: string;
   rowCount: number;
+  /** See `ManifestDocument` doc-comment — this is manifest-write time, not per-doc sync time. */
   lastSynced: string;
 }
 
+/**
+ * Persisted contents of `.totem/index-manifest.json`.
+ *
+ * Schema is versioned via {@link INDEX_MANIFEST_SCHEMA}. Consumers (e.g. the
+ * `totem-status` Visor TUI) read this file to enumerate indexed documents
+ * without needing the LanceDB Go/CGO bindings.
+ *
+ * `gitCommit` carries `git:<sha>` when a HEAD SHA is available at sync time.
+ * The field is OMITTED entirely when no git SHA is available — never
+ * synthesized as a fake-presence value (Tenet 14: honest absence over fake
+ * presence; identity hashes must not masquerade as content hashes).
+ */
 export interface IndexManifest {
   schema: string;
   writtenAt: string;
@@ -132,8 +159,22 @@ export interface IndexManifest {
   gitCommit?: string;
 }
 
+/** Current schema identifier persisted to `.totem/index-manifest.json`. */
 export const INDEX_MANIFEST_SCHEMA = 'totem-index-manifest-v0.2';
 
+/**
+ * Builds an {@link IndexManifest} payload from the per-document data and the
+ * sync run's HEAD SHA + write timestamp.
+ *
+ * - `writtenAt` is serialized to ISO-8601.
+ * - `gitCommit` is included as `git:<sha>` only when `input.headSha` is a
+ *   non-empty string; null / undefined / `''` cause the field to be omitted
+ *   entirely (no `sha1:unknown` or other synthesized fake-presence values).
+ * - `schema` is always set to {@link INDEX_MANIFEST_SCHEMA}.
+ *
+ * Pure helper — does not touch the filesystem. The sync pipeline is
+ * responsible for atomic write/rename of the returned payload.
+ */
 export function buildIndexManifest(input: {
   documents: ManifestDocument[];
   headSha: string | null | undefined;

--- a/packages/core/src/ingest/sync.ts
+++ b/packages/core/src/ingest/sync.ts
@@ -1,3 +1,4 @@
 export type { ResolvedFile } from './file-resolver.js';
 export { getChangedFiles, getHeadSha, resolveFiles } from './file-resolver.js';
-export { runSync, verifyIndexMeta } from './pipeline.js';
+export type { IndexManifest, ManifestDocument } from './pipeline.js';
+export { buildIndexManifest, INDEX_MANIFEST_SCHEMA, runSync, verifyIndexMeta } from './pipeline.js';

--- a/packages/core/src/store/lance-store.test.ts
+++ b/packages/core/src/store/lance-store.test.ts
@@ -546,5 +546,21 @@ describe('LanceStore', () => {
 
       expect(docs[0]?.lastSynced).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
     });
+
+    it('uses the supplied writtenAt for every doc lastSynced (manifest-write invariant)', async () => {
+      await store.insert([
+        makeChunk({ filePath: 'src/a.ts', content: 'a' }),
+        makeChunk({ filePath: 'src/b.ts', content: 'b' }),
+        makeChunk({ filePath: 'src/c.ts', content: 'c' }),
+      ]);
+
+      const writtenAt = new Date('2026-05-07T12:34:56.789Z');
+      const docs = await store.manifestDocuments(writtenAt);
+
+      expect(docs).toHaveLength(3);
+      for (const d of docs) {
+        expect(d.lastSynced).toBe('2026-05-07T12:34:56.789Z');
+      }
+    });
   });
 });

--- a/packages/core/src/store/lance-store.test.ts
+++ b/packages/core/src/store/lance-store.test.ts
@@ -521,6 +521,20 @@ describe('LanceStore', () => {
       expect(docs[0]?.origin).toBe('lodash');
     });
 
+    it('derives origin correctly from Windows-style backslash paths', async () => {
+      await store.insert([
+        makeChunk({ filePath: 'node_modules\\@mmnto\\totem\\dist\\index.js', content: 'x' }),
+        makeChunk({ filePath: 'node_modules\\lodash\\index.js', content: 'y' }),
+      ]);
+
+      const docs = await store.manifestDocuments();
+      const scoped = docs.find((d) => d.sourceFile.includes('@mmnto'));
+      const unscoped = docs.find((d) => d.sourceFile.includes('lodash'));
+
+      expect(scoped?.origin).toBe('@mmnto/totem');
+      expect(unscoped?.origin).toBe('lodash');
+    });
+
     it('does not special-case any specific filename or path identity', async () => {
       // Regression guard: a hardcoded `.totem/lessons` path-identity branch
       // previously existed in the writer (tagged for status-Gemini mock-data

--- a/packages/core/src/store/lance-store.test.ts
+++ b/packages/core/src/store/lance-store.test.ts
@@ -454,4 +454,97 @@ describe('LanceStore', () => {
       expect(result.ftsAvailable).toBe(false);
     });
   });
+
+  describe('manifestDocuments', () => {
+    it('returns empty array when store is empty', async () => {
+      const docs = await store.manifestDocuments();
+      expect(docs).toEqual([]);
+    });
+
+    it('groups rows by filePath with row counts', async () => {
+      await store.insert([
+        makeChunk({ filePath: 'src/a.ts', content: 'a1' }),
+        makeChunk({ filePath: 'src/a.ts', content: 'a2' }),
+        makeChunk({ filePath: 'src/b.ts', content: 'b1' }),
+      ]);
+
+      const docs = await store.manifestDocuments();
+
+      expect(docs).toHaveLength(2);
+      const a = docs.find((d) => d.sourceFile === 'src/a.ts');
+      const b = docs.find((d) => d.sourceFile === 'src/b.ts');
+      expect(a?.rowCount).toBe(2);
+      expect(b?.rowCount).toBe(1);
+    });
+
+    it('returns docs sorted by sourceFile', async () => {
+      await store.insert([
+        makeChunk({ filePath: 'z/last.ts', content: 'z' }),
+        makeChunk({ filePath: 'a/first.ts', content: 'a' }),
+        makeChunk({ filePath: 'm/middle.ts', content: 'm' }),
+      ]);
+
+      const docs = await store.manifestDocuments();
+
+      expect(docs.map((d) => d.sourceFile)).toEqual(['a/first.ts', 'm/middle.ts', 'z/last.ts']);
+    });
+
+    it('derives origin "local" for repo paths', async () => {
+      await store.insert([
+        makeChunk({ filePath: 'src/foo.ts', content: 'x' }),
+        makeChunk({ filePath: '.totem/lessons/lesson-abc.md', content: 'y', type: 'spec' }),
+        makeChunk({ filePath: 'docs/readme.md', content: 'z', type: 'spec' }),
+      ]);
+
+      const docs = await store.manifestDocuments();
+
+      for (const d of docs) {
+        expect(d.origin).toBe('local');
+      }
+    });
+
+    it('derives origin from node_modules pkg name (scoped)', async () => {
+      await store.insert([
+        makeChunk({ filePath: 'node_modules/@mmnto/totem/dist/index.js', content: 'x' }),
+      ]);
+
+      const docs = await store.manifestDocuments();
+
+      expect(docs[0]?.origin).toBe('@mmnto/totem');
+    });
+
+    it('derives origin from node_modules pkg name (unscoped)', async () => {
+      await store.insert([makeChunk({ filePath: 'node_modules/lodash/index.js', content: 'x' })]);
+
+      const docs = await store.manifestDocuments();
+
+      expect(docs[0]?.origin).toBe('lodash');
+    });
+
+    it('does not special-case any specific filename or path identity', async () => {
+      // Regression guard: a hardcoded `.totem/lessons` path-identity branch
+      // previously existed in the writer (tagged for status-Gemini mock-data
+      // matching). Stripped per Tenet 14 — origin must derive from structural
+      // signal (node_modules presence) only, not path-identity matches.
+      await store.insert([
+        makeChunk({
+          filePath: '.totem/lessons/lesson-agent-orientation.md',
+          content: 'x',
+          type: 'spec',
+        }),
+      ]);
+
+      const docs = await store.manifestDocuments();
+
+      expect(docs[0]?.origin).toBe('local');
+    });
+
+    it('populates lastSynced as ISO timestamp', async () => {
+      await store.insert([makeChunk({ filePath: 'src/x.ts', content: 'x' })]);
+
+      const docs = await store.manifestDocuments();
+
+      expect(docs[0]?.lastSynced).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    });
+  });
 });

--- a/packages/core/src/store/lance-store.ts
+++ b/packages/core/src/store/lance-store.ts
@@ -525,9 +525,11 @@ export class LanceStore {
       const lastSynced = writtenAt.toISOString();
       for (const [filePath, count] of counts) {
         let origin = 'local';
+        // Normalize backslashes so Windows-style paths classify the same as POSIX.
+        const normalizedPath = filePath.replace(/\\/g, '/');
 
-        if (filePath.includes('node_modules/')) {
-          const match = filePath.match(/node_modules\/((?:@[^/]+\/)?[^/]+)/);
+        if (normalizedPath.includes('node_modules/')) {
+          const match = normalizedPath.match(/node_modules\/((?:@[^/]+\/)?[^/]+)/);
           if (match?.[1]) {
             origin = match[1];
           }

--- a/packages/core/src/store/lance-store.ts
+++ b/packages/core/src/store/lance-store.ts
@@ -490,8 +490,18 @@ export class LanceStore {
   }
 
   /**
-   * Generates the documents array for the index manifest.
-   * Groups rows by filePath and computes row counts.
+   * Returns one entry per distinct `filePath` in the store, with row counts
+   * and a derived `origin` (`@scope/pkg` or `pkg` when the path lives under
+   * `node_modules/`, otherwise `local`).
+   *
+   * `lastSynced` on every returned entry is the moment this method runs, not
+   * a per-document sync timestamp — LanceDB rows do not carry per-row sync
+   * timestamps in the current schema. Callers that need per-document
+   * staleness data must derive it elsewhere; this method's `lastSynced` is
+   * effectively a manifest-write timestamp.
+   *
+   * Output is sorted by `sourceFile` ascending so the manifest payload is
+   * deterministic across runs.
    */
   async manifestDocuments(): Promise<
     { sourceFile: string; origin: string; rowCount: number; lastSynced: string }[]

--- a/packages/core/src/store/lance-store.ts
+++ b/packages/core/src/store/lance-store.ts
@@ -494,18 +494,19 @@ export class LanceStore {
    * and a derived `origin` (`@scope/pkg` or `pkg` when the path lives under
    * `node_modules/`, otherwise `local`).
    *
-   * `lastSynced` on every returned entry is the moment this method runs, not
-   * a per-document sync timestamp — LanceDB rows do not carry per-row sync
-   * timestamps in the current schema. Callers that need per-document
-   * staleness data must derive it elsewhere; this method's `lastSynced` is
-   * effectively a manifest-write timestamp.
+   * `lastSynced` on every returned entry is set to the supplied `writtenAt`
+   * timestamp (or `new Date()` if omitted). LanceDB rows do not carry per-row
+   * sync timestamps in the current schema, so every document in a single
+   * manifest necessarily carries the same `lastSynced` value — callers
+   * building an `IndexManifest` should pass their `writtenAt` here so that
+   * `documents[].lastSynced === manifest.writtenAt` for that run.
    *
    * Output is sorted by `sourceFile` ascending so the manifest payload is
    * deterministic across runs.
    */
-  async manifestDocuments(): Promise<
-    { sourceFile: string; origin: string; rowCount: number; lastSynced: string }[]
-  > {
+  async manifestDocuments(
+    writtenAt: Date = new Date(),
+  ): Promise<{ sourceFile: string; origin: string; rowCount: number; lastSynced: string }[]> {
     if (!this.table) return [];
 
     const snapshot = await this.openReadSnapshot();
@@ -521,7 +522,7 @@ export class LanceStore {
       }
 
       const docs = [];
-      const now = new Date().toISOString();
+      const lastSynced = writtenAt.toISOString();
       for (const [filePath, count] of counts) {
         let origin = 'local';
 
@@ -536,7 +537,7 @@ export class LanceStore {
           sourceFile: filePath,
           origin,
           rowCount: count,
-          lastSynced: now,
+          lastSynced,
         });
       }
       return docs.sort((a, b) => a.sourceFile.localeCompare(b.sourceFile));

--- a/packages/core/src/store/lance-store.ts
+++ b/packages/core/src/store/lance-store.ts
@@ -514,15 +514,12 @@ export class LanceStore {
       const now = new Date().toISOString();
       for (const [filePath, count] of counts) {
         let origin = 'local';
-        const segments = filePath.split('/');
 
-        if (segments.indexOf('node_modules') !== -1) {
-          const matchArray = [...filePath.matchAll(/node_modules\/((?:@[^\/]+\/)?[^\/]+)/g)];
-          if (matchArray.length > 0 && matchArray[0]?.[1]) {
-            origin = matchArray[0][1];
+        if (filePath.includes('node_modules/')) {
+          const match = filePath.match(/node_modules\/((?:@[^/]+\/)?[^/]+)/);
+          if (match?.[1]) {
+            origin = match[1];
           }
-        } else if (segments.length > 1 && segments[0] === '.totem' && segments[1] === 'lessons') {
-          origin = 'local';
         }
 
         docs.push({


### PR DESCRIPTION
## Mechanical Root Cause

Three classes of defect surfaced by totem-Gemini's architectural audit and Greptile P1 review on the version of `feat/index-manifest` that was squash-merged at `19f5664a` (mmnto-ai/totem#1840). Empirical merge-state verification by API: PR #1840 was merged at `2026-05-07T00:11:47Z` carrying these defects, so this PR is a fix-forward against post-merge `main`.

**Class 1 — Hash-labeling violations (Tenet 14):**

1. The merged writer emitted `indexHash: 'sha1:<headSha>'` — labeling a git commit identity hash as `indexHash`, which by name promises a content hash of the actual index state. Identity hashes masquerading as content hashes is the canonical Tenet 14 violation. The earlier remediation commit (`00a7480b`) only renamed the prefix from `sha256:` to `sha1:` — a symbol shuffle, not a principle fix.
2. The merged writer fell back to `indexHash: 'sha1:unknown'` when no git SHA was available. `sha1:unknown` is a structurally invalid hash URI (the `<algorithm>:<hexdigest>` shape demands a hexdigest, not a string literal). Greptile flagged this as a P1.

**Class 2 — Hardcoded identity heuristics:**

3. `LanceStore.manifestDocuments()` carried an explicit conditional branch on `.totem/lessons` path-identity matches, originally added so the writer's output would mock-match status-Gemini's TUI fixtures. The branch only re-assigned `origin = 'local'` (already the default), so it was functionally dead today. But it's a hardcoded path-identity shortcut: load-bearing if anyone wires it differently. Strip it; derive origin from structural signal only.

**Class 3 — PR hygiene:**

4. Speculative `// totem-ignore` and inline `// totem-context: intentional cleanup` directives in the manifest write block; `totem lint` empirically passes without them.

## Fix Applied

- **`pipeline.ts`**: Renamed the field from `indexHash` to `gitCommit` with `git:<sha>` format (per CodeRabbit's earlier guidance — git commits are git-native, not cryptographic digests). The field is **OMITTED** entirely on no-git rather than synthesizing a fake-presence value. Schema bumped `totem-index-manifest-v0.1` → `v0.2`. The manifest assembly is extracted into a pure `buildIndexManifest({ documents, headSha, writtenAt }) → IndexManifest` helper so the contract is unit-testable.
- **`lance-store.ts`**: Stripped the `.totem/lessons` path-identity branch. Origin now derives from structural signal only: `node_modules/<pkg>` (regex extraction, supports scoped + unscoped) → pkg name; otherwise `local`. Inner branch guard switched from `filePath.split('/').indexOf('node_modules') !== -1` to `filePath.includes('node_modules/')` (allocation-free).
- **Directives**: Removed both `// totem-ignore` and `// totem-context: intentional cleanup`. Empirically verified: `totem lint` passes without either directive.
- **`.gitignore`**: Added `.totem/index-manifest.json` (generated runtime artifact, like `.totem/cache/`).
- **Public API**: Added exports for `buildIndexManifest`, `INDEX_MANIFEST_SCHEMA`, `IndexManifest`, `ManifestDocument` from `@mmnto/totem` (mirrored through `ingest/sync.ts` and `index.ts`).

## Schema conformance

The only consumer of `.totem/index-manifest.json` today is the `IndexManifest` reader in `mmnto-ai/totem-status:substrate.go`. Its struct only deserializes the `documents[]` array and its per-doc fields (`sourceFile`, `origin`, `rowCount`, `lastSynced`). All four are unchanged in shape and meaning. Renaming the unused `indexHash` field to `gitCommit` (and omitting it on no-git) is invisible to status-Gemini's reader, since Go's `encoding/json` ignores unknown fields by default.

## Out of Scope

- Real content-hash computation for a future `indexHash` field. Honest absence is the right call until a downstream consumer needs cache-validity / staleness detection.
- Phase 2 empirical verification (`totem sync` against multiple corpora, sampling 5+ lessons across 2+ repos) per `.handoff/totem-claude/inbox/2026-05-07T0045Z-strategy-claude.md`. That is post-merge work and runs once this PR lands.

## Tests Added

16 new tests across two files:

- **`packages/core/src/ingest/pipeline.test.ts`** — 8 tests on `buildIndexManifest`: schema literal, documents pass-through, ISO timestamp, `gitCommit` presence with `git:` prefix when SHA is provided, `gitCommit` field OMITTED on null/empty/undefined SHA, regression guard against any synthesized `sha\d+:unknown` URI in the output, regression guard against re-introducing `indexHash` field.
- **`packages/core/src/store/lance-store.test.ts`** — 8 tests on `LanceStore.manifestDocuments()`: empty-store contract, row grouping by filePath, sorted output, `local` origin for repo paths, scoped + unscoped `node_modules/<pkg>` extraction, regression guard verifying no specific filename or path identity is special-cased (uses `lesson-agent-orientation.md` as the test fixture — exactly the path that was hardcoded in #1840).

Total: 1815 → 1831 tests pass. `totem lint` PASS (15 warnings, 0 errors). `totem review` PASS (no findings).

## Related Tickets

- Fix-forward against `mmnto-ai/totem#1840` (squash-merged at `19f5664a`).
- Empirical-verification dispatch from strategy-Claude: `.handoff/totem-claude/inbox/2026-05-07T0045Z-strategy-claude.md`.
- Architectural-audit findings from totem-Gemini consolidated inline in the same dispatch (Class 1 + Class 2 above).