### PR TITLE
chore(deps): strategy-doctrine 0.1.3 reconcile (W5 engine row) + #2114 postmerge lessons

### DIFF
--- a/.totem/compile-manifest.json
+++ b/.totem/compile-manifest.json
@@ -1,7 +1,7 @@
 {
-  "compiled_at": "2026-06-07T18:53:02.176Z",
+  "compiled_at": "2026-06-07T19:42:30.826Z",
   "model": "gemini-3-flash-preview",
-  "input_hash": "f9ffde8312d435476469de35f2d3b5f06c39888b9b3420903dc8bdd771f9bd1c",
-  "output_hash": "0758d6fe3ec8bb6d70682a812a1e8ac55572a3f6a4a5bdcc16d1ace52c0faa8f",
-  "rule_count": 483
+  "input_hash": "887b20d48cfafd849ba15003866da2beba5be5d9352627300667375a3b36f60f",
+  "output_hash": "dac020d04b29a00f8d1b30720007d418d4ed8095a6263ca3567269be3b8aa139",
+  "rule_count": 485
 }

--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -8579,6 +8579,42 @@
       "archivedReason": "Stage 4 (mmnto-ai/totem#1682): pattern fired on 1 file(s) in the verification baseline (test files, fixture directories, or files outside fileGlobs scope) — over-broad. Offending paths: packages/cli/CHANGELOG.md. reasonCode: stage4-out-of-scope-match.",
       "archivedAt": "2026-06-07T02:04:45.798Z",
       "unverified": true
+    },
+    {
+      "lessonHash": "904c066615bd94c4",
+      "lessonHeading": "Exclude timestamps from content addresses",
+      "message": "Do not include 'createdAt' (or other timestamp fields) in deterministic hash calculations — identical runs will fail to deduplicate across different execution times.",
+      "engine": "ast-grep",
+      "severity": "warning",
+      "pattern": "",
+      "astGrepPattern": "hash($$$ARGS, createdAt, $$$REST)",
+      "compiledAt": "2026-06-07T19:41:53.478Z",
+      "createdAt": "2026-06-07T19:41:53.478Z",
+      "fileGlobs": [
+        "packages/core/src/artifacts/storage.ts"
+      ],
+      "badExample": "const addr = hash(content, createdAt, metadata);",
+      "goodExample": "const addr = hash(content, metadata);",
+      "unverified": true,
+      "status": "untested-against-codebase"
+    },
+    {
+      "lessonHash": "baffaac1dadd9f3e",
+      "lessonHeading": "Use atomic write-if-absent flags",
+      "message": "Use flag 'wx' instead of 'w' to prevent TOCTOU race conditions and enforce first-write-wins semantics",
+      "engine": "ast-grep",
+      "severity": "warning",
+      "pattern": "",
+      "astGrepPattern": "fs.writeFile($PATH, $DATA, { flag: 'w' })",
+      "compiledAt": "2026-06-07T19:42:29.872Z",
+      "createdAt": "2026-06-07T19:42:29.872Z",
+      "fileGlobs": [
+        "packages/core/src/artifacts/storage.ts"
+      ],
+      "badExample": "await fs.writeFile(path, data, { flag: 'w' });",
+      "goodExample": "await fs.writeFile(path, data, { flag: 'wx' });",
+      "unverified": true,
+      "status": "untested-against-codebase"
     }
   ],
   "nonCompilable": [
@@ -14344,6 +14380,30 @@
       "title": "Include all bot IDs in triage parsers",
       "reasonCode": "out-of-scope",
       "reason": "Lesson describes a completeness requirement (all active bot IDs must be present in a list), which requires semantic knowledge of which bots are currently active. No pattern can detect a missing entry in an enumeration without knowing the ground-truth set of required values."
+    },
+    {
+      "hash": "74ff33fc00277451",
+      "title": "Implement version-tolerant schema readers",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes an architectural principle (version-tolerant schema reading with major/minor version logic) that requires semantic analysis of runtime branching behavior — no single regex or AST pattern can detect whether a schema reader correctly accepts all minor versions while rejecting unknown majors."
+    },
+    {
+      "hash": "a2a2ae65c870d592",
+      "title": "Wrap schema validation in domain errors",
+      "reasonCode": "context-required",
+      "reason": "Lesson requires detecting when a Zod error is caught and NOT rethrown as a domain error — this requires analyzing the catch clause body to determine whether the caught error is a ZodError and whether it is wrapped before rethrowing, which is multi-step semantic analysis that no single pattern or structural combinator can express."
+    },
+    {
+      "hash": "9b526b31a5e374bf",
+      "title": "Persist masked prompts in artifacts",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes an architectural data-flow requirement (masked prompts must be persisted rather than raw prompts) that cannot be detected from a single code pattern — determining whether a prompt has been DLP-masked before being written to persistent storage requires multi-file semantic analysis of the data flow between the masking step and the storage call."
+    },
+    {
+      "hash": "ad7725357294e9cf",
+      "title": "Hash prompt-visible grounding subsets",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes an architectural data-transformation principle (projecting to stable fields before hashing) that cannot be detected by inspecting any single code pattern — the violation requires knowing which fields are included in a hash input and whether they are environment-specific, which demands semantic analysis of the data flow."
     }
   ]
 }

--- a/.totem/lessons/lesson-1b4a418a.md
+++ b/.totem/lessons/lesson-1b4a418a.md
@@ -1,0 +1,6 @@
+## Lesson — Exclude timestamps from content addresses
+
+**Tags:** storage, deduplication
+**Scope:** packages/core/src/artifacts/storage.ts
+
+Omit volatile fields like 'createdAt' from deterministic hash calculations to allow identical runs to deduplicate across different execution times.

