### PR TITLE
feat(spine): Gate-1 miner slice 5c-i — deterministic real-engine firing path (ADR-111)

### DIFF
--- a/packages/cli/src/commands/spine-windtunnel.test.ts
+++ b/packages/cli/src/commands/spine-windtunnel.test.ts
@@ -4,7 +4,13 @@ import * as path from 'node:path';
 
 import { afterEach, describe, expect, it } from 'vitest';
 
-import type { WindtunnelLock } from '@mmnto/totem';
+import type {
+  CompiledRule,
+  GroundTruthLabel,
+  ResolvedPrDiff,
+  RuleFiring,
+  WindtunnelLock,
+} from '@mmnto/totem';
 import {
   isBotIdentity,
   parsePrNumber,
@@ -17,9 +23,11 @@ import { cleanTmpDir } from '../test-utils.js';
 import {
   assertCorpusCompleteness,
   buildReadStrategy,
+  type CertifyingCorpus,
   computeFixtureSha,
   enumeratePrMetas,
   isCommitAncestor,
+  runCertifyingEngine,
   verifyControlIntegrity,
   verifyFreezeProof,
 } from './spine-windtunnel.js';
@@ -553,5 +561,92 @@ describe('assertCorpusCompleteness (S4, mocked git)', () => {
     expect(() => makeCertLock(asOf, [534], { includeGlobs: [], excludeGlobs: [] })).toThrow(
       /at least one glob/,
     );
+  });
+});
+
+// ─── runCertifyingEngine (5c-i — real engine wiring) ─────
+
+describe('runCertifyingEngine (5c-i — certifying real-engine path)', () => {
+  const asOf = 'f'.repeat(40);
+  const certLock = makeCertLock(asOf, [534, 535]);
+
+  /** A regex rule firing on the literal `debugger` token. */
+  const debuggerRule: CompiledRule = {
+    lessonHash: 'cert-debugger',
+    lessonHeading: 'No debugger',
+    pattern: 'debugger',
+    message: 'debugger statement',
+    engine: 'regex',
+    compiledAt: '2026-06-20T00:00:00.000Z',
+  };
+
+  /** readStrategy with a fixed post-image (zero-LLM, no disk, no network). */
+  const post = ['function run() {', '  debugger;', '}'].join('\n'); // totem-ignore
+  const fixedRead = async (): Promise<string | null> => post;
+
+  /** A PR diff that adds a `debugger;` line (the rule fires). */
+  function prDiff(pr: number, kind: ResolvedPrDiff['controlKind']): ResolvedPrDiff {
+    const diff = [
+      'diff --git a/src/app.ts b/src/app.ts',
+      '--- a/src/app.ts',
+      '+++ b/src/app.ts',
+      '@@ -0,0 +1,1 @@',
+      '+  debugger;', // totem-ignore
+    ].join('\n');
+    return { pr, diff, controlKind: kind };
+  }
+
+  it('throws a structured CONFIG_INVALID error when no corpus provider is wired', async () => {
+    await expect(runCertifyingEngine(certLock, fixedRead, undefined)).rejects.toThrow(
+      /no certifying-corpus provider wired/,
+    );
+  });
+
+  it('drives the real engine: fixture corpus → firings → labeled TP scores cleanly', async () => {
+    const corpus: CertifyingCorpus = {
+      rules: [debuggerRule],
+      prDiffs: [prDiff(534, 'corpus')],
+      groundTruth: new Map<string, GroundTruthLabel>(),
+    };
+    const result = await runCertifyingEngine(certLock, fixedRead, () => corpus);
+    expect(result.firings).toHaveLength(1);
+    expect(result.firings[0]!.ruleId).toBe('cert-debugger');
+    expect(result.mintedRuleIds).toEqual(['cert-debugger']);
+    // C2: one distinct file touched.
+    expect(result.filesTouchedInWindow).toBe(1);
+  });
+
+  it('fold-F: an archived rule in the corpus throws (engine never runs on it)', async () => {
+    const corpus: CertifyingCorpus = {
+      rules: [{ ...debuggerRule, status: 'archived' }],
+      prDiffs: [prDiff(534, 'corpus')],
+      groundTruth: new Map(),
+    };
+    await expect(runCertifyingEngine(certLock, fixedRead, () => corpus)).rejects.toThrow(
+      /archived rule/,
+    );
+  });
+
+  it('A1: a labelId collision surfaces as a CONFIG_INVALID error pre-score', async () => {
+    // Two PR diffs with the SAME pr + identical matched line → identical labelId.
+    const corpus: CertifyingCorpus = {
+      rules: [debuggerRule],
+      prDiffs: [prDiff(534, 'corpus'), prDiff(534, 'corpus')], // same pr, same line → collision
+      groundTruth: new Map(),
+    };
+    await expect(runCertifyingEngine(certLock, fixedRead, () => corpus)).rejects.toThrow(
+      /collision/,
+    );
+  });
+
+  it('fold-H: a negative-control firing passes through as controlKind:negative', async () => {
+    const corpus: CertifyingCorpus = {
+      rules: [debuggerRule],
+      prDiffs: [prDiff(999, 'negative')],
+      groundTruth: new Map(),
+    };
+    const result = await runCertifyingEngine(certLock, fixedRead, () => corpus);
+    const negFirings = result.firings.filter((f: RuleFiring) => f.controlKind === 'negative');
+    expect(negFirings).toHaveLength(1);
   });
 });

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -881,6 +881,7 @@ export async function runCertifyingEngine(
         err.message,
         'A firing-label collision voids the run — the labelId→evidenceRef join would overwrite. ' +
           'Measure on the frozen corpus; if collisions occur, extend the label with a diff-hunk span (NOT an ordinal).',
+        err,
       );
     }
     throw err;

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -119,6 +119,42 @@ export interface RunOptions {
   lcDir?: string;
   lockPath?: string;
   phase?: string;
+  /**
+   * 5c-ii injection seam (out of 5c-i scope to populate): the certifying corpus
+   * — resolved-PR diffs (corpus + controls), the active compiled rules, and the
+   * frozen ground-truth labels. When omitted on a certifying run, the real
+   * engine path throws a structured "corpus provider not wired" error rather
+   * than silently scoring an empty set. 5c-ii (the orchestrator) supplies the
+   * live-recorded corpus here; 5c-i unit tests supply a deterministic fixture.
+   */
+  certifyingCorpus?: CertifyingCorpusProvider;
+}
+
+/**
+ * The certifying corpus the real engine scores (5c-ii supplies this; 5c-i
+ * defines the seam + the deterministic engine that consumes it). Returns the
+ * active compiled rules (archived MUST be excluded — fold-F throws otherwise),
+ * the resolved-PR diffs (corpus + positive/negative controls), and the frozen
+ * ground-truth labels keyed by firingLabelId.
+ */
+export type CertifyingCorpusProvider = (
+  lock: WindtunnelLock,
+) => Promise<CertifyingCorpus> | CertifyingCorpus;
+
+export interface CertifyingCorpus {
+  rules: import('@mmnto/totem').CompiledRule[];
+  prDiffs: import('@mmnto/totem').ResolvedPrDiff[];
+  groundTruth: Map<string, import('@mmnto/totem').GroundTruthLabel>;
+}
+
+/** Internal shape the run command's scorer consumes (engine-agnostic). */
+interface EngineResult {
+  mintedRuleIds: string[];
+  firings: import('@mmnto/totem').RuleFiring[];
+  groundTruth: Map<string, import('@mmnto/totem').GroundTruthLabel>;
+  positiveControlTargets: Array<{ pr: number; targetRuleId: string }>;
+  /** C2 — real touched-file exposure (0 for the harness mock). */
+  filesTouchedInWindow: number;
 }
 
 /**
@@ -225,16 +261,19 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   // When lcDir is provided, resolve post-image blobs from the lc clone.
   const readStrategy = buildReadStrategy(lcDir, lock.corpus.selectionRule.asOfCommit, safeExec);
 
-  // Enrich with AST context for any additions (harness: no diff, so no additions).
-  // In the real certifying run, the caller would build additions from PR diffs
-  // and pass them through enrichWithAstContext + applyAstRulesToAdditions with
-  // the shared readStrategy (S1/C1 — same content for regex astContext + AST).
+  // Run the engine. Harness phase → mock engine (no real rules yet). Certifying
+  // phase → the REAL engine path (5c-i): build additions from each resolved-PR
+  // diff → enrichWithAstContext + applyAstRulesToAdditions with the shared
+  // post-image readStrategy → RuleFiring[] → A1 unique-label hard-gate → score.
+  // C2: filesTouchedInWindow is the real exposure computed from the diffs (no
+  // longer the hard-coded 0).
+  const engineResult =
+    lock.phase === 'certifying'
+      ? await runCertifyingEngine(lock, readStrategy, opts.certifyingCorpus)
+      : await runMockEngineAdapter(lock, readStrategy);
 
-  // Run the engine — harness phase uses mock engines.
-  const { mintedRuleIds, firings, groundTruth, positiveControlTargets } = await runMockEngine(
-    lock,
-    readStrategy,
-  );
+  const { mintedRuleIds, firings, groundTruth, positiveControlTargets, filesTouchedInWindow } =
+    engineResult;
 
   // Score
   const verdict = scoreWindtunnel({
@@ -250,7 +289,7 @@ export async function runCommand(opts: RunOptions): Promise<void> {
     },
     actualExposure: {
       activeRulesEvaluated: mintedRuleIds.length,
-      filesTouchedInWindow: 0,
+      filesTouchedInWindow,
       positiveControlsExercised: positiveControlTargets.length,
     },
   });
@@ -750,4 +789,125 @@ async function runMockEngine(
   }
 
   return { mintedRuleIds, firings, groundTruth, positiveControlTargets };
+}
+
+/** Adapt the harness mock engine to the EngineResult shape (filesTouched = 0). */
+async function runMockEngineAdapter(
+  lock: WindtunnelLock,
+  readStrategy: (file: string) => Promise<string | null>,
+): Promise<EngineResult> {
+  const mock = await runMockEngine(lock, readStrategy);
+  return { ...mock, filesTouchedInWindow: 0 };
+}
+
+// ─── Real engine (certifying phase, 5c-i) ────────────
+
+/**
+ * Run the REAL engine for the certifying phase (5c-i — #2189 item 1).
+ *
+ * Replaces the mock for `--phase certifying`: drives each resolved-PR diff
+ * through `buildFirings` (core), which runs `enrichWithAstContext` +
+ * `applyAstRulesToAdditions` with the shared post-image `readStrategy` (S1/C1)
+ * and maps every violation to a `RuleFiring` (content-based labelId). Then:
+ *  - **fold-F**: `buildFirings` throws if any archived rule is in the scored set
+ *    (the engine never runs on an archived rule).
+ *  - **A1 (fold-D)**: `assertUniqueFiringLabels` hard-gates labelId uniqueness
+ *    BEFORE scoring (throws on collision, surfacing the offending refs).
+ *  - **C2**: `filesTouchedInWindow` is the real distinct-file exposure.
+ *  - **fold-H**: neg-control firings flow through as `controlKind:'negative'`;
+ *    unlabeled firings route to needsAdjudication via the scorer.
+ *
+ * The corpus itself (resolved-PR diffs + active rules + frozen ground truth) is
+ * supplied by the 5c-ii orchestrator via the `certifyingCorpus` seam. 5c-i owns
+ * the deterministic engine; it does NOT fetch/compile live data (out of scope).
+ */
+export async function runCertifyingEngine(
+  lock: WindtunnelLock,
+  readStrategy: (file: string) => Promise<string | null>,
+  corpusProvider?: CertifyingCorpusProvider,
+): Promise<EngineResult> {
+  const {
+    buildFirings,
+    assertUniqueFiringLabels,
+    resolveGitRoot,
+    TotemError,
+    FiringLabelCollisionError,
+  } = await import('@mmnto/totem');
+
+  if (!corpusProvider) {
+    // No silent empty-set scoring: a certifying run with no corpus provider is a
+    // wiring error (5c-ii supplies it). Fail loud + actionable (Tenet 4).
+    throw new TotemError(
+      'CONFIG_INVALID',
+      'Wind-tunnel certifying run: no certifying-corpus provider wired (5c-ii orchestration).',
+      'The deterministic real-engine firing path (5c-i) is in place, but the corpus ' +
+        '(resolved-PR diffs + compiled rules + ground truth) is supplied by the 5c-ii ' +
+        'orchestrator. Run via the certifying orchestrator once it lands.',
+    );
+  }
+
+  const corpus = await corpusProvider(lock);
+  const cwd = resolveGitRoot(process.cwd()) ?? process.cwd();
+  const ruleEngineCtx = {
+    logger: { warn: (msg: string) => console.error(`[WindtunnelRun] ${msg}`) },
+    state: { hasWarnedShieldContext: false },
+  };
+
+  let built;
+  try {
+    // buildFirings runs fold-F (archived assert) internally before the engine.
+    built = await buildFirings({
+      rules: corpus.rules,
+      prDiffs: corpus.prDiffs,
+      cwd,
+      readStrategy,
+      ruleEngineCtx,
+      onWarn: (msg) => console.error(`[WindtunnelRun] ${msg}`),
+    });
+  } catch (err) {
+    if (err instanceof FiringLabelCollisionError) {
+      // A1 collisions can also originate here if the engine produced duplicates
+      // — surface as a TotemError with the structured collision detail.
+      throw new TotemError(
+        'CONFIG_INVALID',
+        err.message,
+        'See A1 (fold-D) — measure collisions on the frozen corpus.',
+      );
+    }
+    throw err;
+  }
+
+  // A1 (fold-D): hard-gate labelId uniqueness BEFORE scoring (Tenet 4).
+  try {
+    assertUniqueFiringLabels(built.firings);
+  } catch (err) {
+    if (err instanceof FiringLabelCollisionError) {
+      console.error(`[WindtunnelRun] A1 firing-label collision (fold-D):`);
+      for (const c of err.collisions) {
+        console.error(`  • ${c.labelId.slice(0, 12)}… ×${c.evidenceRefs.length}`);
+      }
+      throw new TotemError(
+        'CONFIG_INVALID',
+        err.message,
+        'A firing-label collision voids the run — the labelId→evidenceRef join would overwrite. ' +
+          'Measure on the frozen corpus; if collisions occur, extend the label with a diff-hunk span (NOT an ordinal).',
+      );
+    }
+    throw err;
+  }
+
+  const mintedRuleIds = corpus.rules.map((r) => r.lessonHash);
+  console.error(
+    `[WindtunnelRun] Certifying engine: ${mintedRuleIds.length} rule(s), ` +
+      `${corpus.prDiffs.length} PR diff(s), ${built.firings.length} firing(s), ` +
+      `${built.filesTouchedInWindow} file(s) touched.`,
+  );
+
+  return {
+    mintedRuleIds,
+    firings: built.firings,
+    groundTruth: corpus.groundTruth,
+    positiveControlTargets: built.positiveControlTargets,
+    filesTouchedInWindow: built.filesTouchedInWindow,
+  };
 }

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -853,29 +853,19 @@ export async function runCertifyingEngine(
     state: { hasWarnedShieldContext: false },
   };
 
