### PR TITLE
chore(deps): bump packageManager pnpm@9.15.4 -> pnpm@11.2.2 (W4 cohort dep wave)

### DIFF
--- a/.changeset/cohort-pnpm-11-bump-w4.md
+++ b/.changeset/cohort-pnpm-11-bump-w4.md
@@ -1,0 +1,42 @@
+---
+'@mmnto/cli': patch
+---
+
+chore(deps): bump packageManager pnpm@9.15.4 -> pnpm@11.2.2 (W4 cohort dep wave)
+
+Lifts the repo's `packageManager` field from `pnpm@9.15.4` to `pnpm@11.2.2`, migrates the pnpm 11-canonical settings home from `package.json` to `pnpm-workspace.yaml`, and deletes `.npmrc` (single-line `engine-strict=true` superseded by `engineStrict: true` in workspace config).
+
+## What ships
+
+| Change                          | Before                             | After                                                                                                                 |
+| ------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `package.json` `packageManager` | `pnpm@9.15.4`                      | `pnpm@11.2.2+sha512.<corepack integrity>`                                                                             |
+| `pnpm-workspace.yaml`           | `packages:` only                   | `engineStrict: true` + `strictDepBuilds: true` + `allowBuilds` map + `minimumReleaseAge` + `minimumReleaseAgeExclude` |
+| `.npmrc`                        | `engine-strict=true` (single line) | deleted                                                                                                               |
+| `pnpm-lock.yaml`                | `lockfileVersion: '9.0'`           | `lockfileVersion: '9.0'` (pnpm 11 reads v9 lockfiles natively; no regen forced)                                       |
+
+## pnpm 11 settings home migration
+
+pnpm 11 dropped reading the `pnpm.*` field from `package.json` entirely; the canonical settings home is now `pnpm-workspace.yaml`. The five settings landed in this PR:
+
+- `engineStrict: true` — migrated from `.npmrc engine-strict=true`. Fails workspace install when active Node doesn't satisfy `engines.node` (W3 cohort constraint at `>=24`).
+- `strictDepBuilds: true` — pnpm 11 default; fails install on unapproved transitive `postinstall`/`install` scripts. Companion to `allowBuilds`.
+- `allowBuilds` — map of approved transitive packages that may run install/build scripts. Six packages enumerated (ast-grep/lang-rust, es5-ext, esbuild, protobufjs, tree-sitter-javascript, tree-sitter-typescript). Source: empirical CI iteration enumerated the eight version-pinned variants needing approval; collapsed to six name-keyed entries per pnpm docs' canonical form.
+- `minimumReleaseAge: 1d` — pnpm 11 default; blocks install of packages published less than 24h ago for supply-chain hygiene against immediate-publish attacks.
+- `minimumReleaseAgeExclude: ['@mmnto/*']` — cohort carve-out. Cohort packages publish-then-install in the same CI window by design; the 1d hygiene gate breaks that loop for `@mmnto/*` but stays in force for all third-party transitive deps.
+
+## Workflow surface unchanged
+
+All 7 workflows (`ci`, `ci-integration`, `compile-manifest`, `lint`, `release`, `release-binary`, `totem-doctor`) remain on `pnpm/action-setup@v5` with no `version:` input — pnpm version is inferred from `packageManager`. The `pnpm/action-setup@v6` line has open inference bugs (`pnpm/action-setup#225`, `#227`) that would have forced an explicit `version: 11.2.2` pin; staying on `@v5` keeps the inference path clean and `packageManager` as the single source of truth.
+
+## Cross-stream coordination
+
+pnpm 11 reads pnpm 9-generated lockfiles cleanly (forward direction; verified empirically). The reverse direction — pnpm 9 reading a pnpm 11-regenerated lockfile — is the cross-stream consumer risk for cohort dependents (liquid-city, totem-status, arhgap11). At merge time a cohort heads-up dispatches the lockfile-format constraint so dependents can bump pnpm in lockstep if they regenerate lockfiles locally.
+
+## Lockfile compatibility note
+
+This PR does NOT regenerate `pnpm-lock.yaml` to a v11-canonical format. pnpm 11 read the existing v9-format lockfile cleanly across all three OSes (`Lockfile is up to date, resolution step is skipped` per the CI log). A v11 regen will happen organically on the next install that produces a resolution diff.
+
+## Why this is a PATCH bump
+
+W4 is a build-tooling change with no published-package API surface delta. Downstream consumers of `@mmnto/cli`, `@mmnto/totem`, `@mmnto/mcp`, `@mmnto/pack-rust-architecture` (and the private `@mmnto/pack-agent-security`) install from npm tarballs and don't see this repo's `packageManager` field or `pnpm-workspace.yaml`. The bump is invisible to library consumers; cohort-dependent repos with their own lockfile regen are addressed via the cross-stream coordination dispatch above.

