### PR TITLE
fix(ci): bump release workflow to Node 24 (ships npm 11.x natively)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,24 +19,19 @@ jobs:
 
       - uses: pnpm/action-setup@v5
 
+      # Node 24 ships with npm 11.x natively, which supports OIDC trusted
+      # publishing (added in npm 11.5.1). Node 22 ships with npm 10.9.x and
+      # `npm install -g npm@11.x` to self-upgrade is broken on the hosted
+      # runner (MODULE_NOT_FOUND: promise-retry — npm loads its own arborist
+      # code, then replaces files mid-install). Avoiding the self-upgrade
+      # entirely by using a Node version that ships the right npm.
+      # No registry-url: it writes an .npmrc with _authToken=${NODE_AUTH_TOKEN},
+      # which blocks npm's OIDC trusted-publishing negotiation. See #1180 +
+      # #1182 history.
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
-          # No registry-url: it writes an .npmrc with
-          # _authToken=${NODE_AUTH_TOKEN}, which blocks npm's OIDC
-          # trusted-publishing negotiation. See #1180 + #1182 history.
-
-      # npm OIDC trusted publishing landed in npm 11.5.1. Node 22 ships with
-      # npm 10.9.x which throws ENEEDAUTH because it has no OIDC negotiation
-      # code path. Upgrade to a pinned npm 11.x so `npm publish` auto-detects
-      # GitHub Actions OIDC and exchanges for a short-lived publish token.
-      #
-      # --force bypasses the self-upgrade race condition where npm loads its
-      # own code mid-install and the on-disk copy gets partially replaced,
-      # producing MODULE_NOT_FOUND for transitive deps like promise-retry.
-      # Pin version (not @latest) keeps this step deterministic.
-      - run: npm install -g --force npm@11.15.0
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

The self-upgrade-npm approach from #1989 and #1990 is fundamentally broken on the hosted runner. \`npm install -g npm@<X>\` to go from 10.9.x → 11.x hits \`MODULE_NOT_FOUND: 'promise-retry'\` deterministically — npm loads its own \`@npmcli/arborist\` code into memory at the start of the install, then replaces files on disk partway through, and transitive deps that get loaded later are gone. \`--force\` and pinning the exact version don't bypass this — they only affect integrity checks.

Node 24 ships with npm 11.x natively, so no self-upgrade is needed.

## Evidence

[Run 26249194762](https://github.com/mmnto-ai/totem/actions/runs/26249194762), the auto-triggered run after #1990 merged. Failed at the pinned \`npm install -g --force npm@11.15.0\` step with the same MODULE_NOT_FOUND that hit the earlier \`@latest\` attempts.

This is the same approach the official npm trusted-publishing docs implicitly recommend — their workflow examples use a Node version that bundles a compatible npm.

## Changes

- \`node-version: 22\` → \`node-version: 24\` in the release workflow only
- Remove the \`npm install -g npm@...\` step (no longer needed)
- Consolidate the explanatory comment block

CI / test workflows stay on Node 22 — this PR only touches \`.github/workflows/release.yml\`.

## State at this PR

- 3/4 packages at 1.45.0 on npm (totem, cli, mcp) ✅
- \`pack-rust-architecture\` still stuck at 1.44.0, trusted-publisher config already corrected to point at \`totem\` repo
- This PR is the last gate to recovering the cohort

## Test plan

- [ ] Merge to main
- [ ] Workflow auto-runs on merge commit
- [ ] \`actions/setup-node@v6\` with node-version: 24 provisions npm 11.x ≥ 11.5
- [ ] OIDC publish step: totem/cli/mcp skip ("already published"), pack-rust-architecture publishes via OIDC
- [ ] \`npm view @mmnto/pack-rust-architecture version\` returns 1.45.0
- [ ] \`@mmnto/pack-rust-architecture@1.45.0\` tag pushed + GH release created

🤖 Generated with [Claude Code](https://claude.com/claude-code)