### PR TITLE
fix(cli): re-exec success path crashed on cross-spawn error: null (1.59.0 hotfix)

### DIFF
--- a/.changeset/reexec-error-null-hotfix.md
+++ b/.changeset/reexec-error-null-hotfix.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/cli': patch
+---
+
+Hotfix: 1.59.0's prefer-local re-exec crashed the parent's exit path after every SUCCESSFUL delegation — cross-spawn fills `error: null` (not `undefined`) on success, and the spawn-failure check read `.message` off the null. The child's work completed but the invoking process exited 1 with a raw TypeError. Caught on the first live delegation; the success shape is now regression-locked in tests.

--- a/packages/cli/src/reexec-local.test.ts
+++ b/packages/cli/src/reexec-local.test.ts
@@ -184,6 +184,41 @@ describe('maybeReexecLocal', () => {
     ).toThrow();
   });
 
+  it("mirrors cross-spawn's real success shape — error: null must not crash the exit path", () => {
+    // Regression: cross-spawn fills `error: null` (not undefined) on success;
+    // 1.59.0 crashed every successful delegation here (live, first run).
+    writePinnedTier(tmpRoot);
+    const spawn = vi.fn().mockReturnValue({ status: 0, signal: null, error: null });
+    const status = maybeReexecLocal({
+      cwd: tmpRoot,
+      argv: ['--version'],
+      env: {},
+      selfPath: path.join(tmpRoot, 'elsewhere', 'index.js'),
+      spawn,
+    });
+    expect(status).toBe(0);
+  });
+
+  it('a spawn-level error is reported on stderr after the announce', () => {
+    writePinnedTier(tmpRoot);
+    const stderr = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    try {
+      const spawn = vi.fn().mockReturnValue({ status: null, error: new Error('boom') });
+      const status = maybeReexecLocal({
+        cwd: tmpRoot,
+        argv: [],
+        env: {},
+        selfPath: path.join(tmpRoot, 'elsewhere', 'index.js'),
+        spawn,
+      });
+      expect(status).toBe(1);
+      const writes = stderr.mock.calls.map((c) => String(c[0])).join('\n');
+      expect(writes).toContain('Delegation failed to start: boom');
+    } finally {
+      stderr.mockRestore();
+    }
+  });
+
   it('a null child status maps to failure, never silent success', () => {
     writePinnedTier(tmpRoot);
     const spawn = vi.fn().mockReturnValue({ status: null });

--- a/packages/cli/src/reexec-local.ts
+++ b/packages/cli/src/reexec-local.ts
@@ -149,7 +149,10 @@ export function maybeReexecLocal(opts?: ReexecOptions): number | undefined {
   });
   // A spawn-level failure AFTER announcing delegation is reported, never
   // swallowed — the user saw the delegation start; they must see why it died.
-  if (child.error !== undefined) {
+  // Loose != null: cross-spawn fills `error: null` on SUCCESS (verified live
+  // on the 1.59.0 first run — a strict !== undefined check crashed every
+  // successful delegation's exit path).
+  if (child.error != null) {
     process.stderr.write(`[totem] Delegation failed to start: ${child.error.message}\n`);
   }
   return child.status ?? 1;


### PR DESCRIPTION
## Problem — 1.59.0 regression, caught on the first live delegation

`cross-spawn` fills `error: null` (not `undefined`) on **success**. The #2153 spawn-failure check used `child.error !== undefined`, so every SUCCESSFUL delegation completed the child's work and then crashed the parent's exit path with a raw `TypeError: Cannot read properties of null` — wrong exit code on every delegated command under 1.59.0.

Found minutes after the 1.59.0 global update, on the very first real delegation in the dogfood repo. The unit mocks omitted the `error` property (undefined) instead of mirroring cross-spawn's real `null` — a mock-fidelity gap, now closed.

## Change

- `child.error != null` (loose) — handles both absent and null.
- Two regression tests: cross-spawn's real success shape (`{ status: 0, signal: null, error: null }`) must return the child status cleanly, and a genuine spawn error must report `Delegation failed to start: <msg>` on stderr after the announce.
- Patch changeset → 1.59.1.

## Verification

17/17 module tests, full-branch `totem lint` PASS 0 errors, full pre-push gate green. The live global-binary verification completes once 1.59.1 publishes and the global updates (the crash lives in the released parent binary, not the workspace).

🤖 Generated with [Claude Code](https://claude.com/claude-code)