### PR TITLE
feat(core+mcp+skills): orchestration resolver + extractor swap + signoff skill (Proposal 282 / ADR-106 Phase 4 PR A)

### DIFF
--- a/.claude/skills/signoff/SKILL.md
+++ b/.claude/skills/signoff/SKILL.md
@@ -5,27 +5,40 @@ description: End-of-session — update memory, write journal entry, clean up
 
 <!-- totem:skill-start -->
 
-End-of-session wrap-up:
+End-of-session wrap-up. Post-Proposal-282 (ADR-106), journals + handoffs live in the per-repo `.totem/orchestration/<agent-id>/` tree (gitignored) — NOT the substrate. Substrate stays as a frozen archive for forensic reads; the active surface is local.
 
-1. Update `MEMORY.md` with any new state (version shipped, tickets closed, key decisions)
-2. Write a journal entry to the substrate journal at `<substrate>/.journal/totem/<filename>.md` summarizing today's work. Use `resolveSubstratePaths(gitRoot).journalRoot` from `@mmnto/totem` to locate the substrate; if `source === 'none'`, fall back to repo-local `.journal/totem/` and warn (ADR-090 graceful degradation).
-3. Commit + push the substrate journal entry from `mmnto-ai/totem-substrate` (NOT this repo — `.journal/` is sediment-frozen here per ADR-100). Use rebase-and-retry on the push since other agents may sign off concurrently:
+1. **Update memory.** Update auto-memory files (e.g. `MEMORY.md`, topic memories) with any new state — version shipped, tickets closed, key decisions, banked feedback or doctrine signals.
+
+2. **Write a journal entry to the per-repo orchestration path.** Filename convention: `<model>-NNNN-<short-topic-slug>.md` (e.g., `claude-0057-phase-4-resolver-shipped.md`).
+
+   **Resolve the path two steps:**
+
+   a. **Identify your agent-id** from the current repo's basename. The hardcoded map (Proposal 282 § Scope item 3 — keep in sync with the ADR-106 cohort list):
+
+   | Repo (`git rev-parse --show-toplevel` basename) | Claude agent-id | Gemini agent-id |
+   |---|---|---|
+   | `totem` | `totem-claude` | `totem-gemini` |
+   | `totem-strategy` | `strategy-claude` | `strategy-gemini` |
+   | `liquid-city` | `lc-claude` | `lc-gemini` |
+   | `arhgap11` | `arhgap11-claude` | `arhgap11-gemini` |
+   | `totem-status` | _(no Claude variant)_ | `status-gemini` |
+   | `totem-playground` | _(orphan stream — no native agent)_ | _(orphan stream)_ |
+
+   Override hook: if the consuming repo carries `.totem/orchestration/config.json` with a `host_agents: string[]` field, prefer that list over the hardcoded map. Reserved for repos that legitimately host an agent not in the default map.
+
+   b. **Resolve the journal directory** via `resolveOrchestrationPaths(repoRoot, agentId).journal` from `@mmnto/totem`. Returns the absolute path to `<repoRoot>/.totem/orchestration/<agent-id>/journal/`. If `source === 'none'` (the tree does not exist yet in this repo), create the directory first via `mkdir -p`; the path is gitignored and safe to create.
+
+3. **No commit, no push.** `.totem/orchestration/` is gitignored — local filesystem write is the entire operation. No more substrate rebase-retry loops; the cross-agent write-collision class is eliminated by the single-writer-per-path invariant (you only ever write into your own `<agent-id>/` subtree).
+
+4. **Clean up stale local branches:**
 
    ```bash
-   cd <substrate-repo-root>
-   git add .journal/totem/<filename>.md
-   git commit -m "journal(totem): <slug>"
-   pushed=0
-   for i in 1 2 3 4 5; do
-     git push origin main && { pushed=1; break; }
-     git pull --rebase --autostash origin main || { echo "Rebase conflict — manual resolution needed"; break; }
-     sleep 1
-   done
-   [ "$pushed" = 1 ] || { echo "ERROR: substrate push failed — surface to user"; exit 1; }
+   git branch -vv | grep ': gone]' | awk '{print $1}' | xargs git branch -D
    ```
 
-   **Why the retry loop:** Substrate `main` accepts only fast-forward pushes. If a peer push (strategy-Claude, lc-Claude, status-Claude, etc.) lands between your commit and your push, yours fails with `non-fast-forward`. Per-agent journal filenames (`<model>-NNNN-*.md`) don't collide, so the rebase auto-succeeds without conflict — typically resolves within 1-2 retries. After 5 retries surface failure to the user; that's likely a genuine same-file edit (e.g., two recipients moving the same `_broadcast/` file to `processed/`) that needs manual resolution.
+5. **Report:** what shipped, what's pending, what's next.
 
-4. Clean up stale local branches: `git branch -vv | grep ': gone]' | awk '{print $1}' | xargs git branch -D`
-5. Report: what shipped, what's pending, what's next
+**Cross-repo handoffs** (when you need to dispatch a message to another agent) write to your own `<repoRoot>/.totem/orchestration/<agent-id>/outbox/<YYYY-MM-DDTHHMMZ>-<your-agent-id>.md` with `to: <recipient-agent-id>` in the frontmatter. Recipients discover inbound handoffs by polling the single-level glob `<workspace>/*/.totem/orchestration/*/outbox/*.md` filtered by their own `to:` frontmatter match.
+
+**Substrate (legacy) is read-only.** Do NOT write new content to `mmnto-ai/totem-substrate:.handoff/` or `:.journal/`. The substrate stays mounted as a frozen archive accessible via `resolveSubstratePaths(cwd)` for forensic reads; the cutover broadcast (when it lands) will confirm the final substrate-write cutoff.
 <!-- totem:skill-end -->

--- a/.claude/skills/signoff/SKILL.md
+++ b/.claude/skills/signoff/SKILL.md
@@ -26,7 +26,7 @@ End-of-session wrap-up. Post-Proposal-282 (ADR-106), journals + handoffs live in
 
    Override hook: if the consuming repo carries `.totem/orchestration/config.json` with a `host_agents: string[]` field, prefer that list over the hardcoded map. Reserved for repos that legitimately host an agent not in the default map.
 
-   b. **Resolve the journal directory** via `resolveOrchestrationPaths(repoRoot, agentId).journal` from `@mmnto/totem`. Returns the absolute path to `<repoRoot>/.totem/orchestration/<agent-id>/journal/`. If `source === 'none'` (the tree does not exist yet in this repo), create the directory first via `mkdir -p`; the path is gitignored and safe to create.
+   b. **Resolve the journal directory** via `resolveOrchestrationPaths(repoRoot, agentId).journal` from `@mmnto/totem`. Returns the absolute path to `<repoRoot>/.totem/orchestration/<agent-id>/journal/` when the tree exists. If `source === 'none'` (the tree does not exist yet in this repo) the resolver returns `null` for every path field — in that case, construct the path manually as `<repoRoot>/.totem/orchestration/<agent-id>/journal/` and create the directory first via `mkdir -p`; the path is gitignored and safe to create.
 
 3. **No commit, no push.** `.totem/orchestration/` is gitignored — local filesystem write is the entire operation. No more substrate rebase-retry loops; the cross-agent write-collision class is eliminated by the single-writer-per-path invariant (you only ever write into your own `<agent-id>/` subtree).
 

--- a/.claude/skills/signoff/SKILL.md
+++ b/.claude/skills/signoff/SKILL.md
@@ -33,7 +33,9 @@ End-of-session wrap-up. Post-Proposal-282 (ADR-106), journals + handoffs live in
 4. **Clean up stale local branches:**
 
    ```bash
-   git branch -vv | grep ': gone]' | awk '{print $1}' | xargs git branch -D
+   git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads | while read -r branch track; do
+     [[ "$track" == "[gone]" ]] && git branch -D -- "$branch"
+   done
    ```
 
 5. **Report:** what shipped, what's pending, what's next.

--- a/.claude/skills/signoff/SKILL.md
+++ b/.claude/skills/signoff/SKILL.md
@@ -15,14 +15,14 @@ End-of-session wrap-up. Post-Proposal-282 (ADR-106), journals + handoffs live in
 
    a. **Identify your agent-id** from the current repo's basename. The hardcoded map (Proposal 282 § Scope item 3 — keep in sync with the ADR-106 cohort list):
 
-   | Repo (`git rev-parse --show-toplevel` basename) | Claude agent-id | Gemini agent-id |
-   |---|---|---|
-   | `totem` | `totem-claude` | `totem-gemini` |
-   | `totem-strategy` | `strategy-claude` | `strategy-gemini` |
-   | `liquid-city` | `lc-claude` | `lc-gemini` |
-   | `arhgap11` | `arhgap11-claude` | `arhgap11-gemini` |
-   | `totem-status` | _(no Claude variant)_ | `status-gemini` |
-   | `totem-playground` | _(orphan stream — no native agent)_ | _(orphan stream)_ |
+   | Repo (`git rev-parse --show-toplevel` basename) | Claude agent-id                     | Gemini agent-id   |
+   | ----------------------------------------------- | ----------------------------------- | ----------------- |
+   | `totem`                                         | `totem-claude`                      | `totem-gemini`    |
+   | `totem-strategy`                                | `strategy-claude`                   | `strategy-gemini` |
+   | `liquid-city`                                   | `lc-claude`                         | `lc-gemini`       |
+   | `arhgap11`                                      | `arhgap11-claude`                   | `arhgap11-gemini` |
+   | `totem-status`                                  | _(no Claude variant)_               | `status-gemini`   |
+   | `totem-playground`                              | _(orphan stream — no native agent)_ | _(orphan stream)_ |
 
    Override hook: if the consuming repo carries `.totem/orchestration/config.json` with a `host_agents: string[]` field, prefer that list over the hardcoded map. Reserved for repos that legitimately host an agent not in the default map.
 
@@ -41,4 +41,5 @@ End-of-session wrap-up. Post-Proposal-282 (ADR-106), journals + handoffs live in
 **Cross-repo handoffs** (when you need to dispatch a message to another agent) write to your own `<repoRoot>/.totem/orchestration/<agent-id>/outbox/<YYYY-MM-DDTHHMMZ>-<your-agent-id>.md` with `to: <recipient-agent-id>` in the frontmatter. Recipients discover inbound handoffs by polling the single-level glob `<workspace>/*/.totem/orchestration/*/outbox/*.md` filtered by their own `to:` frontmatter match.
 
 **Substrate (legacy) is read-only.** Do NOT write new content to `mmnto-ai/totem-substrate:.handoff/` or `:.journal/`. The substrate stays mounted as a frozen archive accessible via `resolveSubstratePaths(cwd)` for forensic reads; the cutover broadcast (when it lands) will confirm the final substrate-write cutoff.
