### PR TITLE
hooks: wire pollMail() into session-context.js for cross-repo mail surfacing

### DIFF
--- a/.claude/hooks/session-context.js
+++ b/.claude/hooks/session-context.js
@@ -51,6 +51,7 @@ async function pollInboundMail(gitRoot) {
       return {
         count: 0,
         files: [],
+        warnings: [],
         scanError: '@mmnto/cli not built at packages/cli/dist; run pnpm -F @mmnto/cli build',
       };
     }
@@ -65,6 +66,10 @@ async function pollInboundMail(gitRoot) {
     return {
       count: (result.mail || []).length,
       files: result.mail || [],
+      // Per-source repo poll failures (e.g. EACCES on a sibling's outbox,
+      // mid-rename race) surface here; pollMail does not throw on them.
+      // Surfaced in the session context per Tenet 13 (sensor visibility).
+      warnings: result.warnings || [],
       scanError: null,
       scanned: result.scanned,
       truncated: result.truncated,
@@ -73,6 +78,7 @@ async function pollInboundMail(gitRoot) {
     return {
       count: 0,
       files: [],
+      warnings: [],
       scanError: String(err && err.message ? err.message : err),
     };
   }
@@ -183,6 +189,12 @@ async function buildStaticContext(gitRoot, branch, ticket) {
       lines.push(`  [scan truncated at ${inbox.scanned} files]`);
     }
   }
+  // Surface per-source warnings (e.g. unreadable sibling outboxes) independently
+  // of the unread-count path — they can co-exist with both zero-mail and
+  // populated-mail states. Per Tenet 13: sensor visibility is the contract.
+  (inbox.warnings || []).forEach((w) => {
+    lines.push(`  Warning: ${w}`);
+  });
   lines.push('');
 
   // Active proposal matching ticket — proposals live in totem-strategy

--- a/.claude/hooks/session-context.js
+++ b/.claude/hooks/session-context.js
@@ -27,6 +27,57 @@ async function loadResolvers(gitRoot) {
   };
 }
 
+// Per-repo convention per ADR-106 § 3. Env override for hook validation
+// (e.g. simulating another agent's view); not used in production.
+// Reject path separators / traversal in override — SELF_AGENT feeds into
+// pollMail's filename-matching, where a malicious value could route to
+// unintended outboxes.
+const DEFAULT_SELF_AGENT = 'totem-claude';
+const _agentOverride = process.env.TOTEM_HOOK_SELF_AGENT_OVERRIDE;
+const SELF_AGENT =
+  _agentOverride && !/[\\/]/.test(_agentOverride) && !_agentOverride.includes('..')
+    ? _agentOverride
+    : DEFAULT_SELF_AGENT;
+
+// Cross-repo inbound mail (ADR-106 § 3). Delegates to the canonical
+// `pollMail()` from `@mmnto/cli` (mmnto-ai/totem#1971, shipped in 1.44.0).
+// The mail command lives in the same workspace; load from packages/cli/dist
+// (the same workspace-relative pattern as loadResolvers above) rather than
+// node_modules — this hook ships in the totem monorepo.
+async function pollInboundMail(gitRoot) {
+  try {
+    const mailPath = join(gitRoot, 'packages', 'cli', 'dist', 'commands', 'mail.js');
+    if (!existsSync(mailPath)) {
+      return {
+        count: 0,
+        files: [],
+        scanError: '@mmnto/cli not built at packages/cli/dist; run pnpm -F @mmnto/cli build',
+      };
+    }
+    const { pollMail } = await import(pathToFileURL(mailPath).href);
+    // `|| {}` defensive: pollMail could theoretically return undefined on
+    // internal failure (its own catch path); destructuring null would throw.
+    const result =
+      pollMail({
+        repoRoot: gitRoot,
+        env: { TOTEM_SELF_AGENT: SELF_AGENT },
+      }) || {};
+    return {
+      count: (result.mail || []).length,
+      files: result.mail || [],
+      scanError: null,
+      scanned: result.scanned,
+      truncated: result.truncated,
+    };
+  } catch (err) {
+    return {
+      count: 0,
+      files: [],
+      scanError: String(err && err.message ? err.message : err),
+    };
+  }
+}
+
 // ─── Helpers ──────────────────────────────────────────────
 
 function getBranch() {
@@ -106,6 +157,33 @@ async function buildStaticContext(gitRoot, branch, ticket) {
       }
     }
   }
