### PR TITLE
chore(deps): bump @google/genai 1.44.0 -> 2.6.0 (W5 cohort dep wave)

### DIFF
--- a/.changeset/cohort-genai-2-bump-w5.md
+++ b/.changeset/cohort-genai-2-bump-w5.md
@@ -8,14 +8,14 @@ Lifts the workspace pin on `@google/genai` from `^1.44.0` to `^2.6.0`, narrows t
 
 ## What ships
 
-| File                                   | Change                                                          |
-| -------------------------------------- | --------------------------------------------------------------- |
-| `package.json` (root devDep)           | `@google/genai`: `^1.44.0` -> `^2.6.0`                          |
-| `packages/cli/package.json` (devDep)   | `@google/genai`: `^1.44.0` -> `^2.6.0`                          |
-| `packages/cli/package.json` (peerDep)  | `@google/genai`: `>=1.0.0` -> `>=2.0.0` (optional, unchanged)   |
-| `packages/core/package.json` (peerDep) | `@google/genai`: `>=1.0.0` -> `>=2.0.0` (optional, unchanged)   |
-| `services/compile-worker/package.json` | `@google/genai`: `^1.0.0` -> `^2.6.0`                           |
-| `pnpm-lock.yaml`                       | Regenerated; 2.6.0 resolves cleanly, no peer warnings           |
+| File                                   | Change                                                        |
+| -------------------------------------- | ------------------------------------------------------------- |
+| `package.json` (root devDep)           | `@google/genai`: `^1.44.0` -> `^2.6.0`                        |
+| `packages/cli/package.json` (devDep)   | `@google/genai`: `^1.44.0` -> `^2.6.0`                        |
+| `packages/cli/package.json` (peerDep)  | `@google/genai`: `>=1.0.0` -> `>=2.0.0` (optional, unchanged) |
+| `packages/core/package.json` (peerDep) | `@google/genai`: `>=1.0.0` -> `>=2.0.0` (optional, unchanged) |
+| `services/compile-worker/package.json` | `@google/genai`: `^1.0.0` -> `^2.6.0`                         |
+| `pnpm-lock.yaml`                       | Regenerated; 2.6.0 resolves cleanly, no peer warnings         |
 
 ## Empirical baseline (dry-run probe `2026-05-24T2207Z`)
 