+
 <!-- totem:skill-end -->

--- a/.gemini/skills/signoff.md
+++ b/.gemini/skills/signoff.md
@@ -18,14 +18,14 @@ At end of session, after the main task is wrapped: when the user signals complet
 
    a. **Identify the agent-id from the current repo's basename.** Hardcoded map (Proposal 282 § Scope item 3 — keep in sync with the ADR-106 cohort list):
 
-   | Repo (`git rev-parse --show-toplevel` basename) | Gemini agent-id |
-   |---|---|
-   | `totem` | `totem-gemini` |
-   | `totem-strategy` | `strategy-gemini` |
-   | `liquid-city` | `lc-gemini` |
-   | `arhgap11` | `arhgap11-gemini` |
-   | `totem-status` | `status-gemini` |
-   | `totem-playground` | _(orphan stream — no native agent)_ |
+   | Repo (`git rev-parse --show-toplevel` basename) | Gemini agent-id                     |
+   | ----------------------------------------------- | ----------------------------------- |
+   | `totem`                                         | `totem-gemini`                      |
+   | `totem-strategy`                                | `strategy-gemini`                   |
+   | `liquid-city`                                   | `lc-gemini`                         |
+   | `arhgap11`                                      | `arhgap11-gemini`                   |
+   | `totem-status`                                  | `status-gemini`                     |
+   | `totem-playground`                              | _(orphan stream — no native agent)_ |
 
    Override hook: if the consuming repo carries `.totem/orchestration/config.json` with a `host_agents: string[]` field, prefer that list over the hardcoded map. Reserved for repos that legitimately host an agent not in the default map.
 

--- a/.gemini/skills/signoff.md
+++ b/.gemini/skills/signoff.md
@@ -29,7 +29,7 @@ At end of session, after the main task is wrapped: when the user signals complet
 
    Override hook: if the consuming repo carries `.totem/orchestration/config.json` with a `host_agents: string[]` field, prefer that list over the hardcoded map. Reserved for repos that legitimately host an agent not in the default map.
 
-   b. **Resolve the journal directory.** The Node-side primitive is `resolveOrchestrationPaths(repoRoot, agentId).journal` from `@mmnto/totem`; invoke via shell as needed. The journal directory is `<repoRoot>/.totem/orchestration/<agent-id>/journal/`. If absent, create it first (`mkdir -p`); the path is gitignored and safe to create.
+   b. **Resolve the journal directory.** The Node-side primitive is `resolveOrchestrationPaths(repoRoot, agentId).journal` from `@mmnto/totem`; invoke via shell as needed. The journal directory is `<repoRoot>/.totem/orchestration/<agent-id>/journal/` when the tree exists. If `source === 'none'` (tree absent) the resolver returns `null` for every path field — construct the path manually using the same formula and create the directory first (`mkdir -p`); the path is gitignored and safe to create.
 
 3. **No commit, no push.** `.totem/orchestration/` is gitignored — local filesystem write is the entire operation. No substrate rebase-retry loops; the cross-agent write-collision class is eliminated by the single-writer-per-path invariant (only ever write into your own `<agent-id>/` subtree).
 

--- a/.gemini/skills/signoff.md
+++ b/.gemini/skills/signoff.md
@@ -1,0 +1,50 @@
+<!-- [totem] Gemini parity for the Claude /signoff skill — Proposal 282 / ADR-106 -->
+
+# Totem Signoff (Gemini parity)
+
+End-of-session wrap-up for Gemini agents. Mirrors the `/signoff` skill at `.claude/skills/signoff/SKILL.md`. Post-Proposal-282 (ADR-106), journals + handoffs live in the per-repo `.totem/orchestration/<agent-id>/` tree (gitignored) — NOT the substrate. Substrate stays as a frozen archive for forensic reads; the active surface is local.
+
+## When to invoke
+
+At end of session, after the main task is wrapped: when the user signals completion, when context is becoming long enough to compact, or when shipping a meaningful milestone (PR merged, design decision made, doctrine banked).
+
+## Steps
+
+1. **Update memory.** Update any agent-managed memory files with new state — version shipped, tickets closed, key decisions, banked feedback or doctrine signals.
+
+2. **Write a journal entry to the per-repo orchestration path.** Filename convention: `gemini-NNNN-<short-topic-slug>.md` (e.g., `gemini-0042-phase-4-dashboard-shipped.md`).
+
+   **Resolve the path two steps:**
+
+   a. **Identify the agent-id from the current repo's basename.** Hardcoded map (Proposal 282 § Scope item 3 — keep in sync with the ADR-106 cohort list):
+
+   | Repo (`git rev-parse --show-toplevel` basename) | Gemini agent-id |
+   |---|---|
+   | `totem` | `totem-gemini` |
+   | `totem-strategy` | `strategy-gemini` |
+   | `liquid-city` | `lc-gemini` |
+   | `arhgap11` | `arhgap11-gemini` |
+   | `totem-status` | `status-gemini` |
+   | `totem-playground` | _(orphan stream — no native agent)_ |
+
+   Override hook: if the consuming repo carries `.totem/orchestration/config.json` with a `host_agents: string[]` field, prefer that list over the hardcoded map. Reserved for repos that legitimately host an agent not in the default map.
+
+   b. **Resolve the journal directory.** The Node-side primitive is `resolveOrchestrationPaths(repoRoot, agentId).journal` from `@mmnto/totem`; invoke via shell as needed. The journal directory is `<repoRoot>/.totem/orchestration/<agent-id>/journal/`. If absent, create it first (`mkdir -p`); the path is gitignored and safe to create.
+
+3. **No commit, no push.** `.totem/orchestration/` is gitignored — local filesystem write is the entire operation. No substrate rebase-retry loops; the cross-agent write-collision class is eliminated by the single-writer-per-path invariant (only ever write into your own `<agent-id>/` subtree).
+
+4. **Clean up stale local branches:**
+
+   ```bash
+   git branch -vv | grep ': gone]' | awk '{print $1}' | xargs git branch -D
+   ```
+
+5. **Report:** what shipped, what's pending, what's next.
+
+## Cross-repo handoffs
+
+When dispatching a message to another agent, write to your own outbox at `<repoRoot>/.totem/orchestration/<agent-id>/outbox/<YYYY-MM-DDTHHMMZ>-<your-agent-id>.md` with `to: <recipient-agent-id>` in the frontmatter. Recipients discover inbound handoffs by polling the single-level glob `<workspace>/*/.totem/orchestration/*/outbox/*.md` and filtering on their own `to:` frontmatter match.
+
+## Substrate is read-only
+
+Do NOT write new content to `mmnto-ai/totem-substrate:.handoff/` or `:.journal/`. The substrate stays mounted as a frozen archive accessible via `resolveSubstratePaths(cwd)` for forensic reads; the cutover broadcast (when it lands) will confirm the final substrate-write cutoff.

--- a/.gemini/skills/signoff.md
+++ b/.gemini/skills/signoff.md
@@ -36,7 +36,9 @@ At end of session, after the main task is wrapped: when the user signals complet
 4. **Clean up stale local branches:**
 
    ```bash
-   git branch -vv | grep ': gone]' | awk '{print $1}' | xargs git branch -D
+   git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads | while read -r branch track; do
+     [[ "$track" == "[gone]" ]] && git branch -D -- "$branch"
+   done
    ```
 
 5. **Report:** what shipped, what's pending, what's next.

--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,12 @@ packages/pack-rust-architecture/tree-sitter-rust.wasm
 .totem/installed-packs.json
 .totem/index-manifest.json
 
