### PR TITLE
chore(tooling): auto-augment empty cohort-link CHANGELOG headers (closes #1969)

### DIFF
--- a/.changeset/1969-augment-cohort-changelog-headers.md
+++ b/.changeset/1969-augment-cohort-changelog-headers.md
@@ -1,0 +1,34 @@
+---
+'@mmnto/cli': patch
+---
+
+chore(tooling): auto-augment empty cohort-link CHANGELOG headers at `changeset version` time (closes #1969)
+
+Ships the structural fix for the recurring empty-cohort-header drift class — same pattern that hit cycles 1-5 (`#1965` / `#2009` / `#2016` / `#2021` / `#2024`) and required manual in-place backfills on each auto-VP PR.
+
+## What ships
+
+- **`tools/augment-cohort-changelog-headers.mjs`** — post-`changeset version` script that detects empty `## X.Y.Z` headers in the three pack CHANGELOGs (`packages/core`, `packages/pack-agent-security`, `packages/pack-rust-architecture`) and injects the canonical generic cohort-link note. Idempotent: any header with a non-blank body line is left untouched.
+- **Wiring:** root `package.json` `"version"` script chains `changeset version && node tools/augment-cohort-changelog-headers.mjs` so the auto-VP PRs ship with augmented headers from the first commit.
+- **`tools/augment-cohort-changelog-headers.test.mjs`** — 9-test bare-node suite covering empty-header detection (mid-file + EOF), idempotency, no-op on bodied headers (cli `### Patch Changes` case + already-augmented case), multi-empty-in-one-file with output-shape assertion, malformed-version-header rejection, and the target-list invariant.
+- **One-time historical sweep:** 84 historical empty headers across the three packs (going back to ~1.32) backfilled in the same commit. The detection pattern is universal; restricting the script to "recent versions only" would add complexity for no gain.
+
+## Doctrine anchor
+
+Per strategy-claude's 2026-05-23T2114Z altitude call on `#1969` (with strategy-agy + strategy-codex peer-review concurrence, N=3 cross-vendor):
+
+- **Option (a) auto-augment**, not (b) native skip (changesets H2 header is hardcoded at apply-release-plan level, not configurable via the `changelog` hook) and not (c) suppress bot findings (right altitude, wrong direction).
+- **Uniform generic note** across all 3 packs, not the asymmetric specific-note pattern that would manually mirror CLI's CHANGELOG content (Tenet 20 stale-mirror trap).
+- **Post-`changeset version` script**, not upstream-changesets RFC (multi-month escalation; declined).
+
+## Canonical note text
+
+```
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+```
+
+Matches the established repo pattern across `1.43.x` / `1.44` / `1.45` / `1.46` / `1.47` / `1.49` cycles. The recently-backfilled `1.49.1` (cycle 5 at `495faba2`) ships with this exact form, so the script's idempotency is verified against live state.
+
+## Why this is a PATCH bump
+
+Build-tooling change with no published-package API surface delta. Future auto-VPs will have augmented pack headers from the start — same artifact as the manual backfill that landed on cycles 1-5, but without the human in the loop.

--- a/.changeset/1969-augment-cohort-changelog-headers.md
+++ b/.changeset/1969-augment-cohort-changelog-headers.md
@@ -23,7 +23,7 @@ Per strategy-claude's 2026-05-23T2114Z altitude call on `#1969` (with strategy-a
 
 ## Canonical note text
 
-```
+```text
 _Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 ```
 

--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
     "format:check": "prettier --check .",
     "prepare": "node tools/install-hooks.js",
     "changeset": "changeset",
-    "version": "changeset version",
+    "version": "changeset version && node tools/augment-cohort-changelog-headers.mjs",
     "release": "pnpm build && node tools/publish-oidc.mjs",
     "docs:inject": "node tools/docs-inject.cjs",
-    "test:docs": "node tools/docs-transforms.test.cjs"
+    "test:docs": "node tools/docs-transforms.test.cjs",
+    "test:augment-headers": "node tools/augment-cohort-changelog-headers.test.mjs"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.98.0",

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -443,6 +443,8 @@ Coordinated cohort bump — no direct changes in this package; consumes the `@mm
 
 ## 1.37.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.36.0
 
 ### Minor Changes
@@ -488,9 +490,15 @@ Coordinated cohort bump — no direct changes in this package; consumes the `@mm
 
 ## 1.35.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.34.3
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.34.2
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.34.1
 
@@ -647,6 +655,8 @@ entry that closes `mmnto-ai/totem#1851`).
 
 ## 1.28.1
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.28.0
 
 ### Minor Changes
@@ -691,6 +701,8 @@ entry that closes `mmnto-ai/totem#1851`).
 
 ## 1.26.1
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.26.0
 
 ### Minor Changes
@@ -712,6 +724,8 @@ entry that closes `mmnto-ai/totem#1851`).
   Closes #1803.
 
 ## 1.25.0
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.24.0
 
