### PR TITLE
feat(core): Trap Ledger schema extension — agent attribution + activity events (A.3.a)

### DIFF
--- a/.changeset/ledger-schema-a3a.md
+++ b/.changeset/ledger-schema-a3a.md
@@ -24,7 +24,7 @@ Forward-only schema extension to `LedgerEventSchema` in `packages/core/src/ledge
 - `correlation_id` (UUID) — trace correlation per ADR-014; populated by A.3.c end-to-end propagation work.
 - `activity_name` — sub-type discriminator for activity events.
 
-**Field relaxations:** `ruleId` and `file` are now optional at the schema level to accommodate activity events. Writer-side discipline enforces required-by-type for `suppress` / `override` / `exemption`. Promotion to a Zod `discriminatedUnion` is deferred to A.3.c per design doc OQ-1.
+**Field relaxations:** `ruleId` and `file` are now optional at the schema level to accommodate activity events. Writer-side discipline enforces required-by-type for `suppress` / `override` / `exemption`. Promotion to a Zod `discriminatedUnion` is deferred to A.3.c per design doc OQ-1 (strategy-Claude T0345Z disposition agreed; rationale and gap-filler tests in `ledger.test.ts` § "writer-side per-branch field presence" lock the discipline until the schema enforces it structurally).
 
 **Backward compatibility:**
 
@@ -45,4 +45,4 @@ Activity-event example added for `mcp_call` / `search_knowledge` shape.
 - A.3.c: orchestrator → MCP `correlation_id` propagation (~1 week).
 - A.4.a / A.4.b: PreToolUse soft-block + pre-push hard-block pair (per C-12, ships alongside A.3.a).
 
-ADR-078 surface amendment (rename agent attribution from `source` to `agent_source` in § Decision 2) routed to strategy-Claude via substrate dispatch T0258Z. No code dependency in either direction.
+ADR-078 surface amendment (rename agent attribution from `source` to `agent_source` in § Decision 2) landed at `mmnto-ai/totem-strategy#329` (commit `b830e0c` on main). Includes the first `Falsifying Metric:` field in the ecosystem per Tenet 19 — sibling capability-claim ADRs 014/029/044 backfilled in `mmnto-ai/totem-strategy#330`.

--- a/.changeset/ledger-schema-a3a.md
+++ b/.changeset/ledger-schema-a3a.md
@@ -11,12 +11,14 @@ feat(core): Trap Ledger schema extension — agent attribution + activity events
 Forward-only schema extension to `LedgerEventSchema` in `packages/core/src/ledger.ts`. First lift of the A.3 telemetry sprint (three-stream claim-discipline consensus, design doc at `mmnto-ai/totem-substrate:.handoff/_shared/2026-05-15-a3a-schema-extension-design.md`).
 
 **New event types** (activity family):
+
 - `mcp_call` — MCP tool invocation; `activity_name` discriminates (`search_knowledge`, `describe_project`, ...)
 - `tool_call_first_significant` — first non-Read/Grep/Glob orchestrator tool call in session
 - `hook_fire` — lifecycle hook executed; `activity_name` discriminates (`SessionStart`, `PreToolUse`, `pre-push`, ...)
 - `session_start` — SessionStart hook fired; new `session_id` minted
 
 **New optional fields:**
+
 - `agent_source: 'claude' | 'gemini' | 'human'` — agent runtime attribution, orthogonal to `source` (emitting subsystem). Implements ADR-078 § Event Attribution; renamed from the ADR's `source` to disambiguate against the load-bearing emitter identifier already in production.
 - `session_id` (UUID) — session correlation, persisted at `.totem/ledger/.session-id` per ADR-029 § Session Heuristic.
 - `correlation_id` (UUID) — trace correlation per ADR-014; populated by A.3.c end-to-end propagation work.
@@ -25,10 +27,12 @@ Forward-only schema extension to `LedgerEventSchema` in `packages/core/src/ledge
 **Field relaxations:** `ruleId` and `file` are now optional at the schema level to accommodate activity events. Writer-side discipline enforces required-by-type for `suppress` / `override` / `exemption`. Promotion to a Zod `discriminatedUnion` is deferred to A.3.c per design doc OQ-1.
 
 **Backward compatibility:**
+
 - Pre-A.3.a override events (no new fields) parse fine — all new fields optional.
 - Post-A.3.a activity events read by pre-A.3.a code: silently dropped (`safeParse` fails on unknown enum value, line skipped). Acceptable — no data corruption, only telemetry-visibility loss in stale tooling. Cohort version bump after merge closes this naturally.
 
 **Doc-sync (bundled):** `docs/wiki/trap-ledger.md` example corrected — pre-existing drift surfaced during A.3.a empirical pass. Three drifts fixed:
+
 - Example `type` was `"exception"` (invalid; not in the enum) → now `"suppress"`.
 - Example `source` was `"totem-context"` (bypass-marker; conflated with code's emitter identifier) → now `"lint"`.
 - Prose claimed `// totem-context:` directives log `override` events — corrected to `suppress` per code comment in `LedgerEventSchema.type`.
