### PR TITLE
feat(cli): totem mail send/reply outbound actuator (#2042)

### DIFF
--- a/.changeset/mail-send-actuator.md
+++ b/.changeset/mail-send-actuator.md
@@ -1,0 +1,32 @@
+---
+'@mmnto/cli': minor
+'@mmnto/totem': minor
+---
+
+feat(cli): `totem mail send` / `mail reply` outbound actuator (#2042)
+
+Adds the actuator half of the ADR-106 coordination triad (the sensor `totem mail`
+already shipped). Before this, `totem mail send` silently fell through to the read
+command and every dispatch was hand-authored against five undocumented conventions —
+a discipline the protocol structurally could not satisfy (Tenet 13: sensor without
+actuator).
+
+- `totem mail send --to --subject [--from --body-file --in-reply-to --priority --related --expected-action --slug]`
+  composes + writes a **ADR-098 v0.4-compliant** dispatch (`schema:` / `timestamp:` /
+  `expected-action:`) to the sender's own outbox; totem is now the first v0.4-compliant
+  emitter. `totem mail reply <source>` is sugar that infers recipient + subject + `in-reply-to`.
+- The write-side validator is **fail-open** (ADR-106 inv6): structural validity is
+  enforced by construction (a malformed-shape dispatch is unrepresentable), while content
+  predicates that can't be guaranteed at construction (unknown recipient, empty refs) emit
+  a **loud emit-time warning** and write anyway — a blocked dispatch is worse than a
+  malformed one (#2119). Usage errors (missing to/subject, ambiguous/unresolvable self,
+  unreadable body-file) and actuation failures stay hard-fail (Tenet 4).
+- Registering the subcommands also closes the silent fall-through: `totem mail <unknown>`
+  now hard-errors instead of running the read as a no-op.
+- `parseHeader` now reads `timestamp:` (v0.4 canonical) with `date:` backwards-compat
+  fallback; the surfaced `MailEntry.date` field name is unchanged (no blast-radius rename).
+- `@mmnto/totem` exports `knownCohortAgents()` — the single source of truth for the
+  recipient set, derived from the cohort map (a hardcoded list in the actuator would
+  re-introduce the very drift this command fights).
+
+Emit-shape + the reader change concurred by strategy-claude (ADR-098 owner); OQ-1 ruled 1b.

--- a/.totem/specs/2042.md
+++ b/.totem/specs/2042.md
@@ -1,0 +1,171 @@
+### Problem Statement
+
+The `totem mail` command currently only supports reading cross-repo mail, lacking an actuator to compose and send outbound messages. As a result, users are forced to hand-author markdown files with undocumented conventions (ADR-098 schema, specific timestamp naming, specific directory structures), leading to drift; implementing `totem mail send` and `totem mail reply` commands will enforce these conventions structurally and eliminate the silent no-op fall-through when users attempt to send mail today.
+
+### Architectural Context
+
+- **ADR-106 & Tenet 13 (Sensor without Actuator):** The absence of a send command creates a structural inability to comply with protocol. This violates the `totem_validation_criterion` by creating unbounded glue cost.
+- **Totem Signoff (Gemini parity) > Cross-repo handoffs:** Established the pattern for outbound communication pathing (`<repoRoot>/.totem/orchestration/<agent-id>/outbox/`) and requires the `to: <recipient-agent-id>` frontmatter.
+- **Discrepancy Resolution:** The issue requires the filename convention `<UTC>Z-<recipient>-<slug>.md`, which slightly alters the older Signoff spec's `<YYYY-MM-DDTHHMMZ>-<your-agent-id>.md`. We will honor the issue's updated `<UTC>Z-<recipient>-<slug>.md` convention as it represents the modern ADR-106 coordination standard.
+
+### Files to Examine
+
+1. `packages/cli/src/commands/mail.ts` — Current entry point; contains the trap where `totem mail send` falls through to the read command.
+2. `packages/cli/src/commands/mail.test.ts` — Existing test interfaces (`MailEntry`, `OutboxFile`) that the new commands must cleanly integrate with.
+3. `.totem/session.json` (or equivalent session state file) — Source of truth for the `claude-00NN` / session sequence signature needed for auto-filling the frontmatter.
+
+### Technical Approach & Contracts
+
+To structurally enforce the consumer doctrine, we will introduce a strict subcommand router to `totem mail`.
+
+**Data Contracts:**
+
+1. **Zod Schema (`Adr098FrontmatterSchema`):**
+   ```typescript
+   export const Adr098FrontmatterSchema = z.object({
+     schema: z.literal('adr-098-v0.4'),
+     to: z.string(),
+     subject: z.string(),
+     seq: z.string().optional(),
+     inReplyTo: z.string().optional(),
+     priority: z.string().optional(),
+     related: z.array(z.string()).optional(),
+   });
+   ```
+
+**Sequence Logic:**
+
+1. **Routing:** Upgrade the command parser for `totem mail` to explicitly demand `send` or `reply` subcommands. If executed with no subcommand, it executes the existing read behavior. If an unknown argument (e.g., `send` currently) is passed without being registered, throw a hard error.
+2. **Path Resolution:** Use the shared helper `resolveGitRoot(process.cwd())` to locate the workspace root. Compute the self agent ID (via `TOTEM_AGENT_ID` env var or falling back to local config).
+3. **Draft Assembly:**
+   - Extract the current seq (e.g., `claude-00NN`) via `readJsonSafe` against the active session state.
+   - Construct the frontmatter using `Adr098FrontmatterSchema`.
+   - Read body from `--body-file`, or fallback to empty string (or `stdin` if available).
+4. **Actuation:** Write the templated markdown to `.totem/orchestration/<self>/outbox/<UTC>Z-<recipient>-<slug>.md`.
+
+### Edge Cases & Traps
+
+- **Silent Fall-through Trap:** The most critical regression to avoid is `totem mail send` acting as a no-op read. The CLI router _must_ throw an error for unknown subcommands or positional arguments.
+- **Filename Collision (Race Condition):** If an agent fires two messages to the same recipient in the same minute, `<UTC>Z-<recipient>-<slug>.md` will collide. The implementation must append a short random hex or the `seq` signature to the filename to guarantee uniqueness.
+- **Missing Directories:** The `outbox/` directory may not exist on a fresh clone or new agent initialization. The write operation must use `fs.mkdirSync(outboxPath, { recursive: true })`.
+- **Unknown Agent Identity:** If `<self>` cannot be resolved, the command must fail with a clear error rather than writing to `.totem/orchestration/undefined/outbox/`.
+- **Gitignore assumption:** The outbox directory may be gitignored. Avoid any automatic `git add` operations inside this command.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Fix CLI Subcommand Routing & Silent Fall-through**
+      Modify the CLI argument parsing in `packages/cli/src/commands/mail.ts` to separate the default read behavior from the new `send` and `reply` commands. Throw a hard error if an unregistered positional argument is provided.
+
+  > TEST DIRECTIVE: Before implementing, write a failing test named `rejects unknown positional arguments and prevents silent fall-through` that proves `totem mail invalid_arg` throws an error instead of executing the read command.
+  > _Steps:_ write test (in `mail.test.ts`) → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Define ADR-098 Zod Contracts & File Helpers**
+      Define the `Adr098FrontmatterSchema` using Zod and a helper function to construct the markdown payload. Implement session state reading using the `readJsonSafe` shared helper to extract the `seq` value.
+      _Steps:_ write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Implement `totem mail send` Actuator**
+      Implement the `send` command. Parse flags (`--to`, `--subject`, `--body-file`, etc.). Use `resolveGitRoot` to find the workspace root. Ensure the target directory exists.
+
+  > TOTEM INVARIANT (Totem Signoff / Cross-repo handoffs): When dispatching a message to another agent, write to your own outbox at `<repoRoot>/.totem/orchestration/<agent-id>/outbox/...` with `to: <recipient-agent-id>` in the frontmatter.
+  > TEST DIRECTIVE: Before implementing, write a failing test named `writes valid adr-098-v0.4 markdown to the correct agent outbox path` that verifies directory creation, collision-free naming, and frontmatter validation.
+  > _Steps:_ write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Implement `totem mail reply` Syntactic Sugar**
+      Implement the `reply` command. It must take a target file (`--in-reply-to <file>`), read it (using `readJsonSafe` or standard file reading for markdown frontmatter), infer the `--to` (from the original `from`) and `--subject` (prefixing `Re: `), and then invoke the logic from Task 3.
+  > TEST DIRECTIVE: Before implementing, write a failing test named `infers recipient and subject correctly from original mail message` that tests the automated field mapping.
+  > _Steps:_ write test → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Routing Isolation:** Run `totem mail send` without flags and assert it fails with "missing required arguments" rather than executing a successful read.
+- **Contract Adherence:** Assert that output written to the file system strictly passes the `Adr098FrontmatterSchema` Zod parse.
+- **Collision Avoidance:** Call `send` identically twice in the same millisecond; assert two distinct files exist in the outbox.
+- **Reply Sugar inference:** Provide a mock inbound mail file. Run `reply` on it. Assert the newly generated file correctly points the `to:` field to the original sender and includes `inReplyTo: <original-file>`.
+- **Missing Directory:** Mock an empty filesystem for the `.totem` directory. Assert `send` recursively creates the orchestration tree before writing.
+
+---
+
+## Implementation Design
+
+> Grounded against the real code (`mail.ts:parseHeader`, `orchestration-resolver.ts:resolveSelfAgents`) + ADR-098 v0.4. **Three spec fabrications corrected:** (1) no `seq:` wire field — `claude-00NN` is the journal-filename signature, never mail frontmatter; (2) wire uses kebab `in-reply-to`, not `inReplyTo`; (3) the `Adr098FrontmatterSchema` in the spec body ignores the v0.3/v0.4/de-facto split (see OQ-1).
+
+### Scope
+
+Add `totem mail send` + `totem mail reply` subcommands that compose a validated ADR-098 dispatch into the sender's own outbox, and fix the silent `totem mail <unknown>` fall-through (the #2042 trap). The write-side validator is **fail-open** (invariant 6): content-validation doubt → warn-and-write, never block. **Explicitly NOT in scope:** `totem mail ack` and read-side mark-on-read / handled-state (ADR-106 A1.3 — separate lane); message-body templating beyond `--body-file`/stdin; any cross-agent writes (single-writer invariant holds).
+
+### Data model deltas
+
+- **`MailSendOptions` (cli, new):** `{ to: string; from?: string; subject: string; bodyFile?: string; inReplyTo?: string; priority?: string; related?: string[]; repoRoot?: string; env?: …; now?: () => Date }`. `now`/`repoRoot`/`env` are test-injection seams (deterministic timestamp). Written by the CLI action from flags; read by `mailSend()`.
+- **Emitted frontmatter schema (Zod, new):** shape is OQ-1. Validator reads it; nobody persists it in memory.
+- **`validateDispatchWellFormed(header, knownAgents): { wellFormed: boolean; warnings: string[] }` (new, pure):** T1 predicates ONLY (inv1/Tenet 9) — recipient ∈ `knownAgents` (exact set membership), required fields present (schema/enum), refs match a format regex. **Never throws, never blocks.** Returns `warnings`; the caller writes regardless. Invariant: emits "well-formed" framing, **never** "valid"/"will-deliver" (inv2 — no unverified authority signal).
+- **`composeDispatch(header, body): string` (new, pure):** deterministic frontmatter+body serializer — the round-trip anchor (its output must parse back through `parseHeader`).
+- **No new state container.** The only durable artifact is the written outbox file: append-only to `<repoRoot>/.totem/orchestration/<from>/outbox/`, never mutated/cleared by this command.
+
+### State lifecycle
+
+- **Scope:** per-invocation. **Lifetime:** compose → validate (warn) → mkdir-recursive → atomic write (temp+rename, per ADR-106 "writes are atomic") → exit. **Ownership:** `mailSend()` owns the write; `mailReply()` reads the source dispatch, infers `to`/`subject`/`in-reply-to`, then delegates to `mailSend()`. No state crosses an invocation boundary.
+
+### Failure modes
+
+| Failure                                                 | Category                        | Agent-facing surface                                  | Recovery                         |
+| ------------------------------------------------------- | ------------------------------- | ----------------------------------------------------- | -------------------------------- |
+| missing `--to` / `--subject`                            | usage                           | **hard error** (compose-blocked)                      | supply flag                      |
+| ambiguous self (>1 mapped agent, no `--from`/env)       | usage                           | **hard error** ("specify --from")                     | supply `--from`                  |
+| unresolvable self (`resolveSelfAgents` → none)          | usage                           | **hard error** (no `.../undefined/outbox` write)      | set `TOTEM_SELF_AGENT`           |
+| `--body-file` unreadable                                | usage                           | **hard error** (intended body lost)                   | fix path                         |
+| unknown subcommand (`totem mail bogus`)                 | usage                           | **hard error** (fixes the #2042 fall-through)         | correct command                  |
+| recipient ∉ known-agent set                             | content-validation              | **WARN + write anyway** (inv6 fail-open)              | dispatch lands; warning surfaced |
+| malformed `--related` / `--in-reply-to` ref (on `send`) | content-validation              | **WARN + write anyway**                               | lands; warn                      |
+| `reply` source file missing/unparseable                 | usage (reply needs it to infer) | **hard error**                                        | fix `--in-reply-to`              |
+| outbox dir absent                                       | runtime (expected)              | mkdir-recursive, proceed                              | created                          |
+| filename collision (same minute+recipient+slug)         | runtime                         | disambiguate suffix (short counter)                   | unique name                      |
+| **write fails (EACCES/ENOSPC)**                         | permanent                       | **hard error** (dispatch did NOT land — Tenet 4 loud) | fix FS                           |
+
+**Fail-open's exact boundary (the load-bearing inv6 reading):** fail-open on _validation uncertainty_ (a malformed-but-delivered dispatch is recoverable; a blocked one is the #2119 catastrophe). Fail-**loud** on _actuation failure_ (a write that didn't land is silent drop — the opposite failure). No row is "silent degradation."
+
+**Two validity classes (strategy-claude concur 1740Z, ADR-098 owner):**
+
+- **Structural** (schema / timestamp / expected-action present + shaped): enforced **by construction** — the actuator _builds_ the shape, so a structurally-invalid dispatch is **unrepresentable**, not rejected-after-the-fact. The strongest form of ADR-098 "enforce via substrate"; inv2 realized; **inv6 doesn't apply** (nothing to fail on).
+- **Content** (recipient ∉ known-agent set, unresolvable refs): can't be guaranteed at construction → **loud-warn + write** (inv6). **The warn MUST surface at emit-time on CLI stderr**, not as a silent frontmatter note — a typo'd recipient writes to the outbox under a wrong name and is undelivered-but-not-errored (the silent-fail class). Loud-warn-and-write (sender catches the typo) ≠ block.
+- Three composing layers, none violating inv6: **structural = correct-by-construction · content = loud-warn-and-deliver · reader (`pollMail` A1.2 scan-errors-always-warn) = never-silent-drop backstop.**
+
+### Invariants to lock in via tests
+
+- A dispatch to an **unknown recipient is still written**, with a warning (inv6 fail-open — the headline test).
+- The validator returns `wellFormed:false` yet **never throws and never blocks** the write (inv2 + inv6).
+- `totem mail <unknown>` / unknown subcommand **hard-errors, never falls through to read** (the #2042 trap).
+- **Sensor↔actuator round-trip:** a file emitted by `send` is immediately surfaced by `pollMail` (the actuator emits exactly what the sensor reads — the "one enumeration, two readers" guarantee).
+- `reply` infers `to:=orig.from`, `subject:=Re: <orig>`, sets `in-reply-to:=<source path>`.
+- Ambiguous-self without `--from` hard-errors (no `undefined` outbox write).
+- A write failure surfaces as a **hard error**, not a swallowed warning (fail-loud on actuation).
+- Two sends in the same minute → two distinct files (collision-free).
+
+### Open questions
+
+- **OQ-1 (load-bearing — which frontmatter shape does the actuator emit?).** The reader (`parseHeader`) consumes `to/from/subject/date`; ADR-098 v0.4 mandates `schema:`/`timestamp:`(replacing `date:`)/`expected-action:`; the **de-facto wire** is `to/from/date/in-reply-to/related-issues/subject` (v0.4-noncompliant — what every live dispatch, incl. the reader, actually uses).
+  - **Options:**
+    - **1a (de-facto):** emit `to/from/date/subject` + optional `in-reply-to`/`related-issues`. Reader-paired today, ships independently, but bakes in a knowingly-v0.4-noncompliant emitter.
+    - **1b (v0.4-compliant):** emit `schema: adr-098-v0.4`/`timestamp:`/`expected-action:` + the rest, **and** teach `parseHeader` to read `timestamp:` (date: fallback). Makes totem the first v0.4-compliant emitter and the enforcement substrate the amendment called for — but widens scope to the reader and touches strategy's doctrine (ADR-098 ownership).
+  - **Recommendation:** **1b, coordinated with strategy** — the actuator is the natural v0.4 enforcement point, and shipping a non-compliant emitter at the one moment we can fix the drift is the wrong precedent. I'd dispatch the exact emit-shape to strategy-claude for ADR-098 concurrence (the same spec→strategy-review pattern as every #474 slice) **before** building, since 1b modifies the reader contract they own. Fallback to 1a only if you want the actuator to ship this session decoupled from the reader change.
+  - **RULED (satur8d, 2026-06-09): 1b — v0.4-compliant, coordinate first.** Build is HELD pending strategy-claude's ADR-098 concurrence on the emit-shape + the `parseHeader` `timestamp:` read. Emit-side v0.4 compliance is **structural** (the actuator always writes `schema:`/`timestamp:`/`expected-action:` by construction — nothing to reject); fail-open (inv6) therefore governs only the _content-validation_ predicates (unknown recipient, malformed refs), reconciling ADR-098's "enforce via substrate" with inv6's "never block transport."
+- **OQ-2 (coordination timing):** dispatch the OQ-1 emit-shape to strategy for concurrence before building (adds a round-trip but de-risks a reader-contract change on their doctrine), or build 1a now and treat 1b as a fast-follow? **Recommendation:** if you pick 1b, coordinate first; if 1a, build now.

--- a/packages/cli/src/commands/mail.test.ts
+++ b/packages/cli/src/commands/mail.test.ts
@@ -1239,6 +1239,36 @@ describe('validateDispatchContent / composeDispatch / resolveSelfSender (units)'
     expect(result.mail[0]!.subject).toBe(subject); // unquoted on read
   });
 
+  it('never decodes control/newline escapes out of a quoted subject (#2134 R4)', () => {
+    // A quoted wire subject encoding control bytes must surface in its escaped
+    // spelling — decoding it would hand `formatTextResult` raw ESC/newline for
+    // stderr (the terminal-injection class the agent-id guard blocks).
+    const escapedEsc = 'subject: "esc \\u001b[31m red"';
+    const escapedNewline = 'subject: "line1\\nline2"';
+    for (const [name, subjectLine] of [
+      ['2026-06-09T1735Z-esc.md', escapedEsc],
+      ['2026-06-09T1736Z-newline.md', escapedNewline],
+    ] as const) {
+      writeOutbox('totem-strategy', 'strategy-claude', [
+        {
+          name,
+          to: 'totem-claude',
+          raw: ['---', 'from: strategy-claude', 'to: totem-claude', subjectLine, '---', ''].join(
+            '\n',
+          ),
+        },
+      ]);
+    }
+    const result = pollMail({ repoRoot: selfRepoRoot(), workspace, env: {} });
+    expect(result.mail).toHaveLength(2);
+    const esc = String.fromCharCode(0x1b);
+    for (const entry of result.mail) {
+      expect(entry.subject).not.toContain(esc);
+      expect(entry.subject).not.toContain('\n');
+      expect(entry.subject.startsWith('"')).toBe(true); // verbatim, still quoted
+    }
+  });
+
   it('resolveSelfSender: explicit > unambiguous map > error', () => {
     const totemRepo = mkDir(path.join(workspace, 'totem'));
     expect(resolveSelfSender(totemRepo, {}, 'totem-gemini')).toBe('totem-gemini'); // explicit wins

--- a/packages/cli/src/commands/mail.test.ts
+++ b/packages/cli/src/commands/mail.test.ts
@@ -1009,6 +1009,55 @@ describe('mailSend — actuator (mmnto-ai/totem#2042)', () => {
       fs.existsSync(path.join(repo, '.totem', 'orchestration', 'totem-claude', 'outbox')),
     ).toBe(false);
   });
+
+  it('rejects control/whitespace/win32-reserved characters in agent ids (#2134 R2)', () => {
+    const repo = sendRepo();
+    // Built via fromCharCode so the source file itself carries no raw control
+    // bytes; ESC is the canonical terminal-injection probe (CR R2).
+    const esc = String.fromCharCode(0x1b);
+    for (const evil of [`evil${esc}]0;pwn`, 'two words', 'a:b', 'a*b']) {
+      expect(() =>
+        mailSend({
+          to: evil,
+          subject: 's',
+          from: 'totem-claude',
+          repoRoot: repo,
+          env: {},
+          now: fixedClock,
+          knownAgents: ['totem-claude'],
+        }),
+      ).toThrow(/unsafe characters/);
+    }
+  });
+
+  it('surfaces the original write error even when temp cleanup also fails (#2134 R2)', () => {
+    // GCA R2: a cleanup rmSync that throws must not shadow the actuation
+    // error — the failed write is the signal. No fs mocking (ESM namespaces
+    // are not spyable): instead, learn the deterministic target path from a
+    // clean send, then plant a NON-EMPTY DIRECTORY at `<filePath>.tmp` so
+    // (a) writeFileSync(tmp) fails with the original error (EISDIR), and
+    // (b) the cleanup rmSync(tmp) also fails (directory, no `recursive`).
+    const repo = sendRepo();
+    const common = {
+      to: 'strategy-claude',
+      subject: 'shadow probe',
+      from: 'totem-claude',
+      repoRoot: repo,
+      env: {},
+      now: fixedClock,
+      knownAgents: ['strategy-claude'],
+    } as const;
+    const probe = mailSend({ ...common });
+    fs.rmSync(probe.filePath); // free the slot so the rerun recomputes the same path
+    const tmpAsDir = `${probe.filePath}.tmp`;
+    fs.mkdirSync(tmpAsDir);
+    fs.writeFileSync(path.join(tmpAsDir, 'occupant.txt'), 'x', 'utf-8');
+    try {
+      expect(() => mailSend({ ...common })).toThrow(/write failed.*could not be removed/);
+    } finally {
+      fs.rmSync(tmpAsDir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe('mailReply — sugar (mmnto-ai/totem#2042)', () => {

--- a/packages/cli/src/commands/mail.test.ts
+++ b/packages/cli/src/commands/mail.test.ts
@@ -15,7 +15,17 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { cleanTmpDir } from '../test-utils.js';
-import { mailCommand, type MailPollResult, pollMail } from './mail.js';
+import {
+  composeDispatch,
+  type DispatchHeader,
+  mailCommand,
+  type MailPollResult,
+  mailReply,
+  mailSend,
+  pollMail,
+  resolveSelfSender,
+  validateDispatchContent,
+} from './mail.js';
 
 // ─── Fixture helpers ────────────────────────────────────
 
@@ -782,5 +792,292 @@ describe('pollMail — structured warnings on FS failures', () => {
     // Mail still surfaces (degraded — no exclusion filter), warning recorded.
     expect(result.mail).toHaveLength(1);
     expect(result.warnings.some((w) => w.startsWith('processed/ scan failed'))).toBe(true);
+  });
+});
+
+// ─── Reader: timestamp: (ADR-098 v0.4) with date: fallback ──
+
+describe('parseHeader — timestamp:/date: precedence (mmnto-ai/totem#2042)', () => {
+  function rawDispatch(fields: string[]): string {
+    return ['---', ...fields, '---', '', 'body', ''].join('\n');
+  }
+
+  it('reads timestamp: as the displayed time', () => {
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      {
+        name: '2026-06-09T1734Z-ts.md',
+        to: 'totem-claude',
+        raw: rawDispatch([
+          'from: strategy-claude',
+          'to: totem-claude',
+          'timestamp: 2026-06-09T17:34:37.127Z',
+          'subject: ts-test',
+        ]),
+      },
+    ]);
+    const result = poll();
+    expect(result.mail).toHaveLength(1);
+    expect(result.mail[0]!.date).toBe('2026-06-09T17:34:37.127Z');
+  });
+
+  it('prefers timestamp: over a legacy date: when both present', () => {
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      {
+        name: '2026-06-09T1734Z-both.md',
+        to: 'totem-claude',
+        raw: rawDispatch([
+          'from: strategy-claude',
+          'to: totem-claude',
+          'date: 2026-01-01T0000Z',
+          'timestamp: 2026-06-09T17:34:37.127Z',
+          'subject: both',
+        ]),
+      },
+    ]);
+    expect(poll().mail[0]!.date).toBe('2026-06-09T17:34:37.127Z');
+  });
+
+  it('still falls back to legacy date: (backwards-compat read)', () => {
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: '2026-06-09T1734Z-legacy.md', to: 'totem-claude', date: '2026-05-18T1700Z' },
+    ]);
+    expect(poll().mail[0]!.date).toBe('2026-05-18T1700Z');
+  });
+});
+
+// ─── Outbound: send / reply (mmnto-ai/totem#2042) ───────
+
+describe('mailSend — actuator (mmnto-ai/totem#2042)', () => {
+  const fixedClock = (): Date => new Date('2026-06-09T17:34:37.127Z');
+  function sendRepo(basename = 'totem'): string {
+    return mkDir(path.join(workspace, basename));
+  }
+
+  it('writes a v0.4-compliant dispatch the poller reads back (sensor↔actuator round-trip)', () => {
+    const res = mailSend({
+      to: 'strategy-claude',
+      subject: 'lane handoff',
+      from: 'totem-claude',
+      body: 'the body',
+      repoRoot: sendRepo(),
+      env: {},
+      now: fixedClock,
+      knownAgents: ['strategy-claude', 'totem-claude'],
+    });
+    // Structural v0.4 compliance, by construction.
+    const written = fs.readFileSync(res.filePath, 'utf-8');
+    expect(written).toContain('schema: adr-098-v0.4');
+    expect(written).toContain('timestamp: 2026-06-09T17:34:37.127Z');
+    expect(written).toContain('expected-action: none');
+    expect(res.warnings).toEqual([]);
+
+    // The poller (sensor) surfaces exactly what the actuator emitted.
+    const recipientRepo = mkDir(path.join(workspace, 'totem-strategy'));
+    const inbox = pollMail({ repoRoot: recipientRepo, workspace, env: {} });
+    expect(inbox.mail).toHaveLength(1);
+    expect(inbox.mail[0]!.to).toBe('strategy-claude');
+    expect(inbox.mail[0]!.from).toBe('totem-claude');
+    expect(inbox.mail[0]!.subject).toBe('lane handoff');
+    expect(inbox.mail[0]!.date).toBe('2026-06-09T17:34:37.127Z');
+  });
+
+  it('FAIL-OPEN: writes to an unknown recipient anyway, with a loud warning (inv6)', () => {
+    const res = mailSend({
+      to: 'totem-typoo',
+      subject: 's',
+      from: 'totem-claude',
+      repoRoot: sendRepo(),
+      env: {},
+      now: fixedClock,
+      knownAgents: ['strategy-claude', 'totem-claude'],
+    });
+    expect(fs.existsSync(res.filePath)).toBe(true); // NOT blocked
+    expect(res.warnings.some((w) => w.includes('not a known cohort agent'))).toBe(true);
+  });
+
+  it('treats broadcast as a known recipient (no warning)', () => {
+    const res = mailSend({
+      to: 'broadcast',
+      subject: 's',
+      from: 'totem-claude',
+      repoRoot: sendRepo(),
+      env: {},
+      now: fixedClock,
+      knownAgents: ['totem-claude'],
+    });
+    expect(res.warnings).toEqual([]);
+  });
+
+  it('hard-errors on ambiguous self with no --from (never silently picks one)', () => {
+    expect(() =>
+      mailSend({ to: 'strategy-claude', subject: 's', repoRoot: sendRepo('totem'), env: {} }),
+    ).toThrow(/ambiguous sender/);
+  });
+
+  it('hard-errors on unresolvable self (never writes .../undefined/outbox)', () => {
+    expect(() =>
+      mailSend({ to: 'x', subject: 's', repoRoot: sendRepo('not-a-cohort-repo'), env: {} }),
+    ).toThrow(/cannot resolve a sender/);
+  });
+
+  it('hard-errors on missing --to / --subject', () => {
+    const repo = sendRepo();
+    expect(() =>
+      mailSend({ to: '  ', subject: 's', from: 'totem-claude', repoRoot: repo, env: {} }),
+    ).toThrow(/--to/);
+    expect(() =>
+      mailSend({ to: 'x', subject: '', from: 'totem-claude', repoRoot: repo, env: {} }),
+    ).toThrow(/--subject/);
+  });
+
+  it('hard-errors on an unreadable --body-file (never ships an empty body)', () => {
+    expect(() =>
+      mailSend({
+        to: 'strategy-claude',
+        subject: 's',
+        from: 'totem-claude',
+        bodyFile: path.join(tmpRoot, 'no-such-body.md'),
+        repoRoot: sendRepo(),
+        env: {},
+        now: fixedClock,
+      }),
+    ).toThrow(/--body-file unreadable/);
+  });
+
+  it('disambiguates same-minute collisions into distinct files', () => {
+    const repo = sendRepo();
+    const common = {
+      to: 'strategy-claude',
+      subject: 'same slug here',
+      from: 'totem-claude',
+      repoRoot: repo,
+      env: {},
+      now: fixedClock,
+      knownAgents: ['strategy-claude'],
+    } as const;
+    const r1 = mailSend({ ...common });
+    const r2 = mailSend({ ...common });
+    expect(r1.filePath).not.toBe(r2.filePath);
+    expect(fs.existsSync(r1.filePath)).toBe(true);
+    expect(fs.existsSync(r2.filePath)).toBe(true);
+  });
+
+  it('creates the outbox tree on a fresh repo', () => {
+    const repo = sendRepo('totem');
+    const res = mailSend({
+      to: 'strategy-claude',
+      subject: 's',
+      from: 'totem-claude',
+      repoRoot: repo,
+      env: {},
+      now: fixedClock,
+      knownAgents: ['strategy-claude'],
+    });
+    expect(res.filePath).toContain(path.join('.totem', 'orchestration', 'totem-claude', 'outbox'));
+    expect(fs.existsSync(res.filePath)).toBe(true);
+  });
+
+  it('rejects a path-traversal --from', () => {
+    expect(() =>
+      mailSend({
+        to: 'x',
+        subject: 's',
+        from: '../evil',
+        repoRoot: sendRepo(),
+        env: {},
+        now: fixedClock,
+      }),
+    ).toThrow(/path-traversal/);
+  });
+});
+
+describe('mailReply — sugar (mmnto-ai/totem#2042)', () => {
+  const fixedClock = (): Date => new Date('2026-06-09T18:00:00.000Z');
+
+  function writeSource(): string {
+    const outbox = mkDir(
+      path.join(
+        workspace,
+        'totem-strategy',
+        '.totem',
+        'orchestration',
+        'strategy-claude',
+        'outbox',
+      ),
+    );
+    const p = path.join(outbox, '2026-06-09T1710Z-totem-claude-orig.md');
+    fs.writeFileSync(
+      p,
+      [
+        '---',
+        'schema: adr-098-v0.4',
+        'from: strategy-claude',
+        'to: totem-claude',
+        'timestamp: 2026-06-09T17:10:00.000Z',
+        'subject: Original subject',
+        '---',
+        '',
+        'orig body',
+        '',
+      ].join('\n'),
+      'utf-8',
+    );
+    return p;
+  }
+
+  it('infers to/subject/in-reply-to from the source dispatch', () => {
+    const src = writeSource();
+    const res = mailReply(src, {
+      from: 'totem-claude',
+      repoRoot: mkDir(path.join(workspace, 'totem')),
+      env: {},
+      now: fixedClock,
+      knownAgents: ['strategy-claude'],
+    });
+    expect(res.header.to).toBe('strategy-claude'); // = source.from
+    expect(res.header.subject).toBe('Re: Original subject');
+    expect(res.header.inReplyTo).toBe(src);
+  });
+
+  it('hard-errors when the source dispatch is missing', () => {
+    expect(() =>
+      mailReply(path.join(tmpRoot, 'nope.md'), {
+        from: 'totem-claude',
+        repoRoot: mkDir(path.join(workspace, 'totem')),
+        env: {},
+      }),
+    ).toThrow(/cannot read reply source dispatch/);
+  });
+});
+
+describe('validateDispatchContent / composeDispatch / resolveSelfSender (units)', () => {
+  it('warns on unknown recipient, silent on known + broadcast (exact predicate)', () => {
+    expect(validateDispatchContent({ to: 'nope' }, ['totem-claude'])).toHaveLength(1);
+    expect(validateDispatchContent({ to: 'totem-claude' }, ['totem-claude'])).toHaveLength(0);
+    expect(validateDispatchContent({ to: 'broadcast' }, ['totem-claude'])).toHaveLength(0);
+    expect(validateDispatchContent({ to: 'TOTEM-CLAUDE' }, ['totem-claude'])).toHaveLength(0); // case-insensitive
+  });
+
+  it('quotes YAML-unsafe subjects so the emit is valid YAML (and unquotes refs)', () => {
+    const header: DispatchHeader = {
+      schema: 'adr-098-v0.4',
+      from: 'totem-claude',
+      to: 'strategy-claude',
+      timestamp: '2026-06-09T17:34:37.127Z',
+      subject: '[#42 brackets: and colon]',
+      expectedAction: 'none',
+      related: ['mmnto-ai/totem#2042'],
+    };
+    const md = composeDispatch(header, 'body');
+    expect(md).toContain('subject: "[#42 brackets: and colon]"');
+    expect(md).toContain('  - mmnto-ai/totem#2042'); // ref stays unquoted
+    expect(md).toContain('related-issues:');
+  });
+
+  it('resolveSelfSender: explicit > unambiguous map > error', () => {
+    const totemRepo = mkDir(path.join(workspace, 'totem'));
+    expect(resolveSelfSender(totemRepo, {}, 'totem-gemini')).toBe('totem-gemini'); // explicit wins
+    expect(resolveSelfSender(totemRepo, { TOTEM_SELF_AGENT: 'totem-claude' })).toBe('totem-claude'); // env → single
+    expect(() => resolveSelfSender(totemRepo, {})).toThrow(/ambiguous/); // map → 2 agents
   });
 });

