### PR TITLE
feat(cli): totem orient --session + SessionStart template wiring (WS2 PR-3, #2044)

### DIFF
--- a/.changeset/orient-session-render-mode.md
+++ b/.changeset/orient-session-render-mode.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/cli': patch
+---
+
+feat(cli): orient cohort distribution (WS2 PR-3, #2044) — two parts:
+
+1. `totem orient --session` render mode: emits the bounded session-orientation block for a SessionStart hook to inject. Reuses the shipped `deriveOrientReport` + `renderOrientForSession`, so the CLI surface, the `--json` report, and the in-process hook cannot diverge. Boot-safe per the SessionStart contract — never throws or exits non-zero, emits nothing when there is no high-signal state (the hook omits the block), and skips the hard `gh` gate so a consumer without `gh` degrades to fail-loud "could not derive" lines instead of an error banner.
+
+2. The scaffolded SessionStart hooks (`CLAUDE_SESSION_START` + `GEMINI_SESSION_START`) now append `totem orient --session` after `totem describe` — additively (Tenet 13: `describe` = static identity sensor, `orient` = live in-flight sensor; append, never replace), each in its own boot-safe try/catch. New consumers get live derived orientation at session-start automatically; existing consumers pick it up on their next hook re-scaffold.

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -98,6 +98,18 @@ try {
 } catch (err) {
   process.stdout.write('[Totem] Briefing unavailable: ' + (err instanceof Error ? err.message : String(err)) + '\\n');
 }
+
+// totem orient --session — live derived in-flight state, ADDITIVE to describe
+// (mmnto-ai/totem#2044 PR-3). Own try/catch; orient --session is itself boot-safe.
+try {
+  execSync('totem orient --session', {
+    timeout: 30000,
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
+  // totem-context: intentional boot-safe best-effort — orient is additive to describe; a SessionStart hook must never crash the boot.
+} catch {
+  /* orient is best-effort; the describe briefing already emitted. Stay silent (boot-safe). */
+}
 `;
 
 export const GEMINI_BEFORE_TOOL = `// [totem] auto-generated — Gemini CLI BeforeTool hook
@@ -394,6 +406,26 @@ try {
       (err instanceof Error ? err.message : String(err)) +
       '\\n',
   );
+}
+
+// ─── totem orient --session — live derived in-flight state (mmnto-ai/totem#2044 PR-3) ──
+// ADDITIVE to describe (Tenet 13: describe = static identity sensor — scope/tier/
+// counts; orient = live in-flight sensor — open PRs/issues/board/freeze). Append,
+// never replace. Its OWN try/catch so an orient failure never disturbs the describe
+// briefing or the boot; \`orient --session\` is itself boot-safe (emits nothing when
+// nothing is high-signal, never exits non-zero, degrades to honest "could not derive").
+try {
+  const orientCliPath = join(process.cwd(), 'node_modules', '@mmnto', 'cli', 'dist', 'index.js');
+  if (existsSync(orientCliPath)) {
+    const orientResult = spawnSync(process.execPath, [orientCliPath, 'orient', '--session'], {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    process.stdout.write((orientResult.stdout || '') + (orientResult.stderr || ''));
+  }
+  // totem-context: intentional boot-safe best-effort — a SessionStart hook must never crash the agent's boot; orient is additive to describe and degrades silently.
+} catch {
+  /* orient is best-effort; the describe briefing already emitted. Stay silent (boot-safe). */
 }
 `;
 

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -106,9 +106,10 @@ try {
     timeout: 30000,
     stdio: ['ignore', 'inherit', 'inherit'],
   });
-  // totem-context: intentional boot-safe best-effort — orient is additive to describe; a SessionStart hook must never crash the boot.
-} catch {
-  /* orient is best-effort; the describe briefing already emitted. Stay silent (boot-safe). */
+} catch (err) {
+  // Boot-safe: orient is additive to describe; a failure never blocks session start —
+  // surface a NON-fatal breadcrumb (matches the Claude-side hook) rather than swallow.
+  process.stderr.write('[SessionStart] orient briefing unavailable (non-fatal): ' + (err instanceof Error ? err.message : String(err)) + '\\n');
 }
 `;
 
@@ -421,11 +422,22 @@ try {
       encoding: 'utf-8',
       timeout: 30000,
     });
+    // spawnSync sets .error (it does NOT throw) on a spawn-level failure; re-throw so
+    // it surfaces through the catch breadcrumb below rather than writing '' silently.
+    if (orientResult.error) {
+      throw orientResult.error;
+    }
     process.stdout.write((orientResult.stdout || '') + (orientResult.stderr || ''));
   }
-  // totem-context: intentional boot-safe best-effort — a SessionStart hook must never crash the agent's boot; orient is additive to describe and degrades silently.
-} catch {
-  /* orient is best-effort; the describe briefing already emitted. Stay silent (boot-safe). */
+} catch (err) {
+  // Boot-safe: orient is additive to describe (already emitted), so a failure never
+  // blocks session start — but surface a NON-fatal breadcrumb to stderr (not stdout,
+  // to keep the prompt clean) for debuggability rather than swallowing silently.
+  process.stderr.write(
+    '[SessionStart] orient briefing unavailable (non-fatal): ' +
+      (err instanceof Error ? err.message : String(err)) +
+      '\\n',
+  );
 }
 `;
 

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1458,6 +1458,19 @@ describe('CLAUDE_SESSION_START template', () => {
     expect(CLAUDE_SESSION_START).not.toContain('design-tenets');
     expect(CLAUDE_SESSION_START).not.toContain('.journal/strategy');
   });
+
+  it('appends `totem orient --session` ADDITIVELY after the describe briefing (#2044 PR-3)', () => {
+    // Tenet 13 sensor separation: describe (static identity) is NOT replaced —
+    // orient (live in-flight state) is appended after it. Both must be present,
+    // and orient runs via the same node_modules/@mmnto/cli dist probe as describe.
+    expect(CLAUDE_SESSION_START).toContain("'describe'"); // describe retained
+    expect(CLAUDE_SESSION_START).toContain("'orient'");
+    expect(CLAUDE_SESSION_START).toContain("'--session'");
+    // Append, not prepend/replace: describe must precede orient in the script.
+    expect(CLAUDE_SESSION_START.indexOf("'describe'")).toBeLessThan(
+      CLAUDE_SESSION_START.indexOf("'--session'"),
+    );
+  });
 });
 
 describe('GEMINI_SESSION_START template', () => {
@@ -1495,6 +1508,16 @@ describe('GEMINI_SESSION_START template', () => {
     expect(GEMINI_SESSION_START).toContain('Briefing unavailable');
     expect(GEMINI_SESSION_START).not.toContain('design-tenets');
     expect(GEMINI_SESSION_START).not.toContain('.journal/strategy');
+  });
+
+  it('appends `totem orient --session` ADDITIVELY after describe (#2044 PR-3)', () => {
+    // Tenet 13: describe (static identity) retained; orient (live in-flight)
+    // appended after it — both present, describe first.
+    expect(GEMINI_SESSION_START).toContain("'totem describe'"); // retained
+    expect(GEMINI_SESSION_START).toContain("'totem orient --session'");
+    expect(GEMINI_SESSION_START.indexOf("'totem describe'")).toBeLessThan(
+      GEMINI_SESSION_START.indexOf("'totem orient --session'"),
+    );
   });
 });
 

--- a/packages/cli/src/commands/orient.test.ts
+++ b/packages/cli/src/commands/orient.test.ts
@@ -571,4 +571,24 @@ describe('orient --session — boot-safe SessionStart projection', () => {
     await expect(orientCommand({ session: true })).resolves.toBeUndefined();
     expect(stdout).toContain('could not derive');
   });
+
+  it('with --json: surfaces an ignored-flag note on stderr, still renders the raw block (not JSON)', async () => {
+    mockFetchOpenPRs.mockReturnValue([
+      { number: 42, title: 'wire orient', headRefName: 'feat/orient', isDraft: false },
+    ]);
+    let stderr = '';
+    const errSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation((chunk: string | Uint8Array) => {
+        stderr += chunk.toString();
+        return true;
+      });
+    await orientCommand({ session: true, json: true });
+    errSpy.mockRestore();
+    // The ignored --json is surfaced (not silently dropped) — greptile mmnto-ai/totem#2062 G2.
+    expect(stderr).toContain('--json ignored');
+    // …and stdout is still the bounded session projection, NOT the JSON report.
+    expect(stdout).toContain('◐ PR #42');
+    expect(stdout).not.toContain('"openPRs"');
+  });
 });

--- a/packages/cli/src/commands/orient.test.ts
+++ b/packages/cli/src/commands/orient.test.ts
@@ -538,3 +538,37 @@ describe('renderOrientForSession — bounded Tier-A projection', () => {
     expect(block).toContain('more open PRs');
   });
 });
+
+// ─── orient --session — boot-safe SessionStart projection (PR-3, #2044) ──
+
+describe('orient --session — boot-safe SessionStart projection', () => {
+  it('emits the bounded session projection to stdout when there is high-signal state', async () => {
+    mockFetchOpenPRs.mockReturnValue([
+      { number: 42, title: 'wire orient', headRefName: 'feat/orient', isDraft: false },
+    ]);
+    await orientCommand({ session: true });
+    // The bounded `renderOrientForSession` projection — header + the PR line…
+    expect(stdout).toContain('orient (derived state)');
+    expect(stdout).toContain('◐ PR #42');
+    // …NOT the full human render (that's `orient` without --session): no full
+    // banner header, no footer. The two surfaces must not be confused.
+    expect(stdout).not.toContain('═══ totem orient');
+    expect(stdout).not.toContain('end orient. State derives');
+  });
+
+  it('emits NOTHING when there is no high-signal state (so the hook omits the block)', async () => {
+    // beforeEach defaults: no PRs / issues / board / freeze → projection is "".
+    await orientCommand({ session: true });
+    expect(stdout).toBe('');
+  });
+
+  it('is boot-safe — a section failure surfaces a fail-loud line but never rejects', async () => {
+    // A malformed freeze.json makes the REAL readFreezeConfig throw, isolating the
+    // parked section to { error } (no thrown derivation). Proves the session path
+    // RESOLVES — a SessionStart hook must never crash the boot (lesson 8d363778) —
+    // AND surfaces the failure loudly (Tenet 4), never a silent blank.
+    fs.writeFileSync(path.join(tmpRoot, '.totem', 'freeze.json'), '{ not valid json');
+    await expect(orientCommand({ session: true })).resolves.toBeUndefined();
+    expect(stdout).toContain('could not derive');
+  });
+});

--- a/packages/cli/src/commands/orient.ts
+++ b/packages/cli/src/commands/orient.ts
@@ -671,6 +671,14 @@ export async function orientCommand(opts: { json?: boolean; session?: boolean })
   // `--json` so a `--session --json` invocation stays in the boot-safe path.
   if (opts.session === true) {
     try {
+      // --session is the hook render contract (raw text) and takes precedence over
+      // --json; surface the ignored flag on stderr rather than dropping it silently
+      // (mmnto-ai/totem#2062 greptile G2). Kept INSIDE the boot-safe try so it can never crash the
+      // hook, and on stderr so it never pollutes the session block on stdout.
+      const { isJsonMode } = await import('../json-output.js');
+      if (opts.json === true || isJsonMode()) {
+        process.stderr.write('[orient] --session takes precedence over --json; --json ignored\n');
+      }
       const report = await deriveOrientReport(cwd);
       const block = renderOrientForSession(report);
       if (block) process.stdout.write(block + '\n');

--- a/packages/cli/src/commands/orient.ts
+++ b/packages/cli/src/commands/orient.ts
@@ -654,14 +654,46 @@ export function renderOrientForSession(report: OrientReport): string {
 
 // ─── Command entry ──────────────────────────────────────
 
-export async function orientCommand(opts: { json?: boolean }): Promise<void> {
+export async function orientCommand(opts: { json?: boolean; session?: boolean }): Promise<void> {
+  const cwd = process.cwd();
+
+  // Session-render mode (mmnto-ai/totem#2044 PR-3): emit ONLY the bounded
+  // `renderOrientForSession` projection so a SessionStart hook can inject it.
+  // The third caller of the single `deriveOrientReport` derivation (alongside
+  // `orient --json`, the human render, and the PR-2 in-process hook
+  // `session-context.mjs:buildOrientBlock`) — they cannot diverge.
+  //
+  // Boot-safety contract (lesson 8d363778): a SessionStart consumer must never
+  // have its boot crashed by orient. On ANY failure, write a stderr breadcrumb
+  // and NOTHING to stdout (the hook simply omits the block) — never throw, never
+  // exit non-zero. An empty block (nothing high-signal) likewise emits nothing,
+  // so the hook omits it rather than printing a bare header. Checked before
+  // `--json` so a `--session --json` invocation stays in the boot-safe path.
+  if (opts.session === true) {
+    try {
+      const report = await deriveOrientReport(cwd);
+      const block = renderOrientForSession(report);
+      if (block) process.stdout.write(block + '\n');
+      // Boot-safe degradation: a SessionStart hook must never crash the agent's
+      // boot (lesson 8d363778), so this catch must NOT rethrow. The failure is
+      // surfaced LOUDLY via the stderr breadcrumb below (Tenet 4 satisfied by
+      // REPORTING, not propagating) and stdout stays empty so the hook omits the
+      // block. Mirrors the sibling session-context.mjs:buildOrientBlock (PR-2).
+      // totem-context: intentional boot-safe degradation, not a fail-open swallow.
+    } catch (err) {
+      process.stderr.write(
+        `[orient] session block skipped: ${err instanceof Error ? err.message : String(err)}\n`,
+      );
+    }
+    return;
+  }
+
   // Honor the subcommand flag AND the root program's global `--json` (commander
   // routes a leading `--json` to the root option; the root sets this env). Same
   // dual-source pattern other JSON-emitting commands use.
   const { isJsonMode } = await import('../json-output.js');
   const json = opts.json === true || isJsonMode();
 
-  const cwd = process.cwd();
   const report = await deriveOrientReport(cwd);
 
   if (json) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -583,8 +583,17 @@ program
     'Derive session orientation from primitives (open PRs/issues/board/freeze) — zero LLM',
   )
   .option('--json', 'Output the OrientReport as structured JSON')
-  .action(async (opts: { json?: boolean }) => {
-    requireGhCli();
+  .option(
+    '--session',
+    'Emit the bounded session-orientation block for a SessionStart hook (boot-safe; empty when nothing high-signal)',
+  )
+  .action(async (opts: { json?: boolean; session?: boolean }) => {
+    // Session-render mode runs INSIDE a SessionStart hook and must never hard-fail
+    // the boot: skip the hard `gh` gate. A missing/unauthenticated gh then degrades
+    // to per-section `⚠ could not derive` lines via renderOrientForSession (or an
+    // omitted block), never a process.exit(1) that would surface an error banner in
+    // the consumer's session context.
+    if (!opts.session) requireGhCli();
     try {
       const { orientCommand } = await import('./commands/orient.js');
       await orientCommand(opts);

--- a/totem.config.ts
+++ b/totem.config.ts
@@ -63,6 +63,12 @@ const config: TotemConfig = {
 
   repositories: ['mmnto-ai/totem', 'mmnto-ai/totem-strategy'],
 
+  // mmnto-ai/totem#2044 (WS2 PR-3): wire the GH Project board into `totem orient`
+  // so its board / coherence-drift sections derive instead of rendering
+  // honest-absent. Both cohort repos map to org Project #1 (the Convergent Spine
+  // roadmap). `TOTEM_ORIENT_PROJECT` env still overrides at runtime.
+  orient: { projectNumber: 1 },
+
   // mmnto-ai/totem#1710: the strategy linkedIndex is auto-injected by the
   // MCP context init via `resolveStrategyRoot`. Listing it here is no
   // longer required — the resolver handles env / config / sibling /

--- a/totem.config.ts
+++ b/totem.config.ts
@@ -1,5 +1,10 @@
 import type { TotemConfig } from '@mmnto/totem';
 
+// The org-level GH Project board both cohort repos derive against (the Convergent
+// Spine roadmap = `orgs/mmnto-ai/projects/1`). Named so `totem orient`'s board wiring
+// reads by intent, not a bare literal.
+const ORIENT_PROJECT_NUMBER = 1;
+
 const config: TotemConfig = {
   targets: [
     { glob: 'packages/**/*.ts', type: 'code', strategy: 'typescript-ast' },
@@ -65,9 +70,8 @@ const config: TotemConfig = {
 
   // mmnto-ai/totem#2044 (WS2 PR-3): wire the GH Project board into `totem orient`
   // so its board / coherence-drift sections derive instead of rendering
-  // honest-absent. Both cohort repos map to org Project #1 (the Convergent Spine
-  // roadmap). `TOTEM_ORIENT_PROJECT` env still overrides at runtime.
-  orient: { projectNumber: 1 },
+  // honest-absent. `TOTEM_ORIENT_PROJECT` env still overrides at runtime.
+  orient: { projectNumber: ORIENT_PROJECT_NUMBER },
 
   // mmnto-ai/totem#1710: the strategy linkedIndex is auto-injected by the
   // MCP context init via `resolveStrategyRoot`. Listing it here is no


### PR DESCRIPTION
## What

Orient cohort distribution — **charter (A) "manual rollout"** (strategy-claude, 2026-06-01). Two parts, both reusing the single `deriveOrientReport` + `renderOrientForSession` derivation so the CLI surface, `--json`, and the in-process hook **cannot diverge**:

1. **`totem orient --session`** render mode — emits the bounded session-orientation block for a SessionStart hook to inject. Boot-safe per the SessionStart contract (lesson 8d363778): never throws or exits non-zero, emits nothing when there's no high-signal state (the hook omits the block), and skips the hard `gh` gate so a `gh`-less consumer degrades to fail-loud "⚠ could not derive" lines rather than an error banner.
2. **`CLAUDE_SESSION_START` + `GEMINI_SESSION_START`** templates now append `orient --session` **after** `describe` — additively (Tenet 13: `describe` = static identity sensor, `orient` = live in-flight sensor; append, never replace), each in its own boot-safe try/catch.

Also wires totem's own **`orient.projectNumber: 1`** (org Project #1) so the board / coherence sections derive instead of rendering honest-absent (validated: board now shows the in-flight card).

## Verification

- Full CLI suite: **2347 passed**
- `totem lint` (full-branch): **PASS, 0 errors** (17 warnings are the known changed-lines-scoping false-positive class — `toContain` in template-content tests, idiomatic boot-safe catch patterns; each mirrors a dormant pattern already in these files)
- `format:check`: clean
- Dogfood: `totem orient --session` → bounded block, exit 0, clean stderr

## Deferred (per charter, not dropped)

- Cross-repo **hook rollout** to consumer repos (totem-strategy, lc) + their `projectNumber` — the deployment of this PR, follows the merge.
- `orient --workspace` cross-repo aggregation → #2061 (after #2059).
- Versioned hook-upgrade engine → #1854. Cohort-version line → parity lane.

Part of **WS2 #2044** (PR-3 (A) totem-side). Charter: mmnto-ai/totem-strategy#438 / #482.

🤖 Generated with [Claude Code](https://claude.com/claude-code)