+
+  // Cross-repo inbound mail (ADR-106 § 3). Surface BEFORE the active-proposal
+  // lookup so any unread handoff is the first inbound signal at session start.
+  // Per claude-0080 standing list (mmnto-ai/totem-strategy → cohort): this
+  // wiring is the consumer-side half of the canonical pollMail() loop;
+  // until now totem-claude's hook only emitted static context + vector search,
+  // leaving cross-repo handoffs invisible.
+  const inbox = await pollInboundMail(gitRoot);
+  lines.push('── Inbound mail (cross-repo outbox poll, ADR-106 § 3) ──');
+  if (inbox.scanError) {
+    lines.push(`Poll failed: ${inbox.scanError}`);
+  } else if (inbox.count === 0) {
+    lines.push(`No unread mail addressed to ${SELF_AGENT} or broadcast.`);
+  } else {
+    lines.push(`${inbox.count} unread for ${SELF_AGENT}:`);
+    inbox.files.slice(0, 10).forEach((m) => {
+      lines.push(`  - ${m.file} (from ${m.from} @ ${m.repo})`);
+      lines.push(`      subject: ${m.subject}`);
+    });
+    if (inbox.files.length > 10) {
+      lines.push(`  ... and ${inbox.files.length - 10} more.`);
+    }
+    if (inbox.truncated) {
+      lines.push(`  [scan truncated at ${inbox.scanned} files]`);
+    }
+  }
+  lines.push('');
 
   // Active proposal matching ticket — proposals live in totem-strategy
   // (NOT substrate; only `.handoff/` + `.journal/` were extracted per


### PR DESCRIPTION
Closes the consumer-side wiring gap for totem-claude's session-start mail surfacing.

## Context

`pollMail()` shipped in `@mmnto/cli@1.44.0` (via `mmnto-ai/totem#1971`). `mmnto-ai/totem-strategy#377` wired it into strategy-claude's `.claude/hooks/SessionStart.cjs`. But the consumer-side wiring — for totem-claude, lc-claude, status-gemini, arhgap11-* — never propagated.

Result: cross-repo handoffs addressed to totem-claude were **silently invisible** at session-start, requiring user-relay as the workaround. The mail-channel was wired one-way: anyone could send to strategy-claude (whose hook polls), but strategy-claude (or anyone) couldn't send to totem-claude and have them see it auto-surfaced.

Empirical anchor: `mmnto-ai/totem-strategy#382` § Phase 2.C Phase 1 baseline shows 3 of today's 17 strategy-claude correction events were R-class (Reminder) corrections that user-relayed because consumer hooks weren't polling. Per `feedback_hook_enforcement_as_totem_justification`, wiring this hook should reduce R-class corrections at session-start.

## Change

`.claude/hooks/session-context.js` (the V2 hook) gains:

- **`pollInboundMail(gitRoot)` helper** — loads `pollMail` from `packages/cli/dist/commands/mail.js` (workspace-relative pattern matching the existing `loadResolvers` approach for `@mmnto/totem` resolvers; no node_modules round-trip in the monorepo).
- **`SELF_AGENT` constant** defaulting to `'totem-claude'` with the same env-override + path-traversal guard pattern as strategy-claude's hook (`TOTEM_HOOK_SELF_AGENT_OVERRIDE`).
- **Inbound-mail section** in `buildStaticContext()`, emitted BEFORE the active-proposal lookup so any unread handoff is the first inbound signal at session-start (mirrors strategy-claude hook order).

## Verification

Smoke-test from totem repo (full hook invocation):
```
node .claude/hooks/session-context.js
→ "── Inbound mail (cross-repo outbox poll, ADR-106 § 3) ──
   No unread mail addressed to totem-claude or broadcast."
```

Direct `pollMail()` test with proper Windows path:
- workspace resolution: ✅ `D:\dev` (parent of repo)
- self identification: ✅ `{"agents":["totem-claude"],"source":"env"}`
- outbox scanning: ✅ 5 outboxes scanned, 0 warnings
- error handling: ✅ soft-fails to scanError pointer on missing `packages/cli/dist`

Token budget unchanged (lines join + 10k char cap still in effect). Output protocol unchanged (additionalContext JSON payload extended, not restructured).

## Pre-push bypass justification

The repo has a pre-existing WWND warning at `docs/wiki/governing-ai-agents.md:58` documented as a known false-positive in totem-claude's `claude-0062` signoff ("Open at signoff" — *"Pre-existing WWND warning... known false-positive, bypass mechanism documented"*). Used `TOTEM_GATE_BYPASS_JUSTIFICATION` to push; this PR does not modify that file and the warning is unrelated to the wiring change.

## Test plan

- [x] Hook executes cleanly without errors
- [x] Mail section emits correct "No unread" message when no inbound queued
- [x] Workspace walker resolves to parent dir
- [x] Self-agent identification works via env override
- [x] Hook stays within 10k char budget
- [x] `pnpm -F @mmnto/totem build` succeeds with hook in place
- [ ] (Post-merge) Verify totem-claude's next session-start surfaces unread mail from `mmnto-ai/totem-strategy/.totem/orchestration/strategy-claude/outbox/`

## Cohort propagation

This is one of the four consumer repos that need wiring. After this lands, candidates for follow-on PRs (separate, not bundled):

- `mmnto-ai/liquid-city` — lc-claude
- `mmnto-ai/totem-status` — status-* agents
- `mmnto-ai/arhgap11` — arhgap11-* agents

Each follows the same shape (load `pollMail` workspace-relative, hardcode `SELF_AGENT`, emit inbound section in their existing hook). Not bundled here to keep blast radius bounded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)