### PR TITLE
feat(spine): Gate-1 label-deriver 5d-ii — held-out disposition source (corpus-dispositions + fetch + integrity) (strategy#709)

### DIFF
--- a/packages/cli/src/commands/spine-corpus-disposition-source.test.ts
+++ b/packages/cli/src/commands/spine-corpus-disposition-source.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildCorpusDispositionsQuery,
+  CorpusDispositionSourceAdapter,
+  mapDispositionThreads,
+} from './spine-corpus-disposition-source.js';
+import type { GhExec } from './spine-review-thread-source.js';
+
+const OWNER = 'mmnto-ai';
+const NAME = 'liquid-city';
+const MERGE_OID = 'a'.repeat(40);
+
+interface ThreadOpt {
+  id?: string;
+  isResolved?: boolean;
+  isOutdated?: boolean;
+  path?: string;
+  line?: number | null;
+  originalLine?: number | null;
+  comments?: Array<{
+    databaseId?: number | null;
+    diffHunk?: string | null;
+    login: string | null;
+    body: string;
+  }>;
+  commentsHasNext?: boolean;
+}
+
+function gqlThread(t: ThreadOpt) {
+  return {
+    id: t.id ?? 'PRRT_1',
+    isResolved: t.isResolved ?? false,
+    isOutdated: t.isOutdated ?? false,
+    path: t.path ?? 'src/a.ts',
+    line: t.line === undefined ? 40 : t.line,
+    originalLine: t.originalLine === undefined ? 38 : t.originalLine,
+    comments: {
+      pageInfo: { hasNextPage: t.commentsHasNext ?? false },
+      nodes: (t.comments ?? [{ login: 'jane', body: 'a note' }]).map((c) => ({
+        databaseId: c.databaseId === undefined ? 1001 : c.databaseId,
+        diffHunk: c.diffHunk === undefined ? '@@ -1 +1 @@\n+x' : c.diffHunk,
+        author: c.login === null ? null : { login: c.login },
+        body: c.body,
+      })),
+    },
+  };
+}
+
+function okPayload(opts?: {
+  mergeOid?: string | null;
+  threads?: ThreadOpt[];
+  threadsHasNext?: boolean;
+}): string {
+  return JSON.stringify({
+    data: {
+      repository: {
+        pullRequest: {
+          mergeCommit: opts?.mergeOid === null ? null : { oid: opts?.mergeOid ?? MERGE_OID },
+          reviewThreads: {
+            pageInfo: { hasNextPage: opts?.threadsHasNext ?? false },
+            nodes: (opts?.threads ?? []).map(gqlThread),
+          },
+        },
+      },
+    },
+  });
+}
+
+function stubExec(payload: string): GhExec & { calls: string[][] } {
+  const calls: string[][] = [];
+  const fn = ((_command: string, args: string[]) => {
+    calls.push(args);
+    return payload;
+  }) as GhExec & { calls: string[][] };
+  fn.calls = calls;
+  return fn;
+}
+
+describe('buildCorpusDispositionsQuery', () => {
+  it('REQUESTS the span anchors + audit ids that the mining query lacks', () => {
+    const q = buildCorpusDispositionsQuery(OWNER, NAME, 42);
+    for (const field of ['diffHunk', 'line', 'originalLine', 'databaseId', 'id']) {
+      expect(q).toContain(field);
+    }
+  });
+
+  it('does NOT add an isResolved:false server filter (surface, don’t filter)', () => {
+    const q = buildCorpusDispositionsQuery(OWNER, NAME, 42);
+    expect(q).toContain('isResolved');
+    expect(q).not.toMatch(/isResolved\s*:/); // no argument form
+  });
+});
+
+describe('mapDispositionThreads', () => {
+  it('lifts the root comment diffHunk to the thread span + preserves ids/flags', () => {
+    const [mapped] = mapDispositionThreads([
+      gqlThread({
+        id: 'PRRT_9',
+        isResolved: true,
+        isOutdated: false,
+        path: 'src/foo.ts',
+        line: 12,
+        originalLine: 10,
+        comments: [
+          {
+            databaseId: 7,
+            diffHunk: '@@ root @@\n+rootline',
+            login: 'coderabbitai[bot]',
+            body: 'finding',
+          },
+          { databaseId: 8, diffHunk: '@@ reply @@', login: 'jane', body: 'fixed' },
+        ],
+      }),
+    ]);
+    expect(mapped).toEqual({
+      threadId: 'PRRT_9',
+      path: 'src/foo.ts',
+      line: 12,
+      originalLine: 10,
+      diffHunk: '@@ root @@\n+rootline',
+      isResolved: true,
+      isOutdated: false,
+      comments: [
+        { commentId: 7, author: 'coderabbitai[bot]', body: 'finding' },
+        { commentId: 8, author: 'jane', body: 'fixed' },
+      ],
+    });
+  });
+
+  it('coerces a null author to "" and omits a null commentId / empty hunk', () => {
+    const [mapped] = mapDispositionThreads([
+      gqlThread({
+        line: null,
+        originalLine: null,
+        comments: [{ databaseId: null, diffHunk: null, login: null, body: 'x' }],
+      }),
+    ]);
+    expect(mapped?.diffHunk).toBe('');
+    expect(mapped?.line).toBeNull();
+    expect(mapped?.comments[0]).toEqual({ author: '', body: 'x' });
+  });
+});
+
+describe('CorpusDispositionSourceAdapter.fetch', () => {
+  it('CI hard-gate: throws on a live fetch in CI without ALLOW_LIVE_FETCH', async () => {
+    const adapter = new CorpusDispositionSourceAdapter({
+      owner: OWNER,
+      name: NAME,
+      exec: stubExec(okPayload()),
+      env: { CI: '1' },
+    });
+    await expect(adapter.fetch(42)).rejects.toThrow(/CI context/i);
+  });
+
+  it('CI hard-gate: ALLOW_LIVE_FETCH escapes the gate', async () => {
+    const adapter = new CorpusDispositionSourceAdapter({
+      owner: OWNER,
+      name: NAME,
+      exec: stubExec(okPayload({ threads: [{}] })),
+      env: { CI: '1', ALLOW_LIVE_FETCH: '1' },
+    });
+    const res = await adapter.fetch(42);
+    expect(res.pr).toBe(42);
+    expect(res.threads).toHaveLength(1);
+  });
+
+  it('maps a held-out PR to a span-anchored CorpusDisposition', async () => {
+    const adapter = new CorpusDispositionSourceAdapter({
+      owner: OWNER,
+      name: NAME,
+      exec: stubExec(okPayload({ threads: [{ path: 'src/z.ts' }] })),
+      env: {},
+    });
+    const res = await adapter.fetch(7);
+    expect(res).toMatchObject({ pr: 7, mergeCommitSha: MERGE_OID });
+    expect(res.threads[0]?.path).toBe('src/z.ts');
+  });
+
+  it('fails loud on a paginated thread set (no silent shrink)', async () => {
+    const adapter = new CorpusDispositionSourceAdapter({
+      owner: OWNER,
+      name: NAME,
+      exec: stubExec(okPayload({ threads: [{}], threadsHasNext: true })),
+      env: {},
+    });
+    await expect(adapter.fetch(7)).rejects.toThrow(/pagination unsupported/i);
+  });
+
+  it('fails loud when a held-out PR has no merge commit', async () => {
+    const adapter = new CorpusDispositionSourceAdapter({
+      owner: OWNER,
+      name: NAME,
+      exec: stubExec(okPayload({ mergeOid: null })),
+      env: {},
+    });
+    await expect(adapter.fetch(7)).rejects.toThrow(/no merge commit/i);
+  });
+});