@@ -864,6 +878,8 @@ entry that closes `mmnto-ai/totem#1851`).
 
 ## 1.20.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.19.0
 
 ### Minor Changes
@@ -904,6 +920,8 @@ entry that closes `mmnto-ai/totem#1851`).
 
 ## 1.18.1
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.18.0
 
 ### Minor Changes
@@ -933,6 +951,8 @@ entry that closes `mmnto-ai/totem#1851`).
 
 ## 1.17.1
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.17.0
 
 ### Minor Changes
@@ -948,6 +968,8 @@ entry that closes `mmnto-ai/totem#1851`).
   New core surface: `RetrospectRoundSchema`, `RetrospectClassificationSchema`, `RetrospectFindingSchema`, `RetrospectReportSchema` plus pure helpers `groupFindingsByRound`, `classifyFinding`, `buildStopConditions`, `computeDedupRate`, `signatureOfBody`, `toRoundPosition`, `toCrossPrBucket`. `toSeverityBucket` is now exported from `@mmnto/totem` so the bot-tax cluster (`#1715` + `#1714` + `#1713`) shares one severity vocabulary. `GitHubCliPrAdapter` gains a `fetchReviews(prNumber)` method that reads `gh api repos/.../pulls/N/reviews --paginate` for `commit_id` + `submitted_at` (the existing `fetchPr` JSON shape doesn't include `commit_id`).
 
 ## 1.16.1
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.16.0
 
@@ -1159,6 +1181,8 @@ entry that closes `mmnto-ai/totem#1851`).
   Detailed patch-level changes: CHANGELOG.md entries 1.14.1 through 1.14.17.
 
 ## 1.14.17
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.14.16
 
@@ -1487,6 +1511,8 @@ entry that closes `mmnto-ai/totem#1851`).
 
 ## 1.14.2
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.14.1
 
 ### Patch Changes
@@ -1586,7 +1612,11 @@ entry that closes `mmnto-ai/totem#1851`).
 
 ## 1.10.1
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.10.0
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.9.0
 
@@ -1609,6 +1639,8 @@ entry that closes `mmnto-ai/totem#1851`).
 - 1bb150d: Add Pipeline 3 example-based compilation prompt for Bad/Good code snippet lessons
 
 ## 1.8.3
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.8.2
 
@@ -1647,6 +1679,8 @@ entry that closes `mmnto-ai/totem#1851`).
   - `totem compile` now shows elapsed time and ETA with throughput-based estimation. Rate-limited LLM calls (429) are automatically retried with jittered exponential backoff.
 
 ## 1.7.1
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.7.0
 
@@ -2061,7 +2095,11 @@ entry that closes `mmnto-ai/totem#1851`).
 
 ## 1.3.3
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.3.2
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.3.1
 
@@ -2143,6 +2181,8 @@ entry that closes `mmnto-ai/totem#1851`).
   Every error now includes a `recoveryHint` telling the user exactly how to fix it. New error classes: `TotemOrchestratorError`, `TotemGitError`. New error code: `GIT_FAILED`. Includes rule fix exempting error class imports from the static import lint rule.
 
 ## 0.43.0
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 0.42.0
 
