### PR TITLE
chore(docs): retire bot-pack-* references per ADR-105 (bot-protocol centralization)

### DIFF
--- a/.totem/specs/1.30.1-data-only-pack-loader.md
+++ b/.totem/specs/1.30.1-data-only-pack-loader.md
@@ -4,7 +4,7 @@ The `resolvePackCallback` function currently crashes the application by uncondit
 
 ### Architectural Context
 
-This fix directly supports the **1.26.0 Pack Ecosystem Graduation** initiative (referenced in active work and roadmap), which focuses on completing the "publishes-and-wires arc for bot packs." Data-only bot packs are a critical use case in this ecosystem, allowing non-developer authors to distribute pure rules, workflows, and templates without requiring a boilerplate TypeScript/JavaScript initialization file.
+This fix supports the data-only pack archetype — packs that ship workflows and templates only, with no `main`/`exports`/`register.*` entry point. The runtime needs to detect "no entry point" and return a no-op `PackRegisterCallback` instead of throwing, so non-developer authors can distribute pure rules, workflows, and templates without requiring a boilerplate TypeScript/JavaScript initialization file.
 
 ### Files to Examine
 
@@ -113,7 +113,7 @@ No new state. The detection runs once per pack at boot time, inside `resolvePack
 2. **MODULE_NOT_FOUND inside pack code is NOT swallowed.** A pack with a valid `main: "./register.cjs"` whose `register.cjs` contains `require('./does-not-exist')` throws — the `MODULE_NOT_FOUND` originates inside `require()`, not `require.resolve`, so the existing wrap fires. Asserts the new `try/catch` is scoped to `require.resolve` only.
 3. **ERR_REQUIRE_ESM still surfaces loud.** A pack with a `package.json` `main: "./register.mjs"` (pure ESM entry) still throws `ERR_REQUIRE_ESM` per ADR-097 § 5 Q5 + `mmnto-ai/totem#1771`. The `try/catch` for `require.resolve` does NOT swallow this code.
 4. **Existing "missing callback shape" guard fires for code packs that resolve but export wrong shape.** A pack with `main: "./register.cjs"` that `module.exports = {}` (no default, no `register` function) still throws "did not export a registration callback." The new code path doesn't bypass the shape check — only the no-resolution case returns no-op.
-5. **Behavioral equivalence to LC consumer scenario.** A pack matching the `@mmnto/pack-bot-coderabbit@0.2.0` shape (`type: module`, `files: ["workflows", "templates"]`, no `main`, no `exports`) loads successfully. This is the regression-reproduction test.
+5. **Behavioral equivalence to the LC consumer scenario.** A pack matching the historical data-only shape (`type: module`, `files: ["workflows", "templates"]`, no `main`, no `exports`) loads successfully. This is the regression-reproduction test.
 
 ### Open questions
 

--- a/.totem/specs/1663.md
+++ b/.totem/specs/1663.md
@@ -137,7 +137,7 @@ Every implementation MUST end with these steps:
 
 No new state containers. No reserved keys / sentinel values: `'any'` is a real enum member, not a sentinel. Empty array `[]` is normalized to `['any']` at preprocess time so an explicit empty doesn't silently mean "no roles." Casing is normalized to lowercase before enum validation so authoring forgiveness doesn't bleed downstream as case-variant role strings.
 
-The `LessonRoleSchema` enum lives in `types.ts` (alongside `LessonFrontmatterSchema`) so MCP, CLI, and core all share a single canonical source. Exporting from `@mmnto/totem` is required because Proposal 248's pack-authoring follow-ups (`@mmnto/pack-bot-coderabbit`, `@mmnto/pack-bot-gemini-code-assist`) need to author lessons against this enum.
+The `LessonRoleSchema` enum lives in `types.ts` (alongside `LessonFrontmatterSchema`) so MCP, CLI, and core all share a single canonical source. Exporting from `@mmnto/totem` is required so future third-party pack authors can author lessons against this enum from outside the monorepo.
 
 ### State lifecycle
 