--- a/packages/cli/src/commands/spine-corpus-disposition-source.test.ts
+++ b/packages/cli/src/commands/spine-corpus-disposition-source.test.ts
@@ -196,4 +196,14 @@ describe('CorpusDispositionSourceAdapter.fetch', () => {
     });
     await expect(adapter.fetch(7)).rejects.toThrow(/no merge commit/i);
   });
+
+  it('surfaces a GitHub GraphQL error message, not a misleading "unparseable" (greptile #2231)', async () => {
+    const adapter = new CorpusDispositionSourceAdapter({
+      owner: OWNER,
+      name: NAME,
+      exec: stubExec(JSON.stringify({ errors: [{ message: 'Bad credentials' }] })),
+      env: {},
+    });
+    await expect(adapter.fetch(7)).rejects.toThrow(/GraphQL error.*Bad credentials/i);
+  });
 });

--- a/packages/cli/src/commands/spine-corpus-disposition-source.ts
+++ b/packages/cli/src/commands/spine-corpus-disposition-source.ts
@@ -193,7 +193,10 @@ export class CorpusDispositionSourceAdapter {
           cwd: this.cwd,
           timeout: GH_TIMEOUT_MS,
           maxBuffer: GH_MAX_BUFFER,
-          env: { ...process.env, GH_PROMPT_DISABLED: '1' },
+          // Honor the injected env end-to-end (GCA #2231): `this.env` defaults to
+          // process.env live, so no behavior change there, but a fully-injected env
+          // now controls the subprocess too, not just the CI hard-gate check.
+          env: { ...this.env, GH_PROMPT_DISABLED: '1' },
         });
     })();
     return this.execPromise;
@@ -228,9 +231,37 @@ export class CorpusDispositionSourceAdapter {
       );
     }
 
