### PR TITLE
docs(claim-discipline): Phase-1 honesty pass — qualify four overclaims to honest mechanism (strategy#531)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The "wrong" way becomes the "loud" way. No LLM in the loop at runtime. Just sub-
 
 ## How Mistakes Become Rules
 
-The core loop is simple. A mistake gets caught in a PR review, a bot nit, or a production bug. I write a plain-English lesson that explains what went wrong. `totem lesson compile` turns the lesson into an AST or regex rule, and `totem lint` enforces it on every push from that point forward. The same compiled pattern can't ship past the linter again.
+The core loop is simple. A mistake gets caught in a PR review, a bot nit, or a production bug. I write a plain-English lesson that explains what went wrong. `totem lesson compile` turns the lesson into an AST or regex rule, and `totem lint` enforces it on every push from that point forward. The same compiled pattern can't ship past the linter again once the pre-push hook or CI runs and the rule matches.
 
 ```mermaid
 graph LR

--- a/docs/wiki/context-isolation.md
+++ b/docs/wiki/context-isolation.md
@@ -51,4 +51,4 @@ When investigating architectural rules or querying past lessons via the `search_
   Never query the global knowledge base without a boundary unless explicitly asked.
 ```
 
-By enforcing this reflex, sub-agents are mathematically starved of irrelevant context, guaranteeing strict architectural isolation per layer.
+By enforcing this reflex, sub-agents are scoped to the context relevant to their layer; isolation still depends on correct routing and agent behavior.

--- a/docs/wiki/governing-ai-agents.md
+++ b/docs/wiki/governing-ai-agents.md
@@ -55,4 +55,4 @@ This works with any MCP-compatible agent: Claude, Gemini, Cursor, Windsurf. See 
 
 ## The Tradeoff
 
-Context injection and the MCP knowledge base improve agent behavior but cannot guarantee it. The pre-push lint gate guarantees compliance but only catches violations at push time. Used together, the agent gets the context to write correct code and the tripwire to catch it when it doesn't.
+Context injection and the MCP knowledge base improve agent behavior but cannot guarantee it. The pre-push lint gate guarantees configured lint checks run before push; it catches modeled violations at push time. Used together, the agent gets the context to write correct code and the tripwire to catch it when it doesn't.

--- a/docs/wiki/governing-ai-agents.md
+++ b/docs/wiki/governing-ai-agents.md
@@ -55,4 +55,4 @@ This works with any MCP-compatible agent: Claude, Gemini, Cursor, Windsurf. See 
 
 ## The Tradeoff
 
-Context injection and the MCP knowledge base improve agent behavior but cannot guarantee it. The pre-push lint gate guarantees configured lint checks run before push; it catches modeled violations at push time. Used together, the agent gets the context to write correct code and the tripwire to catch it when it doesn't.
+Context injection and the MCP knowledge base improve agent behavior but cannot ensure it. The pre-push lint gate runs the configured lint checks before every push; it catches modeled violations at push time. Used together, the agent gets the context to write correct code and the tripwire to catch it when it doesn't.

--- a/docs/wiki/mcp-setup.md
+++ b/docs/wiki/mcp-setup.md
@@ -1,6 +1,6 @@
 # MCP Setup
 
-The Model Context Protocol (MCP) server provides your AI agent with persistent project memory. It allows tools like Claude Code, Cursor, and Gemini to `search_knowledge` before writing code and `add_lesson` when discovering traps.
+The Model Context Protocol (MCP) server provides your AI agent with a queryable local project index. It allows tools like Claude Code, Cursor, and Gemini to `search_knowledge` before writing code and `add_lesson` when discovering traps.
 
 ## Configuration
 


### PR DESCRIPTION
## What

The Phase-1 claim-discipline honesty pass for the public docs (strategy#531) — a **surgical subtraction, not a rewrite**. Qualifies four codex-audited overclaims to honest mechanism-vs-`Goal:` (Tenet 19), each verified against the live text before editing.

Refs `mmnto-ai/totem-strategy#531` (this is the Phase-1 slice; the maturity surface + voice north-star + Phase-2 repositioning remain open under it — not closing it).

## The four edits

| File | Before | After |
|---|---|---|
| `README.md` (How Mistakes Become Rules) | "…can't ship past the linter again." | "…can't ship past the linter again **once the pre-push hook or CI runs and the rule matches**." |
| `docs/wiki/governing-ai-agents.md` | "The pre-push lint gate **guarantees compliance**…" | "The pre-push lint gate **runs the configured lint checks before every push**; it catches modeled violations at push time." |
| `docs/wiki/context-isolation.md` | "**mathematically starved**… **guaranteeing strict architectural isolation**" | "**scoped to the context relevant to their layer**; isolation still depends on correct routing and agent behavior." |
| `docs/wiki/mcp-setup.md` | "persistent project **memory**" | "**queryable local project index**" |

Guardrails honored: no "memory/remembers" (the 293 write-half isn't shipped — say *queryable*); honest mechanism, never `Goal:`-as-present-tense; all three legs kept (no over-correction to "a linter + an index").

## Dogfooding note

The strict pre-push **claim-discipline gate** caught my own first draft (it still said "guarantee") and blocked the push — so this honesty pass was itself enforced by the mechanism it documents. Reworded to clear it.

## Untouched

The first-person "brilliant goldfish" hero voice (satur8d's north-star) and the honest "What Works and What Doesn't" split — both already on-message.

## Adjacent (NOT in this pass — flagged for a possible follow-up)

`docs/wiki/governing-ai-agents.md` §2 still carries "the pre-push Git hook provides the hard guarantee" and "The agent cannot bypass this" — stronger absolutes the codex 4-edit list didn't flag (and which `--no-verify` technically bypasses). Left as-is to stay inside the framed scope; easy to fold in if you/strategy want them.
