### PR TITLE
chore(deps): strategy-doctrine 0.1.2 reconcile + minimumReleaseAge unit fix + stranded lessons

### DIFF
--- a/.totem/compile-manifest.json
+++ b/.totem/compile-manifest.json
@@ -1,7 +1,7 @@
 {
-  "compiled_at": "2026-05-21T17:00:38.822Z",
+  "compiled_at": "2026-06-07T02:04:56.853Z",
   "model": "gemini-3-flash-preview",
-  "input_hash": "520c2c96a85b69882883aa793a5f31d97481d2ff307c158449dee78588ab75a1",
-  "output_hash": "5d7a6c331a819b857ac42a0ab6885f4c17d7bc274cd8a8dc25fe7b8afb98b81f",
-  "rule_count": 482
+  "input_hash": "5dca0066ae548503467cafc2167334a53b7458ee5fd9532126f211188dc44f7b",
+  "output_hash": "ecac4018c302c7bfca2dd12195333c3b6b6bdadfda575ffb51d7a9b26285c2a5",
+  "rule_count": 483
 }

--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -8524,10 +8524,11 @@
     {
       "lessonHash": "42559b2f75734104",
       "lessonHeading": "Hook stderr diagnostics use script-identifier prefix, not",
+      "pattern": "process\\.stderr\\.write\\([^)]*\\[Totem Error\\]",
       "message": "Hook stderr diagnostics must use the script-identifier prefix (e.g., '[auto-context]', '[session-context]'), not '[Totem Error]'. The '[Totem Error]' prefix is reserved for thrown Error objects per styleguide §3.",
       "engine": "regex",
-      "severity": "warning",
-      "pattern": "process\\.stderr\\.write\\([^)]*\\[Totem Error\\]",
+      "badExample": "process.stderr.write('[Totem Error] Failed to load proposals\\n');",
+      "goodExample": "process.stderr.write('[auto-context] Failed to load proposals\\n');",
       "compiledAt": "2026-05-21T17:00:37.880Z",
       "createdAt": "2026-05-21T17:00:37.880Z",
       "fileGlobs": [
@@ -8536,19 +8537,16 @@
         "packages/cli/src/hooks/**/*.ts",
         "packages/cli/src/hooks/**/*.js"
       ],
-      "badExample": "process.stderr.write('[Totem Error] Failed to load proposals\\n');",
-      "goodExample": "process.stderr.write('[auto-context] Failed to load proposals\\n');",
-      "unverified": true,
-      "status": "untested-against-codebase"
+      "severity": "warning",
+      "status": "untested-against-codebase",
+      "unverified": true
     },
     {
       "lessonHash": "c2d9e854231b78f1",
       "lessonHeading": "Proactively remove references to planned features from user",
+      "pattern": "\\b(coming soon|planned (feature|for)|future release|roadmap|under development|slated for|later development phases)\\b",
       "message": "Proactively remove references to planned features from user",
       "engine": "regex",
-      "severity": "warning",
-      "manual": true,
-      "pattern": "\\b(coming soon|planned (feature|for)|future release|roadmap|under development|slated for|later development phases)\\b",
       "compiledAt": "2026-05-21T17:00:26.725Z",
       "createdAt": "2026-05-21T17:00:26.725Z",
       "fileGlobs": [
@@ -8558,7 +8556,29 @@
         "guides/**/*",
         "!docs/wiki/roadmap.md"
       ],
+      "severity": "warning",
+      "manual": true,
       "unverified": true
+    },
+    {
+      "lessonHash": "839aceddfb699160",
+      "lessonHeading": "a config line CI never executes is unverified, no matter",
+      "message": "pnpm minimumReleaseAge takes a bare number (minutes), not a duration string like '1d'. A string value causes NaN arithmetic and crashes every resolving install with 'Invalid time value'.",
+      "engine": "regex",
+      "severity": "error",
+      "pattern": "minimumReleaseAge\\s*:\\s*['\"]?\\d+[a-zA-Z]+['\"]?",
+      "compiledAt": "2026-06-07T02:04:45.430Z",
+      "createdAt": "2026-06-07T02:04:45.430Z",
+      "fileGlobs": [
+        "**/pnpm-workspace.yaml",
+        "**/.npmrc"
+      ],
+      "badExample": "minimumReleaseAge: '1d'",
+      "goodExample": "minimumReleaseAge: 1440 # 1 day in minutes",
+      "unverified": true,
+      "status": "archived",
+      "archivedAt": "2026-06-07T02:04:45.798Z",
+      "archivedReason": "Stage 4 (mmnto-ai/totem#1682): pattern fired on 1 file(s) in the verification baseline (test files, fixture directories, or files outside fileGlobs scope) — over-broad. Offending paths: packages/cli/CHANGELOG.md. reasonCode: stage4-out-of-scope-match."
     }
   ],
   "nonCompilable": [
@@ -14258,6 +14278,54 @@
       "title": "Key security audit findings and acceptable risks",
       "reasonCode": "out-of-scope",
       "reason": "Lesson describes a security audit summary with multiple architectural findings, mitigations, and accepted risks. The findings span memory limits (Zod config values), process execution patterns, regex allowlists, and trust model decisions — no single detectable code pattern captures the lesson's intent without producing either massive false positives or missing the nuanced context of each finding."
+    },
+    {
+      "hash": "501611a19daf5bb9",
+      "title": "Lockfile mutations require auth for optional dependencies",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes a procedural/workflow constraint about developer environment setup (registry auth required before running lockfile-mutating commands). There is no detectable code pattern — the rule governs human behavior in a terminal, not source code constructs."
+    },
+    {
+      "hash": "b67cb7724df04673",
+      "title": "totem lint scopes to CHANGED lines, so extracting code",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes a workflow/process guideline about running lint before pushing code that moves files, and about using totem-context directives instead of totem-ignore. There is no single detectable code pattern that represents a violation — the lesson is about developer workflow, git hook behavior, and diff scoping semantics, not a specific code construct."
+    },
+    {
+      "hash": "ba734ed4a16e07b1",
+      "title": "Avoid warnings for intentional narrow-scope workflows",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes a conceptual UX/behavioral principle about when to suppress advisory warnings based on workflow context. There is no detectable code pattern that distinguishes intentional narrow-scope usage from unintentional narrow-scope usage."
+    },
+    {
+      "hash": "daa1783348385648",
+      "title": "Degrade gracefully on advisory warning failures",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes an architectural resilience principle (graceful degradation of advisory warnings) that cannot be expressed as a detectable code pattern. There is no specific syntactic construct to flag — the violation is the absence of a try/catch or fallback around advisory warning logic, which requires semantic understanding of which code paths are 'advisory' versus 'critical'."
+    },
+    {
+      "hash": "2df5822d1e197507",
+      "title": "Eagerly validate conflicting CLI scope selectors",
+      "reasonCode": "context-required",
+      "reason": "Lesson describes a runtime validation requirement (detecting conflicting CLI flag combinations before git operations begin), not a detectable source-code pattern. The hazard depends on the control-flow relationship between flag-parsing, conflict-checking, and git invocation across multiple call sites; no single-node regex or ast-grep pattern can express whether a conflict check is absent or misplaced relative to git work."
+    },
+    {
+      "hash": "e6554b64330d9bbd",
+      "title": "Warn on missing optional manifest assets",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes an architectural/behavioral principle about how diagnostic tools should classify missing optional assets — there is no detectable code pattern (specific function call, import, or construct) that can be matched to identify violations of this guideline."
+    },
+    {
+      "hash": "e454c47de3efe004",
+      "title": "Calculate scope warnings using post-filter diffs",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes an algorithmic/architectural principle about how to calculate scope warnings (using post-filter diffs rather than pre-filter counts). There is no detectable code pattern — the violation depends on the internal logic of a coverage calculation pipeline, not on any specific syntax, API call, or structural construct that a regex or AST rule could match."
+    },
+    {
+      "hash": "0426b3d40887c709",
+      "title": "Use optionalDependencies for restricted CI packages",
+      "reasonCode": "context-required",
+      "reason": "Lesson describes a package.json structural placement rule: a specific package must appear under 'optionalDependencies' rather than 'dependencies' or 'devDependencies'. Detecting which packages are 'restricted/private' requires knowledge of the registry auth context or a known list of private package names — neither of which can be expressed as a general pattern without producing massive false positives on legitimate devDependencies."
     }
   ]
 }

