### PR TITLE
feat(cli): Phase C slice 3 — distribute signoff + review-reply skills via `totem init` (mmnto-ai/totem#1890)

### DIFF
--- a/.changeset/slice-3-skill-distribution.md
+++ b/.changeset/slice-3-skill-distribution.md
@@ -1,0 +1,20 @@
+---
+'@mmnto/cli': minor
+---
+
+`totem init` now distributes the canonical `signoff` and `review-reply`
+session-utility skills into `.claude/skills/<name>/SKILL.md` on the Claude
+side, using marker-based replacement so canonical updates land everywhere
+on subsequent `totem init` runs while user-authored content below the end
+marker survives.
+
+`totem eject` mirrors the install — removes only marker'd files, with
+bottom-up pruning of empty `.claude/skills/<name>/` and `.claude/skills/`
+directories. User-authored skill files (no markers) are preserved.
+
+Phase C slice 3 (Closes `mmnto-ai/totem#1890`). Gemini parity for the same
+two skills is tracked separately as `mmnto-ai/totem#1891` (slice 4).
+
+The canonical content is single-sourced from
+`mmnto-ai/totem:.claude/skills/<name>/SKILL.md` with an invariant test
+that fails CI if the embedded constant ever drifts from the source.

--- a/.claude/skills/review-reply/SKILL.md
+++ b/.claude/skills/review-reply/SKILL.md
@@ -3,6 +3,8 @@ name: review-reply
 description: Unified PR review triage — fetch, normalize, and batch-action bot comments
 ---
 
+<!-- totem:skill-start -->
+
 Triage PR review comments from all bots for PR $ARGUMENTS.
 
 ## Phase 1: Fetch & Categorize (Deterministic)
@@ -56,3 +58,5 @@ Print summary of actions taken and exit.
 ## CRITICAL: GCA Reply Protocol
 
 **NEVER reply individually to GCA bot comments.** GCA has a quota and will NOT respond to replies unless they contain `@gemini-code-assist`. Always batch ALL GCA responses into a single PR-level comment using the issue comments API endpoint (`/issues/{pr}/comments`), not the review comments reply endpoint.
+
+<!-- totem:skill-end -->

--- a/.claude/skills/signoff/SKILL.md
+++ b/.claude/skills/signoff/SKILL.md
@@ -3,6 +3,8 @@ name: signoff
 description: End-of-session — update memory, write journal entry, clean up
 ---
 
+<!-- totem:skill-start -->
+
 End-of-session wrap-up:
 
 1. Update `MEMORY.md` with any new state (version shipped, tickets closed, key decisions)
@@ -26,3 +28,4 @@ End-of-session wrap-up:
 
 4. Clean up stale local branches: `git branch -vv | grep ': gone]' | awk '{print $1}' | xargs git branch -D`
 5. Report: what shipped, what's pending, what's next
+<!-- totem:skill-end -->

--- a/packages/cli/src/commands/eject.test.ts
+++ b/packages/cli/src/commands/eject.test.ts
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { cleanTmpDir } from '../test-utils.js';
 import type { EjectSummary } from './eject.js';
 import { ejectCommand, scrubPostCheckoutHook, scrubPostMergeHook } from './eject.js';
+import { SKILL_MARKER_END, SKILL_MARKER_START } from './init-templates.js';
 
 function makeTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'totem-eject-'));
@@ -539,5 +540,86 @@ fi
     expect(content).toContain('deploy notification');
     expect(content).not.toContain('[totem]');
     expect(summary.scrubbed).toContain('.git/hooks/post-checkout');
