### PR TITLE
fix(cli): totem mail silently drops frontmatter-only dispatches >2 KiB + --json emits no JSON (#2118, #2097)

### DIFF
--- a/.changeset/mail-parse-silent-drop.md
+++ b/.changeset/mail-parse-silent-drop.md
@@ -1,0 +1,7 @@
+---
+'@mmnto/cli': patch
+---
+
+fix(cli): `totem mail` no longer silently drops frontmatter-only dispatches over 2 KiB (#2118), and `totem mail --json` actually emits JSON (#2097).
+
+`parseHeader` now parses to the closing `---` frontmatter delimiter instead of splitting on the first blank line — the old parser rejected any >2 KiB file without a blank-line separator, which silently dropped every cohort-convention dispatch (whole message in `subject:`, zero blank lines; 8/8 of the observed misses, up to 4,163 bytes of genuine frontmatter). The byte cap now bounds the closing-delimiter search window (16 KiB) instead of rejecting the file, and every mail-shaped parse rejection emits a structured warning (parity with the module's other failure paths) while non-mail-shaped strays stay silent by design. The `--json` flag was being swallowed by the program-level `--json` option (commander parent/child collision); the mail action now reads `optsWithGlobals()`.

--- a/.totem/specs/2118.md
+++ b/.totem/specs/2118.md
@@ -1,0 +1,146 @@
+### Problem Statement
+
+`totem mail` (and hooks using `pollMail`) silently drops valid, frontmatter-only dispatches larger than 2 KiB because the parser incorrectly relies on a double-blank-line separator (`\r?\n\r?\n`) to isolate the header. We need to refactor `parseHeader` to bound its search using the closing YAML frontmatter delimiter (`---`), emit a structured warning instead of silently failing, and optionally fix the broken `--json` flag to emit parseable JSON.
+
+### Architectural Context
+
+- **Error Handling & Logging Conventions (Lesson 9):** Requires `log.error()` to use `'Totem Error'` as the tag, but specifically mandates that `log.warn()` MUST use the command-specific `TAG` constant.
+- **YAML Handoffs:** Code snippets reveal `parseHeader` enforces that "real handoffs open with a YAML frontmatter delimiter." Blank-line separation is a legacy assumption that must be replaced by strict delimiter bounding.
+
+### Files to Examine
+
+1. `packages/cli/src/commands/mail.ts` — Contains `MAX_HEADER_BYTES`, `parseHeader`, `pollMail` read loop, and the CLI command handler.
+2. `packages/cli/src/commands/mail.test.ts` — Missing tests for the >2KB zero-blank-line case and silent drop behavior.
+
+### Technical Approach & Contracts
+
+**1. Delimiter Refactoring (`parseHeader`)**
+Instead of splitting the entire file by `/\r?\n\r?\n/` and validating the first chunk's size, we will strictly parse the frontmatter boundaries:
+
+- Verify the file starts with `---` (optionally preceded by whitespace).
+- Find the index of the _closing_ `---` delimiter (`\n---` or `\r\n---`).
+- **Forged-Frontmatter Defense:** If the closing delimiter is not found, OR its index is strictly greater than `MAX_HEADER_BYTES` (2048), return `null`.
+- Extract the matched boundary as the header string and pass it to the existing metadata parser.
+
+**2. Visibility for Drops (`pollMail`)**
+Update the file iteration loop in `pollMail`. When `parseHeader(content)` returns `null`, emit a structured warning via `log.warn(TAG, ...)` before executing `continue`, ensuring parity with the `readFileSync` failure path.
+
+**3. Adjacent Fix: JSON Output (`mail` command)**
+Address #2097 in the same pass. If the `--json` flag is provided to the CLI command, execute `console.log(JSON.stringify(result, null, 2))`. Ensure that `log.warn` outputs to `stderr` (which is standard for the logger) so it does not corrupt the `stdout` JSON pipeline.
+
+### Edge Cases & Traps
+
+- **CRLF vs LF:** The closing delimiter search must account for both `\n---` and `\r\n---`. Using a simple `.indexOf('\n---')` might miscalculate bytes or miss carriage returns. Use a regex with bounded execution or check both.
+- **JSON Pollution:** Emitting the new warning could pollute `stdout` if the logger isn't strictly writing to `stderr`. This breaks programmatic consumers of `--json`. The warning must be safely routed.
+- **Missing closing delimiter:** A file that starts with `---` but has no closing `---` within 2 KiB must be gracefully rejected (return `null`), not crash the process.
+- **Header exactly at boundary:** An off-by-one error in the `MAX_HEADER_BYTES` check could drop a valid header that exactly hits 2048 bytes. Use `<= MAX_HEADER_BYTES` for the bounding check.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Add failing tests for large frontmatter dispatches**
+  - Modify: `packages/cli/src/commands/mail.test.ts`
+    > TEST DIRECTIVE: Before implementing, write a failing test named `parses frontmatter-only dispatch larger than 2KB without blank lines` that proves the regression is caught. Also write `emits warning on unparseable mail format`.
+  - Steps:
+    1. Create a test payload starting with `---\nsubject: Test\n---\n` followed by >2048 bytes of text, with NO double blank lines.
+    2. Create a test for `pollMail` ensuring a log warning is emitted when a file is unparseable (e.g., missing closing delimiter).
+    3. write test → verify fails → implement (skip implementation, move to Task 2 to fix) → verify passes (after Task 2/3) → lint
+
+- [ ] **Task 2: Refactor YAML boundary parsing**
+  - Modify: `packages/cli/src/commands/mail.ts`
+  - Steps:
+    1. Locate `parseHeader` and remove the `content.split(/\r?\n\r?\n/, 2)` logic.
+    2. Check if `content.trimStart().startsWith('---')`. If not, return `null`.
+    3. Find the closing delimiter using `content.indexOf('\n---', 3)`. (Handle `\r\n` safely by checking `.indexOf` on both or using a bounded regex match).
+    4. If the index is `-1` or exceeds `MAX_HEADER_BYTES`, return `null`.
+    5. Slice the content from `0` to the end of the closing `---` and proceed with the existing parsing logic.
+    6. write test (from Task 1) → verify fails (should already fail) → implement → verify passes → lint
+
+- [ ] **Task 3: Surface silent drops as warnings**
+  - Modify: `packages/cli/src/commands/mail.ts` (specifically `pollMail`)
+    > TOTEM INVARIANT (Error Handling & Logging Conventions): `log.warn()` MUST use the command-specific `TAG` constant. Do not use `'Totem Error'` or raw strings for the tag.
+  - Steps:
+    1. Locate `const header = parseHeader(content); if (!header) continue;` (around line 359).
+    2. Update to log a warning containing the file path when `header` is null.
+    3. Verify `log.warn` is imported and the `TAG` constant is defined in the file.
+    4. write test (from Task 1) → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Fix `--json` emission (Issue #2097)**
+  - Modify: `packages/cli/src/commands/mail.ts` (Command handler)
+    > TEST DIRECTIVE: Before implementing, write a failing test named `emits valid JSON to stdout when --json flag is provided` that proves the regression is caught.
+  - Steps:
+    1. Locate the main action handler for the `mail` command.
+    2. Check if the `json` option is true.
+    3. If true, bypass standard text output and call `console.log(JSON.stringify(result, null, 2))`.
+    4. write test → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Large Frontmatter Test:** Construct a dispatch with standard YAML frontmatter and a dense 3 KiB body with strictly zero `\n\n` occurrences. Assert `pollMail` parses the metadata correctly and does not drop the file.
+- **Security Bounding Test:** Construct a forged dispatch where the closing `---` occurs at byte 3000. Assert `pollMail` drops it and emits a warning.
+- **Warning Emission Test:** Pass a malformed `.md` file without `---` into the outbox. Assert `log.warn` is called with the correct `TAG` and filepath.
+- **JSON Flag Test:** Run `totem mail --json` and assert `JSON.parse` succeeds on stdout, and that any `log.warn` side-effects do not invalidate the stdout payload.
+
+## Implementation Design
+
+### Scope
+
+Fix the two read-side defects in `totem mail`: (1) `parseHeader` silently rejects valid frontmatter-only dispatches — reparse on the closing `---` delimiter with a **raised** named search-window cap, and surface every mail-shaped parse rejection as a structured warning (parity with the `readFileSync` failure path, Tenet 4); (2) route the commander parent/child `--json` collision so `totem mail --json` actually emits JSON (#2097 — root-caused to the program-level `--json` at `index.ts:74` swallowing the subcommand flag; `mailCommand`'s renderer is already correct). Explicitly NOT in scope: inbox model / derived handled-state / processed-marking mechanization (Proposal 290, #390, strategy#506 — the ECL design review owns the class; this is the instance fix, ratified to proceed in parallel), sender-side or dispatch-schema changes, `MAX_SCAN` changes, `index-lite` (does not register mail).
+
+### Data model deltas
+
+- **`MAX_HEADER_BYTES` (2048) → `MAX_HEADER_SEARCH_BYTES` (16384)** — semantics change from "max file size tolerated without a blank-line separator" to "window within which the closing `---` must appear." **The value must rise with the semantics**: observed genuine frontmatter runs to 4163 bytes (2026-06-07T2107Z dispatch, frontmatter-only); a literal port of the suggested fix at 2048 still rejects the entire observed miss class. 16 KiB ≈ 4× observed max, still bounded. Comment carries this provenance.
+- **`HeaderParse` (module-private discriminated result)**: `{ ok: true, header } | { ok: false, mailShaped: boolean, reason: string }`. Written by `parseHeader`, read only by `pollMail`'s scan loop to decide warn-vs-silent-skip and compose the warning message. Not exported; `MailEntry` / `MailPollResult` / `MailCommandOptions` unchanged.
+- **New warning strings** ride the existing `warnings: string[]` (bounded by `MAX_SCAN` per poll; no new container).
+
+### State lifecycle
+
+No new state. `warnings[]` remains per-invocation (created/appended/returned inside `pollMail`, never cached). `TOTEM_JSON_OUTPUT` env (process-lifetime, argv-sniffed at `index.ts:80`) is untouched — no consumer reads `program.opts().json` directly (verified by grep), so the wiring fix cannot regress other commands.
+
+### Failure modes
+
+| Failure                                                              | Category  | Agent-facing surface                                                                                                            | Recovery                                                                                                                |
+| -------------------------------------------------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Mail-shaped file (`---`-opening), closing `---` beyond 16 KiB window | runtime   | **warning** `mail parse failed (repo/agent/file): <reason>` + skip                                                              | sender fixes dispatch; re-warned every poll until then (observable, self-healing)                                       |
+| Mail-shaped file, no closing `---` at all                            | runtime   | **warning** + skip                                                                                                              | same                                                                                                                    |
+| Mail-shaped file, no `to:` inside delimited header                   | runtime   | **warning** + skip (single-writer outbox is dispatches-only by ADR-106 §3; a to:-less file there is sender error)               | sender fixes                                                                                                            |
+| Non-mail-shaped `.md` (doesn't open with `---`)                      | by-design | **silent skip** (unchanged) — stray files are non-mail by contract; warning would be permanent unfixable noise for every poller | n/a (justified: the observed silent-drop class was exclusively mail-shaped; Tenet 4 satisfied by warning on that class) |
+| `readFileSync` / `readdir` / `processed/` failures                   | transient | warning + skip (existing, unchanged)                                                                                            | next poll                                                                                                               |
+| `--json` run with warnings present                                   | n/a       | warnings inside the JSON payload; stdout stays parseable JSON; human text only ever on stderr                                   | n/a                                                                                                                     |
+
+Note: parse warnings fire for **every** poller, including for broken files addressed to someone else — correct, since an unparseable file has no determinable addressee, and the sender (who also polls) is the party who can fix it.
+
+### Invariants to lock in via tests
+
+1. A frontmatter-only dispatch (zero blank lines, ~3.5 KiB replica of the 2015Z shape) with valid `to:` parses and surfaces — the 8/8 regression class.
+2. Body content after the closing `---` can never fabricate `to:`/`from:`/`subject:`/`date:` (forged-frontmatter defense preserved under the new parser).
+3. Every mail-shaped rejection produces a structured warning naming repo/agent/file — no silent-drop path remains for `---`-opening files.
+4. A blank line **inside** the frontmatter region no longer truncates the header (kills the old splitter's failure mode); the interim sender-discipline shape (blank line + body footer after closing `---`) parses identically.
+5. CRLF (`\r\n---`) and LF dispatches parse identically.
+6. `mailCommand({json: true})` emits parseable JSON to stdout with zero stderr leakage into the stream; the commander wiring delivers `json: true` end-to-end (test via spawned `dist` smoke if repo precedent exists, else a minimal commander-replica wiring test).
+7. Existing under-cap lenient test (mail.test.ts:568) is superseded by delimiter semantics — updated, not deleted: the same valid handoff still parses.
+
+### Open questions
+
+- **Q1 — Warn on non-mail-shaped strays?** Options: (a) silent skip (recommended — stray `.md` is non-mail by contract; warning is permanent noise nobody can clear from the recipient side); (b) warn on everything. **Recommendation: (a)**, with mail-shaped rejects always warning.
+- **Q2 — Search-window size.** Options: 8 KiB / **16 KiB** / 64 KiB. **Recommendation: 16 KiB** (4× observed max genuine frontmatter; bounded against pathological files).
+- **Q3 — #2097 fix shape + bundling.** Options: (a) `cmd.optsWithGlobals()` in the mail action (recommended — commander-idiomatic, merges parent+child, minimal diff, both option declarations stay so help/standalone behavior is preserved); (b) drop the subcommand `--json` and read program opts (loses subcommand help line); (c) drop the program-level `--json` (breaks the env-sniff JSON mode for every other command). **Recommendation: (a), folded into this PR — `Closes #2118` + `Closes #2097`** (same read-path, ratified queue named them together).

--- a/packages/cli/src/commands/mail.test.ts
+++ b/packages/cli/src/commands/mail.test.ts
@@ -12,10 +12,10 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { cleanTmpDir } from '../test-utils.js';
-import { type MailPollResult, pollMail } from './mail.js';
+import { mailCommand, type MailPollResult, pollMail } from './mail.js';
 
 // ─── Fixture helpers ────────────────────────────────────
 
@@ -96,6 +96,27 @@ function writeBroadcastProcessed(repo: string, recipientAgent: string, names: st
  */
 function selfRepoRoot(): string {
   return mkDir(path.join(workspace, 'totem'));
+}
+
+/**
+ * Build a frontmatter-only dispatch (zero blank lines) carrying the whole
+ * message in an oversized `subject:` — the cohort adr-098 shape whose
+ * silent drop is the mmnto-ai/totem#2118 regression class (observed live
+ * at 2,110–4,163 bytes; the predecessor parser rejected anything > 2 KiB
+ * without a blank-line separator).
+ */
+function frontmatterOnlyDispatch(subjectBytes: number, eol: '\n' | '\r\n' = '\n'): string {
+  return [
+    '---',
+    'schema: adr-098-v0.4',
+    'from: strategy-claude',
+    'to: totem-claude',
+    'date: 2026-06-07T2015Z',
+    `subject: "[${'W'.repeat(subjectBytes)}]"`,
+    'priority: normal',
+    '---',
+    '',
+  ].join(eol);
 }
 
 beforeEach(() => {
@@ -277,12 +298,17 @@ describe('pollMail — sort + metadata', () => {
 // ─── Frontmatter parsing robustness ─────────────────────
 
 describe('pollMail — frontmatter parsing', () => {
-  it('skips files without `to:` in the frontmatter', () => {
+  it('skips files without `to:` in the frontmatter — with a warning (mail-shaped sender error)', () => {
     writeOutbox('totem-strategy', 'strategy-claude', [
       { name: 'noto.md', to: 'totem-claude', raw: '---\nfrom: x\n---\n' },
     ]);
     const result = poll();
     expect(result.mail).toEqual([]);
+    // An outbox is dispatches-only by ADR-106 § 3; a `to:`-less mail-shaped
+    // file there is sender error, surfaced loud (mmnto-ai/totem#2118).
+    expect(
+      result.warnings.some((w) => w.startsWith('mail parse failed') && w.includes('noto.md')),
+    ).toBe(true);
   });
 
   it('only reads frontmatter from the header block (body `to:` cannot fabricate a match)', () => {
@@ -295,6 +321,10 @@ describe('pollMail — frontmatter parsing', () => {
     ]);
     const result = poll();
     expect(result.mail).toEqual([]);
+    // Rejected for the right reason: no `to:` INSIDE the delimited header.
+    expect(
+      result.warnings.some((w) => w.startsWith('mail parse failed') && w.includes('body-to.md')),
+    ).toBe(true);
   });
 
   it('handles CRLF line endings', () => {
@@ -537,7 +567,7 @@ describe('pollMail — MAX_SCAN truncation', () => {
 // ─── Frontmatter forge defense (GCA R2 security finding on #1971) ───────
 
 describe('pollMail — frontmatter forge defense', () => {
-  it('rejects files that do not start with the YAML `---` delimiter', () => {
+  it('rejects files that do not start with the YAML `---` delimiter — silently (not mail-shaped)', () => {
     writeOutbox('totem-strategy', 'strategy-claude', [
       {
         name: 'no-delimiter.md',
@@ -547,28 +577,36 @@ describe('pollMail — frontmatter forge defense', () => {
     ]);
     const result = poll();
     expect(result.mail).toEqual([]);
+    // A stray .md is non-mail by contract; warning on it every poll would be
+    // permanent, unclearable noise (mmnto-ai/totem#2118 design note).
+    expect(result.warnings).toEqual([]);
   });
 
-  it('rejects large files lacking a blank-line frontmatter separator', () => {
-    // Real frontmatter is tens of bytes; a file > 2 KiB without the
-    // blank-line separator is structurally malformed. Capping the header
-    // scan in that case prevents body lines from fabricating `to:` matches.
+  it('rejects mail-shaped files with no closing `---` delimiter — and warns', () => {
+    // The forge defense, re-derived for delimiter parsing: without a closing
+    // `---`, body lines can't be distinguished from frontmatter, so the file
+    // is rejected — but LOUDLY now (mmnto-ai/totem#2118: parse-null was the
+    // only warning-less failure path in the module).
     const filler = 'x'.repeat(2500);
     writeOutbox('totem-strategy', 'strategy-claude', [
       {
-        name: 'huge-no-separator.md',
+        name: 'huge-no-close.md',
         to: 'unused',
         raw: `---\nfrom: strategy-claude\n${filler}\nto: totem-claude\nsubject: forged\n`,
       },
     ]);
     const result = poll();
     expect(result.mail).toEqual([]);
+    expect(
+      result.warnings.some(
+        (w) => w.startsWith('mail parse failed') && w.includes('huge-no-close.md'),
+      ),
+    ).toBe(true);
   });
 
-  it('accepts a small file without a blank-line separator (header fits in MAX_HEADER_BYTES)', () => {
-    // Below the 2 KiB cap, the whole file is treated as header — that's the
-    // existing lenient behavior, preserved for valid handoffs that omit the
-    // trailing blank line.
+  it('accepts a frontmatter-only file regardless of blank-line separators (delimiter semantics)', () => {
+    // Supersedes the old "small file without blank-line separator" leniency:
+    // the closing `---` is the header terminator, full stop.
     writeOutbox('totem-strategy', 'strategy-claude', [
       {
         name: 'small-no-separator.md',
@@ -579,6 +617,112 @@ describe('pollMail — frontmatter forge defense', () => {
     const result = poll();
     expect(result.mail).toHaveLength(1);
     expect(result.mail[0]!.subject).toBe('tight');
+  });
+});
+
+// ─── Frontmatter-only dispatches > 2 KiB (#2118 regression class) ───────
+
+describe('pollMail — frontmatter-only dispatches (#2118)', () => {
+  it('parses a frontmatter-only dispatch larger than 2 KiB with zero blank lines', () => {
+    // The 8/8 miss class: cohort dispatches carry the whole message in
+    // `subject:` (observed live at 2,110–4,163 bytes, zero blank lines). The
+    // predecessor parser silently dropped every one of these over 2 KiB.
+    const raw = frontmatterOnlyDispatch(3300);
+    expect(raw.length).toBeGreaterThan(2048); // guard: the fixture exercises the old cap
+    expect(raw).not.toMatch(/\n\n/); // guard: genuinely zero blank lines
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: '2026-06-07T2015Z-totem-claude.md', to: 'unused', raw },
+    ]);
+    const result = poll();
+    expect(result.mail).toHaveLength(1);
+    expect(result.mail[0]!.to).toBe('totem-claude');
+    expect(result.mail[0]!.date).toBe('2026-06-07T2015Z');
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('parses a large frontmatter-only CRLF dispatch identically', () => {
+    const raw = frontmatterOnlyDispatch(3300, '\r\n');
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: 'crlf-large.md', to: 'unused', raw },
+    ]);
+    const result = poll();
+    expect(result.mail).toHaveLength(1);
+    expect(result.mail[0]!.to).toBe('totem-claude');
+  });
+
+  it('rejects a dispatch whose closing `---` sits beyond the search window — and warns', () => {
+    // Pathological-file bound: the cap now bounds the SEARCH WINDOW for the
+    // closing delimiter instead of rejecting any large no-blank-line file.
+    const raw = frontmatterOnlyDispatch(20_000);
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: 'over-window.md', to: 'unused', raw },
+    ]);
+    const result = poll();
+    expect(result.mail).toEqual([]);
+    expect(
+      result.warnings.some(
+        (w) => w.startsWith('mail parse failed') && w.includes('over-window.md'),
+      ),
+    ).toBe(true);
+  });
+
+  it('a blank line INSIDE the frontmatter does not truncate the header', () => {
+    // The old splitter cut the header at the first blank line — a blank line
+    // inside the frontmatter region hid every field after it.
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      {
+        name: 'inner-blank.md',
+        to: 'unused',
+        raw: '---\nfrom: strategy-claude\n\nto: totem-claude\nsubject: post-blank\n---\n',
+      },
+    ]);
+    const result = poll();
+    expect(result.mail).toHaveLength(1);
+    expect(result.mail[0]!.subject).toBe('post-blank');
+  });
+
+  it('parses the interim sender-discipline shape (blank line + body footer after closing `---`)', () => {
+    // The cohort's send-side hotfix while old readers are deployed; the new
+    // parser must treat the footer as body, not header.
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      {
+        name: 'footer.md',
+        to: 'unused',
+        raw: '---\nfrom: strategy-claude\nto: totem-claude\nsubject: with footer\n---\n\nFull content in subject above.\n',
+      },
+    ]);
+    const result = poll();
+    expect(result.mail).toHaveLength(1);
+    expect(result.mail[0]!.subject).toBe('with footer');
+  });
+});
+
+// ─── mailCommand --json (#2097) ─────────────────────────
+
+describe('mailCommand — --json output', () => {
+  it('emits valid JSON to stdout when json is set', async () => {
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: '2026-06-07T2015Z.md', to: 'totem-claude', subject: 'json contract' },
+    ]);
+    const writes: string[] = [];
+    const spy = vi
+      .spyOn(process.stdout, 'write')
+      .mockImplementation((chunk: string | Uint8Array) => {
+        writes.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf-8'));
+        return true;
+      });
+    try {
+      await mailCommand({ json: true, repoRoot: selfRepoRoot(), workspace, env: {} });
+    } finally {
+      spy.mockRestore();
+    }
+    // The JSON contract is a single stdout write — one parseable payload,
+    // nothing interleaved.
+    expect(writes).toHaveLength(1);
+    const parsed = JSON.parse(writes[0]!) as MailPollResult;
+    expect(parsed.mail).toHaveLength(1);
+    expect(parsed.mail[0]!.subject).toBe('json contract');
+    expect(parsed.warnings).toEqual([]);
   });
 });
 

--- a/packages/cli/src/commands/mail.test.ts
+++ b/packages/cli/src/commands/mail.test.ts
@@ -681,6 +681,45 @@ describe('pollMail — frontmatter-only dispatches (#2118)', () => {
     expect(result.mail[0]!.subject).toBe('post-blank');
   });
 
+  it('accepts trailing whitespace on the closing `---` line (hand-authored dispatches)', () => {
+    // Greptile R1 on mmnto-ai/totem#2119: tolerate `---  \n` as the closing
+    // delimiter. (The
+    // block-scalar rationale in the finding doesn't hold — YAML block-scalar
+    // content must be indented, so a column-0 `---` can't occur inside one —
+    // but trailing-whitespace tolerance is a real hand-edit robustness win.)
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      {
+        name: 'trailing-ws-close.md',
+        to: 'unused',
+        raw: '---\nfrom: strategy-claude\nto: totem-claude\nsubject: ws close\n---  \nBody.\n',
+      },
+    ]);
+    const result = poll();
+    expect(result.mail).toHaveLength(1);
+    expect(result.mail[0]!.subject).toBe('ws close');
+  });
+
+  it('reports the search-window reason only when content actually exceeds the window', () => {
+    // Greptile R1 on mmnto-ai/totem#2119: the window is content.slice(3, 3 +
+    // MAX), so files
+    // of MAX+1..MAX+3 bytes are NOT truncated — the reason must be the plain
+    // "no closing --- delimiter", reserving the window message for genuine
+    // truncation.
+    const atBoundary = `---\n${'x'.repeat(16_382)}`; // 16,386 bytes, no close
+    const overBoundary = `---\n${'x'.repeat(17_000)}`; // truncated by the window
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: 'at-boundary.md', to: 'unused', raw: atBoundary },
+      { name: 'over-boundary.md', to: 'unused', raw: overBoundary },
+    ]);
+    const result = poll();
+    expect(result.mail).toEqual([]);
+    const atWarning = result.warnings.find((w) => w.includes('at-boundary.md'));
+    const overWarning = result.warnings.find((w) => w.includes('over-boundary.md'));
+    expect(atWarning).toContain('no closing --- delimiter');
+    expect(atWarning).not.toContain('search window');
+    expect(overWarning).toContain('search window');
+  });
+
   it('parses the interim sender-discipline shape (blank line + body footer after closing `---`)', () => {
     // The cohort's send-side hotfix while old readers are deployed; the new
     // parser must treat the footer as body, not header.

--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -101,8 +101,11 @@ export interface MailCommandOptions {
  */
 const MAX_HEADER_SEARCH_BYTES = 16_384;
 
-/** Closing frontmatter delimiter: a `---` line after the opener (LF/CRLF/EOF). */
-const CLOSING_DELIMITER = /\r?\n---(?:\r?\n|$)/;
+/**
+ * Closing frontmatter delimiter: a `---` line after the opener (LF/CRLF/EOF),
+ * tolerating trailing whitespace on the line (hand-authored dispatches).
+ */
+const CLOSING_DELIMITER = /\r?\n---[ \t]*(?:\r?\n|$)/;
 
 /**
  * Discriminated parse result so the scan loop can warn on mail-shaped
@@ -149,7 +152,10 @@ function parseHeader(content: string): HeaderParse {
       ok: false,
       mailShaped: true,
       reason:
-        content.length > MAX_HEADER_SEARCH_BYTES
+        // The window starts at byte 3 (after the opener), so truncation only
+        // actually occurs past 3 + MAX — the window message must not fire for
+        // files the window fully covered (Greptile R1 on mmnto-ai/totem#2119).
+        content.length > 3 + MAX_HEADER_SEARCH_BYTES
           ? `no closing --- within the ${MAX_HEADER_SEARCH_BYTES}-byte search window`
           : 'no closing --- delimiter',
     };

--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -90,52 +90,87 @@ export interface MailCommandOptions {
 // ─── Frontmatter parsing ────────────────────────────────
 
 /**
- * Extract `to:` / `from:` / `subject:` / `date:` from a leading frontmatter
- * block. Restricts the regex search to the header (text before the first
- * blank line) so body lines starting with `to:` etc. cannot fabricate a
- * match or overwrite displayed metadata — same defense pattern as the
- * reference impl.
- *
- * Returns `null` if no `to:` field is present (the only frontmatter field
- * required for a file to be eligible mail).
+ * Hard cap on bytes searched for the CLOSING `---` frontmatter delimiter.
+ * Bounds regex work on pathological files. Genuine cohort frontmatter is
+ * multi-KiB — frontmatter-only dispatches carry the whole message in
+ * `subject:` (4,163 bytes observed live, mmnto-ai/totem#2118) — so the
+ * window is sized ~4× the observed max, NOT the "dozens of bytes" the
+ * 2 KiB predecessor assumed (that assumption silently dropped 8/8 of the
+ * misses in the #2118 forensics). A closing `---` beyond this window is
+ * treated as absent.
  */
-/**
- * Hard cap on bytes scanned for frontmatter when no blank-line separator
- * exists. Defense against forged frontmatter: a malformed handoff without
- * the `---\n\n` delimiter would otherwise let body lines starting with
- * `to:` fabricate metadata. Real frontmatter is dozens of bytes; 2 KiB
- * is generous-but-bounded.
- */
-const MAX_HEADER_BYTES = 2048;
+const MAX_HEADER_SEARCH_BYTES = 16_384;
 
-function parseHeader(content: string): {
-  to: string;
-  from: string | null;
-  subject: string | null;
-  date: string | null;
-} | null {
+/** Closing frontmatter delimiter: a `---` line after the opener (LF/CRLF/EOF). */
+const CLOSING_DELIMITER = /\r?\n---(?:\r?\n|$)/;
+
+/**
+ * Discriminated parse result so the scan loop can warn on mail-shaped
+ * rejects (sender error — must be loud, Tenet 4) while staying silent on
+ * stray non-mail files (a warning there would be permanent, unclearable
+ * noise: the recipient cannot remove a sender's file). Carries the reject
+ * reason for the warning message. mmnto-ai/totem#2118: parse-null was the
+ * module's only warning-less failure path, and it ate real dispatches.
+ */
+type HeaderParse =
+  | {
+      ok: true;
+      header: { to: string; from: string | null; subject: string | null; date: string | null };
+    }
+  | { ok: false; mailShaped: boolean; reason: string };
+
+/**
+ * Extract `to:` / `from:` / `subject:` / `date:` from a leading frontmatter
+ * block. Restricts the regex search to the delimited header (text between
+ * the opening and closing `---` lines) so body lines starting with `to:`
+ * etc. cannot fabricate a match or overwrite displayed metadata.
+ *
+ * `to:` is the only frontmatter field required for a file to be eligible
+ * mail; a mail-shaped file without it is a reject, not a fallback.
+ */
+function parseHeader(content: string): HeaderParse {
   // Defense in depth: real handoffs open with a YAML frontmatter delimiter.
   // Reject anything that doesn't, so a stray .md file in an outbox cannot
   // be coerced into mail.
-  if (!content.startsWith('---')) return null;
+  if (!content.startsWith('---')) {
+    return { ok: false, mailShaped: false, reason: 'no opening --- delimiter' };
+  }
 
-  const parts = content.split(/\r?\n\r?\n/, 2);
-  const header = parts[0] ?? '';
-  // When there's no blank-line separator, the split returns the whole
-  // file as parts[0]. Cap header size in that case so body content can't
-  // fabricate `to:`/`from:` matches.
-  if (parts.length < 2 && content.length > MAX_HEADER_BYTES) return null;
+  // Parse to the CLOSING `---` line (mmnto-ai/totem#2118). The predecessor
+  // split on the first blank line and rejected any >2 KiB file without one —
+  // silently dropping every frontmatter-only dispatch over 2 KiB (the cohort
+  // convention puts the whole message in `subject:`, zero blank lines). The
+  // closing delimiter is the real header terminator; the byte cap bounds the
+  // SEARCH WINDOW instead of rejecting the file outright.
+  const window = content.slice(3, 3 + MAX_HEADER_SEARCH_BYTES);
+  const close = CLOSING_DELIMITER.exec(window);
+  if (!close) {
+    return {
+      ok: false,
+      mailShaped: true,
+      reason:
+        content.length > MAX_HEADER_SEARCH_BYTES
+          ? `no closing --- within the ${MAX_HEADER_SEARCH_BYTES}-byte search window`
+          : 'no closing --- delimiter',
+    };
+  }
+  const header = window.slice(0, close.index);
 
   const toMatch = header.match(/^to:\s*(.+)$/im);
-  if (!toMatch) return null;
+  if (!toMatch) {
+    return { ok: false, mailShaped: true, reason: 'no to: field in frontmatter' };
+  }
   const fromMatch = header.match(/^from:\s*(.+)$/im);
   const subjectMatch = header.match(/^[-\s]*subject:\s*(.+)$/im);
   const dateMatch = header.match(/^date:\s*(.+)$/im);
   return {
-    to: toMatch[1]!.trim(),
-    from: fromMatch ? fromMatch[1]!.trim() : null,
-    subject: subjectMatch ? subjectMatch[1]!.trim() : null,
-    date: dateMatch ? dateMatch[1]!.trim() : null,
+    ok: true,
+    header: {
+      to: toMatch[1]!.trim(),
+      from: fromMatch ? fromMatch[1]!.trim() : null,
+      subject: subjectMatch ? subjectMatch[1]!.trim() : null,
+      date: dateMatch ? dateMatch[1]!.trim() : null,
+    },
   };
 }
 
@@ -356,8 +391,18 @@ export function pollMail(opts: MailCommandOptions = {}): MailPollResult {
       warnings.push(`mail read failed (${slot.repo}/${slot.agent}/${file}): ${String(err)}`);
       continue;
     }
-    const header = parseHeader(content);
-    if (!header) continue;
+    const parsed = parseHeader(content);
+    if (!parsed.ok) {
+      // Tenet 4 parity with the readFileSync path above: a mail-shaped file
+      // that fails to parse is the silent-drop hazard (mmnto-ai/totem#2118 —
+      // eight real dispatches vanished without a trace). Non-mail-shaped
+      // strays stay silent by design (see HeaderParse).
+      if (parsed.mailShaped) {
+        warnings.push(`mail parse failed (${slot.repo}/${slot.agent}/${file}): ${parsed.reason}`);
+      }
+      continue;
+    }
+    const header = parsed.header;
     const toLower = header.to.toLowerCase();
     if (toLower !== 'broadcast' && !selfLower.has(toLower)) continue;
     mail.push({

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -743,8 +743,14 @@ program
         // appears after the subcommand (commander parent/child option collision,
         // mmnto-ai/totem#2097): the value lands on program.opts() and the action
         // receives {}. optsWithGlobals() merges both scopes so `totem mail --json`
-        // and `totem --json mail` agree.
-        await mailCommand(cmd.optsWithGlobals());
+        // and `totem --json mail` agree. Typed destructure so a future global
+        // option can't silently shadow a MailCommandOptions field.
+        const { json, recursive, workspace } = cmd.optsWithGlobals<{
+          json?: boolean;
+          recursive?: boolean;
+          workspace?: string;
+        }>();
+        await mailCommand({ json, recursive, workspace });
       } catch (err) {
         handleError(err);
         // totem-context: handleError returns `never` (process.exit), so the throw is unreachable but required to satisfy the Tenet 4 fail-loud rule that bans bare-catch silent-degrade. Mirrors the verify-badges pattern above.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -735,16 +735,23 @@ program
     '--workspace <path>',
     'Workspace dir to scan (default: $TOTEM_WORKSPACE, else parent of cwd)',
   )
-  .action(async (opts: { json?: boolean; recursive?: boolean; workspace?: string }) => {
-    try {
-      const { mailCommand } = await import('./commands/mail.js');
-      await mailCommand(opts);
-    } catch (err) {
-      handleError(err);
-      // totem-context: handleError returns `never` (process.exit), so the throw is unreachable but required to satisfy the Tenet 4 fail-loud rule that bans bare-catch silent-degrade. Mirrors the verify-badges pattern above.
-      throw err;
-    }
-  });
+  .action(
+    async (_opts: { json?: boolean; recursive?: boolean; workspace?: string }, cmd: Command) => {
+      try {
+        const { mailCommand } = await import('./commands/mail.js');
+        // The program-level `--json` (top of file) swallows the flag when it
+        // appears after the subcommand (commander parent/child option collision,
+        // mmnto-ai/totem#2097): the value lands on program.opts() and the action
+        // receives {}. optsWithGlobals() merges both scopes so `totem mail --json`
+        // and `totem --json mail` agree.
+        await mailCommand(cmd.optsWithGlobals());
+      } catch (err) {
+        handleError(err);
+        // totem-context: handleError returns `never` (process.exit), so the throw is unreachable but required to satisfy the Tenet 4 fail-loud rule that bans bare-catch silent-degrade. Mirrors the verify-badges pattern above.
+        throw err;
+      }
+    },
+  );
 
 program
   .command('remove-secret <index>')


### PR DESCRIPTION
## Summary

Two read-side defects in `totem mail`, fixed together (ratified first in the 2026-06-07 next-wave synthesis; root-cause forensics pinned on strategy#543):

1. **Silent drop of frontmatter-only dispatches > 2 KiB.** `parseHeader` split on the first blank line and rejected any > 2 KiB file without one. The cohort dispatch convention (whole message in `subject:`, frontmatter-only, zero blank lines) produces exactly that shape — `size > 2048 && blankLines === 0` predicted **8/8** observed misses (2,110–4,163 bytes, age-independent, reproduced across three agents and two vendor lanes, including the sender's own SessionStart hook). The drop at the old `if (!header) continue` was the module's **only warning-less failure path**.
2. **`--json` emitted nothing** (#2097). The flag never reached the handler: the program-level `--json` (`index.ts`) swallows a post-subcommand flag (commander parent/child option collision — verified in isolation: sub opts `{}`, program opts `{json:true}`). The renderer itself was already correct.

## Fix

- **Parse to the closing `---` delimiter** — the real header terminator. The byte cap becomes `MAX_HEADER_SEARCH_BYTES` (16 KiB) bounding the **search window** for the closing delimiter instead of rejecting the file. *Deliberate deviation from the suggested fix-shape:* porting "cap bounds the search" at the existing 2048 would still reject every observed miss — genuine cohort frontmatter runs to 4,163 bytes; the window is sized ~4× the observed max (provenance in the constant's comment).
- **Forged-frontmatter defense preserved, re-derived**: fields are matched only inside the delimited header; body `to:` lines cannot fabricate a match; no-closing-delimiter files are rejected.
- **Mail-shaped rejects warn** (`mail parse failed (repo/agent/file): <reason>`) — parity with the module's readFile/readdir/processed-scan failure paths (Tenet 4). Non-mail-shaped strays (no opening `---`) stay silent by design: a recipient cannot clear a sender's stray file, so a warning there is permanent noise. Discriminated `HeaderParse` result carries the distinction.
- **`--json` routed via `cmd.optsWithGlobals()`** — merges both scopes, so `totem mail --json` and `totem --json mail` agree. Both option declarations stay (help text + env-sniff JSON mode untouched).

## Verification

- RED-first: 7 failing tests before implementation (regression class, CRLF variant, over-window reject + warn, inner-blank-line header, no-`to:` warnings, no-close warnings).
- 40/40 mail tests; **2454/2454** full `@mmnto/cli` suite.
- `totem lint` PASS (0 errors) · `totem review` PASS (no findings).
- **Live probe**: re-ran the strategy#543 reproduction (poll as `strategy-claude` on the built CLI) — the 4,163-byte frontmatter-only dispatch the broken parser dropped from the sender's own hook **now surfaces**; `node dist/index.js mail --json` emits parseable JSON end-to-end; zero parse warnings across the live workspace.
- Design doc (approved pre-build) committed in `.totem/specs/2118.md`.

Out of scope, per the ratified design: inbox model / derived handled-state / processed-marking mechanization (Proposal 290, #390, strategy#506 — the ECL design review judges the class; this is the instance fix proceeding in parallel).

Closes #2118
Closes #2097

🤖 Generated with [Claude Code](https://claude.com/claude-code)
