### PR TITLE
feat(doctor): last-attested passthrough + strategy-doctrine 0.1.4 pin bump (#2125)

### DIFF
--- a/.changeset/last-attested-passthrough.md
+++ b/.changeset/last-attested-passthrough.md
@@ -1,0 +1,6 @@
+---
+'@mmnto/totem': patch
+'@mmnto/cli': patch
+---
+
+feat(doctor): wire the `last-attested:` manifest field through to manual-attestation rows (#2125). The parity-manifest schema parses the optional ISO-8601 `last-attested:` date (strategy#540) into `ParityContract.lastAttested`, and `doctor --parity` passes it to the detector's reserved `attested?:` seam — dated rows render `last attested <date>`, undated rows keep the honest `last attested: not recorded`. Message refinement only; the manual-attestation verdict ceiling (`info`/`skip`, never fails) is unchanged. Ships with the `@mmnto/strategy-doctrine` 0.1.3→0.1.4 pin bump that distributes the first attestation dates.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "typescript-eslint": "^8.59.4"
   },
   "optionalDependencies": {
-    "@mmnto/strategy-doctrine": "0.1.3"
+    "@mmnto/strategy-doctrine": "0.1.4"
   }
 }

--- a/packages/cli/src/commands/doctor-parity.test.ts
+++ b/packages/cli/src/commands/doctor-parity.test.ts
@@ -668,6 +668,32 @@ describe('checkParity — manual-attestation wiring', () => {
     expect(blockingDriftIds).toHaveLength(0);
   });
 
