### PR TITLE
feat(spine): Gate-1 cert-corpus materialization producer — materialize command (strategy#709)

### DIFF
--- a/.changeset/spine-709-cert-corpus-producer.md
+++ b/.changeset/spine-709-cert-corpus-producer.md
@@ -1,0 +1,19 @@
+---
+'@mmnto/totem': minor
+---
+
+feat(spine): cert-corpus materialization producer — `totem spine windtunnel materialize` (strategy#709)
+
+The Gate-1 cert run's SCORING corpus had no producer: `loadCertRunFixtures` hard-requires 6 fixtures and only `record` wrote 2 (the minted-rules half). This adds the producer for the 4 unproduced, non-label fixtures — the lock, `split.json`, `pr-diffs.json`, and the positive/negative control dirs — so the cert corpus is materializable upstream of `record`→`freeze`→`run`. The disposition-derived `ground-truth-labels.json` deriver is the next slice (contract ruled).
+
+Cohort-panel-ratified (codex/agy/gemini, distinct lenses) before any code; the folds it surfaced are incorporated:
+
+- **Seed-manifest boundary** (panel OQ1/OQ2): a small curated seed carries the irreducible answer-key decisions (asOfCommit, selection predicate/config, `cutIndex`, control designations + each positive control's `targetRuleId`); everything else — the resolved corpus, the ancestry-cut split, per-PR diffs, the integrity shas, the assembled lock — is derived off the lc clone. Pure derivation + lock assembly in core (`deriveCorpus` / `buildWindtunnelLock`), git I/O in the CLI.
+- **Reuse** (Tenet-21): `resolveSelectionRule` (corpus) + `resolveSplit` (the validated ancestry-cut split with its fail-loud cover/disjointness guards) + `enumeratePrMetas` + `computeFixtureSha`.
+- **Strict write-side** (fold-1): `targetRuleId` is structurally required for positive controls and forbidden otherwise — the producer never relies on the permissive consumer schema, so a positive control can't silently lose its non-vacuity target.
+- **Two-phase sealed lock** (fold OQ-seq): the producer writes the lock WITHOUT `llmReplaySha` (it can't know it — `record` runs after); `freeze` seals it.
+- **pr-diffs integrity digest** (fold-2): a new additive-optional `controls.integrity.prDiffsSha` (sha256 over the canonical `pr-diffs.json`) closes the hole that `fixtureSha` (control-dirs-only) leaves on the independently-loaded scoring source. The producer computes + stamps it; the freeze/run hard-enforcement is the immediate fast-follow.
+- **Fail-loud git** (fold-3): producer-owned diff resolution throws on git faults and rejects an empty diff for a code-touching PR (no silent-empty frozen fixture), unlike the advisory `git.ts` helpers.
+- **Amendment-C double-guard** (fold-4): a contradictory seed (a control outside the corpus, or tagged both positive+negative) fails loud before emit.
+
+Byte-deterministic at a fixed asOfCommit+seed (canonical sorted-key JSON, forward-slash paths, `git hash-object`, no timestamps in fixtures). Tested with a programmatic git fixture (real `git init`, pinned dates) over the direct-to-main / malformed-`(#abc)` / revert-pair / multi-file / empty-diff matrix; the produced output passes the actual freeze gate (S4 completeness + C6 integrity) end-to-end.

--- a/packages/cli/src/commands/spine-cert-materialize.test.ts
+++ b/packages/cli/src/commands/spine-cert-materialize.test.ts
@@ -13,7 +13,7 @@ import {
   WindtunnelLockSchema,
 } from '@mmnto/totem';
 
-import { materializeCommand } from './spine-cert-materialize.js';
+import { materializeCommand, resolvePrGit } from './spine-cert-materialize.js';
 import { assertCorpusCompleteness, verifyControlIntegrity } from './spine-windtunnel.js';
 
 // ─── Programmatic git fixture (agy's substrate: real `git init`, pinned dates) ──
@@ -191,8 +191,11 @@ describe('materializeCommand', () => {
       safeExec,
     );
 
-    // fold-2 digest is correct + re-derivable (content-addressed over canonical pr-diffs).
-    expect(sha256(canonicalStringify(prDiffs))).toBe(lock.controls.integrity.prDiffsSha);
+    // fold-2 digest is the sha256 of the EXACT on-disk pr-diffs.json bytes — so a
+    // freeze/run enforcer can hash the file directly (greptile/GCA panel).
+    expect(sha256(fs.readFileSync(path.join(gate1, 'pr-diffs.json'), 'utf-8'))).toBe(
+      lock.controls.integrity.prDiffsSha,
+    );
   });
 
   it('is byte-deterministic — re-running yields identical fixture bytes', async () => {
@@ -245,15 +248,29 @@ describe('materializeCommand', () => {
       manifestPath: writeSeed(tmp, seedObject(headSha)),
     });
     const lock = WindtunnelLockSchema.parse(readJson(path.join(gate1, 'windtunnel.lock.json')));
-    const prDiffs = readJson(path.join(gate1, 'pr-diffs.json')) as Array<Record<string, unknown>>;
 
-    // a clean re-derive matches the stored digest...
-    expect(sha256(canonicalStringify(prDiffs))).toBe(lock.controls.integrity.prDiffsSha);
-    // ...a tampered control row does NOT (the hole fixtureSha alone leaves open).
+    // the digest = sha256 of the on-disk bytes, so reading the file back matches...
+    const onDisk = fs.readFileSync(path.join(gate1, 'pr-diffs.json'), 'utf-8');
+    expect(sha256(onDisk)).toBe(lock.controls.integrity.prDiffsSha);
+    // ...a tampered control row (re-serialized the same way) does NOT (the hole
+    // fixtureSha alone leaves open).
+    const prDiffs = JSON.parse(onDisk) as Array<Record<string, unknown>>;
     const tampered = prDiffs.map((d) =>
       d.pr === 7 ? { ...d, diff: `${d.diff as string}// x` } : d,
     );
-    expect(sha256(canonicalStringify(tampered))).not.toBe(lock.controls.integrity.prDiffsSha);
+    expect(sha256(`${canonicalStringify(tampered, 2)}\n`)).not.toBe(
+      lock.controls.integrity.prDiffsSha,
+    );
+  });
+
+  it('fold-3: resolvePrGit throws on an empty diff for a code-touching PR', () => {
+    // The guard `diff.trim().length === 0` in resolvePrGit isn't reachable via the
+    // matrix repo (the only empty-diff PRs are non-code → excluded before resolve),
+    // so exercise it directly: git succeeds (non-empty rev-parse) but the diff is
+    // empty — must fail loud, not silently emit an empty frozen fixture.
+    const fakeExec = ((_cmd: string, args: readonly string[]): string =>
+      args[0] === 'rev-parse' ? '0'.repeat(40) : '') as Parameters<typeof resolvePrGit>[2];
+    expect(() => resolvePrGit('/lc', 'a'.repeat(40), fakeExec)).toThrow(/EMPTY diff/);
   });
 
   it('fails loud on a malformed `(#abc)` merge subject (no silent shrink)', async () => {

--- a/packages/cli/src/commands/spine-cert-materialize.test.ts
+++ b/packages/cli/src/commands/spine-cert-materialize.test.ts
@@ -14,11 +14,7 @@ import {
 } from '@mmnto/totem';
 
 import { materializeCommand } from './spine-cert-materialize.js';
-import {
-  assertCorpusCompleteness,
-  computeFixtureSha,
-  verifyControlIntegrity,
-} from './spine-windtunnel.js';
+import { assertCorpusCompleteness, verifyControlIntegrity } from './spine-windtunnel.js';
 
 // ─── Programmatic git fixture (agy's substrate: real `git init`, pinned dates) ──
 

--- a/packages/cli/src/commands/spine-cert-materialize.test.ts
+++ b/packages/cli/src/commands/spine-cert-materialize.test.ts
@@ -1,0 +1,303 @@
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  canonicalStringify,
+  safeExec,
+  SplitArtifactSchema,
+  WindtunnelLockSchema,
+} from '@mmnto/totem';
+
+import { materializeCommand } from './spine-cert-materialize.js';
+import {
+  assertCorpusCompleteness,
+  computeFixtureSha,
+  verifyControlIntegrity,
+} from './spine-windtunnel.js';
+
+// ─── Programmatic git fixture (agy's substrate: real `git init`, pinned dates) ──
+
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: 'Dev',
+  GIT_AUTHOR_EMAIL: 'dev@example.com',
+  GIT_COMMITTER_NAME: 'Dev',
+  GIT_COMMITTER_EMAIL: 'dev@example.com',
+  GIT_AUTHOR_DATE: '2026-01-01T00:00:00Z',
+  GIT_COMMITTER_DATE: '2026-01-01T00:00:00Z',
+};
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, env: GIT_ENV, encoding: 'utf-8' });
+}
+
+interface CommitSpec {
+  subject: string;
+  files: Record<string, string>;
+  /** Build the commit body from the SHAs of already-created commits (e.g. revert refs). */
+  body?: (shas: string[]) => string;
+}
+
+/** Build a synthetic squash-merge history; returns each commit's SHA in order. */
+function makeRepo(dir: string, commits: CommitSpec[]): { headSha: string; shas: string[] } {
+  fs.mkdirSync(dir, { recursive: true });
+  git(dir, 'init', '-q', '-b', 'main');
+  git(dir, 'config', 'commit.gpgsign', 'false');
+  const shas: string[] = [];
+  for (const c of commits) {
+    for (const [rel, content] of Object.entries(c.files)) {
+      const full = path.join(dir, rel);
+      fs.mkdirSync(path.dirname(full), { recursive: true });
+      fs.writeFileSync(full, content, 'utf-8');
+      git(dir, 'add', '--', rel);
+    }
+    const body = c.body ? c.body(shas) : '';
+    git(dir, 'commit', '-q', '-m', body ? `${c.subject}\n\n${body}` : c.subject);
+    shas.push(git(dir, 'rev-parse', 'HEAD').trim());
+  }
+  return { headSha: shas[shas.length - 1]!, shas };
+}
+
+/**
+ * The standard matrix history. An initial non-PR root provides a parent for #1.
+ * Corpus = code-touching, non-bot, non-revert PRs = [1, 2, 5, 6, 7] —
+ *   #3 is docs-only (excluded), the bare `chore: direct bump` has no `(#N)` (skipped).
+ */
+const STANDARD_COMMITS: CommitSpec[] = [
+  { subject: 'chore: init repo', files: { 'base.txt': 'seed\n' } },
+  { subject: 'feat: a (#1)', files: { 'packages/core/src/a.ts': 'export const a = 1;\n' } },
+  { subject: 'feat: b (#2)', files: { 'packages/core/src/b.ts': 'export const b = 2;\n' } },
+  { subject: 'docs: c (#3)', files: { 'README.md': '# docs only\n' } },
+  { subject: 'chore: direct bump', files: { 'packages/core/src/z.ts': 'export const z = 0;\n' } },
+  { subject: 'feat: d (#5)', files: { 'packages/core/src/d.ts': 'export const d = 5;\n' } },
+  {
+    subject: 'feat: e (#6)',
+    files: { 'packages/core/src/e.ts': 'export const e = 6;\n', 'docs/e.md': '# e\n' },
+  },
+  { subject: 'feat: f (#7)', files: { 'packages/core/src/f.ts': 'export const f = 7;\n' } },
+];
+
+function seedObject(
+  asOfCommit: string,
+  overrides?: Record<string, unknown>,
+): Record<string, unknown> {
+  return {
+    gate: 'gate-1',
+    canonicalPath: '.totem/spine/gate-1/windtunnel.lock.json',
+    repo: 'mmnto-ai/liquid-city',
+    phase: 'certifying',
+    selectionRule: {
+      state: 'merged',
+      predicate: 'code-touching non-bot non-revert',
+      window: { type: 'all' },
+      asOfCommit,
+      codePathClassifier: { includeGlobs: ['packages/**'], excludeGlobs: ['**/*.md'] },
+      excludeRevertPairs: true,
+      excludeBotPrs: true,
+    },
+    split: { cutIndex: 2, excludedPrs: [] },
+    controls: {
+      positiveRef: '.totem/spine/gate-1/controls/positive',
+      negativeRef: '.totem/spine/gate-1/controls/negative',
+      mechanism: 'git-hash-object',
+      positive: [{ pr: 6, targetRuleId: 'rule-x' }],
+      negative: [7],
+    },
+    fpDefinition: { rubricRef: 'rubric', groundTruthRef: 'gt', adjudicator: 'disposition-derived' },
+    cullRateThreshold: 0.1,
+    exposureDenominator: {
+      activeRulesEvaluated: { floor: 2 },
+      filesTouchedInWindow: { floor: 0 },
+      positiveControlsExercised: { floor: 1 },
+    },
+    ...overrides,
+  };
+}
+
+function writeSeed(repoRoot: string, seed: Record<string, unknown>): string {
+  const p = path.join(repoRoot, 'seed.json');
+  fs.writeFileSync(p, JSON.stringify(seed, null, 2), 'utf-8');
+  return p;
+}
+
+const readJson = (p: string): unknown => JSON.parse(fs.readFileSync(p, 'utf-8'));
+const sha256 = (s: string): string => createHash('sha256').update(s, 'utf-8').digest('hex');
+
+describe('materializeCommand', () => {
+  let tmp: string;
+  let lcDir: string;
+  let gate1: string;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'cert-corpus-'));
+    lcDir = path.join(tmp, 'lc');
+    gate1 = path.join(tmp, '.totem/spine/gate-1');
+  });
+  afterEach(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('materializes the 4 fixtures; output PASSES the real freeze gate (S4 + C6)', async () => {
+    const { headSha } = makeRepo(lcDir, STANDARD_COMMITS);
+    await materializeCommand({
+      cwd: tmp,
+      lcDir,
+      manifestPath: writeSeed(tmp, seedObject(headSha)),
+    });
+
+    const lock = WindtunnelLockSchema.parse(readJson(path.join(gate1, 'windtunnel.lock.json')));
+    const split = SplitArtifactSchema.parse(readJson(path.join(gate1, 'split.json')));
+    const prDiffs = readJson(path.join(gate1, 'pr-diffs.json')) as Array<{
+      pr: number;
+      controlKind: string;
+      targetRuleId?: string;
+      diff: string;
+    }>;
+
+    // Corpus membership: docs-only #3 + the no-`(#N)` direct commit are excluded.
+    expect(lock.corpus.resolvedPrs.map((p) => p.pr)).toEqual([1, 2, 5, 6, 7]);
+    expect(split.trainPrs).toEqual([1, 2]);
+    expect(split.heldOutPrs).toEqual([5, 6, 7]);
+
+    // pr-diffs covers the held-out (scored) slice, controls tagged within it.
+    expect(prDiffs.map((d) => d.pr)).toEqual([5, 6, 7]);
+    expect(prDiffs.find((d) => d.pr === 5)!.controlKind).toBe('corpus');
+    expect(prDiffs.find((d) => d.pr === 6)).toMatchObject({
+      controlKind: 'positive',
+      targetRuleId: 'rule-x',
+    });
+    expect(prDiffs.find((d) => d.pr === 7)!.controlKind).toBe('negative');
+    expect(prDiffs.find((d) => d.pr === 5)!.diff).toContain('packages/core/src/d.ts');
+    // A 'corpus'/'negative' row must NOT carry a targetRuleId (strict write-side, fold-1).
+    expect(prDiffs.find((d) => d.pr === 7)!.targetRuleId).toBeUndefined();
+
+    // Two-phase sealed lock: producer leaves llmReplaySha unstamped; integrity shas present.
+    expect(lock.controls.integrity.llmReplaySha).toBeUndefined();
+    expect(lock.controls.integrity.fixtureSha).toMatch(/^[0-9a-f]{40}$/);
+    expect(lock.controls.integrity.prDiffsSha).toMatch(/^[0-9a-f]{64}$/);
+
+    // Control dirs: one <pr>.diff per control PR (single-source from the same diff).
+    expect(fs.existsSync(path.join(gate1, 'controls/positive/6.diff'))).toBe(true);
+    expect(fs.existsSync(path.join(gate1, 'controls/negative/7.diff'))).toBe(true);
+    expect(fs.existsSync(path.join(gate1, 'controls/positive/5.diff'))).toBe(false);
+
+    // END-TO-END: the produced lock passes the actual freeze checks unchanged.
+    await assertCorpusCompleteness(lock, lcDir, tmp, safeExec);
+    verifyControlIntegrity(
+      [path.join(tmp, lock.controls.positiveRef), path.join(tmp, lock.controls.negativeRef)],
+      lock.controls.integrity.fixtureSha,
+      tmp,
+      safeExec,
+    );
+
+    // fold-2 digest is correct + re-derivable (content-addressed over canonical pr-diffs).
+    expect(sha256(canonicalStringify(prDiffs))).toBe(lock.controls.integrity.prDiffsSha);
+  });
+
+  it('is byte-deterministic — re-running yields identical fixture bytes', async () => {
+    const { headSha } = makeRepo(lcDir, STANDARD_COMMITS);
+    const manifest = writeSeed(tmp, seedObject(headSha));
+    const files = [
+      'windtunnel.lock.json',
+      'split.json',
+      'pr-diffs.json',
+      'controls/positive/6.diff',
+      'controls/negative/7.diff',
+    ];
+
+    await materializeCommand({ cwd: tmp, lcDir, manifestPath: manifest });
+    const first = files.map((f) => fs.readFileSync(path.join(gate1, f)));
+
+    await materializeCommand({ cwd: tmp, lcDir, manifestPath: manifest });
+    const second = files.map((f) => fs.readFileSync(path.join(gate1, f)));
+
+    files.forEach((f, i) => expect(second[i]!.equals(first[i]!), `${f} drifted`).toBe(true));
+  });
+
+  it('C6 red: tampering a control .diff breaks fixtureSha integrity (fail-loud)', async () => {
+    const { headSha } = makeRepo(lcDir, STANDARD_COMMITS);
+    await materializeCommand({
+      cwd: tmp,
+      lcDir,
+      manifestPath: writeSeed(tmp, seedObject(headSha)),
+    });
+    const lock = WindtunnelLockSchema.parse(readJson(path.join(gate1, 'windtunnel.lock.json')));
+    const controlDirs = [
+      path.join(tmp, lock.controls.positiveRef),
+      path.join(tmp, lock.controls.negativeRef),
+    ];
+
+    // baseline passes
+    verifyControlIntegrity(controlDirs, lock.controls.integrity.fixtureSha, tmp, safeExec);
+    // tamper one byte
+    fs.appendFileSync(path.join(gate1, 'controls/positive/6.diff'), '\n// tampered\n');
+    expect(() =>
+      verifyControlIntegrity(controlDirs, lock.controls.integrity.fixtureSha, tmp, safeExec),
+    ).toThrow(/control fixtures changed|integrity/i);
+  });
+
+  it('fold-2 red: tampering a pr-diffs row breaks the prDiffsSha digest', async () => {
+    const { headSha } = makeRepo(lcDir, STANDARD_COMMITS);
+    await materializeCommand({
+      cwd: tmp,
+      lcDir,
+      manifestPath: writeSeed(tmp, seedObject(headSha)),
+    });
+    const lock = WindtunnelLockSchema.parse(readJson(path.join(gate1, 'windtunnel.lock.json')));
+    const prDiffs = readJson(path.join(gate1, 'pr-diffs.json')) as Array<Record<string, unknown>>;
+
+    // a clean re-derive matches the stored digest...
+    expect(sha256(canonicalStringify(prDiffs))).toBe(lock.controls.integrity.prDiffsSha);
+    // ...a tampered control row does NOT (the hole fixtureSha alone leaves open).
+    const tampered = prDiffs.map((d) =>
+      d.pr === 7 ? { ...d, diff: `${d.diff as string}// x` } : d,
+    );
+    expect(sha256(canonicalStringify(tampered))).not.toBe(lock.controls.integrity.prDiffsSha);
+  });
+
+  it('fails loud on a malformed `(#abc)` merge subject (no silent shrink)', async () => {
+    const { headSha } = makeRepo(lcDir, [
+      { subject: 'chore: init', files: { 'base.txt': 'x\n' } },
+      { subject: 'feat: a (#1)', files: { 'packages/core/src/a.ts': 'export const a = 1;\n' } },
+      { subject: 'feat: bad (#abc)', files: { 'packages/core/src/b.ts': 'export const b = 2;\n' } },
+    ]);
+    await expect(
+      materializeCommand({ cwd: tmp, lcDir, manifestPath: writeSeed(tmp, seedObject(headSha)) }),
+    ).rejects.toThrow();
+  });
+
+  it('excludes a revert pair from the corpus (selectionRule reuse)', async () => {
+    const { headSha } = makeRepo(lcDir, [
+      { subject: 'chore: init', files: { 'base.txt': 'x\n' } },
+      { subject: 'feat: a (#1)', files: { 'packages/core/src/a.ts': 'export const a = 1;\n' } },
+      { subject: 'feat: b (#2)', files: { 'packages/core/src/b.ts': 'export const b = 2;\n' } },
+      {
+        subject: 'revert: b (#3)',
+        files: { 'packages/core/src/b.ts': 'export const b = 2; // reverted\n' },
+        body: (shas) => `This reverts commit ${shas[2]}.`, // shas[2] = #2
+      },
+      { subject: 'feat: d (#4)', files: { 'packages/core/src/d.ts': 'export const d = 4;\n' } },
+      { subject: 'feat: e (#5)', files: { 'packages/core/src/e.ts': 'export const e = 5;\n' } },
+    ]);
+    const seed = seedObject(headSha, {
+      split: { cutIndex: 1, excludedPrs: [] },
+      controls: {
+        positiveRef: '.totem/spine/gate-1/controls/positive',
+        negativeRef: '.totem/spine/gate-1/controls/negative',
+        mechanism: 'git-hash-object',
+        positive: [{ pr: 4, targetRuleId: 'rule-y' }],
+        negative: [5],
+      },
+    });
+    await materializeCommand({ cwd: tmp, lcDir, manifestPath: writeSeed(tmp, seed) });
+
+    const lock = WindtunnelLockSchema.parse(readJson(path.join(gate1, 'windtunnel.lock.json')));
+    // #2 (reverted target) + #3 (the revert) both dropped.
+    expect(lock.corpus.resolvedPrs.map((p) => p.pr)).toEqual([1, 4, 5]);
+  });
+});

