### PR TITLE
chore(bots): GCA + Greptile on-demand; CodeRabbit assertive (cohort #501)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,7 +4,8 @@ tone_instructions: >-
   Direct, technical. Flag real issues only. Totem is deterministic governance — Sensors not Actuators. Core engine (totem lint) is zero-LLM and offline. No statistical replacements, no coupling primitives, no cloud deps in enforcement. Tenets win.
 
 reviews:
-  profile: chill
+  # Trial: assertive cohort-wide (was chill) — mmnto-ai/totem-strategy#507 / #501. Keep until it annoys us.
+  profile: assertive
   high_level_summary: true
   high_level_summary_in_walkthrough: true
   sequence_diagrams: true

--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -8,8 +8,8 @@ code_review:
   max_review_comments: 5
   pull_request_opened:
     help: false # Don't post help message on every PR
-    summary: true # Post PR summary
-    code_review: true # GCA ignores invoke commands when disabled, so must stay enabled
+    summary: false # off — CR already summarizes; keep GCA fully silent on open (no quota for a redundant summary)
+    code_review: false # on-demand — vendor-verified that `/gemini review` still triggers when this is off (mmnto-ai/totem-strategy#501 bot-protocols)
     include_drafts: true # Review draft PRs too
 
 # File Exclusions (glob patterns)

--- a/greptile.json
+++ b/greptile.json
@@ -1,0 +1,3 @@
+{
+  "skipReview": "AUTOMATIC"
+}


### PR DESCRIPTION
## What

Brings totem's review-bot config onto the cohort **bot-stack policy** (`mmnto-ai/totem-strategy#501`, vendor-verified in bot-protocols `mmnto-ai/totem-strategy#504`): **CodeRabbit is the auto-invoked baseline; GCA + Greptile are on-demand** (opt-in per PR via `/gemini review` and `@greptileai`).

Until this lands, GCA + Greptile still auto-review every totem PR — as #2065 demonstrated (both auto-ran despite the policy).

## Changes (config-only)

- **`.gemini/config.yaml`** — `pull_request_opened.code_review: false` + `summary: false` → GCA fully silent on open; `/gemini review` still triggers (cohort vendor-verified — the old `# must stay enabled` comment was wrong and is dropped).
- **`greptile.json`** (new) — `"skipReview": "AUTOMATIC"` → Greptile on-demand; `@greptileai` still triggers.
- **`.coderabbit.yaml`** — `profile: chill` → `assertive` (trial, mirrors `mmnto-ai/totem-strategy#507`; `auto_review` stays on so CR remains the baseline).

No package code, no changeset — repo-level config only.

## Parity

The totem-side of the "bot review configs" parity dimension (raised in the #2065 disposition; tracked in the strategy parity-manifest). Mirrors what strategy shipped (`mmnto-ai/totem-strategy#507` + bot-protocols `mmnto-ai/totem-strategy#504`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
