### PR TITLE
fix(cli): isolate review-alias.test.ts spawn cwd from real .git (#1942)

### DIFF
--- a/.changeset/review-alias-test-isolation-1942.md
+++ b/.changeset/review-alias-test-isolation-1942.md
@@ -1,0 +1,15 @@
+---
+'@mmnto/cli': patch
+---
+
+fix(cli): isolate `review-alias.test.ts` spawn cwd from the real repo (mmnto-ai/totem#1942)
+
+Closes [mmnto-ai/totem#1942](https://github.com/mmnto-ai/totem/issues/1942).
+
+The `shield alias emits deprecation warning` test previously spawned `node dist/index.js shield` with `cwd: process.cwd()` — a path inside the real repo. The spawned process ran `shieldCommand`, which silently calls `upgradePrePushHookIfNeeded(process.cwd())`; that resolved the real git root and rewrote the developer's `.git/hooks/pre-push` from the legacy format to the stateless format mid-test. When `git push` was the calling context (the legacy pre-push hook runs `pnpm run test`, which forked the offending test), bash reported a syntax error against a line whose content matched a different line — the canonical mid-parse-rewrite tell.
+
+The spawn now uses a fresh `os.mkdtempSync` directory under `os.tmpdir()` as its cwd, so `resolveGitRoot` returns `null` and the upgrader short-circuits before writing.
+
+A new vitest `globalSetup` (`packages/cli/vitest.global-setup.ts`) snapshots `.git/hooks/pre-push` at run start and asserts byte-identity at teardown — a future test that introduces the same isolation defect fails with surface-area and remediation guidance inline. The check is coarse (one snapshot per run, not per test) and cheap.
+
+Production behavior of `upgradePrePushHookIfNeeded` is unchanged. The 11 additional test files that the original investigation comment flagged as mutators were cross-worker contamination artifacts — parallel workers snapshotted the pre-mutation hash in `beforeEach`, then observed the post-mutation hash in `afterEach` because `review-alias.test.ts` had written to the shared real file mid-run. Running each in isolation against the legacy-format hook confirmed only `review-alias.test.ts` writes.

--- a/packages/cli/src/commands/review-alias.test.ts
+++ b/packages/cli/src/commands/review-alias.test.ts
@@ -1,19 +1,41 @@
 import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { cleanTmpDir } from '../test-utils.js';
 
 /**
  * Integration tests for the `review` command registration and
  * the deprecated `shield` alias. Uses the built CLI dist output.
+ *
+ * The spawn cwd is a freshly-created tmp directory outside the totem repo so
+ * `shieldCommand`'s silent `upgradePrePushHookIfNeeded` resolves a null git
+ * root and short-circuits — without that isolation the test mutates the real
+ * `.git/hooks/pre-push` mid-run (mmnto-ai/totem#1942).
  */
 describe('review command alias', () => {
+  // Resolve dist path against the test's working directory BEFORE we switch
+  // spawn cwd — `path.resolve` snapshots cwd, so the absolute dist path
+  // remains stable even when child processes run from elsewhere.
   const distEntry = path.resolve(process.cwd(), 'dist/index.js');
+
+  let isolatedCwd: string;
+
+  beforeAll(() => {
+    isolatedCwd = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-review-alias-'));
+  });
+
+  afterAll(() => {
+    cleanTmpDir(isolatedCwd);
+  });
 
   const cli = (args: string): { stdout: string; stderr: string } => {
     // totem-context: test helper — args are hardcoded test strings, not user input
     const result = spawnSync('node', [distEntry, ...args.split(' ')], {
-      cwd: process.cwd(),
+      cwd: isolatedCwd,
       encoding: 'utf-8',
       timeout: 10_000,
       env: { ...process.env, NODE_NO_WARNINGS: '1' },

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -13,5 +13,11 @@ export default defineConfig({
     include: ['src/**/*.test.ts'],
     exclude: ['src/**/*.integration.test.ts'],
     testTimeout: TEST_TIMEOUT_MS,
+    // mmnto-ai/totem#1942 — asserts the real `.git/hooks/pre-push` is not
+    // mutated by any test in the suite. Localizes test-isolation defects in
+    // CLI integration tests that spawn the built binary with a cwd that
+    // resolves to the real repo (e.g., the shield alias's silent
+    // pre-push hook upgrader).
+    globalSetup: ['./vitest.global-setup.ts'],
   },
 });

--- a/packages/cli/vitest.global-setup.ts
+++ b/packages/cli/vitest.global-setup.ts
@@ -16,8 +16,10 @@
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
-const HOOK_PATH = path.resolve(__dirname, '../../.git/hooks/pre-push');
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const HOOK_PATH = path.resolve(HERE, '../../.git/hooks/pre-push');
 
 function hashHook(): { exists: boolean; hash: string; size: number } {
   if (!fs.existsSync(HOOK_PATH)) {

--- a/packages/cli/vitest.global-setup.ts
+++ b/packages/cli/vitest.global-setup.ts
@@ -1,0 +1,49 @@
+// Regression guard for mmnto-ai/totem#1942 — snapshots `.git/hooks/pre-push`
+// at the start of the run and asserts the file is byte-identical at the end.
+//
+// A test that spawns the built CLI (e.g., `node dist/index.js shield`) with a
+// cwd inside the real repo triggers `shieldCommand`'s silent
+// `upgradePrePushHookIfNeeded`, which resolves the real git root and
+// overwrites `.git/hooks/pre-push` mid-run. Pre-#1942 fix this corrupted
+// every developer's hook and could race bash mid-parse during `git push`.
+//
+// The guard is intentionally coarse — one snapshot per test run, not per
+// test — so it stays cheap and durable. If it fires, the offending test is
+// usually obvious from a `git diff .git/hooks/pre-push` against the staged
+// state; if not, temporarily re-enable per-test snapshotting in a
+// `setupFiles` entry to localize.
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const HOOK_PATH = path.resolve(__dirname, '../../.git/hooks/pre-push');
+
+function hashHook(): { exists: boolean; hash: string; size: number } {
+  if (!fs.existsSync(HOOK_PATH)) {
+    return { exists: false, hash: '', size: 0 };
+  }
+  const content = fs.readFileSync(HOOK_PATH);
+  return {
+    exists: true,
+    hash: crypto.createHash('md5').update(content).digest('hex'),
+    size: content.length,
+  };
+}
+
+export function setup(): () => void {
+  const before = hashHook();
+  return () => {
+    const after = hashHook();
+    if (before.hash !== after.hash || before.exists !== after.exists) {
+      throw new Error(
+        `[mmnto-ai/totem#1942] .git/hooks/pre-push was MUTATED during the test run.\n` +
+          `  before: exists=${before.exists} size=${before.size} md5=${before.hash}\n` +
+          `  after:  exists=${after.exists} size=${after.size} md5=${after.hash}\n` +
+          `A test invoked a CLI command (e.g., shield/review) with a cwd inside the real repo, ` +
+          `which triggers the silent pre-push hook upgrader. Isolate the spawn cwd to ` +
+          `os.tmpdir() so resolveGitRoot returns null.`,
+      );
+    }
+  };
+}


### PR DESCRIPTION
## Summary

Closes #1942 (tier-1).

- `packages/cli/src/commands/review-alias.test.ts:42` previously spawned `node dist/index.js shield` with `cwd: process.cwd()` (a path inside the real repo). The spawned `shield` action runs `shieldCommand` → `upgradePrePushHookIfNeeded(process.cwd())`, which resolves the real git root and rewrites `.git/hooks/pre-push` from the legacy format to the stateless format. When `git push` was the calling context (the legacy hook runs `pnpm run test`, which forks the offending test), bash reported a syntax error against a line whose content matched a different line — the canonical mid-parse-rewrite tell.
- Fix: `beforeAll` creates a fresh `os.mkdtempSync` directory under `os.tmpdir()` and the `cli` helper passes it as `cwd`. `resolveGitRoot` returns `null` for that path and the upgrader short-circuits before writing.
- Regression guard: `packages/cli/vitest.global-setup.ts` (wired into `vitest.config.ts`) snapshots `.git/hooks/pre-push` at run start and asserts byte-identity at teardown. A future test that introduces the same isolation defect fails loud with surface area and remediation guidance inline.

## Investigation summary

The original investigation comment on #1942 flagged 12 test files as potential mutators. Empirical evidence with a per-test snapshot/assert pair (Markdown trail in the commit body of `a8b558a3`) showed:

- Only `review-alias.test.ts` writes to the real hook in isolation.
- The other 11 "mutators" in the full-suite run were cross-worker contamination artifacts — parallel workers snapshotted the pre-mutation hash in `beforeEach`, then observed the post-mutation hash in `afterEach` because `review-alias.test.ts` had written to the shared real file mid-run.

The regression guard is intentionally coarse — one snapshot per run, not per test — so it stays cheap and durable.

## What's NOT in scope

- The atomicity of `upgradePrePushHookIfNeeded`'s in-place write. The bash mid-parse race remains exposed when an agent invokes `totem shield` from another shell during an in-flight `git push`. A separate ticket can track tempfile+rename atomic write if the race is observed in production after this lands.
- The production behavior of `upgradePrePushHookIfNeeded` is unchanged.

## Test plan

- [x] Reproduce the bug with the legacy-format hook installed: 12 test files fail under the diagnostic guard (1 real writer + 11 concurrency artifacts).
- [x] Apply the fix; rerun with legacy-format hook: 2208 / 2208 pass, hook byte-identical pre/post.
- [x] Revert the test fix only, keep the regression guard, rerun: `vitest globalSetup` teardown fires with the surface-area + remediation message. Guard catches the defect.
- [x] Reapply the fix; rerun with current new-format hook: 2208 / 2208 pass, hook byte-identical pre/post.
- [x] `pnpm run format:check` — clean.
- [x] `pnpm --filter @mmnto/cli exec tsc --noEmit` — exit 0.
- [x] `pnpm exec totem verify-manifest` — PASS.
- [x] `pnpm exec totem lint` — PASS with warnings (vitest.global-setup.ts trips CLI-only lint rules that pattern-match on `//`; the file is a test-only setup, not a CLI command).
- [x] `pnpm exec totem review` — PASS, no findings (after the `import.meta.url` follow-up commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)