### PR TITLE
feat(cli): totem lint/review --branch / --base <ref> + lint narrow-scope warning (#2090, #2091)

### DIFF
--- a/.changeset/lint-branch-scope-flags.md
+++ b/.changeset/lint-branch-scope-flags.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/cli': patch
+---
+
+feat(cli): `totem lint`/`totem review` gain `--branch` and `--base <ref>` to force the push-gate (branch-vs-base) diff scope regardless of working-tree state (#2091); conflicting scope selectors (`--staged`, `--diff`) hard-error instead of silently winning. `totem lint` additionally warns when its auto-selected `uncommitted`/`staged` scope is narrower than what the pre-push gate will check, with the exact file-count gap (#2090). Both close the local-PASS-hides-gate-failures trap (#2055).

--- a/.totem/specs/2090.md
+++ b/.totem/specs/2090.md
@@ -1,0 +1,105 @@
+### Problem Statement
+
+When `totem lint` runs locally with uncommitted changes, it implicitly scopes its evaluation to only the working tree diff, silently ignoring files that are committed to the local branch but not yet pushed. This creates a false-positive local "PASS" that will eventually fail at the pre-push gate (which evaluates the full branch-vs-base diff), confusing developers.
+
+### Architectural Context
+
+This addresses the `#2055` (local PASS must be trustworthy) initiative and aligns with the **Governing AI Agents > The Tradeoff** paradigm: the pre-push gate acts as a tripwire catching all violations on the branch. To preserve developer trust in local tools, the local lint verdict must not deceptively hide failures that the gate will catch. A warning restores "honest-by-default" behavior without fundamentally altering the flexible local workflow.
+
+### Files to Examine
+
+1. `packages/cli/src/commands/lint.ts` — Where the diff source is determined and where the warning logic should be injected when operating in `uncommitted` mode.
+2. `packages/cli/src/git.ts` — The appropriate home for the git diff resolution helper comparing branch commits against the base.
+3. `packages/cli/src/ui.js` (or `.ts`) — To understand the logger/warning API used to emit the standard warning message.
+
+### Technical Approach & Contracts
+
+**Approach**
+We will introduce a helper to safely compute the list of files modified on the current branch compared to the base branch. In the lint command, when the resolved diff mode is `uncommitted` (or equivalent working tree mode), we will fetch these branch files and subtract the uncommitted files already slated for linting. If the remainder (files modified in commits but not in the working tree) is greater than 0, we emit the warning.
+
+**Data Contracts / Signatures**
+
+```typescript
+// packages/cli/src/git.ts
+/**
+ * Safely resolves files changed between the current branch and the default branch base.
+ * Swallows git errors (e.g., shallow clones, no upstream) to return an empty array,
+ * ensuring lint operations never crash due to git heuristics.
+ */
+export function getBranchVsBaseFiles(cwd: string): string[];
+```
+
+**Sequence Logic**
+
+1. User executes `totem lint`.
+2. CLI determines diff source is `uncommitted` and resolves `filesToLint` (the working tree changes).
+3. CLI calls `getBranchVsBaseFiles(cwd)`.
+   - Resolves default branch via `getDefaultBranch(cwd)`.
+   - Computes `git merge-base HEAD origin/{defaultBranch}`.
+   - Computes `git diff --name-only {base}...HEAD`.
+4. CLI calculates `unlintedBranchFiles` by filtering out any files already present in `filesToLint`.
+5. If `unlintedBranchFiles.length > 0`, emit:
+   `log.warn('Linting uncommitted changes only — the pre-push gate checks the full branch (N more file(s)). Lint a clean tree or use `totem lint --branch` to match.')` (where N is `unlintedBranchFiles.length`).
+
+### Edge Cases & Traps
+
+- **Overlapping Modifiers (The Intersection Trap):** A file can be modified in a branch commit AND have uncommitted changes. The issue asks for "N more file(s)". Do not blindly count branch files. You MUST compute the set difference (`branchFiles \ uncommittedFiles`) to avoid exaggerating the unlinted count.
+- **Git State Failures (The Crash Trap):** If the repo is a shallow clone, has a detached HEAD, or lacks an `origin` remote, `git merge-base` will fail. The lint command must **not** crash. All git branch-diff logic must be wrapped in a `try/catch` that returns an empty array.
+- **Warning Spam on Explicit Flags:** If a user explicitly runs `totem lint --uncommitted` (if such a flag exists), warning them might be redundant. However, to ensure gate-correctness, emitting the warning is still strictly beneficial to remind them of the pre-push disparity. Apply the warning universally when the active lint scope relies purely on the uncommitted working tree.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Create `getBranchVsBaseFiles` helper**
+  - Modify `packages/cli/src/git.ts`.
+  - Export `getBranchVsBaseFiles(cwd: string): string[]`.
+  - Use shared helpers: `getDefaultBranch` and `safeExec`.
+  - Wrap in a `try/catch` returning `[]` on any exception.
+  - Split the `safeExec` output by newline, trim, and filter boolean values to yield an array of strings.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `returns empty array when git merge-base throws instead of crashing` that stubs `safeExec` to throw, proving the lint run is protected from git heuristic failures.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Inject warning logic into lint command**
+  - Modify `packages/cli/src/commands/lint.ts`.
+  - Identify where the diff source resolves to `uncommitted` (and the `filesToLint` array is established).
+  - Compute `const branchFiles = getBranchVsBaseFiles(cwd)`.
+  - Compute `const unlinted = branchFiles.filter(f => !filesToLint.includes(f))`.
+  - If `unlinted.length > 0`, use the UI logger to emit:
+    `Linting uncommitted changes only — the pre-push gate checks the full branch (${unlinted.length} more file(s)). Lint a clean tree or use \`totem lint --branch\` to match.`
+    > TEST DIRECTIVE: Before implementing, write a failing test named `emits warning with correct count of unlinted branch files excluding overlapping uncommitted files` that verifies the exact string output when 2 branch files exist, but 1 overlaps with the uncommitted set (should output "1 more file(s)").
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+1. **Git Failure Resilience:** Mock `safeExec` to throw an error when running `git merge-base`. Verify `totem lint` succeeds without warnings or crashes.
+2. **Accurate File Mathematics:** Mock a scenario with uncommitted files `['A.ts', 'B.ts']` and branch-modified files `['B.ts', 'C.ts', 'D.ts']`. Verify the warning outputs exactly `(2 more file(s))` and does not count `B.ts`.
+3. **Clean Baseline:** Mock a scenario where branch files and uncommitted files are identical, or branch files are empty. Verify no warning is emitted.
+
+## Implementation Design
+
+> Designed jointly with #2091 — see `.totem/specs/2091.md` § Implementation Design for the
+> combined doc (scope, data model, failure modes, invariants, open questions). One PR closes both.
+> Corrections to the generated spec above: the seam is `getDiffForReview`
+> (`packages/cli/src/git.ts:138`, shared lint/review resolver), NOT a new `getBranchVsBaseFiles`
+> helper in isolation; and the file count must derive from the **post-ignore-filter** branch diff
+> (`filterDiffByPatterns` → `extractChangedFiles`) so N matches what the pre-push gate would
+> actually lint — a raw `git diff --name-only` overcounts ignored files.

--- a/.totem/specs/2091.md
+++ b/.totem/specs/2091.md
@@ -1,0 +1,173 @@
+### Problem Statement
+
+The auto-selection logic for `totem lint` and `totem review` scopes defaults to branch-vs-base only when the working tree is completely clean, making it difficult to test the exact pre-push gate locally when uncommitted changes exist. This feature introduces explicit `--branch` and `--base <ref>` flags to forcefully override the auto-selector and diff against the base branch regardless of the working tree state.
+
+### Architectural Context
+
+- **mmnto-ai/totem#2054 (from `getGitBranchDiff` snippet):** The underlying diff logic prefers remote-tracking refs over local branches because local bases in feature-branch workflows are often stale (never checked out). The explicit `--base` flag must pass through to this existing `getGitBranchDiff` function to maintain this architectural guarantee.
+- **Enforcement Model (Pre-Push Gate):** The pre-push hook operates statelessly and deterministically. This new CLI flag brings that deterministic gate logic into the local development loop on demand.
+
+### Files to Examine
+
+1. `packages/cli/src/index.ts` — Command definitions (`reviewOptions`, `lintOptions`) where the new flags must be registered.
+2. `packages/core/src/sys/git.ts` — Houses `getGitBranchDiff(cwd, base)` and `getDefaultBranch`, which provide the actual git operations required for this feature.
+3. `packages/cli/src/utils/diff-selector.ts` (or equivalent command action handlers) — Where the diff-source auto-selection logic lives and must be intercepted.
+
+### Technical Approach & Contracts
+
+We will modify the command option definitions for both `lint` and `review` to accept the new scope modifiers. We will then intercept the diff-source auto-selection logic so that providing either of these flags bypasses working-tree checks entirely and delegates directly to `getGitBranchDiff`.
+
+**Data Contract Changes:**
+Update the shared or command-specific option interfaces (e.g., `LintOptions` and `ReviewOptions`) to include the new scoping flags:
+
+```typescript
+export interface DiffScopeCliOptions {
+  branch?: boolean;
+  base?: string;
+  // Existing flags...
+  staged?: boolean;
+  all?: boolean;
+}
+```
+
+**Sequence Logic (Diff Resolution):**
+
+1. Check for mutually exclusive flags: If `--branch` or `--base` is used alongside an explicit working-tree flag like `--staged` or `--all`, throw an error (Fail Fast).
+2. If `--base <ref>` is provided, imply `--branch = true`.
+3. If `--branch === true`:
+   - Bypass all checks for uncommitted files.
+   - Execute and return `getGitBranchDiff(cwd, options.base)`.
+4. Fall back to existing auto-selector logic (which checks working tree state).
+
+### Edge Cases & Traps
+
+- **Implied `--branch` from `--base`:** Users will frequently type `--base main` without `--branch`. The system must recognize `--base` as an implicit enabler of branch-scope mode.
+- **Mutually Exclusive Scopes:** Using `--branch` alongside `--staged` or `--all` (if such flags exist) creates an impossible state. The CLI must reject this eagerly rather than silently prioritizing one over the other.
+- **Detached HEAD / Initial Repo State:** Ensure `getGitBranchDiff` exceptions bubble up cleanly if the git repo lacks a base branch or commits, rather than resulting in a cryptic null-pointer error.
+- **Shared Diff Logic:** Both `lint` and `review` MUST use the exact same diff resolution logic. Do not duplicate the logic across the two command handlers.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Add Flags to CLI Interfaces and Command Definitions**
+  - Files to modify: `packages/cli/src/index.ts` (and interfaces file if separated)
+  - Test files: `packages/cli/test/index.spec.ts` (or equivalent CLI parsing test)
+    > TEST DIRECTIVE: Before implementing, write a failing test named `rejects --branch and --staged combined` that proves conflicting scope flags throw an error.
+  - Update `reviewOptions` and the equivalent `lintOptions` in the Commander setup to include `.option('--branch', 'Force branch-vs-base diff scope')` and `.option('--base <ref>', 'Explicit base branch override')`.
+  - Update the typescript interfaces for the command options to include `branch?: boolean` and `base?: string`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Update Shared Diff-Source Resolution Logic**
+  - Files to modify: The file containing the diff auto-selection logic (e.g., `packages/cli/src/utils/diff.ts` or directly in the command action utility)
+  - Test files: `packages/cli/test/diff.spec.ts` (or equivalent diff logic test)
+    > TOTEM INVARIANT (Enforcement Model): The pre-push hook runs stateless checks. The `--branch` flag must identically reproduce the push-gate diff scope by ignoring uncommitted files completely.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `uses getGitBranchDiff bypassing uncommitted files when branch flag is true` that verifies `getGitBranchDiff` is called even when unstaged files mock-exist.
+  - Modify the logic:
+    1. If `options.base` is defined, treat `options.branch` as true.
+    2. Throw a validation error if `options.branch` is true AND working-tree flags (like `staged` or `all`) are true.
+    3. If `options.branch` is true, return `getGitBranchDiff(cwd, options.base)`.
+    4. Otherwise, retain existing auto-selection behavior.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Wire Updated Diff Logic to `totem lint`**
+  - Files to modify: `packages/cli/src/commands/lint.ts` (or where lint action is defined)
+  - Test files: `packages/cli/test/commands/lint.spec.ts`
+  - Pass the parsed `branch` and `base` options from the command invocation into the diff resolution function.
+  - Ensure any strict-mode gate failures are respected on the returned diff.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Wire Updated Diff Logic to `totem review`**
+  - Files to modify: `packages/cli/src/commands/review.ts` (or where review action is defined)
+  - Test files: `packages/cli/test/commands/review.spec.ts`
+  - Pass the parsed `branch` and `base` options from the command invocation into the diff resolution function.
+  - write test → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Conflict Test:** Run `totem lint --branch --staged` -> assert fails with mutually exclusive error.
+- **Base Implies Branch Test:** Run `totem lint --base main` with uncommitted files present -> assert uncommitted files are ignored and scope is exactly `main...HEAD`.
+- **Force Push-Gate Scope Test:** Run `totem review --branch` with uncommitted changes in the working tree -> assert output corresponds ONLY to the diff between `origin/main` (or default branch) and `HEAD`, proving working-tree bypass.
+
+## Implementation Design
+
+> Combined design for #2091 (`--branch`/`--base` flags) **and** #2090 (scope-mismatch warning).
+> Both land in the same seam: `getDiffForReview` (`packages/cli/src/git.ts:138`), the shared
+> diff resolver for `lint` and `review`, plus flag registration in `packages/cli/src/index.ts`.
+> One PR, `Closes #2090, Closes #2091`. The generated spec sections above guessed at file paths
+> (`diff-selector.ts`, `core/src/sys/git.ts` helpers); this section reflects the real code.
+
+### Scope
+
+Add `--branch` / `--base <ref>` to `totem lint` and `totem review` (forced push-gate scope), and emit a
+one-line scope-mismatch warning when **lint** auto-selects the `uncommitted`/`staged` source while
+branch-vs-base would cover more files. Will NOT: change the auto-selection cascade, perform any `git fetch`
+(strategy steer: no-fetch, fix at gate-honesty), modify the pre-push hook template, or add the warning to
+`review` (see OQ1).
+
+### Data model deltas
+
+- `DiffForReviewOptions` (`packages/cli/src/git.ts:93`) gains two **optional** fields:
+  - `branch?: boolean` — written by Commander flag parsing; read only by `getDiffForReview`. No invariant beyond truthiness.
+  - `base?: string` — explicit base **branch name** (run through `getGitBranchDiff`'s existing `origin/<base>`-preference resolution, #2054/#2074 — NOT a raw ref range). Non-empty when present; leading-`-` values rejected (flag-injection hardening, same as `getGitDiffRange`).
+  - Invariant: `base` set ⇒ branch mode (implied). `branch`/`base` are mutually exclusive with `staged` and with `diff` — enforced eagerly with a hard error before any git work.
+- `DiffForReviewOptions` gains `warnNarrowScope?: boolean` — set `true` only by the lint command; gates the #2090 warning so review is unaffected (see OQ1).
+- No new `DiffForReviewSource` value: the forced path reports `'branch-vs-base'` (it IS that scope; downstream consumers branch on source and must treat forced/auto identically). The log line discloses the forcing: `Diff source: branch-vs-base (--branch)`.
+- No reserved keys or sentinels.
+
+### State lifecycle
+
+No new state containers. All additions are per-invocation option fields (created at Commander parse, read once inside `getDiffForReview`, garbage with the call). Nothing crosses lifecycle boundaries.
+
+### Failure modes
+
+| Failure                                                                         | Category  | Agent-facing surface                                                                                                                                                            | Recovery                                      |
+| ------------------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `--branch`/`--base` combined with `--staged` or `--diff`                        | init      | hard error (TotemError, exit ≠0) before any git work                                                                                                                            | re-run with one scope selector                |
+| `--base` value empty or leading `-`                                             | init      | hard error (flag-injection guard)                                                                                                                                               | re-run with a valid branch name               |
+| `--base <ref>` resolves to no usable ref (both `origin/<ref>` and `<ref>` fail) | runtime   | existing typed `TotemGitError` from `getGitBranchDiff` with "git fetch origin <ref>" hint — bubbles through the CLI error edge                                                  | fetch/create the base ref                     |
+| Forced branch diff is empty (branch == base)                                    | runtime   | existing "No changes detected" warn + null return (exit 0)                                                                                                                      | none needed — honest empty                    |
+| #2090 warning computation fails (no merge-base, detached HEAD, git error)       | transient | **silent skip of the warning only** — lint verdict, scope, and exit code unaffected                                                                                             | none — next run on a healthy repo warns again |
+| #2090 warning fires with N computed from unfiltered file list                   | —         | (prevented by design: N derives from the **post-ignore-filter** branch diff via `filterDiffByPatterns` → `extractChangedFiles`, so N matches what the gate would actually lint) | —                                             |
+
+Tenet-4 justification for the one silent row: the warning is a best-effort advisory _about_ scope, not a verdict
+input; the failure cases (detached HEAD, no base) are exactly the states where branch-vs-base scope is
+undefined, so there is no honest warning to emit. Lint's own verdict path is untouched.
+
+### Invariants to lock in via tests
+
+- `--base X` forces branch scope even with a dirty working tree (uncommitted content never enters the diff).
+- `--branch` + `--staged` (and `--branch` + `--diff`) error out before any git subprocess is spawned.
+- `--base` with a leading `-` is rejected (flag injection).
+- Forced path and auto-fallback path produce the same `source: 'branch-vs-base'` value (downstream parity).
+- Warning N = |branchFiles \ currentScopeFiles| computed on post-ignore-filter sets; overlap files are not double-counted.
+- No warning when the set difference is empty, when the source is `branch-vs-base`/`explicit-range`, or when `warnNarrowScope` is unset (review path).
+- A throw inside the warning computation never changes lint's verdict, output diff, or exit code.
+
+### Open questions
+
+- **Question 1:** Should the #2090 narrow-scope warning also fire for `totem review`?
+  - **Options:** (a) lint-only via `warnNarrowScope` opt-in; (b) both commands unconditionally.
+  - **Recommendation:** (a) lint-only. The issue names lint; lint is the push-gate mirror. Review's narrow scopes are routinely _intentional_ (staged-slice review is the documented truncation-cliff workaround, upstream-feedback 029) — warning every such run trains ignore.
+- **Question 2:** `--branch` vs `--diff <range>` when both given?
+  - **Options:** (a) hard error (both are explicit scope selectors); (b) `--diff` wins silently.
+  - **Recommendation:** (a) hard error — silent precedence is exactly the implicit-scope dishonesty #2055 exists to kill.
+- **Question 3:** Does `--staged` + the warning need special-casing (#2090 spec's "warning spam" note)?
+  - **Options:** (a) warn in both `uncommitted` and `staged` lint modes; (b) `uncommitted` only.
+  - **Recommendation:** (a) — for lint both modes are narrower than the gate and the issue's rationale ("no one has to hold the scope distinction in their head") applies equally; review is already excluded by OQ1.

--- a/packages/cli/src/commands/lint.test.ts
+++ b/packages/cli/src/commands/lint.test.ts
@@ -25,9 +25,12 @@ vi.mock('../utils.js', async () => {
 });
 
 // ─── Mock git to return a diff so lint proceeds ─────────
+// Spy-able so the #2090/#2091 forwarding tests can assert the exact
+// options object lintCommand hands to the shared diff resolver.
 
+const getDiffForReviewMock = vi.fn(async (..._args: unknown[]) => ({ diff: '' }));
 vi.mock('../git.js', () => ({
-  getDiffForReview: async () => ({ diff: '' }),
+  getDiffForReview: (...args: unknown[]) => getDiffForReviewMock(...args),
 }));
 
 // ─── Mock run-compiled-rules to avoid needing real rules ─
@@ -292,5 +295,43 @@ describe('lintCommand engine bootstrap wiring', () => {
     // also expands Windows 8.3 short names so the assertion is robust
     // on every CI runner.
     expect(fs.realpathSync.native(calledRoot as string)).toBe(fs.realpathSync.native(tmpDir));
+  });
+});
+
+// ─── Diff-scope forwarding (mmnto-ai/totem#2090 / #2091) ─
+
+describe('lintCommand diff-scope forwarding (#2090/#2091)', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+    fs.writeFileSync(path.join(tmpDir, 'totem.config.ts'), 'export default {};', 'utf-8');
+    getDiffForReviewMock.mockClear();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    cleanTmpDir(tmpDir);
+  });
+
+  it('forwards --branch/--base and passes warnNarrowScope: true to getDiffForReview', async () => {
+    const { lintCommand } = await import('./lint.js');
+    await lintCommand({ branch: true, base: 'develop' });
+
+    expect(getDiffForReviewMock).toHaveBeenCalledTimes(1);
+    const optsArg = getDiffForReviewMock.mock.calls[0]![0];
+    expect(optsArg).toMatchObject({ branch: true, base: 'develop', warnNarrowScope: true });
+  });
+
+  it('opts in to the narrow-scope warning even when no scope flags are given', async () => {
+    const { lintCommand } = await import('./lint.js');
+    await lintCommand({});
+
+    expect(getDiffForReviewMock).toHaveBeenCalledTimes(1);
+    const optsArg = getDiffForReviewMock.mock.calls[0]![0];
+    expect(optsArg).toMatchObject({ warnNarrowScope: true });
   });
 });

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -8,6 +8,17 @@ export interface LintOptions {
   out?: string;
   format?: ShieldFormat;
   staged?: boolean;
+  /**
+   * Force the branch-vs-base (push-gate) diff scope (mmnto-ai/totem#2091).
+   * Mutually exclusive with `staged`.
+   */
+  branch?: boolean;
+  /**
+   * Explicit base branch name for the forced branch-vs-base scope
+   * (mmnto-ai/totem#2091). Implies `branch`; resolved via `getGitBranchDiff`'s
+   * origin-preference logic (mmnto-ai/totem#2054).
+   */
+  base?: string;
   /** PR number to post a comment on, or `true` to auto-infer from GitHub Actions env */
   prComment?: number | true;
   /**
@@ -88,7 +99,10 @@ export async function lintCommand(options: LintOptions): Promise<void> {
   const { runFirstLintPromote } = await import('./first-lint-promote-runner.js');
   await runFirstLintPromote({ cwd, configRoot, config, tag: TAG });
 
-  const result = await getDiffForReview(options, config, cwd, TAG);
+  // `warnNarrowScope: true` is the lint-only opt-in for the narrow-scope
+  // advisory (mmnto-ai/totem#2090) — review never sets it, so staged-slice
+  // reviews stay warning-free.
+  const result = await getDiffForReview({ ...options, warnNarrowScope: true }, config, cwd, TAG);
   if (!result) return;
 
   const allIgnore = [...config.ignorePatterns, ...(config.shieldIgnorePatterns ?? [])];

--- a/packages/cli/src/commands/shield-estimate.test.ts
+++ b/packages/cli/src/commands/shield-estimate.test.ts
@@ -169,6 +169,26 @@ describe('runEstimate', () => {
     }
   });
 
+  it('forwards --branch/--base to getDiffForReview without injecting warnNarrowScope (#2090/#2091)', async () => {
+    mockGetDiffForReview.mockResolvedValue(diffResult({ source: 'branch-vs-base' }));
+    mockRunCompiledRules.mockResolvedValue(runCompiledRulesPassResult());
+
+    const { runEstimate } = await import('./shield-estimate.js');
+    await runEstimate(
+      { estimate: true, branch: true, base: 'develop' },
+      makeConfig(),
+      tmpDir,
+      tmpDir,
+    );
+
+    expect(mockGetDiffForReview).toHaveBeenCalledTimes(1);
+    const optsArg = mockGetDiffForReview.mock.calls[0]![0];
+    expect(optsArg).toMatchObject({ branch: true, base: 'develop' });
+    // The narrow-scope warning (mmnto-ai/totem#2090) is a lint-only opt-in —
+    // the review/estimate path must never set it.
+    expect(optsArg).not.toHaveProperty('warnNarrowScope');
+  });
+
   it('emits a [Estimate] preamble before delegating to getDiffForReview', async () => {
     mockGetDiffForReview.mockResolvedValue(diffResult());
     mockRunCompiledRules.mockResolvedValue(runCompiledRulesPassResult());

--- a/packages/cli/src/commands/shield.ts
+++ b/packages/cli/src/commands/shield.ts
@@ -535,6 +535,17 @@ export interface ShieldOptions {
   staged?: boolean;
   /** Explicit ref range for `git diff` (mmnto-ai/totem#1717). Bypasses implicit fallback chain. */
   diff?: string;
+  /**
+   * Force the branch-vs-base (push-gate) diff scope (mmnto-ai/totem#2091).
+   * Mutually exclusive with `staged` and `diff`.
+   */
+  branch?: boolean;
+  /**
+   * Explicit base branch name for the forced branch-vs-base scope
+   * (mmnto-ai/totem#2091). Implies `branch`; resolved via `getGitBranchDiff`'s
+   * origin-preference logic (mmnto-ai/totem#2054).
+   */
+  base?: string;
   mode?: 'standard' | 'structural';
   learn?: boolean;
   yes?: boolean;

--- a/packages/cli/src/git.test.ts
+++ b/packages/cli/src/git.test.ts
@@ -324,6 +324,18 @@ describe('getDiffForReview --branch/--base (#2091)', () => {
     );
   });
 
