### PR TITLE
feat(cli+core): totem gate check engine + freeze-check gate (WS3, #2043)

### DIFF
--- a/.changeset/ws3-gate-check-engine-2043.md
+++ b/.changeset/ws3-gate-check-engine-2043.md
@@ -1,5 +1,6 @@
 ---
 '@mmnto/cli': minor
+'@mmnto/totem': minor
 ---
 
 feat(cli+core): `totem gate check` action-gate engine + freeze-check reference gate (WS3, #2043)

--- a/.changeset/ws3-gate-check-engine-2043.md
+++ b/.changeset/ws3-gate-check-engine-2043.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/cli': minor
+---
+
+feat(cli+core): `totem gate check` action-gate engine + freeze-check reference gate (WS3, #2043)

--- a/.totem/specs/2043.md
+++ b/.totem/specs/2043.md
@@ -1,0 +1,108 @@
+# WS3 — `totem gate check` engine + first reference gate (freeze-check)
+
+**Spec type:** preflight (no GitHub issue in `mmnto-ai/totem`; tracked as `mmnto-ai/totem-strategy#439`, manually authored per the W4/W5 no-issue precedent)
+**Source:** WS3 of Proposal 288 (Drift-Bounded Orientation + Action-Gates), §6.2 (gate engine) / §8 (ships FIRST) / §10 (acceptance)
+**Drafted:** 2026-05-29 (claude-0074)
+**Author:** totem-claude
+**Dispatch lineage:** `strategy-claude` T1740Z WS3 dispatch; my T2053Z ACK
+**Proposal lineage:** `mmnto-ai/totem-strategy#443` (Proposal 288 → Active, merged)
+
+This document was authored manually (not via `totem spec`) because WS3 has no `mmnto-ai/totem` issue and the local embedder is unavailable (degraded retrieval). Grounding is first-hand against source this session.
+
+## Phase 1 summary
+
+### What WS3 builds
+
+A new `totem gate check --event <type> --payload <json>` command that evaluates a **decidable predicate** against a **deterministic source** and returns `allow | warn | deny` + cited provenance — generalizing the read → filter-by-predicate → query-deterministic-source → emit shape proven by the shipped `review-gate.sh`. Plus the first reference gate, **freeze-check** (reads a repo-local `.totem/freeze.json`). Plus the implementing ADR that ratifies the binding gate-disposition contract + the concrete false-positive ceiling (§6.2 defers both to the ADR).
+
+### Grounding (verified against source this session)
+
+- **No `totem gate` / `gate.ts` exists** — greenfield (`packages/cli/src/commands/`, `index.ts` registration both absent).
+- **`totem hook run` ALREADY EXISTS** — "Evaluate compiled-hooks against a tool-call payload (PreToolUse runtime entrypoint)" (`commands/hook-run.ts`). It runs **lesson-compiled rules** (ADR-103 pipeline). This is the adjacency WS3 must be positioned against (see Open Question 1) — gates read _external state_, hooks run _compiled rules_.
+- **`review-gate.sh`** (`.claude/hooks/review-gate.sh`, ADR-083 Actor-Aware Enforcement via Content-Hash Lock) — the shipped primitive to generalize: read hook-input JSON → filter by predicate (git push) → query deterministic source (`.totem/cache/.reviewed-content-hash`) → emit allow (exit 0) / deny (exit 2).
+- **`.totem/freeze.json`** — exists in `mmnto-ai/totem-strategy` (shape `{_note, frozen: [{subsystem, since, reason, tracking, do-not}]}`, 1 live entry: rule-compilation parked 2026-05-17); **absent in totem core** (Tenet 12: core ships the primitive, repos wire opt-in).
+- **`<noun> <verb>` subcommand convention** is established (`totem lesson <verb>`, `totem hook <verb>`, `totem rule <verb>`) — `totem gate check` fits it.
+- **`recordShieldOverride` / `writeReviewedContentHash`** (`commands/shield.ts:425-524`) — the cache-stamp pattern (gate-logic → cache-state → downstream-unblock). Gate-adjacent but a _separate_ concern from WS3's read-only check.
+
+### Knowledge / lesson signals
+
+- **ADR-083** (content-hash lock) + **ADR-103/104** (deterministic rule compilation + the `totem hook` PreToolUse engine) — the architectural neighborhood; WS3 must not duplicate the hook engine.
+- **upstream-feedback 027** (`totem review --override` updates the trap ledger but doesn't stamp the hash → gate stays blocked) — a load-bearing gate-disposition design input: the disposition path must be coherent with what unblocks the host.
+- **`lesson-9aeb28a5`** (don't stamp the reviewed-content-hash cache on forecasts/empty-diffs — bypass risk) → reinforces WS3's **side-effect-free** invariant: `gate check` must never stamp/mutate.
+- **`lesson-76f7d20c`** (dynamic `await import()` in CLI command handlers) → the new command registers with a lazy import.
+
+---
+
+## Implementation Design
+
+### Scope (2 sentences)
+
+Build a new `totem gate check --event <type> --payload <json>` command in totem core that evaluates one registered decidable-predicate gate against a deterministic source and returns a structured `allow | warn | deny` verdict + cited provenance, shipping with the **freeze-check** reference gate (reads a repo-local `.totem/freeze.json`) and a totem-core ADR ratifying the gate-disposition contract + false-positive ceiling. This explicitly does NOT replace or merge into the existing `totem hook run` compiled-rules engine, does NOT implement the dup-issue gate (follow-on), does NOT add a live `freeze.json` to totem core's own tree (fixture only), and does NOT wire the gate into any repo's PreToolUse hook by default (repos opt in).
+
+### Data model deltas
+
+- **`GateEvent`** (new type): `{ event: string; payload: unknown }`. `event` = closed-enum gate-type discriminator (`"freeze-check"`, later `"content-hash"`, `"dup-issue"`); `payload` = gate-specific JSON. Written by the caller (CLI arg / host); read by the dispatcher.
+- **`GateVerdict`** (new type): `{ disposition: "allow" | "warn" | "deny"; reason: string; provenance: GateProvenance }`. **Closed enum** for `disposition` — not a free string, no sentinel overloading. Every verdict carries provenance (invariant).
+- **`GateProvenance`** (new type): `{ source: string; ref: string; matched: string | null; checkedAt: string }` — the cited primitive + matched value (e.g. `source: ".totem/freeze.json"`, `matched: "rule-compilation"`).
+- **gate registry** (new, module-level `Map<string, GateEvaluator>`): event-type → pure evaluator fn. **Bounded** (known gate types only); immutable after module load; written by registration code, read by the dispatcher. Unknown event ⇒ fail loud (never default-allow).
+- **`.totem/freeze.json`** (read-only input to freeze-check; not a new schema — mirrors the totem-strategy shape): `{_note, frozen: [{subsystem, since, reason, tracking, do-not}]}`. freeze-check matches `payload.subsystem`/path against `frozen[].subsystem` (+ optional `do-not` globs).
+- **gate-disposition contract** (ADR-ratified, normative not a code type): the binding semantics of allow/warn/deny and the per-gate FP ceiling.
+
+**Collision/sentinel note:** the command emits the structured `GateVerdict`; it does NOT reuse `review-gate.sh`'s 0/2 exit-code as its data model. The _host_ (PreToolUse wrapper) maps `disposition` → exit code. Keeping the contract host-agnostic is the point (callable by Claude PreToolUse, Gemini/Codex wrappers, humans advisory).
+
+### State lifecycle
+
+- **`GateEvent` / `GateVerdict`:** per-invocation (request-scoped); created on call, destroyed on exit.
+- **gate registry:** process-lifetime; immutable post-load; owned by the gate module.
+- **`.totem/freeze.json`:** persistent, repo-local; written by humans / WS1 tooling; **read-only** from the gate's perspective.
+- **No one-shot flags, no cross-lifecycle consumed-before-success hazards.** `gate check` is a **pure read → decide**; it does not mutate freeze.json, the hash cache, or the trap ledger. (Mutation/stamping is `shield`/`review`'s job, deliberately not the gate's — see `lesson-9aeb28a5`.)
+
+### Failure modes
+
+| Failure                                                          | Category | Agent-facing surface                                                                             | Recovery                                                      |
+| ---------------------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
+| Unknown `--event` type (no registered gate)                      | init     | hard error, non-zero exit, lists known gate types; **never** default-allow                       | caller fixes the event type                                   |
+| Malformed `--payload` JSON                                       | init     | hard error ("invalid payload JSON")                                                              | caller fixes payload                                          |
+| `.totem/freeze.json` absent (freeze-check)                       | runtime  | **`allow`** + provenance `"no-freeze-file"` (absence = nothing frozen — semantically correct)    | n/a (documented empty-freeze case)                            |
+| `.totem/freeze.json` malformed/unparseable                       | runtime  | **hard error / fail closed** — never silent-allow (a corrupt freeze must not be a silent bypass) | fix the freeze file                                           |
+| Gate evaluator throws unexpectedly                               | runtime  | hard error, non-zero exit; never silent-allow                                                    | fix evaluator; deny-class fails closed, all classes fail loud |
+| Predicate undecidable for the payload (e.g. dup-issue ambiguity) | runtime  | **`warn` / require-ack**, never hard-deny (overclaimed determinism trains bypass — lc#448)       | agent acks; governed by the FP ceiling                        |
+| Host has no interception point (some vendors)                    | init     | declared **`orientation-only`** degraded mode (documented)                                       | n/a                                                           |
+
+**Tenet 4 callout:** the _only_ allow-on-absence is the missing-freeze-file case (absence is semantically "nothing frozen"). Malformed/corrupt sources and evaluator errors **fail loud**, never silent-allow.
+
+### Invariants to lock in via tests
+
+- Unknown event type ⇒ non-zero exit, never `allow` (no default-allow path exists).
+- freeze-check ⇒ `deny` (per OQ2) iff `payload.subsystem` matches a `frozen[]` entry; `allow` when no match.
+- Missing `freeze.json` ⇒ `allow` with explicit `"no-freeze-file"` provenance (not an error).
+- Malformed `freeze.json` ⇒ fails loud, never silent-allow.
+- Every `GateVerdict` carries provenance citing the concrete source + matched value (no verdict without provenance).
+- `gate check` is **side-effect-free** — a check never mutates `freeze.json`, the hash cache, or the ledger.
+- Output contract is **host-agnostic & stable** — identical `GateVerdict` shape regardless of caller.
+- **Regression fixture (WS6 #442 seed):** freeze-check would have `deny`'d this session's frozen-subsystem patch.
+
+### Consumer opt-in / wiring (resolved 2026-05-29 — strategy-claude concurrence)
+
+Tenet 12: totem core ships the gate engine; repos wire opt-in. Today PreToolUse wiring is hard-coded at `totem init` with no per-gate selection — WS3 replaces that with explicit opt-in:
+
+- **Opt-in verb:** `totem gate install [--all | --<name>]` (matches the `lesson/hook/rule <verb>` convention), idempotently merging a PreToolUse entry into the repo's `.claude/settings.*`; plus a `totem init --gates=freeze-check,...` sugar for init-time opt-in. New gates ship without new init flags.
+- **One thin parameterized wrapper, not per-gate scripts:** a single `.claude/hooks/` wrapper invokes `totem gate check --event <name>` with the tool-call payload on stdin. Per-gate wrapper files = N copies that drift across repos (the copy-paste-per-repo class being retired) — generalize `review-gate.sh` into the one parameterized shape.
+- **Engine stays a pure function [LOCKED — strategy-claude T2308Z]:** `totem gate check` emits the raw `GateVerdict` JSON to stdout; the **wrapper** maps `disposition` → host exit code (Claude PreToolUse 0/2; other hosts their own). The command is NOT coupled to any host's exit-code contract — that is what keeps it callable by any host (the OQ1 shared-contract property).
+- **Enforcement tier:** `totem init --pilot` → gate `warn`s; default / `--strict` → gate `deny`s on a match (maps onto OQ2).
+
+### Open questions
+
+1. **Relationship to the existing `totem hook run` engine.** `totem hook run` already evaluates compiled-lesson rules against a tool-call payload (the PreToolUse entrypoint); `totem gate check` evaluates decidable predicates against external deterministic state (freeze.json/GH/hash).
+   - **Options:** (a) new `totem gate` noun, sibling to `totem hook` — distinct engine, shared allow|warn|deny contract + provenance shape, host can call both; (b) fold gates into `totem hook run` as a new rule/target type — one entrypoint; (c) ship `totem gate` now, converge into the Spine's "action rule" target type later.
+   - **Recommendation:** **(c)** — ship `totem gate check` as a new noun (the dispatch specified it; gates and compiled-rules read fundamentally different sources), share the `GateVerdict` contract + provenance shape with `hook run`, and defer gate↔rule convergence to the Spine's action-rule target type (the dispatch's own long-term framing). **Surface to strategy-claude for concurrence** — it touches the hook-engine boundary they co-own.
+   - **DISPOSITION (2026-05-29):** strategy-claude **concurred with (c)** (T2214Z); user design-doc review still pending. **Falsifiable convergence criterion (banked for the implementing ADR):** `totem gate` folds into the rule/hook target-type system _when and only when_ the Spine ships an "action rule" target type (a rule whose target = tool-call payload + derived state, per P288 §8); until that target type exists, `gate` remains a separate hand-written-evaluator noun. (Trigger, not "later.")
+
+2. **freeze-check disposition — `deny` or `warn`?**
+   - **Options:** (a) `deny` (hard block on touching a frozen subsystem); (b) `warn`/require-ack.
+   - **Recommendation:** **`deny` on an exact frozen-subsystem match** — freeze.json is an explicit, deterministic, human-authored "do not touch" with FP≈0 by construction, so hard-deny matches its intent; reserve `warn` for lower-precision gates (dup-issue). Ratify in the ADR's FP-ceiling section.
+   - **DISPOSITION:** affirmed by strategy-claude (T2214Z), no notes — "the decidable-vs-undecidable boundary the 5-lane round drew + the lc#448 exhibit."
+
+3. **Where does the binding gate-disposition contract + FP ceiling live?** §6.2 defers it to the implementing ADR.
+   - **Recommendation:** draft a totem-core ADR (next ADR-1xx) ratifying: allow/warn/deny semantics; "undecidable ⇒ warn, never deny"; per-gate FP ceiling (freeze-check FP≈0; dup-issue must stay under a stated ceiling); and the side-effect-free invariant. Co-locate the WS6 (#442) regression harness in totem core beside the engine (my Q4 lean to strategy-claude).
+   - **DISPOSITION:** affirmed by strategy-claude (T2214Z), incl. WS6 co-location; the ADR also ratifies the OQ1 falsifiable convergence criterion.

--- a/.totem/specs/2043.md
+++ b/.totem/specs/2043.md
@@ -1,6 +1,6 @@
 # WS3 — `totem gate check` engine + first reference gate (freeze-check)
 
-**Spec type:** preflight (no GitHub issue in `mmnto-ai/totem`; tracked as `mmnto-ai/totem-strategy#439`, manually authored per the W4/W5 no-issue precedent)
+**Spec type:** preflight (impl issue `mmnto-ai/totem#2043` filed 2026-05-29 under the dual-filing convention; charter `mmnto-ai/totem-strategy#439`. Originally drafted before the impl issue existed — per the W4/W5 no-issue precedent — and manually authored because the local embedder is degraded; the implementing PR closes `#2043`.)
 **Source:** WS3 of Proposal 288 (Drift-Bounded Orientation + Action-Gates), §6.2 (gate engine) / §8 (ships FIRST) / §10 (acceptance)
 **Drafted:** 2026-05-29 (claude-0074)
 **Author:** totem-claude

--- a/packages/cli/src/commands/gate.test.ts
+++ b/packages/cli/src/commands/gate.test.ts
@@ -62,11 +62,9 @@ describe('gateCheckCommand', () => {
     process.chdir(originalCwd);
     vi.restoreAllMocks();
     process.exitCode = undefined;
-    try {
-      fs.rmSync(tmpDir, { recursive: true, force: true });
-    } catch {
-      /* best-effort cleanup (Windows ENOTEMPTY tolerance) */
-    }
+    // maxRetries/retryDelay rides out transient Windows ENOTEMPTY/EBUSY without
+    // an empty catch swallowing real teardown failures (repo test-cleanup idiom).
+    fs.rmSync(tmpDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
 
   it('throws GATE_INVALID on malformed --payload JSON — never silent-allow', async () => {

--- a/packages/cli/src/commands/gate.test.ts
+++ b/packages/cli/src/commands/gate.test.ts
@@ -1,0 +1,126 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TotemError } from '@mmnto/totem';
+
+import { gateCheckCommand } from './gate.js';
+
+/**
+ * CLI-boundary tests for `totem gate check`.
+ *
+ * The engine itself (allow/deny/no-file/fail-closed/side-effect-free) is
+ * covered by `@mmnto/totem`'s gate-engine.test.ts. This file covers the
+ * command seam the engine tests can't reach:
+ *   - `--payload` JSON parsing (a command-layer concern, before the engine runs)
+ *   - the unknown-event throw propagating through the command (never silent-allow)
+ *   - the LOCKED host-agnostic contract: the command emits a raw `GateVerdict`
+ *     to stdout and does NOT map the disposition onto an exit code (a `deny`
+ *     leaves `process.exitCode` untouched — the PreToolUse wrapper owns 0/2).
+ *
+ * The non-zero exit on a thrown error is delegated to the shared `handleError`
+ * entrypoint in index.ts (exercised by every command); these tests assert the
+ * command's own contract — throw on failure, never default-allow.
+ */
+
+function makeTmpDir(): string {
+  // `.native` expands Windows 8.3 short names so process.cwd()/realpath agree.
+  return fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), 'totem-gate-cli-')));
+}
+
+const MINIMAL_CONFIG = [
+  'targets:',
+  '  - glob: "**/*.ts"',
+  '    type: code',
+  '    strategy: typescript-ast',
+  '',
+].join('\n');
+
+const FROZEN = JSON.stringify({
+  _note: 'test fixture',
+  frozen: [
+    { subsystem: 'rule-compilation', since: '2026-05-17', reason: 'paused', tracking: '#1' },
+  ],
+});
+
+describe('gateCheckCommand', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    originalCwd = process.cwd();
+    // The command resolves config + totemDir from process.cwd().
+    fs.writeFileSync(path.join(tmpDir, 'totem.yaml'), MINIMAL_CONFIG);
+    fs.mkdirSync(path.join(tmpDir, '.totem'), { recursive: true });
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+    try {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    } catch {
+      /* best-effort cleanup (Windows ENOTEMPTY tolerance) */
+    }
+  });
+
+  it('throws GATE_INVALID on malformed --payload JSON — never silent-allow', async () => {
+    // Payload parsing fails before the engine (or even config) runs.
+    try {
+      await gateCheckCommand({ event: 'freeze-check', payload: '{ not valid json' });
+      expect.unreachable('expected gateCheckCommand to throw on malformed payload');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TotemError);
+      expect((err as TotemError).code).toBe('GATE_INVALID');
+      expect((err as TotemError).message).toMatch(/invalid --payload json/i);
+    }
+  });
+
+  it('throws on an unknown --event — never default-allow', async () => {
+    await expect(gateCheckCommand({ event: 'made-up-gate', payload: '{}' })).rejects.toThrow(
+      /unknown gate event/i,
+    );
+  });
+
+  it('emits a raw GateVerdict to stdout and does NOT map disposition to an exit code', async () => {
+    fs.writeFileSync(path.join(tmpDir, '.totem', 'freeze.json'), FROZEN);
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await gateCheckCommand({ event: 'freeze-check', payload: '{"subsystem":"rule-compilation"}' });
+
+    // Exactly one JSON line written.
+    expect(spy.mock.calls).toHaveLength(1);
+    const output = spy.mock.calls[0]![0] as string;
+    expect(output.endsWith('\n')).toBe(true);
+
+    const verdict = JSON.parse(output);
+    // Host-agnostic GateVerdict shape (the output-contract-stability invariant).
+    expect(verdict.disposition).toBe('deny');
+    expect(verdict).toHaveProperty('reason');
+    expect(verdict.provenance.source).toBe('.totem/freeze.json');
+    expect(verdict.provenance.matched).toBe('rule-compilation');
+    expect(verdict.provenance.checkedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+
+    // LOCKED: a `deny` is a successful evaluation — the command must not couple
+    // itself to Claude's 0/2 contract. Exit-code mapping is the wrapper's job.
+    expect(process.exitCode).toBeFalsy();
+  });
+
+  it('emits an allow verdict (exit code untouched) when nothing matches', async () => {
+    fs.writeFileSync(path.join(tmpDir, '.totem', 'freeze.json'), FROZEN);
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await gateCheckCommand({ event: 'freeze-check', payload: '{"subsystem":"something-else"}' });
+
+    const output = spy.mock.calls[0]![0] as string;
+    const verdict = JSON.parse(output);
+    expect(verdict.disposition).toBe('allow');
+    expect(verdict.provenance.matched).toBeNull();
+    expect(process.exitCode).toBeFalsy();
+  });
+});

--- a/packages/cli/src/commands/gate.ts
+++ b/packages/cli/src/commands/gate.ts
@@ -1,0 +1,42 @@
+import * as path from 'node:path';
+
+import { evaluateGate, TotemError } from '@mmnto/totem';
+
+import { isGlobalConfigPath, loadConfig, resolveConfigPath } from '../utils.js';
+
+export interface GateCheckCommandOptions {
+  event: string;
+  payload: string;
+}
+
+/**
+ * `totem gate check --event <type> --payload <json>`
+ *
+ * Evaluates a gate against deterministic state and writes the raw `GateVerdict`
+ * JSON to stdout. The command is host-agnostic: it does NOT map the disposition
+ * onto an exit code — the calling PreToolUse wrapper does that. Exit is 0 on a
+ * successful evaluation (any disposition); a non-zero exit means the evaluation
+ * itself failed (unknown event, bad payload, unparseable source) — never a
+ * silent default-allow.
+ */
+export async function gateCheckCommand(opts: GateCheckCommandOptions): Promise<void> {
+  let payload: unknown;
+  try {
+    payload = JSON.parse(opts.payload);
+  } catch (err) {
+    throw new TotemError(
+      'GATE_INVALID',
+      `Invalid --payload JSON: ${err instanceof Error ? err.message : String(err)}`,
+      'Pass valid JSON, e.g. --payload \'{"subsystem":"rule-compilation"}\'.',
+    );
+  }
+
+  const cwd = process.cwd();
+  const configPath = resolveConfigPath(cwd);
+  const config = await loadConfig(configPath);
+  const configRoot = isGlobalConfigPath(configPath) ? cwd : path.dirname(configPath);
+  const totemDir = path.join(configRoot, config.totemDir);
+
+  const verdict = evaluateGate(opts.event, payload, totemDir);
+  process.stdout.write(JSON.stringify(verdict) + '\n');
+}

--- a/packages/cli/src/commands/gate.ts
+++ b/packages/cli/src/commands/gate.ts
@@ -1,7 +1,5 @@
 import * as path from 'node:path';
 
-import { evaluateGate, TotemError } from '@mmnto/totem';
-
 import { isGlobalConfigPath, loadConfig, resolveConfigPath } from '../utils.js';
 
 export interface GateCheckCommandOptions {
@@ -20,6 +18,10 @@ export interface GateCheckCommandOptions {
  * silent default-allow.
  */
 export async function gateCheckCommand(opts: GateCheckCommandOptions): Promise<void> {
+  // Lazy-load @mmnto/totem inside the handler (ADR-072 §3) so the heavy core
+  // module never loads on unrelated CLI invocations (e.g. `totem --help`).
+  const { evaluateGate, TotemError } = await import('@mmnto/totem');
+
   let payload: unknown;
   try {
     payload = JSON.parse(opts.payload);

--- a/packages/cli/src/commands/gate.ts
+++ b/packages/cli/src/commands/gate.ts
@@ -26,8 +26,9 @@ export async function gateCheckCommand(opts: GateCheckCommandOptions): Promise<v
   } catch (err) {
     throw new TotemError(
       'GATE_INVALID',
-      `Invalid --payload JSON: ${err instanceof Error ? err.message : String(err)}`,
+      'Invalid --payload JSON',
       'Pass valid JSON, e.g. --payload \'{"subsystem":"rule-compilation"}\'.',
+      err,
     );
   }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1135,6 +1135,27 @@ hookCmd
     }
   });
 
+// ─── Gate noun-verb subcommands (WS3 — action-gate engine) ───
+
+const gateCmd = program
+  .command('gate')
+  .description('Gate engine — evaluate decidable predicates against deterministic state');
+
+gateCmd
+  .command('check')
+  .description('Evaluate a gate predicate; emit a GateVerdict (allow|warn|deny) as JSON to stdout')
+  .requiredOption('--event <type>', 'Gate event type (e.g. freeze-check)')
+  .requiredOption('--payload <json>', 'Gate-specific JSON payload')
+  .action(async (opts: { event: string; payload: string }) => {
+    try {
+      const { gateCheckCommand } = await import('./commands/gate.js');
+      await gateCheckCommand(opts);
+    } catch (err) {
+      handleError(err); // handleError returns `never`; unreachable throw below satisfies the fail-loud check
+      throw err;
+    }
+  });
+
 // ─── Lesson noun-verb subcommands ────────────────────────
 
 const lessonCmd = program.command('lesson').description('Manage project lessons');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1146,6 +1146,10 @@ gateCmd
   .description('Evaluate a gate predicate; emit a GateVerdict (allow|warn|deny) as JSON to stdout')
   .requiredOption('--event <type>', 'Gate event type (e.g. freeze-check)')
   .requiredOption('--payload <json>', 'Gate-specific JSON payload')
+  .addHelpText(
+    'after',
+    `\nExample:\n  $ totem gate check --event freeze-check --payload '{"subsystem":"rule-compilation"}'\n`,
+  )
   .action(async (opts: { event: string; payload: string }) => {
     try {
       const { gateCheckCommand } = await import('./commands/gate.js');

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -37,7 +37,8 @@ export type TotemErrorCode =
   | 'SESSION_ID_WRITE_FAILED'
   | 'SESSION_ID_READ_FAILED'
   | 'BADGE_VERIFICATION_FAILED'
-  | 'CLAIM_DISCIPLINE_FAILED';
+  | 'CLAIM_DISCIPLINE_FAILED'
+  | 'GATE_INVALID';
 
 export class TotemError extends Error {
   readonly code: TotemErrorCode;

--- a/packages/core/src/freeze.ts
+++ b/packages/core/src/freeze.ts
@@ -8,7 +8,7 @@ import { TotemConfigError } from './errors.js';
 export const FREEZE_FILE = 'freeze.json';
 
 const FreezeEntrySchema = z.object({
-  subsystem: z.string(),
+  subsystem: z.string().min(1, 'subsystem must be a non-empty string'),
   since: z.string().optional(),
   reason: z.string().optional(),
   tracking: z.string().optional(),

--- a/packages/core/src/freeze.ts
+++ b/packages/core/src/freeze.ts
@@ -45,8 +45,10 @@ export function readFreezeConfig(totemDir: string): FreezeConfig | null {
       return null;
     }
     throw new TotemConfigError(
-      `Failed to read ${FREEZE_FILE}: ${err instanceof Error ? err.message : String(err)}`,
+      `Failed to read ${FREEZE_FILE}`,
       'Check filesystem permissions for the .totem directory.',
+      'CONFIG_MISSING',
+      err,
     );
   }
 
@@ -55,8 +57,10 @@ export function readFreezeConfig(totemDir: string): FreezeConfig | null {
     parsed = JSON.parse(raw);
   } catch (err) {
     throw new TotemConfigError(
-      `Malformed ${FREEZE_FILE}: ${err instanceof Error ? err.message : String(err)}`,
+      `Malformed ${FREEZE_FILE}`,
       'Fix the JSON syntax in .totem/freeze.json, or remove the file if nothing is frozen.',
+      'CONFIG_INVALID',
+      err,
     );
   }
 
@@ -65,6 +69,8 @@ export function readFreezeConfig(totemDir: string): FreezeConfig | null {
     throw new TotemConfigError(
       `Invalid ${FREEZE_FILE}: ${result.error.issues.map((i) => i.message).join('; ')}`,
       'freeze.json must be { frozen: [{ subsystem, since?, reason?, tracking?, "do-not"? }] }.',
+      'CONFIG_INVALID',
+      result.error,
     );
   }
 

--- a/packages/core/src/freeze.ts
+++ b/packages/core/src/freeze.ts
@@ -1,0 +1,72 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { z } from 'zod';
+
+import { TotemConfigError } from './errors.js';
+
+export const FREEZE_FILE = 'freeze.json';
+
+const FreezeEntrySchema = z.object({
+  subsystem: z.string(),
+  since: z.string().optional(),
+  reason: z.string().optional(),
+  tracking: z.string().optional(),
+  'do-not': z.array(z.string()).optional(),
+});
+
+const FreezeConfigSchema = z.object({
+  _note: z.string().optional(),
+  frozen: z.array(FreezeEntrySchema),
+});
+
+export type FreezeEntry = z.infer<typeof FreezeEntrySchema>;
+export type FreezeConfig = z.infer<typeof FreezeConfigSchema>;
+
+/**
+ * Read `<totemDir>/freeze.json`, the WS1 freeze primitive.
+ *
+ * - **Absent file → `null`.** Absence means "nothing is frozen" — the only
+ *   allow-on-absence in the gate layer, and semantically correct.
+ * - **Present but unparseable/invalid → THROWS `TotemConfigError` (fail-closed).**
+ *   A corrupt freeze file must never silently bypass itself (Tenet 4).
+ *
+ * This deliberately diverges from the graceful (warn-and-continue) ledger reader:
+ * a gate's deterministic input failing to parse is a hard error, not a shrug.
+ */
+export function readFreezeConfig(totemDir: string): FreezeConfig | null {
+  const filePath = path.join(totemDir, FREEZE_FILE);
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf-8');
+  } catch (err) {
+    if (err instanceof Error && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return null;
+    }
+    throw new TotemConfigError(
+      `Failed to read ${FREEZE_FILE}: ${err instanceof Error ? err.message : String(err)}`,
+      'Check filesystem permissions for the .totem directory.',
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new TotemConfigError(
+      `Malformed ${FREEZE_FILE}: ${err instanceof Error ? err.message : String(err)}`,
+      'Fix the JSON syntax in .totem/freeze.json, or remove the file if nothing is frozen.',
+    );
+  }
+
+  const result = FreezeConfigSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new TotemConfigError(
+      `Invalid ${FREEZE_FILE}: ${result.error.issues.map((i) => i.message).join('; ')}`,
+      'freeze.json must be { frozen: [{ subsystem, since?, reason?, tracking?, "do-not"? }] }.',
+    );
+  }
+
+  return result.data;
+}

--- a/packages/core/src/gate-engine.test.ts
+++ b/packages/core/src/gate-engine.test.ts
@@ -1,0 +1,108 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { TotemConfigError } from './errors.js';
+import { evaluateGate, knownGateEvents } from './gate-engine.js';
+
+let tmpRoot: string;
+let totemDir: string;
+
+function writeFreeze(content: string): void {
+  fs.writeFileSync(path.join(totemDir, 'freeze.json'), content);
+}
+
+const FROZEN = JSON.stringify({
+  _note: 'test fixture',
+  frozen: [
+    { subsystem: 'rule-compilation', since: '2026-05-17', reason: 'paused', tracking: '#1' },
+  ],
+});
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-gate-'));
+  totemDir = path.join(tmpRoot, '.totem');
+  fs.mkdirSync(totemDir, { recursive: true });
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  } catch {
+    /* best-effort cleanup (Windows ENOTEMPTY tolerance) */
+  }
+});
+
+describe('evaluateGate — freeze-check', () => {
+  it('denies when the subsystem matches a frozen entry', () => {
+    writeFreeze(FROZEN);
+    const v = evaluateGate('freeze-check', { subsystem: 'rule-compilation' }, totemDir);
+    expect(v.disposition).toBe('deny');
+    expect(v.provenance.matched).toBe('rule-compilation');
+    expect(v.provenance.source).toBe('.totem/freeze.json');
+    expect(v.reason).toMatch(/frozen/i);
+  });
+
+  it('allows when the subsystem does not match any frozen entry', () => {
+    writeFreeze(FROZEN);
+    const v = evaluateGate('freeze-check', { subsystem: 'something-else' }, totemDir);
+    expect(v.disposition).toBe('allow');
+    expect(v.provenance.matched).toBeNull();
+  });
+
+  it('allows with no-freeze-file provenance when freeze.json is absent', () => {
+    const v = evaluateGate('freeze-check', { subsystem: 'rule-compilation' }, totemDir);
+    expect(v.disposition).toBe('allow');
+    expect(v.provenance.ref).toBe('no-freeze-file');
+    expect(v.reason).toMatch(/nothing is frozen/i);
+  });
+
+  it('fails loud (TotemConfigError) on malformed freeze.json — never silent-allow', () => {
+    writeFreeze('{ not valid json');
+    expect(() => evaluateGate('freeze-check', { subsystem: 'x' }, totemDir)).toThrow(
+      TotemConfigError,
+    );
+  });
+
+  it('fails loud (TotemConfigError) on schema-invalid freeze.json', () => {
+    writeFreeze(JSON.stringify({ frozen: [{ since: '2026-05-17' }] })); // missing `subsystem`
+    expect(() => evaluateGate('freeze-check', { subsystem: 'x' }, totemDir)).toThrow(
+      TotemConfigError,
+    );
+  });
+
+  it('throws on a payload without a subsystem string — never default-allow', () => {
+    writeFreeze(FROZEN);
+    expect(() => evaluateGate('freeze-check', {}, totemDir)).toThrow(/subsystem/i);
+  });
+
+  it('is side-effect-free — never writes or mutates state', () => {
+    writeFreeze(FROZEN);
+    const fp = path.join(totemDir, 'freeze.json');
+    const before = fs.readFileSync(fp, 'utf-8');
+    const entriesBefore = fs.readdirSync(totemDir).sort();
+
+    evaluateGate('freeze-check', { subsystem: 'rule-compilation' }, totemDir);
+
+    expect(fs.readFileSync(fp, 'utf-8')).toBe(before);
+    expect(fs.readdirSync(totemDir).sort()).toEqual(entriesBefore); // no cache stamp, no ledger write
+  });
+
+  it('always carries provenance with an ISO checkedAt', () => {
+    writeFreeze(FROZEN);
+    const v = evaluateGate('freeze-check', { subsystem: 'rule-compilation' }, totemDir);
+    expect(v.provenance.checkedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+describe('evaluateGate — dispatch', () => {
+  it('throws on an unknown gate event — never default-allow', () => {
+    expect(() => evaluateGate('made-up-gate', {}, totemDir)).toThrow(/unknown gate event/i);
+  });
+
+  it('exposes the known gate events', () => {
+    expect(knownGateEvents()).toContain('freeze-check');
+  });
+});

--- a/packages/core/src/gate-engine.test.ts
+++ b/packages/core/src/gate-engine.test.ts
@@ -76,6 +76,30 @@ describe('evaluateGate — freeze-check', () => {
     expect(() => evaluateGate('freeze-check', {}, totemDir)).toThrow(/subsystem/i);
   });
 
+  it('throws on an empty or whitespace-only subsystem payload — never default-allow', () => {
+    writeFreeze(FROZEN);
+    expect(() => evaluateGate('freeze-check', { subsystem: '' }, totemDir)).toThrow(/subsystem/i);
+    expect(() => evaluateGate('freeze-check', { subsystem: '   ' }, totemDir)).toThrow(
+      /subsystem/i,
+    );
+  });
+
+  it('fails loud on a freeze entry with an empty subsystem', () => {
+    writeFreeze(JSON.stringify({ frozen: [{ subsystem: '' }] }));
+    expect(() => evaluateGate('freeze-check', { subsystem: 'x' }, totemDir)).toThrow(
+      TotemConfigError,
+    );
+  });
+
+  it('reflects a custom totemDir name in provenance.source', () => {
+    const customDir = path.join(tmpRoot, '.totem-custom');
+    fs.mkdirSync(customDir, { recursive: true });
+    fs.writeFileSync(path.join(customDir, 'freeze.json'), FROZEN);
+    const v = evaluateGate('freeze-check', { subsystem: 'rule-compilation' }, customDir);
+    expect(v.provenance.source).toBe('.totem-custom/freeze.json');
+    expect(v.disposition).toBe('deny');
+  });
+
   it('is side-effect-free — never writes or mutates state', () => {
     writeFreeze(FROZEN);
     const fp = path.join(totemDir, 'freeze.json');

--- a/packages/core/src/gate-engine.test.ts
+++ b/packages/core/src/gate-engine.test.ts
@@ -84,6 +84,14 @@ describe('evaluateGate — freeze-check', () => {
     );
   });
 
+  it('denies a padded subsystem that matches a frozen entry (no whitespace bypass)', () => {
+    writeFreeze(FROZEN);
+    const v = evaluateGate('freeze-check', { subsystem: '  rule-compilation  ' }, totemDir);
+    expect(v.disposition).toBe('deny');
+    expect(v.provenance.matched).toBe('rule-compilation');
+    expect(v.provenance.ref).toBe('rule-compilation'); // normalized, not the padded input
+  });
+
   it('fails loud on a freeze entry with an empty subsystem', () => {
     writeFreeze(JSON.stringify({ frozen: [{ subsystem: '' }] }));
     expect(() => evaluateGate('freeze-check', { subsystem: 'x' }, totemDir)).toThrow(

--- a/packages/core/src/gate-engine.test.ts
+++ b/packages/core/src/gate-engine.test.ts
@@ -28,11 +28,9 @@ beforeEach(() => {
 });
 
 afterEach(() => {
-  try {
-    fs.rmSync(tmpRoot, { recursive: true, force: true });
-  } catch {
-    /* best-effort cleanup (Windows ENOTEMPTY tolerance) */
-  }
+  // maxRetries/retryDelay rides out transient Windows ENOTEMPTY/EBUSY without
+  // an empty catch swallowing real teardown failures (repo test-cleanup idiom).
+  fs.rmSync(tmpRoot, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
 });
 
 describe('evaluateGate — freeze-check', () => {

--- a/packages/core/src/gate-engine.ts
+++ b/packages/core/src/gate-engine.ts
@@ -1,5 +1,7 @@
+import * as path from 'node:path';
+
 import { TotemError } from './errors.js';
-import { readFreezeConfig } from './freeze.js';
+import { FREEZE_FILE, readFreezeConfig } from './freeze.js';
 import type { GateEvaluator, GateVerdict } from './gate-types.js';
 
 export const FREEZE_CHECK_EVENT = 'freeze-check';
@@ -22,16 +24,20 @@ const freezeCheckEvaluator: GateEvaluator = (payload, totemDir): GateVerdict => 
       ? (payload as { subsystem: string }).subsystem
       : undefined;
 
-  if (subsystem === undefined) {
+  if (subsystem === undefined || subsystem.trim() === '') {
     throw new TotemError(
       'GATE_INVALID',
-      'freeze-check payload requires a "subsystem" string.',
+      'freeze-check payload requires a non-empty "subsystem" string.',
       'Pass --payload \'{"subsystem":"<name>"}\'.',
     );
   }
 
   const checkedAt = new Date().toISOString();
-  const source = '.totem/freeze.json';
+  // Stable, OS-independent provenance label derived from the configured totem
+  // dir name (e.g. `.totem` or a custom `.totem-custom`) — NOT a resolvable
+  // absolute path. Forward-slash by construction so it is deterministic across
+  // platforms and machines (the audit trail must not leak cwd/host paths).
+  const source = `${path.basename(totemDir)}/${FREEZE_FILE}`;
   const config = readFreezeConfig(totemDir);
 
   if (config === null) {

--- a/packages/core/src/gate-engine.ts
+++ b/packages/core/src/gate-engine.ts
@@ -1,0 +1,87 @@
+import { TotemError } from './errors.js';
+import { readFreezeConfig } from './freeze.js';
+import type { GateEvaluator, GateVerdict } from './gate-types.js';
+
+export const FREEZE_CHECK_EVENT = 'freeze-check';
+
+/**
+ * freeze-check: `deny` iff the payload's `subsystem` exactly matches a frozen
+ * subsystem in `.totem/freeze.json`; otherwise `allow`. Absent freeze file →
+ * `allow` (nothing frozen).
+ *
+ * freeze.json is a human-authored, deterministic "do not touch" list, so an
+ * exact subsystem match is FP≈0 and warrants a hard `deny` (OQ2). Glob-matching
+ * a touched path against a frozen entry's `do-not` list is a documented
+ * follow-on; V1 matches on the explicit `subsystem` field.
+ */
+const freezeCheckEvaluator: GateEvaluator = (payload, totemDir): GateVerdict => {
+  const subsystem =
+    payload &&
+    typeof payload === 'object' &&
+    typeof (payload as { subsystem?: unknown }).subsystem === 'string'
+      ? (payload as { subsystem: string }).subsystem
+      : undefined;
+
+  if (subsystem === undefined) {
+    throw new TotemError(
+      'GATE_INVALID',
+      'freeze-check payload requires a "subsystem" string.',
+      'Pass --payload \'{"subsystem":"<name>"}\'.',
+    );
+  }
+
+  const checkedAt = new Date().toISOString();
+  const source = '.totem/freeze.json';
+  const config = readFreezeConfig(totemDir);
+
+  if (config === null) {
+    return {
+      disposition: 'allow',
+      reason: 'No freeze file present — nothing is frozen.',
+      provenance: { source, ref: 'no-freeze-file', matched: null, checkedAt },
+    };
+  }
+
+  const match = config.frozen.find((e) => e.subsystem === subsystem);
+  if (match) {
+    const why = match.reason ? ` (${match.reason})` : '';
+    return {
+      disposition: 'deny',
+      reason: `Subsystem "${subsystem}" is frozen${why}.`,
+      provenance: { source, ref: subsystem, matched: match.subsystem, checkedAt },
+    };
+  }
+
+  return {
+    disposition: 'allow',
+    reason: `Subsystem "${subsystem}" is not frozen.`,
+    provenance: { source, ref: subsystem, matched: null, checkedAt },
+  };
+};
+
+/** Bounded registry of gate evaluators, keyed by event type. Immutable after load. */
+const REGISTRY: ReadonlyMap<string, GateEvaluator> = new Map<string, GateEvaluator>([
+  [FREEZE_CHECK_EVENT, freezeCheckEvaluator],
+]);
+
+/** The known gate event types — for error messages and host discovery. */
+export function knownGateEvents(): string[] {
+  return [...REGISTRY.keys()];
+}
+
+/**
+ * Evaluate a gate. Pure with respect to state: reads deterministic sources,
+ * never mutates. Throws (fail-loud) on an unknown event or an unparseable
+ * source — it never default-allows.
+ */
+export function evaluateGate(event: string, payload: unknown, totemDir: string): GateVerdict {
+  const evaluator = REGISTRY.get(event);
+  if (!evaluator) {
+    throw new TotemError(
+      'GATE_INVALID',
+      `Unknown gate event "${event}". Known events: ${knownGateEvents().join(', ')}.`,
+      'Use one of the known --event values.',
+    );
+  }
+  return evaluator(payload, totemDir);
+}

--- a/packages/core/src/gate-engine.ts
+++ b/packages/core/src/gate-engine.ts
@@ -17,14 +17,20 @@ export const FREEZE_CHECK_EVENT = 'freeze-check';
  * follow-on; V1 matches on the explicit `subsystem` field.
  */
 const freezeCheckEvaluator: GateEvaluator = (payload, totemDir): GateVerdict => {
-  const subsystem =
+  const rawSubsystem =
     payload &&
     typeof payload === 'object' &&
     typeof (payload as { subsystem?: unknown }).subsystem === 'string'
       ? (payload as { subsystem: string }).subsystem
       : undefined;
 
-  if (subsystem === undefined || subsystem.trim() === '') {
+  // Normalize ONCE so the non-empty guard, the freeze-match comparison, and the
+  // emitted provenance all use the same value. Otherwise a padded subsystem
+  // (e.g. " rule-compilation ") passes the guard but fails the exact match,
+  // silently turning a frozen subsystem into `allow` — a freeze bypass.
+  const subsystem = rawSubsystem?.trim();
+
+  if (!subsystem) {
     throw new TotemError(
       'GATE_INVALID',
       'freeze-check payload requires a non-empty "subsystem" string.',

--- a/packages/core/src/gate-types.ts
+++ b/packages/core/src/gate-types.ts
@@ -8,6 +8,13 @@
  * codes and never mutates state (side-effect-free).
  */
 
+/**
+ * Host-agnostic verdict outcome — the host maps each onto its own enforcement
+ * convention (e.g. Claude PreToolUse exit 0/2):
+ *  - `allow` — predicate passed; permit the action.
+ *  - `warn`  — predicate flagged; advisory only, do NOT block (contract member; no gate emits it yet).
+ *  - `deny`  — predicate failed; block the action.
+ */
 export type GateDisposition = 'allow' | 'warn' | 'deny';
 
 export interface GateProvenance {

--- a/packages/core/src/gate-types.ts
+++ b/packages/core/src/gate-types.ts
@@ -1,0 +1,37 @@
+/**
+ * Shared types for the totem gate engine (WS3, Proposal 288 §6.2).
+ *
+ * A gate evaluates a DECIDABLE PREDICATE against DETERMINISTIC STATE and returns
+ * a host-agnostic verdict. The verdict IS the contract: any host (Claude
+ * PreToolUse, Gemini/Codex wrappers, humans-advisory) maps `disposition` onto
+ * its own exit-code / enforcement convention. The engine never maps to exit
+ * codes and never mutates state (side-effect-free).
+ */
+
+export type GateDisposition = 'allow' | 'warn' | 'deny';
+
+export interface GateProvenance {
+  /** The deterministic source consulted (e.g. `.totem/freeze.json`). */
+  source: string;
+  /** A stable reference for what was checked (e.g. the subsystem, or `no-freeze-file`). */
+  ref: string;
+  /** The concrete value that produced the verdict (e.g. the matched frozen subsystem), or null. */
+  matched: string | null;
+  /** ISO-8601 timestamp of when the check ran. */
+  checkedAt: string;
+}
+
+export interface GateVerdict {
+  disposition: GateDisposition;
+  /** Human-readable rationale for the disposition. */
+  reason: string;
+  /** What deterministic source + value backs this verdict. Every verdict carries provenance. */
+  provenance: GateProvenance;
+}
+
+/**
+ * A gate evaluator may READ a deterministic source (freeze.json, a hash cache, a
+ * GH query) but MUST NOT mutate any state. It returns a verdict, or throws
+ * (fail-loud) on an unparseable source — it never default-allows.
+ */
+export type GateEvaluator = (payload: unknown, totemDir: string) => GateVerdict;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,12 @@ export {
   TotemParseError,
 } from './errors.js';
 
+// Gate engine (WS3 — Proposal 288 §6.2)
+export type { FreezeConfig, FreezeEntry } from './freeze.js';
+export { FREEZE_FILE, readFreezeConfig } from './freeze.js';
+export { evaluateGate, FREEZE_CHECK_EVENT, knownGateEvents } from './gate-engine.js';
+export type { GateDisposition, GateEvaluator, GateProvenance, GateVerdict } from './gate-types.js';
+
 // Config schemas
 export type {
   ChunkStrategy,


### PR DESCRIPTION
## What

WS3 of Proposal 288 (Drift-Bounded Orientation + Action-Gates) — the **`totem gate check` action-gate engine** plus its first reference gate, **freeze-check**. This is the ships-first floor (§8) of the drift-bounded epic.

`totem gate check --event <type> --payload <json>` evaluates a **decidable predicate** against **deterministic state** and emits a host-agnostic `GateVerdict` (`allow | warn | deny` + cited provenance) as JSON to stdout. It generalizes the shipped `review-gate.sh` content-hash pattern into a reusable, callable-by-any-host primitive.

Two commits:
- `8614f698` — the engine slice (`totem gate` noun + `check` verb, `GateVerdict`/`GateProvenance` types, freeze-check gate, 10 core tests, the WS3 spec).
- `5e9b1495` — pre-PR housekeeping (stale spec header, missing changeset, CLI-boundary tests).

## Design (full design doc in `.totem/specs/2043.md`)

- **New `totem gate` noun**, sibling to `totem hook` (not folded into `hook run`) — gates read *external state*, hooks run *compiled rules*. Shared `GateVerdict` contract is the seam. Convergence into the Spine's "action rule" target type is the falsifiable trigger documented in the spec's Open Questions.
- **Engine is a pure function. [LOCKED]** `gate check` emits the raw `GateVerdict`; the calling PreToolUse **wrapper** maps disposition → host exit code. The command is NOT coupled to Claude's 0/2 contract — that is what keeps it callable by any host.
- **freeze-check = `deny`** on an exact frozen-subsystem match (reads repo-local `.totem/freeze.json`); `allow` when the file is absent (absence = nothing frozen); **fail-closed** (`TotemConfigError`) on a malformed/schema-invalid freeze file — never a silent default-allow.
- **Side-effect-free:** a `gate check` never stamps the hash cache or writes the ledger (`lesson-9aeb28a5`).

## Testing

- `gate-engine.test.ts` — 10 passing (engine: deny/allow/no-file/fail-closed/side-effect-free/provenance).
- `gate.test.ts` — 4 passing (CLI boundary: malformed `--payload` + unknown `--event` throw; the LOCKED host-agnostic contract — raw verdict to stdout, `process.exitCode` untouched on `deny`).
- `totem review --diff main...HEAD` → **PASS** (1 INFO: `freeze.ts:57` could pass `CONFIG_INVALID` explicitly — optional).
- `tsc --noEmit` clean on `@mmnto/cli`; eslint + prettier clean on changed files.

## Scope / follow-ons

`Refs #2043` (not `Closes`) — the issue's full scope also includes the **`totem gate install` verb** + one parameterized PreToolUse wrapper + `init --gates=` sugar (follow-on PR, which closes #2043) and the **implementing ADR** in `mmnto-ai/totem-strategy/adr/` (ratifies the disposition contract, the per-gate false-positive discipline, the side-effect-free invariant, and the falsifiable convergence criterion).

Charter: `mmnto-ai/totem-strategy#439` · Refs #2043

🤖 Generated with [Claude Code](https://claude.com/claude-code)