--- a/.totem/lessons/lesson-134095fd.md
+++ b/.totem/lessons/lesson-134095fd.md
@@ -1,0 +1,6 @@
+## Lesson — Lockfile mutations require auth for optional dependencies
+
+**Tags:** pnpm, dx, contributing
+**Scope:** CONTRIBUTING.md
+
+Commands that mutate the lockfile (like pnpm add/update) require registry auth to resolve metadata for all dependencies, including optional ones that frozen-lockfile installs would skip.

--- a/.totem/lessons/lesson-1ef06d16.md
+++ b/.totem/lessons/lesson-1ef06d16.md
@@ -1,0 +1,7 @@
+## Lesson — totem lint scopes to CHANGED lines, so extracting code
+
+**Tags:** totem-lint, pre-push-hook, code-extraction, trap, compiled-rules, totem-context
+
+`totem lint` scopes to CHANGED lines, so extracting code verbatim into a new file (e.g. lifting a shared helper like a settings-merge primitive out of a large module) surfaces that code's pre-existing/dormant compiled-rule violations as if they were NEW — they were only dormant because the lines were unchanged. Compounding this: the pre-push git hook runs `totem lint` via the PATH-resolved GLOBAL `totem` binary against the FULL branch-vs-main diff, a BROADER scope than a local `node packages/cli/dist/index.js lint` (which may diff only HEAD~1 or uncommitted, hiding the violations). Net: before the FIRST push of a PR that MOVES code, run a full-branch lint on a clean/committed tree — ideally via the same global binary the hook uses — to surface dormant debt up front instead of discovering it across multiple rejected pushes (format:check is repo-wide prettier and bites the same way on moved/old files). Fix moved code properly, or document a genuinely-intentional pattern with a single-line `// totem-context:` directive placed on the line DIRECTLY above the `} catch` (the rule checks that exact line); never paper over with a bare `// totem-ignore` (AGENTS.md forbids it without a ticket-ref).
+
+**Source:** mcp (added at 2026-05-31T04:11:42.530Z)

