### PR TITLE
feat(orchestrator): panel synthesis engine — independent lanes, script aggregation (#2104, 474 slice 5)

### DIFF
--- a/.totem/specs/2104.md
+++ b/.totem/specs/2104.md
@@ -1,0 +1,232 @@
+### Problem Statement
+
+The orchestrator must be extended to support a "panel synthesis" mode where N independent runs (lanes) of the same task are executed concurrently with isolated contexts. After completion, a deterministic script (not an LLM) must aggregate the individual run artifacts, deduplicate findings by anchor, and label the panel's vendor diversity accurately.
+
+### Architectural Context
+
+- **Issue #474 / Tenet 19 §3**: Multi-turn conversational debate is explicitly CUT from the main path. The architecture enforces an independent-lanes-then-synthesis (blind-round) pattern.
+- **Tenet 9**: Aggregation must be a script, not an LLM.
+- **#2100 Dependency**: Relies on the standard `RunArtifact` emitted by a single lane execution.
+- **Diversity Labeling Trap**: System must strictly distinguish between true cross-vendor diversity and isolated same-vendor runs to prevent overclaiming panel rigor.
+
+### Files to Examine
+
+1. `packages/cli/src/utils.ts` — Contains `runOrchestrator`. We will need to wrap or utilize this to dispatch N parallel, context-isolated lanes.
+2. `packages/cli/src/commands/spec.ts` — Shows how orchestrator configurations and models are initialized; useful for understanding provider extraction for diversity labeling.
+3. `packages/totem/src/types.ts` (or equivalent types entry) — Where the new `PanelArtifact` and `PanelDiversityClass` schemas will reside.
+
+### Technical Approach & Contracts
+
+**Implementation Approach:**
+
+1.  **Data Contracts**: Introduce `PanelArtifact` schema encompassing an array of #2100 `RunArtifact`s, a `PanelDiversityClass`, and a synthesized summary of findings and verdicts.
+2.  **Concurrency & Isolation**: Implement a `runPanelOrchestrator` wrapper that executes N instances of `runOrchestrator` via `Promise.all()`. Each instance must receive a strict, immutable clone of the grounding bundle to prevent object reference leakage between lanes.
+3.  **Deterministic Aggregation**: Write a pure script function (`synthesizePanelArtifacts`) that:
+    - Tallies verdicts (e.g., `pass`: 2, `fail`: 1).
+    - Groups findings by their `anchor` (exact string match).
+    - Surfaces divergences (if an anchor has conflicting suggestions from different lanes).
+4.  **Graceful/Strict Failure**: If any single lane fails or times out, the panel execution must throw. Partial panels are structurally invalid for deterministic verdict merging in this phase.
+
+**Data Contracts (Zod):**
+
+```typescript
+export const PanelDiversityClassSchema = z.enum(['cross-vendor', 'same-vendor-isolated']);
+
+export const SynthesisFindingSchema = z.object({
+  anchor: z.string(),
+  sources: z.array(z.string()), // lane/provider IDs
+  descriptions: z.array(z.string()), // Preserved verbatim from each lane
+  divergent: z.boolean(), // True if sentiments/severities conflict
+});
+
+export const PanelSynthesisSchema = z.object({
+  verdictDistribution: z.record(z.string(), z.number()),
+  findings: z.array(SynthesisFindingSchema),
+  divergences: z.number(), // count of conflicting findings
+});
+
+export const PanelArtifactSchema = z.object({
+  diversityClass: PanelDiversityClassSchema,
+  synthesis: PanelSynthesisSchema,
+  lanes: z.array(RunArtifactSchema), // Standard #2100 artifact
+});
+```
+
+### Edge Cases & Traps
+
+- **Trap — LLM Aggregation**: Developers often reach for an LLM to "summarize" panel outputs. This violates Tenet 9. Aggregation must be purely programmatic grouping by anchor.
+- **Trap — Concurrent Rate Limiting**: Firing N parallel requests to the same provider (e.g., `same-vendor-isolated` using 3x Claude) will drastically increase 429 Too Many Requests errors. You must ensure `runOrchestrator`'s underlying HTTP client implements jittered backoff.
+- **Race Condition — Shared State**: If `runOrchestrator` mutates the input prompt bundle or system context object, concurrent executions will pollute each other. The input bundle must be deep-cloned before passing to each lane.
+- **Edge Case — Partial Panel Failure**: 2 lanes succeed, 1 lane throws an unrecoverable 500. The code must _not_ silently swallow the error and synthesize a 2-lane panel. It must fail fast and surface the lane error.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Define Panel Data Contracts**
+  - Add `PanelDiversityClassSchema`, `SynthesisFindingSchema`, `PanelSynthesisSchema`, and `PanelArtifactSchema` to the orchestrator types file.
+  - > TEST DIRECTIVE: Before implementing, write a failing test named `rejects panel artifact with invalid diversity class` that validates the Zod schemas enforce strict enum values.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Implement Diversity Labeler**
+  - Create `calculateDiversityClass(providers: string[]): PanelDiversityClass` in a new utility file (e.g., `packages/cli/src/orchestrator/panel.ts`).
+  - > TOTEM INVARIANT [Honest Diversity Labeling]: The panel artifact must accurately record cross-vendor vs same-vendor-isolated to prevent overclaiming rigor.
+  - > TEST DIRECTIVE: Before implementing, write a failing test named `classifies varying models from same provider as same-vendor-isolated` (e.g., `claude-3-5-sonnet` + `claude-3-haiku` = `same-vendor-isolated`).
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Implement Deterministic Aggregation Script**
+  - Create `synthesizePanel(artifacts: RunArtifact[]): PanelSynthesis` in `packages/cli/src/orchestrator/panel.ts`.
+  - Group findings by exact `anchor` match. Concatenate sources. Tally overall verdicts into a `Record<string, number>`.
+  - > TOTEM INVARIANT [Tenet 9]: Aggregation is a script, not an LLM. Verdict merge and finding dedup must be purely deterministic.
+  - > TEST DIRECTIVE: Before implementing, write a failing test named `deterministically aggregates findings by identical anchors and tallies verdicts`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Implement Parallel Lane Runner**
+  - Create `runPanelOrchestrator` wrapping `runOrchestrator` (from `packages/cli/src/utils.ts`) in a `Promise.all`.
+  - Ensure deep cloning of the context bundle for each iteration to guarantee lane isolation.
+  - Implement strict failure: if `Promise.all` catches an error, throw the panel execution.
+  - > TEST DIRECTIVE: Before implementing, write a failing test named `rejects entire panel if single lane fails` to prevent silent partial-panel synthesis.
+  - write test → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Diversity Scenarios**: Test `[openai, openai, openai]`, `[anthropic, openai]`, and `[anthropic, anthropic-different-model]`. Ensure correct `cross-vendor` or `same-vendor-isolated` assignment.
+- **Aggregation Scenarios**:
+  - Input: 3 artifacts. 2 have findings at `src/index.ts:42`, 1 has a finding at `src/utils.ts:10`.
+  - Assert: Output synthesis has exactly 2 grouped findings, with the first showing `sources: ['lane-1', 'lane-2']`.
+- **Isolation Scenarios**: Mutating the system context inside a mocked `runOrchestrator` lane must not affect the inputs received by parallel sibling lanes.
+- **Failure Scenarios**: Mock `runOrchestrator` to simulate a timeout in lane 2. Assert `runPanelOrchestrator` throws immediately and does not output a partial artifact.
+
+---
+
+## Implementation Design
+
+> **NB — this section overrides the generated skeleton above**, which made two
+> wrong assumptions verified against the real slice 1–4 code:
+> (1) `RunArtifact` carries **no** `findings`/`verdict` — it is input/output only
+> (`packages/core/src/artifacts/schema.ts:254-272`); findings come from slice 4's
+> `evaluatePostChecks() → PostCheckReport` (`post-checks.ts:44-54`).
+> (2) `PostCheckFinding` has **no path:line anchor** — its stable identity is
+> `ruleName`. So "dedup by anchor" = group by `ruleName`. Types live in
+> `packages/core/src/artifacts/`, not `packages/totem` or `cli`.
+
+### Scope
+
+This slice ships the **deterministic core primitives only** (mirroring slice 4's
+engine-only / no-live-wiring posture): a Zod `PanelArtifact` schema, the pure
+`synthesizePanel()` aggregator (Tenet 9), `classifyDiversity()`, content-addressed
+panel storage, plus tests + fixtures. It will **NOT** ship the parallel CLI lane
+runner (`runPanelOrchestrator`), any backend invocation, gating, or CLI command
+wiring — those are a fast-follow (see OQ1). The panel is a **sensor**: it emits a
+verdict _distribution_, never a single gating verdict (issue's "review-as-actuator
+— sensor only" is out of scope).
+
+### Data model deltas
+
+All new, all in `packages/core/src/artifacts/panel.ts` (Zod, persisted), exported via `index.ts`:
+
+| Symbol                                                   | Holds                                                                                                               | Writer              | Reader                | Invariants                                                                                                                                                               |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- | ------------------- | --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `PanelDiversityClass` (`z.enum`)                         | `'cross-vendor' \| 'same-vendor-isolated'`                                                                          | `classifyDiversity` | synthesis + consumers | derived purely from `distinctProviders`                                                                                                                                  |
+| `PanelDiversity`                                         | `{ providers: string[]; distinctProviders: number; class }`                                                         | `classifyDiversity` | panel artifact        | `providers.length === lanes.length` (per-lane, ordered); `distinctProviders = new Set(providers).size`; raw `providers[]` ALWAYS present so the class can't overclaim    |
+| `SynthesisFinding`                                       | `{ ruleName; tier; verdicts: Record<CheckVerdict,number>; divergent: boolean; messages: string[] }`                 | `synthesizePanel`   | panel artifact        | one entry per distinct `ruleName`; `messages` preserved **verbatim** (no LLM rewrite — Tenet 9); `tier` must be consistent across lanes for a ruleName (else hard error) |
+| `PanelSynthesis`                                         | `{ verdictDistribution: Record<'accepted'\|'rejected',number>; findings: SynthesisFinding[]; divergences: number }` | `synthesizePanel`   | panel artifact        | `divergences === findings.filter(f=>f.divergent).length`; `Σ verdictDistribution === lanes.length`                                                                       |
+| `PanelArtifact`                                          | `{ schemaVersion; lanes: RunArtifact[]; diversity; synthesis; createdAt }`                                          | storage writer      | tolerant reader       | `schemaVersion` starts `"1.0.0"`; reader accepts any `1.x`, rejects `≥2.x` loud (mirror `RunArtifact` F1); `lanes.length ≥ 1`                                            |
+| `panelsDir()` + `writePanelArtifact`/`readPanelArtifact` | `<totemDir>/artifacts/panels/<sha256>.json`                                                                         | storage             | consumers             | content-addressed (hash excludes `createdAt`), write-if-absent `wx` (first-write-wins), mirrors `runsDir`/`storage.ts` exactly                                           |
+
+**Pure functions (no LLM, no I/O):** `classifyDiversity(providers: string[]): PanelDiversity`; `synthesizePanel(lanes: ReadonlyArray<{ artifact: RunArtifact; report: PostCheckReport }>): PanelSynthesis`. No module-level state, no reserved keys, no sentinels.
+
+**Anchor / dedup key = `ruleName`.** `evaluatePostChecks` emits one `PostCheckFinding` per rule per lane, so grouping by `ruleName` collapses the N lanes' verdicts for each rule. `context` (an unbounded `Record<string,unknown>`) is **not** a stable key → finer sub-anchoring deferred (Tenet 21, OQ3).
+
+### State lifecycle
+
+- **`PanelArtifact` on disk:** persistent, write-once, content-addressed, immutable (same model as `RunArtifact`). Created by the storage writer; never mutated; never cleared by this slice.
+- **`synthesizePanel` / `classifyDiversity`:** per-invocation pure; no state crosses calls.
+- **No** session/server/module-level state. No lifecycle-boundary crossings (the class of bug the gate exists to catch is structurally absent here).
+
+### Failure modes
+
+| Failure                                          | Category  | Agent-facing surface                                                                            | Recovery                    |
+| ------------------------------------------------ | --------- | ----------------------------------------------------------------------------------------------- | --------------------------- |
+| `lanes` empty (N=0)                              | runtime   | hard error (throw)                                                                              | caller supplies ≥1 lane     |
+| N=1 (single lane)                                | runtime   | allowed; `class = same-vendor-isolated`, `distinctProviders = 1` (honest under-claim, no error) | n/a                         |
+| a lane `RunArtifact` fails Zod parse             | runtime   | hard error (Tenet 4 — never synthesize over a malformed lane)                                   | fix upstream artifact       |
+| same `ruleName`, conflicting `tier` across lanes | runtime   | hard error (structural impossibility — a rule's tier is static)                                 | n/a (signals corrupt input) |
+| `backend.provider` empty                         | init      | cannot occur — `BackendSchema.provider` is `.min(1)`                                            | n/a                         |
+| panel hash collision                             | permanent | sha256 — negligible, not handled                                                                | n/a                         |
+| write when file already exists                   | transient | write-if-absent: first-write-wins, **no** error (content-addressed ⇒ identical bytes)           | n/a                         |
+
+No row has "silent degradation". Every aggregation surface is loud or structurally impossible.
+
+### Invariants to lock in via tests
+
+- **Order-independent determinism:** `synthesizePanel(lanes)` is identical under any permutation of `lanes` (canonical sort by `ruleName`; per-lane `providers[]` keeps lane order, which is the only order that matters).
+- **Group-by-ruleName:** N lanes each emitting `ruleX` ⇒ exactly ONE `SynthesisFinding` for `ruleX` with its N verdicts tallied.
+- **Divergence semantics:** a finding is `divergent` IFF both `pass` and `fail` appear for that `ruleName` across lanes; `abstain` is neutral (abstain+pass is NOT divergence). `divergences` counts exactly these.
+- **Honest diversity — the Prop-291 guard:** `['gemini','gemini']` ⇒ `distinctProviders=1`, `same-vendor-isolated` (two lanes do **not** make it cross-vendor); `['gemini','anthropic']` ⇒ `distinctProviders=2`, `cross-vendor`.
+- **Verbatim messages:** lane messages survive into `SynthesisFinding.messages` unmodified.
+- **Sensor, not gate:** `PanelSynthesis` exposes no single `isRejected`/boolean gate field; only the `verdictDistribution` tally.
+- **Schema-version tolerance:** a `1.x` panel reads; a `2.x` panel rejects loud (parity with `RunArtifact`).
+- **Content-addressed dedup:** two panels with identical content (differing only in `createdAt`) hash to one file.
+
+### Open questions
+
+1. **Slice boundary — engine-only vs include the lane runner?**
+   - **Options:** (a) core primitives only this slice, defer `runPanelOrchestrator` (CLI parallel dispatch) to a fast-follow — mirrors slice 4 (#2103) which shipped engine+rules+fixtures with no live wiring; (b) include the CLI runner + a `totem panel` command now.
+   - **Recommendation:** (a). Keeps the PR pure/deterministic/reviewable, matches the established slice rhythm, and the runner's partial-panel policy (OQ5) is a separate decidable question best reviewed on its own.
+
+2. **Diversity label shape.**
+   - **Options:** (a) binary enum + always-present `providers[]`/`distinctProviders`; (b) full provider→family cluster map per Prop 291 (collapse a future `vertex`+`gemini` into one Gemini cluster); (c) raw `providers[]` only, no class.
+   - **Recommendation:** (a). At the provider level, `backend.provider` already collapses correlated seats (agy + gemini both report `"gemini"`), so distinctness = cluster count today. Defer the family map until a second same-family provider _string_ actually exists (Tenet 21). `providers[]` is always emitted so nothing overclaims.
+
+3. **"Dedup by anchor" = `ruleName`?** PostCheckFinding has no path:line anchor. **Recommendation:** yes — v1 anchor is `ruleName`; context-level sub-anchoring deferred (context is unbounded, not a stable key). Confirm this satisfies the issue's "dedup by anchor" intent.
+
+4. **Verdict aggregation is sensor-only?** Issue puts "review-as-actuator (sensor only — users wire gates)" out of scope. **Recommendation:** panel emits `verdictDistribution` (tally of each lane's own `PostCheckReport.isRejected`) + `divergences`; it computes **no** panel-level gate. Confirm.
+
+5. **Partial-panel policy** (only if OQ1=b). **Options:** throw on any lane failure (fail-fast, honest-N) vs emit a panel with the failed lane marked. **Recommendation:** fail-fast for v1 — a missing lane silently changes N and the diversity claim. (Moot if OQ1=a.)
+
+---
+
+## Adopted review folds — pre-build round 1
+
+**Verdicts:** totem-gemini PASS · totem-agy PASS (defensive recs) · totem-codex CONDITIONAL PASS · strategy-claude PENDING (blocked on reachability — doctrine/OQ2 ratification owed). **Cluster read (Tenet 19):** the two reporting clusters (OpenAI=codex, Gemini-family=gemini+agy) converge on OQ1-5 as recommended; codex's CONDITIONAL is additive hardening, not a direction change.
+
+1. **Persist post-check inputs, not just the aggregate (codex #1 — audit-immutability).** `PanelArtifact.lanes` becomes `PanelLane[]`, `PanelLane = { laneId: string; artifact: RunArtifact; report: PersistedPostCheckReport }`. Add Zod `PersistedPostCheckReportSchema` / `PersistedPostCheckFindingSchema` in `panel.ts` — do **not** persist slice-4's plain-TS interfaces raw across the disk boundary. `context`, if persisted, is constrained JSON-safe or omitted. Validate `report.isRejected === findings.some(f => f.tier==='decidable' && f.verdict==='fail')` at **write and read**.
+2. **Duplicate-`ruleName`-within-a-lane → hard error (codex #2).** `synthesizePanel` throws if one lane's report carries two findings with the same `ruleName` (else within-lane dups masquerade as cross-lane agreement). Conflicting `tier` for one `ruleName` across lanes also throws (invariant #9).
+3. **Explicit lane identity + canonical ordering (codex #3).** Each lane carries a stable `laneId`. Canonical order: lanes by `laneId`; `synthesis.findings` by `ruleName`; each finding's per-lane verdict/message records by `laneId`; `messages` sorted deterministically. Panel content hash is computed over this canonical form → completion/caller order cannot change the hash. (Refines "order-independent" → order-independent _up to canonicalization_; caller order is not part of identity.)
+4. **Missing-`ruleName`-across-lanes = implicit `abstain` (agy #3).** A rule present in some lanes but absent in others (heterogeneous `appliesTo`) counts as `abstain` for the absent lanes → `Σ verdicts === lanes.length` always. NOT a hard error (would make the panel fragile to legitimately divergent outputs). Distinct from fold #2's within-lane-duplicate throw.
+5. **`verdictDistribution` mapping (agy #1).** `isRejected===false ⟹ 'accepted'`, `true ⟹ 'rejected'` — no third state. Negative test: the panel schema exposes **no** `isRejected`/`verdict`/gate boolean (codex sensor-only precision).
+6. **Storage parity precision (codex).** Mirror run-storage file mode `0o600` + parse-error normalization. Storage tests run against a temp dir (agy #5).
+7. **Locked invariants → 10 (agy #4).** Add: N=1 baseline safety; tier-uniformity throw; within-lane duplicate-`ruleName` throw; `messages` sort determinism — on top of the original list.
+
+**OQ resolution (cluster-endorsed; strategy-claude OQ2 ratified — see round 2):** OQ1 = engine-only core (a) · OQ2 = binary enum + `providers[]`/`distinctProviders` (a) · OQ3 = `ruleName` anchor (yes) · OQ4 = sensor-only (yes) · OQ5 = fail-fast (moot this slice).
+
+---
+
+## Adopted review folds — pre-build round 2 (strategy-claude, doctrine)
+
+**Verdict: PASS, OQ2 ratified with one condition.** Build unblocked on the doctrine lens. The lossless-`providers[]` choice is the load-bearing decision and is correct; the binary class is honest _today only because_ `{gemini, anthropic, openai}` is 1:1 with independent families.
+
+8. **PP1/OQ2 fail-loud tripwire (the condition — SHOULD-before-merge, NOT the family map).** Silent-overclaim path: a provider string that _aliases_ an existing family (`vertex`→Gemini, `bedrock`→Anthropic, `azure`→OpenAI; `vertex` is already live in our sync path) makes `distinctProviders` overcount and `class='cross-vendor'` lie. Fold: (a) name the invariant in a `classifyDiversity` comment — _`distinctProviders` is a valid cluster count only while provider-string ≡ provider-family (1:1)_; (b) check `providers[]` against a known-provider allowlist (the existing `KNOWN_PROVIDERS`, restricted to true vendor families); (c) add `unrecognizedProviders: string[]` + a `diversityConfidence: 'verified' | 'coarse'` marker to `PanelDiversity` — when an unknown string appears, the panel must NOT confidently assert `cross-vendor` (emit `coarse` + "unrecognized provider — diversity may be coarse"). The sensor speaks at its own failure point; Tenet 21 still defers the family map. New locked invariant (#11): an unrecognized provider string ⇒ `diversityConfidence='coarse'` and no confident `cross-vendor` claim.
+9. **PP2 — consumer contract on "isolated" (review-time).** At the `PanelDiversityClass` type definition, document that `same-vendor-isolated` = context-isolation, **not** rater-independence: such a panel's `verdictDistribution` is _N correlated samples, not N independent votes_. Do not rename the enum.
+10. **PP3 — distribution is never the headline (review-time, Tenet 19).** A bare `{accepted, rejected}` tally structurally invites vote-counting (a 2-1 same-vendor split is weak; cross-vendor convergence is strong). The consumer-facing/rendered shape leads with **divergence + diversity**; the tally is one of three co-equal raw signals, subordinate. Keep `diversity` + `synthesis` inseparable in the artifact (already so). Add **no** derived gate field — that crosses into the excluded actuator scope.
+
+**#2106 note (to file):** the panel artifact's first real consumer is the cohort's own review rounds — the by-hand cluster read in round 1 is exactly the `distinctProviders` reasoning the panel mechanizes. Also file strategy-claude's #474 datapoint (review-asks should carry a pushed ref, not a local path) — though co-located review _reads_ are now confirmed fine, so it's attestation-nice, not a precondition.

--- a/packages/core/src/artifacts/panel.test.ts
+++ b/packages/core/src/artifacts/panel.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Panel-synthesis engine tests (mmnto-ai/totem#2104, strategy#474 slice 5).
+ *
+ * The invariants the cohort + strategy pre-build rounds locked in:
+ *   - Tenet 9: aggregation is a pure deterministic script (order-independent).
+ *   - dedup anchor = `ruleName`; divergence = pass∧fail present, abstain neutral.
+ *   - honest diversity (Prop 291): distinctProviders is a cluster count only while
+ *     provider-string ≡ family; an unrecognized string trips `coarse` (PP1 tripwire).
+ *   - sensor-only: no panel-level gate field (PP3).
+ *   - codex folds: persist reports w/ ADR-109 invariant at write+read; within-lane
+ *     duplicate ruleName throws; conflicting tier throws; canonical-order hash.
+ *   - agy folds: missing ruleName across lanes ⇒ implicit abstain (Σ === N); N=1.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { TotemParseError } from '../errors.js';
+import { cleanTmpDir } from '../test-utils.js';
+import {
+  assemblePanelArtifact,
+  classifyDiversity,
+  computePanelArtifactContentHash,
+  PANEL_ARTIFACT_SCHEMA_VERSION,
+  PanelArtifactSchema,
+  type PanelLaneInput,
+  panelsDir,
+  readPanelArtifact,
+  synthesizePanel,
+  writePanelArtifact,
+} from './panel.js';
+import type {
+  CheckVerdict,
+  EnforcementTier,
+  PostCheckFinding,
+  PostCheckReport,
+} from './post-checks.js';
+import { RUN_ARTIFACT_SCHEMA_VERSION, type RunArtifact } from './schema.js';
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+function runArtifact(provider: string, seed = provider): RunArtifact {
+  return {
+    schemaVersion: RUN_ARTIFACT_SCHEMA_VERSION,
+    inputBundle: { maskedPrompt: `prompt ${seed}` },
+    inputHash: 'a'.repeat(64),
+    grounding: { hash: 'b'.repeat(64), provenanceSummary: 'similarity-only' },
+    backend: {
+      provider,
+      model: `${provider}-model`,
+      qualifiedModel: `${provider}:${provider}-model`,
+      admissionClass: 'completion_only',
+      taskProfile: 'Review',
+    },
+    output: { content: `response ${seed}`, metrics: { durationMs: 1000 } },
+    createdAt: '2026-06-14T00:00:00.000Z',
+  };
+}
+
+function finding(
+  ruleName: string,
+  verdict: CheckVerdict,
+  tier: EnforcementTier = 'decidable',
+  message = `${ruleName}:${verdict}`,
+): PostCheckFinding {
+  return { ruleName, tier, verdict, message };
+}
+
+function report(findings: PostCheckFinding[], isRejected?: boolean): PostCheckReport {
+  return {
+    findings,
+    isRejected: isRejected ?? findings.some((f) => f.tier === 'decidable' && f.verdict === 'fail'),
+  };
+}
+
+function lane(
+  laneId: string,
+  provider: string,
+  findings: PostCheckFinding[] = [],
+  isRejected?: boolean,
+): PanelLaneInput {
+  return { laneId, artifact: runArtifact(provider, laneId), report: report(findings, isRejected) };
+}
+
+const AT = '2026-06-14T12:00:00.000Z';
+
+// ─── classifyDiversity ───────────────────────────────────────────────────────
+
+describe('classifyDiversity — honest labeling (Prop 291)', () => {
+  it('two same-family lanes are same-vendor-isolated, not cross-vendor', () => {
+    const d = classifyDiversity(['gemini', 'gemini']);
+    expect(d).toMatchObject({
+      distinctProviders: 1,
+      class: 'same-vendor-isolated',
+      diversityConfidence: 'verified',
+      unrecognizedProviders: [],
+    });
+    expect(d.providers).toEqual(['gemini', 'gemini']); // lossless
+  });
+
+  it('distinct families are cross-vendor + verified', () => {
+    expect(classifyDiversity(['gemini', 'anthropic'])).toMatchObject({
+      distinctProviders: 2,
+      class: 'cross-vendor',
+      diversityConfidence: 'verified',
+      unrecognizedProviders: [],
+    });
+  });
+
+  it('PP1 tripwire: an unrecognized provider string is coarse, never a confident cross-vendor', () => {
+    const d = classifyDiversity(['gemini', 'vertex']);
+    expect(d.distinctProviders).toBe(2);
+    expect(d.unrecognizedProviders).toEqual(['vertex']);
+    // The class reflects the raw count, but confidence MUST flag it untrustworthy
+    // so a consumer cannot read it as a confident independent-cluster claim.
+    expect(d.diversityConfidence).toBe('coarse');
+  });
+
+  it('N=1 baseline labels cleanly without throwing', () => {
+    expect(classifyDiversity(['anthropic'])).toMatchObject({
+      distinctProviders: 1,
+      class: 'same-vendor-isolated',
+      diversityConfidence: 'verified',
+    });
+  });
+});
+
+// ─── synthesizePanel ─────────────────────────────────────────────────────────
+
+describe('synthesizePanel — deterministic aggregation (Tenet 9)', () => {
+  it('groups findings by ruleName across lanes (one entry per rule)', () => {
+    const s = synthesizePanel([
+      lane('l1', 'gemini', [finding('rA', 'pass')]),
+      lane('l2', 'gemini', [finding('rA', 'pass')]),
+      lane('l3', 'gemini', [finding('rA', 'pass')]),
+    ]);
+    expect(s.findings).toHaveLength(1);
+    expect(s.findings[0]).toMatchObject({ ruleName: 'rA', tier: 'decidable' });
+    expect(s.findings[0].verdicts).toEqual({ pass: 3, fail: 0, abstain: 0 });
+  });
+
+  it('is order-independent under lane permutation', () => {
+    const lanes = [
+      lane('l1', 'gemini', [finding('rA', 'pass'), finding('rB', 'fail')]),
+      lane('l2', 'anthropic', [finding('rA', 'fail'), finding('rB', 'fail')]),
+      lane('l3', 'openai', [finding('rA', 'pass')]),
+    ];
+    const forward = synthesizePanel(lanes);
+    const reversed = synthesizePanel([...lanes].reverse());
+    expect(reversed).toEqual(forward);
+  });
+
+  it('divergence: a rule with both pass and fail is divergent; abstain is neutral', () => {
+    const s = synthesizePanel([
+      lane('l1', 'gemini', [finding('rDiv', 'pass'), finding('rCalm', 'pass')]),
+      lane('l2', 'gemini', [finding('rDiv', 'fail'), finding('rCalm', 'abstain')]),
+    ]);
+    const div = s.findings.find((f) => f.ruleName === 'rDiv')!;
+    const calm = s.findings.find((f) => f.ruleName === 'rCalm')!;
+    expect(div.divergent).toBe(true);
+    expect(calm.divergent).toBe(false); // pass + abstain is NOT divergence
+    expect(s.divergences).toBe(1);
+  });
+
+  it('missing ruleName across lanes counts as implicit abstain (Σ verdicts === lane count)', () => {
+    const s = synthesizePanel([
+      lane('l1', 'gemini', [finding('rOnly1', 'pass')]),
+      lane('l2', 'gemini', []), // rOnly1 absent here
+    ]);
+    const f = s.findings.find((x) => x.ruleName === 'rOnly1')!;
+    expect(f.verdicts).toEqual({ pass: 1, fail: 0, abstain: 1 });
+    const sum = f.verdicts.pass + f.verdicts.fail + f.verdicts.abstain;
+    expect(sum).toBe(2);
+  });
+
+  it('preserves lane messages verbatim, sorted', () => {
+    const s = synthesizePanel([
+      lane('l1', 'gemini', [finding('rA', 'pass', 'decidable', 'zebra reason')]),
+      lane('l2', 'gemini', [finding('rA', 'pass', 'decidable', 'apple reason')]),
+    ]);
+    expect(s.findings[0].messages).toEqual(['apple reason', 'zebra reason']);
+  });
+
+  it('verdictDistribution tallies each lane isRejected (accepted/rejected, sums to N)', () => {
+    const s = synthesizePanel([
+      lane('l1', 'gemini', [finding('rA', 'fail')]), // decidable fail ⇒ rejected
+      lane('l2', 'gemini', [finding('rA', 'pass')]), // accepted
+      lane('l3', 'gemini', [finding('rA', 'pass')]), // accepted
+    ]);
+    expect(s.verdictDistribution).toEqual({ accepted: 2, rejected: 1 });
+  });
+
+  it('throws on a within-lane duplicate ruleName (codex #2)', () => {
+    expect(() =>
+      synthesizePanel([lane('l1', 'gemini', [finding('rDup', 'pass'), finding('rDup', 'fail')])]),
+    ).toThrow(/duplicate finding for ruleName/);
+  });
+
+  it('throws on conflicting tier for one ruleName across lanes (codex #9)', () => {
+    expect(() =>
+      synthesizePanel([
+        lane('l1', 'gemini', [finding('rT', 'pass', 'decidable')]),
+        lane('l2', 'gemini', [finding('rT', 'pass', 'sensor')]),
+      ]),
+    ).toThrow(/conflicting tiers/);
+  });
+
+  it('throws on zero lanes', () => {
+    expect(() => synthesizePanel([])).toThrow(/at least one lane/);
+  });
+});
+
+// ─── sensor-only: NO panel gate field (PP3) ──────────────────────────────────
+
+describe('panel is a sensor, never a gate (PP3)', () => {
+  it('PanelSynthesis exposes only verdictDistribution/findings/divergences', () => {
+    const s = synthesizePanel([lane('l1', 'gemini', [finding('rA', 'fail')])]);
+    expect(Object.keys(s).sort()).toEqual(['divergences', 'findings', 'verdictDistribution']);
+    expect(s).not.toHaveProperty('isRejected');
+    expect(s).not.toHaveProperty('verdict');
+    expect(s).not.toHaveProperty('accepted');
+  });
+
+  it('PanelArtifact exposes no top-level gate boolean', () => {
+    const a = assemblePanelArtifact([lane('l1', 'gemini', [finding('rA', 'fail')])], AT);
+    expect(Object.keys(a).sort()).toEqual([
+      'createdAt',
+      'diversity',
+      'lanes',
+      'schemaVersion',
+      'synthesis',
+    ]);
+    expect(a).not.toHaveProperty('isRejected');
+  });
+});
+
+// ─── assemble + schema version tolerance ─────────────────────────────────────
+
+describe('assemblePanelArtifact + schema-version tolerance (F1)', () => {
+  it('assembles a canonical artifact (lanes sorted by laneId)', () => {
+    const a = assemblePanelArtifact(
+      [
+        lane('zzz', 'gemini', [finding('rA', 'pass')]),
+        lane('aaa', 'anthropic', [finding('rA', 'pass')]),
+      ],
+      AT,
+    );
+    expect(a.lanes.map((l) => l.laneId)).toEqual(['aaa', 'zzz']);
+    expect(a.diversity.class).toBe('cross-vendor');
+    expect(a.schemaVersion).toBe(PANEL_ARTIFACT_SCHEMA_VERSION);
+  });
+
+  it('rejects an input lane whose report.isRejected breaks the ADR-109 invariant', () => {
+    // isRejected:true but no decidable fail ⇒ corrupt; assemble validates on the way out.
+    const bad = lane('l1', 'gemini', [finding('rA', 'pass')], /* isRejected */ true);
+    expect(() => assemblePanelArtifact([bad], AT)).toThrow();
+  });
+
+  it('accepts any 1.x schemaVersion, rejects ≥2.x loud', () => {
+    const a = assemblePanelArtifact([lane('l1', 'gemini', [finding('rA', 'pass')])], AT);
+    expect(() => PanelArtifactSchema.parse({ ...a, schemaVersion: '1.5.0' })).not.toThrow();
+    expect(() => PanelArtifactSchema.parse({ ...a, schemaVersion: '2.0.0' })).toThrow();
+  });
+});
+
+// ─── storage: content-address, dedup, round-trip, invariant-at-read ──────────
+
+describe('panel storage (mirrors run storage)', () => {
+  let totemDir: string;
+
+  beforeEach(() => {
+    totemDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-panel-'));
+  });
+  afterEach(() => {
+    cleanTmpDir(totemDir);
+  });
+
+  it('writes at artifacts/panels/<hash>.json and reads it back', () => {
+    const a = assemblePanelArtifact([lane('l1', 'gemini', [finding('rA', 'pass')])], AT);
+    const saved = writePanelArtifact(totemDir, a);
+    expect(saved.existed).toBe(false);
+    expect(saved.path).toBe(path.join(totemDir, 'artifacts', 'panels', `${saved.hash}.json`));
+    expect(panelsDir(totemDir)).toBe(path.join(totemDir, 'artifacts', 'panels'));
+    expect(readPanelArtifact(totemDir, saved.hash)).toEqual(a);
+  });
+
+  it('content address excludes createdAt — identical panels dedup across time', () => {
+    const lanes = [lane('l1', 'gemini', [finding('rA', 'pass')])];
+    const early = assemblePanelArtifact(lanes, '2026-06-14T00:00:00.000Z');
+    const late = assemblePanelArtifact(lanes, '2026-06-15T09:30:00.000Z');
+    expect(computePanelArtifactContentHash(early)).toBe(computePanelArtifactContentHash(late));
+    const first = writePanelArtifact(totemDir, early);
+    const second = writePanelArtifact(totemDir, late);
+    expect(second.existed).toBe(true);
+    expect(second.hash).toBe(first.hash);
+    // first-write-wins: the stored createdAt is the early one.
+    expect(readPanelArtifact(totemDir, first.hash).createdAt).toBe('2026-06-14T00:00:00.000Z');
+  });
+
+  it('content address is stable under lane input permutation', () => {
+    const a = [
+      lane('a', 'gemini', [finding('rA', 'pass')]),
+      lane('b', 'anthropic', [finding('rA', 'fail')]),
+    ];
+    const h1 = computePanelArtifactContentHash(assemblePanelArtifact(a, AT));
+    const h2 = computePanelArtifactContentHash(assemblePanelArtifact([...a].reverse(), AT));
+    expect(h1).toBe(h2);
+  });
+
+  it('throws TotemParseError on a ≥2.x panel on disk', () => {
+    const a = assemblePanelArtifact([lane('l1', 'gemini', [finding('rA', 'pass')])], AT);
+    const hash = 'c'.repeat(64);
+    fs.mkdirSync(panelsDir(totemDir), { recursive: true });
+    fs.writeFileSync(
+      path.join(panelsDir(totemDir), `${hash}.json`),
+      JSON.stringify({ ...a, schemaVersion: '2.0.0' }),
+    );
+    expect(() => readPanelArtifact(totemDir, hash)).toThrow(TotemParseError);
+  });
+
+  it('throws on a disk panel whose persisted report breaks the isRejected invariant', () => {
+    const a = assemblePanelArtifact([lane('l1', 'gemini', [finding('rA', 'pass')])], AT);
+    const corrupt = structuredClone(a);
+    corrupt.lanes[0].report.isRejected = true; // no decidable fail ⇒ invariant broken
+    const hash = 'd'.repeat(64);
+    fs.mkdirSync(panelsDir(totemDir), { recursive: true });
+    fs.writeFileSync(path.join(panelsDir(totemDir), `${hash}.json`), JSON.stringify(corrupt));
+    expect(() => readPanelArtifact(totemDir, hash)).toThrow(TotemParseError);
+  });
+
+  it('rejects an invalid id (not a sha256 hex)', () => {
+    expect(() => readPanelArtifact(totemDir, 'not-a-hash')).toThrow(TotemParseError);
+  });
+});

--- a/packages/core/src/artifacts/panel.test.ts
+++ b/packages/core/src/artifacts/panel.test.ts
@@ -317,6 +317,34 @@ describe('cross-field invariants fail parse, not silently pass (greptile P2, CR 
     c.diversity.providers = ['anthropic', 'gemini'];
     expect(() => PanelArtifactSchema.parse(c)).toThrow();
   });
+
+  it('a diversityConfidence overclaiming "verified" over an unrecognized provider fails parse (greptile — PP1 read guard)', () => {
+    // A lane genuinely on an unrecognized provider assembles correctly as coarse.
+    const a = assemblePanelArtifact(
+      [
+        lane('l1', 'gemini', [finding('rA', 'pass')]),
+        lane('l2', 'vertex', [finding('rA', 'pass')]),
+      ],
+      AT,
+    );
+    expect(a.diversity.diversityConfidence).toBe('coarse'); // sanity: correct assembly
+    const c = structuredClone(a);
+    c.diversity.diversityConfidence = 'verified'; // overclaim — must not pass read
+    expect(() => PanelArtifactSchema.parse(c)).toThrow();
+  });
+
+  it('a class inconsistent with providers fails parse (greptile — re-derived label)', () => {
+    const a = assemblePanelArtifact(
+      [
+        lane('l1', 'gemini', [finding('rA', 'pass')]),
+        lane('l2', 'gemini', [finding('rA', 'pass')]),
+      ],
+      AT,
+    );
+    const c = structuredClone(a); // providers ['gemini','gemini'] ⇒ same-vendor-isolated
+    c.diversity.class = 'cross-vendor'; // overclaim
+    expect(() => PanelArtifactSchema.parse(c)).toThrow();
+  });
 });
 
 // ─── storage: content-address, dedup, round-trip, invariant-at-read ──────────

--- a/packages/core/src/artifacts/panel.test.ts
+++ b/packages/core/src/artifacts/panel.test.ts
@@ -266,6 +266,51 @@ describe('assemblePanelArtifact + schema-version tolerance (F1)', () => {
   });
 });
 
+// ─── cross-field invariants Zod-enforced, not just documented (greptile P2 / CR) ──
+
+describe('cross-field invariants fail parse, not silently pass (greptile P2, CR F1/F2)', () => {
+  // rA: fail in l1, pass in l2 ⇒ divergent; 2 lanes ⇒ N=2, verdictDistribution {1,1}.
+  const valid = () =>
+    assemblePanelArtifact(
+      [
+        lane('l1', 'gemini', [finding('rA', 'fail')]),
+        lane('l2', 'anthropic', [finding('rA', 'pass')]),
+      ],
+      AT,
+    );
+
+  it('a verdictDistribution that does not sum to lane count fails parse', () => {
+    const c = structuredClone(valid());
+    c.synthesis.verdictDistribution.accepted = 99;
+    expect(() => PanelArtifactSchema.parse(c)).toThrow();
+  });
+
+  it('a finding whose verdicts do not sum to lane count fails parse', () => {
+    const c = structuredClone(valid());
+    c.synthesis.findings[0].verdicts.pass += 5;
+    expect(() => PanelArtifactSchema.parse(c)).toThrow();
+  });
+
+  it('a stale divergences count fails parse', () => {
+    const c = structuredClone(valid());
+    c.synthesis.divergences += 1;
+    expect(() => PanelArtifactSchema.parse(c)).toThrow();
+  });
+
+  it('a divergent flag inconsistent with its verdicts fails parse', () => {
+    const c = structuredClone(valid());
+    c.synthesis.findings[0].divergent = false; // rA is genuinely divergent
+    c.synthesis.divergences = 0; // keep the count consistent so only the flag check fires
+    expect(() => PanelArtifactSchema.parse(c)).toThrow();
+  });
+
+  it('a diversity.providers length mismatch with lane count fails parse', () => {
+    const c = structuredClone(valid());
+    c.diversity.providers = [...c.diversity.providers, 'extra'];
+    expect(() => PanelArtifactSchema.parse(c)).toThrow();
+  });
+});
+
 // ─── storage: content-address, dedup, round-trip, invariant-at-read ──────────
 
 describe('panel storage (mirrors run storage)', () => {
@@ -331,7 +376,22 @@ describe('panel storage (mirrors run storage)', () => {
     expect(() => readPanelArtifact(totemDir, hash)).toThrow(TotemParseError);
   });
 
+  it('rejects a disk panel with an inconsistent tally (greptile P2 / CR — re-auditable contract)', () => {
+    const a = assemblePanelArtifact([lane('l1', 'gemini', [finding('rA', 'pass')])], AT);
+    const corrupt = structuredClone(a);
+    corrupt.synthesis.verdictDistribution.accepted = 99; // no longer sums to lane count
+    const badHash = 'e'.repeat(64);
+    fs.mkdirSync(panelsDir(totemDir), { recursive: true });
+    fs.writeFileSync(path.join(panelsDir(totemDir), `${badHash}.json`), JSON.stringify(corrupt));
+    expect(() => readPanelArtifact(totemDir, badHash)).toThrow(TotemParseError);
+  });
+
   it('rejects an invalid id (not a sha256 hex)', () => {
     expect(() => readPanelArtifact(totemDir, 'not-a-hash')).toThrow(TotemParseError);
+  });
+
+  it('throws TotemParseError when a valid hash points to a non-existent file (greptile P2, doc contract)', () => {
+    const missing = 'f'.repeat(64); // well-formed id, but no file on disk
+    expect(() => readPanelArtifact(totemDir, missing)).toThrow(TotemParseError);
   });
 });

--- a/packages/core/src/artifacts/panel.test.ts
+++ b/packages/core/src/artifacts/panel.test.ts
@@ -309,6 +309,14 @@ describe('cross-field invariants fail parse, not silently pass (greptile P2, CR 
     c.diversity.providers = [...c.diversity.providers, 'extra'];
     expect(() => PanelArtifactSchema.parse(c)).toThrow();
   });
+
+  it('a providers array with wrong contents (right length + distinct count) fails parse', () => {
+    const c = structuredClone(valid());
+    // lanes are l1=gemini, l2=anthropic; swap providers so length (2) and distinct
+    // count (2) still match but the per-lane mapping is wrong (CodeRabbit round 2).
+    c.diversity.providers = ['anthropic', 'gemini'];
+    expect(() => PanelArtifactSchema.parse(c)).toThrow();
+  });
 });
 
 // ─── storage: content-address, dedup, round-trip, invariant-at-read ──────────

--- a/packages/core/src/artifacts/panel.ts
+++ b/packages/core/src/artifacts/panel.ts
@@ -223,25 +223,54 @@ export const PanelArtifactSchema = z
         code: z.ZodIssueCode.custom,
         message: `diversity.providers length (${a.diversity.providers.length}) must equal lane count (${n})`,
       });
-    }
-    if (a.diversity.distinctProviders !== new Set(a.diversity.providers).size) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: 'diversity.distinctProviders must equal the number of distinct providers',
+    } else {
+      // providers[] must be GROUNDED in the lane records, not merely correct-length
+      // (CodeRabbit on mmnto-ai/totem#2179): both are in canonical laneId order, so
+      // providers[i] must equal lanes[i]'s backend.provider. Only run when lengths
+      // align — otherwise the length issue above already names the root cause, so
+      // skipping avoids duplicate issues for one fault (CR noise note on #2179).
+      a.lanes.forEach((lane, i) => {
+        if (a.diversity.providers[i] !== lane.artifact.backend.provider) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: `diversity.providers[${i}] must equal lanes[${i}].artifact.backend.provider ("${lane.artifact.backend.provider}")`,
+          });
+        }
       });
     }