@@ -2285,7 +2325,11 @@ entry that closes `mmnto-ai/totem#1851`).
 
 ## 0.34.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 0.33.1
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 0.33.0
 
@@ -2362,7 +2406,11 @@ entry that closes `mmnto-ai/totem#1851`).
 
 ## 0.26.1
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 0.26.0
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 0.25.0
 
@@ -2472,6 +2520,8 @@ entry that closes `mmnto-ai/totem#1851`).
 
 ## 0.16.1
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 0.16.0
 
 ### Minor Changes
@@ -2492,7 +2542,11 @@ entry that closes `mmnto-ai/totem#1851`).
 
 ## 0.13.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 0.12.0
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 0.11.0
 
@@ -2520,7 +2574,11 @@ entry that closes `mmnto-ai/totem#1851`).
 
 ## 0.9.1
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 0.9.0
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 0.8.0
 
@@ -2554,11 +2612,19 @@ entry that closes `mmnto-ai/totem#1851`).
 
 ## 0.6.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 0.5.0
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 0.4.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 0.3.0
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 0.2.2
 

--- a/packages/pack-agent-security/CHANGELOG.md
+++ b/packages/pack-agent-security/CHANGELOG.md
@@ -58,7 +58,11 @@ _Cohort-link bump (no direct package changes). See `.changeset/config.json` for 
 
 ## 1.43.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.42.0
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.41.0
 
@@ -195,6 +199,8 @@ Coordinated cohort bump — no direct changes to this pack.
 
 ## 1.37.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.36.0
 
 Coordinated cohort bump — no direct changes to this pack. See `@mmnto/cli`'s
@@ -202,9 +208,15 @@ CHANGELOG.md for the `totem hook` namespace entry.
 
 ## 1.35.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.34.3
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.34.2
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.34.1
 
@@ -218,17 +230,31 @@ CHANGELOG.md for the `totem init` Ollama floor probe entry.
 
 ## 1.33.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.32.0
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.31.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.30.1
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.30.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.29.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.28.1
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.28.0
 
@@ -260,7 +286,11 @@ CHANGELOG.md for the `totem init` Ollama floor probe entry.
 
 ## 1.27.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.26.1
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.26.0
 
@@ -293,6 +323,8 @@ CHANGELOG.md for the `totem init` Ollama floor probe entry.
   No code change. Constraint-only tightening.
 
 ## 1.25.0
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.24.0
 
@@ -347,21 +379,39 @@ CHANGELOG.md for the `totem init` Ollama floor probe entry.
 
 ## 1.22.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.21.0
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.20.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.19.0
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.18.3
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.18.2
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.18.1
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.18.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.17.1
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.17.0
 
