### PR TITLE
feat(cli): doctor --strict folds in the parity sensor for opted-in repos (#2085)

### DIFF
--- a/.changeset/strict-parity-fold-2085.md
+++ b/.changeset/strict-parity-fold-2085.md
@@ -1,0 +1,7 @@
+---
+'@mmnto/cli': patch
+---
+
+`totem doctor --strict` now exercises the parity sensor when a repo-local `orient.parityManifest` is configured — closing the "green-by-not-checking" gap where consumer CI (which runs `--strict`, not `--parity --strict`) never ran the drift check (mmnto-ai/totem-strategy#545 Half 2).
+
+Zero churn for non-adopters: a repo that hasn't configured a manifest sees byte-identical `--strict` output (the fold is a no-op until you opt in). Per ADR-109 / Tenet 13 the throw-gate stays at the CLI edge, and the standalone `doctor --parity` is unchanged.

--- a/packages/cli/src/commands/doctor-parity.test.ts
+++ b/packages/cli/src/commands/doctor-parity.test.ts
@@ -18,7 +18,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { cleanTmpDir } from '../test-utils.js';
 import { checkParity, doctorParityCliCommand } from './doctor-parity.js';
@@ -755,5 +755,88 @@ describe('checkParity — session-start-orientation wiring', () => {
     expect(blockingDriftIds).toContain('session-start-orientation');
 
     await expect(doctorParityCliCommand({ strict: true, cwdForTest: tmpDir })).rejects.toThrow();
+  });
+});
+
+// ─── S0: --strict parity fold (#2085, mmnto-ai/totem-strategy#545 Half 2) ──
+
+describe('checkParity — configured flag (#2085)', () => {
+  it('configured: false when no orient.parityManifest is set (honest-absent)', async () => {
+    writeConfig(BASE_CONFIG);
+    const { configured } = await checkParity(tmpDir);
+    expect(configured).toBe(false);
+  });
+
+  it('configured: false for a config-less repo (a global profile never leaks in)', async () => {
+    // No totem config at all → resolveConfigPath resolves the GLOBAL profile,
+    // which isGlobalConfigPath excludes — so `configured` stays false and the
+    // strict fold no-ops (a global orient.parityManifest must not leak into the gate).
+    const { configured } = await checkParity(tmpDir);
+    expect(configured).toBe(false);
+  });
+
+  it('configured: true when the field is set even if the manifest file is missing', async () => {
+    // "Configured" means the field is present, NOT that the file loaded — a broken
+    // manifest must still run under --strict to surface the error, not silently no-op.
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: nope.yaml\n`);
+    const { configured } = await checkParity(tmpDir);
+    expect(configured).toBe(true);
+  });
+
+  it('configured: true on a valid configured manifest', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', VALID_MANIFEST_YAML);
+    const { configured } = await checkParity(tmpDir);
+    expect(configured).toBe(true);
+  });
+});
+
+describe('doctorParityCliCommand — onlyWhenConfigured fold (#2085)', () => {
+  it('no-op (renders nothing, no throw) when unconfigured under the fold', async () => {
+    writeConfig(BASE_CONFIG); // no orient.parityManifest
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(
+        doctorParityCliCommand({ strict: true, onlyWhenConfigured: true, cwdForTest: tmpDir }),
+      ).resolves.toBeUndefined();
+      // Byte-identical to a --strict run that never touched parity (satur8d's
+      // zero-churn condition): zero parity lines for a non-adopter repo.
+      expect(errSpy).not.toHaveBeenCalled();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('standalone (no onlyWhenConfigured) STILL renders the honest-absent SKIP', async () => {
+    writeConfig(BASE_CONFIG);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await doctorParityCliCommand({ strict: true, cwdForTest: tmpDir });
+      // onlyWhenConfigured defaults off → the explicit `doctor --parity` SKIP line
+      // is unchanged for the "I asked for parity" case.
+      expect(errSpy).toHaveBeenCalled();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it('runs + gates (throws) under the fold when a configured blocking contract drifts', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', BLOCKING_DEPS_MANIFEST_YAML);
+    writeFloorPackage('totem', '@mmnto/totem', '1.53.3');
+    writeConsumerDeps({ '@mmnto/totem': '^1.40.0' });
+    writeInstalled('@mmnto/totem', '1.40.0');
+
+    await expect(
+      doctorParityCliCommand({ strict: true, onlyWhenConfigured: true, cwdForTest: tmpDir }),
+    ).rejects.toThrow(/PARITY_DRIFT_DETECTED|blocking drift/i);
+  });
+
+  it('runs (no throw) under the fold on a configured manifest with no blocking drift', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', VALID_MANIFEST_YAML);
+    await expect(
+      doctorParityCliCommand({ strict: true, onlyWhenConfigured: true, cwdForTest: tmpDir }),
+    ).resolves.toBeUndefined();
   });
 });

--- a/packages/cli/src/commands/doctor-parity.test.ts
+++ b/packages/cli/src/commands/doctor-parity.test.ts
@@ -839,4 +839,21 @@ describe('doctorParityCliCommand — onlyWhenConfigured fold (#2085)', () => {
       doctorParityCliCommand({ strict: true, onlyWhenConfigured: true, cwdForTest: tmpDir }),
     ).resolves.toBeUndefined();
   });
+
+  it('RENDERS (does not no-op) under the fold when configured but the manifest file is missing', async () => {
+    // The fold gates on the field being SET (configured), not on the file loading —
+    // a configured-but-broken manifest must surface its WARN, never silently no-op.
+    // Guards the exact refactor hazard of flipping the early-return guard to
+    // `onlyWhenConfigured && configured` (which would swallow broken-manifest output).
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: missing.yaml\n`);
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      await expect(
+        doctorParityCliCommand({ strict: true, onlyWhenConfigured: true, cwdForTest: tmpDir }),
+      ).resolves.toBeUndefined(); // not-found is a non-blocking WARN → renders, no throw
+      expect(errSpy).toHaveBeenCalled();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
 });

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -69,6 +69,15 @@ export interface ParityCheckResult {
   results: ParityLine[];
   /** Contract ids whose `warn` is `--strict`-promotable (blocking + drift). */
   blockingDriftIds: string[];
+  /**
+   * Whether a repo-local `orient.parityManifest` field was configured (i.e.
+   * `configValue !== undefined` after the global-leak guard). NOT whether the
+   * manifest file loaded — a configured-but-broken manifest is `configured: true`
+   * so the `--strict` fold surfaces the error instead of silently no-op'ing.
+   * Lets the CLI edge fold parity into `--strict` only for repos that opted in
+   * (mmnto-ai/totem#2085, mmnto-ai/totem-strategy#545 Half 2).
+   */
+  configured: boolean;
 }
 
 // ─── Mechanical artifact registry (CLI-side) ────────────
@@ -356,40 +365,57 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
     configValue = undefined;
   }
 
