### PR TITLE
fix(lint): honor inline suppression under diff-scoped lint (#2214)

### DIFF
--- a/.changeset/fix-2214-totem-context-diff-scope-suppression.md
+++ b/.changeset/fix-2214-totem-context-diff-scope-suppression.md
@@ -1,0 +1,7 @@
+---
+'@mmnto/totem': patch
+---
+
+fix(lint): `// totem-context:` / `// totem-ignore` inline suppression now applies under diff-scoped lint (`totem lint --base main`), identically to full-tree lint (mmnto-ai/totem#2214).
+
+For a multi-line construct (e.g. a `catch_clause` matched by the Tenet-4 `lesson-fail-open-catch-ban` rule), the reported match line is the first _added_ line within the node's range. Under diff scope, when only a line inside the construct's body is in the diff, that reported line drifts off the construct's start line — so a correctly-positioned directive on (or immediately above) the `catch` line was missed and the rule fired anyway, pushing authors toward matcher-evasion (rewriting `catch {}` as `.catch(() => …)` to dodge the `catch_clause` matcher). The ast-grep and tree-sitter match results now carry the construct's start-line text and its preceding-line text as an explicit suppression anchor; suppression checks both the matched line and that anchor, so a directive on the construct line suppresses regardless of which body line landed in the diff. Reported violation locations are unchanged.

--- a/packages/core/src/ast-grep-query.ts
+++ b/packages/core/src/ast-grep-query.ts
@@ -12,6 +12,18 @@ export type AstGrepRule = string | NapiConfig;
 export interface AstGrepMatch {
   lineNumber: number;
   lineText: string;
+  /**
+   * Suppression anchor: the matched construct's start line text and the line
+   * immediately above it. The inline-directive convention (mmnto-ai/totem#1889)
+   * attaches `// totem-ignore` / `// totem-context:` to the construct's start
+   * line or the line above it, but `lineNumber` is the first *added* line
+   * within the node's range — under diff scope it can drift into the construct
+   * body, off the start line, so a directive on the start line is otherwise
+   * missed (mmnto-ai/totem#2214). Consumers check this anchor in addition to
+   * the reported line.
+   */
+  startLineText: string;
+  startPrecedingLineText: string | null;
 }
 
 // ─── Constants ──────────────────────────────────────
@@ -136,6 +148,10 @@ function executeQuery(
           results.push({
             lineNumber: lineNum,
             lineText: lines[lineNum - 1] ?? '',
+            // Suppression anchor — the construct's start line, which may differ
+            // from the reported (first-added) line under diff scope (#2214).
+            startLineText: lines[startLine - 1] ?? '',
+            startPrecedingLineText: startLine > 1 ? (lines[startLine - 2] ?? null) : null,
           });
           break;
         }

--- a/packages/core/src/ast-query.ts
+++ b/packages/core/src/ast-query.ts
@@ -14,6 +14,18 @@ const execFileAsync = promisify(execFile);
 export interface AstMatch {
   lineNumber: number;
   lineText: string;
+  /**
+   * Suppression anchor: the matched construct's start line text and the line
+   * immediately above it. The inline-directive convention (mmnto-ai/totem#1889)
+   * attaches `// totem-ignore` / `// totem-context:` to the construct's start
+   * line or the line above it, but `lineNumber` is the first *added* line
+   * within the node's range — under diff scope it can drift into the construct
+   * body, off the start line, so a directive on the start line is otherwise
+   * missed (mmnto-ai/totem#2214). Consumers check this anchor in addition to
+   * the reported line.
+   */
+  startLineText: string;
+  startPrecedingLineText: string | null;
 }
 
 // ─── Constants ──────────────────────────────────────
@@ -95,6 +107,10 @@ function runQuery(
           results.push({
             lineNumber: lineNum,
             lineText: lines[lineNum - 1] ?? '',
+            // Suppression anchor — the construct's start line, which may differ
+            // from the reported (first-added) line under diff scope (#2214).
+            startLineText: lines[startLine - 1] ?? '',
+            startPrecedingLineText: startLine > 1 ? (lines[startLine - 2] ?? null) : null,
           });
           break;
         }

--- a/packages/core/src/rule-engine.test.ts
+++ b/packages/core/src/rule-engine.test.ts
@@ -313,6 +313,67 @@ describe('applyAstRulesToAdditions', () => {
     expect(violations.length).toBeGreaterThanOrEqual(1);
   });
 
+  // The same start-line suppression anchor flows through the tree-sitter
+  // (engine: 'ast') match path, whose AstMatch results gained the same
+  // startLineText/startPrecedingLineText fields. Cover it directly so a
+  // divergence in how the tree-sitter loop populates the anchor can't
+  // silently regress diff-scoped suppression (greptile #2216).
+  const treeSitterCatchRule = (): CompiledRule =>
+    makeRule({
+      engine: 'ast',
+      lessonHash: 'ts-fail-open-catch',
+      astQuery: '(catch_clause) @violation',
+    });
+
+  it('suppresses via a totem-context directive on the tree-sitter (ast) path when only the body is in the diff (#2214)', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'src', 'app.ts'),
+      [
+        'try {', // 1
+        '  doWork();', // 2
+        '  // totem-context: best-effort cleanup, fail-soft', // 3
+        '} catch (err) {', // 4
+        '  return [];', // 5
+        '}', // 6
+        '',
+      ].join('\n'),
+    );
+
+    const additions = [makeAddition('src/app.ts', '  return [];', 5)];
+
+    const violations = await applyAstRulesToAdditions(
+      ctx,
+      [treeSitterCatchRule()],
+      additions,
+      tmpDir,
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  it('still fires on the tree-sitter (ast) path with NO directive when only the body is in the diff (#2214 — no over-suppression)', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'src', 'app.ts'),
+      [
+        'try {', // 1
+        '  doWork();', // 2
+        '} catch (err) {', // 3
+        '  return [];', // 4
+        '}', // 5
+        '',
+      ].join('\n'),
+    );
+
+    const additions = [makeAddition('src/app.ts', '  return [];', 4)];
+
+    const violations = await applyAstRulesToAdditions(
+      ctx,
+      [treeSitterCatchRule()],
+      additions,
+      tmpDir,
+    );
+    expect(violations.length).toBeGreaterThanOrEqual(1);
+  });
+
   it('compound rule with invalid NAPI config emits failure event without crashing', async () => {
     fs.writeFileSync(path.join(tmpDir, 'src', 'app.ts'), 'const x = 1;\n');
 

--- a/packages/core/src/rule-engine.test.ts
+++ b/packages/core/src/rule-engine.test.ts
@@ -219,6 +219,100 @@ describe('applyAstRulesToAdditions', () => {
     expect(violations[0]!.lineNumber).toBe(3);
   });
 
+  // ── Inline-suppression anchoring under diff scope (mmnto-ai/totem#2214) ──
+  // The reported match line is the first *added* line within a multi-line
+  // construct's range, so when only the catch BODY is in the diff the line
+  // drifts off the catch keyword line — and a directive on (or above) the
+  // catch line was missed. Suppression must anchor to the construct start.
+  const failOpenCatchRule = (): CompiledRule =>
+    makeRule({
+      engine: 'ast-grep',
+      lessonHash: 'fail-open-catch-ban',
+      astGrepPattern: undefined,
+      pattern: '',
+      astGrepYamlRule: {
+        rule: { kind: 'catch_clause', not: { has: { kind: 'throw_statement', stopBy: 'end' } } },
+      },
+    });
+
+  it('suppresses a fail-open catch via a totem-context directive ABOVE the catch when only the body is in the diff (#2214)', async () => {
+    // The try/catch wrapper + the directive pre-existed; only the body line
+    // changed. In diff scope the match line drifts to the added body line, so
+    // pre-#2214 the directive on line 3 (above the catch on line 4) was missed.
+    fs.writeFileSync(
+      path.join(tmpDir, 'src', 'app.ts'),
+      [
+        'try {', // 1
+        '  doWork();', // 2
+        '  // totem-context: best-effort cleanup, fail-soft', // 3
+        '} catch (err) {', // 4
+        '  return [];', // 5
+        '}', // 6
+        '',
+      ].join('\n'),
+    );
+
+    // Diff scope: ONLY the body line (5) is an addition; the catch line (4)
+    // and the directive (3) are unchanged context, absent from `additions`.
+    const additions = [makeAddition('src/app.ts', '  return [];', 5)];
+
+    const violations = await applyAstRulesToAdditions(
+      ctx,
+      [failOpenCatchRule()],
+      additions,
+      tmpDir,
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  it('suppresses a fail-open catch via an INLINE totem-context directive on the catch line when only the body is in the diff (#2214)', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'src', 'app.ts'),
+      [
+        'try {', // 1
+        '  doWork();', // 2
+        '} catch (err) { // totem-context: best-effort cleanup, fail-soft', // 3
+        '  return [];', // 4
+        '}', // 5
+        '',
+      ].join('\n'),
+    );
+
+    const additions = [makeAddition('src/app.ts', '  return [];', 4)];
+
+    const violations = await applyAstRulesToAdditions(
+      ctx,
+      [failOpenCatchRule()],
+      additions,
+      tmpDir,
+    );
+    expect(violations).toHaveLength(0);
+  });
+
+  it('still fires on a fail-open catch with NO directive when only the body is in the diff (#2214 — no over-suppression)', async () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'src', 'app.ts'),
+      [
+        'try {', // 1
+        '  doWork();', // 2
+        '} catch (err) {', // 3
+        '  return [];', // 4
+        '}', // 5
+        '',
+      ].join('\n'),
+    );
+
+    const additions = [makeAddition('src/app.ts', '  return [];', 4)];
+
+    const violations = await applyAstRulesToAdditions(
+      ctx,
+      [failOpenCatchRule()],
+      additions,
+      tmpDir,
+    );
+    expect(violations.length).toBeGreaterThanOrEqual(1);
+  });
+
   it('compound rule with invalid NAPI config emits failure event without crashing', async () => {
     fs.writeFileSync(path.join(tmpDir, 'src', 'app.ts'), 'const x = 1;\n');
 

--- a/packages/core/src/rule-engine.ts
+++ b/packages/core/src/rule-engine.ts
@@ -236,6 +236,42 @@ export function extractJustification(
   return '';
 }
 
+/**
+ * Resolve inline suppression for an AST (tree-sitter or ast-grep) match,
+ * checking BOTH directive anchors.
+ *
+ * The inline-directive convention (mmnto-ai/totem#1889) attaches a
+ * `// totem-ignore` / `// totem-context:` directive to the matched construct's
+ * start line or the line immediately above it. But the reported match line is
+ * the first *added* line within the node's range — under diff scope, where only
+ * a changed body line is an addition, it drifts off the construct's start line,
+ * so a directive on (or above) that start line is missed if we only check the
+ * matched line (mmnto-ai/totem#2214). We check the matched (first-added) line
+ * AND the construct's start-line anchor the match carries; a directive on
+ * either suppresses, making diff-scoped lint behave like full-tree lint.
+ */
+function resolveAstMatchSuppression(
+  ctx: RuleEngineContext,
+  match: { startLineText: string; startPrecedingLineText: string | null },
+  addition: DiffAddition | undefined,
+): { suppressed: boolean; justification: string } {
+  // Anchor 1 — the matched (first-added) line + its preceding line, from the diff.
+  if (addition && isSuppressed(ctx, addition.line, addition.precedingLine)) {
+    return {
+      suppressed: true,
+      justification: extractJustification(ctx, addition.line, addition.precedingLine),
+    };
+  }
+  // Anchor 2 — the construct's start line + the line above it (mmnto-ai/totem#2214).
+  if (isSuppressed(ctx, match.startLineText, match.startPrecedingLineText)) {
+    return {
+      suppressed: true,
+      justification: extractJustification(ctx, match.startLineText, match.startPrecedingLineText),
+    };
+  }
+  return { suppressed: false, justification: '' };
+}
+
 // ─── Regex rule execution ───────────────────────────
 
 /**
@@ -487,11 +523,12 @@ export async function applyAstRulesToAdditions(
 
           for (const match of matches) {
             const addition = fileAdditions.find((a) => a.lineNumber === match.lineNumber);
-            if (addition && isSuppressed(ctx, addition.line, addition.precedingLine)) {
+            const { suppressed, justification } = resolveAstMatchSuppression(ctx, match, addition);
+            if (suppressed) {
               onRuleEvent?.('suppress', rule.lessonHash, {
                 file,
                 line: match.lineNumber,
-                justification: extractJustification(ctx, addition.line, addition.precedingLine),
+                justification,
                 immutable: rule.immutable,
               });
               continue;
@@ -572,13 +609,16 @@ export async function applyAstRulesToAdditions(
 
             for (const match of matches) {
               const addition = fileAdditions.find((a) => a.lineNumber === match.lineNumber);
-              if (addition && isSuppressed(ctx, addition.line, addition.precedingLine)) {
+              const { suppressed, justification } = resolveAstMatchSuppression(
+                ctx,
+                match,
+                addition,
+              );
+              if (suppressed) {
                 onRuleEvent?.('suppress', rule.lessonHash, {
                   file,
                   line: match.lineNumber,
-                  justification: addition
-                    ? extractJustification(ctx, addition.line, addition.precedingLine)
-                    : '',
+                  justification,
                   immutable: rule.immutable,
                 });
                 continue;


### PR DESCRIPTION
## What

`// totem-context:` / `// totem-ignore` inline suppression now applies under **diff-scoped** lint (`totem lint --base main`), identically to full-tree lint.

Previously a *correctly-positioned* directive (on, or immediately above, a `catch` line) was honored full-tree but **not** under `--base main`, so the Tenet-4 `lesson-fail-open-catch-ban` rule fired anyway on legitimately fail-soft catches — pushing authors toward matcher-evasion (rewriting `catch {}` as `.catch(() => …)` to dodge the `catch_clause` matcher). It hit every live IO/LLM adapter cohort-wide (the ADR-111 5b live-adapter family was the live exhibit).

## Root cause

For a multi-line construct, the reported match line is the **first _added_ line within the node's range** (`ast-grep-query.ts` / `ast-query.ts`). Under diff scope, when only a line inside the construct's body is in the diff, that reported line drifts off the construct's start line — and the single-line `isSuppressed(line, precedingLine)` check never sees a directive placed on (or above) the `catch` line. Full-tree lint treats every line as "added", so the first-added line *is* the start line and the directive is found — which is why the escape worked full-tree but not diff-scoped, and read as commit/dirty-tree-dependent.

## Fix

- The ast-grep and tree-sitter match results now carry the construct's **start-line text and its preceding-line text** as an explicit suppression anchor.
- `resolveAstMatchSuppression` (shared by both the tree-sitter and ast-grep loops) checks **both** the matched (first-added) line and that start-line anchor — a directive on either suppresses. Diff-scoped lint now behaves identically to full-tree lint.
- Reported **violation locations are unchanged** (still the first-added line).

## Tests (fixture-first, per the issue's mandated step 1)

Red-repro fixtures confirmed *before* touching the engine:
- directive **above** the catch, only the body line in the diff → was firing, now suppressed.
- **inline** directive on the catch line, only the body line in the diff → was firing, now suppressed.
- **no** directive, only the body line in the diff → still fires (no over-suppression).

## Gate

- Core suite ✅ 2692 · CLI suite ✅ 2703 · full repo build ✅ 5/5
- `format:check` ✅ clean · `totem lint --base main` ✅ PASS, 0 errors
- Changeset: `@mmnto/totem: patch` (fixed cohort)

## Scope

Addresses **#2214** acceptance **1 + 2** (suppression parity full-tree ⇔ diff-scope; diff-anchoring characterized + tested). Acceptance **3** — a *recognized* fail-soft carve-out annotation — is intentionally **deferred** to a follow-up coordinated with `totem-strategy#702` (the Tenet-4 doctrine sharpening, BLIND-gated), which will align to this fix's shape. **#2214 stays open** for that item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