--- a/.changeset/cohort-genai-2-bump-w5.md
+++ b/.changeset/cohort-genai-2-bump-w5.md
@@ -1,0 +1,45 @@
+---
+'@mmnto/cli': patch
+---
+
+chore(deps): bump @google/genai 1.44.0 -> 2.6.0 (W5 cohort dep wave)
+
+Lifts the workspace pin on `@google/genai` from `^1.44.0` to `^2.6.0`, narrows the optional peer envelope in `@mmnto/totem` and `@mmnto/cli` from `>=1.0.0` to `>=2.0.0` to match the major we now test and build against, and bumps the `services/compile-worker` runtime dep in lockstep. Probe-verified API-stable: the four SDK surfaces we use (`new GoogleGenAI({ apiKey })`, `ai.models.embedContent(...)`, `ai.models.generateContent(...)`, plus the `response.text` / `response.usageMetadata` / `response.candidates` read paths) compile and pass tests against 2.6.0's `.d.ts` without code edits.
+
+## What ships
+
+| File                                   | Change                                                          |
+| -------------------------------------- | --------------------------------------------------------------- |
+| `package.json` (root devDep)           | `@google/genai`: `^1.44.0` -> `^2.6.0`                          |
+| `packages/cli/package.json` (devDep)   | `@google/genai`: `^1.44.0` -> `^2.6.0`                          |
+| `packages/cli/package.json` (peerDep)  | `@google/genai`: `>=1.0.0` -> `>=2.0.0` (optional, unchanged)   |
+| `packages/core/package.json` (peerDep) | `@google/genai`: `>=1.0.0` -> `>=2.0.0` (optional, unchanged)   |
+| `services/compile-worker/package.json` | `@google/genai`: `^1.0.0` -> `^2.6.0`                           |
+| `pnpm-lock.yaml`                       | Regenerated; 2.6.0 resolves cleanly, no peer warnings           |
+
+## Empirical baseline (dry-run probe `2026-05-24T2207Z`)
+
+- `pnpm install` on Node 24 from clean checkout — succeeded; 387 sub-packages resolved; no strict peer warnings emitted.
+- `pnpm --filter @mmnto/totem build` (tsc) — zero TS errors against 2.6.0's `.d.ts`.
+- `pnpm --filter @mmnto/cli build` (tsc) — zero TS errors against 2.6.0's `.d.ts`.
+- `src/embedders/gemini-embedder.test.ts` — 15 / 15 pass.
+- `src/orchestrators/gemini-orchestrator.test.ts` — 12 / 12 pass.
+- `src/orchestrators/conformance.test.ts` — 20 / 20 pass.
+
+The four API surfaces we use (`new GoogleGenAI({ apiKey })` at `packages/core/src/embedders/gemini-embedder.ts:91` and `packages/cli/src/orchestrators/gemini-orchestrator.ts:66`; `ai.models.embedContent(...)` at `gemini-embedder.ts:109`; `ai.models.generateContent(...)` at `gemini-orchestrator.ts:77`; plus the `response.embeddings[].values` / `response.text` / `response.usageMetadata.{promptTokenCount, candidatesTokenCount}` / `response.candidates[0].finishReason` read paths) are all present in `node_modules/@google/genai@2.6.0/dist/genai.d.ts` with signature-compatible shapes.
+
+## Why narrow peerDep `>=1.0.0` -> `>=2.0.0`
+
+After this PR, the workspace tests + tsc build run against 2.x's `.d.ts`; the 1.x compat claim would become false advertising the moment a future change relies on a 2.x-only field or shape. Per grep, zero current cohort consumers import `@google/genai` directly, so nothing breaks on the narrow. The optional-peer posture (`peerDependenciesMeta.@google/genai.optional: true`) means consumers providing a 1.x version get a pnpm warning, not an install error. Matches the W3 engine-strict pattern where the advertised envelope narrowed cleanly once cohort safety was confirmed empirically.
+
+## Downstream peerDep flag
+
+`@google/genai@2.0.0` introduced a new `peerDependency` on `@modelcontextprotocol/sdk@^1.25.2` that was absent in 1.x. Benign for our consumption (root + cli devDep; pnpm did not strict-warn on install), but downstream pack consumers with strict peer enforcement who transitively pull `@google/genai` may see a peer warning unless they also provide an MCP SDK. Documented here so consumers hitting the warning can either provide MCP SDK or enable `auto-install-peers=true`.
+
+## Dispositional lineage
+
+The optional-peer dep posture itself is preserved per the disposition of `mmnto-ai/totem-strategy#404` (Proposal 286, closes prereq `mmnto-ai/totem#2018`). The `(c)` graceful-degradation impl in `totem search` — keyword fallback when the embedder is unavailable — is tracked as a separate follow-on against `mmnto-ai/totem#2018` and ships in its own PR; W5 is the version bump only.
+
+## Why this is a PATCH bump
+
+W5 is a dep-pin bump with no published code-surface delta and no enforced contract change. The optional-peer envelope narrowing is advisory (warnings, not errors). Downstream library consumers who do not import `@google/genai` see nothing change; consumers who do import it and are still on 1.x see a peer warning and can bump at their own cadence. Matches the W4 cohort-dep-wave precedent at `e4a24ec5`.

--- a/.changeset/cohort-genai-2-bump-w5.md
+++ b/.changeset/cohort-genai-2-bump-w5.md
@@ -19,7 +19,7 @@ Lifts the workspace pin on `@google/genai` from `^1.44.0` to `^2.6.0`, narrows t
 
 ## Empirical baseline (dry-run probe `2026-05-24T2207Z`)
 