@@ -36,6 +40,7 @@ Forward-only schema extension to `LedgerEventSchema` in `packages/core/src/ledge
 Activity-event example added for `mcp_call` / `search_knowledge` shape.
 
 **Out of scope (next sub-lifts):**
+
 - A.3.b: `totem doctor --compliance` reads this schema and computes the ADR-029 metric (~1 week).
 - A.3.c: orchestrator → MCP `correlation_id` propagation (~1 week).
 - A.4.a / A.4.b: PreToolUse soft-block + pre-push hard-block pair (per C-12, ships alongside A.3.a).

--- a/.changeset/ledger-schema-a3a.md
+++ b/.changeset/ledger-schema-a3a.md
@@ -1,0 +1,43 @@
+---
+'@mmnto/cli': minor
+'@mmnto/totem': minor
+'@mmnto/mcp': minor
+'@mmnto/pack-agent-security': minor
+'@mmnto/pack-rust-architecture': minor
+---
+
+feat(core): Trap Ledger schema extension — agent attribution + activity events (A.3.a)
+
+Forward-only schema extension to `LedgerEventSchema` in `packages/core/src/ledger.ts`. First lift of the A.3 telemetry sprint (three-stream claim-discipline consensus, design doc at `mmnto-ai/totem-substrate:.handoff/_shared/2026-05-15-a3a-schema-extension-design.md`).
+
+**New event types** (activity family):
+- `mcp_call` — MCP tool invocation; `activity_name` discriminates (`search_knowledge`, `describe_project`, ...)
+- `tool_call_first_significant` — first non-Read/Grep/Glob orchestrator tool call in session
+- `hook_fire` — lifecycle hook executed; `activity_name` discriminates (`SessionStart`, `PreToolUse`, `pre-push`, ...)
+- `session_start` — SessionStart hook fired; new `session_id` minted
+
+**New optional fields:**
+- `agent_source: 'claude' | 'gemini' | 'human'` — agent runtime attribution, orthogonal to `source` (emitting subsystem). Implements ADR-078 § Event Attribution; renamed from the ADR's `source` to disambiguate against the load-bearing emitter identifier already in production.
+- `session_id` (UUID) — session correlation, persisted at `.totem/ledger/.session-id` per ADR-029 § Session Heuristic.
+- `correlation_id` (UUID) — trace correlation per ADR-014; populated by A.3.c end-to-end propagation work.
+- `activity_name` — sub-type discriminator for activity events.
+
+**Field relaxations:** `ruleId` and `file` are now optional at the schema level to accommodate activity events. Writer-side discipline enforces required-by-type for `suppress` / `override` / `exemption`. Promotion to a Zod `discriminatedUnion` is deferred to A.3.c per design doc OQ-1.
+
+**Backward compatibility:**
+- Pre-A.3.a override events (no new fields) parse fine — all new fields optional.
+- Post-A.3.a activity events read by pre-A.3.a code: silently dropped (`safeParse` fails on unknown enum value, line skipped). Acceptable — no data corruption, only telemetry-visibility loss in stale tooling. Cohort version bump after merge closes this naturally.
+
+**Doc-sync (bundled):** `docs/wiki/trap-ledger.md` example corrected — pre-existing drift surfaced during A.3.a empirical pass. Three drifts fixed:
+- Example `type` was `"exception"` (invalid; not in the enum) → now `"suppress"`.
+- Example `source` was `"totem-context"` (bypass-marker; conflated with code's emitter identifier) → now `"lint"`.
+- Prose claimed `// totem-context:` directives log `override` events — corrected to `suppress` per code comment in `LedgerEventSchema.type`.
+
+Activity-event example added for `mcp_call` / `search_knowledge` shape.
+
+**Out of scope (next sub-lifts):**
+- A.3.b: `totem doctor --compliance` reads this schema and computes the ADR-029 metric (~1 week).
+- A.3.c: orchestrator → MCP `correlation_id` propagation (~1 week).
+- A.4.a / A.4.b: PreToolUse soft-block + pre-push hard-block pair (per C-12, ships alongside A.3.a).
+
+ADR-078 surface amendment (rename agent attribution from `source` to `agent_source` in § Decision 2) routed to strategy-Claude via substrate dispatch T0258Z. No code dependency in either direction.

--- a/docs/wiki/trap-ledger.md
+++ b/docs/wiki/trap-ledger.md
@@ -10,29 +10,60 @@ The Trap Ledger is an immutable, append-only event stream located at `.totem/led
 
 ### What gets recorded?
 
-The Ledger actively monitors your usage of Totem override directives:
+The Ledger captures two semantic families of events.
 
-- `// totem-ignore` (Hard suppression)
-- `// totem-context:` (Semantic suppression)
-- `// shield-context:` (Deprecated alias, emits warning as of 1.6.0)
+**Override events** (one per directive encountered):
 