+    let json: unknown;
+    try {
+      json = JSON.parse(raw);
+    } catch (err) {
+      throw new TotemError(
+        'CONFIG_INVALID',
+        `corpus-disposition fetch: gh returned non-JSON for held-out PR #${pr}.`,
+        'The gh GraphQL response was not valid JSON.',
+        err,
+      );
+    }
+    // GitHub GraphQL returns HTTP 200 with `{ errors: [...] }` on auth/scope/query
+    // faults — JSON.parse succeeds but `data` is absent, so a bare schema-parse would
+    // throw a misleading "unparseable". Surface the REAL gh error first so a by-hand
+    // freeze diagnoses fast (greptile #2231 P2).
+    if (
+      json !== null &&
+      typeof json === 'object' &&
+      Array.isArray((json as { errors?: unknown }).errors)
+    ) {
+      const errs = (json as { errors: Array<{ message?: string }> }).errors;
+      const first = errs[0]?.message ?? 'unknown GraphQL error';
+      throw new TotemError(
+        'CONFIG_INVALID',
+        `corpus-disposition fetch: GitHub GraphQL error for held-out PR #${pr}: ${first}`,
+        'Check gh auth + token scope for the repo (the freeze is all-or-nothing — no silent skip).',
+      );
+    }
     let parsed: z.infer<typeof GqlResponseSchema>;
     try {
-      parsed = GqlResponseSchema.parse(JSON.parse(raw));
+      parsed = GqlResponseSchema.parse(json);
     } catch (err) {
       throw new TotemError(
         'CONFIG_INVALID',

--- a/packages/cli/src/commands/spine-corpus-disposition-source.ts
+++ b/packages/cli/src/commands/spine-corpus-disposition-source.ts
@@ -1,0 +1,289 @@
+/**
+ * #709 ground-truth deriver — slice 5d-ii: the live held-out disposition adapter.
+ *
+ * Fetches a HELD-OUT corpus PR's review threads WITH span anchoring (the comment
+ * `diffHunk` + the thread line) — the data slice 5d-iii binds a `RuleFiring`'s
+ * matched line to a disposition by content/invariant. Distinct from the mining
+ * `ReviewThreadSourceAdapter` (which fetches TRAIN PRs and carries no span): the
+ * answer key labels HELD-OUT firings, so it needs the held-out PRs' threads,
+ * span-anchored, and a richer `CorpusDisposition` payload (core schema).
+ *
+ * Like the mining adapter, this SURFACES `isResolved`/`isOutdated` and never
+ * filters on them (the #2201 "surface, don't filter" discipline; the taxonomy +
+ * span-bind decide, 5d-i/5d-iii). Unlike it, a fetch failure FAILS LOUD: the
+ * disposition freeze is a by-hand, all-or-nothing producer step (a silent skip
+ * would under-populate the answer-key provenance), so a network/parse/pagination
+ * fault throws a structured TotemError rather than a discriminated skip.
+ *
+ * CI HARD-GATE (agy panel): a live GitHub fetch must NEVER run in CI — the
+ * certifying run is zero-network and reads only the FROZEN `corpus-dispositions.json`.
+ * `fetch` throws if `CI` is set without an explicit `ALLOW_LIVE_FETCH` escape, so
+ * an accidental test/CI invocation fails loud instead of hitting the network.
+ *
+ * Reuses the established `gh` CLI exec pattern (Tenet-21 — no bespoke GraphQL
+ * client). The `exec` seam is injectable so the query-spy + mapping + CI-gate
+ * tests run fully offline.
+ */
+
+import { z } from 'zod';
+
+// Type-only import from '@mmnto/totem'; values are lazy-loaded in the exec seam.
+import type { CorpusDisposition, CorpusDispositionThread } from '@mmnto/totem';
+
+import type { GhExec } from './spine-review-thread-source.js';
+
+// ─── Named constants ─────────────────────────────────
+
+const GH_TIMEOUT_MS = 60_000;
+const GH_MAX_BUFFER = 10 * 1024 * 1024;
+/** Single page; a payload past one page fails LOUD rather than silently shrinking the provenance. */
+const PAGE_SIZE = 100;
+
+// ─── GraphQL response schema (Zod at the IO boundary only) ───────────────────
+
+const PageInfoSchema = z.object({ hasNextPage: z.boolean() });
+
+const GqlCommentSchema = z.object({
+  // databaseId is the audit-anchor the evidence-ref points at (5d-iii). Nullable for system rows.
+  databaseId: z.number().int().nullable(),
+  // diffHunk is the content span the firing binds to; '' for an outdated/synthetic comment.
+  diffHunk: z.string().nullable(),
+  author: z.object({ login: z.string() }).nullable(),
+  body: z.string(),
+});
+
+const GqlThreadSchema = z.object({
+  id: z.string(),
+  isResolved: z.boolean(),
+  isOutdated: z.boolean(),
+  path: z.string(),
+  line: z.number().int().nullable(),
+  originalLine: z.number().int().nullable(),
+  comments: z.object({
+    pageInfo: PageInfoSchema,
+    nodes: z.array(GqlCommentSchema),
+  }),
+});
+
+const GqlResponseSchema = z.object({
+  data: z.object({
+    repository: z
+      .object({
+        pullRequest: z
+          .object({
+            mergeCommit: z.object({ oid: z.string() }).nullable(),
+            reviewThreads: z.object({
+              pageInfo: PageInfoSchema,
+              nodes: z.array(GqlThreadSchema),
+            }),
+          })
+          .nullable(),
+      })
+      .nullable(),
+  }),
+});
+
+// ─── Query construction ──────────────────────────────
+
+/**
+ * Build the held-out `reviewThreads` GraphQL query. ADDITIVELY requests the span
+ * anchors (`line`, `originalLine`, comment `diffHunk`) + the audit ids
+ * (`thread.id`, comment `databaseId`) on top of the mining query's
+ * `isResolved`/`isOutdated`/`path`/`author`/`body`. It deliberately does NOT add
+ * an `isResolved: false` server filter (the "surface, don't filter" ruling).
+ * Exported for the query-spy test.
+ */
+export function buildCorpusDispositionsQuery(owner: string, name: string, pr: number): string {
+  return `query {
+  repository(owner: ${JSON.stringify(owner)}, name: ${JSON.stringify(name)}) {
+    pullRequest(number: ${pr}) {
+      mergeCommit { oid }
+      reviewThreads(first: ${PAGE_SIZE}) {
+        pageInfo { hasNextPage }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          originalLine
+          comments(first: ${PAGE_SIZE}) {
+            pageInfo { hasNextPage }
+            nodes {
+              databaseId
+              diffHunk
+              author { login }
+              body
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+}
+
+// ─── Mapping ─────────────────────────────────────────
+
+/**
+ * Map validated GraphQL thread nodes to `CorpusDispositionThread[]`. The thread's
+ * span source `diffHunk` is the ROOT (first) comment's hunk — the finding's
+ * anchor; a thread with no comments carries ''. A null author (deleted/ghost)
+ * coerces to '' (a non-bot empty author core's logic handles). Pure — exported
+ * for the mapping test.
+ */
+export function mapDispositionThreads(
+  nodes: z.infer<typeof GqlThreadSchema>[],
+): CorpusDispositionThread[] {
+  return nodes.map((t) => ({
+    threadId: t.id,
+    path: t.path,
+    line: t.line,
+    originalLine: t.originalLine,
+    // The root comment's hunk is the finding's span; '' when absent (outdated/empty thread).
+    diffHunk: t.comments.nodes[0]?.diffHunk ?? '',
+    isResolved: t.isResolved,
+    isOutdated: t.isOutdated,
+    comments: t.comments.nodes.map((c) => ({
+      ...(c.databaseId !== null ? { commentId: c.databaseId } : {}),
+      author: c.author?.login ?? '',
+      body: c.body,
+    })),
+  }));
+}
+
+// ─── The adapter ─────────────────────────────────────
+
+export interface CorpusDispositionSourceOptions {
+  owner: string;
+  name: string;
+  cwd?: string;
+  /** Injectable exec seam (tests). Defaults to a `gh`-backed `safeExec`. */
+  exec?: GhExec;
+  /** Process env (injected in tests) — the CI hard-gate reads it. Defaults to `process.env`. */
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * The live held-out `corpus-dispositions` source. By-hand producer-time only
+ * (never CI — the hard-gate enforces it). `fetch` throws loud on any fault.
+ */
+export class CorpusDispositionSourceAdapter {
+  private readonly owner: string;
+  private readonly name: string;
+  private readonly cwd: string;
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly injectedExec: GhExec | undefined;
+  private execPromise: Promise<GhExec> | undefined;
+
+  constructor(opts: CorpusDispositionSourceOptions) {
+    this.owner = opts.owner;
+    this.name = opts.name;
+    this.cwd = opts.cwd ?? process.cwd();
+    this.env = opts.env ?? process.env;
+    this.injectedExec = opts.exec;
+  }
+
+  private async resolveExec(): Promise<GhExec> {
+    if (this.injectedExec) return this.injectedExec;
+    this.execPromise ??= (async () => {
+      const { safeExec } = await import('@mmnto/totem');
+      return (command: string, args: string[]) =>
+        safeExec(command, args, {
+          cwd: this.cwd,
+          timeout: GH_TIMEOUT_MS,
+          maxBuffer: GH_MAX_BUFFER,
+          env: { ...process.env, GH_PROMPT_DISABLED: '1' },
+        });
+    })();
+    return this.execPromise;
+  }
+
+  async fetch(pr: number): Promise<CorpusDisposition> {
+    const { TotemError } = await import('@mmnto/totem');
+
+    // CI hard-gate (agy): a live fetch in CI is a contract violation — the cert run
+    // is zero-network and reads only the frozen fixture. Fail loud, never the network.
+    if (this.env['CI'] && !this.env['ALLOW_LIVE_FETCH']) {
+      throw new TotemError(
+        'CONFIG_INVALID',
+        'corpus-disposition fetch: live GitHub fetch attempted in a CI context.',
+        'fetch-dispositions is a by-hand producer step; the cert run reads the frozen ' +
+          'corpus-dispositions.json. Set ALLOW_LIVE_FETCH=1 only for a deliberate live freeze.',
+      );
+    }
+
+    const query = buildCorpusDispositionsQuery(this.owner, this.name, pr);
+    const exec = await this.resolveExec();
+
+    let raw: string;
+    try {
+      raw = exec('gh', ['api', 'graphql', '-f', `query=${query}`]);
+    } catch (err) {
+      throw new TotemError(
+        'CONFIG_INVALID',
+        `corpus-disposition fetch: gh graphql failed for held-out PR #${pr}.`,
+        'Verify gh auth + repo access (the freeze is all-or-nothing — no silent skip).',
+        err,
+      );
+    }
+
+    let parsed: z.infer<typeof GqlResponseSchema>;
+    try {
+      parsed = GqlResponseSchema.parse(JSON.parse(raw));
+    } catch (err) {
+      throw new TotemError(
+        'CONFIG_INVALID',
+        `corpus-disposition fetch: payload unparseable for held-out PR #${pr}.`,
+        'The gh GraphQL response did not match the expected shape.',
+        err,
+      );
+    }
+
+    const repo = parsed.data.repository;
+    if (!repo) {
+      throw new TotemError(
+        'CONFIG_INVALID',
+        `corpus-disposition fetch: repository ${this.owner}/${this.name} not found or inaccessible (PR #${pr}).`,
+        'Check owner/name + token scope.',
+      );
+    }
+    const pull = repo.pullRequest;
+    if (!pull) {
+      throw new TotemError(
+        'CONFIG_INVALID',
+        `corpus-disposition fetch: held-out PR #${pr} not found in ${this.owner}/${this.name}.`,
+        'Verify the split heldOut set matches the lc repo.',
+      );
+    }
+    const mergeCommitSha = pull.mergeCommit?.oid?.toLowerCase();
+    if (!mergeCommitSha) {
+      throw new TotemError(
+        'CONFIG_INVALID',
+        `corpus-disposition fetch: held-out PR #${pr} has no merge commit oid.`,
+        'A held-out corpus PR must be merged (lc is squash-merge).',
+      );
+    }
+
+    // No-silent-shrink (§6): a paginated payload fails loud rather than freezing a
+    // partial provenance set (the integrity digest must cover the COMPLETE threads).
+    if (pull.reviewThreads.pageInfo.hasNextPage) {
+      throw new TotemError(
+        'CONFIG_INVALID',
+        `corpus-disposition fetch: held-out PR #${pr} has more than ${PAGE_SIZE} review threads (pagination unsupported).`,
+        'Increase PAGE_SIZE or add pagination (TODO #2199) before freezing this corpus.',
+      );
+    }
+    for (const t of pull.reviewThreads.nodes) {
+      if (t.comments.pageInfo.hasNextPage) {
+        throw new TotemError(
+          'CONFIG_INVALID',
+          `corpus-disposition fetch: PR #${pr} thread ${t.id} has more than ${PAGE_SIZE} comments (pagination unsupported).`,
+          'Increase PAGE_SIZE or add pagination before freezing this corpus.',
+        );
+      }
+    }
+
+    return { pr, mergeCommitSha, threads: mapDispositionThreads(pull.reviewThreads.nodes) };
+  }
+}

