### PR TITLE
orchestration: gitignore .totem/orchestration/ per Proposal 282 Phase 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,12 @@ packages/pack-rust-architecture/tree-sitter-rust.wasm
 .totem/installed-packs.json
 .totem/index-manifest.json
 
+# Local-only orchestration per Proposal 282 (mmnto-ai/totem-strategy#341).
+# Each agent writes journals + handoffs into .totem/orchestration/<agent-id>/.
+# Contents are intentionally NOT tracked — substrate (mmnto-ai/totem-substrate)
+# remains the frozen archive for historical orchestration through cutover.
+.totem/orchestration/
+
 # Local scratchpad (personal scratch files go here, not in root)
 scratchpad/
 design/


### PR DESCRIPTION
## Summary
- Adds `.totem/orchestration/` to `.gitignore` per ADR-106 (Ephemeral Coordination Layer) Phase 2.
- Mirror of the strategy reference impl in mmnto-ai/totem-strategy#345.
- No behavior change in this PR — agents continue to use substrate paths through the Phase 3 cutover broadcast (per the 2026-05-17T0554Z awareness broadcast). This just prevents accidental tracking when agents start writing locally after Phase 3 ships.
- Cohort version bump deferred to Phase 4 per ADR-106 § Implementation Migration Notes — this repo is the source of the resolver + state-extractor swap that the bump publishes.

## Trail
- Tracker: mmnto-ai/totem-strategy#342 (Phase 2 checkbox for mmnto-ai/totem)
- Doctrine: `mmnto-ai/totem-strategy:adr/adr-106-ephemeral-coordination-layer.md`
- Precedent: mmnto-ai/totem-strategy#345 (strategy reference impl)
- Proposal: mmnto-ai/totem-strategy#341 (Proposal 282 — Local-Only Orchestration)

## Test plan
- [x] `.gitignore` change is mechanical
- [x] No tracked content affected
- [x] Block placement matches the strategy reference impl pattern (alongside existing `.totem/` entries)
- [x] `totem lint` passes (387 rules, 0 violations)

## Pre-push gate bypass note (audit trail)

Push used `TOTEM_GATE_BYPASS_JUSTIFICATION` to clear a pre-existing WWND Rule 1 warning at `docs/wiki/governing-ai-agents.md:58` ("guarantees compliance") — entirely unrelated to this diff (zero overlap; the warning is in a docs/wiki file the gitignore change does not touch). Filed as separate follow-up ticket so the WWND finding gets a dedicated fix with proper voice review, rather than scope-creeping this mechanical orchestration PR.

Cross-stream coordination note: opened by strategy-Claude as Phase 2 sweep coordinator. Phase 4 impl work (resolver + state-extractor + `/signoff` skill + dashboard updates) remains totem-Claude's lane.

Generated with [Claude Code](https://claude.com/claude-code)