### PR TITLE
feat(cli): totem orient — derive-orientation command (WS2, #2044)

### DIFF
--- a/.changeset/totem-orient-command.md
+++ b/.changeset/totem-orient-command.md
@@ -25,7 +25,7 @@ runs green when `@google/genai` is absent.
 Consumer-safety: owner is derived from `gh repo view`; the GH Project number is
 read from the new optional `orient.projectNumber` field in `totem.config.ts`
 (env `TOTEM_ORIENT_PROJECT` overrides last). With no project configured the
-board section is an honest absence — the cohort's board is never baked in.
+board section is an honest absence — the cohort's board is not baked in.
 
 Core (`@mmnto/totem`): adds the optional `orient.projectNumber` config field
 (`OrientConfigSchema`).

--- a/.changeset/totem-orient-command.md
+++ b/.changeset/totem-orient-command.md
@@ -1,0 +1,31 @@
+---
+'@mmnto/cli': minor
+'@mmnto/totem': patch
+---
+
+feat(cli): `totem orient` — derive session orientation from primitives (zero LLM)
+
+New `totem orient [--json]` command (WS2, #2044). A deterministic sensor that
+derives "what's parked / in flight / open" from live `gh` / `git` / fs
+primitives — `.totem/freeze.json` parked entries, open PRs (with `[draft]`),
+the in-flight GH Project board, epics + sub-issues (with a cross-repo parent
+guard), other open issues, and a one-line index-freshness pointer — each line
+citing its primitive. Adds one new derived signal: a board↔issue **coherence**
+flag (an active board card whose issue is closed/absent = drift), computed by a
+pure predicate from the board + open-issue primitives orient already fetched
+(no extra `gh` call). Sibling to `totem triage` (LLM synthesis on top); they
+compose, not duplicate.
+
+Honest by construction: every section is its value or an `{ error }` envelope —
+nothing silently omitted (Tenet 4); "not yet synced" / "no board configured"
+are explicit absences, not errors (Tenet 14); the footer states the output is a
+snapshot/cache, not a source (Tenet 20). Takes no embedding/LanceDB path, so it
+runs green when `@google/genai` is absent.
+
+Consumer-safety: owner is derived from `gh repo view`; the GH Project number is
+read from the new optional `orient.projectNumber` field in `totem.config.ts`
+(env `TOTEM_ORIENT_PROJECT` overrides last). With no project configured the
+board section is an honest absence — the cohort's board is never baked in.
+
+Core (`@mmnto/totem`): adds the optional `orient.projectNumber` config field
+(`OrientConfigSchema`).

--- a/.totem/specs/2044.md
+++ b/.totem/specs/2044.md
@@ -17,7 +17,7 @@ they compose, not duplicate (`triage.ts` has no board/merged-PR cross-check).
 
 - **Tenet 20 (Derive-or-Couple, Never-Mirror)** — orient is a class-(b) read-time derivation from
   append-only primitives. Direct realization of **Proposal 264 (Derived Standing State)**.
-- **Tenet 4 (Fail Loud, Never Drift)** — an underivable section prints `⚠ could not derive`, never
+- **Tenet 4 (Fail Loud, Never Drift)** — an underivable section prints `WARN could not derive`, never
   a silent empty. **Tenet 14 (honest absence)** — "not yet synced / no board configured" is an
   explicit state, not an error and not a blank.
 - **Sidesteps #2018 by design** — orient must take NO embedding/LanceDB path; it is the
@@ -87,14 +87,14 @@ states the snapshot-not-source contract explicitly.
 | Failure                                                              | Category  | Agent-facing surface                                                            | Recovery                         |
 | -------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------- | -------------------------------- |
 | `gh` CLI not installed                                               | init      | hard error via `requireGhCli()` upfront (same gate as triage)                   | install gh                       |
-| `gh issue list` fails/timeout                                        | transient | section `⚠ could not derive: <err>` / `{error}`; other sections still render    | re-run (per-section isolation)   |
-| `gh pr list` fails                                                   | transient | per-section `⚠` / `{error}`                                                     | re-run                           |
-| `gh project item-list` fails (no board / no access / project absent) | permanent | per-section `⚠` / `{error}`; rest of orient still derives                       | configure board / project number |
-| `freeze.json` present but unparseable                                | permanent | per-section `⚠` / `{error}`                                                     | fix freeze.json                  |
+| `gh issue list` fails/timeout                                        | transient | section `WARN could not derive: <err>` / `{error}`; other sections still render    | re-run (per-section isolation)   |
+| `gh pr list` fails                                                   | transient | per-section `WARN` / `{error}`                                                     | re-run                           |
+| `gh project item-list` fails (no board / no access / project absent) | permanent | per-section `WARN` / `{error}`; rest of orient still derives                       | configure board / project number |
+| `freeze.json` present but unparseable                                | permanent | per-section `WARN` / `{error}`                                                     | fix freeze.json                  |
 | index freshness underivable (never synced)                           | runtime   | explicit "freshness unknown — not yet synced" line (honest absence, NOT silent) | `totem sync`                     |
 | gh succeeds but returns unexpected JSON shape                        | runtime   | Zod parse → `{error}` — treated as ERROR, never empty `[]`                      | —                                |
 
-No row is "silent degradation" — every underivable section is an explicit `⚠` / `{error}` /
+No row is "silent degradation" — every underivable section is an explicit `WARN` / `{error}` /
 honest-absence line (Tenet 4 + 14).
 
 ### Invariants to lock in via tests

--- a/.totem/specs/2044.md
+++ b/.totem/specs/2044.md
@@ -50,8 +50,13 @@ board[], coherence[], epics[], otherOpenIssues[] }`. Each section is **either** 
   _Invariant:_ every section present (value or `{error}`) — none silently omitted.
 - `BoardIssueCoherenceFlag` — `{ boardItemTitle, boardStatus, issueNumber, kind:
 'issue-closed-or-absent' }`. The one new signal, from a **pure** predicate
-  `flagBoardIssueDrift(boardItems, openIssueNumbers) → flag[]`. _Invariant:_ derivable purely from
-  the two primitives orient already fetches — **no extra gh call**; terminal-status cards never flagged.
+  `flagBoardIssueDrift(boardItems, openIssueNumbers, localSlug) → flag[]`. _Invariant:_ derivable
+  purely from the primitives orient already fetches — **no extra gh call**. **Scoped to this repo's
+  Issue cards** (`contentRepo === localSlug && contentType === 'Issue'`): GH Projects are commonly
+  org-level boards spanning repos, so a cross-repo card or a PR card must NOT be flagged against this
+  repo's open-ISSUE set (conservative — derive no coherence rather than wrong coherence). Terminal-status
+  cards never flagged; `localSlug === null` ⇒ no coherence derived. **Requires the board reader to
+  capture `content.repository` + `content.type`.**
 
 **Adapter extensions (additive — blast-radius guarded):**
 
@@ -96,8 +101,9 @@ honest-absence line (Tenet 4 + 14).
 
 - A `gh` failure in one section never blanks another — each derives independently.
 - A successful gh call with an unexpected shape surfaces as `{error}`, never empty `[]` (underivable ≠ none).
-- `flagBoardIssueDrift` flags exactly the active-status cards whose issue number is absent from the
-  open set; terminal-status cards never flagged; **zero** additional gh calls.
+- `flagBoardIssueDrift` flags exactly the active-status, **same-repo, Issue-type** cards whose issue
+  number is absent from the open set; terminal-status, cross-repo, and PR cards never flagged;
+  `localSlug === null` ⇒ no flags; **zero** additional gh calls.
 - A cross-repo `**Parent:** owner/repo#N` never attaches a child to a same-numbered LOCAL epic
   (port the seed's `localSlug` guard + test it).
 - `--json` and human render honor the SAME in-flight board filter and the SAME coherence set

--- a/.totem/specs/2044.md
+++ b/.totem/specs/2044.md
@@ -87,10 +87,10 @@ states the snapshot-not-source contract explicitly.
 | Failure                                                              | Category  | Agent-facing surface                                                            | Recovery                         |
 | -------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------- | -------------------------------- |
 | `gh` CLI not installed                                               | init      | hard error via `requireGhCli()` upfront (same gate as triage)                   | install gh                       |
-| `gh issue list` fails/timeout                                        | transient | section `WARN could not derive: <err>` / `{error}`; other sections still render    | re-run (per-section isolation)   |
-| `gh pr list` fails                                                   | transient | per-section `WARN` / `{error}`                                                     | re-run                           |
-| `gh project item-list` fails (no board / no access / project absent) | permanent | per-section `WARN` / `{error}`; rest of orient still derives                       | configure board / project number |
-| `freeze.json` present but unparseable                                | permanent | per-section `WARN` / `{error}`                                                     | fix freeze.json                  |
+| `gh issue list` fails/timeout                                        | transient | section `WARN could not derive: <err>` / `{error}`; other sections still render | re-run (per-section isolation)   |
+| `gh pr list` fails                                                   | transient | per-section `WARN` / `{error}`                                                  | re-run                           |
+| `gh project item-list` fails (no board / no access / project absent) | permanent | per-section `WARN` / `{error}`; rest of orient still derives                    | configure board / project number |
+| `freeze.json` present but unparseable                                | permanent | per-section `WARN` / `{error}`                                                  | fix freeze.json                  |
 | index freshness underivable (never synced)                           | runtime   | explicit "freshness unknown — not yet synced" line (honest absence, NOT silent) | `totem sync`                     |
 | gh succeeds but returns unexpected JSON shape                        | runtime   | Zod parse → `{error}` — treated as ERROR, never empty `[]`                      | —                                |
 

--- a/.totem/specs/2044.md
+++ b/.totem/specs/2044.md
@@ -1,0 +1,129 @@
+# Spec — #2044 `feat(cli): totem orient` (WS2 implementation)
+
+> `totem spec` could not auto-scaffold this file: the local CLI hit **#2018** (`@google/genai`
+> not installed → index query blocked). This spec is hand-assembled at preflight from the issue
+> body, charter `mmnto-ai/totem-strategy#438` (Proposal 288 §6.1), the WS2 seed
+> `mmnto-ai/totem-strategy:tools/orient.cjs`, and the totem-core surfaces mapped this session.
+
+## Issue summary
+
+Fold the strategy-side seed `tools/orient.cjs` (`pnpm orient`) into a standalone **`totem orient`**
+command in totem core. A **deterministic sensor** (zero LLM, zero embedding) that derives session
+orientation from primitives — open PRs / open issues / GH Project board / `.totem/freeze.json` —
+each line citing the primitive it came from. Sibling to `totem triage` (LLM synthesis on top);
+they compose, not duplicate (`triage.ts` has no board/merged-PR cross-check).
+
+## Governing doctrine
+
+- **Tenet 20 (Derive-or-Couple, Never-Mirror)** — orient is a class-(b) read-time derivation from
+  append-only primitives. Direct realization of **Proposal 264 (Derived Standing State)**.
+- **Tenet 4 (Fail Loud, Never Drift)** — an underivable section prints `⚠ could not derive`, never
+  a silent empty. **Tenet 14 (honest absence)** — "not yet synced / no board configured" is an
+  explicit state, not an error and not a blank.
+- **Sidesteps #2018 by design** — orient must take NO embedding/LanceDB path; it is the
+  deterministic half of `triage`, which is exactly what makes it run green when `@google/genai`
+  is absent.
+
+---
+
+## Implementation Design
+
+### Scope
+
+`totem orient [--json]` in `@mmnto/cli` derives open PRs, open issues (with epic→child grouping),
+GH Project board (in-flight statuses only), `.totem/freeze.json` parked entries, and a one-line
+index-freshness pointer — all from live `gh`/`git`/fs primitives, zero LLM, zero embedding, each
+line citing its primitive — plus one **new** derived signal: a board↔issue **coherence** flag
+(an active board card whose issue is absent from the open-issue set = drift). It will **NOT**
+auto-inject at session-start (that hook + cohort-distribution wiring is PR-2), will **NOT** hoist a
+shared state-derivation module unifying orient with MCP `describe_project` (deferred), and will
+**NOT** extract the coherence predicate into a shared strategy package (strategy builds its own
+portable copy per the boundary call I dispatched).
+
+### Data model deltas
+
+**New (cli):**
+
+- `OrientReport` — the `--json` shape: `{ repo, derivedAt, indexFreshness, parked[], openPRs[],
+board[], coherence[], epics[], otherOpenIssues[] }`. Each section is **either** its derived array
+  **or** a `{ error: string }` envelope. Written by `orientCommand`; read by agents/pipes.
+  _Invariant:_ every section present (value or `{error}`) — none silently omitted.
+- `BoardIssueCoherenceFlag` — `{ boardItemTitle, boardStatus, issueNumber, kind:
+'issue-closed-or-absent' }`. The one new signal, from a **pure** predicate
+  `flagBoardIssueDrift(boardItems, openIssueNumbers) → flag[]`. _Invariant:_ derivable purely from
+  the two primitives orient already fetches — **no extra gh call**; terminal-status cards never flagged.
+
+**Adapter extensions (additive — blast-radius guarded):**
+
+- `GitHubCliPrAdapter.fetchOpenPRs()` += `isDraft` (schema + return) for the `[draft]` badge.
+  Additive optional field; existing callers unaffected.
+- Open issues **with body**: the epic→child map needs each issue's `body` to match `**Parent:** #N`.
+  `fetchOpenIssues()` deliberately omits body → add a dedicated `fetchOpenIssuesWithBody(limit)`
+  (or `{ includeBody }` opt) rather than widening the shared schema that `triage` depends on.
+- **Board reader (genuinely new):** no adapter covers `gh project item-list`. Add a minimal,
+  Zod-validated reader for `{ items: [{ status, title, content:{ number } }] }`. New failure surface.
+
+**Reuse (no new code):**
+
+- freeze → `packages/core/src/freeze.ts` (WS3 #2046). Do **not** re-implement the seed's `readFreeze`.
+- index freshness → registry `lastSync` (already read by `totem list` via core `readRegistry`) +
+  a staleness formatter (placement → Q1).
+
+### State lifecycle
+
+orient is **stateless / per-invocation**: no persistent state, no module-level mutable container, no
+cache. Every run re-derives from live primitives — the output _is_ a cache, never a source (Tenet 20).
+Scope = per-command-invocation; lifetime = the process; mutation owner = `orientCommand`. No state
+crosses a lifecycle boundary (this is the structural reason orient can't drift). The render footer
+states the snapshot-not-source contract explicitly.
+
+### Failure modes
+
+| Failure                                                              | Category  | Agent-facing surface                                                            | Recovery                         |
+| -------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------- | -------------------------------- |
+| `gh` CLI not installed                                               | init      | hard error via `requireGhCli()` upfront (same gate as triage)                   | install gh                       |
+| `gh issue list` fails/timeout                                        | transient | section `⚠ could not derive: <err>` / `{error}`; other sections still render    | re-run (per-section isolation)   |
+| `gh pr list` fails                                                   | transient | per-section `⚠` / `{error}`                                                     | re-run                           |
+| `gh project item-list` fails (no board / no access / project absent) | permanent | per-section `⚠` / `{error}`; rest of orient still derives                       | configure board / project number |
+| `freeze.json` present but unparseable                                | permanent | per-section `⚠` / `{error}`                                                     | fix freeze.json                  |
+| index freshness underivable (never synced)                           | runtime   | explicit "freshness unknown — not yet synced" line (honest absence, NOT silent) | `totem sync`                     |
+| gh succeeds but returns unexpected JSON shape                        | runtime   | Zod parse → `{error}` — treated as ERROR, never empty `[]`                      | —                                |
+
+No row is "silent degradation" — every underivable section is an explicit `⚠` / `{error}` /
+honest-absence line (Tenet 4 + 14).
+
+### Invariants to lock in via tests
+
+- A `gh` failure in one section never blanks another — each derives independently.
+- A successful gh call with an unexpected shape surfaces as `{error}`, never empty `[]` (underivable ≠ none).
+- `flagBoardIssueDrift` flags exactly the active-status cards whose issue number is absent from the
+  open set; terminal-status cards never flagged; **zero** additional gh calls.
+- A cross-repo `**Parent:** owner/repo#N` never attaches a child to a same-numbered LOCAL epic
+  (port the seed's `localSlug` guard + test it).
+- `--json` and human render honor the SAME in-flight board filter and the SAME coherence set
+  (one contract, two surfaces).
+- orient runs green with `@google/genai` ABSENT (structural guard against a #2018 regression — orient
+  must never reach the embedder).
+- The footer always states the snapshot-not-source + perceptual-carve-out line.
+
+### Open questions
+
+- **Q1 — freshness placement.** `formatStaleness` lives in `@mmnto/mcp`; orient is in `@mmnto/cli`.
+  (a) compute inline from registry `lastSync` (no new dep, tiny dup); (b) hoist to `@mmnto/core`,
+  consumed by both orient + mcp (DRY, small refactor); (c) cli→mcp import (wrong dep direction).
+  **Rec: (a) for PR-1**; hoist to core only when a 3rd consumer earns it.
+- **Q2 — orient ↔ describe_project convergence.** MCP `state-extractors.ts` already extracts
+  overlapping state. Hoist a shared core derivation module now, or ship orient standalone and
+  converge later? **Rec: standalone now** — they already share the underlying primitives (freeze
+  reader, gh adapters) in core; only thin assembly logic differs. Premature hoist couples two
+  surfaces before orient's shape is proven (subtraction-first).
+- **Q3 — auto-injection scope.** #438 acceptance includes "auto-injected at session-start across
+  cohort repos." **Rec: PR-1 = command only; PR-2 = `session-context.mjs` wiring + cohort
+  distribution** (rides the `totem gate install`-style channel; its own review surface).
+- **Q4 — help group.** orient in `Setup` (next to `status`) vs `Workflow` (next to `triage`).
+  **Rec: `Setup`** — orient is deterministic state/health; triage is LLM workflow. Minor.
+- **Q5 — owner/project defaults (consumer-safety, load-bearing).** The seed hardcodes
+  `OWNER=mmnto-ai`, `PROJECT=1`. A shipped, multi-consumer command ("Totem is NOT zero-user") must
+  **not** bake the cohort's board. **Rec: derive owner from `gh repo view`; read project number from
+  an optional `totem.config.ts` field (e.g. `orient.projectNumber`); env override last; if no
+  project is configured, the board section is an honest "no board configured" absence, not an error.**

--- a/packages/cli/src/adapters/github-cli-pr.test.ts
+++ b/packages/cli/src/adapters/github-cli-pr.test.ts
@@ -23,14 +23,14 @@ describe('GitHubCliPrAdapter', () => {
     it('returns mapped PR list items', () => {
       mockedExec.mockReturnValue(
         JSON.stringify([
-          { number: 1, title: 'feat: add stuff', headRefName: 'feat/add-stuff' },
-          { number: 2, title: 'fix: bug', headRefName: 'fix/bug' },
+          { number: 1, title: 'feat: add stuff', headRefName: 'feat/add-stuff', isDraft: false },
+          { number: 2, title: 'fix: bug', headRefName: 'fix/bug', isDraft: true },
         ]),
       );
       const result = adapter.fetchOpenPRs();
       expect(result).toEqual([
-        { number: 1, title: 'feat: add stuff', headRefName: 'feat/add-stuff' },
-        { number: 2, title: 'fix: bug', headRefName: 'fix/bug' },
+        { number: 1, title: 'feat: add stuff', headRefName: 'feat/add-stuff', isDraft: false },
+        { number: 2, title: 'fix: bug', headRefName: 'fix/bug', isDraft: true },
       ]);
     });
 

--- a/packages/cli/src/adapters/github-cli-pr.ts
+++ b/packages/cli/src/adapters/github-cli-pr.ts
@@ -21,6 +21,7 @@ const GhPrListItemSchema = z.object({
   number: z.number(),
   title: z.string(),
   headRefName: z.string(),
+  isDraft: z.boolean(),
 });
 
 const GhPrSchema = z.object({
@@ -113,7 +114,7 @@ export class GitHubCliPrAdapter implements PrAdapter {
 
   fetchOpenPRs(): StandardPrListItem[] {
     const prs = ghFetchAndParse(
-      ['pr', 'list', '--state', 'open', '--json', 'number,title,headRefName'],
+      ['pr', 'list', '--state', 'open', '--json', 'number,title,headRefName,isDraft'],
       z.array(GhPrListItemSchema),
       'open PRs',
       this.cwd,
@@ -122,6 +123,7 @@ export class GitHubCliPrAdapter implements PrAdapter {
       number: pr.number,
       title: pr.title,
       headRefName: pr.headRefName,
+      isDraft: pr.isDraft,
     }));
   }
 

--- a/packages/cli/src/adapters/github-cli-project.ts
+++ b/packages/cli/src/adapters/github-cli-project.ts
@@ -17,8 +17,12 @@ import { ghFetchAndParse } from './gh-utils.js';
 
 // `gh project item-list --format json` returns extra columns (assignees,
 // custom fields, …); `.passthrough()` tolerates them and we only validate the
-// three fields orient consumes. `content` is absent for draft cards (no linked
-// issue/PR), so it is optional and its `number` is optional within it.
+// fields orient consumes. `content` is absent for draft cards (no linked
+// issue/PR), so it is optional and its fields are optional within it.
+// `repository` ('owner/repo') + `type` ('Issue' | 'PullRequest' | 'DraftIssue')
+// are load-bearing for the coherence check: GH Projects are commonly org-level
+// boards spanning multiple repos, so the drift predicate MUST scope to this
+// repo's Issue cards or it false-flags every healthy cross-repo / PR card.
 const GhProjectItemSchema = z
   .object({
     status: z.string().optional(),
@@ -26,6 +30,8 @@ const GhProjectItemSchema = z
     content: z
       .object({
         number: z.number().optional(),
+        repository: z.string().optional(),
+        type: z.string().optional(),
       })
       .passthrough()
       .optional(),
@@ -45,6 +51,10 @@ export interface BoardItem {
   title: string;
   /** The linked issue/PR number, when the card is backed by one (draft cards have none). */
   contentNumber?: number;
+  /** The linked issue/PR's repo as 'owner/repo' (org boards span repos); absent for draft cards. */
+  contentRepo?: string;
+  /** The card content kind: 'Issue' | 'PullRequest' | 'DraftIssue'. */
+  contentType?: string;
 }
 
 const BOARD_ITEM_LIMIT = 200;
@@ -77,5 +87,7 @@ export function fetchBoardItems(owner: string, projectNumber: number, cwd: strin
     status: i.status,
     title: i.title,
     contentNumber: i.content?.number,
+    contentRepo: i.content?.repository,
+    contentType: i.content?.type,
   }));
 }

--- a/packages/cli/src/adapters/github-cli-project.ts
+++ b/packages/cli/src/adapters/github-cli-project.ts
@@ -1,0 +1,81 @@
+// totem-context: fetchBoardItems is synchronous — ghFetchAndParse uses safeExec (sync). Do not flag missing await.
+
+import { z } from 'zod';
+
+import { ghFetchAndParse } from './gh-utils.js';
+
+// ─── Board (GH Project) reader ──────────────────────────
+//
+// No existing adapter covers `gh project item-list`; `totem orient` is the
+// first consumer (mmnto-ai/totem#2044). A GH Project lives under an `owner`
+// and a numeric project id, neither derivable from the current repo alone —
+// owner is derived from `gh repo view`, the project number from
+// `orient.projectNumber` config / `TOTEM_ORIENT_PROJECT` env. This reader is
+// Zod-validated so an unexpected shape surfaces as a TotemParseError (the
+// caller maps that to a per-section `{ error }`, never a silent empty —
+// Tenet 4).
+
+// `gh project item-list --format json` returns extra columns (assignees,
+// custom fields, …); `.passthrough()` tolerates them and we only validate the
+// three fields orient consumes. `content` is absent for draft cards (no linked
+// issue/PR), so it is optional and its `number` is optional within it.
+const GhProjectItemSchema = z
+  .object({
+    status: z.string().optional(),
+    title: z.string(),
+    content: z
+      .object({
+        number: z.number().optional(),
+      })
+      .passthrough()
+      .optional(),
+  })
+  .passthrough();
+
+const GhProjectItemListSchema = z
+  .object({
+    items: z.array(GhProjectItemSchema),
+  })
+  .passthrough();
+
+/** A single GH Project board card, reduced to the fields `totem orient` derives from. */
+export interface BoardItem {
+  /** Board status column (e.g. 'In Progress'). Absent items default to 'Todo' at the call site. */
+  status?: string;
+  title: string;
+  /** The linked issue/PR number, when the card is backed by one (draft cards have none). */
+  contentNumber?: number;
+}
+
+const BOARD_ITEM_LIMIT = 200;
+
+/**
+ * Read the in-flight items of a GH Project board for `owner` / `projectNumber`.
+ *
+ * Throws (via `ghFetchAndParse` → `handleGhError`) when the board is
+ * inaccessible / the project is absent / the JSON shape is unexpected; the
+ * `orient` command catches that and renders a per-section `{ error }` envelope.
+ */
+export function fetchBoardItems(owner: string, projectNumber: number, cwd: string): BoardItem[] {
+  const parsed = ghFetchAndParse(
+    [
+      'project',
+      'item-list',
+      String(projectNumber),
+      '--owner',
+      owner,
+      '--format',
+      'json',
+      '--limit',
+      String(BOARD_ITEM_LIMIT),
+    ],
+    GhProjectItemListSchema,
+    `GH Project board ${owner}/${projectNumber}`,
+    cwd,
+  );
+  return parsed.items.map((i) => ({
+    status: i.status,
+    title: i.title,
+    contentNumber: i.content?.number,
+  }));
+}

--- a/packages/cli/src/adapters/github-cli.test.ts
+++ b/packages/cli/src/adapters/github-cli.test.ts
@@ -109,4 +109,37 @@ describe('GitHubCliAdapter', () => {
       expect(() => adapter.fetchOpenIssues()).toThrow('GitHub CLI (gh) is required');
     });
   });
+
+  describe('fetchOpenIssuesWithBody', () => {
+    it('returns mapped issue items including body', () => {
+      mockedExec.mockReturnValue(
+        JSON.stringify([
+          {
+            number: 10,
+            title: 'Epic',
+            body: 'parent stuff',
+            labels: [{ name: 'type: epic' }],
+          },
+          { number: 11, title: 'Child', body: '**Parent:** #10', labels: [] },
+        ]),
+      );
+      const result = adapter.fetchOpenIssuesWithBody();
+      expect(result).toEqual([
+        { number: 10, title: 'Epic', body: 'parent stuff', labels: ['type: epic'] },
+        { number: 11, title: 'Child', body: '**Parent:** #10', labels: [] },
+      ]);
+    });
+
+    it('normalizes null body to empty string', () => {
+      mockedExec.mockReturnValue(
+        JSON.stringify([{ number: 1, title: 'No body', body: null, labels: [] }]),
+      );
+      expect(adapter.fetchOpenIssuesWithBody()[0]!.body).toBe('');
+    });
+
+    it('returns empty array when no open issues', () => {
+      mockedExec.mockReturnValue('[]');
+      expect(adapter.fetchOpenIssuesWithBody()).toEqual([]);
+    });
+  });
 });

--- a/packages/cli/src/adapters/github-cli.ts
+++ b/packages/cli/src/adapters/github-cli.ts
@@ -4,7 +4,12 @@ import { z } from 'zod';
 
 import { getTagDate } from '../git.js';
 import { ghFetchAndParse } from './gh-utils.js';
-import type { IssueAdapter, StandardIssue, StandardIssueListItem } from './issue-adapter.js';
+import type {
+  IssueAdapter,
+  StandardIssue,
+  StandardIssueListItem,
+  StandardIssueWithBody,
+} from './issue-adapter.js';
 
 export interface ClosedIssueListItem {
   number: number;
@@ -27,6 +32,13 @@ const GhIssueListItemSchema = z.object({
   title: z.string(),
   labels: z.array(z.object({ name: z.string() })),
   updatedAt: z.string().datetime(),
+});
+
+const GhIssueWithBodyListItemSchema = z.object({
+  number: z.number(),
+  title: z.string(),
+  body: z.string().nullable(),
+  labels: z.array(z.object({ name: z.string() })),
 });
 
 const GhClosedIssueListItemSchema = z.object({
@@ -137,6 +149,36 @@ export class GitHubCliAdapter implements IssueAdapter {
       labels: i.labels.map((l) => l.name),
       updatedAt: i.updatedAt,
       repo: this.repo,
+    }));
+  }
+
+  /**
+   * Fetch open issues including each issue's `body` (for `totem orient`'s
+   * epic→child grouping). Dedicated method rather than widening
+   * `fetchOpenIssues`, whose schema `triage` depends on.
+   */
+  fetchOpenIssuesWithBody(limit: number = DEFAULT_ISSUE_LIMIT): StandardIssueWithBody[] {
+    const issues = ghFetchAndParse(
+      [
+        ...this.repoFlag,
+        'issue',
+        'list',
+        '--state',
+        'open',
+        '--json',
+        'number,title,body,labels',
+        '--limit',
+        String(limit),
+      ],
+      z.array(GhIssueWithBodyListItemSchema),
+      'open issues with body',
+      this.cwd,
+    );
+    return issues.map((i) => ({
+      number: i.number,
+      title: i.title,
+      body: i.body ?? '',
+      labels: i.labels.map((l) => l.name),
     }));
   }
 }

--- a/packages/cli/src/adapters/issue-adapter.ts
+++ b/packages/cli/src/adapters/issue-adapter.ts
@@ -22,7 +22,26 @@ export interface StandardIssueListItem {
   repo?: string;
 }
 
+/**
+ * Open issue carrying its `body`, for consumers that derive structure from the
+ * issue text (e.g. `totem orient`'s epic→child grouping matches `**Parent:** #N`
+ * in the body). Distinct from `StandardIssueListItem` because `fetchOpenIssues`
+ * deliberately omits `body` (and `updatedAt` is not needed here) — widening the
+ * shared list shape would burden every existing caller (e.g. `triage`).
+ */
+export interface StandardIssueWithBody {
+  number: number;
+  title: string;
+  body: string;
+  labels: string[];
+}
+
 export interface IssueAdapter {
   fetchIssue(issueNumber: number): StandardIssue;
   fetchOpenIssues(limit?: number): StandardIssueListItem[];
+  /**
+   * Fetch open issues including each issue's `body`. Optional so adapters that
+   * don't support body-bearing list queries need not implement it.
+   */
+  fetchOpenIssuesWithBody?(limit?: number): StandardIssueWithBody[];
 }

--- a/packages/cli/src/adapters/pr-adapter.ts
+++ b/packages/cli/src/adapters/pr-adapter.ts
@@ -7,6 +7,8 @@ export interface StandardPrListItem {
   number: number;
   title: string;
   headRefName: string;
+  /** Whether the PR is a draft. Drives the `[draft]` badge in `totem orient`. */
+  isDraft: boolean;
 }
 
 export interface StandardPrComment {

--- a/packages/cli/src/commands/orient-coherence.test.ts
+++ b/packages/cli/src/commands/orient-coherence.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { BoardItem } from '../adapters/github-cli-project.js';
+import { flagBoardIssueDrift, isActiveBoardItem } from './orient-coherence.js';
+
+describe('isActiveBoardItem', () => {
+  it.each([
+    ['Todo', false],
+    ['todo', false],
+    ['Done', false],
+    ['Closed', false],
+    ['Informs', false],
+    ['Backlog', false],
+    ['In Progress', true],
+    ['In Review', true],
+    ['Up Next', true],
+  ])('status %s → active=%s', (status, active) => {
+    expect(isActiveBoardItem({ status, title: 't' })).toBe(active);
+  });
+
+  it('treats an absent status as Todo (inactive)', () => {
+    expect(isActiveBoardItem({ title: 't' })).toBe(false);
+  });
+});
+
+describe('flagBoardIssueDrift', () => {
+  it('flags active cards whose linked issue is absent from the open set', () => {
+    const board: BoardItem[] = [
+      { status: 'In Progress', title: 'Card A', contentNumber: 100 },
+      { status: 'In Review', title: 'Card B', contentNumber: 200 },
+    ];
+    const open = new Set([200]); // #100 is closed/absent
+    expect(flagBoardIssueDrift(board, open)).toEqual([
+      {
+        boardItemTitle: 'Card A',
+        boardStatus: 'In Progress',
+        issueNumber: 100,
+        kind: 'issue-closed-or-absent',
+      },
+    ]);
+  });
+
+  it('never flags terminal-status cards even when their issue is absent', () => {
+    const board: BoardItem[] = [
+      { status: 'Done', title: 'Done card', contentNumber: 1 },
+      { status: 'Todo', title: 'Todo card', contentNumber: 2 },
+      { status: 'Backlog', title: 'Backlog card', contentNumber: 3 },
+    ];
+    expect(flagBoardIssueDrift(board, new Set())).toEqual([]);
+  });
+
+  it('does not flag cards whose issue is still open', () => {
+    const board: BoardItem[] = [{ status: 'In Progress', title: 'A', contentNumber: 5 }];
+    expect(flagBoardIssueDrift(board, new Set([5]))).toEqual([]);
+  });
+
+  it('ignores active cards with no linked issue number (draft cards)', () => {
+    const board: BoardItem[] = [{ status: 'In Progress', title: 'Draft card' }];
+    expect(flagBoardIssueDrift(board, new Set())).toEqual([]);
+  });
+
+  it('issues ZERO gh/exec calls — it is a pure function of its arguments', async () => {
+    // Spy on safeExec at the core boundary; the predicate must never touch it.
+    const core = await import('@mmnto/totem');
+    const spy = vi.spyOn(core, 'safeExec');
+    const board: BoardItem[] = [{ status: 'In Progress', title: 'A', contentNumber: 9 }];
+    flagBoardIssueDrift(board, new Set());
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+});

--- a/packages/cli/src/commands/orient-coherence.test.ts
+++ b/packages/cli/src/commands/orient-coherence.test.ts
@@ -24,13 +24,23 @@ describe('isActiveBoardItem', () => {
 });
 
 describe('flagBoardIssueDrift', () => {
-  it('flags active cards whose linked issue is absent from the open set', () => {
+  const LOCAL = 'mmnto-ai/totem';
+  /** Build a same-repo Issue card (the only kind that can drift) unless overridden. */
+  const issueCard = (over: Partial<BoardItem>): BoardItem => ({
+    status: 'In Progress',
+    title: 'Card',
+    contentRepo: LOCAL,
+    contentType: 'Issue',
+    ...over,
+  });
+
+  it('flags active same-repo Issue cards whose linked issue is absent from the open set', () => {
     const board: BoardItem[] = [
-      { status: 'In Progress', title: 'Card A', contentNumber: 100 },
-      { status: 'In Review', title: 'Card B', contentNumber: 200 },
+      issueCard({ title: 'Card A', contentNumber: 100 }),
+      issueCard({ title: 'Card B', contentNumber: 200, status: 'In Review' }),
     ];
     const open = new Set([200]); // #100 is closed/absent
-    expect(flagBoardIssueDrift(board, open)).toEqual([
+    expect(flagBoardIssueDrift(board, open, LOCAL)).toEqual([
       {
         boardItemTitle: 'Card A',
         boardStatus: 'In Progress',
@@ -42,29 +52,59 @@ describe('flagBoardIssueDrift', () => {
 
   it('never flags terminal-status cards even when their issue is absent', () => {
     const board: BoardItem[] = [
-      { status: 'Done', title: 'Done card', contentNumber: 1 },
-      { status: 'Todo', title: 'Todo card', contentNumber: 2 },
-      { status: 'Backlog', title: 'Backlog card', contentNumber: 3 },
+      issueCard({ status: 'Done', title: 'Done card', contentNumber: 1 }),
+      issueCard({ status: 'Todo', title: 'Todo card', contentNumber: 2 }),
+      issueCard({ status: 'Backlog', title: 'Backlog card', contentNumber: 3 }),
     ];
-    expect(flagBoardIssueDrift(board, new Set())).toEqual([]);
+    expect(flagBoardIssueDrift(board, new Set(), LOCAL)).toEqual([]);
   });
 
   it('does not flag cards whose issue is still open', () => {
-    const board: BoardItem[] = [{ status: 'In Progress', title: 'A', contentNumber: 5 }];
-    expect(flagBoardIssueDrift(board, new Set([5]))).toEqual([]);
+    const board: BoardItem[] = [issueCard({ title: 'A', contentNumber: 5 })];
+    expect(flagBoardIssueDrift(board, new Set([5]), LOCAL)).toEqual([]);
   });
 
   it('ignores active cards with no linked issue number (draft cards)', () => {
-    const board: BoardItem[] = [{ status: 'In Progress', title: 'Draft card' }];
-    expect(flagBoardIssueDrift(board, new Set())).toEqual([]);
+    const board: BoardItem[] = [
+      { status: 'In Progress', title: 'Draft card', contentType: 'DraftIssue' },
+    ];
+    expect(flagBoardIssueDrift(board, new Set(), LOCAL)).toEqual([]);
+  });
+
+  // Regression: org-level boards span repos. A card for ANOTHER repo's issue must
+  // NOT be flagged against this repo's open-issue set (the #2044 controller-review bug).
+  it('never flags cross-repo cards (org board spanning repos)', () => {
+    const board: BoardItem[] = [
+      issueCard({
+        title: 'Strategy card',
+        contentNumber: 433,
+        contentRepo: 'mmnto-ai/totem-strategy',
+      }),
+    ];
+    // #433 is absent from THIS repo's open set, but it's a strategy issue → not drift here.
+    expect(flagBoardIssueDrift(board, new Set(), LOCAL)).toEqual([]);
+  });
+
+  // A PR card's number lives in a different namespace than the open-ISSUE set;
+  // comparing it would always false-flag. PR cards are never issue-drift.
+  it('never flags PullRequest cards', () => {
+    const board: BoardItem[] = [
+      issueCard({ title: 'PR card', contentNumber: 2049, contentType: 'PullRequest' }),
+    ];
+    expect(flagBoardIssueDrift(board, new Set(), LOCAL)).toEqual([]);
+  });
+
+  it('derives NO coherence when the repo is undetermined (localSlug null)', () => {
+    const board: BoardItem[] = [issueCard({ title: 'A', contentNumber: 7 })];
+    expect(flagBoardIssueDrift(board, new Set(), null)).toEqual([]);
   });
 
   it('issues ZERO gh/exec calls — it is a pure function of its arguments', async () => {
     // Spy on safeExec at the core boundary; the predicate must never touch it.
     const core = await import('@mmnto/totem');
     const spy = vi.spyOn(core, 'safeExec');
-    const board: BoardItem[] = [{ status: 'In Progress', title: 'A', contentNumber: 9 }];
-    flagBoardIssueDrift(board, new Set());
+    const board: BoardItem[] = [issueCard({ title: 'A', contentNumber: 9 })];
+    flagBoardIssueDrift(board, new Set(), LOCAL);
     expect(spy).not.toHaveBeenCalled();
     spy.mockRestore();
   });

--- a/packages/cli/src/commands/orient-coherence.ts
+++ b/packages/cli/src/commands/orient-coherence.ts
@@ -31,22 +31,37 @@ export function isActiveBoardItem(item: BoardItem): boolean {
 }
 
 /**
- * Flag active board cards whose linked issue is absent from the open-issue set.
+ * Flag active board cards whose linked issue is absent from THIS repo's open-issue set.
  *
- * - Considers ONLY active-status cards (terminal-status cards are never flagged).
- * - Considers ONLY cards with a linked `contentNumber` (draft cards / PR-backed
- *   cards without an issue number cannot drift against the issue set).
- * - Pure: derives solely from its two arguments — issues NO `gh` calls.
+ * Scoped to the current repo (`localSlug`) because GH Projects are commonly
+ * ORG-level boards spanning multiple repos: a card for another repo's issue —
+ * or a PR card, whose number lives in a different namespace than the issue set —
+ * compared against this repo's open-ISSUE set would false-flag every healthy
+ * cross-repo/PR card as "drift". A coherence sensor that cries wolf on healthy
+ * cards is worse than none, so the gate is deliberately conservative (derive no
+ * coherence rather than wrong coherence):
+ * - ONLY active-status cards (terminal-status cards are never flagged).
+ * - ONLY cards whose `contentRepo` is THIS repo; cross-repo / repo-unknown cards skipped.
+ * - ONLY `Issue`-type cards; PR cards and draft cards (no number) skipped.
+ * - Pure: derives solely from its arguments — issues NO `gh` calls.
+ *
+ * @param localSlug current repo as `owner/repo`; null (repo undetermined) ⇒ NO
+ *   coherence is derived, because an unscoped check can only be wrong.
  */
 export function flagBoardIssueDrift(
   boardItems: BoardItem[],
   openIssueNumbers: ReadonlySet<number>,
+  localSlug: string | null,
 ): BoardIssueCoherenceFlag[] {
   const flags: BoardIssueCoherenceFlag[] = [];
+  if (!localSlug) return flags;
   for (const item of boardItems) {
     if (!isActiveBoardItem(item)) continue;
     const issueNumber = item.contentNumber;
     if (issueNumber === undefined) continue;
+    // Org-board guard: only THIS repo's Issue cards can drift against its issue set.
+    if (item.contentRepo !== localSlug) continue;
+    if (item.contentType !== 'Issue') continue;
     if (openIssueNumbers.has(issueNumber)) continue;
     flags.push({
       boardItemTitle: item.title,

--- a/packages/cli/src/commands/orient-coherence.ts
+++ b/packages/cli/src/commands/orient-coherence.ts
@@ -1,0 +1,59 @@
+// Pure board↔issue coherence predicate for `totem orient` (mmnto-ai/totem#2044).
+//
+// A board card in an ACTIVE status whose linked issue is NOT in the set of open
+// issues is "drift" — the issue was closed (or never opened) but the card was
+// left in flight. This is the one NEW derived signal orient adds on top of the
+// primitives. It is intentionally PURE and separately unit-testable: it derives
+// ONLY from the board items + the open-issue numbers orient already fetched, so
+// it issues ZERO extra `gh` calls.
+
+import type { BoardItem } from '../adapters/github-cli-project.js';
+
+/** A board card flagged as out of sync with the open-issue set. */
+export interface BoardIssueCoherenceFlag {
+  boardItemTitle: string;
+  /** The card's board status (always an active status — terminal cards are never flagged). */
+  boardStatus: string;
+  /** The linked issue number that is closed or absent from the open set. */
+  issueNumber: number;
+  kind: 'issue-closed-or-absent';
+}
+
+// Board "in-flight" = NOT a terminal/reference status. Shared by the command's
+// board filter AND this coherence predicate so the human + --json surfaces and
+// the drift check all honor ONE definition of "active". Ported from the seed
+// (tools/orient.cjs) TERMINAL_STATUS.
+export const TERMINAL_BOARD_STATUS = /^(todo|done|closed|informs|backlog)/i;
+
+/** A board item is active when its status is not a terminal/reference status. Absent status ⇒ 'Todo' ⇒ inactive. */
+export function isActiveBoardItem(item: BoardItem): boolean {
+  return !TERMINAL_BOARD_STATUS.test(item.status || 'Todo');
+}
+
+/**
+ * Flag active board cards whose linked issue is absent from the open-issue set.
+ *
+ * - Considers ONLY active-status cards (terminal-status cards are never flagged).
+ * - Considers ONLY cards with a linked `contentNumber` (draft cards / PR-backed
+ *   cards without an issue number cannot drift against the issue set).
+ * - Pure: derives solely from its two arguments — issues NO `gh` calls.
+ */
+export function flagBoardIssueDrift(
+  boardItems: BoardItem[],
+  openIssueNumbers: ReadonlySet<number>,
+): BoardIssueCoherenceFlag[] {
+  const flags: BoardIssueCoherenceFlag[] = [];
+  for (const item of boardItems) {
+    if (!isActiveBoardItem(item)) continue;
+    const issueNumber = item.contentNumber;
+    if (issueNumber === undefined) continue;
+    if (openIssueNumbers.has(issueNumber)) continue;
+    flags.push({
+      boardItemTitle: item.title,
+      boardStatus: item.status || 'Todo',
+      issueNumber,
+      kind: 'issue-closed-or-absent',
+    });
+  }
+  return flags;
+}

--- a/packages/cli/src/commands/orient-coherence.ts
+++ b/packages/cli/src/commands/orient-coherence.ts
@@ -60,7 +60,9 @@ export function flagBoardIssueDrift(
     const issueNumber = item.contentNumber;
     if (issueNumber === undefined) continue;
     // Org-board guard: only THIS repo's Issue cards can drift against its issue set.
-    if (item.contentRepo !== localSlug) continue;
+    // Case-folded compare — GitHub owner/repo slugs are case-insensitive, so a casing
+    // skew between `gh repo view` and `gh project item-list` must not drop a valid check.
+    if (!item.contentRepo || item.contentRepo.toLowerCase() !== localSlug.toLowerCase()) continue;
     if (item.contentType !== 'Issue') continue;
     if (openIssueNumbers.has(issueNumber)) continue;
     flags.push({

--- a/packages/cli/src/commands/orient.test.ts
+++ b/packages/cli/src/commands/orient.test.ts
@@ -1,0 +1,315 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { BoardItem } from '../adapters/github-cli-project.js';
+import type { StandardIssueWithBody } from '../adapters/issue-adapter.js';
+import type { StandardPrListItem } from '../adapters/pr-adapter.js';
+
+// ─── Adapter mocks (control every primitive orient fetches) ─────────────
+
+const mockFetchOpenPRs = vi.fn<() => StandardPrListItem[]>();
+vi.mock('../adapters/github-cli-pr.js', () => ({
+  GitHubCliPrAdapter: class {
+    fetchOpenPRs() {
+      return mockFetchOpenPRs();
+    }
+  },
+}));
+
+const mockFetchOpenIssuesWithBody = vi.fn<() => StandardIssueWithBody[]>();
+vi.mock('../adapters/github-cli.js', () => ({
+  GitHubCliAdapter: class {
+    fetchOpenIssuesWithBody() {
+      return mockFetchOpenIssuesWithBody();
+    }
+  },
+}));
+
+const mockFetchBoardItems = vi.fn<() => BoardItem[]>();
+vi.mock('../adapters/github-cli-project.js', async () => {
+  const actual = await vi.importActual<typeof import('../adapters/github-cli-project.js')>(
+    '../adapters/github-cli-project.js',
+  );
+  return { ...actual, fetchBoardItems: () => mockFetchBoardItems() };
+});
+
+// ─── @mmnto/totem mock (gh repo view slug + freeze + registry + git root) ─
+//
+// CRITICAL: orient must NEVER reach the embedder. We provide a `createEmbedder`
+// that throws if called — the structural guard that orient dodges #2018 (it
+// runs green with `@google/genai` absent because it never touches embeddings).
+
+const mockSafeExec = vi.fn<() => string>();
+const mockReadRegistry = vi.fn<() => Record<string, unknown>>(() => ({}));
+const embedderTripwire = vi.fn(() => {
+  throw new Error('orient must never reach the embedder (#2018 structural guard)');
+});
+// The repo root orient resolves to. Tests point it at a real temp dir so the
+// REAL readFreezeConfig (kept un-mocked) reads a real `.totem/freeze.json` —
+// exercising the actual fail-loud reader rather than a stub.
+let repoRoot = '/repo/root';
+
+// Spread the real core module, overriding only the primitives orient reads.
+// Full replacement is fragile (core has many transitive exports the adapters
+// need); status.test.ts uses this same importActual pattern. Note:
+// `readFreezeConfig` is intentionally NOT overridden — the freeze section is
+// tested against the real reader via a real temp `.totem/freeze.json`.
+vi.mock('@mmnto/totem', async () => {
+  const actual = await vi.importActual<typeof import('@mmnto/totem')>('@mmnto/totem');
+  return {
+    ...actual,
+    safeExec: () => mockSafeExec(),
+    readRegistry: () => mockReadRegistry(),
+    resolveGitRoot: () => repoRoot,
+    // #2018 structural tripwire: orient must never construct an embedder/store.
+    createEmbedder: embedderTripwire,
+    LanceStore: class {
+      constructor() {
+        embedderTripwire();
+      }
+    },
+  };
+});
+
+// ─── utils mock (config / project number resolution) ────────────────────
+
+const mockLoadConfig = vi.fn();
+vi.mock('../utils.js', () => ({
+  resolveConfigPath: () => '/repo/root/totem.config.ts',
+  loadConfig: () => mockLoadConfig(),
+}));
+
+import { orientCommand, type OrientReport, renderReport } from './orient.js';
+
+// ─── Test harness ───────────────────────────────────────
+
+let stdout: string;
+let writeSpy: ReturnType<typeof vi.spyOn>;
+
+function runJson(): Promise<void> {
+  return orientCommand({ json: true });
+}
+
+function parseJson(): OrientReport {
+  return JSON.parse(stdout) as OrientReport;
+}
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  stdout = '';
+  writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: string | Uint8Array) => {
+    stdout += chunk.toString();
+    return true;
+  });
+  // Real temp repo root so the real readFreezeConfig has a real (empty) .totem.
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-orient-'));
+  fs.mkdirSync(path.join(tmpRoot, '.totem'), { recursive: true });
+  repoRoot = tmpRoot;
+  // Default happy-path primitives.
+  mockSafeExec.mockReturnValue(JSON.stringify({ owner: { login: 'mmnto-ai' }, name: 'totem' }));
+  mockReadRegistry.mockReturnValue({});
+  mockFetchOpenPRs.mockReturnValue([]);
+  mockFetchOpenIssuesWithBody.mockReturnValue([]);
+  mockFetchBoardItems.mockReturnValue([]);
+  mockLoadConfig.mockResolvedValue({ orient: undefined });
+  delete process.env['TOTEM_ORIENT_PROJECT'];
+});
+
+afterEach(() => {
+  writeSpy.mockRestore();
+  vi.clearAllMocks();
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+  delete process.env['TOTEM_ORIENT_PROJECT'];
+});
+
+// ─── Per-section failure isolation ──────────────────────
+
+describe('orient per-section failure isolation', () => {
+  it('an issue-fetch failure does not blank the PR section', async () => {
+    mockFetchOpenPRs.mockReturnValue([
+      { number: 5, title: 'fix', headRefName: 'fix/x', isDraft: false },
+    ]);
+    mockFetchOpenIssuesWithBody.mockImplementation(() => {
+      throw new Error('gh issue list exploded');
+    });
+    await runJson();
+    const r = parseJson();
+    // PRs still derive…
+    expect(r.openPRs).toEqual([{ number: 5, title: 'fix', headRefName: 'fix/x', isDraft: false }]);
+    // …while the issue-derived sections surface as { error }.
+    expect(r.epics).toEqual({ error: 'gh issue list exploded' });
+    expect(r.otherOpenIssues).toEqual({ error: 'gh issue list exploded' });
+  });
+
+  it('a malformed freeze.json isolates to the parked section only ({error}, not blank)', async () => {
+    // Real malformed file → real readFreezeConfig throws TotemConfigError.
+    fs.writeFileSync(path.join(tmpRoot, '.totem', 'freeze.json'), '{ not valid json');
+    mockFetchOpenPRs.mockReturnValue([
+      { number: 9, title: 'fix', headRefName: 'fix/y', isDraft: false },
+    ]);
+    await runJson();
+    const r = parseJson();
+    expect(r.parked).toHaveProperty('error');
+    expect((r.parked as { error: string }).error).toMatch(/freeze\.json/i);
+    // The PR section still derives — failure is isolated.
+    expect(r.openPRs).toEqual([{ number: 9, title: 'fix', headRefName: 'fix/y', isDraft: false }]);
+  });
+
+  it('derives real parked entries from a valid freeze.json', async () => {
+    fs.writeFileSync(
+      path.join(tmpRoot, '.totem', 'freeze.json'),
+      JSON.stringify({
+        frozen: [{ subsystem: 'embedder', since: '2026-01-01', reason: 'blocked. extra' }],
+      }),
+    );
+    await runJson();
+    const r = parseJson();
+    expect(r.parked).toEqual([
+      { subsystem: 'embedder', since: '2026-01-01', reason: 'blocked. extra' },
+    ]);
+  });
+});
+
+// ─── Unexpected shape → {error}, never empty ────────────
+
+describe('orient unexpected-shape handling', () => {
+  it('an unexpected gh repo view shape surfaces as a repo { error }, not a blank', async () => {
+    mockSafeExec.mockReturnValue(JSON.stringify({ owner: {}, name: '' }));
+    await runJson();
+    const r = parseJson();
+    expect(r.repo).toEqual({ error: 'unexpected `gh repo view` shape' });
+  });
+});
+
+// ─── Cross-repo parent guard ────────────────────────────
+
+describe('orient cross-repo parent guard', () => {
+  it('a cross-repo Parent ref never attaches a child to a same-numbered LOCAL epic', async () => {
+    mockSafeExec.mockReturnValue(JSON.stringify({ owner: { login: 'mmnto-ai' }, name: 'totem' }));
+    mockFetchOpenIssuesWithBody.mockReturnValue([
+      { number: 50, title: 'Local epic', body: '', labels: ['type: epic'] },
+      // Child points at other-repo#50 — must NOT attach to local #50.
+      {
+        number: 51,
+        title: 'Foreign child',
+        body: '**Parent:** other-owner/other-repo#50',
+        labels: [],
+      },
+      // Child points at LOCAL #50 (bare ref) — must attach.
+      { number: 52, title: 'Local child', body: '**Parent:** #50', labels: [] },
+    ]);
+    await runJson();
+    const r = parseJson();
+    expect(r.epics).toEqual([
+      {
+        number: 50,
+        title: 'Local epic',
+        labels: ['type: epic'],
+        subIssues: [{ number: 52, title: 'Local child' }],
+      },
+    ]);
+    // The foreign-parent child stays in OTHER (never dropped, never mis-attached).
+    expect(r.otherOpenIssues).toEqual([{ number: 51, title: 'Foreign child', labels: [] }]);
+  });
+});
+
+// ─── Board path + coherence ─────────────────────────────
+
+describe('orient board + coherence', () => {
+  beforeEach(() => {
+    process.env['TOTEM_ORIENT_PROJECT'] = '1';
+  });
+
+  it('filters the board to active items and flags issue drift in --json', async () => {
+    mockFetchOpenIssuesWithBody.mockReturnValue([
+      { number: 200, title: 'Open issue', body: '', labels: [] },
+    ]);
+    mockFetchBoardItems.mockReturnValue([
+      { status: 'In Progress', title: 'Active drift', contentNumber: 100 }, // #100 not open → drift
+      { status: 'In Review', title: 'Active ok', contentNumber: 200 }, // open → ok
+      { status: 'Done', title: 'Terminal', contentNumber: 999 }, // terminal → filtered + never flagged
+    ]);
+    await runJson();
+    const r = parseJson();
+    expect(r.board).toEqual([
+      { status: 'In Progress', title: 'Active drift', contentNumber: 100 },
+      { status: 'In Review', title: 'Active ok', contentNumber: 200 },
+    ]);
+    expect(r.coherence).toEqual([
+      {
+        boardItemTitle: 'Active drift',
+        boardStatus: 'In Progress',
+        issueNumber: 100,
+        kind: 'issue-closed-or-absent',
+      },
+    ]);
+  });
+});
+
+// ─── Honest absence: no board configured ────────────────
+
+describe('orient honest-absence (no board configured)', () => {
+  it('renders an honest "no board configured" line, not an error', async () => {
+    // No env, no config field → board absent (configured=false).
+    mockLoadConfig.mockResolvedValue({ orient: undefined });
+    await orientCommand({ json: false });
+    expect(stdout).toContain('no board configured (set orient.projectNumber');
+    expect(stdout).not.toContain('could not derive');
+  });
+
+  it('renders "freshness unknown — not yet synced" when no registry entry matches', async () => {
+    mockReadRegistry.mockReturnValue({});
+    await orientCommand({ json: false });
+    expect(stdout).toContain('freshness unknown — not yet synced');
+  });
+});
+
+// ─── --json and human render share board filter + coherence ─
+
+describe('orient --json and human render parity', () => {
+  beforeEach(() => {
+    process.env['TOTEM_ORIENT_PROJECT'] = '1';
+  });
+
+  it('both surfaces honor the same active-board filter and coherence set', async () => {
+    mockFetchOpenIssuesWithBody.mockReturnValue([]);
+    mockFetchBoardItems.mockReturnValue([
+      { status: 'In Progress', title: 'Drifting card', contentNumber: 77 },
+      { status: 'Todo', title: 'Hidden todo', contentNumber: 88 },
+    ]);
+
+    // JSON surface
+    await runJson();
+    const r = parseJson();
+    expect(r.board).toHaveLength(1);
+    expect(r.board).toEqual([{ status: 'In Progress', title: 'Drifting card', contentNumber: 77 }]);
+    expect(r.coherence).toHaveLength(1);
+
+    // Human surface, rendered from the SAME report
+    const human = renderReport(r, true);
+    expect(human).toContain('Drifting card');
+    expect(human).not.toContain('Hidden todo'); // Todo filtered out of the active board
+    expect(human).toContain('issue #77 is closed/absent'); // same coherence flag
+  });
+});
+
+// ─── Footer + embedder tripwire ─────────────────────────
+
+describe('orient footer and #2018 structural guard', () => {
+  it('always emits the snapshot-not-source + perceptual-carve-out footer', async () => {
+    await orientCommand({ json: false });
+    expect(stdout).toContain('this output is a');
+    expect(stdout).toContain('snapshot/cache, not a source');
+    expect(stdout).toContain('Deeper judgment is perceptual');
+    expect(stdout).toContain('ask the human');
+  });
+
+  it('never reaches the embedder (runs green with @google/genai absent)', async () => {
+    await orientCommand({ json: false });
+    expect(embedderTripwire).not.toHaveBeenCalled();
+  });
+});

--- a/packages/cli/src/commands/orient.test.ts
+++ b/packages/cli/src/commands/orient.test.ts
@@ -227,10 +227,11 @@ describe('orient board + coherence', () => {
     mockFetchOpenIssuesWithBody.mockReturnValue([
       { number: 200, title: 'Open issue', body: '', labels: [] },
     ]);
+    const local = { contentRepo: 'mmnto-ai/totem', contentType: 'Issue' };
     mockFetchBoardItems.mockReturnValue([
-      { status: 'In Progress', title: 'Active drift', contentNumber: 100 }, // #100 not open → drift
-      { status: 'In Review', title: 'Active ok', contentNumber: 200 }, // open → ok
-      { status: 'Done', title: 'Terminal', contentNumber: 999 }, // terminal → filtered + never flagged
+      { status: 'In Progress', title: 'Active drift', contentNumber: 100, ...local }, // not open → drift
+      { status: 'In Review', title: 'Active ok', contentNumber: 200, ...local }, // open → ok
+      { status: 'Done', title: 'Terminal', contentNumber: 999, ...local }, // terminal → filtered + never flagged
     ]);
     await runJson();
     const r = parseJson();
@@ -246,6 +247,30 @@ describe('orient board + coherence', () => {
         kind: 'issue-closed-or-absent',
       },
     ]);
+  });
+
+  // Regression for the #2044 controller-review bug: GH Project #1 is an org board
+  // spanning repos. A card for a (still-open) strategy issue must SHOW on the board
+  // but NEVER be flagged as drift against THIS repo's open-issue set.
+  it('shows cross-repo cards on the board but never flags them as drift', async () => {
+    mockFetchOpenIssuesWithBody.mockReturnValue([]); // this repo has no open issues
+    mockFetchBoardItems.mockReturnValue([
+      {
+        status: 'In Progress',
+        title: 'Strategy work',
+        contentNumber: 433,
+        contentRepo: 'mmnto-ai/totem-strategy', // different repo
+        contentType: 'Issue',
+      },
+    ]);
+    await runJson();
+    const r = parseJson();
+    // Shown on the org board view…
+    expect(r.board).toEqual([
+      { status: 'In Progress', title: 'Strategy work', contentNumber: 433 },
+    ]);
+    // …but NOT flagged — #433 lives in another repo, not this repo's issue set.
+    expect(r.coherence).toEqual([]);
   });
 });
 
@@ -277,7 +302,13 @@ describe('orient --json and human render parity', () => {
   it('both surfaces honor the same active-board filter and coherence set', async () => {
     mockFetchOpenIssuesWithBody.mockReturnValue([]);
     mockFetchBoardItems.mockReturnValue([
-      { status: 'In Progress', title: 'Drifting card', contentNumber: 77 },
+      {
+        status: 'In Progress',
+        title: 'Drifting card',
+        contentNumber: 77,
+        contentRepo: 'mmnto-ai/totem',
+        contentType: 'Issue',
+      },
       { status: 'Todo', title: 'Hidden todo', contentNumber: 88 },
     ]);
 

--- a/packages/cli/src/commands/orient.test.ts
+++ b/packages/cli/src/commands/orient.test.ts
@@ -247,6 +247,8 @@ describe('orient board + coherence', () => {
         kind: 'issue-closed-or-absent',
       },
     ]);
+    // JSON consumers can tell a configured board apart from an unconfigured one.
+    expect(r.boardConfigured).toBe(true);
   });
 
   // Regression for the #2044 controller-review bug: GH Project #1 is an org board
@@ -285,10 +287,44 @@ describe('orient honest-absence (no board configured)', () => {
     expect(stdout).not.toContain('could not derive');
   });
 
+  it('marks boardConfigured:false in --json so consumers tell it apart from an empty board', async () => {
+    // Unconfigured board and a configured-but-empty board both have `board: []`;
+    // the boolean is the only signal that disambiguates them for a JSON pipe.
+    mockLoadConfig.mockResolvedValue({ orient: undefined });
+    await runJson();
+    const r = parseJson();
+    expect(r.board).toEqual([]);
+    expect(r.boardConfigured).toBe(false);
+  });
+
   it('renders "freshness unknown — not yet synced" when no registry entry matches', async () => {
     mockReadRegistry.mockReturnValue({});
     await orientCommand({ json: false });
     expect(stdout).toContain('freshness unknown — not yet synced');
+  });
+});
+
+// ─── Fail loud, not silent absence: malformed board config ──
+//
+// A user who SET TOTEM_ORIENT_PROJECT expects a board; a non-numeric value must
+// surface as a loud { error } (Tenet 4), NOT masquerade as "no board configured".
+describe('orient fail-loud on invalid board config', () => {
+  it('a non-numeric TOTEM_ORIENT_PROJECT surfaces a board { error }, not honest absence', async () => {
+    process.env['TOTEM_ORIENT_PROJECT'] = 'my-project';
+    await runJson();
+    const r = parseJson();
+    expect(r.board).toHaveProperty('error', expect.stringMatching(/TOTEM_ORIENT_PROJECT/));
+    // configured:true — the user DID configure (just malformed), so it's not "no board".
+    expect(r.boardConfigured).toBe(true);
+    // Board fetch is never attempted for an invalid number (no extra gh call).
+    expect(mockFetchBoardItems).not.toHaveBeenCalled();
+  });
+
+  it('renders the malformed-config error loudly, not the "no board configured" line', async () => {
+    process.env['TOTEM_ORIENT_PROJECT'] = 'not-a-number';
+    await orientCommand({ json: false });
+    expect(stdout).toContain('could not derive');
+    expect(stdout).not.toContain('no board configured');
   });
 });
 
@@ -320,7 +356,7 @@ describe('orient --json and human render parity', () => {
     expect(r.coherence).toHaveLength(1);
 
     // Human surface, rendered from the SAME report
-    const human = renderReport(r, true);
+    const human = renderReport(r);
     expect(human).toContain('Drifting card');
     expect(human).not.toContain('Hidden todo'); // Todo filtered out of the active board
     expect(human).toContain('issue #77 is closed/absent'); // same coherence flag

--- a/packages/cli/src/commands/orient.test.ts
+++ b/packages/cli/src/commands/orient.test.ts
@@ -153,8 +153,7 @@ describe('orient per-section failure isolation', () => {
     ]);
     await runJson();
     const r = parseJson();
-    expect(r.parked).toHaveProperty('error');
-    expect((r.parked as { error: string }).error).toMatch(/freeze\.json/i);
+    expect(r.parked).toHaveProperty('error', expect.stringMatching(/freeze\.json/i));
     // The PR section still derives — failure is isolated.
     expect(r.openPRs).toEqual([{ number: 9, title: 'fix', headRefName: 'fix/y', isDraft: false }]);
   });

--- a/packages/cli/src/commands/orient.ts
+++ b/packages/cli/src/commands/orient.ts
@@ -24,7 +24,6 @@ import { flagBoardIssueDrift, isActiveBoardItem } from './orient-coherence.js';
 
 // ─── Tunables ───────────────────────────────────────────
 
-const PR_LIMIT = 100;
 const ISSUE_LIMIT = 200;
 const EPIC_LABEL = 'type: epic';
 // Hide ai-workflow noise from the OTHER-issues label badges (matches the seed).
@@ -41,8 +40,15 @@ const PROJECT_NUMBER_RE = /^\d+$/;
 
 // ─── Report shape (the `--json` surface) ────────────────
 
+/** The `{ error }` envelope for an underivable section. The `error` key is the
+ *  external JSON-API field name (same convention as `json-output.ts`). */
+interface ErrorEnvelope {
+  // eslint-disable-next-line id-match -- 'error' is the standard JSON API field name for external consumers
+  error: string;
+}
+
 /** A section is EITHER its derived value OR an `{ error }` envelope — never silently omitted. */
-type Section<T> = T | { error: string };
+type Section<T> = T | ErrorEnvelope;
 
 export interface OrientParkedEntry {
   subsystem: string;
@@ -123,7 +129,7 @@ interface DerivedState {
   boardConfigured: boolean;
 }
 
-function isError<T>(s: Section<T>): s is { error: string } {
+function isError<T>(s: Section<T>): s is ErrorEnvelope {
   return typeof s === 'object' && s !== null && 'error' in s;
 }
 
@@ -142,7 +148,7 @@ const GH_TIMEOUT_MS = 20_000;
  * matching the codebase convention; static args only, so there is no injection
  * surface. Returns `{ error }` on failure (Tenet 4 — never a silent empty).
  */
-async function deriveRepoSlug(cwd: string): Promise<{ slug: RepoSlug } | { error: string }> {
+async function deriveRepoSlug(cwd: string): Promise<{ slug: RepoSlug } | ErrorEnvelope> {
   try {
     const { safeExec } = await import('@mmnto/totem');
     const raw = safeExec('gh', ['repo', 'view', '--json', 'owner,name'], {

--- a/packages/cli/src/commands/orient.ts
+++ b/packages/cli/src/commands/orient.ts
@@ -1,0 +1,501 @@
+// `totem orient` — derive session orientation from primitives (mmnto-ai/totem#2044, WS2).
+//
+// A DETERMINISTIC sensor (zero LLM, zero embedding): it derives "what's parked /
+// in flight / open" from live `gh` / `git` / fs primitives — open PRs, open
+// issues (with epic→child grouping), the GH Project board (in-flight only),
+// `.totem/freeze.json`, and an index-freshness pointer — plus one new derived
+// signal: a board↔issue coherence flag. Sibling to `totem triage` (LLM synthesis
+// on top); they compose, not duplicate.
+//
+// Discipline (ported from the strategy seed tools/orient.cjs):
+// - Fail loud, never drift (Tenet 4): an underivable section is an explicit
+//   `⚠ could not derive` line / `{ error }` envelope — NEVER a silent empty.
+// - Honest absence (Tenet 14): "not yet synced" / "no board configured" are
+//   explicit states, not errors and not blanks.
+// - Snapshot, not source (Tenet 20): every run re-derives; the output is a cache.
+// - NO embedding/LanceDB path — this is what makes orient run green when
+//   `@google/genai` is absent (it structurally dodges #2018).
+
+import type { BoardItem } from '../adapters/github-cli-project.js';
+import type { StandardIssueWithBody } from '../adapters/issue-adapter.js';
+import type { StandardPrListItem } from '../adapters/pr-adapter.js';
+import type { BoardIssueCoherenceFlag } from './orient-coherence.js';
+import { flagBoardIssueDrift, isActiveBoardItem } from './orient-coherence.js';
+
+// ─── Tunables ───────────────────────────────────────────
+
+const PR_LIMIT = 100;
+const ISSUE_LIMIT = 200;
+const EPIC_LABEL = 'type: epic';
+// Hide ai-workflow noise from the OTHER-issues label badges (matches the seed).
+const NOISE_LABELS = new Set(['ai-workflow']);
+// A registry entry older than this prints a [STALE] hint (matches `totem list`).
+const STALE_MS = 30 * 24 * 60 * 60 * 1000;
+// Matches "**Parent:** #N" AND fully-qualified "**Parent:** owner/repo#N".
+// Group 1 captures the optional owner/repo prefix; group 2 the number. Only
+// LOCAL parents (no prefix, or prefix == this repo's slug) attach children, so
+// a cross-repo ref can't collide with a same-numbered LOCAL epic.
+const PARENT_RE = /\*\*Parent:\*\*\s*([A-Za-z0-9._/-]+)?#(\d+)/;
+// Validate the env-sourced project number so it can only ever be digits.
+const PROJECT_NUMBER_RE = /^\d+$/;
+
+// ─── Report shape (the `--json` surface) ────────────────
+
+/** A section is EITHER its derived value OR an `{ error }` envelope — never silently omitted. */
+type Section<T> = T | { error: string };
+
+export interface OrientParkedEntry {
+  subsystem: string;
+  since?: string;
+  reason?: string;
+  tracking?: string;
+}
+
+export interface OrientPr {
+  number: number;
+  title: string;
+  headRefName: string;
+  isDraft: boolean;
+}
+
+export interface OrientBoardItem {
+  status: string;
+  title: string;
+  contentNumber?: number;
+}
+
+export interface OrientEpic {
+  number: number;
+  title: string;
+  labels: string[];
+  subIssues: { number: number; title: string }[];
+}
+
+export interface OrientOtherIssue {
+  number: number;
+  title: string;
+  labels: string[];
+}
+
+/** Index-freshness pointer — either a derived staleness fact or an honest "not synced" absence. */
+export interface OrientIndexFreshness {
+  synced: boolean;
+  /** Relative age of the registry `lastSync` (e.g. '2h ago'), when synced. */
+  lastSync?: string;
+  stale?: boolean;
+}
+
+export interface OrientReport {
+  repo: Section<string>;
+  derivedAt: string;
+  indexFreshness: OrientIndexFreshness;
+  parked: Section<OrientParkedEntry[]>;
+  openPRs: Section<OrientPr[]>;
+  board: Section<OrientBoardItem[]>;
+  coherence: Section<BoardIssueCoherenceFlag[]>;
+  epics: Section<OrientEpic[]>;
+  otherOpenIssues: Section<OrientOtherIssue[]>;
+}
+
+// ─── Internal derived state ─────────────────────────────
+
+interface RepoSlug {
+  owner: string;
+  name: string;
+}
+
+interface IssueDerivation {
+  epics: OrientEpic[];
+  others: OrientOtherIssue[];
+  openNumbers: Set<number>;
+}
+
+interface DerivedState {
+  repo: Section<string>;
+  localSlug: string | null;
+  indexFreshness: OrientIndexFreshness;
+  parked: Section<OrientParkedEntry[]>;
+  openPRs: Section<OrientPr[]>;
+  board: Section<OrientBoardItem[]>;
+  /** null when the board could not be derived → coherence can't be computed. */
+  boardItems: BoardItem[] | null;
+  issues: Section<IssueDerivation>;
+  boardConfigured: boolean;
+}
+
+function isError<T>(s: Section<T>): s is { error: string } {
+  return typeof s === 'object' && s !== null && 'error' in s;
+}
+
+function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+// ─── Per-section derivations (each fails in isolation) ──
+
+const GH_TIMEOUT_MS = 20_000;
+
+/**
+ * Derive `{ owner, name }` for the current repo via `gh repo view`.
+ *
+ * Uses `safeExec` (an `execFileSync` wrapper with an argument array — no shell),
+ * matching the codebase convention; static args only, so there is no injection
+ * surface. Returns `{ error }` on failure (Tenet 4 — never a silent empty).
+ */
+async function deriveRepoSlug(cwd: string): Promise<{ slug: RepoSlug } | { error: string }> {
+  try {
+    const { safeExec } = await import('@mmnto/totem');
+    const raw = safeExec('gh', ['repo', 'view', '--json', 'owner,name'], {
+      cwd,
+      timeout: GH_TIMEOUT_MS,
+      env: { ...process.env, GH_PROMPT_DISABLED: '1' },
+    });
+    const parsed = JSON.parse(raw) as { owner?: { login?: string }; name?: string };
+    if (!parsed.owner?.login || !parsed.name) {
+      return { error: 'unexpected `gh repo view` shape' };
+    }
+    return { slug: { owner: parsed.owner.login, name: parsed.name } };
+  } catch (err) {
+    return { error: errMessage(err).trim().split('\n')[0] || 'gh repo view failed' };
+  }
+}
+
+async function deriveParked(repoRoot: string): Promise<Section<OrientParkedEntry[]>> {
+  try {
+    const { readFreezeConfig } = await import('@mmnto/totem');
+    const path = await import('node:path');
+    const totemDir = path.join(repoRoot, '.totem');
+    const config = readFreezeConfig(totemDir);
+    if (!config) return [];
+    return config.frozen.map((f) => ({
+      subsystem: f.subsystem,
+      since: f.since,
+      reason: f.reason,
+      tracking: f.tracking,
+    }));
+  } catch (err) {
+    return { error: errMessage(err) };
+  }
+}
+
+async function derivePRs(cwd: string): Promise<Section<OrientPr[]>> {
+  try {
+    const { GitHubCliPrAdapter } = await import('../adapters/github-cli-pr.js');
+    const adapter = new GitHubCliPrAdapter(cwd);
+    const prs: StandardPrListItem[] = adapter.fetchOpenPRs();
+    return prs.map((p) => ({
+      number: p.number,
+      title: p.title,
+      headRefName: p.headRefName,
+      isDraft: p.isDraft,
+    }));
+  } catch (err) {
+    return { error: errMessage(err) };
+  }
+}
+
+async function deriveIssues(
+  cwd: string,
+  localSlug: string | null,
+): Promise<Section<IssueDerivation>> {
+  let all: StandardIssueWithBody[];
+  try {
+    const { GitHubCliAdapter } = await import('../adapters/github-cli.js');
+    const adapter = new GitHubCliAdapter(cwd);
+    all = adapter.fetchOpenIssuesWithBody(ISSUE_LIMIT);
+  } catch (err) {
+    return { error: errMessage(err) };
+  }
+
+  const openNumbers = new Set(all.map((i) => i.number));
+
+  // Build parent# → [child] from primitives (LOCAL parent refs only).
+  const childOf = new Map<number, StandardIssueWithBody[]>();
+  for (const it of all) {
+    const m = (it.body || '').match(PARENT_RE);
+    if (m && (!m[1] || (localSlug && m[1] === localSlug))) {
+      const parent = Number(m[2]);
+      const list = childOf.get(parent) ?? [];
+      list.push(it);
+      childOf.set(parent, list);
+    }
+  }
+
+  const isEpic = (it: StandardIssueWithBody) => it.labels.includes(EPIC_LABEL);
+  const epicIssues = all.filter(isEpic);
+  const epicNums = new Set(epicIssues.map((e) => e.number));
+
+  // A child is "covered" (omitted from OTHER) ONLY if its parent is a rendered
+  // epic; a child whose parent isn't an epic stays in OTHER so it is never dropped.
+  const coveredChildNums = new Set<number>();
+  for (const [parent, kids] of childOf) {
+    if (epicNums.has(parent)) kids.forEach((k) => coveredChildNums.add(k.number));
+  }
+
+  const epics: OrientEpic[] = epicIssues.map((e) => ({
+    number: e.number,
+    title: e.title,
+    labels: e.labels,
+    subIssues: (childOf.get(e.number) ?? []).map((c) => ({ number: c.number, title: c.title })),
+  }));
+
+  const others: OrientOtherIssue[] = all
+    .filter((it) => !isEpic(it) && !coveredChildNums.has(it.number))
+    .map((i) => ({ number: i.number, title: i.title, labels: i.labels }));
+
+  return { epics, others, openNumbers };
+}
+
+interface BoardDerivation {
+  section: Section<OrientBoardItem[]>;
+  items: BoardItem[] | null;
+  configured: boolean;
+}
+
+/**
+ * Resolve the project number (consumer-safety, Q5): config `orient.projectNumber`
+ * → env `TOTEM_ORIENT_PROJECT` (last override). No project configured ⇒ honest
+ * absence (not an error). Returns `undefined` when no board is configured.
+ */
+async function resolveProjectNumber(cwd: string): Promise<number | undefined> {
+  const env = process.env['TOTEM_ORIENT_PROJECT'];
+  if (env !== undefined && env !== '') {
+    if (!PROJECT_NUMBER_RE.test(env)) return undefined;
+    return Number(env);
+  }
+  // Optional config: orient must work even with NO totem.config.ts at all.
+  try {
+    const { loadConfig, resolveConfigPath } = await import('../utils.js');
+    const configPath = resolveConfigPath(cwd);
+    const config = await loadConfig(configPath);
+    return config.orient?.projectNumber;
+  } catch {
+    // No config / unreadable config is not an orient failure — board absence
+    // is the honest state. (resolveConfigPath throws when no config exists.)
+    return undefined;
+  }
+}
+
+async function deriveBoard(cwd: string, owner: string | null): Promise<BoardDerivation> {
+  const projectNumber = await resolveProjectNumber(cwd);
+  if (projectNumber === undefined) {
+    return { section: [], items: null, configured: false };
+  }
+  if (owner === null) {
+    return {
+      section: { error: 'board configured but repo owner could not be derived (gh repo view)' },
+      items: null,
+      configured: true,
+    };
+  }
+  try {
+    const { fetchBoardItems } = await import('../adapters/github-cli-project.js');
+    const items = fetchBoardItems(owner, projectNumber, cwd);
+    const active = items.filter(isActiveBoardItem).map((i) => ({
+      status: i.status || 'Todo',
+      title: i.title,
+      contentNumber: i.contentNumber,
+    }));
+    return { section: active, items, configured: true };
+  } catch (err) {
+    return { section: { error: errMessage(err) }, items: null, configured: true };
+  }
+}
+
+/**
+ * Derive the index-freshness pointer INLINE from the registry `lastSync` for the
+ * current repo root (Q1: no `@mmnto/cli`→`@mmnto/mcp` dependency). No registry
+ * entry ⇒ honest "not yet synced" absence.
+ */
+async function deriveIndexFreshness(repoRoot: string): Promise<OrientIndexFreshness> {
+  try {
+    const { readRegistry } = await import('@mmnto/totem');
+    const { formatRelativeTime } = await import('./list.js');
+    const path = await import('node:path');
+    const registry = readRegistry();
+    const normalizedRoot = path.normalize(repoRoot);
+    const entry = Object.values(registry).find((e) => path.normalize(e.path) === normalizedRoot);
+    if (!entry) return { synced: false };
+    const age = Date.now() - new Date(entry.lastSync).getTime();
+    return { synced: true, lastSync: formatRelativeTime(age), stale: age > STALE_MS };
+  } catch {
+    // Registry unreadable → treat as not-synced honest absence, not an error
+    // (it's a regenerable cache pointer, never load-bearing for orientation).
+    return { synced: false };
+  }
+}
+
+// ─── Orchestration ──────────────────────────────────────
+
+async function derive(cwd: string): Promise<DerivedState> {
+  const { resolveGitRoot } = await import('@mmnto/totem');
+  const repoRoot = resolveGitRoot(cwd) ?? cwd;
+
+  const slugResult = await deriveRepoSlug(cwd);
+  const repo: Section<string> = isError(slugResult)
+    ? { error: slugResult.error }
+    : `${slugResult.slug.owner}/${slugResult.slug.name}`;
+  const localSlug = isError(slugResult) ? null : `${slugResult.slug.owner}/${slugResult.slug.name}`;
+  const owner = isError(slugResult) ? null : slugResult.slug.owner;
+
+  const [indexFreshness, parked, openPRs, issues, board] = await Promise.all([
+    deriveIndexFreshness(repoRoot),
+    deriveParked(repoRoot),
+    derivePRs(cwd),
+    deriveIssues(cwd, localSlug),
+    deriveBoard(cwd, owner),
+  ]);
+
+  return {
+    repo,
+    localSlug,
+    indexFreshness,
+    parked,
+    openPRs,
+    board: board.section,
+    boardItems: board.items,
+    issues,
+    boardConfigured: board.configured,
+  };
+}
+
+/** Coherence flags derive purely from the board + open-issue primitives (no extra gh call). */
+function deriveCoherence(state: DerivedState): Section<BoardIssueCoherenceFlag[]> {
+  if (isError(state.board)) return { error: state.board.error };
+  if (isError(state.issues)) return { error: state.issues.error };
+  if (state.boardItems === null) return [];
+  return flagBoardIssueDrift(state.boardItems, state.issues.openNumbers);
+}
+
+function toReport(state: DerivedState): OrientReport {
+  const coherence = deriveCoherence(state);
+  return {
+    repo: state.repo,
+    derivedAt: new Date().toISOString(),
+    indexFreshness: state.indexFreshness,
+    parked: state.parked,
+    openPRs: state.openPRs,
+    board: state.board,
+    coherence,
+    epics: isError(state.issues) ? { error: state.issues.error } : state.issues.epics,
+    otherOpenIssues: isError(state.issues) ? { error: state.issues.error } : state.issues.others,
+  };
+}
+
+// ─── Human render ───────────────────────────────────────
+
+const FOOTER = [
+  '— end orient. State derives from the primitives above (Tenet 20); this output is a',
+  '  snapshot/cache, not a source. Deeper judgment is perceptual: ask the human; no',
+  '  deeper/fleet pass needed unless you are doing an audit (a different task).',
+].join('\n');
+
+function renderFreshness(f: OrientIndexFreshness): string {
+  if (!f.synced) return '  freshness unknown — not yet synced (run `totem sync`)';
+  return `  index synced ${f.lastSync}${f.stale ? ' [STALE]' : ''}`;
+}
+
+export function renderReport(report: OrientReport, boardConfigured: boolean): string {
+  const out: string[] = [];
+  const repo = isError(report.repo) ? `(repo undetermined: ${report.repo.error})` : report.repo;
+  out.push(`═══ totem orient — ${repo} ═══  derived ${report.derivedAt}`);
+  out.push(
+    '  (derived from primitives — open PRs / open issues / GH Project board / .totem/freeze.json)',
+  );
+
+  // PARKED
+  out.push('\n⛔ PARKED / FROZEN  (.totem/freeze.json)');
+  if (isError(report.parked)) out.push(`  ⚠ could not derive: ${report.parked.error}`);
+  else if (report.parked.length === 0) out.push('  none');
+  else
+    for (const f of report.parked) {
+      const reason = (f.reason || '').split('. ')[0];
+      out.push(`  • ${f.subsystem} (since ${f.since || '?'})${reason ? ` — ${reason}` : ''}`);
+      if (f.tracking) out.push(`      tracking: ${f.tracking}`);
+    }
+
+  // OPEN PRs
+  out.push('\n◐ OPEN PRs');
+  if (isError(report.openPRs)) out.push(`  ⚠ could not derive: ${report.openPRs.error}`);
+  else if (report.openPRs.length === 0) out.push('  none');
+  else
+    for (const p of report.openPRs) {
+      out.push(`  #${p.number}${p.isDraft ? ' [draft]' : ''} ${p.title}  (${p.headRefName})`);
+    }
+
+  // BOARD in-flight
+  out.push('\n▣ BOARD in-flight  (active statuses only)');
+  if (isError(report.board)) out.push(`  ⚠ could not derive: ${report.board.error}`);
+  else if (!boardConfigured)
+    out.push('  no board configured (set orient.projectNumber in totem.config.ts)');
+  else if (report.board.length === 0) out.push('  none (no items in an active status)');
+  else
+    for (const i of report.board) {
+      const num = i.contentNumber ? `#${i.contentNumber} ` : '';
+      out.push(`  [${i.status}] ${num}${i.title}`);
+    }
+
+  // BOARD↔ISSUE COHERENCE (the new derived signal)
+  out.push('\n⚖ BOARD↔ISSUE COHERENCE  (active card whose issue is closed/absent = drift)');
+  if (isError(report.coherence)) out.push(`  ⚠ could not derive: ${report.coherence.error}`);
+  else if (report.coherence.length === 0) out.push('  none (board and open issues are coherent)');
+  else
+    for (const c of report.coherence) {
+      out.push(
+        `  ⚠ [${c.boardStatus}] "${c.boardItemTitle}" → issue #${c.issueNumber} is closed/absent`,
+      );
+    }
+
+  // EPICS + children
+  out.push('\n✦ EPICS + sub-issues  (label "type: epic"; children via body Parent ref)');
+  if (isError(report.epics)) out.push(`  ⚠ could not derive: ${report.epics.error}`);
+  else if (report.epics.length === 0) out.push('  none');
+  else
+    for (const e of report.epics) {
+      out.push(`  #${e.number} ${e.title}`);
+      if (e.subIssues.length === 0) out.push('     (no tracked sub-issues)');
+      else
+        e.subIssues.forEach((c, idx) =>
+          out.push(`     ${idx === e.subIssues.length - 1 ? '└' : '├'} #${c.number} ${c.title}`),
+        );
+    }
+
+  // OTHER open issues
+  out.push('\n● OTHER open issues  (non-epic, non-child)');
+  if (isError(report.otherOpenIssues))
+    out.push(`  ⚠ could not derive: ${report.otherOpenIssues.error}`);
+  else if (report.otherOpenIssues.length === 0) out.push('  none');
+  else
+    for (const i of report.otherOpenIssues) {
+      const labels = i.labels.filter((l) => !NOISE_LABELS.has(l));
+      out.push(`  #${i.number} ${i.title}${labels.length ? `  [${labels.join(', ')}]` : ''}`);
+    }
+
+  // INDEX FRESHNESS pointer (honest absence when never synced)
+  out.push('\n⟳ INDEX FRESHNESS  (registry lastSync for this repo)');
+  out.push(renderFreshness(report.indexFreshness));
+
+  out.push('');
+  out.push(FOOTER);
+  return out.join('\n');
+}
+
+// ─── Command entry ──────────────────────────────────────
+
+export async function orientCommand(opts: { json?: boolean }): Promise<void> {
+  // Honor the subcommand flag AND the root program's global `--json` (commander
+  // routes a leading `--json` to the root option; the root sets this env). Same
+  // dual-source pattern other JSON-emitting commands use.
+  const { isJsonMode } = await import('../json-output.js');
+  const json = opts.json === true || isJsonMode();
+
+  const cwd = process.cwd();
+  const state = await derive(cwd);
+  const report = toReport(state);
+
+  if (json) {
+    process.stdout.write(JSON.stringify(report, null, 2) + '\n');
+    return;
+  }
+  process.stdout.write(renderReport(report, state.boardConfigured) + '\n');
+}

--- a/packages/cli/src/commands/orient.ts
+++ b/packages/cli/src/commands/orient.ts
@@ -163,7 +163,7 @@ async function deriveRepoSlug(cwd: string): Promise<{ slug: RepoSlug } | ErrorEn
     return { slug: { owner: parsed.owner.login, name: parsed.name } };
     // totem-context: a gh failure becomes a fail-loud { error } envelope (Tenet 4 — surfaced in the report, not swallowed); every other section still derives independently
   } catch (err) {
-    return { error: errMessage(err).trim().split('\n')[0] || 'gh repo view failed' };
+    return { error: errMessage(err) || 'gh repo view failed' };
   }
 }
 
@@ -405,7 +405,7 @@ const FOOTER = [
 
 function renderFreshness(f: OrientIndexFreshness): string {
   if (!f.synced) return '  freshness unknown — not yet synced (run `totem sync`)';
-  return `  index synced ${f.lastSync}${f.stale ? ' [STALE]' : ''}`;
+  return '  index synced ' + f.lastSync + (f.stale ? ' [STALE]' : '');
 }
 
 export function renderReport(report: OrientReport, boardConfigured: boolean): string {
@@ -433,7 +433,8 @@ export function renderReport(report: OrientReport, boardConfigured: boolean): st
   else if (report.openPRs.length === 0) out.push('  none');
   else
     for (const p of report.openPRs) {
-      out.push(`  #${p.number}${p.isDraft ? ' [draft]' : ''} ${p.title}  (${p.headRefName})`);
+      const head = `#${p.number}` + (p.isDraft ? ' [draft]' : '');
+      out.push(`  ${head} ${p.title}  (${p.headRefName})`);
     }
 
   // BOARD in-flight
@@ -445,7 +446,7 @@ export function renderReport(report: OrientReport, boardConfigured: boolean): st
   else
     for (const i of report.board) {
       const num = i.contentNumber ? `#${i.contentNumber} ` : '';
-      out.push(`  [${i.status}] ${num}${i.title}`);
+      out.push(`  [${i.status}] ${num}` + i.title);
     }
 
   // BOARD↔ISSUE COHERENCE (the new derived signal)
@@ -481,7 +482,8 @@ export function renderReport(report: OrientReport, boardConfigured: boolean): st
   else
     for (const i of report.otherOpenIssues) {
       const labels = i.labels.filter((l) => !NOISE_LABELS.has(l));
-      out.push(`  #${i.number} ${i.title}${labels.length ? `  [${labels.join(', ')}]` : ''}`);
+      const labelTag = labels.length ? `  [${labels.join(', ')}]` : '';
+      out.push(`  #${i.number} ${i.title}` + labelTag);
     }
 
   // INDEX FRESHNESS pointer (honest absence when never synced)

--- a/packages/cli/src/commands/orient.ts
+++ b/packages/cli/src/commands/orient.ts
@@ -370,7 +370,7 @@ function deriveCoherence(state: DerivedState): Section<BoardIssueCoherenceFlag[]
   if (isError(state.board)) return { error: state.board.error };
   if (isError(state.issues)) return { error: state.issues.error };
   if (state.boardItems === null) return [];
-  return flagBoardIssueDrift(state.boardItems, state.issues.openNumbers);
+  return flagBoardIssueDrift(state.boardItems, state.issues.openNumbers, state.localSlug);
 }
 
 function toReport(state: DerivedState): OrientReport {

--- a/packages/cli/src/commands/orient.ts
+++ b/packages/cli/src/commands/orient.ts
@@ -101,6 +101,10 @@ export interface OrientReport {
   coherence: Section<BoardIssueCoherenceFlag[]>;
   epics: Section<OrientEpic[]>;
   otherOpenIssues: Section<OrientOtherIssue[]>;
+  /** Whether a board project number is configured. Distinguishes the JSON's
+   *  "no board configured" (false) from "board configured but empty" (true,
+   *  `board: []`) — without it the two collapse to the same shape (Tenet 14). */
+  boardConfigured: boolean;
 }
 
 // ─── Internal derived state ─────────────────────────────
@@ -223,7 +227,9 @@ async function deriveIssues(
   const childOf = new Map<number, StandardIssueWithBody[]>();
   for (const it of all) {
     const m = (it.body || '').match(PARENT_RE);
-    if (m && (!m[1] || (localSlug && m[1] === localSlug))) {
+    // Case-folded compare: GitHub owner/repo slugs are case-insensitive, so a
+    // casing skew must not stop a child attaching to its LOCAL parent epic.
+    if (m && (!m[1] || (localSlug && m[1].toLowerCase() === localSlug.toLowerCase()))) {
       const parent = Number(m[2]);
       const list = childOf.get(parent) ?? [];
       list.push(it);
@@ -262,36 +268,61 @@ interface BoardDerivation {
   configured: boolean;
 }
 
+/** Project-number resolution: a positive int, an honest "no board configured"
+ *  absence, or a LOUD set-but-malformed env state (Tenet 4 — never silent). */
+type ProjectNumberResolution =
+  | { kind: 'resolved'; projectNumber: number }
+  | { kind: 'unconfigured' }
+  | { kind: 'invalid'; raw: string };
+
 /**
  * Resolve the project number (consumer-safety, Q5): config `orient.projectNumber`
  * → env `TOTEM_ORIENT_PROJECT` (last override). No project configured ⇒ honest
- * absence (not an error). Returns `undefined` when no board is configured.
+ * absence (`unconfigured`). A set-but-non-numeric env var is `invalid` — surfaced
+ * loudly by the caller, NOT masqueraded as "no board configured" (Tenet 4).
  */
-async function resolveProjectNumber(cwd: string): Promise<number | undefined> {
+async function resolveProjectNumber(cwd: string): Promise<ProjectNumberResolution> {
   const env = process.env['TOTEM_ORIENT_PROJECT'];
   if (env !== undefined && env !== '') {
-    if (!PROJECT_NUMBER_RE.test(env)) return undefined;
-    return Number(env);
+    // Explicitly-set-but-malformed ⇒ LOUD: a user who set it expects a board, so
+    // don't degrade to silent "unconfigured" (the exact Tenet-4 drift greptile flagged).
+    if (!PROJECT_NUMBER_RE.test(env)) return { kind: 'invalid', raw: env };
+    return { kind: 'resolved', projectNumber: Number(env) };
   }
   // Optional config: orient must work even with NO totem.config.ts at all.
   try {
     const { loadConfig, resolveConfigPath } = await import('../utils.js');
     const configPath = resolveConfigPath(cwd);
     const config = await loadConfig(configPath);
-    return config.orient?.projectNumber;
+    const projectNumber = config.orient?.projectNumber;
+    return projectNumber === undefined
+      ? { kind: 'unconfigured' }
+      : { kind: 'resolved', projectNumber };
     // totem-context: intentional — a missing/unreadable totem.config.ts is honest board-absence (Tenet 14), not an orient failure
   } catch {
     // No config / unreadable config is not an orient failure — board absence
     // is the honest state. (resolveConfigPath throws when no config exists.)
-    return undefined;
+    return { kind: 'unconfigured' };
   }
 }
 
 async function deriveBoard(cwd: string, owner: string | null): Promise<BoardDerivation> {
-  const projectNumber = await resolveProjectNumber(cwd);
-  if (projectNumber === undefined) {
+  const resolution = await resolveProjectNumber(cwd);
+  if (resolution.kind === 'unconfigured') {
     return { section: [], items: null, configured: false };
   }
+  if (resolution.kind === 'invalid') {
+    // Fail loud (Tenet 4): a set-but-malformed TOTEM_ORIENT_PROJECT is an { error }
+    // board section + configured:true, NOT a silent "no board configured" absence.
+    return {
+      section: {
+        error: `TOTEM_ORIENT_PROJECT="${resolution.raw}" is not a positive integer (board not derived)`,
+      },
+      items: null,
+      configured: true,
+    };
+  }
+  const { projectNumber } = resolution;
   if (owner === null) {
     return {
       section: { error: 'board configured but repo owner could not be derived (gh repo view)' },
@@ -392,6 +423,7 @@ function toReport(state: DerivedState): OrientReport {
     coherence,
     epics: isError(state.issues) ? { error: state.issues.error } : state.issues.epics,
     otherOpenIssues: isError(state.issues) ? { error: state.issues.error } : state.issues.others,
+    boardConfigured: state.boardConfigured,
   };
 }
 
@@ -408,7 +440,7 @@ function renderFreshness(f: OrientIndexFreshness): string {
   return '  index synced ' + f.lastSync + (f.stale ? ' [STALE]' : '');
 }
 
-export function renderReport(report: OrientReport, boardConfigured: boolean): string {
+export function renderReport(report: OrientReport): string {
   const out: string[] = [];
   const repo = isError(report.repo) ? `(repo undetermined: ${report.repo.error})` : report.repo;
   out.push(`═══ totem orient — ${repo} ═══  derived ${report.derivedAt}`);
@@ -440,7 +472,7 @@ export function renderReport(report: OrientReport, boardConfigured: boolean): st
   // BOARD in-flight
   out.push('\n▣ BOARD in-flight  (active statuses only)');
   if (isError(report.board)) out.push(`  ⚠ could not derive: ${report.board.error}`);
-  else if (!boardConfigured)
+  else if (!report.boardConfigured)
     out.push('  no board configured (set orient.projectNumber in totem.config.ts)');
   else if (report.board.length === 0) out.push('  none (no items in an active status)');
   else
@@ -512,5 +544,5 @@ export async function orientCommand(opts: { json?: boolean }): Promise<void> {
     process.stdout.write(JSON.stringify(report, null, 2) + '\n');
     return;
   }
-  process.stdout.write(renderReport(report, state.boardConfigured) + '\n');
+  process.stdout.write(renderReport(report) + '\n');
 }

--- a/packages/cli/src/commands/orient.ts
+++ b/packages/cli/src/commands/orient.ts
@@ -161,6 +161,7 @@ async function deriveRepoSlug(cwd: string): Promise<{ slug: RepoSlug } | ErrorEn
       return { error: 'unexpected `gh repo view` shape' };
     }
     return { slug: { owner: parsed.owner.login, name: parsed.name } };
+    // totem-context: a gh failure becomes a fail-loud { error } envelope (Tenet 4 — surfaced in the report, not swallowed); every other section still derives independently
   } catch (err) {
     return { error: errMessage(err).trim().split('\n')[0] || 'gh repo view failed' };
   }
@@ -179,6 +180,7 @@ async function deriveParked(repoRoot: string): Promise<Section<OrientParkedEntry
       reason: f.reason,
       tracking: f.tracking,
     }));
+    // totem-context: a freeze-read failure becomes a fail-loud { error } envelope (Tenet 4 — surfaced, not swallowed)
   } catch (err) {
     return { error: errMessage(err) };
   }
@@ -195,6 +197,7 @@ async function derivePRs(cwd: string): Promise<Section<OrientPr[]>> {
       headRefName: p.headRefName,
       isDraft: p.isDraft,
     }));
+    // totem-context: a gh PR-list failure becomes a fail-loud { error } envelope (Tenet 4 — surfaced, not swallowed)
   } catch (err) {
     return { error: errMessage(err) };
   }
@@ -209,6 +212,7 @@ async function deriveIssues(
     const { GitHubCliAdapter } = await import('../adapters/github-cli.js');
     const adapter = new GitHubCliAdapter(cwd);
     all = adapter.fetchOpenIssuesWithBody(ISSUE_LIMIT);
+    // totem-context: a gh issue-list failure becomes a fail-loud { error } envelope (Tenet 4 — surfaced, not swallowed)
   } catch (err) {
     return { error: errMessage(err) };
   }
@@ -275,6 +279,7 @@ async function resolveProjectNumber(cwd: string): Promise<number | undefined> {
     const configPath = resolveConfigPath(cwd);
     const config = await loadConfig(configPath);
     return config.orient?.projectNumber;
+    // totem-context: intentional — a missing/unreadable totem.config.ts is honest board-absence (Tenet 14), not an orient failure
   } catch {
     // No config / unreadable config is not an orient failure — board absence
     // is the honest state. (resolveConfigPath throws when no config exists.)
@@ -303,6 +308,7 @@ async function deriveBoard(cwd: string, owner: string | null): Promise<BoardDeri
       contentNumber: i.contentNumber,
     }));
     return { section: active, items, configured: true };
+    // totem-context: a gh board-fetch failure becomes a fail-loud { error } section envelope (Tenet 4 — surfaced, not swallowed)
   } catch (err) {
     return { section: { error: errMessage(err) }, items: null, configured: true };
   }
@@ -324,6 +330,7 @@ async function deriveIndexFreshness(repoRoot: string): Promise<OrientIndexFreshn
     if (!entry) return { synced: false };
     const age = Date.now() - new Date(entry.lastSync).getTime();
     return { synced: true, lastSync: formatRelativeTime(age), stale: age > STALE_MS };
+    // totem-context: intentional — an unreadable registry is honest "not synced" absence (Tenet 14) for a regenerable-cache pointer, not an orient failure
   } catch {
     // Registry unreadable → treat as not-synced honest absence, not an error
     // (it's a regenerable cache pointer, never load-bearing for orientation).

--- a/packages/cli/src/help.ts
+++ b/packages/cli/src/help.ts
@@ -33,7 +33,7 @@ export const COMMAND_GROUPS: readonly CommandGroup[] = [
   },
   {
     name: 'Setup',
-    commands: ['init', 'sync', 'hooks', 'doctor', 'status', 'eject'],
+    commands: ['init', 'sync', 'hooks', 'doctor', 'status', 'orient', 'eject'],
   },
 ];
 

--- a/packages/cli/src/index-lite.ts
+++ b/packages/cli/src/index-lite.ts
@@ -536,6 +536,10 @@ registerExcluded('spec <inputs...>', 'Generate a pre-work spec briefing');
 registerExcluded('handoff', 'Generate an end-of-session handoff snapshot');
 registerExcluded('triage-pr <pr-number>', 'Categorized triage view of bot review comments');
 registerExcluded('triage', 'Prioritize open issues into an active work roadmap');
+registerExcluded(
+  'orient',
+  'Derive session orientation from primitives (open PRs/issues/board/freeze)',
+);
 registerExcluded('check', 'Run lint + review sequentially');
 registerExcluded('wrap <pr-numbers...>', 'Post-merge workflow: learn from PR(s)');
 registerExcluded('docs [paths...]', 'Auto-update registered project docs');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -578,6 +578,24 @@ program
   });
 
 program
+  .command('orient')
+  .description(
+    'Derive session orientation from primitives (open PRs/issues/board/freeze) — zero LLM',
+  )
+  .option('--json', 'Output the OrientReport as structured JSON')
+  .action(async (opts: { json?: boolean }) => {
+    requireGhCli();
+    try {
+      const { orientCommand } = await import('./commands/orient.js');
+      await orientCommand(opts);
+    } catch (err) {
+      handleError(err);
+      // totem-context: handleError returns `never` (process.exit), so the throw is unreachable but required to satisfy the Tenet 4 fail-loud rule that bans bare-catch silent-degrade. Mirrors the mail/verify-badges pattern.
+      throw err;
+    }
+  });
+
+program
   .command('handoff')
   .description('Scaffold a structured journal entry for end-of-session handoff')
   .option('--stdout', 'Print scaffold to stdout instead of opening in $EDITOR')

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -243,12 +243,10 @@ export type ConfigTier = z.infer<typeof ConfigTierSchema>;
  * (Tenet 14). This must NOT bake the cohort's board into a shipped command —
  * Totem is NOT zero-user.
  */
-export const OrientConfigSchema = z
-  .object({
-    /** GH Project number for the in-flight board section (e.g. 1). Optional. */
-    projectNumber: z.number().int().positive().optional(),
-  })
-  .optional();
+export const OrientConfigSchema = z.object({
+  /** GH Project number for the in-flight board section (e.g. 1). Optional. */
+  projectNumber: z.number().int().positive().optional(),
+});
 
 /**
  * Default source extensions used when computing the review content hash.
@@ -463,7 +461,7 @@ export const TotemConfigSchema = z.object({
   review: ReviewConfigSchema,
 
   /** Optional: `totem orient` settings (e.g. `{ projectNumber: 1 }` for the GH Project board). */
-  orient: OrientConfigSchema,
+  orient: OrientConfigSchema.optional(),
 });
 
 /**

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -231,6 +231,26 @@ export const ConfigTierSchema = z.enum(['lite', 'standard', 'full']);
 export type ConfigTier = z.infer<typeof ConfigTierSchema>;
 
 /**
+ * `totem orient` configuration (mmnto-ai/totem#2044, WS2).
+ *
+ * `orient` derives session state from primitives (open PRs/issues/board/freeze)
+ * with zero LLM. The GH Project board is the only piece that cannot be derived
+ * from the current repo alone — a board lives under an `owner` and a numeric
+ * project id. Owner is derived from `gh repo view`; the project NUMBER is the
+ * one consumer-specific value, so it is read from this OPTIONAL field (env
+ * `TOTEM_ORIENT_PROJECT` overrides last). When unset, orient renders the board
+ * section as an honest "no board configured" absence — never an error
+ * (Tenet 14). This must NOT bake the cohort's board into a shipped command —
+ * Totem is NOT zero-user.
+ */
+export const OrientConfigSchema = z
+  .object({
+    /** GH Project number for the in-flight board section (e.g. 1). Optional. */
+    projectNumber: z.number().int().positive().optional(),
+  })
+  .optional();
+
+/**
  * Default source extensions used when computing the review content hash.
  * Historical hardcoded set, preserved for backward compatibility with
  * pre-#1527 consumers. Polyglot repos override via `review.sourceExtensions`.
@@ -441,6 +461,9 @@ export const TotemConfigSchema = z.object({
    *  Polyglot repos extend the default `['.ts', '.tsx', '.js', '.jsx']` to cover
    *  additional source languages (e.g., `['.rs', '.gd']` for Rust + Godot). */
   review: ReviewConfigSchema,
+
+  /** Optional: `totem orient` settings (e.g. `{ projectNumber: 1 }` for the GH Project board). */
+  orient: OrientConfigSchema,
 });
 
 /**
@@ -459,6 +482,7 @@ export type Orchestrator = z.infer<typeof OrchestratorSchema>;
 export type GarbageCollectionConfig = z.infer<typeof GarbageCollectionSchema>;
 export type DoctorConfig = z.infer<typeof DoctorConfigSchema>;
 export type DocTarget = z.infer<typeof DocTargetSchema>;
+export type OrientConfig = z.infer<typeof OrientConfigSchema>;
 export type TotemConfig = z.infer<typeof TotemConfigSchema>;
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -49,6 +49,7 @@ export type {
   GarbageCollectionConfig,
   IngestTarget,
   Orchestrator,
+  OrientConfig,
   TotemConfig,
 } from './config-schema.js';
 export {
@@ -70,6 +71,7 @@ export {
   OllamaProviderSchema,
   OpenAIProviderSchema,
   OrchestratorSchema,
+  OrientConfigSchema,
   requireEmbedding,
   ReviewConfigSchema,
   ReviewSourceExtensionSchema,


### PR DESCRIPTION
## Summary

`totem orient [--json]` — a **deterministic** session-orientation command (zero LLM, zero embedding). It derives "what's parked / in flight / open" from live primitives — open PRs, open issues (epic→child grouped), the GH Project board (in-flight only), `.totem/freeze.json`, and an index-freshness pointer — each line citing the primitive it came from. It is the deterministic-sensor sibling to `totem triage` (LLM synthesis); they compose, not duplicate.

Folds the strategy-side seed `tools/orient.cjs` into totem core. Realizes **Proposal 264 (Derived Standing State)** under **Tenet 20 (Derive-or-Couple, Never-Mirror)**: the output is a snapshot/cache, never a source.

Refs #2044 · Charter mmnto-ai/totem-strategy#438 (Proposal 288 §6.1, WS2)

## Design notes

- **Zero embedding by design** — orient takes no LanceDB/embedder path, so it runs green even when `@google/genai` is absent (it structurally sidesteps #2018). A test asserts it never constructs an embedder.
- **Fail loud, never drift (Tenet 4)** — every section is its derived value **or** a `{ error }` envelope; nothing is silently omitted. Honest-absence lines (Tenet 14) for "not yet synced" / "no board configured".
- **Consumer-safe (Totem is NOT zero-user)** — owner is derived from `gh repo view`; the GH Project number comes from an **optional** `orient.projectNumber` config field (env `TOTEM_ORIENT_PROJECT` overrides last). No project configured → honest "no board configured" absence, never an error. The cohort's board is never baked into a shipped command.
- **New signal — board↔issue coherence** — flags an active board card whose linked issue is closed/absent (a Tenet-20 mirror-drift detector for the board). **Scoped to same-repo Issue cards**: GH Projects are commonly org-level boards spanning repos, so cross-repo cards and PR cards are never flagged — a coherence sensor that cries wolf on healthy cross-repo cards is worse than none.

## Scope

- **In (this PR):** the command (human + `--json` `OrientReport`), adapter extensions (`isDraft`, open-issues-with-body, the new `gh project item-list` board reader capturing `content.repository`/`type`), the optional `orient.projectNumber` config field, and help/CLI registration (`Setup` group, non-LLM).
- **Out (PR-2):** session-start auto-injection + cohort distribution. This is why it's **Refs**, not **Closes**, #2044.

## Test coverage

107 files / 2331 tests pass; 30 orient-specific — per-section failure isolation, unexpected-shape→`{error}` (underivable ≠ none), the cross-repo `**Parent:**` guard, the coherence predicate (incl. cross-repo / PR / null-slug regression tests), `--json`↔human-render parity, honest-absence paths, and the #2018 embedder tripwire.

## Verification

- `tsc` clean (cli + core), repo-wide `format:check` clean, full-branch `totem lint` **PASS (0 errors)**, 2331 tests pass.
- `totem review` (workspace build) ran clean — 0 findings ("robust error isolation, strict cross-repo guards"). The global `totem` binary is #2018-blocked (no `@google/genai`), but the workspace build's review path works; CodeRabbit + Gemini Code Assist are the bot review backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
