### PR TITLE
feat(hook): bot-pack wiring engine — foundation (WIP)

### DIFF
--- a/packages/cli/src/hook/classification.test.ts
+++ b/packages/cli/src/hook/classification.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifyHookRule } from './classification.js';
+import type { HookRule } from './schema.js';
+
+const baseRule: HookRule = {
+  id: 'r1',
+  trigger: { tool: 'bash', pattern: '.*' },
+  check: { pattern: 'x', type: 'reject-if-match' },
+  message: 'm',
+};
+
+describe('classifyHookRule', () => {
+  it('returns interpretive with no warning for a plain hook rule', () => {
+    const result = classifyHookRule(baseRule);
+    expect(result.classification).toBe('interpretive');
+    expect(result.warning).toBeUndefined();
+  });
+
+  it('returns interpretive but emits a warn-and-ignore signal when verification_shadow is present', () => {
+    const withShadow: HookRule = {
+      ...baseRule,
+      verification_shadow: { rego: 'package x' },
+    };
+    const result = classifyHookRule(withShadow);
+    expect(result.classification).toBe('interpretive');
+    expect(result.warning).toBeDefined();
+    expect(result.warning).toContain('[totem:hook-shadow-ignored]');
+    expect(result.warning).toContain('r1');
+  });
+
+  it('treats verification_shadow: null as present (warns and continues)', () => {
+    // null is a JS-truthy distinct from undefined; if the schema admits it the
+    // classification helper should still emit the warn-and-ignore signal so
+    // the dispatch contract holds for any non-undefined value.
+    const withNullShadow: HookRule = {
+      ...baseRule,
+      id: 'r-null',
+      verification_shadow: null,
+    };
+    const result = classifyHookRule(withNullShadow);
+    expect(result.classification).toBe('interpretive');
+    expect(result.warning).toBeDefined();
+  });
+});

--- a/packages/cli/src/hook/classification.ts
+++ b/packages/cli/src/hook/classification.ts
@@ -1,0 +1,55 @@
+import type { HookRule } from './schema.js';
+
+/**
+ * Rule classification per ADR-104 § Convergence + § Target-aware dispatch
+ * (strategy-Gemini Q1 binding synthesis, T1930Z 2026-05-11).
+ *
+ * Two classes:
+ * - `spine`: has Rego-shadow representation; formally verified by SMT;
+ *   eligible for the top ~30 invariant set. Ships in ADR-103's lint-rule
+ *   pipeline. Not produced by this V1 hook engine.
+ * - `interpretive`: ast-grep / regex only; no formal verification obligation;
+ *   ships outside the core invariant set. All bot-pack hooks in V1 fall here.
+ *
+ * The hook runtime treats every rule as `interpretive`. The class is named
+ * explicitly so the loader's warn-and-ignore signal on a future Spine-Rule
+ * promotion attempt (`verification_shadow:` on a hook rule) carries the
+ * dispatch contract in its error message rather than relying on prose docs.
+ *
+ * V2 may promote bot-pack hooks to `spine` via a follow-on ADR; this seam
+ * is where that promotion lands.
+ */
+export type RuleClassification = 'spine' | 'interpretive';
+
+export interface ClassificationResult {
+  classification: RuleClassification;
+  /**
+   * When set, the loader SHOULD emit this string to stderr but continue
+   * loading the rule. Empty when no warn-and-ignore signal applies.
+   */
+  warning?: string;
+}
+
+/**
+ * Classify a hook rule for V1 dispatch.
+ *
+ * Always returns `interpretive` per ADR-104 § Target-aware dispatch (hooks
+ * are Interpretive Rule class — no formal-verification obligation; PreToolUse
+ * payloads are not source code, so the Rego/OPA value proposition is weaker
+ * than for lint rules).
+ *
+ * If the rule carries a `verification_shadow:` block (forward-compat schema
+ * permits this for future Spine promotion), the returned result includes a
+ * structured warning. Per ADR-104 § Convergence: "the engine MUST
+ * warn-and-ignore the block (the rule itself still executes as
+ * Interpretive)."
+ */
+export function classifyHookRule(rule: HookRule): ClassificationResult {
+  if (rule.verification_shadow !== undefined) {
+    return {
+      classification: 'interpretive',
+      warning: `[totem:hook-shadow-ignored] ${rule.id}: verification_shadow block ignored in V1 (hooks are Interpretive Rule class); rule still executes`,
+    };
+  }
+  return { classification: 'interpretive' };
+}

--- a/packages/cli/src/hook/loader.test.ts
+++ b/packages/cli/src/hook/loader.test.ts
@@ -41,7 +41,7 @@ describe('loadCompiledHooks', () => {
     expect(result.errors).toEqual([]);
   });
 
