### PR TITLE
feat(cli): totem gate install + parameterized PreToolUse wrapper + init --gates= (WS3 install tail)

### DIFF
--- a/.changeset/prc-gate-install-wrapper-2048.md
+++ b/.changeset/prc-gate-install-wrapper-2048.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/cli': minor
+---
+
+feat(cli): `totem gate install` + parameterized PreToolUse wrapper + `init --gates=` (WS3 install tail, #2048)

--- a/.totem/specs/2048.md
+++ b/.totem/specs/2048.md
@@ -1,0 +1,83 @@
+# Spec — `totem gate install` + parameterized PreToolUse wrapper + `init --gates=` (PR-C, WS3 install tail)
+
+**Issue:** mmnto-ai/totem#2048
+**Charter:** mmnto-ai/totem-strategy#439 (closes on this landing) · **Ratified contract:** ADR-109 (mmnto-ai/totem-strategy#457)
+**Status:** Preflight design — ready to build. The `totem gate check` engine + `GateVerdict` shipped in mmnto-ai/totem#2046; this is the install/wiring tail only.
+**Preflight provenance:** authored from a 4-lane gather verified against the code (every anchor below is a real file:line); the one cross-lane question (wiring depth) was ruled by strategy-claude (dispatch T0041Z).
+
+## What & why
+
+PR-C is the **opt-in distribution layer** for action-gates: the verb + wrapper + init sugar that wire a shipped gate into a consumer repo's Claude PreToolUse hook. It generalizes the shipped `review-gate.sh` content-hash pattern into a reusable, parameterized form. Landing it **closes mmnto-ai/totem-strategy#439's reference-wiring acceptance** (strategy-claude ruled T0041Z that a working `install → wrapper → gate check → disposition → exit-code` mechanism *is* that acceptance). It is also the dropped ADR-108 Q7 / Proposal-257 §5a distribution channel that orientation-hooks (Prop 257) and skills (mmnto-ai/totem-strategy#448) will ride.
+
+## Scope (deliverables)
+
+1. **Extract the settings-merge primitive, namespace-neutral.** Lift `mergeClaudeHooksKey` + `ClaudeSettingsSchema` + `preToolUseHasMatcher` + `ScaffoldOutcome` out of `packages/cli/src/commands/init.ts` into a shared module (suggest `packages/cli/src/commands/host-hooks.ts`). Widen the `entry` param from the closed `ClaudeHookEntry` 3-template union to a structural shape so a gate-wrapper entry is a valid argument. `init.ts` re-imports from the new module — its existing callers (shield-gate, PreWriteShield, SessionStart) must not regress. This is the namespace-neutral install primitive strategy-claude's T0225Z asked for: one merger shared by gate-install, init, and later Prop 257 / mmnto-ai/totem-strategy#448. **Not** a vendor-neutral `installHostHook(vendor)` abstraction — YAGNI, since ADR-109 makes the gate floor Claude/PreToolUse-portability-conditional (no Gemini gate consumer exists; Gemini uses a separate whole-file scaffold path).
+2. **`totem gate install [--all | --<name>]`** — registered as a sibling of `gate check`. `--all` iterates `knownGateEvents()` (the registry is the single source of truth → new gates become installable with zero new CLI flags); `--<name>` validates against `knownGateEvents()` and fails loud on unknown (mirror the engine's no-default-allow). Idempotently merges one PreToolUse entry per gate into committed `.claude/settings.json`. Thin caller of the extracted merger + a `hasGateWrapper` idempotency probe.
+3. **ONE parameterized wrapper** `.claude/hooks/gate-wrapper.cjs` (Node, mirroring `PreWriteShield.cjs` — portable, no bash/jq dependency, `.cjs` extension load-bearing in `type:module` repos). It reads the PreToolUse stdin envelope (`tool_name` / `tool_input`), builds the `--payload` JSON, shells to `totem gate check --event <name> --payload <json>`, parses the emitted `GateVerdict`, and maps **disposition → host exit code**. The `--event <name>` is baked per-entry into the scaffolded `command` string, so "one wrapper, N gates" = N PreToolUse entries pointing at the same script with different `--event` args.
+4. **`totem init --gates=<list|all>`** — thin sugar that parses a comma-list, validates each against `knownGateEvents()`, and routes through the *same* installer function the `gate install` verb uses (no second copy of the merge logic). Register alongside the existing `--bare/--pilot/--strict` options and thread it through `initCommand` options like `forceSkillRefresh`.
+5. **Eject parity** — `eject` must scrub the gate entry it installs, or it is the next orphan-on-eject gap.
+6. **CLI-seam tests** (mirror `gate.test.ts`): idempotent merge, `--all` vs `--<name>`, `--gates=` parse + validation, the disposition→exit-code map incl. the pass-through case, and the eject scrub. **Do not** duplicate `gate-engine.test.ts` (the engine is already covered).
+
+## Design decisions (ratified — ADR-109 + strategy-claude T0041Z)
+
+### Disposition → exit code (the wrapper's whole job; ADR-109 §2)
+- `allow` → exit 0 (silent)
+- `warn` → exit 0 + write `reason`/`provenance` to stderr (advisory; **never** blocks — ADR-109 §1)
+- `deny` → exit 2 (Claude block convention) + `reason`/`provenance` to stderr; under `--pilot` → exit 0 + stderr
+- Branch **only** on `disposition` (ADR-109 R2); `reason`/`provenance` are opaque stderr passthrough, never parsed for control flow.
+- The `--pilot`/`--strict` tier toggle lives in the **wrapper**, not the engine (freeze-check never emits `warn`; the engine stays pure per ADR-109 [LOCKED]).
+
+### The empty-subsystem guardrail (strategy-claude T0041Z — LOAD-BEARING)
+The wrapper MUST distinguish two cases that both look like "gate check did not return allow":
+
+- **No gate applies here → pass through (exit 0).** A PreToolUse Edit/Write delivers `tool_input.file_path` (a *path*), not a `subsystem`. Because path→subsystem mapping is deferred (see Non-goals), an Edit carries **no declared subsystem** → the wrapper must **not** invoke freeze-check for it → exit 0.
+- **A gate applies but its deterministic source is broken → fail-closed block (exit 2).** Only when a gate genuinely applies (a declared subsystem is present) and `totem gate check` exits non-zero (corrupt `freeze.json`, etc.) does the wrapper exit 2.
+
+Rationale: handing freeze-check an empty/unmapped subsystem throws `GATE_INVALID`; a *blanket* fail-closed would then block **every** edit — a gate meant to deny one frozen subsystem denying all edits. **Do not ship a wrapper that is guard-shaped on Edit events while guarding nothing** (Tenet 19: the drift between "mechanism proven" and "frozen subsystems protected"). The wrapper's surface claims "dispatcher / mechanism," not "path-aware freeze protection." For PR-C, freeze-check is exercised via **explicit-subsystem** invocation only (its CLI path + the wrapper unit tests with a synthetic declared-subsystem envelope).
+
+### `gate check` stays untouched
+The wrapper reads stdin and builds the `--payload` arg; **no stdin reader is added to the command**. This keeps the command's contract stable and host-agnostic (ADR-109 [LOCKED]) and confines host-shape parsing to the host wrapper.
+
+### Settings placement
+Committed `.claude/settings.json` (team-level governance — gate opt-in is a repo policy, Tenet 12), matching the PreWriteShield placement rationale, **not** per-developer `settings.local.json`.
+
+## Non-goals (deferred — do NOT build in PR-C)
+
+- **Path→subsystem glob matching.** ADR-109 (line 112) defers it with a falsifiable trigger ("a freeze entry needs path-scoped protection"). **Design seed for when it triggers** (strategy-claude T0041Z): the mapping must be **declared in the freeze entry** (the frozen entry carries its own `paths:`/glob), never **inferred** heuristically from the edited path — declared keeps it a decidable predicate (Tenet 9 / ADR-109's decidable-source requirement); inferred is a fuzzy match that trains bypass. The `freeze.json` schema already carries a dormant optional `do-not: string[]` field as the anchor.
+- `content-hash` and `dup-issue` reference gates (named in Proposal 288 §6.2; not in the V1 roster per ADR-109's earns-its-slot).
+- Any Gemini gate path (orientation-only per ADR-109).
+- Per-gate init flags (the wrapper is `--event`-parameterized; new gates need no new flags).
+
+## Invariants the tests lock
+
+- `install` is idempotent: re-run is a no-op (reuse `mergeClaudeHooksKey`'s `alreadyInstalled` probe with a `hasGateWrapper` predicate keyed on the command substring `gate check --event <name>`, so installing freeze-check twice is a no-op while freeze-check then a future gate adds a second entry).
+- `--all` enumerates `knownGateEvents()` (today `['freeze-check']`); an unknown `--<name>` / `--gates=` member fails loud (no default-install).
+- Wrapper exit map: `allow`→0; `warn`→0+stderr; `deny`→2 (strict) / 0+stderr (pilot); **no-declared-subsystem Edit → 0 (pass through, gate not invoked)**; applicable-gate-source-broken → 2 (fail-closed).
+- `eject` removes the gate entry (parity with install).
+- `init --gates=` routes through the same installer as the verb (one shared function; no duplicated merge logic).
+
+## Acceptance (closes mmnto-ai/totem#2048 + mmnto-ai/totem-strategy#439)
+
+- `totem gate install [--all|freeze-check]` idempotently merges the PreToolUse entry into committed `.claude/settings.json`; re-run is a no-op.
+- `totem init --gates=freeze-check` (and `=all`) wires it via the same path.
+- The wrapper maps disposition→exit code, **passes through** Edits with no declared subsystem (does NOT block-all), and **fail-closes (exit 2)** when an applicable gate's source is broken.
+- `eject` removes the gate entry.
+- CLI-seam tests green; `gate-engine.test.ts` untouched.
+- On merge, **mmnto-ai/totem-strategy#439 closes** (its reference-wiring acceptance is met).
+
+## Key code anchors (verified — preflight run `wgtyyxd1h`)
+
+- `mergeClaudeHooksKey` (the merger to extract): `packages/cli/src/commands/init.ts:221-278`
+- `preToolUseHasMatcher` (idempotency probe): `packages/cli/src/commands/init.ts:280-289`
+- Entry constants (model: `CLAUDE_PREWRITESHIELD_ENTRY:292`): `packages/cli/src/commands/init-templates.ts:186-300`
+- PreWriteShield wrapper template (stdin lifecycle + the 0/1/2 exit-code contract to mirror): `packages/cli/src/commands/init-templates.ts:212-290`
+- `gate check` CLI registration + handler: `packages/cli/src/index.ts:1144-1161`, `packages/cli/src/commands/gate.ts:20-45`
+- `knownGateEvents()` (the `--all` enumeration source): `packages/core/src/gate-engine.ts:80-82`
+- `review-gate.sh` (the pattern being generalized): `.claude/hooks/review-gate.sh`
+- `eject` (parity scrub target): `packages/cli/src/commands/eject.ts:230-327`
+- init option registration (where `--gates=` slots): `packages/cli/src/index.ts:84-118`
+
+## References
+
+- Ratified contract: **ADR-109** (mmnto-ai/totem-strategy#457) · Charter: mmnto-ai/totem-strategy#439 · Engine: mmnto-ai/totem#2046 · Originating issue: mmnto-ai/totem#2043 · WS3 design doc: `.totem/specs/2043.md` §"Consumer opt-in / wiring"
+- Wiring ruling + empty-subsystem guardrail + deferred declared-mapping seed: strategy-claude dispatch **T0041Z** (`.totem/orchestration/strategy-claude/outbox/2026-05-31T0041Z-totem-claude-prc-b-closes-439-glob-stays-deferred-plus-empty-subsystem-guardrail.md`)

--- a/.totem/specs/2048.md
+++ b/.totem/specs/2048.md
@@ -7,20 +7,21 @@
 
 ## What & why
 
-PR-C is the **opt-in distribution layer** for action-gates: the verb + wrapper + init sugar that wire a shipped gate into a consumer repo's Claude PreToolUse hook. It generalizes the shipped `review-gate.sh` content-hash pattern into a reusable, parameterized form. Landing it **closes mmnto-ai/totem-strategy#439's reference-wiring acceptance** (strategy-claude ruled T0041Z that a working `install → wrapper → gate check → disposition → exit-code` mechanism *is* that acceptance). It is also the dropped ADR-108 Q7 / Proposal-257 §5a distribution channel that orientation-hooks (Prop 257) and skills (mmnto-ai/totem-strategy#448) will ride.
+PR-C is the **opt-in distribution layer** for action-gates: the verb + wrapper + init sugar that wire a shipped gate into a consumer repo's Claude PreToolUse hook. It generalizes the shipped `review-gate.sh` content-hash pattern into a reusable, parameterized form. Landing it **closes mmnto-ai/totem-strategy#439's reference-wiring acceptance** (strategy-claude ruled T0041Z that a working `install → wrapper → gate check → disposition → exit-code` mechanism _is_ that acceptance). It is also the dropped ADR-108 Q7 / Proposal-257 §5a distribution channel that orientation-hooks (Prop 257) and skills (mmnto-ai/totem-strategy#448) will ride.
 
 ## Scope (deliverables)
 
 1. **Extract the settings-merge primitive, namespace-neutral.** Lift `mergeClaudeHooksKey` + `ClaudeSettingsSchema` + `preToolUseHasMatcher` + `ScaffoldOutcome` out of `packages/cli/src/commands/init.ts` into a shared module (suggest `packages/cli/src/commands/host-hooks.ts`). Widen the `entry` param from the closed `ClaudeHookEntry` 3-template union to a structural shape so a gate-wrapper entry is a valid argument. `init.ts` re-imports from the new module — its existing callers (shield-gate, PreWriteShield, SessionStart) must not regress. This is the namespace-neutral install primitive strategy-claude's T0225Z asked for: one merger shared by gate-install, init, and later Prop 257 / mmnto-ai/totem-strategy#448. **Not** a vendor-neutral `installHostHook(vendor)` abstraction — YAGNI, since ADR-109 makes the gate floor Claude/PreToolUse-portability-conditional (no Gemini gate consumer exists; Gemini uses a separate whole-file scaffold path).
 2. **`totem gate install [--all | --<name>]`** — registered as a sibling of `gate check`. `--all` iterates `knownGateEvents()` (the registry is the single source of truth → new gates become installable with zero new CLI flags); `--<name>` validates against `knownGateEvents()` and fails loud on unknown (mirror the engine's no-default-allow). Idempotently merges one PreToolUse entry per gate into committed `.claude/settings.json`. Thin caller of the extracted merger + a `hasGateWrapper` idempotency probe.
 3. **ONE parameterized wrapper** `.claude/hooks/gate-wrapper.cjs` (Node, mirroring `PreWriteShield.cjs` — portable, no bash/jq dependency, `.cjs` extension load-bearing in `type:module` repos). It reads the PreToolUse stdin envelope (`tool_name` / `tool_input`), builds the `--payload` JSON, shells to `totem gate check --event <name> --payload <json>`, parses the emitted `GateVerdict`, and maps **disposition → host exit code**. The `--event <name>` is baked per-entry into the scaffolded `command` string, so "one wrapper, N gates" = N PreToolUse entries pointing at the same script with different `--event` args.
-4. **`totem init --gates=<list|all>`** — thin sugar that parses a comma-list, validates each against `knownGateEvents()`, and routes through the *same* installer function the `gate install` verb uses (no second copy of the merge logic). Register alongside the existing `--bare/--pilot/--strict` options and thread it through `initCommand` options like `forceSkillRefresh`.
+4. **`totem init --gates=<list|all>`** — thin sugar that parses a comma-list, validates each against `knownGateEvents()`, and routes through the _same_ installer function the `gate install` verb uses (no second copy of the merge logic). Register alongside the existing `--bare/--pilot/--strict` options and thread it through `initCommand` options like `forceSkillRefresh`.
 5. **Eject parity** — `eject` must scrub the gate entry it installs, or it is the next orphan-on-eject gap.
 6. **CLI-seam tests** (mirror `gate.test.ts`): idempotent merge, `--all` vs `--<name>`, `--gates=` parse + validation, the disposition→exit-code map incl. the pass-through case, and the eject scrub. **Do not** duplicate `gate-engine.test.ts` (the engine is already covered).
 
 ## Design decisions (ratified — ADR-109 + strategy-claude T0041Z)
 
 ### Disposition → exit code (the wrapper's whole job; ADR-109 §2)
+
 - `allow` → exit 0 (silent)
 - `warn` → exit 0 + write `reason`/`provenance` to stderr (advisory; **never** blocks — ADR-109 §1)
 - `deny` → exit 2 (Claude block convention) + `reason`/`provenance` to stderr; under `--pilot` → exit 0 + stderr
@@ -28,17 +29,20 @@ PR-C is the **opt-in distribution layer** for action-gates: the verb + wrapper +
 - The `--pilot`/`--strict` tier toggle lives in the **wrapper**, not the engine (freeze-check never emits `warn`; the engine stays pure per ADR-109 [LOCKED]).
 
 ### The empty-subsystem guardrail (strategy-claude T0041Z — LOAD-BEARING)
+
 The wrapper MUST distinguish two cases that both look like "gate check did not return allow":
 
-- **No gate applies here → pass through (exit 0).** A PreToolUse Edit/Write delivers `tool_input.file_path` (a *path*), not a `subsystem`. Because path→subsystem mapping is deferred (see Non-goals), an Edit carries **no declared subsystem** → the wrapper must **not** invoke freeze-check for it → exit 0.
+- **No gate applies here → pass through (exit 0).** A PreToolUse Edit/Write delivers `tool_input.file_path` (a _path_), not a `subsystem`. Because path→subsystem mapping is deferred (see Non-goals), an Edit carries **no declared subsystem** → the wrapper must **not** invoke freeze-check for it → exit 0.
 - **A gate applies but its deterministic source is broken → fail-closed block (exit 2).** Only when a gate genuinely applies (a declared subsystem is present) and `totem gate check` exits non-zero (corrupt `freeze.json`, etc.) does the wrapper exit 2.
 
-Rationale: handing freeze-check an empty/unmapped subsystem throws `GATE_INVALID`; a *blanket* fail-closed would then block **every** edit — a gate meant to deny one frozen subsystem denying all edits. **Do not ship a wrapper that is guard-shaped on Edit events while guarding nothing** (Tenet 19: the drift between "mechanism proven" and "frozen subsystems protected"). The wrapper's surface claims "dispatcher / mechanism," not "path-aware freeze protection." For PR-C, freeze-check is exercised via **explicit-subsystem** invocation only (its CLI path + the wrapper unit tests with a synthetic declared-subsystem envelope).
+Rationale: handing freeze-check an empty/unmapped subsystem throws `GATE_INVALID`; a _blanket_ fail-closed would then block **every** edit — a gate meant to deny one frozen subsystem denying all edits. **Do not ship a wrapper that is guard-shaped on Edit events while guarding nothing** (Tenet 19: the drift between "mechanism proven" and "frozen subsystems protected"). The wrapper's surface claims "dispatcher / mechanism," not "path-aware freeze protection." For PR-C, freeze-check is exercised via **explicit-subsystem** invocation only (its CLI path + the wrapper unit tests with a synthetic declared-subsystem envelope).
 
 ### `gate check` stays untouched
+
 The wrapper reads stdin and builds the `--payload` arg; **no stdin reader is added to the command**. This keeps the command's contract stable and host-agnostic (ADR-109 [LOCKED]) and confines host-shape parsing to the host wrapper.
 
 ### Settings placement
+
 Committed `.claude/settings.json` (team-level governance — gate opt-in is a repo policy, Tenet 12), matching the PreWriteShield placement rationale, **not** per-developer `settings.local.json`.
 
 ## Non-goals (deferred — do NOT build in PR-C)

--- a/packages/cli/src/commands/eject.ts
+++ b/packages/cli/src/commands/eject.ts
@@ -29,6 +29,8 @@ const TOTEM_SCAFFOLDED_FILES = [
   '.claude/hooks/PreWriteShield.cjs',
   // Phase C slice 1 SessionStart (mmnto-ai/totem#1845).
   '.claude/hooks/SessionStart.cjs',
+  // PR-C action-gate wrapper (mmnto-ai/totem#2048, eject parity).
+  '.claude/hooks/gate-wrapper.cjs',
 ];
 
 // ─── Helpers ────────────────────────────────────────────
@@ -222,6 +224,9 @@ function scrubClaudeSettings(cwd: string, summary: EjectSummary): void {
  *     left over from when Phase B added the install side).
  *   - `hooks.SessionStart` entries whose command references `SessionStart.cjs`
  *     (Phase C slice 1 install — mmnto-ai/totem#1845).
+ *   - `hooks.PreToolUse` Write|Edit entries whose command references
+ *     `gate-wrapper.cjs` (PR-C action-gate install — mmnto-ai/totem#2048;
+ *     one per installed gate). Parity with `gate install` / `init --gates=`.
  *
  * User-defined entries (other matchers, other commands) are preserved.
  * Empty arrays/objects/files are pruned bottom-up to leave a clean
@@ -271,15 +276,21 @@ function scrubCommittedClaudeSettings(cwd: string, summary: EjectSummary): void 
 
   let mutated = false;
 
-  // PreToolUse → drop only the PreWriteShield entry. Other matchers
-  // (Bash legacy, user-defined Write|Edit) preserved. Array guard so a
-  // malformed-but-valid JSON shape (e.g., `"PreToolUse": null`) is
+  // PreToolUse → drop the PreWriteShield entry AND every action-gate
+  // wrapper entry (matcher Write|Edit, command references gate-wrapper.cjs;
+  // one per installed gate — PR-C eject parity, mmnto-ai/totem#2048). Other
+  // matchers (Bash legacy, user-defined Write|Edit) preserved. Array guard
+  // so a malformed-but-valid JSON shape (e.g., `"PreToolUse": null`) is
   // skipped instead of crashing the eject best-effort cleanup.
   const preToolUseRaw = hooks.PreToolUse;
   if (Array.isArray(preToolUseRaw)) {
     const preToolUse = preToolUseRaw as Array<{ matcher?: string; hooks?: Array<unknown> }>;
     const filtered = preToolUse.filter(
-      (entry) => !(entry.matcher === 'Write|Edit' && commandIncludes(entry, 'PreWriteShield')),
+      (entry) =>
+        !(
+          entry.matcher === 'Write|Edit' &&
+          (commandIncludes(entry, 'PreWriteShield') || commandIncludes(entry, 'gate-wrapper.cjs'))
+        ),
     );
     if (filtered.length !== preToolUse.length) {
       mutated = true;

--- a/packages/cli/src/commands/gate-install.test.ts
+++ b/packages/cli/src/commands/gate-install.test.ts
@@ -1,0 +1,434 @@
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { knownGateEvents, TotemError } from '@mmnto/totem';
+
+import { ejectCommand } from './eject.js';
+import { gateInstallCommand, resolveGateEvents } from './gate.js';
+import { commandInstallsGate, GATE_WRAPPER_REL, installGates } from './gate-install.js';
+import { initCommand } from './init.js';
+import { CLAUDE_GATE_WRAPPER } from './init-templates.js';
+
+/**
+ * CLI-seam tests for `totem gate install` + the parameterized gate wrapper
+ * (PR-C, mmnto-ai/totem#2048).
+ *
+ * Locks the invariants in spec 2048.md §"Invariants the tests lock":
+ *   - idempotent merge (re-run is a no-op)
+ *   - `--all` enumerates `knownGateEvents()`; unknown `--<name>` / `--gates=`
+ *     member fails loud (no default-install)
+ *   - the wrapper's disposition → exit-code map, including the LOAD-BEARING
+ *     empty-subsystem pass-through and the applicable-gate-source-broken
+ *     fail-closed
+ *   - `eject` removes the gate entry (parity with install)
+ *   - `init --gates=` routes through the SAME installer as the verb
+ *
+ * The engine itself (allow/deny/no-file/side-effect-free) is covered by
+ * `@mmnto/totem`'s gate-engine.test.ts and is NOT duplicated here.
+ */
+
+function makeTmpDir(): string {
+  // `.native` expands Windows 8.3 short names so process.cwd()/realpath agree.
+  return fs.realpathSync.native(fs.mkdtempSync(path.join(os.tmpdir(), 'totem-gate-install-')));
+}
+
+function readSettings(cwd: string): Record<string, unknown> {
+  const raw = fs.readFileSync(path.join(cwd, '.claude', 'settings.json'), 'utf-8');
+  return JSON.parse(raw);
+}
+
+function preToolUseEntries(cwd: string): Array<{ matcher?: string; hooks?: Array<unknown> }> {
+  const parsed = readSettings(cwd);
+  const hooks = (parsed.hooks ?? {}) as Record<string, unknown>;
+  return (hooks.PreToolUse ?? []) as Array<{ matcher?: string; hooks?: Array<unknown> }>;
+}
+
+/** Count Write|Edit PreToolUse entries whose command references a given gate. */
+function gateEntryCount(cwd: string, event: string): number {
+  return preToolUseEntries(cwd).filter(
+    (e) =>
+      e.matcher === 'Write|Edit' &&
+      Array.isArray(e.hooks) &&
+      e.hooks.some((h) => {
+        const cmd = typeof h === 'string' ? h : ((h as { command?: string })?.command ?? '');
+        // Collision-safe exact --event match (tier-independent).
+        return commandInstallsGate(cmd, event);
+      }),
+  ).length;
+}
+
+describe('installGates / gate install (settings merge)', () => {
+  let cwd: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    cwd = makeTmpDir();
+    originalCwd = process.cwd();
+    process.chdir(cwd);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(cwd, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  it('scaffolds the wrapper and merges one PreToolUse entry per gate', () => {
+    const results = installGates(cwd, ['freeze-check']);
+    // wrapper scaffold + one entry merge
+    expect(results.some((r) => r.file === GATE_WRAPPER_REL && r.action === 'created')).toBe(true);
+    expect(fs.existsSync(path.join(cwd, '.claude', 'hooks', 'gate-wrapper.cjs'))).toBe(true);
+    expect(gateEntryCount(cwd, 'freeze-check')).toBe(1);
+  });
+
+  it('is idempotent: a second install of the same gate is a no-op', () => {
+    installGates(cwd, ['freeze-check']);
+    const before = JSON.stringify(readSettings(cwd));
+
+    const second = installGates(cwd, ['freeze-check']);
+    const entryResult = second.find((r) => r.event === 'freeze-check');
+    expect(entryResult?.action).toBe('skipped');
+    expect(gateEntryCount(cwd, 'freeze-check')).toBe(1);
+    expect(JSON.stringify(readSettings(cwd))).toBe(before);
+  });
+
+  it('keys idempotency on the per-gate command substring (distinct gates → distinct entries)', () => {
+    // freeze-check installed; a hypothetical future gate keyed on a different
+    // --event substring produces a SECOND entry rather than colliding.
+    installGates(cwd, ['freeze-check']);
+    installGates(cwd, ['some-future-gate']);
+    expect(gateEntryCount(cwd, 'freeze-check')).toBe(1);
+    expect(gateEntryCount(cwd, 'some-future-gate')).toBe(1);
+    // Two distinct Write|Edit gate entries under one matcher.
+    const gateEntries = preToolUseEntries(cwd).filter(
+      (e) =>
+        e.matcher === 'Write|Edit' &&
+        Array.isArray(e.hooks) &&
+        e.hooks.some((h) => {
+          const cmd = typeof h === 'string' ? h : ((h as { command?: string })?.command ?? '');
+          return cmd.includes('gate-wrapper.cjs --event ');
+        }),
+    );
+    expect(gateEntries.length).toBe(2);
+  });
+
+  it('preserves a pre-existing user PreToolUse entry when merging', () => {
+    fs.mkdirSync(path.join(cwd, '.claude'), { recursive: true });
+    fs.writeFileSync(
+      path.join(cwd, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'my-hook' }] }],
+        },
+      }),
+    );
+    installGates(cwd, ['freeze-check']);
+    const entries = preToolUseEntries(cwd);
+    expect(entries.some((e) => e.matcher === 'Bash')).toBe(true);
+    expect(gateEntryCount(cwd, 'freeze-check')).toBe(1);
+  });
+
+  it('gateInstallCommand --all installs every known gate', async () => {
+    await gateInstallCommand({ all: true });
+    for (const event of knownGateEvents()) {
+      expect(gateEntryCount(cwd, event)).toBe(1);
+    }
+  });
+});
+
+describe('resolveGateEvents (registry-driven validation)', () => {
+  it('--all enumerates knownGateEvents()', async () => {
+    expect(await resolveGateEvents({ all: true })).toEqual(knownGateEvents());
+  });
+
+  it('a known --<name> resolves to itself', async () => {
+    expect(await resolveGateEvents({ name: 'freeze-check' })).toEqual(['freeze-check']);
+  });
+
+  it('an unknown --<name> fails loud (never default-install)', async () => {
+    await expect(resolveGateEvents({ name: 'made-up-gate' })).rejects.toBeInstanceOf(TotemError);
+    await expect(resolveGateEvents({ name: 'made-up-gate' })).rejects.toThrow(/unknown gate/i);
+  });
+
+  it('no --all and no --<name> fails loud (no default-install)', async () => {
+    await expect(resolveGateEvents({})).rejects.toThrow(/no gate selected/i);
+  });
+});
+
+// ─── The parameterized wrapper's disposition → exit-code map ───────────
+//
+// We render the wrapper template to a temp dir and drive it via stdin with
+// synthetic PreToolUse envelopes. A stub `node_modules/@mmnto/cli/dist/index.js`
+// stands in for the local CLI: it echoes a verdict / exit code driven by env
+// vars so the test controls each disposition deterministically WITHOUT the
+// real engine (the engine is covered by gate-engine.test.ts).
+describe('gate-wrapper.cjs disposition → exit code', () => {
+  let cwd: string;
+
+  beforeEach(() => {
+    cwd = makeTmpDir();
+    // Render the wrapper exactly as `installGates` would.
+    fs.mkdirSync(path.join(cwd, '.claude', 'hooks'), { recursive: true });
+    fs.writeFileSync(path.join(cwd, '.claude', 'hooks', 'gate-wrapper.cjs'), CLAUDE_GATE_WRAPPER);
+  });
+
+  afterEach(() => {
+    fs.rmSync(cwd, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  /** Install a stub local CLI that emits a controlled verdict / exit code. */
+  function writeStubCli(opts: { verdict?: unknown; exit?: number }): void {
+    const distDir = path.join(cwd, 'node_modules', '@mmnto', 'cli', 'dist');
+    fs.mkdirSync(distDir, { recursive: true });
+    const verdictJson = opts.verdict === undefined ? '' : JSON.stringify(opts.verdict);
+    const exitCode = opts.exit ?? 0;
+    // CommonJS stub (the wrapper invokes via `node <path>`); .js is fine here
+    // because there is no package.json type:module in the temp dir.
+    const stub = [
+      '"use strict";',
+      `const out = ${JSON.stringify(verdictJson)};`,
+      'if (out) process.stdout.write(out + "\\n");',
+      `process.exit(${exitCode});`,
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(distDir, 'index.js'), stub);
+  }
+
+  /** Run the rendered wrapper with the given envelope + baked extra args. */
+  function runWrapper(
+    envelope: unknown,
+    extraArgs: string[] = [],
+  ): { status: number | null; stderr: string } {
+    const wrapperPath = path.join(cwd, '.claude', 'hooks', 'gate-wrapper.cjs');
+    const res = spawnSync(
+      process.execPath,
+      [wrapperPath, '--event', 'freeze-check', ...extraArgs],
+      {
+        cwd,
+        input: JSON.stringify(envelope),
+        encoding: 'utf-8',
+        timeout: 30000,
+      },
+    );
+    return { status: res.status, stderr: res.stderr ?? '' };
+  }
+
+  const EDIT_NO_SUBSYSTEM = { tool_name: 'Edit', tool_input: { file_path: 'src/foo.ts' } };
+  const DECLARED = { tool_name: 'Edit', tool_input: { subsystem: 'rule-compilation' } };
+
+  it('allow → exit 0 (silent)', () => {
+    writeStubCli({ verdict: { disposition: 'allow', reason: 'ok', provenance: {} }, exit: 0 });
+    const { status } = runWrapper(DECLARED);
+    expect(status).toBe(0);
+  });
+
+  it('warn → exit 0 + reason/provenance to stderr (advisory, never blocks)', () => {
+    writeStubCli({
+      verdict: { disposition: 'warn', reason: 'heads up', provenance: { source: 's' } },
+      exit: 0,
+    });
+    const { status, stderr } = runWrapper(DECLARED);
+    expect(status).toBe(0);
+    expect(stderr).toMatch(/warn/i);
+    expect(stderr).toContain('heads up');
+  });
+
+  it('deny → exit 2 under --strict (default) + stderr', () => {
+    writeStubCli({
+      verdict: { disposition: 'deny', reason: 'frozen', provenance: { matched: 'x' } },
+      exit: 0,
+    });
+    const { status, stderr } = runWrapper(DECLARED);
+    expect(status).toBe(2);
+    expect(stderr).toContain('frozen');
+  });
+
+  it('deny → exit 0 under --pilot + stderr (advisory tier)', () => {
+    writeStubCli({
+      verdict: { disposition: 'deny', reason: 'frozen', provenance: {} },
+      exit: 0,
+    });
+    const { status, stderr } = runWrapper(DECLARED, ['--pilot']);
+    expect(status).toBe(0);
+    expect(stderr).toContain('frozen');
+  });
+
+  it('no-declared-subsystem Edit → exit 0 pass-through (gate NOT invoked)', () => {
+    // Stub emits a DENY; if the wrapper invoked it, exit would be 2. The
+    // empty-subsystem guardrail must short-circuit to exit 0 WITHOUT shelling
+    // out (LOAD-BEARING: protects every ordinary edit from being blocked).
+    writeStubCli({ verdict: { disposition: 'deny', reason: 'should not run', provenance: {} } });
+    const { status } = runWrapper(EDIT_NO_SUBSYSTEM);
+    expect(status).toBe(0);
+  });
+
+  it('applicable-gate-source-broken (non-zero gate check) → exit 2 fail-closed', () => {
+    // A declared subsystem IS present (gate applies) and `gate check` exits
+    // non-zero (corrupt freeze.json etc.) → fail-closed block.
+    writeStubCli({ exit: 1 });
+    const { status, stderr } = runWrapper(DECLARED);
+    expect(status).toBe(2);
+    expect(stderr).toMatch(/fail-closed/i);
+  });
+
+  it('malformed stdin envelope → exit 0 fail-soft', () => {
+    writeStubCli({ verdict: { disposition: 'deny' } });
+    const wrapperPath = path.join(cwd, '.claude', 'hooks', 'gate-wrapper.cjs');
+    const res = spawnSync(process.execPath, [wrapperPath, '--event', 'freeze-check'], {
+      cwd,
+      input: '{ not valid json',
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    expect(res.status).toBe(0);
+  });
+
+  // ─── FIX 2: applicable gate but no local CLI dist → fail-closed ────────
+  it('applicable gate but the local CLI dist is missing → exit 2 fail-closed (FIX 2)', () => {
+    // Deliberately do NOT write the stub CLI. A declared subsystem makes the
+    // gate APPLY, but @mmnto/cli is not resolvable. freeze-check has no
+    // commit-time hard floor, so an applicable-but-unevaluable gate must fail
+    // closed (exit 2) rather than silently allow (exit 0).
+    const { status, stderr } = runWrapper(DECLARED);
+    expect(status).toBe(2);
+    expect(stderr).toMatch(/not resolvable|not installed|failing closed/i);
+  });
+
+  it('gate check exits 0 with unparseable stdout → exit 2 fail-closed', () => {
+    // verdict undefined → stub emits nothing; the wrapper cannot parse a
+    // verdict from a 0-exit gate → fail-closed.
+    writeStubCli({ verdict: undefined, exit: 0 });
+    const { status, stderr } = runWrapper(DECLARED);
+    expect(status).toBe(2);
+    expect(stderr).toMatch(/unparseable|parse/i);
+  });
+
+  it('well-formed verdict with an unknown disposition → exit 2 fail-closed', () => {
+    writeStubCli({ verdict: { disposition: 'bogus', reason: 'x', provenance: {} }, exit: 0 });
+    const { status, stderr } = runWrapper(DECLARED);
+    expect(status).toBe(2);
+    expect(stderr).toMatch(/unknown disposition/i);
+  });
+
+  // ─── FIX 3: valid JSON but non-object stdin → fail-soft ────────────────
+  it('stdin is valid JSON but non-object (the bytes `null`) → exit 0 fail-soft (FIX 3)', () => {
+    writeStubCli({ verdict: { disposition: 'deny' } });
+    const wrapperPath = path.join(cwd, '.claude', 'hooks', 'gate-wrapper.cjs');
+    const res = spawnSync(process.execPath, [wrapperPath, '--event', 'freeze-check'], {
+      cwd,
+      input: 'null',
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    expect(res.status).toBe(0);
+  });
+});
+
+// ─── eject parity ──────────────────────────────────────────────────────
+describe('eject removes the gate entry (parity with install)', () => {
+  let cwd: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    cwd = makeTmpDir();
+    originalCwd = process.cwd();
+    process.chdir(cwd);
+    fs.mkdirSync(path.join(cwd, '.git', 'hooks'), { recursive: true });
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(cwd, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  it('scrubs the gate PreToolUse entry and the wrapper script on eject', async () => {
+    installGates(cwd, ['freeze-check']);
+    expect(gateEntryCount(cwd, 'freeze-check')).toBe(1);
+    expect(fs.existsSync(path.join(cwd, '.claude', 'hooks', 'gate-wrapper.cjs'))).toBe(true);
+
+    await ejectCommand({ force: true });
+
+    expect(fs.existsSync(path.join(cwd, '.claude', 'hooks', 'gate-wrapper.cjs'))).toBe(false);
+    // Settings file may be removed entirely (if it only held the gate entry)
+    // or scrubbed of the gate entry — either way no gate entry survives.
+    if (fs.existsSync(path.join(cwd, '.claude', 'settings.json'))) {
+      expect(gateEntryCount(cwd, 'freeze-check')).toBe(0);
+    }
+  });
+
+  it('preserves a user PreToolUse entry while scrubbing the gate entry', async () => {
+    fs.mkdirSync(path.join(cwd, '.claude'), { recursive: true });
+    fs.writeFileSync(
+      path.join(cwd, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: { PreToolUse: [{ matcher: 'Bash', hooks: [{ type: 'command', command: 'mine' }] }] },
+      }),
+    );
+    installGates(cwd, ['freeze-check']);
+
+    await ejectCommand({ force: true });
+
+    expect(fs.existsSync(path.join(cwd, '.claude', 'settings.json'))).toBe(true);
+    const entries = preToolUseEntries(cwd);
+    expect(entries.some((e) => e.matcher === 'Bash')).toBe(true);
+    expect(gateEntryCount(cwd, 'freeze-check')).toBe(0);
+  });
+});
+
+// ─── init --gates= routes through the SAME installer ───────────────────
+describe('init --gates= routes through the shared installer', () => {
+  let cwd: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    cwd = makeTmpDir();
+    originalCwd = process.cwd();
+    process.chdir(cwd);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(cwd, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  it('init --gates=freeze-check installs the same entry installGates would', async () => {
+    await initCommand({ bare: true, gates: 'freeze-check' });
+    expect(gateEntryCount(cwd, 'freeze-check')).toBe(1);
+    expect(fs.existsSync(path.join(cwd, '.claude', 'hooks', 'gate-wrapper.cjs'))).toBe(true);
+  });
+
+  it('init --gates=all installs every known gate', async () => {
+    await initCommand({ bare: true, gates: 'all' });
+    for (const event of knownGateEvents()) {
+      expect(gateEntryCount(cwd, event)).toBe(1);
+    }
+  });
+
+  it('init --gates= with an unknown member fails loud', async () => {
+    await expect(initCommand({ bare: true, gates: 'made-up-gate' })).rejects.toThrow(
+      /unknown gate/i,
+    );
+  });
+
+  // ─── FIX 4: empty --gates= selection fails loud, installs nothing ──────
+  it('init --gates=, (empty after parse) throws GATE_INVALID and writes no gate wrapper/entry', async () => {
+    const err = await initCommand({ bare: true, gates: ',' }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(TotemError);
+    expect((err as TotemError).code).toBe('GATE_INVALID');
+    // No orphan wrapper scaffolded, no PreToolUse gate entry merged.
+    expect(fs.existsSync(path.join(cwd, '.claude', 'hooks', 'gate-wrapper.cjs'))).toBe(false);
+    if (fs.existsSync(path.join(cwd, '.claude', 'settings.json'))) {
+      expect(gateEntryCount(cwd, 'freeze-check')).toBe(0);
+    }
+  });
+
+  it('init --gates= (whitespace-only) throws GATE_INVALID and writes no gate wrapper/entry', async () => {
+    const err = await initCommand({ bare: true, gates: '   ' }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(TotemError);
+    expect((err as TotemError).code).toBe('GATE_INVALID');
+    expect(fs.existsSync(path.join(cwd, '.claude', 'hooks', 'gate-wrapper.cjs'))).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/gate-install.test.ts
+++ b/packages/cli/src/commands/gate-install.test.ts
@@ -61,6 +61,19 @@ function gateEntryCount(cwd: string, event: string): number {
   ).length;
 }
 
+/** The single baked command string for a gate (or undefined if none/many). */
+function gateCommandFor(cwd: string, event: string): string | undefined {
+  const cmds: string[] = [];
+  for (const e of preToolUseEntries(cwd)) {
+    if (e.matcher !== 'Write|Edit' || !Array.isArray(e.hooks)) continue;
+    for (const h of e.hooks) {
+      const cmd = typeof h === 'string' ? h : ((h as { command?: string })?.command ?? '');
+      if (commandInstallsGate(cmd, event)) cmds.push(cmd);
+    }
+  }
+  return cmds.length === 1 ? cmds[0] : undefined;
+}
+
 describe('installGates / gate install (settings merge)', () => {
   let cwd: string;
   let originalCwd: string;
@@ -136,6 +149,124 @@ describe('installGates / gate install (settings merge)', () => {
     for (const event of knownGateEvents()) {
       expect(gateEntryCount(cwd, event)).toBe(1);
     }
+  });
+});
+
+// ─── FIX A: tier-AWARE upsert (update in place, never silent no-op/dup) ──
+//
+// Locks the tier-update behavior so it can never regress to either failure
+// mode the pre-fix tier-INDEPENDENT probe had: (a) a tier switch silently
+// dropped as a "skipped — no change" no-op, or (b) a second duplicate entry
+// for the same gate. The invariant: EXACTLY ONE entry per gate, ever, and the
+// baked tier flag flips in place on a different-tier re-install.
+describe('installGates tier-aware upsert (FIX A)', () => {
+  let cwd: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    cwd = makeTmpDir();
+    originalCwd = process.cwd();
+    process.chdir(cwd);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(cwd, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  it('default(strict) then re-install --strict → skipped, one entry, command keeps --strict', () => {
+    installGates(cwd, ['freeze-check']); // default tier === strict
+    const second = installGates(cwd, ['freeze-check'], 'strict');
+    const entryResult = second.find((r) => r.event === 'freeze-check');
+    expect(entryResult?.action).toBe('skipped');
+    expect(gateEntryCount(cwd, 'freeze-check')).toBe(1);
+    expect(gateCommandFor(cwd, 'freeze-check')).toContain('--strict');
+  });
+
+  it('--pilot then --strict → updated, ONE entry, command flips to --strict (not --pilot)', () => {
+    installGates(cwd, ['freeze-check'], 'pilot');
+    expect(gateCommandFor(cwd, 'freeze-check')).toContain('--pilot');
+
+    const switched = installGates(cwd, ['freeze-check'], 'strict');
+    const entryResult = switched.find((r) => r.event === 'freeze-check');
+    expect(entryResult?.action).toBe('updated');
+    // Exactly one entry — no duplicate created by the tier switch.
+    expect(gateEntryCount(cwd, 'freeze-check')).toBe(1);
+    const cmd = gateCommandFor(cwd, 'freeze-check');
+    expect(cmd).toContain('--strict');
+    expect(cmd).not.toContain('--pilot');
+  });
+
+  it('--strict then --pilot → updated back to --pilot, one entry', () => {
+    installGates(cwd, ['freeze-check'], 'strict');
+    const switched = installGates(cwd, ['freeze-check'], 'pilot');
+    const entryResult = switched.find((r) => r.event === 'freeze-check');
+    expect(entryResult?.action).toBe('updated');
+    expect(gateEntryCount(cwd, 'freeze-check')).toBe(1);
+    const cmd = gateCommandFor(cwd, 'freeze-check');
+    expect(cmd).toContain('--pilot');
+    expect(cmd).not.toContain('--strict');
+  });
+
+  it('init --gates= routes the tier through the same upsert (default then --pilot re-init)', async () => {
+    // First init at default (strict).
+    await initCommand({ bare: true, gates: 'freeze-check' });
+    expect(gateEntryCount(cwd, 'freeze-check')).toBe(1);
+    expect(gateCommandFor(cwd, 'freeze-check')).toContain('--strict');
+
+    // Re-init with --pilot → routes through the same installGates upsert:
+    // one entry at the right (pilot) tier, NOT a duplicate.
+    await initCommand({ bare: true, gates: 'freeze-check', pilot: true });
+    expect(gateEntryCount(cwd, 'freeze-check')).toBe(1);
+    const cmd = gateCommandFor(cwd, 'freeze-check');
+    expect(cmd).toContain('--pilot');
+    expect(cmd).not.toContain('--strict');
+  });
+
+  it('coexists with a pre-existing PreWriteShield Write|Edit entry (the post-init layout)', () => {
+    // Realistic post-`totem init` state: a PreWriteShield hook already sits in
+    // committed settings.json under the SAME 'Write|Edit' matcher the gate uses.
+    // The upsert must install the gate as a DISTINCT entry and, on a tier
+    // switch, update ONLY the gate entry — never touching PreWriteShield.
+    fs.mkdirSync(path.join(cwd, '.claude'), { recursive: true });
+    const shieldCommand = 'node .claude/hooks/PreWriteShield.cjs';
+    fs.writeFileSync(
+      path.join(cwd, '.claude', 'settings.json'),
+      JSON.stringify({
+        hooks: {
+          PreToolUse: [
+            { matcher: 'Write|Edit', hooks: [{ type: 'command', command: shieldCommand }] },
+          ],
+        },
+      }),
+    );
+    const hasShield = (): boolean =>
+      preToolUseEntries(cwd).some(
+        (e) =>
+          e.matcher === 'Write|Edit' &&
+          Array.isArray(e.hooks) &&
+          e.hooks.some((h) => {
+            const c = typeof h === 'string' ? h : ((h as { command?: string })?.command ?? '');
+            return c === shieldCommand;
+          }),
+      );
+
+    // Install the gate at pilot → a distinct second Write|Edit entry.
+    installGates(cwd, ['freeze-check'], 'pilot');
+    expect(gateEntryCount(cwd, 'freeze-check')).toBe(1);
+    expect(gateCommandFor(cwd, 'freeze-check')).toContain('--pilot');
+    expect(hasShield()).toBe(true);
+    expect(preToolUseEntries(cwd).filter((e) => e.matcher === 'Write|Edit').length).toBe(2);
+
+    // Tier switch → updates ONLY the gate entry in place; PreWriteShield stays.
+    const switched = installGates(cwd, ['freeze-check'], 'strict');
+    expect(switched.find((r) => r.event === 'freeze-check')?.action).toBe('updated');
+    expect(gateEntryCount(cwd, 'freeze-check')).toBe(1);
+    const cmd2 = gateCommandFor(cwd, 'freeze-check');
+    expect(cmd2).toContain('--strict');
+    expect(cmd2).not.toContain('--pilot');
+    expect(hasShield()).toBe(true);
+    expect(preToolUseEntries(cwd).filter((e) => e.matcher === 'Write|Edit').length).toBe(2);
   });
 });
 

--- a/packages/cli/src/commands/gate-install.ts
+++ b/packages/cli/src/commands/gate-install.ts
@@ -1,0 +1,158 @@
+import * as path from 'node:path';
+
+import {
+  type HostHookEntry,
+  mergeClaudeHooksKey,
+  preToolUseHasMatcher,
+  type ScaffoldOutcome,
+} from './host-hooks.js';
+import { scaffoldFile } from './init.js';
+import {
+  CLAUDE_GATE_WRAPPER,
+  CLAUDE_GATE_WRAPPER_ENTRY,
+  TOTEM_FILE_MARKER,
+} from './init-templates.js';
+
+/**
+ * Install the parameterized PreToolUse gate wrapper + one PreToolUse entry per
+ * named gate into committed `.claude/settings.json` (PR-C, mmnto-ai/totem#2048).
+ *
+ * Single source of truth for BOTH the `totem gate install` verb and
+ * `totem init --gates=` — neither owns a second copy of the merge logic.
+ * Thin caller of the extracted `mergeClaudeHooksKey` merger (host-hooks.ts).
+ *
+ * Idempotency keys on the ACTUAL baked command substring
+ * (`gate-wrapper.cjs --event <name>`), so installing freeze-check twice is a
+ * no-op while freeze-check + a future second gate produce two distinct
+ * entries under the shared `Write|Edit` matcher.
+ *
+ * `--all` / unknown-gate validation is done by the CALLER against
+ * `knownGateEvents()` (the registry is the single source of truth) — this
+ * function trusts that `events` are already-validated known events.
+ */
+
+/** The PreToolUse matcher every gate entry installs under. */
+const GATE_MATCHER = 'Write|Edit';
+
+/** The wrapper script's repo-relative install path. */
+export const GATE_WRAPPER_REL = '.claude/hooks/gate-wrapper.cjs';
+
+/** Enforcement tier baked into the installed command at install time. */
+export type GateTier = 'strict' | 'pilot';
+
+/** The wrapper script basename — the eject scrub keys on this substring. */
+const GATE_WRAPPER_BASENAME = 'gate-wrapper.cjs';
+
+/**
+ * Collision-safe idempotency probe: does `command` install the gate for
+ * EXACTLY this `event`?
+ *
+ * Tokenize on whitespace and require BOTH the wrapper basename AND the token
+ * immediately after `--event` to equal `event`. A loose substring `includes`
+ * would let `--event freeze-check` spuriously match a future
+ * `--event freeze-check-extended`. The probe is tier-INDEPENDENT (it ignores
+ * the baked `--strict` / `--pilot` flag), so re-installing the same gate at a
+ * different tier is still a no-op (one entry per gate, never duplicated).
+ */
+export function commandInstallsGate(command: string, event: string): boolean {
+  const tokens = command.split(/\s+/).filter((t) => t.length > 0);
+  if (!tokens.some((t) => t.includes(GATE_WRAPPER_BASENAME))) {
+    return false;
+  }
+  const eventIdx = tokens.indexOf('--event');
+  return eventIdx !== -1 && tokens[eventIdx + 1] === event;
+}
+
+/** Build the baked PreToolUse command string for a gate at a given tier. */
+function gateCommand(event: string, tier: GateTier): string {
+  return `node ${GATE_WRAPPER_REL} --event ${event} --${tier}`;
+}
+
+/** Build the PreToolUse entry for a single gate (one wrapper, N gates). */
+function gateEntry(event: string, tier: GateTier): HostHookEntry {
+  return {
+    matcher: CLAUDE_GATE_WRAPPER_ENTRY.matcher,
+    hooks: [
+      {
+        type: CLAUDE_GATE_WRAPPER_ENTRY.hooks[0]!.type,
+        command: gateCommand(event, tier),
+      },
+    ],
+  };
+}
+
+export interface GateInstallResult {
+  /** Repo-relative file the result pertains to. */
+  file: string;
+  /**
+   * Outcome of the operation. Matches the actual returns: `created` (new
+   * wrapper / merged entry), `merged` (entry added to existing settings), or
+   * `skipped` (idempotent no-op). scaffoldFile's `exists` outcome is normalized
+   * to `skipped` at the boundary (see installGates) — both mean "no change".
+   */
+  action: ScaffoldOutcome['action'];
+  /** The gate event this result is for (entry results only). */
+  event?: string;
+  err?: string;
+}
+
+/**
+ * Install the gate wrapper script + one PreToolUse entry per `event` into the
+ * given repo `cwd`. Returns one result per filesystem operation (the wrapper
+ * scaffold, then one entry merge per gate) for caller-side summary reporting.
+ *
+ * `tier` (default `'strict'`) is BAKED into the installed command string at
+ * install time — the wrapper reads it ONLY from argv (no env-var override), so
+ * a default install is enforcement-immune to a consumer's environment. `pilot`
+ * is an explicit install-time opt-in.
+ *
+ * `events` MUST already be validated against `knownGateEvents()` by the
+ * caller (the verb / `--gates=` parser) — no default-install, fail-loud on
+ * unknown happens upstream.
+ */
+export function installGates(
+  cwd: string,
+  events: string[],
+  tier: GateTier = 'strict',
+): GateInstallResult[] {
+  const results: GateInstallResult[] = [];
+  const settingsPath = path.join(cwd, '.claude', 'settings.json');
+
+  // 1. Scaffold the ONE parameterized wrapper script (idempotent; marker-keyed).
+  //    scaffoldFile returns 'exists' when a marker-bearing Totem file is already
+  //    present (the idempotent re-run case); normalize that to 'skipped' so the
+  //    GateInstallResult.action stays within created|merged|skipped (both mean
+  //    "no write happened, no change") — see GateInstallResult below.
+  const wrapperPath = path.join(cwd, '.claude', 'hooks', 'gate-wrapper.cjs');
+  const wrapperResult = scaffoldFile(wrapperPath, CLAUDE_GATE_WRAPPER, TOTEM_FILE_MARKER);
+  results.push({
+    file: GATE_WRAPPER_REL,
+    action: wrapperResult.action === 'exists' ? 'skipped' : wrapperResult.action,
+    err: wrapperResult.err,
+  });
+
+  // 2. Merge one PreToolUse entry per gate via the shared merger. The
+  //    idempotency probe matches the EXACT --event token (collision-safe and
+  //    tier-independent), so a re-run — even at a different tier — is a no-op
+  //    while a NEW gate adds a second distinct entry.
+  for (const event of events) {
+    const entryResult = mergeClaudeHooksKey(
+      settingsPath,
+      'PreToolUse',
+      gateEntry(event, tier),
+      (parsed) =>
+        preToolUseHasMatcher(parsed, GATE_MATCHER, (hook) => {
+          const cmd = typeof hook === 'string' ? hook : hook.command;
+          return typeof cmd === 'string' && commandInstallsGate(cmd, event);
+        }),
+    );
+    results.push({
+      file: '.claude/settings.json',
+      action: entryResult.action,
+      event,
+      err: entryResult.err,
+    });
+  }
+
+  return results;
+}

--- a/packages/cli/src/commands/gate-install.ts
+++ b/packages/cli/src/commands/gate-install.ts
@@ -1,11 +1,6 @@
 import * as path from 'node:path';
 
-import {
-  type HostHookEntry,
-  mergeClaudeHooksKey,
-  preToolUseHasMatcher,
-  type ScaffoldOutcome,
-} from './host-hooks.js';
+import { type HostHookEntry, upsertClaudeHookCommand } from './host-hooks.js';
 import { scaffoldFile } from './init.js';
 import {
   CLAUDE_GATE_WRAPPER,
@@ -19,12 +14,13 @@ import {
  *
  * Single source of truth for BOTH the `totem gate install` verb and
  * `totem init --gates=` — neither owns a second copy of the merge logic.
- * Thin caller of the extracted `mergeClaudeHooksKey` merger (host-hooks.ts).
+ * Thin caller of the extracted `upsertClaudeHookCommand` upsert (host-hooks.ts).
  *
- * Idempotency keys on the ACTUAL baked command substring
- * (`gate-wrapper.cjs --event <name>`), so installing freeze-check twice is a
- * no-op while freeze-check + a future second gate produce two distinct
- * entries under the shared `Write|Edit` matcher.
+ * Tier-AWARE upsert keyed on the per-gate `--event <name>` identity (which is
+ * tier-independent): installing freeze-check twice at the SAME tier is a no-op,
+ * installing it at a DIFFERENT tier rewrites the one existing entry's command
+ * in place (never a duplicate), and freeze-check + a future second gate produce
+ * two distinct entries under the shared `Write|Edit` matcher.
  *
  * `--all` / unknown-gate validation is done by the CALLER against
  * `knownGateEvents()` (the registry is the single source of truth) — this
@@ -44,15 +40,16 @@ export type GateTier = 'strict' | 'pilot';
 const GATE_WRAPPER_BASENAME = 'gate-wrapper.cjs';
 
 /**
- * Collision-safe idempotency probe: does `command` install the gate for
+ * Collision-safe gate-identity probe: does `command` install the gate for
  * EXACTLY this `event`?
  *
  * Tokenize on whitespace and require BOTH the wrapper basename AND the token
  * immediately after `--event` to equal `event`. A loose substring `includes`
  * would let `--event freeze-check` spuriously match a future
  * `--event freeze-check-extended`. The probe is tier-INDEPENDENT (it ignores
- * the baked `--strict` / `--pilot` flag), so re-installing the same gate at a
- * different tier is still a no-op (one entry per gate, never duplicated).
+ * the baked `--strict` / `--pilot` flag), so it identifies the single existing
+ * entry for a gate REGARDLESS of tier — the upsert then either no-ops (same
+ * tier) or rewrites that one entry's command (tier switch), never duplicating.
  */
 export function commandInstallsGate(command: string, event: string): boolean {
   const tokens = command.split(/\s+/).filter((t) => t.length > 0);
@@ -81,16 +78,29 @@ function gateEntry(event: string, tier: GateTier): HostHookEntry {
   };
 }
 
+/**
+ * Outcome of a single gate install operation.
+ *
+ * Gate-specific (decoupled from `ScaffoldOutcome['action']`): it adds
+ * `'updated'`, which the wrapper-scaffold step can never produce but the
+ * tier-aware entry upsert can (re-installing a gate at a DIFFERENT tier
+ * rewrites the one existing entry's command in place).
+ *
+ * - `created` — fresh file / wrapper written
+ * - `merged`  — a new entry appended to existing settings
+ * - `updated` — an existing gate entry's command rewritten in place (tier
+ *               switch) — exactly one entry per gate, never duplicated
+ * - `skipped` — idempotent no-op (same-tier re-install, or the wrapper's
+ *               `exists` outcome normalized at the boundary; both mean "no
+ *               change")
+ */
+export type GateInstallAction = 'created' | 'merged' | 'updated' | 'skipped';
+
 export interface GateInstallResult {
   /** Repo-relative file the result pertains to. */
   file: string;
-  /**
-   * Outcome of the operation. Matches the actual returns: `created` (new
-   * wrapper / merged entry), `merged` (entry added to existing settings), or
-   * `skipped` (idempotent no-op). scaffoldFile's `exists` outcome is normalized
-   * to `skipped` at the boundary (see installGates) — both mean "no change".
-   */
-  action: ScaffoldOutcome['action'];
+  /** Outcome of the operation (see {@link GateInstallAction}). */
+  action: GateInstallAction;
   /** The gate event this result is for (entry results only). */
   event?: string;
   err?: string;
@@ -131,20 +141,18 @@ export function installGates(
     err: wrapperResult.err,
   });
 
-  // 2. Merge one PreToolUse entry per gate via the shared merger. The
-  //    idempotency probe matches the EXACT --event token (collision-safe and
-  //    tier-independent), so a re-run — even at a different tier — is a no-op
-  //    while a NEW gate adds a second distinct entry.
+  // 2. Tier-AWARE upsert of one PreToolUse entry per gate. The gate-identity
+  //    probe matches the EXACT --event token (collision-safe and
+  //    tier-independent), so the upsert keeps EXACTLY ONE entry per gate:
+  //    a same-tier re-run is a no-op (`skipped`), a different-tier re-install
+  //    rewrites that entry's command in place (`updated`), and a NEW gate adds
+  //    a second distinct entry (`merged`).
   for (const event of events) {
-    const entryResult = mergeClaudeHooksKey(
+    const entryResult = upsertClaudeHookCommand(
       settingsPath,
-      'PreToolUse',
+      GATE_MATCHER,
       gateEntry(event, tier),
-      (parsed) =>
-        preToolUseHasMatcher(parsed, GATE_MATCHER, (hook) => {
-          const cmd = typeof hook === 'string' ? hook : hook.command;
-          return typeof cmd === 'string' && commandInstallsGate(cmd, event);
-        }),
+      (cmd) => commandInstallsGate(cmd, event),
     );
     results.push({
       file: '.claude/settings.json',

--- a/packages/cli/src/commands/gate.ts
+++ b/packages/cli/src/commands/gate.ts
@@ -1,10 +1,97 @@
 import * as path from 'node:path';
 
 import { isGlobalConfigPath, loadConfig, resolveConfigPath } from '../utils.js';
+import { type GateTier, installGates } from './gate-install.js';
 
 export interface GateCheckCommandOptions {
   event: string;
   payload: string;
+}
+
+export interface GateInstallCommandOptions {
+  /** Install every known gate (`knownGateEvents()`). */
+  all?: boolean;
+  /** Install a single named gate (validated against `knownGateEvents()`). */
+  name?: string;
+  /**
+   * Install under the advisory pilot tier (deny → exit 0 + stderr). Default
+   * (omitted) bakes `--strict` (deny → exit 2), so a default install is
+   * enforcement-immune. `--strict` may be passed for explicitness.
+   */
+  pilot?: boolean;
+  /** Explicit strict tier (the default; accepted for symmetry with `--pilot`). */
+  strict?: boolean;
+}
+
+/** Derive the install-time tier from the CLI options (default strict). */
+function resolveTier(opts: { pilot?: boolean }): GateTier {
+  return opts.pilot ? 'pilot' : 'strict';
+}
+
+/**
+ * Resolve + validate the gate events to install from the CLI options. The
+ * `knownGateEvents()` registry is the single source of truth: `--all`
+ * enumerates it, and a named gate must be a member or we throw (mirror the
+ * engine's no-default-allow — never silently install nothing).
+ */
+export async function resolveGateEvents(opts: GateInstallCommandOptions): Promise<string[]> {
+  const { knownGateEvents, TotemError } = await import('@mmnto/totem');
+  const known = knownGateEvents();
+
+  if (opts.all) {
+    return known;
+  }
+
+  const name = opts.name?.trim();
+  if (!name) {
+    throw new TotemError(
+      'GATE_INVALID',
+      'No gate selected: pass --all or --<name>.',
+      `Use --all or one of: ${known.join(', ')}.`,
+    );
+  }
+
+  if (!known.includes(name)) {
+    throw new TotemError(
+      'GATE_INVALID',
+      `Unknown gate "${name}". Known gates: ${known.join(', ')}.`,
+      'Use --all or one of the known gate names.',
+    );
+  }
+
+  return [name];
+}
+
+/**
+ * `totem gate install [--all | --<name>]`
+ *
+ * Idempotently merges one PreToolUse entry per selected gate into committed
+ * `.claude/settings.json` and scaffolds the shared parameterized wrapper to
+ * `.claude/hooks/gate-wrapper.cjs`. Thin caller of the shared `installGates`
+ * merger (the same path `init --gates=` routes through) — no second copy of
+ * the merge logic. Fails loud on an unknown `--<name>` (no default-install).
+ */
+export async function gateInstallCommand(opts: GateInstallCommandOptions): Promise<void> {
+  const events = await resolveGateEvents(opts);
+  const { log } = await import('../ui.js');
+
+  const cwd = process.cwd();
+  const results = installGates(cwd, events, resolveTier(opts));
+
+  for (const result of results) {
+    if (result.err) {
+      log.error('Totem Error', `Gate install failed for ${result.file}: ${result.err}`);
+      continue;
+    }
+    const label = result.event ? `${result.file} (${result.event})` : result.file;
+    if (result.action === 'created') {
+      log.success('Totem', `Scaffolded ${label}`);
+    } else if (result.action === 'merged') {
+      log.success('Totem', `Installed gate entry into ${label}`);
+    } else {
+      log.dim('Totem', `${label} already present — no change`);
+    }
+  }
 }
 
 /**

--- a/packages/cli/src/commands/gate.ts
+++ b/packages/cli/src/commands/gate.ts
@@ -3,6 +3,14 @@ import * as path from 'node:path';
 import { isGlobalConfigPath, loadConfig, resolveConfigPath } from '../utils.js';
 import { type GateTier, installGates } from './gate-install.js';
 
+/**
+ * Command-specific log tag for non-error output (log.success / log.dim).
+ * `log.error` keeps the mandatory fixed literal `'Totem Error'` tag per the
+ * repo styleguide (command-specific tags for info/success/dim, the unified
+ * error tag for log.error).
+ */
+const TAG = 'Gate';
+
 export interface GateCheckCommandOptions {
   event: string;
   payload: string;
@@ -76,7 +84,8 @@ export async function gateInstallCommand(opts: GateInstallCommandOptions): Promi
   const { log } = await import('../ui.js');
 
   const cwd = process.cwd();
-  const results = installGates(cwd, events, resolveTier(opts));
+  const tier = resolveTier(opts);
+  const results = installGates(cwd, events, tier);
 
   for (const result of results) {
     if (result.err) {
@@ -85,11 +94,15 @@ export async function gateInstallCommand(opts: GateInstallCommandOptions): Promi
     }
     const label = result.event ? `${result.file} (${result.event})` : result.file;
     if (result.action === 'created') {
-      log.success('Totem', `Scaffolded ${label}`);
+      log.success(TAG, `Scaffolded ${label}`);
     } else if (result.action === 'merged') {
-      log.success('Totem', `Installed gate entry into ${label}`);
+      log.success(TAG, `Installed gate entry into ${label}`);
+    } else if (result.action === 'updated') {
+      // Tier switch: the one existing entry's command was rewritten in place.
+      log.success(TAG, `Updated ${result.event ?? result.file} tier to ${tier}`);
     } else {
-      log.dim('Totem', `${label} already present — no change`);
+      // Genuine same-tier no-op — the ONLY case that prints "no change".
+      log.dim(TAG, `${label} already present — no change`);
     }
   }
 }

--- a/packages/cli/src/commands/host-hooks.ts
+++ b/packages/cli/src/commands/host-hooks.ts
@@ -142,10 +142,7 @@ export function mergeClaudeHooksKey(
     parsed.hooks = hooks;
     fs.writeFileSync(filePath, JSON.stringify(parsed, null, 2) + '\n', 'utf-8');
     return { action: 'merged' };
-    // totem-context: intentional — Result-returning installer; failures are reported
-    // to the caller via ScaffoldOutcome.err (surfaced by initCommand's log.error), not
-    // silently swallowed. Rethrowing would break the callers that branch on the returned
-    // { action, err }. Tenet 4 is satisfied by reporting the failure, not by throwing.
+    // totem-context: intentional — mergeClaudeHooksKey is a Result-returning installer; failures are reported to the caller via ScaffoldOutcome.err (surfaced by initCommand's log.error), never silently swallowed. Rethrowing would break the callers that branch on { action, err }, so Tenet 4 is satisfied by reporting the failure, not by throwing.
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return {

--- a/packages/cli/src/commands/host-hooks.ts
+++ b/packages/cli/src/commands/host-hooks.ts
@@ -115,7 +115,7 @@ export function mergeClaudeHooksKey(
     try {
       rawParsed = JSON.parse(raw);
     } catch (err) {
-      throw new Error(`Could not parse ${fileName} (invalid JSON)`, {
+      throw new Error(`[Totem Error] Could not parse ${fileName} (invalid JSON)`, {
         cause: err instanceof Error ? err : new Error(String(err)),
       });
     }
@@ -142,9 +142,16 @@ export function mergeClaudeHooksKey(
     parsed.hooks = hooks;
     fs.writeFileSync(filePath, JSON.stringify(parsed, null, 2) + '\n', 'utf-8');
     return { action: 'merged' };
+    // totem-context: intentional — Result-returning installer; failures are reported
+    // to the caller via ScaffoldOutcome.err (surfaced by initCommand's log.error), not
+    // silently swallowed. Rethrowing would break the callers that branch on the returned
+    // { action, err }. Tenet 4 is satisfied by reporting the failure, not by throwing.
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    return { action: 'skipped', err: `[Totem Error] ${message}` };
+    return {
+      action: 'skipped',
+      err: message.startsWith('[Totem Error]') ? message : `[Totem Error] ${message}`,
+    };
   }
 }
 

--- a/packages/cli/src/commands/host-hooks.ts
+++ b/packages/cli/src/commands/host-hooks.ts
@@ -81,6 +81,68 @@ export interface HostHookEntry {
 }
 
 /**
+ * Outcome of the shared read+ensure-dir+parse+safeParse step.
+ *
+ * - `absent`  — the settings file does not exist yet (caller writes a fresh
+ *               config and returns `'created'`).
+ * - `parsed`  — the file exists and validated against `ClaudeSettingsSchema`.
+ * - `shape-error` — the file is valid JSON but the wrong shape; the caller
+ *                   surfaces `err` as a `'skipped'` outcome (never throws).
+ *
+ * Invalid JSON is NOT represented here: `readAndParseSettings` THROWS for that
+ * case so the caller's `try/catch` maps it to a prefixed `[Totem Error]`,
+ * preserving the exact behavior `mergeClaudeHooksKey` had before extraction.
+ */
+type SettingsReadResult =
+  | { kind: 'absent' }
+  | { kind: 'parsed'; parsed: ParsedSettings }
+  | { kind: 'shape-error'; err: string };
+
+/**
+ * Shared read step for the settings-merge family: ensure the parent dir
+ * exists, then (if the file is present) read → JSON.parse → safeParse against
+ * `ClaudeSettingsSchema`. Extracted so `mergeClaudeHooksKey` (append) and
+ * `upsertClaudeHookCommand` (in-place update) share ONE read+validate path
+ * without either re-implementing it. Behavior is byte-identical to the inline
+ * version `mergeClaudeHooksKey` carried before: same dir-create, same
+ * invalid-JSON throw, same shape-error message.
+ */
+function readAndParseSettings(filePath: string): SettingsReadResult {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+
+  if (!fs.existsSync(filePath)) {
+    return { kind: 'absent' };
+  }
+
+  const fileName = path.basename(filePath);
+  const raw = fs.readFileSync(filePath, 'utf-8');
+  let rawParsed: unknown;
+  try {
+    rawParsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(`[Totem Error] Could not parse ${fileName} (invalid JSON)`, {
+      cause: err instanceof Error ? err : new Error(String(err)),
+    });
+  }
+
+  const result = ClaudeSettingsSchema.safeParse(rawParsed);
+  if (!result.success) {
+    const detail = result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+    // Prefix not added here — call site (initCommand) emits via
+    // log.error('Totem Error', ...) which adds the prefix automatically.
+    return {
+      kind: 'shape-error',
+      err: `Could not merge config: ${fileName} has unexpected shape: ${detail}`,
+    };
+  }
+
+  return { kind: 'parsed', parsed: result.data };
+}
+
+/**
  * Shared merge logic for installing a single hook entry into a Claude
  * settings JSON file (`settings.local.json` or `settings.json`) under
  * `hooks.<key>`. Both `PreToolUse` and `SessionStart` lifecycles share
@@ -96,42 +158,18 @@ export function mergeClaudeHooksKey(
   alreadyInstalled: (parsed: ParsedSettings) => boolean,
 ): ScaffoldOutcome {
   try {
-    const dir = path.dirname(filePath);
-    if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir, { recursive: true });
-    }
+    const read = readAndParseSettings(filePath);
 
-    const fileName = path.basename(filePath);
-
-    const fullConfig = { hooks: { [hookKind]: [entry] } };
-
-    if (!fs.existsSync(filePath)) {
+    if (read.kind === 'absent') {
+      const fullConfig = { hooks: { [hookKind]: [entry] } };
       fs.writeFileSync(filePath, JSON.stringify(fullConfig, null, 2) + '\n', 'utf-8');
       return { action: 'created' };
     }
-
-    const raw = fs.readFileSync(filePath, 'utf-8');
-    let rawParsed: unknown;
-    try {
-      rawParsed = JSON.parse(raw);
-    } catch (err) {
-      throw new Error(`[Totem Error] Could not parse ${fileName} (invalid JSON)`, {
-        cause: err instanceof Error ? err : new Error(String(err)),
-      });
+    if (read.kind === 'shape-error') {
+      return { action: 'skipped', err: read.err };
     }
 
-    const result = ClaudeSettingsSchema.safeParse(rawParsed);
-    if (!result.success) {
-      const detail = result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
-      // Prefix not added here — call site (initCommand) emits via
-      // log.error('Totem Error', ...) which adds the prefix automatically.
-      return {
-        action: 'skipped',
-        err: `Could not merge config: ${fileName} has unexpected shape: ${detail}`,
-      };
-    }
-
-    const parsed = result.data;
+    const parsed = read.parsed;
     if (alreadyInstalled(parsed)) {
       return { action: 'skipped' };
     }
@@ -143,6 +181,117 @@ export function mergeClaudeHooksKey(
     fs.writeFileSync(filePath, JSON.stringify(parsed, null, 2) + '\n', 'utf-8');
     return { action: 'merged' };
     // totem-context: intentional — mergeClaudeHooksKey is a Result-returning installer; failures are reported to the caller via ScaffoldOutcome.err (surfaced by initCommand's log.error), never silently swallowed. Rethrowing would break the callers that branch on { action, err }, so Tenet 4 is satisfied by reporting the failure, not by throwing.
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      action: 'skipped',
+      err: message.startsWith('[Totem Error]') ? message : `[Totem Error] ${message}`,
+    };
+  }
+}
+
+/** Outcome of a tier-aware `PreToolUse` command upsert. */
+export type HookUpsertOutcome = {
+  /**
+   * `created` — fresh settings file written; `merged` — a new entry appended;
+   * `updated` — an existing matching entry's command rewritten in place (e.g.
+   * a tier switch); `skipped` — the desired command was already present (true
+   * no-op) or the file had an unexpected shape (with `err`).
+   */
+  action: 'created' | 'merged' | 'updated' | 'skipped';
+  err?: string;
+};
+
+/**
+ * Tier-AWARE upsert of a single `PreToolUse` command into a Claude settings
+ * JSON file under `hooks.PreToolUse`. Unlike `mergeClaudeHooksKey` (which only
+ * ever appends or no-ops), this guarantees AT MOST ONE entry can match
+ * `(matcher, identifies)` and rewrites that entry's command in place when it
+ * differs from `desiredEntry`'s command — so re-installing the same gate at a
+ * different tier flips the baked command rather than silently no-opping or
+ * duplicating the entry.
+ *
+ * `identifies(command)` decides whether an existing hook command is "the same
+ * gate" (tier-INDEPENDENT). `desiredEntry` carries the canonical
+ * matcher + the single hook whose `command` is the tier-correct target.
+ *
+ * Cases:
+ *   1. no existing match  → append `desiredEntry`           → `merged` (or
+ *      `created` if the file did not exist)
+ *   2. match, same command → no write                        → `skipped`
+ *   3. match, different command → rewrite that hook's command → `updated`
+ *
+ * Result-returning (never throws past its own boundary), mirroring
+ * `mergeClaudeHooksKey`'s contract so callers branch on `{ action, err }`.
+ */
+export function upsertClaudeHookCommand(
+  filePath: string,
+  matcher: PreToolUseMatcher,
+  desiredEntry: HostHookEntry,
+  identifies: (command: string) => boolean,
+): HookUpsertOutcome {
+  try {
+    const desiredCommand = desiredEntry.hooks[0]?.command;
+    if (typeof desiredCommand !== 'string') {
+      // Programmer error in the caller, not a user-file condition — fail loud.
+      throw new Error('[Totem Error] upsertClaudeHookCommand: desiredEntry has no command');
+    }
+
+    const read = readAndParseSettings(filePath);
+
+    if (read.kind === 'absent') {
+      const fullConfig = { hooks: { PreToolUse: [desiredEntry] } };
+      fs.writeFileSync(filePath, JSON.stringify(fullConfig, null, 2) + '\n', 'utf-8');
+      return { action: 'created' };
+    }
+    if (read.kind === 'shape-error') {
+      return { action: 'skipped', err: read.err };
+    }
+
+    const parsed = read.parsed;
+    const hooks = parsed.hooks ?? {};
+    const entries = parsed.hooks?.PreToolUse ?? [];
+
+    // Find the single existing hook (entry index + hook index) that installs
+    // this same gate under the gate matcher, tier-independently. This installer
+    // never CREATES a second matching entry (it updates in place or appends when
+    // none), so a file it produced has at most one match per gate. It does NOT
+    // dedupe PRE-EXISTING duplicates (e.g. a hand-edited config): it updates the
+    // first match and leaves any others as-is.
+    for (const entry of entries) {
+      if (entry.matcher !== matcher || !Array.isArray(entry.hooks)) {
+        continue;
+      }
+      for (const hook of entry.hooks) {
+        const cmd = typeof hook === 'string' ? hook : hook.command;
+        if (typeof cmd !== 'string' || !identifies(cmd)) {
+          continue;
+        }
+        // Case 2: already the desired command (same tier) → true no-op.
+        if (cmd === desiredCommand) {
+          return { action: 'skipped' };
+        }
+        // Case 3: same gate, different command (tier switch) → update in place.
+        // Object hooks are rewritten on `.command`; the degenerate
+        // string-hook shape is replaced with the canonical object hook.
+        if (typeof hook === 'string') {
+          const hookList = entry.hooks as unknown[];
+          hookList[hookList.indexOf(hook)] = { type: 'command', command: desiredCommand };
+        } else {
+          hook.command = desiredCommand;
+        }
+        parsed.hooks = hooks;
+        fs.writeFileSync(filePath, JSON.stringify(parsed, null, 2) + '\n', 'utf-8');
+        return { action: 'updated' };
+      }
+    }
+
+    // Case 1: no existing entry for this gate → append.
+    hooks.PreToolUse = [...entries, desiredEntry];
+    parsed.hooks = hooks;
+    fs.writeFileSync(filePath, JSON.stringify(parsed, null, 2) + '\n', 'utf-8');
+    return { action: 'merged' };
+    // totem-context: intentional — upsertClaudeHookCommand is a Result-returning installer; failures are reported to the caller via HookUpsertOutcome.err (surfaced by the gate install logger), never silently swallowed. Rethrowing would break callers that branch on { action, err }, so Tenet 4 is satisfied by reporting the failure.
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return {

--- a/packages/cli/src/commands/host-hooks.ts
+++ b/packages/cli/src/commands/host-hooks.ts
@@ -1,0 +1,165 @@
+// ─── Host-hook settings-merge primitive (namespace-neutral) ──────────
+//
+// The single source of truth for idempotently merging ONE hook entry into a
+// Claude settings JSON file (`settings.local.json` or committed
+// `settings.json`) under `hooks.<key>`. Extracted from init.ts (PR-C,
+// mmnto-ai/totem#2048) so `gate install`, `init --gates=`, and later
+// Prop 257 / mmnto-ai/totem-strategy#448 share one merger — the
+// "namespace-neutral install primitive" strategy-claude's T0225Z asked for.
+//
+// Deliberately NOT a vendor-neutral `installHostHook(vendor)` abstraction
+// (YAGNI per ADR-109: the gate floor is Claude/PreToolUse-portability-
+// conditional; no Gemini gate consumer exists — Gemini uses a separate
+// whole-file scaffold path).
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { z } from 'zod';
+
+// Zod schema for the subset of a Claude settings JSON file that we validate.
+// `.passthrough()` everywhere preserves unknown keys across read/write so the
+// merge never drops user-defined config it does not understand.
+export const HookCommandSchema = z.union([
+  z.string(),
+  z.object({ type: z.string(), command: z.string() }).passthrough(),
+]);
+
+const PreToolUseEntrySchema = z
+  .object({
+    matcher: z.string().optional(),
+    hooks: z.array(HookCommandSchema).optional(),
+  })
+  .passthrough();
+
+const SessionStartEntrySchema = z
+  .object({
+    // SessionStart entries do NOT carry a `matcher` field (unlike
+    // PreToolUse entries). Adding it here would silently drop unknown
+    // shapes; passthrough preserves any future fields without breaking
+    // round-trip read/write.
+    hooks: z.array(HookCommandSchema).optional(),
+  })
+  .passthrough();
+
+export const ClaudeSettingsSchema = z
+  .object({
+    hooks: z
+      .object({
+        PreToolUse: z.array(PreToolUseEntrySchema).optional(),
+        SessionStart: z.array(SessionStartEntrySchema).optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+export type ParsedSettings = z.infer<typeof ClaudeSettingsSchema>;
+
+/** PreToolUse matcher values Totem installs under. */
+export type PreToolUseMatcher = 'Bash' | 'Write|Edit';
+
+/** Outcome of a settings-merge attempt. */
+export type ScaffoldOutcome = { action: 'created' | 'merged' | 'skipped'; err?: string };
+
+/** The `hooks.<key>` lifecycle a merge targets. */
+export type ClaudeHooksKey = 'PreToolUse' | 'SessionStart';
+
+/**
+ * Structural shape of a single hook entry. Widened from the closed
+ * 3-template `ClaudeHookEntry` union that lived in init.ts so a
+ * gate-wrapper entry (`{ matcher: 'Write|Edit', hooks: [{ type, command }] }`)
+ * is a valid argument without enumerating every concrete template. Any entry
+ * carrying a `hooks` array of `{ type, command }` objects (optionally a
+ * `matcher` / `timeout`) is accepted; passthrough fields (e.g. `timeout`) are
+ * preserved by the merge because the entry is written verbatim.
+ */
+export interface HostHookEntry {
+  matcher?: string;
+  hooks: Array<{ type: string; command: string; [k: string]: unknown }>;
+  [k: string]: unknown;
+}
+
+/**
+ * Shared merge logic for installing a single hook entry into a Claude
+ * settings JSON file (`settings.local.json` or `settings.json`) under
+ * `hooks.<key>`. Both `PreToolUse` and `SessionStart` lifecycles share
+ * the same read → safeparse → idempotency probe → append → write shape;
+ * this is the single source of truth.
+ *
+ * Idempotent: returns `'skipped'` if `alreadyInstalled(parsed)` is true.
+ */
+export function mergeClaudeHooksKey(
+  filePath: string,
+  hookKind: ClaudeHooksKey,
+  entry: HostHookEntry,
+  alreadyInstalled: (parsed: ParsedSettings) => boolean,
+): ScaffoldOutcome {
+  try {
+    const dir = path.dirname(filePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+
+    const fileName = path.basename(filePath);
+
+    const fullConfig = { hooks: { [hookKind]: [entry] } };
+
+    if (!fs.existsSync(filePath)) {
+      fs.writeFileSync(filePath, JSON.stringify(fullConfig, null, 2) + '\n', 'utf-8');
+      return { action: 'created' };
+    }
+
+    const raw = fs.readFileSync(filePath, 'utf-8');
+    let rawParsed: unknown;
+    try {
+      rawParsed = JSON.parse(raw);
+    } catch (err) {
+      throw new Error(`Could not parse ${fileName} (invalid JSON)`, {
+        cause: err instanceof Error ? err : new Error(String(err)),
+      });
+    }
+
+    const result = ClaudeSettingsSchema.safeParse(rawParsed);
+    if (!result.success) {
+      const detail = result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
+      // Prefix not added here — call site (initCommand) emits via
+      // log.error('Totem Error', ...) which adds the prefix automatically.
+      return {
+        action: 'skipped',
+        err: `Could not merge config: ${fileName} has unexpected shape: ${detail}`,
+      };
+    }
+
+    const parsed = result.data;
+    if (alreadyInstalled(parsed)) {
+      return { action: 'skipped' };
+    }
+
+    const existing = parsed.hooks?.[hookKind] ?? [];
+    const hooks = parsed.hooks ?? {};
+    hooks[hookKind] = [...existing, entry];
+    parsed.hooks = hooks;
+    fs.writeFileSync(filePath, JSON.stringify(parsed, null, 2) + '\n', 'utf-8');
+    return { action: 'merged' };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { action: 'skipped', err: `[Totem Error] ${message}` };
+  }
+}
+
+/**
+ * True iff `parsed.hooks.PreToolUse` contains an entry under `matcher`
+ * whose hook list satisfies `probe`. The idempotency primitive both the
+ * shield-gate and gate-install installers key on.
+ */
+export function preToolUseHasMatcher(
+  parsed: ParsedSettings,
+  matcher: PreToolUseMatcher,
+  probe: (entry: z.infer<typeof HookCommandSchema>) => boolean,
+): boolean {
+  const preToolUse = parsed.hooks?.PreToolUse ?? [];
+  return preToolUse.some(
+    (h) => h.matcher === matcher && Array.isArray(h.hooks) && h.hooks.some(probe),
+  );
+}

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -407,6 +407,241 @@ export const CLAUDE_SESSION_START_ENTRY = {
   ],
 };
 
+// ─── Claude Code action-gate wrapper (PR-C, mmnto-ai/totem#2048) ───────
+//
+// ONE parameterized PreToolUse wrapper that generalizes the shipped
+// `review-gate.sh` content-hash pattern into a reusable form. It reads the
+// PreToolUse stdin envelope, shells to `totem gate check --event <name>
+// --payload <json>`, parses the emitted `GateVerdict`, and maps
+// `disposition` → host exit code (ADR-109 §2). One wrapper, N gates: each
+// installed PreToolUse entry points at this same script with a different
+// `--event` arg baked into the `command` string, so new gates need no new
+// CLI flag (the `knownGateEvents()` registry is the single source of truth).
+//
+// `.cjs` extension is load-bearing: `type: module` repos resolve `.js` as
+// ESM and reject the CommonJS `require()` calls; Claude Code execs hooks via
+// plain `node`.
+//
+// Disposition → exit code (ADR-109 §2, branch ONLY on disposition — R2):
+//   allow → exit 0 (silent)
+//   warn  → exit 0 + reason/provenance to stderr (advisory; NEVER blocks)
+//   deny  → reason/provenance to stderr; --strict (default) → exit 2
+//           (Claude block convention), --pilot → exit 0
+//
+// THE EMPTY-SUBSYSTEM GUARDRAIL (strategy-claude T0041Z — LOAD-BEARING):
+//   A normal Edit/Write carries `tool_input.file_path` (a PATH), NOT a
+//   declared `subsystem`. Path→subsystem mapping is deferred (ADR-109
+//   line 112), so an Edit has NO declared subsystem → NO GATE APPLIES →
+//   exit 0 (pass through). The wrapper must NOT invoke `gate check` for it.
+//   Handing freeze-check an empty subsystem throws GATE_INVALID; a blanket
+//   fail-closed would then block EVERY edit (a gate meant to deny ONE frozen
+//   subsystem denying ALL edits — Tenet 19 drift). Only when a declared
+//   subsystem IS present does the wrapper shell out; only then can a broken
+//   deterministic source (corrupt freeze.json) fail-close (exit 2).
+//
+// Tier (--strict default / --pilot) is read by the WRAPPER, not the engine
+// (the engine stays pure per ADR-109 [LOCKED]; freeze-check never emits
+// `warn`). The tier is BAKED into the installed command string at install
+// time and read ONLY from argv — there is NO env-var override, so a default
+// (`--strict`) install is enforcement-immune to a consumer's environment
+// (env-var sourcing would be a fail-open: a `TOTEM_GATE_TIER=pilot` in any
+// shell could silently downgrade every gate to advisory). Pilot is an
+// explicit, install-time opt-in only.
+
+// totem-context: hook script template content — child_process is part of the
+// rendered .cjs payload that Claude Code execs via plain `node`, not a runtime
+// call from this cli source. Same shape as CLAUDE_SESSION_START above.
+export const CLAUDE_GATE_WRAPPER = `// [totem] auto-generated — Claude Code action-gate wrapper
+// ONE parameterized PreToolUse wrapper for the Totem gate engine (PR-C,
+// mmnto-ai/totem#2048). Reads --event <name> from argv (baked per-entry into
+// the installed command), reads the PreToolUse stdin envelope, shells to
+// \`totem gate check\`, and maps the GateVerdict disposition → host exit code.
+// \`.cjs\` extension because package.json may have "type": "module" — Claude
+// Code execs hooks via plain \`node\`, which would otherwise treat \`.js\` as ESM.
+//
+// Exit-code contract (LOAD-BEARING — ADR-109 §2; branch ONLY on disposition):
+//   0 = allow | warn | --pilot deny | NOT-APPLICABLE fail-soft
+//       (unparseable/non-object envelope, no-declared-subsystem pass-through)
+//   2 = deny (--strict, Claude block convention)
+//       | APPLICABLE-gate-not-evaluable fail-closed (missing CLI, non-zero
+//         \`gate check\`, unparseable verdict, or unknown disposition)
+'use strict';
+
+const { spawnSync } = require('child_process');
+const { existsSync } = require('fs');
+const { join } = require('path');
+
+// ─── Parse baked args (--event <name>, optional --pilot / --strict) ─────
+// The tier is read ONLY from argv (baked into the installed command at
+// install time). There is NO env-var override: env sourcing would be a
+// fail-open (any shell with TOTEM_GATE_TIER=pilot could silently downgrade
+// enforcement). Default (no flag) = strict, so a default install is
+// environment-immune; --pilot is an explicit install-time opt-in.
+const argv = process.argv.slice(2);
+let event = '';
+let tier = 'strict';
+for (let i = 0; i < argv.length; i++) {
+  if (argv[i] === '--event') {
+    event = argv[i + 1] || '';
+    i++;
+  } else if (argv[i] === '--pilot') {
+    tier = 'pilot';
+  } else if (argv[i] === '--strict') {
+    tier = 'strict';
+  }
+}
+
+// Read the PreToolUse stdin envelope.
+let stdin = '';
+process.stdin.setEncoding('utf-8');
+process.stdin.on('data', (chunk) => {
+  stdin += chunk;
+});
+process.stdin.on('end', () => {
+  let parsed;
+  try {
+    parsed = stdin ? JSON.parse(stdin) : {};
+  } catch (err) {
+    // Fail-soft on a malformed envelope (mirror PreWriteShield): a broken
+    // host envelope is not an applicable gate, so it must NOT block.
+    process.stderr.write('[totem gate-wrapper] could not parse stdin JSON; allowing\\n');
+    process.exit(0);
+  }
+
+  // Valid JSON can still be a non-object (the bytes \`null\`, \`123\`, or a bare
+  // quoted string). Such an envelope carries no \`tool_input\` to dereference and
+  // is NOT an applicable gate → fail-soft (exit 0). Guarding here also prevents
+  // a TypeError-on-deref from leaking as exit 1.
+  if (parsed === null || typeof parsed !== 'object') {
+    process.stderr.write('[totem gate-wrapper] stdin JSON is not an object; allowing\\n');
+    process.exit(0);
+  }
+
+  const input =
+    typeof parsed.tool_input === 'object' && parsed.tool_input !== null ? parsed.tool_input : {};
+
+  // ─── THE EMPTY-SUBSYSTEM GUARDRAIL ────────────────────────────────────
+  // freeze-check's predicate is on a DECLARED subsystem. A normal Edit/Write
+  // carries tool_input.file_path (a path), NOT a subsystem. With no declared
+  // subsystem, NO GATE APPLIES → pass through (exit 0). Do NOT shell out — a
+  // blanket fail-closed here would block every ordinary edit.
+  const declaredSubsystem =
+    typeof input.subsystem === 'string' && input.subsystem.trim() !== ''
+      ? input.subsystem.trim()
+      : '';
+  if (declaredSubsystem === '') {
+    process.exit(0);
+  }
+
+  // A gate genuinely applies. Build the --payload from the declared fields.
+  // NOTE: this payload projection is freeze-check-shaped (subsystem-only). The
+  // wrapper is --event-parameterized, but the payload it builds is currently
+  // freeze-check-specific; a future gate needing a different payload field must
+  // extend this projection (e.g. branch on \`event\`).
+  const payload = JSON.stringify({ subsystem: declaredSubsystem });
+
+  // Resolve the LOCAL Totem CLI (the global \`totem\` binary may be stale and
+  // missing deps — the known repo gotcha). Invoke node on the installed dist
+  // entry.
+  //
+  // FAIL-CLOSED on a missing CLI: we are PAST the empty-subsystem guardrail, so
+  // a gate genuinely APPLIES here. freeze-check has NO commit-time hard floor
+  // (unlike PreWriteShield, whose fail-soft is backed by \`totem-lint\` at
+  // commit), so an APPLICABLE gate that cannot be evaluated for ANY reason
+  // (missing CLI OR corrupt freeze.json) must fail closed — not silently allow
+  // (guardrail rule + Tenet 4 fail-closed). Fail-SOFT (exit 0) is reserved for
+  // genuinely NOT-APPLICABLE inputs (unparseable/non-object envelope, no
+  // declared subsystem), all of which already returned above.
+  const cliPath = join(process.cwd(), 'node_modules', '@mmnto', 'cli', 'dist', 'index.js');
+  if (!existsSync(cliPath)) {
+    process.stderr.write(
+      '[totem gate] ' +
+        event +
+        ' applies but the totem CLI is not resolvable; failing closed. ' +
+        'Reinstall totem or run \`totem eject\` to remove the gate.\\n',
+    );
+    process.exit(2);
+  }
+
+  const result = spawnSync(
+    process.execPath,
+    [cliPath, 'gate', 'check', '--event', event, '--payload', payload],
+    { encoding: 'utf-8', timeout: 30000 },
+  );
+
+  // ─── FAIL-CLOSED ──────────────────────────────────────────────────────
+  // A gate genuinely applies (a declared subsystem was present) and the
+  // evaluation itself failed (non-zero exit: corrupt freeze.json, spawn
+  // error, etc.). Never silently allow when an applicable gate's source is
+  // broken → exit 2. (No-declared-subsystem already returned exit 0 above,
+  // so this only blocks when a subsystem was actually declared.)
+  if (result.error || typeof result.status !== 'number' || result.status !== 0) {
+    process.stderr.write(
+      '[totem gate-wrapper] gate "' +
+        event +
+        '" evaluation failed (source broken or unavailable) — blocking (fail-closed).\\n' +
+        (result.stderr || (result.error ? String(result.error.message || result.error) : '')) +
+        '\\n',
+    );
+    process.exit(2);
+  }
+
+  let verdict;
+  try {
+    verdict = JSON.parse(result.stdout || '');
+  } catch (err) {
+    // The command emitted unparseable stdout despite a 0 exit — an applicable
+    // gate whose verdict we cannot read is a broken source → fail-closed.
+    process.stderr.write(
+      '[totem gate-wrapper] gate "' + event + '" emitted unparseable verdict — blocking (fail-closed).\\n',
+    );
+    process.exit(2);
+  }
+
+  // ─── Disposition → host exit code (branch ONLY on disposition) ─────────
+  const disposition = verdict && typeof verdict.disposition === 'string' ? verdict.disposition : '';
+  // reason/provenance are OPAQUE stderr passthrough — never parsed for control flow.
+  const detail =
+    (verdict && verdict.reason ? verdict.reason : '') +
+    (verdict && verdict.provenance ? ' [' + JSON.stringify(verdict.provenance) + ']' : '');
+
+  if (disposition === 'allow') {
+    process.exit(0);
+  }
+  if (disposition === 'warn') {
+    process.stderr.write('[totem gate-wrapper] ' + event + ' (warn): ' + detail + '\\n');
+    process.exit(0);
+  }
+  if (disposition === 'deny') {
+    process.stderr.write('[totem gate-wrapper] ' + event + ' (deny): ' + detail + '\\n');
+    process.exit(tier === 'pilot' ? 0 : 2);
+  }
+
+  // Unknown disposition from an applicable gate — fail-closed.
+  process.stderr.write(
+    '[totem gate-wrapper] gate "' + event + '" returned unknown disposition "' + disposition + '" — blocking (fail-closed).\\n',
+  );
+  process.exit(2);
+});
+`;
+
+// The PreToolUse entry constant for the freeze-check gate. The \`--event\`
+// is baked into the command string per-entry (one wrapper, N gates = N
+// entries pointing at the same script with different --event args).
+// Matches the \`Write|Edit\` matcher so the wrapper sees every write — the
+// empty-subsystem guardrail (in the wrapper) is what keeps ordinary edits
+// passing through. Installed into committed \`.claude/settings.json\`
+// (team-level governance — gate opt-in is repo policy, Tenet 12).
+export const CLAUDE_GATE_WRAPPER_ENTRY = {
+  matcher: 'Write|Edit',
+  hooks: [
+    {
+      type: 'command',
+      command: 'node .claude/hooks/gate-wrapper.cjs --event freeze-check',
+    },
+  ],
+};
+
 // ─── Claude Code skill distribution (mmnto-ai/totem#1890 Phase C slice 3) ───
 //
 // Skills are surfaced into consumer repos at `.claude/skills/<name>/SKILL.md`.

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -632,12 +632,20 @@ process.stdin.on('end', () => {
 // empty-subsystem guardrail (in the wrapper) is what keeps ordinary edits
 // passing through. Installed into committed \`.claude/settings.json\`
 // (team-level governance — gate opt-in is repo policy, Tenet 12).
+//
+// SOURCE OF TRUTH for the ACTUAL installed command is
+// gate-install.ts \`gateCommand(event, tier)\` — it builds the per-gate,
+// per-tier string at install time. This constant supplies ONLY the canonical
+// \`matcher\` and hook \`type\` (the fields \`gateEntry()\` reads); its \`command\`
+// here mirrors the DEFAULT install (freeze-check at the default \`--strict\`
+// tier) so a reader sees exactly what a default \`totem gate install\` bakes,
+// not a tier-less never-installed string.
 export const CLAUDE_GATE_WRAPPER_ENTRY = {
   matcher: 'Write|Edit',
   hooks: [
     {
       type: 'command',
-      command: 'node .claude/hooks/gate-wrapper.cjs --event freeze-check',
+      command: 'node .claude/hooks/gate-wrapper.cjs --event freeze-check --strict',
     },
   ],
 };

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1278,7 +1278,17 @@ export default {
           // resolveGateEvents validates a single name against the registry
           // and throws (fail-loud) on unknown — no default-install.
           const [validated] = await resolveGateEvents({ name });
-          gateEvents.push(validated!);
+          // resolveGateEvents returns a non-empty array or throws, so this
+          // never fires today — but guard explicitly (no fragile `!`): fail
+          // loud rather than push `undefined` if it ever returns empty.
+          if (!validated) {
+            throw new TotemError(
+              'GATE_INVALID',
+              `Gate "${name}" did not resolve.`,
+              'This is an internal error — the gate registry returned no event for a validated name.',
+            );
+          }
+          gateEvents.push(validated);
         }
       }
 
@@ -1289,7 +1299,7 @@ export default {
       const gateResults = installGates(cwd, gateEvents, gateTier);
       for (const result of gateResults) {
         if (result.err) {
-          log.error('Totem Error', `Gate install failed for ${result.file}: ${result.err}`); // totem-ignore — internal gate installer error
+          log.error('Totem Error', `Gate install failed for ${result.file}: ${result.err}`);
         } else if (result.action === 'created') {
           summary.push({
             file: result.file,
@@ -1299,6 +1309,13 @@ export default {
           summary.push({
             file: result.file,
             action: `Installed gate "${result.event}" into existing config`,
+          });
+        } else if (result.action === 'updated') {
+          // Tier switch on a re-init — the one existing entry was rewritten in
+          // place (NOT the misleading "already present — no change" no-op).
+          summary.push({
+            file: result.file,
+            action: `Updated gate "${result.event}" tier to ${gateTier}`,
           });
         }
       }

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -6,6 +6,13 @@ import { z } from 'zod';
 import type { IngestTarget } from '@mmnto/totem';
 
 import {
+  type HookCommandSchema,
+  mergeClaudeHooksKey,
+  type ParsedSettings,
+  preToolUseHasMatcher,
+  type ScaffoldOutcome,
+} from './host-hooks.js';
+import {
   AI_TOOLS,
   type AiToolInfo,
   type Ecosystem,
@@ -141,41 +148,13 @@ async function installGeminiHooks(cwd: string): Promise<HookInstallerResult[]> {
 
 // --- Claude Code hook installer ---
 
-// Zod schema for the subset of settings.local.json that we need to validate.
-// Uses .passthrough() to preserve unknown keys during round-trip read/write.
-const HookCommandSchema = z.union([
-  z.string(),
-  z.object({ type: z.string(), command: z.string() }).passthrough(),
-]);
-
-const PreToolUseEntrySchema = z
-  .object({
-    matcher: z.string().optional(),
-    hooks: z.array(HookCommandSchema).optional(),
-  })
-  .passthrough();
-
-const SessionStartEntrySchema = z
-  .object({
-    // SessionStart entries do NOT carry a `matcher` field (unlike
-    // PreToolUse entries). Adding it here would silently drop unknown
-    // shapes; passthrough preserves any future fields without breaking
-    // round-trip read/write.
-    hooks: z.array(HookCommandSchema).optional(),
-  })
-  .passthrough();
-
-const ClaudeSettingsSchema = z
-  .object({
-    hooks: z
-      .object({
-        PreToolUse: z.array(PreToolUseEntrySchema).optional(),
-        SessionStart: z.array(SessionStartEntrySchema).optional(),
-      })
-      .passthrough()
-      .optional(),
-  })
-  .passthrough();
+// The settings-merge primitive (ClaudeSettingsSchema, HookCommandSchema,
+// mergeClaudeHooksKey, preToolUseHasMatcher, and the ScaffoldOutcome /
+// ParsedSettings / ClaudeHooksKey types) lives in host-hooks.js — the
+// namespace-neutral install primitive shared by gate-install, init, and
+// later Prop 257 (PR-C, mmnto-ai/totem#2048). The Totem-specific
+// idempotency probes (hasTotemShield, etc.) and the per-lifecycle scaffold
+// wrappers stay here.
 
 /** Check whether a hook entry already contains a totem review/shield reference. */
 function hasTotemShield(entry: z.infer<typeof HookCommandSchema>): boolean {
@@ -198,94 +177,6 @@ function hasPreWriteShield(entry: z.infer<typeof HookCommandSchema>): boolean {
 function hasTotemSessionStart(entry: z.infer<typeof HookCommandSchema>): boolean {
   if (typeof entry === 'string') return entry.includes('SessionStart.cjs');
   return entry.command.includes('SessionStart.cjs');
-}
-
-type ParsedSettings = z.infer<typeof ClaudeSettingsSchema>;
-type PreToolUseMatcher = 'Bash' | 'Write|Edit';
-type ScaffoldOutcome = { action: 'created' | 'merged' | 'skipped'; err?: string };
-type ClaudeHooksKey = 'PreToolUse' | 'SessionStart';
-type ClaudeHookEntry =
-  | typeof CLAUDE_PRETOOLUSE_ENTRY
-  | typeof CLAUDE_PREWRITESHIELD_ENTRY
-  | typeof CLAUDE_SESSION_START_ENTRY;
-
-/**
- * Shared merge logic for installing a single hook entry into a Claude
- * settings JSON file (`settings.local.json` or `settings.json`) under
- * `hooks.<key>`. Both `PreToolUse` and `SessionStart` lifecycles share
- * the same read → safeparse → idempotency probe → append → write shape;
- * this is the single source of truth.
- *
- * Idempotent: returns `'skipped'` if `alreadyInstalled(parsed)` is true.
- */
-function mergeClaudeHooksKey(
-  filePath: string,
-  hookKind: ClaudeHooksKey,
-  entry: ClaudeHookEntry,
-  alreadyInstalled: (parsed: ParsedSettings) => boolean,
-): ScaffoldOutcome {
-  try {
-    const dir = path.dirname(filePath);
-    if (!fs.existsSync(dir)) {
-      fs.mkdirSync(dir, { recursive: true });
-    }
-
-    const fileName = path.basename(filePath);
-
-    const fullConfig = { hooks: { [hookKind]: [entry] } };
-
-    if (!fs.existsSync(filePath)) {
-      fs.writeFileSync(filePath, JSON.stringify(fullConfig, null, 2) + '\n', 'utf-8');
-      return { action: 'created' };
-    }
-
-    const raw = fs.readFileSync(filePath, 'utf-8');
-    let rawParsed: unknown;
-    try {
-      rawParsed = JSON.parse(raw);
-    } catch (err) {
-      throw new Error(`Could not parse ${fileName} (invalid JSON)`, {
-        cause: err instanceof Error ? err : new Error(String(err)),
-      });
-    }
-
-    const result = ClaudeSettingsSchema.safeParse(rawParsed);
-    if (!result.success) {
-      const detail = result.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`).join('; ');
-      // Prefix not added here — call site (initCommand) emits via
-      // log.error('Totem Error', ...) which adds the prefix automatically.
-      return {
-        action: 'skipped',
-        err: `Could not merge config: ${fileName} has unexpected shape: ${detail}`,
-      };
-    }
-
-    const parsed = result.data;
-    if (alreadyInstalled(parsed)) {
-      return { action: 'skipped' };
-    }
-
-    const existing = parsed.hooks?.[hookKind] ?? [];
-    const hooks = parsed.hooks ?? {};
-    hooks[hookKind] = [...existing, entry];
-    parsed.hooks = hooks;
-    fs.writeFileSync(filePath, JSON.stringify(parsed, null, 2) + '\n', 'utf-8');
-    return { action: 'merged' };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return { action: 'skipped', err: `[Totem Error] ${message}` };
-  }
-}
-
-function preToolUseHasMatcher(
-  parsed: ParsedSettings,
-  matcher: PreToolUseMatcher,
-  probe: (entry: z.infer<typeof HookCommandSchema>) => boolean,
-): boolean {
-  const preToolUse = parsed.hooks?.PreToolUse ?? [];
-  return preToolUse.some(
-    (h) => h.matcher === matcher && Array.isArray(h.hooks) && h.hooks.some(probe),
-  );
 }
 
 function sessionStartHas(
@@ -773,6 +664,11 @@ export async function initCommand(options?: {
    *  or pre-marker scaffold files; force-mode suppresses ONLY the no-marker
    *  guard. Marker-bearing files refresh via the normal path regardless. */
   forceSkillRefresh?: boolean;
+  /** Install action-gate PreToolUse hooks (PR-C, mmnto-ai/totem#2048): a
+   *  comma-list of gate names (validated against `knownGateEvents()`) or
+   *  the literal `all`. Routes through the SAME `installGates` path the
+   *  `gate install` verb uses — no second copy of the merge logic. */
+  gates?: string;
   /** Override home directory for testing. */
   _homeDir?: string;
 }): Promise<void> {
@@ -1345,6 +1241,68 @@ export default {
         }
       }
     } // end of bare mode else block
+
+    // --- Always run: action-gate install (--gates=, PR-C mmnto-ai/totem#2048) ---
+    // Thin sugar that is INTENTIONALLY outside the bare-mode branch: gate
+    // opt-in is an independent, explicit flag (it works in bare repos too).
+    // Parses the comma-list (or `all`), validates each member against
+    // knownGateEvents() (fail loud on unknown), and routes through the SAME
+    // installGates() path the `gate install` verb uses — no second copy of
+    // the merge logic.
+    if (options?.gates) {
+      const { resolveGateEvents } = await import('./gate.js');
+      const { installGates } = await import('./gate-install.js');
+      const { TotemError, knownGateEvents } = await import('@mmnto/totem');
+      const requested = options.gates.trim();
+      let gateEvents: string[];
+      if (requested.toLowerCase() === 'all') {
+        gateEvents = await resolveGateEvents({ all: true });
+      } else {
+        const names = requested
+          .split(',')
+          .map((n) => n.trim())
+          .filter((n) => n.length > 0);
+        // Empty after parse/trim/filter (e.g. `--gates=,` or whitespace-only):
+        // fail loud rather than scaffolding an orphan wrapper with no entry.
+        // Restores parity with the verb's resolveGateEvents no-selection
+        // fail-loud (no default-install).
+        if (names.length === 0) {
+          throw new TotemError(
+            'GATE_INVALID',
+            'No gate selected in --gates=.',
+            `Pass --gates=all or one of: ${knownGateEvents().join(', ')}.`,
+          );
+        }
+        gateEvents = [];
+        for (const name of names) {
+          // resolveGateEvents validates a single name against the registry
+          // and throws (fail-loud) on unknown — no default-install.
+          const [validated] = await resolveGateEvents({ name });
+          gateEvents.push(validated!);
+        }
+      }
+
+      // Tier is derived from the existing init options (pilot vs strict) and
+      // BAKED into the installed command at install time (the wrapper reads it
+      // ONLY from argv — no env override). Default install bakes --strict.
+      const gateTier = options?.pilot ? 'pilot' : 'strict';
+      const gateResults = installGates(cwd, gateEvents, gateTier);
+      for (const result of gateResults) {
+        if (result.err) {
+          log.error('Totem Error', `Gate install failed for ${result.file}: ${result.err}`); // totem-ignore — internal gate installer error
+        } else if (result.action === 'created') {
+          summary.push({
+            file: result.file,
+            action: result.event ? `Scaffolded gate "${result.event}"` : 'Scaffolded gate wrapper',
+          });
+        } else if (result.action === 'merged') {
+          summary.push({
+            file: result.file,
+            action: `Installed gate "${result.event}" into existing config`,
+          });
+        }
+      }
+    }
 
     // --- Print summary ---
     if (summary.length > 0) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -95,6 +95,10 @@ program
     '--force-skill-refresh',
     'Force-overwrite skill files lacking canonical markers (may destroy user content; review the diff after)',
   )
+  .option(
+    '--gates <list>',
+    'Install action-gate PreToolUse hooks: a comma-list of gate names (e.g. freeze-check) or "all"',
+  )
   .action(
     async (options: {
       bare?: boolean;
@@ -102,6 +106,7 @@ program
       strict?: boolean;
       global?: boolean;
       forceSkillRefresh?: boolean;
+      gates?: string;
     }) => {
       try {
         await initCommand({
@@ -110,6 +115,7 @@ program
           strict: options.strict,
           global: options.global,
           forceSkillRefresh: options.forceSkillRefresh,
+          gates: options.gates,
         });
       } catch (err) {
         handleError(err);
@@ -1159,6 +1165,34 @@ gateCmd
       throw err;
     }
   });
+
+gateCmd
+  .command('install [name]')
+  .description('Install a gate PreToolUse hook into committed .claude/settings.json (idempotent)')
+  .option('--all', 'Install every known gate (the knownGateEvents() registry)')
+  .option(
+    '--pilot',
+    'Bake the advisory pilot tier into the installed command (deny → exit 0 + stderr). Default is strict (deny → exit 2).',
+  )
+  .option('--strict', 'Bake the strict enforcement tier (the default; deny → exit 2)')
+  .addHelpText(
+    'after',
+    `\nExamples:\n  $ totem gate install --all\n  $ totem gate install freeze-check\n  $ totem gate install freeze-check --pilot\n`,
+  )
+  .action(
+    async (
+      name: string | undefined,
+      opts: { all?: boolean; pilot?: boolean; strict?: boolean },
+    ) => {
+      try {
+        const { gateInstallCommand } = await import('./commands/gate.js');
+        await gateInstallCommand({ all: opts.all, name, pilot: opts.pilot, strict: opts.strict });
+      } catch (err) {
+        handleError(err); // handleError returns `never`; unreachable throw below satisfies the fail-loud check
+        throw err;
+      }
+    },
+  );
 
 // ─── Lesson noun-verb subcommands ────────────────────────
 


### PR DESCRIPTION
PR-C — the WS3 install/wiring tail. The `totem gate check` engine + `GateVerdict` shipped in #2046 (1.51.0); this is the **opt-in distribution layer** that wires a shipped gate into a consumer repo's Claude PreToolUse hook. It generalizes the hand-wired `review-gate.sh` content-hash pattern into a reusable, parameterized form.

**Ratified contract:** ADR-109 (mmnto-ai/totem-strategy#457). Wiring-depth + guardrail ruling: strategy-claude dispatch T0041Z. Design doc: `.totem/specs/2048.md`.

## What it adds
- **`totem gate install [name] [--all] [--pilot|--strict]`** — sibling of `gate check`. `--all` enumerates `knownGateEvents()` (registry is the single source of truth → new gates installable with zero new flags); unknown/empty selection fails loud. Idempotently merges one PreToolUse entry per gate into committed `.claude/settings.json`.
- **One parameterized wrapper** `.claude/hooks/gate-wrapper.cjs` — reads the PreToolUse stdin envelope, shells to `totem gate check --event <name>`, and maps **disposition → host exit code**. `--event` is baked per-entry (one wrapper, N gates = N entries).
- **`totem init --gates=<list|all>`** — sugar routing through the *same* installer.
- **`host-hooks.ts`** (new) — the settings-merge primitive extracted namespace-neutral from `init.ts` (entry widened to a structural `HostHookEntry`); existing callers (shield-gate, PreWriteShield, SessionStart) unchanged.
- **eject parity** + **27 CLI-seam tests**.

## Design decisions (ratified — ADR-109 + T0041Z)
- **Disposition → exit (ADR-109 §2):** `allow`→0, `warn`→0+stderr, `deny`→2 (strict) / 0+stderr (`--pilot`). Branch **only** on disposition; reason/provenance are opaque stderr passthrough. Tier lives in the wrapper; the engine stays pure.
- **Empty-subsystem guardrail (load-bearing):** an Edit/Write carries a *path*, not a subsystem → no gate applies → **pass through (exit 0) before any shell-out**. A blanket fail-closed would block every edit (Tenet 19).
- **Tier is baked into the installed command and read only from argv** — no `TOTEM_GATE_TIER` env override (env sourcing would be a fail-open: any shell could silently downgrade enforcement). A default install is **env-immune**.
- **Fail-closed (exit 2)** when an *applicable* gate cannot be evaluated — missing CLI, non-zero `gate check`, unparseable/unknown verdict. (freeze-check has no commit-time floor, so applicable-but-unevaluable must block — guardrail rule + Tenet 4.)
- **Engine + `gate check` command untouched** — no stdin reader added; the command stays host-agnostic (ADR-109 LOCKED).

## Non-goals (deferred)
- Path→subsystem **glob matching** (ADR-109 line 112 defers it behind a falsifiable trigger; declared-in-freeze-entry seed captured).
- `content-hash` / `dup-issue` gates; any Gemini gate path; per-gate init flags.

## Verification
- Build clean (core + cli); **2293 tests pass** (incl. 27 new CLI-seam tests covering the full exit map, the guardrail, fail-closed edges, idempotency, eject parity, init routing, fail-loud).
- `totem lint` 0 errors; `totem review` PASS (no findings).
- Multi-lens adversarial review (fail-open/guardrail, ADR-109 conformance, idempotency/eject/no-regression, test adequacy) — both MAJOR fail-opens (env-var downgrade, missing-CLI allow) found and closed before this PR.

Closes #2048

On merge, the reference-wiring acceptance of **mmnto-ai/totem-strategy#439** is met (cross-repo — close manually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)