--- a/.changeset/cohort-pnpm-11-bump-w4.md
+++ b/.changeset/cohort-pnpm-11-bump-w4.md
@@ -27,7 +27,7 @@ pnpm 11 dropped reading the `pnpm.*` field from `package.json` entirely; the can
 
 ## Workflow surface unchanged
 
-All 7 workflows (`ci`, `ci-integration`, `compile-manifest`, `lint`, `release`, `release-binary`, `totem-doctor`) remain on `pnpm/action-setup@v5` with no `version:` input — pnpm version is inferred from `packageManager`. The `pnpm/action-setup@v6` line has open inference bugs (`pnpm/action-setup#225`, `#227`) that would have forced an explicit `version: 11.2.2` pin; staying on `@v5` keeps the inference path clean and `packageManager` as the single source of truth.
+All 7 workflows (`ci`, `ci-integration`, `compile-manifest`, `lint`, `release`, `release-binary`, `totem-doctor`) remain on `pnpm/action-setup@v5` with no `version:` input — the pnpm release is inferred from `packageManager`. The `pnpm/action-setup@v6` line has open inference bugs (`pnpm/action-setup#225`, `#227`) that would have forced an explicit `version: 11.2.2` pin; staying on `@v5` keeps the inference path clean and `packageManager` as the single source of truth.
 
 ## Cross-stream coordination
 

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mmnto/totem-monorepo",
   "private": true,
