### PR TITLE
migration(adr-038): consolidate to AGENTS.md canonical + redirects (step 2/6)

### DIFF
--- a/.claude/docs/contributing.md
+++ b/.claude/docs/contributing.md
@@ -14,7 +14,7 @@ See [`mmnto-ai/totem-strategy:doctrine/bot-protocols.md`](https://github.com/mmn
 
 - Changesets: write `.changeset/` files manually.
 - Use `pnpm run version` (never bare `pnpm version`).
-- After merge: `totem extract <pr> --yes`, then `totem docs` if releasing.
+- After merge: `totem lesson extract <pr> --yes`, then `totem docs` if releasing.
 
 ## Code Style
 

--- a/.claude/docs/contributing.md
+++ b/.claude/docs/contributing.md
@@ -8,23 +8,7 @@
 
 ## PR Review Bot Protocol
 
-Two bots review PRs. Their interaction models are completely different -- confusing them causes missed feedback or duplicate noise.
-
-### CodeRabbit (CR)
-
-- Reply inline to any CR comment thread freely.
-- CR reads every reply in its thread automatically -- no tagging needed.
-- Supports `@coderabbitai fix` commands to trigger automated fixes.
-- One reply per finding is fine; multiple back-and-forth exchanges are normal.
-
-### Gemini Code Assist (GCA)
-
-- ONE batched top-level PR comment per PR. Never reply inline to individual GCA comment threads.
-- Every GCA reply MUST contain `@gemini-code-assist` -- GCA only sees messages that tag it explicitly.
-- Batch all findings into a single numbered-list response: address each finding in order.
-- GCA decline: add a lesson with `review-guidance` tag + update `.gemini/styleguide.md` §6.
-
-> **WARNING:** Do not apply CR habits to GCA. Inline thread replies to GCA threads are invisible to GCA and will be silently ignored. Always compose one top-level comment with `@gemini-code-assist` and the full response.
+See [`mmnto-ai/totem-strategy:doctrine/bot-protocols.md`](https://github.com/mmnto-ai/totem-strategy/blob/main/doctrine/bot-protocols.md) — canonical per [ADR-105](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-105-bot-protocol-centralization.md). Doctrine § 8.1 is the consolidated round-comment SOP (reply structure, @-mention rules, XOR Tag Rule, quota management, decline framing). Do not paraphrase here (paraphrases drift). Same retire-to-pointer pattern as `mmnto-ai/totem-playground@80b4d1b`.
 
 ## Publishing
 

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -34,6 +34,6 @@
 
 ## Totem
 
-- After merging a PR: run `totem extract <pr> --yes`, then `totem docs` if releasing.
+- After merging a PR: run `totem lesson extract <pr> --yes`, then `totem docs` if releasing.
 - **NEVER use `git push --no-verify`.** Fix the violation or file a ticket.
 - Before writing code, you MUST call `search_knowledge` with a query describing what you're about to change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ Not mechanically enforced. Follow because they reduce PR bot noise.
 
 - **Before coding:** `/preflight <issue>`. Create a feature branch.
 - **Before pushing:** `pnpm run format` → `totem lint` → `totem review` → verify compile manifest is current.
-- **After merging a PR:** `totem extract <pr> --yes`, then `totem docs` if releasing. Lessons: `totem lesson extract <prs>` → `totem lesson compile`.
+- **After merging a PR:** `totem lesson extract <pr> --yes`, then `totem docs` if releasing. Lessons: `totem lesson extract <prs>` → `totem lesson compile`.
 - **NEVER use `git push --no-verify`.** Also no `totem-ignore` or `eslint-disable` without a ticket.
 
 ## Contributor Principles

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,77 @@
+# Totem: Agent Instructions
+
+Canonical source of truth for how AI coding agents (Claude Code, Gemini CLI, Cursor, Windsurf, Copilot, etc.) behave in this repo. Per [Totem ADR-038](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-038-agents-md-standard.md), `mmnto-ai/totem` consolidates tool-specific instruction files into this single `AGENTS.md`. Thin `CLAUDE.md` / `GEMINI.md` redirect files exist only so each tool finds its way here. Junie reads `.junie/guidelines.md` directly until that migration follows.
+
+## Session Start Protocol (MANDATORY)
+
+1. Run `totem status` for health; read the active milestone for momentum.
+2. **NEVER GUESS ARCHITECTURE.** Before modifying any core system (hooks, orchestrator, compiler, extract pipeline), run `totem search <system_name>`.
+3. Before writing code, call `search_knowledge` describing what you're changing.
+4. Before planning, query `totem-strategy:search_knowledge` for ADRs.
+5. Don't push speculative fixes. Run `totem lint` locally — front-load all checks before the first push.
+
+## Essentials
+
+- **pnpm only** (never npm/yarn). Use `pnpm dlx` (never `npx`). Windows 11 + Git Bash. TypeScript strict mode.
+- `main` is protected. Feature branches + PRs. Never amend commits on feature branches. Use `Closes #NNN` in PR descriptions.
+- `kebab-case.ts` files, `err` (never `error`) in catch blocks, no empty catches.
+- Named constants for magic numbers. Zod at system boundaries only.
+- Run `pnpm run format` before committing.
+- **NEVER put secrets in config files.** `.env` only.
+
+## Totem Workflow
+
+Not mechanically enforced. Follow because they reduce PR bot noise.
+
+- **Before coding:** `/preflight <issue>`. Create a feature branch.
+- **Before pushing:** `pnpm run format` → `totem lint` → `totem review` → verify compile manifest is current.
+- **After merging a PR:** `totem extract <pr> --yes`, then `totem docs` if releasing. Lessons: `totem lesson extract <prs>` → `totem lesson compile`.
+- **NEVER use `git push --no-verify`.** Also no `totem-ignore` or `eslint-disable` without a ticket.
+
+## Contributor Principles
+
+<!-- totem-ignore-next-line -->
+
+- Update `AI_PROMPT_BLOCK` in `init.ts` when changing reflexes/hooks/prompts.
+- GCA decline: add a lesson with `review-guidance` tag + update `.gemini/styleguide.md` § 6.
+- Changesets: write `.changeset/` files manually. Use `pnpm run version` (never bare `pnpm version`).
+
+## Bot-Protocol Gate (load-bearing — ADR-105 Layer 3)
+
+Before posting ANY PR comment, replying to ANY bot, or running `gh pr comment` / `gh api .../comments`:
+
+<!-- totem:cr-disclaimer: cross-repo doctrine refs into private cohort repos (e.g., mmnto-ai/totem-strategy) remain canonical even when CR's URL-accessibility check returns 404 from the bot account — this is an access-class signal per doctrine § 2.4, not a link-class signal -->
+
+1. **Read** [`mmnto-ai/totem-strategy:doctrine/bot-protocols.md`](https://github.com/mmnto-ai/totem-strategy/blob/main/doctrine/bot-protocols.md) if you haven't this session.
+2. **Apply** the consolidated round-comment SOP (doctrine § 8.1) — ONE main-thread comment per round, structured table, tag only bots with a role this round.
+3. **Never** combine `@gemini-code-assist` + `/gemini review` in the same comment (doctrine § 1.2 — XOR Tag Rule).
+4. **Never** reply citing a SHA before pushing (doctrine § 1.1).
+5. **Workflow surface:** prefer the `/review-reply` skill — it operationalizes the SOP end-to-end.
+
+Enforcement stack per [ADR-105](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-105-bot-protocol-centralization.md): (1) PreToolUse hooks (queued — `mmnto-ai/totem#1900`); (2) skill instructions; (3) **this AGENTS.md** (baseline awareness for all vendor sessions); (4) auto-memory pointer (`feedback_bot_protocols_centralized`).
+
+## Skills
+
+Claude Code skills live under `.claude/skills/`; invoke via `/<skill-name>`. Gemini CLI equivalents (when present) live under `.gemini/skills/`. Each `SKILL.md` is the authoritative definition.
+
+- `/preflight <issue>` — spec + search before coding
+- `/prepush` — format + lint + review before push
+- `/postmerge <prs>` — extract lessons after merge
+- `/signoff` — end-of-session memory + journal
+- `/review-reply <PR>` — doctrine-aligned bot-comment triage
+
+## Context Decay Prevention (Proposal 213)
+
+After >15 turns of code changes: run `totem status`, re-query strategy ADRs for the system you're modifying, and state your architectural assumption before proceeding.
+
+## Agent Discipline (ADR-063)
+
+**Controller, not implementer.** Delegate code+test tasks to background agents. Keep this thread for decisions. Prefer Monitor over Bash `sleep` loops; use `/loop <prompt>` self-paced for poll-and-react.
+
+## Detailed Docs (read when relevant)
+
+- [Architecture context](.claude/docs/architecture.md) — partitions, boundary parameter, linked indexes
+- [Contributing rules](.claude/docs/contributing.md) — `AI_PROMPT_BLOCK`, changesets, code style
+- [Agent workflow](.claude/docs/agent-workflow.md) — dispatch templates, delegation rules
+- [Gemini styleguide](.gemini/styleguide.md) — full code style and architecture rules (Gemini CLI sessions read this directly)
+- Strategy ADRs: query `mcp__totem-strategy__search_knowledge`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,61 +1,7 @@
-# Totem — Development Rules
+# Totem: Claude Code Entry Point
 
-## Session Start Protocol (MANDATORY)
+The canonical agent instructions for this repository live in [`AGENTS.md`](AGENTS.md).
 
-Before writing any code or making any changes:
+Per [Totem ADR-038 "AGENTS.md Standard Adoption"](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-038-agents-md-standard.md), `mmnto-ai/totem` uses a single `AGENTS.md` as the source of truth for how all AI coding agents (Claude Code, Gemini CLI, Cursor, etc.) should behave here. This file exists only so Claude Code finds its way to `AGENTS.md`.
 
-1. Run `totem status` for health and read `docs/active_work.md` for current milestone and momentum.
-2. **NEVER GUESS ARCHITECTURE.** Before modifying any core system (hooks, orchestrator, compiler, extract pipeline), run `totem search <system_name>` to load architectural context.
-3. Do not push speculative fixes to "see what CI says." Run `totem lint` locally. Front-load all checks before the first push.
-
-## Essentials
-
-- **pnpm only** (never npm/yarn). Use `pnpm dlx` (never `npx`). Windows 11 + Git Bash. TypeScript strict mode.
-- `main` is protected. Feature branches + PRs. `Closes #NNN` in PR bodies.
-- `kebab-case.ts` files, `err` (never `error`) in catch blocks.
-- Run `pnpm run format` before committing.
-
-## Totem Workflow
-
-Not mechanically enforced. Follow these because they reduce PR bot noise.
-
-- **Before coding:** Run `/preflight <issue>`. Create a feature branch.
-- **Before pushing:** `pnpm run format` → `totem lint` → `totem review` → verify compile manifest is current.
-- **After merging:** `totem lesson extract <prs>` → `totem lesson compile` (6+ lessons).
-- **NEVER** use `git push --no-verify`, `totem-ignore`, or `eslint-disable` without a ticket.
-- Git pre-push hook runs `totem lint` + `totem verify-manifest` (stateless, no LLM).
-
-## Bot-Protocol Gate (load-bearing — ADR-105 Layer 3)
-
-Before posting ANY PR comment, replying to ANY bot, or running `gh pr comment` / `gh api .../comments`:
-
-1. **Read** [`mmnto-ai/totem-strategy:doctrine/bot-protocols.md`](https://github.com/mmnto-ai/totem-strategy/blob/main/doctrine/bot-protocols.md) if you haven't this session.
-2. **Apply** the consolidated round-comment SOP (doctrine § 8.1) — ONE main-thread comment per round, structured table, tag only bots with a role this round.
-3. **Never** combine `@gemini-code-assist` + `/gemini review` in the same comment (doctrine § 1.2 — XOR Tag Rule; burns GCA quota).
-4. **Never** reply citing a SHA before pushing (doctrine § 1.1 — GCA reviews stale state, wastes quota).
-5. **Workflow surface:** prefer the `/review-reply` skill — it operationalizes the SOP end-to-end.
-
-Enforcement stack per [ADR-105](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-105-bot-protocol-centralization.md): (1) PreToolUse hooks (queued — `mmnto-ai/totem#1900`); (2) skill instructions; (3) **this CLAUDE.md** (baseline awareness); (4) auto-memory pointer (`feedback_bot_protocols_centralized`).
-
-## Skills
-
-- `/preflight <issue>` — spec + search before coding
-- `/prepush` — format + lint + review before push
-- `/postmerge <prs>` — extract lessons after merge
-- `/signoff` — end-of-session memory + journal
-- `/review-reply <PR>` — doctrine-aligned bot-comment triage
-
-## Context Decay Prevention (Proposal 213)
-
-After >15 turns of code changes: run `totem status`, re-query strategy ADRs for the system you're modifying, and state your architectural assumption before proceeding.
-
-## Agent Discipline (ADR-063)
-
-**Controller, not implementer.** Delegate code+test tasks to background agents. Keep this thread for decisions. Prefer Monitor over Bash `sleep` loops; use `/loop <prompt>` self-paced for poll-and-react.
-
-## Detailed Docs (read when relevant)
-
-- [Architecture context](.claude/docs/architecture.md) — partitions, boundary parameter, linked indexes
-- [Contributing rules](.claude/docs/contributing.md) — `AI_PROMPT_BLOCK`, changesets, code style
-- [Agent workflow](.claude/docs/agent-workflow.md) — dispatch templates, delegation rules
-- Strategy ADRs: query `mcp__totem-strategy__search_knowledge`
+Read `AGENTS.md` before doing anything else.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,33 +1,7 @@
-# Totem — Development Rules
+# Totem: Gemini CLI Entry Point
 
-## Essentials
+The canonical agent instructions for this repository live in [`AGENTS.md`](AGENTS.md).
 
-- **pnpm only** (never npm/yarn). Use `pnpm dlx` (never `npx`). Windows 11 + Git Bash. TypeScript strict mode.
-- `main` is protected. Feature branches + PRs. Never amend commits on feature branches.
-- Use `Closes #NNN` in PR descriptions.
-- `kebab-case.ts` files, `err` (never `error`) in catch blocks, no empty catches.
-- Run `pnpm run format` before committing.
-- **NEVER put secrets in config files.** `.env` only.
+Per [Totem ADR-038 "AGENTS.md Standard Adoption"](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-038-agents-md-standard.md), `mmnto-ai/totem` uses a single `AGENTS.md` as the source of truth for how all AI coding agents (Claude Code, Gemini CLI, Cursor, etc.) should behave here. This file exists only so Gemini CLI finds its way to `AGENTS.md`.
 
-## Totem Workflow (BLOCKING)
-
-- Before writing code: call `search_knowledge` with what you're changing
-- Before planning/architecture: query `totem-strategy:search_knowledge` for ADRs
-- After merging a PR: run `totem extract <pr> --yes`, then `totem docs` if releasing
-- **NEVER use `git push --no-verify`.** Fix the violation or file a ticket.
-
-## Contributor Principles
-
-<!-- totem-ignore-next-line -->
-
-- Update `AI_PROMPT_BLOCK` in `init.ts` when changing reflexes/hooks/prompts.
-<!-- totem-ignore-next-line -->
-- GCA decline: add lesson with `review-guidance` tag + update `.gemini/styleguide.md` §6.
-- No `totem-ignore`, `eslint-disable`, or `--no-verify` without a ticket.
-- GCA replies: ONE `@gemini-code-assist` comment per PR.
-
-## Detailed Rules
-
-- See `.gemini/styleguide.md` for full code style, naming, and architecture rules.
-- Changesets: write `.changeset/` files manually. Use `pnpm run version` (never bare `pnpm version`).
-- Named constants for magic numbers. Zod at system boundaries only.
+Read `AGENTS.md` before doing anything else.

--- a/packages/cli/src/commands/config-drift.test.ts
+++ b/packages/cli/src/commands/config-drift.test.ts
@@ -73,16 +73,14 @@ describe('dev hooks match consumer templates', () => {
 // ─── Agent config drift ─────────────────────────────
 
 describe('agent instruction files match consumer AI_PROMPT_BLOCK', () => {
-  const claudeMd = readRoot('CLAUDE.md');
-  const geminiMd = readRoot('GEMINI.md');
+  // Post ADR-038 migration: AGENTS.md is the canonical for Claude Code + Gemini CLI
+  // (read via CLAUDE.md + GEMINI.md redirect files). .junie/guidelines.md remains
+  // canonical for Junie sessions until that migration follows.
+  const agentsMd = readRoot('AGENTS.md');
   const junieGuidelines = readRoot('.junie/guidelines.md');
 
-  it('CLAUDE.md contains the search_knowledge instruction', () => {
-    expect(claudeMd).toContain('search_knowledge');
-  });
-
-  it('GEMINI.md contains the search_knowledge instruction', () => {
-    expect(geminiMd).toContain('search_knowledge');
+  it('AGENTS.md contains the search_knowledge instruction', () => {
+    expect(agentsMd).toContain('search_knowledge');
   });
 
   it('Junie guidelines.md contains the search_knowledge instruction', () => {
@@ -102,28 +100,41 @@ describe('agent instruction files match consumer AI_PROMPT_BLOCK', () => {
 // ─── Instruction file length limits (FR-C01) ─────────
 
 describe('agent instruction files stay concise (FMEA-001 / FR-C01)', () => {
-  // Budget bumped 2026-05 (3000→4000 chars, 25→30 directives) to fit the
-  // ADR-105 Layer-3 bot-protocol gate § that CLAUDE.md now carries at the
-  // root (see mmnto-ai/totem-strategy:doctrine/bot-protocols.md). The gate
-  // is the minimum floor; the discipline still applies to everything else.
-  const MAX_CHARS = 4000;
-  const MAX_DIRECTIVES = 30;
+  // Canonical files carry full agent context (cross-vendor for AGENTS.md,
+  // self-canonical for .junie/guidelines.md). Budget bumped to 6000/40 in
+  // ADR-038 migration to accommodate AGENTS.md absorbing the cross-vendor
+  // content that CLAUDE.md + GEMINI.md previously held separately.
+  const CANONICAL_MAX_CHARS = 6000;
+  const CANONICAL_MAX_DIRECTIVES = 40;
 
-  const files = [
-    { name: 'CLAUDE.md', content: readRoot('CLAUDE.md') },
-    { name: 'GEMINI.md', content: readRoot('GEMINI.md') },
+  // Redirect files exist only to point Claude Code / Gemini CLI at AGENTS.md.
+  // They should stay tiny; this ceiling enforces redirect-shape post-migration.
+  const REDIRECT_MAX_CHARS = 1000;
+
+  const canonical = [
+    { name: 'AGENTS.md', content: readRoot('AGENTS.md') },
     { name: '.junie/guidelines.md', content: readRoot('.junie/guidelines.md') },
   ];
 
-  for (const { name, content } of files) {
-    it(`${name} is under ${MAX_CHARS} characters`, () => {
-      expect(content.length).toBeLessThanOrEqual(MAX_CHARS);
+  const redirects = [
+    { name: 'CLAUDE.md', content: readRoot('CLAUDE.md') },
+    { name: 'GEMINI.md', content: readRoot('GEMINI.md') },
+  ];
+
+  for (const { name, content } of canonical) {
+    it(`${name} is under ${CANONICAL_MAX_CHARS} characters`, () => {
+      expect(content.length).toBeLessThanOrEqual(CANONICAL_MAX_CHARS);
     });
 
-    it(`${name} has fewer than ${MAX_DIRECTIVES} directives`, () => {
-      // Count bullet points and numbered items as distinct directives
+    it(`${name} has fewer than ${CANONICAL_MAX_DIRECTIVES} directives`, () => {
       const directives = content.split('\n').filter((l) => /^\s*[-*]\s|^\s*\d+\.\s/.test(l)).length;
-      expect(directives).toBeLessThanOrEqual(MAX_DIRECTIVES);
+      expect(directives).toBeLessThanOrEqual(CANONICAL_MAX_DIRECTIVES);
+    });
+  }
+
+  for (const { name, content } of redirects) {
+    it(`${name} stays a redirect (under ${REDIRECT_MAX_CHARS} characters)`, () => {
+      expect(content.length).toBeLessThanOrEqual(REDIRECT_MAX_CHARS);
     });
   }
 });
@@ -131,8 +142,12 @@ describe('agent instruction files stay concise (FMEA-001 / FR-C01)', () => {
 // ─── Cross-agent consistency ─────────────────────────
 
 describe('all agent instruction files share the same project rules', () => {
-  // Claude uses a lean root + linked sub-docs; combine them for rule checking
-  const claudeRoot = readRoot('CLAUDE.md');
+  // Post ADR-038 migration: AGENTS.md + .claude/docs/* covers Claude Code (via redirect)
+  // and Gemini CLI (via redirect, no docs subdir — content lives in AGENTS.md proper
+  // plus .gemini/styleguide.md). Junie has its own self-contained .junie/guidelines.md.
+  // The test ensures shared rules don't drift between the cross-vendor canonical and
+  // the Junie canonical.
+  const agentsRoot = readRoot('AGENTS.md');
   const claudeDocs = fs.existsSync(path.join(ROOT, '.claude', 'docs'))
     ? fs
         .readdirSync(path.join(ROOT, '.claude', 'docs'))
@@ -140,8 +155,7 @@ describe('all agent instruction files share the same project rules', () => {
         .map((f) => fs.readFileSync(path.join(ROOT, '.claude', 'docs', f), 'utf-8'))
         .join('\n')
     : '';
-  const claudeMd = claudeRoot + '\n' + claudeDocs;
-  const geminiMd = readRoot('GEMINI.md');
+  const crossVendorCanonical = agentsRoot + '\n' + claudeDocs;
   const junieGuidelines = readRoot('.junie/guidelines.md');
 
   const SHARED_RULES = [
@@ -173,9 +187,8 @@ describe('all agent instruction files share the same project rules', () => {
   ];
 
   for (const rule of SHARED_RULES) {
-    it(`all agent files contain: "${rule}"`, () => {
-      expect(claudeMd).toContain(rule);
-      expect(geminiMd).toContain(rule);
+    it(`agent canonicals contain: "${rule}"`, () => {
+      expect(crossVendorCanonical).toContain(rule);
       expect(junieGuidelines).toContain(rule);
     });
   }
@@ -244,6 +257,7 @@ describe('totem init scaffolds correct paths for each agent', () => {
 
 describe('no secrets in tracked config files', () => {
   const CONFIG_FILES = [
+    'AGENTS.md',
     'CLAUDE.md',
     'GEMINI.md',
     '.junie/guidelines.md',

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -535,7 +535,7 @@ export async function checkSecretLeaks(
   const filesToScan: string[] = [];
 
   // Collect files to scan
-  const candidates = ['CLAUDE.md', '.cursorrules'];
+  const candidates = ['AGENTS.md', 'CLAUDE.md', 'GEMINI.md', '.cursorrules'];
   for (const file of candidates) {
     const fullPath = path.join(cwd, file);
     if (fs.existsSync(fullPath)) {


### PR DESCRIPTION
## Summary

Step 2 of 6 in the ADR-038 cohort migration per [Proposal 272](https://github.com/mmnto-ai/totem-strategy/blob/main/proposals/active/272-adr-038-execution-agents-md-migration.md) § 6.6. Follows `mmnto-ai/totem-strategy#311` (merged at `8bba45d`) as the second-most load-bearing cohort surface. Absorbs the `mmnto-ai/totem#1903` Layer-3 lift per § 6.5.

## Changes

- **`AGENTS.md` (new)** — cross-vendor canonical; lifts `CLAUDE.md` content and dedupes with `GEMINI.md` content (Gemini-specific contributor principles like `pnpm run version` and `Update AI_PROMPT_BLOCK in init.ts` now live in AGENTS.md). Gate § "this CLAUDE.md" → "this AGENTS.md (baseline awareness for all vendor sessions)". T1958Z disclaimer comment embedded at doctrine pointer site citing § 2.4.
- **`CLAUDE.md`, `GEMINI.md` → 7-line redirects** per § 6.2 verbatim template.
- **`.claude/docs/contributing.md`** — PR Review Bot Protocol § retired to doctrine pointer. Same retire-to-pointer pattern as `mmnto-ai/totem-playground@80b4d1b`. Generalize-within-diff per `feedback_generalize_within_diff` (bot-protocol rule body cleanup consistent with the AGENTS.md migration scope).
- **`packages/cli/src/commands/config-drift.test.ts`** — updated to recognize AGENTS.md as the new cross-vendor canonical:
  - `search_knowledge` check: AGENTS.md + .junie/guidelines.md (CLAUDE.md + GEMINI.md dropped since they're now redirects)
  - FR-C01 length budget: split into `CANONICAL_MAX_CHARS=6000` / `CANONICAL_MAX_DIRECTIVES=40` for canonicals (AGENTS.md + .junie/guidelines.md) and `REDIRECT_MAX_CHARS=1000` for redirects (CLAUDE.md, GEMINI.md). Budget bumped because AGENTS.md absorbs cross-vendor content that CLAUDE.md + GEMINI.md previously held separately
  - Cross-agent SHARED_RULES: `agentsRoot + .claude/docs/*` vs `.junie/guidelines.md` (Junie remains self-canonical until that migration follows)
- **`packages/cli/src/commands/doctor.ts`** — secret-leak scan candidate list now covers AGENTS.md + GEMINI.md alongside CLAUDE.md (post-migration AGENTS.md is canonical for cross-vendor content).

## Out of scope (per Proposal 272)

- **`.junie/guidelines.md` migration to AGENTS.md** — Junie isn't in Proposal 272 § 6.2 redirect template. File follow-on if needed.
- **`totem init` AGENTS.md emit** — deferred per Proposal 272 § 6.7 to `mmnto-ai/totem` enforcement backlog. New consumers running `totem init` still get CLAUDE.md scaffolded; the consolidation helper is a separate ticket.

## Empirical correction (continues from #311 PR body)

T1855Z § 6.4 + Proposal 272 § 6.4 claim ADR-105 contains a "one-line edit" surface for "Layer 3 = this CLAUDE.md". Empirically that text lives only in cohort gate § templates, not in ADR-105 itself. The migration handles the framing automatically via gate § template edits per-PR. Same as #311 — no direct ADR-105 edit needed here.

## CR / GCA note (doctrine § 2.4)

`<!-- totem:cr-disclaimer: ... -->` comment in AGENTS.md is the standardized inline disclaimer for the access-class private-repo URL 404 false-positive class (doctrine § 2.4 — codified at `mmnto-ai/totem-strategy@e1cb29a`, applied successfully on #311). If CR's URL-accessibility check fires on any private-repo URL, decline per doctrine § 2.4 in round comment.

## Test plan
- [x] `totem lint` PASS — 9 warnings on `//` chars in my new test comments (false-positive orchestrator-timeout rule matches)
- [x] `pnpm test` PASS — 99 test files, 2136 tests pass (48 in config-drift.test.ts including the migrated assertions)
- [x] `totem review` PASS — no issues found
- [ ] CR R1 — expecting clean or doctrine § 2.4 access-class fires only
- [ ] GCA R1 — expecting clean or quota-out

🤖 Generated with [Claude Code](https://claude.com/claude-code)