### PR TITLE
docs(agents): governance-first lede — enforce/derive/query

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,10 @@
 # Totem: Agent Instructions
 
-Canonical source of truth for how AI coding agents (Claude Code, Gemini CLI, Cursor, Windsurf, Copilot, etc.) behave in this repo. Per [Totem ADR-038](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-038-agents-md-standard.md), `mmnto-ai/totem` consolidates tool-specific instruction files into this single `AGENTS.md`. Thin `CLAUDE.md` / `GEMINI.md` redirect files exist only so each tool finds its way here. Junie reads `.junie/guidelines.md` directly until that migration follows.
+Canonical source of truth for how AI coding agents (Claude Code, Gemini CLI, Cursor, Windsurf, Copilot, etc.) behave in this repo. Per [Totem ADR-038](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-038-agents-md-standard.md), `mmnto-ai/totem` consolidates tool-specific instruction files into this single `AGENTS.md`. Thin `CLAUDE.md` / `GEMINI.md` redirect files exist only so each tool finds its way here.
+
+## What Totem is
+
+Totem is a **deterministic, repo-anchored governance toolkit** — _rules you enforce, state you derive, context you query_. The moat is governance, not memory: lead with enforcement (`totem lint` + the gate engine), not recall. Derivation (`totem status` / `orient`, Tenet 20) and the queryable index + ECL serve it, never lead.
 
 ## Session Start Protocol (MANDATORY)
 
@@ -73,8 +77,8 @@ After >15 turns of code changes: run `totem status`, re-query strategy ADRs for 
 
 ## Detailed Docs (read when relevant)
 
-- [Architecture context](.claude/docs/architecture.md) — partitions, boundary parameter, linked indexes
-- [Contributing rules](.claude/docs/contributing.md) — `AI_PROMPT_BLOCK`, changesets, code style
-- [Agent workflow](.claude/docs/agent-workflow.md) — dispatch templates, delegation rules
-- [Gemini styleguide](.gemini/styleguide.md) — full code style and architecture rules (Gemini CLI sessions read this directly)
+- [Architecture context](.claude/docs/architecture.md)
+- [Contributing rules](.claude/docs/contributing.md)
+- [Agent workflow](.claude/docs/agent-workflow.md)
+- [Gemini styleguide](.gemini/styleguide.md)
 - Strategy ADRs: query `mcp__totem-strategy__search_knowledge`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Canonical source of truth for how AI coding agents (Claude Code, Gemini CLI, Cur
 
 ## What Totem is
 
-Totem is a **deterministic, repo-anchored governance toolkit** — _rules you enforce, state you derive, context you query_. The moat is governance, not memory: lead with enforcement (`totem lint` + the gate engine), not recall. Derivation (`totem status` / `orient`, Tenet 20) and the queryable index + ECL serve it, never lead.
+Totem is a **deterministic, repo-scoped governance toolkit** — _rules you enforce, state you derive, context you query_. The moat is governance, not memory: lead with enforcement (`totem lint` + the gate engine), not recall. Derivation (`totem status` / `orient`, Tenet 20) and the queryable index serve it.
 
 ## Session Start Protocol (MANDATORY)
 


### PR DESCRIPTION
## What

Adds a `## What Totem is` governance-first lede to totem's own `AGENTS.md` so the first thing an agent reads is governance-first (**enforce → derive → query**), not memory/context-first. Mirrors `mmnto-ai/totem-strategy#593` for the totem repo.

## Why

The totem-side §6 propagation row from the #568 moat-reframe round (direction locked by satur8d: *concede the generic agentic-memory war, lead with deterministic governance*). lc-claude's N=1 point applies per-repo — the reframe isn't done until the first line an agent reads is governance-first. Strategy closed it for their AGENTS.md (`mmnto-ai/totem-strategy#593`); this is totem's mirror.

Before: after the ADR-038 pointer, an agent's first read was the Session Start Protocol, which leads with `totem status` → `search` → `search_knowledge` and puts `totem lint` (enforcement) **dead last at step 5** — a context-first entry point.

## How

- New `## What Totem is` lede (tight, single paragraph) ordered enforce → derive → query.
- Session Start Protocol **unchanged** — its orient→search→lint-before-push sequence is a correct action-order; the governance-first framing comes from the new lede.
- Trimmed to stay under the **FR-C01 conciseness budget** (≤6000 chars; landed at 5969 / 36 directives): dropped the Junie migration aside and the Detailed-Docs em-dash descriptions.

**Claim discipline:** the lede claims only shipped surfaces (`totem lint`/gate engine enforce; `status`/`orient` derive; index/ECL query). It deliberately does not claim rules-derived-from-history — the compiler spine (ADR-103) isn't shipped.

Closes #2131