--- a/.totem/lessons/lesson-32916a76.md
+++ b/.totem/lessons/lesson-32916a76.md
@@ -1,0 +1,6 @@
+## Lesson — Avoid warnings for intentional narrow-scope workflows
+
+**Tags:** ux, review, dx
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*
+
+Advisory warnings for narrow scopes should only fire where such scopes are likely unintentional, such as in linting. In workflows like code review where narrow scopes are routine, frequent warnings can train users to ignore them.

--- a/.totem/lessons/lesson-571f1c31.md
+++ b/.totem/lessons/lesson-571f1c31.md
@@ -1,0 +1,6 @@
+## Lesson — Degrade gracefully on advisory warning failures
+
+**Tags:** error-handling, ux
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*
+
+Failures in computing non-critical advisory warnings should degrade to no-warning and never affect the final command verdict. This maintains tool resilience in environments where branch-vs-base resolution is undefined.

--- a/.totem/lessons/lesson-62290675.md
+++ b/.totem/lessons/lesson-62290675.md
@@ -1,0 +1,6 @@
+## Lesson — Eagerly validate conflicting CLI scope selectors
+
+**Tags:** cli, validation, ux
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*
+
+Hard-erroring before any git work when conflicting scope flags (e.g., --staged vs --branch) are used prevents silent precedence. This ensures the tool's behavior matches user intent and avoids 'implicit-scope dishonesty'.