+  // Single source of truth for "is parity configured here" — derived from the
+  // SAME resolution (incl. the isGlobalConfigPath guard above) so the CLI edge
+  // never re-derives config and never leaks a global manifest into the fold.
+  const configured = configValue !== undefined;
+
   const result = loadParityManifest(configValue, manifestRoot);
 
   switch (result.status) {
     case 'not-configured':
       // Honest-absent: exactly one skip line. Not a failure.
-      return single({
-        name: CHECK_NAME,
-        status: 'skip',
-        message: 'no parity manifest configured',
-      });
+      return single(
+        {
+          name: CHECK_NAME,
+          status: 'skip',
+          message: 'no parity manifest configured',
+        },
+        configured,
+      );
 
     case 'not-found':
-      return single({
-        name: CHECK_NAME,
-        status: 'warn',
-        message: `parity manifest not found at ${rel(cwd, result.path)}`,
-        remediation: 'Fix orient.parityManifest in your totem config to point at the manifest.',
-      });
+      return single(
+        {
+          name: CHECK_NAME,
+          status: 'warn',
+          message: `parity manifest not found at ${rel(cwd, result.path)}`,
+          remediation: 'Fix orient.parityManifest in your totem config to point at the manifest.',
+        },
+        configured,
+      );
 
     case 'unparseable':
-      return single({
-        name: CHECK_NAME,
-        status: 'warn',
-        message: `parity manifest unreadable at ${rel(cwd, result.path)}: ${result.reason}`,
-        remediation: 'Fix the manifest YAML / schema, then re-run totem doctor --parity.',
-      });
+      return single(
+        {
+          name: CHECK_NAME,
+          status: 'warn',
+          message: `parity manifest unreadable at ${rel(cwd, result.path)}: ${result.reason}`,
+          remediation: 'Fix the manifest YAML / schema, then re-run totem doctor --parity.',
+        },
+        configured,
+      );
 
     case 'unsupported-schema':
-      return single({
-        name: CHECK_NAME,
-        status: 'warn',
-        message: `parity manifest schema v${result.schemaVersion} unsupported (this doctor supports v${SUPPORTED_PARITY_SCHEMA_VERSION})`,
-        remediation: 'Upgrade @mmnto/cli or align the manifest schema-version.',
-      });
+      return single(
+        {
+          name: CHECK_NAME,
+          status: 'warn',
+          message: `parity manifest schema v${result.schemaVersion} unsupported (this doctor supports v${SUPPORTED_PARITY_SCHEMA_VERSION})`,
+          remediation: 'Upgrade @mmnto/cli or align the manifest schema-version.',
+        },
+        configured,
+      );
 
     case 'ok': {
       const { contracts } = result.manifest;
@@ -605,14 +631,14 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
         ];
       });
 
