### PR TITLE
feat(cli): totem doctor --parity version-pinned drift detection (#2069)

### DIFF
--- a/packages/cli/src/commands/doctor-parity.test.ts
+++ b/packages/cli/src/commands/doctor-parity.test.ts
@@ -1,12 +1,17 @@
 /**
- * Tests for the `totem doctor --parity` sensor skeleton
- * (mmnto-ai/totem-strategy#448).
+ * Tests for the `totem doctor --parity` sensor (mmnto-ai/totem-strategy#448,
+ * PR-1 mmnto-ai/totem#2069).
  *
  * Drives `checkParity` against real temp dirs with a YAML totem config so the
  * config-resolution → manifest-resolution → parse → DiagnosticResult mapping is
  * exercised end-to-end (no mocking of `loadConfig`). Each test writes a local
  * `totem.yaml` so `resolveConfigPath` never falls through to the global
  * `~/.totem/` profile (which would make the not-configured case nondeterministic).
+ *
+ * The version-pinned wiring tests write a self-in-tree fixture (`packages/*​/
+ * package.json`) under the temp dir so the core detector's cohort-floor probe
+ * resolves locally (NEVER networks — the temp dir is not a git repo, so the
+ * origin-remote read fails fast + degrades to the dir/name fallbacks).
  */
 
 import * as fs from 'node:fs';
@@ -16,7 +21,7 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { cleanTmpDir } from '../test-utils.js';
-import { checkParity } from './doctor-parity.js';
+import { checkParity, doctorParityCliCommand } from './doctor-parity.js';
 
 // Minimal valid totem config — `targets` is the only required array; everything
 // else defaults. `orient.parityManifest` is added per-test as needed.
@@ -89,7 +94,7 @@ function writeManifest(relPath: string, yamlText: string): void {
 describe('checkParity — honest-absent', () => {
   it('emits exactly one skip line when orient.parityManifest is absent (no throw)', async () => {
     writeConfig(BASE_CONFIG);
-    const results = await checkParity(tmpDir);
+    const { results } = await checkParity(tmpDir);
     expect(results).toHaveLength(1);
     expect(results[0]!.status).toBe('skip');
     expect(results[0]!.message).toContain('no parity manifest configured');
@@ -100,7 +105,7 @@ describe('checkParity — honest-absent', () => {
     // best-effort) or resolves the GLOBAL ~/.totem profile, which checkParity
     // explicitly ignores for repo-scoping (isGlobalConfigPath). Either way the
     // result is a deterministic skip, regardless of any global orient.parityManifest.
-    const results = await checkParity(tmpDir);
+    const { results } = await checkParity(tmpDir);
     expect(results).toHaveLength(1);
     expect(results[0]!.status).toBe('skip');
   });
@@ -109,7 +114,7 @@ describe('checkParity — honest-absent', () => {
 describe('checkParity — configured-but-missing', () => {
   it('warns (no throw) when the configured manifest path does not exist', async () => {
     writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: doctrine/parity-manifest.yaml\n`);
-    const results = await checkParity(tmpDir);
+    const { results } = await checkParity(tmpDir);
     expect(results).toHaveLength(1);
     expect(results[0]!.status).toBe('warn');
     expect(results[0]!.message).toContain('not found');
@@ -120,7 +125,7 @@ describe('checkParity — unparseable / unsupported-schema', () => {
   it('warns (never crashes) on unparseable YAML', async () => {
     writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: bad.yaml\n`);
     writeManifest('bad.yaml', 'schema-version: 1\ncontracts: [unclosed');
-    const results = await checkParity(tmpDir);
+    const { results } = await checkParity(tmpDir);
     expect(results).toHaveLength(1);
     expect(results[0]!.status).toBe('warn');
     expect(results[0]!.message).toContain('unreadable');
@@ -140,7 +145,7 @@ contracts:
     tractability: mechanical
 `,
     );
-    const results = await checkParity(tmpDir);
+    const { results } = await checkParity(tmpDir);
     expect(results[0]!.status).toBe('warn');
   });
 
@@ -150,7 +155,7 @@ contracts:
       'future.yaml',
       VALID_MANIFEST_YAML.replace('schema-version: 1', 'schema-version: 2'),
     );
-    const results = await checkParity(tmpDir);
+    const { results } = await checkParity(tmpDir);
     expect(results).toHaveLength(1);
     expect(results[0]!.status).toBe('warn');
     expect(results[0]!.message).toContain('schema v2 unsupported');
@@ -158,29 +163,169 @@ contracts:
 });
 
 describe('checkParity — success', () => {
-  it('emits a summary line + one skip stub per contract on a valid manifest', async () => {
+  it('emits a summary line + one line per contract on a valid manifest', async () => {
     writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: doctrine/parity-manifest.yaml\n`);
     writeManifest('doctrine/parity-manifest.yaml', VALID_MANIFEST_YAML);
 
-    const results = await checkParity(tmpDir);
-    // 1 summary + 4 per-contract stubs.
+    const { results } = await checkParity(tmpDir);
+    // 1 summary + 4 per-contract lines.
     expect(results).toHaveLength(5);
 
     const summary = results[0]!;
     expect(summary.status).toBe('pass');
     expect(summary.message).toContain('4 contract(s) loaded');
 
-    // Per-contract lines are skip stubs (drift detection deferred — never fail).
     const perContract = results.slice(1);
-    expect(perContract.every((r) => r.status === 'skip')).toBe(true);
-    expect(perContract.some((r) => r.name === 'Parity: mmnto-cli-version')).toBe(true);
-    expect(perContract.some((r) => r.message.includes('version-pinned'))).toBe(true);
+    // The mechanical contracts keep the skip stub.
+    const orientation = perContract.find((r) => r.name === 'Parity: session-start-orientation')!;
+    expect(orientation.status).toBe('skip');
+    expect(orientation.message).toContain('mechanical');
+    // The version-pinned deps contract (mmnto-cli-version) now runs the
+    // detector — with no consumer pin declared here it lands on a `skip`
+    // (cohort permits absence), NOT the old "not yet implemented" stub.
+    const cliVersion = perContract.find((r) => r.name === 'Parity: mmnto-cli-version')!;
+    expect(cliVersion.status).toBe('skip');
+    expect(cliVersion.message).not.toContain('not yet implemented');
   });
 
-  it('never emits a fail status in the skeleton (sensor-not-gate)', async () => {
+  it('never emits a fail status by default (sensor-not-gate)', async () => {
     writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: doctrine/parity-manifest.yaml\n`);
     writeManifest('doctrine/parity-manifest.yaml', VALID_MANIFEST_YAML);
-    const results = await checkParity(tmpDir);
+    const { results } = await checkParity(tmpDir);
     expect(results.some((r) => r.status === 'fail')).toBe(false);
+  });
+});
+
+// ─── version-pinned detection wiring (PR-1) ─────────────
+
+/** A manifest with a single deps version-pinned contract (no consumers = applies). */
+const DEPS_MANIFEST_YAML = `schema-version: 1
+status: scaffold
+contracts:
+  - id: mmnto-totem-version
+    dimension: dependency-cohort
+    canonical-source: mmnto-ai/totem
+    detection-method: consumer package.json caret range + resolved install vs floor
+    expected-value-or-derivation: consumer pin resolves to the current published @mmnto/totem
+    tractability: version-pinned
+    tracking-issue: mmnto-ai/totem-strategy#482
+`;
+
+/** Same contract marked blocking — exercises the --strict fail-promotion edge. */
+const BLOCKING_DEPS_MANIFEST_YAML = DEPS_MANIFEST_YAML.replace(
+  'tracking-issue: mmnto-ai/totem-strategy#482\n',
+  'tracking-issue: mmnto-ai/totem-strategy#482\n    blocking: true\n',
+);
+
+/** Write a self-in-tree `packages/<dir>/package.json` so the cohort floor resolves locally. */
+function writeFloorPackage(dir: string, name: string, version: string): void {
+  const pkgDir = path.join(tmpDir, 'packages', dir);
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name, version }, null, 2),
+    'utf-8',
+  );
+}
+
+/** Write the consumer's root package.json declaring a dependency pin. */
+function writeConsumerDeps(deps: Record<string, string>): void {
+  fs.writeFileSync(
+    path.join(tmpDir, 'package.json'),
+    JSON.stringify({ name: 'consumer-repo', dependencies: deps }, null, 2),
+    'utf-8',
+  );
+}
+
+/** Write `node_modules/<pkg>/package.json#version` so installed-version resolution wins. */
+function writeInstalled(pkg: string, version: string): void {
+  const dir = path.join(tmpDir, 'node_modules', ...pkg.split('/'));
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ name: pkg, version }, null, 2),
+    'utf-8',
+  );
+}
+
+describe('checkParity — version-pinned wiring', () => {
+  it('PASS — installed @mmnto/totem >= the self-in-tree cohort floor', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', DEPS_MANIFEST_YAML);
+    writeFloorPackage('totem', '@mmnto/totem', '1.50.0'); // floor
+    writeConsumerDeps({ '@mmnto/totem': '^1.50.0' });
+    writeInstalled('@mmnto/totem', '1.53.3'); // installed >= floor
+
+    const { results, blockingDriftIds } = await checkParity(tmpDir);
+    const line = results.find((r) => r.name === 'Parity: mmnto-totem-version')!;
+    expect(line.status).toBe('pass');
+    expect(blockingDriftIds).toHaveLength(0);
+  });
+
+  it('WARN — installed @mmnto/totem < the cohort floor (stale pin), no blocking promotion', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', DEPS_MANIFEST_YAML);
+    writeFloorPackage('totem', '@mmnto/totem', '1.53.3'); // floor
+    writeConsumerDeps({ '@mmnto/totem': '^1.40.0' });
+    writeInstalled('@mmnto/totem', '1.40.0'); // installed < floor
+
+    const { results, blockingDriftIds } = await checkParity(tmpDir);
+    const line = results.find((r) => r.name === 'Parity: mmnto-totem-version')!;
+    expect(line.status).toBe('warn');
+    expect(line.message).toContain('1.53.3'); // floor surfaced
+    // Non-blocking contract → not eligible for --strict promotion.
+    expect(blockingDriftIds).toHaveLength(0);
+  });
+
+  it('a blocking contract drift tags blockingDriftIds (the --strict promotion seam)', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', BLOCKING_DEPS_MANIFEST_YAML);
+    writeFloorPackage('totem', '@mmnto/totem', '1.53.3');
+    writeConsumerDeps({ '@mmnto/totem': '^1.40.0' });
+    writeInstalled('@mmnto/totem', '1.40.0');
+
+    const { results, blockingDriftIds } = await checkParity(tmpDir);
+    const line = results.find((r) => r.name === 'Parity: mmnto-totem-version')!;
+    // The CHECK still returns warn — fail-promotion is the CLI edge's job.
+    expect(line.status).toBe('warn');
+    expect(blockingDriftIds).toEqual(['mmnto-totem-version']);
+  });
+});
+
+describe('doctorParityCliCommand — --strict fail-promotion', () => {
+  it('throws PARITY_DRIFT_DETECTED when a blocking contract drifted under --strict', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', BLOCKING_DEPS_MANIFEST_YAML);
+    writeFloorPackage('totem', '@mmnto/totem', '1.53.3');
+    writeConsumerDeps({ '@mmnto/totem': '^1.40.0' });
+    writeInstalled('@mmnto/totem', '1.40.0');
+
+    await expect(doctorParityCliCommand({ strict: true, cwdForTest: tmpDir })).rejects.toThrow(
+      /PARITY_DRIFT_DETECTED|blocking drift/i,
+    );
+  });
+
+  it('does NOT throw for the same blocking drift without --strict (sensor-not-gate)', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', BLOCKING_DEPS_MANIFEST_YAML);
+    writeFloorPackage('totem', '@mmnto/totem', '1.53.3');
+    writeConsumerDeps({ '@mmnto/totem': '^1.40.0' });
+    writeInstalled('@mmnto/totem', '1.40.0');
+
+    await expect(
+      doctorParityCliCommand({ strict: false, cwdForTest: tmpDir }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('does NOT throw under --strict when drift is NON-blocking (only blocking gates)', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', DEPS_MANIFEST_YAML); // non-blocking
+    writeFloorPackage('totem', '@mmnto/totem', '1.53.3');
+    writeConsumerDeps({ '@mmnto/totem': '^1.40.0' });
+    writeInstalled('@mmnto/totem', '1.40.0');
+
+    await expect(
+      doctorParityCliCommand({ strict: true, cwdForTest: tmpDir }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -168,7 +168,7 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
           };
         }
 
-        const verdict = detectVersionPinnedContract(c, { cwd, gitRoot, repoId });
+        const verdict = detectVersionPinnedContract(c, { cwd, gitRoot, repoId, packageName });
         if (verdict.status === 'warn' && c.blocking === true) {
           blockingDriftIds.push(c.id);
         }
@@ -297,18 +297,18 @@ export async function doctorParityCliCommand(options: ParityCliOptions = {}): Pr
     }
   }
 
-  // Sensor-not-gate: only `--strict` + a `blocking: true` contract's drift
-  // promotes to a non-zero exit. A pre-existing `fail` status (none today, but
-  // future detection slices may emit one) also gates. Non-blocking drift never
-  // gates, even under `--strict`.
-  const failingFromStatus = results.filter((r) => r.status === 'fail').length;
-  const failingFromBlocking = options.strict ? blockingDriftIds.length : 0;
-  const totalFailures = failingFromStatus + failingFromBlocking;
-  if (options.strict && totalFailures > 0) {
+  // Sensor-not-gate: drift is report-only by default (exit 0). Only `--strict`
+  // promotes a `blocking: true` contract's drift to a non-zero exit; non-blocking
+  // drift never gates. PR-1's detector emits no raw `fail` status (version-pinned
+  // is pass/warn/skip), so the gate is purely the strict+blocking promotion — the
+  // gating model for a future slice that DOES emit a `fail` is settled when that
+  // slice lands (CR review #2071: keep the gate from suggesting a non-strict path
+  // that would break sensor-not-gate).
+  if (options.strict && blockingDriftIds.length > 0) {
     throw new TotemError(
       'PARITY_DRIFT_DETECTED',
-      `${totalFailures} parity contract(s) reported blocking drift under --strict.`,
-      'Reconcile each failing contract against its canonical source, then re-run totem doctor --parity --strict.',
+      `${blockingDriftIds.length} parity contract(s) reported blocking drift under --strict.`,
+      'Reconcile each blocking contract against its canonical source, then re-run totem doctor --parity --strict.',
     );
   }
 }

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -1,17 +1,23 @@
 /**
  * Parity-drift sensor for `totem doctor --parity` (mmnto-ai/totem-strategy#448).
  *
- * SKELETON (first slice): resolve the consumer-configured `orient.parityManifest`
- * config-path → parse + Zod-validate the strategy-owned `parity-manifest.yaml`
- * → emit `DiagnosticResult`s. Per-contract drift detection is OUT OF SCOPE for
- * this skeleton (it needs populated deps contracts + per-dimension semantics);
- * each per-contract line is a `skip` info stub here.
+ * PR-1 (mmnto-ai/totem#2069): resolve the consumer-configured
+ * `orient.parityManifest` config-path → parse + Zod-validate the strategy-owned
+ * `parity-manifest.yaml` → emit `DiagnosticResult`s. The FIRST detection slice
+ * is wired here: each `version-pinned` contract whose id resolves a deps package
+ * name (`mmnto-cli-version`, `mmnto-totem-version`, `mmnto-mcp-version`,
+ * `mmnto-pack-rust-architecture-version`) runs through the core
+ * `detectVersionPinnedContract` engine (pin-currency verdict, local-only floor).
+ * ALL other contracts — mechanical, manual-attestation, and the version-pinned
+ * DOCTRINE pins (`governance-doctrine` / `agent-memory-doctrine`, which derive
+ * no deps package name) — keep the `skip` info stub (their drift detection is a
+ * follow-on).
  *
- * Sensor-not-gate: this surface emits `skip`/`warn`/`pass` only — it never
- * produces a `fail` in the skeleton. The `--strict` exit-code decision lives at
- * the CLI edge (reusing the existing doctor `--strict` logic); a `fail` only
- * becomes possible once per-contract drift detection lands. The `blocking`
- * contract field is parsed but unused here (per-contract gating is post-skeleton).
+ * Sensor-not-gate: the core detector returns `skip`/`warn`/`pass` only — never
+ * `fail`. The `--strict` exit-code decision lives at the CLI edge: a `warn` from
+ * a `blocking: true` contract is promoted to `fail` (non-zero) ONLY under
+ * `--strict`. The detector carries that promotion eligibility back via
+ * `blockingDriftIds` so the command can gate without re-loading the manifest.
  *
  * Honest-absent (Tenet 14): unconfigured → exactly one `skip` line; never an
  * error. Configured-but-missing / unparseable / unsupported-schema → `warn`,
@@ -22,23 +28,46 @@
 
 import * as path from 'node:path';
 
+import type { ParityContract, ParityContractVerdict } from '@mmnto/totem';
+
 import type { DiagnosticResult } from './doctor.js';
 
 const CHECK_NAME = 'Parity';
 
 /**
+ * Result of a parity check: the rendered `DiagnosticResult` lines plus the set
+ * of contract ids that produced a drift `warn` AND are `blocking: true`. The
+ * command promotes exactly these to `fail` under `--strict` — carrying the ids
+ * here avoids re-loading the manifest at the CLI edge to recover the `blocking`
+ * flag (which `DiagnosticResult` does not carry).
+ */
+export interface ParityCheckResult {
+  results: DiagnosticResult[];
+  /** Contract ids whose `warn` is `--strict`-promotable (blocking + drift). */
+  blockingDriftIds: string[];
+}
+
+/**
  * Resolve, parse, and report the parity manifest as `DiagnosticResult`s.
  *
- * Returns an ARRAY: the first entry is always the section summary line; in the
- * `ok` path it is followed by one `skip` info stub per contract (the
- * per-contract drift verdict is deferred). All other paths return a single
- * summary entry.
+ * Returns `{ results, blockingDriftIds }`: `results[0]` is always the section
+ * summary line; in the `ok` path it is followed by one line per contract — a
+ * pin-currency verdict for the deps version-pinned contracts, a `skip` stub for
+ * everything else. All non-`ok` paths return a single summary entry and an empty
+ * `blockingDriftIds`.
  *
  * @param cwd The directory to resolve config + manifest against (config/repo root).
  */
-export async function checkParity(cwd: string): Promise<DiagnosticResult[]> {
+export async function checkParity(cwd: string): Promise<ParityCheckResult> {
   const { loadConfig, resolveConfigPath, isGlobalConfigPath } = await import('../utils.js');
-  const { loadParityManifest, SUPPORTED_PARITY_SCHEMA_VERSION } = await import('@mmnto/totem');
+  const {
+    deriveCohortRepoId,
+    detectVersionPinnedContract,
+    loadParityManifest,
+    packageNameForContract,
+    resolveGitRoot,
+    SUPPORTED_PARITY_SCHEMA_VERSION,
+  } = await import('@mmnto/totem');
 
   // Read the config best-effort: a missing/corrupt config is the honest-absent
   // path (no parity manifest configured), not a crash. Mirrors the config-load
@@ -78,43 +107,35 @@ export async function checkParity(cwd: string): Promise<DiagnosticResult[]> {
   switch (result.status) {
     case 'not-configured':
       // Honest-absent: exactly one skip line. Not a failure.
-      return [
-        {
-          name: CHECK_NAME,
-          status: 'skip',
-          message: 'no parity manifest configured',
-        },
-      ];
+      return single({
+        name: CHECK_NAME,
+        status: 'skip',
+        message: 'no parity manifest configured',
+      });
 
     case 'not-found':
-      return [
-        {
-          name: CHECK_NAME,
-          status: 'warn',
-          message: `parity manifest not found at ${rel(cwd, result.path)}`,
-          remediation: 'Fix orient.parityManifest in your totem config to point at the manifest.',
-        },
-      ];
+      return single({
+        name: CHECK_NAME,
+        status: 'warn',
+        message: `parity manifest not found at ${rel(cwd, result.path)}`,
+        remediation: 'Fix orient.parityManifest in your totem config to point at the manifest.',
+      });
 
     case 'unparseable':
-      return [
-        {
-          name: CHECK_NAME,
-          status: 'warn',
-          message: `parity manifest unreadable at ${rel(cwd, result.path)}: ${result.reason}`,
-          remediation: 'Fix the manifest YAML / schema, then re-run totem doctor --parity.',
-        },
-      ];
+      return single({
+        name: CHECK_NAME,
+        status: 'warn',
+        message: `parity manifest unreadable at ${rel(cwd, result.path)}: ${result.reason}`,
+        remediation: 'Fix the manifest YAML / schema, then re-run totem doctor --parity.',
+      });
 
     case 'unsupported-schema':
-      return [
-        {
-          name: CHECK_NAME,
-          status: 'warn',
-          message: `parity manifest schema v${result.schemaVersion} unsupported (this doctor supports v${SUPPORTED_PARITY_SCHEMA_VERSION})`,
-          remediation: 'Upgrade @mmnto/cli or align the manifest schema-version.',
-        },
-      ];
+      return single({
+        name: CHECK_NAME,
+        status: 'warn',
+        message: `parity manifest schema v${result.schemaVersion} unsupported (this doctor supports v${SUPPORTED_PARITY_SCHEMA_VERSION})`,
+        remediation: 'Upgrade @mmnto/cli or align the manifest schema-version.',
+      });
 
     case 'ok': {
       const { contracts } = result.manifest;
@@ -123,16 +144,71 @@ export async function checkParity(cwd: string): Promise<DiagnosticResult[]> {
         status: 'pass',
         message: `parity manifest: ${contracts.length} contract(s) loaded`,
       };
-      // Per-contract skeleton stubs. Drift detection is deferred — each line is
-      // an info `skip` carrying the contract id + dimension + tractability so
-      // the surface is shaped for the follow-on without asserting a verdict.
-      const perContract: DiagnosticResult[] = contracts.map((c) => ({
-        name: `Parity: ${c.id}`,
-        status: 'skip',
-        message: `${c.dimension} (${c.tractability}) — drift detection not yet implemented`,
-      }));
-      return [summary, ...perContract];
+
+      // Shared detection context. The cohort floor + repoId derive from the git
+      // root (anchored there, not the deep cwd — mirrors the core resolver).
+      // resolveGitRoot returns null outside a repo; fall back to cwd so the
+      // local self-in-tree / sibling probes still have an anchor.
+      const gitRoot = safeGitRoot(resolveGitRoot, cwd) ?? cwd;
+      const repoId = deriveCohortRepoId(cwd, { gitRoot });
+
+      const blockingDriftIds: string[] = [];
+      const perContract: DiagnosticResult[] = contracts.map((c) => {
+        // PR-1 only senses version-pinned DEPS contracts (those that resolve a
+        // package name). Everything else — mechanical, manual-attestation, and
+        // the version-pinned doctrine pins (no deps package name) — keeps the
+        // skip stub until its detection slice lands.
+        const packageName =
+          c.tractability === 'version-pinned' ? packageNameForContract(c, gitRoot) : undefined;
+        if (packageName === undefined) {
+          return {
+            name: `Parity: ${c.id}`,
+            status: 'skip',
+            message: `${c.dimension} (${c.tractability}) — drift detection not yet implemented`,
+          };
+        }
+
+        const verdict = detectVersionPinnedContract(c, { cwd, gitRoot, repoId });
+        if (verdict.status === 'warn' && c.blocking === true) {
+          blockingDriftIds.push(c.id);
+        }
+        return verdictToDiagnostic(c, verdict);
+      });
+
+      return { results: [summary, ...perContract], blockingDriftIds };
     }
+  }
+}
+
+/** Wrap a single summary line in the `ParityCheckResult` shape (no blocking ids). */
+function single(result: DiagnosticResult): ParityCheckResult {
+  return { results: [result], blockingDriftIds: [] };
+}
+
+/** Map a core `ParityContractVerdict` to a CLI `DiagnosticResult` for one contract. */
+function verdictToDiagnostic(
+  contract: ParityContract,
+  verdict: ParityContractVerdict,
+): DiagnosticResult {
+  return {
+    name: `Parity: ${contract.id}`,
+    status: verdict.status,
+    message: verdict.message,
+    ...(verdict.remediation !== undefined ? { remediation: verdict.remediation } : {}),
+  };
+}
+
+/**
+ * Resolve the git root, swallowing the `TotemGitError` that `resolveGitRoot`
+ * throws on a git hiccup (permission error / corrupted index) — the parity
+ * sensor degrades to the cwd anchor rather than crashing the doctor pipeline.
+ */
+function safeGitRoot(resolve: (cwd: string) => string | null, cwd: string): string | null {
+  try {
+    return resolve(cwd);
+    // totem-context: resolveGitRoot throws on permission errors / corrupted index; the parity sensor degrades to a cwd anchor rather than crashing — a git hiccup must not sink the doctor pipeline.
+  } catch {
+    return null;
   }
 }
 
@@ -149,13 +225,14 @@ const TAG = CHECK_NAME;
 
 export interface ParityCliOptions {
   /**
-   * Strict mode (Proposal 273 / 279 `--strict` semantics): promote any `fail`
-   * DiagnosticResult to a gate failure (non-zero exit) via a thrown TotemError.
+   * Strict mode (Proposal 273 / 279 `--strict` semantics): promote drift to a
+   * gate failure (non-zero exit) via a thrown TotemError.
    *
-   * In the SKELETON this never fires — `checkParity` emits only `skip`/`warn`/
-   * `pass`, never `fail` (per-contract drift detection is deferred). The wiring
-   * is present so `--strict` composes once a `fail` becomes possible. Default
-   * (non-strict) is sensor-not-gate: `warn`s report and exit 0.
+   * Sensor-not-gate is the default: a drift `warn` reports and exits 0. Under
+   * `--strict`, a `warn` from a `blocking: true` contract (its id carried in
+   * `checkParity`'s `blockingDriftIds`) is rendered as `FAIL` and promoted to a
+   * non-zero exit. Non-blocking drift stays a `warn` even under `--strict` — the
+   * contract's `blocking` flag, not the flag alone, gates the exit code.
    */
   strict?: boolean;
   /** Test seam — production callers omit and the command uses `process.cwd()`. */
@@ -164,8 +241,9 @@ export interface ParityCliOptions {
 
 /**
  * CLI entry — runs `checkParity`, renders each `DiagnosticResult`, and throws a
- * `TotemError` on `fail` under `--strict` so the top-level `handleError`
- * produces the non-zero exit code (no direct `process.exit` per AGENTS.md).
+ * `TotemError` when a blocking contract drifted under `--strict` so the
+ * top-level `handleError` produces the non-zero exit code (no direct
+ * `process.exit` per AGENTS.md).
  */
 export async function doctorParityCliCommand(options: ParityCliOptions = {}): Promise<void> {
   const { TotemError, sanitizeForTerminal } = await import('@mmnto/totem');
@@ -188,10 +266,18 @@ export async function doctorParityCliCommand(options: ParityCliOptions = {}): Pr
       .trim();
 
   const cwd = options.cwdForTest ?? process.cwd();
-  const results = await checkParity(cwd);
+  const { results, blockingDriftIds } = await checkParity(cwd);
+
+  // Under --strict, a blocking contract's drift `warn` is rendered + gated as a
+  // FAIL. We match by the `Parity: <id>` line name so the rendered status agrees
+  // with the exit code. blockingDriftIds is empty in the non-strict path's
+  // effect (the promotion only fires under --strict), so this Set is cheap.
+  const promotable = new Set(blockingDriftIds.map((id) => `Parity: ${id}`));
 
   for (const r of results) {
-    switch (r.status) {
+    const status =
+      options.strict && r.status === 'warn' && promotable.has(r.name) ? 'fail' : r.status;
+    switch (status) {
       case 'pass':
         log.success(TAG, `${successColor(bold('PASS'))} — ${render(r.message)}`);
         break;
@@ -211,14 +297,17 @@ export async function doctorParityCliCommand(options: ParityCliOptions = {}): Pr
     }
   }
 
-  // Sensor-not-gate: only `--strict` promotes `fail` to a non-zero exit. The
-  // skeleton never emits `fail`, so this is inert until per-contract drift
-  // detection lands; the wiring composes ahead of that follow-on.
-  const failures = results.filter((r) => r.status === 'fail');
-  if (options.strict && failures.length > 0) {
+  // Sensor-not-gate: only `--strict` + a `blocking: true` contract's drift
+  // promotes to a non-zero exit. A pre-existing `fail` status (none today, but
+  // future detection slices may emit one) also gates. Non-blocking drift never
+  // gates, even under `--strict`.
+  const failingFromStatus = results.filter((r) => r.status === 'fail').length;
+  const failingFromBlocking = options.strict ? blockingDriftIds.length : 0;
+  const totalFailures = failingFromStatus + failingFromBlocking;
+  if (options.strict && totalFailures > 0) {
     throw new TotemError(
       'PARITY_DRIFT_DETECTED',
-      `${failures.length} parity contract(s) reported drift under --strict.`,
+      `${totalFailures} parity contract(s) reported blocking drift under --strict.`,
       'Reconcile each failing contract against its canonical source, then re-run totem doctor --parity --strict.',
     );
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -551,6 +551,21 @@ export {
   SUPPORTED_PARITY_SCHEMA_VERSION,
 } from './parity-manifest.js';
 
+// Version-pinned parity drift detector (PR-1, mmnto-ai/totem#2069)
+export type {
+  CohortFloorStatus,
+  DeriveCohortRepoIdOptions,
+  DetectVersionPinnedContext,
+  PackageJsonShape,
+  ParityContractVerdict,
+} from './parity-detect.js';
+export {
+  deriveCohortRepoId,
+  detectVersionPinnedContract,
+  packageNameForContract,
+  resolveCohortFloor,
+} from './parity-detect.js';
+
 // Semgrep adapter (Pipeline 4 — import rules from Semgrep YAML)
 export type { SemgrepImportResult } from './semgrep-adapter.js';
 export { parseSemgrepRules } from './semgrep-adapter.js';

--- a/packages/core/src/parity-detect.test.ts
+++ b/packages/core/src/parity-detect.test.ts
@@ -268,12 +268,15 @@ describe('detectVersionPinnedContract', () => {
     expect(verdict.status).not.toBe('fail');
   });
 
-  it('SKIP — pin not declared in the consumer package.json (cohort permits absence)', () => {
+  it('SKIP (distinct) — applicable consumer missing an expected pin is expected-but-absent, NOT cohort-permitted', () => {
     writeSelfInTree(tmpRoot, '1.53.3');
     writeConsumerPkg(tmpRoot, { 'unrelated-dep': '^1.0.0' });
     const verdict = detectVersionPinnedContract(depsContract(), baseCtx({ repoId: 'totem' }));
     expect(verdict.status).toBe('skip');
-    expect(verdict.message).toMatch(/not declared/i);
+    expect(verdict.message).toMatch(/expected but not declared|applicable consumer/i);
+    // Must stay DISTINCT from the not-a-consumer skip — else the consumers field
+    // does nothing for the missing case (strategy design-call 3).
+    expect(verdict.message).not.toMatch(/permits absence|not in consumers/i);
   });
 
   it('SKIP — consumers present and current repo not listed (not-a-consumer)', () => {

--- a/packages/core/src/parity-detect.test.ts
+++ b/packages/core/src/parity-detect.test.ts
@@ -139,6 +139,19 @@ describe('packageNameForContract', () => {
     expect(packageNameForContract(depsContract({ id: 'agent-memory-doctrine' }))).toBeUndefined();
     expect(packageNameForContract(depsContract({ id: 'gate-config' }))).toBeUndefined();
   });
+
+  it('prefers an explicit package: field over the id convention (derive-not-guess, strategy#517)', () => {
+    // Vendor name + a non-conventional id: only the package: field can resolve it.
+    expect(
+      packageNameForContract(
+        depsContract({ id: 'google-genai-coupling', package: '@google/genai' }),
+      ),
+    ).toBe('@google/genai');
+    // package: wins even when the id convention WOULD match (no silent divergence).
+    expect(
+      packageNameForContract(depsContract({ id: 'mmnto-totem-version', package: '@mmnto/totem' })),
+    ).toBe('@mmnto/totem');
+  });
 });
 
 // ─── deriveCohortRepoId ─────────────────────────────────
@@ -287,6 +300,33 @@ describe('detectVersionPinnedContract', () => {
       baseCtx({ repoId: 'totem-status' }),
     );
     expect(verdict.status).toBe('skip');
+  });
+
+  it('SKIP — consumers present but repo id unresolvable: surface it, do NOT silently apply (Greptile P1)', () => {
+    writeSelfInTree(tmpRoot, '1.53.3');
+    writeConsumerPkg(tmpRoot, { '@mmnto/totem': '^1.50.0' });
+    const verdict = detectVersionPinnedContract(
+      depsContract({ consumers: ['totem-strategy'] }),
+      baseCtx({ repoId: undefined }),
+    );
+    expect(verdict.status).toBe('skip');
+    expect(verdict.message).toMatch(/cannot determine applicability|repo id unresolvable/i);
+  });
+
+  it('resolves an installed version hoisted to a PARENT node_modules (monorepo, GCA-1)', () => {
+    // Floor 2.0.0 self-in-tree at the git root; the consumer cwd is a nested
+    // subdir whose dep is hoisted to the root node_modules, not its own.
+    writeSelfInTree(tmpRoot, '2.0.0');
+    const sub = path.join(tmpRoot, 'apps', 'web');
+    fs.mkdirSync(sub, { recursive: true });
+    writeConsumerPkg(sub, { '@mmnto/totem': '^2.0.0' });
+    writeInstalled(tmpRoot, '@mmnto/totem', '2.0.0'); // hoisted at the root, not in sub
+    const verdict = detectVersionPinnedContract(
+      depsContract(),
+      baseCtx({ cwd: sub, gitRoot: tmpRoot, repoId: 'totem' }),
+    );
+    expect(verdict.status).toBe('pass');
+    expect(verdict.message).toContain('2.0.0');
   });
 
   it('SKIP — floor unresolvable (no self-in-tree, no sibling); reason in message, no throw', () => {

--- a/packages/core/src/parity-detect.test.ts
+++ b/packages/core/src/parity-detect.test.ts
@@ -1,0 +1,341 @@
+/**
+ * Tests for the version-pinned parity drift detector (PR-1,
+ * mmnto-ai/totem#2069 on top of skeleton #2070).
+ *
+ * The detector is pure + side-effect-free: every filesystem / git seam is
+ * injectable so these tests drive it against synthetic fixtures, NOT the live
+ * cohort. Each invariant from the spec's "Invariants to lock via tests" list
+ * gets a case: pass / warn / fail-under-blocking+strict (the fail-promotion is a
+ * CLI-edge concern — the detector itself only ever returns warn here) / skip on
+ * not-declared / skip on not-a-consumer / skip on floor-unresolved /
+ * no-throw-on-read-failure / never-networks / claim-class-bound (pin currency
+ * only, never content equality).
+ *
+ * Mirrors the temp-file + discriminated-union style of `parity-manifest.test.ts`
+ * and the injected-seam style of `strategy-resolver.test.ts`.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  deriveCohortRepoId,
+  type DetectVersionPinnedContext,
+  detectVersionPinnedContract,
+  packageNameForContract,
+  resolveCohortFloor,
+} from './parity-detect.js';
+import type { ParityContract } from './parity-manifest.js';
+import { cleanTmpDir } from './test-utils.js';
+
+let tmpRoot: string;
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-parity-detect-'));
+});
+
+afterEach(() => {
+  cleanTmpDir(tmpRoot);
+});
+
+// ─── Fixture builders ───────────────────────────────────
+
+/** Build a minimal version-pinned deps contract for one of the 4 PR-1 ids. */
+function depsContract(over: Partial<ParityContract> = {}): ParityContract {
+  return {
+    id: 'mmnto-totem-version',
+    dimension: 'dependency-cohort',
+    canonicalSource: 'mmnto-ai/totem',
+    detectionMethod: 'consumer package.json caret range + resolved install vs floor',
+    expectedValueOrDerivation: 'consumer pin resolves to the current published @mmnto/totem',
+    tractability: 'version-pinned',
+    trackingIssue: 'mmnto-ai/totem-strategy#482',
+    ...over,
+  };
+}
+
+/** Write a `packages/<dir>/package.json` with the given name + version. */
+function writePackage(rootDir: string, dir: string, name: string, version: string): void {
+  const pkgDir = path.join(rootDir, 'packages', dir);
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name, version }, null, 2),
+    'utf-8',
+  );
+}
+
+/**
+ * Write a self-in-tree totem monorepo at `rootDir` carrying `@mmnto/totem` at
+ * `version`, plus a marker package so the glob has more than one entry.
+ */
+function writeSelfInTree(rootDir: string, version: string): void {
+  writePackage(rootDir, 'totem', '@mmnto/totem', version);
+  writePackage(rootDir, 'cli', '@mmnto/cli', version);
+}
+
+/** Build a base context with all seams pointed at the temp consumer repo. */
+function baseCtx(over: Partial<DetectVersionPinnedContext> = {}): DetectVersionPinnedContext {
+  return {
+    cwd: tmpRoot,
+    gitRoot: tmpRoot,
+    repoId: 'totem-status',
+    ...over,
+  };
+}
+
+/** Write the consumer's package.json declaring `name` in `dependencies`. */
+function writeConsumerPkg(
+  rootDir: string,
+  deps: Record<string, string>,
+  field: 'dependencies' | 'devDependencies' | 'optionalDependencies' = 'dependencies',
+): void {
+  fs.writeFileSync(
+    path.join(rootDir, 'package.json'),
+    JSON.stringify({ name: 'consumer-repo', [field]: deps }, null, 2),
+    'utf-8',
+  );
+}
+
+/** Write `node_modules/<pkg>/package.json#version` so install resolution wins. */
+function writeInstalled(rootDir: string, pkg: string, version: string): void {
+  const dir = path.join(rootDir, 'node_modules', ...pkg.split('/'));
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({ name: pkg, version }, null, 2),
+    'utf-8',
+  );
+}
+
+// ─── packageNameForContract ─────────────────────────────
+
+describe('packageNameForContract', () => {
+  it('derives @mmnto/<x> from an `mmnto-<x>-version` id with no path locator', () => {
+    expect(packageNameForContract(depsContract({ id: 'mmnto-totem-version' }))).toBe(
+      '@mmnto/totem',
+    );
+    expect(packageNameForContract(depsContract({ id: 'mmnto-mcp-version' }))).toBe('@mmnto/mcp');
+    expect(packageNameForContract(depsContract({ id: 'mmnto-cli-version' }))).toBe('@mmnto/cli');
+    expect(
+      packageNameForContract(depsContract({ id: 'mmnto-pack-rust-architecture-version' })),
+    ).toBe('@mmnto/pack-rust-architecture');
+  });
+
+  it('prefers the canonical-source package.json `name` when a path locator is present', () => {
+    writePackage(tmpRoot, 'cli', '@mmnto/cli', '1.0.0');
+    const contract = depsContract({
+      id: 'mmnto-cli-version',
+      canonicalSource: 'mmnto-ai/totem:packages/cli/package.json#version',
+    });
+    expect(packageNameForContract(contract, tmpRoot)).toBe('@mmnto/cli');
+  });
+
+  it('returns undefined for ids that are not deps-version contracts', () => {
+    expect(packageNameForContract(depsContract({ id: 'governance-doctrine' }))).toBeUndefined();
+    expect(packageNameForContract(depsContract({ id: 'agent-memory-doctrine' }))).toBeUndefined();
+    expect(packageNameForContract(depsContract({ id: 'gate-config' }))).toBeUndefined();
+  });
+});
+
+// ─── deriveCohortRepoId ─────────────────────────────────
+
+describe('deriveCohortRepoId', () => {
+  it('extracts <name> from an mmnto-ai/<name> git origin remote (ssh + https, .git suffix)', () => {
+    expect(
+      deriveCohortRepoId(tmpRoot, { remoteUrl: 'git@github.com:mmnto-ai/totem-status.git' }),
+    ).toBe('totem-status');
+    expect(
+      deriveCohortRepoId(tmpRoot, { remoteUrl: 'https://github.com/mmnto-ai/totem.git' }),
+    ).toBe('totem');
+    expect(
+      deriveCohortRepoId(tmpRoot, { remoteUrl: 'https://github.com/mmnto-ai/liquid-city' }),
+    ).toBe('liquid-city');
+  });
+
+  it('falls back to package.json name basename (scope stripped) when no remote', () => {
+    writeConsumerPkg(tmpRoot, {});
+    fs.writeFileSync(
+      path.join(tmpRoot, 'package.json'),
+      JSON.stringify({ name: '@mmnto/totem-status' }, null, 2),
+      'utf-8',
+    );
+    expect(deriveCohortRepoId(tmpRoot, { remoteUrl: undefined, gitRoot: tmpRoot })).toBe(
+      'totem-status',
+    );
+  });
+
+  it('falls back to the git-root dir basename when neither remote nor package name resolve', () => {
+    const named = path.join(tmpRoot, 'my-cohort-repo');
+    fs.mkdirSync(named, { recursive: true });
+    expect(deriveCohortRepoId(named, { remoteUrl: undefined, gitRoot: named })).toBe(
+      'my-cohort-repo',
+    );
+  });
+
+  it('never networks / never throws on a git failure (returns a fallback or undefined)', () => {
+    // A remote-reader that throws must not propagate — the helper degrades.
+    expect(() =>
+      deriveCohortRepoId(tmpRoot, {
+        readRemote: () => {
+          throw new Error('git exploded');
+        },
+        gitRoot: tmpRoot,
+      }),
+    ).not.toThrow();
+  });
+});
+
+// ─── resolveCohortFloor ─────────────────────────────────
+
+describe('resolveCohortFloor', () => {
+  it('resolves self-in-tree when the current git root IS the canonical-source repo', () => {
+    writeSelfInTree(tmpRoot, '1.53.3');
+    const result = resolveCohortFloor('@mmnto/totem', tmpRoot);
+    expect(result.resolved).toBe(true);
+    if (result.resolved) {
+      expect(result.version).toBe('1.53.3');
+      expect(result.source).toBe('self-in-tree');
+    }
+  });
+
+  it('resolves a sibling ../totem checkout when not self-in-tree', () => {
+    // gitRoot is the consumer; the floor lives in a sibling totem checkout.
+    const consumer = path.join(tmpRoot, 'totem-status');
+    const sibling = path.join(tmpRoot, 'totem');
+    fs.mkdirSync(consumer, { recursive: true });
+    writeSelfInTree(sibling, '2.0.0');
+    const result = resolveCohortFloor('@mmnto/totem', consumer);
+    expect(result.resolved).toBe(true);
+    if (result.resolved) {
+      expect(result.version).toBe('2.0.0');
+      expect(result.source).toBe('sibling');
+    }
+  });
+
+  it('is honest-absent (resolved:false + reason) when no floor is reachable + NEVER networks', () => {
+    const consumer = path.join(tmpRoot, 'lonely');
+    fs.mkdirSync(consumer, { recursive: true });
+    const result = resolveCohortFloor('@mmnto/totem', consumer);
+    expect(result.resolved).toBe(false);
+    if (!result.resolved) {
+      expect(result.reason).toMatch(/not locally determinable|sibling/i);
+    }
+  });
+
+  it('does not throw when a package.json in the glob is unreadable/corrupt', () => {
+    const pkgDir = path.join(tmpRoot, 'packages', 'totem');
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, 'package.json'), '{ not valid json', 'utf-8');
+    expect(() => resolveCohortFloor('@mmnto/totem', tmpRoot)).not.toThrow();
+  });
+});
+
+// ─── detectVersionPinnedContract ────────────────────────
+
+describe('detectVersionPinnedContract', () => {
+  it('PASS — installed ≥ floor, consumer declares the pin (sensor reports pass)', () => {
+    writeSelfInTree(tmpRoot, '1.50.0');
+    writeConsumerPkg(tmpRoot, { '@mmnto/totem': '^1.50.0' });
+    writeInstalled(tmpRoot, '@mmnto/totem', '1.53.3');
+    const verdict = detectVersionPinnedContract(depsContract(), baseCtx({ repoId: 'totem' }));
+    expect(verdict.status).toBe('pass');
+  });
+
+  it('WARN — installed < floor (stale pin); message carries declared/installed/floor', () => {
+    writeSelfInTree(tmpRoot, '1.53.3');
+    writeConsumerPkg(tmpRoot, { '@mmnto/totem': '^1.40.0' });
+    writeInstalled(tmpRoot, '@mmnto/totem', '1.40.0');
+    const verdict = detectVersionPinnedContract(depsContract(), baseCtx({ repoId: 'totem' }));
+    expect(verdict.status).toBe('warn');
+    expect(verdict.message).toContain('1.40.0'); // installed
+    expect(verdict.message).toContain('1.53.3'); // floor
+  });
+
+  it('detector NEVER emits fail — even a blocking contract returns warn (CLI promotes)', () => {
+    // Claim-class + layering invariant: fail-promotion is a CLI-edge concern.
+    writeSelfInTree(tmpRoot, '1.53.3');
+    writeConsumerPkg(tmpRoot, { '@mmnto/totem': '^1.40.0' });
+    writeInstalled(tmpRoot, '@mmnto/totem', '1.40.0');
+    const verdict = detectVersionPinnedContract(
+      depsContract({ blocking: true }),
+      baseCtx({ repoId: 'totem' }),
+    );
+    expect(verdict.status).toBe('warn');
+    expect(verdict.status).not.toBe('fail');
+  });
+
+  it('SKIP — pin not declared in the consumer package.json (cohort permits absence)', () => {
+    writeSelfInTree(tmpRoot, '1.53.3');
+    writeConsumerPkg(tmpRoot, { 'unrelated-dep': '^1.0.0' });
+    const verdict = detectVersionPinnedContract(depsContract(), baseCtx({ repoId: 'totem' }));
+    expect(verdict.status).toBe('skip');
+    expect(verdict.message).toMatch(/not declared/i);
+  });
+
+  it('SKIP — consumers present and current repo not listed (not-a-consumer)', () => {
+    writeSelfInTree(tmpRoot, '1.53.3');
+    writeConsumerPkg(tmpRoot, { '@mmnto/totem': '^1.50.0' });
+    const verdict = detectVersionPinnedContract(
+      depsContract({ consumers: ['totem-strategy', 'liquid-city'] }),
+      baseCtx({ repoId: 'totem-status' }),
+    );
+    expect(verdict.status).toBe('skip');
+  });
+
+  it('SKIP — floor unresolvable (no self-in-tree, no sibling); reason in message, no throw', () => {
+    const consumer = path.join(tmpRoot, 'lonely');
+    fs.mkdirSync(consumer, { recursive: true });
+    writeConsumerPkg(consumer, { '@mmnto/totem': '^1.50.0' });
+    const verdict = detectVersionPinnedContract(
+      depsContract(),
+      baseCtx({ cwd: consumer, gitRoot: consumer, repoId: 'totem-status' }),
+    );
+    expect(verdict.status).toBe('skip');
+  });
+
+  it('SKIP — id resolves no deps package name (doctrine pin handed back to CLI as skip)', () => {
+    const verdict = detectVersionPinnedContract(
+      depsContract({ id: 'governance-doctrine' }),
+      baseCtx({ repoId: 'totem' }),
+    );
+    expect(verdict.status).toBe('skip');
+  });
+
+  it('no-throw on a corrupt consumer package.json — degrades to skip/warn', () => {
+    fs.writeFileSync(path.join(tmpRoot, 'package.json'), '{ broken', 'utf-8');
+    writeSelfInTree(tmpRoot, '1.53.3');
+    expect(() =>
+      detectVersionPinnedContract(depsContract(), baseCtx({ repoId: 'totem' })),
+    ).not.toThrow();
+  });
+
+  it('falls back to semver.minVersion(range) when node_modules is absent', () => {
+    // No install — minVersion('^1.53.0') = 1.53.0, equals floor → pass.
+    writeSelfInTree(tmpRoot, '1.53.0');
+    writeConsumerPkg(tmpRoot, { '@mmnto/totem': '^1.53.0' });
+    const verdict = detectVersionPinnedContract(depsContract(), baseCtx({ repoId: 'totem' }));
+    expect(verdict.status).toBe('pass');
+  });
+
+  it('SKIP (never throws) on an invalid declared range — claim guarded', () => {
+    writeSelfInTree(tmpRoot, '1.53.3');
+    writeConsumerPkg(tmpRoot, { '@mmnto/totem': 'not-a-range' });
+    const verdict = detectVersionPinnedContract(depsContract(), baseCtx({ repoId: 'totem' }));
+    expect(verdict.status).toBe('skip');
+  });
+
+  it('claim-class bound — the verdict is pin-currency only, never a content-equality verdict', () => {
+    // A version-pinned contract must never assert content drift. We assert the
+    // message is framed around versions/pins, not file content equality.
+    writeSelfInTree(tmpRoot, '1.53.3');
+    writeConsumerPkg(tmpRoot, { '@mmnto/totem': '^1.40.0' });
+    writeInstalled(tmpRoot, '@mmnto/totem', '1.40.0');
+    const verdict = detectVersionPinnedContract(depsContract(), baseCtx({ repoId: 'totem' }));
+    expect(verdict.message).not.toMatch(/content|file|hash|byte/i);
+    expect(verdict.message).toMatch(/version|pin|floor|install/i);
+  });
+});

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -1,0 +1,543 @@
+/**
+ * Version-pinned parity drift detector (PR-1, mmnto-ai/totem#2069).
+ *
+ * First detection slice on top of the merged manifest-parser skeleton (#2070).
+ * Senses ONE tractability class — `version-pinned` — and only its DEPS subset
+ * (the four `@mmnto/*` cohort-floor contracts: `mmnto-cli-version`,
+ * `mmnto-totem-version`, `mmnto-mcp-version`,
+ * `mmnto-pack-rust-architecture-version`). The verdict is **pin currency only**
+ * (Tenet 20 claim-class bound): does the consumer's `@mmnto/*` pin resolve to
+ * the current published cohort floor? It NEVER asserts semantic / file-content
+ * drift — that would over-claim the `version-pinned` class.
+ *
+ * Layering: core must NOT import cli's `DiagnosticResult` (wrong dependency
+ * direction). This module returns a core-local `ParityContractVerdict`; the CLI
+ * (`doctor-parity.ts`) maps it to `DiagnosticResult` and owns the
+ * `--strict`/`blocking` fail-promotion. The detector itself returns ONLY
+ * `pass`/`warn`/`skip` — never `fail` — so the gate edge stays a CLI concern.
+ *
+ * Design invariants (mirroring `parity-manifest.ts` + `strategy-resolver.ts`):
+ *   - **Honest-absent (Tenet 14):** absence is never an error. Pin not declared,
+ *     not-a-consumer, floor-unresolvable, or a doctrine pin this slice doesn't
+ *     handle → `skip` (the manifest's `-` "cohort permits absence"), never a
+ *     fabricated verdict.
+ *   - **NEVER networks:** the cohort floor is derived LOCALLY — self-in-tree
+ *     (the totem monorepo at the current git root) or a `../totem` sibling
+ *     checkout. Neither reachable → honest-absent `skip` with a reason.
+ *   - **Side-effect-free / no caching:** every call reads from scratch. Each
+ *     filesystem / git seam is injectable so tests drive synthetic fixtures.
+ *   - **Never throws:** every read failure degrades to a `skip`/`warn` verdict;
+ *     the sensor must never crash the doctor pipeline.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import semver from 'semver';
+
+import type { ParityContract } from './parity-manifest.js';
+import { safeExec } from './sys/exec.js';
+import { resolveGitRoot } from './sys/git.js';
+
+// ─── Constants ──────────────────────────────────────────
+
+/**
+ * Fixed scope for every PR-1 deps contract. The id slug (`mmnto-<x>-version`)
+ * is the literal middle of the package name `@mmnto/<x>`; the scope is constant.
+ */
+const MMNTO_SCOPE = '@mmnto/';
+
+/** The `mmnto-…-version` id convention PR-1 maps to a deps package name. */
+const DEPS_CONTRACT_ID = /^mmnto-(.+)-version$/;
+
+/** Sibling totem-monorepo dirname probed for a cohort floor (mirrors `resolveStrategyRoot` layer 3). */
+const SIBLING_TOTEM_DIRNAME = 'totem';
+
+/** Bounded git-command timeout for the origin-remote probe (matches `sys/git.ts`). */
+const GIT_REMOTE_TIMEOUT_MS = 15_000;
+
+/**
+ * The dep fields, in resolution order, that a consumer can declare an `@mmnto/*`
+ * pin under. `dependencies` first so a normal runtime dep wins display, but the
+ * detector treats a declaration in ANY of these as "the pin is declared here."
+ */
+const DEP_FIELDS = ['dependencies', 'devDependencies', 'optionalDependencies'] as const;
+
+// ─── Verdict type ───────────────────────────────────────
+
+/**
+ * Core-local per-contract verdict. The CLI maps this to its `DiagnosticResult`
+ * (core cannot depend on cli). The detector emits ONLY `pass`/`warn`/`skip` —
+ * `fail` is reserved for the CLI's `--strict`/`blocking` promotion edge — but
+ * `fail` stays in the union so the CLI mapping is total over the same shape.
+ */
+export interface ParityContractVerdict {
+  status: 'pass' | 'warn' | 'fail' | 'skip';
+  message: string;
+  remediation?: string;
+}
+
+// ─── deriveCohortRepoId ─────────────────────────────────
+
+/** Test seams for {@link deriveCohortRepoId} (mirrors `StrategyResolverOptions`). */
+export interface DeriveCohortRepoIdOptions {
+  /**
+   * Pre-resolved git `origin` remote URL. Production callers omit it and the
+   * helper shells out via `git remote get-url origin`. When provided (even as
+   * `undefined`, signalling "no remote"), the shell-out is skipped.
+   */
+  remoteUrl?: string;
+  /**
+   * Full override of the remote reader. Takes precedence over `remoteUrl`. A
+   * throwing reader is swallowed (git failure → fall through), so passing one
+   * that throws exercises the no-network / no-throw path.
+   */
+  readRemote?: (cwd: string) => string | undefined;
+  /** Test seam — production callers omit and the helper invokes `resolveGitRoot(cwd)`. */
+  gitRoot?: string | null;
+}
+
+/**
+ * Derive the current repo's cohort id (e.g. `totem-status`) used to evaluate a
+ * contract's `consumers` applicability. Precedence:
+ *   1. git `origin` remote — `…mmnto-ai/<name>(.git)?` → `<name>`.
+ *   2. `package.json` `name` basename (scope stripped) — `@mmnto/totem-status`
+ *      → `totem-status`.
+ *   3. git-root directory basename.
+ *
+ * Returns `undefined` only when nothing resolves. NEVER throws and NEVER
+ * networks beyond the local `git remote get-url` read (which is swallowed on
+ * failure — git being unavailable is a routine fall-through, not an error).
+ */
+export function deriveCohortRepoId(
+  cwd: string,
+  options: DeriveCohortRepoIdOptions = {},
+): string | undefined {
+  // ── 1. git origin remote ──
+  const remoteUrl = readOriginRemote(cwd, options);
+  const fromRemote = repoIdFromRemoteUrl(remoteUrl);
+  if (fromRemote !== undefined) return fromRemote;
+
+  // Anchor the fallbacks at the git root (not the deep cwd) so the dir-basename
+  // fallback names the repo, not a nested subdir. Lazy: only probed when the
+  // remote miss forces a fallback.
+  const root = resolveRootForFallback(cwd, options.gitRoot);
+
+  // ── 2. package.json name basename (scope stripped) ──
+  const fromPkg = repoIdFromPackageName(root);
+  if (fromPkg !== undefined) return fromPkg;
+
+  // ── 3. git-root dir basename ──
+  const base = path.basename(root);
+  return base.length > 0 ? base : undefined;
+}
+
+/**
+ * Read the git `origin` remote URL, honoring the injected seams. A throwing
+ * reader (or a real git failure) is swallowed — the caller falls through to the
+ * package.json / dir-basename fallbacks.
+ */
+function readOriginRemote(cwd: string, options: DeriveCohortRepoIdOptions): string | undefined {
+  if (options.readRemote !== undefined) {
+    try {
+      return options.readRemote(cwd);
+      // totem-context: an injected remote-reader that throws is treated as "no remote resolvable" (fall through to the package.json / dir-basename fallbacks); rethrowing would break the never-throws contract for a routine git miss.
+    } catch {
+      return undefined;
+    }
+  }
+  if ('remoteUrl' in options) return options.remoteUrl;
+  try {
+    return safeExec('git', ['remote', 'get-url', 'origin'], {
+      cwd,
+      timeout: GIT_REMOTE_TIMEOUT_MS,
+    });
+    // totem-context: a missing remote / non-git dir / absent git binary is a routine fall-through to the package.json + dir-basename fallbacks, not a sensor failure — the doctor runs against repos without an origin remote by design.
+  } catch {
+    return undefined;
+  }
+}
+
+/** Extract `<name>` from a `…mmnto-ai/<name>(.git)?` remote URL, else undefined. */
+function repoIdFromRemoteUrl(remoteUrl: string | undefined): string | undefined {
+  if (typeof remoteUrl !== 'string' || remoteUrl.trim().length === 0) return undefined;
+  // Match the org segment in both ssh (`git@…:mmnto-ai/x.git`) and https
+  // (`https://…/mmnto-ai/x.git`) forms; tolerate a trailing `.git` + slashes.
+  const match = remoteUrl.trim().match(/mmnto-ai\/([^/\s]+?)(?:\.git)?\/?$/);
+  return match?.[1];
+}
+
+/** Read `package.json` `name`, strip a leading `@scope/`, return the basename. */
+function repoIdFromPackageName(root: string): string | undefined {
+  const name = readPackageName(path.join(root, 'package.json'));
+  if (name === undefined) return undefined;
+  // `@mmnto/totem-status` → `totem-status`; `plain-name` → `plain-name`.
+  const slash = name.lastIndexOf('/');
+  const base = slash === -1 ? name : name.slice(slash + 1);
+  return base.length > 0 ? base : undefined;
+}
+
+/** Resolve the anchor for fallbacks: injected gitRoot, else `resolveGitRoot(cwd)`, else cwd. */
+function resolveRootForFallback(cwd: string, injected: string | null | undefined): string {
+  if (injected !== undefined) return injected ?? cwd;
+  try {
+    return resolveGitRoot(cwd) ?? cwd;
+    // totem-context: resolveGitRoot throws on permission errors / corrupted index; falling back to cwd keeps the dir-basename fallback working rather than crashing the sensor on a git hiccup.
+  } catch {
+    return cwd;
+  }
+}
+
+// ─── packageNameForContract ─────────────────────────────
+
+/**
+ * Resolve the `@mmnto/*` package name a deps contract pins. Precedence:
+ *   1. **canonical-source path locator** — when `canonicalSource` carries a
+ *      `:path/to/package.json` segment (e.g. `mmnto-cli-version`'s
+ *      `mmnto-ai/totem:packages/cli/package.json#version`), read the `name`
+ *      from that package.json under `floorRoot`. Authoritative — no id guess.
+ *   2. **id convention** — `mmnto-<x>-version` → `@mmnto/<x>`.
+ *
+ * Returns `undefined` for ids that don't match the `mmnto-…-version` convention
+ * (e.g. `governance-doctrine`, `gate-config`) so ONLY the deps contracts this
+ * slice handles resolve a package name; the CLI keeps the rest as `skip` stubs.
+ *
+ * @param floorRoot Optional root the canonical-source path locator anchors at
+ *                  (the resolved cohort-floor repo). Omit when only the id
+ *                  convention is wanted.
+ */
+export function packageNameForContract(
+  contract: ParityContract,
+  floorRoot?: string,
+): string | undefined {
+  // ── 1. canonical-source path locator → read `name` from that package.json ──
+  if (floorRoot !== undefined) {
+    const fromLocator = packageNameFromCanonicalSource(contract.canonicalSource, floorRoot);
+    if (fromLocator !== undefined) return fromLocator;
+  }
+
+  // ── 2. id convention (mmnto-<x>-version → @mmnto/<x>) ──
+  const match = contract.id.match(DEPS_CONTRACT_ID);
+  if (match?.[1] === undefined) return undefined;
+  return `${MMNTO_SCOPE}${match[1]}`;
+}
+
+/**
+ * Read the `name` from the package.json referenced by a `repo:path#fragment`
+ * canonical-source locator, anchored at `floorRoot`. Returns undefined when the
+ * locator has no `:package.json` path segment or the file is unreadable.
+ */
+function packageNameFromCanonicalSource(
+  canonicalSource: string | null,
+  floorRoot: string,
+): string | undefined {
+  if (typeof canonicalSource !== 'string') return undefined;
+  // Shape: `<repo>:<path>#<fragment>` — we only want the `<path>` between the
+  // first `:` and an optional `#`. A bare `mmnto-ai/totem` (no `:`) has no path.
+  const colon = canonicalSource.indexOf(':');
+  if (colon === -1) return undefined;
+  const afterColon = canonicalSource.slice(colon + 1);
+  const hash = afterColon.indexOf('#');
+  const relPath = (hash === -1 ? afterColon : afterColon.slice(0, hash)).trim();
+  if (!relPath.endsWith('package.json')) return undefined;
+  return readPackageName(path.join(floorRoot, relPath));
+}
+
+// ─── resolveCohortFloor ─────────────────────────────────
+
+/**
+ * Honest-absent cohort-floor resolution outcome (discriminated union, mirroring
+ * `StrategyRootStatus`):
+ *   - `resolved: true`  — `version` is the floor; `source` tags WHICH local
+ *     layer supplied it (`self-in-tree` | `sibling`).
+ *   - `resolved: false` — `reason` is an agent-surfacing string (e.g. clone the
+ *     monorepo as a sibling). The sensor renders this as a `skip`.
+ */
+export type CohortFloorStatus =
+  | { resolved: true; version: string; source: 'self-in-tree' | 'sibling' }
+  | { resolved: false; reason: string };
+
+/**
+ * Resolve the "current published version" cohort floor for `packageName`,
+ * derived LOCALLY (NEVER networks), in precedence order:
+ *   (a) **self-in-tree** — the current git root IS the canonical-source repo
+ *       (the totem monorepo): glob `<gitRoot>/packages/*​/package.json`, find
+ *       the one whose `name === packageName`, read its `version`.
+ *   (b) **sibling** — `<gitRoot>/../totem` exists as a directory: glob its
+ *       `packages/*​/package.json` the same way.
+ *   (c) **honest-absent** — neither reachable → `{ resolved: false, reason }`.
+ *
+ * NEVER fabricates a floor and NEVER fetches. Anchors at `gitRoot`, not cwd
+ * (mirroring `strategy-resolver.ts`). Read failures within the glob are
+ * swallowed per-file so one corrupt package.json can't crash the resolver.
+ *
+ * The floor is keyed structurally on `packageName` (the matching
+ * `packages/*​/package.json` `name`), NOT on the consumer's cohort id — a
+ * misderived repoId can't mask a genuine in-tree floor.
+ */
+export function resolveCohortFloor(packageName: string, gitRoot: string): CohortFloorStatus {
+  // ── (a) self-in-tree ──
+  // The canonical-source repo for every deps contract is the totem monorepo. If
+  // the current repo IS that monorepo, its own packages/*/package.json is the
+  // floor. We detect "is the monorepo" structurally (a packages/*/package.json
+  // whose name === packageName), not just by id, so a misderived repoId can't
+  // mask a genuine in-tree floor.
+  const selfVersion = readVersionFromPackagesGlob(gitRoot, packageName);
+  if (selfVersion !== undefined) {
+    return { resolved: true, version: selfVersion, source: 'self-in-tree' };
+  }
+
+  // ── (b) sibling ../totem ──
+  const sibling = path.normalize(path.join(gitRoot, '..', SIBLING_TOTEM_DIRNAME));
+  if (isDirectory(sibling)) {
+    const siblingVersion = readVersionFromPackagesGlob(sibling, packageName);
+    if (siblingVersion !== undefined) {
+      return { resolved: true, version: siblingVersion, source: 'sibling' };
+    }
+  }
+
+  // ── (c) honest-absent ──
+  return {
+    resolved: false,
+    reason: `cohort floor for ${packageName} not locally determinable; clone mmnto-ai/totem as a sibling (../${SIBLING_TOTEM_DIRNAME}) or run from the totem monorepo`,
+  };
+}
+
+/**
+ * Glob `<root>/packages/*​/package.json`, return the `version` of the one whose
+ * `name === packageName`. Returns undefined when `<root>/packages` is absent,
+ * no package matches, or every read fails. Per-file read failures are swallowed
+ * so one corrupt manifest doesn't sink the whole probe.
+ */
+function readVersionFromPackagesGlob(root: string, packageName: string): string | undefined {
+  const packagesDir = path.join(root, 'packages');
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(packagesDir, { withFileTypes: true });
+    // totem-context: an absent or unreadable packages/ dir is the "not the monorepo here" signal — return undefined so the resolver falls through to the sibling / honest-absent layer rather than throwing.
+  } catch {
+    return undefined;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    const pkgJson = path.join(packagesDir, entry.name, 'package.json');
+    const parsed = readPackageJson(pkgJson);
+    if (parsed?.name === packageName && typeof parsed.version === 'string') {
+      return parsed.version;
+    }
+  }
+  return undefined;
+}
+
+// ─── detectVersionPinnedContract ────────────────────────
+
+/** Test seams + context for {@link detectVersionPinnedContract}. */
+export interface DetectVersionPinnedContext {
+  /** The consumer repo to read `package.json` / `node_modules` from. */
+  cwd: string;
+  /** The git root to anchor cohort-floor resolution at (NOT cwd — mirrors the resolver). */
+  gitRoot: string;
+  /** The current repo's cohort id (from {@link deriveCohortRepoId}) for `consumers` applicability. */
+  repoId?: string;
+  /**
+   * Test seam — override the consumer package.json read. Production callers omit
+   * it and the detector reads `<cwd>/package.json`.
+   */
+  readPackageJson?: (absPath: string) => PackageJsonShape | undefined;
+}
+
+/**
+ * Minimal package.json shape the detector reads. Deliberately loose — the file
+ * is untrusted on-disk JSON, so every field is optional + runtime-checked.
+ */
+export interface PackageJsonShape {
+  name?: string;
+  version?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+}
+
+/**
+ * Detect drift for ONE `version-pinned` deps contract. Returns a
+ * `ParityContractVerdict`:
+ *   - **pass** — the consumer's resolved-installed `@mmnto/*` version is ≥ the
+ *     cohort floor (current).
+ *   - **warn** — installed < floor (stale pin). Sensor-not-gate default: the
+ *     detector returns `warn` even for a `blocking` contract; the CLI promotes
+ *     to `fail` only under `--strict`.
+ *   - **skip** — not-a-consumer / pin not declared / floor unresolvable / not a
+ *     deps contract this slice handles / unparseable range (honest-absent).
+ *
+ * NEVER emits `fail` (CLI-edge concern). NEVER throws (read failures degrade to
+ * `skip`). NEVER networks (floor is local-only). NEVER asserts content drift
+ * (claim-class bound to pin currency).
+ */
+export function detectVersionPinnedContract(
+  contract: ParityContract,
+  ctx: DetectVersionPinnedContext,
+): ParityContractVerdict {
+  // ── Applicability: consumers list ──
+  if (contract.consumers !== undefined && ctx.repoId !== undefined) {
+    if (!contract.consumers.includes(ctx.repoId)) {
+      return {
+        status: 'skip',
+        message: `cohort permits absence here (${ctx.repoId} not in consumers)`,
+      };
+    }
+  }
+
+  // ── Resolve the package name (id convention + canonical-source locator) ──
+  // Pass gitRoot as the floorRoot so a canonical-source path locator
+  // (mmnto-cli-version) reads the name from the in-tree package.json.
+  const packageName = packageNameForContract(contract, ctx.gitRoot);
+  if (packageName === undefined) {
+    return {
+      status: 'skip',
+      message: `not a deps version-pinned contract this slice handles (${contract.id})`,
+    };
+  }
+
+  // ── Read the consumer package.json + its declared range for this pkg ──
+  const readPkg = ctx.readPackageJson ?? readPackageJson;
+  const consumerPkg = readPkg(path.join(ctx.cwd, 'package.json'));
+  const declaredRange = consumerPkg ? findDeclaredRange(consumerPkg, packageName) : undefined;
+  if (declaredRange === undefined) {
+    return {
+      status: 'skip',
+      message: `${packageName} not declared in this consumer (cohort permits absence)`,
+    };
+  }
+
+  // Guard an unparseable declared range BEFORE resolving anything else — a
+  // garbage range can't yield a currency verdict, so honest-absent skip.
+  if (semver.validRange(declaredRange) === null) {
+    return {
+      status: 'skip',
+      message: `${packageName} declared range "${declaredRange}" is not a valid semver range`,
+    };
+  }
+
+  // ── Resolve the consumer's installed version (fallback: minVersion(range)) ──
+  const installed = resolveInstalledVersion(ctx.cwd, packageName, declaredRange);
+  if (installed === undefined) {
+    return {
+      status: 'skip',
+      message: `${packageName} pinned (${declaredRange}) but no resolvable installed version`,
+    };
+  }
+
+  // ── Resolve the cohort floor (local-only; honest-absent on miss) ──
+  const floor = resolveCohortFloor(packageName, ctx.gitRoot);
+  if (!floor.resolved) {
+    return { status: 'skip', message: floor.reason };
+  }
+
+  // Guard an invalid floor version (corrupt in-tree manifest) → honest-absent.
+  if (semver.valid(floor.version) === null) {
+    return {
+      status: 'skip',
+      message: `cohort floor for ${packageName} ("${floor.version}") is not a valid version`,
+    };
+  }
+
+  // ── Verdict: pin currency only (semver compare) ──
+  // installed ≥ floor → current; installed < floor → stale. The claim is pin
+  // currency, NOT semantic content — a version-pinned contract may never assert
+  // file/content equality.
+  if (semver.gte(installed, floor.version)) {
+    return {
+      status: 'pass',
+      message: `${packageName} pin current — installed ${installed} ≥ cohort floor ${floor.version} (${floor.source})`,
+    };
+  }
+
+  return {
+    status: 'warn',
+    message: `${packageName} pin stale — declared ${declaredRange}, installed ${installed} < cohort floor ${floor.version} (${floor.source})`,
+    remediation: `Bump the ${packageName} dependency to >= ${floor.version} and reinstall, then re-run totem doctor --parity.`,
+  };
+}
+
+/**
+ * Resolve the consumer's installed `@mmnto/*` version, mirroring
+ * `resolveEngineVersion`'s require-with-ENOENT-fallback idiom: read
+ * `<cwd>/node_modules/<pkg>/package.json#version`; on any read failure fall back
+ * to `semver.minVersion(declaredRange)` (the floor the caret range implies).
+ * Returns undefined only when neither resolves to a valid version.
+ */
+function resolveInstalledVersion(
+  cwd: string,
+  packageName: string,
+  declaredRange: string,
+): string | undefined {
+  const installedPkg = readPackageJson(
+    path.join(cwd, 'node_modules', ...packageName.split('/'), 'package.json'),
+  );
+  if (installedPkg?.version !== undefined && semver.valid(installedPkg.version) !== null) {
+    return installedPkg.version;
+  }
+  // Fallback: the minimum version the declared range admits. `minVersion`
+  // returns a SemVer or null; coerce to the bare version string.
+  const min = semver.minVersion(declaredRange);
+  return min?.version;
+}
+
+/** Find the declared range for `packageName` across the three dep fields, in order. */
+function findDeclaredRange(pkg: PackageJsonShape, packageName: string): string | undefined {
+  for (const field of DEP_FIELDS) {
+    const section = pkg[field];
+    if (section && typeof section === 'object') {
+      const range = section[packageName];
+      if (typeof range === 'string' && range.trim().length > 0) return range;
+    }
+  }
+  return undefined;
+}
+
+// ─── Shared filesystem helpers ──────────────────────────
+
+/**
+ * Read + JSON-parse a package.json into the loose {@link PackageJsonShape}.
+ * Returns undefined on any read / parse failure or a non-object payload —
+ * mirroring `readEngineRange`'s ENOENT-tolerant JSON read so a missing or
+ * corrupt manifest is honest-absent, never a throw.
+ */
+function readPackageJson(absPath: string): PackageJsonShape | undefined {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(absPath, 'utf-8');
+    // totem-context: a missing / unreadable package.json is the honest-absent signal callers degrade to a skip on; rethrowing would force every caller to wrap a routine absence in try/catch.
+  } catch {
+    return undefined;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+    // totem-context: a corrupt package.json degrades to undefined (honest-absent skip), not a crash — the sensor must never sink the doctor pipeline on a malformed consumer manifest.
+  } catch {
+    return undefined;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return undefined;
+  return parsed as PackageJsonShape;
+}
+
+/** Read just the `name` from a package.json, or undefined on any failure. */
+function readPackageName(absPath: string): string | undefined {
+  const parsed = readPackageJson(absPath);
+  return typeof parsed?.name === 'string' ? parsed.name : undefined;
+}
+
+/**
+ * `fs.statSync` raises on missing paths and on EACCES/ENOTDIR; treat any stat
+ * failure as "not a directory" (mirrors `strategy-resolver.ts`).
+ */
+function isDirectory(p: string): boolean {
+  try {
+    return fs.statSync(p).isDirectory();
+    // totem-context: stat failures (ENOENT, EACCES, ENOTDIR) are the sibling-miss signal; rethrowing would force the resolver to wrap a routine absence in try/catch.
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -17,9 +17,12 @@
  * `pass`/`warn`/`skip` — never `fail` — so the gate edge stays a CLI concern.
  *
  * Design invariants (mirroring `parity-manifest.ts` + `strategy-resolver.ts`):
- *   - **Honest-absent (Tenet 14):** absence is never an error. Pin not declared,
- *     not-a-consumer, floor-unresolvable, or a doctrine pin this slice doesn't
- *     handle → `skip` (the manifest's `-` "cohort permits absence"), never a
+ *   - **Honest-absent (Tenet 14):** absence is never an error. Not-a-consumer,
+ *     floor-unresolvable, or a doctrine pin this slice doesn't handle → `skip`
+ *     (the manifest's `-` "cohort permits absence"). An *applicable* consumer
+ *     missing an expected pin is also `skip` while the manifest is scaffold, but
+ *     kept DISTINCT (expected-but-absent → a `warn` once the consumers lists are
+ *     verified) so the `consumers` field still catches the missing case. Never a
  *     fabricated verdict.
  *   - **NEVER networks:** the cohort floor is derived LOCALLY — self-in-tree
  *     (the totem monorepo at the current git root) or a `../totem` sibling
@@ -406,9 +409,17 @@ export function detectVersionPinnedContract(
   const consumerPkg = readPkg(path.join(ctx.cwd, 'package.json'));
   const declaredRange = consumerPkg ? findDeclaredRange(consumerPkg, packageName) : undefined;
   if (declaredRange === undefined) {
+    // Applicable-but-missing: we already passed the `consumers` gate above, so
+    // this repo IS an applicable consumer (or applicability is underivable) — an
+    // expected pin that's absent is drift, NOT cohort-permitted absence. Held as
+    // a skip-with-note while the manifest is scaffold (consumers lists are
+    // best-effort); flips to `warn` once verified. Kept DISTINCT from the
+    // not-a-consumer skip so the `consumers` field still does its job (strategy
+    // ack 2026-06-03T0156Z, design-call 3).
     return {
       status: 'skip',
-      message: `${packageName} not declared in this consumer (cohort permits absence)`,
+      message: `${packageName} expected but not declared — applicable consumer (scaffold: skip; becomes a drift warn once consumers are verified)`,
+      remediation: `Declare ${packageName} in this repo's package.json, or drop this repo from the contract's consumers list if it genuinely does not apply here.`,
     };
   }
 

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -194,32 +194,42 @@ function resolveRootForFallback(cwd: string, injected: string | null | undefined
 // ─── packageNameForContract ─────────────────────────────
 
 /**
- * Resolve the `@mmnto/*` package name a deps contract pins. Precedence:
- *   1. **canonical-source path locator** — when `canonicalSource` carries a
+ * Resolve the `@mmnto/*` (or vendor) package name a deps/vendor contract pins.
+ * Precedence:
+ *   1. **explicit `package:` field** (mmnto-ai/totem-strategy#517) — the
+ *      machine-parseable name, derive-not-guess. Preferred when present.
+ *   2. **canonical-source path locator** — when `canonicalSource` carries a
  *      `:path/to/package.json` segment (e.g. `mmnto-cli-version`'s
  *      `mmnto-ai/totem:packages/cli/package.json#version`), read the `name`
  *      from that package.json under `floorRoot`. Authoritative — no id guess.
- *   2. **id convention** — `mmnto-<x>-version` → `@mmnto/<x>`.
+ *   3. **id convention** — `mmnto-<x>-version` → `@mmnto/<x>` (fallback until all
+ *      contracts carry `package:`).
  *
- * Returns `undefined` for ids that don't match the `mmnto-…-version` convention
- * (e.g. `governance-doctrine`, `gate-config`) so ONLY the deps contracts this
- * slice handles resolve a package name; the CLI keeps the rest as `skip` stubs.
+ * Returns `undefined` for contracts with no `package:`, no path locator, and an
+ * id that doesn't match the convention (e.g. `governance-doctrine`, `gate-config`)
+ * so ONLY the contracts this slice handles resolve a name; the CLI keeps the rest
+ * as `skip` stubs.
  *
  * @param floorRoot Optional root the canonical-source path locator anchors at
- *                  (the resolved cohort-floor repo). Omit when only the id
- *                  convention is wanted.
+ *                  (the resolved cohort-floor repo). Omit when only `package:` /
+ *                  the id convention is wanted.
  */
 export function packageNameForContract(
   contract: ParityContract,
   floorRoot?: string,
 ): string | undefined {
-  // ── 1. canonical-source path locator → read `name` from that package.json ──
+  // ── 1. explicit `package:` field (derive-not-guess; strategy#517) ──
+  if (typeof contract.package === 'string' && contract.package.trim().length > 0) {
+    return contract.package.trim();
+  }
+
+  // ── 2. canonical-source path locator → read `name` from that package.json ──
   if (floorRoot !== undefined) {
     const fromLocator = packageNameFromCanonicalSource(contract.canonicalSource, floorRoot);
     if (fromLocator !== undefined) return fromLocator;
   }
 
-  // ── 2. id convention (mmnto-<x>-version → @mmnto/<x>) ──
+  // ── 3. id convention (mmnto-<x>-version → @mmnto/<x>) ──
   const match = contract.id.match(DEPS_CONTRACT_ID);
   if (match?.[1] === undefined) return undefined;
   // Concatenate (not template-interpolate) so the `@mmnto/` scope's own trailing
@@ -316,18 +326,22 @@ export function resolveCohortFloor(packageName: string, gitRoot: string): Cohort
  */
 function readVersionFromPackagesGlob(root: string, packageName: string): string | undefined {
   const packagesDir = path.join(root, 'packages');
-  let entries: fs.Dirent[];
+  let names: string[];
   try {
-    entries = fs.readdirSync(packagesDir, { withFileTypes: true });
+    names = fs.readdirSync(packagesDir);
     // totem-context: an absent or unreadable packages/ dir is the "not the monorepo here" signal — return undefined so the resolver falls through to the sibling / honest-absent layer rather than throwing.
   } catch {
     return undefined;
   }
 
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const pkgJson = path.join(packagesDir, entry.name, 'package.json');
-    const parsed = readPackageJson(pkgJson);
+  for (const name of names) {
+    const entryPath = path.join(packagesDir, name);
+    // Use the statSync-based `isDirectory` (follows symlinks) rather than a
+    // `Dirent.isDirectory()` filter — pnpm / workspace setups symlink package
+    // dirs, which the lstat-like Dirent check reports as non-directories and
+    // would skip (GCA review #2071).
+    if (!isDirectory(entryPath)) continue;
+    const parsed = readPackageJson(path.join(entryPath, 'package.json'));
     if (parsed?.name === packageName && typeof parsed.version === 'string') {
       return parsed.version;
     }
@@ -345,6 +359,13 @@ export interface DetectVersionPinnedContext {
   gitRoot: string;
   /** The current repo's cohort id (from {@link deriveCohortRepoId}) for `consumers` applicability. */
   repoId?: string;
+  /**
+   * Package name pre-resolved by the caller (the CLI resolves it once for
+   * routing — {@link packageNameForContract}). When provided, the detector skips
+   * re-resolving it (avoids a duplicate locator package.json read). Omit and the
+   * detector resolves it itself.
+   */
+  packageName?: string;
   /**
    * Test seam — override the consumer package.json read. Production callers omit
    * it and the detector reads `<cwd>/package.json`.
@@ -384,7 +405,17 @@ export function detectVersionPinnedContract(
   ctx: DetectVersionPinnedContext,
 ): ParityContractVerdict {
   // ── Applicability: consumers list ──
-  if (contract.consumers !== undefined && ctx.repoId !== undefined) {
+  if (contract.consumers !== undefined) {
+    if (ctx.repoId === undefined) {
+      // Can't decide applicability without a cohort id — surface it (honest-
+      // absent) rather than silently treating the contract as applicable, which
+      // would make the consumers scope a no-op for this repo (Tenet 4 / Greptile
+      // review #2071).
+      return {
+        status: 'skip',
+        message: `cannot determine applicability — repo id unresolvable; contract is scoped to consumers [${contract.consumers.join(', ')}]`,
+      };
+    }
     if (!contract.consumers.includes(ctx.repoId)) {
       return {
         status: 'skip',
@@ -393,10 +424,11 @@ export function detectVersionPinnedContract(
     }
   }
 
-  // ── Resolve the package name (id convention + canonical-source locator) ──
-  // Pass gitRoot as the floorRoot so a canonical-source path locator
-  // (mmnto-cli-version) reads the name from the in-tree package.json.
-  const packageName = packageNameForContract(contract, ctx.gitRoot);
+  // ── Resolve the package name (`package:` → locator → id convention) ──
+  // Prefer a name pre-resolved by the CLI (avoids re-reading a locator's
+  // package.json — Greptile review #2071); fall back to resolving here for
+  // standalone callers (tests). gitRoot is the floorRoot for a path locator.
+  const packageName = ctx.packageName ?? packageNameForContract(contract, ctx.gitRoot);
   if (packageName === undefined) {
     return {
       status: 'skip',
@@ -410,8 +442,9 @@ export function detectVersionPinnedContract(
   const declaredRange = consumerPkg ? findDeclaredRange(consumerPkg, packageName) : undefined;
   if (declaredRange === undefined) {
     // Applicable-but-missing: we already passed the `consumers` gate above, so
-    // this repo IS an applicable consumer (or applicability is underivable) — an
-    // expected pin that's absent is drift, NOT cohort-permitted absence. Held as
+    // this repo IS an applicable consumer (in `consumers`, or `consumers` absent
+    // = applies to all) — an expected pin that's absent is drift, NOT
+    // cohort-permitted absence. Held as
     // a skip-with-note while the manifest is scaffold (consumers lists are
     // best-effort); flips to `warn` once verified. Kept DISTINCT from the
     // not-a-consumer skip so the `consumers` field still does its job (strategy
@@ -474,22 +507,32 @@ export function detectVersionPinnedContract(
 }
 
 /**
- * Resolve the consumer's installed `@mmnto/*` version, mirroring
- * `resolveEngineVersion`'s require-with-ENOENT-fallback idiom: read
- * `<cwd>/node_modules/<pkg>/package.json#version`; on any read failure fall back
- * to `semver.minVersion(declaredRange)` (the floor the caret range implies).
- * Returns undefined only when neither resolves to a valid version.
+ * Resolve the consumer's installed `@mmnto/*` version. Walks UP the directory
+ * tree from `cwd` reading `<dir>/node_modules/<pkg>/package.json#version` at each
+ * ancestor — monorepo / pnpm / npm-workspace installs hoist deps to a parent or
+ * root `node_modules` rather than the sub-package's, so a cwd-only read would
+ * miss them (GCA review #2071). Mirrors Node's own upward node_modules
+ * resolution. On no hit, falls back to `semver.minVersion(declaredRange)` (the
+ * floor the caret range implies). Returns undefined only when neither resolves
+ * to a valid version.
  */
 function resolveInstalledVersion(
   cwd: string,
   packageName: string,
   declaredRange: string,
 ): string | undefined {
-  const installedPkg = readPackageJson(
-    path.join(cwd, 'node_modules', ...packageName.split('/'), 'package.json'),
-  );
-  if (installedPkg?.version !== undefined && semver.valid(installedPkg.version) !== null) {
-    return installedPkg.version;
+  const segments = packageName.split('/');
+  let dir = path.resolve(cwd);
+  for (;;) {
+    const installedPkg = readPackageJson(
+      path.join(dir, 'node_modules', ...segments, 'package.json'),
+    );
+    if (installedPkg?.version !== undefined && semver.valid(installedPkg.version) !== null) {
+      return installedPkg.version;
+    }
+    const parent = path.dirname(dir);
+    if (parent === dir) break; // reached the filesystem root
+    dir = parent;
   }
   // Fallback: the minimum version the declared range admits. `minVersion`
   // returns a SemVer or null; coerce to the bare version string.

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -219,7 +219,9 @@ export function packageNameForContract(
   // ── 2. id convention (mmnto-<x>-version → @mmnto/<x>) ──
   const match = contract.id.match(DEPS_CONTRACT_ID);
   if (match?.[1] === undefined) return undefined;
-  return `${MMNTO_SCOPE}${match[1]}`;
+  // Concatenate (not template-interpolate) so the `@mmnto/` scope's own trailing
+  // `/` reads as the delimiter between scope and package slug.
+  return MMNTO_SCOPE + match[1];
 }
 
 /**
@@ -487,11 +489,12 @@ function resolveInstalledVersion(
 /** Find the declared range for `packageName` across the three dep fields, in order. */
 function findDeclaredRange(pkg: PackageJsonShape, packageName: string): string | undefined {
   for (const field of DEP_FIELDS) {
-    const section = pkg[field];
-    if (section && typeof section === 'object') {
-      const range = section[packageName];
-      if (typeof range === 'string' && range.trim().length > 0) return range;
-    }
+    // `pkg` is loose untrusted JSON; optional-chain the field read so a missing
+    // or non-object dep section yields undefined instead of throwing, then
+    // type-check the value itself. Avoids a null-guard idiom that two compiled
+    // rules disagree on.
+    const range = pkg[field]?.[packageName];
+    if (typeof range === 'string' && range.trim().length > 0) return range;
   }
   return undefined;
 }

--- a/packages/core/src/parity-manifest.ts
+++ b/packages/core/src/parity-manifest.ts
@@ -87,6 +87,10 @@ const RawParityContractSchema = z.object({
   title: z.string().optional(),
   blocking: z.boolean().optional(),
   consumers: z.array(z.string()).optional(),
+  // Explicit package identifier (mmnto-ai/totem-strategy#517) — the machine-
+  // parseable name for version/vendor contracts, so the detector derives the
+  // package rather than guessing it from the id convention.
+  package: z.string().optional(),
 });
 
 /**
@@ -130,6 +134,12 @@ export interface ParityContract {
    * applies to all cohort repos (ADR-102 per-consumer applicability).
    */
   consumers?: string[];
+  /**
+   * Optional explicit package identifier (mmnto-ai/totem-strategy#517) — the
+   * machine-parseable `@mmnto/*` (or vendor) package name a version/vendor
+   * contract pins. Preferred over the id-convention guess when present.
+   */
+  package?: string;
 }
 
 /** A fully parsed + validated parity manifest. */
@@ -291,6 +301,7 @@ function mapContract(raw: z.infer<typeof RawParityContractSchema>): ParityContra
     ...(raw.title !== undefined ? { title: raw.title } : {}),
     ...(raw.blocking !== undefined ? { blocking: raw.blocking } : {}),
     ...(raw.consumers !== undefined ? { consumers: raw.consumers } : {}),
+    ...(raw.package !== undefined ? { package: raw.package } : {}),
   };
 }
 


### PR DESCRIPTION
## What

First **drift-detection** slice on top of the merged `totem doctor --parity` skeleton (#2070). Replaces the version-pinned contracts' `skip` stubs with real **pin-currency** detection against the cohort `parity-manifest.yaml` — scoped to the `version-pinned` tractability class's **deps subset** (the four `@mmnto/*` cohort-floor contracts).

Charter: `mmnto-ai/totem-strategy#448` · manifest: `#508`/`#514`/`#515` · design doc: `.totem/specs/448.md` (`## PR-1` section).

Closes #2069

## How

`packages/core/src/parity-detect.ts` (pure, side-effect-free, **never networks**):

- **`deriveCohortRepoId`** — current repo's cohort id (git `origin` → `package.json` name → dir basename) for `consumers` applicability.
- **`packageNameForContract`** — `@mmnto/*` name from the canonical-source `package.json#name` locator, else the `mmnto-<x>-version` id convention.
- **`resolveCohortFloor`** — "current published version" derived **locally**: self-in-tree (the totem monorepo) → `../totem` sibling → **honest-absent** (mirrors `strategy-resolver.ts`). No npm, no fetch, no fabrication.
- **`detectVersionPinnedContract`** — `semver` pin-currency verdict: installed (node_modules, fallback `minVersion(range)`) vs floor → `pass` / `warn` / `skip`. **Claim-class bound** to pin currency — never asserts semantic content drift.

`packages/cli/src/commands/doctor-parity.ts`: `checkParity` routes version-pinned-with-package-name contracts through the detector; **mechanical / manual-attestation / doctrine pins keep the skip stub**. `--strict` promotes a `blocking: true` contract's `warn` → `fail` (sensor-not-gate by default).

## Semantics (verified by tests)

| Case | Verdict |
| --- | --- |
| installed ≥ cohort floor | `pass` |
| installed < cohort floor | `warn` (→ `fail` only when `blocking` + `--strict`) |
| repo not in `consumers` | `skip` (`-` cohort permits absence) |
| **applicable** consumer, pin missing | `skip` *distinct note* — expected-but-absent (→ `warn` once consumers verified) |
| floor unreachable / not a deps contract / bad range | `skip` (honest-absent, reason in message) |

## Strategy alignment

Built no-assumptions with strategy-claude (design-call acks `2026-06-03T0156Z`): floor = local-only (no fetch); honest-absent `skip` kept **distinct** from `pass` so a non-local consumer's blind spot is visible; applicable-but-missing kept distinct from not-a-consumer (design-call 3, folded here). The `package:` schema field (`mmnto-ai/totem-strategy#517`) is **not yet merged** — the id-convention parse is correct against today's manifest; `package:` folds in when #517 lands.

## Deferred by design

- **No changeset / unpublished** — `--parity` still stubs mechanical + manual-attestation, so a release would mislead. `@mmnto/cli` stays `1.53.3`; publishes when the feature is complete.
- **Mechanical + manual-attestation slices** — follow-ons; mechanical gets its own design pass (canonical-location-per-contract).

## Gate

`totem lint` (full branch) **PASS 0 errors** · `totem review` **PASS no findings** · eslint **0 errors** · `prettier --check` clean · tests **40 core + 14 cli + 134 doctor regression**.

The 66 `totem lint` warnings are false positives from naive pattern rules firing on a new file (`.git` in test-fixture URLs, `consumers.includes()` array-membership, sync `fs` matching prior art in `resolveEngineVersion`/`readEngineRange`) — not contorting correct code to silence them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