--- a/packages/cli/src/commands/mail.test.ts
+++ b/packages/cli/src/commands/mail.test.ts
@@ -1030,6 +1030,29 @@ describe('mailSend — actuator (mmnto-ai/totem#2042)', () => {
     }
   });
 
+  it('never echoes a rejected id raw — control bytes are JSON-escaped in the error (#2134 R3)', () => {
+    const esc = String.fromCharCode(0x1b);
+    let thrown: unknown;
+    try {
+      mailSend({
+        to: `evil${esc}x`,
+        subject: 's',
+        from: 'totem-claude',
+        repoRoot: sendRepo(),
+        env: {},
+        now: fixedClock,
+        knownAgents: ['totem-claude'],
+      });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(Error);
+    // The rejection message must not re-create the very terminal injection it
+    // blocks: no raw ESC on stderr, only its JSON-escaped spelling.
+    expect(String(thrown)).not.toContain(esc);
+    expect(String(thrown)).toContain('u001b');
+  });
+
   it('surfaces the original write error even when temp cleanup also fails (#2134 R2)', () => {
     // GCA R2: a cleanup rmSync that throws must not shadow the actuation
     // error — the failed write is the signal. No fs mocking (ESM namespaces
@@ -1105,7 +1128,38 @@ describe('mailReply — sugar (mmnto-ai/totem#2042)', () => {
     });
     expect(res.header.to).toBe('strategy-claude'); // = source.from
     expect(res.header.subject).toBe('Re: Original subject');
-    expect(res.header.inReplyTo).toBe(src);
+    // Portable repo-relative wire form — never the absolute local path
+    // (GCA R3 on mmnto-ai/totem#2134: no drive letters/usernames in shared
+    // frontmatter).
+    expect(res.header.inReplyTo).toBe(
+      '.totem/orchestration/strategy-claude/outbox/2026-06-09T1710Z-totem-claude-orig.md',
+    );
+  });
+
+  it('falls back to the outbox-dir agent when the source has no from: (#2134 R3)', () => {
+    // Reader parity: pollMail accepts a from:-less dispatch by falling back to
+    // the outbox directory name — reply must not hard-fail where the reader
+    // succeeded.
+    const outbox = mkDir(
+      path.join(
+        workspace,
+        'totem-strategy',
+        '.totem',
+        'orchestration',
+        'strategy-claude',
+        'outbox',
+      ),
+    );
+    const src = path.join(outbox, '2026-06-09T1700Z-totem-claude-legacy.md');
+    fs.writeFileSync(src, '---\nto: totem-claude\nsubject: legacy mail\n---\n\nBody.\n', 'utf-8');
+    const res = mailReply(src, {
+      from: 'totem-claude',
+      repoRoot: mkDir(path.join(workspace, 'totem')),
+      env: {},
+      now: fixedClock,
+      knownAgents: ['strategy-claude'],
+    });
+    expect(res.header.to).toBe('strategy-claude'); // derived from <agent>/outbox/ layout
   });
 
   it('hard-errors when the source dispatch is missing', () => {
@@ -1141,6 +1195,48 @@ describe('validateDispatchContent / composeDispatch / resolveSelfSender (units)'
     expect(md).toContain('subject: "[#42 brackets: and colon]"');
     expect(md).toContain('  - mmnto-ai/totem#2042'); // ref stays unquoted
     expect(md).toContain('related-issues:');
+  });
+
+  it('quotes boolean/null/numeric-shaped scalars so YAML readers keep the string type (#2134 R3)', () => {
+    const base: Omit<DispatchHeader, 'subject'> = {
+      schema: 'adr-098-v0.4',
+      from: 'totem-claude',
+      to: 'strategy-claude',
+      timestamp: '2026-06-09T17:34:37.127Z',
+      expectedAction: 'none',
+    };
+    for (const subject of ['true', 'NO', 'y', 'null', '~', '42', '-3.5', '1e5', '123.']) {
+      const md = composeDispatch({ ...base, subject }, 'body');
+      expect(md).toContain(`subject: ${JSON.stringify(subject)}`);
+    }
+    // Ordinary prose subjects stay unquoted (the de-facto wire shape).
+    expect(composeDispatch({ ...base, subject: 'plain words' }, 'body')).toContain(
+      'subject: plain words',
+    );
+  });
+
+  it('round-trips a quoted subject without accreting quotes (#2134 R3)', () => {
+    // compose → poll: the reader must surface the subject the sender typed,
+    // not yamlScalar's emit-quoting (CR R3 — `Re: "..."` accretion class).
+    const subject = 'R3: the colon-space forces quoting';
+    const md = composeDispatch(
+      {
+        schema: 'adr-098-v0.4',
+        from: 'strategy-claude',
+        to: 'totem-claude',
+        timestamp: '2026-06-09T17:34:37.127Z',
+        subject,
+        expectedAction: 'none',
+      },
+      'body',
+    );
+    expect(md).toContain(`subject: ${JSON.stringify(subject)}`); // quoted on the wire
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: '2026-06-09T1734Z-roundtrip.md', to: 'totem-claude', raw: md },
+    ]);
+    const result = pollMail({ repoRoot: selfRepoRoot(), workspace, env: {} });
+    expect(result.mail).toHaveLength(1);
+    expect(result.mail[0]!.subject).toBe(subject); // unquoted on read
   });
 
   it('resolveSelfSender: explicit > unambiguous map > error', () => {

--- a/packages/cli/src/commands/mail.test.ts
+++ b/packages/cli/src/commands/mail.test.ts
@@ -1269,6 +1269,46 @@ describe('validateDispatchContent / composeDispatch / resolveSelfSender (units)'
     }
   });
 