-- `pnpm install` on Node 24 from clean checkout — succeeded; 387 sub-packages resolved; no strict peer warnings emitted.
+- `pnpm install` on Node 24 from clean checkout — succeeded; 590 sub-packages resolved (re-verified in main checkout install-of-record at `2026-05-25T0054Z`); no strict peer warnings emitted on resolution. Note: subsequent CI Build & Lint surfaced a `strictDepBuilds` gate on the new `@google/genai@2.x` `prepare` script (1.x did not declare one) — fixed at commit `4600c62e` by adding `@google/genai` to `pnpm-workspace.yaml` `allowBuilds`.
 - `pnpm --filter @mmnto/totem build` (tsc) — zero TS errors against 2.6.0's `.d.ts`.
 - `pnpm --filter @mmnto/cli build` (tsc) — zero TS errors against 2.6.0's `.d.ts`.
 - `src/embedders/gemini-embedder.test.ts` — 15 / 15 pass.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.98.0",
     "@changesets/cli": "^2.31.0",
-    "@google/genai": "^1.44.0",
+    "@google/genai": "^2.6.0",
     "eslint": "^10.4.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-simple-import-sort": "^13.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -39,7 +39,7 @@
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.98.0",
-    "@google/genai": "^1.44.0",
+    "@google/genai": "^2.6.0",
     "@types/node": "^22.0.0",
     "esbuild": "^0.28.0",
     "openai": "^4.77.0",
@@ -48,7 +48,7 @@
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": ">=0.50.0",
-    "@google/genai": ">=1.0.0",
+    "@google/genai": ">=2.0.0",
     "openai": ">=4.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,7 +41,7 @@
     "zod": "^3.24.0"
   },
   "peerDependencies": {
-    "@google/genai": ">=1.0.0"
+    "@google/genai": ">=2.0.0"
   },
   "peerDependenciesMeta": {
     "@google/genai": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^2.31.0
         version: 2.31.0(@types/node@22.19.13)
       '@google/genai':
-        specifier: ^1.44.0
-        version: 1.44.0(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))
+        specifier: ^2.6.0
+        version: 2.6.0(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))
       eslint:
         specifier: ^10.4.0
         version: 10.4.0(jiti@2.6.1)
@@ -79,8 +79,8 @@ importers:
         specifier: ^0.98.0
         version: 0.98.0(zod@3.25.76)
       '@google/genai':
-        specifier: ^1.44.0
-        version: 1.44.0(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))
+        specifier: ^2.6.0
+        version: 2.6.0(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.13
@@ -103,8 +103,8 @@ importers:
         specifier: ^0.42.0
         version: 0.42.0
       '@google/genai':
-        specifier: '>=1.0.0'
-        version: 1.44.0(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))
+        specifier: '>=2.0.0'
+        version: 2.6.0(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))
       '@lancedb/lancedb':
         specifier: ^0.26.2
         version: 0.26.2(apache-arrow@17.0.0)
@@ -721,8 +721,8 @@ packages:
     resolution: {integrity: sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@google/genai@1.44.0':
-    resolution: {integrity: sha512-kRt9ZtuXmz+tLlcNntN/VV4LRdpl6ZOu5B1KbfNgfR65db15O6sUQcwnwLka8sT/V6qysD93fWrgJHF2L7dA9A==}
+  '@google/genai@2.6.0':
+    resolution: {integrity: sha512-HjoW3mPuEn7pnuKABJl9VbDoWDSF4nbwYKYvYYor7YjPeDxrrBxHzu2d1Prcd+BAuC4w+85UP6y7ZdcrQAoO7g==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -3544,7 +3544,7 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@google/genai@1.44.0(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))':
+  '@google/genai@2.6.0(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))':
     dependencies:
       google-auth-library: 10.6.1
       p-retry: 4.6.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ engineStrict: true
 strictDepBuilds: true
 allowBuilds:
   '@ast-grep/lang-rust': true
+  '@google/genai': true
   'es5-ext': true
   'esbuild': true
   'protobufjs': true

--- a/services/compile-worker/package.json
+++ b/services/compile-worker/package.json
@@ -9,7 +9,7 @@
     "dev": "tsx src/index.ts"
   },
   "dependencies": {
-    "@google/genai": "^1.0.0",
+    "@google/genai": "^2.6.0",
     "@hono/node-server": "^1.19.11",
     "hono": "^4.0.0"
   },


### PR DESCRIPTION
## Summary

