### PR TITLE
feat(orchestrator): backend admission contract — enrich the runOrchestrator seam additively (474 slice 3)

### DIFF
--- a/.changeset/backend-admission-contract.md
+++ b/.changeset/backend-admission-contract.md
@@ -1,0 +1,8 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+---
+
+feat(orchestrator): backend admission contract (#2102, strategy#474 slice 3).
+
+Both orchestrator seams are additively enriched with the adopted contract fields. Core gains `OutputContract` (`citationsRequired` / `verifyFallback` / `schema` — closed object), `ContextPolicy` (`budget`, validated `int().positive()`, unit: input tokens), `RunMetadata` (`caller` / `command`), an optional top-level `admission` group on the run artifact (additive 1.x — never inside `inputBundle`, so `inputHash` rerun/compare identity is untouched), the `ADMISSION_SELF_GROUNDING_AGENT` constant + `ADMISSION_CLASSES` tuple, and the inferred `BackendAdmissionClass` type. `OrchestratorInvokeOptions` and `runOrchestrator` gain six optional fields (`task`, `groundingBundle`, `backendAdmissionClass`, `contextPolicy`, `outputContract`, `runMetadata`) — providers stay pure transport (vendor payloads are byte-identical), and omitting every field is byte-identical to today. Admission is decided per RESOLVED backend before EACH invoke: a requested class above `completion_only` must be declared in the new `orchestrator.capabilities.admissionClasses` config field or the run fails loud before any tokens are spent, and a cross-provider quota fallback under an elevated class fails before the fallback invoke (primary + admission errors reported together). `groundingBundle` reconciles with `artifact.bundle` (mismatched hashes = hard ambiguous-grounding-identity error). `rerunArtifact` replays a recorded admission group + elevated class verbatim (no silent downgrade); `compareRunArtifacts` gains `sameAdmission` + `admissionDelta`. The spec and review callers now supply `backendAdmissionClass` + `runMetadata` explicitly.

--- a/docs/wiki/config-reference.md
+++ b/docs/wiki/config-reference.md
@@ -27,6 +27,14 @@ export default {
       // Route specific commands to different models
       spec: 'anthropic:claude-3-7-sonnet-latest',
     },
+    capabilities: {
+      // Backend admission classes this orchestrator is declared capable of
+      // serving ('completion_only' | 'self_grounding_agent'). Absent =
+      // ['completion_only']. A caller requesting a class above
+      // 'completion_only' that is not declared here fails before any
+      // provider invoke.
+      admissionClasses: ['completion_only'],
+    },
   },
 
   // Command-Specific Options

