### PR TITLE
feat(spine): S4 corpus selectionRule re-derivation — deterministic offline resolver + hard-error completeness gate (#2189 item 2)

### DIFF
--- a/.changeset/s4-selectionrule-resolver-2189.md
+++ b/.changeset/s4-selectionrule-resolver-2189.md
@@ -1,0 +1,12 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+---
+
+Wind-tunnel S4 corpus re-derivation (mmnto-ai/totem#2189 item 2) — the deterministic `selectionRule(asOfCommit)` resolver behind ADR-110 §6.
+
+- **New pure module `@mmnto/totem` `spine/selection-rule`** — the offline, deterministic corpus predicate (no GitHub-API fields, §4): `selectionRulePredicate` (code-touching + bot + revert-itself), the two-pass `resolveSelectionRule` (drops a revert PR AND its in-window target, fail-safe when the target is out-of-window), `isCodeTouching` (frozen classifier; exclude wins at the file level), `isBotIdentity` (`[bot]` suffix), `parseRevertSha`, `parsePrNumber` (trailing `(#N)`; no-ref → skip, malformed → throw), and `diffPrSets`/`prSetsEqual` (order/duplicate-invariant set-equality).
+- **`windtunnel.lock.v1` gains additive-optional `corpus.selectionRule` fields**: `codePathClassifier {includeGlobs, excludeGlobs}` (required at certifying resolve), `excludeRevertPairs` / `excludeBotPrs` (default `true`). Existing harness locks parse unchanged.
+- **`totem spine windtunnel freeze` corpus-completeness (S4) is now a hard gate at the certifying phase**: it re-derives the code-touching PR set from lc's squash history and throws on any `resolvedPrs ≢ selectionRule(asOfCommit)` divergence (naming the missing/extra PRs). The harness phase stays warn-only. All git output is CRLF/path-separator normalized.
+
+Scope note: this is item 2 of #2189. Item 1 (wire the resolver into the certifying `run`'s pre-scoring gate) remains open on strategy#516.

--- a/.totem/specs/2189.md
+++ b/.totem/specs/2189.md
@@ -154,3 +154,78 @@ No silent-degradation rows: every no-claim path emits an explicit verdict + `nul
 
 - **Q-A — Precision on vacuous-control FAIL: `null` or computed?** Options: (a) `null` — the failure is structural (a positive control's rule didn't fire), no precision claim was reached, and `0` would falsely read as all-FP; (b) compute over whatever labeled firings exist — but that conflates a structural failure with a precision measurement. **Recommendation: (a) `null`.** The ruling's "FAIL = breaching value" addressed the FP case; vacuous-control FAIL makes no precision claim.
 - **Q-B — Model `needs-adjudication` as a 4th `WindtunnelVerdictKind`, or keep `verdict='HONEST-NEGATIVE'` + populated `needsAdjudication[]`?** Options: (a) keep current array-as-discriminator; (b) add a distinct `'NEEDS-ADJUDICATION'` kind. **Recommendation: (a) keep current.** strategy-claude left the needs-adjudication-vs-HONEST-NEGATIVE ordering as my call and recommended ranking exposure-HONEST-NEGATIVE above it for the tie — both already satisfied by the array modeling; a 4th kind widens blast radius (every `switch` + the exit-code logic) for no contract gain.
+
+---
+
+## Implementation Design — Item 2 (S4 `selectionRule` corpus re-derivation)
+
+> **Slice scope: item 2 ONLY.** Item 1 (wire `readStrategy` into `run` — blocked on strategy#516) and item 3 (shipped 1.66.0) are out. Authority: strategy-claude selectionRule design pass (dispatch 2026-06-18T0432Z) + ADR-110 §6 (#676) / §4 / §97.
+
+### Scope (2 sentences)
+
+Implement the deterministic `selectionRule(asOfCommit)` resolver (the ADR-110 §6 predicate) over the lc clone, and upgrade freeze-time corpus completeness from count/warn to a **hard-error deep set-equality** check (`resolvedPrs ≡ selectionRule(asOfCommit)`, `TotemError` on divergence). It does NOT wire the check into the certifying `run`'s pre-scoring gate (that's item 1's call site — this build exposes a reusable verifier item 1 calls before `scoreWindtunnel`) and does NOT freeze the concrete PR instance / `N` (that's manifest-write, operator empirics ≈310 merged / ~117 code-touching).
+
+### Data model deltas
+
+New **optional** fields on `corpus.selectionRule` (`windtunnel-lock.ts`), additive to `windtunnel.lock.v1` — existing harness locks parse unchanged:
+
+- **`codePathClassifier?: { includeGlobs: string[]; excludeGlobs: string[] }`** — the FROZEN glob set defining "code-touching". Written at manifest-write (operator); read by the resolver. Optional in schema (harness locks omit it) but **required at certifying-phase resolve** (`TotemError` if absent — can't classify without it; no safe code-default, so never silently defaulted).
+- **`excludeRevertPairs?: boolean` (zod `.default(true)`)** + **`excludeBotPrs?: boolean` (zod `.default(true)`)** — frozen flags; the default IS strategy-claude's ratified lean (operator flips a frozen field at manifest-write, not code).
+
+New pure module `packages/core/src/spine/selection-rule.ts`:
+
+- **`PrMeta`** = git-derived facts for one merged PR: `{ pr, mergeCommit, isBotAuthor, revertsSha?, changedFiles: string[] }`.
+- **`selectionRulePredicate(meta, config): boolean`** — pure; the §6 conjuncts that operate on per-PR facts (code-touching via classifier globs + revert/bot exclusions). MERGED + ancestry are enforced upstream at enumeration (only ancestor merge commits become `PrMeta`).
+
+No runtime state containers — the resolver is a pure filter over git-derived metadata + frozen config.
+
+### State lifecycle
+
+All per-invocation. The cli enumerates merged PRs reachable from `asOfCommit` in the lc clone (`git log <asOfCommit>` + PR-number parse) via `safeExec`, builds one `PrMeta` per PR (changed files, author identity, revert-body), filters via the pure core predicate, returns a sorted unique PR-number set. No persisted or cross-call state; deterministic (same `asOfCommit` + frozen config → byte-identical set — the property that turns `≡` from a tautology into a real gate). Frozen config lives in the committed manifest (immutable post-freeze).
+
+### Failure modes
+
+| Failure                                                                          | Category | Surface                                                           | Recovery                                                                                |
+| -------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `resolvedPrs ≠ selectionRule(asOfCommit)` (membership or count)                  | runtime  | **hard error (`TotemError`)** naming the diff (missing/extra PRs) | fix manifest `resolvedPrs` or classifier; re-freeze. Voids the run upstream of §5 (§6). |
+| `codePathClassifier` absent at certifying resolve                                | runtime  | hard error (`TotemError`)                                         | add the frozen classifier to the manifest                                               |
+| lc clone inaccessible / `asOfCommit` not an ancestor of lc HEAD                  | runtime  | hard error (`TotemError`)                                         | provide a valid lc clone at/after `asOfCommit`                                          |
+| Direct-to-main commit with no `(#N)` ref (legit non-PR, e.g. `chore(deps)` bump) | runtime  | **skip** (a no-ref commit is a non-PR, not an error)              | — (correct behavior; the §6 set-equality is the real silent-drop gate)                  |
+| Genuinely **malformed** `(#N)` ref                                               | runtime  | hard error (`TotemError`)                                         | fix the enumeration convention assumption                                               |
+| Harness phase (no real corpus)                                                   | n/a      | warn-only, skip re-derivation                                     | — (existing harness tolerance preserved; certifying phase hard-errors)                  |
+
+No silent-degradation rows in certifying phase — divergence/access/parse faults are loud (Tenet 4). Harness-phase warn-only is justified: no real corpus exists to verify yet.
+
+### Invariants to lock in via tests (mocked `safeExec` git history)
+
+- Deep equality is **membership + count, not reference**: `[12,13]` vs `[13,12]` ⇒ equal; either side missing/extra ⇒ `TotemError`.
+- A `docs:`/config-only PR is EXCLUDED by the classifier; a code-touching `feat` PR reachable from `asOfCommit` is INCLUDED.
+- Boundary is **ancestry, not timestamp**: a PR whose merge commit is not an ancestor of `asOfCommit` is excluded regardless of `merged_at`.
+- `excludeRevertPairs=true` removes BOTH the revert and its target; `=false` keeps both. `excludeBotPrs=true` removes a `[bot]`-authored PR; `=false` keeps it.
+- Same `asOfCommit` + same frozen config ⇒ identical set across repeated runs (determinism).
+- Missing classifier at certifying phase throws; harness phase still warn-only.
+- **Trailing-`(#N)` extraction:** `…spec (#533) (#534)` ⇒ PR **#534** (not #533); `…(closes #522) (#524)` ⇒ **#524**. First-match would misattribute an issue-ref as the PR number.
+- **No-ref commit is skipped, not errored:** a direct-to-main commit (no `(#N)`) is a non-PR and is excluded silently; only a _malformed_ ref hard-errors.
+
+### Resolved decisions (strategy-claude concurrence, dispatch 2026-06-18T0506Z)
+
+- **Q-1 — bot + revert detection = git-convention (CONCURRED; the `author_association`/linkage wording was an API-field slip).** **Bot** = author identity ends with `[bot]`, keyed off the **PR's authored-by** (lc's squash style ⇒ the squash-commit author _is_ the PR author). **Revert** = `This reverts commit <sha>` in the commit body; exclude the named target sha. No GitHub-API fields in the predicate — preserves the §4 offline-derivation invariant (strategy-claude will offer the operator a one-line §6 amendment to codify it; does not block this build).
+- **Q-2 — lc is 100% squash-merge (derived: `git log --merges` empty, all subjects carry trailing `(#N)`).** Enumeration = walk in-ancestry from `asOfCommit`, **extract the trailing `(#N)`**, **skip no-ref commits as non-PRs** (do NOT hard-error), reserve hard-error for a genuinely malformed ref. Support the squash pattern strictly; merge-commit (`Merge pull request #N`) support is optional cheap future-proofing. The §6 set-equality vs the frozen manifest is the real divergence gate — a dropped/added/substituted PR voids the run there, not at per-commit parse.
+- **Field shapes — all three confirmed** (`codePathClassifier` required-at-certifying-resolve with `TotemError` if absent; `excludeRevertPairs`/`excludeBotPrs` additive-optional, default `true`).
+
+### Panel review folds (accepted — codex / gemini / agy, 2026-06-18 0532–0545Z)
+
+Panel result: **gemini APPROVE (no concerns); codex CONCERN (hold pending folds 1–4, pre-cleared conditional on them); agy PASS-with-concerns.** All folds are implementation-fidelity sharpenings — none challenge the settled contract.
+
+1. **Revert-pair exclusion is a resolver-level TWO-PASS, NOT the pure predicate** (codex blocking + agy). The pure `selectionRulePredicate(meta, config)` over a single `PrMeta` can drop the revert PR itself (via `meta.revertsSha`) but CANNOT drop the reverted _target_ (whose `mergeCommit` matches another PR's `revertsSha`) — that needs cross-candidate context. Resolver shape: (a) enumerate ancestor PR metas; (b) build `revertedTargetShas` from every meta carrying `revertsSha`; (c) apply the per-PR predicate (code-touching / bot / revert-itself); (d) drop any candidate whose `mergeCommit ∈ revertedTargetShas`; (e) **fail-safe** — a target sha not mapping to an in-window candidate (direct-to-main or out-of-ancestry) returns `undefined` → drop only the revert PR, never hard-error. The §6 set-equality is the divergence backstop. _(This moves revert handling out of `selectionRulePredicate` into the cli/resolver layer; the pure predicate keeps code-touching + bot + revert-itself only.)_
+2. **`codePathClassifier` precedence PINNED** (codex blocking + agy): normalize all changed paths to forward-slash first; a file is code-touching iff it matches ≥1 `includeGlob` AND no `excludeGlob` — **exclude wins at the FILE level, not the PR level**; a PR is included iff ≥1 changed file survives; docs/config/generated-only PRs are excluded (no file survives); certifying-resolve without a classifier → `TotemError`, harness may warn/skip.
+3. **Malformed-trailer narrow definition** (codex + agy): no trailing `(#…)` → **skip** (non-PR, return null); a trailing but invalid ref (`(#abc)`, `(#)`, `(#0)`, `(#-123)`) → **`TotemError`**. Regex anchored end-of-subject: `/\(#(\d+)\)\s*$/`.
+4. **Symmetric-difference `TotemError`** (codex + agy): the divergence error names **missing** (in git, absent from manifest) and **extra** (in manifest, absent from git) PR-number lists separately; equality = sorted-unique membership + count, never reference/order.
+5. **Windows CRLF + path-separator hygiene** (agy — same class as the #2188 freeze-proof CRLF bug): every `safeExec` git-output splitter normalizes `\r\n`→`\n` + trims before parsing (else `\r` leaks into SHAs/paths/authors and silently breaks set-equality); all git-derived paths normalized to forward-slash before globbing. Tests mock BOTH `\r\n` and `\n` streams.
+6. **Phase-separation tested on BOTH branches** (agy): harness → warn/degrade-and-pass; certifying → hard-fail `TotemError`. Unit tests exercise both so a harness bypass can't leak into certifying.
+7. **Bot-suffix precision** (agy): `.toLowerCase().endsWith('[bot]')` on the PR authored-by; a test asserts a human handle merely _containing_ "bot" (e.g. `revertbot`) is NOT caught.
+
+### `totem review` folds (accepted)
+
+8. **Window-awareness (CRITICAL):** `resolveSelectionRule` now applies `sel.window` — `all` = every qualifying PR; `bounded { n }` = the **N most-recent qualifying PRs** (the resolver receives metas in git-log newest-first order, so it takes the first N qualifying after predicate + revert filtering). Without this a bounded lock would re-derive the full history and false-fail. **NB — flag to strategy-claude:** the bounded _count_ semantics ("N most-recent qualifying") is my defensible default; the 0432Z/0506Z dispatches pinned the membership predicate, not the window-count rule. Non-blocking — the certifying corpus is `window: all` per their empirics (≈310 merged / ~117 code-touching); bounded is not the certifying path.
+9. **Single-call enumeration (N+1 fix):** `enumeratePrMetas` uses one `git log --name-only` with a record-separator-led format (`%x1e…`) so each commit's changed-file list trails its format block in the same record — replacing an N+1 `git diff-tree`-per-commit spawn.

--- a/packages/cli/src/commands/spine-windtunnel.test.ts
+++ b/packages/cli/src/commands/spine-windtunnel.test.ts
@@ -5,13 +5,20 @@ import * as path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import type { WindtunnelLock } from '@mmnto/totem';
-import { safeExec, WindtunnelLockSchema } from '@mmnto/totem';
+import {
+  isBotIdentity,
+  parsePrNumber,
+  parseRevertSha,
+  safeExec,
+  WindtunnelLockSchema,
+} from '@mmnto/totem';
 
 import { cleanTmpDir } from '../test-utils.js';
 import {
   assertCorpusCompleteness,
   buildReadStrategy,
   computeFixtureSha,
+  enumeratePrMetas,
   isCommitAncestor,
   verifyControlIntegrity,
   verifyFreezeProof,
@@ -286,5 +293,213 @@ describe('assertCorpusCompleteness (S4 — loud on inaccessible clone)', () => {
     const repo = makeTmpRepo();
     const lock = makeLock(sha);
     await expect(assertCorpusCompleteness(lock, lcRepo, repo, safeExec)).resolves.toBeUndefined();
+  });
+});
+
+// ─── S4 selectionRule resolver (#2189 item 2, mocked git) ───
+
+const F = '\x1f';
+const R = '\x1e';
+const HELPERS = { parsePrNumber, parseRevertSha, isBotIdentity };
+const CLASSIFIER = { includeGlobs: ['packages/**/*.ts', 'src/**'], excludeGlobs: ['**/*.md'] };
+
+interface LogRecord {
+  sha: string;
+  author: string;
+  subject: string;
+  body?: string;
+  files?: string[];
+}
+
+/**
+ * Build a `git log --name-only --format=%x1e…` stream: a record separator leads
+ * each commit, the format fields follow, then the changed-file list — matching
+ * the single-call shape `enumeratePrMetas` parses.
+ */
+function buildLog(records: LogRecord[], eol: '\n' | '\r\n' = '\n'): string {
+  const stream = records
+    .map(
+      (r) =>
+        `${R}${r.sha}${F}${r.author}${F}${r.subject}${F}${r.body ?? ''}${F}\n${(r.files ?? []).join('\n')}\n`,
+    )
+    .join('');
+  return eol === '\r\n' ? stream.replace(/\n/g, '\r\n') : stream;
+}
+
+/** Mock safeExec routing the git calls the resolver makes (single `git log`). */
+function mockSafeExec(opts: {
+  headSha: string;
+  isAncestor: boolean;
+  log: string;
+}): typeof safeExec {
+  return ((file: string, args: string[]) => {
+    if (file !== 'git') throw new Error(`unexpected exec: ${file}`);
+    if (args[0] === 'rev-parse' && args[1] === 'HEAD') return opts.headSha;
+    if (args[0] === 'merge-base' && args[1] === '--is-ancestor') {
+      if (opts.isAncestor) return '';
+      const err = new Error('not an ancestor') as Error & { status: number };
+      err.status = 1;
+      throw err;
+    }
+    if (args[0] === 'log') return opts.log;
+    throw new Error(`unexpected git call: ${args.join(' ')}`);
+  }) as unknown as typeof safeExec;
+}
+
+const sha40 = (n: number): string => `${n}`.padStart(40, '0');
+
+function makeCertLock(
+  asOfCommit: string,
+  prNums: number[],
+  classifier: unknown = CLASSIFIER,
+): WindtunnelLock {
+  return WindtunnelLockSchema.parse({
+    schema: 'windtunnel.lock.v1',
+    canonicalPath: '.totem/spine/gate-1/windtunnel.lock.json',
+    gate: 'gate-1',
+    phase: 'certifying',
+    corpus: {
+      repo: 'mmnto-ai/liquid-city',
+      selectionRule: {
+        state: 'merged',
+        predicate: 'code-touching',
+        window: { type: 'all' },
+        asOfCommit,
+        ...(classifier != null ? { codePathClassifier: classifier } : {}),
+      },
+      resolvedPrs: prNums.map((n) => ({
+        pr: n,
+        mergeCommit: sha40(n),
+        baseSha: 'b'.repeat(40),
+        headSha: 'd'.repeat(40),
+      })),
+    },
+    fpDefinition: { rubricRef: 'r', groundTruthRef: 'g', adjudicator: 'a', precisionFloor: 1.0 },
+    controls: {
+      positiveRef: 'controls/positive/',
+      negativeRef: 'controls/negative/',
+      integrity: { mechanism: 'sha', fixtureSha: 'e'.repeat(40) },
+    },
+    cullRateThreshold: 0.5,
+    exposureDenominator: {
+      activeRulesEvaluated: { floor: 2 },
+      filesTouchedInWindow: { floor: 0 },
+      positiveControlsExercised: { floor: 0 },
+    },
+  });
+}
+
+// Scenario: git derives [534, 535]; #536 is docs-only → excluded.
+const SCENARIO_RECORDS: LogRecord[] = [
+  {
+    sha: sha40(534),
+    author: 'Jane <j@x.com>',
+    subject: 'feat: a (#534)',
+    files: ['packages/core/src/a.ts'],
+  },
+  { sha: sha40(535), author: 'Jane <j@x.com>', subject: 'fix: b (#535)', files: ['src/b.ts'] },
+  { sha: sha40(536), author: 'Jane <j@x.com>', subject: 'docs: c (#536)', files: ['README.md'] },
+];
+
+describe('enumeratePrMetas (mocked git)', () => {
+  it('parses PRs, skips no-ref commits, and is CRLF-immune (log + changed files)', () => {
+    const records: LogRecord[] = [
+      {
+        sha: sha40(534),
+        author: 'Jane <j@x.com>',
+        subject: 'feat: alpha (#534)',
+        files: ['packages/core/src/a.ts', 'packages/core/src/b.ts'],
+      },
+      {
+        sha: sha40(535),
+        author: 'dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>', // real git %an <%ae>
+        subject: 'chore(deps): bump (#535)',
+        files: ['package.json'],
+      },
+      {
+        sha: sha40(700),
+        author: 'Bot Op <o@x.com>',
+        subject: 'chore(deps): straight to main 1.66.0',
+        files: ['x.ts'],
+      },
+      {
+        sha: sha40(536),
+        author: 'Jane <j@x.com>',
+        subject: 'fix: revert it (#536)',
+        body: `This reverts commit ${sha40(534)}`,
+        files: ['src/x.ts'],
+      },
+    ];
+    const lf = enumeratePrMetas(
+      'aof',
+      'lc',
+      mockSafeExec({ headSha: 'h'.repeat(40), isAncestor: true, log: buildLog(records, '\n') }),
+      HELPERS,
+    );
+    const crlf = enumeratePrMetas(
+      'aof',
+      'lc',
+      mockSafeExec({ headSha: 'h'.repeat(40), isAncestor: true, log: buildLog(records, '\r\n') }),
+      HELPERS,
+    );
+    expect(lf).toEqual(crlf); // CRLF hygiene: identical metas + clean file paths regardless of EOL
+    expect(lf.map((m) => m.pr)).toEqual([534, 535, 536]); // direct-to-main (#700-slot) skipped
+    expect(lf.find((m) => m.pr === 535)!.isBotAuthor).toBe(true);
+    expect(lf.find((m) => m.pr === 536)!.revertsSha).toBe(sha40(534));
+    expect(lf.find((m) => m.pr === 534)!.changedFiles).toEqual([
+      'packages/core/src/a.ts',
+      'packages/core/src/b.ts',
+    ]); // no \r leaked
+  });
+
+  it('propagates a malformed trailing ref as a throw (never silent)', () => {
+    const records: LogRecord[] = [
+      { sha: sha40(1), author: 'Jane <j@x.com>', subject: 'bad (#abc)', files: ['src/x.ts'] },
+    ];
+    expect(() =>
+      enumeratePrMetas(
+        'aof',
+        'lc',
+        mockSafeExec({ headSha: 'h'.repeat(40), isAncestor: true, log: buildLog(records) }),
+        HELPERS,
+      ),
+    ).toThrow(/Malformed PR ref/);
+  });
+});
+
+describe('assertCorpusCompleteness (S4, mocked git)', () => {
+  const asOf = 'f'.repeat(40);
+  const exec = (isAncestor = true): typeof safeExec =>
+    mockSafeExec({ headSha: 'h'.repeat(40), isAncestor, log: buildLog(SCENARIO_RECORDS) });
+
+  it('harness phase is warn-only — never throws even on a count mismatch', async () => {
+    const lock = makeLock(asOf); // phase: harness, resolvedPrs: [#1]
+    await expect(assertCorpusCompleteness(lock, 'lc', 'repo', exec())).resolves.toBeUndefined();
+  });
+
+  it('certifying phase passes when resolvedPrs ≡ selectionRule', async () => {
+    const lock = makeCertLock(asOf, [534, 535]);
+    await expect(assertCorpusCompleteness(lock, 'lc', 'repo', exec())).resolves.toBeUndefined();
+  });
+
+  it('certifying phase throws naming missing + extra on divergence', async () => {
+    const lock = makeCertLock(asOf, [534, 999]); // missing 535, extra 999
+    await expect(assertCorpusCompleteness(lock, 'lc', 'repo', exec())).rejects.toThrow(
+      /Missing from manifest.*535[\s\S]*Extra in manifest.*999/,
+    );
+  });
+
+  it('certifying phase throws when codePathClassifier is absent', async () => {
+    const lock = makeCertLock(asOf, [534, 535], null);
+    await expect(assertCorpusCompleteness(lock, 'lc', 'repo', exec())).rejects.toThrow(
+      /codePathClassifier is required/,
+    );
+  });
+
+  it('certifying phase throws when asOfCommit is not an ancestor of lc HEAD', async () => {
+    const lock = makeCertLock(asOf, [534, 535]);
+    await expect(assertCorpusCompleteness(lock, 'lc', 'repo', exec(false))).rejects.toThrow(
+      /not an ancestor/,
+    );
   });
 });

--- a/packages/cli/src/commands/spine-windtunnel.test.ts
+++ b/packages/cli/src/commands/spine-windtunnel.test.ts
@@ -502,4 +502,24 @@ describe('assertCorpusCompleteness (S4, mocked git)', () => {
       /not an ancestor/,
     );
   });
+
+  it('certifying phase wraps a malformed-ref parse error as a TotemError (greptile P2)', async () => {
+    const lock = makeCertLock(asOf, [534, 535]);
+    const badExec = mockSafeExec({
+      headSha: 'h'.repeat(40),
+      isAncestor: true,
+      log: buildLog([
+        { sha: sha40(1), author: 'Jane <j@x.com>', subject: 'bad (#abc)', files: ['src/x.ts'] },
+      ]),
+    });
+    await expect(assertCorpusCompleteness(lock, 'lc', 'repo', badExec)).rejects.toThrow(
+      /Wind-tunnel freeze \(S4\):.*Malformed PR ref/,
+    );
+  });
+
+  it('rejects a codePathClassifier with empty includeGlobs at parse (greptile P2)', () => {
+    expect(() => makeCertLock(asOf, [534], { includeGlobs: [], excludeGlobs: [] })).toThrow(
+      /at least one glob/,
+    );
+  });
 });

