### PR TITLE
fix(ci): publish via OIDC trusted publishing (revive #1182, drop NPM_TOKEN)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,9 @@ jobs:
         with:
           node-version: 22
           cache: pnpm
-          registry-url: https://registry.npmjs.org
+          # No registry-url: it writes an .npmrc with
+          # _authToken=${NODE_AUTH_TOKEN}, which blocks npm's OIDC
+          # trusted-publishing negotiation. See #1180 + #1182 history.
 
       - run: pnpm install --frozen-lockfile
 
@@ -32,25 +34,28 @@ jobs:
       - name: Allow tag overwrites for republish resilience
         run: git config --global push.followTags false
 
-      - name: Create Release PR or Publish
+      - name: Create Release PR (version-only)
         id: changesets
         uses: changesets/action@v1
         with:
           version: pnpm run version
-          publish: pnpm run release
-          createGithubReleases: true
+          # No `publish` parameter: `changeset publish` does not propagate
+          # OIDC tokens correctly to pnpm child processes
+          # (changesets/action#515). Publishing happens in the next step
+          # via tools/publish-oidc.mjs, which uses npm CLI directly.
+          createGithubReleases: false
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
-          # changesets-action reads NPM_TOKEN (not NODE_AUTH_TOKEN). When this
-          # env var is unset, the action falls back to OIDC trusted publishing.
-          # OIDC silently 404'd on @mmnto/pack-rust-architecture@1.45.0 (run
-          # 26214453900, attempts 1+2), so expose NPM_TOKEN as the primary
-          # auth path. NODE_AUTH_TOKEN stays for setup-node's .npmrc auth line.
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish unpublished packages via OIDC
+        if: steps.changesets.outputs.hasChangesets == 'false'
+        id: publish
+        run: node tools/publish-oidc.mjs
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Push release tags
-        if: steps.changesets.outputs.published == 'true'
+        if: steps.publish.outputs.published == 'true'
         run: |
           git push origin --tags --force
           git tag -f v0

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prepare": "node tools/install-hooks.js",
     "changeset": "changeset",
     "version": "changeset version",
-    "release": "pnpm build && changeset publish",
+    "release": "pnpm build && node tools/publish-oidc.mjs",
     "docs:inject": "node tools/docs-inject.cjs",
     "test:docs": "node tools/docs-transforms.test.cjs"
   },

