### PR TITLE
fix(core): trim clause-internal-cut heading tails (#1872)

### DIFF
--- a/.changeset/fix-lesson-heading-clause-truncation.md
+++ b/.changeset/fix-lesson-heading-clause-truncation.md
@@ -1,0 +1,35 @@
+---
+'@mmnto/totem': patch
+---
+
+`generateLessonHeading` / `truncateHeading` now strip clause-internal-cut tails
+where a verb/adjective-shaped trailing word is anchored to an immediately-preceding
+preposition. Closes the per-postmerge-cycle tax LC was paying on extracted
+headings like:
+
+- `Validate const_name suffix before codegen to prevent` → `Validate const_name suffix before codegen`
+- `RON tuple syntax differs from array syntax for fixed-size` → `RON tuple syntax differs from array syntax`
+- `Snapshot canonical form should exclude metadata to isolate` → `Snapshot canonical form should exclude metadata`
+- `Document pre-resource call sites to enable auditable` → `Document pre-resource call sites`
+
+The prior single-word `DANGLING_TAIL_RE` only caught trailing prepositions
+(`...for the`); it didn't recognize that `<prep> <expectant-word>` patterns
+(`...to prevent`, `...for fixed-size`) leave the heading mid-clause.
+
+The fix walks backwards from the end of the heading collecting consecutive
+expectant-shaped words (verb/adjective suffixes `-ate|-ize|-ify|-able|-ible|-ing|-ent|-ant`,
+or hyphenated compounds), then checks the IMMEDIATE anchor word. If the
+anchor is a preposition, the run is stripped and the existing dangling-tail
+check removes the prep too. The immediate-adjacency check protects common
+nouns ending in those suffixes (`component`, `client`, `state`, `environment`,
+`load-balancer`) — when an article like `the` sits between the preposition
+and the noun, the run stops at the noun and the heading is preserved.
+
+Closes `mmnto-ai/totem#1872`. Original fix in `mmnto-ai/totem#253` / `mmnto-ai/totem#348`
+addressed an earlier shape; this regression is the same defect class re-emerging
+from extractor LLM output that produces phrasings the prior heuristic didn't cover.
+
+Empirical evidence base: three consecutive `mmnto-ai/liquid-city` postmerge cycles
+(`mmnto-ai/liquid-city#229` 75% truncated, `mmnto-ai/liquid-city#234` 33% truncated,
+`mmnto-ai/liquid-city#238` 14% truncated) — pattern stable across cycles, fix
+addresses all observed cases.

--- a/.totem/specs/1872.md
+++ b/.totem/specs/1872.md
@@ -1,0 +1,34 @@
+### Problem Statement
+
+The `totem lesson extract` command is producing mid-clause truncated lesson headings because the post-LLM truncation function (`truncateHeading`) enforces a strict ~60 character limit that slices sentences awkwardly (e.g., leaving dangling prepositions). The truncation logic must be updated to be word-boundary-aware, specifically by including the current trailing word if it fits within a slightly expanded character window.
+
+### Architectural Context
+
+This is a regression of issues `#348` and `#253`. The codebase previously attempted to fix heading truncations (`#320`) but implemented a cut that lacked proper word boundary/sentence-end semantics. As observed in LC postmerge cycles `#229` and `#234`, headings are abruptly chopped near 60 characters without trailing context. We must implement the community-proposed fix shape: making the cut word-boundary-aware by including the next word if it falls within an acceptable overflow buffer (65–75 chars) rather than performing a blind truncation.
+
+### Files to Examine
+
+1. `packages/core/src/lesson-format.ts` — Contains the `truncateHeading` function which performs the post-process truncation causing this regression.
+2. `packages/core/src/__tests__/lesson-format.test.ts` (or equivalent test file) — Needs regression tests demonstrating that mid-clause chops are prevented and full words are included up to the relaxed limit.
+
+### Technical Approach & Contracts
+
+We will update `truncateHeading` in `packages/core/src/lesson-format.ts` to implement a "soft limit / hard limit" word-boundary-aware truncation algorithm.
+
+**Logic flow:**
+
+1. Maintain the current behavior of stripping trailing ellipses.
+2. Establish a `SOFT_LIMIT = 60` and `HARD_LIMIT = 75`.
+3. If `text.length <= SOFT_LIMIT`, return as is.
+4. If `text.length > SOFT_LIMIT`, find the next space _after_ `SOFT_LIMIT` (`indexOf(' ', SOFT_LIMIT)`).
+5. If the next space is found at an index `<= HARD_LIMIT`, substring to that space (including the next word).
+6. If no space is found but `text.length <= HARD_LIMIT`, return the whole string.
+7. If the next word exceeds `HARD_LIMIT`, fallback to finding the last space _before_ `SOFT_LIMIT` (`lastIndexOf(' ', SOFT_LIMIT)`).
+8. If no spaces exist (a single 60+ char string), fallback to a strict substring at `SOFT_LIMIT`.
+
+**Trade-offs:**
+We could alternatively remove the post-process limit entirely and rely only on an LLM prompt constraint. However, since LLM prompt adherence can drift and produce heavily malformed layouts, implementing the smart-boundary truncation provides immediate architectural stability and definitively resolves the `#348` regression while honoring the requested 65–70 character buffer strategy.
+
+### Edge Cases & Traps
+
+- **Prefix Padding Trap:** The issue notes truncation falls in the

--- a/packages/core/src/lesson-format.test.ts
+++ b/packages/core/src/lesson-format.test.ts
@@ -163,6 +163,93 @@ describe('truncateHeading', () => {
       'Guard reversed marker ordering',
     );
   });