--- a/packages/cli/src/commands/spine-cert-materialize.ts
+++ b/packages/cli/src/commands/spine-cert-materialize.ts
@@ -29,9 +29,10 @@ function gitText(args: string[], cwd: string, safeExec: SafeExecFn, what: string
   try {
     return safeExec('git', args, { cwd }).replace(/\r\n/g, '\n');
   } catch (err) {
-    throw new Error(
-      `cert-corpus materialize: git ${what} failed in ${cwd} — ${err instanceof Error ? err.message : String(err)}`,
-    );
+    // §9: original as `cause`, never concatenate `err.message`. Stays a plain Error
+    // (like the shipped `enumeratePrMetas`) — wrapped into a TotemError at the
+    // command boundary, which carries this through the cause chain.
+    throw new Error(`cert-corpus materialize: git ${what} failed in ${cwd}`, { cause: err });
   }
 }
 
@@ -167,26 +168,20 @@ export async function materializeCommand(opts: MaterializeOptions): Promise<void
       isBotIdentity,
     });
   } catch (err) {
+    // §9: pass the original as `cause`, never concatenate `err.message` (the debug
+    // logger surfaces the cause chain). The hint points there for the specifics.
     throw new TotemError(
       'CONFIG_INVALID',
-      `cert-corpus materialize: PR enumeration failed off ${lcDir} — ${err instanceof Error ? err.message : String(err)}`,
-      'Verify --lc-dir is an lc clone whose history includes asOfCommit and the merge subjects are well-formed.',
+      `cert-corpus materialize: PR enumeration failed off ${lcDir}`,
+      'Verify --lc-dir is an lc clone whose history includes asOfCommit and the merge subjects are well-formed (TOTEM_DEBUG=1 surfaces the underlying fault).',
       err,
     );
   }