--- a/tools/publish-oidc.mjs
+++ b/tools/publish-oidc.mjs
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * Publishes workspace packages to npm via OIDC trusted publishing.
+ *
+ * Mechanism:
+ *   1. `pnpm pack` to produce a tarball with `workspace:*` deps resolved
+ *      to concrete version ranges
+ *   2. `npm publish <tarball> --provenance` to upload via OIDC
+ *
+ * Why this script exists:
+ *   - `changeset publish` doesn't propagate OIDC tokens to pnpm child
+ *     processes (changesets/action#515)
+ *   - `pnpm publish` itself doesn't support OIDC (pnpm/pnpm#9812)
+ *   - `npm publish` supports OIDC natively (npm 11.5+ on Node 22+) but
+ *     doesn't resolve `workspace:*` protocols
+ *   - Combining `pnpm pack` (resolves workspace) with `npm publish`
+ *     (does OIDC) gives both.
+ *
+ * Preconditions when run in CI:
+ *   - Workflow grants `permissions: id-token: write`
+ *   - Trusted publishers configured on npm.com for each non-private package
+ *   - No `NPM_TOKEN`/`NODE_AUTH_TOKEN` env (those would short-circuit OIDC)
+ *   - No `.npmrc` written by `actions/setup-node`'s `registry-url`
+ *
+ * Outputs:
+ *   - `published`: "true" if at least one package was published, else "false"
+ *   - `published_packages`: newline-separated `name@version` list
+ *
+ * Side effects:
+ *   - Creates local git tags `<name>@<version>` for each published package
+ *   - Creates a GitHub release per tag with CHANGELOG section as body
+ *
+ * Idempotency: skips packages already published at the same version on npm.
+ */
+import { spawnSync } from 'node:child_process';
+import { appendFileSync, existsSync, readFileSync, readdirSync, unlinkSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(__dirname, '..');
+const PACKAGES_DIR = join(REPO_ROOT, 'packages');
+
+// Topological order: @mmnto/totem (packages/core) has no workspace deps among
+// published packages; cli + mcp depend on it; pack-rust-architecture is
+// independent. Private packages (pack-agent-security) are skipped at runtime
+// by the `pkg.private` check, but must still appear in PKG_ORDER so the
+// "new unknown package" guard below trips when packages are added.
+const PKG_ORDER = ['core', 'cli', 'mcp', 'pack-agent-security', 'pack-rust-architecture'];
+
+// Guard: fail loudly if a new package is added to packages/ but not listed
+// above, so the publish order is reviewed instead of silently fallen-through.
+const discovered = readdirSync(PACKAGES_DIR).filter((d) =>
+  existsSync(join(PACKAGES_DIR, d, 'package.json')),
+);
+const unknown = discovered.filter((d) => !PKG_ORDER.includes(d));
+if (unknown.length > 0) {
+  console.error(`[publish-oidc] Unknown packages in packages/: ${unknown.join(', ')}`);
+  console.error(
+    '[publish-oidc] Add them to PKG_ORDER in tools/publish-oidc.mjs and pick a position based on workspace deps.',
+  );
+  process.exit(1);
+}
+
+const isAlreadyOnNpm = (name, version) => {
+  const result = spawnSync('npm', ['view', `${name}@${version}`, 'version'], {
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  return result.status === 0 && result.stdout.trim() === version;
+};
+
+const extractChangelogSection = (pkgDir, version) => {
+  const changelogPath = join(pkgDir, 'CHANGELOG.md');
+  if (!existsSync(changelogPath)) return null;
+  const content = readFileSync(changelogPath, 'utf-8');
+  // Split on `## ` headings; sections[0] is preamble before any heading,
+  // sections[1..] each start with `<version>\n<body>...`
+  const sections = content.split(/^## /m);
+  for (const section of sections.slice(1)) {
+    const newlineIdx = section.indexOf('\n');
+    const heading = (newlineIdx === -1 ? section : section.slice(0, newlineIdx)).trim();
+    // Heading may be just the version or `<version> <date>` etc — match the leading token
+    const headingVersion = heading.split(/\s+/)[0];
+    if (headingVersion === version) {
+      return newlineIdx === -1 ? '' : section.slice(newlineIdx + 1).trim();
+    }
+  }
+  return null;
+};
+
+const published = [];
+
+for (const dir of PKG_ORDER) {
+  const pkgDir = join(PACKAGES_DIR, dir);
+  const pkgJsonPath = join(pkgDir, 'package.json');
+  if (!existsSync(pkgJsonPath)) {
+    console.log(`[publish-oidc] Skip ${dir}: no package.json`);
+    continue;
+  }
+
+  const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf-8'));
+  if (pkg.private) {
+    console.log(`[publish-oidc] Skip ${pkg.name}: private package`);
+    continue;
+  }
+
+  if (isAlreadyOnNpm(pkg.name, pkg.version)) {
+    console.log(`[publish-oidc] Skip ${pkg.name}@${pkg.version}: already published`);
+    continue;
+  }
+
+  console.log(`[publish-oidc] Packing ${pkg.name}@${pkg.version}`);
+  const packResult = spawnSync('pnpm', ['pack'], {
+    cwd: pkgDir,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  if (packResult.status !== 0) {
+    console.error(`[publish-oidc] pnpm pack failed for ${pkg.name} (exit ${packResult.status})`);
+    console.error(packResult.stderr);
+    process.exit(1);
+  }
+  const tarballName = packResult.stdout.trim().split('\n').pop();
+  const tarballPath = join(pkgDir, tarballName);
+  if (!tarballName || !existsSync(tarballPath)) {
+    console.error(`[publish-oidc] Couldn't locate tarball after pnpm pack for ${pkg.name}`);
+    console.error(`stdout: ${packResult.stdout}`);
+    process.exit(1);
+  }
+
+  console.log(`[publish-oidc] Publishing ${pkg.name}@${pkg.version} via OIDC`);
+  const publishResult = spawnSync(
+    'npm',
+    ['publish', tarballName, '--provenance', '--access', 'public'],
+    {
+      cwd: pkgDir,
+      stdio: 'inherit',
+    },
+  );
+
+  try {
+    unlinkSync(tarballPath);
+  } catch {
+    // best-effort cleanup
+  }
+
+  if (publishResult.status !== 0) {
+    console.error(`[publish-oidc] npm publish failed for ${pkg.name}@${pkg.version}`);
+    console.error(
+      '[publish-oidc] If this is E404 on a previously-published package: verify trusted publishers configured on npm.com for this package match repo=mmnto-ai/totem workflow=release.yml.',
+    );
+    process.exit(1);
+  }
+
+  published.push({ name: pkg.name, version: pkg.version, dir: pkgDir });
+}
+
+// Tag + GitHub release per published package.
+for (const { name, version, dir } of published) {
+  const tag = `${name}@${version}`;
+
+  // Tag may already exist from a prior partial run; skip silently.
+  const tagExists = spawnSync('git', ['rev-parse', tag], { stdio: 'ignore' }).status === 0;
+  if (!tagExists) {
+    spawnSync('git', ['tag', tag], { stdio: 'inherit' });
+    console.log(`[publish-oidc] Tagged ${tag}`);
+  }
+
+  const releaseExists = spawnSync('gh', ['release', 'view', tag], { stdio: 'ignore' }).status === 0;
+  if (releaseExists) {
+    console.log(`[publish-oidc] GitHub release ${tag} already exists, skipping`);
+    continue;
+  }
+
+  const notes = extractChangelogSection(dir, version) ?? `Released ${name}@${version}`;
+  const releaseResult = spawnSync(
+    'gh',
+    [
+      'release',
+      'create',
+      tag,
+      '--title',
+      `${name}@${version}`,
+      '--notes',
+      notes,
+      '--target',
+      'main',
+    ],
+    { stdio: 'inherit' },
+  );
+  if (releaseResult.status !== 0) {
+    console.error(
+      `[publish-oidc] gh release create failed for ${tag} (continuing — publish itself succeeded)`,
+    );
+  }
+}
+
+const publishedFlag = published.length > 0 ? 'true' : 'false';
+const publishedList = published.map((p) => `${p.name}@${p.version}`).join('\n');
+console.log(`[publish-oidc] Done: ${published.length} published`);
+
+if (process.env.GITHUB_OUTPUT) {
+  appendFileSync(process.env.GITHUB_OUTPUT, `published=${publishedFlag}\n`);
+  appendFileSync(
+    process.env.GITHUB_OUTPUT,
+    `published_packages<<EOF_PUBLISHED\n${publishedList}\nEOF_PUBLISHED\n`,
+  );
+}

--- a/tools/publish-oidc.mjs
+++ b/tools/publish-oidc.mjs
@@ -33,8 +33,8 @@
  * Idempotency: skips packages already published at the same version on npm.
  */
 import { spawnSync } from 'node:child_process';
-import { appendFileSync, existsSync, readFileSync, readdirSync, unlinkSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { appendFileSync, existsSync, readdirSync, readFileSync, unlinkSync } from 'node:fs';
+import { basename, dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -121,7 +121,11 @@ for (const dir of PKG_ORDER) {
     console.error(packResult.stderr);
     process.exit(1);
   }
-  const tarballName = packResult.stdout.trim().split('\n').pop();
+  // pnpm pack writes the tarball name to the last line of stdout; in some
+  // configurations it may be an absolute path rather than a relative filename.
+  // basename() normalizes both cases to the bare filename so join() stays sane.
+  const tarballLine = packResult.stdout.trim().split('\n').pop();
+  const tarballName = tarballLine ? basename(tarballLine) : '';
   const tarballPath = join(pkgDir, tarballName);
   if (!tarballName || !existsSync(tarballPath)) {
     console.error(`[publish-oidc] Couldn't locate tarball after pnpm pack for ${pkg.name}`);


### PR DESCRIPTION
## Summary

Switch the release workflow from token-based npm publish to OIDC trusted publishing. Eliminates `NPM_TOKEN` dependency (annual token-rotation pain, hit empirically when 1.45.0 cohort got stuck at 1.44.0 because the secret had expired).

This **revives the approach from #1182** (`pnpm pack` + `npm publish <tarball>`), which was reverted in #1183 because trusted publishers weren't configured on npm.com at the time. They are now (verified during this session).

### Why this shape

- `changeset publish` doesn't propagate OIDC tokens correctly to pnpm child processes ([changesets/action#515](https://github.com/changesets/action/issues/515))
- `pnpm publish` itself doesn't support OIDC ([pnpm/pnpm#9812](https://github.com/pnpm/pnpm/issues/9812))
- `npm publish` supports OIDC natively (npm 11.5+ on Node 22+) but doesn't resolve `workspace:*` protocols
- Combining `pnpm pack` (resolves workspace) with `npm publish <tarball>` (does OIDC) gets both ✓

### Changes

- `tools/publish-oidc.mjs` — new: per-package `pnpm pack` + `npm publish --provenance --access public` in topological order (core → cli/mcp → pack-rust-architecture). Skips already-published versions for idempotent re-runs. Tags + GH releases after each publish.
- `.github/workflows/release.yml` — drops `registry-url` from setup-node (it writes an `.npmrc` that short-circuits OIDC), drops `NPM_TOKEN`/`NODE_AUTH_TOKEN` env vars, drops `publish: pnpm run release` from changesets-action (now version-only), adds OIDC publish step gated on `hasChangesets == 'false'`.
- `package.json` — `release` script now points at the new tool.

### Required preconditions (already in place)

- `permissions: id-token: write` on the workflow job ✓ (was already there)
- Trusted publishers configured on npm.com for each of `@mmnto/cli`, `@mmnto/totem`, `@mmnto/mcp`, `@mmnto/pack-rust-architecture` with `repo=mmnto-ai/totem` + `workflow=release.yml` ✓ (verified during diagnosis)
- npm CLI 11.5+ on Node 22+ ✓ (Node 22 has this by default)

### Implicit test

When this PR merges to main, the workflow runs:
1. `changesets-action` finds no unconsumed changesets → `hasChangesets=false`
2. Publish step fires → finds `1.45.0` in package.json files, `1.44.0` on npm → publishes all four
3. We finally have 1.45.0 on npm, unblocking the P281 cohort and recompile-sync push

If the publish step fails, the workflow reports the error in-place and we iterate without affecting `main`'s release state (already at 1.45.0 in git for ~24 hours).

## Test plan

- [ ] Merge to main
- [ ] Watch release workflow run
- [ ] Verify all four packages at 1.45.0 on npm (`npm view @mmnto/cli @mmnto/totem @mmnto/mcp @mmnto/pack-rust-architecture version`)
- [ ] Verify per-package git tags pushed (`@mmnto/cli@1.45.0`, etc.)
- [ ] Verify GitHub releases created
- [ ] Verify no \`NPM_TOKEN\` references remain in workflows (`grep -r NPM_TOKEN .github/`)
- [ ] Follow-up: flip cli/totem/mcp packages' publishing access to "require 2FA and disallow tokens" once OIDC is verified working (pack-rust-architecture is already on this strict setting from earlier diagnosis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)