+  it('passes last-attested through to the detector — dated rows render the date, undated stay honest-absent (mmnto-ai/totem#2125)', async () => {
+    // strategy#540 shipped `last-attested:` in the manifest; the reserved
+    // `attested?:` seam gets its producer. Message refinement ONLY — the
+    // verdict stays `info` regardless (the never-fails keystone).
+    const datedManifest = MANUAL_ATTEST_MANIFEST_YAML.replace(
+      "    package: '@google/genai'\n",
+      "    package: '@google/genai'\n    last-attested: '2026-06-08'\n",
+    );
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', datedManifest);
+    writeConsumerDeps({ '@google/genai': '^0.3.0' });
+
+    const { results, blockingDriftIds } = await checkParity(tmpDir);
+    const perContract = results.slice(1);
+
+    const genai = perContract.find((r) => r.name === 'Parity: google-genai-coupling')!;
+    expect(genai.status).toBe('info'); // date refines the message, never the status
+    expect(genai.message).toContain('last attested 2026-06-08');
+
+    const doctrine = perContract.find((r) => r.name === 'Parity: governance-doctrine')!;
+    expect(doctrine.status).toBe('info');
+    expect(doctrine.message).toMatch(/last attested: not recorded/i); // undated row stays honest-absent
+
+    expect(blockingDriftIds).toHaveLength(0);
+  });
+
   it('manual-attestation is structurally non-gating: a blocking:true contract never enters blockingDriftIds', async () => {
     // Even marked blocking, an info verdict (the manual-attestation ceiling) never
     // promotes — the contract cannot fail even under --strict.

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -619,9 +619,14 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
         if (c.tractability === 'manual-attestation') {
           // The detector reads the sub-class discriminant (`c.package`) + the
           // canonical source directly off the contract. `package:` set ⇒ vendor-SDK
-          // pin read; unset ⇒ doctrine-row pure-info surface. No `attested` yet (the
-          // schema has no last-attested field — strategy's follow-on lane).
-          const verdict = detectManualAttestationContract(c, { cwd, repoId });
+          // pin read; unset ⇒ doctrine-row pure-info surface. `attested` carries the
+          // manifest's `last-attested:` date when present (strategy#540 /
+          // mmnto-ai/totem#2125) — message refinement only, never a verdict input.
+          const verdict = detectManualAttestationContract(c, {
+            cwd,
+            repoId,
+            ...(c.lastAttested !== undefined ? { attested: c.lastAttested } : {}),
+          });
           return [verdictToLine(c, verdict)];
         }
 

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -581,11 +581,11 @@ export interface DetectManualAttestationContext {
   /** The current repo's cohort id (from {@link deriveCohortRepoId}) for `consumers` applicability. */
   repoId?: string;
   /**
-   * OPTIONAL local attestation date (ISO-8601). Absent today — the manifest schema
-   * has no `last-attested:` field yet; strategy owns that follow-on (#2073 design
-   * 2045Z). RESERVED seam so date-staleness is a clean drop-in: when a date lands
-   * the message reports it, but the VERDICT stays `info` regardless — staleness is
-   * a message refinement, NEVER a status change (manual-attestation never warns).
+   * OPTIONAL local attestation date (ISO-8601), sourced from the manifest's
+   * `last-attested:` field (strategy#540 shipped the producer; the doctor wires
+   * it through per mmnto-ai/totem#2125). When present the message reports it,
+   * but the VERDICT stays `info` regardless — staleness is a message
+   * refinement, NEVER a status change (manual-attestation never warns).
    */
   attested?: string;
   /**
@@ -653,9 +653,10 @@ export function detectManualAttestationContract(
     }
   }
 
-  // The last-attested suffix: a date if one was supplied (the reserved seam — the
-  // manifest has no `last-attested:` field yet), else the honest "not recorded".
-  // NEVER fabricated; a present date refines the MESSAGE, never the status.
+  // The last-attested suffix: the manifest's `last-attested:` date when one was
+  // supplied (strategy#540 via mmnto-ai/totem#2125), else the honest "not
+  // recorded". NEVER fabricated; a present date refines the MESSAGE, never the
+  // status.
   const trimmedAttested = ctx.attested?.trim();
   const attestedSuffix = trimmedAttested
     ? `last attested ${trimmedAttested}`

--- a/packages/core/src/parity-manifest.test.ts
+++ b/packages/core/src/parity-manifest.test.ts
@@ -180,6 +180,23 @@ describe('parseParityManifest', () => {
     expect('title' in orientation).toBe(false);
     expect('blocking' in orientation).toBe(false);
     expect('consumers' in orientation).toBe(false);
+    expect('lastAttested' in orientation).toBe(false);
+  });
+
+  it('maps last-attested to lastAttested; absent stays structurally absent (mmnto-ai/totem#2125)', () => {
+    // strategy#540: optional quoted ISO-8601 date on manual-attestation rows.
+    const dated = VALID_MANIFEST_YAML.replace(
+      'tracking-issue: mmnto-ai/totem#2018\n',
+      "tracking-issue: mmnto-ai/totem#2018\n    last-attested: '2026-06-08'\n",
+    );
+    const result = parseParityManifest(dated);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    const corpus = result.manifest.contracts[2]!;
+    expect(corpus.lastAttested).toBe('2026-06-08');
+    // Sibling rows without the field carry no key at all (honest-absent, no
+    // fabricated provenance).
+    expect('lastAttested' in result.manifest.contracts[0]!).toBe(false);
   });
 
   it('returns unparseable on invalid YAML (no throw)', () => {

--- a/packages/core/src/parity-manifest.ts
+++ b/packages/core/src/parity-manifest.ts
@@ -91,6 +91,10 @@ const RawParityContractSchema = z.object({
   // parseable name for version/vendor contracts, so the detector derives the
   // package rather than guessing it from the id convention.
   package: z.string().optional(),
+  // Optional attestation date on manual-attestation rows (strategy#540 /
+  // mmnto-ai/totem#2125) — the producer for the detector's reserved
+  // `attested?:` seam. Message refinement only; never a verdict input.
+  'last-attested': z.string().optional(),
 });
 
 /**
@@ -140,6 +144,13 @@ export interface ParityContract {
    * contract pins. Preferred over the id-convention guess when present.
    */
   package?: string;
+  /**
+   * Optional ISO-8601 attestation date (strategy#540 / mmnto-ai/totem#2125),
+   * present on manual-attestation rows whose claim was actually reviewed.
+   * Absent = no citable attestation event (honest-absent — the doctor renders
+   * "last attested: not recorded", never fabricates a date).
+   */
+  lastAttested?: string;
 }
 
 /** A fully parsed + validated parity manifest. */
@@ -294,6 +305,7 @@ function mapContract(raw: z.infer<typeof RawParityContractSchema>): ParityContra
     dimension: raw.dimension,
     canonicalSource: raw['canonical-source'],
     ...(raw['source-note'] !== undefined ? { sourceNote: raw['source-note'] } : {}),
+    ...(raw['last-attested'] !== undefined ? { lastAttested: raw['last-attested'] } : {}),
     detectionMethod: raw['detection-method'],
     expectedValueOrDerivation: raw['expected-value-or-derivation'],
     tractability: raw.tractability,

--- a/packages/core/src/parity-manifest.ts
+++ b/packages/core/src/parity-manifest.ts
@@ -150,10 +150,13 @@ export interface ParityContract {
    */
   package?: string;
   /**
-   * Optional ISO-8601 attestation date (strategy#540 / mmnto-ai/totem#2125),
-   * present on manual-attestation rows whose claim was actually reviewed.
-   * Absent = no citable attestation event (honest-absent — the doctor renders
-   * "last attested: not recorded", never fabricates a date).
+   * Optional attestation marker (strategy#540 / mmnto-ai/totem#2125), present
+   * on manual-attestation rows whose claim was actually reviewed. An
+   * UNVALIDATED string carrying an intended ISO-8601 date — format is
+   * deliberately not enforced at the schema boundary (see the raw-schema note:
+   * rejection there is manifest-wide), so consumers must treat it as
+   * render-only text. Absent = no citable attestation event (honest-absent —
+   * the doctor renders "last attested: not recorded", never fabricates a date).
    */
   lastAttested?: string;
 }

--- a/packages/core/src/parity-manifest.ts
+++ b/packages/core/src/parity-manifest.ts
@@ -94,6 +94,11 @@ const RawParityContractSchema = z.object({
   // Optional attestation date on manual-attestation rows (strategy#540 /
   // mmnto-ai/totem#2125) — the producer for the detector's reserved
   // `attested?:` seam. Message refinement only; never a verdict input.
+  // DELIBERATELY format-unvalidated (Greptile R1 on mmnto-ai/totem#2126,
+  // declined): a Zod rejection here is MANIFEST-WIDE — one malformed date
+  // would take all contracts dark as `unparseable` (a total sensor outage)
+  // versus rendering a verbatim blemish on one info line. Render-only field;
+  // the producer side schema-reviews the manifest before publish.
   'last-attested': z.string().optional(),
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         version: 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
     optionalDependencies:
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.3
-        version: 0.1.3
+        specifier: 0.1.4
+        version: 0.1.4
 
   packages/cli:
     dependencies:
@@ -847,8 +847,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.3':
-    resolution: {integrity: sha512-Do4ePQEAZIpQlHP49yR9u8Jsvx77tc4L+T31gkh+mmZzPhagP4mHXvaECAFKwraA7+6Yl44Wq3dMhNedAIGeIw==}
+  '@mmnto/strategy-doctrine@0.1.4':
+    resolution: {integrity: sha512-sTWY/fsJK9F3XZ6WSU9Jc976RGTIWH91FoEq7D2TMTOwtVegUto309Urei2H/pt3VrttQy2260rxoj+0iS/lCQ==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3679,7 +3679,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.3':
+  '@mmnto/strategy-doctrine@0.1.4':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
## Summary

The reserved `attested?:` seam (the #2080 manual-attestation slice) gets its producer. strategy#540/#576 shipped the optional `last-attested:` ISO-8601 date in `parity-manifest.yaml`, and `@mmnto/strategy-doctrine@0.1.4` distributes the first real attestation dates. This PR wires the passthrough end to end:

1. **Schema** (`parity-manifest.ts`): `'last-attested': z.string().optional()` on the raw contract, mapped to `ParityContract.lastAttested` — absent stays structurally absent (honest-absent, no fabricated provenance).
2. **Wiring** (`doctor-parity.ts`): `attested: c.lastAttested` at the manual-attestation call site — the spot the seam comment reserved.
3. **Pin bump**: `@mmnto/strategy-doctrine` 0.1.3 → 0.1.4 via explicit `pnpm add` (the cached-failed-optional trap, lesson 134095fd).

Message refinement only: dated rows render `last attested <date>`, undated rows keep `last attested: not recorded`. The manual-attestation verdict ceiling (`info`/`skip`, structurally cannot fail under `--strict`) is **unchanged** — the new test asserts the date never touches the status, and `blockingDriftIds` stays empty.

## End-to-end smoke (the exact acceptance from strategy's 0033Z spec)

Authed `totem doctor --parity` against the 0.1.4 distributed snapshot:

> `INFO — @google/genai coupling tracked — declared ^2.6.0, installed 2.6.0; no cohort floor (Tenet 16, attest only). last attested 2026-06-08`

Both vendor-SDK rows carry the date; both doctrine rows honestly render `not recorded` (no citable doctrine-currency review event exists — per the strategy#576 design, not a gap).

## Verification

- RED-first tests: schema round-trip + structural absence (core), dated/undated rendering + verdict-unchanged + non-gating (cli wiring).
- Full suites: core 2188/2188, CLI 2461/2461 · `totem lint` PASS (0 errors) · `totem review` PASS.

Sequencing per strategy's 0120Z (accepted): lands before the next release cut so one bump wave carries this + the #2122 grounding bundle.

Closes #2125

🤖 Generated with [Claude Code](https://claude.com/claude-code)
