### PR TITLE
chore(lessons): compile 11 stranded grounding/doctor/mail lessons

### DIFF
--- a/.totem/compile-manifest.json
+++ b/.totem/compile-manifest.json
@@ -1,7 +1,7 @@
 {
-  "compiled_at": "2026-06-07T19:42:30.826Z",
+  "compiled_at": "2026-06-08T03:06:24.609Z",
   "model": "gemini-3-flash-preview",
   "input_hash": "887b20d48cfafd849ba15003866da2beba5be5d9352627300667375a3b36f60f",
-  "output_hash": "dac020d04b29a00f8d1b30720007d418d4ed8095a6263ca3567269be3b8aa139",
-  "rule_count": 485
+  "output_hash": "18d8b661faedd3349255d4954b3aeb3e74b307b596d37862a324f9ac0374462e",
+  "rule_count": 486
 }

--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -8583,36 +8583,56 @@
     {
       "lessonHash": "904c066615bd94c4",
       "lessonHeading": "Exclude timestamps from content addresses",
+      "pattern": "",
       "message": "Do not include 'createdAt' (or other timestamp fields) in deterministic hash calculations — identical runs will fail to deduplicate across different execution times.",
       "engine": "ast-grep",
-      "severity": "warning",
-      "pattern": "",
       "astGrepPattern": "hash($$$ARGS, createdAt, $$$REST)",
+      "badExample": "const addr = hash(content, createdAt, metadata);",
+      "goodExample": "const addr = hash(content, metadata);",
       "compiledAt": "2026-06-07T19:41:53.478Z",
       "createdAt": "2026-06-07T19:41:53.478Z",
       "fileGlobs": [
         "packages/core/src/artifacts/storage.ts"
       ],
-      "badExample": "const addr = hash(content, createdAt, metadata);",
-      "goodExample": "const addr = hash(content, metadata);",
-      "unverified": true,
-      "status": "untested-against-codebase"
+      "severity": "warning",
+      "status": "untested-against-codebase",
+      "unverified": true
     },
     {
       "lessonHash": "baffaac1dadd9f3e",
       "lessonHeading": "Use atomic write-if-absent flags",
+      "pattern": "",
       "message": "Use flag 'wx' instead of 'w' to prevent TOCTOU race conditions and enforce first-write-wins semantics",
       "engine": "ast-grep",
-      "severity": "warning",
-      "pattern": "",
       "astGrepPattern": "fs.writeFile($PATH, $DATA, { flag: 'w' })",
+      "badExample": "await fs.writeFile(path, data, { flag: 'w' });",
+      "goodExample": "await fs.writeFile(path, data, { flag: 'wx' });",
       "compiledAt": "2026-06-07T19:42:29.872Z",
       "createdAt": "2026-06-07T19:42:29.872Z",
       "fileGlobs": [
         "packages/core/src/artifacts/storage.ts"
       ],
-      "badExample": "await fs.writeFile(path, data, { flag: 'w' });",
-      "goodExample": "await fs.writeFile(path, data, { flag: 'wx' });",
+      "severity": "warning",
+      "status": "untested-against-codebase",
+      "unverified": true
+    },
+    {
+      "lessonHash": "3743c1ac58a8e1b5",
+      "lessonHeading": "Merge global options in subcommands",
+      "message": "Use optsWithGlobals() instead of opts() in subcommands to merge parent-level Commander options",
+      "engine": "ast-grep",
+      "severity": "warning",
+      "pattern": "",
+      "astGrepPattern": "$CMD.opts()",
+      "compiledAt": "2026-06-08T03:05:46.563Z",
+      "createdAt": "2026-06-08T03:05:46.563Z",
+      "fileGlobs": [
+        "packages/cli/src/**/*.ts",
+        "!**/*.test.*",
+        "!**/*.spec.*"
+      ],
+      "badExample": "const options = command.opts();",
+      "goodExample": "const options = command.optsWithGlobals();",
       "unverified": true,
       "status": "untested-against-codebase"
     }
@@ -14404,6 +14424,66 @@
       "title": "Hash prompt-visible grounding subsets",
       "reasonCode": "out-of-scope",
       "reason": "Lesson describes an architectural data-transformation principle (projecting to stable fields before hashing) that cannot be detected by inspecting any single code pattern — the violation requires knowing which fields are included in a hash input and whether they are environment-specific, which demands semantic analysis of the data flow."
