### PR TITLE
feat(spine): Gate-1 label-deriver 5d-i — closed disposition taxonomy classifier (strategy#709)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -822,6 +822,8 @@ export type {
   CompileStageResult,
 } from './spine/compile.js';
 export { compileCandidate, runCompileStage } from './spine/compile.js';
+export type { DispositionClass, DispositionComment } from './spine/disposition-taxonomy.js';
+export { classifyDisposition, dispositionToLabel } from './spine/disposition-taxonomy.js';
 export type {
   DraftExtractor,
   ExtractStageDeps,

--- a/packages/core/src/spine/disposition-taxonomy.test.ts
+++ b/packages/core/src/spine/disposition-taxonomy.test.ts
@@ -181,4 +181,19 @@ describe('classifyDisposition — negation / over-match regressions (#2230 bot p
     // bare praise without a fix confirmation is not an accepted-fix (only "…, fixed" is).
     expect(classifyDisposition(thread('Good catch!'))).toBe('ambiguous');
   });
+
+  it('CR round-3 — `fixed` is negation-guarded: "not fixed yet" / "has not been fixed" are not TP', () => {
+    for (const reply of [
+      "This isn't fixed yet.",
+      'This has not been fixed.',
+      'Never fixed this.',
+      'No, that was not fixed.',
+    ]) {
+      expect(classifyDisposition(thread(reply))).not.toBe('accepted-fix');
+    }
+    // …but a genuine fix in its own clause still credits, even beside a negated one.
+    expect(classifyDisposition(thread('Not sure that was the cause, but I fixed it anyway.'))).toBe(
+      'accepted-fix',
+    );
+  });
 });

--- a/packages/core/src/spine/disposition-taxonomy.test.ts
+++ b/packages/core/src/spine/disposition-taxonomy.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  classifyDisposition,
+  type DispositionClass,
+  type DispositionComment,
+  dispositionToLabel,
+} from './disposition-taxonomy.js';
+
+// A held-out review thread: a bot finding + zero-or-more human replies.
+const BOT = 'coderabbitai[bot]';
+const HUMAN = 'satur8d';
+
+function thread(...replies: string[]): DispositionComment[] {
+  return [
+    { author: BOT, body: 'Potential null deref on `foo.bar` here.' },
+    ...replies.map((body) => ({ author: HUMAN, body })),
+  ];
+}
+
+describe('classifyDisposition — accepted-fix ⟹ TP', () => {
+  it.each([
+    'Fixed in the latest push.',
+    'Good catch, addressed.',
+    'Nice catch — done.',
+    'This has been fixed.',
+    'Applied the suggestion.',
+  ])('credits an unambiguous fix reply: %s', (reply) => {
+    expect(classifyDisposition(thread(reply))).toBe('accepted-fix');
+  });
+
+  it('maps accepted-fix → TP', () => {
+    expect(dispositionToLabel('accepted-fix')).toBe('TP');
+  });
+});
+
+describe('classifyDisposition — declined-as-false-positive ⟹ FP (correctness rebuttals only)', () => {
+  it.each([
+    'This is a false positive — the value is never null here.',
+    'Not a bug, the guard above covers it.',
+    'Works as intended.',
+    'This is by design.',
+    'Intentional — we want the eager throw.',
+    'Not applicable here.',
+    'This is correct.',
+  ])('credits an unambiguous correctness rebuttal: %s', (reply) => {
+    expect(classifyDisposition(thread(reply))).toBe('declined-as-false-positive');
+  });
+
+  it('maps declined-as-false-positive → FP', () => {
+    expect(dispositionToLabel('declined-as-false-positive')).toBe('FP');
+  });
+});
+
+describe('classifyDisposition — soft declines ⟹ UNLABELED', () => {
+  it('scope: out-of-scope / separate PR', () => {
+    expect(classifyDisposition(thread('Out of scope for this PR.'))).toBe('scope');
+    expect(classifyDisposition(thread('Will do this in a separate PR.'))).toBe('scope');
+  });
+
+  it('defer: follow-up / tracked / won’t fix', () => {
+    expect(classifyDisposition(thread('Tracked in #1234, follow-up.'))).toBe('defer');
+    expect(classifyDisposition(thread("Won't fix for now."))).toBe('defer');
+  });
+
+  it('superseded: the flagged code was refactored away', () => {
+    expect(classifyDisposition(thread('Refactored — no longer applies.'))).toBe('superseded');
+  });
+
+  it('style: a subjective nit', () => {
+    expect(classifyDisposition(thread('Just a nit, leaving as-is.'))).toBe('style');
+  });
+
+  it.each<DispositionClass>(['scope', 'defer', 'superseded', 'style', 'ambiguous'])(
+    'every UNLABELED class maps to null: %s',
+    (cls) => {
+      expect(dispositionToLabel(cls)).toBeNull();
+    },
+  );
+});
+
+describe('classifyDisposition — ambiguous ⟹ UNLABELED (conservative-by-construction)', () => {
+  it('no human reply (bot-only thread) is ambiguous — isResolved alone is never TP', () => {
+    expect(classifyDisposition([{ author: BOT, body: 'Consider extracting this.' }])).toBe(
+      'ambiguous',
+    );
+  });
+
+  it('an empty / whitespace human reply is ambiguous', () => {
+    expect(classifyDisposition(thread('   '))).toBe('ambiguous');
+  });
+
+  it('a human reply with no recognizable disposition is ambiguous', () => {
+    expect(classifyDisposition(thread('Thanks for the review!'))).toBe('ambiguous');
+  });
+
+  it('conflicting fix + false-positive signals collapse to ambiguous', () => {
+    expect(classifyDisposition(thread('It is by design, but I fixed it anyway.'))).toBe(
+      'ambiguous',
+    );
+  });
+
+  it('an impure fix (fix + scope) does not credit TP', () => {
+    expect(classifyDisposition(thread('Fixed the related part; the rest is out of scope.'))).toBe(
+      'ambiguous',
+    );
+  });
+
+  it('an impure rebuttal (false-positive + defer) does not credit FP', () => {
+    expect(
+      classifyDisposition(thread('Arguably a false positive, but tracked in #99 either way.')),
+    ).toBe('ambiguous');
+  });
+});
+
+describe("codex's falsifying case — a scope/defer decline must NEVER become FP", () => {
+  it('"declined, tracked for later / too broad for this PR" is UNLABELED, not FP', () => {
+    const cls = classifyDisposition(thread('Declined — tracked for later, too broad for this PR.'));
+    expect(cls).not.toBe('declined-as-false-positive');
+    expect(dispositionToLabel(cls)).toBeNull();
+  });
+
+  it('the binary primitive would have called this `declined`; we keep it UNLABELED', () => {
+    // bare "declined" with no correctness rebuttal is not an FP claim.
+    expect(dispositionToLabel(classifyDisposition(thread('Declined.')))).toBeNull();
+  });
+});
+
+describe('classifyDisposition — bot replies are not dispositions', () => {
+  it('a bot follow-up does not count as a human fix signal', () => {
+    const t: DispositionComment[] = [
+      { author: BOT, body: 'Potential issue.' },
+      { author: 'greptileai[bot]', body: 'Fixed in the suggested commit.' },
+    ];
+    expect(classifyDisposition(t)).toBe('ambiguous');
+  });
+});

