### PR TITLE
ci(totem-lint): advisory-ize the job until the spine — continue-on-error + loud annotation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -40,9 +40,12 @@ jobs:
       - name: Run totem lint (ADVISORY — frozen lesson-rules pending spine)
         id: totem_lint
         continue-on-error: true
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          # Ensure the base branch is available for diff
-          git fetch origin ${{ github.base_ref }} --depth=1
+          # Ensure the base branch is available for diff (env-mapped to avoid
+          # template injection into the shell — zizmor template-injection).
+          git fetch origin "$BASE_REF" --depth=1
           node packages/cli/dist/index.js lint
 
       # Surface the advisory state as a REAL GitHub annotation (PR checks pane +
@@ -63,8 +66,10 @@ jobs:
       # bury a real finding. Refs: mmnto-ai/totem#2055.
       - name: Generate SARIF report
         if: always()
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          git fetch origin ${{ github.base_ref }} --depth=1 2>/dev/null || true
+          git fetch origin "$BASE_REF" --depth=1 2>/dev/null || true
           node packages/cli/dist/index.js lint --format sarif --out totem-lint.sarif || true
 
       - name: Upload SARIF to GitHub Security

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,12 +38,29 @@ jobs:
       # spine makes these rules legitimate again.
       # mmnto-ai/totem-strategy#430 · mmnto-ai/totem#2055 · mirrors strategy#656
       - name: Run totem lint (ADVISORY — frozen lesson-rules pending spine)
+        id: totem_lint
         continue-on-error: true
         run: |
           # Ensure the base branch is available for diff
           git fetch origin ${{ github.base_ref }} --depth=1
           node packages/cli/dist/index.js lint
 
+      # Surface the advisory state as a REAL GitHub annotation (PR checks pane +
+      # annotations rail), not just the step name — so a green job never reads as
+      # "lint clean" when the frozen rules actually flagged something
+      # (never-skip-silently). Fires only when the advisory lint had findings.
+      - name: Advisory annotation (when totem lint flagged findings)
+        if: steps.totem_lint.outcome == 'failure'
+        run: |
+          echo "::warning title=Totem lint ADVISORY::Totem lint flagged findings but the job is advisory — these may be #2055-class false-positives from frozen lesson-rules (safe-regex2 freeze). Drop continue-on-error when the spine recompiles. Refs: mmnto-ai/totem#2055, mmnto-ai/totem-strategy#430."
+
+      # NOTE (advisory posture): the SARIF steps below still run while the lint job
+      # is advisory, so frozen #2055-class false-positives surface as Code Scanning
+      # alerts under the `totem-lint` category. Kept ON deliberately — the findings
+      # are an audit trail for the #474 false-positive measurement, and the dedicated
+      # `totem-lint` category keeps them from masking CodeQL alerts (separate
+      # category). Revisit (gate the upload) if the category gets noisy enough to
+      # bury a real finding. Refs: mmnto-ai/totem#2055.
       - name: Generate SARIF report
         if: always()
         run: |

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,17 @@ jobs:
 
       - run: pnpm build
 
-      - name: Run totem lint (PR diff)
+      # ADVISORY until the rule-compilation freeze lifts (the convergent spine).
+      # The compiled lesson-rules carry frozen #2055-class false-positives that
+      # cannot be recompiled away under the freeze (safe-regex2 ReDoS gate). A
+      # perma-red check trains bypass-blindness and masks a future REAL regression
+      # (red->red is invisible) — so the job keeps RUNNING (findings still print)
+      # but is non-failing. The clean deterministic gates stay hard in the pre-push
+      # hook + the PR bot review is the real gate. Drop continue-on-error when the
+      # spine makes these rules legitimate again.
+      # mmnto-ai/totem-strategy#430 · mmnto-ai/totem#2055 · mirrors strategy#656
+      - name: Run totem lint (ADVISORY — frozen lesson-rules pending spine)
+        continue-on-error: true
         run: |
           # Ensure the base branch is available for diff
           git fetch origin ${{ github.base_ref }} --depth=1


### PR DESCRIPTION
## Mechanical Root Cause

The compiled lesson-rules carry frozen #2055-class false-positives that **cannot** be recompiled away under the rule-compilation freeze (the `safe-regex2` ReDoS gate rejects the patterns). The "Totem Lint" CI job runs those rules, so it shows **red on every code PR** that trips a stale rule. As a non-required check that is perpetually red, it (a) trains reviewers to ignore the red X — the ADR-109 noisy-gate-trains-bypass pattern at the CI layer — and (b) masks a future _real_ totem-lint regression (red -> red is invisible).

## Fix Applied

Advisory-ize the job until the freeze lifts — mirrors the already-merged `mmnto-ai/totem-strategy#656`; operator-ruled:

- `continue-on-error: true` + `id: totem_lint` on the lint step — it still runs and prints findings, but no longer fails the job.
- A conditional **`::warning` annotation step** (`if: steps.totem_lint.outcome == 'failure'`) that surfaces the advisory state in the PR checks pane + annotations rail, so a green job never silently reads as "lint clean" (never-skip-silently). Fires only when the advisory lint actually flagged something.
- A deliberate comment documenting the intentional SARIF posture (audit trail for the #474 false-positive measurement; the dedicated `totem-lint` Code-Scanning category keeps it from masking CodeQL alerts).

Rule-archival was considered and rejected: the lesson-archival path is itself frozen, and hand-editing `compiled-rules.json` violates Tenet 20 (regenerable cache) and deepens cohort divergence. Reverts to a hard one-liner (drop `continue-on-error`) when the spine relegitimizes the rules.

## Out of Scope

- The clean deterministic gates (`eslint` / `tsc` / `prettier` / tests / xrepo-refs in the pre-push hook + the PR bot review) stay HARD — only the frozen lesson-rule job's posture changes.
- The compiled rules + engine are untouched (no rule-archival).
- Whether the Totem Lint workflow should become a **parity-managed surface** (so the advisory posture stays uniform cohort-wide) — deliberate follow-on.
- Gating the SARIF upload off during advisory mode — deliberate follow-on (the inline comment documents the revisit trigger).

## Tests Added/Updated

- [ ] Added/updated automated tests covering the root-cause mechanism
- [x] N/A — CI-workflow-config change (`.github/workflows/lint.yml` only). The behavior is GitHub-Actions semantics (`continue-on-error` + an `outcome`-conditional annotation), exercised by the live CI run on this PR and confirmed by the bot review (Greptile verified `steps.totem_lint.outcome` fires the warning exactly when expected); there is no unit-testable code path.

## Related Tickets

Refs mmnto-ai/totem#2055 (freeze-tax false-positive cluster) · mmnto-ai/totem-strategy#430 (sibling frozen-rule gap) · mmnto-ai/totem-strategy#656 (the strategy-side mirror).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