+    },
+    {
+      "hash": "6ed4577ce4f9c533",
+      "title": "Use identity hashes over raw bytes",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes an architectural data-modeling principle (store hashes instead of raw bytes in grounding artifacts). There is no detectable code pattern that distinguishes a 'content hash' field from a 'raw bytes' field without semantic understanding of the data model and its purpose."
+    },
+    {
+      "hash": "52bb5e2fc4f0900f",
+      "title": "Discriminate warnings for stray files",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes a conceptual architectural principle about warning message design and categorization — there is no detectable code pattern that distinguishes 'malformed expected files' from 'unrelated strays' without semantic knowledge of what files are expected in context."
+    },
+    {
+      "hash": "831a526c0cb833b7",
+      "title": "Canonically sort bundle items",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes a data-ordering invariant that must hold before a hashing operation. Detecting violations requires knowing which array contains bundle items, whether a sort by the correct identity fields has been applied upstream, and whether the sort precedes the hash call — multi-step semantic analysis that no single regex or AST pattern can express."
+    },
+    {
+      "hash": "b911710b734e1a05",
+      "title": "Implement fail-safe-down for provenance classes",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes an architectural security principle (fail-safe-down for unknown provenance classes) that requires semantic analysis of how provenance metadata is consumed and what constitutes 'unknown or non-canonical' classes. No detectable code pattern can distinguish compliant from non-compliant handling of provenance class values without understanding the full trust evaluation logic."
+    },
+    {
+      "hash": "71e757e017a2cbda",
+      "title": "Align JSDoc with actual validation semantics",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes a documentation accuracy requirement — that JSDoc comments must explicitly state when format validation is intentionally not enforced. There is no detectable code pattern that can distinguish a JSDoc comment that correctly documents the absence of validation from one that incorrectly omits that disclosure. Enforcing this requires semantic understanding of both the comment intent and the runtime behavior."
+    },
+    {
+      "hash": "b2f7fff0d01a5eec",
+      "title": "Maintain structural absence for optional fields",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes a data-mapping architectural principle (preserving structural absence vs. fabricating default values for optional fields) that cannot be detected by a code pattern — the violation depends on semantic understanding of what constitutes 'absent' vs. 'fabricated' provenance in the domain model, not any detectable syntactic construct."
+    },
+    {
+      "hash": "d22bcb9ca9166bc4",
+      "title": "Avoid the cached-failed-optional pnpm trap",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes a procedural workflow convention (use 'pnpm add' instead of manual lockfile edits when bumping pins) rather than a detectable code pattern in source files. The violation is an omitted CLI command during a dependency update workflow, not a structural or textual pattern that appears in committed code."
+    },
+    {
+      "hash": "52b5b3b7a4fd2c81",
+      "title": "Use delimiters for frontmatter parsing",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes an algorithmic/architectural principle about frontmatter parsing strategy (delimiter-based vs blank-line splitting vs byte caps). There is no detectable code pattern that distinguishes a compliant delimiter-search implementation from a non-compliant blank-line split or byte-cap approach without semantic analysis of the parsing logic."
+    },
+    {
+      "hash": "6547c4586ac547c9",
+      "title": "Decouple attestation dates from status verdicts",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes an architectural/design principle about how attestation dates should be treated relative to status verdict logic. There is no detectable code pattern that can distinguish 'date used as informational metadata' from 'date used to trigger a failure verdict' without semantic analysis of the control flow and data flow relationships between date values and status outcomes."
+    },
+    {
+      "hash": "c93ae909872fa54e",
+      "title": "Default absent sourceRepo to current repo",
+      "reasonCode": "out-of-scope",
+      "reason": "Lesson describes a data-modeling convention (omit a field when a condition holds) that requires knowing the runtime value of 'sourceRepo' relative to the current repository context. No static pattern can determine whether a present 'sourceRepo' field matches or differs from the run's own repository."
     }
   ]
 }

--- a/.totem/lessons/lesson-0dcab464.md
+++ b/.totem/lessons/lesson-0dcab464.md
@@ -1,0 +1,6 @@
+## Lesson — Use identity hashes over raw bytes
+
+**Tags:** security, performance, artifacts
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Store content hashes instead of raw bytes in grounding artifacts to identify evidence. This prevents artifact bloat and avoids creating a secondary Data Loss Prevention (DLP) surface for sensitive content already tracked elsewhere.

--- a/.totem/lessons/lesson-349cf3bb.md
+++ b/.totem/lessons/lesson-349cf3bb.md
@@ -1,0 +1,6 @@
+## Lesson — Discriminate warnings for stray files
+
+**Tags:** logging, ux, error-handling
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Differentiating between malformed expected files and unrelated strays allows for actionable warnings without creating permanent log noise.

--- a/.totem/lessons/lesson-407d11e4.md
+++ b/.totem/lessons/lesson-407d11e4.md
@@ -1,0 +1,6 @@
+## Lesson — Canonically sort bundle items
+
+**Tags:** hashing, determinism, grounding
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Grounding bundle items must be sorted by identity fields (sourceType, sourceRepo, filePath, contentHash) before hashing. This ensures the resulting hash remains stable even if the underlying retrieval order changes due to score fluctuations.

--- a/.totem/lessons/lesson-44a22fa9.md
+++ b/.totem/lessons/lesson-44a22fa9.md
@@ -1,0 +1,6 @@
+## Lesson — Merge global options in subcommands
+
+**Tags:** cli, commander, options
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Commander subcommands fail to detect flags also defined at the program level unless optsWithGlobals() is used to merge option scopes.

