### PR TITLE
fix(core): review/lint branch-vs-base prefers origin/<base> over stale local ref (#2054)

### DIFF
--- a/.changeset/review-base-origin-first.md
+++ b/.changeset/review-base-origin-first.md
@@ -1,0 +1,10 @@
+---
+'@mmnto/totem': patch
+'@mmnto/cli': patch
+---
+
+fix(core): `totem review`/`lint` branch-vs-base diff prefers `origin/<base>` over a stale local ref, so false-CRITICALs can't false-block the push gate (mmnto-ai/totem#2054 / mmnto-ai/totem#2055).
+
+`getGitBranchDiff` tried the local `<base>` ref before `origin/<base>`. On a feature-branch workflow the local default branch is never checked out, so it is stale (or absent); `git diff <stale-base>...HEAD` then re-includes already-merged code as "new" — manufacturing false-CRITICAL review findings that block the push gate (the review hook will not stamp on a FAIL) and inflating the diff into the 50k truncation cliff.
+
+It now prefers the remote-tracking `origin/<base>` (the current merged base), falling back to the local ref only when origin is absent (offline / no-remote / shallow CI). Three-dot `...HEAD` already resolves merge-base, so this stays a local, no-network change — no fetch added. Fixes `review`, `lint`, and `verify-badges` through the shared helper. Part of the gate-correctness cluster (mmnto-ai/totem#2055).

--- a/packages/cli/src/git.ts
+++ b/packages/cli/src/git.ts
@@ -149,6 +149,7 @@ export async function getDiffForReview(
     getGitBranchDiff,
     getGitDiff,
     getGitDiffRange,
+    sanitizeForTerminal,
   } = await import('@mmnto/totem');
 
   const allIgnore = [...config.ignorePatterns, ...(config.shieldIgnorePatterns ?? [])];
@@ -175,8 +176,14 @@ export async function getDiffForReview(
 
     if (!diff.trim()) {
       const base = getDefaultBranch(cwd);
-      // Resolution prefers origin/<base> over the (often stale) local ref (#2054).
-      log.info(tag, `Diff source: branch-vs-base (prefers origin/${base}...HEAD)`);
+      // Sanitize the git-derived branch name before logging (terminal-injection
+      // hardening). Name both refs in resolution order so the line isn't
+      // misleading when the offline fallback to the local ref fires (mmnto-ai/totem#2054).
+      const safeBase = sanitizeForTerminal(base);
+      log.info(
+        tag,
+        `Diff source: branch-vs-base (origin/${safeBase}...HEAD, else local ${safeBase})`,
+      );
       diff = filterDiffByPatterns(getGitBranchDiff(cwd, base), allIgnore);
       source = 'branch-vs-base';
     }

--- a/packages/cli/src/git.ts
+++ b/packages/cli/src/git.ts
@@ -175,7 +175,8 @@ export async function getDiffForReview(
 
     if (!diff.trim()) {
       const base = getDefaultBranch(cwd);
-      log.info(tag, `Diff source: branch-vs-base (${base}...HEAD)`);
+      // Resolution prefers origin/<base> over the (often stale) local ref (#2054).
+      log.info(tag, `Diff source: branch-vs-base (prefers origin/${base}...HEAD)`);
       diff = filterDiffByPatterns(getGitBranchDiff(cwd, base), allIgnore);
       source = 'branch-vs-base';
     }

--- a/packages/core/src/sys/git.test.ts
+++ b/packages/core/src/sys/git.test.ts
@@ -115,16 +115,17 @@ describe('getGitBranchDiff base-ref resolution (#2054)', () => {
    * exact thing #2054 changes). Keyed by bare ref (`main`, `origin/main`).
    */
   function routeDiffByRef(routes: Record<string, { ok?: string; fail?: string }>): void {
-    vi.mocked(crossSpawn.sync).mockImplementation(((...callArgs: unknown[]) => {
-      const args = (callArgs[1] as readonly string[] | undefined) ?? [];
-      const range = args[1] ?? ''; // args === ['diff', '<ref>...HEAD']
-      for (const [ref, outcome] of Object.entries(routes)) {
-        if (range === `${ref}...HEAD`) {
-          return outcome.fail ? fail(new Error(outcome.fail)) : ok(outcome.ok ?? '');
-        }
-      }
-      return fail(new Error(`unexpected git call: ${args.join(' ')}`));
-    }) as never);
+    vi.mocked(crossSpawn.sync).mockImplementation((_command, args) => {
+      const range = (args ?? [])[1] ?? ''; // args === ['diff', '<ref>...HEAD']
+      const outcome = routes[range.replace(/\.\.\.HEAD$/, '')];
+      let result;
+      if (!outcome) result = fail(new Error(`unexpected git call: ${(args ?? []).join(' ')}`));
+      else if (outcome.fail) result = fail(new Error(outcome.fail));
+      else result = ok(outcome.ok ?? '');
+      // cross-spawn's full SpawnSyncReturns shape is irrelevant to these tests;
+      // the ok()/fail() fixtures carry the only fields safeExec reads.
+      return result as never;
+    });
   }
 
   it('prefers origin/<base> over a (possibly stale) local <base> when both resolve', () => {
@@ -163,9 +164,11 @@ describe('getGitBranchDiff base-ref resolution (#2054)', () => {
       caught = err;
     }
     expect(caught).toBeInstanceOf(TotemGitError);
-    expect((caught as Error).message).toMatch(/Failed to get branch diff \(main\.\.\.HEAD\)/);
-    // The fetch hint lives in the recovery field, not the message.
-    expect((caught as TotemGitError).recoveryHint).toMatch(/git fetch origin main/);
+    if (caught instanceof TotemGitError) {
+      expect(caught.message).toMatch(/Failed to get branch diff \(main\.\.\.HEAD\)/);
+      // The fetch hint lives in the recovery field, not the message.
+      expect(caught.recoveryHint).toMatch(/git fetch origin main/);
+    }
   });
 });
 

--- a/packages/core/src/sys/git.test.ts
+++ b/packages/core/src/sys/git.test.ts
@@ -9,11 +9,13 @@ vi.mock('cross-spawn', () => ({
   sync: vi.fn(),
 }));
 
+import { TotemGitError } from '../errors.js';
 import { fail, ok } from '../test-utils.js';
 import {
   extractChangedFiles,
   filterDiffByPatterns,
   findRepoRootSync,
+  getGitBranchDiff,
   getGitDiffRange,
   getGitLogSince,
   getLatestTag,
@@ -101,6 +103,69 @@ describe('getGitDiffRange (#1717)', () => {
     expect(() => getGitDiffRange('/tmp', 'nope..nope')).toThrow(
       /Failed to compute diff for range 'nope..nope'/,
     );
+  });
+});
+
+describe('getGitBranchDiff base-ref resolution (#2054)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  /**
+   * Route the cross-spawn mock by which ref a `git diff <ref>...HEAD` call
+   * names, so tests assert *which ref wins* independent of call order (the
+   * exact thing #2054 changes). Keyed by bare ref (`main`, `origin/main`).
+   */
+  function routeDiffByRef(routes: Record<string, { ok?: string; fail?: string }>): void {
+    vi.mocked(crossSpawn.sync).mockImplementation(((...callArgs: unknown[]) => {
+      const args = (callArgs[1] as readonly string[] | undefined) ?? [];
+      const range = args[1] ?? ''; // args === ['diff', '<ref>...HEAD']
+      for (const [ref, outcome] of Object.entries(routes)) {
+        if (range === `${ref}...HEAD`) {
+          return outcome.fail ? fail(new Error(outcome.fail)) : ok(outcome.ok ?? '');
+        }
+      }
+      return fail(new Error(`unexpected git call: ${args.join(' ')}`));
+    }) as never);
+  }
+
+  it('prefers origin/<base> over a (possibly stale) local <base> when both resolve', () => {
+    // Old order [local, origin] short-circuits on the local ref and would
+    // return the stale-local diff; origin-first is the #2054 fix.
+    routeDiffByRef({
+      'origin/main': { ok: 'ORIGIN_DIFF' },
+      main: { ok: 'STALE_LOCAL_DIFF' },
+    });
+    expect(getGitBranchDiff('/tmp', 'main')).toBe('ORIGIN_DIFF');
+    expect(vi.mocked(crossSpawn.sync)).toHaveBeenNthCalledWith(
+      1,
+      'git',
+      ['diff', 'origin/main...HEAD'],
+      expect.any(Object),
+    );
+  });
+
+  it('falls back to local <base> when origin/<base> is absent (offline / no-remote — nothing lost)', () => {
+    routeDiffByRef({
+      'origin/main': { fail: "fatal: ambiguous argument 'origin/main...HEAD'" },
+      main: { ok: 'LOCAL_DIFF' },
+    });
+    expect(getGitBranchDiff('/tmp', 'main')).toBe('LOCAL_DIFF');
+  });
+
+  it('throws a TotemGitError with a fetch hint when neither ref resolves', () => {
+    routeDiffByRef({
+      'origin/main': { fail: 'fatal: bad revision' },
+      main: { fail: 'fatal: bad revision' },
+    });
+    let caught: unknown;
+    try {
+      getGitBranchDiff('/tmp', 'main');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(TotemGitError);
+    expect((caught as Error).message).toMatch(/Failed to get branch diff \(main\.\.\.HEAD\)/);
+    // The fetch hint lives in the recovery field, not the message.
+    expect((caught as TotemGitError).recoveryHint).toMatch(/git fetch origin main/);
   });
 });
 

--- a/packages/core/src/sys/git.test.ts
+++ b/packages/core/src/sys/git.test.ts
@@ -144,6 +144,21 @@ describe('getGitBranchDiff base-ref resolution (#2054)', () => {
     );
   });
 
+  it('normalizes an already-origin-prefixed base instead of doubling it (#2074)', () => {
+    // base='origin/main' must resolve `origin/main...HEAD`, never `origin/origin/main`.
+    routeDiffByRef({
+      'origin/main': { ok: 'ORIGIN_DIFF' },
+      main: { ok: 'LOCAL_DIFF' },
+    });
+    expect(getGitBranchDiff('/tmp', 'origin/main')).toBe('ORIGIN_DIFF');
+    expect(vi.mocked(crossSpawn.sync)).toHaveBeenNthCalledWith(
+      1,
+      'git',
+      ['diff', 'origin/main...HEAD'],
+      expect.any(Object),
+    );
+  });
+
   it('falls back to local <base> when origin/<base> is absent (offline / no-remote — nothing lost)', () => {
     routeDiffByRef({
       'origin/main': { fail: "fatal: ambiguous argument 'origin/main...HEAD'" },

--- a/packages/core/src/sys/git.ts
+++ b/packages/core/src/sys/git.ts
@@ -125,8 +125,11 @@ export function getGitBranchDiff(cwd: string, base?: string): string {
   // in review/lint). `origin/<base>` is the current merged base and is a local
   // ref (no network); three-dot `...HEAD` resolves merge-base = the true fork
   // point. Falls back to local <base> when origin is absent (offline / no-remote).
-  // This audit (#2054) supersedes lesson-8d9946e1's "local before remote" default.
-  const refs = [`origin/${baseBranch}`, baseBranch];
+  // This audit (mmnto-ai/totem#2054) supersedes lesson-8d9946e1's "local before remote" default.
+  // Normalize off any `origin/` prefix first so an already-remote-prefixed base
+  // can't become `origin/origin/<base>` — an invalid ref + wasted spawn (mmnto-ai/totem#2074).
+  const localRef = baseBranch.replace(/^origin\//, '');
+  const refs = [`origin/${localRef}`, localRef];
   for (const ref of refs) {
     try {
       return safeExec('git', ['diff', `${ref}...HEAD`], {
@@ -140,8 +143,8 @@ export function getGitBranchDiff(cwd: string, base?: string): string {
       if (ref === refs[refs.length - 1]) {
         const msg = err instanceof Error ? err.message : String(err);
         throw new TotemGitError(
-          `Failed to get branch diff (${baseBranch}...HEAD): ${msg}`,
-          `Ensure the base branch '${baseBranch}' exists locally or as a remote ref. Try 'git fetch origin ${baseBranch}'.`,
+          `Failed to get branch diff (${localRef}...HEAD): ${msg}`,
+          `Ensure the base branch '${localRef}' exists locally or as a remote ref. Try 'git fetch origin ${localRef}'.`,
           err,
         );
       }

--- a/packages/core/src/sys/git.ts
+++ b/packages/core/src/sys/git.ts
@@ -119,8 +119,14 @@ export function getDefaultBranch(cwd: string): string {
 
 export function getGitBranchDiff(cwd: string, base?: string): string {
   const baseBranch = base ?? getDefaultBranch(cwd);
-  // Try local ref first, then remote — CI may only have origin/<branch>
-  const refs = [baseBranch, `origin/${baseBranch}`];
+  // Prefer the remote-tracking ref over the local branch (mmnto-ai/totem#2054).
+  // On a feature-branch workflow the local <base> is never checked out → stale,
+  // so `<base>...HEAD` re-includes already-merged code as "new" (false-CRITICALs
+  // in review/lint). `origin/<base>` is the current merged base and is a local
+  // ref (no network); three-dot `...HEAD` resolves merge-base = the true fork
+  // point. Falls back to local <base> when origin is absent (offline / no-remote).
+  // This audit (#2054) supersedes lesson-8d9946e1's "local before remote" default.
+  const refs = [`origin/${baseBranch}`, baseBranch];
   for (const ref of refs) {
     try {
       return safeExec('git', ['diff', `${ref}...HEAD`], {


### PR DESCRIPTION
## What

`getGitBranchDiff` (core) tried the **local** `<base>` ref before `origin/<base>`. On a feature-branch workflow the local default branch is never checked out → stale (or absent), so `git diff <stale-base>...HEAD` re-includes already-merged code as "new" — manufacturing **false-CRITICALs** that false-block the push gate in `totem review`/`lint` (the review hook won't stamp a passing content-hash on a FAIL) and inflating the diff into the 50k truncation cliff.

This reorders the ref preference to **`origin/<base>` first, local as fallback**. Three-dot `...HEAD` already resolves merge-base, so the remote-tracking ref gives the true fork point relative to the *current* merged base. It's a local, **no-network** change (no fetch added — keeps the gate offline/deterministic) and fixes `review`, `lint`, and `verify-badges` through the one shared helper.

## Why this is safe — nothing lost

`getGitBranchDiff` returns the diff from the first ref that *resolves* (`git diff X...HEAD` only throws when `X` is absent, not when the diff is empty). Across all four states, only the buggy case changes:

| local `<base>` | `origin/<base>` | old `[local, origin]` | new `[origin, local]` |
| --- | --- | --- | --- |
| present | present | local (← stale bug) | **origin (correct)** |
| present | absent | local | origin throws → **local** (same) |
| absent | present | local throws → origin | origin (same) |
| absent | absent | `TotemGitError` | `TotemGitError` (same) |

`origin/<base>` is a local remote-tracking ref, so there's no network cost. The only theoretical regression — a local `main` *intentionally ahead* of `origin/main` — isn't a totem workflow (`main` is protected; feature-branch + PR; local `main` is only ever behind-or-equal). The offline / no-remote fallback is locked by a test.

## Deliberate lesson inversion

This is an audited inversion of `lesson-8d9946e1` ("local before remote"), covered by that lesson's own escape clause ("unless a full audit of stale merge-base risks is performed"). No compiled rule enforces ref-order. Documented inline at the reorder site.

## Tests / gates

- 3 new core tests: origin-preferred when both resolve / origin-absent → local fallback / both-absent → throws with fetch hint.
- Full suites green: core 2103 + cli 2363.
- `totem lint` PASS (0 errors), `format:check` clean, `totem review` PASS (0 findings), plus `verify-manifest` / `claim-discipline --strict` / `doctor --strict` all pass.

> **Reviewers:** the residual `totem lint` warnings are the **#2063 false-positive class** — the "no static type assertions" rule mis-firing on vitest mock casts, plus the absolute-claims voice rule on the changeset prose. Non-blocking; tracked in #2063.

Closes #2054
Part of #2055
