### PR TITLE
chore(deps): bump @anthropic-ai/sdk 0.78 -> 0.98 (W2 cohort dep wave)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:docs": "node tools/docs-transforms.test.cjs"
   },
   "devDependencies": {
-    "@anthropic-ai/sdk": "^0.78.0",
+    "@anthropic-ai/sdk": "^0.98.0",
     "@changesets/cli": "^2.31.0",
     "@google/genai": "^1.44.0",
     "eslint": "^10.4.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,7 @@
     "zod": "^3.24.0"
   },
   "devDependencies": {
-    "@anthropic-ai/sdk": "^0.78.0",
+    "@anthropic-ai/sdk": "^0.98.0",
     "@google/genai": "^1.44.0",
     "@types/node": "^22.0.0",
     "esbuild": "^0.28.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.78.0
-        version: 0.78.0(zod@3.25.76)
+        specifier: ^0.98.0
+        version: 0.98.0(zod@3.25.76)
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@22.19.13)
@@ -76,8 +76,8 @@ importers:
         version: 3.25.76
     devDependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.78.0
-        version: 0.78.0(zod@3.25.76)
+        specifier: ^0.98.0
+        version: 0.98.0(zod@3.25.76)
       '@google/genai':
         specifier: ^1.44.0
         version: 1.44.0(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))
@@ -104,7 +104,7 @@ importers:
         version: 0.42.0
       '@google/genai':
         specifier: '>=1.0.0'
-        version: 1.44.0
+        version: 1.44.0(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))
       '@lancedb/lancedb':
         specifier: ^0.26.2
         version: 0.26.2(apache-arrow@17.0.0)
@@ -228,8 +228,8 @@ importers:
 
 packages:
 