--- a/.totem/lessons/lesson-457c5460.md
+++ b/.totem/lessons/lesson-457c5460.md
@@ -1,0 +1,6 @@
+## Lesson — Implement fail-safe-down for provenance classes
+
+**Tags:** security, provenance, architecture
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Consumers of provenance metadata should treat unknown or non-canonical classes as untrusted by default. This fail-safe-down approach prevents invented classes from conferring trust and ensures security as the provenance vocabulary expands.

--- a/.totem/lessons/lesson-6e4b3e2b.md
+++ b/.totem/lessons/lesson-6e4b3e2b.md
@@ -1,0 +1,6 @@
+## Lesson — Align JSDoc with actual validation semantics
+
+**Tags:** documentation, validation, dx
+**Scope:** packages/core/src/parity-manifest.ts
+
+Documentation must explicitly state when format validation (like ISO-8601) is intentionally not enforced to ensure the public contract matches runtime behavior.

--- a/.totem/lessons/lesson-7d7f3d32.md
+++ b/.totem/lessons/lesson-7d7f3d32.md
@@ -1,0 +1,6 @@
+## Lesson — Maintain structural absence for optional fields
+
+**Tags:** schema, typescript, architecture
+**Scope:** packages/core/src/parity-manifest.ts
+
+When mapping optional fields from raw manifests, ensure absent values remain structurally absent ('honest-absent') in the domain model to avoid fabricating provenance for missing data.

--- a/.totem/lessons/lesson-b04a526c.md
+++ b/.totem/lessons/lesson-b04a526c.md
@@ -1,0 +1,5 @@
+## Lesson — Avoid the cached-failed-optional pnpm trap
+
+**Tags:** pnpm, dependencies, devops
+
+Use explicit 'pnpm add' when bumping dependency pins to clear potential cached failure states from previous optional dependency resolution attempts that may persist in the lockfile.

--- a/.totem/lessons/lesson-d2d76024.md
+++ b/.totem/lessons/lesson-d2d76024.md
@@ -1,0 +1,6 @@
+## Lesson — Use delimiters for frontmatter parsing
+
+**Tags:** parsing, frontmatter, robustness
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Searching for a closing delimiter within a window sized to observed data maximums is more robust than splitting on blank lines or using arbitrary byte caps.

--- a/.totem/lessons/lesson-ef90eb0b.md
+++ b/.totem/lessons/lesson-ef90eb0b.md
@@ -1,0 +1,6 @@
+## Lesson — Decouple attestation dates from status verdicts
+
+**Tags:** cli, architecture, metadata
+**Scope:** packages/cli/src/commands/doctor-parity.ts
+
+Attestation dates should be treated as informational metadata and decoupled from status verdict logic to ensure that the presence or absence of a date does not inadvertently trigger failures.

--- a/.totem/lessons/lesson-f53cf68e.md
+++ b/.totem/lessons/lesson-f53cf68e.md
@@ -1,0 +1,6 @@
+## Lesson — Default absent sourceRepo to current repo
+
+**Tags:** metadata, grounding, dx
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Omit the `sourceRepo` field from grounding metadata when the item belongs to the run's own repository. This convention reduces artifact bloat while allowing consumers to safely assume the local repo is the source when the field is missing.


### PR DESCRIPTION
## What

Compile the stranded lesson backlog (11 lessons) extracted from recently-merged PRs:

- **Grounding bundle** — #2101 (identity-hashes-over-bytes, canonical bundle sort, fail-safe-down provenance classes, default-absent sourceRepo)
- **Doctor last-attested / parity** — #2125 / #2126 (honest-absent optional fields, decouple-attestation-dates-from-verdicts, JSDoc-validation alignment)
- **Mail frontmatter** — #2118 / #2119 (delimiter-window frontmatter parsing, `optsWithGlobals` for subcommand flags, discriminate-stray-file warnings)
- pnpm cached-failed-optional trap (dep-pin workflow)

## Result

`485 -> 486` rules. **One** mechanically-detectable rule compiled — *"Merge global options in subcommands"* (`$CMD.opts()` -> `optsWithGlobals()`, marked `unverified` / `untested-against-codebase`). The other 10 are conceptual/architectural and recorded as `out-of-scope` (honest skip with a reason each, not a failure). `0 failed`.

## Disposition pass

Per strategy-claude's heads-up that the extract disposition-state guard (#2124) is still **open**: I did a manual pass over the batch. Each lesson reflects design **actually shipped** in its source PR — none prescribes a finding that was declined, so there is no prescription-laundering in this batch. The structural guard (#2124) remains the right general-case fix.

Freeze gate N/A: totem carries no `.totem/freeze.json` (the legacy-compile ReDoS freeze is strategy-side only), and none of the 11 lessons contains lookbehind regex.

## Gates

- `pnpm run format:check` — clean
- `totem lint` — **PASS**, 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)