### PR TITLE
chore(ci): disable CodeRabbit's redundant ESLint tool

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -67,8 +67,14 @@ reviews:
     ast-grep:
       enabled: true
       essential_rules: true
+    # ESLint is enforced authoritatively in CI ("Build & Lint" on macOS/Ubuntu/Windows,
+    # which blocks merge) and in the pre-push hook (`pnpm run lint`). CodeRabbit runs its
+    # own ESLint in an isolated sandbox that cannot install this repo's deps — the pnpm
+    # `workspace:*` protocol refs, the native `@lancedb/lancedb` binary, and ESLint 10 —
+    # so it emits a recurring, non-fatal "ESLint install failed" warning on every PR.
+    # Disabled as pure redundancy (no coverage loss); our ESLint gate is unchanged.
     eslint:
-      enabled: true
+      enabled: false
     shellcheck:
       enabled: true
     markdownlint:


### PR DESCRIPTION
## Why

CodeRabbit runs its **own** ESLint in an isolated sandbox, which first has to install this repo's dependencies to load the flat config's plugins. That install fails here for three reasons, any one sufficient:

- pnpm **`workspace:*`** protocol refs (`@mmnto/totem`) that non-workspace installers can't resolve;
- the **native `@lancedb/lancedb`** binary, which fails to fetch/build in a restricted bot sandbox;
- **ESLint `^10.4.0`**, newer than CodeRabbit's runner reliably supports.

Result: a recurring, **non-fatal** `ESLint install failed` warning on every PR. (CodeRabbit's overall review still completes and passes.)

## Fix

Disable the redundant tool (`reviews.tools.eslint.enabled: false`), with the rationale inlined in `.coderabbit.yaml` for future maintainers.

**No coverage loss:** ESLint is already enforced authoritatively in **CI** ("Build & Lint" on macOS/Ubuntu/Windows — blocks merge) and in the **pre-push hook** (`pnpm run lint`). CodeRabbit's AI review + ast-grep / shellcheck / markdownlint are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)