--- a/.totem/lessons/lesson-675b103c.md
+++ b/.totem/lessons/lesson-675b103c.md
@@ -1,0 +1,9 @@
+## Lesson — a config line CI never executes is unverified, no matter
+
+**Tags:** pnpm, supply-chain, minimumReleaseAge, trap, engine-parity, ci, config-validation
+
+**Applies-to:** infrastructure
+
+pnpm's `minimumReleaseAge` (pnpm-workspace.yaml) takes MINUTES as a bare number — NOT a duration string. pnpm 11.2.2 multiplies the value raw (`'1d' * 60 * 1000` → NaN), producing an Invalid-Date cutoff that crashes EVERY resolving install with "pnpm: Invalid time value" at detectMinReleaseAgeViolation — and the failing importer moves between runs because any freshly-resolved package falls into the violation branch (`ts <= NaN` is false). The `1d` shape reads plausibly because Renovate's same-named setting DOES take duration strings. The misconfig hides in two shadows: CI installs with --frozen-lockfile (no resolution → cutoff never constructed) and an older global pnpm (9.x ignores the unknown key), so the line first executes — and first crashes — on the first corepack-resolving install, weeks after merge. Fix: express as minutes (`1440`), comment the unit. Generalizes the engine-parity rule: a config line CI never executes is unverified, no matter how green the checks.
+
+**Source:** mcp (added at 2026-06-07T02:00:57.165Z)

--- a/.totem/lessons/lesson-6af3b2a2.md
+++ b/.totem/lessons/lesson-6af3b2a2.md
@@ -1,0 +1,6 @@
+## Lesson — Warn on missing optional manifest assets
+
+**Tags:** cli, dx, parity
+**Scope:** packages/cli/**/*.ts
+
+Diagnostic tools should treat configured but missing assets from optional dependencies as non-blocking warnings to support environments where the dependency was intentionally skipped.

--- a/.totem/lessons/lesson-6d0b9cdb.md
+++ b/.totem/lessons/lesson-6d0b9cdb.md
@@ -1,0 +1,6 @@
+## Lesson — Calculate scope warnings using post-filter diffs
+
+**Tags:** git, ux, lint
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*
+
+Narrow-scope warnings should be calculated using post-ignore-filter diffs to ensure exact parity with the pre-push gate. This prevents overcounting ignored files and ensures the warning accurately reflects the gap in coverage.

--- a/.totem/lessons/lesson-87ff817d.md
+++ b/.totem/lessons/lesson-87ff817d.md
@@ -1,0 +1,6 @@
+## Lesson — Exclude private scopes from pnpm supply-chain checks
+
+**Tags:** pnpm, security, ci
+**Scope:** pnpm-workspace.yaml
+
+Pnpm 11's supply-chain checks fail on unauthed metadata 404s unless the scope is added to minimumReleaseAgeExclude, even if the dependency is marked as optional.

--- a/.totem/lessons/lesson-d12015d9.md
+++ b/.totem/lessons/lesson-d12015d9.md
@@ -1,0 +1,6 @@
+## Lesson — Guard git refs against flag injection
+
+**Tags:** git, security, cli
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*
+
+User-provided git references in CLI flags must be guarded against flag injection. This prevents positional arguments from being interpreted as additional git options during command execution.

