### PR TITLE
fix(ci): upgrade npm to 11.5+ for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,12 @@ jobs:
           # _authToken=${NODE_AUTH_TOKEN}, which blocks npm's OIDC
           # trusted-publishing negotiation. See #1180 + #1182 history.
 
+      # npm OIDC trusted publishing landed in npm 11.5.1. Node 22 ships with
+      # npm 10.9.x which throws ENEEDAUTH because it has no OIDC negotiation
+      # code path. Upgrade to the latest npm so `npm publish` auto-detects
+      # GitHub Actions OIDC and exchanges for a short-lived publish token.
+      - run: npm install -g npm@latest
+
       - run: pnpm install --frozen-lockfile
 
       - run: pnpm build


### PR DESCRIPTION
## Summary

Follow-on fix for #1987. The OIDC publish step landed ENEEDAUTH on first attempt because Node 22 ships with **npm 10.9.7**, and npm's OIDC trusted-publishing negotiation code path landed in **npm 11.5.1**. Without that version, `npm publish` in a workflow with `id-token: write` has no idea it should request a GitHub OIDC token and exchange it for a short-lived publish token.

The fix is one line: `npm install -g npm@latest` between setup-node and the publish step.

## Evidence

Run [`26247698698`](https://github.com/mmnto-ai/totem/actions/runs/26247698698) (the auto-triggered publish after #1987 merged):

```
2026-05-21T19:16:35.0796800Z npm: 10.9.7
...
2026-05-21T19:17:01.3684346Z npm error code ENEEDAUTH
2026-05-21T19:17:01.3685208Z npm error need auth This command requires you to be logged in to https://registry.npmjs.org/
2026-05-21T19:17:01.3686274Z npm error need auth You need to authorize this machine using `npm adduser`
```

`pnpm pack` ran cleanly (workspace deps resolved, tarball at expected path), so the fix is genuinely scoped to npm CLI version.

## Test plan

- [ ] Merge to main
- [ ] Watch the auto-triggered release workflow
- [ ] Verify the `Run npm install -g npm@latest` step bumps npm to 11.5+ (visible in the step's stdout)
- [ ] Verify `Publish unpublished packages via OIDC` step now succeeds
- [ ] Verify all four packages at 1.45.0 on npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)