### PR TITLE
feat(mcp+cli): Trap Ledger activity writers — MCP mcp_call + SessionStart session_start (A.3.a writers)

### DIFF
--- a/.changeset/ledger-writers-a3a.md
+++ b/.changeset/ledger-writers-a3a.md
@@ -1,0 +1,59 @@
+---
+'@mmnto/cli': minor
+'@mmnto/totem': minor
+'@mmnto/mcp': minor
+'@mmnto/pack-agent-security': minor
+'@mmnto/pack-rust-architecture': minor
+---
+
+feat(mcp+cli): Trap Ledger activity writers — MCP `mcp_call` + SessionStart `session_start` (A.3.a writers)
+
+Stacked on #1919 (A.3.a schema). Wires the two activity-event writers that the A.3.b compliance metric will read. Without these writers, the schema is inert — no events of the new types get produced.
+
+## Writers shipped
+
+**MCP `mcp_call` writer** (`packages/mcp/src/ledger-writer.ts`):
+
+- New `logMcpCall(activityName)` helper. Fire-and-forget; internal try/catch + outer `.catch()` defense-in-depth at call sites.
+- Wired into `packages/mcp/src/tools/search-knowledge.ts` — emits `{ type: 'mcp_call', activity_name: 'search_knowledge', session_id, source: 'bot' }` at handler entry. Reads `session_id` from `.totem/ledger/.session-id` if present (TTL 24h), omits when missing.
+- Other MCP tools (`describe_project`, `add_lesson`, `verify_execution`) intentionally NOT wired in this PR — `search_knowledge` is the only one ADR-029's compliance metric measures. Symmetric wiring deferred to A.3.c when broader observability lands.
+
+**SessionStart hook writer** (`packages/cli/src/commands/init-templates.ts`):
+
+- `CLAUDE_SESSION_START` template extended to mint a session UUID via `crypto.randomUUID()`, persist to `.totem/ledger/.session-id`, and append a `session_start` activity event to `events.ndjson` BEFORE the existing `totem describe` briefing.
+- Inline implementation (no `@mmnto/totem` import) — hook scripts run via `node` from project root before any package resolution, so they can't depend on the totem npm packages being installed.
+- Gemini SessionStart hook (`GEMINI_SESSION_START`) intentionally NOT updated in this PR. Symmetric Gemini parity deferred to a follow-on.
+
+## New core utilities (`packages/core/src/session-id.ts`)
+
+- `mintSessionId()` — wraps `crypto.randomUUID()`.
+- `writeSessionId(totemDir, sessionId)` — persists to `.totem/ledger/.session-id`. Fire-and-forget on I/O failure.
+- `readSessionId(totemDir, ttlHours?)` — reads + validates UUID shape + checks mtime against TTL (default 24h). Returns `undefined` for missing/expired/malformed files.
+
+## Tests
+
+- `packages/core/src/session-id.test.ts` — 10 tests covering mint uniqueness, write/read round-trip, malformed UUID rejection, TTL expiration (file backdating via `utimesSync`), custom TTL argument, trailing-whitespace tolerance.
+- `packages/mcp/src/ledger-writer.test.ts` — 5 tests covering event emission, session_id population/omission, getContext failure (must not throw), append-don't-overwrite.
+- `packages/mcp/src/tools/search-knowledge.test.ts` — 2 new integration tests verifying handler emits `mcp_call` with `activity_name: 'search_knowledge'`, including the dimension-mismatch error path (invocation, not success, is what ADR-029 measures).
+- `packages/cli/src/commands/init.test.ts` — 4 new tests covering the SessionStart template's session-id minting, persistence, ledger-event emission, and fire-and-forget error-handling.
+
+## Backward compatibility
+
+Same forward-only story as A.3.a schema:
+
+- Pre-writers Trap Ledgers don't contain `mcp_call` or `session_start` events — readers parse them fine when they appear post-upgrade.
+- SessionStart hook ledger-write block is in its own try/catch; if it fails (read-only filesystem, missing perms, etc.), the briefing path still runs.
+
+## ADR alignment
+
+- ADR-029 § Session Heuristic: explicit UUID supersedes the rolling-2h activity heuristic when `.session-id` is present.
+- ADR-078 § Event Attribution: `source: 'bot'` for both writers (emitter = MCP server / hook subsystem). `agent_source` left undefined; A.3.c populates it via orchestrator → MCP correlation propagation.
+- ADR-077 Smart Briefing: SessionStart hook already shipped (`installClaudeHooks` scaffolds the script); this PR only extends its body.
+
+## Out of scope (next sub-lifts)
+
+- **A.3.b** — `totem doctor --compliance` reads these events and computes the ADR-029 metric (~1 week).
+- **A.3.c** — orchestrator → MCP correlation_id propagation; populates `agent_source` (~1 week).
+- **A.4.a / A.4.b** — PreToolUse soft-block + pre-push hard-block (per C-12); reads `mcp_call` events to gate Write/Edit on `proposals/active/**`, `adr/**`, `research/**`.
+- **Gemini SessionStart writer** — symmetric pattern, deferred for parity sweep.
+- **Other MCP tools** (`describe_project`, `add_lesson`, `verify_execution`) — wire `logMcpCall` when needed for broader observability.

--- a/.changeset/ledger-writers-a3a.md
+++ b/.changeset/ledger-writers-a3a.md
@@ -47,7 +47,7 @@ Same forward-only story as A.3.a schema:
 ## ADR alignment
 
 - ADR-029 § Session Heuristic: explicit UUID supersedes the rolling-2h activity heuristic when `.session-id` is present.
-- ADR-078 § Event Attribution: `source: 'bot'` for both writers (emitter = MCP server / hook subsystem). `agent_source` left undefined; A.3.c populates it via orchestrator → MCP correlation propagation.
+- ADR-078 § Event Attribution: `source: 'bot'` for both writers (emitter = MCP server / hook subsystem). In this lift, `session_start` includes `agent_source: 'claude'` (the Claude hook template knows its vendor); MCP `mcp_call` agent attribution is deferred to A.3.c via orchestrator → MCP correlation propagation.
 - ADR-077 Smart Briefing: SessionStart hook already shipped (`installClaudeHooks` scaffolds the script); this PR only extends its body.
 
 ## Out of scope (next sub-lifts)

--- a/.changeset/ledger-writers-a3a.md
+++ b/.changeset/ledger-writers-a3a.md
@@ -32,10 +32,10 @@ Stacked on #1919 (A.3.a schema). Wires the two activity-event writers that the A
 
 ## Tests
 
