### PR TITLE
fix(hooks): prefer per-repo orchestration journal over substrate (#1976)

### DIFF
--- a/.claude/hooks/session-context.js
+++ b/.claude/hooks/session-context.js
@@ -143,18 +143,40 @@ async function buildStaticContext(gitRoot, branch, ticket) {
   let journalDir = null;
   let journalSourceLabel = null;
 
-  const orchestration = resolveOrchestrationPaths(gitRoot, SELF_AGENT);
-  if (orchestration.journal) {
-    journalDir = orchestration.journal;
-    journalSourceLabel = 'orchestration';
-  } else {
+  // Guard against stale dist exports: if a consumer ran the hook after pulling
+  // the new code but before rebuilding core, `resolveOrchestrationPaths` may
+  // be undefined on the imported module. Degrade to substrate fallback instead
+  // of throwing TypeError on the call site.
+  const orchestration =
+    typeof resolveOrchestrationPaths === 'function'
+      ? resolveOrchestrationPaths(gitRoot, SELF_AGENT)
+      : null;
+
+  if (orchestration && orchestration.journal) {
+    // Commit to orchestration only when it has at least one .md entry.
+    // A directory that exists but is empty (fresh agent bootstrap with no
+    // session writes yet) should fall through to substrate so historical
+    // journals stay visible during the transition window.
+    try {
+      if (readdirSync(orchestration.journal).some((f) => f.endsWith('.md'))) {
+        journalDir = orchestration.journal;
+        journalSourceLabel = 'orchestration';
+      }
+    } catch (err) {
+      process.stderr.write(
+        `[session-context] Could not enumerate orchestration journal: ${err.message}\n`,
+      );
+    }
+  }
+
+  if (!journalDir) {
     // Fall back to substrate for legacy/pre-cutover repos whose agent ECL
-    // hasn't been bootstrapped yet. Preserves visibility into historical
-    // journals during the transition window.
+    // hasn't been bootstrapped yet, OR repos whose per-repo journal directory
+    // exists but is empty.
     const substrate = resolveSubstratePaths(gitRoot);
     if (substrate.source === 'none') {
       process.stderr.write(
-        `[session-context] Per-repo journal at .totem/orchestration/${SELF_AGENT}/journal/ empty + substrate unreachable. ` +
+        `[session-context] Per-repo journal at .totem/orchestration/${SELF_AGENT}/journal/ missing or empty + substrate unreachable. ` +
           'Setup: write a journal entry, OR clone mmnto-ai/totem-substrate as sibling, OR set TOTEM_SUBSTRATE_PATH.\n',
       );
     } else if (substrate.journalRoot) {

--- a/.claude/hooks/session-context.js
+++ b/.claude/hooks/session-context.js
@@ -24,6 +24,7 @@ async function loadResolvers(gitRoot) {
   return {
     resolveSubstratePaths: mod.resolveSubstratePaths,
     resolveStrategyRoot: mod.resolveStrategyRoot,
+    resolveOrchestrationPaths: mod.resolveOrchestrationPaths,
   };
 }
 
@@ -125,8 +126,10 @@ async function buildStaticContext(gitRoot, branch, ticket) {
 
   let resolveSubstratePaths;
   let resolveStrategyRoot;
+  let resolveOrchestrationPaths;
   try {
-    ({ resolveSubstratePaths, resolveStrategyRoot } = await loadResolvers(gitRoot));
+    ({ resolveSubstratePaths, resolveStrategyRoot, resolveOrchestrationPaths } =
+      await loadResolvers(gitRoot));
   } catch (err) {
     process.stderr.write(
       `[session-context] Resolvers unavailable (core dist missing?): ${err.message}\n`,
@@ -134,33 +137,52 @@ async function buildStaticContext(gitRoot, branch, ticket) {
     return lines.join('\n');
   }
 
-  // Substrate journal (per ADR-100 Phase C — `<substrate>/.journal/totem/`).
-  const substrate = resolveSubstratePaths(gitRoot);
-  if (substrate.source === 'none') {
-    process.stderr.write(
-      '[session-context] Substrate unreachable + repo-local sediment empty. ' +
-        'Setup: clone mmnto-ai/totem-substrate as sibling, OR set TOTEM_SUBSTRATE_PATH.\n',
-    );
-  } else if (substrate.journalRoot) {
-    const totemJournalDir = join(substrate.journalRoot, 'totem');
-    if (existsSync(totemJournalDir)) {
-      try {
-        const files = readdirSync(totemJournalDir)
-          .filter((f) => f.endsWith('.md'))
-          .sort()
-          .reverse();
-        if (files.length > 0) {
-          const latest = files[0];
-          lines.push(`Latest journal (${substrate.source}): ${latest}`);
-          const content = readFileSync(join(totemJournalDir, latest), 'utf-8');
-          const journalLines = content.split('\n').slice(0, 20);
-          lines.push(...journalLines);
-          lines.push('...');
-          lines.push('');
-        }
-      } catch (err) {
-        process.stderr.write(`[session-context] Could not read journal: ${err.message}\n`);
+  // Journal source resolution (per ADR-106 § 3 — per-repo orchestration ECL
+  // is canonical; substrate is frozen-archive, legacy fallback only).
+  // Mirrors the strategy-side fix at mmnto-ai/totem-strategy#371.
+  let journalDir = null;
+  let journalSourceLabel = null;
+
+  const orchestration = resolveOrchestrationPaths(gitRoot, SELF_AGENT);
+  if (orchestration.journal) {
+    journalDir = orchestration.journal;
+    journalSourceLabel = 'orchestration';
+  } else {
+    // Fall back to substrate for legacy/pre-cutover repos whose agent ECL
+    // hasn't been bootstrapped yet. Preserves visibility into historical
+    // journals during the transition window.
+    const substrate = resolveSubstratePaths(gitRoot);
+    if (substrate.source === 'none') {
+      process.stderr.write(
+        `[session-context] Per-repo journal at .totem/orchestration/${SELF_AGENT}/journal/ empty + substrate unreachable. ` +
+          'Setup: write a journal entry, OR clone mmnto-ai/totem-substrate as sibling, OR set TOTEM_SUBSTRATE_PATH.\n',
+      );
+    } else if (substrate.journalRoot) {
+      const totemJournalDir = join(substrate.journalRoot, 'totem');
+      if (existsSync(totemJournalDir)) {
+        journalDir = totemJournalDir;
+        journalSourceLabel = substrate.source;
       }
+    }
+  }
+
+  if (journalDir) {
+    try {
+      const files = readdirSync(journalDir)
+        .filter((f) => f.endsWith('.md'))
+        .sort()
+        .reverse();
+      if (files.length > 0) {
+        const latest = files[0];
+        lines.push(`Latest journal (${journalSourceLabel}): ${latest}`);
+        const content = readFileSync(join(journalDir, latest), 'utf-8');
+        const journalLines = content.split('\n').slice(0, 20);
+        lines.push(...journalLines);
+        lines.push('...');
+        lines.push('');
+      }
+    } catch (err) {
+      process.stderr.write(`[session-context] Could not read journal: ${err.message}\n`);
     }
   }
 


### PR DESCRIPTION
Closes #1976.

## Context

`.claude/hooks/session-context.js` was reading journals only from `<substrate>/.journal/totem/`. Post-ADR-106 cutover, journals live at `<repoRoot>/.totem/orchestration/<agent>/journal/`; substrate is **frozen archive**. The hook surfaced pre-cutover entries (`claude-0059-...`) while three newer sessions (`claude-0060` / `0061` / `0062`) were invisible to the session-start context.

Empirical anchor (smoke-test in `mmnto-ai/totem#1975` review):

```
$ node .claude/hooks/session-context.js
...
Latest journal (substrate): claude-0059-phase-4-closed-cohort-1.43.3.md
```

But the actual most-recent entries are:

```
$ ls .totem/orchestration/totem-claude/journal/ | tail -3
claude-0060-verify-lockfile-sync-gate-shipped.md
claude-0061-1942-test-isolation-and-1966-signoff-visiting-fallback.md
claude-0062-totem-mail-subcommand-1970-shipped.md
```

Three sessions of context lost.

## Change

Mirrors the strategy-side fix in `mmnto-ai/totem-strategy#371` and the existing convention in `extractStrategyPointer` (`packages/mcp/src/state-extractors.ts`, Layer 1 orchestration → Layer 2 substrate).

- **`loadResolvers()`** now also re-exports `resolveOrchestrationPaths` (already shipped from `@mmnto/totem` core via `mmnto-ai/totem#1951`; no new API).
- **Journal resolution** in `buildStaticContext()`:
  1. First try `resolveOrchestrationPaths(gitRoot, SELF_AGENT)`. If `.journal` is non-null, read latest from there with label `Latest journal (orchestration): ...`.
  2. **Fall back to substrate** when per-repo journal dir is absent (legacy / pre-cutover repos whose ECL hasn't been bootstrapped). Label preserves the substrate `source` (`Latest journal (sediment): ...` etc.) so the operator can see which surface served.
- **Setup warning** updated: when both orchestration empty AND substrate unreachable, the stderr hint now names the per-repo path first (`.totem/orchestration/<SELF_AGENT>/journal/`) followed by the substrate setup options, matching the new precedence.

## Verification

Smoke-test in this branch:

```
$ pnpm -r --filter ./packages/core build  # rebuild dist
$ node .claude/hooks/session-context.js
...
Latest journal (orchestration): claude-0062-totem-mail-subcommand-1970-shipped.md
```

The actual latest surfaces; mail surface unchanged; rest of context intact.

## Pre-push bypass justification

WWND Rule 1 fired on the pre-existing warning at `docs/wiki/governing-ai-agents.md:58` (matches `"guarantees"`). Bypassed with `TOTEM_GATE_BYPASS_JUSTIFICATION` per the documented carve-out — this PR does not touch that file. Same bypass pattern used 4× in claude-0062 and prior. Known false-positive tracked separately.

## Test plan

- [x] Smoke-test confirms `Latest journal (orchestration): claude-0062-...` surfaces
- [x] Inbound-mail section still emits cleanly (no regression on `mmnto-ai/totem#1975`)
- [x] `pnpm run format:check` clean
- [x] `pnpm run lint` clean (7 pre-existing warnings, none in this diff)
- [x] `pnpm run test` — 4470 tests pass
- [x] `totem verify-manifest` clean
- [ ] (Post-merge) Verify next session-start surfaces a `claude-0063`+ entry once one exists in `.totem/orchestration/totem-claude/journal/`
- [ ] (Cross-repo) Same shape may need to apply to `mmnto-ai/liquid-city`, `mmnto-ai/totem-status`, `mmnto-ai/arhgap11` consumer hooks if they have analogous journal-loader code — strategy-claude's lane

## Related

- `mmnto-ai/totem#1976` — this ticket
- `mmnto-ai/totem#1975` — surfaced the bug during smoke-test of the mail-wiring PR
- `mmnto-ai/totem#1951` — Phase 4 PR A; introduced the `resolveOrchestrationPaths` helper this fix uses
- `mmnto-ai/totem-strategy#371` — same-class fix on strategy side (cross-stream parity)
- `mmnto-ai/totem#1977` — companion tier-3 chore (rename hook to `.mjs`); orthogonal, not bundled

🤖 Generated with [Claude Code](https://claude.com/claude-code)