### PR TITLE
fix(mcp): raise non-Windows vitest timeout floor 5s → 15s for ledger-writer cold-import

### DIFF
--- a/.changeset/ledger-writer-ci-timeout.md
+++ b/.changeset/ledger-writer-ci-timeout.md
@@ -1,0 +1,11 @@
+---
+'@mmnto/mcp': patch
+---
+
+fix(mcp): raise non-Windows vitest timeout floor 5s → 15s to absorb shared-runner cold-import variability
+
+`packages/mcp/src/ledger-writer.test.ts` uses a `vi.resetModules() + await import('./ledger-writer.js')` pattern in `beforeEach`. Local runs land near 1s for the cold-graph first test (`appends an mcp_call event to events.ndjson with the activity_name`). Under Ubuntu shared-runner CI load (run `25936416424` on the `mmnto-ai/totem#1927` post-merge push), the same test exceeded the 5000ms default and failed, while macOS + Windows in the same run passed.
+
+The Windows branch already bumped its floor to 30s for subprocess-driving slowness. The same shape of variability — cold-graph imports on shared CI hardware — applies to Linux/macOS too; the floor just hadn't been calibrated for it yet. Raising to 15s gives ~15× headroom over the observed local cost without masking real test slowness in the rest of the `@mmnto/mcp` suite.
+
+No runtime code change. Test-config only.

--- a/packages/mcp/vitest.config.ts
+++ b/packages/mcp/vitest.config.ts
@@ -2,8 +2,10 @@ import { defineConfig } from 'vitest/config';
 
 // Windows process spawn / kill is materially slower than Linux/macOS, and
 // subprocess-driving tests (git, node -e children, doctor temp-cleanup) trip
-// vitest's 5s default. Bump only on Windows to keep tight feedback elsewhere.
-const TEST_TIMEOUT_MS = process.platform === 'win32' ? 30_000 : 5_000;
+// vitest's 5s default. Linux/macOS also see cold-import variability on shared
+// CI runners — the `vi.resetModules() + await import` pattern in ledger-writer
+// tests has spiked past 5s under load even though local runs land near 1s.
+const TEST_TIMEOUT_MS = process.platform === 'win32' ? 30_000 : 15_000;
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
## Summary

- CI Ubuntu on the `mmnto-ai/totem#1927` post-merge push (CI run [25936416424](https://github.com/mmnto-ai/totem/actions/runs/25936416424)) timed out on `packages/mcp/src/ledger-writer.test.ts > logMcpCall > appends an mcp_call event to events.ndjson with the activity_name` at 5000ms. macOS + Windows in the same run passed; npm publish + binary releases all succeeded.
- Local + macOS finish near 1s. The flake is cold-import variability on shared Ubuntu CI hardware — every test in `ledger-writer.test.ts` pays a `vi.resetModules() + await import('./ledger-writer.js')` cost via `beforeEach`, and the suite's first test bears the worst-case cold-graph cost.
- This PR raises the non-Windows `TEST_TIMEOUT_MS` floor in `packages/mcp/vitest.config.ts` from 5s → 15s, matching the precedent the Windows branch set (30s) for subprocess slowness. Comment updated to call out the shared-runner cold-import class explicitly.
- 1-line config change, no runtime code touched. `@mmnto/mcp` patch changeset attached.

## Test plan

- [x] `pnpm --filter @mmnto/mcp build` — green
- [x] `pnpm --filter @mmnto/mcp test` — all 9 files / 146 tests pass locally (`ledger-writer.test.ts` total 1012ms, cold-graph test 969ms)
- [ ] CI green across ubuntu-latest / macos-latest / windows-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)