@@ -378,6 +428,8 @@ CHANGELOG.md for the `totem init` Ollama floor probe entry.
   New core surface: `RetrospectRoundSchema`, `RetrospectClassificationSchema`, `RetrospectFindingSchema`, `RetrospectReportSchema` plus pure helpers `groupFindingsByRound`, `classifyFinding`, `buildStopConditions`, `computeDedupRate`, `signatureOfBody`, `toRoundPosition`, `toCrossPrBucket`. `toSeverityBucket` is now exported from `@mmnto/totem` so the bot-tax cluster (`#1715` + `#1714` + `#1713`) shares one severity vocabulary. `GitHubCliPrAdapter` gains a `fetchReviews(prNumber)` method that reads `gh api repos/.../pulls/N/reviews --paginate` for `commit_id` + `submitted_at` (the existing `fetchPr` JSON shape doesn't include `commit_id`).
 
 ## 1.16.1
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.16.0
 
@@ -401,13 +453,23 @@ CHANGELOG.md for the `totem init` Ollama floor probe entry.
 
 ## 1.15.9
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.15.8
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.15.7
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.15.6
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.15.5
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.15.4
 
@@ -524,6 +586,8 @@ CHANGELOG.md for the `totem init` Ollama floor probe entry.
 
 ## 1.14.17
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.14.16
 
 ### Patch Changes
@@ -582,6 +646,12 @@ CHANGELOG.md for the `totem init` Ollama floor probe entry.
 
 ## 1.14.13
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.14.12
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.14.11
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._

--- a/packages/pack-rust-architecture/CHANGELOG.md
+++ b/packages/pack-rust-architecture/CHANGELOG.md
@@ -58,7 +58,11 @@ _Cohort-link bump (no direct package changes). See `.changeset/config.json` for 
 
 ## 1.43.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.42.0
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.41.0
 
@@ -195,6 +199,8 @@ Coordinated cohort bump — no direct changes to this pack.
 
 ## 1.37.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.36.0
 
 Coordinated cohort bump — no direct changes to this pack. See `@mmnto/cli`'s
@@ -202,9 +208,15 @@ CHANGELOG.md for the `totem hook` namespace entry.
 
 ## 1.35.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.34.3
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.34.2
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.34.1
 
@@ -218,17 +230,31 @@ CHANGELOG.md for the `totem init` Ollama floor probe entry.
 
 ## 1.33.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.32.0
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.31.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.30.1
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.30.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.29.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.28.1
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.28.0
 
@@ -260,7 +286,11 @@ CHANGELOG.md for the `totem init` Ollama floor probe entry.
 
 ## 1.27.0
 
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
+
 ## 1.26.1
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.26.0
 
@@ -293,6 +323,8 @@ CHANGELOG.md for the `totem init` Ollama floor probe entry.
   No code change. Constraint-only tightening.
 
 ## 1.25.0
+
+_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
 
 ## 1.24.0
 

--- a/tools/augment-cohort-changelog-headers.mjs
+++ b/tools/augment-cohort-changelog-headers.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Augment empty cohort-link CHANGELOG headers.
+ *
+ * Wired into root `package.json` "version" script after `changeset version`.
+ * Detects `## X.Y.Z` headers with no body (immediately followed by blank line
+ * + either next `## ` header or EOF) in the three pack CHANGELOGs that
+ * exhibit the empty-cohort-header pattern, and injects the canonical
+ * generic cohort-link note.
+ *
+ * Idempotent — re-running on already-augmented CHANGELOG is a no-op (any
+ * header with a non-blank body line is left untouched).
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const rootDir = join(__dirname, '..');
+
+export const TARGET_CHANGELOGS = [
+  'packages/core/CHANGELOG.md',
+  'packages/pack-agent-security/CHANGELOG.md',
+  'packages/pack-rust-architecture/CHANGELOG.md',
+];
+
+export const COHORT_NOTE =
+  '_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._';
+
+const VERSION_HEADER_RE = /^## \d+\.\d+\.\d+$/;
+
+/**
+ * Augment the content of one CHANGELOG file. Pure function — used by tests.
+ *
+ * @param {string} content
+ * @returns {{ content: string, augmented: number }}
+ */
+export function augmentChangelog(content) {
+  const lines = content.split('\n');
+  const result = [];
+  let augmented = 0;
+
+  for (let i = 0; i < lines.length; i++) {
+    result.push(lines[i]);
+
+    if (!VERSION_HEADER_RE.test(lines[i])) continue;
+
+    // Empty-header detection: next line must be blank, and the line after
+    // must be either another `## ` header or end-of-file.
+    const nextLine = lines[i + 1];
+    const lineAfter = lines[i + 2];
+    const isEmpty = nextLine === '' && (lineAfter === undefined || lineAfter.startsWith('## '));
+
+    if (!isEmpty) continue;
+
+    // Output shape: header, blank, note, blank, (next ## | EOF).
+    // The blank at lines[i+1] is consumed by the i++ below; we emit fresh
+    // blanks on both sides of the note so the spacing is canonical
+    // regardless of what came before.
+    result.push('');
+    result.push(COHORT_NOTE);
+    result.push('');
+    augmented++;
+    i++; // Skip the original blank at lines[i+1].
+  }
+
+  return { content: result.join('\n'), augmented };
+}
+
+async function main() {
+  let totalAugmented = 0;
+  const summaryRows = [];
+
+  for (const target of TARGET_CHANGELOGS) {
+    const path = join(rootDir, target);
+    const content = readFileSync(path, 'utf8');
+    const { content: newContent, augmented } = augmentChangelog(content);
+
+    if (augmented > 0) {
+      writeFileSync(path, newContent, 'utf8');
+      summaryRows.push(`  ${target}: augmented ${augmented} header(s)`);
+      totalAugmented += augmented;
+    }
+  }
+
+  if (totalAugmented === 0) {
+    console.log('[augment-headers] No empty cohort-link headers found (no-op).');
+  } else {
+    console.log(`[augment-headers] Augmented ${totalAugmented} header(s):`);
+    for (const row of summaryRows) console.log(row);
+  }
+}
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+if (isMain) {
+  main().catch((err) => {
+    console.error('[augment-headers] ERROR:', err.message);
+    process.exit(1);
+  });
+}

--- a/tools/augment-cohort-changelog-headers.test.mjs
+++ b/tools/augment-cohort-changelog-headers.test.mjs
@@ -1,0 +1,162 @@
+#!/usr/bin/env node
+/**
+ * Tests for tools/augment-cohort-changelog-headers.mjs
+ *
+ * Bare-node test runner (matches docs-transforms.test.cjs pattern). Exits 0
+ * on all green; non-zero on any failure.
+ */
+
+import { strict as assert } from 'node:assert';
+
+import {
+  COHORT_NOTE,
+  TARGET_CHANGELOGS,
+  augmentChangelog,
+} from './augment-cohort-changelog-headers.mjs';
+
+let testCount = 0;
+let failCount = 0;
+
+function test(name, fn) {
+  testCount++;
+  try {
+    fn();
+    console.log(`  ✓ ${name}`);
+  } catch (err) {
+    failCount++;
+    console.error(`  ✗ ${name}`);
+    console.error(`    ${err.message}`);
+  }
+}
+
+console.log('augment-cohort-changelog-headers:');
+
+test('empty header followed by next version header → augment', () => {
+  const input = ['# Pkg', '', '## 1.49.1', '', '## 1.49.0', '', '_existing body_', ''].join('\n');
+  const { content, augmented } = augmentChangelog(input);
+  assert.equal(augmented, 1);
+  assert.ok(content.includes(COHORT_NOTE));
+  // The pre-existing 1.49.0 body should be untouched.
+  assert.ok(content.includes('_existing body_'));
+});
+
+test('empty header at EOF → augment', () => {
+  const input = ['# Pkg', '', '## 1.49.1', ''].join('\n');
+  const { content, augmented } = augmentChangelog(input);
+  assert.equal(augmented, 1);
+  assert.ok(content.includes(COHORT_NOTE));
+});
+
+test('header with existing cohort-link body → no-op (idempotency anchor)', () => {
+  const input = [
+    '# Pkg',
+    '',
+    '## 1.49.1',
+    '',
+    COHORT_NOTE,
+    '',
+    '## 1.49.0',
+    '',
+    '_prior cohort note_',
+    '',
+  ].join('\n');
+  const { content, augmented } = augmentChangelog(input);
+  assert.equal(augmented, 0);
+  assert.equal(content, input);
+});
+
+test('idempotency: re-running on augmented output → no-op', () => {
+  const input = ['# Pkg', '', '## 1.49.1', '', '## 1.49.0', '', '_prior cohort note_', ''].join(
+    '\n',
+  );
+  const { content: pass1, augmented: a1 } = augmentChangelog(input);
+  assert.equal(a1, 1, 'first pass should augment the empty 1.49.1');
+  const { content: pass2, augmented: a2 } = augmentChangelog(pass1);
+  assert.equal(a2, 0, 'second pass should be a no-op');
+  assert.equal(pass1, pass2);
+});
+
+test('header with ### Patch Changes body → no-op (cli case)', () => {
+  const input = [
+    '# Pkg',
+    '',
+    '## 1.49.1',
+    '',
+    '### Patch Changes',
+    '',
+    '- e4a24ec: chore(deps): bump packageManager',
+    '',
+    '## 1.49.0',
+    '',
+    '### Minor Changes',
+    '',
+    '- abc: prior change',
+    '',
+  ].join('\n');
+  const { content, augmented } = augmentChangelog(input);
+  assert.equal(augmented, 0);
+  assert.equal(content, input);
+});
+
+test('multiple empty headers in one file → augment all with canonical spacing', () => {
+  const input = ['# Pkg', '', '## 1.49.1', '', '## 1.49.0', '', '## 1.48.0', ''].join('\n');
+  const { content, augmented } = augmentChangelog(input);
+  // 1.49.1 + 1.49.0 are followed by another `## ` header (empty); 1.48.0 is at EOF (empty).
+  assert.equal(augmented, 3);
+  const escaped = COHORT_NOTE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const occurrences = (content.match(new RegExp(escaped, 'g')) || []).length;
+  assert.equal(occurrences, 3);
+  // Output shape: each augmented section must end with a blank line
+  // before the next `## ` (or EOF). Asserting this guards against the
+  // `_NOTE_\n## 1.48.0` malformed spacing class.
+  assert.ok(
+    !content.includes(`${COHORT_NOTE}\n## `),
+    'note must be separated from the next ## header by a blank line',
+  );
+});
+
+test('mixed empty + non-empty → augment only empty', () => {
+  const input = [
+    '# Pkg',
+    '',
+    '## 1.49.1',
+    '',
+    '### Patch Changes',
+    '',
+    '- abc: change',
+    '',
+    '## 1.49.0',
+    '',
+    '## 1.48.0',
+    '',
+    '_pre-existing note_',
+    '',
+  ].join('\n');
+  const { content, augmented } = augmentChangelog(input);
+  // 1.49.1 has body → skip; 1.49.0 empty (followed by 1.48.0) → augment; 1.48.0 has body → skip.
+  assert.equal(augmented, 1);
+  assert.ok(content.includes('_pre-existing note_'));
+  assert.ok(content.includes('### Patch Changes'));
+});
+
+test('version header regex: rejects malformed headers', () => {
+  // Should not augment a header that doesn't match the `## X.Y.Z` pattern.
+  const input = ['# Pkg', '', '## 1.49', '', '## not-a-version', '', '## 1.49.0-rc.1', ''].join(
+    '\n',
+  );
+  const { content, augmented } = augmentChangelog(input);
+  // None of these match `^## \d+\.\d+\.\d+$` exactly (prerelease suffix breaks it; 1.49 has only 2 segments).
+  assert.equal(augmented, 0);
+  assert.equal(content, input);
+});
+
+test('target list exposes the three exhibiting packs', () => {
+  assert.deepEqual(TARGET_CHANGELOGS, [
+    'packages/core/CHANGELOG.md',
+    'packages/pack-agent-security/CHANGELOG.md',
+    'packages/pack-rust-architecture/CHANGELOG.md',
+  ]);
+});
+
+console.log(`\n${testCount - failCount}/${testCount} tests passed.`);
+process.exit(failCount > 0 ? 1 : 0);


### PR DESCRIPTION
## Mechanical Root Cause

The changesets `apply-release-plan` package emits the `## X.Y.Z` H2 header as a hardcoded line in `get-changelog-entry.ts`, NOT via the configurable `changelog` hook. When a fixed-cohort package gets a lockstep version bump WITHOUT a direct dep edge into the version-bumping package, changesets emits the H2 header but no body — producing an empty cohort-link entry. This drift class has hit five consecutive auto-VP cycles (#1965 → #2009 → #2016 → #2021 → #2024), each requiring a manual in-place backfill on the changeset-release/main branch.

Closes #1969.

## Fix Applied

Three-part structural fix:

1. **`tools/augment-cohort-changelog-headers.mjs`** — post-`changeset version` script that detects `## X.Y.Z` headers immediately followed by blank line + (next `## ` header | EOF) in the three pack CHANGELOGs (`packages/core`, `packages/pack-agent-security`, `packages/pack-rust-architecture`) and injects the canonical generic note. Idempotent — any header with a non-blank body line is left untouched.

2. **Wiring:** root `package.json` `"version"` script chains `changeset version && node tools/augment-cohort-changelog-headers.mjs` so auto-VP PRs ship augmented headers from the first commit. Cycle 6 (the next auto-VP) is the empirical proof point — it should arrive with augmented headers, no manual intervention required.

3. **One-time historical sweep:** 84 empty headers across the three packs (going back to ~1.32) backfilled in the same commit. The detection pattern is universal; restricting to "recent versions only" would add complexity for no gain. Per-package breakdown:
   - `packages/core/CHANGELOG.md`: 33 augmented
   - `packages/pack-agent-security/CHANGELOG.md`: 35 augmented
   - `packages/pack-rust-architecture/CHANGELOG.md`: 16 augmented

### Doctrine anchor

Per strategy-claude's 2026-05-23T2114Z altitude call on #1969 with strategy-agy + strategy-codex peer-review concurrence (N=3 cross-vendor):

- **Option (a) auto-augment**, not (b) native skip (changesets H2 header is hardcoded at apply-release-plan level, not configurable via the `changelog` hook), not (c) suppress bot findings (right altitude, wrong direction).
- **Uniform generic note** across all 3 packs, not asymmetric specific-note that would manually mirror CLI's CHANGELOG content (Tenet 20 stale-mirror trap).
- **Post-`changeset version` script**, not upstream-changesets RFC (multi-month escalation; declined).

### Canonical note text

```
_Cohort-link bump (no direct package changes). See `.changeset/config.json` for the fixed-cohort definition._
```

Matches the established repo pattern across `1.43.x` / `1.44` / `1.45` / `1.46` / `1.47` / `1.49` cycles. The recently-backfilled `1.49.1` (cycle 5 at `495faba2`) ships with this exact form, so the script's idempotency is verified against live state — running the script on the current repo state is a no-op AFTER the historical sweep lands.

## Out of Scope

- **CHANGELOG content prose changes** beyond the empty-header injection. The 84 historical augmentations add the canonical note to versions that previously had no body; they don't modify any existing prose.
- **Workflow integration into changesets-action** beyond the standard `"version"` script chain. The action calls `pnpm run version` and commits the result; no additional CI wiring needed.
- **Symmetric augmentation for `@mmnto/cli` and `@mmnto/mcp`.** These packages get direct changeset entries (with `### Patch Changes` / `### Minor Changes` bodies) when they're the bumping target, and their empty-header case happens less consistently. The 3 target packs are the empirically-derived exhibiting set per the #1969 table.
- **Banking as a new memory rule.** Per `feedback_wallpaper_layers_antipattern` — the existing rules (`feedback_default_to_subtraction`, `feedback_if_derivable_let_it_be`, Tenet 20) compose to produce this design without needing a new entry.

## Tests Added/Updated

- [x] Added/updated automated tests covering the root-cause mechanism

9 tests in `tools/augment-cohort-changelog-headers.test.mjs` (bare-node runner; wired into `pnpm run test:augment-headers`):

| Test | Mechanism covered |
|---|---|
| empty header followed by next version header → augment | mid-file detection |
| empty header at EOF → augment | EOF boundary detection |
| header with existing cohort-link body → no-op | idempotency anchor |
| idempotency: re-running on augmented output → no-op | two-pass invariant |
| header with `### Patch Changes` body → no-op | cli case |
| multiple empty headers in one file → augment all with canonical spacing | output-shape assertion (guards against `_NOTE_\n## ` malformed spacing) |
| mixed empty + non-empty → augment only empty | per-header decision boundary |
| version header regex: rejects malformed headers | `## X.Y.Z` strict regex (rejects `## 1.49`, prereleases, non-numeric) |
| target list exposes the three exhibiting packs | structural invariant |

**Live verification:** running the script on the post-commit state is a no-op (all 84 historical + cycle-5's 3 augmentations already in place; no empty headers remaining for the script to find).

## Related Tickets

Closes #1969.

Drift precedents now eliminated:
- #1965 (cycle 1)
- #2009 (cycle 2)
- #2016 (cycle 3)
- #2021 (cycle 4)
- #2024 (cycle 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)