### PR TITLE
feat(orchestrator): grounded single-run artifact + rerun/compare primitives (#2100)

### DIFF
--- a/.changeset/grounded-run-artifacts.md
+++ b/.changeset/grounded-run-artifacts.md
@@ -1,0 +1,10 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+---
+
+feat(orchestrator): grounded single-run artifact + rerun/compare primitives (#2100, strategy#474 slice 1)
+
+Every opted-in orchestrator run (spec + review standard verdict, always-on) now emits an immutable, content-addressed JSON record under `.totem/artifacts/runs/<sha256>.json`: the post-DLP masked prompt bundle, grounding hash + provenance summary (`similarity-only` wholesale in this slice), the RESOLVED backend (post quota-fallback) with admission class, and the output + metrics. Response-cache hits emit nothing — artifacts record actual invokes. Emission is strictly additive (`runOrchestrator` return contract unchanged; non-opted callers byte-identical) and never fails the run.
+
+New primitives + thin verbs: `totem artifact rerun <hash>` re-invokes the exact stored bundle against the recorded backend (bypassing retrieval AND the response cache) and appends a new record; `totem artifact compare <a> <b>` returns a deterministic structural diff (equality flags, content hashes, numeric metric deltas — no similarity scoring). Core exports `RunArtifactSchema` with a version-tolerant reader (accepts any 1.x; migration-on-read registry for majors) so the accumulated fixture corpus survives schema evolution.

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,9 @@ packages/pack-rust-architecture/tree-sitter-rust.wasm
 .totem/sync.lock
 .totem/temp/
 .totem/cache/
+# Grounded run artifacts (mmnto-ai/totem#2100) — machine-local run records,
+# content-addressed, carry prompt content; never tracked.
+.totem/artifacts/
 .totem/secrets.json
 .totem/*.log
 .totem/*.jsonl

--- a/.totem/compile-manifest.json
+++ b/.totem/compile-manifest.json
@@ -1,7 +1,7 @@
 {
-  "compiled_at": "2026-06-07T03:17:56.149Z",
+  "compiled_at": "2026-06-07T18:53:02.176Z",
   "model": "gemini-3-flash-preview",
-  "input_hash": "5dca0066ae548503467cafc2167334a53b7458ee5fd9532126f211188dc44f7b",
+  "input_hash": "f9ffde8312d435476469de35f2d3b5f06c39888b9b3420903dc8bdd771f9bd1c",
   "output_hash": "0758d6fe3ec8bb6d70682a812a1e8ac55572a3f6a4a5bdcc16d1ace52c0faa8f",
   "rule_count": 483
 }

--- a/.totem/compile-manifest.json
+++ b/.totem/compile-manifest.json
@@ -1,7 +1,7 @@
 {
-  "compiled_at": "2026-06-07T02:04:56.853Z",
+  "compiled_at": "2026-06-07T03:17:56.149Z",
   "model": "gemini-3-flash-preview",
   "input_hash": "5dca0066ae548503467cafc2167334a53b7458ee5fd9532126f211188dc44f7b",
-  "output_hash": "ecac4018c302c7bfca2dd12195333c3b6b6bdadfda575ffb51d7a9b26285c2a5",
+  "output_hash": "0758d6fe3ec8bb6d70682a812a1e8ac55572a3f6a4a5bdcc16d1ace52c0faa8f",
   "rule_count": 483
 }

--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -8563,22 +8563,22 @@
     {
       "lessonHash": "839aceddfb699160",
       "lessonHeading": "a config line CI never executes is unverified, no matter",
+      "pattern": "minimumReleaseAge\\s*:\\s*['\"]?\\d+[a-zA-Z]+['\"]?",
       "message": "pnpm minimumReleaseAge takes a bare number (minutes), not a duration string like '1d'. A string value causes NaN arithmetic and crashes every resolving install with 'Invalid time value'.",
       "engine": "regex",
-      "severity": "error",
-      "pattern": "minimumReleaseAge\\s*:\\s*['\"]?\\d+[a-zA-Z]+['\"]?",
+      "badExample": "minimumReleaseAge: '1d'",
+      "goodExample": "minimumReleaseAge: 1440 # 1 day in minutes",
       "compiledAt": "2026-06-07T02:04:45.430Z",
       "createdAt": "2026-06-07T02:04:45.430Z",
       "fileGlobs": [
         "**/pnpm-workspace.yaml",
         "**/.npmrc"
       ],
-      "badExample": "minimumReleaseAge: '1d'",
-      "goodExample": "minimumReleaseAge: 1440 # 1 day in minutes",
-      "unverified": true,
+      "severity": "error",
       "status": "archived",
+      "archivedReason": "Stage 4 (mmnto-ai/totem#1682): pattern fired on 1 file(s) in the verification baseline (test files, fixture directories, or files outside fileGlobs scope) — over-broad. Offending paths: packages/cli/CHANGELOG.md. reasonCode: stage4-out-of-scope-match.",
       "archivedAt": "2026-06-07T02:04:45.798Z",
-      "archivedReason": "Stage 4 (mmnto-ai/totem#1682): pattern fired on 1 file(s) in the verification baseline (test files, fixture directories, or files outside fileGlobs scope) — over-broad. Offending paths: packages/cli/CHANGELOG.md. reasonCode: stage4-out-of-scope-match."
+      "unverified": true
     }
   ],
   "nonCompilable": [
@@ -14326,6 +14326,24 @@
       "title": "Use optionalDependencies for restricted CI packages",
       "reasonCode": "context-required",
       "reason": "Lesson describes a package.json structural placement rule: a specific package must appear under 'optionalDependencies' rather than 'dependencies' or 'devDependencies'. Detecting which packages are 'restricted/private' requires knowledge of the registry auth context or a known list of private package names — neither of which can be expressed as a general pattern without producing massive false positives on legitimate devDependencies."
+    },
+    {
+      "hash": "8fc9518536623e49",
+      "title": "Filter rule verification by fileGlobs",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes a procedural/architectural requirement for a verification pipeline (filtering matches by fileGlobs before archiving), not a detectable code pattern in source files."
+    },
+    {
+      "hash": "611db5dd48f97f8d",
+      "title": "Guard git refs against flag injection",
+      "reasonCode": "context-required",
+      "reason": "Lesson requires knowing which arguments are user-provided git refs and whether they are preceded by a '--' separator; a pattern cannot distinguish a guarded ref (preceded by '--') from an unguarded one without tracking argument position and the presence of the '--' sentinel across the call site."
+    },
+    {
+      "hash": "0926b8e544f13624",
+      "title": "Include all bot IDs in triage parsers",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes a completeness requirement (all active bot IDs must be present in a list), which requires semantic knowledge of which bots are currently active. No pattern can detect a missing entry in an enumeration without knowing the ground-truth set of required values."
     }
   ]
 }

--- a/.totem/lessons/lesson-1fa69571.md
+++ b/.totem/lessons/lesson-1fa69571.md
@@ -1,0 +1,6 @@
+## Lesson — Filter rule verification by fileGlobs
+
+**Tags:** linting, tooling, architecture
+**Scope:** .totem/compiled-rules.json
+
+Verification stages must filter codebase matches against a rule's `fileGlobs` before archiving for over-breadth to avoid false positives from historical mentions in changelogs or documentation.

--- a/.totem/lessons/lesson-d3f5aeaa.md
+++ b/.totem/lessons/lesson-d3f5aeaa.md
@@ -1,0 +1,6 @@
+## Lesson — Include all bot IDs in triage parsers
+
+**Tags:** dx, tooling, github-actions
+**Scope:** packages/cli/src/parsers/bot-review-parser.ts
+
+Triage and review parsing tools must explicitly include all active bot identifiers (e.g., `greptile-apps[bot]`) to prevent critical feedback from being silently ignored by automation.

