### PR TITLE
fix(ci): release workflow — expose NPM_TOKEN so changesets-action stops falling back to OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,12 @@ jobs:
           createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          # changesets-action reads NPM_TOKEN (not NODE_AUTH_TOKEN). When this
+          # env var is unset, the action falls back to OIDC trusted publishing.
+          # OIDC silently 404'd on @mmnto/pack-rust-architecture@1.45.0 (run
+          # 26214453900, attempts 1+2), so expose NPM_TOKEN as the primary
+          # auth path. NODE_AUTH_TOKEN stays for setup-node's .npmrc auth line.
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Push release tags


### PR DESCRIPTION
## Recovery for `mmnto-ai/totem#1984` publish failure

The Version Packages PR for cohort 1.45.0 (P281 ship) merged cleanly to git but the Release workflow failed to publish. Run `26214453900` failed both initial run and re-run with:

```
🦋 error '@mmnto/pack-rust-architecture@1.45.0' is not in this registry.
🦋 error 404 PUT https://registry.npmjs.org/@mmnto/pack-rust-architecture
```

Diagnosis confirms npm registry has `@mmnto/pack-rust-architecture@1.44.0` but rejected the publish of `@mmnto/pack-rust-architecture@1.45.0` with a 404 on PUT — characteristic of an OIDC trusted-publisher rejection.

## Root cause

The workflow env block exposed only `NODE_AUTH_TOKEN` (setup-node's `.npmrc` auth-line target). `changesets-action` reads `NPM_TOKEN` (not `NODE_AUTH_TOKEN`) and, when `NPM_TOKEN` is absent, falls back to OIDC trusted publishing. Confirmed in the failed run's log:

```
No NPM_TOKEN found, but OIDC is available - using npm trusted publishing
```

OIDC trusted-publisher config for `@mmnto/pack-rust-architecture` is either misconfigured or missing on the npm side at 1.45.0. (1.44.0 published successfully via OIDC, so something changed npm-side between releases — the workflow code path didn't change.)

## Fix

Add `NPM_TOKEN: ${{ secrets.NPM_TOKEN }}` alongside `NODE_AUTH_TOKEN`. When `secrets.NPM_TOKEN` exists, `changesets-action` uses it directly instead of falling through to OIDC. `NODE_AUTH_TOKEN` stays for `setup-node`'s `.npmrc` generation. If `secrets.NPM_TOKEN` is unset, behavior is unchanged (still falls back to OIDC; npm-side config still needs the fix).

## Caveat — this may not be the complete fix

This PR is Path 1 of a two-path recovery analysis:

| Path | What it does | Who can do it |
|---|---|---|
| **1. This PR** | Expose `NPM_TOKEN` env var so changesets uses it instead of OIDC | Repo-side ✓ |
| **2. NPM admin** | Re-configure OIDC trusted-publisher for `@mmnto/pack-rust-architecture` at npmjs.com → package settings → Trusted Publisher | User-side (npm package admin) |

**Path 1 only helps if `secrets.NPM_TOKEN` is set in the repo's GitHub Actions secrets AND valid.** If the secret is unset (or expired/rotated), the release will still fail with the same 404 because changesets will still fall through to OIDC.

If after merging this PR the next Release workflow run still 404s on `pack-rust-architecture@1.45.0`, that confirms Path 2 is needed (npm-side admin work).

## Validation plan

- Lint PASS, 0 violations (one-line YAML edit)
- Pre-push review fast-path skipped (non-code change)
- Empirical validation comes when this merges: the Release workflow will trigger on `main`, and if `NPM_TOKEN` is set in repo secrets, `pack-rust-architecture@1.45.0` should publish

## Test plan

- [ ] Merge this PR
- [ ] Watch the Release workflow run on `main`
- [ ] If `pack-rust-architecture@1.45.0` publishes cleanly → root cause confirmed, recovery complete
- [ ] If still 404s → escalate to Path 2 (npm OIDC config)

Closes (partial): recovery from the `#1984` release failure surfaced by the post-merge Release workflow exit code 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)