### PR TITLE
chore(changelog): backfill cohort-link headers 1.47.1 across 3 packs

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -6,6 +6,8 @@ _Cohort-link bump for the Node 24 engine constraint enforcement shipping with th
 
 ## 1.47.1
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.47.0
 
 _Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition; the `--scope-to-diff` feature driving this release ships in `@mmnto/cli`._

--- a/packages/pack-agent-security/CHANGELOG.md
+++ b/packages/pack-agent-security/CHANGELOG.md
@@ -6,6 +6,8 @@ _Cohort-link bump for the Node 24 engine constraint enforcement shipping with th
 
 ## 1.47.1
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.47.0
 
 _Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._

--- a/packages/pack-rust-architecture/CHANGELOG.md
+++ b/packages/pack-rust-architecture/CHANGELOG.md
@@ -6,6 +6,8 @@ _Cohort-link bump for the Node 24 engine constraint enforcement shipping with th
 
 ## 1.47.1
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.47.0
 
 _Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._


### PR DESCRIPTION
## Summary

- Backfills **3 empty cohort-bump CHANGELOG headers** at version `1.47.1` across `@mmnto/totem` (core), `@mmnto/pack-rust-architecture`, `@mmnto/pack-agent-security`
- Restores the canonical `_Cohort-link bump (no direct package changes)..._` note established in #1965 and reinforced in #2009
- Pure historical CHANGELOG content fix — no version bumps, no functional change, no changeset

## Drift inventory (before this PR)

| Package | Empty headers | Versions |
|---|---|---|
| `@mmnto/totem` (core) | 1 | 1.47.1 |
| `@mmnto/pack-rust-architecture` | 1 | 1.47.1 |
| `@mmnto/pack-agent-security` | 1 | 1.47.1 |
| **Total** | **3** | |

After this PR: **0** empty cohort-bump headers in 1.47.1. (1.48.0 sections were already curated by hand with the more-specific Node-24-engines style; this fixes the gap left by the #2010 / #2012 auto-VP cycle that shipped 1.47.1.)

## Why this happened

#2010 was a cli-scoped chore (canonical-skill-template CR fixes, lc#406 R1 deferral). The auto-VP at #2012 lockstep-bumped the rest of the cohort but the changesets bot doesn't auto-augment empty headers for fixed-cohort linked packages — same root cause as #2009's batch of 11. This is the next instance of the recurring drift tracked at #1969.

The 1.48.0 sections were curated at VP-merge time because the cohort change there (`engines.node` declaration) materially applied to every package. 1.47.1's substance was cli-only, so the auto-VP left the sibling headers empty.

## Scope discussion

Strict matching of #2009's precedent (generic canonical text) was chosen over the more-informative 1.48.0 specific style because:
- The 1.47.1 substance lives entirely in `@mmnto/cli`'s entry; the pack CHANGELOGs have no direct relationship to the change
- The existing 1.47.0 entries in both packs already use the generic text — consistency within each file's local neighborhood
- This is a backfill chore matching #2009's shape, not a stylistic upgrade

## Follow-on

The underlying mechanism question (banking author discipline vs automating VP post-generation augmentation) remains tracked at #1969. This PR is the discipline recovery; the automation question is separate.

## Test plan

- [x] `pnpm run format` — no format-induced changes
- [x] `pnpm exec totem lint` — PASS, 0 violations (387 rules)
- [x] `pnpm exec totem review` — deterministic fast-path (all 3 files non-code, skipped)
- [x] Diff stat = +6 insertions, 0 deletions = 3 notes × 2 lines (note + blank)

🤖 Generated with [Claude Code](https://claude.com/claude-code)