### PR TITLE
chore(coderabbit): suppress the "Review skipped" status banner

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -16,6 +16,13 @@ reviews:
   review_details: true
   poem: true
 
+  # auto_review is off (below), so CR posts a "Review skipped" status comment on
+  # EVERY PR — pure noise without auto-invocation, and the surface that has caused
+  # review-triage misses (the skip banner read as "CR didn't review"). Suppress it
+  # (CR's own remediation: reviews.review_status). On-demand `@coderabbitai review`
+  # is unaffected — it still posts the full review.
+  review_status: false
+
   # On-demand only — operator ruling 2026-06-10 (mmnto-ai/totem-strategy#622):
   # all three review bots (CR / GCA / Greptile) are opt-in per PR. Trigger
   # stays `@coderabbitai review`. Doctrine: bot-protocols.md stack section


### PR DESCRIPTION
## What

Set `reviews.review_status: false` in `.coderabbit.yaml`.

## Why

Auto-review is off repo-wide (on-demand `@coderabbitai review` only — the #622 ruling). With auto-invocation disabled, CR posts a **"Review skipped"** status comment on **every** PR. It's pure noise — and worse, it's the exact surface that has repeatedly caused review-triage misses (the skip banner / "initiate chat" tip read as "CR didn't review", when the real review is an issue-comment posted on demand).

`reviews.review_status: false` is CR's own remediation for the skip banner. **On-demand reviews are unaffected** — `@coderabbitai review` still posts the full review.

Config-only; no code change. YAML validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)