--- a/.totem/specs/2100.md
+++ b/.totem/specs/2100.md
@@ -1,0 +1,206 @@
+### Problem Statement
+
+We need to emit a deterministic, content-addressed JSON artifact for every orchestrator run under `.totem/artifacts/` that captures the exact inputs, grounding provenance, backend configuration, and execution outputs. This immutable record will serve as the foundation for exact reruns (preventing silent context drift) and output comparisons across different models or prompts.
+
+### Architectural Context
+
+From the Totem Reliability Model: The system strictly separates the "Deterministic Substrate" from non-deterministic LLM execution. The orchestrator artifact acts as the immutable bridge between these layers, providing a verifiable, offline record of exactly what was sent to the non-deterministic provider and what was returned. Any schema changes to this artifact post-Phase 2 will be expensive, so it must be aggressively versioned (`schemaVersion`) and strictly validated via Zod.
+
+### Files to Examine
+
+1. `packages/cli/src/utils.ts` — Contains `runOrchestrator`. We will need to wrap or extend this to capture the required inputs, intercept the `OrchestratorResult`, and emit the artifact.
+2. `packages/core/src/types.ts` (or equivalent core types file) — To review existing `OrchestratorResult` types so we can accurately map its metrics (tokens, duration, finish reason) into the new artifact schema.
+
+### Technical Approach & Contracts
+
+We will implement an immutable run ledger stored in `.totem/artifacts/runs/`. Artifact filenames will be the SHA-256 hash of their contents to guarantee content-addressability.
+
+**Data Contracts:**
+Create `packages/core/src/artifacts/schema.ts`:
+
+```typescript
+import { z } from 'zod';
+
+export const BackendConfigSchema = z.object({
+  identity: z.string(),
+  admissionClass: z.enum(['completion_only', 'self_grounding_agent']),
+  taskProfile: z.string(),
+  model: z.string(),
+  provider: z.string(),
+  temperature: z.number(),
+});
+
+export const RunArtifactSchema = z.object({
+  schemaVersion: z.literal('1.0.0'),
+  inputBundle: z.object({
+    prompt: z.string(),
+    diffScope: z.string().optional(), // From lint/review --branch
+    retrievedContext: z.string().optional(),
+    specContract: z.string().optional(),
+  }),
+  inputHash: z.string(),
+  grounding: z.object({
+    hash: z.string(),
+    provenanceSummary: z.string(), // Day-one requirement (e.g., "similarity-only")
+  }),
+  backend: BackendConfigSchema,
+  output: z.object({
+    raw: z.string(),
+    parsedResult: z.unknown().optional(), // Pluggable parse shape
+    metrics: z.object({
+      promptTokens: z.number().optional(),
+      completionTokens: z.number().optional(),
+      durationMs: z.number(),
+      finishReason: z.string().optional(),
+    }),
+  }),
+});
+
+export type RunArtifact = z.infer<typeof RunArtifactSchema>;
+```
+
+**Workflow:**
+
+1. **Emit:** After `runOrchestrator` completes, stringify the `inputBundle` deterministically, hash it for `inputHash`. Do the same for grounding context. Assemble the full `RunArtifact` object. Deterministically stringify the full object, calculate its SHA-256 hash, and write it to `.totem/artifacts/runs/<hash>.json`.
+2. **Rerun:** Expose a `rerunArtifact(hash)` primitive that uses the Shared Helper `readJsonSafe` to load the artifact, extracts the exact `inputBundle` and `backend` config, and executes a new run WITHOUT fetching new context (guaranteeing no drift).
+3. **Compare:** Expose a `compareArtifacts(hashA, hashB)` primitive that loads two artifacts and returns a structured diff of their outputs and metrics.
+
+### Edge Cases & Traps
+
+- **JSON Key Ordering for Hashing:** Node's `JSON.stringify` does not guarantee key order. Hashing the raw object directly can result in different hashes for identical logical payloads. We MUST use a deterministic JSON stringify approach (e.g., sorting keys recursively) before generating the SHA-256 hash.
+- **`.gitignore` Leakage:** The `.totem/artifacts/` directory will grow unbounded. The init/scaffold process must ensure `.totem/artifacts/` is added to the consumer project's `.gitignore`.
+- **Date/Time Non-Determinism:** Do not include execution timestamps in the top-level hash payload if you want exact identical runs to map to the same artifact. If identical runs should produce the _same_ artifact hash (deduplication), exclude timestamps. Recommendation: Exclude execution timestamps from the hashable payload to allow native deduplication.
+- **Rerun Context Leakage:** When rerunning from an artifact, the system must strictly bypass the live context retrieval pipeline. If the retrieval pipeline is accidentally invoked, silent context drift occurs, violating the core constraint of the rerun primitive.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Define Artifact Contracts and Hash Utility**
+  - Create `packages/core/src/artifacts/schema.ts` with the Zod schemas defined above.
+  - Create `packages/core/src/artifacts/hash.ts` with a deterministic JSON stringification and SHA-256 hashing function (`calculateDeterministicHash(obj: unknown)`).
+    > TEST DIRECTIVE: Before implementing, write a failing test named `guarantees identical hashes for objects with different key insertion orders` that proves the hash function is deterministic.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Implement Artifact Storage Service**
+  - Create `packages/core/src/artifacts/storage.ts` exporting `saveRunArtifact(artifact: RunArtifact): string` and `loadRunArtifact(hash: string): RunArtifact`.
+  - Use Node `fs` for saving to `.totem/artifacts/runs/`.
+  - **MANDATORY**: Use the Shared Helper `readJsonSafe(filePath, RunArtifactSchema)` for loading.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `rejects loading corrupted or invalid schema artifacts` using an intentionally malformed JSON file.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Instrument Orchestrator to Emit Artifacts**
+  - Modify `packages/cli/src/utils.ts` (in or around `runOrchestrator`).
+  - Upon successful backend completion, construct the `RunArtifact` payload.
+  - Call `saveRunArtifact` and return the `hash` alongside the existing `OrchestratorResult`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `emits content-addressed artifact with valid schema after successful orchestrator run` that mocks the backend and verifies file creation.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Implement Rerun Primitive**
+  - Create `packages/cli/src/orchestrator/rerun.ts` exporting `rerunArtifact(hash: string)`.
+  - The function must load the artifact via `loadRunArtifact`, extract the `inputBundle`, and directly invoke the backend completion logic _bypassing_ all live retrieval steps.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `rerun executes using strictly cached bundle inputs without triggering retrieval` that spies on the retrieval module to ensure it is never called.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 5: Implement Compare Primitive**
+  - Create `packages/cli/src/orchestrator/compare.ts` exporting `compareArtifacts(hashA: string, hashB: string)`.
+  - Return an object detailing the delta: `backendDiff`, `outputDiff` (string similarity or basic boolean match), and `metricsDiff` (token/duration delta).
+    > TEST DIRECTIVE: Before implementing, write a failing test named `generates structural diff between two distinct artifact hashes` that compares two known mock artifacts.
+  - write test → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Hashing Determinism:** Create two JSON objects with identical data but jumbled key order. Assert `calculateDeterministicHash` returns the exact same string.
+- **Append-Only / Deduplication:** Run the orchestrator twice with the exact same prompt, diff, and temperature. Assert that the exact same artifact hash is generated and the file write is safely idempotent.
+- **Schema Enforcement:** Attempt to load a `.totem/artifacts/runs/<hash>.json` file that is missing `schemaVersion` or has `schemaVersion: "0.9.0"`. Assert `readJsonSafe` throws a validation error.
+- **Rerun Isolation:** Execute a rerun using a mocked orchestrator. Assert that the `inputBundle` from the artifact is perfectly reconstructed and passed to the backend, and that the retrieval service mock reports 0 invocations.
+
+## Implementation Design
+
+> Grounded against actual code 2026-06-07 (the generated spec above diverges from
+> code reality in three places — corrected here; see "Spec corrections").
+
+### Spec corrections (verified against source)
+
+1. **`runOrchestrator` (`packages/cli/src/utils.ts:411`) returns `Promise<string | undefined>`, NOT `OrchestratorResult`.** The `OrchestratorResult` (tokens/duration/finishReason) is consumed _inside_ the function. Task 3's "return the hash alongside the existing OrchestratorResult" would change the return contract for all 12 call sites — forbidden by the #2106 constraint (additive-with-defaults; spec/review migrate first, every other caller compiles untouched). Emission must hook _inside_ `runOrchestrator`, where result, post-fallback `qualifiedModel`, and the DLP-masked prompt are all in scope.
+2. **DLP:** the artifact must record `safePrompt`/`safeSystemPrompt` (post-`maskSecrets`, utils.ts:531) — what was actually sent — never the raw prompt. The generated spec misses this; recording raw would persist secrets to disk.
+3. **Response cache (utils.ts:494–511):** a cache HIT short-circuits before `invoke` — no metrics exist, nothing ran. Cache hits emit NO artifact, and the rerun primitive must bypass the response cache (a "rerun" that replays the cache is silent drift — the same trap class as live-retrieval leakage).
+4. Verified-correct claims: `readJsonSafe(filePath, schema?)` exists at `packages/core/src/sys/fs.ts:12` (Zod-aware) ✓; `totem review` routes to `shieldCommand` (`index.ts:493` → `shield.ts`), so slice-1 migration targets are `spec.ts` + `shield.ts`, both existing `runOrchestrator` callers ✓.
+
+### Scope (2 sentences)
+
+Emit an immutable, content-addressed run artifact from inside `runOrchestrator` for opted-in callers (`spec.ts` + `shield.ts` in this slice), plus library primitives `rerunArtifact(hash)` / `compareArtifacts(a, b)` with thin CLI verbs. NOT in scope: backend admission classes beyond recording the constant (`#2102`), real grounding provenance classes (`#2101` — this slice records `'similarity-only'` wholesale), structural post-checks (`#2103`), panel synthesis (`#2104`), any ledger/disposition semantics (Phase 2), and NO change to the `runOrchestrator` return type or any non-opted caller.
+
+### Data model deltas
+
+| New                                                                          | What it holds                                                                                                                                                                                                                                                                                                                                                                                                                                                    | Writes                              | Reads                                         | Invariants                                                                                                                |
+| ---------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- | --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `RunArtifactSchema` (Zod, `packages/core/src/artifacts/schema.ts`)           | `schemaVersion` (semver string, written as `1.0.0`; see evolution policy below); `inputBundle` {maskedPrompt, maskedSystemPrompt?, diffScope?, specContract?}; `inputHash`; `grounding` {hash, provenanceSummary}; `backend` {provider, model, qualifiedModel, admissionClass, taskProfile (= tag), temperature?}; `output` {content, metrics {inputTokens?, outputTokens?, cacheReadInputTokens?, durationMs, finishReason?}}; `createdAt` (excluded from hash) | cli emission point                  | rerun/compare, downstream slices              | All required unless `?`; core never imports cli — cli maps `OrchestratorResult` fields at the edge                        |
+| `opts.artifact?: ArtifactRequest` — additive field on `runOrchestrator` opts | caller-supplied bundle context: {diffScope?, specContract?, groundingHash, provenanceSummary, onEmitted?: (hash, path) => void}                                                                                                                                                                                                                                                                                                                                  | the 2 migrated callers              | `runOrchestrator` emission block              | `undefined` = today's behavior, byte-for-byte; return type unchanged                                                      |
+| `.totem/artifacts/runs/<hash>.json` store                                    | one immutable artifact per actual LLM invoke                                                                                                                                                                                                                                                                                                                                                                                                                     | `saveRunArtifact` (write-if-absent) | `loadRunArtifact` via `readJsonSafe` + schema | append-only: existing file is NEVER rewritten (same hash ⇒ same content by construction); dir gitignored                  |
+| `calculateDeterministicHash(obj)` (`packages/core/src/artifacts/hash.ts`)    | recursive key-sorted stringify → sha256 hex                                                                                                                                                                                                                                                                                                                                                                                                                      | —                                   | hashing inputBundle + content address         | content address computed over the artifact MINUS `createdAt` (dedup of identical runs; timestamps don't perturb identity) |
+
+No reserved keys, no sentinels. `provenanceSummary` is `z.string()` with a documented `'similarity-only'` constant — #2101 owns the class enum; an enum here would force a schema bump when it lands.
+
+**Schema-evolution policy (strategy review F1 — load-bearing).** The loader is version-tolerant within the major: `schemaVersion` validates as `^1\.` (not a `z.literal`), all post-1.0.0 fields are additive-optional, and `loadRunArtifact` carries a migration-on-read registry (empty at 1.0.0; a major bump REQUIRES a migration entry before the writer ships). Hard-reject only unknown majors / unparseable versions. Rationale: #2101's per-item provenance classes will bump the schema, and a hard `1.0.0` literal would orphan the accumulated eval-fixture corpus (the 2090/2091 exhibits) — an append-only ledger whose reader rejects its own history isn't append-only in practice.
+
+### State lifecycle
+
+- **Artifact files:** persistent, append-only. Created at successful `invoke` return (incl. quota-fallback success — recording the _resolved_ model); never mutated, never auto-deleted (growth bounded per-run, dir gitignored; pruning is a future verb, not this slice).
+- **`opts.artifact` request:** per-call, owned by the caller, consumed once inside `runOrchestrator` after the invoke completes. No cross-lifecycle state.
+- **No module-level state, no caches, no singletons.**
+
+### Failure modes
+
+| Failure                                                       | Category         | Agent-facing surface                                                         | Recovery                                                                                                                        |
+| ------------------------------------------------------------- | ---------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| Artifact dir create / file write fails                        | runtime          | `log.warn` (loud), run result still returned                                 | next run retries; Tenet-4 note: degradation is WARNED, never silent — and the run's primary output is not hostage to its ledger |
+| Emission requested but response-cache HIT                     | by design        | `log.dim` "cache hit — no artifact"                                          | run with `--fresh` to force an invoke                                                                                           |
+| `rerunArtifact`: hash not found                               | permanent        | hard `TotemParseError` (from `readJsonSafe`)                                 | operator supplies a valid hash (`totem artifact list`-style discovery deferred)                                                 |
+| `rerunArtifact`: unknown schemaVersion MAJOR (or unparseable) | permanent        | hard Zod validation error naming the version                                 | add the migration entry (writer-side bug — see evolution policy)                                                                |
+| `rerunArtifact`: known minor ≠ current                        | none (by design) | loads normally — additive-optional tolerance                                 | n/a (F1 policy)                                                                                                                 |
+| `rerunArtifact`: provider/quota failure                       | transient        | existing orchestrator error path, unchanged                                  | retry; rerun NEVER writes over the source artifact (new run = new artifact)                                                     |
+| `compareArtifacts`: either hash missing/invalid               | permanent        | hard error                                                                   | operator corrects                                                                                                               |
+| DLP mask fails before invoke                                  | runtime          | existing hard `TotemOrchestratorError` (unchanged) — no invoke ⇒ no artifact | fix and rerun                                                                                                                   |
+
+### Invariants to lock in via tests
+
+- Identical logical payloads with different key-insertion order hash identically.
+- An artifact emitted after a DLP redaction contains the MASKED prompt; the raw secret never reaches disk.
+- A response-cache hit emits no artifact; `rerunArtifact` performs zero response-cache reads and zero live-retrieval calls (spy: 0 invocations).
+- A non-opted `runOrchestrator` caller observes byte-identical behavior (return value, cache writes, telemetry) with the feature merged.
+- After a quota fallback, the artifact records the fallback `qualifiedModel`, not the requested one.
+- Emitting an artifact whose hash already exists leaves the existing file byte-identical (append-only).
+- Artifact-write failure surfaces a warning AND the caller still receives the run content.
+- A `1.0.0` artifact loads under a future `1.x` reader untouched (corpus survives minor bumps); an unknown-major artifact fails validation with the version named.
+- `compareArtifacts` output is a pure function of its two inputs — byte/structural equality and numeric metric deltas only, no similarity scoring (F3 / Tenet 9).
+
+### Review round (strategy-claude dispatch 2026-06-07T0253Z — design CONFORMS; three findings folded)
+
+- **F1 (load-bearing):** version-tolerant loading — folded into the schema-evolution policy above.
+- **F2:** the generated Test Plan's "run twice, assert same hash" dedup test is unrunnable as written against a live backend (a second run either response-cache-hits — no artifact, by this design — or re-invokes with nondeterministic output → different content address). It is valid ONLY under a deterministic mocked backend. **Where this Implementation Design and the generated sections above conflict, the Implementation Design supersedes.**
+- **F3:** `compareArtifacts` stays deterministic: structural/byte diff + numeric metrics delta ONLY. The generated spec's "string similarity" suggestion would sneak a scorer into the deterministic substrate (Tenet 9); semantic similarity is eval-harness territory (#2103+), never a core primitive.
+
+### Open questions — RESOLVED (operator rulings, satur8d, relayed via the 0253Z dispatch; settled)
+
+- **CLI verbs in-slice: GO** — thin `totem artifact rerun <hash>` / `totem artifact compare <a> <b>`, JSON output, no interactivity. (The #474 ruling titled the slice "run-artifact + rerun/compare"; sensors nobody can invoke don't get dogfooded.)
+- **Always-on emission for spec/review: GO** — a flag means fixtures exist only when remembered (Tenet 3).
+- **`admissionClass: 'completion_only'` constant: GO** — day-one self-description; #2102 only changes who supplies the value.

--- a/packages/cli/src/commands/artifact.ts
+++ b/packages/cli/src/commands/artifact.ts
@@ -3,12 +3,13 @@
  * verbs over the run-artifact primitives (mmnto-ai/totem#2100, operator
  * ruling: verbs ship in-slice — sensors nobody can invoke don't get
  * dogfooded). JSON to stdout, no interactivity; the primitives carry all the
- * semantics (`services/run-artifacts.ts`).
+ * semantics (`services/run-artifacts.ts`). Everything (including `node:path`)
+ * is lazy-imported per the CLI command-module contract.
  */
 
-import * as path from 'node:path';
-
 export async function artifactRerunCommand(hash: string): Promise<void> {
+  const path = await import('node:path');
+  const { sanitizeForTerminal } = await import('@mmnto/totem');
   const { log } = await import('../ui.js');
   const { loadConfig, loadEnv, resolveConfigPath, writeOutput } = await import('../utils.js');
   const { rerunArtifact } = await import('../services/run-artifacts.js');
@@ -19,7 +20,10 @@ export async function artifactRerunCommand(hash: string): Promise<void> {
   const config = await loadConfig(configPath);
   const configRoot = path.dirname(configPath);
 
-  log.info('Artifact', `Rerunning ${hash.slice(0, 12)}… with its recorded bundle + backend...`);
+  // Sanitize before logging — the hash is raw CLI input until loadRunArtifact
+  // gates it (CR review on #2114: terminal-escape injection).
+  const safeHashPreview = sanitizeForTerminal(hash).slice(0, 12);
+  log.info('Artifact', `Rerunning ${safeHashPreview}… with its recorded bundle + backend...`);
   const result = await rerunArtifact({ hash, config, cwd, configRoot });
   writeOutput(
     JSON.stringify(
@@ -31,6 +35,7 @@ export async function artifactRerunCommand(hash: string): Promise<void> {
 }
 
 export async function artifactCompareCommand(hashA: string, hashB: string): Promise<void> {
+  const path = await import('node:path');
   const { loadConfig, loadEnv, resolveConfigPath, writeOutput } = await import('../utils.js');
   const { compareArtifacts } = await import('../services/run-artifacts.js');
 

--- a/packages/cli/src/commands/artifact.ts
+++ b/packages/cli/src/commands/artifact.ts
@@ -1,0 +1,44 @@
+/**
+ * `totem artifact rerun <hash>` / `totem artifact compare <a> <b>` — thin CLI
+ * verbs over the run-artifact primitives (mmnto-ai/totem#2100, operator
+ * ruling: verbs ship in-slice — sensors nobody can invoke don't get
+ * dogfooded). JSON to stdout, no interactivity; the primitives carry all the
+ * semantics (`services/run-artifacts.ts`).
+ */
+
+import * as path from 'node:path';
+
+export async function artifactRerunCommand(hash: string): Promise<void> {
+  const { log } = await import('../ui.js');
+  const { loadConfig, loadEnv, resolveConfigPath, writeOutput } = await import('../utils.js');
+  const { rerunArtifact } = await import('../services/run-artifacts.js');
+
+  const cwd = process.cwd();
+  const configPath = resolveConfigPath(cwd);
+  loadEnv(cwd);
+  const config = await loadConfig(configPath);
+  const configRoot = path.dirname(configPath);
+
+  log.info('Artifact', `Rerunning ${hash.slice(0, 12)}… with its recorded bundle + backend...`);
+  const result = await rerunArtifact({ hash, config, cwd, configRoot });
+  writeOutput(
+    JSON.stringify(
+      { sourceHash: result.sourceHash, hash: result.hash, path: result.path },
+      null,
+      2,
+    ),
+  );
+}
+
+export async function artifactCompareCommand(hashA: string, hashB: string): Promise<void> {
+  const { loadConfig, loadEnv, resolveConfigPath, writeOutput } = await import('../utils.js');
+  const { compareArtifacts } = await import('../services/run-artifacts.js');
+
+  const cwd = process.cwd();
+  const configPath = resolveConfigPath(cwd);
+  loadEnv(cwd);
+  const config = await loadConfig(configPath);
+  const totemDirAbs = path.join(path.dirname(configPath), config.totemDir);
+
+  writeOutput(JSON.stringify(compareArtifacts(totemDirAbs, hashA, hashB), null, 2));
+}

--- a/packages/cli/src/commands/shield.ts
+++ b/packages/cli/src/commands/shield.ts
@@ -1360,6 +1360,10 @@ export async function shieldCommand(options: ShieldOptions): Promise<void> {
   );
   log.dim(DISPLAY_TAG, `Prompt: ${(prompt.length / 1024).toFixed(0)}KB`);
 
+  // Grounded run artifact (mmnto-ai/totem#2100): always-on for the standard
+  // review verdict path — every run is a future eval fixture. Wholesale
+  // similarity-only grounding hash in slice 1; per-item classes are #2101.
+  const { calculateDeterministicHash, PROVENANCE_SIMILARITY_ONLY } = await import('@mmnto/totem');
   const content = await runOrchestrator({
     prompt,
     tag: TAG,
@@ -1369,6 +1373,10 @@ export async function shieldCommand(options: ShieldOptions): Promise<void> {
     configRoot,
     totalResults,
     temperature: 0,
+    artifact: {
+      groundingHash: calculateDeterministicHash(context),
+      provenanceSummary: PROVENANCE_SIMILARITY_ONLY,
+    },
   });
   if (content != null) {
     await handleVerdictResult(content, diff, options, config, cwd, configRoot, 'standard');

--- a/packages/cli/src/commands/spec.ts
+++ b/packages/cli/src/commands/spec.ts
@@ -380,6 +380,11 @@ export async function specCommand(inputs: string[], options: SpecOptions): Promi
     options,
     config,
     cwd,
+    // Anchor cache + artifacts at the config dir, not the invocation cwd —
+    // without this, a `totem spec` from a subdirectory writes artifacts to
+    // `<cwd>/.totem/` where the `totem artifact` verbs (which resolve from
+    // the config path) can never find them (Greptile P1 on #2114).
+    configRoot: path.dirname(configPath),
     totalResults,
     artifact: {
       groundingHash: calculateDeterministicHash(context),

--- a/packages/cli/src/commands/spec.ts
+++ b/packages/cli/src/commands/spec.ts
@@ -370,7 +370,22 @@ export async function specCommand(inputs: string[], options: SpecOptions): Promi
   const prompt = await assemblePrompt(parsed, context, systemPrompt);
   log.dim(TAG, `Prompt: ${(prompt.length / 1024).toFixed(0)}KB`);
 
-  const content = await runOrchestrator({ prompt, tag: TAG, options, config, cwd, totalResults });
+  // Grounded run artifact (mmnto-ai/totem#2100): always-on for spec —
+  // every run is a future eval fixture. The grounding hash covers the
+  // retrieved context wholesale; per-item provenance classes are #2101.
+  const { calculateDeterministicHash, PROVENANCE_SIMILARITY_ONLY } = await import('@mmnto/totem');
+  const content = await runOrchestrator({
+    prompt,
+    tag: TAG,
+    options,
+    config,
+    cwd,
+    totalResults,
+    artifact: {
+      groundingHash: calculateDeterministicHash(context),
+      provenanceSummary: PROVENANCE_SIMILARITY_ONLY,
+    },
+  });
   if (content == null) return;
 
   if (options.stdout) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -527,6 +527,7 @@ artifactCommand
     try {
       const { artifactRerunCommand } = await import('./commands/artifact.js');
       await artifactRerunCommand(hash);
+      // totem-context: handleError is the CLI error boundary (returns `never` — prints + process.exit), identical to every sibling command action in this file; nothing is swallowed.
     } catch (err) {
       handleError(err);
     }
@@ -539,6 +540,7 @@ artifactCommand
     try {
       const { artifactCompareCommand } = await import('./commands/artifact.js');
       await artifactCompareCommand(hashA, hashB);
+      // totem-context: handleError is the CLI error boundary (returns `never` — prints + process.exit), identical to every sibling command action in this file; nothing is swallowed.
     } catch (err) {
       handleError(err);
     }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -512,6 +512,38 @@ reviewOptions(
   }
 });
 
+// Grounded run artifacts (mmnto-ai/totem#2100): thin verbs over the
+// rerun/compare primitives — JSON out, no interactivity.
+const artifactCommand = program
+  .command('artifact')
+  .description('Inspect grounded run artifacts (.totem/artifacts/runs/)');
+
+artifactCommand
+  .command('rerun <hash>')
+  .description(
+    'Re-invoke a recorded run with its exact stored bundle + backend (emits a new artifact)',
+  )
+  .action(async (hash: string) => {
+    try {
+      const { artifactRerunCommand } = await import('./commands/artifact.js');
+      await artifactRerunCommand(hash);
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
+artifactCommand
+  .command('compare <hashA> <hashB>')
+  .description('Deterministic artifact-vs-artifact diff (structural equality + metric deltas)')
+  .action(async (hashA: string, hashB: string) => {
+    try {
+      const { artifactCompareCommand } = await import('./commands/artifact.js');
+      await artifactCompareCommand(hashA, hashB);
+    } catch (err) {
+      handleError(err);
+    }
+  });
+
 program
   .command('triage-pr <pr-number>')
   .description('Categorized triage view of bot review comments on a PR')

--- a/packages/cli/src/services/run-artifacts.test.ts
+++ b/packages/cli/src/services/run-artifacts.test.ts
@@ -1,0 +1,170 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { RunArtifact, TotemConfig } from '@mmnto/totem';
+import { RUN_ARTIFACT_SCHEMA_VERSION, saveRunArtifact } from '@mmnto/totem';
+
+import { cleanTmpDir } from '../test-utils.js';
+
+// Partial-mock utils so rerunArtifact's delegation is observable without a
+// live backend. Everything else in utils stays real.
+vi.mock('../utils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils.js')>();
+  return { ...actual, runOrchestrator: vi.fn() };
+});
+
+import { runOrchestrator } from '../utils.js';
+import { compareRunArtifacts, rerunArtifact } from './run-artifacts.js';
+
+const mockedRunOrchestrator = vi.mocked(runOrchestrator);
+
+const NEW_HASH = 'f'.repeat(64);
+
+function artifact(overrides: Partial<RunArtifact> = {}): RunArtifact {
+  return {
+    schemaVersion: RUN_ARTIFACT_SCHEMA_VERSION,
+    inputBundle: { maskedPrompt: 'stored prompt', maskedSystemPrompt: 'stored system' },
+    inputHash: 'a'.repeat(64),
+    grounding: { hash: 'b'.repeat(64), provenanceSummary: 'similarity-only' },
+    backend: {
+      provider: 'gemini',
+      model: 'gemini-3.1-pro-preview',
+      qualifiedModel: 'gemini:gemini-3.1-pro-preview',
+      admissionClass: 'completion_only',
+      taskProfile: 'Spec',
+      temperature: 0,
+    },
+    output: { content: 'stored response', metrics: { durationMs: 1200, inputTokens: 80 } },
+    createdAt: '2026-06-07T03:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function config(overrides?: Partial<TotemConfig>): TotemConfig {
+  return {
+    targets: [{ glob: '**/*.ts', type: 'code', strategy: 'typescript-ast' }],
+    orchestrator: { provider: 'gemini', defaultModel: 'gemini-3-flash-preview' },
+    totemDir: '.totem',
+    lanceDir: '.lancedb',
+    ignorePatterns: [],
+    contextWarningThreshold: 40_000,
+    ...overrides,
+  } as TotemConfig;
+}
+
+describe('rerunArtifact', () => {
+  let tmpDir: string;
+  let sourceHash: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-rerun-'));
+    sourceHash = saveRunArtifact(path.join(tmpDir, '.totem'), artifact()).hash;
+    mockedRunOrchestrator.mockImplementation(async (opts) => {
+      // Simulate the emission seam: a real run records a NEW artifact.
+      opts.artifact?.onEmitted?.(NEW_HASH, `/runs/${NEW_HASH}.json`);
+      return 'rerun content';
+    });
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  it('re-invokes with the stored bundle verbatim — no retrieval, no response cache', async () => {
+    const result = await rerunArtifact({ hash: sourceHash, config: config(), cwd: tmpDir });
+
+    expect(mockedRunOrchestrator).toHaveBeenCalledTimes(1);
+    const call = mockedRunOrchestrator.mock.calls[0]![0];
+    expect(call.prompt).toBe('stored prompt'); // the EXACT stored bundle
+    expect(call.systemPrompt).toBe('stored system');
+    expect(call.options.fresh).toBe(true); // response cache bypassed — a cached replay is not a rerun
+    expect(call.options.model).toBe('gemini:gemini-3.1-pro-preview'); // resolved backend, not config default
+    expect(call.temperature).toBe(0);
+    expect(call.tag).toBe('Spec');
+    // Grounding identity carried verbatim — the rerun makes no new grounding claim.
+    expect(call.artifact).toMatchObject({
+      groundingHash: 'b'.repeat(64),
+      provenanceSummary: 'similarity-only',
+    });
+
+    expect(result.sourceHash).toBe(sourceHash);
+    expect(result.hash).toBe(NEW_HASH); // append-only: the rerun is a NEW record
+    expect(result.content).toBe('rerun content');
+  });
+
+  it('throws on a missing source hash without invoking anything', async () => {
+    await expect(
+      rerunArtifact({ hash: 'e'.repeat(64), config: config(), cwd: tmpDir }),
+    ).rejects.toThrow();
+    expect(mockedRunOrchestrator).not.toHaveBeenCalled();
+  });
+});
+
+describe('compareRunArtifacts', () => {
+  it('reports identical artifacts as identical with zero metric deltas', () => {
+    const cmp = compareRunArtifacts(artifact(), artifact());
+    expect(cmp.sameInput).toBe(true);
+    expect(cmp.sameGrounding).toBe(true);
+    expect(cmp.sameBackend).toBe(true);
+    expect(cmp.sameOutput).toBe(true);
+    expect(cmp.backendDelta).toEqual([]);
+    expect(cmp.metricsDelta.durationMs).toBe(0);
+  });
+
+  it('reports output divergence with content hashes, never similarity scores (F3)', () => {
+    const b = artifact({
+      output: { content: 'different response', metrics: { durationMs: 900, inputTokens: 90 } },
+    });
+    const cmp = compareRunArtifacts(artifact(), b);
+    expect(cmp.sameInput).toBe(true);
+    expect(cmp.sameOutput).toBe(false);
+    expect(cmp.outputDelta.contentHashA).toMatch(/^[0-9a-f]{64}$/);
+    expect(cmp.outputDelta.contentHashB).toMatch(/^[0-9a-f]{64}$/);
+    expect(cmp.outputDelta.contentHashA).not.toBe(cmp.outputDelta.contentHashB);
+    expect(cmp.metricsDelta.durationMs).toBe(-300); // b minus a
+    expect(cmp.metricsDelta.inputTokens).toBe(10);
+    // Deterministic-substrate discipline: no scorer fields of any kind.
+    expect(JSON.stringify(cmp)).not.toMatch(/similarity|score/i);
+  });
+
+  it('names every differing backend field', () => {
+    const b = artifact({
+      backend: {
+        provider: 'anthropic',
+        model: 'claude-opus-4-8',
+        qualifiedModel: 'anthropic:claude-opus-4-8',
+        admissionClass: 'completion_only',
+        taskProfile: 'Spec',
+        temperature: 0.7,
+      },
+    });
+    const cmp = compareRunArtifacts(artifact(), b);
+    expect(cmp.sameBackend).toBe(false);
+    expect(cmp.backendDelta).toEqual(
+      expect.arrayContaining(['provider', 'model', 'qualifiedModel', 'temperature']),
+    );
+    expect(cmp.backendDelta).not.toContain('taskProfile');
+  });
+
+  it('null token metrics yield null deltas (honest-absent, never NaN)', () => {
+    const a = artifact({
+      output: { content: 'x', metrics: { durationMs: 100, inputTokens: null } },
+    });
+    const b = artifact({
+      output: { content: 'x', metrics: { durationMs: 150, inputTokens: 80 } },
+    });
+    const cmp = compareRunArtifacts(a, b);
+    expect(cmp.metricsDelta.inputTokens).toBeNull();
+    expect(cmp.metricsDelta.durationMs).toBe(50);
+  });
+
+  it('is a pure function — same inputs, deep-equal output', () => {
+    const a = artifact();
+    const b = artifact({ output: { content: 'y', metrics: { durationMs: 1 } } });
+    expect(compareRunArtifacts(a, b)).toEqual(compareRunArtifacts(a, b));
+  });
+});

--- a/packages/cli/src/services/run-artifacts.ts
+++ b/packages/cli/src/services/run-artifacts.ts
@@ -19,7 +19,7 @@
 import * as path from 'node:path';
 
 import type { RunArtifact, TotemConfig } from '@mmnto/totem';
-import { calculateDeterministicHash, loadRunArtifact } from '@mmnto/totem';
+import { calculateDeterministicHash, loadRunArtifact, TotemOrchestratorError } from '@mmnto/totem';
 
 import { runOrchestrator } from '../utils.js';
 
@@ -91,8 +91,10 @@ export async function rerunArtifact(opts: RerunArtifactOptions): Promise<RerunAr
   if (content === undefined || emitted === undefined) {
     // --raw can't happen (we don't pass it), so this is an emission failure —
     // the rerun ran but its record didn't land. Loud, not a silent partial.
-    throw new Error(
-      `Rerun of ${opts.hash.slice(0, 12)}… completed but no artifact was recorded — see the emission warning above.`,
+    // TotemOrchestratorError per the CLI error taxonomy (GCA review on #2114).
+    throw new TotemOrchestratorError(
+      `Rerun of ${opts.hash.slice(0, 12)}… completed but no artifact was recorded.`,
+      'See the emission warning above for why the record did not land, then retry the rerun.',
     );
   }
 
@@ -147,6 +149,12 @@ function tokenDelta(a: number | null | undefined, b: number | null | undefined):
 export function compareRunArtifacts(a: RunArtifact, b: RunArtifact): RunArtifactComparison {
   const backendDelta = BACKEND_FIELDS.filter((field) => a.backend[field] !== b.backend[field]);
 
+  const sameOutput = a.output.content === b.output.content;
+  // Short-circuit the second sha256 pass when the contents are byte-identical
+  // (Greptile review on #2114) — the equal-outputs fast path is explicit.
+  const contentHashA = calculateDeterministicHash(a.output.content);
+  const contentHashB = sameOutput ? contentHashA : calculateDeterministicHash(b.output.content);
+
   return {
     sameInput: a.inputHash === b.inputHash,
     sameGrounding:
@@ -154,11 +162,8 @@ export function compareRunArtifacts(a: RunArtifact, b: RunArtifact): RunArtifact
       a.grounding.provenanceSummary === b.grounding.provenanceSummary,
     sameBackend: backendDelta.length === 0,
     backendDelta,
-    sameOutput: a.output.content === b.output.content,
-    outputDelta: {
-      contentHashA: calculateDeterministicHash(a.output.content),
-      contentHashB: calculateDeterministicHash(b.output.content),
-    },
+    sameOutput,
+    outputDelta: { contentHashA, contentHashB },
     metricsDelta: {
       durationMs: b.output.metrics.durationMs - a.output.metrics.durationMs,
       inputTokens: tokenDelta(a.output.metrics.inputTokens, b.output.metrics.inputTokens),

--- a/packages/cli/src/services/run-artifacts.ts
+++ b/packages/cli/src/services/run-artifacts.ts
@@ -1,0 +1,180 @@
+/**
+ * Rerun + compare primitives over grounded run artifacts
+ * (mmnto-ai/totem#2100, strategy#474 slice 1).
+ *
+ * - **Rerun = same immutable bundle.** `rerunArtifact` re-invokes the
+ *   recorded backend with the artifact's EXACT `inputBundle` — it never
+ *   touches live retrieval (it imports none) and forces `fresh: true` so the
+ *   response cache cannot replay a prior answer as if it were a new run.
+ *   The rerun emits a NEW artifact; the source record is never mutated.
+ *
+ * - **Compare = artifact-vs-artifact diff, deterministic only.** Structural
+ *   equality + content hashes + numeric metric deltas. Deliberately NO
+ *   similarity scoring of any kind (#2100 review F3 / Tenet 9) — a scorer in
+ *   the deterministic substrate would be an LLM-judge smuggled past the
+ *   admission contract. Semantic comparison is eval-harness territory
+ *   (#2103+), never a core primitive.
+ */
+
+import * as path from 'node:path';
+
+import type { RunArtifact, TotemConfig } from '@mmnto/totem';
+import { calculateDeterministicHash, loadRunArtifact } from '@mmnto/totem';
+
+import { runOrchestrator } from '../utils.js';
+
+// ─── Rerun ───────────────────────────────────────────────
+
+export interface RerunArtifactOptions {
+  /** Content address of the source artifact. */
+  hash: string;
+  config: TotemConfig;
+  cwd: string;
+  /** Directory containing totem.config.* — defaults to cwd (mirrors runOrchestrator). */
+  configRoot?: string;
+}
+
+export interface RerunArtifactResult {
+  /** The artifact the rerun replayed. */
+  sourceHash: string;
+  /** Content address of the NEW record the rerun emitted (append-only). */
+  hash: string;
+  /** Absolute path of the new record. */
+  path: string;
+  /** The rerun's response content. */
+  content: string;
+}
+
+/**
+ * Replay a recorded run against its recorded backend with zero input drift.
+ * Throws (via `loadRunArtifact`) before invoking anything when the source
+ * hash is missing or invalid.
+ */
+export async function rerunArtifact(opts: RerunArtifactOptions): Promise<RerunArtifactResult> {
+  const configRoot = opts.configRoot ?? opts.cwd;
+  const totemDirAbs = path.join(configRoot, opts.config.totemDir);
+  const source = loadRunArtifact(totemDirAbs, opts.hash);
+
+  let emitted: { hash: string; path: string } | undefined;
+  const content = await runOrchestrator({
+    prompt: source.inputBundle.maskedPrompt,
+    ...(source.inputBundle.maskedSystemPrompt !== undefined
+      ? { systemPrompt: source.inputBundle.maskedSystemPrompt }
+      : {}),
+    tag: source.backend.taskProfile,
+    // fresh: a response-cache replay is not a rerun (silent drift, same trap
+    // class as live-retrieval leakage). model: the RESOLVED backend recorded
+    // at emission, not whatever the config resolves to today.
+    options: { fresh: true, model: source.backend.qualifiedModel },
+    config: opts.config,
+    cwd: opts.cwd,
+    configRoot,
+    ...(source.backend.temperature !== undefined
+      ? { temperature: source.backend.temperature }
+      : {}),
+    artifact: {
+      // The rerun makes no new grounding claim — identity carried verbatim.
+      groundingHash: source.grounding.hash,
+      provenanceSummary: source.grounding.provenanceSummary,
+      ...(source.inputBundle.diffScope !== undefined
+        ? { diffScope: source.inputBundle.diffScope }
+        : {}),
+      ...(source.inputBundle.specContract !== undefined
+        ? { specContract: source.inputBundle.specContract }
+        : {}),
+      onEmitted: (hash, artifactPath) => {
+        emitted = { hash, path: artifactPath };
+      },
+    },
+  });
+
+  if (content === undefined || emitted === undefined) {
+    // --raw can't happen (we don't pass it), so this is an emission failure —
+    // the rerun ran but its record didn't land. Loud, not a silent partial.
+    throw new Error(
+      `Rerun of ${opts.hash.slice(0, 12)}… completed but no artifact was recorded — see the emission warning above.`,
+    );
+  }
+
+  return { sourceHash: opts.hash, hash: emitted.hash, path: emitted.path, content };
+}
+
+// ─── Compare ─────────────────────────────────────────────
+
+export interface RunArtifactComparison {
+  /** `inputHash` equality — same logical bundle in. */
+  sameInput: boolean;
+  /** Grounding hash + provenance equality. */
+  sameGrounding: boolean;
+  /** Backend identity equality across all recorded fields. */
+  sameBackend: boolean;
+  /** Backend field names that differ (empty when sameBackend). */
+  backendDelta: string[];
+  /** Byte equality of output content. */
+  sameOutput: boolean;
+  outputDelta: {
+    contentHashA: string;
+    contentHashB: string;
+  };
+  /** Numeric deltas, B minus A; null when either side did not report. */
+  metricsDelta: {
+    durationMs: number;
+    inputTokens: number | null;
+    outputTokens: number | null;
+  };
+}
+
+/** Backend fields compared one by one so the delta NAMES what changed. */
+const BACKEND_FIELDS = [
+  'provider',
+  'model',
+  'qualifiedModel',
+  'admissionClass',
+  'taskProfile',
+  'temperature',
+] as const;
+
+/** Numeric delta honoring honest-absent: null in, null out — never NaN. */
+function tokenDelta(a: number | null | undefined, b: number | null | undefined): number | null {
+  if (typeof a !== 'number' || typeof b !== 'number') return null;
+  return b - a;
+}
+
+/**
+ * Deterministic artifact-vs-artifact diff. Pure function of its two inputs —
+ * no I/O, no scoring, no randomness.
+ */
+export function compareRunArtifacts(a: RunArtifact, b: RunArtifact): RunArtifactComparison {
+  const backendDelta = BACKEND_FIELDS.filter((field) => a.backend[field] !== b.backend[field]);
+
+  return {
+    sameInput: a.inputHash === b.inputHash,
+    sameGrounding:
+      a.grounding.hash === b.grounding.hash &&
+      a.grounding.provenanceSummary === b.grounding.provenanceSummary,
+    sameBackend: backendDelta.length === 0,
+    backendDelta,
+    sameOutput: a.output.content === b.output.content,
+    outputDelta: {
+      contentHashA: calculateDeterministicHash(a.output.content),
+      contentHashB: calculateDeterministicHash(b.output.content),
+    },
+    metricsDelta: {
+      durationMs: b.output.metrics.durationMs - a.output.metrics.durationMs,
+      inputTokens: tokenDelta(a.output.metrics.inputTokens, b.output.metrics.inputTokens),
+      outputTokens: tokenDelta(a.output.metrics.outputTokens, b.output.metrics.outputTokens),
+    },
+  };
+}
+
+/** Load-then-compare convenience for the CLI verb. */
+export function compareArtifacts(
+  totemDirAbs: string,
+  hashA: string,
+  hashB: string,
+): RunArtifactComparison {
+  return compareRunArtifacts(
+    loadRunArtifact(totemDirAbs, hashA),
+    loadRunArtifact(totemDirAbs, hashB),
+  );
+}

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -6,6 +6,7 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { SearchResult, TotemConfig } from '@mmnto/totem';
+import { RunArtifactSchema } from '@mmnto/totem';
 
 import { cleanTmpDir } from './test-utils.js';
 import {
@@ -1190,5 +1191,193 @@ describe('formatLessonSection', () => {
     const result = formatLessonSection([makeLesson('Short', 'A tiny lesson')], undefined, true);
     expect(result).toContain('A tiny lesson');
     expect(result).not.toContain('...');
+  });
+});
+
+// ─── runOrchestrator artifact emission (mmnto-ai/totem#2100) ──
+
+describe('runOrchestrator artifact emission (#2100)', { timeout: 15_000 }, () => {
+  let tmpDir: string;
+
+  const GROUNDING_HASH = 'b'.repeat(64);
+
+  function artifactRequest(onEmitted?: (hash: string, artifactPath: string) => void) {
+    return {
+      groundingHash: GROUNDING_HASH,
+      provenanceSummary: 'similarity-only',
+      ...(onEmitted !== undefined ? { onEmitted } : {}),
+    };
+  }
+
+  function artifactConfig(overrides?: Partial<TotemConfig>): TotemConfig {
+    return {
+      targets: [{ glob: '**/*.ts', type: 'code', strategy: 'typescript-ast' }],
+      orchestrator: {
+        provider: 'gemini',
+        defaultModel: 'gemini-3-flash-preview',
+      },
+      totemDir: '.totem',
+      lanceDir: '.lancedb',
+      ignorePatterns: [],
+      contextWarningThreshold: 40_000,
+      ...overrides,
+    } as TotemConfig;
+  }
+
+  function runsDirPath(): string {
+    return path.join(tmpDir, '.totem', 'artifacts', 'runs');
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-artifact-emit-'));
+    vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+    const mockInvoke = vi.fn().mockResolvedValue({
+      content: 'mock result',
+      inputTokens: 100,
+      outputTokens: 50,
+      durationMs: 500,
+    });
+    mockedCreateOrchestrator.mockReturnValue(mockInvoke);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanTmpDir(tmpDir);
+  });
+
+  it('emits content-addressed artifact with valid schema after successful orchestrator run', async () => {
+    const emitted: Array<{ hash: string; artifactPath: string }> = [];
+    const result = await runOrchestrator({
+      prompt: 'test prompt',
+      tag: 'Spec',
+      options: { fresh: true },
+      config: artifactConfig(),
+      cwd: tmpDir,
+      artifact: artifactRequest((hash, artifactPath) => emitted.push({ hash, artifactPath })),
+    });
+
+    expect(result).toBe('mock result');
+    expect(emitted).toHaveLength(1);
+    const file = path.join(runsDirPath(), `${emitted[0]!.hash}.json`);
+    expect(emitted[0]!.artifactPath).toBe(file);
+    expect(fs.existsSync(file)).toBe(true);
+
+    const artifact = RunArtifactSchema.parse(JSON.parse(fs.readFileSync(file, 'utf-8')));
+    expect(artifact.inputBundle.maskedPrompt).toBe('test prompt');
+    expect(artifact.grounding).toEqual({
+      hash: GROUNDING_HASH,
+      provenanceSummary: 'similarity-only',
+    });
+    expect(artifact.backend.admissionClass).toBe('completion_only');
+    expect(artifact.backend.taskProfile).toBe('Spec');
+    expect(artifact.backend.provider).toBe('gemini');
+    expect(artifact.output.content).toBe('mock result');
+    expect(artifact.output.metrics).toMatchObject({
+      inputTokens: 100,
+      outputTokens: 50,
+      durationMs: 500,
+    });
+  });
+
+  it('records the MASKED prompt — a custom secret never reaches the artifact', async () => {
+    const secret = 'SUPER-SECRET-TOKEN-12345';
+    const emitted: string[] = [];
+    await runOrchestrator({
+      prompt: `deploy with ${secret} now`,
+      tag: 'Spec',
+      options: { fresh: true },
+      config: artifactConfig(),
+      cwd: tmpDir,
+      customSecrets: [{ type: 'literal', value: secret }],
+      artifact: artifactRequest((hash) => emitted.push(hash)),
+    });
+
+    const file = path.join(runsDirPath(), `${emitted[0]!}.json`);
+    const rawOnDisk = fs.readFileSync(file, 'utf-8');
+    expect(rawOnDisk).not.toContain(secret);
+    const artifact = RunArtifactSchema.parse(JSON.parse(rawOnDisk));
+    expect(artifact.inputBundle.maskedPrompt).not.toContain(secret);
+  });
+
+  it('a response-cache hit emits NO artifact (artifacts record actual invokes)', async () => {
+    const onEmitted = vi.fn();
+    const opts = {
+      prompt: 'cacheable prompt',
+      tag: 'Spec', // Spec carries a default response-cache TTL
+      options: {},
+      config: artifactConfig(),
+      cwd: tmpDir,
+      artifact: { ...artifactRequest(), onEmitted },
+    };
+    await runOrchestrator(opts);
+    expect(onEmitted).toHaveBeenCalledTimes(1);
+    expect(fs.readdirSync(runsDirPath())).toHaveLength(1);
+
+    await runOrchestrator(opts); // second run hits the response cache
+    expect(onEmitted).toHaveBeenCalledTimes(1); // unchanged
+    expect(fs.readdirSync(runsDirPath())).toHaveLength(1); // unchanged
+  });
+
+  it('a non-opted caller creates no artifacts directory (byte-identical behavior)', async () => {
+    const result = await runOrchestrator({
+      prompt: 'plain run',
+      tag: 'Spec',
+      options: { fresh: true },
+      config: artifactConfig(),
+      cwd: tmpDir,
+    });
+    expect(result).toBe('mock result');
+    expect(fs.existsSync(path.join(tmpDir, '.totem', 'artifacts'))).toBe(false);
+  });
+
+  it('an artifact write failure warns but never fails the run', async () => {
+    // Occupy the artifacts path with a FILE so mkdir of artifacts/runs throws.
+    fs.mkdirSync(path.join(tmpDir, '.totem'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, '.totem', 'artifacts'), 'not a directory');
+
+    const onEmitted = vi.fn();
+    const result = await runOrchestrator({
+      prompt: 'run whose ledger write fails',
+      tag: 'Spec',
+      options: { fresh: true },
+      config: artifactConfig(),
+      cwd: tmpDir,
+      artifact: { ...artifactRequest(), onEmitted },
+    });
+
+    expect(result).toBe('mock result'); // the run is not hostage to its ledger
+    expect(onEmitted).not.toHaveBeenCalled();
+  });
+
+  it('after a quota fallback the artifact records the RESOLVED model, not the requested one', async () => {
+    const quotaErr = new Error('429 quota exhausted');
+    quotaErr.name = 'QuotaError';
+    const mockInvoke = vi
+      .fn()
+      .mockRejectedValueOnce(quotaErr)
+      .mockResolvedValue({ content: 'fallback result', durationMs: 300 });
+    mockedCreateOrchestrator.mockReturnValue(mockInvoke);
+
+    const emitted: string[] = [];
+    await runOrchestrator({
+      prompt: 'quota-bound prompt',
+      tag: 'Spec',
+      options: { fresh: true },
+      config: artifactConfig({
+        orchestrator: {
+          provider: 'gemini',
+          defaultModel: 'gemini-3.1-pro-preview',
+          fallbackModel: 'gemini-3-flash-preview',
+        },
+      }),
+      cwd: tmpDir,
+      artifact: artifactRequest((hash) => emitted.push(hash)),
+    });
+
+    const file = path.join(runsDirPath(), `${emitted[0]!}.json`);
+    const artifact = RunArtifactSchema.parse(JSON.parse(fs.readFileSync(file, 'utf-8')));
+    expect(artifact.backend.qualifiedModel).toBe('gemini-3-flash-preview');
+    expect(artifact.output.content).toBe('fallback result');
   });
 });

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -5,10 +5,14 @@ import * as path from 'node:path';
 
 import dotenv from 'dotenv';
 
-import type { CustomSecret, SearchResult, TotemConfig } from '@mmnto/totem';
+import type { CustomSecret, RunArtifact, SearchResult, TotemConfig } from '@mmnto/totem';
 import {
+  ADMISSION_COMPLETION_ONLY,
+  calculateDeterministicHash,
   CONFIG_FILES,
   maskSecrets,
+  RUN_ARTIFACT_SCHEMA_VERSION,
+  saveRunArtifact,
   TotemConfigError,
   TotemConfigSchema,
   TotemOrchestratorError,
@@ -401,6 +405,30 @@ function buildResponseCacheHash(
 }
 
 /**
+ * Caller-supplied context for grounded run-artifact emission
+ * (mmnto-ai/totem#2100). STRICTLY additive: callers that omit `artifact`
+ * observe byte-identical `runOrchestrator` behavior — the #2106 constraint
+ * (12 call sites compile untouched; spec/review migrate first).
+ *
+ * The caller supplies what only it knows (its grounding context + how that
+ * context was assembled); `runOrchestrator` supplies what only IT knows (the
+ * post-DLP masked prompt, the post-quota-fallback resolved backend, the
+ * `OrchestratorResult` metrics that never leave this function).
+ */
+export interface RunArtifactRequest {
+  /** Deterministic hash of the grounding context the caller assembled (sha256 hex). */
+  groundingHash: string;
+  /** What KIND of grounding — slice 1 passes `PROVENANCE_SIMILARITY_ONLY` wholesale. */
+  provenanceSummary: string;
+  /** Deterministic diff input when the run was scoped (`lint/review --branch`, #2098). */
+  diffScope?: string;
+  /** The grounded spec contract, when the run senses against one. */
+  specContract?: string;
+  /** Fires after a successful write (or dedup hit) with the content address + path. */
+  onEmitted?: (hash: string, artifactPath: string) => void;
+}
+
+/**
  * Validate orchestrator config, then either output raw context (--raw) or
  * invoke the configured orchestrator provider and return the LLM content.
  *
@@ -428,6 +456,13 @@ export async function runOrchestrator(opts: {
   temperature?: number;
   /** User-defined custom secrets to redact via DLP before outbound LLM calls (#921). */
   customSecrets?: CustomSecret[];
+  /**
+   * Opt-in grounded run-artifact emission (mmnto-ai/totem#2100). When set, a
+   * successful ACTUAL invoke (never a response-cache hit) appends an immutable
+   * content-addressed record under `<totemDir>/artifacts/runs/`. Emission
+   * failure warns and never fails the run. Omitted = today's behavior.
+   */
+  artifact?: RunArtifactRequest;
 }): Promise<string | undefined> {
   const { prompt, systemPrompt, tag, options, config, cwd } = opts;
   const configRoot = opts.configRoot ?? cwd;
@@ -502,6 +537,12 @@ export async function runOrchestrator(opts: {
         const ageMs = Date.now() - cacheData.timestamp;
         if (ageMs < ttlSeconds * 1000) {
           log.dim(tag, `Result loaded from cache (TTL: ${ttlSeconds}s)`);
+          if (opts.artifact !== undefined) {
+            // mmnto-ai/totem#2100: artifacts record ACTUAL invokes. A cached
+            // response is a replay of an already-recorded run, not new ground
+            // truth — emitting here would forge a run that never happened.
+            log.dim(tag, 'Response cache hit — no run artifact emitted.');
+          }
           return cacheData.content;
         }
       } catch {
@@ -638,6 +679,72 @@ export async function runOrchestrator(opts: {
       );
     } catch {
       // Ignore cache write errors
+    }
+  }
+
+  // ── Grounded run-artifact emission (mmnto-ai/totem#2100) ──
+  // Placed AFTER the invoke + quota-fallback resolution so the record carries
+  // the RESOLVED backend (qualifiedModel reflects any fallback) and the
+  // MASKED prompt (what actually crossed the wire — raw would persist
+  // secrets to disk). Failure warns and never fails the run: the run's
+  // primary output is not hostage to its ledger (Tenet-4-compliant — the
+  // degradation is warned, never silent).
+  if (opts.artifact !== undefined) {
+    try {
+      const inputBundle = {
+        maskedPrompt: safePrompt,
+        ...(safeSystemPrompt !== undefined && safeSystemPrompt.length > 0
+          ? { maskedSystemPrompt: safeSystemPrompt }
+          : {}),
+        ...(opts.artifact.diffScope !== undefined ? { diffScope: opts.artifact.diffScope } : {}),
+        ...(opts.artifact.specContract !== undefined
+          ? { specContract: opts.artifact.specContract }
+          : {}),
+      };
+      const runArtifact: RunArtifact = {
+        schemaVersion: RUN_ARTIFACT_SCHEMA_VERSION,
+        inputBundle,
+        inputHash: calculateDeterministicHash(inputBundle),
+        grounding: {
+          hash: opts.artifact.groundingHash,
+          provenanceSummary: opts.artifact.provenanceSummary,
+        },
+        backend: {
+          provider: resolved.parsed.provider,
+          model,
+          qualifiedModel,
+          // Constant in slice 1 — every runOrchestrator backend is factually
+          // completion-only today; #2102 (admission contract) changes who
+          // supplies this value, not the field.
+          admissionClass: ADMISSION_COMPLETION_ONLY,
+          taskProfile: tag,
+          ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+        },
+        output: {
+          content: result.content,
+          metrics: {
+            inputTokens: result.inputTokens,
+            outputTokens: result.outputTokens,
+            ...(result.cacheReadInputTokens !== undefined
+              ? { cacheReadInputTokens: result.cacheReadInputTokens }
+              : {}),
+            durationMs: result.durationMs,
+            ...(result.finishReason !== undefined ? { finishReason: result.finishReason } : {}),
+          },
+        },
+        createdAt: new Date().toISOString(),
+      };
+      const saved = saveRunArtifact(path.join(configRoot, config.totemDir), runArtifact);
+      log.dim(
+        tag,
+        `Run artifact ${saved.existed ? 'already recorded' : 'recorded'}: ${saved.hash.slice(0, 12)}…`,
+      );
+      opts.artifact.onEmitted?.(saved.hash, saved.path);
+    } catch (err) {
+      log.warn(
+        tag,
+        `Run artifact emission failed (run unaffected): ${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -740,6 +740,7 @@ export async function runOrchestrator(opts: {
         `Run artifact ${saved.existed ? 'already recorded' : 'recorded'}: ${saved.hash.slice(0, 12)}…`,
       );
       opts.artifact.onEmitted?.(saved.hash, saved.path);
+      // totem-context: by-design degrade per the #2100 failure table — the ledger write is observability; rethrowing would hold the run's PRIMARY output hostage to its record. The degradation is WARNED (Tenet-4-compliant), never silent.
     } catch (err) {
       log.warn(
         tag,

--- a/packages/core/src/artifacts/hash.test.ts
+++ b/packages/core/src/artifacts/hash.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { calculateDeterministicHash } from './hash.js';
+
+describe('calculateDeterministicHash', () => {
+  it('guarantees identical hashes for objects with different key insertion orders', () => {
+    const a = {
+      inputBundle: { maskedPrompt: 'p', diffScope: 'd' },
+      backend: { provider: 'gemini', model: 'm' },
+      schemaVersion: '1.0.0',
+    };
+    const b = {
+      schemaVersion: '1.0.0',
+      backend: { model: 'm', provider: 'gemini' },
+      inputBundle: { diffScope: 'd', maskedPrompt: 'p' },
+    };
+    expect(calculateDeterministicHash(a)).toBe(calculateDeterministicHash(b));
+  });
+
+  it('sorts keys recursively, not just at the top level', () => {
+    const a = { outer: { z: { b: 2, a: 1 }, y: [1, 2] } };
+    const b = { outer: { y: [1, 2], z: { a: 1, b: 2 } } };
+    expect(calculateDeterministicHash(a)).toBe(calculateDeterministicHash(b));
+  });
+
+  it('preserves array order as significant (reordered arrays hash differently)', () => {
+    expect(calculateDeterministicHash({ items: [1, 2] })).not.toBe(
+      calculateDeterministicHash({ items: [2, 1] }),
+    );
+  });
+
+  it('produces distinct hashes for distinct payloads', () => {
+    expect(calculateDeterministicHash({ a: 1 })).not.toBe(calculateDeterministicHash({ a: 2 }));
+  });
+
+  it('returns 64-char lowercase sha256 hex', () => {
+    expect(calculateDeterministicHash({ a: 1 })).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('treats null and absent fields as distinct payloads', () => {
+    expect(calculateDeterministicHash({ a: null })).not.toBe(calculateDeterministicHash({}));
+  });
+});

--- a/packages/core/src/artifacts/hash.ts
+++ b/packages/core/src/artifacts/hash.ts
@@ -1,0 +1,48 @@
+/**
+ * Deterministic content hashing for run artifacts (mmnto-ai/totem#2100).
+ *
+ * Node's `JSON.stringify` preserves key insertion order, so two logically
+ * identical payloads assembled in different orders would hash differently —
+ * breaking content-addressing and the identical-run dedup guarantee. This
+ * module canonicalizes (recursive key sort) BEFORE hashing so the content
+ * address is a pure function of the logical payload.
+ *
+ * Array order is deliberately significant — a reordered array is a different
+ * payload, not a different spelling of the same one.
+ *
+ * Scope: plain JSON data only (the artifact is Zod-validated JSON). Cyclic
+ * structures throw via `JSON.stringify` — an artifact can never be cyclic, so
+ * a cycle here is a caller bug, not an input class to tolerate.
+ */
+
+import * as crypto from 'node:crypto';
+
+/**
+ * Recursively rebuild a value with object keys in sorted order so the
+ * subsequent stringify is canonical. Arrays keep their element order;
+ * primitives (and null) pass through untouched.
+ */
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(canonicalize);
+  }
+  if (typeof value === 'object' && value !== null) {
+    const sorted: Record<string, unknown> = {};
+    for (const key of Object.keys(value).sort()) {
+      sorted[key] = canonicalize((value as Record<string, unknown>)[key]);
+    }
+    return sorted;
+  }
+  return value;
+}
+
+/**
+ * sha256 hex (full 64 chars) of the canonical (recursively key-sorted) JSON
+ * serialization of `payload`. The full digest — not a truncation — because
+ * the hash IS the artifact's filename / identity and must not invite
+ * collision shortcuts (contrast `hashManagedBlock`'s display-only 12 chars).
+ */
+export function calculateDeterministicHash(payload: unknown): string {
+  const canonical = JSON.stringify(canonicalize(payload));
+  return crypto.createHash('sha256').update(canonical, 'utf-8').digest('hex');
+}

--- a/packages/core/src/artifacts/schema.test.ts
+++ b/packages/core/src/artifacts/schema.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RunArtifact } from './schema.js';
+import { RUN_ARTIFACT_SCHEMA_VERSION, RunArtifactSchema } from './schema.js';
+
+/** A minimal valid artifact for mutation in each case. */
+function validArtifact(): RunArtifact {
+  return {
+    schemaVersion: RUN_ARTIFACT_SCHEMA_VERSION,
+    inputBundle: { maskedPrompt: 'prompt after DLP' },
+    inputHash: 'a'.repeat(64),
+    grounding: { hash: 'b'.repeat(64), provenanceSummary: 'similarity-only' },
+    backend: {
+      provider: 'gemini',
+      model: 'gemini-3.1-pro-preview',
+      qualifiedModel: 'gemini:gemini-3.1-pro-preview',
+      admissionClass: 'completion_only',
+      taskProfile: 'Spec',
+    },
+    output: { content: 'response', metrics: { durationMs: 1200 } },
+    createdAt: '2026-06-07T03:00:00.000Z',
+  };
+}
+
+describe('RunArtifactSchema', () => {
+  it('accepts a minimal valid 1.0.0 artifact', () => {
+    expect(RunArtifactSchema.parse(validArtifact())).toEqual(validArtifact());
+  });
+
+  it('accepts a future 1.x minor (corpus survives minor bumps — F1)', () => {
+    const future = { ...validArtifact(), schemaVersion: '1.4.2' };
+    expect(RunArtifactSchema.parse(future).schemaVersion).toBe('1.4.2');
+  });
+
+  it('rejects an unknown major, naming the version in the error', () => {
+    const v2 = { ...validArtifact(), schemaVersion: '2.0.0' };
+    const result = RunArtifactSchema.safeParse(v2);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues.map((i) => i.message).join('\n')).toContain('2.0.0');
+    }
+  });
+
+  it('rejects a missing required field (maskedPrompt)', () => {
+    const artifact = validArtifact();
+    const { maskedPrompt: _dropped, ...bundleWithout } = artifact.inputBundle;
+    expect(RunArtifactSchema.safeParse({ ...artifact, inputBundle: bundleWithout }).success).toBe(
+      false,
+    );
+  });
+
+  it('rejects an unknown admissionClass', () => {
+    const artifact = validArtifact();
+    const broken = {
+      ...artifact,
+      backend: { ...artifact.backend, admissionClass: 'agentic_swarm' },
+    };
+    expect(RunArtifactSchema.safeParse(broken).success).toBe(false);
+  });
+
+  it('accepts null token metrics (provider did not report)', () => {
+    const artifact = validArtifact();
+    artifact.output.metrics.inputTokens = null;
+    artifact.output.metrics.outputTokens = null;
+    expect(RunArtifactSchema.safeParse(artifact).success).toBe(true);
+  });
+});

--- a/packages/core/src/artifacts/schema.ts
+++ b/packages/core/src/artifacts/schema.ts
@@ -1,0 +1,125 @@
+/**
+ * Run-artifact contract for the grounded single-run ledger (mmnto-ai/totem#2100,
+ * strategy#474 slice 1).
+ *
+ * The artifact is the immutable bridge between the deterministic substrate and
+ * non-deterministic LLM execution: a verifiable, offline record of exactly what
+ * was sent (post-DLP — the MASKED prompt, never raw) and what came back.
+ * Everything downstream (post-checks #2103, panel synthesis #2104, the Phase-2
+ * disposition ledger) consumes this shape, so it stays minimal but versioned.
+ *
+ * Schema-evolution policy (strategy review F1 on the #2100 design, 0253Z
+ * dispatch): the reader is version-tolerant WITHIN the major —
+ *   - `schemaVersion` validates as `1.x` (never a literal pin),
+ *   - every post-1.0.0 field must be additive-optional,
+ *   - a MAJOR bump requires a migration entry in the loader before the writer
+ *     ships (`loadRunArtifact`'s migration-on-read registry).
+ * Hard-reject only unknown majors. Rationale: an append-only ledger whose
+ * reader rejects its own history isn't append-only in practice — a literal pin
+ * would orphan the accumulated eval-fixture corpus at #2101's first bump.
+ *
+ * Zod here is a system boundary (persisted JSON read back from disk), per the
+ * repo's Zod-at-boundaries-only rule.
+ */
+
+import { z } from 'zod';
+
+/** The schemaVersion WRITTEN by this code. Readers accept any 1.x (F1). */
+export const RUN_ARTIFACT_SCHEMA_VERSION = '1.0.0';
+
+/** The major this reader understands; other majors need a migration entry. */
+export const RUN_ARTIFACT_KNOWN_MAJOR = 1;
+
+/**
+ * Slice-1 wholesale provenance summary: the current ad-hoc context assembly is
+ * similarity-retrieved, and the bundle must say so from day one (the
+ * illusion-of-grounding trap cannot be retrofitted away). #2101 owns per-item
+ * provenance classes; this stays a free string so that lands without a major.
+ */
+export const PROVENANCE_SIMILARITY_ONLY = 'similarity-only';
+
+/**
+ * Slice-1 admission class for both migrated callers (spec + review): factually
+ * completion-only today. #2102 (backend admission contract) changes who
+ * supplies the value, not the field. Day-one self-description, same retrofit
+ * argument as provenance.
+ */
+export const ADMISSION_COMPLETION_ONLY = 'completion_only' as const;
+
+/** sha256 hex content hash (full digest — identity, not display). */
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+
+/** Accept any 1.x version; reject other majors with the version named (F1). */
+const schemaVersionField = z.string().refine(
+  (v) => new RegExp(`^${RUN_ARTIFACT_KNOWN_MAJOR}\\.\\d+\\.\\d+$`).test(v),
+  (v) => ({
+    message: `unsupported run-artifact schemaVersion "${v}" — this reader understands major ${RUN_ARTIFACT_KNOWN_MAJOR}.x; a new major requires a migration entry in loadRunArtifact`,
+  }),
+);
+
+/**
+ * The assembled prompt inputs, POST-DLP. `maskedPrompt`/`maskedSystemPrompt`
+ * are what actually crossed the wire (`maskSecrets` output) — recording the
+ * raw prompt would persist secrets to disk.
+ */
+export const InputBundleSchema = z.object({
+  maskedPrompt: z.string(),
+  maskedSystemPrompt: z.string().optional(),
+  /** Deterministic diff input when the caller ran with a forced scope (#2098). */
+  diffScope: z.string().optional(),
+  /** The grounded spec contract, when present (review sensing against a spec doc). */
+  specContract: z.string().optional(),
+});
+
+/** What KIND of grounding the run had — day-one field, never retrofittable. */
+export const GroundingSchema = z.object({
+  /** Deterministic hash of the grounding context that entered the bundle. */
+  hash: z.string().regex(SHA256_HEX, 'grounding.hash must be a sha256 hex digest'),
+  /** Wholesale class in slice 1 (`similarity-only`); per-item classes are #2101. */
+  provenanceSummary: z.string().min(1),
+});
+
+/** Backend identity as RESOLVED (post quota-fallback), not as requested. */
+export const BackendSchema = z.object({
+  provider: z.string().min(1),
+  model: z.string().min(1),
+  /** The full provider-qualified string telemetry/cache key on (`provider:model`). */
+  qualifiedModel: z.string().min(1),
+  admissionClass: z.enum(['completion_only', 'self_grounding_agent']),
+  /** The command tag the run served (`Spec`, `Review`, ...) — the task profile. */
+  taskProfile: z.string().min(1),
+  temperature: z.number().optional(),
+});
+
+/**
+ * Token counts mirror `OrchestratorResult`: `null` means the provider did not
+ * report (honest-absent), distinct from the field being absent entirely.
+ */
+export const RunMetricsSchema = z.object({
+  inputTokens: z.number().nullable().optional(),
+  outputTokens: z.number().nullable().optional(),
+  cacheReadInputTokens: z.number().nullable().optional(),
+  durationMs: z.number(),
+  finishReason: z.string().optional(),
+});
+
+export const RunArtifactSchema = z.object({
+  schemaVersion: schemaVersionField,
+  inputBundle: InputBundleSchema,
+  /** Deterministic hash of `inputBundle` alone — the rerun identity. */
+  inputHash: z.string().regex(SHA256_HEX, 'inputHash must be a sha256 hex digest'),
+  grounding: GroundingSchema,
+  backend: BackendSchema,
+  output: z.object({
+    content: z.string(),
+    metrics: RunMetricsSchema,
+  }),
+  /**
+   * ISO-8601 emission time. EXCLUDED from the content address (identical runs
+   * dedup to one artifact regardless of when they ran) — observability only.
+   */
+  createdAt: z.string(),
+});
+
+export type RunArtifact = z.infer<typeof RunArtifactSchema>;
+export type InputBundle = z.infer<typeof InputBundleSchema>;

--- a/packages/core/src/artifacts/schema.ts
+++ b/packages/core/src/artifacts/schema.ts
@@ -49,9 +49,12 @@ export const ADMISSION_COMPLETION_ONLY = 'completion_only' as const;
 /** sha256 hex content hash (full digest — identity, not display). */
 const SHA256_HEX = /^[0-9a-f]{64}$/;
 
+/** Major-1 semver literal — keep in sync with {@link RUN_ARTIFACT_KNOWN_MAJOR} (CR review on #2114: a literal beats runtime RegExp construction; the major only changes alongside a migration entry anyway). */
+const SCHEMA_VERSION_RE = /^1\.\d+\.\d+$/;
+
 /** Accept any 1.x version; reject other majors with the version named (F1). */
 const schemaVersionField = z.string().refine(
-  (v) => new RegExp(`^${RUN_ARTIFACT_KNOWN_MAJOR}\\.\\d+\\.\\d+$`).test(v),
+  (v) => SCHEMA_VERSION_RE.test(v),
   (v) => ({
     message: `unsupported run-artifact schemaVersion "${v}" — this reader understands major ${RUN_ARTIFACT_KNOWN_MAJOR}.x; a new major requires a migration entry in loadRunArtifact`,
   }),

--- a/packages/core/src/artifacts/storage.test.ts
+++ b/packages/core/src/artifacts/storage.test.ts
@@ -1,0 +1,102 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { TotemParseError } from '../errors.js';
+import { cleanTmpDir } from '../test-utils.js';
+import type { RunArtifact } from './schema.js';
+import { RUN_ARTIFACT_SCHEMA_VERSION } from './schema.js';
+import {
+  computeRunArtifactContentHash,
+  loadRunArtifact,
+  runsDir,
+  saveRunArtifact,
+} from './storage.js';
+
+function artifact(overrides: Partial<RunArtifact> = {}): RunArtifact {
+  return {
+    schemaVersion: RUN_ARTIFACT_SCHEMA_VERSION,
+    inputBundle: { maskedPrompt: 'prompt after DLP' },
+    inputHash: 'a'.repeat(64),
+    grounding: { hash: 'b'.repeat(64), provenanceSummary: 'similarity-only' },
+    backend: {
+      provider: 'gemini',
+      model: 'gemini-3.1-pro-preview',
+      qualifiedModel: 'gemini:gemini-3.1-pro-preview',
+      admissionClass: 'completion_only',
+      taskProfile: 'Spec',
+    },
+    output: { content: 'response', metrics: { durationMs: 1200 } },
+    createdAt: '2026-06-07T03:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('run-artifact storage', () => {
+  let totemDir: string;
+
+  beforeEach(() => {
+    totemDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-artifacts-'));
+  });
+
+  afterEach(() => {
+    cleanTmpDir(totemDir);
+  });
+
+  it('saves a valid artifact at its content-address and loads it back', () => {
+    const saved = saveRunArtifact(totemDir, artifact());
+    expect(saved.existed).toBe(false);
+    expect(saved.path).toBe(path.join(runsDir(totemDir), `${saved.hash}.json`));
+    expect(fs.existsSync(saved.path)).toBe(true);
+    expect(loadRunArtifact(totemDir, saved.hash)).toEqual(artifact());
+  });
+
+  it('content-address excludes createdAt — identical runs dedup across time', () => {
+    const early = artifact({ createdAt: '2026-06-07T03:00:00.000Z' });
+    const late = artifact({ createdAt: '2026-06-08T09:30:00.000Z' });
+    expect(computeRunArtifactContentHash(early)).toBe(computeRunArtifactContentHash(late));
+  });
+
+  it('append-only: re-saving the same logical run never rewrites the existing file', () => {
+    const first = saveRunArtifact(totemDir, artifact({ createdAt: '2026-06-07T03:00:00.000Z' }));
+    const second = saveRunArtifact(totemDir, artifact({ createdAt: '2026-06-08T09:30:00.000Z' }));
+    expect(second.hash).toBe(first.hash);
+    expect(second.existed).toBe(true);
+    // The ORIGINAL record survives byte-identical — including its createdAt.
+    expect(loadRunArtifact(totemDir, first.hash).createdAt).toBe('2026-06-07T03:00:00.000Z');
+  });
+
+  it('different logical runs get different content addresses', () => {
+    const a = saveRunArtifact(totemDir, artifact());
+    const b = saveRunArtifact(
+      totemDir,
+      artifact({ output: { content: 'different response', metrics: { durationMs: 900 } } }),
+    );
+    expect(a.hash).not.toBe(b.hash);
+  });
+
+  it('rejects loading corrupted or invalid schema artifacts', () => {
+    const dir = runsDir(totemDir);
+    fs.mkdirSync(dir, { recursive: true });
+    const corrupted = 'c'.repeat(64);
+    fs.writeFileSync(path.join(dir, `${corrupted}.json`), '{not json at all');
+    expect(() => loadRunArtifact(totemDir, corrupted)).toThrow(TotemParseError);
+
+    const wrongMajor = 'd'.repeat(64);
+    fs.writeFileSync(
+      path.join(dir, `${wrongMajor}.json`),
+      JSON.stringify({ ...artifact(), schemaVersion: '2.0.0' }),
+    );
+    expect(() => loadRunArtifact(totemDir, wrongMajor)).toThrow(/2\.0\.0/);
+  });
+
+  it('loading a missing hash throws with the path named', () => {
+    expect(() => loadRunArtifact(totemDir, 'e'.repeat(64))).toThrow(TotemParseError);
+  });
+
+  it('rejects a non-hash id before touching the filesystem (path-traversal guard)', () => {
+    expect(() => loadRunArtifact(totemDir, '../../secrets')).toThrow(/sha256/i);
+  });
+});

--- a/packages/core/src/artifacts/storage.test.ts
+++ b/packages/core/src/artifacts/storage.test.ts
@@ -48,7 +48,9 @@ describe('run-artifact storage', () => {
   it('saves a valid artifact at its content-address and loads it back', () => {
     const saved = saveRunArtifact(totemDir, artifact());
     expect(saved.existed).toBe(false);
-    expect(saved.path).toBe(path.join(runsDir(totemDir), `${saved.hash}.json`));
+    // Explicit segments, not runsDir() — asserting against the helper under
+    // test would mask a path-layout regression (CR review on #2114).
+    expect(saved.path).toBe(path.join(totemDir, 'artifacts', 'runs', `${saved.hash}.json`));
     expect(fs.existsSync(saved.path)).toBe(true);
     expect(loadRunArtifact(totemDir, saved.hash)).toEqual(artifact());
   });

--- a/packages/core/src/artifacts/storage.ts
+++ b/packages/core/src/artifacts/storage.ts
@@ -1,0 +1,125 @@
+/**
+ * Append-only, content-addressed storage for run artifacts
+ * (mmnto-ai/totem#2100). Layout: `<totemDir>/artifacts/runs/<hash>.json`,
+ * where `<hash>` is the sha256 of the artifact's canonical serialization
+ * EXCLUDING `createdAt` — identical runs dedup to one record regardless of
+ * when they ran, and a rerun NEVER mutates a prior record (write-if-absent).
+ *
+ * The directory is machine-local state (gitignored alongside
+ * `.totem/cache/`); growth is bounded per-run and pruning is a future verb,
+ * deliberately not this slice.
+ *
+ * Reads go through `readJsonSafe` + `RunArtifactSchema` so a corrupted or
+ * wrong-major artifact is a loud `TotemParseError`, never a silent partial
+ * (Tenet 4). Version tolerance within the major + the migration-on-read
+ * registry implement the F1 evolution policy from the #2100 design review.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { TotemParseError } from '../errors.js';
+import { readJsonSafe } from '../sys/fs.js';
+import { calculateDeterministicHash } from './hash.js';
+import type { RunArtifact } from './schema.js';
+import { RunArtifactSchema } from './schema.js';
+
+/** Storage layout segments under the totem dir (exact layout = impl call, #2100). */
+const RUNS_DIR_SEGMENTS = ['artifacts', 'runs'] as const;
+
+/** Filename guard — the id IS a filesystem path segment, so gate it hard. */
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+
+/**
+ * Migration-on-read registry (F1). Keyed by MAJOR; each entry lifts a parsed
+ * raw object of that major to the current `RunArtifact` shape. EMPTY at
+ * 1.0.0 by design — the policy requires a major bump to land its migration
+ * entry here BEFORE the writer ships, so the registry being empty is the
+ * honest statement that no other major has ever been written.
+ */
+const MIGRATIONS: ReadonlyMap<number, (raw: unknown) => RunArtifact> = new Map();
+
+/** Absolute runs directory for a given absolute totem dir. */
+export function runsDir(totemDirAbs: string): string {
+  return path.join(totemDirAbs, ...RUNS_DIR_SEGMENTS);
+}
+
+/**
+ * Content address of an artifact: deterministic hash over everything EXCEPT
+ * `createdAt` (observability, not identity — see schema docstring).
+ */
+export function computeRunArtifactContentHash(artifact: RunArtifact): string {
+  const { createdAt: _excluded, ...identity } = artifact;
+  return calculateDeterministicHash(identity);
+}
+
+export interface SaveRunArtifactResult {
+  /** The content address (= filename stem). */
+  hash: string;
+  /** Absolute path of the stored artifact. */
+  path: string;
+  /** True when an identical logical run was already recorded (no write happened). */
+  existed: boolean;
+}
+
+/**
+ * Persist an artifact at its content address, write-if-absent. An existing
+ * file is NEVER rewritten: same hash ⇒ same logical content by construction,
+ * and the original record (including its `createdAt`) is the durable one —
+ * append-only means the FIRST write wins forever.
+ */
+export function saveRunArtifact(totemDirAbs: string, artifact: RunArtifact): SaveRunArtifactResult {
+  // Validate on the way OUT too — a writer bug must not poison the ledger
+  // with a record the reader will later reject (the corpus is the point).
+  const validated = RunArtifactSchema.parse(artifact);
+  const hash = computeRunArtifactContentHash(validated);
+  const dir = runsDir(totemDirAbs);
+  const filePath = path.join(dir, `${hash}.json`);
+
+  if (fs.existsSync(filePath)) {
+    return { hash, path: filePath, existed: true };
+  }
+
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(validated, null, 2), {
+    encoding: 'utf-8',
+    mode: 0o600, // matches the response-cache mode — run records carry prompt content
+  });
+  return { hash, path: filePath, existed: false };
+}
+
+/**
+ * Load + validate an artifact by content address. Throws `TotemParseError`
+ * on a missing file, corrupt JSON, or schema violation (including an unknown
+ * major with no migration entry) — loud, never a silent partial.
+ */
+export function loadRunArtifact(totemDirAbs: string, hash: string): RunArtifact {
+  if (!SHA256_HEX.test(hash)) {
+    throw new TotemParseError(
+      `Invalid run-artifact id "${hash}" — expected a 64-char sha256 hex content address.`,
+      'Pass the hash exactly as reported at emission (or from the artifacts/runs/ filename).',
+    );
+  }
+  const filePath = path.join(runsDir(totemDirAbs), `${hash}.json`);
+
+  // Migration seam (F1): peek the major BEFORE strict validation so a known
+  // older major routes through its migration instead of failing the current
+  // schema. With an empty registry this is a straight fall-through today.
+  const raw = readJsonSafe(filePath);
+  const major = readMajor(raw);
+  if (major !== undefined) {
+    const migrate = MIGRATIONS.get(major);
+    if (migrate !== undefined) return migrate(raw);
+  }
+
+  return RunArtifactSchema.parse(raw);
+}
+
+/** Best-effort major extraction from a raw parsed payload; undefined when absent/garbled. */
+function readMajor(raw: unknown): number | undefined {
+  if (typeof raw !== 'object' || raw === null) return undefined;
+  const version = (raw as Record<string, unknown>)['schemaVersion'];
+  if (typeof version !== 'string') return undefined;
+  const major = Number.parseInt(version.split('.')[0] ?? '', 10);
+  return Number.isNaN(major) ? undefined : major;
+}

--- a/packages/core/src/artifacts/storage.ts
+++ b/packages/core/src/artifacts/storage.ts
@@ -18,7 +18,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { TotemParseError } from '../errors.js';
+import { rethrowAsParseError, TotemParseError } from '../errors.js';
 import { readJsonSafe } from '../sys/fs.js';
 import { calculateDeterministicHash } from './hash.js';
 import type { RunArtifact } from './schema.js';
@@ -81,10 +81,24 @@ export function saveRunArtifact(totemDirAbs: string, artifact: RunArtifact): Sav
   }
 
   fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(filePath, JSON.stringify(validated, null, 2), {
-    encoding: 'utf-8',
-    mode: 0o600, // matches the response-cache mode — run records carry prompt content
-  });
+  try {
+    // `wx` = atomic create-exclusive: closes the TOCTOU window between the
+    // existsSync fast-path and the write, so concurrent saves of the same
+    // hash can never overwrite the first record (CR review on #2114) —
+    // first-write-wins is enforced by the filesystem, not the check above.
+    fs.writeFileSync(filePath, JSON.stringify(validated, null, 2), {
+      encoding: 'utf-8',
+      mode: 0o600, // matches the response-cache mode — run records carry prompt content
+      flag: 'wx',
+    });
+  } catch (err) {
+    // A concurrent writer won the race — same hash ⇒ same logical content,
+    // so the existing record IS this save's outcome (append-only dedup).
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+      return { hash, path: filePath, existed: true };
+    }
+    throw err;
+  }
   return { hash, path: filePath, existed: false };
 }
 
@@ -112,7 +126,19 @@ export function loadRunArtifact(totemDirAbs: string, hash: string): RunArtifact 
     if (migrate !== undefined) return migrate(raw);
   }
 
-  return RunArtifactSchema.parse(raw);
+  try {
+    return RunArtifactSchema.parse(raw);
+  } catch (err) {
+    // Normalize the ZodError to the module's stated load contract (GCA + CR
+    // review on #2114): JSON-read failures and schema failures both surface
+    // as TotemParseError, with the Zod issue text (incl. the rejected
+    // schemaVersion) preserved via the message + cause.
+    rethrowAsParseError(
+      `Run artifact ${hash} failed schema validation`,
+      err,
+      'The artifact may be corrupted or written by an incompatible totem version; re-emit it (or add the migration entry for its major).',
+    );
+  }
 }
 
 /** Best-effort major extraction from a raw parsed payload; undefined when absent/garbled. */

--- a/packages/core/src/artifacts/storage.ts
+++ b/packages/core/src/artifacts/storage.ts
@@ -128,11 +128,8 @@ export function loadRunArtifact(totemDirAbs: string, hash: string): RunArtifact 
 
   try {
     return RunArtifactSchema.parse(raw);
+    // totem-context: rethrowAsParseError always throws (returns `never`) — this catch RE-throws via the shared helper, normalizing ZodError to the module's stated TotemParseError load contract (GCA + CR review on #2114); nothing is swallowed.
   } catch (err) {
-    // Normalize the ZodError to the module's stated load contract (GCA + CR
-    // review on #2114): JSON-read failures and schema failures both surface
-    // as TotemParseError, with the Zod issue text (incl. the rejected
-    // schemaVersion) preserved via the message + cause.
     rethrowAsParseError(
       `Run artifact ${hash} failed schema validation`,
       err,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -513,6 +513,7 @@ export {
 export { readJsonSafe } from './sys/fs.js';
 
 // Grounded run artifacts (mmnto-ai/totem#2100, strategy#474 slice 1)
+export { calculateDeterministicHash } from './artifacts/hash.js';
 export type { InputBundle, RunArtifact } from './artifacts/schema.js';
 export {
   ADMISSION_COMPLETION_ONLY,
@@ -520,7 +521,6 @@ export {
   RUN_ARTIFACT_SCHEMA_VERSION,
   RunArtifactSchema,
 } from './artifacts/schema.js';
-export { calculateDeterministicHash } from './artifacts/hash.js';
 export type { SaveRunArtifactResult } from './artifacts/storage.js';
 export {
   computeRunArtifactContentHash,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -512,6 +512,23 @@ export {
 // Filesystem helpers
 export { readJsonSafe } from './sys/fs.js';
 
+// Grounded run artifacts (mmnto-ai/totem#2100, strategy#474 slice 1)
+export type { InputBundle, RunArtifact } from './artifacts/schema.js';
+export {
+  ADMISSION_COMPLETION_ONLY,
+  PROVENANCE_SIMILARITY_ONLY,
+  RUN_ARTIFACT_SCHEMA_VERSION,
+  RunArtifactSchema,
+} from './artifacts/schema.js';
+export { calculateDeterministicHash } from './artifacts/hash.js';
+export type { SaveRunArtifactResult } from './artifacts/storage.js';
+export {
+  computeRunArtifactContentHash,
+  loadRunArtifact,
+  runsDir,
+  saveRunArtifact,
+} from './artifacts/storage.js';
+
 // Strategy-root resolver (mmnto-ai/totem#1710)
 export type {
   StrategyResolverConfig,


### PR DESCRIPTION
## What

Strategy#474 slice 1 (epic #2106): every opted-in orchestrator run emits an immutable, content-addressed record under `.totem/artifacts/runs/<sha256>.json`; rerun/compare primitives + thin verbs ship in-slice.

- **core** — `RunArtifactSchema` (Zod at the persisted-JSON boundary) with the **F1 version-tolerant reader**: accepts any `1.x`, migration-on-read registry for majors, hard-rejects only unknown majors — an append-only ledger whose reader rejects its own history isn''t append-only in practice. `calculateDeterministicHash` canonicalizes (recursive key sort) before sha256. Storage is write-if-absent: first write wins forever; `createdAt` is excluded from the content address so identical runs dedup across time.
- **cli** — emission is **strictly additive** (`opts.artifact?`; `runOrchestrator` return contract unchanged; the other 10 call sites compile untouched) and hooks INSIDE `runOrchestrator`, where the three things only it knows live: the **post-DLP masked prompt** (raw would persist secrets), the **post-quota-fallback resolved backend**, and the `OrchestratorResult` metrics. Response-cache hits emit nothing (artifacts record actual invokes); emission failure warns and never fails the run. `spec` + `review` (standard verdict) migrate **always-on** (operator ruling — a flag means fixtures exist only when remembered).
- **verbs** — `totem artifact rerun <hash>` replays the exact stored bundle against the recorded backend with `fresh: true` (a response-cache replay is not a rerun); `totem artifact compare <a> <b>` is a pure deterministic diff — equality flags, content hashes, numeric metric deltas, **no similarity scoring** (review F3 / Tenet 9).

## Design provenance

Design doc ships in this PR at `.totem/specs/2100.md`: generated spec + Implementation Design with three **verified spec corrections** (the generated spec fabricated the `runOrchestrator` return contract, missed DLP, missed the response-cache interplay — grounded against `utils.ts` with file:line), strategy-claude review folds F1–F3 (dispatch 2026-06-07T0253Z, design CONFORMS), and the operator rulings on all three open questions.

## Verification

- 32 new tests across core (hash determinism, schema evolution incl. 1.x-tolerance, append-only storage, traversal guard) and cli (emission schema-validity, DLP masking, cache-hit suppression, non-opted byte-identical behavior, write-failure resilience, quota-fallback recording, rerun bundle fidelity, compare purity). RED-first per task.
- Full gates: build ✅ · suites ✅ (2 pre-existing environmental failures reproduce without this change) · format ✅ · full-branch `totem lint` 0 errors · `totem review` PASS 0 findings · manifest verified.
- **Dogfood:** the `totem review` gate run on this very branch emitted the first real artifact (`5985a231…`) — DLP masking exercised live — and `totem artifact compare` round-tripped it through the schema.

Found-while-building (ticketed, not in this PR): #2113 (compile records a tracked-set `input_hash` while lessons are untracked → verify rejects compile''s own output).

Closes #2100. Refs strategy#474 · #2106 · #2101 (provenance classes consume the `provenanceSummary` seam) · #2102 (admission contract supplies `admissionClass`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)