### PR TITLE
feat(cli): verify-lockfile-sync pre-push gate (#1961)

### DIFF
--- a/.changeset/verify-lockfile-sync.md
+++ b/.changeset/verify-lockfile-sync.md
@@ -1,0 +1,20 @@
+---
+'@mmnto/cli': patch
+---
+
+feat(cli): add `verify-lockfile-sync` pre-push gate (mmnto-ai/totem#1961)
+
+Closes [mmnto-ai/totem#1961](https://github.com/mmnto-ai/totem/issues/1961).
+
+New deterministic pre-push check that blocks pushes containing `package.json` dependency-pin additions when `pnpm-lock.yaml` is tracked but missing from the same diff range. Catches the cohort-sync failure pattern where a caret bump in `package.json` lands without a regenerated lockfile and CI's `pnpm install --frozen-lockfile` rejects it ~3 minutes later — recorded N=4 across the cohort, including `mmnto-ai/liquid-city#225/#248/#289/#357`.
+
+The gate is invoked from the generated pre-push hook script (`buildPrePushHook` in `install-hooks.ts`), slotted before the WWND claim-discipline gate so the mechanical fast-fail runs before the slower prose-discipline walk. The check is conditioned on `pnpm-lock.yaml` existing in the working tree, so consumers using a different package manager are unaffected.
+
+Implementation notes:
+
+- `packages/cli/src/commands/verify-lockfile-sync.ts` — pure function `verifyLockfileSyncCommand()` returning a `{ valid, reason? }` result, plus `verifyLockfileSyncCliCommand()` throwing `TotemError` for the CLI surface. Mirrors the `verify-badges.ts` shape.
+- Best-effort fall-through on git failures (lockfile not tracked, no remote, detached HEAD, missing refs) — matches the carve-out at `verify-manifest.ts:127-131` so a degraded git state does not block legitimate pushes.
+- Regex `/^\+\s*"(?!version")[^"]+"\s*:\s*"[\^~]?\d+\.\d+/m` excludes the package's own `"version"` field (false-positive class on Version Packages release commits where the lockfile happens to be absent from a partial diff), `workspace:^` references, and bare integer values like `"node": "20"` in `engines` blocks.
+- No bypass flag. The fix is mechanical (`pnpm install`); a bypass invites the exact drift the gate exists to prevent. The standard `git push --no-verify` escape hatch remains available but is explicitly banned in AGENTS.md.
+
+Encodes the rule body of `feedback_strategy_claude_canonical_cohort_sync` from prose-memory (which has reliably failed to self-activate across N=4 cycles) into mechanism, per Tenet 15 (Axiom Mandate — encode as mechanism, not prose).

--- a/.totem/specs/1961.md
+++ b/.totem/specs/1961.md
@@ -1,0 +1,189 @@
+### Problem Statement
+
+Totem needs a pre-push check that intercepts and blocks git pushes when a developer bumps a dependency in `package.json` but fails to commit the regenerated `pnpm-lock.yaml`. This ensures durability for cohort-sync operations and prevents inevitable `ERR_PNPM_OUTDATED_LOCKFILE` failures in `--frozen-lockfile` CI environments.
+
+### Architectural Context
+
+- **Tenet 15 (Axiom Mandate):** The decision to move this from a prose-based memory (`feedback_strategy_claude_canonical_cohort_sync`) to a mechanistic check fulfills the axiom that mechanism is durable while prose memory is weak.
+- **Hook Tiering:** Per `packages/cli/src/commands/install-hooks.ts`, hooks have 'strict' and 'standard' tiers. This check must run within the standard pipeline but fail predictably.
+
+### Files to Examine
+
+1. `packages/cli/src/commands/install-hooks.ts` — To understand how the pre-push hook surface is generated and how it delegates to the CLI.
+2. `packages/cli/src/commands/pre-push.ts` (or equivalent hook runner) — To locate where the new lockfile validation check should be injected into the existing pre-push lifecycle.
+
+### Technical Approach & Contracts
+
+**Core Mechanism:**
+The validation will be built as a standalone, deterministic TS function `checkLockfileSync` that parses the git diff of the commits about to be pushed.
+
+**Data Contracts:**
+
+```typescript
+export interface PrePushContext {
+  readonly cwd: string;
+  readonly localSha: string;
+  readonly remoteSha: string;
+}
+
+export interface ValidationResult {
+  readonly pass: boolean;
+  readonly reason?: string;
+}
+```
+
+**Sequence Logic:**
+
+1. **Resolve Range:** If `remoteSha` is `0000000000000000000000000000000000000000` (new branch push), fallback to diffing against `getDefaultBranch(cwd)`.
+2. **Fast-Fail (Not Tracked):** Execute `git ls-files pnpm-lock.yaml` via `safeExec`. If empty, the repo does not track the lockfile; return `{ pass: true }`.
+3. **Diff Extraction:** Execute `git diff --name-only <range>` via `safeExec`.
+4. **Fast-Fail (Lockfile Included):** If `pnpm-lock.yaml` is in the diff, return `{ pass: true }`.
+5. **Fast-Fail (No Package.json):** If no file ending in `package.json` is in the diff, return `{ pass: true }`.
+6. **Deep Inspection:** Execute `git diff <range> -- "*package.json"` to get the unified diff.
+7. **Regex Evaluation:** Scan the unified diff for line additions matching dependency bumps. A safe regex for this within unified diffs is: `/^\+\s*"[^"]+"\s*:\s*"[\^~]?\d+/m`.
+8. **Result:** If a match is found, return `{ pass: false, reason: "Tracked lockfile detected. Run `pnpm install` and stage pnpm-lock.yaml before pushing." }`.
+
+**Shared Helpers Required:**
+
+- `safeExec` (MUST be used for all git commands)
+- `resolveGitRoot` (to ensure operations run from the repo root)
+- `getDefaultBranch` (to handle the zero-SHA new branch edge case)
+
+### Edge Cases & Traps
+
+- **The Zero-SHA Trap:** Git pre-push passes `0000000000000000000000000000000000000000` as the remote SHA when pushing a newly created branch. Diffing against this throws a fatal error. You must intercept this and diff against the default branch instead.
+- **Monorepo Sub-packages:** The check must catch a bump in `packages/core/package.json` while validating the root `pnpm-lock.yaml`. Do not restrict the package.json check to the root.
+- **File Deletions:** Removing a dependency creates a line starting with `-` in the diff. The regex MUST strictly match `+` additions to avoid false positives when a dev uninstalls a package without regenerating (though they should, standard CI won't necessarily fail on lockfile drift for removals like it does for missing new pins).
+- **Whitespace Only Diffs:** Ensure the regex requires an actual version string format (e.g., matching a digit after a quote/caret) to prevent blocking on Prettier formatting changes in `package.json`.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Scaffold Validation Context and Interfaces**
+  - **Files:** Create `packages/cli/src/checks/lockfile-sync.ts` and `packages/cli/src/checks/lockfile-sync.test.ts`
+  - **Action:** Define the `PrePushContext` and `ValidationResult` interfaces. Export an empty `checkLockfileSync(ctx: PrePushContext): ValidationResult` function that returns `{ pass: true }`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Implement Range Resolution & Zero-SHA Fallback**
+  - **Files:** `packages/cli/src/checks/lockfile-sync.ts`, `packages/cli/src/checks/lockfile-sync.test.ts`
+  - **Action:** Implement the logic to derive the git diff range. Use `getDefaultBranch(ctx.cwd)` if `remoteSha` is forty zeros.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `resolves to default branch when remoteSha is forty zeros` using a mocked `getDefaultBranch`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Implement Lockfile Tracking & Diff Presence Fast-Fails**
+  - **Files:** `packages/cli/src/checks/lockfile-sync.ts`, `packages/cli/src/checks/lockfile-sync.test.ts`
+  - **Action:** Use `safeExec` to run `git ls-files pnpm-lock.yaml` and `git diff --name-only <range>`. If lockfile isn't tracked, or if lockfile IS in the diff, return pass.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `passes early when pnpm-lock.yaml is in the changed files diff`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Implement Deep Package.json Diff Inspection**
+  - **Files:** `packages/cli/src/checks/lockfile-sync.ts`, `packages/cli/src/checks/lockfile-sync.test.ts`
+  - **Action:** If a `package.json` is modified, run `safeExec` to get the unified diff: `git diff <range> -- "*package.json"`. Apply the regex `/^\+\s*"[^"]+"\s*:\s*"[\^~]?\d+/m`. If it matches, return a failure with the exact error message from the spec.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `rejects when caret bump in nested package.json lacks root pnpm-lock.yaml diff`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `passes when package.json diff only contains deletions`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 5: Integrate Check into Pre-push Runner**
+  - **Files:** `packages/cli/src/commands/pre-push.ts` (or equivalent runner file)
+  - **Action:** Wire `checkLockfileSync` into the execution chain. Extract `localSha` and `remoteSha` from stdin (which git passes to pre-push hooks). If validation fails, `console.error` the reason and `process.exit(1)`.
+  - write test → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Zero-SHA New Branch:** Verify a simulated `00000000...` remote ref correctly falls back to `main`/`master` and checks diffs from branching point.
+- **Monorepo Nesting:** Verify `git diff ... -- "*package.json"` correctly captures an addition of `+ "foo": "^1.2.3"` in `apps/web/package.json` and fails the push.
+- **Legitimate Diff:** Verify that if BOTH `package.json` and `pnpm-lock.yaml` are modified in the range, the push succeeds.
+- **Untracked Lockfile:** Verify that if `pnpm-lock.yaml` exists but is gitignored, the push succeeds regardless of `package.json` bumps.
+
+---
+
+## Implementation Design
+
+### Scope
+
+WILL: add a sibling pre-push gate `totem verify-lockfile-sync` that fails if any committed `package.json` in the local-ahead-of-default-branch range contains added/modified dependency version pins while `pnpm-lock.yaml` is tracked but absent from the same range. Hook generator (`install-hooks.ts:buildPrePushHook`) injects one new line slotted before the WWND claim-discipline gate.
+
+WILL NOT: read git push stdin (per-ref iteration); cover npm/yarn/bun lockfiles (pnpm-only per issue § NOT in scope); run `pnpm install` automatically; add a doctor sub-mode; add a `--strict`/`--standard` tier distinction (gate is universally applicable when the precondition fires).
+
+### Data model deltas
+
+No new persistent state. No schema additions. Two new internal types in the command module:
+
+| Type                              | Holds                                       | Writer               | Reader                             | Invariants                                                                                                                                                  |
+| --------------------------------- | ------------------------------------------- | -------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LockfileSyncContext` (interface) | `cwd: string`, `baseBranch: string \| null` | CLI command driver   | `verifyLockfileSync` pure function | `cwd` is absolute path. `baseBranch` may be null when git/remote unavailable — falls through to a fast-pass per Tenet 4 carve-out (init/transient surface). |
+| `LockfileSyncResult` (interface)  | `pass: boolean`, `reason?: string`          | `verifyLockfileSync` | CLI wrapper / tests                | When `pass: false`, `reason` MUST be present and end in actionable text (the "Run `pnpm install`" sentence).                                                |
+
+Neither type is exported on a public API surface — internal to the command module. The check itself is a pure function (no state container), invoked once per push.
+
+### State lifecycle
+
+No state crosses session/request boundaries. Each invocation:
+
+1. **Scope**: per-invocation
+2. **Lifetime**: created at command entry, GC'd at return
+3. **Ownership**: `verifyLockfileSync` (pure function, no module-level state)
+
+No state hazards.
+
+### Failure modes
+
+| Failure                                                                     | Category                 | Agent-facing surface            | Recovery                                                                                                      |
+| --------------------------------------------------------------------------- | ------------------------ | ------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| `pnpm-lock.yaml` not tracked (e.g., gitignored, not in the index)           | precondition not met     | silent pass (exit 0)            | n/a — gate does not apply                                                                                     |
+| `git ls-files` errors (not a repo, exec fails)                              | init                     | warning to stderr, exit 0       | best-effort per Tenet 4 carve-out (same shape as verify-manifest's `getDefaultBranch` try/catch fall-through) |
+| `getDefaultBranch` fails (no remote, detached HEAD)                         | init                     | warning to stderr, exit 0       | best-effort fall-through                                                                                      |
+| `git diff --name-only` exec fails                                           | transient                | warning to stderr, exit 0       | best-effort fall-through                                                                                      |
+| `package.json` has dep-pin addition AND `pnpm-lock.yaml` missing from range | **load-bearing**         | hard error (TotemError, exit 1) | "Run `pnpm install` and stage `pnpm-lock.yaml` before pushing."                                               |
+| `package.json` has dep-pin addition AND `pnpm-lock.yaml` present in range   | expected legitimate diff | silent pass                     | n/a                                                                                                           |
+| No `package.json` in diff range                                             | gate not applicable      | silent pass                     | n/a                                                                                                           |
+
+The best-effort fall-throughs match the verify-manifest pattern at `verify-manifest.ts:127-131` (the `getDefaultBranch` try/catch). That carve-out is explicitly justified there against Tenet 4 — init-class transient failures that block legitimate pushes are worse than the gate occasionally no-op'ing when git's local state is degraded.
+
+### Invariants to lock in via tests
+
+1. Zero-SHA detection — not exercised (we don't read stdin), so the equivalent invariant is: **diff range resolves to `origin/<default>...HEAD` regardless of git push state**.
+2. **Pure passes when lockfile is gitignored** — even if package.json has caret bumps, no false positive.
+3. **Monorepo nested package.json triggers the gate** — `apps/web/package.json` bumping `^1.2.3` with no root `pnpm-lock.yaml` diff must fail.
+4. **Deletions don't trigger the gate** — regex must reject `-` lines; uninstall-without-lockfile-regen is not in scope and must not false-positive.
+5. **Whitespace/prettier-only diffs don't trigger** — regex requires digit-after-quote-or-tilde.
+6. **Both files in range passes** — legitimate `pnpm install` commits show both files; gate must pass.
+7. **Best-effort fall-through on git failures returns pass** — simulated `safeExec` throw must not break the push.
+8. **Hook script wires the gate before the WWND claim-discipline gate** — install-hooks.test.ts asserts the new line is present in `buildPrePushHook` output.
+
+### Open questions
+
+1. **Question:** Bypass mechanism — should `verify-lockfile-sync` honor `TOTEM_GATE_BYPASS_JUSTIFICATION` like the WWND gate, or no bypass at all?
+   - **Options:** (a) No bypass — running `pnpm install` is the standard fix, mechanical class. (b) Honor `TOTEM_GATE_BYPASS_JUSTIFICATION` for consistency with cohort doctrine. (c) New `--allow-lockfile-drift` flag mirroring `verify-manifest --allow-compile-drift`.
+   - **Recommendation:** (a) No bypass. Failure mode is purely mechanical (run one command); a bypass invites the exact discipline drift the gate exists to prevent. If urgency strikes, `git push --no-verify` already exists as the universal escape hatch (and is explicitly banned in AGENTS.md, so the cost is visible).
+
+2. **Question:** Module location — `packages/cli/src/checks/lockfile-sync.ts` (per auto-spec) or `packages/cli/src/commands/verify-lockfile-sync.ts` (mirrors verify-manifest/verify-badges siblings)?
+   - **Options:** (a) commands/ directory matching siblings; (b) new checks/ directory per spec.
+   - **Recommendation:** (a) commands/ — no precedent for a `checks/` directory; verify-manifest is itself a "check" and lives in commands/. Simpler is better.
+
+3. **Question:** Command name — `verify-lockfile-sync` vs `verify-lockfile` vs `verify-lockfile-pin`?
+   - **Options:** All three valid; `-sync` emphasizes the relationship between pkg.json and lockfile; `-pin` emphasizes the version pin trigger.
+   - **Recommendation:** `verify-lockfile-sync` — clearest about what's being verified (their relationship, not the lockfile alone).
+
+4. **Question:** Hook order — slot between `verify-badges` and the WWND claim-discipline gate, OR after both?
+   - **Options:** (a) before WWND (fast-fail on mechanical issue before walking the prose surface); (b) after WWND (preserve existing order, append at end).
+   - **Recommendation:** (a) before WWND. Mechanical gates should fail first because they're cheap and unambiguous; the prose-discipline gate is slower and has nuance.

--- a/packages/cli/src/commands/install-hooks.test.ts
+++ b/packages/cli/src/commands/install-hooks.test.ts
@@ -240,6 +240,34 @@ describe('buildPrePushHook', () => {
   });
 
   // totem-context: hook-content assertion (not an orchestrator test, no LLM calls — default vitest timeout is sufficient)
+  it('contains $TOTEM_CMD verify-lockfile-sync (mmnto-ai/totem#1961)', () => {
+    const hook = buildPrePushHook(FALLBACK);
+    // totem-context: substring match on hook script content (not secret masking) — toContain is correct here
+    expect(hook).toContain('$TOTEM_CMD verify-lockfile-sync');
+  });
+
+  // totem-context: hook-content assertion (not an orchestrator test, no LLM calls — default vitest timeout is sufficient)
+  it('gates verify-lockfile-sync on pnpm-lock.yaml existing', () => {
+    const hook = buildPrePushHook(FALLBACK);
+    expect(hook).toMatch(/-f "pnpm-lock\.yaml".*verify-lockfile-sync/s);
+  });
+
+  // totem-context: hook-content assertion (not an orchestrator test, no LLM calls — default vitest timeout is sufficient)
+  it('slots verify-lockfile-sync before claim-discipline in the pre-push sequence', () => {
+    const hook = buildPrePushHook(FALLBACK);
+    // Assert presence with toContain (precise matcher); index comparison is
+    // safe only because both substrings are guaranteed present by the
+    // toContain assertions above.
+    // totem-context: substring match on hook script content (not secret masking) — toContain is correct here
+    expect(hook).toContain('$TOTEM_CMD verify-lockfile-sync');
+    // totem-context: substring match on hook script content (not secret masking) — toContain is correct here
+    expect(hook).toContain('$TOTEM_CMD doctor --claim-discipline');
+    const lockfileIdx = hook.indexOf('$TOTEM_CMD verify-lockfile-sync');
+    const claimDisciplineIdx = hook.indexOf('$TOTEM_CMD doctor --claim-discipline');
+    expect(lockfileIdx).toBeLessThan(claimDisciplineIdx);
+  });
+
+  // totem-context: hook-content assertion (not an orchestrator test, no LLM calls — default vitest timeout is sufficient)
   it('contains $TOTEM_CMD doctor --claim-discipline --strict (Proposal 279 Q3)', () => {
     const hook = buildPrePushHook(FALLBACK);
     expect(hook).toContain('$TOTEM_CMD doctor --claim-discipline --strict');

--- a/packages/cli/src/commands/install-hooks.ts
+++ b/packages/cli/src/commands/install-hooks.ts
@@ -350,6 +350,18 @@ if [ -n "$TOTEM_CMD" ]; then
     fi
   fi
 
+  # Verify lockfile-sync (mmnto-ai/totem#1961 — block caret bumps committed
+  # without a regenerated pnpm-lock.yaml). Gate is universally applicable to
+  # any repo that tracks pnpm-lock.yaml; pre-conditions are checked inside
+  # the command (lockfile tracked + diff range resolvable). Slotted before
+  # the WWND claim-discipline gate so this mechanical fast-fail runs before
+  # the slower prose-discipline walk.
+  if [ -f "pnpm-lock.yaml" ]; then
+    if ! $TOTEM_CMD verify-lockfile-sync; then
+      exit 1
+    fi
+  fi
+
   # WWND claim-discipline gate (Proposal 279 § Implementation Notes Q3 —
   # slot after verify-badges; gates on public-surface absolute promises,
   # missing-Goal-prefix, covenant-without-backing). Fires only when at

--- a/packages/cli/src/commands/verify-lockfile-sync.test.ts
+++ b/packages/cli/src/commands/verify-lockfile-sync.test.ts
@@ -1,0 +1,322 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Fixtures: unified-diff snippets covering the gate's matrix.
+
+const CARET_BUMP_DIFF = `diff --git a/package.json b/package.json
+index aaaaaa..bbbbbb 100644
+--- a/package.json
++++ b/package.json
+@@ -10,7 +10,7 @@
+   "dependencies": {
+-    "@mmnto/cli": "^1.43.2",
++    "@mmnto/cli": "^1.43.3",
+     "zod": "^3.22.0"
+   }
+`;
+
+const NESTED_PKG_BUMP_DIFF = `diff --git a/apps/web/package.json b/apps/web/package.json
+index aaaaaa..bbbbbb 100644
+--- a/apps/web/package.json
++++ b/apps/web/package.json
+@@ -5,5 +5,5 @@
+   "dependencies": {
+-    "foo": "^1.2.3",
++    "foo": "^1.2.4",
+   }
+`;
+
+const DELETIONS_ONLY_DIFF = `diff --git a/package.json b/package.json
+index aaaaaa..bbbbbb 100644
+--- a/package.json
++++ b/package.json
+@@ -10,8 +10,7 @@
+   "dependencies": {
+-    "removed-dep": "^1.2.3",
+     "kept": "^2.0.0"
+   }
+`;
+
+const VERSION_FIELD_ONLY_DIFF = `diff --git a/packages/cli/package.json b/packages/cli/package.json
+index aaaaaa..bbbbbb 100644
+--- a/packages/cli/package.json
++++ b/packages/cli/package.json
+@@ -1,6 +1,6 @@
+ {
+   "name": "@mmnto/cli",
+-  "version": "1.43.2",
++  "version": "1.43.3",
+   "type": "module",
+`;
+
+const WORKSPACE_REF_DIFF = `diff --git a/packages/cli/package.json b/packages/cli/package.json
+index aaaaaa..bbbbbb 100644
+--- a/packages/cli/package.json
++++ b/packages/cli/package.json
+@@ -10,6 +10,7 @@
+   "dependencies": {
++    "@mmnto/totem": "workspace:^",
+     "commander": "^11.0.0"
+   }
+`;
+
+describe('verifyLockfileSyncCommand', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('passes when not inside a git repo', async () => {
+    vi.doMock('@mmnto/totem', async () => {
+      const actual = await vi.importActual<typeof import('@mmnto/totem')>('@mmnto/totem');
+      return { ...actual, resolveGitRoot: () => null };
+    });
+    const { verifyLockfileSyncCommand } = await import('./verify-lockfile-sync.js');
+    const result = await verifyLockfileSyncCommand();
+    expect(result.valid).toBe(true);
+  });
+
+  it('passes when pnpm-lock.yaml is not tracked (gitignored or absent)', async () => {
+    vi.doMock('@mmnto/totem', async () => {
+      const actual = await vi.importActual<typeof import('@mmnto/totem')>('@mmnto/totem');
+      return {
+        ...actual,
+        resolveGitRoot: () => '/repo',
+        safeExec: (_cmd: string, args: string[]) => {
+          if (args[0] === 'ls-files') return ''; // not tracked
+          throw new Error('unexpected');
+        },
+      };
+    });
+    const { verifyLockfileSyncCommand } = await import('./verify-lockfile-sync.js');
+    const result = await verifyLockfileSyncCommand();
+    expect(result.valid).toBe(true);
+  });
+
+  it('passes when pnpm-lock.yaml is present in the diff range alongside the package.json bump', async () => {
+    vi.doMock('@mmnto/totem', async () => {
+      const actual = await vi.importActual<typeof import('@mmnto/totem')>('@mmnto/totem');
+      return {
+        ...actual,
+        resolveGitRoot: () => '/repo',
+        getDefaultBranch: () => 'main',
+        safeExec: (_cmd: string, args: string[]) => {
+          if (args[0] === 'ls-files') return 'pnpm-lock.yaml';
+          if (args[0] === 'diff' && args.includes('--name-only')) {
+            return 'package.json\npnpm-lock.yaml';
+          }
+          if (args[0] === 'diff') return CARET_BUMP_DIFF;
+          throw new Error('unexpected');
+        },
+      };
+    });
+    const { verifyLockfileSyncCommand } = await import('./verify-lockfile-sync.js');
+    const result = await verifyLockfileSyncCommand();
+    expect(result.valid).toBe(true);
+  });
+
+  it('fails when a nested apps/web/package.json bumps a dep and pnpm-lock.yaml is missing from the diff', async () => {
+    vi.doMock('@mmnto/totem', async () => {
+      const actual = await vi.importActual<typeof import('@mmnto/totem')>('@mmnto/totem');
+      return {
+        ...actual,
+        resolveGitRoot: () => '/repo',
+        getDefaultBranch: () => 'main',
+        safeExec: (_cmd: string, args: string[]) => {
+          if (args[0] === 'ls-files') return 'pnpm-lock.yaml';
+          if (args[0] === 'diff' && args.includes('--name-only')) {
+            return 'apps/web/package.json';
+          }
+          if (args[0] === 'diff') return NESTED_PKG_BUMP_DIFF;
+          throw new Error('unexpected');
+        },
+      };
+    });
+    const { verifyLockfileSyncCommand } = await import('./verify-lockfile-sync.js');
+    const result = await verifyLockfileSyncCommand();
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/pnpm install/);
+    expect(result.reason).toMatch(/pnpm-lock\.yaml/);
+  });
+
+  it('passes when package.json diff contains only deletions', async () => {
+    vi.doMock('@mmnto/totem', async () => {
+      const actual = await vi.importActual<typeof import('@mmnto/totem')>('@mmnto/totem');
+      return {
+        ...actual,
+        resolveGitRoot: () => '/repo',
+        getDefaultBranch: () => 'main',
+        safeExec: (_cmd: string, args: string[]) => {
+          if (args[0] === 'ls-files') return 'pnpm-lock.yaml';
+          if (args[0] === 'diff' && args.includes('--name-only')) return 'package.json';
+          if (args[0] === 'diff') return DELETIONS_ONLY_DIFF;
+          throw new Error('unexpected');
+        },
+      };
+    });
+    const { verifyLockfileSyncCommand } = await import('./verify-lockfile-sync.js');
+    const result = await verifyLockfileSyncCommand();
+    expect(result.valid).toBe(true);
+  });
+
+  it('passes when only the package "version" field changed (Version Packages release shape)', async () => {
+    vi.doMock('@mmnto/totem', async () => {
+      const actual = await vi.importActual<typeof import('@mmnto/totem')>('@mmnto/totem');
+      return {
+        ...actual,
+        resolveGitRoot: () => '/repo',
+        getDefaultBranch: () => 'main',
+        safeExec: (_cmd: string, args: string[]) => {
+          if (args[0] === 'ls-files') return 'pnpm-lock.yaml';
+          if (args[0] === 'diff' && args.includes('--name-only')) {
+            return 'packages/cli/package.json';
+          }
+          if (args[0] === 'diff') return VERSION_FIELD_ONLY_DIFF;
+          throw new Error('unexpected');
+        },
+      };
+    });
+    const { verifyLockfileSyncCommand } = await import('./verify-lockfile-sync.js');
+    const result = await verifyLockfileSyncCommand();
+    expect(result.valid).toBe(true);
+  });
+
+  it('passes when an added dependency uses a workspace:^ reference (no semver-pin shape)', async () => {
+    vi.doMock('@mmnto/totem', async () => {
+      const actual = await vi.importActual<typeof import('@mmnto/totem')>('@mmnto/totem');
+      return {
+        ...actual,
+        resolveGitRoot: () => '/repo',
+        getDefaultBranch: () => 'main',
+        safeExec: (_cmd: string, args: string[]) => {
+          if (args[0] === 'ls-files') return 'pnpm-lock.yaml';
+          if (args[0] === 'diff' && args.includes('--name-only')) {
+            return 'packages/cli/package.json';
+          }
+          if (args[0] === 'diff') return WORKSPACE_REF_DIFF;
+          throw new Error('unexpected');
+        },
+      };
+    });
+    const { verifyLockfileSyncCommand } = await import('./verify-lockfile-sync.js');
+    const result = await verifyLockfileSyncCommand();
+    expect(result.valid).toBe(true);
+  });
+
+  it('passes when no package.json files appear in the diff range', async () => {
+    vi.doMock('@mmnto/totem', async () => {
+      const actual = await vi.importActual<typeof import('@mmnto/totem')>('@mmnto/totem');
+      return {
+        ...actual,
+        resolveGitRoot: () => '/repo',
+        getDefaultBranch: () => 'main',
+        safeExec: (_cmd: string, args: string[]) => {
+          if (args[0] === 'ls-files') return 'pnpm-lock.yaml';
+          if (args[0] === 'diff' && args.includes('--name-only')) {
+            return 'src/index.ts\nREADME.md';
+          }
+          throw new Error('unexpected');
+        },
+      };
+    });
+    const { verifyLockfileSyncCommand } = await import('./verify-lockfile-sync.js');
+    const result = await verifyLockfileSyncCommand();
+    expect(result.valid).toBe(true);
+  });
+
+  it('fails on the cohort-sync caret bump shape when pnpm-lock.yaml is missing', async () => {
+    vi.doMock('@mmnto/totem', async () => {
+      const actual = await vi.importActual<typeof import('@mmnto/totem')>('@mmnto/totem');
+      return {
+        ...actual,
+        resolveGitRoot: () => '/repo',
+        getDefaultBranch: () => 'main',
+        safeExec: (_cmd: string, args: string[]) => {
+          if (args[0] === 'ls-files') return 'pnpm-lock.yaml';
+          if (args[0] === 'diff' && args.includes('--name-only')) return 'package.json';
+          if (args[0] === 'diff') return CARET_BUMP_DIFF;
+          throw new Error('unexpected');
+        },
+      };
+    });
+    const { verifyLockfileSyncCommand } = await import('./verify-lockfile-sync.js');
+    const result = await verifyLockfileSyncCommand();
+    expect(result.valid).toBe(false);
+    expect(result.reason).toMatch(/Run `pnpm install`/);
+  });
+
+  it('falls through to pass when getDefaultBranch throws (degraded git state)', async () => {
+    vi.doMock('@mmnto/totem', async () => {
+      const actual = await vi.importActual<typeof import('@mmnto/totem')>('@mmnto/totem');
+      return {
+        ...actual,
+        resolveGitRoot: () => '/repo',
+        getDefaultBranch: () => {
+          throw new Error('detached HEAD / no remote');
+        },
+        safeExec: (_cmd: string, args: string[]) => {
+          if (args[0] === 'ls-files') return 'pnpm-lock.yaml';
+          throw new Error('unexpected');
+        },
+      };
+    });
+    const { verifyLockfileSyncCommand } = await import('./verify-lockfile-sync.js');
+    const result = await verifyLockfileSyncCommand();
+    expect(result.valid).toBe(true);
+  });
+
+  it('falls through to pass when both origin/<base> and local <base> diff lookups fail', async () => {
+    vi.doMock('@mmnto/totem', async () => {
+      const actual = await vi.importActual<typeof import('@mmnto/totem')>('@mmnto/totem');
+      return {
+        ...actual,
+        resolveGitRoot: () => '/repo',
+        getDefaultBranch: () => 'main',
+        safeExec: (_cmd: string, args: string[]) => {
+          if (args[0] === 'ls-files') return 'pnpm-lock.yaml';
+          if (args[0] === 'diff') throw new Error('fatal: bad revision');
+          throw new Error('unexpected');
+        },
+      };
+    });
+    const { verifyLockfileSyncCommand } = await import('./verify-lockfile-sync.js');
+    const result = await verifyLockfileSyncCommand();
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('verifyLockfileSyncCliCommand', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('throws TotemError when the underlying check fails', async () => {
+    vi.doMock('@mmnto/totem', async () => {
+      const actual = await vi.importActual<typeof import('@mmnto/totem')>('@mmnto/totem');
+      return {
+        ...actual,
+        resolveGitRoot: () => '/repo',
+        getDefaultBranch: () => 'main',
+        safeExec: (_cmd: string, args: string[]) => {
+          if (args[0] === 'ls-files') return 'pnpm-lock.yaml';
+          if (args[0] === 'diff' && args.includes('--name-only')) return 'package.json';
+          if (args[0] === 'diff') return CARET_BUMP_DIFF;
+          throw new Error('unexpected');
+        },
+      };
+    });
+    const { verifyLockfileSyncCliCommand } = await import('./verify-lockfile-sync.js');
+    await expect(verifyLockfileSyncCliCommand()).rejects.toThrow(/pnpm install/);
+  });
+
+  it('resolves cleanly when the underlying check passes', async () => {
+    vi.doMock('@mmnto/totem', async () => {
+      const actual = await vi.importActual<typeof import('@mmnto/totem')>('@mmnto/totem');
+      return { ...actual, resolveGitRoot: () => null };
+    });
+    const { verifyLockfileSyncCliCommand } = await import('./verify-lockfile-sync.js');
+    await expect(verifyLockfileSyncCliCommand()).resolves.toBeUndefined();
+  });
+});

--- a/packages/cli/src/commands/verify-lockfile-sync.test.ts
+++ b/packages/cli/src/commands/verify-lockfile-sync.test.ts
@@ -137,7 +137,7 @@ describe('verifyLockfileSyncCommand', () => {
     const { verifyLockfileSyncCommand } = await import('./verify-lockfile-sync.js');
     const result = await verifyLockfileSyncCommand();
     expect(result.valid).toBe(false);
-    expect(result.reason).toMatch(/pnpm install/);
+    expect(result.reason).toMatch(/Tracked lockfile detected/);
     expect(result.reason).toMatch(/pnpm-lock\.yaml/);
   });
 
@@ -244,7 +244,8 @@ describe('verifyLockfileSyncCommand', () => {
     const { verifyLockfileSyncCommand } = await import('./verify-lockfile-sync.js');
     const result = await verifyLockfileSyncCommand();
     expect(result.valid).toBe(false);
-    expect(result.reason).toMatch(/Run `pnpm install`/);
+    expect(result.reason).toMatch(/Tracked lockfile detected/);
+    expect(result.reason).toMatch(/package\.json adds a dependency pin/);
   });
 
   it('falls through to pass when getDefaultBranch throws (degraded git state)', async () => {
@@ -308,7 +309,16 @@ describe('verifyLockfileSyncCliCommand', () => {
       };
     });
     const { verifyLockfileSyncCliCommand } = await import('./verify-lockfile-sync.js');
-    await expect(verifyLockfileSyncCliCommand()).rejects.toThrow(/pnpm install/);
+    // The thrown TotemError's message describes the failure; the recovery
+    // action (`pnpm install`) lives on recoveryHint, which the top-level
+    // handleError prints under "Fix:" — separate-concerns per the codebase
+    // pattern at verify-badges.ts:99-109.
+    await expect(verifyLockfileSyncCliCommand()).rejects.toThrow(/Tracked lockfile detected/);
+    try {
+      await verifyLockfileSyncCliCommand();
+    } catch (err) {
+      expect((err as Error & { recoveryHint?: string }).recoveryHint).toMatch(/pnpm install/);
+    }
   });
 
   it('resolves cleanly when the underlying check passes', async () => {

--- a/packages/cli/src/commands/verify-lockfile-sync.ts
+++ b/packages/cli/src/commands/verify-lockfile-sync.ts
@@ -182,7 +182,7 @@ export async function verifyLockfileSyncCliCommand(): Promise<void> {
     const label = errorColor(bold('FAIL'));
     log.error('Totem Error', `${label} — Lockfile sync verification failed.`);
     throw new TotemError(
-      'LOCKFILE_SYNC_FAILED',
+      'CHECK_FAILED',
       result.reason!,
       `Run \`pnpm install\` from the repo root to regenerate ${LOCKFILE_PATH}, then stage and commit it before re-pushing. CI runs with \`--frozen-lockfile\` and rejects pushes where a tracked package.json declares dependency pins that the lockfile does not reflect.`,
     );

--- a/packages/cli/src/commands/verify-lockfile-sync.ts
+++ b/packages/cli/src/commands/verify-lockfile-sync.ts
@@ -1,0 +1,190 @@
+// ─── Constants ──────────────────────────────────────────
+
+const TAG = 'VerifyLockfileSync';
+
+// Single-lockfile assumption (pnpm-only per mmnto-ai/totem#1961 NOT-in-scope).
+// Workspaces produce a single root lockfile by default; nested lockfiles in
+// pnpm are rare and not covered by this gate.
+const LOCKFILE_PATH = 'pnpm-lock.yaml';
+
+const AUX_LOOKUP_TIMEOUT_MS = 10_000;
+
+// Match dependency-pin additions in a unified diff. Anchors, left to right:
+//   `^\+`         — line starts with a single `+`. Unified-diff file-header
+//                   lines (`+++ b/path`) fail because the next char is `+`,
+//                   not `\s` or `"`.
+//   `\s*"`        — optional indent, then the opening quote of a JSON key.
+//   `(?!version")` — negative lookahead rejects the package's own top-level
+//                   `"version"` field, which appears in every Version
+//                   Packages release commit without a lockfile diff yet
+//                   correctly indicates the lockfile WAS regenerated (it
+//                   appears separately in the diff and trips the fast-pass).
+//                   The exclusion only matters when the lockfile happens to
+//                   be absent for unrelated reasons.
+//   `[^"]+"\s*:\s*"`
+//                — the rest of the key plus the `: "` value-opener.
+//   `[\^~]?\d+\.\d+`
+//                — value starts with optional caret/tilde, then requires a
+//                   major.minor digit pair. Rejects bare integer values like
+//                   `"node": "20"` in the `engines` block (an over-tightening
+//                   that costs one false-negative class on engine-only bumps,
+//                   which generally don't require a lockfile diff anyway) and
+//                   rejects `workspace:^` references (no leading digit).
+const DEP_BUMP_RE = /^\+\s*"(?!version")[^"]+"\s*:\s*"[\^~]?\d+\.\d+/m;
+
+// ─── Types ──────────────────────────────────────────────
+
+export interface VerifyLockfileSyncResult {
+  valid: boolean;
+  /** Set only when valid === false; describes the failure and recovery action. */
+  reason?: string;
+}
+
+// ─── Main command ───────────────────────────────────────
+
+/**
+ * Programmatic surface — returns the verification result without exiting or
+ * throwing. The CLI action layer wraps this and throws a `TotemError` when
+ * `result.valid === false` so the top-level `handleError` produces the exit
+ * code (avoids direct `process.exit()` calls per AGENTS.md doctrine).
+ *
+ * Best-effort fall-through on git failures (matches verify-manifest's pattern
+ * at packages/cli/src/commands/verify-manifest.ts:127-131): init-class
+ * transient failures (no remote, detached HEAD, missing refs) skip the gate
+ * rather than block pushes that are otherwise legitimate. Tenet 4's
+ * fail-loud mandate has a documented carve-out for best-effort init-time
+ * surfaces; the empty catches below carry `totem-context:` directives
+ * locating that carve-out.
+ */
+export async function verifyLockfileSyncCommand(): Promise<VerifyLockfileSyncResult> {
+  const { getDefaultBranch, resolveGitRoot, safeExec } = await import('@mmnto/totem');
+  const { bold, log, success: successColor } = await import('../ui.js');
+
+  const cwd = process.cwd();
+  const repoRoot = resolveGitRoot(cwd);
+  if (!repoRoot) {
+    log.info(TAG, 'Not inside a git repo — skipping lockfile-sync verification.');
+    return { valid: true };
+  }
+
+  // Precondition: the lockfile must be tracked. When gitignored or absent
+  // from the index the gate does not apply (e.g., consumers using a
+  // different package manager, or workspaces that explicitly exclude the
+  // lockfile).
+  let trackedLockfile = '';
+  try {
+    trackedLockfile = safeExec('git', ['ls-files', '--', LOCKFILE_PATH], {
+      cwd: repoRoot,
+      timeout: AUX_LOOKUP_TIMEOUT_MS,
+    });
+    // totem-context: best-effort tracking probe — git failures here fall through to pass, matching verify-manifest's getDefaultBranch carve-out (mmnto/totem#1440 Tenet 4 init-class)
+  } catch {
+    return { valid: true };
+  }
+  if (trackedLockfile.length === 0) {
+    log.info(TAG, `${LOCKFILE_PATH} is not tracked — skipping.`);
+    return { valid: true };
+  }
+
+  // Resolve the default branch for the diff range. Best-effort: a degraded
+  // git state (no remote, detached HEAD) falls through rather than blocking
+  // pushes whose ref topology happens to defeat detection.
+  let baseBranch: string;
+  try {
+    baseBranch = getDefaultBranch(repoRoot);
+    // totem-context: best-effort default-branch lookup — git failures here fall through to pass, matching verify-manifest's getDefaultBranch carve-out (mmnto/totem#1440 Tenet 4 init-class)
+  } catch {
+    return { valid: true };
+  }
+
+  // Prefer origin/<base> over local <base> — local refs may be stale when
+  // the user hasn't pulled recently, producing inconsistent gate behavior
+  // between local and CI. Matches verify-manifest's `tryReadBaseFingerprint`
+  // ref-order pattern.
+  let changedFiles = '';
+  let resolvedRef: string | null = null;
+  for (const ref of [`origin/${baseBranch}`, baseBranch]) {
+    try {
+      changedFiles = safeExec('git', ['diff', '--name-only', `${ref}...HEAD`], {
+        cwd: repoRoot,
+        timeout: AUX_LOOKUP_TIMEOUT_MS,
+      });
+      resolvedRef = ref;
+      break;
+      // totem-context: best-effort diff-range probe — try next ref candidate; fully exhausted both → fall through to pass (mmnto/totem#1440 Tenet 4 init-class)
+    } catch {
+      continue;
+    }
+  }
+  if (resolvedRef === null) {
+    log.info(TAG, 'Could not resolve diff range against default branch — skipping.');
+    return { valid: true };
+  }
+
+  const files = changedFiles.split('\n').filter(Boolean);
+
+  // Fast-pass: lockfile present in the diff range → the push includes the
+  // expected lockfile companion to whatever package.json changes ride
+  // alongside it. Most cohort-sync PRs and all Version Packages PRs land
+  // here.
+  if (files.includes(LOCKFILE_PATH)) {
+    const label = successColor(bold('PASS'));
+    log.success(TAG, `${label} — ${LOCKFILE_PATH} present in diff range.`);
+    return { valid: true };
+  }
+
+  // Filter to package.json files in any directory (monorepo nested case).
+  const pkgJsonPaths = files.filter((f) => f === 'package.json' || f.endsWith('/package.json'));
+  if (pkgJsonPaths.length === 0) {
+    return { valid: true };
+  }
+
+  // Pull the unified diff for the package.json files and scan for
+  // dependency-pin additions. `safeExec`'s arg-array form handles quoting,
+  // so multiple paths pass safely with no shell metacharacter risk.
+  let unifiedDiff = '';
+  try {
+    unifiedDiff = safeExec('git', ['diff', `${resolvedRef}...HEAD`, '--', ...pkgJsonPaths], {
+      cwd: repoRoot,
+      timeout: AUX_LOOKUP_TIMEOUT_MS,
+    });
+    // totem-context: best-effort unified-diff lookup — failure here means the gate cannot evaluate confidently, so fall through to pass rather than block (mmnto/totem#1440 Tenet 4 init-class)
+  } catch {
+    return { valid: true };
+  }
+
+  if (DEP_BUMP_RE.test(unifiedDiff)) {
+    return {
+      valid: false,
+      reason:
+        `Tracked lockfile detected, but ${LOCKFILE_PATH} is missing from the diff range while a package.json adds a dependency pin. ` +
+        `Run \`pnpm install\` and stage ${LOCKFILE_PATH} before pushing.`,
+    };
+  }
+
+  const label = successColor(bold('PASS'));
+  log.success(TAG, `${label} — package.json diff present without dependency-pin additions.`);
+  return { valid: true };
+}
+
+/**
+ * CLI entry — wraps `verifyLockfileSyncCommand` and throws on failure so the
+ * top-level `handleError` produces the non-zero exit code without a direct
+ * `process.exit` call.
+ */
+export async function verifyLockfileSyncCliCommand(): Promise<void> {
+  const { TotemError } = await import('@mmnto/totem');
+  const { bold, errorColor, log } = await import('../ui.js');
+
+  const result = await verifyLockfileSyncCommand();
+  if (!result.valid) {
+    log.error('Totem Error', result.reason!);
+    const label = errorColor(bold('FAIL'));
+    log.error('Totem Error', `${label} — Lockfile sync verification failed.`);
+    throw new TotemError(
+      'LOCKFILE_SYNC_FAILED',
+      result.reason!,
+      `Run \`pnpm install\` from the repo root to regenerate ${LOCKFILE_PATH}, then stage and commit it before re-pushing. CI runs with \`--frozen-lockfile\` and rejects pushes where a tracked package.json declares dependency pins that the lockfile does not reflect.`,
+    );
+  }
+}

--- a/packages/cli/src/commands/verify-lockfile-sync.ts
+++ b/packages/cli/src/commands/verify-lockfile-sync.ts
@@ -36,7 +36,7 @@ const DEP_BUMP_RE = /^\+\s*"(?!version")[^"]+"\s*:\s*"[\^~]?\d+\.\d+/m;
 
 export interface VerifyLockfileSyncResult {
   valid: boolean;
-  /** Set only when valid === false; describes the failure and recovery action. */
+  /** Set only when valid === false; describes the detected failure. The recovery action lives on the TotemError's recoveryHint at the CLI layer. */
   reason?: string;
 }
 
@@ -156,9 +156,7 @@ export async function verifyLockfileSyncCommand(): Promise<VerifyLockfileSyncRes
   if (DEP_BUMP_RE.test(unifiedDiff)) {
     return {
       valid: false,
-      reason:
-        `Tracked lockfile detected, but ${LOCKFILE_PATH} is missing from the diff range while a package.json adds a dependency pin. ` +
-        `Run \`pnpm install\` and stage ${LOCKFILE_PATH} before pushing.`,
+      reason: `Tracked lockfile detected, but ${LOCKFILE_PATH} is missing from the diff range while a package.json adds a dependency pin.`,
     };
   }
 
@@ -174,13 +172,9 @@ export async function verifyLockfileSyncCommand(): Promise<VerifyLockfileSyncRes
  */
 export async function verifyLockfileSyncCliCommand(): Promise<void> {
   const { TotemError } = await import('@mmnto/totem');
-  const { bold, errorColor, log } = await import('../ui.js');
 
   const result = await verifyLockfileSyncCommand();
   if (!result.valid) {
-    log.error('Totem Error', result.reason!);
-    const label = errorColor(bold('FAIL'));
-    log.error('Totem Error', `${label} — Lockfile sync verification failed.`);
     throw new TotemError(
       'CHECK_FAILED',
       result.reason!,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -682,6 +682,22 @@ program
   });
 
 program
+  .command('verify-lockfile-sync')
+  .description(
+    'Verify pnpm-lock.yaml is in the diff range when a package.json adds a dependency pin (cohort-sync gate, mmnto-ai/totem#1961)',
+  )
+  .action(async () => {
+    try {
+      const { verifyLockfileSyncCliCommand } = await import('./commands/verify-lockfile-sync.js');
+      await verifyLockfileSyncCliCommand();
+    } catch (err) {
+      handleError(err);
+      // totem-context: handleError returns `never` (process.exit), so the throw is unreachable but required to satisfy the Tenet 4 fail-loud rule that bans bare-catch silent-degrade. Mirrors the verify-badges pattern above.
+      throw err;
+    }
+  });
+
+program
   .command('import')
   .description('Import rules from external linter configs (ESLint, Semgrep)')
   .option('--from-semgrep <path>', 'Import rules from a Semgrep YAML rules file')


### PR DESCRIPTION
## Summary

Closes #1961. New deterministic pre-push gate that blocks pushes containing `package.json` dependency-pin additions when `pnpm-lock.yaml` is tracked but missing from the same diff range.

- Encodes `feedback_strategy_claude_canonical_cohort_sync` from prose memory (N=4 cycles of self-activation failure: `mmnto-ai/liquid-city#225/#248/#289/#357`) into mechanism per Tenet 15 — Axiom Mandate.
- Mirrors `verify-badges` / `verify-manifest` shape: pure function + CLI wrapper + shell-hook slot.
- Slotted before the WWND claim-discipline gate so the mechanical fast-fail runs before the slower prose-discipline walk.

## What changed

| File | Change |
|---|---|
| `packages/cli/src/commands/verify-lockfile-sync.ts` (new) | `verifyLockfileSyncCommand()` pure function + `verifyLockfileSyncCliCommand()` wrapper |
| `packages/cli/src/commands/verify-lockfile-sync.test.ts` (new) | 13 vitest cases covering caret-bump, deletions, workspace refs, `version` field, monorepo nested, lockfile-in-diff fast-pass, gitignored lockfile, no-package-json, git-failure fall-through (×2), CLI throw + resolve |
| `packages/cli/src/commands/install-hooks.ts` | `buildPrePushHook` injects `$TOTEM_CMD verify-lockfile-sync` gated on `pnpm-lock.yaml` existing |
| `packages/cli/src/commands/install-hooks.test.ts` | 3 new assertions: presence + gating + slot-before-claim-discipline |
| `packages/cli/src/index.ts` | Registers `verify-lockfile-sync` subcommand |
| `.changeset/verify-lockfile-sync.md` | Patch bump for `@mmnto/cli` |
| `.totem/specs/1961.md` | Spec + design doc |

## Design points

- **Regex `/^\+\s*"(?!version")[^"]+"\s*:\s*"[\^~]?\d+\.\d+/m`** — excludes the package's own `"version"` field (Version Packages release commits with a partial diff), `workspace:^` references, and bare integers like `"node": "20"` in engines blocks.
- **Best-effort fall-through on git failures** — matches the carve-out at `verify-manifest.ts:127-131`. A degraded git state does not block legitimate pushes; matches the catch-placement discipline (`totem-context:` directive on the last try-body statement per `feedback_totem_context_directive_placement`).
- **No bypass flag.** The fix is mechanical: run `pnpm install`. `git push --no-verify` remains the universal escape hatch but is banned in AGENTS.md.
- **Reused `CHECK_FAILED` TotemErrorCode** rather than adding a new union member — keeps the blast radius at `@mmnto/cli` only and avoids a core cohort bump.

## Test plan

- [x] 13 new vitest cases for `verify-lockfile-sync` (all green)
- [x] 3 new install-hooks assertions for the hook-script wire-up (all green)
- [x] Full CLI suite: 2208 tests pass (was 2192 + 16 new)
- [x] `pnpm exec totem lint` — 0 errors, 141 warnings (all pre-existing or false-positive class)
- [x] `pnpm exec totem review` — PASS, no findings
- [x] `pnpm exec totem verify-manifest` — PASS
- [x] Dogfooded — the new `verify-lockfile-sync` gate fired clean on this PR's push (no dep-pin additions in the diff)
- [ ] CI green on `mmnto-ai/totem` workflows

## Notes

- WWND claim-discipline gate fired on the pre-existing `docs/wiki/governing-ai-agents.md:58` "guarantees" warning unrelated to this PR. Bypassed via `TOTEM_GATE_BYPASS_JUSTIFICATION` per the audit-trail pattern banked in MEMORY. Tracked at #1950.
- Spec + design doc captured at `.totem/specs/1961.md` follows the precedent set by #1934 / #1908 / #1907.

🤖 Generated with [Claude Code](https://claude.com/claude-code)