--- a/packages/cli/src/commands/spine-windtunnel.test.ts
+++ b/packages/cli/src/commands/spine-windtunnel.test.ts
@@ -465,6 +465,18 @@ describe('enumeratePrMetas (mocked git)', () => {
       ),
     ).toThrow(/Malformed PR ref/);
   });
+
+  it('throws on a truncated/malformed git record (<5 fields) — never silent (CodeRabbit)', () => {
+    const truncated = `${R}${sha40(1)}${F}Jane <j@x.com>${F}feat: x (#5)`; // only 3 fields
+    expect(() =>
+      enumeratePrMetas(
+        'aof',
+        'lc',
+        mockSafeExec({ headSha: 'h'.repeat(40), isAncestor: true, log: truncated }),
+        HELPERS,
+      ),
+    ).toThrow(/malformed git log record/);
+  });
 });
 
 describe('assertCorpusCompleteness (S4, mocked git)', () => {

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -1,6 +1,8 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import type { PrMeta, SelectionRuleConfig, WindtunnelLock } from '@mmnto/totem';
+
 // ─── Named constants ─────────────────────────────────
 
 const LOCK_REL_PATH = '.totem/spine/gate-1/windtunnel.lock.json';
@@ -510,51 +512,160 @@ export function verifyControlIntegrity(
 }
 
 /**
- * Assert corpus completeness (S4): resolvedPrs === selectionRule(asOfCommit).
- * In the harness phase this is a structural check only (no real lc API call).
+ * Assert corpus completeness (S4, ADR-110 §6): the manifest's `resolvedPrs` must
+ * deep-set-equal `selectionRule(asOfCommit)` re-derived from the offline lc clone.
+ *
+ * - **Harness phase:** warn-only (no real corpus yet) — surfaces accessibility
+ *   but skips the re-derivation.
+ * - **Certifying phase:** hard error. Re-derives the code-touching PR set from
+ *   lc's squash history and throws on ANY membership/count divergence (§6: a
+ *   dropped/added/substituted PR voids the run). Requires a frozen
+ *   `codePathClassifier`.
  */
 export async function assertCorpusCompleteness(
-  lock: import('@mmnto/totem').WindtunnelLock,
+  lock: WindtunnelLock,
   lcDir: string,
   repoRoot: string,
   safeExec: SafeExecFn,
 ): Promise<void> {
-  // Verify the lc clone is accessible + at the correct asOfCommit.
-  // `merge-base --is-ancestor` exits non-zero to MEAN "not an ancestor" — that
-  // is a boolean predicate, not an error, so it gets its own probe helper.
-  const asOfCommit = lock.corpus.selectionRule.asOfCommit;
+  const {
+    resolveSelectionRule,
+    diffPrSets,
+    parsePrNumber,
+    parseRevertSha,
+    isBotIdentity,
+    TotemError,
+  } = await import('@mmnto/totem');
+
+  const sel = lock.corpus.selectionRule;
+  const asOfCommit = sel.asOfCommit;
+
+  // Verify the lc clone is accessible (CRLF-normalized output).
   let headSha: string;
   try {
-    headSha = safeExec('git', ['rev-parse', 'HEAD'], { cwd: lcDir }).trim();
+    headSha = safeExec('git', ['rev-parse', 'HEAD'], { cwd: lcDir }).replace(/\r\n/g, '\n').trim();
   } catch (err) {
-    // S4: an inaccessible lc clone means freeze-time completeness cannot be
-    // proven. The harness phase tolerates this (no real corpus yet) but must
-    // surface it loudly — never silently pass off an unverifiable corpus.
     throw new Error(
       `Wind-tunnel freeze: cannot access lc clone at ${lcDir} to verify corpus completeness (S4): ${err instanceof Error ? err.message : String(err)}. ` +
         `Provide a valid --lc-dir / TOTEM_LC_DIR clone, or omit it to skip the completeness assertion entirely.`,
     );
   }
 
+  // `merge-base --is-ancestor` encodes the answer in its exit code (boolean), so
+  // it gets its own probe helper.
   const isAncestor = isCommitAncestor(asOfCommit, headSha, lcDir, safeExec);
-  if (!isAncestor) {
+
+  // Harness phase: no real corpus yet — warn-only, skip the re-derivation.
+  if (lock.phase === 'harness') {
     console.error(
-      `[WindtunnelFreeze] WARNING: asOfCommit ${asOfCommit} is not an ancestor of lc HEAD ${headSha} — corpus completeness assertion may be unreliable.`,
+      isAncestor
+        ? `[WindtunnelFreeze] lc clone includes asOfCommit ${asOfCommit} ✓`
+        : `[WindtunnelFreeze] WARNING: asOfCommit ${asOfCommit} is not an ancestor of lc HEAD ${headSha} (harness — re-derivation skipped).`,
     );
-  } else {
-    console.error(`[WindtunnelFreeze] lc clone at ${lcDir} includes asOfCommit ${asOfCommit} ✓`);
+    console.error(
+      `[WindtunnelFreeze] harness phase — S4 corpus re-derivation skipped (warn-only). resolvedPrs: ${lock.corpus.resolvedPrs.length} entries.`,
+    );
+    void repoRoot;
+    return;
   }
 
-  // Structural completeness: count + warn (the actual re-derivation of the full
-  // code-touching PR set requires querying the lc repo's merge history, which
-  // is operator-level work; the tool asserts the lock is non-empty and warns
-  // if the resolvedPrs count seems low).
-  const prCount = lock.corpus.resolvedPrs.length;
-  console.error(
-    `[WindtunnelFreeze] resolvedPrs: ${prCount} entries (completeness requires operator verification against selectionRule)`,
-  );
+  // Certifying phase: hard-error re-derivation.
+  if (!isAncestor) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `Wind-tunnel freeze (S4, certifying): asOfCommit ${asOfCommit} is not an ancestor of lc HEAD ${headSha} — cannot re-derive the corpus.`,
+      'Point --lc-dir at an lc clone whose history includes asOfCommit.',
+    );
+  }
+  if (!sel.codePathClassifier) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `Wind-tunnel freeze (S4, certifying): corpus.selectionRule.codePathClassifier is required to re-derive the code-touching PR set — there is no safe default for "what counts as code".`,
+      'Add a frozen codePathClassifier { includeGlobs, excludeGlobs } to the manifest and re-freeze.',
+    );
+  }
 
