### PR TITLE
chore(freeze): consumer-local cohort freeze registry — rule-compilation stopgap (strategy#584)

### DIFF
--- a/.totem/freeze.json
+++ b/.totem/freeze.json
@@ -1,0 +1,17 @@
+{
+  "_note": "Consumer-local copy of the cohort-scoped freeze registry (stopgap per mmnto-ai/totem-strategy#584 — canonical lives in totem-strategy:.totem/freeze.json; this copy exists so the freeze is locally derivable by ANY seat in this repo, including memoryless ones, until #584's distribution half lands via @mmnto/strategy-doctrine + doctor/orient). The `frozen` entry below is verbatim from the canonical (do not edit here — divergent copies drift; Tenet 20). The existing freeze-check action gate and the gate engine read this file deterministically. Remove this file when #584 distribution ships, or when the freeze lifts post-spine. Gate-side reconciliation ruling (manifest-acknowledge WITHOUT the LLM rule-gen pass while frozen) is tracked at mmnto-ai/totem#2137.",
+  "frozen": [
+    {
+      "subsystem": "rule-compilation (legacy lesson-compile path)",
+      "since": "2026-05-17",
+      "scope": "cohort",
+      "reason": "Parked pending the Convergent Spine replacement. The legacy `totem lesson compile` path cannot recompile: safe-regex2's ReDoS gate rejects the lookbehind in the xrepo-qualify-refs lesson, and the upstream fix was declined (mmnto-ai/totem#1855 NOT_PLANNED, orphaned-by-ADR-103).",
+      "tracking": "Rule-compilation freeze (2026-05-17) — multi-gate lift status (GH Project board, orgs/mmnto-ai/projects/1)",
+      "do-not": [
+        "edit .totem/lessons/**",
+        "run `totem lesson compile`",
+        "hand-edit .totem/compiled-rules.json (Tenet 20 — it's a regenerable cache)"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Adds `.totem/freeze.json` with the cohort-scoped `rule-compilation` freeze entry, verbatim from the canonical (`totem-strategy:.totem/freeze.json`).

## Why now

Totem ships the freeze READERS (the `freeze-check` action gate + `readFreezeConfig` in core) but held no freeze file — so the cohort freeze was not locally derivable here. That gap bit #2127, and became urgent today: a memoryless seat (totem-codex) now operates in this repo with no standing memory of the freeze; its only protection was one line in an onboarding dispatch. Strategy flagged the totem-side stopgap as worth landing ahead of the spine schedule (ECL 2026-06-10T0708Z, ruling on [strategy#584](https://github.com/mmnto-ai/totem-strategy/issues/584)).

## Shape

- Entry is **verbatim** from the canonical — the `_note` marks this as a consumer copy (do not edit here; remove when strategy#584''s distribution half lands via `@mmnto/strategy-doctrine`, or when the freeze lifts post-spine).
- `scope: "cohort"` rides along for cross-repo shape consistency; today''s `FreezeConfigSchema` tolerates-and-strips it (the #584 totem-core reader will validate the enum at read time per the ruling on that issue).
- Validated through the real `readFreezeConfig` reader: parses OK, 1 frozen entry.
- Gate-side freeze-aware reconciliation (manifest-acknowledge without the LLM rule-gen pass while frozen) is tracked separately at #2137.

🤖 Generated with [Claude Code](https://claude.com/claude-code)