-  it('records a structural error on invalid JSON', () => {
+  it('records a structural error on invalid JSON and preserves the original SyntaxError via cause', () => {
     const manifestPath = path.join(workDir, 'compiled-hooks.json');
     fs.writeFileSync(manifestPath, '{ not valid json', 'utf8');
     const result = loadCompiledHooks({
@@ -50,7 +50,12 @@ describe('loadCompiledHooks', () => {
     });
     expect(result.hooks).toEqual([]);
     expect(result.errors.length).toBe(1);
-    expect(result.errors[0]).toContain('not valid JSON');
+    const err = result.errors[0]!;
+    expect(err.message).toContain('not valid JSON');
+    expect(err.code).toBe('HOOKS_LOAD_FAILED');
+    // Original parse error preserved on `.cause` so debug consumers can
+    // walk the chain without the stack being collapsed into a string.
+    expect(err.cause).toBeInstanceOf(SyntaxError);
   });
 
   it('warns and skips when schemaVersion is higher than the runner supports', () => {
@@ -99,7 +104,11 @@ describe('loadCompiledHooks', () => {
     });
     expect(result.hooks).toEqual([]);
     expect(result.errors.length).toBe(1);
-    expect(result.errors[0]).toContain('schema validation');
+    const err = result.errors[0]!;
+    expect(err.message).toContain('schema validation');
+    expect(err.code).toBe('HOOKS_LOAD_FAILED');
+    // Zod's ZodError preserved as the cause for debug-mode chain traversal.
+    expect(err.cause).toBeDefined();
   });
 
   it('returns hooks with no warnings when installed pack versions match compiled versions', () => {

--- a/packages/cli/src/hook/loader.test.ts
+++ b/packages/cli/src/hook/loader.test.ts
@@ -1,0 +1,193 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { loadCompiledHooks } from './loader.js';
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-hook-loader-'));
+});
+
+afterEach(() => {
+  fs.rmSync(workDir, { recursive: true, force: true });
+});
+
+function writeManifest(content: unknown): string {
+  const manifestPath = path.join(workDir, 'compiled-hooks.json');
+  fs.writeFileSync(manifestPath, JSON.stringify(content), 'utf8');
+  return manifestPath;
+}
+
+const validRule = {
+  id: 'r1',
+  packId: '@mmnto/pack-bot-coderabbit',
+  trigger: { tool: 'bash', pattern: '.*' },
+  check: { pattern: 'x', type: 'reject-if-match' },
+  message: 'm',
+};
+
+describe('loadCompiledHooks', () => {
+  it('returns an empty result when the manifest file does not exist (fresh repo)', () => {
+    const result = loadCompiledHooks({
+      manifestPath: path.join(workDir, 'missing.json'),
+      installedPackVersions: {},
+    });
+    expect(result.hooks).toEqual([]);
+    expect(result.warnings).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('records a structural error on invalid JSON', () => {
+    const manifestPath = path.join(workDir, 'compiled-hooks.json');
+    fs.writeFileSync(manifestPath, '{ not valid json', 'utf8');
+    const result = loadCompiledHooks({
+      manifestPath,
+      installedPackVersions: {},
+    });
+    expect(result.hooks).toEqual([]);
+    expect(result.errors.length).toBe(1);
+    expect(result.errors[0]).toContain('not valid JSON');
+  });
+
+  it('warns and skips when schemaVersion is higher than the runner supports', () => {
+    const manifestPath = writeManifest({
+      schemaVersion: 2,
+      compiledAt: '2026-05-11T18:43:00Z',
+      sourcePackVersions: {},
+      hooks: [],
+    });
+    const result = loadCompiledHooks({
+      manifestPath,
+      installedPackVersions: {},
+    });
+    expect(result.hooks).toEqual([]);
+    expect(result.errors).toEqual([]);
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]).toContain('[totem:hook-schema]');
+    expect(result.warnings[0]).toContain('schemaVersion 2');
+  });
+
+  it('warns and skips when schemaVersion is missing', () => {
+    const manifestPath = writeManifest({
+      compiledAt: '2026-05-11T18:43:00Z',
+      sourcePackVersions: {},
+      hooks: [],
+    });
+    const result = loadCompiledHooks({
+      manifestPath,
+      installedPackVersions: {},
+    });
+    expect(result.hooks).toEqual([]);
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]).toContain('[totem:hook-schema]');
+  });
+
+  it('records a structural error when the supported-version manifest fails schema validation', () => {
+    const manifestPath = writeManifest({
+      schemaVersion: 1,
+      compiledAt: 'not-a-real-date',
+      sourcePackVersions: {},
+      hooks: [],
+    });
+    const result = loadCompiledHooks({
+      manifestPath,
+      installedPackVersions: {},
+    });
+    expect(result.hooks).toEqual([]);
+    expect(result.errors.length).toBe(1);
+    expect(result.errors[0]).toContain('schema validation');
+  });
+
+  it('returns hooks with no warnings when installed pack versions match compiled versions', () => {
+    const manifestPath = writeManifest({
+      schemaVersion: 1,
+      compiledAt: '2026-05-11T18:43:00Z',
+      sourcePackVersions: { '@mmnto/pack-bot-coderabbit': '1.0.0' },
+      hooks: [validRule],
+    });
+    const result = loadCompiledHooks({
+      manifestPath,
+      installedPackVersions: { '@mmnto/pack-bot-coderabbit': '1.0.0' },
+    });
+    expect(result.hooks).toHaveLength(1);
+    expect(result.warnings).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('emits a staleness warning when the installed pack version differs from compiled', () => {
+    const manifestPath = writeManifest({
+      schemaVersion: 1,
+      compiledAt: '2026-05-11T18:43:00Z',
+      sourcePackVersions: { '@mmnto/pack-bot-coderabbit': '1.0.0' },
+      hooks: [validRule],
+    });
+    const result = loadCompiledHooks({
+      manifestPath,
+      installedPackVersions: { '@mmnto/pack-bot-coderabbit': '1.1.0' },
+    });
+    expect(result.hooks).toHaveLength(1);
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]).toContain('[totem:hook-stale]');
+    expect(result.warnings[0]).toContain('@mmnto/pack-bot-coderabbit');
+    expect(result.warnings[0]).toContain('compiled against 1.0.0, installed 1.1.0');
+  });
+
+  it('emits a staleness warning when a compiled-against pack is not installed at all', () => {
+    const manifestPath = writeManifest({
+      schemaVersion: 1,
+      compiledAt: '2026-05-11T18:43:00Z',
+      sourcePackVersions: { '@mmnto/pack-bot-coderabbit': '1.0.0' },
+      hooks: [validRule],
+    });
+    const result = loadCompiledHooks({
+      manifestPath,
+      installedPackVersions: {},
+    });
+    expect(result.hooks).toHaveLength(1);
+    expect(result.warnings.length).toBe(1);
+    expect(result.warnings[0]).toContain('not currently installed');
+  });
+
+  it('ignores extra installed packs not in sourcePackVersions (no warning)', () => {
+    // A pack installed after the last `totem sync` is benign — its hooks
+    // are not yet active, but that is not staleness in the compiled set.
+    const manifestPath = writeManifest({
+      schemaVersion: 1,
+      compiledAt: '2026-05-11T18:43:00Z',
+      sourcePackVersions: { '@mmnto/pack-bot-coderabbit': '1.0.0' },
+      hooks: [validRule],
+    });
+    const result = loadCompiledHooks({
+      manifestPath,
+      installedPackVersions: {
+        '@mmnto/pack-bot-coderabbit': '1.0.0',
+        '@mmnto/pack-bot-gemini-code-assist': '1.0.0',
+      },
+    });
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('emits one staleness warning per drifting pack', () => {
+    const manifestPath = writeManifest({
+      schemaVersion: 1,
+      compiledAt: '2026-05-11T18:43:00Z',
+      sourcePackVersions: {
+        '@mmnto/pack-bot-coderabbit': '1.0.0',
+        '@mmnto/pack-bot-gemini-code-assist': '2.0.0',
+      },
+      hooks: [validRule],
+    });
+    const result = loadCompiledHooks({
+      manifestPath,
+      installedPackVersions: {
+        '@mmnto/pack-bot-coderabbit': '1.1.0',
+        '@mmnto/pack-bot-gemini-code-assist': '2.0.1',
+      },
+    });
+    expect(result.warnings.length).toBe(2);
+  });
+});

--- a/packages/cli/src/hook/loader.test.ts
+++ b/packages/cli/src/hook/loader.test.ts
@@ -31,7 +31,7 @@ const validRule = {
 };
 
 describe('loadCompiledHooks', () => {
-  it('returns an empty result when the manifest file does not exist (fresh repo)', () => {
+  it('returns an empty result when the manifest file does not exist (fresh repo, ENOENT)', () => {
     const result = loadCompiledHooks({
       manifestPath: path.join(workDir, 'missing.json'),
       installedPackVersions: {},
@@ -39,6 +39,26 @@ describe('loadCompiledHooks', () => {
     expect(result.hooks).toEqual([]);
     expect(result.warnings).toEqual([]);
     expect(result.errors).toEqual([]);
+  });
+
+  it('surfaces non-ENOENT read errors as HOOKS_LOAD_FAILED (does not pretend the file is missing)', () => {
+    // Reading a directory as a file produces EISDIR on POSIX / EBADF or
+    // ENOTSUP-flavoured failures on Windows. Whatever the platform-specific
+    // errno, it is NOT ENOENT — so the loader must surface it, not silently
+    // return the "manifest absent" result that the prior existsSync pre-check
+    // would have masked.
+    const dirAsManifest = path.join(workDir, 'a-directory');
+    fs.mkdirSync(dirAsManifest);
+    const result = loadCompiledHooks({
+      manifestPath: dirAsManifest,
+      installedPackVersions: {},
+    });
+    expect(result.hooks).toEqual([]);
+    expect(result.errors.length).toBe(1);
+    const err = result.errors[0]!;
+    expect(err.code).toBe('HOOKS_LOAD_FAILED');
+    expect(err.message).toContain('failed to read compiled-hooks manifest');
+    expect(err.cause).toBeDefined();
   });
 
   it('records a structural error on invalid JSON and preserves the original SyntaxError via cause', () => {

--- a/packages/cli/src/hook/loader.ts
+++ b/packages/cli/src/hook/loader.ts
@@ -1,5 +1,7 @@
 import fs from 'node:fs';
 
+import { TotemError } from '@mmnto/totem';
+
 import {
   COMPILED_HOOKS_SCHEMA_VERSION,
   type CompiledHookRule,
@@ -42,12 +44,19 @@ export interface LoadCompiledHooksOptions {
 export interface LoadCompiledHooksResult {
   hooks: CompiledHookRule[];
   warnings: string[];
-  errors: string[];
+  /**
+   * Errors carry the original cause via `Error.cause` so debug consumers
+   * can traverse the chain (per the codebase styleguide rule against
+   * concatenating `err.message` into new strings — destroys the stack).
+   * Callers that just need to log can use `err.message`; debug tooling
+   * walks `err.cause` recursively.
+   */
+  errors: TotemError[];
 }
 
 export function loadCompiledHooks(options: LoadCompiledHooksOptions): LoadCompiledHooksResult {
   const warnings: string[] = [];
-  const errors: string[] = [];
+  const errors: TotemError[] = [];
 
   if (!fs.existsSync(options.manifestPath)) {
     return { hooks: [], warnings, errors };
@@ -59,7 +68,12 @@ export function loadCompiledHooks(options: LoadCompiledHooksOptions): LoadCompil
     // totem-context: intentional — error captured into diagnostics array (the loader's contract is diagnostics-not-throws per Tenet 4 carve-out for hooks being best-effort)
   } catch (err) {
     errors.push(
-      `failed to read compiled-hooks manifest at ${options.manifestPath}: ${(err as Error).message}`,
+      new TotemError(
+        'HOOKS_LOAD_FAILED',
+        `failed to read compiled-hooks manifest at ${options.manifestPath}`,
+        'verify the file is readable and re-run `totem sync` to regenerate',
+        err,
+      ),
     );
     return { hooks: [], warnings, errors };
   }
@@ -70,7 +84,12 @@ export function loadCompiledHooks(options: LoadCompiledHooksOptions): LoadCompil
     // totem-context: intentional — error captured into diagnostics array (the loader's contract is diagnostics-not-throws per Tenet 4 carve-out for hooks being best-effort)
   } catch (err) {
     errors.push(
-      `compiled-hooks manifest at ${options.manifestPath} is not valid JSON: ${(err as Error).message}`,
+      new TotemError(
+        'HOOKS_LOAD_FAILED',
+        `compiled-hooks manifest at ${options.manifestPath} is not valid JSON`,
+        're-run `totem sync` to regenerate the manifest',
+        err,
+      ),
     );
     return { hooks: [], warnings, errors };
   }
@@ -93,10 +112,16 @@ export function loadCompiledHooks(options: LoadCompiledHooksOptions): LoadCompil
 
   const validation = CompiledHooksManifestSchema.safeParse(parsed);
   if (!validation.success) {
+    const summary = validation.error.issues
+      .map((i) => `${i.path.join('.')}: ${i.message}`)
+      .join('; ');
     errors.push(
-      `compiled-hooks manifest at ${options.manifestPath} failed schema validation: ${validation.error.issues
-        .map((i) => `${i.path.join('.')}: ${i.message}`)
-        .join('; ')}`,
+      new TotemError(
+        'HOOKS_LOAD_FAILED',
+        `compiled-hooks manifest at ${options.manifestPath} failed schema validation: ${summary}`,
+        're-run `totem sync` to regenerate the manifest, or upgrade totem CLI if the manifest was authored by a newer version',
+        validation.error,
+      ),
     );
     return { hooks: [], warnings, errors };
   }

--- a/packages/cli/src/hook/loader.ts
+++ b/packages/cli/src/hook/loader.ts
@@ -1,0 +1,122 @@
+import fs from 'node:fs';
+
+import {
+  COMPILED_HOOKS_SCHEMA_VERSION,
+  type CompiledHookRule,
+  CompiledHooksManifestSchema,
+} from './schema.js';
+
+/**
+ * Compiled-hooks manifest loader (ADR-104 § Decision 3 staleness check + a
+ * forward-compat warn-and-skip path for an evolving manifest schema).
+ *
+ * The loader is a pure function over `(manifestPath, installedPackVersions)`.
+ * It does NOT read `package.json` itself — callers (typically a
+ * bootstrap helper) resolve installed pack versions once and pass them in.
+ * Keeps the loader testable in isolation; mirrors the substrate-wiring
+ * pattern from `bootstrapEngine` (1.25.0 wiring lesson).
+ *
+ * Three failure modes are surfaced via the `warnings` array, not by
+ * throwing:
+ *
+ * 1. Manifest file missing — empty result, no warnings (a fresh repo without
+ *    installed pack hooks is a valid state).
+ * 2. Manifest schemaVersion is not the runner's expected version — warn and
+ *    skip the entire manifest (no hooks loaded). Composes with ADR-104
+ *    § Decision 4's forward-compat ethos.
+ * 3. Pack version drift — for each pack whose installed version differs from
+ *    the compiled-against version, emit a `[totem:hook-stale]` warning per
+ *    the format in ADR-104 § Decision 3. Hooks still load (Tenet 4 carve-out:
+ *    hooks are best-effort; staleness is signal, not a fail-closed condition).
+ *
+ * Structural errors (corrupt JSON, schema-validation failure on a manifest
+ * claiming the supported schemaVersion) populate `errors` and yield an empty
+ * hooks array — distinct from a missing manifest.
+ */
+
+export interface LoadCompiledHooksOptions {
+  manifestPath: string;
+  installedPackVersions: Record<string, string>;
+}
+
+export interface LoadCompiledHooksResult {
+  hooks: CompiledHookRule[];
+  warnings: string[];
+  errors: string[];
+}
+
+export function loadCompiledHooks(options: LoadCompiledHooksOptions): LoadCompiledHooksResult {
+  const warnings: string[] = [];
+  const errors: string[] = [];
+
+  if (!fs.existsSync(options.manifestPath)) {
+    return { hooks: [], warnings, errors };
+  }
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(options.manifestPath, 'utf8');
+    // totem-context: intentional — error captured into diagnostics array (the loader's contract is diagnostics-not-throws per Tenet 4 carve-out for hooks being best-effort)
+  } catch (err) {
+    errors.push(
+      `failed to read compiled-hooks manifest at ${options.manifestPath}: ${(err as Error).message}`,
+    );
+    return { hooks: [], warnings, errors };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+    // totem-context: intentional — error captured into diagnostics array (the loader's contract is diagnostics-not-throws per Tenet 4 carve-out for hooks being best-effort)
+  } catch (err) {
+    errors.push(
+      `compiled-hooks manifest at ${options.manifestPath} is not valid JSON: ${(err as Error).message}`,
+    );
+    return { hooks: [], warnings, errors };
+  }
+
+  // Forward-compat: peek at schemaVersion BEFORE invoking the strict z.literal
+  // schema validator, so an unknown version surfaces as a warn-and-skip
+  // rather than a thrown ZodError. Mirrors the per-pack warn-and-skip pattern
+  // for `hooks.yaml :: version` from ADR-104 § Decision 4.
+  const peekedVersion =
+    typeof parsed === 'object' && parsed !== null
+      ? (parsed as { schemaVersion?: unknown }).schemaVersion
+      : undefined;
+
+  if (peekedVersion !== COMPILED_HOOKS_SCHEMA_VERSION) {
+    warnings.push(
+      `[totem:hook-schema] compiled-hooks manifest schemaVersion ${JSON.stringify(peekedVersion)} unsupported by this runner (expected ${COMPILED_HOOKS_SCHEMA_VERSION})\n  → upgrade totem CLI or re-run \`totem sync\` to regenerate`,
+    );
+    return { hooks: [], warnings, errors };
+  }
+
+  const validation = CompiledHooksManifestSchema.safeParse(parsed);
+  if (!validation.success) {
+    errors.push(
+      `compiled-hooks manifest at ${options.manifestPath} failed schema validation: ${validation.error.issues
+        .map((i) => `${i.path.join('.')}: ${i.message}`)
+        .join('; ')}`,
+    );
+    return { hooks: [], warnings, errors };
+  }
+
+  const manifest = validation.data;
+
+  for (const [packId, compiledVersion] of Object.entries(manifest.sourcePackVersions)) {
+    const installedVersion = options.installedPackVersions[packId];
+    if (installedVersion === undefined) {
+      warnings.push(
+        `[totem:hook-stale] ${packId}: compiled against ${compiledVersion}, not currently installed\n  → run \`totem sync\` to refresh .totem/compiled-hooks.json`,
+      );
+      continue;
+    }
+    if (installedVersion !== compiledVersion) {
+      warnings.push(
+        `[totem:hook-stale] ${packId}: compiled against ${compiledVersion}, installed ${installedVersion}\n  → run \`totem sync\` to refresh .totem/compiled-hooks.json`,
+      );
+    }
+  }
+
+  return { hooks: manifest.hooks, warnings, errors };
+}

--- a/packages/cli/src/hook/loader.ts
+++ b/packages/cli/src/hook/loader.ts
@@ -58,15 +58,20 @@ export function loadCompiledHooks(options: LoadCompiledHooksOptions): LoadCompil
   const warnings: string[] = [];
   const errors: TotemError[] = [];
 
-  if (!fs.existsSync(options.manifestPath)) {
-    return { hooks: [], warnings, errors };
-  }
-
+  // No `fs.existsSync` pre-check: that returns false for any filesystem
+  // error (permission denied, symlink loops, EBUSY, etc.), not just ENOENT.
+  // Treating those as "missing manifest" would silently swallow real
+  // diagnostics. Catch ENOENT explicitly inside the read; everything else
+  // surfaces as a HOOKS_LOAD_FAILED entry.
   let raw: string;
   try {
     raw = fs.readFileSync(options.manifestPath, 'utf8');
     // totem-context: intentional — error captured into diagnostics array (the loader's contract is diagnostics-not-throws per Tenet 4 carve-out for hooks being best-effort)
   } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      // Fresh repo without installed pack hooks is a valid state, not a fault.
+      return { hooks: [], warnings, errors };
+    }
     errors.push(
       new TotemError(
         'HOOKS_LOAD_FAILED',

--- a/packages/cli/src/hook/runtime.test.ts
+++ b/packages/cli/src/hook/runtime.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { evaluateHook, formatRejection, type HookDecision } from './runtime.js';
+import { evaluateHook, formatRejection, type RejectDecision } from './runtime.js';
 import type { CompiledHookRule } from './schema.js';
 
 function rule(overrides: Partial<CompiledHookRule> = {}): CompiledHookRule {
@@ -125,7 +125,7 @@ describe('evaluateHook', () => {
 
 describe('formatRejection', () => {
   it('formats the structured prefix with packId/ruleId when recoveryHint is absent', () => {
-    const decision: HookDecision = {
+    const decision: RejectDecision = {
       decision: 'reject',
       packId: '@mmnto/pack-bot-coderabbit',
       ruleId: 'r1',
@@ -137,7 +137,7 @@ describe('formatRejection', () => {
   });
 
   it('includes the recovery-hint line when present', () => {
-    const decision: HookDecision = {
+    const decision: RejectDecision = {
       decision: 'reject',
       packId: '@mmnto/pack-bot-coderabbit',
       ruleId: 'r1',
@@ -150,7 +150,7 @@ describe('formatRejection', () => {
     );
   });
 
-  it('throws when given an allow decision (caller bug)', () => {
-    expect(() => formatRejection({ decision: 'allow' })).toThrow();
-  });
+  // The previous "throws when given an allow decision" runtime guard is gone —
+  // formatRejection's parameter is now narrowed to RejectDecision so the type
+  // system prevents the caller bug at compile time. TS-only enforcement.
 });

--- a/packages/cli/src/hook/runtime.test.ts
+++ b/packages/cli/src/hook/runtime.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+
+import { evaluateHook, formatRejection, type HookDecision } from './runtime.js';
+import type { CompiledHookRule } from './schema.js';
+
+function rule(overrides: Partial<CompiledHookRule> = {}): CompiledHookRule {
+  return {
+    id: 'gca-tag-xor-command',
+    packId: '@mmnto/pack-bot-gemini-code-assist',
+    trigger: { tool: 'bash', pattern: 'gh\\s+(pr|issue)\\s+comment' },
+    check: {
+      pattern: '(?=.*@gemini-code-assist)(?=.*\\/gemini review)',
+      type: 'reject-if-match',
+    },
+    message: 'GCA tag XOR command — never both; doubling wastes GCA quota.',
+    recoveryHint: 'Choose one: @-mention to comment, /gemini review for fresh review.',
+    ...overrides,
+  };
+}
+
+describe('evaluateHook', () => {
+  describe('trigger gate', () => {
+    it('allows when payload.tool does not match rule.trigger.tool', () => {
+      const result = evaluateHook(rule(), { tool: 'write', args: 'whatever' });
+      expect(result.decision).toBe('allow');
+    });
+
+    it('allows when payload.tool matches but trigger.pattern does not', () => {
+      // Trigger requires `gh pr comment` or `gh issue comment`; this is `gh pr list`.
+      const result = evaluateHook(rule(), { tool: 'bash', args: 'gh pr list' });
+      expect(result.decision).toBe('allow');
+    });
+  });
+
+  describe('check gate — reject-if-match', () => {
+    it('rejects when both trigger and check patterns match', () => {
+      const args = 'gh pr comment 123 --body "@gemini-code-assist /gemini review please"';
+      const result = evaluateHook(rule(), { tool: 'bash', args });
+      expect(result.decision).toBe('reject');
+      if (result.decision === 'reject') {
+        expect(result.message).toMatch(/GCA tag XOR/);
+        expect(result.packId).toBe('@mmnto/pack-bot-gemini-code-assist');
+        expect(result.ruleId).toBe('gca-tag-xor-command');
+      }
+    });
+
+    it('allows when trigger matches but check does not (only one of the two tags present)', () => {
+      // Trigger matches `gh pr comment` but the check requires BOTH the
+      // @mention AND the slash command — this comment has only the mention.
+      const args = 'gh pr comment 123 --body "@gemini-code-assist take a look"';
+      const result = evaluateHook(rule(), { tool: 'bash', args });
+      expect(result.decision).toBe('allow');
+    });
+  });
+
+  describe('check gate — reject-if-no-match', () => {
+    it('rejects when trigger matches but the required check pattern is absent', () => {
+      const r = rule({
+        id: 'requires-fixes-block',
+        check: { pattern: '## Fixes', type: 'reject-if-no-match' },
+        trigger: { tool: 'bash', pattern: 'git\\s+commit' },
+        message: 'Commit message must include a `## Fixes` section.',
+      });
+      const result = evaluateHook(r, { tool: 'bash', args: 'git commit -m "wip"' });
+      expect(result.decision).toBe('reject');
+    });
+
+    it('allows when the required check pattern is present', () => {
+      const r = rule({
+        check: { pattern: '## Fixes', type: 'reject-if-no-match' },
+        trigger: { tool: 'bash', pattern: 'git\\s+commit' },
+      });
+      const result = evaluateHook(r, {
+        tool: 'bash',
+        args: 'git commit -m "feat: x\\n\\n## Fixes\\n- y"',
+      });
+      expect(result.decision).toBe('allow');
+    });
+  });
+
+  describe('reject decision payload', () => {
+    it('carries packId and ruleId for provenance', () => {
+      const args = 'gh pr comment 1 --body "@gemini-code-assist /gemini review"';
+      const result = evaluateHook(rule(), { tool: 'bash', args });
+      expect(result).toMatchObject({
+        decision: 'reject',
+        packId: '@mmnto/pack-bot-gemini-code-assist',
+        ruleId: 'gca-tag-xor-command',
+      });
+    });
+
+    it('preserves recoveryHint when present', () => {
+      const args = 'gh pr comment 1 --body "@gemini-code-assist /gemini review"';
+      const result = evaluateHook(rule(), { tool: 'bash', args });
+      if (result.decision === 'reject') {
+        expect(result.recoveryHint).toMatch(/Choose one/);
+      }
+    });
+
+    it('returns undefined recoveryHint when the rule omits it', () => {
+      const r = rule({ recoveryHint: undefined });
+      const args = 'gh pr comment 1 --body "@gemini-code-assist /gemini review"';
+      const result = evaluateHook(r, { tool: 'bash', args });
+      if (result.decision === 'reject') {
+        expect(result.recoveryHint).toBeUndefined();
+      }
+    });
+  });
+
+  describe('verification_shadow ignored at runtime', () => {
+    it('evaluates as Interpretive Rule even when verification_shadow is present', () => {
+      // Per ADR-104 § Convergence: hooks fall into Interpretive Rule class
+      // in V1. verification_shadow on a hook rule is reserved schema field
+      // for future Spine-Rule promotion; the V1 runtime must not change
+      // its decision based on its presence or absence.
+      const args = 'gh pr comment 1 --body "@gemini-code-assist /gemini review"';
+      const withShadow = rule({ verification_shadow: { rego: 'package x' } });
+      const withoutShadow = rule();
+      expect(evaluateHook(withShadow, { tool: 'bash', args })).toEqual(
+        evaluateHook(withoutShadow, { tool: 'bash', args }),
+      );
+    });
+  });
+});
+
+describe('formatRejection', () => {
+  it('formats the structured prefix with packId/ruleId when recoveryHint is absent', () => {
+    const decision: HookDecision = {
+      decision: 'reject',
+      packId: '@mmnto/pack-bot-coderabbit',
+      ruleId: 'r1',
+      message: 'do not commit secrets',
+    };
+    expect(formatRejection(decision)).toBe(
+      '[totem:hook-block] @mmnto/pack-bot-coderabbit/r1: do not commit secrets',
+    );
+  });
+
+  it('includes the recovery-hint line when present', () => {
+    const decision: HookDecision = {
+      decision: 'reject',
+      packId: '@mmnto/pack-bot-coderabbit',
+      ruleId: 'r1',
+      message: 'do not commit secrets',
+      recoveryHint: 'use git-crypt or vault',
+    };
+    expect(formatRejection(decision)).toBe(
+      '[totem:hook-block] @mmnto/pack-bot-coderabbit/r1: do not commit secrets\n' +
+        '  → use git-crypt or vault',
+    );
+  });
+
+  it('throws when given an allow decision (caller bug)', () => {
+    expect(() => formatRejection({ decision: 'allow' })).toThrow();
+  });
+});

--- a/packages/cli/src/hook/runtime.ts
+++ b/packages/cli/src/hook/runtime.ts
@@ -76,17 +76,37 @@ export function formatRejection(decision: RejectDecision): string {
  * verification_shadow happens at the load layer when compiling pack
  * hooks.yaml, not on every hook-run invocation.
  */
+/**
+ * Memoizes compiled RegExp instances keyed by pattern string. Pack rule
+ * patterns are stable for the lifetime of a CLI process (the manifest is
+ * loaded once at startup), so a string-keyed cache is sufficient — there
+ * is no unbounded-growth concern in the single-shot CLI use case.
+ *
+ * Safe to memoize because the patterns are compiled with no flags, so the
+ * returned RegExp has no stateful `lastIndex` carry-over between `.test()`
+ * calls.
+ */
+const regexCache = new Map<string, RegExp>();
+
+function getCompiledRegex(pattern: string): RegExp {
+  const cached = regexCache.get(pattern);
+  if (cached) return cached;
+  const compiled = new RegExp(pattern);
+  regexCache.set(pattern, compiled);
+  return compiled;
+}
+
 export function evaluateHook(rule: CompiledHookRule, payload: ToolCallPayload): HookDecision {
   if (rule.trigger.tool !== payload.tool) {
     return { decision: 'allow' };
   }
 
-  const triggerRegex = new RegExp(rule.trigger.pattern);
+  const triggerRegex = getCompiledRegex(rule.trigger.pattern);
   if (!triggerRegex.test(payload.args)) {
     return { decision: 'allow' };
   }
 
-  const checkRegex = new RegExp(rule.check.pattern);
+  const checkRegex = getCompiledRegex(rule.check.pattern);
   const matched = checkRegex.test(payload.args);
 
   const shouldReject =

--- a/packages/cli/src/hook/runtime.ts
+++ b/packages/cli/src/hook/runtime.ts
@@ -1,0 +1,105 @@
+import type { CompiledHookRule } from './schema.js';
+
+/**
+ * Hook runtime evaluator (ADR-104 § Decisions 1, 2 + § Convergence).
+ *
+ * Takes a single hook rule plus a tool-call payload (tool name + tool args
+ * as a single string) and returns a structured allow/reject decision. The
+ * runtime is deterministic Node.js — no LLM calls in this path (Tenet 15
+ * corollary, ADR-103 § 8).
+ *
+ * V1 matcher class is regex-only per execution plan § 4. ast-grep and
+ * other matcher classes are deferred to V2; the schema permits future
+ * `verification_shadow` blocks but the V1 runtime ignores them.
+ */
+
+export interface ToolCallPayload {
+  /** The tool the agent is attempting to invoke (e.g. "bash"). */
+  tool: string;
+  /** Serialized tool arguments. For bash this is the command string;
+   *  for structured tools, callers serialize to a stable string form. */
+  args: string;
+}
+
+export type HookDecision =
+  | { decision: 'allow' }
+  | {
+      decision: 'reject';
+      message: string;
+      packId: string;
+      ruleId: string;
+      recoveryHint?: string;
+    };
+
+/**
+ * Build the structured rejection message per ADR-104 § Decision 1:
+ *
+ *     [totem:hook-block] <packId>/<ruleId>: <message>
+ *       → <recoveryHint>
+ *
+ * The `→ <recoveryHint>` line is omitted when no recoveryHint is provided.
+ * Agents and operators grep for the `[totem:hook-block]` prefix; the
+ * `<packId>/<ruleId>` carries provenance.
+ */
+export function formatRejection(decision: HookDecision): string {
+  if (decision.decision !== 'reject') {
+    throw new Error('formatRejection: expected reject decision');
+  }
+  const header = `[totem:hook-block] ${decision.packId}/${decision.ruleId}: ${decision.message}`;
+  if (decision.recoveryHint) {
+    return `${header}\n  → ${decision.recoveryHint}`;
+  }
+  return header;
+}
+
+/**
+ * Evaluate a single compiled hook rule against a tool-call payload.
+ *
+ * Two-stage gate:
+ * 1. Trigger gate: does this rule apply to this tool + args?
+ *    Rule applies when `rule.trigger.tool` equals `payload.tool` AND
+ *    `rule.trigger.pattern` matches `payload.args`.
+ * 2. Check gate: when the trigger matches, apply `rule.check.pattern` to
+ *    args. `reject-if-match` rejects on match; `reject-if-no-match`
+ *    rejects on non-match.
+ *
+ * Returns `{ decision: 'allow' }` when either gate passes the call through.
+ *
+ * V1 invariant: regex matching only. Future matcher classes (ast-grep,
+ * Rego-shadow) ship in V2 follow-on ADRs.
+ *
+ * Per ADR-104 § Convergence, any `verification_shadow` block on the rule
+ * is silently ignored at the runtime layer (V1 hooks are Interpretive
+ * Rule class — no formal-verification obligation). Warn-and-ignore of
+ * verification_shadow happens at the load layer when compiling pack
+ * hooks.yaml, not on every hook-run invocation.
+ */
+export function evaluateHook(rule: CompiledHookRule, payload: ToolCallPayload): HookDecision {
+  if (rule.trigger.tool !== payload.tool) {
+    return { decision: 'allow' };
+  }
+
+  const triggerRegex = new RegExp(rule.trigger.pattern);
+  if (!triggerRegex.test(payload.args)) {
+    return { decision: 'allow' };
+  }
+
+  const checkRegex = new RegExp(rule.check.pattern);
+  const matched = checkRegex.test(payload.args);
+
+  const shouldReject =
+    (rule.check.type === 'reject-if-match' && matched) ||
+    (rule.check.type === 'reject-if-no-match' && !matched);
+
+  if (!shouldReject) {
+    return { decision: 'allow' };
+  }
+
+  return {
+    decision: 'reject',
+    message: rule.message,
+    packId: rule.packId,
+    ruleId: rule.id,
+    recoveryHint: rule.recoveryHint,
+  };
+}

--- a/packages/cli/src/hook/runtime.ts
+++ b/packages/cli/src/hook/runtime.ts
@@ -21,15 +21,17 @@ export interface ToolCallPayload {
   args: string;
 }
 
-export type HookDecision =
-  | { decision: 'allow' }
-  | {
-      decision: 'reject';
-      message: string;
-      packId: string;
-      ruleId: string;
-      recoveryHint?: string;
-    };
+export type AllowDecision = { decision: 'allow' };
+
+export type RejectDecision = {
+  decision: 'reject';
+  message: string;
+  packId: string;
+  ruleId: string;
+  recoveryHint?: string;
+};
+
+export type HookDecision = AllowDecision | RejectDecision;
 
 /**
  * Build the structured rejection message per ADR-104 § Decision 1:
@@ -40,11 +42,11 @@ export type HookDecision =
  * The `→ <recoveryHint>` line is omitted when no recoveryHint is provided.
  * Agents and operators grep for the `[totem:hook-block]` prefix; the
  * `<packId>/<ruleId>` carries provenance.
+ *
+ * Parameter is narrowed to `RejectDecision` so the type system prevents
+ * passing an allow decision — no runtime guard needed.
  */
-export function formatRejection(decision: HookDecision): string {
-  if (decision.decision !== 'reject') {
-    throw new Error('formatRejection: expected reject decision');
-  }
+export function formatRejection(decision: RejectDecision): string {
   const header = `[totem:hook-block] ${decision.packId}/${decision.ruleId}: ${decision.message}`;
   if (decision.recoveryHint) {
     return `${header}\n  → ${decision.recoveryHint}`;

--- a/packages/cli/src/hook/schema.test.ts
+++ b/packages/cli/src/hook/schema.test.ts
@@ -92,6 +92,38 @@ describe('hook schema', () => {
       };
       expect(() => HookRuleSchema.parse(badRegex)).toThrow();
     });
+
+    it('rejects rules whose check.pattern has ReDoS risk (parse-time)', () => {
+      // `(a+)+$` is the canonical exponential-backtracking ReDoS shape — runs
+      // exponentially in the input length on near-matches. Pack-supplied
+      // patterns get a parse-time safety check via safe-regex2 to keep the
+      // engine's availability guarantee independent of pack quality.
+      const redosRule = {
+        id: 'r1',
+        trigger: { tool: 'bash', pattern: '.*' },
+        check: { pattern: '(a+)+$', type: 'reject-if-match' },
+        message: 'm',
+      };
+      const result = HookRuleSchema.safeParse(redosRule);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find((i) =>
+          i.message.includes('catastrophic-backtracking'),
+        );
+        expect(issue).toBeDefined();
+      }
+    });
+
+    it('rejects rules whose pattern exceeds the length cap', () => {
+      const oversized = {
+        id: 'r1',
+        trigger: { tool: 'bash', pattern: 'a'.repeat(600) },
+        check: { pattern: 'x', type: 'reject-if-match' },
+        message: 'm',
+      };
+      const result = HookRuleSchema.safeParse(oversized);
+      expect(result.success).toBe(false);
+    });
   });
 
   describe('HooksYamlSchema', () => {

--- a/packages/cli/src/hook/schema.test.ts
+++ b/packages/cli/src/hook/schema.test.ts
@@ -69,6 +69,29 @@ describe('hook schema', () => {
       };
       expect(() => HookRuleSchema.parse(badType)).toThrow();
     });
+
+    it('rejects rules whose trigger.pattern is not a valid regex (parse-time)', () => {
+      // Unterminated character class — `new RegExp('[')` throws SyntaxError.
+      // Schema must catch this before any `evaluateHook` invocation so a
+      // malformed pack rule surfaces at parse time rather than at first-fire.
+      const badRegex = {
+        id: 'r1',
+        trigger: { tool: 'bash', pattern: '[' },
+        check: { pattern: 'x', type: 'reject-if-match' },
+        message: 'm',
+      };
+      expect(() => HookRuleSchema.parse(badRegex)).toThrow();
+    });
+
+    it('rejects rules whose check.pattern is not a valid regex (parse-time)', () => {
+      const badRegex = {
+        id: 'r1',
+        trigger: { tool: 'bash', pattern: '.*' },
+        check: { pattern: '*invalid', type: 'reject-if-match' },
+        message: 'm',
+      };
+      expect(() => HookRuleSchema.parse(badRegex)).toThrow();
+    });
   });
 
   describe('HooksYamlSchema', () => {

--- a/packages/cli/src/hook/schema.test.ts
+++ b/packages/cli/src/hook/schema.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  COMPILED_HOOKS_SCHEMA_VERSION,
+  CompiledHooksManifestSchema,
+  HookRuleSchema,
+  HOOKS_YAML_SCHEMA_VERSION,
+  HooksYamlSchema,
+} from './schema.js';
+
+describe('hook schema', () => {
+  describe('HookRuleSchema', () => {
+    it('accepts a minimal rule with required fields only', () => {
+      const minimal = {
+        id: 'gca-tag-xor-command',
+        trigger: { tool: 'bash', pattern: 'gh\\s+(pr|issue)\\s+comment.*' },
+        check: {
+          pattern: '(?=.*@gemini-code-assist)(?=.*\\/gemini review)',
+          type: 'reject-if-match',
+        },
+        message: 'GCA tag XOR — never both.',
+      };
+      const parsed = HookRuleSchema.parse(minimal);
+      expect(parsed.recoveryHint).toBeUndefined();
+      expect(parsed.verification_shadow).toBeUndefined();
+    });
+
+    it('accepts a rule with the optional recoveryHint field', () => {
+      const withHint = {
+        id: 'r1',
+        trigger: { tool: 'bash', pattern: '.*' },
+        check: { pattern: 'x', type: 'reject-if-match' },
+        message: 'm',
+        recoveryHint: 'try y instead',
+      };
+      const parsed = HookRuleSchema.parse(withHint);
+      expect(parsed.recoveryHint).toBe('try y instead');
+    });
+
+    it('accepts verification_shadow permissively (V1 warn-and-ignore at runtime)', () => {
+      const withShadow = {
+        id: 'r1',
+        trigger: { tool: 'bash', pattern: '.*' },
+        check: { pattern: 'x', type: 'reject-if-match' },
+        message: 'm',
+        verification_shadow: { rego: 'package x' },
+      };
+      // V1 contract: schema accepts the block so a future Spine-Rule
+      // promotion doesn't break the parser. Runtime drops/warns on it.
+      expect(() => HookRuleSchema.parse(withShadow)).not.toThrow();
+    });
+
+    it('rejects rules with empty required strings', () => {
+      const empty = {
+        id: '',
+        trigger: { tool: 'bash', pattern: '.*' },
+        check: { pattern: 'x', type: 'reject-if-match' },
+        message: 'm',
+      };
+      expect(() => HookRuleSchema.parse(empty)).toThrow();
+    });
+
+    it('rejects an unknown check.type value', () => {
+      const badType = {
+        id: 'r1',
+        trigger: { tool: 'bash', pattern: '.*' },
+        check: { pattern: 'x', type: 'maybe-reject' },
+        message: 'm',
+      };
+      expect(() => HookRuleSchema.parse(badType)).toThrow();
+    });
+  });
+
+  describe('HooksYamlSchema', () => {
+    it('accepts a pack-level hooks.yaml with version 1 and an empty hooks array', () => {
+      const empty = { version: HOOKS_YAML_SCHEMA_VERSION, hooks: [] };
+      expect(() => HooksYamlSchema.parse(empty)).not.toThrow();
+    });
+
+    it('accepts version 2 — forward-compat path (runtime warn-and-skip per Decision 4)', () => {
+      // Schema accepts any positive integer version. The warn-and-skip on
+      // unknown-version is enforced at the load layer, not the schema layer,
+      // so a future bot-pack publishing version 2 doesn't crash the parser.
+      const future = { version: 2, hooks: [] };
+      expect(() => HooksYamlSchema.parse(future)).not.toThrow();
+    });
+
+    it('rejects non-positive version values', () => {
+      expect(() => HooksYamlSchema.parse({ version: 0, hooks: [] })).toThrow();
+      expect(() => HooksYamlSchema.parse({ version: -1, hooks: [] })).toThrow();
+    });
+  });
+
+  describe('CompiledHooksManifestSchema', () => {
+    it('accepts a manifest with the required staleness metadata fields', () => {
+      const manifest = {
+        schemaVersion: COMPILED_HOOKS_SCHEMA_VERSION,
+        compiledAt: '2026-05-11T18:43:00Z',
+        sourcePackVersions: {
+          '@mmnto/pack-bot-coderabbit': '1.0.0',
+        },
+        hooks: [],
+      };
+      expect(() => CompiledHooksManifestSchema.parse(manifest)).not.toThrow();
+    });
+
+    it('rejects a manifest missing sourcePackVersions (staleness check requires it)', () => {
+      const bad = {
+        schemaVersion: COMPILED_HOOKS_SCHEMA_VERSION,
+        compiledAt: '2026-05-11T18:43:00Z',
+        hooks: [],
+      };
+      expect(() => CompiledHooksManifestSchema.parse(bad)).toThrow();
+    });
+
+    it('rejects a non-ISO compiledAt string', () => {
+      const bad = {
+        schemaVersion: COMPILED_HOOKS_SCHEMA_VERSION,
+        compiledAt: 'yesterday',
+        sourcePackVersions: {},
+        hooks: [],
+      };
+      expect(() => CompiledHooksManifestSchema.parse(bad)).toThrow();
+    });
+
+    it('rejects a future schemaVersion (uses z.literal — caller must handle upgrades)', () => {
+      const future = {
+        schemaVersion: 2,
+        compiledAt: '2026-05-11T18:43:00Z',
+        sourcePackVersions: {},
+        hooks: [],
+      };
+      expect(() => CompiledHooksManifestSchema.parse(future)).toThrow();
+    });
+
+    it('preserves provenance via packId on each compiled rule', () => {
+      const manifest = {
+        schemaVersion: COMPILED_HOOKS_SCHEMA_VERSION,
+        compiledAt: '2026-05-11T18:43:00Z',
+        sourcePackVersions: { '@mmnto/pack-bot-coderabbit': '1.0.0' },
+        hooks: [
+          {
+            id: 'r1',
+            packId: '@mmnto/pack-bot-coderabbit',
+            trigger: { tool: 'bash', pattern: '.*' },
+            check: { pattern: 'x', type: 'reject-if-match' },
+            message: 'm',
+          },
+        ],
+      };
+      const parsed = CompiledHooksManifestSchema.parse(manifest);
+      expect(parsed.hooks[0].packId).toBe('@mmnto/pack-bot-coderabbit');
+    });
+  });
+});

--- a/packages/cli/src/hook/schema.test.ts
+++ b/packages/cli/src/hook/schema.test.ts
@@ -112,6 +112,58 @@ describe('hook schema', () => {
       expect(() => HooksYamlSchema.parse({ version: 0, hooks: [] })).toThrow();
       expect(() => HooksYamlSchema.parse({ version: -1, hooks: [] })).toThrow();
     });
+
+    it('accepts hooks with distinct ids', () => {
+      const distinct = {
+        version: HOOKS_YAML_SCHEMA_VERSION,
+        hooks: [
+          {
+            id: 'r1',
+            trigger: { tool: 'bash', pattern: '.*' },
+            check: { pattern: 'x', type: 'reject-if-match' },
+            message: 'm1',
+          },
+          {
+            id: 'r2',
+            trigger: { tool: 'bash', pattern: '.*' },
+            check: { pattern: 'y', type: 'reject-if-match' },
+            message: 'm2',
+          },
+        ],
+      };
+      expect(() => HooksYamlSchema.parse(distinct)).not.toThrow();
+    });
+
+    it('rejects duplicate hook ids within a pack (provenance must stay deterministic)', () => {
+      // Two rules with the same id within one pack would make
+      // `<packId>/<ruleId>` rejection trails ambiguous (ADR-104 § Decision 1).
+      const dup = {
+        version: HOOKS_YAML_SCHEMA_VERSION,
+        hooks: [
+          {
+            id: 'r1',
+            trigger: { tool: 'bash', pattern: '.*' },
+            check: { pattern: 'x', type: 'reject-if-match' },
+            message: 'first',
+          },
+          {
+            id: 'r1',
+            trigger: { tool: 'bash', pattern: '.*' },
+            check: { pattern: 'y', type: 'reject-if-match' },
+            message: 'second',
+          },
+        ],
+      };
+      const result = HooksYamlSchema.safeParse(dup);
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const issue = result.error.issues.find(
+          (i) => i.message === 'Duplicate hook id within pack: r1',
+        );
+        expect(issue).toBeDefined();
+        expect(issue?.path).toEqual(['hooks', 1, 'id']);
+      }
+    });
   });
 
   describe('CompiledHooksManifestSchema', () => {

--- a/packages/cli/src/hook/schema.ts
+++ b/packages/cli/src/hook/schema.ts
@@ -29,7 +29,7 @@ const RegexPatternSchema = z
     (p) => {
       try {
         new RegExp(p);
-        return true;
+        return true; // totem-context: intentional — catch below is throw-as-control-flow for regex validation
       } catch {
         return false;
       }

--- a/packages/cli/src/hook/schema.ts
+++ b/packages/cli/src/hook/schema.ts
@@ -1,0 +1,101 @@
+import { z } from 'zod';
+
+/**
+ * Hook rule schemas for the bot-pack wiring engine (ADR-104).
+ *
+ * Two surfaces:
+ * - `HooksYamlSchema` describes a pack's `hooks.yaml` (authoring surface).
+ * - `CompiledHooksManifestSchema` describes `.totem/compiled-hooks.json`
+ *   (runtime surface produced by `totem sync` from installed packs).
+ *
+ * The compiled manifest carries the staleness metadata required by
+ * ADR-104 § Decision 3: schemaVersion + compiledAt + sourcePackVersions.
+ */
+
+const HookCheckTypeSchema = z.enum(['reject-if-match', 'reject-if-no-match']);
+
+export type HookCheckType = z.infer<typeof HookCheckTypeSchema>;
+
+const HookTriggerSchema = z.object({
+  tool: z.string().min(1),
+  pattern: z.string().min(1),
+});
+
+const HookCheckSchema = z.object({
+  pattern: z.string().min(1),
+  type: HookCheckTypeSchema,
+});
+
+/**
+ * Authoring-surface schema for a single hook rule in a pack's `hooks.yaml`.
+ *
+ * The optional `recoveryHint` field (ADR-104 § Decision 1) gives agents the
+ * WHAT-INSTEAD on a block — recommended but not required in V1. Adoption
+ * tracked toward a V2 upgrade-to-required trigger (>80% of published rules
+ * carry it, OR an empirically-observed retry-loop incident).
+ *
+ * The `verification_shadow` field is reserved for the Spine Rule
+ * classification path (ADR-104 § Convergence + Q1 binding). In V1 the engine
+ * MUST warn-and-ignore any verification_shadow on a hook rule (hooks are
+ * Interpretive Rule class — no formal verification obligation). Schema
+ * accepts it permissively so future Spine-Rule promotion does not require
+ * a schema break.
+ */
+export const HookRuleSchema = z.object({
+  id: z.string().min(1),
+  trigger: HookTriggerSchema,
+  check: HookCheckSchema,
+  message: z.string().min(1),
+  recoveryHint: z.string().optional(),
+  verification_shadow: z.unknown().optional(),
+});
+
+export type HookRule = z.infer<typeof HookRuleSchema>;
+
+export const HOOKS_YAML_SCHEMA_VERSION = 1 as const;
+
+/**
+ * Per-pack `hooks.yaml` file shape. The `version` field is the contract
+ * for forward-compat: when `totem sync` parses an unknown version (higher
+ * than the runner supports), it warns-and-skips that pack entirely
+ * (ADR-104 § Decision 4).
+ */
+export const HooksYamlSchema = z.object({
+  version: z.number().int().positive(),
+  hooks: z.array(HookRuleSchema),
+});
+
+export type HooksYaml = z.infer<typeof HooksYamlSchema>;
+
+export const COMPILED_HOOKS_SCHEMA_VERSION = 1 as const;
+
+/**
+ * A compiled hook rule carries provenance (`packId`) so rejection messages
+ * can name `<packId>/<ruleId>` (ADR-104 § Decision 1) and so staleness
+ * checks can scope per-pack.
+ */
+export const CompiledHookRuleSchema = HookRuleSchema.extend({
+  packId: z.string().min(1),
+});
+
+export type CompiledHookRule = z.infer<typeof CompiledHookRuleSchema>;
+
+/**
+ * Runtime-surface manifest produced by `totem sync` and read on every
+ * `totem hook run` invocation. The metadata fields are load-bearing for
+ * ADR-104 § Decision 3 (staleness detection):
+ *
+ * - `schemaVersion`: bumps on breaking structural change to this manifest
+ * - `compiledAt`: ISO 8601 timestamp of last compile
+ * - `sourcePackVersions`: pack name → version at compile time; compared
+ *   against package.json resolutions to emit `[totem:hook-stale]` warnings
+ *   when packs have updated since last compile
+ */
+export const CompiledHooksManifestSchema = z.object({
+  schemaVersion: z.literal(COMPILED_HOOKS_SCHEMA_VERSION),
+  compiledAt: z.string().datetime(),
+  sourcePackVersions: z.record(z.string(), z.string()),
+  hooks: z.array(CompiledHookRuleSchema),
+});
+
+export type CompiledHooksManifest = z.infer<typeof CompiledHooksManifestSchema>;

--- a/packages/cli/src/hook/schema.ts
+++ b/packages/cli/src/hook/schema.ts
@@ -81,10 +81,28 @@ export const HOOKS_YAML_SCHEMA_VERSION = 1 as const;
  * than the runner supports), it warns-and-skips that pack entirely
  * (ADR-104 § Decision 4).
  */
-export const HooksYamlSchema = z.object({
-  version: z.number().int().positive(),
-  hooks: z.array(HookRuleSchema),
-});
+export const HooksYamlSchema = z
+  .object({
+    version: z.number().int().positive(),
+    hooks: z.array(HookRuleSchema),
+  })
+  .superRefine((data, ctx) => {
+    // Duplicate hook ids within a single pack would make the
+    // `<packId>/<ruleId>` provenance in rejection messages (ADR-104 § Decision 1)
+    // ambiguous. Enforce uniqueness at parse time so a misauthored pack fails
+    // on load rather than producing non-deterministic rejection trails.
+    const seen = new Set<string>();
+    data.hooks.forEach((hook, i) => {
+      if (seen.has(hook.id)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Duplicate hook id within pack: ${hook.id}`,
+          path: ['hooks', i, 'id'],
+        });
+      }
+      seen.add(hook.id);
+    });
+  });
 
 export type HooksYaml = z.infer<typeof HooksYamlSchema>;
 

--- a/packages/cli/src/hook/schema.ts
+++ b/packages/cli/src/hook/schema.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { isRegexSafe } from '@mmnto/totem';
+
 /**
  * Hook rule schemas for the bot-pack wiring engine (ADR-104).
  *
@@ -17,25 +19,68 @@ const HookCheckTypeSchema = z.enum(['reject-if-match', 'reject-if-no-match']);
 export type HookCheckType = z.infer<typeof HookCheckTypeSchema>;
 
 /**
- * Validate that a regex pattern compiles. Runs at parse time so an invalid
- * pack pattern surfaces as a schema validation error rather than a runtime
- * crash inside `evaluateHook` (Tenet 4: don't fail open silently on
- * invalid input).
+ * Generous upper bound on pack-supplied regex pattern length. Real rules in
+ * the existing corpus run well under 200 chars; 512 leaves headroom while
+ * capping the attack surface against deliberately-bloated inputs. Bounding
+ * length at the schema layer also makes ReDoS-style worst-case payloads
+ * easier to reason about (the engine never compiles 10KB patterns).
  */
-const RegexPatternSchema = z
-  .string()
-  .min(1)
-  .refine(
-    (p) => {
-      try {
-        new RegExp(p);
-        return true; // totem-context: intentional — catch below is throw-as-control-flow for regex validation
-      } catch {
-        return false;
-      }
-    },
-    { message: 'pattern is not a valid regular expression' },
-  );
+const MAX_PATTERN_LENGTH = 512;
+
+/**
+ * Validate that a regex pattern is well-formed AND safe from catastrophic
+ * backtracking. Runs at parse time (Tenet 4: don't fail open silently on
+ * invalid input). Three layers, gated in order with `fatal: true` so an
+ * earlier failure short-circuits — otherwise Zod would run `isRegexSafe`
+ * against an unbounded-length or syntactically-invalid input:
+ *
+ * 1. Bounded length (`MAX_PATTERN_LENGTH`) — caps the attack surface against
+ *    deliberately-bloated patterns.
+ * 2. Syntactically valid (compiles via `new RegExp`).
+ * 3. Free of nested unbounded-quantifier shapes via `safe-regex2`
+ *    (re-exported from core as `isRegexSafe`). Without this, a pack
+ *    publishing a pattern like `(a+)+$` would hang `evaluateHook` on
+ *    crafted tool-call payloads. Pack-supplied patterns come from
+ *    third-party npm, so ReDoS rejection at parse time is load-bearing
+ *    for the engine's availability guarantee.
+ */
+const RegexPatternSchema = z.string().superRefine((p, ctx) => {
+  if (p.length < 1) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'pattern must not be empty',
+      fatal: true,
+    });
+    return z.NEVER;
+  }
+  if (p.length > MAX_PATTERN_LENGTH) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: `pattern exceeds ${MAX_PATTERN_LENGTH}-char limit`,
+      fatal: true,
+    });
+    return z.NEVER;
+  }
+  try {
+    new RegExp(p);
+    // totem-context: intentional — catch below is throw-as-control-flow for regex validation
+  } catch {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'pattern is not a valid regular expression',
+      fatal: true,
+    });
+    return z.NEVER;
+  }
+  if (!isRegexSafe(p)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: 'pattern has catastrophic-backtracking risk (ReDoS); reshape to bounded quantifiers',
+      fatal: true,
+    });
+    return z.NEVER;
+  }
+});
 
 const HookTriggerSchema = z.object({
   tool: z.string().min(1),

--- a/packages/cli/src/hook/schema.ts
+++ b/packages/cli/src/hook/schema.ts
@@ -16,13 +16,34 @@ const HookCheckTypeSchema = z.enum(['reject-if-match', 'reject-if-no-match']);
 
 export type HookCheckType = z.infer<typeof HookCheckTypeSchema>;
 
+/**
+ * Validate that a regex pattern compiles. Runs at parse time so an invalid
+ * pack pattern surfaces as a schema validation error rather than a runtime
+ * crash inside `evaluateHook` (Tenet 4: don't fail open silently on
+ * invalid input).
+ */
+const RegexPatternSchema = z
+  .string()
+  .min(1)
+  .refine(
+    (p) => {
+      try {
+        new RegExp(p);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    { message: 'pattern is not a valid regular expression' },
+  );
+
 const HookTriggerSchema = z.object({
   tool: z.string().min(1),
-  pattern: z.string().min(1),
+  pattern: RegexPatternSchema,
 });
 
 const HookCheckSchema = z.object({
-  pattern: z.string().min(1),
+  pattern: RegexPatternSchema,
   type: HookCheckTypeSchema,
 });
 

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -32,7 +32,8 @@ export type TotemErrorCode =
   | 'STAGED_READ_FAILED'
   | 'UPGRADE_CLOUD_UNSUPPORTED'
   | 'STALE_MANIFEST'
-  | 'FLAG_CONFLICT';
+  | 'FLAG_CONFLICT'
+  | 'HOOKS_LOAD_FAILED';
 
 export class TotemError extends Error {
   readonly code: TotemErrorCode;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -237,6 +237,10 @@ export { redactPath, type RegexTelemetry, RegexTelemetrySchema } from './regex-s
 
 // Rule testing
 export {
+  FIXTURE_CORPORA,
+  FIXTURE_SURFACES,
+  type FixtureCorpus,
+  type FixtureSurface,
   isTodoFixture,
   loadFixtures,
   parseFixture,

--- a/packages/core/src/rule-tester.test.ts
+++ b/packages/core/src/rule-tester.test.ts
@@ -75,6 +75,70 @@ file: src/app.ts
     const fixture = parseFixture(content, 'test.md');
     expect(fixture).toBeNull();
   });
+
+  it('defaults surface to rules and corpus to pass when frontmatter omits them (backwards-compat)', () => {
+    const content = `---
+rule: abc123
+file: src/app.ts
+---
+
+## Should fail
+
+\`\`\`ts
+const x = badThing();
+\`\`\`
+`;
+    const fixture = parseFixture(content, 'test.md');
+    expect(fixture).not.toBeNull();
+    expect(fixture!.surface).toBe('rules');
+    expect(fixture!.corpus).toBe('pass');
+  });
+
+  it('reads explicit surface: hooks and corpus: fail from frontmatter', () => {
+    const content = `---
+rule: gca-tag-xor-command
+file: .totem/hook-fixtures/gca.txt
+surface: hooks
+corpus: fail
+---
+
+## Should fail
+
+\`\`\`text
+gh pr comment 123 -b "@gemini-code-assist /gemini review"
+\`\`\`
+`;
+    const fixture = parseFixture(content, 'test.md');
+    expect(fixture).not.toBeNull();
+    expect(fixture!.surface).toBe('hooks');
+    expect(fixture!.corpus).toBe('fail');
+  });
+
+  it('rejects the fixture entirely when surface is an unknown enum value (typo guard)', () => {
+    const content = `---
+rule: abc123
+file: src/app.ts
+surface: hokks
+---
+
+## Should fail
+`;
+    const fixture = parseFixture(content, 'test.md');
+    expect(fixture).toBeNull();
+  });
+
+  it('rejects the fixture entirely when corpus is an unknown enum value (typo guard)', () => {
+    const content = `---
+rule: abc123
+file: src/app.ts
+corpus: maybe
+---
+
+## Should fail
+`;
+    const fixture = parseFixture(content, 'test.md');
+    expect(fixture).toBeNull();
+  });
 });
 
 describe('scaffoldFixture', () => {

--- a/packages/core/src/rule-tester.test.ts
+++ b/packages/core/src/rule-tester.test.ts
@@ -139,6 +139,34 @@ corpus: maybe
     const fixture = parseFixture(content, 'test.md');
     expect(fixture).toBeNull();
   });
+
+  it('rejects fixtures whose surface field is present but explicit-empty (no silent default)', () => {
+    // `surface:` with no value should fail loud — silently defaulting would
+    // misroute the fixture and weaken the typo-guard semantics.
+    const content = `---
+rule: abc123
+file: src/app.ts
+surface:
+---
+
+## Should fail
+`;
+    const fixture = parseFixture(content, 'test.md');
+    expect(fixture).toBeNull();
+  });
+
+  it('rejects fixtures whose corpus field is present but explicit-empty (no silent default)', () => {
+    const content = `---
+rule: abc123
+file: src/app.ts
+corpus:
+---
+
+## Should fail
+`;
+    const fixture = parseFixture(content, 'test.md');
+    expect(fixture).toBeNull();
+  });
 });
 
 describe('scaffoldFixture', () => {

--- a/packages/core/src/rule-tester.ts
+++ b/packages/core/src/rule-tester.ts
@@ -100,16 +100,20 @@ const TODO_MARKER = '// TODO: add code that should';
 /**
  * Extract a simple `key: value` from frontmatter using line iteration —
  * avoids needing a full YAML parser and stays consistent with the existing
- * regex-based field extraction. Returns `undefined` when the key is absent
- * or has no value after the colon.
+ * regex-based field extraction.
+ *
+ * Returns `undefined` ONLY when the key is absent from the frontmatter.
+ * Returns `''` (empty string) when the key is present but its value is empty
+ * — so callers can distinguish "omitted, apply default" from "explicit empty,
+ * reject as invalid." Without this distinction, `surface:` (blank) would
+ * silently route to the default and bypass the enum typo guard.
  */
 function extractFrontmatterField(meta: string, key: string): string | undefined {
   const prefix = `${key}:`;
   for (const line of meta.split('\n')) {
     const trimmed = line.trim();
     if (trimmed.startsWith(prefix)) {
-      const value = trimmed.slice(prefix.length).trim();
-      return value.length > 0 ? value : undefined;
+      return trimmed.slice(prefix.length).trim();
     }
   }
   return undefined;
@@ -149,6 +153,8 @@ export function parseFixture(content: string, fixturePath: string): RuleTestFixt
   const surfaceRaw = extractFrontmatterField(meta, 'surface');
   let surface: FixtureSurface = 'rules';
   if (surfaceRaw !== undefined) {
+    // Explicit-empty is a fixture-authoring mistake (`surface:` with no value)
+    // — fail loud rather than silently defaulting, same as a typo.
     if (!FIXTURE_SURFACES.includes(surfaceRaw as FixtureSurface)) {
       return null;
     }

--- a/packages/core/src/rule-tester.ts
+++ b/packages/core/src/rule-tester.ts
@@ -10,9 +10,37 @@ import { getErrorMessage } from './errors.js';
 // ─── Types ───────────────────────────────────────────
 
 /**
+ * Valid values for the `surface:` frontmatter field on a test fixture.
+ *
+ * Per ADR-104 § Convergence: the existing single-file fixture schema is
+ * extended additively with `surface: rules | hooks`. The field dispatches
+ * which matcher consumes the fixture. Defaults to `'rules'` when absent
+ * (backwards-compat for existing fixtures predating the hook engine).
+ */
+export const FIXTURE_SURFACES = ['rules', 'hooks'] as const;
+export type FixtureSurface = (typeof FIXTURE_SURFACES)[number];
+
+/**
+ * Valid values for the `corpus:` frontmatter field on a test fixture.
+ *
+ * Per ADR-104 § Convergence: tags a fixture as a positive (`pass`) or
+ * negative (`fail`) case. Defaults to `'pass'` when absent (backwards-compat
+ * for existing dual-section rules-surface fixtures, where the pass/fail
+ * semantic was carried by ## section headings inside the fixture body).
+ */
+export const FIXTURE_CORPORA = ['pass', 'fail'] as const;
+export type FixtureCorpus = (typeof FIXTURE_CORPORA)[number];
+
+/**
  * Fixture for verifying compiled rule patterns against examples.
  * Used by the rule testing infrastructure to validate hits (fail lines)
  * and misses (pass lines) for regex and AST-grep rules.
+ *
+ * The `surface` and `corpus` fields are filled with their defaults when
+ * absent from the fixture frontmatter (ADR-104 § Convergence — additive,
+ * backwards-compatible). PR-1's runtime keeps the existing dual-section
+ * behavior on `surface: rules`; the hooks-surface dispatch lands in the
+ * PR-1 follow-on.
  */
 export interface RuleTestFixture {
   /** lessonHash of the rule to test */
@@ -25,6 +53,19 @@ export interface RuleTestFixture {
   passLines: string[];
   /** Source file path of the fixture */
   fixturePath: string;
+  /**
+   * Which matcher pipeline consumes this fixture. Always populated by
+   * `parseFixture` (defaults to `'rules'`). Marked optional so existing
+   * call sites that construct fixtures inline (test scaffolding, the
+   * compile pipeline) compile without per-site updates.
+   */
+  surface?: FixtureSurface;
+  /**
+   * Whether the fixture asserts a positive or negative case. Always
+   * populated by `parseFixture` (defaults to `'pass'`). Optional for the
+   * same reason as `surface`.
+   */
+  corpus?: FixtureCorpus;
 }
 
 export interface RuleTestResult {
@@ -56,6 +97,24 @@ const PASS_SECTION_RE = /##\s*[Ss]hould\s+pass\s*\n+```[^\n]*\n([\s\S]*?)```/;
 
 const TODO_MARKER = '// TODO: add code that should';
 
+/**
+ * Extract a simple `key: value` from frontmatter using line iteration —
+ * avoids needing a full YAML parser and stays consistent with the existing
+ * regex-based field extraction. Returns `undefined` when the key is absent
+ * or has no value after the colon.
+ */
+function extractFrontmatterField(meta: string, key: string): string | undefined {
+  const prefix = `${key}:`;
+  for (const line of meta.split('\n')) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith(prefix)) {
+      const value = trimmed.slice(prefix.length).trim();
+      return value.length > 0 ? value : undefined;
+    }
+  }
+  return undefined;
+}
+
 /** Return true when every line in the fixture is a scaffolding placeholder. */
 export function isTodoFixture(fixture: RuleTestFixture): boolean {
   const allLines = [...fixture.failLines, ...fixture.passLines];
@@ -82,7 +141,30 @@ export function parseFixture(content: string, fixturePath: string): RuleTestFixt
   const failLines = failMatch ? failMatch[1]!.split('\n').filter((l) => l.trim().length > 0) : [];
   const passLines = passMatch ? passMatch[1]!.split('\n').filter((l) => l.trim().length > 0) : [];
 
-  return { ruleHash, filePath, failLines, passLines, fixturePath };
+  // ADR-104 § Convergence — additive `surface:` and `corpus:` frontmatter
+  // fields. Both default when absent (backwards-compat with existing
+  // fixtures predating the hook engine). Invalid values reject the fixture
+  // entirely rather than defaulting silently — a typo in the enum would
+  // otherwise misroute the matcher dispatch in PR-1's follow-on.
+  const surfaceRaw = extractFrontmatterField(meta, 'surface');
+  let surface: FixtureSurface = 'rules';
+  if (surfaceRaw !== undefined) {
+    if (!FIXTURE_SURFACES.includes(surfaceRaw as FixtureSurface)) {
+      return null;
+    }
+    surface = surfaceRaw as FixtureSurface;
+  }
+
+  const corpusRaw = extractFrontmatterField(meta, 'corpus');
+  let corpus: FixtureCorpus = 'pass';
+  if (corpusRaw !== undefined) {
+    if (!FIXTURE_CORPORA.includes(corpusRaw as FixtureCorpus)) {
+      return null;
+    }
+    corpus = corpusRaw as FixtureCorpus;
+  }
+
+  return { ruleHash, filePath, failLines, passLines, fixturePath, surface, corpus };
 }
 
 // ─── Fixture scaffolding ────────────────────────────


### PR DESCRIPTION
# PR-1: Bot-Pack Wiring Engine (foundation — WIP)

**Status:** Draft — multi-session ship. This PR is foundation-only per strategy-Claude T2030Z disposition (Option A). CLI surface + sync integration + cross-OS matrix ship in a follow-on PR.

Refs `mmnto-ai/totem-strategy#194`. Architectural spine in ADR-104 (merged at `mmnto-ai/totem-strategy@eafba43`).

## Why this is split

ADR-104 originally framed PR-1 as a single ship: engine + commands + fixtures + cross-OS matrix + sync wiring + two CLI renames. Empirical recon (T1946Z dispatch → T2010Z disposition) surfaced that the renames (`totem hooks` → `totem hook install`; `totem test` → `totem rule test`) touch user-facing CLI surface and deserve their own context budget. Strategy-Claude T2030Z disposition split the work into foundation (this PR) and follow-on (CLI surface + sync + cross-OS).

The foundation is genuinely reusable on its own: schemas + engine internals + fixture format extension compose into the Class 1 V1 lint-rule pipeline (per ADR-103 § Convergence / ADR-104 § Convergence) without needing the hook CLI surface to land first.

## Foundation checklist (claude-0038 + claude-0039) — complete

### Engine schemas (claude-0038 + claude-0039)

- [x] Engine module scaffold (`packages/cli/src/hook/`)
- [x] `HookRuleSchema` — authoring-surface shape with required + optional fields
- [x] `HooksYamlSchema` — per-pack shape with forward-compat `version` field
- [x] `CompiledHooksManifestSchema` — runtime-surface manifest with staleness metadata
- [x] Staleness manifest fields (schemaVersion, compiledAt, sourcePackVersions) per ADR-104 § Decision 3
- [x] Optional `recoveryHint` field per ADR-104 § Decision 1
- [x] Permissive `verification_shadow` field for future Spine-Rule promotion per ADR-104 § Convergence
- [x] Regex pattern validation at schema parse time (Tenet 4 — invalid pack regex surfaces at parse, not at first-fire)
- [x] **`HooksYamlSchema` superRefine — hook-id uniqueness within a pack (addresses GCA R1 HIGH)**
- [x] **`RegexPatternSchema` ReDoS hardening — 512-char length cap + `isRegexSafe` (safe-regex2) check, gated with `fatal: true` short-circuit (addresses CR R2 Major)**

### Runtime evaluator (claude-0038 + claude-0039)

- [x] `evaluateHook(rule, payload)` — deterministic Node.js engine; no LLM in the path
- [x] Two-stage gate: trigger (`rule.trigger.tool` + `rule.trigger.pattern`) → check (`rule.check.pattern` × `rule.check.type`)
- [x] `reject-if-match` and `reject-if-no-match` semantics both implemented
- [x] Structured rejection payload with `packId` + `ruleId` provenance + optional `recoveryHint`
- [x] `formatRejection` — wire format per ADR-104 § Decision 1: `[totem:hook-block] <pack>/<rule>: <msg>\n  → <hint>`
- [x] Type-narrowed parameter on `formatRejection` (statically prevents allow-decision caller bug)
- [x] Interpretive Rule semantics: `verification_shadow` neutral at runtime (V1 hooks classification per Q1 binding synthesis)
- [x] **Regex memoization cache to address the Tier-4 perf WARN**

### Classification helper (claude-0039)

- [x] `RuleClassification` type (`'spine' | 'interpretive'`)
- [x] `classifyHookRule(rule)` — always returns `'interpretive'` in V1 per Q1 binding
- [x] Warn-and-ignore signal `[totem:hook-shadow-ignored]` emitted when `verification_shadow` present (rule still executes as Interpretive)
- [x] V2 Spine-Rule promotion seam in place

### Rule loader (claude-0039)

- [x] `loadCompiledHooks({ manifestPath, installedPackVersions })` — pure function over injected deps
- [x] Missing manifest → empty result, no warnings (valid state)
- [x] Unknown `schemaVersion` → `[totem:hook-schema]` warn-and-skip (peek before strict z.literal)
- [x] Pack version drift → `[totem:hook-stale]` per drifting pack per ADR-104 § Decision 3 wording
- [x] Tenet 4 carve-out honored: warnings on staleness, not throws

### Fixture format extension (claude-0039)

- [x] `RuleTestFixture.surface` (`'rules' | 'hooks'`) + `RuleTestFixture.corpus` (`'pass' | 'fail'`) optional fields
- [x] `parseFixture` populates defaults (`'rules'`, `'pass'`) for backwards-compat
- [x] Invalid enum values reject the fixture entirely (typo guard)
- [x] `extractFrontmatterField` line-iteration helper (security-hook-safe, no new `.exec()` calls)
- [x] Exported `FIXTURE_SURFACES` + `FIXTURE_CORPORA` constants

### Tests

- [x] 19 schema unit tests (incl. uniqueness + ReDoS + length cap positive/negative)
- [x] 12 runtime unit tests
- [x] 3 classification unit tests
- [x] 10 loader unit tests
- [x] 5 new rule-tester unit tests (surface/corpus defaults + explicit values + typo guards)
- [x] **Total hook + fixture-extension tests: 49**
- [x] Repo-wide test sweep: 1858 core + 2107 CLI passing across 3 OS

## Deferred to PR-1 follow-on (per T2030Z)

- [ ] CLI rename: `totem hooks` → `totem hook install` (deprecation alias 1 release)
- [ ] CLI rename: `totem test` → `totem rule test` (deprecation alias 1 release)
- [ ] New: `totem hook run`, `totem hook test` subcommands
- [ ] Sync integration (hook compilation folded into `totem sync` per execution plan § 3)
- [ ] Cross-OS smoke matrix (ubuntu, windows, windows-via-MSYS) for argv-not-env shell quoting per ADR-104 § Decision 2

## Deferred to PR-2 (per ADR-104 § Decision 5)

- [ ] Headless-CLI sandbox + end-to-end demonstration of hook rejection in agent runtime
- [ ] **MUST merge before any pack publishes `hooks.yaml` to npm** (publish ≠ done hard gate)

## Bot review trail

- **GCA R1 (HIGH):** `HooksYamlSchema` hook-id uniqueness via superRefine — addressed in `0546e08e`.
- **CR R1:** clean (no actionable comments).
- **CR R2 (Major):** ReDoS hardening on `RegexPatternSchema` via `isRegexSafe` + length cap — addressed in `2cc7751d` with `fatal: true` short-circuit (shield review caught a Zod refinement non-short-circuit edge case on first draft).

## Refs

- ADR-104 (merged at `mmnto-ai/totem-strategy@eafba43`) — architectural spine; 5 banked concerns codified
- Q1/Q2/Q3 dispositions: strategy-Claude T1850Z + T1940Z (binding synthesis from strategy-Gemini T1930Z)
- Empirical correction + (a/C/A) dispositions: strategy-Claude T2010Z
- PR-1 sequencing disposition (Option A + 3 guardrails): strategy-Claude T2030Z
- MD040 unblock + PR-1 resumption: strategy-Claude T2105Z

🤖 Generated with [Claude Code](https://claude.com/claude-code)