+# Local-only orchestration per Proposal 282 (mmnto-ai/totem-strategy#341).
+# Each agent writes journals + handoffs into .totem/orchestration/<agent-id>/.
+# Contents are intentionally NOT tracked — substrate (mmnto-ai/totem-substrate)
+# remains the frozen archive for historical orchestration through cutover.
+.totem/orchestration/
+
 # Local scratchpad (personal scratch files go here, not in root)
 scratchpad/
 design/

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -456,7 +456,7 @@ End-of-session wrap-up. Post-Proposal-282 (ADR-106), journals + handoffs live in
 
    Override hook: if the consuming repo carries \`.totem/orchestration/config.json\` with a \`host_agents: string[]\` field, prefer that list over the hardcoded map. Reserved for repos that legitimately host an agent not in the default map.
 
-   b. **Resolve the journal directory** via \`resolveOrchestrationPaths(repoRoot, agentId).journal\` from \`@mmnto/totem\`. Returns the absolute path to \`<repoRoot>/.totem/orchestration/<agent-id>/journal/\`. If \`source === 'none'\` (the tree does not exist yet in this repo), create the directory first via \`mkdir -p\`; the path is gitignored and safe to create.
+   b. **Resolve the journal directory** via \`resolveOrchestrationPaths(repoRoot, agentId).journal\` from \`@mmnto/totem\`. Returns the absolute path to \`<repoRoot>/.totem/orchestration/<agent-id>/journal/\` when the tree exists. If \`source === 'none'\` (the tree does not exist yet in this repo) the resolver returns \`null\` for every path field — in that case, construct the path manually as \`<repoRoot>/.totem/orchestration/<agent-id>/journal/\` and create the directory first via \`mkdir -p\`; the path is gitignored and safe to create.
 
 3. **No commit, no push.** \`.totem/orchestration/\` is gitignored — local filesystem write is the entire operation. No more substrate rebase-retry loops; the cross-agent write-collision class is eliminated by the single-writer-per-path invariant (you only ever write into your own \`<agent-id>/\` subtree).
 

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -465,7 +465,9 @@ End-of-session wrap-up. Post-Proposal-282 (ADR-106), journals + handoffs live in
   `4. **Clean up stale local branches:**
 
    \`\`\`bash
-   git branch -vv | grep ': gone]' | awk '{print $1}' | xargs git branch -D
+   git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads | while read -r branch track; do
+     [[ "$track" == "[gone]" ]] && git branch -D -- "$branch"
+   done
    \`\`\`
 
 5. **Report:** what shipped, what's pending, what's next.

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -445,14 +445,14 @@ End-of-session wrap-up. Post-Proposal-282 (ADR-106), journals + handoffs live in
 
    a. **Identify your agent-id** from the current repo's basename. The hardcoded map (Proposal 282 § Scope item 3 — keep in sync with the ADR-106 cohort list):
 
-   | Repo (\`git rev-parse --show-toplevel\` basename) | Claude agent-id | Gemini agent-id |
-   |---|---|---|
-   | \`totem\` | \`totem-claude\` | \`totem-gemini\` |
-   | \`totem-strategy\` | \`strategy-claude\` | \`strategy-gemini\` |
-   | \`liquid-city\` | \`lc-claude\` | \`lc-gemini\` |
-   | \`arhgap11\` | \`arhgap11-claude\` | \`arhgap11-gemini\` |
-   | \`totem-status\` | _(no Claude variant)_ | \`status-gemini\` |
-   | \`totem-playground\` | _(orphan stream — no native agent)_ | _(orphan stream)_ |
+   | Repo (\`git rev-parse --show-toplevel\` basename) | Claude agent-id                     | Gemini agent-id   |
+   | ----------------------------------------------- | ----------------------------------- | ----------------- |
+   | \`totem\`                                         | \`totem-claude\`                      | \`totem-gemini\`    |
+   | \`totem-strategy\`                                | \`strategy-claude\`                   | \`strategy-gemini\` |
+   | \`liquid-city\`                                   | \`lc-claude\`                         | \`lc-gemini\`       |
+   | \`arhgap11\`                                      | \`arhgap11-claude\`                   | \`arhgap11-gemini\` |
+   | \`totem-status\`                                  | _(no Claude variant)_               | \`status-gemini\`   |
+   | \`totem-playground\`                              | _(orphan stream — no native agent)_ | _(orphan stream)_ |
 
    Override hook: if the consuming repo carries \`.totem/orchestration/config.json\` with a \`host_agents: string[]\` field, prefer that list over the hardcoded map. Reserved for repos that legitimately host an agent not in the default map.
 
@@ -473,6 +473,7 @@ End-of-session wrap-up. Post-Proposal-282 (ADR-106), journals + handoffs live in
 **Cross-repo handoffs** (when you need to dispatch a message to another agent) write to your own \`<repoRoot>/.totem/orchestration/<agent-id>/outbox/<YYYY-MM-DDTHHMMZ>-<your-agent-id>.md\` with \`to: <recipient-agent-id>\` in the frontmatter. Recipients discover inbound handoffs by polling the single-level glob \`<workspace>/*/.totem/orchestration/*/outbox/*.md\` filtered by their own \`to:\` frontmatter match.
 
 **Substrate (legacy) is read-only.** Do NOT write new content to \`mmnto-ai/totem-substrate:.handoff/\` or \`:.journal/\`. The substrate stays mounted as a frozen archive accessible via \`resolveSubstratePaths(cwd)\` for forensic reads; the cutover broadcast (when it lands) will confirm the final substrate-write cutoff.
+
 ${SKILL_MARKER_END}
 `;
 

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -435,31 +435,44 @@ description: End-of-session — update memory, write journal entry, clean up
 
 ${SKILL_MARKER_START}
 
-End-of-session wrap-up:
+End-of-session wrap-up. Post-Proposal-282 (ADR-106), journals + handoffs live in the per-repo \`.totem/orchestration/<agent-id>/\` tree (gitignored) — NOT the substrate. Substrate stays as a frozen archive for forensic reads; the active surface is local.
 
-1. Update \`MEMORY.md\` with any new state (version shipped, tickets closed, key decisions)
-2. Write a journal entry to the substrate journal at \`<substrate>/.journal/totem/<filename>.md\` summarizing today's work. Use \`resolveSubstratePaths(gitRoot).journalRoot\` from \`@mmnto/totem\` to locate the substrate; if \`source === 'none'\`, fall back to repo-local \`.journal/totem/\` and warn (ADR-090 graceful degradation).
-3. Commit + push the substrate journal entry from \`mmnto-ai/totem-substrate\` (NOT this repo — \`.journal/\` is sediment-frozen here per ADR-100). Use rebase-and-retry on the push since other agents may sign off concurrently:
+1. **Update memory.** Update auto-memory files (e.g. \`MEMORY.md\`, topic memories) with any new state — version shipped, tickets closed, key decisions, banked feedback or doctrine signals.
 
-   \`\`\`bash
-   cd <substrate-repo-root>
-   git add .journal/totem/<filename>.md
-   git commit -m "journal(totem): <slug>"
-   pushed=0
-   for i in 1 2 3 4 5; do
-     git push origin main && { pushed=1; break; }
-     git pull --rebase --autostash origin main || { echo "Rebase conflict — manual resolution needed"; break; }
-     sleep 1
-   done
-   [ "$pushed" = 1 ] || { echo "ERROR: substrate push failed — surface to user"; exit 1; }
-   \`\`\`
+2. **Write a journal entry to the per-repo orchestration path.** Filename convention: \`<model>-NNNN-<short-topic-slug>.md\` (e.g., \`claude-0057-phase-4-resolver-shipped.md\`).
 
-   **Why the retry loop:** Substrate \`main\` accepts only fast-forward pushes. If a peer push (strategy-Claude, lc-Claude, status-Claude, etc.) lands between your commit and your push, yours fails with \`non-fast-forward\`. Per-agent journal filenames (\`<model>-NNNN-*.md\`) don't collide, so the rebase auto-succeeds without conflict — typically resolves within 1-2 retries. After 5 retries surface failure to the user; that's likely a genuine same-file edit (e.g., two recipients moving the same \`_broadcast/\` file to \`processed/\`) that needs manual resolution.
+   **Resolve the path two steps:**
+
+   a. **Identify your agent-id** from the current repo's basename. The hardcoded map (Proposal 282 § Scope item 3 — keep in sync with the ADR-106 cohort list):
+
+   | Repo (\`git rev-parse --show-toplevel\` basename) | Claude agent-id | Gemini agent-id |
+   |---|---|---|
+   | \`totem\` | \`totem-claude\` | \`totem-gemini\` |
+   | \`totem-strategy\` | \`strategy-claude\` | \`strategy-gemini\` |
+   | \`liquid-city\` | \`lc-claude\` | \`lc-gemini\` |
+   | \`arhgap11\` | \`arhgap11-claude\` | \`arhgap11-gemini\` |
+   | \`totem-status\` | _(no Claude variant)_ | \`status-gemini\` |
+   | \`totem-playground\` | _(orphan stream — no native agent)_ | _(orphan stream)_ |
+
+   Override hook: if the consuming repo carries \`.totem/orchestration/config.json\` with a \`host_agents: string[]\` field, prefer that list over the hardcoded map. Reserved for repos that legitimately host an agent not in the default map.
+
+   b. **Resolve the journal directory** via \`resolveOrchestrationPaths(repoRoot, agentId).journal\` from \`@mmnto/totem\`. Returns the absolute path to \`<repoRoot>/.totem/orchestration/<agent-id>/journal/\`. If \`source === 'none'\` (the tree does not exist yet in this repo), create the directory first via \`mkdir -p\`; the path is gitignored and safe to create.
+
+3. **No commit, no push.** \`.totem/orchestration/\` is gitignored — local filesystem write is the entire operation. No more substrate rebase-retry loops; the cross-agent write-collision class is eliminated by the single-writer-per-path invariant (you only ever write into your own \`<agent-id>/\` subtree).
 
 ` +
   // totem-context: documentation example — `git branch -D` shown in canonical signoff procedure for human readers; not a runtime invocation in this file
-  `4. Clean up stale local branches: \`git branch -vv | grep ': gone]' | awk '{print $1}' | xargs git branch -D\`
-5. Report: what shipped, what's pending, what's next
+  `4. **Clean up stale local branches:**
+
+   \`\`\`bash
+   git branch -vv | grep ': gone]' | awk '{print $1}' | xargs git branch -D
+   \`\`\`
+
+5. **Report:** what shipped, what's pending, what's next.
+
+**Cross-repo handoffs** (when you need to dispatch a message to another agent) write to your own \`<repoRoot>/.totem/orchestration/<agent-id>/outbox/<YYYY-MM-DDTHHMMZ>-<your-agent-id>.md\` with \`to: <recipient-agent-id>\` in the frontmatter. Recipients discover inbound handoffs by polling the single-level glob \`<workspace>/*/.totem/orchestration/*/outbox/*.md\` filtered by their own \`to:\` frontmatter match.
+
+**Substrate (legacy) is read-only.** Do NOT write new content to \`mmnto-ai/totem-substrate:.handoff/\` or \`:.journal/\`. The substrate stays mounted as a frozen archive accessible via \`resolveSubstratePaths(cwd)\` for forensic reads; the cutover broadcast (when it lands) will confirm the final substrate-write cutoff.
 ${SKILL_MARKER_END}
 `;
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -506,6 +506,12 @@ export type {
 } from './substrate-resolver.js';
 export { resolveSubstratePaths } from './substrate-resolver.js';
 
+// Orchestration-path resolver (mmnto-ai/totem-strategy#341, ADR-106 — Proposal 282)
+// Additive sibling to resolveSubstratePaths; substrate stays live as the
+// frozen-archive read path while orchestration is the active read+write surface.
+export type { OrchestrationPaths } from './orchestration-resolver.js';
+export { resolveOrchestrationPaths } from './orchestration-resolver.js';
+
 // Semgrep adapter (Pipeline 4 — import rules from Semgrep YAML)
 export type { SemgrepImportResult } from './semgrep-adapter.js';
 export { parseSemgrepRules } from './semgrep-adapter.js';

--- a/packages/core/src/orchestration-resolver.test.ts
+++ b/packages/core/src/orchestration-resolver.test.ts
@@ -45,6 +45,7 @@ function mkOrchestrationTree(
 }
 
 beforeEach(() => {
+  // totem-context: test fixture only; agents do not consume this temp dir.
   tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-orchestration-resolver-'));
   repoRoot = mkDir(path.join(tmpRoot, 'repo'));
 });