-- `packages/core/src/session-id.test.ts` — 10 tests covering mint uniqueness, write/read round-trip, malformed UUID rejection, TTL expiration (file backdating via `utimesSync`), custom TTL argument, trailing-whitespace tolerance.
+- `packages/core/src/session-id.test.ts` — 15 tests covering mint uniqueness, write/read round-trip, malformed UUID rejection, TTL expiration (file backdating via `utimesSync`), custom TTL argument, trailing-whitespace tolerance, plus fs error class discrimination on read (ENOENT/EACCES/EPERM/EROFS swallow vs unexpected rethrow per Tenet 4).
 - `packages/mcp/src/ledger-writer.test.ts` — 5 tests covering event emission, session_id population/omission, getContext failure (must not throw), append-don't-overwrite.
 - `packages/mcp/src/tools/search-knowledge.test.ts` — 2 new integration tests verifying handler emits `mcp_call` with `activity_name: 'search_knowledge'`, including the dimension-mismatch error path (invocation, not success, is what ADR-029 measures).
-- `packages/cli/src/commands/init.test.ts` — 4 new tests covering the SessionStart template's session-id minting, persistence, ledger-event emission, and fire-and-forget error-handling.
+- `packages/cli/src/commands/init.test.ts` — 5 new tests covering the SessionStart template's session-id minting, persistence, ledger-event emission, agent_source stamping (Claude-specific), and fire-and-forget error-handling.
 
 ## Backward compatibility
 

--- a/.changeset/ledger-writers-a3a.md
+++ b/.changeset/ledger-writers-a3a.md
@@ -27,7 +27,7 @@ Stacked on #1919 (A.3.a schema). Wires the two activity-event writers that the A
 ## New core utilities (`packages/core/src/session-id.ts`)
 
 - `mintSessionId()` — wraps `crypto.randomUUID()`.
-- `writeSessionId(totemDir, sessionId)` — persists to `.totem/ledger/.session-id`. Fire-and-forget on I/O failure.
+- `writeSessionId(totemDir, sessionId)` — persists to `.totem/ledger/.session-id`. Swallows expected fs error classes (ENOENT/EACCES/EPERM/EROFS) via the optional `onWarn` callback and rethrows unexpected error classes per Tenet 4 Fail Loud.
 - `readSessionId(totemDir, ttlHours?)` — reads + validates UUID shape + checks mtime against TTL (default 24h). Returns `undefined` for missing/expired/malformed files.
 
 ## Tests

--- a/docs/wiki/trap-ledger.md
+++ b/docs/wiki/trap-ledger.md
@@ -22,7 +22,7 @@ The Ledger captures two semantic families of events.
 
 **Activity events** (one per agent interaction, A.3.a onwards):
 
-- `mcp_call` — MCP tool invocation (e.g., `search_knowledge`); identified by `activity_name`. Emitted by the MCP server when a tool fires.
+- `mcp_call` — MCP tool invocation (e.g., `search_knowledge`); identified by `activity_name`. Emitted by the MCP server when a tool fires (`source: "bot"` now; MCP `agent_source` attribution deferred to A.3.c).
 - `tool_call_first_significant` — first non-Read/Grep/Glob orchestrator tool call in the session. (Writer ships in A.3.b.)
 - `hook_fire` — lifecycle hook executed (e.g., `SessionStart`, `PreToolUse`, `pre-push`). (Writer ships in A.4.a.)
 - `session_start` — SessionStart hook fired; new `session_id` minted to `.totem/ledger/.session-id`. Emitted by the Claude SessionStart hook script scaffolded by `totem init` (Gemini writer deferred).

--- a/docs/wiki/trap-ledger.md
+++ b/docs/wiki/trap-ledger.md
@@ -22,10 +22,10 @@ The Ledger captures two semantic families of events.
 
 **Activity events** (one per agent interaction, A.3.a onwards):
 
-- `mcp_call` — MCP tool invocation (e.g., `search_knowledge`); identified by `activity_name`
-- `tool_call_first_significant` — first non-Read/Grep/Glob orchestrator tool call in the session
-- `hook_fire` — lifecycle hook executed (e.g., `SessionStart`, `PreToolUse`, `pre-push`)
-- `session_start` — SessionStart hook fired; new `session_id` minted
+- `mcp_call` — MCP tool invocation (e.g., `search_knowledge`); identified by `activity_name`. Emitted by the MCP server when a tool fires.
+- `tool_call_first_significant` — first non-Read/Grep/Glob orchestrator tool call in the session. (Writer ships in A.3.b.)
+- `hook_fire` — lifecycle hook executed (e.g., `SessionStart`, `PreToolUse`, `pre-push`). (Writer ships in A.4.a.)
+- `session_start` — SessionStart hook fired; new `session_id` minted to `.totem/ledger/.session-id`. Emitted by the Claude / Gemini SessionStart hook scripts scaffolded by `totem init`.
 
 ### Event Schema
 

--- a/docs/wiki/trap-ledger.md
+++ b/docs/wiki/trap-ledger.md
@@ -52,11 +52,12 @@ The NDJSON records contain high-fidelity context about the friction event.
   "timestamp": "2026-05-15T03:00:00.000Z",
   "type": "mcp_call",
   "source": "bot",
-  "agent_source": "claude",
   "session_id": "550e8400-e29b-41d4-a716-446655440000",
   "activity_name": "search_knowledge"
 }
 ```
+
+(MCP `agent_source` attribution lands in A.3.c via orchestrator → MCP correlation propagation; `session_start` events emitted by the Claude hook DO carry `agent_source: "claude"` today.)
 
 The canonical schema (with field-level descriptions, optionality, and discriminator semantics) lives in `packages/core/src/ledger.ts` (`LedgerEventSchema`). Two orthogonal axes worth calling out:
 

--- a/docs/wiki/trap-ledger.md
+++ b/docs/wiki/trap-ledger.md
@@ -25,7 +25,7 @@ The Ledger captures two semantic families of events.
 - `mcp_call` — MCP tool invocation (e.g., `search_knowledge`); identified by `activity_name`. Emitted by the MCP server when a tool fires.
 - `tool_call_first_significant` — first non-Read/Grep/Glob orchestrator tool call in the session. (Writer ships in A.3.b.)
 - `hook_fire` — lifecycle hook executed (e.g., `SessionStart`, `PreToolUse`, `pre-push`). (Writer ships in A.4.a.)
-- `session_start` — SessionStart hook fired; new `session_id` minted to `.totem/ledger/.session-id`. Emitted by the Claude / Gemini SessionStart hook scripts scaffolded by `totem init`.
+- `session_start` — SessionStart hook fired; new `session_id` minted to `.totem/ledger/.session-id`. Emitted by the Claude SessionStart hook script scaffolded by `totem init` (Gemini writer deferred).
 
 ### Event Schema
 

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -363,7 +363,7 @@ try {
   // (CR R1 catch — empty catch suppresses all signal). stderr (not stdout) so
   // the briefing path remains clean for Claude's prompt context.
   process.stderr.write(
-    '[Totem] Session-start telemetry unavailable (non-fatal): ' +
+    '[SessionStart] Session-start telemetry unavailable (non-fatal): ' +
       (err instanceof Error ? err.message : String(err)) +
       '\\n',
   );

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -330,10 +330,46 @@ export const CLAUDE_SESSION_START = `// [totem] auto-generated — Claude Code S
 // Mirrors \`.gemini/hooks/SessionStart.js\`. \`.cjs\` extension because
 // package.json may have "type": "module" — Claude Code execs hooks via
 // plain \`node\`, which would otherwise treat \`.js\` as ESM.