-  let derived;
-  try {
-    derived = deriveCorpus({ seed, metas });
-  } catch (err) {
-    // CertCorpusSeedError / SplitCoverError — already structured fail-loud.
-    throw new TotemError(
-      'CONFIG_INVALID',
-      `cert-corpus materialize: ${err instanceof Error ? err.message : String(err)}`,
-      'Fix the seed (controls / cutIndex / excludedPrs) and retry.',
-      err,
-    );
-  }
-  const { corpus, split, prDiffRoles } = derived;
+  // deriveCorpus throws CertCorpusSeedError / SplitCoverError — already structured,
+  // user-facing fail-loud errors; let them propagate verbatim (§9: don't re-wrap +
+  // concatenate err.message, which would bury the specific reason behind a
+  // debug-only cause).
+  const { corpus, split, prDiffRoles } = deriveCorpus({ seed, metas });
 
   // 3. Resolve git base/head/diff for EVERY corpus PR (fail-loud; validates non-empty).
   const mergeByPr = new Map(metas.map((m) => [m.pr, m.mergeCommit]));
@@ -196,10 +191,11 @@ export async function materializeCommand(opts: MaterializeOptions): Promise<void
       gitByPr.set(pr, resolvePrGit(lcDir, mergeByPr.get(pr)!, safeExec));
     }
   } catch (err) {
+    // §9: original as `cause`, no `err.message` concatenation.
     throw new TotemError(
       'CONFIG_INVALID',
-      `cert-corpus materialize: ${err instanceof Error ? err.message : String(err)}`,
-      'Verify the lc clone is complete at asOfCommit (all corpus merge commits + parents present).',
+      'cert-corpus materialize: git resolution failed for one or more corpus PRs',
+      'Verify the lc clone is complete at asOfCommit (all corpus merge commits + parents present); TOTEM_DEBUG=1 surfaces the underlying git fault.',
       err,
     );
   }

