### PR TITLE
docs(readme): drop unverified badges; list integrations in body

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Node](https://img.shields.io/badge/node-%3E%3D20-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org)
 [![pnpm](https://img.shields.io/badge/pnpm-managed-F69220?logo=pnpm&logoColor=white)](https://pnpm.io)
 
-**Editor integrations:** [Claude Code](.claude/) · [Gemini CLI](.gemini/) · [GitHub Copilot](.github/copilot-instructions.md) · [JetBrains Junie](.junie/) · others tracked in [#1924](https://github.com/mmnto-ai/totem/issues/1924). See [`AGENTS.md`](AGENTS.md) for how integration works.
+**Editor integrations:** [Claude Code](.claude/) · [Gemini CLI](.gemini/) · [GitHub Copilot](.github/copilot-instructions.md) · [JetBrains Junie](.junie/) · others in progress. See [`AGENTS.md`](AGENTS.md) for how integration works.
 
 _AI coding agents are brilliant goldfish. Totem is the file-based substrate they read from and write to. It keeps architectural context durable across sessions._
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 [![npm version](https://img.shields.io/npm/v/@mmnto/totem.svg)](https://www.npmjs.com/package/@mmnto/totem)
 [![CI](https://github.com/mmnto-ai/totem/actions/workflows/ci.yml/badge.svg)](https://github.com/mmnto-ai/totem/actions/workflows/ci.yml)
 [![MCP Server](https://img.shields.io/badge/MCP-Server-1f6feb)](https://github.com/mmnto-ai/totem/tree/main/packages/mcp)
-[![Tool-agnostic](https://img.shields.io/badge/Tool--agnostic-Claude%20%E2%80%A2%20Cursor%20%E2%80%A2%20Gemini%20%E2%80%A2%20Windsurf%20%E2%80%A2%20Copilot-2ea44f)](https://github.com/mmnto-ai/totem/blob/main/AGENTS.md)
-[![AGENTS.md](https://img.shields.io/badge/AGENTS.md-Compliant-8957e5)](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-038-agents-md-standard.md)
 [![License: Apache-2.0](https://img.shields.io/github/license/mmnto-ai/totem)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%3E%3D20-339933?logo=nodedotjs&logoColor=white)](https://nodejs.org)
 [![pnpm](https://img.shields.io/badge/pnpm-managed-F69220?logo=pnpm&logoColor=white)](https://pnpm.io)
+
+**Editor integrations:** [Claude Code](.claude/) · [Gemini CLI](.gemini/) · [GitHub Copilot](.github/copilot-instructions.md) · [JetBrains Junie](.junie/) · others tracked in [#1924](https://github.com/mmnto-ai/totem/issues/1924). See [`AGENTS.md`](AGENTS.md) for how integration works.
 
 _AI coding agents are brilliant goldfish. Totem is the file-based substrate they read from and write to. It keeps architectural context durable across sessions._
 


### PR DESCRIPTION
## Summary

Self-audit of mmnto-ai/totem#1923 surfaced two badges shipped without sufficient verification:

| Badge | Issue |
|---|---|
| **Tool-agnostic** (Claude · Cursor · Gemini · Windsurf · Copilot) | (a) **Overclaim** — Cursor + Windsurf integration files don't exist in tree. (b) **Invented shape** — GitHub code search for `img.shields.io/badge/Tool--agnostic` in READMEs returns 1 result: us. |
| **AGENTS.md Compliant** | Shape is real-emerging (37 repos use the badge URL pattern, mostly external orgs — IgniteUI, Ivy-Interactive, etc.) **but our link target points to our own ADR-038 not to a canonical standard**, making the click-through self-referential. |

Replace with one body line listing **verified** editor integrations, each linked to its in-tree mechanism. Editors not yet integrated → tracked in mmnto-ai/totem#1924.

## Diff

- 8 badges → **6 badges** (drop Tool-agnostic + AGENTS.md)
- +1 line in body: `**Editor integrations:** [Claude Code](.claude/) · [Gemini CLI](.gemini/) · [GitHub Copilot](.github/copilot-instructions.md) · [JetBrains Junie](.junie/) · others tracked in #1924. See [\`AGENTS.md\`](AGENTS.md) for how integration works.`

Each link is verifiable mechanism — click and confirm the file exists.

## Verification done before this PR

| Tool | Integration file in repo? |
|---|---|
| Claude Code | ✅ `.claude/` |
| Gemini CLI | ✅ `.gemini/` |
| GitHub Copilot | ✅ `.github/copilot-instructions.md` |
| JetBrains Junie | ✅ `.junie/skills/` |
| Cursor | ❌ no `.cursor/` or `.cursorrules` — tracked in #1924 |
| Windsurf | ❌ no `.windsurf/` or `.windsurfrules` — tracked in #1924 |

## Why now

Per Tenet 19 (Claim Discipline), README claims should be mechanism-anchored. The audit pattern this PR responds to: a badge that lists capabilities without verifying each is exactly the "BMad as claim-discipline counter-exemplar" pattern flagged in cohort doctrine work this morning. Fix-forward keeps the README honest.

## Test plan

- [x] Pre-push checks passed (formatting, lint, 4255 tests)
- [ ] CI green
- [ ] Visual check: 6 badges + 1 integrations line render correctly
- [ ] Editor link click-throughs all land on existing files

🤖 Generated with [Claude Code](https://claude.com/claude-code)