+  it('discloses only --base when --branch was not passed (Greptile on #2098)', async () => {
+    mockGetGitBranchDiff.mockReturnValue(diffFor('a.ts'));
+
+    await getDiffForReview({ base: 'develop' }, config, '/tmp', 'Lint');
+
+    const disclosure = mockLog.info.mock.calls.find((c) => String(c[1]).startsWith('Diff source:'));
+    expect(disclosure).toBeDefined();
+    expect(disclosure![1]).toBe(
+      'Diff source: branch-vs-base (--base; origin/develop...HEAD, else local develop)',
+    );
+  });
+
   it('--branch + --staged throws FLAG_CONFLICT before any git function is invoked', async () => {
     await expect(
       getDiffForReview({ branch: true, staged: true }, config, '/tmp', 'Lint'),
@@ -352,6 +364,16 @@ describe('getDiffForReview --branch/--base (#2091)', () => {
     ).rejects.toThrow(/--base.*--staged/);
 
     expect(mockGetGitBranchDiff).not.toHaveBeenCalled();
+  });
+
+  it('--base + --diff throws a conflict error before any git work (Greptile on #2098)', async () => {
+    await expect(
+      getDiffForReview({ base: 'main', diff: 'HEAD^..HEAD' }, config, '/tmp', 'Lint'),
+    ).rejects.toThrow(/--base.*--diff/);
+
+    expect(mockGetGitBranchDiff).not.toHaveBeenCalled();
+    expect(mockGetGitDiffRange).not.toHaveBeenCalled();
+    expect(mockGetDefaultBranch).not.toHaveBeenCalled();
   });
 
   it('rejects a --base value with a leading dash (flag-injection guard)', async () => {

--- a/packages/cli/src/git.test.ts
+++ b/packages/cli/src/git.test.ts
@@ -67,13 +67,28 @@ vi.mock('@mmnto/totem', async () => {
   };
 });
 
+// Mock the ui logger so the #2090/#2091 tests can assert on the exact
+// disclosure / warning lines getDiffForReview emits.
+vi.mock('./ui.js', () => ({
+  log: {
+    info: vi.fn(),
+    success: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    dim: vi.fn(),
+  },
+}));
+
 // Must import after mock setup — vitest hoists vi.mock.
 // Aliased so the imports don't shadow the top-of-file re-export checks.
 const totemMod = await import('@mmnto/totem');
+const uiMod = await import('./ui.js');
 const mockSafeExec = vi.mocked(totemMod.safeExec);
 const mockGetGitDiff = vi.mocked(totemMod.getGitDiff);
 const mockGetGitBranchDiff = vi.mocked(totemMod.getGitBranchDiff);
 const mockGetGitDiffRange = vi.mocked(totemMod.getGitDiffRange);
+const mockGetDefaultBranch = vi.mocked(totemMod.getDefaultBranch);
+const mockLog = vi.mocked(uiMod.log);
 
 describe('isAncestor', () => {
   it('returns true for direct ancestor', () => {
@@ -242,5 +257,269 @@ describe('getDiffForReview --diff (#1717)', () => {
     expect(result).not.toBeNull();
     expect(result!.source).toBe('staged');
     expect(mockGetGitDiff).toHaveBeenCalledWith('staged', '/tmp');
+  });
+});
+
+// ─── getDiffForReview --branch/--base (#2091) ────────────
+
+/** Build a minimal unified diff touching the given files. */
+function diffFor(...files: string[]): string {
+  const lines = files.flatMap((f) => [
+    `diff --git a/${f} b/${f}`,
+    `--- a/${f}`,
+    `+++ b/${f}`,
+    '@@ -1 +1 @@',
+    '+x',
+  ]);
+  return `${lines.join('\n')}\n`;
+}
+
+describe('getDiffForReview --branch/--base (#2091)', () => {
+  const config = { ignorePatterns: [] as string[] };
+
+  beforeEach(() => {
+    mockGetGitDiffRange.mockReset();
+    mockGetGitDiff.mockReset();
+    mockGetGitBranchDiff.mockReset();
+    mockGetDefaultBranch.mockClear();
+    mockLog.info.mockClear();
+    mockLog.warn.mockClear();
+  });
+
+  it('--base forces branch scope even with a dirty working tree', async () => {
+    // Dirty tree: getGitDiff WOULD return uncommitted content — the forced
+    // path must never consult it, so none of it can enter the diff.
+    mockGetGitDiff.mockReturnValue(diffFor('dirty.ts'));
+    mockGetGitBranchDiff.mockReturnValue(diffFor('committed.ts'));
+
+    const result = await getDiffForReview({ base: 'develop' }, config, '/tmp', 'Lint');
+
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe('branch-vs-base');
+    expect(result!.changedFiles).toEqual(['committed.ts']);
+    expect(mockGetGitDiff).not.toHaveBeenCalled();
+    expect(mockGetGitBranchDiff).toHaveBeenCalledWith('/tmp', 'develop');
+  });
+
+  it('--branch resolves the default branch and reports source: branch-vs-base', async () => {
+    mockGetGitBranchDiff.mockReturnValue(diffFor('a.ts'));
+
+    const result = await getDiffForReview({ branch: true }, config, '/tmp', 'Lint');
+
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe('branch-vs-base');
+    expect(mockGetGitBranchDiff).toHaveBeenCalledWith('/tmp', 'main');
+    expect(mockGetGitDiff).not.toHaveBeenCalled();
+  });
+
+  it('logs the forced diff-source disclosure line marking the forcing flag', async () => {
+    mockGetGitBranchDiff.mockReturnValue(diffFor('a.ts'));
+
+    await getDiffForReview({ branch: true }, config, '/tmp', 'Lint');
+
+    const disclosure = mockLog.info.mock.calls.find((c) => String(c[1]).startsWith('Diff source:'));
+    expect(disclosure).toBeDefined();
+    expect(disclosure![1]).toBe(
+      'Diff source: branch-vs-base (--branch; origin/main...HEAD, else local main)',
+    );
+  });
+
+  it('--branch + --staged throws FLAG_CONFLICT before any git function is invoked', async () => {
+    await expect(
+      getDiffForReview({ branch: true, staged: true }, config, '/tmp', 'Lint'),
+    ).rejects.toMatchObject({ code: 'FLAG_CONFLICT' });
+
+    expect(mockGetGitDiff).not.toHaveBeenCalled();
+    expect(mockGetGitBranchDiff).not.toHaveBeenCalled();
+    expect(mockGetGitDiffRange).not.toHaveBeenCalled();
+    expect(mockGetDefaultBranch).not.toHaveBeenCalled();
+  });
+
+  it('--branch + --diff throws a conflict error naming both flags before any git work', async () => {
+    await expect(
+      getDiffForReview({ branch: true, diff: 'HEAD^..HEAD' }, config, '/tmp', 'Lint'),
+    ).rejects.toThrow(/--branch.*--diff/);
+
+    expect(mockGetGitDiff).not.toHaveBeenCalled();
+    expect(mockGetGitBranchDiff).not.toHaveBeenCalled();
+    expect(mockGetGitDiffRange).not.toHaveBeenCalled();
+    expect(mockGetDefaultBranch).not.toHaveBeenCalled();
+  });
+
+  it('--base + --staged throws a conflict error (base implies branch scope)', async () => {
+    await expect(
+      getDiffForReview({ base: 'main', staged: true }, config, '/tmp', 'Lint'),
+    ).rejects.toThrow(/--base.*--staged/);
+
+    expect(mockGetGitBranchDiff).not.toHaveBeenCalled();
+  });
+
+  it('rejects a --base value with a leading dash (flag-injection guard)', async () => {
+    await expect(getDiffForReview({ base: '--no-index' }, config, '/tmp', 'Lint')).rejects.toThrow(
+      /git-flag injection/,
+    );
+
+    expect(mockGetGitBranchDiff).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty/whitespace --base value', async () => {
+    await expect(getDiffForReview({ base: '   ' }, config, '/tmp', 'Lint')).rejects.toThrow(
+      /Empty base branch/,
+    );
+
+    expect(mockGetGitBranchDiff).not.toHaveBeenCalled();
+  });
+
+  it('returns null with the existing no-changes warn when the forced branch diff is empty', async () => {
+    mockGetGitBranchDiff.mockReturnValue('');
+
+    const result = await getDiffForReview({ branch: true }, config, '/tmp', 'Lint');
+
+    expect(result).toBeNull();
+    const warned = mockLog.warn.mock.calls.find((c) =>
+      String(c[1]).includes('No changes detected'),
+    );
+    expect(warned).toBeDefined();
+  });
+
+  it('lets getGitBranchDiff errors bubble on the forced path', async () => {
+    mockGetGitBranchDiff.mockImplementation(() => {
+      // totem-context: throw inside a vitest mock to prove the forced path does NOT swallow getGitBranchDiff failures (its TotemGitError carries the actionable fetch hint); sentinel message is test-only
+      throw new Error('fatal: bad revision');
+    });
+
+    await expect(getDiffForReview({ branch: true }, config, '/tmp', 'Lint')).rejects.toThrow(
+      /bad revision/,
+    );
+  });
+});
+
+// ─── getDiffForReview narrow-scope warning (#2090) ───────
+
+describe('getDiffForReview narrow-scope warning (#2090)', () => {
+  const config = { ignorePatterns: [] as string[] };
+  const NARROW_SCOPE_RE = /pre-push gate checks the full branch/;
+
+  function findNarrowScopeWarning() {
+    return mockLog.warn.mock.calls.find((c) => NARROW_SCOPE_RE.test(String(c[1])));
+  }
+
+  beforeEach(() => {
+    mockGetGitDiffRange.mockReset();
+    mockGetGitDiff.mockReset();
+    mockGetGitBranchDiff.mockReset();
+    mockGetDefaultBranch.mockClear();
+    mockLog.info.mockClear();
+    mockLog.warn.mockClear();
+  });
+
+  it('warns with the set difference — overlap files are not double-counted', async () => {
+    mockGetGitDiff.mockReturnValue(diffFor('A.ts', 'B.ts'));
+    mockGetGitBranchDiff.mockReturnValue(diffFor('B.ts', 'C.ts', 'D.ts'));
+
+    const result = await getDiffForReview({ warnNarrowScope: true }, config, '/tmp', 'Lint');
+
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe('uncommitted');
+    const warning = findNarrowScopeWarning();
+    expect(warning).toBeDefined();
+    // B.ts overlaps both scopes — N must be 2 (C.ts, D.ts), not 3.
+    expect(warning![1]).toBe(
+      'Linting uncommitted changes only — the pre-push gate checks the full branch (2 more file(s)). Lint a clean tree or use `totem lint --branch` to match.',
+    );
+  });
+
+  it('computes N from the post-ignore-filter branch diff (ignored files excluded)', async () => {
+    const cfgWithIgnores = { ignorePatterns: ['package-lock.json'] };
+    mockGetGitDiff.mockReturnValue(diffFor('A.ts'));
+    mockGetGitBranchDiff.mockReturnValue(diffFor('B.ts', 'package-lock.json'));
+
+    await getDiffForReview({ warnNarrowScope: true }, cfgWithIgnores, '/tmp', 'Lint');
+
+    const warning = findNarrowScopeWarning();
+    expect(warning).toBeDefined();
+    // Raw --name-only would say 2; the gate-honest post-filter count is 1.
+    expect(warning![1]).toContain('(1 more file(s))');
+  });
+
+  it('staged-mode warning opens with "Linting staged changes only"', async () => {
+    mockGetGitDiff.mockReturnValue(diffFor('A.ts'));
+    mockGetGitBranchDiff.mockReturnValue(diffFor('A.ts', 'B.ts'));
+
+    const result = await getDiffForReview(
+      { staged: true, warnNarrowScope: true },
+      config,
+      '/tmp',
+      'Lint',
+    );
+
+    expect(result!.source).toBe('staged');
+    const warning = findNarrowScopeWarning();
+    expect(warning).toBeDefined();
+    expect(String(warning![1]).startsWith('Linting staged changes only —')).toBe(true);
+  });
+
+  it('does not warn when the set difference is empty', async () => {
+    mockGetGitDiff.mockReturnValue(diffFor('A.ts', 'B.ts'));
+    mockGetGitBranchDiff.mockReturnValue(diffFor('A.ts'));
+
+    await getDiffForReview({ warnNarrowScope: true }, config, '/tmp', 'Lint');
+
+    expect(findNarrowScopeWarning()).toBeUndefined();
+  });
+
+  it('does not warn when the source resolves to branch-vs-base (auto-fallback)', async () => {
+    mockGetGitDiff.mockReturnValue('');
+    mockGetGitBranchDiff.mockReturnValue(diffFor('A.ts'));
+
+    const result = await getDiffForReview({ warnNarrowScope: true }, config, '/tmp', 'Lint');
+
+    expect(result!.source).toBe('branch-vs-base');
+    expect(findNarrowScopeWarning()).toBeUndefined();
+    // Branch diff was computed once for the scope itself — never a second
+    // time for the warning.
+    expect(mockGetGitBranchDiff).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not warn when the source is explicit-range', async () => {
+    mockGetGitDiffRange.mockReturnValue(diffFor('A.ts'));
+
+    const result = await getDiffForReview(
+      { diff: 'HEAD^..HEAD', warnNarrowScope: true },
+      config,
+      '/tmp',
+      'Lint',
+    );
+
+    expect(result!.source).toBe('explicit-range');
+    expect(findNarrowScopeWarning()).toBeUndefined();
+    expect(mockGetGitBranchDiff).not.toHaveBeenCalled();
+  });
+
+  it('does no branch-diff work and never warns when warnNarrowScope is unset (review path)', async () => {
+    mockGetGitDiff.mockReturnValue(diffFor('A.ts'));
+
+    await getDiffForReview({}, config, '/tmp', 'Review');
+
+    expect(findNarrowScopeWarning()).toBeUndefined();
+    expect(mockGetGitBranchDiff).not.toHaveBeenCalled();
+  });
+
+  it('a throw inside the warning computation leaves the result identical to the no-warning case', async () => {
+    mockGetGitDiff.mockReturnValue(diffFor('A.ts'));
+    mockGetGitBranchDiff.mockImplementation(() => {
+      // totem-context: throw inside a vitest mock simulating a git failure (detached HEAD / no base) to prove the advisory is non-fatal per the Tenet-4 silent-skip row; sentinel message is test-only
+      throw new Error('fatal: no merge base');
+    });
+
+    const withFailure = await getDiffForReview({ warnNarrowScope: true }, config, '/tmp', 'Lint');
+
+    mockGetGitBranchDiff.mockReset();
+    mockLog.warn.mockClear();
+    const baseline = await getDiffForReview({}, config, '/tmp', 'Lint');
+
+    expect(withFailure).toEqual(baseline);
+    expect(withFailure!.source).toBe('uncommitted');
+    expect(findNarrowScopeWarning()).toBeUndefined();
   });
 });

--- a/packages/cli/src/git.ts
+++ b/packages/cli/src/git.ts
@@ -94,6 +94,27 @@ export interface DiffForReviewOptions {
   staged?: boolean;
   /** Explicit ref range (mmnto-ai/totem#1717). When set, bypasses the implicit fallback chain. */
   diff?: string;
+  /**
+   * Force the branch-vs-base (push-gate) diff scope regardless of working-tree
+   * state (mmnto-ai/totem#2091). Mutually exclusive with `staged` and `diff`.
+   */
+  branch?: boolean;
+  /**
+   * Explicit base branch NAME for the forced branch-vs-base scope
+   * (mmnto-ai/totem#2091). Resolved through `getGitBranchDiff`'s
+   * origin-preference logic (`origin/<base>...HEAD`, else local `<base>` —
+   * mmnto-ai/totem#2054); NOT a raw ref range. Setting `base` implies
+   * `branch`. Mutually exclusive with `staged` and `diff`.
+   */
+  base?: string;
+  /**
+   * Lint-only opt-in for the narrow-scope advisory (mmnto-ai/totem#2090).
+   * When the resolved source is `staged`/`uncommitted` and the branch-vs-base
+   * scope the pre-push gate checks would cover more files, a one-line warning
+   * names the gap. Never set by `review` — staged-slice review is routinely
+   * intentional (truncation-cliff workaround), so warning there trains ignore.
+   */
+  warnNarrowScope?: boolean;
 }
 
 export interface DiffForReviewConfig {
@@ -123,9 +144,12 @@ export const REVIEW_DIFF_TRUNCATION_THRESHOLD = 50_000;
  * Shared diff-fetching logic used by both `shield` and `lint` commands.
  *
  * Resolution order:
- *   1. `--diff <range>` (explicit, no fallback)
- *   2. `--staged` (staged-only) or working-tree (`all`) diff
- *   3. Branch-vs-base diff (`<default>...HEAD`) when 2 yields nothing
+ *   1. `--branch` / `--base <ref>` (forced push-gate scope, mmnto-ai/totem#2091 —
+ *      jumps straight to the branch-vs-base diff of step 4, ignoring the
+ *      working tree; mutually exclusive with 2 and 3)
+ *   2. `--diff <range>` (explicit, no fallback)
+ *   3. `--staged` (staged-only) or working-tree (`all`) diff
+ *   4. Branch-vs-base diff (`<default>...HEAD`) when 3 yields nothing
  *
  * The chosen resolution path is logged to stderr (mmnto-ai/totem#1717) so the operator's
  * mental model matches the actual git invocation. Diffs exceeding
@@ -143,6 +167,8 @@ export async function getDiffForReview(
 ): Promise<DiffForReviewResult | null> {
   const { log } = await import('./ui.js');
   const {
+    TotemError,
+    TotemGitError,
     extractChangedFiles,
     filterDiffByPatterns,
     getDefaultBranch,
@@ -152,12 +178,72 @@ export async function getDiffForReview(
     sanitizeForTerminal,
   } = await import('@mmnto/totem');
 
+  // ── Eager scope-selector validation (mmnto-ai/totem#2091) ──
+  // `--base` implies branch scope. Both are mutually exclusive with the
+  // other explicit scope selectors — validated BEFORE any git work so the
+  // error names the conflicting flags instead of silently preferring one
+  // scope (the implicit-scope dishonesty mmnto-ai/totem#2055 exists to kill).
+  const forcedBranchScope = options.branch === true || options.base !== undefined;
+  if (forcedBranchScope) {
+    const forcingFlags = [
+      ...(options.branch ? ['--branch'] : []),
+      ...(options.base !== undefined ? ['--base'] : []),
+    ].join('/');
+    const conflicting = [
+      ...(options.staged ? ['--staged'] : []),
+      ...(options.diff !== undefined ? ['--diff'] : []),
+    ];
+    if (conflicting.length > 0) {
+      throw new TotemError(
+        'FLAG_CONFLICT',
+        `${forcingFlags} cannot be combined with ${conflicting.join(', ')}: each selects a different diff scope, and silent precedence would hide which scope actually ran.`,
+        'Re-run with exactly one scope selector: --branch/--base <ref>, --staged, or --diff <range>.',
+      );
+    }
+    if (options.base !== undefined) {
+      // Mirrors getGitDiffRange's flag-injection guard (mmnto-ai/totem#1717):
+      // reject empty values and leading `-` before the name reaches git.
+      const trimmedBase = options.base.trim();
+      if (trimmedBase.length === 0) {
+        throw new TotemGitError(
+          'Empty base branch supplied to --base.',
+          'Provide a non-empty branch name, e.g. --base main.',
+        );
+      }
+      if (trimmedBase.startsWith('-')) {
+        throw new TotemGitError(
+          `Invalid base branch: ${trimmedBase}. Branch names may not start with '-' (git-flag injection guard).`,
+          'Provide a plain branch name such as "main" without leading dashes.',
+        );
+      }
+    }
+  }
+
   const allIgnore = [...config.ignorePatterns, ...(config.shieldIgnorePatterns ?? [])];
 
   let diff: string;
   let source: DiffForReviewSource;
 
-  if (options.diff !== undefined) {
+  if (forcedBranchScope) {
+    // Forced push-gate scope (mmnto-ai/totem#2091): bypass the working-tree
+    // checks entirely and diff branch-vs-base — exactly what the pre-push
+    // gate evaluates. Reuses the auto-fallback's source value so downstream
+    // consumers treat forced and auto branch scope identically; the log line
+    // discloses the forcing. getGitBranchDiff's TotemGitError (with its
+    // "git fetch origin <ref>" hint) bubbles when the base resolves nowhere.
+    const base = options.base !== undefined ? options.base.trim() : getDefaultBranch(cwd);
+    const safeBase = sanitizeForTerminal(base);
+    log.info(
+      tag,
+      `Diff source: branch-vs-base (--branch; origin/${safeBase}...HEAD, else local ${safeBase})`,
+    );
+    diff = filterDiffByPatterns(getGitBranchDiff(cwd, base), allIgnore);
+    source = 'branch-vs-base';
+    if (!diff.trim()) {
+      log.warn(tag, 'No changes detected. Nothing to review.');
+      return null;
+    }
+  } else if (options.diff !== undefined) {
     // Explicit-range path — no fallback. getGitDiffRange rejects flag-injection
     // (leading `-`) and empty values; ignore patterns still apply per repo policy.
     log.info(tag, `Diff source: explicit range (${options.diff})`);
@@ -203,6 +289,36 @@ export async function getDiffForReview(
 
   const changedFiles = extractChangedFiles(diff);
   log.info(tag, `Changed files (${changedFiles.length}): ${changedFiles.join(', ')}`);
+
+  // ── Narrow-scope advisory (mmnto-ai/totem#2090) — lint-only opt-in ──
+  // When lint resolved a working-tree scope, compare against the
+  // branch-vs-base scope the pre-push gate checks. The branch file set runs
+  // through the SAME post-ignore-filter pipeline as the gate would, so N
+  // counts only files the gate would actually lint (raw `--name-only`
+  // overcounts ignored files). Set difference avoids double-counting files
+  // changed both on the branch and in the working tree.
+  if (options.warnNarrowScope && (source === 'staged' || source === 'uncommitted')) {
+    try {
+      const branchDiff = filterDiffByPatterns(
+        getGitBranchDiff(cwd, getDefaultBranch(cwd)),
+        allIgnore,
+      );
+      const branchFiles = extractChangedFiles(branchDiff);
+      const currentScope = new Set(changedFiles);
+      const unlinted = branchFiles.filter((file) => !currentScope.has(file));
+      if (unlinted.length > 0) {
+        const opening =
+          source === 'staged' ? 'Linting staged changes only' : 'Linting uncommitted changes only';
+        log.warn(
+          tag,
+          `${opening} — the pre-push gate checks the full branch (${unlinted.length} more file(s)). Lint a clean tree or use \`totem lint --branch\` to match.`,
+        );
+      }
+      // totem-context: Tenet-4-justified silent skip (mmnto-ai/totem#2090) — the warning is a best-effort advisory ABOUT scope, not a verdict input; its failure states (detached HEAD, no base branch, shallow clone) are exactly where branch-vs-base scope is undefined, so there is no honest warning to emit. Lint's verdict, diff, and exit code are untouched.
+    } catch {
+      // Intentionally silent — see the totem-context justification above.
+    }
+  }
 
   return { diff, changedFiles, source };
 }

--- a/packages/cli/src/git.ts
+++ b/packages/cli/src/git.ts
@@ -184,11 +184,14 @@ export async function getDiffForReview(
   // error names the conflicting flags instead of silently preferring one
   // scope (the implicit-scope dishonesty mmnto-ai/totem#2055 exists to kill).
   const forcedBranchScope = options.branch === true || options.base !== undefined;
+  // Names the flag(s) the user actually passed — shared by the conflict error
+  // AND the diff-source disclosure line so neither cites a flag that wasn't
+  // given (a `--base`-only run must not log `--branch` — Greptile on #2098).
+  const forcingFlags = [
+    ...(options.branch ? ['--branch'] : []),
+    ...(options.base !== undefined ? ['--base'] : []),
+  ].join('/');
   if (forcedBranchScope) {
-    const forcingFlags = [
-      ...(options.branch ? ['--branch'] : []),
-      ...(options.base !== undefined ? ['--base'] : []),
-    ].join('/');
     const conflicting = [
       ...(options.staged ? ['--staged'] : []),
       ...(options.diff !== undefined ? ['--diff'] : []),
@@ -235,7 +238,7 @@ export async function getDiffForReview(
     const safeBase = sanitizeForTerminal(base);
     log.info(
       tag,
-      `Diff source: branch-vs-base (--branch; origin/${safeBase}...HEAD, else local ${safeBase})`,
+      `Diff source: branch-vs-base (${forcingFlags}; origin/${safeBase}...HEAD, else local ${safeBase})`,
     );
     diff = filterDiffByPatterns(getGitBranchDiff(cwd, base), allIgnore);
     source = 'branch-vs-base';

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -285,6 +285,14 @@ program
   .option('--format <format>', 'Output format: text (default), sarif, or json')
   .option('--staged', 'Lint only staged changes (default: all uncommitted)')
   .option(
+    '--branch',
+    'Force the branch-vs-base diff scope the pre-push gate checks, regardless of working-tree state (mutually exclusive with --staged)',
+  )
+  .option(
+    '--base <ref>',
+    'Base branch for the push-gate scope (implies --branch; resolved as origin/<ref>...HEAD, else local <ref>)',
+  )
+  .option(
     '--pr-comment [number]',
     'Post a summary comment on a PR (auto-infers number in GitHub Actions)',
   )
@@ -301,6 +309,8 @@ program
       out?: string;
       format?: string;
       staged?: boolean;
+      branch?: boolean;
+      base?: string;
       prComment?: string | true;
       timeoutMode?: string;
       astParseMode?: string;
@@ -358,6 +368,14 @@ const reviewOptions = (cmd: Command) =>
       '--diff <ref-range>',
       'Review an explicit git diff range (e.g. "HEAD^..HEAD" or "main...feature"). Bypasses the implicit working-tree → staged → branch-vs-base fallback.',
     )
+    .option(
+      '--branch',
+      'Force the branch-vs-base diff scope the pre-push gate checks, regardless of working-tree state (mutually exclusive with --staged and --diff)',
+    )
+    .option(
+      '--base <ref>',
+      'Base branch for the push-gate scope (implies --branch; resolved as origin/<ref>...HEAD, else local <ref>)',
+    )
     .option('--deterministic', 'REMOVED — use `totem lint` instead', false)
     .option('--format <format>', 'REMOVED — use `totem lint --format` instead')
     .option(
@@ -392,10 +410,12 @@ const reviewOptions = (cmd: Command) =>
       'after',
       [
         '',
-        'Diff resolution (when --diff is omitted):',
+        'Diff resolution (when --diff and --branch/--base are omitted):',
         '  1. --staged          → staged-only diff',
         '  2. (default)         → working-tree diff (all uncommitted)',
         '  3. (fallback)        → branch-vs-base diff when 1/2 produce nothing',
+        '--branch (or --base <ref>) forces scope 3 — the exact diff the pre-push',
+        'gate checks — regardless of working-tree state (mmnto-ai/totem#2091).',
         `The chosen path is logged to stderr; large diffs (>${REVIEW_DIFF_TRUNCATION_THRESHOLD} chars)`,
         'trigger an explicit truncation warning before the LLM call.',
         '',
@@ -426,6 +446,8 @@ async function runReview(opts: {
   fresh?: boolean;
   staged?: boolean;
   diff?: string;
+  branch?: boolean;
+  base?: string;
   deterministic?: boolean;
   format?: string;
   mode?: string;
@@ -444,6 +466,8 @@ async function runReview(opts: {
     await lintCommand({
       format: (opts.format as 'text' | 'sarif' | 'json') ?? 'text',
       staged: opts.staged,
+      branch: opts.branch,
+      base: opts.base,
       out: opts.out,
     });
     return;


### PR DESCRIPTION
## What

Gate-correctness pair (children of #2055 — local PASS must be trustworthy), one seam: `getDiffForReview`, the shared lint/review diff resolver.

**#2091 — forced push-gate scope.** `--branch` diffs branch-vs-base (`origin/<base>...HEAD`, else local — the #2054 origin-preference resolution) regardless of working-tree state; `--base <ref>` overrides the base *name* and implies `--branch`. Conflicting scope selectors (`--staged`, `--diff`) **hard-error before any git work** — silent precedence between explicit selectors is the implicit-scope dishonesty #2055 exists to kill. The forced path reuses the `'branch-vs-base'` source value (downstream parity) with a disclosing log line; `--base` values get the same flag-injection guard as `--diff` ranges.

**#2090 — narrow-scope advisory (lint-only).** When lint auto-narrows to `uncommitted`/`staged` while the branch carries more, one line names the gap:

> Linting uncommitted changes only — the pre-push gate checks the full branch (N more file(s)). Lint a clean tree or use `totem lint --branch` to match.

N derives from the **post-ignore-filter** branch diff (`filterDiffByPatterns` → `extractChangedFiles`) — exact gate parity, no overcounting of ignored files; set-difference avoids double-counting overlap files. Warning-compute failure degrades to no-warning and can never touch the verdict (the sole silent row — Tenet-4-justified in the design doc: the failure states are exactly where branch-vs-base scope is undefined). Review never opts in (`warnNarrowScope` is lint's call-site decision): staged-slice review is routinely intentional (truncation-cliff workaround), and a warning that fires on intentional use trains ignore.

## Design provenance

Full implementation design (data model, failure-mode table, test invariants, 3 OQ rulings): `.totem/specs/2091.md` § Implementation Design (committed in this PR). strategy-claude concurred ×3 on the OQs (2026-06-06T2000Z dispatch) and ruled the lane orthogonal to the in-flight #474 review-redesign round; satur8d greenlit at the preflight gate.

## Tests

21 new (cli suite 2412 → 2433): conflict ordering (errors before any git call), flag-injection guards, dirty-tree bypass, forced/auto source parity, warning N math (overlap + post-filter), all no-warning paths, throw-inside-warning leaves result identical, lint-forwards-`warnNarrowScope`/review-does-not.

## Gates

`lint --branch` (the new flag as its own push gate): PASS, 0 errors · `format:check` clean · `review --branch`: PASS, no issues · build clean. Two pre-existing env-dependent test failures (`pre-compact-hook`, `content-hash-parity`) fail identically on clean `main` in the same shell environment — baseline-equal, not regressions; CI is the arbiter.

Closes #2090
Closes #2091

🤖 Generated with [Claude Code](https://claude.com/claude-code)