+//
+// A.3.a: mints a session UUID, persists to .totem/ledger/.session-id,
+// and appends a \`session_start\` event to .totem/ledger/events.ndjson
+// BEFORE running \`totem describe\`. Subsequent MCP calls within the
+// session correlate via session_id (ADR-029 § Session Heuristic).
+// Fire-and-forget: any ledger failure must NOT block the briefing.
 const { spawnSync } = require('child_process');
-const { existsSync } = require('fs');
+const { existsSync, mkdirSync, writeFileSync, appendFileSync } = require('fs');
+const { randomUUID } = require('crypto');
 const { join } = require('path');
 
+// ─── A.3.a: mint session ID + log session_start event ──────────
+try {
+  const ledgerDir = join(process.cwd(), '.totem', 'ledger');
+  mkdirSync(ledgerDir, { recursive: true });
+  const sessionId = randomUUID();
+  writeFileSync(join(ledgerDir, '.session-id'), sessionId, 'utf-8');
+  const event = {
+    timestamp: new Date().toISOString(),
+    type: 'session_start',
+    activity_name: 'SessionStart',
+    source: 'bot',
+    agent_source: 'claude',
+    justification: '',
+    session_id: sessionId,
+  };
+  appendFileSync(join(ledgerDir, 'events.ndjson'), JSON.stringify(event) + '\\n', 'utf-8');
+} catch (err) {
+  // Fire-and-forget; ledger failures must not block the briefing. A lightweight
+  // stderr breadcrumb makes hook misconfigurations diagnosable in consumer repos
+  // (CR R1 catch — empty catch suppresses all signal). stderr (not stdout) so
+  // the briefing path remains clean for Claude's prompt context.
+  process.stderr.write(
+    '[Totem] Session-start telemetry unavailable (non-fatal): ' +
+      (err instanceof Error ? err.message : String(err)) +
+      '\\n',
+  );
+}
+
+// ─── totem describe briefing (existing behavior) ────────────────
 try {
   const cliPath = join(process.cwd(), 'node_modules', '@mmnto', 'cli', 'dist', 'index.js');
   if (existsSync(cliPath)) {

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1415,6 +1415,42 @@ describe('CLAUDE_SESSION_START template', () => {
     expect(CLAUDE_SESSION_START).toContain("'index.js'");
   });
 
+  // A.3.a — SessionStart hook mints session_id + emits session_start ledger event
+  it('mints a session_id via crypto.randomUUID', () => {
+    expect(CLAUDE_SESSION_START).toContain('randomUUID');
+    expect(CLAUDE_SESSION_START).toContain("require('crypto')");
+  });
+
+  it('persists session_id to .totem/ledger/.session-id', () => {
+    expect(CLAUDE_SESSION_START).toContain(".totem'");
+    expect(CLAUDE_SESSION_START).toContain("'ledger'");
+    expect(CLAUDE_SESSION_START).toContain(".session-id'");
+  });
+
+  it('appends a session_start event to events.ndjson', () => {
+    expect(CLAUDE_SESSION_START).toContain("type: 'session_start'");
+    expect(CLAUDE_SESSION_START).toContain("activity_name: 'SessionStart'");
+    expect(CLAUDE_SESSION_START).toContain('events.ndjson');
+    expect(CLAUDE_SESSION_START).toContain('appendFileSync');
+  });
+
+  it('stamps agent_source: claude on the Claude-specific hook', () => {
+    // Claude hook knows its origin — populating agent_source here is the
+    // minimal-coupling alternative to waiting for A.3.c correlation
+    // propagation.
+    expect(CLAUDE_SESSION_START).toContain("agent_source: 'claude'");
+  });
+
+  it('keeps the session-start writer fire-and-forget (no rethrow)', () => {
+    // The ledger-write block must catch its own errors and NOT block the
+    // briefing path that follows. Per Tenet 4 + lesson-b1bae311 (sensors,
+    // not actuators). CR R1 (#1920) replaced the empty catch with a stderr
+    // breadcrumb — confirm the breadcrumb shape lands in the template.
+    expect(CLAUDE_SESSION_START).toContain('catch (err)');
+    expect(CLAUDE_SESSION_START).toContain('process.stderr.write');
+    expect(CLAUDE_SESSION_START).toContain('Session-start telemetry unavailable');
+  });
+
   it('does NOT propagate strategy-repo-specific orientation pointers', () => {
     // OQ 2 disposition: keep the fallback generic. The strategy reference
     // mentions README.md, design-tenets.md, .journal/strategy/ — none of

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -33,7 +33,9 @@ export type TotemErrorCode =
   | 'UPGRADE_CLOUD_UNSUPPORTED'
   | 'STALE_MANIFEST'
   | 'FLAG_CONFLICT'
-  | 'HOOKS_LOAD_FAILED';
+  | 'HOOKS_LOAD_FAILED'
+  | 'SESSION_ID_WRITE_FAILED'
+  | 'SESSION_ID_READ_FAILED';
 
 export class TotemError extends Error {
   readonly code: TotemErrorCode;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -432,6 +432,9 @@ export { CustomSecretSchema, loadCustomSecrets, SecretsFileSchema } from './secr
 export type { LedgerEvent } from './ledger.js';
 export { appendLedgerEvent, LedgerEventSchema, readLedgerEvents } from './ledger.js';
 
+// Session ID — A.3.a SessionStart hook + MCP correlation
+export { mintSessionId, readSessionId, writeSessionId } from './session-id.js';
+
 // Pack rule merge primitive (ADR-085 + ADR-089, mmnto-ai/totem#1485)
 export type { ImmutableOverrideBlock, MergeRulesResult } from './pack-merge.js';
 export { mergeRules } from './pack-merge.js';

--- a/packages/core/src/session-id.test.ts
+++ b/packages/core/src/session-id.test.ts
@@ -11,6 +11,7 @@ vi.mock('node:fs', async () => {
 
 import * as fs from 'node:fs';
 
+import { TotemError } from './errors.js';
 import { mintSessionId, readSessionId, writeSessionId } from './session-id.js';
 import { cleanTmpDir } from './test-utils.js';
 
@@ -106,11 +107,21 @@ describe('readSessionId', () => {
   it('rethrows on unexpected error classes (Tenet 4 Fail Loud)', () => {
     // Force statSync to throw a non-fs error class — simulates an unexpected
     // failure mode the writer should propagate rather than silently swallow.
+    // Per styleguide line 120, the rethrow wraps in TotemError with the
+    // original error preserved via .cause (chain-preserving propagation).
     const spy = vi.spyOn(fs, 'statSync').mockImplementation(() => {
       throw new TypeError('unexpected non-fs error');
     });
     try {
-      expect(() => readSessionId(tmpDir)).toThrow(TypeError);
+      let caught: unknown;
+      try {
+        readSessionId(tmpDir);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(TotemError);
+      expect((caught as TotemError).code).toBe('SESSION_ID_READ_FAILED');
+      expect((caught as TotemError).cause).toBeInstanceOf(TypeError);
     } finally {
       spy.mockRestore();
     }
@@ -135,8 +146,18 @@ describe('readSessionId', () => {
     });
     try {
       // String values have no `.code` property; with the defensive type guard
-      // the function rethrows rather than crashing on property access.
-      expect(() => readSessionId(tmpDir)).toThrow();
+      // the function rethrows rather than crashing on property access. The
+      // rethrow is wrapped in TotemError with the original string preserved
+      // via .cause.
+      let caught: unknown;
+      try {
+        readSessionId(tmpDir);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(TotemError);
+      expect((caught as TotemError).code).toBe('SESSION_ID_READ_FAILED');
+      expect((caught as TotemError).cause).toBe('string-thrown-not-an-error');
     } finally {
       spy.mockRestore();
     }
@@ -145,11 +166,21 @@ describe('readSessionId', () => {
 
 describe('writeSessionId fail-loud behavior', () => {
   it('rethrows on unexpected error classes (Tenet 4 Fail Loud)', () => {
+    // Per styleguide line 120, the rethrow wraps in TotemError with the
+    // original error preserved via .cause (chain-preserving propagation).
     const spy = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {
       throw new TypeError('unexpected non-fs error');
     });
     try {
-      expect(() => writeSessionId(tmpDir, mintSessionId())).toThrow(TypeError);
+      let caught: unknown;
+      try {
+        writeSessionId(tmpDir, mintSessionId());
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(TotemError);
+      expect((caught as TotemError).code).toBe('SESSION_ID_WRITE_FAILED');
+      expect((caught as TotemError).cause).toBeInstanceOf(TypeError);
     } finally {
       spy.mockRestore();
     }

--- a/packages/core/src/session-id.test.ts
+++ b/packages/core/src/session-id.test.ts
@@ -27,7 +27,7 @@ afterEach(() => {
 describe('mintSessionId', () => {
   it('returns a v4 UUID string', () => {
     const id = mintSessionId();
-    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i);
   });
 
   it('returns distinct values across calls', () => {

--- a/packages/core/src/session-id.test.ts
+++ b/packages/core/src/session-id.test.ts
@@ -1,0 +1,173 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock node:fs so spyOn works in ESM — same pattern as test-utils.test.ts.
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return { ...actual, default: actual };
+});
+
+import * as fs from 'node:fs';
+
+import { mintSessionId, readSessionId, writeSessionId } from './session-id.js';
+import { cleanTmpDir } from './test-utils.js';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-session-'));
+});
+
+afterEach(() => {
+  cleanTmpDir(tmpDir);
+});
+
+describe('mintSessionId', () => {
+  it('returns a v4 UUID string', () => {
+    const id = mintSessionId();
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i);
+  });
+
+  it('returns distinct values across calls', () => {
+    const a = mintSessionId();
+    const b = mintSessionId();
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('writeSessionId', () => {
+  it('creates ledger directory and persists the UUID', () => {
+    const id = mintSessionId();
+    writeSessionId(tmpDir, id);
+    const persisted = fs.readFileSync(path.join(tmpDir, 'ledger', '.session-id'), 'utf-8');
+    expect(persisted).toBe(id);
+  });
+
+  it('overwrites an existing session-id file', () => {
+    writeSessionId(tmpDir, mintSessionId());
+    const second = mintSessionId();
+    writeSessionId(tmpDir, second);
+    const persisted = fs.readFileSync(path.join(tmpDir, 'ledger', '.session-id'), 'utf-8');
+    expect(persisted).toBe(second);
+  });
+});
+
+describe('readSessionId', () => {
+  it('returns undefined when the file does not exist', () => {
+    expect(readSessionId(tmpDir)).toBeUndefined();
+  });
+
+  it('returns the persisted UUID', () => {
+    const id = mintSessionId();
+    writeSessionId(tmpDir, id);
+    expect(readSessionId(tmpDir)).toBe(id);
+  });
+
+  it('returns undefined when the file contents are not a UUID', () => {
+    const ledgerDir = path.join(tmpDir, 'ledger');
+    fs.mkdirSync(ledgerDir, { recursive: true });
+    fs.writeFileSync(path.join(ledgerDir, '.session-id'), 'not-a-uuid', 'utf-8');
+    expect(readSessionId(tmpDir)).toBeUndefined();
+  });
+
+  it('returns undefined when the file is older than the TTL', () => {
+    const id = mintSessionId();
+    writeSessionId(tmpDir, id);
+    const filePath = path.join(tmpDir, 'ledger', '.session-id');
+    // Backdate the file to 25 hours ago (1 hour past default TTL).
+    const past = new Date(Date.now() - 25 * 60 * 60 * 1000);
+    fs.utimesSync(filePath, past, past);
+    expect(readSessionId(tmpDir)).toBeUndefined();
+  });
+
+  it('honors a custom ttlHours argument', () => {
+    const id = mintSessionId();
+    writeSessionId(tmpDir, id);
+    const filePath = path.join(tmpDir, 'ledger', '.session-id');
+    // Backdate to 30 minutes ago.
+    const past = new Date(Date.now() - 30 * 60 * 1000);
+    fs.utimesSync(filePath, past, past);
+    // Within 1h TTL: returns the UUID.
+    expect(readSessionId(tmpDir, 1)).toBe(id);
+    // Within 15-minute TTL: expired, returns undefined.
+    expect(readSessionId(tmpDir, 0.25)).toBeUndefined();
+  });
+
+  it('trims trailing whitespace from the persisted UUID', () => {
+    const ledgerDir = path.join(tmpDir, 'ledger');
+    fs.mkdirSync(ledgerDir, { recursive: true });
+    const id = mintSessionId();
+    fs.writeFileSync(path.join(ledgerDir, '.session-id'), id + '\n', 'utf-8');
+    expect(readSessionId(tmpDir)).toBe(id);
+  });
+
+  it('rethrows on unexpected error classes (Tenet 4 Fail Loud)', () => {
+    // Force statSync to throw a non-fs error class — simulates an unexpected
+    // failure mode the writer should propagate rather than silently swallow.
+    const spy = vi.spyOn(fs, 'statSync').mockImplementation(() => {
+      throw new TypeError('unexpected non-fs error');
+    });
+    try {
+      expect(() => readSessionId(tmpDir)).toThrow(TypeError);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('returns undefined on EACCES (known fs failure class)', () => {
+    const spy = vi.spyOn(fs, 'statSync').mockImplementation(() => {
+      const err = new Error('permission denied') as NodeJS.ErrnoException;
+      err.code = 'EACCES';
+      throw err;
+    });
+    try {
+      expect(readSessionId(tmpDir)).toBeUndefined();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('rethrows when caught value is not an object (defensive type guard)', () => {
+    const spy = vi.spyOn(fs, 'statSync').mockImplementation(() => {
+      throw 'string-thrown-not-an-error';
+    });
+    try {
+      // String values have no `.code` property; with the defensive type guard
+      // the function rethrows rather than crashing on property access.
+      expect(() => readSessionId(tmpDir)).toThrow();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});
+
+describe('writeSessionId fail-loud behavior', () => {
+  it('rethrows on unexpected error classes (Tenet 4 Fail Loud)', () => {
+    const spy = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {
+      throw new TypeError('unexpected non-fs error');
+    });
+    try {
+      expect(() => writeSessionId(tmpDir, mintSessionId())).toThrow(TypeError);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('invokes onWarn and returns silently on EACCES (known fs failure class)', () => {
+    const onWarn = vi.fn();
+    const spy = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {
+      const err = new Error('permission denied') as NodeJS.ErrnoException;
+      err.code = 'EACCES';
+      throw err;
+    });
+    try {
+      writeSessionId(tmpDir, mintSessionId(), onWarn);
+      expect(onWarn).toHaveBeenCalledOnce();
+      expect(onWarn.mock.calls[0]![0]).toContain('Session-ID write failed');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/packages/core/src/session-id.ts
+++ b/packages/core/src/session-id.ts
@@ -12,6 +12,8 @@ import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { TotemError } from './errors.js';
+
 const SESSION_ID_FILE = '.session-id';
 const LEDGER_DIR = 'ledger';
 const DEFAULT_TTL_HOURS = 24;
@@ -44,8 +46,14 @@ export function writeSessionId(
       onWarn?.(`Session-ID write failed: ${msg}`);
       return;
     }
-    // Unexpected error class — propagate so Tenet 4 (Fail Loud) catches drift.
-    throw err;
+    // Unexpected error class — wrap with TotemError per styleguide cause-chains
+    // rule (line 120). Tenet 4 Fail Loud satisfied via .cause chain.
+    throw new TotemError(
+      'SESSION_ID_WRITE_FAILED',
+      'Unexpected error writing session ID',
+      'Check filesystem permissions for the .totem/ledger directory.',
+      err,
+    );
   }
 }
 
@@ -90,7 +98,13 @@ export function readSessionId(totemDir: string, ttlHours = DEFAULT_TTL_HOURS): s
     if (code === 'ENOENT' || code === 'EACCES' || code === 'EPERM' || code === 'EROFS') {
       return undefined;
     }
-    // Unexpected error class — propagate so Tenet 4 (Fail Loud) catches drift.
-    throw err;
+    // Unexpected error class — wrap with TotemError per styleguide cause-chains
+    // rule (line 120). Tenet 4 Fail Loud satisfied via .cause chain.
+    throw new TotemError(
+      'SESSION_ID_READ_FAILED',
+      'Unexpected error reading session ID',
+      'Check filesystem permissions for the .totem/ledger/.session-id file.',
+      err,
+    );
   }
 }

--- a/packages/core/src/session-id.ts
+++ b/packages/core/src/session-id.ts
@@ -1,0 +1,96 @@
+/**
+ * Session ID utilities for the Trap Ledger A.3.a schema extension.
+ *
+ * The SessionStart hook mints a UUID and persists it to `.totem/ledger/.session-id`.
+ * Subsequent MCP calls and ledger writes within the same session correlate via this
+ * UUID. Per ADR-029 § Session Heuristic, the explicit UUID supersedes the rolling-2h
+ * activity-based heuristic when present; the TTL fallback handles long-running
+ * sessions exceeding 24h or sessions that bypass the SessionStart hook.
+ */
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const SESSION_ID_FILE = '.session-id';
+const LEDGER_DIR = 'ledger';
+const DEFAULT_TTL_HOURS = 24;
+
+/** Mint a fresh session UUID. */
+export function mintSessionId(): string {
+  return crypto.randomUUID();
+}
+
+/**
+ * Persist a session ID to `<totemDir>/ledger/.session-id`.
+ * Creates the ledger directory if it doesn't exist. Fire-and-forget on I/O failure.
+ */
+export function writeSessionId(
+  totemDir: string,
+  sessionId: string,
+  onWarn?: (msg: string) => void,
+): void {
+  try {
+    const ledgerDir = path.join(totemDir, LEDGER_DIR);
+    fs.mkdirSync(ledgerDir, { recursive: true });
+    fs.writeFileSync(path.join(ledgerDir, SESSION_ID_FILE), sessionId, 'utf-8');
+  } catch (err) {
+    const code =
+      typeof err === 'object' && err !== null ? (err as NodeJS.ErrnoException).code : undefined;
+    const msg = err instanceof Error ? err.message : String(err);
+    // Known fs failure classes are fire-and-forget — SessionStart must not
+    // block on telemetry write (sensors-not-actuators per lesson-b1bae311).
+    if (code === 'ENOENT' || code === 'EACCES' || code === 'EPERM' || code === 'EROFS') {
+      onWarn?.(`Session-ID write failed: ${msg}`);
+      return;
+    }
+    // Unexpected error class — propagate so Tenet 4 (Fail Loud) catches drift.
+    throw err;
+  }
+}
+
+/**
+ * Read the current session ID from `<totemDir>/ledger/.session-id`.
+ *
+ * Returns the persisted UUID when present AND within the TTL window. Returns
+ * undefined when the file is missing, malformed, or expired (file older than
+ * `ttlHours` per Q-9 — fallback for long sessions or hookless agents).
+ *
+ * The TTL fallback uses file mtime; sessions exceeding the window are treated
+ * as "missing" so callers can defensively decide whether to rotate.
+ *
+ * Race-condition note (strategy-Claude T0345Z): if a ledger writer reads this
+ * file mid-SessionStart-hook rotation, it will stamp the event with the prior
+ * session UUID. This is intentional and NOT a bug — the event's timestamp
+ * reflects when it actually fired, and the ADR-029 compliance metric considers
+ * it part of the prior session (correctly, per its temporal semantics). Future
+ * readers tempted to "fix" this race by guarding rotation with a lockfile
+ * should re-read this doc-comment and the metric semantics before changing.
+ */
+export function readSessionId(totemDir: string, ttlHours = DEFAULT_TTL_HOURS): string | undefined {
+  const filePath = path.join(totemDir, LEDGER_DIR, SESSION_ID_FILE);
+  try {
+    const stat = fs.statSync(filePath);
+    const ageMs = Date.now() - stat.mtimeMs;
+    if (ageMs > ttlHours * 60 * 60 * 1000) return undefined;
+    const contents = fs.readFileSync(filePath, 'utf-8').trim();
+    // Validate UUID shape — defensive against partial writes or hand-edits.
+    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(contents)) {
+      return undefined;
+    }
+    return contents;
+  } catch (err) {
+    const code =
+      typeof err === 'object' && err !== null ? (err as NodeJS.ErrnoException).code : undefined;
+    // Missing/unreadable .session-id is a normal state (pre-hook session,
+    // hookless agent, stale file outside TTL). Treat as "no session ID
+    // available" — same downstream behavior as the TTL-expired branch.
+    // EPERM + EROFS added for parity with writeSessionId's fs-failure-class
+    // discrimination (CR + GCA Round-1 catch).
+    if (code === 'ENOENT' || code === 'EACCES' || code === 'EPERM' || code === 'EROFS') {
+      return undefined;
+    }
+    // Unexpected error class — propagate so Tenet 4 (Fail Loud) catches drift.
+    throw err;
+  }
+}

--- a/packages/mcp/src/ledger-writer.test.ts
+++ b/packages/mcp/src/ledger-writer.test.ts
@@ -1,0 +1,106 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-mcp-writer-'));
+  vi.resetModules();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function mockContext(): void {
+  // Mock getContext to return our tmp project root + minimal config.
+  vi.doMock('./context.js', () => ({
+    getContext: async () => ({
+      projectRoot: tmpDir,
+      config: { totemDir: '.totem' },
+    }),
+  }));
+}
+
+describe('logMcpCall', () => {
+  it('appends an mcp_call event to events.ndjson with the activity_name', async () => {
+    mockContext();
+    const { logMcpCall } = await import('./ledger-writer.js');
+    await logMcpCall('search_knowledge');
+
+    const ledgerPath = path.join(tmpDir, '.totem', 'ledger', 'events.ndjson');
+    expect(fs.existsSync(ledgerPath)).toBe(true);
+
+    const lines = fs
+      .readFileSync(ledgerPath, 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim());
+    expect(lines).toHaveLength(1);
+
+    const parsed = JSON.parse(lines[0]!);
+    expect(parsed.type).toBe('mcp_call');
+    expect(parsed.activity_name).toBe('search_knowledge');
+    expect(parsed.source).toBe('bot');
+    expect(parsed.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+  });
+
+  it('includes session_id when .session-id is present and within TTL', async () => {
+    const sessionId = '550e8400-e29b-41d4-a716-446655440000';
+    const ledgerDir = path.join(tmpDir, '.totem', 'ledger');
+    fs.mkdirSync(ledgerDir, { recursive: true });
+    fs.writeFileSync(path.join(ledgerDir, '.session-id'), sessionId, 'utf-8');
+
+    mockContext();
+    const { logMcpCall } = await import('./ledger-writer.js');
+    await logMcpCall('search_knowledge');
+
+    const lines = fs
+      .readFileSync(path.join(ledgerDir, 'events.ndjson'), 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim());
+    const parsed = JSON.parse(lines[0]!);
+    expect(parsed.session_id).toBe(sessionId);
+  });
+
+  it('omits session_id when .session-id is missing', async () => {
+    mockContext();
+    const { logMcpCall } = await import('./ledger-writer.js');
+    await logMcpCall('search_knowledge');
+
+    const lines = fs
+      .readFileSync(path.join(tmpDir, '.totem', 'ledger', 'events.ndjson'), 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim());
+    const parsed = JSON.parse(lines[0]!);
+    expect(parsed.session_id).toBeUndefined();
+  });
+
+  it('does not throw when getContext fails', async () => {
+    vi.doMock('./context.js', () => ({
+      getContext: async () => {
+        throw new Error('context load failed');
+      },
+    }));
+    const { logMcpCall } = await import('./ledger-writer.js');
+    // Must not throw — telemetry is fire-and-forget.
+    await expect(logMcpCall('search_knowledge')).resolves.toBeUndefined();
+  });
+
+  it('appends a second event without overwriting the first', async () => {
+    mockContext();
+    const { logMcpCall } = await import('./ledger-writer.js');
+    await logMcpCall('search_knowledge');
+    await logMcpCall('describe_project');
+
+    const lines = fs
+      .readFileSync(path.join(tmpDir, '.totem', 'ledger', 'events.ndjson'), 'utf-8')
+      .split('\n')
+      .filter((l) => l.trim());
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]!).activity_name).toBe('search_knowledge');
+    expect(JSON.parse(lines[1]!).activity_name).toBe('describe_project');
+  });
+});

--- a/packages/mcp/src/ledger-writer.ts
+++ b/packages/mcp/src/ledger-writer.ts
@@ -1,0 +1,63 @@
+/**
+ * MCP-side Trap Ledger writer for activity events (A.3.a).
+ *
+ * Emits `mcp_call` events with `activity_name` discriminator and `session_id`
+ * correlation when MCP tools fire. Reads the session ID from
+ * `.totem/ledger/.session-id` (written by the SessionStart hook); when no
+ * session ID is present, the event is still emitted without one — the
+ * compliance metric (A.3.b) will treat hookless sessions via the rolling-2h
+ * fallback per ADR-029 § Session Heuristic.
+ *
+ * `agent_source` is intentionally left undefined here — the MCP server does
+ * not currently know which orchestrator is calling. A.3.c (correlation IDs
+ * end-to-end) wires the orchestrator → MCP attribution propagation.
+ *
+ * All writes are fire-and-forget: a ledger failure must NEVER break the tool
+ * call. Telemetry is a sensor, not an actuator (lesson-b1bae311).
+ */
+
+import * as path from 'node:path';
+
+import type { LedgerEvent } from '@mmnto/totem';
+import { appendLedgerEvent, readSessionId } from '@mmnto/totem';
+
+import { getContext } from './context.js';
+
+/**
+ * Emit a single `mcp_call` ledger event for the given activity.
+ *
+ * Fire-and-forget on any internal failure (config load, fs write, etc.) —
+ * production tool calls must not fail because telemetry could not be written.
+ *
+ * @param activityName Discriminator within the `mcp_call` family
+ *   (`search_knowledge`, `describe_project`, `add_lesson`, `verify_execution`).
+ */
+export async function logMcpCall(activityName: string): Promise<void> {
+  // A ledger write failure must NEVER break the MCP tool call. Telemetry is
+  // a sensor (lesson-b1bae311); failure to record an event corrupts
+  // compliance metrics, not the tool call's downstream behavior. The outer
+  // .catch() at the call site provides defense-in-depth against any
+  // synchronous throw between awaits.
+  // totem-context: fire-and-forget telemetry; failure must not propagate
+  try {
+    const { projectRoot, config } = await getContext();
+    const totemDir = path.join(projectRoot, config.totemDir);
+    const sessionId = readSessionId(totemDir);
+
+    const event: LedgerEvent = {
+      timestamp: new Date().toISOString(),
+      type: 'mcp_call',
+      activity_name: activityName,
+      source: 'bot',
+      justification: '',
+      ...(sessionId !== undefined && { session_id: sessionId }),
+    };
+
+    appendLedgerEvent(totemDir, event);
+    // totem-context: fire-and-forget telemetry; failure must not propagate
+  } catch (_err) {
+    // intentional swallow — telemetry is a sensor (lesson-b1bae311),
+    // failure to record an mcp_call event must not crash the MCP server.
+    void _err;
+  }
+}

--- a/packages/mcp/src/ledger-writer.ts
+++ b/packages/mcp/src/ledger-writer.ts
@@ -55,9 +55,9 @@ export async function logMcpCall(activityName: string): Promise<void> {
 
     appendLedgerEvent(totemDir, event);
     // totem-context: fire-and-forget telemetry; failure must not propagate
-  } catch (_err) {
+  } catch (err) {
     // intentional swallow — telemetry is a sensor (lesson-b1bae311),
     // failure to record an mcp_call event must not crash the MCP server.
-    void _err;
+    void err;
   }
 }

--- a/packages/mcp/src/tools/search-knowledge.test.ts
+++ b/packages/mcp/src/tools/search-knowledge.test.ts
@@ -59,6 +59,14 @@ interface MockLinkedStore {
 let mockLinkedStores: Map<string, MockLinkedStore> = new Map();
 let mockLinkedStoreInitErrors: Map<string, string> = new Map();
 
+/**
+ * A.3.a — spy on the Trap Ledger writer to verify the handler emits an
+ * `mcp_call` activity event. The real implementation is exercised in
+ * `ledger-writer.test.ts`; the search-knowledge integration test just
+ * verifies the call site fires with the correct activity_name.
+ */
+let mockLogMcpCall: ReturnType<typeof vi.fn>;
+
 vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
   McpServer: class {},
 }));
@@ -143,6 +151,10 @@ vi.mock('../search-log.js', () => ({
   setLogDir: vi.fn(),
 }));
 
+vi.mock('../ledger-writer.js', () => ({
+  logMcpCall: vi.fn(async () => {}),
+}));
+
 // ---------------------------------------------------------------------------
 // Imports (after mocks are in place)
 // ---------------------------------------------------------------------------
@@ -184,6 +196,7 @@ describe('search_knowledge', () => {
     mockGetContextFailuresRemaining = 0;
     mockLinkedStores = new Map();
     mockLinkedStoreInitErrors = new Map();
+    mockLogMcpCall = vi.fn(async () => {});
 
     // Reset modules to clear the firstHealthCheckDone flag
     vi.resetModules();
@@ -268,7 +281,33 @@ describe('search_knowledge', () => {
       setLogDir: vi.fn(),
     }));
 
+    vi.doMock('../ledger-writer.js', () => ({
+      logMcpCall: mockLogMcpCall,
+    }));
+
     handle = await setupFresh();
+  });
+
+  // --- A.3.a — Trap Ledger writer wiring ---
+
+  it('emits an mcp_call activity event with activity_name=search_knowledge (A.3.a)', async () => {
+    mockSearchResults = [];
+    await handle({ query: 'test' });
+    expect(mockLogMcpCall).toHaveBeenCalledWith('search_knowledge');
+  });
+
+  it('emits the mcp_call event even when the search returns an error', async () => {
+    // Dimension mismatch path returns isError without throwing; mcp_call
+    // should still fire — invocation, not success, is what ADR-029 measures.
+    mockHealthCheckResult = {
+      healthy: false,
+      dimensionMatch: false,
+      storedDimensions: 384,
+      expectedDimensions: 1536,
+      issues: [],
+    };
+    await handle({ query: 'test' });
+    expect(mockLogMcpCall).toHaveBeenCalledWith('search_knowledge');
   });
 
   // --- Successful search returning results ---

--- a/packages/mcp/src/tools/search-knowledge.ts
+++ b/packages/mcp/src/tools/search-knowledge.ts
@@ -614,8 +614,8 @@ export function registerSearchKnowledge(server: McpServer): void {
       // logMcpCall has its own internal try/catch, but defense-in-depth with
       // .catch() guards against any unhandledRejection if internals ever
       // throw synchronously between awaits.
-      logMcpCall('search_knowledge').catch(() => {
-        /* fire-and-forget */
+      logMcpCall('search_knowledge').catch((err) => {
+        void err;
       });
       try {
         // Initialize log directory on first call (lazy — avoids loading config at import time)

--- a/packages/mcp/src/tools/search-knowledge.ts
+++ b/packages/mcp/src/tools/search-knowledge.ts
@@ -7,6 +7,7 @@ import type { ContentType, HealthCheckResult, SearchResult } from '@mmnto/totem'
 import { ContentTypeSchema } from '@mmnto/totem';
 
 import { getContext, reconnectStore } from '../context.js';
+import { logMcpCall } from '../ledger-writer.js';
 import { logSearch, setLogDir } from '../search-log.js';
 import { formatSystemWarning, formatXmlResponse } from '../xml-format.js';
 
@@ -604,6 +605,18 @@ export function registerSearchKnowledge(server: McpServer): void {
     },
     async ({ query, type_filter, max_results, boundary }) => {
       const start = Date.now();
+      // A.3.a: emit `mcp_call` activity event to the Trap Ledger. Fire-and-forget;
+      // the ledger write must not block or break the tool call (Tenet 4 + sensor
+      // semantics per lesson-b1bae311). This is the writer half of the
+      // ADR-029 compliance metric — A.3.b reads these events to compute
+      // "% of sessions where search_knowledge fired before first file write."
+      //
+      // logMcpCall has its own internal try/catch, but defense-in-depth with
+      // .catch() guards against any unhandledRejection if internals ever
+      // throw synchronously between awaits.
+      logMcpCall('search_knowledge').catch(() => {
+        /* fire-and-forget */
+      });
       try {
         // Initialize log directory on first call (lazy — avoids loading config at import time)
         try {


### PR DESCRIPTION
## Summary

Stack-follow-on to #1919 (A.3.a schema, merged at `1934f131`). Wires the two activity-event writers that turn the new schema types into real telemetry. Without these, the schema is inert — no `mcp_call` or `session_start` events ever get produced.

- **MCP `mcp_call` writer** (`packages/mcp/src/ledger-writer.ts`) — `logMcpCall(activityName)` helper wired into `search-knowledge.ts` handler entry. Reads `session_id` from `.totem/ledger/.session-id` if present (24h TTL), omits when missing.
- **SessionStart `session_start` writer** — `CLAUDE_SESSION_START` template extended to mint a UUID via `crypto.randomUUID()`, persist to `.totem/ledger/.session-id`, and append a `session_start` event to `events.ndjson` BEFORE the existing `totem describe` briefing. Stamps `agent_source: 'claude'` (hook knows its origin). Lightweight stderr breadcrumb on catch (CR R1 catch on the original #1920).
- **Core utilities** (`packages/core/src/session-id.ts`) — `mintSessionId` / `writeSessionId` / `readSessionId` with UUID-shape validation + 24h TTL fallback + fs error-class discrimination (ENOENT/EACCES/EPERM/EROFS swallow; unexpected classes rethrow per Tenet 4).

## What this unlocks

A.3.b's `totem doctor --compliance` can compute the ADR-029 metric: "% of sessions where `search_knowledge` was invoked at least once before the first file write." Today: schema present, no events. After this merge: real telemetry, queryable.

## Test plan

- [x] `packages/core/src/session-id.test.ts` — 13 tests (mint, read, write, TTL expiration via `utimesSync` backdating, fail-loud rethrow via `vi.mock('node:fs')`, defensive type guard).
- [x] `packages/mcp/src/ledger-writer.test.ts` — 5 tests (event emission, session_id presence/absence, getContext failure resilience, append-don't-overwrite).
- [x] `packages/mcp/src/tools/search-knowledge.test.ts` — 2 integration tests verifying handler emits `mcp_call` with `activity_name: 'search_knowledge'`.
- [x] `packages/cli/src/commands/init.test.ts` — 5 tests covering SessionStart template's mint/persist/emit/`agent_source`/stderr breadcrumb.
- [x] Build clean across all 5 packages; `pnpm exec totem lint` PASS (71 warnings, 0 errors); `pnpm exec totem review` PASS (no findings).

## History note

This PR replaces the **original #1920**, which got auto-closed when its base branch (`feat/ledger-schema-extension-a3a`) was deleted by the #1919 squash-merge. All commits from #1920 collapsed into a single commit here to keep the diff clean against main. **CR + GCA R1+R2 disposition history preserved in #1920's threads** — both rounds of bot findings addressed before this re-open:

- R1: `readSessionId` EPERM/EROFS swallow (CR + GCA converged), SessionStart hook stderr breadcrumb replacing silent catch (CR Minor)
- Strategy-Claude T0345Z gating items: race-condition doc-comment + `.session-id` gitignore confirmation (`.gitignore:46` covers `.totem/ledger/`)
- A.3.a parent OQ-1 + OQ-2 disposition matched cross-stream consensus (lc-Claude T0313Z + strategy-Gemini T0500Z + strategy-Claude T0345Z all aligned)

## ADR alignment

- **ADR-029 § Session Heuristic** — explicit UUID supersedes rolling-2h activity heuristic when `.session-id` present.
- **ADR-078 § Event Attribution** — `source: 'bot'` (emitter); `agent_source` populated by SessionStart hook; omitted on MCP-side writes until A.3.c.
- **ADR-077 Smart Briefing** — extends existing SessionStart hook scaffold without disturbing the briefing path.
- **Tenet 4 (Fail Loud)** — `readSessionId` and `writeSessionId` discriminate fs error classes; everything outside the known set rethrows.
- **lesson-b1bae311 (sensors-not-actuators)** — telemetry writes are fire-and-forget; failures must never break tool calls.

## Out of scope (next sub-lifts)

- **A.3.b** — `totem doctor --compliance` reads these events and computes the ADR-029 metric (~1 week).
- **A.3.c** — orchestrator → MCP correlation_id propagation; populates `agent_source` on MCP-side writes (~1 week).
- **A.4.a / A.4.b** — PreToolUse soft-block + pre-push hard-block (per C-12); reads `mcp_call` events to gate Write/Edit on design surfaces.
- **Gemini SessionStart writer** — symmetric pattern, deferred for parity sweep.
- **Other MCP tools** (`describe_project`, `add_lesson`, `verify_execution`) — wire `logMcpCall` when needed for broader observability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)