-Whenever `totem lint` or `totem review` encounters one of these directives, it logs an `override` event to the ledger.
+- `// totem-ignore` (Hard suppression) → `type: "suppress"`
+- `// totem-context:` (Semantic suppression) → `type: "suppress"`
+- `// shield-context:` (Deprecated alias, emits warning as of 1.6.0) → `type: "suppress"`
+- `totem shield --override` → `type: "override"`
+- Pattern exemptions → `type: "exemption"`
+
+**Activity events** (one per agent interaction, A.3.a onwards):
+
+- `mcp_call` — MCP tool invocation (e.g., `search_knowledge`); identified by `activity_name`
+- `tool_call_first_significant` — first non-Read/Grep/Glob orchestrator tool call in the session
+- `hook_fire` — lifecycle hook executed (e.g., `SessionStart`, `PreToolUse`, `pre-push`)
+- `session_start` — SessionStart hook fired; new `session_id` minted
 
 ### Event Schema
 
-The NDJSON records contain high-fidelity context about the friction event:
+The NDJSON records contain high-fidelity context about the friction event.
+
+**Override event example:**
 
 ```json
 {
   "timestamp": "2026-03-25T14:32:00.000Z",
-  "type": "exception",
+  "type": "suppress",
   "ruleId": "no-console-in-core",
   "file": "packages/core/src/logger.ts",
   "line": 42,
   "justification": "This is the logger module, console is required here.",
-  "source": "totem-context"
+  "source": "lint"
 }
 ```
+
+**Activity event example** (A.3.a onwards, ADR-029 compliance metric source):
+
+```json
+{
+  "timestamp": "2026-05-15T03:00:00.000Z",
+  "type": "mcp_call",
+  "source": "bot",
+  "agent_source": "claude",
+  "session_id": "550e8400-e29b-41d4-a716-446655440000",
+  "activity_name": "search_knowledge"
+}
+```
+
+The canonical schema (with field-level descriptions, optionality, and discriminator semantics) lives in `packages/core/src/ledger.ts` (`LedgerEventSchema`). Two orthogonal axes worth calling out:
+
+- `source` — emitting subsystem (`lint` | `shield` | `bot`)
+- `agent_source` — agent runtime that produced the event (`claude` | `gemini` | `human`)
+
+Per ADR-078 § Event Attribution: agent attribution lives in `agent_source`; `source` identifies which Totem subsystem fired the event. Pre-A.3.a events have no `agent_source` field and are forward-compatible (the field is optional).
 
 ---
 

--- a/packages/cli/src/commands/ledger-analyzer.test.ts
+++ b/packages/cli/src/commands/ledger-analyzer.test.ts
@@ -123,6 +123,66 @@ describe('readLedgerBypassCounts', () => {
     expect(counts.get('rule-a')).toBe(1);
     expect(counts.get('rule-b')).toBe(1);
   });
+
+  // A.3.a — type-based filter (CR/GCA Round-1 fix). The prior implementation
+  // used absence of `ruleId` as a proxy to skip activity events, which would
+  // mis-count an activity event that happened to carry a ruleId. Now the
+  // filter is type-based: only `suppress` and `override` count toward bypass
+  // rate.
+
+  it('excludes activity events even when they carry a ruleId', async () => {
+    // Construct an mcp_call event that happens to carry a ruleId — the prior
+    // absence-of-ruleId proxy would have counted this. With the type filter
+    // it's correctly excluded.
+    const sneakyActivityEvent = JSON.stringify({
+      timestamp: '2026-05-15T03:00:00.000Z',
+      type: 'mcp_call',
+      ruleId: 'should-not-count', // <-- the bug surface that proxy filter missed
+      source: 'bot',
+      agent_source: 'claude',
+      session_id: '550e8400-e29b-41d4-a716-446655440000',
+      activity_name: 'search_knowledge',
+      justification: '',
+    });
+    writeLedger(tmpDir, [
+      makeLedgerEvent('legit-rule'),
+      sneakyActivityEvent,
+      makeLedgerEvent('legit-rule'),
+    ]);
+
+    const counts = await readLedgerBypassCounts(tmpDir);
+    expect(counts.get('legit-rule')).toBe(2);
+    expect(counts.get('should-not-count')).toBeUndefined();
+    expect(counts.size).toBe(1);
+  });
+
+  it('excludes session_start and exemption events from bypass counts', async () => {
+    // session_start and exemption are not bypass events; neither should
+    // contribute to the rule-scoped bypass-rate metric.
+    const sessionStartEvent = JSON.stringify({
+      timestamp: '2026-05-15T03:00:00.000Z',
+      type: 'session_start',
+      source: 'bot',
+      agent_source: 'claude',
+      session_id: '550e8400-e29b-41d4-a716-446655440000',
+      activity_name: 'SessionStart',
+      justification: '',
+    });
+    const exemptionEvent = JSON.stringify({
+      timestamp: '2026-05-15T03:01:00.000Z',
+      type: 'exemption',
+      ruleId: 'auto-exempt-rule',
+      file: 'src/index.ts',
+      source: 'lint',
+      justification: '',
+    });
+    writeLedger(tmpDir, [makeLedgerEvent('legit-rule'), sessionStartEvent, exemptionEvent]);
+
+    const counts = await readLedgerBypassCounts(tmpDir);
+    expect(counts.get('legit-rule')).toBe(1);
+    expect(counts.get('auto-exempt-rule')).toBeUndefined();
+    expect(counts.size).toBe(1);
+  });
 });
 
 // ─── analyzeLedger ──────────────────────────────────────

