### PR TITLE
feat(cli): totem doctor --parity mechanical content-equality — skills slice (#2073)

### DIFF
--- a/packages/cli/src/commands/doctor-parity.test.ts
+++ b/packages/cli/src/commands/doctor-parity.test.ts
@@ -420,6 +420,23 @@ describe('doctorParityCliCommand — --strict fail-promotion', () => {
     ).resolves.toBeUndefined();
   });
 
+  it('throws under --strict when a blocking MECHANICAL contract drifts across multiple artifacts', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest(
+      'm.yaml',
+      SKILLS_MANIFEST_YAML.replace(
+        'tracking-issue: mmnto-ai/totem-strategy#497\n',
+        'tracking-issue: mmnto-ai/totem-strategy#497\n    blocking: true\n',
+      ),
+    );
+    for (const s of DISTRIBUTED_CLAUDE_SKILLS) {
+      writeSkill(s.name, s.content.replace(SKILL_MARKER_START, `${SKILL_MARKER_START}\nDRIFT`));
+    }
+    await expect(doctorParityCliCommand({ strict: true, cwdForTest: tmpDir })).rejects.toThrow(
+      /PARITY_DRIFT_DETECTED|blocking drift/i,
+    );
+  });
+
   it('does NOT throw under --strict when drift is NON-blocking (only blocking gates)', async () => {
     writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
     writeManifest('m.yaml', DEPS_MANIFEST_YAML); // non-blocking

--- a/packages/cli/src/commands/doctor-parity.test.ts
+++ b/packages/cli/src/commands/doctor-parity.test.ts
@@ -22,6 +22,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { cleanTmpDir } from '../test-utils.js';
 import { checkParity, doctorParityCliCommand } from './doctor-parity.js';
+import { DISTRIBUTED_CLAUDE_SKILLS, SKILL_MARKER_START } from './init-templates.js';
 
 // Minimal valid totem config — `targets` is the only required array; everything
 // else defaults. `orient.parityManifest` is added per-test as needed.
@@ -289,6 +290,108 @@ describe('checkParity — version-pinned wiring', () => {
     // The CHECK still returns warn — fail-promotion is the CLI edge's job.
     expect(line.status).toBe('warn');
     expect(blockingDriftIds).toEqual(['mmnto-totem-version']);
+  });
+});
+
+// ─── mechanical skills detection wiring (#2073) ─────────
+
+/** A manifest with the claude-skills mechanical contract (all distributed skills). */
+const SKILLS_MANIFEST_YAML = `schema-version: 1
+status: scaffold
+contracts:
+  - id: claude-skills
+    dimension: skills
+    canonical-source: mmnto-ai/totem:packages/cli/src/commands/init-templates.ts#DISTRIBUTED_CLAUDE_SKILLS
+    detection-method: managed-block content equality per distributed skill
+    expected-value-or-derivation: consumer skill managed-blocks match distributed source
+    tractability: mechanical
+    tracking-issue: mmnto-ai/totem-strategy#497
+`;
+
+/** Write a consumer skill artifact at `.claude/skills/<name>/SKILL.md`. */
+function writeSkill(name: string, content: string): void {
+  const abs = path.join(tmpDir, '.claude', 'skills', name, 'SKILL.md');
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content, 'utf-8');
+}
+
+describe('checkParity — mechanical skills wiring (#2073)', () => {
+  it('emits one line per distributed skill; PASS when each consumer block matches canonical', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', SKILLS_MANIFEST_YAML);
+    // Install every distributed skill verbatim → each block matches its canonical.
+    for (const s of DISTRIBUTED_CLAUDE_SKILLS) writeSkill(s.name, s.content);
+
+    const { results } = await checkParity(tmpDir);
+    const skillLines = results.filter((r) => r.name.startsWith('Parity: claude-skills'));
+    expect(skillLines).toHaveLength(DISTRIBUTED_CLAUDE_SKILLS.length);
+    expect(skillLines.every((r) => r.status === 'pass')).toBe(true);
+  });
+
+  it('WARN on a drifted skill block with no fork marker', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', SKILLS_MANIFEST_YAML);
+    const first = DISTRIBUTED_CLAUDE_SKILLS[0]!;
+    // Inject drift INSIDE the managed block (right after the start marker).
+    writeSkill(
+      first.name,
+      first.content.replace(SKILL_MARKER_START, `${SKILL_MARKER_START}\nDRIFT INJECTED`),
+    );
+
+    const { results } = await checkParity(tmpDir);
+    const line = results.find((r) => r.name === `Parity: claude-skills (${first.name})`)!;
+    expect(line.status).toBe('warn');
+    expect(line.message).toMatch(/drift/i);
+  });
+
+  it('INFO (not warn) when a drifted skill carries a totem:fork marker', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', SKILLS_MANIFEST_YAML);
+    const first = DISTRIBUTED_CLAUDE_SKILLS[0]!;
+    const drifted = first.content.replace(
+      SKILL_MARKER_START,
+      `${SKILL_MARKER_START}\nDRIFT INJECTED`,
+    );
+    writeSkill(
+      first.name,
+      `${drifted}\n<!-- totem:fork reason="local override" owner="satur8d" attested="2026-06-03" -->\n`,
+    );
+
+    const { results } = await checkParity(tmpDir);
+    const line = results.find((r) => r.name === `Parity: claude-skills (${first.name})`)!;
+    expect(line.status).toBe('info');
+    expect(line.message).toMatch(/intentional fork/i);
+  });
+
+  it('SKIP when a skill artifact is not installed (cohort permits absence), never fail', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', SKILLS_MANIFEST_YAML);
+    // Install nothing → every skill line is a skip.
+
+    const { results } = await checkParity(tmpDir);
+    const skillLines = results.filter((r) => r.name.startsWith('Parity: claude-skills'));
+    expect(skillLines.length).toBeGreaterThan(0);
+    expect(skillLines.every((r) => r.status === 'skip')).toBe(true);
+    expect(results.some((r) => r.status === 'fail')).toBe(false);
+  });
+
+  it('tags a blocking multi-artifact contract id ONCE even when several artifacts drift', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest(
+      'm.yaml',
+      SKILLS_MANIFEST_YAML.replace(
+        'tracking-issue: mmnto-ai/totem-strategy#497\n',
+        'tracking-issue: mmnto-ai/totem-strategy#497\n    blocking: true\n',
+      ),
+    );
+    // Drift EVERY distributed skill → multiple warns under the one blocking
+    // contract; its id must appear exactly once in blockingDriftIds.
+    for (const s of DISTRIBUTED_CLAUDE_SKILLS) {
+      writeSkill(s.name, s.content.replace(SKILL_MARKER_START, `${SKILL_MARKER_START}\nDRIFT`));
+    }
+
+    const { blockingDriftIds } = await checkParity(tmpDir);
+    expect(blockingDriftIds).toEqual(['claude-skills']);
   });
 });
 

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -154,12 +154,8 @@ function resolveRunningBinary(
     const pkg = req('../../package.json') as { version?: unknown };
     if (typeof pkg.version !== 'string') return undefined;
     return { version: pkg.version, path: cliRoot };
-  } catch (err) {
-    // The binary self-report is cosmetic — ANY resolution failure yields an
-    // unannotated verdict, never a crash (Tenet 13: a cosmetic read must not
-    // break the sensor). Re-throw a non-Error throw value so a truly anomalous
-    // failure still surfaces (fail-loud intent) rather than masking everything.
-    if (!(err instanceof Error)) throw err;
+    // totem-context: best-effort cosmetic read — the binary self-report degrades to absent on ANY resolution failure and NEVER re-throws (GCA review), so a shadowed / broken install can't crash the doctor pipeline (Tenet 13: a cosmetic read must not break the sensor).
+  } catch {
     return undefined;
   }
 }
@@ -473,6 +469,7 @@ export async function doctorParityCliCommand(options: ParityCliOptions = {}): Pr
       case 'info':
         // An attested, intentional fork — neutral/informational, never gated.
         log.info(TAG, `${bold('INFO')} — ${render(r.message)}`);
+        if (r.remediation) log.dim(TAG, `→ ${render(r.remediation)}`);
         break;
       case 'unknown':
         // The Stale-Doctor-Paradox state: the canonical was unresolvable, so the

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -34,18 +34,13 @@
  * keep core off the CLI cold-start graph, matching the other doctor checks.
  */
 
-import { createRequire } from 'node:module';
 import * as path from 'node:path';
-import * as url from 'node:url';
 
 import type { ManagedBlockMarkers, ParityContract, ParityContractVerdict } from '@mmnto/totem';
 