--- a/packages/cli/src/commands/spine-cert-materialize.ts
+++ b/packages/cli/src/commands/spine-cert-materialize.ts
@@ -1,0 +1,257 @@
+// ─── #709 cert-corpus materialization producer — CLI (git I/O + writers) ─────
+//
+// `totem spine windtunnel materialize --lc-dir <p> --manifest <seed.json>` turns a
+// curated seed manifest + the lc clone into the 4 unproduced cert-run scoring
+// fixtures (the lock, split.json, pr-diffs.json, the positive/negative control
+// dirs) so `loadCertRunFixtures` stops throwing. The PURE derivation + lock
+// assembly live in core (`deriveCorpus` / `buildWindtunnelLock`); this module is
+// the git I/O + the writers (panel OQ2 — CLI = I/O driver only).
+//
+// Fold-3 (codex panel): the producer-owned git helpers are FAIL-LOUD — unlike the
+// advisory `git.ts` helpers (which swallow errors → ''/[]), a git fault here
+// throws, and an empty diff for a code-touching corpus PR is rejected (a wrong
+// ref must never become a silently-empty frozen fixture).
+
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import type { ResolvedPrInput } from '@mmnto/totem';
+
+import { computeFixtureSha, enumeratePrMetas } from './spine-windtunnel.js';
+
+type SafeExecFn = typeof import('@mmnto/totem').safeExec;
+
+const sha256Hex = (s: string): string => createHash('sha256').update(s, 'utf-8').digest('hex');
+
+/** Run git FAIL-LOUD (Tenet 4) — no swallowing to ''/[] like the advisory git.ts helpers (fold-3). */
+function gitText(args: string[], cwd: string, safeExec: SafeExecFn, what: string): string {
+  try {
+    return safeExec('git', args, { cwd }).replace(/\r\n/g, '\n');
+  } catch (err) {
+    throw new Error(
+      `cert-corpus materialize: git ${what} failed in ${cwd} — ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+interface PrGitResolution {
+  baseSha: string;
+  headSha: string;
+  diff: string;
+}
+
+/**
+ * Resolve a squash-merged PR's base/head/diff off the lc clone (fail-loud).
+ * head = the squash merge commit (already a 40-hex SHA from `enumeratePrMetas`);
+ * base = its first parent; diff = base..head. Rejects an empty diff — every
+ * corpus PR is code-touching by construction, so an empty diff means a wrong ref
+ * or a silent git fault, not a real no-op (fold-3 no-silent-empty).
+ */
+function resolvePrGit(lcDir: string, mergeCommit: string, safeExec: SafeExecFn): PrGitResolution {
+  const headSha = mergeCommit;
+  const baseSha = gitText(
+    ['rev-parse', '--verify', '--end-of-options', `${mergeCommit}^`],
+    lcDir,
+    safeExec,
+    `rev-parse parent of ${mergeCommit}`,
+  ).trim();
+  const diff = gitText(
+    ['diff', '--no-color', '--no-ext-diff', '--end-of-options', baseSha, headSha],
+    lcDir,
+    safeExec,
+    `diff ${baseSha}..${headSha}`,
+  );
+  if (diff.trim().length === 0) {
+    throw new Error(
+      `cert-corpus materialize: PR merge ${mergeCommit} produced an EMPTY diff (${baseSha}..${headSha}) — ` +
+        `a code-touching corpus PR must have a non-empty diff (fold-3 no-silent-empty).`,
+    );
+  }
+  return { baseSha, headSha, diff };
+}
+
+export interface MaterializeOptions {
+  lcDir?: string;
+  manifestPath: string;
+  /** Override the gate-1 output dir (default: dirname of the seed's canonicalPath, under the repo root). */
+  outDir?: string;
+  /** Working dir the repo root + manifest path resolve from (default: `process.cwd()`; injected for tests). */
+  cwd?: string;
+}
+
+/**
+ * Materialize the cert-run scoring corpus (the producer slice of strategy#709).
+ * Two-phase lock: this writes the lock WITHOUT `llmReplaySha` (the producer can't
+ * know it — `record` runs after); `freeze` stamps + seals it (panel OQ-seq).
+ */
+export async function materializeCommand(opts: MaterializeOptions): Promise<void> {
+  const {
+    safeExec,
+    resolveGitRoot,
+    TotemError,
+    CertCorpusSeedSchema,
+    deriveCorpus,
+    buildWindtunnelLock,
+    canonicalStringify,
+    parsePrNumber,
+    parseRevertSha,
+    isBotIdentity,
+  } = await import('@mmnto/totem');
+
+  const cwd = opts.cwd ?? process.cwd();
+  const repoRoot = resolveGitRoot(cwd) ?? cwd;
+  const lcDir = opts.lcDir ?? process.env['TOTEM_LC_DIR'];
+  if (!lcDir) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      'cert-corpus materialize requires the lc clone (--lc-dir or TOTEM_LC_DIR).',
+      'Pass --lc-dir <path-to-liquid-city-clone> whose history includes the seed asOfCommit.',
+    );
+  }
+
+  // 1. Load + validate the curated seed manifest.
+  let seedRaw: unknown;
+  try {
+    seedRaw = JSON.parse(fs.readFileSync(path.resolve(cwd, opts.manifestPath), 'utf-8'));
+  } catch (err) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `cert-corpus materialize: cannot read/parse the seed manifest at ${opts.manifestPath}`,
+      'Provide a valid JSON seed manifest (see CertCorpusSeedSchema).',
+      err,
+    );
+  }
+  const seedParse = CertCorpusSeedSchema.safeParse(seedRaw);
+  if (!seedParse.success) {
+    const issues = seedParse.error.issues
+      .map((i) => `  • ${i.path.join('.')}: ${i.message}`)
+      .join('\n');
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `cert-corpus materialize: seed manifest invalid:\n${issues}`,
+      'Fix the seed manifest and retry.',
+    );
+  }
+  const seed = seedParse.data;
+
+  // 2. Enumerate PRs off the clone, then derive (pure) — corpus + split + roles.
+  let metas;
+  try {
+    metas = enumeratePrMetas(seed.selectionRule.asOfCommit, lcDir, safeExec, {
+      parsePrNumber,
+      parseRevertSha,
+      isBotIdentity,
+    });
+  } catch (err) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `cert-corpus materialize: PR enumeration failed off ${lcDir} — ${err instanceof Error ? err.message : String(err)}`,
+      'Verify --lc-dir is an lc clone whose history includes asOfCommit and the merge subjects are well-formed.',
+      err,
+    );
+  }
+  let derived;
+  try {
+    derived = deriveCorpus({ seed, metas });
+  } catch (err) {
+    // CertCorpusSeedError / SplitCoverError — already structured fail-loud.
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `cert-corpus materialize: ${err instanceof Error ? err.message : String(err)}`,
+      'Fix the seed (controls / cutIndex / excludedPrs) and retry.',
+      err,
+    );
+  }
+  const { corpus, split, prDiffRoles } = derived;
+
+  // 3. Resolve git base/head/diff for EVERY corpus PR (fail-loud; validates non-empty).
+  const mergeByPr = new Map(metas.map((m) => [m.pr, m.mergeCommit]));
+  const gitByPr = new Map<number, PrGitResolution>();
+  try {
+    for (const pr of corpus) {
+      gitByPr.set(pr, resolvePrGit(lcDir, mergeByPr.get(pr)!, safeExec));
+    }
+  } catch (err) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `cert-corpus materialize: ${err instanceof Error ? err.message : String(err)}`,
+      'Verify the lc clone is complete at asOfCommit (all corpus merge commits + parents present).',
+      err,
+    );
+  }
+
+  const resolvedPrs: ResolvedPrInput[] = corpus.map((pr) => {
+    const g = gitByPr.get(pr)!;
+    return { pr, mergeCommit: mergeByPr.get(pr)!, baseSha: g.baseSha, headSha: g.headSha };
+  });
+
+  // 4. pr-diffs = the held-out (scored) slice; strict roles from core (targetRuleId iff positive).
+  const prDiffs = prDiffRoles.map((role) => {
+    const diff = gitByPr.get(role.pr)!.diff;
+    return role.targetRuleId
+      ? { pr: role.pr, diff, controlKind: role.controlKind, targetRuleId: role.targetRuleId }
+      : { pr: role.pr, diff, controlKind: role.controlKind };
+  });
+
+  // 5. Write split.json + pr-diffs.json (canonical, sorted-key, LF + trailing newline).
+  const gate1Dir = opts.outDir
+    ? path.resolve(cwd, opts.outDir)
+    : path.join(repoRoot, path.dirname(seed.canonicalPath));
+  fs.mkdirSync(gate1Dir, { recursive: true });
+
+  const writeCanonical = (file: string, value: unknown): void => {
+    fs.writeFileSync(file, `${canonicalStringify(value, 2)}\n`, 'utf-8');
+  };
+  writeCanonical(path.join(gate1Dir, 'split.json'), split);
+  writeCanonical(path.join(gate1Dir, 'pr-diffs.json'), prDiffs);
+
+  // fold-2: content-addressed digest over the canonical pr-diffs (the SCORING source
+  // `loadCertRunFixtures` reads independently of the control dirs). freeze/run
+  // re-derives + asserts this; closes the hole `fixtureSha` (control-dirs-only) leaves.
+  const prDiffsSha = sha256Hex(canonicalStringify(prDiffs));
+
+  // 6. Control dirs — one `<pr>.diff` per control PR, derived from the SAME resolved
+  // diff (single-source, fold-5). Clean first so stale files never pollute fixtureSha.
+  const posDir = path.join(repoRoot, seed.controls.positiveRef);
+  const negDir = path.join(repoRoot, seed.controls.negativeRef);
+  for (const dir of [posDir, negDir]) {
+    fs.rmSync(dir, { recursive: true, force: true });
+    fs.mkdirSync(dir, { recursive: true });
+  }
+  for (const role of prDiffRoles) {
+    if (role.controlKind === 'corpus') continue;
+    const dir = role.controlKind === 'positive' ? posDir : negDir;
+    fs.writeFileSync(path.join(dir, `${role.pr}.diff`), gitByPr.get(role.pr)!.diff, 'utf-8');
+  }
+
+  const fixtureSha = computeFixtureSha([posDir, negDir], repoRoot, safeExec);
+  if (!fixtureSha) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      'cert-corpus materialize: the seed declares no positive/negative controls, so there is nothing ' +
+        'for the §5 integrity gate (fixtureSha) to hash.',
+      'Add at least one positive and/or negative control to the seed (non-vacuity).',
+    );
+  }
+
+  // 7. Assemble + write the lock (two-phase: no llmReplaySha — freeze seals it post-record).
+  const lock = buildWindtunnelLock({ seed, resolvedPrs, integrity: { fixtureSha, prDiffsSha } });
+  writeCanonical(path.join(gate1Dir, path.basename(seed.canonicalPath)), lock);
+
+  console.error(`[CertCorpusMaterialize] gate1Dir: ${gate1Dir}`);
+  console.error(
+    `  corpus: ${corpus.length} PR(s) · train: ${split.trainPrs.length} · held-out (scored): ${split.heldOutPrs.length}`,
+  );
+  console.error(
+    `  controls: ${split.positiveControlPrs.length} positive · ${split.negativeControlPrs.length} negative`,
+  );
+  console.error(`  fixtureSha:  ${fixtureSha}`);
+  console.error(`  prDiffsSha:  ${prDiffsSha}`);
+  console.error(
+    `  llmReplaySha: (pending — run \`spine windtunnel record\` then \`freeze\` to seal)`,
+  );
+  console.error(
+    `  Wrote split.json, pr-diffs.json, ${path.basename(seed.canonicalPath)} + control dirs.`,
+  );
+}

--- a/packages/cli/src/commands/spine-cert-materialize.ts
+++ b/packages/cli/src/commands/spine-cert-materialize.ts
@@ -48,7 +48,11 @@ interface PrGitResolution {
  * corpus PR is code-touching by construction, so an empty diff means a wrong ref
  * or a silent git fault, not a real no-op (fold-3 no-silent-empty).
  */
-function resolvePrGit(lcDir: string, mergeCommit: string, safeExec: SafeExecFn): PrGitResolution {
+export function resolvePrGit(
+  lcDir: string,
+  mergeCommit: string,
+  safeExec: SafeExecFn,
+): PrGitResolution {
   const headSha = mergeCommit;
   const baseSha = gitText(
     ['rev-parse', '--verify', '--end-of-options', `${mergeCommit}^`],
@@ -109,6 +113,25 @@ export async function materializeCommand(opts: MaterializeOptions): Promise<void
       'Pass --lc-dir <path-to-liquid-city-clone> whose history includes the seed asOfCommit.',
     );
   }
+
+  // Constrain every seed-derived write/delete target to within `repoRoot` (CR
+  // panel 🔴): the producer mkdir/writes the gate-1 dir and RECURSIVELY deletes
+  // the control dirs, so an absolute or `../` ref in the seed (or a typo) could
+  // escape the workspace. `path.resolve` collapses `..` and lets an absolute ref
+  // ignore `repoRoot`; a `..`-leading or absolute relative path — or repoRoot
+  // itself — is refused fail-loud (no write/delete outside, never ON, the root).
+  const resolveWithinRepo = (input: string, field: string): string => {
+    const abs = path.resolve(repoRoot, input);
+    const rel = path.relative(repoRoot, abs);
+    if (rel === '' || rel.startsWith('..') || path.isAbsolute(rel)) {
+      throw new TotemError(
+        'CONFIG_INVALID',
+        `cert-corpus materialize: ${field} ("${input}") resolves outside (or onto) the repo root — refusing to write/delete there.`,
+        `Provide a repo-relative ${field} nested under ${repoRoot}.`,
+      );
+    }
+    return abs;
+  };
 
   // 1. Load + validate the curated seed manifest.
   let seedRaw: unknown;
@@ -197,26 +220,37 @@ export async function materializeCommand(opts: MaterializeOptions): Promise<void
   // 5. Write split.json + pr-diffs.json (canonical, sorted-key, LF + trailing newline).
   const gate1Dir = opts.outDir
     ? path.resolve(cwd, opts.outDir)
-    : path.join(repoRoot, path.dirname(seed.canonicalPath));
+    : resolveWithinRepo(path.dirname(seed.canonicalPath), 'seed.canonicalPath directory');
   fs.mkdirSync(gate1Dir, { recursive: true });
 
-  const writeCanonical = (file: string, value: unknown): void => {
-    fs.writeFileSync(file, `${canonicalStringify(value, 2)}\n`, 'utf-8');
+  // Atomic write (GCA panel): serialize to a temp file then rename, so a reader / CI
+  // gate never observes a partially-written manifest. Returns the exact bytes written,
+  // so an integrity digest can be taken over the on-disk content, not a re-derived
+  // form that could drift from it.
+  const writeCanonical = (file: string, value: unknown): string => {
+    const text = `${canonicalStringify(value, 2)}\n`;
+    const tmp = `${file}.tmp`;
+    fs.writeFileSync(tmp, text, 'utf-8');
+    fs.renameSync(tmp, file);
+    return text;
   };
   writeCanonical(path.join(gate1Dir, 'split.json'), split);
-  writeCanonical(path.join(gate1Dir, 'pr-diffs.json'), prDiffs);
+  const prDiffsText = writeCanonical(path.join(gate1Dir, 'pr-diffs.json'), prDiffs);
 
-  // fold-2: content-addressed digest over the canonical pr-diffs (the SCORING source
-  // `loadCertRunFixtures` reads independently of the control dirs). The producer
-  // STAMPS it here; freeze/run will re-derive + assert it to close the hole
-  // `fixtureSha` (control-dirs-only) leaves — that enforcement is the follow-up
-  // slice (#2225), not yet wired, so the digest is stamped-but-not-yet-authoritative.
-  const prDiffsSha = sha256Hex(canonicalStringify(prDiffs));
+  // fold-2: integrity digest over the EXACT on-disk `pr-diffs.json` bytes (indented +
+  // trailing newline, as written above) — the SCORING source `loadCertRunFixtures`
+  // reads independently of the control dirs. Hashing the on-disk bytes (not the
+  // compact `canonicalStringify`) lets a freeze/run enforcer `sha256` the file
+  // directly, tool-agnostically (greptile/GCA panel). The producer STAMPS it here;
+  // freeze/run will re-derive + assert it to close the hole `fixtureSha`
+  // (control-dirs-only) leaves — that enforcement is the follow-up slice (#2225),
+  // not yet wired, so the digest is stamped-but-not-yet-authoritative.
+  const prDiffsSha = sha256Hex(prDiffsText);
 
   // 6. Control dirs — one `<pr>.diff` per control PR, derived from the SAME resolved
   // diff (single-source, fold-5). Clean first so stale files never pollute fixtureSha.
-  const posDir = path.join(repoRoot, seed.controls.positiveRef);
-  const negDir = path.join(repoRoot, seed.controls.negativeRef);
+  const posDir = resolveWithinRepo(seed.controls.positiveRef, 'seed.controls.positiveRef');
+  const negDir = resolveWithinRepo(seed.controls.negativeRef, 'seed.controls.negativeRef');
   for (const dir of [posDir, negDir]) {
     fs.rmSync(dir, { recursive: true, force: true });
     fs.mkdirSync(dir, { recursive: true });

--- a/packages/cli/src/commands/spine-cert-materialize.ts
+++ b/packages/cli/src/commands/spine-cert-materialize.ts
@@ -207,8 +207,10 @@ export async function materializeCommand(opts: MaterializeOptions): Promise<void
   writeCanonical(path.join(gate1Dir, 'pr-diffs.json'), prDiffs);
 
   // fold-2: content-addressed digest over the canonical pr-diffs (the SCORING source
-  // `loadCertRunFixtures` reads independently of the control dirs). freeze/run
-  // re-derives + asserts this; closes the hole `fixtureSha` (control-dirs-only) leaves.
+  // `loadCertRunFixtures` reads independently of the control dirs). The producer
+  // STAMPS it here; freeze/run will re-derive + assert it to close the hole
+  // `fixtureSha` (control-dirs-only) leaves — that enforcement is the follow-up
+  // slice (#2225), not yet wired, so the digest is stamped-but-not-yet-authoritative.
   const prDiffsSha = sha256Hex(canonicalStringify(prDiffs));
 
   // 6. Control dirs — one `<pr>.diff` per control PR, derived from the SAME resolved

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1876,6 +1876,35 @@ windtunnelCmd
     },
   );
 
+windtunnelCmd
+  .command('materialize')
+  .description(
+    'Materialize the cert-run scoring corpus (lock + split + pr-diffs + control dirs) from a seed manifest + lc clone (strategy#709)',
+  )
+  .requiredOption('--manifest <path>', 'Path to the curated cert-corpus seed manifest (JSON)')
+  .option(
+    '--lc-dir <path>',
+    'Path to the lc clone (env: TOTEM_LC_DIR)',
+    process.env['TOTEM_LC_DIR'],
+  )
+  .option(
+    '--out <dir>',
+    'Override the gate-1 output dir (default: dirname of the seed canonicalPath, under the repo root)',
+  )
+  .action(async (opts: { manifest: string; lcDir?: string; out?: string }) => {
+    try {
+      const { materializeCommand } = await import('./commands/spine-cert-materialize.js');
+      await materializeCommand({
+        manifestPath: opts.manifest,
+        lcDir: opts.lcDir,
+        outDir: opts.out,
+      });
+    } catch (err) {
+      handleError(err);
+      throw err;
+    }
+  });
+
 // Fire-and-forget: reap orphaned temp files from previous crashed runs
 reapOrphanedTempFiles(process.cwd(), '.totem').catch(() => {});
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -790,6 +790,20 @@ export { CandidateRuleRecordSchema, ClassifierDispositionSchema } from './spine/
 // it off the public barrel avoids inviting CLI-layer coupling to an ephemeral
 // type (greptile #2202). It stays reachable structurally via `ExtractStageResult`.
 export type {
+  CertCorpusSeed,
+  DerivedCorpus,
+  LockIntegrityInput,
+  PrControlKind,
+  PrDiffRole,
+  ResolvedPrInput,
+} from './spine/cert-corpus-seed.js';
+export {
+  buildWindtunnelLock,
+  CertCorpusSeedError,
+  CertCorpusSeedSchema,
+  deriveCorpus,
+} from './spine/cert-corpus-seed.js';
+export type {
   ClassifierResult,
   ClassifyStageDeps,
   ClassifyStageResult,

--- a/packages/core/src/spine/cert-corpus-seed.test.ts
+++ b/packages/core/src/spine/cert-corpus-seed.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildWindtunnelLock,
+  type CertCorpusSeed,
+  CertCorpusSeedError,
+  CertCorpusSeedSchema,
+  deriveCorpus,
+} from './cert-corpus-seed.js';
+import type { PrMeta } from './selection-rule.js';
+
+const sha = (n: number): string => String(n).padStart(40, '0');
+const sha256 = (s: string): string => s.padStart(64, '0');
+
+/** Newest-first (git --topo-order) PrMeta, all code-touching non-bot by default. */
+function meta(pr: number, overrides?: Partial<PrMeta>): PrMeta {
+  return {
+    pr,
+    mergeCommit: sha(pr),
+    author: 'Dev <dev@example.com>',
+    isBotAuthor: false,
+    changedFiles: ['packages/core/src/x.ts'],
+    ...overrides,
+  };
+}
+
+/** PRs 5,4,3,2,1 newest-first → corpus [1..5]. */
+const METAS: PrMeta[] = [meta(5), meta(4), meta(3), meta(2), meta(1)];
+
+function seed(overrides?: Partial<CertCorpusSeed>): CertCorpusSeed {
+  return CertCorpusSeedSchema.parse({
+    gate: 'gate-1',
+    canonicalPath: '.totem/spine/gate-1/windtunnel.lock.json',
+    repo: 'mmnto-ai/liquid-city',
+    phase: 'certifying',
+    selectionRule: {
+      state: 'merged',
+      predicate: 'code-touching non-bot non-revert',
+      window: { type: 'all' },
+      asOfCommit: sha(999),
+      codePathClassifier: { includeGlobs: ['packages/**'], excludeGlobs: ['**/*.md'] },
+    },
+    split: { cutIndex: 2, excludedPrs: [] },
+    controls: {
+      positiveRef: '.totem/spine/gate-1/controls/positive',
+      negativeRef: '.totem/spine/gate-1/controls/negative',
+      mechanism: 'git-hash-object',
+      positive: [{ pr: 3, targetRuleId: 'rule-abc' }],
+      negative: [4],
+    },
+    fpDefinition: { rubricRef: 'r', groundTruthRef: 'g', adjudicator: 'disposition-derived' },
+    cullRateThreshold: 0.1,
+    exposureDenominator: {
+      activeRulesEvaluated: { floor: 2 },
+      filesTouchedInWindow: { floor: 0 },
+      positiveControlsExercised: { floor: 1 },
+    },
+    ...overrides,
+  });
+}
+
+describe('deriveCorpus', () => {
+  it('derives corpus, ancestry-cut split, and held-out control roles', () => {
+    const { corpus, split, prDiffRoles } = deriveCorpus({ seed: seed(), metas: METAS });
+
+    expect(corpus).toEqual([1, 2, 3, 4, 5]);
+    // cutIndex 2 → oldest 2 PRs train, remainder held-out.
+    expect(split.trainPrs).toEqual([1, 2]);
+    expect(split.heldOutPrs).toEqual([3, 4, 5]);
+    expect(split.positiveControlPrs).toEqual([3]);
+    expect(split.negativeControlPrs).toEqual([4]);
+
+    // pr-diffs covers ONLY the held-out (scored) slice, controls tagged within it.
+    expect(prDiffRoles).toEqual([
+      { pr: 3, controlKind: 'positive', targetRuleId: 'rule-abc' },
+      { pr: 4, controlKind: 'negative' },
+      { pr: 5, controlKind: 'corpus' },
+    ]);
+  });
+
+  it('excludes bot + revert PRs from the corpus (selectionRule reuse)', () => {
+    const metas: PrMeta[] = [
+      meta(5),
+      meta(4, { isBotAuthor: true }),
+      meta(3, { revertsSha: sha(2) }), // revert of #2's merge commit
+      meta(2),
+      meta(1),
+    ];
+    const { corpus, split } = deriveCorpus({
+      // corpus shrinks to [1, 5] → cutIndex 1 keeps a non-empty train + held-out.
+      seed: seed({
+        split: { cutIndex: 1, excludedPrs: [] },
+        controls: { ...seed().controls, positive: [], negative: [] },
+      }),
+      metas,
+    });
+    // #4 (bot) dropped; #3 (revert) + #2 (its target) dropped as a pair.
+    expect(corpus).toEqual([1, 5]);
+    expect(split.trainPrs).toEqual([1]);
+    expect(split.heldOutPrs).toEqual([5]);
+  });
+
+  it('throws (Amendment-C) when a control PR is not a corpus member', () => {
+    const s = seed({
+      controls: { ...seed().controls, positive: [{ pr: 999, targetRuleId: 'r' }], negative: [4] },
+    });
+    expect(() => deriveCorpus({ seed: s, metas: METAS })).toThrow(CertCorpusSeedError);
+    expect(() => deriveCorpus({ seed: s, metas: METAS })).toThrow(/not in the resolved corpus/);
+  });
+
+  it('throws on an empty corpus (no qualifying code-touching PRs)', () => {
+    const docsOnly: PrMeta[] = [meta(1, { changedFiles: ['README.md'] })];
+    expect(() => deriveCorpus({ seed: seed(), metas: docsOnly })).toThrow(/EMPTY corpus/);
+  });
+});
+
+describe('CertCorpusSeedSchema (strict write-side, fold-1 / fold-4)', () => {
+  it('rejects a positive control with no targetRuleId', () => {
+    expect(() =>
+      seed({
+        controls: {
+          ...seed().controls,
+          // @ts-expect-error — exercising the runtime guard
+          positive: [{ pr: 3 }],
+        },
+      }),
+    ).toThrow();
+  });
+
+  it('rejects a PR tagged both positive and negative', () => {
+    expect(() =>
+      seed({
+        controls: { ...seed().controls, positive: [{ pr: 3, targetRuleId: 'r' }], negative: [3] },
+      }),
+    ).toThrow(/BOTH positive and negative/);
+  });
+});
+
+describe('buildWindtunnelLock', () => {
+  const resolvedPrs = [1, 2, 3, 4, 5].map((pr) => ({
+    pr,
+    mergeCommit: sha(pr),
+    baseSha: sha(pr + 100),
+    headSha: sha(pr + 200),
+  }));
+
+  it('assembles a schema-valid lock; sorts resolvedPrs; omits llmReplaySha (two-phase)', () => {
+    const lock = buildWindtunnelLock({
+      seed: seed(),
+      resolvedPrs: [...resolvedPrs].reverse(), // unsorted input
+      integrity: { fixtureSha: sha(7), prDiffsSha: sha256('abc') },
+    });
+    expect(lock.corpus.resolvedPrs.map((p) => p.pr)).toEqual([1, 2, 3, 4, 5]);
+    expect(lock.controls.integrity.fixtureSha).toBe(sha(7));
+    expect(lock.controls.integrity.prDiffsSha).toBe(sha256('abc'));
+    expect(lock.controls.integrity.llmReplaySha).toBeUndefined();
+    expect(lock.fpDefinition.precisionFloor).toBe(1.0);
+  });
+
+  it('stamps llmReplaySha when supplied (the sealed phase)', () => {
+    const lock = buildWindtunnelLock({
+      seed: seed(),
+      resolvedPrs,
+      integrity: { fixtureSha: sha(7), prDiffsSha: sha256('abc'), llmReplaySha: sha256('def') },
+    });
+    expect(lock.controls.integrity.llmReplaySha).toBe(sha256('def'));
+  });
+
+  it('fails loud on a malformed integrity sha', () => {
+    expect(() =>
+      buildWindtunnelLock({
+        seed: seed(),
+        resolvedPrs,
+        integrity: { fixtureSha: 'not-a-sha', prDiffsSha: sha256('abc') },
+      }),
+    ).toThrow();
+  });
+});

--- a/packages/core/src/spine/cert-corpus-seed.ts
+++ b/packages/core/src/spine/cert-corpus-seed.ts
@@ -1,0 +1,301 @@
+// ─── #709 Gate-1 cert-corpus materialization — seed manifest + pure producer ──
+//
+// The cert run's SCORING corpus (`split.json`, `pr-diffs.json`, the control dirs,
+// and the lock that pins them) has no producer today — `loadCertRunFixtures`
+// hard-requires them but only `record` (the minted-rules half) writes anything.
+// This module is the PURE half of the producer (panel-ratified, strategy#709):
+// it turns a small CURATED seed manifest + the git-enumerated `PrMeta[]` into the
+// derived corpus + a validated frozen split + the per-held-out-PR control roles,
+// and assembles the windtunnel lock once the I/O-derived integrity shas are known.
+//
+// Boundary (panel OQ1/OQ2): the SEED carries the irreducible answer-key decisions
+// (asOfCommit, selection predicate/config, cutIndex, control designations +
+// positive `targetRuleId`); EVERYTHING else is derived. All git I/O (enumeration,
+// diff resolution, hashing) lives in the CLI; this module is pure + fully testable
+// without git. Reuses `resolveSelectionRule` (corpus) + `resolveSplit` (the
+// validated ancestry-cut split, with all its fail-loud cover/disjointness guards).
+
+import { z } from 'zod';
+
+import { type PrMeta, resolveSelectionRule, type SelectionRuleConfig } from './selection-rule.js';
+import { mergeCommitMap, resolveSplit, type SplitArtifact } from './split.js';
+import { type WindtunnelLock, WindtunnelLockSchema } from './windtunnel-lock.js';
+
+const COMMIT_SHA_RE = /^[0-9a-f]{40}$/;
+
+// ─── Seed manifest schema (the curated answer-key inputs) ────────────────────
+
+const CodePathClassifierSeedSchema = z.object({
+  includeGlobs: z.array(z.string().min(1)).min(1, 'includeGlobs must list at least one glob'),
+  excludeGlobs: z.array(z.string().min(1)),
+});
+
+/**
+ * Positive controls MUST name the rule expected to fire (fold-1, codex panel):
+ * a positive control with no `targetRuleId` silently weakens the non-vacuity
+ * contract (`buildFirings` only records a positive target when one is present),
+ * so the seed makes it structurally required — the producer never relies on the
+ * permissive consumer `ResolvedPrDiffSchema` (where `targetRuleId` is optional).
+ */
+const PositiveControlSeedSchema = z.object({
+  pr: z.number().int().positive(),
+  targetRuleId: z.string().min(1, 'a positive control must name its targetRuleId'),
+});
+
+export const CertCorpusSeedSchema = z
+  .object({
+    gate: z.string().min(1),
+    canonicalPath: z.string().min(1),
+    repo: z.string().min(1),
+    // The producer materializes the CERTIFYING scoring corpus; the harness phase
+    // has no real corpus to materialize.
+    phase: z.literal('certifying'),
+    selectionRule: z.object({
+      state: z.string(),
+      predicate: z.string().refine((s) => s.trim().length > 0, {
+        message: 'selectionRule.predicate must be a non-empty expression',
+      }),
+      window: z.discriminatedUnion('type', [
+        z.object({ type: z.literal('all') }),
+        z.object({ type: z.literal('bounded'), n: z.number().int().positive() }),
+      ]),
+      asOfCommit: z.string().regex(COMMIT_SHA_RE, 'asOfCommit must be a 40-hex SHA'),
+      codePathClassifier: CodePathClassifierSeedSchema,
+      excludeRevertPairs: z.boolean().default(true),
+      excludeBotPrs: z.boolean().default(true),
+    }),
+    split: z.object({
+      cutIndex: z.number().int().nonnegative(),
+      // The atomic revert pairs to drop from train/held-out (kept in the cover).
+      // Usually empty when `excludeRevertPairs` already culls reverts at selection.
+      excludedPrs: z.array(z.number().int().positive()).default([]),
+    }),
+    controls: z.object({
+      positiveRef: z.string().min(1),
+      negativeRef: z.string().min(1),
+      mechanism: z.string().min(1),
+      positive: z.array(PositiveControlSeedSchema).default([]),
+      negative: z.array(z.number().int().positive()).default([]),
+    }),
+    fpDefinition: z.object({
+      rubricRef: z.string(),
+      groundTruthRef: z.string(),
+      adjudicator: z.string(),
+    }),
+    cullRateThreshold: z.number().min(0).lt(1),
+    exposureDenominator: z.object({
+      activeRulesEvaluated: z.object({ floor: z.number().int().min(2) }),
+      filesTouchedInWindow: z.object({ floor: z.number().int().nonnegative() }),
+      positiveControlsExercised: z.object({ floor: z.number().int().nonnegative() }),
+    }),
+  })
+  .superRefine((seed, ctx) => {
+    // Amendment-C seed-level guard (fold-4): reject a contradictory seed BEFORE
+    // emit, so a producer bug can never "repair" it by silently moving a control.
+    const posPrs = seed.controls.positive.map((p) => p.pr);
+    const negPrs = seed.controls.negative;
+    const posSet = new Set(posPrs);
+    const negSet = new Set(negPrs);
+    if (posSet.size !== posPrs.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'controls.positive contains duplicate PRs',
+        path: ['controls', 'positive'],
+      });
+    }
+    if (negSet.size !== negPrs.length) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'controls.negative contains duplicate PRs',
+        path: ['controls', 'negative'],
+      });
+    }
+    const both = posPrs.filter((pr) => negSet.has(pr));
+    if (both.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `control PRs tagged BOTH positive and negative: [${both.join(', ')}] (a PR cannot be both)`,
+        path: ['controls'],
+      });
+    }
+  });
+
+export type CertCorpusSeed = z.infer<typeof CertCorpusSeedSchema>;
+
+// ─── Derivation output ───────────────────────────────────────────────────────
+
+export type PrControlKind = 'corpus' | 'positive' | 'negative';
+
+/** The control role of one held-out (scored) PR — drives pr-diffs.json + control-dir routing. */
+export interface PrDiffRole {
+  pr: number;
+  controlKind: PrControlKind;
+  /** Present iff `controlKind === 'positive'` (the rule that MUST fire). */
+  targetRuleId?: string;
+}
+
+export interface DerivedCorpus {
+  /** The full corpus = `resolveSelectionRule(metas, config)` = the lock's resolvedPrs PR set. */
+  corpus: number[];
+  /** The validated frozen split (train/held-out/excluded + control tags). */
+  split: SplitArtifact;
+  /**
+   * Per-held-out-PR control roles — the SCORED slice (`pr-diffs.json` covers
+   * held-out, controls are tags within it; mining runs over train, never scored).
+   */
+  prDiffRoles: PrDiffRole[];
+}
+
+/** Fail-loud producer fault (Tenet 4): a contradictory seed never materializes. */
+export class CertCorpusSeedError extends Error {
+  constructor(message: string) {
+    super(`[Totem Error] cert-corpus producer: ${message}`);
+    this.name = 'CertCorpusSeedError';
+  }
+}
+
+/**
+ * Pure derivation: corpus + frozen split + held-out control roles from the seed
+ * and the git-enumerated `PrMeta[]` (newest-first `--topo-order`, as
+ * `enumeratePrMetas` returns). Throws `CertCorpusSeedError` on any contradiction
+ * BEFORE emit (Amendment-C: controls must be corpus members; `resolveSplit` then
+ * enforces controls ⊆ held-out + the disjoint cover). No git, no I/O.
+ */
+export function deriveCorpus(params: { seed: CertCorpusSeed; metas: PrMeta[] }): DerivedCorpus {
+  const { seed, metas } = params;
+
+  const config: SelectionRuleConfig = {
+    codePathClassifier: seed.selectionRule.codePathClassifier,
+    excludeRevertPairs: seed.selectionRule.excludeRevertPairs,
+    excludeBotPrs: seed.selectionRule.excludeBotPrs,
+    window: seed.selectionRule.window,
+  };
+
+  const corpus = resolveSelectionRule(metas, config);
+  if (corpus.length === 0) {
+    throw new CertCorpusSeedError(
+      `selectionRule(${seed.selectionRule.asOfCommit}) resolved an EMPTY corpus — no qualifying ` +
+        `code-touching PRs. Check the codePathClassifier globs and the enumerated history.`,
+    );
+  }
+
+  // Amendment-C (fold-4): every designated control must be a corpus member, else
+  // the answer key references a PR outside the scored universe (non-vacuity).
+  const corpusSet = new Set(corpus);
+  const posPrs = seed.controls.positive.map((p) => p.pr);
+  const negPrs = seed.controls.negative;
+  const outOfCorpus = [...posPrs, ...negPrs].filter((pr) => !corpusSet.has(pr));
+  if (outOfCorpus.length > 0) {
+    throw new CertCorpusSeedError(
+      `control PRs not in the resolved corpus: [${outOfCorpus.join(', ')}] — controls must be ` +
+        `corpus members (Amendment-C / non-vacuity).`,
+    );
+  }
+
+  // resolveSplit needs corpus-covering ancestry order + merge commits; metas
+  // (⊇ corpus) provide both. It fail-loud-validates the cut, excludedPrs ⊆ corpus,
+  // controls ⊆ held-out, and the three-way disjoint cover.
+  const split = resolveSplit({
+    asOfCommit: seed.selectionRule.asOfCommit,
+    corpus,
+    orderedNewestFirst: metas.map((m) => m.pr),
+    excludedPrs: seed.split.excludedPrs,
+    cutIndex: seed.split.cutIndex,
+    positiveControlPrs: posPrs,
+    negativeControlPrs: negPrs,
+    predicate: seed.selectionRule.predicate,
+    mergeCommitByPr: mergeCommitMap(metas),
+  });
+
+  const posSet = new Set(posPrs);
+  const negSet = new Set(negPrs);
+  const targetByPr = new Map(seed.controls.positive.map((p) => [p.pr, p.targetRuleId]));
+  const prDiffRoles: PrDiffRole[] = split.heldOutPrs.map((pr) => {
+    if (posSet.has(pr)) return { pr, controlKind: 'positive', targetRuleId: targetByPr.get(pr)! };
+    if (negSet.has(pr)) return { pr, controlKind: 'negative' };
+    return { pr, controlKind: 'corpus' };
+  });
+
+  return { corpus, split, prDiffRoles };
+}
+
+// ─── Lock assembly (pure; the CLI supplies the I/O-derived integrity shas) ────
+
+/** A resolved corpus PR with the git-derived base/head the lock pins. */
+export interface ResolvedPrInput {
+  pr: number;
+  mergeCommit: string;
+  baseSha: string;
+  headSha: string;
+}
+
+/** The integrity shas the CLI computes off disk after materializing the fixtures. */
+export interface LockIntegrityInput {
+  /** 40-hex `git hash-object` digest over the control dirs (`computeFixtureSha`). */
+  fixtureSha: string;
+  /** 64-hex sha256 over the canonical `pr-diffs.json` (fold-2). */
+  prDiffsSha: string;
+  /** 64-hex sha256 over the frozen `llm-replay.v1` — stamped by `freeze` after `record` (two-phase). */
+  llmReplaySha?: string;
+}
+
+/**
+ * Assemble + validate the windtunnel lock (pure). The producer authors the WHOLE
+ * lock (panel OQ4 — single writer); the I/O-derived integrity shas are passed in.
+ * `llmReplaySha` is OMITTED at producer time and stamped later by `freeze` (the
+ * two-phase sealed lock, panel OQ-seq). Parses through `WindtunnelLockSchema`, so
+ * a malformed assembly (unsorted/duplicate resolvedPrs, bad sha) fails loud here.
+ */
+export function buildWindtunnelLock(params: {
+  seed: CertCorpusSeed;
+  resolvedPrs: ResolvedPrInput[];
+  integrity: LockIntegrityInput;
+}): WindtunnelLock {
+  const { seed, resolvedPrs, integrity } = params;
+  const sortedPrs = [...resolvedPrs].sort((a, b) => a.pr - b.pr);
+
+  const lock = {
+    schema: 'windtunnel.lock.v1' as const,
+    canonicalPath: seed.canonicalPath,
+    gate: seed.gate,
+    phase: seed.phase,
+    corpus: {
+      repo: seed.repo,
+      selectionRule: {
+        state: seed.selectionRule.state,
+        predicate: seed.selectionRule.predicate,
+        window: seed.selectionRule.window,
+        asOfCommit: seed.selectionRule.asOfCommit,
+        codePathClassifier: seed.selectionRule.codePathClassifier,
+        excludeRevertPairs: seed.selectionRule.excludeRevertPairs,
+        excludeBotPrs: seed.selectionRule.excludeBotPrs,
+      },
+      resolvedPrs: sortedPrs.map((p) => ({
+        pr: p.pr,
+        mergeCommit: p.mergeCommit,
+        baseSha: p.baseSha,
+        headSha: p.headSha,
+      })),
+    },
+    fpDefinition: {
+      rubricRef: seed.fpDefinition.rubricRef,
+      groundTruthRef: seed.fpDefinition.groundTruthRef,
+      adjudicator: seed.fpDefinition.adjudicator,
+      precisionFloor: 1.0 as const,
+    },
+    controls: {
+      positiveRef: seed.controls.positiveRef,
+      negativeRef: seed.controls.negativeRef,
+      integrity: {
+        mechanism: seed.controls.mechanism,
+        fixtureSha: integrity.fixtureSha,
+        prDiffsSha: integrity.prDiffsSha,
+        ...(integrity.llmReplaySha ? { llmReplaySha: integrity.llmReplaySha } : {}),
+      },
+    },
+    cullRateThreshold: seed.cullRateThreshold,
+    exposureDenominator: seed.exposureDenominator,
+  };
+
+  return WindtunnelLockSchema.parse(lock);
+}

