### PR TITLE
fix(core): harden resolveOrchestrationPaths with path.resolve(repoRoot) (#1953)

### DIFF
--- a/.changeset/orchestration-resolver-abspath-hardening.md
+++ b/.changeset/orchestration-resolver-abspath-hardening.md
@@ -1,0 +1,13 @@
+---
+'@mmnto/totem': patch
+'@mmnto/mcp': patch
+'@mmnto/cli': patch
+---
+
+fix(core): harden resolveOrchestrationPaths with path.resolve(repoRoot) — match resolveSubstratePaths absolute-output guarantee
+
+Closes [mmnto-ai/totem#1953](https://github.com/mmnto-ai/totem/issues/1953). Tier-1 follow-up from the GCA review on [mmnto-ai/totem#1952](https://github.com/mmnto-ai/totem/pull/1952) (Phase 4 PR C changeset).
+
+`resolveOrchestrationPaths` (`packages/core/src/orchestration-resolver.ts`) previously trusted the JSDoc contract that callers supply an absolute `repoRoot`. A caller violating the contract by passing a relative path would get relative `outbox` / `processed` / `journal` paths back — a quiet correctness slip rather than a loud error. `resolveSubstratePaths` runs `path.resolve(configRoot)` on its anchor for the same reason; symmetric guarantee now restored.
+
+One-line fix: `const resolvedRoot = path.resolve(repoRoot);` applied before composition, sibling to the existing path-traversal guard. Plus one new test confirming relative `repoRoot` input produces absolute output (parity with the substrate-resolver path-shape contract). 19 resolver tests green.

--- a/packages/core/src/orchestration-resolver.test.ts
+++ b/packages/core/src/orchestration-resolver.test.ts
@@ -185,6 +185,22 @@ describe('resolveOrchestrationPaths — robustness', () => {
     );
   });
 
+  it('returns absolute paths when given a relative repoRoot (parity with resolveSubstratePaths)', () => {
+    // Contract violation case: caller passes a relative anchor. Without
+    // `path.resolve` at the top of the resolver, the output would be
+    // relative too — a quiet correctness slip. Mirrors
+    // `resolveSubstratePaths` (substrate-resolver.ts) which runs
+    // `path.resolve(configRoot)` on its anchor for the same reason.
+    mkOrchestrationTree(repoRoot, 'totem-claude', 'all');
+    const relativeRepo = path.relative(process.cwd(), repoRoot);
+    const result = resolveOrchestrationPaths(relativeRepo, 'totem-claude');
+    expect(result.source).toBe('orchestration');
+    expect(result.outbox).not.toBeNull();
+    expect(path.isAbsolute(result.outbox!)).toBe(true);
+    expect(path.isAbsolute(result.processed!)).toBe(true);
+    expect(path.isAbsolute(result.journal!)).toBe(true);
+  });
+
   it('OrchestrationPaths exported type is discriminable on source', () => {
     const result: OrchestrationPaths = resolveOrchestrationPaths(repoRoot, 'totem-claude');
     if (result.source === 'none') {

--- a/packages/core/src/orchestration-resolver.ts
+++ b/packages/core/src/orchestration-resolver.ts
@@ -102,7 +102,14 @@ export function resolveOrchestrationPaths(repoRoot: string, agentId: string): Or
     return { outbox: null, processed: null, journal: null, source: 'none' };
   }
 
-  const base = path.normalize(path.join(repoRoot, '.totem', 'orchestration', agentId));
+  // Resolve `repoRoot` to absolute before composition. Without this, a
+  // caller that supplies a relative anchor (against the contract on the
+  // `repoRoot` JSDoc above) returns relative paths in `outbox` /
+  // `processed` / `journal` — a quiet correctness slip rather than a
+  // loud error. `resolveSubstratePaths` runs the same anchor through
+  // `path.resolve` for the same reason; symmetric guarantee.
+  const resolvedRoot = path.resolve(repoRoot);
+  const base = path.normalize(path.join(resolvedRoot, '.totem', 'orchestration', agentId));
   const outbox = path.normalize(path.join(base, 'outbox'));
   const processed = path.normalize(path.join(base, 'processed'));
   const journal = path.normalize(path.join(base, 'journal'));


### PR DESCRIPTION
## Summary

- One-line fix: `path.resolve(repoRoot)` at the top of `resolveOrchestrationPaths`, sibling to the existing path-traversal guard.
- One new test (19 total): relative `repoRoot` input → absolute output, confirming parity with `resolveSubstratePaths`.

Closes #1953. Tier-1 follow-up from the GCA review on #1952.

## Why

`resolveOrchestrationPaths` previously trusted the JSDoc contract that callers supply an absolute `repoRoot`. A caller violating the contract by passing a relative path would get relative `outbox` / `processed` / `journal` paths back — a quiet correctness slip rather than a loud error. `resolveSubstratePaths` runs `path.resolve(configRoot)` on its anchor for the same reason; this restores the symmetric absolute-output behavior.

## Test plan

- [x] 19 resolver tests green (was 18)
- [x] 1977 `@mmnto/totem` tests green
- [x] `pnpm totem review` (shield) PASS — no findings
- [x] Changeset: patch bump across the fixed cohort (`@mmnto/totem`, `@mmnto/mcp`, `@mmnto/cli`)

## Pre-push gate note

Push required `TOTEM_GATE_BYPASS_JUSTIFICATION` for the pre-existing "guarantees" warning on `docs/wiki/governing-ai-agents.md:58` (WWND Rule 1, working as designed per the PR α calibration). My diff is confined to `packages/core/src/orchestration-resolver.{ts,test.ts}` + `.changeset/`. Bypass justification recorded in the commit's local push event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)