### PR TITLE
feat(cli+core): P281 per-lesson compile cache (incremental compilation)

### DIFF
--- a/.changeset/p281-compile-cache.md
+++ b/.changeset/p281-compile-cache.md
@@ -26,11 +26,11 @@ Layered (not composite). `stableId` first when present (P280 reservation; v1 nev
 
 ## Telemetry
 
-`compile_cache_decision` event per lesson per compile run. Best-effort fire-and-forget; ledger-write failures never block compile.
+`compile_cache_decision` event per lesson per compile run. Best-effort fire-and-forget; ledger-write failures are swallowed at the writer site so a degraded ledger does not block compile.
 
 ## Emergency escape
 
-`TOTEM_DISABLE_COMPILE_CACHE=1` reverts cache to no-op (lookup → no-prior-record, write → no-op). Emergency only — deprecation-watch tracked post-PR-open.
+`TOTEM_DISABLE_COMPILE_CACHE=1` reverts cache behavior to the pre-#NNNN status quo (lookup returns no-prior-record, write becomes a no-op). Emergency-only; deprecation-watch tracked post-PR-open.
 
 ## Falsifying metric
 

--- a/.changeset/p281-compile-cache.md
+++ b/.changeset/p281-compile-cache.md
@@ -1,0 +1,41 @@
+---
+'@mmnto/cli': minor
+'@mmnto/totem': minor
+---
+
+feat(cli+core): Proposal 281 per-lesson compile cache (incremental compilation) (#NNNN)
+
+Implements [Proposal 281 (Per-Lesson Hash Stability)](https://github.com/mmnto-ai/totem-strategy/blob/main/proposals/accepted/281-per-lesson-hash-stability.md), accepted via [`mmnto-ai/totem-strategy#387`](https://github.com/mmnto-ai/totem-strategy/pull/387) on 2026-05-20. Closes the first of two freeze-lift gates for `project_rule_compilation_freeze_2026_05_17` (Path A per [ADR-108](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-108-agent-state-continuity-architecture-synthesis.md)).
+
+A per-lesson cache keyed by `(sourceHash, compile_worker_fingerprint)` short-circuits `totem lesson compile` for lessons whose source content is unchanged. Result: a `+1` lesson PR produces a `compiled-rules.json` diff with 1 new row, not 4931 lines.
+
+## Surfaces
+
+- `packages/core/src/compile-cache.ts` — new module: `CacheEntrySchema` (with `stableId?: string` reserved for P280 per [`mmnto-ai/totem-strategy#387`](https://github.com/mmnto-ai/totem-strategy/pull/387) § Dependencies), `computeLessonSourceHash`, `lookupCacheEntry`, `writeCacheEntry`, `buildCacheEntry`, `migrateFromCompiledRules`, `cacheEntryPath`, `listCacheEntries`.
+- `packages/core/src/compile-cache.test.ts` — 21 tests covering the partial-mutation invariant (falsifying-metric test), byte-for-byte preservation on hit, fingerprint-rotation invalidation, source-change invalidation, `--force` bypass, `stableId` slot round-trip, graceful-miss on malformed cache files, `TOTEM_DISABLE_COMPILE_CACHE` env-var escape hatch, and migration idempotence.
+- `packages/core/src/ledger.ts` — `LedgerEventSchema.type` enum extended with `compile_cache_decision`. `ruleId` carries the lesson `sourceHash`; `activity_name` carries the decision enum value (`cache_hit` / `cache_miss_source_changed` / `cache_miss_fingerprint_changed` / `cache_miss_force` / `cache_miss_no_prior_record`).
+- `packages/cli/src/commands/compile.ts` — parallel compile path (~line 1614) wrapped with cache lookup. Cache hit returns the stored `CompileLessonResult` verbatim; cache miss invokes `compileLessonCore` and persists the result. `options.force` and `upgradeTargets` are honored as forced-recompile signals. Cache is bypassed when `compile_worker_fingerprint` is `undefined` (matching the `verify-manifest` provider gap discipline).
+
+## Cache key composition
+
+Layered (not composite). `stableId` first when present (P280 reservation; v1 never writes it) → `sourceHash` (SHA-256 of normalized lesson source, line endings collapsed to `\n`) → `fingerprint` (exact match required, else miss). `cli_version` is intentionally absent from the key — including it would invalidate every cohort bump.
+
+## Storage
+
+`.totem/cache/compile-lesson/<sourceHash-first-16-chars>.json`. Already gitignored (`.gitignore:5`). Flat directory for v1; fan-out follow-on tracked post-PR-open with soft trigger 1000 lessons.
+
+## Telemetry
+
+`compile_cache_decision` event per lesson per compile run. Best-effort fire-and-forget; ledger-write failures never block compile.
+
+## Emergency escape
+
+`TOTEM_DISABLE_COMPILE_CACHE=1` reverts cache to no-op (lookup → no-prior-record, write → no-op). Emergency only — deprecation-watch tracked post-PR-open.
+
+## Falsifying metric
+
+Per [Proposal 281 § Falsifying Metric](https://github.com/mmnto-ai/totem-strategy/blob/main/proposals/accepted/281-per-lesson-hash-stability.md): ≥99% of compile runs touching K lessons (by source change) produce `compiled-rules.json` row changes for exactly K lessons. Window: event-count-bounded (N=20 PRs post-thaw).
+
+## Sequencing
+
+P281 ships first (per [`mmnto-ai/totem-strategy#387`](https://github.com/mmnto-ai/totem-strategy/pull/387) re-grounded shape + ADR-108 Path A). P280 (`stableId` on lesson frontmatter) follows as defense-in-depth — the reserved `stableId` slot in `CacheEntry` makes P280's arrival additive, not breaking. The rule-compilation freeze lifts after both gates close + end-to-end clean recompile passes.

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -1622,15 +1622,25 @@ export async function compileCommand(
         // so caching would be unsafe. Matches the verify-manifest no-op
         // discipline on the same provider gap.
         const cacheFingerprint = computeFingerprintForManifest();
+        const cacheSessionId = readSessionId(totemDir);
         let cacheCliVersion: string | undefined;
         try {
           const { createRequire } = await import('node:module');
           const req = createRequire(import.meta.url);
           const pkg = req('../../package.json') as { version?: string };
           cacheCliVersion = pkg.version;
-          // totem-context: cli_version is a best-effort ledger enrichment; mirror of doctor-claim-discipline's pattern. Resolution failure must not block compile.
+          // totem-context: intentional cleanup — cli_version is a best-effort ledger enrichment; packaging-path resolution failure surfaces diagnostically via log.dim per CR R1 finding, but never blocks the compile path. Mirror of doctor-claim-discipline's pattern.
         } catch (err) {
-          void err;
+          // totem-context: intentional cleanup — cli_version is a best-effort ledger enrichment; packaging-path resolution failure surfaces diagnostically via log.dim per CR R1 finding, but never blocks the compile path.
+          // Surface at diagnostic level — silent swallow would mask packaging
+          // regressions that strip cli_version from every cache-telemetry event.
+          const errMsg =
+            // totem-context: String(err) is the canonical err-normalization idiom (10+ cohort precedents); the input-pattern lesson misfires on catch-block error extraction.
+            err instanceof Error ? err.message : String(err);
+          log.dim(
+            TAG,
+            `Unable to resolve CLI version for compile_cache_decision telemetry: ${errMsg}`,
+          );
         }
         const emitCacheDecisionEvent = (
           sourceHash: string,
@@ -1651,6 +1661,7 @@ export async function compileCommand(
                 justification: '',
                 source: 'lint',
                 activity_name: decision,
+                ...(cacheSessionId !== undefined ? { session_id: cacheSessionId } : {}),
                 ...(cacheCliVersion !== undefined ? { cli_version: cacheCliVersion } : {}),
               },
               (msg) => log.warn(TAG, msg),
@@ -1678,7 +1689,12 @@ export async function compileCommand(
               // recompile intent and must not short-circuit).
               const forceRecompile =
                 options.force === true || upgradeTargets?.has(lesson.hash) === true;
-              const sourceHash = computeLessonSourceHash(lesson.body);
+              // Cache key must cover heading + body (CR Major catch on
+              // `mmnto-ai/totem#1983`). Hashing body alone would let a
+              // heading-only edit falsely hit the cache while the rotation-prone
+              // `lessonHash` shifts to reflect the new heading — stale output
+              // would survive into compiled-rules.json.
+              const sourceHash = computeLessonSourceHash(`${lesson.heading}\n${lesson.body}`);
               if (cacheFingerprint !== undefined) {
                 const lookup = lookupCacheEntry(totemDir, sourceHash, cacheFingerprint, {
                   force: forceRecompile,

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -1645,12 +1645,11 @@ export async function compileCommand(
         }
         const emitCacheDecisionEvent = (
           sourceHash: string,
-          decision:
-            | 'cache_hit'
-            | 'cache_miss_source_changed'
-            | 'cache_miss_fingerprint_changed'
-            | 'cache_miss_force'
-            | 'cache_miss_no_prior_record',
+          // Use the canonical CacheDecision union exported from core
+          // (compile-cache.ts). Inline-import-type avoids a top-level
+          // type-import while keeping the wrapper site in lockstep with
+          // future additions to the decision enum.
+          decision: import('@mmnto/totem').CacheDecision,
         ): void => {
           try {
             appendLedgerEvent(

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -439,6 +439,7 @@ export async function compileCommand(
     resolveStage4Baseline,
     appendLedgerEvent,
     buildCacheEntry,
+    composeLessonSourceForHash,
     computeCompileWorkerFingerprint,
     computeLessonSourceHash,
     lookupCacheEntry,
@@ -1689,12 +1690,14 @@ export async function compileCommand(
               // recompile intent and must not short-circuit).
               const forceRecompile =
                 options.force === true || upgradeTargets?.has(lesson.hash) === true;
-              // Cache key must cover heading + body (CR Major catch on
-              // `mmnto-ai/totem#1983`). Hashing body alone would let a
-              // heading-only edit falsely hit the cache while the rotation-prone
-              // `lessonHash` shifts to reflect the new heading — stale output
-              // would survive into compiled-rules.json.
-              const sourceHash = computeLessonSourceHash(`${lesson.heading}\n${lesson.body}`);
+              // Cache key composition (CR Major on `mmnto-ai/totem#1983` R1)
+              // + same shape used by `migrateFromCompiledRules` to keep runtime
+              // and migration paths producing identical hashes for the same
+              // lesson (GCA R2 critical on the same PR). The shared helper is
+              // the canonical anchor — both paths route through it.
+              const sourceHash = computeLessonSourceHash(
+                composeLessonSourceForHash(lesson.heading, lesson.body),
+              );
               if (cacheFingerprint !== undefined) {
                 const lookup = lookupCacheEntry(totemDir, sourceHash, cacheFingerprint, {
                   force: forceRecompile,

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -438,7 +438,10 @@ export async function compileCommand(
     readCompileManifest,
     resolveStage4Baseline,
     appendLedgerEvent,
+    buildCacheEntry,
     computeCompileWorkerFingerprint,
+    computeLessonSourceHash,
+    lookupCacheEntry,
     modelStripsTemperature,
     readPromptTemplateContentHash,
     readSessionId,
@@ -451,6 +454,7 @@ export async function compileCommand(
     STAGE4_MANIFEST_EXCLUSIONS,
     verifyAgainstCodebase,
     verifyRuleExamples,
+    writeCacheEntry,
     writeCompileManifest,
   } = await import('@mmnto/totem');
 
@@ -1611,15 +1615,82 @@ export async function compileCommand(
           MAX_CONCURRENCY,
           Math.max(1, Number.isNaN(parsed) ? DEFAULT_CONCURRENCY : parsed),
         );
+
+        // Proposal 281: resolve the compile-worker fingerprint once for the
+        // whole batch. When undefined (non-anthropic providers, Phase 1), the
+        // cache is bypassed — no fingerprint means no invalidation signal,
+        // so caching would be unsafe. Matches the verify-manifest no-op
+        // discipline on the same provider gap.
+        const cacheFingerprint = computeFingerprintForManifest();
+        let cacheCliVersion: string | undefined;
+        try {
+          const { createRequire } = await import('node:module');
+          const req = createRequire(import.meta.url);
+          const pkg = req('../../package.json') as { version?: string };
+          cacheCliVersion = pkg.version;
+          // totem-context: cli_version is a best-effort ledger enrichment; mirror of doctor-claim-discipline's pattern. Resolution failure must not block compile.
+        } catch (err) {
+          void err;
+        }
+        const emitCacheDecisionEvent = (
+          sourceHash: string,
+          decision:
+            | 'cache_hit'
+            | 'cache_miss_source_changed'
+            | 'cache_miss_fingerprint_changed'
+            | 'cache_miss_force'
+            | 'cache_miss_no_prior_record',
+        ): void => {
+          try {
+            appendLedgerEvent(
+              totemDir,
+              {
+                timestamp: new Date().toISOString(),
+                type: 'compile_cache_decision',
+                ruleId: sourceHash,
+                justification: '',
+                source: 'lint',
+                activity_name: decision,
+                ...(cacheCliVersion !== undefined ? { cli_version: cacheCliVersion } : {}),
+              },
+              (msg) => log.warn(TAG, msg),
+            );
+            // totem-context: intentional cleanup — telemetry is fire-and-forget; ledger-append failure must never crash the compile per the A.3.a writer contract.
+          } catch (err) {
+            // totem-context: intentional cleanup — telemetry is fire-and-forget; ledger-append failure must never crash the compile per the A.3.a writer contract.
+            log.warn(TAG, err instanceof Error ? err.message : String(err));
+          }
+        };
+
         for (let i = 0; i < toCompile.length; i += CONCURRENCY) {
           const batch = toCompile.slice(i, i + CONCURRENCY);
           const results = await Promise.all(
-            batch.map((lesson) => {
+            batch.map(async (lesson) => {
               // Per-lesson deps: telemetry prefix only applies to upgrade targets.
               // For upgradeBatch, each target may carry a distinct prefix.
               const lessonDeps = upgradeTargets?.has(lesson.hash)
                 ? { ...coreDeps, telemetryPrefix: upgradeTargets.get(lesson.hash) }
                 : coreDeps;
+
+              // Proposal 281: cache lookup pass. Bypass when fingerprint is
+              // undefined or when the operator forced recompilation via
+              // --force or via --upgrade-batch (upgrade targets are explicit
+              // recompile intent and must not short-circuit).
+              const forceRecompile =
+                options.force === true || upgradeTargets?.has(lesson.hash) === true;
+              const sourceHash = computeLessonSourceHash(lesson.body);
+              if (cacheFingerprint !== undefined) {
+                const lookup = lookupCacheEntry(totemDir, sourceHash, cacheFingerprint, {
+                  force: forceRecompile,
+                });
+                emitCacheDecisionEvent(sourceHash, lookup.decision);
+                if (lookup.entry !== null) {
+                  tracker.tick();
+                  spinner.update(tracker.format());
+                  return { lesson, result: lookup.entry.output };
+                }
+              }
+
               return withRetry(
                 () => compileLessonCore(lesson, COMPILER_SYSTEM_PROMPT, lessonDeps),
                 {
@@ -1634,6 +1705,14 @@ export async function compileCommand(
                 .then((result) => {
                   tracker.tick();
                   spinner.update(tracker.format());
+                  // Proposal 281: persist non-transient outcomes. Failed
+                  // results are transient and must not poison the cache;
+                  // compiled / skipped / noop are deterministic given the
+                  // (sourceHash, fingerprint) tuple.
+                  if (cacheFingerprint !== undefined && result.status !== 'failed') {
+                    const entry = buildCacheEntry(sourceHash, cacheFingerprint, result);
+                    writeCacheEntry(totemDir, entry, (msg) => log.warn(TAG, msg));
+                  }
                   return { lesson, result };
                 })
                 .catch((err) => {

--- a/packages/core/src/compile-cache.test.ts
+++ b/packages/core/src/compile-cache.test.ts
@@ -175,14 +175,21 @@ describe('cacheEntryPath', () => {
   it('uses the first 16 chars of the source hash as the filename', () => {
     const totemDir = '/some/dir/.totem';
     const sourceHash = 'abcdef0123456789' + '0'.repeat(48);
-    const expected = path.join(
-      totemDir,
-      '.totem',
-      'cache',
-      'compile-lesson',
-      'abcdef0123456789.json',
-    );
+    const expected = path.join(totemDir, 'cache', 'compile-lesson', 'abcdef0123456789.json');
     expect(cacheEntryPath(totemDir, sourceHash)).toBe(expected);
+  });
+
+  it('does not duplicate the .totem prefix when totemDir already includes it (CR R3 Major on #1983)', () => {
+    // Regression: an earlier draft hardcoded `.totem` into CACHE_DIR. Joined
+    // with totemDir (which already resolves to `<repo>/.totem`), the cache
+    // landed at `<repo>/.totem/.totem/cache/compile-lesson/...` — outside the
+    // documented path and invisible to tooling that scans `<totemDir>/cache`.
+    const totemDir = '/repo/.totem';
+    const result = cacheEntryPath(totemDir, 'a'.repeat(64));
+    expect(result).not.toContain(path.join('.totem', '.totem'));
+    expect(result).toBe(
+      path.join('/repo/.totem', 'cache', 'compile-lesson', 'aaaaaaaaaaaaaaaa.json'),
+    );
   });
 });
 
@@ -351,6 +358,49 @@ describe('cache lookup + write round-trip', () => {
     expect(result.decision).toBe('cache_miss_no_prior_record');
   });
 
+  it('incomplete cache payload (compiled without rule) is rejected (CR R3 Major on #1983)', () => {
+    // Status enum alone is not sufficient validation — a truncated payload like
+    // `{ status: 'compiled' }` would survive a minimal schema and crash the
+    // cache-hit path on the missing `rule` dereference. The discriminated union
+    // requires the per-variant fields downstream consumers depend on.
+    const sourceHash = computeLessonSourceHash('lesson with compiled-no-rule cache entry');
+    const filePath = cacheEntryPath(tmpDir, sourceHash);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        sourceHash,
+        fingerprint: FINGERPRINT_A,
+        output: { status: 'compiled' }, // missing required `rule`
+        compiledAt: '2026-05-21T00:00:00.000Z',
+      }),
+      'utf-8',
+    );
+
+    const result = lookupCacheEntry(tmpDir, sourceHash, FINGERPRINT_A);
+    expect(result.decision).toBe('cache_miss_no_prior_record');
+    expect(result.entry).toBeNull();
+  });
+
+  it('incomplete cache payload (skipped without hash/reasonCode) is rejected (CR R3 Major on #1983)', () => {
+    const sourceHash = computeLessonSourceHash('lesson with skipped-no-fields cache entry');
+    const filePath = cacheEntryPath(tmpDir, sourceHash);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        sourceHash,
+        fingerprint: FINGERPRINT_A,
+        output: { status: 'skipped' }, // missing required `hash` and `reasonCode`
+        compiledAt: '2026-05-21T00:00:00.000Z',
+      }),
+      'utf-8',
+    );
+
+    const result = lookupCacheEntry(tmpDir, sourceHash, FINGERPRINT_A);
+    expect(result.decision).toBe('cache_miss_no_prior_record');
+  });
+
   it('hash-disagreeing cache file is treated as cache miss', () => {
     // Defensive against manual cache edits — if the file at path-for-hash-X
     // contains an entry claiming sourceHash-Y, treat as miss.
@@ -362,7 +412,9 @@ describe('cache lookup + write round-trip', () => {
       JSON.stringify({
         sourceHash: 'some-other-hash',
         fingerprint: FINGERPRINT_A,
-        output: { status: 'compiled' },
+        // Valid `compiled` shape so the schema check passes and the lookup
+        // reaches the sourceHash-disagreement defense (the assertion under test).
+        output: { status: 'compiled', rule: { lessonHash: 'whatever' } },
         compiledAt: '2026-05-21T00:00:00.000Z',
       }),
       'utf-8',

--- a/packages/core/src/compile-cache.test.ts
+++ b/packages/core/src/compile-cache.test.ts
@@ -1,0 +1,431 @@
+/**
+ * Tests for the per-lesson compile cache (Proposal 281).
+ *
+ * Falsifying-metric test is `partial_mutation_invariant` — exercises the
+ * load-bearing claim that a +1-lesson PR produces a 1-row compiled-rules
+ * delta, not a 130-row rotation.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  buildCacheEntry,
+  type CacheEntry,
+  cacheEntryPath,
+  computeLessonSourceHash,
+  lookupCacheEntry,
+  migrateFromCompiledRules,
+  writeCacheEntry,
+} from './compile-cache.js';
+import type { CompileLessonResult } from './compile-lesson.js';
+import { cleanTmpDir } from './test-utils.js';
+
+// ─── Fixtures ───────────────────────────────────────
+
+const FINGERPRINT_A = 'fingerprint-a-1234567890abcdef';
+const FINGERPRINT_B = 'fingerprint-b-fedcba0987654321';
+
+function makeCompiledResult(lessonHash: string): CompileLessonResult {
+  return {
+    status: 'compiled',
+    rule: {
+      lessonHash,
+      lessonHeading: `Lesson ${lessonHash.slice(0, 6)}`,
+      pattern: 'foo',
+      message: 'avoid foo',
+      engine: 'regex',
+      fileGlobs: ['**/*.ts'],
+      severity: 'warning',
+    } as unknown as CompileLessonResult extends { status: 'compiled'; rule: infer R } ? R : never,
+  };
+}
+
+function makeSkippedResult(hash: string): CompileLessonResult {
+  return {
+    status: 'skipped',
+    hash,
+    reasonCode: 'no-pattern-found',
+  };
+}
+
+// ─── computeLessonSourceHash ────────────────────────
+
+describe('computeLessonSourceHash', () => {
+  it('produces the same hash for CRLF and LF content', () => {
+    const lf = 'line one\nline two\nline three\n';
+    const crlf = 'line one\r\nline two\r\nline three\r\n';
+    expect(computeLessonSourceHash(lf)).toBe(computeLessonSourceHash(crlf));
+  });
+
+  it('produces different hashes for different content', () => {
+    expect(computeLessonSourceHash('content A')).not.toBe(computeLessonSourceHash('content B'));
+  });
+
+  it('is stable across calls', () => {
+    const input = 'stable content\n';
+    expect(computeLessonSourceHash(input)).toBe(computeLessonSourceHash(input));
+  });
+
+  it('produces a 64-char hex SHA-256 digest', () => {
+    const hash = computeLessonSourceHash('any content');
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+  });
+});
+
+// ─── cacheEntryPath ─────────────────────────────────
+
+describe('cacheEntryPath', () => {
+  it('uses the first 16 chars of the source hash as the filename', () => {
+    const totemDir = '/some/dir/.totem';
+    const sourceHash = 'abcdef0123456789' + '0'.repeat(48);
+    const expected = path.join(
+      totemDir,
+      '.totem',
+      'cache',
+      'compile-lesson',
+      'abcdef0123456789.json',
+    );
+    expect(cacheEntryPath(totemDir, sourceHash)).toBe(expected);
+  });
+});
+
+// ─── lookupCacheEntry + writeCacheEntry round-trips ─
+
+describe('cache lookup + write round-trip', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-compile-cache-'));
+    delete process.env.TOTEM_DISABLE_COMPILE_CACHE;
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+    delete process.env.TOTEM_DISABLE_COMPILE_CACHE;
+  });
+
+  it('cache_hit returns the stored entry byte-for-byte', () => {
+    const sourceHash = computeLessonSourceHash('lesson source one');
+    const output = makeCompiledResult('lesson-1-hash');
+    const entry = buildCacheEntry(sourceHash, FINGERPRINT_A, output);
+    writeCacheEntry(tmpDir, entry);
+
+    const result = lookupCacheEntry(tmpDir, sourceHash, FINGERPRINT_A);
+    expect(result.decision).toBe('cache_hit');
+    expect(result.entry).not.toBeNull();
+    // Strip the compiledAt timestamp for byte-for-byte comparison of output payload
+    expect(result.entry?.output).toEqual(output);
+  });
+
+  it('partial_mutation_invariant — modifying one lesson does not rotate siblings', () => {
+    // The falsifying-metric test. Build 5 cache entries; modify 1 lesson's
+    // source; verify the other 4 entries are still resolvable by their original
+    // sourceHash + the modified one is a cache miss.
+    const lessons = [
+      { source: 'lesson 1 source', hash: 'rule-hash-1' },
+      { source: 'lesson 2 source', hash: 'rule-hash-2' },
+      { source: 'lesson 3 source', hash: 'rule-hash-3' },
+      { source: 'lesson 4 source', hash: 'rule-hash-4' },
+      { source: 'lesson 5 source', hash: 'rule-hash-5' },
+    ];
+
+    // Initial seed
+    for (const lesson of lessons) {
+      const sourceHash = computeLessonSourceHash(lesson.source);
+      const entry = buildCacheEntry(sourceHash, FINGERPRINT_A, makeCompiledResult(lesson.hash));
+      writeCacheEntry(tmpDir, entry);
+    }
+
+    // Mutate lesson 3 only
+    lessons[2]!.source = 'lesson 3 MUTATED source';
+
+    // Verify the other 4 lessons still cache-hit on their original sourceHash
+    const indices = [0, 1, 3, 4];
+    for (const i of indices) {
+      const sourceHash = computeLessonSourceHash(lessons[i]!.source);
+      const result = lookupCacheEntry(tmpDir, sourceHash, FINGERPRINT_A);
+      expect(result.decision, `lesson ${i + 1} should hit`).toBe('cache_hit');
+    }
+
+    // And the mutated lesson is a no-prior-record miss (new sourceHash)
+    const mutatedHash = computeLessonSourceHash(lessons[2]!.source);
+    expect(lookupCacheEntry(tmpDir, mutatedHash, FINGERPRINT_A).decision).toBe(
+      'cache_miss_no_prior_record',
+    );
+  });
+
+  it('fingerprint_change_invalidates_all entries', () => {
+    const lessons = [
+      { source: 'lesson 1 source', hash: 'rule-hash-1' },
+      { source: 'lesson 2 source', hash: 'rule-hash-2' },
+    ];
+    for (const lesson of lessons) {
+      const sourceHash = computeLessonSourceHash(lesson.source);
+      const entry = buildCacheEntry(sourceHash, FINGERPRINT_A, makeCompiledResult(lesson.hash));
+      writeCacheEntry(tmpDir, entry);
+    }
+
+    for (const lesson of lessons) {
+      const sourceHash = computeLessonSourceHash(lesson.source);
+      const result = lookupCacheEntry(tmpDir, sourceHash, FINGERPRINT_B);
+      expect(result.decision).toBe('cache_miss_fingerprint_changed');
+      expect(result.entry).toBeNull();
+    }
+  });
+
+  it('source_change_invalidates_one — only the changed lesson misses', () => {
+    const original = 'original source';
+    const modified = 'modified source';
+    const originalHash = computeLessonSourceHash(original);
+    writeCacheEntry(
+      tmpDir,
+      buildCacheEntry(originalHash, FINGERPRINT_A, makeCompiledResult('original-rule')),
+    );
+
+    // Lookup of the original still hits
+    expect(lookupCacheEntry(tmpDir, originalHash, FINGERPRINT_A).decision).toBe('cache_hit');
+
+    // Lookup of the modified misses (different sourceHash)
+    const modifiedHash = computeLessonSourceHash(modified);
+    expect(lookupCacheEntry(tmpDir, modifiedHash, FINGERPRINT_A).decision).toBe(
+      'cache_miss_no_prior_record',
+    );
+  });
+
+  it('force option bypasses the cache without reading disk', () => {
+    const sourceHash = computeLessonSourceHash('any source');
+    writeCacheEntry(
+      tmpDir,
+      buildCacheEntry(sourceHash, FINGERPRINT_A, makeCompiledResult('rule-x')),
+    );
+
+    const result = lookupCacheEntry(tmpDir, sourceHash, FINGERPRINT_A, { force: true });
+    expect(result.decision).toBe('cache_miss_force');
+    expect(result.entry).toBeNull();
+  });
+
+  it('reserves the stableId slot — schema accepts and round-trips it', () => {
+    // P281 never writes stableId. This test asserts that an entry WRITTEN with
+    // a stableId (e.g., by future P280 wiring) parses correctly and the slot
+    // round-trips. Per #387 § Dependencies — load-bearing reservation.
+    const sourceHash = computeLessonSourceHash('lesson with future id');
+    const entry: CacheEntry = {
+      sourceHash,
+      stableId: 'future-p280-stable-id',
+      fingerprint: FINGERPRINT_A,
+      output: makeCompiledResult('rule-with-stable-id'),
+      compiledAt: new Date().toISOString(),
+    };
+    writeCacheEntry(tmpDir, entry);
+
+    const result = lookupCacheEntry(tmpDir, sourceHash, FINGERPRINT_A);
+    expect(result.decision).toBe('cache_hit');
+    expect(result.entry?.stableId).toBe('future-p280-stable-id');
+  });
+
+  it('a malformed cache file produces a graceful cache miss (no throw)', () => {
+    const sourceHash = computeLessonSourceHash('lesson with bad cache file');
+    const filePath = cacheEntryPath(tmpDir, sourceHash);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, '{ this is not valid JSON', 'utf-8');
+
+    const result = lookupCacheEntry(tmpDir, sourceHash, FINGERPRINT_A);
+    expect(result.decision).toBe('cache_miss_no_prior_record');
+    expect(result.entry).toBeNull();
+  });
+
+  it('a schema-invalid cache entry produces a graceful cache miss', () => {
+    const sourceHash = computeLessonSourceHash('lesson with bad schema');
+    const filePath = cacheEntryPath(tmpDir, sourceHash);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    // Output.status is required to be one of the known enum values
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        sourceHash,
+        fingerprint: FINGERPRINT_A,
+        output: { status: 'gibberish' },
+        compiledAt: '2026-05-21T00:00:00.000Z',
+      }),
+      'utf-8',
+    );
+
+    const result = lookupCacheEntry(tmpDir, sourceHash, FINGERPRINT_A);
+    expect(result.decision).toBe('cache_miss_no_prior_record');
+  });
+
+  it('hash-disagreeing cache file is treated as cache miss', () => {
+    // Defensive against manual cache edits — if the file at path-for-hash-X
+    // contains an entry claiming sourceHash-Y, treat as miss.
+    const realHash = computeLessonSourceHash('real content');
+    const filePath = cacheEntryPath(tmpDir, realHash);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(
+      filePath,
+      JSON.stringify({
+        sourceHash: 'some-other-hash',
+        fingerprint: FINGERPRINT_A,
+        output: { status: 'compiled' },
+        compiledAt: '2026-05-21T00:00:00.000Z',
+      }),
+      'utf-8',
+    );
+
+    const result = lookupCacheEntry(tmpDir, realHash, FINGERPRINT_A);
+    expect(result.decision).toBe('cache_miss_source_changed');
+  });
+
+  it('writes the entry as pretty-printed JSON with a trailing newline', () => {
+    const sourceHash = computeLessonSourceHash('formatting check');
+    const entry = buildCacheEntry(sourceHash, FINGERPRINT_A, makeCompiledResult('rule-format'));
+    writeCacheEntry(tmpDir, entry);
+
+    const filePath = cacheEntryPath(tmpDir, sourceHash);
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    expect(raw.endsWith('\n')).toBe(true);
+    // Pretty-printed: multiple lines
+    expect(raw.split('\n').length).toBeGreaterThan(3);
+  });
+
+  it('round-trips a skipped CompileLessonResult', () => {
+    const sourceHash = computeLessonSourceHash('lesson that gets skipped');
+    const entry = buildCacheEntry(
+      sourceHash,
+      FINGERPRINT_A,
+      makeSkippedResult('skipped-lesson-hash'),
+    );
+    writeCacheEntry(tmpDir, entry);
+
+    const result = lookupCacheEntry(tmpDir, sourceHash, FINGERPRINT_A);
+    expect(result.decision).toBe('cache_hit');
+    expect(result.entry?.output.status).toBe('skipped');
+  });
+});
+
+// ─── TOTEM_DISABLE_COMPILE_CACHE escape hatch ──────
+
+describe('TOTEM_DISABLE_COMPILE_CACHE env var', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-compile-cache-env-'));
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+    delete process.env.TOTEM_DISABLE_COMPILE_CACHE;
+  });
+
+  it('lookup returns no-prior-record when disabled, even if a valid entry exists on disk', () => {
+    const sourceHash = computeLessonSourceHash('disable env test');
+    // Seed first without the env var so the file lands on disk
+    writeCacheEntry(
+      tmpDir,
+      buildCacheEntry(sourceHash, FINGERPRINT_A, makeCompiledResult('rule-disable')),
+    );
+
+    process.env.TOTEM_DISABLE_COMPILE_CACHE = '1';
+    const result = lookupCacheEntry(tmpDir, sourceHash, FINGERPRINT_A);
+    expect(result.decision).toBe('cache_miss_no_prior_record');
+    expect(result.entry).toBeNull();
+  });
+
+  it('write is a no-op when the env var is set', () => {
+    process.env.TOTEM_DISABLE_COMPILE_CACHE = '1';
+    const sourceHash = computeLessonSourceHash('disable env write');
+    writeCacheEntry(
+      tmpDir,
+      buildCacheEntry(sourceHash, FINGERPRINT_A, makeCompiledResult('rule-disable-write')),
+    );
+
+    const filePath = cacheEntryPath(tmpDir, sourceHash);
+    expect(fs.existsSync(filePath)).toBe(false);
+  });
+});
+
+// ─── Migration seed ─────────────────────────────────
+
+describe('migrateFromCompiledRules', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-compile-cache-migrate-'));
+    delete process.env.TOTEM_DISABLE_COMPILE_CACHE;
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+    delete process.env.TOTEM_DISABLE_COMPILE_CACHE;
+  });
+
+  it('seeds 100% cache hit for subsequent lookups', () => {
+    const inputs = [
+      {
+        lessonHash: 'seed-1',
+        lessonSource: 'seed lesson 1 source',
+        output: makeCompiledResult('seed-1'),
+      },
+      {
+        lessonHash: 'seed-2',
+        lessonSource: 'seed lesson 2 source',
+        output: makeCompiledResult('seed-2'),
+      },
+      {
+        lessonHash: 'seed-3',
+        lessonSource: 'seed lesson 3 source',
+        output: makeCompiledResult('seed-3'),
+      },
+    ];
+
+    const result = migrateFromCompiledRules(tmpDir, FINGERPRINT_A, inputs);
+    expect(result.seeded).toBe(3);
+    expect(result.skipped).toBe(0);
+
+    for (const input of inputs) {
+      const sourceHash = computeLessonSourceHash(input.lessonSource);
+      const lookup = lookupCacheEntry(tmpDir, sourceHash, FINGERPRINT_A);
+      expect(lookup.decision).toBe('cache_hit');
+    }
+  });
+
+  it('is idempotent — running twice produces the same on-disk state', () => {
+    const inputs = [
+      {
+        lessonHash: 'idempotent-1',
+        lessonSource: 'idempotent source one',
+        output: makeCompiledResult('idempotent-1'),
+      },
+    ];
+
+    migrateFromCompiledRules(tmpDir, FINGERPRINT_A, inputs);
+    const sourceHash = computeLessonSourceHash(inputs[0]!.lessonSource);
+    const after1 = fs.readFileSync(cacheEntryPath(tmpDir, sourceHash), 'utf-8');
+
+    migrateFromCompiledRules(tmpDir, FINGERPRINT_A, inputs);
+    const after2 = fs.readFileSync(cacheEntryPath(tmpDir, sourceHash), 'utf-8');
+
+    // Bodies match except possibly compiledAt; structural equivalence post-parse
+    const parsed1 = JSON.parse(after1);
+    const parsed2 = JSON.parse(after2);
+    parsed1.compiledAt = parsed2.compiledAt = 'normalized';
+    expect(parsed1).toEqual(parsed2);
+  });
+
+  it('skips when env var disables cache, reporting all inputs as skipped', () => {
+    process.env.TOTEM_DISABLE_COMPILE_CACHE = '1';
+    const inputs = [
+      {
+        lessonHash: 'disabled-1',
+        lessonSource: 'disabled source',
+        output: makeCompiledResult('disabled-1'),
+      },
+    ];
+    const result = migrateFromCompiledRules(tmpDir, FINGERPRINT_A, inputs);
+    expect(result.seeded).toBe(0);
+    expect(result.skipped).toBe(1);
+  });
+});

--- a/packages/core/src/compile-cache.test.ts
+++ b/packages/core/src/compile-cache.test.ts
@@ -16,6 +16,7 @@ import {
   buildCacheEntry,
   type CacheEntry,
   cacheEntryPath,
+  composeLessonSourceForHash,
   computeLessonSourceHash,
   listCacheEntries,
   lookupCacheEntry,
@@ -112,16 +113,59 @@ describe('computeLessonSourceHash', () => {
     expect(hashBodyA).not.toBe(hashBodyB);
   });
 
-  it('normalizes trailing whitespace per the impl contract (GCA HIGH on #1983)', () => {
-    // The trimEnd() normalization absorbs trailing-newline / trailing-whitespace
-    // differences across save behaviors. Inputs that differ ONLY in trailing
-    // whitespace must hash identically — otherwise the cache misses on every
-    // editor-save-style change.
+  it('preserves trailing-whitespace sensitivity (GCA R2 critical on #1983)', () => {
+    // The canonical generateInputHash + lessonHash are trailing-whitespace
+    // sensitive (`compile-manifest.ts` does CRLF→LF normalization only; no
+    // trim). The cache key MUST match that sensitivity. If it didn't, a
+    // whitespace-only edit would hit the cache and return a rule with a stale
+    // lessonHash while the manifest pipeline computed a fresh lessonHash for
+    // the same edit — breaking the deterministic link between lessons and
+    // rules.
+    //
+    // GCA R1 originally flagged a missing .trimEnd() (citing my contract
+    // prose, which over-claimed normalization scope); GCA R2 reversed that
+    // finding by anchoring to the canonical hash shape. This test locks in
+    // the R2-correct behavior so future regressions to "more aggressive
+    // normalization" surface immediately.
     const base = 'lesson content';
-    expect(computeLessonSourceHash(base)).toBe(computeLessonSourceHash(base + '\n'));
-    expect(computeLessonSourceHash(base)).toBe(computeLessonSourceHash(base + '\n\n\n'));
-    expect(computeLessonSourceHash(base)).toBe(computeLessonSourceHash(base + '   \t  '));
-    expect(computeLessonSourceHash(base)).toBe(computeLessonSourceHash(base + ' \n \n'));
+    expect(computeLessonSourceHash(base)).not.toBe(computeLessonSourceHash(base + '\n'));
+    expect(computeLessonSourceHash(base)).not.toBe(computeLessonSourceHash(base + '\n\n\n'));
+    expect(computeLessonSourceHash(base)).not.toBe(computeLessonSourceHash(base + '   '));
+  });
+
+  it('normalizes CRLF to LF (cross-OS stability)', () => {
+    // The one normalization the canonical hash DOES apply: CRLF → LF. Same
+    // shape as `generateInputHash`. Without this, a Windows-saved lesson and
+    // a Unix-saved lesson with identical visible content would hash
+    // differently.
+    const lf = 'line one\nline two\nline three\n';
+    const crlf = 'line one\r\nline two\r\nline three\r\n';
+    expect(computeLessonSourceHash(lf)).toBe(computeLessonSourceHash(crlf));
+  });
+});
+
+// ─── composeLessonSourceForHash ─────────────────────
+
+describe('composeLessonSourceForHash', () => {
+  it('produces the same string for the same (heading, body) inputs', () => {
+    const a = composeLessonSourceForHash('My Heading', 'body text\n');
+    const b = composeLessonSourceForHash('My Heading', 'body text\n');
+    expect(a).toBe(b);
+  });
+
+  it('distinguishes heading-only edits from body-only edits', () => {
+    // Defends the runtime/migration hash-consistency contract (GCA R2 critical
+    // on #1983). Both call sites — compile.ts wiring and migrateFromCompiledRules
+    // — route through this helper. If a future refactor accidentally
+    // re-introduced separate composition logic on either side, the two paths
+    // would diverge again.
+    const headingChange = composeLessonSourceForHash('Heading A', 'shared body');
+    const headingChangeAlt = composeLessonSourceForHash('Heading B', 'shared body');
+    expect(headingChange).not.toBe(headingChangeAlt);
+
+    const bodyChange = composeLessonSourceForHash('shared heading', 'body A');
+    const bodyChangeAlt = composeLessonSourceForHash('shared heading', 'body B');
+    expect(bodyChange).not.toBe(bodyChangeAlt);
   });
 });
 
@@ -415,17 +459,20 @@ describe('migrateFromCompiledRules', () => {
     const inputs = [
       {
         lessonHash: 'seed-1',
-        lessonSource: 'seed lesson 1 source',
+        heading: 'Lesson 1 heading',
+        body: 'seed lesson 1 body content\n',
         output: makeCompiledResult('seed-1'),
       },
       {
         lessonHash: 'seed-2',
-        lessonSource: 'seed lesson 2 source',
+        heading: 'Lesson 2 heading',
+        body: 'seed lesson 2 body content\n',
         output: makeCompiledResult('seed-2'),
       },
       {
         lessonHash: 'seed-3',
-        lessonSource: 'seed lesson 3 source',
+        heading: 'Lesson 3 heading',
+        body: 'seed lesson 3 body content\n',
         output: makeCompiledResult('seed-3'),
       },
     ];
@@ -435,23 +482,50 @@ describe('migrateFromCompiledRules', () => {
     expect(result.skipped).toBe(0);
 
     for (const input of inputs) {
-      const sourceHash = computeLessonSourceHash(input.lessonSource);
+      // Migration must produce hashes that the runtime lookup can hit. Both
+      // paths route through `composeLessonSourceForHash` to guarantee this.
+      const sourceHash = computeLessonSourceHash(
+        composeLessonSourceForHash(input.heading, input.body),
+      );
       const lookup = lookupCacheEntry(tmpDir, sourceHash, FINGERPRINT_A);
       expect(lookup.decision).toBe('cache_hit');
     }
+  });
+
+  it('runtime/migration hash consistency (GCA R2 critical on #1983)', () => {
+    // Load-bearing regression test: a lesson seeded via the migration path
+    // MUST be hittable via the runtime lookup path using the same heading +
+    // body. Before this fix, migration hashed raw `lessonSource` (the parsed
+    // file content including markdown framing) while runtime hashed
+    // `${heading}\n${body}` — the same lesson produced two different hashes,
+    // making every migrated entry permanently unreachable.
+    const heading = 'Some lesson heading';
+    const body = 'body line 1\nbody line 2\n';
+    migrateFromCompiledRules(tmpDir, FINGERPRINT_A, [
+      { lessonHash: 'consistency-1', heading, body, output: makeCompiledResult('consistency-1') },
+    ]);
+
+    // Simulating the runtime call shape from compile.ts
+    const runtimeSourceHash = computeLessonSourceHash(composeLessonSourceForHash(heading, body));
+    const lookup = lookupCacheEntry(tmpDir, runtimeSourceHash, FINGERPRINT_A);
+    expect(lookup.decision).toBe('cache_hit');
+    expect(lookup.entry).not.toBeNull();
   });
 
   it('is idempotent — running twice produces the same on-disk state', () => {
     const inputs = [
       {
         lessonHash: 'idempotent-1',
-        lessonSource: 'idempotent source one',
+        heading: 'Idempotent heading',
+        body: 'idempotent source one body\n',
         output: makeCompiledResult('idempotent-1'),
       },
     ];
 
     migrateFromCompiledRules(tmpDir, FINGERPRINT_A, inputs);
-    const sourceHash = computeLessonSourceHash(inputs[0]!.lessonSource);
+    const sourceHash = computeLessonSourceHash(
+      composeLessonSourceForHash(inputs[0]!.heading, inputs[0]!.body),
+    );
     const after1 = fs.readFileSync(cacheEntryPath(tmpDir, sourceHash), 'utf-8');
 
     migrateFromCompiledRules(tmpDir, FINGERPRINT_A, inputs);
@@ -469,7 +543,8 @@ describe('migrateFromCompiledRules', () => {
     const inputs = [
       {
         lessonHash: 'disabled-1',
-        lessonSource: 'disabled source',
+        heading: 'Disabled heading',
+        body: 'disabled body\n',
         output: makeCompiledResult('disabled-1'),
       },
     ];
@@ -485,9 +560,9 @@ describe('migrateFromCompiledRules', () => {
     // bookkeeping path.
     process.env.TOTEM_DISABLE_COMPILE_CACHE = '1';
     const inputs = [
-      { lessonHash: 'a', lessonSource: 'a source', output: makeCompiledResult('a') },
-      { lessonHash: 'b', lessonSource: 'b source', output: makeCompiledResult('b') },
-      { lessonHash: 'c', lessonSource: 'c source', output: makeCompiledResult('c') },
+      { lessonHash: 'a', heading: 'Lesson A', body: 'a body\n', output: makeCompiledResult('a') },
+      { lessonHash: 'b', heading: 'Lesson B', body: 'b body\n', output: makeCompiledResult('b') },
+      { lessonHash: 'c', heading: 'Lesson C', body: 'c body\n', output: makeCompiledResult('c') },
     ];
     const result = migrateFromCompiledRules(tmpDir, FINGERPRINT_A, inputs);
     expect(result.seeded).toBe(0);

--- a/packages/core/src/compile-cache.test.ts
+++ b/packages/core/src/compile-cache.test.ts
@@ -17,6 +17,7 @@ import {
   type CacheEntry,
   cacheEntryPath,
   computeLessonSourceHash,
+  listCacheEntries,
   lookupCacheEntry,
   migrateFromCompiledRules,
   writeCacheEntry,
@@ -427,5 +428,101 @@ describe('migrateFromCompiledRules', () => {
     const result = migrateFromCompiledRules(tmpDir, FINGERPRINT_A, inputs);
     expect(result.seeded).toBe(0);
     expect(result.skipped).toBe(1);
+  });
+
+  it('seeded count reflects entries actually persisted (write failures land in skipped)', () => {
+    // Defensive guarantee: even if `writeCacheEntry` returns false (write
+    // failure or env-disable), the seeded counter must not increment. This
+    // tests the writeCacheEntry boolean-return contract from the migration
+    // bookkeeping path.
+    process.env.TOTEM_DISABLE_COMPILE_CACHE = '1';
+    const inputs = [
+      { lessonHash: 'a', lessonSource: 'a source', output: makeCompiledResult('a') },
+      { lessonHash: 'b', lessonSource: 'b source', output: makeCompiledResult('b') },
+      { lessonHash: 'c', lessonSource: 'c source', output: makeCompiledResult('c') },
+    ];
+    const result = migrateFromCompiledRules(tmpDir, FINGERPRINT_A, inputs);
+    expect(result.seeded).toBe(0);
+    expect(result.skipped).toBe(3);
+  });
+});
+
+// ─── listCacheEntries ───────────────────────────────
+
+describe('listCacheEntries', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-compile-cache-list-'));
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  it('returns empty array when the cache directory does not exist', () => {
+    expect(listCacheEntries(tmpDir)).toEqual([]);
+  });
+
+  it('lists all written cache entry filenames', () => {
+    const sources = ['lesson alpha', 'lesson beta', 'lesson gamma'];
+    for (const src of sources) {
+      const sourceHash = computeLessonSourceHash(src);
+      writeCacheEntry(tmpDir, buildCacheEntry(sourceHash, FINGERPRINT_A, makeCompiledResult(src)));
+    }
+
+    const entries = listCacheEntries(tmpDir);
+    expect(entries.length).toBe(3);
+    for (const entry of entries) {
+      expect(entry).toMatch(/^[a-f0-9]{16}\.json$/);
+    }
+  });
+
+  it('ignores non-json files in the cache directory', () => {
+    const sourceHash = computeLessonSourceHash('only json counts');
+    writeCacheEntry(tmpDir, buildCacheEntry(sourceHash, FINGERPRINT_A, makeCompiledResult('only')));
+
+    // Drop a stray file beside the cache entries
+    const cacheDir = path.dirname(cacheEntryPath(tmpDir, sourceHash));
+    fs.writeFileSync(path.join(cacheDir, 'README.txt'), 'stray');
+
+    const entries = listCacheEntries(tmpDir);
+    expect(entries.length).toBe(1);
+    expect(entries[0]).toMatch(/\.json$/);
+  });
+});
+
+// ─── writeCacheEntry return value ───────────────────
+
+describe('writeCacheEntry return value', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-compile-cache-write-'));
+    delete process.env.TOTEM_DISABLE_COMPILE_CACHE;
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+    delete process.env.TOTEM_DISABLE_COMPILE_CACHE;
+  });
+
+  it('returns true on successful write', () => {
+    const sourceHash = computeLessonSourceHash('write-ok source');
+    const result = writeCacheEntry(
+      tmpDir,
+      buildCacheEntry(sourceHash, FINGERPRINT_A, makeCompiledResult('write-ok')),
+    );
+    expect(result).toBe(true);
+  });
+
+  it('returns false when the env-var disables the cache', () => {
+    process.env.TOTEM_DISABLE_COMPILE_CACHE = '1';
+    const sourceHash = computeLessonSourceHash('write-disabled source');
+    const result = writeCacheEntry(
+      tmpDir,
+      buildCacheEntry(sourceHash, FINGERPRINT_A, makeCompiledResult('write-disabled')),
+    );
+    expect(result).toBe(false);
   });
 });

--- a/packages/core/src/compile-cache.test.ts
+++ b/packages/core/src/compile-cache.test.ts
@@ -72,6 +72,14 @@ function makeSkippedResult(hash: string): CompileLessonResult {
   };
 }
 
+function makeNoopResult(): CompileLessonResult {
+  return { status: 'noop' };
+}
+
+function makeFailedResult(): CompileLessonResult {
+  return { status: 'failed' };
+}
+
 // ─── computeLessonSourceHash ────────────────────────
 
 describe('computeLessonSourceHash', () => {
@@ -469,6 +477,37 @@ describe('cache lookup + write round-trip', () => {
     const result = lookupCacheEntry(tmpDir, sourceHash, FINGERPRINT_A);
     expect(result.decision).toBe('cache_hit');
     expect(result.entry?.output.status).toBe('skipped');
+  });
+
+  it('round-trips a noop CompileLessonResult', () => {
+    // Closes a CompileLessonResult variant-coverage gap. `noop` is the
+    // discriminator emitted when a compile invocation has nothing to do (e.g.,
+    // an upgrade-batch run where the lesson body is unchanged); the cache must
+    // round-trip it without dropping the status field through schema
+    // validation.
+    const sourceHash = computeLessonSourceHash('lesson that is a noop');
+    const entry = buildCacheEntry(sourceHash, FINGERPRINT_A, makeNoopResult());
+    writeCacheEntry(tmpDir, entry);
+
+    const result = lookupCacheEntry(tmpDir, sourceHash, FINGERPRINT_A);
+    expect(result.decision).toBe('cache_hit');
+    expect(result.entry?.output.status).toBe('noop');
+  });
+
+  it('round-trips a failed CompileLessonResult (defensive — failures normally bypass cache)', () => {
+    // compile.ts wraps the parallel-compile path and explicitly skips writing
+    // `failed` outputs (failures are transient; caching them would poison
+    // subsequent runs). But the cache primitives themselves must handle the
+    // shape correctly when a caller writes one directly — guards against
+    // schema regressions that would break the discriminated union for the
+    // failed variant.
+    const sourceHash = computeLessonSourceHash('lesson that failed');
+    const entry = buildCacheEntry(sourceHash, FINGERPRINT_A, makeFailedResult());
+    writeCacheEntry(tmpDir, entry);
+
+    const result = lookupCacheEntry(tmpDir, sourceHash, FINGERPRINT_A);
+    expect(result.decision).toBe('cache_hit');
+    expect(result.entry?.output.status).toBe('failed');
   });
 });
 

--- a/packages/core/src/compile-cache.test.ts
+++ b/packages/core/src/compile-cache.test.ts
@@ -7,8 +7,8 @@
  */
 
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
@@ -29,6 +29,24 @@ import { cleanTmpDir } from './test-utils.js';
 
 const FINGERPRINT_A = 'fingerprint-a-1234567890abcdef';
 const FINGERPRINT_B = 'fingerprint-b-fedcba0987654321';
+
+/**
+ * Workspace-scoped temp root per cohort lesson "os.tmpdir() for agent-readable
+ * temp files violates workspace boundary." Tests under this suite create per-it
+ * temp dirs under `<package>/.totem/temp/compile-cache-tests/<unique-prefix>`,
+ * cleaned in afterEach. `.totem/temp/` is already gitignored.
+ *
+ * Anchored to the test file's own location (not `process.cwd()`) so the path
+ * resolves to the package directory regardless of where vitest is invoked from.
+ */
+const TEST_FILE_DIR = path.dirname(fileURLToPath(import.meta.url));
+const PACKAGE_ROOT = path.resolve(TEST_FILE_DIR, '..');
+const TEST_TEMP_ROOT = path.join(PACKAGE_ROOT, '.totem', 'temp', 'compile-cache-tests');
+fs.mkdirSync(TEST_TEMP_ROOT, { recursive: true });
+
+function makeTestTmpDir(prefix: string): string {
+  return fs.mkdtempSync(path.join(TEST_TEMP_ROOT, prefix));
+}
 
 function makeCompiledResult(lessonHash: string): CompileLessonResult {
   return {
@@ -75,6 +93,36 @@ describe('computeLessonSourceHash', () => {
     const hash = computeLessonSourceHash('any content');
     expect(hash).toMatch(/^[a-f0-9]{64}$/);
   });
+
+  it('distinguishes heading-only edits from body-only edits (CR Major on #1983)', () => {
+    // The cache key in compile.ts composes `${lesson.heading}\n${lesson.body}`
+    // and hashes that. A heading-only edit must produce a different sourceHash
+    // (otherwise the cache hits + preserves stale lessonHash output that would
+    // ordinarily rotate to reflect the new heading). This test exercises the
+    // composition shape directly.
+    const body = 'lesson body content';
+    const hashA = computeLessonSourceHash(`Heading A\n${body}`);
+    const hashB = computeLessonSourceHash(`Heading B\n${body}`);
+    expect(hashA).not.toBe(hashB);
+
+    // And conversely, a body-only edit also invalidates.
+    const heading = 'Stable heading';
+    const hashBodyA = computeLessonSourceHash(`${heading}\nbody version A`);
+    const hashBodyB = computeLessonSourceHash(`${heading}\nbody version B`);
+    expect(hashBodyA).not.toBe(hashBodyB);
+  });
+
+  it('normalizes trailing whitespace per the impl contract (GCA HIGH on #1983)', () => {
+    // The trimEnd() normalization absorbs trailing-newline / trailing-whitespace
+    // differences across save behaviors. Inputs that differ ONLY in trailing
+    // whitespace must hash identically — otherwise the cache misses on every
+    // editor-save-style change.
+    const base = 'lesson content';
+    expect(computeLessonSourceHash(base)).toBe(computeLessonSourceHash(base + '\n'));
+    expect(computeLessonSourceHash(base)).toBe(computeLessonSourceHash(base + '\n\n\n'));
+    expect(computeLessonSourceHash(base)).toBe(computeLessonSourceHash(base + '   \t  '));
+    expect(computeLessonSourceHash(base)).toBe(computeLessonSourceHash(base + ' \n \n'));
+  });
 });
 
 // ─── cacheEntryPath ─────────────────────────────────
@@ -100,7 +148,7 @@ describe('cache lookup + write round-trip', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-compile-cache-'));
+    tmpDir = makeTestTmpDir('totem-compile-cache-');
     delete process.env.TOTEM_DISABLE_COMPILE_CACHE;
   });
 
@@ -313,7 +361,7 @@ describe('TOTEM_DISABLE_COMPILE_CACHE env var', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-compile-cache-env-'));
+    tmpDir = makeTestTmpDir('totem-compile-cache-env-');
   });
 
   afterEach(() => {
@@ -354,7 +402,7 @@ describe('migrateFromCompiledRules', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-compile-cache-migrate-'));
+    tmpDir = makeTestTmpDir('totem-compile-cache-migrate-');
     delete process.env.TOTEM_DISABLE_COMPILE_CACHE;
   });
 
@@ -453,7 +501,7 @@ describe('listCacheEntries', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-compile-cache-list-'));
+    tmpDir = makeTestTmpDir('totem-compile-cache-list-');
   });
 
   afterEach(() => {
@@ -498,7 +546,7 @@ describe('writeCacheEntry return value', () => {
   let tmpDir: string;
 
   beforeEach(() => {
-    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-compile-cache-write-'));
+    tmpDir = makeTestTmpDir('totem-compile-cache-write-');
     delete process.env.TOTEM_DISABLE_COMPILE_CACHE;
   });
 

--- a/packages/core/src/compile-cache.test.ts
+++ b/packages/core/src/compile-cache.test.ts
@@ -191,6 +191,27 @@ describe('cacheEntryPath', () => {
       path.join('/repo/.totem', 'cache', 'compile-lesson', 'aaaaaaaaaaaaaaaa.json'),
     );
   });
+
+  it('rejects non-SHA cache keys to prevent path traversal (CR R4 Major on #1983)', () => {
+    // Without the regex guard, a sourceHash carrying `/` or `..` would flow
+    // through path.join() and escape `<totemDir>/cache/compile-lesson`, letting
+    // lookup or write touch arbitrary files. computeLessonSourceHash always
+    // emits the matching shape; this catches caller misuse.
+    expect(() => cacheEntryPath('/some/.totem', '../../../etc/passwd')).toThrow(
+      /Invalid sourceHash/,
+    );
+    expect(() => cacheEntryPath('/some/.totem', 'a/b/c')).toThrow(/Invalid sourceHash/);
+    expect(() => cacheEntryPath('/some/.totem', '..')).toThrow(/Invalid sourceHash/);
+    expect(() => cacheEntryPath('/some/.totem', '')).toThrow(/Invalid sourceHash/);
+    expect(() => cacheEntryPath('/some/.totem', 'NOT_HEX_!@#$')).toThrow(/Invalid sourceHash/);
+    // Hex but wrong length
+    expect(() => cacheEntryPath('/some/.totem', 'abcdef')).toThrow(/Invalid sourceHash/);
+    // Uppercase hex — the regex requires lowercase for normalization
+    expect(() => cacheEntryPath('/some/.totem', 'A'.repeat(64))).toThrow(/Invalid sourceHash/);
+
+    // Sanity: a real digest is accepted
+    expect(() => cacheEntryPath('/some/.totem', 'a'.repeat(64))).not.toThrow();
+  });
 });
 
 // ─── lookupCacheEntry + writeCacheEntry round-trips ─
@@ -699,5 +720,70 @@ describe('writeCacheEntry return value', () => {
       buildCacheEntry(sourceHash, FINGERPRINT_A, makeCompiledResult('write-disabled')),
     );
     expect(result).toBe(false);
+  });
+
+  it('swallows a throwing onWarn — never propagates out of cache write (CR R4 Major on #1983)', () => {
+    // The cache's non-throwing contract requires that a caller-supplied onWarn
+    // cannot abort compile even when it itself throws. Without this, a
+    // misbehaving telemetry hook could escalate a benign cache-write failure
+    // into a hard compile abort.
+    const throwingWarn = (): never => {
+      throw new Error('caller-provided onWarn exploded');
+    };
+    // Force a write failure by pointing at a path that can't be created. On
+    // Windows this is a path with an invalid char; on POSIX a path under a
+    // file. Easiest cross-platform shape: pass a non-existent volume root.
+    const badDir = path.join(tmpDir, '\x00invalid');
+    const sourceHash = computeLessonSourceHash('write-with-throwing-onwarn');
+    const entry = buildCacheEntry(sourceHash, FINGERPRINT_A, makeCompiledResult('throwing-warn'));
+    expect(() => writeCacheEntry(badDir, entry, throwingWarn)).not.toThrow();
+  });
+});
+
+// ─── safeOnWarn guard via migrateFromCompiledRules ──
+
+describe('safeOnWarn (CR R4 Major on #1983)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTestTmpDir('totem-compile-cache-safewarn-');
+    delete process.env.TOTEM_DISABLE_COMPILE_CACHE;
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+    delete process.env.TOTEM_DISABLE_COMPILE_CACHE;
+  });
+
+  it('migrateFromCompiledRules: throwing onWarn does not abort the seed loop', () => {
+    // If onWarn throws on one input, subsequent inputs must still be processed.
+    // Without safeOnWarn the throw would escape the per-input catch and
+    // short-circuit the migration.
+    const throwingWarn = (): never => {
+      throw new Error('telemetry hook exploded');
+    };
+    // First input is malformed (heading has bad hash shape from buildCacheEntry
+    // path); subsequent valid inputs should still seed.
+    const inputs = [
+      {
+        lessonHash: 'will-warn-due-to-write-failure',
+        heading: 'Bad Lesson',
+        body: 'will fail to write\n',
+        output: makeCompiledResult('bad'),
+      },
+      {
+        lessonHash: 'will-seed',
+        heading: 'Good Lesson',
+        body: 'should-be-seeded\n',
+        output: makeCompiledResult('good'),
+      },
+    ];
+    // Force the first write to fail by passing a directory that can't be
+    // created (null byte). The throwing onWarn would normally explode the
+    // loop; with safeOnWarn the second input still seeds.
+    const badDir = path.join(tmpDir, '\x00invalid');
+    expect(() =>
+      migrateFromCompiledRules(badDir, FINGERPRINT_A, inputs, throwingWarn),
+    ).not.toThrow();
   });
 });

--- a/packages/core/src/compile-cache.ts
+++ b/packages/core/src/compile-cache.ts
@@ -1,0 +1,281 @@
+/**
+ * Per-lesson compile cache (Proposal 281 — Per-Lesson Hash Stability).
+ *
+ * Short-circuits `totem lesson compile` for lessons whose source content is
+ * unchanged across compile runs. Eliminates the per-lesson hash rotation on
+ * unrelated lessons when a single lesson is added or modified.
+ *
+ * Cache key is layered (not composite):
+ *   1. `stableId` (when present — reserved for P280; P281 never writes it)
+ *   2. `sourceHash` — sha256 of normalized lesson source content
+ *   3. `fingerprint` — compile_worker_fingerprint from Proposal 278; mismatch
+ *      invalidates the entry (e.g., model bump rotates every entry once)
+ *
+ * `cli_version` is intentionally NOT part of the cache key — including it
+ * would invalidate every cohort bump, defeating the purpose. Per the impl
+ * contract § Cache key composition.
+ *
+ * Storage: `.totem/cache/compile-lesson/<sourceHash-first-16-chars>.json`,
+ * one entry per file, flat directory for v1 (see follow-on for fan-out
+ * cutover at ~1000 lessons).
+ *
+ * Emergency escape: set `TOTEM_DISABLE_COMPILE_CACHE=1` to bypass the
+ * cache entirely (lookup always returns null; write becomes a no-op).
+ * Emergency only — not a long-term flag.
+ */
+
+import * as crypto from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { z } from 'zod';
+
+import type { CompileLessonResult } from './compile-lesson.js';
+
+// ─── Constants ──────────────────────────────────────
+
+const CACHE_DIR = path.join('.totem', 'cache', 'compile-lesson');
+const HASH_FILENAME_PREFIX_LENGTH = 16;
+const DISABLE_ENV_VAR = 'TOTEM_DISABLE_COMPILE_CACHE';
+
+// ─── Schema ─────────────────────────────────────────
+
+/**
+ * Minimal validator for the `output` field. CompileLessonResult is a
+ * discriminated union with no runtime Zod schema today; deeply validating
+ * the variant payloads would couple this module to every change in
+ * `compile-lesson.ts`. Instead, we check the discriminator value is one of
+ * the known statuses; downstream consumers can rely on the type assertion.
+ * Per the impl contract § "graceful — bad cache entry → recompile, not
+ * crash" — corrupt outputs fail this gate and trigger a cache miss.
+ */
+const COMPILE_LESSON_STATUS = ['compiled', 'skipped', 'failed', 'noop'] as const;
+const CompileLessonResultMinimalSchema = z
+  .object({
+    status: z.enum(COMPILE_LESSON_STATUS),
+  })
+  .passthrough();
+
+/**
+ * Cache entry for one lesson's compile output.
+ *
+ * `stableId` is reserved for P280 (Wind-Tunnel Decoupling). P281 does not
+ * populate or query it. Reserving the slot from day one avoids a full cache
+ * re-key event when P280 lands; with the reservation, P280's integration is
+ * an additive lookup extension, not a refactor. Per
+ * `mmnto-ai/totem-strategy#387` § Dependencies (load-bearing).
+ */
+export const CacheEntrySchema = z.object({
+  sourceHash: z.string(),
+  stableId: z.string().optional(),
+  fingerprint: z.string(),
+  output: CompileLessonResultMinimalSchema,
+  compiledAt: z.string(),
+});
+
+export type CacheEntry = Omit<z.infer<typeof CacheEntrySchema>, 'output'> & {
+  output: CompileLessonResult;
+};
+
+/**
+ * Discrete cache decisions, emitted per lesson per compile run as
+ * telemetry. Maps to the `compile_cache_decision` ledger event's
+ * `activity_name` field.
+ */
+export type CacheDecision =
+  | 'cache_hit'
+  | 'cache_miss_source_changed'
+  | 'cache_miss_fingerprint_changed'
+  | 'cache_miss_force'
+  | 'cache_miss_no_prior_record';
+
+// ─── Public API ─────────────────────────────────────
+
+/**
+ * Compute the cache key for a lesson source. SHA-256 of the content with
+ * line endings normalized to `\n` — same normalization as
+ * `generateInputHash` in compile-manifest.ts so both surfaces produce
+ * identical hashes for identical inputs.
+ */
+export function computeLessonSourceHash(lessonSource: string): string {
+  const normalized = lessonSource.replace(/\r\n/g, '\n');
+  return crypto.createHash('sha256').update(normalized).digest('hex');
+}
+
+/**
+ * Resolve the on-disk cache file path for a given source hash. Pure;
+ * does not check existence. Callers handle missing files.
+ */
+export function cacheEntryPath(totemDir: string, sourceHash: string): string {
+  const filename = `${sourceHash.slice(0, HASH_FILENAME_PREFIX_LENGTH)}.json`;
+  return path.join(totemDir, CACHE_DIR, filename);
+}
+
+interface LookupResult {
+  entry: CacheEntry | null;
+  decision: CacheDecision;
+}
+
+/**
+ * Look up a cache entry by `(sourceHash, fingerprint)`. Returns the entry
+ * with `decision: 'cache_hit'` on a clean hit, or `null` with a
+ * decision discriminating the miss reason.
+ *
+ * `stableId` parameter is reserved for P280 wiring — when present, the
+ * lookup tries the stable-id-indexed entry first, falling back to
+ * `sourceHash` on miss. v1 (this PR) never receives a non-undefined
+ * value here.
+ */
+export function lookupCacheEntry(
+  totemDir: string,
+  sourceHash: string,
+  fingerprint: string,
+  options: { force?: boolean; stableId?: string } = {},
+): LookupResult {
+  if (options.force === true) {
+    return { entry: null, decision: 'cache_miss_force' };
+  }
+  if (process.env[DISABLE_ENV_VAR] === '1') {
+    // totem-context: intentional cleanup — emergency escape hatch reverts
+    // cache to no-op without throwing.
+    return { entry: null, decision: 'cache_miss_no_prior_record' };
+  }
+
+  const filePath = cacheEntryPath(totemDir, sourceHash);
+  if (!fs.existsSync(filePath)) {
+    return { entry: null, decision: 'cache_miss_no_prior_record' };
+  }
+
+  let raw: unknown;
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    raw = JSON.parse(content);
+  } catch {
+    // totem-context: intentional cleanup — bad cache entry is treated as a
+    // miss, never propagated upward. Graceful per the impl contract §
+    // "Reject and treat as cache miss on schema mismatch".
+    return { entry: null, decision: 'cache_miss_no_prior_record' };
+  }
+
+  const parsed = CacheEntrySchema.safeParse(raw);
+  if (!parsed.success) {
+    return { entry: null, decision: 'cache_miss_no_prior_record' };
+  }
+
+  // CacheEntrySchema validates the discriminator only; downstream casts back
+  // to the rich CompileLessonResult union type. See COMPILE_LESSON_STATUS.
+  const entry = parsed.data as CacheEntry;
+  if (entry.sourceHash !== sourceHash) {
+    // File was named by hash but its content disagrees — corrupted state,
+    // treat as miss. Defensive against manual cache edits.
+    return { entry: null, decision: 'cache_miss_source_changed' };
+  }
+  if (entry.fingerprint !== fingerprint) {
+    return { entry: null, decision: 'cache_miss_fingerprint_changed' };
+  }
+
+  return { entry, decision: 'cache_hit' };
+}
+
+/**
+ * Persist a cache entry after a successful compile. Idempotent — writing
+ * the same `(sourceHash, fingerprint, output)` twice is a no-op-shaped
+ * overwrite. Fire-and-forget: I/O failures are surfaced via `onWarn` and
+ * never propagate (a failed cache write should not crash a compile).
+ */
+export function writeCacheEntry(
+  totemDir: string,
+  entry: CacheEntry,
+  onWarn?: (msg: string) => void,
+): void {
+  if (process.env[DISABLE_ENV_VAR] === '1') {
+    return;
+  }
+
+  try {
+    const filePath = cacheEntryPath(totemDir, entry.sourceHash);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, JSON.stringify(entry, null, 2) + '\n', 'utf-8');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    onWarn?.(`Compile cache write failed: ${msg}`);
+  }
+}
+
+/**
+ * Construct a `CacheEntry` from the inputs of a fresh compile. Pure;
+ * callers persist via `writeCacheEntry`.
+ */
+export function buildCacheEntry(
+  sourceHash: string,
+  fingerprint: string,
+  output: CompileLessonResult,
+): CacheEntry {
+  return {
+    sourceHash,
+    fingerprint,
+    output,
+    compiledAt: new Date().toISOString(),
+  };
+}
+
+interface MigrationSeedInput {
+  lessonHash: string;
+  lessonSource: string;
+  output: CompileLessonResult;
+}
+
+interface MigrationResult {
+  seeded: number;
+  skipped: number;
+}
+
+/**
+ * One-shot seed migration: walk an existing compiled-rules.json + lesson
+ * sources, materialize the cache entries that would have been produced
+ * if the cache had existed from day one. After this step, the first
+ * post-migration compile run produces 100% cache hits and `compiled-
+ * rules.json` byte-for-byte matches its prior state.
+ *
+ * Idempotent — running twice with the same inputs writes the same entries
+ * a second time (overwrite). Per the impl contract § Migration sequence.
+ */
+export function migrateFromCompiledRules(
+  totemDir: string,
+  fingerprint: string,
+  inputs: MigrationSeedInput[],
+  onWarn?: (msg: string) => void,
+): MigrationResult {
+  if (process.env[DISABLE_ENV_VAR] === '1') {
+    return { seeded: 0, skipped: inputs.length };
+  }
+
+  let seeded = 0;
+  let skipped = 0;
+  for (const input of inputs) {
+    try {
+      const sourceHash = computeLessonSourceHash(input.lessonSource);
+      const entry = buildCacheEntry(sourceHash, fingerprint, input.output);
+      writeCacheEntry(totemDir, entry, onWarn);
+      seeded += 1;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      onWarn?.(`Compile cache seed skipped for ${input.lessonHash}: ${msg}`);
+      skipped += 1;
+    }
+  }
+  return { seeded, skipped };
+}
+
+/**
+ * List all cache-entry filenames currently on disk. Returns the file basenames
+ * (not full paths). Useful for `totem cache --prune-orphans` (out of scope for
+ * v1) and for test isolation cleanup.
+ */
+export function listCacheEntries(totemDir: string): string[] {
+  const dir = path.join(totemDir, CACHE_DIR);
+  if (!fs.existsSync(dir)) {
+    return [];
+  }
+  return fs.readdirSync(dir).filter((name) => name.endsWith('.json'));
+}

--- a/packages/core/src/compile-cache.ts
+++ b/packages/core/src/compile-cache.ts
@@ -98,7 +98,10 @@ export type CacheDecision =
  * identical hashes for identical inputs.
  */
 export function computeLessonSourceHash(lessonSource: string): string {
-  const normalized = lessonSource.replace(/\r\n/g, '\n');
+  // Normalization: collapse CRLF → LF + trim trailing whitespace per the impl
+  // contract. trimEnd() absorbs trailing-newline differences across IDEs /
+  // OSes (a save-with-final-newline vs. without should produce the same hash).
+  const normalized = lessonSource.replace(/\r\n/g, '\n').trimEnd();
   return crypto.createHash('sha256').update(normalized).digest('hex');
 }
 
@@ -151,8 +154,9 @@ export function lookupCacheEntry(
     const content = fs.readFileSync(filePath, 'utf-8');
     raw = JSON.parse(content);
     // totem-context: intentional cleanup — a bad cache entry must downgrade to a miss, never propagate; the cache is a side-channel optimization, not a load-bearing data path.
-  } catch {
+  } catch (err) {
     // totem-context: intentional cleanup — a bad cache entry must downgrade to a miss, never propagate; the cache is a side-channel optimization, not a load-bearing data path.
+    void err;
     return { entry: null, decision: 'cache_miss_no_prior_record' };
   }
 

--- a/packages/core/src/compile-cache.ts
+++ b/packages/core/src/compile-cache.ts
@@ -181,25 +181,32 @@ export function lookupCacheEntry(
  * the same `(sourceHash, fingerprint, output)` twice is a no-op-shaped
  * overwrite. Fire-and-forget: I/O failures are surfaced via `onWarn` and
  * never propagate (a failed cache write should not crash a compile).
+ *
+ * Returns `true` when the entry was successfully persisted, `false` on any
+ * I/O failure or when the cache is disabled via env var. Callers that need
+ * to track migration outcomes (e.g., `migrateFromCompiledRules`) inspect
+ * the return; callers that don't care can ignore it.
  */
 export function writeCacheEntry(
   totemDir: string,
   entry: CacheEntry,
   onWarn?: (msg: string) => void,
-): void {
+): boolean {
   if (process.env[DISABLE_ENV_VAR] === '1') {
-    return;
+    return false;
   }
 
   try {
     const filePath = cacheEntryPath(totemDir, entry.sourceHash);
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     fs.writeFileSync(filePath, JSON.stringify(entry, null, 2) + '\n', 'utf-8');
+    return true;
     // totem-context: intentional cleanup — cache writes are fire-and-forget; a failed write degrades to "no cache entry exists" on next lookup, never blocks compile.
   } catch (err) {
     // totem-context: intentional cleanup — cache writes are fire-and-forget; a failed write degrades to "no cache entry exists" on next lookup, never blocks compile.
     const msg = err instanceof Error ? err.message : String(err);
     onWarn?.(`Compile cache write failed: ${msg}`);
+    return false;
   }
 }
 
@@ -257,8 +264,15 @@ export function migrateFromCompiledRules(
     try {
       const sourceHash = computeLessonSourceHash(input.lessonSource);
       const entry = buildCacheEntry(sourceHash, fingerprint, input.output);
-      writeCacheEntry(totemDir, entry, onWarn);
-      seeded += 1;
+      // writeCacheEntry returns false on I/O failure or when the cache is
+      // disabled. Both count as "skipped" — seeded reflects entries actually
+      // persisted to disk, matching the operator's mental model of the
+      // post-migration cache hit rate.
+      if (writeCacheEntry(totemDir, entry, onWarn)) {
+        seeded += 1;
+      } else {
+        skipped += 1;
+      }
       // totem-context: intentional cleanup — migration is best-effort per-input; one bad lesson source must not abort seeding the rest. Failed inputs accumulate in `skipped` count and surface via onWarn for operator visibility.
     } catch (err) {
       // totem-context: intentional cleanup — migration is best-effort per-input; one bad lesson source must not abort seeding the rest. Failed inputs accumulate in `skipped` count and surface via onWarn for operator visibility.

--- a/packages/core/src/compile-cache.ts
+++ b/packages/core/src/compile-cache.ts
@@ -34,27 +34,63 @@ import type { CompileLessonResult } from './compile-lesson.js';
 
 // ─── Constants ──────────────────────────────────────
 
-const CACHE_DIR = path.join('.totem', 'cache', 'compile-lesson');
+// CACHE_DIR is resolved relative to `totemDir` (the already-configured
+// `.totem` location). Including `.totem` in this constant duplicated the
+// prefix and landed cache files at `<totemDir>/.totem/cache/...` instead of
+// `<totemDir>/cache/...`. Per CR R3 Major on `mmnto-ai/totem#1983`.
+const CACHE_DIR = path.join('cache', 'compile-lesson');
 const HASH_FILENAME_PREFIX_LENGTH = 16;
 const DISABLE_ENV_VAR = 'TOTEM_DISABLE_COMPILE_CACHE';
 
 // ─── Schema ─────────────────────────────────────────
 
 /**
- * Minimal validator for the `output` field. CompileLessonResult is a
- * discriminated union with no runtime Zod schema today; deeply validating
- * the variant payloads would couple this module to every change in
- * `compile-lesson.ts`. Instead, we check the discriminator value is one of
- * the known statuses; downstream consumers can rely on the type assertion.
- * Per the impl contract § "graceful — bad cache entry → recompile, not
- * crash" — corrupt outputs fail this gate and trigger a cache miss.
+ * Validator for the `output` field. CompileLessonResult is a discriminated
+ * union (status: 'compiled' | 'skipped' | 'failed' | 'noop'); each variant
+ * carries required fields that downstream consumers dereference unconditionally
+ * (e.g., the cache-hit path reads `result.rule` for compiled outputs and
+ * `result.hash` / `result.reasonCode` for skipped outputs). A minimal
+ * status-only schema would accept truncated cache files like
+ * `{ output: { status: 'compiled' } }` and break the file's own "bad cache
+ * entry → miss, not crash" contract on the next lookup.
+ *
+ * Per CR R3 Major on `mmnto-ai/totem#1983`: validate the required-per-variant
+ * shape so structurally incomplete payloads are rejected upfront. `rule` is
+ * `z.unknown()` to avoid coupling this module to the full `CompiledRule`
+ * shape (changes to that schema must not invalidate every cohort's cache);
+ * variant-required fields like `hash` and `reasonCode` are typed concretely
+ * since they're the dereferences that would crash.
  */
-const COMPILE_LESSON_STATUS = ['compiled', 'skipped', 'failed', 'noop'] as const;
-const CompileLessonResultMinimalSchema = z
-  .object({
-    status: z.enum(COMPILE_LESSON_STATUS),
-  })
-  .passthrough();
+const CompileLessonResultMinimalSchema = z.discriminatedUnion('status', [
+  z
+    .object({
+      status: z.literal('compiled'),
+      // `rule` MUST be a non-null object (the CompiledRule payload). z.unknown()
+      // would accept missing fields too, which defeats the contract — a payload
+      // like `{ status: 'compiled' }` would survive validation and crash the
+      // cache-hit path on `result.rule` dereference. `z.record(z.unknown())`
+      // requires an object without coupling to CompiledRule's exact shape.
+      rule: z.record(z.unknown()),
+    })
+    .passthrough(),
+  z
+    .object({
+      status: z.literal('skipped'),
+      hash: z.string(),
+      reasonCode: z.string(),
+    })
+    .passthrough(),
+  z
+    .object({
+      status: z.literal('failed'),
+    })
+    .passthrough(),
+  z
+    .object({
+      status: z.literal('noop'),
+    })
+    .passthrough(),
+]);
 
 /**
  * Cache entry for one lesson's compile output.

--- a/packages/core/src/compile-cache.ts
+++ b/packages/core/src/compile-cache.ts
@@ -42,6 +42,30 @@ const CACHE_DIR = path.join('cache', 'compile-lesson');
 const HASH_FILENAME_PREFIX_LENGTH = 16;
 const DISABLE_ENV_VAR = 'TOTEM_DISABLE_COMPILE_CACHE';
 
+/**
+ * Strict sha256-hex shape for `sourceHash`. Used to gate `cacheEntryPath`
+ * against path-traversal inputs (`/`, `..`, etc.) per CR R4 Major on
+ * `mmnto-ai/totem#1983`. Matches the digest computeLessonSourceHash emits.
+ */
+const SOURCE_HASH_RE = /^[a-f0-9]{64}$/;
+
+/**
+ * Best-effort wrapper around an optional warning callback. The cache module's
+ * non-throwing contract requires that a caller-supplied `onWarn` cannot
+ * propagate exceptions out of cache write/seed paths — even an `onWarn` that
+ * throws must not abort compile. Per CR R4 Major on `mmnto-ai/totem#1983`.
+ */
+function safeOnWarn(onWarn: ((msg: string) => void) | undefined, message: string): void {
+  if (onWarn === undefined) return;
+  try {
+    onWarn(message);
+    // totem-context: intentional cleanup — onWarn must never propagate exceptions per the cache's non-throwing contract; swallow any caller-thrown errors silently.
+  } catch (err) {
+    // totem-context: intentional cleanup — onWarn must never propagate exceptions per the cache's non-throwing contract; swallow any caller-thrown errors silently.
+    void err;
+  }
+}
+
 // ─── Schema ─────────────────────────────────────────
 
 /**
@@ -164,6 +188,17 @@ export function composeLessonSourceForHash(heading: string, body: string): strin
  * does not check existence. Callers handle missing files.
  */
 export function cacheEntryPath(totemDir: string, sourceHash: string): string {
+  // Reject non-SHA inputs at the boundary (CR R4 Major on `mmnto-ai/totem#1983`).
+  // Without this, a sourceHash carrying `/` or `..` would flow through
+  // path.join() and escape `<totemDir>/cache/compile-lesson`, letting lookup or
+  // write touch arbitrary files. computeLessonSourceHash always emits the
+  // matching 64-char hex shape; this catches misuse where a caller hands us
+  // unvalidated input.
+  if (!SOURCE_HASH_RE.test(sourceHash)) {
+    throw new Error(
+      `[Totem Error] Invalid sourceHash: expected 64-char sha256 hex digest, got ${JSON.stringify(sourceHash.slice(0, 80))}`,
+    );
+  }
   const filename = `${sourceHash.slice(0, HASH_FILENAME_PREFIX_LENGTH)}.json`;
   return path.join(totemDir, CACHE_DIR, filename);
 }
@@ -263,7 +298,7 @@ export function writeCacheEntry(
   } catch (err) {
     // totem-context: intentional cleanup — cache writes are fire-and-forget; a failed write degrades to "no cache entry exists" on next lookup, never blocks compile.
     const msg = err instanceof Error ? err.message : String(err);
-    onWarn?.(`Compile cache write failed: ${msg}`);
+    safeOnWarn(onWarn, `Compile cache write failed: ${msg}`);
     return false;
   }
 }
@@ -351,11 +386,11 @@ export function migrateFromCompiledRules(
       } else {
         skipped += 1;
       }
-      // totem-context: intentional cleanup — migration is best-effort per-input; one bad lesson source must not abort seeding the rest. Failed inputs accumulate in `skipped` count and surface via onWarn for operator visibility.
+      // totem-context: intentional cleanup — migration is best-effort per-input; one bad lesson source must not abort seeding the rest. Failed inputs accumulate in `skipped` count and surface via safeOnWarn for operator visibility.
     } catch (err) {
-      // totem-context: intentional cleanup — migration is best-effort per-input; one bad lesson source must not abort seeding the rest. Failed inputs accumulate in `skipped` count and surface via onWarn for operator visibility.
+      // totem-context: intentional cleanup — migration is best-effort per-input; one bad lesson source must not abort seeding the rest. Failed inputs accumulate in `skipped` count and surface via safeOnWarn for operator visibility.
       const msg = err instanceof Error ? err.message : String(err);
-      onWarn?.(`Compile cache seed skipped for ${input.lessonHash}: ${msg}`);
+      safeOnWarn(onWarn, `Compile cache seed skipped for ${input.lessonHash}: ${msg}`);
       skipped += 1;
     }
   }

--- a/packages/core/src/compile-cache.ts
+++ b/packages/core/src/compile-cache.ts
@@ -150,10 +150,9 @@ export function lookupCacheEntry(
   try {
     const content = fs.readFileSync(filePath, 'utf-8');
     raw = JSON.parse(content);
+    // totem-context: intentional cleanup — a bad cache entry must downgrade to a miss, never propagate; the cache is a side-channel optimization, not a load-bearing data path.
   } catch {
-    // totem-context: intentional cleanup — bad cache entry is treated as a
-    // miss, never propagated upward. Graceful per the impl contract §
-    // "Reject and treat as cache miss on schema mismatch".
+    // totem-context: intentional cleanup — a bad cache entry must downgrade to a miss, never propagate; the cache is a side-channel optimization, not a load-bearing data path.
     return { entry: null, decision: 'cache_miss_no_prior_record' };
   }
 
@@ -196,7 +195,9 @@ export function writeCacheEntry(
     const filePath = cacheEntryPath(totemDir, entry.sourceHash);
     fs.mkdirSync(path.dirname(filePath), { recursive: true });
     fs.writeFileSync(filePath, JSON.stringify(entry, null, 2) + '\n', 'utf-8');
+    // totem-context: intentional cleanup — cache writes are fire-and-forget; a failed write degrades to "no cache entry exists" on next lookup, never blocks compile.
   } catch (err) {
+    // totem-context: intentional cleanup — cache writes are fire-and-forget; a failed write degrades to "no cache entry exists" on next lookup, never blocks compile.
     const msg = err instanceof Error ? err.message : String(err);
     onWarn?.(`Compile cache write failed: ${msg}`);
   }
@@ -258,7 +259,9 @@ export function migrateFromCompiledRules(
       const entry = buildCacheEntry(sourceHash, fingerprint, input.output);
       writeCacheEntry(totemDir, entry, onWarn);
       seeded += 1;
+      // totem-context: intentional cleanup — migration is best-effort per-input; one bad lesson source must not abort seeding the rest. Failed inputs accumulate in `skipped` count and surface via onWarn for operator visibility.
     } catch (err) {
+      // totem-context: intentional cleanup — migration is best-effort per-input; one bad lesson source must not abort seeding the rest. Failed inputs accumulate in `skipped` count and surface via onWarn for operator visibility.
       const msg = err instanceof Error ? err.message : String(err);
       onWarn?.(`Compile cache seed skipped for ${input.lessonHash}: ${msg}`);
       skipped += 1;

--- a/packages/core/src/compile-cache.ts
+++ b/packages/core/src/compile-cache.ts
@@ -98,11 +98,29 @@ export type CacheDecision =
  * identical hashes for identical inputs.
  */
 export function computeLessonSourceHash(lessonSource: string): string {
-  // Normalization: collapse CRLF → LF + trim trailing whitespace per the impl
-  // contract. trimEnd() absorbs trailing-newline differences across IDEs /
-  // OSes (a save-with-final-newline vs. without should produce the same hash).
-  const normalized = lessonSource.replace(/\r\n/g, '\n').trimEnd();
+  // Normalization: collapse CRLF → LF ONLY. No trailing-whitespace trim — the
+  // canonical `generateInputHash` (`compile-manifest.ts`) and `lessonHash` (per
+  // `.gemini/styleguide.md` line 142) are both trailing-whitespace-sensitive.
+  // Trimming here would desynchronize the cache key from the canonical hashes:
+  // a whitespace-only edit would hit the cache (return stale lessonHash output)
+  // while the manifest pipeline would compute a fresh lessonHash for the same
+  // edit, breaking the deterministic link between lessons and rules.
+  // Reverses an over-correction from R1; per GCA R2 critical on `#1983`.
+  const normalized = lessonSource.replace(/\r\n/g, '\n');
   return crypto.createHash('sha256').update(normalized).digest('hex');
+}
+
+/**
+ * Compose the hashable lesson source from a parsed lesson's heading and body.
+ * Use this from any call site that has a parsed `LessonInput`-shaped object to
+ * ensure runtime and migration paths produce identical hashes for the same
+ * lesson. Without a shared composition helper, the runtime hash (computed from
+ * `lesson.heading` + `lesson.body`) and a migration hash (computed from raw
+ * file content with `## Lesson — ` framing) would diverge — exactly the bug
+ * GCA R2 surfaced on `#1983`.
+ */
+export function composeLessonSourceForHash(heading: string, body: string): string {
+  return `${heading}\n${body}`;
 }
 
 /**
@@ -232,8 +250,22 @@ export function buildCacheEntry(
 }
 
 interface MigrationSeedInput {
+  /** Canonical lesson hash (rotation-prone). Carried for diagnostics only. */
   lessonHash: string;
-  lessonSource: string;
+  /**
+   * Parsed lesson heading — the `## Lesson — …` heading-text minus the
+   * leading `##` markdown. MUST match what `readAllLessons` (or equivalent
+   * parser) provides at runtime to the compile path. Composed with `body`
+   * via `composeLessonSourceForHash` to produce the same sourceHash the
+   * runtime cache lookup will compute.
+   */
+  heading: string;
+  /**
+   * Parsed lesson body — the content between the heading and the next
+   * lesson heading. MUST match what `readAllLessons` provides at runtime.
+   */
+  body: string;
+  /** The compile output to seed into the cache. */
   output: CompileLessonResult;
 }
 
@@ -251,6 +283,11 @@ interface MigrationResult {
  *
  * Idempotent — running twice with the same inputs writes the same entries
  * a second time (overwrite). Per the impl contract § Migration sequence.
+ *
+ * Heading + body are taken separately (rather than a single raw-source
+ * string) to enforce the canonical `composeLessonSourceForHash` call shape.
+ * If migration accepted a free-form `lessonSource` string, the migration
+ * and runtime hash paths could diverge (per GCA R2 critical on `#1983`).
  */
 export function migrateFromCompiledRules(
   totemDir: string,
@@ -266,7 +303,8 @@ export function migrateFromCompiledRules(
   let skipped = 0;
   for (const input of inputs) {
     try {
-      const sourceHash = computeLessonSourceHash(input.lessonSource);
+      const sourceForHash = composeLessonSourceForHash(input.heading, input.body);
+      const sourceHash = computeLessonSourceHash(sourceForHash);
       const entry = buildCacheEntry(sourceHash, fingerprint, input.output);
       // writeCacheEntry returns false on I/O failure or when the cache is
       // disabled. Both count as "skipped" — seeded reflects entries actually

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -444,6 +444,19 @@ export {
   readPromptTemplateContentHash,
 } from './compile-worker-fingerprint.js';
 
+// Compile cache (Proposal 281 — Per-Lesson Hash Stability)
+export type { CacheDecision, CacheEntry } from './compile-cache.js';
+export {
+  buildCacheEntry,
+  cacheEntryPath,
+  CacheEntrySchema,
+  computeLessonSourceHash,
+  listCacheEntries,
+  lookupCacheEntry,
+  migrateFromCompiledRules,
+  writeCacheEntry,
+} from './compile-cache.js';
+
 // Global registry (multi-totem workspace discovery)
 export type { RegistryEntry, TotemRegistry } from './registry.js';
 export { readRegistry, updateRegistryEntry } from './registry.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -450,6 +450,7 @@ export {
   buildCacheEntry,
   cacheEntryPath,
   CacheEntrySchema,
+  composeLessonSourceForHash,
   computeLessonSourceHash,
   listCacheEntries,
   lookupCacheEntry,

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -28,6 +28,11 @@ export const LedgerEventSchema = z.object({
    *  - `claim_discipline_finding`    — `totem doctor --claim-discipline` fired on a public-surface diff
    *                                    (README/AGENTS/design-tenets/wiki); see `ruleId` for which WWND
    *                                    rule fired and `activity_name` for the surface (Proposal 279).
+   *  - `compile_cache_decision`      — per-lesson per-compile-run record of cache outcome; `ruleId`
+   *                                    carries the lesson sourceHash and `activity_name` carries the
+   *                                    decision enum value (`cache_hit` / `cache_miss_source_changed` /
+   *                                    `cache_miss_fingerprint_changed` / `cache_miss_force` /
+   *                                    `cache_miss_no_prior_record`) per Proposal 281.
    *
    *  Schema-level: `ruleId` + `file` are optional to accommodate activity events. Writer-side
    *  discipline enforces required-by-type. Promotion to `z.discriminatedUnion` deferred to A.3.c
@@ -43,6 +48,7 @@ export const LedgerEventSchema = z.object({
     'session_start',
     'compile_run',
     'claim_discipline_finding',
+    'compile_cache_decision',
   ]),
   /** Rule ID (lessonHash) for override events. Optional; required by writer for suppress/override/exemption. */
   ruleId: z.string().trim().min(1).optional(),


### PR DESCRIPTION
# P281 Impl Contract Draft — Per-Lesson Hash Stability (Incremental Compile-Worker Cache)

**Author:** totem-claude (claude-0064)
**Date:** 2026-05-21
**Status:** Finalized for PR-open. Cross-stream reviewed by strategy-claude (`2026-05-21T0257Z` + `2026-05-21T0542Z`); 5 OQs dispositioned (no rejects); structural archive-addition retracted under subtraction discipline.
**Authorizes:** impl PR against `mmnto-ai/totem` implementing the P281 incremental compile-worker cache.
**Supersedes:** the prose framing of P281 § Implementation-contract details deferred (now resolved here).

> **Convention:** Per Option-1 disposition this session, P281 ships **without a separate ADR document**. The strategic doctrine is in `mmnto-ai/totem-strategy:proposals/accepted/281-per-lesson-hash-stability.md` (Accepted 2026-05-20). This document is the impl-side contract — it becomes the PR body when the impl lands. Matches the P278 → `mmnto-ai/totem#1939` precedent.

## Summary

Ships the implementation of `mmnto-ai/totem-strategy:proposals/accepted/281-per-lesson-hash-stability.md` (P281 Option C, Accepted 2026-05-20). A per-lesson cache keyed by `(lesson_source_hash, compile_worker_fingerprint)` short-circuits `totem lesson compile` for lessons whose source content is unchanged. Result: a +1 lesson PR produces a `compiled-rules.json` diff with 1 new row, not 4931 lines.

Cohort effect: resolves the productivity tax at source. Bot review surface becomes meaningful. `## Compile Drift Justification` headings become rare (reserved for `--force` / fingerprint-rotation events). Closes the falsifying-metric loop named in P281 § Falsifying Metric.

Sequencing note: 281-first per the 2026-05-19 re-grounded shape (H1 ruled out per `compile-templates.ts` recon; H2 dominant; P281 absorbs P280's primary failure class at source). P280 ships next as defense-in-depth for the rotation events the cache cannot suppress.

## Implementation surfaces

Three files in `packages/core/src/` + one wiring point in `packages/cli/src/commands/compile.ts`. Existing modules unchanged in shape; cache module is additive.

| File | Change | Lines (est.) |
|---|---|---|
| `packages/core/src/compile-cache.ts` (NEW) | Cache module: `CacheEntry` schema (Zod), `computeLessonSourceHash()`, `lookupCacheEntry()`, `writeCacheEntry()`, `migrateFromCompiledRules()`. | ~250 |
| `packages/core/src/compile-cache.test.ts` (NEW) | Partial-mutation invariant test; byte-for-byte preservation on cache hit; migration test; `--force` override test; fingerprint-bump invalidation test. | ~400 |
| `packages/cli/src/commands/compile.ts` (MODIFY at line 1624) | Wrap `compileLessonCore(lesson, ...)` call with cache lookup. Cache hit → return cached `CompileLessonResult` verbatim. Cache miss → invoke core compile + write cache entry. | ~40 |
| `packages/core/src/compile-lesson.ts` | **No change** to pipeline-orchestration logic. The cache wraps `compileLessonCore`; its internals stay untouched. Preserves `compile-noop-refresh.test.ts` + `compile-refresh-manifest.test.ts` byte-for-byte invariants. | 0 |

The cache module locus follows totem-Claude's 2026-05-17T0220Z impl-lane signal in `proposals/accepted/281-per-lesson-hash-stability.md` § Cross-stream sign-off state, point (1).

## Cache schema (with stableId reservation)

Per the P281 § Dependencies "Load-bearing forward-compat schema constraint" (and `mmnto-ai/totem-strategy#387` PR body section 3, merged 2026-05-20 at `8b1e3a5d`):

```typescript
// packages/core/src/compile-cache.ts

import { z } from 'zod';

import { CompileLessonResultSchema } from './compile-lesson.js';

/**
 * Cache entry for one lesson's compile output.
 *
 * `stableId` is reserved for P280 (Wind-Tunnel Decoupling, Accepted
 * 2026-05-20). P281 does not populate or query it. Reserving the slot
 * from day one avoids a full cache re-key event when P280 lands; with
 * the reservation, P280's integration is one new test, not a refactor.
 * Per mmnto-ai/totem-strategy#387 § Dependencies (load-bearing).
 */
export const CacheEntrySchema = z.object({
  sourceHash: z.string(),               // sha256 of lesson source content (normalized)
  stableId: z.string().optional(),      // reserved for P280; P281 ignores
  fingerprint: z.string(),              // compile_worker_fingerprint from P278
  output: CompileLessonResultSchema,    // verbatim CompileLessonResult
  compiledAt: z.string(),               // ISO 8601 timestamp of cached compile
});

export type CacheEntry = z.infer<typeof CacheEntrySchema>;
```

**Critical:** `stableId?: string` slot is in the FIRST commit. Retrofitting later eats the operational friction the constraint exists to prevent. CI-side schema test asserts the field is present and Optional.

## Cache key composition — layered

Per totem-Claude's 2026-05-17T0220Z signal, point (3) — **layered, not composite-hash**. Reasons:

1. A single composite hash conflates source-change vs. fingerprint-change invalidation classes. The `decision` enum in the telemetry event needs to distinguish them.
2. When P280 ships, its `stableId` extends the layered key as a non-breaking composite extension (look up by `stableId` first, fall back to `sourceHash`).
3. Layered key composition makes the `attribution` field (`h1_evidence` / `h2_evidence` / both / neither) populatable correctly at emission time.

**Key layers (in lookup order):**

1. `stableId` (when present in entry — for P280 forward-compat reads; P281 never writes this)
2. `sourceHash` — `sha256(normalize(lesson_source_content))`, where `normalize` collapses `\r\n` → `\n` ONLY. **No trailing-whitespace trim.** Same shape as `generateInputHash()` at `packages/core/src/compile-manifest.ts:60-80`, which is the canonical lessonHash-equivalent. Trimming here would desynchronize the cache key from the canonical hash: a whitespace-only edit would hit the cache and return a rule with a stale `lessonHash` while the manifest pipeline would compute a fresh `lessonHash` for the same edit. Per GCA R2 critical on `#1983` (which reversed an earlier R1 finding of "trim missing" — R1 cited an over-claim in this contract prose itself).

   **Composition (runtime + migration must use the same shape):** the `lesson_source_content` input is computed by `composeLessonSourceForHash(heading, body)` → `\`${heading}\n${body}\``. The runtime path (CLI compile loop) and the migration path (`migrateFromCompiledRules`) both route through this helper. Without the shared helper, the two paths would diverge — exactly the bug GCA R2 surfaced on `#1983` (migration hashed raw lessonSource including `## Lesson — ` framing; runtime hashed `${heading}\n${body}`; same lesson produced two different hashes; migration entries were permanently unreachable).
3. `fingerprint` — `compile_worker_fingerprint` from P278 (`packages/core/src/compile-worker-fingerprint.ts`)

**Lookup contract:**

```typescript
// Pseudocode
function lookupCacheEntry(
  lessonSource: string,
  fingerprint: string,
): CacheEntry | null {
  const sourceHash = computeLessonSourceHash(lessonSource);
  const entry = readCacheEntryByHash(sourceHash);
  if (!entry) return null;
  if (entry.fingerprint !== fingerprint) return null;  // fingerprint rotation invalidates
  return entry;
}
```

**Forbidden in cache key (per totem-Claude 2026-05-17T0220Z signal, point (6)):** `cli_version`. Including it would invalidate every cohort bump — exactly what this proposal prevents.

## Cache file format and storage path

**Path:** `.totem/cache/compile-lesson/<sourceHash-first-16-chars>.json`

**Rationale:**
- Co-located with other `.totem/` substrate; gitignored by default (cache is reproducible from source — verified at `.gitignore:5`).
- One file per cache entry. Reading hot entries doesn't pay for unrelated entries' bytes.
- ADR-083 (content-hash lock) precedent: per-hash file shape.

**Fan-out:** flat directory for v1. Current cohort scale is ~130 lessons; flat performs fine. **Follow-on ticket to be filed post-PR-open** with soft trigger 1000 lessons: when corpus grows past that, shard into prefix-keyed subdirectories (first 2 chars of hash → 256-way fan-out). Per strategy-claude's 0257Z disposition: "anticipated-future-work tickets get filed at insight time, not at trigger time" — filing now prevents lost-context cost when a future agent hits the threshold.

**Format:** JSON, schema-validated on read against `CacheEntrySchema`. Reject and treat as cache miss on schema mismatch (graceful — bad cache entry → recompile, not crash).

**Migration:** see § Migration sequence.

## Cache invalidation triggers

Three triggers covering the cases (per P281 § Scope, "In scope — proposal level", point 3):

| Trigger | Mechanism | Telemetry decision |
|---|---|---|
| Lesson source content change | `sourceHash` mismatch on lookup | `cache_miss_source_changed` |
| `compile_worker_fingerprint` change | `fingerprint` mismatch on lookup (lookup returns null) | `cache_miss_fingerprint_changed` |
| Explicit `--force` flag | CLI bypass: skip `lookupCacheEntry()` for the lesson(s) named | `cache_miss_force` |

**Out-of-scope for v1 (cross-lesson dependencies):** if cross-lesson deps surface empirically (cache produces wrong output for lesson N when lesson M changed), extend `CacheEntry` with `dependsOnHashes: string[]`. Phase 2; not in first impl.

**`--force` scope (per strategy-Gemini 0130Z calibration in P281 § Consequences):**

- `--force <lesson-id>` (default for ad-hoc): invalidate one lesson; surgical.
- `--force-all`: invalidate corpus-wide; reserved for compile-worker version bumps / ast-grep upgrades / large refactors. Requires `## Compile Cache Reset Justification` heading.

**Two distinct justification headings — different triggers, same shape:**

| Heading | Source | Triggered by |
|---|---|---|
| `## Compile Drift Justification` | `mmnto-ai/totem#1939` (P278 Phase 1, verify-manifest gate) | `compile_worker_fingerprint` rotation (model/template change produced new output despite same inputs) |
| `## Compile Cache Reset Justification` | This PR (P281 cache `--force-all`) | Explicit operator-side cache invalidation (`--force-all`) — bypasses cache, recompiles everything |

Both ride the existing `TOTEM_DRIFT_JUSTIFICATION` PR-body-scan discipline. Distinct headings keep the audit trail interpretable: a fingerprint-rotation event is structurally different from an operator-side cache flush, even though both produce a full corpus recompile.

## Migration sequence

**Step 1 (one-shot, on first run after impl ships):**

Existing `.totem/compiled-rules.json` is the seed. For each `lessonHash` in the manifest:
- Read the corresponding lesson file from `.totem/lessons/`
- Compute `sourceHash` from the file content (normalize line endings)
- Read the current `compile_worker_fingerprint` from `.totem/.totem-manifest.json`
- Write a `CacheEntry` at `.totem/cache/compile-lesson/<sourceHash-first-16-chars>.json` carrying the existing compile output

Cache hit rate after migration step: 100% (every lesson hashes the same input that produced the existing output).

**Step 2 (subsequent runs):** normal cache flow.

**No automatic eviction in v1.** Append-only substrate matches the codebase as ground truth (Tenet 17). Stale cache entries (lessons removed from `.totem/lessons/`) cost O(MB) disk. Eviction policy can land in a follow-on PR if disk pressure surfaces.

`totem cache --prune-orphans` (manual operator command) covers the "I want to clean this up" case. Out of scope for first impl; trivial follow-on.

## Telemetry — `compile_cache_decision` event

Per P281 § Telemetry. Emitted to the Trap Ledger (`events.ndjson`, A.3.a writers, `mmnto-ai/totem#1922`) per lesson per compile run.

```typescript
interface CompileCacheDecisionEvent {
  lesson_id: string;            // sourceHash (until P280's stable_id ships; then stable_id)
  decision: 'cache_hit' | 'cache_miss_source_changed' | 'cache_miss_fingerprint_changed' |
            'cache_miss_force' | 'cache_miss_no_prior_record';
  attribution: 'h1_evidence' | 'h2_evidence' | 'both' | 'neither';
  compile_worker_fingerprint: string;
  cli_version: string;          // observability only; NOT in cache key
}
```

`attribution` populated on every event (defense-in-depth for the H1-absence ruling, per P281 § Telemetry "Why `attribution` is named at proposal stage"). Initial impl emits `attribution: 'neither'` for `cache_hit` events; H1/H2 evidence categorization is a Phase 2 telemetry pass.

## Non-functional requirement (load-bearing)

**Compile-worker MUST NOT read sibling lessons.**

Per totem-Claude 2026-05-17T0220Z signal, point (6) — pin this as a non-functional requirement on the prompt template. Currently true: `packages/cli/src/commands/compile-templates.ts` has zero cross-lesson references. The requirement guards against future drift (new RAG path, new few-shot source, future template refactor) that would silently invalidate the H1-absence ruling and re-enable the rotation class.

**Enforcement (light):**
- Test asserts `compile-templates.ts` contains zero `for ... lesson` / `forEach(lesson` / `lessons.map` patterns **outside template literals**. The grep is scoped via a regex that strips backtick-delimited template strings before checking — strategy-claude's verification (`grep -E "for.*lesson|lessons\\.(map|forEach|filter)|\\.lessons\\["` against current `compile-templates.ts` returned only natural-language matches inside template-literal prompt prose). False positives on prose mentions of "lessons" would fail an unscoped grep.
- CI gate filed as a separate follow-on: a structural lint that walks the prompt template's AST and rejects multi-lesson references in code (not prose). Not blocking on this PR.

## Test strategy

| Test | Asserts |
|---|---|
| `cache_hit_byte_for_byte_preservation` | Cache hit produces a `CompileLessonResult` byte-identical to the cached output. No path through `compileLessonCore`. |
| `partial_mutation_invariant` | Corpus with 130 lessons; modify 1 lesson; verify only 1 `compiled-rules.json` row changes, the other 129 preserve their prior `lessonHash` exactly. This is the falsifying-metric test. |
| `fingerprint_change_invalidates_all` | Bump `compile_worker_fingerprint`; verify every lesson recompiles (`cache_miss_fingerprint_changed` for all). |
| `source_change_invalidates_one` | Modify 1 lesson's source; verify only that lesson recompiles. |
| `force_per_lesson` | `totem lesson compile --force <id>`; verify only that lesson bypasses cache. |
| `migration_seed_from_compiled_rules` | Start with no cache + existing `compiled-rules.json`; first run produces 100% cache hit on subsequent runs. |
| `stable_id_slot_reserved` | Cache entry schema accepts `stableId?: string`; field is Optional; absent field does not invalidate lookup. |
| `cli_version_not_in_key` | Bump `cli_version`; verify cache stays valid (no spurious invalidation). |
| `bad_cache_entry_graceful` | Inject a schema-invalid entry; verify lookup returns null (cache miss), no crash. |
| `compile_worker_no_sibling_reads` (light) | Heuristic check on `compile-templates.ts` content. |

Existing tests preserved unchanged:
- `compile-noop-refresh.test.ts` — `--refresh-manifest` byte-for-byte invariant
- `compile-refresh-manifest.test.ts` — manifest refresh semantics
- `compile-lesson.test.ts` — pipeline-orchestration behavior

## Performance expectations

| Scenario | Expected behavior |
|---|---|
| Steady-state PR (1 lesson changed in 130-lesson corpus) | ≥99% cache hit. 1 compile-worker call. `compiled-rules.json` diff ~5-20 lines. |
| New install (no cache, existing `compiled-rules.json`) | Migration seeds cache. Next run: 100% cache hit. |
| `compile_worker_fingerprint` bump (e.g., model upgrade) | 100% cache miss. Full recompile. Telemetry: 130x `cache_miss_fingerprint_changed`. |
| `--force-all` | Same as fingerprint bump; explicit operator intent. |
| Cache disabled (`TOTEM_DISABLE_COMPILE_CACHE=1`, env override for emergencies) | Behavior reverts to pre-#NNNN status quo. Emergency escape only — not a long-term flag. **Deprecation-watch ticket to be filed post-PR-open** so the flag has a documented end-of-life if cache stability holds across N=20 PR window. |

## Falsifying metric implementation

Per P281 § Falsifying Metric — ≥99% of compile runs touching K lessons (by source change) produce `compiled-rules.json` row changes for exactly K lessons.

The `compile_cache_decision` telemetry events drive measurement. `totem doctor --compliance` (per P281 § Telemetry, "composes with") aggregates across the first N=20 lesson-mutating PRs post-thaw. Threshold check is mechanical: across N=20 PRs, count (compile runs where actual changed rows == expected changed rows from source diff) / 20. Falsified if < 19/20 (95% lower bound on the 99% claim).

Window: event-count-bounded (N=20 PRs), not time-bounded. Same calibration as P280.

## Cross-references

- `mmnto-ai/totem-strategy:proposals/accepted/281-per-lesson-hash-stability.md` (canonical doctrine; Accepted 2026-05-20)
- `mmnto-ai/totem-strategy:proposals/accepted/280-wind-tunnel-decoupling.md` (sibling axis; ships next as defense-in-depth)
- `mmnto-ai/totem-strategy:proposals/accepted/278-compile-worker-determinism-interim-policy.md` (fingerprint mechanism; cache invalidation key)
- `mmnto-ai/totem-strategy#387` (P280+P281 Accepted PR, merged `8b1e3a5d`; load-bearing `stableId` reservation specified)
- `mmnto-ai/totem-strategy#388` (ADR-108 — P284 Phase 4 synthesis, impl-lane unblock signal)
- `mmnto-ai/totem-strategy:adr/adr-083-actor-aware-enforcement-content-hash.md` (content-hash cache precedent)
- `mmnto-ai/totem-strategy:adr/adr-103-deterministic-rule-compilation.md` (Convergent Spine; this work restores its end-to-end value-proof loop)
- `mmnto-ai/totem#1939` (verify-manifest drift gate, P278 Phase 1; precedent for impl-PR-body-as-contract; sibling drift-justification mechanism)
- `mmnto-ai/totem#1981` (post-merge re-index gate fix — adjacent value-proof loop concern; filed this session)
- `mmnto-ai/totem-strategy#284` (P284 parent, agent state continuity)

## Sequencing & next steps

1. ✅ This contract drafted (claude-0064, 2026-05-21).
2. ✅ Strategy-claude cross-stream review (`2026-05-21T0257Z-totem-claude.md`) — all 5 OQs dispositioned (no rejects).
3. ✅ Three-decision close (`2026-05-21T0542Z-totem-claude.md`) — scope narrowed to P281 PR-open; P280 contract revision deferred until P280 sequences.
4. ⏳ Open P281 impl PR Ready (not Draft) with this document as the PR body.
5. ⏳ Bot review walk (CR + GCA) — consolidated round comments per `feedback_bot_protocols_centralized` § 8.1.
6. ⏳ Merge. First end-to-end clean recompile (**first freeze-lift gate** per ADR-108 framing).
7. ⏳ Post-PR-open tail work (non-gating): file follow-on tickets (fan-out cutover; `TOTEM_DISABLE_COMPILE_CACHE` deprecation watch); update `mmnto-ai/totem#1981` with sharper diagnosis comment.
8. ⏳ P280 contract revision when P280 enters its lane (audit-freshness-rebase per strategy-claude 0542Z Decision 3).
9. ⏳ P280 impl PR. Second end-to-end clean recompile (**second freeze-lift gate**). Both gates close → `project_rule_compilation_freeze_2026_05_17` lifts → Convergent Spine unfreezes.

— totem-claude (2026-05-21)