+  it('escapes raw control bytes from hand-authored wire fields (#2134 R5)', () => {
+    // The escaped-sequence guard (R4) covers the wire ENCODING of controls;
+    // this covers raw bytes typed directly into a dispatch — quoted, unquoted,
+    // and in from: — a reader exposure that predates the actuator.
+    const esc = String.fromCharCode(0x1b);
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      {
+        name: '2026-06-09T1737Z-rawquoted.md',
+        to: 'totem-claude',
+        raw: [
+          '---',
+          `from: strategy${esc}-claude`,
+          'to: totem-claude',
+          `subject: "quoted ${esc}[31m raw"`,
+          '---',
+          '',
+        ].join('\n'),
+      },
+      {
+        name: '2026-06-09T1738Z-rawunquoted.md',
+        to: 'totem-claude',
+        raw: [
+          '---',
+          'from: strategy-claude',
+          'to: totem-claude',
+          `subject: unquoted ${esc}[31m raw`,
+          '---',
+          '',
+        ].join('\n'),
+      },
+    ]);
+    const result = pollMail({ repoRoot: selfRepoRoot(), workspace, env: {} });
+    expect(result.mail).toHaveLength(2);
+    for (const entry of result.mail) {
+      expect(entry.subject).not.toContain(esc);
+      expect(entry.from).not.toContain(esc);
+      expect(entry.subject).toContain('u001b'); // escaped spelling — lossless, visible
+    }
+  });
+
   it('resolveSelfSender: explicit > unambiguous map > error', () => {
     const totemRepo = mkDir(path.join(workspace, 'totem'));
     expect(resolveSelfSender(totemRepo, {}, 'totem-gemini')).toBe('totem-gemini'); // explicit wins

--- a/packages/cli/src/commands/mail.test.ts
+++ b/packages/cli/src/commands/mail.test.ts
@@ -989,6 +989,26 @@ describe('mailSend — actuator (mmnto-ai/totem#2042)', () => {
       }),
     ).toThrow(/path-traversal/);
   });