-  void repoRoot; // used in freeze proof above
+  const config: SelectionRuleConfig = {
+    codePathClassifier: sel.codePathClassifier,
+    excludeRevertPairs: sel.excludeRevertPairs,
+    excludeBotPrs: sel.excludeBotPrs,
+    window: sel.window,
+  };
+  const metas = enumeratePrMetas(asOfCommit, lcDir, safeExec, {
+    parsePrNumber,
+    parseRevertSha,
+    isBotIdentity,
+  });
+  const expected = resolveSelectionRule(metas, config);
+  const actual = lock.corpus.resolvedPrs.map((p) => p.pr);
+  const diff = diffPrSets(expected, actual);
+  if (diff.missing.length > 0 || diff.extra.length > 0) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `Wind-tunnel freeze (S4): corpus completeness FAILED — resolvedPrs ≠ selectionRule(${asOfCommit}).\n` +
+        `  Missing from manifest (present in git): [${diff.missing.join(', ')}]\n` +
+        `  Extra in manifest (absent from git):     [${diff.extra.join(', ')}]`,
+      'Fix the manifest resolvedPrs or codePathClassifier and re-freeze — §6: a corpus divergence voids the run.',
+    );
+  }
+  console.error(
+    `[WindtunnelFreeze] S4 corpus completeness VERIFIED: ${expected.length} PR(s) ≡ resolvedPrs ✓`,
+  );
+  void repoRoot;
+}
+
+/**
+ * Enumerate merged (squash) PRs reachable from `asOfCommit` in the lc clone as
+ * `PrMeta`. lc is 100% squash-merge: each ancestor commit's subject carries a
+ * trailing `(#N)`. Commits with no trailing ref are direct-to-main non-PRs and
+ * are SKIPPED (not errors); a malformed trailing ref throws (via `parsePrNumber`).
+ * All git output is CRLF-normalized before parsing (Windows hygiene).
+ */
+export function enumeratePrMetas(
+  asOfCommit: string,
+  lcDir: string,
+  safeExec: SafeExecFn,
+  helpers: {
+    parsePrNumber: (subject: string) => number | null;
+    parseRevertSha: (body: string) => string | undefined;
+    isBotIdentity: (author: string) => boolean;
+  },
+): PrMeta[] {
+  const F = '\x1f'; // field separator
+  const R = '\x1e'; // record separator (LEADS each commit so its trailing file list stays in-record)
+  // One `git log --name-only` call — the changed files trail each commit's format
+  // block within the same record, avoiding an N+1 `git diff-tree` spawn per commit.
+  const raw = safeExec(
+    'git',
+    ['log', asOfCommit, '--name-only', `--format=${R}%H${F}%an <%ae>${F}%s${F}%b${F}`],
+    { cwd: lcDir },
+  ).replace(/\r\n/g, '\n');
+
+  const metas: PrMeta[] = [];
+  for (const rec of raw.split(R)) {
+    if (rec.trim().length === 0) continue;
+    // Files trail the LAST field separator; only the body may contain an F, so
+    // pop the files block off the end and rejoin the remainder as the body
+    // (robust to a vanishingly rare F inside a commit body).
+    const parts = rec.split(F);
+    const filesBlock = parts.length > 4 ? parts.pop()! : '';
+    const [sha = '', author = '', subject = '', ...bodyParts] = parts;
+    const body = bodyParts.join(F);
+    const pr = helpers.parsePrNumber(subject);
+    if (pr === null) continue; // no trailing (#N) → direct-to-main non-PR, skip
+    metas.push({
+      pr,
+      mergeCommit: sha.trim().toLowerCase(),
+      author: author.trim(),
+      isBotAuthor: helpers.isBotIdentity(author),
+      revertsSha: helpers.parseRevertSha(body),
+      changedFiles: filesBlock
+        .split('\n')
+        .map((l) => l.trim().replace(/\\/g, '/'))
+        .filter(Boolean),
+    });
+  }
+  return metas;
 }
 
 // ─── Mock engine (harness phase) ─────────────────────

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -534,7 +534,6 @@ export async function assertCorpusCompleteness(
     parsePrNumber,
     parseRevertSha,
     isBotIdentity,
-    SelectionRuleParseError,
     TotemError,
   } = await import('@mmnto/totem');
 
