### PR TITLE
feat(cli): totem orient session-start auto-injection (WS2 PR-2, #2044)

### DIFF
--- a/.changeset/orient-session-inject.md
+++ b/.changeset/orient-session-inject.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/cli': patch
+---
+
+`totem orient` session-start auto-injection (WS2 PR-2): add programmatic `deriveOrientReport` and `renderOrientForSession` exports so the SessionStart hook injects derived, bounded orientation (parked subsystems, open PRs, board↔issue coherence drift, a counts pointer) into the session payload.

--- a/.claude/hooks/session-context.mjs
+++ b/.claude/hooks/session-context.mjs
@@ -112,7 +112,12 @@ async function buildOrientBlock(gitRoot) {
     const report = await deriveOrientReport(gitRoot);
     return renderOrientForSession(report);
   } catch (err) {
-    process.stderr.write(`[session-context] orient block skipped: ${err.message}\n`);
+    // Match the sibling pollInboundMail's null-safe extraction: `err.message`
+    // alone throws a TypeError when `err` is null/undefined (crashing the very
+    // boot this catch protects) and prints "undefined" for non-Error throws.
+    process.stderr.write(
+      `[session-context] orient block skipped: ${err && err.message ? err.message : String(err)}\n`,
+    );
     return '';
   }
 }

--- a/.claude/hooks/session-context.mjs
+++ b/.claude/hooks/session-context.mjs
@@ -85,6 +85,38 @@ async function pollInboundMail(gitRoot) {
   }
 }
 
+// Derived session orientation (mmnto-ai/totem#2044 PR-2). Loads the orient
+// command's programmatic entry from the freshly-built workspace dist — the same
+// pattern as pollInboundMail / buildVectorContext, deliberately NOT the global
+// `totem` binary (sidesteps the stale-resolve trap mmnto-ai/totem#2053).
+//
+// Best-effort + bounded. orient runs ~4 sequential synchronous gh calls
+// (repo view + PRs + issues + board), each bounded by the adapter's per-call
+// timeout — a few seconds on a responsive gh. A SessionStart hook must never
+// crash the boot (lesson 8d363778): on a missing dist OR any failure we emit a
+// stderr diagnostic and return '' so the block is simply omitted. The rendered
+// block is itself hard-bounded by renderOrientForSession, so it can never
+// displace high-value content (the #467 net-neutral-truncation guardrail).
+async function buildOrientBlock(gitRoot) {
+  try {
+    const orientPath = join(gitRoot, 'packages', 'cli', 'dist', 'commands', 'orient.js');
+    if (!existsSync(orientPath)) {
+      process.stderr.write(
+        '[session-context] orient block skipped: @mmnto/cli not built at packages/cli/dist; run pnpm -F @mmnto/cli build\n',
+      );
+      return '';
+    }
+    const { deriveOrientReport, renderOrientForSession } = await import(
+      pathToFileURL(orientPath).href
+    );
+    const report = await deriveOrientReport(gitRoot);
+    return renderOrientForSession(report);
+  } catch (err) {
+    process.stderr.write(`[session-context] orient block skipped: ${err.message}\n`);
+    return '';
+  }
+}
+
 // ─── Helpers ──────────────────────────────────────────────
 
 function getBranch() {
@@ -256,6 +288,20 @@ async function buildStaticContext(gitRoot, branch, ticket) {
     lines.push(`  Warning: ${w}`);
   });
   lines.push('');
+
+  // Derived orientation (parked / open PRs / coherence drift / counts pointer),
+  // mmnto-ai/totem#2044 PR-2. Placed in the high-value early tier but AFTER the
+  // journal carryforward and inbound mail: the main() slice keeps the first
+  // MAX_TOTAL_CHARS, so anything later is the first to truncate. orient is
+  // bounded and high-value, but journal + mail are higher — so orient sits ahead
+  // of only the (situational) active-proposal excerpt and the low-value vector
+  // tail. Net result: truncation eats the already-truncating vector tail, never
+  // journal/mail (strategy charter (A), 2026-06-01; #467 net-neutral guardrail).
+  const orientBlock = await buildOrientBlock(gitRoot);
+  if (orientBlock) {
+    lines.push(orientBlock);
+    lines.push('');
+  }
 
   // Active proposal matching ticket — proposals live in totem-strategy
   // (NOT substrate; only `.handoff/` + `.journal/` were extracted per

