### PR TITLE
docs(readme): capability + stack badge row

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 [![npm version](https://img.shields.io/npm/v/@mmnto/totem.svg)](https://www.npmjs.com/package/@mmnto/totem)
 [![CI](https://github.com/mmnto-ai/totem/actions/workflows/ci.yml/badge.svg)](https://github.com/mmnto-ai/totem/actions/workflows/ci.yml)
+[![MCP Server](https://img.shields.io/badge/MCP-Server-1f6feb)](https://github.com/mmnto-ai/totem/tree/main/packages/mcp)
+[![Tool-agnostic](https://img.shields.io/badge/Tool--agnostic-Claude%20%E2%80%A2%20Cursor%20%E2%80%A2%20Gemini%20%E2%80%A2%20Windsurf%20%E2%80%A2%20Copilot-2ea44f)](https://github.com/mmnto-ai/totem/blob/main/AGENTS.md)
+[![AGENTS.md](https://img.shields.io/badge/AGENTS.md-ADR--038-8957e5)](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-038-agents-md-standard.md)
+[![License: Apache-2.0](https://img.shields.io/github/license/mmnto-ai/totem)](LICENSE)
+[![Node](https://img.shields.io/badge/node-%3E%3D20-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org)
+[![pnpm](https://img.shields.io/badge/pnpm-managed-F69220?logo=pnpm&logoColor=white)](https://pnpm.io)
 
 _AI coding agents are brilliant goldfish. Totem is the file-based substrate they read from and write to. It keeps architectural context durable across sessions._
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CI](https://github.com/mmnto-ai/totem/actions/workflows/ci.yml/badge.svg)](https://github.com/mmnto-ai/totem/actions/workflows/ci.yml)
 [![MCP Server](https://img.shields.io/badge/MCP-Server-1f6feb)](https://github.com/mmnto-ai/totem/tree/main/packages/mcp)
 [![Tool-agnostic](https://img.shields.io/badge/Tool--agnostic-Claude%20%E2%80%A2%20Cursor%20%E2%80%A2%20Gemini%20%E2%80%A2%20Windsurf%20%E2%80%A2%20Copilot-2ea44f)](https://github.com/mmnto-ai/totem/blob/main/AGENTS.md)
-[![AGENTS.md](https://img.shields.io/badge/AGENTS.md-ADR--038-8957e5)](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-038-agents-md-standard.md)
+[![AGENTS.md](https://img.shields.io/badge/AGENTS.md-Compliant-8957e5)](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-038-agents-md-standard.md)
 [![License: Apache-2.0](https://img.shields.io/github/license/mmnto-ai/totem)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org)
 [![pnpm](https://img.shields.io/badge/pnpm-managed-F69220?logo=pnpm&logoColor=white)](https://pnpm.io)


### PR DESCRIPTION
## Summary

Adds 6 badges to the README entry-point making load-bearing capability claims + stack details visible at a glance:

- **MCP Server** — links to `packages/mcp`; surfaces ADR-009 capability claim
- **Tool-agnostic** (Claude · Cursor · Gemini · Windsurf · Copilot) — surfaces Tenet 16 model-stack-agnosticism; links to `AGENTS.md`
- **AGENTS.md** — ADR-038 citizenship; links to the standard
- **License: Apache-2.0** — auto-pulled from repo
- **Node ≥20** — hardcoded (packages/core lacks `engines` field — separate fix)
- **pnpm** — surfaces `packageManager` field

Pure README-cosmetic diff (1 file, +6 lines). No code changes.

## Why now

`lc-Claude`'s BMad ecosystem evaluation (2026-05-15) surfaced that BMad-METHOD (47k⭐) uses README badges to communicate stack (Python / uv / Discord) at the entry point. Totem's README had only `npm version` + `CI` — invisible on what the project IS or which tools it works with.

The new badges:
1. **Surface load-bearing capability claims** (MCP, Tool-agnostic, AGENTS.md) per Tenet 19 claim-discipline — entry-point claims now point to concrete mechanism.
2. **Provide stack-at-a-glance** (License, Node, pnpm) for visitors who'd otherwise crack open package.json.
3. **Invert "badges decorate" → "badges load-bear"** — totem's differentiator made visible at the surface BMad uses to sell vibes.

Adjacent to mmnto-ai/totem#1918 B.4 README reframe.

## Test plan

- [x] Pre-push hook passed (formatting check, lint, 4255 tests)
- [ ] CI green on remote
- [ ] Visual check after merge that all 8 badges render
- [ ] License badge correctly auto-detects Apache-2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)