+  });
+});
+
+describe('eject — distributed Claude skills (mmnto-ai/totem#1890 Phase C slice 3)', () => {
+  let cwd: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    cwd = makeTmpDir();
+    originalCwd = process.cwd();
+    process.chdir(cwd);
+    fs.mkdirSync(path.join(cwd, '.git', 'hooks'), { recursive: true });
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    cleanTmpDir(cwd);
+  });
+
+  function writeSkill(name: string, body: string): string {
+    const filePath = path.join(cwd, '.claude', 'skills', name, 'SKILL.md');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, body, 'utf-8');
+    return filePath;
+  }
+
+  it('removes signoff + review-reply SKILL.md files when markers are present', async () => {
+    const signoffPath = writeSkill(
+      'signoff',
+      `---\nname: signoff\n---\n\n${SKILL_MARKER_START}\nbody\n${SKILL_MARKER_END}\n`,
+    );
+    const reviewReplyPath = writeSkill(
+      'review-reply',
+      `---\nname: review-reply\n---\n\n${SKILL_MARKER_START}\nbody\n${SKILL_MARKER_END}\n`,
+    );
+
+    await ejectCommand({ force: true });
+
+    expect(fs.existsSync(signoffPath)).toBe(false);
+    expect(fs.existsSync(reviewReplyPath)).toBe(false);
+  });
+
+  it('prunes empty per-skill directories and the skills root after removal', async () => {
+    writeSkill(
+      'signoff',
+      `---\nname: signoff\n---\n\n${SKILL_MARKER_START}\nbody\n${SKILL_MARKER_END}\n`,
+    );
+    writeSkill(
+      'review-reply',
+      `---\nname: review-reply\n---\n\n${SKILL_MARKER_START}\nbody\n${SKILL_MARKER_END}\n`,
+    );
+
+    await ejectCommand({ force: true });
+
+    expect(fs.existsSync(path.join(cwd, '.claude', 'skills', 'signoff'))).toBe(false);
+    expect(fs.existsSync(path.join(cwd, '.claude', 'skills', 'review-reply'))).toBe(false);
+    expect(fs.existsSync(path.join(cwd, '.claude', 'skills'))).toBe(false);
+  });
+
+  it('preserves user-authored skill files without markers', async () => {
+    const customPath = writeSkill('signoff', '# my custom signoff\n\ndo it differently\n');
+
+    await ejectCommand({ force: true });
+
+    expect(fs.existsSync(customPath)).toBe(true);
+    expect(fs.readFileSync(customPath, 'utf-8')).toContain('do it differently');
+  });
+
+  it('preserves the skills root if a non-distributed skill remains', async () => {
+    writeSkill(
+      'signoff',
+      `---\nname: signoff\n---\n\n${SKILL_MARKER_START}\nbody\n${SKILL_MARKER_END}\n`,
+    );
+    // User has their own skill not managed by totem
+    const customSkill = writeSkill('panel-audit', '# Custom panel audit skill\n');
+
+    await ejectCommand({ force: true });
+
+    expect(fs.existsSync(path.join(cwd, '.claude', 'skills', 'signoff'))).toBe(false);
+    expect(fs.existsSync(customSkill)).toBe(true);
+    expect(fs.existsSync(path.join(cwd, '.claude', 'skills'))).toBe(true);
   });
 });

--- a/packages/cli/src/commands/eject.ts
+++ b/packages/cli/src/commands/eject.ts
@@ -1,6 +1,8 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { SKILL_MARKER_END, SKILL_MARKER_START } from './init-templates.js';
+
 // ─── Constants ──────────────────────────────────────────
 
 const TAG = 'Eject';
@@ -9,6 +11,9 @@ const TOTEM_HOOK_END = '[totem] end post-merge';
 const TOTEM_CHECKOUT_MARKER = '[totem] post-checkout hook';
 const TOTEM_CHECKOUT_END = '[totem] end post-checkout';
 const TOTEM_FILE_MARKER = '// [totem] auto-generated';
+
+/** Skill names distributed by Phase C slice 3 (mmnto-ai/totem#1890). */
+const DISTRIBUTED_CLAUDE_SKILL_NAMES = ['signoff', 'review-reply'];
 
 /** Files that may have AI reflex blocks appended by `totem init`. */
 const REFLEX_FILES = ['CLAUDE.md', '.cursorrules'];
