### PR TITLE
feat(doctor): add checkAgentsMdCanonical (Proposal 272 § 6.7)

### DIFF
--- a/.changeset/doctor-agents-md-canonical.md
+++ b/.changeset/doctor-agents-md-canonical.md
@@ -1,0 +1,18 @@
+---
+'@mmnto/cli': minor
+---
+
+feat(doctor): add `agents-md-canonical` diagnostic per Proposal 272 § 6.7
+
+Verifies that `CLAUDE.md` follows the ADR-038 redirect-shape constraint:
+
+- Gates on whether the cwd is a project root (`package.json` OR `.git` present).
+- Passes if there's no `CLAUDE.md` (nothing to enforce).
+- Passes if `CLAUDE.md` is ≤ 600 bytes.
+- Fails if `CLAUDE.md` claims to be a redirect (matches the canonical-phrase + `AGENTS.md` link pattern) but `AGENTS.md` does not actually exist.
+- Fails if `CLAUDE.md` is > 600 bytes AND does not match the redirect pattern.
+- Passes for a "verbose redirect" (> 600 bytes but matches the pattern AND `AGENTS.md` exists) — covers downstream consumers who pad the redirect with vendor-specific addendums.
+
+Surface translation: Proposal 272 § 6.7 names this as a `totem lint` rule, but `totem lint` is diff-based content scanning. The predicate here is a repo-shape check, which fits the existing `check*` function registry in `doctor.ts`. Routing confirmed by strategy-Claude.
+
+Closes #1905. Follow-on `doctor --strict` + pre-push wiring tracked in #1906.

