### PR TITLE
feat(review): deterministic structural post-checks with decidable tiers (#2103, 474 slice 4)

### DIFF
--- a/.totem/specs/2103.md
+++ b/.totem/specs/2103.md
@@ -1,0 +1,241 @@
+> **⚠ REVIEWERS — the authoritative contract is the [`## Implementation Design`](#implementation-design) section at the bottom.** This auto-generated spec was written before the code was read; its **file paths** (`packages/cli/src/services/post-checks/…`) and **type contracts** are **superseded**. Real types live in `packages/core/src/artifacts/schema.ts`; **admission class is a closed two-value enum** (`completion_only` | `self_grounding_agent`) — `spec`/`review` are `runMetadata.caller` values, **not** admission classes; rule applicability keys off the whole artifact (`appliesTo(artifact)`), not a `targetClasses` array. The sections below are retained only for the problem framing, the ADR-109/Tenet-9 anchors, the edge-case list, and the #2090/#2091 eval-fixture pointers. **OQ5 is resolved: this slice ships the engine + rules + fixtures only — no live `spec`/`review` gating wiring.**
+
+### Problem Statement
+
+The system requires zero-LLM, deterministic post-checks that evaluate an LLM's run artifact against its grounding bundle, keyed off the run's `runMetadata.caller` (`spec` / `review`) and `backend.admissionClass` (`completion_only` / `self_grounding_agent`). These checks must rigidly split into "decidable" (which gate and reject the run on failure) and "undecidable" (which act only as telemetry sensors), ensuring noisy LLM-based evaluations do not block workflows.
+
+### Architectural Context
+
+- **ADR-109 (Noisy gates train bypass):** Blurring decidable structural checks with undecidable heuristic/LLM checks trains users to bypass the gate entirely. Gating MUST be restricted exclusively to deterministic, decidable structural checks.
+- **Tenet 9:** Verdict aggregation must be a script, not an LLM. An LLM cannot grade its own structural compliance.
+- **Artifact & Grounding Bundle Seams:** Builds on the foundational types established in #2100, #2101, and #2102.
+
+### Files to Examine
+
+1. `packages/cli/src/services/run-artifacts.ts` — Understand the structure of run artifacts and how they are loaded, as this is the primary input to the post-checks.
+2. `.totem/specs/2090.md` & `2091.md` (if available in the repo) — Contains the ground truth fixtures for the `spec` class checks where a nonexistent file was invented.
+
+### Technical Approach & Contracts
+
+> **[SUPERSEDED by `## Implementation Design`]** — the `PostCheckContext`/`PostCheckRule` shapes and the `packages/cli/src/services/post-checks/` location below are the pre-grounding draft. The design section relocates them to `packages/core/src/artifacts/`, replaces `targetClasses: string[]` with `appliesTo(artifact): boolean`, and replaces `ctx.{cwd,gitRoot}` with `ctx.{configRoot,readFile,overrideMemory}`. Read the code block below only for the broad shape (tier enum, verdict enum, aggregator idea); take the field-level contract from the design section.
+
+We will implement an extensible, zero-LLM structural evaluation runner.
+
+**Data Contracts (`packages/cli/src/services/post-checks/types.ts`):**
+
+```typescript
+import { z } from 'zod';
+
+export const EnforcementTierSchema = z.enum(['decidable', 'sensor']);
+export type EnforcementTier = z.infer<typeof EnforcementTierSchema>;
+
+export const CheckVerdictSchema = z.enum(['pass', 'fail', 'abstain']);
+export type CheckVerdict = z.infer<typeof CheckVerdictSchema>;
+
+export const PostCheckFindingSchema = z.object({
+  ruleName: z.string(),
+  tier: EnforcementTierSchema,
+  verdict: CheckVerdictSchema,
+  message: z.string(),
+  context: z.record(z.unknown()).optional(),
+});
+export type PostCheckFinding = z.infer<typeof PostCheckFindingSchema>;
+
+export const PostCheckReportSchema = z.object({
+  findings: z.array(PostCheckFindingSchema),
+  // true if ANY decidable check returns 'fail'
+  isRejected: z.boolean(),
+});
+export type PostCheckReport = z.infer<typeof PostCheckReportSchema>;
+
+export interface PostCheckContext {
+  cwd: string;
+  gitRoot: string; // resolved via resolveGitRoot
+  outputContract?: z.ZodSchema;
+}
+
+export interface PostCheckRule {
+  name: string;
+  tier: EnforcementTier;
+  targetClasses: string[]; // e.g., ['spec', 'review'] or ['*']
+  evaluate: (
+    artifact: RunArtifact,
+    bundle: GroundingBundle,
+    ctx: PostCheckContext,
+  ) => CheckVerdict | Promise<CheckVerdict>;
+}
+```
+
+**Implementation Approach:**
+
+1. **Aggregator Engine:** A central `evaluatePostChecks` function that takes the artifact, bundle, and a list of registered `PostCheckRule` instances. It maps over them, executes the relevant ones based on the artifact's admission class, and computes the final `isRejected` state purely based on the `decidable` tier findings.
+2. **Contract Rule (Decidable):** Verifies the `artifact.output` payload cleanly parses against `ctx.outputContract`.
+3. **Citation Resolution Rule (Decidable):** Parses citation markers from the output (or bundle references), uses `fs.existsSync` and line number boundary checks to ensure the cited files physically exist in the workspace.
+4. **Spec Rule (Decidable):** Targets `spec` class. Uses regex to extract file paths (e.g., matching `[\w\-]+/[\w\-./]+`). If a path does not exist on disk, the output text _must_ contain the exact string `VERIFY:`. If missing, it fails.
+5. **Review Rule (Decidable):** Targets `review` class. Compares the output against the grounding bundle's override memory. If an anchored span marked as a rejected override reappears in the output verbatim, it fails.
+
+### Edge Cases & Traps
+
+- **Security / Path Traversal:** When checking if cited files exist, paths MUST be resolved securely relative to the git root using `resolveGitRoot`. An LLM outputting `../../../etc/passwd` must not crash the resolution or erroneously pass.
+- **Sensor vs. Gate Leakage:** A failed `sensor` rule (like summary faithfulness) setting `isRejected = true` would be a catastrophic regression of ADR-109. The aggregator logic must strictly filter by `tier === 'decidable'`.
+- **False Positives in Spec Paths:** The regex extracting paths from `spec` outputs might match arbitrary text. Restrict path extraction to code blocks, backticked strings, or standardized citation formats to prevent deterministic false failures.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Define Post-Check Contracts & Aggregator**
+  - Create `packages/cli/src/services/post-checks/types.ts` with the schemas defined above.
+  - Create `packages/cli/src/services/post-checks/aggregator.ts`.
+  - Implement `evaluatePostChecks(artifact, bundle, rules, ctx): Promise<PostCheckReport>`.
+    > TOTEM INVARIANT (ADR-109): Only rules with tier === 'decidable' are permitted to set `isRejected: true` on failure.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `allows undecidable sensor failures to pass gate while failing on decidable failures` that proves the regression is caught.
+  - Update `packages/cli/src/services/post-checks/aggregator.test.ts`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Implement Output Contract Rule**
+  - Create `packages/cli/src/services/post-checks/rules/contract.ts`.
+  - Implement a `decidable` rule targeting `['*']`.
+  - If `ctx.outputContract` is undefined, return `abstain`.
+  - Try parsing `artifact.output` with the schema. Return `pass` if successful, `fail` if throws.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `rejects output that fails outputContract validation` that proves the regression is caught.
+  - Update `packages/cli/src/services/post-checks/rules/contract.test.ts`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Implement Citation Resolution Rule**
+  - Create `packages/cli/src/services/post-checks/rules/citation.ts`.
+  - Implement a `decidable` rule targeting `['self_grounding_agent', 'review']`.
+  - Parse citations (assuming a standard structure in the bundle/artifact, or using `extractChangedFiles` from shared helpers if analyzing diff chunks).
+  - Use `resolveGitRoot` to securely anchor paths. Return `fail` if a cited file does not physically exist.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `fails when a cited file does not exist in the repository` that proves the regression is caught.
+  - Update `packages/cli/src/services/post-checks/rules/citation.test.ts`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Implement Spec VERIFY Requirement Rule**
+  - Create `packages/cli/src/services/post-checks/rules/spec-verify.ts`.
+  - Implement a `decidable` rule targeting `['spec']`.
+  - Extract backticked paths or explicit file path strings from `artifact.output`.
+  - Use `resolveGitRoot` and `fs.existsSync`.
+  - If any path does _not_ exist AND the string `VERIFY:` does not appear anywhere in `artifact.output`, return `fail`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `fails spec output that invents a nonexistent path without VERIFY marker` that proves the regression is caught.
+  - Update `packages/cli/src/services/post-checks/rules/spec-verify.test.ts`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 5: Integrate 2090/2091 Fixture Evaluation**
+  - Create `packages/cli/src/services/post-checks/fixtures.test.ts`.
+  - Load the seeded 2090/2091 fixtures (using `readJsonSafe` from `@mmnto/totem` shared helpers).
+  - Execute `evaluatePostChecks` using the `Spec VERIFY Requirement Rule` against these fixtures.
+  - Assert that the structural checks deterministically fail the run exactly as modeled in the PR #2098 ground truth.
+    > TOTEM INVARIANT (Tenet 9): Verdict aggregation must be completely deterministic and execute with zero LLM calls during the fixture run.
+  - write test → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Aggregator Logic**: Pass an array of mock findings with mixed tiers (`decidable` and `sensor`) and mixed verdicts (`pass`, `fail`, `abstain`). Ensure `isRejected` is exactly `true` if and only if a `decidable` rule returns `fail`.
+- **Contract Adherence**: Supply an artifact outputting an array to a rule expecting an object. Must fail the decidable rule.
+- **Spec VERIFY Check**: Provide an artifact with `packages/cli/src/utils/diff-selector.ts` (nonexistent). Must fail if `VERIFY:` is missing. Must pass if `VERIFY:` is present.
+- **Security Check**: Attempt to provide `../../../../../etc/passwd` in a citation or spec output. Must gracefully handle path resolution via `resolveGitRoot` and not crash or execute outside the git boundary.
+
+---
+
+## Implementation Design
+
+> **Spec correction (grounded against the real #2100/#2101/#2102 code).** The auto-generated spec above assumed (a) everything lives in `packages/cli/src/services/post-checks/` and (b) four admission classes incl. `spec`/`review`. Both are wrong. The real types are in `packages/core/src/artifacts/schema.ts`; **admission class is a closed two-value enum** (`completion_only` | `self_grounding_agent`) — `spec`/`review` are `runMetadata.caller` / `backend.taskProfile` values, not admission classes. This design supersedes the spec's contracts where they differ.
+
+### Scope
+
+Deliver a pure, zero-LLM post-check engine in `packages/core/src/artifacts/` that evaluates a loaded `RunArtifact` against its `grounding.bundle` + admitted `outputContract`, emitting per-finding verdicts split into `decidable` (may gate) vs `sensor` (telemetry only) tiers, with `isRejected` computed ONLY from decidable failures (ADR-109). It will **NOT** wire gating into the live `spec`/`review` commands (OQ5), **NOT** build the override-memory store (#2105 — this slice consumes an injected set), and **NOT** add any LLM-judge or citation-_supports_ gate.
+
+### Data model deltas
+
+New module `packages/core/src/artifacts/post-checks.ts` (+ `post-checks/rules/*.ts`). **No persisted-schema changes** — `RunArtifact` already carries every input (`admission.outputContract`, `grounding.bundle`, `runMetadata.caller`, `backend.{taskProfile,admissionClass}`, `output.content`). New types are in-memory only → plain TS interfaces, **not Zod** (Zod-at-boundaries rule; these never hit disk):
+
+- `EnforcementTier = 'decidable' | 'sensor'` — declared **statically** on each rule; read by the aggregator. Held: the gate-eligibility of a rule. Invariant: tier is NEVER derived from a verdict.
+- `CheckVerdict = 'pass' | 'fail' | 'abstain'` — returned by `evaluate`; read by aggregator.
+- `PostCheckFinding { ruleName; tier; verdict; message; context? }` — one per applicable rule.
+- `PostCheckReport { findings; isRejected }` — **aggregator is sole writer of `isRejected`**; invariant `isRejected === findings.some(f => f.tier==='decidable' && f.verdict==='fail')`.
+- `PostCheckRule { name; tier; appliesTo(artifact): boolean; evaluate(artifact, ctx): CheckVerdict | Promise<CheckVerdict> }` — `appliesTo` inspects the **whole artifact** (so it can key on `runMetadata.caller` AND `admissionClass`, not a single `targetClasses` array). Rules are module constants.
+- `PostCheckContext { configRoot; readFile?; overrideMemory? }` — `configRoot` anchors citation `filePath` resolution (schema rule: absent `sourceRepo` ⇒ run's own repo); `overrideMemory` injected, empty until #2105.
+
+No reserved keys / sentinels — tier and verdict are separate fields.
+
+### State lifecycle
+
+All state is **per-invocation**. `evaluatePostChecks` is pure: maps the rule set over the artifact, collects findings, computes `isRejected`, returns. No module-level mutable state, no cache, no server-lifetime state. Injected `overrideMemory` is owned by the caller (#2105's store later); this slice only reads it.
+
+### Failure modes
+
+| Failure                                                    | Category | Agent-facing surface                                 | Recovery                                                                   |
+| ---------------------------------------------------------- | -------- | ---------------------------------------------------- | -------------------------------------------------------------------------- |
+| Cited path escapes repo (`../../etc/passwd`)               | runtime  | `fail` (decidable); never reads outside `configRoot` | `resolveGitRoot` + path-containment check; out-of-root ⇒ fail, no fs throw |
+| Cited file missing on disk                                 | runtime  | `fail` (decidable)                                   | the intended gate — output cites nonexistent evidence                      |
+| `outputContract.schema` present, `output.content` not JSON | runtime  | `fail` (decidable)                                   | structured-output contract violated                                        |
+| No `outputContract` / no `bundle` (slice-1 artifact)       | runtime  | every rule `abstain`                                 | honest-absent; report all-abstain, `isRejected=false`                      |
+| `overrideMemory` absent (pre-#2105)                        | runtime  | override rule `abstain`                              | engine complete; rule no-ops until store supplied                          |
+| Unknown provenance class on an item                        | runtime  | `sensor` finding (not-upgraded), never gates         | fail-safe-down (F2); the F2 enforcement test rides this slice              |
+| A rule's `evaluate` throws unexpectedly                    | runtime  | OQ4 — loud decidable `fail` w/ error in `message`    | one broken rule must not blind the others                                  |
+
+No row is `silent degradation`: every abstain is an explicit finding (Tenet 4 honest-absent).
+
+### Invariants to lock in via tests
+
+- A `sensor` rule returning `fail` leaves `isRejected===false`; only a `decidable` `fail` sets it true.
+- A `spec`-caller artifact citing a nonexistent path WITHOUT `VERIFY:` ⇒ decidable `fail`; WITH `VERIFY:` ⇒ pass/abstain (the #2090/#2091 fixtures reproduce this exactly).
+- A cited path resolving outside `configRoot` returns `fail` with **no** filesystem throw.
+- An unknown provenance-class item is treated as not-upgraded and never contributes to a gate (F2).
+- The review override rule gates ONLY when an override set is supplied; empty set ⇒ abstain.
+- `outputContract` absent ⇒ all contract/citation rules abstain, `isRejected===false`.
+
+### Open questions
+
+- **OQ1 — class-targeting key.** Rules must know "spec run vs review run"; admission class can't carry it (closed 2-value enum). Options: (a) `runMetadata.caller` (`'spec'`/`'review'`, added by #2102 for this); (b) `backend.taskProfile` (`'Spec'`/`'Review'`). **Recommend (a)**, falling back to `taskProfile` when `caller` absent (slice-1/2 artifacts predate `runMetadata`).
+- **OQ2 — override rule vs store (#2105).** #2103 "owns the check," #2105 "owns the memory." Options: (a) implement the rule now against an injected `OverrideSet` (empty ⇒ abstain), #2105 supplies the store; (b) defer the review override rule wholly to #2105. **Recommend (a)** — engine stays complete, slice boundary sits at the data not the logic.
+- **OQ3 — citation extraction format.** What counts as a citation in `output.content`? Options: (a) conservative — only backticked `` `path` `` / `` `path:line` `` tokens resolved against bundle `filePath`s; (b) any path-like regex (the spec's own false-positive trap). **Recommend (a)**; citation-_resolves_ (file exists + line-in-range) gates, citation-_supports_ stays sensor-only (ADR-109).
+- **OQ4 — unexpected rule throw.** Options: (a) catch ⇒ emit a loud decidable `fail` naming the error; (b) propagate and fail the whole run. **Recommend (a)** — a swallowed error breaks Tenet 4; surfacing it as a visible fail keeps the other checks alive.
+- **OQ5 — live wiring (scope boundary).** Does this slice GATE the real `spec`/`review` commands, or land engine + rules + fixtures only? **Recommend engine + rules + fixtures only** (the issue's stated deliverable); live gating wiring rides a follow-on once #2104/#2105 land, so production output isn't gated on day-one rules. Flag if you want wiring in-scope now.
+
+---
+
+## Review folds (cohort pre-build round, 2026-06-14 — operator-approved)
+
+Verdicts: **totem-gemini PASS · totem-agy PASS · totem-codex CONDITIONAL PASS**. OQ5 resolved by operator = **engine + rules + fixtures only, no live `spec`/`review` gating this slice.** The build target below supersedes the OQ recommendations where they differ.
+
+### Contract folds (codex — must-fold before build)
+
+1. **OQ4 revised — a thrown rule PRESERVES its declared tier.** Not "throw → loud _decidable_ fail" (that lets a _sensor_ rule reject by throwing — an ADR-109 leak). A thrown **decidable** rule → `decidable` fail (may reject); a thrown **sensor** rule → `sensor` fail (never rejects). A genuine engine-integrity fault is an **engine-level exception thrown out of `evaluatePostChecks`**, never rewritten into a `PostCheckFinding`. Locked by test: _a sensor rule that throws leaves `isRejected === false`._
+2. **OQ1 revised — `taskProfileAlias` helper.** Identity = `artifact.admission?.runMetadata?.caller ?? taskProfileAlias(artifact.backend.taskProfile)`, where aliases are `Spec→spec`, `Review→review`, **`Shield→review`** (old review artifacts carry `taskProfile: 'Shield'` — `TAG='Shield'`/`DISPLAY_TAG='Review'` in `packages/cli/src/commands/shield-templates.ts`). An unknown value makes caller-scoped rules **abstain loudly**, never guess.
+3. **OQ3/OutputContract — THREE rules, not one.** Split the single contract rule into:
+   - **structured-output** (decidable): `outputContract.schema` absent → abstain; present → parse `output.content` as JSON and validate against the JSON-Schema; non-JSON → decidable `fail`. (Prose output is never treated as malformed JSON unless a schema was supplied.)
+   - **citation-resolves** (decidable): when `citationsRequired`, gate only on mechanics — cited file exists, line-in-range, cited bundle item exists. Claim _support_ stays sensor-only.
+   - **verify-fallback** (decidable): `verifyFallback` controls whether an explicit `VERIFY:` is an acceptable substitute for an uncitable path/API/schema claim; if `false` while citations are required, `VERIFY:` is **not** a pass.
+
+### Passes with riders
+
+- **F2** (PASS): include an enforcement test with a non-canonical class (e.g. `execution-verified`) asserting not-upgraded + `isRejected === false`.
+- **OQ2 override boundary** (PASS): #2103 defines only the **minimum rule-consumption interface** (injected `OverrideSet`) + tests — no persisted store, no file reader, no durable finding identity, no anchored-span key format beyond what the injected set supplies. Empty/absent override memory → explicit `abstain` finding.
+
+### Build directives (agy — fold into impl + tests)
+
+- **win32 containment:** reject raw-absolute / drive-letter citations up front; normalize separators (`\\`→`/`) **before** resolve; `resolvedAbsolute.startsWith(normalizedRoot + '/')`. Out-of-root → decidable `fail`, never a throw.
+- **citation extraction:** strip multi-line code fences (` ```…``` `) from `output.content` _before_ backtick extraction; reject backticked tokens lacking a path separator OR a known extension (`.ts/.js/.md/.json/.tsx/.go`) so single-word tokens (`` `main` ``) are ignored.
+- **line-in-range matrix:** `line<=0` → fail; `line>totalLines` → fail; non-numeric → path-only (skip line check); range `start-end` → fail if `start<=0 || end<=0 || end<start || end>totalLines`. 1-indexed against `content.split('\n')`.
+- **fixtures:** `#2090`/`#2091` ground truth is markdown in `.totem/specs/` — the fixture loader parses frontmatter/YAML, not raw JSON; `fixtures.test.ts` makes **zero** LLM calls.
+- **test-matrix (must-cover profiles):** (a) slice-1 historic `{caller:undefined, completion_only, no contract, no bundle}` → all-abstain, `isRejected=false`; (b) code-blind `{caller:'spec', runMetadata.codeBlind:true}` → spec checks run, missing code context doesn't false-fail; (c) F2 unknown-provenance item → lowest-trust, no crash.

--- a/packages/core/src/artifacts/post-checks-rules.test.ts
+++ b/packages/core/src/artifacts/post-checks-rules.test.ts
@@ -85,6 +85,9 @@ describe('isContained — win32-safe containment', () => {
     // POSIX treats `\` as a literal char; normalization must still catch this escape.
     expect(isContained('/repo', 'src\\..\\..\\etc/passwd')).toBe(false);
   });
+  it('does not false-reject a filename that merely starts with .. (segment check, not startsWith)', () => {
+    expect(isContained('/repo', '..foo.ts')).toBe(true);
+  });
   it('rejects an absolute path', () => {
     expect(isContained('/repo', '/etc/passwd')).toBe(false);
   });

--- a/packages/core/src/artifacts/post-checks-rules.test.ts
+++ b/packages/core/src/artifacts/post-checks-rules.test.ts
@@ -1,0 +1,275 @@
+/**
+ * Post-check rule + helper tests (mmnto-ai/totem#2103, strategy#474 slice 4).
+ * Covers the agy edge-case matrix (containment/win32, citation extraction,
+ * line-range boundaries), the codex contract folds (3 OutputContract rules,
+ * spec VERIFY + verifyFallback), the OQ2 override boundary, and the F2
+ * provenance sensor end-to-end through the engine.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { evaluatePostChecks, type PostCheckContext } from './post-checks.js';
+import {
+  citationResolvesRule,
+  DEFAULT_RULES,
+  extractCitations,
+  isContained,
+  lineRefValid,
+  overrideReappearanceRule,
+  specVerifyRule,
+  structuredOutputRule,
+} from './post-checks-rules.js';
+import type { RunArtifact } from './schema.js';
+
+interface ArtifactOpts {
+  caller?: string;
+  taskProfile?: string;
+  content?: string;
+  outputContract?: {
+    schema?: Record<string, unknown>;
+    citationsRequired?: boolean;
+    verifyFallback?: boolean;
+  };
+  bundleItems?: Array<{ filePath: string; provenance?: string }>;
+}
+
+function artifact(o: ArtifactOpts = {}): RunArtifact {
+  const { caller, taskProfile = 'Spec', content = '', outputContract, bundleItems } = o;
+  const a: Record<string, unknown> = {
+    backend: { taskProfile },
+    output: { content },
+    grounding: {},
+  };
+  if (caller !== undefined || outputContract !== undefined) {
+    const admission: Record<string, unknown> = {};
+    if (caller !== undefined) admission.runMetadata = { caller };
+    if (outputContract !== undefined) admission.outputContract = outputContract;
+    a.admission = admission;
+  }
+  if (bundleItems !== undefined) {
+    (a.grounding as Record<string, unknown>).bundle = {
+      items: bundleItems.map((b) => ({
+        provenance: b.provenance ?? 'similarity-only',
+        filePath: b.filePath,
+      })),
+    };
+  }
+  return a as unknown as RunArtifact;
+}
+
+/** A readFile stub: returns a 5-line file for any path whose normalized form ends with a known suffix. */
+function readStub(existing: string[]): PostCheckContext['readFile'] {
+  const norm = (p: string) => p.replace(/\\/g, '/');
+  return (abs) => (existing.some((e) => norm(abs).endsWith(e)) ? 'a\nb\nc\nd\ne' : undefined);
+}
+
+const ctx = (existing: string[] = []): PostCheckContext => ({
+  configRoot: '/repo',
+  readFile: readStub(existing),
+});
+
+describe('isContained — win32-safe containment', () => {
+  it('accepts a relative path nested in root', () => {
+    expect(isContained('/repo', 'src/x.ts')).toBe(true);
+  });
+  it('rejects parent-traversal escape', () => {
+    expect(isContained('/repo', '../../etc/passwd')).toBe(false);
+  });
+  it('rejects mixed-separator traversal (win32)', () => {
+    expect(isContained('/repo', 'src\\..\\..\\etc/passwd')).toBe(false);
+  });
+  it('rejects an absolute path', () => {
+    expect(isContained('/repo', '/etc/passwd')).toBe(false);
+  });
+  it('rejects a drive-letter path', () => {
+    expect(isContained('/repo', 'C:\\Windows\\System32')).toBe(false);
+  });
+});
+
+describe('extractCitations', () => {
+  it('parses path, path:line, and path:start-end', () => {
+    const cites = extractCitations('see `src/a.ts`, `src/b.ts:12`, and `src/c.ts:3-9`');
+    expect(cites).toEqual([
+      { raw: 'src/a.ts', filePath: 'src/a.ts' },
+      { raw: 'src/b.ts:12', filePath: 'src/b.ts', line: 12 },
+      { raw: 'src/c.ts:3-9', filePath: 'src/c.ts', line: 3, endLine: 9 },
+    ]);
+  });
+  it('strips fenced code blocks before extracting', () => {
+    const content = 'real `src/real.ts`\n```ts\nimport `src/fake.ts`\n```\n';
+    expect(extractCitations(content).map((c) => c.filePath)).toEqual(['src/real.ts']);
+  });
+  it('ignores backticked tokens with no separator or known extension', () => {
+    expect(extractCitations('run `main` then `pnpm test`')).toEqual([]);
+  });
+  it('keeps a bare filename with a known extension', () => {
+    expect(extractCitations('the `tsconfig.json` file').map((c) => c.filePath)).toEqual([
+      'tsconfig.json',
+    ]);
+  });
+});
+
+describe('lineRefValid — boundary matrix', () => {
+  it('path-only (no line) always passes', () => expect(lineRefValid(5)).toBe(true));
+  it('line in range passes', () => expect(lineRefValid(5, 5)).toBe(true));
+  it('line 0 fails', () => expect(lineRefValid(5, 0)).toBe(false));
+  it('line beyond EOF fails', () => expect(lineRefValid(5, 6)).toBe(false));
+  it('valid range passes', () => expect(lineRefValid(5, 2, 4)).toBe(true));
+  it('inverted range fails', () => expect(lineRefValid(5, 4, 2)).toBe(false));
+  it('range past EOF fails', () => expect(lineRefValid(5, 2, 99)).toBe(false));
+});
+
+describe('structuredOutputRule', () => {
+  it('abstains when no schema is declared', async () => {
+    expect(
+      (await structuredOutputRule.evaluate(artifact({ content: 'prose' }), ctx())).verdict,
+    ).toBe('abstain');
+  });
+  it('applies to all runs (abstains without a schema rather than being gated out)', () => {
+    expect(structuredOutputRule.appliesTo(artifact({ content: 'prose' }))).toBe(true);
+  });
+  it('fails when schema is declared but content is not JSON', async () => {
+    const a = artifact({ content: 'not json', outputContract: { schema: { type: 'object' } } });
+    expect((await structuredOutputRule.evaluate(a, ctx())).verdict).toBe('fail');
+  });
+  it('passes when schema is declared and content is JSON', async () => {
+    const a = artifact({ content: '{"ok":true}', outputContract: { schema: { type: 'object' } } });
+    expect((await structuredOutputRule.evaluate(a, ctx())).verdict).toBe('pass');
+  });
+});
+
+describe('citationResolvesRule', () => {
+  it('abstains when citations are not required by the contract', async () => {
+    const a = artifact({ content: 'see `src/a.ts`' });
+    expect((await citationResolvesRule.evaluate(a, ctx(['src/a.ts']))).verdict).toBe('abstain');
+  });
+  it('passes when every citation resolves and lines are in range', async () => {
+    const a = artifact({
+      content: 'see `src/a.ts:2` and `src/b.ts`',
+      outputContract: { citationsRequired: true },
+    });
+    expect((await citationResolvesRule.evaluate(a, ctx(['src/a.ts', 'src/b.ts']))).verdict).toBe(
+      'pass',
+    );
+  });
+  it('fails on a missing file', async () => {
+    const a = artifact({
+      content: 'see `src/gone.ts`',
+      outputContract: { citationsRequired: true },
+    });
+    expect((await citationResolvesRule.evaluate(a, ctx([]))).verdict).toBe('fail');
+  });
+  it('fails on an out-of-range line', async () => {
+    const a = artifact({
+      content: 'see `src/a.ts:99`',
+      outputContract: { citationsRequired: true },
+    });
+    expect((await citationResolvesRule.evaluate(a, ctx(['src/a.ts']))).verdict).toBe('fail');
+  });
+  it('fails a review citation outside the delivered bundle', async () => {
+    const a = artifact({
+      caller: 'review',
+      content: 'see `src/a.ts`',
+      outputContract: { citationsRequired: true },
+      bundleItems: [{ filePath: 'src/other.ts' }],
+    });
+    expect((await citationResolvesRule.evaluate(a, ctx(['src/a.ts']))).verdict).toBe('fail');
+  });
+  it('abstains when there are no citations to resolve', async () => {
+    const a = artifact({
+      content: 'no citations here',
+      outputContract: { citationsRequired: true },
+    });
+    expect((await citationResolvesRule.evaluate(a, ctx())).verdict).toBe('abstain');
+  });
+});
+
+describe('specVerifyRule — the #2090/#2091 fabrication class', () => {
+  const invented = 'The fix lives in `packages/cli/src/utils/diff-selector.ts`.';
+
+  it('fails a spec citing a nonexistent path without VERIFY:', async () => {
+    const a = artifact({ caller: 'spec', content: invented });
+    expect((await specVerifyRule.evaluate(a, ctx([]))).verdict).toBe('fail');
+  });
+  it('passes when VERIFY: marks the unresolved path', async () => {
+    const a = artifact({
+      caller: 'spec',
+      content: `${invented}\nVERIFY: this path may not exist yet.`,
+    });
+    expect((await specVerifyRule.evaluate(a, ctx([]))).verdict).toBe('pass');
+  });
+  it('still fails with VERIFY: when verifyFallback is disabled', async () => {
+    const a = artifact({
+      caller: 'spec',
+      content: `${invented}\nVERIFY: x`,
+      outputContract: { verifyFallback: false },
+    });
+    expect((await specVerifyRule.evaluate(a, ctx([]))).verdict).toBe('fail');
+  });
+  it('passes when all cited paths resolve', async () => {
+    const a = artifact({
+      caller: 'spec',
+      content: 'see `packages/cli/src/utils/diff-selector.ts`',
+    });
+    expect(
+      (await specVerifyRule.evaluate(a, ctx(['packages/cli/src/utils/diff-selector.ts']))).verdict,
+    ).toBe('pass');
+  });
+  it('does not apply to review runs', () => {
+    expect(specVerifyRule.appliesTo(artifact({ caller: 'review' }))).toBe(false);
+  });
+});
+
+describe('overrideReappearanceRule — OQ2 boundary', () => {
+  it('abstains when no override memory is supplied', async () => {
+    const a = artifact({ caller: 'review', content: 'anything' });
+    expect((await overrideReappearanceRule.evaluate(a, ctx())).verdict).toBe('abstain');
+  });
+  it('passes when no override reappears', async () => {
+    const a = artifact({ caller: 'review', content: 'clean output' });
+    const c: PostCheckContext = { ...ctx(), overrideMemory: { reappearsIn: () => [] } };
+    expect((await overrideReappearanceRule.evaluate(a, c)).verdict).toBe('pass');
+  });
+  it('fails when the store reports a reappearance', async () => {
+    const a = artifact({ caller: 'review', content: 'the rejected claim is back' });
+    const c: PostCheckContext = { ...ctx(), overrideMemory: { reappearsIn: () => ['override-7'] } };
+    expect((await overrideReappearanceRule.evaluate(a, c)).verdict).toBe('fail');
+  });
+});
+
+describe('engine + DEFAULT_RULES integration', () => {
+  it('rejects the #2090 fabrication end-to-end', async () => {
+    const a = artifact({
+      caller: 'spec',
+      content: 'see `packages/cli/src/utils/diff-selector.ts`',
+    });
+    const r = await evaluatePostChecks(a, DEFAULT_RULES, ctx([]));
+    expect(r.isRejected).toBe(true);
+    expect(r.findings.find((f) => f.ruleName === 'spec-verify')?.verdict).toBe('fail');
+  });
+
+  it('F2: a non-canonical provenance class is a SENSOR signal and never rejects', async () => {
+    const a = artifact({
+      caller: 'spec',
+      content: 'no citations',
+      bundleItems: [{ filePath: 'src/a.ts', provenance: 'execution-verified' }],
+    });
+    const r = await evaluatePostChecks(a, DEFAULT_RULES, ctx());
+    const prov = r.findings.find((f) => f.ruleName === 'provenance-fail-safe-down');
+    expect(prov).toMatchObject({ tier: 'sensor', verdict: 'fail' });
+    expect(r.isRejected).toBe(false);
+  });
+
+  it('a slice-1 historic artifact (no caller, no contract, no bundle) is all-abstain and does not reject', async () => {
+    const a = artifact({ caller: undefined, taskProfile: 'Spec', content: '' });
+    // taskProfile 'Spec' still resolves caller -> spec; use an unknown profile for a true historic no-caller run.
+    const historic = artifact({
+      taskProfile: 'LegacyUnknown',
+      content: 'plain text, no citations',
+    });
+    const r = await evaluatePostChecks(historic, DEFAULT_RULES, ctx());
+    expect(r.isRejected).toBe(false);
+    expect(r.findings.every((f) => f.verdict === 'abstain')).toBe(true);
+    void a;
+  });
+});

--- a/packages/core/src/artifacts/post-checks-rules.test.ts
+++ b/packages/core/src/artifacts/post-checks-rules.test.ts
@@ -112,6 +112,9 @@ describe('extractCitations', () => {
   it('ignores backticked tokens with no separator or known extension', () => {
     expect(extractCitations('run `main` then `pnpm test`')).toEqual([]);
   });
+  it('ignores URL tokens even when they carry a separator and a known extension', () => {
+    expect(extractCitations('see `https://pkg.go.dev/path/filepath.ts`')).toEqual([]);
+  });
   it('keeps a bare filename with a known extension', () => {
     expect(extractCitations('the `tsconfig.json` file').map((c) => c.filePath)).toEqual([
       'tsconfig.json',

--- a/packages/core/src/artifacts/post-checks-rules.test.ts
+++ b/packages/core/src/artifacts/post-checks-rules.test.ts
@@ -25,6 +25,7 @@ interface ArtifactOpts {
   caller?: string;
   taskProfile?: string;
   content?: string;
+  codeBlind?: boolean;
   outputContract?: {
     schema?: Record<string, unknown>;
     citationsRequired?: boolean;
@@ -34,15 +35,20 @@ interface ArtifactOpts {
 }
 
 function artifact(o: ArtifactOpts = {}): RunArtifact {
-  const { caller, taskProfile = 'Spec', content = '', outputContract, bundleItems } = o;
+  const { caller, taskProfile = 'Spec', content = '', codeBlind, outputContract, bundleItems } = o;
   const a: Record<string, unknown> = {
     backend: { taskProfile },
     output: { content },
     grounding: {},
   };
-  if (caller !== undefined || outputContract !== undefined) {
+  if (caller !== undefined || codeBlind !== undefined || outputContract !== undefined) {
     const admission: Record<string, unknown> = {};
-    if (caller !== undefined) admission.runMetadata = { caller };
+    if (caller !== undefined || codeBlind !== undefined) {
+      const runMetadata: Record<string, unknown> = {};
+      if (caller !== undefined) runMetadata.caller = caller;
+      if (codeBlind !== undefined) runMetadata.codeBlind = codeBlind;
+      admission.runMetadata = runMetadata;
+    }
     if (outputContract !== undefined) admission.outputContract = outputContract;
     a.admission = admission;
   }
@@ -261,9 +267,9 @@ describe('engine + DEFAULT_RULES integration', () => {
     expect(r.isRejected).toBe(false);
   });
 
-  it('a slice-1 historic artifact (no caller, no contract, no bundle) is all-abstain and does not reject', async () => {
-    const a = artifact({ caller: undefined, taskProfile: 'Spec', content: '' });
-    // taskProfile 'Spec' still resolves caller -> spec; use an unknown profile for a true historic no-caller run.
+  it('slice-1 historic artifact (unknown profile, no contract, no bundle) is all-abstain and does not reject', async () => {
+    // Unknown taskProfile + no caller → resolveCaller undefined → caller-scoped rules
+    // don't apply; the contract/bundle rules abstain. Protects retrofitted history.
     const historic = artifact({
       taskProfile: 'LegacyUnknown',
       content: 'plain text, no citations',
@@ -271,6 +277,22 @@ describe('engine + DEFAULT_RULES integration', () => {
     const r = await evaluatePostChecks(historic, DEFAULT_RULES, ctx());
     expect(r.isRejected).toBe(false);
     expect(r.findings.every((f) => f.verdict === 'abstain')).toBe(true);
-    void a;
+  });
+
+  it('code-blind profile: spec checks still run and a resolvable citation does not false-fail', async () => {
+    // agy must-cover profile (b): a code-blind spec run (zero code retrieved) still runs
+    // spec-verify; the codeBlind flag is inert to the gates and must not cause a fail.
+    const a = artifact({
+      caller: 'spec',
+      codeBlind: true,
+      content: 'see `packages/cli/src/utils/diff-selector.ts`',
+    });
+    const r = await evaluatePostChecks(
+      a,
+      DEFAULT_RULES,
+      ctx(['packages/cli/src/utils/diff-selector.ts']),
+    );
+    expect(r.isRejected).toBe(false);
+    expect(r.findings.find((f) => f.ruleName === 'spec-verify')?.verdict).toBe('pass');
   });
 });

--- a/packages/core/src/artifacts/post-checks-rules.test.ts
+++ b/packages/core/src/artifacts/post-checks-rules.test.ts
@@ -75,7 +75,8 @@ describe('isContained — win32-safe containment', () => {
   it('rejects parent-traversal escape', () => {
     expect(isContained('/repo', '../../etc/passwd')).toBe(false);
   });
-  it('rejects mixed-separator traversal (win32)', () => {
+  it('rejects backslash-separator traversal on any platform', () => {
+    // POSIX treats `\` as a literal char; normalization must still catch this escape.
     expect(isContained('/repo', 'src\\..\\..\\etc/passwd')).toBe(false);
   });
   it('rejects an absolute path', () => {

--- a/packages/core/src/artifacts/post-checks-rules.ts
+++ b/packages/core/src/artifacts/post-checks-rules.ts
@@ -57,13 +57,13 @@ export function isContained(configRoot: string, citedPath: string): boolean {
   // makes traversal detection identical on win32 and POSIX.
   const normalizedCited = citedPath.replace(/\\/g, '/');
   const root = path.resolve(configRoot);
-  const resolved = path.resolve(configRoot, normalizedCited);
-  // path.relative containment (GCA review): robust vs a `startsWith(root + '/')`
-  // prefix check — no hardcoded separator (so a filesystem-root config never
-  // double-slashes into a false fail), and a cross-drive escape comes back as an
-  // absolute path. `''` = the citation IS the root.
-  const rel = path.relative(root, resolved);
-  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+  // path.join (NOT path.resolve) so a normalized-absolute segment can't reset the
+  // base out of root (GCA review — absolute-path injection); then path.relative +
+  // a FIRST-SEGMENT check (not startsWith, which would false-reject a `..foo` file)
+  // and a cross-drive guard. No hardcoded separator → a filesystem-root config
+  // never double-slashes into a false fail.
+  const rel = path.relative(root, path.join(root, normalizedCited));
+  return rel.split(path.sep)[0] !== '..' && !path.isAbsolute(rel);
 }
 
 /** A parsed citation token: the path plus an optional 1-indexed line or line range. */

--- a/packages/core/src/artifacts/post-checks-rules.ts
+++ b/packages/core/src/artifacts/post-checks-rules.ts
@@ -47,8 +47,13 @@ function readFileVia(ctx: PostCheckContext, absPath: string): string | undefined
  */
 export function isContained(configRoot: string, citedPath: string): boolean {
   if (path.isAbsolute(citedPath) || /^[a-zA-Z]:/.test(citedPath)) return false;
+  // Normalize separators BEFORE resolving: on POSIX `\` is a literal filename
+  // char, so `src\..\..\etc/passwd` would NOT get its `..` collapsed by
+  // path.resolve and would escape the root undetected. Forward-slashing first
+  // makes traversal detection identical on win32 and POSIX.
+  const normalizedCited = citedPath.replace(/\\/g, '/');
   const root = path.resolve(configRoot).replace(/\\/g, '/');
-  const resolved = path.resolve(configRoot, citedPath).replace(/\\/g, '/');
+  const resolved = path.resolve(configRoot, normalizedCited).replace(/\\/g, '/');
   return resolved === root || resolved.startsWith(root + '/');
 }
 
@@ -74,8 +79,8 @@ export function extractCitations(content: string): Citation[] {
     const token = match[1].trim();
     const parsed = /^(.+?)(?::(\d+)(?:-(\d+))?)?$/.exec(token);
     if (parsed === null) continue;
-    const filePath = parsed[1];
-    if (!filePath.includes('/') && !filePath.includes('\\') && !KNOWN_EXTENSION.test(filePath)) {
+    const filePath = parsed[1].replace(/\\/g, '/');
+    if (!filePath.includes('/') && !KNOWN_EXTENSION.test(filePath)) {
       continue;
     }
     const citation: Citation = { raw: token, filePath };

--- a/packages/core/src/artifacts/post-checks-rules.ts
+++ b/packages/core/src/artifacts/post-checks-rules.ts
@@ -30,10 +30,9 @@ const CANONICAL_PROVENANCE: ReadonlySet<string> = new Set(PROVENANCE_CLASSES);
 
 /** Default file read: returns the text, or `undefined` if the path does not resolve (honest-absent). */
 function defaultReadFile(absPath: string): string | undefined {
-  // totem-context: honest-absent — a missing/unreadable cited file returns undefined, a
-  // meaningful "not found" signal the citation rules convert into a decidable fail.
   try {
     return readFileSync(absPath, 'utf8');
+    // totem-context: honest-absent — undefined means "not found", consumed as a citation fail.
   } catch {
     return undefined;
   }
@@ -139,11 +138,10 @@ export const structuredOutputRule: PostCheckRule = {
     if (a.admission?.outputContract?.schema === undefined) {
       return { verdict: 'abstain', message: 'no outputContract.schema declared' };
     }
-    // totem-context: fail-loud — a JSON parse failure becomes a decidable 'fail' verdict
-    // (the gate the contract declares), never a silent pass.
     try {
       JSON.parse(a.output.content);
       return { verdict: 'pass', message: 'output parses as JSON (shape-validation deferred)' };
+      // totem-context: fail-loud — a parse failure becomes a decidable 'fail' verdict, not a silent pass.
     } catch {
       return {
         verdict: 'fail',

--- a/packages/core/src/artifacts/post-checks-rules.ts
+++ b/packages/core/src/artifacts/post-checks-rules.ts
@@ -1,0 +1,298 @@
+/**
+ * The default deterministic post-check rule set (mmnto-ai/totem#2103, strategy#474
+ * slice 4). Each rule is zero-LLM and returns a verdict at its STATIC tier; the
+ * aggregator ({@link evaluatePostChecks}) owns rejection. Rule decomposition
+ * follows the cohort pre-build round (codex): the OutputContract's three knobs
+ * (`schema` / `citationsRequired` / `verifyFallback`) are distinct
+ * responsibilities, not one rule.
+ *
+ * Helpers (containment, citation extraction, line-range) are exported for
+ * direct unit testing — they are the load-bearing edge-case surface (agy).
+ */
+
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+import {
+  type CheckResult,
+  type PostCheckContext,
+  type PostCheckRule,
+  resolveCaller,
+} from './post-checks.js';
+import { PROVENANCE_CLASSES } from './schema.js';
+
+const KNOWN_EXTENSION = /\.(ts|tsx|js|jsx|mjs|cjs|md|json|ya?ml|go|py|rs|java|c|cpp|h)$/i;
+const CANONICAL_PROVENANCE: ReadonlySet<string> = new Set(PROVENANCE_CLASSES);
+
+/** Default file read: returns the text, or `undefined` if the path does not resolve (honest-absent). */
+function defaultReadFile(absPath: string): string | undefined {
+  // totem-context: honest-absent — a missing/unreadable cited file returns undefined, a
+  // meaningful "not found" signal the citation rules convert into a decidable fail.
+  try {
+    return readFileSync(absPath, 'utf8');
+  } catch {
+    return undefined;
+  }
+}
+
+function readFileVia(ctx: PostCheckContext, absPath: string): string | undefined {
+  return (ctx.readFile ?? defaultReadFile)(absPath);
+}
+
+/**
+ * Is `citedPath` a relative path nested inside `configRoot`? Rejects absolute
+ * paths and Windows drive-letters up front, normalizes separators BEFORE
+ * resolving (win32: `src\..\..\etc/passwd` must not slip), then requires the
+ * resolved path to stay under the root (agy review on mmnto-ai/totem#2103).
+ */
+export function isContained(configRoot: string, citedPath: string): boolean {
+  if (path.isAbsolute(citedPath) || /^[a-zA-Z]:/.test(citedPath)) return false;
+  const root = path.resolve(configRoot).replace(/\\/g, '/');
+  const resolved = path.resolve(configRoot, citedPath).replace(/\\/g, '/');
+  return resolved === root || resolved.startsWith(root + '/');
+}
+
+/** A parsed citation token: the path plus an optional 1-indexed line or line range. */
+export interface Citation {
+  raw: string;
+  filePath: string;
+  line?: number;
+  endLine?: number;
+}
+
+/**
+ * Conservatively extract `path` / `path:line` / `path:start-end` citations from
+ * backticked spans in `content`. Strips fenced code blocks first (their sample
+ * paths / command logs would false-fail), and ignores backticked tokens that
+ * carry neither a path separator nor a known extension — so `` `main` `` /
+ * `` `pnpm test` `` are not treated as citations (agy review on mmnto-ai/totem#2103).
+ */
+export function extractCitations(content: string): Citation[] {
+  const withoutFences = content.replace(/```[\s\S]*?```/g, '');
+  const citations: Citation[] = [];
+  for (const match of withoutFences.matchAll(/`([^`]+)`/g)) {
+    const token = match[1].trim();
+    const parsed = /^(.+?)(?::(\d+)(?:-(\d+))?)?$/.exec(token);
+    if (parsed === null) continue;
+    const filePath = parsed[1];
+    if (!filePath.includes('/') && !filePath.includes('\\') && !KNOWN_EXTENSION.test(filePath)) {
+      continue;
+    }
+    const citation: Citation = { raw: token, filePath };
+    if (parsed[2] !== undefined) citation.line = Number(parsed[2]);
+    if (parsed[3] !== undefined) citation.endLine = Number(parsed[3]);
+    citations.push(citation);
+  }
+  return citations;
+}
+
+/**
+ * Is a citation's line reference valid against a file of `totalLines` lines?
+ * Path-only citations (no line) always pass the line check. 1-indexed; a range
+ * requires `0 < start <= end <= totalLines` (agy boundary matrix).
+ */
+export function lineRefValid(totalLines: number, line?: number, endLine?: number): boolean {
+  if (line === undefined) return true;
+  if (!Number.isInteger(line) || line <= 0 || line > totalLines) return false;
+  if (endLine !== undefined) {
+    if (!Number.isInteger(endLine) || endLine < line || endLine > totalLines) return false;
+  }
+  return true;
+}
+
+function countLines(text: string): number {
+  return text.split('\n').length;
+}
+
+// ── Rules ──────────────────────────────────────────────────────────────────
+
+/**
+ * Structured-output contract (decidable, all callers). Absent `schema` ⇒
+ * abstain (prose output is never treated as malformed JSON). Present ⇒
+ * `output.content` must parse as JSON; non-JSON is a decidable fail. NOTE: deep
+ * JSON-Schema shape validation is a follow-on — core carries no validator
+ * dependency this slice, so the gate is parse-only (codex review: "non-JSON is
+ * a decidable fail").
+ */
+export const structuredOutputRule: PostCheckRule = {
+  name: 'structured-output',
+  tier: 'decidable',
+  appliesTo: () => true,
+  evaluate: (a): CheckResult => {
+    if (a.admission?.outputContract?.schema === undefined) {
+      return { verdict: 'abstain', message: 'no outputContract.schema declared' };
+    }
+    // totem-context: fail-loud — a JSON parse failure becomes a decidable 'fail' verdict
+    // (the gate the contract declares), never a silent pass.
+    try {
+      JSON.parse(a.output.content);
+      return { verdict: 'pass', message: 'output parses as JSON (shape-validation deferred)' };
+    } catch {
+      return {
+        verdict: 'fail',
+        message: 'outputContract.schema declared but output.content is not valid JSON',
+      };
+    }
+  },
+};
+
+/**
+ * Citation resolution (decidable). Gates only when the caller declared
+ * `citationsRequired`. For each cited path: must be in-root, the file must
+ * exist, and any line reference must be in range. For a `review` run, a citation
+ * outside the delivered grounding bundle is also a fail (review cites what it was
+ * given). Claim *support* (does the cited text back the claim) stays sensor-only
+ * — out of scope here (ADR-109).
+ */
+export const citationResolvesRule: PostCheckRule = {
+  name: 'citation-resolves',
+  tier: 'decidable',
+  appliesTo: () => true,
+  evaluate: (a, ctx): CheckResult => {
+    if (a.admission?.outputContract?.citationsRequired !== true) {
+      return { verdict: 'abstain', message: 'citations not required by outputContract' };
+    }
+    const citations = extractCitations(a.output.content);
+    if (citations.length === 0) {
+      return { verdict: 'abstain', message: 'no resolvable path citations in output' };
+    }
+    const bundlePaths =
+      resolveCaller(a) === 'review' && a.grounding.bundle !== undefined
+        ? new Set(a.grounding.bundle.items.map((i) => i.filePath))
+        : undefined;
+    const failures: string[] = [];
+    for (const c of citations) {
+      if (!isContained(ctx.configRoot, c.filePath)) {
+        failures.push(`${c.raw} (escapes repo root)`);
+        continue;
+      }
+      const text = readFileVia(ctx, path.resolve(ctx.configRoot, c.filePath));
+      if (text === undefined) {
+        failures.push(`${c.raw} (file not found)`);
+        continue;
+      }
+      if (!lineRefValid(countLines(text), c.line, c.endLine)) {
+        failures.push(`${c.raw} (line out of range)`);
+        continue;
+      }
+      if (bundlePaths !== undefined && !bundlePaths.has(c.filePath)) {
+        failures.push(`${c.raw} (not in delivered grounding bundle)`);
+      }
+    }
+    if (failures.length === 0) {
+      return { verdict: 'pass', message: `all ${citations.length} citations resolve` };
+    }
+    return {
+      verdict: 'fail',
+      message: `unresolvable citation(s): ${failures.join('; ')}`,
+      context: { failures },
+    };
+  },
+};
+
+/**
+ * Spec VERIFY requirement (decidable, caller `spec`). A spec that references a
+ * path which does not resolve on disk must mark it with `VERIFY:` — otherwise it
+ * is a fabricated path (the mmnto-ai/totem#2090/#2091 class). `VERIFY:` is accepted
+ * as the escape UNLESS the caller set `outputContract.verifyFallback === false`
+ * (the verify-fallback knob, folded here where `VERIFY:` is actually consumed —
+ * codex review).
+ */
+export const specVerifyRule: PostCheckRule = {
+  name: 'spec-verify',
+  tier: 'decidable',
+  appliesTo: (a) => resolveCaller(a) === 'spec',
+  evaluate: (a, ctx): CheckResult => {
+    const content = a.output.content;
+    const citations = extractCitations(content);
+    if (citations.length === 0) {
+      return { verdict: 'abstain', message: 'no path citations in spec output' };
+    }
+    const unresolved = citations.filter((c) => {
+      if (!isContained(ctx.configRoot, c.filePath)) return true;
+      return readFileVia(ctx, path.resolve(ctx.configRoot, c.filePath)) === undefined;
+    });
+    if (unresolved.length === 0) {
+      return { verdict: 'pass', message: `all ${citations.length} cited paths resolve` };
+    }
+    const verifyAllowed = a.admission?.outputContract?.verifyFallback !== false;
+    const hasVerifyMarker = /\bVERIFY:/.test(content);
+    if (verifyAllowed && hasVerifyMarker) {
+      return {
+        verdict: 'pass',
+        message: `${unresolved.length} unresolved path(s) but VERIFY: present`,
+      };
+    }
+    const paths = unresolved.map((c) => c.filePath);
+    return {
+      verdict: 'fail',
+      message: hasVerifyMarker
+        ? `unresolved path(s) and verifyFallback is disabled: ${paths.join(', ')}`
+        : `unresolved cited path(s) without VERIFY:: ${paths.join(', ')}`,
+      context: { unresolved: paths },
+    };
+  },
+};
+
+/**
+ * Override-memory reappearance (decidable, caller `review`). A finding the
+ * operator dispositioned (rejected) must not reappear in a later review. The
+ * anchored-span key format lives in the store (mmnto-ai/totem#2105); this rule only
+ * asks the injected {@link OverrideSet} whether any reappears. Absent store ⇒
+ * abstain (the rule no-ops until #2105 wires a store).
+ */
+export const overrideReappearanceRule: PostCheckRule = {
+  name: 'override-reappearance',
+  tier: 'decidable',
+  appliesTo: (a) => resolveCaller(a) === 'review',
+  evaluate: (a, ctx): CheckResult => {
+    if (ctx.overrideMemory === undefined) {
+      return { verdict: 'abstain', message: 'no override memory supplied (store lands in #2105)' };
+    }
+    const reappeared = ctx.overrideMemory.reappearsIn(a.output.content);
+    if (reappeared.length === 0) {
+      return { verdict: 'pass', message: 'no dispositioned overrides reappeared' };
+    }
+    return {
+      verdict: 'fail',
+      message: `dispositioned override(s) reappeared: ${reappeared.join(', ')}`,
+      context: { reappeared: [...reappeared] },
+    };
+  },
+};
+
+/**
+ * Provenance fail-safe-down sensor (SENSOR, all grounded runs; mmnto-ai/totem#2101
+ * F2 rider, enforcement test rides #2103). A grounding item whose `provenance`
+ * is not a canonical class is surfaced as NOT-upgraded (lowest trust). SENSOR
+ * tier: it is telemetry and can NEVER gate — an invented class must not confer,
+ * nor deny, trust by gating.
+ */
+export const provenanceSensorRule: PostCheckRule = {
+  name: 'provenance-fail-safe-down',
+  tier: 'sensor',
+  appliesTo: (a) => a.grounding.bundle !== undefined,
+  evaluate: (a): CheckResult => {
+    const items = a.grounding.bundle?.items ?? [];
+    const unknown = [
+      ...new Set(items.map((i) => i.provenance).filter((p) => !CANONICAL_PROVENANCE.has(p))),
+    ];
+    if (unknown.length === 0) {
+      return { verdict: 'pass', message: 'all provenance classes canonical' };
+    }
+    return {
+      verdict: 'fail',
+      message: `non-canonical provenance treated as not-upgraded: ${unknown.join(', ')}`,
+      context: { unknown },
+    };
+  },
+};
+
+/** The default rule set, in execution order. */
+export const DEFAULT_RULES: readonly PostCheckRule[] = [
+  structuredOutputRule,
+  citationResolvesRule,
+  specVerifyRule,
+  overrideReappearanceRule,
+  provenanceSensorRule,
+];

--- a/packages/core/src/artifacts/post-checks-rules.ts
+++ b/packages/core/src/artifacts/post-checks-rules.ts
@@ -160,6 +160,13 @@ export const structuredOutputRule: PostCheckRule = {
  * outside the delivered grounding bundle is also a fail (review cites what it was
  * given). Claim *support* (does the cited text back the claim) stays sensor-only
  * — out of scope here (ADR-109).
+ *
+ * Intentional overlap (CR #2177 review): on a `spec` run with `citationsRequired`,
+ * an unresolved path is ALSO flagged by spec-verify — both correctly fail it, so the
+ * report can carry two decidable findings for one path. The rules are independent by
+ * design (different escapes: spec-verify owns the `VERIFY:` fallback, this owns
+ * line-range + bundle membership); de-duplicating overlapping decidable fails belongs
+ * at the live-wiring / aggregation layer (#2104), not by coupling rules in this slice.
  */
 export const citationResolvesRule: PostCheckRule = {
   name: 'citation-resolves',

--- a/packages/core/src/artifacts/post-checks-rules.ts
+++ b/packages/core/src/artifacts/post-checks-rules.ts
@@ -10,6 +10,10 @@
  * direct unit testing — they are the load-bearing edge-case surface (agy).
  */
 
+// `node:fs` is a STATIC import by design (CR #2177 review #3, declined): @mmnto/totem
+// (core) is a Node package — native LanceDB + tree-sitter bindings — never an
+// edge/Deno/browser target, so the module-load portability concern does not apply.
+// The `readFile` seam exists for test injection, not runtime portability.
 import { readFileSync } from 'node:fs';
 import * as path from 'node:path';
 
@@ -52,9 +56,14 @@ export function isContained(configRoot: string, citedPath: string): boolean {
   // path.resolve and would escape the root undetected. Forward-slashing first
   // makes traversal detection identical on win32 and POSIX.
   const normalizedCited = citedPath.replace(/\\/g, '/');
-  const root = path.resolve(configRoot).replace(/\\/g, '/');
-  const resolved = path.resolve(configRoot, normalizedCited).replace(/\\/g, '/');
-  return resolved === root || resolved.startsWith(root + '/');
+  const root = path.resolve(configRoot);
+  const resolved = path.resolve(configRoot, normalizedCited);
+  // path.relative containment (GCA review): robust vs a `startsWith(root + '/')`
+  // prefix check — no hardcoded separator (so a filesystem-root config never
+  // double-slashes into a false fail), and a cross-drive escape comes back as an
+  // absolute path. `''` = the citation IS the root.
+  const rel = path.relative(root, resolved);
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
 }
 
 /** A parsed citation token: the path plus an optional 1-indexed line or line range. */
@@ -80,6 +89,9 @@ export function extractCitations(content: string): Citation[] {
     const parsed = /^(.+?)(?::(\d+)(?:-(\d+))?)?$/.exec(token);
     if (parsed === null) continue;
     const filePath = parsed[1].replace(/\\/g, '/');
+    // Skip URLs (CR review): a `https://…/x.ts` token has a separator + extension,
+    // would fail containment, and would false-fail a spec that links external docs.
+    if (/^https?:\/\//.test(filePath)) continue;
     if (!filePath.includes('/') && !KNOWN_EXTENSION.test(filePath)) {
       continue;
     }
@@ -163,7 +175,9 @@ export const citationResolvesRule: PostCheckRule = {
     }
     const bundlePaths =
       resolveCaller(a) === 'review' && a.grounding.bundle !== undefined
-        ? new Set(a.grounding.bundle.items.map((i) => i.filePath))
+        ? // normalize separators (GCA review): bundle filePaths may be win32 backslash,
+          // cited filePaths are forward-slashed, so compare on a common separator.
+          new Set(a.grounding.bundle.items.map((i) => i.filePath.replace(/\\/g, '/')))
         : undefined;
     const failures: string[] = [];
     for (const c of citations) {
@@ -221,7 +235,10 @@ export const specVerifyRule: PostCheckRule = {
       return { verdict: 'pass', message: `all ${citations.length} cited paths resolve` };
     }
     const verifyAllowed = a.admission?.outputContract?.verifyFallback !== false;
-    const hasVerifyMarker = /\bVERIFY:/.test(content);
+    // Strip fences before the marker search too (Greptile review) — a VERIFY: that
+    // exists only inside a code block (which extractCitations already strips) must
+    // not excuse unresolved paths the citation pass never saw.
+    const hasVerifyMarker = /\bVERIFY:/.test(content.replace(/```[\s\S]*?```/g, ''));
     if (verifyAllowed && hasVerifyMarker) {
       return {
         verdict: 'pass',

--- a/packages/core/src/artifacts/post-checks.test.ts
+++ b/packages/core/src/artifacts/post-checks.test.ts
@@ -136,6 +136,10 @@ describe('resolveCaller — caller identity + taskProfile aliases', () => {
     expect(resolveCaller(makeArtifact({ caller: 'review', taskProfile: 'Spec' }))).toBe('review');
   });
 
+  it('lower-cases a capitalized explicit caller so caller-scoped gates still match', () => {
+    expect(resolveCaller(makeArtifact({ caller: 'Spec', taskProfile: 'Shield' }))).toBe('spec');
+  });
+
   it('falls back to taskProfile alias Spec → spec', () => {
     expect(resolveCaller(makeArtifact({ taskProfile: 'Spec' }))).toBe('spec');
   });

--- a/packages/core/src/artifacts/post-checks.test.ts
+++ b/packages/core/src/artifacts/post-checks.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Post-check engine tests (mmnto-ai/totem#2103, strategy#474 slice 4).
+ *
+ * The invariants the cohort pre-build round locked in:
+ *   - ADR-109: `isRejected` IFF a `decidable` rule fails; a `sensor` fail never gates.
+ *   - codex must-fold: a rule that THROWS fails at its OWN declared tier — a
+ *     sensor throw must not reject (no silent upgrade to decidable).
+ *   - codex OQ1: caller identity prefers `runMetadata.caller`, else a `taskProfile`
+ *     alias incl. the legacy `Shield → review`; unknown → undefined (abstain loudly).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  type CheckResult,
+  evaluatePostChecks,
+  type PostCheckContext,
+  type PostCheckRule,
+  resolveCaller,
+} from './post-checks.js';
+import type { RunArtifact } from './schema.js';
+
+function makeArtifact(overrides: { caller?: string; taskProfile?: string } = {}): RunArtifact {
+  const { caller, taskProfile = 'Spec' } = overrides;
+  return {
+    backend: { taskProfile },
+    ...(caller !== undefined ? { admission: { runMetadata: { caller } } } : {}),
+  } as unknown as RunArtifact;
+}
+
+const ctx: PostCheckContext = { configRoot: '/repo' };
+
+function rule(
+  name: string,
+  tier: 'decidable' | 'sensor',
+  evaluate: () => CheckResult | Promise<CheckResult>,
+  appliesTo: () => boolean = () => true,
+): PostCheckRule {
+  return { name, tier, appliesTo, evaluate };
+}
+
+const pass: CheckResult = { verdict: 'pass', message: 'ok' };
+const fail: CheckResult = { verdict: 'fail', message: 'bad' };
+const abstain: CheckResult = { verdict: 'abstain', message: 'n/a' };
+
+describe('evaluatePostChecks — ADR-109 gate isolation', () => {
+  it('rejects when a decidable rule fails', async () => {
+    const r = await evaluatePostChecks(makeArtifact(), [rule('d', 'decidable', () => fail)], ctx);
+    expect(r.isRejected).toBe(true);
+  });
+
+  it('does NOT reject when only a sensor rule fails', async () => {
+    const r = await evaluatePostChecks(makeArtifact(), [rule('s', 'sensor', () => fail)], ctx);
+    expect(r.isRejected).toBe(false);
+    expect(r.findings).toHaveLength(1);
+    expect(r.findings[0]).toMatchObject({ ruleName: 's', tier: 'sensor', verdict: 'fail' });
+  });
+
+  it('a sensor rule that THROWS yields a sensor fail and does NOT reject', async () => {
+    const r = await evaluatePostChecks(
+      makeArtifact(),
+      [
+        rule('boom', 'sensor', () => {
+          // totem-context: test fixture — an arbitrary Error exercises the engine's
+          // non-Totem throw path; a TotemError would not test that path.
+          throw new Error('kaboom');
+        }),
+      ],
+      ctx,
+    );
+    expect(r.isRejected).toBe(false);
+    expect(r.findings[0]).toMatchObject({ tier: 'sensor', verdict: 'fail' });
+    expect(r.findings[0].message).toContain('kaboom');
+  });
+
+  it('a decidable rule that throws yields a decidable fail and rejects', async () => {
+    const r = await evaluatePostChecks(
+      makeArtifact(),
+      [
+        rule('boom', 'decidable', () => {
+          // totem-context: test fixture — an arbitrary Error exercises the engine's
+          // non-Totem throw path; a TotemError would not test that path.
+          throw new Error('nope');
+        }),
+      ],
+      ctx,
+    );
+    expect(r.isRejected).toBe(true);
+    expect(r.findings[0]).toMatchObject({ tier: 'decidable', verdict: 'fail' });
+  });
+
+  it('skips rules whose appliesTo is false (no finding emitted)', async () => {
+    const r = await evaluatePostChecks(
+      makeArtifact(),
+      [
+        rule(
+          'skip',
+          'decidable',
+          () => fail,
+          () => false,
+        ),
+      ],
+      ctx,
+    );
+    expect(r.findings).toHaveLength(0);
+    expect(r.isRejected).toBe(false);
+  });
+
+  it('all-abstain report does not reject', async () => {
+    const r = await evaluatePostChecks(
+      makeArtifact(),
+      [rule('a', 'decidable', () => abstain), rule('b', 'sensor', () => abstain)],
+      ctx,
+    );
+    expect(r.isRejected).toBe(false);
+    expect(r.findings).toHaveLength(2);
+  });
+
+  it('mixed verdicts reject only on the decidable fail', async () => {
+    const r = await evaluatePostChecks(
+      makeArtifact(),
+      [
+        rule('dp', 'decidable', () => pass),
+        rule('sf', 'sensor', () => fail),
+        rule('df', 'decidable', () => fail),
+      ],
+      ctx,
+    );
+    expect(r.isRejected).toBe(true);
+    expect(r.findings).toHaveLength(3);
+  });
+});
+
+describe('resolveCaller — caller identity + taskProfile aliases', () => {
+  it('prefers explicit runMetadata.caller over taskProfile', () => {
+    expect(resolveCaller(makeArtifact({ caller: 'review', taskProfile: 'Spec' }))).toBe('review');
+  });
+
+  it('falls back to taskProfile alias Spec → spec', () => {
+    expect(resolveCaller(makeArtifact({ taskProfile: 'Spec' }))).toBe('spec');
+  });
+
+  it('falls back to taskProfile alias Review → review', () => {
+    expect(resolveCaller(makeArtifact({ taskProfile: 'Review' }))).toBe('review');
+  });
+
+  it('aliases the legacy Shield routing tag to review', () => {
+    expect(resolveCaller(makeArtifact({ taskProfile: 'Shield' }))).toBe('review');
+  });
+
+  it('returns undefined for an unknown taskProfile', () => {
+    expect(resolveCaller(makeArtifact({ taskProfile: 'Mystery' }))).toBeUndefined();
+  });
+});

--- a/packages/core/src/artifacts/post-checks.ts
+++ b/packages/core/src/artifacts/post-checks.ts
@@ -108,7 +108,10 @@ const TASK_PROFILE_ALIASES: Readonly<Record<string, string>> = {
  */
 export function resolveCaller(artifact: RunArtifact): string | undefined {
   const caller = artifact.admission?.runMetadata?.caller;
-  if (caller !== undefined) return caller;
+  // Lower-case the explicit caller too (CR review): an artifact carrying
+  // `caller: 'Spec'` would otherwise be returned verbatim and silently skip every
+  // caller-scoped gate (which compare against lower-case `'spec'`/`'review'`).
+  if (caller !== undefined) return caller.toLowerCase();
   return TASK_PROFILE_ALIASES[artifact.backend.taskProfile];
 }
 

--- a/packages/core/src/artifacts/post-checks.ts
+++ b/packages/core/src/artifacts/post-checks.ts
@@ -1,0 +1,147 @@
+/**
+ * Deterministic structural post-checks (mmnto-ai/totem#2103, strategy#474 slice 4).
+ *
+ * Zero-LLM, caller-side checks over a finished run artifact. Each check is a
+ * {@link PostCheckRule} that returns a verdict at a STATIC enforcement tier:
+ *   - `decidable` — a structural fact that can be mechanically resolved (a cited
+ *     file exists, a line is in range, output parses against a schema). These
+ *     MAY gate: a decidable `fail` rejects the run.
+ *   - `sensor` — a softer signal (claim support, summary faithfulness). These
+ *     NEVER gate; they are telemetry only.
+ *
+ * The load-bearing invariant (ADR-109 — blurring decidable gates with soft
+ * sensors trains users to bypass the gate): `isRejected` is true IFF some
+ * `decidable` rule returned `fail`. A `sensor` finding can never set it — and
+ * critically (mmnto-ai/totem#2103 codex review), a rule that THROWS is a fail at
+ * the rule's OWN declared tier, never silently upgraded to decidable. A sensor
+ * rule that throws must not reject the run.
+ *
+ * Verdict aggregation is a pure script, never an LLM (Tenet 9). This module is
+ * in-memory only (no persisted shape) → plain TS interfaces, not Zod.
+ */
+
+import { getErrorMessage } from '../errors.js';
+import type { RunArtifact } from './schema.js';
+
+/** Whether a rule's verdict may gate (`decidable`) or is telemetry only (`sensor`). */
+export type EnforcementTier = 'decidable' | 'sensor';
+
+/** A single rule's outcome. `abstain` = the rule did not apply to this artifact's content (honest-absent), distinct from `pass`. */
+export type CheckVerdict = 'pass' | 'fail' | 'abstain';
+
+/**
+ * What a rule's `evaluate` returns: the verdict plus a human-facing reason
+ * (every finding explains itself — Tenet 4, no silent degradation) and optional
+ * structured context for the eval harness.
+ */
+export interface CheckResult {
+  verdict: CheckVerdict;
+  message: string;
+  context?: Record<string, unknown>;
+}
+
+/** A finding as recorded in the report: a {@link CheckResult} stamped with the rule's identity + static tier. */
+export interface PostCheckFinding extends CheckResult {
+  ruleName: string;
+  tier: EnforcementTier;
+}
+
+/** The aggregate report. `isRejected` is owned solely by {@link evaluatePostChecks}. */
+export interface PostCheckReport {
+  findings: PostCheckFinding[];
+  /** True IFF a `decidable` finding has verdict `fail`. Nothing else may set it. */
+  isRejected: boolean;
+}
+
+/**
+ * The minimum override-memory interface a review rule consumes (mmnto-ai/totem#2103
+ * OQ2 — this slice owns the CHECK, mmnto-ai/totem#2105 owns the STORE). #2103 defines
+ * only this read shape; no persisted schema, no file reader, no durable identity
+ * format beyond what the injected set supplies. Absent ⇒ the override rule abstains.
+ */
+export interface OverrideSet {
+  /**
+   * Identities of recorded (still-rejected) overrides whose anchored span
+   * reappears verbatim in `outputContent`. Empty ⇒ none reappeared. The
+   * anchored-span KEY FORMAT lives entirely in the store (mmnto-ai/totem#2105);
+   * #2103 only asks "did any reappear" and never constructs a key (OQ2 boundary).
+   */
+  reappearsIn(outputContent: string): readonly string[];
+}
+
+/** Per-invocation context. `configRoot` anchors citation `filePath` resolution (schema: absent `sourceRepo` ⇒ run's own repo). */
+export interface PostCheckContext {
+  configRoot: string;
+  /** Test seam — override the file read. Production callers omit it (defaults to a real fs read). */
+  readFile?: (absPath: string) => string | undefined;
+  /** Injected by the caller; empty/absent until mmnto-ai/totem#2105 supplies a store. */
+  overrideMemory?: OverrideSet;
+}
+
+/** A structural post-check. `tier` is STATIC (never derived from a verdict). `appliesTo` sees the whole artifact so it can key on caller AND admission class. */
+export interface PostCheckRule {
+  name: string;
+  tier: EnforcementTier;
+  appliesTo(artifact: RunArtifact): boolean;
+  evaluate(artifact: RunArtifact, ctx: PostCheckContext): CheckResult | Promise<CheckResult>;
+}
+
+/**
+ * Caller-identity aliases (mmnto-ai/totem#2103 codex review). Old review artifacts
+ * carry `backend.taskProfile: 'Shield'` (the routing `TAG`), not `'Review'` (the
+ * `DISPLAY_TAG`) — see `packages/cli/src/commands/shield-templates.ts`. A fallback
+ * that accepted only `Spec`/`Review` would silently skip review rules on existing
+ * review fixtures.
+ */
+const TASK_PROFILE_ALIASES: Readonly<Record<string, string>> = {
+  Spec: 'spec',
+  Review: 'review',
+  Shield: 'review',
+};
+
+/**
+ * The run's caller identity (`spec` / `review` / …) for caller-scoped rule
+ * targeting. Prefers the explicit `runMetadata.caller` (mmnto-ai/totem#2102), falling
+ * back to a `taskProfile` alias for slice-1/2 artifacts that predate it. An
+ * UNKNOWN profile returns `undefined` — caller-scoped rules then abstain loudly,
+ * never guess.
+ */
+export function resolveCaller(artifact: RunArtifact): string | undefined {
+  const caller = artifact.admission?.runMetadata?.caller;
+  if (caller !== undefined) return caller;
+  return TASK_PROFILE_ALIASES[artifact.backend.taskProfile];
+}
+
+/**
+ * Run every applicable rule and aggregate. Pure, deterministic, zero-LLM.
+ *
+ * A rule that THROWS yields a `fail` at the rule's OWN declared tier (a sensor
+ * throw is a sensor fail — it must not reject; mmnto-ai/totem#2103 codex review).
+ * Only a genuine engine bug (not a rule fault) escapes this loop as an
+ * exception — engine-integrity faults are never laundered into a finding.
+ */
+export async function evaluatePostChecks(
+  artifact: RunArtifact,
+  rules: readonly PostCheckRule[],
+  ctx: PostCheckContext,
+): Promise<PostCheckReport> {
+  const findings: PostCheckFinding[] = [];
+  for (const rule of rules) {
+    if (!rule.appliesTo(artifact)) continue;
+    let result: CheckResult;
+    // totem-context: fail-loud, not swallow — a rule's own throw is converted into a
+    // 'fail' finding at the rule's declared tier (OQ4) and surfaced in the report. Only
+    // rule.evaluate is wrapped, so a genuine engine-integrity fault still bubbles out.
+    try {
+      result = await rule.evaluate(artifact, ctx);
+    } catch (err) {
+      result = {
+        verdict: 'fail',
+        message: `rule "${rule.name}" threw: ${getErrorMessage(err)}`,
+      };
+    }
+    findings.push({ ruleName: rule.name, tier: rule.tier, ...result });
+  }
+  const isRejected = findings.some((f) => f.tier === 'decidable' && f.verdict === 'fail');
+  return { findings, isRejected };
+}

--- a/packages/core/src/artifacts/post-checks.ts
+++ b/packages/core/src/artifacts/post-checks.ts
@@ -139,11 +139,9 @@ export async function evaluatePostChecks(
   for (const rule of rules) {
     if (!rule.appliesTo(artifact)) continue;
     let result: CheckResult;
-    // totem-context: fail-loud, not swallow — a rule's own throw is converted into a
-    // 'fail' finding at the rule's declared tier (OQ4) and surfaced in the report. Only
-    // rule.evaluate is wrapped, so a genuine engine-integrity fault still bubbles out.
     try {
       result = await rule.evaluate(artifact, ctx);
+      // totem-context: fail-loud — a rule throw becomes a tier-preserving 'fail' finding (OQ4).
     } catch (err) {
       result = {
         verdict: 'fail',

--- a/packages/core/src/artifacts/post-checks.ts
+++ b/packages/core/src/artifacts/post-checks.ts
@@ -82,6 +82,13 @@ export interface PostCheckContext {
 export interface PostCheckRule {
   name: string;
   tier: EnforcementTier;
+  /**
+   * Whether this rule applies to the artifact. MUST be a pure, non-throwing
+   * predicate — the engine wraps only `evaluate` (a rule throw → a tier-preserving
+   * fail), so a throwing `appliesTo` would escape as an unhandled engine fault
+   * (CR review). All built-in predicates are trivially safe; third-party rules
+   * must honor this.
+   */
   appliesTo(artifact: RunArtifact): boolean;
   evaluate(artifact: RunArtifact, ctx: PostCheckContext): CheckResult | Promise<CheckResult>;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -568,6 +568,30 @@ export {
   RunArtifactSchema,
   RunMetadataSchema,
 } from './artifacts/schema.js';
+// Deterministic structural post-checks (mmnto-ai/totem#2103 slice 4)
+export type {
+  CheckResult,
+  CheckVerdict,
+  EnforcementTier,
+  OverrideSet,
+  PostCheckContext,
+  PostCheckFinding,
+  PostCheckReport,
+  PostCheckRule,
+} from './artifacts/post-checks.js';
+export { evaluatePostChecks, resolveCaller } from './artifacts/post-checks.js';
+export type { Citation } from './artifacts/post-checks-rules.js';
+export {
+  citationResolvesRule,
+  DEFAULT_RULES,
+  extractCitations,
+  isContained,
+  lineRefValid,
+  overrideReappearanceRule,
+  provenanceSensorRule,
+  specVerifyRule,
+  structuredOutputRule,
+} from './artifacts/post-checks-rules.js';
 export type { SaveRunArtifactResult } from './artifacts/storage.js';
 export {
   computeRunArtifactContentHash,


### PR DESCRIPTION
## Mechanical Root Cause

`totem spec` and `totem review` fabricate (invent file paths, mislocate seams) because synthesis is **ungrounded** — there is no deterministic, zero-LLM layer that checks an LLM run's output against the derived code state. #2103 (strategy#474 slice 4) is that missing layer: a structural post-check engine that consumes the run artifact (#2100) + grounding bundle (#2101) and produces gate-or-sensor verdicts.

## Fix Applied

A zero-LLM post-check engine in `packages/core/src/artifacts/`:

- **`evaluatePostChecks`** — each rule returns a verdict at a STATIC tier (`decidable` may gate, `sensor` is telemetry only); `isRejected` is driven ONLY by a decidable fail (ADR-109 — noisy gates train bypass); aggregation is a pure script (Tenet 9). A thrown rule fails at its OWN declared tier — a sensor throw never rejects (codex OQ4).
- **5 rules** — structured-output · citation-resolves · spec-verify (the #2090/#2091 fabrication class) · override-reappearance (consumes an injected `OverrideSet`) · provenance fail-safe-down sensor (F2).
- **Helpers** — win32-safe path containment, code-fence-stripping citation extraction, line-range boundary matrix.
- **`resolveCaller`** with the `Shield -> review` taskProfile alias (legacy review artifacts route under `TAG='Shield'`).

Cohort pre-build review: totem-gemini **PASS**, totem-agy **PASS**, totem-codex **CONDITIONAL PASS** — all 3 codex folds applied (tier-preserving throw · `Shield` alias · OutputContract split into 3 rules) plus agy's edge specifics. Exported from the core barrel for #2104/#2105.

## Out of Scope

- **Live `spec`/`review` gating wiring** (OQ5, operator-ruled) — this slice ships **engine + rules + fixtures only**; live wiring rides a follow-on once #2104/#2105 land, so production output isn't gated on day-one rules.
- **The override-memory STORE** — #2105 owns it; this slice consumes an injected `OverrideSet` (empty ⇒ abstain).
- **Deep JSON-Schema shape validation** — core carries no validator dependency; structured-output gates parse-as-JSON only (documented in-code).

## Tests Added/Updated

- [x] Added/updated automated tests covering the root-cause mechanism
- [ ] N/A

**49 tests** (`post-checks.test.ts` + `post-checks-rules.test.ts`): the ADR-109 `isRejected`-only-on-decidable invariant, codex's sensor-throw fold, the `Shield -> review` alias, win32 containment (incl. the cross-platform backslash-traversal fix CI caught), citation extraction + line-range boundary matrix, the **#2090 fabrication end-to-end**, the F2 provenance sensor, and the must-cover profiles (slice-1 historic / code-blind / unknown-provenance). Hard gates green on all platforms (tsc / eslint / prettier / 49 tests).

## Related Tickets

Closes #2103. Part of #2106 (474 phase-1 implementation) · mmnto-ai/totem-strategy#474.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
