### PR TITLE
feat(spine): Gate-1 label-deriver 5d-iii-i — disposition-derived answer key (derive-labels) (strategy#709)

### DIFF
--- a/.changeset/spine-gate1-label-deriver.md
+++ b/.changeset/spine-gate1-label-deriver.md
@@ -1,0 +1,13 @@
+---
+'@mmnto/totem': minor
+---
+
+feat(spine): Gate-1 ground-truth label deriver (strategy#709 5d)
+
+Produces `ground-truth-labels.json` — the cert run's disposition-derived ANSWER KEY (`firingLabelId → TP|FP`) — completing the Gate-1 label deriver. With it the certifying run is executable end-to-end. Cohort-panel-ratified (codex/agy/gemini, distinct lenses) before any code. Ships the full 5d arc as one release (5d-i/5d-ii landed changeset-deferred):
+
+- **5d-i** — closed disposition taxonomy classifier (`classifyDisposition` / `dispositionToLabel`): `accepted-fix → TP`, `declined-as-false-positive → FP`; every other class (scope / defer / superseded / style / ambiguous) → UNLABELED (omitted, so the scorer routes the firing to `needsAdjudication`).
+- **5d-ii** — held-out disposition source + `controls.integrity.corpusDispositionsSha` (`totem spine windtunnel fetch-dispositions`): freezes the corpus PRs' span-anchored review threads as the answer-key provenance.
+- **5d-iii** — the deriver: `deriveLabelsFromDispositions` (pure core span-join) + `totem spine windtunnel derive-labels`. A corpus firing binds to a disposition on the same PR by **added-line content** — the firing's normalized `matchedLine` must equal an ADDED (`+`) hunk row (context/removed rows and file headers ineligible; never physical-line equality); 0-or-multiple matches omit (ambiguity never labels). Positive controls label TP only for the declared `(pr, targetRuleId)` target; incidental non-target firings are omitted and reported; negatives never label. The deriver hard-gates `corpusDispositionsSha` before deriving and stamps `controls.integrity.groundTruthSha` over the emitted answer key (the run-side verify + freeze-warn land in the 5d-iii-ii fast-follow, mirroring the producer → enforcement split).
+
+Firings are enumerated through a shared certifying firing-setup (`buildCertifyingFirings`) + corpus-assembly path (`assembleCertifyingCorpus`, `buildGate1Stage4Deps`) that the certifying run also calls, so the answer-key labelIds match the run's `buildFirings` labelIds byte-for-byte — the drift surface the panel flagged, locked by an equivalence test.

--- a/packages/cli/src/commands/spine-cert-run-corpus.ts
+++ b/packages/cli/src/commands/spine-cert-run-corpus.ts
@@ -176,12 +176,16 @@ export function buildGate1Stage4Deps(
 ): Stage4VerifierDeps {
   if (lcDir) {
     return {
+      // The `--` separator keeps the revision unambiguous from any path args and blocks
+      // arg injection (CR coding guideline) — this shared path decides which files
+      // Stage-4 sees for BOTH the run and the deriver, so rev/path ambiguity here would
+      // shift archived-rule decisions and the derived labels.
       listFiles: async () =>
-        safeExec('git', ['ls-tree', '-r', '--name-only', asOf], { cwd: lcDir })
+        safeExec('git', ['ls-tree', '-r', '--name-only', asOf, '--'], { cwd: lcDir })
           .split('\n')
           .filter(Boolean),
       readFile: async (f: string) =>
-        safeExec('git', ['show', `${asOf}:${f.replace(/\\/g, '/')}`], { cwd: lcDir }),
+        safeExec('git', ['show', `${asOf}:${f.replace(/\\/g, '/')}`, '--'], { cwd: lcDir }),
       workingDirectory: lcDir,
     };
   }

--- a/packages/cli/src/commands/spine-cert-run-corpus.ts
+++ b/packages/cli/src/commands/spine-cert-run-corpus.ts
@@ -15,6 +15,9 @@ import type {
   WindtunnelLock,
 } from '@mmnto/totem';
 
+/** Local alias for the core git exec port (mirrors spine-windtunnel.ts / spine-cert-materialize.ts). */
+type SafeExecFn = typeof import('@mmnto/totem').safeExec;
+
 import { buildCertifyingCorpus } from './spine-cert-corpus.js';
 import { buildReplayAdapters } from './spine-cert-record.js';
 import { type ReplayArtifact, ReplayArtifactSchema } from './spine-llm-replay.js';
@@ -26,7 +29,10 @@ const SPLIT_FILE = 'split.json';
 const REPLAY_FILE = 'llm-replay.v1.json';
 const CONTENT_FILE = 'review-content.json';
 export const PR_DIFFS_FILE = 'pr-diffs.json';
-const GROUND_TRUTH_FILE = 'ground-truth-labels.json';
+/** The cert-run answer key — produced by `derive-labels` (5d-iii), read by the run. */
+export const GROUND_TRUTH_FILE = 'ground-truth-labels.json';
+/** The frozen held-out disposition provenance — produced by `fetch-dispositions` (5d-ii). */
+export const CORPUS_DISPOSITIONS_FILE = 'corpus-dispositions.json';
 const LEDGERS_FILE = 'miner-ledgers.json';
 
 // ─── Fixture schemas (the committed cert-run inputs) ──
@@ -83,7 +89,7 @@ export interface CertRunFixtureInputs {
  */
 export async function loadCertRunFixtures(
   gate1Dir: string,
-  opts?: { expectedPrDiffsSha?: string },
+  opts?: { expectedPrDiffsSha?: string; skipGroundTruth?: boolean },
 ): Promise<CertRunFixtureInputs> {
   const { SplitArtifactSchema, TotemError } = await import('@mmnto/totem');
 
@@ -140,9 +146,58 @@ export async function loadCertRunFixtures(
   }
   const prDiffs = z.array(ResolvedPrDiffSchema).parse(parseJson(prDiffsRaw, prDiffsFile));
 
+  // 5d-iii circularity guard: the label-deriver reuses this loader to enumerate
+  // firings byte-identically to the run, but it PRODUCES ground-truth-labels.json
+  // — so it must NOT read it (the file may not yet exist on a first derive, and
+  // reading it would make the deriver depend on its own output). `skipGroundTruth`
+  // returns an empty map; the run omits the flag and loads the frozen answer key.
+  if (opts?.skipGroundTruth) {
+    return { split, artifact, content, prDiffs, groundTruth: new Map<string, GroundTruthLabel>() };
+  }
+
   const gtRecord = GroundTruthSchema.parse(loadJson(path.join(gate1Dir, GROUND_TRUTH_FILE)));
   const groundTruth = new Map<string, GroundTruthLabel>(Object.entries(gtRecord));
   return { split, artifact, content, prDiffs, groundTruth };
+}
+
+/**
+ * Build the Stage-4 verifier deps (listFiles/readFile over the frozen post-image
+ * at `asOf`) — the SHARED constructor both the certifying run and the 5d-iii
+ * deriver use, so the archived-rule exclusion (hence the scored rule set, hence
+ * the firing labelIds) is identical. With an lc clone, files resolve via
+ * `git ls-tree`/`git show` at `asOf` (a local clone — zero network); without one,
+ * Stage-4 sees no files (rules read as untested, NOT archived). Tests inject a
+ * fake `Stage4VerifierDeps` into `assembleCertifyingCorpus` directly instead.
+ */
+export function buildGate1Stage4Deps(
+  lcDir: string | undefined,
+  asOf: string,
+  safeExec: SafeExecFn,
+): Stage4VerifierDeps {
+  if (lcDir) {
+    return {
+      listFiles: async () =>
+        safeExec('git', ['ls-tree', '-r', '--name-only', asOf], { cwd: lcDir })
+          .split('\n')
+          .filter(Boolean),
+      readFile: async (f: string) =>
+        safeExec('git', ['show', `${asOf}:${f.replace(/\\/g, '/')}`], { cwd: lcDir }),
+      workingDirectory: lcDir,
+    };
+  }
+  return {
+    // No lc clone → Stage-4 sees no files (rules read as 'no-matches' / untested,
+    // NOT archived) — the wind-tunnel firing/scoring still runs.
+    listFiles: async () => [],
+    readFile: async (f: string) => {
+      const { TotemError } = await import('@mmnto/totem');
+      throw new TotemError(
+        'CONFIG_INVALID',
+        `Cert run: no lc clone (--lc-dir) — cannot read ${f} for Stage-4.`,
+        'Provide the lc clone via --lc-dir or the TOTEM_LC_DIR environment variable.',
+      );
+    },
+  };
 }
 
 /** Derive the SplitLedger from the loaded split + the lock's resolved corpus. */
@@ -184,55 +239,73 @@ export interface ReplayCorpusProviderOptions {
  * `miner-ledgers.json`) for §7 observability. Throws loud if the lock lacks the
  * L2 replay hash (no safe default for an integrity gate).
  */
+/**
+ * Assemble the REPLAY-mode `CertifyingCorpus` (rules + prDiffs + provenance) from
+ * the committed gate-1 fixtures — the SHARED path both the certifying run (via
+ * `buildReplayCorpusProvider`) and the 5d-iii label-deriver call, so the corpus
+ * they enumerate firings over is byte-identical (the answer-key labelIds the
+ * deriver mints are the ones the run looks up). The deriver passes
+ * `skipGroundTruth: true` — it PRODUCES `ground-truth-labels.json`, so it must
+ * not read it (circularity guard); the run omits the flag and loads the frozen
+ * answer key. Returns the fold-I ledgers too; the caller decides whether to emit
+ * them (the run does; the deriver discards — they belong to the run artifact).
+ */
+export async function assembleCertifyingCorpus(
+  opts: ReplayCorpusProviderOptions & { skipGroundTruth?: boolean },
+  lock: WindtunnelLock,
+): Promise<{ corpus: CertifyingCorpus; ledgers: MinerLedgers }> {
+  const { TotemError } = await import('@mmnto/totem');
+  const expectedHash = lock.controls.integrity.llmReplaySha;
+  if (!expectedHash) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      'Certifying run: lock is missing controls.integrity.llmReplaySha (L2) — the frozen ' +
+        'llm-replay fixture cannot be integrity-checked.',
+      'Re-freeze the lock after a `record` run.',
+    );
+  }
+
+  // #2225 (#709 fold-2): hash-bind the SCORING source. `pr-diffs.json` is otherwise
+  // unprotected — `fixtureSha` covers only the control dirs — so a silent mutation of
+  // any row (advisory-window OR control) would corrupt the answer key while the
+  // control-dir gate stays green. The absent-from-lock case is a lock precondition
+  // (checked here); `loadCertRunFixtures` verifies the digest on the SAME read it
+  // parses — no check/use split (CR). Fail loud (strategy ruled: verify at freeze AND run).
+  const expectedPrDiffsSha = lock.controls.integrity.prDiffsSha;
+  if (!expectedPrDiffsSha) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      'Certifying run: lock is missing controls.integrity.prDiffsSha (#709 fold-2) — the ' +
+        'pr-diffs.json scoring source cannot be integrity-checked.',
+      'Re-materialize the cert corpus with `spine windtunnel materialize`.',
+    );
+  }
+
+  const { split, artifact, content, prDiffs, groundTruth } = await loadCertRunFixtures(
+    opts.gate1Dir,
+    { expectedPrDiffsSha, skipGroundTruth: opts.skipGroundTruth },
+  );
+  const { extractor, classifier } = buildReplayAdapters(artifact, expectedHash);
+
+  return buildCertifyingCorpus({
+    split,
+    splitLedger: splitLedgerFrom(split, lock),
+    source: frozenSourceFrom(content),
+    extractor,
+    classifier,
+    seedClassesProvided: opts.seedClassesProvided ?? false,
+    stage4: opts.stage4,
+    now: opts.now,
+    prDiffs,
+    groundTruth,
+  });
+}
+
 export function buildReplayCorpusProvider(
   opts: ReplayCorpusProviderOptions,
 ): CertifyingCorpusProvider {
   return async (lock: WindtunnelLock): Promise<CertifyingCorpus> => {
-    const { TotemError } = await import('@mmnto/totem');
-    const expectedHash = lock.controls.integrity.llmReplaySha;
-    if (!expectedHash) {
-      throw new TotemError(
-        'CONFIG_INVALID',
-        'Certifying run: lock is missing controls.integrity.llmReplaySha (L2) — the frozen ' +
-          'llm-replay fixture cannot be integrity-checked.',
-        'Re-freeze the lock after a `record` run.',
-      );
-    }
-
-    // #2225 (#709 fold-2): hash-bind the SCORING source. `pr-diffs.json` is otherwise
-    // unprotected — `fixtureSha` covers only the control dirs — so a silent mutation of
-    // any row (advisory-window OR control) would corrupt the answer key while the
-    // control-dir gate stays green. The absent-from-lock case is a lock precondition
-    // (checked here); `loadCertRunFixtures` verifies the digest on the SAME read it
-    // parses — no check/use split (CR). Fail loud (strategy ruled: verify at freeze AND run).
-    const expectedPrDiffsSha = lock.controls.integrity.prDiffsSha;
-    if (!expectedPrDiffsSha) {
-      throw new TotemError(
-        'CONFIG_INVALID',
-        'Certifying run: lock is missing controls.integrity.prDiffsSha (#709 fold-2) — the ' +
-          'pr-diffs.json scoring source cannot be integrity-checked.',
-        'Re-materialize the cert corpus with `spine windtunnel materialize`.',
-      );
-    }
-
-    const { split, artifact, content, prDiffs, groundTruth } = await loadCertRunFixtures(
-      opts.gate1Dir,
-      { expectedPrDiffsSha },
-    );
-    const { extractor, classifier } = buildReplayAdapters(artifact, expectedHash);
-
-    const { corpus, ledgers } = await buildCertifyingCorpus({
-      split,
-      splitLedger: splitLedgerFrom(split, lock),
-      source: frozenSourceFrom(content),
-      extractor,
-      classifier,
-      seedClassesProvided: opts.seedClassesProvided ?? false,
-      stage4: opts.stage4,
-      now: opts.now,
-      prDiffs,
-      groundTruth,
-    });
+    const { corpus, ledgers } = await assembleCertifyingCorpus(opts, lock);
 
     // fold-I (§7): emit the miner ledgers, observable beside the cert-run report.
     if (opts.onLedgers) {

--- a/packages/cli/src/commands/spine-cert-run-corpus.ts
+++ b/packages/cli/src/commands/spine-cert-run-corpus.ts
@@ -233,17 +233,6 @@ export interface ReplayCorpusProviderOptions {
 }
 
 /**
- * Build the REPLAY-mode `CertifyingCorpusProvider` the certifying run injects.
- *
- * Loads the committed cert-run fixtures (split, frozen `llm-replay.v1` artifact,
- * frozen review content, resolved-PR diffs, ground-truth labels) from the gate-1
- * dir, constructs the zero-network replay adapters (gated on the lock's L2
- * `llmReplaySha`) + a frozen review-thread source, then composes them through
- * `buildCertifyingCorpus`. fold-I ledgers are emitted (default: written to
- * `miner-ledgers.json`) for §7 observability. Throws loud if the lock lacks the
- * L2 replay hash (no safe default for an integrity gate).
- */
-/**
  * Assemble the REPLAY-mode `CertifyingCorpus` (rules + prDiffs + provenance) from
  * the committed gate-1 fixtures — the SHARED path both the certifying run (via
  * `buildReplayCorpusProvider`) and the 5d-iii label-deriver call, so the corpus
@@ -305,6 +294,14 @@ export async function assembleCertifyingCorpus(
   });
 }
 
+/**
+ * Build the REPLAY-mode `CertifyingCorpusProvider` the certifying run injects: a thin
+ * wrapper over `assembleCertifyingCorpus` (fixture-load + replay adapters + the
+ * `buildCertifyingCorpus` composition) that also emits the fold-I miner ledgers
+ * (default: `miner-ledgers.json`) for §7 observability. The deriver calls
+ * `assembleCertifyingCorpus` directly instead (it skips ground-truth + discards the
+ * ledgers, which belong to the run artifact).
+ */
 export function buildReplayCorpusProvider(
   opts: ReplayCorpusProviderOptions,
 ): CertifyingCorpusProvider {

--- a/packages/cli/src/commands/spine-derive-labels.test.ts
+++ b/packages/cli/src/commands/spine-derive-labels.test.ts
@@ -1,0 +1,179 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { type CompiledRule, deriveLabelsFromDispositions, type ResolvedPrDiff } from '@mmnto/totem';
+
+import { deriveLabelsCommand } from './spine-derive-labels.js';
+import { buildCertifyingFirings } from './spine-windtunnel.js';
+
+const SHA40 = (n: number): string => n.toString(16).padStart(40, '0');
+
+/** A regex rule firing on `forbiddenCall(` (a made-up token — won't trip totem's own lint). */
+function forbiddenCallRule(): CompiledRule {
+  return {
+    lessonHash: 'rule-fc',
+    lessonHeading: 'No forbiddenCall',
+    pattern: 'forbiddenCall\\(',
+    message: 'forbidden call',
+    engine: 'regex',
+    compiledAt: '2026-06-22T00:00:00.000Z',
+  };
+}
+
+/** A unified diff that ADDS the given lines to `file` from line 1. */
+function diffAdding(lines: string[], file: string): string {
+  return [
+    `diff --git a/${file} b/${file}`,
+    `--- a/${file}`,
+    `+++ b/${file}`,
+    `@@ -0,0 +1,${lines.length} @@`,
+    ...lines.map((l) => `+${l}`),
+  ].join('\n');
+}
+
+// ─── Equivalence: deriver labelIds ⊆ the run's buildFirings labelIds (panel) ──
+//
+// Both the certifying run and the deriver enumerate firings via the SAME
+// `buildCertifyingFirings` — so the answer-key labelIds the deriver mints are the
+// ones the run looks up. This proves the join end-to-end over REAL firings (zero
+// network: an in-memory readStrategy stub) + the determinism of the shared path.
+
+describe('5d-iii equivalence — buildCertifyingFirings ↔ deriveLabelsFromDispositions', () => {
+  const rules = [forbiddenCallRule()];
+  const prDiffs: ResolvedPrDiff[] = [
+    { pr: 7, diff: diffAdding(['forbiddenCall()'], 'src/x.ts'), controlKind: 'corpus' },
+  ];
+  const readStrategy = async (): Promise<string | null> => 'forbiddenCall()\n';
+
+  it('enumerates ≥1 firing and the deriver keys ONLY on real firing labelIds', async () => {
+    const built = await buildCertifyingFirings({
+      rules,
+      prDiffs,
+      readStrategy,
+      logPrefix: '[Test]',
+    });
+    expect(built.firings.length).toBeGreaterThan(0);
+
+    const firingLabelIds = new Set(built.firings.map((f) => f.labelId));
+    const firing = built.firings[0]!;
+    const dispositions = [
+      {
+        pr: 7,
+        mergeCommitSha: SHA40(7),
+        threads: [
+          {
+            path: 'src/x.ts',
+            // bind by the firing's own added content (what GitHub's diffHunk would carry).
+            diffHunk: `@@ -0,0 +1,1 @@\n+${firing.matchedLine}`,
+            isResolved: false,
+            isOutdated: false,
+            comments: [{ author: 'Jane', body: 'fixed' }],
+          },
+        ],
+      },
+    ];
+
+    const { labels } = deriveLabelsFromDispositions(built.firings, dispositions);
+    // every emitted labelId is a real firing labelId the run will look up (⊆).
+    for (const id of Object.keys(labels)) {
+      expect(firingLabelIds.has(id)).toBe(true);
+    }
+    expect(labels[firing.labelId]).toBe('TP');
+  });
+
+  it('is deterministic — two runs of the shared firing-setup mint identical labelIds', async () => {
+    const a = await buildCertifyingFirings({ rules, prDiffs, readStrategy, logPrefix: '[Test]' });
+    const b = await buildCertifyingFirings({ rules, prDiffs, readStrategy, logPrefix: '[Test]' });
+    expect(b.firings.map((f) => f.labelId).sort()).toEqual(a.firings.map((f) => f.labelId).sort());
+  });
+});
+
+// ─── Integrity gates (command-level; no git needed — the gate fires first) ────
+
+function writeLockFixture(dir: string, integrity: Record<string, string>): void {
+  const lock = {
+    schema: 'windtunnel.lock.v1',
+    canonicalPath: '.totem/spine/gate-1/windtunnel.lock.json',
+    gate: 'gate-1',
+    phase: 'certifying',
+    corpus: {
+      repo: 'mmnto-ai/liquid-city',
+      selectionRule: {
+        state: 'merged',
+        predicate: 'code-touching',
+        window: { type: 'all' },
+        asOfCommit: 'a'.repeat(40),
+        codePathClassifier: { includeGlobs: ['**/*.ts'], excludeGlobs: [] },
+      },
+      resolvedPrs: [3, 5].map((n) => ({
+        pr: n,
+        mergeCommit: SHA40(n),
+        baseSha: 'b'.repeat(40),
+        headSha: 'd'.repeat(40),
+      })),
+    },
+    fpDefinition: { rubricRef: 'r', groundTruthRef: 'g', adjudicator: 'a', precisionFloor: 1.0 },
+    controls: {
+      positiveRef: 'controls/positive/',
+      negativeRef: 'controls/negative/',
+      integrity: { mechanism: 'sha', fixtureSha: 'e'.repeat(40), ...integrity },
+    },
+    cullRateThreshold: 0.5,
+    exposureDenominator: {
+      activeRulesEvaluated: { floor: 2 },
+      filesTouchedInWindow: { floor: 0 },
+      positiveControlsExercised: { floor: 0 },
+    },
+  };
+  fs.writeFileSync(path.join(dir, 'windtunnel.lock.json'), JSON.stringify(lock, null, 2));
+}
+
+describe('deriveLabelsCommand — integrity gates', () => {
+  let dir: string;
+  let savedLcDir: string | undefined;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-derive-'));
+    // The no-lc-dir guard reads TOTEM_LC_DIR — neutralize the ambient env for tests.
+    savedLcDir = process.env['TOTEM_LC_DIR'];
+    delete process.env['TOTEM_LC_DIR'];
+  });
+  afterEach(() => {
+    if (savedLcDir === undefined) delete process.env['TOTEM_LC_DIR'];
+    else process.env['TOTEM_LC_DIR'] = savedLcDir;
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+  });
+
+  it('fails loud when no lc clone is provided (the answer key would be silently empty)', async () => {
+    writeLockFixture(dir, { corpusDispositionsSha: 'f'.repeat(64) });
+    await expect(
+      deriveLabelsCommand({ lockPath: path.join(dir, 'windtunnel.lock.json'), cwd: dir }),
+    ).rejects.toThrow(/no lc clone/i);
+  });
+
+  it('hard-fails when the lock is missing corpusDispositionsSha (un-gated provenance)', async () => {
+    writeLockFixture(dir, {}); // no corpusDispositionsSha stamped
+    await expect(
+      deriveLabelsCommand({
+        lockPath: path.join(dir, 'windtunnel.lock.json'),
+        lcDir: dir, // a real dir; the gate fires before any git use
+        cwd: dir,
+      }),
+    ).rejects.toThrow(/corpusDispositionsSha/);
+  });
+
+  it('hard-fails when corpus-dispositions.json does not match the stamped digest', async () => {
+    writeLockFixture(dir, { corpusDispositionsSha: 'a'.repeat(64) }); // a digest the file won't match
+    fs.writeFileSync(path.join(dir, 'corpus-dispositions.json'), '[]\n', 'utf-8');
+    await expect(
+      deriveLabelsCommand({
+        lockPath: path.join(dir, 'windtunnel.lock.json'),
+        lcDir: dir,
+        cwd: dir,
+      }),
+    ).rejects.toThrow(/integrity FAILED/i);
+  });
+});

--- a/packages/cli/src/commands/spine-derive-labels.ts
+++ b/packages/cli/src/commands/spine-derive-labels.ts
@@ -1,0 +1,194 @@
+// ─── #709 ground-truth deriver — slice 5d-iii-i: the derive-labels command ────
+//
+// `totem spine windtunnel derive-labels [--lock-path] [--lc-dir] [--output-dir]`
+// produces `ground-truth-labels.json` — the cert-run ANSWER KEY (firingLabelId →
+// TP|FP) — by enumerating firings byte-identically to the certifying run (the
+// SHARED firing-setup) and joining each against the frozen held-out
+// `corpus-dispositions.json` (5d-ii) through the closed 5d-i taxonomy. HARD-GATES
+// `controls.integrity.corpusDispositionsSha` before deriving (a tampered
+// disposition would silently flip a label — the #2224/#2225 lesson) and stamps
+// `controls.integrity.groundTruthSha` over the emitted answer key. A by-hand
+// producer step (like `materialize` / `fetch-dispositions`): the certifying RUN
+// consumes the frozen labels (5d-iii-ii) and never re-derives — that, plus the
+// digest, is what makes "the run graded against the key the deriver emitted"
+// verifiable. The deriver MUST NOT call `loadCertRunFixtures` (it reads the file
+// we emit — circularity); it uses `assembleCertifyingCorpus({ skipGroundTruth })`.
+
+import { createHash } from 'node:crypto';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import {
+  assembleCertifyingCorpus,
+  buildGate1Stage4Deps,
+  CORPUS_DISPOSITIONS_FILE,
+  GROUND_TRUTH_FILE,
+} from './spine-cert-run-corpus.js';
+import { buildCertifyingFirings, buildReadStrategy } from './spine-windtunnel.js';
+
+const sha256Hex = (s: string): string => createHash('sha256').update(s, 'utf-8').digest('hex');
+
+export interface DeriveLabelsOptions {
+  /** Path to the wind-tunnel lock (default `.totem/spine/gate-1/windtunnel.lock.json`). */
+  lockPath?: string;
+  /** Path to the lc clone (env: TOTEM_LC_DIR) — the post-image blob source the firings read. */
+  lcDir?: string;
+  /** Gate-1 output dir (default: the lock's dir). */
+  outputDir?: string;
+  /** Working dir (default `process.cwd()`; injected for tests). */
+  cwd?: string;
+}
+
+export async function deriveLabelsCommand(opts: DeriveLabelsOptions): Promise<void> {
+  const {
+    WindtunnelLockSchema,
+    CorpusDispositionsSchema,
+    deriveLabelsFromDispositions,
+    canonicalStringify,
+    safeExec,
+    TotemError,
+  } = await import('@mmnto/totem');
+
+  const cwd = opts.cwd ?? process.cwd();
+  const lockPath = opts.lockPath
+    ? path.resolve(cwd, opts.lockPath)
+    : path.resolve(cwd, '.totem/spine/gate-1/windtunnel.lock.json');
+  const gate1Dir = opts.outputDir ? path.resolve(cwd, opts.outputDir) : path.dirname(lockPath);
+  const lcDir = opts.lcDir ?? process.env['TOTEM_LC_DIR'];
+
+  // The deriver enumerates REAL firings over the post-image, so it needs the lc
+  // clone — without it `readStrategy` returns null for every file and NO rule
+  // fires, silently minting an empty answer key. Fail loud (Tenet 4).
+  if (!lcDir) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      'derive-labels: no lc clone (--lc-dir / TOTEM_LC_DIR) — cannot read the post-image to ' +
+        'enumerate firings, so the answer key would be silently empty.',
+      'Provide the lc clone via --lc-dir or the TOTEM_LC_DIR environment variable.',
+    );
+  }
+
+  const readRaw = (p: string, hint: string): string => {
+    try {
+      return fs.readFileSync(p, 'utf-8');
+    } catch (err) {
+      throw new TotemError(
+        'CONFIG_INVALID',
+        `derive-labels: required file not found at ${p}`,
+        hint,
+        err,
+      );
+    }
+  };
+
+  const lock = WindtunnelLockSchema.parse(
+    JSON.parse(readRaw(lockPath, 'Run `spine windtunnel materialize` first.')),
+  );
+
+  // ── corpusDispositionsSha derive-time HARD-GATE (must LAND — the #2224 trap
+  // #2225 closed for prDiffsSha). Verify-then-parse on a SINGLE read (no check/use
+  // split), CRLF→LF normalized to match the 5d-ii stamp + freeze-warn. A tampered
+  // disposition would silently flip a label, so a missing OR mismatched digest is a
+  // hard fail BEFORE any firing enumeration or label emission. ──
+  const expectedDispositionsSha = lock.controls.integrity.corpusDispositionsSha;
+  if (!expectedDispositionsSha) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      'derive-labels: lock is missing controls.integrity.corpusDispositionsSha — the held-out ' +
+        'disposition provenance cannot be integrity-checked, so the answer key cannot be trusted.',
+      'Run `spine windtunnel fetch-dispositions` first (5d-ii stamps the digest).',
+    );
+  }
+  const dispositionsPath = path.join(gate1Dir, CORPUS_DISPOSITIONS_FILE);
+  const dispositionsRaw = readRaw(
+    dispositionsPath,
+    'Run `spine windtunnel fetch-dispositions` first (it writes corpus-dispositions.json).',
+  );
+  const actualDispositionsSha = sha256Hex(dispositionsRaw.replace(/\r\n/g, '\n'));
+  if (actualDispositionsSha !== expectedDispositionsSha) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `derive-labels: corpus-dispositions.json integrity FAILED — expected ${expectedDispositionsSha}, ` +
+        `got ${actualDispositionsSha} (the frozen disposition provenance was tampered or re-serialized).`,
+      'Restore the frozen corpus-dispositions.json or re-run `spine windtunnel fetch-dispositions`.',
+    );
+  }
+  const dispositions = CorpusDispositionsSchema.parse(JSON.parse(dispositionsRaw));
+
+  // ── Enumerate firings via the SHARED path — byte-identical to the certifying
+  // run (assembleCertifyingCorpus + buildCertifyingFirings). skipGroundTruth: the
+  // deriver PRODUCES the answer key, so it must not read it (circularity guard). ──
+  const asOf = lock.corpus.selectionRule.asOfCommit;
+  const readStrategy = buildReadStrategy(lcDir, asOf, safeExec);
+  const stage4 = buildGate1Stage4Deps(lcDir, asOf, safeExec);
+  // `now` feeds the corpus compile-stage timestamp only; it does NOT enter the
+  // content-based firing labelId, so the answer key is deterministic regardless.
+  const now = new Date().toISOString();
+  const { corpus } = await assembleCertifyingCorpus(
+    { gate1Dir, stage4, now, skipGroundTruth: true },
+    lock,
+  );
+  const built = await buildCertifyingFirings({
+    rules: corpus.rules,
+    prDiffs: corpus.prDiffs,
+    readStrategy,
+    logPrefix: '[DeriveLabels]',
+  });
+
+  // ── Derive the answer key (pure, zero-LLM) ──
+  const { labels, diagnostics, evidence } = deriveLabelsFromDispositions(
+    built.firings,
+    dispositions,
+  );
+
+  // ── Write the answer key canonically (sorted-key, LF + trailing newline) so the
+  // groundTruthSha covers the exact on-disk bytes a run/freeze enforcer re-hashes. ──
+  fs.mkdirSync(gate1Dir, { recursive: true });
+  const gtPath = path.join(gate1Dir, GROUND_TRUTH_FILE);
+  const text = `${canonicalStringify(labels, 2)}\n`;
+  const gtTmp = `${gtPath}.tmp`;
+  fs.writeFileSync(gtTmp, text, 'utf-8');
+  fs.renameSync(gtTmp, gtPath);
+  const groundTruthSha = sha256Hex(text);
+
+  // ── Stamp groundTruthSha into the lock (read-modify-write canonical), mirroring
+  // how `fetch-dispositions` stamps corpusDispositionsSha. Idempotent. The run-side
+  // verify + freeze-warn land in 5d-iii-ii (producer → enforcement split). ──
+  const stampedLock = {
+    ...lock,
+    controls: {
+      ...lock.controls,
+      integrity: { ...lock.controls.integrity, groundTruthSha },
+    },
+  };
+  const lockText = `${canonicalStringify(stampedLock, 2)}\n`;
+  const lockTmp = `${lockPath}.tmp`;
+  fs.writeFileSync(lockTmp, lockText, 'utf-8');
+  fs.renameSync(lockTmp, lockPath);
+
+  // ── Diagnostic report (gemini: deriver reports DATA QUALITY). Deterministic +
+  // zero-LLM. A sparse answer key is HONEST-NEGATIVE territory — contract-working,
+  // not failure — so surface the coverage + why, never densify-to-PASS. ──
+  const d = diagnostics;
+  const labeled = d.labelCounts.TP + d.labelCounts.FP;
+  console.error(`[DeriveLabels] gate1Dir: ${gate1Dir}`);
+  console.error(
+    `  firings: ${d.totalFirings} (corpus ${d.corpusFirings} · positive ${d.positiveFirings} · negative ${d.negativeFirings})`,
+  );
+  console.error(`  labeled: ${labeled} (TP ${d.labelCounts.TP} · FP ${d.labelCounts.FP})`);
+  console.error(
+    `  disposition density: ${(d.dispositionDensity * 100).toFixed(1)}% ` +
+      `(${d.boundCorpusFirings}/${d.corpusFirings} corpus firings bound a disposition)`,
+  );
+  console.error(
+    `  unlabeled: ${d.unlabeledFirings} (${(d.unlabeledRate * 100).toFixed(1)}% of scored) — ` +
+      `no-match ${d.unlabeledByReason['no-matching-disposition']} · ` +
+      `ambiguous ${d.unlabeledByReason['ambiguous-multiple-dispositions']} · ` +
+      `unlabeled-class ${d.unlabeledByReason['unlabeled-class']} · ` +
+      `incidental-positive ${d.unlabeledByReason['incidental-positive']}`,
+  );
+  console.error(`  groundTruthSha: ${groundTruthSha} (stamped into ${path.basename(lockPath)})`);
+  console.error(
+    `  Wrote ${GROUND_TRUTH_FILE} (${evidence.length} labeled firing(s) with disposition provenance).`,
+  );
+}