@@ -196,7 +196,7 @@ The asymmetry between YAML (whole-frontmatter fallback) and prose (per-field fal
    - **Options:**
      - (a) Export. Pack authors and CLI integrations get the canonical enum from day one.
      - (b) Internal-only. Lock the surface until bot-prompt integration ships.
-   - **Recommendation:** (a). Proposal 248's `@mmnto/pack-bot-*` follow-ups will need this enum to author lessons with the right `applies-to:`. Exporting in V1 unblocks pack work without a second cycle. Public-surface additions are low-risk because the enum is closed and the filter signature is conservative.
+   - **Recommendation:** (a). Future third-party pack authors will need this enum to author lessons with the right `applies-to:`. Exporting in V1 unblocks pack work without a second cycle. Public-surface additions are low-risk because the enum is closed and the filter signature is conservative.
 
 4. **Question:** Does the MCP `add_lesson` argument naming follow snake_case (`applies_to`) per item 020 §101 ("snake_case is conventional for MCP arg names"), or kebab-case (`applies-to`) for parity with the on-disk frontmatter key?
    - **Options:**

--- a/docs/active_work.md
+++ b/docs/active_work.md
@@ -55,10 +55,9 @@ The strategic frame is "publishing without runtime-wiring is incomplete; ship ga
 
 #### Headline work — Pack v0.1 graduation
 
+> **Bot-pack arc retired (2026-05-12).** The bot-pack publish + wire-into-hooks + memory-refactor bullets that previously sat here are superseded by [ADR-105 (Bot-Protocol Centralization)](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-105-bot-protocol-centralization.md). Bot-interaction protocols now live at `mmnto-ai/totem-strategy:doctrine/bot-protocols.md`; mechanical enforcement is tracked at [`mmnto-ai/totem#1900`](https://github.com/mmnto-ai/totem/issues/1900).
+
 - [ ] **`mmnto-ai/totem#1803` Option C — engines field migration.** Move the pack engine-version constraint from `peerDependencies['@mmnto/totem']` to `engines['@mmnto/totem']` per ADR-097 § Q6 amendment. Closes the structural collision with `mmnto-ai/totem#1777` (fixed-group sibling cannot peer-dep `@mmnto/totem` without triggering a MAJOR cascade) while preserving real semver cross-check at boot. Resolver mod + schema cascade across `pack-rust-architecture` and `pack-agent-security` + warning-text fix in `totem sync`. Unblocks Pack v0.1 alpha-pilot Leg 3 (external consumer adoption / LC un-quarantine).
-- [ ] **Bot-pack publish.** Lift `pack-staging/pack-bot-coderabbit-v0.1/` and `pack-staging/pack-bot-gemini-code-assist-v0.1/` to `@mmnto/pack-bot-coderabbit@1.x` and `@mmnto/pack-bot-gemini-code-assist@1.x` on npm. Publishing pipeline is proven; low risk.
-- [ ] **Bot-pack wire-into-hooks.** Session-start hooks for Claude Code and Gemini CLI consult the bot packs alongside the existing `totem describe` orientation pass. Same shape as the language-pack `extends` mechanism.
-- [ ] **Memory refactor.** Thin or remove the ~11 bot-specific rules in strategy-Claude memory that duplicate pack content; replace with one pointer rule directing future sessions to `@mmnto/pack-bot-coderabbit/workflows/*` and `@mmnto/pack-bot-gemini-code-assist/workflows/*` as the canonical source. Memory keeps session-incident receipts; pack holds the canonical operational rules.
 - [ ] **LC un-quarantine validation.** Pattern-quality review per `mmnto-ai/totem#1793` BEFORE un-quarantining the 4-rule `.rs` cohort (3 from upstream-014, 1 from upstream-048). End-to-end validation that PR #1795's substrate-wiring fix + #1803's engines-field migration unblock the LC PR-C cascade is the load-bearing signal that closes the alpha-pilot gate.
 
 #### Headline work — Substrate hardening (Tenet 15)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -155,7 +155,8 @@ Packs distribute compiled rules and extension surfaces across the Totem ecosyste
 - **Pack Categories:**
   - **Security packs:** `@mmnto/pack-agent-security` ships immutable rules covering unauthorized process spawning, dynamic code evaluation, network exfiltration, and obfuscated string assembly. Severity is locked.
   - **Language architecture packs:** Per ADR-097 the canonical archetype is `@mmnto/pack-<lang>-architecture`. `@mmnto/pack-rust-architecture` is the first non-trivial third-party consumer; it bundles `tree-sitter-rust.wasm` from `@vscode/tree-sitter-wasm` and registers via the dual-channel pattern (`api.registerLanguage` for the WASM substrate plus `napi.registerDynamicLanguage` for the napi-side runtime).
-  - **Bot operations packs:** Per Proposal 248 the per-bot interpretive layer ships as packs (`@mmnto/pack-bot-coderabbit`, `@mmnto/pack-bot-gemini-code-assist`). Vendor-drift isolation is the load-bearing reason. v0.1 stubs sit in `pack-staging/` pending the Pack Ecosystem Graduation arc.
+
+  Note: a "bot operations pack" category was previously proposed (Proposal 248). It was retired 2026-05-12 per [ADR-105](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-105-bot-protocol-centralization.md); bot-interaction protocols now live as canonical doctrine at `mmnto-ai/totem-strategy:doctrine/bot-protocols.md` with mechanical enforcement deferred to runtime hooks ([`mmnto-ai/totem#1900`](https://github.com/mmnto-ai/totem/issues/1900)).
 
 - **Bootstrap Semantics (ADR-091 § Bootstrap):**
   - **`pending-verification` install→lint promotion:** Pack rules ship with `status: 'pending-verification'`. The first `totem lint` run after installation runs them through the Stage 4 verifier and persists outcomes to a committable `.totem/verification-outcomes.json` (canonical-key-order via shared `canonicalStringify`).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -8,14 +8,13 @@ Totem is a standard library for codebase governance — deterministic primitives
 
 ## 1.26.0: Pack Ecosystem Graduation (Active)
 
-**Theme:** Close the Pack Ecosystem alpha-pilot graduation by completing the publishes-and-wires arc for bot packs, then collapse convention-rule duplication between agent memory and packs. Pair with deterministic-substrate hardening for rule classes currently encoded only as LLM-prose in CR / GCA styleguides (Tenet 15 violations surfaced by drift firing N=7+ across PR cycles).
+**Theme:** Close the Pack Ecosystem alpha-pilot graduation by finishing the language-pack publishes-and-wires arc, then start the deterministic-substrate hardening for rule classes currently encoded only as LLM-prose in CR / GCA styleguides (Tenet 15 violations surfaced by drift firing N=7+ across PR cycles).
 
 The strategic frame is "publishing without runtime-wiring is incomplete; ship gates require both." Memory rule `feedback_publishing_requires_wiring.md` codifies the principle after the substrate-wiring gap took 1.22.0 → 1.25.0 to close.
 
+> **Note on bot packs.** A previous version of this milestone included a "Bot Interpretive Pack" graduation arc (publish `@mmnto/pack-bot-coderabbit` + `@mmnto/pack-bot-gemini-code-assist`, wire into session-start hooks, refactor agent memory). It was retired on 2026-05-12 per [ADR-105 (Bot-Protocol Centralization)](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-105-bot-protocol-centralization.md). Bot-interaction protocols now live as canonical doctrine at `mmnto-ai/totem-strategy:doctrine/bot-protocols.md`; mechanical enforcement is tracked at [`mmnto-ai/totem#1900`](https://github.com/mmnto-ai/totem/issues/1900). The Pack channel remains valid for portable expertise (language packs, security packs).
+
 - **Headline Work — Pack v0.1 Graduation:**
-  - [ ] **Bot-pack publish:** `@mmnto/pack-bot-coderabbit@1.x` and `@mmnto/pack-bot-gemini-code-assist@1.x` to npm. Lift from `pack-staging/` per the proven `@mmnto/pack-rust-architecture` publish pipeline.
-  - [ ] **Bot-pack wire-into-hooks:** Session-start hooks for Claude Code and Gemini CLI consult the bot packs alongside the existing orientation pass.
-  - [ ] **Memory-as-pack-pointer refactor:** Thin or remove the bot-specific rules in agent memory that duplicate pack content; replace with one pointer rule citing `@mmnto/pack-bot-coderabbit/workflows/*` and `@mmnto/pack-bot-gemini-code-assist/workflows/*` as canonical.
   - [ ] **LC un-quarantine validation:** Pattern-quality review per `mmnto-ai/totem#1793` BEFORE un-quarantining the 4-rule `.rs` cohort. End-to-end empirical validation that PR #1795's substrate-wiring fix unblocks the LC PR-C cascade is the load-bearing signal that closes the alpha-pilot gate.
 
 - **Headline Work — Substrate Hardening (Tenet 15):**

--- a/docs/wiki/pack-ecosystem.md
+++ b/docs/wiki/pack-ecosystem.md
@@ -1,6 +1,6 @@
 # The Pack Ecosystem
 
-Totem 1.25.0+ distributes ecosystem-specific baseline rules, structural constraints, and interpretive bot guidelines as installable NPM packages under the `@mmnto/pack-*` scope.
+Totem 1.25.0+ distributes ecosystem-specific baseline rules and structural constraints as installable NPM packages under the `@mmnto/pack-*` scope.
 
 Packs replace the monolithic internal baseline system. You install a pack into your project using the standard Node.js ecosystem, and Totem dynamically incorporates its rules via the `loadInstalledPacks()` runtime invocation.
 

--- a/docs/wiki/pack-ecosystem.md
+++ b/docs/wiki/pack-ecosystem.md
@@ -6,22 +6,19 @@ Packs replace the monolithic internal baseline system. You install a pack into y
 
 ## Pack Categories
 
-Packs are structurally divided into three distinct categories based on their role and scope:
+Packs are structurally divided into two distinct categories based on their role and scope:
 
 ### 1. Language & Architecture Packs
 
 **(e.g., `@mmnto/pack-rust-architecture`, forthcoming: `@mmnto/pack-godot-architecture`)**
 These packs encode structural, deterministic AST and regex rules specific to a language or framework. They are the core enforcement primitives that protect your architecture from common footguns (e.g., empty catch blocks in TypeScript, or incorrect macro usages in Rust).
 
-### 2. Bot Interpretive Packs
-
-**(e.g., `@mmnto/pack-bot-coderabbit`, `@mmnto/pack-bot-gemini-code-assist`)**
-These packs are structurally distinct. They encode _interpretive knowledge_ of bot output and behavior, not workflow enforcement. They contain guidelines and patterns necessary for LLMs (like CodeRabbit or Gemini) to interact with your codebase effectively without hallucinating structural patterns.
-
-### 3. Capability Packs
+### 2. Capability Packs
 
 **(e.g., `@mmnto/pack-agent-security`)**
 These packs provide cross-cutting rule families that aren't tied to a specific language. For instance, the `pack-agent-security` module (which is `private: true` and restricted to workspace-only use) provides immutable security constraints protecting against unauthorized code evaluation or network exfiltration.
+
+> **Note on bot-interaction protocols.** A "Bot Interpretive Pack" archetype was previously proposed for distributing cohort bot-interaction protocols (CodeRabbit, Gemini Code Assist, etc.) as separate npm packages. That model was retired on 2026-05-12 per [ADR-105](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-105-bot-protocol-centralization.md). Bot-interaction protocols now live as canonical doctrine at `mmnto-ai/totem-strategy:doctrine/bot-protocols.md`, with mechanical enforcement deferred to runtime hooks ([`mmnto-ai/totem#1900`](https://github.com/mmnto-ai/totem/issues/1900)). The Pack channel remains valid for portable expertise (language packs, security packs); it was a channel mismatch for internal cohort protocols.
 
 ## Architecture and the Zero-Trust Default
 
@@ -45,7 +42,7 @@ This acts as a strict structural contract (as amended by ADR-097 § Q6).
 
 ## Publishing & Trust
 
-Canonical `@mmnto` packs (such as the 0.2.0 bot pack cohort) are published to NPM via OIDC, include cryptographic attestations, and are Sigstore-signed. This provides supply-chain security for governance primitives, ensuring that the rules governing your codebase haven't been tampered with.
+Canonical `@mmnto` packs are published to NPM via OIDC, include cryptographic attestations, and are Sigstore-signed. This provides supply-chain security for governance primitives, ensuring that the rules governing your codebase haven't been tampered with.
 
 ## Consumer Positioning: The Graduation Phase
 

--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -8,14 +8,13 @@ Totem is a standard library for codebase governance — deterministic primitives
 
 ## 1.26.0: Pack Ecosystem Graduation (Active)
 
-**Theme:** Close the Pack v0.1 alpha pilot by completing the publish-and-wire arc for bot packs, then collapse the convention-rule duplication between memory and packs. Pair with deterministic-substrate hardening for the rule classes currently encoded only as LLM-prose in CR/GCA styleguides (Tenet 15 violations surfaced by drift firing across multiple agents and repos).
+**Theme:** Close the Pack v0.1 alpha pilot by closing the remaining language-pack publish-and-wire arc and starting the convention-rule deterministic substrate that replaces LLM-prose enforcement (Tenet 15 violations surfaced by drift firing across multiple agents and repos).
 
-The strategic frame is **publishing without runtime-wiring is incomplete; ship gates require both**. The substrate-wiring gap shipped in `mmnto-ai/totem#1795` (1.25.0) closed the runtime-completeness leg of the alpha-pilot graduation gate; 1.26.0 closes the publish-and-wire leg for bot packs and starts the convention-rule deterministic substrate.
+The strategic frame is **publishing without runtime-wiring is incomplete; ship gates require both**. The substrate-wiring gap shipped in `mmnto-ai/totem#1795` (1.25.0) closed the runtime-completeness leg of the alpha-pilot graduation gate.
+
+> **Note on bot packs.** A "Bot Interpretive Pack" graduation arc previously sat under this milestone (publish `@mmnto/pack-bot-coderabbit` + `@mmnto/pack-bot-gemini-code-assist`, wire into session hooks, refactor agent memory to point at packs). It was retired on 2026-05-12 per [ADR-105 (Bot-Protocol Centralization)](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-105-bot-protocol-centralization.md). Bot-interaction protocols now live as canonical doctrine at `mmnto-ai/totem-strategy:doctrine/bot-protocols.md`; mechanical enforcement is tracked at [`mmnto-ai/totem#1900`](https://github.com/mmnto-ai/totem/issues/1900).
 
 - **Headline Work — Pack v0.1 graduation:**
-  - [ ] **Bot-pack publish.** Lift `pack-staging/pack-bot-coderabbit-v0.1/` and `pack-staging/pack-bot-gemini-code-assist-v0.1/` to `@mmnto/pack-bot-coderabbit@1.x` and `@mmnto/pack-bot-gemini-code-assist@1.x` on npm. Publishing pipeline is proven; low risk.
-  - [ ] **Bot-pack wire-into-hooks.** Session-start hooks for Claude Code and Gemini CLI consult the bot packs alongside the existing `totem describe` orientation pass. Same shape as the language-pack `extends` mechanism.
-  - [ ] **Memory refactor.** Thin the bot-specific rules in agent memory that duplicate pack content; replace with one pointer rule directing future sessions to `@mmnto/pack-bot-coderabbit/workflows/*` and `@mmnto/pack-bot-gemini-code-assist/workflows/*` as the canonical source. Memory keeps session-incident receipts; the pack holds canonical operational rules.
   - [ ] **LC un-quarantine validation.** Pattern-quality review per `mmnto-ai/totem#1793` BEFORE un-quarantining the 4-rule `.rs` cohort (3 from upstream-014, 1 from upstream-048). End-to-end validation that PR #1795's substrate-wiring fix unblocks the LC PR-C cascade is the load-bearing signal that closes the alpha-pilot gate.
 
 - **Headline Work — Substrate hardening (Tenet 15):**

--- a/packages/core/src/pack-discovery.ts
+++ b/packages/core/src/pack-discovery.ts
@@ -380,11 +380,9 @@ function resolvePackCallback(
     );
   }
 
-  // Probe for an entry point before attempting to load. Bot Interpretive
-  // Packs (e.g. @mmnto/pack-bot-coderabbit) intentionally ship workflows +
-  // templates only with no `main`/`exports`/`register.*`; they are
-  // documented as a structurally distinct archetype in
-  // `docs/wiki/pack-ecosystem.md`. For these packs, return a no-op
+  // Probe for an entry point before attempting to load. Data-only packs
+  // intentionally ship workflows + templates only with no
+  // `main`/`exports`/`register.*`. For these packs, return a no-op
   // callback so the pack is registered as known-but-data-only and its
   // workflows/templates remain available to other consumers (session
   // hooks, totem describe, etc.). See mmnto-ai/totem#1848 for the


### PR DESCRIPTION
## Summary

- Sweep `mmnto-ai/totem` references to the retired `pack-bot-coderabbit` and `pack-bot-gemini-code-assist` packs per [ADR-105 (Bot-Protocol Centralization)](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-105-bot-protocol-centralization.md), merged 2026-05-12 in `mmnto-ai/totem-strategy#304`.
- Bot-interaction protocols now live as canonical doctrine at [`mmnto-ai/totem-strategy:doctrine/bot-protocols.md`](https://github.com/mmnto-ai/totem-strategy/blob/main/doctrine/bot-protocols.md). Mechanical enforcement is tracked at `mmnto-ai/totem#1900`.
- The Pack-as-distribution model (Proposal 248 + ADR-104) was retired; the standalone GitHub repos `mmnto-ai/pack-bot-coderabbit` and `mmnto-ai/pack-bot-gemini-code-assist` are deleted and the npm packages `@mmnto/pack-bot-coderabbit` / `@mmnto/pack-bot-gemini-code-assist` are unpublished. ADR-104 (bot-pack wiring engine) is shelved.

## Scope (surgical, doc-heavy)

| File | Change |
|---|---|
| `packages/core/src/pack-discovery.ts` | Comment-only: drop `@mmnto/pack-bot-coderabbit` as the data-only-pack example. The no-op behavior is name-agnostic; the data-only archetype remains valid for any future data-only pack. |
| `docs/wiki/pack-ecosystem.md` | Retire the "Bot Interpretive Packs" pack category; renumber Capability Packs to category 2; add an ADR-105 + doctrine pointer note. |
| `docs/wiki/roadmap.md` | Remove the bot-pack publish + wire-into-hooks + memory-refactor bullets from the 1.26.0 milestone; add an ADR-105 supersede note. |
| `docs/roadmap.md` | Same as `docs/wiki/roadmap.md`. |
| `docs/active_work.md` | Surgical removal of bot-pack bullets in the 1.26.0 section; deprecation banner preserved. |
| `docs/architecture.md` | Drop the "Bot operations packs" sub-bullet from the Pack Categories list; add an ADR-105 + doctrine pointer. |
| `.totem/specs/1.30.1-data-only-pack-loader.md` | Generalize 2 example references away from the deleted packs. |
| `.totem/specs/1663.md` | Generalize the Proposal 248 follow-up reference to "future third-party pack authors." |

## Out of scope (per dispatch)

- Test fixtures in `packages/cli/src/hook/*.test.ts` and `packages/core/src/pack-discovery.test.ts` that use `pack-bot-coderabbit` as a fixture-name string: kept (per the substrate dispatch — fixture strings, not load-bearing wiring; behavior is name-agnostic).
- `packages/core/CHANGELOG.md`: historical entries kept untouched.
- `mmnto-ai/pack-bot-coderabbit` and `mmnto-ai/pack-bot-gemini-code-assist` standalone repos: already deleted by strategy-Claude.
- `mmnto-ai/totem-strategy` cleanup: landed in `mmnto-ai/totem-strategy#304`.
- Memory cleanup (auto-memory entries): handled separately, no git impact on this repo.

## Verification

- `pnpm run format` — no changes
- `totem lint` — PASS (383 rules, 0 violations)
- `totem review` — PASS (no findings)
- Pre-push hook — 4216 tests passed
- `pack-discovery.ts` change is comment-only; no logic change to `resolvePackCallback` or any caller.

## Test plan

- [x] `pnpm run format` clean
- [x] `totem lint` PASS
- [x] `totem review` PASS
- [x] Pre-push hooks pass (full test suite + Totem lint)
- [ ] CR + GCA review-round (auto-fired by push)

## References

- ADR-105: `mmnto-ai/totem-strategy:adr/adr-105-bot-protocol-centralization.md`
- Doctrine: `mmnto-ai/totem-strategy:doctrine/bot-protocols.md`
- Strategy-side cleanup: `mmnto-ai/totem-strategy#304` (merged)
- Mechanical enforcement backlog: `mmnto-ai/totem#1900`
- Substrate dispatch (T1928Z): `mmnto-ai/totem-substrate:.handoff/totem-claude/processed/2026-05-12T1928Z-strategy-claude.md` (filed by strategy-Claude in flight as claude-0057)

🤖 Generated with [Claude Code](https://claude.com/claude-code)