### PR TITLE
feat(orchestrator): grounding bundle with day-one provenance classes (#2101)

### DIFF
--- a/.changeset/grounding-bundle-provenance.md
+++ b/.changeset/grounding-bundle-provenance.md
@@ -1,0 +1,8 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+---
+
+feat(orchestrator): grounding bundle with day-one provenance classes (#2101, strategy#474 slice 2).
+
+Every run artifact now carries a per-item `grounding.bundle`: each delivered evidence item self-describes its provenance class (`similarity-only` | `structurally-verified` | `spec-contract` | `compiled-rule` — open vocabulary with canonical constants, consumers fail-safe-down on unknown classes), its identity (`sourceType`, `filePath`, optional `sourceRepo`; absent = the run's own repo), and a `contentHash` (identity, never bytes — the masked prompt already carries content once). The first cut wraps existing retrieval honestly as `similarity-only`; structural resolvers (#344/#375) graduate items later. `grounding.hash` becomes the deterministic hash of the bundle (recomputable from the artifact surface alone) and `provenanceSummary` is derived as a sorted class-count string (`similarity-only:14`; zero items → `ungrounded`). Bundle items are canonically sorted so retrieval order never moves the hash. Reruns carry the bundle verbatim. `RUN_ARTIFACT_SCHEMA_VERSION` bumps to 1.1.0 (additive; the version-tolerant reader parses slice-1 artifacts unchanged — they cannot be re-classed and stay as-is). New core exports: `GroundingItemSchema`, `GroundingBundleSchema`, `buildGroundingBundle`, `summarizeProvenance`, `PROVENANCE_CLASSES`, `PROVENANCE_UNGROUNDED`.

--- a/.totem/specs/2101.md
+++ b/.totem/specs/2101.md
@@ -1,0 +1,168 @@
+### Problem Statement
+
+The deterministic context-assembly layer needs a formal `GroundingBundle` schema to explicitly classify the provenance of retrieved information (e.g., `similarity-only`, `structurally-verified`). Currently, fuzzy vector searches are passed to the LLM without strict classification; this work wraps existing retrievals honestly as `similarity-only` and deterministically hashes the resulting bundle so the artifact API can verify the grounding quality.
+
+### Architectural Context
+
+From provided context:
+
+- **Structural Layers (Deep Dive):** Emphasizes the hard separation between the fuzzy semantic layer and the rigid deterministic layer. The deterministic layer must own the bundle classification.
+- **`RunArtifactRequest` (packages/cli/src/utils.ts):** Already contains `groundingHash` and `provenanceSummary` fields from slice 1, expecting a SHA-256 hex and a provenance string (e.g., `PROVENANCE_SIMILARITY_ONLY`).
+
+### Files to Examine
+
+1. `packages/cli/src/utils.ts` — Contains the `RunArtifactRequest` interface which consumes the hash and summary.
+2. `packages/cli/src/commands/spec.ts` — Currently retrieves LanceDB context; needs to wrap it in the new bundle schema.
+3. `packages/cli/src/commands/shield.ts` — Also retrieves context; requires the same bundle wrapping.
+
+### Technical Approach & Contracts
+
+We will implement a standard Zod schema for the Grounding Bundle and a deterministic hashing utility.
+
+**Data Contracts:**
+
+```typescript
+import { z } from 'zod';
+
+export const ProvenanceClassSchema = z.enum([
+  'similarity-only',
+  'structurally-verified',
+  'spec-contract',
+  'compiled-rule',
+]);
+
+export const GroundingItemSchema = z.object({
+  provenance: ProvenanceClassSchema,
+  source: z.string(), // File path, URL, or identifier
+  content: z.string(),
+  // Optional metadata must be string-keyed if used, but strictly limited to avoid hashing instability
+});
+
+export const GroundingBundleSchema = z.object({
+  items: z.array(GroundingItemSchema),
+});
+
+export type ProvenanceClass = z.infer<typeof ProvenanceClassSchema>;
+export type GroundingItem = z.infer<typeof GroundingItemSchema>;
+export type GroundingBundle = z.infer<typeof GroundingBundleSchema>;
+```
+
+**Sequence Logic:**
+
+1. **Schema & Utilities:** Create a `grounding.ts` utility file in the CLI package. Implement a `hashGroundingBundle(bundle: GroundingBundle): string` function.
+2. **Deterministic Hashing:** To avoid JSON key-order race conditions, the hashing function must map items to a strict array tuple before stringifying: `JSON.stringify(bundle.items.map(i => [i.provenance, i.source, i.content]))`, then hash with Node's `crypto.createHash('sha256')`.
+3. **Command Integration (`spec` & `shield`):**
+   - Intercept the LanceDB retrieval results.
+   - Map them into `GroundingItem` records hardcoded to `similarity-only`.
+   - Construct the `GroundingBundle` and calculate the `groundingHash`.
+   - Derive the `provenanceSummary`. If the array is empty, it should explicitly report `PROVENANCE_EMPTY`. If all items are `similarity-only`, report `PROVENANCE_SIMILARITY_ONLY`.
+   - Pass these into the `RunArtifactRequest` or equivalent artifact recording step.
+
+### Edge Cases & Traps
+
+- **JSON Serialization Instability:** Relying on `JSON.stringify(item)` directly for hashing is an architectural trap. Different V8 engines or minor code reshuffling can alter object key insertion order, mutating the hash for identical data. The approach must strictly serialize values in a guaranteed order (e.g., tuple extraction).
+- **Honest-Absent Discipline:** If LanceDB returns no results, the system must NOT omit the bundle step. It must create an empty bundle, hash the empty state, and honestly report `PROVENANCE_EMPTY`.
+- **Silent Upgrades:** The implementation must not provide a mechanism to default or auto-upgrade provenance. `similarity-only` must be explicitly passed by the caller.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Define GroundingBundle Contracts & Hashing**
+  - Create `packages/cli/src/grounding.ts`.
+  - Export the Zod schemas (`ProvenanceClassSchema`, `GroundingItemSchema`, `GroundingBundleSchema`) and their inferred types.
+  - Implement `hashGroundingBundle(bundle: GroundingBundle): string` using `crypto.createHash('sha256')` and strict tuple serialization `[provenance, source, content]`.
+  - Implement `summarizeProvenance(bundle: GroundingBundle): string` (returns `PROVENANCE_EMPTY`, `PROVENANCE_SIMILARITY_ONLY`, or `PROVENANCE_MIXED`).
+    > TEST DIRECTIVE: Before implementing, write a failing test named `generates identical hashes for bundles with different object key insertion orders` to prove the hashing mechanism is deterministic.
+  - write test (in `packages/cli/src/__tests__/grounding.test.ts`) → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Integrate GroundingBundle into Spec Command**
+  - Modify `packages/cli/src/commands/spec.ts`.
+  - Import the schemas and utility functions from `grounding.ts`.
+  - Locate the LanceDB retrieval logic. Map the raw semantic results into `GroundingItem` objects with provenance `'similarity-only'`.
+    > TOTEM INVARIANT (Honest-absent discipline): A bundle with zero structurally-verified items says so; nothing upgrades provenance silently.
+  - Generate the bundle, calculate the hash, and calculate the summary.
+  - Inject `groundingHash` and `provenanceSummary` into the downstream artifact request.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `honestly reports PROVENANCE_EMPTY and valid hash when no semantic index results are found` in the spec command tests.
+  - update existing test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Integrate GroundingBundle into Shield Command**
+  - Modify `packages/cli/src/commands/shield.ts`.
+  - Apply the exact same wrapping logic used in Task 2 to the shield command's context retrieval.
+  - Ensure the resulting hash and summary are passed to the shield's artifact submission payload.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `tags all retrieved context explicitly as similarity-only in shield artifact payload`.
+  - update existing test → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+1. **Deterministic Hashing:** Create two identical semantic context chunks but assign object keys in different orders (`{content, source, provenance}` vs `{provenance, source, content}`). Assert they produce the exact same SHA-256 hex.
+2. **Empty States (Honest-Absent):** Mock the LanceStore to return 0 results. Assert the commands generate a valid SHA-256 hash representing an empty array and output `PROVENANCE_EMPTY`.
+3. **Schema Rejection:** Attempt to parse a bundle containing an invalid provenance string (e.g., `similarity`) using `GroundingBundleSchema.parse()`. Assert it throws a Zod validation error, proving day-one immutability of the allowed classes.
+
+## Implementation Design
+
+> Supersedes three spec proposals after the verify-against-code pass: (1) classes are an **open string with canonical constants**, not `z.enum` — the issue says "(extensible)" and slice 1's `provenanceSummary` precedent exists precisely so additions land minor-not-major (the spec's own Test 3 would forbid that); (2) hashing reuses core's existing `calculateDeterministicHash` — the spec's hand-rolled tuple serialization would create a second hashing convention (the 292 §6/§9.1 "one enumeration, two readers" violation); (3) the schema lives in **core** (`packages/core/src/artifacts/`), beside the artifact schema it extends — CLI assembles, core defines and validates.
+
+### Scope
+
+Add a `GroundingBundle` schema (core) where every item self-describes its provenance class, assemble it caller-side in `spec`/`shield` wrapping today's retrieval honestly as `similarity-only`, hash the bundle into the run artifact, and derive `provenanceSummary` from the bundle instead of asserting it wholesale. NOT in scope: the structural resolvers (#344/#375 own populating `structurally-verified`), post-check enforcement (#2103), any re-classing of existing artifacts (day-one means day-one), provider-side changes (providers stay dumb pipes), new `totem artifact` verbs, and bundling shield's `fileContext`/`smartHints` (today's grounding hash covers `RetrievedContext` only; widening the surface is a separate, explicit decision).
+
+### Data model deltas
+
+- **`PROVENANCE_CLASSES` canonical constants (core):** `similarity-only` | `structurally-verified` | `spec-contract` | `compiled-rule`. Schema-level validation is `z.string().min(1)` (extensible without a major); the constants define the canonical vocabulary; honest-usage discipline (and future post-checks) governs values. `PROVENANCE_SIMILARITY_ONLY` is retained and becomes one of the four. **Fail-safe-down rider (strategy review F2, doctrine-line now, test rides #2103):** every consumer (summarize, eval thresholds, future sensing) treats a non-canonical class string as NOT-upgraded — lowest trust — so an invented class can never confer trust absent code-side graduation. Safe today because classes are builder-emitted constants, never model-supplied.
+- **`GroundingItemSchema` (core, new):** `{ provenance: string, contentHash: sha256-hex, sourceType: string ('spec'|'session_log'|'code'|'lesson'), filePath: string, sourceRepo?: string }`. Written by `buildGroundingBundle` (core helper); read by conformance-sensing, the eval harness, and `artifact compare`. **Absent `sourceRepo` means the run's own repo** (strategy review F1) — cross-repo post-checks resolve `filePath` against the run's config root when the field is absent, deterministically. **Identity + hash only — no content bytes**: the artifact's `maskedPrompt` already carries the bytes once; duplicating them bloats every artifact and creates a second DLP surface. `contentHash` is sha256 of the raw retrieved snippet (hash of secret-bearing text is not reversible — same posture as `groundingHash` today).
+- **`GroundingBundleSchema` (core, new):** `{ items: GroundingItem[] }`. **No stored summary/count fields** — counts are derived (derive-or-couple: a stored `classCounts` is a mirror that can drift from `items`).
+- **`GroundingSchema` delta (core, additive):** gains `bundle: GroundingBundleSchema.optional()`. Old artifacts lack it (the F1 version-tolerant reader carries them); new artifacts always populate it.
+- **`RunArtifactRequest` delta (cli, additive):** gains `bundle?: GroundingBundle`, passed through verbatim into `grounding.bundle`.
+- **Derivation helpers (core, new):** `buildGroundingBundle(items: Array<{sourceType, result: SearchResult}>): GroundingBundle` — maps + **canonically sorts** items (by `sourceType`, `filePath`, `contentHash`) so retrieval order (score-dependent, nondeterministic across runs) never changes the hash; `summarizeProvenance(bundle): string` — sorted class-count string (`similarity-only:14` / `similarity-only:12,structurally-verified:2`), zero items → `'ungrounded'` (more honest than the spec's `PROVENANCE_EMPTY` — it names the epistemic state, not the mechanical one). Sorted counts beat the spec's `PROVENANCE_MIXED`: deterministic, parseable, and the eval harness can threshold on them.
+- **Hash semantics change:** `grounding.hash` becomes `calculateDeterministicHash(bundle)` (was: hash of raw `RetrievedContext`). The bundle is the verifier's surface — the attestation must hash what the verifier will hash. Item content is covered transitively via per-item `contentHash`.
+- **`RUN_ARTIFACT_SCHEMA_VERSION`:** minor bump (additive field + changed hash derivation is a meaning change worth a version marker). Migration registry stays empty by policy — the F1 reader parses both shapes; the bump is a marker, not a migration.
+
+### State lifecycle
+
+No new persistent state containers. The bundle is per-invocation: assembled in the command (after retrieval, before `runOrchestrator`), embedded in the immutable artifact at emission, never mutated. The rerun path (`run-artifacts.ts`) carries `source.grounding` — including `bundle` — **verbatim** (rerun makes no new grounding claim; one-line passthrough addition).
+
+### Failure modes
+
+| Failure                                       | Category                | Agent-facing surface                                                                                                                                  | Recovery                                          |
+| --------------------------------------------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| Retrieval returns zero items                  | runtime (expected)      | bundle emitted with `items: []`, summary `'ungrounded'` — loud in the artifact, run proceeds (a spec run with no index hits is degraded, not invalid) | next run with populated index                     |
+| Bundle fails schema validation at emission    | runtime (bug)           | existing #2100 contract: artifact emission warns and never fails the run                                                                              | fix + rerun; the warn is the signal               |
+| Old artifact (no `bundle`) hits rerun/compare | permanent (by design)   | parses via version-tolerant reader; rerun carries grounding verbatim sans bundle; compare shows hash inequality vs new-format runs honestly           | none needed — old artifacts are immutable history |
+| Caller passes a non-canonical class string    | runtime (future misuse) | schema accepts (extensible by design); conformance-sensing/post-checks (#2103) own flagging unknown classes                                           | doctrine + post-check, not schema rejection       |
+| Item missing `filePath`/`sourceType`          | init (bug)              | hard Zod error at bundle build — identity fields are required, fabricated/absent identity is the illusion-of-grounding trap                           | fix at the call site                              |
+
+### Invariants to lock in via tests
+
+1. First-cut builder emits **only** `similarity-only` items — no input shape can produce an upgraded class (nothing upgrades provenance silently).
+2. Same item set in different retrieval order → **identical bundle hash** (canonical sort inside the builder; `calculateDeterministicHash` key-sorts objects but is order-significant for arrays).
+3. `summarizeProvenance` derives from `items` only; zero items → `'ungrounded'`; multi-class counts render in sorted class order (deterministic string).
+4. `grounding.hash` recorded in the artifact equals `calculateDeterministicHash` of the recorded `grounding.bundle` — one enumeration, two readers (the gate-correctness cluster's generalization, applied at birth).
+5. A slice-1 artifact (no `bundle`, wholesale summary) still parses, reruns, and compares (version tolerance).
+6. Rerun of a bundled artifact carries `bundle` byte-identical (no new grounding claim).
+7. Bundle items carry no content bytes (schema has no content field — asserted structurally).
+8. Both callers (spec + shield) emit bundles whose item count equals their retrieved-context totals (no silent item drops between retrieval and bundle).
+
+### Open questions
+
+- **Q1 — Class vocabulary: open string + canonical constants (recommended) vs `z.enum`.** Open string matches the issue's "(extensible)", the slice-1 precedent, and lets #344/#375 graduate classes without majors; the schema stops validating vocabulary, which #2103's post-checks own. `z.enum` gives day-one rejection of typos but makes every future class a breaking schema change for old readers.
+- **Q2 — `grounding.hash` semantics: switch to hash-of-bundle (recommended) vs keep hash-of-context and add a separate `bundleHash`.** Switching keeps ONE hash with one meaning (the verifier's surface); keeping both preserves slice-1 comparability across the boundary at the cost of two hashes that will be confused. Old-vs-new comparability is already broken by the format change either way.
+- **Q3 — `RUN_ARTIFACT_SCHEMA_VERSION` minor bump: yes (recommended) vs no.** Bump marks the hash-semantics change observably; reader is tolerant either way. Cost: trivially touches the F1 test fixtures.

--- a/packages/cli/src/commands/shield.ts
+++ b/packages/cli/src/commands/shield.ts
@@ -1361,9 +1361,12 @@ export async function shieldCommand(options: ShieldOptions): Promise<void> {
   log.dim(DISPLAY_TAG, `Prompt: ${(prompt.length / 1024).toFixed(0)}KB`);
 
   // Grounded run artifact (mmnto-ai/totem#2100): always-on for the standard
-  // review verdict path — every run is a future eval fixture. Wholesale
-  // similarity-only grounding hash in slice 1; per-item classes are #2101.
-  const { calculateDeterministicHash, PROVENANCE_SIMILARITY_ONLY } = await import('@mmnto/totem');
+  // review verdict path — every run is a future eval fixture. Per-item
+  // provenance bundle (mmnto-ai/totem#2101): every retrieved item enters classed
+  // similarity-only; hash + summary are DERIVED from the bundle.
+  const { calculateDeterministicHash, summarizeProvenance } = await import('@mmnto/totem');
+  const { buildRetrievalGroundingBundle } = await import('../utils.js');
+  const groundingBundle = buildRetrievalGroundingBundle(context);
   const content = await runOrchestrator({
     prompt,
     tag: TAG,
@@ -1374,8 +1377,9 @@ export async function shieldCommand(options: ShieldOptions): Promise<void> {
     totalResults,
     temperature: 0,
     artifact: {
-      groundingHash: calculateDeterministicHash(context),
-      provenanceSummary: PROVENANCE_SIMILARITY_ONLY,
+      groundingHash: calculateDeterministicHash(groundingBundle),
+      provenanceSummary: summarizeProvenance(groundingBundle),
+      bundle: groundingBundle,
     },
   });
   if (content != null) {

--- a/packages/cli/src/commands/spec.ts
+++ b/packages/cli/src/commands/spec.ts
@@ -370,10 +370,14 @@ export async function specCommand(inputs: string[], options: SpecOptions): Promi
   const prompt = await assemblePrompt(parsed, context, systemPrompt);
   log.dim(TAG, `Prompt: ${(prompt.length / 1024).toFixed(0)}KB`);
 
-  // Grounded run artifact (mmnto-ai/totem#2100): always-on for spec —
-  // every run is a future eval fixture. The grounding hash covers the
-  // retrieved context wholesale; per-item provenance classes are #2101.
-  const { calculateDeterministicHash, PROVENANCE_SIMILARITY_ONLY } = await import('@mmnto/totem');
+  // Grounded run artifact (mmnto-ai/totem#2100): always-on for spec — every
+  // run is a future eval fixture. Per-item provenance bundle (mmnto-ai/totem#2101): every
+  // retrieved item enters classed similarity-only; hash + summary are DERIVED
+  // from the bundle, so the attested hash is recomputable from the artifact
+  // surface alone.
+  const { calculateDeterministicHash, summarizeProvenance } = await import('@mmnto/totem');
+  const { buildRetrievalGroundingBundle } = await import('../utils.js');
+  const groundingBundle = buildRetrievalGroundingBundle(context);
   const content = await runOrchestrator({
     prompt,
     tag: TAG,
@@ -387,8 +391,9 @@ export async function specCommand(inputs: string[], options: SpecOptions): Promi
     configRoot: path.dirname(configPath),
     totalResults,
     artifact: {
-      groundingHash: calculateDeterministicHash(context),
-      provenanceSummary: PROVENANCE_SIMILARITY_ONLY,
+      groundingHash: calculateDeterministicHash(groundingBundle),
+      provenanceSummary: summarizeProvenance(groundingBundle),
+      bundle: groundingBundle,
     },
   });
   if (content == null) return;

--- a/packages/cli/src/services/run-artifacts.test.ts
+++ b/packages/cli/src/services/run-artifacts.test.ts
@@ -96,6 +96,35 @@ describe('rerunArtifact', () => {
     expect(result.content).toBe('rerun content');
   });
 
+  it('carries the grounding bundle verbatim on rerun — no new grounding claim (mmnto-ai/totem#2101)', async () => {
+    const bundle = {
+      items: [
+        {
+          provenance: 'similarity-only',
+          contentHash: 'c'.repeat(64),
+          sourceType: 'code',
+          filePath: 'src/x.ts',
+        },
+      ],
+    };
+    const bundledHash = saveRunArtifact(
+      path.join(tmpDir, '.totem'),
+      artifact({
+        inputBundle: { maskedPrompt: 'bundled prompt' },
+        grounding: { hash: 'd'.repeat(64), provenanceSummary: 'similarity-only:1', bundle },
+      }),
+    ).hash;
+
+    await rerunArtifact({ hash: bundledHash, config: config(), cwd: tmpDir });
+
+    const call = mockedRunOrchestrator.mock.calls[0]![0];
+    expect(call.artifact).toMatchObject({
+      groundingHash: 'd'.repeat(64),
+      provenanceSummary: 'similarity-only:1',
+      bundle,
+    });
+  });
+
   it('throws on a missing source hash without invoking anything', async () => {
     await expect(
       rerunArtifact({ hash: 'e'.repeat(64), config: config(), cwd: tmpDir }),

--- a/packages/cli/src/services/run-artifacts.ts
+++ b/packages/cli/src/services/run-artifacts.ts
@@ -73,9 +73,11 @@ export async function rerunArtifact(opts: RerunArtifactOptions): Promise<RerunAr
       ? { temperature: source.backend.temperature }
       : {}),
     artifact: {
-      // The rerun makes no new grounding claim — identity carried verbatim.
+      // The rerun makes no new grounding claim — identity carried verbatim,
+      // including the per-item bundle when the source artifact has one (mmnto-ai/totem#2101).
       groundingHash: source.grounding.hash,
       provenanceSummary: source.grounding.provenanceSummary,
+      ...(source.grounding.bundle !== undefined ? { bundle: source.grounding.bundle } : {}),
       ...(source.inputBundle.diffScope !== undefined
         ? { diffScope: source.inputBundle.diffScope }
         : {}),

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -6,10 +6,11 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { SearchResult, TotemConfig } from '@mmnto/totem';
-import { RunArtifactSchema } from '@mmnto/totem';
+import { calculateDeterministicHash, RunArtifactSchema, summarizeProvenance } from '@mmnto/totem';
 
 import { cleanTmpDir } from './test-utils.js';
 import {
+  buildRetrievalGroundingBundle,
   formatLessonSection,
   formatResults,
   getSystemPrompt,
@@ -1194,6 +1195,46 @@ describe('formatLessonSection', () => {
   });
 });
 
+// ─── buildRetrievalGroundingBundle (mmnto-ai/totem#2101) ──
+
+describe('buildRetrievalGroundingBundle', () => {
+  function result(filePath: string, sourceRepo?: string) {
+    return {
+      content: `content of ${filePath}`,
+      filePath,
+      ...(sourceRepo !== undefined ? { sourceRepo } : {}),
+    };
+  }
+
+  it('maps every partition with its sourceType — item count equals retrieval totals (invariant 8)', () => {
+    const bundle = buildRetrievalGroundingBundle({
+      specs: [result('specs/a.md')],
+      sessions: [result('journal/s1.md'), result('journal/s2.md')],
+      code: [result('src/x.ts'), result('src/y.ts', 'strategy')],
+      lessons: [result('lessons/l1.md')],
+    });
+    expect(bundle.items).toHaveLength(6);
+    const byType = (t: string) => bundle.items.filter((i) => i.sourceType === t).length;
+    expect(byType('spec')).toBe(1);
+    expect(byType('session_log')).toBe(2);
+    expect(byType('code')).toBe(2);
+    expect(byType('lesson')).toBe(1);
+    expect(bundle.items.every((i) => i.provenance === 'similarity-only')).toBe(true);
+    expect(bundle.items.find((i) => i.filePath === 'src/y.ts')?.sourceRepo).toBe('strategy');
+  });
+
+  it('empty retrieval yields an empty bundle that summarizes as ungrounded', () => {
+    const bundle = buildRetrievalGroundingBundle({
+      specs: [],
+      sessions: [],
+      code: [],
+      lessons: [],
+    });
+    expect(bundle.items).toEqual([]);
+    expect(summarizeProvenance(bundle)).toBe('ungrounded');
+  });
+});
+
 // ─── runOrchestrator artifact emission (mmnto-ai/totem#2100) ──
 
 describe('runOrchestrator artifact emission (#2100)', { timeout: 15_000 }, () => {
@@ -1273,11 +1314,48 @@ describe('runOrchestrator artifact emission (#2100)', { timeout: 15_000 }, () =>
     expect(artifact.backend.taskProfile).toBe('Spec');
     expect(artifact.backend.provider).toBe('gemini');
     expect(artifact.output.content).toBe('mock result');
+    expect(artifact.grounding.bundle).toBeUndefined(); // no bundle supplied → none recorded (never fabricated)
     expect(artifact.output.metrics).toMatchObject({
       inputTokens: 100,
       outputTokens: 50,
       durationMs: 500,
     });
+  });
+
+  it('records the grounding bundle verbatim and the attested hash recomputes from it (mmnto-ai/totem#2101)', async () => {
+    const bundle = {
+      items: [
+        {
+          provenance: 'similarity-only',
+          contentHash: 'c'.repeat(64),
+          sourceType: 'code',
+          filePath: 'src/x.ts',
+          sourceRepo: 'strategy',
+        },
+      ],
+    };
+    const emitted: string[] = [];
+    await runOrchestrator({
+      prompt: 'bundled run',
+      tag: 'Spec',
+      options: { fresh: true },
+      config: artifactConfig(),
+      cwd: tmpDir,
+      artifact: {
+        groundingHash: calculateDeterministicHash(bundle),
+        provenanceSummary: summarizeProvenance(bundle),
+        bundle,
+        onEmitted: (hash) => emitted.push(hash),
+      },
+    });
+
+    const file = path.join(runsDirPath(), `${emitted[0]!}.json`);
+    const artifact = RunArtifactSchema.parse(JSON.parse(fs.readFileSync(file, 'utf-8')));
+    expect(artifact.grounding.bundle).toEqual(bundle);
+    expect(artifact.grounding.provenanceSummary).toBe('similarity-only:1');
+    // Invariant 4 at the emission seam: one enumeration, two readers — the
+    // recorded hash is recomputable from the recorded bundle alone.
+    expect(artifact.grounding.hash).toBe(calculateDeterministicHash(artifact.grounding.bundle));
   });
 
   it('records the MASKED prompt — a custom secret never reaches the artifact', async () => {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -5,9 +5,16 @@ import * as path from 'node:path';
 
 import dotenv from 'dotenv';
 
-import type { CustomSecret, RunArtifact, SearchResult, TotemConfig } from '@mmnto/totem';
+import type {
+  CustomSecret,
+  GroundingBundle,
+  RunArtifact,
+  SearchResult,
+  TotemConfig,
+} from '@mmnto/totem';
 import {
   ADMISSION_COMPLETION_ONLY,
+  buildGroundingBundle,
   calculateDeterministicHash,
   CONFIG_FILES,
   maskSecrets,
@@ -416,16 +423,47 @@ function buildResponseCacheHash(
  * `OrchestratorResult` metrics that never leave this function).
  */
 export interface RunArtifactRequest {
-  /** Deterministic hash of the grounding context the caller assembled (sha256 hex). */
+  /** Deterministic hash of the grounding surface — `calculateDeterministicHash(bundle)` when a bundle is supplied (mmnto-ai/totem#2101). */
   groundingHash: string;
-  /** What KIND of grounding — slice 1 passes `PROVENANCE_SIMILARITY_ONLY` wholesale. */
+  /** Derived class-count summary (`summarizeProvenance(bundle)`) when a bundle is supplied; explicit string otherwise (bundle-less reruns of slice-1 artifacts). */
   provenanceSummary: string;
+  /**
+   * Per-item provenance record (mmnto-ai/totem#2101), recorded verbatim into
+   * `grounding.bundle`. Optional ONLY for reruns of slice-1 artifacts, which
+   * carry their original grounding identity and have no bundle to forge.
+   */
+  bundle?: GroundingBundle;
   /** Deterministic diff input when the run was scoped (`lint/review --branch`, #2098). */
   diffScope?: string;
   /** The grounded spec contract, when the run senses against one. */
   specContract?: string;
   /** Fires after a successful write (or dedup hit) with the content address + path. */
   onEmitted?: (hash: string, artifactPath: string) => void;
+}
+
+/** The identity-relevant subset of a retrieval hit — what the bundle records. */
+type RetrievalItem = Pick<SearchResult, 'content' | 'filePath' | 'sourceRepo'>;
+
+/**
+ * Assemble the grounding bundle for the spec/review retrieval shape
+ * (mmnto-ai/totem#2101): every partition's items enter under their partition
+ * as `sourceType`, classed `similarity-only` by the core builder. Shared by
+ * both callers so the retrieval→bundle mapping has ONE enumeration — a
+ * caller-local copy that drifted would silently drop a partition from the
+ * provenance record.
+ */
+export function buildRetrievalGroundingBundle(context: {
+  specs: RetrievalItem[];
+  sessions: RetrievalItem[];
+  code: RetrievalItem[];
+  lessons: RetrievalItem[];
+}): GroundingBundle {
+  return buildGroundingBundle([
+    ...context.specs.map((result) => ({ sourceType: 'spec', result })),
+    ...context.sessions.map((result) => ({ sourceType: 'session_log', result })),
+    ...context.code.map((result) => ({ sourceType: 'code', result })),
+    ...context.lessons.map((result) => ({ sourceType: 'lesson', result })),
+  ]);
 }
 
 /**
@@ -708,6 +746,9 @@ export async function runOrchestrator(opts: {
         grounding: {
           hash: opts.artifact.groundingHash,
           provenanceSummary: opts.artifact.provenanceSummary,
+          // Verbatim passthrough — the bundle was assembled and hashed by the
+          // caller (mmnto-ai/totem#2101); this seam records, never re-derives or upgrades.
+          ...(opts.artifact.bundle !== undefined ? { bundle: opts.artifact.bundle } : {}),
         },
         backend: {
           provider: resolved.parsed.provider,

--- a/packages/core/src/artifacts/grounding.test.ts
+++ b/packages/core/src/artifacts/grounding.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Grounding-bundle tests (mmnto-ai/totem#2101, strategy#474 slice 2).
+ *
+ * The invariants under test are the design doc's eight, minus the caller-side
+ * ones (those live in the CLI test suites):
+ *   1. first-cut builder emits ONLY similarity-only items,
+ *   2. input order never moves the bundle hash (canonical sort),
+ *   3. summary derives from items alone; zero items → 'ungrounded',
+ *   5. slice-1 artifacts (no bundle) still parse (F1 tolerance),
+ *   7. items carry identity + hash, never content bytes.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildGroundingBundle,
+  type GroundingSourceItem,
+  summarizeProvenance,
+} from './grounding.js';
+import { calculateDeterministicHash } from './hash.js';
+import {
+  GroundingItemSchema,
+  PROVENANCE_CLASSES,
+  PROVENANCE_COMPILED_RULE,
+  PROVENANCE_SIMILARITY_ONLY,
+  PROVENANCE_UNGROUNDED,
+  RUN_ARTIFACT_SCHEMA_VERSION,
+  RunArtifactSchema,
+} from './schema.js';
+
+function source(
+  overrides: Partial<GroundingSourceItem['result']> = {},
+  sourceType = 'code',
+): GroundingSourceItem {
+  return {
+    sourceType,
+    result: { content: 'function x() {}', filePath: 'src/x.ts', ...overrides },
+  };
+}
+
+function baseArtifact(): Record<string, unknown> {
+  return {
+    schemaVersion: RUN_ARTIFACT_SCHEMA_VERSION,
+    inputBundle: { maskedPrompt: 'prompt after DLP' },
+    inputHash: 'a'.repeat(64),
+    grounding: { hash: 'b'.repeat(64), provenanceSummary: 'similarity-only' },
+    backend: {
+      provider: 'gemini',
+      model: 'gemini-3.1-pro-preview',
+      qualifiedModel: 'gemini:gemini-3.1-pro-preview',
+      admissionClass: 'completion_only',
+      taskProfile: 'Spec',
+    },
+    output: { content: 'response', metrics: { durationMs: 100 } },
+    createdAt: '2026-06-07T23:00:00.000Z',
+  };
+}
+
+describe('buildGroundingBundle', () => {
+  it('includes every input item — duplicates are delivery records, never deduped', () => {
+    const item = source();
+    const bundle = buildGroundingBundle([item, item, source({ filePath: 'src/y.ts' })]);
+    expect(bundle.items).toHaveLength(3);
+  });
+
+  it('first cut emits only similarity-only — no input shape produces an upgraded class', () => {
+    const bundle = buildGroundingBundle([
+      source(),
+      source({ filePath: 'lessons/l1.md' }, 'lesson'),
+      source({ filePath: 'spec.md', sourceRepo: 'strategy' }, 'spec'),
+    ]);
+    expect(bundle.items.every((i) => i.provenance === PROVENANCE_SIMILARITY_ONLY)).toBe(true);
+  });
+
+  it('same item set in any input order produces a deep-equal bundle and identical hash', () => {
+    const items = [
+      source({ filePath: 'src/b.ts' }),
+      source({ filePath: 'src/a.ts' }, 'spec'),
+      source({ filePath: 'src/a.ts', sourceRepo: 'strategy' }),
+      source({ content: 'other content', filePath: 'src/a.ts' }),
+    ];
+    const forward = buildGroundingBundle(items);
+    const reversed = buildGroundingBundle([...items].reverse());
+    expect(forward).toEqual(reversed);
+    expect(calculateDeterministicHash(forward)).toBe(calculateDeterministicHash(reversed));
+  });
+
+  it('contentHash uses the one deterministic-hash convention; items carry no content bytes', () => {
+    const bundle = buildGroundingBundle([source({ content: 'the snippet' })]);
+    expect(bundle.items[0]!.contentHash).toBe(calculateDeterministicHash('the snippet'));
+    expect(JSON.stringify(bundle)).not.toContain('the snippet');
+  });
+
+  it("carries sourceRepo only when present — absent means the run's own repo (F1)", () => {
+    const bundle = buildGroundingBundle([
+      source({ sourceRepo: 'strategy' }),
+      source({ filePath: 'src/local.ts' }),
+    ]);
+    const cross = bundle.items.find((i) => i.sourceRepo !== undefined);
+    const local = bundle.items.find((i) => i.sourceRepo === undefined);
+    expect(cross?.sourceRepo).toBe('strategy');
+    expect(local).toBeDefined();
+    expect('sourceRepo' in local!).toBe(false);
+  });
+});
+
+describe('summarizeProvenance', () => {
+  it('derives sorted class counts from items alone', () => {
+    const bundle = buildGroundingBundle([source(), source({ filePath: 'src/y.ts' })]);
+    expect(summarizeProvenance(bundle)).toBe(`${PROVENANCE_SIMILARITY_ONLY}:2`);
+  });
+
+  it('renders multi-class bundles in sorted class order (deterministic string)', () => {
+    // Hand-built bundle: the builder cannot emit upgraded classes (by design),
+    // but the summarizer must handle them for the mmnto-ai/totem#344/#375 graduation path.
+    const bundle = {
+      items: [
+        {
+          provenance: PROVENANCE_SIMILARITY_ONLY,
+          contentHash: 'c'.repeat(64),
+          sourceType: 'code',
+          filePath: 'a.ts',
+        },
+        {
+          provenance: PROVENANCE_COMPILED_RULE,
+          contentHash: 'd'.repeat(64),
+          sourceType: 'lesson',
+          filePath: 'b.md',
+        },
+        {
+          provenance: PROVENANCE_SIMILARITY_ONLY,
+          contentHash: 'e'.repeat(64),
+          sourceType: 'code',
+          filePath: 'c.ts',
+        },
+      ],
+    };
+    expect(summarizeProvenance(bundle)).toBe(
+      `${PROVENANCE_COMPILED_RULE}:1,${PROVENANCE_SIMILARITY_ONLY}:2`,
+    );
+  });
+
+  it("zero items → 'ungrounded' — abstention named, never empty", () => {
+    expect(summarizeProvenance({ items: [] })).toBe(PROVENANCE_UNGROUNDED);
+    expect(PROVENANCE_UNGROUNDED.length).toBeGreaterThan(0);
+  });
+});
+
+describe('grounding schemas', () => {
+  it('item requires identity fields — fabricated/absent identity is the illusion-of-grounding trap', () => {
+    expect(() =>
+      GroundingItemSchema.parse({
+        provenance: PROVENANCE_SIMILARITY_ONLY,
+        contentHash: 'f'.repeat(64),
+        sourceType: 'code',
+      }),
+    ).toThrow();
+    expect(() =>
+      GroundingItemSchema.parse({
+        provenance: PROVENANCE_SIMILARITY_ONLY,
+        contentHash: 'not-a-hash',
+        sourceType: 'code',
+        filePath: 'a.ts',
+      }),
+    ).toThrow();
+  });
+
+  it('accepts non-canonical class strings — open vocabulary; consumers fail-safe-down (F2)', () => {
+    const parsed = GroundingItemSchema.parse({
+      provenance: 'execution-verified',
+      contentHash: 'f'.repeat(64),
+      sourceType: 'code',
+      filePath: 'a.ts',
+    });
+    expect(parsed.provenance).toBe('execution-verified');
+    expect(PROVENANCE_CLASSES).not.toContain('execution-verified');
+  });
+
+  it('a bundled artifact parses, and a slice-1 artifact without a bundle still parses (F1 tolerance)', () => {
+    const slice1 = { ...baseArtifact(), schemaVersion: '1.0.0' };
+    expect(() => RunArtifactSchema.parse(slice1)).not.toThrow();
+
+    const bundle = buildGroundingBundle([source()]);
+    const bundled = {
+      ...baseArtifact(),
+      grounding: {
+        hash: calculateDeterministicHash(bundle),
+        provenanceSummary: summarizeProvenance(bundle),
+        bundle,
+      },
+    };
+    const parsed = RunArtifactSchema.parse(bundled);
+    expect(parsed.grounding.bundle?.items).toHaveLength(1);
+    // Invariant 4: the attested hash is recomputable from the artifact surface alone.
+    expect(parsed.grounding.hash).toBe(calculateDeterministicHash(parsed.grounding.bundle));
+  });
+
+  it('the written schema version is a 1.x minor bump marking the bundle semantics (Q3)', () => {
+    expect(RUN_ARTIFACT_SCHEMA_VERSION).toBe('1.1.0');
+  });
+});

--- a/packages/core/src/artifacts/grounding.test.ts
+++ b/packages/core/src/artifacts/grounding.test.ts
@@ -190,6 +190,10 @@ describe('grounding schemas', () => {
       },
     };
     const parsed = RunArtifactSchema.parse(bundled);
+    // Explicit presence guard (Greptile R1 on mmnto-ai/totem#2122): an absent
+    // bundle must fail HERE as a clear assertion, not as a confusing
+    // crypto.update error inside the hash recompute below.
+    expect(parsed.grounding.bundle).toBeDefined();
     expect(parsed.grounding.bundle?.items).toHaveLength(1);
     // Invariant 4: the attested hash is recomputable from the artifact surface alone.
     expect(parsed.grounding.hash).toBe(calculateDeterministicHash(parsed.grounding.bundle));

--- a/packages/core/src/artifacts/grounding.ts
+++ b/packages/core/src/artifacts/grounding.ts
@@ -1,0 +1,102 @@
+/**
+ * Grounding-bundle assembly (mmnto-ai/totem#2101, strategy#474 slice 2).
+ *
+ * The bundle is the per-item provenance record for everything the
+ * deterministic layer DELIVERED into a run's prompt: each item names what it
+ * is (`sourceType` + `filePath` + optional `sourceRepo`), what it contained
+ * (`contentHash` — identity, never bytes), and HOW it was obtained
+ * (`provenance` class). The first cut wraps similarity retrieval honestly as
+ * `similarity-only`; structural resolvers (mmnto-ai/totem#344/#375) graduate items to
+ * `structurally-verified` by supplying them explicitly — this builder can
+ * never upgrade a class on its own (honest-absent: nothing upgrades
+ * provenance silently).
+ *
+ * Assembly is caller-side (the deterministic layer) — providers stay dumb
+ * pipes. The bundle is what `grounding.hash` attests, so it must be a pure
+ * function of the logical item set: items are canonically sorted here because
+ * retrieval order is score-dependent and `calculateDeterministicHash` is
+ * order-significant for arrays.
+ */
+
+import { calculateDeterministicHash } from './hash.js';
+import {
+  type GroundingBundle,
+  type GroundingItem,
+  PROVENANCE_SIMILARITY_ONLY,
+  PROVENANCE_UNGROUNDED,
+} from './schema.js';
+
+/**
+ * One retrieved evidence item as the caller holds it — the `result` shape is
+ * the identity-relevant subset of `SearchResult`, kept structural so callers
+ * and tests don't need a full store hit to build one.
+ */
+export interface GroundingSourceItem {
+  /** Retrieval partition the item entered the prompt under (`spec` | `session_log` | `code` | `lesson`). */
+  sourceType: string;
+  result: {
+    content: string;
+    filePath: string;
+    /** Linked-index name for cross-repo hits; absent = the run's own repo (strategy review F1 on mmnto-ai/totem#2101). */
+    sourceRepo?: string | undefined;
+  };
+}
+
+/**
+ * Locale-independent string compare (localeCompare is environment-dependent
+ * and would let two machines disagree on the canonical order — and therefore
+ * the hash — of the same bundle).
+ */
+function compareStrings(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/** Canonical item order: (sourceType, sourceRepo, filePath, contentHash). */
+function compareItems(a: GroundingItem, b: GroundingItem): number {
+  return (
+    compareStrings(a.sourceType, b.sourceType) ||
+    compareStrings(a.sourceRepo ?? '', b.sourceRepo ?? '') ||
+    compareStrings(a.filePath, b.filePath) ||
+    compareStrings(a.contentHash, b.contentHash)
+  );
+}
+
+/**
+ * Map retrieved items into a canonical grounding bundle. Every input item is
+ * included — duplicates are delivery records, not noise (the bundle records
+ * what entered the prompt, and a snippet delivered twice was delivered
+ * twice). All items are classed `similarity-only`: this is the first-cut
+ * wrapper around the existing retrieval, and the ONLY class this builder can
+ * emit by construction.
+ */
+export function buildGroundingBundle(items: GroundingSourceItem[]): GroundingBundle {
+  const mapped: GroundingItem[] = items.map(({ sourceType, result }) => ({
+    provenance: PROVENANCE_SIMILARITY_ONLY,
+    contentHash: calculateDeterministicHash(result.content),
+    sourceType,
+    filePath: result.filePath,
+    ...(result.sourceRepo !== undefined ? { sourceRepo: result.sourceRepo } : {}),
+  }));
+  mapped.sort(compareItems);
+  return { items: mapped };
+}
+
+/**
+ * Derive the artifact's `provenanceSummary` from the bundle — never asserted
+ * wholesale (derive-or-couple: a stored summary is a mirror that can drift
+ * from `items`). Sorted class-count string (`similarity-only:14`,
+ * `compiled-rule:1,similarity-only:2`) so the eval harness can threshold on
+ * it deterministically; zero items → `'ungrounded'` (abstention named, not
+ * silent — Tenet 14 honest-absent).
+ */
+export function summarizeProvenance(bundle: GroundingBundle): string {
+  if (bundle.items.length === 0) return PROVENANCE_UNGROUNDED;
+  const counts = new Map<string, number>();
+  for (const item of bundle.items) {
+    counts.set(item.provenance, (counts.get(item.provenance) ?? 0) + 1);
+  }
+  return [...counts.keys()]
+    .sort(compareStrings)
+    .map((cls) => `${cls}:${counts.get(cls)}`)
+    .join(',');
+}

--- a/packages/core/src/artifacts/grounding.ts
+++ b/packages/core/src/artifacts/grounding.ts
@@ -95,8 +95,13 @@ export function summarizeProvenance(bundle: GroundingBundle): string {
   for (const item of bundle.items) {
     counts.set(item.provenance, (counts.get(item.provenance) ?? 0) + 1);
   }
-  return [...counts.keys()]
-    .sort(compareStrings)
-    .map((cls) => `${cls}:${counts.get(cls)}`)
-    .join(',');
+  return (
+    [...counts.keys()]
+      .sort(compareStrings)
+      // Non-null assertion: every key comes from the same map's own key set
+      // (Greptile R1 on mmnto-ai/totem#2122 — a future logic change must fail
+      // the type check, not silently render `class:undefined`).
+      .map((cls) => `${cls}:${counts.get(cls)!}`)
+      .join(',')
+  );
 }

--- a/packages/core/src/artifacts/schema.ts
+++ b/packages/core/src/artifacts/schema.ts
@@ -24,19 +24,50 @@
 
 import { z } from 'zod';
 
-/** The schemaVersion WRITTEN by this code. Readers accept any 1.x (F1). */
-export const RUN_ARTIFACT_SCHEMA_VERSION = '1.0.0';
+/**
+ * The schemaVersion WRITTEN by this code. Readers accept any 1.x (F1).
+ * 1.1.0 (mmnto-ai/totem#2101): `grounding` gained the optional per-item
+ * `bundle`, and `grounding.hash` semantics changed from hash-of-raw-context
+ * to hash-of-bundle — the minor is the observable marker for that meaning
+ * change; the registry stays empty because the tolerant reader parses both.
+ */
+export const RUN_ARTIFACT_SCHEMA_VERSION = '1.1.0';
 
 /** The major this reader understands; other majors need a migration entry. */
 export const RUN_ARTIFACT_KNOWN_MAJOR = 1;
 
 /**
- * Slice-1 wholesale provenance summary: the current ad-hoc context assembly is
- * similarity-retrieved, and the bundle must say so from day one (the
- * illusion-of-grounding trap cannot be retrofitted away). #2101 owns per-item
- * provenance classes; this stays a free string so that lands without a major.
+ * Canonical provenance classes (mmnto-ai/totem#2101, strategy#474 items 1+7).
+ * `similarity-only` is the honest class for today's retrieval; the others are
+ * reserved for graduation — `structurally-verified` lands via mmnto-ai/totem#344/#375
+ * resolvers, `spec-contract`/`compiled-rule` via their respective delivery
+ * paths. Schema-level validation stays an open string (extensible without a
+ * major — the same reasoning that kept slice 1's `provenanceSummary` free).
+ *
+ * Fail-safe-down rider (strategy review F2 on mmnto-ai/totem#2101): every consumer
+ * (summaries, eval thresholds, future conformance sensing) must treat a
+ * non-canonical class string as NOT-upgraded — lowest trust — so an invented
+ * class can never confer trust absent code-side graduation. Safe today
+ * because classes are builder-emitted constants, never model-supplied; the
+ * enforcement test rides mmnto-ai/totem#2103.
  */
 export const PROVENANCE_SIMILARITY_ONLY = 'similarity-only';
+export const PROVENANCE_STRUCTURALLY_VERIFIED = 'structurally-verified';
+export const PROVENANCE_SPEC_CONTRACT = 'spec-contract';
+export const PROVENANCE_COMPILED_RULE = 'compiled-rule';
+export const PROVENANCE_CLASSES = [
+  PROVENANCE_SIMILARITY_ONLY,
+  PROVENANCE_STRUCTURALLY_VERIFIED,
+  PROVENANCE_SPEC_CONTRACT,
+  PROVENANCE_COMPILED_RULE,
+] as const;
+
+/**
+ * `provenanceSummary` for a bundle with zero items: the run was UNGROUNDED —
+ * abstention named epistemically (what the absence means), not mechanically
+ * ("empty"). Honest-absent: a degraded run says so in its own record.
+ */
+export const PROVENANCE_UNGROUNDED = 'ungrounded';
 
 /**
  * Slice-1 admission class for both migrated callers (spec + review): factually
@@ -74,12 +105,49 @@ export const InputBundleSchema = z.object({
   specContract: z.string().optional(),
 });
 
+/**
+ * One delivered evidence item (mmnto-ai/totem#2101): identity + content hash
+ * + provenance class. NO content bytes — `inputBundle.maskedPrompt` already
+ * carries the bytes once; duplicating them bloats every artifact and creates
+ * a second DLP surface. Identity fields are required: fabricated or absent
+ * identity is the illusion-of-grounding trap the bundle exists to close.
+ */
+export const GroundingItemSchema = z.object({
+  /** Provenance class — open vocabulary, canonical values in {@link PROVENANCE_CLASSES}; consumers fail-safe-down on unknown strings (F2). */
+  provenance: z.string().min(1),
+  /** Deterministic hash of the delivered snippet content (identity, not bytes). */
+  contentHash: z.string().regex(SHA256_HEX, 'contentHash must be a sha256 hex digest'),
+  /** Retrieval partition the item entered the prompt under (`spec` | `session_log` | `code` | `lesson`). */
+  sourceType: z.string().min(1),
+  /** Path relative to the owning repo root — display + structural-resolution identity. */
+  filePath: z.string().min(1),
+  /** Linked-index name for cross-repo hits; ABSENT = the run's own repo (F1) — post-checks resolve `filePath` against the run's config root when absent. */
+  sourceRepo: z.string().min(1).optional(),
+});
+
+/**
+ * The per-item grounding record. No stored summary/count fields — counts are
+ * derived by `summarizeProvenance` (derive-or-couple: a stored mirror can
+ * drift from `items`).
+ */
+export const GroundingBundleSchema = z.object({
+  items: z.array(GroundingItemSchema),
+});
+
 /** What KIND of grounding the run had — day-one field, never retrofittable. */
 export const GroundingSchema = z.object({
-  /** Deterministic hash of the grounding context that entered the bundle. */
+  /**
+   * Deterministic hash of the grounding surface. From 1.1.0 this is
+   * `calculateDeterministicHash(bundle)` — the verifier recomputes it from
+   * the artifact surface ALONE (one enumeration, two readers). Slice-1
+   * artifacts (no `bundle`) carry their original hash-of-raw-context, which
+   * is self-consistent but not recomputable offline.
+   */
   hash: z.string().regex(SHA256_HEX, 'grounding.hash must be a sha256 hex digest'),
-  /** Wholesale class in slice 1 (`similarity-only`); per-item classes are #2101. */
+  /** Derived from the bundle since 1.1.0 (sorted class counts, or `ungrounded`); wholesale string in slice-1 artifacts. */
   provenanceSummary: z.string().min(1),
+  /** Per-item provenance record (mmnto-ai/totem#2101). Optional: slice-1 artifacts predate it and cannot be re-classed. */
+  bundle: GroundingBundleSchema.optional(),
 });
 
 /** Backend identity as RESOLVED (post quota-fallback), not as requested. */
@@ -126,3 +194,5 @@ export const RunArtifactSchema = z.object({
 
 export type RunArtifact = z.infer<typeof RunArtifactSchema>;
 export type InputBundle = z.infer<typeof InputBundleSchema>;
+export type GroundingItem = z.infer<typeof GroundingItemSchema>;
+export type GroundingBundle = z.infer<typeof GroundingBundleSchema>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -512,12 +512,26 @@ export {
 // Filesystem helpers
 export { readJsonSafe } from './sys/fs.js';
 
-// Grounded run artifacts (mmnto-ai/totem#2100, strategy#474 slice 1)
+// Grounded run artifacts (mmnto-ai/totem#2100 slice 1, mmnto-ai/totem#2101 slice 2)
+export type { GroundingSourceItem } from './artifacts/grounding.js';
+export { buildGroundingBundle, summarizeProvenance } from './artifacts/grounding.js';
 export { calculateDeterministicHash } from './artifacts/hash.js';
-export type { InputBundle, RunArtifact } from './artifacts/schema.js';
+export type {
+  GroundingBundle,
+  GroundingItem,
+  InputBundle,
+  RunArtifact,
+} from './artifacts/schema.js';
 export {
   ADMISSION_COMPLETION_ONLY,
+  GroundingBundleSchema,
+  GroundingItemSchema,
+  PROVENANCE_CLASSES,
+  PROVENANCE_COMPILED_RULE,
   PROVENANCE_SIMILARITY_ONLY,
+  PROVENANCE_SPEC_CONTRACT,
+  PROVENANCE_STRUCTURALLY_VERIFIED,
+  PROVENANCE_UNGROUNDED,
   RUN_ARTIFACT_SCHEMA_VERSION,
   RunArtifactSchema,
 } from './artifacts/schema.js';


### PR DESCRIPTION
## Summary

strategy#474 slice 2 — the grounding bundle with day-one provenance classes. Every `totem spec` / `totem review` run artifact now carries a per-item `grounding.bundle` where each delivered evidence item self-describes:

- **`provenance`** — `similarity-only` | `structurally-verified` | `spec-contract` | `compiled-rule`. Open vocabulary with canonical constants (extensible minor-not-major, the slice-1 string seam landing as designed); **consumers fail-safe-down** on non-canonical classes (strategy review F2 — an invented class can never confer trust; enforcement test rides #2103).
- **Identity** — `sourceType` / `filePath` / optional `sourceRepo` (**absent = the run's own repo**, strategy review F1).
- **`contentHash`** — identity, never bytes: `maskedPrompt` already carries content once; duplicating would bloat artifacts and add a second DLP surface.

First cut wraps the existing retrieval **honestly as `similarity-only`** — the builder cannot emit an upgraded class by construction (nothing upgrades provenance silently). Structural resolvers (#344/#375) graduate items later by supplying them explicitly.

## Mechanics

- `grounding.hash` becomes `calculateDeterministicHash(bundle)` — **recomputable from the artifact surface alone** (one enumeration, two readers; hash-of-context attested what a verifier could not check offline).
- `provenanceSummary` is **derived** (sorted class-count string, `similarity-only:8`; zero items → `ungrounded`) — never asserted wholesale; no stored count mirrors.
- Bundle items are **canonically sorted** (sourceType, sourceRepo, filePath, contentHash; locale-independent compare) so score-dependent retrieval order never moves the hash.
- **Reruns carry the bundle verbatim** — a rerun makes no new grounding claim.
- `RUN_ARTIFACT_SCHEMA_VERSION` 1.0.0 → **1.1.0** (additive; the version-tolerant reader parses slice-1 artifacts unchanged — they predate the bundle and cannot be re-classed, by design).
- One shared `buildRetrievalGroundingBundle` for both callers — a caller-local copy that drifted would silently drop a partition from the provenance record.

## Design provenance

Preflight design doc committed at `.totem/specs/2101.md`. The verify-against-code pass overrode three generated-spec proposals (z.enum → open string; hand-rolled tuple hashing → the existing `calculateDeterministicHash`, avoiding a second hashing convention; cli placement → core). Strategy-claude design review: **CONFORMS** (2348Z dispatch), both folds (F1 absent-sourceRepo default, F2 fail-safe-down rider) applied pre-build; operator-greenlit.

## Verification

- RED-first throughout: core builder/summarizer/schema invariants (31), emission seam, rerun passthrough, retrieval-mapping invariant 8.
- Full suites: core **2187/2187**, CLI **2460/2460**. `totem lint` PASS (0 errors) · `totem review` PASS.
- **Dogfood proof:** the review gate run on this branch emitted the first real 1.1.0 artifact (`478c3bf2…`) — 8-item bundle, `similarity-only:8`, and the attested `grounding.hash` recomputes from the recorded bundle alone (invariant 4 verified live).

Out of scope per the ratified design: structural resolvers (#344/#375), post-check enforcement (#2103), re-classing old artifacts, fileContext/smartHints widening, new artifact verbs.

Closes #2101

🤖 Generated with [Claude Code](https://claude.com/claude-code)