--- a/packages/cli/src/commands/spine-derive-labels.ts
+++ b/packages/cli/src/commands/spine-derive-labels.ts
@@ -80,9 +80,21 @@ export async function deriveLabelsCommand(opts: DeriveLabelsOptions): Promise<vo
       );
     }
   };
+  // Wrap JSON.parse so a malformed fixture surfaces a structured CLI error instead of a
+  // raw SyntaxError (GCA) — `TotemError('CONFIG_INVALID')` to match the CLI-layer
+  // convention in `loadCertRunFixtures` / `fetch-dispositions` (NOT TotemParseError,
+  // which the styleguide reserves for the core compile/parse layer).
+  const parseJson = (raw: string, p: string, hint: string): unknown => {
+    try {
+      return JSON.parse(raw);
+    } catch (err) {
+      throw new TotemError('CONFIG_INVALID', `derive-labels: ${p} is not valid JSON`, hint, err);
+    }
+  };
 
+  const lockHint = 'Run `spine windtunnel materialize` first.';
   const lock = WindtunnelLockSchema.parse(
-    JSON.parse(readRaw(lockPath, 'Run `spine windtunnel materialize` first.')),
+    parseJson(readRaw(lockPath, lockHint), lockPath, lockHint),
   );
 
   // ── corpusDispositionsSha derive-time HARD-GATE (must LAND — the #2224 trap