@@ -322,6 +327,66 @@ function scrubCommittedClaudeSettings(cwd: string, summary: EjectSummary): void 
 }
 
 /**
+ * Remove the distributed Claude session-utility skills installed by Phase C
+ * slice 3 (mmnto-ai/totem#1890). Marker-checked: only removes files whose
+ * canonical content (between SKILL_MARKER_START / SKILL_MARKER_END) is
+ * present. User-authored skills without markers are preserved.
+ *
+ * Bottom-up directory pruning matches the existing scrub helper precedent —
+ * empty `.claude/skills/<name>/` and `.claude/skills/` get unlinked so the
+ * filesystem state is clean.
+ */
+function scrubClaudeSkills(cwd: string, summary: EjectSummary): void {
+  const skillsRoot = path.join(cwd, '.claude', 'skills');
+
+  for (const name of DISTRIBUTED_CLAUDE_SKILL_NAMES) {
+    const rel = `.claude/skills/${name}/SKILL.md`;
+    const filePath = path.join(skillsRoot, name, 'SKILL.md');
+    if (!fs.existsSync(filePath)) {
+      summary.skipped.push(`${rel} (not found)`);
+      continue;
+    }
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    if (!content.includes(SKILL_MARKER_START) || !content.includes(SKILL_MARKER_END)) {
+      summary.skipped.push(`${rel} (no Totem markers — user-authored)`);
+      continue;
+    }
+
+    try {
+      fs.unlinkSync(filePath);
+      summary.removed.push(rel);
+      // totem-context: intentional cleanup — eject best-effort per Tenet 4 carve-out
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      summary.skipped.push(`${rel} (${msg})`);
+      continue;
+    }
+
+    // Prune the per-skill directory if empty.
+    const skillDir = path.join(skillsRoot, name);
+    try {
+      if (fs.existsSync(skillDir) && fs.readdirSync(skillDir).length === 0) {
+        fs.rmdirSync(skillDir);
+      }
+      // totem-context: intentional cleanup — best-effort directory pruning
+    } catch {
+      /* eject best-effort */
+    }
+  }
+
+  // Prune the skills root if empty after per-skill pruning.
+  try {
+    if (fs.existsSync(skillsRoot) && fs.readdirSync(skillsRoot).length === 0) {
+      fs.rmdirSync(skillsRoot);
+    }
+    // totem-context: intentional cleanup — best-effort skills-root pruning
+  } catch {
+    /* eject best-effort */
+  }
+}
+
+/**
  * Remove the AI Integration block appended by `totem init` to reflex files.
  */
 function scrubReflexFiles(cwd: string, summary: EjectSummary): void {
@@ -426,10 +491,13 @@ export async function ejectCommand(options: EjectOptions): Promise<void> {
   // 4. Scrub Claude settings.json (committed PreWriteShield + SessionStart entries)
   scrubCommittedClaudeSettings(cwd, summary);
 
-  // 5. Scrub AI reflex blocks from markdown files
+  // 5. Scrub distributed Claude session-utility skills (Phase C slice 3)
+  scrubClaudeSkills(cwd, summary);
+
+  // 6. Scrub AI reflex blocks from markdown files
   scrubReflexFiles(cwd, summary);
 
-  // 6. Delete artifacts
+  // 7. Delete artifacts
   deleteArtifacts(cwd, summary);
 
   // Print summary

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -371,6 +371,131 @@ export const CLAUDE_SESSION_START_ENTRY = {
   ],
 };
 
+// ─── Claude Code skill distribution (mmnto-ai/totem#1890 Phase C slice 3) ───
+//
+// Skills are surfaced into consumer repos at `.claude/skills/<name>/SKILL.md`.
+// Marker-based replace: canonical content lives between SKILL_MARKER_START
+// and SKILL_MARKER_END. Re-running `totem init` replaces inside-marker
+// content with the current canonical; content AFTER the end marker is
+// user-customization territory and survives across refreshes.
+//
+// v0.1 ships two skills: signoff and review-reply. Both passed the
+// canonical/customization audit (universal across consumer repos,
+// idempotent on refresh, no `totem <name>` subcommand collision).
+//
+// Source-of-truth is `mmnto-ai/totem:.claude/skills/<name>/SKILL.md`. The
+// `installed-skills-match-source.test.ts` invariant locks these constants
+// against the source files so canonical drift fails CI rather than
+// silently propagating stale skill content to consumers.
+
+export const SKILL_MARKER_START = '<!-- totem:skill-start -->';
+export const SKILL_MARKER_END = '<!-- totem:skill-end -->';
+
+export const SIGNOFF_SKILL_CONTENT =
+  `---
+name: signoff
+description: End-of-session — update memory, write journal entry, clean up
+---
+
+${SKILL_MARKER_START}
+
+End-of-session wrap-up:
+
+1. Update \`MEMORY.md\` with any new state (version shipped, tickets closed, key decisions)
+2. Write a journal entry to the substrate journal at \`<substrate>/.journal/totem/<filename>.md\` summarizing today's work. Use \`resolveSubstratePaths(gitRoot).journalRoot\` from \`@mmnto/totem\` to locate the substrate; if \`source === 'none'\`, fall back to repo-local \`.journal/totem/\` and warn (ADR-090 graceful degradation).
+3. Commit + push the substrate journal entry from \`mmnto-ai/totem-substrate\` (NOT this repo — \`.journal/\` is sediment-frozen here per ADR-100). Use rebase-and-retry on the push since other agents may sign off concurrently:
+
+   \`\`\`bash
+   cd <substrate-repo-root>
+   git add .journal/totem/<filename>.md
+   git commit -m "journal(totem): <slug>"
+   pushed=0
+   for i in 1 2 3 4 5; do
+     git push origin main && { pushed=1; break; }
+     git pull --rebase --autostash origin main || { echo "Rebase conflict — manual resolution needed"; break; }
+     sleep 1
+   done
+   [ "$pushed" = 1 ] || { echo "ERROR: substrate push failed — surface to user"; exit 1; }
+   \`\`\`
+
+   **Why the retry loop:** Substrate \`main\` accepts only fast-forward pushes. If a peer push (strategy-Claude, lc-Claude, status-Claude, etc.) lands between your commit and your push, yours fails with \`non-fast-forward\`. Per-agent journal filenames (\`<model>-NNNN-*.md\`) don't collide, so the rebase auto-succeeds without conflict — typically resolves within 1-2 retries. After 5 retries surface failure to the user; that's likely a genuine same-file edit (e.g., two recipients moving the same \`_broadcast/\` file to \`processed/\`) that needs manual resolution.
+
+` +
+  // totem-context: documentation example — `git branch -D` shown in canonical signoff procedure for human readers; not a runtime invocation in this file
+  `4. Clean up stale local branches: \`git branch -vv | grep ': gone]' | awk '{print $1}' | xargs git branch -D\`
+5. Report: what shipped, what's pending, what's next
+${SKILL_MARKER_END}
+`;
+
+export const REVIEW_REPLY_SKILL_CONTENT = `---
+name: review-reply
+description: Unified PR review triage — fetch, normalize, and batch-action bot comments
+---
+
+${SKILL_MARKER_START}
+
+Triage PR review comments from all bots for PR $ARGUMENTS.
+
+## Phase 1: Fetch & Categorize (Deterministic)
+
+Run the triage command to fetch, normalize, deduplicate, and categorize all bot comments:
+
+\`\`\`bash
+pnpm totem triage-pr $ARGUMENTS
+\`\`\`
+
+This outputs a categorized inbox grouped by blast radius (Security → Architecture → Convention → Nits) with cross-bot deduplication already applied. The heavy lifting is done in TypeScript — no LLM math needed.
+
+**STOP HERE.** Present the output to the user and wait for them to specify actions. Do NOT proceed to Phase 2 until the user replies.
+
+## Phase 2: Execute Actions (Bulk Support)
+
+The user may type individual IDs (e.g., \`fix 4, 11\`) OR use bulk actions:
+
+- \`fix all security\`
+- \`defer all nits\`
+- \`extract all architecture\`
+
+### \`fix <numbers | category>\`
+
+Mark items as will-fix. No API calls — just acknowledge. The user will make code changes next.
+
+### \`defer <numbers | category> [ticket]\`
+
+Auto-reply on the PR acknowledging the deferral:
+
+- **CodeRabbit items:** Reply inline to each thread with "Tracked in #NNN" or "Deferred — not blocking for this PR."
+- **GCA items:** DO NOT reply inline. Batch ALL GCA responses into ONE issue comment: \`@gemini-code-assist\` followed by a numbered list addressing each finding. Use \`gh api repos/{owner}/{repo}/issues/$ARGUMENTS/comments --input -\` with JSON payload.
+- **SARIF items:** No reply needed (our own tool).
+
+### \`nit <numbers | category>\`
+
+Same as defer but reply text is "Acknowledged — nit / by design."
+
+### \`extract <numbers | category>\`
+
+For each selected finding, generate a lesson and call \`mcp__totem-dev__add_lesson\` (or equivalent):
+
+- Use the bot's finding as the lesson body
+- Add relevant tags from the file path and finding category
+- The lesson will automatically get \`lifecycle: nursery\` treatment
+
+### \`done\`
+
+Print summary of actions taken and exit.
+
+## CRITICAL: GCA Reply Protocol
+
+**NEVER reply individually to GCA bot comments.** GCA has a quota and will NOT respond to replies unless they contain \`@gemini-code-assist\`. Always batch ALL GCA responses into a single PR-level comment using the issue comments API endpoint (\`/issues/{pr}/comments\`), not the review comments reply endpoint.
+
+${SKILL_MARKER_END}
+`;
+
+export const DISTRIBUTED_CLAUDE_SKILLS = [
+  { name: 'signoff', content: SIGNOFF_SKILL_CONTENT },
+  { name: 'review-reply', content: REVIEW_REPLY_SKILL_CONTENT },
+] as const;
+
 // ─── Config generation ──────────────────────────────────
 
 export async function generateConfig(

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -25,6 +25,7 @@ import {
   REFLEX_VERSION,
   scaffoldClaudeHooks,
   scaffoldClaudeSessionStart,
+  scaffoldClaudeSkill,
   scaffoldClaudeWriteShield,
   scaffoldFile,
   scaffoldMcpConfig,
@@ -37,9 +38,14 @@ import {
   CLAUDE_PREWRITESHIELD_ENTRY,
   CLAUDE_SESSION_START,
   CLAUDE_SESSION_START_ENTRY,
+  DISTRIBUTED_CLAUDE_SKILLS,
   GEMINI_BEFORE_TOOL,
   GEMINI_SESSION_START,
   generateConfigForFormat,
+  REVIEW_REPLY_SKILL_CONTENT,
+  SIGNOFF_SKILL_CONTENT,
+  SKILL_MARKER_END,
+  SKILL_MARKER_START,
 } from './init-templates.js';
 
 const SERVER_ENTRY = { type: 'stdio', command: 'npx', args: ['-y', '@mmnto/mcp'] };
@@ -1625,5 +1631,120 @@ describe('GEMINI_BEFORE_TOOL write_file/edit_file extension', () => {
 
   it('cites the seal at mmnto-ai/totem-strategy#145 in BeforeTool extension', () => {
     expect(GEMINI_BEFORE_TOOL).toContain('mmnto-ai/totem-strategy#145');
+  });
+});
+
+describe('scaffoldClaudeSkill (mmnto-ai/totem#1890 Phase C slice 3)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-skill-test-'));
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  it('creates the file with canonical content when none exists', () => {
+    const filePath = path.join(tmpDir, '.claude', 'skills', 'signoff', 'SKILL.md');
+    const result = scaffoldClaudeSkill(filePath, SIGNOFF_SKILL_CONTENT);
+    expect(result.action).toBe('created');
+    expect(fs.readFileSync(filePath, 'utf-8')).toBe(SIGNOFF_SKILL_CONTENT);
+  });
+
+  it('refreshes inside-marker content and preserves user addenda below the end marker', () => {
+    const filePath = path.join(tmpDir, '.claude', 'skills', 'signoff', 'SKILL.md');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+
+    const oldCanonical = `---
+name: signoff
+description: End-of-session — update memory, write journal entry, clean up
+---
+
+${SKILL_MARKER_START}
+OLD canonical step 1.
+OLD canonical step 2.
+${SKILL_MARKER_END}
+
+## User addenda
+
+LC-specific: run \`pnpm docs:inject\` before journal write.
+`;
+    fs.writeFileSync(filePath, oldCanonical, 'utf-8');
+
+    const result = scaffoldClaudeSkill(filePath, SIGNOFF_SKILL_CONTENT);
+    expect(result.action).toBe('refreshed');
+
+    const after = fs.readFileSync(filePath, 'utf-8');
+    expect(after).toContain('LC-specific: run `pnpm docs:inject`');
+    // Inside-marker content should match canonical's inside-marker section.
+    const canonicalEnd = SIGNOFF_SKILL_CONTENT.indexOf(SKILL_MARKER_END);
+    expect(
+      after.startsWith(SIGNOFF_SKILL_CONTENT.slice(0, canonicalEnd + SKILL_MARKER_END.length)),
+    ).toBe(true);
+  });
+
+  it('returns `unchanged` when the file already matches canonical byte-for-byte', () => {
+    const filePath = path.join(tmpDir, '.claude', 'skills', 'signoff', 'SKILL.md');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, SIGNOFF_SKILL_CONTENT, 'utf-8');
+
+    const result = scaffoldClaudeSkill(filePath, SIGNOFF_SKILL_CONTENT);
+    expect(result.action).toBe('unchanged');
+  });
+
+  it('preserves a user-authored file without markers and surfaces a migration hint', () => {
+    const filePath = path.join(tmpDir, '.claude', 'skills', 'signoff', 'SKILL.md');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const userContent = '# My custom signoff\n\nDo it my way.\n';
+    fs.writeFileSync(filePath, userContent, 'utf-8');
+
+    const result = scaffoldClaudeSkill(filePath, SIGNOFF_SKILL_CONTENT);
+    expect(result.action).toBe('preserved');
+    expect(result.err).toContain('canonical markers');
+    expect(fs.readFileSync(filePath, 'utf-8')).toBe(userContent);
+  });
+
+  it('preserves a file whose markers are out of order (malformed)', () => {
+    const filePath = path.join(tmpDir, '.claude', 'skills', 'signoff', 'SKILL.md');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const malformed = `# Custom\n${SKILL_MARKER_END}\n[bogus content]\n${SKILL_MARKER_START}\n`;
+    fs.writeFileSync(filePath, malformed, 'utf-8');
+
+    const result = scaffoldClaudeSkill(filePath, SIGNOFF_SKILL_CONTENT);
+    expect(result.action).toBe('preserved');
+    expect(fs.readFileSync(filePath, 'utf-8')).toBe(malformed);
+  });
+
+  it('DISTRIBUTED_CLAUDE_SKILLS lists signoff and review-reply with their canonical content', () => {
+    const names = DISTRIBUTED_CLAUDE_SKILLS.map((s) => s.name);
+    expect(names).toEqual(['signoff', 'review-reply']);
+    const lookup = Object.fromEntries(DISTRIBUTED_CLAUDE_SKILLS.map((s) => [s.name, s.content]));
+    expect(lookup.signoff).toBe(SIGNOFF_SKILL_CONTENT);
+    expect(lookup['review-reply']).toBe(REVIEW_REPLY_SKILL_CONTENT);
+  });
+});
+
+describe('Distributed skill constants match source-of-truth (mmnto-ai/totem#1890)', () => {
+  // The canonical skill content embedded in init-templates.ts MUST match the
+  // SKILL.md file checked into .claude/skills/<name>/SKILL.md verbatim. If
+  // they drift, consumers of `totem init` ship stale skill content. This
+  // invariant fails CI rather than silently propagating the drift.
+  const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+
+  it('SIGNOFF_SKILL_CONTENT matches .claude/skills/signoff/SKILL.md', () => {
+    const source = fs.readFileSync(
+      path.join(repoRoot, '.claude', 'skills', 'signoff', 'SKILL.md'),
+      'utf-8',
+    );
+    expect(SIGNOFF_SKILL_CONTENT).toBe(source);
+  });
+
+  it('REVIEW_REPLY_SKILL_CONTENT matches .claude/skills/review-reply/SKILL.md', () => {
+    const source = fs.readFileSync(
+      path.join(repoRoot, '.claude', 'skills', 'review-reply', 'SKILL.md'),
+      'utf-8',
+    );
+    expect(REVIEW_REPLY_SKILL_CONTENT).toBe(source);
   });
 });

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -19,6 +19,7 @@ import {
   CLAUDE_PREWRITESHIELD_ENTRY,
   CLAUDE_SESSION_START,
   CLAUDE_SESSION_START_ENTRY,
+  DISTRIBUTED_CLAUDE_SKILLS,
   GEMINI_BEFORE_TOOL,
   GEMINI_SESSION_START,
   GEMINI_SKILL,
@@ -27,6 +28,8 @@ import {
   REFLEX_START,
   REFLEX_VERSION,
   REFLEX_VERSION_RE,
+  SKILL_MARKER_END,
+  SKILL_MARKER_START,
   TOTEM_FILE_MARKER,
 } from './init-templates.js';
 
@@ -380,7 +383,107 @@ async function installClaudeHooks(cwd: string): Promise<HookInstallerResult[]> {
     ...sessionStartEntryResult,
   });
 