--- a/.totem/specs/2044.md
+++ b/.totem/specs/2044.md
@@ -133,3 +133,143 @@ honest-absence line (Tenet 4 + 14).
   **not** bake the cohort's board. **Rec: derive owner from `gh repo view`; read project number from
   an optional `totem.config.ts` field (e.g. `orient.projectNumber`); env override last; if no
   project is configured, the board section is an honest "no board configured" absence, not an error.**
+
+> **PR-1 STATUS:** shipped + merged — squash `1d879fc9` (PR #2052), 2026-05-31. All five OQs above
+> resolved as recommended. #2044 stays OPEN for PR-2 (below).
+
+---
+
+# Implementation Design — PR-2 (session-start auto-injection)
+
+> Hand-assembled at preflight (claude-0081, 2026-06-01) from #2044 / charter `mmnto-ai/totem-strategy#438`
+> (acceptance: "auto-injected at session-start across cohort repos") / `mmnto-ai/totem-strategy#467`
+> (Tier-A distillation rides WS2 — "`totem orient` makes session-start _derived_; this makes it _lean_").
+> Grounded in the real surfaces: `.claude/hooks/session-context.mjs` (the existing SessionStart hook) and
+> `packages/cli/src/commands/orient.ts` (PR-1, shipped). `totem spec` NOT run (fabrication-prone per
+> strategy#474; #2018-blocked locally; would clobber this file).
+
+### Scope
+
+PR-2 wires `totem orient` into totem's **own** SessionStart hook (`.claude/hooks/session-context.mjs`)
+as a compact, high-signal **derived block** (parked + open PRs + board↔issue coherence drift + a counts
+pointer), via a new **pure programmatic export** on the orient command — so the dogfood session-start
+payload becomes orient-derived (the reshape #467's Tier-A half gates behind).
+
+The deferred PR-1 GCA nit (`(it.body || '')` → `it.body`, orient.ts:229) is **re-deferred** — though a
+verified no-op (`StandardIssueWithBody.body` is a required string, adapter-normalized `i.body ?? ''`),
+touching that line is a false-positive magnet: it surfaces a dormant `match`→`matchAll` lint flag (the
+lesson-1ef06d16 trap) and an un-grounded "you removed a null check" review/bot flag (the #474 class).
+Zero feature value, real review-noise cost → it has not earned its slot in this PR (Tenet 21). Belongs in
+a dedicated micro-cleanup.
+
+It will **NOT** build the cohort-distribution install verb (writing orientation hooks into consumer
+`.claude`/`.gemini` paths — that is PR-3, rides the `totem gate install`-style channel with its own
+review surface; #438 stays OPEN for it). It will **NOT** rebalance the existing journal/vector char
+budget beyond _placing_ the orient block in the high-value early tier (the budget rebalance is a
+separately-tracked follow-on, per the `session-context.mjs:215` comment). It will **NOT** change
+`totem orient`'s own command output, and will **NOT** make orient reach the embedder (the #2018 guard
+holds).
+
+### Data model deltas
+
+**New exports on `packages/cli/src/commands/orient.ts` (consumed by the hook):**
+
+- `deriveOrientReport(cwd: string): Promise<OrientReport>` — runs the existing private `derive → toReport`
+  and returns the report **without writing stdout**. _Writer:_ orient module. _Readers:_ `orientCommand`
+  (refactored to delegate — DRY, no behavior change) + the SessionStart hook. _Invariant:_ identical
+  report shape to `orient --json` (one derivation, two callers — cannot diverge). No new I/O beyond the
+  gh/git reads `derive` already does.
+- `renderOrientForSession(report: OrientReport): string` — a **compact** projection. Emits ONLY: parked,
+  open PRs, coherence drift, and a one-line counts pointer (`N epics · M other open issues — run \`totem
+  orient\` for the full board`). _Writer:_ orient module. _Reader:_ the hook. _Invariant:_ never emits
+the full epic/other-issue enumeration (Tier-A lean, #467); every emitted section keeps the
+`{error}`/honest-absence contract (a `⚠ could not derive` line, never a silent omit).
+
+**Hook (`.claude/hooks/session-context.mjs`) — additive:**
+
+- One new dynamic-import of `packages/cli/dist/commands/orient.js` (same workspace-relative-dist pattern
+  as `pollMail` / `getAutoContext` — deliberately **not** the global `totem` binary, so it dodges #2053),
+  wrapped in try/catch, emitting the compact block into `buildStaticContext`'s `lines`.
+
+No new config field, no new persistent state, no new module-level container, no reserved keys/sentinels.
+
+### State lifecycle
+
+The orient block is **stateless / per-session-start-invocation**: derived fresh on each session boot,
+embedded in `additionalContext`, never persisted, never cached across sessions. _Scope:_ per hook run.
+_Lifetime:_ the hook process. _Mutation owner:_ `buildStaticContext`. No state crosses a lifecycle
+boundary — same structural no-drift property as orient itself (the output IS the cache, never a source;
+Tenet 20).
+
+### Failure modes
+
+| Failure                                                   | Category  | Agent-facing surface                                                                                                                          | Recovery                                           |
+| --------------------------------------------------------- | --------- | --------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------- |
+| cli dist missing (`orient.js` not built)                  | init      | hook stderr diagnostic + **omit** the orient block; session still boots (same path as the mail/vector "not built" branches)                   | `pnpm -F @mmnto/cli build`                         |
+| `deriveOrientReport` throws (e.g. `resolveGitRoot` fails) | runtime   | hook try/catch → stderr diagnostic + omit the orient block; journal/mail/vector still render                                                  | re-run; check `gh`                                 |
+| an individual orient section underivable (gh fail)        | transient | **inside** the rendered block as a `⚠ could not derive: <err>` line (Tenet 4 — surfaced, not swallowed)                                       | re-run (per-section isolation)                     |
+| orient block pushes combined context past the 10k cap     | runtime   | existing `MAX_TOTAL_CHARS` slice truncates the **tail**; orient emits in the high-value early tier so it survives (ordering, not silent loss) | — (by design; budget rebalance tracked separately) |
+
+The two "omit the block" rows are the **only** degradations, and they are the established session-hook
+resilience floor (lesson `8d363778`: a SessionStart hook must never throw / never crash the boot).
+Justification against Tenet 4: the omission is **loud on stderr** (a diagnostic the operator sees), and
+the sole alternative — letting the hook throw — violates the never-crash-the-boot invariant. This is the
+documented carve-out for session hooks, not a new silent-drift surface.
+
+### Invariants to lock in via tests
+
+- `deriveOrientReport(cwd)` returns the **same** report object that `orient --json` serializes (one
+  derivation, two callers — the refactor cannot introduce divergence).
+- `renderOrientForSession` **never** emits the full epic/other-issue enumeration — only counts + the
+  `totem orient` pointer (the falsifiable #467 Tier-A-lean guard).
+- `renderOrientForSession` **does** surface a parked entry, an open PR, and a coherence-drift flag when
+  each is present (the compact projection drops bulk, not high-value signals).
+- An `{error}` section renders as a `⚠ could not derive` line in the compact projection — never a silent
+  omission (the Tenet-4 contract carries through the projection).
+- The hook **omits** the orient block (does not throw) when the cli dist is absent OR
+  `deriveOrientReport` rejects — `buildStaticContext` still returns and the session boots (resilience
+  floor; asserted via a throwing stub).
+- The `it.body` simplification is behavior-identical: a child with an empty body and a child with a
+  `**Parent:**` ref classify exactly as before.
+
+### Open questions
+
+- **Q1 — PR-2 scope: dogfood-only vs +cohort distribution.** #438 acceptance reads "across cohort repos."
+  - **Options:** (a) **dogfood-only** — wire totem's own hook now; the cohort-distribution install verb
+    becomes PR-3 (rides the gate-install channel, own review surface); #438 stays OPEN for it. (b) both
+    surfaces in PR-2.
+  - **Recommendation: (a).** It is exactly what #467's Tier-A reshape gates behind, reviewable in
+    isolation, and the distribution channel is a separate, previously-contested mechanism (the pack-route
+    was killed per the #448 inventory) that earns its own design + review. Matches PR-1's command-only
+    minimalism (Tenet 21).
+- **Q2 — compact projection content (what survives into Tier-A).**
+  - **Options:** (a) parked + open PRs + coherence drift + a counts pointer; (b) (a) plus epic headlines;
+    (c) the full render.
+  - **Recommendation: (a)** — anomalies + in-flight + pointer; the agent runs `totem orient` on demand
+    for the full board. "Pointers not bodies" (#467).
+- **Q3 — budget / ordering.** The hook already runs tight (a 250-line journal cap + a 6k-char vector
+  block against a 10k total cap; the code comment calls a deeper rebalance "out of scope, tracked
+  separately").
+  - **Options:** (a) place the compact orient block in the high-value **early** tier (right after the
+    parked/journal-carryforward surface, before the vector tail) so truncation eats vector, not orient —
+    no cap change; (b) also raise/rebalance `MAX_TOTAL_CHARS` in this PR.
+  - **Recommendation: (a)** — ordering, not a cap bump; keeps PR-2 out of the tracked budget-rebalance
+    work, and orient survives truncation by position (consistent with #435's "high-value emits first").
+  - **RESOLVED → (a) adjacent** (strategy-claude charter, 2026-06-01T0229Z; durable amendment posted as
+    a `mmnto-ai/totem-strategy#467` issue comment). PR-2 ships orient by ordering; **#467 owns** the
+    measure→distill→cap-rebalance campaign, sequenced right after. The measured budget table above is
+    logged as #467's step-1 "measure first" (Tenet 2) census baseline. **Binding guardrail (below).**
+
+### Binding guardrail (strategy charter 0229Z)
+
+PR-2 must be **net-neutral-or-positive on high-value-content truncation.** The orient block ships
+**bounded + early-tier** — it must never displace high-value content (journal carryforward, parked,
+inbound mail). Truncation absorbs the _already-truncating_ low-value vector tail, so net session signal
+goes **up**, not down. Concretely this promotes one invariant from implicit to locked: the compact
+projection carries its **own hard char/item bound** (favorable ordering alone is insufficient — a runaway
+orient block could itself push high-value content past the cap). If orient cannot be bounded into the
+early tier, the call reverts to (B); not expected. Added to the invariants list:
+
+- `renderOrientForSession` output is **hard-bounded** (per-section item caps + a total char ceiling on
+  the block) — so the orient block can never grow to displace journal/mail/parked high-value content
+  (the net-neutral-truncation guardrail; the falsifiable test).

--- a/packages/cli/src/commands/orient.test.ts
+++ b/packages/cli/src/commands/orient.test.ts
@@ -489,6 +489,22 @@ describe('renderOrientForSession — bounded Tier-A projection', () => {
     expect(issuesErr).toContain('issues: ⚠ could not derive: gh issue list exploded');
   });
 
+  it('surfaces an otherOpenIssues error that splits independently from epics (Tenet 4 type-gap)', () => {
+    // toReport couples these today, but the type permits the split — a derived
+    // `epics` with an errored `otherOpenIssues` must still fail loud, not coerce
+    // the count to 0 silently.
+    const block = renderOrientForSession(
+      makeReport({
+        epics: [{ number: 1, title: 'Epic One', labels: ['type: epic'], subIssues: [] }],
+        otherOpenIssues: { error: 'gh issue list (others) exploded' },
+      }),
+    );
+    expect(block).toContain(
+      'other open issues: ⚠ could not derive: gh issue list (others) exploded',
+    );
+    expect(block).toContain('1 epic'); // epics still surface
+  });
+
   it('returns "" when there is nothing high-signal (so the hook omits the block)', () => {
     expect(renderOrientForSession(makeReport())).toBe('');
     // A zero count must NOT emit a "0 epics" pointer line.

--- a/packages/cli/src/commands/orient.test.ts
+++ b/packages/cli/src/commands/orient.test.ts
@@ -82,7 +82,13 @@ vi.mock('../utils.js', () => ({
   loadConfig: () => mockLoadConfig(),
 }));
 
-import { orientCommand, type OrientReport, renderReport } from './orient.js';
+import {
+  deriveOrientReport,
+  orientCommand,
+  type OrientReport,
+  renderOrientForSession,
+  renderReport,
+} from './orient.js';
 
 // ─── Test harness ───────────────────────────────────────
 
@@ -377,5 +383,142 @@ describe('orient footer and #2018 structural guard', () => {
   it('never reaches the embedder (runs green with @google/genai absent)', async () => {
     await orientCommand({ json: false });
     expect(embedderTripwire).not.toHaveBeenCalled();
+  });
+});
+
+// ─── PR-2: programmatic entry + session-start projection (mmnto-ai/totem#2044) ──
+
+describe('deriveOrientReport — one derivation, two callers (cannot diverge)', () => {
+  it('returns the SAME report `orient --json` serializes (modulo the derivedAt stamp)', async () => {
+    // A small but non-empty world so the comparison is meaningful.
+    mockFetchOpenPRs.mockReturnValue([
+      { number: 42, title: 'do thing', headRefName: 'feat/x', isDraft: false },
+    ]);
+    mockFetchOpenIssuesWithBody.mockReturnValue([
+      { number: 7, title: 'Other Seven', body: '', labels: [] },
+    ]);
+
+    await runJson();
+    const fromCommand = parseJson();
+    const fromApi = await deriveOrientReport(repoRoot);
+
+    // derivedAt is a wall-clock stamp set per call — the only field allowed to differ.
+    const { derivedAt: _a, ...cmdRest } = fromCommand;
+    const { derivedAt: _b, ...apiRest } = fromApi;
+    expect(apiRest).toEqual(cmdRest);
+  });
+});
+
+describe('renderOrientForSession — bounded Tier-A projection', () => {
+  function makeReport(overrides: Partial<OrientReport> = {}): OrientReport {
+    return {
+      repo: 'mmnto-ai/totem',
+      derivedAt: '2026-06-01T00:00:00.000Z',
+      indexFreshness: { synced: false },
+      parked: [],
+      openPRs: [],
+      board: [],
+      coherence: [],
+      epics: [],
+      otherOpenIssues: [],
+      boardConfigured: false,
+      ...overrides,
+    };
+  }
+
+  it('surfaces high-value signals (parked, open PR, coherence drift) + a counts pointer', () => {
+    const block = renderOrientForSession(
+      makeReport({
+        parked: [{ subsystem: 'embedder', since: '2026-01-01' }],
+        openPRs: [{ number: 42, title: 'do thing', headRefName: 'feat/x', isDraft: false }],
+        coherence: [
+          {
+            boardItemTitle: 'Stale card',
+            boardStatus: 'In Progress',
+            issueNumber: 99,
+            kind: 'issue-closed-or-absent',
+          },
+        ],
+        epics: [{ number: 1, title: 'Epic One', labels: ['type: epic'], subIssues: [] }],
+        otherOpenIssues: [{ number: 7, title: 'Other Seven', labels: [] }],
+      }),
+    );
+    expect(block).toContain('embedder'); // parked subsystem
+    expect(block).toContain('#42'); // open PR
+    expect(block).toContain('do thing');
+    expect(block).toContain('#99'); // coherence drift
+    expect(block).toContain('1 epic · 1 other open issue'); // counts pointer
+    expect(block).toContain('run `totem orient`');
+  });
+
+  it('NEVER enumerates epics / children / other issues (the #467 Tier-A-lean guard)', () => {
+    const block = renderOrientForSession(
+      makeReport({
+        epics: [
+          {
+            number: 1,
+            title: 'Epic One',
+            labels: ['type: epic'],
+            subIssues: [{ number: 2, title: 'Child Two' }],
+          },
+        ],
+        otherOpenIssues: [{ number: 7, title: 'Other Seven', labels: [] }],
+      }),
+    );
+    // Counts only — the titles must not appear (pointers not bodies).
+    expect(block).toContain('1 epic · 1 other open issue');
+    expect(block).not.toContain('Epic One');
+    expect(block).not.toContain('Child Two');
+    expect(block).not.toContain('Other Seven');
+  });
+
+  it('an {error} section renders a fail-loud `⚠ could not derive` line, never a silent omit', () => {
+    const parkedErr = renderOrientForSession(
+      makeReport({ parked: { error: 'freeze.json unreadable' } }),
+    );
+    expect(parkedErr).toContain('⚠ could not derive');
+    expect(parkedErr).toContain('freeze.json unreadable');
+
+    // epics + otherOpenIssues share deriveIssues → one issues error line.
+    const issuesErr = renderOrientForSession(
+      makeReport({
+        epics: { error: 'gh issue list exploded' },
+        otherOpenIssues: { error: 'gh issue list exploded' },
+      }),
+    );
+    expect(issuesErr).toContain('issues: ⚠ could not derive: gh issue list exploded');
+  });
+
+  it('returns "" when there is nothing high-signal (so the hook omits the block)', () => {
+    expect(renderOrientForSession(makeReport())).toBe('');
+    // A zero count must NOT emit a "0 epics" pointer line.
+    expect(renderOrientForSession(makeReport({ epics: [], otherOpenIssues: [] }))).toBe('');
+  });
+
+  it('is HARD-BOUNDED — long content cannot blow past the char cap (net-neutral-truncation guardrail)', () => {
+    // Within the per-section item cap (10) but with long titles, so the CHAR
+    // ceiling — not the item cap — is what bounds the block.
+    const longTitle = 'x'.repeat(300);
+    const prs = Array.from({ length: 10 }, (_, i) => ({
+      number: i,
+      title: longTitle,
+      headRefName: `feat/branch-${i}`,
+      isDraft: false,
+    }));
+    const block = renderOrientForSession(makeReport({ openPRs: prs }));
+    // Bounded: ≤ SESSION_BLOCK_MAX_CHARS (1500) plus the short truncation marker.
+    expect(block.length).toBeLessThanOrEqual(1500 + 32);
+    expect(block).toContain('…(orient block truncated)');
+  });
+
+  it('caps per-section item counts with a "… and N more" overflow line', () => {
+    const flood = Array.from({ length: 25 }, (_, i) => ({
+      number: i,
+      title: `t${i}`,
+      headRefName: `b${i}`,
+      isDraft: false,
+    }));
+    const block = renderOrientForSession(makeReport({ openPRs: flood }));
+    expect(block).toContain('more open PRs');
   });
 });

--- a/packages/cli/src/commands/orient.ts
+++ b/packages/cli/src/commands/orient.ts
@@ -427,6 +427,25 @@ function toReport(state: DerivedState): OrientReport {
   };
 }
 
+/**
+ * Programmatic entry: derive the full `OrientReport` for `cwd` WITHOUT writing
+ * stdout. Identical report to `orient --json` (one derivation, two callers —
+ * cannot diverge). Reused by `orientCommand` (the CLI surface) and the
+ * SessionStart hook (`.claude/hooks/session-context.mjs`, mmnto-ai/totem#2044
+ * PR-2), which dynamic-imports this from `packages/cli/dist/commands/orient.js`
+ * — the workspace-dist pattern, deliberately NOT the global `totem` binary
+ * (sidesteps the stale-resolve trap mmnto-ai/totem#2053).
+ *
+ * Latency note: orient's gh adapters are synchronous (`safeExec`/execFileSync),
+ * so this runs ~4 sequential blocking gh calls (repo view + PRs + issues + board),
+ * each bounded by the adapter's per-call timeout. Callers on a latency-sensitive
+ * path (the hook) wrap it best-effort and degrade on failure.
+ */
+export async function deriveOrientReport(cwd: string): Promise<OrientReport> {
+  const state = await derive(cwd);
+  return toReport(state);
+}
+
 // ─── Human render ───────────────────────────────────────
 
 const FOOTER = [
@@ -527,6 +546,105 @@ export function renderReport(report: OrientReport): string {
   return out.join('\n');
 }
 
+// ─── Session-start projection (the auto-injected Tier-A block) ──
+
+// Bounds for the session-start orient block (mmnto-ai/totem#2044 PR-2).
+// Binding guardrail (strategy charter 2026-06-01T0229Z, mmnto-ai/totem-strategy#467):
+// the block must be HARD-BOUNDED so it can never displace high-value session
+// content (journal carryforward, parked, inbound mail) past the hook's
+// MAX_TOTAL_CHARS cap — favorable ordering alone is insufficient, a runaway block
+// would itself crowd out high-value content. Net-neutral-or-positive on
+// high-value-content truncation; truncation absorbs the low-value vector tail.
+const SESSION_BLOCK_MAX_CHARS = 1500;
+const SESSION_PARKED_CAP = 8;
+const SESSION_PR_CAP = 10;
+const SESSION_COHERENCE_CAP = 10;
+
+/**
+ * Compact projection of an `OrientReport` for auto-injection at session start.
+ *
+ * Emits ONLY high-signal state — parked/frozen subsystems, open PRs, and board↔
+ * issue coherence drift — plus a one-line COUNTS pointer for epics/other-issues
+ * (NOT the full enumeration: "pointers not bodies", mmnto-ai/totem-strategy#467
+ * Tier-A discipline). An underivable section stays a `⚠ could not derive` line
+ * (Tenet 4 — never a silent omit), so the projection inherits orient's fail-loud
+ * contract. Hard-bounded by `SESSION_BLOCK_MAX_CHARS` (the guardrail above).
+ *
+ * Returns '' when there is nothing high-signal to surface (no parked, no PRs, no
+ * drift, no derivable counts) so the hook can omit the block entirely rather than
+ * inject an empty header.
+ */
+export function renderOrientForSession(report: OrientReport): string {
+  const out: string[] = [];
+  const repo = isError(report.repo) ? '(repo undetermined)' : report.repo;
+  out.push(`── orient (derived state): ${repo} ──`);
+  const headerLen = out.length;
+
+  // PARKED / FROZEN — you must not touch these subsystems (high value).
+  if (isError(report.parked)) {
+    out.push(`⛔ parked: ⚠ could not derive: ${report.parked.error}`);
+  } else if (report.parked.length > 0) {
+    const shown = report.parked.slice(0, SESSION_PARKED_CAP).map((f) => f.subsystem);
+    const more = report.parked.length > SESSION_PARKED_CAP ? ' …' : '';
+    out.push(`⛔ parked/frozen (${report.parked.length}): ${shown.join(', ')}` + more);
+  }
+
+  // OPEN PRs — what's in flight.
+  if (isError(report.openPRs)) {
+    out.push(`◐ open PRs: ⚠ could not derive: ${report.openPRs.error}`);
+  } else if (report.openPRs.length > 0) {
+    for (const p of report.openPRs.slice(0, SESSION_PR_CAP)) {
+      const draft = p.isDraft ? ' [draft]' : '';
+      out.push(`◐ PR #${p.number}` + draft + ` ${p.title} (${p.headRefName})`);
+    }
+    if (report.openPRs.length > SESSION_PR_CAP) {
+      out.push(`  … and ${report.openPRs.length - SESSION_PR_CAP} more open PRs`);
+    }
+  }
+
+  // BOARD↔ISSUE COHERENCE drift — the anomaly signal (active card, issue closed/absent).
+  if (isError(report.coherence)) {
+    out.push(`⚖ coherence: ⚠ could not derive: ${report.coherence.error}`);
+  } else if (report.coherence.length > 0) {
+    for (const c of report.coherence.slice(0, SESSION_COHERENCE_CAP)) {
+      out.push(
+        `⚖ drift: [${c.boardStatus}] "${c.boardItemTitle}" → #${c.issueNumber} closed/absent`,
+      );
+    }
+    if (report.coherence.length > SESSION_COHERENCE_CAP) {
+      out.push(`  … and ${report.coherence.length - SESSION_COHERENCE_CAP} more drift flags`);
+    }
+  }
+
+  // COUNTS pointer — NOT the enumeration (Tier-A lean: the agent runs `totem
+  // orient` on demand for the full epic/issue board). One fail-loud line if the
+  // issue derivation failed — epics + otherOpenIssues share `deriveIssues`, so
+  // they error together with the same message; surface it once, never drop it
+  // silently (Tenet 4). A zero count emits nothing (no "0 epics" noise).
+  if (isError(report.epics)) {
+    out.push(`● issues: ⚠ could not derive: ${report.epics.error}`);
+  } else {
+    const epicCount = report.epics.length;
+    const otherCount = isError(report.otherOpenIssues) ? 0 : report.otherOpenIssues.length;
+    const parts: string[] = [];
+    if (epicCount > 0) parts.push(`${epicCount} epic${epicCount === 1 ? '' : 's'}`);
+    if (otherCount > 0) {
+      parts.push(`${otherCount} other open issue${otherCount === 1 ? '' : 's'}`);
+    }
+    if (parts.length > 0) {
+      out.push(`● ${parts.join(' · ')} — run \`totem orient\` for the full board`);
+    }
+  }
+
+  // Nothing high-signal beyond the header ⇒ let the hook omit the block.
+  if (out.length === headerLen) return '';
+
+  const block = out.join('\n');
+  return block.length > SESSION_BLOCK_MAX_CHARS
+    ? block.slice(0, SESSION_BLOCK_MAX_CHARS) + '\n  …(orient block truncated)'
+    : block;
+}
+
 // ─── Command entry ──────────────────────────────────────
 
 export async function orientCommand(opts: { json?: boolean }): Promise<void> {
@@ -537,8 +655,7 @@ export async function orientCommand(opts: { json?: boolean }): Promise<void> {
   const json = opts.json === true || isJsonMode();
 
   const cwd = process.cwd();
-  const state = await derive(cwd);
-  const report = toReport(state);
+  const report = await deriveOrientReport(cwd);
 
   if (json) {
     process.stdout.write(JSON.stringify(report, null, 2) + '\n');

--- a/packages/cli/src/commands/orient.ts
+++ b/packages/cli/src/commands/orient.ts
@@ -624,6 +624,13 @@ export function renderOrientForSession(report: OrientReport): string {
   if (isError(report.epics)) {
     out.push(`● issues: ⚠ could not derive: ${report.epics.error}`);
   } else {
+    // `epics` and `otherOpenIssues` share `deriveIssues`, so `toReport` errors
+    // them together today — but the type (`Section<...>`) permits an independent
+    // split. Surface an errored `otherOpenIssues` explicitly rather than silently
+    // coercing its count to 0 (Tenet 4 — never a silent omit, even type-only).
+    if (isError(report.otherOpenIssues)) {
+      out.push(`● other open issues: ⚠ could not derive: ${report.otherOpenIssues.error}`);
+    }
     const epicCount = report.epics.length;
     const otherCount = isError(report.otherOpenIssues) ? 0 : report.otherOpenIssues.length;
     const parts: string[] = [];


### PR DESCRIPTION
## What & why

WS2 **PR-2** — wire `totem orient` into totem's own SessionStart hook so the session-start payload becomes **derived**, not hand-maintained. This is the payload reshape that `mmnto-ai/totem-strategy#467`'s Tier-A distillation gates behind. **Dogfood-only**; cohort distribution is deferred to **PR-3** (strategy charter (A) "adjacent", 2026-06-01). #2044 stays OPEN for PR-3.

## Changes

- **`orient.ts`** — two pure exports the hook consumes:
  - `deriveOrientReport(cwd)` — runs the existing `derive→toReport` **without writing stdout**. `orientCommand` refactored to delegate (one derivation, two callers — cannot diverge).
  - `renderOrientForSession(report)` — a compact, **hard-bounded** Tier-A projection: parked + open PRs + board↔issue coherence drift + a counts pointer. Never the full epic/issue enumeration ("pointers not bodies", #467). Keeps the fail-loud `{error}` contract; returns `''` when nothing is high-signal.
- **`session-context.mjs`** — emits the bounded block in the high-value **early tier, after journal + inbound mail**, so the 10k `MAX_TOTAL_CHARS` slice truncates only the already-truncating vector tail, never high-value content (the net-neutral-truncation guardrail). Loads from `packages/cli/dist` (workspace-dist pattern, not the global binary — sidesteps #2053); `try/catch` omits the block on dist-missing/failure so the hook never crashes session boot (lesson `8d363778`).
- **Tests** — `deriveOrientReport ≡ --json` shape; projection keeps high-value / drops enumeration; `{error}` → fail-loud line; hard char + per-section bounds.

## Guardrail (binding — strategy charter)

PR-2 must be net-neutral-or-positive on high-value-content truncation. Verified empirically: orient lands after journal+mail and absorbs truncation alongside the vector tail — journal+mail preserved, net session signal up.

## Known follow-ons (not in this PR)

- **Session-start latency:** orient's gh adapters are synchronous → **~3s** added to session boot (measured). Degrades gracefully; a bound/cache is a tracked follow-on (session-start-consumption, #467 family).
- The deferred PR-1 `it.body` nit is **re-deferred** (a false-positive magnet for zero feature value; Tenet 21).

Spec: `.totem/specs/2044.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)