--- a/packages/cli/src/commands/shield.ts
+++ b/packages/cli/src/commands/shield.ts
@@ -1364,7 +1364,8 @@ export async function shieldCommand(options: ShieldOptions): Promise<void> {
   // review verdict path — every run is a future eval fixture. Per-item
   // provenance bundle (mmnto-ai/totem#2101): every retrieved item enters classed
   // similarity-only; hash + summary are DERIVED from the bundle.
-  const { calculateDeterministicHash, summarizeProvenance } = await import('@mmnto/totem');
+  const { ADMISSION_COMPLETION_ONLY, calculateDeterministicHash, summarizeProvenance } =
+    await import('@mmnto/totem');
   const { buildRetrievalGroundingBundle } = await import('../utils.js');
   const groundingBundle = buildRetrievalGroundingBundle(context);
   const content = await runOrchestrator({
@@ -1376,6 +1377,12 @@ export async function shieldCommand(options: ShieldOptions): Promise<void> {
     configRoot,
     totalResults,
     temperature: 0,
+    // Admission contract (mmnto-ai/totem#2102): the same value the slice-1
+    // constant recorded, now caller-supplied — the review verdict path is
+    // factually completion-only. `caller` is the user-facing command identity
+    // (`totem review`; `shield` is its hidden deprecated alias).
+    backendAdmissionClass: ADMISSION_COMPLETION_ONLY,
+    runMetadata: { caller: 'review' },
     artifact: {
       groundingHash: calculateDeterministicHash(groundingBundle),
       provenanceSummary: summarizeProvenance(groundingBundle),

--- a/packages/cli/src/commands/spec.ts
+++ b/packages/cli/src/commands/spec.ts
@@ -375,7 +375,8 @@ export async function specCommand(inputs: string[], options: SpecOptions): Promi
   // retrieved item enters classed similarity-only; hash + summary are DERIVED
   // from the bundle, so the attested hash is recomputable from the artifact
   // surface alone.
-  const { calculateDeterministicHash, summarizeProvenance } = await import('@mmnto/totem');
+  const { ADMISSION_COMPLETION_ONLY, calculateDeterministicHash, summarizeProvenance } =
+    await import('@mmnto/totem');
   const { buildRetrievalGroundingBundle } = await import('../utils.js');
   const groundingBundle = buildRetrievalGroundingBundle(context);
   const content = await runOrchestrator({
@@ -390,6 +391,10 @@ export async function specCommand(inputs: string[], options: SpecOptions): Promi
     // the config path) can never find them (Greptile P1 on #2114).
     configRoot: path.dirname(configPath),
     totalResults,
+    // Admission contract (mmnto-ai/totem#2102): the same value the slice-1
+    // constant recorded, now caller-supplied — spec is factually completion-only.
+    backendAdmissionClass: ADMISSION_COMPLETION_ONLY,
+    runMetadata: { caller: 'spec' },
     artifact: {
       groundingHash: calculateDeterministicHash(groundingBundle),
       provenanceSummary: summarizeProvenance(groundingBundle),

--- a/packages/cli/src/orchestrators/conformance.test.ts
+++ b/packages/cli/src/orchestrators/conformance.test.ts
@@ -336,16 +336,29 @@ describe('shell provider conformance', () => {
 
   // ─── Admission-contract transport (mmnto-ai/totem#2102) ──
 
-  it('ignores the admission transport fields — no leak into the spawned command', async () => {
+  it('ignores the admission transport fields — no leak anywhere in the spawn payload', async () => {
     const { spawn } = await import('node:child_process');
     emitSuccess('conformance-ok');
     const result = await invokeShellOrchestrator({ ...shellOpts(), ...ADMISSION_TRANSPORT });
 
     expect(result.content).toBe('conformance-ok');
-    const spawnedCmd = vi.mocked(spawn).mock.calls[0]![0] as string;
-    expect(spawnedCmd).toContain('echo');
+
+    // #2148 round-1: assert over the WHOLE spawn payload, not just the
+    // command string — normalized over node's two spawn overloads,
+    // (cmd, options) and (cmd, argv, options), so a transport value smuggled
+    // via argv, env, cwd, or any other option surfaces here too.
+    const spawnCall = vi.mocked(spawn).mock.calls[0]! as unknown[];
+    const command = spawnCall[0] as string;
+    const argv = Array.isArray(spawnCall[1]) ? (spawnCall[1] as string[]) : [];
+    const options = (Array.isArray(spawnCall[1]) ? spawnCall[2] : spawnCall[1]) ?? {};
+    const wholePayload = [command, JSON.stringify(argv), JSON.stringify(options)].join('\n');
+
+    // The legit command content still crosses the wire…
+    expect(command).toContain('echo');
+    expect(wholePayload).toContain('echo');
+    // …but none of the admission transport values appear ANYWHERE in it.
     for (const value of ['self_grounding_agent', 'conformance-task', '8000', 'citationsRequired']) {
-      expect(spawnedCmd).not.toContain(value);
+      expect(wholePayload).not.toContain(value);
     }
   });
 });

--- a/packages/cli/src/orchestrators/conformance.test.ts
+++ b/packages/cli/src/orchestrators/conformance.test.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { OrchestratorResult } from './orchestrator.js';
+import type { OrchestratorInvokeOptions, OrchestratorResult } from './orchestrator.js';
 
 // ─── Mock SDKs ──────────────────────────────────────
 
@@ -78,6 +78,20 @@ const baseOpts = {
   totemDir: '.totem',
 };
 
+/**
+ * The six admission-contract transport fields (mmnto-ai/totem#2102). Providers
+ * are pure transport: every vendor payload is built explicitly field-by-field,
+ * so supplying these must leave the vendor call byte-identical.
+ */
+const ADMISSION_TRANSPORT: Partial<OrchestratorInvokeOptions> = {
+  task: 'conformance-task',
+  groundingBundle: { items: [] },
+  backendAdmissionClass: 'self_grounding_agent',
+  contextPolicy: { budget: 8000 },
+  outputContract: { citationsRequired: true, verifyFallback: true },
+  runMetadata: { caller: 'conformance' },
+};
+
 // ─── Conformance contract assertions ────────────────
 
 function assertOrchestratorResult(result: OrchestratorResult): void {
@@ -103,6 +117,10 @@ interface SdkFixture {
   setupQuota: () => void;
   setupGenericError: () => void;
   invoke: () => Promise<OrchestratorResult>;
+  /** The mocked vendor-SDK entry point — what actually crosses the wire. */
+  vendorMock: ReturnType<typeof vi.fn>;
+  /** Invoke with extra OrchestratorInvokeOptions layered over baseOpts. */
+  invokeWith: (extra: Partial<OrchestratorInvokeOptions>) => Promise<OrchestratorResult>;
 }
 
 const sdkFixtures: SdkFixture[] = [
@@ -125,6 +143,8 @@ const sdkFixtures: SdkFixture[] = [
       mockGenerateContent.mockRejectedValueOnce(new Error('Model not found'));
     },
     invoke: () => invokeGeminiOrchestrator(baseOpts),
+    vendorMock: mockGenerateContent,
+    invokeWith: (extra) => invokeGeminiOrchestrator({ ...baseOpts, ...extra }),
   },
   {
     name: 'anthropic',
@@ -143,6 +163,8 @@ const sdkFixtures: SdkFixture[] = [
       mockCreate.mockRejectedValueOnce(new Error('invalid_api_key'));
     },
     invoke: () => invokeAnthropicOrchestrator(baseOpts),
+    vendorMock: mockCreate,
+    invokeWith: (extra) => invokeAnthropicOrchestrator({ ...baseOpts, ...extra }),
   },
   {
     name: 'openai',
@@ -160,6 +182,8 @@ const sdkFixtures: SdkFixture[] = [
       mockChatCreate.mockRejectedValueOnce(new Error('invalid_api_key'));
     },
     invoke: () => invokeOpenAIOrchestrator(baseOpts),
+    vendorMock: mockChatCreate,
+    invokeWith: (extra) => invokeOpenAIOrchestrator({ ...baseOpts, ...extra }),
   },
 ];
 
@@ -202,6 +226,23 @@ describe.each(sdkFixtures)('$name provider conformance', (fixture) => {
     fixture.setupHappy();
     const result = await fixture.invoke();
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  // ─── Admission-contract transport (mmnto-ai/totem#2102) ──
+
+  it('vendor payload is byte-identical with and without the admission transport fields', async () => {
+    fixture.setupHappy();
+    await fixture.invokeWith({});
+    fixture.setupHappy();
+    await fixture.invokeWith(ADMISSION_TRANSPORT);
+
+    const [bare] = fixture.vendorMock.mock.calls[0]!;
+    const [withTransport] = fixture.vendorMock.mock.calls[1]!;
+    expect(withTransport).toEqual(bare);
+    // None of the Totem-specific transport keys leak into the vendor payload.
+    for (const key of Object.keys(ADMISSION_TRANSPORT)) {
+      expect(withTransport).not.toHaveProperty(key);
+    }
   });
 });
 
@@ -291,5 +332,20 @@ describe('shell provider conformance', () => {
     emitSuccess('ok');
     const result = await invokeShellOrchestrator(shellOpts());
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  // ─── Admission-contract transport (mmnto-ai/totem#2102) ──
+
+  it('ignores the admission transport fields — no leak into the spawned command', async () => {
+    const { spawn } = await import('node:child_process');
+    emitSuccess('conformance-ok');
+    const result = await invokeShellOrchestrator({ ...shellOpts(), ...ADMISSION_TRANSPORT });
+
+    expect(result.content).toBe('conformance-ok');
+    const spawnedCmd = vi.mocked(spawn).mock.calls[0]![0] as string;
+    expect(spawnedCmd).toContain('echo');
+    for (const value of ['self_grounding_agent', 'conformance-task', '8000', 'citationsRequired']) {
+      expect(spawnedCmd).not.toContain(value);
+    }
   });
 });

--- a/packages/cli/src/orchestrators/orchestrator.ts
+++ b/packages/cli/src/orchestrators/orchestrator.ts
@@ -1,4 +1,11 @@
-import type { Orchestrator as OrchestratorConfig } from '@mmnto/totem';
+import type {
+  BackendAdmissionClass,
+  ContextPolicy,
+  GroundingBundle,
+  Orchestrator as OrchestratorConfig,
+  OutputContract,
+  RunMetadata,
+} from '@mmnto/totem';
 import { TotemConfigError, TotemOrchestratorError } from '@mmnto/totem';
 
 import { invokeShellOrchestrator } from './shell-orchestrator.js';
@@ -59,6 +66,27 @@ export interface OrchestratorInvokeOptions {
    * providers that support caching when `enableContextCaching` is true.
    */
   cacheTTL?: number;
+
+  // ─── Admission contract transport (mmnto-ai/totem#2102, strategy#474 slice 3) ──
+  //
+  // Providers are PURE TRANSPORT for these six fields: every vendor payload is
+  // built explicitly field-by-field, so no provider reads or acts on any of
+  // them this slice. Admission is decided in `runOrchestrator` (CLI seam);
+  // output enforcement is caller-side post-invocation (#2103) — Totem is not
+  // zero-user, so backend cooperation is never assumed.
+
+  /** Neutral task identity for routing/telemetry. Defaults to `tag` at the CLI seam — `tag` stays the UI/cache key. */
+  task?: string;
+  /** The delivered grounding identity (mmnto-ai/totem#2101), reconciled with `artifact.bundle` at the CLI seam. */
+  groundingBundle?: GroundingBundle;
+  /** Requested admission class — gated against `orchestrator.capabilities.admissionClasses` BEFORE any invoke. */
+  backendAdmissionClass?: BackendAdmissionClass;
+  /** Advisory context policy (budget unit: input tokens). Recorded, never enforced here. */
+  contextPolicy?: ContextPolicy;
+  /** Caller-declared output contract. Read by #2103 post-checks, never by providers. */
+  outputContract?: OutputContract;
+  /** Caller identity metadata, recorded verbatim into the run artifact. */
+  runMetadata?: RunMetadata;
 }
 
 /** A provider-bound function that invokes an LLM and returns the result. */

--- a/packages/cli/src/services/run-artifacts.test.ts
+++ b/packages/cli/src/services/run-artifacts.test.ts
@@ -131,6 +131,54 @@ describe('rerunArtifact', () => {
     ).rejects.toThrow();
     expect(mockedRunOrchestrator).not.toHaveBeenCalled();
   });
+
+  // ─── Admission replay (mmnto-ai/totem#2102) ──
+
+  it('replays a recorded admission group + elevated class verbatim — no silent downgrade (invariant 7)', async () => {
+    const admission = {
+      outputContract: { citationsRequired: true, verifyFallback: true },
+      contextPolicy: { budget: 16_000 },
+      runMetadata: { caller: 'spec', command: 'spec' },
+    };
+    const elevatedHash = saveRunArtifact(
+      path.join(tmpDir, '.totem'),
+      artifact({
+        backend: {
+          provider: 'gemini',
+          model: 'gemini-3.1-pro-preview',
+          qualifiedModel: 'gemini:gemini-3.1-pro-preview',
+          admissionClass: 'self_grounding_agent',
+          taskProfile: 'Spec',
+        },
+        admission,
+      }),
+    ).hash;
+
+    await rerunArtifact({ hash: elevatedHash, config: config(), cwd: tmpDir });
+
+    const call = mockedRunOrchestrator.mock.calls[0]![0];
+    expect(call.backendAdmissionClass).toBe('self_grounding_agent');
+    expect(call.outputContract).toEqual(admission.outputContract);
+    expect(call.contextPolicy).toEqual(admission.contextPolicy);
+    expect(call.runMetadata).toEqual(admission.runMetadata);
+  });
+
+  it('rerunning an artifact without an admission group stays byte-identical to today (invariant 7)', async () => {
+    await rerunArtifact({ hash: sourceHash, config: config(), cwd: tmpDir });
+
+    const call = mockedRunOrchestrator.mock.calls[0]![0] as Record<string, unknown>;
+    // None of the #2102 keys appear — a slice-1 rerun is today's call shape.
+    for (const key of [
+      'task',
+      'groundingBundle',
+      'backendAdmissionClass',
+      'contextPolicy',
+      'outputContract',
+      'runMetadata',
+    ]) {
+      expect(call).not.toHaveProperty(key);
+    }
+  });
 });
 
 describe('compareRunArtifacts', () => {
@@ -195,5 +243,53 @@ describe('compareRunArtifacts', () => {
     const a = artifact();
     const b = artifact({ output: { content: 'y', metrics: { durationMs: 1 } } });
     expect(compareRunArtifacts(a, b)).toEqual(compareRunArtifacts(a, b));
+  });
+
+  // ─── Admission comparison (mmnto-ai/totem#2102) ──
+
+  it('two slice-1 artifacts (no admission group) compare as sameAdmission with an empty delta (invariant 6)', () => {
+    const cmp = compareRunArtifacts(artifact(), artifact());
+    expect(cmp.sameAdmission).toBe(true);
+    expect(cmp.admissionDelta).toEqual([]);
+  });
+
+  it('artifacts differing only in the admission group compare sameAdmission: false with a named delta (invariant 8)', () => {
+    const a = artifact({
+      admission: { contextPolicy: { budget: 8000 }, runMetadata: { caller: 'spec' } },
+    });
+    const b = artifact({
+      admission: { contextPolicy: { budget: 16_000 }, runMetadata: { caller: 'spec' } },
+    });
+    const cmp = compareRunArtifacts(a, b);
+    expect(cmp.sameAdmission).toBe(false);
+    expect(cmp.admissionDelta).toEqual(['contextPolicy']);
+    // Everything else is untouched — the delta is admission-only and NAMED.
+    expect(cmp.sameInput).toBe(true);
+    expect(cmp.sameGrounding).toBe(true);
+    expect(cmp.sameBackend).toBe(true);
+    expect(cmp.sameOutput).toBe(true);
+  });
+
+  it('admission-group presence vs absence names every present member in the delta', () => {
+    const withGroup = artifact({
+      admission: {
+        outputContract: { citationsRequired: true },
+        runMetadata: { caller: 'spec' },
+      },
+    });
+    const cmp = compareRunArtifacts(withGroup, artifact());
+    expect(cmp.sameAdmission).toBe(false);
+    expect(cmp.admissionDelta).toEqual(expect.arrayContaining(['outputContract', 'runMetadata']));
+    expect(cmp.admissionDelta).not.toContain('contextPolicy');
+  });
+
+  it('identical admission groups compare sameAdmission: true', () => {
+    const admission = {
+      outputContract: { citationsRequired: true, verifyFallback: false },
+      contextPolicy: { budget: 4096 },
+    };
+    const cmp = compareRunArtifacts(artifact({ admission }), artifact({ admission }));
+    expect(cmp.sameAdmission).toBe(true);
+    expect(cmp.admissionDelta).toEqual([]);
   });
 });

--- a/packages/cli/src/services/run-artifacts.ts
+++ b/packages/cli/src/services/run-artifacts.ts
@@ -165,8 +165,24 @@ const BACKEND_FIELDS = [
   'temperature',
 ] as const;
 
-/** Admission members compared one by one (mmnto-ai/totem#2102) — mirrors {@link BACKEND_FIELDS}. */
-const ADMISSION_FIELDS = ['outputContract', 'contextPolicy', 'runMetadata'] as const;
+/** The artifact `admission` group's member names — the closed key union the schema defines. */
+type AdmissionField = keyof NonNullable<RunArtifact['admission']>;
+
+/**
+ * Admission members compared one by one (mmnto-ai/totem#2102) — mirrors
+ * {@link BACKEND_FIELDS}. Compile-time exhaustive against the artifact
+ * `admission` group (mmnto-ai/totem#2148 round-1): `satisfies Record<AdmissionField, true>`
+ * fails tsc when the schema gains a member this map doesn't name (missing
+ * key) AND when this map names a member the schema lost (excess key) — a
+ * schema field can never silently fall out of the compare delta.
+ */
+const ADMISSION_FIELD_SET = {
+  outputContract: true,
+  contextPolicy: true,
+  runMetadata: true,
+} as const satisfies Record<AdmissionField, true>;
+
+const ADMISSION_FIELDS = Object.keys(ADMISSION_FIELD_SET) as readonly AdmissionField[];
 
 /**
  * Structural member equality via the deterministic hash (key-order

--- a/packages/cli/src/services/run-artifacts.ts
+++ b/packages/cli/src/services/run-artifacts.ts
@@ -19,7 +19,12 @@
 import * as path from 'node:path';
 
 import type { RunArtifact, TotemConfig } from '@mmnto/totem';
-import { calculateDeterministicHash, loadRunArtifact, TotemOrchestratorError } from '@mmnto/totem';
+import {
+  ADMISSION_COMPLETION_ONLY,
+  calculateDeterministicHash,
+  loadRunArtifact,
+  TotemOrchestratorError,
+} from '@mmnto/totem';
 
 import { runOrchestrator } from '../utils.js';
 
@@ -72,6 +77,24 @@ export async function rerunArtifact(opts: RerunArtifactOptions): Promise<RerunAr
     ...(source.backend.temperature !== undefined
       ? { temperature: source.backend.temperature }
       : {}),
+    // ── Admission replay (mmnto-ai/totem#2102) ──
+    // The recorded contract replays verbatim: an elevated class re-enters the
+    // admission gate (a `self_grounding_agent` rerun must fail loud when the
+    // capability is no longer declared, never silently downgrade — Tenet 4).
+    // `completion_only` stays omitted: the default IS the constant, keeping a
+    // slice-1 rerun byte-identical to today (invariant 7).
+    ...(source.backend.admissionClass !== ADMISSION_COMPLETION_ONLY
+      ? { backendAdmissionClass: source.backend.admissionClass }
+      : {}),
+    ...(source.admission?.outputContract !== undefined
+      ? { outputContract: source.admission.outputContract }
+      : {}),
+    ...(source.admission?.contextPolicy !== undefined
+      ? { contextPolicy: source.admission.contextPolicy }
+      : {}),
+    ...(source.admission?.runMetadata !== undefined
+      ? { runMetadata: source.admission.runMetadata }
+      : {}),
     artifact: {
       // The rerun makes no new grounding claim — identity carried verbatim,
       // including the per-item bundle when the source artifact has one (mmnto-ai/totem#2101).
@@ -114,6 +137,10 @@ export interface RunArtifactComparison {
   sameBackend: boolean;
   /** Backend field names that differ (empty when sameBackend). */
   backendDelta: string[];
+  /** Admission-group equality (mmnto-ai/totem#2102) — presence AND content. */
+  sameAdmission: boolean;
+  /** Admission member names that differ (empty when sameAdmission). */
+  admissionDelta: string[];
   /** Byte equality of output content. */
   sameOutput: boolean;
   outputDelta: {
@@ -138,6 +165,19 @@ const BACKEND_FIELDS = [
   'temperature',
 ] as const;
 
+/** Admission members compared one by one (mmnto-ai/totem#2102) — mirrors {@link BACKEND_FIELDS}. */
+const ADMISSION_FIELDS = ['outputContract', 'contextPolicy', 'runMetadata'] as const;
+
+/**
+ * Structural member equality via the deterministic hash (key-order
+ * independent — the same identity primitive the artifacts use). Absent on
+ * both sides is equal; absent on one side is a NAMED delta, never hidden.
+ */
+function sameAdmissionMember(a: object | undefined, b: object | undefined): boolean {
+  if (a === undefined || b === undefined) return a === b;
+  return calculateDeterministicHash(a) === calculateDeterministicHash(b);
+}
+
 /** Numeric delta honoring honest-absent: null in, null out — never NaN. */
 function tokenDelta(a: number | null | undefined, b: number | null | undefined): number | null {
   if (typeof a !== 'number' || typeof b !== 'number') return null;
@@ -150,6 +190,10 @@ function tokenDelta(a: number | null | undefined, b: number | null | undefined):
  */
 export function compareRunArtifacts(a: RunArtifact, b: RunArtifact): RunArtifactComparison {
   const backendDelta = BACKEND_FIELDS.filter((field) => a.backend[field] !== b.backend[field]);
+
+  const admissionDelta = ADMISSION_FIELDS.filter(
+    (field) => !sameAdmissionMember(a.admission?.[field], b.admission?.[field]),
+  );
 
   const sameOutput = a.output.content === b.output.content;
   // Short-circuit the second sha256 pass when the contents are byte-identical
@@ -164,6 +208,8 @@ export function compareRunArtifacts(a: RunArtifact, b: RunArtifact): RunArtifact
       a.grounding.provenanceSummary === b.grounding.provenanceSummary,
     sameBackend: backendDelta.length === 0,
     backendDelta,
+    sameAdmission: admissionDelta.length === 0,
+    admissionDelta,
     sameOutput,
     outputDelta: { contentHashA, contentHashB },
     metricsDelta: {

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -1459,3 +1459,421 @@ describe('runOrchestrator artifact emission (#2100)', { timeout: 15_000 }, () =>
     expect(artifact.output.content).toBe('fallback result');
   });
 });
+
+// ─── runOrchestrator admission contract (mmnto-ai/totem#2102) ──
+
+describe('runOrchestrator admission contract (#2102)', { timeout: 15_000 }, () => {
+  let tmpDir: string;
+
+  const GROUNDING_HASH = 'b'.repeat(64);
+
+  function artifactRequest(onEmitted?: (hash: string, artifactPath: string) => void) {
+    return {
+      groundingHash: GROUNDING_HASH,
+      provenanceSummary: 'similarity-only',
+      ...(onEmitted !== undefined ? { onEmitted } : {}),
+    };
+  }
+
+  /** Orchestrator config WITHOUT a declared capability (today's default). */
+  function plainConfig(overrides?: Partial<TotemConfig>): TotemConfig {
+    return {
+      targets: [{ glob: '**/*.ts', type: 'code', strategy: 'typescript-ast' }],
+      orchestrator: {
+        provider: 'gemini',
+        defaultModel: 'gemini-3-flash-preview',
+      },
+      totemDir: '.totem',
+      lanceDir: '.lancedb',
+      ignorePatterns: [],
+      contextWarningThreshold: 40_000,
+      ...overrides,
+    } as TotemConfig;
+  }
+
+  /** Orchestrator config that DECLARES self_grounding_agent capability. */
+  function declaredConfig(orchestratorOverrides?: Record<string, unknown>): TotemConfig {
+    const base = plainConfig();
+    return {
+      ...base,
+      orchestrator: {
+        ...base.orchestrator,
+        capabilities: { admissionClasses: ['self_grounding_agent'] },
+        ...orchestratorOverrides,
+      },
+    } as TotemConfig;
+  }
+
+  function runsDirPath(): string {
+    return path.join(tmpDir, '.totem', 'artifacts', 'runs');
+  }
+
+  function readArtifact(hash: string) {
+    const file = path.join(runsDirPath(), `${hash}.json`);
+    return RunArtifactSchema.parse(JSON.parse(fs.readFileSync(file, 'utf-8')));
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-admission-'));
+    vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+    const mockInvoke = vi.fn().mockResolvedValue({
+      content: 'mock result',
+      inputTokens: 100,
+      outputTokens: 50,
+      durationMs: 500,
+    });
+    mockedCreateOrchestrator.mockReturnValue(mockInvoke);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanTmpDir(tmpDir);
+  });
+
+  it('omitting every new field yields a byte-identical invoke payload and identical artifact backend (invariant 1)', async () => {
+    const emitted: string[] = [];
+    await runOrchestrator({
+      prompt: 'test prompt',
+      tag: 'Spec',
+      options: { fresh: true },
+      config: plainConfig(),
+      cwd: tmpDir,
+      artifact: artifactRequest((hash) => emitted.push(hash)),
+    });
+
+    // Byte-identical provider payload: the EXACT pre-#2102 key set, no
+    // admission transport keys of any kind.
+    const invoke = mockedCreateOrchestrator.mock.results[0]!.value;
+    expect(invoke.mock.calls[0]![0]).toStrictEqual({
+      prompt: 'test prompt',
+      model: 'gemini-3-flash-preview',
+      cwd: tmpDir,
+      tag: 'Spec',
+      totemDir: '.totem',
+      temperature: undefined,
+    });
+
+    // Identical artifact backend — decided by DEFAULT now, not constant.
+    const artifact = readArtifact(emitted[0]!);
+    expect(artifact.backend.admissionClass).toBe('completion_only');
+    expect(artifact.backend.taskProfile).toBe('Spec');
+    expect(artifact.admission).toBeUndefined();
+  });
+
+  it('a requested-but-undeclared admission class fails loud before any invoke — no tokens, no artifact (invariant 2)', async () => {
+    await expect(
+      runOrchestrator({
+        prompt: 'elevated request',
+        tag: 'Spec',
+        options: { fresh: true },
+        config: plainConfig(), // no capabilities declared
+        cwd: tmpDir,
+        backendAdmissionClass: 'self_grounding_agent',
+        artifact: artifactRequest(),
+      }),
+    ).rejects.toThrow(/self_grounding_agent/);
+
+    const invoke = mockedCreateOrchestrator.mock.results[0]?.value;
+    if (invoke !== undefined) {
+      expect(invoke).not.toHaveBeenCalled();
+    }
+    expect(fs.existsSync(path.join(tmpDir, '.totem', 'artifacts'))).toBe(false);
+  });
+
+  it('the admitted class lands in backend.admissionClass verbatim; taskProfile records task ?? tag (invariant 3)', async () => {
+    const emitted: string[] = [];
+    await runOrchestrator({
+      prompt: 'admitted run',
+      tag: 'Spec',
+      options: { fresh: true },
+      config: declaredConfig(),
+      cwd: tmpDir,
+      backendAdmissionClass: 'self_grounding_agent',
+      task: 'eval-fixture',
+      artifact: artifactRequest((hash) => emitted.push(hash)),
+    });
+
+    const artifact = readArtifact(emitted[0]!);
+    expect(artifact.backend.admissionClass).toBe('self_grounding_agent');
+    expect(artifact.backend.taskProfile).toBe('eval-fixture');
+  });
+
+  it('inputHash is unaffected by every new contract field (invariant 4)', async () => {
+    const emitted: string[] = [];
+    const shared = {
+      prompt: 'identical prompt',
+      tag: 'Spec',
+      options: { fresh: true },
+      config: declaredConfig(),
+      cwd: tmpDir,
+    };
+    await runOrchestrator({
+      ...shared,
+      artifact: artifactRequest((hash) => emitted.push(hash)),
+    });
+    await runOrchestrator({
+      ...shared,
+      task: 'eval-fixture',
+      backendAdmissionClass: 'self_grounding_agent',
+      contextPolicy: { budget: 8000 },
+      outputContract: { citationsRequired: true },
+      runMetadata: { caller: 'test' },
+      artifact: artifactRequest((hash) => emitted.push(hash)),
+    });
+
+    const bare = readArtifact(emitted[0]!);
+    const hydrated = readArtifact(emitted[1]!);
+    expect(hydrated.inputHash).toBe(bare.inputHash);
+  });
+
+  it('a declared self_grounding_agent run whose quota fallback resolves cross-provider fails BEFORE the fallback invoke (invariant 5)', async () => {
+    const quotaErr = new Error('429 quota exhausted');
+    quotaErr.name = 'QuotaError';
+    const mockInvoke = vi.fn().mockRejectedValueOnce(quotaErr).mockResolvedValue({
+      content: 'fallback result',
+      durationMs: 300,
+    });
+    mockedCreateOrchestrator.mockReturnValue(mockInvoke);
+
+    const onEmitted = vi.fn();
+    await expect(
+      runOrchestrator({
+        prompt: 'elevated quota-bound run',
+        tag: 'Spec',
+        options: { fresh: true },
+        config: declaredConfig({ fallbackModel: 'anthropic:claude-sonnet-4-6' }),
+        cwd: tmpDir,
+        backendAdmissionClass: 'self_grounding_agent',
+        artifact: { ...artifactRequest(), onEmitted },
+      }),
+      // Primary error + admission error reported together.
+    ).rejects.toThrow(/429 quota exhausted[\s\S]*self_grounding_agent/);
+
+    // Exactly ONE invoke: the primary. The cross-provider fallback was never invoked.
+    expect(mockInvoke).toHaveBeenCalledTimes(1);
+    expect(onEmitted).not.toHaveBeenCalled();
+  });
+
+  it('a same-provider quota fallback under an elevated class is admitted', async () => {
+    const quotaErr = new Error('429 quota exhausted');
+    quotaErr.name = 'QuotaError';
+    const mockInvoke = vi.fn().mockRejectedValueOnce(quotaErr).mockResolvedValue({
+      content: 'fallback result',
+      durationMs: 300,
+    });
+    mockedCreateOrchestrator.mockReturnValue(mockInvoke);
+
+    const emitted: string[] = [];
+    const result = await runOrchestrator({
+      prompt: 'elevated quota-bound run',
+      tag: 'Spec',
+      options: { fresh: true },
+      config: declaredConfig({
+        defaultModel: 'gemini-3.1-pro-preview',
+        fallbackModel: 'gemini-3-flash-preview',
+      }),
+      cwd: tmpDir,
+      backendAdmissionClass: 'self_grounding_agent',
+      artifact: artifactRequest((hash) => emitted.push(hash)),
+    });
+
+    expect(result).toBe('fallback result');
+    const artifact = readArtifact(emitted[0]!);
+    expect(artifact.backend.admissionClass).toBe('self_grounding_agent');
+    expect(artifact.backend.qualifiedModel).toBe('gemini-3-flash-preview');
+  });
+
+  it('records the admission group only when at least one member is supplied', async () => {
+    const emitted: string[] = [];
+    const admission = {
+      outputContract: { citationsRequired: true, verifyFallback: true },
+      contextPolicy: { budget: 16_000 },
+      runMetadata: { caller: 'test', command: 'spec' },
+    };
+    await runOrchestrator({
+      prompt: 'contract run',
+      tag: 'Spec',
+      options: { fresh: true },
+      config: plainConfig(),
+      cwd: tmpDir,
+      ...admission,
+      artifact: artifactRequest((hash) => emitted.push(hash)),
+    });
+    // Class-only run: backendAdmissionClass is recorded in backend, NOT the group.
+    await runOrchestrator({
+      prompt: 'class-only run',
+      tag: 'Spec',
+      options: { fresh: true },
+      config: declaredConfig(),
+      cwd: tmpDir,
+      backendAdmissionClass: 'self_grounding_agent',
+      artifact: artifactRequest((hash) => emitted.push(hash)),
+    });
+
+    const withGroup = readArtifact(emitted[0]!);
+    expect(withGroup.admission).toEqual(admission);
+
+    const classOnlyRaw = fs.readFileSync(path.join(runsDirPath(), `${emitted[1]!}.json`), 'utf-8');
+    expect(JSON.parse(classOnlyRaw)).not.toHaveProperty('admission');
+  });
+
+  it('threads the supplied transport fields to the provider invoke verbatim', async () => {
+    await runOrchestrator({
+      prompt: 'threaded run',
+      tag: 'Spec',
+      options: { fresh: true },
+      config: declaredConfig(),
+      cwd: tmpDir,
+      task: 'eval-fixture',
+      backendAdmissionClass: 'self_grounding_agent',
+      contextPolicy: { budget: 8000 },
+      outputContract: { citationsRequired: true },
+      runMetadata: { caller: 'test' },
+    });
+
+    const invoke = mockedCreateOrchestrator.mock.results[0]!.value;
+    expect(invoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        task: 'eval-fixture',
+        backendAdmissionClass: 'self_grounding_agent',
+        contextPolicy: { budget: 8000 },
+        outputContract: { citationsRequired: true },
+        runMetadata: { caller: 'test' },
+      }),
+    );
+  });
+
+  it('mismatched groundingBundle and artifact.bundle is an ambiguous grounding identity — hard error before invoke', async () => {
+    const bundleA = {
+      items: [
+        {
+          provenance: 'similarity-only',
+          contentHash: 'c'.repeat(64),
+          sourceType: 'code',
+          filePath: 'src/a.ts',
+        },
+      ],
+    };
+    const bundleB = {
+      items: [
+        {
+          provenance: 'similarity-only',
+          contentHash: 'd'.repeat(64),
+          sourceType: 'code',
+          filePath: 'src/b.ts',
+        },
+      ],
+    };
+
+    await expect(
+      runOrchestrator({
+        prompt: 'ambiguous run',
+        tag: 'Spec',
+        options: { fresh: true },
+        config: plainConfig(),
+        cwd: tmpDir,
+        groundingBundle: bundleA,
+        artifact: {
+          groundingHash: calculateDeterministicHash(bundleB),
+          provenanceSummary: summarizeProvenance(bundleB),
+          bundle: bundleB,
+        },
+      }),
+    ).rejects.toThrow(/ambiguous grounding identity/i);
+
+    const invoke = mockedCreateOrchestrator.mock.results[0]?.value;
+    if (invoke !== undefined) {
+      expect(invoke).not.toHaveBeenCalled();
+    }
+  });
+
+  it('a supplied groundingBundle flows into the artifact bundle role when artifact.bundle is absent', async () => {
+    const bundle = {
+      items: [
+        {
+          provenance: 'similarity-only',
+          contentHash: 'c'.repeat(64),
+          sourceType: 'code',
+          filePath: 'src/x.ts',
+        },
+      ],
+    };
+    const emitted: string[] = [];
+    await runOrchestrator({
+      prompt: 'bundle-flow run',
+      tag: 'Spec',
+      options: { fresh: true },
+      config: plainConfig(),
+      cwd: tmpDir,
+      groundingBundle: bundle,
+      artifact: {
+        groundingHash: calculateDeterministicHash(bundle),
+        provenanceSummary: summarizeProvenance(bundle),
+        onEmitted: (hash) => emitted.push(hash),
+      },
+    });
+
+    const artifact = readArtifact(emitted[0]!);
+    expect(artifact.grounding.bundle).toEqual(bundle);
+  });
+
+  it('a supplied artifact.bundle flows into the invoke-seam groundingBundle role', async () => {
+    const bundle = {
+      items: [
+        {
+          provenance: 'similarity-only',
+          contentHash: 'c'.repeat(64),
+          sourceType: 'code',
+          filePath: 'src/x.ts',
+        },
+      ],
+    };
+    await runOrchestrator({
+      prompt: 'bundle-flow run',
+      tag: 'Spec',
+      options: { fresh: true },
+      config: plainConfig(),
+      cwd: tmpDir,
+      artifact: {
+        groundingHash: calculateDeterministicHash(bundle),
+        provenanceSummary: summarizeProvenance(bundle),
+        bundle,
+      },
+    });
+
+    const invoke = mockedCreateOrchestrator.mock.results[0]!.value;
+    expect(invoke).toHaveBeenCalledWith(expect.objectContaining({ groundingBundle: bundle }));
+  });
+
+  it('matching groundingBundle and artifact.bundle reconcile cleanly (no false ambiguity)', async () => {
+    const bundle = {
+      items: [
+        {
+          provenance: 'similarity-only',
+          contentHash: 'c'.repeat(64),
+          sourceType: 'code',
+          filePath: 'src/x.ts',
+        },
+      ],
+    };
+    const emitted: string[] = [];
+    const result = await runOrchestrator({
+      prompt: 'reconciled run',
+      tag: 'Spec',
+      options: { fresh: true },
+      config: plainConfig(),
+      cwd: tmpDir,
+      groundingBundle: bundle,
+      artifact: {
+        groundingHash: calculateDeterministicHash(bundle),
+        provenanceSummary: summarizeProvenance(bundle),
+        bundle,
+        onEmitted: (hash) => emitted.push(hash),
+      },
+    });
+
+    expect(result).toBe('mock result');
+    expect(readArtifact(emitted[0]!).grounding.bundle).toEqual(bundle);
+  });
+});

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -1627,6 +1627,33 @@ describe('runOrchestrator admission contract (#2102)', { timeout: 15_000 }, () =
     expect(hydrated.inputHash).toBe(bare.inputHash);
   });
 
+  it('a provider-qualified PRIMARY that resolves cross-provider under an elevated class is denied BEFORE the invoke', async () => {
+    // #2148 round-1 (CR major + Greptile P2): the capability declaration is
+    // config-level (base-provider scoped), but `resolveOrchestrator` can route
+    // a provider-qualified primary model to a DIFFERENT provider — the gate
+    // must hold per RESOLVED backend on the primary path too, not just the
+    // quota-fallback path.
+    const onEmitted = vi.fn();
+    await expect(
+      runOrchestrator({
+        prompt: 'cross-provider elevated primary',
+        tag: 'Spec',
+        options: { fresh: true, model: 'anthropic:claude-sonnet-4-6' },
+        config: declaredConfig(), // gemini base config WITH self_grounding_agent declared
+        cwd: tmpDir,
+        backendAdmissionClass: 'self_grounding_agent',
+        artifact: { ...artifactRequest(), onEmitted },
+      }),
+    ).rejects.toThrow(/cross-provider routing is not admitted/i);
+
+    // ZERO invokes: every orchestrator the mocked factory handed out stayed idle.
+    for (const created of mockedCreateOrchestrator.mock.results) {
+      expect(created.value).not.toHaveBeenCalled();
+    }
+    expect(onEmitted).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(tmpDir, '.totem', 'artifacts'))).toBe(false);
+  });
+
   it('a declared self_grounding_agent run whose quota fallback resolves cross-provider fails BEFORE the fallback invoke (invariant 5)', async () => {
     const quotaErr = new Error('429 quota exhausted');
     quotaErr.name = 'QuotaError';
@@ -1816,6 +1843,48 @@ describe('runOrchestrator admission contract (#2102)', { timeout: 15_000 }, () =
 
     const artifact = readArtifact(emitted[0]!);
     expect(artifact.grounding.bundle).toEqual(bundle);
+    // #2148 round-1: the recorded hash must recompute from the recorded
+    // bundle — the adopted-bundle path verifies the attested hash (never
+    // recomputes it) before recording.
+    expect(artifact.grounding.hash).toBe(calculateDeterministicHash(artifact.grounding.bundle));
+  });
+
+  it('an adopted groundingBundle whose hash mismatches artifact.groundingHash is rejected before invoke (verify-and-reject)', async () => {
+    // #2148 round-1: with `artifact.bundle` omitted, the artifact records the
+    // ADOPTED `opts.groundingBundle` but used to trust `artifact.groundingHash`
+    // verbatim — persisting a record whose grounding.hash does not match its
+    // grounding.bundle. The seam records, never re-derives, so the fix is
+    // verify-and-reject, not recompute.
+    const bundle = {
+      items: [
+        {
+          provenance: 'similarity-only',
+          contentHash: 'c'.repeat(64),
+          sourceType: 'code',
+          filePath: 'src/x.ts',
+        },
+      ],
+    };
+    await expect(
+      runOrchestrator({
+        prompt: 'forged grounding hash',
+        tag: 'Spec',
+        options: { fresh: true },
+        config: plainConfig(),
+        cwd: tmpDir,
+        groundingBundle: bundle,
+        artifact: {
+          groundingHash: 'e'.repeat(64), // does NOT recompute from the adopted bundle
+          provenanceSummary: 'similarity-only:1',
+        },
+      }),
+    ).rejects.toThrow(/ambiguous grounding identity/i);
+
+    const invoke = mockedCreateOrchestrator.mock.results[0]?.value;
+    if (invoke !== undefined) {
+      expect(invoke).not.toHaveBeenCalled();
+    }
+    expect(fs.existsSync(path.join(tmpDir, '.totem', 'artifacts'))).toBe(false);
   });
 
   it('a supplied artifact.bundle flows into the invoke-seam groundingBundle role', async () => {
@@ -1875,5 +1944,53 @@ describe('runOrchestrator admission contract (#2102)', { timeout: 15_000 }, () =
 
     expect(result).toBe('mock result');
     expect(readArtifact(emitted[0]!).grounding.bundle).toEqual(bundle);
+  });
+
+  // ─── Response-cache key carries the contract (#2148 round-1) ──
+
+  it('absent contract fields leave the response-cache key byte-identical to the legacy shape (invariant 1 — legacy keys stay warm)', async () => {
+    await runOrchestrator({
+      prompt: 'cache key probe',
+      tag: 'Spec', // Spec carries a default response-cache TTL
+      options: {},
+      config: plainConfig(),
+      cwd: tmpDir,
+    });
+
+    // The exact legacy construction (see the null-byte delimiter test above):
+    // prompt, systemPrompt, qualifiedModel — and NOTHING else when every
+    // contract field is absent.
+    const legacyHash = crypto
+      .createHash('sha256')
+      .update('cache key probe')
+      .update('\0')
+      .update('')
+      .update('\0')
+      .update('gemini-3-flash-preview')
+      .digest('hex')
+      .slice(0, 16);
+    expect(fs.existsSync(path.join(tmpDir, '.totem', 'cache', `spec-${legacyHash}.json`))).toBe(
+      true,
+    );
+  });
+
+  it('contract fields produce a distinct response-cache key, and differing in ONE contract field differs again (no aliasing)', async () => {
+    const shared = {
+      prompt: 'aliasing probe',
+      tag: 'Spec', // Spec carries a default response-cache TTL
+      options: {},
+      config: plainConfig(),
+      cwd: tmpDir,
+    };
+    await runOrchestrator(shared); // legacy-shaped
+    await runOrchestrator({ ...shared, contextPolicy: { budget: 8000 } });
+    await runOrchestrator({ ...shared, contextPolicy: { budget: 16_000 } });
+
+    // Three ACTUAL invokes — a contract-bearing call must never be served the
+    // legacy call's cached payload (or another contract's) as a replay.
+    const invoke = mockedCreateOrchestrator.mock.results[0]!.value;
+    expect(invoke).toHaveBeenCalledTimes(3);
+    // …and three distinct cache keys on disk.
+    expect(fs.readdirSync(path.join(tmpDir, '.totem', 'cache'))).toHaveLength(3);
   });
 });

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -387,11 +387,32 @@ const DEFAULT_TTLS: Record<string, number> = {
 };
 
 /**
+ * The admission-contract fields that participate in the response-cache key
+ * (mmnto-ai/totem#2102, #2148 round-1): two calls differing solely in these
+ * fields must never alias to one cached payload. `groundingBundle` is the
+ * RECONCILED bundle (the transported identity), not just `opts.groundingBundle`.
+ */
+interface ResponseCacheContract {
+  groundingBundle?: GroundingBundle;
+  backendAdmissionClass?: BackendAdmissionClass;
+  outputContract?: OutputContract;
+  contextPolicy?: ContextPolicy;
+  runMetadata?: RunMetadata;
+}
+
+/**
  * Build the response-cache key for the orthogonal command-level cache (#52).
  *
  * Hashes prompt, systemPrompt, and the qualifiedModel string with `\0` byte
  * delimiters between every field so boundary-case inputs (e.g. `prompt="AB",
  * systemPrompt=""` vs `prompt="A", systemPrompt="B"`) produce distinct keys.
+ *
+ * When at least one admission-contract field is present (mmnto-ai/totem#2148
+ * round-1), a deterministic serialization of the contract joins the hash
+ * input so calls differing only in contract fields key separately. When
+ * every field is absent the hash input is BYTE-IDENTICAL to the legacy shape
+ * — invariant 1 (the mmnto/totem#1291 additive precedent): legacy callers'
+ * cache entries stay warm.
  *
  * Used by both the read path (lookup) and write path (store) inside
  * `runOrchestrator` to guarantee the keys are identical — extracted as a
@@ -404,16 +425,34 @@ function buildResponseCacheHash(
   prompt: string,
   systemPrompt: string | undefined,
   qualifiedModel: string,
+  contract?: ResponseCacheContract,
 ): string {
-  return crypto
+  const hash = crypto
     .createHash('sha256')
     .update(prompt)
     .update('\0')
     .update(systemPrompt ?? '')
     .update('\0')
-    .update(qualifiedModel)
-    .digest('hex')
-    .slice(0, 16);
+    .update(qualifiedModel);
+  // Conditional spreads: an absent field contributes NO key, so the
+  // all-absent contract is an empty object and the legacy branch below.
+  const contractFields = {
+    ...(contract?.groundingBundle !== undefined
+      ? { groundingBundleHash: calculateDeterministicHash(contract.groundingBundle) }
+      : {}),
+    ...(contract?.backendAdmissionClass !== undefined
+      ? { backendAdmissionClass: contract.backendAdmissionClass }
+      : {}),
+    ...(contract?.outputContract !== undefined ? { outputContract: contract.outputContract } : {}),
+    ...(contract?.contextPolicy !== undefined ? { contextPolicy: contract.contextPolicy } : {}),
+    ...(contract?.runMetadata !== undefined ? { runMetadata: contract.runMetadata } : {}),
+  };
+  if (Object.keys(contractFields).length > 0) {
+    // calculateDeterministicHash is key-order independent — the same identity
+    // primitive the artifacts use, so the serialization is deterministic.
+    hash.update('\0').update(calculateDeterministicHash(contractFields));
+  }
+  return hash.digest('hex').slice(0, 16);
 }
 
 /**
@@ -474,10 +513,16 @@ export function buildRetrievalGroundingBundle(context: {
 /**
  * Admission gate (mmnto-ai/totem#2102, strategy#474 slice 3): a requested
  * class above `completion_only` must be declared in
- * `orchestrator.capabilities.admissionClasses`. Decided per RESOLVED backend
- * before EACH invoke (primary AND quota-fallback) and fails BEFORE any
- * tokens are spent — a denied run emits no artifact. Declaration is a
- * capability claim only; output enforcement is caller-side (#2103).
+ * `orchestrator.capabilities.admissionClasses`. The declaration is
+ * CONFIG-LEVEL — scoped to the base provider — so this check alone is not
+ * per-resolved-backend: `resolveOrchestrator` can route a provider-qualified
+ * model (primary or fallback) to a different provider. It is therefore
+ * paired with a cross-provider denial on BOTH paths (mmnto-ai/totem#2148
+ * round-1 added the primary's): an elevated class whose resolved provider differs from the
+ * base config's fails loud. Together they decide admission per RESOLVED
+ * backend before EACH invoke, BEFORE any tokens are spent — a denied run
+ * emits no artifact. Declaration is a capability claim only; output
+ * enforcement is caller-side (mmnto-ai/totem#2103).
  */
 function assertAdmissionDeclared(
   requested: BackendAdmissionClass,
@@ -606,12 +651,44 @@ export async function runOrchestrator(opts: {
       'CONFIG_INVALID',
     );
   }
+  // mmnto-ai/totem#2148 round-1, VERIFY-AND-REJECT (never recompute — this seam records,
+  // never re-derives): when the artifact's bundle role is adopted from
+  // `opts.groundingBundle` (no `artifact.bundle` supplied), the caller-attested
+  // `artifact.groundingHash` must recompute from that adopted bundle —
+  // otherwise the artifact would persist a grounding.hash that does not match
+  // its recorded grounding.bundle.
+  if (
+    opts.artifact !== undefined &&
+    opts.groundingBundle !== undefined &&
+    opts.artifact.bundle === undefined &&
+    calculateDeterministicHash(opts.groundingBundle) !== opts.artifact.groundingHash
+  ) {
+    throw new TotemConfigError(
+      'Ambiguous grounding identity: artifact.groundingHash does not match the deterministic hash of the adopted groundingBundle.',
+      'Supply artifact.groundingHash as calculateDeterministicHash(groundingBundle), or make them agree.',
+      'CONFIG_INVALID',
+    );
+  }
   const groundingBundle = opts.groundingBundle ?? opts.artifact?.bundle;
 
   // #2102: caller-supplied wins over the defaults; the defaults reproduce
   // today's behavior exactly (taskProfile = tag, class = completion_only).
   const requestedAdmissionClass = opts.backendAdmissionClass ?? ADMISSION_COMPLETION_ONLY;
   const taskProfile = opts.task ?? tag;
+
+  // mmnto-ai/totem#2148 round-1: the contract fields participating in the response-cache
+  // key. Built ONCE from the caller-supplied (not defaulted) values plus the
+  // reconciled bundle, and passed to BOTH the read and write paths so the
+  // keys stay identical. All-absent = empty object = legacy key (invariant 1).
+  const cacheContract: ResponseCacheContract = {
+    ...(groundingBundle !== undefined ? { groundingBundle } : {}),
+    ...(opts.backendAdmissionClass !== undefined
+      ? { backendAdmissionClass: opts.backendAdmissionClass }
+      : {}),
+    ...(opts.outputContract !== undefined ? { outputContract: opts.outputContract } : {}),
+    ...(opts.contextPolicy !== undefined ? { contextPolicy: opts.contextPolicy } : {}),
+    ...(opts.runMetadata !== undefined ? { runMetadata: opts.runMetadata } : {}),
+  };
 
   const baseProvider = config.orchestrator.provider;
   const baseInvoke = createOrchestrator(config.orchestrator);
@@ -637,6 +714,23 @@ export async function runOrchestrator(opts: {
   // cache: a denied class must not be served a replay either). No tokens are
   // spent and no artifact is emitted for a denied run.
   assertAdmissionDeclared(requestedAdmissionClass, config.orchestrator);
+  // mmnto-ai/totem#2148 round-1: `resolveOrchestrator` can route a provider-qualified
+  // PRIMARY model to a DIFFERENT provider than the base config, and the
+  // capability declaration is config-level (base-provider scoped) — so an
+  // elevated class that passed the declaration check must still be denied
+  // when the primary resolves cross-provider, same conservative slice-3 rule
+  // as the quota-fallback path below. Per-provider capability declarations
+  // are the future relaxation.
+  if (
+    requestedAdmissionClass !== ADMISSION_COMPLETION_ONLY &&
+    resolved.parsed.provider !== baseProvider
+  ) {
+    throw new TotemConfigError(
+      `Admission denied: model '${rawModel}' resolves to provider '${resolved.parsed.provider}' (base config: '${baseProvider}') while admission class '${requestedAdmissionClass}' is requested — cross-provider routing is not admitted above '${ADMISSION_COMPLETION_ONLY}' until per-provider capability declarations exist.`,
+      'Use a model on the base provider, or drop the elevated backendAdmissionClass request.',
+      'CONFIG_INVALID',
+    );
+  }
 
   log.info(tag, `Model: ${bold(rawModel)}`);
 
@@ -645,7 +739,7 @@ export async function runOrchestrator(opts: {
   let cachePath = '';
 
   if (useCache) {
-    const hash = buildResponseCacheHash(prompt, systemPrompt, qualifiedModel);
+    const hash = buildResponseCacheHash(prompt, systemPrompt, qualifiedModel, cacheContract);
     const cacheDir = path.join(configRoot, config.totemDir, 'cache');
     cachePath = path.join(cacheDir, `${tagKey}-${hash}.json`);
 
@@ -823,7 +917,7 @@ export async function runOrchestrator(opts: {
       // resolution that may have happened above. Uses the same helper as the
       // read path so the keys are guaranteed identical (mmnto/totem#1291
       // mmnto/totem#1292 review fix from GCA + CodeRabbit).
-      const cacheHash = buildResponseCacheHash(prompt, systemPrompt, qualifiedModel);
+      const cacheHash = buildResponseCacheHash(prompt, systemPrompt, qualifiedModel, cacheContract);
       const cacheDir = path.join(configRoot, config.totemDir, 'cache');
       const finalCachePath = path.join(cacheDir, `${tagKey}-${cacheHash}.json`);
       fs.mkdirSync(cacheDir, { recursive: true });

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -6,9 +6,14 @@ import * as path from 'node:path';
 import dotenv from 'dotenv';
 
 import type {
+  BackendAdmissionClass,
+  ContextPolicy,
   CustomSecret,
   GroundingBundle,
+  Orchestrator,
+  OutputContract,
   RunArtifact,
+  RunMetadata,
   SearchResult,
   TotemConfig,
 } from '@mmnto/totem';
@@ -467,6 +472,30 @@ export function buildRetrievalGroundingBundle(context: {
 }
 
 /**
+ * Admission gate (mmnto-ai/totem#2102, strategy#474 slice 3): a requested
+ * class above `completion_only` must be declared in
+ * `orchestrator.capabilities.admissionClasses`. Decided per RESOLVED backend
+ * before EACH invoke (primary AND quota-fallback) and fails BEFORE any
+ * tokens are spent — a denied run emits no artifact. Declaration is a
+ * capability claim only; output enforcement is caller-side (#2103).
+ */
+function assertAdmissionDeclared(
+  requested: BackendAdmissionClass,
+  orchestrator: Orchestrator,
+): void {
+  if (requested === ADMISSION_COMPLETION_ONLY) return;
+  // Absent declaration = ['completion_only'] — factually true of every backend today.
+  const declared = orchestrator.capabilities?.admissionClasses ?? [ADMISSION_COMPLETION_ONLY];
+  if (!declared.includes(requested)) {
+    throw new TotemConfigError(
+      `Admission denied: requested backend admission class '${requested}' is not declared in orchestrator.capabilities.admissionClasses.`,
+      "Declare the class in your orchestrator config (capabilities: { admissionClasses: ['self_grounding_agent'] }) or drop the backendAdmissionClass request.",
+      'CONFIG_INVALID',
+    );
+  }
+}
+
+/**
  * Validate orchestrator config, then either output raw context (--raw) or
  * invoke the configured orchestrator provider and return the LLM content.
  *
@@ -501,6 +530,27 @@ export async function runOrchestrator(opts: {
    * failure warns and never fails the run. Omitted = today's behavior.
    */
   artifact?: RunArtifactRequest;
+
+  // ─── Admission contract (mmnto-ai/totem#2102, strategy#474 slice 3) ──
+  // All six are optional and defaulted through the existing surfaces, so
+  // omitting every one is byte-identical to today (#1291 additive precedent).
+
+  /** Neutral task identity — records to `backend.taskProfile` as `task ?? tag` (`tag` stays the UI/cache/TTL key). */
+  task?: string;
+  /**
+   * The delivered grounding identity, reconciled with `artifact.bundle`:
+   * one supplied serves both roles; both supplied must hash-agree, else a
+   * hard ambiguous-grounding-identity error before any invoke.
+   */
+  groundingBundle?: GroundingBundle;
+  /** Requested admission class — gated against `orchestrator.capabilities.admissionClasses` before EACH invoke. Defaults to `completion_only`. */
+  backendAdmissionClass?: BackendAdmissionClass;
+  /** Advisory context policy (budget unit: input tokens) — recorded into the artifact `admission` group. */
+  contextPolicy?: ContextPolicy;
+  /** Caller-declared output contract — recorded; #2103 post-checks enforce. */
+  outputContract?: OutputContract;
+  /** Caller identity metadata — recorded verbatim into the artifact `admission` group. */
+  runMetadata?: RunMetadata;
 }): Promise<string | undefined> {
   const { prompt, systemPrompt, tag, options, config, cwd } = opts;
   const configRoot = opts.configRoot ?? cwd;
@@ -540,6 +590,29 @@ export async function runOrchestrator(opts: {
     );
   }
 
+  // ── Grounding identity reconciliation (mmnto-ai/totem#2102) ──
+  // One identity, two seams: when both are supplied they must agree; when
+  // only one is supplied it serves both roles (invoke-seam transport +
+  // artifact record).
+  if (
+    opts.groundingBundle !== undefined &&
+    opts.artifact?.bundle !== undefined &&
+    calculateDeterministicHash(opts.groundingBundle) !==
+      calculateDeterministicHash(opts.artifact.bundle)
+  ) {
+    throw new TotemConfigError(
+      'Ambiguous grounding identity: groundingBundle and artifact.bundle were both supplied with mismatched deterministic hashes.',
+      'Supply only one of the two, or make them agree.',
+      'CONFIG_INVALID',
+    );
+  }
+  const groundingBundle = opts.groundingBundle ?? opts.artifact?.bundle;
+
+  // #2102: caller-supplied wins over the defaults; the defaults reproduce
+  // today's behavior exactly (taskProfile = tag, class = completion_only).
+  const requestedAdmissionClass = opts.backendAdmissionClass ?? ADMISSION_COMPLETION_ONLY;
+  const taskProfile = opts.task ?? tag;
+
   const baseProvider = config.orchestrator.provider;
   const baseInvoke = createOrchestrator(config.orchestrator);
 
@@ -558,6 +631,13 @@ export async function runOrchestrator(opts: {
   let model = resolved.parsed.model;
   let qualifiedModel = resolved.qualifiedModel;
   let invoke = resolved.invoke;
+
+  // ── Admission gate, primary path (mmnto-ai/totem#2102) ──
+  // Decided per RESOLVED backend BEFORE the invoke (and before the response
+  // cache: a denied class must not be served a replay either). No tokens are
+  // spent and no artifact is emitted for a denied run.
+  assertAdmissionDeclared(requestedAdmissionClass, config.orchestrator);
+
   log.info(tag, `Model: ${bold(rawModel)}`);
 
   const ttlSeconds = config.orchestrator.cacheTtls?.[tagKey] ?? DEFAULT_TTLS[tagKey] ?? 0;
@@ -633,6 +713,21 @@ export async function runOrchestrator(opts: {
   const enableContextCaching = config.orchestrator.enableContextCaching;
   const cacheTTL = config.orchestrator.cacheTTL;
 
+  // #2102 transport: thread the adopted field names verbatim when supplied.
+  // Conditional spreads keep the omit-everything invoke payload byte-identical
+  // to today (#1291 additive precedent, invariant 1). Providers transport
+  // these, never read them this slice.
+  const admissionTransport = {
+    ...(opts.task !== undefined ? { task: opts.task } : {}),
+    ...(groundingBundle !== undefined ? { groundingBundle } : {}),
+    ...(opts.backendAdmissionClass !== undefined
+      ? { backendAdmissionClass: opts.backendAdmissionClass }
+      : {}),
+    ...(opts.contextPolicy !== undefined ? { contextPolicy: opts.contextPolicy } : {}),
+    ...(opts.outputContract !== undefined ? { outputContract: opts.outputContract } : {}),
+    ...(opts.runMetadata !== undefined ? { runMetadata: opts.runMetadata } : {}),
+  };
+
   let result: OrchestratorResult;
   try {
     result = await invoke({
@@ -645,6 +740,7 @@ export async function runOrchestrator(opts: {
       temperature: opts.temperature,
       ...(enableContextCaching !== undefined ? { enableContextCaching } : {}),
       ...(cacheTTL !== undefined ? { cacheTTL } : {}),
+      ...admissionTransport,
     });
   } catch (err: unknown) {
     if (err instanceof Error && err.name === 'QuotaError') {
@@ -655,6 +751,29 @@ export async function runOrchestrator(opts: {
           `Quota exhausted for ${rawModel}. Retrying with fallback model: ${bold(rawFallback)}...`,
         );
         const fallbackResolved = resolveOrchestrator(rawFallback, baseProvider, baseInvoke);
+
+        // ── Admission gate, fallback path (mmnto-ai/totem#2102) ──
+        // `resolveOrchestrator` can route a provider-qualified fallbackModel
+        // to a DIFFERENT provider, and a single config-level declaration
+        // cannot honestly cover backends with different real capabilities.
+        // Slice-3 rule, conservative and deterministic: an elevated class
+        // admits the fallback only when it resolves to the SAME provider as
+        // the primary — cross-provider fails loud BEFORE the fallback invoke,
+        // reporting the primary and admission errors together. Per-provider
+        // capability declarations are the future relaxation.
+        if (
+          requestedAdmissionClass !== ADMISSION_COMPLETION_ONLY &&
+          fallbackResolved.parsed.provider !== resolved.parsed.provider
+        ) {
+          throw new TotemOrchestratorError(
+            `Primary model '${rawModel}' failed and the quota fallback '${rawFallback}' was denied admission.\n\n` +
+              `Primary error:\n${err.message}\n\n` +
+              `Admission error:\nfallback resolves to provider '${fallbackResolved.parsed.provider}' (primary: '${resolved.parsed.provider}') while admission class '${requestedAdmissionClass}' is requested — a cross-provider fallback is not admitted above '${ADMISSION_COMPLETION_ONLY}'.`,
+            'Use a same-provider fallbackModel, or drop the elevated backendAdmissionClass request.',
+            err,
+          );
+        }
+
         try {
           result = await fallbackResolved.invoke({
             prompt: safePrompt,
@@ -666,6 +785,7 @@ export async function runOrchestrator(opts: {
             temperature: opts.temperature,
             ...(enableContextCaching !== undefined ? { enableContextCaching } : {}),
             ...(cacheTTL !== undefined ? { cacheTTL } : {}),
+            ...admissionTransport,
           });
           // Update model/invoke so telemetry and cache log the correct values
           model = fallbackResolved.parsed.model;
@@ -747,18 +867,19 @@ export async function runOrchestrator(opts: {
           hash: opts.artifact.groundingHash,
           provenanceSummary: opts.artifact.provenanceSummary,
           // Verbatim passthrough — the bundle was assembled and hashed by the
-          // caller (mmnto-ai/totem#2101); this seam records, never re-derives or upgrades.
-          ...(opts.artifact.bundle !== undefined ? { bundle: opts.artifact.bundle } : {}),
+          // caller (mmnto-ai/totem#2101); this seam records, never re-derives
+          // or upgrades. Post-reconciliation (#2102): a caller-supplied
+          // `groundingBundle` serves this role when `artifact.bundle` is absent.
+          ...(groundingBundle !== undefined ? { bundle: groundingBundle } : {}),
         },
         backend: {
           provider: resolved.parsed.provider,
           model,
           qualifiedModel,
-          // Constant in slice 1 — every runOrchestrator backend is factually
-          // completion-only today; #2102 (admission contract) changes who
-          // supplies this value, not the field.
-          admissionClass: ADMISSION_COMPLETION_ONLY,
-          taskProfile: tag,
+          // #2102: caller-supplied wins; the default reproduces the slice-1
+          // constant — every undeclared backend is factually completion-only.
+          admissionClass: requestedAdmissionClass,
+          taskProfile,
           ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
         },
         output: {
@@ -773,6 +894,22 @@ export async function runOrchestrator(opts: {
             ...(result.finishReason !== undefined ? { finishReason: result.finishReason } : {}),
           },
         },
+        // #2102: the admitted contract group is recorded ONLY when the caller
+        // supplied at least one member — an omitted contract stays an omitted
+        // key, never an empty object (additive 1.x, slice-1 artifacts unchanged).
+        ...(opts.outputContract !== undefined ||
+        opts.contextPolicy !== undefined ||
+        opts.runMetadata !== undefined
+          ? {
+              admission: {
+                ...(opts.outputContract !== undefined
+                  ? { outputContract: opts.outputContract }
+                  : {}),
+                ...(opts.contextPolicy !== undefined ? { contextPolicy: opts.contextPolicy } : {}),
+                ...(opts.runMetadata !== undefined ? { runMetadata: opts.runMetadata } : {}),
+              },
+            }
+          : {}),
         createdAt: new Date().toISOString(),
       };
       const saved = saveRunArtifact(path.join(configRoot, config.totemDir), runArtifact);

--- a/packages/core/src/artifacts/schema.test.ts
+++ b/packages/core/src/artifacts/schema.test.ts
@@ -1,7 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
-import type { RunArtifact } from './schema.js';
-import { RUN_ARTIFACT_SCHEMA_VERSION, RunArtifactSchema } from './schema.js';
+import type { BackendAdmissionClass, RunArtifact } from './schema.js';
+import {
+  ADMISSION_COMPLETION_ONLY,
+  ADMISSION_SELF_GROUNDING_AGENT,
+  ContextPolicySchema,
+  OutputContractSchema,
+  RUN_ARTIFACT_SCHEMA_VERSION,
+  RunArtifactSchema,
+  RunMetadataSchema,
+} from './schema.js';
 
 /** A minimal valid artifact for mutation in each case. */
 function validArtifact(): RunArtifact {
@@ -63,5 +71,89 @@ describe('RunArtifactSchema', () => {
     artifact.output.metrics.inputTokens = null;
     artifact.output.metrics.outputTokens = null;
     expect(RunArtifactSchema.safeParse(artifact).success).toBe(true);
+  });
+});
+
+// ─── Admission contract (mmnto-ai/totem#2102, strategy#474 slice 3) ──
+
+describe('admission contract schemas (#2102)', () => {
+  it('exports both admission-class constants matching the BackendSchema enum', () => {
+    expect(ADMISSION_COMPLETION_ONLY).toBe('completion_only');
+    expect(ADMISSION_SELF_GROUNDING_AGENT).toBe('self_grounding_agent');
+    // Compile-time lock: BackendAdmissionClass is inferred from the enum, so
+    // both constants must be assignable to it.
+    const classes: BackendAdmissionClass[] = [
+      ADMISSION_COMPLETION_ONLY,
+      ADMISSION_SELF_GROUNDING_AGENT,
+    ];
+    expect(classes).toHaveLength(2);
+  });
+
+  it('accepts self_grounding_agent as a backend admissionClass', () => {
+    const artifact = validArtifact();
+    artifact.backend.admissionClass = ADMISSION_SELF_GROUNDING_AGENT;
+    expect(RunArtifactSchema.safeParse(artifact).success).toBe(true);
+  });
+
+  it('a slice-1 artifact (no admission group) still parses (invariant 6 — additive 1.x)', () => {
+    const parsed = RunArtifactSchema.parse(validArtifact());
+    expect(parsed.admission).toBeUndefined();
+  });
+
+  it('accepts a fully hydrated top-level admission group and roundtrips it verbatim', () => {
+    const artifact: RunArtifact = {
+      ...validArtifact(),
+      admission: {
+        outputContract: {
+          citationsRequired: true,
+          verifyFallback: true,
+          schema: { type: 'object', properties: { verdict: { type: 'string' } } },
+        },
+        contextPolicy: { budget: 32_000 },
+        runMetadata: { caller: 'spec', command: 'spec' },
+      },
+    };
+    expect(RunArtifactSchema.parse(artifact)).toEqual(artifact);
+  });
+
+  it('the admission group lives at the top level, never inside inputBundle (inputHash identity)', () => {
+    const artifact = validArtifact();
+    const polluted = {
+      ...artifact,
+      inputBundle: { ...artifact.inputBundle, admission: { contextPolicy: { budget: 1 } } },
+    };
+    // Zod strips unknown keys: the polluted member never lands in the bundle.
+    const parsed = RunArtifactSchema.parse(polluted);
+    expect(parsed.inputBundle).toEqual(artifact.inputBundle);
+  });
+
+  it('ContextPolicy budget must be a positive integer (input tokens — declared ≠ nonsense)', () => {
+    expect(ContextPolicySchema.safeParse({ budget: 8000 }).success).toBe(true);
+    expect(ContextPolicySchema.safeParse({}).success).toBe(true);
+    expect(ContextPolicySchema.safeParse({ budget: 0 }).success).toBe(false);
+    expect(ContextPolicySchema.safeParse({ budget: -100 }).success).toBe(false);
+    expect(ContextPolicySchema.safeParse({ budget: 1.5 }).success).toBe(false);
+  });
+
+  it('rejects an artifact whose admission carries an invalid budget', () => {
+    const broken = {
+      ...validArtifact(),
+      admission: { contextPolicy: { budget: -1 } },
+    };
+    expect(RunArtifactSchema.safeParse(broken).success).toBe(false);
+  });
+
+  it('OutputContract is a closed object — unknown keys are stripped, never key soup', () => {
+    const parsed = OutputContractSchema.parse({
+      citationsRequired: false,
+      arbitraryExtension: 'smuggled',
+    });
+    expect(parsed).toEqual({ citationsRequired: false });
+  });
+
+  it('RunMetadata rejects empty caller/command strings', () => {
+    expect(RunMetadataSchema.safeParse({ caller: 'spec' }).success).toBe(true);
+    expect(RunMetadataSchema.safeParse({ caller: '' }).success).toBe(false);
+    expect(RunMetadataSchema.safeParse({ command: '' }).success).toBe(false);
   });
 });

--- a/packages/core/src/artifacts/schema.ts
+++ b/packages/core/src/artifacts/schema.ts
@@ -77,6 +77,26 @@ export const PROVENANCE_UNGROUNDED = 'ungrounded';
  */
 export const ADMISSION_COMPLETION_ONLY = 'completion_only' as const;
 
+/**
+ * Elevated admission class (mmnto-ai/totem#2102, strategy#474 slice 3): the
+ * backend is admitted to ground itself (agentic retrieval/tool use) rather
+ * than complete over caller-delivered context. Requestable only when declared
+ * in `orchestrator.capabilities.admissionClasses` — the admission gate in
+ * `runOrchestrator` fails loud pre-invoke otherwise.
+ */
+export const ADMISSION_SELF_GROUNDING_AGENT = 'self_grounding_agent' as const;
+
+/**
+ * Closed two-value enum this slice — single source of truth for both
+ * `BackendSchema.admissionClass` and the config-side capability declaration
+ * (`orchestrator.capabilities.admissionClasses`); a parallel definition is
+ * the drift vector the #1429 model-validation review named.
+ */
+export const ADMISSION_CLASSES = [
+  ADMISSION_COMPLETION_ONLY,
+  ADMISSION_SELF_GROUNDING_AGENT,
+] as const;
+
 /** sha256 hex content hash (full digest — identity, not display). */
 const SHA256_HEX = /^[0-9a-f]{64}$/;
 
@@ -156,10 +176,59 @@ export const BackendSchema = z.object({
   model: z.string().min(1),
   /** The full provider-qualified string telemetry/cache key on (`provider:model`). */
   qualifiedModel: z.string().min(1),
-  admissionClass: z.enum(['completion_only', 'self_grounding_agent']),
+  admissionClass: z.enum(ADMISSION_CLASSES),
   /** The command tag the run served (`Spec`, `Review`, ...) — the task profile. */
   taskProfile: z.string().min(1),
   temperature: z.number().optional(),
+});
+
+/**
+ * Caller-declared output contract (mmnto-ai/totem#2102): the citations-or-
+ * `VERIFY:` declaration. Callers write; #2103 post-checks read; providers
+ * transport, never enforce (Totem is not zero-user — backend cooperation is
+ * never assumed, enforcement is caller-side post-invocation). Closed object:
+ * extensible by additive optional fields, not an index signature.
+ */
+export const OutputContractSchema = z.object({
+  /** Response claims must carry citations into the delivered grounding. */
+  citationsRequired: z.boolean().optional(),
+  /** Whether an explicit `VERIFY:` escalation is an acceptable fallback for an uncitable claim. */
+  verifyFallback: z.boolean().optional(),
+  /** JSON-Schema definition for structured output. */
+  schema: z.record(z.unknown()).optional(),
+});
+
+/**
+ * Caller-declared context policy (mmnto-ai/totem#2102). Advisory this slice —
+ * recorded for honesty, enforced by nothing yet — but validated so
+ * declared-not-enforced never means accepting nonsense.
+ */
+export const ContextPolicySchema = z.object({
+  /** Advisory context budget. Unit: INPUT TOKENS. */
+  budget: z.number().int().positive().optional(),
+});
+
+/**
+ * Caller identity metadata (mmnto-ai/totem#2102, the #2100 runMetadata
+ * target) — recorded verbatim into the artifact.
+ */
+export const RunMetadataSchema = z.object({
+  /** The command/module that issued the run (e.g. `spec`, `review`). */
+  caller: z.string().min(1).optional(),
+  /** The CLI command identity the run served, when distinct from `caller`. */
+  command: z.string().min(1).optional(),
+});
+
+/**
+ * The admitted contract group (mmnto-ai/totem#2102). Top-level and optional,
+ * NOT inside `inputBundle` — `inputBundle` feeds `inputHash`, and polluting
+ * it would break rerun/compare identity for identical prompts. Recorded only
+ * when the caller supplied at least one member.
+ */
+const RunAdmissionSchema = z.object({
+  outputContract: OutputContractSchema.optional(),
+  contextPolicy: ContextPolicySchema.optional(),
+  runMetadata: RunMetadataSchema.optional(),
 });
 
 /**
@@ -185,6 +254,8 @@ export const RunArtifactSchema = z.object({
     content: z.string(),
     metrics: RunMetricsSchema,
   }),
+  /** Admitted contract group (mmnto-ai/totem#2102) — additive 1.x optional; slice-1/2 artifacts predate it. */
+  admission: RunAdmissionSchema.optional(),
   /**
    * ISO-8601 emission time. EXCLUDED from the content address (identical runs
    * dedup to one artifact regardless of when they ran) — observability only.
@@ -196,3 +267,8 @@ export type RunArtifact = z.infer<typeof RunArtifactSchema>;
 export type InputBundle = z.infer<typeof InputBundleSchema>;
 export type GroundingItem = z.infer<typeof GroundingItemSchema>;
 export type GroundingBundle = z.infer<typeof GroundingBundleSchema>;
+export type OutputContract = z.infer<typeof OutputContractSchema>;
+export type ContextPolicy = z.infer<typeof ContextPolicySchema>;
+export type RunMetadata = z.infer<typeof RunMetadataSchema>;
+/** Inferred from the `BackendSchema` enum — the canonical admission-class union (mmnto-ai/totem#2102). */
+export type BackendAdmissionClass = z.infer<typeof BackendSchema>['admissionClass'];

--- a/packages/core/src/config-schema.test.ts
+++ b/packages/core/src/config-schema.test.ts
@@ -386,6 +386,69 @@ describe('OrchestratorSchema', () => {
       expect(result.success).toBe(true);
     }
   });
+
+  // ─── Capability declaration (mmnto-ai/totem#2102, strategy#474 slice 3) ──
+
+  it('accepts orchestrator config without capabilities (defaults to undefined)', () => {
+    const result = OrchestratorSchema.safeParse(ANTHROPIC_ORCHESTRATOR);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.capabilities).toBeUndefined();
+    }
+  });
+
+  it('accepts a declared admissionClasses capability list', () => {
+    const result = OrchestratorSchema.safeParse({
+      provider: 'anthropic',
+      defaultModel: 'claude-sonnet-4-6',
+      capabilities: { admissionClasses: ['completion_only', 'self_grounding_agent'] },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.capabilities?.admissionClasses).toEqual([
+        'completion_only',
+        'self_grounding_agent',
+      ]);
+    }
+  });
+
+  it('accepts an empty capabilities object (no classes declared)', () => {
+    const result = OrchestratorSchema.safeParse({
+      provider: 'anthropic',
+      capabilities: {},
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.capabilities?.admissionClasses).toBeUndefined();
+    }
+  });
+
+  it('rejects an unknown admission class, failing on the admissionClasses path', () => {
+    const result = OrchestratorSchema.safeParse({
+      provider: 'anthropic',
+      capabilities: { admissionClasses: ['agentic_swarm'] },
+    });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const classIssues = result.error.issues.filter((i) => i.path.includes('admissionClasses'));
+      expect(classIssues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('accepts capabilities on every provider variant', () => {
+    const capabilities = { admissionClasses: ['self_grounding_agent' as const] };
+    const variants = [
+      { provider: 'shell' as const, command: 'echo {file}', capabilities },
+      { provider: 'anthropic' as const, capabilities },
+      { provider: 'gemini' as const, capabilities },
+      { provider: 'openai' as const, capabilities },
+      { provider: 'ollama' as const, capabilities },
+    ];
+    for (const variant of variants) {
+      const result = OrchestratorSchema.safeParse(variant);
+      expect(result.success).toBe(true);
+    }
+  });
 });
 
 // ─── Backwards compatibility ─────────────────────────

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { ADMISSION_CLASSES } from './artifacts/schema.js';
 import { TotemConfigError } from './errors.js';
 import { CustomSecretSchema } from './secrets.js';
 
@@ -125,6 +126,22 @@ const BaseOrchestratorFields = {
    * https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
    */
   cacheTTL: z.union([z.literal(300), z.literal(3600)]).optional(),
+  /**
+   * Declared backend-capability contract (mmnto-ai/totem#2102, strategy#474
+   * slice 3). `admissionClasses` lists the backend admission classes this
+   * orchestrator is declared capable of serving; canonical values live in
+   * core `ADMISSION_CLASSES`. Read by the `runOrchestrator` admission gate
+   * only: a caller requesting a class above `completion_only` that is not
+   * declared here fails loud BEFORE any provider invoke (no tokens spent,
+   * no artifact emitted). Absent = `['completion_only']` — factually true
+   * of every backend today. A declaration is a capability claim, never an
+   * enforcement mechanism (output enforcement is caller-side, #2103).
+   */
+  capabilities: z
+    .object({
+      admissionClasses: z.array(z.enum(ADMISSION_CLASSES)).optional(),
+    })
+    .optional(),
 };
 
 export const ShellOrchestratorSchema = z.object({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -512,20 +512,28 @@ export {
 // Filesystem helpers
 export { readJsonSafe } from './sys/fs.js';
 
-// Grounded run artifacts (mmnto-ai/totem#2100 slice 1, mmnto-ai/totem#2101 slice 2)
+// Grounded run artifacts (mmnto-ai/totem#2100 slice 1, mmnto-ai/totem#2101 slice 2, mmnto-ai/totem#2102 slice 3)
 export type { GroundingSourceItem } from './artifacts/grounding.js';
 export { buildGroundingBundle, summarizeProvenance } from './artifacts/grounding.js';
 export { calculateDeterministicHash } from './artifacts/hash.js';
 export type {
+  BackendAdmissionClass,
+  ContextPolicy,
   GroundingBundle,
   GroundingItem,
   InputBundle,
+  OutputContract,
   RunArtifact,
+  RunMetadata,
 } from './artifacts/schema.js';
 export {
+  ADMISSION_CLASSES,
   ADMISSION_COMPLETION_ONLY,
+  ADMISSION_SELF_GROUNDING_AGENT,
+  ContextPolicySchema,
   GroundingBundleSchema,
   GroundingItemSchema,
+  OutputContractSchema,
   PROVENANCE_CLASSES,
   PROVENANCE_COMPILED_RULE,
   PROVENANCE_SIMILARITY_ONLY,
@@ -534,6 +542,7 @@ export {
   PROVENANCE_UNGROUNDED,
   RUN_ARTIFACT_SCHEMA_VERSION,
   RunArtifactSchema,
+  RunMetadataSchema,
 } from './artifacts/schema.js';
 export type { SaveRunArtifactResult } from './artifacts/storage.js';
 export {


### PR DESCRIPTION
Closes #2102. Part of the #2106 Phase-1 decomposition (474 slice 3).

## What

Additively enriches both orchestrator seams with the adopted admission-contract fields — `task` · `groundingBundle` · `backendAdmissionClass` · `contextPolicy` · `outputContract` · `runMetadata` — all optional, absent = byte-identical to today (locked by test, the #1291 precedent).

- **Core:** `OutputContract` / `ContextPolicy` (budget validated `int().positive()`, unit: input tokens) / `RunMetadata` Zod schemas + an optional top-level `admission` group on `RunArtifact` (additive 1.x, deliberately OUTSIDE `inputBundle` so `inputHash` identity is untouched); `ADMISSION_CLASSES` single-source tuple; `orchestrator.capabilities.admissionClasses` config declaration (absent = `['completion_only']`, factually true of every backend today). Docs row in `config-reference.md`.
- **Admission gate (`runOrchestrator`):** decided per RESOLVED backend before EACH invoke. Requested-but-undeclared class fails loud pre-invoke — no tokens spent, no artifact emitted. A quota fallback that resolves cross-provider under an elevated class is denied BEFORE the fallback invoke, reporting the primary + admission errors together (a single config-level declaration cannot honestly cover backends with different real capabilities; per-provider declarations are the future relaxation).
- **Recording:** `backend.admissionClass` is now caller-supplied (`?? completion_only`) — the slice-1 constant's comment said exactly this would happen; `taskProfile` records `task ?? tag`; `groundingBundle` reconciles with `artifact.bundle` (hash mismatch = hard error: ambiguous grounding identity).
- **Rerun/compare carry the contract:** `rerunArtifact()` replays a recorded `admission` group + class verbatim (no silent downgrade); `compareRunArtifacts()` gains `sameAdmission` + `admissionDelta`.
- **Callers:** `spec` + `review` supply the contract explicitly; the other 8+ `runOrchestrator` callers compile untouched.

## Provenance

Design doc in `.totem/specs/2102.md` (Implementation Design section), pre-build-reviewed by totem-codex (3 warnings, all folded — including the cross-provider quota-fallback admission bypass, whose regression scenario is invariant 5 verbatim), operator-approved before code.

## Verification

All 8 design invariants are test-mapped (see `.totem/specs/2102.md` § Invariants). Targeted suites: 240 cli + 177 core tests green. Full `totem lint` (workspace build): PASS, 0 errors. `totem review`: PASS, no findings. Full `pnpm test`: green except 10 pre-existing host-env bash-hook failures (`pre-compact-hook` / `shield.content-hash-parity`), reproduced byte-for-byte on clean main `78ac727f` in a fresh worktree — zero overlap with this change; Linux/macOS CI does not hit that class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)