--- a/packages/cli/src/commands/spine-fetch-dispositions.test.ts
+++ b/packages/cli/src/commands/spine-fetch-dispositions.test.ts
@@ -112,7 +112,9 @@ describe('fetchDispositionsCommand', () => {
     writeFixtures(dir);
   });
   afterEach(() => {
-    fs.rmSync(dir, { recursive: true, force: true });
+    // maxRetries/retryDelay: the repo convention for temp-dir teardown — guards the
+    // Windows file-lock ENOTEMPTY flake (describe.test.ts / doctor.test.ts pattern).
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
 
   it('freezes corpus-dispositions.json for the corpus held-out PRs only (5, not 7/9)', async () => {

--- a/packages/cli/src/commands/spine-fetch-dispositions.test.ts
+++ b/packages/cli/src/commands/spine-fetch-dispositions.test.ts
@@ -170,4 +170,15 @@ describe('fetchDispositionsCommand', () => {
       }),
     ).rejects.toThrow(/no held-out CORPUS PRs/i);
   });
+
+  it('rejects a non-"owner/name" lock repo before any fetch (greptile #2231)', async () => {
+    // A 3-part repo ("github.com/owner/name") must fail at parse, not slip through
+    // as owner="github.com". No injected source → the live repo-parse path runs.
+    const lock = JSON.parse(fs.readFileSync(path.join(dir, 'windtunnel.lock.json'), 'utf-8'));
+    lock.corpus.repo = 'github.com/mmnto-ai/liquid-city';
+    fs.writeFileSync(path.join(dir, 'windtunnel.lock.json'), JSON.stringify(lock, null, 2));
+    await expect(
+      fetchDispositionsCommand({ lockPath: path.join(dir, 'windtunnel.lock.json'), cwd: dir }),
+    ).rejects.toThrow(/is not "owner\/name"/i);
+  });
 });

--- a/packages/cli/src/commands/spine-fetch-dispositions.test.ts
+++ b/packages/cli/src/commands/spine-fetch-dispositions.test.ts
@@ -1,0 +1,171 @@
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import type { CorpusDisposition } from '@mmnto/totem';
+
+import {
+  type CorpusDispositionSource,
+  corpusHeldOutPrs,
+  fetchDispositionsCommand,
+} from './spine-fetch-dispositions.js';
+
+describe('corpusHeldOutPrs', () => {
+  it('is heldOut minus the positive/negative controls, sorted ascending', () => {
+    expect(
+      corpusHeldOutPrs({
+        heldOutPrs: [9, 3, 7, 5, 11],
+        positiveControlPrs: [7],
+        negativeControlPrs: [11],
+      }),
+    ).toEqual([3, 5, 9]);
+  });
+
+  it('is empty when every held-out PR is a control', () => {
+    expect(
+      corpusHeldOutPrs({ heldOutPrs: [7, 11], positiveControlPrs: [7], negativeControlPrs: [11] }),
+    ).toEqual([]);
+  });
+});
+
+// ─── Command integration (temp gate-1 dir, injected fake source) ─────────────
+
+const SHA40 = (n: number): string => n.toString(16).padStart(40, '0');
+
+function writeFixtures(dir: string): void {
+  const lock = {
+    schema: 'windtunnel.lock.v1',
+    canonicalPath: '.totem/spine/gate-1/windtunnel.lock.json',
+    gate: 'gate-1',
+    phase: 'certifying',
+    corpus: {
+      repo: 'mmnto-ai/liquid-city',
+      selectionRule: {
+        state: 'merged',
+        predicate: 'code-touching',
+        window: { type: 'all' },
+        asOfCommit: 'a'.repeat(40),
+        codePathClassifier: { includeGlobs: ['**/*.ts'], excludeGlobs: [] },
+      },
+      resolvedPrs: [3, 5, 7, 9].map((n) => ({
+        pr: n,
+        mergeCommit: SHA40(n),
+        baseSha: 'b'.repeat(40),
+        headSha: 'd'.repeat(40),
+      })),
+    },
+    fpDefinition: { rubricRef: 'r', groundTruthRef: 'g', adjudicator: 'a', precisionFloor: 1.0 },
+    controls: {
+      positiveRef: 'controls/positive/',
+      negativeRef: 'controls/negative/',
+      integrity: { mechanism: 'sha', fixtureSha: 'e'.repeat(40) },
+    },
+    cullRateThreshold: 0.5,
+    exposureDenominator: {
+      activeRulesEvaluated: { floor: 2 },
+      filesTouchedInWindow: { floor: 0 },
+      positiveControlsExercised: { floor: 0 },
+    },
+  };
+  const split = {
+    asOfCommit: 'a'.repeat(40),
+    trainPrs: [3],
+    heldOutPrs: [5, 7, 9],
+    excludedPrs: [],
+    positiveControlPrs: [7],
+    negativeControlPrs: [9],
+    splitRule: { predicate: 'code-touching', cutIndex: 1 },
+  };
+  fs.writeFileSync(path.join(dir, 'windtunnel.lock.json'), JSON.stringify(lock, null, 2));
+  fs.writeFileSync(path.join(dir, 'split.json'), JSON.stringify(split, null, 2));
+}
+
+/** A fake source: one thread per PR, deterministic content. */
+const fakeSource: CorpusDispositionSource = {
+  async fetch(pr: number): Promise<CorpusDisposition> {
+    return {
+      pr,
+      mergeCommitSha: SHA40(pr),
+      threads: [
+        {
+          threadId: `T${pr}`,
+          path: `src/pr${pr}.ts`,
+          line: pr,
+          originalLine: pr - 1,
+          diffHunk: `@@ pr${pr} @@\n+line`,
+          isResolved: true,
+          isOutdated: false,
+          comments: [{ commentId: pr, author: 'coderabbitai[bot]', body: 'finding' }],
+        },
+      ],
+    };
+  },
+};
+
+describe('fetchDispositionsCommand', () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-fetch-disp-'));
+    writeFixtures(dir);
+  });
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('freezes corpus-dispositions.json for the corpus held-out PRs only (5, not 7/9)', async () => {
+    await fetchDispositionsCommand({
+      lockPath: path.join(dir, 'windtunnel.lock.json'),
+      cwd: dir,
+      source: fakeSource,
+    });
+    const written = JSON.parse(
+      fs.readFileSync(path.join(dir, 'corpus-dispositions.json'), 'utf-8'),
+    );
+    // heldOut [5,7,9], controls {7,9} → only PR 5 is a corpus disposition.
+    expect(written.map((d: CorpusDisposition) => d.pr)).toEqual([5]);
+    expect(written[0].threads[0].diffHunk).toBe('@@ pr5 @@\n+line');
+  });
+
+  it('stamps corpusDispositionsSha = sha256 of the exact on-disk bytes', async () => {
+    await fetchDispositionsCommand({
+      lockPath: path.join(dir, 'windtunnel.lock.json'),
+      cwd: dir,
+      source: fakeSource,
+    });
+    const bytes = fs.readFileSync(path.join(dir, 'corpus-dispositions.json'), 'utf-8');
+    const expected = createHash('sha256').update(bytes, 'utf-8').digest('hex');
+    const lock = JSON.parse(fs.readFileSync(path.join(dir, 'windtunnel.lock.json'), 'utf-8'));
+    expect(lock.controls.integrity.corpusDispositionsSha).toBe(expected);
+    expect(bytes.endsWith('\n')).toBe(true); // trailing newline (canonical)
+  });
+
+  it('is deterministic — a second run reproduces the identical digest', async () => {
+    const opts = { lockPath: path.join(dir, 'windtunnel.lock.json'), cwd: dir, source: fakeSource };
+    await fetchDispositionsCommand(opts);
+    const sha1 = JSON.parse(fs.readFileSync(path.join(dir, 'windtunnel.lock.json'), 'utf-8'))
+      .controls.integrity.corpusDispositionsSha;
+    await fetchDispositionsCommand(opts);
+    const sha2 = JSON.parse(fs.readFileSync(path.join(dir, 'windtunnel.lock.json'), 'utf-8'))
+      .controls.integrity.corpusDispositionsSha;
+    expect(sha2).toBe(sha1);
+  });
+
+  it('fails loud when the split has no held-out corpus PRs', async () => {
+    // Rewrite the split so every held-out PR is a control.
+    const split = JSON.parse(fs.readFileSync(path.join(dir, 'split.json'), 'utf-8'));
+    split.heldOutPrs = [7, 9];
+    split.positiveControlPrs = [7];
+    split.negativeControlPrs = [9];
+    fs.writeFileSync(path.join(dir, 'split.json'), JSON.stringify(split, null, 2));
+    await expect(
+      fetchDispositionsCommand({
+        lockPath: path.join(dir, 'windtunnel.lock.json'),
+        cwd: dir,
+        source: fakeSource,
+      }),
+    ).rejects.toThrow(/no held-out CORPUS PRs/i);
+  });
+});

