### PR TITLE
docs(models): June-2026 model + provider refresh — drop deprecating gemini-2.5, add gemini-3.5-flash + Antigravity (agy)

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -393,6 +393,8 @@ orchestrator: {
 }
 ```
 
+> **Note:** This example uses the Gemini CLI, whose consumer access (AI Pro / Ultra / free) is retiring **June 18, 2026** — see [supported-models.md](supported-models.md#google-gemini). The shell provider accepts any CLI that emits one-shot JSON; substitute your tool's command accordingly.
+
 ### Generic OpenAI Provider (native API)
 
 Direct SDK calls using the standard OpenAI-compatible format. Defaults to `gpt-5.4-mini` for execution capabilities:

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -393,16 +393,6 @@ orchestrator: {
 }
 ```
 
-The same provider runs the **Antigravity CLI** (`agy`) — the successor to the Gemini CLI (which is being retired in favor of `agy`; see [supported-models.md](supported-models.md)) — as a shell target like any other agent CLI. The command below mirrors the Gemini CLI's flag interface; confirm against your installed `agy` version:
-
-```typescript
-orchestrator: {
-  provider: 'shell',
-  command: 'agy --model {model} -o json -e none < {file}',
-  defaultModel: 'gemini-3.5-flash',
-}
-```
-
 ### Generic OpenAI Provider (native API)
 
 Direct SDK calls using the standard OpenAI-compatible format. Defaults to `gpt-5.4-mini` for execution capabilities:

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -393,6 +393,16 @@ orchestrator: {
 }
 ```
 
+The same provider runs the **Antigravity CLI** (`agy`) — the successor to the Gemini CLI (which is being retired in favor of `agy`; see [supported-models.md](supported-models.md)) — as a shell target like any other agent CLI. The command below mirrors the Gemini CLI's flag interface; confirm against your installed `agy` version:
+
+```typescript
+orchestrator: {
+  provider: 'shell',
+  command: 'agy --model {model} -o json -e none < {file}',
+  defaultModel: 'gemini-3.5-flash',
+}
+```
+
 ### Generic OpenAI Provider (native API)
 
 Direct SDK calls using the standard OpenAI-compatible format. Defaults to `gpt-5.4-mini` for execution capabilities:

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -388,7 +388,7 @@ orchestrator: {
   provider: 'shell',
   command: 'gemini --model {model} -o json -e none < {file}',
   defaultModel: 'gemini-3-flash-preview',
-  fallbackModel: 'gemini-2.5-flash',
+  fallbackModel: 'gemini-3.1-flash-lite',
   overrides: { spec: 'gemini-3.1-pro-preview' },
 }
 ```
@@ -422,8 +422,8 @@ Direct SDK calls via Google GenAI. Requires API keys and adheres to bound consen
 ```typescript
 orchestrator: {
   provider: 'gemini',
-  defaultModel: 'gemini-2.5-flash',
-  fallbackModel: 'gemini-2.5-pro',
+  defaultModel: 'gemini-3-flash-preview',
+  fallbackModel: 'gemini-3.1-pro-preview',
 }
 ```
 

--- a/docs/reference/supported-models.md
+++ b/docs/reference/supported-models.md
@@ -14,15 +14,15 @@ Used by `totem review`, `totem spec`, `totem triage`, `totem extract`, etc.
 
 ### Google Gemini
 
-| Role                | Model ID                         | Notes                                                                          |
-| ------------------- | -------------------------------- | ------------------------------------------------------------------------------ |
-| Flagship (agentic)  | `gemini-3.5-flash`               | GA flagship — coding/agentic; Gemini API + Antigravity (per Google model docs) |
-| Default (fast)      | `gemini-3-flash-preview`         | Preview — current Totem default                                                |
-| Pro (complex tasks) | `gemini-3.1-pro-preview`         | Replaced `gemini-3-pro-preview` (March 2026)                                   |
-| Image generation    | `gemini-3.1-flash-image-preview` | Flash variant optimized for image tasks                                        |
-| Fast-lite (newest)  | `gemini-3.1-flash-lite`          | 2.5x faster TTFT than Flash, lowest cost                                       |
-| Stable fast         | `gemini-2.5-flash`               | GA — **deprecating June 17, 2026**                                             |
-| Stable pro          | `gemini-2.5-pro`                 | GA — **deprecating June 17, 2026**                                             |
+| Role                | Model ID                         | Notes                                                                                                                               |
+| ------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Flagship (agentic)  | `gemini-3.5-flash`               | GA flagship — coding/agentic; Gemini API + Antigravity. **Not Totem's default** (default stays `gemini-3-flash-preview`, next row). |
+| Default (fast)      | `gemini-3-flash-preview`         | Preview — current Totem default                                                                                                     |
+| Pro (complex tasks) | `gemini-3.1-pro-preview`         | Replaced `gemini-3-pro-preview` (March 2026)                                                                                        |
+| Image generation    | `gemini-3.1-flash-image-preview` | Flash variant optimized for image tasks                                                                                             |
+| Fast-lite (newest)  | `gemini-3.1-flash-lite`          | 2.5x faster TTFT than Flash, lowest cost                                                                                            |
+| Stable fast         | `gemini-2.5-flash`               | GA — **deprecating June 17, 2026**                                                                                                  |
+| Stable pro          | `gemini-2.5-pro`                 | GA — **deprecating June 17, 2026**                                                                                                  |
 
 **Listing API:** `GET https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY`
 

