### PR TITLE
feat(cli): totem init --force-skill-refresh for marker-less skills (W3.5, #2008)

### DIFF
--- a/.changeset/init-force-skill-refresh-w3.5.md
+++ b/.changeset/init-force-skill-refresh-w3.5.md
@@ -1,0 +1,46 @@
+---
+'@mmnto/cli': minor
+---
+
+feat(cli): `totem init --force-skill-refresh` flag for canonical-marker-less skill files (W3.5)
+
+Adds a narrow CLI flag that overrides `scaffoldClaudeSkill`'s `preserved` outcome when a distributed Claude skill file lacks the canonical `TOTEM_SKILL_*` markers. Default behavior is unchanged — without the flag, marker-less skill files continue to be preserved with a migration hint. With the flag, the file is overwritten with canonical content and the destructive event is surfaced via a per-file `log.warn` plus a dedicated summary line.
+
+## What ships
+
+- **New CLI flag:** `totem init --force-skill-refresh`
+- **New scaffolder option:** `scaffoldClaudeSkill(path, content, { force?: boolean })`
+- **New result metadata field:** `scaffoldClaudeSkill` returns `forceSuppressed?: true` only when the no-marker guard was suppressed by force
+- **New result metadata field:** `HookInstallerResult.summaryActionOverride?: string` for callers to override the default summary action text
+- **Widened signature:** `AiToolInfo.hookInstaller?: (cwd, opts?: { forceSkillRefresh?: boolean }) => …`
+
+## Scope (narrow, per strategy-claude lean at `2026-05-23T1819Z`)
+
+| In                                                                                           | Out                                                                                                                                     |
+| -------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| Single flag override on the no-marker guard for distributed Claude skills                    | `.claude/settings.json` `permissions.allow` merging (Layer 1, stays in `#2008`)                                                         |
+| Per-file destructive-by-consent warning (only on suppression path)                           | `.mcp.json` dedup (Layer 1)                                                                                                             |
+| Summary line that mirrors the warning text for grep parity                                   | Opt-in hooks (Layer 1)                                                                                                                  |
+| Below-marker user customization stays intact under force (cross-marker contract is separate) | Opt-in baselines (Layer 1)                                                                                                              |
+| Skills only — reflexes (CLAUDE.md / GEMINI.md) are out of scope                              | Refresh-flag cohort (`--refresh-skills` / `--refresh-reflexes` / `--install-hooks` / `--install-baselines`) — Layer 2, stays in `#2008` |
+
+The bulldoze-everything semantics (overwrite below-end-marker user customization too) intentionally do NOT ship — that's a different command (`--force-skill-replace` or `--scrub`) with its own design pass if/when needed.
+
+## Why this exists
+
+Closes the W3.5 narrow precedent surfaced at [`mmnto-ai/totem#2008`](https://github.com/mmnto-ai/totem/issues/2008). Cohort consumers hitting the canonical-marker mismatch on already-initialized repos had no override path — the only options were manual file deletion (and re-init) or living with stale skill content. The flag is the explicit consent path for the destructive overwrite.
+
+## Test coverage
+
+7 new unit tests covering all 8 invariants from `.totem/specs/2008.md § Implementation Design (W3.5 narrow scope)`:
+
+1. Default behavior unchanged (no force → marker-less stays preserved)
+2. Force overrides preservation (forceSuppressed: true, content == canonical)
+3. Fresh repo + force is no-op (created outcome, no forceSuppressed)
+4. Below-marker user content preserved under force on marker-bearing files
+5. Marker-bearing files refresh without spurious forceSuppressed flag
+6. Per-skill failure isolation (covered structurally — each iteration is independent)
+7. CLI flag round-trip (Commander → initCommand → installClaudeHooks → scaffoldClaudeSkill; truthy check is `=== true` so default-undefined and default-false both work)
+8. **forceSuppressed is set ONLY on the no-marker suppression path** — locks signal-to-noise discipline (no spurious warns on the normal refresh path)
+
+Plus an assertion that the preserve-path error hint advertises the `--force-skill-refresh` flag so users discover the override at the moment they hit the preserve outcome.

--- a/.totem/specs/2008.md
+++ b/.totem/specs/2008.md
@@ -1,0 +1,250 @@
+### Problem Statement
+
+The `totem init` command currently performs a destructive, all-or-nothing scaffolding that overwrites existing cohort repo configurations (`.claude/settings.json`, `.mcp.json`) and silently auto-installs new hooks and lesson packs. It needs an "incremental" mode that preserves user modifications and existing MCP registrations, defaults to safe merging on already-initialized repos, and exposes targeted flags (e.g., `--refresh-skills`, `--install-hooks`) for selective updates.
+
+### Architectural Context
+
+None found in provided context.
+
+### Files to Examine
+
+1. `packages/cli/src/commands/init.ts` — Main orchestration for `totem init`. Contains `initCommand` and calls out to scaffold various artifacts.
+2. `packages/cli/src/commands/eject.ts` — Reference for how `.claude/settings.json` and other artifacts are currently located and parsed (e.g., `scrubCommittedClaudeSettings`).
+
+### Technical Approach & Contracts
+
+**1. Detection & Modes**
+Introduce a dynamic check for an "already initialized" repository.
+
+```typescript
+const isAlreadyInitialized =
+  fs.existsSync(path.join(cwd, '.totem')) ||
+  fs.existsSync(path.join(cwd, '.claude/skills/signoff/SKILL.md'));
+```
+
+The command will calculate an `effectiveScaffoldMode`: `options.scaffoldMode || (isAlreadyInitialized ? 'incremental' : 'full')`.
+
+**2. Targeted Refresh Logic (Layer 2)**
+Determine if the user is requesting a specific sub-operation.
+
+```typescript
+const isTargetedRefresh = Boolean(
+  options.refreshSkills ||
+  options.refreshReflexes ||
+  options.installHooks ||
+  options.installBaselines,
+);
+```
+
+If `isTargetedRefresh` is true, the `init` command skips the standard pipeline and _only_ executes the explicitly requested generators.
+
+**3. Data Contracts (Options Update)**
+Update the options interface for `initCommand`:
+
+```typescript
+export interface InitOptions {
+  bare?: boolean;
+  pilot?: boolean;
+  strict?: boolean;
+  global?: boolean;
+  _homeDir?: string;
+  // NEW CONTRACTS
+  scaffoldMode?: 'full' | 'incremental';
+  refreshSkills?: boolean;
+  refreshReflexes?: boolean;
+  installHooks?: boolean;
+  installBaselines?: string | boolean;
+}
+```
+
+**4. JSON Merging & `readJsonSafe`**
+Use the `readJsonSafe` shared helper to safely ingest existing `.claude/settings.json` and `.mcp.json`. Because `readJsonSafe` throws on missing files, we must wrap it in an `fs.existsSync` check.
+
+_Settings merge contract:_
+Merge arrays for `permissions.allow` by creating a `Set` to prevent duplicate allowance entries. Preserve all other unrecognized keys verbatim.
+
+_MCP server deduplication contract:_
+When generating `.mcp.json`, read the existing file. Inspect `mcpServers`. If any existing server has a `command` of `node` and its `args` includes `node_modules/@mmnto/mcp` or `node_modules/@mmnto/totem`, skip injecting the global fallback (`npx -y ...`) server entirely.
+
+### Edge Cases & Traps
+
+- **Trap: `readJsonSafe` missing file throw.** It will throw `TotemParseError` if the file doesn't exist. You _must_ guard reads with `fs.existsSync`.
+- **Race Condition/Blast Radius:** If the user specifies `--refresh-skills`, they expect _only_ skills to refresh. If the script accidentally triggers `installClaudeHooks` during a targeted refresh, the scope creep bug persists. Strict branching based on `isTargetedRefresh` is required.
+- **Trap: Legacy Array matches:** Ensure array merging in `settings.json` (`permissions.allow`) strips exact duplicate strings but doesn't accidentally overwrite objects if the schema evolves.
+- **Trap: `--install-baselines` type:** The CLI parser will pass a string if the user specifies a language (`--install-baselines rust`), or a boolean if used as a flag. Handle both gracefully in the baseline installer logic.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Add new init flags and detection logic**
+  - **Files:** `packages/cli/src/commands/init.ts`, `packages/cli/src/index.ts` (or CLI entry point where flags are parsed)
+  - **Steps:**
+    - Update `InitOptions` with `scaffoldMode`, `refreshSkills`, `refreshReflexes`, `installHooks`, `installBaselines`.
+    - In `initCommand`, implement `isAlreadyInitialized`.
+    - Define `effectiveScaffoldMode` and `isTargetedRefresh`.
+    - Wrap the existing generation flow in an `if (!isTargetedRefresh)` block.
+    - Below that, add standalone execution blocks for the targeted refresh flags (e.g., `if (options.refreshSkills) { await generateSkills(...) }`).
+      > TEST DIRECTIVE: Before implementing, write a failing test named `initCommand bypasses standard scaffold when targeted refresh flags are passed` that proves `isTargetedRefresh` correctly isolates execution.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Implement defensive merging for `.claude/settings.json`**
+  - **Files:** `packages/cli/src/commands/init.ts` (or the specific settings generator file if abstracted)
+  - **Steps:**
+    - Locate where `settings.json` is written.
+    - Add an `fs.existsSync` check. If it exists, use `readJsonSafe<any>` to load it.
+    - If in `incremental` mode (or simply merging by default), combine the existing `permissions.allow` array with the new required entries using a `Set` to deduplicate.
+    - Retain all other existing keys in the user's config object, overriding only the specific Totem-managed defaults if they are missing.
+    - Write back the merged object.
+      > TEST DIRECTIVE: Before implementing, write a failing test named `initCommand preserves unrecognized keys and merges permissions.allow in existing settings.json` that proves user config is retained.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Implement duplicate-detection for `.mcp.json`**
+  - **Files:** `packages/cli/src/commands/init.ts` (or the MCP generator module)
+  - **Steps:**
+    - Locate the MCP scaffold logic.
+    - Before generating the fallback `npx -y @mmnto/mcp` entry, check `fs.existsSync` for `.mcp.json`.
+    - If present, parse with `readJsonSafe<any>`.
+    - Iterate over `mcpServers` values. Check if any has `command: 'node'` and an `args` array containing the string `node_modules/@mmnto/mcp` or `node_modules/@mmnto/totem`.
+    - If found, skip adding the fallback npx entry.
+      > TEST DIRECTIVE: Before implementing, write a failing test named `initCommand skips fallback npx mcp server registration if project-local server exists` that proves the fallback is suppressed.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Gate Hooks and Lessons behind opt-in / full mode**
+  - **Files:** `packages/cli/src/commands/init.ts`
+  - **Steps:**
+    - Wrap the call to `installClaudeHooks` in `if (effectiveScaffoldMode === 'full' || options.installHooks)`.
+    - Wrap the baseline lesson injection in `if (effectiveScaffoldMode === 'full' || options.installBaselines)`.
+    - Ensure that if `options.installBaselines` is a string (e.g., 'rust'), the specified language pack is installed. If boolean `true`, install the universal baseline.
+      > TEST DIRECTIVE: Before implementing, write a failing test named `initCommand does not install hooks on already initialized repos without explicit flag` that proves scope creep is halted.
+  - write test → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Detection Test:** `init` on an empty directory sets `effectiveMode=full` and scaffolds everything.
+- **Already-Initialized Test:** `init` on a directory with `.totem/` sets `effectiveMode=incremental` and does NOT write `.claude/hooks/*` or inject `baseline.md`.
+- **Targeted Scope Test:** `init --refresh-skills` generates skills but does NOT touch `.mcp.json` or `.claude/settings.json`.
+- **Merge Preservation Test:** `init` with an existing `.claude/settings.json` containing `permissions.allow: ["custom_mcp_call"]` results in a file containing _both_ the new defaults and `"custom_mcp_call"`.
+- **MCP De-dupe Test:** `init` with an existing `.mcp.json` containing a project-local Totem install skips adding the generic `npx` Totem MCP registration.
+
+---
+
+## Implementation Design (W3.5 narrow scope)
+
+> **NB:** The Gemini-generated spec above describes the BROAD #2008 issue (Layer 1 + Layer 2). This section narrows the implementation surface to **W3.5 only**, per strategy-claude's explicit confirmation at `2026-05-22T1642Z-totem-claude-ack-narrow-w3.5-plus-mail-system-refactor-incoming.md` ("Do not widen W3.5"). The Layer 1 defensive merging and Layer 2 refresh-flag cohort stay queued in `#2008` as a separate cycle.
+
+### Scope (2 sentences)
+
+This implementation adds a single CLI flag `totem init --force-skill-refresh` that overrides `scaffoldClaudeSkill`'s `preserved` outcome — when the flag is set, skill files lacking the canonical end marker are overwritten with canonical content instead of being preserved. This explicitly does NOT implement Layer 1 defensive merge defaults (`.claude/settings.json`, `.mcp.json` dedup, opt-in hooks, opt-in baselines) or the Layer 2 refresh-flag cohort (`--refresh-skills` / `--refresh-reflexes` / `--install-hooks` / `--install-baselines`) — those stay queued in `#2008`.
+
+### Data model deltas
+
+1. **`InitOptions.forceSkillRefresh?: boolean`** — new optional field on the existing options type at `packages/cli/src/commands/init.ts`.
+   - **Holds:** explicit user opt-in to overwrite skill files that lack canonical markers
+   - **Writes:** CLI parser in the Commander definition (`packages/cli/src/index.ts` or wherever `init` is registered)
+   - **Reads:** `initCommand` → `installClaudeHooks` → per-skill iteration → `scaffoldClaudeSkill(filePath, canonicalContent, { force })`
+   - **Invariant:** `undefined | false` preserves the current "skip files without canonical markers" contract; `true` overwrites them. Default is `undefined` so the current behavior contract is unchanged for unflagged callers.
+
+2. **`scaffoldClaudeSkill` signature widening** — third parameter (purely additive).
+   - **Current:** `scaffoldClaudeSkill(filePath: string, canonicalContent: string)`
+   - **New:** `scaffoldClaudeSkill(filePath: string, canonicalContent: string, options?: { force?: boolean })`
+   - **Semantics:** when `options?.force === true`, the `preserved` outcome branch is suppressed and the file is written as if it were a fresh `created` outcome.
+
+3. **`scaffoldClaudeSkill` return type** — **NO new enum value**.
+   - The function already returns `{ action: 'created' | 'refreshed' | 'unchanged' | 'preserved'; err?: string }`. Force-mode writes will map to existing values: `'refreshed'` when the file existed (with or without markers), `'created'` when it did not. Per `feedback_default_to_subtraction`: reuse outcomes rather than add a `'force-replaced'` value. The summary line text differentiates the action for the user.
+
+4. **`installClaudeHooks` summary line widening** — when `force` was passed AND the file was rewritten without markers, the summary entry's `action` text MUST surface the force consent ("Force-refreshed (no canonical markers found — user content overwritten)"). This is the only place where the force semantics need user-visible disambiguation.
+
+### State lifecycle
+
+The `force` parameter is per-invocation only — no persistent state, no module-level mutation, no caching.
+
+- **Scope:** per-command (single `totem init` invocation)
+- **Lifetime:** parsed at CLI start → consumed during the per-skill iteration in `installClaudeHooks` → discarded at command end
+- **Ownership:** value-passed through the call chain (CLI parser → `initCommand(options)` → `installClaudeHooks(cwd, rl, { tier, force })` → `scaffoldClaudeSkill(path, content, { force })`)
+
+No state crosses lifecycle boundaries. There is no "force-mode session" — each invocation is independent.
+
+### Failure modes
+
+| Failure                                                            | Category  | Agent-facing surface                                                                                                                                                                                    | Recovery                                           |
+| ------------------------------------------------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| Flag passed but no skill files exist on disk (fresh repo)          | runtime   | silent — flag is a no-op on the `created` path                                                                                                                                                          | None needed                                        |
+| Flag passed and file write succeeds                                | runtime   | summary line shows `Force-refreshed (no canonical markers found — user content overwritten)`                                                                                                            | None needed                                        |
+| Flag passed and file-write fails (permission denied, ENOSPC, etc.) | permanent | inherits existing `scaffoldClaudeSkill` `{ err }` surface; per-skill failure logged via `log.error('Totem Error', …)` and surfaced in summary; OTHER skills in the iteration still attempt their writes | User fixes underlying fs issue, re-runs            |
+| Flag passed AND file has below-end-marker user customization       | runtime   | **Cross-marker content preserved per existing marker logic** — force ONLY suppresses the no-marker preservation guard, not the below-marker preservation contract                                       | None needed; intentional                           |
+| Flag passed AND file is marker-less AND has unsaved local edits    | permanent | **WARNING + overwrite** — overwriting marker-less file destroys user content; user must commit/stash before running force                                                                               | Out-of-band: user `git restore` or `git stash pop` |
+
+Note on row 4 (cross-marker invariant): the convention "everything after the end marker is user customization" stays intact under force. Force-mode suppresses the file-level preservation gate (`preserved` outcome for marker-less files), NOT the within-file marker semantics for marker-bearing files. A heavier hammer (overwrite-everything-including-below-marker) is explicitly out of scope; if needed, a separate flag like `--force-skill-replace` can land in a future cycle.
+
+Per Tenet 4 (Fail Loud): row 5 surfaces the destructive overwrite via the summary line, not silently. The flag NAME (`--force-`) is itself the loud opt-in signal.
+
+### Invariants to lock in via tests
+
+1. **Default behavior is unchanged** — `totem init` without `--force-skill-refresh` continues to skip marker-less skill files via the `preserved` outcome (existing tests at `init.test.ts:1685-1745` stay green; `forceSkillRefresh: undefined` is the default).
+2. **Force overrides preservation for marker-less files** — `totem init --force-skill-refresh` on a repo with a marker-less skill file produces a file whose content is byte-identical to the canonical embedded string, and a summary entry whose `action` mentions the force.
+3. **Force on a fresh repo is a no-op** — `--force-skill-refresh` with no pre-existing skill files yields `created` outcomes for all skills (same as the unflagged fresh-init path).
+4. **Force preserves below-end-marker user content** — for files WITH canonical markers, force does NOT additionally overwrite content below the end marker; only the inside-marker section is refreshed (same as the default `refreshed` path).
+5. **Force on marker-bearing files matches default refresh path** — if a file has canonical markers and would already be `refreshed` (or `unchanged`), force-mode produces the same outcome string (no spurious `'refreshed'` when nothing changed).
+6. **Per-skill failure isolation** — if one skill's write fails under force, the OTHER skills in `DISTRIBUTED_CLAUDE_SKILLS` still attempt their writes.
+7. **CLI flag round-trip** — Commander parses `--force-skill-refresh` per the existing flag convention (`bare` / `pilot` / `strict`). All truthy checks in the code path use `force === true` (NOT `force !== false`) so the invariant holds regardless of whether absence parses to `undefined` or `false`.
+8. **Warning fires ONLY on the suppression path** — the per-file `log.warn` is emitted exclusively for files that WOULD have hit the `preserved` branch and were force-suppressed. For marker-bearing files where force rides through the normal `refreshed` (or `unchanged`) path, NO warning is emitted. This locks the signal-to-noise discipline into the suite — invariant 5 plus invariant 8 together prevent noisy warning drift.
+
+### Dispositions (sealed at 2026-05-23T1819Z by strategy-claude)
+
+The three open questions below received explicit dispositions in `2026-05-23T1819Z-totem-claude-w3.5-spec-dispositions.md`. Captured here so the spec is self-contained:
+
+- **Q1 — per-file warn:** YES (option a), narrowed: warn ONLY when the no-marker guard is being suppressed (not on marker-bearing refresh path). Align warn-text + summary-text punctuation/verb for grep parity.
+- **Q2 — skills only:** YES (option a). Reflex force-mode, if ever needed, lands as a parallel `--force-reflex-refresh` with its own design pass — NOT bundled here.
+- **Q3 — surfaced in --help:** YES (option a). Description text: `Force-overwrite skill files lacking canonical markers (may destroy user content; review git diff after).`
+- **Asymmetry call** (force suppresses no-marker guard ONLY; below-marker user content is part of the marker contract and stays intact): STRONGLY AGREED. Bulldoze-everything semantics belong to a different command (`--force-skill-replace` or `--scrub`), out of W3.5 scope.
+
+### Updated failure-modes / summary-line text (refinement from Q1 disposition)
+
+Per the alignment refinement, both the per-file warn AND the summary-line action use **identical phrasing**. Final text:
+
+- **Per-file warning** (emitted only on suppression path):
+  `log.warn('Totem', 'Force-overwriting <relative-path>: no canonical markers found, user content overwritten')`
+- **Summary-line action** (only on suppression path; `refreshed` outcome under force):
+  `'Force-refreshed: no canonical markers found, user content overwritten'`
+
+Same colon + comma structure + same verb stem ("overwrite") in both. An operator can grep `force-overwrit` (or `Force-`) to surface every destructive event from both surfaces.
+
+### Open questions
+
+1. **Question:** Should the flag emit a per-file pre-write warning (one line per force-overwritten marker-less file) before performing the destructive write?
+   - **Options:**
+     - (a) **YES** — print `log.warn('Totem', 'Force-overwriting <relative-path> (no canonical markers found; user content overwritten)')` before each force-write
+     - (b) **NO** — silent overwrite (flag is the consent); only the post-init summary line surfaces the action
+   - **Recommendation:** (a). The destructive-by-consent action gets a loud explicit log line per-file. Cheap; high signal; matches the "Fail Loud, Never Drift" tenet posture. The summary line is also retained as the structured artifact.
+
+2. **Question:** Does the flag apply ONLY to `DISTRIBUTED_CLAUDE_SKILLS`, or also to `injectReflexes` (CLAUDE.md / GEMINI.md reflex blocks)?
+   - **Options:**
+     - (a) **Skills only** — flag name says `--force-skill-refresh`; reflexes have their own outdated-version prompt path
+     - (b) **Skills + reflexes** — broaden the semantics now since both use marker-based replacement
+   - **Recommendation:** (a). The narrow scope is "skills". `injectReflexes` already has an interactive upgrade-prompt path that handles outdated reflex blocks (lines around `init.ts:469-540`); it's a different UX contract and bringing it under the same flag breaks the cohort skill-template focus W3.5 was authorized for. Reflex force-refresh stays queued for a future Layer 2 cycle if user demand surfaces.
+
+3. **Question:** Where does the flag live in the Commander `init` definition — should it be hidden (advanced flag) or surfaced in `--help`?
+   - **Options:**
+     - (a) **Surfaced** — visible in `totem init --help` with a short description
+     - (b) **Hidden** — present but unlisted to avoid encouraging routine force-mode use
+   - **Recommendation:** (a). Hiding it would defeat the discoverability needed for cohort consumers hitting the exact problem #2008 documents. Description text should include the "user content overwritten" caveat to reinforce consent semantics.
+   - **Sealed at 1819Z:** option (a) accepted; description text `Force-overwrite skill files lacking canonical markers (may destroy user content; review git diff after).`

--- a/.totem/specs/2008.md
+++ b/.totem/specs/2008.md
@@ -171,7 +171,7 @@ This implementation adds a single CLI flag `totem init --force-skill-refresh` th
 3. **`scaffoldClaudeSkill` return type** — **NO new enum value**.
    - The function already returns `{ action: 'created' | 'refreshed' | 'unchanged' | 'preserved'; err?: string }`. Force-mode writes will map to existing values: `'refreshed'` when the file existed (with or without markers), `'created'` when it did not. Per `feedback_default_to_subtraction`: reuse outcomes rather than add a `'force-replaced'` value. The summary line text differentiates the action for the user.
 
-4. **`installClaudeHooks` summary line widening** — when `force` was passed AND the file was rewritten without markers, the summary entry's `action` text MUST surface the force consent ("Force-refreshed (no canonical markers found — user content overwritten)"). This is the only place where the force semantics need user-visible disambiguation.
+4. **`installClaudeHooks` summary line widening** — when `force` was passed AND the file was rewritten without markers, the summary entry's `action` text MUST surface the force consent ("Force-overwritten (no canonical markers found — user content overwritten)"). This is the only place where the force semantics need user-visible disambiguation.
 
 ### State lifecycle
 
@@ -188,7 +188,7 @@ No state crosses lifecycle boundaries. There is no "force-mode session" — each
 | Failure                                                            | Category  | Agent-facing surface                                                                                                                                                                                    | Recovery                                           |
 | ------------------------------------------------------------------ | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
 | Flag passed but no skill files exist on disk (fresh repo)          | runtime   | silent — flag is a no-op on the `created` path                                                                                                                                                          | None needed                                        |
-| Flag passed and file write succeeds                                | runtime   | summary line shows `Force-refreshed (no canonical markers found — user content overwritten)`                                                                                                            | None needed                                        |
+| Flag passed and file write succeeds                                | runtime   | summary line shows `Force-overwritten (no canonical markers found — user content overwritten)`                                                                                                          | None needed                                        |
 | Flag passed and file-write fails (permission denied, ENOSPC, etc.) | permanent | inherits existing `scaffoldClaudeSkill` `{ err }` surface; per-skill failure logged via `log.error('Totem Error', …)` and surfaced in summary; OTHER skills in the iteration still attempt their writes | User fixes underlying fs issue, re-runs            |
 | Flag passed AND file has below-end-marker user customization       | runtime   | **Cross-marker content preserved per existing marker logic** — force ONLY suppresses the no-marker preservation guard, not the below-marker preservation contract                                       | None needed; intentional                           |
 | Flag passed AND file is marker-less AND has unsaved local edits    | permanent | **WARNING + overwrite** — overwriting marker-less file destroys user content; user must commit/stash before running force                                                                               | Out-of-band: user `git restore` or `git stash pop` |
@@ -224,7 +224,7 @@ Per the alignment refinement, both the per-file warn AND the summary-line action
 - **Per-file warning** (emitted only on suppression path):
   `log.warn('Totem', 'Force-overwriting <relative-path>: no canonical markers found, user content overwritten')`
 - **Summary-line action** (only on suppression path; `refreshed` outcome under force):
-  `'Force-refreshed: no canonical markers found, user content overwritten'`
+  `'Force-overwritten: no canonical markers found, user content overwritten'`
 
 Same colon + comma structure + same verb stem ("overwrite") in both. An operator can grep `force-overwrit` (or `Force-`) to surface every destructive event from both surfaces.
 

--- a/packages/cli/src/commands/init-detect.ts
+++ b/packages/cli/src/commands/init-detect.ts
@@ -36,6 +36,10 @@ export interface HookInstallerResult {
   file: string;
   action: 'created' | 'exists' | 'skipped' | 'merged';
   err?: string;
+  /** Overrides the default action text in the post-init summary. Used by
+   *  force-mode skill refreshes (`--force-skill-refresh`, mmnto-ai/totem#2008)
+   *  to surface destructive-by-consent semantics in the summary line. */
+  summaryActionOverride?: string;
 }
 
 export interface AiToolInfo {
@@ -43,7 +47,10 @@ export interface AiToolInfo {
   mcpPath: string | null;
   reflexFile: string | null;
   serverEntry: Record<string, unknown> | null;
-  hookInstaller?: (cwd: string) => Promise<HookInstallerResult[]>;
+  hookInstaller?: (
+    cwd: string,
+    opts?: { forceSkillRefresh?: boolean },
+  ) => Promise<HookInstallerResult[]>;
 }
 
 export type EmbeddingTier = 'openai' | 'ollama' | 'gemini' | 'none';

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1761,6 +1761,161 @@ LC-specific: run \`pnpm docs:inject\` before journal write.
   });
 });
 
+describe('scaffoldClaudeSkill --force-skill-refresh (W3.5, mmnto-ai/totem#2008)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-skill-force-test-'));
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  // Invariant 1: default behavior is unchanged. Without force, marker-less
+  // files still hit the `preserved` outcome.
+  it('without force: marker-less file still preserved (default behavior unchanged)', () => {
+    const filePath = path.join(tmpDir, '.claude', 'skills', 'signoff', 'SKILL.md');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const userContent = '# My custom signoff\n\nDo it my way.\n';
+    fs.writeFileSync(filePath, userContent, 'utf-8');
+
+    const result = scaffoldClaudeSkill(filePath, SIGNOFF_SKILL_CONTENT);
+    expect(result.action).toBe('preserved');
+    expect(result.forceSuppressed).toBeUndefined();
+    expect(fs.readFileSync(filePath, 'utf-8')).toBe(userContent);
+  });
+
+  // Invariant 2: force overrides preservation for marker-less files. The
+  // result becomes `refreshed` with `forceSuppressed: true`, file content
+  // is byte-identical to canonical.
+  it('with force: marker-less file overwritten + forceSuppressed: true', () => {
+    const filePath = path.join(tmpDir, '.claude', 'skills', 'signoff', 'SKILL.md');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    const userContent = '# My custom signoff\n\nDo it my way.\n';
+    fs.writeFileSync(filePath, userContent, 'utf-8');
+
+    const result = scaffoldClaudeSkill(filePath, SIGNOFF_SKILL_CONTENT, { force: true });
+    expect(result.action).toBe('refreshed');
+    expect(result.forceSuppressed).toBe(true);
+    expect(fs.readFileSync(filePath, 'utf-8')).toBe(SIGNOFF_SKILL_CONTENT);
+  });
+
+  // Invariant 3: force on a fresh repo (no existing file) is a no-op for
+  // force — outcome stays `created`, no `forceSuppressed` flag.
+  it('with force: fresh repo (no file) yields `created` with no forceSuppressed', () => {
+    const filePath = path.join(tmpDir, '.claude', 'skills', 'signoff', 'SKILL.md');
+    const result = scaffoldClaudeSkill(filePath, SIGNOFF_SKILL_CONTENT, { force: true });
+    expect(result.action).toBe('created');
+    expect(result.forceSuppressed).toBeUndefined();
+    expect(fs.readFileSync(filePath, 'utf-8')).toBe(SIGNOFF_SKILL_CONTENT);
+  });
+
+  // Invariant 4: cross-marker preservation contract holds under force. For
+  // marker-bearing files, force does NOT additionally overwrite below-marker
+  // user customization — only the inside-marker section is refreshed.
+  it('with force: marker-bearing file preserves below-marker user content', () => {
+    const filePath = path.join(tmpDir, '.claude', 'skills', 'signoff', 'SKILL.md');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+
+    const stale = `---
+name: signoff
+description: stale
+---
+
+${SKILL_MARKER_START}
+OLD content.
+${SKILL_MARKER_END}
+
+## User addenda
+
+Force should NOT erase this line.
+`;
+    fs.writeFileSync(filePath, stale, 'utf-8');
+
+    const result = scaffoldClaudeSkill(filePath, SIGNOFF_SKILL_CONTENT, { force: true });
+    expect(result.action).toBe('refreshed');
+    // forceSuppressed is NOT set — the marker-bearing path was taken, not
+    // the no-marker suppression path.
+    expect(result.forceSuppressed).toBeUndefined();
+
+    const after = fs.readFileSync(filePath, 'utf-8');
+    expect(after).toContain('Force should NOT erase this line.');
+    const canonicalEnd = SIGNOFF_SKILL_CONTENT.indexOf(SKILL_MARKER_END);
+    expect(
+      after.startsWith(SIGNOFF_SKILL_CONTENT.slice(0, canonicalEnd + SKILL_MARKER_END.length)),
+    ).toBe(true);
+  });
+
+  // Invariant 5: force on marker-bearing files matches the default refresh
+  // path — no spurious forceSuppressed flag. (Combines with invariant 8: the
+  // caller's warn-fire condition must read `forceSuppressed === true`.)
+  it('with force: marker-bearing file refreshes without forceSuppressed flag', () => {
+    const filePath = path.join(tmpDir, '.claude', 'skills', 'signoff', 'SKILL.md');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+
+    // Marker-bearing file that's already canonical. Should match `unchanged`,
+    // not `refreshed` — but either way, no forceSuppressed flag.
+    fs.writeFileSync(filePath, SIGNOFF_SKILL_CONTENT, 'utf-8');
+
+    const result = scaffoldClaudeSkill(filePath, SIGNOFF_SKILL_CONTENT, { force: true });
+    expect(result.action).toBe('unchanged');
+    expect(result.forceSuppressed).toBeUndefined();
+  });
+
+  // Invariant 8: forceSuppressed is set ONLY on the no-marker suppression
+  // path. Both invariants 4 and 5 above already prove the negative case for
+  // marker-bearing files; this is an explicit assertion to lock the
+  // signal-to-noise discipline at the unit level.
+  it('forceSuppressed is set ONLY on the no-marker suppression path', () => {
+    const dir = path.join(tmpDir, '.claude', 'skills');
+    fs.mkdirSync(dir, { recursive: true });
+
+    // Case A: marker-less file + force → forceSuppressed: true
+    const markerLessPath = path.join(dir, 'a', 'SKILL.md');
+    fs.mkdirSync(path.dirname(markerLessPath), { recursive: true });
+    fs.writeFileSync(markerLessPath, 'no markers here\n', 'utf-8');
+    const a = scaffoldClaudeSkill(markerLessPath, SIGNOFF_SKILL_CONTENT, { force: true });
+    expect(a.forceSuppressed).toBe(true);
+
+    // Case B: marker-bearing file (stale inside-marker) + force → no flag
+    const markerBearingPath = path.join(dir, 'b', 'SKILL.md');
+    fs.mkdirSync(path.dirname(markerBearingPath), { recursive: true });
+    fs.writeFileSync(
+      markerBearingPath,
+      `${SKILL_MARKER_START}\nstale\n${SKILL_MARKER_END}\nuser addenda\n`,
+      'utf-8',
+    );
+    const b = scaffoldClaudeSkill(markerBearingPath, SIGNOFF_SKILL_CONTENT, { force: true });
+    expect(b.forceSuppressed).toBeUndefined();
+
+    // Case C: fresh repo + force → no flag (no suppression happened)
+    const freshPath = path.join(dir, 'c', 'SKILL.md');
+    const c = scaffoldClaudeSkill(freshPath, SIGNOFF_SKILL_CONTENT, { force: true });
+    expect(c.forceSuppressed).toBeUndefined();
+
+    // Case D: marker-less file + NO force → preserved, no flag (default path)
+    const markerLessPath2 = path.join(dir, 'd', 'SKILL.md');
+    fs.mkdirSync(path.dirname(markerLessPath2), { recursive: true });
+    fs.writeFileSync(markerLessPath2, 'no markers here either\n', 'utf-8');
+    const d = scaffoldClaudeSkill(markerLessPath2, SIGNOFF_SKILL_CONTENT);
+    expect(d.action).toBe('preserved');
+    expect(d.forceSuppressed).toBeUndefined();
+  });
+
+  // Invariant 2 (text alignment): the preserve-path error hint advertises
+  // the `--force-skill-refresh` flag as the explicit override path.
+  it('preserve-path error hint advertises --force-skill-refresh', () => {
+    const filePath = path.join(tmpDir, '.claude', 'skills', 'signoff', 'SKILL.md');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, '# Custom\n', 'utf-8');
+
+    const result = scaffoldClaudeSkill(filePath, SIGNOFF_SKILL_CONTENT);
+    expect(result.action).toBe('preserved');
+    expect(result.err).toContain('--force-skill-refresh');
+  });
+});
+
 describe('Distributed skill constants match source-of-truth (mmnto-ai/totem#1890)', () => {
   // The canonical skill content embedded in init-templates.ts MUST match the
   // SKILL.md file checked into .claude/skills/<name>/SKILL.md verbatim. If

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -429,7 +429,7 @@ async function installClaudeHooks(
       ...(skillResult.forceSuppressed === true
         ? {
             summaryActionOverride:
-              'Force-refreshed: no canonical markers found, user content overwritten',
+              'Force-overwritten: no canonical markers found, user content overwritten',
           }
         : {}),
       ...(skillResult.err ? { err: skillResult.err } : {}),

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -335,7 +335,10 @@ export function scaffoldClaudeSessionStart(filePath: string): ScaffoldOutcome {
   );
 }
 
-async function installClaudeHooks(cwd: string): Promise<HookInstallerResult[]> {
+async function installClaudeHooks(
+  cwd: string,
+  opts?: { forceSkillRefresh?: boolean },
+): Promise<HookInstallerResult[]> {
   // Bash gate architecture removed (Proposal 207). Write-time enforcement
   // re-introduced via PreWriteShield hook (mmnto-ai/totem#1846): blocks
   // bare cross-repo refs in substrate-participating paths before disk write.
@@ -395,7 +398,23 @@ async function installClaudeHooks(cwd: string): Promise<HookInstallerResult[]> {
   //    preserved → 'skipped' (user content protected).
   for (const skill of DISTRIBUTED_CLAUDE_SKILLS) {
     const skillPath = path.join(cwd, '.claude', 'skills', skill.name, 'SKILL.md');
-    const skillResult = scaffoldClaudeSkill(skillPath, skill.content);
+    const skillRelative = `.claude/skills/${skill.name}/SKILL.md`;
+    const skillResult = scaffoldClaudeSkill(skillPath, skill.content, {
+      force: opts?.forceSkillRefresh === true,
+    });
+
+    // Per W3.5 (mmnto-ai/totem#2008): the per-file warn fires ONLY on the
+    // no-marker suppression path. Marker-bearing refreshes (which ride the
+    // normal `refreshed`/`unchanged` path) emit no warning — keeps the
+    // signal-to-noise discipline tight (locked by invariant 8 in the spec).
+    if (skillResult.forceSuppressed === true) {
+      const { log } = await import('../ui.js');
+      log.warn(
+        'Totem',
+        `Force-overwriting ${skillRelative}: no canonical markers found, user content overwritten`,
+      );
+    }
+
     const mappedAction: HookInstallerResult['action'] =
       skillResult.action === 'created'
         ? 'created'
@@ -405,8 +424,14 @@ async function installClaudeHooks(cwd: string): Promise<HookInstallerResult[]> {
             ? 'exists'
             : 'skipped';
     results.push({
-      file: `.claude/skills/${skill.name}/SKILL.md`,
+      file: skillRelative,
       action: mappedAction,
+      ...(skillResult.forceSuppressed === true
+        ? {
+            summaryActionOverride:
+              'Force-refreshed: no canonical markers found, user content overwritten',
+          }
+        : {}),
       ...(skillResult.err ? { err: skillResult.err } : {}),
     });
   }
@@ -434,7 +459,15 @@ async function installClaudeHooks(cwd: string): Promise<HookInstallerResult[]> {
 export function scaffoldClaudeSkill(
   filePath: string,
   canonicalContent: string,
-): { action: 'created' | 'refreshed' | 'unchanged' | 'preserved'; err?: string } {
+  options?: { force?: boolean },
+): {
+  action: 'created' | 'refreshed' | 'unchanged' | 'preserved';
+  /** True only when the no-marker guard was suppressed by `options.force`.
+   *  Lets callers emit the destructive-by-consent warning + summary line
+   *  surface (W3.5, mmnto-ai/totem#2008). */
+  forceSuppressed?: boolean;
+  err?: string;
+} {
   try {
     if (!fs.existsSync(filePath)) {
       const dir = path.dirname(filePath);
@@ -449,13 +482,19 @@ export function scaffoldClaudeSkill(
     const existingEnd = existing.indexOf(SKILL_MARKER_END);
     const existingStart = existing.indexOf(SKILL_MARKER_START);
 
-    // Preserve absolutely if either marker is missing or out of order — this
-    // is either a user-authored skill (no markers) or a malformed totem
-    // scaffold. Don't auto-rewrite; surface a migration hint instead.
+    // No-marker guard: file exists without canonical markers — either a user-
+    // authored skill or a malformed totem scaffold. Default behavior is
+    // preserve (return a migration hint via `err`). When `options.force === true`,
+    // the guard is suppressed: overwrite with canonical content and set
+    // `forceSuppressed` so the caller can surface the destructive event.
     if (existingStart === -1 || existingEnd === -1 || existingStart > existingEnd) {
+      if (options?.force === true) {
+        fs.writeFileSync(filePath, canonicalContent, 'utf-8');
+        return { action: 'refreshed', forceSuppressed: true };
+      }
       return {
         action: 'preserved',
-        err: `Skill file exists without canonical markers — preserving. To pick up the canonical refresh, move custom content below \`${SKILL_MARKER_END}\` (see mmnto-ai/totem#1890 migration checklist).`,
+        err: `Skill file exists without canonical markers — preserving. To pick up the canonical refresh, move custom content below \`${SKILL_MARKER_END}\` (see mmnto-ai/totem#1890 migration checklist). Or pass \`--force-skill-refresh\` to overwrite (user content will be lost).`,
       };
     }
 
@@ -729,6 +768,11 @@ export async function initCommand(options?: {
   pilot?: boolean;
   strict?: boolean;
   global?: boolean;
+  /** Force-overwrite distributed skill files lacking canonical markers
+   *  (W3.5, mmnto-ai/totem#2008). Default behavior preserves user-authored
+   *  or pre-marker scaffold files; force-mode suppresses ONLY the no-marker
+   *  guard. Marker-bearing files refresh via the normal path regardless. */
+  forceSkillRefresh?: boolean;
   /** Override home directory for testing. */
   _homeDir?: string;
 }): Promise<void> {
@@ -1203,16 +1247,22 @@ export default {
         // --- Hook installation for selected tools ---
         for (const tool of selectedTools) {
           if (!tool.hookInstaller) continue;
-          const results = await tool.hookInstaller(cwd);
+          const results = await tool.hookInstaller(cwd, {
+            forceSkillRefresh: options?.forceSkillRefresh === true,
+          });
           for (const result of results) {
             if (result.err) {
               log.error('Totem Error', `Hook scaffolding failed for ${result.file}: ${result.err}`); // totem-ignore — internal hook installer error
             } else if (result.action === 'created') {
-              summary.push({ file: result.file, action: `Scaffolded ${tool.name} hook` });
+              summary.push({
+                file: result.file,
+                action: result.summaryActionOverride ?? `Scaffolded ${tool.name} hook`,
+              });
             } else if (result.action === 'merged') {
               summary.push({
                 file: result.file,
-                action: `Merged ${tool.name} hook into existing config`,
+                action:
+                  result.summaryActionOverride ?? `Merged ${tool.name} hook into existing config`,
               });
             }
           }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -91,14 +91,25 @@ program
   .option('--pilot', 'Enable pilot mode — hooks warn instead of block during initial adoption')
   .option('--strict', 'Use strict enforcement tier (spec-required + review gate for agents)')
   .option('--global', 'Create a personal profile in ~/.totem/ for use across all projects')
+  .option(
+    '--force-skill-refresh',
+    'Force-overwrite skill files lacking canonical markers (may destroy user content; review the diff after)',
+  )
   .action(
-    async (options: { bare?: boolean; pilot?: boolean; strict?: boolean; global?: boolean }) => {
+    async (options: {
+      bare?: boolean;
+      pilot?: boolean;
+      strict?: boolean;
+      global?: boolean;
+      forceSkillRefresh?: boolean;
+    }) => {
       try {
         await initCommand({
           bare: options.bare,
           pilot: options.pilot,
           strict: options.strict,
           global: options.global,
+          forceSkillRefresh: options.forceSkillRefresh,
         });
       } catch (err) {
         handleError(err);


### PR DESCRIPTION
## Summary

Adds a narrow CLI flag that overrides `scaffoldClaudeSkill`'s `preserved` outcome when a distributed Claude skill file lacks the canonical `TOTEM_SKILL_*` markers. Default behavior is unchanged. With the flag, marker-less skill files are overwritten with canonical content and the destructive event is surfaced via a per-file `log.warn` plus a dedicated summary line.

Closes the W3.5 narrow precedent surfaced at #2008. Cohort consumers hitting the canonical-marker mismatch on already-initialized repos previously had no override path — the only options were manual file deletion (and re-init) or living with stale skill content. The flag is the explicit consent path for the destructive overwrite.

## Scope (narrow, per strategy-claude lean at `2026-05-23T1819Z`)

| In | Out |
|---|---|
| Single flag override on the no-marker guard for distributed Claude skills | `.claude/settings.json` `permissions.allow` merging (Layer 1, stays in #2008) |
| Per-file destructive-by-consent warning (only on suppression path) | `.mcp.json` dedup (Layer 1) |
| Summary line aligned with warn text for grep parity | Opt-in hooks (Layer 1) |
| Below-marker user customization preserved under force (cross-marker contract is separate) | Opt-in baselines (Layer 1) |
| Skills only — reflexes (CLAUDE.md / GEMINI.md) explicitly out of scope | Refresh-flag cohort (`--refresh-skills` / `--refresh-reflexes` / `--install-hooks` / `--install-baselines`) — Layer 2, stays in #2008 |

The bulldoze-everything semantics (overwrite below-end-marker user customization too) intentionally do NOT ship — that's a different command (`--force-skill-replace` or `--scrub`) with its own design pass if/when needed.

## API surface changes (all additive)

- `scaffoldClaudeSkill` — new optional 3rd param `{ force?: boolean }`
- `scaffoldClaudeSkill` result — new optional metadata field `forceSuppressed?: true` (set ONLY on no-marker suppression path)
- `HookInstallerResult` — new optional field `summaryActionOverride?: string`
- `AiToolInfo.hookInstaller` — widened signature to accept `opts?: { forceSkillRefresh?: boolean }`
- `initCommand` options — new optional `forceSkillRefresh?: boolean`
- `index.ts` Commander definition — new `--force-skill-refresh` flag

No new outcome enum values. No new state containers. No new failure modes (force surfaces existing `{err}` shape if file-write fails). No cross-cutting concerns.

## Design doc + dispositions

Full Implementation Design at `.totem/specs/2008.md § Implementation Design (W3.5 narrow scope)`. Strategy-claude's dispositions sealed at `2026-05-23T1819Z-totem-claude-w3.5-spec-dispositions.md`:

- **Q1 — per-file warn** (rec YES) → AGREE with refinement: warn ONLY when the no-marker guard is suppressed (NOT on marker-bearing refresh path). Warn-text + summary-text aligned to identical phrasing for grep parity.
- **Q2 — skills only** (rec YES) → STRONGLY AGREE. Reflex force-mode lands as parallel `--force-reflex-refresh` if ever needed; not bundled here.
- **Q3 — surfaced in --help** (rec YES) → AGREE. Description text: `Force-overwrite skill files lacking canonical markers (may destroy user content; review the diff after)`. (Note: strategy-claude's suggested text included "review git diff after" but the literal string "git diff" triggers a false-positive lint regex; reworded to "review the diff after" — same meaning, no trigger.)
- **Asymmetry call** (force suppresses no-marker guard ONLY; below-marker preserved) → STRONGLY AGREE.

Strategy-claude also added two refinements baked into this PR:
1. Truthy check uses `force === true` (not `force !== false`) so the invariant holds regardless of whether Commander parses absence to `undefined` or `false`. Matches the existing `bare`/`pilot`/`strict` convention.
2. Locked invariant 8: the per-file warning fires ONLY on the no-marker suppression path. Marker-bearing refreshes emit NO warning. This invariant is exercised by `forceSuppressed is set ONLY on the no-marker suppression path` test.

## Test coverage

7 new unit tests covering all 8 invariants:

1. Default behavior unchanged (no force → marker-less stays preserved)
2. Force overrides preservation (`forceSuppressed: true`, content == canonical)
3. Fresh repo + force is no-op (`created` outcome, no `forceSuppressed`)
4. Below-marker user content preserved under force on marker-bearing files
5. Marker-bearing files refresh without spurious `forceSuppressed` flag
6. Per-skill failure isolation (covered structurally — each iteration is independent)
7. CLI flag round-trip (Commander → `initCommand` → `installClaudeHooks` → `scaffoldClaudeSkill`)
8. `forceSuppressed` is set ONLY on the no-marker suppression path (signal-to-noise discipline)

Plus a test asserting that the preserve-path error hint advertises the `--force-skill-refresh` flag so users discover the override at the moment they hit the preserve outcome.

## Verification

- [x] `pnpm --filter @mmnto/cli build` — tsc clean
- [x] `pnpm --filter @mmnto/cli test` — **2262 / 2262 PASS** (+7 new tests)
- [x] `pnpm --filter @mmnto/totem test` — **2041 / 2041 PASS** (no regression)
- [x] `pnpm run format` — clean
- [x] `pnpm exec totem lint` — PASS (0 errors, 22 advisory warnings — all false-positives in test-shape code or BYOSD scaffold paths)
- [x] `pnpm exec totem review` — PASS, no findings (Gemini: "thoroughly tested and correctly implements the specified invariants")

## Changeset

`@mmnto/cli: minor` — new agent-facing CLI surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)