-    // providers[] must be GROUNDED in the lane records, not merely correct-length
-    // (CodeRabbit on mmnto-ai/totem#2179): both are in canonical laneId order, so
-    // providers[i] must equal lanes[i]'s backend.provider — otherwise `class` /
-    // `diversityConfidence` could disagree with the actual lanes undetected.
-    a.lanes.forEach((lane, i) => {
-      if (a.diversity.providers[i] !== lane.artifact.backend.provider) {
-        ctx.addIssue({
-          code: z.ZodIssueCode.custom,
-          message: `diversity.providers[${i}] must equal lanes[${i}].artifact.backend.provider ("${lane.artifact.backend.provider}")`,
-        });
-      }
-    });
+    // The diversity LABEL fields (distinctProviders / class / unrecognizedProviders /
+    // diversityConfidence) are PURE FUNCTIONS of providers[] — re-derive and require a
+    // match, so a tampered artifact can't carry diversityConfidence:'verified' or
+    // class:'cross-vendor' over an unrecognized alias and bypass the PP1 tripwire at
+    // READ (greptile on mmnto-ai/totem#2179). classifyDiversity is the single source of truth.
+    const derived = classifyDiversity(a.diversity.providers);
+    if (a.diversity.distinctProviders !== derived.distinctProviders) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `diversity.distinctProviders (${a.diversity.distinctProviders}) must equal the value derived from providers (${derived.distinctProviders})`,
+      });
+    }
+    if (a.diversity.class !== derived.class) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `diversity.class "${a.diversity.class}" must equal the value derived from providers ("${derived.class}")`,
+      });
+    }
+    if (a.diversity.diversityConfidence !== derived.diversityConfidence) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `diversity.diversityConfidence "${a.diversity.diversityConfidence}" must equal the value derived from providers ("${derived.diversityConfidence}")`,
+      });
+    }
+    if (
+      a.diversity.unrecognizedProviders.length !== derived.unrecognizedProviders.length ||
+      !a.diversity.unrecognizedProviders.every((p, i) => p === derived.unrecognizedProviders[i])
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `diversity.unrecognizedProviders must equal the set derived from providers ([${derived.unrecognizedProviders.join(', ')}])`,
+      });
+    }
     const vd = a.synthesis.verdictDistribution;
     if (vd.accepted + vd.rejected !== n) {
       ctx.addIssue({

--- a/packages/core/src/artifacts/panel.ts
+++ b/packages/core/src/artifacts/panel.ts
@@ -46,16 +46,17 @@ export const PANEL_ARTIFACT_KNOWN_MAJOR = 1;
 /** Major-1 semver literal — keep in sync with {@link PANEL_ARTIFACT_KNOWN_MAJOR} (a literal beats runtime RegExp construction; the major only changes alongside a migration entry). */
 const PANEL_SCHEMA_VERSION_RE = /^1\.\d+\.\d+$/;
 
-/** Accept any 1.x version; reject other majors with the version named (F1). */
-const panelSchemaVersionField = z.string().refine(
-  (v) => PANEL_SCHEMA_VERSION_RE.test(v),
-  (v) => ({
-    message: `unsupported panel-artifact schemaVersion "${v}" — this reader understands major ${PANEL_ARTIFACT_KNOWN_MAJOR}.x; a new major requires a migration entry in readPanelArtifact`,
-  }),
-);
+/** Accept any 1.x version; reject other majors loud (F1). Zod `.regex()` is the
+ * validation boundary (mirrors schema.ts's `z.string().regex(...)`) — not a bare
+ * RegExp.test; the ZodError carries the offending value. */
+const panelSchemaVersionField = z.string().regex(PANEL_SCHEMA_VERSION_RE, {
+  message: `unsupported panel-artifact schemaVersion — this reader understands major ${PANEL_ARTIFACT_KNOWN_MAJOR}.x; a new major requires a migration entry in readPanelArtifact`,
+});
 
 /** sha256 hex content hash (full digest — identity, not display). */
 const SHA256_HEX = /^[0-9a-f]{64}$/;
+/** Zod guard for the content-address id — the validation boundary (mirrors schema.ts; no bare RegExp.test). */
+const Sha256HexSchema = z.string().regex(SHA256_HEX);
 
 // ─── Diversity ──────────────────────────────────────────────────────────────
 
@@ -440,7 +441,7 @@ export function writePanelArtifact(
       flag: 'wx',
     });
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+    if (err !== null && typeof err === 'object' && 'code' in err && err.code === 'EEXIST') {
       return { hash, path: filePath, existed: true };
     }
     throw err;
@@ -455,7 +456,7 @@ export function writePanelArtifact(
  * — loud, never a silent partial (Tenet 4).
  */
 export function readPanelArtifact(totemDirAbs: string, hash: string): PanelArtifact {
-  if (!SHA256_HEX.test(hash)) {
+  if (!Sha256HexSchema.safeParse(hash).success) {
     throw new TotemParseError(
       `Invalid panel-artifact id "${hash}" — expected a 64-char sha256 hex content address.`,
       'Pass the hash exactly as reported at emission (or from the artifacts/panels/ filename).',
@@ -487,8 +488,8 @@ export function readPanelArtifact(totemDirAbs: string, hash: string): PanelArtif
 
 /** Best-effort major extraction from a raw parsed payload; undefined when absent/garbled. */
 function readMajor(raw: unknown): number | undefined {
-  if (typeof raw !== 'object' || raw === null) return undefined;
-  const version = (raw as Record<string, unknown>)['schemaVersion'];
+  if (typeof raw !== 'object' || raw === null || !('schemaVersion' in raw)) return undefined;
+  const version = raw.schemaVersion;
   if (typeof version !== 'string') return undefined;
   const major = Number.parseInt(version.split('.')[0] ?? '', 10);
   return Number.isNaN(major) ? undefined : major;

--- a/packages/core/src/artifacts/panel.ts
+++ b/packages/core/src/artifacts/panel.ts
@@ -1,0 +1,495 @@
+/**
+ * Panel synthesis — independent lanes, deterministic script aggregation
+ * (mmnto-ai/totem#2104, strategy#474 slice 5).
+ *
+ * A "panel" is N independent runs (lanes) of the same task over one immutable
+ * grounding bundle, each emitting a #2100 {@link RunArtifact} plus its #2103
+ * {@link PostCheckReport}. This module is the ENGINE: a pure, zero-LLM script
+ * (Tenet 9) that aggregates the lanes — group findings by `ruleName`, tally
+ * lane verdicts, surface divergence, and label vendor diversity HONESTLY — plus
+ * content-addressed storage for the resulting {@link PanelArtifact}. It does NOT
+ * run backends or dispatch lanes (the CLI runner is a deferred fast-follow), and
+ * it emits NO panel-level gate: the panel is a SENSOR (a verdict *distribution*,
+ * never a single accept/reject), leaving any gating policy to a later consumer.
+ *
+ * Diversity-labeling honesty is the load-bearing decision (strategy#474 / Prop
+ * 291 / Tenet 19): cross-VENDOR convergence is the strong signal, NOT vote count.
+ * The raw `providers[]` is always emitted lossless so a label can never overclaim
+ * rigor, and an unrecognized provider string trips a fail-loud `coarse` marker
+ * (see {@link classifyDiversity}).
+ *
+ * Schema-evolution policy mirrors {@link RunArtifactSchema} (F1): the reader is
+ * version-tolerant within major 1; a major bump needs a migration entry before
+ * the writer ships. Zod is the persisted-JSON boundary (read back from disk).
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { z } from 'zod';
+
+import { rethrowAsParseError, TotemParseError } from '../errors.js';
+import { readJsonSafe } from '../sys/fs.js';
+import { calculateDeterministicHash } from './hash.js';
+import type { CheckVerdict, PostCheckReport } from './post-checks.js';
+import type { RunArtifact } from './schema.js';
+import { RunArtifactSchema } from './schema.js';
+
+// ─── Schema version (mirrors RunArtifact F1) ────────────────────────────────
+
+/** The panel schemaVersion WRITTEN by this code. Readers accept any 1.x. */
+export const PANEL_ARTIFACT_SCHEMA_VERSION = '1.0.0';
+
+/** The major this reader understands; other majors need a migration entry. */
+export const PANEL_ARTIFACT_KNOWN_MAJOR = 1;
+
+/** Major-1 semver literal — keep in sync with {@link PANEL_ARTIFACT_KNOWN_MAJOR} (a literal beats runtime RegExp construction; the major only changes alongside a migration entry). */
+const PANEL_SCHEMA_VERSION_RE = /^1\.\d+\.\d+$/;
+
+/** Accept any 1.x version; reject other majors with the version named (F1). */
+const panelSchemaVersionField = z.string().refine(
+  (v) => PANEL_SCHEMA_VERSION_RE.test(v),
+  (v) => ({
+    message: `unsupported panel-artifact schemaVersion "${v}" — this reader understands major ${PANEL_ARTIFACT_KNOWN_MAJOR}.x; a new major requires a migration entry in readPanelArtifact`,
+  }),
+);
+
+/** sha256 hex content hash (full digest — identity, not display). */
+const SHA256_HEX = /^[0-9a-f]{64}$/;
+
+// ─── Diversity ──────────────────────────────────────────────────────────────
+
+/**
+ * The two honest diversity labels.
+ *
+ * `same-vendor-isolated` means **context-isolation, NOT rater-independence**: the
+ * lanes ran in isolated contexts but on one vendor family, so the panel's
+ * `verdictDistribution` is **N correlated samples, not N independent votes**
+ * (Prop 277 correlated-raters; strategy-claude PP2). A consumer must never read a
+ * same-vendor split as independent agreement. `cross-vendor` means ≥2 distinct
+ * provider families ran — the Tenet-19 strong-signal case — and is trustworthy
+ * only when `diversityConfidence === 'verified'` (see {@link classifyDiversity}).
+ */
+export const PanelDiversityClassSchema = z.enum(['cross-vendor', 'same-vendor-isolated']);
+export type PanelDiversityClass = z.infer<typeof PanelDiversityClassSchema>;
+
+/**
+ * Provider strings whose vendor FAMILY is known and currently 1:1 with the
+ * string. INVARIANT: `distinctProviders` is a valid independent-cluster count
+ * only while provider-string ≡ provider-family (1:1). The day a string that
+ * ALIASES one of these families appears (`vertex`→Gemini, `bedrock`→Anthropic,
+ * `azure`→OpenAI), counting it as a separate cluster would silently overclaim
+ * `cross-vendor`. So an unrecognized string trips `diversityConfidence='coarse'`
+ * rather than confidently asserting diversity — the sensor speaking at its own
+ * failure point. The actual provider→family MAP is deliberately deferred until a
+ * real aliasing string exists (Tenet 21); this allowlist is the tripwire, not
+ * the map.
+ */
+const KNOWN_PROVIDER_FAMILIES: ReadonlySet<string> = new Set(['gemini', 'anthropic', 'openai']);
+
+/**
+ * Honest vendor-diversity label for a panel. `providers[]` is ALWAYS present and
+ * lossless (per-lane, canonical laneId order) so no derived field can overclaim.
+ */
+export const PanelDiversitySchema = z.object({
+  /** Per-lane provider strings, lossless, in canonical (laneId-sorted) order. */
+  providers: z.array(z.string()),
+  /** `new Set(providers).size` — a true cluster count ONLY while confidence is `verified`. */
+  distinctProviders: z.number().int().nonnegative(),
+  class: PanelDiversityClassSchema,
+  /** Sorted unique providers outside {@link KNOWN_PROVIDER_FAMILIES} — the overclaim risk. */
+  unrecognizedProviders: z.array(z.string()),
+  /** `verified` when every provider's family is known; `coarse` otherwise (don't trust `cross-vendor`). */
+  diversityConfidence: z.enum(['verified', 'coarse']),
+});
+export type PanelDiversity = z.infer<typeof PanelDiversitySchema>;
+
+// ─── Synthesis ──────────────────────────────────────────────────────────────
+
+/**
+ * One rule's outcome aggregated across all lanes. The dedup anchor is `ruleName`
+ * (PostCheckFinding has no path:line anchor); `messages` are preserved VERBATIM
+ * (Tenet 9 — no LLM rewrite) and sorted for determinism.
+ */
+export const SynthesisFindingSchema = z.object({
+  ruleName: z.string(),
+  tier: z.enum(['decidable', 'sensor']),
+  /** Lane verdict tally; the three keys always sum to `lanes.length` (absent lanes count as `abstain`). */
+  verdicts: z.object({
+    pass: z.number().int().nonnegative(),
+    fail: z.number().int().nonnegative(),
+    abstain: z.number().int().nonnegative(),
+  }),
+  /** True IFF both `pass` and `fail` appear across lanes (`abstain` is neutral). */
+  divergent: z.boolean(),
+  /** Verbatim lane messages (present lanes only), sorted. */
+  messages: z.array(z.string()),
+});
+export type SynthesisFinding = z.infer<typeof SynthesisFindingSchema>;
+
+/**
+ * The deterministic aggregation. SENSOR ONLY: a `verdictDistribution` tally (of
+ * each lane's own `PostCheckReport.isRejected`) plus per-rule findings and a
+ * divergence count — and deliberately NO panel-level `isRejected`/gate boolean.
+ * A bare tally invites the vote-counting Tenet 19 forbids, so consumers must
+ * lead with divergence + diversity; the tally is one subordinate raw signal.
+ */
+export const PanelSynthesisSchema = z.object({
+  /** Tally of lane outcomes: `isRejected===false ⟹ accepted`, `true ⟹ rejected`. Sums to lane count. */
+  verdictDistribution: z.object({
+    accepted: z.number().int().nonnegative(),
+    rejected: z.number().int().nonnegative(),
+  }),
+  findings: z.array(SynthesisFindingSchema),
+  /** `=== findings.filter(f => f.divergent).length`. */
+  divergences: z.number().int().nonnegative(),
+});
+export type PanelSynthesis = z.infer<typeof PanelSynthesisSchema>;
+
+// ─── Persisted post-check report (a JSON-safe Zod copy of the slice-4 shape) ──
+
+/**
+ * A persisted copy of a {@link PostCheckFinding}. slice-4's report is plain TS
+ * (in-memory only); persisting the panel's audit inputs across the disk boundary
+ * needs a Zod boundary (codex #1). `context` is OMITTED from the persisted copy:
+ * it is rule-specific, unbounded, not JSON-safe by contract, and never load-bearing
+ * for synthesis (which keys on `ruleName`) — "constrain JSON-safe or omit", omitted.
+ */
+export const PersistedPostCheckFindingSchema = z.object({
+  ruleName: z.string(),
+  tier: z.enum(['decidable', 'sensor']),
+  verdict: z.enum(['pass', 'fail', 'abstain']),
+  message: z.string(),
+});
+export type PersistedPostCheckFinding = z.infer<typeof PersistedPostCheckFindingSchema>;
+
+/**
+ * A persisted copy of a {@link PostCheckReport}. The `isRejected` ADR-109
+ * invariant is re-validated here at BOTH write and read (codex #1): a stored
+ * report whose `isRejected` disagrees with its findings is a corrupt audit
+ * record and must be rejected loud, never trusted.
+ */
+export const PersistedPostCheckReportSchema = z
+  .object({
+    findings: z.array(PersistedPostCheckFindingSchema),
+    isRejected: z.boolean(),
+  })
+  .refine(
+    (r) => r.isRejected === r.findings.some((f) => f.tier === 'decidable' && f.verdict === 'fail'),
+    {
+      message:
+        'persisted report isRejected must equal "some decidable finding failed" (ADR-109) — record is corrupt',
+    },
+  );
+export type PersistedPostCheckReport = z.infer<typeof PersistedPostCheckReportSchema>;
+
+// ─── Panel artifact ───────────────────────────────────────────────────────────
+
+/**
+ * One persisted lane: its stable id, the #2100 run artifact, and the persisted
+ * #2103 report. The full inputs are stored (not just the aggregate) so a panel
+ * is re-auditable offline without re-running rules that may have since changed
+ * (codex #1 — the same immutability principle behind RunArtifact).
+ */
+export const PanelLaneSchema = z.object({
+  laneId: z.string().min(1),
+  artifact: RunArtifactSchema,
+  report: PersistedPostCheckReportSchema,
+});
+export type PanelLane = z.infer<typeof PanelLaneSchema>;
+
+export const PanelArtifactSchema = z.object({
+  schemaVersion: panelSchemaVersionField,
+  /** Persisted lanes, canonical laneId order. At least one — a zero-lane panel is structurally meaningless. */
+  lanes: z.array(PanelLaneSchema).min(1),
+  diversity: PanelDiversitySchema,
+  synthesis: PanelSynthesisSchema,
+  /**
+   * ISO-8601 emission time. EXCLUDED from the content address (identical panels
+   * dedup regardless of when they ran) — observability only.
+   */
+  createdAt: z.string(),
+});
+export type PanelArtifact = z.infer<typeof PanelArtifactSchema>;
+
+/**
+ * In-memory lane input to the pure aggregators: a stable `laneId`, the run
+ * artifact, and slice-4's live {@link PostCheckReport}. The caller (a future CLI
+ * runner) computes the report via `evaluatePostChecks`; this engine stays pure
+ * over the precomputed pairs.
+ */
+export interface PanelLaneInput {
+  laneId: string;
+  artifact: RunArtifact;
+  report: PostCheckReport;
+}
+
+// ─── Pure aggregators ─────────────────────────────────────────────────────────
+
+/**
+ * Label the vendor diversity of a panel from its per-lane provider strings.
+ * Pure. The `class` is the mechanical reading of `distinctProviders`; the
+ * `diversityConfidence` marker is whether that reading is trustworthy — `coarse`
+ * means an unrecognized provider string is present, so a `cross-vendor` class
+ * MUST NOT be taken as a confident independent-cluster claim (strategy-claude
+ * PP1/OQ2 tripwire). See {@link KNOWN_PROVIDER_FAMILIES} for the invariant.
+ */
+export function classifyDiversity(providers: readonly string[]): PanelDiversity {
+  const distinctProviders = new Set(providers).size;
+  const unrecognizedProviders = [
+    ...new Set(providers.filter((p) => !KNOWN_PROVIDER_FAMILIES.has(p))),
+  ].sort();
+  return {
+    providers: [...providers],
+    distinctProviders,
+    class: distinctProviders >= 2 ? 'cross-vendor' : 'same-vendor-isolated',
+    unrecognizedProviders,
+    diversityConfidence: unrecognizedProviders.length === 0 ? 'verified' : 'coarse',
+  };
+}
+
+/**
+ * Aggregate N lanes into a {@link PanelSynthesis}. Pure, deterministic, zero-LLM.
+ * Output is identical under any permutation of `lanes` (findings sorted by
+ * `ruleName`; per-rule lanes walked in laneId order; messages sorted).
+ *
+ * Throws (fail-loud, never silently degrade — Tenet 4) on a corrupt input
+ * contract: a lane with two findings sharing one `ruleName` (would masquerade as
+ * cross-lane agreement — codex #2), or one `ruleName` carrying conflicting
+ * `tier`s across lanes (a rule's tier is static — codex #9). A `ruleName` simply
+ * ABSENT from some lanes is NOT an error: those lanes count as implicit
+ * `abstain` (agy #4), so each finding's verdicts sum to `lanes.length`.
+ */
+export function synthesizePanel(lanes: readonly PanelLaneInput[]): PanelSynthesis {
+  if (lanes.length === 0) {
+    throw new Error('synthesizePanel requires at least one lane (got 0).');
+  }
+
+  const ordered = [...lanes].sort((a, b) => a.laneId.localeCompare(b.laneId));
+
+  // Index each lane's findings by ruleName, hard-erroring on within-lane dupes.
+  const perLane = ordered.map((lane) => {
+    const byRule = new Map<
+      string,
+      { tier: 'decidable' | 'sensor'; verdict: CheckVerdict; message: string }
+    >();
+    for (const f of lane.report.findings) {
+      if (byRule.has(f.ruleName)) {
+        throw new Error(
+          `lane "${lane.laneId}" has duplicate finding for ruleName "${f.ruleName}" — within-lane duplicates would masquerade as cross-lane agreement.`,
+        );
+      }
+      byRule.set(f.ruleName, { tier: f.tier, verdict: f.verdict, message: f.message });
+    }
+    return byRule;
+  });
+
+  const ruleNames = [...new Set(perLane.flatMap((m) => [...m.keys()]))].sort();
+
+  const findings: SynthesisFinding[] = ruleNames.map((ruleName) => {
+    const verdicts = { pass: 0, fail: 0, abstain: 0 };
+    const messages: string[] = [];
+    let tier: 'decidable' | 'sensor' | undefined;
+    for (const byRule of perLane) {
+      const hit = byRule.get(ruleName);
+      if (hit === undefined) {
+        // Absent here = the rule did not apply to this lane (heterogeneous
+        // appliesTo) → implicit abstain, keeping Σ verdicts === lanes.length.
+        verdicts.abstain += 1;
+        continue;
+      }
+      if (tier !== undefined && tier !== hit.tier) {
+        throw new Error(
+          `ruleName "${ruleName}" has conflicting tiers across lanes ("${tier}" vs "${hit.tier}") — a rule's tier is static.`,
+        );
+      }
+      tier = hit.tier;
+      verdicts[hit.verdict] += 1;
+      messages.push(hit.message);
+    }
+    return {
+      ruleName,
+      // `tier` is defined: a ruleName is in the set only if ≥1 lane carried it.
+      tier: tier as 'decidable' | 'sensor',
+      verdicts,
+      divergent: verdicts.pass > 0 && verdicts.fail > 0,
+      messages: messages.sort(),
+    };
+  });
+
+  const verdictDistribution = { accepted: 0, rejected: 0 };
+  for (const lane of ordered) {
+    if (lane.report.isRejected) verdictDistribution.rejected += 1;
+    else verdictDistribution.accepted += 1;
+  }
+
+  return {
+    verdictDistribution,
+    findings,
+    divergences: findings.filter((f) => f.divergent).length,
+  };
+}
+
+/**
+ * Assemble a full {@link PanelArtifact} from lane inputs. Pure. Canonicalizes
+ * lane order by `laneId` so the content address is stable regardless of caller /
+ * completion order, derives diversity from the per-lane providers (same canonical
+ * order), synthesizes, and validates the whole shape (which re-checks each
+ * persisted report's ADR-109 invariant). `createdAt` is supplied by the caller
+ * (this module reads no clock — determinism).
+ */
+export function assemblePanelArtifact(
+  lanes: readonly PanelLaneInput[],
+  createdAt: string,
+): PanelArtifact {
+  if (lanes.length === 0) {
+    throw new Error('assemblePanelArtifact requires at least one lane (got 0).');
+  }
+  const ordered = [...lanes].sort((a, b) => a.laneId.localeCompare(b.laneId));
+  const synthesis = synthesizePanel(ordered);
+  const diversity = classifyDiversity(ordered.map((l) => l.artifact.backend.provider));
+  const persistedLanes: PanelLane[] = ordered.map((l) => ({
+    laneId: l.laneId,
+    artifact: l.artifact,
+    report: {
+      isRejected: l.report.isRejected,
+      findings: l.report.findings.map((f) => ({
+        ruleName: f.ruleName,
+        tier: f.tier,
+        verdict: f.verdict,
+        message: f.message,
+      })),
+    },
+  }));
+  // parse() validates the assembled shape AND each report's isRejected invariant
+  // on the way out — a builder bug must never poison the ledger (Tenet 4).
+  return PanelArtifactSchema.parse({
+    schemaVersion: PANEL_ARTIFACT_SCHEMA_VERSION,
+    lanes: persistedLanes,
+    diversity,
+    synthesis,
+    createdAt,
+  });
+}
+
+// ─── Content-addressed storage (mirrors storage.ts exactly) ───────────────────
+
+/** Storage layout segments under the totem dir. */
+const PANELS_DIR_SEGMENTS = ['artifacts', 'panels'] as const;
+
+/**
+ * Migration-on-read registry (F1). Keyed by MAJOR. EMPTY at 1.0.0 by design —
+ * the policy requires a major bump to land its migration entry here before the
+ * writer ships, so empty is the honest statement that no other major exists.
+ */
+const MIGRATIONS: ReadonlyMap<number, (raw: unknown) => PanelArtifact> = new Map();
+
+/** Absolute panels directory for a given absolute totem dir. */
+export function panelsDir(totemDirAbs: string): string {
+  return path.join(totemDirAbs, ...PANELS_DIR_SEGMENTS);
+}
+
+/**
+ * Content address of a panel: deterministic hash over everything EXCEPT
+ * `createdAt` (observability, not identity). The artifact is already canonical
+ * (assemblePanelArtifact sorts lanes/findings/messages), so the address is a
+ * pure function of the logical panel.
+ */
+export function computePanelArtifactContentHash(artifact: PanelArtifact): string {
+  const { createdAt: _excluded, ...identity } = artifact;
+  return calculateDeterministicHash(identity);
+}
+
+export interface SavePanelArtifactResult {
+  /** The content address (= filename stem). */
+  hash: string;
+  /** Absolute path of the stored artifact. */
+  path: string;
+  /** True when an identical logical panel was already recorded (no write happened). */
+  existed: boolean;
+}
+
+/**
+ * Persist a panel at its content address, write-if-absent. An existing file is
+ * NEVER rewritten (append-only: first write wins). Validates on the way out so a
+ * writer bug cannot poison the ledger with a record the reader would reject.
+ */
+export function writePanelArtifact(
+  totemDirAbs: string,
+  artifact: PanelArtifact,
+): SavePanelArtifactResult {
+  const validated = PanelArtifactSchema.parse(artifact);
+  const hash = computePanelArtifactContentHash(validated);
+  const dir = panelsDir(totemDirAbs);
+  const filePath = path.join(dir, `${hash}.json`);
+
+  if (fs.existsSync(filePath)) {
+    return { hash, path: filePath, existed: true };
+  }
+
+  fs.mkdirSync(dir, { recursive: true });
+  try {
+    // `wx` = atomic create-exclusive: closes the TOCTOU window between the
+    // existsSync fast-path and the write so concurrent saves of the same hash
+    // can never overwrite the first record — first-write-wins is enforced by
+    // the filesystem. mode 0o600 matches run storage: panels embed run records
+    // that carry masked prompt content.
+    fs.writeFileSync(filePath, JSON.stringify(validated, null, 2), {
+      encoding: 'utf-8',
+      mode: 0o600,
+      flag: 'wx',
+    });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+      return { hash, path: filePath, existed: true };
+    }
+    throw err;
+  }
+  return { hash, path: filePath, existed: false };
+}
+
+/**
+ * Load + validate a panel by content address. Throws {@link TotemParseError} on
+ * a missing file, corrupt JSON, schema violation, an unknown major with no
+ * migration entry, or a persisted report whose `isRejected` invariant is broken
+ * — loud, never a silent partial (Tenet 4).
+ */
+export function readPanelArtifact(totemDirAbs: string, hash: string): PanelArtifact {
+  if (!SHA256_HEX.test(hash)) {
+    throw new TotemParseError(
+      `Invalid panel-artifact id "${hash}" — expected a 64-char sha256 hex content address.`,
+      'Pass the hash exactly as reported at emission (or from the artifacts/panels/ filename).',
+    );
+  }
+  const filePath = path.join(panelsDir(totemDirAbs), `${hash}.json`);
+
+  // Migration seam (F1): peek the major BEFORE strict validation so a known
+  // older major routes through its migration. Empty registry ⇒ straight
+  // fall-through today.
+  const raw = readJsonSafe(filePath);
+  const major = readMajor(raw);
+  if (major !== undefined) {
+    const migrate = MIGRATIONS.get(major);
+    if (migrate !== undefined) return migrate(raw);
+  }
+
+  try {
+    return PanelArtifactSchema.parse(raw);
+    // totem-context: rethrowAsParseError always throws (returns `never`) — this catch RE-throws via the shared helper, normalizing ZodError to the module's stated TotemParseError load contract; nothing is swallowed.
+  } catch (err) {
+    rethrowAsParseError(
+      `Panel artifact ${hash} failed schema validation`,
+      err,
+      'The artifact may be corrupted or written by an incompatible totem version; re-emit it (or add the migration entry for its major).',
+    );
+  }
+}
+
+/** Best-effort major extraction from a raw parsed payload; undefined when absent/garbled. */
+function readMajor(raw: unknown): number | undefined {
+  if (typeof raw !== 'object' || raw === null) return undefined;
+  const version = (raw as Record<string, unknown>)['schemaVersion'];
+  if (typeof version !== 'string') return undefined;
+  const major = Number.parseInt(version.split('.')[0] ?? '', 10);
+  return Number.isNaN(major) ? undefined : major;
+}

--- a/packages/core/src/artifacts/panel.ts
+++ b/packages/core/src/artifacts/panel.ts
@@ -199,18 +199,67 @@ export const PanelLaneSchema = z.object({
 });
 export type PanelLane = z.infer<typeof PanelLaneSchema>;
 
-export const PanelArtifactSchema = z.object({
-  schemaVersion: panelSchemaVersionField,
-  /** Persisted lanes, canonical laneId order. At least one — a zero-lane panel is structurally meaningless. */
-  lanes: z.array(PanelLaneSchema).min(1),
-  diversity: PanelDiversitySchema,
-  synthesis: PanelSynthesisSchema,
-  /**
-   * ISO-8601 emission time. EXCLUDED from the content address (identical panels
-   * dedup regardless of when they ran) — observability only.
-   */
-  createdAt: z.string(),
-});
+export const PanelArtifactSchema = z
+  .object({
+    schemaVersion: panelSchemaVersionField,
+    /** Persisted lanes, canonical laneId order. At least one — a zero-lane panel is structurally meaningless. */
+    lanes: z.array(PanelLaneSchema).min(1),
+    diversity: PanelDiversitySchema,
+    synthesis: PanelSynthesisSchema,
+    /**
+     * ISO-8601 emission time. EXCLUDED from the content address (identical panels
+     * dedup regardless of when they ran) — observability only.
+     */
+    createdAt: z.string(),
+  })
+  // Cross-field invariants the sensor DOCUMENTS are now ENFORCED at the persisted
+  // boundary (greptile P2 on mmnto-ai/totem#2179): a hand-edited / corrupt artifact
+  // with inconsistent tallies must FAIL parse, not silently violate the stated
+  // guarantees — the same .refine() discipline as the ADR-109 isRejected check.
+  .superRefine((a, ctx) => {
+    const n = a.lanes.length;
+    if (a.diversity.providers.length !== n) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `diversity.providers length (${a.diversity.providers.length}) must equal lane count (${n})`,
+      });
+    }
+    if (a.diversity.distinctProviders !== new Set(a.diversity.providers).size) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'diversity.distinctProviders must equal the number of distinct providers',
+      });
+    }
+    const vd = a.synthesis.verdictDistribution;
+    if (vd.accepted + vd.rejected !== n) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `verdictDistribution (accepted ${vd.accepted} + rejected ${vd.rejected}) must sum to lane count (${n})`,
+      });
+    }
+    for (const f of a.synthesis.findings) {
+      const sum = f.verdicts.pass + f.verdicts.fail + f.verdicts.abstain;
+      if (sum !== n) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `finding "${f.ruleName}" verdicts sum (${sum}) must equal lane count (${n}) — present verdicts plus implicit abstain`,
+        });
+      }
+      if (f.divergent !== (f.verdicts.pass > 0 && f.verdicts.fail > 0)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `finding "${f.ruleName}" divergent flag must equal (pass > 0 && fail > 0)`,
+        });
+      }
+    }
+    const divergent = a.synthesis.findings.filter((f) => f.divergent).length;
+    if (a.synthesis.divergences !== divergent) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `synthesis.divergences (${a.synthesis.divergences}) must equal the count of divergent findings (${divergent})`,
+      });
+    }
+  });
 export type PanelArtifact = z.infer<typeof PanelArtifactSchema>;
 
 /**
@@ -346,8 +395,12 @@ export function assemblePanelArtifact(
   if (lanes.length === 0) {
     throw new Error('assemblePanelArtifact requires at least one lane (got 0).');
   }
+  // synthesizePanel owns its own canonical sort (it is independently callable), so
+  // hand it the raw lanes rather than a pre-sorted copy it would only re-sort (CR
+  // nit on mmnto-ai/totem#2179). `ordered` is assemble's OWN canonical order, needed
+  // for the persisted lanes[] and the per-lane diversity providers[] (both go to disk).
+  const synthesis = synthesizePanel(lanes);
   const ordered = [...lanes].sort((a, b) => a.laneId.localeCompare(b.laneId));
-  const synthesis = synthesizePanel(ordered);
   const diversity = classifyDiversity(ordered.map((l) => l.artifact.backend.provider));
   const persistedLanes: PanelLane[] = ordered.map((l) => ({
     laneId: l.laneId,
@@ -381,7 +434,9 @@ const PANELS_DIR_SEGMENTS = ['artifacts', 'panels'] as const;
 /**
  * Migration-on-read registry (F1). Keyed by MAJOR. EMPTY at 1.0.0 by design —
  * the policy requires a major bump to land its migration entry here before the
- * writer ships, so empty is the honest statement that no other major exists.
+ * writer ships, so empty is the honest statement that no other major exists. Each
+ * entry MUST return current-schema output; readPanelArtifact re-validates it via
+ * parse() before returning (CR note on mmnto-ai/totem#2179).
  */
 const MIGRATIONS: ReadonlyMap<number, (raw: unknown) => PanelArtifact> = new Map();
 