--- a/docs/reference/supported-models.md
+++ b/docs/reference/supported-models.md
@@ -14,22 +14,22 @@ Used by `totem review`, `totem spec`, `totem triage`, `totem extract`, etc.
 
 ### Google Gemini
 
-| Role                | Model ID                         | Notes                                        |
-| ------------------- | -------------------------------- | -------------------------------------------- |
+| Role                | Model ID                         | Notes                                                                          |
+| ------------------- | -------------------------------- | ------------------------------------------------------------------------------ |
 | Flagship (agentic)  | `gemini-3.5-flash`               | GA flagship — coding/agentic; Gemini API + Antigravity (per Google model docs) |
-| Default (fast)      | `gemini-3-flash-preview`         | Preview — current Totem default              |
-| Pro (complex tasks) | `gemini-3.1-pro-preview`         | Replaced `gemini-3-pro-preview` (March 2026) |
-| Image generation    | `gemini-3.1-flash-image-preview` | Flash variant optimized for image tasks      |
-| Fast-lite (newest)  | `gemini-3.1-flash-lite`          | 2.5x faster TTFT than Flash, lowest cost     |
-| Stable fast         | `gemini-2.5-flash`               | GA — **deprecating June 17, 2026**           |
-| Stable pro          | `gemini-2.5-pro`                 | GA — **deprecating June 17, 2026**           |
+| Default (fast)      | `gemini-3-flash-preview`         | Preview — current Totem default                                                |
+| Pro (complex tasks) | `gemini-3.1-pro-preview`         | Replaced `gemini-3-pro-preview` (March 2026)                                   |
+| Image generation    | `gemini-3.1-flash-image-preview` | Flash variant optimized for image tasks                                        |
+| Fast-lite (newest)  | `gemini-3.1-flash-lite`          | 2.5x faster TTFT than Flash, lowest cost                                       |
+| Stable fast         | `gemini-2.5-flash`               | GA — **deprecating June 17, 2026**                                             |
+| Stable pro          | `gemini-2.5-pro`                 | GA — **deprecating June 17, 2026**                                             |
 
 **Listing API:** `GET https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY`
 
 - Auth: API key as query parameter
 - Docs: https://ai.google.dev/api/models
 - Note: `gemini-3-pro-preview` was discontinued March 26, 2026. Use `gemini-3.1-pro-preview`.
-- **Gemini CLI → Antigravity CLI (`agy`):** per Google's announced transition, the Gemini CLI is folding into the Antigravity CLI, with consumer Gemini CLI / Code Assist access ending mid-2026 (enterprise retains access). The shell-provider orchestrator (see [architecture.md](architecture.md)) can invoke `agy` as a CLI target like any other tool; `gemini-3.5-flash` is reachable via the Gemini API and Antigravity. Confirm exact dates and CLI flags against Google's current docs before relying on them.
+- **Gemini CLI → Antigravity (`agy`):** Google is retiring the Gemini CLI and Gemini Code Assist IDE extensions for consumer (AI Pro / Ultra / free) usage on **June 18, 2026**, folding them into the Antigravity platform (enterprise retains access). `gemini-3.5-flash` is reachable via the Gemini API and Antigravity. Note: Antigravity's `agy` is an _agentic_ CLI (a harness, not a one-shot `-o json` completion tool), so it is **not** a drop-in shell-provider orchestrator target — integration is TBD.
 
 ### Anthropic (Claude)
 

--- a/docs/reference/supported-models.md
+++ b/docs/reference/supported-models.md
@@ -1,6 +1,6 @@
 # Supported Models & AI Tools Reference
 