--- a/.totem/specs/agents-md-canonical.md
+++ b/.totem/specs/agents-md-canonical.md
@@ -1,0 +1,185 @@
+### Problem Statement
+
+Implement the `agents-md-canonical` deterministic lint rule for `totem lint` to fulfill Proposal 272 § 6.7. This replaces the LLM-prose enforcement of ADR-038, automatically verifying that any repository containing agent configuration files (e.g., `CLAUDE.md`, `.cursorrules`) explicitly delegates to a single, centralized `AGENTS.md` file.
+
+### Architectural Context
+
+- **ADR-038 "AGENTS.md Standard Adoption"**: Establishes `AGENTS.md` as the single source of truth for agent instructions.
+- **Pack Ecosystem Graduation (Active Work)**: Mandates collapsing convention-rule duplication and replacing LLM-prose enforcement (Tenet 15 violations) with deterministic-substrate hardening.
+- **Derived Standing State**: State is derived from substrate, not maintained in prose. The linter must deterministically fail if the substrate (agent files) drifts from the standard.
+
+### Files to Examine
+
+1. `CLAUDE.md` — Contains the canonical text pattern that must be enforced: `"The canonical agent instructions for this repository live in [\`AGENTS.md\`](AGENTS.md)."`
+2. `packages/core/src/rules/index.ts` (or equivalent rule registry) — To understand how new text/file-based rules are registered and executed.
+3. `packages/pack-agent-security/test/repo-sweep.test.ts` — Provides context on how rules are evaluated across a repository using AST Grep or regex matchers.
+
+### Technical Approach & Contracts
+
+We will implement a custom file-based rule in the core linter (or `pack-agent-security`, depending on standard rule placement).
+
+**Contract Requirements:**
+
+- **Target Files Pattern**: `CLAUDE.md`, `.cursorrules`, `.github/copilot-instructions.md`, `windsurfrules`.
+- **Validation Logic**:
+  1. Use `resolveGitRoot` to determine the repository root.
+  2. If any Target File exists in the root (or standard subdirectories), it MUST contain the regex pattern `/AGENTS\.md/i` (or ideally the exact delegation string).
+  3. If a Target File exists, the `AGENTS.md` file MUST also exist at the Git root.
+- **Data Contract Change**: Add `agents-md-canonical` to the rule registry types/schemas.
+  ```typescript
+  // Example expected internal rule output format
+  export interface RuleViolation {
+    ruleId: 'agents-md-canonical';
+    filePath: string;
+    message: string;
+    severity: 'error';
+  }
+  ```
+
+**Trade-offs Considered:**
+
+- _AST Grep vs. Regex/Text Match_: AST Grep is powerful for code, but Markdown is heavily prose-based. A direct file read and Regex match is faster, more reliable for Markdown prose, and avoids complex AST parsers for simple substring checks. _Recommendation: Use regex/text matching via standard Node `fs` operations combined with the `resolveGitRoot` helper._
+
+### Edge Cases & Traps
+
+- **Missing Git Root**: Repositories not yet initialized with Git will cause `resolveGitRoot` to return `null`. The rule must handle this gracefully (e.g., fallback to `process.cwd()`).
+- **Missing Target Files**: If no agent files exist, the rule should immediately pass (no enforcement needed if no agents are configured).
+- **Case Sensitivity**: Operating systems handle file names differently (`claude.md` vs `CLAUDE.md`). The file scanner must be case-insensitive when identifying target files, but strict on the exact string match inside the file.
+- **Empty Files**: An empty `.cursorrules` file should trigger a violation, not crash the parser.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Define Rule Tests & Interface**
+  - Files to modify: `packages/core/test/rules/agents-md-canonical.test.ts` (create), `packages/core/src/rules/agents-md-canonical.ts` (create)
+    > TEST DIRECTIVE: Before implementing, write a failing test named `flags agent files missing AGENTS.md delegation` that proves the regression is caught. Write additional tests for `passes when delegation exists` and `fails when AGENTS.md is missing from root`.
+  - Step 1: Create the test file with mock file system setups mimicking the presence/absence of `CLAUDE.md` and `AGENTS.md`.
+  - Step 2: Create the empty rule function `evaluateAgentsMdCanonical(cwd: string): RuleViolation[]`.
+  - Step 3: Run the test to ensure it fails.
+  - Step 4: Implement the rule logic. Use `resolveGitRoot(cwd)` to find the root. Check for target files (`CLAUDE.md`, `.cursorrules`). If found, verify `AGENTS.md` exists and the target file contains the string `AGENTS.md`.
+  - Step 5: Verify passes → lint.
+
+- [ ] **Task 2: Refine Canonical String Matching**
+  - Files to modify: `packages/core/src/rules/agents-md-canonical.ts`, `packages/core/test/rules/agents-md-canonical.test.ts`
+    > TOTEM INVARIANT (ADR-038 "AGENTS.md Standard Adoption"): The agent file must not just contain "AGENTS.md", it must explicitly delegate instructions to it to prevent duplication.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `rejects file containing AGENTS.md without explicit delegation phrasing` that proves the regression is caught.
+  - Step 1: Update tests to expect a stricter match (e.g., `canonical agent instructions` or similar verifiable delegation text, rather than just the word `AGENTS.md`).
+  - Step 2: Verify test fails.
+  - Step 3: Update the regex/string matching logic in `evaluateAgentsMdCanonical`.
+  - Step 4: Verify passes → lint.
+
+- [ ] **Task 3: Integrate Rule into Linter Registry**
+  - Files to modify: `packages/core/src/rules/index.ts` (or standard rule manifest)
+  - Step 1: Write a test in the integration suite verifying that running the linter with `agents-md-canonical` enabled correctly scans a mock directory.
+  - Step 2: Verify test fails.
+  - Step 3: Import and register `evaluateAgentsMdCanonical` in the main rule registry. Assign it the standard error severity.
+  - Step 4: Verify passes → lint.
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Baseline Pass**: Directory with `AGENTS.md` and `CLAUDE.md` containing the exact canonical delegation string. Returns 0 violations.
+- **Baseline Skip**: Directory with NO agent files (`CLAUDE.md`, `.cursorrules`, etc.). Returns 0 violations.
+- **Missing Delegation**: Directory with `CLAUDE.md` containing generic text, but missing the canonical delegation string. Returns 1 violation pointing to `CLAUDE.md`.
+- **Missing AGENTS.md**: Directory with `.cursorrules` containing the canonical delegation string, but `AGENTS.md` does not exist at the Git root. Returns 1 violation complaining about the missing `AGENTS.md` target.
+- **Graceful Degradation**: Running the rule in a non-Git directory falls back safely and correctly evaluates files relative to the current working directory without throwing unhandled exceptions.
+
+---
+
+## Implementation Design (Phase 3)
+
+> **Note on the Gemini-generated body above.** The original spec assumed a custom `packages/core/src/rules/` registry that does not exist. Totem rules compile from `.totem/lessons/*.md` to regex/AST-grep patterns evaluated against **diff additions only** (see `packages/cli/src/commands/run-compiled-rules.ts`). Repo-shape predicates do not fit that engine. This Implementation Design supersedes the contract sketched in "Technical Approach & Contracts" above and is the source of truth for the PR.
+
+### Scope (2 sentences)
+
+Add a single `checkAgentsMdCanonical` diagnostic to `packages/cli/src/commands/doctor.ts` plus minimal wiring so `totem doctor` surfaces a `fail` when a repo's `CLAUDE.md` violates the ADR-038 redirect shape per Proposal 272 § 6.7. Will **not** touch `totem lint` engine, `compiled-rules.json`, the lesson pipeline, `GEMINI.md`, or any cohort `CLAUDE.md` files (those already shipped in claude-0044).
+
+### Data model deltas
+
+No new types, no new state containers. Uses the existing `DiagnosticResult` shape (`{ name, status, message, remediation? }`) already exported by `doctor.ts`. No persisted state.
+
+Two new module-level constants (private, named):
+
+- `CLAUDE_MD_REDIRECT_MAX_BYTES = 600` — the size gate from Proposal 272 § 6.7. Reason for naming: avoids the magic-number anti-pattern; lets the gate be re-cited by the violation message verbatim. Headroom: the largest current cohort redirect is 558 bytes (`totem-playground`); 600 leaves ~42 bytes for typical title-line variance.
+- `AGENTS_MD_REDIRECT_PATTERN = /canonical agent instructions[^.]*\[`AGENTS\.md`\]\(AGENTS\.md\)/i` — minimal shape signature. The literal phrase "canonical agent instructions" plus the `[`AGENTS.md`](AGENTS.md)` link is what every cohort redirect contains. Tight enough that a fat `CLAUDE.md` accidentally containing the word "AGENTS.md" doesn't pass; loose enough that minor wording variants survive.
+
+### State lifecycle
+
+No state. Pure function over filesystem reads (no caching, no memoization). Per-invocation: read `CLAUDE.md` if present, read `AGENTS.md` if present (existence check only, not contents), return a `DiagnosticResult`.
+
+### Failure modes
+
+| Failure                                                                         | Category  | Agent-facing surface                                                                                                                                                    | Recovery                                                                 |
+| ------------------------------------------------------------------------------- | --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Repo has neither `package.json` nor `.git`                                      | gating    | `status: 'skip'`, message "not a project root"                                                                                                                          | none — intentional opt-out for non-project dirs                          |
+| No `CLAUDE.md` present                                                          | gating    | `status: 'pass'`, message "no CLAUDE.md (no enforcement)"                                                                                                               | none — nothing to lint                                                   |
+| `CLAUDE.md` ≤ 600 bytes                                                         | runtime   | `status: 'pass'`, message "CLAUDE.md is a redirect (N bytes)"                                                                                                           | none                                                                     |
+| `CLAUDE.md` > 600 bytes AND matches `AGENTS_MD_REDIRECT_PATTERN`                | runtime   | `status: 'pass'`, message "CLAUDE.md is a verbose redirect (N bytes)"                                                                                                   | none — odd but valid; the pattern is load-bearing, the size is heuristic |
+| `CLAUDE.md` > 600 bytes AND does NOT match the redirect pattern                 | runtime   | `status: 'fail'`, message "CLAUDE.md is N bytes and not a redirect (ADR-038)", remediation "Lift content to AGENTS.md and replace CLAUDE.md with the redirect template" | operator-side fix; same pattern as `checkConfig`'s fail-with-remediation |
+| `CLAUDE.md` > 600 bytes AND matches redirect pattern AND `AGENTS.md` is missing | runtime   | `status: 'fail'`, message "CLAUDE.md redirects to AGENTS.md but AGENTS.md does not exist", remediation "Create AGENTS.md per ADR-038"                                   | operator-side fix                                                        |
+| `CLAUDE.md` unreadable (permission / IO error)                                  | transient | `status: 'warn'`, message "CLAUDE.md unreadable"                                                                                                                        | matches existing `checkCompiledRules` pattern (catch, warn)              |
+
+Every "silent degradation" row here would be a Tenet 4 violation; none present. The `skip` rows are gating predicates, not silent degradations.
+
+### Invariants to lock in via tests
+
+- A cohort redirect (484-558 bytes, contains the canonical phrase) passes (verified against all 7 current cohort redirects as fixtures).
+- A 1500-byte CLAUDE.md filled with project rules but no redirect phrase **fails** with the "not a redirect" message.
+- A 1500-byte CLAUDE.md that matches the redirect pattern (verbose redirect) **passes** — the pattern is the load-bearing signal, not the size.
+- A 700-byte CLAUDE.md that matches the redirect pattern AND `AGENTS.md` is absent **fails** with the "AGENTS.md missing" message.
+- A directory with no `CLAUDE.md` **passes** (skip-equivalent — nothing to enforce).
+- A directory with no `package.json` AND no `.git` **skips** entirely (intentional opt-out for scratch dirs).
+- The size threshold and pattern are exported (or stably referenced) so the test asserts them by reference, not duplicated literal — preventing the FR-C01-class drift CR loves to flag.
+
+### Open questions
+
+- **Question 1:** Surface — `totem doctor` only, or also `totem lint`?
+  - **Options:**
+    - (a) `totem doctor` only — clean architecture fit (repo-health diagnostic surface); requires operator/CI to invoke doctor; doesn't auto-fire on PR.
+    - (b) Both — add the check to `doctor.ts` and also call it from `lint.ts` after `runCompiledRules`. Adds a second invocation site but no logic duplication.
+    - (c) `totem lint` only — proposal-text-literal; awkward fit (needs side-channel that bypasses the diff-based engine).
+  - **Recommendation:** (a) `totem doctor` only. The proposal's intent is "automated enforcement of the redirect shape"; doctor IS that surface. Add a follow-on issue for "wire `totem doctor --strict` into pre-push or CI" if we want it to fire on PRs. Faithful translation of the proposal text, not literal — and the conversion should be called out explicitly in the PR body so strategy-Claude can sanity-check.
+
+- **Question 2:** Redirect-pattern strictness.
+  - **Options:**
+    - (a) Strict — require the exact ADR-038 link, the exact phrase, AND a `Read AGENTS.md` sentinel. Catches anyone trying to back-door content with a single decoy sentence.
+    - (b) Minimal — what I proposed: "canonical agent instructions" + the AGENTS.md link.
+    - (c) Looser — just the `[\`AGENTS.md\`](AGENTS.md)` link presence.
+  - **Recommendation:** (b) minimal. Strict (a) over-fits to today's exact template — the next time we tweak the redirect for Cursor/Windsurf parity, every consumer breaks. Looser (c) lets a fat CLAUDE.md that mentions AGENTS.md in passing skate. Minimal is the right pinpoint.
+
+- **Question 3:** Threshold value — keep proposal-text 600, or pick another?
+  - **Options:**
+    - (a) 600 — proposal text; 42-byte headroom on the largest current redirect.
+    - (b) 800 — more headroom; catches "redirect plus a paragraph of vendor-specific addendum" cases as still-OK.
+    - (c) Make it configurable (`agentsMdCanonicalMaxBytes` in totem.config.ts).
+  - **Recommendation:** (a) 600 — proposal text. Configurability (c) is a YAGNI hook; the gate is heuristic and the pattern is the load-bearing signal anyway.
+
+- **Question 4:** `GEMINI.md` parity.
+  - **Options:**
+    - (a) Out of scope — Proposal 272 § 6.7 only names CLAUDE.md.
+    - (b) Mirror enforcement on GEMINI.md too — symmetric per ADR-038.
+  - **Recommendation:** (a) out of scope for this PR. File a follow-on. Reason: Proposal 272 text is explicit on CLAUDE.md; expanding scope now invites bot-round churn on a hand-bundled "since we're here" change.
+
+- **Question 5:** Where should the new function live — `doctor.ts` (with sibling `check*` functions) or a new file (`checks/agents-md-canonical.ts`)?
+  - **Options:**
+    - (a) Append to `doctor.ts` like every existing check.
+    - (b) New file in a new directory.
+  - **Recommendation:** (a) append to `doctor.ts`. The file is already a registry of check functions; adding another preserves "find all checks by reading one file." A separate-file refactor is a different PR if doctor.ts gets unwieldy later.

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -8,7 +8,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { cleanTmpDir } from '../test-utils.js';
 import type { DiagnosticResult } from './doctor.js';
 import {
+  AGENTS_MD_REDIRECT_PATTERN,
   BYPASS_THRESHOLD,
+  checkAgentsMdCanonical,
   checkCompiledRules,
   checkConfig,
   checkEmbeddingConfig,
@@ -22,6 +24,7 @@ import {
   checkStaleRules,
   checkStrategyRoot,
   checkUpgradeCandidates,
+  CLAUDE_MD_REDIRECT_MAX_BYTES,
   doctorCommand,
   findLegacyGrandfatheredRules,
   findStaleRules,
@@ -378,6 +381,7 @@ const EXPECTED_DIAGNOSTIC_NAMES = [
   'Strategy Root',
   'Secret Scan',
   'Secrets File Security',
+  'AGENTS.md Canonical',
   'Upgrade Candidates',
   'Stale Rules',
   'Grandfathered Rules',
@@ -529,6 +533,144 @@ describe('checkSecretsFileTracked', () => {
     // tmpDir is not a git repo — execSync will throw, which we catch
     const result = checkSecretsFileTracked(tmpDir);
     expect(result.status).toBe('pass');
+  });
+});
+
+// ─── AGENTS.md canonical redirect check (Proposal 272 § 6.7 / #1905) ──
+
+describe('checkAgentsMdCanonical', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  function makeProjectRoot(): void {
+    fs.writeFileSync(path.join(tmpDir, 'package.json'), '{"name":"fixture"}');
+  }
+
+  function canonicalRedirect(repoSlug = 'mmnto-ai/fixture'): string {
+    return [
+      '# Fixture: Claude Code Entry Point',
+      '',
+      'The canonical agent instructions for this repository live in [`AGENTS.md`](AGENTS.md).',
+      '',
+      `Per [Totem ADR-038 "AGENTS.md Standard Adoption"](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-038-agents-md-standard.md), \`${repoSlug}\` uses a single \`AGENTS.md\` as the source of truth for how all AI coding agents (Claude Code, Gemini CLI, Cursor, etc.) should behave here. This file exists only so Claude Code finds its way to \`AGENTS.md\`.`,
+      '',
+      'Read `AGENTS.md` before doing anything else.',
+      '',
+    ].join('\n');
+  }
+
+  it('skips non-project directories', () => {
+    // No package.json, no .git
+    const result = checkAgentsMdCanonical(tmpDir);
+    expect(result.status).toBe('skip');
+    expect(result.message).toContain('not a project root');
+  });
+
+  it('passes when CLAUDE.md is absent', () => {
+    makeProjectRoot();
+    const result = checkAgentsMdCanonical(tmpDir);
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('no CLAUDE.md');
+  });
+
+  it('passes for a canonical cohort redirect (under threshold)', () => {
+    makeProjectRoot();
+    const redirect = canonicalRedirect();
+    expect(Buffer.byteLength(redirect, 'utf-8')).toBeLessThanOrEqual(CLAUDE_MD_REDIRECT_MAX_BYTES);
+    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), redirect);
+    fs.writeFileSync(path.join(tmpDir, 'AGENTS.md'), 'canonical');
+
+    const result = checkAgentsMdCanonical(tmpDir);
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('redirect');
+  });
+
+  it('fails when CLAUDE.md is fat and does not match the redirect pattern', () => {
+    makeProjectRoot();
+    const fat = `# Project Rules\n\n${'Some load-bearing rule that should live in AGENTS.md. '.repeat(20)}`;
+    expect(Buffer.byteLength(fat, 'utf-8')).toBeGreaterThan(CLAUDE_MD_REDIRECT_MAX_BYTES);
+    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), fat);
+
+    const result = checkAgentsMdCanonical(tmpDir);
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('not a redirect');
+    expect(result.remediation).toContain('AGENTS.md');
+  });
+
+  it('passes for a verbose redirect (over threshold but matches pattern) with AGENTS.md present', () => {
+    makeProjectRoot();
+    // Pad the redirect with an extra paragraph above the threshold while
+    // keeping the canonical phrase + link intact.
+    const verbose =
+      canonicalRedirect() +
+      '\n\n## Local addendum\n\n' +
+      'Long-form addendum for a downstream consumer that needs vendor-specific notes. '.repeat(4);
+    expect(Buffer.byteLength(verbose, 'utf-8')).toBeGreaterThan(CLAUDE_MD_REDIRECT_MAX_BYTES);
+    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), verbose);
+    fs.writeFileSync(path.join(tmpDir, 'AGENTS.md'), 'canonical');
+
+    const result = checkAgentsMdCanonical(tmpDir);
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('verbose redirect');
+  });
+
+  it('fails when CLAUDE.md is a verbose redirect but AGENTS.md is missing', () => {
+    makeProjectRoot();
+    const verbose =
+      canonicalRedirect() +
+      '\n\n## Addendum\n\n' +
+      'Long-form addendum for a downstream consumer. '.repeat(8);
+    expect(Buffer.byteLength(verbose, 'utf-8')).toBeGreaterThan(CLAUDE_MD_REDIRECT_MAX_BYTES);
+    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), verbose);
+    // No AGENTS.md
+
+    const result = checkAgentsMdCanonical(tmpDir);
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('AGENTS.md does not exist');
+    expect(result.remediation).toContain('Create AGENTS.md');
+  });
+
+  it('fails when a small CLAUDE.md matches the redirect pattern but AGENTS.md is missing', () => {
+    // Defends against the template-copied-but-AGENTS.md-not-authored case.
+    // The AGENTS.md existence requirement is independent of file size.
+    makeProjectRoot();
+    const redirect = canonicalRedirect();
+    expect(Buffer.byteLength(redirect, 'utf-8')).toBeLessThanOrEqual(CLAUDE_MD_REDIRECT_MAX_BYTES);
+    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), redirect);
+    // No AGENTS.md — the test surface
+
+    const result = checkAgentsMdCanonical(tmpDir);
+    expect(result.status).toBe('fail');
+    expect(result.message).toContain('AGENTS.md does not exist');
+  });
+
+  it('recognizes a bare .git directory as a project root', () => {
+    fs.mkdirSync(path.join(tmpDir, '.git'));
+    // No package.json, no CLAUDE.md — should pass (nothing to enforce)
+    const result = checkAgentsMdCanonical(tmpDir);
+    expect(result.status).toBe('pass');
+    expect(result.message).toContain('no CLAUDE.md');
+  });
+
+  it('redirect pattern is case-insensitive on the canonical phrase', () => {
+    expect(
+      AGENTS_MD_REDIRECT_PATTERN.test(
+        'The Canonical Agent Instructions for this repository live in [`AGENTS.md`](AGENTS.md).',
+      ),
+    ).toBe(true);
+  });
+
+  it('redirect pattern rejects content that mentions AGENTS.md without the canonical delegation phrase', () => {
+    expect(AGENTS_MD_REDIRECT_PATTERN.test('See [`AGENTS.md`](AGENTS.md) for more info.')).toBe(
+      false,
+    );
   });
 });
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -638,6 +638,102 @@ export function checkSecretsFileTracked(cwd: string, totemDir = '.totem'): Diagn
   };
 }
 