-  "packageManager": "pnpm@9.15.4",
+  "packageManager": "pnpm@11.2.2+sha512.36e6621fad506178936455e70247b8808ef4ec25797a9f437a93281a020484e2607f6a469a22e982987c3dbb8866e3071514ab10a4a1749e06edcd1ec118436f",
   "scripts": {
     "build": "turbo run build",
     "dev": "turbo run dev",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,18 @@
 packages:
   - 'packages/*'
+
+engineStrict: true
+
+strictDepBuilds: true
+allowBuilds:
+  '@ast-grep/lang-rust': true
+  'es5-ext': true
+  'esbuild': true
+  'protobufjs': true
+  'tree-sitter-javascript': true
+  'tree-sitter-typescript': true
+
+minimumReleaseAge: 1d
+# Cohort packages publish-then-install in the same CI window by design.
+minimumReleaseAgeExclude:
+  - '@mmnto/*'


### PR DESCRIPTION
## Mechanical Root Cause

The repo's `packageManager` pinned `pnpm@9.15.4` while pnpm 11 is the current active major. The W4 lane in the cohort dep wave plan lifts pnpm to 11.2.2 so the repo can use the v11 features (`strictDepBuilds`, `allowBuilds` map for transitive build-script policy, `minimumReleaseAge` for supply-chain hygiene with cohort carve-out via `minimumReleaseAgeExclude`). The v9 → v11 jump also removes reading of the `pnpm.*` field from `package.json`, so the build-script policy that would live there in v10 has a new canonical home in `pnpm-workspace.yaml`.

## Fix Applied

Four-file diff:

- **`package.json`**: `packageManager: pnpm@9.15.4` → `pnpm@11.2.2+sha512.<corepack integrity>`. The integrity hash is corepack's canonical secure form for v11.
- **`pnpm-workspace.yaml`**: gains the full canonical v11 settings block — `engineStrict`, `strictDepBuilds`, `allowBuilds` (map of 6 transitive packages from the empirical CI enumeration), `minimumReleaseAge: 1d`, `minimumReleaseAgeExclude: ['@mmnto/*']`.
- **`.npmrc`**: deleted. The single line `engine-strict=true` is now `engineStrict: true` in `pnpm-workspace.yaml`.
- **`.changeset/cohort-pnpm-11-bump-w4.md`**: patch-level changeset for the fixed-cohort lockstep bump.

Workflow surface is unchanged: all 7 workflows stay on `pnpm/action-setup@v5` with no `version:` input. The pnpm release is inferred from `packageManager` per `feedback_if_derivable_let_it_be`. The `@v6` line has open inference bugs (`pnpm/action-setup#225`, `#227`) that the dry-run confirmed we can avoid entirely by staying on `@v5` + inference.

## Out of Scope

- **Lockfile regeneration to v11 format.** pnpm 11 reads the v9 `lockfileVersion: '9.0'` cleanly (verified across ubuntu/macos/windows in the dry-run probe; `Lockfile is up to date, resolution step is skipped`). A v11-canonical regen will happen organically on the next install that produces a resolution diff; forcing it now would balloon the diff with no behavior change.
- **Per-version-pinned `allowBuilds` entries.** Source enumeration named 8 version-pinned variants (`esbuild@0.27.3`, `esbuild@0.28.0`, etc.); collapsed to 6 name-keyed entries per pnpm docs' canonical form. If the name-only match misses transitive variants in CI, fallback to per-version entries.
- **Cohort heads-up dispatch.** Cross-stream consumers (liquid-city, totem-status, arhgap11) need a lockfile-format heads-up at merge time — strategy-claude's framing was "merge-time dispatch, not earlier" to avoid forcing dependents to do verification work twice.
- **W4 spec doc commit (`/.totem/specs/w4-pnpm-major-bump.md`).** Working artifact; carries pre-dry-run dispositions that the dry-run subsequently corrected (see § Notable below). Per `feedback_default_to_subtraction`: implementation PR body is the canonical artifact going forward.

## Tests Added/Updated

- [ ] Added/updated automated tests covering the root-cause mechanism
- [x] N/A (explain why verification logic is not applicable)

This is a build-tooling change with no published-package API surface delta and no library code touched. The verification surface is **CI itself**: workspace install + lint + 4531 tests + cross-platform matrix (ubuntu/macos/windows) all running against the new pnpm 11.2.2 toolchain. The dry-run probe at the now-closed #2022 already proved the matrix passes against this exact config; this PR runs that matrix again with the production-strict `strictDepBuilds: true` setting that the probe deferred via `false`.

Manual invariant (per spec): `pnpm install --frozen-lockfile` fails loud with `ERR_PNPM_UNSUPPORTED_ENGINE` when the active Node is below the cohort's `>=24` floor. The `engineStrict: true` setting in `pnpm-workspace.yaml` enforces this; the W3 cohort engines bump (#2013) is the dependency this PR builds on.

## Related Tickets

W4 lane in the cohort dep wave plan (no GitHub issue; tracked internally via the spec doc + the wave plan).

Empirical antecedent: dry-run probe at #2022 (closed; not merged). Iteration 1 surfaced the pnpm-11-canonical-settings-home migration; iteration 2 confirmed the toolchain works end-to-end across all 3 OSes.

## Notable: methodology disposition

The dry-run probe surfaced primary-source defects in TWO of the spec's preliminary dispositions:

1. **Q4 (action-setup version):** spec leaned toward CI dry-run to decide between `@v5` + inference vs `@v6` + explicit pin. Empirical answer: `@v5` + inference works cleanly. The v6 inference bugs (#225/#227) were real but not load-bearing for our path.
2. **Q2 (build-script policy):** spec disposition placed `pnpm.allowBuilds` in `package.json`. Empirical answer: pnpm 11 silently ignores the `pnpm.*` field; canonical home is `pnpm-workspace.yaml` with `allowBuilds` as a MAP, not array. Verified via the CI `[WARN]` text + https://pnpm.io/settings primary-source.

Cross-vendor methodology (per `feedback_cross_vendor_methodology_for_doctrine_validation`) fired on Q2: strategy-claude × empirical-CI N=2 disagreement → primary-source verification → revised disposition. Probe cost: ~10 min CI wall time across two iterations. Catch cost if it had shipped: a silent `[WARN]` + ignored block (no strict-mode trigger absent `strictDepBuilds: true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)