### PR TITLE
chore(repo): wire totem as a strategy-doctrine consumer — optionalDeps pin + orient.parityManifest (Prop 292 S1 dogfood)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,13 @@ git clone https://github.com/mmnto-ai/totem-strategy.git
 
 This gives you the full surface without the submodule ceremony. If the strategy repo isn't present, the affected commands degrade with actionable error messages — they don't silently fail. Run `totem doctor` to see which surfaces are affected.
 
+## The `@mmnto/strategy-doctrine` Optional Pin
+
+The root `package.json` carries `@mmnto/strategy-doctrine` in `optionalDependencies`. It is a **restricted npm package** (cohort-internal doctrine snapshot — the data source for `totem doctor --parity`); installing it requires npm read-auth that external contributors don't have. This is expected and non-blocking:
+
+- **`pnpm install` on a fresh clone works without auth** — pnpm skips the optional pin gracefully, and `totem doctor --parity` degrades to a non-blocking WARN.
+- **Lockfile-mutating commands** (`pnpm add <pkg>`, `pnpm update`, regenerating `pnpm-lock.yaml`) fail without auth: even though the pin is optional, pnpm must still _resolve_ it into the lockfile, and the restricted registry metadata is not readable anonymously. If your contribution needs a dependency change, edit `package.json`, leave `pnpm-lock.yaml` untouched, and say so in the PR — a maintainer will regenerate the lockfile.
+
 ## Contributor License Agreement (CLA)
 
 All contributors must sign our [Contributor License Agreement](.github/CLA.md) before their first Pull Request can be merged. This is a one-time requirement.

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "turbo": "^2.9.14",
     "typescript": "^5.7.0",
     "typescript-eslint": "^8.59.4"
+  },
+  "optionalDependencies": {
+    "@mmnto/strategy-doctrine": "0.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,10 @@ settings:
 importers:
 
   .:
+    optionalDependencies:
+      '@mmnto/strategy-doctrine':
+        specifier: 0.1.1
+        version: 0.1.1
     devDependencies:
       '@anthropic-ai/sdk':
         specifier: ^0.98.0
@@ -833,6 +837,9 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@mmnto/strategy-doctrine@0.1.1':
+    resolution: {integrity: sha512-3l6F7eOm3qWJ9UTpOwIA6gzxD5y6wXqLEVlWXNrqez3qwjn+bhfvMEE4c10AD9ddXVbsDfBhMN+3+9yKELKflQ==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3649,6 +3656,9 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@mmnto/strategy-doctrine@0.1.1':
+    optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':
     dependencies:

--- a/totem.config.ts
+++ b/totem.config.ts
@@ -71,7 +71,14 @@ const config: TotemConfig = {
   // mmnto-ai/totem#2044 (WS2 PR-3): wire the GH Project board into `totem orient`
   // so its board / coherence-drift sections derive instead of rendering
   // honest-absent. `TOTEM_ORIENT_PROJECT` env still overrides at runtime.
-  orient: { projectNumber: ORIENT_PROJECT_NUMBER },
+  // mmnto-ai/totem#2093 (Prop 292 S1): parityManifest resolves through the
+  // `@mmnto/strategy-doctrine` optionalDependencies pin (restricted pkg; npm
+  // read-auth required). Unauthed installs skip the optional pin and
+  // `doctor --parity` degrades to a non-blocking WARN — expected in public CI.
+  orient: {
+    projectNumber: ORIENT_PROJECT_NUMBER,
+    parityManifest: 'node_modules/@mmnto/strategy-doctrine/parity-manifest.yaml',
+  },
 
   // mmnto-ai/totem#1710: the strategy linkedIndex is auto-injected by the
   // MCP context init via `resolveStrategyRoot`. Listing it here is no


### PR DESCRIPTION
## What

Totem becomes a consumer of the published `@mmnto/strategy-doctrine@0.1.1` doctrine snapshot (Proposal 292 S1 distribution, strategy#554):

1. **`package.json`** — `@mmnto/strategy-doctrine: 0.1.1` in **`optionalDependencies`** (exact pin = the currency floor; bumps are deliberate).
2. **`totem.config.ts`** — `orient.parityManifest` → `node_modules/@mmnto/strategy-doctrine/parity-manifest.yaml`, added via the `init --doctrine` manual-snippet path (#2089's conservative bail — our config has a pre-existing `orient` block).
3. **`CONTRIBUTING.md`** — the unauthed-contributor boundary, stated honestly: fresh-clone `pnpm install` works (optional pin skipped gracefully); lockfile-mutating commands need npm read-auth because even an optional pin must be *resolved* into the lockfile.
4. **`pnpm-lock.yaml`** — pin recorded with `optional: true`.

## Why optionalDependencies (the seam call, empirically verified)

Restricted package ⇒ install needs npm read-auth; totem is public and its CI runs unauthed. Verified against **both** engines (cold store, auth verifiably stripped):

| Path (unauthed) | pnpm 9.15.4 | pnpm 11.2.2 (CI engine) |
|---|---|---|
| `pnpm install --frozen-lockfile`, optionalDeps | exit 0, pkg skipped | exit 0, pkg skipped¹ |
| same, devDeps | exit 1 fetch 404 | exit 1 |
| fresh-clone plain `pnpm install` | — | exit 0, pkg skipped |
| lockfile mutation (`pnpm add`/`update`), any flags | exit 1 | exit 1 |

¹ requires the `minimumReleaseAgeExclude: ['@mmnto/*']` policy exclusion — **already present** in our `pnpm-workspace.yaml`; without it pnpm 11's supply-chain check fails closed on the unauthed metadata 404 regardless of dep type.

A CI read-token alternative is dominated for a public repo: fork PRs never receive secrets, so it cannot keep fork CI green. optionalDeps is green by construction.

**This PR's own CI run is the real-gate proof**: unauthed `pnpm install --frozen-lockfile` must skip the pin, and Doctor (`--strict`, which folds in `--parity` per #2086) must report the configured-but-absent manifest as a non-blocking WARN.

## First real local run (authed)

`doctor --parity` with the pin installed loads **20 contracts** and immediately found genuine drift: 5 WARNs (SessionStart hook, 3 git hooks, 1 managed block vs `@mmnto/cli@1.53.8` canonical) — the known stale-hook-template case (#1854 lane, intentionally not remediated here). Honest verdicts, exit 0.

Follow-up filed: #2094 (the configured-but-missing WARN hint misdiagnoses the optional-skip state).

Closes #2093

🤖 Generated with [Claude Code](https://claude.com/claude-code)