--- a/.totem/lessons/lesson-1d298060.md
+++ b/.totem/lessons/lesson-1d298060.md
@@ -1,0 +1,6 @@
+## Lesson — Sanitize CLI inputs before
+
+**Tags:** security, cli, logging
+**Scope:** packages/cli/src/commands/artifact.ts
+
+Validate or strip ANSI escape codes from user-provided strings before logging to the terminal to prevent terminal injection attacks.

--- a/.totem/lessons/lesson-5b0bcfb3.md
+++ b/.totem/lessons/lesson-5b0bcfb3.md
@@ -1,0 +1,6 @@
+## Lesson — Implement version-tolerant schema readers
+
+**Tags:** architecture, schema, zod
+**Scope:** packages/core/src/artifacts/schema.ts
+
+Accept all minor versions (e.g., 1.x) while rejecting unknown majors to ensure an append-only ledger remains readable across non-breaking updates.

--- a/.totem/lessons/lesson-82d72307.md
+++ b/.totem/lessons/lesson-82d72307.md
@@ -1,0 +1,6 @@
+## Lesson — Wrap schema validation in domain errors
+
+**Tags:** error-handling, zod
+**Scope:** packages/core/src/artifacts/storage.ts
+
+Catch raw Zod errors and rethrow them as structured domain-specific errors to maintain a consistent error contract across the service layer.

--- a/.totem/lessons/lesson-b138844e.md
+++ b/.totem/lessons/lesson-b138844e.md
@@ -1,0 +1,6 @@
+## Lesson — Persist masked prompts in artifacts
+
+**Tags:** security, privacy, dlp
+**Scope:** packages/cli/src/utils.ts
+
+Always record post-DLP masked prompts in persistent storage to ensure that secrets or PII are not accidentally leaked into long-lived artifact files.

--- a/.totem/lessons/lesson-cbf48cd2.md
+++ b/.totem/lessons/lesson-cbf48cd2.md
@@ -1,0 +1,6 @@
+## Lesson — Use atomic write-if-absent flags
+
+**Tags:** filesystem, security, concurrency
+**Scope:** packages/core/src/artifacts/storage.ts
+
+Utilize the 'wx' flag in file operations instead of an exists-then-write pattern to prevent TOCTOU race conditions and enforce 'first write wins' semantics.

--- a/.totem/lessons/lesson-e4916351.md
+++ b/.totem/lessons/lesson-e4916351.md
@@ -1,0 +1,6 @@
+## Lesson — Hash prompt-visible grounding subsets
+
+**Tags:** hashing, dx, reproducibility
+**Scope:** packages/cli/src/commands/shield.ts
+
+Project raw search results to stable, prompt-visible fields before hashing to prevent spurious drift caused by environment-specific metadata like absolute file paths.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "typescript-eslint": "^8.59.4"
   },
   "optionalDependencies": {
-    "@mmnto/strategy-doctrine": "0.1.2"
+    "@mmnto/strategy-doctrine": "0.1.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         version: 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
     optionalDependencies:
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.2
-        version: 0.1.2
+        specifier: 0.1.3
+        version: 0.1.3
 
   packages/cli:
     dependencies:
@@ -847,8 +847,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.2':
-    resolution: {integrity: sha512-e6Aha7biSWBWR4nRAo8F5iYdFFajK9QOt7YMp6zWrjy5rWgTPmoMFrtXZynnq6GNm2B8T4gVRYsWLMeWfoktqg==}
+  '@mmnto/strategy-doctrine@0.1.3':
+    resolution: {integrity: sha512-Do4ePQEAZIpQlHP49yR9u8Jsvx77tc4L+T31gkh+mmZzPhagP4mHXvaECAFKwraA7+6Yl44Wq3dMhNedAIGeIw==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3679,7 +3679,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.2':
+  '@mmnto/strategy-doctrine@0.1.3':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
## What

1. **`@mmnto/strategy-doctrine` 0.1.2 → 0.1.3** — the snapshot carrying the W5 `pnpm-engine-version` parity row (toolchain-version dimension, floor 11.2.2, strategy#566). Empirical sensor results after the bump:
   - the new engine row renders an honest `SKIP — toolchain-version (version-pinned) — drift detection not yet implemented` stub → sense side is #2115 (filed, my lane per the 1857Z dispatch);
   - the doctrine row stays `SKIP — floor not locally determinable` → #2108 unchanged; pin-staleness sensing does NOT materialize yet (correcting the 1857Z dispatch expectation, same class as the 0.1.2 round).
2. **#2114 postmerge lessons** — 7 extracted (the commit message says 5; the terminal echoed only the tail of the extract — all 7 verified legitimate), compile refresh: 485 rules, 2 newly compiled. Compile ran on the COMMITTED tree per the #2113 ordering, and `verify-manifest` passes.

## Reconcile incident (recorded for the record)

The first install ran against a 401-dead npm token and — because the package is optional by design (#2018) — **silently dropped strategy-doctrine from the lockfile** instead of failing (lesson `134095fd` recurring, live). After re-auth, bare `pnpm install` would NOT re-resolve the cached failed-optional state ("Already up to date" against a mismatched specifier); an explicit `pnpm add @mmnto/strategy-doctrine@0.1.3 -O -w` cut through.

## Verification

`corepack pnpm install` green under the pinned engine · installed 0.1.3 confirmed on disk + both lockfile entries · `format:check` clean · full-branch `totem lint` PASS 0 errors · `totem review` deterministic fast-path (all non-code) · `verify-manifest` PASS.

Refs strategy#566 · #2115 · #2108 · dispatches 2026-06-07T1857Z/1901Z.

🤖 Generated with [Claude Code](https://claude.com/claude-code)