@@ -113,7 +125,13 @@ export async function deriveLabelsCommand(opts: DeriveLabelsOptions): Promise<vo
       'Restore the frozen corpus-dispositions.json or re-run `spine windtunnel fetch-dispositions`.',
     );
   }
-  const dispositions = CorpusDispositionsSchema.parse(JSON.parse(dispositionsRaw));
+  const dispositions = CorpusDispositionsSchema.parse(
+    parseJson(
+      dispositionsRaw,
+      dispositionsPath,
+      'Restore the frozen corpus-dispositions.json or re-run `spine windtunnel fetch-dispositions`.',
+    ),
+  );
 
   // ── Enumerate firings via the SHARED path — byte-identical to the certifying
   // run (assembleCertifyingCorpus + buildCertifyingFirings). skipGroundTruth: the
@@ -124,6 +142,12 @@ export async function deriveLabelsCommand(opts: DeriveLabelsOptions): Promise<vo
   // `now` feeds the corpus compile-stage timestamp only; it does NOT enter the
   // content-based firing labelId, so the answer key is deterministic regardless.
   const now = new Date().toISOString();
+  // `seedClassesProvided` is intentionally omitted (defaults false), matching the run's
+  // `buildReplayCorpusProvider` call which also leaves it false (greptile). It is safe to
+  // pin: it is a fold-I §7 ledger ATTESTATION threaded only into the extract-stage ledger
+  // — it does not enter rule compilation or the content-based labelId — so it cannot break
+  // the byte-identical guarantee even if a future run set it. Thread it through both the
+  // run and the deriver together if it ever becomes a real RunOption.
   const { corpus } = await assembleCertifyingCorpus(
     { gate1Dir, stage4, now, skipGroundTruth: true },
     lock,

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -5,7 +5,11 @@ import * as path from 'node:path';
 import type { PrMeta, SelectionRuleConfig, WindtunnelLock } from '@mmnto/totem';
 
 import { persistCertifyingOutcome } from './spine-cert-persist.js';
-import { buildReplayCorpusProvider, PR_DIFFS_FILE } from './spine-cert-run-corpus.js';
+import {
+  buildGate1Stage4Deps,
+  buildReplayCorpusProvider,
+  PR_DIFFS_FILE,
+} from './spine-cert-run-corpus.js';
 
 // ─── Named constants ─────────────────────────────────
 
@@ -360,28 +364,8 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   if (lock.phase === 'certifying' && !corpusProvider) {
     const gate1Dir = path.dirname(lockPath);
     const asOf = lock.corpus.selectionRule.asOfCommit;
-    const stage4: import('@mmnto/totem').Stage4VerifierDeps = lcDir
-      ? {
-          listFiles: async () =>
-            safeExec('git', ['ls-tree', '-r', '--name-only', asOf], { cwd: lcDir })
-              .split('\n')
-              .filter(Boolean),
-          readFile: async (f: string) =>
-            safeExec('git', ['show', `${asOf}:${f.replace(/\\/g, '/')}`], { cwd: lcDir }),
-          workingDirectory: lcDir,
-        }
-      : {
-          // No lc clone → Stage-4 sees no files (rules read as 'no-matches' /
-          // untested, NOT archived) — the wind-tunnel firing/scoring still runs.
-          listFiles: async () => [],
-          readFile: async (f: string) => {
-            throw new TotemError(
-              'CONFIG_INVALID',
-              `Cert run: no lc clone (--lc-dir) — cannot read ${f} for Stage-4.`,
-              'Provide the lc clone via --lc-dir or the TOTEM_LC_DIR environment variable.',
-            );
-          },
-        };
+    // Shared Stage-4 constructor (the deriver builds it the same way — no drift).
+    const stage4 = buildGate1Stage4Deps(lcDir, asOf, safeExec);
     corpusProvider = buildReplayCorpusProvider({
       gate1Dir,
       stage4,
@@ -958,6 +942,77 @@ async function runMockEngineAdapter(
 // ─── Real engine (certifying phase, 5c-i) ────────────
 
 /**
+ * Build the certifying-run firings from a corpus's rules + prDiffs — the SHARED
+ * firing-setup the certifying run AND the 5d-iii label-deriver both call, so they
+ * enumerate byte-identical `RuleFiring` labelIds over the same fixtures. The panel
+ * anti-drift mandate: any divergence here (cwd resolution / ruleEngineCtx / the
+ * buildFirings call) would silently break the deriver↔run labelId join and void
+ * the answer key. Encapsulates:
+ *  - cwd resolution (`resolveGitRoot(process.cwd())` — NOT raw `process.cwd()`, #1304),
+ *  - the per-invocation `ruleEngineCtx` (logger + shield-warn state),
+ *  - `buildFirings` (fold-F archived-assert runs inside it),
+ *  - the A1 (fold-D) post-dedup labelId-uniqueness hard-gate.
+ * `logPrefix` differentiates the caller in warn output ([WindtunnelRun] / [DeriveLabels]).
+ */
+export async function buildCertifyingFirings(input: {
+  rules: import('@mmnto/totem').CompiledRule[];
+  prDiffs: import('@mmnto/totem').ResolvedPrDiff[];
+  readStrategy: (file: string) => Promise<string | null>;
+  logPrefix: string;
+}): Promise<import('@mmnto/totem').BuildFiringsResult> {
+  const {
+    buildFirings,
+    assertUniqueFiringLabels,
+    resolveGitRoot,
+    TotemError,
+    FiringLabelCollisionError,
+  } = await import('@mmnto/totem');
+
+  const cwd = resolveGitRoot(process.cwd()) ?? process.cwd();
+  const ruleEngineCtx = {
+    logger: { warn: (msg: string) => console.error(`${input.logPrefix} ${msg}`) },
+    state: { hasWarnedShieldContext: false },
+  };
+
+  // buildFirings runs fold-F (archived assert) internally before the engine; its
+  // only throw is ArchivedRuleInScopeError, which propagates. A1 (labelId
+  // collision) is the caller-side pre-score gate below — not raised at construction
+  // — so the structured per-collision report is threaded here. (greptile #2215 P2.)
+  const built = await buildFirings({
+    rules: input.rules,
+    prDiffs: input.prDiffs,
+    cwd,
+    readStrategy: input.readStrategy,
+    ruleEngineCtx,
+    onWarn: (msg) => console.error(`${input.logPrefix} ${msg}`),
+  });
+
+  // A1 (fold-D): post-dedup uniqueness INVARIANT before scoring (Tenet 4).
+  // `buildFirings` collapses same-labelId matches (fold-D dedup), so a collision
+  // here signals a dedup BUG, not corpus data — fail loud as an internal invariant.
+  try {
+    assertUniqueFiringLabels(built.firings);
+  } catch (err) {
+    if (err instanceof FiringLabelCollisionError) {
+      console.error(`${input.logPrefix} A1 post-dedup invariant violated (fold-D):`);
+      for (const c of err.collisions) {
+        console.error(`  • ${c.labelId.slice(0, 12)}… ×${c.evidenceRefs.length}`);
+      }
+      throw new TotemError(
+        'CONFIG_INVALID',
+        err.message,
+        'A post-dedup firing-label collision is an internal invariant violation: buildFirings ' +
+          'should have collapsed same-labelId matches. This indicates a dedup defect, not a corpus issue.',
+        err,
+      );
+    }
+    throw err;
+  }
+
+  return built;
+}
+
+/**
  * Run the REAL engine for the certifying phase (5c-i — #2189 item 1).
  *
  * Replaces the mock for `--phase certifying`: drives each resolved-PR diff
@@ -981,13 +1036,7 @@ export async function runCertifyingEngine(
   readStrategy: (file: string) => Promise<string | null>,
   corpusProvider?: CertifyingCorpusProvider,
 ): Promise<EngineResult> {
-  const {
-    buildFirings,
-    assertUniqueFiringLabels,
-    resolveGitRoot,
-    TotemError,
-    FiringLabelCollisionError,
-  } = await import('@mmnto/totem');
+  const { TotemError } = await import('@mmnto/totem');
 
   if (!corpusProvider) {
     // No silent empty-set scoring: a certifying run with no corpus provider is a
@@ -1002,48 +1051,16 @@ export async function runCertifyingEngine(
   }
 
   const corpus = await corpusProvider(lock);
-  const cwd = resolveGitRoot(process.cwd()) ?? process.cwd();
-  const ruleEngineCtx = {
-    logger: { warn: (msg: string) => console.error(`[WindtunnelRun] ${msg}`) },
-    state: { hasWarnedShieldContext: false },
-  };
-
-  // buildFirings runs fold-F (archived assert) internally before the engine; its
-  // only throw is ArchivedRuleInScopeError, which propagates. A1 (labelId
-  // collision) is deliberately NOT raised here — it is the caller's pre-score gate
-  // below (assertUniqueFiringLabels), so the structured per-collision report is
-  // threaded there rather than swallowed at construction. (greptile #2215 P2.)
-  const built = await buildFirings({
+  // Enumerate firings via the SHARED certifying firing-setup (cwd resolution +
+  // ruleEngineCtx + buildFirings + the A1 collision gate). The 5d-iii deriver calls
+  // the SAME path, so the answer-key labelIds it mints are byte-identical to the
+  // firings scored here — drift in this setup would silently void the answer key.
+  const built = await buildCertifyingFirings({
     rules: corpus.rules,
     prDiffs: corpus.prDiffs,
-    cwd,
     readStrategy,
-    ruleEngineCtx,
-    onWarn: (msg) => console.error(`[WindtunnelRun] ${msg}`),
+    logPrefix: '[WindtunnelRun]',
   });
-
-  // A1 (fold-D): post-dedup uniqueness INVARIANT before scoring (Tenet 4).
-  // `buildFirings` now collapses same-labelId matches (fold-D dedup), so this can
-  // no longer fire on an honest multi-match line — a collision here signals a
-  // dedup BUG, not corpus data, so it fails loud as an internal invariant.
-  try {
-    assertUniqueFiringLabels(built.firings);
-  } catch (err) {
-    if (err instanceof FiringLabelCollisionError) {
-      console.error(`[WindtunnelRun] A1 post-dedup invariant violated (fold-D):`);
-      for (const c of err.collisions) {
-        console.error(`  • ${c.labelId.slice(0, 12)}… ×${c.evidenceRefs.length}`);
-      }
-      throw new TotemError(
-        'CONFIG_INVALID',
-        err.message,
-        'A post-dedup firing-label collision is an internal invariant violation: buildFirings ' +
-          'should have collapsed same-labelId matches. This indicates a dedup defect, not a corpus issue.',
-        err,
-      );
-    }
-    throw err;
-  }
 
   const mintedRuleIds = corpus.rules.map((r) => r.lessonHash);
   console.error(

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1925,6 +1925,35 @@ windtunnelCmd
     }
   });
 
+windtunnelCmd
+  .command('derive-labels')
+  .description(
+    'Derive ground-truth-labels.json — the cert-run answer key (firingLabelId → TP|FP) — from the frozen dispositions, hard-gating corpusDispositionsSha and stamping groundTruthSha (strategy#709 5d-iii; by-hand/live, never CI)',
+  )
+  .option(
+    '--lc-dir <path>',
+    'Path to the lc clone (env: TOTEM_LC_DIR)',
+    process.env['TOTEM_LC_DIR'],
+  )
+  .option(
+    '--lock-path <path>',
+    'Override the lock file path (default: .totem/spine/gate-1/windtunnel.lock.json)',
+  )
+  .option('--output-dir <dir>', 'Override the gate-1 output dir (default: the lock’s dir)')
+  .action(async (opts: { lcDir?: string; lockPath?: string; outputDir?: string }) => {
+    try {
+      const { deriveLabelsCommand } = await import('./commands/spine-derive-labels.js');
+      await deriveLabelsCommand({
+        lcDir: opts.lcDir,
+        lockPath: opts.lockPath,
+        outputDir: opts.outputDir,
+      });
+    } catch (err) {
+      handleError(err);
+      throw err;
+    }
+  });
+
 // Fire-and-forget: reap orphaned temp files from previous crashed runs
 reapOrphanedTempFiles(process.cwd(), '.totem').catch(() => {});
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -833,6 +833,13 @@ export {
   CorpusDispositionsSchema,
   CorpusDispositionThreadSchema,
 } from './spine/corpus-dispositions.js';
+export type {
+  DeriveLabelDiagnostics,
+  DeriveLabelsResult,
+  LabelEvidence,
+  UnlabeledReason,
+} from './spine/derive-labels.js';
+export { deriveLabelsFromDispositions } from './spine/derive-labels.js';
 export type { DispositionClass, DispositionComment } from './spine/disposition-taxonomy.js';
 export { classifyDisposition, dispositionToLabel } from './spine/disposition-taxonomy.js';
 export type {

--- a/packages/core/src/spine/derive-labels.test.ts
+++ b/packages/core/src/spine/derive-labels.test.ts
@@ -75,6 +75,16 @@ describe('deriveLabelsFromDispositions — span-join (added-line-only)', () => {
     expect(diagnostics.unlabeledByReason['no-matching-disposition']).toBe(1);
   });
 
+  it('binds a real added line that itself starts with `++` (diff row "+++i") — not a file header', () => {
+    const { labels } = deriveLabelsFromDispositions(
+      [firing({ labelId: 'L1', matchedLine: '++i;' })],
+      // source line `++i;` appears in a unified diff as the row "+++i;" (add-marker + content);
+      // it must bind, unlike the `+++ <path>` file header (CR #10 false-negative guard).
+      [disposition(1, [thread({ diffHunk: '@@ -1,1 +1,2 @@\n+++i;' })])],
+    );
+    expect(labels['L1']).toBe('TP');
+  });
+
   it('does NOT bind across files (path mismatch) even on identical added content', () => {
     const { labels } = deriveLabelsFromDispositions(
       [firing({ labelId: 'L1', filePath: 'src/a.ts' })],
@@ -117,6 +127,15 @@ describe('deriveLabelsFromDispositions — ambiguity', () => {
     );
     expect(labels['L1']).toBeUndefined();
     expect(diagnostics.unlabeledByReason['ambiguous-multiple-dispositions']).toBe(1);
+  });
+
+  it('throws loud on a duplicate-PR dispositions entry (no silent last-wins)', () => {
+    expect(() =>
+      deriveLabelsFromDispositions(
+        [firing({ labelId: 'L1' })],
+        [disposition(1, [thread({})]), disposition(1, [thread({})])],
+      ),
+    ).toThrow(/duplicate disposition entry for PR 1/);
   });
 });
 

--- a/packages/core/src/spine/derive-labels.test.ts
+++ b/packages/core/src/spine/derive-labels.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, it } from 'vitest';
+
+import type { CorpusDisposition, CorpusDispositionThread } from './corpus-dispositions.js';
+import { deriveLabelsFromDispositions } from './derive-labels.js';
+import type { RuleFiring } from './windtunnel-scorer.js';
+
+// ─── builders ────────────────────────────────────────
+
+function firing(over: Partial<RuleFiring> & Pick<RuleFiring, 'labelId'>): RuleFiring {
+  return {
+    ruleId: 'rule-a',
+    pr: 1,
+    filePath: 'src/a.ts',
+    matchedLine: 'forbiddenCall()',
+    controlKind: 'corpus',
+    ...over,
+  };
+}
+
+function thread(over: Partial<CorpusDispositionThread>): CorpusDispositionThread {
+  return {
+    path: 'src/a.ts',
+    diffHunk: '@@ -1,2 +1,3 @@\n context();\n+forbiddenCall()',
+    isResolved: false,
+    isOutdated: false,
+    comments: [{ author: 'Jane', body: 'fixed' }],
+    ...over,
+  };
+}
+
+function disposition(pr: number, threads: CorpusDispositionThread[]): CorpusDisposition {
+  return { pr, mergeCommitSha: String(pr).padStart(40, '0'), threads };
+}
+
+// ─── span-join: added-line-only binding (codex hard fold) ────────────────────
+
+describe('deriveLabelsFromDispositions — span-join (added-line-only)', () => {
+  it('binds a corpus firing to a disposition via an ADDED (+) hunk row', () => {
+    const { labels, diagnostics } = deriveLabelsFromDispositions(
+      [firing({ labelId: 'L1' })],
+      [disposition(1, [thread({})])],
+    );
+    expect(labels['L1']).toBe('TP'); // 'fixed' → accepted-fix → TP
+    expect(diagnostics.boundCorpusFirings).toBe(1);
+  });
+
+  it('does NOT bind to a CONTEXT row (leading space) — context-only ⟹ no label', () => {
+    const { labels, diagnostics } = deriveLabelsFromDispositions(
+      [firing({ labelId: 'L1' })],
+      // same text present ONLY as a context row — never as an added row.
+      [disposition(1, [thread({ diffHunk: '@@ -1,2 +1,2 @@\n context();\n forbiddenCall()' })])],
+    );
+    expect(labels['L1']).toBeUndefined();
+    expect(diagnostics.unlabeledByReason['no-matching-disposition']).toBe(1);
+  });
+
+  it('binds via the ADDED row even when the same text also appears as a context row', () => {
+    const { labels } = deriveLabelsFromDispositions(
+      [firing({ labelId: 'L1' })],
+      [
+        disposition(1, [
+          thread({ diffHunk: '@@ -1,3 +1,4 @@\n forbiddenCall()\n-old()\n+forbiddenCall()' }),
+        ]),
+      ],
+    );
+    expect(labels['L1']).toBe('TP');
+  });
+
+  it('ignores a +++ file header that coincidentally matches the line', () => {
+    const { labels, diagnostics } = deriveLabelsFromDispositions(
+      [firing({ labelId: 'L1', matchedLine: '+ b/forbiddenCall()' })],
+      [disposition(1, [thread({ diffHunk: '+++ b/forbiddenCall()\n context();' })])],
+    );
+    expect(labels['L1']).toBeUndefined();
+    expect(diagnostics.unlabeledByReason['no-matching-disposition']).toBe(1);
+  });
+
+  it('does NOT bind across files (path mismatch) even on identical added content', () => {
+    const { labels } = deriveLabelsFromDispositions(
+      [firing({ labelId: 'L1', filePath: 'src/a.ts' })],
+      [disposition(1, [thread({ path: 'src/other.ts' })])],
+    );
+    expect(labels['L1']).toBeUndefined();
+  });
+
+  it('matches trailing-whitespace-drifted content (mirrors normalizeMatchedLine)', () => {
+    const { labels } = deriveLabelsFromDispositions(
+      [firing({ labelId: 'L1', matchedLine: 'forbiddenCall()' })],
+      // the added row carries trailing whitespace; the bind must still hold.
+      [disposition(1, [thread({ diffHunk: '@@ -1,1 +1,2 @@\n+forbiddenCall()   ' })])],
+    );
+    expect(labels['L1']).toBe('TP');
+  });
+});
+
+// ─── ambiguity never labels (codex: 0 or >1 ⟹ omit) ──────────────────────────
+
+describe('deriveLabelsFromDispositions — ambiguity', () => {
+  it('omits when ZERO dispositions bind', () => {
+    const { labels, diagnostics } = deriveLabelsFromDispositions(
+      [firing({ labelId: 'L1', pr: 99 })],
+      [disposition(1, [thread({})])],
+    );
+    expect(labels['L1']).toBeUndefined();
+    expect(diagnostics.unlabeledByReason['no-matching-disposition']).toBe(1);
+  });
+
+  it('omits when MORE THAN ONE disposition binds (ambiguous)', () => {
+    const { labels, diagnostics } = deriveLabelsFromDispositions(
+      [firing({ labelId: 'L1' })],
+      [
+        disposition(1, [
+          thread({}),
+          thread({ comments: [{ author: 'Jo', body: 'false positive' }] }),
+        ]),
+      ],
+    );
+    expect(labels['L1']).toBeUndefined();
+    expect(diagnostics.unlabeledByReason['ambiguous-multiple-dispositions']).toBe(1);
+  });
+});
+
+// ─── taxonomy projection (5d-i) ──────────────────────────────────────────────
+
+describe('deriveLabelsFromDispositions — taxonomy projection', () => {
+  it('accepted-fix ⟹ TP, declined-as-false-positive ⟹ FP, soft-decline ⟹ UNLABELED', () => {
+    const { labels, diagnostics } = deriveLabelsFromDispositions(
+      [
+        firing({ labelId: 'TPf', pr: 1, filePath: 'src/a.ts' }),
+        firing({ labelId: 'FPf', pr: 2, filePath: 'src/b.ts' }),
+        firing({ labelId: 'UNf', pr: 3, filePath: 'src/c.ts' }),
+      ],
+      [
+        disposition(1, [thread({ comments: [{ author: 'Jane', body: 'fixed' }] })]),
+        disposition(2, [
+          thread({
+            path: 'src/b.ts',
+            comments: [{ author: 'Jane', body: 'this is a false positive' }],
+          }),
+        ]),
+        disposition(3, [
+          thread({
+            path: 'src/c.ts',
+            comments: [{ author: 'Jane', body: 'out of scope for this PR' }],
+          }),
+        ]),
+      ],
+    );
+    expect(labels['TPf']).toBe('TP');
+    expect(labels['FPf']).toBe('FP');
+    expect(labels['UNf']).toBeUndefined(); // soft decline routes to UNLABELED
+    expect(diagnostics.unlabeledByReason['unlabeled-class']).toBe(1);
+  });
+});
+
+// ─── control kinds ───────────────────────────────────────────────────────────
+
+describe('deriveLabelsFromDispositions — control kinds', () => {
+  it('negative-control firings never label (the scorer culls)', () => {
+    const { labels, diagnostics } = deriveLabelsFromDispositions(
+      [firing({ labelId: 'N1', controlKind: 'negative' })],
+      [],
+    );
+    expect(labels['N1']).toBeUndefined();
+    expect(diagnostics.negativeFirings).toBe(1);
+  });
+
+  it('positive-control: TP ONLY for the declared (pr,targetRuleId) target; incidental omitted', () => {
+    const { labels, diagnostics } = deriveLabelsFromDispositions(
+      [
+        // declared target: ruleId === targetRuleId ⟹ structural TP
+        firing({ labelId: 'PT', controlKind: 'positive', pr: 5, ruleId: 'R1', targetRuleId: 'R1' }),
+        // incidental: a different rule fired on the positive fixture ⟹ omit + report
+        firing({ labelId: 'PI', controlKind: 'positive', pr: 5, ruleId: 'R2', targetRuleId: 'R1' }),
+      ],
+      [],
+    );
+    expect(labels['PT']).toBe('TP');
+    expect(labels['PI']).toBeUndefined();
+    expect(diagnostics.unlabeledByReason['incidental-positive']).toBe(1);
+    expect(diagnostics.positiveFirings).toBe(2);
+  });
+});
+
+// ─── diagnostics + evidence ──────────────────────────────────────────────────
+
+describe('deriveLabelsFromDispositions — diagnostics + evidence', () => {
+  it('reports density, per-rule counts, evidence-refs, and is deterministic', () => {
+    const firings: RuleFiring[] = [
+      firing({ labelId: 'a', ruleId: 'rule-x', pr: 1, filePath: 'src/a.ts' }),
+      firing({ labelId: 'b', ruleId: 'rule-x', pr: 2, filePath: 'src/b.ts' }), // unbound
+    ];
+    const dispositions = [
+      disposition(1, [
+        thread({ threadId: 'T_abc', comments: [{ commentId: 42, author: 'Jane', body: 'fixed' }] }),
+      ]),
+    ];
+    const first = deriveLabelsFromDispositions(firings, dispositions);
+    const second = deriveLabelsFromDispositions(firings, dispositions);
+
+    expect(first).toEqual(second); // deterministic
+    expect(first.diagnostics.corpusFirings).toBe(2);
+    expect(first.diagnostics.boundCorpusFirings).toBe(1);
+    expect(first.diagnostics.dispositionDensity).toBe(0.5);
+    expect(first.diagnostics.labelCounts).toEqual({ TP: 1, FP: 0 });
+    expect(first.diagnostics.perRuleLabeled['rule-x']).toEqual({ TP: 1, FP: 0 });
+    // evidence-ref links the emitted label back to its disposition source (audit).
+    expect(first.evidence).toHaveLength(1);
+    expect(first.evidence[0]).toMatchObject({
+      labelId: 'a',
+      label: 'TP',
+      threadId: 'T_abc',
+      commentId: 42,
+      source: 'corpus-disposition',
+    });
+    // the answer key carries ONLY TP|FP values (no evidence leaks into the hashed key).
+    expect(Object.values(first.labels)).toEqual(['TP']);
+  });
+
+  it('density is 0 (not NaN) when there are no corpus firings', () => {
+    const { diagnostics } = deriveLabelsFromDispositions(
+      [firing({ labelId: 'N', controlKind: 'negative' })],
+      [],
+    );
+    expect(diagnostics.dispositionDensity).toBe(0);
+    expect(diagnostics.unlabeledRate).toBe(0);
+  });
+});

--- a/packages/core/src/spine/derive-labels.ts
+++ b/packages/core/src/spine/derive-labels.ts
@@ -1,0 +1,236 @@
+import type { CorpusDisposition } from './corpus-dispositions.js';
+import { classifyDisposition, dispositionToLabel } from './disposition-taxonomy.js';
+import { normalizeMatchedLine } from './windtunnel-firing.js';
+import type { GroundTruthLabel, RuleFiring } from './windtunnel-scorer.js';
+
+/**
+ * strategy#709 5d-iii — the ground-truth label deriver (pure core).
+ *
+ * Produces the cert-run answer key (`firingLabelId → TP|FP`) by joining the
+ * enumerated `RuleFiring`s against the frozen held-out `CorpusDisposition`s, then
+ * classifying each bound thread through the closed 5d-i taxonomy. The CLI
+ * `derive-labels` command supplies firings enumerated byte-identically to the
+ * certifying run (shared firing-setup) and the integrity-gated dispositions;
+ * this function is the deterministic, zero-LLM transform between them.
+ *
+ * Span-join invariant (codex hard fold): a corpus firing binds to a disposition
+ * thread on the SAME pr ONLY when (a) the thread's path matches the firing's
+ * file and (b) the firing's normalized `matchedLine` equals an ADDED (`+`)
+ * post-image row of the thread's `diffHunk`. Context rows, removed rows, hunk
+ * headers, and file headers are INELIGIBLE — a disposition labels a firing only
+ * by content the PR actually added, never by a line it merely sits near. 0 or
+ * >1 bound threads ⟹ omit (the scorer routes the un-keyed firing to
+ * `needsAdjudication`).
+ */
+
+/** Why a non-negative firing received no label (diagnostic only; never in the answer key). */
+export type UnlabeledReason =
+  /** corpus firing: no disposition thread bound by path + added-line content. */
+  | 'no-matching-disposition'
+  /** corpus firing: >1 disposition thread bound — ambiguous, never labels. */
+  | 'ambiguous-multiple-dispositions'
+  /** corpus firing: a thread bound, but its taxonomy class is non-label-bearing (UNLABELED). */
+  | 'unlabeled-class'
+  /** positive-control firing that is NOT the declared (pr, targetRuleId) target. */
+  | 'incidental-positive';
+
+/**
+ * Deriver-side data-quality diagnostics (gemini: deriver reports DATA QUALITY,
+ * the scorer reports MODEL PERFORMANCE). Deterministic + zero-LLM. Surfaced so a
+ * sparse first verdict reads as "here's the coverage + why", not a silent fail.
+ */
+export interface DeriveLabelDiagnostics {
+  /** Total firings enumerated (all control kinds). */
+  totalFirings: number;
+  /** Negative-control firings (no label — the scorer culls the rule). */
+  negativeFirings: number;
+  /** Corpus firings (the real precision surface). */
+  corpusFirings: number;
+  /** Positive-control firings. */
+  positiveFirings: number;
+  /** Corpus firings that received a TP/FP label. */
+  boundCorpusFirings: number;
+  /** boundCorpusFirings / corpusFirings — 0 when there are no corpus firings. */
+  dispositionDensity: number;
+  /** Non-negative firings with no label (the scorer's future `needsAdjudication` set). */
+  unlabeledFirings: number;
+  /** unlabeledFirings / (corpusFirings + positiveFirings) — 0 when that denominator is 0. */
+  unlabeledRate: number;
+  /** Label counts in the emitted answer key. */
+  labelCounts: { TP: number; FP: number };
+  /** Per-rule labeled-firing counts (ruleId → {TP, FP}); only rules that labeled appear. */
+  perRuleLabeled: Record<string, { TP: number; FP: number }>;
+  /** Breakdown of why firings went unlabeled. */
+  unlabeledByReason: Record<UnlabeledReason, number>;
+}
+
+/**
+ * Provenance for one emitted label — links the answer-key entry back to its
+ * disposition source for audit. NOT part of the hashed answer key (whose values
+ * stay a bare `TP|FP`); surfaced in the deriver's report only.
+ */
+export interface LabelEvidence {
+  labelId: string;
+  label: GroundTruthLabel;
+  pr: number;
+  ruleId: string;
+  filePath: string;
+  /** Source disposition thread id (corpus labels only; positive-target labels omit it). */
+  threadId?: string;
+  /** Root review-comment databaseId of the bound thread (corpus labels only). */
+  commentId?: number;
+  source: 'corpus-disposition' | 'positive-control-target';
+}
+
+export interface DeriveLabelsResult {
+  /**
+   * The answer key: `firingLabelId → TP|FP`. The ONLY thing written to
+   * `ground-truth-labels.json` (and the bytes `groundTruthSha` covers).
+   */
+  labels: Record<string, GroundTruthLabel>;
+  diagnostics: DeriveLabelDiagnostics;
+  /** Per-label provenance (audit; surfaced in the report, never in the hashed key). */
+  evidence: LabelEvidence[];
+}
+
+/**
+ * Extract the normalized ADDED (`+`) post-image rows of a unified-diff hunk.
+ * Only `+`-prefixed content rows are eligible: context rows (leading space),
+ * removed rows (`-`), the hunk header (`@@`), file headers (`+++`/`---`), and
+ * the no-newline marker (`\`) are all excluded. Each eligible row is stripped of
+ * its leading `+` and normalized with `normalizeMatchedLine` (the SAME rule the
+ * firing's `matchedLine` is built with) so the content bind keys on identical
+ * bytes.
+ */
+function addedHunkLines(diffHunk: string): Set<string> {
+  const added = new Set<string>();
+  for (const row of diffHunk.split('\n')) {
+    if (row.charCodeAt(0) !== 0x2b /* '+' */) continue; // added rows only
+    if (row.startsWith('+++')) continue; // file header, not added content
+    added.add(normalizeMatchedLine(row.slice(1)));
+  }
+  return added;
+}
+
+/**
+ * Derive the cert-run ground-truth answer key from enumerated firings + frozen
+ * held-out dispositions. Pure + deterministic — no I/O, no clock, no LLM.
+ */
+export function deriveLabelsFromDispositions(
+  firings: readonly RuleFiring[],
+  dispositions: readonly CorpusDisposition[],
+): DeriveLabelsResult {
+  const dispByPr = new Map<number, CorpusDisposition>();
+  for (const d of dispositions) dispByPr.set(d.pr, d);
+
+  const labels: Record<string, GroundTruthLabel> = {};
+  const evidence: LabelEvidence[] = [];
+  const perRuleLabeled: Record<string, { TP: number; FP: number }> = {};
+  const labelCounts = { TP: 0, FP: 0 };
+  const unlabeledByReason: Record<UnlabeledReason, number> = {
+    'no-matching-disposition': 0,
+    'ambiguous-multiple-dispositions': 0,
+    'unlabeled-class': 0,
+    'incidental-positive': 0,
+  };
+  let negativeFirings = 0;
+  let corpusFirings = 0;
+  let positiveFirings = 0;
+  let boundCorpusFirings = 0;
+
+  const emit = (firing: RuleFiring, label: GroundTruthLabel, ev: LabelEvidence): void => {
+    labels[firing.labelId] = label;
+    labelCounts[label] += 1;
+    (perRuleLabeled[firing.ruleId] ??= { TP: 0, FP: 0 })[label] += 1;
+    evidence.push(ev);
+  };
+
+  for (const firing of firings) {
+    switch (firing.controlKind) {
+      case 'negative':
+        // Negative controls never label — the scorer culls the firing rule (S2/C5).
+        negativeFirings += 1;
+        break;
+      case 'positive': {
+        positiveFirings += 1;
+        // TP structurally ONLY for the declared (pr, targetRuleId) target firing
+        // (codex BLOCKING-1). An incidental non-target firing on a positive
+        // fixture is NOT laundered TP — omit it and report; the scorer routes the
+        // un-keyed firing to needsAdjudication.
+        if (firing.targetRuleId !== undefined && firing.ruleId === firing.targetRuleId) {
+          emit(firing, 'TP', {
+            labelId: firing.labelId,
+            label: 'TP',
+            pr: firing.pr,
+            ruleId: firing.ruleId,
+            filePath: firing.filePath,
+            source: 'positive-control-target',
+          });
+        } else {
+          unlabeledByReason['incidental-positive'] += 1;
+        }
+        break;
+      }
+      case 'corpus': {
+        corpusFirings += 1;
+        const disp = dispByPr.get(firing.pr);
+        const bound = disp
+          ? disp.threads.filter(
+              (t) =>
+                t.path.replace(/\\/g, '/') === firing.filePath &&
+                addedHunkLines(t.diffHunk).has(firing.matchedLine),
+            )
+          : [];
+        if (bound.length !== 1) {
+          unlabeledByReason[
+            bound.length === 0 ? 'no-matching-disposition' : 'ambiguous-multiple-dispositions'
+          ] += 1;
+          break;
+        }
+        const thread = bound[0]!;
+        const label = dispositionToLabel(classifyDisposition(thread.comments));
+        if (label === null) {
+          unlabeledByReason['unlabeled-class'] += 1;
+          break;
+        }
+        boundCorpusFirings += 1;
+        emit(firing, label, {
+          labelId: firing.labelId,
+          label,
+          pr: firing.pr,
+          ruleId: firing.ruleId,
+          filePath: firing.filePath,
+          threadId: thread.threadId,
+          commentId: thread.comments[0]?.commentId,
+          source: 'corpus-disposition',
+        });
+        break;
+      }
+    }
+  }
+
+  const unlabeledFirings =
+    unlabeledByReason['no-matching-disposition'] +
+    unlabeledByReason['ambiguous-multiple-dispositions'] +
+    unlabeledByReason['unlabeled-class'] +
+    unlabeledByReason['incidental-positive'];
+  const scoredDenominator = corpusFirings + positiveFirings;
+
+  return {
+    labels,
+    evidence,
+    diagnostics: {
+      totalFirings: firings.length,
+      negativeFirings,
+      corpusFirings,
+      positiveFirings,
+      boundCorpusFirings,
+      dispositionDensity: corpusFirings === 0 ? 0 : boundCorpusFirings / corpusFirings,
+      unlabeledFirings,
+      unlabeledRate: scoredDenominator === 0 ? 0 : unlabeledFirings / scoredDenominator,
+      labelCounts,
+      perRuleLabeled,
+      unlabeledByReason,
+    },
+  };
+}

--- a/packages/core/src/spine/derive-labels.ts
+++ b/packages/core/src/spine/derive-labels.ts
@@ -1,4 +1,4 @@
-import type { CorpusDisposition } from './corpus-dispositions.js';
+import type { CorpusDisposition, CorpusDispositionThread } from './corpus-dispositions.js';
 import { classifyDisposition, dispositionToLabel } from './disposition-taxonomy.js';
 import { normalizeMatchedLine } from './windtunnel-firing.js';
 import type { GroundTruthLabel, RuleFiring } from './windtunnel-scorer.js';
@@ -106,7 +106,10 @@ function addedHunkLines(diffHunk: string): Set<string> {
   const added = new Set<string>();
   for (const row of diffHunk.split('\n')) {
     if (row.charCodeAt(0) !== 0x2b /* '+' */) continue; // added rows only
-    if (row.startsWith('+++')) continue; // file header, not added content
+    // The unified-diff file header is "+++ <path>" — three '+' THEN A SPACE. A real
+    // added line such as `++i` appears as the diff row "+++i" (no space) and MUST
+    // bind, so match the header by its trailing space, not a bare `+++` prefix (CR).
+    if (/^\+\+\+ /.test(row)) continue; // file header, not added content
     added.add(normalizeMatchedLine(row.slice(1)));
   }
   return added;
@@ -120,8 +123,36 @@ export function deriveLabelsFromDispositions(
   firings: readonly RuleFiring[],
   dispositions: readonly CorpusDisposition[],
 ): DeriveLabelsResult {
+  // Index dispositions by PR. Fail loud on a duplicate-PR entry (greptile): a producer
+  // bug in `fetch-dispositions`, or a partially-valid manual edit that still passes the
+  // re-stamped `corpusDispositionsSha` gate, could ship two entries for one PR — and a
+  // silent last-wins Map would drop the first entry's threads, so firings that should
+  // bind to them get a wrong `no-matching-disposition` with no diagnostic. A structural
+  // input-contract violation throws (Tenet 4); only DATA ambiguity fails soft to UNLABELED.
   const dispByPr = new Map<number, CorpusDisposition>();
-  for (const d of dispositions) dispByPr.set(d.pr, d);
+  for (const d of dispositions) {
+    if (dispByPr.has(d.pr)) {
+      throw new Error(
+        `deriveLabelsFromDispositions: duplicate disposition entry for PR ${d.pr} — the ` +
+          `dispositions array must carry exactly one entry per PR (a producer or edit bug).`,
+      );
+    }
+    dispByPr.set(d.pr, d);
+  }
+
+  // Memoize the parsed added-line set per disposition THREAD: the span-join scans every
+  // thread for each corpus firing, so without this `addedHunkLines` would re-split +
+  // re-normalize the same `diffHunk` once per firing (GCA). The WeakMap keys on the
+  // thread object, so it's GC-friendly and stays internal to this call (still pure).
+  const addedLinesCache = new WeakMap<CorpusDispositionThread, Set<string>>();
+  const getAddedLines = (thread: CorpusDispositionThread): Set<string> => {
+    let cached = addedLinesCache.get(thread);
+    if (!cached) {
+      cached = addedHunkLines(thread.diffHunk);
+      addedLinesCache.set(thread, cached);
+    }
+    return cached;
+  };
 
   const labels: Record<string, GroundTruthLabel> = {};
   const evidence: LabelEvidence[] = [];
@@ -178,7 +209,7 @@ export function deriveLabelsFromDispositions(
           ? disp.threads.filter(
               (t) =>
                 t.path.replace(/\\/g, '/') === firing.filePath &&
-                addedHunkLines(t.diffHunk).has(firing.matchedLine),
+                getAddedLines(t).has(firing.matchedLine),
             )
           : [];
         if (bound.length !== 1) {

--- a/packages/core/src/spine/windtunnel-firing.ts
+++ b/packages/core/src/spine/windtunnel-firing.ts
@@ -101,8 +101,13 @@ export class ArchivedRuleInScopeError extends Error {
  * whitespace is dropped so cosmetic EOL drift between the post-image and the
  * diff does not split a firing into a new labelId; interior content is
  * preserved (the label must still distinguish genuinely different lines).
+ *
+ * Exported so the 5d-iii label-deriver's span-join normalizes a disposition's
+ * added hunk rows with the EXACT same rule the firing's `matchedLine` uses —
+ * the content bind keys on the same bytes the labelId keys on, so the two can
+ * never silently drift apart (codex hard fold + the panel anti-drift mandate).
  */
-function normalizeMatchedLine(line: string): string {
+export function normalizeMatchedLine(line: string): string {
   return line.replace(/\s+$/, '');
 }
 

--- a/packages/core/src/spine/windtunnel-lock.ts
+++ b/packages/core/src/spine/windtunnel-lock.ts
@@ -126,6 +126,23 @@ export const WindtunnelLockSchema = z
           .string()
           .regex(SHA256_REGEX, 'corpusDispositionsSha must be a 64-hex sha256')
           .optional(),
+        // #709 5d-iii: an integrity digest over the frozen `ground-truth-labels.json`
+        // — the cert-run ANSWER KEY (firingLabelId → TP|FP) the deriver produces from
+        // the dispositions. Run-critical like `prDiffsSha`: the certifying run reads
+        // the MATERIALIZED frozen labels (never re-derives), so the digest is what
+        // makes "the answer key the run graded against is the one the deriver emitted"
+        // verifiable. ENCODING (mirrors prDiffsSha / corpusDispositionsSha): sha256
+        // (64-hex) over the EXACT on-disk `ground-truth-labels.json` bytes (canonical
+        // 2-space JSON + trailing newline, CRLF→LF-normalized), so an enforcer can
+        // `sha256` the file directly. STAMPED by `derive-labels` (5d-iii-i); the run's
+        // `loadCertRunFixtures` verify-then-parses it on a single read + `freeze` warns
+        // (5d-iii-ii). Additive-optional: locks with no derived answer key parse
+        // unchanged; once the run-enforcement lands the certifying path hard-errors if
+        // absent (no safe default for an integrity hash).
+        groundTruthSha: z
+          .string()
+          .regex(SHA256_REGEX, 'groundTruthSha must be a 64-hex sha256')
+          .optional(),
       }),
     }),
     cullRateThreshold: z


### PR DESCRIPTION
## What

**Gate-1 ground-truth label deriver (strategy#709 5d-iii-i)** — produces `ground-truth-labels.json`, the cert run's disposition-derived **answer key** (`firingLabelId → TP|FP`). With this slice the certifying run is executable end-to-end (the missing input was the answer key the scorer grades against).

This is **5d-iii-i** of a two-PR cut (mirroring the producer #2224 → enforcement #2227 split):

- **5d-iii-i (this PR):** the deriver — produces + stamps the answer key.
- **5d-iii-ii (fast-follow):** run-side `groundTruthSha` verify-then-parse in `loadCertRunFixtures` + a `freeze` warn.

## How

- **Core span-join** (`deriveLabelsFromDispositions`, pure/zero-LLM): a corpus firing binds to a held-out disposition on the same PR by **added-line content** — the firing's normalized `matchedLine` must equal an ADDED (`+`) hunk row (context/removed rows + `+++`/`---` headers ineligible; `line`/`originalLine` are locator hints only — never physical-line equality). 0-or->1 bound dispositions ⟹ omit (ambiguity never labels). The bound thread is classified through the 5d-i taxonomy (`accepted-fix → TP`, `declined-as-false-positive → FP`, else UNLABELED → omitted → the scorer's `needsAdjudication`).
- **Positive controls:** TP **only** for the declared `(pr, targetRuleId)` target firing; incidental non-target firings are omitted + reported (never laundered TP). Negatives never label.
- **CLI** `totem spine windtunnel derive-labels`: hard-gates `controls.integrity.corpusDispositionsSha` (verify-then-parse single read, CRLF→LF) **before** any derivation — a tampered disposition would silently flip a label (the #2224/#2225 lesson); stamps `controls.integrity.groundTruthSha` over the canonical answer-key bytes; emits a deterministic data-quality diagnostic (disposition density / UNLABELED rate / per-rule counts). Requires the lc clone (no post-image ⟹ silently-empty key ⟹ fail loud).
- **Drift kill (panel "do both"):** firings are enumerated through a **shared** certifying firing-setup (`buildCertifyingFirings`) + corpus-assembly path (`assembleCertifyingCorpus` + `buildGate1Stage4Deps`) that `runCertifyingEngine` now also calls — so the answer-key labelIds match the run's `buildFirings` labelIds byte-for-byte. `normalizeMatchedLine` is exported + reused so the span-join can't drift from the firing's own normalization.
- **Circularity guard:** the deriver never calls `loadCertRunFixtures` (it reads the file we emit); it reuses the shared corpus path with `skipGroundTruth: true`.

## Tests

- **Core** (`derive-labels.test.ts`, 13): added-line-only binding (vs context-only / dual-occurrence / `+++` header / path mismatch / trailing-ws drift), ambiguity (0 / >1), taxonomy projection (TP/FP/UNLABELED), control kinds (negative skip, positive target-vs-incidental), diagnostics + evidence-refs + determinism.
- **CLI** (`spine-derive-labels.test.ts`, 5): the panel's minimal-fixture **equivalence** test (deriver labelIds ⊆ the run's `buildCertifyingFirings` labelIds + determinism) and the integrity gates (no-lc-dir, `corpusDispositionsSha` missing, `corpusDispositionsSha` mismatch).
- Refactor regression: existing `windtunnel-firing` / `windtunnel-lock` / `spine-cert-run-corpus` / `spine-windtunnel` suites green (the run now routes through the extracted shared setup).
- Deferred to 5d-iii-ii: tampered-`ground-truth-labels.json` hard-fail in `loadCertRunFixtures` (the run-side `groundTruthSha` verify lives there).

## Changeset

One consolidated `@mmnto/totem` minor covering the full **5d** arc (5d-i / 5d-ii landed changeset-deferred), so the deriver ships as a single Version Packages entry.

## Provenance

Cohort pre-build panel **PASS 3/3** (codex contract / agy build / gemini tenet, distinct lenses); operator greenlit. Advances strategy#709 5d; part of the Convergent Spine (#2199). Not a full close of any totem issue.