--- a/packages/cli/src/commands/spine-fetch-dispositions.ts
+++ b/packages/cli/src/commands/spine-fetch-dispositions.ts
@@ -103,15 +103,19 @@ export async function fetchDispositionsCommand(opts: FetchDispositionsOptions): 
   // Build the live source from the lock's repo unless a fake is injected (tests).
   let source = opts.source;
   if (!source) {
-    const [owner, name] = lock.corpus.repo.split('/');
-    if (!owner || !name) {
+    // Require EXACTLY "owner/name" (greptile #2231 P2): a bare `!owner || !name`
+    // guard lets "github.com/owner/name" through as owner="github.com" → wrong
+    // fetch + a confusing "repo not found". The lock schema is plain z.string(),
+    // so this is the only parse-time defense.
+    const repoParts = lock.corpus.repo.split('/');
+    if (repoParts.length !== 2 || !repoParts[0] || !repoParts[1]) {
       throw new TotemError(
         'CONFIG_INVALID',
         `fetch-dispositions: lock.corpus.repo "${lock.corpus.repo}" is not "owner/name".`,
         'Set corpus.repo in the lock to the "owner/name" form.',
       );
     }
-    source = new CorpusDispositionSourceAdapter({ owner, name, cwd });
+    source = new CorpusDispositionSourceAdapter({ owner: repoParts[0], name: repoParts[1], cwd });
   }
 
   // Fetch each held-out corpus PR (fail-loud — the freeze is all-or-nothing).

--- a/packages/cli/src/commands/spine-fetch-dispositions.ts
+++ b/packages/cli/src/commands/spine-fetch-dispositions.ts
@@ -1,0 +1,160 @@
+// ─── #709 ground-truth deriver — slice 5d-ii: the fetch-dispositions command ──
+//
+// `totem spine windtunnel fetch-dispositions [--lock-path] [--output-dir]`
+// freezes `corpus-dispositions.json` — the held-out CORPUS PRs' review threads,
+// span-anchored — and stamps `controls.integrity.corpusDispositionsSha` into the
+// lock. A by-hand, live producer step (like `record`): NEVER CI (the adapter's
+// hard-gate enforces it). The certifying RUN never touches this; only the deriver
+// (5d-iii) reads the frozen file. This module is the I/O driver (load → fetch →
+// canonical write → stamp); the fetch + mapping live in the adapter, the schema
+// in core.
+
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import type { CorpusDisposition } from '@mmnto/totem';
+
+import { CorpusDispositionSourceAdapter } from './spine-corpus-disposition-source.js';
+
+const sha256Hex = (s: string): string => createHash('sha256').update(s, 'utf-8').digest('hex');
+
+/** The held-out disposition source — the live adapter in the CLI, a fake in tests. */
+export interface CorpusDispositionSource {
+  fetch(pr: number): Promise<CorpusDisposition>;
+}
+
+export interface FetchDispositionsOptions {
+  /** Path to the wind-tunnel lock (default `.totem/spine/gate-1/windtunnel.lock.json`). */
+  lockPath?: string;
+  /** Gate-1 output dir (default: the lock's dir). */
+  outputDir?: string;
+  /** Working dir (default `process.cwd()`; injected for tests). */
+  cwd?: string;
+  /** Injected source (tests). In the live CLI it is built from the lock's repo. */
+  source?: CorpusDispositionSource;
+}
+
+/**
+ * Compute the held-out CORPUS PRs whose dispositions label firings: `heldOutPrs`
+ * minus the positive/negative controls (positives are structural-TP; negatives
+ * are culled — neither reads a disposition). Deterministic ascending order.
+ */
+export function corpusHeldOutPrs(split: {
+  heldOutPrs: number[];
+  positiveControlPrs: number[];
+  negativeControlPrs: number[];
+}): number[] {
+  const controls = new Set([...split.positiveControlPrs, ...split.negativeControlPrs]);
+  return split.heldOutPrs.filter((pr) => !controls.has(pr)).sort((a, b) => a - b);
+}
+
+export async function fetchDispositionsCommand(opts: FetchDispositionsOptions): Promise<void> {
+  const {
+    WindtunnelLockSchema,
+    SplitArtifactSchema,
+    CorpusDispositionsSchema,
+    canonicalStringify,
+    TotemError,
+  } = await import('@mmnto/totem');
+
+  const cwd = opts.cwd ?? process.cwd();
+  const lockPath = opts.lockPath
+    ? path.resolve(cwd, opts.lockPath)
+    : path.resolve(cwd, '.totem/spine/gate-1/windtunnel.lock.json');
+  const gate1Dir = opts.outputDir ? path.resolve(cwd, opts.outputDir) : path.dirname(lockPath);
+
+  const readJsonFile = (p: string): unknown => {
+    let raw: string;
+    try {
+      raw = fs.readFileSync(p, 'utf-8');
+    } catch (err) {
+      throw new TotemError(
+        'CONFIG_INVALID',
+        `fetch-dispositions: required file not found at ${p}`,
+        'Run `spine windtunnel materialize` first (lock + split.json must exist).',
+        err,
+      );
+    }
+    try {
+      return JSON.parse(raw);
+    } catch (err) {
+      throw new TotemError(
+        'CONFIG_INVALID',
+        `fetch-dispositions: ${p} is not valid JSON`,
+        'Fix the JSON and retry.',
+        err,
+      );
+    }
+  };
+
+  const lock = WindtunnelLockSchema.parse(readJsonFile(lockPath));
+  const split = SplitArtifactSchema.parse(readJsonFile(path.join(gate1Dir, 'split.json')));
+
+  const prs = corpusHeldOutPrs(split);
+  if (prs.length === 0) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      'fetch-dispositions: the split has no held-out CORPUS PRs (all held-out PRs are controls).',
+      'A cert corpus needs ≥1 non-control held-out PR for the answer key to label.',
+    );
+  }
+
+  // Build the live source from the lock's repo unless a fake is injected (tests).
+  let source = opts.source;
+  if (!source) {
+    const [owner, name] = lock.corpus.repo.split('/');
+    if (!owner || !name) {
+      throw new TotemError(
+        'CONFIG_INVALID',
+        `fetch-dispositions: lock.corpus.repo "${lock.corpus.repo}" is not "owner/name".`,
+        'Set corpus.repo in the lock to the "owner/name" form.',
+      );
+    }
+    source = new CorpusDispositionSourceAdapter({ owner, name, cwd });
+  }
+
+  // Fetch each held-out corpus PR (fail-loud — the freeze is all-or-nothing).
+  const dispositions: CorpusDisposition[] = [];
+  for (const pr of prs) {
+    dispositions.push(await source.fetch(pr));
+  }
+  // Sort by pr for a deterministic frozen artifact (fetch order is already ascending,
+  // but sort defensively so an injected source can't perturb the on-disk bytes/digest).
+  dispositions.sort((a, b) => a.pr - b.pr);
+
+  // Write-side Zod validation (agy) BEFORE writing — never freeze a malformed artifact.
+  const validated = CorpusDispositionsSchema.parse(dispositions);
+
+  // Canonical write (sorted-key, LF + trailing newline) — the digest is over these
+  // exact on-disk bytes, so a freeze/deriver enforcer can sha256 the file directly.
+  fs.mkdirSync(gate1Dir, { recursive: true });
+  const dispositionsPath = path.join(gate1Dir, 'corpus-dispositions.json');
+  const text = `${canonicalStringify(validated, 2)}\n`;
+  const tmp = `${dispositionsPath}.tmp`;
+  fs.writeFileSync(tmp, text, 'utf-8');
+  fs.renameSync(tmp, dispositionsPath);
+  const corpusDispositionsSha = sha256Hex(text);
+
+  // Stamp the provenance digest into the lock (read-modify-write canonical), mirroring
+  // how `materialize` stamps prDiffsSha. Idempotent: re-running overwrites the field.
+  const stampedLock = {
+    ...lock,
+    controls: {
+      ...lock.controls,
+      integrity: { ...lock.controls.integrity, corpusDispositionsSha },
+    },
+  };
+  const lockText = `${canonicalStringify(stampedLock, 2)}\n`;
+  const lockTmp = `${lockPath}.tmp`;
+  fs.writeFileSync(lockTmp, lockText, 'utf-8');
+  fs.renameSync(lockTmp, lockPath);
+
+  const threadCount = validated.reduce((n, d) => n + d.threads.length, 0);
+  console.error(`[FetchDispositions] gate1Dir: ${gate1Dir}`);
+  console.error(`  held-out corpus PRs: ${prs.length} · review threads: ${threadCount}`);
+  console.error(
+    `  corpusDispositionsSha: ${corpusDispositionsSha} (stamped into ${path.basename(lockPath)})`,
+  );
+  console.error(`  Wrote corpus-dispositions.json (the deriver's frozen provenance).`);
+}

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -151,6 +151,36 @@ export async function freezeCommand(opts: FreezeOptions): Promise<void> {
     console.error(`  Re-materialize the cert corpus with \`spine windtunnel materialize\`.`);
   }
 