@@ -471,7 +526,10 @@ export function readPanelArtifact(totemDirAbs: string, hash: string): PanelArtif
   const major = readMajor(raw);
   if (major !== undefined) {
     const migrate = MIGRATIONS.get(major);
-    if (migrate !== undefined) return migrate(raw);
+    // Re-validate migrated output against the CURRENT schema before returning (CR
+    // note on mmnto-ai/totem#2179): a migration's contract is to PRODUCE the current
+    // shape, so a migration bug must fail loud here — never return it unvalidated.
+    if (migrate !== undefined) return PanelArtifactSchema.parse(migrate(raw));
   }
 
   try {

--- a/packages/core/src/artifacts/panel.ts
+++ b/packages/core/src/artifacts/panel.ts
@@ -230,6 +230,18 @@ export const PanelArtifactSchema = z
         message: 'diversity.distinctProviders must equal the number of distinct providers',
       });
     }
+    // providers[] must be GROUNDED in the lane records, not merely correct-length
+    // (CodeRabbit on mmnto-ai/totem#2179): both are in canonical laneId order, so
+    // providers[i] must equal lanes[i]'s backend.provider — otherwise `class` /
+    // `diversityConfidence` could disagree with the actual lanes undetected.
+    a.lanes.forEach((lane, i) => {
+      if (a.diversity.providers[i] !== lane.artifact.backend.provider) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `diversity.providers[${i}] must equal lanes[${i}].artifact.backend.provider ("${lane.artifact.backend.provider}")`,
+        });
+      }
+    });
     const vd = a.synthesis.verdictDistribution;
     if (vd.accepted + vd.rejected !== n) {
       ctx.addIssue({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -599,6 +599,38 @@ export {
   runsDir,
   saveRunArtifact,
 } from './artifacts/storage.js';
+// Panel synthesis — independent lanes, script aggregation (mmnto-ai/totem#2104 slice 5)
+export type {
+  PanelArtifact,
+  PanelDiversity,
+  PanelDiversityClass,
+  PanelLane,
+  PanelLaneInput,
+  PanelSynthesis,
+  PersistedPostCheckFinding,
+  PersistedPostCheckReport,
+  SavePanelArtifactResult,
+  SynthesisFinding,
+} from './artifacts/panel.js';
+export {
+  assemblePanelArtifact,
+  classifyDiversity,
+  computePanelArtifactContentHash,
+  PANEL_ARTIFACT_KNOWN_MAJOR,
+  PANEL_ARTIFACT_SCHEMA_VERSION,
+  PanelArtifactSchema,
+  PanelDiversityClassSchema,
+  PanelDiversitySchema,
+  PanelLaneSchema,
+  panelsDir,
+  PanelSynthesisSchema,
+  PersistedPostCheckFindingSchema,
+  PersistedPostCheckReportSchema,
+  readPanelArtifact,
+  SynthesisFindingSchema,
+  synthesizePanel,
+  writePanelArtifact,
+} from './artifacts/panel.js';
 
 // Strategy-root resolver (mmnto-ai/totem#1710)
 export type {


### PR DESCRIPTION
## #2104 — Panel synthesis engine (474 slice 5)

Engine-only core primitives. The live CLI lane runner (`runPanelOrchestrator` + a `totem panel` command) is a **deferred fast-follow** (new slice), mirroring #2103's no-live-wiring posture. Part of the #474 grounded spec/review redesign (#2106 Phase-1 tracking).

### What this adds
`packages/core/src/artifacts/panel.ts` + co-located `panel.test.ts`:

- **Data contracts** — `PanelArtifact { schemaVersion, lanes: PanelLane[], diversity, synthesis, createdAt }`. Each `PanelLane` persists `{ laneId, artifact: RunArtifact, report }` — the full post-check inputs (a JSON-safe Zod copy of slice-4's in-memory `PostCheckReport`), so a panel is re-auditable offline without re-running rules that may have changed. The ADR-109 `isRejected` invariant is re-validated at **write and read**.
- **`synthesizePanel()`** — pure, zero-LLM aggregation (Tenet 9): group findings by `ruleName`, tally lane verdicts, surface divergence (`pass` ∧ `fail` present; `abstain` neutral). A rule absent from a lane counts as implicit `abstain` (Σ verdicts === lane count). Throws fail-loud on within-lane duplicate `ruleName` or cross-lane `tier` conflict (Tenet 4).
- **`classifyDiversity()`** — honest vendor labeling: lossless `providers[]` + `distinctProviders` + binary `class`, plus a **fail-loud `coarse` tripwire** — an unrecognized provider string that could *alias* a known family (`vertex`→Gemini, `bedrock`→Anthropic, `azure`→OpenAI) sets `diversityConfidence='coarse'` so `cross-vendor` is never silently overclaimed. The provider→family map is deferred until a real aliasing string exists (Tenet 21); this is the tripwire, not the map.
- **Sensor, not gate** — a `verdictDistribution` tally only; **no** panel-level `isRejected`/gate field. Cross-vendor convergence is the strong signal, not vote count (Tenet 19); gating policy is left to a later consumer.
- **Content-addressed storage** mirroring `storage.ts` (`0o600`, `wx` write-once, content hash excluding `createdAt`, 1.x-tolerant reader / loud ≥2.x reject).

24 tests lock the 11 invariants + the tripwire + storage round-trip (temp dir).

### Pre-build cohort review (BLIND, 4 independent lenses)
| Reviewer | Lens | Verdict |
| --- | --- | --- |
| totem-gemini | architecture/tenet | PASS |
| totem-agy | integration/test-invariant | PASS (defensive recs folded) |
| totem-codex | correctness/contract | CONDITIONAL — 3 folds adopted (persist reports, within-lane-dup throw, `laneId` canonical order) |
| strategy-claude | doctrine | PASS — OQ2 ratified; PP1 provider-alias tripwire folded |

Design + all adopted folds: `.totem/specs/2104.md`.

### Gate status
Hard gates green: `tsc` (all pkgs), `eslint`, `prettier --check .`, vitest (2375 incl. 24 panel). The advisory **Totem Lint** job (#2178, `continue-on-error`) reports only verified **frozen-compiled-lesson false positives** on established codebase idiom — dispositioned in a comment below.

Closes #2104.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
