### PR TITLE
feat(cli): totem doctor --parity sensor skeleton — parser + config-path resolver

### DIFF
--- a/packages/cli/src/commands/doctor-parity.test.ts
+++ b/packages/cli/src/commands/doctor-parity.test.ts
@@ -96,9 +96,10 @@ describe('checkParity — honest-absent', () => {
   });
 
   it('treats a config-less repo as not-configured (skip, no throw)', async () => {
-    // No totem config at all → loadConfig path is best-effort honest-absent.
-    // (resolveConfigPath may fall to the global profile; either way the field
-    // is absent, so the sensor must skip, never throw.)
+    // No totem config at all → resolveConfigPath either throws (caught,
+    // best-effort) or resolves the GLOBAL ~/.totem profile, which checkParity
+    // explicitly ignores for repo-scoping (isGlobalConfigPath). Either way the
+    // result is a deterministic skip, regardless of any global orient.parityManifest.
     const results = await checkParity(tmpDir);
     expect(results).toHaveLength(1);
     expect(results[0]!.status).toBe('skip');

--- a/packages/cli/src/commands/doctor-parity.test.ts
+++ b/packages/cli/src/commands/doctor-parity.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tests for the `totem doctor --parity` sensor skeleton
+ * (mmnto-ai/totem-strategy#448).
+ *
+ * Drives `checkParity` against real temp dirs with a YAML totem config so the
+ * config-resolution → manifest-resolution → parse → DiagnosticResult mapping is
+ * exercised end-to-end (no mocking of `loadConfig`). Each test writes a local
+ * `totem.yaml` so `resolveConfigPath` never falls through to the global
+ * `~/.totem/` profile (which would make the not-configured case nondeterministic).
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { cleanTmpDir } from '../test-utils.js';
+import { checkParity } from './doctor-parity.js';
+
+// Minimal valid totem config — `targets` is the only required array; everything
+// else defaults. `orient.parityManifest` is added per-test as needed.
+const BASE_CONFIG = `targets:
+  - glob: "**/*.ts"
+    type: code
+    strategy: typescript-ast
+`;
+
+// A small manifest mirroring the real shape (version-pinned + null source-note +
+// optional title/blocking/consumers), reused across the success-path tests.
+const VALID_MANIFEST_YAML = `schema-version: 1
+status: scaffold
+contracts:
+  - id: session-start-orientation
+    dimension: orientation
+    canonical-source: mmnto-ai/totem:packages/cli/src/commands/init-templates.ts#SessionStart
+    detection-method: SessionStart hook present
+    expected-value-or-derivation: hook managed-block matches distributed template
+    tractability: mechanical
+    tracking-issue: mmnto-ai/totem-strategy#438
+  - id: mmnto-cli-version
+    dimension: toolchain-version
+    canonical-source: mmnto-ai/totem:packages/cli/package.json#version
+    detection-method: consumer package.json caret range
+    expected-value-or-derivation: consumer pin resolves to current @mmnto/cli
+    tractability: version-pinned
+    tracking-issue: mmnto-ai/totem-strategy#482
+  - id: mcp-corpus-indexing
+    dimension: knowledge-index
+    canonical-source: null
+    source-note: consumer-local capability; no external canonical source
+    detection-method: .lancedb index present
+    expected-value-or-derivation: index present + fresh
+    tractability: mechanical
+    tracking-issue: mmnto-ai/totem#2018
+  - id: gate-config
+    dimension: enforcement
+    title: Canonical gate set
+    canonical-source: mmnto-ai/totem
+    detection-method: installed gates vs canonical gate set
+    expected-value-or-derivation: consumer installed gates == canonical
+    tractability: mechanical
+    tracking-issue: mmnto-ai/totem-strategy#482
+    blocking: false
+    consumers:
+      - mmnto-ai/totem
+`;
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-doctor-parity-'));
+});
+
+afterEach(() => {
+  cleanTmpDir(tmpDir);
+});
+
+function writeConfig(body: string): void {
+  fs.writeFileSync(path.join(tmpDir, 'totem.yaml'), body, 'utf-8');
+}
+
+function writeManifest(relPath: string, yamlText: string): void {
+  const abs = path.join(tmpDir, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, yamlText, 'utf-8');
+}
+
+describe('checkParity — honest-absent', () => {
+  it('emits exactly one skip line when orient.parityManifest is absent (no throw)', async () => {
+    writeConfig(BASE_CONFIG);
+    const results = await checkParity(tmpDir);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.status).toBe('skip');
+    expect(results[0]!.message).toContain('no parity manifest configured');
+  });
+
+  it('treats a config-less repo as not-configured (skip, no throw)', async () => {
+    // No totem config at all → loadConfig path is best-effort honest-absent.
+    // (resolveConfigPath may fall to the global profile; either way the field
+    // is absent, so the sensor must skip, never throw.)
+    const results = await checkParity(tmpDir);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.status).toBe('skip');
+  });
+});
+
+describe('checkParity — configured-but-missing', () => {
+  it('warns (no throw) when the configured manifest path does not exist', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: doctrine/parity-manifest.yaml\n`);
+    const results = await checkParity(tmpDir);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.status).toBe('warn');
+    expect(results[0]!.message).toContain('not found');
+  });
+});
+
+describe('checkParity — unparseable / unsupported-schema', () => {
+  it('warns (never crashes) on unparseable YAML', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: bad.yaml\n`);
+    writeManifest('bad.yaml', 'schema-version: 1\ncontracts: [unclosed');
+    const results = await checkParity(tmpDir);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.status).toBe('warn');
+    expect(results[0]!.message).toContain('unreadable');
+  });
+
+  it('warns (never crashes) on a Zod-invalid manifest', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: bad.yaml\n`);
+    writeManifest(
+      'bad.yaml',
+      `schema-version: 1
+status: scaffold
+contracts:
+  - id: broken
+    dimension: orientation
+    canonical-source: null
+    detection-method: x
+    tractability: mechanical
+`,
+    );
+    const results = await checkParity(tmpDir);
+    expect(results[0]!.status).toBe('warn');
+  });
+
+  it('warns and does NOT parse contracts on an unsupported schema-version', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: future.yaml\n`);
+    writeManifest(
+      'future.yaml',
+      VALID_MANIFEST_YAML.replace('schema-version: 1', 'schema-version: 2'),
+    );
+    const results = await checkParity(tmpDir);
+    expect(results).toHaveLength(1);
+    expect(results[0]!.status).toBe('warn');
+    expect(results[0]!.message).toContain('schema v2 unsupported');
+  });
+});
+
+describe('checkParity — success', () => {
+  it('emits a summary line + one skip stub per contract on a valid manifest', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: doctrine/parity-manifest.yaml\n`);
+    writeManifest('doctrine/parity-manifest.yaml', VALID_MANIFEST_YAML);
+
+    const results = await checkParity(tmpDir);
+    // 1 summary + 4 per-contract stubs.
+    expect(results).toHaveLength(5);
+
+    const summary = results[0]!;
+    expect(summary.status).toBe('pass');
+    expect(summary.message).toContain('4 contract(s) loaded');
+
+    // Per-contract lines are skip stubs (drift detection deferred — never fail).
+    const perContract = results.slice(1);
+    expect(perContract.every((r) => r.status === 'skip')).toBe(true);
+    expect(perContract.some((r) => r.name === 'Parity: mmnto-cli-version')).toBe(true);
+    expect(perContract.some((r) => r.message.includes('version-pinned'))).toBe(true);
+  });
+
+  it('never emits a fail status in the skeleton (sensor-not-gate)', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: doctrine/parity-manifest.yaml\n`);
+    writeManifest('doctrine/parity-manifest.yaml', VALID_MANIFEST_YAML);
+    const results = await checkParity(tmpDir);
+    expect(results.some((r) => r.status === 'fail')).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -45,6 +45,12 @@ export async function checkParity(cwd: string): Promise<DiagnosticResult[]> {
   // fallback in doctorCommand — surface only on a defective error object so
   // sentinels still propagate.
   let configValue: string | undefined;
+  // Relative manifest paths anchor at the config's OWN directory, not the
+  // invocation cwd, so the field resolves consistently no matter which subdir
+  // the doctor runs from. resolveConfigPath only checks cwd + the global profile
+  // today (no upward walk), so this equals cwd for the local case — the explicit
+  // anchor just keeps it correct if resolution ever changes.
+  let manifestRoot = cwd;
   try {
     const configPath = resolveConfigPath(cwd);
     // Repo-scoped by design: the manifest location is per-repo, so a config-less
@@ -55,6 +61,7 @@ export async function checkParity(cwd: string): Promise<DiagnosticResult[]> {
     if (isGlobalConfigPath(configPath)) {
       configValue = undefined;
     } else {
+      manifestRoot = path.dirname(configPath);
       const config = await loadConfig(configPath);
       configValue = config.orient?.parityManifest;
     }
@@ -66,7 +73,7 @@ export async function checkParity(cwd: string): Promise<DiagnosticResult[]> {
     configValue = undefined;
   }
 
-  const result = loadParityManifest(configValue, cwd);
+  const result = loadParityManifest(configValue, manifestRoot);
 
   switch (result.status) {
     case 'not-configured':

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -1,0 +1,196 @@
+/**
+ * Parity-drift sensor for `totem doctor --parity` (mmnto-ai/totem-strategy#448).
+ *
+ * SKELETON (first slice): resolve the consumer-configured `orient.parityManifest`
+ * config-path → parse + Zod-validate the strategy-owned `parity-manifest.yaml`
+ * → emit `DiagnosticResult`s. Per-contract drift detection is OUT OF SCOPE for
+ * this skeleton (it needs populated deps contracts + per-dimension semantics);
+ * each per-contract line is a `skip` info stub here.
+ *
+ * Sensor-not-gate: this surface emits `skip`/`warn`/`pass` only — it never
+ * produces a `fail` in the skeleton. The `--strict` exit-code decision lives at
+ * the CLI edge (reusing the existing doctor `--strict` logic); a `fail` only
+ * becomes possible once per-contract drift detection lands. The `blocking`
+ * contract field is parsed but unused here (per-contract gating is post-skeleton).
+ *
+ * Honest-absent (Tenet 14): unconfigured → exactly one `skip` line; never an
+ * error. Configured-but-missing / unparseable / unsupported-schema → `warn`,
+ * never a crash (mirrors the `findStaleRules` best-effort fallback idiom in
+ * doctor.ts). Dynamic-import `@mmnto/totem` to keep core off the CLI cold-start
+ * graph, matching the other doctor checks.
+ */
+
+import * as path from 'node:path';
+
+import type { DiagnosticResult } from './doctor.js';
+
+const CHECK_NAME = 'Parity';
+
+/**
+ * Resolve, parse, and report the parity manifest as `DiagnosticResult`s.
+ *
+ * Returns an ARRAY: the first entry is always the section summary line; in the
+ * `ok` path it is followed by one `skip` info stub per contract (the
+ * per-contract drift verdict is deferred). All other paths return a single
+ * summary entry.
+ *
+ * @param cwd The directory to resolve config + manifest against (config/repo root).
+ */
+export async function checkParity(cwd: string): Promise<DiagnosticResult[]> {
+  const { loadConfig, resolveConfigPath } = await import('../utils.js');
+  const { loadParityManifest, SUPPORTED_PARITY_SCHEMA_VERSION } = await import('@mmnto/totem');
+
+  // Read the config best-effort: a missing/corrupt config is the honest-absent
+  // path (no parity manifest configured), not a crash. Mirrors the config-load
+  // fallback in doctorCommand — surface only on a defective error object so
+  // sentinels still propagate.
+  let configValue: string | undefined;
+  try {
+    const configPath = resolveConfigPath(cwd);
+    const config = await loadConfig(configPath);
+    configValue = config.orient?.parityManifest;
+    // totem-context: a missing/corrupt totem config is the honest-absent path (treated as "no parity manifest configured"), not a sensor failure — the doctor runs against config-less repos by design.
+  } catch (err) {
+    if (err instanceof Error && err.message.length === 0) {
+      throw err;
+    }
+    configValue = undefined;
+  }
+
+  const result = loadParityManifest(configValue, cwd);
+
+  switch (result.status) {
+    case 'not-configured':
+      // Honest-absent: exactly one skip line. Not a failure.
+      return [
+        {
+          name: CHECK_NAME,
+          status: 'skip',
+          message: 'no parity manifest configured',
+        },
+      ];
+
+    case 'not-found':
+      return [
+        {
+          name: CHECK_NAME,
+          status: 'warn',
+          message: `parity manifest not found at ${rel(cwd, result.path)}`,
+          remediation: 'Fix orient.parityManifest in your totem config to point at the manifest.',
+        },
+      ];
+
+    case 'unparseable':
+      return [
+        {
+          name: CHECK_NAME,
+          status: 'warn',
+          message: `parity manifest unreadable at ${rel(cwd, result.path)}: ${result.reason}`,
+          remediation: 'Fix the manifest YAML / schema, then re-run totem doctor --parity.',
+        },
+      ];
+
+    case 'unsupported-schema':
+      return [
+        {
+          name: CHECK_NAME,
+          status: 'warn',
+          message: `parity manifest schema v${result.schemaVersion} unsupported (this doctor supports v${SUPPORTED_PARITY_SCHEMA_VERSION})`,
+          remediation: 'Upgrade @mmnto/cli or align the manifest schema-version.',
+        },
+      ];
+
+    case 'ok': {
+      const { contracts } = result.manifest;
+      const summary: DiagnosticResult = {
+        name: CHECK_NAME,
+        status: 'pass',
+        message: `parity manifest: ${contracts.length} contract(s) loaded`,
+      };
+      // Per-contract skeleton stubs. Drift detection is deferred — each line is
+      // an info `skip` carrying the contract id + dimension + tractability so
+      // the surface is shaped for the follow-on without asserting a verdict.
+      const perContract: DiagnosticResult[] = contracts.map((c) => ({
+        name: `Parity: ${c.id}`,
+        status: 'skip',
+        message: `${c.dimension} (${c.tractability}) — drift detection not yet implemented`,
+      }));
+      return [summary, ...perContract];
+    }
+  }
+}
+
+/** Repo-root-relative display path; falls back to the absolute path. */
+function rel(cwd: string, target: string): string {
+  const r = path.relative(cwd, target);
+  return r.length > 0 ? r : target;
+}
+
+// ─── CLI entry ──────────────────────────────────────────
+
+const TAG = 'Parity';
+
+export interface ParityCliOptions {
+  /**
+   * Strict mode (Proposal 273 / 279 `--strict` semantics): promote any `fail`
+   * DiagnosticResult to a gate failure (non-zero exit) via a thrown TotemError.
+   *
+   * In the SKELETON this never fires — `checkParity` emits only `skip`/`warn`/
+   * `pass`, never `fail` (per-contract drift detection is deferred). The wiring
+   * is present so `--strict` composes once a `fail` becomes possible. Default
+   * (non-strict) is sensor-not-gate: `warn`s report and exit 0.
+   */
+  strict?: boolean;
+  /** Test seam — production callers omit and the command uses `process.cwd()`. */
+  cwdForTest?: string;
+}
+
+/**
+ * CLI entry — runs `checkParity`, renders each `DiagnosticResult`, and throws a
+ * `TotemError` on `fail` under `--strict` so the top-level `handleError`
+ * produces the non-zero exit code (no direct `process.exit` per AGENTS.md).
+ */
+export async function doctorParityCliCommand(options: ParityCliOptions = {}): Promise<void> {
+  const { TotemError } = await import('@mmnto/totem');
+  const {
+    bold,
+    errorColor,
+    log,
+    success: successColor,
+    warn: warnColor,
+  } = await import('../ui.js');
+
+  const cwd = options.cwdForTest ?? process.cwd();
+  const results = await checkParity(cwd);
+
+  for (const r of results) {
+    switch (r.status) {
+      case 'pass':
+        log.success(TAG, `${successColor(bold('PASS'))} — ${r.message}`);
+        break;
+      case 'warn':
+        log.warn(TAG, `${warnColor(bold('WARN'))} — ${r.message}`);
+        if (r.remediation) log.dim(TAG, `→ ${r.remediation}`);
+        break;
+      case 'fail':
+        log.error(TAG, `${errorColor(bold('FAIL'))} — ${r.message}`);
+        if (r.remediation) log.dim(TAG, `→ ${r.remediation}`);
+        break;
+      case 'skip':
+        log.dim(TAG, `SKIP — ${r.message}`);
+        break;
+    }
+  }
+
+  // Sensor-not-gate: only `--strict` promotes `fail` to a non-zero exit. The
+  // skeleton never emits `fail`, so this is inert until per-contract drift
+  // detection lands; the wiring composes ahead of that follow-on.
+  const failures = results.filter((r) => r.status === 'fail');
+  if (options.strict && failures.length > 0) {
+    throw new TotemError(
+      'PARITY_DRIFT_DETECTED',
+      `${failures.length} parity contract(s) reported drift under --strict.`,
+      'Reconcile each failing contract against its canonical source, then re-run totem doctor --parity --strict.',
+    );
+  }
+}

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -200,7 +200,9 @@ export async function doctorParityCliCommand(options: ParityCliOptions = {}): Pr
         if (r.remediation) log.dim(TAG, `→ ${render(r.remediation)}`);
         break;
       case 'fail':
-        log.error(TAG, `${errorColor(bold('FAIL'))} — ${render(r.message)}`);
+        // Mandated 'Totem Error' tag (packages/cli convention) — marks internal
+        // error output, distinct from the contextual TAG used for pass/warn/skip.
+        log.error('Totem Error', `${errorColor(bold('FAIL'))} — ${render(r.message)}`);
         if (r.remediation) log.dim(TAG, `→ ${render(r.remediation)}`);
         break;
       case 'skip':

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -37,7 +37,7 @@ const CHECK_NAME = 'Parity';
  * @param cwd The directory to resolve config + manifest against (config/repo root).
  */
 export async function checkParity(cwd: string): Promise<DiagnosticResult[]> {
-  const { loadConfig, resolveConfigPath } = await import('../utils.js');
+  const { loadConfig, resolveConfigPath, isGlobalConfigPath } = await import('../utils.js');
   const { loadParityManifest, SUPPORTED_PARITY_SCHEMA_VERSION } = await import('@mmnto/totem');
 
   // Read the config best-effort: a missing/corrupt config is the honest-absent
@@ -47,8 +47,17 @@ export async function checkParity(cwd: string): Promise<DiagnosticResult[]> {
   let configValue: string | undefined;
   try {
     const configPath = resolveConfigPath(cwd);
-    const config = await loadConfig(configPath);
-    configValue = config.orient?.parityManifest;
+    // Repo-scoped by design: the manifest location is per-repo, so a config-less
+    // repo that only resolves the GLOBAL ~/.totem profile is honest-absent for
+    // parity. Never leak a global orient.parityManifest into a repo-less result
+    // (that would make the sensor machine-dependent) — only a repo-local config
+    // contributes the field.
+    if (isGlobalConfigPath(configPath)) {
+      configValue = undefined;
+    } else {
+      const config = await loadConfig(configPath);
+      configValue = config.orient?.parityManifest;
+    }
     // totem-context: a missing/corrupt totem config is the honest-absent path (treated as "no parity manifest configured"), not a sensor failure — the doctor runs against config-less repos by design.
   } catch (err) {
     if (err instanceof Error && err.message.length === 0) {
@@ -128,7 +137,8 @@ function rel(cwd: string, target: string): string {
 
 // ─── CLI entry ──────────────────────────────────────────
 
-const TAG = 'Parity';
+// Same value as CHECK_NAME — aliased (not re-literal'd) so the two can't drift.
+const TAG = CHECK_NAME;
 
 export interface ParityCliOptions {
   /**
@@ -151,7 +161,7 @@ export interface ParityCliOptions {
  * produces the non-zero exit code (no direct `process.exit` per AGENTS.md).
  */
 export async function doctorParityCliCommand(options: ParityCliOptions = {}): Promise<void> {
-  const { TotemError } = await import('@mmnto/totem');
+  const { TotemError, sanitizeForTerminal } = await import('@mmnto/totem');
   const {
     bold,
     errorColor,
@@ -160,24 +170,34 @@ export async function doctorParityCliCommand(options: ParityCliOptions = {}): Pr
     warn: warnColor,
   } = await import('../ui.js');
 
+  // Manifest-derived text (paths, parse reasons, contract metadata) is sourced
+  // from repo-controlled files; sanitize + flatten before logging so embedded
+  // ANSI / newlines can't forge extra doctor lines (matches checkStrategyRoot
+  // in doctor.ts).
+  const render = (text: string): string =>
+    sanitizeForTerminal(text)
+      .replace(/[\t\n]+/g, ' ')
+      .replace(/ {2,}/g, ' ')
+      .trim();
+
   const cwd = options.cwdForTest ?? process.cwd();
   const results = await checkParity(cwd);
 
   for (const r of results) {
     switch (r.status) {
       case 'pass':
-        log.success(TAG, `${successColor(bold('PASS'))} — ${r.message}`);
+        log.success(TAG, `${successColor(bold('PASS'))} — ${render(r.message)}`);
         break;
       case 'warn':
-        log.warn(TAG, `${warnColor(bold('WARN'))} — ${r.message}`);
-        if (r.remediation) log.dim(TAG, `→ ${r.remediation}`);
+        log.warn(TAG, `${warnColor(bold('WARN'))} — ${render(r.message)}`);
+        if (r.remediation) log.dim(TAG, `→ ${render(r.remediation)}`);
         break;
       case 'fail':
-        log.error(TAG, `${errorColor(bold('FAIL'))} — ${r.message}`);
-        if (r.remediation) log.dim(TAG, `→ ${r.remediation}`);
+        log.error(TAG, `${errorColor(bold('FAIL'))} — ${render(r.message)}`);
+        if (r.remediation) log.dim(TAG, `→ ${render(r.remediation)}`);
         break;
       case 'skip':
-        log.dim(TAG, `SKIP — ${r.message}`);
+        log.dim(TAG, `SKIP — ${render(r.message)}`);
         break;
     }
   }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1072,6 +1072,13 @@ program
       parity?: boolean;
     }) => {
       try {
+        if (opts.claimDiscipline && opts.parity) {
+          const { TotemConfigError } = await import('@mmnto/totem');
+          throw new TotemConfigError(
+            'Cannot combine --claim-discipline with --parity.',
+            'Choose exactly one specialized doctor mode.',
+          );
+        }
         if (opts.claimDiscipline) {
           const { doctorClaimDisciplineCliCommand } =
             await import('./commands/doctor-claim-discipline.js');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1059,12 +1059,17 @@ program
     '--scope-to-diff',
     'Narrow --claim-discipline scan to files in the current push diff (mmnto-ai/totem#2002 — prevents pre-existing standing-gate warnings from firing on unrelated diffs)',
   )
+  .option(
+    '--parity',
+    'Run only the parity-drift sensor against the cohort parity manifest (mmnto-ai/totem-strategy#448)',
+  )
   .action(
     async (opts: {
       pr?: boolean;
       strict?: boolean;
       claimDiscipline?: boolean;
       scopeToDiff?: boolean;
+      parity?: boolean;
     }) => {
       try {
         if (opts.claimDiscipline) {
@@ -1074,6 +1079,11 @@ program
             strict: opts.strict,
             scopeToDiff: opts.scopeToDiff,
           });
+          return;
+        }
+        if (opts.parity) {
+          const { doctorParityCliCommand } = await import('./commands/doctor-parity.js');
+          await doctorParityCliCommand({ strict: opts.strict });
           return;
         }
         const { doctorCommand } = await import('./commands/doctor.js');

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -246,6 +246,17 @@ export type ConfigTier = z.infer<typeof ConfigTierSchema>;
 export const OrientConfigSchema = z.object({
   /** GH Project number for the in-flight board section (e.g. 1). Optional. */
   projectNumber: z.number().int().positive().optional(),
+  /**
+   * Config-path to the cohort parity manifest (`parity-manifest.yaml`) the
+   * `totem doctor --parity` sensor parses for cross-repo drift
+   * (mmnto-ai/totem-strategy#448). Mirrors `projectNumber` as the one
+   * consumer-specific value the sensor cannot derive from the repo alone —
+   * the manifest is strategy-owned, so its location is per-consumer. Resolved
+   * relative to the config/repo root by `resolveParityManifestPath`. OPTIONAL:
+   * when unset, the sensor renders an honest "no parity manifest configured"
+   * skip — never an error (Tenet 14, honest-absent).
+   */
+  parityManifest: z.string().optional(),
 });
 
 /**

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -38,7 +38,8 @@ export type TotemErrorCode =
   | 'SESSION_ID_READ_FAILED'
   | 'BADGE_VERIFICATION_FAILED'
   | 'CLAIM_DISCIPLINE_FAILED'
-  | 'GATE_INVALID';
+  | 'GATE_INVALID'
+  | 'PARITY_DRIFT_DETECTED';
 
 export class TotemError extends Error {
   readonly code: TotemErrorCode;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -534,6 +534,23 @@ export { resolveSubstratePaths } from './substrate-resolver.js';
 export type { OrchestrationPaths, SelfAgentResolution } from './orchestration-resolver.js';
 export { resolveOrchestrationPaths, resolveSelfAgents } from './orchestration-resolver.js';
 
+// Parity-manifest parser + config-path resolver (mmnto-ai/totem-strategy#448)
+export type {
+  ParityContract,
+  ParityManifest,
+  ParityManifestLoadResult,
+  ParityManifestParseResult,
+  ParityManifestPathStatus,
+  ParityTractability,
+} from './parity-manifest.js';
+export {
+  loadParityManifest,
+  ParityTractabilitySchema,
+  parseParityManifest,
+  resolveParityManifestPath,
+  SUPPORTED_PARITY_SCHEMA_VERSION,
+} from './parity-manifest.js';
+
 // Semgrep adapter (Pipeline 4 — import rules from Semgrep YAML)
 export type { SemgrepImportResult } from './semgrep-adapter.js';
 export { parseSemgrepRules } from './semgrep-adapter.js';

--- a/packages/core/src/parity-manifest.test.ts
+++ b/packages/core/src/parity-manifest.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Tests for the parity-manifest parser + config-path resolver
+ * (mmnto-ai/totem-strategy#448).
+ *
+ * The resolver is filesystem-driven, so tests construct real temp files. The
+ * parser is pure-text and exercised directly. The round-trip fixture is built
+ * from the real `doctrine/parity-manifest.yaml` shape — including a
+ * `version-pinned` contract, a `null` canonical-source with a `source-note`,
+ * and an entry carrying the optional `title`/`blocking`/`consumers` fields.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  loadParityManifest,
+  parseParityManifest,
+  resolveParityManifestPath,
+  SUPPORTED_PARITY_SCHEMA_VERSION,
+} from './parity-manifest.js';
+import { cleanTmpDir } from './test-utils.js';
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-parity-manifest-'));
+});
+
+afterEach(() => {
+  cleanTmpDir(tmpRoot);
+});
+
+// A fixture mirroring the real parity-manifest.yaml shape: a `mechanical`
+// contract with a repo:path canonical-source, a `version-pinned` contract, a
+// `null` canonical-source + `source-note`, and one entry carrying the optional
+// `title`/`blocking`/`consumers` fields.
+const VALID_MANIFEST_YAML = `schema-version: 1
+status: scaffold
+
+contracts:
+  - id: session-start-orientation
+    dimension: orientation
+    canonical-source: mmnto-ai/totem:packages/cli/src/commands/init-templates.ts#SessionStart
+    detection-method: SessionStart hook present and invokes \`totem orient --session\`
+    expected-value-or-derivation: hook managed-block matches distributed template
+    tractability: mechanical
+    tracking-issue: mmnto-ai/totem-strategy#438
+
+  - id: mmnto-cli-version
+    dimension: toolchain-version
+    canonical-source: mmnto-ai/totem:packages/cli/package.json#version
+    detection-method: consumer package.json caret range + resolved install
+    expected-value-or-derivation: consumer pin resolves to the current published @mmnto/cli
+    tractability: version-pinned
+    tracking-issue: mmnto-ai/totem-strategy#482
+
+  - id: mcp-corpus-indexing
+    dimension: knowledge-index
+    canonical-source: null
+    source-note: consumer-local capability; no external canonical source
+    detection-method: .lancedb index present + search responds
+    expected-value-or-derivation: index present + fresh + search responsive
+    tractability: mechanical
+    tracking-issue: mmnto-ai/totem#2018
+
+  - id: gate-config
+    dimension: enforcement
+    title: Canonical gate set
+    canonical-source: mmnto-ai/totem
+    detection-method: installed gates vs the expected canonical gate set
+    expected-value-or-derivation: consumer installed gates == canonical gate set
+    tractability: mechanical
+    tracking-issue: mmnto-ai/totem-strategy#482
+    blocking: false
+    consumers:
+      - mmnto-ai/totem
+      - mmnto-ai/totem-strategy
+`;
+
+// ─── resolveParityManifestPath ──────────────────────────
+
+describe('resolveParityManifestPath', () => {
+  it('returns not-configured when the config value is undefined (honest-absent, no throw)', () => {
+    expect(resolveParityManifestPath(undefined, tmpRoot)).toEqual({ status: 'not-configured' });
+  });
+
+  it('returns not-configured for a whitespace-only config value', () => {
+    expect(resolveParityManifestPath('   ', tmpRoot)).toEqual({ status: 'not-configured' });
+  });
+
+  it('returns not-found (distinct signal) when configured path does not exist', () => {
+    const result = resolveParityManifestPath('does/not/exist.yaml', tmpRoot);
+    expect(result.status).toBe('not-found');
+    if (result.status === 'not-found') {
+      expect(result.path).toBe(path.normalize(path.join(tmpRoot, 'does/not/exist.yaml')));
+    }
+  });
+
+  it('resolves a relative path against the config/repo root', () => {
+    const rel = 'doctrine/parity-manifest.yaml';
+    const abs = path.join(tmpRoot, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, VALID_MANIFEST_YAML, 'utf-8');
+
+    const result = resolveParityManifestPath(rel, tmpRoot);
+    expect(result.status).toBe('resolved');
+    if (result.status === 'resolved') {
+      expect(result.path).toBe(path.normalize(abs));
+    }
+  });
+
+  it('honors an absolute path verbatim', () => {
+    const abs = path.join(tmpRoot, 'manifest.yaml');
+    fs.writeFileSync(abs, VALID_MANIFEST_YAML, 'utf-8');
+    const result = resolveParityManifestPath(abs, tmpRoot);
+    expect(result.status).toBe('resolved');
+    if (result.status === 'resolved') {
+      expect(result.path).toBe(path.normalize(abs));
+    }
+  });
+
+  it('returns not-found (not resolved) when the path points at a directory', () => {
+    const dir = path.join(tmpRoot, 'a-dir');
+    fs.mkdirSync(dir, { recursive: true });
+    expect(resolveParityManifestPath('a-dir', tmpRoot).status).toBe('not-found');
+  });
+});
+
+// ─── parseParityManifest ────────────────────────────────
+
+describe('parseParityManifest', () => {
+  it('round-trips the full manifest shape, mapping kebab-case → camelCase', () => {
+    const result = parseParityManifest(VALID_MANIFEST_YAML);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+
+    const { manifest } = result;
+    expect(manifest.schemaVersion).toBe(SUPPORTED_PARITY_SCHEMA_VERSION);
+    expect(manifest.status).toBe('scaffold');
+    expect(manifest.contracts).toHaveLength(4);
+
+    // mechanical contract with a repo:path canonical-source.
+    const orientation = manifest.contracts[0]!;
+    expect(orientation.id).toBe('session-start-orientation');
+    expect(orientation.dimension).toBe('orientation');
+    expect(orientation.canonicalSource).toBe(
+      'mmnto-ai/totem:packages/cli/src/commands/init-templates.ts#SessionStart',
+    );
+    expect(orientation.detectionMethod).toContain('SessionStart hook present');
+    expect(orientation.expectedValueOrDerivation).toContain('managed-block');
+    expect(orientation.tractability).toBe('mechanical');
+    expect(orientation.trackingIssue).toBe('mmnto-ai/totem-strategy#438');
+
+    // version-pinned contract.
+    const cliVersion = manifest.contracts[1]!;
+    expect(cliVersion.id).toBe('mmnto-cli-version');
+    expect(cliVersion.tractability).toBe('version-pinned');
+
+    // null canonical-source + source-note.
+    const corpus = manifest.contracts[2]!;
+    expect(corpus.canonicalSource).toBeNull();
+    expect(corpus.sourceNote).toBe('consumer-local capability; no external canonical source');
+
+    // title / blocking / consumers optional fields.
+    const gate = manifest.contracts[3]!;
+    expect(gate.title).toBe('Canonical gate set');
+    expect(gate.blocking).toBe(false);
+    expect(gate.consumers).toEqual(['mmnto-ai/totem', 'mmnto-ai/totem-strategy']);
+  });
+
+  it('omits optional fields that are absent (no undefined keys leak through)', () => {
+    const result = parseParityManifest(VALID_MANIFEST_YAML);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    const orientation = result.manifest.contracts[0]!;
+    expect('sourceNote' in orientation).toBe(false);
+    expect('title' in orientation).toBe(false);
+    expect('blocking' in orientation).toBe(false);
+    expect('consumers' in orientation).toBe(false);
+  });
+
+  it('returns unparseable on invalid YAML (no throw)', () => {
+    const result = parseParityManifest('schema-version: 1\ncontracts: [unclosed');
+    expect(result.status).toBe('unparseable');
+  });
+
+  it('returns unparseable on a Zod-invalid contract (missing required field)', () => {
+    const bad = `schema-version: 1
+status: scaffold
+contracts:
+  - id: broken
+    dimension: orientation
+    canonical-source: null
+    detection-method: something
+    tractability: mechanical
+`; // missing expected-value-or-derivation + tracking-issue
+    const result = parseParityManifest(bad);
+    expect(result.status).toBe('unparseable');
+  });
+
+  it('returns unparseable on an invalid tractability claim-class', () => {
+    const bad = VALID_MANIFEST_YAML.replace('tractability: mechanical', 'tractability: bogus');
+    const result = parseParityManifest(bad);
+    expect(result.status).toBe('unparseable');
+  });
+
+  it('does NOT parse contracts when schema-version is unsupported', () => {
+    const future = VALID_MANIFEST_YAML.replace('schema-version: 1', 'schema-version: 2');
+    const result = parseParityManifest(future);
+    expect(result.status).toBe('unsupported-schema');
+    if (result.status === 'unsupported-schema') {
+      expect(result.schemaVersion).toBe(2);
+    }
+    // The discriminated union has no `manifest` on the unsupported branch.
+    expect('manifest' in result).toBe(false);
+  });
+
+  it('returns unparseable when schema-version is missing entirely', () => {
+    const noVersion = VALID_MANIFEST_YAML.replace('schema-version: 1\n', '');
+    expect(parseParityManifest(noVersion).status).toBe('unparseable');
+  });
+});
+
+// ─── loadParityManifest (resolve + read + parse) ────────
+
+describe('loadParityManifest', () => {
+  it('returns not-configured when unset', () => {
+    expect(loadParityManifest(undefined, tmpRoot)).toEqual({ status: 'not-configured' });
+  });
+
+  it('returns not-found when configured path is missing', () => {
+    const result = loadParityManifest('missing.yaml', tmpRoot);
+    expect(result.status).toBe('not-found');
+  });
+
+  it('loads + parses a valid manifest end-to-end', () => {
+    const rel = 'parity-manifest.yaml';
+    fs.writeFileSync(path.join(tmpRoot, rel), VALID_MANIFEST_YAML, 'utf-8');
+    const result = loadParityManifest(rel, tmpRoot);
+    expect(result.status).toBe('ok');
+    if (result.status === 'ok') {
+      expect(result.manifest.contracts).toHaveLength(4);
+      expect(result.path).toBe(path.normalize(path.join(tmpRoot, rel)));
+    }
+  });
+
+  it('surfaces unsupported-schema with the offending version + path', () => {
+    const rel = 'parity-manifest.yaml';
+    fs.writeFileSync(
+      path.join(tmpRoot, rel),
+      VALID_MANIFEST_YAML.replace('schema-version: 1', 'schema-version: 99'),
+      'utf-8',
+    );
+    const result = loadParityManifest(rel, tmpRoot);
+    expect(result.status).toBe('unsupported-schema');
+    if (result.status === 'unsupported-schema') {
+      expect(result.schemaVersion).toBe(99);
+    }
+  });
+
+  it('degrades unparseable YAML to a warn-class signal (never throws)', () => {
+    const rel = 'parity-manifest.yaml';
+    fs.writeFileSync(path.join(tmpRoot, rel), 'schema-version: 1\ncontracts: [oops', 'utf-8');
+    const result = loadParityManifest(rel, tmpRoot);
+    expect(result.status).toBe('unparseable');
+  });
+});

--- a/packages/core/src/parity-manifest.ts
+++ b/packages/core/src/parity-manifest.ts
@@ -175,9 +175,9 @@ export function resolveParityManifestPath(
   }
 
   const trimmed = configValue.trim();
-  const absolute = path.isAbsolute(trimmed)
-    ? path.normalize(trimmed)
-    : path.normalize(path.join(root, trimmed));
+  // path.resolve (not join) so a relative `root` still yields an ABSOLUTE path —
+  // the not-found / resolved branches document `path` as absolute.
+  const absolute = path.isAbsolute(trimmed) ? path.normalize(trimmed) : path.resolve(root, trimmed);
 
   if (!fileExists(absolute)) {
     return { status: 'not-found', path: absolute };

--- a/packages/core/src/parity-manifest.ts
+++ b/packages/core/src/parity-manifest.ts
@@ -240,19 +240,18 @@ export function parseParityManifest(yamlText: string): ParityManifestParseResult
   }
 
   // ── schema-version gate (BEFORE full validation) ──
-  // Read the version with a minimal probe so an unsupported version short-
-  // circuits before the v1-shaped contract schema rejects an incompatible
-  // future shape with a misleading error.
-  if (!doc || typeof doc !== 'object') {
-    return { status: 'unparseable', reason: 'Manifest is not a YAML mapping' };
-  }
-  const rawVersion = (doc as Record<string, unknown>)['schema-version'];
-  if (typeof rawVersion !== 'number') {
+  // Probe `schema-version` with a minimal Zod schema (NOT a type assertion) so
+  // an unsupported version short-circuits before the v1-shaped contract schema
+  // rejects an incompatible future shape with a misleading error. A non-mapping
+  // doc or a missing / non-numeric version fails the probe → unparseable.
+  const versionProbe = z.object({ 'schema-version': z.number() }).safeParse(doc);
+  if (!versionProbe.success) {
     return {
       status: 'unparseable',
-      reason: 'Manifest is missing a numeric `schema-version`',
+      reason: 'Manifest is not a mapping with a numeric `schema-version`',
     };
   }
+  const rawVersion = versionProbe.data['schema-version'];
   if (rawVersion !== SUPPORTED_PARITY_SCHEMA_VERSION) {
     return { status: 'unsupported-schema', schemaVersion: rawVersion };
   }

--- a/packages/core/src/parity-manifest.ts
+++ b/packages/core/src/parity-manifest.ts
@@ -1,0 +1,343 @@
+/**
+ * Parity-manifest parser + config-path resolver (mmnto-ai/totem-strategy#448).
+ *
+ * The strategy repo owns `doctrine/parity-manifest.yaml` — the canonical,
+ * machine-readable enumeration of cohort parity dimensions the `totem doctor
+ * --parity` sensor checks for drift. This module is the SKELETON foundation:
+ * it resolves the consumer-configured config-path to the manifest, parses +
+ * Zod-validates the manifest at the system boundary, and maps the YAML
+ * kebab-case keys to camelCase type fields. Per-contract drift detection
+ * (per-dimension semantics against populated deps contracts) is OUT OF SCOPE
+ * for this skeleton and lives in a follow-on.
+ *
+ * Design invariants:
+ *   - **Honest-absent (Tenet 14):** absence is never an error. Unconfigured →
+ *     a `not-configured` signal; configured-but-missing → a distinct
+ *     `not-found` signal. The resolver and parser NEVER throw for absence.
+ *   - **Zod at the boundary only:** the manifest is untrusted on-disk input;
+ *     Zod validates it once at the parse boundary, then callers work with
+ *     typed values.
+ *   - **schema-version gate:** the supported schema version is `1`. An
+ *     unsupported version does NOT parse contracts — the parser returns an
+ *     `unsupported-schema` signal so the doctor can refuse an incompatible
+ *     future shape (per the manifest's own header contract).
+ *   - **Pure:** no caching, no logging, no process state. Each call reads from
+ *     scratch.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { parse as parseYaml } from 'yaml';
+import { z } from 'zod';
+
+// ─── Constants ──────────────────────────────────────────
+
+/**
+ * The single parity-manifest schema version this doctor build understands.
+ * The manifest carries `schema-version: 1` as top-level lifecycle DATA so the
+ * doctor can refuse to parse an incompatible future shape rather than
+ * silently misread it. Bump in lockstep with a schema migration.
+ */
+export const SUPPORTED_PARITY_SCHEMA_VERSION = 1;
+
+// ─── Tractability claim-class ───────────────────────────
+
+/**
+ * Tractability bounds what the doctor may assert about a contract (the
+ * honest-absent rule):
+ *   - `mechanical`         file-content / structural equality; doctor may
+ *                          pass/warn/fail.
+ *   - `version-pinned`     consumer pins a canonical version/SHA; doctor checks
+ *                          pin currency only, never semantic content.
+ *   - `manual-attestation` genuinely semantic, no mechanical sensor; doctor
+ *                          surfaces staleness only, NEVER fails.
+ */
+export const ParityTractabilitySchema = z.enum([
+  'mechanical',
+  'version-pinned',
+  'manual-attestation',
+]);
+export type ParityTractability = z.infer<typeof ParityTractabilitySchema>;
+
+// ─── Contract + manifest types ──────────────────────────
+
+/**
+ * Internal Zod schema for one raw manifest contract entry, keyed by the YAML
+ * kebab-case field names. Mapped to the camelCase `ParityContract` after
+ * validation. `.passthrough()` is intentionally NOT used — unknown keys are
+ * dropped rather than carried, keeping the parsed shape bounded.
+ *
+ * `canonical-source` is `string | null` (null = no external canonical source);
+ * it is the ONLY ref the resolver will ever touch. `source-note` is a
+ * human-only context field and is NEVER parsed as a ref (per the schema
+ * refinement in the manifest header).
+ */
+const RawParityContractSchema = z.object({
+  id: z.string(),
+  dimension: z.string(),
+  'canonical-source': z.string().nullable(),
+  'source-note': z.string().optional(),
+  'detection-method': z.string(),
+  'expected-value-or-derivation': z.string(),
+  tractability: ParityTractabilitySchema,
+  'tracking-issue': z.string(),
+  // Optional schema-against fields raised by totem-claude per the manifest
+  // header (raised AGAINST the schema rather than diverging silently).
+  title: z.string().optional(),
+  blocking: z.boolean().optional(),
+  consumers: z.array(z.string()).optional(),
+});
+
+/**
+ * Internal Zod schema for the top-level manifest document. `schema-version`
+ * and `status` are lifecycle DATA the doctor reads before trusting the
+ * contracts array.
+ */
+const RawParityManifestSchema = z.object({
+  'schema-version': z.number(),
+  status: z.string(),
+  contracts: z.array(RawParityContractSchema),
+});
+
+/**
+ * One parsed parity contract — the camelCase public shape. Mirrors the #508
+ * manifest schema exactly. `blocking` is parsed but UNUSED in the skeleton
+ * (per-contract gating is post-skeleton). `consumers` (absent = applies to all
+ * cohort repos) supports ADR-102 per-consumer applicability so the doctor can
+ * later distinguish drift from cohort-permits-absence.
+ */
+export interface ParityContract {
+  id: string;
+  dimension: string;
+  /** `null` = no external canonical source. The ONLY ref the resolver touches. */
+  canonicalSource: string | null;
+  /** Human-only context for `canonicalSource`. NEVER parsed as a ref. */
+  sourceNote?: string;
+  detectionMethod: string;
+  expectedValueOrDerivation: string;
+  tractability: ParityTractability;
+  trackingIssue: string;
+  /** Optional human-readable title. */
+  title?: string;
+  /**
+   * Optional doctor exit-code policy flag. Parsed but UNUSED in the skeleton —
+   * per-contract gating is deferred to a follow-on.
+   */
+  blocking?: boolean;
+  /**
+   * Optional cohort applicability (which repos carry this contract). Absent =
+   * applies to all cohort repos (ADR-102 per-consumer applicability).
+   */
+  consumers?: string[];
+}
+
+/** A fully parsed + validated parity manifest. */
+export interface ParityManifest {
+  schemaVersion: number;
+  status: string;
+  contracts: ParityContract[];
+}
+
+// ─── Config-path resolution ─────────────────────────────
+
+/**
+ * Honest-absent resolver outcome (discriminated union):
+ *   - `not-configured` — no `orient.parityManifest` set. Sensor → `skip`.
+ *   - `not-found`      — configured, but no file at the resolved path. Sensor
+ *                        → `warn` (distinct, actionable).
+ *   - `resolved`       — a file exists at `path` (absolute).
+ *
+ * Resolution NEVER throws for absence — both absent states are first-class
+ * return values, not exceptions.
+ */
+export type ParityManifestPathStatus =
+  | { status: 'not-configured' }
+  | { status: 'not-found'; path: string }
+  | { status: 'resolved'; path: string };
+
+/**
+ * Resolve the configured `orient.parityManifest` config-path to an absolute
+ * manifest path. Relative values anchor at `root` (the config/repo root);
+ * absolute values are normalized as-is. Mirrors `resolveStrategyRoot`'s
+ * relative-anchoring behavior so a deep cwd doesn't mis-anchor the value.
+ *
+ * @param configValue The raw `orient.parityManifest` config string (or undefined).
+ * @param root        The config/repo root to anchor relative values against.
+ */
+export function resolveParityManifestPath(
+  configValue: string | undefined,
+  root: string,
+): ParityManifestPathStatus {
+  // Honest-absent: unset (or whitespace-only) → not configured, not an error.
+  if (typeof configValue !== 'string' || configValue.trim().length === 0) {
+    return { status: 'not-configured' };
+  }
+
+  const trimmed = configValue.trim();
+  const absolute = path.isAbsolute(trimmed)
+    ? path.normalize(trimmed)
+    : path.normalize(path.join(root, trimmed));
+
+  if (!fileExists(absolute)) {
+    return { status: 'not-found', path: absolute };
+  }
+
+  return { status: 'resolved', path: absolute };
+}
+
+/**
+ * `fs.statSync` raises on missing paths and on EACCES/ENOTDIR; treat any stat
+ * failure (or a non-file) as "not present" so the resolver returns the
+ * `not-found` signal rather than throwing.
+ */
+function fileExists(p: string): boolean {
+  try {
+    return fs.statSync(p).isFile();
+    // totem-context: intentional fall-through — a stat failure (ENOENT/EACCES/ENOTDIR) is the honest-absent "not found" signal the resolver returns as data; rethrowing would force every caller to wrap a routine absence in try/catch.
+  } catch {
+    return false;
+  }
+}
+
+// ─── Parsing ────────────────────────────────────────────
+
+/**
+ * Honest-absent parse outcome (discriminated union):
+ *   - `unparseable`        — invalid YAML or Zod-schema validation failure.
+ *                            Sensor → `warn` (never crash).
+ *   - `unsupported-schema` — `schema-version` ≠ the supported version.
+ *                            Contracts are NOT parsed. Sensor → `warn`.
+ *   - `ok`                 — a fully parsed + validated manifest.
+ *
+ * Parsing NEVER throws — every failure is a first-class return value so the
+ * doctor pipeline degrades to a `warn` line rather than crashing (mirrors the
+ * `findStaleRules` best-effort fallback idiom).
+ */
+export type ParityManifestParseResult =
+  | { status: 'unparseable'; reason: string }
+  | { status: 'unsupported-schema'; schemaVersion: number }
+  | { status: 'ok'; manifest: ParityManifest };
+
+/**
+ * Parse raw YAML manifest text into a validated `ParityManifest`.
+ *
+ * Order of operations matters: the `schema-version` gate runs BEFORE the full
+ * contract validation so an unsupported future shape is rejected with a clear
+ * `unsupported-schema` signal rather than a confusing Zod failure against a
+ * v1-shaped schema. Within v1, contracts are Zod-validated and the kebab-case
+ * YAML keys are mapped to the camelCase `ParityContract` fields.
+ */
+export function parseParityManifest(yamlText: string): ParityManifestParseResult {
+  // ── YAML parse ──
+  let doc: unknown;
+  try {
+    doc = parseYaml(yamlText);
+    // totem-context: invalid YAML is returned as an `unparseable` signal (sensor degrades to warn), not rethrown — the doctor pipeline must not crash on a malformed strategy-owned manifest.
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return { status: 'unparseable', reason: `Invalid YAML: ${reason}` };
+  }
+
+  // ── schema-version gate (BEFORE full validation) ──
+  // Read the version with a minimal probe so an unsupported version short-
+  // circuits before the v1-shaped contract schema rejects an incompatible
+  // future shape with a misleading error.
+  if (!doc || typeof doc !== 'object') {
+    return { status: 'unparseable', reason: 'Manifest is not a YAML mapping' };
+  }
+  const rawVersion = (doc as Record<string, unknown>)['schema-version'];
+  if (typeof rawVersion !== 'number') {
+    return {
+      status: 'unparseable',
+      reason: 'Manifest is missing a numeric `schema-version`',
+    };
+  }
+  if (rawVersion !== SUPPORTED_PARITY_SCHEMA_VERSION) {
+    return { status: 'unsupported-schema', schemaVersion: rawVersion };
+  }
+
+  // ── Full Zod validation of the v1 shape ──
+  const parsed = RawParityManifestSchema.safeParse(doc);
+  if (!parsed.success) {
+    return {
+      status: 'unparseable',
+      reason: `Manifest failed schema validation: ${parsed.error.issues
+        .map((i) => `${i.path.join('.') || '(root)'}: ${i.message}`)
+        .join('; ')}`,
+    };
+  }
+
+  // ── Map kebab-case → camelCase ──
+  const manifest: ParityManifest = {
+    schemaVersion: parsed.data['schema-version'],
+    status: parsed.data.status,
+    contracts: parsed.data.contracts.map(mapContract),
+  };
+
+  return { status: 'ok', manifest };
+}
+
+/** Map one validated raw contract to the camelCase public `ParityContract`. */
+function mapContract(raw: z.infer<typeof RawParityContractSchema>): ParityContract {
+  return {
+    id: raw.id,
+    dimension: raw.dimension,
+    canonicalSource: raw['canonical-source'],
+    ...(raw['source-note'] !== undefined ? { sourceNote: raw['source-note'] } : {}),
+    detectionMethod: raw['detection-method'],
+    expectedValueOrDerivation: raw['expected-value-or-derivation'],
+    tractability: raw.tractability,
+    trackingIssue: raw['tracking-issue'],
+    ...(raw.title !== undefined ? { title: raw.title } : {}),
+    ...(raw.blocking !== undefined ? { blocking: raw.blocking } : {}),
+    ...(raw.consumers !== undefined ? { consumers: raw.consumers } : {}),
+  };
+}
+
+/**
+ * Convenience: resolve the config-path, read the file, and parse it in one
+ * call. Returns the resolver's honest-absent signals (`not-configured` /
+ * `not-found`) directly, or the parse result. Read failures degrade to an
+ * `unparseable` parse result (never throws), so the doctor surface has a single
+ * exhaustive switch to render against.
+ */
+export type ParityManifestLoadResult =
+  | { status: 'not-configured' }
+  | { status: 'not-found'; path: string }
+  | { status: 'unparseable'; reason: string; path: string }
+  | { status: 'unsupported-schema'; schemaVersion: number; path: string }
+  | { status: 'ok'; manifest: ParityManifest; path: string };
+
+export function loadParityManifest(
+  configValue: string | undefined,
+  root: string,
+): ParityManifestLoadResult {
+  const resolved = resolveParityManifestPath(configValue, root);
+  if (resolved.status === 'not-configured') return { status: 'not-configured' };
+  if (resolved.status === 'not-found') {
+    return { status: 'not-found', path: resolved.path };
+  }
+
+  let text: string;
+  try {
+    text = fs.readFileSync(resolved.path, 'utf-8');
+    // totem-context: a read failure on a path that existSync'd a moment ago (race / permission flip) degrades to an `unparseable` warn, not a throw — the sensor must never crash the doctor pipeline.
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    return { status: 'unparseable', reason: `Unreadable: ${reason}`, path: resolved.path };
+  }
+
+  const result = parseParityManifest(text);
+  if (result.status === 'ok') {
+    return { status: 'ok', manifest: result.manifest, path: resolved.path };
+  }
+  if (result.status === 'unsupported-schema') {
+    return {
+      status: 'unsupported-schema',
+      schemaVersion: result.schemaVersion,
+      path: resolved.path,
+    };
+  }
+  return { status: 'unparseable', reason: result.reason, path: resolved.path };
+}


### PR DESCRIPTION
## What

Skeleton (first slice) of the `totem doctor --parity` parity-drift sensor. Extends the existing `totem doctor` (no new noun) to parse the strategy-owned `parity-manifest.yaml` and report cohort parity — **schema-independent foundation only**.

## Scope (this PR)

- **`packages/core/src/parity-manifest.ts`** — config-path resolver (`resolveParityManifestPath`; honest-absent `not-configured` / `not-found` discriminated unions, never throws) + YAML parser (`parseParityManifest`) with a **schema-version gate** (v1) that runs *before* Zod validation + kebab→camelCase mapping, plus a `loadParityManifest` convenience. Reuses the existing `yaml` core dependency.
- **`orient.parityManifest`** config field (sibling to `orient.projectNumber`) — the one consumer-specific value the sensor can't derive (the manifest is strategy-owned, so its location is per-consumer). **Config-path** resolution per the Seam-1 ruling (not vendored/fetched).
- **`packages/cli/src/commands/doctor-parity.ts`** — `checkParity(cwd) → DiagnosticResult[]` (skip when unconfigured; warn on not-found / unparseable / unsupported-schema; pass summary + per-contract skip stubs on ok) + `--parity` flag wired into `totem doctor`, sibling to `--claim-discipline`. **Sensor-not-gate**: emits only skip/warn/pass; the `--strict` wiring is present but inert until per-contract detection lands.

## Out of scope (next slice)

Per-contract **drift detection** — needs the populated version-pinned deps contracts (the ADR-102 fold strategy is adding to the manifest) + per-dimension semantics. Each per-contract line is a `skip` stub here. The `governance-doctrine` dimension's canonical-vs-forkable verdict is deferred to `mmnto-ai/totem-strategy#511` D1/D4.

## Tests

`parity-manifest.test.ts` (18) + `doctor-parity.test.ts` (8): honest-absent (no throw / exit 0), unparseable + unsupported-schema → warn-not-crash, schema-version gate, kebab→camel round-trip incl. a `version-pinned` contract / `null` canonical-source + `source-note` / `title`/`blocking`/`consumers`.

## Gate

`totem lint` PASS (0 errors) · `totem review` PASS (0 findings) · format clean · parity tests 18+8 pass. The 47 lint *warnings* are the **`#2063`** known test-idiom false-positive class plus established `doctor.ts` sync / error-normalization idioms (`String(err)`, `readFileSync`) — non-blocking, dispositioned.

---

Part of #2069. Refs `mmnto-ai/totem-strategy#448` (charter), `mmnto-ai/totem-strategy#508` (manifest), `mmnto-ai/totem-strategy#514` (schema fields, merged).
