### PR TITLE
fix(spine): enforce prDiffsSha at certifying run + freeze (#709 fold-2 enforcement)

### DIFF
--- a/.changeset/spine-2225-prdiffssha-enforcement.md
+++ b/.changeset/spine-2225-prdiffssha-enforcement.md
@@ -1,0 +1,10 @@
+---
+'@mmnto/totem': patch
+---
+
+fix(spine): enforce prDiffsSha at the certifying run + freeze (#709 fold-2 enforcement)
+
+The #709 producer stamps `controls.integrity.prDiffsSha` (a sha256 over the exact on-disk `pr-diffs.json` bytes), but nothing re-derived or asserted it — so the certifying run's scoring source was **stamped-but-runtime-unauthoritative**: a silent mutation of any row (advisory-window or control) would corrupt the disposition-derived answer key while `fixtureSha` (control-dirs-only) stayed green. This closes that seam (codex-panel-caught, affirmed + sharpened by strategy-claude: digest the FULL pr-diffs.json, verify at freeze AND run).
+
+- **Certifying run** (`buildReplayCorpusProvider`): re-derive the digest over the on-disk `pr-diffs.json` bytes and **hard-error** on absent/mismatch — beside the `llmReplaySha` L2 gate.
+- **Freeze**: a **warn-only** pre-merge check, mirroring the `fixtureSha` freeze behavior (the run is the authoritative gate).

--- a/packages/cli/src/commands/spine-cert-run-corpus.test.ts
+++ b/packages/cli/src/commands/spine-cert-run-corpus.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -110,10 +111,10 @@ function stage4(files: Record<string, string>): Stage4VerifierDeps {
   };
 }
 
-/** A minimal lock partial — the provider reads only the L2 hash + resolved corpus. */
-function lockWith(llmReplaySha?: string): WindtunnelLock {
+/** A minimal lock partial — the provider reads the L2 hash, the pr-diffs digest, + resolved corpus. */
+function lockWith(llmReplaySha?: string, prDiffsSha?: string): WindtunnelLock {
   return {
-    controls: { integrity: { llmReplaySha } },
+    controls: { integrity: { llmReplaySha, prDiffsSha } },
     corpus: { resolvedPrs: [{ pr: 1, mergeCommit: sha(1) }] },
   } as unknown as WindtunnelLock;
 }
@@ -171,6 +172,13 @@ async function fixtureHash(): Promise<string> {
   return hash;
 }
 
+/** sha256 of the exact on-disk pr-diffs.json bytes — the digest the run gate (#2225) asserts. */
+function prDiffsHash(): string {
+  return createHash('sha256')
+    .update(fs.readFileSync(path.join(gate1Dir, 'pr-diffs.json'), 'utf-8'), 'utf-8')
+    .digest('hex');
+}
+
 // ─── Tests ───────────────────────────────────────────
 
 describe('buildReplayCorpusProvider (run-path)', () => {
@@ -186,7 +194,7 @@ describe('buildReplayCorpusProvider (run-path)', () => {
       },
     });
 
-    const corpus = await provider(lockWith(hash));
+    const corpus = await provider(lockWith(hash, prDiffsHash()));
 
     expect(corpus.rules).toHaveLength(1);
     expect(corpus.provenanceByRule.get(corpus.rules[0]!.lessonHash)?.mergedPr).toBe(1);
@@ -210,7 +218,35 @@ describe('buildReplayCorpusProvider (run-path)', () => {
       stage4: stage4({ 'src/a.ts': 'forbiddenCall()' }),
       now: NOW,
     });
-    await provider(lockWith(hash));
+    await provider(lockWith(hash, prDiffsHash()));
     expect(fs.existsSync(path.join(gate1Dir, 'miner-ledgers.json'))).toBe(true);
+  });
+
+  it('throws loud when the lock lacks the prDiffsSha digest (#2225 scoring-source gate)', async () => {
+    const hash = await fixtureHash();
+    const provider = buildReplayCorpusProvider({
+      gate1Dir,
+      stage4: stage4({ 'src/a.ts': 'forbiddenCall()' }),
+      now: NOW,
+    });
+    // llmReplaySha present, prDiffsSha omitted → the fold-2 gate fires.
+    await expect(provider(lockWith(hash, undefined))).rejects.toThrow(/prDiffsSha/);
+  });
+
+  it('throws loud when pr-diffs.json is tampered after freeze (#2225 fold-2)', async () => {
+    const hash = await fixtureHash();
+    const lock = lockWith(hash, prDiffsHash()); // digest captured over the frozen bytes
+    // a schema-valid but byte-different scoring source — passes Zod, fails the digest.
+    fs.writeFileSync(
+      path.join(gate1Dir, 'pr-diffs.json'),
+      JSON.stringify([{ pr: 1, diff: 'tampered', controlKind: 'corpus' }]),
+      'utf-8',
+    );
+    const provider = buildReplayCorpusProvider({
+      gate1Dir,
+      stage4: stage4({ 'src/a.ts': 'forbiddenCall()' }),
+      now: NOW,
+    });
+    await expect(provider(lock)).rejects.toThrow(/pr-diffs\.json integrity/);
   });
 });