+
+  it('rejects a path-traversal --to and never escapes the outbox (#2134)', () => {
+    const repo = sendRepo();
+    expect(() =>
+      mailSend({
+        to: '../../../evil',
+        subject: 's',
+        from: 'totem-claude',
+        repoRoot: repo,
+        env: {},
+        now: fixedClock,
+        knownAgents: ['totem-claude'],
+      }),
+    ).toThrow(/path-traversal/);
+    // The guard fires before any mkdir/write, so nothing escaped — not even the
+    // sender's own outbox was created.
+    expect(
+      fs.existsSync(path.join(repo, '.totem', 'orchestration', 'totem-claude', 'outbox')),
+    ).toBe(false);
+  });
 });
 
 describe('mailReply — sugar (mmnto-ai/totem#2042)', () => {

--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -179,15 +179,31 @@ function parseHeader(content: string): HeaderParse {
   const timestampMatch = header.match(/^timestamp:\s*(.+)$/im);
   const dateMatch = header.match(/^date:\s*(.+)$/im);
   const when = timestampMatch ? timestampMatch[1]! : dateMatch ? dateMatch[1]! : null;
+  // Every field below is sender-controlled wire text that downstream writers
+  // (`formatTextResult` → stderr, `--json` consumers' logs) display verbatim —
+  // escape raw control bytes at this single boundary so no parse path (quoted,
+  // unquoted, hand-authored) can carry terminal-injection bytes into
+  // `MailEntry` (CR R5 on mmnto-ai/totem#2134; the unquoted exposure predates
+  // this PR — closing the whole class here, not just the unquote fallback).
   return {
     ok: true,
     header: {
-      to: toMatch[1]!.trim(),
-      from: fromMatch ? fromMatch[1]!.trim() : null,
-      subject,
-      date: when !== null ? when.trim() : null,
+      to: escapeControlBytes(toMatch[1]!.trim()),
+      from: fromMatch ? escapeControlBytes(fromMatch[1]!.trim()) : null,
+      subject: subject !== null ? escapeControlBytes(subject) : null,
+      date: when !== null ? escapeControlBytes(when.trim()) : null,
     },
   };
+}
+
+/**
+ * Replace each raw control byte with its JSON-escaped spelling (ESC becomes
+ * the six characters backslash-u-0-0-1-b, LF becomes backslash-n, …) so the
+ * value stays display-safe AND lossless — the escaped form is visible instead
+ * of interpreted. Printable text passes through unchanged.
+ */
+function escapeControlBytes(value: string): string {
+  return value.replace(/\p{Cc}/gu, (ch) => JSON.stringify(ch).slice(1, -1));
 }
 
 /**

--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -191,23 +191,30 @@ function parseHeader(content: string): HeaderParse {
 }
 
 /**
- * Strict JSON-string shape: the exact output space of `yamlScalar`'s
- * `JSON.stringify` quoting (double-quoted, every inner quote/backslash/control
- * escaped). Anything else — hand-authored asymmetric quotes, raw control
- * bytes, single quotes — deliberately does NOT match and reads verbatim.
+ * Strict PRINTABLE JSON-string shape: a double-quoted scalar whose decoded
+ * value provably contains no control bytes. The only escapes admitted are
+ * `\"` `\\` `\/` — the ones that decode to printables. Escapes that decode to
+ * control bytes (`\n`, `\t`, `\b\f\r`, `\uXXXX`) deliberately do NOT match
+ * (CR R4 on mmnto-ai/totem#2134): a control-bearing quoted subject would
+ * otherwise decode into raw ESC/newline that `formatTextResult` writes to
+ * stderr — the same terminal-injection class the agent-id guard blocks.
+ * Likewise hand-authored asymmetric quotes, raw control bytes, and single
+ * quotes — all read verbatim.
  */
-const JSON_STRING_SCALAR = /^"(?:[^"\\\p{Cc}]|\\(?:["\\/bfnrt]|u[0-9a-fA-F]{4}))*"$/u;
+const PRINTABLE_JSON_STRING_SCALAR = /^"(?:[^"\\\p{Cc}]|\\["\\/])*"$/u;
 
 /**
  * Undo `yamlScalar`'s double-quoting on read so quoted scalars round-trip:
  * compose → parse → `Re: <subject>` must not accrete quotes, and `pollMail`
  * must surface the subject the sender typed (CR R3 on mmnto-ai/totem#2134).
  * The shape pre-check makes `JSON.parse` infallible here — no catch needed —
- * and confines unquoting to strings `yamlScalar` itself could have emitted, so
- * reader behavior for legacy/hand-authored mail is unchanged.
+ * and confines unquoting to printable-only strings, so a wire value encoding
+ * control bytes surfaces in its escaped spelling instead of decoding into the
+ * terminal (display stays lossless AND injection-free), and reader behavior
+ * for legacy/hand-authored mail is unchanged.
  */
 function unquoteScalar(value: string): string {
-  return JSON_STRING_SCALAR.test(value) ? (JSON.parse(value) as string) : value;
+  return PRINTABLE_JSON_STRING_SCALAR.test(value) ? (JSON.parse(value) as string) : value;
 }
 
 /**

--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -168,6 +168,7 @@ function parseHeader(content: string): HeaderParse {
   }
   const fromMatch = header.match(/^from:\s*(.+)$/im);
   const subjectMatch = header.match(/^[-\s]*subject:\s*(.+)$/im);
+  const subject = subjectMatch ? unquoteScalar(subjectMatch[1]!.trim()) : null;
   // ADR-098 v0.4 codified `timestamp:` (full RFC3339) as canonical, replacing
   // legacy `date:`; `date:` remains a backwards-compat read (the amendment's
   // own migration note). Read `timestamp:` first, fall back to `date:`. The
@@ -183,10 +184,30 @@ function parseHeader(content: string): HeaderParse {
     header: {
       to: toMatch[1]!.trim(),
       from: fromMatch ? fromMatch[1]!.trim() : null,
-      subject: subjectMatch ? subjectMatch[1]!.trim() : null,
+      subject,
       date: when !== null ? when.trim() : null,
     },
   };
+}
+
+/**
+ * Strict JSON-string shape: the exact output space of `yamlScalar`'s
+ * `JSON.stringify` quoting (double-quoted, every inner quote/backslash/control
+ * escaped). Anything else — hand-authored asymmetric quotes, raw control
+ * bytes, single quotes — deliberately does NOT match and reads verbatim.
+ */
+const JSON_STRING_SCALAR = /^"(?:[^"\\\p{Cc}]|\\(?:["\\/bfnrt]|u[0-9a-fA-F]{4}))*"$/u;
+
+/**
+ * Undo `yamlScalar`'s double-quoting on read so quoted scalars round-trip:
+ * compose → parse → `Re: <subject>` must not accrete quotes, and `pollMail`
+ * must surface the subject the sender typed (CR R3 on mmnto-ai/totem#2134).
+ * The shape pre-check makes `JSON.parse` infallible here — no catch needed —
+ * and confines unquoting to strings `yamlScalar` itself could have emitted, so
+ * reader behavior for legacy/hand-authored mail is unchanged.
+ */
+function unquoteScalar(value: string): string {
+  return JSON_STRING_SCALAR.test(value) ? (JSON.parse(value) as string) : value;
 }
 
 /**
@@ -602,7 +623,13 @@ function yamlScalar(value: string): string {
     /[\n"]/.test(value) ||
     /^[[\]{}>|*&!%@`'"#-]/.test(value) ||
     /:\s/.test(value) ||
-    /\s#/.test(value);
+    /\s#/.test(value) ||
+    // YAML 1.1 plain-scalar coercion traps: a bare boolean/null/numeric-shaped
+    // value would parse as a non-string once the derivation engine YAML-parses
+    // the wire (GCA R3 on mmnto-ai/totem#2134; incl. YAML 1.1's bare y/n and
+    // exponential/trailing-dot floats). Quote to pin the string type.
+    /^(?:y|n|yes|no|true|false|on|off|null|~)$/i.test(value) ||
+    /^[+-]?(?:\d+\.?|\d*\.\d+)(?:[eE][+-]?\d+)?$/.test(value);
   return needsQuote ? JSON.stringify(value) : value;
 }
 
@@ -708,9 +735,12 @@ function assertSafeAgentId(id: string, label: string): void {
   // whitespace/win32-reserved characters that would propagate into the
   // dispatch markdown and CLI logs (CR R2, same PR).
   if (!isPathSafeAgentId(id)) {
+    // JSON-escape the echoed id: this rejection path exists precisely because
+    // the value may carry control bytes — echoing it raw to stderr would
+    // re-create the terminal injection it blocks (CR R3 on mmnto-ai/totem#2134).
     throw new TotemError(
       'MAIL_SEND_FAILED',
-      `invalid --${label} "${id}" (path-traversal, unsafe characters, or empty)`,
+      `invalid --${label} ${JSON.stringify(id)} (path-traversal, unsafe characters, or empty)`,
       'pass a plain agent-id such as "totem-claude" (no path separators, "..", whitespace, or control characters).',
     );
   }
@@ -895,9 +925,10 @@ export function mailSend(opts: MailSendOptions): MailSendResult {
 /**
  * `totem mail reply <source>` — syntactic sugar over `mailSend`. Reads the
  * source dispatch (HARD error if missing/unparseable — reply structurally needs
- * it to infer the recipient + subject), then sends with `to = source.from`,
- * `subject = "Re: <source.subject>"`, and `in-reply-to = source path`. Any
- * field can still be overridden via opts.
+ * it to infer the recipient + subject), then sends with `to = source.from`
+ * (falling back to the source's outbox-dir agent, reader parity),
+ * `subject = "Re: <source.subject>"`, and `in-reply-to` set to the source's
+ * repo-relative wire form. Any field can still be overridden via opts.
  */
 export function mailReply(
   source: string,
@@ -926,7 +957,11 @@ export function mailReply(
       'the source must be an ADR-098 dispatch with a frontmatter block; use `mail send --to` for a fresh dispatch.',
     );
   }
-  const replyTo = opts.to ?? parsed.header.from ?? '';
+  // Reader-parity fallback (CR R3 on mmnto-ai/totem#2134): `pollMail` accepts
+  // a dispatch without `from:` by falling back to the outbox directory name,
+  // so a reply to such mail must not hard-fail where the reader succeeded —
+  // derive the sender from the `<agent>/outbox/<file>` layout.
+  const replyTo = opts.to ?? parsed.header.from ?? senderFromSourcePath(source) ?? '';
   if (replyTo.trim().length === 0) {
     throw new TotemError(
       'MAIL_SEND_FAILED',
@@ -935,7 +970,32 @@ export function mailReply(
     );
   }
   const subject = opts.subject ?? `Re: ${parsed.header.subject ?? '(no subject)'}`;
-  return mailSend({ ...opts, to: replyTo, subject, inReplyTo: source });
+  return mailSend({ ...opts, to: replyTo, subject, inReplyTo: portableSourceRef(source) });
+}
+
+/**
+ * Derive the sender agent-id from a dispatch path's `<agent>/outbox/<file>`
+ * layout — the same fallback `pollMail` applies when frontmatter omits
+ * `from:` (reader↔reply parity, CR R3 on mmnto-ai/totem#2134).
+ */
+function senderFromSourcePath(source: string): string | null {
+  const segments = path.resolve(source).split(/[/\\]/);
+  const outboxIdx = segments.lastIndexOf('outbox');
+  return outboxIdx > 0 ? (segments[outboxIdx - 1] ?? null) : null;
+}
+
+/**
+ * Reduce a reply-source path to the portable repo-relative wire form
+ * (`.totem/orchestration/<agent>/outbox/<file>` — the de-facto cohort shape
+ * for `in-reply-to:`) so an absolute local path never leaks machine-specific
+ * structure (drive letters, usernames) into shared frontmatter (GCA R3 on
+ * mmnto-ai/totem#2134). Falls back to the basename when the source lives
+ * outside a recognizable orchestration tree.
+ */
+function portableSourceRef(source: string): string {
+  const normalized = source.replace(/\\/g, '/');
+  const idx = normalized.lastIndexOf('.totem/orchestration/');
+  return idx >= 0 ? normalized.slice(idx) : path.basename(source);
 }
 
 /**

--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -700,16 +700,18 @@ export function resolveSelfSender(
 }
 
 function assertSafeAgentId(id: string, label: string): void {
-  // Reuse core's single traversal guard (`isPathSafeAgentId` →
-  // AGENT_ID_TRAVERSAL_PATTERN) rather than re-deriving the pattern — both the
-  // sender's `--from` (an outbox directory segment) and the recipient's `--to`
-  // (interpolated into the filename) must be blocked from `/`, `\`, `..`, or a
-  // null byte (Greptile P2 / GCA + CR path-traversal critical, mmnto-ai/totem#2134).
+  // Reuse core's single path-segment guard (`isPathSafeAgentId`) rather than
+  // re-deriving the pattern — both the sender's `--from` (an outbox directory
+  // segment) and the recipient's `--to` (interpolated into the filename) must
+  // be blocked from `/`, `\`, `..`, a null byte (Greptile P2 / GCA + CR
+  // path-traversal critical, mmnto-ai/totem#2134), and from control/
+  // whitespace/win32-reserved characters that would propagate into the
+  // dispatch markdown and CLI logs (CR R2, same PR).
   if (!isPathSafeAgentId(id)) {
     throw new TotemError(
       'MAIL_SEND_FAILED',
-      `invalid --${label} "${id}" (path-traversal or empty)`,
-      'pass a plain agent-id such as "totem-claude" (no path separators or "..").',
+      `invalid --${label} "${id}" (path-traversal, unsafe characters, or empty)`,
+      'pass a plain agent-id such as "totem-claude" (no path separators, "..", whitespace, or control characters).',
     );
   }
 }
@@ -865,11 +867,24 @@ export function mailSend(opts: MailSendOptions): MailSendResult {
     // remove any partial temp first (force suppresses ENOENT; maxRetries/
     // retryDelay guard a transient win32 lock), then surface the original
     // error with the path so the sender knows nothing shipped.
-    fs.rmSync(tmp, { force: true, maxRetries: 3, retryDelay: 50 });
+    const hint = 'check outbox directory permissions and available disk space.';
+    try {
+      fs.rmSync(tmp, { force: true, maxRetries: 3, retryDelay: 50 });
+    } catch (cleanupErr) {
+      // A failed cleanup must not shadow the actuation error (GCA R2 on
+      // mmnto-ai/totem#2134): rethrow the ORIGINAL failure as the cause, with
+      // the stranded-temp note folded into the message so both stay visible.
+      throw new TotemError(
+        'MAIL_SEND_FAILED',
+        `write failed (${filePath}): ${String(err)} (temp file ${tmp} could not be removed: ${String(cleanupErr)})`,
+        hint,
+        err,
+      );
+    }
     throw new TotemError(
       'MAIL_SEND_FAILED',
       `write failed (${filePath}): ${String(err)}`,
-      'check outbox directory permissions and available disk space.',
+      hint,
       err,
     );
   }

--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -21,7 +21,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { resolveSelfAgents } from '@mmnto/totem';
+import { knownCohortAgents, resolveSelfAgents, TotemError } from '@mmnto/totem';
 
 // ─── Constants ──────────────────────────────────────────
 
@@ -47,7 +47,7 @@ export interface MailEntry {
   from: string;
   /** Recipient (from frontmatter `to:`, preserved verbatim). */
   to: string;
-  /** ISO timestamp from frontmatter `date:`, or null if absent. */
+  /** ISO timestamp from frontmatter `timestamp:` (ADR-098 v0.4 canonical), falling back to legacy `date:`; null if absent. */
   date: string | null;
   /** Subject line from frontmatter, or `(no subject)` if absent. */
   subject: string;
@@ -168,14 +168,23 @@ function parseHeader(content: string): HeaderParse {
   }
   const fromMatch = header.match(/^from:\s*(.+)$/im);
   const subjectMatch = header.match(/^[-\s]*subject:\s*(.+)$/im);
+  // ADR-098 v0.4 codified `timestamp:` (full RFC3339) as canonical, replacing
+  // legacy `date:`; `date:` remains a backwards-compat read (the amendment's
+  // own migration note). Read `timestamp:` first, fall back to `date:`. The
+  // surfaced field stays `MailEntry.date` (no rename) — it is the displayed
+  // time, and a cosmetic rename would widen blast radius across hooks +
+  // `--json` consumers for no contract gain (Tenet 5; strategy-claude concur
+  // 2026-06-09, folded into ADR-098's migration note on the strategy side).
+  const timestampMatch = header.match(/^timestamp:\s*(.+)$/im);
   const dateMatch = header.match(/^date:\s*(.+)$/im);
+  const when = timestampMatch ? timestampMatch[1]! : dateMatch ? dateMatch[1]! : null;
   return {
     ok: true,
     header: {
       to: toMatch[1]!.trim(),
       from: fromMatch ? fromMatch[1]!.trim() : null,
       subject: subjectMatch ? subjectMatch[1]!.trim() : null,
-      date: dateMatch ? dateMatch[1]!.trim() : null,
+      date: when !== null ? when.trim() : null,
     },
   };
 }
@@ -484,5 +493,424 @@ export async function mailCommand(opts: MailCommandOptions = {}): Promise<MailPo
     log.info(TAG, line);
   }
 
+  return result;
+}
+
+// ─── Outbound: send / reply (mmnto-ai/totem#2042) ───────
+//
+// The actuator half of the ADR-106 coordination triad (sensor = `pollMail`
+// above). Before this, `totem mail send` silently fell through to the read
+// command and every dispatch was hand-authored against five undocumented
+// conventions — a discipline the protocol structurally could not satisfy
+// (Tenet 13: sensor without actuator). Three composing validity layers,
+// none violating ADR-106 inv6 (fail-open transport):
+//
+//   structural  — v0.4 compliance by CONSTRUCTION (the `DispatchHeader` type
+//                 makes a malformed-shape dispatch unrepresentable);
+//   content     — predicates that can't be guaranteed at construction
+//                 (recipient known? refs non-empty?) → LOUD warn + write
+//                 anyway (a blocked dispatch is worse than a malformed one,
+//                 the mmnto-ai/totem#2119 exhibit);
+//   reader      — `pollMail`'s scan-errors-always-warn is the never-silent
+//                 -drop backstop.
+//
+// (OQ-1 ruled 1b by satur8d 2026-06-09; emit-shape + reader `timestamp:` read
+// concurred by strategy-claude, ADR-098 owner, same day.)
+
+/** ADR-098 v0.4 canonical schema literal emitted by the actuator. */
+const ADR098_SCHEMA = 'adr-098-v0.4';
+
+/**
+ * Path-traversal / empty guard for an agent-id used as an outbox directory
+ * segment. Mirrors core's `AGENT_ID_TRAVERSAL_PATTERN` (not exported) so a
+ * malicious or fat-fingered `--from` cannot escape `.totem/orchestration/`.
+ */
+const AGENT_ID_UNSAFE = /[/\\\0]|\.\./;
+
+/**
+ * Structurally-complete dispatch header. ADR-098 v0.4 compliance is enforced
+ * *by construction*: you cannot build this object without `schema` / `from` /
+ * `to` / `timestamp` / `subject` / `expectedAction`, so a structurally invalid
+ * dispatch is unrepresentable rather than rejected after the fact — the
+ * strongest form of "enforce via substrate" (inv2 realized). The content
+ * predicates that CANNOT be guaranteed at construction time (is the recipient
+ * a known agent? do refs resolve?) are the validator's job, and warn rather
+ * than block (inv6).
+ */
+export interface DispatchHeader {
+  schema: string;
+  from: string;
+  to: string;
+  /** Full RFC3339 UTC, e.g. `2026-06-09T17:34:37.127Z` (ADR-098 v0.4). */
+  timestamp: string;
+  subject: string;
+  /** ADR-098 v0.4 mandatory; the `none` literal for informational dispatches. */
+  expectedAction: string;
+  inReplyTo?: string;
+  priority?: string;
+  related?: string[];
+}
+
+export interface MailSendOptions {
+  /** Recipient agent-id (or `broadcast`). */
+  to: string;
+  /** Subject line (the cohort convention carries the gist here). */
+  subject: string;
+  /** Sender agent-id; default resolves from self, erroring if ambiguous. */
+  from?: string;
+  /** Read the dispatch body from this file (hard error if unreadable). */
+  bodyFile?: string;
+  /** Direct body text (test/stdin seam); `bodyFile` overrides when both set. */
+  body?: string;
+  /** `in-reply-to:` frontmatter — the source dispatch path. */
+  inReplyTo?: string;
+  /** `priority:` frontmatter. */
+  priority?: string;
+  /** `related-issues:` frontmatter list. */
+  related?: string[];
+  /** `expected-action:` frontmatter; defaults to the `none` literal. */
+  expectedAction?: string;
+  /** Filename slug override; default derived from the subject. */
+  slug?: string;
+  /** Repo root (default: cwd). Test injection point. */
+  repoRoot?: string;
+  /** Env override (default: process.env). Test injection point. */
+  env?: Record<string, string | undefined>;
+  /** Clock injection for deterministic timestamps/filenames in tests. */
+  now?: () => Date;
+  /** Known-recipient set override (default: `knownCohortAgents()`). */
+  knownAgents?: readonly string[];
+}
+
+export interface MailSendResult {
+  /** Absolute path of the written dispatch. */
+  filePath: string;
+  /** Basename of the written dispatch. */
+  fileName: string;
+  /** The composed (structurally-valid-by-construction) header. */
+  header: DispatchHeader;
+  /** Content-class warnings surfaced at emit-time; dispatch still written. */
+  warnings: string[];
+}
+
+/**
+ * Double-quote a frontmatter scalar (JSON form is a valid YAML double-quoted
+ * scalar) only when the raw value would otherwise mis-parse: edge whitespace,
+ * a newline/quote, a leading flow/indicator char, or a `: ` / ` #` sequence
+ * (YAML's map-value + comment triggers). Now that the actuator is the
+ * v0.4-compliant emitter, the output must be real YAML — the derivation engine
+ * will parse it, unlike the regex reader. Refs like `owner/repo#123` (no space
+ * before `#`) stay unquoted, matching the de-facto wire.
+ */
+function yamlScalar(value: string): string {
+  const needsQuote =
+    value === '' ||
+    value !== value.trim() ||
+    /[\n"]/.test(value) ||
+    /^[[\]{}>|*&!%@`'"#-]/.test(value) ||
+    /:\s/.test(value) ||
+    /\s#/.test(value);
+  return needsQuote ? JSON.stringify(value) : value;
+}
+
+/**
+ * Serialize a dispatch header + body to ADR-098 v0.4 markdown. Pure +
+ * deterministic — the round-trip anchor: its output MUST parse back through
+ * `parseHeader` (the sensor↔actuator "one enumeration, two readers" pairing).
+ * Frontmatter keys are kebab-case wire form, the surface the reader greps.
+ */
+export function composeDispatch(header: DispatchHeader, body: string): string {
+  const lines: string[] = ['---'];
+  lines.push(`schema: ${header.schema}`);
+  lines.push(`from: ${header.from}`);
+  lines.push(`to: ${header.to}`);
+  lines.push(`timestamp: ${header.timestamp}`);
+  lines.push(`subject: ${yamlScalar(header.subject)}`);
+  lines.push(`expected-action: ${yamlScalar(header.expectedAction)}`);
+  if (header.inReplyTo !== undefined) lines.push(`in-reply-to: ${yamlScalar(header.inReplyTo)}`);
+  if (header.priority !== undefined) lines.push(`priority: ${yamlScalar(header.priority)}`);
+  if (header.related !== undefined && header.related.length > 0) {
+    lines.push('related-issues:');
+    for (const ref of header.related) lines.push(`  - ${yamlScalar(ref)}`);
+  }
+  lines.push('---');
+  lines.push('');
+  // Exactly one trailing newline on the body for stable round-trips.
+  lines.push(body.replace(/\s+$/, ''));
+  lines.push('');
+  return lines.join('\n');
+}
+
+/**
+ * Content-class validation (inv1: exact predicates only — set membership and
+ * non-emptiness, never judgment). NEVER throws, NEVER blocks: returns warnings
+ * the caller surfaces at emit-time and writes anyway (inv6). The headline check
+ * is the unknown-recipient typo class (strategy-claude 2026-06-09): a typo'd
+ * recipient writes under a wrong name and is undelivered-but-not-errored unless
+ * the sender is told loudly.
+ */
+export function validateDispatchContent(
+  header: { to: string; related?: string[] },
+  knownAgents: readonly string[],
+): string[] {
+  const warnings: string[] = [];
+  const to = header.to.trim();
+  const known = new Set(knownAgents.map((a) => a.toLowerCase()));
+  if (to.toLowerCase() !== 'broadcast' && !known.has(to.toLowerCase())) {
+    warnings.push(
+      `recipient "${to}" is not a known cohort agent — the dispatch WILL be written but may be undeliverable (check for a typo). Known: ${[...knownAgents].sort().join(', ')}, broadcast.`,
+    );
+  }
+  if (header.related !== undefined) {
+    for (const ref of header.related) {
+      if (ref.trim().length === 0) {
+        warnings.push('a related-issues entry is empty/whitespace (kept verbatim).');
+      }
+    }
+  }
+  return warnings;
+}
+
+/**
+ * Resolve the single sender identity for an outbound dispatch. Unlike the
+ * reader (which resolves a SET of self-agents to filter by), send must pick
+ * ONE. Precedence: explicit `--from` > unambiguous `resolveSelfAgents` > error.
+ * A >1 ambiguous map (e.g. totem hosts both totem-claude + totem-gemini) is a
+ * hard usage error — never silently pick one (it would mis-attribute the
+ * dispatch). Zero is a hard error too — never write to `.../undefined/outbox`.
+ */
+export function resolveSelfSender(
+  repoRoot: string,
+  env: Record<string, string | undefined>,
+  explicitFrom?: string,
+): string {
+  if (explicitFrom !== undefined && explicitFrom.trim().length > 0) {
+    return explicitFrom.trim();
+  }
+  const resolved = resolveSelfAgents(repoRoot, env);
+  if (resolved.agents.length === 1) return resolved.agents[0]!;
+  if (resolved.agents.length === 0) {
+    throw new TotemError(
+      'MAIL_SEND_FAILED',
+      'cannot resolve a sender identity for the outbound dispatch',
+      'set TOTEM_SELF_AGENT or pass --from <agent-id>.',
+    );
+  }
+  throw new TotemError(
+    'MAIL_SEND_FAILED',
+    `ambiguous sender — this repo hosts ${resolved.agents.join(', ')}`,
+    'pass --from <agent-id> to disambiguate.',
+  );
+}
+
+function assertSafeAgentId(id: string, label: string): void {
+  // totem-context: AGENT_ID_UNSAFE is a NON-global regex (no `g` flag), so
+  // `.test()` is stateless here — this is path-traversal sanitization on an
+  // agent-id used as a directory segment, NOT shell-command matching (the lint
+  // lesson's anchored-regex guidance targets command detection, not this).
+  if (id.length === 0 || AGENT_ID_UNSAFE.test(id)) {
+    throw new TotemError(
+      'MAIL_SEND_FAILED',
+      `invalid --${label} "${id}" (path-traversal or empty)`,
+      'pass a plain agent-id such as "totem-claude" (no path separators or "..").',
+    );
+  }
+}
+
+/**
+ * Filename-safe minute-granularity UTC stamp: `YYYY-MM-DDTHHMMZ`. Colons are
+ * illegal in win32 filenames (strategy-claude 2026-06-09, non-negotiable) and
+ * this matches every existing outbox name; the frontmatter carries the full
+ * RFC3339 `timestamp:` separately.
+ */
+function compactStamp(d: Date): string {
+  const iso = d.toISOString();
+  // `17:34` → `1734` (drop the colon, illegal in win32 filenames).
+  const hhmm = iso.slice(11, 16).replace(':', '');
+  return `${iso.slice(0, 10)}T${hhmm}Z`;
+}
+
+/** Short, kebab filename slug (concise-dispatch-filename discipline: ~3-6 words). */
+function slugify(subject: string, explicit?: string): string {
+  const source = explicit !== undefined && explicit.trim().length > 0 ? explicit : subject;
+  const slug = source
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .split('-')
+    .filter((s) => s.length > 0)
+    .slice(0, 6)
+    .join('-')
+    .slice(0, 48);
+  return slug.length > 0 ? slug : 'dispatch';
+}
+
+/**
+ * First non-colliding outbox path for `<base>.md`, suffixing `-2`, `-3`, … on
+ * collision (two dispatches to the same recipient in the same minute with the
+ * same slug). Deterministic — no randomness.
+ */
+function uniqueOutboxPath(outboxDir: string, base: string): string {
+  let candidate = path.join(outboxDir, `${base}.md`);
+  let n = 2;
+  while (fs.existsSync(candidate)) {
+    candidate = path.join(outboxDir, `${base}-${n}.md`);
+    n += 1;
+  }
+  return candidate;
+}
+
+/**
+ * Compose + validate + write an outbound dispatch to the sender's own outbox.
+ * Structural validity is by construction; content warnings are returned (the
+ * CLI wrapper surfaces them loudly) and never block the write. The only HARD
+ * failures are usage errors (missing to/subject, unresolvable/ambiguous self,
+ * unreadable body-file) and actuation failure (a write that didn't land —
+ * fail-loud, Tenet 4, the opposite of the inv6 content case).
+ */
+export function mailSend(opts: MailSendOptions): MailSendResult {
+  const env = opts.env ?? process.env;
+  const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
+  const now = (opts.now ?? (() => new Date()))();
+
+  const to = opts.to.trim();
+  if (to.length === 0)
+    throw new TotemError(
+      'MAIL_SEND_FAILED',
+      '--to <recipient> is required',
+      'pass --to <recipient-agent-id> (or "broadcast").',
+    );
+  const subject = opts.subject.trim();
+  if (subject.length === 0)
+    throw new TotemError(
+      'MAIL_SEND_FAILED',
+      '--subject <text> is required',
+      'pass --subject "<text>".',
+    );
+
+  const from = resolveSelfSender(repoRoot, env, opts.from);
+  assertSafeAgentId(from, 'from');
+
+  // Body precedence: bodyFile > body > empty. A declared --body-file that can't
+  // be read is a hard usage error — the intended body is lost, never silently
+  // ship an empty dispatch in its place.
+  let body = opts.body ?? '';
+  if (opts.bodyFile !== undefined) {
+    try {
+      body = fs.readFileSync(opts.bodyFile, 'utf-8');
+      // totem-context: a declared --body-file that can't be read is a hard usage error (the user named a body source that doesn't resolve); rethrow as a clear message rather than degrade to an empty dispatch.
+    } catch (err) {
+      throw new TotemError(
+        'MAIL_SEND_FAILED',
+        `--body-file unreadable (${opts.bodyFile}): ${String(err)}`,
+        'check the --body-file path exists and is readable.',
+        err,
+      );
+    }
+  }
+
+  const header: DispatchHeader = {
+    schema: ADR098_SCHEMA,
+    from,
+    to,
+    timestamp: now.toISOString(),
+    subject,
+    expectedAction: opts.expectedAction?.trim() || 'none',
+    ...(opts.inReplyTo !== undefined ? { inReplyTo: opts.inReplyTo } : {}),
+    ...(opts.priority !== undefined ? { priority: opts.priority } : {}),
+    ...(opts.related !== undefined && opts.related.length > 0 ? { related: opts.related } : {}),
+  };
+
+  const warnings = validateDispatchContent(header, opts.knownAgents ?? knownCohortAgents());
+
+  const outboxDir = path.join(repoRoot, '.totem', 'orchestration', from, 'outbox');
+  fs.mkdirSync(outboxDir, { recursive: true });
+
+  const base = `${compactStamp(now)}-${to}-${slugify(subject, opts.slug)}`;
+  const filePath = uniqueOutboxPath(outboxDir, base);
+  const content = composeDispatch(header, body);
+
+  // Atomic write (ADR-106: temp + rename; readers never see a torn write).
+  const tmp = `${filePath}.tmp`;
+  try {
+    fs.writeFileSync(tmp, content, 'utf-8');
+    fs.renameSync(tmp, filePath);
+  } catch (err) {
+    // Actuation failure is fail-LOUD (Tenet 4): a write that did not land is a
+    // silent drop — the inverse of the inv6 content-warn case. Best-effort
+    // remove any partial temp first (force suppresses ENOENT; maxRetries/
+    // retryDelay guard a transient win32 lock), then surface the original
+    // error with the path so the sender knows nothing shipped.
+    fs.rmSync(tmp, { force: true, maxRetries: 3, retryDelay: 50 });
+    throw new TotemError(
+      'MAIL_SEND_FAILED',
+      `write failed (${filePath}): ${String(err)}`,
+      'check outbox directory permissions and available disk space.',
+      err,
+    );
+  }
+
+  return { filePath, fileName: path.basename(filePath), header, warnings };
+}
+
+/**
+ * `totem mail reply <source>` — syntactic sugar over `mailSend`. Reads the
+ * source dispatch (HARD error if missing/unparseable — reply structurally needs
+ * it to infer the recipient + subject), then sends with `to = source.from`,
+ * `subject = "Re: <source.subject>"`, and `in-reply-to = source path`. Any
+ * field can still be overridden via opts.
+ */
+export function mailReply(
+  source: string,
+  opts: Omit<MailSendOptions, 'to' | 'subject' | 'inReplyTo'> & {
+    to?: string;
+    subject?: string;
+  } = {},
+): MailSendResult {
+  let content: string;
+  try {
+    content = fs.readFileSync(source, 'utf-8');
+    // totem-context: reply cannot proceed without the source (it infers to/subject from it) — a missing/unreadable source is a hard usage error, rethrown clearly, not a degraded send.
+  } catch (err) {
+    throw new TotemError(
+      'MAIL_SEND_FAILED',
+      `cannot read reply source dispatch (${source}): ${String(err)}`,
+      'check the reply <source> path exists and is readable.',
+      err,
+    );
+  }
+  const parsed = parseHeader(content);
+  if (!parsed.ok) {
+    throw new TotemError(
+      'MAIL_SEND_FAILED',
+      `reply source is not parseable mail (${source}): ${parsed.reason}`,
+      'the source must be an ADR-098 dispatch with a frontmatter block; use `mail send --to` for a fresh dispatch.',
+    );
+  }
+  const replyTo = opts.to ?? parsed.header.from ?? '';
+  if (replyTo.trim().length === 0) {
+    throw new TotemError(
+      'MAIL_SEND_FAILED',
+      `reply source has no "from:" to reply to (${source})`,
+      'use `totem mail send --to <agent>` instead.',
+    );
+  }
+  const subject = opts.subject ?? `Re: ${parsed.header.subject ?? '(no subject)'}`;
+  return mailSend({ ...opts, to: replyTo, subject, inReplyTo: source });
+}
+
+/**
+ * CLI wrapper for `mail send` / `mail reply`. Surfaces content warnings LOUDLY
+ * on stderr at emit-time (inv6: the dispatch still wrote — this is the typo
+ * backstop, not a block), then confirms the written path.
+ */
+export async function mailSendCommand(result: MailSendResult): Promise<MailSendResult> {
+  const { log } = await import('../ui.js');
+  for (const w of result.warnings) log.warn(TAG, w);
+  log.success(TAG, `Dispatch written: ${path.relative(process.cwd(), result.filePath)}`);
+  log.info(
+    TAG,
+    `  to: ${result.header.to} · from: ${result.header.from} · ${result.header.timestamp}`,
+  );
   return result;
 }

--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -21,7 +21,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { knownCohortAgents, resolveSelfAgents, TotemError } from '@mmnto/totem';
+import { isPathSafeAgentId, knownCohortAgents, resolveSelfAgents, TotemError } from '@mmnto/totem';
 
 // ─── Constants ──────────────────────────────────────────
 
@@ -521,13 +521,6 @@ export async function mailCommand(opts: MailCommandOptions = {}): Promise<MailPo
 const ADR098_SCHEMA = 'adr-098-v0.4';
 
 /**
- * Path-traversal / empty guard for an agent-id used as an outbox directory
- * segment. Mirrors core's `AGENT_ID_TRAVERSAL_PATTERN` (not exported) so a
- * malicious or fat-fingered `--from` cannot escape `.totem/orchestration/`.
- */
-const AGENT_ID_UNSAFE = /[/\\\0]|\.\./;
-
-/**
  * Structurally-complete dispatch header. ADR-098 v0.4 compliance is enforced
  * *by construction*: you cannot build this object without `schema` / `from` /
  * `to` / `timestamp` / `subject` / `expectedAction`, so a structurally invalid
@@ -622,8 +615,11 @@ function yamlScalar(value: string): string {
 export function composeDispatch(header: DispatchHeader, body: string): string {
   const lines: string[] = ['---'];
   lines.push(`schema: ${header.schema}`);
-  lines.push(`from: ${header.from}`);
-  lines.push(`to: ${header.to}`);
+  // `from`/`to` are traversal-validated agent-ids, but YAML-quote them anyway
+  // (defense in depth) so a non-standard recipient can't inject frontmatter
+  // once the v0.4 derivation engine YAML-parses this (CodeRabbit, mmnto-ai/totem#2134).
+  lines.push(`from: ${yamlScalar(header.from)}`);
+  lines.push(`to: ${yamlScalar(header.to)}`);
   lines.push(`timestamp: ${header.timestamp}`);
   lines.push(`subject: ${yamlScalar(header.subject)}`);
   lines.push(`expected-action: ${yamlScalar(header.expectedAction)}`);
@@ -704,17 +700,30 @@ export function resolveSelfSender(
 }
 
 function assertSafeAgentId(id: string, label: string): void {
-  // totem-context: AGENT_ID_UNSAFE is a NON-global regex (no `g` flag), so
-  // `.test()` is stateless here — this is path-traversal sanitization on an
-  // agent-id used as a directory segment, NOT shell-command matching (the lint
-  // lesson's anchored-regex guidance targets command detection, not this).
-  if (id.length === 0 || AGENT_ID_UNSAFE.test(id)) {
+  // Reuse core's single traversal guard (`isPathSafeAgentId` →
+  // AGENT_ID_TRAVERSAL_PATTERN) rather than re-deriving the pattern — both the
+  // sender's `--from` (an outbox directory segment) and the recipient's `--to`
+  // (interpolated into the filename) must be blocked from `/`, `\`, `..`, or a
+  // null byte (Greptile P2 / GCA + CR path-traversal critical, mmnto-ai/totem#2134).
+  if (!isPathSafeAgentId(id)) {
     throw new TotemError(
       'MAIL_SEND_FAILED',
       `invalid --${label} "${id}" (path-traversal or empty)`,
       'pass a plain agent-id such as "totem-claude" (no path separators or "..").',
     );
   }
+}
+
+/**
+ * Reduce a recipient/agent token to a filename-safe form: a defense-in-depth
+ * layer on top of `assertSafeAgentId` (which already rejects traversal). Even a
+ * validated-but-odd `to` (e.g. a stray `:`/space — illegal in win32 filenames)
+ * cannot corrupt the outbox filename. Valid kebab agent-ids pass through
+ * unchanged; `broadcast` is preserved.
+ */
+function fileToken(value: string): string {
+  const cleaned = value.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+  return cleaned.length > 0 ? cleaned : 'recipient';
 }
 
 /**
@@ -780,6 +789,9 @@ export function mailSend(opts: MailSendOptions): MailSendResult {
       '--to <recipient> is required',
       'pass --to <recipient-agent-id> (or "broadcast").',
     );
+  // `to` is interpolated into the outbox filename + the frontmatter — block
+  // path-traversal here, same guard as `from` (GCA/Greptile/CR critical, mmnto-ai/totem#2134).
+  assertSafeAgentId(to, 'to');
   const subject = opts.subject.trim();
   if (subject.length === 0)
     throw new TotemError(
@@ -824,9 +836,21 @@ export function mailSend(opts: MailSendOptions): MailSendResult {
   const warnings = validateDispatchContent(header, opts.knownAgents ?? knownCohortAgents());
 
   const outboxDir = path.join(repoRoot, '.totem', 'orchestration', from, 'outbox');
-  fs.mkdirSync(outboxDir, { recursive: true });
+  try {
+    fs.mkdirSync(outboxDir, { recursive: true });
+    // totem-context: a failed outbox mkdir (EACCES, read-only FS, a file where
+    // the dir should be) means the dispatch cannot land — fail LOUD (Tenet 4)
+    // with the path, never proceed to a write that will also fail (GCA mmnto-ai/totem#2134).
+  } catch (err) {
+    throw new TotemError(
+      'MAIL_SEND_FAILED',
+      `could not create outbox directory (${outboxDir}): ${String(err)}`,
+      'check write permissions on the repo .totem/orchestration tree.',
+      err,
+    );
+  }
 
-  const base = `${compactStamp(now)}-${to}-${slugify(subject, opts.slug)}`;
+  const base = `${compactStamp(now)}-${fileToken(to)}-${slugify(subject, opts.slug)}`;
   const filePath = uniqueOutboxPath(outboxDir, base);
   const content = composeDispatch(header, body);
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -723,7 +723,10 @@ program
 
 // Canonical cross-repo outbox poll (mmnto-ai/totem#1970; ADR-106 § 3 / ADR-107).
 // Replaces ad-hoc per-hook implementations with one cohort-portable surface.
-program
+// `send`/`reply` subcommands (mmnto-ai/totem#2042) are the actuator half;
+// registering them also closes the silent fall-through trap — Commander now
+// rejects `totem mail <unknown>` instead of running the read as a no-op.
+const mailCmd = program
   .command('mail')
   .description('Show unread cross-repo mail addressed to this repo’s agent(s) (ADR-106 § 3)')
   .option('--json', 'Emit JSON to stdout instead of human-readable text to stderr')
@@ -755,6 +758,77 @@ program
         handleError(err);
         // totem-context: handleError returns `never` (process.exit), so the throw is unreachable but required to satisfy the Tenet 4 fail-loud rule that bans bare-catch silent-degrade. Mirrors the verify-badges pattern above.
         throw err;
+      }
+    },
+  );
+
+mailCmd
+  .command('send')
+  .description(
+    'Compose + write a validated ADR-098 v0.4 dispatch to your outbox (mmnto-ai/totem#2042)',
+  )
+  .requiredOption('--to <agent>', 'Recipient agent-id (or "broadcast")')
+  .requiredOption('--subject <text>', 'Subject line')
+  .option('--from <agent>', 'Sender agent-id (default: resolved self; required if ambiguous)')
+  .option('--body-file <path>', 'Read the dispatch body from this file')
+  .option('--in-reply-to <path>', 'Source dispatch path this replies to')
+  .option('--priority <level>', 'priority: frontmatter value')
+  .option('--related <refs...>', 'related-issues: frontmatter refs')
+  .option('--expected-action <text>', 'expected-action: frontmatter (default: none)')
+  .option('--slug <slug>', 'Filename slug override (default: derived from subject)')
+  .action(
+    async (opts: {
+      to: string;
+      subject: string;
+      from?: string;
+      bodyFile?: string;
+      inReplyTo?: string;
+      priority?: string;
+      related?: string[];
+      expectedAction?: string;
+      slug?: string;
+    }) => {
+      try {
+        const { mailSend, mailSendCommand } = await import('./commands/mail.js');
+        await mailSendCommand(mailSend(opts));
+        // totem-context: handleError is the CLI error boundary (returns `never` — prints + process.exit), identical to every sibling command action; nothing is swallowed.
+      } catch (err) {
+        handleError(err);
+      }
+    },
+  );
+
+mailCmd
+  .command('reply <source>')
+  .description(
+    'Reply to a dispatch — infers recipient + subject from the source (mmnto-ai/totem#2042)',
+  )
+  .option('--from <agent>', 'Sender agent-id (default: resolved self; required if ambiguous)')
+  .option('--body-file <path>', 'Read the reply body from this file')
+  .option('--subject <text>', 'Override the inferred "Re: …" subject')
+  .option('--to <agent>', 'Override the inferred recipient')
+  .option('--priority <level>', 'priority: frontmatter value')
+  .option('--related <refs...>', 'related-issues: frontmatter refs')
+  .option('--expected-action <text>', 'expected-action: frontmatter (default: none)')
+  .action(
+    async (
+      source: string,
+      opts: {
+        from?: string;
+        bodyFile?: string;
+        subject?: string;
+        to?: string;
+        priority?: string;
+        related?: string[];
+        expectedAction?: string;
+      },
+    ) => {
+      try {
+        const { mailReply, mailSendCommand } = await import('./commands/mail.js');
+        await mailSendCommand(mailReply(source, opts));
+        // totem-context: handleError is the CLI error boundary (returns `never` — prints + process.exit), identical to every sibling command action; nothing is swallowed.
+      } catch (err) {
+        handleError(err);
       }
     },
   );

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -39,7 +39,8 @@ export type TotemErrorCode =
   | 'BADGE_VERIFICATION_FAILED'
   | 'CLAIM_DISCIPLINE_FAILED'
   | 'GATE_INVALID'
-  | 'PARITY_DRIFT_DETECTED';
+  | 'PARITY_DRIFT_DETECTED'
+  | 'MAIL_SEND_FAILED';
 
 export class TotemError extends Error {
   readonly code: TotemErrorCode;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -563,7 +563,11 @@ export { resolveSubstratePaths } from './substrate-resolver.js';
 // Additive sibling to resolveSubstratePaths; substrate stays live as the
 // frozen-archive read path while orchestration is the active read+write surface.
 export type { OrchestrationPaths, SelfAgentResolution } from './orchestration-resolver.js';
-export { resolveOrchestrationPaths, resolveSelfAgents } from './orchestration-resolver.js';
+export {
+  knownCohortAgents,
+  resolveOrchestrationPaths,
+  resolveSelfAgents,
+} from './orchestration-resolver.js';
 
 // Parity-manifest parser + config-path resolver (mmnto-ai/totem-strategy#448)
 export type {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -564,6 +564,7 @@ export { resolveSubstratePaths } from './substrate-resolver.js';
 // frozen-archive read path while orchestration is the active read+write surface.
 export type { OrchestrationPaths, SelfAgentResolution } from './orchestration-resolver.js';
 export {
+  isPathSafeAgentId,
   knownCohortAgents,
   resolveOrchestrationPaths,
   resolveSelfAgents,

--- a/packages/core/src/orchestration-resolver.test.ts
+++ b/packages/core/src/orchestration-resolver.test.ts
@@ -376,6 +376,17 @@ describe('resolveSelfAgents — config.json host_agents override', () => {
     expect(result.agents).toEqual(['valid-agent']);
   });
 
+  it('drops control/whitespace/win32-reserved entries from host_agents (#2134 R3)', () => {
+    const totemRoot = mkDir(path.join(tmpRoot, 'totem'));
+    writeConfig(
+      totemRoot,
+      JSON.stringify({ host_agents: ['two words', 'a*b', 'a:b', 'valid-agent'] }),
+    );
+    const result = resolveSelfAgents(totemRoot, {});
+    expect(result.source).toBe('config');
+    expect(result.agents).toEqual(['valid-agent']);
+  });
+
   it('rejects mixed-type host_agents and falls through to basename map', () => {
     // Zod array schema is strict: any non-string entry fails the parse, so the
     // whole config is ignored. Stricter than silent per-entry filtering, but
@@ -432,6 +443,17 @@ describe('resolveSelfAgents — TOTEM_SELF_AGENT env var (highest precedence)', 
     });
     expect(result.source).toBe('env');
     expect(result.agents).toEqual(['real-agent']);
+  });
+
+  it('drops control/whitespace/win32-reserved entries from env var (#2134 R3)', () => {
+    // The read path enforces the same full path-segment contract as the mail
+    // actuator's recipient validation — not just the traversal subset.
+    const totemRoot = mkDir(path.join(tmpRoot, 'totem'));
+    const result = resolveSelfAgents(totemRoot, {
+      TOTEM_SELF_AGENT: 'two words,a:b,a*b,ok-agent',
+    });
+    expect(result.source).toBe('env');
+    expect(result.agents).toEqual(['ok-agent']);
   });
 
   it('falls through to config when env var is empty after sanitization', () => {

--- a/packages/core/src/orchestration-resolver.test.ts
+++ b/packages/core/src/orchestration-resolver.test.ts
@@ -16,6 +16,8 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
+  isPathSafeAgentId,
+  knownCohortAgents,
   type OrchestrationPaths,
   resolveOrchestrationPaths,
   resolveSelfAgents,
@@ -472,5 +474,53 @@ describe('resolveSelfAgents — path-normalization', () => {
     const result = resolveSelfAgents(totemRoot + path.sep, {});
     expect(result.source).toBe('map');
     expect(result.agents).toEqual(['totem-claude', 'totem-gemini']);
+  });
+});
+
+describe('isPathSafeAgentId — path-segment guard (mmnto-ai/totem#2134)', () => {
+  it('accepts plain cohort agent-ids', () => {
+    for (const id of ['totem-claude', 'strategy-claude', 'status-gemini', 'broadcast', 'a.b_c-1']) {
+      expect(isPathSafeAgentId(id)).toBe(true);
+    }
+  });
+
+  it('rejects traversal, separators, and null bytes', () => {
+    for (const id of ['', '..', '../evil', 'a/b', 'a\\b', 'a\0b']) {
+      expect(isPathSafeAgentId(id)).toBe(false);
+    }
+  });
+
+  it('rejects control, whitespace, and win32-reserved characters (CR R2)', () => {
+    // Control/escape chars are terminal-injection vectors into logs and
+    // dispatch markdown; `< > : " | ? *` are illegal in win32 filenames.
+    // ESC/DEL are built via fromCharCode so the source carries no raw
+    // control bytes.
+    const esc = String.fromCharCode(0x1b);
+    const del = String.fromCharCode(0x7f);
+    const unsafe = [
+      'a b',
+      'a\tb',
+      'a\nb',
+      `esc${esc}[31m`,
+      `del${del}`,
+      ...'<>:"|?*'.split('').map((c) => `a${c}b`),
+    ];
+    for (const id of unsafe) {
+      expect(isPathSafeAgentId(id)).toBe(false);
+    }
+  });
+});
+
+describe('knownCohortAgents — single-source recipient set', () => {
+  it('derives from the cohort map and every id passes the path-segment guard', () => {
+    const agents = knownCohortAgents();
+    expect(agents).toContain('totem-claude');
+    expect(agents).toContain('strategy-claude');
+    // Self-consistency lock: an id added to COHORT_AGENT_MAP that fails the
+    // guard would be unroutable by `totem mail send` — catch it here, not in
+    // a failed dispatch.
+    for (const id of agents) {
+      expect(isPathSafeAgentId(id)).toBe(true);
+    }
   });
 });

