### PR TITLE
feat(spine): Gate-1 wind-tunnel evidence harness (#2188, 299 Gate 1)

### DIFF
--- a/.changeset/windtunnel-gate1-cli.md
+++ b/.changeset/windtunnel-gate1-cli.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/cli': minor
+---
+
+Gate-1 wind-tunnel CLI (mmnto-ai/totem#2188): add `totem spine windtunnel freeze` and `totem spine windtunnel run` commands with `--lc-dir` / `TOTEM_LC_DIR` option, git-derived freeze proof (C3), phase rejection for harness→certifying (P1), shared post-image readStrategy (S1/C1), and mock engine for harness-phase validation (OQ2).

--- a/.changeset/windtunnel-gate1-core.md
+++ b/.changeset/windtunnel-gate1-core.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/totem': minor
+---
+
+Gate-1 wind-tunnel evidence harness (mmnto-ai/totem#2188): add `WindtunnelLockSchema` + `WindtunnelLock` type (spine/windtunnel-lock.ts), pure `scoreWindtunnel` scorer (spine/windtunnel-scorer.ts), and `readStrategy` injection seam on `AstGateOptions` / `enrichWithAstContext` for regex+AST firing parity with production `totem lint` (C1).

--- a/.totem/specs/2188.md
+++ b/.totem/specs/2188.md
@@ -1,0 +1,268 @@
+### Problem Statement
+
+Implement the Gate-1 evidence engine (wind-tunnel) for Proposal 299 to falsifiably evaluate generated rules against a frozen historical repository state. This requires defining the structural contract for `.totem/spine/gate-1/windtunnel.lock.json` and building a retrospective replay CLI tool that guarantees zero false positives over a historical corpus while ensuring non-vacuous true positives on known control fixtures.
+
+### Architectural Context
+
+- **ADR-089 (Zero-Trust Default) & PR #2183**: New rules must be evaluated against strict criteria before promotion. The `legitimacy` / `ruleClass` markers introduced in #2183 are the source of truth for determining which rules are eligible for this wind-tunnel replay.
+- **Stateless Execution (#1908/Proposal 273)**: All rule evaluation (like `totem lint`) must operate without polluting the user's working directory or requiring state flags. Retrospective analysis of historical commits MUST occur in isolated environments to prevent git tree corruption.
+
+### Files to Examine
+
+1. `packages/core/src/compiler-schema.ts` — Understand how `legitimacy` and `ruleClass` are currently structured to filter eligible rules.
+2. `packages/cli/src/commands/verify-manifest.ts` — Existing pattern for CLI commands reading locked repository configuration.
+3. `packages/cli/src/commands/install-hooks.ts` — Reference for strict-tier gating and execution boundaries.
+
+### Technical Approach & Contracts
+
+To evaluate historical commits, the deterministic linting engine requires actual file content. Checking out historical commits in the active working directory is an architectural trap that will strand users in detached-HEAD states on failure.
+
+**Recommended Approach:**
+
+1. **Isolated Worktrees**: Use ephemeral `git worktree` instances managed via `safeExec` to checkout and evaluate historical commits safely.
+2. **Strict Manifest Contract**: Define a Zod schema that enforces the `windtunnel.lock.json` shape precisely as requested in the issue.
+3. **Execution Sequence**:
+   - Resolve git root (`resolveGitRoot`).
+   - Read and validate `.totem/spine/gate-1/windtunnel.lock.json` (`readJsonSafe`).
+   - Verify repo is not a shallow clone (which would break historical replays).
+   - Filter active compiled rules requiring validation.
+   - For each corpus commit and adversarial fixture: create worktree, lint, assert 0 violations (Zero-Confirmed-FP floor).
+   - For each positive control: create worktree, lint, assert _exact_ expected rules fire (Non-Vacuous Pass).
+   - Calculate and output the exposure denominator tuple.
+
+**Data Contract: `WindtunnelManifestSchema`**
+
+```typescript
+export const WindtunnelManifestSchema = z.object({
+  version: z.literal('1.0'),
+  params: z.object({
+    N: z.number().int().positive().describe('Frozen window size'),
+    precisionFloor: z.literal('zero-confirmed-FP'),
+    falsePositiveDefinition: z.string(),
+    exposureDenominator: z
+      .tuple([
+        z.number().int().describe('Active rules'),
+        z.number().int().describe('Files'),
+        z.number().int().describe('Controls'),
+      ])
+      .optional(), // Calculated during run, can be pinned here
+  }),
+  corpus: z.object({
+    author: z.literal('lc'),
+    commits: z.array(z.string().length(40)).describe('Full SHAs of merged PR history'),
+  }),
+  controls: z.object({
+    positive: z.array(
+      z.object({
+        commit: z.string().length(40),
+        expectedFiredRules: z
+          .array(z.string())
+          .min(1)
+          .describe('Rule IDs that MUST fire to prove non-vacuousness'),
+      }),
+    ),
+    adversarial: z.array(
+      z.object({
+        commit: z.string().length(40),
+        expectedFiredRules: z.array(z.string()).max(0).describe('Near-misses that MUST NOT fire'),
+      }),
+    ),
+  }),
+});
+```
+
+### Edge Cases & Traps
+
+- **Git Shallow Clones**: CI environments often do shallow clones (`--depth=1`). Replaying historical commits will fail obscurely. The tool must run `git rev-parse --is-shallow-repository` and fail fast with an actionable error.
+- **Worktree Leaks**: If the Node process crashes or is interrupted (`SIGINT`), lingering git worktrees will pollute the user's `.git/worktrees` internal registry. A robust `try/finally` block + `process.on('SIGINT')` trap is required.
+- **Resource Exhaustion**: Creating `N` worktrees simultaneously will exhaust disk I/O and process limits. The replay loop MUST be strictly serial.
+- **Vacuous Pass Trap**: A rule might pass the "zero false positive" test simply by being broken and never matching anything. The positive controls must explicitly verify that the _exact target rule_ fires.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Define Windtunnel Manifest Schema**
+  - Create `packages/core/src/spine/windtunnel-schema.ts`.
+  - Export `WindtunnelManifestSchema` as defined in the technical approach.
+  - Export inferred type `WindtunnelManifest`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `rejects manifest with empty expectedFiredRules in positive controls` that proves the schema prevents vacuous control definitions.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Build Ephemeral Worktree Manager**
+  - Create `packages/cli/src/utils/git-worktree.ts`.
+  - Implement `withEphemeralWorktree(commitSha: string, callback: (worktreePath: string) => Promise<T>): Promise<T>`.
+  - Use `safeExec('git', ['worktree', 'add', '--detach', tmpPath, commitSha])`.
+  - Ensure teardown in a `finally` block uses `safeExec('git', ['worktree', 'remove', '-f', tmpPath])`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `cleans up git worktree even when callback throws an error` that proves disk and git tree state are restored.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Implement Replay Engine Core**
+  - Create `packages/cli/src/spine/windtunnel-engine.ts`.
+  - Implement the engine that takes a `WindtunnelManifest` and a list of active rules.
+  - Iterate serially through `corpus.commits` and `controls.adversarial` -> run lint engine -> throw `FalsePositiveError` if ANY rule fires.
+  - Iterate serially through `controls.positive` -> run lint engine -> throw `VacuousPassError` if `expectedFiredRules` are missing from the output.
+  - Compute the exposure tuple: `[rules.length, totalFilesEvaluated, totalCommitsEvaluated]`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `throws VacuousPassError when positive control fails to trigger the designated rule` that proves the done-criterion.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Expose `totem spine windtunnel` CLI Command**
+  - Create `packages/cli/src/commands/spine-windtunnel.ts`.
+  - Use `resolveGitRoot` to locate and `readJsonSafe` to parse `.totem/spine/gate-1/windtunnel.lock.json`.
+  - Pre-flight check: use `safeExec` to verify `git rev-parse --is-shallow-repository` returns `false`.
+  - Execute the engine from Task 3, outputting the exposure denominator tuple on success, or exiting `1` on precision/vacuous errors.
+  - Register the command in the CLI router.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `exits immediately with clear error if repository is a shallow clone` that proves CI edge cases are caught early.
+  - write test → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Schema Validation**: Verify `WindtunnelManifestSchema` strictly rejects invalid commit SHAs, negative `N`, and empty positive controls.
+- **Worktree Safety**: Create a mock git repository, run the worktree manager, induce a crash, and verify `git worktree list` does not contain orphaned paths.
+- **Engine Falsifiability**:
+  - Mock a linting engine that always returns 0 violations -> must fail positive control.
+  - Mock a linting engine that always returns 1 violation -> must fail negative corpus control (zero-confirmed-FP).
+  - Mock perfect linting engine -> asserts correct exposure denominator calculation.
+
+---
+
+## Implementation Design
+
+> Authored after grounding against the real code + strategy-claude's operator-ruled lens (0658Z). **Two corrections to the Gemini spec above, which this supersedes:** (1) the lock schema is strategy-claude's `windtunnel.lock.v1`, NOT the Gemini `WindtunnelManifestSchema` (controls are referenced-by-path, not inline; corpus is a selection-rule + frozen `resolvedPrs`, not an inline SHA array). (2) **No git-worktrees / historical checkouts.** The corpus is **lc PR diffs**, and the rule engine (`runCompiledRules`/`applyRulesToAdditions`) already consumes a `diff: string` — so the replay feeds each PR's diff to the engine. A local lc clone exists at `D:\Dev\liquid-city`, so corpus diffs resolve offline + deterministically from `resolvedPrs` @ `asOfCommit`.
+
+### Sharpenings folded (strategy-claude APPROVE — 2026-06-17T17:36Z)
+
+The 0658Z schema/params ruling + this 17:36Z spec APPROVE settle the contract. Four sharpenings fold in below — **S1 is binding on correctness; S2–S4 close residual vacuous-pass / silent-shrink holes** — plus the OQ2 mock additions. OQ2/OQ3 are ratified. None reopen the contract.
+
+**S1 — [BINDING] Firing-parity with production `totem lint`.** The replay must feed each rule the _same context production lint feeds it_, or the wind-tunnel measures a different engine than Gate 2 arms. Grounded against `packages/core/src/rule-engine.ts`: the **regex family** (`applyRulesToAdditions`) consumes diff additions only — fine on a diff string. But the **AST / ast-grep family** (`applyAstRulesToAdditions`, L515–558) parses the **full post-image file** and only _scopes reports_ to `addedLineNumbers` — an additions-only feed makes it silently **under-fire**. The engine already exposes the exact seam: a `readStrategy(file) => Promise<string>` injection (L535–536) overriding the default working-tree `fs.readFile`. So the replay supplies a `readStrategy` that resolves the **post-image blob** offline from the lc clone (`git show <PR-head-@-asOfCommit>:<path>`) — no worktrees, no checkout, exact parity (the engine parses content identical to an on-disk lint). This **refines the intro's "feeds the diff" simplification**: a corpus item is `{ diff, readStrategy }`, not `diff` alone.
+
+- _Parity test (locks it):_ a rule that fires in real `totem lint` over a PR checkout MUST fire in the diff+`readStrategy` replay of that PR. If parity is ever unreachable for a whole-file rule, resolve more post-image blobs — **never fall back to worktrees.** **→ Extended by C1 (Verdict folds): the post-image seam must also cover `enrichWithAstContext` (regex `astContext`), and the parity test is bidirectional (== production firings).**
+
+**S2 — Hole A: cull-laundering guard (sharpest).** The negative-control cull (a rule that fires on a near-miss ⇒ culled + recorded in `cullLedger`) is a laundering path for the precision claim: cull the noisy rules, then report 1.0 on the clean residue. A 10-minted / 2-survivor run clears `activeRules ≥ 2` and shows a perfect number — but that's closer to HONEST-NEGATIVE (_mining mints mostly-illegitimate rules_). Fold:
+
+- `WindtunnelVerdict` carries `mintedRuleCount` / `culledCount` / `survivingRuleCount` as **first-class fields** (the ledger has the rows; the verdict must surface the ratio).
+- Precision is stated explicitly as **"over surviving rules."**
+- A high cull rate pulls the verdict toward **HONEST-NEGATIVE**, not a clean PASS — `activeRules ≥ 2` is a masquerade guard, not a yield bar. (Cull-rate threshold pinned in the lock; the ratio is surfaced loudly even when it does not flip the verdict.)
+
+**S3 — Hole B: two-freezes lifecycle (not one).** There are two distinct locks: the **harness-validation** lock (mock rules, `mintedRuleCount ≈ 0`) and the **post-#516 certifying** lock. The exposure floor `positiveControlsExercised.floor ≥ mintedRuleCount` is vacuous at harness time (≥ 0), so the harness lock MUST NOT be reused as the certifying lock — else the real run passes with zero positive controls. "Frozen-once" is **per-lock**, not one lock across both phases: the certifying run **re-freezes** the exposure floor against the real minted set. The lock carries a `phase: "harness" | "certifying"` discriminator; a certifying `run` rejects a harness-phase lock.
+
+**S4 — Hole C: freeze-time completeness (twin of the run-time guard).** The run-time guard is airtight (corpus diff unresolvable ⇒ hard error, never skip). But `freeze` had no completeness check — nothing stopped it snapshotting 50 of 117 code-touching PRs into `resolvedPrs` and looking legitimate. The contract is **N = ALL code-touching lc PRs**; completeness _is_ the point. Add the freeze-time assertion: `resolvedPrs === selectionRule(asOfCommit)` — re-derivable + diffable, so the freeze itself cannot silently drop PRs.
+
+**OQ2 mock additions.** Harness-only-now is ratified, but the mock-engine validation MUST exercise the **HONEST-NEGATIVE** (exposure-floor trip) and **needs-adjudication** (unlabeled-firing) verdicts — not just the always-0 / always-1 / perfect mocks. Those two verdicts are exactly where a vacuous-pass bug hides.
+
+**OQ3 ratified.** Gate-1-scoped `fixtureSha` (reuse the `git hash-object` recipe; do NOT extend the existing `.totem/tests` `FIXTURE_DIR`).
+
+### Verdict folds (codex CONCERN + agy recs — 2026-06-17 pre-build round)
+
+Panel: **gemini APPROVE** (tenet — no changes), **agy PASS + 3 recs**, **codex CONCERN / hold** (5 blocking + 3 precision). All codex blocking items are folded below; C1's `enrichWithAstContext` claim was **verified against the code** (`ast-gate.ts` L74–82 reads staged/disk via `git show :<file>`, no injection seam). These **deepen S1 and the freeze proof — they do not reopen the contract** (C3 realizes strategy-claude's stated "git-log greppable" intent).
+
+**C1 — [BINDING; supersedes S1's mechanism] Parity covers the _whole_ production classification path, not just the AST engine.** Production `run-compiled-rules.ts` (L214) calls `enrichWithAstContext(additions, { cwd })` **before** rule execution; regex rules then suppress matches via `addition.astContext` (`rule-engine.ts` L316: non-`code` context ⇒ skip). `enrichWithAstContext`→`classifyFile` (`ast-gate.ts` L74–82) reads **staged** content (`git show :<file>`) with a disk fallback and has **no content-injection seam** — so an AST-only `readStrategy` still measures a different engine (regex rules classify `astContext` from the wrong tree or fail-open as code ⇒ **over-fire in comments/strings**). Fold:
+
+- **Production change (now in scope):** add a content-injection seam to `AstGateOptions` (e.g. `readStrategy?: (file) => Promise<string | null>`) so `enrichWithAstContext` classifies from the same post-image content the AST engine gets. Minimal, additive, default-unchanged for normal lint.
+- The wind-tunnel `run` passes **one shared** post-image `readStrategy` into **both** `enrichWithAstContext` and `applyAstRulesToAdditions`, so regex + AST see identical content.
+- **Parity test is bidirectional:** for a fixed PR/rule set, replay firings **==** production firings — including a **negative fixture** where production suppresses a regex match in a comment/string and the replay must **not** emit it (catches replay-only _over_-firing, not just under-firing). Covers **both** Tree-sitter and ast-grep families (folds P3).
+
+**C2 — Missing post-image blob ⇒ hard error, never a silent no-match.** `matchAstQueriesBatch` / the ast-grep branch return zero matches when content is `null`; for the wind-tunnel a missing blob is corpus shrinkage, not a clean non-firing. Fold: the wind-tunnel `readStrategy` **throws** on any unresolved blob for an evaluated added file. Only cases production also excludes (deleted file with no additions; intentionally-skipped symlink) may legitimately have no blob. Test: missing/unresolvable blob ⇒ hard error, not a zero-firing result.
+
+**C3 — `frozenAt.commit` proof is git-derived, not a self-embedded trusted field.** A file cannot contain the SHA of the commit that contains it (the hash includes the content). Fold: `run` **derives/verifies** the proof from git history — `git log --format=%H -- .totem/spine/gate-1/windtunnel.lock.json` ⇒ that commit MUST be an ancestor of the run commit; if `frozenAt.commit` is retained in the lock, additionally verify the lock blob **at that commit is byte-identical** to the current lock + ancestry holds.
+
+**C4 — `resolvedPrs` entries pin replay identity, not just membership.** A PR number alone doesn't map to a diff offline (local git has no PR#→merge/base/head map; refs move/disappear). Fold: each entry is structured + immutable — `{ pr, mergeCommit, baseSha, headSha, diffSha? }` — with unique/sorted validation. The S4 completeness assertion compares this **structured set** against `selectionRule(asOfCommit)`, not a count or bare PR-number list.
+
+**C5 — `cullRateThreshold` is required, frozen, and non-vacuous.** Pinning alone isn't enough — if it permits `1.0`, omission, or post-hoc override, a 10-mint / 8-cull / 2-survive run still "reports but doesn't decide." Fold: schema makes it **required**, frozen, constrained to `0 ≤ threshold < 1` (default operator-ratified). The scorer **mechanically returns `HONEST-NEGATIVE`** when `culledCount / mintedRuleCount > threshold`, while still reporting minted/culled/surviving; precision is labeled "over surviving rules" **only after** the cull-rate guard runs.
+
+**Precision folds.** **P1** — phase rejection keys off an **external requested phase** (`run --phase certifying`), not only the lock's self-declared phase, so harness output can't be mistaken for certification. **P2** — pin floor comparator semantics in tests: name the fields as minimums and test the exact equality boundary (`activeRules == 2` passes, `== 1` ⇒ HONEST-NEGATIVE; `positiveControls == mintedRuleCount` passes). **P3** — folded into C1's bidirectional parity test (Tree-sitter + ast-grep + regex/astContext).
+
+**agy recs.** **A1** — export `spine/windtunnel-lock.ts` + `spine/windtunnel-scorer.ts` from `packages/core/src/index.ts` (else CLI module-resolution fails under strict TS); the lc clone path is a `--lc-dir <path>` CLI option (env fallback), never hardcoded in core. **A2** — ground-truth labels key on a **content-based per-firing id** (`hash(ruleId + pr + filePath + normalizedMatchedLineText)`), not raw line numbers, so labels survive line-drift. **A3** — normalize paths to forward-slash in all match/id schemas + keep ADR-098 filenames colon-free (Windows ADS) on write and symmetric on read.
+
+### Scope
+
+Build the **Gate-1 wind-tunnel harness**: the `windtunnel.lock.v1` schema + a `totem spine windtunnel <freeze|run>` command pair + a pure scoring engine that, given rule-firings over the frozen corpus/controls plus per-firing ground-truth labels, emits the ADR-110 §4/§5 verdict (PASS / HONEST-NEGATIVE / FAIL, exposure tuple, precision, cull-ledger). It will **NOT** regenerate rules (that's strategy#516 — the harness is validated now with fixtures + a mock engine, and runs for real post-#516), will **NOT** author the ground-truth labels (operator-adjudicated; the tool emits the firing/label queue + the mechanical negative-control cull), and will **NOT** use git-worktrees (diff + post-image-blob replay via the engine's `readStrategy` seam, achieving firing-parity with production `totem lint` — S1).
+
+### Data model deltas
+
+| New unit                                                                    | Holds                                                                                                                                                                                                                                                                      | Writer                                       | Reader             | Invariants                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `WindtunnelLockSchema` + `WindtunnelLock` (core `spine/windtunnel-lock.ts`) | strategy-claude's `windtunnel.lock.v1` shape (`phase: "harness" \| "certifying"` (S3); corpus selection-rule + `asOfCommit` + frozen `resolvedPrs`; `fpDefinition` refs; `controls` refs + `integrity.fixtureSha`; `exposureDenominator` floors; `cullRateThreshold` (S2)) | `freeze` cmd                                 | `run` cmd + scorer | `precisionFloor === 1.0`; `window.type ∈ {all, bounded}`; `asOfCommit` 40-hex; `resolvedPrs` non-empty when `window=all`, entries structured `{pr,mergeCommit,baseSha,headSha}` + unique/sorted (C4); `cullRateThreshold` required ∈ `[0,1)` (C5); `exposureDenominator.activeRulesEvaluated.floor ≥ 2`; `positiveControlsExercised.floor ≥ mintedRuleCount`. **Frozen-once per-phase** (S3 — a certifying `run` rejects a harness-phase lock; see lifecycle). |
+| `.totem/spine/gate-1/windtunnel.lock.json`                                  | the persisted lock                                                                                                                                                                                                                                                         | `freeze`                                     | `run`              | freeze proof **git-derived at run time** (lock commit via `git log -- <lock>` is an ancestor of the run; blob byte-identical) — NOT a self-embedded trusted field (C3, §6)                                                                                                                                                                                                                                                                                     |
+| `ground-truth-labels.json` (referenced)                                     | **per-firing** TP/FP labels (NOT per-PR)                                                                                                                                                                                                                                   | operator adjudication (out of scope tooling) | scorer             | a firing with no label ⇒ `needs-adjudication`, never a silent pass                                                                                                                                                                                                                                                                                                                                                                                             |
+| `controls/{positive,negative}/` diff fixtures (referenced)                  | held-out real lc PRs (positive) + adversarial near-miss diffs (negative)                                                                                                                                                                                                   | hand-curated                                 | `run`              | integrity-hashed; positive must fire its target rule, negative must not fire                                                                                                                                                                                                                                                                                                                                                                                   |
+| `WindtunnelVerdict` (pure scorer output)                                    | `{verdict, precision /* over surviving rules */, mintedRuleCount, culledCount, survivingRuleCount, exposureTuple:[a,b,c], cullLedger[], nonVacuity, needsAdjudication[]}`                                                                                                  | core scorer                                  | `run` cmd report   | exposure reported as a **tuple, never collapsed to a product**; minted/culled/surviving surfaced as first-class fields (S2); precision is **over surviving rules**                                                                                                                                                                                                                                                                                             |
+
+No reserved keys; controls + labels + rubric are separate referenced files (T20/T21), keeping the lock lean.
+
+### State lifecycle
+
+All artifacts are **persistent** under `.totem/spine/gate-1/`. The lock is **frozen-once per-phase** (S3): `freeze` writes it under its own commit; any later `run` **derives** the lock's commit from git history (`git log -- <lock>`), asserts it is an ancestor of the run, and verifies the lock blob at that commit is byte-identical (C3 — the proof is git-derived, never a self-embedded field). There are **two locks across the build's life** — a `phase: "harness"` lock (mock rules, `mintedRuleCount ≈ 0`, validates the harness now) and a `phase: "certifying"` lock (re-frozen post-#516 against the real minted set, with a non-vacuous `positiveControlsExercised.floor`); a certifying `run` rejects a harness-phase lock so the real run cannot inherit a vacuous floor. `freeze` also asserts corpus completeness — `resolvedPrs === selectionRule(asOfCommit)` (S4) — so it cannot silently shrink the corpus. Ground-truth labels **accrete** during operator adjudication, then freeze before the certifying run. The scorer holds only per-run computation (no cross-run/session state). Control-fixture integrity is pinned via `controls.integrity.fixtureSha` (git-hash-object over the control dir, same mechanism as `.wind-tunnel-sha`).
+
+### Failure modes
+
+| Failure                                                                                                                                                | Category    | Surface                                                                                                          | Recovery                                                                                              |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- | ---------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Lock missing / schema-invalid                                                                                                                          | init        | hard error                                                                                                       | fix/regenerate the lock                                                                               |
+| Run when the git-derived lock commit (`git log -- <lock>`) is not an ancestor of HEAD, or its blob differs from the current lock (unfrozen / tampered) | runtime     | hard error (§6, C3 — proof is git-derived, never a self-embedded field)                                          | `freeze` first; re-run                                                                                |
+| `controls.integrity.fixtureSha` mismatch (control tampered)                                                                                            | runtime     | hard error                                                                                                       | re-freeze controls deliberately or revert tampering                                                   |
+| Corpus PR diff unresolvable (lc clone absent / PR not @ `asOfCommit`)                                                                                  | runtime     | **hard error — never skip** (a silent skip shrinks the corpus, §5)                                               | provide the lc clone @ pin                                                                            |
+| Firing with no ground-truth label                                                                                                                      | runtime     | `needs-adjudication` queue emitted, exit non-zero (NOT pass)                                                     | adjudicate the queue, re-run                                                                          |
+| Positive control fails to fire its target rule                                                                                                         | runtime     | `FAIL` (vacuous)                                                                                                 | fix rule/control                                                                                      |
+| Negative control fires                                                                                                                                 | runtime     | rule **culled** + recorded in `cullLedger` (mechanical, pre-labeling)                                            | culled rule cannot earn hard tier                                                                     |
+| Adjudication-count cap hit on run 1                                                                                                                    | runtime     | label first K, **report the cap in the run report** (never silently shrink)                                      | label more, re-run                                                                                    |
+| Exposure floor violated (activeRules<2 or positiveControls<mintedRuleCount)                                                                            | runtime     | `HONEST-NEGATIVE` (masquerade guard, ADR-110 §4)                                                                 | add rules/controls                                                                                    |
+| High cull rate (culled ≫ surviving) — cull-laundering masquerade (S2)                                                                                  | runtime     | verdict pulled to `HONEST-NEGATIVE`; minted/culled/surviving surfaced; precision stated **over surviving rules** | not a clean PASS — mining mints mostly-illegitimate rules; investigate the miner                      |
+| Certifying `run` against a harness-phase lock (S3)                                                                                                     | runtime     | hard error — exposure floor was vacuous (`≥ mintedRuleCount ≈ 0`) at harness freeze                              | re-freeze a `phase: "certifying"` lock against the real minted set                                    |
+| `freeze` snapshots an incomplete `resolvedPrs` (≠ `selectionRule(asOfCommit)`) (S4)                                                                    | freeze      | hard error — completeness assertion fails                                                                        | re-resolve the full code-touching set; never hand-trim                                                |
+| AST/ast-grep rule under-fires (additions-only feed, no post-image blob) (S1)                                                                           | runtime     | parity test FAILS — replay measures a different engine than Gate 2                                               | supply the `readStrategy` post-image blob; never fall back to worktrees                               |
+| Regex rule over-fires in comment/string (replay `astContext` from wrong tree) (C1)                                                                     | runtime     | **bidirectional** parity test FAILS                                                                              | seam `enrichWithAstContext`; feed the shared post-image `readStrategy` to regex classification too    |
+| Post-image blob unresolvable for an evaluated added file (C2)                                                                                          | runtime     | **hard error — never a zero-firing result** (a silent no-match is corpus shrinkage)                              | resolve the blob; only production-excluded files (deleted-no-additions, skipped symlink) may lack one |
+| `frozenAt` not git-derivable / blob mismatch / not an ancestor of run (C3)                                                                             | runtime     | hard error — freeze proof unverifiable                                                                           | re-freeze the lock; never trust a self-embedded SHA                                                   |
+| `resolvedPrs` entry lacks replay identity (no merge/base/head SHA) (C4)                                                                                | freeze/init | hard error — schema rejects                                                                                      | freeze structured immutable entries                                                                   |
+
+No row is silent degradation — every corpus/label gap is loud (the §5 cull-ledger / no-silent-shrink discipline is the spine of this design).
+
+### Invariants to lock in via tests
+
+- Lock schema rejects: `precisionFloor ≠ 1.0`, non-40-hex `asOfCommit`, empty `resolvedPrs` under `window=all`, `resolvedPrs` entries missing merge/base/head SHAs (C4), `cullRateThreshold` absent or ∉ `[0,1)` (C5), `activeRulesEvaluated.floor < 2`, `positiveControlsExercised.floor < mintedRuleCount`.
+- Scorer: **any** firing labeled FP ⇒ verdict `FAIL` (precision < 1.0; zero-confirmed-FP floor).
+- Scorer: a positive control whose target rule does not fire ⇒ `FAIL` (non-vacuity).
+- Scorer: a rule firing on a negative control is culled **and recorded** in `cullLedger` (not silently dropped).
+- Scorer: exposure is emitted as a 3-tuple and never collapsed; floors `activeRules ≥ 2` and `positiveControls ≥ mintedRuleCount` enforced.
+- Scorer: unlabeled firings ⇒ `needs-adjudication` (not PASS); an adjudication cap is surfaced in the report.
+- Integrity: a control-dir hash mismatch ⇒ hard error.
+- Freeze: a `run` against an unfrozen / not-yet-preceding lock ⇒ hard error.
+- **Parity (S1+C1):** **bidirectional** — for a fixed PR/rule set, replay firings **==** production `totem lint` firings across regex + Tree-sitter + ast-grep. Covers under-fire (AST post-image) AND over-fire (a regex match suppressed in a comment/string by production `astContext` must not appear in replay). The shared post-image `readStrategy` feeds **both** `enrichWithAstContext` and `applyAstRulesToAdditions`.
+- **Cull-laundering (S2):** verdict surfaces `mintedRuleCount`/`culledCount`/`survivingRuleCount`; precision is computed **over surviving rules**; a cull rate over the pinned threshold pulls the verdict to `HONEST-NEGATIVE`.
+- **Two-freezes (S3):** a `phase: "certifying"` `run` rejects a `phase: "harness"` lock; the certifying lock re-freezes `positiveControlsExercised.floor` against the real minted set.
+- **Freeze-completeness (S4):** `freeze` asserts `resolvedPrs === selectionRule(asOfCommit)` (re-derivable + diffable) ⇒ hard error on any silent drop.
+- **OQ2 mocks:** the mock-engine suite exercises `HONEST-NEGATIVE` (exposure-floor trip) and `needs-adjudication` (unlabeled firing), not just always-0 / always-1 / perfect.
+- **Missing blob (C2):** the wind-tunnel `readStrategy` throws on any unresolved post-image blob for an evaluated added file ⇒ hard error (not a zero-firing result).
+- **Freeze proof (C3):** `run` derives the lock commit from `git log -- <lock>` + asserts ancestry of the run + blob byte-identity; a self-embedded-only `frozenAt.commit` is rejected.
+- **Replay identity (C4):** `resolvedPrs` entries carry `{pr,mergeCommit,baseSha,headSha}` (unique/sorted); completeness compares the structured set to `selectionRule(asOfCommit)`.
+- **Cull-rate guard (C5):** `cullRateThreshold` required, frozen, `0 ≤ t < 1`; scorer mechanically returns `HONEST-NEGATIVE` when `culledCount / mintedRuleCount > t`.
+- **Phase (P1):** `run --phase certifying` rejects a `phase: "harness"` lock (external requested phase, not the lock's self-declaration).
+- **Floor boundary (P2):** test exact equality — `activeRules == 2` passes / `== 1` ⇒ HONEST-NEGATIVE; `positiveControls == mintedRuleCount` passes.
+- **Label identity (A2):** ground-truth firing ids are content-based (`hash(ruleId + pr + filePath + normalizedMatchedLineText)`), not raw line numbers.
+
+### Open questions
+
+- **OQ1 — Corpus diff source.** Local lc clone (`D:\Dev\liquid-city`) vs `gh pr diff` fetch. **Rec: local clone**, path configurable, resolved @ `asOfCommit` — offline + deterministic + matches "frozen." (Confirmed a clone exists.)
+- **OQ2 — #2188 scope boundary. [RATIFIED 17:36Z]** Harness-only now (fixtures + mock engine; the real certifying run rides post-#516 once rules exist) vs attempt a real lc run now. **Ruled: harness-only** — there are no regenerated rules to score yet; building the wind-tunnel before the plane flies is the point. (+ mock suite must exercise HONEST-NEGATIVE + needs-adjudication — see OQ2 mock additions above.)
+- **OQ3 — Integrity coupling. [RATIFIED 17:36Z]** Extend `update-wind-tunnel-sha.sh`'s `FIXTURE_DIR` to include the gate-1 control dir vs add a **gate-1-scoped** hash (separate). **Ruled: gate-1-scoped** — don't perturb the existing `.totem/tests` `.wind-tunnel-sha` lock; reuse the same `git hash-object` recipe, store in `controls.integrity.fixtureSha` + a CI verify step.
+- **OQ4 — Command surface.** `totem spine windtunnel <freeze|run>` subcommand group vs flat commands. **Rec: `spine` group** — forward-compat for gate-2+ and keeps the spine surface cohesive.
+- **OQ5 — Labeling workflow.** In scope vs consumption-only. **Rec: consumption-only** — the tool emits the firing/label queue + the mechanical negative-control cull; operator adjudication (frozen-ground-truth + tiebreak) produces `ground-truth-labels.json`. (Matches strategy-claude's adjudicator ruling.)

--- a/packages/cli/src/commands/spine-windtunnel.test.ts
+++ b/packages/cli/src/commands/spine-windtunnel.test.ts
@@ -13,6 +13,7 @@ import {
   buildReadStrategy,
   computeFixtureSha,
   isCommitAncestor,
+  verifyControlIntegrity,
   verifyFreezeProof,
 } from './spine-windtunnel.js';
 
@@ -213,6 +214,53 @@ describe('computeFixtureSha (gate-1-scoped integrity hash)', () => {
     fs.writeFileSync(path.join(ctrl, 'a.diff'), 'CHANGED\n');
     const after = computeFixtureSha(ctrl, repo, safeExec);
     expect(after).not.toBe(before);
+  });
+
+  it('is stable across nested subdirectories (recursive + separator-normalized)', () => {
+    const repo = makeTmpRepo();
+    const ctrl = path.join(repo, 'controls');
+    fs.mkdirSync(path.join(ctrl, 'positive'), { recursive: true });
+    fs.mkdirSync(path.join(ctrl, 'negative'), { recursive: true });
+    fs.writeFileSync(path.join(ctrl, 'positive', 'p1.diff'), 'p\n');
+    fs.writeFileSync(path.join(ctrl, 'negative', 'n1.diff'), 'n\n');
+    const first = computeFixtureSha(ctrl, repo, safeExec);
+    const second = computeFixtureSha(ctrl, repo, safeExec);
+    expect(first).toMatch(HEX40);
+    expect(second).toBe(first);
+  });
+});
+
+// ─── verifyControlIntegrity (C6 / §5) ────────────────────
+
+describe('verifyControlIntegrity (C6 / §5 — mandatory, fail-loud)', () => {
+  it('throws when the control dir is missing (no silent skip)', () => {
+    const repo = makeTmpRepo();
+    const ctrl = path.join(repo, 'controls'); // never created
+    expect(() => verifyControlIntegrity(ctrl, FAKE_SHA, repo, safeExec)).toThrow(/missing/);
+  });
+
+  it('throws when the control dir is empty', () => {
+    const repo = makeTmpRepo();
+    const ctrl = path.join(repo, 'controls');
+    fs.mkdirSync(ctrl, { recursive: true });
+    expect(() => verifyControlIntegrity(ctrl, FAKE_SHA, repo, safeExec)).toThrow(/empty/);
+  });
+
+  it('throws on a fixtureSha mismatch (tamper)', () => {
+    const repo = makeTmpRepo();
+    const ctrl = path.join(repo, 'controls');
+    fs.mkdirSync(ctrl, { recursive: true });
+    fs.writeFileSync(path.join(ctrl, 'a.diff'), 'aaa\n');
+    expect(() => verifyControlIntegrity(ctrl, 'f'.repeat(40), repo, safeExec)).toThrow(/expected/);
+  });
+
+  it('passes when the control hash matches the declared fixtureSha', () => {
+    const repo = makeTmpRepo();
+    const ctrl = path.join(repo, 'controls');
+    fs.mkdirSync(ctrl, { recursive: true });
+    fs.writeFileSync(path.join(ctrl, 'a.diff'), 'aaa\n');
+    const sha = computeFixtureSha(ctrl, repo, safeExec)!;
+    expect(() => verifyControlIntegrity(ctrl, sha, repo, safeExec)).not.toThrow();
   });
 });
 

--- a/packages/cli/src/commands/spine-windtunnel.test.ts
+++ b/packages/cli/src/commands/spine-windtunnel.test.ts
@@ -185,82 +185,85 @@ describe('buildReadStrategy (C2 — post-image blob, throw on missing)', () => {
 
 // ─── computeFixtureSha (integrity) ───────────────────────
 
+/** Create populated positive + negative control dirs; returns [positive, negative]. */
+function makeControlDirs(repo: string): [string, string] {
+  const positive = path.join(repo, 'controls', 'positive');
+  const negative = path.join(repo, 'controls', 'negative');
+  fs.mkdirSync(positive, { recursive: true });
+  fs.mkdirSync(negative, { recursive: true });
+  fs.writeFileSync(path.join(positive, 'p1.diff'), 'positive control\n');
+  fs.writeFileSync(path.join(negative, 'n1.diff'), 'negative control\n');
+  return [positive, negative];
+}
+
 describe('computeFixtureSha (gate-1-scoped integrity hash)', () => {
-  it('returns null for an empty control dir', () => {
+  it('returns null when no control dir has files', () => {
     const repo = makeTmpRepo();
     const ctrl = path.join(repo, 'controls');
     fs.mkdirSync(ctrl, { recursive: true });
-    expect(computeFixtureSha(ctrl, repo, safeExec)).toBeNull();
+    expect(computeFixtureSha([ctrl], repo, safeExec)).toBeNull();
   });
 
-  it('returns a stable aggregate hash for a populated control dir', () => {
+  it('returns a stable aggregate hash across positive + negative dirs', () => {
     const repo = makeTmpRepo();
-    const ctrl = path.join(repo, 'controls');
-    fs.mkdirSync(ctrl, { recursive: true });
-    fs.writeFileSync(path.join(ctrl, 'a.diff'), 'aaa\n');
-    fs.writeFileSync(path.join(ctrl, 'b.diff'), 'bbb\n');
-    const first = computeFixtureSha(ctrl, repo, safeExec);
-    const second = computeFixtureSha(ctrl, repo, safeExec);
+    const dirs = makeControlDirs(repo);
+    const first = computeFixtureSha(dirs, repo, safeExec);
+    const second = computeFixtureSha(dirs, repo, safeExec);
     expect(first).toMatch(HEX40);
     expect(second).toBe(first);
   });
 
-  it('changes when a control file changes (tamper-evident)', () => {
+  it('changes when a POSITIVE control file changes (tamper-evident)', () => {
     const repo = makeTmpRepo();
-    const ctrl = path.join(repo, 'controls');
-    fs.mkdirSync(ctrl, { recursive: true });
-    fs.writeFileSync(path.join(ctrl, 'a.diff'), 'aaa\n');
-    const before = computeFixtureSha(ctrl, repo, safeExec);
-    fs.writeFileSync(path.join(ctrl, 'a.diff'), 'CHANGED\n');
-    const after = computeFixtureSha(ctrl, repo, safeExec);
-    expect(after).not.toBe(before);
+    const dirs = makeControlDirs(repo);
+    const before = computeFixtureSha(dirs, repo, safeExec);
+    fs.writeFileSync(path.join(dirs[0], 'p1.diff'), 'CHANGED\n');
+    expect(computeFixtureSha(dirs, repo, safeExec)).not.toBe(before);
   });
 
-  it('is stable across nested subdirectories (recursive + separator-normalized)', () => {
+  it('changes when a NEGATIVE control file changes (negative controls are protected too)', () => {
     const repo = makeTmpRepo();
-    const ctrl = path.join(repo, 'controls');
-    fs.mkdirSync(path.join(ctrl, 'positive'), { recursive: true });
-    fs.mkdirSync(path.join(ctrl, 'negative'), { recursive: true });
-    fs.writeFileSync(path.join(ctrl, 'positive', 'p1.diff'), 'p\n');
-    fs.writeFileSync(path.join(ctrl, 'negative', 'n1.diff'), 'n\n');
-    const first = computeFixtureSha(ctrl, repo, safeExec);
-    const second = computeFixtureSha(ctrl, repo, safeExec);
-    expect(first).toMatch(HEX40);
-    expect(second).toBe(first);
+    const dirs = makeControlDirs(repo);
+    const before = computeFixtureSha(dirs, repo, safeExec);
+    fs.writeFileSync(path.join(dirs[1], 'n1.diff'), 'CHANGED\n');
+    expect(computeFixtureSha(dirs, repo, safeExec)).not.toBe(before);
   });
 });
 
 // ─── verifyControlIntegrity (C6 / §5) ────────────────────
 
 describe('verifyControlIntegrity (C6 / §5 — mandatory, fail-loud)', () => {
-  it('throws when the control dir is missing (no silent skip)', () => {
+  it('throws when a control dir is missing (no silent skip)', () => {
     const repo = makeTmpRepo();
-    const ctrl = path.join(repo, 'controls'); // never created
-    expect(() => verifyControlIntegrity(ctrl, FAKE_SHA, repo, safeExec)).toThrow(/missing/);
+    const [positive] = makeControlDirs(repo);
+    const missingNegative = path.join(repo, 'controls', 'gone');
+    expect(() =>
+      verifyControlIntegrity([positive, missingNegative], FAKE_SHA, repo, safeExec),
+    ).toThrow(/missing/);
   });
 
-  it('throws when the control dir is empty', () => {
+  it('throws when the control dirs are empty', () => {
     const repo = makeTmpRepo();
-    const ctrl = path.join(repo, 'controls');
-    fs.mkdirSync(ctrl, { recursive: true });
-    expect(() => verifyControlIntegrity(ctrl, FAKE_SHA, repo, safeExec)).toThrow(/empty/);
+    const positive = path.join(repo, 'controls', 'positive');
+    const negative = path.join(repo, 'controls', 'negative');
+    fs.mkdirSync(positive, { recursive: true });
+    fs.mkdirSync(negative, { recursive: true });
+    expect(() => verifyControlIntegrity([positive, negative], FAKE_SHA, repo, safeExec)).toThrow(
+      /empty/,
+    );
   });
 
   it('throws on a fixtureSha mismatch (tamper)', () => {
     const repo = makeTmpRepo();
-    const ctrl = path.join(repo, 'controls');
-    fs.mkdirSync(ctrl, { recursive: true });
-    fs.writeFileSync(path.join(ctrl, 'a.diff'), 'aaa\n');
-    expect(() => verifyControlIntegrity(ctrl, 'f'.repeat(40), repo, safeExec)).toThrow(/expected/);
+    const dirs = makeControlDirs(repo);
+    expect(() => verifyControlIntegrity(dirs, 'f'.repeat(40), repo, safeExec)).toThrow(/expected/);
   });
 
-  it('passes when the control hash matches the declared fixtureSha', () => {
+  it('passes when the aggregate hash matches the declared fixtureSha', () => {
     const repo = makeTmpRepo();
-    const ctrl = path.join(repo, 'controls');
-    fs.mkdirSync(ctrl, { recursive: true });
-    fs.writeFileSync(path.join(ctrl, 'a.diff'), 'aaa\n');
-    const sha = computeFixtureSha(ctrl, repo, safeExec)!;
-    expect(() => verifyControlIntegrity(ctrl, sha, repo, safeExec)).not.toThrow();
+    const dirs = makeControlDirs(repo);
+    const sha = computeFixtureSha(dirs, repo, safeExec)!;
+    expect(() => verifyControlIntegrity(dirs, sha, repo, safeExec)).not.toThrow();
   });
 });
 

--- a/packages/cli/src/commands/spine-windtunnel.test.ts
+++ b/packages/cli/src/commands/spine-windtunnel.test.ts
@@ -1,0 +1,239 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { WindtunnelLock } from '@mmnto/totem';
+import { safeExec, WindtunnelLockSchema } from '@mmnto/totem';
+
+import { cleanTmpDir } from '../test-utils.js';
+import {
+  assertCorpusCompleteness,
+  buildReadStrategy,
+  computeFixtureSha,
+  isCommitAncestor,
+  verifyFreezeProof,
+} from './spine-windtunnel.js';
+
+// ─── Fixtures ────────────────────────────────────────────
+
+const HEX40 = /^[0-9a-f]{40}$/;
+const FAKE_SHA = 'a'.repeat(40);
+
+const createdDirs: string[] = [];
+
+afterEach(() => {
+  while (createdDirs.length > 0) {
+    cleanTmpDir(createdDirs.pop()!);
+  }
+});
+
+/** Create an isolated temp dir tracked for afterEach cleanup. */
+function makeTmpDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-spine-wt-'));
+  createdDirs.push(dir);
+  return dir;
+}
+
+/** Initialize a throwaway git repo with a deterministic identity. */
+function makeTmpRepo(): string {
+  const dir = makeTmpDir();
+  safeExec('git', ['init'], { cwd: dir });
+  safeExec('git', ['config', 'user.email', 'test@example.com'], { cwd: dir });
+  safeExec('git', ['config', 'user.name', 'Totem Test'], { cwd: dir });
+  safeExec('git', ['config', 'commit.gpgsign', 'false'], { cwd: dir });
+  return dir;
+}
+
+/** Stage everything and commit; returns the new commit SHA. */
+function commitAll(dir: string, message: string): string {
+  safeExec('git', ['add', '-A'], { cwd: dir });
+  safeExec('git', ['commit', '-m', message], { cwd: dir });
+  return safeExec('git', ['rev-parse', 'HEAD'], { cwd: dir });
+}
+
+/** Build a schema-valid lock pinned to `asOfCommit`. */
+function makeLock(asOfCommit: string): WindtunnelLock {
+  return WindtunnelLockSchema.parse({
+    schema: 'windtunnel.lock.v1',
+    canonicalPath: '.totem/spine/gate-1/windtunnel.lock.json',
+    gate: 'gate-1',
+    phase: 'harness',
+    corpus: {
+      repo: 'mmnto-ai/liquid-city',
+      selectionRule: {
+        state: 'merged',
+        predicate: 'code-touching',
+        window: { type: 'all' },
+        asOfCommit,
+      },
+      resolvedPrs: [
+        { pr: 1, mergeCommit: 'b'.repeat(40), baseSha: 'c'.repeat(40), headSha: 'd'.repeat(40) },
+      ],
+    },
+    fpDefinition: {
+      rubricRef: '.totem/spine/gate-1/fp-rubric.md',
+      groundTruthRef: '.totem/spine/gate-1/ground-truth-labels.json',
+      adjudicator: 'frozen-ground-truth+operator-tiebreak',
+      precisionFloor: 1.0,
+    },
+    controls: {
+      positiveRef: '.totem/spine/gate-1/controls/positive/',
+      negativeRef: '.totem/spine/gate-1/controls/negative/',
+      integrity: { mechanism: '.wind-tunnel-sha', fixtureSha: 'e'.repeat(40) },
+    },
+    cullRateThreshold: 0.5,
+    exposureDenominator: {
+      activeRulesEvaluated: { floor: 2 },
+      filesTouchedInWindow: { floor: 0 },
+      positiveControlsExercised: { floor: 0 },
+    },
+  });
+}
+
+// ─── verifyFreezeProof (C3) ──────────────────────────────
+
+describe('verifyFreezeProof (C3 — git-derived freeze proof)', () => {
+  it('throws when the lock has never been committed (repo has history, lock does not)', () => {
+    const repo = makeTmpRepo();
+    // The repo has commits, but the lock file itself was never committed —
+    // git log succeeds and returns zero commits for the lock path.
+    fs.writeFileSync(path.join(repo, 'README.md'), '# repo\n');
+    commitAll(repo, 'initial');
+    const lockPath = path.join(repo, 'windtunnel.lock.json');
+    fs.writeFileSync(lockPath, '{"a":1}\n');
+    expect(() => verifyFreezeProof(lockPath, repo, safeExec)).toThrow(/never been committed/);
+  });
+
+  it('passes when the lock is committed and unchanged (CRLF/newline immune)', () => {
+    const repo = makeTmpRepo();
+    const lockPath = path.join(repo, 'windtunnel.lock.json');
+    // Trailing newline present — a raw string compare against `git show` would
+    // spuriously fail here; the hash-based proof must pass.
+    fs.writeFileSync(lockPath, '{"a":1}\n');
+    commitAll(repo, 'freeze lock');
+    expect(() => verifyFreezeProof(lockPath, repo, safeExec)).not.toThrow();
+  });
+
+  it('throws when the lock was modified after freeze (tamper)', () => {
+    const repo = makeTmpRepo();
+    const lockPath = path.join(repo, 'windtunnel.lock.json');
+    fs.writeFileSync(lockPath, '{"a":1}\n');
+    commitAll(repo, 'freeze lock');
+    fs.writeFileSync(lockPath, '{"a":2}\n'); // post-freeze tamper
+    expect(() => verifyFreezeProof(lockPath, repo, safeExec)).toThrow(
+      /differs from the committed blob/,
+    );
+  });
+});
+
+// ─── isCommitAncestor ────────────────────────────────────
+
+describe('isCommitAncestor', () => {
+  it('returns true for a genuine ancestor', () => {
+    const repo = makeTmpRepo();
+    fs.writeFileSync(path.join(repo, 'a.txt'), '1');
+    const c1 = commitAll(repo, 'c1');
+    fs.writeFileSync(path.join(repo, 'b.txt'), '2');
+    const c2 = commitAll(repo, 'c2');
+    expect(isCommitAncestor(c1, c2, repo, safeExec)).toBe(true);
+  });
+
+  it('returns false for a non-ancestor (exit 1 is a clean boolean, not an error)', () => {
+    const repo = makeTmpRepo();
+    fs.writeFileSync(path.join(repo, 'a.txt'), '1');
+    const c1 = commitAll(repo, 'c1');
+    fs.writeFileSync(path.join(repo, 'b.txt'), '2');
+    const c2 = commitAll(repo, 'c2');
+    expect(isCommitAncestor(c2, c1, repo, safeExec)).toBe(false);
+  });
+
+  it('re-throws on a bad ref rather than masking it as false', () => {
+    const repo = makeTmpRepo();
+    fs.writeFileSync(path.join(repo, 'a.txt'), '1');
+    commitAll(repo, 'c1');
+    expect(() => isCommitAncestor(FAKE_SHA, 'HEAD', repo, safeExec)).toThrow();
+  });
+});
+
+// ─── buildReadStrategy (C2) ──────────────────────────────
+
+describe('buildReadStrategy (C2 — post-image blob, throw on missing)', () => {
+  it('returns null for every file when no lc clone is provided', async () => {
+    const readStrategy = buildReadStrategy(undefined, FAKE_SHA, safeExec);
+    expect(await readStrategy('any/file.ts')).toBeNull();
+  });
+
+  it('resolves the post-image blob from the lc clone at asOfCommit', async () => {
+    const repo = makeTmpRepo();
+    fs.writeFileSync(path.join(repo, 'src.ts'), 'export const x = 1;\n');
+    const sha = commitAll(repo, 'add src');
+    const readStrategy = buildReadStrategy(repo, sha, safeExec);
+    expect(await readStrategy('src.ts')).toContain('export const x = 1;');
+  });
+
+  it('throws on an unresolvable blob — never a silent no-match (corpus shrinkage)', async () => {
+    const repo = makeTmpRepo();
+    fs.writeFileSync(path.join(repo, 'src.ts'), 'x\n');
+    const sha = commitAll(repo, 'add src');
+    const readStrategy = buildReadStrategy(repo, sha, safeExec);
+    await expect(readStrategy('does-not-exist.ts')).rejects.toThrow(/unresolvable/);
+  });
+});
+
+// ─── computeFixtureSha (integrity) ───────────────────────
+
+describe('computeFixtureSha (gate-1-scoped integrity hash)', () => {
+  it('returns null for an empty control dir', () => {
+    const repo = makeTmpRepo();
+    const ctrl = path.join(repo, 'controls');
+    fs.mkdirSync(ctrl, { recursive: true });
+    expect(computeFixtureSha(ctrl, repo, safeExec)).toBeNull();
+  });
+
+  it('returns a stable aggregate hash for a populated control dir', () => {
+    const repo = makeTmpRepo();
+    const ctrl = path.join(repo, 'controls');
+    fs.mkdirSync(ctrl, { recursive: true });
+    fs.writeFileSync(path.join(ctrl, 'a.diff'), 'aaa\n');
+    fs.writeFileSync(path.join(ctrl, 'b.diff'), 'bbb\n');
+    const first = computeFixtureSha(ctrl, repo, safeExec);
+    const second = computeFixtureSha(ctrl, repo, safeExec);
+    expect(first).toMatch(HEX40);
+    expect(second).toBe(first);
+  });
+
+  it('changes when a control file changes (tamper-evident)', () => {
+    const repo = makeTmpRepo();
+    const ctrl = path.join(repo, 'controls');
+    fs.mkdirSync(ctrl, { recursive: true });
+    fs.writeFileSync(path.join(ctrl, 'a.diff'), 'aaa\n');
+    const before = computeFixtureSha(ctrl, repo, safeExec);
+    fs.writeFileSync(path.join(ctrl, 'a.diff'), 'CHANGED\n');
+    const after = computeFixtureSha(ctrl, repo, safeExec);
+    expect(after).not.toBe(before);
+  });
+});
+
+// ─── assertCorpusCompleteness (S4) ───────────────────────
+
+describe('assertCorpusCompleteness (S4 — loud on inaccessible clone)', () => {
+  it('throws when the lc clone is inaccessible', async () => {
+    const repo = makeTmpRepo();
+    const missing = path.join(repo, 'no-such-clone');
+    const lock = makeLock(FAKE_SHA);
+    await expect(assertCorpusCompleteness(lock, missing, repo, safeExec)).rejects.toThrow(
+      /cannot access lc clone/,
+    );
+  });
+
+  it('resolves when the lc clone is accessible and includes asOfCommit', async () => {
+    const lcRepo = makeTmpRepo();
+    fs.writeFileSync(path.join(lcRepo, 'x.ts'), '1');
+    const sha = commitAll(lcRepo, 'lc c1');
+    const repo = makeTmpRepo();
+    const lock = makeLock(sha);
+    await expect(assertCorpusCompleteness(lock, lcRepo, repo, safeExec)).resolves.toBeUndefined();
+  });
+});

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -283,7 +283,7 @@ type SafeExecFn = typeof import('@mmnto/totem').safeExec;
  * swallow. Any other failure (bad ref, repo unreadable) re-throws so it is not
  * masked as a clean "false".
  */
-function isCommitAncestor(
+export function isCommitAncestor(
   ancestor: string,
   descendant: string,
   cwd: string,
@@ -307,7 +307,7 @@ function isCommitAncestor(
  * the lc clone. Throws on unresolvable blob for an evaluated added file (C2).
  * When lcDir is absent, returns null for all files (fail-open — harness mock).
  */
-function buildReadStrategy(
+export function buildReadStrategy(
   lcDir: string | undefined,
   asOfCommit: string,
   safeExec: SafeExecFn,
@@ -337,7 +337,7 @@ function buildReadStrategy(
  * an ancestor of HEAD. The lock blob at that commit must be byte-identical to
  * the current lock.
  */
-function verifyFreezeProof(lockPath: string, repoRoot: string, safeExec: SafeExecFn): void {
+export function verifyFreezeProof(lockPath: string, repoRoot: string, safeExec: SafeExecFn): void {
   const relLockPath = path.relative(repoRoot, lockPath).replace(/\\/g, '/');
 
   let logOutput: string;
@@ -371,20 +371,24 @@ function verifyFreezeProof(lockPath: string, repoRoot: string, safeExec: SafeExe
     );
   }
 
-  // Verify blob byte-identity
-  const currentContent = fs.readFileSync(lockPath, 'utf-8');
-  let historicContent: string;
+  // Verify blob identity via git object hashes (CRLF-immune, matching the
+  // .wind-tunnel-sha discipline) rather than a raw string compare — the latter
+  // spuriously fails on trailing-newline / line-ending normalization because
+  // `git show` output and the on-disk working file can differ by EOL alone.
+  let workingHash: string;
+  let committedHash: string;
   try {
-    historicContent = safeExec('git', ['show', `${freezeCommit}:${relLockPath}`], {
+    workingHash = safeExec('git', ['hash-object', lockPath], { cwd: repoRoot });
+    committedHash = safeExec('git', ['rev-parse', `${freezeCommit}:${relLockPath}`], {
       cwd: repoRoot,
     });
   } catch (err) {
     throw new Error(
-      `Wind-tunnel freeze proof: cannot read lock blob at ${freezeCommit}: ${err instanceof Error ? err.message : String(err)}`,
+      `Wind-tunnel freeze proof: cannot resolve lock blob at ${freezeCommit}: ${err instanceof Error ? err.message : String(err)}`,
     );
   }
 
-  if (currentContent !== historicContent) {
+  if (workingHash !== committedHash) {
     throw new Error(
       `Wind-tunnel freeze proof: current lock differs from the committed blob at ${freezeCommit} (C3 — lock was modified after freeze).`,
     );
@@ -397,7 +401,7 @@ function verifyFreezeProof(lockPath: string, repoRoot: string, safeExec: SafeExe
  * Compute gate-1-scoped fixtureSha via `git hash-object` over the control dir
  * (OQ3 — do NOT extend the existing .totem/tests FIXTURE_DIR).
  */
-function computeFixtureSha(
+export function computeFixtureSha(
   controlDir: string,
   repoRoot: string,
   safeExec: SafeExecFn,
@@ -432,7 +436,7 @@ function computeFixtureSha(
  * Assert corpus completeness (S4): resolvedPrs === selectionRule(asOfCommit).
  * In the harness phase this is a structural check only (no real lc API call).
  */
-async function assertCorpusCompleteness(
+export async function assertCorpusCompleteness(
   lock: import('@mmnto/totem').WindtunnelLock,
   lcDir: string,
   repoRoot: string,

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -1,0 +1,493 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+// ─── Named constants ─────────────────────────────────
+
+const LOCK_REL_PATH = '.totem/spine/gate-1/windtunnel.lock.json';
+const COMMIT_SHA_REGEX = /^[0-9a-f]{40}$/;
+
+// ─── freeze command ───────────────────────────────────
+
+export interface FreezeOptions {
+  lcDir?: string;
+  lockPath?: string;
+}
+
+/**
+ * `totem spine windtunnel freeze`
+ *
+ * Validates that the lock file at `LOCK_REL_PATH` (or `opts.lockPath`) is
+ * schema-valid and that `resolvedPrs === selectionRule(asOfCommit)` (S4 —
+ * completeness assertion). Writes the canonical lock path.
+ *
+ * The completeness assertion requires the lc clone (`--lc-dir`) so the
+ * command can re-derive the full code-touching PR set at `asOfCommit` and
+ * diff it against `resolvedPrs`. In the harness phase (no real lc run yet)
+ * the assertion is skipped with a loud warning.
+ */
+export async function freezeCommand(opts: FreezeOptions): Promise<void> {
+  const { WindtunnelLockSchema, safeExec, resolveGitRoot, TotemError } =
+    await import('@mmnto/totem');
+
+  const cwd = process.cwd();
+  const repoRoot = resolveGitRoot(cwd) ?? cwd;
+  const lockPath = opts.lockPath ?? path.join(repoRoot, LOCK_REL_PATH);
+  const lcDir = opts.lcDir ?? process.env['TOTEM_LC_DIR'];
+
+  // Read + validate the lock
+  let rawJson: string;
+  try {
+    rawJson = fs.readFileSync(lockPath, 'utf-8');
+  } catch {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `Wind-tunnel lock not found at ${lockPath}`,
+      `Create the lock file at ${LOCK_REL_PATH} before running freeze.`,
+    );
+  }
+
+  let rawObj: unknown;
+  try {
+    rawObj = JSON.parse(rawJson);
+  } catch {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `Wind-tunnel lock at ${lockPath} is not valid JSON`,
+      'Fix the JSON syntax and retry.',
+    );
+  }
+
+  const parsed = WindtunnelLockSchema.safeParse(rawObj);
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((i) => `  • ${i.path.join('.')}: ${i.message}`)
+      .join('\n');
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `Wind-tunnel lock schema validation failed:\n${issues}`,
+      'Fix the lock file and retry.',
+    );
+  }
+
+  const lock = parsed.data;
+  console.error(`[WindtunnelFreeze] Lock schema valid — phase: ${lock.phase}`);
+
+  // S4: completeness assertion
+  if (lcDir) {
+    console.error(`[WindtunnelFreeze] lc-dir provided — asserting corpus completeness (S4)`);
+    await assertCorpusCompleteness(lock, lcDir, repoRoot, safeExec);
+  } else {
+    console.error(
+      `[WindtunnelFreeze] WARNING: --lc-dir not provided — corpus completeness assertion (S4) skipped.`,
+    );
+    console.error(`  Set TOTEM_LC_DIR or pass --lc-dir to enable completeness check.`);
+  }
+
+  // Compute gate-1-scoped fixtureSha (OQ3)
+  const controlDirRef = lock.controls.positiveRef;
+  const controlDir = path.join(repoRoot, controlDirRef);
+  if (fs.existsSync(controlDir)) {
+    const fixtureSha = computeFixtureSha(controlDir, repoRoot, safeExec);
+    if (fixtureSha && fixtureSha !== lock.controls.integrity.fixtureSha) {
+      console.error(
+        `[WindtunnelFreeze] WARNING: controls.integrity.fixtureSha in lock (${lock.controls.integrity.fixtureSha}) does not match computed hash (${fixtureSha})`,
+      );
+      console.error(`  Update the lock with fixtureSha: "${fixtureSha}" and re-freeze.`);
+    } else if (fixtureSha) {
+      console.error(`[WindtunnelFreeze] Fixture integrity verified: ${fixtureSha}`);
+    }
+  } else {
+    console.error(
+      `[WindtunnelFreeze] Control dir ${controlDir} does not exist — integrity check skipped.`,
+    );
+  }
+
+  console.error(`[WindtunnelFreeze] DONE — lock at ${lockPath} is schema-valid.`);
+  console.error(`  Commit the lock file to establish the freeze proof (C3).`);
+}
+
+// ─── run command ─────────────────────────────────────
+
+export interface RunOptions {
+  lcDir?: string;
+  lockPath?: string;
+  phase?: string;
+}
+
+/**
+ * `totem spine windtunnel run`
+ *
+ * Reads and validates the lock, derives the freeze proof from git history (C3),
+ * rejects a harness lock when `--phase certifying` is passed (P1), builds the
+ * shared post-image readStrategy, runs the engine (mock for harness phase),
+ * scores the result, and prints the verdict.
+ *
+ * Exit codes: 0 = PASS, 1 = FAIL / HONEST-NEGATIVE / needs-adjudication.
+ */
+export async function runCommand(opts: RunOptions): Promise<void> {
+  const {
+    WindtunnelLockSchema,
+    safeExec,
+    resolveGitRoot,
+    TotemError,
+    scoreWindtunnel,
+    firingLabelId,
+  } = await import('@mmnto/totem');
+
+  const cwd = process.cwd();
+  const repoRoot = resolveGitRoot(cwd) ?? cwd;
+  const lockPath = opts.lockPath ?? path.join(repoRoot, LOCK_REL_PATH);
+  const lcDir = opts.lcDir ?? process.env['TOTEM_LC_DIR'];
+  const requestedPhase = opts.phase;
+
+  // Read + validate the lock
+  let rawJson: string;
+  try {
+    rawJson = fs.readFileSync(lockPath, 'utf-8');
+  } catch {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `Wind-tunnel lock not found at ${lockPath}`,
+      `Run 'totem spine windtunnel freeze' first.`,
+    );
+  }
+
+  let rawObj: unknown;
+  try {
+    rawObj = JSON.parse(rawJson);
+  } catch {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `Wind-tunnel lock at ${lockPath} is not valid JSON`,
+      'Fix the JSON syntax and retry.',
+    );
+  }
+
+  const parsed = WindtunnelLockSchema.safeParse(rawObj);
+  if (!parsed.success) {
+    const issues = parsed.error.issues
+      .map((i) => `  • ${i.path.join('.')}: ${i.message}`)
+      .join('\n');
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `Wind-tunnel lock schema validation failed:\n${issues}`,
+      'Fix the lock file and retry.',
+    );
+  }
+
+  const lock = parsed.data;
+
+  // P1: phase rejection — a certifying run rejects a harness-phase lock.
+  if (requestedPhase === 'certifying' && lock.phase === 'harness') {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `Phase mismatch: --phase certifying requested but the lock is phase "harness" (P1).`,
+      `Re-freeze with a "certifying" phase lock after the real rule set is minted (post strategy#516).`,
+    );
+  }
+
+  // C3: derive freeze proof from git history (not a self-embedded trusted field).
+  verifyFreezeProof(lockPath, repoRoot, safeExec);
+
+  // C6: verify fixture integrity (controls.integrity.fixtureSha)
+  const controlDir = path.join(repoRoot, lock.controls.positiveRef);
+  if (fs.existsSync(controlDir)) {
+    const actualSha = computeFixtureSha(controlDir, repoRoot, safeExec);
+    if (actualSha && actualSha !== lock.controls.integrity.fixtureSha) {
+      throw new TotemError(
+        'CONFIG_INVALID',
+        `Control fixture integrity check failed: expected ${lock.controls.integrity.fixtureSha}, got ${actualSha}`,
+        'Revert the tampering or re-freeze the lock with the updated fixtureSha.',
+      );
+    }
+  }
+
+  console.error(`[WindtunnelRun] Lock valid — phase: ${lock.phase}`);
+
+  // Build the shared post-image readStrategy (S1/C1).
+  // For the harness phase (no lc clone required — mock engine), we use a
+  // simple null-returning strategy (all files → skip classification = fail-open).
+  // When lcDir is provided, resolve post-image blobs from the lc clone.
+  const readStrategy = buildReadStrategy(lcDir, lock.corpus.selectionRule.asOfCommit, safeExec);
+
+  // Enrich with AST context for any additions (harness: no diff, so no additions).
+  // In the real certifying run, the caller would build additions from PR diffs
+  // and pass them through enrichWithAstContext + applyAstRulesToAdditions with
+  // the shared readStrategy (S1/C1 — same content for regex astContext + AST).
+
+  // Run the engine — harness phase uses mock engines.
+  const { mintedRuleIds, firings, groundTruth, positiveControlTargets } = await runMockEngine(
+    lock,
+    readStrategy,
+  );
+
+  // Score
+  const verdict = scoreWindtunnel({
+    firings,
+    groundTruth,
+    positiveControlTargets,
+    mintedRuleIds,
+    cullRateThreshold: lock.cullRateThreshold,
+    exposureFloors: {
+      activeRulesEvaluated: lock.exposureDenominator.activeRulesEvaluated.floor,
+      filesTouchedInWindow: lock.exposureDenominator.filesTouchedInWindow.floor,
+      positiveControlsExercised: lock.exposureDenominator.positiveControlsExercised.floor,
+    },
+    actualExposure: {
+      activeRulesEvaluated: mintedRuleIds.length,
+      filesTouchedInWindow: 0,
+      positiveControlsExercised: positiveControlTargets.length,
+    },
+  });
+
+  // Print verdict — exposure tuple never collapsed
+  console.log(`WindtunnelVerdict: ${verdict.verdict}`);
+  console.log(`  precision:         ${verdict.precision.toFixed(4)} (over surviving rules)`);
+  console.log(`  mintedRuleCount:   ${verdict.mintedRuleCount}`);
+  console.log(`  culledCount:       ${verdict.culledCount}`);
+  console.log(`  survivingRuleCount:${verdict.survivingRuleCount}`);
+  console.log(
+    `  exposureTuple:     [${verdict.exposureTuple.join(', ')}]  (activeRules, filesTouched, positiveControls)`,
+  );
+  console.log(`  nonVacuity:        ${verdict.nonVacuity}`);
+  if (verdict.cullLedger.length > 0) {
+    console.log(`  cullLedger (${verdict.cullLedger.length} entries):`);
+    for (const entry of verdict.cullLedger) {
+      console.log(`    • rule ${entry.ruleId} culled on pr#${entry.pr} (${entry.reason})`);
+    }
+  }
+  if (verdict.needsAdjudication.length > 0) {
+    console.log(`  needsAdjudication (${verdict.needsAdjudication.length} firing(s)):`);
+    for (const id of verdict.needsAdjudication) {
+      console.log(`    • ${id}`);
+    }
+  }
+
+  // Exit non-zero on FAIL / HONEST-NEGATIVE / needs-adjudication
+  if (verdict.verdict !== 'PASS' || verdict.needsAdjudication.length > 0) {
+    process.exitCode = 1;
+  }
+
+  // Reference firingLabelId to satisfy the import (used in mock engine)
+  void firingLabelId;
+}
+
+// ─── Helpers ─────────────────────────────────────────
+
+type SafeExecFn = typeof import('@mmnto/totem').safeExec;
+
+/**
+ * Build a post-image readStrategy (S1/C1).
+ * When lcDir is provided, resolves blobs via `git show <asOfCommit>:<path>` in
+ * the lc clone. Throws on unresolvable blob for an evaluated added file (C2).
+ * When lcDir is absent, returns null for all files (fail-open — harness mock).
+ */
+function buildReadStrategy(
+  lcDir: string | undefined,
+  asOfCommit: string,
+  safeExec: SafeExecFn,
+): (file: string) => Promise<string | null> {
+  if (!lcDir) {
+    return async () => null;
+  }
+
+  return async (file: string) => {
+    const normalized = file.replace(/\\/g, '/');
+    try {
+      const content = safeExec('git', ['show', `${asOfCommit}:${normalized}`], { cwd: lcDir });
+      return content;
+    } catch (err) {
+      // C2: missing blob for an evaluated added file is a hard error, not a
+      // silent no-match (corpus shrinkage).
+      throw new Error(
+        `Wind-tunnel readStrategy: blob unresolvable for ${file} at ${asOfCommit} in ${lcDir}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  };
+}
+
+/**
+ * Verify the freeze proof from git history (C3).
+ * `git log --format=%H -- <lockPath>` must return at least one commit that is
+ * an ancestor of HEAD. The lock blob at that commit must be byte-identical to
+ * the current lock.
+ */
+function verifyFreezeProof(lockPath: string, repoRoot: string, safeExec: SafeExecFn): void {
+  const relLockPath = path.relative(repoRoot, lockPath).replace(/\\/g, '/');
+
+  let logOutput: string;
+  try {
+    logOutput = safeExec('git', ['log', '--format=%H', '--', relLockPath], { cwd: repoRoot });
+  } catch (err) {
+    throw new Error(
+      `Wind-tunnel freeze proof: git log failed for ${relLockPath}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  const commits = logOutput
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => COMMIT_SHA_REGEX.test(l));
+
+  if (commits.length === 0) {
+    throw new Error(
+      `Wind-tunnel freeze proof: no commits found for ${relLockPath} — the lock has never been committed. Run 'totem spine windtunnel freeze' and commit the lock first (C3).`,
+    );
+  }
+
+  const freezeCommit = commits[0]!;
+
+  // Verify freezeCommit is an ancestor of HEAD
+  try {
+    safeExec('git', ['merge-base', '--is-ancestor', freezeCommit, 'HEAD'], { cwd: repoRoot });
+  } catch {
+    throw new Error(
+      `Wind-tunnel freeze proof: lock commit ${freezeCommit} is not an ancestor of HEAD (C3 — tampered or wrong branch).`,
+    );
+  }
+
+  // Verify blob byte-identity
+  const currentContent = fs.readFileSync(lockPath, 'utf-8');
+  let historicContent: string;
+  try {
+    historicContent = safeExec('git', ['show', `${freezeCommit}:${relLockPath}`], {
+      cwd: repoRoot,
+    });
+  } catch (err) {
+    throw new Error(
+      `Wind-tunnel freeze proof: cannot read lock blob at ${freezeCommit}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  if (currentContent !== historicContent) {
+    throw new Error(
+      `Wind-tunnel freeze proof: current lock differs from the committed blob at ${freezeCommit} (C3 — lock was modified after freeze).`,
+    );
+  }
+
+  console.error(`[WindtunnelRun] Freeze proof verified: lock committed at ${freezeCommit}`);
+}
+
+/**
+ * Compute gate-1-scoped fixtureSha via `git hash-object` over the control dir
+ * (OQ3 — do NOT extend the existing .totem/tests FIXTURE_DIR).
+ */
+function computeFixtureSha(
+  controlDir: string,
+  repoRoot: string,
+  safeExec: SafeExecFn,
+): string | null {
+  try {
+    const allEntries = fs.readdirSync(controlDir, { recursive: true });
+    const files = allEntries
+      .map((f) => (f instanceof Buffer ? f.toString('utf-8') : String(f)))
+      .filter((f) => !fs.statSync(path.join(controlDir, f)).isDirectory())
+      .sort();
+
+    if (files.length === 0) return null;
+
+    const hashes = files.map((f) => {
+      const fullPath = path.join(controlDir, f);
+      return safeExec('git', ['hash-object', fullPath], { cwd: repoRoot }).trim();
+    });
+
+    // Combine individual file hashes into a single aggregate
+    const combined = hashes.join('\n');
+    return safeExec('git', ['hash-object', '--stdin'], {
+      cwd: repoRoot,
+      input: combined,
+    } as Parameters<SafeExecFn>[2]).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Assert corpus completeness (S4): resolvedPrs === selectionRule(asOfCommit).
+ * In the harness phase this is a structural check only (no real lc API call).
+ */
+async function assertCorpusCompleteness(
+  lock: import('@mmnto/totem').WindtunnelLock,
+  lcDir: string,
+  repoRoot: string,
+  safeExec: SafeExecFn,
+): Promise<void> {
+  // Verify the lc clone is accessible + at the correct asOfCommit
+  const asOfCommit = lock.corpus.selectionRule.asOfCommit;
+  try {
+    const headSha = safeExec('git', ['rev-parse', 'HEAD'], { cwd: lcDir }).trim();
+    const isAncestor = (() => {
+      try {
+        safeExec('git', ['merge-base', '--is-ancestor', asOfCommit, headSha], { cwd: lcDir });
+        return true;
+      } catch {
+        return false;
+      }
+    })();
+
+    if (!isAncestor) {
+      console.error(
+        `[WindtunnelFreeze] WARNING: asOfCommit ${asOfCommit} is not an ancestor of lc HEAD ${headSha} — corpus completeness assertion may be unreliable.`,
+      );
+    } else {
+      console.error(`[WindtunnelFreeze] lc clone at ${lcDir} includes asOfCommit ${asOfCommit} ✓`);
+    }
+  } catch {
+    console.error(
+      `[WindtunnelFreeze] WARNING: cannot verify lc clone at ${lcDir} — completeness assertion skipped.`,
+    );
+    return;
+  }
+
+  // Structural completeness: count + warn (the actual re-derivation of the full
+  // code-touching PR set requires querying the lc repo's merge history, which
+  // is operator-level work; the tool asserts the lock is non-empty and warns
+  // if the resolvedPrs count seems low).
+  const prCount = lock.corpus.resolvedPrs.length;
+  console.error(
+    `[WindtunnelFreeze] resolvedPrs: ${prCount} entries (completeness requires operator verification against selectionRule)`,
+  );
+
+  void repoRoot; // used in freeze proof above
+}
+
+// ─── Mock engine (harness phase) ─────────────────────
+
+/**
+ * Run mock engines for harness-phase validation (OQ2).
+ * Returns firings + ground-truth labels that exercise all verdict paths:
+ * PASS, HONEST-NEGATIVE (exposure floor, unlabeled), FAIL (FP, vacuity).
+ * For the actual harness lock (mintedRuleIds ≈ []), this returns empty results.
+ */
+async function runMockEngine(
+  lock: import('@mmnto/totem').WindtunnelLock,
+  _readStrategy: (file: string) => Promise<string | null>,
+): Promise<{
+  mintedRuleIds: string[];
+  firings: import('@mmnto/totem').RuleFiring[];
+  groundTruth: Map<string, import('@mmnto/totem').GroundTruthLabel>;
+  positiveControlTargets: Array<{ pr: number; targetRuleId: string }>;
+}> {
+  const { firingLabelId } = await import('@mmnto/totem');
+
+  // In harness phase, there are no real minted rules yet (strategy#516 pending)
+  const mintedRuleIds: string[] = [];
+  const firings: import('@mmnto/totem').RuleFiring[] = [];
+  const groundTruth = new Map<string, import('@mmnto/totem').GroundTruthLabel>();
+  const positiveControlTargets: Array<{ pr: number; targetRuleId: string }> = [];
+
+  // Emit a diagnostic so operators know the mock engine ran
+  console.error(
+    `[WindtunnelRun] Mock engine active (harness phase — no compiled rules yet; strategy#516 pending).`,
+  );
+  console.error(`  resolvedPrs count: ${lock.corpus.resolvedPrs.length}`);
+
+  // Exercise firingLabelId to validate A2 path in harness
+  if (lock.corpus.resolvedPrs.length > 0) {
+    const samplePr = lock.corpus.resolvedPrs[0]!;
+    const sampleId = firingLabelId('mock-rule', samplePr.pr, 'sample/file.ts', 'sample line');
+    console.error(`  sample firingLabelId (A2 validation): ${sampleId}`);
+  }
+
+  return { mintedRuleIds, firings, groundTruth, positiveControlTargets };
+}

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -31,7 +31,9 @@ export async function freezeCommand(opts: FreezeOptions): Promise<void> {
 
   const cwd = process.cwd();
   const repoRoot = resolveGitRoot(cwd) ?? cwd;
-  const lockPath = opts.lockPath ?? path.join(repoRoot, LOCK_REL_PATH);
+  const lockPath = opts.lockPath
+    ? path.resolve(cwd, opts.lockPath)
+    : path.join(repoRoot, LOCK_REL_PATH);
   const lcDir = opts.lcDir ?? process.env['TOTEM_LC_DIR'];
 
   // Read + validate the lock
@@ -128,18 +130,14 @@ export interface RunOptions {
  * Exit codes: 0 = PASS, 1 = FAIL / HONEST-NEGATIVE / needs-adjudication.
  */
 export async function runCommand(opts: RunOptions): Promise<void> {
-  const {
-    WindtunnelLockSchema,
-    safeExec,
-    resolveGitRoot,
-    TotemError,
-    scoreWindtunnel,
-    firingLabelId,
-  } = await import('@mmnto/totem');
+  const { WindtunnelLockSchema, safeExec, resolveGitRoot, TotemError, scoreWindtunnel } =
+    await import('@mmnto/totem');
 
   const cwd = process.cwd();
   const repoRoot = resolveGitRoot(cwd) ?? cwd;
-  const lockPath = opts.lockPath ?? path.join(repoRoot, LOCK_REL_PATH);
+  const lockPath = opts.lockPath
+    ? path.resolve(cwd, opts.lockPath)
+    : path.join(repoRoot, LOCK_REL_PATH);
   const lcDir = opts.lcDir ?? process.env['TOTEM_LC_DIR'];
   const requestedPhase = opts.phase;
 
@@ -267,9 +265,6 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   if (verdict.verdict !== 'PASS' || verdict.needsAdjudication.length > 0) {
     process.exitCode = 1;
   }
-
-  // Reference firingLabelId to satisfy the import (used in mock engine)
-  void firingLabelId;
 }
 
 // ─── Helpers ─────────────────────────────────────────
@@ -378,10 +373,10 @@ export function verifyFreezeProof(lockPath: string, repoRoot: string, safeExec: 
   let workingHash: string;
   let committedHash: string;
   try {
-    workingHash = safeExec('git', ['hash-object', lockPath], { cwd: repoRoot });
+    workingHash = safeExec('git', ['hash-object', lockPath], { cwd: repoRoot }).trim();
     committedHash = safeExec('git', ['rev-parse', `${freezeCommit}:${relLockPath}`], {
       cwd: repoRoot,
-    });
+    }).trim();
   } catch (err) {
     throw new Error(
       `Wind-tunnel freeze proof: cannot resolve lock blob at ${freezeCommit}: ${err instanceof Error ? err.message : String(err)}`,

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -277,6 +277,31 @@ export async function runCommand(opts: RunOptions): Promise<void> {
 type SafeExecFn = typeof import('@mmnto/totem').safeExec;
 
 /**
+ * Boolean predicate: is `ancestor` an ancestor of `descendant` in the repo at
+ * `cwd`? `git merge-base --is-ancestor` encodes the answer in its exit code
+ * (0 = yes, 1 = no), so a non-zero exit is a legitimate FALSE, not an error to
+ * swallow. Any other failure (bad ref, repo unreadable) re-throws so it is not
+ * masked as a clean "false".
+ */
+function isCommitAncestor(
+  ancestor: string,
+  descendant: string,
+  cwd: string,
+  safeExec: SafeExecFn,
+): boolean {
+  try {
+    safeExec('git', ['merge-base', '--is-ancestor', ancestor, descendant], { cwd });
+    return true;
+  } catch (err) {
+    const status = (err as { status?: number | null }).status;
+    if (status === 1) return false;
+    throw new Error(
+      `Wind-tunnel: 'git merge-base --is-ancestor ${ancestor} ${descendant}' failed in ${cwd}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+/**
  * Build a post-image readStrategy (S1/C1).
  * When lcDir is provided, resolves blobs via `git show <asOfCommit>:<path>` in
  * the lc clone. Throws on unresolvable blob for an evaluated added file (C2).
@@ -377,29 +402,30 @@ function computeFixtureSha(
   repoRoot: string,
   safeExec: SafeExecFn,
 ): string | null {
-  try {
-    const allEntries = fs.readdirSync(controlDir, { recursive: true });
-    const files = allEntries
-      .map((f) => (f instanceof Buffer ? f.toString('utf-8') : String(f)))
-      .filter((f) => !fs.statSync(path.join(controlDir, f)).isDirectory())
-      .sort();
+  // No try/catch around the body: a hash/IO failure must propagate so the
+  // integrity check fails LOUD (Tenet 4 — a silently null'd hash would skip the
+  // run-time tamper gate, the §5 no-silent-shrink discipline this design rests
+  // on). The only "soft" case is an empty control dir, returned as null and
+  // handled by callers (control dir absent / not yet populated at harness time).
+  const allEntries = fs.readdirSync(controlDir, { recursive: true });
+  const files = allEntries
+    .map((f) => (f instanceof Buffer ? f.toString('utf-8') : String(f)))
+    .filter((f) => !fs.statSync(path.join(controlDir, f)).isDirectory())
+    .sort();
 
-    if (files.length === 0) return null;
+  if (files.length === 0) return null;
 
-    const hashes = files.map((f) => {
-      const fullPath = path.join(controlDir, f);
-      return safeExec('git', ['hash-object', fullPath], { cwd: repoRoot }).trim();
-    });
+  const hashes = files.map((f) => {
+    const fullPath = path.join(controlDir, f);
+    return safeExec('git', ['hash-object', fullPath], { cwd: repoRoot }).trim();
+  });
 
-    // Combine individual file hashes into a single aggregate
-    const combined = hashes.join('\n');
-    return safeExec('git', ['hash-object', '--stdin'], {
-      cwd: repoRoot,
-      input: combined,
-    } as Parameters<SafeExecFn>[2]).trim();
-  } catch {
-    return null;
-  }
+  // Combine individual file hashes into a single order-stable aggregate digest.
+  const combined = hashes.join('\n');
+  return safeExec('git', ['hash-object', '--stdin'], {
+    cwd: repoRoot,
+    input: combined,
+  }).trim();
 }
 
 /**
@@ -412,31 +438,30 @@ async function assertCorpusCompleteness(
   repoRoot: string,
   safeExec: SafeExecFn,
 ): Promise<void> {
-  // Verify the lc clone is accessible + at the correct asOfCommit
+  // Verify the lc clone is accessible + at the correct asOfCommit.
+  // `merge-base --is-ancestor` exits non-zero to MEAN "not an ancestor" — that
+  // is a boolean predicate, not an error, so it gets its own probe helper.
   const asOfCommit = lock.corpus.selectionRule.asOfCommit;
+  let headSha: string;
   try {
-    const headSha = safeExec('git', ['rev-parse', 'HEAD'], { cwd: lcDir }).trim();
-    const isAncestor = (() => {
-      try {
-        safeExec('git', ['merge-base', '--is-ancestor', asOfCommit, headSha], { cwd: lcDir });
-        return true;
-      } catch {
-        return false;
-      }
-    })();
-
-    if (!isAncestor) {
-      console.error(
-        `[WindtunnelFreeze] WARNING: asOfCommit ${asOfCommit} is not an ancestor of lc HEAD ${headSha} — corpus completeness assertion may be unreliable.`,
-      );
-    } else {
-      console.error(`[WindtunnelFreeze] lc clone at ${lcDir} includes asOfCommit ${asOfCommit} ✓`);
-    }
-  } catch {
-    console.error(
-      `[WindtunnelFreeze] WARNING: cannot verify lc clone at ${lcDir} — completeness assertion skipped.`,
+    headSha = safeExec('git', ['rev-parse', 'HEAD'], { cwd: lcDir }).trim();
+  } catch (err) {
+    // S4: an inaccessible lc clone means freeze-time completeness cannot be
+    // proven. The harness phase tolerates this (no real corpus yet) but must
+    // surface it loudly — never silently pass off an unverifiable corpus.
+    throw new Error(
+      `Wind-tunnel freeze: cannot access lc clone at ${lcDir} to verify corpus completeness (S4): ${err instanceof Error ? err.message : String(err)}. ` +
+        `Provide a valid --lc-dir / TOTEM_LC_DIR clone, or omit it to skip the completeness assertion entirely.`,
     );
-    return;
+  }
+
+  const isAncestor = isCommitAncestor(asOfCommit, headSha, lcDir, safeExec);
+  if (!isAncestor) {
+    console.error(
+      `[WindtunnelFreeze] WARNING: asOfCommit ${asOfCommit} is not an ancestor of lc HEAD ${headSha} — corpus completeness assertion may be unreliable.`,
+    );
+  } else {
+    console.error(`[WindtunnelFreeze] lc clone at ${lcDir} includes asOfCommit ${asOfCommit} ✓`);
   }
 
   // Structural completeness: count + warn (the actual re-derivation of the full

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -189,18 +189,11 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   // C3: derive freeze proof from git history (not a self-embedded trusted field).
   verifyFreezeProof(lockPath, repoRoot, safeExec);
 
-  // C6: verify fixture integrity (controls.integrity.fixtureSha)
+  // C6 / §5: fixture integrity is MANDATORY — a missing or empty control dir
+  // while the lock declares a fixtureSha is corpus shrinkage / tampering, not a
+  // reason to skip. verifyControlIntegrity throws loud on missing/empty/mismatch.
   const controlDir = path.join(repoRoot, lock.controls.positiveRef);
-  if (fs.existsSync(controlDir)) {
-    const actualSha = computeFixtureSha(controlDir, repoRoot, safeExec);
-    if (actualSha && actualSha !== lock.controls.integrity.fixtureSha) {
-      throw new TotemError(
-        'CONFIG_INVALID',
-        `Control fixture integrity check failed: expected ${lock.controls.integrity.fixtureSha}, got ${actualSha}`,
-        'Revert the tampering or re-freeze the lock with the updated fixtureSha.',
-      );
-    }
-  }
+  verifyControlIntegrity(controlDir, lock.controls.integrity.fixtureSha, repoRoot, safeExec);
 
   console.error(`[WindtunnelRun] Lock valid — phase: ${lock.phase}`);
 
@@ -414,11 +407,19 @@ export function computeFixtureSha(
   const allEntries = fs.readdirSync(controlDir, { recursive: true });
   const files = allEntries
     .map((f) => (f instanceof Buffer ? f.toString('utf-8') : String(f)))
+    // Normalize to forward-slash BEFORE sorting (A3): Windows readdir yields
+    // '\' separators, which would otherwise reorder the sort and change the
+    // aggregate digest across platforms. path.join below re-localizes for IO.
+    .map((f) => f.replace(/\\/g, '/'))
     .filter((f) => !fs.statSync(path.join(controlDir, f)).isDirectory())
     .sort();
 
   if (files.length === 0) return null;
 
+  // `git hash-object <path>` applies the repo's clean/EOL filter by default
+  // (verified: a CRLF file under `* text=auto` hashes identically to its LF
+  // form), so each per-file hash is CRLF-immune WITHOUT --filters (and
+  // --no-filters would defeat that immunity).
   const hashes = files.map((f) => {
     const fullPath = path.join(controlDir, f);
     return safeExec('git', ['hash-object', fullPath], { cwd: repoRoot }).trim();
@@ -430,6 +431,35 @@ export function computeFixtureSha(
     cwd: repoRoot,
     input: combined,
   }).trim();
+}
+
+/**
+ * Verify control-fixture integrity (C6 / §5 no-silent-shrink). The lock ALWAYS
+ * declares a fixtureSha (schema-required), so a missing OR empty control dir is
+ * corpus shrinkage / tampering — it MUST fail loud, never silently pass.
+ */
+export function verifyControlIntegrity(
+  controlDir: string,
+  expectedSha: string,
+  repoRoot: string,
+  safeExec: SafeExecFn,
+): void {
+  if (!fs.existsSync(controlDir)) {
+    throw new Error(
+      `Wind-tunnel integrity: control dir ${controlDir} is missing but the lock declares fixtureSha ${expectedSha} (§5 no-silent-shrink). Restore the fixtures or re-freeze the lock.`,
+    );
+  }
+  const actualSha = computeFixtureSha(controlDir, repoRoot, safeExec);
+  if (actualSha === null) {
+    throw new Error(
+      `Wind-tunnel integrity: control dir ${controlDir} is empty but the lock declares fixtureSha ${expectedSha} (§5 no-silent-shrink). Restore the fixtures or re-freeze the lock.`,
+    );
+  }
+  if (actualSha !== expectedSha) {
+    throw new Error(
+      `Wind-tunnel integrity: control fixtures changed — expected ${expectedSha}, got ${actualSha}. Revert the tampering or re-freeze with the updated fixtureSha.`,
+    );
+  }
 }
 
 /**

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -141,6 +141,21 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   const lcDir = opts.lcDir ?? process.env['TOTEM_LC_DIR'];
   const requestedPhase = opts.phase;
 
+  // Validate --phase up front: an unrecognized value (e.g. a typo "certifyng")
+  // would otherwise slip past the P1 guard below (which only matches the exact
+  // string "certifying") and silently run as if no phase were requested.
+  if (
+    requestedPhase !== undefined &&
+    requestedPhase !== 'harness' &&
+    requestedPhase !== 'certifying'
+  ) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `Invalid --phase "${requestedPhase}" — must be "harness" or "certifying".`,
+      'Pass --phase certifying (or harness), or omit it.',
+    );
+  }
+
   // Read + validate the lock
   let rawJson: string;
   try {
@@ -373,7 +388,7 @@ export function verifyFreezeProof(lockPath: string, repoRoot: string, safeExec: 
   let workingHash: string;
   let committedHash: string;
   try {
-    workingHash = safeExec('git', ['hash-object', lockPath], { cwd: repoRoot }).trim();
+    workingHash = safeExec('git', ['hash-object', '--', lockPath], { cwd: repoRoot }).trim();
     committedHash = safeExec('git', ['rev-parse', `${freezeCommit}:${relLockPath}`], {
       cwd: repoRoot,
     }).trim();
@@ -439,7 +454,8 @@ export function computeFixtureSha(
   // --no-filters would defeat that immunity).
   const combined = entries
     .map(
-      (e) => `${e.key}:${safeExec('git', ['hash-object', e.fullPath], { cwd: repoRoot }).trim()}`,
+      (e) =>
+        `${e.key}:${safeExec('git', ['hash-object', '--', e.fullPath], { cwd: repoRoot }).trim()}`,
     )
     .join('\n');
 

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -83,11 +83,14 @@ export async function freezeCommand(opts: FreezeOptions): Promise<void> {
     console.error(`  Set TOTEM_LC_DIR or pass --lc-dir to enable completeness check.`);
   }
 
-  // Compute gate-1-scoped fixtureSha (OQ3)
-  const controlDirRef = lock.controls.positiveRef;
-  const controlDir = path.join(repoRoot, controlDirRef);
-  if (fs.existsSync(controlDir)) {
-    const fixtureSha = computeFixtureSha(controlDir, repoRoot, safeExec);
+  // Compute gate-1-scoped fixtureSha (OQ3) over BOTH control dirs so the lock's
+  // single fixtureSha protects positive AND negative fixtures.
+  const controlDirs = [
+    path.join(repoRoot, lock.controls.positiveRef),
+    path.join(repoRoot, lock.controls.negativeRef),
+  ];
+  if (controlDirs.some((d) => fs.existsSync(d))) {
+    const fixtureSha = computeFixtureSha(controlDirs, repoRoot, safeExec);
     if (fixtureSha && fixtureSha !== lock.controls.integrity.fixtureSha) {
       console.error(
         `[WindtunnelFreeze] WARNING: controls.integrity.fixtureSha in lock (${lock.controls.integrity.fixtureSha}) does not match computed hash (${fixtureSha})`,
@@ -98,7 +101,7 @@ export async function freezeCommand(opts: FreezeOptions): Promise<void> {
     }
   } else {
     console.error(
-      `[WindtunnelFreeze] Control dir ${controlDir} does not exist — integrity check skipped.`,
+      `[WindtunnelFreeze] Control dirs [${controlDirs.join(', ')}] do not exist — integrity check skipped.`,
     );
   }
 
@@ -189,11 +192,15 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   // C3: derive freeze proof from git history (not a self-embedded trusted field).
   verifyFreezeProof(lockPath, repoRoot, safeExec);
 
-  // C6 / §5: fixture integrity is MANDATORY — a missing or empty control dir
-  // while the lock declares a fixtureSha is corpus shrinkage / tampering, not a
-  // reason to skip. verifyControlIntegrity throws loud on missing/empty/mismatch.
-  const controlDir = path.join(repoRoot, lock.controls.positiveRef);
-  verifyControlIntegrity(controlDir, lock.controls.integrity.fixtureSha, repoRoot, safeExec);
+  // C6 / §5: fixture integrity is MANDATORY over BOTH control dirs (positive
+  // AND negative) — a missing/empty control dir while the lock declares a
+  // fixtureSha is corpus shrinkage / tampering, not a reason to skip.
+  // verifyControlIntegrity throws loud on missing/empty/mismatch.
+  const controlDirs = [
+    path.join(repoRoot, lock.controls.positiveRef),
+    path.join(repoRoot, lock.controls.negativeRef),
+  ];
+  verifyControlIntegrity(controlDirs, lock.controls.integrity.fixtureSha, repoRoot, safeExec);
 
   console.error(`[WindtunnelRun] Lock valid — phase: ${lock.phase}`);
 
@@ -391,42 +398,56 @@ export function verifyFreezeProof(lockPath: string, repoRoot: string, safeExec: 
 }
 
 /**
- * Compute gate-1-scoped fixtureSha via `git hash-object` over the control dir
+ * Compute gate-1-scoped fixtureSha via `git hash-object` over ALL control dirs
+ * (positive AND negative), so the single fixtureSha protects every fixture
  * (OQ3 — do NOT extend the existing .totem/tests FIXTURE_DIR).
  */
 export function computeFixtureSha(
-  controlDir: string,
+  controlDirs: string[],
   repoRoot: string,
   safeExec: SafeExecFn,
 ): string | null {
   // No try/catch around the body: a hash/IO failure must propagate so the
   // integrity check fails LOUD (Tenet 4 — a silently null'd hash would skip the
   // run-time tamper gate, the §5 no-silent-shrink discipline this design rests
-  // on). The only "soft" case is an empty control dir, returned as null and
-  // handled by callers (control dir absent / not yet populated at harness time).
-  const allEntries = fs.readdirSync(controlDir, { recursive: true });
-  const files = allEntries
-    .map((f) => (f instanceof Buffer ? f.toString('utf-8') : String(f)))
-    // Normalize to forward-slash BEFORE sorting (A3): Windows readdir yields
-    // '\' separators, which would otherwise reorder the sort and change the
-    // aggregate digest across platforms. path.join below re-localizes for IO.
-    .map((f) => f.replace(/\\/g, '/'))
-    .filter((f) => !fs.statSync(path.join(controlDir, f)).isDirectory())
-    .sort();
+  // on). The only "soft" case is no files across all dirs, returned as null and
+  // handled by callers (controls absent / not yet populated at harness time).
+  //
+  // Hashes EVERY provided control dir (positive AND negative) so the single
+  // fixtureSha protects all fixtures — a tampered negative control (the cull
+  // guard) is as detectable as a tampered positive one.
+  const entries: Array<{ key: string; fullPath: string }> = [];
+  for (const dir of controlDirs) {
+    if (!fs.existsSync(dir)) continue;
+    const dirKey = path.basename(dir.replace(/[/\\]+$/, ''));
+    const files = fs
+      .readdirSync(dir, { recursive: true })
+      .map((f) => (f instanceof Buffer ? f.toString('utf-8') : String(f)))
+      // Normalize to forward-slash (A3): Windows readdir yields '\' separators,
+      // which would otherwise reorder the sort and change the digest per-platform.
+      .map((f) => f.replace(/\\/g, '/'))
+      .filter((f) => !fs.statSync(path.join(dir, f)).isDirectory());
+    for (const f of files) {
+      // Dir-qualified key: keeps cross-dir order stable AND makes a file moving
+      // between positive/ and negative/ change the aggregate (tamper-evident).
+      entries.push({ key: `${dirKey}/${f}`, fullPath: path.join(dir, f) });
+    }
+  }
 
-  if (files.length === 0) return null;
+  if (entries.length === 0) return null;
+
+  entries.sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
 
   // `git hash-object <path>` applies the repo's clean/EOL filter by default
   // (verified: a CRLF file under `* text=auto` hashes identically to its LF
   // form), so each per-file hash is CRLF-immune WITHOUT --filters (and
   // --no-filters would defeat that immunity).
-  const hashes = files.map((f) => {
-    const fullPath = path.join(controlDir, f);
-    return safeExec('git', ['hash-object', fullPath], { cwd: repoRoot }).trim();
-  });
+  const combined = entries
+    .map(
+      (e) => `${e.key}:${safeExec('git', ['hash-object', e.fullPath], { cwd: repoRoot }).trim()}`,
+    )
+    .join('\n');
 
-  // Combine individual file hashes into a single order-stable aggregate digest.
-  const combined = hashes.join('\n');
   return safeExec('git', ['hash-object', '--stdin'], {
     cwd: repoRoot,
     input: combined,
@@ -435,24 +456,27 @@ export function computeFixtureSha(
 
 /**
  * Verify control-fixture integrity (C6 / §5 no-silent-shrink). The lock ALWAYS
- * declares a fixtureSha (schema-required), so a missing OR empty control dir is
- * corpus shrinkage / tampering — it MUST fail loud, never silently pass.
+ * declares a fixtureSha (schema-required) covering ALL control dirs (positive
+ * AND negative), so any missing/empty control dir or hash mismatch is corpus
+ * shrinkage / tampering — it MUST fail loud, never silently pass.
  */
 export function verifyControlIntegrity(
-  controlDir: string,
+  controlDirs: string[],
   expectedSha: string,
   repoRoot: string,
   safeExec: SafeExecFn,
 ): void {
-  if (!fs.existsSync(controlDir)) {
-    throw new Error(
-      `Wind-tunnel integrity: control dir ${controlDir} is missing but the lock declares fixtureSha ${expectedSha} (§5 no-silent-shrink). Restore the fixtures or re-freeze the lock.`,
-    );
+  for (const dir of controlDirs) {
+    if (!fs.existsSync(dir)) {
+      throw new Error(
+        `Wind-tunnel integrity: control dir ${dir} is missing but the lock declares fixtureSha ${expectedSha} (§5 no-silent-shrink). Restore the fixtures or re-freeze the lock.`,
+      );
+    }
   }
-  const actualSha = computeFixtureSha(controlDir, repoRoot, safeExec);
+  const actualSha = computeFixtureSha(controlDirs, repoRoot, safeExec);
   if (actualSha === null) {
     throw new Error(
-      `Wind-tunnel integrity: control dir ${controlDir} is empty but the lock declares fixtureSha ${expectedSha} (§5 no-silent-shrink). Restore the fixtures or re-freeze the lock.`,
+      `Wind-tunnel integrity: control dirs [${controlDirs.join(', ')}] are empty but the lock declares fixtureSha ${expectedSha} (§5 no-silent-shrink). Restore the fixtures or re-freeze the lock.`,
     );
   }
   if (actualSha !== expectedSha) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1774,6 +1774,61 @@ program
     }
   });
 
+// ─── Spine noun-verb subcommands (mmnto-ai/totem#2188) ──────────────────────
+
+const spineCmd = program
+  .command('spine')
+  .description('Spine evidence harness — Gate-1 wind-tunnel evaluation');
+
+const windtunnelCmd = spineCmd
+  .command('windtunnel')
+  .description('Gate-1 wind-tunnel: freeze corpus lock + run evidence harness');
+
+windtunnelCmd
+  .command('freeze')
+  .description('Validate and freeze the wind-tunnel corpus lock (schema + S4 completeness)')
+  .option(
+    '--lc-dir <path>',
+    'Path to the lc clone (env: TOTEM_LC_DIR)',
+    process.env['TOTEM_LC_DIR'],
+  )
+  .option(
+    '--lock-path <path>',
+    'Override the lock file path (default: .totem/spine/gate-1/windtunnel.lock.json)',
+  )
+  .action(async (opts: { lcDir?: string; lockPath?: string }) => {
+    try {
+      const { freezeCommand } = await import('./commands/spine-windtunnel.js');
+      await freezeCommand({ lcDir: opts.lcDir, lockPath: opts.lockPath });
+    } catch (err) {
+      handleError(err);
+      throw err;
+    }
+  });
+
+windtunnelCmd
+  .command('run')
+  .description('Run the wind-tunnel against the frozen corpus lock')
+  .option(
+    '--lc-dir <path>',
+    'Path to the lc clone (env: TOTEM_LC_DIR)',
+    process.env['TOTEM_LC_DIR'],
+  )
+  .option(
+    '--lock-path <path>',
+    'Override the lock file path (default: .totem/spine/gate-1/windtunnel.lock.json)',
+  )
+  .option('--phase <phase>', 'Required phase for this run (certifying rejects a harness lock, P1)')
+  .action(async (opts: { lcDir?: string; lockPath?: string; phase?: string }) => {
+    try {
+      const { runCommand } = await import('./commands/spine-windtunnel.js');
+      await runCommand({ lcDir: opts.lcDir, lockPath: opts.lockPath, phase: opts.phase });
+    } catch (err) {
+      handleError(err);
+      throw err;
+    }
+  });
+
 // Fire-and-forget: reap orphaned temp files from previous crashed runs
 reapOrphanedTempFiles(process.cwd(), '.totem').catch(() => {});
 

--- a/packages/core/src/ast-gate.test.ts
+++ b/packages/core/src/ast-gate.test.ts
@@ -126,4 +126,66 @@ describe('enrichWithAstContext', () => {
     expect(additions[0]!.astContext).toBeUndefined();
     expect(warnings.some((w) => w.includes('escapes project root'))).toBe(true);
   });
+
+  it('uses injected readStrategy content when provided (C1 seam)', async () => {
+    // readStrategy returns TypeScript with a comment — should classify as comment
+    const tsContent = '// a comment\nconst x = 1;\n';
+    const additions: DiffAddition[] = [
+      { file: 'src/app.ts', line: '// a comment', lineNumber: 1, precedingLine: null },
+      { file: 'src/app.ts', line: 'const x = 1;', lineNumber: 2, precedingLine: '// a comment' },
+    ];
+
+    await enrichWithAstContext(additions, {
+      cwd: tmpDir,
+      readStrategy: async (_file) => tsContent,
+    });
+
+    expect(additions[0]!.astContext).toBe('comment');
+    expect(additions[1]!.astContext).toBe('code');
+  });
+
+  it('skips classification and warns when readStrategy returns null', async () => {
+    const warnings: string[] = [];
+    const additions: DiffAddition[] = [
+      { file: 'src/app.ts', line: 'const x = 1;', lineNumber: 1, precedingLine: null },
+    ];
+
+    await enrichWithAstContext(additions, {
+      cwd: tmpDir,
+      readStrategy: async (_file) => null,
+      onWarn: (msg) => warnings.push(msg),
+    });
+
+    expect(additions[0]!.astContext).toBeUndefined();
+    expect(warnings.some((w) => w.includes('readStrategy returned null'))).toBe(true);
+  });
+
+  it('propagates readStrategy errors without falling back to disk (C2)', async () => {
+    const additions: DiffAddition[] = [
+      { file: 'src/app.ts', line: 'const x = 1;', lineNumber: 1, precedingLine: null },
+    ];
+
+    await expect(
+      enrichWithAstContext(additions, {
+        cwd: tmpDir,
+        readStrategy: async (_file) => {
+          throw new Error('blob not found in lc clone');
+        },
+      }),
+    ).rejects.toThrow('blob not found in lc clone');
+  });
+
+  it('preserves existing behavior when no readStrategy is provided', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'src', 'no-strategy.ts'),
+      '// comment line\nconst z = 99;\n',
+    );
+    const additions: DiffAddition[] = [
+      { file: 'src/no-strategy.ts', line: '// comment line', lineNumber: 1, precedingLine: null },
+    ];
+
+    await enrichWithAstContext(additions, { cwd: tmpDir });
+    // Disk fallback reads the file and classifies
+    expect(additions[0]!.astContext).toBe('comment');
+  });
 });

--- a/packages/core/src/ast-gate.ts
+++ b/packages/core/src/ast-gate.ts
@@ -81,41 +81,13 @@ async function classifyFile(
     return;
   }
 
-  let content: string;
-  if (options.readStrategy) {
-    // Injection seam: callers supply post-image content for parity with the
-    // AST engine. null → skip (same as unreadable). Throws propagate (C2).
-    const injected = await options.readStrategy(file);
-    if (injected === null) {
-      onWarn?.(`AST gate: readStrategy returned null for ${file}, skipping classification`);
-      return;
-    }
-    content = injected;
-  } else {
-    try {
-      // Prefer staged content (git show :path) over disk file to match the diff being evaluated.
-      // Falls back to disk if git is unavailable or file isn't staged.
-      const { safeExec } = await import('./sys/exec.js');
-      content = safeExec('git', ['show', `:${file}`], { cwd });
-    } catch {
-      try {
-        content = fs.readFileSync(fullPath, 'utf-8');
-      } catch {
-        onWarn?.(`AST gate: cannot read ${file}, skipping classification`);
-        return;
-      }
-    }
-  }
+  const content = await resolveContent(file, fullPath, cwd, options);
+  if (content === null) return; // unreadable / readStrategy returned null — skip classification
 
   const lineNumbers = additions.map((a) => a.lineNumber);
 
-  let classifications: Map<number, AstContext>;
-  try {
-    classifications = await classifyLines(content, lineNumbers, lang);
-  } catch {
-    onWarn?.(`AST gate: parse failed for ${file}, skipping classification`);
-    return;
-  }
+  const classifications = await classifyContent(content, lineNumbers, lang, file, onWarn);
+  if (classifications === null) return; // parse failed — skip classification (fail-open)
 
   // Enrich additions with their AST context
   for (const addition of additions) {
@@ -123,5 +95,73 @@ async function classifyFile(
     if (ctx) {
       addition.astContext = ctx;
     }
+  }
+}
+
+/**
+ * Resolve the file content to classify. When `options.readStrategy` is set
+ * (the wind-tunnel parity seam, mmnto-ai/totem#2188), it is the sole source:
+ * a `null` return means "skip" (same as unreadable) and a throw propagates
+ * (C2 — a missing post-image blob must not silently no-match). When absent,
+ * the established staged (`git show :path`) → disk fallback is used.
+ *
+ * Returns `null` when the file cannot be read and classification should be
+ * skipped (fail-open — AST enrichment is advisory, not a hard sensor).
+ */
+async function resolveContent(
+  file: string,
+  fullPath: string,
+  cwd: string,
+  options: AstGateOptions,
+): Promise<string | null> {
+  if (options.readStrategy) {
+    const injected = await options.readStrategy(file);
+    if (injected === null) {
+      options.onWarn?.(`AST gate: readStrategy returned null for ${file}, skipping classification`);
+    }
+    return injected;
+  }
+
+  // totem-context: intentional fallback — git show :path is the preferred staged read; a non-staged file falls through to the disk read below (advisory AST enrichment, never a hard sensor).
+  try {
+    // Prefer staged content (git show :path) over disk file to match the diff being evaluated.
+    const { safeExec } = await import('./sys/exec.js');
+    return safeExec('git', ['show', `:${file}`], { cwd });
+  } catch (gitErr) {
+    // totem-context: intentional fallback — staged read missing/unavailable, read from disk; dual placement so the rule fires on either the catch-keyword line or the catch-body line.
+    void gitErr;
+  }
+
+  // totem-context: intentional fail-open — an unreadable file degrades to skip-classification (advisory AST enrichment, never a hard sensor).
+  try {
+    return fs.readFileSync(fullPath, 'utf-8');
+  } catch (diskErr) {
+    // totem-context: intentional fail-open — unreadable file → skip classification; dual placement so the rule fires on either the catch-keyword line or the catch-body line.
+    void diskErr;
+    options.onWarn?.(`AST gate: cannot read ${file}, skipping classification`);
+    return null;
+  }
+}
+
+/**
+ * Classify the given lines of `content`, returning the per-line AST context
+ * map. Returns `null` when the parse fails so the caller skips classification
+ * (fail-open — AST enrichment is advisory, not a hard sensor).
+ */
+async function classifyContent(
+  content: string,
+  lineNumbers: number[],
+  lang: Parameters<typeof classifyLines>[2],
+  file: string,
+  onWarn?: (msg: string) => void,
+): Promise<Map<number, AstContext> | null> {
+  // totem-context: intentional fail-open — an unparseable file degrades to skip-classification (advisory AST enrichment, never a hard sensor); dual placement so the rule fires on either the catch-keyword line or the catch-body line.
+  try {
+    return await classifyLines(content, lineNumbers, lang);
+  } catch (parseErr) {
+    // totem-context: intentional fail-open — unparseable file → skip classification; dual placement so the rule fires on either the catch-keyword line or the catch-body line.
+    void parseErr;
+    onWarn?.(`AST gate: parse failed for ${file}, skipping classification`);
+    return null;
   }
 }

--- a/packages/core/src/ast-gate.ts
+++ b/packages/core/src/ast-gate.ts
@@ -11,6 +11,15 @@ export interface AstGateOptions {
   cwd?: string;
   /** Optional callback for non-fatal warnings (e.g., file not readable) */
   onWarn?: (msg: string) => void;
+  /**
+   * Optional content injection seam (C1 — wind-tunnel parity).
+   * When provided, classifyFile uses this instead of git-show / disk reads,
+   * so regex astContext classification sees the same post-image content as
+   * the AST engine. Returning null skips classification for that file (same
+   * as an unreadable file). Throwing propagates — callers must not silently
+   * swallow (C2: missing blob is corpus shrinkage, not a clean no-match).
+   */
+  readStrategy?: (file: string) => Promise<string | null>;
 }
 
 // ─── Public API ─────────────────────────────────────
@@ -49,7 +58,7 @@ export async function enrichWithAstContext(
     const lang = extensionToLanguage(ext);
     if (!lang) continue; // Unsupported language — leave as undefined (fail-open)
 
-    promises.push(classifyFile(file, fileAdditions, lang, cwd, options.onWarn));
+    promises.push(classifyFile(file, fileAdditions, lang, cwd, options));
   }
 
   await Promise.all(promises);
@@ -60,8 +69,9 @@ async function classifyFile(
   additions: DiffAddition[],
   lang: Parameters<typeof classifyLines>[2],
   cwd: string,
-  onWarn?: (msg: string) => void,
+  options: AstGateOptions,
 ): Promise<void> {
+  const onWarn = options.onWarn;
   const fullPath = path.resolve(cwd, file);
 
   // Path containment: skip files that escape the working directory
@@ -72,17 +82,28 @@ async function classifyFile(
   }
 
   let content: string;
-  try {
-    // Prefer staged content (git show :path) over disk file to match the diff being evaluated.
-    // Falls back to disk if git is unavailable or file isn't staged.
-    const { safeExec } = await import('./sys/exec.js');
-    content = safeExec('git', ['show', `:${file}`], { cwd });
-  } catch {
-    try {
-      content = fs.readFileSync(fullPath, 'utf-8');
-    } catch {
-      onWarn?.(`AST gate: cannot read ${file}, skipping classification`);
+  if (options.readStrategy) {
+    // Injection seam: callers supply post-image content for parity with the
+    // AST engine. null → skip (same as unreadable). Throws propagate (C2).
+    const injected = await options.readStrategy(file);
+    if (injected === null) {
+      onWarn?.(`AST gate: readStrategy returned null for ${file}, skipping classification`);
       return;
+    }
+    content = injected;
+  } else {
+    try {
+      // Prefer staged content (git show :path) over disk file to match the diff being evaluated.
+      // Falls back to disk if git is unavailable or file isn't staged.
+      const { safeExec } = await import('./sys/exec.js');
+      content = safeExec('git', ['show', `:${file}`], { cwd });
+    } catch {
+      try {
+        content = fs.readFileSync(fullPath, 'utf-8');
+      } catch {
+        onWarn?.(`AST gate: cannot read ${file}, skipping classification`);
+        return;
+      }
     }
   }
 

--- a/packages/core/src/ast-gate.ts
+++ b/packages/core/src/ast-gate.ts
@@ -127,16 +127,16 @@ async function resolveContent(
     // Prefer staged content (git show :path) over disk file to match the diff being evaluated.
     const { safeExec } = await import('./sys/exec.js');
     return safeExec('git', ['show', `:${file}`], { cwd });
+    // totem-context: intentional fallback — staged read missing → disk read below.
   } catch (gitErr) {
-    // totem-context: intentional fallback — staged read missing/unavailable, read from disk; dual placement so the rule fires on either the catch-keyword line or the catch-body line.
     void gitErr;
   }
 
   // totem-context: intentional fail-open — an unreadable file degrades to skip-classification (advisory AST enrichment, never a hard sensor).
   try {
     return fs.readFileSync(fullPath, 'utf-8');
+    // totem-context: intentional fail-open — unreadable file → skip classification.
   } catch (diskErr) {
-    // totem-context: intentional fail-open — unreadable file → skip classification; dual placement so the rule fires on either the catch-keyword line or the catch-body line.
     void diskErr;
     options.onWarn?.(`AST gate: cannot read ${file}, skipping classification`);
     return null;
@@ -155,11 +155,11 @@ async function classifyContent(
   file: string,
   onWarn?: (msg: string) => void,
 ): Promise<Map<number, AstContext> | null> {
-  // totem-context: intentional fail-open — an unparseable file degrades to skip-classification (advisory AST enrichment, never a hard sensor); dual placement so the rule fires on either the catch-keyword line or the catch-body line.
+  // totem-context: intentional fail-open — an unparseable file degrades to skip-classification (advisory AST enrichment, never a hard sensor).
   try {
     return await classifyLines(content, lineNumbers, lang);
+    // totem-context: intentional fail-open — unparseable file → skip classification.
   } catch (parseErr) {
-    // totem-context: intentional fail-open — unparseable file → skip classification; dual placement so the rule fires on either the catch-keyword line or the catch-body line.
     void parseErr;
     onWarn?.(`AST gate: parse failed for ${file}, skipping classification`);
     return null;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -780,3 +780,16 @@ export {
   toCrossPrBucket,
   toRoundPosition,
 } from './retrospect.js';
+
+// Spine: Gate-1 wind-tunnel evidence harness (mmnto-ai/totem#2188)
+export type { WindtunnelLock } from './spine/windtunnel-lock.js';
+export { firingLabelId, WindtunnelLockSchema } from './spine/windtunnel-lock.js';
+export type {
+  CullLedgerEntry,
+  GroundTruthLabel,
+  RuleFiring,
+  ScorerInput,
+  WindtunnelVerdict,
+  WindtunnelVerdictKind,
+} from './spine/windtunnel-scorer.js';
+export { scoreWindtunnel } from './spine/windtunnel-scorer.js';

--- a/packages/core/src/spine/windtunnel-lock.test.ts
+++ b/packages/core/src/spine/windtunnel-lock.test.ts
@@ -1,0 +1,244 @@
+import { describe, expect, it } from 'vitest';
+
+import { firingLabelId, WindtunnelLockSchema } from './windtunnel-lock.js';
+
+// ─── Helpers ─────────────────────────────────────────
+
+const VALID_SHA = '0'.repeat(40);
+const VALID_SHA_2 = '1'.repeat(40);
+const VALID_SHA_3 = 'a'.repeat(40);
+
+function validLock(overrides?: Record<string, unknown>) {
+  return {
+    schema: 'windtunnel.lock.v1',
+    canonicalPath: '.totem/spine/gate-1/windtunnel.lock.json',
+    gate: 'gate-1',
+    phase: 'harness',
+    corpus: {
+      repo: 'mmnto-ai/liquid-city',
+      selectionRule: {
+        state: 'merged',
+        predicate: 'touches-code',
+        window: { type: 'all' },
+        asOfCommit: VALID_SHA,
+      },
+      resolvedPrs: [
+        {
+          pr: 1,
+          mergeCommit: VALID_SHA,
+          baseSha: VALID_SHA_2,
+          headSha: VALID_SHA_3,
+        },
+        {
+          pr: 2,
+          mergeCommit: VALID_SHA_2,
+          baseSha: VALID_SHA_3,
+          headSha: VALID_SHA,
+        },
+      ],
+    },
+    fpDefinition: {
+      rubricRef: 'controls/rubric.md',
+      groundTruthRef: 'controls/ground-truth-labels.json',
+      adjudicator: 'operator',
+      precisionFloor: 1.0,
+    },
+    controls: {
+      positiveRef: 'controls/positive/',
+      negativeRef: 'controls/negative/',
+      integrity: {
+        mechanism: 'git-hash-object',
+        fixtureSha: VALID_SHA,
+      },
+    },
+    cullRateThreshold: 0.25,
+    exposureDenominator: {
+      activeRulesEvaluated: { floor: 2 },
+      filesTouchedInWindow: { floor: 0 },
+      positiveControlsExercised: { floor: 0 },
+    },
+    ...overrides,
+  };
+}
+
+// ─── Schema acceptance ───────────────────────────────
+
+describe('WindtunnelLockSchema acceptance', () => {
+  it('accepts a valid harness-phase lock', () => {
+    const result = WindtunnelLockSchema.safeParse(validLock());
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a certifying-phase lock', () => {
+    const result = WindtunnelLockSchema.safeParse(validLock({ phase: 'certifying' }));
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts a bounded window lock', () => {
+    const lock = validLock();
+    (lock.corpus.selectionRule as Record<string, unknown>).window = { type: 'bounded', n: 50 };
+    const result = WindtunnelLockSchema.safeParse(lock);
+    expect(result.success).toBe(true);
+  });
+});
+
+// ─── Schema rejection invariants ─────────────────────
+
+describe('WindtunnelLockSchema rejection', () => {
+  it('rejects precisionFloor !== 1.0', () => {
+    const lock = validLock();
+    (lock.fpDefinition as Record<string, unknown>).precisionFloor = 0.9;
+    const result = WindtunnelLockSchema.safeParse(lock);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-40-hex asOfCommit', () => {
+    const lock = validLock();
+    (lock.corpus.selectionRule as Record<string, unknown>).asOfCommit = 'notahex';
+    const result = WindtunnelLockSchema.safeParse(lock);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects empty resolvedPrs', () => {
+    const lock = validLock();
+    (lock.corpus as Record<string, unknown>).resolvedPrs = [];
+    const result = WindtunnelLockSchema.safeParse(lock);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects resolvedPrs entries missing mergeCommit (C4)', () => {
+    const lock = validLock();
+    (lock.corpus as Record<string, unknown>).resolvedPrs = [
+      { pr: 1, baseSha: VALID_SHA, headSha: VALID_SHA_2 },
+    ];
+    const result = WindtunnelLockSchema.safeParse(lock);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects resolvedPrs entries missing baseSha (C4)', () => {
+    const lock = validLock();
+    (lock.corpus as Record<string, unknown>).resolvedPrs = [
+      { pr: 1, mergeCommit: VALID_SHA, headSha: VALID_SHA_2 },
+    ];
+    const result = WindtunnelLockSchema.safeParse(lock);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects resolvedPrs entries missing headSha (C4)', () => {
+    const lock = validLock();
+    (lock.corpus as Record<string, unknown>).resolvedPrs = [
+      { pr: 1, mergeCommit: VALID_SHA, baseSha: VALID_SHA_2 },
+    ];
+    const result = WindtunnelLockSchema.safeParse(lock);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects duplicate pr numbers in resolvedPrs (C4)', () => {
+    const lock = validLock();
+    (lock.corpus as Record<string, unknown>).resolvedPrs = [
+      { pr: 1, mergeCommit: VALID_SHA, baseSha: VALID_SHA_2, headSha: VALID_SHA_3 },
+      { pr: 1, mergeCommit: VALID_SHA_2, baseSha: VALID_SHA_3, headSha: VALID_SHA },
+    ];
+    const result = WindtunnelLockSchema.safeParse(lock);
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result)).toContain('unique');
+  });
+
+  it('rejects unsorted pr numbers in resolvedPrs (C4)', () => {
+    const lock = validLock();
+    (lock.corpus as Record<string, unknown>).resolvedPrs = [
+      { pr: 2, mergeCommit: VALID_SHA, baseSha: VALID_SHA_2, headSha: VALID_SHA_3 },
+      { pr: 1, mergeCommit: VALID_SHA_2, baseSha: VALID_SHA_3, headSha: VALID_SHA },
+    ];
+    const result = WindtunnelLockSchema.safeParse(lock);
+    expect(result.success).toBe(false);
+    expect(JSON.stringify(result)).toContain('sorted');
+  });
+
+  it('rejects absent cullRateThreshold (C5)', () => {
+    const lock = validLock();
+    delete (lock as Record<string, unknown>)['cullRateThreshold'];
+    const result = WindtunnelLockSchema.safeParse(lock);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects cullRateThreshold >= 1 (C5)', () => {
+    const lock = validLock({ cullRateThreshold: 1.0 });
+    const result = WindtunnelLockSchema.safeParse(lock);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects negative cullRateThreshold (C5)', () => {
+    const lock = validLock({ cullRateThreshold: -0.1 });
+    const result = WindtunnelLockSchema.safeParse(lock);
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts cullRateThreshold = 0 (boundary)', () => {
+    const lock = validLock({ cullRateThreshold: 0 });
+    const result = WindtunnelLockSchema.safeParse(lock);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects activeRulesEvaluated.floor < 2', () => {
+    const lock = validLock();
+    lock.exposureDenominator.activeRulesEvaluated.floor = 1;
+    const result = WindtunnelLockSchema.safeParse(lock);
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts activeRulesEvaluated.floor = 2 (boundary)', () => {
+    const lock = validLock();
+    lock.exposureDenominator.activeRulesEvaluated.floor = 2;
+    const result = WindtunnelLockSchema.safeParse(lock);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects unknown phase', () => {
+    const lock = validLock({ phase: 'unknown' });
+    const result = WindtunnelLockSchema.safeParse(lock);
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-40-hex mergeCommit', () => {
+    const lock = validLock();
+    (lock.corpus as Record<string, unknown>).resolvedPrs = [
+      { pr: 1, mergeCommit: 'short', baseSha: VALID_SHA, headSha: VALID_SHA_2 },
+    ];
+    const result = WindtunnelLockSchema.safeParse(lock);
+    expect(result.success).toBe(false);
+  });
+});
+
+// ─── firingLabelId ───────────────────────────────────
+
+describe('firingLabelId (A2)', () => {
+  it('returns a 64-char hex SHA-256', () => {
+    const id = firingLabelId('rule-abc', 42, 'src/foo.ts', 'const secret = "abc"');
+    expect(id).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('is deterministic for the same inputs', () => {
+    const a = firingLabelId('rule-abc', 42, 'src/foo.ts', 'const secret = "abc"');
+    const b = firingLabelId('rule-abc', 42, 'src/foo.ts', 'const secret = "abc"');
+    expect(a).toBe(b);
+  });
+
+  it('differs when ruleId differs', () => {
+    const a = firingLabelId('rule-abc', 42, 'src/foo.ts', 'line');
+    const b = firingLabelId('rule-def', 42, 'src/foo.ts', 'line');
+    expect(a).not.toBe(b);
+  });
+
+  it('differs when pr differs', () => {
+    const a = firingLabelId('rule-abc', 1, 'src/foo.ts', 'line');
+    const b = firingLabelId('rule-abc', 2, 'src/foo.ts', 'line');
+    expect(a).not.toBe(b);
+  });
+
+  it('normalizes Windows backslash paths (A3)', () => {
+    const forward = firingLabelId('rule', 1, 'src/foo.ts', 'line');
+    const backward = firingLabelId('rule', 1, 'src\\foo.ts', 'line');
+    expect(forward).toBe(backward);
+  });
+});

--- a/packages/core/src/spine/windtunnel-lock.ts
+++ b/packages/core/src/spine/windtunnel-lock.ts
@@ -56,7 +56,10 @@ export const WindtunnelLockSchema = z
       negativeRef: z.string(),
       integrity: z.object({
         mechanism: z.string(),
-        fixtureSha: z.string(),
+        // fixtureSha is a git hash-object digest (40-hex) that feeds the
+        // hard-error integrity gate — validate its format here so a malformed
+        // value fails at parse, not cryptically at run (greptile P2).
+        fixtureSha: z.string().regex(COMMIT_SHA_REGEX, 'fixtureSha must be a 40-hex SHA'),
       }),
     }),
     cullRateThreshold: z

--- a/packages/core/src/spine/windtunnel-lock.ts
+++ b/packages/core/src/spine/windtunnel-lock.ts
@@ -1,0 +1,132 @@
+import { createHash } from 'node:crypto';
+
+import { z } from 'zod';
+
+// ─── Named constants ─────────────────────────────────
+
+const COMMIT_SHA_REGEX = /^[0-9a-f]{40}$/;
+const MIN_ACTIVE_RULES_FLOOR = 2;
+
+// ─── Sub-schemas ─────────────────────────────────────
+
+const ResolvedPrSchema = z.object({
+  pr: z.number().int().positive(),
+  mergeCommit: z.string().regex(COMMIT_SHA_REGEX, 'mergeCommit must be a 40-hex SHA'),
+  baseSha: z.string().regex(COMMIT_SHA_REGEX, 'baseSha must be a 40-hex SHA'),
+  headSha: z.string().regex(COMMIT_SHA_REGEX, 'headSha must be a 40-hex SHA'),
+  diffSha: z.string().regex(COMMIT_SHA_REGEX, 'diffSha must be a 40-hex SHA').optional(),
+});
+
+// ─── Main schema ─────────────────────────────────────
+
+export const WindtunnelLockSchema = z
+  .object({
+    schema: z.literal('windtunnel.lock.v1'),
+    canonicalPath: z.string(),
+    gate: z.string(),
+    // frozenAt.commit is NOT trusted as a freeze proof (C3 — proof is git-derived at run time).
+    frozenAt: z
+      .object({
+        timestamp: z.string().optional(),
+        commit: z.string().optional(),
+      })
+      .optional(),
+    phase: z.enum(['harness', 'certifying']),
+    corpus: z.object({
+      repo: z.string(),
+      selectionRule: z.object({
+        state: z.string(),
+        predicate: z.string(),
+        window: z.discriminatedUnion('type', [
+          z.object({ type: z.literal('all') }),
+          z.object({ type: z.literal('bounded'), n: z.number().int().positive() }),
+        ]),
+        asOfCommit: z.string().regex(COMMIT_SHA_REGEX, 'asOfCommit must be a 40-hex SHA'),
+      }),
+      resolvedPrs: z.array(ResolvedPrSchema).min(1, 'resolvedPrs must be non-empty'),
+    }),
+    fpDefinition: z.object({
+      rubricRef: z.string(),
+      groundTruthRef: z.string(),
+      adjudicator: z.string(),
+      precisionFloor: z.literal(1.0),
+    }),
+    controls: z.object({
+      positiveRef: z.string(),
+      negativeRef: z.string(),
+      integrity: z.object({
+        mechanism: z.string(),
+        fixtureSha: z.string(),
+      }),
+    }),
+    cullRateThreshold: z
+      .number()
+      .min(0, 'cullRateThreshold must be >= 0')
+      .lt(1, 'cullRateThreshold must be < 1'),
+    exposureDenominator: z.object({
+      activeRulesEvaluated: z.object({
+        floor: z
+          .number()
+          .int()
+          .min(
+            MIN_ACTIVE_RULES_FLOOR,
+            `activeRulesEvaluated.floor must be >= ${MIN_ACTIVE_RULES_FLOOR}`,
+          ),
+      }),
+      filesTouchedInWindow: z.object({
+        floor: z.number().int().nonnegative(),
+      }),
+      positiveControlsExercised: z.object({
+        floor: z.number().int().nonnegative(),
+      }),
+    }),
+  })
+  .superRefine((data, ctx) => {
+    const prs = data.corpus.resolvedPrs;
+    const prNums = prs.map((p) => p.pr);
+
+    // C4: unique pr numbers
+    const uniquePrs = new Set(prNums);
+    if (uniquePrs.size !== prNums.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'resolvedPrs must have unique pr numbers',
+        path: ['corpus', 'resolvedPrs'],
+      });
+    }
+
+    // C4: sorted ascending by pr number
+    const sortedPrNums = [...prNums].sort((a, b) => a - b);
+    for (let i = 0; i < prNums.length; i++) {
+      if (prNums[i] !== sortedPrNums[i]) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'resolvedPrs must be sorted ascending by pr number',
+          path: ['corpus', 'resolvedPrs'],
+        });
+        break;
+      }
+    }
+  });
+
+export type WindtunnelLock = z.infer<typeof WindtunnelLockSchema>;
+
+// ─── Utilities ───────────────────────────────────────
+
+/**
+ * Compute a content-based per-firing label id (A2).
+ * Keyed on hash(ruleId + pr + filePath + normalizedMatchedLineText) to survive
+ * line-drift without raw line-number anchoring.
+ */
+export function firingLabelId(
+  ruleId: string,
+  pr: number,
+  filePath: string,
+  normalizedMatchedLineText: string,
+): string {
+  // A3: normalize path to forward-slash (Windows cross-platform)
+  const normalizedPath = filePath.replace(/\\/g, '/');
+  return createHash('sha256')
+    .update(`${ruleId}\x00${pr}\x00${normalizedPath}\x00${normalizedMatchedLineText}`)
+    .digest('hex');
+}

--- a/packages/core/src/spine/windtunnel-parity.test.ts
+++ b/packages/core/src/spine/windtunnel-parity.test.ts
@@ -1,0 +1,242 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { enrichWithAstContext } from '../ast-gate.js';
+import type { CompiledRule, DiffAddition, Violation } from '../compiler-schema.js';
+import { applyAstRulesToAdditions, applyRulesToAdditions } from '../rule-engine.js';
+import { cleanTmpDir, makeRuleEngineCtx } from '../test-utils.js';
+
+/**
+ * Bidirectional firing-parity test for the wind-tunnel readStrategy seam
+ * (S1+C1, .totem/specs/2188.md Invariants).
+ *
+ * The wind-tunnel replays each PR's diff against the rule engine and must
+ * observe the SAME firings production `totem lint` would observe — otherwise
+ * it measures a different engine than Gate 2 arms. The seam that makes this
+ * exact is the post-image `readStrategy` injected into BOTH
+ * `enrichWithAstContext` (regex `astContext` classification) and
+ * `applyAstRulesToAdditions` (whole-file AST parsing). This file proves parity
+ * is bidirectional:
+ *
+ *   - OVER-FIRE (C1): a regex match that lands inside a comment/string must NOT
+ *     become a violation. Production suppresses it via `astContext`; the replay,
+ *     fed the same post-image content through the same seam, must suppress it
+ *     identically. Caught by comparing readStrategy-fed firings to disk-fed
+ *     firings (the production baseline) — they must be equal.
+ *   - UNDER-FIRE (S1): an AST/ast-grep rule needs the whole post-image file, not
+ *     just the additions. The readStrategy supplying that post-image must fire
+ *     identically to the same content read from disk.
+ */
+
+// ─── Named constants ─────────────────────────────────
+
+const SRC_FILE = 'src/app.ts';
+const DEBUGGER_RULE: CompiledRule = {
+  lessonHash: 'wt-parity-debugger',
+  lessonHeading: 'No debugger statements',
+  // Matches the literal token `debugger` — appears in both code and a comment
+  // in the fixture below, so astContext is what decides over-firing.
+  pattern: 'debugger',
+  message: 'debugger statement',
+  engine: 'regex',
+  compiledAt: '2026-06-17T00:00:00.000Z',
+};
+
+const CONSOLE_LOG_AST_RULE: CompiledRule = {
+  lessonHash: 'wt-parity-console-log',
+  lessonHeading: 'No console.log',
+  pattern: '',
+  message: 'console.log call',
+  engine: 'ast-grep',
+  astGrepPattern: 'console.log($$$)',
+  compiledAt: '2026-06-17T00:00:00.000Z',
+};
+
+// Post-image fixture: the trigger token appears on a real code line (line 2)
+// AND inside a comment (line 3). A faithful replay fires a *violation* only on
+// the code line; the comment line is telemetry-only.
+const POST_IMAGE = [
+  'function run() {', // 1
+  '  debugger;', // 2 — real code → violation // totem-ignore
+  '  // debugger; left in by mistake — but this is a comment // totem-ignore', // 3 — comment → suppressed
+  '  console.log("hi");', // 4
+  '}', // 5
+].join('\n');
+
+const CODE_LINE = '  debugger;'; // totem-ignore
+const COMMENT_LINE = '  // debugger; left in by mistake — but this is a comment // totem-ignore';
+const CONSOLE_LINE = '  console.log("hi");';
+
+// ─── Helpers ─────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-wt-parity-'));
+  fs.mkdirSync(path.join(tmpDir, 'src'), { recursive: true });
+});
+
+afterEach(() => {
+  cleanTmpDir(tmpDir);
+});
+
+function additionsForDebugger(): DiffAddition[] {
+  // Both the code line and the comment line are "added" in this PR. The replay
+  // must classify each from the post-image and fire only on the code line.
+  return [
+    { file: SRC_FILE, line: CODE_LINE, lineNumber: 2, precedingLine: 'function run() {' },
+    { file: SRC_FILE, line: COMMENT_LINE, lineNumber: 3, precedingLine: CODE_LINE },
+  ];
+}
+
+/** Normalize a violation list into a comparable, order-independent shape. */
+function fingerprint(violations: Violation[]): string {
+  return violations
+    .map((v) => `${v.rule.lessonHash}|${v.file}|${v.lineNumber}|${v.line}`)
+    .sort()
+    .join('\n');
+}
+
+// ─── Assertion 1: over-fire suppression + disk/readStrategy parity (C1) ─
+
+describe('bidirectional parity — over-fire suppression (C1)', () => {
+  it('a regex match inside a comment does NOT become a violation when classified from the post-image', async () => {
+    const additions = additionsForDebugger();
+
+    // Inject the post-image content through the readStrategy seam (the path the
+    // wind-tunnel uses): line 2 classifies as code, line 3 as comment.
+    await enrichWithAstContext(additions, {
+      cwd: tmpDir,
+      readStrategy: async () => POST_IMAGE,
+    });
+
+    expect(additions[0]!.astContext).toBe('code');
+    expect(additions[1]!.astContext).toBe('comment');
+
+    const ctx = makeRuleEngineCtx();
+    const violations = applyRulesToAdditions(ctx, [DEBUGGER_RULE], additions);
+
+    // Only the real code line fires; the comment match is telemetry-only.
+    expect(violations).toHaveLength(1);
+    expect(violations[0]!.lineNumber).toBe(2);
+    expect(violations[0]!.line).toBe(CODE_LINE);
+  });
+
+  it('readStrategy-injected content fires identically to the same content on disk (replay == production)', async () => {
+    // ── Production baseline: content on disk, NO readStrategy ──
+    fs.writeFileSync(path.join(tmpDir, SRC_FILE), POST_IMAGE, 'utf-8');
+    const diskAdditions = additionsForDebugger();
+    await enrichWithAstContext(diskAdditions, { cwd: tmpDir });
+    const diskCtx = makeRuleEngineCtx();
+    const diskViolations = applyRulesToAdditions(diskCtx, [DEBUGGER_RULE], diskAdditions);
+
+    // ── Replay: identical content fed via readStrategy (file may differ on disk) ──
+    const replayAdditions = additionsForDebugger();
+    await enrichWithAstContext(replayAdditions, {
+      cwd: tmpDir,
+      readStrategy: async () => POST_IMAGE,
+    });
+    const replayCtx = makeRuleEngineCtx();
+    const replayViolations = applyRulesToAdditions(replayCtx, [DEBUGGER_RULE], replayAdditions);
+
+    // Parity: the two firing sets are byte-identical.
+    expect(fingerprint(replayViolations)).toBe(fingerprint(diskViolations));
+    expect(replayViolations).toHaveLength(1);
+    expect(replayViolations[0]!.lineNumber).toBe(2);
+  });
+
+  it('proves the seam matters: stale on-disk content would mis-suppress without the post-image', async () => {
+    // On disk the file has the debugger ON A CODE LINE (no comment); but the PR
+    // post-image moved it into a comment. Without the readStrategy seam, the
+    // replay would classify against the wrong tree. Feeding the post-image makes
+    // line 3 a comment (suppressed) — exactly what production sees for this PR.
+    const staleDisk = [
+      'function run() {',
+      '  debugger;', // totem-ignore
+      '  debugger;', // totem-ignore — on disk this is CODE
+      '  console.log("hi");',
+      '}',
+    ].join('\n');
+    fs.writeFileSync(path.join(tmpDir, SRC_FILE), staleDisk, 'utf-8');
+
+    const additions = additionsForDebugger();
+    await enrichWithAstContext(additions, {
+      cwd: tmpDir,
+      readStrategy: async () => POST_IMAGE, // the PR's actual post-image
+    });
+
+    // Line 3 is a comment in the post-image, so it is suppressed despite being
+    // code on disk — the seam decided correctly.
+    expect(additions[1]!.astContext).toBe('comment');
+    const ctx = makeRuleEngineCtx();
+    const violations = applyRulesToAdditions(ctx, [DEBUGGER_RULE], additions);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]!.lineNumber).toBe(2);
+  });
+});
+
+// ─── Assertion 2: AST whole-file seam parity (S1) ────
+
+describe('bidirectional parity — AST whole-file seam (S1)', () => {
+  it('applyAstRulesToAdditions fires identically via readStrategy and via disk (parity)', async () => {
+    const additions: DiffAddition[] = [
+      { file: SRC_FILE, line: CONSOLE_LINE, lineNumber: 4, precedingLine: COMMENT_LINE },
+    ];
+
+    // ── Production baseline: content on disk, no readStrategy ──
+    fs.writeFileSync(path.join(tmpDir, SRC_FILE), POST_IMAGE, 'utf-8');
+    const diskCtx = makeRuleEngineCtx();
+    const diskViolations = await applyAstRulesToAdditions(
+      diskCtx,
+      [CONSOLE_LOG_AST_RULE],
+      additions,
+      tmpDir,
+    );
+
+    // ── Replay: identical post-image fed via readStrategy ──
+    const replayCtx = makeRuleEngineCtx();
+    const replayViolations = await applyAstRulesToAdditions(
+      replayCtx,
+      [CONSOLE_LOG_AST_RULE],
+      additions,
+      tmpDir,
+      undefined,
+      undefined,
+      async () => POST_IMAGE,
+    );
+
+    // The AST engine parses the WHOLE post-image in both cases — firings match.
+    expect(fingerprint(replayViolations)).toBe(fingerprint(diskViolations));
+    expect(replayViolations).toHaveLength(1);
+    expect(replayViolations[0]!.lineNumber).toBe(4);
+  });
+
+  it('the post-image readStrategy lets the AST engine see whole-file context an additions-only feed lacks (under-fire guard)', async () => {
+    // The addition we evaluate is line 4 (console.log). The AST engine parses
+    // the full post-image (functions, braces) to resolve it as a call
+    // expression. A readStrategy returning ONLY the bare addition line would
+    // still parse, but the point of S1 is that the engine receives the full
+    // post-image — proven by feeding the whole file and getting the fire.
+    const additions: DiffAddition[] = [
+      { file: SRC_FILE, line: CONSOLE_LINE, lineNumber: 4, precedingLine: COMMENT_LINE },
+    ];
+
+    const ctx = makeRuleEngineCtx();
+    const violations = await applyAstRulesToAdditions(
+      ctx,
+      [CONSOLE_LOG_AST_RULE],
+      additions,
+      tmpDir,
+      undefined,
+      undefined,
+      async () => POST_IMAGE,
+    );
+
+    expect(violations).toHaveLength(1);
+    expect(violations[0]!.lineNumber).toBe(4);
+    expect(violations[0]!.rule.lessonHash).toBe(CONSOLE_LOG_AST_RULE.lessonHash);
+  });
+});

--- a/packages/core/src/spine/windtunnel-parity.test.ts
+++ b/packages/core/src/spine/windtunnel-parity.test.ts
@@ -58,6 +58,11 @@ const CONSOLE_LOG_AST_RULE: CompiledRule = {
 // Post-image fixture: the trigger token appears on a real code line (line 2)
 // AND inside a comment (line 3). A faithful replay fires a *violation* only on
 // the code line; the comment line is telemetry-only.
+//
+// The inline `// totem-ignore` markers below keep Totem's own corpus rules from
+// flagging the intentional `debugger` / `console.log` fixture tokens in this
+// test file — same pattern as ast-gate.test.ts and the pack-agent-security
+// fixtures. Bare (no ticket-ref) per the established test-fixture convention.
 const POST_IMAGE = [
   'function run() {', // 1
   '  debugger;', // 2 — real code → violation // totem-ignore

--- a/packages/core/src/spine/windtunnel-scorer.test.ts
+++ b/packages/core/src/spine/windtunnel-scorer.test.ts
@@ -1,0 +1,425 @@
+import { describe, expect, it } from 'vitest';
+
+import { firingLabelId } from './windtunnel-lock.js';
+import type { GroundTruthLabel, RuleFiring, ScorerInput } from './windtunnel-scorer.js';
+import { scoreWindtunnel } from './windtunnel-scorer.js';
+
+// ─── Helpers ─────────────────────────────────────────
+
+function makeFiring(
+  ruleId: string,
+  pr: number,
+  controlKind: RuleFiring['controlKind'],
+  matchedLine = 'const x = 1;',
+  filePath = 'src/foo.ts',
+): RuleFiring {
+  return {
+    ruleId,
+    pr,
+    filePath,
+    matchedLine,
+    controlKind,
+    labelId: firingLabelId(ruleId, pr, filePath, matchedLine),
+  };
+}
+
+function baseInput(overrides?: Partial<ScorerInput>): ScorerInput {
+  return {
+    firings: [],
+    groundTruth: new Map(),
+    positiveControlTargets: [],
+    mintedRuleIds: ['rule-a', 'rule-b'],
+    cullRateThreshold: 0.5,
+    exposureFloors: {
+      activeRulesEvaluated: 2,
+      filesTouchedInWindow: 0,
+      positiveControlsExercised: 0,
+    },
+    actualExposure: {
+      activeRulesEvaluated: 2,
+      filesTouchedInWindow: 5,
+      positiveControlsExercised: 1,
+    },
+    ...overrides,
+  };
+}
+
+// ─── FP label → FAIL ─────────────────────────────────
+
+describe('FP label → FAIL', () => {
+  it('returns FAIL when any firing is labeled FP', () => {
+    const firing = makeFiring('rule-a', 1, 'corpus');
+    const gt = new Map<string, GroundTruthLabel>([[firing.labelId, 'FP']]);
+    const result = scoreWindtunnel(baseInput({ firings: [firing], groundTruth: gt }));
+    expect(result.verdict).toBe('FAIL');
+    expect(result.precision).toBeLessThan(1);
+  });
+});
+
+// ─── Non-vacuity → FAIL ──────────────────────────────
+
+describe('positive control does not fire its target rule → FAIL', () => {
+  it('returns FAIL when positive control target rule never fires', () => {
+    const result = scoreWindtunnel(
+      baseInput({
+        positiveControlTargets: [{ pr: 10, targetRuleId: 'rule-a' }],
+        firings: [],
+      }),
+    );
+    expect(result.verdict).toBe('FAIL');
+    expect(result.nonVacuity).toBe(false);
+  });
+
+  it('returns PASS when positive control target rule fires', () => {
+    const firing = makeFiring('rule-a', 10, 'positive');
+    const gt = new Map<string, GroundTruthLabel>([[firing.labelId, 'TP']]);
+    const result = scoreWindtunnel(
+      baseInput({
+        positiveControlTargets: [{ pr: 10, targetRuleId: 'rule-a' }],
+        firings: [firing],
+        groundTruth: gt,
+      }),
+    );
+    expect(result.verdict).toBe('PASS');
+    expect(result.nonVacuity).toBe(true);
+  });
+});
+
+// ─── Negative control → culled + recorded ────────────
+
+describe('negative control fires → culled and recorded in cullLedger', () => {
+  it('culls the rule and records in cullLedger (not silently dropped)', () => {
+    const firing = makeFiring('rule-a', 99, 'negative', 'near-miss line');
+    const result = scoreWindtunnel(baseInput({ firings: [firing] }));
+    expect(result.culledCount).toBe(1);
+    expect(result.cullLedger).toHaveLength(1);
+    expect(result.cullLedger[0]!.ruleId).toBe('rule-a');
+    expect(result.cullLedger[0]!.reason).toBe('negative-control-fired');
+  });
+
+  it('does not count a culled rule as a surviving rule', () => {
+    const firing = makeFiring('rule-a', 99, 'negative');
+    const result = scoreWindtunnel(
+      baseInput({ firings: [firing], mintedRuleIds: ['rule-a', 'rule-b'] }),
+    );
+    expect(result.mintedRuleCount).toBe(2);
+    expect(result.culledCount).toBe(1);
+    expect(result.survivingRuleCount).toBe(1);
+  });
+});
+
+// ─── Unlabeled firing → needsAdjudication (not PASS) ─
+
+describe('unlabeled firing → needsAdjudication, not PASS', () => {
+  it('returns HONEST-NEGATIVE with firing in needsAdjudication when label is missing', () => {
+    const firing = makeFiring('rule-a', 1, 'corpus');
+    // No groundTruth entry for this firing
+    const result = scoreWindtunnel(baseInput({ firings: [firing], groundTruth: new Map() }));
+    expect(result.verdict).toBe('HONEST-NEGATIVE');
+    expect(result.needsAdjudication).toContain(firing.labelId);
+  });
+});
+
+// ─── Exposure floor trip → HONEST-NEGATIVE (P2) ──────
+
+describe('exposure floor check (P2)', () => {
+  it('returns HONEST-NEGATIVE when activeRules < floor', () => {
+    const result = scoreWindtunnel(
+      baseInput({
+        actualExposure: {
+          activeRulesEvaluated: 1,
+          filesTouchedInWindow: 5,
+          positiveControlsExercised: 0,
+        },
+        exposureFloors: {
+          activeRulesEvaluated: 2,
+          filesTouchedInWindow: 0,
+          positiveControlsExercised: 0,
+        },
+      }),
+    );
+    expect(result.verdict).toBe('HONEST-NEGATIVE');
+  });
+
+  it('returns PASS when activeRules exactly equals floor = 2 (P2 equality boundary)', () => {
+    const result = scoreWindtunnel(
+      baseInput({
+        actualExposure: {
+          activeRulesEvaluated: 2,
+          filesTouchedInWindow: 5,
+          positiveControlsExercised: 0,
+        },
+        exposureFloors: {
+          activeRulesEvaluated: 2,
+          filesTouchedInWindow: 0,
+          positiveControlsExercised: 0,
+        },
+      }),
+    );
+    // All firings empty + labeled TP by default → PASS
+    expect(result.verdict).toBe('PASS');
+  });
+
+  it('returns HONEST-NEGATIVE when activeRules = 1 (below floor 2, P2)', () => {
+    const result = scoreWindtunnel(
+      baseInput({
+        actualExposure: {
+          activeRulesEvaluated: 1,
+          filesTouchedInWindow: 0,
+          positiveControlsExercised: 0,
+        },
+      }),
+    );
+    expect(result.verdict).toBe('HONEST-NEGATIVE');
+  });
+
+  it('returns HONEST-NEGATIVE when positiveControls < positiveControlsExercised floor', () => {
+    const result = scoreWindtunnel(
+      baseInput({
+        actualExposure: {
+          activeRulesEvaluated: 3,
+          filesTouchedInWindow: 5,
+          positiveControlsExercised: 0,
+        },
+        exposureFloors: {
+          activeRulesEvaluated: 2,
+          filesTouchedInWindow: 0,
+          positiveControlsExercised: 2,
+        },
+      }),
+    );
+    expect(result.verdict).toBe('HONEST-NEGATIVE');
+  });
+
+  it('passes when positiveControls exactly equals floor (P2 equality boundary)', () => {
+    const result = scoreWindtunnel(
+      baseInput({
+        actualExposure: {
+          activeRulesEvaluated: 3,
+          filesTouchedInWindow: 5,
+          positiveControlsExercised: 2,
+        },
+        exposureFloors: {
+          activeRulesEvaluated: 2,
+          filesTouchedInWindow: 0,
+          positiveControlsExercised: 2,
+        },
+      }),
+    );
+    expect(result.verdict).toBe('PASS');
+  });
+});
+
+// ─── Cull-rate guard → HONEST-NEGATIVE (C5/S2) ───────
+
+describe('cull-rate guard (C5/S2)', () => {
+  it('returns HONEST-NEGATIVE when cull rate exceeds threshold', () => {
+    // 2 minted, 2 culled → rate = 1.0 > threshold 0.5
+    const firingA = makeFiring('rule-a', 99, 'negative');
+    const firingB = makeFiring('rule-b', 99, 'negative', 'other line');
+    const result = scoreWindtunnel(
+      baseInput({
+        firings: [firingA, firingB],
+        mintedRuleIds: ['rule-a', 'rule-b'],
+        cullRateThreshold: 0.5,
+      }),
+    );
+    expect(result.verdict).toBe('HONEST-NEGATIVE');
+    expect(result.culledCount).toBe(2);
+  });
+
+  it('does not apply cull-rate guard when mintedRuleCount = 0 (harness phase)', () => {
+    const result = scoreWindtunnel(
+      baseInput({
+        mintedRuleIds: [],
+        firings: [],
+        cullRateThreshold: 0.0,
+        // Need actualExposure to pass floor check even with 0 minted
+        exposureFloors: {
+          activeRulesEvaluated: 0,
+          filesTouchedInWindow: 0,
+          positiveControlsExercised: 0,
+        },
+        actualExposure: {
+          activeRulesEvaluated: 0,
+          filesTouchedInWindow: 0,
+          positiveControlsExercised: 0,
+        },
+      }),
+    );
+    // No minted rules, no firings → PASS (vacuous but valid for harness)
+    expect(result.verdict).toBe('PASS');
+  });
+});
+
+// ─── exposureTuple is always a 3-tuple (never collapsed) ─
+
+describe('exposureTuple invariant', () => {
+  it('emits a 3-tuple, never collapsed to a product', () => {
+    const result = scoreWindtunnel(baseInput());
+    expect(Array.isArray(result.exposureTuple)).toBe(true);
+    expect(result.exposureTuple).toHaveLength(3);
+    expect(typeof result.exposureTuple[0]).toBe('number');
+    expect(typeof result.exposureTuple[1]).toBe('number');
+    expect(typeof result.exposureTuple[2]).toBe('number');
+  });
+});
+
+// ─── Precision over surviving rules (S2) ─────────────
+
+describe('precision is over surviving rules (S2)', () => {
+  it('labels precision as over surviving rules after culling', () => {
+    const culled = makeFiring('rule-a', 99, 'negative');
+    const tp = makeFiring('rule-b', 1, 'corpus');
+    const gt = new Map<string, GroundTruthLabel>([[tp.labelId, 'TP']]);
+    const result = scoreWindtunnel(
+      baseInput({
+        firings: [culled, tp],
+        mintedRuleIds: ['rule-a', 'rule-b'],
+        groundTruth: gt,
+        cullRateThreshold: 0.9,
+      }),
+    );
+    expect(result.verdict).toBe('PASS');
+    expect(result.precision).toBe(1.0);
+    expect(result.culledCount).toBe(1);
+    expect(result.survivingRuleCount).toBe(1);
+  });
+});
+
+// ─── Mock engine: always-0 fires → FAIL vacuity ──────
+
+describe('OQ2: mock engine coverage', () => {
+  it('mock always-0 engine: positive control target never fires → FAIL', () => {
+    // Always-0 engine: no firings. Positive control target expects rule-a.
+    const result = scoreWindtunnel(
+      baseInput({
+        firings: [], // always-0: never fires
+        positiveControlTargets: [{ pr: 1, targetRuleId: 'rule-a' }],
+      }),
+    );
+    expect(result.verdict).toBe('FAIL');
+  });
+
+  it('mock always-1 engine: fires on negative control → culled, possibly HONEST-NEGATIVE', () => {
+    // Always-1 engine fires on the negative control
+    const negFiring = makeFiring('rule-a', 99, 'negative', 'near-miss');
+    const result = scoreWindtunnel(
+      baseInput({
+        firings: [negFiring],
+        mintedRuleIds: ['rule-a'],
+        cullRateThreshold: 0.5,
+      }),
+    );
+    // 1 minted, 1 culled → rate = 1.0 > 0.5 → HONEST-NEGATIVE
+    expect(result.verdict).toBe('HONEST-NEGATIVE');
+    expect(result.cullLedger).toHaveLength(1);
+  });
+
+  it('mock exposure-floor-trip engine → HONEST-NEGATIVE', () => {
+    const result = scoreWindtunnel(
+      baseInput({
+        actualExposure: {
+          activeRulesEvaluated: 1,
+          filesTouchedInWindow: 0,
+          positiveControlsExercised: 0,
+        },
+        exposureFloors: {
+          activeRulesEvaluated: 2,
+          filesTouchedInWindow: 0,
+          positiveControlsExercised: 0,
+        },
+      }),
+    );
+    expect(result.verdict).toBe('HONEST-NEGATIVE');
+  });
+
+  it('mock unlabeled-firing engine → needs-adjudication HONEST-NEGATIVE', () => {
+    const firing = makeFiring('rule-a', 5, 'corpus', 'some matched line');
+    // No groundTruth labels → unlabeled
+    const result = scoreWindtunnel(
+      baseInput({
+        firings: [firing],
+        groundTruth: new Map(),
+      }),
+    );
+    expect(result.verdict).toBe('HONEST-NEGATIVE');
+    expect(result.needsAdjudication).toHaveLength(1);
+    expect(result.needsAdjudication[0]).toBe(firing.labelId);
+  });
+
+  it('mock perfect engine: all TPs, positive control fires, exposure met → PASS', () => {
+    const corpusFiring = makeFiring('rule-a', 1, 'corpus', 'pattern match');
+    const positiveFiring = makeFiring('rule-a', 10, 'positive', 'target match');
+    const gt = new Map<string, GroundTruthLabel>([
+      [corpusFiring.labelId, 'TP'],
+      [positiveFiring.labelId, 'TP'],
+    ]);
+    const result = scoreWindtunnel(
+      baseInput({
+        firings: [corpusFiring, positiveFiring],
+        groundTruth: gt,
+        positiveControlTargets: [{ pr: 10, targetRuleId: 'rule-a' }],
+      }),
+    );
+    expect(result.verdict).toBe('PASS');
+    expect(result.precision).toBe(1.0);
+    expect(result.nonVacuity).toBe(true);
+  });
+});
+
+// ─── Bidirectional parity concept (S1+C1) ────────────
+
+describe('bidirectional parity (S1+C1)', () => {
+  it('negative fixture: regex match suppressed in comment must not appear as TP', () => {
+    // Simulate a firing that should be FP (comment/string context suppressed in production)
+    const firing = makeFiring('rule-a', 1, 'corpus', '// const secret = "abc"');
+    const gt = new Map<string, GroundTruthLabel>([[firing.labelId, 'FP']]);
+    const result = scoreWindtunnel(baseInput({ firings: [firing], groundTruth: gt }));
+    expect(result.verdict).toBe('FAIL');
+    expect(result.precision).toBeLessThan(1.0);
+  });
+});
+
+// ─── Label identity (A2) ─────────────────────────────
+
+describe('content-based firing label id (A2)', () => {
+  it('same content → same label id (deterministic)', () => {
+    const id1 = firingLabelId('rule-a', 1, 'src/foo.ts', 'const x = 1;');
+    const id2 = firingLabelId('rule-a', 1, 'src/foo.ts', 'const x = 1;');
+    expect(id1).toBe(id2);
+  });
+
+  it('different matched line → different label id (survives line-drift)', () => {
+    const id1 = firingLabelId('rule-a', 1, 'src/foo.ts', 'const x = 1;');
+    const id2 = firingLabelId('rule-a', 1, 'src/foo.ts', 'const y = 2;');
+    expect(id1).not.toBe(id2);
+  });
+});
+
+// ─── Phase (P1) ──────────────────────────────────────
+
+describe('phase discrimination (P1)', () => {
+  it('harness lock emits PASS at harness phase with zero minted rules', () => {
+    // Harness phase: mintedRuleCount ≈ 0, exposureFloors allow it
+    const result = scoreWindtunnel(
+      baseInput({
+        mintedRuleIds: [],
+        firings: [],
+        exposureFloors: {
+          activeRulesEvaluated: 0,
+          filesTouchedInWindow: 0,
+          positiveControlsExercised: 0,
+        },
+        actualExposure: {
+          activeRulesEvaluated: 0,
+          filesTouchedInWindow: 0,
+          positiveControlsExercised: 0,
+        },
+      }),
+    );
+    // Zero rules, zero firings → vacuous PASS (valid for harness)
+    expect(result.verdict).toBe('PASS');
+    expect(result.mintedRuleCount).toBe(0);
+  });
+});

--- a/packages/core/src/spine/windtunnel-scorer.test.ts
+++ b/packages/core/src/spine/windtunnel-scorer.test.ts
@@ -368,11 +368,17 @@ describe('OQ2: mock engine coverage', () => {
   });
 });
 
-// ─── Bidirectional parity concept (S1+C1) ────────────
+// ─── Scorer-level FP handling (NOT the parity test) ──
+//
+// The real bidirectional firing-parity test (S1+C1) — replay firings ==
+// production firings through enrichWithAstContext + the rule engine, covering
+// both the regex/astContext over-fire suppression and the AST whole-file
+// under-fire cases — lives in `windtunnel-parity.test.ts`. That test exercises
+// the production classification path end-to-end; the case below only confirms
+// the scorer turns a labeled FP into a FAIL verdict.
 
-describe('bidirectional parity (S1+C1)', () => {
-  it('negative fixture: regex match suppressed in comment must not appear as TP', () => {
-    // Simulate a firing that should be FP (comment/string context suppressed in production)
+describe('scorer FP handling (see windtunnel-parity.test.ts for the real S1+C1 parity test)', () => {
+  it('a firing labeled FP (e.g. a comment-context match) yields FAIL with precision < 1', () => {
     const firing = makeFiring('rule-a', 1, 'corpus', '// const secret = "abc"');
     const gt = new Map<string, GroundTruthLabel>([[firing.labelId, 'FP']]);
     const result = scoreWindtunnel(baseInput({ firings: [firing], groundTruth: gt }));

--- a/packages/core/src/spine/windtunnel-scorer.test.ts
+++ b/packages/core/src/spine/windtunnel-scorer.test.ts
@@ -226,6 +226,9 @@ describe('cull-rate guard (C5/S2)', () => {
     );
     expect(result.verdict).toBe('HONEST-NEGATIVE');
     expect(result.culledCount).toBe(2);
+    // precision is the not-computed sentinel (0), NOT a survival ratio
+    // (survivingRuleCount / mintedRuleCount) — locks the greptile-P1 / CR fix.
+    expect(result.precision).toBe(0);
   });
 
   it('does not apply cull-rate guard when mintedRuleCount = 0 (harness phase)', () => {

--- a/packages/core/src/spine/windtunnel-scorer.ts
+++ b/packages/core/src/spine/windtunnel-scorer.ts
@@ -140,7 +140,12 @@ export function scoreWindtunnel(input: ScorerInput): WindtunnelVerdict {
   if (mintedRuleCount > 0 && culledCount / mintedRuleCount > cullRateThreshold) {
     return {
       verdict: 'HONEST-NEGATIVE',
-      precision: survivingRuleCount > 0 ? survivingRuleCount / mintedRuleCount : 0,
+      // precision is NOT computed here (this returns before FP/TP adjudication
+      // at Step 5), so report the same "not-computed" sentinel the exposure-floor
+      // HONEST-NEGATIVE path uses (0) — never a survival ratio mislabeled as
+      // precision. Whether a HONEST-NEGATIVE should instead carry the real
+      // precision-over-survivors is a §4/§5 contract question deferred to #2189.
+      precision: 0,
       mintedRuleCount,
       culledCount,
       survivingRuleCount,

--- a/packages/core/src/spine/windtunnel-scorer.ts
+++ b/packages/core/src/spine/windtunnel-scorer.ts
@@ -1,0 +1,253 @@
+// ─── Types ──────────────────────────────────────────
+
+export type WindtunnelVerdictKind = 'PASS' | 'HONEST-NEGATIVE' | 'FAIL';
+export type GroundTruthLabel = 'TP' | 'FP';
+
+export interface CullLedgerEntry {
+  ruleId: string;
+  pr: number;
+  filePath: string;
+  matchedLine: string;
+  reason: 'negative-control-fired';
+}
+
+export interface WindtunnelVerdict {
+  verdict: WindtunnelVerdictKind;
+  /** Precision over surviving rules (after cull). */
+  precision: number;
+  mintedRuleCount: number;
+  culledCount: number;
+  survivingRuleCount: number;
+  /** 3-tuple: [activeRulesEvaluated, filesTouchedInWindow, positiveControlsExercised]. Never collapsed to a product. */
+  exposureTuple: [number, number, number];
+  cullLedger: CullLedgerEntry[];
+  /** True when all positive controls fired their target rule. */
+  nonVacuity: boolean;
+  /** Label ids of firings with no ground-truth label (operator adjudication required). */
+  needsAdjudication: string[];
+}
+
+export interface RuleFiring {
+  ruleId: string;
+  pr: number;
+  filePath: string;
+  matchedLine: string;
+  controlKind: 'corpus' | 'positive' | 'negative';
+  /** For positive controls: the rule that MUST fire to prove non-vacuousness. */
+  targetRuleId?: string;
+  /** Content-based label id (A2). Compute via firingLabelId from windtunnel-lock. */
+  labelId: string;
+}
+
+export interface ScorerInput {
+  firings: RuleFiring[];
+  /** Maps firingLabelId → TP/FP label. Unlabeled firings ⇒ needsAdjudication. */
+  groundTruth: Map<string, GroundTruthLabel>;
+  positiveControlTargets: Array<{ pr: number; targetRuleId: string }>;
+  mintedRuleIds: string[];
+  cullRateThreshold: number;
+  exposureFloors: {
+    activeRulesEvaluated: number;
+    filesTouchedInWindow: number;
+    positiveControlsExercised: number;
+  };
+  actualExposure: {
+    activeRulesEvaluated: number;
+    filesTouchedInWindow: number;
+    positiveControlsExercised: number;
+  };
+}
+
+// ─── Pure scorer ─────────────────────────────────────
+
+/**
+ * Score a wind-tunnel run. Pure function: no IO, no clock, no randomness.
+ * Implements ADR-110 §4/§5 done-criterion exactly per spec invariants.
+ *
+ * Verdict ordering (highest precedence first):
+ *   1. Exposure floor below minimum → HONEST-NEGATIVE (masquerade guard)
+ *   2. Cull rate exceeds threshold → HONEST-NEGATIVE (cull-laundering guard)
+ *   3. Positive control does not fire its target → FAIL (vacuous pass)
+ *   4. Any firing labeled FP → FAIL (precision < 1.0)
+ *   5. Any unlabeled firing → HONEST-NEGATIVE (needs adjudication, not PASS)
+ *   6. All labeled TP → PASS
+ */
+export function scoreWindtunnel(input: ScorerInput): WindtunnelVerdict {
+  const {
+    firings,
+    groundTruth,
+    positiveControlTargets,
+    mintedRuleIds,
+    cullRateThreshold,
+    exposureFloors,
+    actualExposure,
+  } = input;
+
+  const mintedRuleCount = mintedRuleIds.length;
+  const cullLedger: CullLedgerEntry[] = [];
+  const needsAdjudication: string[] = [];
+
+  // Step 1: Cull rules that fire on negative controls (S2/C5).
+  // A rule firing on ANY negative-control item is culled + recorded in
+  // cullLedger. Never silently dropped.
+  const culledRuleIds = new Set<string>();
+  for (const firing of firings) {
+    if (firing.controlKind === 'negative') {
+      culledRuleIds.add(firing.ruleId);
+      cullLedger.push({
+        ruleId: firing.ruleId,
+        pr: firing.pr,
+        filePath: firing.filePath.replace(/\\/g, '/'),
+        matchedLine: firing.matchedLine,
+        reason: 'negative-control-fired',
+      });
+    }
+  }
+
+  const culledCount = culledRuleIds.size;
+  const survivingRuleCount = mintedRuleCount - culledCount;
+
+  // Exposure tuple: always a 3-tuple, never collapsed (spec invariant).
+  const exposureTuple: [number, number, number] = [
+    actualExposure.activeRulesEvaluated,
+    actualExposure.filesTouchedInWindow,
+    actualExposure.positiveControlsExercised,
+  ];
+
+  // Step 2: Exposure floor check (P2).
+  // activeRules < floor or positiveControls < floor → HONEST-NEGATIVE.
+  if (
+    actualExposure.activeRulesEvaluated < exposureFloors.activeRulesEvaluated ||
+    actualExposure.positiveControlsExercised < exposureFloors.positiveControlsExercised
+  ) {
+    return {
+      verdict: 'HONEST-NEGATIVE',
+      precision: 0,
+      mintedRuleCount,
+      culledCount,
+      survivingRuleCount,
+      exposureTuple,
+      cullLedger,
+      nonVacuity: false,
+      needsAdjudication,
+    };
+  }
+
+  // Step 3: Cull-rate guard (C5/S2).
+  // culledCount / mintedRuleCount > threshold → HONEST-NEGATIVE.
+  // Guard applies only when mintedRuleCount > 0 (avoids division by zero at
+  // harness phase where mintedRuleCount ≈ 0).
+  if (mintedRuleCount > 0 && culledCount / mintedRuleCount > cullRateThreshold) {
+    return {
+      verdict: 'HONEST-NEGATIVE',
+      precision: survivingRuleCount > 0 ? survivingRuleCount / mintedRuleCount : 0,
+      mintedRuleCount,
+      culledCount,
+      survivingRuleCount,
+      exposureTuple,
+      cullLedger,
+      nonVacuity: false,
+      needsAdjudication,
+    };
+  }
+
+  // Step 4: Positive control non-vacuity check.
+  // Every positive control target must have its targetRuleId fire on an
+  // uncalled rule (not culled). A vacuous pass (rule never fires) → FAIL.
+  let nonVacuity = true;
+  for (const target of positiveControlTargets) {
+    const fired = firings.some(
+      (f) =>
+        f.controlKind === 'positive' &&
+        f.pr === target.pr &&
+        f.ruleId === target.targetRuleId &&
+        !culledRuleIds.has(f.ruleId),
+    );
+    if (!fired) {
+      nonVacuity = false;
+      break;
+    }
+  }
+
+  if (!nonVacuity) {
+    return {
+      verdict: 'FAIL',
+      precision: 0,
+      mintedRuleCount,
+      culledCount,
+      survivingRuleCount,
+      exposureTuple,
+      cullLedger,
+      nonVacuity: false,
+      needsAdjudication,
+    };
+  }
+
+  // Step 5: Check FP labels and collect unlabeled firings.
+  // Scope: non-negative-control, non-culled firings only.
+  let hasFp = false;
+  let tpCount = 0;
+  let labeledCount = 0;
+
+  for (const firing of firings) {
+    if (firing.controlKind === 'negative') continue;
+    if (culledRuleIds.has(firing.ruleId)) continue;
+
+    const label = groundTruth.get(firing.labelId);
+    if (label === undefined) {
+      needsAdjudication.push(firing.labelId);
+    } else if (label === 'FP') {
+      hasFp = true;
+      labeledCount++;
+    } else {
+      tpCount++;
+      labeledCount++;
+    }
+  }
+
+  // FP → FAIL (precision < 1.0; zero-confirmed-FP floor violated)
+  if (hasFp) {
+    const precision = labeledCount > 0 ? tpCount / labeledCount : 0;
+    return {
+      verdict: 'FAIL',
+      precision,
+      mintedRuleCount,
+      culledCount,
+      survivingRuleCount,
+      exposureTuple,
+      cullLedger,
+      nonVacuity: true,
+      needsAdjudication,
+    };
+  }
+
+  // Unlabeled firings → not PASS (operator must adjudicate first)
+  if (needsAdjudication.length > 0) {
+    const precision = labeledCount > 0 ? tpCount / labeledCount : 1.0;
+    return {
+      verdict: 'HONEST-NEGATIVE',
+      precision,
+      mintedRuleCount,
+      culledCount,
+      survivingRuleCount,
+      exposureTuple,
+      cullLedger,
+      nonVacuity: true,
+      needsAdjudication,
+    };
+  }
+
+  // All firings labeled TP, exposure floors met, positive controls verified → PASS
+  const precision = labeledCount > 0 ? tpCount / labeledCount : 1.0;
+  return {
+    verdict: 'PASS',
+    precision,
+    mintedRuleCount,
+    culledCount,
+    survivingRuleCount,
+    exposureTuple,
+    cullLedger,
+    nonVacuity: true,
+    needsAdjudication: [],
+  };
+}


### PR DESCRIPTION
## Summary

Gate-1 **wind-tunnel evidence harness** — slice 2 of Proposal 299 (the provenance/`ruleClass` marker landed in #2183). This is the falsifiable acceptance engine ADR-110 operationalizes: it scores regenerated rules over a frozen lc corpus + controls and emits a non-vacuous PASS / HONEST-NEGATIVE / FAIL verdict.

Per the ratified **harness-only-now** scope (OQ2): the schema, pure scorer, freeze/run plumbing, the firing-parity seam, and the mock-engine validation ship now; the real certifying run rides post-strategy#516 once rules exist. Building the wind-tunnel before the plane flies is the point.

## What's in it

- **`@mmnto/core`**
  - `spine/windtunnel-lock.ts` — `WindtunnelLockSchema` (`windtunnel.lock.v1`) + `firingLabelId` (content-based, line-drift-immune).
  - `spine/windtunnel-scorer.ts` — pure scorer (no IO/clock/randomness) implementing the ADR-110 §4/§5 done-criterion.
  - `ast-gate.ts` — additive `readStrategy` injection seam (default-unchanged for normal lint) so a replay can feed post-image content to both regex `astContext` classification and the AST engine.
- **`@mmnto/cli`** — `totem spine windtunnel <freeze|run>` (new `spine` command group), `--lc-dir`, git-derived freeze proof, mandatory control-fixture integrity.
- **Tests** — schema invariants, scorer verdicts (incl. HONEST-NEGATIVE + needs-adjudication), a **bidirectional firing-parity test** through the real engine (over-fire suppression with a stale-disk discriminator + AST whole-file parity), and the CLI freeze-proof / integrity / readStrategy paths against real throwaway git repos.

## Provenance

Design contract authored against the real code and ratified before build:
strategy-claude lens **APPROVE** (4 sharpenings folded) → pre-build review panel **codex** (contract) / **gemini** (tenet) / **agy** (build-completeness) → codex CONCERN folded (5 blocking + 3 precision) → codex **re-confirm CONFIRM**. Then `totem review` (3 rounds, each a real fix) → **PASS**. Full design in `.totem/specs/2188.md`.

## Deferrals (tracked)

Three items are deliberately deferred to the post-#516 certifying build and tracked in **#2189**: wiring the shared `readStrategy` into the `run` engine path (the seam is unit-proven now), the S4 full `resolvedPrs === selectionRule(asOfCommit)` re-derivation (currently accessibility + ancestry + structured-schema), and ratifying the scorer's verdict precedence (exposure-floor/cull-rate vs FP→FAIL).

## Gate

Build (core+cli, 0 errors) · `totem lint --base main` PASS (0 errors) · `format:check` clean · tests (core 2465 + cli 2608) · `totem review` PASS. No `lesson compile` (freeze respected).

Closes #2188
Refs #2189 · ADR-110 (mmnto-ai/totem-strategy#669) · Proposal 299 (strategy#661) · strategy#516

🤖 Generated with [Claude Code](https://claude.com/claude-code)
