### PR TITLE
chore(changeset): @mmnto/cli minor for #1998 (--ast-parse-mode lenient)

### DIFF
--- a/.changeset/lint-ast-parse-mode-lenient-1982.md
+++ b/.changeset/lint-ast-parse-mode-lenient-1982.md
@@ -51,4 +51,4 @@ interface AstParseFailureOutcome {
 }
 ```
 
-Parser-error text is sanitized (C0 controls + DEL stripped; TAB/LF/CR preserved) before logging or persisting — defensive against terminal control bytes that ast-grep might surface in snippets of parsed content.
+Parser-error text is sanitized via the canonical `sanitizeForTerminal()` helper from `@mmnto/totem` core (`packages/core/src/terminal-sanitize.ts`) before logging or persisting. Strips CSI/ANSI escapes, C0 controls (including bare CR per CR [mmnto-ai/totem#1739](https://github.com/mmnto-ai/totem/issues/1739) R3 — cursor-rewind spoofing), and C1 controls (`\x80-\x9F`). Preserves TAB and LF. Defends against terminal injection from ast-grep's parsed-content snippets.

--- a/.changeset/lint-ast-parse-mode-lenient-1982.md
+++ b/.changeset/lint-ast-parse-mode-lenient-1982.md
@@ -1,0 +1,54 @@
+---
+'@mmnto/cli': minor
+'@mmnto/totem': patch
+---
+
+feat(cli): `--ast-parse-mode lenient` operator escape for AST parse failures ([mmnto-ai/totem#1982](https://github.com/mmnto-ai/totem/issues/1982))
+
+Closes [mmnto-ai/totem#1982](https://github.com/mmnto-ai/totem/issues/1982). Mirrors the existing `--timeout-mode lenient` precedent at `packages/cli/src/commands/lint.ts` for a different failure class: AST parse errors that currently abort the entire lint run (e.g. `ast-grep batch parse failed: rust is not supported in napi` on Windows).
+
+Empirical trigger: `mmnto-ai/liquid-city#348` (Bevy 0.14 → 0.18.1) hit the napi-unsupported-Rust parse failure on every changed Rust file, blocking pre-push with no audited escape route (`--no-verify` violates AGENTS.md spirit).
+
+## What ships
+
+**New CLI flag:**
+
+```bash
+totem lint --ast-parse-mode lenient
+```
+
+**Env var equivalent (session-level escape, usable in pre-push hooks):**
+
+```bash
+TOTEM_LINT_AST_PARSE_MODE=lenient totem lint
+```
+
+Precedence: CLI flag > env var > default `'strict'`.
+
+**`'lenient'`** captures the parse failure into a new `AstParseFailureOutcome` array, logs a warning naming the affected language, sets `astViolations = []`, and continues with regex results. **`'strict'`** (default) preserves the current hard-fail behavior.
+
+**Diagnostic hint upgrade in `@mmnto/totem`:** `AST_GREP_HINT` (surfaced via every `TotemParseError`'s `recoveryHint`) now names the new escape route and cross-refs [mmnto-ai/totem#1786](https://github.com/mmnto-ai/totem/issues/1786) for the durable per-file degrade fix.
+
+## Semantic asymmetry vs `--timeout-mode lenient` (deliberately documented)
+
+| Flag                       | Skip granularity                                         | Why                                                                                                                                                                               |
+| -------------------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--timeout-mode lenient`   | **per-rule** (per rule-file pair that times out)         | Bounded evaluator captures timeouts in-loop without throwing                                                                                                                      |
+| `--ast-parse-mode lenient` | **run-wide** (skip ALL AST rules on first parse failure) | AST batch parser raises `TotemParseError` that escapes the per-file loop in core; per-file degrade is [mmnto-ai/totem#1786](https://github.com/mmnto-ai/totem/issues/1786)'s lane |
+
+For the current trigger (napi unsupported language), per-file vs run-wide is operationally equivalent — every Rust file fails parse the same way. The asymmetry matters when future mixed-language scenarios surface (e.g. Python parses, Rust doesn't); that's `#1786`'s design space, not this scope.
+
+## Telemetry / programmatic access
+
+`runCompiledRules()` now returns `astParseFailures: AstParseFailureOutcome[]` alongside `regexTimeouts`:
+
+```typescript
+interface AstParseFailureOutcome {
+  file: string; // '*' (run-wide; per-file granularity is #1786)
+  language: string; // 'rust' or 'unknown' if not parseable from msg
+  message: string; // first 200 chars of sanitized parser-error text
+  mode: 'lenient';
+}
+```
+
+Parser-error text is sanitized (C0 controls + DEL stripped; TAB/LF/CR preserved) before logging or persisting — defensive against terminal control bytes that ast-grep might surface in snippets of parsed content.

--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -116,6 +116,7 @@ export async function runCompiledRules(
     RegexEvaluator,
     resolveGitRoot,
     safeExec,
+    sanitizeForTerminal,
     saveRuleMetrics,
     TotemError,
   } = await import('@mmnto/totem');
@@ -410,12 +411,12 @@ export async function runCompiledRules(
         // regex results stand. The proper per-file degrade lives in
         // mmnto-ai/totem#1786; this is the gap-bridge.
         //
-        // Sanitize parser-error text before logging/persisting: ast-grep
-        // surfaces snippets of parsed content/paths which could contain
-        // terminal control bytes. Strip C0 controls (\x00-\x1F except \t \n)
-        // and DEL (\x7F) so warning output doesn't smuggle escape sequences
-        // through operator terminals or log aggregators.
-        const safeMsg = msg.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F]/g, '');
+        // Sanitize parser-error text via the canonical sanitizeForTerminal
+        // (packages/core/src/terminal-sanitize.ts). ast-grep surfaces
+        // snippets of parsed content/paths which may contain terminal
+        // control bytes (CSI sequences, bare CR for cursor-rewind spoofing,
+        // C0/C1 controls). Defends per CR mmnto-ai/totem#1739 R3.
+        const safeMsg = sanitizeForTerminal(msg);
         // matchAll used to satisfy a CodeRabbit security rule that prefers
         // exhaustive iteration over single-match extraction; we still only
         // need the first language token for the outcome shape.