--- a/.totem/lessons/lesson-f4431630.md
+++ b/.totem/lessons/lesson-f4431630.md
@@ -1,0 +1,6 @@
+## Lesson — Use optionalDependencies for restricted CI packages
+
+**Tags:** pnpm, ci, dependencies
+**Scope:** package.json
+
+Placing restricted/private packages in optionalDependencies allows public CI and fork PRs to pass installation by skipping the package when registry read-auth is missing.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "typescript-eslint": "^8.59.4"
   },
   "optionalDependencies": {
-    "@mmnto/strategy-doctrine": "0.1.1"
+    "@mmnto/strategy-doctrine": "0.1.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,10 +7,6 @@ settings:
 importers:
 
   .:
-    optionalDependencies:
-      '@mmnto/strategy-doctrine':
-        specifier: 0.1.1
-        version: 0.1.1
     devDependencies:
       '@anthropic-ai/sdk':
         specifier: ^0.98.0
@@ -48,6 +44,10 @@ importers:
       typescript-eslint:
         specifier: ^8.59.4
         version: 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
+    optionalDependencies:
+      '@mmnto/strategy-doctrine':
+        specifier: 0.1.2
+        version: 0.1.2
 
   packages/cli:
     dependencies:
@@ -269,24 +269,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@ast-grep/napi-linux-arm64-musl@0.42.0':
     resolution: {integrity: sha512-f/oW3KaHuOMuBkCcvI6R71xM9SvkdUVKHhbJEtBFo5D1j6CjY9ipWdjlk9mOJ2KLLM6uYdjjvkJkBPlPuFTukg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@ast-grep/napi-linux-x64-gnu@0.42.0':
     resolution: {integrity: sha512-y9T/Tm6V6zkmcAJlWXUO0ACYLSlk5o5NVU+AYun7NzDWIM86Y3lnoDF5WxeZKonVoaGAnkCXVlNH8Tsr/NTQWw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@ast-grep/napi-linux-x64-musl@0.42.0':
     resolution: {integrity: sha512-t1PwL6YweDL63QDK3TC9QTKROcVgN4XoMxlp/zN2NYvCUM90mSvqh/Py/ouchzluHaqCzEeEp9089WFEDWwQOA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@ast-grep/napi-win32-arm64-msvc@0.42.0':
     resolution: {integrity: sha512-bxKLXF1JmU33BoJKrbWcGsG7Xmk2zCQaUjmeHrxhgBhg2w2zo3CSf5S6DOyOp13hefgLXBLn6oXNzXgqpX/+lA==}
@@ -794,24 +798,28 @@ packages:
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@lancedb/lancedb-linux-arm64-musl@0.26.2':
     resolution: {integrity: sha512-pR6Hs/0iphItrJYYLf/yrqCC+scPcHpCGl6rHqcU2GHxo5RFpzlMzqW1DiXScGiBRuCcD9HIMec+kBsOgXv4GQ==}
     engines: {node: '>= 18'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@lancedb/lancedb-linux-x64-gnu@0.26.2':
     resolution: {integrity: sha512-u4UUSPwd2YecgGqWjh9W0MHKgsVwB2Ch2ROpF8AY+IA7kpGsbB18R1/t7v2B0q7pahRy20dgsaku5LH1zuzMRQ==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@lancedb/lancedb-linux-x64-musl@0.26.2':
     resolution: {integrity: sha512-XIS4qkVfGlzmsUPqAG2iKt8ykuz28GfemGC0ijXwu04kC1pYiCFzTpB3UIZjm5oM7OTync1aQ3mGTj1oCciSPA==}
     engines: {node: '>= 18'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@lancedb/lancedb-win32-arm64-msvc@0.26.2':
     resolution: {integrity: sha512-//tZDPitm2PxNvalHP+m+Pf6VvFAeQgcht1+HJnutjH4gp6xYW6ynQlWWFDBmz9WRkUT+mXu2O4FUIhbdNaJSQ==}
@@ -828,6 +836,7 @@ packages:
   '@lancedb/lancedb@0.26.2':
     resolution: {integrity: sha512-umk4WMCTwJntLquwvUbpqE+TXREolcQVL9MHcxr8EhRjsha88+ATJ4QuS/hpyiE1CG3R/XcgrMgJAGkziPC/gA==}
     engines: {node: '>= 18'}
+    cpu: [x64, arm64]
     os: [darwin, linux, win32]
     peerDependencies:
       apache-arrow: '>=15.0.0 <=18.1.0'
@@ -838,8 +847,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.1':
-    resolution: {integrity: sha512-3l6F7eOm3qWJ9UTpOwIA6gzxD5y6wXqLEVlWXNrqez3qwjn+bhfvMEE4c10AD9ddXVbsDfBhMN+3+9yKELKflQ==}
+  '@mmnto/strategy-doctrine@0.1.2':
+    resolution: {integrity: sha512-e6Aha7biSWBWR4nRAo8F5iYdFFajK9QOt7YMp6zWrjy5rWgTPmoMFrtXZynnq6GNm2B8T4gVRYsWLMeWfoktqg==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -931,66 +940,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -3657,7 +3679,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.1':
+  '@mmnto/strategy-doctrine@0.1.2':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,9 @@ allowBuilds:
   'tree-sitter-javascript': true
   'tree-sitter-typescript': true
 
-minimumReleaseAge: 1d
+# Minutes (pnpm 11.2.2 multiplies this raw — a duration string like `1d` yields
+# NaN → Invalid Date → "Invalid time value" crash on any resolving install).
+minimumReleaseAge: 1440
 # Cohort packages publish-then-install in the same CI window by design.
 minimumReleaseAgeExclude:
   - '@mmnto/*'


### PR DESCRIPTION
## What

Housekeeping batch, three commits:

1. **`@mmnto/strategy-doctrine` 0.1.1 → 0.1.2** (root `optionalDependencies` + lockfile) — the 0.1.2 snapshot carries the strategy#545 `parity-manifest-currency` flip (`manual-attestation` → `version-pinned`, PR strategy#562). Reconcile requested in the strategy-claude 2026-06-07T0205Z dispatch.
2. **`pnpm-workspace.yaml` `minimumReleaseAge: 1d` → `1440`** — pnpm takes this in **minutes as a bare number**; 11.2.2 multiplies the value raw, so the duration string (introduced in #2023) computed a `NaN` cutoff (Invalid Date) and crashed **every resolving install** with `pnpm: Invalid time value`. It hid for two weeks behind frozen-lockfile CI (never constructs the cutoff) and the global pnpm 9 (ignores the key); today''s corepack-pnpm-11 resolving install was the first execution of the line. The supply-chain gate now actually works.
3. **11 stranded lesson files + compile-manifest refresh** — ten MCP-added lessons accumulated untracked since 2026-05-31, plus the new minimumReleaseAge-unit trap lesson; recompile yields 483 rules (manifest `5dca0066` → `ecac4018`).

## Sensor verification (honest result)

`totem doctor --parity` after the bump: the doctrine row **does** route through the version-pinned path now (the manual-attestation INFO is gone) — but it verdicts `SKIP — cohort floor for @mmnto/strategy-doctrine not locally determinable` rather than `pass`, because `resolveCohortFloor` only probes self-in-tree + the `../totem` sibling, never the canonical-source repo for strategy-published packages. Follow-ons filed, not in this PR:

- #2108 — floor resolution for strategy-published packages (the SKIP-not-PASS gap)
- #2107 — doctor-side `strategy-doctrine.lock` content-drift reader (the strategy#545 TODO, byte-for-byte normalization constraint recorded)

## Verification

- `corepack pnpm install` green under the pinned engine (pnpm 11.2.2); installed `@mmnto/strategy-doctrine@0.1.2` confirmed on disk + both lockfile entries.
- `pnpm run format:check` clean · full-branch `totem lint --base main` PASS (387 rules, 0 violations) · `totem review --base main` deterministic fast-path (all non-code).

Refs: strategy#545 · strategy#562 · Proposal 292 §10.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)