- Bumps `@google/genai` from `^1.44.0` to `^2.6.0` across the workspace (root devDep, `packages/cli` devDep, `services/compile-worker` runtime dep).
- Narrows the optional peer envelope in `@mmnto/totem` and `@mmnto/cli` from `>=1.0.0` to `>=2.0.0` to match the major we now test and build against.
- Pure version-bump: zero code edits at the 2 SDK call sites (`packages/core/src/embedders/gemini-embedder.ts:91,109`, `packages/cli/src/orchestrators/gemini-orchestrator.ts:66,77`) — probe-verified API-stable.

## Dispositional lineage

Optional-peer dep posture preserved per the disposition of [`mmnto-ai/totem-strategy#404`](https://github.com/mmnto-ai/totem-strategy/pull/404) (Proposal 286 — option (c) graceful-degradation), which closes the prereq triage on `mmnto-ai/totem#2018`. The graceful-degradation impl (keyword fallback in `totem search` when the embedder is unavailable) is tracked as a separate follow-on against `mmnto-ai/totem#2018`; this PR is the version bump only.

## Empirical baseline (dry-run probe `2026-05-24T2207Z`, re-verified in main checkout pre-push)

- `pnpm install` — succeeded; 590 sub-packages resolved; pnpm did NOT strict-warn on the new `@modelcontextprotocol/sdk@^1.25.2` peerDep (already satisfied transitively via `@modelcontextprotocol/sdk@1.27.1` in our tree).
- `pnpm --filter @mmnto/totem build` (tsc) — zero TS errors against 2.6.0's `.d.ts`.
- `pnpm --filter @mmnto/cli build` (tsc) — zero TS errors against 2.6.0's `.d.ts`.
- `src/embedders/gemini-embedder.test.ts` — 15 / 15 pass.
- `src/orchestrators/gemini-orchestrator.test.ts` — 12 / 12 pass.
- `src/orchestrators/conformance.test.ts` — 20 / 20 pass.

The four SDK surfaces we use (`new GoogleGenAI({ apiKey })`, `ai.models.embedContent(...)`, `ai.models.generateContent(...)`, and the `response.text` / `response.usageMetadata` / `response.candidates` / `response.embeddings[].values` read paths) all present in `node_modules/@google/genai@2.6.0/dist/genai.d.ts` with signature-compatible shapes.

## Downstream peerDep flag

`@google/genai@2.0.0` introduced a new `peerDependency` on `@modelcontextprotocol/sdk@^1.25.2` that was absent in 1.x. Benign for our consumption (the peer is already transitively satisfied in our tree), but downstream pack consumers with strict peer enforcement who transitively pull `@google/genai` and lack MCP SDK may see a peer warning. The changeset body documents this so consumers hitting the warning can either provide MCP SDK or enable `auto-install-peers=true`.

## Why this is a PATCH bump

W5 is a dep-pin bump with no published code-surface delta and no enforced contract change. The optional-peer envelope narrowing is advisory (warnings, not errors). Downstream library consumers who do not import `@google/genai` see nothing change. Matches the W4 cohort-dep-wave precedent at `e4a24ec5`.

## Test plan

- [x] `pnpm run format` (prepush step 1)
- [x] `pnpm exec totem lint` — PASS, 0 violations across 387 rules
- [x] `pnpm exec totem review` — PASS, deterministic fast-path (all changed files non-code)
- [x] Targeted vitest suites green: gemini-embedder (15/15), gemini-orchestrator (12/12), conformance (20/20)
- [x] tsc zero errors against 2.6.0's `.d.ts` in both `@mmnto/totem` and `@mmnto/cli`
- [ ] CI matrix (ubuntu / macos / windows) — pending
- [ ] CR / GCA bot reviews — pending

## Forward-looking note (not in scope)

`@google/genai@2.x` ships a new `mcpToTool(...)` export (`node_modules/@google/genai@2.6.0/dist/genai.d.ts:8146`) that lets the SDK wrap MCP `Client` instances as Gemini-callable tools. This unlocks the SDK-side primitive for closing the Gemini-deaf-to-`@mmnto/mcp` asymmetry (Claude routes can query our MCP surface live; Gemini routes can't). Heads-up dispatched to strategy-claude at `2026-05-25T0122Z` for gameplan synthesis; activation requires new code (not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)