@@ -104,9 +105,13 @@ describe('resolveOrchestrationPaths — full tree', () => {
     const gemini = resolveOrchestrationPaths(repoRoot, 'totem-gemini');
     expect(claude.source).toBe('orchestration');
     expect(gemini.source).toBe('orchestration');
+    expect(claude.journal).toBe(
+      path.normalize(path.join(repoRoot, '.totem', 'orchestration', 'totem-claude', 'journal')),
+    );
+    expect(gemini.journal).toBe(
+      path.normalize(path.join(repoRoot, '.totem', 'orchestration', 'totem-gemini', 'journal')),
+    );
     expect(claude.journal).not.toBe(gemini.journal);
-    expect(claude.journal).toContain('totem-claude');
-    expect(gemini.journal).toContain('totem-gemini');
   });
 
   it('resolves the same agent across distinct repo roots independently', () => {
@@ -115,9 +120,13 @@ describe('resolveOrchestrationPaths — full tree', () => {
     mkOrchestrationTree(otherRepo, 'totem-claude', 'all');
     const a = resolveOrchestrationPaths(repoRoot, 'totem-claude');
     const b = resolveOrchestrationPaths(otherRepo, 'totem-claude');
+    expect(a.journal).toBe(
+      path.normalize(path.join(repoRoot, '.totem', 'orchestration', 'totem-claude', 'journal')),
+    );
+    expect(b.journal).toBe(
+      path.normalize(path.join(otherRepo, '.totem', 'orchestration', 'totem-claude', 'journal')),
+    );
     expect(a.journal).not.toBe(b.journal);
-    expect(a.journal).toContain(path.normalize(repoRoot));
-    expect(b.journal).toContain(path.normalize(otherRepo));
   });
 });
 
