### PR TITLE
chore(bots): CR auto-invocation off — all review bots on-demand

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,9 +16,14 @@ reviews:
   review_details: true
   poem: true
 
+  # On-demand only — operator ruling 2026-06-10 (mmnto-ai/totem-strategy#622):
+  # all three review bots (CR / GCA / Greptile) are opt-in per PR. Trigger
+  # stays `@coderabbitai review`. Doctrine: bot-protocols.md stack section
+  # (merged via mmnto-ai/totem-strategy#623); sensed by the `cr-on-demand`
+  # parity-manifest row.
   auto_review:
-    enabled: true
-    auto_incremental_review: true
+    enabled: false
+    auto_incremental_review: false
     drafts: false
 
   path_instructions:


### PR DESCRIPTION
## Context

Operator ruling 2026-06-10 (mmnto-ai/totem-strategy#622): the CodeRabbit auto-review baseline is retired cohort-wide — all three review bots (CR / GCA / Greptile) are on-demand, opt-in per PR. Canonical doctrine + the `cr-on-demand` parity-manifest row merged strategy-side (strategy#623); totem-status landed its half same-day. This PR is the totem half.

Exhibit behind the ruling: CR ran out its plan-tier review rate limit mid-round on strategy #620/#621 today (it also failed to review #2146 here for the same reason).

## Changes

- `.coderabbit.yaml`: `reviews.auto_review.enabled` and `auto_incremental_review` flipped to `false`, with the ruling cited inline. `drafts: false` kept as-is. Trigger stays `@coderabbitai review`; the assertive-profile trial is untouched.

The `cr-on-demand` parity-manifest row (file-value-equality on `reviews.auto_review.enabled`) senses this once the doctor parses cohort configs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)