+  // #709 5d-ii: provenance heads-up on the corpus-dispositions.json digest. Unlike
+  // prDiffsSha (run-critical), this is PROVENANCE — the hard gate is the deriver
+  // (5d-iii) re-deriving over the frozen dispositions, so freeze is warn-only,
+  // mirroring the prDiffsSha/fixtureSha warn shape. CRLF→LF normalized.
+  if (lock.controls.integrity.corpusDispositionsSha) {
+    const dispositionsPath = path.join(path.dirname(lockPath), 'corpus-dispositions.json');
+    if (fs.existsSync(dispositionsPath)) {
+      const actual = createHash('sha256')
+        .update(fs.readFileSync(dispositionsPath, 'utf-8').replace(/\r\n/g, '\n'), 'utf-8')
+        .digest('hex');
+      if (actual !== lock.controls.integrity.corpusDispositionsSha) {
+        console.error(
+          `[WindtunnelFreeze] WARNING: controls.integrity.corpusDispositionsSha in lock (${lock.controls.integrity.corpusDispositionsSha}) does not match computed digest of corpus-dispositions.json (${actual})`,
+        );
+        console.error(
+          `  Re-run \`spine windtunnel fetch-dispositions\` or update corpusDispositionsSha and re-freeze.`,
+        );
+      } else {
+        console.error(`[WindtunnelFreeze] corpus-dispositions.json digest verified: ${actual}`);
+      }
+    } else {
+      console.error(
+        `[WindtunnelFreeze] WARNING: lock declares controls.integrity.corpusDispositionsSha but corpus-dispositions.json is missing at ${dispositionsPath} — the label-deriver will fail.`,
+      );
+      console.error(
+        `  Re-run \`spine windtunnel fetch-dispositions\` to co-locate it with the lock.`,
+      );
+    }
+  }
+
   console.error(`[WindtunnelFreeze] DONE — lock at ${lockPath} is schema-valid.`);
   console.error(`  Commit the lock file to establish the freeze proof (C3).`);
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1905,6 +1905,26 @@ windtunnelCmd
     }
   });
 
+windtunnelCmd
+  .command('fetch-dispositions')
+  .description(
+    'Freeze corpus-dispositions.json — the held-out PRs’ span-anchored review threads — and stamp corpusDispositionsSha (strategy#709, by-hand/live; never CI)',
+  )
+  .option(
+    '--lock-path <path>',
+    'Override the lock file path (default: .totem/spine/gate-1/windtunnel.lock.json)',
+  )
+  .option('--output-dir <dir>', 'Override the gate-1 output dir (default: the lock’s dir)')
+  .action(async (opts: { lockPath?: string; outputDir?: string }) => {
+    try {
+      const { fetchDispositionsCommand } = await import('./commands/spine-fetch-dispositions.js');
+      await fetchDispositionsCommand({ lockPath: opts.lockPath, outputDir: opts.outputDir });
+    } catch (err) {
+      handleError(err);
+      throw err;
+    }
+  });
+
 // Fire-and-forget: reap orphaned temp files from previous crashed runs
 reapOrphanedTempFiles(process.cwd(), '.totem').catch(() => {});
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -822,8 +822,6 @@ export type {
   CompileStageResult,
 } from './spine/compile.js';
 export { compileCandidate, runCompileStage } from './spine/compile.js';
