### PR TITLE
feat(doctor): 296 deliverable-1 doctor-side — promoted fields + capability-probe family + declared-floor rendering

### DIFF
--- a/.changeset/probe-family-2140.md
+++ b/.changeset/probe-family-2140.md
@@ -1,0 +1,11 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+---
+
+feat(doctor): 296 deliverable-1 doctor-side — promoted manifest fields + capability-probe detector family + declared-floor verdict rendering (#2140)
+
+- Parse the four promoted optional parity-manifest fields (`manifestation:`, `senses:`, `vendor-adapter:`, `repo-role-variance:`) into `ParityContract` — max-tolerance at the raw boundary (one mis-shaped or future value narrows per-row, never a manifest-wide outage), honest-absent mapping, `schema-version` unchanged.
+- New `detectCapabilityProbeContract` core detector + CLI probe registry routing `manifestation: capability-probe` rows: `knowledge-search-access` (`.mcp.json` registration, present rung) and `claude-settings-minimum-capability` (settings suppression sensing; absent file = pass). Verdicts carry the probed level; when a row declares a stronger `senses:` than the probe proves, the verdict caps at `unknown` (the green-halo guard).
+- The `semver.minVersion` fallback in version-pinned (and vendor-SDK attestation) verdicts now renders as a `declared`-level claim with the originating range — never reads as installed-level (296 §6(a)3 post-#605).
+- Bump `@mmnto/strategy-doctrine` to 0.1.5 (the promoted 26-contract manifest, the floor this build senses).

--- a/.totem/specs/2140.md
+++ b/.totem/specs/2140.md
@@ -1,0 +1,173 @@
+### Problem Statement
+
+The parity doctor must be updated to parse four newly promoted optional manifest fields (manifestation, senses, vendor-adapter, repo-role-variance) while keeping the schema version at 1. We must also implement a local, non-throwing `capability-probe` detector family for specific configuration capabilities, and adjust the version-pinned detector to accurately reflect when it is falling back to a "declared" version rather than an installed one.
+
+### Architectural Context
+
+- **Proposal 296 & Settlement #605/#606**: Defines the newly promoted fields and the `capability-probe` constraints.
+- **lesson-7d7f3d32 (Honest-Absent Mapping)**: Mandates that absent optional fields remain structurally absent in the AST. They must not be populated with synthetic defaults.
+- **Detector Constraints**: Probes must be deterministic, local-execution only (zero network IO), and must never throw.
+
+### Files to Examine
+
+1. `packages/core/src/parity-manifest.ts` — Requires `ParityContract` Zod schema and type updates.
+2. `packages/core/src/parity-detect.ts` — Target for the new `detectCapabilityProbeContract` and the fallback formatting update for `detectVersionPinnedContract`.
+3. `packages/cli/src/commands/doctor-parity.ts` — CLI routing logic requires updates to dispatch based on the `manifestation` field and assert sanity checks against strategy.
+
+### Technical Approach & Contracts
+
+**1. Schema Updates (`ParityContract`)**
+Update the Zod schema to include the additive fields without bumping `schema-version`.
+
+```typescript
+manifestation: z.enum(['correct-by-construction', 'managed-block', 'version-pin', 'attestation', 'capability-probe']).optional(),
+senses: z.enum(['declared', 'present', 'loaded', 'usable']).optional(),
+'vendor-adapter': z.string().optional(),
+'repo-role-variance': z.string().optional()
+```
+
+**2. Probe Implementation**
+Implement `detectCapabilityProbeContract(contract, cwd)` returning a standard `Verdict` (`pass`, `warn`, `skip`, `unknown`).
+
+- Switch on `contract.id`.
+- For `knowledge-search-access` / `claude-settings-minimum-capability`: Perform local configuration or file existence checks.
+- If execution is required, **must** use the shared `safeExec` helper with a strict timeout.
+- Wrap all FS or execution logic in `try/catch` to guarantee it never throws.
+
+**3. Declared-Floor Verdict**
+Modify `detectVersionPinnedContract`. Identify the execution path where no resolved install is found and it falls back to `semver.minVersion(declaredRange)`. The resulting message must be explicitly prefixed/formatted as `declared: <version>` rather than just `<version>`, preventing false positives where the user believes the version is installed.
+
+**4. CLI Routing & Sanity Checks**
+Update `checkParity`. Before routing by `contract.id`, check `contract.manifestation`.
+
+- If `capability-probe`, route to `detectCapabilityProbeContract`.
+- Implement build-time sanity checks (e.g., if `id === 'pnpm-engine-version'`, assert `senses === 'declared'`). Flag contradictions to strategy via a console warning or Totem diagnostic, do not silently diverge or mutate the AST.
+
+### Edge Cases & Traps
+
+- **Zod Default Trap**: Applying `.default()` to the new Zod fields violates `lesson-7d7f3d32`. Use `.optional()` only.
+- **Network Probes**: Any probe that inadvertently triggers a network request (e.g., triggering a lazy install or update check via CLI tools) violates strict constraints. Use `--offline` flags or equivalent if probing via `safeExec`.
+- **Honest-Absent Routing**: Older contracts or existing manifests will lack `manifestation`. The CLI router must gracefully fall back to existing id-based heuristic routing if `manifestation` is `undefined`.
+- **Semver Min-Version Failures**: `semver.minVersion` can return `null` if the declared range is malformed or purely abstract. The declared-floor fallback must handle `null` safely (e.g., falling back to `unknown` or `warn` instead of crashing).
+
+### Implementation Tasks
+
+- [ ] **Task 1: Implement Promoted Schema Fields**
+  - Modify `packages/core/src/parity-manifest.ts`. Add `manifestation`, `senses`, `vendor-adapter`, and `repo-role-variance` to the `ParityContract` schema.
+  - Modify `packages/core/test/parity-manifest.test.ts` to cover the new fields.
+    > TOTEM INVARIANT (Honest-Absent Mapping): Ensure missing fields parse to `undefined` without injecting default keys. Use `.optional()` without `.default()`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `respects honest-absent mapping for promoted optional fields` that proves omitted fields are not populated with default string values in the parsed result.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Implement Capability Probe Detector**
+  - Modify `packages/core/src/parity-detect.ts`. Create `detectCapabilityProbeContract`.
+  - Add strict local-exec checks for `knowledge-search-access` and `claude-settings-minimum-capability`. Use `safeExec` if CLI invocation is needed.
+  - Modify `packages/core/test/parity-detect.test.ts`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `capability probe gracefully handles and warns on execution exceptions` that mocks a throwing `fs` or `safeExec` call and asserts it returns a `warn` or `unknown` verdict rather than throwing.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Enforce Declared-Floor Verdict Format**
+  - Modify `detectVersionPinnedContract` in `packages/core/src/parity-detect.ts`.
+  - When returning `semver.minVersion(declaredRange)` as a fallback, format the verdict message to explicitly include the word `declared:` (e.g., `declared: ^1.2.0`).
+  - Modify `packages/core/test/parity-detect.test.ts`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `formats version fallback message with declared floor prefix` to prove that uninstalled targets render the `declared:` prefix.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: CLI Routing and Strategy Sanity Checks**
+  - Modify `checkParity` in `packages/cli/src/commands/doctor-parity.ts`.
+  - Route contracts with `manifestation === 'capability-probe'` to the new detector.
+  - Add sanity check logic to flag (warn) if `pnpm-engine-version` does not have `senses: declared` or if `ecl-conventions` is not `manifestation: correct-by-construction`.
+  - Modify `packages/cli/test/doctor-parity.test.ts`.
+  - write test → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+1. **Schema Integrity:** Provide a payload with all 4 new fields; verify exact extraction. Provide a payload missing all 4 fields; verify `schema-version` is 1 and the 4 fields are strictly `undefined`.
+2. **Capability Constraints:** Force an invalid/missing path for the capability targets; assert the detector returns `skip` or `warn` instead of crashing the doctor run.
+3. **Verdict Fallback Format:** Run a version-pin test against a non-existent package with a range `>=2.0.0`; assert the output string contains `declared:`.
+4. **Sanity Check Logging:** Feed a synthetic contract for `pnpm-engine-version` mapped to `senses: loaded`; assert the CLI outputs a strategy contradiction warning.
+
+## Implementation Design
+
+### Scope
+
+Parse the four promoted optional manifest fields into `ParityContract`, add a `detectCapabilityProbeContract` core detector + CLI probe registry routing `manifestation: capability-probe` rows (both deliverable-1 rows), and split the version-resolution helper so the minVersion fallback renders as a `declared`-level claim. This will NOT: bump `schema-version`; implement hardcoded per-id classification sanity-asserts in the CLI (deviation from the generated spec — that's a Tenet-20 mirror of strategy's classification that would drift; the sanity check is performed as build-time review instead, results recorded in the PR); implement the `usable`-rung live-search exec for `knowledge-search-access` (see Open Questions); touch any other stub contract.
+
+### Data model deltas
+
+- **`ParityContract` gains 4 optional fields** (core, `parity-manifest.ts`): `manifestation?: string`, `senses?: string`, `vendorAdapter?: string[]`, `repoRoleVariance?: string`. Written by `mapContract` (parse boundary only), read by CLI routing (`manifestation`) and verdict messages (`senses`). Invariant: absent stays structurally absent (lesson-7d7f3d32, no `.default()`).
+- **Validation posture — deliberately NOT closed enums.** Raw-schema fields are max-tolerance (`z.unknown().optional()`), narrowed in `mapContract`: string-typed fields keep string values; `vendor-adapter` accepts `string[]` or single `string` (normalized to array); any other shape → field treated as absent. Rationale: a closed enum on a new field re-creates the manifest-wide total-outage trap this round was settled around (one future rung value → all 26 contracts dark) — same precedent as the deliberately-unvalidated `last-attested`. Recognized values are exported as const tuples (`PARITY_MANIFESTATIONS`, `PARITY_SENSES`) for routing narrowing; an unrecognized `manifestation` value routes to the existing stub path WITH the verbatim value in the line (fail-loud per row, never per manifest).
+- **`CapabilityProbe` descriptor** (CLI-side registry → core detector context): `{ kind: 'settings-floor' | 'mcp-registration', path, lineName, ... }` + injectable `readFile` seam, mirroring the existing `MechanicalArtifact`/`GeneratedArtifact` split (core = pure verdict logic, CLI = wiring).
+- **`resolveInstalledVersion` return splits** to `{ version, source: 'installed' | 'declared-min' } | undefined`. Read by both `detectVersionPinnedContract` and `detectManualAttestationContract` message builders. No reserved keys or sentinels anywhere.
+
+### State lifecycle
+
+None. All detectors stay pure, side-effect-free, read-from-scratch per call (existing invariant). The probe registry is a pure function of `(contractId, gitRoot)`. No new module state, caches, or flags.
+
+### Failure modes
+
+| Failure                                                                                                | Category        | Agent-facing surface                                                                  | Recovery                       |
+| ------------------------------------------------------------------------------------------------------ | --------------- | ------------------------------------------------------------------------------------- | ------------------------------ |
+| `.claude/settings.json` absent                                                                         | runtime         | `pass` (contract: floor is "not suppressed", absent = pass)                           | n/a — by design                |
+| `.claude/settings.json` unreadable/unparseable JSON                                                    | runtime         | `unknown` + remediation (can prove neither suppression nor floor; never self-certify) | fix the JSON, re-run           |
+| settings explicitly suppress floor (`disableAllHooks: true`, totem server in `disabledMcpjsonServers`) | runtime         | `warn` + remediation naming the key                                                   | remove the suppression         |
+| `.mcp.json` absent (knowledge-search-access present rung)                                              | runtime         | `warn` — no registered query path (the row's whole point)                             | `totem init` / register server |
+| `.mcp.json` present, no totem server entry                                                             | runtime         | `warn`                                                                                | register server                |
+| `.mcp.json` unparseable                                                                                | runtime         | `unknown`                                                                             | fix JSON                       |
+| unrecognized `manifestation` value on a row                                                            | init (manifest) | per-row stub line carrying the verbatim value — loud, never manifest-wide             | strategy fixes the row         |
+| mis-shaped promoted field (e.g. numeric senses)                                                        | init (manifest) | field narrowed to absent; row still senses under existing routing                     | strategy fixes the row         |
+| minVersion fallback fires (no installed copy)                                                          | runtime         | verdict message renders `declared`-level claim explicitly (the settled constraint)    | install deps                   |
+| probe row in repo where `consumers` excludes it                                                        | runtime         | `skip` cohort-permits-absence (shared guard)                                          | n/a                            |
+
+No silent-degradation rows. The mis-shaped-field narrowing is render/routing metadata only (never a verdict input), same claim-class as `last-attested`.
+
+### Invariants to lock in via tests
+
+- A manifest omitting all four fields parses with the four keys structurally absent (no `undefined`-valued keys, no defaults).
+- A manifest with an unknown `manifestation` value (e.g. `quantum-entanglement`) still parses ALL contracts; that row renders a stub line containing the verbatim value.
+- `vendor-adapter` as YAML list parses to `string[]`; as bare string normalizes to one-element array; as number narrows to absent without failing the manifest.
+- `claude-settings-minimum-capability`: absent settings file → `pass`; `disableAllHooks: true` → `warn`; totem server in `disabledMcpjsonServers` → `warn`; unparseable JSON → `unknown`; detector never throws on any input.
+- `knowledge-search-access`: `.mcp.json` with a totem MCP server entry → `pass` at the probed (present) level, message states the probed level explicitly (NOT a usable-level claim — the §6(a)3 scoping); absent/unregistered → `warn`.
+- Version-pinned pass AND warn verdicts distinguish resolved-install from minVersion-fallback in the message; the fallback path renders `declared` and never reads as installed-level. Same for the manual-attestation `installed X` text.
+- Probe verdicts are `pass|warn|skip|unknown` only — never `fail` (CLI edge owns promotion), never `info`.
+- Routing precedence: `manifestation: capability-probe` is checked before tractability dispatch; a capability-probe row with no registered probe gets an honest "probe not yet implemented" skip stub.
+- Fielded-doctor regression: the promoted 26-contract manifest loads with zero behavior change for all 24 existing rows (the CR cross-repo claim, now locked locally).
+
+### Review fold (totem-codex 0701Z spec review — all findings adopted)
+
+- **W1 confirmed:** the generated scaffold's top half (closed enums, `vendor-adapter: z.string()`) is superseded — this Implementation Design section is authoritative. `z.string()` would reject the live `vendor-adapter: [claude]` list outright.
+- **W2 confirmed:** no runtime per-id classification asserts (Tenet-20 mirror); build-time review only.
+- **W3 adopted — the green-halo cap, generalized:** a presence-only probe must never render an ordinary PASS on a row that declares `senses: usable`. Each probe descriptor carries its `probedLevel`; the detector compares against the row's declared `senses:` — **when probedLevel < declared, the verdict is capped at `unknown`** ("manifest declares usable; this probe proves present only — usable unprovable under the §12.5 no-network constraint"), never `pass`. A failed present rung is still `warn` (if present fails, usable certainly fails — provable drift). This is a generic guard derived from the descriptor, not row-specific hardcoding; when strategy downshifts the row's `senses:` (or a no-network usable probe becomes possible), the same probe renders `pass` with no code change.
+- **I1 adopted:** the declared-min fallback message carries the originating range (`declared-min 1.53.0 from range ^1.53.0`), both call sites.
+- **I2 adopted:** tests are co-located (`packages/core/src/*.test.ts`, `packages/cli/src/commands/*.test.ts`) — no new test roots.
+
+### Open questions
+
+- **Question (RESOLVED via codex W3 — pending user approval):** `knowledge-search-access` declares `senses: usable` but the usable-rung exec networks (query embedding via Gemini API), contradicting §12.5's never-network constraint.
+  - **Settled shape:** ship the present rung; verdict capped at `unknown` while probedLevel < declared (see Review fold); dispatch the rung contradiction + row-downshift question (`senses: usable` → `present` until a no-network usable probe exists) to strategy after the build.
+- **Question:** Apply the declared-level rendering to the manual-attestation vendor-SDK `info` path too (it shares `resolveInstalledVersion`)?
+  - **Options:** yes (one shared helper, consistent honesty) / no (strictly only the ruled version-pinned surface).
+  - **Recommendation:** Yes — same fallback, same honesty gap, one helper.
+- **Question:** For the settings floor probe, which totem MCP server name(s) count? Hardcode known names vs derive from `.mcp.json` entries.
+  - **Options:** derive (suppression check = any `.mcp.json` server whose command references totem, cross-checked against `disabledMcpjsonServers`) / hardcode `totem-dev` etc. (a mirror).
+  - **Recommendation:** Derive from `.mcp.json`; with no `.mcp.json`, the MCP half is vacuous (nothing to suppress) and only the hooks half applies.

--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "typescript-eslint": "^8.59.4"
   },
   "optionalDependencies": {
-    "@mmnto/strategy-doctrine": "0.1.4"
+    "@mmnto/strategy-doctrine": "0.1.5"
   }
 }

--- a/packages/cli/src/commands/doctor-parity.test.ts
+++ b/packages/cli/src/commands/doctor-parity.test.ts
@@ -883,3 +883,117 @@ describe('doctorParityCliCommand — onlyWhenConfigured fold (#2085)', () => {
     }
   });
 });
