### PR TITLE
feat(cli): totem doctor --parity session-start-orientation — whole-file SessionStart drift + completing slice (#2073)

### DIFF
--- a/.changeset/doctor-parity-complete.md
+++ b/.changeset/doctor-parity-complete.md
@@ -1,0 +1,12 @@
+---
+'@mmnto/totem': patch
+'@mmnto/cli': patch
+---
+
+`totem doctor --parity` now senses drift across all three tractability classes (the completing slice of the doctor --parity sensor, totem-strategy#448).
+
+- **mechanical content-equality** — managed-block skills (`.claude/skills/*/SKILL.md`), the four per-repo-regenerated git hooks (`.git/hooks/*`, catching stale-version drift), and the static whole-file SessionStart hooks (`.claude/hooks/SessionStart.cjs` + `.gemini/hooks/SessionStart.js`).
+- **version-pinned** — `@mmnto/*` cohort-floor pin-currency for the dependency contracts.
+- **manual-attestation** — the no-mechanical-sensor class (doctrine-currency rows + vendor-SDK couplings) surfaced as `info`/`skip` only, never failing.
+
+All detection is strictly local-read-only — no network, no cross-repo fetch. Verdicts split `pass`/`warn`/`info`/`unknown`/`skip`, and only a `blocking` drift gates under `--strict`.

--- a/packages/cli/src/commands/doctor-parity.test.ts
+++ b/packages/cli/src/commands/doctor-parity.test.ts
@@ -22,7 +22,13 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { cleanTmpDir } from '../test-utils.js';
 import { checkParity, doctorParityCliCommand } from './doctor-parity.js';
-import { DISTRIBUTED_CLAUDE_SKILLS, SKILL_MARKER_START } from './init-templates.js';
+import {
+  CLAUDE_SESSION_START,
+  DISTRIBUTED_CLAUDE_SKILLS,
+  GEMINI_SESSION_START,
+  SESSION_START_MARKER,
+  SKILL_MARKER_START,
+} from './init-templates.js';
 import {
   buildHookContent,
   buildPostCheckoutHookContent,
@@ -177,18 +183,27 @@ describe('checkParity — success', () => {
     writeManifest('doctrine/parity-manifest.yaml', VALID_MANIFEST_YAML);
 
     const { results } = await checkParity(tmpDir);
-    // 1 summary + 4 per-contract lines.
-    expect(results).toHaveLength(5);
+    // 1 summary + 5 per-contract lines: session-start-orientation is now WIRED and
+    // expands to TWO artifacts (claude + gemini) — no longer a stub — plus the three
+    // single-line contracts (mmnto-cli-version, mcp-corpus-indexing, gate-config).
+    expect(results).toHaveLength(6);
 
     const summary = results[0]!;
     expect(summary.status).toBe('pass');
     expect(summary.message).toContain('4 contract(s) loaded');
 
     const perContract = results.slice(1);
-    // The mechanical contracts keep the skip stub.
-    const orientation = perContract.find((r) => r.name === 'Parity: session-start-orientation')!;
-    expect(orientation.status).toBe('skip');
-    expect(orientation.message).toContain('mechanical');
+    // session-start-orientation is wired to the two whole-file SessionStart hooks;
+    // neither is installed here, so both are skip (cohort permits absence), NOT the
+    // old "not yet implemented" stub.
+    const orientationLines = perContract.filter((r) =>
+      r.name.startsWith('Parity: session-start-orientation'),
+    );
+    expect(orientationLines).toHaveLength(2);
+    for (const line of orientationLines) {
+      expect(line.status).toBe('skip');
+      expect(line.message).not.toContain('not yet implemented');
+    }
     // The version-pinned deps contract (mmnto-cli-version) now runs the
     // detector — with no consumer pin declared here it lands on a `skip`
     // (cohort permits absence), NOT the old "not yet implemented" stub.
@@ -671,5 +686,74 @@ describe('checkParity — manual-attestation wiring', () => {
     await expect(
       doctorParityCliCommand({ strict: true, cwdForTest: tmpDir }),
     ).resolves.toBeUndefined();
+  });
+});
+
+// ─── session-start-orientation detection wiring (mmnto-ai/totem#2073 orientation slice) ──
+
+/** A manifest with the single session-start-orientation mechanical contract. */
+const SESSION_START_MANIFEST_YAML = `schema-version: 1
+status: scaffold
+contracts:
+  - id: session-start-orientation
+    dimension: orientation
+    canonical-source: mmnto-ai/totem:packages/cli/src/commands/init-templates.ts#SessionStart
+    detection-method: SessionStart hook present and invokes totem orient --session
+    expected-value-or-derivation: hook matches the distributed template at pinned @mmnto/cli
+    tractability: mechanical
+    tracking-issue: mmnto-ai/totem-strategy#438
+`;
+
+/** Write a repo file at a nested relative path under the temp consumer repo. */
+function writeRepoFile(relPath: string, content: string): void {
+  const abs = path.join(tmpDir, relPath);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content, 'utf-8');
+}
+
+describe('checkParity — session-start-orientation wiring', () => {
+  it('both SessionStart templates open with SESSION_START_MARKER (single-source-of-truth contract)', () => {
+    expect(GEMINI_SESSION_START.startsWith(SESSION_START_MARKER)).toBe(true);
+    expect(CLAUDE_SESSION_START.startsWith(SESSION_START_MARKER)).toBe(true);
+  });
+
+  it('routes to two lines (claude + gemini); a verbatim gemini hook → pass, absent claude → skip', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', SESSION_START_MANIFEST_YAML);
+    // Gemini hook installed verbatim → pass; Claude hook absent here → skip.
+    writeRepoFile('.gemini/hooks/SessionStart.js', GEMINI_SESSION_START);
+
+    const { results } = await checkParity(tmpDir);
+    const perContract = results.slice(1);
+    expect(perContract).toHaveLength(2);
+
+    const gemini = perContract.find(
+      (r) => r.name === 'Parity: session-start-orientation (gemini)',
+    )!;
+    expect(gemini.status).toBe('pass');
+    const claude = perContract.find(
+      (r) => r.name === 'Parity: session-start-orientation (claude)',
+    )!;
+    expect(claude.status).toBe('skip');
+    expect(perContract.every((r) => !r.message.includes('not yet implemented'))).toBe(true);
+  });
+
+  it('a drifted owned gemini SessionStart → warn (NOT unknown); blocking promotes to a --strict throw', async () => {
+    const blocking = SESSION_START_MANIFEST_YAML.replace(
+      'tracking-issue: mmnto-ai/totem-strategy#438\n',
+      'tracking-issue: mmnto-ai/totem-strategy#438\n    blocking: true\n',
+    );
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', blocking);
+    // Still owned (the marker opens the file), but the body drifted → warn, not unknown.
+    writeRepoFile('.gemini/hooks/SessionStart.js', `${GEMINI_SESSION_START}\n// local drift\n`);
+
+    const { results, blockingDriftIds } = await checkParity(tmpDir);
+    const gemini = results.find((r) => r.name === 'Parity: session-start-orientation (gemini)')!;
+    expect(gemini.status).toBe('warn');
+    expect(gemini.status).not.toBe('unknown');
+    expect(blockingDriftIds).toContain('session-start-orientation');
+
+    await expect(doctorParityCliCommand({ strict: true, cwdForTest: tmpDir })).rejects.toThrow();
   });
 });

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -1,24 +1,28 @@
 /**
  * Parity-drift sensor for `totem doctor --parity` (mmnto-ai/totem-strategy#448).
  *
- * Two detection slices are wired here:
+ * Detection is wired across all three tractability classes (mmnto-ai/totem#2073):
  *   - **version-pinned** (PR-1, mmnto-ai/totem#2069): each deps contract whose id
  *     resolves an `@mmnto/*` package name runs through the core
  *     `detectVersionPinnedContract` engine (pin-currency verdict, local-only floor).
- *   - **mechanical content-equality** (mmnto-ai/totem#2073 skills slice): each
- *     managed-block contract this slice handles (`claude-skills`,
- *     `review-reply-skill-content`) compares the consumer's installed
- *     `.claude/skills/<name>/SKILL.md` managed-block against the running
- *     `@mmnto/cli`'s OWN canonical template (the in-process `init-templates`
- *     export — local-read-only, no node_modules reach-in), via the core
- *     `detectMechanicalContract` engine (CRLF/LF-normalized content-hash + a
- *     fork-marker → `info` escape + an `unknown` Stale-Doctor-Paradox guard).
+ *   - **mechanical content-equality** (mmnto-ai/totem#2073): three artifact shapes,
+ *     all local-read-only against the running `@mmnto/cli`'s OWN in-process template:
+ *       · **skills** (`claude-skills`): managed-block equality of
+ *         `.claude/skills/<name>/SKILL.md` via `detectMechanicalContract`.
+ *       · **git-hooks**: per-repo REGENERATED whole-file/region equality of the four
+ *         `.git/hooks/*` (package-manager + tier parameterized) via
+ *         `detectGeneratedArtifactContract` — catches stale-version drift (#1854).
+ *       · **session-start-orientation**: STATIC whole-file equality of the
+ *         `.claude/hooks/SessionStart.cjs` + `.gemini/hooks/SessionStart.js` templates,
+ *         also via `detectGeneratedArtifactContract` (no parameterization).
+ *   - **manual-attestation** (mmnto-ai/totem#2080): the no-mechanical-sensor class —
+ *     `detectManualAttestationContract` surfaces the doctrine-currency row / vendor-SDK
+ *     pin as `info` (or honest-absent `skip`), NEVER pass/warn/fail (the "never fails"
+ *     contract; structurally cannot gate under `--strict`).
  *
- * ALL other contracts — the parameterized hook contracts (`git-hooks`,
- * `session-start-orientation`), the file-value-equality bot-configs, the
- * structural-presence dimensions, and every `manual-attestation` contract —
- * keep the `skip` "not yet implemented" stub; their detection is a follow-on
- * slice (the #2073 tail).
+ * The remaining contracts — the file-value-equality bot-configs (`cr-profile` etc.)
+ * and the structural-presence dimensions — keep the `skip` "not yet implemented" stub;
+ * their detection is a follow-on.
  *
  * The parity sensor owns its OWN render + result type (`ParityLine`) carrying a
  * WIDER status vocabulary (pass/warn/fail/info/unknown/skip) than the shared
@@ -215,6 +219,50 @@ function gitHookArtifactsFor(
   ];
 }
 
+// ─── SessionStart hook artifact registry (CLI-side, mmnto-ai/totem#2073 orientation slice) ──
+
+/**
+ * The running `@mmnto/cli`'s own whole-file SessionStart hook templates, dynamic-
+ * imported by the caller from `init-templates` (kept off the cold-start graph) and
+ * threaded in so the registry stays a pure function. Unlike the git hooks these are
+ * STATIC — no package-manager / tier parameterization — so the canonical is the
+ * verbatim template string. Both vendor templates open with the same `marker`.
+ */
+interface SessionStartTemplateSource {
+  claude: string;
+  gemini: string;
+  marker: string;
+}
+
+/**
+ * Resolve the two whole-file SessionStart hook artifacts the `session-start-orientation`
+ * contract checks: `.claude/hooks/SessionStart.cjs` (canonical `CLAUDE_SESSION_START`)
+ * and `.gemini/hooks/SessionStart.js` (canonical `GEMINI_SESSION_START`). Whole-file
+ * static canonical, no end marker, no regeneration. A vendor file absent here is
+ * honest-absent `skip` (cohort permits absence) via the detector's presence semantics;
+ * a present file whose marker opens it but whose body drifted is `warn` (the orientation
+ * slice generalized `isOwnedGeneratedFile` to treat a marker-at-start JS file as owned).
+ */
+function sessionStartArtifactsFor(
+  gitRoot: string,
+  templates: SessionStartTemplateSource,
+): GeneratedArtifact[] {
+  return [
+    {
+      consumerPath: path.join(gitRoot, '.claude', 'hooks', 'SessionStart.cjs'),
+      canonicalContent: templates.claude,
+      ownershipMarker: templates.marker,
+      lineName: 'Parity: session-start-orientation (claude)',
+    },
+    {
+      consumerPath: path.join(gitRoot, '.gemini', 'hooks', 'SessionStart.js'),
+      canonicalContent: templates.gemini,
+      ownershipMarker: templates.marker,
+      lineName: 'Parity: session-start-orientation (gemini)',
+    },
+  ];
+}
+
 /**
  * Resolve the running `@mmnto/cli`'s version + install path for the req-#5
  * binary self-report (the Stale-Doctor-Paradox guard — surface WHICH binary
@@ -361,11 +409,21 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
         REVIEW_REPLY_SKILL_CONTENT,
         SKILL_MARKER_START,
         SKILL_MARKER_END,
+        CLAUDE_SESSION_START,
+        GEMINI_SESSION_START,
+        SESSION_START_MARKER,
       } = await import('./init-templates.js');
       const skillTemplates: SkillTemplateSource = {
         distributedSkills: DISTRIBUTED_CLAUDE_SKILLS,
         reviewReplyContent: REVIEW_REPLY_SKILL_CONTENT,
         markers: { start: SKILL_MARKER_START, end: SKILL_MARKER_END },
+      };
+      // The running CLI's own whole-file SessionStart hook templates (static — no
+      // parameterization), lazy-loaded on the ok path only (mmnto-ai/totem#2073 orientation slice).
+      const sessionStartTemplates: SessionStartTemplateSource = {
+        claude: CLAUDE_SESSION_START,
+        gemini: GEMINI_SESSION_START,
+        marker: SESSION_START_MARKER,
       };
 
       // The running CLI's own hook generators + markers + package-manager probe,
@@ -451,15 +509,22 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
             }
           }
 
-          // git hooks: regenerate the canonical per-repo (package manager + tier) via
-          // the running generator and content-compare — catches stale-version drift
-          // (the detection half of mmnto-ai/totem#1854) without a frozen-string false-positive.
+          // Generated-artifact contracts (whole-file / region content-equality): the git
+          // hooks (regenerated per-repo for this package manager + tier — catches the
+          // stale-version drift half of mmnto-ai/totem#1854) and the static whole-file
+          // SessionStart hooks (orientation slice). Both resolve a GeneratedArtifact[] and
+          // run the same presence-aware detector + once-per-contract blocking tag.
+          let generatedArtifacts: GeneratedArtifact[] | undefined;
           if (c.id === 'git-hooks') {
-            const artifacts = gitHookArtifactsFor(gitRoot, hookTier, fallbackCmd, hookBuilders);
-            // A drift on any hook tags the contract id at most ONCE so the --strict
+            generatedArtifacts = gitHookArtifactsFor(gitRoot, hookTier, fallbackCmd, hookBuilders);
+          } else if (c.id === 'session-start-orientation') {
+            generatedArtifacts = sessionStartArtifactsFor(gitRoot, sessionStartTemplates);
+          }
+          if (generatedArtifacts !== undefined) {
+            // A drift on any artifact tags the contract id at most ONCE so the --strict
             // count reflects contracts, not artifacts (mirrors the skills branch).
             let blockingDrift = false;
-            const lines = artifacts.map((a) => {
+            const lines = generatedArtifacts.map((a) => {
               const verdict = detectGeneratedArtifactContract({
                 canonicalContent: a.canonicalContent,
                 consumerPath: a.consumerPath,

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -515,10 +515,20 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
           // SessionStart hooks (orientation slice). Both resolve a GeneratedArtifact[] and
           // run the same presence-aware detector + once-per-contract blocking tag.
           let generatedArtifacts: GeneratedArtifact[] | undefined;
+          // Artifact-class copy threaded into the detector so the absence/drift
+          // remediation names the RIGHT installer per class (Greptile review on
+          // mmnto-ai/totem#2082): git hooks → `totem hook install`; the static
+          // SessionStart hooks → `totem init`.
+          let artifactLabel = 'artifact';
+          let installCommand = 'totem init';
           if (c.id === 'git-hooks') {
             generatedArtifacts = gitHookArtifactsFor(gitRoot, hookTier, fallbackCmd, hookBuilders);
+            artifactLabel = 'git hook';
+            installCommand = 'totem hook install';
           } else if (c.id === 'session-start-orientation') {
             generatedArtifacts = sessionStartArtifactsFor(gitRoot, sessionStartTemplates);
+            artifactLabel = 'SessionStart hook';
+            installCommand = 'totem init';
           }
           if (generatedArtifacts !== undefined) {
             // A drift on any artifact tags the contract id at most ONCE so the --strict
@@ -529,6 +539,8 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
                 canonicalContent: a.canonicalContent,
                 consumerPath: a.consumerPath,
                 ownershipMarker: a.ownershipMarker,
+                artifactLabel,
+                installCommand,
                 ...(a.endMarker !== undefined ? { endMarker: a.endMarker } : {}),
                 ...(binary !== undefined ? { binary } : {}),
               });

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -81,6 +81,15 @@ export const BARE_REF_REGEX_SOURCE = '(?<!\\b[\\w-]+/[\\w-]+)#(\\d+)(?![-\\w])';
 
 // --- Gemini CLI hook templates ---
 
+/**
+ * The ownership/presence marker that opens BOTH whole-file SessionStart hook
+ * templates (`GEMINI_SESSION_START` + `CLAUDE_SESSION_START`). The
+ * `totem doctor --parity` orientation slice (mmnto-ai/totem#2073) keys
+ * presence-detection + owned-file classification on this marker; a test asserts
+ * both templates start with it, so the constant stays the single source of truth.
+ */
+export const SESSION_START_MARKER = '// [totem] auto-generated';
+
 export const GEMINI_SESSION_START = `// [totem] auto-generated — Gemini CLI SessionStart hook
 // Runs \`totem describe\` at the start of every Gemini CLI session to emit
 // the project-orientation banner ("[Describe] Project: ... Lessons: N

--- a/packages/core/src/parity-detect.test.ts
+++ b/packages/core/src/parity-detect.test.ts
@@ -812,6 +812,75 @@ describe('detectGeneratedArtifactContract', () => {
     expect(v.status).not.toBe('warn');
     expect(v.message).toMatch(/canonical hook region|unprovable/i);
   });
+
+  // ── whole-file JS SessionStart hooks (mmnto-ai/totem#2073 orientation slice) ──
+  // The `// [totem] auto-generated` marker OPENS the file (no shell shebang), so
+  // isOwnedGeneratedFile must treat it as OWNED — a drifted JS hook is `warn`, not
+  // `unknown`. This exercises the generalization the orientation slice adds.
+  const SESSION_MARKER = '// [totem] auto-generated';
+  function ownedSessionStart(body: string): string {
+    return `${SESSION_MARKER} — SessionStart hook\nconst { execSync } = require('child_process');\n${body}\n`;
+  }
+
+  it('pass — owned whole-file JS SessionStart equals canonical (marker opens the file, no shebang)', () => {
+    const consumerPath = writeArtifact(
+      '.claude/hooks/SessionStart.cjs',
+      ownedSessionStart('run();'),
+    );
+    const v = detectGeneratedArtifactContract(
+      genCtx({
+        consumerPath,
+        canonicalContent: ownedSessionStart('run();'),
+        ownershipMarker: SESSION_MARKER,
+      }),
+    );
+    expect(v.status).toBe('pass');
+  });
+
+  it('warn — a drifted owned JS SessionStart is drift, NOT unknown (the orientation-slice keystone)', () => {
+    const consumerPath = writeArtifact(
+      '.gemini/hooks/SessionStart.js',
+      ownedSessionStart('runOld();'),
+    );
+    const v = detectGeneratedArtifactContract(
+      genCtx({
+        consumerPath,
+        canonicalContent: ownedSessionStart('runNew();'),
+        ownershipMarker: SESSION_MARKER,
+      }),
+    );
+    expect(v.status).toBe('warn');
+    expect(v.status).not.toBe('unknown');
+    expect(v.message).toMatch(/drift/i);
+  });
+
+  it('unknown — a JS file with USER content before the marker is appended, not owned (preserved)', () => {
+    const consumerPath = writeArtifact(
+      '.claude/hooks/SessionStart.cjs',
+      `// my own preamble\nconsole.log('user');\n${ownedSessionStart('run();')}`,
+    );
+    const v = detectGeneratedArtifactContract(
+      genCtx({
+        consumerPath,
+        canonicalContent: ownedSessionStart('run();'),
+        ownershipMarker: SESSION_MARKER,
+      }),
+    );
+    expect(v.status).toBe('unknown');
+    expect(v.status).not.toBe('warn');
+  });
+
+  it('skip — a present JS file with no totem marker is a user hook (presence semantics, not drift)', () => {
+    const consumerPath = writeArtifact(
+      '.gemini/hooks/SessionStart.js',
+      `console.log('my own session start');\n`,
+    );
+    const v = detectGeneratedArtifactContract(
+      genCtx({ consumerPath, ownershipMarker: SESSION_MARKER }),
+    );
+    expect(v.status).toBe('skip');
+    expect(v.status).not.toBe('warn');
+  });
 });
 
 // ─── detectManualAttestationContract (mmnto-ai/totem#2073 manual-attestation slice) ──