-export type { DispositionClass, DispositionComment } from './spine/disposition-taxonomy.js';
-export { classifyDisposition, dispositionToLabel } from './spine/disposition-taxonomy.js';
 export type {
   CorpusDisposition,
   CorpusDispositionComment,
@@ -835,6 +833,8 @@ export {
   CorpusDispositionsSchema,
   CorpusDispositionThreadSchema,
 } from './spine/corpus-dispositions.js';
+export type { DispositionClass, DispositionComment } from './spine/disposition-taxonomy.js';
+export { classifyDisposition, dispositionToLabel } from './spine/disposition-taxonomy.js';
 export type {
   DraftExtractor,
   ExtractStageDeps,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -823,6 +823,17 @@ export type {
 } from './spine/compile.js';
 export { compileCandidate, runCompileStage } from './spine/compile.js';
 export type {
+  CorpusDisposition,
+  CorpusDispositionComment,
+  CorpusDispositionThread,
+} from './spine/corpus-dispositions.js';
+export {
+  CorpusDispositionCommentSchema,
+  CorpusDispositionSchema,
+  CorpusDispositionsSchema,
+  CorpusDispositionThreadSchema,
+} from './spine/corpus-dispositions.js';
+export type {
   DraftExtractor,
   ExtractStageDeps,
   ExtractStageResult,

--- a/packages/core/src/spine/corpus-dispositions.test.ts
+++ b/packages/core/src/spine/corpus-dispositions.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type CorpusDisposition,
+  CorpusDispositionSchema,
+  CorpusDispositionsSchema,
+} from './corpus-dispositions.js';
+
+const SHA = 'a'.repeat(40);
+
+const valid: CorpusDisposition = {
+  pr: 42,
+  mergeCommitSha: SHA,
+  threads: [
+    {
+      threadId: 'PRRT_kwDO',
+      path: 'src/foo.ts',
+      line: 40,
+      originalLine: 38,
+      diffHunk: '@@ -36,6 +36,8 @@\n+  const x = foo.bar;',
+      isResolved: true,
+      isOutdated: false,
+      comments: [
+        { commentId: 1001, author: 'coderabbitai[bot]', body: 'Possible null deref.' },
+        { author: 'satur8d', body: 'Fixed.' },
+      ],
+    },
+  ],
+};
+
+describe('CorpusDispositionSchema', () => {
+  it('parses a fully-populated disposition', () => {
+    expect(CorpusDispositionSchema.parse(valid)).toEqual(valid);
+  });
+
+  it('accepts a thread with no span hints (line/originalLine absent or null)', () => {
+    const noHints: CorpusDisposition = {
+      pr: 7,
+      mergeCommitSha: SHA,
+      threads: [
+        {
+          path: 'src/a.ts',
+          line: null,
+          diffHunk: '@@ -1 +1 @@\n+x',
+          isResolved: false,
+          isOutdated: true,
+          comments: [{ author: 'x', body: 'by design' }],
+        },
+      ],
+    };
+    expect(CorpusDispositionSchema.parse(noHints)).toEqual(noHints);
+  });
+
+  it('rejects a non-40-hex mergeCommitSha', () => {
+    expect(() => CorpusDispositionSchema.parse({ ...valid, mergeCommitSha: 'abc' })).toThrow(
+      /40-hex SHA/,
+    );
+  });
+
+  it('rejects a non-positive pr', () => {
+    expect(() => CorpusDispositionSchema.parse({ ...valid, pr: 0 })).toThrow();
+  });
+
+  it('parses an array payload (the frozen corpus-dispositions.json shape)', () => {
+    expect(CorpusDispositionsSchema.parse([valid])).toHaveLength(1);
+    expect(CorpusDispositionsSchema.parse([])).toEqual([]);
+  });
+});

--- a/packages/core/src/spine/corpus-dispositions.ts
+++ b/packages/core/src/spine/corpus-dispositions.ts
@@ -1,0 +1,80 @@
+// ─── #709 ground-truth deriver — slice 5d-ii: the held-out disposition source ─
+//
+// The frozen `corpus-dispositions.json` fixture: the held-out CORPUS PRs' review
+// threads, captured WITH span anchoring (the comment `diffHunk` + the thread
+// line) so slice 5d-iii can bind a `RuleFiring`'s matched line to a disposition
+// by CONTENT/invariant (not raw line — #709 contract addition #3). This is the
+// data the deriver classifies (via `classifyDisposition`, 5d-i) into TP/FP.
+//
+// Why a SEPARATE source from `review-content.json` (codex panel, BLOCKING-2):
+//  - `review-content.json` is the TRAIN slice (mining fetches train PRs only —
+//    FM-h, extract.ts), so it does not contain the held-out PRs' dispositions at
+//    all; and its `ReviewThread` shape carries no `line`/`diffHunk`, so it cannot
+//    bind a firing to a span. The answer key labels HELD-OUT firings, so it needs
+//    the HELD-OUT PRs' threads, span-anchored.
+//  - The disposition source is the evaluation corpus, DISJOINT from the rule's
+//    train provenance (ADR-111 §5; strategy-claude RULED #1, label-only: these
+//    threads NEVER feed mining/provenance).
+//
+// This module is the PROVENANCE shape only — RAW fetched threads. The taxonomy
+// class + the TP/FP label + the firing evidence-ref are DERIVED downstream
+// (5d-iii) and live in `ground-truth-labels.json`, NOT here — so
+// `corpusDispositionsSha` stays a clean provenance digest over the deriver's
+// INPUT (strategy-claude RULED #3: corpusDispositionsSha = provenance, the
+// Prop-285 §6.6 crystallized-hallucination guard), never over its own output.
+//
+// Resolution flags are SURFACED, never filtered (the #2201 "surface, don't
+// filter" discipline): unlike the train extractor's resolved-thread gate, a
+// resolved/outdated held-out thread is disposition EVIDENCE (an "accepted fix" or
+// a "superseded" signal), so it is captured and the taxonomy/span-bind decides
+// (codex WARNING-5). `isResolved` alone is never a label.
+
+import { z } from 'zod';
+
+const COMMIT_SHA_RE = /^[0-9a-f]{40}$/;
+
+/** One review-thread comment — the audit-anchored provenance the taxonomy reads. */
+export const CorpusDispositionCommentSchema = z.object({
+  /** GitHub review-comment databaseId — the evidence-ref anchor (5d-iii links labels back to it). */
+  commentId: z.number().int().nonnegative().optional(),
+  /** Comment author login; '' for a deleted/ghost account (coerced at the adapter, never dropped). */
+  author: z.string(),
+  body: z.string(),
+});
+
+/**
+ * One held-out review thread, span-anchored. `diffHunk` (the root comment's
+ * unified-diff hunk) is the CONTENT span source the firing binds to; `line` /
+ * `originalLine` are locator HINTS only (#709 #3 — never physical-line equality).
+ */
+export const CorpusDispositionThreadSchema = z.object({
+  /** GitHub review-thread node id — the audit anchor. Optional (older payloads). */
+  threadId: z.string().optional(),
+  path: z.string(),
+  /** Post-image anchored line — a locator HINT (binding keys on diffHunk content). `null` when GitHub has none. */
+  line: z.number().int().positive().nullable().optional(),
+  /** Base-image anchored line — a locator HINT. */
+  originalLine: z.number().int().positive().nullable().optional(),
+  /** The root comment's unified diff hunk — the content/invariant span the firing binds to. */
+  diffHunk: z.string(),
+  /** GitHub `reviewThreads.isResolved` — surfaced as disposition evidence, NOT a filter. */
+  isResolved: z.boolean(),
+  /** GitHub `reviewThreads.isOutdated` — surfaced; an outdated hunk must still bind by content (5d-iii). */
+  isOutdated: z.boolean(),
+  comments: z.array(CorpusDispositionCommentSchema),
+});
+
+/** One held-out CORPUS PR's dispositions (provenance for the answer key). */
+export const CorpusDispositionSchema = z.object({
+  pr: z.number().int().positive(),
+  /** Lowercase 40-hex merge-commit SHA (lc is squash-merge). */
+  mergeCommitSha: z.string().regex(COMMIT_SHA_RE, 'mergeCommitSha must be a 40-hex SHA'),
+  threads: z.array(CorpusDispositionThreadSchema),
+});
+
+/** The frozen `corpus-dispositions.json` payload — one entry per held-out corpus PR. */
+export const CorpusDispositionsSchema = z.array(CorpusDispositionSchema);
+
+export type CorpusDispositionComment = z.infer<typeof CorpusDispositionCommentSchema>;
+export type CorpusDispositionThread = z.infer<typeof CorpusDispositionThreadSchema>;
+export type CorpusDisposition = z.infer<typeof CorpusDispositionSchema>;

--- a/packages/core/src/spine/windtunnel-lock.ts
+++ b/packages/core/src/spine/windtunnel-lock.ts
@@ -110,6 +110,22 @@ export const WindtunnelLockSchema = z
         // lands the certifying path will hard-error if absent (no safe default for
         // an integrity hash).
         prDiffsSha: z.string().regex(SHA256_REGEX, 'prDiffsSha must be a 64-hex sha256').optional(),
+        // #709 fold-2 sibling (5d-ii): an integrity digest over the frozen
+        // `corpus-dispositions.json` — the held-out disposition PROVENANCE the
+        // label-deriver classifies into the answer key. Unlike `prDiffsSha` (run-
+        // critical, the scoring source the run reads), this is a PROVENANCE digest:
+        // the deriver verifies it before deriving (Prop-285 §6.6 crystallized-
+        // hallucination guard — a tampered disposition would silently flip a label),
+        // and `freeze` surfaces a provenance warn. ENCODING (mirrors prDiffsSha):
+        // sha256 (64-hex) over the EXACT on-disk `corpus-dispositions.json` bytes
+        // (canonical 2-space JSON + trailing newline, CRLF→LF-normalized), so an
+        // enforcer can `sha256` the file directly. STAMPED by `fetch-dispositions`;
+        // the deriver re-derives + hard-fails on mismatch (5d-iii). Additive-
+        // optional: locks with no disposition source parse unchanged.
+        corpusDispositionsSha: z
+          .string()
+          .regex(SHA256_REGEX, 'corpusDispositionsSha must be a 64-hex sha256')
+          .optional(),
       }),
     }),
     cullRateThreshold: z

