### PR TITLE
feat(spine): Gate-1 rule-mining miner slice 4 — Stage-3 Compile + Stage-4 Verify (ADR-111)

### DIFF
--- a/.totem/specs/adr-111-miner-build.md
+++ b/.totem/specs/adr-111-miner-build.md
@@ -287,3 +287,110 @@ No silent-degradation rows — the only "soft" path (classifier internal failure
 **Carried-forward (panel-confirmed):** flag-3 frozen-actuator seam = slice-4-binding (slice-3 mints only the `structural` _label_, compiles nothing); flag-4/#2201 (ADR-095 before-promotion gate) = independent of slice 3.
 
 **Pre-build status:** design folded + panel-reviewed (gemini APPROVE / strategy FAITHFUL+flag-5 / codex CONCERN-folds / agy PASS-folds — all convergent, no blockers; the binding fold is the auditable safe-default). **Build gated on operator greenlight (Phase-4 gate).**
+
+---
+
+## Implementation Design (Slice 4 — Stage-3 Compile + Stage-4 Verify-Against-Codebase)
+
+**Grounded:** 2026-06-19 via an Explore sweep of the compile/Stage-4 surface (kept off the controller context) + the slice-1/2/3 envelope/ledger/harness code. `totem spec` skipped (cross-repo-ADR-driven → confabulation risk, per #2172/0103). **Recovery note (2026-06-19):** this section was authored + panel-reviewed (4/4 convergent) but the on-disk append was lost (uncommitted spec WIP, consistent with the shared-working-tree cross-stream hazard — a co-resident checkout can clobber untracked WIP); reconstructed verbatim-faithful from the four 2211Z pre-build dispatches + the four panel verdicts (codex 2224Z / strategy 2226Z / agy 2228Z / gemini 2230Z) + strategy's 2153Z flag-3 read, all retained under `.totem/orchestration/totem-claude/{outbox,processed}/`.
+
+### Scope
+
+Build the **fresh non-frozen G-series compile actuator** + wire the shipped Stage-4 codebase verifier. For each **compile-routed (structural)** slice-3 `CandidateRuleRecord`: parse its `dslSource` (lesson-markdown body) into a `CompiledRule` via the reused `lesson-pattern.ts` format/parser + per-engine safety validators, mint it `unverified:true` with **`legitimacy`/`ruleClass` ABSENT**, run `verifyAgainstCodebase` (#1682) through an **injected `Stage4VerifierDeps` port**, map the Stage-4 outcome onto the rule's `status`/`confidence`/`severity`, and record the outcome on the classifier ledger (flip `stage4Confirmed` + set the new `stage4Outcome`). Output `CompiledCandidate[]` carrying `provenance` forward for slice-5's wind-tunnel stamp.
+
+**Will NOT:** call the frozen legacy actuator (`compileLesson`/`buildCompiledRule`/`buildManualRule`, the `LessonInput` path) — flag-3, BINDING; use any LLM (Stage-4 is the deterministic zero-LLM backstop, Tenet-15); stamp `legitimacy`/`ruleClass`/controls or run the wind-tunnel (slice 5); persist any rule to a loadable manifest (slice 5, after stamping); project `CandidateRuleRecord`/`CompiledCandidate` into `legitimacy.provenance` (slice 5).
+
+### The freeze boundary (flag-3 — RESOLVED, structurally)
+
+strategy-claude verified (2153Z + 2226Z) that **no G-series compile entrypoint exists** (`packages/core/src/spine/` has no `compile.ts`; the only `compile.ts` is the CLI's frozen `LessonInput → compiled-rules.json` actuator). So slice 4 **builds** the actuator; it cannot route through the frozen one (different input type — `CandidateRuleRecord` vs `LessonInput`). **The frozen boundary is the ACTUATOR, not the format/parser/validator:**
+
+- **Reuse permitted (outside freeze, confirmed by ≥3 live non-frozen call sites):** `extractManualPattern`/`engineFields` (`lesson-pattern.ts` — data-format/parser), `hashLesson` (pure util), `validateRegex` (defined in `compiler.ts`, NOT the frozen `compile-lesson.ts`; already consumed live by `eslint-adapter`/`lesson-linter`/`semgrep-adapter` — a frozen-internal fn wouldn't be a shared leaf; `freeze.json`'s `do-not` ops — edit `.totem/lessons/**`, run `totem lesson compile`, hand-edit `compiled-rules.json` — touch none of it), `verifyAgainstCodebase` (#1682, shipped).
+- **Forbidden (the line):** importing/calling `compileLesson`/`buildCompiledRule`/`buildManualRule`, or re-entering the `LessonInput` `compileCommand` path. ADR-103's full depth (DSL→IR→SMT→GFV) stays **inherited/deferred** per ADR-111 §2 — slice 4 builds only the compile _seam_ + the #1682 verifier.
+
+### Data model deltas (`packages/core/src/spine/`)
+
+- **`CompiledCandidate`** (`spine/compile.ts`, new) — `{ provenance: ProvenanceRecordSchema, classifierLedgerRef: string, rule: CompiledRule, stage4: Stage4VerificationResult }`. The slice-4 output, one per compiled (structural) candidate. Carries `provenance` **un-projected** (slice-5 projects it into `legitimacy.provenance`) and the full `stage4` payload (so the `no-matches` vs `out-of-scope` distinction survives to slice 5 — codex).
+- **`ClassifierLedgerEntry.stage4Outcome`** (`spine/ledgers.ts`, **the Q3 binding fold**) — additive enum riding alongside `stage4Confirmed`/`dispositionSource`: `'confirmed' | 'untested-no-matches' | 'archived-out-of-scope' | 'compile-rejected'`. The §8 done-criterion reads the **ledger** (not `rule.status`, which lives on the rule); the bare `stage4Confirmed:false` boolean **conflates** `no-matches→untested` (neutral/inconclusive) with `out-of-scope→archived` (the backstop _actively rejected_ a mis-structural candidate — a real classifier-over-eager thesis signal). Identical Tenet-19 shape to slice-3 flag-5 (`dispositionSource`). **No new FM clause** (a done-criterion reporting field, not a falsifying condition; harness a–i unchanged, fixtures gain the field).
+- **`CompiledRule`** — REUSE the shipped `CompiledRuleSchema`. Mint with `unverified:true`, NO `legitimacy`, NO `ruleClass`, **NO `manual:true`** (the reused markdown is the manual/Pipeline-1 _syntax_ but the provenance class is LLM-generated/unverified — codex). `refineLegitimacyRuleClassConsistency` requires both-present-or-both-absent; both-absent is valid. `pattern`/`astQuery`/`astGrepPattern`/`astGrepYamlRule` via `engineFields`; `fileGlobs` sanitized exactly as the existing compiler path; `lessonHash = hashLesson(...)`; any `compiledAt`/`createdAt`/`archivedAt` use **injected `now`**.
+
+### The actuator
+
+- **`compileCandidate(candidate, { now })`** — pure (no IO): throws on `classifierDisposition === 'behavioral'` (FM(c) code backstop); parses `dslSource` via `extractManualPattern`; **per-engine safety validation, fail-loud** — regex → `validateRegex`, ast-grep flat/yaml → `validateAstGrepPattern` (+ sanitized globs); on `{valid:false}` the candidate resolves to `stage4Outcome: 'compile-rejected'` (a counted, reported state — loud, never a silent compile or skipped check; strategy sharpening). A structural candidate whose `dslSource` yields **no usable pattern at all** → **throw** (producer-contract violation: slice-2's `isUsableDsl` preflight should have prevented emission; surfacing a preflight↔parser desync loudly, not routinely rejecting — agy red fixture #2).
+- **`runCompileStage(classifyResult, deps)`** — selects **only** compile-routed (structural) entries; compiles **sequentially in stable classify-output order** (ordinals before any async reorder); for each, runs Stage-4 then maps the outcome; updates the classifier ledger entry found by `classifierLedgerRef` — requiring **exactly one** match (missing/duplicate → fail loud; else confirmation is lost or applied to the wrong row — codex). `deps = { stage4: Stage4VerifierDeps, now: string }`.
+
+### Stage-4 outcome → status mapping
+
+| Stage-4 outcome        | `status`                                                                     | `confidence`/`severity`      | `stage4Confirmed` | `stage4Outcome`         |
+| ---------------------- | ---------------------------------------------------------------------------- | ---------------------------- | ----------------- | ----------------------- |
+| `in-scope-bad-example` | `active` (set explicitly)                                                    | `confidence: high`           | `true`            | `confirmed`             |
+| `candidate-debt`       | `active` (set explicitly)                                                    | `severity: warning` (forced) | `true`            | `confirmed`             |
+| `no-matches`           | `untested-against-codebase`                                                  | —                            | `false`           | `untested-no-matches`   |
+| `out-of-scope`         | `archived` (reason `stage4-out-of-scope-match`, `archivedAt`=injected `now`) | —                            | `false`           | `archived-out-of-scope` |
+| (validation failure)   | not produced as a rule                                                       | —                            | `false`           | `compile-rejected`      |
+
+`status:'active'` is set **explicitly** (never relying on legacy "missing status ⇒ active"). `stage4Confirmed` means "Stage-4 produced positive in-scope evidence sufficient for an active rule" → active outcomes confirmed, inert/archive/rejected not. **Out-of-scope archival is slice-4's call** (§4 deterministic structural backstop — the SAFE direction, demote-never-promote; distinct axis from the wind-tunnel's legitimacy-over-controls — strategy Q4).
+
+### Determinism (Tenet-15 / OQ1)
+
+Inject `now: string` (no `new Date()` in core — matches the `asOfCommit` frozen-timestamp discipline). **Sort `deps.stage4.listFiles()`** before feeding `verifyAgainstCodebase` (the verifier preserves file order for `candidateDebtLines`; unsorted walks change output — codex). Compile sequentially in stable order. Identical inputs + fixed deps → identical `CompiledCandidate[]` + ledgers.
+
+### State lifecycle
+
+- **`CompiledCandidate[]`** — per-run, in-memory, built as `runCompileStage` iterates; never persisted in slice 4 (non-persistence is the load-bearing §1 "blast-radius-zero" guard — slice 5 stamps before any manifest write).
+- **`ClassifierLedger`** — slice-3 wrote it; slice 4 **mutates the matched entry** (sets `stage4Confirmed` + `stage4Outcome`) as the sole slice-4 ledger write. No new ledger (§8 has five; Tenet-21).
+- Cross-lifecycle seam: the classifier ledger is written at classify (slice 3) and **completed** at compile (slice 4) — the matched-entry update is the only mutation, keyed by `classifierLedgerRef`, exactly-one-or-fail-loud.
+
+### Failure modes
+
+| Failure                                                                | Category           | Surface                                                              | Recovery                              |
+| ---------------------------------------------------------------------- | ------------------ | -------------------------------------------------------------------- | ------------------------------------- |
+| behavioral candidate handed to `compileCandidate`                      | contract violation | **throw** (FM(c) code backstop)                                      | fix routing; never compile behavioral |
+| structural `dslSource` yields no usable pattern                        | producer bug       | **throw** (preflight↔parser desync, fail loud — Tenet 4)             | fix slice-2 preflight / parser sync   |
+| pattern parses but fails `validateRegex`/`validateAstGrepPattern`      | runtime            | `stage4Outcome: 'compile-rejected'` (counted, reported; no rule)     | candidate not promoted; surfaced      |
+| missing or duplicate classifier-ledger entry for `classifierLedgerRef` | integrity          | **fail loud**                                                        | fix ref minting / join                |
+| `out-of-scope` (rule fires on clean baseline)                          | backstop           | `status: archived` (safe demote)                                     | rejected by producer before slice 5   |
+| `no-matches`                                                           | neutral            | `status: untested-against-codebase` (legitimately unconfirmed)       | wind-tunnel may still score (slice 5) |
+| ast/ast-grep-yaml rule verified without `workingDirectory`             | runtime            | **loud error** (never graceful-degrade to `no-matches` — agy fix #3) | set deps                              |
+| `deps.readFile` throws on a listed file                                | runtime            | **propagate loudly** preserving `cause` (agy fix #4)                 | —                                     |
+
+### Invariants to lock via tests (deterministic, fixture Stage-4 deps)
+
+- **Frozen-actuator never called** (agy fold-1, BINDING): spy/mock asserts `compileLesson`/`buildCompiledRule`/`buildManualRule` are never invoked in a G-series run; structural assertion that `compiledAt`/`createdAt`/`archivedAt` strictly equal injected `now` (no `new Date()`).
+- **Only structural compiles**: behavioral → throw (handed directly to `compileCandidate` AND present in `runCompileStage`'s input); `runCompileStage` selects only compile-routed entries.
+- **Four Stage-4 outcome maps** (agy fold-2): one fixture `Stage4VerifierDeps` file-map per outcome (`in-scope-bad-example`/`candidate-debt`/`no-matches`/`out-of-scope`) → asserts the status/confidence/severity/`stage4Confirmed`/`stage4Outcome` row above.
+- **Parse fidelity both engines**: regex AND ast-grep-yaml round-trip through `extractManualPattern`/`engineFields`.
+- **Mapping/mint constraints**: `unverified:true`; no `legitimacy`/`ruleClass`/`manual`; provenance + `classifierLedgerRef` on `CompiledCandidate` not the rule; `lessonHash = hashLesson(...)`; globs sanitized.
+- **Classifier-ledger join**: exactly-one match required; missing ref → fail loud; duplicate ref → fail loud; `stage4Confirmed`/`stage4Outcome` flip on the **right** `clr-…` row.
+- **`compile-rejected` on unsafe pattern**: a ReDoS-unsafe regex (and an invalid ast-grep rule) → `stage4Outcome: 'compile-rejected'`, no active rule.
+- **Determinism**: fixed `now` + fixed deps → byte-identical output; unsorted `listFiles` would change output (so the sort is locked).
+- **Red fixtures** (agy appendix): `unusable-dsl-source`→throw; `missing-working-directory`→loud; `readFile-failure`→propagate with `cause`.
+- **§8 harness end-to-end** (real classify→compile output → `runFalsificationHarness` green) + the OQ4 active-invariant red craft below.
+
+### §8 harness change (OQ4 — gemini/agy/strategy convergent)
+
+Add an `active ⟹ stage4Confirmed === true` consistency check, scoped to `status:'active'` rules **only** — explicitly **exempt** `archived` + `untested-against-codebase` (legitimately `stage4Confirmed:false`, NOT FM violations — agy fold-3). **No new FM letter** (strategy's lean; by-construction the `Stage4Decision` atomic map makes desync unreachable, but the check is locked symmetric to FM(c)). Red craft: an active rule with `stage4Confirmed:false` → hard harness failure; archived/untested pass clean. §8 can then report the verify-split "N structural-routed → A confirmed-active / B untested / C archived-by-backstop / D compile-rejected" (the compile-stage twin of the classifier-routing split §8 already reports).
+
+### Panel verdicts + folds (authoritative over inline text where they conflict)
+
+Four-seat cohort panel, all independent (#2167), **4/4 convergent, no blockers**:
+
+- **gemini** (tenet/architecture) — **APPROVED, no concerns** (7/7 PASS; Tenet-21 reuse, flag-3 boundary, Tenet-9 sensor-only/legitimacy-absent, Tenet-15 inject-`now`, core-IO-free DI, decomposition, OQ4-here all PASS).
+- **strategy-claude** (ADR-111 fidelity) — **FAITHFUL DISCHARGE + 1 binding fold (Q3)** + 4 confirmations: Q1/OQ3 `validateRegex` CONFIRMED outside-freeze (structural) + fail-loud-on-`{valid:false}` sharpening; Q4 archival = slice-4's (§4, distinct axis); Q5/OQ4 active⟹confirmed by-construction (verified≠certified), no new FM letter; OQ1/2/5 concur.
+- **codex** (contract/correctness) — **CONCERN → build-folds**: per-engine validator (`validateRegex` regex-only; ast-grep needs `validateAstGrepPattern`+globs; don't import `buildManualRule` for it); no `manual:true`; explicit `status:'active'` + injected-`now` timestamps; classifier-ledger join exactly-one; sort `listFiles`; retain `stage4` payload to slice 5 (no 6th ledger).
+- **agy** (build/test-completeness) — **PASS + 4 folds**: frozen import/call-spy; 4-outcome fixture maps; harness active-only exemption map; decoupled provenance handoff; + 4 red-fixture targets (behavioral-throw, unusable-dsl-throw, missing-workingDirectory-loud, readFile-failure-propagate).
+
+**Binding build item:** the Q3 `stage4Outcome` ledger field (3-seat: strategy Q3 = codex "stage4Confirmed loses no-matches vs out-of-scope" = the slice-3 flag-5 shape).
+
+### Carried-forward bindings (slice 5, pinned here)
+
+1. **Stamp-before-persist** — slice 5 stamps `legitimacy`/`ruleClass` BEFORE any write to a loadable manifest; never persist an unstamped `unverified:true` rule to `.totem/compiled-rules.json`.
+2. **Archived ≠ wind-tunnel FP** — `out-of-scope` archivals are rejected by the producer before the wind-tunnel; they never enter the scored set. Conversely Stage-4-`active` ≠ legitimate (still Yellow, still owes the wind-tunnel).
+3. **#2201 resolution-filtering** (ADR-111 §6/§8 — the ADR-095 label was strategy's mislabel, corrected) — before-promotion gate; lands in the slice-5 adapter's initial impl as a named, separately-reviewable sub-step (flag-4 holds by construction).
+4. **Engine-proxy verify** — confirm `run-compiled-rules.ts` honors top-level `unverified:true` so a leaked unstamped candidate can't read as `hard` (the engine-type proxy fallback for an unstamped rule).
+
+### Dispositions
+
+- **Operator 2026-06-19:** "finish the spine first" — **build greenlight** for slice 4 (Phase-4 gate cleared). Merge remains a separate explicit operator call per PR (close-keyword caution: PR "Part of #2199", #2199 stays open).
+- **Cohort panel (pre-build, 2026-06-19):** 4/4 convergent (above); the only build-blocking item was Q3 (the additive `stage4Outcome` field), folded into this design. strategy owns the ADR-111 §3 prose↔schema erratum + §5 codification (their fast-follows, non-blocking).
+
+**Pre-build status:** design folded + panel-blessed (4/4 approve) + re-persisted after WIP loss. **Build greenlit (operator 2026-06-19).** Next: slice 5 (certifying run = #2189 item 1) folds in #2201 + discharges the 4 bindings above.

--- a/packages/core/src/spine/compile.test.ts
+++ b/packages/core/src/spine/compile.test.ts
@@ -1,0 +1,422 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import type { CandidateRuleRecord } from './candidate-rule.js';
+import {
+  type ClassifierResult,
+  type ClassifyStageResult,
+  type DraftClassifier,
+  runClassifyStage,
+} from './classify.js';
+import {
+  compileCandidate,
+  type CompiledCandidate,
+  type CompileStageDeps,
+  runCompileStage,
+} from './compile.js';
+import type { DraftCandidate, ExtractStageResult } from './extract.js';
+import type { MinerLedgers, SplitLedger } from './ledgers.js';
+import { runFalsificationHarness } from './miner-harness.js';
+
+// The frozen LessonInput actuator is wrapped in spies so the call-spy test (agy
+// fold-1) can assert the G-series path NEVER touches it. `validateAstGrepPattern`
+// (the one symbol compile.ts imports from this module) is preserved via `...actual`.
+vi.mock('../compile-lesson.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../compile-lesson.js')>();
+  return {
+    ...actual,
+    compileLesson: vi.fn(actual.compileLesson),
+    buildCompiledRule: vi.fn(actual.buildCompiledRule),
+    buildManualRule: vi.fn(actual.buildManualRule),
+  };
+});
+import * as frozenActuator from '../compile-lesson.js';
+
+const sha = (n: number): string => String(n).padStart(40, '0');
+const NOW = '2026-06-19T12:00:00.000Z';
+
+// ── dslSource fixtures (lesson-markdown bodies the slice-2/3 format produces) ──
+
+const REGEX_DSL = [
+  '**Pattern:** `forbiddenCall\\(`',
+  '**Engine:** regex',
+  '**Severity:** warning',
+  '',
+  '### Bad Example',
+  '```ts',
+  'forbiddenCall()',
+  '```',
+].join('\n');
+
+// Same pattern, severity error — used to prove candidate-debt FORCES warning.
+const REGEX_DSL_ERROR = REGEX_DSL.replace('**Severity:** warning', '**Severity:** error');
+
+// A ReDoS-unsafe pattern — `validateRegex` rejects → compile-rejected.
+const REDOS_DSL = ['**Pattern:** `(a+)+$`', '**Engine:** regex'].join('\n');
+
+// engine: ast (tree-sitter query) — no ReDoS validator, so it compiles; used to
+// exercise the workingDirectory guard without the ast-grep napi parser.
+const AST_DSL = ['**Pattern:** `(call_expression)`', '**Engine:** ast'].join('\n');
+
+// A compound ast-grep yaml rule — parse-fidelity check for the yaml engine.
+const ASTGREP_YAML_DSL = [
+  '**Engine:** ast-grep',
+  '**Pattern:**',
+  '```yaml',
+  'rule:',
+  '  pattern: console.log($MSG)',
+  '```',
+].join('\n');
+
+// No `**Pattern:**` — `extractManualPattern` returns null (a structural candidate
+// here is a producer-contract violation: slice-2 preflight should have dropped it).
+const NO_PATTERN_DSL = 'Prefer composition over inheritance — a behavioral note.';
+
+// ── Builders ──────────────────────────────────────────────────────────────────
+
+function candidateRule(
+  pr: number,
+  dslSource: string,
+  disposition: 'structural' | 'behavioral' = 'structural',
+  ordinal = 0,
+): CandidateRuleRecord {
+  return {
+    provenance: { mergedPr: pr, reviewThread: `rt-${pr}`, commitSha: sha(pr) },
+    classifierDisposition: disposition,
+    classifierLedgerRef: `clr-${pr}-${ordinal}`,
+    dslSource,
+    unverified: true,
+  };
+}
+
+/** A minimal ClassifyStageResult with emission + classifier ledgers consistent with the candidates. */
+function classifyResultOf(candidates: CandidateRuleRecord[]): ClassifyStageResult {
+  return {
+    candidates,
+    emissionLedger: {
+      entries: candidates.map((c, i) => ({
+        candidateRef: `cand-${c.provenance.mergedPr}-${i}`,
+        provenance: c.provenance,
+        classifierDisposition: c.classifierDisposition,
+        routing: c.classifierDisposition === 'structural' ? 'compile' : 'rag-only',
+        classifierLedgerRef: c.classifierLedgerRef,
+        unverified: true,
+      })),
+      extractionInputsAttestation: { seedClassesProvided: false },
+    },
+    classifierLedger: {
+      entries: candidates.map((c) => ({
+        candidateRef: c.classifierLedgerRef,
+        disposition: c.classifierDisposition,
+        stage4Confirmed: false,
+        dispositionSource: 'classified' as const,
+      })),
+    },
+  };
+}
+
+/** Stage-4 deps backed by an in-memory file map. `readFile` rejects for a listed-but-absent file. */
+function compileDeps(
+  files: Record<string, string>,
+  overrides: Partial<CompileStageDeps> = {},
+): CompileStageDeps {
+  return {
+    now: NOW,
+    stage4: {
+      listFiles: () => Promise.resolve(Object.keys(files)),
+      readFile: (f: string) =>
+        f in files ? Promise.resolve(files[f] as string) : Promise.reject(new Error(`absent ${f}`)),
+      ...overrides.stage4,
+    },
+    ...('baseline' in overrides ? { baseline: overrides.baseline } : {}),
+    ...('now' in overrides ? { now: overrides.now } : {}),
+  };
+}
+
+const single = (dsl: string, disp: 'structural' | 'behavioral' = 'structural') =>
+  classifyResultOf([candidateRule(1, dsl, disp)]);
+
+// ── compileCandidate (pure) ─────────────────────────────────────────────────
+
+describe('compileCandidate', () => {
+  it('compiles a regex structural candidate: unverified, no legitimacy/ruleClass/manual, injected now', () => {
+    const out = compileCandidate(candidateRule(1, REGEX_DSL), { now: NOW });
+    expect(out.kind).toBe('compiled');
+    if (out.kind !== 'compiled') throw new Error('unreachable');
+    const { rule } = out;
+    expect(rule.engine).toBe('regex');
+    expect(rule.pattern).toBe('forbiddenCall\\(');
+    expect(rule.unverified).toBe(true);
+    expect(rule.legitimacy).toBeUndefined();
+    expect(rule.ruleClass).toBeUndefined();
+    expect(rule.manual).toBeUndefined();
+    expect(rule.badExample).toBe('forbiddenCall()');
+    expect(rule.compiledAt).toBe(NOW);
+    expect(rule.createdAt).toBe(NOW);
+    expect(rule.lessonHeading).toBe('Gate-1 rule candidate (clr-1-0)');
+  });
+
+  it('throws on a behavioral candidate (FM(c) code backstop)', () => {
+    expect(() => compileCandidate(candidateRule(1, REGEX_DSL, 'behavioral'), { now: NOW })).toThrow(
+      /behavioral candidate .* must never be compiled/,
+    );
+  });
+
+  it('throws on a structural candidate with no usable pattern (preflight↔parser desync)', () => {
+    expect(() => compileCandidate(candidateRule(1, NO_PATTERN_DSL), { now: NOW })).toThrow(
+      /no usable pattern/,
+    );
+  });
+
+  it('rejects (not throws) a ReDoS-unsafe regex → compile-rejected', () => {
+    const out = compileCandidate(candidateRule(1, REDOS_DSL), { now: NOW });
+    expect(out.kind).toBe('rejected');
+  });
+
+  it('parses a compound ast-grep yaml rule (engine ast-grep, astGrepYamlRule populated)', () => {
+    const out = compileCandidate(candidateRule(1, ASTGREP_YAML_DSL), { now: NOW });
+    expect(out.kind).toBe('compiled');
+    if (out.kind !== 'compiled') throw new Error('unreachable');
+    expect(out.rule.engine).toBe('ast-grep');
+    expect(out.rule.astGrepYamlRule).toBeDefined();
+    expect(out.rule.pattern).toBe('');
+  });
+});
+
+// ── runCompileStage — the four Stage-4 outcome maps (regex, deterministic) ────
+
+describe('runCompileStage — Stage-4 outcome → status/ledger maps', () => {
+  it('in-scope-bad-example → active/high/confirmed', async () => {
+    const r = await runCompileStage(
+      single(REGEX_DSL),
+      compileDeps({ 'src/a.ts': 'forbiddenCall()' }),
+    );
+    expect(r.compiled).toHaveLength(1);
+    expect(r.compiled[0]?.stage4.outcome).toBe('in-scope-bad-example');
+    expect(r.compiled[0]?.rule.status).toBe('active');
+    expect(r.compiled[0]?.rule.confidence).toBe('high');
+    expect(r.classifierLedger.entries[0]?.stage4Confirmed).toBe(true);
+    expect(r.classifierLedger.entries[0]?.stage4Outcome).toBe('confirmed');
+  });
+
+  it('candidate-debt → active, severity FORCED to warning, confirmed', async () => {
+    const r = await runCompileStage(
+      single(REGEX_DSL_ERROR),
+      compileDeps({ 'src/a.ts': 'forbiddenCall(x)' }),
+    );
+    expect(r.compiled[0]?.stage4.outcome).toBe('candidate-debt');
+    expect(r.compiled[0]?.rule.status).toBe('active');
+    expect(r.compiled[0]?.rule.severity).toBe('warning'); // forced down from error
+    expect(r.classifierLedger.entries[0]?.stage4Outcome).toBe('confirmed');
+  });
+
+  it('no-matches → untested-against-codebase, not confirmed', async () => {
+    const r = await runCompileStage(
+      single(REGEX_DSL),
+      compileDeps({ 'src/a.ts': 'const ok = 1;' }),
+    );
+    expect(r.compiled[0]?.stage4.outcome).toBe('no-matches');
+    expect(r.compiled[0]?.rule.status).toBe('untested-against-codebase');
+    expect(r.classifierLedger.entries[0]?.stage4Confirmed).toBe(false);
+    expect(r.classifierLedger.entries[0]?.stage4Outcome).toBe('untested-no-matches');
+  });
+
+  it('out-of-scope (fires on a baseline file) → archived, archivedAt=now, not confirmed', async () => {
+    const r = await runCompileStage(
+      single(REGEX_DSL),
+      compileDeps({ 'src/a.test.ts': 'forbiddenCall()' }),
+    );
+    expect(r.compiled[0]?.stage4.outcome).toBe('out-of-scope');
+    expect(r.compiled[0]?.rule.status).toBe('archived');
+    expect(r.compiled[0]?.rule.archivedAt).toBe(NOW);
+    expect(r.compiled[0]?.rule.archivedReason).toMatch(/stage4-out-of-scope-match/);
+    expect(r.classifierLedger.entries[0]?.stage4Outcome).toBe('archived-out-of-scope');
+  });
+});
+
+// ── runCompileStage — routing, rejection, ledger join, fail-loud ──────────────
+
+describe('runCompileStage — selection, rejection & fail-loud', () => {
+  it('compiles only structural; skips behavioral (untouched ledger entry)', async () => {
+    const cls = classifyResultOf([
+      candidateRule(1, REGEX_DSL, 'structural'),
+      candidateRule(2, 'prefer X over Y', 'behavioral'),
+    ]);
+    const r = await runCompileStage(cls, compileDeps({ 'src/a.ts': 'forbiddenCall()' }));
+    expect(r.compiled).toHaveLength(1);
+    expect(r.compiled[0]?.classifierLedgerRef).toBe('clr-1-0');
+    const behavioral = r.classifierLedger.entries.find((e) => e.candidateRef === 'clr-2-0');
+    expect(behavioral?.stage4Confirmed).toBe(false);
+    expect(behavioral?.stage4Outcome).toBeUndefined(); // never compiled
+  });
+
+  it('records compile-rejected on the ledger and emits no CompiledCandidate', async () => {
+    const r = await runCompileStage(single(REDOS_DSL), compileDeps({ 'src/a.ts': 'aaaa' }));
+    expect(r.compiled).toHaveLength(0);
+    expect(r.classifierLedger.entries[0]?.stage4Confirmed).toBe(false);
+    expect(r.classifierLedger.entries[0]?.stage4Outcome).toBe('compile-rejected');
+  });
+
+  it('fails loud when a structural candidate has no matching classifier-ledger entry', async () => {
+    const cls = single(REGEX_DSL);
+    cls.classifierLedger.entries = []; // drop the join target
+    await expect(runCompileStage(cls, compileDeps({}))).rejects.toThrow(
+      /matches 0 classifier-ledger entries/,
+    );
+  });
+
+  it('fails loud on a duplicate classifier-ledger ref', async () => {
+    const cls = single(REGEX_DSL);
+    cls.classifierLedger.entries.push({ ...cls.classifierLedger.entries[0]! });
+    await expect(
+      runCompileStage(cls, compileDeps({ 'src/a.ts': 'forbiddenCall()' })),
+    ).rejects.toThrow(/matches 2 classifier-ledger entries/);
+  });
+
+  it('throws on an ast/ast-grep rule without a workingDirectory (never degrades to no-matches)', async () => {
+    await expect(
+      runCompileStage(single(AST_DSL), compileDeps({ 'src/a.ts': 'x' })),
+    ).rejects.toThrow(/requires deps\.stage4\.workingDirectory/);
+  });
+
+  it('propagates a readFile failure loudly (preserves cause)', async () => {
+    const deps: CompileStageDeps = {
+      now: NOW,
+      stage4: {
+        listFiles: () => Promise.resolve(['src/a.ts']),
+        readFile: () => Promise.reject(new Error('disk gone')),
+      },
+    };
+    await expect(runCompileStage(single(REGEX_DSL), deps)).rejects.toThrow(
+      /could not read src\/a\.ts/,
+    );
+  });
+
+  it('throws directly on a behavioral candidate handed to compileCandidate via the stage too', async () => {
+    // runCompileStage filters behavioral out, but compileCandidate is the FM(c) backstop.
+    expect(() =>
+      compileCandidate(candidateRule(9, REGEX_DSL, 'behavioral'), { now: NOW }),
+    ).toThrow();
+  });
+});
+
+// ── Determinism + provenance handoff ──────────────────────────────────────────
+
+describe('runCompileStage — determinism & handoff', () => {
+  it('is deterministic: identical inputs + fixed now/deps → identical output', async () => {
+    const files = { 'src/b.ts': 'forbiddenCall(y)', 'src/a.ts': 'forbiddenCall()' };
+    const a = await runCompileStage(single(REGEX_DSL), compileDeps(files));
+    const b = await runCompileStage(single(REGEX_DSL), compileDeps(files));
+    expect(JSON.stringify(a)).toBe(JSON.stringify(b));
+  });
+
+  it('carries provenance forward un-projected onto the CompiledCandidate', async () => {
+    const r = await runCompileStage(
+      single(REGEX_DSL),
+      compileDeps({ 'src/a.ts': 'forbiddenCall()' }),
+    );
+    const cc: CompiledCandidate | undefined = r.compiled[0];
+    expect(cc?.provenance).toEqual({ mergedPr: 1, reviewThread: 'rt-1', commitSha: sha(1) });
+    expect(cc?.rule.legitimacy).toBeUndefined(); // slice-5 stamps it
+  });
+
+  it('never calls the frozen LessonInput actuator (compileLesson/buildCompiledRule/buildManualRule)', async () => {
+    await runCompileStage(single(REGEX_DSL), compileDeps({ 'src/a.ts': 'forbiddenCall()' }));
+    expect(vi.mocked(frozenActuator.compileLesson)).not.toHaveBeenCalled();
+    expect(vi.mocked(frozenActuator.buildCompiledRule)).not.toHaveBeenCalled();
+    expect(vi.mocked(frozenActuator.buildManualRule)).not.toHaveBeenCalled();
+  });
+});
+
+// ── End-to-end harness lock (real classify → compile → §8 harness green) ──────
+
+const asStructural: ClassifierResult = {
+  disposition: 'structural',
+  dispositionSource: 'classified',
+};
+const structuralClassifier: DraftClassifier = { classify: () => Promise.resolve(asStructural) };
+
+function draft(pr: number, dslSource: string): DraftCandidate {
+  return { provenance: { mergedPr: pr, reviewThread: `rt-${pr}`, commitSha: sha(pr) }, dslSource };
+}
+
+function extractResultOf(drafts: DraftCandidate[]): ExtractStageResult {
+  const prs = [...new Set(drafts.map((d) => d.provenance.mergedPr))].sort((a, b) => a - b);
+  return {
+    drafts,
+    dropLedger: { entries: [] },
+    apiUsageLedger: {
+      entries: prs.map((pr) => ({
+        targetPr: pr,
+        slice: 'train' as const,
+        fetchKind: 'review-thread',
+      })),
+      heldOutFetchCount: 0,
+    },
+    seedBlindness: { seedClassesProvided: false },
+  };
+}
+
+function splitLedgerFixture(): SplitLedger {
+  return {
+    split: {
+      asOfCommit: sha(100),
+      trainPrs: [1, 2],
+      heldOutPrs: [3, 4],
+      excludedPrs: [],
+      positiveControlPrs: [3],
+      negativeControlPrs: [4],
+      splitRule: { predicate: 'code-touching non-bot', cutIndex: 2 },
+    },
+    corpus: [1, 2, 3, 4],
+    corpusMergeCommits: [1, 2, 3, 4].map((pr) => ({ pr, mergeCommit: sha(pr) })),
+  };
+}
+
+describe('runCompileStage — end-to-end §8 harness lock', () => {
+  it('real classify → compile output passes runFalsificationHarness green', async () => {
+    const extract = extractResultOf([draft(1, REGEX_DSL), draft(2, REGEX_DSL)]);
+    const split = splitLedgerFixture();
+    const classify = await runClassifyStage(extract, split, { classifier: structuralClassifier });
+    const compileRes = await runCompileStage(
+      classify,
+      compileDeps({ 'src/a.ts': 'forbiddenCall()' }),
+    );
+
+    const ledgers: MinerLedgers = {
+      emission: classify.emissionLedger,
+      drop: extract.dropLedger,
+      classifier: compileRes.classifierLedger, // the COMPILE-UPDATED ledger
+      split,
+      apiUsage: extract.apiUsageLedger,
+    };
+    const result = runFalsificationHarness(ledgers);
+    expect(result.ok).toBe(true);
+    expect(result.violations).toEqual([]);
+    // both train PRs confirmed-active
+    expect(compileRes.compiled).toHaveLength(2);
+    expect(compileRes.classifierLedger.entries.every((e) => e.stage4Outcome === 'confirmed')).toBe(
+      true,
+    );
+  });
+
+  it('a desynced stage4Confirmed vs stage4Outcome trips the consistency guard', async () => {
+    const extract = extractResultOf([draft(1, REGEX_DSL), draft(2, REGEX_DSL)]);
+    const split = splitLedgerFixture();
+    const classify = await runClassifyStage(extract, split, { classifier: structuralClassifier });
+    const compileRes = await runCompileStage(
+      classify,
+      compileDeps({ 'src/a.ts': 'forbiddenCall()' }),
+    );
+    // Forge a desync: a confirmed outcome whose stage4Confirmed is flipped to false.
+    compileRes.classifierLedger.entries[0]!.stage4Confirmed = false;
+    const ledgers: MinerLedgers = {
+      emission: classify.emissionLedger,
+      drop: extract.dropLedger,
+      classifier: compileRes.classifierLedger,
+      split,
+      apiUsage: extract.apiUsageLedger,
+    };
+    const clauses = runFalsificationHarness(ledgers).violations.map((v) => v.clause);
+    expect(clauses).toContain('stage4-consistency');
+  });
+});

--- a/packages/core/src/spine/compile.test.ts
+++ b/packages/core/src/spine/compile.test.ts
@@ -272,13 +272,19 @@ describe('runCompileStage — selection, rejection & fail-loud', () => {
     ).rejects.toThrow(/matches 2 classifier-ledger entries/);
   });
 
-  it('throws on an ast/ast-grep rule without a workingDirectory (never degrades to no-matches)', async () => {
+  it('throws on an ast rule without a workingDirectory (never degrades to no-matches)', async () => {
     await expect(
       runCompileStage(single(AST_DSL), compileDeps({ 'src/a.ts': 'x' })),
     ).rejects.toThrow(/requires deps\.stage4\.workingDirectory/);
   });
 
-  it('propagates a readFile failure loudly (preserves cause)', async () => {
+  it('throws on an ast-grep rule without a workingDirectory too (both tree-sitter engines)', async () => {
+    await expect(
+      runCompileStage(single(ASTGREP_YAML_DSL), compileDeps({ 'src/a.ts': 'x' })),
+    ).rejects.toThrow(/requires deps\.stage4\.workingDirectory/);
+  });
+
+  it('propagates a readFile failure loudly, preserving the original cause', async () => {
     const deps: CompileStageDeps = {
       now: NOW,
       stage4: {
@@ -286,9 +292,15 @@ describe('runCompileStage — selection, rejection & fail-loud', () => {
         readFile: () => Promise.reject(new Error('disk gone')),
       },
     };
-    await expect(runCompileStage(single(REGEX_DSL), deps)).rejects.toThrow(
-      /could not read src\/a\.ts/,
+    // compile.ts owns "no swallowing catch" — assert the ORIGINAL error survives as
+    // the cause, not the verifier's wrapper message (which compile.ts does not own).
+    const err = await runCompileStage(single(REGEX_DSL), deps).then(
+      () => null,
+      (e: unknown) => e,
     );
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).cause).toBeInstanceOf(Error);
+    expect(((err as Error).cause as Error).message).toBe('disk gone');
   });
 
   it('throws directly on a behavioral candidate handed to compileCandidate via the stage too', async () => {

--- a/packages/core/src/spine/compile.ts
+++ b/packages/core/src/spine/compile.ts
@@ -206,19 +206,24 @@ function mapStage4Outcome(outcome: Stage4Outcome, now: string): Stage4Mapping {
  * stable classify-output order (deterministic ordinals before any async reorder).
  * Returns the `CompiledCandidate[]` + the classifier ledger with `stage4Confirmed`
  * and `stage4Outcome` filled on every compile-routed entry (behavioral/rag-only
- * entries are left untouched). Mutates nothing; the input ledger is copied.
+ * entries are left untouched). Mutates nothing: returns a new ledger object with a
+ * new entries array — updated entries are spread copies, unmodified entries share
+ * the original reference (a structural copy, not a deep copy).
  */
 export async function runCompileStage(
   classify: ClassifyStageResult,
   deps: CompileStageDeps,
 ): Promise<CompileStageResult> {
   const baseline = deps.baseline ?? getDefaultBaseline();
-  // Determinism (codex fold): canonicalize the file-walk order before the verifier —
-  // it preserves file order for `candidateDebtLines`, so an unsorted `listFiles` would
-  // make the output (and `CompiledCandidate.stage4`) non-reproducible.
+  // Determinism (codex fold) + perf (GCA): resolve the file list ONCE, sorted, and
+  // reuse that snapshot for every candidate. `verifyAgainstCodebase` calls
+  // `listFiles()` on each invocation, so an un-memoized wrapper would re-walk the
+  // repo once per structural candidate (N walks); the frozen snapshot also keeps the
+  // file order identical across candidates. Lazy — a zero-candidate run never walks.
+  let fileSnapshot: readonly string[] | undefined;
   const stage4: Stage4VerifierDeps = {
     ...deps.stage4,
-    listFiles: async () => [...(await deps.stage4.listFiles())].sort(),
+    listFiles: async () => (fileSnapshot ??= [...(await deps.stage4.listFiles())].sort()),
   };
   const compiled: CompiledCandidate[] = [];
   const updates = new Map<

--- a/packages/core/src/spine/compile.ts
+++ b/packages/core/src/spine/compile.ts
@@ -1,0 +1,284 @@
+// ─── ADR-111 Gate-1 miner slice 4: Stage-3 Compile + Stage-4 Verify ──────────
+//
+// The fresh, non-frozen G-series compile actuator. For each compile-routed
+// (structural) `CandidateRuleRecord` it parses the lesson-markdown `dslSource`
+// into a `CompiledRule`, runs the shipped Stage-4 codebase verifier, maps the
+// outcome onto the rule's status/confidence/severity, and records the outcome on
+// the classifier ledger (flips `stage4Confirmed` + sets `stage4Outcome`).
+//
+// FREEZE BOUNDARY (flag-3, BINDING): the frozen thing is the legacy `LessonInput`
+// ACTUATOR (`compileLesson`/`buildCompiledRule`/`buildManualRule`, the
+// `totem lesson compile` path), NOT the lesson-markdown format, its parser, or the
+// pure validators. This module REUSES `extractManualPattern`/`engineFields`/
+// `hashLesson`/`validateRegex`/`validateAstGrepPattern`/`verifyAgainstCodebase`
+// (data-format + pure-validator + verifier reuse — Tenet 21) and NEVER imports or
+// calls the frozen actuator. The compiled rule is minted `unverified: true` with
+// `legitimacy`/`ruleClass` ABSENT (the wind-tunnel stamps them in slice 5) and is
+// never persisted to a loadable manifest here (slice-5 stamp-before-persist).
+
+// `validateAstGrepPattern` is a PURE validator (no IO/state) that happens to be
+// defined in `compile-lesson.ts`. Importing it is validator reuse — OUTSIDE the
+// freeze boundary, which is the `LessonInput` actuator path, not the validators
+// (strategy-claude 2226Z, structural: the validator is already a shared leaf). We
+// deliberately import ONLY this validator and NEVER the frozen actuator functions.
+import { validateAstGrepPattern } from '../compile-lesson.js';
+import { engineFields, hashLesson, sanitizeFileGlobs, validateRegex } from '../compiler.js';
+import {
+  type CompiledRule,
+  CompiledRuleSchema,
+  type ProvenanceRecord,
+} from '../compiler-schema.js';
+import { extractManualPattern, type ManualPattern } from '../lesson-pattern.js';
+import {
+  getDefaultBaseline,
+  type Stage4Baseline,
+  type Stage4Outcome,
+  type Stage4VerificationResult,
+  type Stage4VerifierDeps,
+  verifyAgainstCodebase,
+} from '../stage4-verifier.js';
+import type { CandidateRuleRecord } from './candidate-rule.js';
+import type { ClassifyStageResult } from './classify.js';
+import type { ClassifierLedger, Stage4LedgerOutcome } from './ledgers.js';
+
+/**
+ * The slice-4 output: a compiled, Stage-4-verified candidate. Carries `provenance`
+ * UN-PROJECTED (slice 5 projects it into `legitimacy.provenance` when it stamps the
+ * wind-tunnel verdict) and the full `stage4` payload (so the `no-matches` vs
+ * `out-of-scope` distinction survives downstream — codex). The `rule` is
+ * `unverified: true`, `legitimacy`/`ruleClass`-free, never `manual`.
+ */
+export interface CompiledCandidate {
+  provenance: ProvenanceRecord;
+  classifierLedgerRef: string;
+  rule: CompiledRule;
+  stage4: Stage4VerificationResult;
+}
+
+/** Pure compile outcome (no IO): a compiled rule, or a loud per-engine validation rejection. */
+export type CompileOutcome =
+  | { kind: 'compiled'; rule: CompiledRule }
+  | { kind: 'rejected'; reason: string };
+
+export interface CompileStageDeps {
+  stage4: Stage4VerifierDeps;
+  /** Injected timestamp — no `new Date()` in core (Tenet 15 determinism, OQ1). */
+  now: string;
+  /** Stage-4 baseline; defaults to `getDefaultBaseline()` (test/fixture globs). */
+  baseline?: Stage4Baseline;
+}
+
+export interface CompileStageResult {
+  compiled: CompiledCandidate[];
+  /** The classifier ledger with `stage4Confirmed` + `stage4Outcome` filled on every compile-routed entry. */
+  classifierLedger: ClassifierLedger;
+}
+
+/** Stable, deterministic lesson heading for a candidate (unique via its `clr-…` ledger ref). */
+function candidateHeading(candidate: CandidateRuleRecord): string {
+  return `Gate-1 rule candidate (${candidate.classifierLedgerRef})`;
+}
+
+/**
+ * Compile a single compile-routed candidate's `dslSource` into a `CompiledRule`.
+ * PURE (no IO). Throws — fail loud, never a silent skip — on a behavioral candidate
+ * (FM(c) code backstop) or a structural candidate whose `dslSource` yields no usable
+ * pattern (a producer-contract violation: slice-2's `isUsableDsl` preflight should
+ * have prevented emission, so this surfaces a preflight↔parser desync). Returns a
+ * `rejected` outcome (NOT a throw) when the pattern parses but fails per-engine
+ * safety validation (e.g. ReDoS) — a counted, reported `compile-rejected` state.
+ */
+export function compileCandidate(
+  candidate: CandidateRuleRecord,
+  opts: { now: string },
+): CompileOutcome {
+  if (candidate.classifierDisposition === 'behavioral') {
+    throw new Error(
+      `[Totem Error] compileCandidate: behavioral candidate '${candidate.classifierLedgerRef}' must never be compiled (FM(c))`,
+    );
+  }
+  // May throw TotemParseError (e.g. a yaml fence under a non-ast-grep engine) — that
+  // propagates loudly as a producer bug; it would also have been dropped at extract.
+  const mp: ManualPattern | null = extractManualPattern(candidate.dslSource);
+  if (mp === null) {
+    throw new Error(
+      `[Totem Error] compileCandidate: structural candidate '${candidate.classifierLedgerRef}' has no usable pattern — slice-2 preflight (isUsableDsl) should have dropped it (preflight↔parser desync)`,
+    );
+  }
+
+  const fileGlobs = sanitizeFileGlobs(mp.fileGlobs ?? []);
+
+  // Per-engine safety validation, fail loud → `compile-rejected` (strategy sharpening:
+  // call the validator and reject on `{valid:false}`, never a silent/skipped compile).
+  if (mp.engine === 'regex') {
+    const v = validateRegex(mp.pattern);
+    if (!v.valid) return { kind: 'rejected', reason: v.reason ?? 'invalid regex pattern' };
+  } else if (mp.engine === 'ast-grep') {
+    const v = validateAstGrepPattern(mp.astGrepYamlRule ?? mp.pattern, fileGlobs);
+    if (!v.valid) return { kind: 'rejected', reason: v.reason ?? 'invalid ast-grep rule' };
+  }
+  // engine 'ast' (tree-sitter S-expression): no ReDoS-class validator applies — the
+  // query was already structurally parsed by `extractManualPattern`.
+
+  const heading = candidateHeading(candidate);
+  const ef = engineFields(mp.engine, mp.astGrepYamlRule ?? mp.pattern);
+  const rule = CompiledRuleSchema.parse({
+    lessonHash: hashLesson(heading, candidate.dslSource),
+    lessonHeading: heading,
+    message: mp.message ?? heading,
+    engine: mp.engine,
+    ...ef,
+    ...(fileGlobs.length > 0 ? { fileGlobs } : {}),
+    severity: mp.severity,
+    ...(mp.badExample !== undefined ? { badExample: mp.badExample } : {}),
+    compiledAt: opts.now,
+    createdAt: opts.now,
+    // Yellow/sensor-only: legitimacy + ruleClass ABSENT (slice-5 wind-tunnel stamps
+    // them); never `manual` (the markdown is the DSL carrier, NOT a Pipeline-1 trust
+    // claim — codex). `deriveRuleClass` forces 'advisory' on `unverified:true`.
+    unverified: true,
+  });
+  return { kind: 'compiled', rule };
+}
+
+interface Stage4Mapping {
+  rulePatch: Partial<CompiledRule>;
+  stage4Confirmed: boolean;
+  stage4Outcome: Stage4LedgerOutcome;
+}
+
+/**
+ * Map a Stage-4 verifier outcome onto the rule's status/confidence/severity + the
+ * classifier-ledger fields (mirrors the frozen `applyStage4` semantics, but injects
+ * `now` instead of `new Date()` and sets `status` EXPLICITLY rather than relying on
+ * "missing status ⇒ active"). `stage4Confirmed` = "Stage-4 produced positive in-scope
+ * evidence sufficient for an active rule" → only the two active outcomes are confirmed.
+ */
+function mapStage4Outcome(outcome: Stage4Outcome, now: string): Stage4Mapping {
+  switch (outcome) {
+    case 'in-scope-bad-example':
+      return {
+        rulePatch: { status: 'active', confidence: 'high' },
+        stage4Confirmed: true,
+        stage4Outcome: 'confirmed',
+      };
+    case 'candidate-debt':
+      // Real code differs from the authored badExample — force severity to the warning
+      // floor (never elevate), keep active (mirrors applyStage4).
+      return {
+        rulePatch: { status: 'active', severity: 'warning' },
+        stage4Confirmed: true,
+        stage4Outcome: 'confirmed',
+      };
+    case 'no-matches':
+      return {
+        rulePatch: { status: 'untested-against-codebase' },
+        stage4Confirmed: false,
+        stage4Outcome: 'untested-no-matches',
+      };
+    case 'out-of-scope':
+      // The §4 deterministic backstop ACTIVELY rejected a mis-structural candidate
+      // (fired on the verification baseline ⇒ over-broad). Archival is the SAFE
+      // direction (demote, never promote) and is the producer's call (slice 4), a
+      // distinct axis from the wind-tunnel's legitimacy gate (slice 5).
+      return {
+        rulePatch: {
+          status: 'archived',
+          archivedAt: now,
+          archivedReason:
+            'Stage 4 (mmnto-ai/totem#1682): pattern fired on the verification baseline (test/fixture scope) — over-broad. reasonCode: stage4-out-of-scope-match.',
+        },
+        stage4Confirmed: false,
+        stage4Outcome: 'archived-out-of-scope',
+      };
+    default: {
+      const _exhaustive: never = outcome;
+      throw new Error(
+        `[Totem Error] mapStage4Outcome: unknown Stage-4 outcome '${String(_exhaustive)}'`,
+      );
+    }
+  }
+}
+
+/**
+ * Run the Stage-3 Compile + Stage-4 Verify stage over a classify result. Selects
+ * ONLY compile-routed (structural) candidates and compiles them SEQUENTIALLY in
+ * stable classify-output order (deterministic ordinals before any async reorder).
+ * Returns the `CompiledCandidate[]` + the classifier ledger with `stage4Confirmed`
+ * and `stage4Outcome` filled on every compile-routed entry (behavioral/rag-only
+ * entries are left untouched). Mutates nothing; the input ledger is copied.
+ */
+export async function runCompileStage(
+  classify: ClassifyStageResult,
+  deps: CompileStageDeps,
+): Promise<CompileStageResult> {
+  const baseline = deps.baseline ?? getDefaultBaseline();
+  // Determinism (codex fold): canonicalize the file-walk order before the verifier —
+  // it preserves file order for `candidateDebtLines`, so an unsorted `listFiles` would
+  // make the output (and `CompiledCandidate.stage4`) non-reproducible.
+  const stage4: Stage4VerifierDeps = {
+    ...deps.stage4,
+    listFiles: async () => [...(await deps.stage4.listFiles())].sort(),
+  };
+  const compiled: CompiledCandidate[] = [];
+  const updates = new Map<
+    string,
+    { stage4Confirmed: boolean; stage4Outcome: Stage4LedgerOutcome }
+  >();
+
+  const structural = classify.candidates.filter((c) => c.classifierDisposition === 'structural');
+  for (const candidate of structural) {
+    // Classifier-ledger join: require EXACTLY ONE entry (missing or duplicate fails
+    // loud — else the Stage-4 confirmation is lost or applied to the wrong row).
+    const matches = classify.classifierLedger.entries.filter(
+      (e) => e.candidateRef === candidate.classifierLedgerRef,
+    );
+    if (matches.length !== 1) {
+      throw new Error(
+        `[Totem Error] runCompileStage: classifierLedgerRef '${candidate.classifierLedgerRef}' matches ${matches.length} classifier-ledger entries (expected exactly 1)`,
+      );
+    }
+
+    const outcome = compileCandidate(candidate, { now: deps.now });
+    if (outcome.kind === 'rejected') {
+      updates.set(candidate.classifierLedgerRef, {
+        stage4Confirmed: false,
+        stage4Outcome: 'compile-rejected',
+      });
+      continue;
+    }
+
+    // ast / ast-grep rules need a working directory — fail loud, never degrade to
+    // `no-matches` (agy fold). Regex verification does not need it.
+    if (outcome.rule.engine !== 'regex' && deps.stage4.workingDirectory === undefined) {
+      throw new Error(
+        `[Totem Error] runCompileStage: ${outcome.rule.engine} rule for '${candidate.classifierLedgerRef}' requires deps.stage4.workingDirectory`,
+      );
+    }
+
+    // A `readFile` failure inside the verifier propagates loudly (fail-loud Tenet 4) —
+    // no swallowing catch here.
+    const stage4Result = await verifyAgainstCodebase(outcome.rule, baseline, stage4);
+    const mapping = mapStage4Outcome(stage4Result.outcome, deps.now);
+    const rule = CompiledRuleSchema.parse({ ...outcome.rule, ...mapping.rulePatch });
+    compiled.push({
+      provenance: candidate.provenance,
+      classifierLedgerRef: candidate.classifierLedgerRef,
+      rule,
+      stage4: stage4Result,
+    });
+    updates.set(candidate.classifierLedgerRef, {
+      stage4Confirmed: mapping.stage4Confirmed,
+      stage4Outcome: mapping.stage4Outcome,
+    });
+  }
+
+  const classifierLedger: ClassifierLedger = {
+    entries: classify.classifierLedger.entries.map((e) => {
+      const u = updates.get(e.candidateRef);
+      return u ? { ...e, stage4Confirmed: u.stage4Confirmed, stage4Outcome: u.stage4Outcome } : e;
+    }),
+  };
+
+  return { compiled, classifierLedger };
+}

--- a/packages/core/src/spine/ledgers.ts
+++ b/packages/core/src/spine/ledgers.ts
@@ -40,6 +40,31 @@ export type Routing = z.infer<typeof RoutingSchema>;
 export const DispositionSourceSchema = z.enum(['classified', 'error-default']);
 export type DispositionSource = z.infer<typeof DispositionSourceSchema>;
 
+/**
+ * Compile + Stage-4 disposition of a compile-routed (structural) candidate (slice 4).
+ * Recorded additively on the classifier ledger so the §8 done-criterion (which reads
+ * the LEDGER, not the compiled `rule.status`) can distinguish the verify-stage outcomes
+ * rather than collapse them onto the `stage4Confirmed` boolean:
+ *   - `confirmed`             — Stage-4 found positive in-scope evidence (active rule).
+ *   - `untested-no-matches`   — Stage-4 ran, zero hits (neutral/inconclusive).
+ *   - `archived-out-of-scope` — the §4 backstop ACTIVELY rejected a mis-structural
+ *                               candidate (fired on the baseline) — a classifier-over-eager
+ *                               signal, NOT the same as `no-matches` (Tenet 19, the
+ *                               compile-stage twin of `dispositionSource`).
+ *   - `compile-rejected`      — the pattern parsed but failed per-engine safety
+ *                               validation (e.g. ReDoS); never produced as a rule.
+ * Absent on entries the compile stage never touched (behavioral/rag-only, or a
+ * classify-only run). NOT a falsifying condition (no FM clause) — a done-criterion
+ * diagnostic; the harness only locks its consistency with `stage4Confirmed`.
+ */
+export const Stage4LedgerOutcomeSchema = z.enum([
+  'confirmed',
+  'untested-no-matches',
+  'archived-out-of-scope',
+  'compile-rejected',
+]);
+export type Stage4LedgerOutcome = z.infer<typeof Stage4LedgerOutcomeSchema>;
+
 // ── 1. Emission ledger ──────────────────────────────────────────────────────
 
 export const EmissionLedgerEntrySchema = z.object({
@@ -117,6 +142,15 @@ export const ClassifierLedgerEntrySchema = z.object({
    * condition — a diagnostic, like `stage4Confirmed`.
    */
   dispositionSource: DispositionSourceSchema,
+  /**
+   * Compile + Stage-4 outcome (slice 4), set by `runCompileStage` on the matched
+   * compile-routed entry. OPTIONAL — absent until the compile stage runs (and
+   * never set on behavioral/rag-only entries, which are never compiled). When
+   * present it MUST be consistent with `stage4Confirmed`: `confirmed` ⟺
+   * `stage4Confirmed === true`; the other three outcomes ⟺ `false`. The §8 harness
+   * locks that consistency (no new FM clause) — see `Stage4LedgerOutcomeSchema`.
+   */
+  stage4Outcome: Stage4LedgerOutcomeSchema.optional(),
 });
 export type ClassifierLedgerEntry = z.infer<typeof ClassifierLedgerEntrySchema>;
 

--- a/packages/core/src/spine/miner-harness.test.ts
+++ b/packages/core/src/spine/miner-harness.test.ts
@@ -39,12 +39,14 @@ function greenLedgers() {
           disposition: 'structural',
           stage4Confirmed: true,
           dispositionSource: 'classified',
+          stage4Outcome: 'confirmed',
         },
         {
           candidateRef: 'cl-2',
           disposition: 'structural',
           stage4Confirmed: true,
           dispositionSource: 'classified',
+          stage4Outcome: 'confirmed',
         },
       ],
     },
@@ -158,6 +160,7 @@ describe('runFalsificationHarness — each red fixture fails on EXACTLY its clau
       disposition: 'structural',
       stage4Confirmed: true,
       dispositionSource: 'classified',
+      stage4Outcome: 'confirmed',
     });
     expect(clauses(g)).toEqual(['e-emission']);
   });
@@ -199,6 +202,40 @@ describe('runFalsificationHarness — each red fixture fails on EXACTLY its clau
     g.emission.entries.pop(); // remove the PR 2 candidate, do not drop it either
     g.classifier.entries.pop();
     expect(clauses(g)).toEqual(['i']);
+  });
+});
+
+describe('runFalsificationHarness — stage4 consistency (slice 4; NOT an FM letter)', () => {
+  it('flags a confirmed outcome whose stage4Confirmed is false (the OQ4 red craft)', () => {
+    const g = clone(greenLedgers());
+    g.classifier.entries[0].stage4Confirmed = false; // still stage4Outcome: 'confirmed'
+    expect(clauses(g)).toEqual(['stage4-consistency']);
+  });
+
+  it('flags stage4Confirmed:true with no recorded outcome (cannot be confirmed without evidence)', () => {
+    const g = clone(greenLedgers());
+    delete (g.classifier.entries[0] as Record<string, unknown>).stage4Outcome;
+    expect(clauses(g)).toEqual(['stage4-consistency']);
+  });
+
+  it('flags a compile-rejected outcome marked stage4Confirmed:true', () => {
+    const g = clone(greenLedgers());
+    g.classifier.entries[0].stage4Outcome = 'compile-rejected'; // stage4Confirmed still true
+    expect(clauses(g)).toEqual(['stage4-consistency']);
+  });
+
+  it('passes archived-out-of-scope with stage4Confirmed:false (legitimately unconfirmed — agy fold-3)', () => {
+    const g = clone(greenLedgers());
+    g.classifier.entries[0].stage4Confirmed = false;
+    g.classifier.entries[0].stage4Outcome = 'archived-out-of-scope';
+    expect(runFalsificationHarness(g).ok).toBe(true);
+  });
+
+  it('passes untested-no-matches with stage4Confirmed:false (legitimately unconfirmed)', () => {
+    const g = clone(greenLedgers());
+    g.classifier.entries[0].stage4Confirmed = false;
+    g.classifier.entries[0].stage4Outcome = 'untested-no-matches';
+    expect(runFalsificationHarness(g).ok).toBe(true);
   });
 });
 

--- a/packages/core/src/spine/miner-harness.ts
+++ b/packages/core/src/spine/miner-harness.ts
@@ -22,6 +22,10 @@ export type FmClause =
   | 'g'
   | 'h'
   | 'i'
+  // NOT a Falsifying-Metric letter (a–i are unchanged). A done-criterion
+  // CONSISTENCY guard (slice 4): the compile/Stage-4 outcome recorded on a
+  // classifier entry must agree with its `stage4Confirmed` boolean.
+  | 'stage4-consistency'
   | 'schema';
 
 export interface FmViolation {
@@ -63,6 +67,7 @@ export function runFalsificationHarness(rawLedgers: unknown): FalsificationResul
 export function checkParsedLedgers(ledgers: MinerLedgers): FmViolation[] {
   const violations: FmViolation[] = [];
   checkClassifierRouting(ledgers, violations); // (c)
+  checkStage4Consistency(ledgers, violations); // (consistency, not an FM letter)
   checkSplitCover(ledgers, violations); // (d) / (g) / (e-split)
   checkEmissionMembership(ledgers, violations); // (e-emission)
   checkSeedBlindness(ledgers, violations); // (f)
@@ -112,6 +117,36 @@ function checkClassifierRouting(ledgers: MinerLedgers, out: FmViolation[]): void
       out.push({
         clause: 'c',
         detail: `candidate ${e.candidateRef}: compile-routed but classifier ledger attests behavioral`,
+      });
+    }
+  }
+}
+
+// (consistency, NOT an FM letter) — the compile/Stage-4 outcome recorded on a
+// classifier entry must agree with its `stage4Confirmed` boolean. By construction
+// `runCompileStage`'s atomic outcome→{status, stage4Confirmed, stage4Outcome} map
+// makes desync unreachable; this locks it anyway (symmetric to FM(c)'s by-
+// construction check). `confirmed` ⟺ `stage4Confirmed:true`; the three inert
+// outcomes ⟺ `false`; an entry with NO recorded outcome can never be confirmed
+// (nothing produced the evidence — e.g. a behavioral/rag-only or pre-compile entry).
+// Per the panel (strategy/codex/gemini flag-5 shape) this is a done-criterion guard,
+// NOT a new lettered Falsifying-Metric clause — a–i are unchanged.
+function checkStage4Consistency(ledgers: MinerLedgers, out: FmViolation[]): void {
+  for (const c of ledgers.classifier.entries) {
+    if (c.stage4Outcome === undefined) {
+      if (c.stage4Confirmed) {
+        out.push({
+          clause: 'stage4-consistency',
+          detail: `classifier entry ${c.candidateRef}: stage4Confirmed is true but no stage4Outcome was recorded`,
+        });
+      }
+      continue;
+    }
+    const confirmedByOutcome = c.stage4Outcome === 'confirmed';
+    if (c.stage4Confirmed !== confirmedByOutcome) {
+      out.push({
+        clause: 'stage4-consistency',
+        detail: `classifier entry ${c.candidateRef}: stage4Confirmed=${c.stage4Confirmed} is inconsistent with stage4Outcome='${c.stage4Outcome}'`,
       });
     }
   }


### PR DESCRIPTION
Slice 4 of 5 of the ADR-111 Gate-1 rule-mining miner (the Convergent Spine producer keystone). Builds the **fresh, non-frozen G-series compile actuator** + wires the shipped Stage-4 codebase verifier. **Part of #2199** (stays open — slice 5 remains).

## What it does

For each compile-routed (structural) slice-3 `CandidateRuleRecord`: parse its lesson-markdown `dslSource` → `CompiledRule`, run `verifyAgainstCodebase` (#1682) via an injected `Stage4VerifierDeps` port, map the Stage-4 outcome onto the rule's status/confidence/severity, and record the disposition on the classifier ledger. Output `CompiledCandidate[]` carrying `provenance` forward for slice-5's wind-tunnel stamp.

## Freeze boundary (flag-3, BINDING)

No G-series compile entrypoint existed, so this **builds** one. The frozen thing is the legacy `LessonInput` **actuator** (`compileLesson`/`buildCompiledRule`/`buildManualRule`, the `totem lesson compile` path) — **never** imported or called here. Reused (outside-freeze, pure): `extractManualPattern`/`engineFields` (format/parser), `hashLesson`, `validateRegex` + `validateAstGrepPattern` (validators), `verifyAgainstCodebase`. A frozen-actuator call-spy test locks this.

## Changes

- **`spine/compile.ts`** (new) — `compileCandidate` (pure; behavioral→throw [FM(c)], no-usable-pattern→throw [preflight↔parser desync], unsafe-pattern→`compile-rejected`) + `runCompileStage` (structural-only, sequential stable order, injected `now`, sorted `listFiles`, exactly-one classifier-ledger join [missing/dup→fail loud], ast/ast-grep `workingDirectory` fail-loud, `readFile` failure propagates). Mints `unverified:true`, **no** `legitimacy`/`ruleClass`/`manual`.
- **`spine/ledgers.ts`** — additive **optional** `ClassifierLedgerEntry.stage4Outcome` (`confirmed | untested-no-matches | archived-out-of-scope | compile-rejected`). The §8 done-criterion reads the ledger; the bare `stage4Confirmed` boolean conflated *untested* with *archived-by-backstop*. **No new FM clause** (the slice-3 flag-5 shape).
- **`spine/miner-harness.ts`** — a `stage4-consistency` guard (`stage4Confirmed ⟺ stage4Outcome==='confirmed'`), explicitly **not** a Falsifying-Metric letter (a–i unchanged). archived/untested are legitimately unconfirmed.

### Stage-4 outcome → status map

| outcome | status | confidence/severity | stage4Confirmed | stage4Outcome |
| --- | --- | --- | --- | --- |
| `in-scope-bad-example` | `active` | confidence `high` | true | `confirmed` |
| `candidate-debt` | `active` | severity `warning` (forced) | true | `confirmed` |
| `no-matches` | `untested-against-codebase` | — | false | `untested-no-matches` |
| `out-of-scope` | `archived` (reason `stage4-out-of-scope-match`, `archivedAt`=injected `now`) | — | false | `archived-out-of-scope` |
| (validation failure) | not produced as a rule | — | false | `compile-rejected` |

## Tests + gate

- 21 `compile.test.ts` (4 outcome maps via fixture deps, behavioral/unusable throws, compile-rejected, join uniqueness, workingDirectory + readFile fail-loud, determinism, frozen-actuator call-spy, e2e harness lock) + 5 harness-consistency tests.
- spine 208 ✓ · full workspace suite (incl. cli 2619) ✓ · `tsc` all packages ✓ · prettier ✓ · `totem lint --base main` **PASS, 0 errors**.

## Design + provenance

Design + the 4/4 convergent cohort-panel folds (codex contract / strategy ADR-111-fidelity / agy build / gemini tenet) are in `.totem/specs/adr-111-miner-build.md`. The binding fold was the auditable `stage4Outcome` (3-seat).

## Carried slice-5 bindings

1. Stamp-before-persist (legitimacy/ruleClass before any loadable-manifest write).
2. Archived-out-of-scope candidates never enter the wind-tunnel scored set.
3. #2201 resolution-filtering (ADR-111 §6/§8) in the slice-5 adapter's initial impl.
4. Verify `run-compiled-rules.ts` engine-proxy honors top-level `unverified:true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