+
+// === Capability-probe routing (mmnto-ai/totem#2140) ===
+
+const PROBE_MANIFEST_YAML = `schema-version: 1
+status: active
+contracts:
+  - id: knowledge-search-access
+    dimension: knowledge-index
+    canonical-source: null
+    detection-method: capability probe, two rungs
+    expected-value-or-derivation: at least one working query path per agent surface
+    tractability: mechanical
+    manifestation: capability-probe
+    senses: usable
+    vendor-adapter: [claude]
+    tracking-issue: mmnto-ai/totem#2140
+  - id: claude-settings-minimum-capability
+    dimension: vendor-agent-surface
+    canonical-source: null
+    detection-method: JSON file-read of .claude/settings.json
+    expected-value-or-derivation: governance floor capabilities enabled-or-unsuppressed
+    tractability: mechanical
+    manifestation: capability-probe
+    senses: present
+    vendor-adapter: [claude]
+    tracking-issue: mmnto-ai/totem#2140
+`;
+
+describe('checkParity - capability-probe routing (mmnto-ai/totem#2140)', () => {
+  it('routes manifestation: capability-probe BEFORE tractability (mechanical rows do not stub)', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: parity-manifest.yaml\n`);
+    writeManifest('parity-manifest.yaml', PROBE_MANIFEST_YAML);
+    const { results } = await checkParity(tmpDir);
+    const probeLines = results.filter(
+      (r) =>
+        r.name.includes('knowledge-search-access') ||
+        r.name.includes('claude-settings-minimum-capability'),
+    );
+    expect(probeLines).toHaveLength(2);
+    for (const line of probeLines) {
+      expect(line.message).not.toContain('not yet implemented');
+    }
+  });
+
+  it('knowledge-search-access with a registered totem server caps at UNKNOWN (declares usable, probe proves present)', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: parity-manifest.yaml\n`);
+    writeManifest('parity-manifest.yaml', PROBE_MANIFEST_YAML);
+    fs.writeFileSync(
+      path.join(tmpDir, '.mcp.json'),
+      JSON.stringify({ mcpServers: { 'totem-dev': { command: 'node', args: ['mcp.js'] } } }),
+      'utf-8',
+    );
+    const { results } = await checkParity(tmpDir);
+    const line = results.find((r) => r.name.includes('knowledge-search-access'))!;
+    expect(line.status).toBe('unknown');
+    expect(line.message).toMatch(/usable/i);
+  });
+
+  it('knowledge-search-access WARNs when no .mcp.json exists', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: parity-manifest.yaml\n`);
+    writeManifest('parity-manifest.yaml', PROBE_MANIFEST_YAML);
+    const { results } = await checkParity(tmpDir);
+    const line = results.find((r) => r.name.includes('knowledge-search-access'))!;
+    expect(line.status).toBe('warn');
+  });
+
+  it('claude-settings-minimum-capability PASSes with no settings file (floor = not suppressed)', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: parity-manifest.yaml\n`);
+    writeManifest('parity-manifest.yaml', PROBE_MANIFEST_YAML);
+    const { results } = await checkParity(tmpDir);
+    const line = results.find((r) => r.name.includes('claude-settings-minimum-capability'))!;
+    expect(line.status).toBe('pass');
+    expect(line.message).toContain('present'); // names the probed level
+  });
+
+  it('a capability-probe row with no registered probe gets an honest skip stub', async () => {
+    const unknownRow = PROBE_MANIFEST_YAML.replace(
+      'id: knowledge-search-access',
+      'id: some-future-probe-row',
+    );
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: parity-manifest.yaml\n`);
+    writeManifest('parity-manifest.yaml', unknownRow);
+    const { results } = await checkParity(tmpDir);
+    const line = results.find((r) => r.name.includes('some-future-probe-row'))!;
+    expect(line.status).toBe('skip');
+    expect(line.message).toMatch(/probe not yet implemented|not yet implemented/i);
+  });
+
+  it('an UNRECOGNIZED manifestation value renders a loud per-row stub carrying the verbatim value', async () => {
+    const future = PROBE_MANIFEST_YAML.replace(
+      'manifestation: capability-probe\n    senses: usable',
+      'manifestation: quantum-entanglement\n    senses: usable',
+    );
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: parity-manifest.yaml\n`);
+    writeManifest('parity-manifest.yaml', future);
+    const { results } = await checkParity(tmpDir);
+    const line = results.find((r) => r.name.includes('knowledge-search-access'))!;
+    expect(line.status).toBe('skip');
+    expect(line.message).toContain('quantum-entanglement');
+  });
+
+  it('honors the consumers scope on probe rows (cohort permits absence)', async () => {
+    const scoped = PROBE_MANIFEST_YAML.replace(
+      'id: knowledge-search-access',
+      'id: knowledge-search-access\n    consumers: [some-other-repo]',
+    );
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: parity-manifest.yaml\n`);
+    writeManifest('parity-manifest.yaml', scoped);
+    const { results } = await checkParity(tmpDir);
+    const line = results.find((r) => r.name.includes('knowledge-search-access'))!;
+    expect(line.status).toBe('skip');
+    expect(line.message).toMatch(/permits absence|not in consumers/i);
+  });
+});

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -272,6 +272,60 @@ function sessionStartArtifactsFor(
   ];
 }
 
+// ─── Capability-probe registry (CLI-side, mmnto-ai/totem#2140) ──
+
+/**
+ * One probe a `manifestation: capability-probe` contract maps to: the core
+ * detector context minus the per-row `declaredSenses` (threaded at the call
+ * site from the contract), plus the display name. Mirrors the mechanical /
+ * generated-artifact registries: CLI owns the wiring, core owns the verdict.
+ */
+interface CapabilityProbeArtifact {
+  kind: 'mcp-registration' | 'settings-floor';
+  consumerPath: string;
+  mcpJsonPath?: string;
+  probedLevel: 'declared' | 'present' | 'loaded' | 'usable';
+  lineName: string;
+}
+
+/**
+ * Resolve the probe(s) a capability-probe contract runs, or `undefined` when
+ * this build ships no probe for the row (→ honest skip stub). Both deliverable-1
+ * probes are PRESENT-rung by design: `knowledge-search-access`'s usable rung (a
+ * live bounded search exec) is deliberately NOT shipped — real `totem search`
+ * embeds the query via a cloud API, which a 296 §12.5 never-network probe cannot
+ * run; the core detector caps the verdict at `unknown` accordingly (the
+ * green-halo cap) and the rung contradiction is flagged to strategy.
+ */
+function capabilityProbesFor(
+  contractId: string,
+  gitRoot: string,
+): CapabilityProbeArtifact[] | undefined {
+  switch (contractId) {
+    case 'knowledge-search-access':
+      return [
+        {
+          kind: 'mcp-registration',
+          consumerPath: path.join(gitRoot, '.mcp.json'),
+          probedLevel: 'present',
+          lineName: 'Parity: knowledge-search-access',
+        },
+      ];
+    case 'claude-settings-minimum-capability':
+      return [
+        {
+          kind: 'settings-floor',
+          consumerPath: path.join(gitRoot, '.claude', 'settings.json'),
+          mcpJsonPath: path.join(gitRoot, '.mcp.json'),
+          probedLevel: 'present',
+          lineName: 'Parity: claude-settings-minimum-capability',
+        },
+      ];
+    default:
+      return undefined;
+  }
+}
+
 /**
  * Resolve the running `@mmnto/cli`'s version + install path for the req-#5
  * binary self-report (the Stale-Doctor-Paradox guard — surface WHICH binary
@@ -315,6 +369,7 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
   const { loadConfig, resolveConfigPath, isGlobalConfigPath } = await import('../utils.js');
   const {
     deriveCohortRepoId,
+    detectCapabilityProbeContract,
     detectGeneratedArtifactContract,
     detectManualAttestationContract,
     detectMechanicalContract,
@@ -322,6 +377,7 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
     extractManagedBlock,
     loadParityManifest,
     packageNameForContract,
+    PARITY_MANIFESTATIONS,
     resolveGitRoot,
     SUPPORTED_PARITY_SCHEMA_VERSION,
   } = await import('@mmnto/totem');
@@ -493,10 +549,79 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
       const fallbackCmd = getFallbackCommand(gitRoot);
 
       const blockingDriftIds: string[] = [];
+      // The consumers-scope guard shared by the routing branches that don't
+      // self-guard in core (mechanical + capability-probe): a scoped contract
+      // must not emit drift in a repo that is not an intended consumer.
+      const consumersSkip = (c: ParityContract): ParityLine[] | undefined => {
+        if (c.consumers === undefined) return undefined;
+        if (repoId === undefined) {
+          return [
+            lineFor(`Parity: ${c.id}`, {
+              status: 'skip',
+              message: `cannot determine applicability — repo id unresolvable; contract is scoped to consumers [${c.consumers.join(', ')}]`,
+            }),
+          ];
+        }
+        if (!c.consumers.includes(repoId)) {
+          return [
+            lineFor(`Parity: ${c.id}`, {
+              status: 'skip',
+              message: `cohort permits absence here (${repoId} not in consumers)`,
+            }),
+          ];
+        }
+        return undefined;
+      };
+
       // flatMap, not map: a mechanical contract (claude-skills) expands to one
       // line PER distributed skill, so the per-contract count can exceed the
       // contract count.
       const perContract: ParityLine[] = contracts.flatMap((c) => {
+        // ── manifestation routing (promoted field, mmnto-ai/totem#2140) ──
+        // capability-probe rows route BEFORE the tractability dispatch: both
+        // deliverable-1 rows are `tractability: mechanical` (Green-decidable)
+        // but sense via probes, not artifact content-equality. Recognized
+        // NON-probe rungs (managed-block, version-pin, …) are informational —
+        // they fall through to the existing tractability routing unchanged.
+        if (c.manifestation === 'capability-probe') {
+          const scopeSkip = consumersSkip(c);
+          if (scopeSkip !== undefined) return scopeSkip;
+          const probes = capabilityProbesFor(c.id, gitRoot);
+          if (probes === undefined) {
+            return [
+              stub(c, `${c.dimension} (capability-probe) — probe not yet implemented for this row`),
+            ];
+          }
+          let blockingDrift = false;
+          const lines = probes.map((p) => {
+            const verdict = detectCapabilityProbeContract({
+              kind: p.kind,
+              consumerPath: p.consumerPath,
+              probedLevel: p.probedLevel,
+              ...(p.mcpJsonPath !== undefined ? { mcpJsonPath: p.mcpJsonPath } : {}),
+              ...(c.senses !== undefined ? { declaredSenses: c.senses } : {}),
+            });
+            if (verdict.status === 'warn' && c.blocking === true) blockingDrift = true;
+            return lineFor(p.lineName, verdict);
+          });
+          if (blockingDrift) blockingDriftIds.push(c.id);
+          return lines;
+        }
+        if (
+          c.manifestation !== undefined &&
+          !(PARITY_MANIFESTATIONS as readonly string[]).includes(c.manifestation)
+        ) {
+          // Fail-loud PER ROW, never per manifest (the total-outage guard): an
+          // unrecognized rung value surfaces verbatim instead of darking the
+          // sensor or silently mis-routing.
+          return [
+            stub(
+              c,
+              `manifestation '${c.manifestation}' unrecognized by this doctor — drift detection not yet implemented`,
+            ),
+          ];
+        }
+
         // ── version-pinned deps (PR-1) ──
         if (c.tractability === 'version-pinned') {
           const packageName = packageNameForContract(c, gitRoot);
@@ -516,24 +641,8 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
           // detectVersionPinnedContract, which self-guards). A scoped mechanical
           // contract must not emit drift — or, under --strict, fail — in a repo that
           // is not an intended consumer (CodeRabbit review on mmnto-ai/totem#2079).
-          if (c.consumers !== undefined) {
-            if (repoId === undefined) {
-              return [
-                lineFor(`Parity: ${c.id}`, {
-                  status: 'skip',
-                  message: `cannot determine applicability — repo id unresolvable; contract is scoped to consumers [${c.consumers.join(', ')}]`,
-                }),
-              ];
-            }
-            if (!c.consumers.includes(repoId)) {
-              return [
-                lineFor(`Parity: ${c.id}`, {
-                  status: 'skip',
-                  message: `cohort permits absence here (${repoId} not in consumers)`,
-                }),
-              ];
-            }
-          }
+          const scopeSkip = consumersSkip(c);
+          if (scopeSkip !== undefined) return scopeSkip;
 
           // Generated-artifact contracts (whole-file / region content-equality): the git
           // hooks (regenerated per-repo for this package manager + tier — catches the

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -574,13 +574,17 @@ export {
 export type {
   ParityContract,
   ParityManifest,
+  ParityManifestation,
   ParityManifestLoadResult,
   ParityManifestParseResult,
   ParityManifestPathStatus,
+  ParitySense,
   ParityTractability,
 } from './parity-manifest.js';
 export {
   loadParityManifest,
+  PARITY_MANIFESTATIONS,
+  PARITY_SENSES,
   ParityTractabilitySchema,
   parseParityManifest,
   resolveParityManifestPath,
@@ -590,8 +594,10 @@ export {
 // Version-pinned parity drift detector (PR-1, mmnto-ai/totem#2069)
 // + mechanical content-equality detector (mmnto-ai/totem#2073 skills slice)
 export type {
+  CapabilityProbeKind,
   CohortFloorStatus,
   DeriveCohortRepoIdOptions,
+  DetectCapabilityProbeContext,
   DetectGeneratedArtifactContext,
   DetectManualAttestationContext,
   DetectMechanicalContext,
@@ -603,6 +609,7 @@ export type {
 } from './parity-detect.js';
 export {
   deriveCohortRepoId,
+  detectCapabilityProbeContract,
   detectGeneratedArtifactContract,
   detectManualAttestationContract,
   detectMechanicalContract,

--- a/packages/core/src/parity-detect.test.ts
+++ b/packages/core/src/parity-detect.test.ts
@@ -1174,6 +1174,55 @@ describe('detectCapabilityProbeContract — mcp-registration probe', () => {
     expect(v.status).toBe('unknown');
   });
 
+  it('WARN (no crash, no index-keyed names) when mcpServers is a malformed ARRAY', () => {
+    // GCA high on the #2140 PR: an array satisfies `typeof === 'object'` and
+    // Object.entries over it would derive index-keyed "names" ('0', '1').
+    const abs = writeJson(tmpRoot, '.mcp.json', {
+      mcpServers: [{ command: 'totem', args: ['mcp'] }],
+    });
+    const v = detectCapabilityProbeContract({
+      kind: 'mcp-registration',
+      consumerPath: abs,
+      probedLevel: 'present',
+    });
+    expect(v.status).toBe('warn');
+    expect(v.message).not.toContain('[0]');
+  });
+
+  it('does NOT match a non-totem server whose command path merely contains "totem"', () => {
+    // Greptile P2 on the #2140 PR: a path segment like /home/totem-projects/
+    // must not classify an unrelated server as a totem server.
+    const abs = writeJson(tmpRoot, '.mcp.json', {
+      mcpServers: {
+        'other-mcp': { command: '/home/totem-projects/other-mcp/run.sh', args: ['--serve'] },
+      },
+    });
+    const v = detectCapabilityProbeContract({
+      kind: 'mcp-registration',
+      consumerPath: abs,
+      probedLevel: 'present',
+    });
+    expect(v.status).toBe('warn'); // not recognized as totem → no registered query path
+  });
+
+  it('DOES match a totem server by command basename or @mmnto arg (derive-not-hardcode)', () => {
+    const abs = writeJson(tmpRoot, '.mcp.json', {
+      mcpServers: {
+        'renamed-knowledge': { command: 'C:/tools/totem.exe', args: ['mcp'] },
+        'scoped-runner': { command: 'node', args: ['node_modules/@mmnto/mcp/dist/index.js'] },
+      },
+    });
+    const v = detectCapabilityProbeContract({
+      kind: 'mcp-registration',
+      consumerPath: abs,
+      probedLevel: 'present',
+      declaredSenses: 'present',
+    });
+    expect(v.status).toBe('pass');
+    expect(v.message).toContain('renamed-knowledge');
+    expect(v.message).toContain('scoped-runner');
+  });
+
   it('NEVER throws — a throwing readFile seam degrades to a verdict', () => {
     const v = detectCapabilityProbeContract({
       kind: 'mcp-registration',

--- a/packages/core/src/parity-detect.test.ts
+++ b/packages/core/src/parity-detect.test.ts
@@ -1307,6 +1307,20 @@ describe('detectCapabilityProbeContract — settings-floor probe', () => {
     expect(v.status).toBe('pass');
   });
 
+  it('PASS when settings.json is a shape-invalid ARRAY (cannot express suppression; not walked as an object)', () => {
+    // GCA round 3: `typeof === 'object'` accepts arrays — guard mirrors
+    // totemServerNames. An array settings doc degrades to suppresses-nothing.
+    const abs = writeJson(tmpRoot, '.claude/settings.json', [{ disableAllHooks: true }]);
+    const v = detectCapabilityProbeContract({
+      kind: 'settings-floor',
+      consumerPath: abs,
+      mcpJsonPath: path.join(tmpRoot, '.mcp.json'),
+      probedLevel: 'present',
+      declaredSenses: 'present',
+    });
+    expect(v.status).toBe('pass');
+  });
+
   it('UNKNOWN on unparseable settings JSON (cannot prove the floor either way)', () => {
     const abs = path.join(tmpRoot, '.claude', 'settings.json');
     fs.mkdirSync(path.dirname(abs), { recursive: true });

--- a/packages/core/src/parity-detect.test.ts
+++ b/packages/core/src/parity-detect.test.ts
@@ -21,8 +21,10 @@ import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { TotemConfigError } from './errors.js';
 import {
   deriveCohortRepoId,
+  detectCapabilityProbeContract,
   type DetectGeneratedArtifactContext,
   detectGeneratedArtifactContract,
   type DetectManualAttestationContext,
@@ -1089,5 +1091,255 @@ describe('detectManualAttestationContract', () => {
       expect(v.status).not.toBe('fail');
       expect(v.status).not.toBe('unknown');
     }
+  });
+});
+
+// ─── detectCapabilityProbeContract (mmnto-ai/totem#2140) ──
+
+/** Write a JSON file at an arbitrary repo-relative path. */
+function writeJson(rootDir: string, rel: string, value: unknown): string {
+  const abs = path.join(rootDir, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, JSON.stringify(value, null, 2), 'utf-8');
+  return abs;
+}
+
+/** A realistic .mcp.json registering the totem MCP server. */
+const MCP_JSON_WITH_TOTEM = {
+  mcpServers: {
+    'totem-dev': { command: 'node', args: ['packages/mcp/dist/index.js'] },
+    'totem-strategy': { command: 'totem', args: ['mcp', '--root', '../totem-strategy'] },
+  },
+};
+
+describe('detectCapabilityProbeContract — mcp-registration probe', () => {
+  it('WARN when .mcp.json is absent — no registered query path is the drift this row exists for', () => {
+    const v = detectCapabilityProbeContract({
+      kind: 'mcp-registration',
+      consumerPath: path.join(tmpRoot, '.mcp.json'),
+      probedLevel: 'present',
+    });
+    expect(v.status).toBe('warn');
+    expect(v.message).toMatch(/no .mcp.json|not registered|no registered/i);
+  });
+
+  it('WARN when .mcp.json registers no totem server', () => {
+    const abs = writeJson(tmpRoot, '.mcp.json', {
+      mcpServers: { 'some-other': { command: 'other-tool', args: [] } },
+    });
+    const v = detectCapabilityProbeContract({
+      kind: 'mcp-registration',
+      consumerPath: abs,
+      probedLevel: 'present',
+    });
+    expect(v.status).toBe('warn');
+  });
+
+  it('PASS at the probed level when registered AND the row declares no stronger level', () => {
+    const abs = writeJson(tmpRoot, '.mcp.json', MCP_JSON_WITH_TOTEM);
+    const v = detectCapabilityProbeContract({
+      kind: 'mcp-registration',
+      consumerPath: abs,
+      probedLevel: 'present',
+      declaredSenses: 'present',
+    });
+    expect(v.status).toBe('pass');
+    // The §6(a)3 scoping: the verdict names the level it actually probed.
+    expect(v.message).toContain('present');
+  });
+
+  it('UNKNOWN (green-halo cap) when the row declares usable but the probe only proves present', () => {
+    // codex W3 / the 296 settlement class: a presence-only PASS must never read
+    // as a capability PASS. probedLevel < declared senses → cap at unknown.
+    const abs = writeJson(tmpRoot, '.mcp.json', MCP_JSON_WITH_TOTEM);
+    const v = detectCapabilityProbeContract({
+      kind: 'mcp-registration',
+      consumerPath: abs,
+      probedLevel: 'present',
+      declaredSenses: 'usable',
+    });
+    expect(v.status).toBe('unknown');
+    expect(v.message).toMatch(/usable/i);
+    expect(v.message).toMatch(/present/i);
+  });
+
+  it('UNKNOWN on unparseable .mcp.json (can prove neither registration nor absence)', () => {
+    const abs = path.join(tmpRoot, '.mcp.json');
+    fs.writeFileSync(abs, '{ not valid json', 'utf-8');
+    const v = detectCapabilityProbeContract({
+      kind: 'mcp-registration',
+      consumerPath: abs,
+      probedLevel: 'present',
+    });
+    expect(v.status).toBe('unknown');
+  });
+
+  it('NEVER throws — a throwing readFile seam degrades to a verdict', () => {
+    const v = detectCapabilityProbeContract({
+      kind: 'mcp-registration',
+      consumerPath: path.join(tmpRoot, '.mcp.json'),
+      probedLevel: 'present',
+      readFile: () => {
+        throw new TotemConfigError('synthetic read failure (test seam)', 'n/a — test fixture');
+      },
+    });
+    expect(['warn', 'unknown', 'skip']).toContain(v.status);
+  });
+});
+
+describe('detectCapabilityProbeContract — settings-floor probe', () => {
+  it('PASS when .claude/settings.json is absent — the floor is "not suppressed", not "configured"', () => {
+    const v = detectCapabilityProbeContract({
+      kind: 'settings-floor',
+      consumerPath: path.join(tmpRoot, '.claude', 'settings.json'),
+      mcpJsonPath: path.join(tmpRoot, '.mcp.json'),
+      probedLevel: 'present',
+      declaredSenses: 'present',
+    });
+    expect(v.status).toBe('pass');
+  });
+
+  it('PASS when settings exist but suppress nothing', () => {
+    writeJson(tmpRoot, '.mcp.json', MCP_JSON_WITH_TOTEM);
+    const abs = writeJson(tmpRoot, '.claude/settings.json', {
+      permissions: { allow: ['Read', 'Glob'] },
+    });
+    const v = detectCapabilityProbeContract({
+      kind: 'settings-floor',
+      consumerPath: abs,
+      mcpJsonPath: path.join(tmpRoot, '.mcp.json'),
+      probedLevel: 'present',
+      declaredSenses: 'present',
+    });
+    expect(v.status).toBe('pass');
+  });
+
+  it('WARN when disableAllHooks suppresses the hook floor', () => {
+    const abs = writeJson(tmpRoot, '.claude/settings.json', { disableAllHooks: true });
+    const v = detectCapabilityProbeContract({
+      kind: 'settings-floor',
+      consumerPath: abs,
+      mcpJsonPath: path.join(tmpRoot, '.mcp.json'),
+      probedLevel: 'present',
+      declaredSenses: 'present',
+    });
+    expect(v.status).toBe('warn');
+    expect(v.message).toContain('disableAllHooks');
+  });
+
+  it('WARN when a totem MCP server (derived from .mcp.json) is explicitly disabled', () => {
+    writeJson(tmpRoot, '.mcp.json', MCP_JSON_WITH_TOTEM);
+    const abs = writeJson(tmpRoot, '.claude/settings.json', {
+      disabledMcpjsonServers: ['totem-dev'],
+    });
+    const v = detectCapabilityProbeContract({
+      kind: 'settings-floor',
+      consumerPath: abs,
+      mcpJsonPath: path.join(tmpRoot, '.mcp.json'),
+      probedLevel: 'present',
+      declaredSenses: 'present',
+    });
+    expect(v.status).toBe('warn');
+    expect(v.message).toContain('totem-dev');
+  });
+
+  it('PASS when a NON-totem server is disabled — only the governance floor is in scope', () => {
+    writeJson(tmpRoot, '.mcp.json', MCP_JSON_WITH_TOTEM);
+    const abs = writeJson(tmpRoot, '.claude/settings.json', {
+      disabledMcpjsonServers: ['some-other'],
+    });
+    const v = detectCapabilityProbeContract({
+      kind: 'settings-floor',
+      consumerPath: abs,
+      mcpJsonPath: path.join(tmpRoot, '.mcp.json'),
+      probedLevel: 'present',
+      declaredSenses: 'present',
+    });
+    expect(v.status).toBe('pass');
+  });
+
+  it('UNKNOWN on unparseable settings JSON (cannot prove the floor either way)', () => {
+    const abs = path.join(tmpRoot, '.claude', 'settings.json');
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, '{ nope', 'utf-8');
+    const v = detectCapabilityProbeContract({
+      kind: 'settings-floor',
+      consumerPath: abs,
+      mcpJsonPath: path.join(tmpRoot, '.mcp.json'),
+      probedLevel: 'present',
+      declaredSenses: 'present',
+    });
+    expect(v.status).toBe('unknown');
+  });
+
+  it('probe verdicts never include fail or info', () => {
+    const abs = writeJson(tmpRoot, '.claude/settings.json', { disableAllHooks: true });
+    const verdicts = [
+      detectCapabilityProbeContract({
+        kind: 'settings-floor',
+        consumerPath: abs,
+        mcpJsonPath: path.join(tmpRoot, '.mcp.json'),
+        probedLevel: 'present',
+      }),
+      detectCapabilityProbeContract({
+        kind: 'mcp-registration',
+        consumerPath: path.join(tmpRoot, '.mcp.json'),
+        probedLevel: 'present',
+      }),
+    ];
+    for (const v of verdicts) {
+      expect(['pass', 'warn', 'skip', 'unknown']).toContain(v.status);
+    }
+  });
+});
+
+// ─── Declared-floor verdict rendering (mmnto-ai/totem#2140, 296 §6(a)3 post-#605) ──
+
+describe('declared-min fallback rendering', () => {
+  it('version-pinned PASS via the minVersion fallback renders the declared level + originating range', () => {
+    writeSelfInTree(tmpRoot, '1.50.0');
+    writeConsumerPkg(tmpRoot, { '@mmnto/totem': '^1.53.0' });
+    // NO writeInstalled — resolution falls back to minVersion of the range.
+    const verdict = detectVersionPinnedContract(depsContract(), baseCtx({ repoId: 'totem' }));
+    expect(verdict.status).toBe('pass');
+    expect(verdict.message).toMatch(/declared/i);
+    expect(verdict.message).toContain('^1.53.0'); // the originating range (codex I1)
+    expect(verdict.message).not.toMatch(/installed 1\.53\.0/);
+  });
+
+  it('version-pinned WARN via the minVersion fallback renders the declared level', () => {
+    writeSelfInTree(tmpRoot, '2.0.0');
+    writeConsumerPkg(tmpRoot, { '@mmnto/totem': '^1.40.0' });
+    const verdict = detectVersionPinnedContract(depsContract(), baseCtx({ repoId: 'totem' }));
+    expect(verdict.status).toBe('warn');
+    expect(verdict.message).toMatch(/declared/i);
+    expect(verdict.message).toContain('^1.40.0');
+  });
+
+  it('a RESOLVED install still renders as installed (no declared marking)', () => {
+    writeSelfInTree(tmpRoot, '1.50.0');
+    writeConsumerPkg(tmpRoot, { '@mmnto/totem': '^1.50.0' });
+    writeInstalled(tmpRoot, '@mmnto/totem', '1.53.3');
+    const verdict = detectVersionPinnedContract(depsContract(), baseCtx({ repoId: 'totem' }));
+    expect(verdict.status).toBe('pass');
+    expect(verdict.message).toContain('installed 1.53.3');
+    expect(verdict.message).not.toMatch(/declared-min/i);
+  });
+
+  it('manual-attestation vendor-SDK info renders declared-min when no install resolves (shared helper)', () => {
+    writeConsumerPkg(tmpRoot, { '@anthropic-ai/sdk': '^0.98.0' });
+    const v = detectManualAttestationContract(
+      depsContract({
+        id: 'anthropic-sdk-coupling',
+        tractability: 'manual-attestation',
+        package: '@anthropic-ai/sdk',
+        canonicalSource: null,
+      }),
+      { cwd: tmpRoot, repoId: 'totem' },
+    );
+    expect(v.status).toBe('info');
+    expect(v.message).toMatch(/declared/i);
+    expect(v.message).toContain('^0.98.0');
+    expect(v.message).not.toMatch(/installed 0\.98\.0/);
   });
 });

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -39,7 +39,7 @@ import * as path from 'node:path';
 
 import semver from 'semver';
 
-import type { ParityContract } from './parity-manifest.js';
+import { PARITY_SENSES, type ParityContract, type ParitySense } from './parity-manifest.js';
 import { safeExec } from './sys/exec.js';
 import { resolveGitRoot } from './sys/git.js';
 
@@ -480,13 +480,18 @@ export function detectVersionPinnedContract(
   }
 
   // ── Resolve the consumer's installed version (fallback: minVersion(range)) ──
-  const installed = resolveInstalledVersion(ctx.cwd, packageName, declaredRange);
-  if (installed === undefined) {
+  const resolved = resolveInstalledVersion(ctx.cwd, packageName, declaredRange);
+  if (resolved === undefined) {
     return {
       status: 'skip',
       message: `${packageName} pinned (${declaredRange}) but no resolvable installed version`,
     };
   }
+  const installed = resolved.version;
+  // The verdict-format constraint (296 §6(a)3 post-#605): a minVersion-derived
+  // version is a DECLARED-level claim — the message must carry the degraded
+  // level + the originating range, never read as installed-level.
+  const declaredOnly = resolved.source === 'declared-min';
 
   // ── Resolve the cohort floor (local-only; honest-absent on miss) ──
   const floor = resolveCohortFloor(packageName, ctx.gitRoot);
@@ -507,17 +512,44 @@ export function detectVersionPinnedContract(
   // currency, NOT semantic content — a version-pinned contract may never assert
   // file/content equality.
   if (semver.gte(installed, floor.version)) {
+    if (declaredOnly) {
+      return {
+        status: 'pass',
+        message: `${packageName} pin current at the declared level — declared-min ${installed} from range ${declaredRange} ≥ cohort floor ${floor.version} (${floor.source}); no installed copy resolved`,
+      };
+    }
     return {
       status: 'pass',
       message: `${packageName} pin current — installed ${installed} ≥ cohort floor ${floor.version} (${floor.source})`,
     };
   }
 
+  if (declaredOnly) {
+    return {
+      status: 'warn',
+      message: `${packageName} pin stale at the declared level — declared-min ${installed} from range ${declaredRange} < cohort floor ${floor.version} (${floor.source}); no installed copy resolved`,
+      remediation: `Bump the ${packageName} dependency to >= ${floor.version} and reinstall, then re-run totem doctor --parity.`,
+    };
+  }
   return {
     status: 'warn',
     message: `${packageName} pin stale — declared ${declaredRange}, installed ${installed} < cohort floor ${floor.version} (${floor.source})`,
     remediation: `Bump the ${packageName} dependency to >= ${floor.version} and reinstall, then re-run totem doctor --parity.`,
   };
+}
+
+/**
+ * A consumer version resolution, tagged with WHICH state-level produced it
+ * (mmnto-ai/totem#2140, the 296 §6(a)3 `declared` floor):
+ *   - `installed`    — read from an actual on-disk `node_modules` copy.
+ *   - `declared-min` — `semver.minVersion(declaredRange)`: derived from the
+ *     DECLARATION alone, below `present` on the sensed-state scale. Verdicts
+ *     built on this source must render the degraded level (the settled
+ *     verdict-format constraint, strategy#605) — never read as installed-level.
+ */
+interface ResolvedConsumerVersion {
+  version: string;
+  source: 'installed' | 'declared-min';
 }
 
 /**
@@ -527,14 +559,15 @@ export function detectVersionPinnedContract(
  * root `node_modules` rather than the sub-package's, so a cwd-only read would
  * miss them (GCA review #2071). Mirrors Node's own upward node_modules
  * resolution. On no hit, falls back to `semver.minVersion(declaredRange)` (the
- * floor the caret range implies). Returns undefined only when neither resolves
- * to a valid version.
+ * floor the caret range implies), tagged `declared-min` so callers render the
+ * degraded claim level. Returns undefined only when neither resolves to a
+ * valid version.
  */
 function resolveInstalledVersion(
   cwd: string,
   packageName: string,
   declaredRange: string,
-): string | undefined {
+): ResolvedConsumerVersion | undefined {
   const segments = packageName.split('/');
   let dir = path.resolve(cwd);
   for (;;) {
@@ -542,7 +575,7 @@ function resolveInstalledVersion(
       path.join(dir, 'node_modules', ...segments, 'package.json'),
     );
     if (installedPkg?.version !== undefined && semver.valid(installedPkg.version) !== null) {
-      return installedPkg.version;
+      return { version: installedPkg.version, source: 'installed' };
     }
     const parent = path.dirname(dir);
     if (parent === dir) break; // reached the filesystem root
@@ -551,7 +584,7 @@ function resolveInstalledVersion(
   // Fallback: the minimum version the declared range admits. `minVersion`
   // returns a SemVer or null; coerce to the bare version string.
   const min = semver.minVersion(declaredRange);
-  return min?.version;
+  return min === null ? undefined : { version: min.version, source: 'declared-min' };
 }
 
 /** Find the declared range for `packageName` across the three dep fields, in order. */
@@ -702,12 +735,18 @@ export function detectManualAttestationContract(
   // range never reaches semver.minVersion (resolveInstalledVersion's fallback). An
   // unparseable range still surfaces as info (the coupling IS declared), just with
   // installed unresolved — never a throw, never a warn.
-  const installed =
+  const resolved =
     semver.validRange(declaredRange) !== null
       ? resolveInstalledVersion(ctx.cwd, pkg, declaredRange)
       : undefined;
+  // Same verdict-format constraint as the version-pinned path (296 §6(a)3): a
+  // minVersion-derived value is a declared-level claim, marked as such.
   const installedText =
-    installed !== undefined ? `installed ${installed}` : 'installed: unresolved';
+    resolved === undefined
+      ? 'installed: unresolved'
+      : resolved.source === 'installed'
+        ? `installed ${resolved.version}`
+        : `declared-min ${resolved.version} from range ${declaredRange} (no installed copy resolved)`;
 
   return {
     status: 'info',
@@ -1224,6 +1263,232 @@ export function detectGeneratedArtifactContract(
     ),
     remediation: `Re-run ${install} to restore the managed ${label}, or remove the local edits before the totem marker so it can be verified independently.`,
   };
+}
+
+// ─── Capability-probe detector (mmnto-ai/totem#2140, 296 §6(a)2 probe rung) ──
+
+/**
+ * The probe sub-kinds this slice ships (the two deliverable-1 rows):
+ *   - `mcp-registration` — does `.mcp.json` register a totem MCP server? The
+ *     PRESENT rung of `knowledge-search-access` ("a working query path exists
+ *     from this agent surface"). The usable rung (a live bounded search exec)
+ *     is deliberately NOT shipped: real `totem search` embeds the query via a
+ *     cloud API, which a §12.5 never-network probe cannot run — flagged to
+ *     strategy with the row-downshift question.
+ *   - `settings-floor` — does `.claude/settings.json` suppress the governance
+ *     floor (`claude-settings-minimum-capability`)? Canonical-at-intent-altitude
+ *     (296 §6(c)): the canonical is a minimum-capability CONTRACT, so the probe
+ *     senses explicit SUPPRESSION only — an absent file (or any unrelated
+ *     content) is `pass`; the doctor never prescribes settings content.
+ */
+export type CapabilityProbeKind = 'mcp-registration' | 'settings-floor';
+
+/** Inputs + test seams for {@link detectCapabilityProbeContract}. */
+export interface DetectCapabilityProbeContext {
+  kind: CapabilityProbeKind;
+  /** Absolute path of the probed file (`.mcp.json` / `.claude/settings.json`). */
+  consumerPath: string;
+  /**
+   * `settings-floor` only: absolute path to `.mcp.json`, read to DERIVE the
+   * totem MCP server names cross-checked against `disabledMcpjsonServers`
+   * (derive-not-hardcode, Tenet 20). Absent/unreadable → nothing to cross-check
+   * (the MCP half of the floor is vacuous; the hooks half still applies).
+   */
+  mcpJsonPath?: string;
+  /** The state-level THIS probe proves by design (`present` for both kinds today). */
+  probedLevel: ParitySense;
+  /**
+   * The row's declared `senses:` (open string off the contract). When it names
+   * a RECOGNIZED level stronger than `probedLevel`, a would-be `pass` is capped
+   * at `unknown` — the green-halo invariant at probe altitude: a presence-PASS
+   * must never render as a capability-PASS (296 §6(a)3 / strategy#591).
+   */
+  declaredSenses?: string;
+  /** Test seam — override the file read. Production callers omit it. */
+  readFile?: (absPath: string) => string | undefined;
+}
+
+/** Rank a senses level on the §6(a)3 scale; -1 for unrecognized values. */
+function senseRank(level: string | undefined): number {
+  return level === undefined ? -1 : PARITY_SENSES.indexOf(level as ParitySense);
+}
+
+/** JSON file read that NEVER throws: absent / unparseable are first-class outcomes. */
+type JsonReadResult =
+  | { status: 'absent' }
+  | { status: 'unparseable' }
+  | { status: 'ok'; value: unknown };
+
+function readJsonResult(
+  readFile: (absPath: string) => string | undefined,
+  absPath: string,
+): JsonReadResult {
+  let raw: string | undefined;
+  try {
+    raw = readFile(absPath);
+    // totem-context: a throwing injected reader is the probe's degraded-read signal (the never-throws contract); treated as absent rather than crashing the doctor pipeline.
+  } catch {
+    raw = undefined;
+  }
+  if (raw === undefined) return { status: 'absent' };
+  try {
+    return { status: 'ok', value: JSON.parse(raw) };
+    // totem-context: malformed JSON is a first-class `unparseable` outcome the probe maps to an honest `unknown` — never a throw.
+  } catch {
+    return { status: 'unparseable' };
+  }
+}
+
+/**
+ * Derive the totem MCP server names registered in a parsed `.mcp.json` doc: an
+ * `mcpServers` entry counts when its NAME or its command/args text references
+ * totem (`totem` / `@mmnto`). Derivation, not a hardcoded name list, so renamed
+ * or per-repo servers still match (Tenet 20).
+ */
+function totemServerNames(doc: unknown): string[] {
+  if (typeof doc !== 'object' || doc === null) return [];
+  const servers = (doc as { mcpServers?: unknown }).mcpServers;
+  if (typeof servers !== 'object' || servers === null) return [];
+  const names: string[] = [];
+  for (const [name, config] of Object.entries(servers as Record<string, unknown>)) {
+    const command =
+      typeof config === 'object' && config !== null
+        ? String((config as { command?: unknown }).command ?? '')
+        : '';
+    const args =
+      typeof config === 'object' &&
+      config !== null &&
+      Array.isArray((config as { args?: unknown }).args)
+        ? ((config as { args: unknown[] }).args.filter((a) => typeof a === 'string') as string[])
+        : [];
+    const haystack = `${name} ${command} ${args.join(' ')}`.toLowerCase();
+    if (haystack.includes('totem') || haystack.includes('@mmnto')) names.push(name);
+  }
+  return names;
+}
+
+/**
+ * Apply the green-halo cap to a would-be `pass`: when the row DECLARES a
+ * recognized senses level stronger than what this probe proved, the verdict is
+ * `unknown` (the declared contract is unprovable by this probe), never `pass`.
+ * Failure verdicts are NOT capped — a failed weaker rung disproves the stronger
+ * one (no registration ⇒ certainly not usable).
+ */
+function passAtProbedLevel(
+  ctx: DetectCapabilityProbeContext,
+  confirmation: string,
+): ParityContractVerdict {
+  const probed = senseRank(ctx.probedLevel);
+  const declared = senseRank(ctx.declaredSenses);
+  if (declared !== -1 && probed !== -1 && probed < declared) {
+    return {
+      status: 'unknown',
+      message: `manifest declares senses: ${ctx.declaredSenses}; this probe proves ${ctx.probedLevel} only — ${confirmation}; ${ctx.declaredSenses} is unprovable by a no-network probe (296 §12.5)`,
+    };
+  }
+  return {
+    status: 'pass',
+    message: `probed level: ${ctx.probedLevel} — ${confirmation}`,
+  };
+}
+
+/**
+ * Detect ONE capability-probe contract (`manifestation: capability-probe`,
+ * 296 §6(a)2). Deterministic, local-read-only, NEVER networks, NEVER throws,
+ * and NEVER emits `fail` (CLI edge owns promotion) or `info` (probes decide,
+ * they do not attest — "sense-only" means no actuator, not an info ceiling;
+ * the 296 §6(a)4 settled vocabulary is pass/warn/skip/unknown).
+ */
+export function detectCapabilityProbeContract(
+  ctx: DetectCapabilityProbeContext,
+): ParityContractVerdict {
+  const readFile = ctx.readFile ?? readFileText;
+
+  if (ctx.kind === 'mcp-registration') {
+    const probe = readJsonResult(readFile, ctx.consumerPath);
+    if (probe.status === 'absent') {
+      return {
+        status: 'warn',
+        message: `no .mcp.json at ${ctx.consumerPath} — no registered query path on this agent surface`,
+        remediation:
+          'Register the totem MCP server in .mcp.json (totem init scaffolds it), or use `pnpm exec totem search` as the non-MCP transport.',
+      };
+    }
+    if (probe.status === 'unparseable') {
+      return {
+        status: 'unknown',
+        message: `${ctx.consumerPath} is unparseable JSON — registration unprovable either way`,
+        remediation: 'Fix the .mcp.json syntax, then re-run totem doctor --parity.',
+      };
+    }
+    const names = totemServerNames(probe.value);
+    if (names.length === 0) {
+      return {
+        status: 'warn',
+        message: `.mcp.json registers no totem MCP server — no registered query path on this agent surface`,
+        remediation:
+          'Register the totem MCP server in .mcp.json (totem init scaffolds it), or use `pnpm exec totem search` as the non-MCP transport.',
+      };
+    }
+    return passAtProbedLevel(
+      ctx,
+      `totem MCP server(s) [${names.join(', ')}] registered in .mcp.json`,
+    );
+  }
+
+  // ── settings-floor ──
+  const probe = readJsonResult(readFile, ctx.consumerPath);
+  if (probe.status === 'absent') {
+    // The floor is "not suppressed", never "explicitly configured" — an absent
+    // settings file suppresses nothing (canonical-at-intent-altitude, 296 §6(c)).
+    return passAtProbedLevel(
+      ctx,
+      `no ${path.basename(ctx.consumerPath)} present; governance floor not suppressed (absent = unsuppressed)`,
+    );
+  }
+  if (probe.status === 'unparseable') {
+    return {
+      status: 'unknown',
+      message: `${ctx.consumerPath} is unparseable JSON — the governance floor is unprovable either way`,
+      remediation: 'Fix the settings JSON syntax, then re-run totem doctor --parity.',
+    };
+  }
+  const settings =
+    typeof probe.value === 'object' && probe.value !== null
+      ? (probe.value as Record<string, unknown>)
+      : {};
+
+  if (settings['disableAllHooks'] === true) {
+    return {
+      status: 'warn',
+      message: `governance floor suppressed — disableAllHooks: true in ${ctx.consumerPath} (SessionStart orientation cannot fire)`,
+      remediation:
+        'Remove disableAllHooks (or scope the suppression below the governance hooks) to restore the minimum-capability floor.',
+    };
+  }
+
+  const disabledRaw = settings['disabledMcpjsonServers'];
+  const disabled = Array.isArray(disabledRaw)
+    ? disabledRaw.filter((v): v is string => typeof v === 'string')
+    : [];
+  if (disabled.length > 0 && ctx.mcpJsonPath !== undefined) {
+    const mcpProbe = readJsonResult(readFile, ctx.mcpJsonPath);
+    const totemNames = mcpProbe.status === 'ok' ? totemServerNames(mcpProbe.value) : [];
+    const suppressed = totemNames.filter((n) => disabled.includes(n));
+    if (suppressed.length > 0) {
+      return {
+        status: 'warn',
+        message: `governance floor suppressed — totem MCP server(s) [${suppressed.join(', ')}] listed in disabledMcpjsonServers in ${ctx.consumerPath}`,
+        remediation:
+          'Remove the totem MCP server(s) from disabledMcpjsonServers to restore the minimum-capability floor.',
+      };
+    }
+  }
+
+  return passAtProbedLevel(
+    ctx,
+    `governance floor not suppressed in ${path.basename(ctx.consumerPath)}`,
+  );
 }
 
 // ─── Shared filesystem helpers ──────────────────────────

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -1465,8 +1465,11 @@ export function detectCapabilityProbeContract(
       remediation: 'Fix the settings JSON syntax, then re-run totem doctor --parity.',
     };
   }
+  // Array guard mirrors totemServerNames (GCA round 3): an array settings doc
+  // is shape-invalid, cannot express suppression, and must not be walked as a
+  // key-value object — it degrades to the empty (suppresses-nothing) shape.
   const settings =
-    typeof probe.value === 'object' && probe.value !== null
+    typeof probe.value === 'object' && probe.value !== null && !Array.isArray(probe.value)
       ? (probe.value as Record<string, unknown>)
       : {};
 

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -1340,31 +1340,43 @@ function readJsonResult(
 }
 
 /**
- * Derive the totem MCP server names registered in a parsed `.mcp.json` doc: an
- * `mcpServers` entry counts when its NAME or its command/args text references
- * totem (`totem` / `@mmnto`). Derivation, not a hardcoded name list, so renamed
- * or per-repo servers still match (Tenet 20).
+ * Derive the totem MCP server names registered in a parsed `.mcp.json` doc.
+ * Derivation, not a hardcoded name list, so renamed or per-repo servers still
+ * match (Tenet 20) — but the signals are deliberately BOUNDED (GCA + Greptile
+ * round on the PR): a bare `totem` substring anywhere in a command/arg path
+ * would false-positive on unrelated servers under totem-named directories
+ * (`/home/totem-projects/other-mcp/run.sh`), and in the settings-floor probe a
+ * false positive becomes a spurious governance-floor WARN. An entry counts when:
+ *   - its NAME contains `totem`, or
+ *   - its command BASENAME is the totem binary, or
+ *   - an arg references the `@mmnto` package scope.
  */
 function totemServerNames(doc: unknown): string[] {
   if (typeof doc !== 'object' || doc === null) return [];
   const servers = (doc as { mcpServers?: unknown }).mcpServers;
-  if (typeof servers !== 'object' || servers === null) return [];
+  // Array.isArray guard: a malformed array still satisfies `typeof === 'object'`,
+  // and Object.entries over it would derive index-keyed "names" (GCA review).
+  if (typeof servers !== 'object' || servers === null || Array.isArray(servers)) return [];
   const names: string[] = [];
   for (const [name, config] of Object.entries(servers as Record<string, unknown>)) {
-    const command =
-      typeof config === 'object' && config !== null
-        ? String((config as { command?: unknown }).command ?? '')
-        : '';
-    const args =
-      typeof config === 'object' &&
-      config !== null &&
-      Array.isArray((config as { args?: unknown }).args)
-        ? ((config as { args: unknown[] }).args.filter((a) => typeof a === 'string') as string[])
-        : [];
-    const haystack = `${name} ${command} ${args.join(' ')}`.toLowerCase();
-    if (haystack.includes('totem') || haystack.includes('@mmnto')) names.push(name);
+    if (isTotemServer(name, config)) names.push(name);
   }
   return names;
+}
+
+/** The bounded totem-server signals for one `.mcp.json` entry (see {@link totemServerNames}). */
+function isTotemServer(name: string, config: unknown): boolean {
+  if (name.toLowerCase().includes('totem')) return true;
+  if (typeof config !== 'object' || config === null) return false;
+  const command = (config as { command?: unknown }).command;
+  if (typeof command === 'string') {
+    // Basename only, extension-tolerant — the command must BE the totem binary,
+    // not merely live under a totem-named path (the Greptile P2 class).
+    const base = path.basename(command.trim()).toLowerCase();
+    if (base === 'totem' || base === 'totem.exe' || base === 'totem.cmd') return true;
+  }
+  const args = (config as { args?: unknown }).args;
+  return Array.isArray(args) && args.some((a) => typeof a === 'string' && a.includes('@mmnto'));
 }
 
 /**

--- a/packages/core/src/parity-manifest.test.ts
+++ b/packages/core/src/parity-manifest.test.ts
@@ -285,3 +285,101 @@ describe('loadParityManifest', () => {
     expect(result.status).toBe('unparseable');
   });
 });
+
+// ─── Promoted 296 deliverable-1 fields (mmnto-ai/totem#2140) ──
+
+// A contract carrying all four promoted optional fields, in the shapes the
+// promoted manifest actually uses (strategy#606: `vendor-adapter` is a YAML
+// LIST; the rest are strings).
+const PROMOTED_FIELDS_YAML = `schema-version: 1
+status: active
+
+contracts:
+  - id: knowledge-search-access
+    dimension: knowledge-index
+    canonical-source: null
+    detection-method: capability probe, two rungs
+    expected-value-or-derivation: at least one working query path per agent surface
+    tractability: mechanical
+    manifestation: capability-probe
+    senses: usable
+    vendor-adapter: [claude, gemini]
+    repo-role-variance: publisher self-read skips on workspace pins (by design)
+    tracking-issue: mmnto-ai/totem#2140
+`;
+
+describe('parseParityManifest — promoted 296 fields (mmnto-ai/totem#2140)', () => {
+  it('parses all four promoted fields, mapping kebab-case → camelCase', () => {
+    const result = parseParityManifest(PROMOTED_FIELDS_YAML);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    const row = result.manifest.contracts[0]!;
+    expect(row.manifestation).toBe('capability-probe');
+    expect(row.senses).toBe('usable');
+    expect(row.vendorAdapter).toEqual(['claude', 'gemini']);
+    expect(row.repoRoleVariance).toBe('publisher self-read skips on workspace pins (by design)');
+  });
+
+  it('respects honest-absent mapping for promoted optional fields (no keys, no defaults)', () => {
+    const result = parseParityManifest(VALID_MANIFEST_YAML);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    for (const row of result.manifest.contracts) {
+      expect('manifestation' in row).toBe(false);
+      expect('senses' in row).toBe(false);
+      expect('vendorAdapter' in row).toBe(false);
+      expect('repoRoleVariance' in row).toBe(false);
+    }
+  });
+
+  it('normalizes a bare-string vendor-adapter to a one-element array', () => {
+    const bare = PROMOTED_FIELDS_YAML.replace(
+      'vendor-adapter: [claude, gemini]',
+      'vendor-adapter: claude',
+    );
+    const result = parseParityManifest(bare);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.manifest.contracts[0]!.vendorAdapter).toEqual(['claude']);
+  });
+
+  it('keeps an UNRECOGNIZED manifestation value verbatim — never a manifest-wide failure', () => {
+    // The total-outage guard (the 296 settlement class): a future rung value on
+    // one row must not take all contracts dark. The field is render/routing
+    // metadata, so an unknown value parses through verbatim; the ROUTER decides
+    // how to surface it (per-row stub line), never the parser.
+    const future = PROMOTED_FIELDS_YAML.replace(
+      'manifestation: capability-probe',
+      'manifestation: quantum-entanglement',
+    );
+    const result = parseParityManifest(future);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.manifest.contracts[0]!.manifestation).toBe('quantum-entanglement');
+  });
+
+  it('narrows a mis-shaped promoted field to absent without failing the manifest', () => {
+    // A numeric senses (authoring error) drops to absent on that row — never
+    // manifest-wide unparseable (the last-attested precedent: rejection at the
+    // raw boundary is a TOTAL sensor outage; narrowing is per-row).
+    const misShaped = PROMOTED_FIELDS_YAML.replace('senses: usable', 'senses: 3');
+    const result = parseParityManifest(misShaped);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    const row = result.manifest.contracts[0]!;
+    expect('senses' in row).toBe(false);
+    // The other promoted fields on the same row are unaffected.
+    expect(row.manifestation).toBe('capability-probe');
+  });
+
+  it('narrows a mis-shaped vendor-adapter (non-string list member) to absent', () => {
+    const misShaped = PROMOTED_FIELDS_YAML.replace(
+      'vendor-adapter: [claude, gemini]',
+      'vendor-adapter: [claude, 7]',
+    );
+    const result = parseParityManifest(misShaped);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect('vendorAdapter' in result.manifest.contracts[0]!).toBe(false);
+  });
+});

--- a/packages/core/src/parity-manifest.test.ts
+++ b/packages/core/src/parity-manifest.test.ts
@@ -382,4 +382,20 @@ describe('parseParityManifest — promoted 296 fields (mmnto-ai/totem#2140)', ()
     if (result.status !== 'ok') return;
     expect('vendorAdapter' in result.manifest.contracts[0]!).toBe(false);
   });
+
+  it('TRIMS a quoted promoted field with stray surrounding spaces (routing must still compare)', () => {
+    // Greptile outside-diff finding on the #2140 PR: trimming only the
+    // emptiness TEST but returning the raw value would let a padded
+    // `manifestation: ' capability-probe '` dodge routing and the green-halo cap.
+    const padded = PROMOTED_FIELDS_YAML.replace(
+      'manifestation: capability-probe',
+      "manifestation: ' capability-probe '",
+    ).replace('senses: usable', "senses: ' usable '");
+    const result = parseParityManifest(padded);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    const row = result.manifest.contracts[0]!;
+    expect(row.manifestation).toBe('capability-probe');
+    expect(row.senses).toBe('usable');
+  });
 });

--- a/packages/core/src/parity-manifest.test.ts
+++ b/packages/core/src/parity-manifest.test.ts
@@ -383,6 +383,30 @@ describe('parseParityManifest — promoted 296 fields (mmnto-ai/totem#2140)', ()
     expect('vendorAdapter' in result.manifest.contracts[0]!).toBe(false);
   });
 
+  it('TRIMS vendor-adapter LIST members + drops empties (list and bare-string normalize identically)', () => {
+    // GCA + CR round-2 convergence: `[' claude ', '  ']` must parse the same
+    // as `' claude '` — authoring shape must not change the parsed result.
+    const padded = PROMOTED_FIELDS_YAML.replace(
+      'vendor-adapter: [claude, gemini]',
+      "vendor-adapter: [' claude ', '  ']",
+    );
+    const result = parseParityManifest(padded);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect(result.manifest.contracts[0]!.vendorAdapter).toEqual(['claude']);
+  });
+
+  it('an all-empty vendor-adapter list narrows to absent (not an empty array)', () => {
+    const empty = PROMOTED_FIELDS_YAML.replace(
+      'vendor-adapter: [claude, gemini]',
+      "vendor-adapter: ['  ', ' ']",
+    );
+    const result = parseParityManifest(empty);
+    expect(result.status).toBe('ok');
+    if (result.status !== 'ok') return;
+    expect('vendorAdapter' in result.manifest.contracts[0]!).toBe(false);
+  });
+
   it('TRIMS a quoted promoted field with stray surrounding spaces (routing must still compare)', () => {
     // Greptile outside-diff finding on the #2140 PR: trimming only the
     // emptiness TEST but returning the raw value would let a padded

--- a/packages/core/src/parity-manifest.ts
+++ b/packages/core/src/parity-manifest.ts
@@ -371,10 +371,14 @@ export function parseParityManifest(yamlText: string): ParityManifestParseResult
  * Narrow an unknown promoted-field value to a non-empty string, else undefined
  * (mis-shaped → treated as absent on that row; see the raw-schema note — the
  * field is routing/render metadata, so per-row absence beats manifest-wide
- * unparseable).
+ * unparseable). Returns the TRIMMED value — a YAML-quoted field with stray
+ * surrounding spaces must still hit routing comparisons and the green-halo cap
+ * (Greptile outside-diff finding on the #2140 PR).
  */
 function narrowString(value: unknown): string | undefined {
-  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
 }
 
 /**
@@ -385,7 +389,8 @@ function narrowString(value: unknown): string | undefined {
  */
 function narrowStringArray(value: unknown): string[] | undefined {
   if (typeof value === 'string') {
-    return value.trim().length > 0 ? [value] : undefined;
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? [trimmed] : undefined;
   }
   if (Array.isArray(value) && value.length > 0 && value.every((v) => typeof v === 'string')) {
     return value as string[];

--- a/packages/core/src/parity-manifest.ts
+++ b/packages/core/src/parity-manifest.ts
@@ -60,6 +60,35 @@ export const ParityTractabilitySchema = z.enum([
 ]);
 export type ParityTractability = z.infer<typeof ParityTractabilitySchema>;
 
+// ─── Promoted 296 deliverable-1 fields (mmnto-ai/totem#2140) ──
+
+/**
+ * The §6(a)2 manifestation-ladder rungs THIS doctor build recognizes (best →
+ * weakest). Deliberately NOT a Zod enum at the parse boundary: a closed enum
+ * would fail validation MANIFEST-WIDE on one future rung value — the exact
+ * total-outage class the 296 settlement (strategy#605) ruled additive fields
+ * around (and the `last-attested` format-unvalidation precedent). Routing
+ * narrows against this list; an unrecognized value stays verbatim on the row
+ * and surfaces as a per-row line, never a dark manifest.
+ */
+export const PARITY_MANIFESTATIONS = [
+  'correct-by-construction',
+  'managed-block',
+  'version-pin',
+  'attestation',
+  'capability-probe',
+] as const;
+export type ParityManifestation = (typeof PARITY_MANIFESTATIONS)[number];
+
+/**
+ * The §6(a)3 sensed-state scale (post-#605: `declared` is the floor — the
+ * minVersion-fallback honesty level). Ordered weakest → strongest so the
+ * probe-vs-declared comparison (the green-halo cap, mmnto-ai/totem#2140) can
+ * index into it. Same not-a-Zod-enum rationale as {@link PARITY_MANIFESTATIONS}.
+ */
+export const PARITY_SENSES = ['declared', 'present', 'loaded', 'usable'] as const;
+export type ParitySense = (typeof PARITY_SENSES)[number];
+
 // ─── Contract + manifest types ──────────────────────────
 
 /**
@@ -100,6 +129,16 @@ const RawParityContractSchema = z.object({
   // versus rendering a verbatim blemish on one info line. Render-only field;
   // the producer side schema-reviews the manifest before publish.
   'last-attested': z.string().optional(),
+  // The four promoted 296 deliverable-1 fields (strategy#605/#606,
+  // mmnto-ai/totem#2140). Max-tolerance at the raw boundary (`z.unknown()`) for
+  // the same manifest-wide-outage reason as `last-attested` above; shape
+  // narrowing happens per-row in `mapContract` (mis-shaped → field absent on
+  // that row, never a dark manifest). They are routing/render metadata, never
+  // verdict inputs, so per-row narrowing does not launder a verdict.
+  manifestation: z.unknown().optional(),
+  senses: z.unknown().optional(),
+  'vendor-adapter': z.unknown().optional(),
+  'repo-role-variance': z.unknown().optional(),
 });
 
 /**
@@ -159,6 +198,28 @@ export interface ParityContract {
    * the doctor renders "last attested: not recorded", never fabricates a date).
    */
   lastAttested?: string;
+  /**
+   * Optional §6(a)2 manifestation-ladder rung (promoted field, strategy#606).
+   * An open string, NOT `ParityManifestation` — recognized values are narrowed
+   * at the ROUTING edge against {@link PARITY_MANIFESTATIONS}; an unrecognized
+   * value rides verbatim so the router can surface it loudly per-row.
+   */
+  manifestation?: string;
+  /**
+   * Optional §6(a)3 sensed-state level the row's detection-method probes BY
+   * DESIGN (`declared|present|loaded|usable`). Open string for the same
+   * reason as `manifestation`. Runtime degradation below this level is a
+   * verdict-format concern (the declared-floor rendering), never a parse one.
+   */
+  senses?: string;
+  /**
+   * Optional vendor surfaces this row manifests through (promoted field).
+   * Normalized to an array — the manifest authors both `[claude, gemini]`
+   * lists and bare strings.
+   */
+  vendorAdapter?: string[];
+  /** Optional one-line legitimate role-based manifestation difference (§6(c)). */
+  repoRoleVariance?: string;
 }
 
 /** A fully parsed + validated parity manifest. */
@@ -306,8 +367,38 @@ export function parseParityManifest(yamlText: string): ParityManifestParseResult
   return { status: 'ok', manifest };
 }
 
+/**
+ * Narrow an unknown promoted-field value to a non-empty string, else undefined
+ * (mis-shaped → treated as absent on that row; see the raw-schema note — the
+ * field is routing/render metadata, so per-row absence beats manifest-wide
+ * unparseable).
+ */
+function narrowString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+/**
+ * Narrow an unknown `vendor-adapter` value to `string[]`: a YAML list of
+ * strings passes through; a bare string normalizes to a one-element array
+ * (both shapes appear in the promoted manifest). Any other shape — including a
+ * list with one non-string member — narrows to undefined (absent on that row).
+ */
+function narrowStringArray(value: unknown): string[] | undefined {
+  if (typeof value === 'string') {
+    return value.trim().length > 0 ? [value] : undefined;
+  }
+  if (Array.isArray(value) && value.length > 0 && value.every((v) => typeof v === 'string')) {
+    return value as string[];
+  }
+  return undefined;
+}
+
 /** Map one validated raw contract to the camelCase public `ParityContract`. */
 function mapContract(raw: z.infer<typeof RawParityContractSchema>): ParityContract {
+  const manifestation = narrowString(raw.manifestation);
+  const senses = narrowString(raw.senses);
+  const vendorAdapter = narrowStringArray(raw['vendor-adapter']);
+  const repoRoleVariance = narrowString(raw['repo-role-variance']);
   return {
     id: raw.id,
     dimension: raw.dimension,
@@ -322,6 +413,10 @@ function mapContract(raw: z.infer<typeof RawParityContractSchema>): ParityContra
     ...(raw.blocking !== undefined ? { blocking: raw.blocking } : {}),
     ...(raw.consumers !== undefined ? { consumers: raw.consumers } : {}),
     ...(raw.package !== undefined ? { package: raw.package } : {}),
+    ...(manifestation !== undefined ? { manifestation } : {}),
+    ...(senses !== undefined ? { senses } : {}),
+    ...(vendorAdapter !== undefined ? { vendorAdapter } : {}),
+    ...(repoRoleVariance !== undefined ? { repoRoleVariance } : {}),
   };
 }
 

--- a/packages/core/src/parity-manifest.ts
+++ b/packages/core/src/parity-manifest.ts
@@ -393,7 +393,11 @@ function narrowStringArray(value: unknown): string[] | undefined {
     return trimmed.length > 0 ? [trimmed] : undefined;
   }
   if (Array.isArray(value) && value.length > 0 && value.every((v) => typeof v === 'string')) {
-    return value as string[];
+    // Trim members + drop empties so list and bare-string inputs normalize
+    // identically (GCA + CR round-2 convergence on the #2140 PR) — equivalent
+    // YAML must not parse differently by authoring shape.
+    const trimmed = (value as string[]).map((v) => v.trim()).filter((v) => v.length > 0);
+    return trimmed.length > 0 ? trimmed : undefined;
   }
   return undefined;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         version: 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
     optionalDependencies:
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.4
-        version: 0.1.4
+        specifier: 0.1.5
+        version: 0.1.5
 
   packages/cli:
     dependencies:
@@ -847,8 +847,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.4':
-    resolution: {integrity: sha512-sTWY/fsJK9F3XZ6WSU9Jc976RGTIWH91FoEq7D2TMTOwtVegUto309Urei2H/pt3VrttQy2260rxoj+0iS/lCQ==}
+  '@mmnto/strategy-doctrine@0.1.5':
+    resolution: {integrity: sha512-l8ClO3MZ4Cuazl/qbgOfwENoBN8AY7A/solRlPCmrIkYqix2dGjr0SRL8mew2jaWXgKufOq6NXNFEHhRYz6kcg==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3679,7 +3679,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.4':
+  '@mmnto/strategy-doctrine@0.1.5':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
Closes #2140 — the totem half of Proposal 296 deliverable-1 (strategy half merged as [strategy#606](https://github.com/mmnto-ai/totem-strategy/pull/606); manifest floor `@mmnto/strategy-doctrine@0.1.5`, bumped here).

## What

**Core — promoted-field parsing (`parity-manifest.ts`).** The four promoted optional fields (`manifestation:` / `senses:` / `vendor-adapter:` / `repo-role-variance:`) parse into `ParityContract`. Max-tolerance at the raw Zod boundary (`z.unknown().optional()`) with per-row narrowing in `mapContract` — a mis-shaped or future value drops to absent on ITS row, never a manifest-wide `unparseable` (the total-outage class the 296 settlement ruled additive fields around; same precedent as the deliberately-unvalidated `last-attested`). `vendor-adapter` normalizes bare string → one-element array. Recognized values export as const tuples (`PARITY_MANIFESTATIONS`, `PARITY_SENSES`); `schema-version` unchanged. Honest-absent throughout (lesson-7d7f3d32).

**Core — `detectCapabilityProbeContract`.** Deterministic, local-read-only, never throws / networks / emits `fail`-or-`info`. Two kinds:
- `mcp-registration` (`knowledge-search-access`, present rung): totem server names DERIVED from `.mcp.json` entries, not hardcoded.
- `settings-floor` (`claude-settings-minimum-capability`): suppression sensing only — absent settings file = pass (canonical-at-intent-altitude, 296 §6(c)); WARNs only on explicit `disableAllHooks` / totem server in `disabledMcpjsonServers`.

**The green-halo cap** (totem-codex review W3): each probe carries its `probedLevel`; when the row declares a stronger `senses:`, a would-be PASS caps at `unknown` — a presence-PASS can never render as a capability-PASS. Generic (descriptor-derived, no row hardcoding); self-resolves to `pass` if strategy downshifts the row.

**Core — declared-floor rendering (296 §6(a)3 post-#605).** `resolveInstalledVersion` returns a tagged source; the `semver.minVersion` fallback now renders `declared-min <v> from range <r>` in version-pinned pass/warn AND the vendor-SDK attestation info path — never reads as installed-level.

**CLI — routing.** `manifestation: capability-probe` routes ahead of the tractability dispatch; unrecognized `manifestation` values render a loud per-row stub carrying the verbatim value; the `consumers`-scope guard is extracted and shared with the mechanical branch.

## Verification

- Core 119 tests + CLI 49 tests green (13 new probe/parse cases, 4 new declared-floor cases); `totem lint` PASS (0 errors); `totem review` PASS (0 findings); `format:check` clean.
- **Live run against the promoted manifest** (26 contracts loaded): `claude-settings-minimum-capability` → `PASS — probed level: present`; `knowledge-search-access` → `UNKNOWN — manifest declares senses: usable; this probe proves present only — totem MCP server(s) [totem-dev, totem-strategy] registered in .mcp.json; usable is unprovable by a no-network probe (296 §12.5)`.
- Pre-existing local failures in `pre-compact-hook.test.ts` (bash content-hash scripts on this Windows host) reproduce on clean HEAD with this work stashed — unrelated to this diff; green in CI on #2139.

## Deliberately NOT in this PR

- The `usable`-rung live-search probe — real `totem search` embeds the query via a cloud API, contradicting the §12.5 never-network probe constraint. Flagged to strategy with the row-downshift question (`senses: usable` → `present` until a no-network usable probe exists).
- Runtime per-id classification asserts (a Tenet-20 mirror of strategy-owned classifications). The build-time sanity check of strategy''s three classification calls was performed instead: `pnpm-engine-version → senses: declared`, `ecl-conventions → manifestation: correct-by-construction`, and packaging/bot-config attestation-rung-with-mechanical-sensing are all consistent with detector reality.

Spec + implementation design (incl. the totem-codex review fold): `.totem/specs/2140.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)