--- a/packages/cli/src/commands/ledger-analyzer.ts
+++ b/packages/cli/src/commands/ledger-analyzer.ts
@@ -85,6 +85,8 @@ export async function readLedgerBypassCounts(
       if (!result.success) continue;
       const event = result.data;
       if (event.type === 'exemption') continue;
+      // Skip activity events (A.3.a) — they have no ruleId; bypass-rate is rule-scoped.
+      if (!event.ruleId) continue;
       counts.set(event.ruleId, (counts.get(event.ruleId) ?? 0) + 1);
     } catch {
       onWarn?.('Skipping malformed ledger line');

--- a/packages/cli/src/commands/ledger-analyzer.ts
+++ b/packages/cli/src/commands/ledger-analyzer.ts
@@ -84,8 +84,13 @@ export async function readLedgerBypassCounts(
       const result = LedgerEventSchema.safeParse(parsed);
       if (!result.success) continue;
       const event = result.data;
-      if (event.type === 'exemption') continue;
-      // Skip activity events (A.3.a) — they have no ruleId; bypass-rate is rule-scoped.
+      // Bypass-rate is rule-scoped: include only the two rule-bypass event types
+      // (suppress + override). Excludes `exemption` and all A.3.a activity events
+      // (mcp_call, session_start, etc.) by type rather than via the absence-of-
+      // ruleId proxy. CR/GCA Round-1 catch — type-based filter is more robust
+      // (the prior proxy would miscount an activity event that happened to
+      // carry a ruleId).
+      if (event.type !== 'suppress' && event.type !== 'override') continue;
       if (!event.ruleId) continue;
       counts.set(event.ruleId, (counts.get(event.ruleId) ?? 0) + 1);
     } catch {

--- a/packages/cli/src/commands/recurrence-stats.ts
+++ b/packages/cli/src/commands/recurrence-stats.ts
@@ -232,6 +232,8 @@ export async function runRecurrenceStats(options: RunRecurrenceStatsOptions = {}
   const ledgerEvents = readLedgerEvents(totemDir, (msg) => log.warn(TAG, msg));
   const overrideEvents = ledgerEvents.filter((e) => e.type === 'override');
   for (const event of overrideEvents) {
+    // Override events carry `file` by writer discipline; A.3.a relaxed the schema-level requirement.
+    if (!event.file) continue;
     const synthetic: NormalizedBotFinding = {
       tool: 'unknown',
       severity: 'medium',

--- a/packages/core/src/ledger.test.ts
+++ b/packages/core/src/ledger.test.ts
@@ -204,6 +204,93 @@ describe('LedgerEventSchema', () => {
   });
 });
 
+// ─── Writer-side per-branch field-presence (A.3.c discriminated-union gap-filler) ─────
+//
+// The flat schema (A.3.a) allows `ruleId`, `file`, `agent_source`, `session_id`, and
+// `activity_name` to be undefined globally. Per OQ-1 disposition (strategy-Claude
+// T0345Z), the discriminated-union promotion is deferred to A.3.c. These tests
+// enforce writer-side discipline in the A.3.a window: each event type carries the
+// fields its semantics require. Without them, an A.3.b metric computation could
+// read `null` on an LLM-boundary action because a writer silently dropped a field.
+//
+// Tests lock the discipline; they FAIL when a writer omits a required-by-type field.
+// When the schema is promoted to discriminatedUnion in A.3.c, these tests become
+// redundant against the schema (which is the point of promotion); they survive as
+// regression coverage.
+
+describe('writer-side per-branch field presence', () => {
+  // Helper: each test builds an event using makeEvent/makeActivityEvent
+  // factories (which always populate required-by-type fields), then asserts
+  // each required field is defined and non-empty on the resulting object.
+  // The test catches the regression where the factories drift and stop
+  // populating a per-branch required field — at which point the assertion
+  // fires with a descriptive label. The schema itself remains permissive
+  // (flat optional) per OQ-1; A.3.c's discriminatedUnion promotion will
+  // make this discipline structural.
+  function expectWriterCarriesFields(
+    event: LedgerEvent,
+    requiredByType: ReadonlyArray<keyof LedgerEvent>,
+  ): void {
+    for (const field of requiredByType) {
+      const fieldValue = event[field];
+      expect(fieldValue, `expected ${event.type} event to carry ${String(field)}`).toBeDefined();
+      if (typeof fieldValue === 'string') {
+        expect(fieldValue.length, `expected non-empty ${String(field)}`).toBeGreaterThan(0);
+      }
+    }
+  }
+
+  it('suppress events carry ruleId + file', () => {
+    expectWriterCarriesFields(makeEvent({ type: 'suppress' }), ['ruleId', 'file']);
+  });
+
+  it('override events carry ruleId + file', () => {
+    expectWriterCarriesFields(makeEvent({ type: 'override', source: 'shield' }), [
+      'ruleId',
+      'file',
+    ]);
+  });
+
+  it('exemption events carry ruleId + file', () => {
+    expectWriterCarriesFields(makeEvent({ type: 'exemption', source: 'bot' }), ['ruleId', 'file']);
+  });
+
+  it('mcp_call events carry agent_source + session_id + activity_name', () => {
+    expectWriterCarriesFields(makeActivityEvent({ type: 'mcp_call' }), [
+      'agent_source',
+      'session_id',
+      'activity_name',
+    ]);
+  });
+
+  it('session_start events carry agent_source + session_id', () => {
+    // session_start is what the SessionStart hook emits; agent_source identifies
+    // the orchestrator vendor (hook knows its own origin), session_id is the
+    // freshly-minted UUID that subsequent events correlate against.
+    expectWriterCarriesFields(
+      makeActivityEvent({ type: 'session_start', activity_name: 'SessionStart' }),
+      ['agent_source', 'session_id'],
+    );
+  });
+
+  it('hook_fire events carry agent_source + session_id + activity_name', () => {
+    expectWriterCarriesFields(
+      makeActivityEvent({ type: 'hook_fire', activity_name: 'PreToolUse' }),
+      ['agent_source', 'session_id', 'activity_name'],
+    );
+  });
+
+  it('tool_call_first_significant events carry agent_source + session_id', () => {
+    // activity_name (e.g., 'Write', 'Bash') is informational on this event type
+    // but not required by writer discipline — the timestamp + session_id pair is
+    // what the ADR-029 metric anchors on.
+    expectWriterCarriesFields(
+      makeActivityEvent({ type: 'tool_call_first_significant', activity_name: 'Write' }),
+      ['agent_source', 'session_id'],
+    );
+  });
+});
+
 // ─── appendLedgerEvent ──────────────────────────────────
 
 describe('appendLedgerEvent', () => {

--- a/packages/core/src/ledger.test.ts
+++ b/packages/core/src/ledger.test.ts
@@ -32,6 +32,19 @@ function makeEvent(overrides: Partial<LedgerEvent> = {}): LedgerEvent {
   };
 }
 
+function makeActivityEvent(overrides: Partial<LedgerEvent> = {}): LedgerEvent {
+  return {
+    timestamp: '2026-05-15T03:00:00.000Z',
+    type: 'mcp_call',
+    justification: '',
+    source: 'bot',
+    agent_source: 'claude',
+    session_id: '550e8400-e29b-41d4-a716-446655440000',
+    activity_name: 'search_knowledge',
+    ...overrides,
+  };
+}
+
 // ─── LedgerEventSchema ─────────────────────────────────
 
 describe('LedgerEventSchema', () => {
@@ -69,6 +82,125 @@ describe('LedgerEventSchema', () => {
     const event = makeEvent({ timestamp: 'not-a-timestamp' });
     const result = LedgerEventSchema.safeParse(event);
     expect(result.success).toBe(false);
+  });
+
+  // ─── Activity events (A.3.a schema extension) ────────────────
+
+  it('accepts an mcp_call activity event with agent_source + session_id + activity_name', () => {
+    const event = makeActivityEvent();
+    const result = LedgerEventSchema.safeParse(event);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.type).toBe('mcp_call');
+      expect(result.data.agent_source).toBe('claude');
+      expect(result.data.session_id).toBe('550e8400-e29b-41d4-a716-446655440000');
+      expect(result.data.activity_name).toBe('search_knowledge');
+      expect(result.data.ruleId).toBeUndefined();
+      expect(result.data.file).toBeUndefined();
+    }
+  });
+
+  it('accepts a session_start activity event without ruleId or file', () => {
+    const event = makeActivityEvent({
+      type: 'session_start',
+      activity_name: 'SessionStart',
+    });
+    const result = LedgerEventSchema.safeParse(event);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.type).toBe('session_start');
+      expect(result.data.activity_name).toBe('SessionStart');
+    }
+  });
+
+  it('accepts a tool_call_first_significant activity event', () => {
+    const event = makeActivityEvent({
+      type: 'tool_call_first_significant',
+      activity_name: 'Write',
+      file: 'src/foo.ts',
+    });
+    const result = LedgerEventSchema.safeParse(event);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a hook_fire activity event with activity_name discriminator', () => {
+    const event = makeActivityEvent({
+      type: 'hook_fire',
+      activity_name: 'PreToolUse',
+    });
+    const result = LedgerEventSchema.safeParse(event);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts all three agent_source values', () => {
+    for (const value of ['claude', 'gemini', 'human'] as const) {
+      const event = makeActivityEvent({ agent_source: value });
+      const result = LedgerEventSchema.safeParse(event);
+      expect(result.success).toBe(true);
+    }
+  });
+
+  it('rejects an unknown agent_source value', () => {
+    const event = makeActivityEvent({
+      // @ts-expect-error — intentionally invalid for the test
+      agent_source: 'cursor',
+    });
+    const result = LedgerEventSchema.safeParse(event);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a malformed session_id UUID', () => {
+    const event = makeActivityEvent({ session_id: 'not-a-uuid' });
+    const result = LedgerEventSchema.safeParse(event);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a malformed correlation_id UUID', () => {
+    const event = makeActivityEvent({ correlation_id: 'not-a-uuid' });
+    const result = LedgerEventSchema.safeParse(event);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an empty activity_name', () => {
+    const event = makeActivityEvent({ activity_name: '' });
+    const result = LedgerEventSchema.safeParse(event);
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a pre-A.3.a override event (no new optional fields populated)', () => {
+    // Mirrors what a pre-A.3.a writer produces; round-trip must remain compatible.
+    const legacyEvent = {
+      timestamp: '2026-03-25T12:00:00.000Z',
+      type: 'suppress' as const,
+      ruleId: 'abc123',
+      file: 'src/index.ts',
+      justification: 'legacy',
+      source: 'lint' as const,
+    };
+    const result = LedgerEventSchema.safeParse(legacyEvent);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.agent_source).toBeUndefined();
+      expect(result.data.session_id).toBeUndefined();
+      expect(result.data.correlation_id).toBeUndefined();
+      expect(result.data.activity_name).toBeUndefined();
+    }
+  });
+
+  it('accepts an override event with the new optional attribution fields populated', () => {
+    const event = makeEvent({
+      type: 'override',
+      source: 'shield',
+      agent_source: 'claude',
+      session_id: '550e8400-e29b-41d4-a716-446655440000',
+      correlation_id: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
+    });
+    const result = LedgerEventSchema.safeParse(event);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.agent_source).toBe('claude');
+      expect(result.data.correlation_id).toBe('6ba7b810-9dad-11d1-80b4-00c04fd430c8');
+    }
   });
 });
 