-  '@anthropic-ai/sdk@0.78.0':
-    resolution: {integrity: sha512-PzQhR715td/m1UaaN5hHXjYB8Gl2lF9UVhrrGrZeysiF6Rb74Wc9GCB8hzLdzmQtBd1qe89F9OptgB9Za1Ib5w==}
+  '@anthropic-ai/sdk@0.98.0':
+    resolution: {integrity: sha512-N7aXtCvC5g6T1Y4V29lJjceu/zTkVkIZF0jdBvagr0TRFHuKeImffalGWEfqZKrvjH+IQbzJWw6TmSmUzrlMgg==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -310,10 +310,6 @@ packages:
     resolution: {integrity: sha512-nCcY680f8D9SY8V+QJ3fkqfyEYTUMVNzoX94VzRrNvXIWlhhnCzH6Fz0zFTtg2xFq0BCGX+DTciB4PnwKcZPFQ==}
     peerDependencies:
       web-tree-sitter: ^0.26.0
-
-  '@babel/runtime@7.28.6':
-    resolution: {integrity: sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==}
-    engines: {node: '>=6.9.0'}
 
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
@@ -1015,6 +1011,9 @@ packages:
     resolution: {integrity: sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==}
     cpu: [x64]
     os: [win32]
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1748,6 +1747,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
@@ -2715,6 +2717,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -3137,9 +3142,10 @@ packages:
 
 snapshots:
 
-  '@anthropic-ai/sdk@0.78.0(zod@3.25.76)':
+  '@anthropic-ai/sdk@0.98.0(zod@3.25.76)':
     dependencies:
       json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
     optionalDependencies:
       zod: 3.25.76
 
@@ -3191,8 +3197,6 @@ snapshots:
   '@ast-grep/wasm@0.42.1(web-tree-sitter@0.26.6)':
     dependencies:
       web-tree-sitter: 0.26.6
-
-  '@babel/runtime@7.28.6': {}
 
   '@babel/runtime@7.29.2': {}
 
@@ -3540,17 +3544,6 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@google/genai@1.44.0':
-    dependencies:
-      google-auth-library: 10.6.1
-      p-retry: 4.6.2
-      protobufjs: 7.5.4
-      ws: 8.19.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
   '@google/genai@1.44.0(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))':
     dependencies:
       google-auth-library: 10.6.1
@@ -3788,6 +3781,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
+
+  '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -4629,6 +4624,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-uri@3.1.0: {}
 
   fastq@1.20.1:
@@ -4977,7 +4974,7 @@ snapshots:
 
   json-schema-to-ts@3.1.1:
     dependencies:
-      '@babel/runtime': 7.28.6
+      '@babel/runtime': 7.29.2
       ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
@@ -5735,6 +5732,11 @@ snapshots:
   sprintf-js@1.0.3: {}
 
   stackback@0.0.2: {}
+
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
 
   statuses@2.0.2: {}
 


### PR DESCRIPTION
## Summary

- Bumps `@anthropic-ai/sdk` workspace devDep `0.78.0` → `0.98.0` (20 upstream releases, 2026-03-13 → 2026-05-21)
- Pure devDep refresh — `peerDependencies` range (`>=0.50.0`) is **unchanged**, no consumer-visible behavior change
- No changeset (matches #2003 W1 tooling-bundle precedent — published cohort surface is identical)

## Files changed

| File | Change |
|---|---|
| `package.json` (root devDep) | `^0.78.0` → `^0.98.0` |
| `packages/cli/package.json` (devDep) | `^0.78.0` → `^0.98.0` |
| `pnpm-lock.yaml` | `0.78.0(zod@3.25.76)` → `0.98.0(zod@3.25.76)` |

## Breaking-change audit (0.79 → 0.98)

API surface used by `packages/cli/src/orchestrators/anthropic-orchestrator.ts` is stable across the range:

- `new Anthropic()` constructor (env-var auto-detect)
- `client.messages.create({ model, max_tokens, system, messages, temperature })`
- system block array with `cache_control: { type: 'ephemeral', ttl?: '1h' }`
- `response.content` text blocks, `response.usage.{input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens}`, `response.stop_reason`

Notable changes in range (none impact our usage):

| Version | Change | Impact |
|---|---|---|
| 0.79 | zod v4 import path for Zod ^3.25 compat | Positive — lockfile pins zod@3.25.76 |
| 0.83 | DEPRECATED client-side compaction helpers | We don't use them |
| 0.89 | DEPRECATED Sonnet/Opus 4 models | We route to `sonnet-4-6` / `opus-4-7` (both supported) |
| 0.90 | ADDED `claude-opus-4-7` model id | Matches our compile routing |
| 0.96 | zod/v4-only types enforcement | We don't import SDK types (mocked in tests) |
| 0.98 | ADDED thinking-token-count beta | Additive |

Plus several additive features (Managed Agents, CMA Memory beta, OIDC workspace federation, AbortSignal for tool runner) that we don't currently consume but are now available.

## BYOSD pattern preserves consumer flexibility

`anthropic-orchestrator.ts` loads the SDK dynamically: `(await import('@anthropic-ai/sdk')).default`. Tests use `vi.mock('@anthropic-ai/sdk', ...)` to isolate the runtime entirely. The published `@mmnto/cli` package doesn't bundle the SDK — consumers bring their own. The `peerDependencies` range `>=0.50.0` (optional) is unchanged so consumers on any 0.50+ version continue to satisfy.

## Why no changeset

Pure dev-time refresh with zero consumer-visible behavior change. Matches the W1 tooling-bundle precedent at #2003 (which also shipped without a changeset and accordingly contributed nothing to 1.47.0's CHANGELOG). Decision can be revisited if reviewers want a traceability entry — adding a patch changeset would force a 1.48.1 release entry documenting the bump.

## Test plan

- [x] `pnpm install` — clean (lockfile updated; zod still pinned at 3.25.76)
- [x] `pnpm --filter @mmnto/cli build` — tsc PASS (no type-surface drift)
- [x] `pnpm --filter @mmnto/cli test` — 2255/2255 PASS
- [x] `pnpm --filter @mmnto/totem test` — 2041/2041 PASS
- [x] `pnpm run format` — no diff
- [x] `pnpm exec totem lint` — PASS, 0 violations (387 rules)
- [x] `pnpm exec totem review` — fast-path (all 3 files non-code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)