+  // 5. Distribute session-utility skills (mmnto-ai/totem#1890 Phase C
+  //    slice 3). Marker-based replace: fresh repos get the canonical
+  //    content; refreshes replace the inside-marker section while
+  //    preserving user customizations below the end marker.
+  //
+  //    scaffoldClaudeSkill's native action union ('created' | 'refreshed' |
+  //    'unchanged' | 'preserved') is mapped onto the existing
+  //    HookInstallerResult union for installer summary compatibility:
+  //    refreshed → 'merged' (file mutated), unchanged → 'exists' (no-op),
+  //    preserved → 'skipped' (user content protected).
+  for (const skill of DISTRIBUTED_CLAUDE_SKILLS) {
+    const skillPath = path.join(cwd, '.claude', 'skills', skill.name, 'SKILL.md');
+    const skillResult = scaffoldClaudeSkill(skillPath, skill.content);
+    const mappedAction: HookInstallerResult['action'] =
+      skillResult.action === 'created'
+        ? 'created'
+        : skillResult.action === 'refreshed'
+          ? 'merged'
+          : skillResult.action === 'unchanged'
+            ? 'exists'
+            : 'skipped';
+    results.push({
+      file: `.claude/skills/${skill.name}/SKILL.md`,
+      action: mappedAction,
+      ...(skillResult.err ? { err: skillResult.err } : {}),
+    });
+  }
+
   return results;
