### PR TITLE
chore(changelog): backfill cohort-link headers 1.43.6 → 1.47.0 across 3 packs

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -140,6 +140,8 @@ _Cohort-link bump (no direct package changes). See `.changeset/config.json` for 
 
 ## 1.43.6
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.43.5
 
 _Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._

--- a/packages/pack-agent-security/CHANGELOG.md
+++ b/packages/pack-agent-security/CHANGELOG.md
@@ -2,13 +2,23 @@
 
 ## 1.47.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.46.0
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.45.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.44.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.43.6
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.43.5
 

--- a/packages/pack-rust-architecture/CHANGELOG.md
+++ b/packages/pack-rust-architecture/CHANGELOG.md
@@ -2,13 +2,23 @@
 
 ## 1.47.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.46.0
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.45.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.44.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.43.6
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.43.5
 


### PR DESCRIPTION
## Summary

- Backfills **11 empty cohort-bump CHANGELOG headers** across `@mmnto/totem`, `@mmnto/pack-agent-security`, `@mmnto/pack-rust-architecture` for releases 1.43.6 through 1.47.0
- Restores the canonical `_Cohort-link bump (no direct package changes)..._` note established in #1965 (CR R1 on the 1.43.5 VP PR)
- Pure historical CHANGELOG content fix — no version bumps, no functional change, no changeset

## Drift inventory (before this PR)

| Package | Empty headers | Versions |
|---|---|---|
| `@mmnto/pack-rust-architecture` | 5 | 1.43.6, 1.44.0, 1.45.0, 1.46.0, 1.47.0 |
| `@mmnto/pack-agent-security` | 5 | 1.43.6, 1.44.0, 1.45.0, 1.46.0, 1.47.0 |
| `@mmnto/totem` (core) | 1 | 1.43.6 only (rest had real changes; 1.47.0 already has a body) |
| **Total** | **11** | |

After this PR: **0** empty cohort-bump headers in the affected releases.

## Diagnostic (per `feedback_drift_correction_must_be_quantifiable`)

The inflection at 1.43.6 is **NOT** a config regression. `git show 4db7d641` (#1965 VP for 1.43.5) confirms the `_Cohort-link bump..._` note was added **manually** as a follow-on commit inside the VP PR after CR R1 flagged the empty 1.43.5 header. The discipline didn't propagate to subsequent VP cycles because the changesets bot doesn't auto-augment empty headers for fixed-cohort linked packages — that's its default output for packages with no direct changeset.

## Follow-on (out of scope here — flagging for next cycle)

Decide between:
- **(a)** Bank "always include the cohort-link note in pack CHANGELOGs at VP-merge time" as author discipline, or
- **(b)** Automate the augmentation via a VP post-generation hook

This PR is the discipline recovery; the automation question is separate and will be handled either at next signoff (bank as memory rule) or via a follow-on issue (mechanism fix).

## Scope discussion

Strategy-claude's lean dispatched at `2026-05-22T0542Z` scoped to `pack-rust-architecture` only (5 headers). The actual drift inventory turned out symmetric across all three packs (11 headers total). Widened scope to match **#1965's symmetric-sweep precedent** ("Generalizes within diff: inserts a uniform one-line note under every empty header in scope across the three affected CHANGELOGs"), after user signaled on the widened inventory at session start.

## Test plan

- [x] `pnpm run format` — no format-induced changes
- [x] `totem lint` — PASS, 0 violations (387 rules)
- [x] `totem review` — deterministic fast-path (all 3 files non-code, skipped)
- [x] `--scope-to-diff` claim-discipline gate — PASS, no findings
- [x] Diff stat = +22 insertions, 0 deletions = 11 notes × 2 lines (note + blank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)