--- a/packages/core/src/spine/cert-corpus-seed.ts
+++ b/packages/core/src/spine/cert-corpus-seed.ts
@@ -293,7 +293,9 @@ export function buildWindtunnelLock(params: {
         mechanism: seed.controls.mechanism,
         fixtureSha: integrity.fixtureSha,
         prDiffsSha: integrity.prDiffsSha,
-        ...(integrity.llmReplaySha ? { llmReplaySha: integrity.llmReplaySha } : {}),
+        // `!== undefined` (not truthy): an explicit `''` must reach the schema and
+        // fail its 64-hex regex, never be silently dropped (CR panel — fail-loud).
+        ...(integrity.llmReplaySha !== undefined ? { llmReplaySha: integrity.llmReplaySha } : {}),
       },
     },
     cullRateThreshold: seed.cullRateThreshold,

--- a/packages/core/src/spine/cert-corpus-seed.ts
+++ b/packages/core/src/spine/cert-corpus-seed.ts
@@ -23,11 +23,14 @@ import { type WindtunnelLock, WindtunnelLockSchema } from './windtunnel-lock.js'
 
 const COMMIT_SHA_RE = /^[0-9a-f]{40}$/;
 
+/** A required string that rejects whitespace-only values (`.min(1)` alone would admit `"   "`). */
+const nonBlank = (msg?: string): z.ZodString => z.string().trim().min(1, msg);
+
 // ─── Seed manifest schema (the curated answer-key inputs) ────────────────────
 
 const CodePathClassifierSeedSchema = z.object({
-  includeGlobs: z.array(z.string().min(1)).min(1, 'includeGlobs must list at least one glob'),
-  excludeGlobs: z.array(z.string().min(1)),
+  includeGlobs: z.array(nonBlank()).min(1, 'includeGlobs must list at least one glob'),
+  excludeGlobs: z.array(nonBlank()),
 });
 
 /**
@@ -39,14 +42,14 @@ const CodePathClassifierSeedSchema = z.object({
  */
 const PositiveControlSeedSchema = z.object({
   pr: z.number().int().positive(),
-  targetRuleId: z.string().min(1, 'a positive control must name its targetRuleId'),
+  targetRuleId: nonBlank('a positive control must name its targetRuleId'),
 });
 
 export const CertCorpusSeedSchema = z
   .object({
-    gate: z.string().min(1),
-    canonicalPath: z.string().min(1),
-    repo: z.string().min(1),
+    gate: nonBlank(),
+    canonicalPath: nonBlank(),
+    repo: nonBlank(),
     // The producer materializes the CERTIFYING scoring corpus; the harness phase
     // has no real corpus to materialize.
     phase: z.literal('certifying'),
@@ -71,9 +74,9 @@ export const CertCorpusSeedSchema = z
       excludedPrs: z.array(z.number().int().positive()).default([]),
     }),
     controls: z.object({
-      positiveRef: z.string().min(1),
-      negativeRef: z.string().min(1),
-      mechanism: z.string().min(1),
+      positiveRef: nonBlank(),
+      negativeRef: nonBlank(),
+      mechanism: nonBlank(),
       positive: z.array(PositiveControlSeedSchema).default([]),
       negative: z.array(z.number().int().positive()).default([]),
     }),

