### PR TITLE
chore(hooks): regenerate .gemini SessionStart from 1.56.0 canonical + exempt generated hooks from prettier

### DIFF
--- a/.gemini/hooks/SessionStart.js
+++ b/.gemini/hooks/SessionStart.js
@@ -1,16 +1,30 @@
 // [totem] auto-generated — Gemini CLI SessionStart hook
-// Runs `totem status` at the start of every Gemini CLI session.
+// Runs `totem describe` at the start of every Gemini CLI session to emit
+// the project-orientation banner ("[Describe] Project: ... Lessons: N
+// Targets: N Hooks: ..."). Matches the family-canonical pattern used by
+// totem-strategy, totem-substrate, arhgap11, and totem-status, and
+// matches the Claude-side SessionStart hook scaffolded by this same init
+// pass (mmnto-ai/totem#1884).
 const { execSync } = require('child_process');
 
 try {
-  execSync('node packages/cli/dist/index.js status', {
+  execSync('totem describe', {
     timeout: 30000,
     stdio: ['ignore', 'inherit', 'inherit'],
   });
 } catch (err) {
-  process.stderr.write(
-    '[Totem Error] Status unavailable: ' +
-      (err instanceof Error ? err.message : String(err)) +
-      '\n',
-  );
+  process.stdout.write('[Totem] Briefing unavailable: ' + (err instanceof Error ? err.message : String(err)) + '\n');
+}
+
+// totem orient --session — live derived in-flight state, ADDITIVE to describe
+// (mmnto-ai/totem#2044 PR-3). Own try/catch; orient --session is itself boot-safe.
+try {
+  execSync('totem orient --session', {
+    timeout: 30000,
+    stdio: ['ignore', 'inherit', 'inherit'],
+  });
+} catch (err) {
+  // Boot-safe: orient is additive to describe; a failure never blocks session start —
+  // surface a NON-fatal breadcrumb (matches the Claude-side hook) rather than swallow.
+  process.stderr.write('[SessionStart] orient briefing unavailable (non-fatal): ' + (err instanceof Error ? err.message : String(err)) + '\n');
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,4 +10,8 @@ pnpm-lock.yaml
 # Compiled rules hash must match compile-manifest.json — prettier would invalidate it
 .totem/compiled-rules.json
 .totem/compile-manifest.json
+# Distributed SessionStart hooks are generated verbatim from @mmnto/cli templates;
+# doctor --parity content-hashes them against the canonical — prettier rewrap reads as drift
+.claude/hooks/
+.gemini/hooks/
 cloc-results.json


### PR DESCRIPTION
## What

Two-file chore closing the last live `doctor --parity` WARN in this repo:

1. **`.gemini/hooks/SessionStart.js`** — regenerated verbatim from the running CLI''s `GEMINI_SESSION_START` canonical (1.56.0). The installed hook was stale: pre-#2044 shape (`totem status` only, no `totem orient --session`) plus an unmarked local tweak (invoking `node packages/cli/dist/index.js` instead of the global binary). No `totem:fork` marker was present, so per the parity contract the divergence is drift, not an attested fork — reconciled to canonical.
2. **`.prettierignore`** — added `.claude/hooks/` + `.gemini/hooks/`. This is load-bearing: the distributed hooks are content-hashed byte-wise (modulo line-ending/trailing-whitespace normalization) against the in-process canonical, and `pnpm run format` rewraps the template''s long line — which immediately re-reads as drift. Without the exemption the format gate and the parity sensor fight over the same file (verified live: post-format hash `2674718e5b85` vs canonical `9f6693764dba`). Same class as the existing `compiled-rules.json` exemption.

## Verification

- `totem doctor --parity`: 0 WARNs (was 1 after the git-hooks `--force` repair, 4 before)
- `pnpm run format:check`: clean
- `totem lint` (workspace build, 1.56.0): PASS — 8 warnings, 0 errors; warnings are against the canonical template''s own idioms (`execSync`, `String(err)`), cohort-canonical content not authored here

## Note for a possible follow-up

If the old hook''s workspace-build invocation (`node packages/cli/dist/index.js`) was intentional for this monorepo, the contract-conformant way to keep it is a `totem:fork` marker (renders as INFO, not WARN). Defaulting to canonical here since no marker existed.

Found during the live ship-truth pass for strategy Proposal 296 (sibling findings: #2137, #2138).

🤖 Generated with [Claude Code](https://claude.com/claude-code)