@@ -180,5 +312,42 @@ describe('readLedgerEvents', () => {
   it('returns empty array when file does not exist', () => {
     const events = readLedgerEvents(tmpDir);
     expect(events).toEqual([]);
+  });
+
+  it('round-trips activity events alongside override events', () => {
+    // Mixed-event ledger — simulates a real session where override events
+    // (lint/shield bypasses) coexist with activity events (MCP calls, etc.).
+    const sessionId = '550e8400-e29b-41d4-a716-446655440000';
+    const sessionStart = makeActivityEvent({
+      type: 'session_start',
+      activity_name: 'SessionStart',
+      session_id: sessionId,
+    });
+    const mcpCall = makeActivityEvent({
+      type: 'mcp_call',
+      activity_name: 'search_knowledge',
+      session_id: sessionId,
+    });
+    const overrideEvent = makeEvent({
+      type: 'override',
+      source: 'shield',
+      ruleId: 'rule-xyz',
+      agent_source: 'claude',
+      session_id: sessionId,
+    });
+
+    appendLedgerEvent(tmpDir, sessionStart);
+    appendLedgerEvent(tmpDir, mcpCall);
+    appendLedgerEvent(tmpDir, overrideEvent);
+
+    const events = readLedgerEvents(tmpDir);
+    expect(events).toHaveLength(3);
+    expect(events[0]!.type).toBe('session_start');
+    expect(events[1]!.type).toBe('mcp_call');
+    expect(events[1]!.activity_name).toBe('search_knowledge');
+    expect(events[2]!.type).toBe('override');
+    expect(events[2]!.ruleId).toBe('rule-xyz');
+    // All three share the session_id — enables per-session compliance computation (A.3.b).
+    expect(events.every((e) => e.session_id === sessionId)).toBe(true);
   });
 });

