### PR TITLE
chore(doctrine): pin @mmnto/strategy-doctrine 0.1.10 -> 0.1.12 (cohort sync)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "typescript-eslint": "^8.59.4"
   },
   "optionalDependencies": {
-    "@mmnto/strategy-doctrine": "0.1.10"
+    "@mmnto/strategy-doctrine": "0.1.12"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         version: 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
     optionalDependencies:
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.10
-        version: 0.1.10
+        specifier: 0.1.12
+        version: 0.1.12
 
   packages/cli:
     dependencies:
@@ -853,8 +853,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.10':
-    resolution: {integrity: sha512-RMg2mmn1aWKye+rEJ8T1lDiJ/4Lj6qwgC+zL7bVH055rR1RyyFx13oJX5Zy6rKoDUJo45IjtSVtragKNMix89Q==}
+  '@mmnto/strategy-doctrine@0.1.12':
+    resolution: {integrity: sha512-Hn4PdmZ1TGMYYMAQ7Xj2rNpFpeHneSXRD5WF2WFJNvxZizY174FLgWTHyHOnS28GN1K8I/h/ITQC4g87YgJj9Q==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3685,7 +3685,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.10':
+  '@mmnto/strategy-doctrine@0.1.12':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
## What

Bump the `@mmnto/strategy-doctrine` cohort pin **0.1.10 → 0.1.12** (root `optionalDependencies`) + lockfile, adopting strategy-claude's published doctrine batch cut (`totem-strategy` `2d52346`, `mmnto-ai/totem-strategy#713` — `@mmnto/strategy-doctrine@0.1.12`, npm `latest`).

## Why

Consumer-side cohort-sync: strategy-claude cut + published the 0.1.12 doctrine batch. This pin adopts it. **Supersedes the held #2213 0.1.10 → 0.1.11 bump** — 0.1.11's `npm-registry-read-auth` parity row is folded into the 0.1.12 cut, so the doctrine **content** is adopted here.

## Verification

- `doctor`: `cohort channel ok (@mmnto/strategy-doctrine@0.1.12)`, freeze state `[cohort@0.1.12]`, **0 failures**.
- Pin + lockfile only. No changeset (the root package is private — matches the prior `chore(doctrine): pin ...` bumps, e.g. #2171).

## Not in scope

#2213's doctor-side **capability-probe wiring** for the read-auth parity row is doctor *code*, separate from this pin adoption — #2213 stays open for it (no closing keyword here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