+
+  // ─── Clause-internal truncation (mmnto-ai/totem#1872) ──
+  // Empirical regressions from mmnto-ai/liquid-city#229 / #234 / #238:
+  // headings ≤60 chars whose final word is a complete English word
+  // (prevent, fixed-size, isolate, auditable) but in context completes
+  // an incomplete prepositional/infinitival phrase. The trailing word
+  // alone passes the single-word dangling-tail check, but the phrase
+  // reads as mid-clause cut.
+
+  it('trims trailing infinitive after "to" (LC#229)', () => {
+    expect(truncateHeading('Validate const_name suffix before codegen to prevent')).toBe(
+      'Validate const_name suffix before codegen',
+    );
+  });
+
+  it('trims trailing hyphenated adjective after "for" (LC#229)', () => {
+    expect(truncateHeading('RON tuple syntax differs from array syntax for fixed-size')).toBe(
+      'RON tuple syntax differs from array syntax',
+    );
+  });
+
+  it('trims trailing -ate verb after "to" (LC#229)', () => {
+    expect(truncateHeading('Snapshot canonical form should exclude metadata to isolate')).toBe(
+      'Snapshot canonical form should exclude metadata',
+    );
+  });
+
+  it('trims chained trailing expectant words (LC#234)', () => {
+    // "to enable auditable" — strip "auditable" (-able), then "enable" (-able),
+    // then "to" (dangling prep) — three iterations
+    expect(truncateHeading('Document pre-resource call sites to enable auditable')).toBe(
+      'Document pre-resource call sites',
+    );
+  });
+
+  it('does NOT trim bare verb at end when no preceding preposition', () => {
+    // "validate" has -ate suffix but no preposition before it in heading
+    expect(truncateHeading('Always validate')).toBe('Always validate');
+  });
+
+  it('does NOT trim valid prepositional phrase ending in plain noun', () => {
+    // "from user" / "in CI" / "for tests" — trailing word is a plain noun
+    // (no expectant suffix, no hyphen), so the prep+noun pair is kept.
+    expect(truncateHeading('Sanitize input from user')).toBe('Sanitize input from user');
+    expect(truncateHeading('Run integration tests in CI')).toBe('Run integration tests in CI');
+  });
+
+  // ─── False-positive guards (totem review CRITICAL on this PR) ──
+  // The first iteration of the fix used a non-adjacent prep check
+  // ("does the heading contain ANY prep") and over-stripped common
+  // programming nouns ending in expectant suffixes. The walk-back-then-
+  // immediate-anchor approach should preserve all of these.
+
+  it('does NOT strip when anchor before expectant word is an article', () => {
+    // "component" matches -ent suffix but anchor "the" is an article (not a prep)
+    expect(truncateHeading('Pass the props to the component')).toBe(
+      'Pass the props to the component',
+    );
+  });
+
+  it('does NOT strip when consecutive expectant words have non-prep anchor', () => {
+    // "client state" — both -ent/-ate, anchor is "Restore" (verb, not prep)
+    expect(truncateHeading('Restore client state')).toBe('Restore client state');
+  });
+
+  it('does NOT strip hyphenated noun with non-prep anchor', () => {
+    // "load-balancer" hyphenated, but anchor "Configure" is not a prep
+    expect(truncateHeading('Configure load-balancer')).toBe('Configure load-balancer');
+  });
+
+  it('does NOT strip expectant-suffixed common nouns with article anchor', () => {
+    // "environment" / "variable" / "string" all match suffixes but anchor "the"
+    expect(truncateHeading('Detect the environment')).toBe('Detect the environment');
+    expect(truncateHeading('Reset the variable')).toBe('Reset the variable');
+    expect(truncateHeading('Parse the string')).toBe('Parse the string');
+  });
+
+  it('handles >60-char heading with mid-clause cut at word boundary', () => {
+    // After cutting to 60 chars at word boundary the heading should still
+    // strip trailing incomplete-clause tails.
+    const long = 'Ensure all consumer repos qualify cross-repo references to prevent broken links';
+    // Truncates to "Ensure all consumer repos qualify cross-repo references" (~54 chars)
+    // No trailing prep+verb after truncation, so it stays clean.
+    const result = truncateHeading(long);
+    expect(result.length).toBeLessThanOrEqual(HEADING_MAX_CHARS);
+    expect(result).not.toMatch(/\sto\s+prevent$/);
+  });
 });
 
 // ─── rewriteLessonHeadings ─────────────────────────────