--- a/packages/core/src/orchestration-resolver.ts
+++ b/packages/core/src/orchestration-resolver.ts
@@ -166,6 +166,17 @@ export function knownCohortAgents(): string[] {
 }
 
 /**
+ * True iff `id` is safe to use as a `.totem/orchestration/<id>/…` path segment
+ * (or any filename token): a non-empty string with no path separators, null
+ * byte, or `..` traversal. The single source of truth for the traversal guard —
+ * consumers (e.g. `totem mail send`'s `--from`/`--to` validation) reuse this
+ * rather than re-deriving the pattern (Greptile P2 on mmnto-ai/totem#2134).
+ */
+export function isPathSafeAgentId(id: string): boolean {
+  return typeof id === 'string' && id.length > 0 && !AGENT_ID_TRAVERSAL_PATTERN.test(id);
+}
+
+/**
  * Zod schema for the optional `<repoRoot>/.totem/orchestration/config.json`
  * override file. Only `host_agents` is consumed by the resolver; the
  * `passthrough()` allows unrelated fields (downstream consumers may add

--- a/packages/core/src/orchestration-resolver.ts
+++ b/packages/core/src/orchestration-resolver.ts
@@ -153,6 +153,19 @@ const COHORT_AGENT_MAP: Readonly<Record<string, readonly string[]>> = Object.fre
 });
 
 /**
+ * Flattened set of all cohort agent-ids the basename map pre-knows, derived
+ * from `COHORT_AGENT_MAP` so there is exactly one source of truth (the very
+ * drift `totem mail send` exists to kill — a hardcoded recipient list in the
+ * actuator would re-introduce it). Consumed by the outbound mail validator
+ * (`mail send`) to flag an unknown recipient — a *content* warning, never a
+ * block (ADR-106 inv6 fail-open). `broadcast` is a valid recipient too, but
+ * it is a routing literal, not an agent, so callers handle it separately.
+ */
+export function knownCohortAgents(): string[] {
+  return Object.values(COHORT_AGENT_MAP).flat();
+}
+
+/**
  * Zod schema for the optional `<repoRoot>/.totem/orchestration/config.json`
  * override file. Only `host_agents` is consumed by the resolver; the
  * `passthrough()` allows unrelated fields (downstream consumers may add

--- a/packages/core/src/orchestration-resolver.ts
+++ b/packages/core/src/orchestration-resolver.ts
@@ -223,16 +223,16 @@ export interface SelfAgentResolution {
 
 /**
  * Parse a comma-separated `TOTEM_SELF_AGENT` value into a clean list.
- * Empty / whitespace-only entries dropped; path-traversal entries dropped.
+ * Empty / whitespace-only entries dropped; entries failing the full
+ * path-segment guard (traversal, control/whitespace/win32-reserved) dropped —
+ * the read path enforces the same contract as the mail actuator's recipient
+ * validation (CR R3 on mmnto-ai/totem#2134).
  */
 function parseEnvAgentList(raw: string): string[] {
-  return (
-    raw
-      .split(',')
-      .map((s) => s.trim())
-      // totem-context: AGENT_ID_TRAVERSAL_PATTERN is a non-global regex (no `g` flag), so `.test()` is stateless here; this is path-traversal sanitization, not shell-command identification.
-      .filter((s) => s.length > 0 && !AGENT_ID_TRAVERSAL_PATTERN.test(s))
-  );
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter(isPathSafeAgentId);
 }
 
 /**
@@ -247,9 +247,10 @@ function parseEnvAgentList(raw: string): string[] {
  *   3. Hardcoded `COHORT_AGENT_MAP` by `path.basename(repoRoot)`
  *   4. `{ agents: [], source: 'none' }`
  *
- * Path-traversal entries (`..`, `/`, `\`, null byte) are dropped at every
- * layer — same guard as `resolveOrchestrationPaths`. An empty list from a
- * higher-precedence layer falls through to the next (so a malformed env
+ * Entries failing `isPathSafeAgentId` (path traversal, null byte, control/
+ * whitespace/win32-reserved characters) are dropped at every layer — the
+ * same contract the mail actuator enforces on recipients. An empty list from
+ * a higher-precedence layer falls through to the next (so a malformed env
  * var doesn't shadow a valid config or map entry).
  *
  * Pure utility — no caching, no logging, no side effects other than a
@@ -280,10 +281,10 @@ export function resolveSelfAgents(
       const content = fs.readFileSync(configPath, 'utf-8');
       const parseResult = ConfigSchema.safeParse(JSON.parse(content));
       if (parseResult.success && parseResult.data.host_agents !== undefined) {
-        const agents = parseResult.data.host_agents
-          .filter((a) => a.length > 0)
-          // totem-context: AGENT_ID_TRAVERSAL_PATTERN is non-global (no `g` flag), so `.test()` is stateless here; this is path-traversal sanitization on repo-controlled config input, not shell-command identification.
-          .filter((a) => !AGENT_ID_TRAVERSAL_PATTERN.test(a));
+        // Same full path-segment guard as the env layer (CR R3 on
+        // mmnto-ai/totem#2134): traversal AND control/whitespace/win32-reserved
+        // entries dropped from repo-controlled config input too.
+        const agents = parseResult.data.host_agents.filter(isPathSafeAgentId);
         if (agents.length > 0) {
           return { agents, source: 'config' };
         }

--- a/packages/core/src/orchestration-resolver.ts
+++ b/packages/core/src/orchestration-resolver.ts
@@ -86,6 +86,17 @@ function isDirectory(p: string): boolean {
  */
 const AGENT_ID_TRAVERSAL_PATTERN = /[/\\\0]|\.\./;
 