--- a/packages/core/src/spine/disposition-taxonomy.test.ts
+++ b/packages/core/src/spine/disposition-taxonomy.test.ts
@@ -24,7 +24,7 @@ describe('classifyDisposition — accepted-fix ⟹ TP', () => {
     'Good catch, addressed.',
     'Nice catch — done.',
     'This has been fixed.',
-    'Applied the suggestion.',
+    'The fix has been applied.',
   ])('credits an unambiguous fix reply: %s', (reply) => {
     expect(classifyDisposition(thread(reply))).toBe('accepted-fix');
   });
@@ -40,9 +40,8 @@ describe('classifyDisposition — declined-as-false-positive ⟹ FP (correctness
     'Not a bug, the guard above covers it.',
     'Works as intended.',
     'This is by design.',
-    'Intentional — we want the eager throw.',
+    'This is intentional — we want the eager throw.',
     'Not applicable here.',
-    'This is correct.',
   ])('credits an unambiguous correctness rebuttal: %s', (reply) => {
     expect(classifyDisposition(thread(reply))).toBe('declined-as-false-positive');
   });
@@ -133,5 +132,45 @@ describe('classifyDisposition — bot replies are not dispositions', () => {
       { author: 'greptileai[bot]', body: 'Fixed in the suggested commit.' },
     ];
     expect(classifyDisposition(t)).toBe('ambiguous');
+  });
+});
+
+describe('classifyDisposition — negation / over-match regressions (#2230 bot panel + strategy-claude)', () => {
+  it('GCA :95 — "this is not correct" / "correct, I will fix it" is an AGREEMENT, never FP', () => {
+    expect(dispositionToLabel(classifyDisposition(thread('This is not correct.')))).not.toBe('FP');
+    expect(
+      dispositionToLabel(classifyDisposition(thread('You are correct, I will fix it.'))),
+    ).not.toBe('FP');
+  });
+
+  it('greptile :91 — "this behavior is not intentional" is not a false-positive rebuttal', () => {
+    expect(
+      classifyDisposition(thread('This behavior is not intentional but matches the contract.')),
+    ).not.toBe('declined-as-false-positive');
+  });
+
+  it('strategy-claude — "intentionally structured it, will fix the edge case" is not FP', () => {
+    // future-tense "will fix" is not in the fix bank; the anchored `is intentional`
+    // no longer trips on the bare adverb → no false FP.
+    expect(
+      classifyDisposition(thread('Intentionally structured it this way; will fix the edge case.')),
+    ).not.toBe('declined-as-false-positive');
+  });
+
+  it('greptile :78 P1 — negation-blind "not been addressed" / "not applied" is not a fix', () => {
+    expect(classifyDisposition(thread('This has not been addressed yet.'))).not.toBe(
+      'accepted-fix',
+    );
+    expect(classifyDisposition(thread('That was not applied.'))).not.toBe('accepted-fix');
+  });
+
+  it('strategy-claude / greptile — "Well done, but this still needs work" is not a fix', () => {
+    expect(classifyDisposition(thread('Well done, but this still needs work.'))).not.toBe(
+      'accepted-fix',
+    );
+  });
+
+  it('greptile :112 — lowercase "todo: track this" is recognized as a defer', () => {
+    expect(classifyDisposition(thread('todo: track this separately.'))).toBe('defer');
   });
 });