--- a/packages/core/src/spine/windtunnel-lock.ts
+++ b/packages/core/src/spine/windtunnel-lock.ts
@@ -95,17 +95,20 @@ export const WindtunnelLockSchema = z
           .string()
           .regex(SHA256_REGEX, 'llmReplaySha must be a 64-hex sha256')
           .optional(),
-        // #709 fold-2 (codex panel): an integrity digest over the canonical
-        // `pr-diffs.json` — the SCORING source `loadCertRunFixtures` reads
-        // independently of the control dirs. `fixtureSha` hashes only the
-        // control dirs, so a tampered `corpus`-kind (or any) row in pr-diffs.json
-        // would pass every runtime check. This sha256 (64-hex, over the canonical
-        // serialization) is STAMPED by the producer; the certifying run/freeze
-        // re-derive + assertion that makes it runtime-authoritative is a follow-up
-        // slice (#2225) — NOT yet wired here, so the hole is not closed until it
-        // lands. Additive-optional: harness locks (no scoring corpus) parse
-        // unchanged; once the enforcement lands the certifying path will hard-error
-        // if absent (no safe default for an integrity hash).
+        // #709 fold-2 (codex panel): an integrity digest over the SCORING source
+        // `pr-diffs.json`, which `loadCertRunFixtures` reads independently of the
+        // control dirs. `fixtureSha` hashes only the control dirs, so a tampered
+        // `corpus`-kind (or any) row in pr-diffs.json would pass every runtime check.
+        // ENCODING (pin — greptile panel): this sha256 (64-hex) is taken over the
+        // EXACT on-disk `pr-diffs.json` bytes (canonical 2-space JSON + trailing
+        // newline, as the producer writes them), so a freeze/run enforcer can
+        // `sha256` the file directly — NOT over the compact `canonicalStringify`.
+        // STAMPED by the producer; the certifying run/freeze re-derive + assertion
+        // that makes it runtime-authoritative is a follow-up slice (#2225) — NOT yet
+        // wired here, so the hole is not closed until it lands. Additive-optional:
+        // harness locks (no scoring corpus) parse unchanged; once the enforcement
+        // lands the certifying path will hard-error if absent (no safe default for
+        // an integrity hash).
         prDiffsSha: z.string().regex(SHA256_REGEX, 'prDiffsSha must be a 64-hex sha256').optional(),
       }),
     }),