-  let built;
-  try {
-    // buildFirings runs fold-F (archived assert) internally before the engine.
-    built = await buildFirings({
-      rules: corpus.rules,
-      prDiffs: corpus.prDiffs,
-      cwd,
-      readStrategy,
-      ruleEngineCtx,
-      onWarn: (msg) => console.error(`[WindtunnelRun] ${msg}`),
-    });
-  } catch (err) {
-    if (err instanceof FiringLabelCollisionError) {
-      // A1 collisions can also originate here if the engine produced duplicates
-      // — surface as a TotemError with the structured collision detail.
-      throw new TotemError(
-        'CONFIG_INVALID',
-        err.message,
-        'See A1 (fold-D) — measure collisions on the frozen corpus.',
-      );
-    }
-    throw err;
-  }
+  // buildFirings runs fold-F (archived assert) internally before the engine; its
+  // only throw is ArchivedRuleInScopeError, which propagates. A1 (labelId
+  // collision) is deliberately NOT raised here — it is the caller's pre-score gate
+  // below (assertUniqueFiringLabels), so the structured per-collision report is
+  // threaded there rather than swallowed at construction. (greptile #2215 P2.)
+  const built = await buildFirings({
+    rules: corpus.rules,
+    prDiffs: corpus.prDiffs,
+    cwd,
+    readStrategy,
+    ruleEngineCtx,
+    onWarn: (msg) => console.error(`[WindtunnelRun] ${msg}`),
+  });
 
   // A1 (fold-D): hard-gate labelId uniqueness BEFORE scoring (Tenet 4).
   try {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -871,6 +871,21 @@ export {
   SplitCoverError,
   validateSplitCover,
 } from './spine/split.js';
+export type {
+  BuildFiringsInput,
+  BuildFiringsResult,
+  FiringLabelCollision,
+  PerRuleControlResult,
+  ResolvedPrDiff,
+} from './spine/windtunnel-firing.js';
+export {
+  ArchivedRuleInScopeError,
+  assertNoArchivedRules,
+  assertUniqueFiringLabels,
+  buildFirings,
+  computePerRuleControlResults,
+  FiringLabelCollisionError,
+} from './spine/windtunnel-firing.js';
 export type { WindtunnelLock } from './spine/windtunnel-lock.js';
 export { firingLabelId, WindtunnelLockSchema } from './spine/windtunnel-lock.js';
 export type {

--- a/packages/core/src/spine/windtunnel-firing.test.ts
+++ b/packages/core/src/spine/windtunnel-firing.test.ts
@@ -1,0 +1,514 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CompiledRule } from '../compiler-schema.js';
+import { makeRuleEngineCtx } from '../test-utils.js';
+import {
+  ArchivedRuleInScopeError,
+  assertNoArchivedRules,
+  assertUniqueFiringLabels,
+  buildFirings,
+  computePerRuleControlResults,
+  FiringLabelCollisionError,
+  type ResolvedPrDiff,
+} from './windtunnel-firing.js';
+import { firingLabelId } from './windtunnel-lock.js';
+import type { GroundTruthLabel, RuleFiring } from './windtunnel-scorer.js';
+import { scoreWindtunnel } from './windtunnel-scorer.js';
+
+// ─── Fixtures ────────────────────────────────────────
+
+const FILE = 'src/app.ts';
+
+/** A regex rule firing on the literal `debugger` token (code context). */
+function debuggerRule(overrides: Partial<CompiledRule> = {}): CompiledRule {
+  return {
+    lessonHash: 'rule-debugger',
+    lessonHeading: 'No debugger',
+    pattern: 'debugger',
+    message: 'debugger statement',
+    engine: 'regex',
+    compiledAt: '2026-06-20T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/** A regex rule firing on `eval(` (a second, distinct rule). */
+function evalRule(overrides: Partial<CompiledRule> = {}): CompiledRule {
+  return {
+    lessonHash: 'rule-eval',
+    lessonHeading: 'No eval',
+    pattern: 'eval\\(',
+    message: 'eval call',
+    engine: 'regex',
+    compiledAt: '2026-06-20T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+/** Build a unified diff that ADDS the given lines to FILE starting at line 1. */
+function diffAdding(lines: string[], file = FILE): string {
+  const body = lines.map((l) => `+${l}`).join('\n');
+  return [
+    `diff --git a/${file} b/${file}`,
+    `--- a/${file}`,
+    `+++ b/${file}`,
+    `@@ -0,0 +1,${lines.length} @@`,
+    body,
+  ].join('\n');
+}
+
+/** readStrategy returning a fixed post-image for any file (zero-LLM, no disk). */
+function fixedReadStrategy(content: string): (file: string) => Promise<string | null> {
+  return async () => content;
+}
+
+// ─── Real-engine path (replaces runMockEngine) ───────
+
+describe('buildFirings — real engine path', () => {
+  it('fires the regex rule on a real code line and maps it to a RuleFiring with a content-based labelId', async () => {
+    const post = ['function run() {', '  debugger;', '}'].join('\n'); // totem-ignore
+    const prDiffs: ResolvedPrDiff[] = [
+      { pr: 100, diff: diffAdding(['  debugger;']), controlKind: 'corpus' }, // totem-ignore
+    ];
+    const result = await buildFirings({
+      rules: [debuggerRule()],
+      prDiffs,
+      cwd: '/repo',
+      readStrategy: fixedReadStrategy(post),
+      ruleEngineCtx: makeRuleEngineCtx(),
+    });
+
+    expect(result.firings).toHaveLength(1);
+    const firing = result.firings[0]!;
+    expect(firing.ruleId).toBe('rule-debugger');
+    expect(firing.pr).toBe(100);
+    expect(firing.controlKind).toBe('corpus');
+    expect(firing.labelId).toBe(firingLabelId('rule-debugger', 100, FILE, firing.matchedLine));
+  });
+
+  it('suppresses an over-fire: a regex match inside a comment is NOT a firing (astContext parity, C1)', async () => {
+    // Line 2 is real code; line 3 is a comment. Both are added. The engine must
+    // fire only on the code line (the comment match is telemetry-only).
+    const post = [
+      'function run() {',
+      '  debugger;', // 2 — code // totem-ignore
+      '  // debugger; left here — comment // totem-ignore', // 3 — comment
+      '}',
+    ].join('\n');
+    const prDiffs: ResolvedPrDiff[] = [
+      {
+        pr: 101,
+        diff: diffAdding([
+          '  debugger;', // totem-ignore
+          '  // debugger; left here — comment // totem-ignore',
+        ]),
+        controlKind: 'corpus',
+      },
+    ];
+    const result = await buildFirings({
+      rules: [debuggerRule()],
+      prDiffs,
+      cwd: '/repo',
+      readStrategy: fixedReadStrategy(post),
+      ruleEngineCtx: makeRuleEngineCtx(),
+    });
+
+    // Only the code line fires.
+    expect(result.firings).toHaveLength(1);
+    expect(result.firings[0]!.matchedLine).toContain('debugger');
+  });
+
+  it('counts distinct touched files across all diffs (C2 real exposure)', async () => {
+    const post = 'const x = 1;\n';
+    const prDiffs: ResolvedPrDiff[] = [
+      { pr: 1, diff: diffAdding(['const x = 1;'], 'src/a.ts'), controlKind: 'corpus' },
+      { pr: 2, diff: diffAdding(['const y = 2;'], 'src/b.ts'), controlKind: 'corpus' },
+      { pr: 3, diff: diffAdding(['const z = 3;'], 'src/a.ts'), controlKind: 'corpus' }, // dup file
+    ];
+    const result = await buildFirings({
+      rules: [debuggerRule()],
+      prDiffs,
+      cwd: '/repo',
+      readStrategy: fixedReadStrategy(post),
+      ruleEngineCtx: makeRuleEngineCtx(),
+    });
+    expect(result.filesTouchedInWindow).toBe(2); // a.ts + b.ts, not 3
+  });
+
+  it('derives positiveControlTargets from positive-control diffs', async () => {
+    const post = ['  debugger;'].join('\n'); // totem-ignore
+    const prDiffs: ResolvedPrDiff[] = [
+      {
+        pr: 50,
+        diff: diffAdding(['  debugger;']), // totem-ignore
+        controlKind: 'positive',
+        targetRuleId: 'rule-debugger',
+      },
+    ];
+    const result = await buildFirings({
+      rules: [debuggerRule()],
+      prDiffs,
+      cwd: '/repo',
+      readStrategy: fixedReadStrategy(post),
+      ruleEngineCtx: makeRuleEngineCtx(),
+    });
+    expect(result.positiveControlTargets).toEqual([{ pr: 50, targetRuleId: 'rule-debugger' }]);
+    expect(result.firings[0]!.controlKind).toBe('positive');
+    expect(result.firings[0]!.targetRuleId).toBe('rule-debugger');
+  });
+
+  it('fold-H: a firing on a NEGATIVE control passes through as controlKind:negative (not dropped)', async () => {
+    const post = ['  debugger;'].join('\n'); // totem-ignore
+    const prDiffs: ResolvedPrDiff[] = [
+      { pr: 99, diff: diffAdding(['  debugger;']), controlKind: 'negative' }, // totem-ignore
+    ];
+    const result = await buildFirings({
+      rules: [debuggerRule()],
+      prDiffs,
+      cwd: '/repo',
+      readStrategy: fixedReadStrategy(post),
+      ruleEngineCtx: makeRuleEngineCtx(),
+    });
+    expect(result.firings).toHaveLength(1);
+    expect(result.firings[0]!.controlKind).toBe('negative');
+  });
+
+  it('emits no firings when no rule matches the diff', async () => {
+    const post = 'const safe = 1;\n';
+    const prDiffs: ResolvedPrDiff[] = [
+      { pr: 1, diff: diffAdding(['const safe = 1;']), controlKind: 'corpus' },
+    ];
+    const result = await buildFirings({
+      rules: [debuggerRule()],
+      prDiffs,
+      cwd: '/repo',
+      readStrategy: fixedReadStrategy(post),
+      ruleEngineCtx: makeRuleEngineCtx(),
+    });
+    expect(result.firings).toHaveLength(0);
+  });
+});
+
+// ─── fold-F: archived-excluded loud assert ───────────
+
+describe('fold-F — archived rule in scored set throws (Tenet 4)', () => {
+  it('assertNoArchivedRules throws naming the archived rule', () => {
+    const rules = [debuggerRule(), evalRule({ status: 'archived' })];
+    expect(() => assertNoArchivedRules(rules)).toThrow(ArchivedRuleInScopeError);
+    expect(() => assertNoArchivedRules(rules)).toThrow(/rule-eval/);
+  });
+
+  it('assertNoArchivedRules passes on active-only rules', () => {
+    expect(() =>
+      assertNoArchivedRules([debuggerRule({ status: 'active' }), evalRule()]),
+    ).not.toThrow();
+  });
+
+  it('buildFirings throws (and never invokes the engine) when an archived rule is present', async () => {
+    const post = ['  debugger;'].join('\n'); // totem-ignore
+    const prDiffs: ResolvedPrDiff[] = [
+      { pr: 1, diff: diffAdding(['  debugger;']), controlKind: 'corpus' }, // totem-ignore
+    ];
+    await expect(
+      buildFirings({
+        rules: [debuggerRule(), evalRule({ status: 'archived' })],
+        prDiffs,
+        cwd: '/repo',
+        readStrategy: fixedReadStrategy(post),
+        ruleEngineCtx: makeRuleEngineCtx(),
+      }),
+    ).rejects.toThrow(ArchivedRuleInScopeError);
+  });
+
+  it('zero archived refs reach the firings (the engine ran only on active rules)', async () => {
+    const post = ['  debugger;', '  eval(x);'].join('\n'); // totem-ignore
+    const prDiffs: ResolvedPrDiff[] = [
+      {
+        pr: 1,
+        diff: diffAdding(['  debugger;', '  eval(x);']), // totem-ignore
+        controlKind: 'corpus',
+      },
+    ];
+    const result = await buildFirings({
+      rules: [debuggerRule(), evalRule()], // both active
+      prDiffs,
+      cwd: '/repo',
+      readStrategy: fixedReadStrategy(post),
+      ruleEngineCtx: makeRuleEngineCtx(),
+    });
+    const firedRuleIds = new Set(result.firings.map((f) => f.ruleId));
+    expect(firedRuleIds.has('rule-debugger')).toBe(true);
+    expect(firedRuleIds.has('rule-eval')).toBe(true);
+  });
+});
+
+// ─── A1 (fold-D): hard-gate-unique FLOOR ─────────────
+
+describe('A1 (fold-D) — assertUniqueFiringLabels hard-gate', () => {
+  function firing(labelId: string, ruleId = 'r', pr = 1): RuleFiring {
+    return { ruleId, pr, filePath: FILE, matchedLine: 'x', controlKind: 'corpus', labelId };
+  }
+
+  it('passes when all labelIds are unique', () => {
+    expect(() => assertUniqueFiringLabels([firing('a'), firing('b'), firing('c')])).not.toThrow();
+  });
+
+  it('throws a FiringLabelCollisionError when two firings share a labelId', () => {
+    expect(() => assertUniqueFiringLabels([firing('dup'), firing('dup')])).toThrow(
+      FiringLabelCollisionError,
+    );
+  });
+
+  it('surfaces the colliding labelId + every evidence ref', () => {
+    const dup = firingLabelId('r', 1, FILE, 'line');
+    const a: RuleFiring = {
+      ruleId: 'r',
+      pr: 1,
+      filePath: FILE,
+      matchedLine: 'line',
+      controlKind: 'corpus',
+      labelId: dup,
+    };
+    const b: RuleFiring = { ...a };
+    let caught: FiringLabelCollisionError | undefined;
+    try {
+      assertUniqueFiringLabels([a, b]);
+    } catch (err) {
+      caught = err as FiringLabelCollisionError;
+    }
+    expect(caught).toBeInstanceOf(FiringLabelCollisionError);
+    expect(caught!.collisions).toHaveLength(1);
+    expect(caught!.collisions[0]!.labelId).toBe(dup);
+    expect(caught!.collisions[0]!.evidenceRefs).toHaveLength(2);
+    expect(caught!.collisions[0]!.evidenceRefs[0]!.ruleId).toBe('r');
+  });
+});
+
+// ─── C1: per-rule control results (NOT global nonVacuity) ─
+
+describe('C1 — computePerRuleControlResults (per-rule, survivor-only)', () => {
+  function f(
+    ruleId: string,
+    controlKind: RuleFiring['controlKind'],
+    pr: number,
+    matched = 'x',
+  ): RuleFiring {
+    return {
+      ruleId,
+      pr,
+      filePath: FILE,
+      matchedLine: matched,
+      controlKind,
+      labelId: firingLabelId(ruleId, pr, FILE, matched),
+    };
+  }
+
+  it('positiveControl is true ONLY for the rule that fired its declared target (never global)', () => {
+    // rule-a fired its positive target on pr 10; rule-b is a survivor that never
+    // exercised a positive control. The global nonVacuity (all targets fired)
+    // would be true — but rule-b's positiveControl must NOT inherit that.
+    const firings = [f('rule-a', 'positive', 10), f('rule-b', 'corpus', 1)];
+    const result = computePerRuleControlResults({
+      firings,
+      mintedRuleIds: ['rule-a', 'rule-b'],
+      positiveControlTargets: [{ pr: 10, targetRuleId: 'rule-a' }],
+    });
+    expect(result.get('rule-a')!.positiveControl).toBe(true);
+    expect(result.get('rule-b')!.positiveControl).toBe(false);
+  });
+
+  it('negativeControl is false (and the rule is excluded as culled) when it fires on a negative control', () => {
+    const firings = [f('rule-a', 'negative', 99)];
+    const result = computePerRuleControlResults({
+      firings,
+      mintedRuleIds: ['rule-a', 'rule-b'],
+      positiveControlTargets: [],
+    });
+    // rule-a fired on a negative control → culled → not a survivor → absent.
+    expect(result.has('rule-a')).toBe(false);
+    // rule-b never fired on a negative control → clean (negativeControl true).
+    expect(result.get('rule-b')!.negativeControl).toBe(true);
+  });
+
+  it('a clean survivor carries negativeControl:true with no positive evidence', () => {
+    const result = computePerRuleControlResults({
+      firings: [],
+      mintedRuleIds: ['rule-a'],
+      positiveControlTargets: [],
+    });
+    expect(result.get('rule-a')).toEqual({
+      positiveControl: false,
+      negativeControl: true,
+      evidenceRefs: [],
+    });
+  });
+
+  it('records evidenceRefs (the firingLabelIds) for both control legs', () => {
+    const posFiring = f('rule-a', 'positive', 10);
+    const result = computePerRuleControlResults({
+      firings: [posFiring],
+      mintedRuleIds: ['rule-a'],
+      positiveControlTargets: [{ pr: 10, targetRuleId: 'rule-a' }],
+    });
+    expect(result.get('rule-a')!.evidenceRefs).toContain(posFiring.labelId);
+  });
+});
+
+// ─── fold-H: OQ4 real-firing integration matrix ──────
+//
+// End-to-end through the REAL engine (buildFirings) → scoreWindtunnel. Zero-LLM,
+// deterministic: fixture rules + fixture diffs + injected post-image readStrategy.
+
+describe('fold-H — OQ4 real-firing matrix (buildFirings → scoreWindtunnel)', () => {
+  /** Run the deterministic engine, gate uniqueness (A1), then score. */
+  async function fireAndScore(opts: {
+    rules: CompiledRule[];
+    prDiffs: ResolvedPrDiff[];
+    post: string;
+    groundTruth?: Map<string, GroundTruthLabel>;
+    mintedRuleIds?: string[];
+    exposureFloors?: {
+      activeRulesEvaluated: number;
+      filesTouchedInWindow: number;
+      positiveControlsExercised: number;
+    };
+  }) {
+    const built = await buildFirings({
+      rules: opts.rules,
+      prDiffs: opts.prDiffs,
+      cwd: '/repo',
+      readStrategy: fixedReadStrategy(opts.post),
+      ruleEngineCtx: makeRuleEngineCtx(),
+    });
+    assertUniqueFiringLabels(built.firings); // A1 pre-score gate
+    const mintedRuleIds = opts.mintedRuleIds ?? opts.rules.map((r) => r.lessonHash);
+    return scoreWindtunnel({
+      firings: built.firings,
+      groundTruth: opts.groundTruth ?? new Map(),
+      positiveControlTargets: built.positiveControlTargets,
+      mintedRuleIds,
+      cullRateThreshold: 0.9,
+      exposureFloors: opts.exposureFloors ?? {
+        activeRulesEvaluated: 0,
+        filesTouchedInWindow: 0,
+        positiveControlsExercised: 0,
+      },
+      actualExposure: {
+        activeRulesEvaluated: mintedRuleIds.length,
+        filesTouchedInWindow: built.filesTouchedInWindow,
+        positiveControlsExercised: built.positiveControlTargets.length,
+      },
+    });
+  }
+
+  it('confirmed-FP firing (sub-floor precision) ⟹ FAIL', async () => {
+    const post = ['  debugger;'].join('\n'); // totem-ignore
+    const prDiffs: ResolvedPrDiff[] = [
+      { pr: 1, diff: diffAdding(['  debugger;']), controlKind: 'corpus' }, // totem-ignore
+    ];
+    const built = await buildFirings({
+      rules: [debuggerRule()],
+      prDiffs,
+      cwd: '/repo',
+      readStrategy: fixedReadStrategy(post),
+      ruleEngineCtx: makeRuleEngineCtx(),
+    });
+    const fpLabel = built.firings[0]!.labelId;
+    const verdict = await fireAndScore({
+      rules: [debuggerRule()],
+      prDiffs,
+      post,
+      groundTruth: new Map([[fpLabel, 'FP']]),
+    });
+    expect(verdict.verdict).toBe('FAIL');
+    expect(verdict.precision).toBeLessThan(1);
+  });
+
+  it('vacuous positive control (target never fires) ⟹ FAIL / null precision', async () => {
+    // The positive control declares rule-eval must fire, but the post-image has
+    // no eval( — so the target never fires (vacuous).
+    const post = ['const safe = 1;'].join('\n');
+    const prDiffs: ResolvedPrDiff[] = [
+      {
+        pr: 10,
+        diff: diffAdding(['const safe = 1;']),
+        controlKind: 'positive',
+        targetRuleId: 'rule-eval',
+      },
+    ];
+    const verdict = await fireAndScore({ rules: [evalRule()], prDiffs, post });
+    expect(verdict.verdict).toBe('FAIL');
+    expect(verdict.nonVacuity).toBe(false);
+    expect(verdict.precision).toBeNull();
+  });
+
+  it('unlabeled firing ⟹ HONEST-NEGATIVE (needsAdjudication)', async () => {
+    const post = ['  debugger;'].join('\n'); // totem-ignore
+    const prDiffs: ResolvedPrDiff[] = [
+      { pr: 1, diff: diffAdding(['  debugger;']), controlKind: 'corpus' }, // totem-ignore
+    ];
+    const verdict = await fireAndScore({
+      rules: [debuggerRule()],
+      prDiffs,
+      post,
+      groundTruth: new Map(), // unlabeled
+    });
+    expect(verdict.verdict).toBe('HONEST-NEGATIVE');
+    expect(verdict.needsAdjudication).toHaveLength(1);
+  });
+
+  it('all-TP firings with exposure met ⟹ PASS', async () => {
+    const post = ['  debugger;'].join('\n'); // totem-ignore
+    const prDiffs: ResolvedPrDiff[] = [
+      { pr: 1, diff: diffAdding(['  debugger;']), controlKind: 'corpus' }, // totem-ignore
+    ];
+    const built = await buildFirings({
+      rules: [debuggerRule()],
+      prDiffs,
+      cwd: '/repo',
+      readStrategy: fixedReadStrategy(post),
+      ruleEngineCtx: makeRuleEngineCtx(),
+    });
+    const tpLabel = built.firings[0]!.labelId;
+    const verdict = await fireAndScore({
+      rules: [debuggerRule()],
+      prDiffs,
+      post,
+      groundTruth: new Map([[tpLabel, 'TP']]),
+    });
+    expect(verdict.verdict).toBe('PASS');
+    expect(verdict.precision).toBe(1.0);
+  });
+
+  it('C2: real filesTouched below the floor ⟹ HONEST-NEGATIVE even when the other legs pass', async () => {
+    // One TP firing on a single file. The other two legs pass (activeRules ok,
+    // no positive controls required) but the filesTouchedInWindow floor is 5 and
+    // only 1 file is touched → the third leg demotes to HONEST-NEGATIVE.
+    const post = ['  debugger;'].join('\n'); // totem-ignore
+    const prDiffs: ResolvedPrDiff[] = [
+      { pr: 1, diff: diffAdding(['  debugger;']), controlKind: 'corpus' }, // totem-ignore
+    ];
+    const built = await buildFirings({
+      rules: [debuggerRule()],
+      prDiffs,
+      cwd: '/repo',
+      readStrategy: fixedReadStrategy(post),
+      ruleEngineCtx: makeRuleEngineCtx(),
+    });
+    const tpLabel = built.firings[0]!.labelId;
+    const verdict = await fireAndScore({
+      rules: [debuggerRule()],
+      prDiffs,
+      post,
+      groundTruth: new Map([[tpLabel, 'TP']]),
+      exposureFloors: {
+        activeRulesEvaluated: 0,
+        filesTouchedInWindow: 5, // floor exceeds the 1 file actually touched
+        positiveControlsExercised: 0,
+      },
+    });
+    expect(built.filesTouchedInWindow).toBe(1);
+    expect(verdict.verdict).toBe('HONEST-NEGATIVE');
+    expect(verdict.precision).toBeNull();
+  });
+});

--- a/packages/core/src/spine/windtunnel-firing.ts
+++ b/packages/core/src/spine/windtunnel-firing.ts
@@ -1,0 +1,355 @@
+import { enrichWithAstContext } from '../ast-gate.js';
+import type { CompiledRule, DiffAddition, Violation } from '../compiler-schema.js';
+import { extractAddedLines } from '../diff-parser.js';
+import type { RuleEngineContext } from '../rule-engine.js';
+import { applyAstRulesToAdditions, applyRulesToAdditions } from '../rule-engine.js';
+import { firingLabelId } from './windtunnel-lock.js';
+import type { RuleFiring } from './windtunnel-scorer.js';
+
+// ─── Types ───────────────────────────────────────────
+
+/**
+ * One resolved PR's diff plus its role in the wind-tunnel. The certifying run
+ * (5c-ii) builds these from each resolved-PR diff + the controls; 5c-i is the
+ * deterministic engine that turns them into `RuleFiring[]`.
+ *
+ * `controlKind` is the role of the PR/corpus item being scanned, NOT a property
+ * of any individual rule — every rule that fires on a `negative` item is culled
+ * (fold-H: neg-control firings pass through as `controlKind:'negative'`, never
+ * dropped pre-score). `targetRuleId` is the rule a `positive` control MUST fire
+ * to prove non-vacuousness (the positive-control contract the scorer checks).
+ */
+export interface ResolvedPrDiff {
+  pr: number;
+  /** Unified diff text for the PR (post-image additions are extracted from it). */
+  diff: string;
+  controlKind: 'corpus' | 'positive' | 'negative';
+  /** For positive controls: the rule expected to fire (proves non-vacuousness). */
+  targetRuleId?: string;
+}
+
+/**
+ * C1 (fold-B's data prerequisite) — a PER-RULE control result over the
+ * surviving (active, non-culled) rules. `positiveControl`/`negativeControl` are
+ * derived from THIS rule's actual firings, NEVER from the run-level
+ * `nonVacuity` (which is a global AND across all positive-control targets and
+ * would over-stamp a rule that never exercised a control). 5c-ii consumes this
+ * to stamp legitimacy per-rule, survivor-only.
+ */
+export interface PerRuleControlResult {
+  /** True iff this rule fired its positive-control target (per-rule, not global). */
+  positiveControl: boolean;
+  /** True iff this rule did NOT fire on any negative control (clean = passed). */
+  negativeControl: boolean;
+  /** Evidence: the firingLabelIds that establish each control result. */
+  evidenceRefs: string[];
+}
+
+/**
+ * A1 (fold-D) collision detail — surfaced when two firings normalize to the
+ * same `labelId` (the `labelId→evidenceRef`/ground-truth join would silently
+ * overwrite). Emitted into the thrown error so the cert-run report can name the
+ * colliding labelIds + their evidence refs.
+ */
+export interface FiringLabelCollision {
+  labelId: string;
+  /** The colliding firings' evidence (ruleId/pr/filePath/matchedLine). */
+  evidenceRefs: Array<{ ruleId: string; pr: number; filePath: string; matchedLine: string }>;
+}
+
+/** Thrown by `assertUniqueFiringLabels` (A1 hard-gate floor, Tenet 4). */
+export class FiringLabelCollisionError extends Error {
+  readonly collisions: FiringLabelCollision[];
+  constructor(collisions: FiringLabelCollision[]) {
+    const detail = collisions
+      .map(
+        (c) =>
+          `  • labelId ${c.labelId.slice(0, 12)}… collides across ${c.evidenceRefs.length} firings: ` +
+          c.evidenceRefs
+            .map((e) => `[rule ${e.ruleId} pr#${e.pr} ${e.filePath} "${e.matchedLine}"]`)
+            .join(', '),
+      )
+      .join('\n');
+    super(
+      `Wind-tunnel firing-label collision (A1, fold-D): ${collisions.length} labelId(s) map to ` +
+        `multiple firings — the labelId→evidenceRef contract is violated and ground-truth ` +
+        `joins would silently overwrite.\n${detail}`,
+    );
+    this.name = 'FiringLabelCollisionError';
+    this.collisions = collisions;
+  }
+}
+
+/** Thrown when an archived rule reaches the scored set (fold-F, Tenet 4). */
+export class ArchivedRuleInScopeError extends Error {
+  readonly archivedRuleIds: string[];
+  constructor(archivedRuleIds: string[]) {
+    super(
+      `Wind-tunnel scorer-input (fold-F): ${archivedRuleIds.length} archived rule(s) reached the ` +
+        `scored set — archived rules must never enter the wind-tunnel (archived ≠ wind-tunnel FP). ` +
+        `Filter to active rules before building firings. Offending: [${archivedRuleIds.join(', ')}]`,
+    );
+    this.name = 'ArchivedRuleInScopeError';
+    this.archivedRuleIds = archivedRuleIds;
+  }
+}
+
+// ─── Helpers ─────────────────────────────────────────
+
+/**
+ * Normalize a matched line for the content-based labelId (A2/A3). Trailing
+ * whitespace is dropped so cosmetic EOL drift between the post-image and the
+ * diff does not split a firing into a new labelId; interior content is
+ * preserved (the label must still distinguish genuinely different lines).
+ */
+function normalizeMatchedLine(line: string): string {
+  return line.replace(/\s+$/, '');
+}
+
+/** The rule id used for firings + ground-truth joins (the lessonHash). */
+function ruleIdOf(rule: CompiledRule): string {
+  return rule.lessonHash;
+}
+
+// ─── fold-F: archived-excluded loud assert ───────────
+
+/**
+ * fold-F — assert no `status:'archived'` rule is in the scored set (Tenet 4).
+ * Called at the scorer input boundary BEFORE the engine runs, so
+ * `applyAstRulesToAdditions` is never invoked on an archived rule and zero
+ * archived refs can reach `RuleFiring[]`. Archived ≠ wind-tunnel FP: an
+ * archived rule that "fires" is not evidence of imprecision, it is a corpus
+ * contamination that must fail loud.
+ */
+export function assertNoArchivedRules(rules: CompiledRule[]): void {
+  const archived = rules.filter((r) => r.status === 'archived').map(ruleIdOf);
+  if (archived.length > 0) {
+    throw new ArchivedRuleInScopeError(archived);
+  }
+}
+
+// ─── A1 (fold-D): hard-gate-unique FLOOR ─────────────
+
+/**
+ * A1 (fold-D) — hard-gate `firings.length === unique(labelIds).size` BEFORE
+ * `scoreWindtunnel` (Tenet 4). On collision THROW, surfacing the colliding
+ * labelIds + their evidence refs. We do NOT add an occurrence discriminator /
+ * ordinal (strategy ruling: ordinal regresses `firingLabelId`'s line-drift
+ * resistance); we measure collisions on the frozen corpus and fail loud if any
+ * occur. Preserves the `labelId→evidenceRef` contract: a 1:1 labelId→firing map
+ * is the invariant the ground-truth join depends on.
+ */
+export function assertUniqueFiringLabels(firings: RuleFiring[]): void {
+  const byLabel = new Map<string, RuleFiring[]>();
+  for (const f of firings) {
+    const existing = byLabel.get(f.labelId);
+    if (existing) existing.push(f);
+    else byLabel.set(f.labelId, [f]);
+  }
+  const collisions: FiringLabelCollision[] = [];
+  for (const [labelId, group] of byLabel) {
+    if (group.length > 1) {
+      collisions.push({
+        labelId,
+        evidenceRefs: group.map((f) => ({
+          ruleId: f.ruleId,
+          pr: f.pr,
+          filePath: f.filePath,
+          matchedLine: f.matchedLine,
+        })),
+      });
+    }
+  }
+  if (collisions.length > 0) {
+    throw new FiringLabelCollisionError(collisions);
+  }
+}
+
+// ─── Real engine path (replaces runMockEngine) ───────
+
+export interface BuildFiringsInput {
+  /** Active compiled rules (already loaded; archived must be pre-filtered). */
+  rules: CompiledRule[];
+  /** Resolved-PR diffs + controls (corpus / positive / negative). */
+  prDiffs: ResolvedPrDiff[];
+  /** Repo root for AST file resolution (NOT process.cwd() — #1304). */
+  cwd: string;
+  /** Post-image content seam (S1/C1 — same content for regex astContext + AST). */
+  readStrategy: (file: string) => Promise<string | null>;
+  /** Per-invocation rule-engine context (logger + per-ctx state). */
+  ruleEngineCtx: RuleEngineContext;
+  onWarn?: (msg: string) => void;
+}
+
+export interface BuildFiringsResult {
+  firings: RuleFiring[];
+  /** Distinct files touched across all PR diffs (C2 — real exposure). */
+  filesTouchedInWindow: number;
+  /** Positive-control targets, derived from the prDiffs (for the scorer). */
+  positiveControlTargets: Array<{ pr: number; targetRuleId: string }>;
+}
+
+/**
+ * The real-engine firing path (replaces `runMockEngine` for the certifying
+ * phase). For each resolved-PR diff: extract additions → `enrichWithAstContext`
+ * (regex astContext via the shared post-image readStrategy) → regex engine +
+ * `applyAstRulesToAdditions` (AST/ast-grep, same readStrategy) → map every
+ * `Violation` to a `RuleFiring` with `labelId = firingLabelId(...)`.
+ *
+ * Invariants honored here:
+ *  - **fold-F**: throws if any archived rule is present (assertNoArchivedRules),
+ *    so the engine is never invoked on an archived rule.
+ *  - **fold-H**: a firing on a `negative` PR is emitted as `controlKind:'negative'`
+ *    (the scorer culls + ledgers it — never dropped pre-score). Unlabeled firings
+ *    stay in `firings` (no ground-truth) so the scorer routes them to
+ *    needsAdjudication.
+ *  - **C2**: `filesTouchedInWindow` is the count of distinct post-image files
+ *    across all diffs — the real third exposure leg.
+ *
+ * Note: A1 (assertUniqueFiringLabels) is the caller's pre-score gate so the
+ * collision report can be threaded into the cert-run report; this function does
+ * not swallow it.
+ */
+export async function buildFirings(input: BuildFiringsInput): Promise<BuildFiringsResult> {
+  const { rules, prDiffs, cwd, readStrategy, ruleEngineCtx, onWarn } = input;
+
+  // fold-F: hard-gate the scored set BEFORE touching the engine.
+  assertNoArchivedRules(rules);
+
+  const firings: RuleFiring[] = [];
+  const touchedFiles = new Set<string>();
+  const positiveControlTargets: Array<{ pr: number; targetRuleId: string }> = [];
+
+  for (const prDiff of prDiffs) {
+    if (prDiff.controlKind === 'positive' && prDiff.targetRuleId) {
+      positiveControlTargets.push({ pr: prDiff.pr, targetRuleId: prDiff.targetRuleId });
+    }
+
+    const additions: DiffAddition[] = extractAddedLines(prDiff.diff);
+    for (const a of additions) {
+      touchedFiles.add(a.file.replace(/\\/g, '/'));
+    }
+    if (additions.length === 0 || rules.length === 0) continue;
+
+    // Enrich with AST context (regex over-fire suppression parity, C1) using the
+    // SAME post-image content the AST engine will parse (S1).
+    await enrichWithAstContext(additions, { cwd, readStrategy, onWarn });
+
+    // Regex-engine violations.
+    const regexViolations = applyRulesToAdditions(ruleEngineCtx, rules, additions);
+    // AST / ast-grep violations (whole post-image via the shared readStrategy).
+    const astViolations = await applyAstRulesToAdditions(
+      ruleEngineCtx,
+      rules,
+      additions,
+      cwd,
+      undefined,
+      onWarn,
+      readStrategy,
+    );
+
+    for (const v of [...regexViolations, ...astViolations]) {
+      firings.push(violationToFiring(v, prDiff));
+    }
+  }
+
+  return {
+    firings,
+    filesTouchedInWindow: touchedFiles.size,
+    positiveControlTargets,
+  };
+}
+
+/** Map one engine `Violation` to a scored `RuleFiring` (content-based labelId). */
+function violationToFiring(violation: Violation, prDiff: ResolvedPrDiff): RuleFiring {
+  const ruleId = ruleIdOf(violation.rule);
+  const filePath = violation.file.replace(/\\/g, '/');
+  const matchedLine = normalizeMatchedLine(violation.line);
+  const firing: RuleFiring = {
+    ruleId,
+    pr: prDiff.pr,
+    filePath,
+    matchedLine,
+    controlKind: prDiff.controlKind,
+    labelId: firingLabelId(ruleId, prDiff.pr, filePath, matchedLine),
+  };
+  // Carry the positive control's target so the scorer's non-vacuity check can
+  // match on (pr, ruleId) — only meaningful for positive-control firings.
+  if (prDiff.controlKind === 'positive' && prDiff.targetRuleId) {
+    firing.targetRuleId = prDiff.targetRuleId;
+  }
+  return firing;
+}
+
+// ─── C1: per-rule control results ────────────────────
+
+/**
+ * C1 (fold-B's data prerequisite) — build a `Map<ruleId, PerRuleControlResult>`
+ * over the SURVIVING rules (active rules that were NOT culled by a negative
+ * control). `positiveControl` is true ONLY when THIS rule fired its declared
+ * positive-control target — derived from the rule's own firings, never from the
+ * global `nonVacuity`. `negativeControl` is true when the rule fired on NO
+ * negative control. 5c-ii reads this to stamp legitimacy survivor-only.
+ *
+ * Survivors = mintedRuleIds minus rules that fired on any negative control
+ * (those are culled; the scorer records them in the cullLedger and we do not
+ * stamp them).
+ */
+export function computePerRuleControlResults(input: {
+  firings: RuleFiring[];
+  mintedRuleIds: string[];
+  positiveControlTargets: Array<{ pr: number; targetRuleId: string }>;
+}): Map<string, PerRuleControlResult> {
+  const { firings, mintedRuleIds, positiveControlTargets } = input;
+
+  // Rules culled by a negative-control firing (not survivors).
+  const culled = new Set<string>();
+  for (const f of firings) {
+    if (f.controlKind === 'negative') culled.add(f.ruleId);
+  }
+
+  // Per-rule negative-control evidence: the firings that PROVE a rule fired on a
+  // negative control (its negativeControl is therefore false — it gets culled).
+  // A clean rule has no negative-control firing → negativeControl true by absence.
+  const negFiringsByRule = new Map<string, string[]>();
+  for (const f of firings) {
+    if (f.controlKind !== 'negative') continue;
+    const arr = negFiringsByRule.get(f.ruleId) ?? [];
+    arr.push(f.labelId);
+    negFiringsByRule.set(f.ruleId, arr);
+  }
+
+  // Per-rule positive-control evidence: a firing whose (pr, ruleId) matches a
+  // declared positive-control target on a positive-control item.
+  const targetByRule = new Map<string, Set<number>>();
+  for (const t of positiveControlTargets) {
+    const prs = targetByRule.get(t.targetRuleId) ?? new Set<number>();
+    prs.add(t.pr);
+    targetByRule.set(t.targetRuleId, prs);
+  }
+  const posFiringsByRule = new Map<string, string[]>();
+  for (const f of firings) {
+    if (f.controlKind !== 'positive') continue;
+    const prs = targetByRule.get(f.ruleId);
+    if (prs && prs.has(f.pr)) {
+      const arr = posFiringsByRule.get(f.ruleId) ?? [];
+      arr.push(f.labelId);
+      posFiringsByRule.set(f.ruleId, arr);
+    }
+  }
+
+  const result = new Map<string, PerRuleControlResult>();
+  for (const ruleId of mintedRuleIds) {
+    if (culled.has(ruleId)) continue; // not a survivor — never stamped
+    const posEvidence = posFiringsByRule.get(ruleId) ?? [];
+    const negEvidence = negFiringsByRule.get(ruleId) ?? [];
+    result.set(ruleId, {
+      // Per-rule, NOT global nonVacuity: true only if THIS rule fired its target.
+      positiveControl: posEvidence.length > 0,
+      // Clean (passed) when the rule fired on NO negative control.
+      negativeControl: negEvidence.length === 0,
+      evidenceRefs: [...posEvidence, ...negEvidence],
+    });
+  }
+  return result;
+}

--- a/packages/core/src/spine/windtunnel-firing.ts
+++ b/packages/core/src/spine/windtunnel-firing.ts
@@ -235,7 +235,11 @@ export async function buildFirings(input: BuildFiringsInput): Promise<BuildFirin
     // SAME post-image content the AST engine will parse (S1).
     await enrichWithAstContext(additions, { cwd, readStrategy, onWarn });
 
-    // Regex-engine violations.
+    // Both engines receive the FULL rule set and self-filter by `rule.engine`
+    // into DISJOINT partitions — applyRulesToAdditions takes `engine === 'regex'
+    // || !engine`; applyAstRulesToAdditions takes `engine === 'ast' | 'ast-grep'`
+    // (rule-engine.ts). No rule is processed by both, so double-processing can
+    // never manufacture a same-rule labelId self-collision at the A1 gate. (CR #2215.)
     const regexViolations = applyRulesToAdditions(ruleEngineCtx, rules, additions);
     // AST / ast-grep violations (whole post-image via the shared readStrategy).
     const astViolations = await applyAstRulesToAdditions(

--- a/packages/core/src/spine/windtunnel-firing.ts
+++ b/packages/core/src/spine/windtunnel-firing.ts
@@ -308,17 +308,6 @@ export function computePerRuleControlResults(input: {
     if (f.controlKind === 'negative') culled.add(f.ruleId);
   }
 
-  // Per-rule negative-control evidence: the firings that PROVE a rule fired on a
-  // negative control (its negativeControl is therefore false — it gets culled).
-  // A clean rule has no negative-control firing → negativeControl true by absence.
-  const negFiringsByRule = new Map<string, string[]>();
-  for (const f of firings) {
-    if (f.controlKind !== 'negative') continue;
-    const arr = negFiringsByRule.get(f.ruleId) ?? [];
-    arr.push(f.labelId);
-    negFiringsByRule.set(f.ruleId, arr);
-  }
-
   // Per-rule positive-control evidence: a firing whose (pr, ruleId) matches a
   // declared positive-control target on a positive-control item.
   const targetByRule = new Map<string, Set<number>>();
@@ -342,13 +331,15 @@ export function computePerRuleControlResults(input: {
   for (const ruleId of mintedRuleIds) {
     if (culled.has(ruleId)) continue; // not a survivor — never stamped
     const posEvidence = posFiringsByRule.get(ruleId) ?? [];
-    const negEvidence = negFiringsByRule.get(ruleId) ?? [];
     result.set(ruleId, {
       // Per-rule, NOT global nonVacuity: true only if THIS rule fired its target.
       positiveControl: posEvidence.length > 0,
-      // Clean (passed) when the rule fired on NO negative control.
-      negativeControl: negEvidence.length === 0,
-      evidenceRefs: [...posEvidence, ...negEvidence],
+      // Survivors are non-culled by construction (a negative-control firing culls
+      // the rule and we `continue` above), so a rule reaching here fired on NO
+      // negative control → negativeControl is invariantly true; the negative leg
+      // carries no evidence refs (it is an absence, not a firing). (greptile #2215 P2.)
+      negativeControl: true,
+      evidenceRefs: posEvidence,
     });
   }
   return result;

--- a/packages/core/src/spine/windtunnel-scorer.test.ts
+++ b/packages/core/src/spine/windtunnel-scorer.test.ts
@@ -208,6 +208,45 @@ describe('exposure floor check (P2)', () => {
     );
     expect(result.verdict).toBe('PASS');
   });
+
+  // ── C2 (5c-i): the third exposure leg is now load-bearing ──
+
+  it('returns HONEST-NEGATIVE when filesTouchedInWindow < floor (C2 — third leg enforced)', () => {
+    const result = scoreWindtunnel(
+      baseInput({
+        actualExposure: {
+          activeRulesEvaluated: 3, // passes
+          filesTouchedInWindow: 1, // BELOW floor
+          positiveControlsExercised: 2, // passes
+        },
+        exposureFloors: {
+          activeRulesEvaluated: 2,
+          filesTouchedInWindow: 5,
+          positiveControlsExercised: 2,
+        },
+      }),
+    );
+    expect(result.verdict).toBe('HONEST-NEGATIVE');
+    expect(result.precision).toBeNull();
+  });
+
+  it('passes when filesTouchedInWindow exactly equals floor (C2 equality boundary)', () => {
+    const result = scoreWindtunnel(
+      baseInput({
+        actualExposure: {
+          activeRulesEvaluated: 3,
+          filesTouchedInWindow: 5,
+          positiveControlsExercised: 2,
+        },
+        exposureFloors: {
+          activeRulesEvaluated: 2,
+          filesTouchedInWindow: 5,
+          positiveControlsExercised: 2,
+        },
+      }),
+    );
+    expect(result.verdict).toBe('PASS');
+  });
 });
 
 // ─── Cull-rate guard → HONEST-NEGATIVE (C5/S2) ───────

--- a/packages/core/src/spine/windtunnel-scorer.ts
+++ b/packages/core/src/spine/windtunnel-scorer.ts
@@ -221,11 +221,20 @@ export function scoreWindtunnel(input: ScorerInput): WindtunnelVerdict {
 
   // ── Masquerade guards (may only DEMOTE a would-be PASS) ──
 
-  // Step 5: Exposure floor (P2). activeRules/positiveControls below floor →
+  // Step 5: Exposure floor (P2 + C2). All THREE exposure legs are enforced:
+  // activeRules / filesTouchedInWindow / positiveControls below their floor →
   // HONEST-NEGATIVE (no claim → precision null). Ranked above needs-adjudication
   // (Step 7): labeling won't rescue a sub-floor run (strategy-claude tie-break).
+  //
+  // C2 (5c-i): `filesTouchedInWindow` was previously omitted (the CLI passed a
+  // hard-coded 0, so the leg was inert). The certifying run computes real
+  // touched-file exposure from the corpus/diffs; this guard makes the third leg
+  // load-bearing — a sub-floor file exposure is a masquerade (the run scanned too
+  // little of the window to make a precision claim) and must demote to
+  // HONEST-NEGATIVE even when the other two legs pass.
   if (
     actualExposure.activeRulesEvaluated < exposureFloors.activeRulesEvaluated ||
+    actualExposure.filesTouchedInWindow < exposureFloors.filesTouchedInWindow ||
     actualExposure.positiveControlsExercised < exposureFloors.positiveControlsExercised
   ) {
     return {


### PR DESCRIPTION
## Summary

Slice **5c-i** of the ADR-111 Gate-1 rule-mining miner — the **deterministic real-engine firing path** for the certifying run (the #2189 item-1 / #2199 spine track, build-sequence step 1). Replaces the certifying-phase mock with the real engine: each resolved-PR diff → `enrichWithAstContext` + `applyAstRulesToAdditions(readStrategy)` → `RuleFiring[]` with content-based labelIds. Built off the 4/4-panel-locked design at `.totem/specs/adr-111-slice5c-certifying-orchestrator.md`.

## Folds discharged (5c-i scope)

- **A1 (fold-D)** — `assertUniqueFiringLabels` hard-gates `firings.length === unique(labelIds)` pre-score and THROWS on collision, surfacing the colliding labelIds + evidence refs (Tenet 4). No ordinal/occurrence discriminator — preserves the `labelId→evidenceRef` contract; a richer key is a later versioned extension only if the corpus needs it.
- **C1** — `computePerRuleControlResults` surfaces a per-rule `{positiveControl, negativeControl, evidenceRefs}` over survivors, derived **per-rule and never from the global `nonVacuity`** (the data prerequisite for 5c-ii's fold-B stamping).
- **C2** — `scoreWindtunnel` now enforces the third exposure leg (`filesTouchedInWindow`), which was previously inert (the CLI passed a hard-coded 0); the certifying path computes real touched-file exposure from the diffs. Sub-floor file exposure ⟹ HONEST-NEGATIVE.
- **fold-F** — `assertNoArchivedRules` throws at the scorer-input boundary; the engine is never invoked on a `status:'archived'` rule (archived ≠ wind-tunnel FP).
- **fold-H** — neg-control firings pass through as `controlKind:'negative'`; unlabeled firings ⟹ `needsAdjudication`; duplicate label ⟹ hard error pre-score.

## Scope boundary

5c-i is the deterministic firing path only. The live-recorded corpus (fetch/compile/record), fold-B legitimacy **stamping**, fold-C parse-before-write persistence, the `record` subcommand, fold-I ledgers, fold-K E2E isolation, and the §5 split-artifact precondition are **5c-ii** — wired through the `CertifyingCorpusProvider` injection seam left here. An unwired certifying run fails loud with `CONFIG_INVALID` (never a silent empty-set score); `runMockEngine` is retained for the harness phase.

Part of the #2189 item-1 / #2199 spine track; item 1 finishes with 5c-ii (this slice does not complete it).

## Test plan

- **Core** (`@mmnto/totem`): 22 new firing tests + 2 scorer C2 boundary cases — spine suite 59 green.
- **CLI**: 5 new `runCertifyingEngine` tests — windtunnel suite 35 green.
- Zero-LLM, deterministic — fixture rules + PR-diff fixtures + injected post-image `readStrategy`; no network.
- Real gate (controller-verified post-commit): `totem lint --base main` PASS (0 errors), `format:check` clean, full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