--- a/packages/core/src/spine/disposition-taxonomy.test.ts
+++ b/packages/core/src/spine/disposition-taxonomy.test.ts
@@ -136,60 +136,54 @@ describe('classifyDisposition — bot replies are not dispositions', () => {
 });
 
 describe('classifyDisposition — negation / over-match regressions (#2230 bot panel + strategy-claude)', () => {
-  it('GCA :95 — "this is not correct" / "correct, I will fix it" is an AGREEMENT, never FP', () => {
-    expect(dispositionToLabel(classifyDisposition(thread('This is not correct.')))).not.toBe('FP');
-    expect(
-      dispositionToLabel(classifyDisposition(thread('You are correct, I will fix it.'))),
-    ).not.toBe('FP');
+  // CR #2230 round-4: every negation regression asserts FULLY UNLABELED
+  // (dispositionToLabel === null), not just "not the one label" — so a regression
+  // to EITHER mislabel (TP or FP) fails the test, not only the expected direction.
+  const isUnlabeled = (reply: string): boolean =>
+    dispositionToLabel(classifyDisposition(thread(reply))) === null;
+
+  it('GCA :95 — "this is not correct" / "correct, I will fix it" is an AGREEMENT, neither TP nor FP', () => {
+    expect(isUnlabeled('This is not correct.')).toBe(true);
+    expect(isUnlabeled('You are correct, I will fix it.')).toBe(true);
   });
 
   it('greptile :91 — "this behavior is not intentional" is not a false-positive rebuttal', () => {
-    expect(
-      classifyDisposition(thread('This behavior is not intentional but matches the contract.')),
-    ).not.toBe('declined-as-false-positive');
+    expect(isUnlabeled('This behavior is not intentional but matches the contract.')).toBe(true);
   });
 
   it('strategy-claude — "intentionally structured it, will fix the edge case" is not FP', () => {
     // future-tense "will fix" is not in the fix bank; the anchored `is intentional`
     // no longer trips on the bare adverb → no false FP.
-    expect(
-      classifyDisposition(thread('Intentionally structured it this way; will fix the edge case.')),
-    ).not.toBe('declined-as-false-positive');
+    expect(isUnlabeled('Intentionally structured it this way; will fix the edge case.')).toBe(true);
   });
 
   it('greptile :78 P1 — negation-blind "not been addressed" / "not applied" is not a fix', () => {
-    expect(classifyDisposition(thread('This has not been addressed yet.'))).not.toBe(
-      'accepted-fix',
-    );
-    expect(classifyDisposition(thread('That was not applied.'))).not.toBe('accepted-fix');
+    expect(isUnlabeled('This has not been addressed yet.')).toBe(true);
+    expect(isUnlabeled('That was not applied.')).toBe(true);
   });
 
   it('strategy-claude / greptile — "Well done, but this still needs work" is not a fix', () => {
-    expect(classifyDisposition(thread('Well done, but this still needs work.'))).not.toBe(
-      'accepted-fix',
-    );
+    expect(isUnlabeled('Well done, but this still needs work.')).toBe(true);
   });
 
   it('greptile :112 — lowercase "todo: track this" is recognized as a defer', () => {
     expect(classifyDisposition(thread('todo: track this separately.'))).toBe('defer');
   });
 
-  it('CR round-2 — praise words dropped: "not a good catch" is not a fix, "good catch" alone is not TP', () => {
-    expect(classifyDisposition(thread('Not a good catch — the guard is in the parent.'))).not.toBe(
-      'accepted-fix',
-    );
+  it('CR round-2 — praise words dropped: "not a good catch" / bare "good catch" are unlabeled', () => {
+    expect(isUnlabeled('Not a good catch — the guard is in the parent.')).toBe(true);
     // bare praise without a fix confirmation is not an accepted-fix (only "…, fixed" is).
     expect(classifyDisposition(thread('Good catch!'))).toBe('ambiguous');
   });
 
-  it('CR round-3 — `fixed` is negation-guarded: "not fixed yet" / "has not been fixed" are not TP', () => {
+  it('CR round-3 — `fixed` is negation-guarded: "not fixed yet" / "has not been fixed" are unlabeled', () => {
     for (const reply of [
       "This isn't fixed yet.",
       'This has not been fixed.',
       'Never fixed this.',
       'No, that was not fixed.',
     ]) {
-      expect(classifyDisposition(thread(reply))).not.toBe('accepted-fix');
+      expect(isUnlabeled(reply)).toBe(true);
     }
     // …but a genuine fix in its own clause still credits, even beside a negated one.
     expect(classifyDisposition(thread('Not sure that was the cause, but I fixed it anyway.'))).toBe(

--- a/packages/core/src/spine/disposition-taxonomy.test.ts
+++ b/packages/core/src/spine/disposition-taxonomy.test.ts
@@ -21,8 +21,8 @@ function thread(...replies: string[]): DispositionComment[] {
 describe('classifyDisposition — accepted-fix ⟹ TP', () => {
   it.each([
     'Fixed in the latest push.',
-    'Good catch, addressed.',
-    'Nice catch — done.',
+    'Good catch — fixed.',
+    'It has now been addressed.',
     'This has been fixed.',
     'The fix has been applied.',
   ])('credits an unambiguous fix reply: %s', (reply) => {
@@ -172,5 +172,13 @@ describe('classifyDisposition — negation / over-match regressions (#2230 bot p
 
   it('greptile :112 — lowercase "todo: track this" is recognized as a defer', () => {
     expect(classifyDisposition(thread('todo: track this separately.'))).toBe('defer');
+  });
+
+  it('CR round-2 — praise words dropped: "not a good catch" is not a fix, "good catch" alone is not TP', () => {
+    expect(classifyDisposition(thread('Not a good catch — the guard is in the parent.'))).not.toBe(
+      'accepted-fix',
+    );
+    // bare praise without a fix confirmation is not an accepted-fix (only "…, fixed" is).
+    expect(classifyDisposition(thread('Good catch!'))).toBe('ambiguous');
   });
 });

--- a/packages/core/src/spine/disposition-taxonomy.ts
+++ b/packages/core/src/spine/disposition-taxonomy.ts
@@ -70,12 +70,11 @@ export interface DispositionComment {
 const FIX_PATTERNS: readonly RegExp[] = [
   /\bfixed\b/i,
   // Confirmed-PAST construction only. The bare `addressed`/`applied`/`done` words —
-  // and the praise words `good catch`/`nice catch` (CR #2230 round-2) — were
-  // negation-blind ("this has not been addressed", "not a good catch …") and, in the
-  // praise case, not even a fix CONFIRMATION (acknowledging a real finding ≠ acting
-  // on it). All minted false TPs. The canonical bare accept `fixed` is kept; the TP
-  // signal "good catch, fixed!" is still covered by `fixed`. Finer negation handling
-  // is the 5d-ii real-corpus measure-first task (strategy-claude RULED #4 run-first).
+  // and the praise words `good catch`/`nice catch` (CR #2230 round-2) — were dropped:
+  // praise is not a fix CONFIRMATION (acknowledging a real finding ≠ acting on it),
+  // and the bare words minted false TPs. The canonical bare accept `fixed` is kept
+  // ("good catch, fixed!" still credits) but is now guarded against negation by
+  // `hasUnnegatedFix` (CR #2230 round-3 — "not fixed yet" no longer a false TP).
   /\b(?:has|have|now)\s+been\s+(?:fixed|addressed|applied)\b/i,
 ];
 
@@ -140,6 +139,35 @@ const STYLE_PATTERNS: readonly RegExp[] = [
 const matchesAny = (text: string, bank: readonly RegExp[]): boolean =>
   bank.some((p) => p.test(text));
 
+/**
+ * A negator that, in the same clause as a fix signal, VOIDS it — "this has not
+ * been fixed", "isn't fixed yet", "never addressed". (CR #2230 round-3: the bare
+ * `fixed` token was still negation-blind.) Applied ONLY to the FIX bank: none of
+ * its patterns are intrinsically negative, so a clause-scoped negator is an
+ * unambiguous inversion. The FALSE_POSITIVE bank deliberately does NOT get this —
+ * several of its patterns ARE negative constructions ("not a bug", "not applicable").
+ */
+const FIX_NEGATOR =
+  /\b(?:not|never|no|without|isn't|wasn't|hasn't|haven't|won't|doesn't|didn't|aren't|weren't)\b/i;
+
+/**
+ * Split into clauses for negation scoping. Breaks on sentence punctuation AND the
+ * contrastive conjunctions ("but"/"however"/"though") so "not sure, but I fixed it"
+ * keeps the fix in its own un-negated clause. Over-splitting only risks losing a
+ * true fix → UNLABELED → honest-negative (the safe direction), never a false TP.
+ */
+const splitClauses = (text: string): string[] =>
+  text.split(/[.!?;\n]+|\b(?:but|however|though)\b/i);
+
+/**
+ * A fix is credited only from a clause that matches a FIX pattern and carries no
+ * negator — so "fixed" survives ("good catch, fixed!") while "not been fixed yet"
+ * and "hasn't fixed it" do not (closing the negation class CR's adjacency-only
+ * `not\s+fixed` suggestion left open for the non-adjacent "not been fixed" form).
+ */
+const hasUnnegatedFix = (text: string): boolean =>
+  splitClauses(text).some((c) => matchesAny(c, FIX_PATTERNS) && !FIX_NEGATOR.test(c));
+
 // ── The classifier ───────────────────────────────────────────────────────────
 
 /**
@@ -168,7 +196,9 @@ export function classifyDisposition(comments: ReadonlyArray<DispositionComment>)
   if (humanText.length === 0) return 'ambiguous';
 
   const joined = humanText.join('\n');
-  const fix = matchesAny(joined, FIX_PATTERNS);
+  // Clause-scoped + negation-aware (CR #2230 round-3): "not fixed yet" / "hasn't
+  // been addressed" must not credit a fix. The other banks match on the whole text.
+  const fix = hasUnnegatedFix(joined);
   const fp = matchesAny(joined, FALSE_POSITIVE_PATTERNS);
   const scope = matchesAny(joined, SCOPE_PATTERNS);
   const defer = matchesAny(joined, DEFER_PATTERNS);

--- a/packages/core/src/spine/disposition-taxonomy.ts
+++ b/packages/core/src/spine/disposition-taxonomy.ts
@@ -69,12 +69,15 @@ export interface DispositionComment {
  */
 const FIX_PATTERNS: readonly RegExp[] = [
   /\bfixed\b/i,
+  // Confirmed-PAST construction only. The bare `addressed`/`applied`/`done` words
+  // were negation-blind ("this has not been addressed", "not applied", "Well done,
+  // but this still needs work") and minted false TPs (greptile #2230 P1 +
+  // strategy-claude loose-token note). The canonical bare accept `fixed` is kept;
+  // finer negation handling is the 5d-ii real-corpus measure-first task
+  // (strategy-claude RULED #4 run-first), not a blind tighten here.
   /\b(?:has|have|now)\s+been\s+(?:fixed|addressed|applied)\b/i,
-  /\baddressed\b/i,
-  /\bapplied\b/i,
   /\bgood\s+catch\b/i,
   /\bnice\s+catch\b/i,
-  /\bdone\b/i,
 ];
 
 /**
@@ -88,9 +91,16 @@ const FALSE_POSITIVE_PATTERNS: readonly RegExp[] = [
   /\bnot\s+a\s+(?:bug|problem|issue|real)\b/i,
   /\b(?:works|working|behaves)\s+as\s+(?:intended|designed|expected)\b/i,
   /\bby\s+design\b/i,
-  /\bintentional(?:ly)?\b/i,
-  /\bnot\s+(?:applicable|relevant|correct|an\s+issue)\b/i,
-  /\bthis\s+is\s+(?:correct|fine|intended|safe)\b/i,
+  // Anchored to the AFFIRMATIVE copula. Bare `intentional(ly)` was negation- and
+  // future-blind: "this behavior is not intentional" (greptile #2230 :91) and
+  // "intentionally structured it, will fix the edge case" (strategy-claude note)
+  // both minted a false FP. `is intentional` keeps the genuine rebuttal.
+  /\bis\s+intentional\b/i,
+  // `correct` REMOVED from both `not …` and `this is …` (GCA #2230 :95). In review,
+  // "this is not correct" / "this is correct, I'll fix it" AGREE with the finding
+  // (a True Positive) — matching `correct` here inverted the label to FP.
+  /\bnot\s+(?:applicable|relevant|an\s+issue)\b/i,
+  /\bthis\s+is\s+(?:fine|intended|safe)\b/i,
   /\bincorrect\s+(?:finding|flag|warning|suggestion)\b/i,
 ];
 
@@ -109,7 +119,7 @@ const DEFER_PATTERNS: readonly RegExp[] = [
   /\btracked\s+in\s+#?\d+/i,
   /\bwon'?t\s+fix\b/i,
   /\b(?:later|future|subsequent|backlog)\b/i,
-  /\bTODO\b/,
+  /\bTODO\b/i, // /i for parity with every other bank (greptile #2230 :112 — "todo: track this")
 ];
 
 /** superseded decline (UNLABELED): the flagged code is gone. */

--- a/packages/core/src/spine/disposition-taxonomy.ts
+++ b/packages/core/src/spine/disposition-taxonomy.ts
@@ -69,15 +69,14 @@ export interface DispositionComment {
  */
 const FIX_PATTERNS: readonly RegExp[] = [
   /\bfixed\b/i,
-  // Confirmed-PAST construction only. The bare `addressed`/`applied`/`done` words
-  // were negation-blind ("this has not been addressed", "not applied", "Well done,
-  // but this still needs work") and minted false TPs (greptile #2230 P1 +
-  // strategy-claude loose-token note). The canonical bare accept `fixed` is kept;
-  // finer negation handling is the 5d-ii real-corpus measure-first task
-  // (strategy-claude RULED #4 run-first), not a blind tighten here.
+  // Confirmed-PAST construction only. The bare `addressed`/`applied`/`done` words —
+  // and the praise words `good catch`/`nice catch` (CR #2230 round-2) — were
+  // negation-blind ("this has not been addressed", "not a good catch …") and, in the
+  // praise case, not even a fix CONFIRMATION (acknowledging a real finding ≠ acting
+  // on it). All minted false TPs. The canonical bare accept `fixed` is kept; the TP
+  // signal "good catch, fixed!" is still covered by `fixed`. Finer negation handling
+  // is the 5d-ii real-corpus measure-first task (strategy-claude RULED #4 run-first).
   /\b(?:has|have|now)\s+been\s+(?:fixed|addressed|applied)\b/i,
-  /\bgood\s+catch\b/i,
-  /\bnice\s+catch\b/i,
 ];
 
 /**
@@ -200,8 +199,9 @@ export function classifyDisposition(comments: ReadonlyArray<DispositionComment>)
   if (defer) return 'defer';
   if (style) return 'style';
 
-  // 6. Human spoke but no recognizable disposition (incl. fix+softDecline or
-  // fp+softDecline impurity that fell through) → ambiguous.
+  // 6. Reached only when fix=false AND fp=false AND no soft-decline matched — the
+  // human spoke but carried no recognizable disposition. (Impure label-bearing
+  // cases are already caught by the `fix || fp` guard above, never here.)
   return 'ambiguous';
 }
 

--- a/packages/core/src/spine/disposition-taxonomy.ts
+++ b/packages/core/src/spine/disposition-taxonomy.ts
@@ -1,0 +1,217 @@
+// ─── #709 ground-truth deriver — slice 5d-i: the closed disposition taxonomy ──
+//
+// The deterministic, LLM-FREE classifier that turns a held-out review thread's
+// human dispositions into a closed taxonomy class, then into a cert-run
+// ground-truth label (TP / FP / UNLABELED). It is the answer-key's labeling
+// primitive: slice 5d-iii enumerates the real `RuleFiring`s (via replay) and
+// joins each to a held-out disposition by span; THIS module decides what that
+// disposition MEANS.
+//
+// Contract (strategy#709 c.4762840182 + c.4764980503, RULED): the label SOURCE is
+// the disposition-derived DRAFT under a CLOSED taxonomy —
+//   accepted-fix                 ⟹ TP
+//   declined-as-false-positive   ⟹ FP
+//   scope · defer · superseded · style · ambiguous ⟹ UNLABELED (omit)
+// inheriting ADR-110/111 unchanged. Zero LLM-judge (that is #710 Phase-2); this
+// is a heuristic over the review text + the binary disposition vocabulary.
+//
+// Why a NEW classifier and not the binary `bot-review-parser` primitive
+// (codex panel, BLOCKING-3): that primitive intentionally over-matches the WHOLE
+// decline vocabulary to `declined` ("a lost lesson, never a laundered one",
+// mmnto-ai/totem#2124) — SAFE for keeping bad lessons out of mining, UNSAFE as a
+// cert FALSE-POSITIVE label. A "declined, tracked for later / too broad for this
+// PR" (a scope/defer decline) is NOT evidence the code is clean; mapping it to FP
+// would FAIL a sound rule. So this classifier PARTITIONS that vocabulary: only an
+// unambiguous correctness rebuttal ("false positive / by design / works as
+// intended") becomes FP; scope/defer/superseded/style declines stay UNLABELED.
+//
+// Conservative-by-construction (codex/gemini/agy/strategy-claude converged): only
+// an UNAMBIGUOUS accepted-fix → TP and an UNAMBIGUOUS declined-as-false-positive →
+// FP; every conflict, soft signal, or absent human disposition → UNLABELED. Under-
+// labeling routes to the scorer's `needsAdjudication` → HONEST-NEGATIVE (Tenet 4
+// fail-soft for the answer key), never a guessed PASS. The resolution flags
+// (`isResolved`/`isOutdated`) are disposition EVIDENCE, not determinative, and are
+// the span-join's concern (5d-iii) — this taxonomy is text-driven only, so a bare
+// `isResolved` thread never becomes TP on the flag alone (codex WARNING-5).
+
+import { isBotIdentity } from './selection-rule.js';
+import type { GroundTruthLabel } from './windtunnel-scorer.js';
+
+// ── The closed taxonomy ──────────────────────────────────────────────────────
+
+/**
+ * The closed disposition taxonomy (strategy#709 RULED). `accepted-fix` and
+ * `declined-as-false-positive` are the only LABEL-BEARING classes; the rest are
+ * deliberately UNLABELED outcomes — a valid-but-not-actioned decline is NOT
+ * evidence the code is clean, so it never labels a firing.
+ */
+export type DispositionClass =
+  | 'accepted-fix' // → TP
+  | 'declined-as-false-positive' // → FP
+  | 'scope' // → UNLABELED — valid finding, out of this PR's scope
+  | 'defer' // → UNLABELED — valid finding, deferred (later / tracked / won't-fix)
+  | 'superseded' // → UNLABELED — the flagged code was refactored/removed away
+  | 'style' // → UNLABELED — a stylistic nit / subjective preference
+  | 'ambiguous'; // → UNLABELED — no clear human disposition, or conflicting signals
+
+/** A single review-thread comment (the provider-neutral subset the taxonomy reads). */
+export interface DispositionComment {
+  author: string;
+  body: string;
+}
+
+// ── Pattern banks (the partition of the decline vocabulary) ──────────────────
+
+/**
+ * accepted-fix signal: a human confirmed the finding was actioned. A commit-SHA
+ * or `tracked-in-#` reference alone is NOT here — a tracked reference is a DEFER
+ * (the fix is future), and a bare SHA is too noisy to credit as acceptance.
+ */
+const FIX_PATTERNS: readonly RegExp[] = [
+  /\bfixed\b/i,
+  /\b(?:has|have|now)\s+been\s+(?:fixed|addressed|applied)\b/i,
+  /\baddressed\b/i,
+  /\bapplied\b/i,
+  /\bgood\s+catch\b/i,
+  /\bnice\s+catch\b/i,
+  /\bdone\b/i,
+];
+
+/**
+ * declined-as-false-positive signal: a CORRECTNESS rebuttal — the human asserts
+ * the code is correct and the finding is WRONG. This is the ONLY decline class
+ * that becomes an FP label, so the bank is kept tight to genuine correctness
+ * claims (not the broad pushback vocabulary the binary primitive matches).
+ */
+const FALSE_POSITIVE_PATTERNS: readonly RegExp[] = [
+  /\bfalse\s+positive\b/i,
+  /\bnot\s+a\s+(?:bug|problem|issue|real)\b/i,
+  /\b(?:works|working|behaves)\s+as\s+(?:intended|designed|expected)\b/i,
+  /\bby\s+design\b/i,
+  /\bintentional(?:ly)?\b/i,
+  /\bnot\s+(?:applicable|relevant|correct|an\s+issue)\b/i,
+  /\bthis\s+is\s+(?:correct|fine|intended|safe)\b/i,
+  /\bincorrect\s+(?:finding|flag|warning|suggestion)\b/i,
+];
+
+/** scope decline (UNLABELED): valid finding, not this PR. */
+const SCOPE_PATTERNS: readonly RegExp[] = [
+  /\bout\s+of\s+scope\b/i,
+  /\btoo\s+broad\b/i,
+  /\b(?:separate|different|another|its\s+own)\s+PR\b/i,
+  /\bnot\s+(?:in\s+)?this\s+PR\b/i,
+  /\bunrelated\b/i,
+];
+
+/** defer decline (UNLABELED): valid finding, postponed. `won't fix` lands here (conservative — not an FP). */
+const DEFER_PATTERNS: readonly RegExp[] = [
+  /\bfollow[\s-]?up\b/i,
+  /\btracked\s+in\s+#?\d+/i,
+  /\bwon'?t\s+fix\b/i,
+  /\b(?:later|future|subsequent|backlog)\b/i,
+  /\bTODO\b/,
+];
+
+/** superseded decline (UNLABELED): the flagged code is gone. */
+const SUPERSEDED_PATTERNS: readonly RegExp[] = [
+  /\b(?:refactored|rewritten|removed|deleted|moved)\b/i,
+  /\bno\s+longer\s+(?:applies|exists|relevant|present)\b/i,
+  /\bobsolete\b/i,
+];
+
+/** style decline (UNLABELED): subjective / cosmetic. */
+const STYLE_PATTERNS: readonly RegExp[] = [
+  /\bnit(?:pick)?\b/i,
+  /\b(?:just\s+a\s+)?preference\b/i,
+  /\bsubjective\b/i,
+  /\bstylistic\b/i,
+  /\bcosmetic\b/i,
+];
+
+const matchesAny = (text: string, bank: readonly RegExp[]): boolean =>
+  bank.some((p) => p.test(text));
+
+// ── The classifier ───────────────────────────────────────────────────────────
+
+/**
+ * Classify a held-out review thread's disposition under the closed taxonomy.
+ *
+ * Reads the HUMAN (non-bot) comments only — the human is the one who disposes; a
+ * bot's own follow-up is not a disposition (and `isResolved` alone is never TP,
+ * codex WARNING-5). Conservative precedence:
+ *   1. No human disposition comment              → ambiguous (UNLABELED)
+ *   2. accepted-fix AND false-positive present   → ambiguous (conflicting signals)
+ *   3. accepted-fix, no decline of any kind      → accepted-fix (TP)
+ *   4. false-positive, no fix and no soft decline → declined-as-false-positive (FP)
+ *   5. otherwise a soft decline present          → scope | defer | superseded | style (UNLABELED)
+ *   6. no recognizable signal                    → ambiguous (UNLABELED)
+ *
+ * Steps 3/4 require a CLEAN signal: a fix that is also scoped/deferred, or an FP
+ * rebuttal that is also a scope/defer decline, collapses to ambiguous — the
+ * answer key must not credit a contradictory disposition. This defeats codex's
+ * falsifying case ("declined, too broad / tracked for later" never becomes FP).
+ */
+export function classifyDisposition(comments: ReadonlyArray<DispositionComment>): DispositionClass {
+  const humanText = comments
+    .filter((c) => !isBotIdentity(c.author) && c.body.trim().length > 0)
+    .map((c) => c.body);
+
+  if (humanText.length === 0) return 'ambiguous';
+
+  const joined = humanText.join('\n');
+  const fix = matchesAny(joined, FIX_PATTERNS);
+  const fp = matchesAny(joined, FALSE_POSITIVE_PATTERNS);
+  const scope = matchesAny(joined, SCOPE_PATTERNS);
+  const defer = matchesAny(joined, DEFER_PATTERNS);
+  const superseded = matchesAny(joined, SUPERSEDED_PATTERNS);
+  const style = matchesAny(joined, STYLE_PATTERNS);
+  const softDecline = scope || defer || superseded || style;
+
+  // 2. Conflicting label-bearing signals → never credit one over the other.
+  if (fix && fp) return 'ambiguous';
+
+  // 3. Clean accepted-fix: a fix that is ALSO scoped/deferred is contradictory.
+  if (fix && !softDecline) return 'accepted-fix';
+
+  // 4. Clean correctness rebuttal: an FP that is ALSO a soft decline is impure.
+  if (fp && !softDecline) return 'declined-as-false-positive';
+
+  // A label-bearing signal that reached here is IMPURE (it co-occurs with a soft
+  // decline — "fixed the related part; the rest is out of scope", "arguably a
+  // false positive, but tracked in #99"). We cannot attribute the fix/rebuttal to
+  // THIS firing's span, so it credits neither a label nor a soft-decline class.
+  if (fix || fp) return 'ambiguous';
+
+  // 5. A pure soft decline (no label-bearing signal) → its specific UNLABELED
+  // class (precedence: the most label-protective first — a scope/superseded claim
+  // is a stronger "do not label" than a style nit).
+  if (scope) return 'scope';
+  if (superseded) return 'superseded';
+  if (defer) return 'defer';
+  if (style) return 'style';
+
+  // 6. Human spoke but no recognizable disposition (incl. fix+softDecline or
+  // fp+softDecline impurity that fell through) → ambiguous.
+  return 'ambiguous';
+}
+
+/**
+ * Project a taxonomy class onto a cert-run ground-truth label. The two
+ * label-bearing classes map to TP/FP; every UNLABELED class returns `null` — the
+ * deriver OMITS the firing's labelId from `ground-truth-labels.json`, and the
+ * scorer routes the un-keyed firing to `needsAdjudication` → HONEST-NEGATIVE.
+ */
+export function dispositionToLabel(cls: DispositionClass): GroundTruthLabel | null {
+  switch (cls) {
+    case 'accepted-fix':
+      return 'TP';
+    case 'declined-as-false-positive':
+      return 'FP';
+    case 'scope':
+    case 'defer':
+    case 'superseded':
+    case 'style':
+    case 'ambiguous':
+      return null;
+  }
+}


### PR DESCRIPTION
## What

The first sub-slice (5d-i of 3) of the cert-corpus **ground-truth label deriver** (`mmnto-ai/totem-strategy#709`) — the last piece before a runnable Gate-1 cert run. This ships the **LLM-free closed disposition taxonomy classifier** (pure, core, zero-IO):

- `classifyDisposition(comments) → DispositionClass`
- `dispositionToLabel(class) → 'TP' | 'FP' | null`

under the RULED closed taxonomy (#709 c.4762840182 / c.4764980503):

| class | label |
|---|---|
| `accepted-fix` | **TP** |
| `declined-as-false-positive` | **FP** |
| `scope` · `defer` · `superseded` · `style` · `ambiguous` | **UNLABELED** (omit) |

## Why a new classifier (not the binary `bot-review-parser` primitive)

The existing primitive intentionally over-matches the **whole** decline vocabulary to `declined` ("a lost lesson, never a laundered one", #2124) — safe for keeping bad lessons out of mining, **unsafe as a cert FALSE-POSITIVE label**. A "declined, tracked for later / too broad for this PR" (a scope/defer decline) is **not** evidence the code is clean; mapping it to FP would FAIL a sound rule. So this classifier **partitions** the vocabulary: only an unambiguous correctness rebuttal ("false positive / by design / works as intended") becomes FP; scope/defer/superseded/style declines stay UNLABELED.

**Conservative-by-construction:** every conflict, impurity, or absent human disposition collapses to UNLABELED → the scorer's `needsAdjudication` → HONEST-NEGATIVE (Tenet 4 fail-soft for the answer key), never a guessed PASS. Resolution flags (`isResolved`/`isOutdated`) are the span-join's concern (5d-iii), so a bare `isResolved` thread is never TP.

## Cohort-panel-ratified

Pre-build panel (codex / agy / gemini, distinct lenses) + strategy-claude **RULED on #709 c.4764980503** — no contract change. This sub-slice implements:
- codex BLOCKING-3 (dedicated 5-way classifier, binary parser as input material only; conservative under-labeling)
- gemini (extend-via-new-classifier, abstention-as-UNLABELED, core purity)

## Tests

32 unit tests, including codex's exact **falsifying case** ("declined, too broad / tracked for later" never becomes FP), conflict/impurity → ambiguous, and bot-reply-is-not-a-disposition. Full gate green: build · 2757 core tests · ESLint · prettier.

## Scope

Part of the strategy#709 deriver — sub-slice 5d-i of 3; this **does not close** #709. Next: 5d-ii (held-out disposition fetch + freeze + integrity digest), 5d-iii (the deriver orchestrator + `derive-labels` command). Changeset is **consciously deferred** to 5d-iii (the user-facing command) — 5d-i is an internal core building block with no consumer yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)