--- a/packages/cli/src/commands/spine-cert-run-corpus.test.ts
+++ b/packages/cli/src/commands/spine-cert-run-corpus.test.ts
@@ -172,10 +172,13 @@ async function fixtureHash(): Promise<string> {
   return hash;
 }
 
-/** sha256 of the exact on-disk pr-diffs.json bytes — the digest the run gate (#2225) asserts. */
+/** sha256 of the CRLF→LF-normalized on-disk pr-diffs.json — the digest the run gate (#2225) asserts. */
 function prDiffsHash(): string {
   return createHash('sha256')
-    .update(fs.readFileSync(path.join(gate1Dir, 'pr-diffs.json'), 'utf-8'), 'utf-8')
+    .update(
+      fs.readFileSync(path.join(gate1Dir, 'pr-diffs.json'), 'utf-8').replace(/\r\n/g, '\n'),
+      'utf-8',
+    )
     .digest('hex');
 }
 

--- a/packages/cli/src/commands/spine-cert-run-corpus.ts
+++ b/packages/cli/src/commands/spine-cert-run-corpus.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -175,6 +176,34 @@ export function buildReplayCorpusProvider(
     const { split, artifact, content, prDiffs, groundTruth } = await loadCertRunFixtures(
       opts.gate1Dir,
     );
+
+    // #2225 (#709 fold-2): hash-bind the SCORING source. `pr-diffs.json` is loaded +
+    // Zod-parsed but otherwise unprotected — `fixtureSha` covers only the control
+    // dirs — so a silent mutation of any row (advisory-window OR control) would
+    // corrupt the answer key while the control-dir gate stays green. Re-derive the
+    // digest over the EXACT on-disk bytes and assert vs the lock; fail loud (mirrors
+    // the llmReplaySha L2 gate; strategy ruled: verify at freeze AND run).
+    const expectedPrDiffsSha = lock.controls.integrity.prDiffsSha;
+    if (!expectedPrDiffsSha) {
+      throw new TotemError(
+        'CONFIG_INVALID',
+        'Certifying run: lock is missing controls.integrity.prDiffsSha (#709 fold-2) — the ' +
+          'pr-diffs.json scoring source cannot be integrity-checked.',
+        'Re-materialize the cert corpus with `spine windtunnel materialize`.',
+      );
+    }
+    const actualPrDiffsSha = createHash('sha256')
+      .update(fs.readFileSync(path.join(opts.gate1Dir, 'pr-diffs.json'), 'utf-8'), 'utf-8')
+      .digest('hex');
+    if (actualPrDiffsSha !== expectedPrDiffsSha) {
+      throw new TotemError(
+        'CONFIG_INVALID',
+        `Certifying run: pr-diffs.json integrity FAILED — expected ${expectedPrDiffsSha}, got ` +
+          `${actualPrDiffsSha} (the frozen scoring corpus was tampered or re-serialized).`,
+        'Restore the frozen pr-diffs.json or re-materialize the cert corpus.',
+      );
+    }
+
     const { extractor, classifier } = buildReplayAdapters(artifact, expectedHash);
 
     const { corpus, ledgers } = await buildCertifyingCorpus({

--- a/packages/cli/src/commands/spine-cert-run-corpus.ts
+++ b/packages/cli/src/commands/spine-cert-run-corpus.ts
@@ -81,13 +81,15 @@ export interface CertRunFixtureInputs {
  * dynamically imported per the CLI lazy-import convention, not pulled in at
  * module load.
  */
-export async function loadCertRunFixtures(gate1Dir: string): Promise<CertRunFixtureInputs> {
+export async function loadCertRunFixtures(
+  gate1Dir: string,
+  opts?: { expectedPrDiffsSha?: string },
+): Promise<CertRunFixtureInputs> {
   const { SplitArtifactSchema, TotemError } = await import('@mmnto/totem');
 
-  const loadJson = (file: string): unknown => {
-    let raw: string;
+  const readRaw = (file: string): string => {
     try {
-      raw = fs.readFileSync(file, 'utf-8');
+      return fs.readFileSync(file, 'utf-8');
     } catch (err) {
       throw new TotemError(
         'CONFIG_INVALID',
@@ -96,6 +98,8 @@ export async function loadCertRunFixtures(gate1Dir: string): Promise<CertRunFixt
         err,
       );
     }
+  };
+  const parseJson = (raw: string, file: string): unknown => {
     try {
       return JSON.parse(raw);
     } catch (err) {
@@ -107,13 +111,35 @@ export async function loadCertRunFixtures(gate1Dir: string): Promise<CertRunFixt
       );
     }
   };
+  const loadJson = (file: string): unknown => parseJson(readRaw(file), file);
 
   const split = SplitArtifactSchema.parse(loadJson(path.join(gate1Dir, SPLIT_FILE)));
   const artifact = ReplayArtifactSchema.parse(loadJson(path.join(gate1Dir, REPLAY_FILE)));
   const content = z
     .array(ReviewThreadContentSchema)
     .parse(loadJson(path.join(gate1Dir, CONTENT_FILE)));
-  const prDiffs = z.array(ResolvedPrDiffSchema).parse(loadJson(path.join(gate1Dir, PR_DIFFS_FILE)));
+
+  // #2225 (#709 fold-2): verify-then-parse the SCORING source on a SINGLE read — the
+  // digest must cover the exact bytes that get parsed + scored, not a separate read
+  // (CR: no check/use split). CRLF→LF normalized to match the producer's LF-stamped
+  // digest. The absent-from-lock case is the caller's precondition (it omits the sha).
+  const prDiffsFile = path.join(gate1Dir, PR_DIFFS_FILE);
+  const prDiffsRaw = readRaw(prDiffsFile);
+  if (opts?.expectedPrDiffsSha !== undefined) {
+    const actual = createHash('sha256')
+      .update(prDiffsRaw.replace(/\r\n/g, '\n'), 'utf-8')
+      .digest('hex');
+    if (actual !== opts.expectedPrDiffsSha) {
+      throw new TotemError(
+        'CONFIG_INVALID',
+        `Certifying run: pr-diffs.json integrity FAILED — expected ${opts.expectedPrDiffsSha}, got ` +
+          `${actual} (the frozen scoring corpus was tampered or re-serialized).`,
+        'Restore the frozen pr-diffs.json or re-materialize the cert corpus.',
+      );
+    }
+  }
+  const prDiffs = z.array(ResolvedPrDiffSchema).parse(parseJson(prDiffsRaw, prDiffsFile));
+
   const gtRecord = GroundTruthSchema.parse(loadJson(path.join(gate1Dir, GROUND_TRUTH_FILE)));
   const groundTruth = new Map<string, GroundTruthLabel>(Object.entries(gtRecord));
   return { split, artifact, content, prDiffs, groundTruth };
@@ -173,12 +199,12 @@ export function buildReplayCorpusProvider(
       );
     }
 
-    // #2225 (#709 fold-2): hash-bind the SCORING source BEFORE loading + parsing it
-    // (verify-bytes-then-parse, matching the llmReplaySha gate's position — greptile).
-    // `pr-diffs.json` is otherwise unprotected — `fixtureSha` covers only the control
-    // dirs — so a silent mutation of any row (advisory-window OR control) would corrupt
-    // the answer key while the control-dir gate stays green. Fail loud (strategy ruled:
-    // verify at freeze AND run).
+    // #2225 (#709 fold-2): hash-bind the SCORING source. `pr-diffs.json` is otherwise
+    // unprotected — `fixtureSha` covers only the control dirs — so a silent mutation of
+    // any row (advisory-window OR control) would corrupt the answer key while the
+    // control-dir gate stays green. The absent-from-lock case is a lock precondition
+    // (checked here); `loadCertRunFixtures` verifies the digest on the SAME read it
+    // parses — no check/use split (CR). Fail loud (strategy ruled: verify at freeze AND run).
     const expectedPrDiffsSha = lock.controls.integrity.prDiffsSha;
     if (!expectedPrDiffsSha) {
       throw new TotemError(
@@ -188,34 +214,10 @@ export function buildReplayCorpusProvider(
         'Re-materialize the cert corpus with `spine windtunnel materialize`.',
       );
     }
-    const prDiffsPath = path.join(opts.gate1Dir, PR_DIFFS_FILE);
-    let prDiffsBytes: string;
-    try {
-      prDiffsBytes = fs.readFileSync(prDiffsPath, 'utf-8');
-    } catch (err) {
-      throw new TotemError(
-        'CONFIG_INVALID',
-        `Certifying run: pr-diffs.json not found at ${prDiffsPath}, but the lock declares a digest.`,
-        'Re-materialize the cert corpus so pr-diffs.json is co-located with the lock.',
-        err,
-      );
-    }
-    // Normalize CRLF→LF before hashing so a Windows checkout (git autocrlf) doesn't
-    // spuriously fail the gate — the producer stamps the digest over LF bytes (GCA).
-    const actualPrDiffsSha = createHash('sha256')
-      .update(prDiffsBytes.replace(/\r\n/g, '\n'), 'utf-8')
-      .digest('hex');
-    if (actualPrDiffsSha !== expectedPrDiffsSha) {
-      throw new TotemError(
-        'CONFIG_INVALID',
-        `Certifying run: pr-diffs.json integrity FAILED — expected ${expectedPrDiffsSha}, got ` +
-          `${actualPrDiffsSha} (the frozen scoring corpus was tampered or re-serialized).`,
-        'Restore the frozen pr-diffs.json or re-materialize the cert corpus.',
-      );
-    }
 
     const { split, artifact, content, prDiffs, groundTruth } = await loadCertRunFixtures(
       opts.gate1Dir,
+      { expectedPrDiffsSha },
     );
     const { extractor, classifier } = buildReplayAdapters(artifact, expectedHash);
 

--- a/packages/cli/src/commands/spine-cert-run-corpus.ts
+++ b/packages/cli/src/commands/spine-cert-run-corpus.ts
@@ -25,7 +25,7 @@ import type { CertifyingCorpus, CertifyingCorpusProvider } from './spine-windtun
 const SPLIT_FILE = 'split.json';
 const REPLAY_FILE = 'llm-replay.v1.json';
 const CONTENT_FILE = 'review-content.json';
-const PR_DIFFS_FILE = 'pr-diffs.json';
+export const PR_DIFFS_FILE = 'pr-diffs.json';
 const GROUND_TRUTH_FILE = 'ground-truth-labels.json';
 const LEDGERS_FILE = 'miner-ledgers.json';
 

--- a/packages/cli/src/commands/spine-cert-run-corpus.ts
+++ b/packages/cli/src/commands/spine-cert-run-corpus.ts
@@ -173,16 +173,12 @@ export function buildReplayCorpusProvider(
       );
     }
 
-    const { split, artifact, content, prDiffs, groundTruth } = await loadCertRunFixtures(
-      opts.gate1Dir,
-    );
-
-    // #2225 (#709 fold-2): hash-bind the SCORING source. `pr-diffs.json` is loaded +
-    // Zod-parsed but otherwise unprotected — `fixtureSha` covers only the control
-    // dirs — so a silent mutation of any row (advisory-window OR control) would
-    // corrupt the answer key while the control-dir gate stays green. Re-derive the
-    // digest over the EXACT on-disk bytes and assert vs the lock; fail loud (mirrors
-    // the llmReplaySha L2 gate; strategy ruled: verify at freeze AND run).
+    // #2225 (#709 fold-2): hash-bind the SCORING source BEFORE loading + parsing it
+    // (verify-bytes-then-parse, matching the llmReplaySha gate's position — greptile).
+    // `pr-diffs.json` is otherwise unprotected — `fixtureSha` covers only the control
+    // dirs — so a silent mutation of any row (advisory-window OR control) would corrupt
+    // the answer key while the control-dir gate stays green. Fail loud (strategy ruled:
+    // verify at freeze AND run).
     const expectedPrDiffsSha = lock.controls.integrity.prDiffsSha;
     if (!expectedPrDiffsSha) {
       throw new TotemError(
@@ -192,8 +188,22 @@ export function buildReplayCorpusProvider(
         'Re-materialize the cert corpus with `spine windtunnel materialize`.',
       );
     }
+    const prDiffsPath = path.join(opts.gate1Dir, PR_DIFFS_FILE);
+    let prDiffsBytes: string;
+    try {
+      prDiffsBytes = fs.readFileSync(prDiffsPath, 'utf-8');
+    } catch (err) {
+      throw new TotemError(
+        'CONFIG_INVALID',
+        `Certifying run: pr-diffs.json not found at ${prDiffsPath}, but the lock declares a digest.`,
+        'Re-materialize the cert corpus so pr-diffs.json is co-located with the lock.',
+        err,
+      );
+    }
+    // Normalize CRLF→LF before hashing so a Windows checkout (git autocrlf) doesn't
+    // spuriously fail the gate — the producer stamps the digest over LF bytes (GCA).
     const actualPrDiffsSha = createHash('sha256')
-      .update(fs.readFileSync(path.join(opts.gate1Dir, 'pr-diffs.json'), 'utf-8'), 'utf-8')
+      .update(prDiffsBytes.replace(/\r\n/g, '\n'), 'utf-8')
       .digest('hex');
     if (actualPrDiffsSha !== expectedPrDiffsSha) {
       throw new TotemError(
@@ -204,6 +214,9 @@ export function buildReplayCorpusProvider(
       );
     }
 
+    const { split, artifact, content, prDiffs, groundTruth } = await loadCertRunFixtures(
+      opts.gate1Dir,
+    );
     const { extractor, classifier } = buildReplayAdapters(artifact, expectedHash);
 
     const { corpus, ledgers } = await buildCertifyingCorpus({

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -138,6 +138,14 @@ export async function freezeCommand(opts: FreezeOptions): Promise<void> {
       );
       console.error(`  Re-materialize the cert corpus to co-locate pr-diffs.json with the lock.`);
     }
+  } else if (lock.phase === 'certifying') {
+    // CR: a certifying lock with NO prDiffsSha passes freeze clean, then the run
+    // hard-fails. Surface it here. (Harness locks legitimately have no scoring
+    // corpus — additive-optional — so this is certifying-scoped, not unconditional.)
+    console.error(
+      `[WindtunnelFreeze] WARNING: controls.integrity.prDiffsSha is absent on a certifying lock — the certifying run will hard-fail (#709 fold-2).`,
+    );
+    console.error(`  Re-materialize the cert corpus with \`spine windtunnel materialize\`.`);
   }
 
   console.error(`[WindtunnelFreeze] DONE — lock at ${lockPath} is schema-valid.`);

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -5,7 +5,7 @@ import * as path from 'node:path';
 import type { PrMeta, SelectionRuleConfig, WindtunnelLock } from '@mmnto/totem';
 
 import { persistCertifyingOutcome } from './spine-cert-persist.js';
-import { buildReplayCorpusProvider } from './spine-cert-run-corpus.js';
+import { buildReplayCorpusProvider, PR_DIFFS_FILE } from './spine-cert-run-corpus.js';
 
 // ─── Named constants ─────────────────────────────────
 
@@ -117,7 +117,10 @@ export async function freezeCommand(opts: FreezeOptions): Promise<void> {
   // (the hard gate is the certifying run). Warn-only, mirroring fixtureSha. CRLF→LF
   // normalized so a Windows checkout doesn't spuriously warn (GCA).
   if (lock.controls.integrity.prDiffsSha) {
-    const prDiffsPath = path.join(path.dirname(lockPath), 'pr-diffs.json');
+    // Co-location contract: pr-diffs.json lives in the gate-1 dir beside the lock —
+    // freeze resolves it via dirname(lockPath), the run via opts.gate1Dir (= the same
+    // dir). Shared `PR_DIFFS_FILE` constant so a rename can't drift between them (CR).
+    const prDiffsPath = path.join(path.dirname(lockPath), PR_DIFFS_FILE);
     if (fs.existsSync(prDiffsPath)) {
       const actual = createHash('sha256')
         .update(fs.readFileSync(prDiffsPath, 'utf-8').replace(/\r\n/g, '\n'), 'utf-8')

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
@@ -110,6 +111,23 @@ export async function freezeCommand(opts: FreezeOptions): Promise<void> {
     console.error(
       `[WindtunnelFreeze] Control dirs [${controlDirs.join(', ')}] do not exist — integrity check skipped.`,
     );
+  }
+
+  // #2225 (#709 fold-2): pre-merge heads-up on the pr-diffs.json scoring-source
+  // digest (the hard gate is the certifying run). Warn-only, mirroring fixtureSha.
+  const prDiffsPath = path.join(path.dirname(lockPath), 'pr-diffs.json');
+  if (lock.controls.integrity.prDiffsSha && fs.existsSync(prDiffsPath)) {
+    const actual = createHash('sha256')
+      .update(fs.readFileSync(prDiffsPath, 'utf-8'), 'utf-8')
+      .digest('hex');
+    if (actual !== lock.controls.integrity.prDiffsSha) {
+      console.error(
+        `[WindtunnelFreeze] WARNING: controls.integrity.prDiffsSha in lock (${lock.controls.integrity.prDiffsSha}) does not match computed digest of pr-diffs.json (${actual})`,
+      );
+      console.error(`  Re-materialize the cert corpus or update prDiffsSha and re-freeze.`);
+    } else {
+      console.error(`[WindtunnelFreeze] pr-diffs.json digest verified: ${actual}`);
+    }
   }
 
   console.error(`[WindtunnelFreeze] DONE — lock at ${lockPath} is schema-valid.`);

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -113,20 +113,30 @@ export async function freezeCommand(opts: FreezeOptions): Promise<void> {
     );
   }
 
-  // #2225 (#709 fold-2): pre-merge heads-up on the pr-diffs.json scoring-source
-  // digest (the hard gate is the certifying run). Warn-only, mirroring fixtureSha.
-  const prDiffsPath = path.join(path.dirname(lockPath), 'pr-diffs.json');
-  if (lock.controls.integrity.prDiffsSha && fs.existsSync(prDiffsPath)) {
-    const actual = createHash('sha256')
-      .update(fs.readFileSync(prDiffsPath, 'utf-8'), 'utf-8')
-      .digest('hex');
-    if (actual !== lock.controls.integrity.prDiffsSha) {
-      console.error(
-        `[WindtunnelFreeze] WARNING: controls.integrity.prDiffsSha in lock (${lock.controls.integrity.prDiffsSha}) does not match computed digest of pr-diffs.json (${actual})`,
-      );
-      console.error(`  Re-materialize the cert corpus or update prDiffsSha and re-freeze.`);
+  // #2225 (#709 fold-2): pre-merge heads-up on the pr-diffs.json scoring-source digest
+  // (the hard gate is the certifying run). Warn-only, mirroring fixtureSha. CRLF→LF
+  // normalized so a Windows checkout doesn't spuriously warn (GCA).
+  if (lock.controls.integrity.prDiffsSha) {
+    const prDiffsPath = path.join(path.dirname(lockPath), 'pr-diffs.json');
+    if (fs.existsSync(prDiffsPath)) {
+      const actual = createHash('sha256')
+        .update(fs.readFileSync(prDiffsPath, 'utf-8').replace(/\r\n/g, '\n'), 'utf-8')
+        .digest('hex');
+      if (actual !== lock.controls.integrity.prDiffsSha) {
+        console.error(
+          `[WindtunnelFreeze] WARNING: controls.integrity.prDiffsSha in lock (${lock.controls.integrity.prDiffsSha}) does not match computed digest of pr-diffs.json (${actual})`,
+        );
+        console.error(`  Re-materialize the cert corpus or update prDiffsSha and re-freeze.`);
+      } else {
+        console.error(`[WindtunnelFreeze] pr-diffs.json digest verified: ${actual}`);
+      }
     } else {
-      console.error(`[WindtunnelFreeze] pr-diffs.json digest verified: ${actual}`);
+      // greptile: declared-but-missing — surface the gap proactively at freeze, not
+      // only later at run time via loadCertRunFixtures.
+      console.error(
+        `[WindtunnelFreeze] WARNING: lock declares controls.integrity.prDiffsSha but pr-diffs.json is missing at ${prDiffsPath} — the certifying run will fail.`,
+      );
+      console.error(`  Re-materialize the cert corpus to co-locate pr-diffs.json with the lock.`);
     }
   }
 


### PR DESCRIPTION
## What

Enforce `controls.integrity.prDiffsSha` at the certifying **run** + **freeze** — the freeze/run hard-enforcement deliberately deferred out of the #709 producer (#2224). The producer stamps the digest; this makes the cert run's scoring source runtime-authoritative.

## Why

`pr-diffs.json` is the cert run's scoring source — loaded + Zod-parsed but otherwise unprotected, since `fixtureSha` covers only the control dirs. So a silent mutation of any row (advisory-window or control) would corrupt the disposition-derived answer key while the control-dir gate stayed green. Codex panel-caught (fold-2), affirmed + sharpened by strategy-claude (digest the FULL `pr-diffs.json`; verify at freeze AND run).

## Change

- **Run** (`buildReplayCorpusProvider`): re-derive `sha256` over the **exact on-disk `pr-diffs.json` bytes** and **hard-error** on absent/mismatch — beside the `llmReplaySha` L2 gate.
- **Freeze** (`freezeCommand`): a **warn-only** pre-merge check, mirroring the `fixtureSha` freeze behavior. The run is the authoritative hard gate; this freeze-warns / run-hard-fails split is the established pattern for `fixtureSha`/`llmReplaySha`.

## Tests / gate

- Threaded `prDiffsSha` through the run-corpus test `lockWith` + two new tests: the **absent-digest gate**, and a **tamper red** (a schema-valid but byte-different `pr-diffs.json` → trips the digest gate, not Zod). Windtunnel freeze tests unaffected (the warn is additive).
- cli **2725** · eslint **0** · format · `totem lint --base main` **PASS (0 errors)** · changeset (`@mmnto/totem` patch).

Closes #2225.

Related: `mmnto-ai/totem-strategy#709`, #2224, #2188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