### PR DESCRIPTION
## Summary

- Adds the changeset that was missed when #1998 merged
- Marks `@mmnto/cli` minor (new `--ast-parse-mode <strict|lenient>` flag) + `@mmnto/totem` patch (AST_GREP_HINT diagnostic upgrade in core)
- Triggers the next cohort release to publish 1.46.0 with the operator escape from #1982

## Why

#1998 added a user-facing CLI flag but I missed the changeset on the merge. lc-claude is on WAIT posture for `impl/348-bevy-018-upgrade` (Bevy 0.14 → 0.18.1) — the durable install path is `pnpm i @mmnto/cli@1.46.0` which requires this changeset to ship.

Per strategy-claude's 2026-05-22T0048Z disposition + user instruction: ship 1.46.0 with **ONLY #1998** (single-PR release). Rationale:

1. lc-claude WAIT posture is highest unblock priority — shorter merge-to-release latency
2. Single user-facing flag = minimal blast radius; bisecting against 1.45.0 is trivial if anything regresses
3. Class A remainder (A1 #1981 hooks; #1994 cache-internal) is package-independent and ships in whatever the next natural release window is

## Lesson banked

Anchored on the OIDC PR sequence from claude-0065 (#1987–#1992) — all CI-only, no changesets needed. Carried that pattern by reflex to #1998 without re-checking that this PR ships user-visible behavior to a published package. Discipline going forward: changeset-check is a pause-point on EVERY PR regardless of recent precedent.

## Test plan

- [ ] CI green
- [ ] Merge → changesets-action opens "Release 1.46.0" PR automatically
- [ ] Merge release PR → release.yml publishes `@mmnto/cli@1.46.0` + `@mmnto/totem@1.45.1` via OIDC (provenance gate from #1995 validates)
- [ ] lc-claude unblocks via `pnpm i @mmnto/cli@1.46.0` + `totem lint --ast-parse-mode lenient` on Bevy 0.18 push

🤖 Generated with [Claude Code](https://claude.com/claude-code)