-> **Last validated:** 2026-05-02 (1.25.0 ship state)
+> **Last validated:** 2026-05-02 (1.25.0 ship state). The Gemini tier below was refreshed 2026-06-13 from Google's published model docs (a targeted update, not a full re-validation).
 
 Totem supports four LLM provider families for orchestration, and exports project
 knowledge to all major AI coding tools. This document tracks model IDs, tool
@@ -16,6 +16,7 @@ Used by `totem review`, `totem spec`, `totem triage`, `totem extract`, etc.
 
 | Role                | Model ID                         | Notes                                        |
 | ------------------- | -------------------------------- | -------------------------------------------- |
+| Flagship (agentic)  | `gemini-3.5-flash`               | GA flagship — coding/agentic; Gemini API + Antigravity (per Google model docs) |
 | Default (fast)      | `gemini-3-flash-preview`         | Preview — current Totem default              |
 | Pro (complex tasks) | `gemini-3.1-pro-preview`         | Replaced `gemini-3-pro-preview` (March 2026) |
 | Image generation    | `gemini-3.1-flash-image-preview` | Flash variant optimized for image tasks      |
@@ -28,6 +29,7 @@ Used by `totem review`, `totem spec`, `totem triage`, `totem extract`, etc.
 - Auth: API key as query parameter
 - Docs: https://ai.google.dev/api/models
 - Note: `gemini-3-pro-preview` was discontinued March 26, 2026. Use `gemini-3.1-pro-preview`.
+- **Gemini CLI → Antigravity CLI (`agy`):** per Google's announced transition, the Gemini CLI is folding into the Antigravity CLI, with consumer Gemini CLI / Code Assist access ending mid-2026 (enterprise retains access). The shell-provider orchestrator (see [architecture.md](architecture.md)) can invoke `agy` as a CLI target like any other tool; `gemini-3.5-flash` is reachable via the Gemini API and Antigravity. Confirm exact dates and CLI flags against Google's current docs before relying on them.
 
 ### Anthropic (Claude)
 


### PR DESCRIPTION
## What

Refreshes the model/provider docs to current state (June 2026), two parts:

**1. Drop June-17-deprecating models** (`architecture.md` provider examples) — replaced `gemini-2.5-flash`/`gemini-2.5-pro` with the successors `supported-models.md` already declares:

- `provider: 'gemini'` defaultModel → `gemini-3-flash-preview`; fallbackModel → `gemini-3.1-pro-preview`
- `provider: 'shell'` fallbackModel → `gemini-3.1-flash-lite`

**2. Add gemini-3.5-flash + document the Antigravity (agy) transition**:

- `supported-models.md`: adds `gemini-3.5-flash` (GA flagship, coding/agentic) — it was missing from the canonical table — and a note on the Gemini CLI → Antigravity CLI (`agy`) transition.
- `architecture.md`: model-ID swaps in the provider examples. (An `agy` shell-provider example was originally proposed here but **dropped after review** — see Update below.)

## Sourcing / claim discipline

Model facts are **sourced from Google's published model docs and attributed in-text** — a targeted refresh, not an independent re-validation (the "Last validated" stamp is left honest). The `gemini-3.5-flash` GA claim and the Gemini-CLI → Antigravity consumer sunset date (**June 18, 2026**) were **web-verified** against Google I/O 2026 coverage during review. Docs-only; no code or config defaults changed.

## Update — 2026-06-13 (totem-claude, post-review)

Reviewed + corrected on behalf of `@totem-claude` (the model-strategy owner):

- **Dropped the proposed `agy` shell-provider example.** Verified against the installed Antigravity CLI (`agy` v1.0.8): its flags differ from the Gemini CLI (`-o json` / `-e none` don't exist), and more fundamentally agy is an _agentic harness with no JSON output mode_ — so it can't satisfy the shell provider's one-shot-JSON contract. It is not a drop-in shell-provider target; `supported-models.md` now documents the transition and flags integration as TBD.
- **Verified + kept** `gemini-3.5-flash` (GA, May 2026) and the **June 18, 2026** consumer sunset.
- **Bot-round nits addressed** (Greptile 4/5 + CodeRabbit): the shell-provider example now cross-references the CLI retirement; the Flagship row is clarified as _not_ Totem's default (default stays `gemini-3-flash-preview` — flipping the orchestrator default to the GA flagship is a separate runtime decision, out of scope here).

## Owner note (original, agy)

Surfaced by the totem-strategy docs-governance inventory (mmnto-ai/totem-strategy#639 / Proposal 297); the deeper fix (architecture.md deriving model defaults from supported-models rather than hardcoding) is the 297 REFRESH, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