-import {
-  DISTRIBUTED_CLAUDE_SKILLS,
-  REVIEW_REPLY_SKILL_CONTENT,
-  SKILL_MARKER_END,
-  SKILL_MARKER_START,
-} from './init-templates.js';
+// init-templates (large canonical strings) + the node:url / node:module builtins
+// are dynamic-imported inside checkParity per the packages/cli lazy-load
+// guideline — see the `ok` branch.
 
 const CHECK_NAME = 'Parity';
 
@@ -74,9 +69,6 @@ export interface ParityCheckResult {
 
 // ─── Mechanical artifact registry (CLI-side) ────────────
 
-/** The managed-block markers shared by every distributed skill artifact. */
-const SKILL_MARKERS: ManagedBlockMarkers = { start: SKILL_MARKER_START, end: SKILL_MARKER_END };
-
 /**
  * One on-disk artifact a mechanical contract maps to: the consumer file path,
  * its marker pair, the canonical block extracted from the running `@mmnto/cli`'s
@@ -87,6 +79,17 @@ interface MechanicalArtifact {
   markers: ManagedBlockMarkers;
   canonicalBlock: string | undefined;
   lineName: string;
+}
+
+/**
+ * The distributed-skill canonical sources, dynamic-imported by the caller from
+ * `init-templates` (kept off the CLI cold-start graph per the packages/cli
+ * lazy-load guideline) and threaded in so this registry stays a pure function.
+ */
+interface SkillTemplateSource {
+  distributedSkills: ReadonlyArray<{ name: string; content: string }>;
+  reviewReplyContent: string;
+  markers: ManagedBlockMarkers;
 }
 
 /**
@@ -105,21 +108,23 @@ function mechanicalArtifactsFor(
   contractId: string,
   gitRoot: string,
   extract: (content: string, markers: ManagedBlockMarkers) => string | undefined,
+  templates: SkillTemplateSource,
 ): MechanicalArtifact[] | undefined {
+  const { markers } = templates;
   switch (contractId) {
     case 'claude-skills':
-      return DISTRIBUTED_CLAUDE_SKILLS.map((s) => ({
+      return templates.distributedSkills.map((s) => ({
         consumerPath: path.join(gitRoot, '.claude', 'skills', s.name, 'SKILL.md'),
-        markers: SKILL_MARKERS,
-        canonicalBlock: extract(s.content, SKILL_MARKERS),
+        markers,
+        canonicalBlock: extract(s.content, markers),
         lineName: `Parity: claude-skills (${s.name})`,
       }));
     case 'review-reply-skill-content':
       return [
         {
           consumerPath: path.join(gitRoot, '.claude', 'skills', 'review-reply', 'SKILL.md'),
-          markers: SKILL_MARKERS,
-          canonicalBlock: extract(REVIEW_REPLY_SKILL_CONTENT, SKILL_MARKERS),
+          markers,
+          canonicalBlock: extract(templates.reviewReplyContent, markers),
           lineName: 'Parity: review-reply-skill-content',
         },
       ];
@@ -137,12 +142,15 @@ function mechanicalArtifactsFor(
  * own URL, so it names the actual running install (workspace dist vs a
  * node_modules vendor vs a global shadow).
  */
-function resolveRunningBinary(): { version: string; path: string } | undefined {
+function resolveRunningBinary(
+  urlMod: typeof import('node:url'),
+  createRequireFn: typeof import('node:module').createRequire,
+): { version: string; path: string } | undefined {
   try {
-    const here = url.fileURLToPath(import.meta.url);
+    const here = urlMod.fileURLToPath(import.meta.url);
     // dist/commands/doctor-parity.js → up two → the @mmnto/cli package root.
     const cliRoot = path.resolve(path.dirname(here), '..', '..');
-    const req = createRequire(import.meta.url);
+    const req = createRequireFn(import.meta.url);
     const pkg = req('../../package.json') as { version?: unknown };
     if (typeof pkg.version !== 'string') return undefined;
     return { version: pkg.version, path: cliRoot };
@@ -257,13 +265,30 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
         message: `parity manifest: ${contracts.length} contract(s) loaded`,
       };
 
+      // Lazy-load init-templates (large canonical strings) + the node builtins
+      // only on the ok path — the honest-absent cases above never pay for them
+      // (packages/cli lazy-load guideline).
+      const { createRequire } = await import('node:module');
+      const url = await import('node:url');
+      const {
+        DISTRIBUTED_CLAUDE_SKILLS,
+        REVIEW_REPLY_SKILL_CONTENT,
+        SKILL_MARKER_START,
+        SKILL_MARKER_END,
+      } = await import('./init-templates.js');
+      const skillTemplates: SkillTemplateSource = {
+        distributedSkills: DISTRIBUTED_CLAUDE_SKILLS,
+        reviewReplyContent: REVIEW_REPLY_SKILL_CONTENT,
+        markers: { start: SKILL_MARKER_START, end: SKILL_MARKER_END },
+      };
+
       // Shared detection context. The cohort floor + repoId derive from the git
       // root (anchored there, not the deep cwd — mirrors the core resolver).
       // resolveGitRoot returns null outside a repo; fall back to cwd so the
       // local self-in-tree / sibling probes still have an anchor.
       const gitRoot = safeGitRoot(resolveGitRoot, cwd) ?? cwd;
       const repoId = deriveCohortRepoId(cwd, { gitRoot });
-      const binary = resolveRunningBinary();
+      const binary = resolveRunningBinary(url, createRequire);
 
       const blockingDriftIds: string[] = [];
       // flatMap, not map: a mechanical contract (claude-skills) expands to one
@@ -285,7 +310,12 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
 
         // ── mechanical managed-block content-equality (mmnto-ai/totem#2073 skills slice) ──
         if (c.tractability === 'mechanical') {
-          const artifacts = mechanicalArtifactsFor(c.id, gitRoot, extractManagedBlock);
+          const artifacts = mechanicalArtifactsFor(
+            c.id,
+            gitRoot,
+            extractManagedBlock,
+            skillTemplates,
+          );
           if (artifacts === undefined) {
             return [
               stub(
@@ -420,14 +450,18 @@ export async function doctorParityCliCommand(options: ParityCliOptions = {}): Pr
   const { results, blockingDriftIds } = await checkParity(cwd);
 
   // Under --strict, a blocking contract's drift `warn` is rendered + gated as a
-  // FAIL. We match by the `Parity: <id>` line name so the rendered status agrees
-  // with the exit code. blockingDriftIds is empty in the non-strict path's
-  // effect (the promotion only fires under --strict), so this Set is cheap.
-  const promotable = new Set(blockingDriftIds.map((id) => `Parity: ${id}`));
+  // FAIL. A contract's drift can render across MULTIPLE artifact lines
+  // (e.g. `Parity: claude-skills (signoff)`), so a line is promotable when its
+  // name is the `Parity: <id>` summary OR a `Parity: <id> (…)` artifact line —
+  // an exact-name Set would leave the artifact lines rendered as WARN while the
+  // command still exits non-zero (GCA review on the PR). The trailing space
+  // guards against a contract id that is a prefix of another.
+  const isPromotable = (name: string): boolean =>
+    blockingDriftIds.some((id) => name === `Parity: ${id}` || name.startsWith(`Parity: ${id} `));
 
   for (const r of results) {
     const status =
-      options.strict && r.status === 'warn' && promotable.has(r.name) ? 'fail' : r.status;
+      options.strict && r.status === 'warn' && isPromotable(r.name) ? 'fail' : r.status;
     switch (status) {
       case 'pass':
         log.success(TAG, `${successColor(bold('PASS'))} — ${render(r.message)}`);

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -1,60 +1,170 @@
 /**
  * Parity-drift sensor for `totem doctor --parity` (mmnto-ai/totem-strategy#448).
  *
- * PR-1 (mmnto-ai/totem#2069): resolve the consumer-configured
- * `orient.parityManifest` config-path → parse + Zod-validate the strategy-owned
- * `parity-manifest.yaml` → emit `DiagnosticResult`s. The FIRST detection slice
- * is wired here: each `version-pinned` contract whose id resolves a deps package
- * name (`mmnto-cli-version`, `mmnto-totem-version`, `mmnto-mcp-version`,
- * `mmnto-pack-rust-architecture-version`) runs through the core
- * `detectVersionPinnedContract` engine (pin-currency verdict, local-only floor).
- * ALL other contracts — mechanical, manual-attestation, and the version-pinned
- * DOCTRINE pins (`governance-doctrine` / `agent-memory-doctrine`, which derive
- * no deps package name) — keep the `skip` info stub (their drift detection is a
- * follow-on).
+ * Two detection slices are wired here:
+ *   - **version-pinned** (PR-1, mmnto-ai/totem#2069): each deps contract whose id
+ *     resolves an `@mmnto/*` package name runs through the core
+ *     `detectVersionPinnedContract` engine (pin-currency verdict, local-only floor).
+ *   - **mechanical content-equality** (mmnto-ai/totem#2073 skills slice): each
+ *     managed-block contract this slice handles (`claude-skills`,
+ *     `review-reply-skill-content`) compares the consumer's installed
+ *     `.claude/skills/<name>/SKILL.md` managed-block against the running
+ *     `@mmnto/cli`'s OWN canonical template (the in-process `init-templates`
+ *     export — local-read-only, no node_modules reach-in), via the core
+ *     `detectMechanicalContract` engine (CRLF/LF-normalized content-hash + a
+ *     fork-marker → `info` escape + an `unknown` Stale-Doctor-Paradox guard).
  *
- * Sensor-not-gate: the core detector returns `skip`/`warn`/`pass` only — never
- * `fail`. The `--strict` exit-code decision lives at the CLI edge: a `warn` from
- * a `blocking: true` contract is promoted to `fail` (non-zero) ONLY under
- * `--strict`. The detector carries that promotion eligibility back via
- * `blockingDriftIds` so the command can gate without re-loading the manifest.
+ * ALL other contracts — the parameterized hook contracts (`git-hooks`,
+ * `session-start-orientation`), the file-value-equality bot-configs, the
+ * structural-presence dimensions, and every `manual-attestation` contract —
+ * keep the `skip` "not yet implemented" stub; their detection is a follow-on
+ * slice (the #2073 tail).
  *
- * Honest-absent (Tenet 14): unconfigured → exactly one `skip` line; never an
- * error. Configured-but-missing / unparseable / unsupported-schema → `warn`,
- * never a crash (mirrors the `findStaleRules` best-effort fallback idiom in
- * doctor.ts). Dynamic-import `@mmnto/totem` to keep core off the CLI cold-start
- * graph, matching the other doctor checks.
+ * The parity sensor owns its OWN render + result type (`ParityLine`) carrying a
+ * WIDER status vocabulary (pass/warn/fail/info/unknown/skip) than the shared
+ * `CheckStatus`, so the verdict-state split (#2073 req #1) never ripples
+ * `CheckStatus` across the unrelated doctor checks.
+ *
+ * Sensor-not-gate: the detectors return `skip`/`warn`/`pass`/`info`/`unknown` —
+ * never `fail`. The `--strict` exit-code decision lives at the CLI edge: a
+ * `warn` from a `blocking: true` contract is promoted to `fail` (non-zero) ONLY
+ * under `--strict`. `info`/`unknown` are never gated. Honest-absent (Tenet 14):
+ * unconfigured → exactly one `skip` line; configured-but-missing / unparseable /
+ * unsupported-schema → `warn`, never a crash. Dynamic-import `@mmnto/totem` to
+ * keep core off the CLI cold-start graph, matching the other doctor checks.
  */
 
+import { createRequire } from 'node:module';
 import * as path from 'node:path';
+import * as url from 'node:url';
 
-import type { ParityContract, ParityContractVerdict } from '@mmnto/totem';
+import type { ManagedBlockMarkers, ParityContract, ParityContractVerdict } from '@mmnto/totem';
 
-import type { DiagnosticResult } from './doctor.js';
+import {
+  DISTRIBUTED_CLAUDE_SKILLS,
+  REVIEW_REPLY_SKILL_CONTENT,
+  SKILL_MARKER_END,
+  SKILL_MARKER_START,
+} from './init-templates.js';
 
 const CHECK_NAME = 'Parity';
 
 /**
- * Result of a parity check: the rendered `DiagnosticResult` lines plus the set
- * of contract ids that produced a drift `warn` AND are `blocking: true`. The
- * command promotes exactly these to `fail` under `--strict` — carrying the ids
- * here avoids re-loading the manifest at the CLI edge to recover the `blocking`
- * flag (which `DiagnosticResult` does not carry).
+ * A parity output line — the per-contract verdict plus its display name. Carries
+ * the WIDER `ParityContractVerdict` status vocabulary (pass/warn/fail/info/
+ * unknown/skip) rather than the shared `CheckStatus`, so the sensor honors the
+ * verdict-state split (#2073 req #1) without rippling `CheckStatus` across the
+ * other doctor checks. The parity command owns its own renderer.
+ */
+export interface ParityLine extends ParityContractVerdict {
+  name: string;
+}
+
+/**
+ * Result of a parity check: the rendered `ParityLine`s plus the set of contract
+ * ids that produced a drift `warn` AND are `blocking: true`. The command
+ * promotes exactly these to `fail` under `--strict` — carrying the ids here
+ * avoids re-loading the manifest at the CLI edge to recover the `blocking` flag.
  */
 export interface ParityCheckResult {
-  results: DiagnosticResult[];
+  results: ParityLine[];
   /** Contract ids whose `warn` is `--strict`-promotable (blocking + drift). */
   blockingDriftIds: string[];
 }
 
+// ─── Mechanical artifact registry (CLI-side) ────────────
+
+/** The managed-block markers shared by every distributed skill artifact. */
+const SKILL_MARKERS: ManagedBlockMarkers = { start: SKILL_MARKER_START, end: SKILL_MARKER_END };
+
 /**
- * Resolve, parse, and report the parity manifest as `DiagnosticResult`s.
+ * One on-disk artifact a mechanical contract maps to: the consumer file path,
+ * its marker pair, the canonical block extracted from the running `@mmnto/cli`'s
+ * own template, and the display name for its verdict line.
+ */
+interface MechanicalArtifact {
+  consumerPath: string;
+  markers: ManagedBlockMarkers;
+  canonicalBlock: string | undefined;
+  lineName: string;
+}
+
+/**
+ * Resolve the on-disk artifact(s) a mechanical contract checks, or `undefined`
+ * when this slice doesn't handle the contract (hooks / presence / value-equality
+ * → kept as `skip` stubs). `claude-skills` yields one artifact PER distributed
+ * skill; `review-reply-skill-content` is the single review-reply skill (it
+ * overlaps `claude-skills` by design — both are distinct manifest contracts on
+ * the same file; flagged to strategy as a manifest observation).
+ *
+ * The canonical block is extracted from the running CLI's OWN `init-templates`
+ * export (passed-in `extract` is the core `extractManagedBlock`, dynamic-imported
+ * by the caller to keep `@mmnto/totem` off the cold-start graph) — local-read-only.
+ */
+function mechanicalArtifactsFor(
+  contractId: string,
+  gitRoot: string,
+  extract: (content: string, markers: ManagedBlockMarkers) => string | undefined,
+): MechanicalArtifact[] | undefined {
+  switch (contractId) {
+    case 'claude-skills':
+      return DISTRIBUTED_CLAUDE_SKILLS.map((s) => ({
+        consumerPath: path.join(gitRoot, '.claude', 'skills', s.name, 'SKILL.md'),
+        markers: SKILL_MARKERS,
+        canonicalBlock: extract(s.content, SKILL_MARKERS),
+        lineName: `Parity: claude-skills (${s.name})`,
+      }));
+    case 'review-reply-skill-content':
+      return [
+        {
+          consumerPath: path.join(gitRoot, '.claude', 'skills', 'review-reply', 'SKILL.md'),
+          markers: SKILL_MARKERS,
+          canonicalBlock: extract(REVIEW_REPLY_SKILL_CONTENT, SKILL_MARKERS),
+          lineName: 'Parity: review-reply-skill-content',
+        },
+      ];
+    default:
+      return undefined;
+  }
+}
+
+/**
+ * Resolve the running `@mmnto/cli`'s version + install path for the req-#5
+ * binary self-report (the Stale-Doctor-Paradox guard — surface WHICH binary
+ * computed the skills verdict so a shadowed/stale global is visible). Best-effort:
+ * a resolution failure degrades the self-report to absent (the verdict still
+ * renders, just without provenance), never a crash. Resolves from THIS module's
+ * own URL, so it names the actual running install (workspace dist vs a
+ * node_modules vendor vs a global shadow).
+ */
+function resolveRunningBinary(): { version: string; path: string } | undefined {
+  try {
+    const here = url.fileURLToPath(import.meta.url);
+    // dist/commands/doctor-parity.js → up two → the @mmnto/cli package root.
+    const cliRoot = path.resolve(path.dirname(here), '..', '..');
+    const req = createRequire(import.meta.url);
+    const pkg = req('../../package.json') as { version?: unknown };
+    if (typeof pkg.version !== 'string') return undefined;
+    return { version: pkg.version, path: cliRoot };
+  } catch (err) {
+    // The binary self-report is cosmetic — ANY resolution failure yields an
+    // unannotated verdict, never a crash (Tenet 13: a cosmetic read must not
+    // break the sensor). Re-throw a non-Error throw value so a truly anomalous
+    // failure still surfaces (fail-loud intent) rather than masking everything.
+    if (!(err instanceof Error)) throw err;
+    return undefined;
+  }
+}
+
+/**
+ * Resolve, parse, and report the parity manifest as `ParityLine`s.
  *
  * Returns `{ results, blockingDriftIds }`: `results[0]` is always the section
- * summary line; in the `ok` path it is followed by one line per contract — a
- * pin-currency verdict for the deps version-pinned contracts, a `skip` stub for
- * everything else. All non-`ok` paths return a single summary entry and an empty
- * `blockingDriftIds`.
+ * summary line; in the `ok` path it is followed by one line per contract (or
+ * per artifact, for multi-artifact mechanical contracts) — a pin-currency
+ * verdict for the deps version-pinned contracts, a content-equality verdict for
+ * the mechanical skills contracts, and a `skip` stub for everything else. All
+ * non-`ok` paths return a single summary entry and an empty `blockingDriftIds`.
  *
  * @param cwd The directory to resolve config + manifest against (config/repo root).
  */
@@ -62,7 +172,9 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
   const { loadConfig, resolveConfigPath, isGlobalConfigPath } = await import('../utils.js');
   const {
     deriveCohortRepoId,
+    detectMechanicalContract,
     detectVersionPinnedContract,
+    extractManagedBlock,
     loadParityManifest,
     packageNameForContract,
     resolveGitRoot,
@@ -139,7 +251,7 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
 
     case 'ok': {
       const { contracts } = result.manifest;
-      const summary: DiagnosticResult = {
+      const summary: ParityLine = {
         name: CHECK_NAME,
         status: 'pass',
         message: `parity manifest: ${contracts.length} contract(s) loaded`,
@@ -151,28 +263,59 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
       // local self-in-tree / sibling probes still have an anchor.
       const gitRoot = safeGitRoot(resolveGitRoot, cwd) ?? cwd;
       const repoId = deriveCohortRepoId(cwd, { gitRoot });
+      const binary = resolveRunningBinary();
 
       const blockingDriftIds: string[] = [];
-      const perContract: DiagnosticResult[] = contracts.map((c) => {
-        // PR-1 only senses version-pinned DEPS contracts (those that resolve a
-        // package name). Everything else — mechanical, manual-attestation, and
-        // the version-pinned doctrine pins (no deps package name) — keeps the
-        // skip stub until its detection slice lands.
-        const packageName =
-          c.tractability === 'version-pinned' ? packageNameForContract(c, gitRoot) : undefined;
-        if (packageName === undefined) {
-          return {
-            name: `Parity: ${c.id}`,
-            status: 'skip',
-            message: `${c.dimension} (${c.tractability}) — drift detection not yet implemented`,
-          };
+      // flatMap, not map: a mechanical contract (claude-skills) expands to one
+      // line PER distributed skill, so the per-contract count can exceed the
+      // contract count.
+      const perContract: ParityLine[] = contracts.flatMap((c) => {
+        // ── version-pinned deps (PR-1) ──
+        if (c.tractability === 'version-pinned') {
+          const packageName = packageNameForContract(c, gitRoot);
+          if (packageName === undefined) {
+            return [
+              stub(c, `${c.dimension} (version-pinned) — drift detection not yet implemented`),
+            ];
+          }
+          const verdict = detectVersionPinnedContract(c, { cwd, gitRoot, repoId, packageName });
+          if (verdict.status === 'warn' && c.blocking === true) blockingDriftIds.push(c.id);
+          return [verdictToLine(c, verdict)];
         }
 
-        const verdict = detectVersionPinnedContract(c, { cwd, gitRoot, repoId, packageName });
-        if (verdict.status === 'warn' && c.blocking === true) {
-          blockingDriftIds.push(c.id);
+        // ── mechanical managed-block content-equality (mmnto-ai/totem#2073 skills slice) ──
+        if (c.tractability === 'mechanical') {
+          const artifacts = mechanicalArtifactsFor(c.id, gitRoot, extractManagedBlock);
+          if (artifacts === undefined) {
+            return [
+              stub(
+                c,
+                `${c.dimension} (mechanical) — drift detection not yet implemented for this sub-class`,
+              ),
+            ];
+          }
+          // A multi-artifact contract (claude-skills) can drift on several
+          // artifacts; tag the contract id at most ONCE so the --strict count
+          // reflects contracts, not artifacts.
+          let blockingDrift = false;
+          const lines = artifacts.map((a) => {
+            const verdict = detectMechanicalContract({
+              canonicalBlock: a.canonicalBlock,
+              consumerPath: a.consumerPath,
+              markers: a.markers,
+              ...(binary !== undefined ? { binary } : {}),
+            });
+            if (verdict.status === 'warn' && c.blocking === true) blockingDrift = true;
+            return lineFor(a.lineName, verdict);
+          });
+          if (blockingDrift) blockingDriftIds.push(c.id);
+          return lines;
         }
-        return verdictToDiagnostic(c, verdict);
+
+        // ── manual-attestation + anything else → skip stub (the mmnto-ai/totem#2073 tail) ──
+        return [
+          stub(c, `${c.dimension} (${c.tractability}) — drift detection not yet implemented`),
+        ];
       });
 
       return { results: [summary, ...perContract], blockingDriftIds };
@@ -181,21 +324,28 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
 }
 
 /** Wrap a single summary line in the `ParityCheckResult` shape (no blocking ids). */
-function single(result: DiagnosticResult): ParityCheckResult {
+function single(result: ParityLine): ParityCheckResult {
   return { results: [result], blockingDriftIds: [] };
 }
 
-/** Map a core `ParityContractVerdict` to a CLI `DiagnosticResult` for one contract. */
-function verdictToDiagnostic(
-  contract: ParityContract,
-  verdict: ParityContractVerdict,
-): DiagnosticResult {
+/** Map a core `ParityContractVerdict` to a `ParityLine` keyed by the contract id. */
+function verdictToLine(contract: ParityContract, verdict: ParityContractVerdict): ParityLine {
+  return lineFor(`Parity: ${contract.id}`, verdict);
+}
+
+/** Build a `ParityLine` from an explicit display name + a core verdict. */
+function lineFor(name: string, verdict: ParityContractVerdict): ParityLine {
   return {
-    name: `Parity: ${contract.id}`,
+    name,
     status: verdict.status,
     message: verdict.message,
     ...(verdict.remediation !== undefined ? { remediation: verdict.remediation } : {}),
   };
+}
+
+/** The `skip` "not yet implemented" stub for a contract this build doesn't sense. */
+function stub(contract: ParityContract, message: string): ParityLine {
+  return { name: `Parity: ${contract.id}`, status: 'skip', message };
 }
 
 /**
@@ -231,8 +381,9 @@ export interface ParityCliOptions {
    * Sensor-not-gate is the default: a drift `warn` reports and exits 0. Under
    * `--strict`, a `warn` from a `blocking: true` contract (its id carried in
    * `checkParity`'s `blockingDriftIds`) is rendered as `FAIL` and promoted to a
-   * non-zero exit. Non-blocking drift stays a `warn` even under `--strict` — the
-   * contract's `blocking` flag, not the flag alone, gates the exit code.
+   * non-zero exit. Non-blocking drift stays a `warn` even under `--strict`, and
+   * `info` (attested fork) / `unknown` (unprovable) NEVER promote — the
+   * contract's `blocking` flag on a `warn`, not the flag alone, gates the exit.
    */
   strict?: boolean;
   /** Test seam — production callers omit and the command uses `process.cwd()`. */
@@ -240,7 +391,7 @@ export interface ParityCliOptions {
 }
 
 /**
- * CLI entry — runs `checkParity`, renders each `DiagnosticResult`, and throws a
+ * CLI entry — runs `checkParity`, renders each `ParityLine`, and throws a
  * `TotemError` when a blocking contract drifted under `--strict` so the
  * top-level `handleError` produces the non-zero exit code (no direct
  * `process.exit` per AGENTS.md).
@@ -285,6 +436,17 @@ export async function doctorParityCliCommand(options: ParityCliOptions = {}): Pr
         log.warn(TAG, `${warnColor(bold('WARN'))} — ${render(r.message)}`);
         if (r.remediation) log.dim(TAG, `→ ${render(r.remediation)}`);
         break;
+      case 'info':
+        // An attested, intentional fork — neutral/informational, never gated.
+        log.info(TAG, `${bold('INFO')} — ${render(r.message)}`);
+        break;
+      case 'unknown':
+        // The Stale-Doctor-Paradox state: the canonical was unresolvable, so the
+        // verdict is unprovable (NOT a pass — no self-certification). A caution,
+        // not drift; never gated.
+        log.warn(TAG, `${warnColor(bold('UNKNOWN'))} — ${render(r.message)}`);
+        if (r.remediation) log.dim(TAG, `→ ${render(r.remediation)}`);
+        break;
       case 'fail':
         // Mandated 'Totem Error' tag (packages/cli convention) — marks internal
         // error output, distinct from the contextual TAG used for pass/warn/skip.
@@ -299,11 +461,11 @@ export async function doctorParityCliCommand(options: ParityCliOptions = {}): Pr
 
   // Sensor-not-gate: drift is report-only by default (exit 0). Only `--strict`
   // promotes a `blocking: true` contract's drift to a non-zero exit; non-blocking
-  // drift never gates. PR-1's detector emits no raw `fail` status (version-pinned
-  // is pass/warn/skip), so the gate is purely the strict+blocking promotion — the
-  // gating model for a future slice that DOES emit a `fail` is settled when that
-  // slice lands (CR review #2071: keep the gate from suggesting a non-strict path
-  // that would break sensor-not-gate).
+  // drift never gates, and `info`/`unknown` are never promoted. The detectors
+  // emit no raw `fail` status, so the gate is purely the strict+blocking
+  // promotion — the gating model for a future slice that DOES emit a `fail` is
+  // settled when that slice lands (CR review mmnto-ai/totem#2071: keep the gate from
+  // suggesting a non-strict path that would break sensor-not-gate).
   if (options.strict && blockingDriftIds.length > 0) {
     throw new TotemError(
       'PARITY_DRIFT_DETECTED',

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -552,17 +552,26 @@ export {
 } from './parity-manifest.js';
 
 // Version-pinned parity drift detector (PR-1, mmnto-ai/totem#2069)
+// + mechanical content-equality detector (mmnto-ai/totem#2073 skills slice)
 export type {
   CohortFloorStatus,
   DeriveCohortRepoIdOptions,
+  DetectMechanicalContext,
   DetectVersionPinnedContext,
+  ForkMarker,
+  ManagedBlockMarkers,
   PackageJsonShape,
   ParityContractVerdict,
 } from './parity-detect.js';
 export {
   deriveCohortRepoId,
+  detectMechanicalContract,
   detectVersionPinnedContract,
+  extractManagedBlock,
+  hashManagedBlock,
+  normalizeManagedBlock,
   packageNameForContract,
+  parseForkMarker,
   resolveCohortFloor,
 } from './parity-detect.js';
 

--- a/packages/core/src/parity-detect.test.ts
+++ b/packages/core/src/parity-detect.test.ts
@@ -537,6 +537,16 @@ describe('detectMechanicalContract', () => {
     expect(v.message).toMatch(/markers absent|unmanaged/i);
   });
 
+  it('info — a marker-stripped file carrying a totem:fork marker is an intentional fork, not drift', () => {
+    const consumerPath = writeArtifact(
+      '.claude/skills/x/SKILL.md',
+      'heavily customized, no skill markers\n<!-- totem:fork reason="full rewrite" attested="2026-06-03" -->',
+    );
+    const v = detectMechanicalContract(mechCtx({ consumerPath }));
+    expect(v.status).toBe('info');
+    expect(v.message).toMatch(/intentional fork/i);
+  });
+
   it('never emits fail and degrades a missing read to skip (detector invariant)', () => {
     const v = detectMechanicalContract(mechCtx({ readFile: () => undefined }));
     expect(v.status).toBe('skip');

--- a/packages/core/src/parity-detect.test.ts
+++ b/packages/core/src/parity-detect.test.ts
@@ -523,6 +523,14 @@ describe('detectMechanicalContract', () => {
     expect(v.status).not.toBe('pass');
   });
 
+  it('pass — a legitimately EMPTY canonical block is compared, not conflated with unknown', () => {
+    // Markers present but no content on both sides → equal → pass, NOT unknown
+    // (empty `''` is distinct from an unresolvable `undefined`).
+    const consumerPath = writeArtifact('.claude/skills/x/SKILL.md', skillFile(''));
+    const v = detectMechanicalContract(mechCtx({ consumerPath, canonicalBlock: '' }));
+    expect(v.status).toBe('pass');
+  });
+
   it('skip — consumer artifact absent (cohort permits absence), distinct from drift', () => {
     const v = detectMechanicalContract(
       mechCtx({ consumerPath: path.join(tmpRoot, 'nope/SKILL.md') }),

--- a/packages/core/src/parity-detect.test.ts
+++ b/packages/core/src/parity-detect.test.ts
@@ -23,9 +23,15 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
   deriveCohortRepoId,
+  type DetectMechanicalContext,
+  detectMechanicalContract,
   type DetectVersionPinnedContext,
   detectVersionPinnedContract,
+  extractManagedBlock,
+  hashManagedBlock,
+  normalizeManagedBlock,
   packageNameForContract,
+  parseForkMarker,
   resolveCohortFloor,
 } from './parity-detect.js';
 import type { ParityContract } from './parity-manifest.js';
@@ -380,5 +386,171 @@ describe('detectVersionPinnedContract', () => {
     const verdict = detectVersionPinnedContract(depsContract(), baseCtx({ repoId: 'totem' }));
     expect(verdict.message).not.toMatch(/content|file|hash|byte/i);
     expect(verdict.message).toMatch(/version|pin|floor|install/i);
+  });
+});
+
+// ─── Mechanical content-equality detector (mmnto-ai/totem#2073) ──
+
+const MARKERS = { start: '<!-- totem:skill-start -->', end: '<!-- totem:skill-end -->' };
+
+/**
+ * Build a distributed skill artifact: a managed block between the markers, with
+ * an optional `fork` marker placed AFTER the end marker (user-customization
+ * territory — outside the compared block, so the marker itself never drifts).
+ */
+function skillFile(body: string, opts: { fork?: string } = {}): string {
+  const trailer = opts.fork !== undefined ? `\n${opts.fork}\n` : '';
+  return `---\nname: x\n---\n\n${MARKERS.start}\n${body}\n${MARKERS.end}\n${trailer}`;
+}
+
+/** Write a consumer artifact at `<tmpRoot>/<rel>`; returns the absolute path. */
+function writeArtifact(rel: string, content: string): string {
+  const abs = path.join(tmpRoot, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content, 'utf-8');
+  return abs;
+}
+
+/** Base mechanical context; canonicalBlock + consumerPath default to a known artifact. */
+function mechCtx(over: Partial<DetectMechanicalContext> = {}): DetectMechanicalContext {
+  return {
+    canonicalBlock: 'CANONICAL BODY\nline two',
+    consumerPath: path.join(tmpRoot, '.claude/skills/x/SKILL.md'),
+    markers: MARKERS,
+    ...over,
+  };
+}
+
+describe('normalizeManagedBlock', () => {
+  it('collapses CRLF and lone CR to LF', () => {
+    expect(normalizeManagedBlock('a\r\nb\rc')).toBe('a\nb\nc');
+  });
+
+  it('strips trailing whitespace per line and trims surrounding blank lines', () => {
+    expect(normalizeManagedBlock('\n\na  \nb\t\n\n')).toBe('a\nb');
+  });
+});
+
+describe('extractManagedBlock', () => {
+  it('returns the content between the first start and the following end marker', () => {
+    expect(extractManagedBlock(`pre ${MARKERS.start}INNER${MARKERS.end} post`, MARKERS)).toBe(
+      'INNER',
+    );
+  });
+
+  it('returns undefined when either marker is absent', () => {
+    expect(extractManagedBlock(`only ${MARKERS.start} no end`, MARKERS)).toBeUndefined();
+    expect(extractManagedBlock('no markers at all', MARKERS)).toBeUndefined();
+  });
+});
+
+describe('parseForkMarker', () => {
+  it('parses reason/owner/attested, whitespace-tolerant', () => {
+    expect(
+      parseForkMarker('<!--  totem:fork   reason="x y"  owner="me" attested="2026-06-03" -->'),
+    ).toEqual({ reason: 'x y', owner: 'me', attested: '2026-06-03' });
+  });
+
+  it('returns an empty object for a bare marker, undefined when absent', () => {
+    expect(parseForkMarker('<!-- totem:fork -->')).toEqual({});
+    expect(parseForkMarker('no marker here')).toBeUndefined();
+  });
+
+  it('matches a fork marker authored across multiple lines (dotAll)', () => {
+    expect(parseForkMarker('<!-- totem:fork\n  reason="multi line"\n  owner="me"\n-->')).toEqual({
+      reason: 'multi line',
+      owner: 'me',
+    });
+  });
+});
+
+describe('detectMechanicalContract', () => {
+  it('pass — consumer block equals canonical after normalization', () => {
+    const consumerPath = writeArtifact(
+      '.claude/skills/x/SKILL.md',
+      skillFile('CANONICAL BODY\nline two'),
+    );
+    expect(detectMechanicalContract(mechCtx({ consumerPath })).status).toBe('pass');
+  });
+
+  it('pass — CRLF consumer vs LF canonical, otherwise identical (win32 guard, req #3)', () => {
+    const crlf = skillFile('CANONICAL BODY\nline two').replace(/\n/g, '\r\n');
+    const consumerPath = writeArtifact('.claude/skills/x/SKILL.md', crlf);
+    expect(detectMechanicalContract(mechCtx({ consumerPath })).status).toBe('pass');
+  });
+
+  it('pass — a trailing-whitespace-only difference normalizes equal', () => {
+    const consumerPath = writeArtifact(
+      '.claude/skills/x/SKILL.md',
+      skillFile('CANONICAL BODY  \nline two\t'),
+    );
+    expect(detectMechanicalContract(mechCtx({ consumerPath })).status).toBe('pass');
+  });
+
+  it('warn — drift with no fork marker, reporting the consumer content-hash', () => {
+    const consumerPath = writeArtifact('.claude/skills/x/SKILL.md', skillFile('DRIFTED BODY'));
+    const v = detectMechanicalContract(mechCtx({ consumerPath }));
+    expect(v.status).toBe('warn');
+    expect(v.message).toMatch(/drift/i);
+    expect(v.message).toContain(hashManagedBlock(normalizeManagedBlock('DRIFTED BODY')));
+  });
+
+  it('info — drift WITH a fork marker is an attested intentional fork, never warn (req #7)', () => {
+    const consumerPath = writeArtifact(
+      '.claude/skills/x/SKILL.md',
+      skillFile('DRIFTED BODY', {
+        fork: '<!-- totem:fork reason="local override" owner="satur8d" attested="2026-06-03" -->',
+      }),
+    );
+    const v = detectMechanicalContract(mechCtx({ consumerPath }));
+    expect(v.status).toBe('info');
+    expect(v.message).toMatch(/intentional fork/i);
+    expect(v.message).toContain('2026-06-03');
+  });
+
+  it('pass — a fork marker present but content actually matching is still pass (no false fork)', () => {
+    const consumerPath = writeArtifact(
+      '.claude/skills/x/SKILL.md',
+      skillFile('CANONICAL BODY\nline two', { fork: '<!-- totem:fork reason="x" -->' }),
+    );
+    expect(detectMechanicalContract(mechCtx({ consumerPath })).status).toBe('pass');
+  });
+
+  it('unknown — an unresolvable canonical is never rendered pass (Stale-Doctor-Paradox guard)', () => {
+    const consumerPath = writeArtifact('.claude/skills/x/SKILL.md', skillFile('whatever'));
+    const v = detectMechanicalContract(mechCtx({ consumerPath, canonicalBlock: undefined }));
+    expect(v.status).toBe('unknown');
+    expect(v.status).not.toBe('pass');
+  });
+
+  it('skip — consumer artifact absent (cohort permits absence), distinct from drift', () => {
+    const v = detectMechanicalContract(
+      mechCtx({ consumerPath: path.join(tmpRoot, 'nope/SKILL.md') }),
+    );
+    expect(v.status).toBe('skip');
+  });
+
+  it('warn — a present file with markers stripped is unmanaged drift, not pass', () => {
+    const consumerPath = writeArtifact('.claude/skills/x/SKILL.md', 'no markers, just text');
+    const v = detectMechanicalContract(mechCtx({ consumerPath }));
+    expect(v.status).toBe('warn');
+    expect(v.message).toMatch(/markers absent|unmanaged/i);
+  });
+
+  it('never emits fail and degrades a missing read to skip (detector invariant)', () => {
+    const v = detectMechanicalContract(mechCtx({ readFile: () => undefined }));
+    expect(v.status).toBe('skip');
+    expect(v.status).not.toBe('fail');
+  });
+
+  it('binary self-report (req #5) — names the resolving @mmnto/cli in the verdict', () => {
+    const consumerPath = writeArtifact(
+      '.claude/skills/x/SKILL.md',
+      skillFile('CANONICAL BODY\nline two'),
+    );
+    const v = detectMechanicalContract(
+      mechCtx({ consumerPath, binary: { version: '1.53.5', path: '/usr/local/bin/totem' } }),
+    );
+    expect(v.message).toContain('@mmnto/cli@1.53.5');
   });
 });

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -689,6 +689,14 @@ export function hashManagedBlock(normalized: string): string {
   return crypto.createHash('sha256').update(normalized, 'utf-8').digest('hex').slice(0, 12);
 }
 
+/** Format a fork marker's attested/owner attributes as a message suffix. */
+function formatForkMeta(fork: ForkMarker): string {
+  return (
+    (fork.attested !== undefined ? `, attested ${fork.attested}` : '') +
+    (fork.owner !== undefined ? `, owner ${fork.owner}` : '')
+  );
+}
+
 /**
  * Detect drift for ONE mechanical managed-block contract (the #2073 mechanical
  * skills slice). Compares the consumer's installed managed-block against the
@@ -742,14 +750,26 @@ export function detectMechanicalContract(ctx: DetectMechanicalContext): ParityCo
     };
   }
 
-  // ── Extract the consumer's managed block (markers absent → warn: unmanaged) ──
+  // ── Extract the consumer's managed block ──
   const consumerBlock = extractManagedBlock(consumerContent, ctx.markers);
   if (consumerBlock === undefined) {
+    // Markers absent. A fork marker still signals an INTENTIONAL override (a
+    // heavy fork can strip the managed-block markers entirely) → `info`; only an
+    // unmarked, unmanaged file is drift `warn`.
+    const strippedFork = parseForkMarker(consumerContent);
+    if (strippedFork !== undefined) {
+      return {
+        status: 'info',
+        message: tag(
+          `intentional fork${formatForkMeta(strippedFork)} — managed-block markers absent in ${ctx.consumerPath}`,
+        ),
+      };
+    }
     return {
       status: 'warn',
       message: `managed-block markers absent in ${ctx.consumerPath} — file is unmanaged or marker-stripped`,
       remediation:
-        'Re-run totem init to restore the managed block, or add a totem:fork marker if this file is an intentional override.',
+        'Re-run totem init to restore the managed block, or add a totem:fork marker if this divergence is intentional.',
     };
   }
 
@@ -767,13 +787,10 @@ export function detectMechanicalContract(ctx: DetectMechanicalContext): ParityCo
   // ── Differ: an attested fork is `info`; otherwise drift `warn` (req #7 + #1) ──
   const fork = parseForkMarker(consumerContent);
   if (fork !== undefined) {
-    const meta =
-      (fork.attested !== undefined ? `, attested ${fork.attested}` : '') +
-      (fork.owner !== undefined ? `, owner ${fork.owner}` : '');
     return {
       status: 'info',
       message: tag(
-        `intentional fork${meta} — differs from canonical (consumer ${hashManagedBlock(consumerNorm)} vs canonical ${hashManagedBlock(canonicalNorm)})`,
+        `intentional fork${formatForkMeta(fork)} — differs from canonical (consumer ${hashManagedBlock(consumerNorm)} vs canonical ${hashManagedBlock(canonicalNorm)})`,
       ),
     };
   }

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -33,6 +33,7 @@
  *     the sensor must never crash the doctor pipeline.
  */
 
+import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -69,13 +70,26 @@ const DEP_FIELDS = ['dependencies', 'devDependencies', 'optionalDependencies'] a
 // ─── Verdict type ───────────────────────────────────────
 
 /**
- * Core-local per-contract verdict. The CLI maps this to its `DiagnosticResult`
- * (core cannot depend on cli). The detector emits ONLY `pass`/`warn`/`skip` —
- * `fail` is reserved for the CLI's `--strict`/`blocking` promotion edge — but
- * `fail` stays in the union so the CLI mapping is total over the same shape.
+ * Core-local per-contract verdict. The CLI renders this directly (core cannot
+ * depend on cli's `DiagnosticResult`/`CheckStatus`). The verdict vocabulary is
+ * intentionally WIDER than the shared `CheckStatus` so the parity sensor can
+ * honor the round's verdict-state split (mmnto-ai/totem#2073 req #1 — don't
+ * collapse to a binary pass/fail) without rippling `CheckStatus` across every
+ * unrelated doctor check:
+ *   - `pass`    — verified equal / current.
+ *   - `warn`    — drift (sensor-not-gate default; the CLI promotes a `warn` from
+ *                 a `blocking: true` contract to `fail` ONLY under `--strict`).
+ *   - `info`    — an intentional, attested fork (req #7) — NEVER gated/promoted.
+ *   - `unknown` — the Stale-Doctor-Paradox state: the canonical could not be
+ *                 resolved, so the doctor can prove neither drift NOR currency.
+ *                 NEVER rendered as `pass` (no self-certification); NEVER gated.
+ *   - `skip`    — not-applicable / cohort-permits-absence / out of this slice.
+ *
+ * `fail` stays in the union as the CLI-edge promotion target, but a DETECTOR
+ * never emits it (the gate edge is a CLI concern, unchanged from PR-1).
  */
 export interface ParityContractVerdict {
-  status: 'pass' | 'warn' | 'fail' | 'skip';
+  status: 'pass' | 'warn' | 'fail' | 'info' | 'unknown' | 'skip';
   message: string;
   remediation?: string;
 }
@@ -553,7 +567,239 @@ function findDeclaredRange(pkg: PackageJsonShape, packageName: string): string |
   return undefined;
 }
 
+// ─── Mechanical content-equality detector (mmnto-ai/totem#2073) ──
+
+/**
+ * A consumer's hand-added fork/override marker (mmnto-ai/totem#2073 req #7).
+ * When present on a managed-block artifact, a content difference reads as an
+ * INTENTIONAL, attested fork (`info`) rather than drift (`warn`). Sibling to —
+ * NOT merged with — Proposal 292's publisher-generated currency sidecar
+ * (strategy-claude 2026-06-04T0158Z: shared `totem:` namespace + `attested`
+ * (ISO-8601) / `owner` field conventions, but separate author + lifecycle).
+ *
+ * Shape: `<!-- totem:fork reason="…" owner="…" attested="YYYY-MM-DD" -->`.
+ * Every attribute is optional — a bare `totem:fork` marker still flags a fork.
+ */
+export interface ForkMarker {
+  reason?: string;
+  owner?: string;
+  /** ISO-8601 date the fork was last attested (as authored; not validated here). */
+  attested?: string;
+}
+
+/** The marker pair delimiting a managed block within a distributed artifact. */
+export interface ManagedBlockMarkers {
+  start: string;
+  end: string;
+}
+
+/** Inputs + test seams for {@link detectMechanicalContract}. */
+export interface DetectMechanicalContext {
+  /**
+   * The canonical managed-block content, ALREADY extracted from the running
+   * `@mmnto/cli`'s own template by the CLI (core cannot import init-templates —
+   * wrong dependency direction). `undefined`/empty signals the canonical was
+   * unresolvable → `unknown` (the Stale-Doctor-Paradox guard).
+   */
+  canonicalBlock: string | undefined;
+  /** Absolute path to the consumer artifact on disk (e.g. `.claude/skills/<n>/SKILL.md`). */
+  consumerPath: string;
+  /** The marker pair delimiting the managed block in BOTH canonical + consumer. */
+  markers: ManagedBlockMarkers;
+  /**
+   * Running `@mmnto/cli` provenance for the req-#5 self-report. The
+   * Stale-Doctor-Paradox includes the doctor ITSELF being a shadowed/stale
+   * binary supplying a stale in-process canonical; surfacing which binary
+   * computed the verdict keeps the skills verdict honest about its own
+   * provenance (a one-line self-report, not a resolver cascade — that's the
+   * on-disk hooks case).
+   */
+  binary?: { version: string; path: string };
+  /**
+   * Test seam — override the consumer file read. Production callers omit it and
+   * the detector reads `<consumerPath>` (UTF-8); a read failure is honest-absent.
+   */
+  readFile?: (absPath: string) => string | undefined;
+}
+
+/**
+ * Normalize a managed block for content comparison (req #3): CRLF / lone-CR → LF,
+ * strip trailing whitespace per line, and trim leading/trailing blank lines. Two
+ * blocks that differ ONLY in line endings or trailing whitespace — the win32
+ * checkout false-positive class — normalize equal.
+ */
+export function normalizeManagedBlock(block: string): string {
+  return block
+    .replace(/\r\n?/g, '\n') // CRLF + lone CR → LF
+    .replace(/[ \t]+$/gm, '') // trailing whitespace per line
+    .replace(/^\n+/, '') // leading blank lines
+    .replace(/\n+$/, ''); // trailing blank lines
+}
+
+/**
+ * Extract the content BETWEEN the first `markers.start` and the first following
+ * `markers.end`. Returns undefined when either marker is absent (an unmanaged or
+ * marker-stripped file). The markers themselves are excluded from the result.
+ */
+export function extractManagedBlock(
+  content: string,
+  markers: ManagedBlockMarkers,
+): string | undefined {
+  const startIdx = content.indexOf(markers.start);
+  if (startIdx === -1) return undefined;
+  const afterStart = startIdx + markers.start.length;
+  const endIdx = content.indexOf(markers.end, afterStart);
+  if (endIdx === -1) return undefined;
+  return content.slice(afterStart, endIdx);
+}
+
+/**
+ * Parse a `<!-- totem:fork reason="…" owner="…" attested="…" -->` marker from
+ * anywhere in `content`. Whitespace-tolerant (mirrors `REFLEX_VERSION_RE`).
+ * Returns undefined when no marker is present; each attribute is independently
+ * optional, so a bare `<!-- totem:fork -->` returns an empty marker object
+ * (still a fork signal). The attribute patterns are fixed literals (no dynamic
+ * RegExp) and linear (no nested quantifiers) — ReDoS-safe.
+ */
+export function parseForkMarker(content: string): ForkMarker | undefined {
+  // `s` (dotAll) so a marker authored across multiple lines still matches; `.*?`
+  // stays non-greedy + bounded by the first `-->`, so it remains linear (ReDoS-safe).
+  const markerMatch = /<!--\s*totem:fork\b(.*?)-->/is.exec(content);
+  if (markerMatch === null) return undefined;
+  const attrsText = markerMatch[1] ?? '';
+  const marker: ForkMarker = {};
+  // Iterate ALL key="value" pairs with matchAll (not a single match() — per the
+  // security lesson, one match() lets a safe prefix shadow later pairs); a
+  // marker's attributes are unordered + each independently optional.
+  for (const pair of attrsText.matchAll(/(\w+)\s*=\s*"([^"]*)"/g)) {
+    const value = pair[2] ?? '';
+    if (pair[1] === 'reason') marker.reason = value;
+    else if (pair[1] === 'owner') marker.owner = value;
+    else if (pair[1] === 'attested') marker.attested = value;
+  }
+  return marker;
+}
+
+/**
+ * Short content hash (sha256, first 12 hex chars) of a normalized block, for the
+ * verdict's machine-readable record (req #6). The hash IS the content-equality
+ * evidence — bytes, never prose-parsing (req #2's spirit).
+ */
+export function hashManagedBlock(normalized: string): string {
+  return crypto.createHash('sha256').update(normalized, 'utf-8').digest('hex').slice(0, 12);
+}
+
+/**
+ * Detect drift for ONE mechanical managed-block contract (the #2073 mechanical
+ * skills slice). Compares the consumer's installed managed-block against the
+ * running `@mmnto/cli`'s own canonical block (passed in by the CLI), normalized
+ * for line-endings + trailing whitespace (req #3) and content-hashed (req #6).
+ * Honors the verdict-state split (req #1) + the fork marker (req #7):
+ *
+ *   - `pass`    — normalized blocks equal.
+ *   - `warn`    — blocks differ, no fork marker (drift); reports both short hashes.
+ *   - `info`    — blocks differ AND a `totem:fork` marker is present (attested fork).
+ *   - `unknown` — canonical unresolvable (the doctor may itself be stale/shadowed);
+ *                 never self-certify as `pass`.
+ *   - `skip`    — consumer artifact not installed (cohort permits absence).
+ *
+ * NEVER throws (reads degrade), NEVER networks (canonical is in-process), NEVER
+ * emits `fail` (the gate edge is a CLI concern, unchanged from PR-1).
+ */
+export function detectMechanicalContract(ctx: DetectMechanicalContext): ParityContractVerdict {
+  const provenance =
+    ctx.binary !== undefined
+      ? ` (checked by @mmnto/cli@${ctx.binary.version} at ${ctx.binary.path})`
+      : '';
+  // Append the binary self-report (req #5) by concatenation (not interpolation)
+  // so the provenance suffix never reads as a jammed token in a message.
+  const tag = (msg: string): string => msg + provenance;
+
+  // ── Canonical unresolvable → unknown (Stale-Doctor-Paradox guard) ──
+  // Collapse a non-string / empty canonical to '' so the guard is a single
+  // length check (no boolean `||` for a numeric-default rule to misread).
+  const canonical = typeof ctx.canonicalBlock === 'string' ? ctx.canonicalBlock : '';
+  if (canonical.length === 0) {
+    return {
+      status: 'unknown',
+      message: tag(
+        'cannot resolve canonical template from the running @mmnto/cli — verdict unprovable',
+      ),
+      remediation:
+        'Reinstall @mmnto/cli (the running binary may be stale or shadowed), then re-run totem doctor --parity.',
+    };
+  }
+
+  // ── Read the consumer artifact (absent → skip; cohort permits absence) ──
+  const readFile = ctx.readFile ?? readFileText;
+  const consumerContent = readFile(ctx.consumerPath);
+  if (consumerContent === undefined) {
+    return {
+      status: 'skip',
+      message: `artifact not installed at ${ctx.consumerPath} — cohort permits absence`,
+      remediation:
+        'Run totem init to install the distributed artifact, or ignore if this repo intentionally omits it.',
+    };
+  }
+
+  // ── Extract the consumer's managed block (markers absent → warn: unmanaged) ──
+  const consumerBlock = extractManagedBlock(consumerContent, ctx.markers);
+  if (consumerBlock === undefined) {
+    return {
+      status: 'warn',
+      message: `managed-block markers absent in ${ctx.consumerPath} — file is unmanaged or marker-stripped`,
+      remediation:
+        'Re-run totem init to restore the managed block, or add a totem:fork marker if this file is an intentional override.',
+    };
+  }
+
+  // ── Normalize + compare (req #3) ──
+  const canonicalNorm = normalizeManagedBlock(canonical);
+  const consumerNorm = normalizeManagedBlock(consumerBlock);
+
+  if (canonicalNorm === consumerNorm) {
+    return {
+      status: 'pass',
+      message: tag(`matches canonical — hash ${hashManagedBlock(consumerNorm)}`),
+    };
+  }
+
+  // ── Differ: an attested fork is `info`; otherwise drift `warn` (req #7 + #1) ──
+  const fork = parseForkMarker(consumerContent);
+  if (fork !== undefined) {
+    const meta =
+      (fork.attested !== undefined ? `, attested ${fork.attested}` : '') +
+      (fork.owner !== undefined ? `, owner ${fork.owner}` : '');
+    return {
+      status: 'info',
+      message: tag(
+        `intentional fork${meta} — differs from canonical (consumer ${hashManagedBlock(consumerNorm)} vs canonical ${hashManagedBlock(canonicalNorm)})`,
+      ),
+    };
+  }
+
+  return {
+    status: 'warn',
+    message: tag(
+      `drift — consumer ${hashManagedBlock(consumerNorm)} != canonical ${hashManagedBlock(canonicalNorm)}`,
+    ),
+    remediation:
+      'Reconcile the artifact to the canonical (re-run totem init), or add a totem:fork marker if the divergence is intentional.',
+  };
+}
+
 // ─── Shared filesystem helpers ──────────────────────────
+
+/** Read a UTF-8 text file, or undefined on any read failure (honest-absent). */
+function readFileText(absPath: string): string | undefined {
+  try {
+    // totem-context: a runtime sensor must read the ACTUAL on-disk installed artifact (not the git-index version — a consumer's installed skill may be untracked), and this detector is synchronous by design (mirrors readPackageJson / isDirectory below); making one reader async would ripple through the whole pure detector.
+    return fs.readFileSync(absPath, 'utf-8');
+    // totem-context: a missing / unreadable artifact is the honest-absent signal the mechanical detector degrades to a skip on; rethrowing would force the caller to wrap a routine absence in try/catch.
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Read + JSON-parse a package.json into the loose {@link PackageJsonShape}.

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -724,10 +724,11 @@ export function detectMechanicalContract(ctx: DetectMechanicalContext): ParityCo
   const tag = (msg: string): string => msg + provenance;
 
   // ── Canonical unresolvable → unknown (Stale-Doctor-Paradox guard) ──
-  // Collapse a non-string / empty canonical to '' so the guard is a single
-  // length check (no boolean `||` for a numeric-default rule to misread).
-  const canonical = typeof ctx.canonicalBlock === 'string' ? ctx.canonicalBlock : '';
-  if (canonical.length === 0) {
+  // `undefined` = the CLI could not extract the canonical (a build/marker bug);
+  // an EMPTY string is a legitimately empty template that must still be COMPARED,
+  // not conflated with unresolvable (GCA + Greptile review on the PR). `=== undefined`
+  // is a single condition, so there's no boolean `||` for a numeric-default rule to misread.
+  if (ctx.canonicalBlock === undefined) {
     return {
       status: 'unknown',
       message: tag(
@@ -737,6 +738,7 @@ export function detectMechanicalContract(ctx: DetectMechanicalContext): ParityCo
         'Reinstall @mmnto/cli (the running binary may be stale or shadowed), then re-run totem doctor --parity.',
     };
   }
+  const canonical = ctx.canonicalBlock;
 
   // ── Read the consumer artifact (absent → skip; cohort permits absence) ──
   const readFile = ctx.readFile ?? readFileText;


### PR DESCRIPTION
First **mechanical detection slice** of `totem doctor --parity` (mmnto-ai/totem#2073), built on the strategy-claude green-light (2026-06-04, 3-lane BLIND round confirming the doctor is **strictly local-read-only**, Tenet 6).

## What it does
Adds a **managed-block content-equality** detector that compares a consumer's installed `.claude/skills/<name>/SKILL.md` managed-block (between `<!-- totem:skill-start/-end -->`) against the running `@mmnto/cli`'s **own** canonical template — CRLF/LF + trailing-whitespace normalized and content-hashed. The canonical is the in-process `init-templates` export (the doctor *is* the pinned `@mmnto/cli`), so there's **no network and no node_modules reach-in**. Wired for the two totem-source skill contracts: `claude-skills` + `review-reply-skill-content`.

## Green-light requirements honored
- **Verdict-state split** (req #1): `pass` / `warn` (drift) / `info` (attested fork) / **`unknown`** (Stale-Doctor-Paradox — an unresolvable canonical is *never* self-certified as `pass`) / `skip`
- **req #3** — CRLF/LF + trailing-whitespace normalize-before-hash (win32 cohort)
- **req #5** — binary self-report (`checked by @mmnto/cli@<v> at <path>`); the full ADR-072 resolver cascade is the on-disk hooks case (next slice)
- **req #7** — first-class fork/override marker reader: `<!-- totem:fork reason="…" owner="…" attested="…" -->` (drift → `info`, never `warn`). Shape field-aligned with Proposal 292 per strategy-claude

## Design
- **core** (`parity-detect.ts`): `detectMechanicalContract` + pure helpers (`normalizeManagedBlock`, `extractManagedBlock`, `parseForkMarker`, `hashManagedBlock`); `ParityContractVerdict` widened with `info`/`unknown`.
- **cli** (`doctor-parity.ts`): CLI-side artifact registry + tractability routing + `ParityLine` (a parity-local result type carrying the wider status, so `CheckStatus` doesn't ripple across the other doctor checks). Detector never emits `fail`; the `--strict`+`blocking` gate edge is unchanged from PR-1.

Design doc: `.totem/specs/2073.md` (`## Implementation Design — Mechanical Slice`).

## Scope / out of scope
This is the first mechanical PR. Deferred to fast-follows + the #2073 tail: the parameterized **hook** contracts (`git-hooks`, `session-start-orientation`), the **file-value-equality** bot-configs, the **structural-presence** dimensions, the **manual-attestation** slice, and **publish** (the completing slice triggers the release).

## Verification
- core + cli parity suites green; full suite 2369 cli + core, 4/4 turbo
- full-branch `totem lint` 0 errors; repo-wide `format:check` clean; `totem review` PASS (zero findings)
- integration smoke against the real 20-contract manifest: dogfooded skills render `PASS` with content-hash + self-report; everything else degrades to honest `skip`

## Notes
- **No changeset** — unpublished by design (the feature is incomplete; `@mmnto/cli` stays at the current floor until the completing slice).
- **Manifest observation** (for strategy): `review-reply-skill-content` overlaps `claude-skills` (review-reply is checked by both — same file, identical hash, both PASS). Possible manifest cleanup; not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