--- a/packages/core/src/spine/windtunnel-lock.ts
+++ b/packages/core/src/spine/windtunnel-lock.ts
@@ -100,10 +100,12 @@ export const WindtunnelLockSchema = z
         // independently of the control dirs. `fixtureSha` hashes only the
         // control dirs, so a tampered `corpus`-kind (or any) row in pr-diffs.json
         // would pass every runtime check. This sha256 (64-hex, over the canonical
-        // serialization) closes that hole; the certifying run/freeze re-derives +
-        // asserts it. Additive-optional: harness locks (no scoring corpus) parse
-        // unchanged; the certifying path hard-errors if absent (no safe default
-        // for an integrity hash).
+        // serialization) is STAMPED by the producer; the certifying run/freeze
+        // re-derive + assertion that makes it runtime-authoritative is a follow-up
+        // slice (#2225) — NOT yet wired here, so the hole is not closed until it
+        // lands. Additive-optional: harness locks (no scoring corpus) parse
+        // unchanged; once the enforcement lands the certifying path will hard-error
+        // if absent (no safe default for an integrity hash).
         prDiffsSha: z.string().regex(SHA256_REGEX, 'prDiffsSha must be a 64-hex sha256').optional(),
       }),
     }),

--- a/packages/core/src/spine/windtunnel-lock.ts
+++ b/packages/core/src/spine/windtunnel-lock.ts
@@ -95,6 +95,16 @@ export const WindtunnelLockSchema = z
           .string()
           .regex(SHA256_REGEX, 'llmReplaySha must be a 64-hex sha256')
           .optional(),
