### PR TITLE
feat(cli): install Claude SessionStart hook + eject parity (#1845 slice 1, closes #1852)

### DIFF
--- a/.changeset/init-claude-session-start-hook.md
+++ b/.changeset/init-claude-session-start-hook.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/totem': minor
+---
+
+`totem init` now installs a Claude Code `SessionStart` hook (`.claude/hooks/SessionStart.cjs` + a merged entry in committed `.claude/settings.json`), giving Claude sessions the same `totem describe` orientation banner that Gemini-side `.gemini/hooks/SessionStart.js` has produced since pre-Phase-B. New repos joining the family no longer require a manual mirror from a sibling project to get parity. The hook is `.cjs` (load-bearing for `package.json` `type: module` repos), routes the CLI's stderr to stdout so the orientation lands in Claude's prompt, and falls back gracefully if `@mmnto/cli` isn't installed or the describe call fails. Closes the install-side asymmetry from `mmnto-ai/totem#1845` slice 1.
+
+`totem eject` now scrubs both the new SessionStart entry and the Phase B PreWriteShield entry from committed `.claude/settings.json`, plus removes the corresponding `.claude/hooks/*.cjs` scaffold files (marker-checked so user-authored hooks survive). Closes the eject-parity gap left over from Phase B (`mmnto-ai/totem#1852`). User-defined entries under `hooks.PreToolUse` and `hooks.SessionStart` are preserved; empty arrays/objects/files are pruned bottom-up.
+
+Refactor: extracted `mergeClaudeHooksKey` as the single source of truth for the read → safeparse → idempotency probe → append → write merge logic. `scaffoldClaudeHooks`, `scaffoldClaudeWriteShield`, and the new `scaffoldClaudeSessionStart` are thin wrappers. `ClaudeSettingsSchema` now validates both `hooks.PreToolUse` and `hooks.SessionStart` shapes (passthrough preserves user fields).

--- a/.totem/specs/1845.md
+++ b/.totem/specs/1845.md
@@ -120,6 +120,7 @@ This PR scaffolds a Claude Code `SessionStart` hook (`.claude/hooks/SessionStart
   - **Reads:** Claude Code at session-start (executes via `node .claude/hooks/SessionStart.cjs`).
   - **Invariants:** filename MUST be `.cjs` (load-bearing per spec — `package.json` `type: module` repos otherwise resolve `.js` as ESM and reject the CJS `require()` calls in the hook); marker MUST be present in the rendered output for `scaffoldFile` to detect prior install.
 - **`CLAUDE_SESSION_START_ENTRY`** (new module constant in `init-templates.ts`) — the JSON entry shape merged into `.claude/settings.json#hooks.SessionStart`:
+
   ```json
   {
     "hooks": [
@@ -129,6 +130,7 @@ This PR scaffolds a Claude Code `SessionStart` hook (`.claude/hooks/SessionStart
   ```
 
   - **Note:** SessionStart entries have NO `matcher` field (unlike `PreToolUse` entries). The existing `mergeClaudePreToolUseEntry` + `preToolUseHasMatcher` helpers are PreToolUse-shaped and can't be reused as-is — sibling needed (see OQ 4).
+
 - **`ClaudeSettingsSchema`** extension (in `init.ts`) — add optional `hooks.SessionStart: Array<{ hooks: Array<HookCommand> }>` validation. Passthrough already preserves the field on round-trip; explicit shape buys validation on merge.
 - **`TOTEM_SCAFFOLDED_FILES`** (in `eject.ts`) — append `.claude/hooks/SessionStart.cjs`. Marker-checked delete still gates against user-owned content.
 - **No new state containers.** All state is per-`init` invocation; no module variables, singletons, or shared mutable state.

--- a/.totem/specs/1845.md
+++ b/.totem/specs/1845.md
@@ -1,0 +1,200 @@
+### Problem Statement
+
+`totem init` currently installs a `SessionStart` hook for Gemini to provide orientation context (via `totem describe`) but fails to do so for Claude Code, leaving Claude sessions starting "cold". The fix requires symmetrically installing a `.claude/hooks/SessionStart.cjs` script and idempotently wiring it into `.claude/settings.json`.
+
+### Architectural Context
+
+- **Model-Stack Agnosticism (Tenet 16):** Emphasized in the issue. Both Gemini and Claude must have symmetric orientation capabilities at startup.
+- **Eject Parity Trap:** The issue correctly identifies what needs to change in `init.ts`, but omits the corresponding cleanup required in `eject.ts`. Totem's architecture mandates that anything `init` installs, `eject` must cleanly remove.
+- **ESM Node Resolution:** The `.cjs` extension is a load-bearing requirement due to `type: module` strictness in modern repositories, which will fail to `require()` standard `.js` files in hook execution environments.
+
+### Files to Examine
+
+1. `packages/cli/src/commands/init.ts` — Contains the `installClaudeHooks` function where the hook script and settings modifications will be implemented.
+2. `packages/cli/src/commands/eject.ts` — Contains `scrubClaudeSettings` which must be updated to clean up the newly added `.claude/settings.json` hook.
+
+### Technical Approach & Contracts
+
+**1. Hook Script Generation**
+Define a `CLAUDE_SESSION_START` constant in `init.ts` containing the CJS payload. It must:
+
+- Route `stderr` to `stdout` to avoid noisy prompt errors.
+- Wrap execution of `@mmnto/cli describe` in a `try/catch` and fail gracefully if the CLI is missing or errors out.
+
+**2. Settings Injection (Idempotent Merge)**
+Modify `installClaudeHooks` to process `.claude/settings.json` (note: not `.local.json`).
+Contract structure required for the payload:
+
+```typescript
+type ClaudeSettings = {
+  hooks?: {
+    SessionStart?: Array<{
+      hooks: Array<{ type: string; command: string; timeout: number }>;
+    }>;
+    [key: string]: any;
+  };
+  [key: string]: any;
+};
+```
+
+Read the file. If missing, create it. If present, parse it, ensure the `hooks.SessionStart` array exists, and append the hook object _only if_ an entry with `command: "node .claude/hooks/SessionStart.cjs"` does not already exist.
+
+**3. Ejection Cleanup**
+Update `eject.ts` to explicitly delete `.claude/hooks/SessionStart.cjs` and surgically remove the corresponding entry from the `hooks.SessionStart` array in `.claude/settings.json`. If the array or `hooks` object becomes empty, delete the parent key to leave a clean file.
+
+### Edge Cases & Traps
+
+- **Destructive Settings Merge:** Simply overwriting `.claude/settings.json` or `hooks.SessionStart` will wipe out a user's custom Claude Code hooks. Deep, idempotent merging is mandatory.
+- **Missing Eject Logic:** The issue explicitly requests changes to `init`, but adding configuration without adding corresponding `eject` cleanup will break the state contract of `totem eject` and fail CI health checks.
+- **File Extension Strictness:** Using `.js` instead of `.cjs` will cause an `ERR_REQUIRE_ESM` crash when Claude triggers the hook in a repo using `"type": "module"`.
+- **JSON Formatting Preservation:** When rewriting `.claude/settings.json`, use `JSON.stringify(data, null, 2)` to preserve readability for the committed configuration file.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Define CJS Hook Payload & Write Script File**
+  - Modify `packages/cli/src/commands/init.ts` to include a `CLAUDE_SESSION_START` constant matching the `totem-strategy` reference (stderr routed to stdout, graceful fallback).
+  - Update `installClaudeHooks` to write this payload to `.claude/hooks/SessionStart.cjs`.
+  - Add this file to the returned `HookInstallerResult[]` array.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `writes Claude SessionStart hook with .cjs extension` that proves `init.ts` scaffolds the script file correctly.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Idempotently Wire Hook into Settings JSON**
+  - Modify `installClaudeHooks` in `packages/cli/src/commands/init.ts` to check if `.claude/settings.json` exists.
+  - Read and parse the file (or create an empty object).
+  - Traverse and ensure `hooks.SessionStart` exists as an array.
+  - Append the `node .claude/hooks/SessionStart.cjs` hook config if it is not already in the array.
+  - Write the file back using `JSON.stringify(..., null, 2)`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `idempotently merges Claude SessionStart hook into existing settings.json` that proves existing hooks are preserved and duplicate injections do not occur.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Implement Eject Cleanup for Claude Settings**
+  - Modify `scrubClaudeSettings` in `packages/cli/src/commands/eject.ts` (or add a companion function) to target `.claude/settings.json` (in addition to `settings.local.json`).
+  - Read and parse the file. Filter out the `SessionStart` entry targeting `SessionStart.cjs`.
+  - If `hooks.SessionStart` becomes empty, delete the `SessionStart` key.
+  - Remove `.claude/hooks/SessionStart.cjs` using `fs.unlinkSync` if it exists.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `scrubs injected Claude SessionStart hook without removing user hooks` that proves the `eject` command cleans up only the Totem-injected configuration.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Init Idempotency:** Run `totem init` twice on a mock repo. Verify `.claude/settings.json` contains exactly one instance of the `SessionStart.cjs` hook.
+- **Init Preservation:** Seed a mock repo with a `.claude/settings.json` containing a dummy `SessionStart` hook (e.g., `echo "custom"`). Run `totem init` and verify both the dummy hook and the new Totem hook exist in the array.
+- **Init Extension Validation:** Assert the hook script is generated with `.cjs`, not `.js`.
+- **Eject Integrity:** Run `totem init` then `totem eject`. Assert `.claude/settings.json` does not contain the `SessionStart.cjs` hook and `.claude/hooks/SessionStart.cjs` is physically deleted. Assert `.claude/settings.local.json` cleanup is unaffected.
+
+---
+
+## Implementation Design
+
+> **Slice 1 of Phase C 3-way split.** Per locked sequencing: slice 1 = symmetric Claude SS hook (this PR), slice 2 = `describe`-canonical reconciliation, slice 3 = session-utility skill suite distribution. Slices 2 + 3 are out of scope here.
+
+### Scope (2 sentences)
+
+This PR scaffolds a Claude Code `SessionStart` hook (`.claude/hooks/SessionStart.cjs`) and merges its entry into committed `.claude/settings.json` so `totem init` produces parity with the Gemini-side install (which has scaffolded `.gemini/hooks/SessionStart.js` since pre-Phase-B). Eject parity for the new SessionStart entry + script is included; **eject cleanup for Phase B's `PreWriteShield` (the same architectural class of gap, tracked at `mmnto-ai/totem#1852`) is OUT of scope** — see OQ 1.
+
+### Data model deltas
+
+- **`CLAUDE_SESSION_START`** (new module constant in `init-templates.ts`) — the CJS payload, ported verbatim from `mmnto-ai/totem-strategy:.claude/hooks/SessionStart.cjs` with project name parameterized to "Totem" instead of "Totem Strategy". Carries `TOTEM_FILE_MARKER` for `scaffoldFile` idempotency.
+  - **Holds:** the literal hook script content.
+  - **Writes:** `init.ts:installClaudeHooks` (via `scaffoldFile`).
+  - **Reads:** Claude Code at session-start (executes via `node .claude/hooks/SessionStart.cjs`).
+  - **Invariants:** filename MUST be `.cjs` (load-bearing per spec — `package.json` `type: module` repos otherwise resolve `.js` as ESM and reject the CJS `require()` calls in the hook); marker MUST be present in the rendered output for `scaffoldFile` to detect prior install.
+- **`CLAUDE_SESSION_START_ENTRY`** (new module constant in `init-templates.ts`) — the JSON entry shape merged into `.claude/settings.json#hooks.SessionStart`:
+  ```json
+  {
+    "hooks": [
+      { "type": "command", "command": "node .claude/hooks/SessionStart.cjs", "timeout": 30000 }
+    ]
+  }
+  ```
+
+  - **Note:** SessionStart entries have NO `matcher` field (unlike `PreToolUse` entries). The existing `mergeClaudePreToolUseEntry` + `preToolUseHasMatcher` helpers are PreToolUse-shaped and can't be reused as-is — sibling needed (see OQ 4).
+- **`ClaudeSettingsSchema`** extension (in `init.ts`) — add optional `hooks.SessionStart: Array<{ hooks: Array<HookCommand> }>` validation. Passthrough already preserves the field on round-trip; explicit shape buys validation on merge.
+- **`TOTEM_SCAFFOLDED_FILES`** (in `eject.ts`) — append `.claude/hooks/SessionStart.cjs`. Marker-checked delete still gates against user-owned content.
+- **No new state containers.** All state is per-`init` invocation; no module variables, singletons, or shared mutable state.
+
+### State lifecycle
+
+- **Hook script file** (`.claude/hooks/SessionStart.cjs`): persistent, written at `totem init` time, deleted at `totem eject` time. Marker-checked on both ends.
+- **Settings JSON entry** (`.claude/settings.json#hooks.SessionStart[N]`): persistent, merged at `totem init` time (idempotent on duplicate runs), removed at `totem eject` time. Other `SessionStart` entries (user-defined) preserved.
+- No state crosses lifecycle boundaries.
+
+### Failure modes
+
+| Failure                                                                            | Category                  | Agent-facing surface                                                                                | Recovery                                                                                         |
+| ---------------------------------------------------------------------------------- | ------------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ |
+| `.claude/settings.json` already contains the Totem `SessionStart.cjs` entry        | runtime (idempotent path) | `'skipped'` ScaffoldOutcome (no message change)                                                     | none needed — re-runs are no-ops                                                                 |
+| `.claude/settings.json` exists but is invalid JSON                                 | permanent                 | `'skipped'` with structured `err` propagated to `initCommand` log                                   | user fixes the JSON manually                                                                     |
+| `.claude/settings.json` shape doesn't match `ClaudeSettingsSchema` after extension | permanent                 | `'skipped'` with Zod-issue detail in `err`                                                          | user fixes the shape                                                                             |
+| `.claude/hooks/SessionStart.cjs` exists without Totem marker (user-authored)       | permanent                 | `scaffoldFile` returns `'skipped'` with no overwrite                                                | user explicitly removes their hook OR accepts the marker conflict                                |
+| Hook script execution fails at session-start (cli not installed)                   | runtime (degraded)        | hook prints `'[Totem] @mmnto/cli not installed...'` to stdout, exits 0                              | `pnpm install`                                                                                   |
+| Hook script execution throws (process error)                                       | runtime (degraded)        | hook prints `'[Totem] Briefing unavailable: <err>'` to stdout, exits 0                              | depends on err                                                                                   |
+| Hook script timeout (>30s)                                                         | transient                 | Claude Code aborts hook, session continues without orientation                                      | next session re-runs                                                                             |
+| Eject: `.claude/hooks/SessionStart.cjs` exists without marker                      | runtime                   | `removeScaffoldedFiles` skips, records in summary                                                   | user removes manually if intended                                                                |
+| Eject: `.claude/settings.json` filtered to empty `hooks.SessionStart`              | runtime                   | array key deleted; if `hooks` becomes empty, delete `hooks` key; if file becomes empty `{}`, unlink | already handled by existing `scrubClaudeSettings` cleanup pattern (mirror it for committed file) |
+
+No silent-degradation rows. The two `runtime (degraded)` rows are explicit `process.stdout.write` messages with `[Totem]` prefix — visible breadcrumb at session start, not silent. Justified against Tenet 4 because session-start orientation is non-load-bearing for correctness; cold start is acceptable.
+
+### Invariants to lock in via tests
+
+- **Init: `.cjs` extension preserved.** Hook file scaffolded with `.cjs`, not `.js`. (Load-bearing per spec.)
+- **Init: settings.json entry merge is idempotent.** Running `totem init` twice on an empty repo produces exactly one `SessionStart.cjs` entry.
+- **Init: settings.json entry merge preserves user hooks.** Pre-seeded `SessionStart` entry with `command: "echo custom"` survives `totem init`; new Totem entry sits alongside.
+- **Init: settings.json entry merge coexists with PreWriteShield.** Pre-seeded `PreToolUse` entry (Phase B's PreWriteShield) is untouched by SessionStart install.
+- **Init: hook script content matches the canonical reference shape.** Contains the `@mmnto/cli` not-installed fallback message AND the process-error fallback. Routes stderr to stdout (substring assertion on `process.stdout.write((result.stdout || '') + (result.stderr || ''))`).
+- **Eject: SessionStart entry removed without affecting Phase B's PreWriteShield entry.** Filter is shape-specific (matches by `command` substring, not by index/position).
+- **Eject: SessionStart hook script is physically deleted only when marker present.** User-authored hook (no marker) preserved.
+- **Eject: settings.json file unlink-on-empty contract preserved.** Cleanup chain `delete entry → maybe delete SessionStart array → maybe delete hooks → maybe unlink file` matches the existing `.local.json` pattern.
+
+### Open questions
+
+1. **Scope: close `mmnto-ai/totem#1852` (Phase B PreWriteShield eject parity) in this PR, or leave for that ticket?**
+   - **Background:** Phase B added init-side scaffolding for `.claude/hooks/PreWriteShield.cjs` + `.claude/settings.json#hooks.PreToolUse[Write|Edit]` but never updated eject. This PR adds eject cleanup for the new SessionStart entry; if I touch the same `scrubClaudeSettings` shape for committed-file cleanup, it's a small additional delta to also handle PreWriteShield + add `.claude/hooks/PreWriteShield.cjs` to `TOTEM_SCAFFOLDED_FILES`.
+   - **Options:** (a) Strict slice 1 — only handle SessionStart eject; leave the PreWriteShield eject gap to `#1852`. (b) Close `#1852` in this PR — a few lines extra. The eject helper for committed `settings.json` is naturally shared.
+   - **Recommendation:** **(b)** — close `#1852`. The eject asymmetry is real, the additional shape is tiny (one more matcher predicate, one more file in `TOTEM_SCAFFOLDED_FILES`), and shipping slice 1 with a known eject inconsistency on its own committed-settings.json surface invites bot review noise ("Why does this PR's eject scrub SessionStart but not PreWriteShield from the same file?"). Closing `#1852` here is the cleaner architectural posture.
+   - **Tradeoff:** widens diff slightly; adds one more entry to PR body's "Closes" line. Acceptable.
+
+2. **Hook content: how closely mirror the `totem-strategy` reference?**
+   - **Options:** (a) Verbatim port, with project name parameterized to "Totem" or generic. (b) Strip the project-specific orientation message and use a generic "[Totem] @mmnto/cli not installed; run `pnpm install`" — no per-project README pointer. (c) Make project-name fully parametric via init prompt (overengineered).
+   - **Recommendation:** **(b)** — generic. The strategy reference's "Read README.md, design-tenets.md, ..." line is `totem-strategy`-specific; baking it into `totem init` would propagate strategy-repo conventions into every consumer. Generic message says: cli not installed → install it; cli installed but errored → here's the error. Project-specific orientation is the job of `totem describe` itself, not the fallback message.
+   - **Tradeoff:** consumers who already retrofitted the strategy version will see slightly different fallback text after re-init; their content has the `[totem]` marker, so `scaffoldFile` will return `'exists'` and skip — they won't actually get the new generic version unless they delete + re-init (per `claude-0032` MEMORY pattern + `#1854`).
+
+3. **Idempotency probe: dedup based on `command` substring match, mirroring `hasPreWriteShield`?**
+   - **Options:** (a) Substring `"SessionStart.cjs"` match. (b) Substring `"node .claude/hooks/SessionStart.cjs"` (full command). (c) Exact entry deep-equal.
+   - **Recommendation:** **(a)** — substring `"SessionStart.cjs"`. Mirrors `hasPreWriteShield`'s pattern. Robust against future timeout tuning or quoting variants of the command. Stricter than (c) which would re-merge if the user added their own `timeout` override.
+   - **Tradeoff:** false-skip if a user has their own SessionStart hook also named `SessionStart.cjs`. Edge case; matches the existing project convention.
+
+4. **Merge helper: extend `mergeClaudePreToolUseEntry` to support SessionStart, or sibling function?**
+   - **Options:** (a) Generalize `mergeClaudePreToolUseEntry` → `mergeClaudeSettingsEntry(filePath, hookKind, entry, alreadyInstalled)`. (b) Sibling `mergeClaudeSessionStartEntry(filePath, entry, alreadyInstalled)` that mirrors the merge logic but writes to `hooks.SessionStart` instead of `hooks.PreToolUse`. (c) Extract a deeper helper `mergeClaudeHooksKey(filePath, key, entry, alreadyInstalled)` and have both call it.
+   - **Recommendation:** **(c)** — extract `mergeClaudeHooksKey`. Both PreToolUse and SessionStart land in `.claude/settings.json#hooks.<key>`; the merge logic (read → safeparse → idempotency probe → append → write) is identical except for the key name. Existing `mergeClaudePreToolUseEntry` becomes a thin wrapper for backward compat (still callable from `scaffoldClaudeHooks` + `scaffoldClaudeWriteShield`); new `mergeClaudeSessionStartEntry` becomes a sibling thin wrapper. One source of truth for the JSON merge logic, mirroring Phase B's discipline.
+   - **Tradeoff:** small refactor of working code. Risk: (a) is a wider blast radius; (b) duplicates ~30 lines. (c) is the right factoring — Phase B already established the "shared merge helper" pattern; extending it once is cheaper than the duplication tax of (b) compounding next time we add a hook key.
+
+5. **Settings file: committed `.claude/settings.json` (matching Phase B's PreWriteShield)?**
+   - **Options:** (a) Committed `.claude/settings.json`. (b) Per-developer `.claude/settings.local.json`.
+   - **Recommendation:** **(a)** — committed. Per `claude-0032` MEMORY (`feedback_settings_file_asymmetry_architecturally_correct`): committed `settings.json` IS team-level guarantee, `settings.local.json` IS per-developer environment safety. Orientation IS a team-level guarantee — every team member's Claude session should boot with the same `totem describe` context. PR body should annotate this explicitly so reviewers don't flag the choice as inconsistent with the legacy shield-gate placement in `.local.json`.
+   - **Tradeoff:** committed file means consumers who already committed their own `settings.json` see merge attempts; idempotent so safe.
+
+6. **TSDoc / README: surface that init now writes a committed `settings.json` SessionStart entry?**
+   - **Options:** (a) PR body + changeset only. (b) Update `docs/wiki/installation.md` or similar to document the file. (c) Both.
+   - **Recommendation:** **(a)** — PR body + changeset. Wiki docs are out of scope for slice 1; the changeset entry IS the user-facing docs surface for `init` behavior changes per established `1.30.0`/`1.31.0`/`1.32.0` cohort pattern.
+   - **Tradeoff:** documentation deferred to slice 2 / 3 if those slices touch related surfaces.

--- a/packages/cli/src/commands/eject.test.ts
+++ b/packages/cli/src/commands/eject.test.ts
@@ -264,6 +264,60 @@ describe('ejectCommand', () => {
     expect(fs.existsSync(path.join(hookDir, 'SessionStart.cjs'))).toBe(true);
   });
 
+  it('skips committed Claude settings.json when JSON root is not an object (e.g., array, string, null)', async () => {
+    const settingsDir = path.join(cwd, '.claude');
+    fs.mkdirSync(settingsDir, { recursive: true });
+    // A `.claude/settings.json` consisting of just `[]` parses successfully
+    // but isn't a config object — eject must skip it cleanly without
+    // crashing on the implicit Object property access.
+    fs.writeFileSync(path.join(settingsDir, 'settings.json'), '[]');
+
+    await ejectCommand({ force: true });
+
+    // File should still exist (eject skipped, didn't mutate)
+    expect(fs.existsSync(path.join(settingsDir, 'settings.json'))).toBe(true);
+    expect(fs.readFileSync(path.join(settingsDir, 'settings.json'), 'utf-8')).toBe('[]');
+  });
+
+  it('skips committed Claude settings.json when hooks key is malformed (string instead of object)', async () => {
+    const settingsDir = path.join(cwd, '.claude');
+    fs.mkdirSync(settingsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(settingsDir, 'settings.json'),
+      JSON.stringify({ hooks: 'unexpected-string' }),
+    );
+
+    await ejectCommand({ force: true });
+
+    // File should still exist (eject skipped, didn't crash)
+    expect(fs.existsSync(path.join(settingsDir, 'settings.json'))).toBe(true);
+  });
+
+  it('skips entries when hooks.PreToolUse is a non-array (e.g., null) without crashing', async () => {
+    const settingsDir = path.join(cwd, '.claude');
+    fs.mkdirSync(settingsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(settingsDir, 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PreToolUse: null,
+          SessionStart: [
+            { hooks: [{ type: 'command', command: 'node .claude/hooks/SessionStart.cjs' }] },
+          ],
+        },
+      }),
+    );
+
+    await ejectCommand({ force: true });
+
+    // SessionStart still scrubbed even though PreToolUse was malformed.
+    const updated = JSON.parse(fs.readFileSync(path.join(settingsDir, 'settings.json'), 'utf-8'));
+    // After mutation: SessionStart removed, PreToolUse:null preserved as
+    // unexpected-shape input. The file may or may not exist depending on
+    // pruning; if it does, it must not contain the SessionStart entry.
+    expect(updated.hooks?.SessionStart).toBeUndefined();
+  });
+
   it('preserves user-defined permissions and unrelated keys in committed Claude settings.json', async () => {
     const settingsDir = path.join(cwd, '.claude');
     fs.mkdirSync(settingsDir, { recursive: true });

--- a/packages/cli/src/commands/eject.test.ts
+++ b/packages/cli/src/commands/eject.test.ts
@@ -140,6 +140,157 @@ describe('ejectCommand', () => {
     // Should not throw
   });
 
+  // Phase C slice 1 (mmnto-ai/totem#1845) added committed `.claude/settings.json`
+  // SessionStart eject parity. Same PR closes mmnto-ai/totem#1852 by also
+  // scrubbing the Phase B PreWriteShield entry from the same file. Both
+  // entries must be removed without disturbing user-defined hooks.
+  it('scrubs SessionStart entry from committed Claude settings.json', async () => {
+    const settingsDir = path.join(cwd, '.claude');
+    fs.mkdirSync(settingsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(settingsDir, 'settings.json'),
+      JSON.stringify(
+        {
+          hooks: {
+            SessionStart: [
+              { hooks: [{ type: 'command', command: 'node .claude/hooks/SessionStart.cjs' }] },
+              { hooks: [{ type: 'command', command: 'echo "user-defined"' }] },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await ejectCommand({ force: true });
+
+    const updated = JSON.parse(fs.readFileSync(path.join(settingsDir, 'settings.json'), 'utf-8'));
+    expect(updated.hooks.SessionStart).toHaveLength(1);
+    expect(updated.hooks.SessionStart[0].hooks[0].command).toBe('echo "user-defined"');
+  });
+
+  it('scrubs PreWriteShield entry from committed Claude settings.json (closes #1852)', async () => {
+    const settingsDir = path.join(cwd, '.claude');
+    fs.mkdirSync(settingsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(settingsDir, 'settings.json'),
+      JSON.stringify(
+        {
+          hooks: {
+            PreToolUse: [
+              {
+                matcher: 'Write|Edit',
+                hooks: [{ type: 'command', command: 'node .claude/hooks/PreWriteShield.cjs' }],
+              },
+              {
+                matcher: 'Write',
+                hooks: [{ type: 'command', command: 'echo "user-defined"' }],
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await ejectCommand({ force: true });
+
+    const updated = JSON.parse(fs.readFileSync(path.join(settingsDir, 'settings.json'), 'utf-8'));
+    expect(updated.hooks.PreToolUse).toHaveLength(1);
+    expect(updated.hooks.PreToolUse[0].matcher).toBe('Write');
+  });
+
+  it('scrubs both PreWriteShield and SessionStart entries in one pass, leaving file empty', async () => {
+    const settingsDir = path.join(cwd, '.claude');
+    fs.mkdirSync(settingsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(settingsDir, 'settings.json'),
+      JSON.stringify(
+        {
+          hooks: {
+            PreToolUse: [
+              {
+                matcher: 'Write|Edit',
+                hooks: [{ type: 'command', command: 'node .claude/hooks/PreWriteShield.cjs' }],
+              },
+            ],
+            SessionStart: [
+              { hooks: [{ type: 'command', command: 'node .claude/hooks/SessionStart.cjs' }] },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await ejectCommand({ force: true });
+
+    // Both entries gone → both arrays empty → both keys deleted → hooks
+    // empty → hooks key deleted → file empty {} → file unlinked.
+    expect(fs.existsSync(path.join(settingsDir, 'settings.json'))).toBe(false);
+  });
+
+  it('removes scaffolded .claude/hooks/SessionStart.cjs and PreWriteShield.cjs files', async () => {
+    const hookDir = path.join(cwd, '.claude', 'hooks');
+    fs.mkdirSync(hookDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(hookDir, 'SessionStart.cjs'),
+      '// [totem] auto-generated — Claude Code SessionStart hook\nconsole.log("hi");',
+    );
+    fs.writeFileSync(
+      path.join(hookDir, 'PreWriteShield.cjs'),
+      '// [totem] auto-generated — Claude Code PreWriteShield hook\nconsole.log("hi");',
+    );
+
+    await ejectCommand({ force: true });
+
+    expect(fs.existsSync(path.join(hookDir, 'SessionStart.cjs'))).toBe(false);
+    expect(fs.existsSync(path.join(hookDir, 'PreWriteShield.cjs'))).toBe(false);
+  });
+
+  it('does not remove .claude/hooks/SessionStart.cjs if user-authored (no Totem marker)', async () => {
+    const hookDir = path.join(cwd, '.claude', 'hooks');
+    fs.mkdirSync(hookDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(hookDir, 'SessionStart.cjs'),
+      'console.log("user-authored, no marker");',
+    );
+
+    await ejectCommand({ force: true });
+
+    expect(fs.existsSync(path.join(hookDir, 'SessionStart.cjs'))).toBe(true);
+  });
+
+  it('preserves user-defined permissions and unrelated keys in committed Claude settings.json', async () => {
+    const settingsDir = path.join(cwd, '.claude');
+    fs.mkdirSync(settingsDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(settingsDir, 'settings.json'),
+      JSON.stringify(
+        {
+          permissions: { allow: ['Bash'] },
+          hooks: {
+            SessionStart: [
+              { hooks: [{ type: 'command', command: 'node .claude/hooks/SessionStart.cjs' }] },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await ejectCommand({ force: true });
+
+    const updated = JSON.parse(fs.readFileSync(path.join(settingsDir, 'settings.json'), 'utf-8'));
+    expect(updated.permissions).toBeDefined();
+    expect(updated.permissions.allow).toEqual(['Bash']);
+    expect(updated.hooks).toBeUndefined();
+  });
+
   it('removes post-merge hook with new conditional format (if/fi block)', async () => {
     const hookPath = path.join(cwd, '.git', 'hooks', 'post-merge');
     fs.writeFileSync(

--- a/packages/cli/src/commands/eject.ts
+++ b/packages/cli/src/commands/eject.ts
@@ -19,6 +19,11 @@ const TOTEM_SCAFFOLDED_FILES = [
   '.gemini/hooks/BeforeTool.js',
   '.gemini/skills/totem.md',
   '.totem/hooks/shield-gate.cjs',
+  // Phase B PreWriteShield (mmnto-ai/totem#1853, eject parity closing
+  // mmnto-ai/totem#1852).
+  '.claude/hooks/PreWriteShield.cjs',
+  // Phase C slice 1 SessionStart (mmnto-ai/totem#1845).
+  '.claude/hooks/SessionStart.cjs',
 ];
 
 // ─── Helpers ────────────────────────────────────────────
@@ -205,6 +210,110 @@ function scrubClaudeSettings(cwd: string, summary: EjectSummary): void {
 }
 
 /**
+ * Remove Totem-injected hook entries from the committed `.claude/settings.json`.
+ * Targets both:
+ *   - `hooks.PreToolUse` entries whose command references `PreWriteShield`
+ *     (Phase B install — closes mmnto-ai/totem#1852, the eject parity gap
+ *     left over from when Phase B added the install side).
+ *   - `hooks.SessionStart` entries whose command references `SessionStart.cjs`
+ *     (Phase C slice 1 install — mmnto-ai/totem#1845).
+ *
+ * User-defined entries (other matchers, other commands) are preserved.
+ * Empty arrays/objects/files are pruned bottom-up to leave a clean
+ * filesystem state, matching the legacy scrubClaudeSettings cleanup chain.
+ */
+function scrubCommittedClaudeSettings(cwd: string, summary: EjectSummary): void {
+  const filePath = path.join(cwd, '.claude', 'settings.json');
+  if (!fs.existsSync(filePath)) {
+    summary.skipped.push('.claude/settings.json (not found)');
+    return;
+  }
+
+  // Read separately from parse so permission errors fail loud (they are
+  // a distinct failure mode from invalid JSON, which is recoverable as
+  // a documented eject skip per Tenet 4's "best-effort cleanup" carve-out).
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      summary.skipped.push('.claude/settings.json (invalid JSON)');
+      return;
+    }
+    throw err;
+  }
+
+  const hooks = parsed.hooks as Record<string, unknown[]> | undefined;
+  if (!hooks) {
+    summary.skipped.push('.claude/settings.json (no hooks)');
+    return;
+  }
+
+  const commandIncludes = (entry: { hooks?: Array<unknown> }, needle: string): boolean => {
+    const entryHooks = entry.hooks ?? [];
+    return entryHooks.some((h) => {
+      const cmd = typeof h === 'string' ? h : ((h as { command?: string } | null)?.command ?? '');
+      return cmd.includes(needle);
+    });
+  };
+
+  let mutated = false;
+
+  // PreToolUse → drop only the PreWriteShield entry. Other matchers
+  // (Bash legacy, user-defined Write|Edit) preserved.
+  const preToolUse = hooks.PreToolUse as
+    | Array<{ matcher?: string; hooks?: Array<unknown> }>
+    | undefined;
+  if (preToolUse) {
+    const filtered = preToolUse.filter(
+      (entry) => !(entry.matcher === 'Write|Edit' && commandIncludes(entry, 'PreWriteShield')),
+    );
+    if (filtered.length !== preToolUse.length) {
+      mutated = true;
+      if (filtered.length === 0) {
+        delete hooks.PreToolUse;
+      } else {
+        hooks.PreToolUse = filtered;
+      }
+    }
+  }
+
+  // SessionStart → drop only the Totem entry (matches by command needle,
+  // no matcher field on SessionStart entries).
+  const sessionStart = hooks.SessionStart as Array<{ hooks?: Array<unknown> }> | undefined;
+  if (sessionStart) {
+    const filtered = sessionStart.filter((entry) => !commandIncludes(entry, 'SessionStart.cjs'));
+    if (filtered.length !== sessionStart.length) {
+      mutated = true;
+      if (filtered.length === 0) {
+        delete hooks.SessionStart;
+      } else {
+        hooks.SessionStart = filtered;
+      }
+    }
+  }
+
+  if (!mutated) {
+    summary.skipped.push('.claude/settings.json (no Totem hooks)');
+    return;
+  }
+
+  // Bottom-up pruning matches the .local.json cleanup chain.
+  if (Object.keys(hooks).length === 0) {
+    delete parsed.hooks;
+  }
+
+  if (Object.keys(parsed).length === 0) {
+    fs.unlinkSync(filePath);
+    summary.removed.push('.claude/settings.json');
+  } else {
+    fs.writeFileSync(filePath, JSON.stringify(parsed, null, 2) + '\n', 'utf-8');
+    summary.scrubbed.push('.claude/settings.json');
+  }
+}
+
+/**
  * Remove the AI Integration block appended by `totem init` to reflex files.
  */
 function scrubReflexFiles(cwd: string, summary: EjectSummary): void {
@@ -303,13 +412,16 @@ export async function ejectCommand(options: EjectOptions): Promise<void> {
   // 2. Remove scaffolded Gemini/Claude hook files
   removeScaffoldedFiles(cwd, summary);
 
-  // 3. Scrub Claude settings.local.json
+  // 3. Scrub Claude settings.local.json (per-developer shield-gate)
   scrubClaudeSettings(cwd, summary);
 
-  // 4. Scrub AI reflex blocks from markdown files
+  // 4. Scrub Claude settings.json (committed PreWriteShield + SessionStart entries)
+  scrubCommittedClaudeSettings(cwd, summary);
+
+  // 5. Scrub AI reflex blocks from markdown files
   scrubReflexFiles(cwd, summary);
 
-  // 5. Delete artifacts
+  // 6. Delete artifacts
   deleteArtifacts(cwd, summary);
 
   // Print summary

--- a/packages/cli/src/commands/eject.ts
+++ b/packages/cli/src/commands/eject.ts
@@ -233,9 +233,9 @@ function scrubCommittedClaudeSettings(cwd: string, summary: EjectSummary): void 
   // a distinct failure mode from invalid JSON, which is recoverable as
   // a documented eject skip per Tenet 4's "best-effort cleanup" carve-out).
   const raw = fs.readFileSync(filePath, 'utf-8');
-  let parsed: Record<string, unknown>;
+  let rawParsed: unknown;
   try {
-    parsed = JSON.parse(raw);
+    rawParsed = JSON.parse(raw);
   } catch (err) {
     if (err instanceof SyntaxError) {
       summary.skipped.push('.claude/settings.json (invalid JSON)');
@@ -243,12 +243,18 @@ function scrubCommittedClaudeSettings(cwd: string, summary: EjectSummary): void 
     }
     throw err;
   }
+  if (!rawParsed || typeof rawParsed !== 'object' || Array.isArray(rawParsed)) {
+    summary.skipped.push('.claude/settings.json (unexpected root shape)');
+    return;
+  }
+  const parsed = rawParsed as Record<string, unknown>;
 
-  const hooks = parsed.hooks as Record<string, unknown[]> | undefined;
-  if (!hooks) {
+  const hooksRaw = parsed.hooks;
+  if (!hooksRaw || typeof hooksRaw !== 'object' || Array.isArray(hooksRaw)) {
     summary.skipped.push('.claude/settings.json (no hooks)');
     return;
   }
+  const hooks = hooksRaw as Record<string, unknown>;
 
   const commandIncludes = (entry: { hooks?: Array<unknown> }, needle: string): boolean => {
     const entryHooks = entry.hooks ?? [];
@@ -261,11 +267,12 @@ function scrubCommittedClaudeSettings(cwd: string, summary: EjectSummary): void 
   let mutated = false;
 
   // PreToolUse → drop only the PreWriteShield entry. Other matchers
-  // (Bash legacy, user-defined Write|Edit) preserved.
-  const preToolUse = hooks.PreToolUse as
-    | Array<{ matcher?: string; hooks?: Array<unknown> }>
-    | undefined;
-  if (preToolUse) {
+  // (Bash legacy, user-defined Write|Edit) preserved. Array guard so a
+  // malformed-but-valid JSON shape (e.g., `"PreToolUse": null`) is
+  // skipped instead of crashing the eject best-effort cleanup.
+  const preToolUseRaw = hooks.PreToolUse;
+  if (Array.isArray(preToolUseRaw)) {
+    const preToolUse = preToolUseRaw as Array<{ matcher?: string; hooks?: Array<unknown> }>;
     const filtered = preToolUse.filter(
       (entry) => !(entry.matcher === 'Write|Edit' && commandIncludes(entry, 'PreWriteShield')),
     );
@@ -281,8 +288,9 @@ function scrubCommittedClaudeSettings(cwd: string, summary: EjectSummary): void 
 
   // SessionStart → drop only the Totem entry (matches by command needle,
   // no matcher field on SessionStart entries).
-  const sessionStart = hooks.SessionStart as Array<{ hooks?: Array<unknown> }> | undefined;
-  if (sessionStart) {
+  const sessionStartRaw = hooks.SessionStart;
+  if (Array.isArray(sessionStartRaw)) {
+    const sessionStart = sessionStartRaw as Array<{ hooks?: Array<unknown> }>;
     const filtered = sessionStart.filter((entry) => !commandIncludes(entry, 'SessionStart.cjs'));
     if (filtered.length !== sessionStart.length) {
       mutated = true;

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -294,6 +294,78 @@ export const CLAUDE_PREWRITESHIELD_ENTRY = {
   ],
 };
 
+// --- Claude Code SessionStart hook (mmnto-ai/totem#1845 slice 1) ---
+//
+// Symmetric to .gemini/hooks/SessionStart.js: runs the Totem CLI's
+// `describe` at session start so Claude boots with project orientation
+// (project name, tier, lessons count, targets list) instead of starting
+// cold. Wires into committed `.claude/settings.json` (team-level
+// guarantee per the same architectural rule that placed PreWriteShield
+// there in Phase B; orientation IS a team contract).
+//
+// `.cjs` extension is load-bearing: package.json `type: module` repos
+// otherwise resolve `.js` as ESM and reject the CommonJS `require()`
+// calls. Claude Code execs hooks via plain `node`.
+//
+// stderr is routed to stdout because the Totem CLI writes diagnostic
+// output to stderr; SessionStart context must land in Claude's prompt,
+// not in user-visible noise.
+//
+// Fallbacks are deliberately generic — project-specific orientation is
+// the job of `totem describe` itself, not the fallback message.
+
+// totem-context: hook script template content — child_process is part
+// of the rendered .cjs payload that Claude Code execs via plain `node`,
+// not a runtime call from this cli source. Same shape as
+// GEMINI_SESSION_START + CLAUDE_PREWRITESHIELD above. Hook scripts
+// can't go through safeExec because they don't have access to the cli
+// runtime when Claude execs them.
+export const CLAUDE_SESSION_START = `// [totem] auto-generated — Claude Code SessionStart hook
+// Runs \`@mmnto/cli describe\` at the start of every Claude Code session.
+// Mirrors \`.gemini/hooks/SessionStart.js\`. \`.cjs\` extension because
+// package.json may have "type": "module" — Claude Code execs hooks via
+// plain \`node\`, which would otherwise treat \`.js\` as ESM.
+const { spawnSync } = require('child_process');
+const { existsSync } = require('fs');
+const { join } = require('path');
+
+try {
+  const cliPath = join(process.cwd(), 'node_modules', '@mmnto', 'cli', 'dist', 'index.js');
+  if (existsSync(cliPath)) {
+    const result = spawnSync(process.execPath, [cliPath, 'describe'], {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    if (result.error) {
+      throw result.error;
+    }
+    // Totem CLI writes diagnostic output to stderr; route to stdout so the
+    // session-start context lands in Claude's prompt rather than user-visible noise.
+    process.stdout.write((result.stdout || '') + (result.stderr || ''));
+  } else {
+    process.stdout.write(
+      '[Totem] @mmnto/cli not installed. Run \`pnpm install\` (or your package manager equivalent) to enable session-start orientation.\\n',
+    );
+  }
+} catch (err) {
+  process.stdout.write(
+    '[Totem] Briefing unavailable: ' +
+      (err instanceof Error ? err.message : String(err)) +
+      '\\n',
+  );
+}
+`;
+
+export const CLAUDE_SESSION_START_ENTRY = {
+  hooks: [
+    {
+      type: 'command',
+      command: 'node .claude/hooks/SessionStart.cjs',
+      timeout: 30000,
+    },
+  ],
+};
+
 // ─── Config generation ──────────────────────────────────
 
 export async function generateConfig(

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -22,6 +22,7 @@ import {
   installBaselineLessons,
   REFLEX_VERSION,
   scaffoldClaudeHooks,
+  scaffoldClaudeSessionStart,
   scaffoldClaudeWriteShield,
   scaffoldFile,
   scaffoldMcpConfig,
@@ -32,6 +33,8 @@ import {
   BARE_REF_REGEX_SOURCE,
   CLAUDE_PREWRITESHIELD,
   CLAUDE_PREWRITESHIELD_ENTRY,
+  CLAUDE_SESSION_START,
+  CLAUDE_SESSION_START_ENTRY,
   GEMINI_BEFORE_TOOL,
   generateConfigForFormat,
 } from './init-templates.js';
@@ -1194,6 +1197,159 @@ describe('scaffoldClaudeWriteShield', () => {
 
     expect(result.action).toBe('skipped');
     expect(result.err).toContain('invalid JSON');
+  });
+});
+
+// Phase C slice 1 — symmetric Claude SessionStart hook (mmnto-ai/totem#1845).
+// Locks the install-side parity with .gemini/hooks/SessionStart.js: scaffold
+// the .cjs script, merge a SessionStart entry into committed
+// .claude/settings.json, idempotency on re-run, preserve user hooks +
+// coexist with Phase B's PreWriteShield entry under the same hooks object.
+describe('scaffoldClaudeSessionStart', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-claude-sessionstart-'));
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  it('creates settings.json with SessionStart entry when none exists', () => {
+    const filePath = path.join(tmpDir, '.claude', 'settings.json');
+    const result = scaffoldClaudeSessionStart(filePath);
+
+    expect(result).toEqual({ action: 'created' });
+    const content = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    expect(content.hooks).toBeDefined();
+    expect(content.hooks.SessionStart).toHaveLength(1);
+    expect(content.hooks.SessionStart[0].hooks[0]).toEqual({
+      type: 'command',
+      command: 'node .claude/hooks/SessionStart.cjs',
+      timeout: 30000,
+    });
+    // SessionStart entries do NOT carry a `matcher` field.
+    expect(content.hooks.SessionStart[0].matcher).toBeUndefined();
+  });
+
+  it('is idempotent — double invoke does not duplicate', () => {
+    const filePath = path.join(tmpDir, '.claude', 'settings.json');
+
+    const first = scaffoldClaudeSessionStart(filePath);
+    expect(first).toEqual({ action: 'created' });
+
+    const second = scaffoldClaudeSessionStart(filePath);
+    expect(second).toEqual({ action: 'skipped' });
+
+    const content = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    expect(content.hooks.SessionStart).toHaveLength(1);
+  });
+
+  it('preserves a user-defined SessionStart entry alongside the Totem entry', () => {
+    const dir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(dir, { recursive: true });
+    const filePath = path.join(dir, 'settings.json');
+    const existing = {
+      hooks: {
+        SessionStart: [{ hooks: [{ type: 'command', command: 'echo "user-defined"' }] }],
+      },
+    };
+    fs.writeFileSync(filePath, JSON.stringify(existing, null, 2) + '\n', 'utf-8');
+
+    const result = scaffoldClaudeSessionStart(filePath);
+
+    expect(result).toEqual({ action: 'merged' });
+    const content = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    expect(content.hooks.SessionStart).toHaveLength(2);
+    expect(content.hooks.SessionStart[0].hooks[0].command).toBe('echo "user-defined"');
+    expect(content.hooks.SessionStart[1].hooks[0].command).toContain('SessionStart.cjs');
+  });
+
+  it('coexists with Phase B PreWriteShield entry under the same hooks object', () => {
+    const dir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(dir, { recursive: true });
+    const filePath = path.join(dir, 'settings.json');
+    const existing = {
+      hooks: { PreToolUse: [CLAUDE_PREWRITESHIELD_ENTRY] },
+    };
+    fs.writeFileSync(filePath, JSON.stringify(existing, null, 2) + '\n', 'utf-8');
+
+    const result = scaffoldClaudeSessionStart(filePath);
+
+    expect(result).toEqual({ action: 'merged' });
+    const content = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    expect(content.hooks.PreToolUse).toHaveLength(1);
+    expect(content.hooks.PreToolUse[0].matcher).toBe('Write|Edit');
+    expect(content.hooks.SessionStart).toHaveLength(1);
+    expect(content.hooks.SessionStart[0].hooks[0].command).toContain('SessionStart.cjs');
+  });
+
+  it('skips when a Totem SessionStart entry is already present', () => {
+    const dir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(dir, { recursive: true });
+    const filePath = path.join(dir, 'settings.json');
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({ hooks: { SessionStart: [CLAUDE_SESSION_START_ENTRY] } }, null, 2) + '\n',
+      'utf-8',
+    );
+
+    const result = scaffoldClaudeSessionStart(filePath);
+
+    expect(result).toEqual({ action: 'skipped' });
+  });
+
+  it('returns error on malformed JSON', () => {
+    const dir = path.join(tmpDir, '.claude');
+    fs.mkdirSync(dir, { recursive: true });
+    const filePath = path.join(dir, 'settings.json');
+    fs.writeFileSync(filePath, '{ broken!!!', 'utf-8');
+
+    const result = scaffoldClaudeSessionStart(filePath);
+
+    expect(result.action).toBe('skipped');
+    expect(result.err).toContain('invalid JSON');
+  });
+});
+
+describe('CLAUDE_SESSION_START template', () => {
+  it('contains the totem auto-generated marker', () => {
+    expect(CLAUDE_SESSION_START).toContain('// [totem] auto-generated');
+  });
+
+  it('routes stderr to stdout (substring contract)', () => {
+    // The hook MUST surface CLI stderr alongside stdout because the Totem
+    // CLI writes diagnostic output (the actual `describe` text) to stderr;
+    // routing it to stdout is the only way Claude sees the orientation
+    // banner in its prompt context. Substring-match keeps copy edits cheap
+    // while still locking the breadcrumb chain.
+    expect(CLAUDE_SESSION_START).toContain('result.stdout');
+    expect(CLAUDE_SESSION_START).toContain('result.stderr');
+    expect(CLAUDE_SESSION_START).toContain('process.stdout.write');
+  });
+
+  it('includes the @mmnto/cli not-installed fallback message', () => {
+    expect(CLAUDE_SESSION_START).toContain('@mmnto/cli not installed');
+  });
+
+  it('includes the process-error fallback path', () => {
+    expect(CLAUDE_SESSION_START).toContain('Briefing unavailable');
+  });
+
+  it('uses the canonical node_modules/@mmnto/cli/dist/index.js path probe', () => {
+    expect(CLAUDE_SESSION_START).toContain('@mmnto');
+    expect(CLAUDE_SESSION_START).toContain("'cli'");
+    expect(CLAUDE_SESSION_START).toContain("'dist'");
+    expect(CLAUDE_SESSION_START).toContain("'index.js'");
+  });
+
+  it('does NOT propagate strategy-repo-specific orientation pointers', () => {
+    // OQ 2 disposition: keep the fallback generic. The strategy reference
+    // mentions README.md, design-tenets.md, .journal/strategy/ — none of
+    // those should leak into the consumer-facing baseline.
+    expect(CLAUDE_SESSION_START).not.toContain('design-tenets');
+    expect(CLAUDE_SESSION_START).not.toContain('.journal/strategy');
   });
 });
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -17,6 +17,8 @@ import {
   CLAUDE_PRETOOLUSE_ENTRY,
   CLAUDE_PREWRITESHIELD,
   CLAUDE_PREWRITESHIELD_ENTRY,
+  CLAUDE_SESSION_START,
+  CLAUDE_SESSION_START_ENTRY,
   GEMINI_BEFORE_TOOL,
   GEMINI_SESSION_START,
   GEMINI_SKILL,
@@ -105,20 +107,29 @@ const HookCommandSchema = z.union([
   z.object({ type: z.string(), command: z.string() }).passthrough(),
 ]);
 
+const PreToolUseEntrySchema = z
+  .object({
+    matcher: z.string().optional(),
+    hooks: z.array(HookCommandSchema).optional(),
+  })
+  .passthrough();
+
+const SessionStartEntrySchema = z
+  .object({
+    // SessionStart entries do NOT carry a `matcher` field (unlike
+    // PreToolUse entries). Adding it here would silently drop unknown
+    // shapes; passthrough preserves any future fields without breaking
+    // round-trip read/write.
+    hooks: z.array(HookCommandSchema).optional(),
+  })
+  .passthrough();
+
 const ClaudeSettingsSchema = z
   .object({
     hooks: z
       .object({
-        PreToolUse: z
-          .array(
-            z
-              .object({
-                matcher: z.string().optional(),
-                hooks: z.array(HookCommandSchema).optional(),
-              })
-              .passthrough(),
-          )
-          .optional(),
+        PreToolUse: z.array(PreToolUseEntrySchema).optional(),
+        SessionStart: z.array(SessionStartEntrySchema).optional(),
       })
       .passthrough()
       .optional(),
@@ -142,19 +153,34 @@ function hasPreWriteShield(entry: z.infer<typeof HookCommandSchema>): boolean {
   return entry.command.includes('PreWriteShield');
 }
 
+/** Check whether a hook entry already contains a SessionStart.cjs reference. */
+function hasTotemSessionStart(entry: z.infer<typeof HookCommandSchema>): boolean {
+  if (typeof entry === 'string') return entry.includes('SessionStart.cjs');
+  return entry.command.includes('SessionStart.cjs');
+}
+
 type ParsedSettings = z.infer<typeof ClaudeSettingsSchema>;
 type PreToolUseMatcher = 'Bash' | 'Write|Edit';
 type ScaffoldOutcome = { action: 'created' | 'merged' | 'skipped'; err?: string };
+type ClaudeHooksKey = 'PreToolUse' | 'SessionStart';
+type ClaudeHookEntry =
+  | typeof CLAUDE_PRETOOLUSE_ENTRY
+  | typeof CLAUDE_PREWRITESHIELD_ENTRY
+  | typeof CLAUDE_SESSION_START_ENTRY;
 
 /**
- * Shared merge logic for installing a single PreToolUse entry into a
- * Claude settings JSON file (settings.local.json or settings.json).
+ * Shared merge logic for installing a single hook entry into a Claude
+ * settings JSON file (`settings.local.json` or `settings.json`) under
+ * `hooks.<key>`. Both `PreToolUse` and `SessionStart` lifecycles share
+ * the same read → safeparse → idempotency probe → append → write shape;
+ * this is the single source of truth.
  *
- * Idempotent: returns 'skipped' if `alreadyInstalled(parsed)` returns true.
+ * Idempotent: returns `'skipped'` if `alreadyInstalled(parsed)` is true.
  */
-function mergeClaudePreToolUseEntry(
+function mergeClaudeHooksKey(
   filePath: string,
-  entry: typeof CLAUDE_PRETOOLUSE_ENTRY | typeof CLAUDE_PREWRITESHIELD_ENTRY,
+  hookKind: ClaudeHooksKey,
+  entry: ClaudeHookEntry,
   alreadyInstalled: (parsed: ParsedSettings) => boolean,
 ): ScaffoldOutcome {
   try {
@@ -165,7 +191,7 @@ function mergeClaudePreToolUseEntry(
 
     const fileName = path.basename(filePath);
 
-    const fullConfig = { hooks: { PreToolUse: [entry] } };
+    const fullConfig = { hooks: { [hookKind]: [entry] } };
 
     if (!fs.existsSync(filePath)) {
       fs.writeFileSync(filePath, JSON.stringify(fullConfig, null, 2) + '\n', 'utf-8');
@@ -198,9 +224,9 @@ function mergeClaudePreToolUseEntry(
       return { action: 'skipped' };
     }
 
-    const preToolUse = parsed.hooks?.PreToolUse ?? [];
+    const existing = parsed.hooks?.[hookKind] ?? [];
     const hooks = parsed.hooks ?? {};
-    hooks.PreToolUse = [...preToolUse, entry];
+    hooks[hookKind] = [...existing, entry];
     parsed.hooks = hooks;
     fs.writeFileSync(filePath, JSON.stringify(parsed, null, 2) + '\n', 'utf-8');
     return { action: 'merged' };
@@ -221,12 +247,20 @@ function preToolUseHasMatcher(
   );
 }
 
+function sessionStartHas(
+  parsed: ParsedSettings,
+  probe: (entry: z.infer<typeof HookCommandSchema>) => boolean,
+): boolean {
+  const sessionStart = parsed.hooks?.SessionStart ?? [];
+  return sessionStart.some((h) => Array.isArray(h.hooks) && h.hooks.some(probe));
+}
+
 /**
  * Merge Totem hooks into .claude/settings.local.json without overwriting
  * existing user-defined hooks. Installs the Bash matcher for shield-gate.
  */
 export function scaffoldClaudeHooks(filePath: string): ScaffoldOutcome {
-  return mergeClaudePreToolUseEntry(filePath, CLAUDE_PRETOOLUSE_ENTRY, (parsed) =>
+  return mergeClaudeHooksKey(filePath, 'PreToolUse', CLAUDE_PRETOOLUSE_ENTRY, (parsed) =>
     preToolUseHasMatcher(parsed, 'Bash', hasTotemShield),
   );
 }
@@ -241,8 +275,22 @@ export function scaffoldClaudeHooks(filePath: string): ScaffoldOutcome {
  * (team-level governance, sealed at mmnto-ai/totem-strategy#145).
  */
 export function scaffoldClaudeWriteShield(filePath: string): ScaffoldOutcome {
-  return mergeClaudePreToolUseEntry(filePath, CLAUDE_PREWRITESHIELD_ENTRY, (parsed) =>
+  return mergeClaudeHooksKey(filePath, 'PreToolUse', CLAUDE_PREWRITESHIELD_ENTRY, (parsed) =>
     preToolUseHasMatcher(parsed, 'Write|Edit', hasPreWriteShield),
+  );
+}
+
+/**
+ * Merge the Claude SessionStart hook entry into .claude/settings.json
+ * (committed, team-level) without overwriting existing user-defined
+ * hooks. Symmetric with the Gemini-side .gemini/hooks/SessionStart.js
+ * install (mmnto-ai/totem#1845 slice 1) — orientation IS a team-level
+ * guarantee, so it shares the committed settings.json placement with
+ * Phase B's PreWriteShield.
+ */
+export function scaffoldClaudeSessionStart(filePath: string): ScaffoldOutcome {
+  return mergeClaudeHooksKey(filePath, 'SessionStart', CLAUDE_SESSION_START_ENTRY, (parsed) =>
+    sessionStartHas(parsed, hasTotemSessionStart),
   );
 }
 
@@ -250,26 +298,48 @@ async function installClaudeHooks(cwd: string): Promise<HookInstallerResult[]> {
   // Bash gate architecture removed (Proposal 207). Write-time enforcement
   // re-introduced via PreWriteShield hook (mmnto-ai/totem#1846): blocks
   // bare cross-repo refs in substrate-participating paths before disk write.
-  // Sealed at mmnto-ai/totem-strategy#145.
+  // Sealed at mmnto-ai/totem-strategy#145. SessionStart hook added in
+  // mmnto-ai/totem#1845 slice 1 for parity with Gemini-side install.
   const results: HookInstallerResult[] = [];
+  const settingsPath = path.join(cwd, '.claude', 'settings.json');
 
-  // 1. Scaffold the hook script — committed to .claude/hooks/ for team-level
-  //    propagation per OQ 2 of the design (mmnto-ai/totem-strategy:.totem/specs).
-  const hookPath = path.join(cwd, '.claude', 'hooks', 'PreWriteShield.cjs');
-  const hookResult = scaffoldFile(hookPath, CLAUDE_PREWRITESHIELD, TOTEM_FILE_MARKER);
+  // 1. Scaffold the PreWriteShield hook script (committed to .claude/hooks/).
+  const preWritePath = path.join(cwd, '.claude', 'hooks', 'PreWriteShield.cjs');
+  const preWriteResult = scaffoldFile(preWritePath, CLAUDE_PREWRITESHIELD, TOTEM_FILE_MARKER);
   results.push({
     file: '.claude/hooks/PreWriteShield.cjs',
-    ...hookResult,
+    ...preWriteResult,
   });
 
-  // 2. Merge the PreToolUse entry into committed .claude/settings.json
-  //    (distinct from settings.local.json which holds the per-developer
-  //    shield-gate from before Proposal 207).
-  const settingsPath = path.join(cwd, '.claude', 'settings.json');
-  const settingsResult = scaffoldClaudeWriteShield(settingsPath);
+  // 2. Scaffold the SessionStart hook script (committed to .claude/hooks/).
+  //    Symmetric with .gemini/hooks/SessionStart.js — Tenet 16 parity.
+  const sessionStartPath = path.join(cwd, '.claude', 'hooks', 'SessionStart.cjs');
+  const sessionStartResult = scaffoldFile(
+    sessionStartPath,
+    CLAUDE_SESSION_START,
+    TOTEM_FILE_MARKER,
+  );
+  results.push({
+    file: '.claude/hooks/SessionStart.cjs',
+    ...sessionStartResult,
+  });
+
+  // 3. Merge the PreWriteShield PreToolUse entry into committed
+  //    .claude/settings.json (distinct from settings.local.json which
+  //    holds the per-developer shield-gate from before Proposal 207).
+  const writeShieldEntryResult = scaffoldClaudeWriteShield(settingsPath);
   results.push({
     file: '.claude/settings.json',
-    ...settingsResult,
+    ...writeShieldEntryResult,
+  });
+
+  // 4. Merge the SessionStart entry into committed .claude/settings.json.
+  //    Same file as step 3; the merge helper appends idempotently under
+  //    `hooks.SessionStart` without disturbing `hooks.PreToolUse`.
+  const sessionStartEntryResult = scaffoldClaudeSessionStart(settingsPath);
+  results.push({
+    file: '.claude/settings.json (SessionStart)',
+    ...sessionStartEntryResult,
   });
 
   return results;


### PR DESCRIPTION
## Summary

- `totem init` now installs a Claude Code `SessionStart` hook (`.claude/hooks/SessionStart.cjs` + a merged entry under `hooks.SessionStart` in committed `.claude/settings.json`), giving Claude sessions the same `totem describe` orientation banner that Gemini-side `.gemini/hooks/SessionStart.js` has produced since pre-Phase-B.
- `totem eject` now scrubs **both** the new SessionStart entry and the Phase B `PreWriteShield` entry from committed `.claude/settings.json`, plus removes the corresponding `.claude/hooks/*.cjs` scaffold files (marker-checked so user-authored hooks survive). **Closes the eject-parity gap from `#1852` in the same PR** since both gaps live on the same committed surface.
- Refactor: extracted `mergeClaudeHooksKey` as the single source of truth for the read → safeparse → idempotency probe → append → write merge logic. `scaffoldClaudeHooks`, `scaffoldClaudeWriteShield`, and the new `scaffoldClaudeSessionStart` are thin wrappers.

PR is **slice 1 of the Phase C 3-way split** for `#1845`. Slices 2 (`describe`-canonical reconciliation) and 3 (session-utility skill suite distribution) are out of scope here.

## Architectural notes (per design doc, all greenlit)

- **OQ 1: Closes `#1852` (Phase B eject parity)** — same architectural class of gap on the same committed file. Avoids leaving a known inconsistency that would invite bot review noise ("why does this PR scrub SessionStart but not PreWriteShield from the same file?"). Tiny additional diff because the eject helper is naturally shared.
- **OQ 2: Generic fallback message** — strategy-repo orientation pointers (README.md, design-tenets.md, .journal/strategy/) deliberately NOT propagated. Project-specific orientation is the job of `totem describe` itself, not the fallback.
- **OQ 4: Extracted `mergeClaudeHooksKey`** — Phase B established the "shared merge helper" pattern; paying the small refactor cost here once instead of duplicating ~30 lines per future hook key.
- **OQ 5: Committed `.claude/settings.json`** — matches Phase B's PreWriteShield placement. Orientation IS a team-level guarantee; same architectural rule that placed PreWriteShield there applies here. Distinct from the legacy shield-gate in `.local.json` (per-developer).
- **`.cjs` extension is load-bearing** — `package.json type: module` repos otherwise resolve `.js` as ESM and reject the CommonJS `require()` calls. Claude Code execs hooks via plain `node`.
- **Read separated from parse in eject** — permission errors fail loud (Tenet 4), invalid JSON skipped per eject best-effort. Defensive guards added against valid-but-unexpected JSON shapes (root non-object, `hooks` non-object, `hooks.PreToolUse`/`hooks.SessionStart` non-array) so eject degrades cleanly instead of crashing on TypeError.

## Mid-implementation discovery (banked)

The Tenet 4 `Ban fail-open catch blocks` lint rule's matcher is pure ast-grep (`not.has.throw_statement` walking the catch body); the `// totem-context: intentional cleanup` directive in the lesson's recommendation is documentation guidance, NOT actually checked by the matcher. Refactored to read raw → throw on permission errors (loud) + parse → swallow only `SyntaxError` for invalid JSON (eject best-effort). Worth filing as a follow-up: extend the matcher to honor the documented suppression directive, OR update the lesson to remove the misleading guidance.

## Test plan

- [x] `pnpm --filter @mmnto/cli test init.test.ts eject.test.ts` — 152/152 pass (24 new)
- [x] `pnpm test` — 2035+ tests across all workspaces pass
- [x] `pnpm exec totem lint` — PASS, 0 errors (warnings are pre-existing #1793 corpus-health on test files only)
- [x] `pnpm exec totem review` — PASS, no critical findings
- [x] `pnpm exec totem verify-manifest` — PASS, 471 rules

### Test invariants locked

- Init: `.cjs` extension contract preserved
- Init: settings.json merge idempotent on re-run
- Init: preserves user-defined SessionStart entries alongside Totem entry
- Init: coexists with Phase B PreWriteShield under the same `hooks` object
- Init: hook content routes stderr→stdout (substring contract on the breadcrumb chain)
- Init: generic fallback (no strategy-repo orientation pointer leak)
- Eject: SessionStart entry removed without affecting Phase B PreWriteShield
- Eject: PreWriteShield entry removed (closes `#1852`)
- Eject: bottom-up pruning when both arrays empty → file unlinked
- Eject: `.claude/hooks/SessionStart.cjs` + `.claude/hooks/PreWriteShield.cjs` deleted only when marker present
- Eject: user-authored hooks (no marker) preserved
- Eject: defensive against valid-but-unexpected JSON shapes (root non-object, `hooks` non-object, `hooks.PreToolUse`/`SessionStart` non-array)

Closes `#1845` (slice 1) and `#1852`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)