+// ─── AGENTS.md canonical-redirect check (Proposal 272 § 6.7 / mmnto-ai/totem#1905) ───
+
+/**
+ * Maximum byte size for a `CLAUDE.md` that's purely a thin redirect to
+ * `AGENTS.md`. Anchored to Proposal 272 § 6.7. Empirical headroom:
+ * the largest post-migration cohort redirect is 558 bytes.
+ */
+export const CLAUDE_MD_REDIRECT_MAX_BYTES = 600;
+
+/**
+ * Minimal shape signature for a `CLAUDE.md` redirect to `AGENTS.md`
+ * per ADR-038. The canonical phrase plus the link target is load-bearing;
+ * surrounding wording is intentionally unconstrained so future template
+ * tweaks survive without breaking every consumer.
+ */
+export const AGENTS_MD_REDIRECT_PATTERN =
+  /canonical agent instructions[^.]*\[`AGENTS\.md`\]\(AGENTS\.md\)/i;
+
+export function checkAgentsMdCanonical(cwd: string): DiagnosticResult {
+  const hasPackageJson = fs.existsSync(path.join(cwd, 'package.json'));
+  // totem-ignore-next-line — predicate is "is THIS cwd a project root" (Proposal 272 § 6.7); existsSync correctly handles both .git/ dir and .git file (worktrees). resolveGitRoot would traverse UP and report a parent repo, which is the wrong semantic.
+  const hasGitDir = fs.existsSync(path.join(cwd, '.git'));
+
+  if (!hasPackageJson && !hasGitDir) {
+    return {
+      name: 'AGENTS.md Canonical',
+      status: 'skip',
+      message: 'not a project root',
+    };
+  }
+
+  const claudeMdPath = path.join(cwd, 'CLAUDE.md');
+  if (!fs.existsSync(claudeMdPath)) {
+    return {
+      name: 'AGENTS.md Canonical',
+      status: 'pass',
+      message: 'no CLAUDE.md (no enforcement)',
+    };
+  }
+
+  let content: string;
+  try {
+    // totem-ignore-next-line — sync read of a tiny on-disk file (~1KB max for the canonical redirect); the doctor pipeline is sync and intentionally reads unstaged on-disk state (the whole point of the check is to surface disk-vs-canonical drift).
+    content = fs.readFileSync(claudeMdPath, 'utf-8'); // totem-context: intentional cleanup — best-effort read; a permission / IO error surfaces as `warn`, matching the `checkCompiledRules` / `checkConfig` convention.
+  } catch {
+    return {
+      name: 'AGENTS.md Canonical',
+      status: 'warn',
+      message: 'CLAUDE.md unreadable',
+    };
+  }
+
+  const bytes = Buffer.byteLength(content, 'utf-8');
+  // totem-ignore-next-line — non-global regex on markdown document content (not shell/command input); the .test()-related lessons target command-validation contexts. The pattern is anchored by its load-bearing literal substrings ("canonical agent instructions" + the AGENTS.md link), so ^ would be wrong here.
+  const matchesRedirect = AGENTS_MD_REDIRECT_PATTERN.test(content);
+
+  // Whenever CLAUDE.md claims to be a redirect, AGENTS.md MUST exist —
+  // independent of size. Without this, a small CLAUDE.md copied from the
+  // template (but with no AGENTS.md authored) would silently pass.
+  if (matchesRedirect && !fs.existsSync(path.join(cwd, 'AGENTS.md'))) {
+    return {
+      name: 'AGENTS.md Canonical',
+      status: 'fail',
+      message: 'CLAUDE.md redirects to AGENTS.md but AGENTS.md does not exist',
+      remediation: 'Create AGENTS.md per ADR-038',
+    };
+  }
+
+  // Below the size threshold, CLAUDE.md is too small to carry meaningful
+  // load-bearing content. Proposal 272 § 6.7 picks 600 bytes as the gate.
+  if (bytes <= CLAUDE_MD_REDIRECT_MAX_BYTES) {
+    return {
+      name: 'AGENTS.md Canonical',
+      status: 'pass',
+      message: matchesRedirect
+        ? `CLAUDE.md is a redirect (${bytes} bytes)`
+        : `CLAUDE.md is under the redirect threshold (${bytes} bytes)`,
+    };
+  }
+
+  if (!matchesRedirect) {
+    return {
+      name: 'AGENTS.md Canonical',
+      status: 'fail',
+      message: `CLAUDE.md is ${bytes} bytes and not a redirect to AGENTS.md (ADR-038)`,
+      remediation: 'Lift content to AGENTS.md and replace CLAUDE.md with the redirect template',
+    };
+  }
+
+  return {
+    name: 'AGENTS.md Canonical',
+    status: 'pass',
+    message: `CLAUDE.md is a verbose redirect (${bytes} bytes)`,
+  };
+}
+
 // ─── Upgrade candidate check (mmnto/totem#1131) ────────────────────
 
 /**
@@ -1615,6 +1711,7 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<Diagno
     await checkStrategyRoot(cwd, loadedConfig),
     await checkSecretLeaks(cwd),
     checkSecretsFileTracked(cwd),
+    checkAgentsMdCanonical(cwd),
     await checkUpgradeCandidates(cwd),
     await checkStaleRules(cwd, '.totem', doctorThresholds),
     await checkGrandfatheredRules(cwd),

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -658,8 +658,7 @@ export const AGENTS_MD_REDIRECT_PATTERN =
 
 export function checkAgentsMdCanonical(cwd: string): DiagnosticResult {
   const hasPackageJson = fs.existsSync(path.join(cwd, 'package.json'));
-  // totem-ignore-next-line — predicate is "is THIS cwd a project root" (Proposal 272 § 6.7); existsSync correctly handles both .git/ dir and .git file (worktrees). resolveGitRoot would traverse UP and report a parent repo, which is the wrong semantic.
-  const hasGitDir = fs.existsSync(path.join(cwd, '.git'));
+  const hasGitDir = fs.existsSync(path.join(cwd, '.git')); // totem-context: predicate is "is THIS cwd a project root" (Proposal 272 § 6.7); existsSync correctly handles both .git/ dir and .git file (worktrees). resolveGitRoot would traverse UP and report a parent repo, which is the wrong semantic.
 
   if (!hasPackageJson && !hasGitDir) {
     return {
@@ -680,8 +679,7 @@ export function checkAgentsMdCanonical(cwd: string): DiagnosticResult {
 
   let content: string;
   try {
-    // totem-ignore-next-line — sync read of a tiny on-disk file (~1KB max for the canonical redirect); the doctor pipeline is sync and intentionally reads unstaged on-disk state (the whole point of the check is to surface disk-vs-canonical drift).
-    content = fs.readFileSync(claudeMdPath, 'utf-8'); // totem-context: intentional cleanup — best-effort read; a permission / IO error surfaces as `warn`, matching the `checkCompiledRules` / `checkConfig` convention.
+    content = fs.readFileSync(claudeMdPath, 'utf-8'); // totem-context: intentional cleanup — best-effort sync read of a tiny on-disk file (~1KB max for the canonical redirect). The doctor pipeline is sync; the check intentionally reads unstaged on-disk state (the whole point is to surface disk-vs-canonical drift). A permission / IO error surfaces as `warn`, matching the `checkCompiledRules` / `checkConfig` convention.
   } catch {
     return {
       name: 'AGENTS.md Canonical',
@@ -691,8 +689,7 @@ export function checkAgentsMdCanonical(cwd: string): DiagnosticResult {
   }
 
   const bytes = Buffer.byteLength(content, 'utf-8');
-  // totem-ignore-next-line — non-global regex on markdown document content (not shell/command input); the .test()-related lessons target command-validation contexts. The pattern is anchored by its load-bearing literal substrings ("canonical agent instructions" + the AGENTS.md link), so ^ would be wrong here.
-  const matchesRedirect = AGENTS_MD_REDIRECT_PATTERN.test(content);
+  const matchesRedirect = AGENTS_MD_REDIRECT_PATTERN.test(content); // totem-context: non-global regex on markdown document content (not shell/command input); the .test()-related lessons target command-validation contexts. The pattern is anchored by its load-bearing literal substrings ("canonical agent instructions" + the AGENTS.md link), so ^ would be wrong here.
 
   // Whenever CLAUDE.md claims to be a redirect, AGENTS.md MUST exist —
   // independent of size. Without this, a small CLAUDE.md copied from the


### PR DESCRIPTION
## Summary

Adds the `agents-md-canonical` diagnostic to `totem doctor` per [Proposal 272 § 6.7](https://github.com/mmnto-ai/totem-strategy/blob/main/proposals/active/272-adr-038-execution-agents-md-migration.md) — the first enforcement-backlog item after the ADR-038 cohort migration shipped in #1904.

- New `checkAgentsMdCanonical` function in `packages/cli/src/commands/doctor.ts` plus dispatcher wiring.
- 9 new unit tests covering: project-root gate, no-CLAUDE.md pass, cohort-redirect pass, fat-non-redirect fail, fat-but-redirect-shaped pass, missing-AGENTS.md fail (both > and ≤ 600 bytes), bare-`.git` recognition, regex case-insensitivity, false-mention rejection.
- Phase-3 design doc committed at `.totem/specs/agents-md-canonical.md` (approved by strategy-Claude T0120Z).
- Changeset queues a minor bump on the `@mmnto/cli` cohort.

Predicate (per Proposal 272 § 6.7 + the design-doc tightening surfaced by `totem review`):

| State | Verdict |
|---|---|
| Not a project root (no `package.json` AND no `.git`) | skip |
| No `CLAUDE.md` | pass |
| `CLAUDE.md` matches redirect pattern AND `AGENTS.md` missing | **fail** |
| `CLAUDE.md` ≤ 600 bytes | pass |
| `CLAUDE.md` > 600 bytes AND doesn't match redirect pattern | **fail** |
| `CLAUDE.md` > 600 bytes AND matches pattern AND `AGENTS.md` exists | pass (verbose redirect) |

The threshold + pattern are exported (`CLAUDE_MD_REDIRECT_MAX_BYTES`, `AGENTS_MD_REDIRECT_PATTERN`) so tests assert by reference, not duplicated literal — prevents the FR-C01-class drift CR likes to flag.

## Surface translation

Proposal 272 § 6.7 names this as a `totem lint` rule, but `totem lint` is a diff-based content scanner. The predicate here is a repo-shape check (file existence + size + content pattern), which fits the existing `check*` function registry in `doctor.ts`.

Routing confirmed by strategy-Claude:
> The "lint" framing in Proposal 272 § 6.7 was naming-by-association ("rules go in lint"), not surface design. `doctor` matches: it's an explicit registry of `check*` functions, runs on operator demand. The predicate IS a doctor check.

Source: substrate dispatch `.handoff/totem-claude/processed/2026-05-14T0120Z-strategy-claude.md` (handoff `a9caa4c` → reply `8a16e13`).

The companion follow-on (`doctor --strict` mode + pre-push wiring) is tracked separately in #1906 — it's the surface that makes this diagnostic auto-fire on PR/push. Don't gate this PR on it.

## Live verification

`totem doctor` against this repo:

```
✓ AGENTS.md Canonical  CLAUDE.md is a redirect (529 bytes)
```

Largest cohort post-migration redirect is 558 bytes — 600 leaves ~42 bytes headroom for typical title-line variance.

## Tightening from `totem review`

Internal review (`totem review` Gemini pass) caught a real logic gap in the first-draft predicate: a small CLAUDE.md (≤ 600 bytes) that copies the redirect template but has no `AGENTS.md` would silently pass. Fixed by moving the AGENTS.md-existence check above the size short-circuit, so it fires whenever the redirect pattern matches — regardless of size. New test `fails when a small CLAUDE.md matches the redirect pattern but AGENTS.md is missing` locks the invariant.

## Test plan

- [ ] CR clean R1 (or addressable)
- [ ] GCA clean R1 (or addressable)
- [ ] CI green: lint, tests, build
- [ ] `totem doctor` reports `AGENTS.md Canonical: pass` against the totem repo itself
- [ ] No regression in existing diagnostic count (was 13; now 14 — `EXPECTED_DIAGNOSTIC_NAMES` updated)

Closes #1905.
Follow-on: #1906 (`doctor --strict` + pre-push wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)