--- a/packages/core/src/lesson-format.ts
+++ b/packages/core/src/lesson-format.ts
@@ -9,10 +9,119 @@ const DANGLING_TAIL_RE =
   /\s+(?:the|a|an|of|for|in|on|at|to|by|with|from|into|via|and|or|but|is|are|was|were|that|this|its|their|your|against|between|within|about|after|before|during|through|across|can|must|should|when|if|as|than|like|e\.g\.?)$/i;
 
 /**
+ * Prepositions that, when they immediately precede an expectant-tail run,
+ * signal a mid-clause cut. The prep must be the IMMEDIATE anchor of the
+ * run — an article like "the" between the prep and the trailing word
+ * (as in "Pass the props to the component") stops the run at the noun and
+ * leaves the heading kept.
+ */
+const ANCHOR_PREPS = new Set([
+  'to',
+  'for',
+  'by',
+  'with',
+  'from',
+  'into',
+  'via',
+  'against',
+  'between',
+  'within',
+  'about',
+  'after',
+  'before',
+  'during',
+  'through',
+  'across',
+  'of',
+  'on',
+  'at',
+  'in',
+]);
+
+/**
+ * Suffixes that strongly signal a trailing word is a verb or attributive
+ * adjective expecting a noun complement. Used to detect "expectant runs"
+ * — consecutive trailing words like "enable auditable" — that signal an
+ * incomplete clause when anchored to a preposition.
+ *
+ * Note: many common English nouns (component, client, state, environment,
+ * string) also match these suffixes. The walk-backwards-collect logic
+ * relies on the IMMEDIATE-anchor check (must be a preposition with no
+ * intervening article/noun) to avoid over-stripping those.
+ */
+const EXPECTANT_SUFFIX_RE = /(?:ate|ize|ise|ify|able|ible|ing|ent|ant)$/i;
+
+function isExpectantWord(word: string): boolean {
+  // Hyphenated words (fixed-size, real-time, multi-tenant) are almost
+  // always attributive adjectives — treat as expectant.
+  if (word.includes('-')) return true;
+  return EXPECTANT_SUFFIX_RE.test(word);
+}
+
+/**
+ * Strip a trailing run of expectant words (one or more verb/adjective-shaped
+ * words at the end of the heading) when the run is IMMEDIATELY anchored to
+ * a preposition. Examples (mmnto-ai/totem#1872 regression evidence):
+ *
+ *   "Validate ... to prevent"          → strip "prevent" (anchored to "to")
+ *   "RON tuple ... for fixed-size"     → strip "fixed-size" (anchored to "for")
+ *   "Snapshot ... to isolate"          → strip "isolate" (anchored to "to")
+ *   "Document ... to enable auditable" → strip "enable auditable" (anchored to "to")
+ *
+ * The run is collected by walking backwards from the end as long as each
+ * word is "expectant" (verb/adjective-shaped or hyphenated). The anchor is
+ * the word immediately before the run. If the anchor is in ANCHOR_PREPS,
+ * strip the run; the existing dangling-tail check then strips the preposition.
+ *
+ * False positives are avoided by the immediate-adjacency check: in "Pass
+ * the props to the component", the anchor before "component" is "the"
+ * (not a preposition), so the heading is kept.
+ */
+function trimIncompleteClause(text: string): string {
+  const words = text.split(/\s+/);
+  if (words.length < 2) return text;
+
+  let runStart = words.length;
+  while (runStart > 0 && isExpectantWord(words[runStart - 1]!)) {
+    runStart--;
+  }
+  if (runStart === words.length) return text; // no trailing expectant run
+  if (runStart === 0) return text; // entire heading is expectant — no anchor
+
+  const anchor = words[runStart - 1]!;
+  if (!ANCHOR_PREPS.has(anchor.toLowerCase())) return text;
+
+  const trimmed = words.slice(0, runStart).join(' ').trimEnd();
+  if (trimmed.length < MIN_WORD_BREAK) return text;
+  return trimmed;
+}
+
+/**
+ * Iteratively trim trailing fragments that leave a heading mid-clause.
+ * Chains the existing dangling-tail strip with the clause-incomplete strip
+ * so multi-word tails ("to enable auditable") collapse cleanly.
+ */
+function trimTrailingFragments(text: string): string {
+  let prev = text;
+  for (;;) {
+    let next = prev;
+    if (DANGLING_TAIL_RE.test(next)) {
+      next = next.replace(DANGLING_TAIL_RE, '').trimEnd();
+    }
+    next = trimIncompleteClause(next);
+    if (next === prev || next.length < MIN_WORD_BREAK)
+      return next.length < MIN_WORD_BREAK ? prev : next;
+    prev = next;
+  }
+}
+
+/**
  * Truncate a heading string to HEADING_MAX_CHARS at a word boundary.
  * Strips trailing ellipsis/periods added by LLMs before enforcing the limit.
  * Also trims dangling prepositions/articles/conjunctions that leave the
- * heading feeling incomplete (e.g. "must be tested against the" → "must be tested").
+ * heading feeling incomplete (e.g. "must be tested against the" → "must be tested"),
+ * and clause-internal-cut tails where a verb/adjective follows a preposition
+ * (e.g. "to prevent" → drop both, per mmnto-ai/totem#1872).
  */
 export function truncateHeading(heading: string): string {
   // Strip trailing ellipsis (…) or triple-dot (...) that LLMs love to add
@@ -22,33 +131,14 @@ export function truncateHeading(heading: string): string {
     .trim();
 
   if (text.length <= HEADING_MAX_CHARS) {
-    // Even short headings can have dangling tails from LLM ellipsis stripping
-    let cleaned = text;
-    let prev = cleaned;
-    while (DANGLING_TAIL_RE.test(cleaned)) {
-      cleaned = cleaned.replace(DANGLING_TAIL_RE, '').trimEnd();
-      if (cleaned === prev || cleaned.length < MIN_WORD_BREAK) return prev;
-      prev = cleaned;
-    }
-    return cleaned || text;
+    return trimTrailingFragments(text) || text;
   }
 
   const truncated = text.slice(0, HEADING_MAX_CHARS);
   const lastSpace = truncated.lastIndexOf(' ');
   text = (lastSpace > MIN_WORD_BREAK ? truncated.slice(0, lastSpace) : truncated).trimEnd();
 
-  // Trim dangling tail words (may need multiple passes for chains like "for the")
-  let prev = text;
-  while (DANGLING_TAIL_RE.test(text)) {
-    text = text.replace(DANGLING_TAIL_RE, '').trimEnd();
-    if (text === prev || text.length < MIN_WORD_BREAK) {
-      text = prev;
-      break;
-    }
-    prev = text;
-  }
-
-  return text;
+  return trimTrailingFragments(text);
 }
 
 /**


### PR DESCRIPTION
## Summary

Closes the lesson extractor heading-truncation regression that LC has been paying recurring per-postmerge-cycle tax on across 3 consecutive cycles (`mmnto-ai/liquid-city#229` 75%, `mmnto-ai/liquid-city#234` 33%, `mmnto-ai/liquid-city#238` 14% truncated). Same defect class as the original `mmnto-ai/totem#253` / `mmnto-ai/totem#348` fixes — re-emerging from extractor LLM output that produces phrasings the prior heuristic didn't cover.

## What was broken

The prior `DANGLING_TAIL_RE` only stripped trailing single prepositions/articles (`...for the` → `...for`). The empirical LC failure mode was `<prep> <expectant-word>` — where the trailing word alone is a perfectly fine English word (`prevent`, `isolate`, `fixed-size`, `auditable`) but in context completes an incomplete prepositional/infinitival phrase. The single-word check passed on these and the heading shipped mid-clause.

| Empirical heading | Source | Should be |
|---|---|---|
| `Validate const_name suffix before codegen to prevent` | `mmnto-ai/liquid-city#229` | `Validate const_name suffix before codegen` |
| `RON tuple syntax differs from array syntax for fixed-size` | `mmnto-ai/liquid-city#229` | `RON tuple syntax differs from array syntax` |
| `Snapshot canonical form should exclude metadata to isolate` | `mmnto-ai/liquid-city#229` | `Snapshot canonical form should exclude metadata` |
| `Document pre-resource call sites to enable auditable` | `mmnto-ai/liquid-city#234` | `Document pre-resource call sites` |

## What's fixed

**Walk-backwards-collect-then-anchor algorithm:**

1. From the end, collect a run of consecutive expectant-shaped words (verb/adjective suffixes `-ate|-ize|-ise|-ify|-able|-ible|-ing|-ent|-ant` or hyphenated compounds).
2. Check the IMMEDIATE anchor — the word right before the run.
3. If the anchor is a preposition (`to|for|by|with|from|into|via|against|...`), strip the run. The existing dangling-tail check then strips the preposition too.

For `Document pre-resource call sites to enable auditable`: walk back collects `enable auditable` (both `-able`), the anchor is `to` (preposition) → strip both → `Document pre-resource call sites to` → existing dangling strips `to` → `Document pre-resource call sites`. ✓

## False-positive guard (load-bearing)

`totem review` first-iteration **CRITICAL** caught that a non-adjacent prep check ("does the heading contain ANY preposition") would have over-stripped common programming nouns ending in expectant suffixes — `component`, `client`, `state`, `environment`, `load-balancer`. CR's example: `Pass the props to the component` would have been over-stripped to `Pass the props`.

The walk-back-collect-then-IMMEDIATE-anchor approach naturally protects these. In `Pass the props to the component`, the walk back finds `component` (expectant), but the anchor is `the` (article, not preposition) → stop. Heading kept as-is.

Locked empirically via 4 new regression tests:
- `does NOT strip when anchor before expectant word is an article`
- `does NOT strip when consecutive expectant words have non-prep anchor`
- `does NOT strip hyphenated noun with non-prep anchor`
- `does NOT strip expectant-suffixed common nouns with article anchor`

## Test plan

- [x] 7 new regression tests for the empirical LC failure modes
- [x] 4 new false-positive guards locking common-noun preservation (CR concern)
- [x] All 43 lesson-format tests pass (was 32, +11 new)
- [x] Full workspace tests: 2042+ tests pass via turbo
- [x] `pnpm exec totem lint` — PASS
- [x] `pnpm exec totem review` — PASS, no findings
- [x] `pnpm exec totem verify-manifest` — PASS (478 rules, hashes match)
- [x] `pnpm run build` — tsc clean

## Out of scope

The issue body suggests two fix directions: (a) word-boundary-aware truncation, or (b) LLM-prompt constraint. The existing code is already word-boundary-aware (cuts at last whitespace before char 60); the issue was that it cut at a word boundary that happened to land in mid-clause. This PR ships clause-boundary-awareness on top. The complementary LLM-prompt constraint at extract time (so LLM output doesn't produce these phrasings to begin with) is upstream prevention worth a separate ticket if the regex heuristic still misses cases in the field.

The migration tool proposed in `mmnto-ai/totem#348` (`totem sync --rewrite-headings` to fix pre-existing truncated population in downstream repos) is not in scope here; `rewriteLessonHeadings` already exists and now picks up the new logic, but distributing it via a CLI flag is separate work.

Closes `mmnto-ai/totem#1872`

🤖 Generated with [Claude Code](https://claude.com/claude-code)