### PR TITLE
docs(agents): Pass-3 memory→AGENTS.md layer-boundary migration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Canonical source of truth for how AI coding agents (Claude Code, Gemini CLI, Cur
 - Named constants for magic numbers. Zod at system boundaries only.
 - Run `pnpm run format` before committing.
 - **NEVER put secrets in config files.** `.env` only.
-- **Totem is NOT zero-user.** Ships in production on `satur8d` (NBA sports intelligence) and `arhgap11` (3D voxel research game) in addition to dogfooding the totem repo itself. Architectural decisions should respect downstream consumers — breaking changes need migration paths, not just "fix in next major."
+- **Totem is NOT zero-user.** Ships in production on `satur8d` and `arhgap11` in addition to dogfooding this repo. Breaking changes need migration paths, not just "fix in next major."
 
 ## Totem Workflow
 
@@ -27,9 +27,9 @@ Not mechanically enforced. Follow because they reduce PR bot noise.
 - **Before coding:** `/preflight <issue>`. Create a feature branch.
 - **Before pushing:** `pnpm run format` → `totem lint` → `totem review` → verify compile manifest is current.
 - **After merging a PR:** `totem lesson extract <pr> --yes`, then `totem docs` if releasing. Lessons: `totem lesson extract <prs>` → `totem lesson compile`.
-- **NEVER bypass quality gates.** No `git push --no-verify`, `totem-ignore`, `eslint-disable`, `@ts-ignore`, skipped tests, or ignore patterns added to pass CI — without filing a ticket for the root cause. Suppressions need a comment referencing the ticket.
-- **Open PRs Ready-for-review, not Draft.** Solo-dev + bot-review repo: Draft state prevents the only reviewers (CodeRabbit, GCA) from engaging. CR's `.coderabbit.yaml` has `auto_review.drafts: false`; GCA behavior on Drafts is unreliable. Open Ready; flip to Draft only when you explicitly need WIP-without-bot-review.
-- **Vendor routing — code vs strategy.** Claude is the default code executor: production code, tests, CLI commands, corpus edits. Gemini stays strategic: proposals, ADR drafting, research spikes, schema sanity-checks, dissimilar-auditor passes. Cross-vendor "second pair of eyes" is fine in both directions; "Gemini implement this" is not the default.
+- **NEVER bypass quality gates without a ticket.** No `--no-verify`, `totem-ignore`, `eslint-disable`, `@ts-ignore`, skipped tests, or CI-pacifying ignore patterns. Suppressions need a ticket-ref comment.
+- **Open PRs Ready, not Draft.** CR (`auto_review.drafts: false`) + GCA don't review Drafts; in this solo-dev + bot-review repo Draft has no audience.
+- **Vendor routing.** Claude is the default code executor (production code, tests, CLI, corpus). Gemini stays strategic (proposals, ADRs, audits, dissimilar-auditor passes). Cross-vendor second-opinion fine both directions; "Gemini implement" is not the default.
 
 ## Contributor Principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,7 @@ Canonical source of truth for how AI coding agents (Claude Code, Gemini CLI, Cur
 - Named constants for magic numbers. Zod at system boundaries only.
 - Run `pnpm run format` before committing.
 - **NEVER put secrets in config files.** `.env` only.
+- **Totem is NOT zero-user.** Ships in production on `satur8d` (NBA sports intelligence) and `arhgap11` (3D voxel research game) in addition to dogfooding the totem repo itself. Architectural decisions should respect downstream consumers — breaking changes need migration paths, not just "fix in next major."
 
 ## Totem Workflow
 
@@ -26,7 +27,9 @@ Not mechanically enforced. Follow because they reduce PR bot noise.
 - **Before coding:** `/preflight <issue>`. Create a feature branch.
 - **Before pushing:** `pnpm run format` → `totem lint` → `totem review` → verify compile manifest is current.
 - **After merging a PR:** `totem lesson extract <pr> --yes`, then `totem docs` if releasing. Lessons: `totem lesson extract <prs>` → `totem lesson compile`.
-- **NEVER use `git push --no-verify`.** Also no `totem-ignore` or `eslint-disable` without a ticket.
+- **NEVER bypass quality gates.** No `git push --no-verify`, `totem-ignore`, `eslint-disable`, `@ts-ignore`, skipped tests, or ignore patterns added to pass CI — without filing a ticket for the root cause. Suppressions need a comment referencing the ticket.
+- **Open PRs Ready-for-review, not Draft.** Solo-dev + bot-review repo: Draft state prevents the only reviewers (CodeRabbit, GCA) from engaging. CR's `.coderabbit.yaml` has `auto_review.drafts: false`; GCA behavior on Drafts is unreliable. Open Ready; flip to Draft only when you explicitly need WIP-without-bot-review.
+- **Vendor routing — code vs strategy.** Claude is the default code executor: production code, tests, CLI commands, corpus edits. Gemini stays strategic: proposals, ADR drafting, research spikes, schema sanity-checks, dissimilar-auditor passes. Cross-vendor "second pair of eyes" is fine in both directions; "Gemini implement this" is not the default.
 
 ## Contributor Principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@ Not mechanically enforced. Follow because they reduce PR bot noise.
 - **After merging a PR:** `totem lesson extract <pr> --yes`, then `totem docs` if releasing. Lessons: `totem lesson extract <prs>` → `totem lesson compile`.
 - **NEVER bypass quality gates without a ticket.** No `--no-verify`, `totem-ignore`, `eslint-disable`, `@ts-ignore`, skipped tests, or CI-pacifying ignore patterns. Suppressions need a ticket-ref comment.
 - **Open PRs Ready, not Draft.** CR (`auto_review.drafts: false`) + GCA don't review Drafts; in this solo-dev + bot-review repo Draft has no audience.
-- **Vendor routing.** Claude is the default code executor (production code, tests, CLI, corpus). Gemini stays strategic (proposals, ADRs, audits, dissimilar-auditor passes). Cross-vendor second-opinion fine both directions; "Gemini implement" is not the default.
+- **Vendor routing.** Claude is the default code executor; Gemini stays strategic (proposals, ADRs, audits). Cross-vendor second-opinion fine both ways; "Gemini implement" is not the default.
 
 ## Contributor Principles
 


### PR DESCRIPTION
## Summary

Pass-3 of the totem-claude memory audit migrated four entries from auto-memory into `AGENTS.md` because they apply to **any agent** working in this repo, not just my orchestrator role.

The full audit cut 135 → 1 active memory entry across three passes. Pass-3 specifically targets layer-boundary discipline: content that survives the "applies to any agent in this repo" filter belongs in repo-canonical instructions (committed, PR-reviewed, cross-vendor), not in per-agent auto-memory.

Companion dogfood at `mmnto-ai/totem-strategy#414` (strategy-claude's parallel audit landed first; this is the totem-side application).

## What's migrated

| Was in memory | Now in AGENTS.md § |
|---|---|
| `user_projects.md` — Totem ships in production on `satur8d` + `arhgap11` (not zero-user) | Essentials |
| `feedback_no_suppress.md` — broader no-bypass class beyond `--no-verify`/`totem-ignore`/`eslint-disable` (adds `@ts-ignore`, skipped tests, CI-pacifying ignore-patterns; explicit ticket-ref-comment requirement) | Totem Workflow |
| `feedback_no_draft_prs_solo_dev.md` — Draft prevents the only reviewers (CR + GCA) from engaging in this solo-dev + bot-review repo | Totem Workflow |
| `feedback_claude_default_executor.md` — vendor routing (Claude default code executor; Gemini strategic) | Totem Workflow |

## FR-C01 budget

First commit landed AGENTS.md at 6378 chars; pre-push hook caught the FR-C01 / FMEA-001 ceiling (`CANONICAL_MAX_CHARS = 6000` in `config-drift.test.ts`). Second commit trimmed verbose parentheticals + condensed rationale to keep the load-bearing WHY while restoring headroom. Final: 5987 chars (13-char buffer), 36/40 directives. Substance unchanged.

## Layer-boundary heuristic banked

Post-audit discipline now in `MEMORY.md`: for any banking attempt, check (a) is the content strictly orchestrator-role-or-guardrail-AND-incident-anchored, AND (b) is it already in project-instructions / `CLAUDE.md` / `AGENTS.md` / `doctrine/**`? If (b), it's restated content — cut or migrate.

Sole surviving memory entry: `feedback_ask_before_pr_merge.md` (anchored to `mmnto-ai/totem#807`).

## Test plan

- [x] `pnpm run format` — clean
- [x] `totem lint` — PASS (387 rules, 0 violations)
- [x] `totem review` — non-code fast-path
- [x] `pnpm --filter @mmnto/cli test` — 4563 tests pass (was 2262 in this package alone)
- [x] `config-drift.test.ts` AGENTS.md char-count + directive-count tests pass
- [ ] Bot review (CR + GCA) on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)