### PR TITLE
feat(lint): advisory-ize the frozen-lesson regex rule class in the local gate — engine-type split (#2181)

### DIFF
--- a/.totem/specs/2181.md
+++ b/.totem/specs/2181.md
@@ -1,0 +1,64 @@
+# Spec: #2181 — advisory-ize the frozen-lesson rule class in the local pre-push gate
+
+**Issue:** mmnto-ai/totem#2181 · **Branch:** `feat/local-lint-frozen-advisory`
+**Ruling source:** strategy-claude 2258Z (engine-type discriminator, operator-greenlit) + #2181 body
+**Tenets:** 9 (Green/Yellow boundary), 13 (Sensors not Actuators), 21 (subtraction — one discriminator)
+**Rides:** Proposal 299 §5 Gate-1 precondition (sense in Yellow, enforce in Green) · durable marker → spine strategy#516
+
+## 1. Problem
+
+The local pre-push `totem lint` gate hard-blocks (exit-1) on frozen compiled-lesson **regex** findings. Those rules are un-recompilable under the standing `rule-compilation` freeze, so they misfire densely as false positives on any new source file — on #2179 this forced `--no-verify` (gate-tree case C) on **every** push. `#2178` already advisory-ized the **CI** Totem Lint job; the **local pre-push hook was never advisory-ized**. Same class as the #2180 review-gate decommission: a local hard-gate re-justifying a frozen mechanism.
+
+## 2. Ruling — one discriminator: engine type
+
+Confirmed by strategy-claude (2258Z), operator-greenlit:
+
+> `engine === 'regex'` → **advisory** · `ast` / `ast-grep` → **hard**. Demote uniformly by engine, **NOT** by severity — one discriminator beats two (Tenet 21).
+
+Grounded fact (Explore-confirmed pre-build): `totem lint` runs only `.totem/compiled-rules.json`; **every** rule there is lesson-derived (`lessonHash`), and there is **no first-class AST checker outside it** — the structural/precision family that "stays hard" _is_ the `ast`/`ast-grep` engine. So engine-type is the faithful operationalization of "frozen-lesson class → advisory; AST family stays hard," not a workaround. It is also the **conservative** proxy: it keeps more rules hard, and the advisory set widens only at cohort-verify if a hard rule proves load-bearing.
+
+`tsc` / tests / `format:check` / lockfile-sync / `check-xrepo-refs` are **separate** pre-push steps, already hard — out of scope here, untouched.
+
+## 3. Design — the contract
+
+**Layer:** `packages/cli/src/commands/run-compiled-rules.ts` (the lint engine). Engine-level so **all** callers inherit consistently (local pre-push, `totem lint`, CI shield). CI is already `continue-on-error` (#2178) so no double-count. Ships in `@mmnto/cli` → lc + totem-status inherit on the next version wave.
+
+**Exit-tally reclassification** (currently severity-only, lines 486–487/602):
+
+```
+isBlocking(v) := (v.rule.engine === 'ast' || v.rule.engine === 'ast-grep')
+                 && (v.rule.severity ?? 'error') === 'error'
+errors   = violations.filter(isBlocking)        // exit-1, "### Errors", FAIL
+warnings = violations.filter(v => !isBlocking)  // non-blocking, "### Warnings", PASS, printed
+```
+
+- `engine` is a **required** enum (`'regex'|'ast'|'ast-grep'`) — always present; `!== 'regex'` ≡ hard engine. Predicate mirrors the existing `astRules` filter (line 328).
+- "Demote uniformly by engine" → **no severity sub-condition on the regex demotion**: a regex rule is advisory whether its `severity` is error or warning.
+- Hard engines keep their **existing** severity behavior (error blocks, warning doesn't) — that _is_ "stay hard."
+- Non-blocking findings stay **printed** (the issue's "printed, excluded from the exit-1 tally") via the existing "### Warnings" section. A one-line note marks that frozen-lesson (regex) rules are advisory under the compile freeze, so operators read them as sensed-not-enforced rather than silent or blocking.
+
+**Output-format coherence** (all already keyed off `errors`/`warnings` — no new fields):
+
+- **human:** regex findings render under "### Warnings" (PASS) not "### Errors" (FAIL). Verdict line stays coherent.
+- **json:** `pass = errors.length === 0` → `true` on a regex-only run; counts shift but field shape is unchanged (backward-compatible).
+- **sarif:** `buildSarifLog(errors, …)` already error-only → regex findings excluded from SARIF results, surfaced via the existing warning-summary note. PR bot review stays the real sensor.
+
+## 4. Contract change (breaking, by design)
+
+`runCompiledRules` previously threw `SHIELD_FAILED` for **any** error-severity violation. After #2181 a **regex** error-severity violation is advisory (no throw, exit 0, still in `result.violations`, printed). Five existing tests encode the old contract and are updated:
+
+- regex-match / fileGlob / multi-rule "is detected" tests → assert violation **detected + advisory (no throw)**, not throw.
+- "throws SHIELD_FAILED …" → re-pointed to an `ast-grep` (hard-engine) rule, the path that still blocks.
+- SARIF test → keep the warning-exclusion assertion; drop the regex-error-throws half.
+
+New tests assert the split directly: regex error → advisory/exit-0/printed; `ast-grep` error → still blocks; mixed run blocks only on the AST error.
+
+## 5. Interim vs durable
+
+This is **interim**. Engine-type is an inferred proxy for "frozen-lesson regex." When spine strategy#516 regenerates rules from merged-PR history, that is the point to stamp a real `provenance` / `ruleClass` field so the class is an explicit attribute, not engine-inferred. Captured as a spine deliverable on #2181. The durable per-finding regex inline-suppression (`totem-ignore` parity with the AST engine) also rides the spine — returns case-C `--no-verify` to a rare exception.
+
+## 6. Verify criterion (strategy-claude cohort-verify; lc = live prover)
+
+> Does the advisory-ize actually stop the #2179 false-positive flood **without dropping a single real structural catch**?
+
+Self-test on push: my own push of this branch should **not** require `--no-verify` once the regex class is advisory. A missed structural catch would surface first in lc's box.

--- a/packages/cli/src/commands/run-compiled-rules.test.ts
+++ b/packages/cli/src/commands/run-compiled-rules.test.ts
@@ -516,10 +516,46 @@ describe('runCompiledRules', () => {
     expect(results[0].ruleId).toBe('totem/warning-summary');
     // Tightened back (greptile #2182): assert the corrected, accurate message and
     // guard against regressing to the stale "warning-severity" label — the bucket
-    // now includes regex error-severity findings demoted to advisory.
+    // now includes regex error-severity findings demoted to advisory. Both rules are
+    // regex, so the frozen-lesson mention IS present.
     expect(results[0].message.text).toContain('advisory (non-blocking) finding(s) detected');
     expect(results[0].message.text).not.toContain('warning-severity');
+    expect(results[0].message.text).toContain('frozen-lesson');
     expect(results[0].message.text).toContain('totem lint');
+  });
+
+  it('SARIF advisory note omits the frozen-lesson mention for an ast-grep warning-only run (greptile #2182)', async () => {
+    // ast-grep severity:warning is non-blocking but NOT a frozen-lesson regex
+    // advisory — the SARIF summary must not claim frozen-lesson regex rules.
+    const rules = [
+      makeRule('console\\.log\\("foo"\\)', 'No foo log', 'No foo log', {
+        engine: 'ast-grep',
+        astGrepPattern: 'console.log("foo")',
+        severity: 'warning',
+      }),
+    ];
+    writeRules(tmpDir, rules);
+
+    fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, 'src', 'app.ts'),
+      '// context\n  console.log("foo");\n// context\n',
+    );
+    const diff = makeDiff('src/app.ts', '  console.log("foo");');
+
+    const result = await runCompiledRules({
+      diff,
+      cwd: tmpDir,
+      totemDir: TOTEM_DIR,
+      format: 'sarif',
+      tag: 'Test',
+    });
+
+    const sarif = JSON.parse(result.output);
+    const results = sarif.runs[0].results;
+    expect(results).toHaveLength(1);
+    expect(results[0].message.text).toContain('advisory (non-blocking) finding(s) detected');
+    expect(results[0].message.text).not.toContain('frozen-lesson');
   });
 
   // ─── Ignore patterns ────────────────────────────────

--- a/packages/cli/src/commands/run-compiled-rules.test.ts
+++ b/packages/cli/src/commands/run-compiled-rules.test.ts
@@ -514,7 +514,11 @@ describe('runCompiledRules', () => {
     expect(results).toHaveLength(1);
     expect(results[0].level).toBe('note');
     expect(results[0].ruleId).toBe('totem/warning-summary');
-    expect(results[0].message.text).toContain('finding(s) detected');
+    // Tightened back (greptile #2182): assert the corrected, accurate message and
+    // guard against regressing to the stale "warning-severity" label — the bucket
+    // now includes regex error-severity findings demoted to advisory.
+    expect(results[0].message.text).toContain('advisory (non-blocking) finding(s) detected');
+    expect(results[0].message.text).not.toContain('warning-severity');
     expect(results[0].message.text).toContain('totem lint');
   });
 

--- a/packages/cli/src/commands/run-compiled-rules.test.ts
+++ b/packages/cli/src/commands/run-compiled-rules.test.ts
@@ -384,6 +384,54 @@ describe('runCompiledRules', () => {
     ).rejects.toThrow('Violations detected');
   });
 
+  it('emits the frozen-lesson advisory note when a regex advisory is present (mmnto-ai/totem#2182)', async () => {
+    const rules = [makeRule('console\\.log', 'Remove debug logging', 'No console.log')];
+    writeRules(tmpDir, rules);
+
+    const diff = makeDiff('src/app.ts', '  console.log("debug");');
+
+    const result = await runCompiledRules({
+      diff,
+      cwd: tmpDir,
+      totemDir: TOTEM_DIR,
+      format: 'text',
+      tag: 'Test',
+    });
+
+    expect(result.output).toContain('sensed-not-enforced');
+  });
+
+  it('does NOT emit the frozen-lesson note for an ast-grep warning-only run (gemini #2182)', async () => {
+    // ast-grep severity:warning lands in `warnings` too, but it is NOT a
+    // frozen-lesson regex advisory — the note must not mislabel it.
+    const rules = [
+      makeRule('console\\.log\\("foo"\\)', 'No foo log', 'No foo log', {
+        engine: 'ast-grep',
+        astGrepPattern: 'console.log("foo")',
+        severity: 'warning',
+      }),
+    ];
+    writeRules(tmpDir, rules);
+
+    fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, 'src', 'app.ts'),
+      '// context\n  console.log("foo");\n// context\n',
+    );
+    const diff = makeDiff('src/app.ts', '  console.log("foo");');
+
+    const result = await runCompiledRules({
+      diff,
+      cwd: tmpDir,
+      totemDir: TOTEM_DIR,
+      format: 'text',
+      tag: 'Test',
+    });
+
+    expect(result.violations).toHaveLength(1);
+    expect(result.output).not.toContain('sensed-not-enforced');
+  });
+
   // ─── Excluded files ──────────────────────────────────
 
   it('excludes compiled-rules.json from scanning', async () => {

--- a/packages/cli/src/commands/run-compiled-rules.test.ts
+++ b/packages/cli/src/commands/run-compiled-rules.test.ts
@@ -68,22 +68,28 @@ describe('runCompiledRules', () => {
 
   // ─── Regex matching ──────────────────────────────────
 
-  it('detects a violation when regex matches added line', async () => {
+  it('detects a regex violation but treats it as advisory — no throw (mmnto-ai/totem#2181)', async () => {
     const rules = [makeRule('console\\.log', 'Remove debug logging', 'No console.log')];
     writeRules(tmpDir, rules);
 
     const diff = makeDiff('src/app.ts', '  console.log("debug");');
 
-    // runCompiledRules throws SHIELD_FAILED for error-severity violations
-    await expect(
-      runCompiledRules({
-        diff,
-        cwd: tmpDir,
-        totemDir: TOTEM_DIR,
-        format: 'json',
-        tag: 'Test',
-      }),
-    ).rejects.toThrow('Violations detected');
+    // mmnto-ai/totem#2181: regex-engine (frozen-lesson) rules are advisory. The
+    // violation is still detected and printed, but it does NOT block — no throw,
+    // exit 0, counted as a (non-blocking) warning.
+    const result = await runCompiledRules({
+      diff,
+      cwd: tmpDir,
+      totemDir: TOTEM_DIR,
+      format: 'json',
+      tag: 'Test',
+    });
+
+    expect(result.violations).toHaveLength(1);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.pass).toBe(true);
+    expect(parsed.errors).toBe(0);
+    expect(parsed.warnings).toBe(1);
   });
 
   it('returns no violations when regex does not match', async () => {
@@ -208,18 +214,21 @@ describe('runCompiledRules', () => {
     ];
     writeRules(tmpDir, rules);
 
-    // Diff with a .sh file — should match and throw
+    // Diff with a .sh file — should match the shell-only rule
     const shDiff = makeDiff('scripts/build.sh', '# TODO: fix later');
 
-    await expect(
-      runCompiledRules({
-        diff: shDiff,
-        cwd: tmpDir,
-        totemDir: TOTEM_DIR,
-        format: 'json',
-        tag: 'Test',
-      }),
-    ).rejects.toThrow('Violations detected');
+    // mmnto-ai/totem#2181: the glob still matches and the regex violation is
+    // recorded, but it is advisory (non-blocking) — no throw.
+    const result = await runCompiledRules({
+      diff: shDiff,
+      cwd: tmpDir,
+      totemDir: TOTEM_DIR,
+      format: 'json',
+      tag: 'Test',
+    });
+
+    expect(result.violations).toHaveLength(1);
+    expect(JSON.parse(result.output).pass).toBe(true);
   });
 
   // ─── Output formats ─────────────────────────────────
@@ -248,11 +257,23 @@ describe('runCompiledRules', () => {
     expect(parsed.violations).toHaveLength(0);
   });
 
-  it('throws SHIELD_FAILED for error-severity violations in text format', async () => {
-    const rules = [makeRule('badPattern', 'Found bad pattern', 'Bad pattern rule')];
+  it('throws SHIELD_FAILED for ast-grep (hard-engine) error-severity violations (mmnto-ai/totem#2181)', async () => {
+    // ast/ast-grep is the hard engine that STAYS blocking under #2181.
+    const rules = [
+      makeRule('console\\.log\\("foo"\\)', 'No foo log', 'No foo log', {
+        engine: 'ast-grep',
+        astGrepPattern: 'console.log("foo")',
+      }),
+    ];
     writeRules(tmpDir, rules);
 
-    const diff = makeDiff('src/index.ts', '  badPattern();');
+    fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, 'src', 'app.ts'),
+      '// context\n  console.log("foo");\n// context\n',
+    );
+
+    const diff = makeDiff('src/app.ts', '  console.log("foo");');
 
     await expect(
       runCompiledRules({
@@ -314,21 +335,53 @@ describe('runCompiledRules', () => {
       ' }',
     ].join('\n');
 
-    // This will throw SHIELD_FAILED because there are error-severity violations
-    let caughtErr: unknown;
-    try {
-      await runCompiledRules({
+    // mmnto-ai/totem#2181: both rules are regex-engine → advisory. All violations
+    // are still reported, but the run does not block (no throw, pass true).
+    const result = await runCompiledRules({
+      diff,
+      cwd: tmpDir,
+      totemDir: TOTEM_DIR,
+      format: 'json',
+      tag: 'Test',
+    });
+
+    expect(result.violations.length).toBeGreaterThanOrEqual(2);
+    const parsed = JSON.parse(result.output);
+    expect(parsed.pass).toBe(true);
+    expect(parsed.errors).toBe(0);
+  });
+
+  // ─── Engine-type advisory split (mmnto-ai/totem#2181) ─────────
+
+  it('mixed run: the ast-grep error blocks even though the regex match is advisory', async () => {
+    const rules = [
+      // regex-engine → advisory (matches console.log on the added line)
+      makeRule('console\\.log', 'regex advisory', 'Regex rule'),
+      // ast-grep-engine → hard (matches the same line structurally)
+      makeRule('console\\.log\\("foo"\\)', 'No foo log', 'No foo log', {
+        engine: 'ast-grep',
+        astGrepPattern: 'console.log("foo")',
+      }),
+    ];
+    writeRules(tmpDir, rules);
+
+    fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, 'src', 'app.ts'),
+      '// context\n  console.log("foo");\n// context\n',
+    );
+    const diff = makeDiff('src/app.ts', '  console.log("foo");');
+
+    // The regex match alone would not block; the ast-grep error makes the run fail.
+    await expect(
+      runCompiledRules({
         diff,
         cwd: tmpDir,
         totemDir: TOTEM_DIR,
-        format: 'json',
+        format: 'text',
         tag: 'Test',
-      });
-    } catch (err) {
-      caughtErr = err;
-    }
-
-    expect(caughtErr).toBeDefined();
+      }),
+    ).rejects.toThrow('Violations detected');
   });
 
   // ─── Excluded files ──────────────────────────────────
@@ -378,9 +431,12 @@ describe('runCompiledRules', () => {
 
   // ─── SARIF output ──────────────────────────────────
 
-  it('SARIF output excludes warning-severity findings', async () => {
+  it('SARIF output excludes advisory (non-blocking) findings, emitting only a summary note (mmnto-ai/totem#2181)', async () => {
+    // Both a regex error-severity finding (now advisory under #2181) and a
+    // warning-severity finding are non-blocking, so neither appears as a SARIF
+    // result annotation — only the single summary note does. No throw.
     const rules = [
-      makeRule('errorPattern', 'This is an error', 'Error rule', { severity: 'error' }),
+      makeRule('errorPattern', 'This is a regex error', 'Error rule', { severity: 'error' }),
       makeRule('warnPattern', 'This is a warning', 'Warning rule', { severity: 'warning' }),
     ];
     writeRules(tmpDir, rules);
@@ -396,31 +452,8 @@ describe('runCompiledRules', () => {
       ' // end',
     ].join('\n');
 
-    // Error-severity violations cause a throw, but we need the SARIF output
-    let caughtErr: unknown;
-    try {
-      await runCompiledRules({
-        diff,
-        cwd: tmpDir,
-        totemDir: TOTEM_DIR,
-        format: 'sarif',
-        tag: 'Test',
-      });
-    } catch (err) {
-      caughtErr = err;
-    }
-
-    expect(caughtErr).toBeDefined();
-
-    // Read the SARIF output from the error or capture it via --out
-    // Since the function throws, check that warning-only runs produce clean SARIF
-    const warningOnlyRules = [
-      makeRule('warnPattern', 'This is a warning', 'Warning rule', { severity: 'warning' }),
-    ];
-    writeRules(tmpDir, warningOnlyRules);
-
     const result = await runCompiledRules({
-      diff: makeDiff('src/app.ts', '  warnPattern();'),
+      diff,
       cwd: tmpDir,
       totemDir: TOTEM_DIR,
       format: 'sarif',
@@ -429,11 +462,11 @@ describe('runCompiledRules', () => {
 
     const sarif = JSON.parse(result.output);
     const results = sarif.runs[0].results;
-    // Warning-only violations produce a single summary note, not individual annotations
+    // Non-blocking findings produce a single summary note, not individual annotations.
     expect(results).toHaveLength(1);
     expect(results[0].level).toBe('note');
     expect(results[0].ruleId).toBe('totem/warning-summary');
-    expect(results[0].message.text).toContain('1 warning-severity finding(s) detected');
+    expect(results[0].message.text).toContain('finding(s) detected');
     expect(results[0].message.text).toContain('totem lint');
   });
 

--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -482,9 +482,26 @@ export async function runCompiledRules(
     );
   }
 
-  // Classify violations by severity (computed once, reused across all output formats)
-  const errors = violations.filter((v) => (v.rule.severity ?? 'error') === 'error');
-  const warnings = violations.filter((v) => (v.rule.severity ?? 'error') === 'warning');
+  // Classify violations into blocking (exit-1) vs advisory (printed, non-blocking).
+  // Computed once, reused across all output formats.
+  //
+  // mmnto-ai/totem#2181 — engine-type advisory split. `totem lint` runs only
+  // .totem/compiled-rules.json, and every rule there is a frozen compiled lesson
+  // (un-recompilable under the standing rule-compilation freeze). The regex engine
+  // is the false-positive flood that forced `--no-verify` on every #2179 push; the
+  // ast/ast-grep family is the structural/precision class that earns hard
+  // enforcement. Demote the whole regex class to advisory — printed, excluded from
+  // the exit-1 tally — REGARDLESS of severity (one discriminator: engine, not
+  // engine×severity; Tenet 21). Hard engines keep their existing severity behavior
+  // (error blocks, warning doesn't) — that is "stay hard". `engine` is a required
+  // enum, so `!== 'regex'` is exactly the ast/ast-grep family (mirrors the astRules
+  // filter above). The durable provenance/ruleClass marker rides the spine
+  // (mmnto-ai/totem-strategy#516); engine-type is the conservative interim proxy.
+  const isBlocking = (v: Violation): boolean =>
+    (v.rule.engine === 'ast' || v.rule.engine === 'ast-grep') &&
+    (v.rule.severity ?? 'error') === 'error';
+  const errors = violations.filter(isBlocking);
+  const warnings = violations.filter((v) => !isBlocking(v));
 
   // Convert to unified findings model once (ADR-071)
   const { violationToFinding } = await import('@mmnto/totem');
@@ -584,6 +601,9 @@ export async function runCompiledRules(
       if (warnings.length > 0) {
         lines.push('');
         lines.push('### Warnings');
+        lines.push(
+          '_Advisory — printed for awareness, excluded from the exit code. Frozen-lesson (regex) rules are sensed-not-enforced under the rule-compilation freeze (mmnto-ai/totem#2181); PR review is the real sensor._',
+        );
         for (const v of warnings) {
           lines.push(`- **${v.file}:${v.lineNumber}** - ${v.rule.message}`);
           lines.push(`  Pattern: \`/${v.rule.pattern}/\``);

--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -519,18 +519,20 @@ export async function runCompiledRules(
     const req = createRequire(import.meta.url);
     const version = (req('../../package.json') as { version: string }).version;
     const commitHash = getHeadSha(cwd) ?? undefined;
-    // SARIF is a strict channel for error-severity findings only.
-    // Warnings are probationary (Rule Nursery) and stay as local telemetry
-    // to prevent alert fatigue in the PR UI (Proposal 190).
+    // SARIF results carry only BLOCKING findings (ast/ast-grep error-severity).
+    // The non-blocking set — frozen-lesson regex rules (any severity, demoted to
+    // advisory under mmnto-ai/totem#2181) plus probationary warning-severity rules
+    // — is omitted from the per-finding annotations and surfaced as a single
+    // summary note, to avoid alert fatigue in the PR UI (Proposal 190).
     const sarif = buildSarifLog(errors, rules, { version, commitHash });
 
-    // Surface warning count as a single note so users know they exist
+    // Surface the non-blocking (advisory) count as a single note so users know they exist
     if (warnings.length > 0) {
       const summaryRuleIdx = sarif.runs[0].tool.driver.rules.length;
       sarif.runs[0].tool.driver.rules.push({
         id: 'totem/warning-summary',
         shortDescription: {
-          text: 'Probationary warnings detected — run `totem lint` locally to review',
+          text: 'Advisory (non-blocking) findings detected — run `totem lint` locally to review',
         },
       });
       sarif.runs[0].results.push({
@@ -538,7 +540,7 @@ export async function runCompiledRules(
         ruleIndex: summaryRuleIdx,
         level: 'note',
         message: {
-          text: `${warnings.length} warning-severity finding(s) detected. Warnings are probationary and not shown in PR reviews. Run \`totem lint\` locally to review.`,
+          text: `${warnings.length} advisory (non-blocking) finding(s) detected — frozen-lesson regex rules (mmnto-ai/totem#2181) and probationary warnings, excluded from PR annotations. Run \`totem lint\` locally to review.`,
         },
         locations: [
           {

--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -493,18 +493,25 @@ export async function runCompiledRules(
   // enforcement. Demote the whole regex class to advisory — printed, excluded from
   // the exit-1 tally — REGARDLESS of severity (one discriminator: engine, not
   // engine×severity; Tenet 21). Hard engines keep their existing severity behavior
-  // (error blocks, warning doesn't) — that is "stay hard". Only an explicit
-  // ast/ast-grep engine blocks; any other engine (incl. a hypothetical legacy
-  // `undefined`) falls to advisory by design — the conservative default. A missing
-  // `engine` cannot actually reach here: it is a required enum and loadCompiledRules
-  // strict-parses the file, rejecting it with a regenerate hint otherwise
-  // (greptile #2182). The durable provenance/ruleClass marker rides the spine
+  // (error blocks, warning doesn't) — that is "stay hard".
+  //
+  // `isHardEngine` is the single source of truth for "blocks". Only an explicit
+  // ast/ast-grep engine is hard; a regex engine OR a legacy rule with no `engine`
+  // field falls to advisory — matching rule-engine.ts's `r.engine === 'regex' ||
+  // !r.engine` convention, where a missing engine is treated AS regex (gemini /
+  // greptile #2182). The durable provenance/ruleClass marker rides the spine
   // (mmnto-ai/totem-strategy#516); engine-type is the conservative interim proxy.
+  const isHardEngine = (v: Violation): boolean =>
+    v.rule.engine === 'ast' || v.rule.engine === 'ast-grep';
   const isBlocking = (v: Violation): boolean =>
-    (v.rule.engine === 'ast' || v.rule.engine === 'ast-grep') &&
-    (v.rule.severity ?? 'error') === 'error';
+    isHardEngine(v) && (v.rule.severity ?? 'error') === 'error';
   const errors = violations.filter(isBlocking);
   const warnings = violations.filter((v) => !isBlocking(v));
+  // Whether any non-blocking finding is a frozen-lesson regex-class rule (regex, or a
+  // legacy rule with no engine) vs only ast/ast-grep probationary warnings. Gates the
+  // frozen-lesson wording in BOTH the text note and the SARIF summary, so an
+  // ast-warning-only run is never mislabeled as frozen-lesson (gemini/greptile #2182).
+  const hasFrozenLessonAdvisory = warnings.some((v) => !isHardEngine(v));
 
   // Convert to unified findings model once (ADR-071)
   const { violationToFinding } = await import('@mmnto/totem');
@@ -540,7 +547,14 @@ export async function runCompiledRules(
         ruleIndex: summaryRuleIdx,
         level: 'note',
         message: {
-          text: `${warnings.length} advisory (non-blocking) finding(s) detected — frozen-lesson regex rules (mmnto-ai/totem#2181) and probationary warnings, excluded from PR annotations. Run \`totem lint\` locally to review.`,
+          // Conditionalize the frozen-lesson mention exactly like the text note
+          // (greptile #2182): an ast/ast-grep-warning-only run has no regex-class
+          // advisory, so it must not claim frozen-lesson regex rules.
+          text: `${warnings.length} advisory (non-blocking) finding(s) detected${
+            hasFrozenLessonAdvisory
+              ? ' (incl. frozen-lesson regex rules demoted under mmnto-ai/totem#2181)'
+              : ''
+          } — excluded from PR annotations. Run \`totem lint\` locally to review.`,
         },
         locations: [
           {
@@ -606,12 +620,12 @@ export async function runCompiledRules(
       if (warnings.length > 0) {
         lines.push('');
         lines.push('### Warnings');
-        // mmnto-ai/totem#2181: the frozen-lesson advisory note applies only to
-        // regex-engine findings. ast/ast-grep severity:warning findings can also
-        // land in `warnings` (genuine Rule-Nursery probationary warnings) — so only
-        // emit the note when a regex advisory is actually present, else a regex-free
-        // warning list would be mislabeled as frozen-lesson advisory (gemini #2182).
-        if (warnings.some((v) => v.rule.engine === 'regex')) {
+        // mmnto-ai/totem#2181: the frozen-lesson advisory note applies only to the
+        // regex-class (regex, or legacy no-engine). ast/ast-grep severity:warning
+        // findings also land in `warnings` (genuine Rule-Nursery probationary
+        // warnings) — emit the note only when a regex-class advisory is actually
+        // present, else a regex-free warning list is mislabeled (gemini #2182).
+        if (hasFrozenLessonAdvisory) {
           lines.push(
             '_Advisory — printed for awareness, excluded from the exit code. Frozen-lesson (regex) rules are sensed-not-enforced under the rule-compilation freeze (mmnto-ai/totem#2181); PR review is the real sensor._',
           );

--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -493,9 +493,12 @@ export async function runCompiledRules(
   // enforcement. Demote the whole regex class to advisory — printed, excluded from
   // the exit-1 tally — REGARDLESS of severity (one discriminator: engine, not
   // engine×severity; Tenet 21). Hard engines keep their existing severity behavior
-  // (error blocks, warning doesn't) — that is "stay hard". `engine` is a required
-  // enum, so `!== 'regex'` is exactly the ast/ast-grep family (mirrors the astRules
-  // filter above). The durable provenance/ruleClass marker rides the spine
+  // (error blocks, warning doesn't) — that is "stay hard". Only an explicit
+  // ast/ast-grep engine blocks; any other engine (incl. a hypothetical legacy
+  // `undefined`) falls to advisory by design — the conservative default. A missing
+  // `engine` cannot actually reach here: it is a required enum and loadCompiledRules
+  // strict-parses the file, rejecting it with a regenerate hint otherwise
+  // (greptile #2182). The durable provenance/ruleClass marker rides the spine
   // (mmnto-ai/totem-strategy#516); engine-type is the conservative interim proxy.
   const isBlocking = (v: Violation): boolean =>
     (v.rule.engine === 'ast' || v.rule.engine === 'ast-grep') &&
@@ -601,9 +604,16 @@ export async function runCompiledRules(
       if (warnings.length > 0) {
         lines.push('');
         lines.push('### Warnings');
-        lines.push(
-          '_Advisory — printed for awareness, excluded from the exit code. Frozen-lesson (regex) rules are sensed-not-enforced under the rule-compilation freeze (mmnto-ai/totem#2181); PR review is the real sensor._',
-        );
+        // mmnto-ai/totem#2181: the frozen-lesson advisory note applies only to
+        // regex-engine findings. ast/ast-grep severity:warning findings can also
+        // land in `warnings` (genuine Rule-Nursery probationary warnings) — so only
+        // emit the note when a regex advisory is actually present, else a regex-free
+        // warning list would be mislabeled as frozen-lesson advisory (gemini #2182).
+        if (warnings.some((v) => v.rule.engine === 'regex')) {
+          lines.push(
+            '_Advisory — printed for awareness, excluded from the exit code. Frozen-lesson (regex) rules are sensed-not-enforced under the rule-compilation freeze (mmnto-ai/totem#2181); PR review is the real sensor._',
+          );
+        }
         for (const v of warnings) {
           lines.push(`- **${v.file}:${v.lineNumber}** - ${v.rule.message}`);
           lines.push(`  Pattern: \`/${v.rule.pattern}/\``);


### PR DESCRIPTION
## What

Advisory-ize the **frozen-lesson regex rule class** in the local pre-push `totem lint` gate, by one discriminator — **engine type**. Closes #2181.

- `engine === 'regex'` → **advisory** (printed, excluded from the exit-1 tally, **regardless of severity**)
- `ast` / `ast-grep` (the structural/precision family) → **stay HARD** (error-severity blocks)

## Why

The local pre-push gate hard-blocked (exit-1) on frozen compiled-lesson **regex** findings. Those rules are un-recompilable under the standing `rule-compilation` freeze, so they misfire densely as false positives on any new source file — on #2179 this forced `--no-verify` on **every** push. #2178 already advisory-ized the **CI** Totem Lint job (`continue-on-error`); the **local pre-push hook was never advisory-ized**. Same class as the #2180 review-gate decommission: a local hard-gate re-justifying a frozen mechanism.

This is Proposal 299's invariant applied (strategy#661): **sense in Yellow, enforce in Green** — a rule earns hard enforcement by legitimacy.

## Design

- **One discriminator (Tenet 21).** strategy-claude's 2258Z ruling (operator-greenlit): demote uniformly by **engine**, not engine×severity. `totem lint` runs only `.totem/compiled-rules.json` and **every** rule there is lesson-derived; the structural family that "stays hard" *is* the `ast`/`ast-grep` engine — so engine-type is the faithful, and **conservative** (keeps more hard), operationalization.
- **Engine-level** change in `packages/cli/src/commands/run-compiled-rules.ts` so all callers inherit consistently (local pre-push, `totem lint`, CI shield). Output formats already key off `errors`/`warnings` — **no new fields**, backward-compatible JSON/SARIF.
- **Breaking-by-design:** a regex error-severity violation no longer throws `SHIELD_FAILED`. Five tests that encoded the old contract are updated; new tests assert the split directly (regex → advisory; `ast-grep` error → still blocks; mixed run blocks only on the AST error).

## Interim vs durable

Interim — engine-type is an inferred proxy for "frozen-lesson regex." The durable `provenance`/`ruleClass` marker (an explicit attribute, not engine-inferred) and per-finding regex inline-suppression ride the spine (strategy#516); captured as a spine deliverable on #2181.

## Verification

- `pnpm build` ✓ (tsc clean, all packages) · `pnpm lint` ✓ (0 errors) · `pnpm test` ✓ (**2580 tests pass**) · `format:check` ✓
- **Self-test — the gate is no longer self-defeating:** this branch's own pre-push `totem lint` now **PASSes (20 advisory warnings, 0 errors)** where it previously hard-blocked. The 20 are textbook frozen-lesson FPs — including one flagging this PR's own `||` boolean check at `run-compiled-rules.ts:501` as "use `??` for numeric metrics." `0 errors` = no structural (ast) catch dropped.

Verify criterion (strategy-claude cohort-verify; lc = live prover): *does the advisory-ize stop the #2179 flood without dropping a single real structural catch?* — met locally; lc is the live prover.

Spec: `.totem/specs/2181.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