+}
+
+/**
+ * Install or refresh a Claude Code skill file at the target path using
+ * marker-based replacement. The canonical content lives between
+ * `SKILL_MARKER_START` and `SKILL_MARKER_END`; content AFTER the end marker
+ * is user-customization territory and survives across refreshes (Phase C
+ * slice 3 design doc, mmnto-ai/totem#1890).
+ *
+ * Outcomes:
+ * - `created` — file didn't exist; wrote canonical
+ * - `refreshed` — file existed with markers; replaced inside-marker content,
+ *   preserved everything after the end marker
+ * - `unchanged` — file existed with markers and the merged content was
+ *   byte-identical to the existing content
+ * - `preserved` — file exists without the end marker (user-authored,
+ *   pre-marker scaffold, or malformed); skipped to preserve user content.
+ *   Surfaces a warning hint via `err` so callers can log a migration nudge.
+ */
+export function scaffoldClaudeSkill(
+  filePath: string,
+  canonicalContent: string,
+): { action: 'created' | 'refreshed' | 'unchanged' | 'preserved'; err?: string } {
+  try {
+    if (!fs.existsSync(filePath)) {
+      const dir = path.dirname(filePath);
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+      fs.writeFileSync(filePath, canonicalContent, 'utf-8');
+      return { action: 'created' };
+    }
+
+    const existing = fs.readFileSync(filePath, 'utf-8');
+    const existingEnd = existing.indexOf(SKILL_MARKER_END);
+    const existingStart = existing.indexOf(SKILL_MARKER_START);
+
+    // Preserve absolutely if either marker is missing or out of order — this
+    // is either a user-authored skill (no markers) or a malformed totem
+    // scaffold. Don't auto-rewrite; surface a migration hint instead.
+    if (existingStart === -1 || existingEnd === -1 || existingStart > existingEnd) {
+      return {
+        action: 'preserved',
+        err: `Skill file exists without canonical markers — preserving. To pick up the canonical refresh, move custom content below \`${SKILL_MARKER_END}\` (see mmnto-ai/totem#1890 migration checklist).`,
+      };
+    }
+
+    const canonicalEnd = canonicalContent.indexOf(SKILL_MARKER_END);
+    if (canonicalEnd === -1) {
+      // Canonical content is missing its own end marker — shouldn't happen
+      // (the source-of-truth invariant test guards this), but degrade safely.
+      return {
+        action: 'preserved',
+        err: 'Canonical skill content is missing its end marker — preserving existing file.',
+      };
+    }
+
+    const canonicalThroughEnd = canonicalContent.slice(0, canonicalEnd + SKILL_MARKER_END.length);
+    const existingAfterEnd = existing.slice(existingEnd + SKILL_MARKER_END.length);
+    const merged = canonicalThroughEnd + existingAfterEnd;
+
+    if (merged === existing) {
+      return { action: 'unchanged' };
+    }
+
+    fs.writeFileSync(filePath, merged, 'utf-8');
+    return { action: 'refreshed' };
+    // totem-context: intentional cleanup — preserve user's skill file on any IO failure rather than aborting init mid-flight; mirrors scaffoldFile's failure posture
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { action: 'preserved', err: `[Totem Error] ${message}` };
+  }
 }
 
 // Wire up hook installers on the AI_TOOLS entries that need them.