--- a/packages/pack-agent-security/test/repo-sweep.test.ts
+++ b/packages/pack-agent-security/test/repo-sweep.test.ts
@@ -282,6 +282,13 @@ const ALLOWLIST: AllowEntry[] = [
   },
   {
     hash: 'c2c09301bb56a02b',
+    file: 'packages/cli/src/commands/spine-corpus-disposition-source.ts',
+    expectedCount: 1,
+    reason:
+      'The #709 5d-ii held-out CorpusDispositionSourceAdapter invokes its injected `GhExec` seam (a function parameter named `exec`) once to run `gh api graphql` for a held-out corpus PR — the identical safe call-shape as the sibling spine-review-thread-source adapter. The seam delegates to lazy-loaded `safeExec` (cross-spawn, no shell); the PR number is numeric and owner/name are JSON-escaped into a single `-f query=` argument — no shell-injection vector. Not `child_process.exec`; the rule fires only on the `exec(` call-shape (strategy#709).',
+  },
+  {
+    hash: 'c2c09301bb56a02b',
     file: 'packages/cli/src/orchestrators/orchestrator.ts',
     expectedCount: 1,
     reason: 'safeExec alias for git state probes inside the LLM orchestration pipeline.',


### PR DESCRIPTION
## What

Sub-slice **5d-ii of 3** of the cert-corpus **ground-truth label deriver** (`mmnto-ai/totem-strategy#709`). Builds the **held-out disposition source** — the data the deriver (5d-iii) classifies into the answer key.

**core**
- `corpus-dispositions.json` schema (`CorpusDisposition`) — the held-out CORPUS PRs' review threads, **span-anchored** (`diffHunk` + line hints + audit ids). Raw **provenance** only (the taxonomy class / TP-FP label / firing evidence-ref are derived in 5d-iii), so the digest stays a clean input digest.
- `controls.integrity.corpusDispositionsSha` — additive-optional lock field.

**CLI**
- `CorpusDispositionSourceAdapter` — a live `gh`-GraphQL fetch that **additively** requests the span anchors (`line`/`originalLine`/comment `diffHunk`) + ids on top of the mining query's resolution flags; the #2201 "surface, don't filter" discipline preserved. **CI hard-gate**: a live fetch in CI without `ALLOW_LIVE_FETCH` throws. **Fail-loud** (the freeze is all-or-nothing), unlike the mining adapter's discriminated skip.
- `spine windtunnel fetch-dispositions` — loads lock+split, fetches the held-out **corpus** PRs (`heldOut` minus controls), canonical-writes `corpus-dispositions.json`, stamps `corpusDispositionsSha` into the lock. Source injectable for offline tests; write-side Zod validation before freeze.
- `freeze` — provenance **warn-only** on `corpusDispositionsSha` (mirrors the `prDiffsSha`/`fixtureSha` warn shape; the hard gate is the deriver re-deriving in 5d-iii).

## Why

The firings the cert run scores are over the **held-out** corpus PRs, but mining (`record`) fetches **train** PRs only (FM-h) — so the held-out dispositions exist nowhere, and the train `ReviewThread` shape carries no span. This fetches them at producer-time (by-hand, like `record`; the **run stays zero-network**), span-anchored for the 5d-iii content/invariant bind, frozen + hash-bound. Satisfies ADR-111 §5 disjointness (held-out, **label-only** — never feeds mining).

## Cohort-panel-ratified

Implements the panel folds (codex/agy/gemini + strategy-claude RULED on #709 c.4764980503 — no contract change):
- **codex BLOCKING-2** — a distinct span-bearing `corpus-dispositions.json` (thread/comment ids, `line`/`originalLine` hints, `diffHunk`), not the train `ReviewThread` shape.
- **agy** — core schema + CLI I/O split; the CI hard-gate; injectable source for offline tests.
- **gemini** — `corpusDispositionsSha` single-homed in `controls.integrity` beside the other digests.
- **strategy** — `corpusDispositionsSha` = **provenance** (the deriver's input; Prop-285 §6.6 crystallized-hallucination guard), distinct from the run-critical `prDiffsSha`.

## Tests

20 offline tests: query-spy (span fields requested, no `isResolved` server filter), mapping (root-comment `diffHunk` → thread span, null coercions), CI hard-gate, pagination / no-merge fail-loud, the command's corpus-only PR selection, deterministic digest, and the schema. Full gate green: build · 2730 core · 2740 CLI · ESLint 0-err · prettier · `totem lint` PASS · security FP-sweep (the `gh`/`safeExec` seam allowlisted, identical to the sibling mining adapter).

## Scope

Part of strategy#709 — sub-slice 5d-ii of 3; **does not close** #709. Next: 5d-iii (the deriver orchestrator + `derive-labels` command) consumes this provenance + 5d-i's classifier. Changeset **consciously deferred** to 5d-iii (the user-facing command) — `fetch-dispositions` produces provenance only the deriver uses; it's an internal building block until 5d-iii.

🤖 Generated with [Claude Code](https://claude.com/claude-code)