+/**
+ * Characters that no cohort agent-id legitimately contains and that are unsafe
+ * in a filename token or a logged/rendered string: Unicode control characters
+ * (`\p{Cc}` — terminal-injection into CLI logs and dispatch markdown),
+ * whitespace, and the win32-reserved set `< > : " | ? *`. Complements
+ * `AGENT_ID_TRAVERSAL_PATTERN` (separators, null byte, `..`) so that
+ * `isPathSafeAgentId` is a full path-segment guard, not only a traversal
+ * guard (CR R2 on mmnto-ai/totem#2134).
+ */
+const AGENT_ID_UNSAFE_CHAR_PATTERN = /[\p{Cc}\s<>:"|?*]/u;
+
 export function resolveOrchestrationPaths(repoRoot: string, agentId: string): OrchestrationPaths {
   // Defense-in-depth: reject path-traversal patterns in `agentId` before
   // composing the base path. The hardcoded map in the /signoff skill is
@@ -168,12 +179,20 @@ export function knownCohortAgents(): string[] {
 /**
  * True iff `id` is safe to use as a `.totem/orchestration/<id>/…` path segment
  * (or any filename token): a non-empty string with no path separators, null
- * byte, or `..` traversal. The single source of truth for the traversal guard —
+ * byte, or `..` traversal, and no control/whitespace/win32-reserved characters
+ * (which would otherwise propagate into dispatch markdown, filenames, and CLI
+ * logs — terminal-injection class). The single source of truth for the guard —
  * consumers (e.g. `totem mail send`'s `--from`/`--to` validation) reuse this
- * rather than re-deriving the pattern (Greptile P2 on mmnto-ai/totem#2134).
+ * rather than re-deriving the pattern (Greptile P2 + CR R2 on
+ * mmnto-ai/totem#2134).
  */
 export function isPathSafeAgentId(id: string): boolean {
-  return typeof id === 'string' && id.length > 0 && !AGENT_ID_TRAVERSAL_PATTERN.test(id);
+  return (
+    typeof id === 'string' &&
+    id.length > 0 &&
+    !AGENT_ID_TRAVERSAL_PATTERN.test(id) &&
+    !AGENT_ID_UNSAFE_CHAR_PATTERN.test(id)
+  );
 }
 
 /**


### PR DESCRIPTION
## What

Adds the **actuator** half of the ADR-106 coordination triad (the sensor `totem mail` already shipped): `totem mail send` + `totem mail reply`. Before this, `totem mail send` silently fell through to the read command as a no-op, and every dispatch was hand-authored against five undocumented conventions — a discipline the protocol structurally could not satisfy (Tenet 13: sensor without actuator). Closes #2042.

## The 5 + 1 contract (the design spine)

The write-side validator realizes the gate contract from the moat-reframe falsification, with strategy-claude (ADR-098 owner) concurring 5/5 on the emit-shape:

- **Structural validity — by construction.** A `DispatchHeader` cannot be built without `schema` / `from` / `to` / `timestamp` / `subject` / `expected-action`, so a structurally-invalid dispatch is *unrepresentable*, not rejected after the fact — the strongest form of "enforce via substrate" (inv2 realized; inv6 doesn't even apply here).
- **Content validity — loud-warn-and-deliver (inv6 fail-open).** Predicates that can't be guaranteed at construction (recipient ∉ known cohort agents, empty refs) emit a **loud emit-time stderr warning** and write anyway. A blocked dispatch is worse than a malformed one — a typo'd recipient writing to the outbox under a wrong name is the exact silent-fail class (#2119).
- **Reader backstop — never-silent-drop.** `pollMail`'s scan-errors-always-warn (ADR-106 A1.2) is the third layer.
- **Hard-fail stays hard (Tenet 4):** usage errors (missing `--to`/`--subject`, ambiguous/unresolvable self, unreadable `--body-file`) and *actuation* failure (a write that didn't land) throw `TotemError`.

## Changes

- `totem mail send --to --subject [--from --body-file --in-reply-to --priority --related --expected-action --slug]` and `totem mail reply <source>` (infers recipient + `Re:` subject + `in-reply-to`).
- Emits **ADR-098 v0.4-compliant** frontmatter (`schema: adr-098-v0.4` / `timestamp:` RFC3339 / `expected-action:`) — totem is now the first v0.4-compliant emitter. Filename keeps the de-facto compact-minute stamp (colons are illegal on win32).
- `parseHeader` now reads `timestamp:` (v0.4 canonical) with `date:` backwards-compat fallback; `MailEntry.date` field name unchanged (no blast-radius rename — strategy folds the read-precedence into ADR-098's migration note on their side).
- Registering the subcommands closes the silent fall-through: `totem mail <unknown>` now hard-errors.
- `@mmnto/totem` exports `knownCohortAgents()` — single source of truth for the recipient set, derived from the cohort map (a hardcoded list would re-introduce the very drift this command fights).

## Out of scope (deferred)

`totem mail ack` + read-side mark-on-read / handled-state (ADR-106 A1.3 — separate lane).

## Tests

20 new tests (60 total in `mail.test.ts`, all green): sensor↔actuator round-trip, the fail-open headline (unknown recipient still written + warned), v0.4 emit shape, `timestamp:`/`date:` read precedence, ambiguous/unresolvable self, missing to/subject, unreadable body-file, same-minute collision disambiguation, path-traversal `--from`, reply inference, YAML-unsafe-subject quoting. Verified end-to-end through the built CLI (fall-through rejection + loud-warn-and-write). Design doc: `.totem/specs/2042.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