--- a/packages/core/src/parity-detect.test.ts
+++ b/packages/core/src/parity-detect.test.ts
@@ -881,6 +881,40 @@ describe('detectGeneratedArtifactContract', () => {
     expect(v.status).toBe('skip');
     expect(v.status).not.toBe('warn');
   });
+
+  it('SessionStart absence + drift copy names the artifact + totem init, never the git-hook installer (Greptile #2082)', () => {
+    // Absent → skip copy + remediation must NOT point at the git-hook installer.
+    const absent = detectGeneratedArtifactContract(
+      genCtx({
+        consumerPath: path.join(tmpRoot, '.claude/hooks/SessionStart.cjs'),
+        ownershipMarker: SESSION_MARKER,
+        artifactLabel: 'SessionStart hook',
+        installCommand: 'totem init',
+      }),
+    );
+    expect(absent.status).toBe('skip');
+    expect(absent.message).toContain('SessionStart hook');
+    expect(absent.remediation).toContain('totem init');
+    expect(absent.remediation).not.toMatch(/totem hook install/i);
+
+    // Drifted owned → warn remediation points at totem init, not totem hook install.
+    const consumerPath = writeArtifact(
+      '.gemini/hooks/SessionStart.js',
+      ownedSessionStart('old();'),
+    );
+    const drifted = detectGeneratedArtifactContract(
+      genCtx({
+        consumerPath,
+        canonicalContent: ownedSessionStart('new();'),
+        ownershipMarker: SESSION_MARKER,
+        artifactLabel: 'SessionStart hook',
+        installCommand: 'totem init',
+      }),
+    );
+    expect(drifted.status).toBe('warn');
+    expect(drifted.remediation).toContain('totem init');
+    expect(drifted.remediation).not.toMatch(/totem hook install/i);
+  });
 });
 
 // ─── detectManualAttestationContract (mmnto-ai/totem#2073 manual-attestation slice) ──

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -1009,16 +1009,26 @@ function extractInclusiveRegion(content: string, start: string, end: string): st
 }
 
 /**
- * Whether a hook is a totem-OWNED whole file (generated verbatim by `build*Hook`)
- * rather than a totem block APPENDED into a pre-existing user hook. A generated
- * hook is `#!/bin/sh\n# <marker> …`, so the only content before the marker is the
- * shebang line plus the start of its comment; an appended hook carries the user's
- * prior hook content there.
+ * Whether a file is a totem-OWNED whole file (generated verbatim by a `build*`
+ * template) rather than a totem block APPENDED into a pre-existing user file. Two
+ * generated shapes are owned:
+ *   - **whole-file marker-at-start** — the ownership marker OPENS the file, so
+ *     nothing meaningful precedes it. The JS SessionStart hooks (`// [totem]
+ *     auto-generated …` at index 0, no shebang — mmnto-ai/totem#2073 orientation
+ *     slice) are this shape.
+ *   - **shell shebang + comment** — a shell hook generated as `#!/bin/sh\n#
+ *     <marker> …`, so the only content before the marker is the shebang line plus
+ *     the start of its comment (the git-hooks slice).
+ * An APPENDED block carries the user's prior content before the marker → NOT owned
+ * (the detector degrades it to `unknown`, claim-class-tight).
  */
 function isOwnedGeneratedFile(content: string, marker: string): boolean {
   const idx = content.indexOf(marker);
   if (idx === -1) return false;
-  return /^#![^\n]*\n#[ \t]*$/.test(content.slice(0, idx));
+  const before = content.slice(0, idx);
+  // Marker opens the file (whole-file JS templates), OR only a shebang + comment-
+  // start precedes it (shell hooks). User content before the marker → appended.
+  return before.trim().length === 0 || /^#![^\n]*\n#[ \t]*$/.test(before);
 }
 
 /**

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -990,6 +990,19 @@ export interface DetectGeneratedArtifactContext {
    * canonical-generator resolution; the detector just reports the resolved binary.
    */
   binary?: { version: string; path: string };
