### PR TITLE
fix(ci): pin npm version + --force to avoid self-upgrade race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,9 +29,14 @@ jobs:
 
       # npm OIDC trusted publishing landed in npm 11.5.1. Node 22 ships with
       # npm 10.9.x which throws ENEEDAUTH because it has no OIDC negotiation
-      # code path. Upgrade to the latest npm so `npm publish` auto-detects
+      # code path. Upgrade to a pinned npm 11.x so `npm publish` auto-detects
       # GitHub Actions OIDC and exchanges for a short-lived publish token.
-      - run: npm install -g npm@latest
+      #
+      # --force bypasses the self-upgrade race condition where npm loads its
+      # own code mid-install and the on-disk copy gets partially replaced,
+      # producing MODULE_NOT_FOUND for transitive deps like promise-retry.
+      # Pin version (not @latest) keeps this step deterministic.
+      - run: npm install -g --force npm@11.15.0
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

Follow-on to #1989. \`npm install -g npm@latest\` started hitting \`MODULE_NOT_FOUND: 'promise-retry'\` on \`@npmcli/arborist\` deterministically in the release workflow. Classic npm self-upgrade race: npm loads its own arborist code into memory at the start of the install, then partway through replaces files on disk, so transitive deps that get loaded later go missing.

## Evidence

[Run 26248129389](https://github.com/mmnto-ai/totem/actions/runs/26248129389), attempts 3 and 4 both failed at the same step with the same error:

\`\`\`
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error Require stack:
npm error - /opt/hostedtoolcache/node/22.22.2/x64/lib/node_modules/npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
\`\`\`

Attempt 2 of the same run had succeeded with the same command — so the race is non-deterministic against \`@latest\`, depending on npm version transitions.

## Fix

- Pin to \`npm@11.15.0\` (current latest at time of writing, well above OIDC's 11.5.1 minimum)
- Add \`--force\` to bypass the integrity check that triggers the load-mid-replace race

Both keep the OIDC requirement satisfied (npm 11.5+) and make this step idempotent across re-runs.

## State at this PR

- Three of four packages already at 1.45.0 on npm via OIDC ✅
- Only \`pack-rust-architecture\` still stuck (trusted publisher config was just corrected to point at \`totem\` repo)
- This PR lets us re-run the workflow on a green publish step and finish the cohort recovery

## Test plan

- [ ] Merge to main
- [ ] Workflow auto-runs on merge commit
- [ ] \`npm install -g --force npm@11.15.0\` completes cleanly
- [ ] OIDC publish step runs; totem/cli/mcp skip ("already published"), pack-rust-architecture publishes
- [ ] \`npm view @mmnto/pack-rust-architecture version\` returns 1.45.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)