### PR TITLE
chore(docs): redact two exposure classes from public agent instructions

### DIFF
--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -9,7 +9,7 @@
 ## Environment
 
 - **pnpm only** (never npm/yarn). Use `pnpm dlx` (never `npx`).
-- Windows 11 + Git Bash. TypeScript strict mode.
+- TypeScript strict mode.
 - **NEVER put secrets in config files.** `.env` only.
 
 ## Code Style

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,13 +16,13 @@ Totem is a **deterministic, git-native governance toolkit** — _rules you enfor
 
 ## Essentials
 
-- **pnpm only** (never npm/yarn). Use `pnpm dlx` (never `npx`). Windows 11 + Git Bash. TypeScript strict mode.
+- **pnpm only** (never npm/yarn). Use `pnpm dlx` (never `npx`). TypeScript strict mode.
 - `main` is protected. Feature branches + PRs. Never amend commits on feature branches. Use `Closes #NNN` in PR descriptions.
 - `kebab-case.ts` files, `err` (never `error`) in catch blocks, no empty catches.
 - Named constants for magic numbers. Zod at system boundaries only.
 - Run `pnpm run format` before committing.
 - **NEVER put secrets in config files.** `.env` only.
-- **Totem is NOT zero-user.** Ships in production on `satur8d` and `arhgap11` in addition to dogfooding this repo. Breaking changes need migration paths, not just "fix in next major."
+- **Totem is NOT zero-user.** Ships in production for downstream consumers beyond this repo's dogfood. Breaking changes need migration paths, not just "fix in next major."
 
 ## Totem Workflow
 
@@ -32,7 +32,7 @@ Not mechanically enforced. Follow because they reduce PR bot noise.
 - **Before pushing:** `pnpm run format` → `totem lint` → `totem review` → verify compile manifest is current.
 - **After merging a PR:** `totem lesson extract <pr> --yes`, then `totem docs` if releasing. Lessons: `totem lesson extract <prs>` → `totem lesson compile`.
 - **NEVER bypass quality gates without a ticket.** No `--no-verify`, `totem-ignore`, `eslint-disable`, `@ts-ignore`, skipped tests, or CI-pacifying ignore patterns. Suppressions need a ticket-ref comment.
-- **Open PRs Ready, not Draft.** CR (`auto_review.drafts: false`) + GCA don't review Drafts; in this solo-dev + bot-review repo Draft has no audience.
+- **Open PRs Ready, not Draft.** CR (`auto_review.drafts: false`) + GCA don't review Drafts; Drafts here have no review audience.
 - **Vendor routing.** Claude is the default code executor; Gemini stays strategic (proposals, ADRs, audits). Cross-vendor second-opinion fine both ways; "Gemini implement" is not the default.
 
 ## Contributor Principles

--- a/packages/cli/src/commands/config-drift.test.ts
+++ b/packages/cli/src/commands/config-drift.test.ts
@@ -165,7 +165,6 @@ describe('all agent instruction files share the same project rules', () => {
     'Use `Closes #NNN` in PR descriptions',
     // Environment
     'pnpm only',
-    'Windows 11 + Git Bash',
     'TypeScript strict mode',
     'NEVER put secrets in config files',
     // Code Style


### PR DESCRIPTION
## Context

Operator-initiated redaction (2026-06-10), relayed via strategy dispatch. Go-forward only — history stays; severity does not justify a rewrite. The larger public-floor vs cohort-overlay split is design work tracked in mmnto-ai/totem-strategy#619 (under the #511 corpus-separation track); this small PR intentionally does not wait for it.

## Changes

1. **Downstream-deployment names dropped** from the non-zero-user rule in `AGENTS.md`. The load-bearing claim is kept: Totem ships in production for downstream consumers beyond this repo's dogfood, so breaking changes still need migration paths.
2. **Operator-fingerprint phrasing dropped** (host-environment and team-shape profile claims) from `AGENTS.md` and `.junie/guidelines.md`. The operational rules those lines justified are kept verbatim.
3. `config-drift.test.ts` cross-vendor consistency list loses its host-environment `SHARED_RULES` entry (it asserted the redacted literal in both canonicals).

Verified: config-drift suite 47/47 green, repo `format` clean, full-branch `totem lint` PASS (one pre-existing warning-class hit on a diff-touched line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)