### PR TITLE
chore(changeset): @mmnto/cli patch — frozen-lesson advisory split (#2181/#2182)

### DIFF
--- a/.changeset/frozen-lesson-advisory-2181.md
+++ b/.changeset/frozen-lesson-advisory-2181.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/cli': patch
+---
+
+Advisory-ize the frozen-lesson regex rule class in the local pre-push `totem lint` gate (engine-type split). Regex-engine compiled-lesson rules are demoted to advisory — printed, but excluded from the exit-1 tally regardless of severity — while `ast`/`ast-grep` structural rules stay hard-blocking. This stops the frozen-lesson false-positive flood (un-recompilable under the rule-compilation freeze) that was forcing `--no-verify` on every push, matching the advisory posture already applied to the CI Totem Lint job. (#2181, #2182)

--- a/.changeset/frozen-lesson-advisory-2181.md
+++ b/.changeset/frozen-lesson-advisory-2181.md
@@ -2,4 +2,4 @@
 '@mmnto/cli': patch
 ---
 
-Advisory-ize the frozen-lesson regex rule class in the local pre-push `totem lint` gate (engine-type split). Regex-engine compiled-lesson rules are demoted to advisory — printed, but excluded from the exit-1 tally regardless of severity — while `ast`/`ast-grep` structural rules stay hard-blocking. This stops the frozen-lesson false-positive flood (un-recompilable under the rule-compilation freeze) that was forcing `--no-verify` on every push, matching the advisory posture already applied to the CI Totem Lint job. (#2181, #2182)
+Advisory-ize the frozen-lesson regex rule class in the local pre-push `totem lint` gate via an engine-type split. Regex-engine compiled-lesson rules are now advisory — printed, but excluded from the exit-1 tally regardless of severity — while `ast`/`ast-grep` structural rules stay hard-blocking. This stops the frozen-lesson false-positive flood (un-recompilable under the rule-compilation freeze) that was forcing `--no-verify` on every push, matching the advisory posture already applied to the CI Totem Lint job (#2181, #2182).


### PR DESCRIPTION
Adds the missing changeset for the engine-type advisory split (#2182, merged `4d918ef1`) so it ships in the next `@mmnto/cli` wave and the cohort — lc as live prover — inherits the new `totem lint` posture, closing the lc half of strategy-claude's cohort-verify.

Patch bump 1.64.0 → 1.64.1. On merge, the Release workflow opens a Version Packages PR; merging **that** triggers the OIDC publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)