@@ -602,17 +601,16 @@ export async function assertCorpusCompleteness(
       isBotIdentity,
     });
   } catch (err) {
-    // A malformed trailing ref in lc history is a config/contract fault — surface
-    // it as a TotemError, not a raw SelectionRuleParseError (greptile P2).
-    if (err instanceof SelectionRuleParseError) {
-      throw new TotemError(
-        'CONFIG_INVALID',
-        `Wind-tunnel freeze (S4): ${err.message}`,
-        'Fix the malformed merge subject in the lc history, or correct the frozen manifest.',
-        err,
-      );
-    }
-    throw err;
+    // Any enumeration fault — a malformed PR ref or a truncated/malformed git
+    // record — is a config/contract fault in the certifying context. Surface as
+    // a TotemError (with cause); never let it escape unwrapped or silently
+    // shrink the corpus (greptile + CodeRabbit).
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `Wind-tunnel freeze (S4): corpus re-derivation failed — ${err instanceof Error ? err.message : String(err)}`,
+      'Fix the malformed merge subject / git history in the lc clone, or correct the frozen manifest.',
+      err,
+    );
   }
   const expected = resolveSelectionRule(metas, config);
   const actual = lock.corpus.resolvedPrs.map((p) => p.pr);
@@ -671,11 +669,20 @@ export function enumeratePrMetas(
   const metas: PrMeta[] = [];
   for (const rec of raw.split(R)) {
     if (rec.trim().length === 0) continue;
+    const parts = rec.split(F);
+    // A real record always has ≥5 F-delimited fields (sha, author, subject,
+    // body, files); fewer means truncated/malformed git output. Throw loud
+    // rather than silently dropping the PR (corpus shrinkage — the §5 failure
+    // mode this gate exists to block, CodeRabbit).
+    if (parts.length < 5) {
+      throw new Error(
+        `Wind-tunnel: malformed git log record (${parts.length} field(s), expected >=5) near "${(parts[0] ?? '').slice(0, 12)}"`,
+      );
+    }
     // Files trail the LAST field separator; only the body may contain an F, so
     // pop the files block off the end and rejoin the remainder as the body
     // (robust to a vanishingly rare F inside a commit body).
-    const parts = rec.split(F);
-    const filesBlock = parts.length > 4 ? parts.pop()! : '';
+    const filesBlock = parts.pop()!;
     const [sha = '', author = '', subject = '', ...bodyParts] = parts;
     const body = bodyParts.join(F);
     const pr = helpers.parsePrNumber(subject);

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -534,6 +534,7 @@ export async function assertCorpusCompleteness(
     parsePrNumber,
     parseRevertSha,
     isBotIdentity,
+    SelectionRuleParseError,
     TotemError,
   } = await import('@mmnto/totem');
 
@@ -545,9 +546,11 @@ export async function assertCorpusCompleteness(
   try {
     headSha = safeExec('git', ['rev-parse', 'HEAD'], { cwd: lcDir }).replace(/\r\n/g, '\n').trim();
   } catch (err) {
-    throw new Error(
-      `Wind-tunnel freeze: cannot access lc clone at ${lcDir} to verify corpus completeness (S4): ${err instanceof Error ? err.message : String(err)}. ` +
-        `Provide a valid --lc-dir / TOTEM_LC_DIR clone, or omit it to skip the completeness assertion entirely.`,
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `Wind-tunnel freeze: cannot access lc clone at ${lcDir} to verify corpus completeness (S4).`,
+      'Provide a valid --lc-dir / TOTEM_LC_DIR clone, or omit it to skip the completeness assertion entirely.',
+      err,
     );
   }
 
@@ -591,11 +594,26 @@ export async function assertCorpusCompleteness(
     excludeBotPrs: sel.excludeBotPrs,
     window: sel.window,
   };
-  const metas = enumeratePrMetas(asOfCommit, lcDir, safeExec, {
-    parsePrNumber,
-    parseRevertSha,
-    isBotIdentity,
-  });
+  let metas: PrMeta[];
+  try {
+    metas = enumeratePrMetas(asOfCommit, lcDir, safeExec, {
+      parsePrNumber,
+      parseRevertSha,
+      isBotIdentity,
+    });
+  } catch (err) {
+    // A malformed trailing ref in lc history is a config/contract fault — surface
+    // it as a TotemError, not a raw SelectionRuleParseError (greptile P2).
+    if (err instanceof SelectionRuleParseError) {
+      throw new TotemError(
+        'CONFIG_INVALID',
+        `Wind-tunnel freeze (S4): ${err.message}`,
+        'Fix the malformed merge subject in the lc history, or correct the frozen manifest.',
+        err,
+      );
+    }
+    throw err;
+  }
   const expected = resolveSelectionRule(metas, config);
   const actual = lock.corpus.resolvedPrs.map((p) => p.pr);
   const diff = diffPrSets(expected, actual);
@@ -635,9 +653,18 @@ export function enumeratePrMetas(
   const R = '\x1e'; // record separator (LEADS each commit so its trailing file list stays in-record)
   // One `git log --name-only` call — the changed files trail each commit's format
   // block within the same record, avoiding an N+1 `git diff-tree` spawn per commit.
+  // `--end-of-options` guards asOfCommit from being parsed as an option even if a
+  // future caller passes an unvalidated ref (defense-in-depth; the lock schema
+  // already constrains asOfCommit to a 40-hex SHA, and safeExec uses no shell).
   const raw = safeExec(
     'git',
-    ['log', asOfCommit, '--name-only', `--format=${R}%H${F}%an <%ae>${F}%s${F}%b${F}`],
+    [
+      'log',
+      '--name-only',
+      `--format=${R}%H${F}%an <%ae>${F}%s${F}%b${F}`,
+      '--end-of-options',
+      asOfCommit,
+    ],
     { cwd: lcDir },
   ).replace(/\r\n/g, '\n');
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -782,6 +782,23 @@ export {
 } from './retrospect.js';
 
 // Spine: Gate-1 wind-tunnel evidence harness (mmnto-ai/totem#2188)
+export type {
+  CodePathClassifier,
+  PrMeta,
+  PrSetDiff,
+  SelectionRuleConfig,
+} from './spine/selection-rule.js';
+export {
+  diffPrSets,
+  isBotIdentity,
+  isCodeTouching,
+  parsePrNumber,
+  parseRevertSha,
+  prSetsEqual,
+  resolveSelectionRule,
+  SelectionRuleParseError,
+  selectionRulePredicate,
+} from './spine/selection-rule.js';
 export type { WindtunnelLock } from './spine/windtunnel-lock.js';
 export { firingLabelId, WindtunnelLockSchema } from './spine/windtunnel-lock.js';
 export type {

--- a/packages/core/src/spine/selection-rule.test.ts
+++ b/packages/core/src/spine/selection-rule.test.ts
@@ -77,6 +77,14 @@ describe('isCodeTouching — exclude wins at the file level', () => {
       true,
     );
   });
+
+  it('supports brace alternation (**/*.{ts,tsx}) — greptile P2', () => {
+    const c: CodePathClassifier = { includeGlobs: ['**/*.{ts,tsx,rs}'], excludeGlobs: [] };
+    expect(isCodeTouching(['src/a.ts'], c)).toBe(true);
+    expect(isCodeTouching(['packages/core/b.tsx'], c)).toBe(true);
+    expect(isCodeTouching(['crates/c.rs'], c)).toBe(true);
+    expect(isCodeTouching(['src/a.js'], c)).toBe(false);
+  });
 });
 
 // ─── isBotIdentity ───────────────────────────────────

--- a/packages/core/src/spine/selection-rule.test.ts
+++ b/packages/core/src/spine/selection-rule.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CodePathClassifier, PrMeta, SelectionRuleConfig } from './selection-rule.js';
+import {
+  diffPrSets,
+  isBotIdentity,
+  isCodeTouching,
+  parsePrNumber,
+  parseRevertSha,
+  prSetsEqual,
+  resolveSelectionRule,
+  SelectionRuleParseError,
+  selectionRulePredicate,
+} from './selection-rule.js';
+
+// ─── Helpers ─────────────────────────────────────────
+
+const CLASSIFIER: CodePathClassifier = {
+  includeGlobs: ['packages/**/*.ts', 'src/**', '**/*.rs'],
+  excludeGlobs: ['**/*.md', 'docs/**', '**/*.json'],
+};
+
+function cfg(overrides?: Partial<SelectionRuleConfig>): SelectionRuleConfig {
+  return {
+    codePathClassifier: CLASSIFIER,
+    excludeRevertPairs: true,
+    excludeBotPrs: true,
+    window: { type: 'all' },
+    ...overrides,
+  };
+}
+
+function meta(pr: number, overrides?: Partial<PrMeta>): PrMeta {
+  const author = overrides?.author ?? 'Jane Doe <jane@example.com>';
+  return {
+    pr,
+    mergeCommit: overrides?.mergeCommit ?? `${pr}`.padStart(40, '0'),
+    author,
+    isBotAuthor: overrides?.isBotAuthor ?? isBotIdentity(author),
+    revertsSha: overrides?.revertsSha,
+    changedFiles: overrides?.changedFiles ?? ['packages/core/src/x.ts'],
+  };
+}
+
+// ─── isCodeTouching / glob precedence ────────────────
+
+describe('isCodeTouching — exclude wins at the file level', () => {
+  it('includes a PR touching any code file', () => {
+    expect(isCodeTouching(['packages/core/src/x.ts'], CLASSIFIER)).toBe(true);
+    expect(isCodeTouching(['src/engine/run.ts'], CLASSIFIER)).toBe(true);
+    expect(isCodeTouching(['crates/foo/lib.rs'], CLASSIFIER)).toBe(true);
+  });
+
+  it('excludes a docs/config-only PR (no file survives the classifier)', () => {
+    expect(isCodeTouching(['packages/core/README.md'], CLASSIFIER)).toBe(false);
+    expect(isCodeTouching(['docs/guide/intro.md'], CLASSIFIER)).toBe(false);
+    expect(isCodeTouching(['package.json'], CLASSIFIER)).toBe(false);
+  });
+
+  it('includes a MIXED PR (code + doc) — file-level exclude does not exclude the PR', () => {
+    expect(
+      isCodeTouching(['packages/core/README.md', 'packages/core/src/index.ts'], CLASSIFIER),
+    ).toBe(true);
+  });
+
+  it('exclude wins over include at the file level (a .json under packages is not code)', () => {
+    // packages/core/tsconfig.json matches includeGlob packages/**/*.ts? no (.json). matches **/*.json exclude.
+    expect(isCodeTouching(['packages/core/data.json'], CLASSIFIER)).toBe(false);
+  });
+
+  it('normalizes backslash paths before matching', () => {
+    expect(isCodeTouching(['packages\\core\\src\\x.ts'], CLASSIFIER)).toBe(true);
+  });
+
+  it('**/*.md matches a root-level file (the **​/ zero-segment case)', () => {
+    expect(isCodeTouching(['README.md'], { includeGlobs: ['**/*.md'], excludeGlobs: [] })).toBe(
+      true,
+    );
+  });
+});
+
+// ─── isBotIdentity ───────────────────────────────────
+
+describe('isBotIdentity — [bot] suffix only', () => {
+  it('matches GitHub bot accounts in git %an <%ae> form (case-insensitive)', () => {
+    expect(isBotIdentity('dependabot[bot]')).toBe(true); // name-only
+    // The real git author string — display name + noreply email. The whole
+    // string ends with ">", so a naive .endsWith('[bot]') would miss it.
+    expect(
+      isBotIdentity('dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>'),
+    ).toBe(true);
+    expect(isBotIdentity('Renovate[bot] <bot@renovate.com>')).toBe(true);
+    expect(isBotIdentity('renovate[BOT]')).toBe(true);
+  });
+
+  it('does NOT match a human handle merely containing "bot"', () => {
+    expect(isBotIdentity('revertbot')).toBe(false);
+    expect(isBotIdentity('Robotnik')).toBe(false);
+    expect(isBotIdentity('Jane Doe')).toBe(false);
+    expect(isBotIdentity('Jane Doe <jane@example.com>')).toBe(false);
+  });
+
+  it('tolerates trailing CR/whitespace', () => {
+    expect(isBotIdentity('dependabot[bot]\r')).toBe(true);
+    expect(isBotIdentity('  dependabot[bot]  ')).toBe(true);
+  });
+});
+
+// ─── parseRevertSha ──────────────────────────────────
+
+describe('parseRevertSha', () => {
+  it('extracts the target sha from a revert body', () => {
+    expect(parseRevertSha('This reverts commit abcdef1234567890abcdef1234567890abcdef12.')).toBe(
+      'abcdef1234567890abcdef1234567890abcdef12',
+    );
+  });
+
+  it('returns undefined when there is no revert line', () => {
+    expect(parseRevertSha('feat: a normal commit body')).toBeUndefined();
+  });
+
+  it('tolerates CRLF bodies', () => {
+    expect(parseRevertSha('This reverts commit deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\r\n')).toBe(
+      'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+    );
+  });
+});
+
+// ─── parsePrNumber — trailing (#N), skip-no-ref, malformed ───
+
+describe('parsePrNumber', () => {
+  it('extracts the TRAILING (#N), not an earlier issue ref', () => {
+    expect(parsePrNumber('on-foot interior breach spec (#533) (#534)')).toBe(534);
+    expect(parsePrNumber('first-drive feedback (closes #522) (#524)')).toBe(524);
+    expect(parsePrNumber('feat: simple change (#12)')).toBe(12);
+  });
+
+  it('returns null for a direct-to-main commit with no (#N) (a non-PR, skip)', () => {
+    expect(parsePrNumber('chore(deps): bump @mmnto/* to 1.66.0')).toBeNull();
+    expect(parsePrNumber('hotfix straight to main')).toBeNull();
+  });
+
+  it('throws on a malformed trailing ref (never silent)', () => {
+    expect(() => parsePrNumber('bad ref (#abc)')).toThrow(SelectionRuleParseError);
+    expect(() => parsePrNumber('empty ref (#)')).toThrow(SelectionRuleParseError);
+    expect(() => parsePrNumber('zero ref (#0)')).toThrow(SelectionRuleParseError);
+    expect(() => parsePrNumber('negative ref (#-1)')).toThrow(SelectionRuleParseError);
+  });
+
+  it('tolerates a trailing CR', () => {
+    expect(parsePrNumber('feat: change (#42)\r')).toBe(42);
+  });
+});
+
+// ─── selectionRulePredicate (per-PR) ─────────────────
+
+describe('selectionRulePredicate', () => {
+  it('passes a code-touching, human, non-revert PR', () => {
+    expect(selectionRulePredicate(meta(1), cfg())).toBe(true);
+  });
+
+  it('excludes a non-code-touching PR', () => {
+    expect(selectionRulePredicate(meta(1, { changedFiles: ['README.md'] }), cfg())).toBe(false);
+  });
+
+  it('excludes a bot PR when excludeBotPrs is on; keeps it when off', () => {
+    const botPr = meta(1, { author: 'dependabot[bot]' });
+    expect(selectionRulePredicate(botPr, cfg({ excludeBotPrs: true }))).toBe(false);
+    expect(selectionRulePredicate(botPr, cfg({ excludeBotPrs: false }))).toBe(true);
+  });
+
+  it('excludes a revert PR itself when excludeRevertPairs is on; keeps it when off', () => {
+    const revertPr = meta(1, { revertsSha: 'a'.repeat(40) });
+    expect(selectionRulePredicate(revertPr, cfg({ excludeRevertPairs: true }))).toBe(false);
+    expect(selectionRulePredicate(revertPr, cfg({ excludeRevertPairs: false }))).toBe(true);
+  });
+});
+
+// ─── resolveSelectionRule — two-pass revert + fail-safe ───
+
+describe('resolveSelectionRule', () => {
+  it('returns sorted unique PR numbers', () => {
+    expect(resolveSelectionRule([meta(13), meta(11), meta(12), meta(11)], cfg())).toEqual([
+      11, 12, 13,
+    ]);
+  });
+
+  it('drops BOTH the revert PR and its in-window target (two-pass)', () => {
+    const target = meta(20, { mergeCommit: 'f'.repeat(40) });
+    const revert = meta(21, { revertsSha: 'f'.repeat(40) });
+    const other = meta(22);
+    expect(
+      resolveSelectionRule([target, revert, other], cfg({ excludeRevertPairs: true })),
+    ).toEqual([22]);
+  });
+
+  it('fail-safe: a reverted target outside the window drops nothing but the revert itself', () => {
+    // The revert points at a sha that is not any in-window candidate's mergeCommit.
+    const revert = meta(21, { revertsSha: 'deadbeef'.padEnd(40, '0') });
+    const other = meta(22);
+    expect(resolveSelectionRule([revert, other], cfg({ excludeRevertPairs: true }))).toEqual([22]);
+  });
+
+  it('keeps both revert and target when excludeRevertPairs is false', () => {
+    const target = meta(20, { mergeCommit: 'f'.repeat(40) });
+    const revert = meta(21, { revertsSha: 'f'.repeat(40) });
+    expect(resolveSelectionRule([target, revert], cfg({ excludeRevertPairs: false }))).toEqual([
+      20, 21,
+    ]);
+  });
+
+  it('excludes bot PRs and non-code PRs from the set', () => {
+    const human = meta(1);
+    const bot = meta(2, { author: 'renovate[bot]' });
+    const docOnly = meta(3, { changedFiles: ['docs/x.md'] });
+    expect(resolveSelectionRule([human, bot, docOnly], cfg())).toEqual([1]);
+  });
+
+  it('matches an abbreviated revert sha against the full target mergeCommit (prefix)', () => {
+    const target = meta(20, { mergeCommit: 'abc123def456'.padEnd(40, '0') });
+    const revert = meta(21, { revertsSha: 'abc123d' });
+    expect(resolveSelectionRule([target, revert], cfg())).toEqual([]);
+  });
+
+  it('bounded window keeps the N MOST-RECENT qualifying PRs (input is newest-first)', () => {
+    // metas in git-log order (newest first): 50, 49, 48, 47.
+    const metas = [meta(50), meta(49), meta(48), meta(47)];
+    expect(resolveSelectionRule(metas, cfg({ window: { type: 'bounded', n: 2 } }))).toEqual([
+      49, 50,
+    ]);
+    // 'all' keeps everything.
+    expect(resolveSelectionRule(metas, cfg({ window: { type: 'all' } }))).toEqual([47, 48, 49, 50]);
+  });
+
+  it('bounded window counts only QUALIFYING PRs toward N (skips non-code before the slice)', () => {
+    // newest-first: 50 (doc), 49 (code), 48 (code) → N=2 → [48, 49], not [49, 50].
+    const metas = [meta(50, { changedFiles: ['README.md'] }), meta(49), meta(48)];
+    expect(resolveSelectionRule(metas, cfg({ window: { type: 'bounded', n: 2 } }))).toEqual([
+      48, 49,
+    ]);
+  });
+});
+
+// ─── diffPrSets / prSetsEqual ────────────────────────
+
+describe('deep set-equality (§6)', () => {
+  it('is order- and duplicate-invariant', () => {
+    expect(prSetsEqual([12, 13], [13, 12])).toBe(true);
+    expect(prSetsEqual([12, 13, 13], [13, 12])).toBe(true);
+  });
+
+  it('reports missing (in git, not manifest) and extra (in manifest, not git) separately', () => {
+    const d = diffPrSets([534, 535, 536], [536, 611]);
+    expect(d.missing).toEqual([534, 535]);
+    expect(d.extra).toEqual([611]);
+    expect(prSetsEqual([534, 535, 536], [536, 611])).toBe(false);
+  });
+
+  it('equal sets yield empty diff', () => {
+    expect(diffPrSets([1, 2, 3], [3, 2, 1])).toEqual({ missing: [], extra: [] });
+  });
+});

--- a/packages/core/src/spine/selection-rule.ts
+++ b/packages/core/src/spine/selection-rule.ts
@@ -75,10 +75,11 @@ function escapeRegexChar(ch: string): string {
 
 /**
  * Translate a path glob to an anchored RegExp. Supports:
- *   `**​/`  → zero or more path segments
- *   `**`   → any characters including `/`
- *   `*`    → any characters except `/`
- *   `?`    → a single character except `/`
+ *   `**​/`     → zero or more path segments
+ *   `**`      → any characters including `/`
+ *   `*`       → any characters except `/`
+ *   `?`       → a single character except `/`
+ *   `{a,b,c}` → brace alternation (e.g. `**​/*.{ts,tsx}`)
  * Sufficient for the frozen code-path classifier; avoids a glob dependency and
  * keeps matching deterministic/offline.
  */
@@ -104,6 +105,19 @@ function globToRegExp(glob: string): RegExp {
     } else if (c === '?') {
       re += '[^/]';
       i += 1;
+    } else if (c === '{') {
+      const end = g.indexOf('}', i);
+      if (end > i) {
+        const alts = g
+          .slice(i + 1, end)
+          .split(',')
+          .map((alt) => alt.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')); // alternatives are literals
+        re += `(?:${alts.join('|')})`; // '{ts,tsx}' → '(?:ts|tsx)'
+        i = end + 1;
+      } else {
+        re += escapeRegexChar(c); // unmatched '{' → literal
+        i += 1;
+      }
     } else {
       re += escapeRegexChar(c);
       i += 1;

--- a/packages/core/src/spine/selection-rule.ts
+++ b/packages/core/src/spine/selection-rule.ts
@@ -1,0 +1,257 @@
+// ─── S4 corpus selectionRule predicate (ADR-110 §6) ─────────────────────────
+//
+// Pure, deterministic re-derivation of the wind-tunnel corpus from offline git
+// metadata — NO GitHub-API fields (the §4 offline-derivation invariant). Given
+// the same `asOfCommit` + the same frozen config, `resolveSelectionRule` yields
+// a byte-identical PR-number set on every run; that determinism is what turns
+// the §6 check `resolvedPrs ≡ selectionRule(asOfCommit)` from a tautology into a
+// real gate. IO (git enumeration → PrMeta) lives in the cli layer; this module
+// is the pure mathematical predicate over PrMeta.
+
+// ─── Types ──────────────────────────────────────────
+
+/**
+ * Frozen code-path classifier. A changed file is code-touching iff it matches
+ * ≥1 `includeGlobs` AND no `excludeGlobs` — exclude wins at the FILE level.
+ */
+export interface CodePathClassifier {
+  includeGlobs: string[];
+  excludeGlobs: string[];
+}
+
+/** Frozen selectionRule config, read from `lock.corpus.selectionRule`. */
+export interface SelectionRuleConfig {
+  /** Required at certifying resolve (caller hard-errors if absent). */
+  codePathClassifier: CodePathClassifier;
+  /** Exclude a revert PR AND its reverted target. Manifest flag, default true. */
+  excludeRevertPairs: boolean;
+  /** Exclude `[bot]`-authored PRs. Manifest flag, default true. */
+  excludeBotPrs: boolean;
+  /**
+   * Corpus window. `all` = every qualifying PR reachable from `asOfCommit`;
+   * `bounded` = the `n` MOST-RECENT qualifying PRs (newest-first by merge order).
+   */
+  window: { type: 'all' } | { type: 'bounded'; n: number };
+}
+
+/** Git-derived facts about one merged (squash) PR reachable from `asOfCommit`. */
+export interface PrMeta {
+  pr: number;
+  /** The squash-merge commit SHA (lowercase 40-hex). */
+  mergeCommit: string;
+  /** Author identity (name/email) used for bot detection. */
+  author: string;
+  /** True iff `author` ends with `[bot]` (case-insensitive). */
+  isBotAuthor: boolean;
+  /** If this PR is a revert, the target SHA from `This reverts commit <sha>`. */
+  revertsSha?: string;
+  /** Changed file paths, forward-slash normalized. */
+  changedFiles: string[];
+}
+
+/** Symmetric difference between the expected (git) and actual (manifest) PR sets. */
+export interface PrSetDiff {
+  /** In git, absent from the manifest. */
+  missing: number[];
+  /** In the manifest, absent from git. */
+  extra: number[];
+}
+
+/** Thrown when a merge subject carries a TRAILING `(#…)` that is not a valid PR ref. */
+export class SelectionRuleParseError extends Error {
+  constructor(public readonly subject: string) {
+    super(
+      `Malformed PR ref in merge subject (trailing parenthesized ref is not a positive integer): ${subject}`,
+    );
+    this.name = 'SelectionRuleParseError';
+  }
+}
+
+// ─── Glob matching (self-contained; frozen narrow classifier) ────────────────
+
+function escapeRegexChar(ch: string): string {
+  return /[.*+?^${}()|[\]\\]/.test(ch) ? `\\${ch}` : ch;
+}
+
+/**
+ * Translate a path glob to an anchored RegExp. Supports:
+ *   `**​/`  → zero or more path segments
+ *   `**`   → any characters including `/`
+ *   `*`    → any characters except `/`
+ *   `?`    → a single character except `/`
+ * Sufficient for the frozen code-path classifier; avoids a glob dependency and
+ * keeps matching deterministic/offline.
+ */
+function globToRegExp(glob: string): RegExp {
+  const g = glob.replace(/\\/g, '/');
+  let re = '';
+  let i = 0;
+  while (i < g.length) {
+    const c = g[i]!;
+    if (c === '*') {
+      if (g[i + 1] === '*') {
+        if (g[i + 2] === '/') {
+          re += '(?:[^/]+/)*'; // '**/' → zero or more segments (matches the empty case)
+          i += 3;
+        } else {
+          re += '.*'; // '**' (e.g. trailing) → any chars incl. '/'
+          i += 2;
+        }
+      } else {
+        re += '[^/]*'; // '*' → any chars within a segment
+        i += 1;
+      }
+    } else if (c === '?') {
+      re += '[^/]';
+      i += 1;
+    } else {
+      re += escapeRegexChar(c);
+      i += 1;
+    }
+  }
+  return new RegExp(`^${re}$`);
+}
+
+const globCache = new Map<string, RegExp>();
+function matchGlob(filePath: string, glob: string): boolean {
+  let re = globCache.get(glob);
+  if (!re) {
+    re = globToRegExp(glob);
+    globCache.set(glob, re);
+  }
+  return re.test(filePath);
+}
+
+/**
+ * A PR is code-touching iff at least one changed file matches ≥1 includeGlob and
+ * no excludeGlob. Exclude wins at the FILE level (not the PR level), so a PR
+ * with a mix of code + doc files is still code-touching, while a docs/config/
+ * generated-only PR is excluded because no file survives the classifier.
+ */
+export function isCodeTouching(changedFiles: string[], classifier: CodePathClassifier): boolean {
+  return changedFiles.some((raw) => {
+    const file = raw.replace(/\\/g, '/');
+    const included = classifier.includeGlobs.some((g) => matchGlob(file, g));
+    if (!included) return false;
+    const excluded = classifier.excludeGlobs.some((g) => matchGlob(file, g));
+    return !excluded;
+  });
+}
+
+// ─── Git-convention detectors (offline, §4) ──────────────────────────────────
+
+/**
+ * Bot iff the author identity is a GitHub bot. `author` is git's `%an <%ae>` —
+ * e.g. `dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>` — so
+ * checking the whole string's suffix would fail (it ends with `>`). Strip the
+ * trailing ` <email>` and test the display NAME's `[bot]` suffix, and also match
+ * a `[bot]@` noreply email; robust to the name-only or name+email forms.
+ */
+export function isBotIdentity(author: string): boolean {
+  const a = author.replace(/\r/g, '').trim().toLowerCase();
+  const name = a.replace(/\s*<[^>]*>\s*$/, '');
+  return name.endsWith('[bot]') || /\[bot\]@/.test(a);
+}
+
+const REVERT_BODY_REGEX = /^This reverts commit ([0-9a-f]{7,40})\b/im;
+
+/** Extract the reverted target SHA from a `This reverts commit <sha>` body line. */
+export function parseRevertSha(commitBody: string): string | undefined {
+  const m = REVERT_BODY_REGEX.exec(commitBody.replace(/\r/g, ''));
+  return m ? m[1]!.toLowerCase() : undefined;
+}
+
+// ─── PR-number extraction (lc squash convention) ─────────────────────────────
+
+const TRAILING_PR_REGEX = /\(#(\d+)\)\s*$/;
+const TRAILING_PAREN_REF_REGEX = /\(#[^)]*\)\s*$/;
+
+/**
+ * Extract the PR number from a squash-merge subject's TRAILING `(#N)`.
+ * - No trailing `(#…)` at all → `null` (a direct-to-main non-PR commit; skip).
+ * - Trailing `(#N)` with a positive integer → that number. Anchored to the END,
+ *   so `…spec (#533) (#534)` → 534 and `…(closes #522) (#524)` → 524 (earlier
+ *   refs are issue refs, not the PR).
+ * - Trailing parenthesized ref that is NOT a positive integer (`(#abc)`, `(#)`,
+ *   `(#0)`, `(#-1)`) → throws `SelectionRuleParseError` (malformed, never silent).
+ */
+export function parsePrNumber(subject: string): number | null {
+  const s = subject.replace(/\r/g, '');
+  const m = TRAILING_PR_REGEX.exec(s);
+  if (m) {
+    const n = Number(m[1]);
+    if (Number.isInteger(n) && n > 0) return n;
+    throw new SelectionRuleParseError(subject); // e.g. "(#0)"
+  }
+  if (TRAILING_PAREN_REF_REGEX.test(s)) {
+    throw new SelectionRuleParseError(subject); // e.g. "(#abc)", "(#)", "(#-1)"
+  }
+  return null;
+}
+
+// ─── The predicate + two-pass resolver ───────────────────────────────────────
+
+/**
+ * Per-PR predicate (pure, single-PrMeta): code-touching AND (not bot, when
+ * excluded) AND (not itself a revert, when excluded). The reverted-TARGET
+ * exclusion is NOT here — it needs cross-candidate context and lives in the
+ * second pass of `resolveSelectionRule`.
+ */
+export function selectionRulePredicate(meta: PrMeta, config: SelectionRuleConfig): boolean {
+  if (!isCodeTouching(meta.changedFiles, config.codePathClassifier)) return false;
+  if (config.excludeBotPrs && meta.isBotAuthor) return false;
+  if (config.excludeRevertPairs && meta.revertsSha !== undefined) return false;
+  return true;
+}
+
+/**
+ * Resolve the corpus PR set from enumerated PrMetas (already filtered to
+ * ancestors of `asOfCommit` by the caller). Two-pass when excluding revert
+ * pairs: (1) collect reverted-target SHAs; (2) apply the per-PR predicate, then
+ * drop any candidate whose `mergeCommit` is a reverted target. Fail-safe: a
+ * target SHA that maps to no in-window candidate (direct-to-main / out-of-
+ * ancestry) drops nothing — only the revert PR itself is excluded (by the
+ * predicate). Returns sorted unique PR numbers.
+ */
+export function resolveSelectionRule(metas: PrMeta[], config: SelectionRuleConfig): number[] {
+  const revertedTargetShas: string[] = [];
+  if (config.excludeRevertPairs) {
+    for (const m of metas) {
+      if (m.revertsSha) revertedTargetShas.push(m.revertsSha);
+    }
+  }
+  const isRevertedTarget = (mergeCommit: string): boolean =>
+    revertedTargetShas.some((t) => mergeCommit.toLowerCase().startsWith(t));
+
+  // Qualifying PRs in INPUT order — the caller passes them in git-log order
+  // (newest-first), so a bounded window's "most recent N" is the first N here.
+  const qualifying: number[] = [];
+  const seen = new Set<number>();
+  for (const m of metas) {
+    if (!selectionRulePredicate(m, config)) continue;
+    if (isRevertedTarget(m.mergeCommit)) continue;
+    if (seen.has(m.pr)) continue;
+    seen.add(m.pr);
+    qualifying.push(m.pr);
+  }
+  const windowed =
+    config.window.type === 'bounded' ? qualifying.slice(0, config.window.n) : qualifying;
+  return [...windowed].sort((a, b) => a - b);
+}
+
+// ─── Deep set-equality (§6) ───────────────────────────────────────────────────
+
+/** Symmetric difference; both sides normalized to unique sets, order-invariant. */
+export function diffPrSets(expected: number[], actual: number[]): PrSetDiff {
+  const e = new Set(expected);
+  const a = new Set(actual);
+  const missing = [...e].filter((x) => !a.has(x)).sort((x, y) => x - y);
+  const extra = [...a].filter((x) => !e.has(x)).sort((x, y) => x - y);
+  return { missing, extra };
+}
+
+/** Membership + count equality (NOT reference/order). */
+export function prSetsEqual(expected: number[], actual: number[]): boolean {
+  const d = diffPrSets(expected, actual);
+  return d.missing.length === 0 && d.extra.length === 0;
+}

--- a/packages/core/src/spine/selection-rule.ts
+++ b/packages/core/src/spine/selection-rule.ts
@@ -264,7 +264,7 @@ export function diffPrSets(expected: number[], actual: number[]): PrSetDiff {
   return { missing, extra };
 }
 
-/** Membership + count equality (NOT reference/order). */
+/** Order- and duplicate-invariant set-membership equality (both sides deduped). */
 export function prSetsEqual(expected: number[], actual: number[]): boolean {
   const d = diffPrSets(expected, actual);
   return d.missing.length === 0 && d.extra.length === 0;

--- a/packages/core/src/spine/windtunnel-lock.ts
+++ b/packages/core/src/spine/windtunnel-lock.ts
@@ -42,6 +42,19 @@ export const WindtunnelLockSchema = z
           z.object({ type: z.literal('bounded'), n: z.number().int().positive() }),
         ]),
         asOfCommit: z.string().regex(COMMIT_SHA_REGEX, 'asOfCommit must be a 40-hex SHA'),
+        // S4 (#2189 item 2): the frozen code-path classifier + exclusion flags the
+        // resolver re-derives against. Additive-optional so existing harness locks
+        // parse unchanged; `codePathClassifier` is required at CERTIFYING resolve
+        // (the resolver hard-errors if absent — no safe code-default for "what is
+        // code"). Flags default to the strategy-claude-ratified lean (exclude).
+        codePathClassifier: z
+          .object({
+            includeGlobs: z.array(z.string().min(1)),
+            excludeGlobs: z.array(z.string().min(1)),
+          })
+          .optional(),
+        excludeRevertPairs: z.boolean().default(true),
+        excludeBotPrs: z.boolean().default(true),
       }),
       resolvedPrs: z.array(ResolvedPrSchema).min(1, 'resolvedPrs must be non-empty'),
     }),

--- a/packages/core/src/spine/windtunnel-lock.ts
+++ b/packages/core/src/spine/windtunnel-lock.ts
@@ -49,7 +49,12 @@ export const WindtunnelLockSchema = z
         // code"). Flags default to the strategy-claude-ratified lean (exclude).
         codePathClassifier: z
           .object({
-            includeGlobs: z.array(z.string().min(1)),
+            // includeGlobs must list ≥1 glob — an empty set makes EVERY file
+            // non-code, so the certifying gate would false-fail "Extra: [all PRs]"
+            // (greptile P2). excludeGlobs may be empty (no exclusions).
+            includeGlobs: z
+              .array(z.string().min(1))
+              .min(1, 'includeGlobs must list at least one glob'),
             excludeGlobs: z.array(z.string().min(1)),
           })
           .optional(),


### PR DESCRIPTION
## What & why

**Item 2** of #2189 (the post-#2188 deferrals) — the deterministic `selectionRule(asOfCommit)` corpus re-derivation behind ADR-110 §6. Contract settled with strategy-claude (predicate 0432Z + concurrence 0506Z) and vetted by the codex/gemini/agy pre-build panel.

> **Scope: item 2 only.** Item 1 (wire the resolver into the certifying `run` pre-scoring gate) stays open on strategy#516. This PR is *not* the certifying run.

## Changes

- **New pure core module `spine/selection-rule`** — offline, deterministic (no GitHub-API fields, §4):
  - `selectionRulePredicate` (code-touching + bot + revert-itself) and the **two-pass** `resolveSelectionRule` (drops a revert PR AND its in-window target; fail-safe when the target is out-of-window — only the revert is dropped).
  - **window-aware:** `all` = every qualifying PR; `bounded { n }` = the N most-recent qualifying PRs.
  - `isCodeTouching` (frozen classifier; **exclude wins at the file level**), `isBotIdentity` (handles git's `%an <%ae>` `[bot]` form), `parseRevertSha`, `parsePrNumber` (trailing `(#N)`; no-ref → skip, malformed → throw), `diffPrSets`/`prSetsEqual` (order/duplicate-invariant).
- **`windtunnel.lock.v1` gains additive-optional `corpus.selectionRule` fields**: `codePathClassifier {includeGlobs, excludeGlobs}` (required at certifying resolve), `excludeRevertPairs` / `excludeBotPrs` (default `true`). Existing harness locks parse unchanged.
- **`totem spine windtunnel freeze` S4 is now a hard gate at the certifying phase**: one `git log --name-only` re-derivation, deep set-equality vs `resolvedPrs`, throws naming **missing/extra** PRs on divergence. Harness phase stays warn-only. CRLF + path-separator normalized throughout.

## Verification

- **Tests:** `selection-rule.test.ts` (33) + `spine-windtunnel.test.ts` S4 section (mocked-git: enumeration, CRLF immunity, harness-vs-certifying, divergence, missing-classifier, not-ancestor). Core spine suite **95**, CLI spine **26**, all green.
- **`totem lint`** PASS (0 errors), **`totem review`** PASS (no findings), `tsc` + `format:check` clean.

## Review provenance (folds applied)

- **Panel** (codex/gemini/agy): gemini APPROVE; codex CONCERN→pre-cleared on folds; agy PASS-with-concerns. Folded: **revert two-pass** (can't live in the pure predicate), classifier precedence (exclude-wins-at-file-level), narrow malformed-trailer, symmetric-diff errors, **Windows CRLF/path-separator hygiene**, phase-separation both-branches, bot-suffix precision.
- **`totem review`**: window-awareness (CRITICAL — a bounded lock would have false-failed), single-call enumeration (N+1 fix), and the **bot `%an <%ae>` detection bug** (the test had used a bare name and missed it).

## Flagged forward (non-blocking)

The **bounded-window *count* semantics** ("N most-recent qualifying") is my defensible default — the 0432Z/0506Z dispatches pinned the membership predicate, not the window-count rule. The certifying corpus is `window: all` per strategy-claude's empirics, so bounded is not the certifying path; flagging to strategy-claude for confirmation.

Refs: #2189 · #2188 · ADR-110 (mmnto-ai/totem-strategy#669, §6 #676) · strategy#516