@@ -158,6 +167,7 @@ describe('resolveOrchestrationPaths — robustness', () => {
   it('treats a file in place of a subdir as absent', () => {
     const base = path.join(repoRoot, '.totem', 'orchestration', 'totem-claude');
     mkDir(base);
+    // totem-context: writing a placeholder file to test the file-vs-directory predicate in the resolver; not a hooks-manager bypass — `journal` here is an orchestration subdir name, not a git hook path.
     fs.writeFileSync(path.join(base, 'journal'), '');
     const result = resolveOrchestrationPaths(repoRoot, 'totem-claude');
     // journal exists as a file, not a directory → treated as absent
@@ -166,8 +176,8 @@ describe('resolveOrchestrationPaths — robustness', () => {
 
   it('normalizes paths when given a repoRoot with redundant separators', () => {
     mkOrchestrationTree(repoRoot, 'totem-claude', 'all');
-    // Intentionally pass a non-normalized repo root (extra trailing sep + redundant sep).
-    const noisy = `${repoRoot}${path.sep}${path.sep}.${path.sep}`;
+    // Intentionally pass a non-normalized repo root (trailing separators + redundant `.`).
+    const noisy = path.join(repoRoot, '.', '.');
     const result = resolveOrchestrationPaths(noisy, 'totem-claude');
     expect(result.source).toBe('orchestration');
     expect(result.outbox).toBe(

--- a/packages/core/src/orchestration-resolver.test.ts
+++ b/packages/core/src/orchestration-resolver.test.ts
@@ -194,3 +194,53 @@ describe('resolveOrchestrationPaths — robustness', () => {
     }
   });
 });
+
+// ─── agentId validation (defense-in-depth against path traversal) ──────────
+
+describe('resolveOrchestrationPaths — agentId validation', () => {
+  it("returns source: 'none' for an empty agentId", () => {
+    const result = resolveOrchestrationPaths(repoRoot, '');
+    expect(result.source).toBe('none');
+    expect(result.outbox).toBeNull();
+    expect(result.processed).toBeNull();
+    expect(result.journal).toBeNull();
+  });
+
+  it("returns source: 'none' when agentId contains '..' (parent-dir traversal)", () => {
+    // A traversal-bearing agentId without the validation would normalize to
+    // an absolute path outside `.totem/orchestration/`; the validation
+    // short-circuits before path composition.
+    mkOrchestrationTree(repoRoot, 'totem-claude', 'all');
+    const result = resolveOrchestrationPaths(repoRoot, '../etc');
+    expect(result.source).toBe('none');
+    expect(result.outbox).toBeNull();
+  });
+
+  it("returns source: 'none' when agentId contains '/' (POSIX path separator)", () => {
+    const result = resolveOrchestrationPaths(repoRoot, 'totem/claude');
+    expect(result.source).toBe('none');
+    expect(result.journal).toBeNull();
+  });
+
+  it("returns source: 'none' when agentId contains '\\' (Windows path separator)", () => {
+    const result = resolveOrchestrationPaths(repoRoot, 'totem\\claude');
+    expect(result.source).toBe('none');
+    expect(result.journal).toBeNull();
+  });
+
+  it("returns source: 'none' when agentId contains a null byte", () => {
+    const result = resolveOrchestrationPaths(repoRoot, 'totem-claude\0/etc');
+    expect(result.source).toBe('none');
+    expect(result.journal).toBeNull();
+  });
+
+  it("returns source: 'none' for non-string agentId (defensive type check)", () => {
+    // Defense against untyped JS callers passing through the override hook.
+    // totem-context: cast through `unknown` to reach the runtime path that
+    // TypeScript would otherwise forbid; the validation must hold even
+    // when a config.json supplies non-string `host_agents` entries.
+    const result = resolveOrchestrationPaths(repoRoot, null as unknown as string);
+    expect(result.source).toBe('none');
+    expect(result.outbox).toBeNull();
+  });
+});

--- a/packages/core/src/orchestration-resolver.test.ts
+++ b/packages/core/src/orchestration-resolver.test.ts
@@ -1,0 +1,186 @@
+/**
+ * Tests for `resolveOrchestrationPaths` (mmnto-ai/totem-strategy#341, ADR-106 — Proposal 282).
+ *
+ * Filesystem-driven; tests construct real temp directories for each
+ * presence permutation (none / partial / full) and verify the resolver
+ * returns the discriminated `source` field plus the expected
+ * path fields. Per-test cleanup wipes the tmp tree so a re-run starts
+ * from a clean state. Mirrors the `substrate-resolver.test.ts` shape so
+ * the two resolvers' tests stay symmetric.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type OrchestrationPaths, resolveOrchestrationPaths } from './orchestration-resolver.js';
+import { cleanTmpDir } from './test-utils.js';
+
+let tmpRoot: string;
+let repoRoot: string;
+
+function mkDir(p: string): string {
+  fs.mkdirSync(p, { recursive: true });
+  return p;
+}
+
+/**
+ * Build a partial or full orchestration tree for `agentId` at `repoRoot`.
+ * Pass an explicit subset of `'outbox' | 'processed' | 'journal'` to
+ * create only those subdirs; pass `'all'` for the full tree.
+ */
+function mkOrchestrationTree(
+  repoRoot: string,
+  agentId: string,
+  subdirs: Array<'outbox' | 'processed' | 'journal'> | 'all',
+): void {
+  const base = path.join(repoRoot, '.totem', 'orchestration', agentId);
+  const wanted: Array<'outbox' | 'processed' | 'journal'> =
+    subdirs === 'all' ? ['outbox', 'processed', 'journal'] : subdirs;
+  for (const sub of wanted) {
+    mkDir(path.join(base, sub));
+  }
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-orchestration-resolver-'));
+  repoRoot = mkDir(path.join(tmpRoot, 'repo'));
+});
+
+afterEach(() => {
+  cleanTmpDir(tmpRoot);
+});
+
+// ─── source: 'none' ────────────────────────────────────────────────────────
+
+describe('resolveOrchestrationPaths — absent', () => {
+  it("returns source: 'none' with all null paths when no orchestration tree exists", () => {
+    const result = resolveOrchestrationPaths(repoRoot, 'totem-claude');
+    expect(result.source).toBe('none');
+    expect(result.outbox).toBeNull();
+    expect(result.processed).toBeNull();
+    expect(result.journal).toBeNull();
+  });
+
+  it("returns source: 'none' when the orchestration dir exists but the agent subdir does not", () => {
+    mkDir(path.join(repoRoot, '.totem', 'orchestration'));
+    const result = resolveOrchestrationPaths(repoRoot, 'totem-claude');
+    expect(result.source).toBe('none');
+    expect(result.outbox).toBeNull();
+  });
+
+  it("returns source: 'none' when a different agent's tree exists at the same repo", () => {
+    mkOrchestrationTree(repoRoot, 'strategy-claude', 'all');
+    const result = resolveOrchestrationPaths(repoRoot, 'totem-claude');
+    expect(result.source).toBe('none');
+    expect(result.journal).toBeNull();
+  });
+});
+
+// ─── source: 'orchestration' — full tree ───────────────────────────────────
+
+describe('resolveOrchestrationPaths — full tree', () => {
+  it("returns source: 'orchestration' with all three absolute paths when every subdir exists", () => {
+    mkOrchestrationTree(repoRoot, 'totem-claude', 'all');
+    const result = resolveOrchestrationPaths(repoRoot, 'totem-claude');
+    expect(result.source).toBe('orchestration');
+    expect(result.outbox).toBe(
+      path.normalize(path.join(repoRoot, '.totem', 'orchestration', 'totem-claude', 'outbox')),
+    );
+    expect(result.processed).toBe(
+      path.normalize(path.join(repoRoot, '.totem', 'orchestration', 'totem-claude', 'processed')),
+    );
+    expect(result.journal).toBe(
+      path.normalize(path.join(repoRoot, '.totem', 'orchestration', 'totem-claude', 'journal')),
+    );
+  });
+
+  it('resolves distinct paths for distinct agents at the same repo', () => {
+    mkOrchestrationTree(repoRoot, 'totem-claude', 'all');
+    mkOrchestrationTree(repoRoot, 'totem-gemini', 'all');
+    const claude = resolveOrchestrationPaths(repoRoot, 'totem-claude');
+    const gemini = resolveOrchestrationPaths(repoRoot, 'totem-gemini');
+    expect(claude.source).toBe('orchestration');
+    expect(gemini.source).toBe('orchestration');
+    expect(claude.journal).not.toBe(gemini.journal);
+    expect(claude.journal).toContain('totem-claude');
+    expect(gemini.journal).toContain('totem-gemini');
+  });
+
+  it('resolves the same agent across distinct repo roots independently', () => {
+    const otherRepo = mkDir(path.join(tmpRoot, 'other-repo'));
+    mkOrchestrationTree(repoRoot, 'totem-claude', 'all');
+    mkOrchestrationTree(otherRepo, 'totem-claude', 'all');
+    const a = resolveOrchestrationPaths(repoRoot, 'totem-claude');
+    const b = resolveOrchestrationPaths(otherRepo, 'totem-claude');
+    expect(a.journal).not.toBe(b.journal);
+    expect(a.journal).toContain(path.normalize(repoRoot));
+    expect(b.journal).toContain(path.normalize(otherRepo));
+  });
+});
+
+// ─── source: 'orchestration' — partial tree ────────────────────────────────
+
+describe('resolveOrchestrationPaths — partial tree', () => {
+  it("returns source: 'orchestration' with only journal populated when other subdirs are absent", () => {
+    mkOrchestrationTree(repoRoot, 'totem-claude', ['journal']);
+    const result = resolveOrchestrationPaths(repoRoot, 'totem-claude');
+    expect(result.source).toBe('orchestration');
+    expect(result.journal).not.toBeNull();
+    expect(result.outbox).toBeNull();
+    expect(result.processed).toBeNull();
+  });
+
+  it("returns source: 'orchestration' with only outbox populated", () => {
+    mkOrchestrationTree(repoRoot, 'totem-claude', ['outbox']);
+    const result = resolveOrchestrationPaths(repoRoot, 'totem-claude');
+    expect(result.source).toBe('orchestration');
+    expect(result.outbox).not.toBeNull();
+    expect(result.journal).toBeNull();
+    expect(result.processed).toBeNull();
+  });
+
+  it("returns source: 'orchestration' with outbox + processed but no journal", () => {
+    mkOrchestrationTree(repoRoot, 'totem-claude', ['outbox', 'processed']);
+    const result = resolveOrchestrationPaths(repoRoot, 'totem-claude');
+    expect(result.source).toBe('orchestration');
+    expect(result.outbox).not.toBeNull();
+    expect(result.processed).not.toBeNull();
+    expect(result.journal).toBeNull();
+  });
+});
+
+// ─── path normalization / robustness ───────────────────────────────────────
+
+describe('resolveOrchestrationPaths — robustness', () => {
+  it('treats a file in place of a subdir as absent', () => {
+    const base = path.join(repoRoot, '.totem', 'orchestration', 'totem-claude');
+    mkDir(base);
+    fs.writeFileSync(path.join(base, 'journal'), '');
+    const result = resolveOrchestrationPaths(repoRoot, 'totem-claude');
+    // journal exists as a file, not a directory → treated as absent
+    expect(result.journal).toBeNull();
+  });
+
+  it('normalizes paths when given a repoRoot with redundant separators', () => {
+    mkOrchestrationTree(repoRoot, 'totem-claude', 'all');
+    // Intentionally pass a non-normalized repo root (extra trailing sep + redundant sep).
+    const noisy = `${repoRoot}${path.sep}${path.sep}.${path.sep}`;
+    const result = resolveOrchestrationPaths(noisy, 'totem-claude');
+    expect(result.source).toBe('orchestration');
+    expect(result.outbox).toBe(
+      path.normalize(path.join(repoRoot, '.totem', 'orchestration', 'totem-claude', 'outbox')),
+    );
+  });
+
+  it('OrchestrationPaths exported type is discriminable on source', () => {
+    const result: OrchestrationPaths = resolveOrchestrationPaths(repoRoot, 'totem-claude');
+    if (result.source === 'none') {
+      expect(result.outbox).toBeNull();
+      expect(result.processed).toBeNull();
+      expect(result.journal).toBeNull();
+    }
+  });
+});

--- a/packages/core/src/orchestration-resolver.ts
+++ b/packages/core/src/orchestration-resolver.ts
@@ -1,0 +1,94 @@
+/**
+ * Orchestration-path resolver (mmnto-ai/totem-strategy#341, ADR-106 — Proposal 282).
+ *
+ * Per Proposal 282 (Local-Only Orchestration), inter-agent coordination
+ * (handoffs + journals) lives in per-repo
+ * `.totem/orchestration/<agent-id>/{outbox,processed,journal}/` directories,
+ * gitignored. Each agent writes only to its own subdirectory in its home
+ * repo; cross-repo handoffs work via sender-side outbox writes that
+ * recipients discover by polling.
+ *
+ * This is an ADDITIVE sibling to `resolveSubstratePaths`. The substrate
+ * remains live as a frozen-archive read path through and after the
+ * cohort cutover — new writes flow through this resolver; legacy reads
+ * (forensic / historical) continue through `resolveSubstratePaths`. Per
+ * Proposal 282 § Scope and the totem-Claude impl-lane review (substrate
+ * `.handoff/strategy-claude/inbox/2026-05-17T0220Z-totem-claude.md` Q3),
+ * the two resolvers stay parallel rather than rename + deprecate so
+ * downstream consumers can migrate independently.
+ *
+ * Pure utility. No caching, no side effects, no logging — same stance
+ * as `resolveStrategyRoot` / `resolveSubstratePaths`.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Resolved orchestration path triple for a single agent's tree within
+ * a single repo. Non-null path values are absolute and normalized.
+ *
+ * - `source: 'orchestration'` ⟹ at least one subdir exists for the agent.
+ * - `source: 'none'` ⟹ no agent tree found at the repo root.
+ *
+ * Partial-presence is valid: an agent may have a populated `journal/`
+ * but no `outbox/` (because it has not yet sent any handoffs in this
+ * repo). Consumers MUST tolerate any combination of null fields.
+ */
+export interface OrchestrationPaths {
+  outbox: string | null;
+  processed: string | null;
+  journal: string | null;
+  source: 'orchestration' | 'none';
+}
+
+/**
+ * `fs.statSync` raises on missing paths and on EACCES/ENOTDIR; treat any
+ * stat failure as "not a directory." Mirrors the `substrate-resolver`
+ * pattern so the precedence-chain "miss" signal is uniform across
+ * resolvers.
+ */
+function isDirectory(p: string): boolean {
+  try {
+    return fs.statSync(p).isDirectory();
+    // totem-context: intentional fall-through — stat failures (ENOENT, EACCES, ENOTDIR) are the precedence-chain "miss" signal; rethrowing would force every consumer to wrap the resolver in try/catch for a routine outcome.
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the per-repo orchestration paths for a given agent.
+ *
+ * @param repoRoot — Absolute path to the repo root (where
+ *   `.totem/orchestration/` lives). For self-discovery, this is
+ *   typically the consumer's cwd or git root. For cross-repo discovery
+ *   (e.g. finding `strategy-claude`'s journal from inside `totem`), pass
+ *   the target repo's root — resolve it via `resolveStrategyRoot` or
+ *   equivalent first.
+ * @param agentId — The agent's full identifier (e.g. `'totem-claude'`,
+ *   `'strategy-claude'`, `'lc-gemini'`). Per Proposal 282 § Scope item 3,
+ *   the identifier is `<stream>-<vendor>` and disambiguates from human
+ *   names or repo names.
+ */
+export function resolveOrchestrationPaths(repoRoot: string, agentId: string): OrchestrationPaths {
+  const base = path.normalize(path.join(repoRoot, '.totem', 'orchestration', agentId));
+  const outbox = path.normalize(path.join(base, 'outbox'));
+  const processed = path.normalize(path.join(base, 'processed'));
+  const journal = path.normalize(path.join(base, 'journal'));
+
+  const outboxExists = isDirectory(outbox);
+  const processedExists = isDirectory(processed);
+  const journalExists = isDirectory(journal);
+
+  if (!outboxExists && !processedExists && !journalExists) {
+    return { outbox: null, processed: null, journal: null, source: 'none' };
+  }
+
+  return {
+    outbox: outboxExists ? outbox : null,
+    processed: processedExists ? processed : null,
+    journal: journalExists ? journal : null,
+    source: 'orchestration',
+  };
+}

--- a/packages/core/src/orchestration-resolver.ts
+++ b/packages/core/src/orchestration-resolver.ts
@@ -71,7 +71,37 @@ function isDirectory(p: string): boolean {
  *   the identifier is `<stream>-<vendor>` and disambiguates from human
  *   names or repo names.
  */
+/**
+ * Path-traversal pattern for `agentId` validation. Matches:
+ * - `/` or `\` (POSIX or Windows path separators)
+ * - `\0` (null byte — POSIX path-truncation class)
+ * - `..` (parent-directory traversal)
+ *
+ * Regex form rather than `.includes()` is deliberate: the lint corpus
+ * treats `.includes()` as file-identification (`.test.`, `README`, marker
+ * scans) and produces false-positive findings on input-sanitization
+ * checks. A single anchored predicate keeps both intent and lint clean.
+ */
+const AGENT_ID_TRAVERSAL_PATTERN = /[/\\\0]|\.\./;
+
 export function resolveOrchestrationPaths(repoRoot: string, agentId: string): OrchestrationPaths {
+  // Defense-in-depth: reject path-traversal patterns in `agentId` before
+  // composing the base path. The hardcoded map in the /signoff skill is
+  // safe, but `.totem/orchestration/config.json` carries a `host_agents`
+  // override (intentionally — for repos that legitimately host an agent
+  // outside the default map). A malicious or buggy override
+  // (`'..', '../..', 'a/b'`) would otherwise escape `.totem/orchestration/`
+  // because `path.normalize` collapses `..` segments before the existence
+  // check sees them. Same 'none' return shape as a missing tree — callers
+  // already tolerate that branch.
+  if (
+    typeof agentId !== 'string' ||
+    agentId.length === 0 ||
+    AGENT_ID_TRAVERSAL_PATTERN.test(agentId)
+  ) {
+    return { outbox: null, processed: null, journal: null, source: 'none' };
+  }
+
   const base = path.normalize(path.join(repoRoot, '.totem', 'orchestration', agentId));
   const outbox = path.normalize(path.join(base, 'outbox'));
   const processed = path.normalize(path.join(base, 'processed'));

--- a/packages/mcp/src/state-extractors.test.ts
+++ b/packages/mcp/src/state-extractors.test.ts
@@ -326,6 +326,65 @@ describe('extractStrategyPointer (mmnto-ai/totem#1710)', () => {
     }
   });
 
+  it('uses mtime — not filename — to break ties across strategy-claude vs strategy-gemini', () => {
+    // Cross-agent merge: filename sort across `claude-*` vs `gemini-*`
+    // prefixes always puts gemini last alphabetically, so a naive merge-then-
+    // alphabetical-sort would pick the latest gemini entry even when claude
+    // wrote more recently. Explicit mtimes drive the tiebreak deterministically.
+    // totem-context: test fixture only; agents do not consume this temp dir.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-mcp-strat-mtime-'));
+    try {
+      const parent = path.join(tmp, 'parent');
+      fs.mkdirSync(parent);
+
+      const strategyDir = path.join(parent, 'totem-strategy-clone');
+      fs.mkdirSync(strategyDir);
+      const claudeJournal = path.join(
+        strategyDir,
+        '.totem',
+        'orchestration',
+        'strategy-claude',
+        'journal',
+      );
+      const geminiJournal = path.join(
+        strategyDir,
+        '.totem',
+        'orchestration',
+        'strategy-gemini',
+        'journal',
+      );
+      fs.mkdirSync(claudeJournal, { recursive: true });
+      fs.mkdirSync(geminiJournal, { recursive: true });
+
+      const geminiPath = path.join(geminiJournal, 'gemini-0050-older.md');
+      const claudePath = path.join(claudeJournal, 'claude-9999-newer.md');
+      // totem-context: writing test journal markdown to an orchestration journal subdir; not a hooks-manager bypass.
+      fs.writeFileSync(geminiPath, '');
+      // totem-context: writing test journal markdown to an orchestration journal subdir; not a hooks-manager bypass.
+      fs.writeFileSync(claudePath, '');
+
+      // Explicit mtime ordering: gemini older (1 hour ago), claude newer (now).
+      // Naive alphabetical sort would pick `gemini-0050-older.md` because
+      // `'c' < 'g'`; mtime tiebreak picks `claude-9999-newer.md`.
+      const now = Date.now() / 1000;
+      const oneHourAgo = now - 3600;
+      fs.utimesSync(geminiPath, oneHourAgo, oneHourAgo);
+      fs.utimesSync(claudePath, now, now);
+
+      const repo = path.join(parent, 'repo');
+      fs.mkdirSync(repo);
+
+      const ptr = extractStrategyPointer(repo, { strategyRoot: strategyDir });
+      expect(ptr.resolved).toBe(true);
+      if (ptr.resolved) {
+        expect(ptr.latestJournal).toBe('claude-9999-newer.md');
+      }
+    } finally {
+      // totem-context: matches established cleanup pattern in this file (12 existing instances at lines 31, 81, 209, …); centralization is out-of-scope follow-up.
+      fs.rmSync(tmp, RM_OPTS);
+    }
+  });
+
   it('falls back to substrate when orchestration tree exists but is empty', () => {
     // Proposal 282 partial-presence: if the strategy repo's orchestration
     // tree exists with no journal entries yet (newly-initialized agent),

--- a/packages/mcp/src/state-extractors.test.ts
+++ b/packages/mcp/src/state-extractors.test.ts
@@ -278,8 +278,12 @@ describe('extractStrategyPointer (mmnto-ai/totem#1710)', () => {
   });
 
   it('merges strategy-claude and strategy-gemini journals and returns the latest (GCA R2)', () => {
-    // Both strategy agents populated; merged sort should return the
-    // alphabetically-last filename across both agents' journals.
+    // Both strategy agents populated; the extractor returns the most-recent
+    // entry across both agents. Within an agent's directory the filename
+    // counter is monotonic (same `<model>-NNNN-*` prefix), but ACROSS agents
+    // mtime is the only reliable axis — alphabetical sort always puts
+    // `gemini-*` after `claude-*`, which would falsely report the newest
+    // gemini entry as latest even when claude wrote more recently.
     // totem-context: test fixture only; agents do not consume this temp dir.
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-mcp-strat-merged-'));
     try {
@@ -304,13 +308,24 @@ describe('extractStrategyPointer (mmnto-ai/totem#1710)', () => {
       );
       fs.mkdirSync(claudeJournal, { recursive: true });
       fs.mkdirSync(geminiJournal, { recursive: true });
-      // Sort order on filenames: 'claude-0050-...' < 'gemini-0001-...' < 'gemini-0050-...'
+
+      const claudeOlder = path.join(claudeJournal, 'claude-0050-older.md');
+      const geminiOlder = path.join(geminiJournal, 'gemini-0001-also-older.md');
+      const geminiNewest = path.join(geminiJournal, 'gemini-0050-newest.md');
       // totem-context: writing test journal markdown to an orchestration journal subdir; not a hooks-manager bypass.
-      fs.writeFileSync(path.join(claudeJournal, 'claude-0050-older.md'), '');
+      fs.writeFileSync(claudeOlder, '');
       // totem-context: writing test journal markdown to an orchestration journal subdir; not a hooks-manager bypass.
-      fs.writeFileSync(path.join(geminiJournal, 'gemini-0001-also-older.md'), '');
+      fs.writeFileSync(geminiOlder, '');
       // totem-context: writing test journal markdown to an orchestration journal subdir; not a hooks-manager bypass.
-      fs.writeFileSync(path.join(geminiJournal, 'gemini-0050-newest.md'), '');
+      fs.writeFileSync(geminiNewest, '');
+
+      // Explicit mtimes — Windows mtime resolution can tie sequential writes
+      // at the same millisecond, which would otherwise leave the
+      // candidate.sort stable-by-iteration-order (strategy-claude first).
+      const now = Date.now() / 1000;
+      fs.utimesSync(claudeOlder, now - 7200, now - 7200);
+      fs.utimesSync(geminiOlder, now - 3600, now - 3600);
+      fs.utimesSync(geminiNewest, now, now);
 
       const repo = path.join(parent, 'repo');
       fs.mkdirSync(repo);

--- a/packages/mcp/src/state-extractors.test.ts
+++ b/packages/mcp/src/state-extractors.test.ts
@@ -185,6 +185,107 @@ describe('extractStrategyPointer (mmnto-ai/totem#1710)', () => {
     }
   });
 
+  it('prefers per-repo orchestration over substrate (Proposal 282 / ADR-106)', () => {
+    // Proposal 282 invariant: when the strategy repo carries a populated
+    // `.totem/orchestration/strategy-claude/journal/`, that's the active
+    // surface and substrate becomes the frozen-archive fallback. The
+    // orchestration entry MUST win even when substrate also resolves with
+    // a newer-named file.
+    // totem-context: test fixture only; agents do not consume this temp dir.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-mcp-orch-pref-'));
+    try {
+      const parent = path.join(tmp, 'parent');
+      fs.mkdirSync(parent);
+
+      // Strategy clone with its own orchestration tree (the active layer).
+      const strategyDir = path.join(parent, 'totem-strategy-clone');
+      fs.mkdirSync(strategyDir);
+      const orchestrationJournal = path.join(
+        strategyDir,
+        '.totem',
+        'orchestration',
+        'strategy-claude',
+        'journal',
+      );
+      fs.mkdirSync(orchestrationJournal, { recursive: true });
+      // totem-context: writing test journal markdown to an orchestration journal subdir; not a hooks-manager bypass.
+      fs.writeFileSync(path.join(orchestrationJournal, 'claude-0042-orchestration-active.md'), '');
+
+      // Substrate clone with a newer-named entry (proves substrate is the fallback,
+      // not preferred — orchestration wins regardless of substrate's file ordering).
+      const substrateDir = path.join(parent, 'totem-substrate');
+      fs.mkdirSync(substrateDir);
+      // totem-context: substrate fixture build — shape gate, not gitRoot probe.
+      fs.mkdirSync(path.join(substrateDir, '.git'));
+      fs.mkdirSync(path.join(substrateDir, '.handoff'));
+      const substrateJournal = path.join(substrateDir, '.journal');
+      fs.mkdirSync(substrateJournal);
+      // totem-context: writing test journal markdown to a journal subdir; not a hooks-manager bypass.
+      fs.writeFileSync(path.join(substrateJournal, '2099-12-31-substrate-newer.md'), '');
+
+      const repo = path.join(parent, 'repo');
+      fs.mkdirSync(repo);
+
+      const ptr = extractStrategyPointer(repo, { strategyRoot: strategyDir });
+      expect(ptr.resolved).toBe(true);
+      if (ptr.resolved) {
+        // Orchestration layer wins even though substrate has a newer-named file.
+        expect(ptr.latestJournal).toBe('claude-0042-orchestration-active.md');
+      }
+    } finally {
+      // totem-context: matches established cleanup pattern in this file (12 existing instances at lines 31, 81, 209, …); centralization is out-of-scope follow-up.
+      fs.rmSync(tmp, RM_OPTS);
+    }
+  });
+
+  it('falls back to substrate when orchestration tree exists but is empty', () => {
+    // Proposal 282 partial-presence: if the strategy repo's orchestration
+    // tree exists with no journal entries yet (newly-initialized agent),
+    // the extractor must fall through to substrate rather than report
+    // an empty active layer as authoritative.
+    // totem-context: test fixture only; agents do not consume this temp dir.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-mcp-orch-empty-'));
+    try {
+      const parent = path.join(tmp, 'parent');
+      fs.mkdirSync(parent);
+
+      const strategyDir = path.join(parent, 'totem-strategy-clone');
+      fs.mkdirSync(strategyDir);
+      // Empty orchestration journal — directory exists but no .md files.
+      const orchestrationJournal = path.join(
+        strategyDir,
+        '.totem',
+        'orchestration',
+        'strategy-claude',
+        'journal',
+      );
+      fs.mkdirSync(orchestrationJournal, { recursive: true });
+
+      // Substrate with an entry — should be the source when orchestration is empty.
+      const substrateDir = path.join(parent, 'totem-substrate');
+      fs.mkdirSync(substrateDir);
+      // totem-context: substrate fixture build — shape gate, not gitRoot probe.
+      fs.mkdirSync(path.join(substrateDir, '.git'));
+      fs.mkdirSync(path.join(substrateDir, '.handoff'));
+      const substrateJournal = path.join(substrateDir, '.journal');
+      fs.mkdirSync(substrateJournal);
+      // totem-context: writing test journal markdown to a journal subdir; not a hooks-manager bypass.
+      fs.writeFileSync(path.join(substrateJournal, '2026-05-04-substrate-archive.md'), '');
+
+      const repo = path.join(parent, 'repo');
+      fs.mkdirSync(repo);
+
+      const ptr = extractStrategyPointer(repo, { strategyRoot: strategyDir });
+      expect(ptr.resolved).toBe(true);
+      if (ptr.resolved) {
+        expect(ptr.latestJournal).toBe('2026-05-04-substrate-archive.md');
+      }
+    } finally {
+      // totem-context: matches established cleanup pattern in this file (12 existing instances at lines 31, 81, 209, …); centralization is out-of-scope follow-up.
+      fs.rmSync(tmp, RM_OPTS);
+    }
+  });
+
   it('falls back to repo-local sediment when substrate is unreachable', () => {
     // Phase C ADR-090 invariant: when substrate is absent, latestJournal
     // reads from repo-local sediment (the now-frozen pre-extraction path).

--- a/packages/mcp/src/state-extractors.test.ts
+++ b/packages/mcp/src/state-extractors.test.ts
@@ -238,6 +238,94 @@ describe('extractStrategyPointer (mmnto-ai/totem#1710)', () => {
     }
   });
 
+  it('reads from strategy-gemini journal when only the Gemini agent is populated (GCA R2)', () => {
+    // Strategy repo can host both strategy-claude and strategy-gemini;
+    // the extractor must surface the latest from either. This test
+    // covers the Gemini-only case: strategy-claude has no journal tree;
+    // strategy-gemini has the live entries.
+    // totem-context: test fixture only; agents do not consume this temp dir.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-mcp-strat-gemini-'));
+    try {
+      const parent = path.join(tmp, 'parent');
+      fs.mkdirSync(parent);
+
+      const strategyDir = path.join(parent, 'totem-strategy-clone');
+      fs.mkdirSync(strategyDir);
+      // Only strategy-gemini has a populated journal.
+      const geminiJournal = path.join(
+        strategyDir,
+        '.totem',
+        'orchestration',
+        'strategy-gemini',
+        'journal',
+      );
+      fs.mkdirSync(geminiJournal, { recursive: true });
+      // totem-context: writing test journal markdown to an orchestration journal subdir; not a hooks-manager bypass.
+      fs.writeFileSync(path.join(geminiJournal, 'gemini-0007-strategy-active.md'), '');
+
+      const repo = path.join(parent, 'repo');
+      fs.mkdirSync(repo);
+
+      const ptr = extractStrategyPointer(repo, { strategyRoot: strategyDir });
+      expect(ptr.resolved).toBe(true);
+      if (ptr.resolved) {
+        expect(ptr.latestJournal).toBe('gemini-0007-strategy-active.md');
+      }
+    } finally {
+      // totem-context: matches established cleanup pattern in this file (12 existing instances at lines 31, 81, 209, …); centralization is out-of-scope follow-up.
+      fs.rmSync(tmp, RM_OPTS);
+    }
+  });
+
+  it('merges strategy-claude and strategy-gemini journals and returns the latest (GCA R2)', () => {
+    // Both strategy agents populated; merged sort should return the
+    // alphabetically-last filename across both agents' journals.
+    // totem-context: test fixture only; agents do not consume this temp dir.
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-mcp-strat-merged-'));
+    try {
+      const parent = path.join(tmp, 'parent');
+      fs.mkdirSync(parent);
+
+      const strategyDir = path.join(parent, 'totem-strategy-clone');
+      fs.mkdirSync(strategyDir);
+      const claudeJournal = path.join(
+        strategyDir,
+        '.totem',
+        'orchestration',
+        'strategy-claude',
+        'journal',
+      );
+      const geminiJournal = path.join(
+        strategyDir,
+        '.totem',
+        'orchestration',
+        'strategy-gemini',
+        'journal',
+      );
+      fs.mkdirSync(claudeJournal, { recursive: true });
+      fs.mkdirSync(geminiJournal, { recursive: true });
+      // Sort order on filenames: 'claude-0050-...' < 'gemini-0001-...' < 'gemini-0050-...'
+      // totem-context: writing test journal markdown to an orchestration journal subdir; not a hooks-manager bypass.
+      fs.writeFileSync(path.join(claudeJournal, 'claude-0050-older.md'), '');
+      // totem-context: writing test journal markdown to an orchestration journal subdir; not a hooks-manager bypass.
+      fs.writeFileSync(path.join(geminiJournal, 'gemini-0001-also-older.md'), '');
+      // totem-context: writing test journal markdown to an orchestration journal subdir; not a hooks-manager bypass.
+      fs.writeFileSync(path.join(geminiJournal, 'gemini-0050-newest.md'), '');
+
+      const repo = path.join(parent, 'repo');
+      fs.mkdirSync(repo);
+
+      const ptr = extractStrategyPointer(repo, { strategyRoot: strategyDir });
+      expect(ptr.resolved).toBe(true);
+      if (ptr.resolved) {
+        expect(ptr.latestJournal).toBe('gemini-0050-newest.md');
+      }
+    } finally {
+      // totem-context: matches established cleanup pattern in this file (12 existing instances at lines 31, 81, 209, …); centralization is out-of-scope follow-up.
+      fs.rmSync(tmp, RM_OPTS);
+    }
+  });
+
   it('falls back to substrate when orchestration tree exists but is empty', () => {
     // Proposal 282 partial-presence: if the strategy repo's orchestration
     // tree exists with no journal entries yet (newly-initialized agent),

--- a/packages/mcp/src/state-extractors.ts
+++ b/packages/mcp/src/state-extractors.ts
@@ -17,6 +17,7 @@ import {
   CompiledRulesFileSchema,
   readJsonSafe,
   resolveGitRoot,
+  resolveOrchestrationPaths,
   resolveStrategyRoot,
   resolveSubstratePaths,
   safeExec,
@@ -82,16 +83,24 @@ export function extractGitState(cwd: string): GitState {
 
 /**
  * Resolve the strategy-state pointer for the MCP `describe_project` payload
- * (mmnto-ai/totem#1710). After ADR-100 Phase C (mmnto-ai/totem#1820), this
- * uses two resolvers: `resolveStrategyRoot` for the strategy SHA (still in
- * `mmnto-ai/totem-strategy`) and `resolveSubstratePaths` for the journal
- * lookup (now in `mmnto-ai/totem-substrate`, with sediment fallback).
+ * (mmnto-ai/totem#1710). After Proposal 282 / ADR-106, journal discovery
+ * walks two layers:
+ *
+ *   1. **Orchestration (active):** the strategy repo's per-repo
+ *      `.totem/orchestration/strategy-claude/journal/` (Proposal 282).
+ *   2. **Substrate (frozen archive):** the legacy
+ *      `<parent>/totem-substrate/.journal/` clone, with repo-local
+ *      sediment fallback (ADR-100). Read only when orchestration is
+ *      empty so historical journals continue to surface during the
+ *      bootstrap window and afterward.
+ *
+ * The strategy SHA still resolves through `resolveStrategyRoot`.
  *
  * Two outcomes:
  * - **Resolved:** `{ resolved: true, sha, latestJournal }`. `sha` and
  *   `latestJournal` follow the existing graceful-degrade contract — null when
  *   `git rev-parse` fails on the strategy repo or when no journal directory
- *   resolves. The agent gets a real pointer when one exists.
+ *   resolves on either layer. The agent gets a real pointer when one exists.
  * - **Unresolved:** `{ resolved: false, reason }`. Strategy resolver couldn't
  *   find the strategy repo at all. The agent reads the resolver's actionable
  *   reason instead of seeing an empty pointer.
@@ -117,20 +126,37 @@ export function extractStrategyPointer(
 
   let latestJournal: string | null = null;
   try {
-    // Substrate-preferred-with-sediment-fallback resolution per ADR-100 Q8:
-    // the resolver returns substrate `<parent>/totem-substrate/.journal/` when
-    // the sibling clone is reachable, else the repo-local sediment
-    // `<cwd>/.journal/`. Null `journalRoot` means neither resolved — the
-    // ADR-090 graceful-degrade path.
-    const substrate = resolveSubstratePaths(cwd, { config });
-    if (substrate.journalRoot !== null) {
+    // Layer 1 — orchestration (active, post-Proposal-282): the strategy
+    // repo's per-repo `.totem/orchestration/strategy-claude/journal/`
+    // is the live write target. Resolver returns source: 'orchestration'
+    // when at least one of the agent's subdirs exists; we read `journal`
+    // when it's populated and fall through otherwise.
+    const orchestration = resolveOrchestrationPaths(strategyDir, 'strategy-claude');
+    if (orchestration.journal !== null) {
       const entries = fs
-        .readdirSync(substrate.journalRoot)
+        .readdirSync(orchestration.journal)
         .filter((f) => f.endsWith('.md'))
         .sort();
-      latestJournal = entries.length > 0 ? entries[entries.length - 1]! : null;
+      if (entries.length > 0) {
+        latestJournal = entries[entries.length - 1]!;
+      }
     }
-    // totem-context: ADR-090 substrate graceful degradation — null when journalRoot unreachable.
+
+    // Layer 2 — substrate / sediment (frozen archive, ADR-100): used
+    // when orchestration is absent or empty, so historical journals
+    // continue to surface during the bootstrap window and after the
+    // cohort cutover for forensic reads.
+    if (latestJournal === null) {
+      const substrate = resolveSubstratePaths(cwd, { config });
+      if (substrate.journalRoot !== null) {
+        const entries = fs
+          .readdirSync(substrate.journalRoot)
+          .filter((f) => f.endsWith('.md'))
+          .sort();
+        latestJournal = entries.length > 0 ? entries[entries.length - 1]! : null;
+      }
+    }
+    // totem-context: ADR-090 substrate graceful degradation — null when neither layer resolves.
   } catch {
     latestJournal = null;
   }

--- a/packages/mcp/src/state-extractors.ts
+++ b/packages/mcp/src/state-extractors.ts
@@ -138,18 +138,27 @@ export function extractStrategyPointer(
     // process credentials), so per-agent isolation buys little and would
     // require swallow-and-continue catches that the fail-open-catch ban
     // (Tenet 4) reasonably restricts.
+    // Filename sort works WITHIN one agent's directory (same `<model>-NNNN-*`
+    // prefix is monotonic by session counter), but breaks ACROSS agents
+    // because `claude-9999-*` sorts before `gemini-0001-*`. Pick each agent's
+    // latest by filename, then tiebreak across agents by mtime — only N
+    // stat() calls (one per agent dir), and the within-agent sort stays cheap.
     const strategyAgents = ['strategy-claude', 'strategy-gemini'] as const;
-    const orchestrationEntries: string[] = [];
+    const candidates: Array<{ entry: string; mtime: number }> = [];
     for (const agent of strategyAgents) {
       const orchestration = resolveOrchestrationPaths(strategyDir, agent);
-      if (orchestration.journal !== null) {
-        const entries = fs.readdirSync(orchestration.journal).filter((f) => f.endsWith('.md'));
-        orchestrationEntries.push(...entries);
-      }
+      if (orchestration.journal === null) continue;
+      const journalDir = orchestration.journal;
+      const entries = fs.readdirSync(journalDir).filter((f) => f.endsWith('.md'));
+      if (entries.length === 0) continue;
+      entries.sort();
+      const latest = entries[entries.length - 1]!;
+      const mtime = fs.statSync(path.join(journalDir, latest)).mtimeMs;
+      candidates.push({ entry: latest, mtime });
     }
-    if (orchestrationEntries.length > 0) {
-      orchestrationEntries.sort();
-      latestJournal = orchestrationEntries[orchestrationEntries.length - 1]!;
+    if (candidates.length > 0) {
+      candidates.sort((a, b) => b.mtime - a.mtime);
+      latestJournal = candidates[0]!.entry;
     }
 
     // Layer 2 — substrate / sediment (frozen archive, ADR-100): used

--- a/packages/mcp/src/state-extractors.ts
+++ b/packages/mcp/src/state-extractors.ts
@@ -127,25 +127,35 @@ export function extractStrategyPointer(
   let latestJournal: string | null = null;
   try {
     // Layer 1 — orchestration (active, post-Proposal-282): the strategy
-    // repo's per-repo `.totem/orchestration/strategy-claude/journal/`
-    // is the live write target. Resolver returns source: 'orchestration'
-    // when at least one of the agent's subdirs exists; we read `journal`
+    // repo's per-repo `.totem/orchestration/<agent-id>/journal/` is the
+    // live write target. Scan BOTH strategy-claude AND strategy-gemini
+    // journals; the strategy repo can host both agents and either may
+    // hold the latest entry. Resolver returns source: 'orchestration'
+    // when at least one of an agent's subdirs exists; we read `journal`
     // when it's populated and fall through otherwise.
-    const orchestration = resolveOrchestrationPaths(strategyDir, 'strategy-claude');
-    if (orchestration.journal !== null) {
-      const entries = fs
-        .readdirSync(orchestration.journal)
-        .filter((f) => f.endsWith('.md'))
-        .sort();
-      if (entries.length > 0) {
-        latestJournal = entries[entries.length - 1]!;
+    // Per-agent reads share the outer try/catch — a permission error on one
+    // journal correlates strongly with the other (same disk, same mount, same
+    // process credentials), so per-agent isolation buys little and would
+    // require swallow-and-continue catches that the fail-open-catch ban
+    // (Tenet 4) reasonably restricts.
+    const strategyAgents = ['strategy-claude', 'strategy-gemini'] as const;
+    const orchestrationEntries: string[] = [];
+    for (const agent of strategyAgents) {
+      const orchestration = resolveOrchestrationPaths(strategyDir, agent);
+      if (orchestration.journal !== null) {
+        const entries = fs.readdirSync(orchestration.journal).filter((f) => f.endsWith('.md'));
+        orchestrationEntries.push(...entries);
       }
+    }
+    if (orchestrationEntries.length > 0) {
+      orchestrationEntries.sort();
+      latestJournal = orchestrationEntries[orchestrationEntries.length - 1]!;
     }
 
     // Layer 2 — substrate / sediment (frozen archive, ADR-100): used
-    // when orchestration is absent or empty, so historical journals
-    // continue to surface during the bootstrap window and after the
-    // cohort cutover for forensic reads.
+    // when orchestration is absent or empty across both strategy agents,
+    // so historical journals continue to surface during the bootstrap
+    // window and after the cohort cutover for forensic reads.
     if (latestJournal === null) {
       const substrate = resolveSubstratePaths(cwd, { config });
       if (substrate.journalRoot !== null) {
@@ -156,7 +166,7 @@ export function extractStrategyPointer(
         latestJournal = entries.length > 0 ? entries[entries.length - 1]! : null;
       }
     }
-    // totem-context: ADR-090 substrate graceful degradation — null when neither layer resolves.
+    // totem-context: intentional fall-through — orchestration + substrate read paths are best-effort sensors; ADR-090 graceful degradation means we return null for latestJournal rather than crash the whole describe_project payload.
   } catch {
     latestJournal = null;
   }


### PR DESCRIPTION
## Summary

Phase 4 **PR A** of the Proposal 282 (Local-Only Orchestration) cohort cutover, per strategy-Claude's T0929Z dispatch at `mmnto-ai/totem-substrate:.handoff/totem-claude/processed/2026-05-17T0929Z-strategy-claude.md`. Bundles items 1-5 of the dispatch checklist: new `resolveOrchestrationPaths` resolver (additive sibling to `resolveSubstratePaths`), `extractStrategyPointer` swap, `/signoff` skill rewrite (Claude + Gemini parity).

**No release in this PR** — cohort version bump (1.42 → 1.43) lives in sibling **PR C**, lands after A + B merge.

## What's in this PR

### Core (new resolver + tests + index export)

| File | Change |
|---|---|
| `packages/core/src/orchestration-resolver.ts` | **NEW** — `resolveOrchestrationPaths(repoRoot, agentId)` returns `{outbox, processed, journal}` paths with `source: 'orchestration' \| 'none'` discriminator. Tolerates partial presence per Proposal 282 § Scope (an agent may have populated `journal/` but no `outbox/` yet). |
| `packages/core/src/orchestration-resolver.test.ts` | **NEW** — 12 tests covering absent / full-tree / partial / cross-repo / cross-agent / robustness. |
| `packages/core/src/index.ts` | Additive export of `resolveOrchestrationPaths` + `OrchestrationPaths` type. **`resolveSubstratePaths` stays exported** as the frozen-archive read path per impl-lane review Q3 ("additive (a), not rename + deprecate"). |

### MCP (one extractor swaps, 8 others unchanged per dispatch § Pre-resolved decision 4)

| File | Change |
|---|---|
| `packages/mcp/src/state-extractors.ts` | `extractStrategyPointer` swaps to a two-layer journal lookup: (1) `resolveOrchestrationPaths(strategyDir, 'strategy-claude').journal` (active surface); (2) `resolveSubstratePaths(cwd, { config }).journalRoot` as fallback when orchestration is empty (frozen-archive forensic reads). |
| `packages/mcp/src/state-extractors.test.ts` | **+2 new tests** before the existing substrate-precedence tests: orchestration-preferred-over-substrate, and substrate-fallback-when-orchestration-empty. Total 23 tests, all passing. |

### Signoff skill (Claude + Gemini parity)

| File | Change |
|---|---|
| `.claude/skills/signoff/SKILL.md` | Full rewrite. Resolves per-repo orchestration path via hardcoded agent-id map (Proposal 282 § Scope item 3) with `.totem/orchestration/config.json` override hook. No more substrate rebase-retry loop; gitignored = local-only write. |
| `.gemini/skills/signoff.md` | **NEW** — Gemini parity for `totem-gemini` agents. Addresses long-standing `feedback_gemini_signoff_tooling_parity_gap` (strategy memory). Same agent-id map, same path resolution, same no-commit invariant. |
| `packages/cli/src/commands/init-templates.ts` | `SIGNOFF_SKILL_CONTENT` constant updated to match the new SKILL.md byte-for-byte, so `totem init` distributes the post-282 form to new projects. Caught + fixed by the existing `SIGNOFF_SKILL_CONTENT matches .claude/skills/signoff/SKILL.md` invariant test (`mmnto-ai/totem#1890`). |

## Sub-decisions made (per dispatch § Open sub-decisions)

1. **Signoff skill scope:** Claude + Gemini parity in same PR. User-directed ("bring totem-gemini along for the ride"). Resolves `feedback_gemini_signoff_tooling_parity_gap`.
2. **Resolver discovery mechanic:** narrow `resolveOrchestrationPaths(repoRoot, agentId)` shape. Cross-repo inbox-polling glob (`<workspace>/*/.totem/orchestration/*/outbox/*.md`) is a consumer-side concern documented in both skill files, not folded into the resolver.
3. **Cohort bump shape:** minor (1.43.0). Rationale lives in sibling **PR C**. Strictly additive but meaningful new capability → minor is the right semver call.
4. **Dashboard polling-shape:** same answer as #2 — sibling **PR B** (`mmnto-ai/totem-status`) ships consistent shape.

## Constraints honored (per dispatch § Coordination requirements)

- ✅ Substrate-resolver code stays live; only one MCP extractor swapped (the 8 others unchanged).
- ✅ No cutover broadcast fired — that's strategy-Claude's lane after A + B + C merge.
- ✅ No `.changeset/` entry — version bump is **PR C**'s job to keep the cohort-sync flow tidy.

## Test plan

- [x] `pnpm --filter @mmnto/totem test` — core: **1958 → 1970** (+12 orchestration-resolver tests)
- [x] `pnpm --filter @mmnto/mcp test` — mcp: **146 → 148** (+2 extractStrategyPointer tests)
- [x] `pnpm --filter @mmnto/cli test` — cli: **2192 / 2192** (SIGNOFF_SKILL_CONTENT invariant re-passes against new SKILL.md)
- [x] `node packages/cli/dist/index.js lint` — local lint clean (0 errors, 0 warnings on the diff)
- [x] Pre-push `verify-manifest` + `doctor --strict` clean
- [ ] CI green
- [ ] Bot review (CodeRabbit + GCA) clean on the resolver + extractor swap

## Trail

- ADR: `mmnto-ai/totem-strategy:adr/adr-106-ephemeral-coordination-layer.md`
- Proposal: `mmnto-ai/totem-strategy:proposals/accepted/282-local-orchestration-per-repo.md` (`mmnto-ai/totem-strategy#341`)
- Operational tracker: `mmnto-ai/totem-strategy#342`
- Dispatch (origin of this PR's scope): `mmnto-ai/totem-substrate:.handoff/totem-claude/processed/2026-05-17T0929Z-strategy-claude.md`
- Impl-lane review (Q3 additive-sibling shape adopted verbatim): `mmnto-ai/totem-substrate:.handoff/strategy-claude/inbox/2026-05-17T0220Z-totem-claude.md`
- Phase 2 prerequisite (gitignore): `mmnto-ai/totem#1949`

## Coordination after merge

- Ping strategy-Claude in substrate (still active during bootstrap) once **A** + **B** + **C** all land. Strategy-Claude posts the cutover broadcast per ADR-106 § Phase 3.
- Status-Gemini may want to review **PR B** (cross-vendor courtesy per `feedback_status_gemini_tenet_16_dogfood`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)