### PR TITLE
docs(readme): drop demoted "coordinate work" clause; lead query/enforce/derive (strategy#531)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ When using LLMs on projects, I found that agents kept making the same architectu
 
 They can make the wrong way look brilliant (until you realize what happened). They'll rarely ask: _"doesn't a shared helper already exist for this?"_
 
-Totem is what I extracted to solve that friction. It's a file-based toolkit. The lint engine, substrate, and knowledge index are deterministic; the compiler and review commands are LLM-powered. Agents read from and write to a substrate of plain markdown lessons, a queryable knowledge index, compiled lint rules, and CLI primitives in order to coordinate work. The structural pieces (the substrate, the index, the compiled-rule lint engine) ship today. The discipline and telemetry layers (whether agents consistently query the index, whether compliance gets measured end-to-end) are in active development; see [What Works and What Doesn't](#what-works-and-what-doesnt) for the honest split.
+Totem is what I extracted to solve that friction. It's a file-based toolkit. The lint engine, substrate, and knowledge index are deterministic; the compiler and review commands are LLM-powered. Agents read from and write to a substrate of plain markdown lessons, a queryable knowledge index, compiled lint rules, and CLI primitives — so context stays queryable, rules stay enforceable, and state stays derivable. The structural pieces (the substrate, the index, the compiled-rule lint engine) ship today. The discipline and telemetry layers (whether agents consistently query the index, whether compliance gets measured end-to-end) are in active development; see [What Works and What Doesn't](#what-works-and-what-doesnt) for the honest split.
 
 ---
 


### PR DESCRIPTION
## What

Fixes the residual **"coordinate work"** clause in the README opener — the cohort framing Proposal 294 (D1/D3) demoted from the public lede — and reframes it to the single-vendor **query / enforce / derive** triplet.

Tagline slice of `mmnto-ai/totem-strategy#531` (public-facing repositioning). Handoff: strategy-claude `2026-06-04T2132Z`.

## Changes

- **README opener:** `…CLI primitives in order to coordinate work.` → `…CLI primitives — so context stays queryable, rules stay enforceable, and state stays derivable.`
- **GH repo description** (set alongside this PR): the canonical line — `Deterministic, file-anchored toolkit for AI-agent work — context you can query, rules you can enforce, state you can derive.`

## Kept / guardrails (Tenet 19)

- **Goldfish hero voice** untouched — satur8d's voice north-star (294 §7); the canonical line is the disciplined sub-line/description, not the hero.
- "enforceable" = the compiled lint rules already in the list (deterministic rules / lint / hooks only); no "memory/remembers"; all three legs retained (not over-corrected to "a linter + an index").

## Not in scope

The rest of the README Phase-1 honesty pass (the four codex-audited edits) stays queued on satur8d's go.