### PR DESCRIPTION
## Summary

Phase C slice 3 of `mmnto-ai/totem#1845` — distributes the canonical `signoff` and `review-reply` session-utility skills via `totem init` on the Claude side, with marker-based replace so canonical updates land on every `totem init` refresh while user-authored customization below the closing marker survives.

Design doc + canonical/customization audit + migration checklist live in `mmnto-ai/totem#1890`.

## Mechanism

Each distributed `SKILL.md` is wrapped in `<!-- totem:skill-start -->` … `<!-- totem:skill-end -->` markers. The body inside is canonical (refreshed on every `totem init`); content after the closing marker is user territory (preserved verbatim).

`scaffoldClaudeSkill(filePath, canonicalContent)` returns:
- **`created`** — file didn't exist, wrote canonical
- **`refreshed`** — file with markers + addenda, replaced inside-marker content
- **`unchanged`** — file with markers, byte-identical to canonical
- **`preserved`** — file without markers (user-authored or malformed), didn't touch; surfaces a migration hint

## Eject parity

`scrubClaudeSkills` marker-checks each distributed skill file before unlinking; bottom-up prunes empty `.claude/skills/<name>/` and `.claude/skills/` directories. User-authored skills without markers (or with markers but no Totem fingerprint) are left alone.

## Source-of-truth invariant

