### PR TITLE
fix(ci): audit + sweep narrow timing thresholds across packages

### DIFF
--- a/.changeset/ci-timing-audit.md
+++ b/.changeset/ci-timing-audit.md
@@ -1,0 +1,24 @@
+---
+'@mmnto/cli': patch
+'@mmnto/totem': patch
+'@mmnto/pack-agent-security': patch
+'@mmnto/pack-rust-architecture': patch
+---
+
+fix(ci): audit + sweep narrow timing thresholds across packages
+
+Three independent CI flakes hit across three platforms in three hours after the #1928 merge to main, each on a different timing-window assertion:
+
+- **Ubuntu** (`@mmnto/mcp` `ledger-writer.test.ts`): vitest `testTimeout` 5_000ms tripped on cold-import (fixed in #1928).
+- **macOS** (`@mmnto/totem` `regex-safety/evaluator.test.ts:97`): `softWarningMs: 1` + 1000 trivial-pattern lines finished <1ms on fast hardware; `softWarningTriggered` assertion flipped false.
+- **Windows** (`@mmnto/cli` `run-compiled-rules.test.ts:203`): `RegexEvaluator` `DEFAULT_CONFIG.timeoutMs: 100` tripped at "timeout after 139ms" on a single-line `.sh` corpus — Windows worker thread spawn + IPC + shared-runner scheduling jitter exceeded the budget.
+
+This PR audits and uniformly addresses the class:
+
+**1. Vitest test-runner ceilings (4 configs)** — `packages/{cli,core,pack-agent-security,pack-rust-architecture}/vitest.config.ts` bumped non-Windows floor `5_000` → `15_000` to match the `@mmnto/mcp` precedent set in #1928. Windows stays at 30_000 (subprocess spawn). Comments updated to call out the shared-runner cold-import class explicitly.
+
+**2. `RegexEvaluator` production defaults** (`packages/core/src/regex-safety/evaluator.ts`) — `timeoutMs: 100 → 250`, `softWarningMs: 50 → 100`. 250ms keeps per-rule budget snappy in production while giving Windows worker IPC + CI scheduling ~2× headroom over the observed worst case (139ms). Backward compatible: callers passing explicit config are unaffected; callers using defaults gain headroom.
+
+**3. Soft-warning wall-clock test** (`packages/core/src/regex-safety/evaluator.test.ts:92`) — refactored from `softWarningMs: 1` + 1000 lines to `softWarningMs: 5` + 50_000 lines. Same assertion, but 50× wall-clock margin instead of a 1ms threshold racing fast hardware.
+
+No public API change. Verified locally: 2161 `@mmnto/cli` tests + matching cohort across `@mmnto/totem`, `@mmnto/mcp`, and the two packs all green.

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -2,8 +2,11 @@ import { defineConfig } from 'vitest/config';
 
 // Windows process spawn / kill is materially slower than Linux/macOS, and
 // subprocess-driving tests (git, node -e children, doctor temp-cleanup) trip
-// vitest's 5s default. Bump only on Windows to keep tight feedback elsewhere.
-const TEST_TIMEOUT_MS = process.platform === 'win32' ? 30_000 : 5_000;
+// vitest's 5s default. Linux/macOS also see cold-import variability on shared
+// CI runners — the `vi.resetModules() + await import` pattern (e.g.,
+// ledger-writer in @mmnto/mcp) has spiked past 5s under load even though
+// local runs land near 1s. Floor matches @mmnto/mcp post-#1928.
+const TEST_TIMEOUT_MS = process.platform === 'win32' ? 30_000 : 15_000;
 
 export default defineConfig({
   test: {

--- a/packages/core/src/regex-safety/evaluator.test.ts
+++ b/packages/core/src/regex-safety/evaluator.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from 'vitest';
 
 import { RegexEvaluator } from './evaluator.js';
 
+// Soft-warning wall-clock test fixtures (mmnto-ai/totem CI run 25937713095 macOS flake).
+// Workload sized for 50× wall-clock margin so the assertion is reliable regardless of host speed.
+const SOFT_WARNING_TEST_TIMEOUT_MS = 2_000;
+const SOFT_WARNING_THRESHOLD_MS = 5;
+const SOFT_WARNING_TEST_LINE_COUNT = 50_000;
+
 describe('RegexEvaluator — happy path', () => {
   it('returns matched line indices for a simple pattern', async () => {
     const evaluator = new RegexEvaluator();
@@ -90,19 +96,16 @@ describe('RegexEvaluator — timeout', () => {
   });
 
   it('emits softWarningTriggered for evaluations between softWarningMs and timeoutMs', async () => {
-    // Wall-clock assertion — softWarning must trip. The original 1ms threshold
-    // + 1000 lines spec'd "should exceed 1ms on any reasonable host," but fast
-    // hardware (M-series Mac CI runners) finishes 1000 trivial-pattern matches
-    // in <1ms, so the assertion was racy. Widen the workload so soft-warning
-    // fires with multi-x margin regardless of host speed (mmnto-ai/totem CI run
-    // 25937713095 macOS flake).
-    const evaluator = new RegexEvaluator({ timeoutMs: 2000, softWarningMs: 5 });
+    const evaluator = new RegexEvaluator({
+      timeoutMs: SOFT_WARNING_TEST_TIMEOUT_MS,
+      softWarningMs: SOFT_WARNING_THRESHOLD_MS,
+    });
     try {
       const result = await evaluator.evaluate({
         ruleHash: 'slow',
         pattern: 'foo',
         flags: '',
-        lines: new Array(50_000).fill('foo'),
+        lines: new Array(SOFT_WARNING_TEST_LINE_COUNT).fill('foo'),
       });
       expect(result.kind).toBe('ok');
       if (result.kind === 'ok') {

--- a/packages/core/src/regex-safety/evaluator.test.ts
+++ b/packages/core/src/regex-safety/evaluator.test.ts
@@ -90,23 +90,22 @@ describe('RegexEvaluator — timeout', () => {
   });
 
   it('emits softWarningTriggered for evaluations between softWarningMs and timeoutMs', async () => {
-    // Simulate a slow-but-not-pathological pattern by using a moderately
-    // backtracking regex with bounded input. Actual wall-clock depends
-    // on the host, so we pick a pattern that reliably falls in the
-    // soft-warning window and adjust thresholds low enough to trip it.
-    const evaluator = new RegexEvaluator({ timeoutMs: 500, softWarningMs: 1 });
+    // Wall-clock assertion — softWarning must trip. The original 1ms threshold
+    // + 1000 lines spec'd "should exceed 1ms on any reasonable host," but fast
+    // hardware (M-series Mac CI runners) finishes 1000 trivial-pattern matches
+    // in <1ms, so the assertion was racy. Widen the workload so soft-warning
+    // fires with multi-x margin regardless of host speed (mmnto-ai/totem CI run
+    // 25937713095 macOS flake).
+    const evaluator = new RegexEvaluator({ timeoutMs: 2000, softWarningMs: 5 });
     try {
       const result = await evaluator.evaluate({
         ruleHash: 'slow',
         pattern: 'foo',
         flags: '',
-        // Many lines guarantee the total evaluation takes > 1ms.
-        lines: new Array(1000).fill('foo'),
+        lines: new Array(50_000).fill('foo'),
       });
       expect(result.kind).toBe('ok');
       if (result.kind === 'ok') {
-        // With softWarningMs = 1 and 1000 lines, elapsed should exceed 1ms
-        // on any reasonable host and softWarning should trip.
         expect(result.softWarningTriggered).toBe(true);
       }
     } finally {

--- a/packages/core/src/regex-safety/evaluator.ts
+++ b/packages/core/src/regex-safety/evaluator.ts
@@ -49,9 +49,16 @@ export type EvaluateResult =
   | { kind: 'timeout'; elapsedMs: number }
   | { kind: 'error'; message: string; elapsedMs: number };
 
+// Defaults sized for shared CI runners. On Windows the worker thread spawn +
+// IPC overhead (see `workerReady` doc above) can stack ~30-50ms before the
+// first `postMessage` even fires; pair that with shared-runner scheduling
+// jitter and a 100ms timeout trips on otherwise-trivial regex evaluations
+// (Windows main-branch CI run 25939618872 saw "timeout after 139ms" on a
+// single-line `.sh` corpus). 250ms keeps the per-rule budget snappy in
+// production while giving CI hardware ~2× headroom over observed worst-case.
 const DEFAULT_CONFIG: RegexEvaluatorConfig = {
-  timeoutMs: 100,
-  softWarningMs: 50,
+  timeoutMs: 250,
+  softWarningMs: 100,
 };
 
 type PendingEntry = {

--- a/packages/core/src/regex-safety/evaluator.ts
+++ b/packages/core/src/regex-safety/evaluator.ts
@@ -56,9 +56,11 @@ export type EvaluateResult =
 // (Windows main-branch CI run 25939618872 saw "timeout after 139ms" on a
 // single-line `.sh` corpus). 250ms keeps the per-rule budget snappy in
 // production while giving CI hardware ~2× headroom over observed worst-case.
+const DEFAULT_TIMEOUT_MS = 250;
+const DEFAULT_SOFT_WARNING_MS = 100;
 const DEFAULT_CONFIG: RegexEvaluatorConfig = {
-  timeoutMs: 250,
-  softWarningMs: 100,
+  timeoutMs: DEFAULT_TIMEOUT_MS,
+  softWarningMs: DEFAULT_SOFT_WARNING_MS,
 };
 
 type PendingEntry = {

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -2,8 +2,11 @@ import { defineConfig } from 'vitest/config';
 
 // Windows process spawn / kill is materially slower than Linux/macOS, and
 // subprocess-driving tests (git, node -e children, doctor temp-cleanup) trip
-// vitest's 5s default. Bump only on Windows to keep tight feedback elsewhere.
-const TEST_TIMEOUT_MS = process.platform === 'win32' ? 30_000 : 5_000;
+// vitest's 5s default. Linux/macOS also see cold-import variability on shared
+// CI runners — the `vi.resetModules() + await import` pattern (e.g.,
+// ledger-writer in @mmnto/mcp) has spiked past 5s under load even though
+// local runs land near 1s. Floor matches @mmnto/mcp post-#1928.
+const TEST_TIMEOUT_MS = process.platform === 'win32' ? 30_000 : 15_000;
 
 export default defineConfig({
   test: {

--- a/packages/pack-agent-security/vitest.config.ts
+++ b/packages/pack-agent-security/vitest.config.ts
@@ -2,8 +2,11 @@ import { defineConfig } from 'vitest/config';
 
 // Windows process spawn / kill is materially slower than Linux/macOS, and
 // subprocess-driving tests (git, node -e children, doctor temp-cleanup) trip
-// vitest's 5s default. Bump only on Windows to keep tight feedback elsewhere.
-const TEST_TIMEOUT_MS = process.platform === 'win32' ? 30_000 : 5_000;
+// vitest's 5s default. Linux/macOS also see cold-import variability on shared
+// CI runners — the `vi.resetModules() + await import` pattern (e.g.,
+// ledger-writer in @mmnto/mcp) has spiked past 5s under load even though
+// local runs land near 1s. Floor matches @mmnto/mcp post-#1928.
+const TEST_TIMEOUT_MS = process.platform === 'win32' ? 30_000 : 15_000;
 
 export default defineConfig({
   test: {

--- a/packages/pack-rust-architecture/vitest.config.ts
+++ b/packages/pack-rust-architecture/vitest.config.ts
@@ -2,8 +2,11 @@ import { defineConfig } from 'vitest/config';
 
 // Windows process spawn / kill is materially slower than Linux/macOS, and
 // subprocess-driving tests (git, node -e children, doctor temp-cleanup) trip
-// vitest's 5s default. Bump only on Windows to keep tight feedback elsewhere.
-const TEST_TIMEOUT_MS = process.platform === 'win32' ? 30_000 : 5_000;
+// vitest's 5s default. Linux/macOS also see cold-import variability on shared
+// CI runners — the `vi.resetModules() + await import` pattern (e.g.,
+// ledger-writer in @mmnto/mcp) has spiked past 5s under load even though
+// local runs land near 1s. Floor matches @mmnto/mcp post-#1928.
+const TEST_TIMEOUT_MS = process.platform === 'win32' ? 30_000 : 15_000;
 
 export default defineConfig({
   test: {


### PR DESCRIPTION
## Summary

After #1928 merged, two more independent CI flakes fired on main within ~3 hours — different platforms, different tests, same class. Rather than continue per-flake patching, this PR audits and sweeps the whole class.

## The three flakes (one per platform, all same shape)

| Platform | Test | Threshold | Failure mode |
|---|---|---|---|
| Ubuntu | `@mmnto/mcp` `ledger-writer.test.ts` | `testTimeout: 5_000` | Cold-import `vi.resetModules()` exceeded 5s on shared CI (fixed in #1928) |
| macOS | `@mmnto/totem` `regex-safety/evaluator.test.ts:97` | `softWarningMs: 1` + 1000 lines | Fast hardware finished <1ms; `softWarningTriggered` assertion flipped false |
| Windows | `@mmnto/cli` `run-compiled-rules.test.ts:203` | `RegexEvaluator.DEFAULT_CONFIG.timeoutMs: 100` | Worker IPC + scheduling stacked >100ms ("timeout after 139ms") on a single-line `.sh` corpus |

## Fix surface (3 categories)

1. **Vitest test-runner ceilings** — `packages/{cli,core,pack-agent-security,pack-rust-architecture}/vitest.config.ts` non-Windows floor `5_000` → `15_000`, matching `@mmnto/mcp` post-#1928. Windows stays at 30_000. Comments updated to name the shared-runner cold-import class.

2. **`RegexEvaluator` production defaults** — `packages/core/src/regex-safety/evaluator.ts:52-55` `timeoutMs: 100 → 250`, `softWarningMs: 50 → 100`. Backward-compatible (callers passing explicit config unaffected); production rule budget stays interactive-snappy with ~2× headroom over observed Windows worst case.

3. **Wall-clock assertion refactor** — `packages/core/src/regex-safety/evaluator.test.ts:92` `softWarningMs: 1` + 1000 lines → `softWarningMs: 5` + 50_000 lines. Same `softWarningTriggered === true` assertion, 50× margin instead of a 1ms threshold racing fast hardware.

## What this PR is NOT

- Not a runtime API change — `RegexEvaluator` accepts the same config shape; only the unspecified-default values shift.
- Not a fix for unrelated test flakes — only the three classes documented above.

## Test plan

- [x] `pnpm build` — green
- [x] `pnpm test` — all 5 packages green locally (2161 cli tests + cohort)
- [ ] CI green across ubuntu-latest / macos-latest / windows-latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)