-      return { results: [summary, ...perContract], blockingDriftIds };
+      return { results: [summary, ...perContract], blockingDriftIds, configured };
     }
   }
 }
 
 /** Wrap a single summary line in the `ParityCheckResult` shape (no blocking ids). */
-function single(result: ParityLine): ParityCheckResult {
-  return { results: [result], blockingDriftIds: [] };
+function single(result: ParityLine, configured: boolean): ParityCheckResult {
+  return { results: [result], blockingDriftIds: [], configured };
 }
 
 /** Map a core `ParityContractVerdict` to a `ParityLine` keyed by the contract id. */
@@ -673,6 +699,15 @@ export interface ParityCliOptions {
    * contract's `blocking` flag on a `warn`, not the flag alone, gates the exit.
    */
   strict?: boolean;
+  /**
+   * Folded-into-`--strict` mode (mmnto-ai/totem#2085, mmnto-ai/totem-strategy#545
+   * Half 2): when set, the command no-ops (renders nothing, throws nothing, exits 0)
+   * if no repo-local `orient.parityManifest` is configured — so `doctor --strict`
+   * exercises parity for opted-in repos while staying byte-identical for non-adopters
+   * (satur8d's zero-churn condition). Default (omitted) preserves the standalone
+   * `doctor --parity` behavior, which still renders the honest-absent SKIP line.
+   */
+  onlyWhenConfigured?: boolean;
   /** Test seam — production callers omit and the command uses `process.cwd()`. */
   cwdForTest?: string;
 }
@@ -704,7 +739,13 @@ export async function doctorParityCliCommand(options: ParityCliOptions = {}): Pr
       .trim();
 
   const cwd = options.cwdForTest ?? process.cwd();
-  const { results, blockingDriftIds } = await checkParity(cwd);
+  const { results, blockingDriftIds, configured } = await checkParity(cwd);
+
+  // Folded-into-`--strict` no-op: when this run is the strict fold (not an explicit
+  // `doctor --parity`) and no repo-local manifest is configured, render and gate
+  // nothing — a non-adopter's `doctor --strict` stays byte-identical to before the
+  // fold. Explicit `--parity` (onlyWhenConfigured omitted) still shows the SKIP.
+  if (options.onlyWhenConfigured && !configured) return;
 
   // Under --strict, a blocking contract's drift `warn` is rendered + gated as a
   // FAIL. A contract's drift can render across MULTIPLE artifact lines

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1098,6 +1098,18 @@ program
         if (opts.strict && results.some((r) => r.status === 'fail')) {
           process.exitCode = 1;
         }
+        // S0 (mmnto-ai/totem#2085, mmnto-ai/totem-strategy#545 Half 2): fold parity
+        // into the strict suite. When a repo-local orient.parityManifest is configured,
+        // `doctor --strict` also exercises the parity sensor — so consumer CI (which
+        // runs `--strict`, not `--parity --strict`) is no longer green-by-not-checking.
+        // `onlyWhenConfigured` makes it a no-op (no output, no throw) for repos that
+        // never configured a manifest — zero churn for non-adopters. Per ADR-109 /
+        // Tenet 13 the throw-gate lives here at the CLI edge, not inside the composable
+        // doctorCommand. The `--parity` branch returned above, so this never double-runs.
+        if (opts.strict) {
+          const { doctorParityCliCommand } = await import('./commands/doctor-parity.js');
+          await doctorParityCliCommand({ strict: true, onlyWhenConfigured: true });
+        }
         // totem-context: handleError() returns `never` (calls process.exit), so this catch terminates the process rather than silently swallowing — matches the CLI-entrypoint pattern used by every other commander action in this file.
       } catch (err) {
         handleError(err);


### PR DESCRIPTION
## What

Closes the **green-by-not-checking** gap (mmnto-ai/totem-strategy#545 Half 2): consumer CI runs `totem doctor --strict`, which never exercised the parity sensor because `--parity` was an exclusive early-return mode (`index.ts:1091`). Now `--strict` runs the sensor **when (and only when)** a repo-local `orient.parityManifest` is configured — a **no-op (byte-identical output) for non-adopters**, so there is zero consumer-CI churn until a repo opts in.

This is **S0** of the decouple-gate work — satur8d-approved, independent of the distribution build (292 S1–S3, which waits on strategy's seam-1/seam-3 framing).

## How

- `index.ts` — the CLI-edge fold: after the 12-check suite, `if (opts.strict)` calls `doctorParityCliCommand({ strict: true, onlyWhenConfigured: true })`. The `--parity` branch returns above, so it never double-runs.
- `doctor-parity.ts`:
  - `ParityCheckResult.configured: boolean` — single-sourced in `checkParity` (reusing the `isGlobalConfigPath` global-leak guard), so the CLI edge never re-derives config and a global manifest can't leak into the gate. It reflects whether the **field is set**, not whether the file loaded — a configured-but-broken manifest is `configured: true` so `--strict` surfaces the error instead of silently no-op'ing.
  - `ParityCliOptions.onlyWhenConfigured?: boolean` — the command self-gates. The standalone `doctor --parity` is unchanged (still renders the honest-absent SKIP).
- `doctor.ts` is **untouched**.

## Why the CLI edge (not inside `doctorCommand`)

Per **ADR-109 / Tenet 13 (Sensors-Not-Actuators)** and `DoctorOptions:1274` ("the exit-code decision lives at the CLI edge"), the parity throw-gate is an exit decision and belongs at the edge. Folding it into `doctorCommand` would (a) embed an actuator in a function documented composable/side-effect-free, and (b) force a `CheckStatus` widening — `doctorCommand` returns `CheckStatus = pass|warn|fail|skip`, but parity emits the richer `info`/`unknown`. strategy-claude concurred this correction (the design was bounced for review before code).

## Verified no-op here

This repo does not configure `orient.parityManifest`, so `totem doctor --strict` is byte-identical to before. The behavior change fires only for opted-in repos (e.g. totem-strategy post-#546, which loads 19 contracts across the full claim-class spectrum).

## Tests / gate

- 8 new tests covering all six invariants (configured-flag derivation incl. the global-leak case; the no-op-renders-nothing assertion vs. the standalone SKIP; the strict-fold throw-gate on blocking drift; configured-but-broken still runs).
- Full gate green: `tsc` · 2391/2391 CLI tests · eslint 0 errors · prettier · `totem lint` PASS (0 errors) · `totem review` PASS (no findings) · `verify_execution` PASS.

Closes #2085. Refs strategy#545, strategy#546, strategy#448, #2073.

🤖 Generated with [Claude Code](https://claude.com/claude-code)