+  /**
+   * Human-facing noun for this artifact class in the absence/drift copy (e.g.
+   * `'git hook'`, `'SessionStart hook'`). Defaults to `'artifact'`. Threaded so the
+   * detector — now shared across git hooks AND the static SessionStart hooks — never
+   * hardcodes one class's terminology (Greptile review on mmnto-ai/totem#2082).
+   */
+  artifactLabel?: string;
+  /**
+   * The install/repair command the remediation points at — `'totem hook install'` for
+   * git hooks, `'totem init'` for SessionStart hooks. Defaults to `'totem init'` so a
+   * SessionStart absence/drift is never told to run the git-hook installer.
+   */
+  installCommand?: string;
   /** Test seam — override the consumer file read. Production callers omit it. */
   readFile?: (absPath: string) => string | undefined;
 }
@@ -1061,12 +1074,19 @@ export function detectGeneratedArtifactContract(
   // the provenance suffix never reads as a jammed token in a message.
   const tag = (msg: string): string => msg + provenance;
 
-  // ── Canonical unregenerable → unknown (Stale-Doctor-Paradox guard) ──
+  // Artifact-class copy (Greptile review on mmnto-ai/totem#2082): this detector serves
+  // both git hooks and the static SessionStart hooks, so the noun + install command are
+  // threaded in rather than hardcoded. Defaults keep standalone callers SessionStart-safe
+  // (never "run totem hook install" for a non-git artifact).
+  const label = ctx.artifactLabel ?? 'artifact';
+  const install = ctx.installCommand ?? 'totem init';
+
+  // ── Canonical unresolvable → unknown (Stale-Doctor-Paradox guard) ──
   if (ctx.canonicalContent === undefined) {
     return {
       status: 'unknown',
       message: tag(
-        'cannot regenerate canonical hook from the running @mmnto/cli — verdict unprovable',
+        `cannot resolve canonical ${label} from the running @mmnto/cli — verdict unprovable`,
       ),
       remediation:
         'Reinstall @mmnto/cli (the running binary may be stale or shadowed), then re-run totem doctor --parity.',
@@ -1080,9 +1100,8 @@ export function detectGeneratedArtifactContract(
   if (consumerContent === undefined) {
     return {
       status: 'skip',
-      message: `git hook not installed at ${ctx.consumerPath} — cohort permits absence`,
-      remediation:
-        'Run totem hook install to install the managed git hooks, or ignore if this repo intentionally omits them.',
+      message: `${label} not installed at ${ctx.consumerPath} — cohort permits absence`,
+      remediation: `Run ${install} to install the managed ${label}, or ignore if this repo intentionally omits it.`,
     };
   }
 
@@ -1120,7 +1139,7 @@ export function detectGeneratedArtifactContract(
       return {
         status: 'unknown',
         message: tag(
-          'cannot resolve the canonical hook region (end marker absent in the regenerated template) — verdict unprovable',
+          `cannot resolve the canonical ${label} region (end marker absent in the regenerated template) — verdict unprovable`,
         ),
         remediation:
           'Reinstall @mmnto/cli (the running binary may be stale or shadowed), then re-run totem doctor --parity.',
@@ -1159,8 +1178,7 @@ export function detectGeneratedArtifactContract(
         message: tag(
           `drift — totem block ${hashManagedBlock(consumerRegionNorm)} != canonical ${hashManagedBlock(canonicalRegionNorm)}`,
         ),
-        remediation:
-          'Re-run totem hook install to regenerate the managed block, or add a totem:fork marker if the divergence is intentional.',
+        remediation: `Re-run ${install} to regenerate the managed block, or add a totem:fork marker if the divergence is intentional.`,
       };
     }
     // Consumer has the start marker but not the end (truncated / stripped) → fall through
@@ -1184,28 +1202,26 @@ export function detectGeneratedArtifactContract(
       message: tag(
         `drift — consumer ${hashManagedBlock(consumerNorm)} != canonical ${hashManagedBlock(canonicalNorm)}`,
       ),
-      remediation:
-        'Re-run totem hook install to regenerate the hook from the current @mmnto/cli, or add a totem:fork marker if the divergence is intentional.',
+      remediation: `Re-run ${install} to regenerate the ${label} from the current @mmnto/cli, or add a totem:fork marker if the divergence is intentional.`,
     };
   }
 
-  // ── Totem block appended inside a user-modified hook with no end marker to ──
+  // ── Totem block appended inside a user-modified artifact with no end marker to ──
   // isolate it: can prove neither drift nor currency → unknown (claim-class-tight).
   if (fork !== undefined) {
     return {
       status: 'info',
       message: tag(
-        `intentional fork${formatForkMeta(fork)} — totem block embedded in a user-modified hook (${ctx.consumerPath})`,
+        `intentional fork${formatForkMeta(fork)} — totem block embedded in a user-modified ${label} (${ctx.consumerPath})`,
       ),
     };
   }
   return {
     status: 'unknown',
     message: tag(
-      `totem block embedded in a user-modified hook at ${ctx.consumerPath} — cannot isolate it for comparison`,
+      `totem block embedded in a user-modified ${label} at ${ctx.consumerPath} — cannot isolate it for comparison`,
     ),
-    remediation:
-      'Re-run totem hook install (or adopt a hook manager) so the managed block can be verified independently.',
+    remediation: `Re-run ${install} to restore the managed ${label}, or remove the local edits before the totem marker so it can be verified independently.`,
   };
 }
 


### PR DESCRIPTION
## What

The **completing slice** of `totem doctor --parity` (totem-strategy#448). Wires the `session-start-orientation` mechanical contract — whole-file SessionStart hook drift — and carries the changeset that ships the full sensor.

Closes #2073.

## Changes

- **Core (keystone):** generalize `isOwnedGeneratedFile` — *"owned when nothing meaningful precedes the marker"* — so a marker-at-start JS template (the SessionStart hooks have no shell shebang) reads as **owned**: a drifted SessionStart is `warn`, not `unknown`. Preserves the shell-shebang and appended-block cases verbatim.
- **CLI:** `sessionStartArtifactsFor` → 2 descriptors (`.claude/hooks/SessionStart.cjs` ← `CLAUDE_SESSION_START`, `.gemini/hooks/SessionStart.js` ← `GEMINI_SESSION_START`), wired into the mechanical branch and **unified** with the git-hooks arm (both resolve `GeneratedArtifact[]` → one detector loop). Reuses `detectGeneratedArtifactContract` on a **static** (unparameterized) canonical — simpler than git-hooks (no `fallbackCmd`/tier).
- **Single source of truth:** export `SESSION_START_MARKER` from `init-templates`; a test asserts both templates open with it.
- **Doc:** corrected the stale `doctor-parity.ts` module header to list all wired slices (it predated the hooks + manual-attestation merges).
- **Changeset (patch):** the cohort `fixed` group → 1.53.5 → 1.53.6; the changelog describes the whole `doctor --parity` capability (the prior slices merged changeset-less).

## Publish coupling

Per strategy's "one publishable cut": this PR carries the completing changeset, so **merging it is the publish-go** — the changesets Version Packages PR cuts 1.53.6 shipping orientation **+ the 3 prior unpublished slices** (skills #2078, hooks #2079, manual-attestation #2080), and closes #2073. No license payload (Apache-2.0 already on `@latest`).

## Testing

Fixtures, not the live cohort. Core: the `isOwnedGeneratedFile` generalization (JS-owned → warn-not-unknown keystone + shell/appended preserved). CLI: routing to 2 lines, verbatim → `pass`, absent → `skip`, drifted-owned → `warn` + `--strict` throw, single-source-of-truth marker assertion. Full suites: **core 2155/2155, cli 2383/2383**; `totem lint` 0 errors, `format:check`, `totem review` clean.

## Scope-out

The `.claude/settings.json` hook **registration** (`CLAUDE_SESSION_START_ENTRY`) is a structural-presence sub-class — deferred; this slice checks the hook **file** content-equality.
