### PR TITLE
feat(cli): totem doctor --parity manual-attestation detection — doctrine + vendor-SDK slice (#2073)

### DIFF
--- a/packages/cli/src/commands/doctor-parity.test.ts
+++ b/packages/cli/src/commands/doctor-parity.test.ts
@@ -582,3 +582,94 @@ describe('doctorParityCliCommand — --strict fail-promotion', () => {
     ).resolves.toBeUndefined();
   });
 });
+
+// ─── manual-attestation detection wiring (mmnto-ai/totem#2073 manual-attestation slice) ──
+
+/**
+ * A manifest carrying both manual-attestation sub-classes: two doctrine rows
+ * (no package, cross-repo canonical) + two vendor-SDK couplings (package set),
+ * one of the latter scoped to a consumer this repo is NOT, to exercise the skip.
+ */
+const MANUAL_ATTEST_MANIFEST_YAML = `schema-version: 1
+status: scaffold
+contracts:
+  - id: governance-doctrine
+    dimension: doctrine
+    canonical-source: mmnto-ai/totem-strategy:AGENTS.md
+    detection-method: doctor surfaces last attested and flags staleness only
+    expected-value-or-derivation: tracked for doctrine-currency visibility
+    tractability: manual-attestation
+    tracking-issue: mmnto-ai/totem-strategy#511
+  - id: google-genai-coupling
+    dimension: dependency-cohort
+    canonical-source: null
+    package: '@google/genai'
+    detection-method: doctor surfaces each consumer's pin + last-attested; flags staleness only
+    expected-value-or-derivation: tracked for coupling visibility
+    tractability: manual-attestation
+    tracking-issue: mmnto-ai/totem#2018
+  - id: anthropic-sdk-coupling
+    dimension: dependency-cohort
+    canonical-source: null
+    package: '@anthropic-ai/sdk'
+    detection-method: doctor surfaces each consumer's pin + last-attested; flags staleness only
+    expected-value-or-derivation: tracked for coupling visibility
+    tractability: manual-attestation
+    tracking-issue: mmnto-ai/totem-strategy#482
+    consumers:
+      - liquid-city
+`;
+
+describe('checkParity — manual-attestation wiring', () => {
+  it('routes both sub-classes off the stub: doctrine → info surface, vendor-SDK → info pin, scoped-out → skip', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', MANUAL_ATTEST_MANIFEST_YAML);
+    // The consumer declares @google/genai so its coupling surfaces a pin; this
+    // repo is not `liquid-city`, so the anthropic coupling lands on a scope skip.
+    writeConsumerDeps({ '@google/genai': '^0.3.0' });
+
+    const { results, blockingDriftIds } = await checkParity(tmpDir);
+    const perContract = results.slice(1);
+
+    const doctrine = perContract.find((r) => r.name === 'Parity: governance-doctrine')!;
+    expect(doctrine.status).toBe('info');
+    expect(doctrine.message).toContain('mmnto-ai/totem-strategy:AGENTS.md');
+    expect(doctrine.message).toContain('mmnto-ai/totem-strategy#511');
+    expect(doctrine.message).not.toContain('not yet implemented');
+
+    const genai = perContract.find((r) => r.name === 'Parity: google-genai-coupling')!;
+    expect(genai.status).toBe('info');
+    expect(genai.message).toContain('@google/genai');
+    expect(genai.message).toContain('^0.3.0');
+
+    const anthropic = perContract.find((r) => r.name === 'Parity: anthropic-sdk-coupling')!;
+    expect(anthropic.status).toBe('skip');
+    expect(anthropic.message).toMatch(/cohort permits absence/i);
+    expect(anthropic.message).not.toContain('not yet implemented');
+
+    // No manual-attestation contract is rendered as the old stub, fail, or warn.
+    expect(perContract.every((r) => !r.message.includes('not yet implemented'))).toBe(true);
+    expect(results.some((r) => r.status === 'fail' || r.status === 'warn')).toBe(false);
+    expect(blockingDriftIds).toHaveLength(0);
+  });
+
+  it('manual-attestation is structurally non-gating: a blocking:true contract never enters blockingDriftIds', async () => {
+    // Even marked blocking, an info verdict (the manual-attestation ceiling) never
+    // promotes — the contract cannot fail even under --strict.
+    const blockingManifest = MANUAL_ATTEST_MANIFEST_YAML.replace(
+      'tracking-issue: mmnto-ai/totem-strategy#511\n',
+      'tracking-issue: mmnto-ai/totem-strategy#511\n    blocking: true\n',
+    );
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', blockingManifest);
+    writeConsumerDeps({ '@google/genai': '^0.3.0' });
+
+    const { blockingDriftIds } = await checkParity(tmpDir);
+    expect(blockingDriftIds).toHaveLength(0);
+
+    // And the CLI command resolves (no throw) under --strict.
+    await expect(
+      doctorParityCliCommand({ strict: true, cwdForTest: tmpDir }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -259,6 +259,7 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
   const {
     deriveCohortRepoId,
     detectGeneratedArtifactContract,
+    detectManualAttestationContract,
     detectMechanicalContract,
     detectVersionPinnedContract,
     extractManagedBlock,
@@ -506,7 +507,22 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
           return lines;
         }
 
-        // ── manual-attestation + anything else → skip stub (the mmnto-ai/totem#2073 tail) ──
+        // ── manual-attestation (mmnto-ai/totem#2073 manual-attestation slice) ──
+        // The claim-class with no mechanical sensor: the detector surfaces the
+        // tracked vendor-SDK pin (package set) or doctrine-currency row (no package)
+        // as `info`, or honest-absent `skip` — NEVER pass/warn/fail/unknown. An
+        // `info` can't enter blockingDriftIds, so these contracts cannot fail even
+        // under --strict (the manifest's "never fails" contract).
+        if (c.tractability === 'manual-attestation') {
+          // The detector reads the sub-class discriminant (`c.package`) + the
+          // canonical source directly off the contract. `package:` set ⇒ vendor-SDK
+          // pin read; unset ⇒ doctrine-row pure-info surface. No `attested` yet (the
+          // schema has no last-attested field — strategy's follow-on lane).
+          const verdict = detectManualAttestationContract(c, { cwd, repoId });
+          return [verdictToLine(c, verdict)];
+        }
+
+        // ── anything else (a future tractability) → skip stub; the slice boundary stays observable ──
         return [
           stub(c, `${c.dimension} (${c.tractability}) — drift detection not yet implemented`),
         ];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -557,6 +557,7 @@ export type {
   CohortFloorStatus,
   DeriveCohortRepoIdOptions,
   DetectGeneratedArtifactContext,
+  DetectManualAttestationContext,
   DetectMechanicalContext,
   DetectVersionPinnedContext,
   ForkMarker,
@@ -567,6 +568,7 @@ export type {
 export {
   deriveCohortRepoId,
   detectGeneratedArtifactContract,
+  detectManualAttestationContract,
   detectMechanicalContract,
   detectVersionPinnedContract,
   extractManagedBlock,

--- a/packages/core/src/parity-detect.test.ts
+++ b/packages/core/src/parity-detect.test.ts
@@ -25,6 +25,8 @@ import {
   deriveCohortRepoId,
   type DetectGeneratedArtifactContext,
   detectGeneratedArtifactContract,
+  type DetectManualAttestationContext,
+  detectManualAttestationContract,
   type DetectMechanicalContext,
   detectMechanicalContract,
   type DetectVersionPinnedContext,
@@ -32,6 +34,7 @@ import {
   extractManagedBlock,
   hashManagedBlock,
   normalizeManagedBlock,
+  type PackageJsonShape,
   packageNameForContract,
   parseForkMarker,
   resolveCohortFloor,
@@ -808,5 +811,180 @@ describe('detectGeneratedArtifactContract', () => {
     expect(v.status).toBe('unknown');
     expect(v.status).not.toBe('warn');
     expect(v.message).toMatch(/canonical hook region|unprovable/i);
+  });
+});
+
+// ─── detectManualAttestationContract (mmnto-ai/totem#2073 manual-attestation slice) ──
+
+describe('detectManualAttestationContract', () => {
+  /** A vendor-SDK manual-attestation coupling (`package` set → local pin readable). */
+  function vendorContract(over: Partial<ParityContract> = {}): ParityContract {
+    return {
+      id: 'google-genai-coupling',
+      dimension: 'dependency-cohort',
+      canonicalSource: null,
+      detectionMethod: "doctor surfaces each consumer's pin + last-attested; flags staleness only",
+      expectedValueOrDerivation:
+        'tracked for coupling visibility; cohort floor is a pending decision',
+      tractability: 'manual-attestation',
+      trackingIssue: 'mmnto-ai/totem#2018',
+      package: '@google/genai',
+      ...over,
+    };
+  }
+
+  /** A doctrine manual-attestation row (no `package`; cross-repo canonical). */
+  function doctrineContract(over: Partial<ParityContract> = {}): ParityContract {
+    return {
+      id: 'governance-doctrine',
+      dimension: 'doctrine',
+      canonicalSource: 'mmnto-ai/totem-strategy:AGENTS.md',
+      detectionMethod: 'doctor surfaces "last attested <date/SHA>" and flags staleness only',
+      expectedValueOrDerivation:
+        'tracked for doctrine-currency visibility; the mechanical pin is a pending deliverable',
+      tractability: 'manual-attestation',
+      trackingIssue: 'mmnto-ai/totem-strategy#511',
+      ...over,
+    };
+  }
+
+  function maCtx(
+    over: Partial<DetectManualAttestationContext> = {},
+  ): DetectManualAttestationContext {
+    return { cwd: tmpRoot, repoId: 'totem', ...over };
+  }
+
+  /** A read seam that throws — proves the doctrine-row path performs NO package.json read. */
+  const throwingRead = (): PackageJsonShape | undefined => {
+    throw new Error('readPackageJson must not be called on the doctrine-row path');
+  };
+
+  // ── Vendor-SDK sub-class ──
+  it('vendor-SDK: declared + installed → info naming pkg, range, installed version, no-floor', () => {
+    writeConsumerPkg(tmpRoot, { '@google/genai': '^0.3.0' });
+    writeInstalled(tmpRoot, '@google/genai', '0.3.1');
+    const v = detectManualAttestationContract(vendorContract(), maCtx());
+    expect(v.status).toBe('info');
+    expect(v.message).toContain('@google/genai');
+    expect(v.message).toContain('^0.3.0');
+    expect(v.message).toContain('installed 0.3.1');
+    expect(v.message).toMatch(/no cohort floor|attest only/i);
+  });
+
+  it('vendor-SDK: applicable consumer but package NOT declared → skip, NOT warn (vendor spread permitted)', () => {
+    writeConsumerPkg(tmpRoot, { 'some-other-dep': '^1.0.0' });
+    const v = detectManualAttestationContract(vendorContract(), maCtx());
+    expect(v.status).toBe('skip');
+    expect(v.status).not.toBe('warn');
+    expect(v.message).toMatch(/not present here|vendor spread/i);
+  });
+
+  it('vendor-SDK: an unparseable declared range → info with installed unresolved (never throws, never warn)', () => {
+    writeConsumerPkg(tmpRoot, { '@google/genai': 'not-a-range' });
+    const v = detectManualAttestationContract(vendorContract(), maCtx());
+    expect(v.status).toBe('info');
+    expect(v.status).not.toBe('warn');
+    expect(v.message).toContain('installed: unresolved');
+  });
+
+  it('vendor-SDK with no consumer package.json at all → skip, never throws (production honest-absent reader)', () => {
+    // tmpRoot has no package.json written this case.
+    const v = detectManualAttestationContract(vendorContract(), maCtx());
+    expect(v.status).toBe('skip');
+  });
+
+  // ── consumers-scope guard (verbatim parity with detectVersionPinnedContract) ──
+  it('consumers scope: repo not in consumers → skip cohort-permits-absence', () => {
+    const v = detectManualAttestationContract(
+      vendorContract({
+        id: 'anthropic-sdk-coupling',
+        package: '@anthropic-ai/sdk',
+        consumers: ['totem', 'liquid-city'],
+      }),
+      maCtx({ repoId: 'totem-status' }),
+    );
+    expect(v.status).toBe('skip');
+    expect(v.message).toMatch(/cohort permits absence/i);
+  });
+
+  it('consumers scope: repoId unresolvable on a scoped contract → skip (cannot determine applicability)', () => {
+    const v = detectManualAttestationContract(
+      vendorContract({ consumers: ['totem'] }),
+      maCtx({ repoId: undefined }),
+    );
+    expect(v.status).toBe('skip');
+    expect(v.message).toMatch(/cannot determine applicability/i);
+  });
+
+  // ── Doctrine sub-class (zero I/O — local-read-only) ──
+  it('doctrine row: info naming canonicalSource + tracking issue + not-recorded; performs ZERO package.json read', () => {
+    const v = detectManualAttestationContract(
+      doctrineContract(),
+      // A throwing read seam proves the doctrine path never touches package.json.
+      maCtx({ readPackageJson: throwingRead }),
+    );
+    expect(v.status).toBe('info');
+    expect(v.message).toContain('mmnto-ai/totem-strategy:AGENTS.md');
+    expect(v.message).toContain('mmnto-ai/totem-strategy#511');
+    expect(v.message).toMatch(/last attested: not recorded/i);
+  });
+
+  it('doctrine row with a null canonicalSource → info with the no-external-source phrasing', () => {
+    const v = detectManualAttestationContract(
+      doctrineContract({ canonicalSource: null }),
+      maCtx({ readPackageJson: throwingRead }),
+    );
+    expect(v.status).toBe('info');
+    expect(v.message).toMatch(/no external canonical source/i);
+  });
+
+  // ── attested seam (forward-compat for the strategy `last-attested:` follow-on) ──
+  it('attested date supplied → message reports it; status stays info (staleness is a message refinement, not a status)', () => {
+    const v = detectManualAttestationContract(
+      doctrineContract(),
+      maCtx({ attested: '2026-06-04', readPackageJson: throwingRead }),
+    );
+    expect(v.status).toBe('info');
+    expect(v.message).toContain('last attested 2026-06-04');
+  });
+
+  // ── Claim-class ceiling KEYSTONE: info|skip ONLY, never pass/warn/fail/unknown ──
+  it('claim-class ceiling: across every input shape the verdict is ONLY info or skip', () => {
+    writeConsumerPkg(tmpRoot, { '@google/genai': '^0.3.0' });
+    const verdicts = [
+      // vendor declared (resolves via minVersion fallback) → info
+      detectManualAttestationContract(vendorContract(), maCtx()),
+      // vendor not declared → skip
+      detectManualAttestationContract(vendorContract({ package: '@not/installed' }), maCtx()),
+      // vendor invalid range → info (installed unresolved)
+      detectManualAttestationContract(
+        vendorContract({ package: '@google/genai' }),
+        maCtx({ readPackageJson: () => ({ dependencies: { '@google/genai': '@@bad@@' } }) }),
+      ),
+      // not-a-consumer → skip
+      detectManualAttestationContract(
+        vendorContract({ consumers: ['liquid-city'] }),
+        maCtx({ repoId: 'totem-status' }),
+      ),
+      // repoId unresolvable on a scoped contract → skip
+      detectManualAttestationContract(
+        vendorContract({ consumers: ['totem'] }),
+        maCtx({ repoId: undefined }),
+      ),
+      // doctrine row → info
+      detectManualAttestationContract(doctrineContract(), maCtx({ readPackageJson: throwingRead })),
+      // doctrine null source → info
+      detectManualAttestationContract(
+        doctrineContract({ canonicalSource: null }),
+        maCtx({ readPackageJson: throwingRead }),
+      ),
+    ];
+    for (const v of verdicts) {
+      expect(['info', 'skip']).toContain(v.status);
+      expect(v.status).not.toBe('pass');
+      expect(v.status).not.toBe('warn');
+      expect(v.status).not.toBe('fail');
+      expect(v.status).not.toBe('unknown');
+    }
   });
 });

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -592,6 +592,16 @@ export interface DetectManualAttestationContext {
    * Test seam — override the consumer package.json read. Production callers omit it
    * and the detector reads `<cwd>/package.json`. Invoked ONLY on the vendor-SDK
    * path; the doctrine-row path performs no read at all (a throwing seam proves it).
+   *
+   * Scope note (Greptile review on mmnto-ai/totem#2080): this seam covers ONLY the
+   * top-level consumer package.json read (the declared-range lookup). The
+   * installed-version half (`resolveInstalledVersion`) reads the REAL `node_modules`
+   * ancestry and, for any VALID range, falls back to `semver.minVersion(range)` — so
+   * `"installed: unresolved"` arises solely from an UNPARSEABLE range, never from
+   * absent node_modules. A test injecting this seam with a valid range but no on-disk
+   * install therefore sees the minVersion fallback BY DESIGN. The boundary is shared
+   * verbatim with `detectVersionPinnedContract` (same `resolveInstalledVersion`, same
+   * seam scope) — deliberately not widened here to keep the two detectors aligned.
    */
   readPackageJson?: (absPath: string) => PackageJsonShape | undefined;
 }
@@ -646,27 +656,22 @@ export function detectManualAttestationContract(
   // The last-attested suffix: a date if one was supplied (the reserved seam — the
   // manifest has no `last-attested:` field yet), else the honest "not recorded".
   // NEVER fabricated; a present date refines the MESSAGE, never the status.
-  const attestedSuffix =
-    typeof ctx.attested === 'string' && ctx.attested.trim().length > 0
-      ? `last attested ${ctx.attested.trim()}`
-      : 'last attested: not recorded';
+  const trimmedAttested = ctx.attested?.trim();
+  const attestedSuffix = trimmedAttested
+    ? `last attested ${trimmedAttested}`
+    : 'last attested: not recorded';
 
   // The `package:` field is the sub-class discriminant, read directly off the
   // contract (single source of truth). A whitespace-only value is treated as
-  // absent (doctrine-like) rather than a degenerate vendor pin.
-  const pkg =
-    typeof contract.package === 'string' && contract.package.trim().length > 0
-      ? contract.package.trim()
-      : undefined;
+  // absent (doctrine-like) rather than a degenerate vendor pin (`|| undefined`
+  // collapses an empty trim to the doctrine-row branch).
+  const pkg = contract.package?.trim() || undefined;
 
   // ── Doctrine row (no package): a pure info surface, ZERO on-disk I/O ──
   // canonicalSource is cross-repo (mmnto-ai/totem-strategy:AGENTS.md); the
   // local-read-only doctor surfaces it as TEXT and never resolves it.
   if (pkg === undefined) {
-    const source =
-      typeof contract.canonicalSource === 'string' && contract.canonicalSource.trim().length > 0
-        ? contract.canonicalSource.trim()
-        : 'no external canonical source';
+    const source = contract.canonicalSource?.trim() || 'no external canonical source';
     return {
       status: 'info',
       message: `doctrine currency tracked — ${contract.dimension} (canonical: ${source}); no local pin mechanism, pending doctrine-distribution (${contract.trackingIssue}). ${attestedSuffix}`,

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -567,6 +567,148 @@ function findDeclaredRange(pkg: PackageJsonShape, packageName: string): string |
   return undefined;
 }
 
+// ─── Manual-attestation detector (mmnto-ai/totem#2073 manual-attestation slice) ──
+
+/**
+ * Inputs + test seams for {@link detectManualAttestationContract}. The sub-class
+ * discriminant (`package:`) + the canonical source are read DIRECTLY off the
+ * `contract` argument (single source of truth) — the context carries only the
+ * consumer-local read seams + the reserved attestation date.
+ */
+export interface DetectManualAttestationContext {
+  /** The consumer repo to read `package.json` from (the vendor-SDK pin read). */
+  cwd: string;
+  /** The current repo's cohort id (from {@link deriveCohortRepoId}) for `consumers` applicability. */
+  repoId?: string;
+  /**
+   * OPTIONAL local attestation date (ISO-8601). Absent today — the manifest schema
+   * has no `last-attested:` field yet; strategy owns that follow-on (#2073 design
+   * 2045Z). RESERVED seam so date-staleness is a clean drop-in: when a date lands
+   * the message reports it, but the VERDICT stays `info` regardless — staleness is
+   * a message refinement, NEVER a status change (manual-attestation never warns).
+   */
+  attested?: string;
+  /**
+   * Test seam — override the consumer package.json read. Production callers omit it
+   * and the detector reads `<cwd>/package.json`. Invoked ONLY on the vendor-SDK
+   * path; the doctrine-row path performs no read at all (a throwing seam proves it).
+   */
+  readPackageJson?: (absPath: string) => PackageJsonShape | undefined;
+}
+
+/**
+ * Detect "drift" for ONE `manual-attestation` contract — the claim-class with NO
+ * mechanical sensor (Tenet 19). The verdict ceiling is **`info` or `skip` ONLY**:
+ * the doctor may SURFACE the tracked coupling/doctrine + FLAG staleness, but may
+ * NEVER assert drift (`warn`), failure (`fail`), currency (`pass`), or an
+ * unprovable-canonical (`unknown`) — there is no canonical to prove against. This
+ * is the manifest's "surfaces last-attested + flags staleness only, NEVER fails"
+ * contract, claim-class-tighter than the mechanical / version-pinned detectors
+ * (which may `warn`). The `info`/`skip` ceiling means the contract can never enter
+ * the CLI's `blockingDriftIds`, so it is structurally incapable of failing even
+ * under `--strict`.
+ *
+ * Two sub-classes, discriminated by the contract's `package:`:
+ *   - **vendor-SDK coupling** (`packageName` set — `@google/genai`,
+ *     `@anthropic-ai/sdk`): reads the consumer's LOCAL pin (declared range +
+ *     resolved installed version, reusing the version-pinned machinery) and
+ *     surfaces it as `info` — NO cohort floor exists, so NO currency claim is made
+ *     (Tenet 16, attest-don't-enforce). The DURABLE manual-attestation case.
+ *   - **doctrine row** (`packageName` unset — `governance-doctrine`,
+ *     `agent-memory-doctrine`): `canonicalSource` is a cross-repo AGENTS.md the
+ *     local-read-only doctor must NOT fetch. Emits a pure `info` doctrine-currency
+ *     surface from the contract fields with ZERO on-disk I/O. TRANSIENT — graduates
+ *     to version-pinned when doctrine-distribution ships (strategy#511 / #526).
+ *
+ * NEVER throws (reads degrade to skip), NEVER networks, NEVER reads the cross-repo
+ * `canonicalSource`, and NEVER emits `pass`/`warn`/`fail`/`unknown`.
+ */
+export function detectManualAttestationContract(
+  contract: ParityContract,
+  ctx: DetectManualAttestationContext,
+): ParityContractVerdict {
+  // ── Applicability: consumers list (verbatim parity with detectVersionPinnedContract) ──
+  if (contract.consumers !== undefined) {
+    if (ctx.repoId === undefined) {
+      return {
+        status: 'skip',
+        message: `cannot determine applicability — repo id unresolvable; contract is scoped to consumers [${contract.consumers.join(', ')}]`,
+      };
+    }
+    if (!contract.consumers.includes(ctx.repoId)) {
+      return {
+        status: 'skip',
+        message: `cohort permits absence here (${ctx.repoId} not in consumers)`,
+      };
+    }
+  }
+
+  // The last-attested suffix: a date if one was supplied (the reserved seam — the
+  // manifest has no `last-attested:` field yet), else the honest "not recorded".
+  // NEVER fabricated; a present date refines the MESSAGE, never the status.
+  const attestedSuffix =
+    typeof ctx.attested === 'string' && ctx.attested.trim().length > 0
+      ? `last attested ${ctx.attested.trim()}`
+      : 'last attested: not recorded';
+
+  // The `package:` field is the sub-class discriminant, read directly off the
+  // contract (single source of truth). A whitespace-only value is treated as
+  // absent (doctrine-like) rather than a degenerate vendor pin.
+  const pkg =
+    typeof contract.package === 'string' && contract.package.trim().length > 0
+      ? contract.package.trim()
+      : undefined;
+
+  // ── Doctrine row (no package): a pure info surface, ZERO on-disk I/O ──
+  // canonicalSource is cross-repo (mmnto-ai/totem-strategy:AGENTS.md); the
+  // local-read-only doctor surfaces it as TEXT and never resolves it.
+  if (pkg === undefined) {
+    const source =
+      typeof contract.canonicalSource === 'string' && contract.canonicalSource.trim().length > 0
+        ? contract.canonicalSource.trim()
+        : 'no external canonical source';
+    return {
+      status: 'info',
+      message: `doctrine currency tracked — ${contract.dimension} (canonical: ${source}); no local pin mechanism, pending doctrine-distribution (${contract.trackingIssue}). ${attestedSuffix}`,
+    };
+  }
+
+  // ── Vendor-SDK coupling (package set): surface the consumer's LOCAL pin ──
+  // Reuse the version-pinned package.json read, but STOP before any floor compare —
+  // there is no agreed cohort floor (Tenet 16), so the doctor asserts NO currency;
+  // the verdict is an info visibility surface, never pass/warn.
+  const readPkg = ctx.readPackageJson ?? readPackageJson;
+  const consumerPkg = readPkg(path.join(ctx.cwd, 'package.json'));
+  const declaredRange = consumerPkg ? findDeclaredRange(consumerPkg, pkg) : undefined;
+
+  if (declaredRange === undefined) {
+    // Applicable consumer, but the vendor SDK is not declared here. UNLIKE the
+    // version-pinned applicable-but-missing case (which becomes a drift `warn` once
+    // consumers are verified), a manual-attestation coupling NEVER warns: vendor
+    // spread is permitted by design (no cohort floor) → honest-absent skip.
+    return {
+      status: 'skip',
+      message: `${pkg} coupling not present here — cohort permits vendor spread (attest-don't-enforce)`,
+    };
+  }
+
+  // Resolve the installed version only for a valid range — guard FIRST so a garbage
+  // range never reaches semver.minVersion (resolveInstalledVersion's fallback). An
+  // unparseable range still surfaces as info (the coupling IS declared), just with
+  // installed unresolved — never a throw, never a warn.
+  const installed =
+    semver.validRange(declaredRange) !== null
+      ? resolveInstalledVersion(ctx.cwd, pkg, declaredRange)
+      : undefined;
+  const installedText =
+    installed !== undefined ? `installed ${installed}` : 'installed: unresolved';
+
+  return {
+    status: 'info',
+    message: `${pkg} coupling tracked — declared ${declaredRange}, ${installedText}; no cohort floor (Tenet 16, attest only). ${attestedSuffix}`,
+  };
+}
+
 // ─── Mechanical content-equality detector (mmnto-ai/totem#2073) ──
 
 /**


### PR DESCRIPTION
## What

Completes the **detection layer** of `totem doctor --parity` (#2073) by replacing the manual-attestation `stub` with a real `detectManualAttestationContract` — the claim-class with **no mechanical sensor**.

Refs #2073 (the tracking issue; the **publish** — a later, separate slice — closes it).

## The claim-class ceiling (the load-bearing invariant)

The verdict is **`info` or `skip` ONLY — never `pass`/`warn`/`fail`/`unknown`.** A manual-attestation contract has no canonical to prove against, so the doctor may **surface** and **flag**, never **assert**. This is the manifest's "surfaces last-attested + flags staleness only, **never fails**" contract — claim-class-tighter than the mechanical/version-pinned detectors (which may `warn`). Because `info` never enters `blockingDriftIds`, these contracts are **structurally incapable of failing even under `--strict`**.

## Two sub-classes (discriminated by the contract's `package:`)

- **Doctrine rows** (`governance-doctrine`, `agent-memory-doctrine`) — no `package`; `canonical-source` is a cross-repo `totem-strategy:AGENTS.md` the **local-read-only** doctor must not fetch. → a pure `info` doctrine-currency surface with **zero on-disk I/O**. Transient: graduates to `version-pinned` when doctrine-distribution ships (strategy#511 / #526).
- **Vendor-SDK couplings** (`@google/genai`, `@anthropic-ai/sdk`) — `package` set, so the doctor reads the consumer's **local pin** (declared range + resolved installed version, reusing the version-pinned `package.json` machinery) **minus the floor compare**. No agreed cohort floor → no currency claim (Tenet 16, attest-don't-enforce). The durable manual-attestation case.

## Design notes

- **`attested?` seam reserved** for the staleness follow-on: the manifest has no `last-attested:` field yet (strategy owns that — a separate manifest PR). Until then the surface reads "last attested: not recorded"; a future date refines the **message**, never the status. No fabricated dates (Tenet 19).
- **Single source of truth:** the sub-class discriminant (`package:`) + canonical source are read directly off the `contract` arg; the context carries only consumer-local read seams.
- **No `warn` on applicable-but-missing** — unlike the version-pinned detector, a declared-elsewhere vendor SDK absent here is honest-absent `skip` (vendor spread is permitted), never drift.

## Testing

Detection logic proven by **fixtures, not the live cohort** (the doctor `--parity` still `SKIP`s here — no `parity-manifest.yaml` configured; that manifest is strategy's lane).

- Core: a `detectManualAttestationContract` block incl. the **claim-class-ceiling keystone** (every input shape → only `info`/`skip`), the doctrine-row **zero-I/O proof** (a throwing read seam is never called), consumers-scope parity, and the `attested` forward-compat case.
- CLI: a manual-attestation wiring block (both sub-classes routed off the stub; scoped-out → `skip`; a `blocking:true` contract never enters `blockingDriftIds`).
- Full suites green: **core 2151/2151, cli 2380/2380**. `totem lint` PASS (0 errors), `format:check` PASS, `totem review` PASS (no findings).

## Not in scope

The orientation fast-follow (whole-file `.claude`/`.gemini` SessionStart, reuses the #2079 primitive) and the **changeset + publish** that closes #2073 — both later, separate slices. No changeset here: ships unpublished, like the skills (#2078) / hooks (#2079) slices.
