### PR TITLE
docs(readme): tighten knowledge-index + cross-repo-mesh claims per lc-Claude audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,9 +85,9 @@ AI agents are stateless by default. Every new session starts from zero, with no 
 
 Totem's approach is to ship a queryable knowledge index that holds your lessons and ADRs in a local semantic store (Tree-sitter + LanceDB). The index lives in your repo as plain files, so there's no cloud dependency and no vendor lock-in.
 
-Any MCP-compatible agent can query it (e.g., Claude, Gemini, Cursor, Windsurf, Copilot). Before your agent writes a line of code, it can ask "what patterns are banned in this codebase?" or "what's the architecture of the auth system?" and get a real answer grounded in your project's actual history. Whether an agent actually issues that query before deriving from scratch is currently an agent-discipline question — see [What Works and What Doesn't](#what-works-and-what-doesnt).
+Any MCP-compatible agent can query it. Before your agent writes a line of code, it can ask "what patterns are banned in this codebase?" or "what's the architecture of the auth system?" and get a real set of ranked candidates from your project's actual history (the agent still has to read them and synthesize — a queryable index returns candidates, not pre-synthesized answers). Whether an agent actually issues that query before deriving from scratch is currently an agent-discipline question — see [What Works and What Doesn't](#what-works-and-what-doesnt).
 
-With [Cross-Repo Mesh](docs/wiki/cross-repo-mesh.md), you can federate search across sibling repos. One repo's lessons become queryable from all linked repos, so context doesn't stop at the repo boundary. (Local filesystem-linked siblings are free; centralized federation with RBAC and hosted compile is the paid tier — see [Open Core Covenant](https://github.com/mmnto-ai/totem/blob/main/COVENANT.md).)
+With [Cross-Repo Mesh](docs/wiki/cross-repo-mesh.md), federation across sibling repos is supported via the opt-in `linkedIndexes` config — one repo's lessons become queryable from all linked repos when cohorts opt in, so context doesn't stop at the repo boundary. (Local filesystem-linked siblings are free; centralized federation with RBAC and hosted compile is the paid tier — see [Open Core Covenant](https://github.com/mmnto-ai/totem/blob/main/COVENANT.md).)
 
 ## What's in the Box
 


### PR DESCRIPTION
## Summary

Three claim-discipline tightenings on the README in response to `lc-Claude`'s consumer-side empirical audit of B.4 (posted as postscript on mmnto-ai/totem#1918 at [issuecomment-4463791338](https://github.com/mmnto-ai/totem/pull/1918#issuecomment-4463791338)).

| # | Claim | Before | After | Evidence |
|---|---|---|---|---|
| 1 | Queryable Knowledge Index "answer" | "get a real **answer** grounded in your project's actual history" | "get a real set of **ranked candidates** from your project's actual history (agent reads + synthesizes)" | LC's 74-query corpus: topScores cluster ~0.016-0.033 (moderate similarity). Agent must still read + synthesize; the index doesn't pre-synthesize. |
| 2 | Cross-Repo Mesh framing | "you **can federate** search across sibling repos" | "federation **is supported via the opt-in `linkedIndexes` config** — one repo's lessons become queryable from all linked repos **when cohorts opt in**" | LC has 458 local-only / 0 linked indexed documents, `linkedIndexes` unconfigured. Present-tense reads as default-on; reality is opt-in. |
| 3 | Named-agent list | "(e.g., Claude, Gemini, Cursor, Windsurf, Copilot)" | Dropped — body integration list above already names verified tools with mechanism-anchored links | LC: 2/5 verified (Claude, Gemini); 3/5 unexercised (Cursor, Windsurf, Copilot not installed). Same shape as the mmnto-ai/totem#1923 → mmnto-ai/totem#1925 Tool-agnostic badge fix-forward; this closes the parallel surface in README body. |

## Why now

`lc-Claude` ran the audit pre-merge but the empirical signal landed post-merge. Per [[feedback_reproduction_evidence_preservation]] doctrine, postscript on the merged PR preserves the audit trail; this fix-forward closes the claim-discipline gap in the README itself.

## Meta-note

This audit is exactly what mmnto-ai/totem-strategy#331 (Proposal 277 / Ollama spot-check tier) would automate. The mechanism doesn't exist yet — when A.3.b lands `totem doctor --compliance` and spot-check ships, this class of catch becomes a pre-push gate instead of a post-merge audit. The 2026-05-15 session has now produced THREE README claim-discipline failures caught post-merge by human/agent audit:

1. mmnto-ai/totem#1923 → mmnto-ai/totem#1925 (Tool-agnostic badge fix-forward)
2. mmnto-ai/totem#1925 → R2 (issue-number ref in user-facing README)
3. mmnto-ai/totem#1918 → this PR (3 claim tightenings)

Strong empirical case for Proposal 277 mechanism actually landing. Seed regression corpus is growing.

## Test plan

- [x] Pre-push checks passed (formatting, lint, 4282 tests)
- [ ] CI green
- [ ] Visual check: rendered text reads honestly

🤖 Generated with [Claude Code](https://claude.com/claude-code)