--- a/packages/core/src/ledger.test.ts
+++ b/packages/core/src/ledger.test.ts
@@ -204,29 +204,38 @@ describe('LedgerEventSchema', () => {
   });
 });
 
-// ─── Writer-side per-branch field-presence (A.3.c discriminated-union gap-filler) ─────
+// ─── Test-fixture per-branch field-presence (factory output validation) ─────
 //
-// The flat schema (A.3.a) allows `ruleId`, `file`, `agent_source`, `session_id`, and
-// `activity_name` to be undefined globally. Per OQ-1 disposition (strategy-Claude
-// T0345Z), the discriminated-union promotion is deferred to A.3.c. These tests
-// enforce writer-side discipline in the A.3.a window: each event type carries the
-// fields its semantics require. Without them, an A.3.b metric computation could
-// read `null` on an LLM-boundary action because a writer silently dropped a field.
+// SCOPE (honest about what this catches): these tests exercise the local
+// `makeEvent` / `makeActivityEvent` test factories defined above and assert
+// each event type's factory output carries its required-by-semantics fields.
+// They catch FIXTURE drift — if a future edit to `makeEvent` removes a default
+// required-by-type field, these tests fail.
 //
-// Tests lock the discipline; they FAIL when a writer omits a required-by-type field.
-// When the schema is promoted to discriminatedUnion in A.3.c, these tests become
-// redundant against the schema (which is the point of promotion); they survive as
-// regression coverage.
+// THEY DO NOT exercise real writers (CR R2 catch — `ledger.test.ts:291`).
+// Writer-regression coverage lives in the consumer-side test files where the
+// actual writers run:
+//   - `mcp_call`     → `packages/mcp/src/ledger-writer.test.ts` (logMcpCall)
+//   - `session_start`→ `packages/cli/src/commands/init.test.ts` (CLAUDE_SESSION_START template content tests)
+//   - `suppress` / `override` / `exemption` → run-compiled-rules.test.ts /
+//     shield.test.ts / exemption.test.ts (writers in @mmnto/cli)
+//
+// STRUCTURAL FIX: per OQ-1 disposition (strategy-Claude T0345Z, cross-stream
+// dispatch chain), the discriminated-union promotion in A.3.c will enforce
+// per-branch field presence at the schema level — at that point these
+// fixture-validation tests become redundant against the schema AND the
+// distributed consumer-side writer tests serve as the regression coverage.
+//
+// Retaining the block as a sanity-check on factory stability; full real-writer
+// coverage in the A.3.a window would require cross-package test imports that
+// exceed the sprint's "no call-site changes to existing writers" DoD.
 
