### PR TITLE
feat(cli): prefer-local re-exec at the entrypoint (#2018 L1)

### DIFF
--- a/.changeset/prefer-local-reexec.md
+++ b/.changeset/prefer-local-reexec.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/cli': minor
+---
+
+Prefer-local re-exec at the entrypoint (mmnto-ai/totem#2018 L1). When a foreign totem binary — typically an ambient global install — starts inside a project that carries its own `@mmnto/cli` (workspace-HEAD build or pinned dependency, the ADR-072 cascade's deterministic tiers), it now delegates to the project-local build instead of running with the wrong dependency tree. The delegation is announced on stderr; `TOTEM_NO_REEXEC=1` opts out. Forecloses both variants of the recurring wrong-binary class: missing externalized peer SDKs (mmnto-ai/totem#2018) and stale-version shadowing (mmnto-ai/totem#2053).

--- a/docs/wiki/installation.md
+++ b/docs/wiki/installation.md
@@ -14,6 +14,10 @@ pnpm dlx @mmnto/cli lint
 
 This ensures you are always running the latest version of the Codebase Immune System, with full access to the LanceDB vector database and LLM orchestrator.
 
+### Global installs delegate to the project-local CLI
+
+If you do install Totem globally, the binary prefers the project it runs in: when started inside a project that carries its own `@mmnto/cli` (a `node_modules` install, or the totem monorepo's built workspace), it delegates to that local build and announces the delegation on stderr. The project-local install is version-pinned and resolves the optional LLM SDK peer dependencies; the global binary cannot. Set `TOTEM_NO_REEXEC=1` to opt out and force the invoked binary to run in place.
+
 ## 2. Standalone Binary (Totem Lite)
 
 For developers working in pure Rust, Go, or Python environments who do not want to install a Node.js runtime, Totem 1.12.0 introduced the **Totem Lite** binary.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,6 +29,7 @@
     "@clack/prompts": "^1.1.0",
     "@mmnto/totem": "workspace:*",
     "commander": "^13.1.0",
+    "cross-spawn": "^7.0.6",
     "dotenv": "^16.4.0",
     "jiti": "^2.4.0",
     "ora": "^9.3.0",
@@ -40,6 +41,7 @@
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.98.0",
     "@google/genai": "^2.6.0",
+    "@types/cross-spawn": "^6.0.6",
     "@types/node": "^22.0.0",
     "esbuild": "^0.28.0",
     "openai": "^4.77.0",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,7 +9,6 @@ import { z } from 'zod';
 import { initCommand } from './commands/init.js';
 import { REVIEW_DIFF_TRUNCATION_THRESHOLD } from './git.js';
 import { TotemHelp } from './help.js';
-import { maybeReexecLocal } from './reexec-local.js';
 import { reapOrphanedTempFiles } from './utils.js';
 
 const require = createRequire(import.meta.url);
@@ -18,6 +17,9 @@ const { version } = z.object({ version: z.string() }).parse(require('../package.
 // mmnto-ai/totem#2018 L1: when a foreign binary (ambient global) starts inside
 // a project carrying its own @mmnto/cli, delegate to the project-local build
 // BEFORE any command wiring — the wrong dependency tree must never get to run.
+// Dynamic import per the CLI lazy-load convention; it still resolves eagerly
+// here by design — delegation has to happen before everything else.
+const { maybeReexecLocal } = await import('./reexec-local.js');
 const reexecStatus = maybeReexecLocal({ selfVersion: version });
 if (reexecStatus !== undefined) {
   process.exit(reexecStatus);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,10 +9,19 @@ import { z } from 'zod';
 import { initCommand } from './commands/init.js';
 import { REVIEW_DIFF_TRUNCATION_THRESHOLD } from './git.js';
 import { TotemHelp } from './help.js';
+import { maybeReexecLocal } from './reexec-local.js';
 import { reapOrphanedTempFiles } from './utils.js';
 
 const require = createRequire(import.meta.url);
 const { version } = z.object({ version: z.string() }).parse(require('../package.json'));
+
+// mmnto-ai/totem#2018 L1: when a foreign binary (ambient global) starts inside
+// a project carrying its own @mmnto/cli, delegate to the project-local build
+// BEFORE any command wiring — the wrong dependency tree must never get to run.
+const reexecStatus = maybeReexecLocal({ selfVersion: version });
+if (reexecStatus !== undefined) {
+  process.exit(reexecStatus);
+}
 
 // Retrospect thresholds (mmnto-ai/totem#1713). Shared across option default,
 // help text, and validation so they don't drift.

--- a/packages/cli/src/reexec-local.test.ts
+++ b/packages/cli/src/reexec-local.test.ts
@@ -1,0 +1,166 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { maybeReexecLocal, resolveLocalEntry } from './reexec-local.js';
+
+function writeWorkspaceTier(root: string, name = '@mmnto/cli'): string {
+  fs.mkdirSync(path.join(root, 'packages', 'cli', 'dist'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, 'packages', 'cli', 'package.json'),
+    `{"name":"${name}","version":"9.9.9"}`,
+  );
+  const entry = path.join(root, 'packages', 'cli', 'dist', 'index.js');
+  fs.writeFileSync(entry, '');
+  return entry;
+}
+
+function writePinnedTier(root: string): string {
+  const pkgDir = path.join(root, 'node_modules', '@mmnto', 'cli');
+  fs.mkdirSync(path.join(pkgDir, 'dist'), { recursive: true });
+  fs.writeFileSync(path.join(pkgDir, 'package.json'), '{"name":"@mmnto/cli","version":"8.8.8"}');
+  const entry = path.join(pkgDir, 'dist', 'index.js');
+  fs.writeFileSync(entry, '');
+  return entry;
+}
+
+describe('resolveLocalEntry (mmnto-ai/totem#2018 L1 — ADR-072 cascade tiers 1+2)', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-reexec-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('tier 1: resolves the workspace-HEAD build, identity-guarded on the package name', () => {
+    const entry = writeWorkspaceTier(tmpRoot);
+    expect(resolveLocalEntry(tmpRoot)?.entry).toBe(entry);
+  });
+
+  it('tier 1 guard: a packages/cli that is NOT @mmnto/cli does not match', () => {
+    writeWorkspaceTier(tmpRoot, 'someone-elses-cli');
+    expect(resolveLocalEntry(tmpRoot)).toBeUndefined();
+  });
+
+  it('tier 1 requires the built entry — package.json alone is not enough', () => {
+    writeWorkspaceTier(tmpRoot);
+    fs.rmSync(path.join(tmpRoot, 'packages', 'cli', 'dist', 'index.js'));
+    expect(resolveLocalEntry(tmpRoot)).toBeUndefined();
+  });
+
+  it('tier 2: resolves the pinned @mmnto/cli entry', () => {
+    const entry = writePinnedTier(tmpRoot);
+    expect(resolveLocalEntry(tmpRoot)?.entry).toBe(entry);
+  });
+
+  it('tier 1 beats tier 2 when both are present', () => {
+    const workspaceEntry = writeWorkspaceTier(tmpRoot);
+    writePinnedTier(tmpRoot);
+    expect(resolveLocalEntry(tmpRoot)?.entry).toBe(workspaceEntry);
+  });
+
+  it('walks up from a nested cwd', () => {
+    const entry = writePinnedTier(tmpRoot);
+    const nested = path.join(tmpRoot, 'src', 'deep');
+    fs.mkdirSync(nested, { recursive: true });
+    expect(resolveLocalEntry(nested)?.entry).toBe(entry);
+  });
+
+  it('no local install anywhere → undefined', () => {
+    expect(resolveLocalEntry(tmpRoot)).toBeUndefined();
+  });
+
+  it('reports the candidate version when readable', () => {
+    writePinnedTier(tmpRoot);
+    expect(resolveLocalEntry(tmpRoot)?.version).toBe('8.8.8');
+  });
+});
+
+describe('maybeReexecLocal', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-reexec-run-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('TOTEM_NO_REEXEC=1 disables delegation entirely', () => {
+    writePinnedTier(tmpRoot);
+    const spawn = vi.fn();
+    const status = maybeReexecLocal({
+      cwd: tmpRoot,
+      argv: ['lint'],
+      env: { TOTEM_NO_REEXEC: '1' },
+      selfPath: path.join(tmpRoot, 'elsewhere', 'index.js'),
+      spawn,
+    });
+    expect(status).toBeUndefined();
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('already running the local entry → no delegation (identity short-circuit)', () => {
+    const entry = writePinnedTier(tmpRoot);
+    const spawn = vi.fn();
+    const status = maybeReexecLocal({
+      cwd: tmpRoot,
+      argv: ['lint'],
+      env: {},
+      selfPath: entry,
+      spawn,
+    });
+    expect(status).toBeUndefined();
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('foreign binary + local install present → delegates with loop guard and returns child status', () => {
+    const entry = writePinnedTier(tmpRoot);
+    const spawn = vi.fn().mockReturnValue({ status: 3 });
+    const status = maybeReexecLocal({
+      cwd: tmpRoot,
+      argv: ['lint', '--branch'],
+      env: { PATH: 'x' },
+      selfPath: path.join(tmpRoot, 'elsewhere', 'index.js'),
+      spawn,
+    });
+    expect(status).toBe(3);
+    const [cmd, args, opts] = spawn.mock.calls[0]!;
+    expect(cmd).toBe(process.execPath);
+    expect(args).toEqual([entry, 'lint', '--branch']);
+    expect((opts as { env: Record<string, string> }).env['TOTEM_NO_REEXEC']).toBe('1');
+    expect((opts as { stdio: string }).stdio).toBe('inherit');
+  });
+
+  it('no local install → runs in place (undefined), no spawn', () => {
+    const spawn = vi.fn();
+    const status = maybeReexecLocal({
+      cwd: tmpRoot,
+      argv: ['lint'],
+      env: {},
+      selfPath: path.join(tmpRoot, 'elsewhere', 'index.js'),
+      spawn,
+    });
+    expect(status).toBeUndefined();
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('a null child status maps to failure, never silent success', () => {
+    writePinnedTier(tmpRoot);
+    const spawn = vi.fn().mockReturnValue({ status: null });
+    const status = maybeReexecLocal({
+      cwd: tmpRoot,
+      argv: [],
+      env: {},
+      selfPath: path.join(tmpRoot, 'elsewhere', 'index.js'),
+      spawn,
+    });
+    expect(status).toBe(1);
+  });
+});

--- a/packages/cli/src/reexec-local.test.ts
+++ b/packages/cli/src/reexec-local.test.ts
@@ -151,6 +151,39 @@ describe('maybeReexecLocal', () => {
     expect(spawn).not.toHaveBeenCalled();
   });
 
+  it('a probe I/O error falls through to running in place (#2153 round-1)', () => {
+    // packages/cli/package.json as a DIRECTORY: existsSync passes, readFileSync
+    // throws EISDIR mid-probe — the sandboxed-permissions class.
+    fs.mkdirSync(path.join(tmpRoot, 'packages', 'cli', 'dist'), { recursive: true });
+    fs.writeFileSync(path.join(tmpRoot, 'packages', 'cli', 'dist', 'index.js'), '');
+    fs.mkdirSync(path.join(tmpRoot, 'packages', 'cli', 'package.json'));
+    const spawn = vi.fn();
+    const status = maybeReexecLocal({
+      cwd: tmpRoot,
+      argv: [],
+      env: {},
+      selfPath: path.join(tmpRoot, 'elsewhere', 'index.js'),
+      spawn,
+    });
+    expect(status).toBeUndefined();
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('TOTEM_DEBUG=1 surfaces the probe error instead of swallowing it', () => {
+    fs.mkdirSync(path.join(tmpRoot, 'packages', 'cli', 'dist'), { recursive: true });
+    fs.writeFileSync(path.join(tmpRoot, 'packages', 'cli', 'dist', 'index.js'), '');
+    fs.mkdirSync(path.join(tmpRoot, 'packages', 'cli', 'package.json'));
+    expect(() =>
+      maybeReexecLocal({
+        cwd: tmpRoot,
+        argv: [],
+        env: { TOTEM_DEBUG: '1' },
+        selfPath: path.join(tmpRoot, 'elsewhere', 'index.js'),
+        spawn: vi.fn(),
+      }),
+    ).toThrow();
+  });
+
   it('a null child status maps to failure, never silent success', () => {
     writePinnedTier(tmpRoot);
     const spawn = vi.fn().mockReturnValue({ status: null });

--- a/packages/cli/src/reexec-local.ts
+++ b/packages/cli/src/reexec-local.ts
@@ -17,10 +17,10 @@
  * pathological realpath mismatch can never re-exec recursively).
  */
 
-import type { spawnSync as SpawnSyncType } from 'node:child_process';
-import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+
+import { sync as spawnSync } from 'cross-spawn';
 
 const VERSION_RE = /"version"\s*:\s*"([^"]+)"/;
 const NAME_IS_CLI_RE = /"name"\s*:\s*"@mmnto\/cli"/;
@@ -97,7 +97,7 @@ export interface ReexecOptions {
   selfPath?: string;
   /** This binary's own version, for the delegation notice. */
   selfVersion?: string;
-  spawn?: typeof SpawnSyncType;
+  spawn?: typeof spawnSync;
 }
 
 /**
@@ -126,11 +126,11 @@ export function maybeReexecLocal(opts?: ReexecOptions): number | undefined {
 
   const spawn = opts?.spawn ?? spawnSync;
   const argv = opts?.argv ?? process.argv.slice(2);
-  // totem-context: direct spawnSync justified — delegation needs stdio inherit
-  // + non-throwing exit-code propagation, which safeExec (pipe-buffered,
-  // throws on non-zero) cannot provide. Target is process.execPath + the
-  // identity-guarded local entry; argv as array, no shell. Allowlisted in
-  // pack-agent-security repo-sweep.
+  // totem-context: direct cross-spawn justified (same primitive safeExec
+  // wraps) — delegation needs stdio inherit + non-throwing exit-code
+  // propagation, which safeExec (pipe-buffered, throws on non-zero) cannot
+  // provide. Target is process.execPath + the identity-guarded local entry;
+  // argv as array, no shell. Allowlisted in pack-agent-security repo-sweep.
   const child = spawn(process.execPath, [local.entry, ...argv], {
     stdio: 'inherit',
     env: { ...env, TOTEM_NO_REEXEC: '1' },

--- a/packages/cli/src/reexec-local.ts
+++ b/packages/cli/src/reexec-local.ts
@@ -1,0 +1,134 @@
+/**
+ * Prefer-local re-exec at the CLI entrypoint (mmnto-ai/totem#2018 L1).
+ *
+ * Promotes the deterministic tiers of the ADR-072 resolve cascade (shipped
+ * for git hooks in mmnto-ai/totem#2053) into the binary itself: when a
+ * foreign totem — typically an ambient global install — starts inside a
+ * project that carries its own `@mmnto/cli`, the entrypoint delegates to the
+ * project-local build instead of running with the wrong dependency tree.
+ * Tenet 14 (Never Tie Governance to Volatile State): the pinned local install
+ * is deterministic; the PATH global is ambient. This forecloses both variants
+ * of the recurring class — missing externalized peer SDKs (mmnto-ai/totem#2018)
+ * and stale-version shadowing (mmnto-ai/totem#2053) — by making the wrong
+ * binary unreachable from inside a workspace.
+ *
+ * The delegation is announced on stderr, never silent, and `TOTEM_NO_REEXEC=1`
+ * opts out (it also rides the child environment as the loop guard, so a
+ * pathological realpath mismatch can never re-exec recursively).
+ */
+
+import type { spawnSync as SpawnSyncType } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+const VERSION_RE = /"version"\s*:\s*"([^"]+)"/;
+const NAME_IS_CLI_RE = /"name"\s*:\s*"@mmnto\/cli"/;
+
+export interface LocalEntry {
+  /** Absolute path to the local `dist/index.js` to delegate to. */
+  entry: string;
+  /** The local install's version, when its package.json is readable. */
+  version?: string;
+  /** Which cascade tier matched: workspace-HEAD or the pinned dependency. */
+  tier: 'workspace' | 'pinned';
+}
+
+/** Probe-grade version read — no JSON.parse, no fail-open catch. */
+function readVersion(pkgJsonPath: string): string | undefined {
+  if (!fs.existsSync(pkgJsonPath)) return undefined;
+  return VERSION_RE.exec(fs.readFileSync(pkgJsonPath, 'utf-8'))?.[1];
+}
+
+/**
+ * Resolve the project-local CLI entry by walking up from `cwd`, mirroring the
+ * ADR-072 cascade's deterministic tiers:
+ *
+ * 1. **Workspace-HEAD** — `packages/cli/dist/index.js`, identity-guarded on
+ *    `packages/cli/package.json` declaring `@mmnto/cli` (the dogfood monorepo;
+ *    the build you just made wins over any installed copy).
+ * 2. **Pinned dependency** — `node_modules/@mmnto/cli/dist/index.js`, the
+ *    project's version-locked install via the package's own entry point.
+ *
+ * Both tiers require the BUILT entry to exist — an unbuilt checkout falls
+ * through to running in place (where the mmnto-ai/totem#2018 L2 hint explains
+ * the build step).
+ */
+export function resolveLocalEntry(cwd: string): LocalEntry | undefined {
+  let dir = path.resolve(cwd);
+  for (;;) {
+    const workspacePkg = path.join(dir, 'packages', 'cli', 'package.json');
+    const workspaceEntry = path.join(dir, 'packages', 'cli', 'dist', 'index.js');
+    if (
+      fs.existsSync(workspaceEntry) &&
+      fs.existsSync(workspacePkg) &&
+      NAME_IS_CLI_RE.test(fs.readFileSync(workspacePkg, 'utf-8'))
+    ) {
+      return { entry: workspaceEntry, version: readVersion(workspacePkg), tier: 'workspace' };
+    }
+
+    const pinnedDir = path.join(dir, 'node_modules', '@mmnto', 'cli');
+    const pinnedEntry = path.join(pinnedDir, 'dist', 'index.js');
+    if (fs.existsSync(pinnedEntry)) {
+      return {
+        entry: pinnedEntry,
+        version: readVersion(path.join(pinnedDir, 'package.json')),
+        tier: 'pinned',
+      };
+    }
+
+    const parent = path.dirname(dir);
+    if (parent === dir) return undefined;
+    dir = parent;
+  }
+}
+
+/** Realpath when resolvable; the input when the path does not exist. */
+function safeRealpath(p: string): string {
+  return fs.existsSync(p) ? fs.realpathSync(p) : p;
+}
+
+export interface ReexecOptions {
+  cwd?: string;
+  /** Forwarded argv (everything after `node <entry>`). */
+  argv?: string[];
+  env?: NodeJS.ProcessEnv;
+  /** The running entry script — `process.argv[1]` in production. */
+  selfPath?: string;
+  /** This binary's own version, for the delegation notice. */
+  selfVersion?: string;
+  spawn?: typeof SpawnSyncType;
+}
+
+/**
+ * Delegate to the project-local CLI when this binary is not it.
+ *
+ * Returns the child's exit code when delegation happened (the caller exits
+ * with it), or `undefined` to run in place. A null child status maps to
+ * failure (1), never silent success.
+ */
+export function maybeReexecLocal(opts?: ReexecOptions): number | undefined {
+  const env = opts?.env ?? process.env;
+  if (env['TOTEM_NO_REEXEC'] === '1') return undefined;
+
+  const cwd = opts?.cwd ?? process.cwd();
+  const local = resolveLocalEntry(cwd);
+  if (local === undefined) return undefined;
+
+  const selfPath = opts?.selfPath ?? process.argv[1] ?? '';
+  if (safeRealpath(local.entry) === safeRealpath(selfPath)) return undefined;
+
+  const localLabel = local.version !== undefined ? `@mmnto/cli@${local.version}` : '@mmnto/cli';
+  const selfLabel = opts?.selfVersion !== undefined ? ` (this binary: ${opts.selfVersion})` : '';
+  process.stderr.write(
+    `[totem] Delegating to the project-local ${localLabel} at ${local.entry}${selfLabel} — set TOTEM_NO_REEXEC=1 to disable.\n`,
+  );
+
+  const spawn = opts?.spawn ?? spawnSync;
+  const argv = opts?.argv ?? process.argv.slice(2);
+  const child = spawn(process.execPath, [local.entry, ...argv], {
+    stdio: 'inherit',
+    env: { ...env, TOTEM_NO_REEXEC: '1' },
+  });
+  return child.status ?? 1;
+}

--- a/packages/cli/src/reexec-local.ts
+++ b/packages/cli/src/reexec-local.ts
@@ -126,6 +126,11 @@ export function maybeReexecLocal(opts?: ReexecOptions): number | undefined {
 
   const spawn = opts?.spawn ?? spawnSync;
   const argv = opts?.argv ?? process.argv.slice(2);
+  // totem-context: direct spawnSync justified — delegation needs stdio inherit
+  // + non-throwing exit-code propagation, which safeExec (pipe-buffered,
+  // throws on non-zero) cannot provide. Target is process.execPath + the
+  // identity-guarded local entry; argv as array, no shell. Allowlisted in
+  // pack-agent-security repo-sweep.
   const child = spawn(process.execPath, [local.entry, ...argv], {
     stdio: 'inherit',
     env: { ...env, TOTEM_NO_REEXEC: '1' },

--- a/packages/cli/src/reexec-local.ts
+++ b/packages/cli/src/reexec-local.ts
@@ -112,11 +112,23 @@ export function maybeReexecLocal(opts?: ReexecOptions): number | undefined {
   if (env['TOTEM_NO_REEXEC'] === '1') return undefined;
 
   const cwd = opts?.cwd ?? process.cwd();
-  const local = resolveLocalEntry(cwd);
-  if (local === undefined) return undefined;
-
-  const selfPath = opts?.selfPath ?? process.argv[1] ?? '';
-  if (safeRealpath(local.entry) === safeRealpath(selfPath)) return undefined;
+  let local: LocalEntry | undefined;
+  let alreadyLocal = false;
+  try {
+    local = resolveLocalEntry(cwd);
+    if (local !== undefined) {
+      const selfPath = opts?.selfPath ?? process.argv[1] ?? '';
+      alreadyLocal = safeRealpath(local.entry) === safeRealpath(selfPath);
+    }
+  } catch (err) {
+    // The probe is best-effort: an unreadable path mid-walk (EACCES/EISDIR in
+    // sandboxed or permission-restricted environments) falls through to
+    // running in place — a probe failure must never crash the CLI with a raw
+    // I/O stack (mmnto-ai/totem#2153 round-1). TOTEM_DEBUG=1 surfaces it.
+    if (env['TOTEM_DEBUG'] === '1') throw err;
+    return undefined;
+  }
+  if (local === undefined || alreadyLocal) return undefined;
 
   const localLabel = local.version !== undefined ? `@mmnto/cli@${local.version}` : '@mmnto/cli';
   const selfLabel = opts?.selfVersion !== undefined ? ` (this binary: ${opts.selfVersion})` : '';
@@ -135,5 +147,10 @@ export function maybeReexecLocal(opts?: ReexecOptions): number | undefined {
     stdio: 'inherit',
     env: { ...env, TOTEM_NO_REEXEC: '1' },
   });
+  // A spawn-level failure AFTER announcing delegation is reported, never
+  // swallowed — the user saw the delegation start; they must see why it died.
+  if (child.error !== undefined) {
+    process.stderr.write(`[totem] Delegation failed to start: ${child.error.message}\n`);
+  }
   return child.status ?? 1;
 }

--- a/packages/pack-agent-security/test/repo-sweep.test.ts
+++ b/packages/pack-agent-security/test/repo-sweep.test.ts
@@ -223,6 +223,13 @@ const ALLOWLIST: AllowEntry[] = [
   },
   {
     hash: 'c2c09301bb56a02b',
+    file: 'packages/cli/src/reexec-local.ts',
+    expectedCount: 1,
+    reason:
+      'The mmnto-ai/totem#2018 L1 prefer-local re-exec. Cannot route through safeExec: delegation needs stdio inherit (live passthrough of the child CLI session) and non-throwing exit-code propagation (a delegated `totem lint` exiting 1 is a normal outcome to forward, not an exception), while safeExec is pipe-buffered and throws on non-zero. The spawn target is process.execPath (node itself) + the identity-guarded @mmnto/cli entry path; argv rides as an array, no shell, TOTEM_NO_REEXEC loop guard on the child env.',
+  },
+  {
+    hash: 'c2c09301bb56a02b',
     file: 'packages/cli/src/commands/doctor.ts',
     expectedCount: 7,
     reason:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       commander:
         specifier: ^13.1.0
         version: 13.1.0
+      cross-spawn:
+        specifier: ^7.0.6
+        version: 7.0.6
       dotenv:
         specifier: ^16.4.0
         version: 16.6.1
@@ -88,6 +91,9 @@ importers:
       '@google/genai':
         specifier: ^2.6.0
         version: 2.6.0(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))
+      '@types/cross-spawn':
+        specifier: ^6.0.6
+        version: 6.0.6
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.13


### PR DESCRIPTION
Closes #2018 — layer 1 of the layered plan on the issue (L2 shipped in #2150 / 1.58.1; L3 is the `knowledge-search-access` usable-rung probe riding the #2140 family, no work owed here).

## What

When a foreign totem binary — typically an ambient global install — starts inside a project that carries its own `@mmnto/cli`, the entrypoint now delegates to the project-local build before any command wiring. This promotes the deterministic tiers of the ADR-072 resolve cascade (shipped for git hooks in #2053) into the binary itself, per Tenet 14: the pinned local install is deterministic, the PATH global is ambient. It forecloses both variants of the recurring wrong-binary class — missing externalized peer SDKs (#2018, 6 recurrences across 2 agent seats) and stale-version shadowing (#2053) — by making the wrong binary unreachable from inside a workspace.

- **Resolution** (`resolveLocalEntry`): walk up from cwd — tier 1 `packages/cli/dist/index.js` identity-guarded on the package name (workspace-HEAD), tier 2 `node_modules/@mmnto/cli/dist/index.js` (pinned). Both require the BUILT entry; an unbuilt checkout runs in place, where the L2 hint explains the build step.
- **Delegation** (`maybeReexecLocal`): realpath identity short-circuit (already-local runs in place); `TOTEM_NO_REEXEC=1` opts out AND rides the child env as the loop guard; announced on stderr with both versions, never silent; child exit code propagated, null status maps to failure. Spawn via `cross-spawn` (the primitive `safeExec` wraps — `safeExec` itself is pipe-buffered and throws on non-zero, which delegation cannot use), target `process.execPath` + the guarded entry, argv as array, no shell. Allowlisted in the pack-agent-security repo sweep with justification, mirroring the `exec.ts` precedent.
- Docs: installation.md gains the delegation + opt-out subsection. Minor changeset.

## Verification

TDD (13 unit tests RED→GREEN covering both tiers, the guard, identity short-circuit, opt-out, argv/env/status propagation). End-to-end verified live: the workspace build run inside a stub consumer project delegated with the announce line, forwarded argv intact, and propagated exit code 42; run in its own workspace it identity-short-circuits (no loop, Windows realpaths normalized). Full pre-push gate green: repo format, eslint, 5049 tests, full-branch `totem lint` 0 errors. Two gate rounds during development are their own commits: the security-pack sweep allowlist (with the safeExec-cannot-serve-this rationale) and the cross-spawn routing the lint rule correctly demanded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)