The canonical content embedded in `init-templates.ts` is single-sourced from `mmnto-ai/totem:.claude/skills/<name>/SKILL.md` (the skill files actually in use by this repo). A new test in `init.test.ts` (`Distributed skill constants match source-of-truth`) asserts byte-equality between the constant and the source file so drift fails CI rather than silently propagating stale skill content to consumers.

## What's NOT in this PR

- **Gemini parity** — tracked separately as `mmnto-ai/totem#1891` (slice 4). Strategy-Claude flagged a soft 2-week SLA after slice 3 merge to keep the Tenet 16 framing intact.
- **preflight / prepush / postmerge distribution** — those skills overlap with `totem` subcommands and carry family-specific customization. Deferred to a future slice that decides "collapse into CLI" vs "ship as thin orchestrator templates."
- **Migration tooling** — per-repo migration is a ~5-min manual pass (backup → re-init → move customizations below the closing marker). Tooling is over-engineering at N=5 family repos.

## Test plan

- [x] **A1.** Fresh init writes canonical with markers (`'created'`)
- [x] **A2.** Refresh on file with markers + user addenda → replaces inside-marker, preserves outside-marker (`'refreshed'`)
- [x] **A3.** Refresh on byte-identical file is no-op (`'unchanged'`)
- [x] **A4.** Refresh on file without markers preserves user content + surfaces migration hint (`'preserved'`)
- [x] **A5.** Refresh on malformed markers (out of order) preserves
- [x] **A6.** `DISTRIBUTED_CLAUDE_SKILLS` lists both skills with correct content references
- [x] **B1.** Eject removes marker'd files
- [x] **B2.** Eject prunes empty per-skill dirs + the skills root
- [x] **B3.** Eject preserves user-authored skill files without markers
- [x] **B4.** Eject preserves the skills root when a non-distributed skill remains
- [x] **C1.** `SIGNOFF_SKILL_CONTENT` matches `.claude/skills/signoff/SKILL.md` byte-for-byte
- [x] **C2.** `REVIEW_REPLY_SKILL_CONTENT` matches `.claude/skills/review-reply/SKILL.md` byte-for-byte
- [x] All 2063 tests across `@mmnto/cli` PASS (12 new)
- [x] `totem lint` PASS — 0 errors, 59 warnings (pre-existing false-positive cluster on test files)
- [x] `totem review` PASS — no critical issues
- [x] Source SKILL.md files in `mmnto-ai/totem` itself updated with markers so they remain canonical

## Cohort sync coordination

Strategy-Claude has offered to handle the per-repo migration inside the 1.34.x cohort sync PR that catches this merge. Coord before the Version Packages cycle picks this up so the migration sequences cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)