+        // #709 fold-2 (codex panel): an integrity digest over the canonical
+        // `pr-diffs.json` — the SCORING source `loadCertRunFixtures` reads
+        // independently of the control dirs. `fixtureSha` hashes only the
+        // control dirs, so a tampered `corpus`-kind (or any) row in pr-diffs.json
+        // would pass every runtime check. This sha256 (64-hex, over the canonical
+        // serialization) closes that hole; the certifying run/freeze re-derives +
+        // asserts it. Additive-optional: harness locks (no scoring corpus) parse
+        // unchanged; the certifying path hard-errors if absent (no safe default
+        // for an integrity hash).
+        prDiffsSha: z.string().regex(SHA256_REGEX, 'prDiffsSha must be a 64-hex sha256').optional(),
       }),
     }),
     cullRateThreshold: z


### PR DESCRIPTION
## What

The Gate-1 cert-corpus materialization producer (**`mmnto-ai/totem-strategy#709`**): `totem spine windtunnel materialize --lc-dir <p> --manifest <seed.json>` writes the 4 unproduced cert-run **scoring** fixtures — the lock, `split.json`, `pr-diffs.json`, and the positive/negative control dirs — so `loadCertRunFixtures` stops throwing. Upstream of `record` → `freeze` → `run`. (`record` already produces the other 2; the disposition-derived `ground-truth-labels.json` **deriver** is the next slice.)

## Design — cohort-panel-ratified before any code

Pre-build panel on distinct lenses (codex = contract, agy = build/test, gemini = tenet/arch), unanimous **PASS-with-folds**. The boundary: a small **curated seed manifest** carries the irreducible answer-key decisions (`asOfCommit`, selection config, `cutIndex`, control designations + each positive control's `targetRuleId`); **everything else is derived** off the lc clone. Pure derivation + lock assembly in core (`deriveCorpus` / `buildWindtunnelLock`, reusing `resolveSelectionRule` / `resolveSplit`); git I/O in the CLI.

## Panel folds incorporated

- **fold-1 strict write-side** — `targetRuleId` required iff `controlKind: 'positive'`, forbidden otherwise (a positive control can't silently lose its non-vacuity target).
- **fold-2 pr-diffs integrity digest** — new additive-optional `controls.integrity.prDiffsSha` (sha256 over canonical `pr-diffs.json`) closes the hole that `fixtureSha` (control-dirs-only) leaves on the independently-loaded scoring source. *Producer computes + stamps it; the freeze/run **hard-enforcement** is the immediate fast-follow (flagged to strategy-claude — closest to their contract).*
- **fold-3 fail-loud git** — producer-owned diff resolution throws on git faults and rejects an empty diff for a code-touching PR (no silent-empty frozen fixture).
- **fold-4 Amendment-C double-guard** — a contradictory seed (control outside the corpus, or tagged both positive+negative) fails loud before emit.
- **Two-phase sealed lock** — the producer omits `llmReplaySha` (it can't know it — `record` runs after); `freeze` seals it.

## Tests / gate

- Programmatic git fixture (real `git init`, pinned dates) over the direct-to-main / malformed-`(#abc)` / revert-pair / multi-file / empty-diff matrix; byte-determinism; both integrity red tests (C6 `fixtureSha` + fold-2 `prDiffsSha`).
- The produced output **passes the actual freeze gate end-to-end** (`S4 corpus completeness VERIFIED` + C6 integrity).
- core **2725** / cli **2722** green · `format:check` · `lint --base main` **PASS (0 errors)** · changeset (`@mmnto/totem: minor`).

## Scope

The **producer** half of `mmnto-ai/totem-strategy#709`. This PR intentionally carries **no closing keyword** — the disposition-derived ground-truth-labels deriver (contract ruled) and the `prDiffsSha` freeze/run enforcement are the next slices. Related: `mmnto-ai/totem-strategy#709`, `mmnto-ai/totem#2188` (lock schema + harness, shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
