### PR TITLE
chore(license): reconcile package licenses to Apache-2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@mmnto/totem-monorepo",
   "private": true,
+  "license": "Apache-2.0",
   "packageManager": "pnpm@11.2.2+sha512.36e6621fad506178936455e70247b8808ef4ec25797a9f437a93281a020484e2607f6a469a22e982987c3dbb8866e3071514ab10a4a1749e06edcd1ec118436f",
   "scripts": {
     "build": "turbo run build",

--- a/packages/pack-agent-security/README.md
+++ b/packages/pack-agent-security/README.md
@@ -25,4 +25,4 @@ Will land with `totem install pack/agent-security` once the pack resolver ships.
 
 ## License
 
-MIT. Same as the Totem monorepo.
+Apache-2.0. Same as the Totem monorepo.

--- a/packages/pack-agent-security/package.json
+++ b/packages/pack-agent-security/package.json
@@ -3,7 +3,7 @@
   "version": "1.53.3",
   "private": true,
   "description": "Zero-Trust Agent Governance security pack for Totem (ADR-089). Ships compound ast-grep rules that block known prompt-injection attack patterns at the commit boundary.",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mmnto-ai/totem.git",

--- a/packages/pack-rust-architecture/README.md
+++ b/packages/pack-rust-architecture/README.md
@@ -68,4 +68,4 @@ This pack is the first non-trivial consumer of the ADR-097 § 10 Pack v0.1 subst
 
 ## License
 
-MIT. Same as the Totem monorepo.
+Apache-2.0. Same as the Totem monorepo.

--- a/packages/pack-rust-architecture/package.json
+++ b/packages/pack-rust-architecture/package.json
@@ -3,7 +3,7 @@
   "version": "1.53.3",
   "private": false,
   "description": "Baseline architectural lessons for Rust + Bevy ECS consumers. ADR-097 Stage 1 pilot. Numeric safety, compile-time discipline, ECS hot-path patterns, schedule edges, determinism fixtures, test-vs-production parity.",
-  "license": "MIT",
+  "license": "Apache-2.0",
   "main": "./register.cjs",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## What

Reconcile every package's `license` to **Apache-2.0**, matching the repo `LICENSE` file.

## Why

The repo license is Apache-2.0 (the `LICENSE` file; GitHub detects it correctly), and `@mmnto/cli` / `totem` / `mcp` all declare Apache-2.0 — but two packages declared **MIT**:

| Package | Before | After | Published? |
|---|---|---|---|
| `@mmnto/pack-rust-architecture` | MIT | **Apache-2.0** | public (on npm as MIT) |
| `@mmnto/pack-agent-security` | MIT | **Apache-2.0** | private |
| root `@mmnto/totem-monorepo` | *(missing)* | **Apache-2.0** | private |

`@mmnto/pack-rust-architecture` is **published declaring MIT with no matching MIT `LICENSE` text**, contradicting its repo (Apache-2.0) and its siblings — which is what read as an **invalid / mismatched license on GitHub** (package + dependency-graph views). Almost certainly scaffolding-default drift, not a deliberate dual-license.

## Scope / decisions

- **Metadata-only** — matches the established field-only pattern (no package ships its own `LICENSE` file; all rely on the repo root).
- **No changeset, on purpose.** The changeset `fixed` group republishes the entire cohort, which would prematurely publish the still-incomplete `totem doctor --parity` detection (on `main`, unpublished by design). The corrected license propagates to npm at the **next** cohort release instead.
- Already-published `@mmnto/pack-rust-architecture@1.53.3` **stays MIT** (an npm tarball can't be relicensed retroactively); this governs future versions.

## Note

This is a licensing declaration — flagged as the consistent + conventional reconciliation (Apache-2.0 carries a patent grant, the right default for shipped tooling), not legal advice. Confirm it matches mmnto-ai's intent before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