-describe('writer-side per-branch field presence', () => {
+describe('test-fixture per-branch field presence (factory output validation)', () => {
   // Helper: each test builds an event using makeEvent/makeActivityEvent
-  // factories (which always populate required-by-type fields), then asserts
-  // each required field is defined and non-empty on the resulting object.
-  // The test catches the regression where the factories drift and stop
-  // populating a per-branch required field — at which point the assertion
-  // fires with a descriptive label. The schema itself remains permissive
-  // (flat optional) per OQ-1; A.3.c's discriminatedUnion promotion will
-  // make this discipline structural.
+  // factories (which populate required-by-type fields by default), then
+  // asserts each required field is defined and non-empty on the resulting
+  // object. Catches factory drift; does NOT catch real writer regressions
+  // (see § "SCOPE" above for the writer-coverage map).
   function expectWriterCarriesFields(
     event: LedgerEvent,
     requiredByType: ReadonlyArray<keyof LedgerEvent>,

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -8,17 +8,45 @@ import { z } from 'zod';
 export const LedgerEventSchema = z.object({
   /** ISO 8601 timestamp */
   timestamp: z.string().datetime(),
-  /** Event type: suppress (inline directive), override (shield --override), exemption (auto/manual pattern exemption) */
-  type: z.enum(['suppress', 'override', 'exemption']),
-  /** Rule ID (lessonHash) that was suppressed/overridden */
-  ruleId: z.string().min(1),
-  /** File where the suppression/override occurred */
-  file: z.string().min(1),
+  /**
+   * Event type. Two semantic families:
+   *
+   *  Override events (require `ruleId` + `file` at writer side):
+   *  - `suppress`  — inline directive (`// totem-ignore`, `// totem-context:`)
+   *  - `override`  — `shield --override`
+   *  - `exemption` — auto/manual pattern exemption
+   *
+   *  Activity events (require `agent_source` + `session_id` at writer side; no rule context):
+   *  - `mcp_call`                    — MCP tool invocation (see `activity_name` for which tool)
+   *  - `tool_call_first_significant` — first non-Read/Grep/Glob orchestrator tool call in session
+   *  - `hook_fire`                   — lifecycle hook executed (see `activity_name` for which hook)
+   *  - `session_start`               — SessionStart hook fired; new `session_id` minted
+   *
+   *  Schema-level: `ruleId` + `file` are optional to accommodate activity events. Writer-side
+   *  discipline enforces required-by-type. Promotion to `z.discriminatedUnion` deferred to A.3.c
+   *  per design doc OQ-1 (.handoff/_shared/2026-05-15-a3a-schema-extension-design.md).
+   */
+  type: z.enum([
+    'suppress',
+    'override',
+    'exemption',
+    'mcp_call',
+    'tool_call_first_significant',
+    'hook_fire',
+    'session_start',
+  ]),
+  /** Rule ID (lessonHash) for override events. Optional; required by writer for suppress/override/exemption. */
+  ruleId: z.string().trim().min(1).optional(),
+  /** File where the suppression/override occurred. Optional; required by writer for suppress/override/exemption. */
+  file: z.string().trim().min(1).optional(),
   /** Line number in the file */
   line: z.number().int().positive().optional(),
   /** The justification text from totem-context: (or deprecated shield-context: alias). Empty for totem-ignore. */
   justification: z.string().default(''),
-  /** Source of the event */
+  /**
+   * Emitting subsystem. Identifies which code path produced the event,
+   * orthogonal to `agent_source` (agent runtime attribution).
+   */
   source: z.enum(['lint', 'shield', 'bot']),
   /**
    * True when the bypassed rule was shipped by a pack with
@@ -28,6 +56,36 @@ export const LedgerEventSchema = z.object({
    * mmnto-ai/totem#1485). Absent on events from non-immutable rules.
    */
   immutable: z.boolean().optional(),
+  /**
+   * Agent runtime that produced the event. Orthogonal to `source`
+   * (which identifies the emitting subsystem). Optional for
+   * backward-compat with pre-A.3.a events; required by writer for
+   * activity events. Per ADR-078 § Event Attribution, with the
+   * field renamed from `source` to disambiguate against the
+   * load-bearing emitter identifier already in production code.
+   */
+  agent_source: z.enum(['claude', 'gemini', 'human']).optional(),
+  /**
+   * Session UUID minted at SessionStart hook fire (24h TTL, rotates on
+   * subsequent SessionStart). Persisted to `.totem/ledger/.session-id`
+   * for cross-event correlation within a session. Per ADR-029 § Session
+   * Heuristic (explicit UUID supersedes the rolling-2h activity heuristic
+   * when present). Optional for backward-compat.
+   */
+  session_id: z.string().uuid().optional(),
+  /**
+   * Trace correlation ID per ADR-014 — links an orchestrator run to
+   * the MCP tool calls it triggered. Optional; populated by A.3.c
+   * end-to-end correlation propagation.
+   */
+  correlation_id: z.string().uuid().optional(),
+  /**
+   * Sub-type discriminator for activity events. Examples:
+   *   `mcp_call`  → 'search_knowledge' | 'describe_project' | ...
+   *   `hook_fire` → 'SessionStart' | 'PreToolUse' | 'pre-push' | ...
+   * Optional; meaningful only on activity events.
+   */
+  activity_name: z.string().trim().min(1).optional(),
 });
 
 export type LedgerEvent = z.infer<typeof LedgerEventSchema>;


### PR DESCRIPTION
## Summary

First lift of the A.3 telemetry sprint. Forward-only extension to `LedgerEventSchema` (`packages/core/src/ledger.ts`) to unlock the ADR-029 compliance metric.

- 4 new event types (`mcp_call`, `tool_call_first_significant`, `hook_fire`, `session_start`).
- 4 new optional fields: `agent_source` (claude/gemini/human; implements ADR-078 § Event Attribution), `session_id` (UUID), `correlation_id` (UUID per ADR-014), `activity_name` (sub-type discriminator).
- `ruleId` and `file` relaxed to optional at schema level; writer-side discipline still enforces required-by-type for `suppress` / `override` / `exemption`.
- Two consumer-side defensive guards: `ledger-analyzer.ts` (skip events without `ruleId`); `recurrence-stats.ts` (skip override events without `file`).
- Bundled doc-sync: `docs/wiki/trap-ledger.md` example had three pre-existing drifts (`type: "exception"` invalid; `source: "totem-context"` stale; prose claimed totem-context: directives log `override` events but code emits `suppress`).

## Design context

Design doc landed for cross-agent review at `mmnto-ai/totem-substrate:.handoff/_shared/2026-05-15-a3a-schema-extension-design.md` (commit `be8b0a2`). Three-stream consensus surface: `.handoff/_shared/2026-05-14-three-stream-claim-discipline.md` (consensus merge `db1ec72`). Cross-agent reviews dispatched at substrate `T0258Z` to strategy-Claude / strategy-Gemini / lc-Claude.

Two open questions still receiving cohort review (won't block merge per design-doc fallback):

- **OQ-1** — flat schema vs Zod `discriminatedUnion`. Lean: flat for A.3.a; promote to discriminated union in A.3.c.
- **OQ-2** — `session_id` source of truth (SessionStart hook generates UUID, persists to `.totem/ledger/.session-id`, 24h rotation).

## Backward compatibility

- Pre-A.3.a override events parse fine (all new fields optional).
- Post-A.3.a activity events read by pre-A.3.a code: silently dropped (`safeParse` fails on unknown enum value, line skipped). Acceptable — no corruption, only stale-tooling visibility loss. Cohort version bump after merge closes this naturally.

## Test plan

- [x] `packages/core/src/ledger.test.ts` — 23 tests total (was 10); 13 new tests covering each new event type, all `agent_source` values, UUID validation, empty-string rejection, pre-A.3.a forward-compat, append+read round-trip with mixed override + activity events sharing a `session_id`.
- [x] `pnpm --filter @mmnto/totem run test` — 74 files / 1876 tests pass.
- [x] `pnpm --filter @mmnto/cli run test` — 99 files / 2154 tests pass (after consumer-side defensive guards).
- [x] `pnpm run build` — typecheck clean across all 5 packages.
- [x] `pnpm exec totem lint` — PASS, 0 errors (3 warnings on `.min(1)` pattern; pre-existing rule fires even when `.trim().min(1)` is used — out-of-scope rule-tightening, not a blocker).
- [x] `pnpm exec totem review` — PASS, no findings.

## Out of scope (next sub-lifts in A.3 sprint)

- **A.3.b** — `totem doctor --compliance` reads this schema and computes the ADR-029 metric (~1 week).
- **A.3.c** — orchestrator → MCP `correlation_id` propagation (~1 week).
- **A.4.a / A.4.b** — PreToolUse soft-block + pre-push hard-block pair, per C-12 (ships alongside A.3.a).
- **ADR-078 surface amendment** — rename agent attribution from `source` → `agent_source` in § Decision 2; routed to strategy-Claude via substrate dispatch T0258Z. No code dependency in either direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)