### PR TITLE
fix(spine): cert-run papercuts #2237 — record loadEnv, freeze auto-seals llmReplaySha, persist firing detail on FAIL

### DIFF
--- a/.changeset/spine-cert-run-papercuts.md
+++ b/.changeset/spine-cert-run-papercuts.md
@@ -1,0 +1,11 @@
+---
+'@mmnto/cli': patch
+---
+
+spine: cert-run papercuts (#2237) — record `loadEnv`, freeze auto-seals `llmReplaySha`, persist firing detail on FAIL
+
+Three fix-forwards the first end-to-end Gate-1 cert run (strategy#709) surfaced — each a gap that only showed up because the pipeline had never run live before:
+
+- **`spine windtunnel record` now `loadEnv(cwd)`** before resolving the provider credential, so an `.env`-only `ANTHROPIC_API_KEY` is visible. The spine commands (unlike ~18 others) did not load `.env`, so `record` fail-closed as "no credential resolved" until the key was exported by hand.
+- **`freeze` now auto-SEALS `controls.integrity.llmReplaySha`** from the frozen `llm-replay.v1.json` — the two-phase lock's documented sealer (materialize omits it, record produces it, freeze seals it). It computes the same `computeArtifactHash` the run re-verifies, so the operator no longer hand-edits the lock. Absent fixture on a certifying lock warns (mirroring `prDiffsSha`/`groundTruthSha`).
+- **The certifying-run report now persists per-firing detail** (rule, pr, file, matched-line) REGARDLESS of verdict. Previously a FAIL / honest-negative run kept only the `needsAdjudication` labelId hashes, so the firings were not observable for blind-by-pattern adjudication.

--- a/packages/cli/src/commands/spine-cert-persist.test.ts
+++ b/packages/cli/src/commands/spine-cert-persist.test.ts
@@ -127,6 +127,21 @@ describe('persistCertifyingOutcome', () => {
     expect(report.persisted).toBe(false);
     expect(report.verdict.verdict).toBe('HONEST-NEGATIVE');
     expect(report.skips).toContainEqual({ reason: 'verdict-not-pass', verdict: 'HONEST-NEGATIVE' });
+
+    // #2237 papercut-3: firing detail is persisted REGARDLESS of verdict — a non-PASS
+    // run must still carry the (rule, pr, file, matched-line) records for blind-by-pattern
+    // adjudication, not only the needsAdjudication labelId hashes the verdict surfaces.
+    expect(report.firings).toEqual([
+      {
+        labelId: 'label-r1-pos',
+        ruleId: 'r1',
+        pr: 1,
+        filePath: 'src/a.ts',
+        matchedLine: 'debugger;',
+        controlKind: 'positive',
+        targetRuleId: 'r1',
+      },
+    ]);
   });
 
   it('the report filename embeds the injected timestamp slug + a run-identity hash', async () => {

--- a/packages/cli/src/commands/spine-cert-persist.ts
+++ b/packages/cli/src/commands/spine-cert-persist.ts
@@ -124,6 +124,20 @@ export async function persistCertifyingOutcome(
     stampedRuleIds: projection.stamped.map((r) => r.lessonHash),
     skips: projection.skips,
     firingCount: input.firings.length,
+    // #2237 papercut-3: persist per-firing detail REGARDLESS of verdict. The verdict
+    // surfaces only `needsAdjudication` labelId hashes; a FAIL / honest-negative run
+    // dropped the (rule, pr, file, matched-line) records entirely, blocking
+    // blind-by-pattern adjudication observability (e.g. cert #1's 2 firings could not
+    // be re-surfaced without a re-run). Persist them on every verdict.
+    firings: input.firings.map((f) => ({
+      labelId: f.labelId,
+      ruleId: f.ruleId,
+      pr: f.pr,
+      filePath: f.filePath,
+      matchedLine: f.matchedLine,
+      controlKind: f.controlKind,
+      ...(f.targetRuleId ? { targetRuleId: f.targetRuleId } : {}),
+    })),
   };
   // Content hash over the run identity (NOT the timestamp) so the same run is
   // recognizable across re-runs; the timestamp disambiguates the filename.

--- a/packages/cli/src/commands/spine-cert-run-corpus.ts
+++ b/packages/cli/src/commands/spine-cert-run-corpus.ts
@@ -26,7 +26,8 @@ import type { CertifyingCorpus, CertifyingCorpusProvider } from './spine-windtun
 // ─── Fixture file names under the gate-1 dir ─────────
 
 const SPLIT_FILE = 'split.json';
-const REPLAY_FILE = 'llm-replay.v1.json';
+/** The frozen llm-replay fixture — produced by `record` (A2), sealed into the lock by `freeze`. */
+export const REPLAY_FILE = 'llm-replay.v1.json';
 const CONTENT_FILE = 'review-content.json';
 export const PR_DIFFS_FILE = 'pr-diffs.json';
 /** The cert-run answer key — produced by `derive-labels` (5d-iii), read by the run. */

--- a/packages/cli/src/commands/spine-windtunnel.test.ts
+++ b/packages/cli/src/commands/spine-windtunnel.test.ts
@@ -694,4 +694,20 @@ describe('computeReplaySeal (#2237 papercut-2 — llm-replay seal hash)', () => 
     fs.writeFileSync(replayPath, JSON.stringify(artifact), 'utf-8');
     expect(await computeReplaySeal(replayPath)).toBe(computeArtifactHash(artifact));
   });
+
+  it('throws a loud TotemError on invalid JSON (no raw SyntaxError escapes freeze)', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-seal-'));
+    createdDirs.push(dir);
+    const replayPath = path.join(dir, 'llm-replay.v1.json');
+    fs.writeFileSync(replayPath, '{ this is not json', 'utf-8');
+    await expect(computeReplaySeal(replayPath)).rejects.toThrow(/not valid JSON/);
+  });
+
+  it('throws a loud TotemError on a schema-invalid fixture (no raw ZodError escapes freeze)', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-seal-'));
+    createdDirs.push(dir);
+    const replayPath = path.join(dir, 'llm-replay.v1.json');
+    fs.writeFileSync(replayPath, JSON.stringify({ kind: 'wrong-kind' }), 'utf-8');
+    await expect(computeReplaySeal(replayPath)).rejects.toThrow(/schema validation/);
+  });
 });

--- a/packages/cli/src/commands/spine-windtunnel.test.ts
+++ b/packages/cli/src/commands/spine-windtunnel.test.ts
@@ -20,11 +20,13 @@ import {
 } from '@mmnto/totem';
 
 import { cleanTmpDir } from '../test-utils.js';
+import { computeArtifactHash, type ReplayArtifact } from './spine-llm-replay.js';
 import {
   assertCorpusCompleteness,
   buildReadStrategy,
   type CertifyingCorpus,
   computeFixtureSha,
+  computeReplaySeal,
   enumeratePrMetas,
   isCommitAncestor,
   runCertifyingEngine,
@@ -654,5 +656,42 @@ describe('runCertifyingEngine (5c-i — certifying real-engine path)', () => {
     const result = await runCertifyingEngine(certLock, fixedRead, () => corpus);
     const negFirings = result.firings.filter((f: RuleFiring) => f.controlKind === 'negative');
     expect(negFirings).toHaveLength(1);
+  });
+});
+
+// ─── computeReplaySeal (#2237 papercut-2 — freeze auto-seals llmReplaySha) ───
+
+describe('computeReplaySeal (#2237 papercut-2 — llm-replay seal hash)', () => {
+  function makeReplayArtifact(): ReplayArtifact {
+    return {
+      kind: 'llm-replay.v1',
+      provenance: {
+        promptTemplateHash: 'p'.repeat(64),
+        systemPromptHash: 's'.repeat(64),
+        provider: 'anthropic',
+        model: 'stub-model-1',
+        temperature: 0,
+        orchestratorVersion: 'stub-orchestrator-0',
+        adapterKind: 'extractor+classifier',
+        keyVersion: 'v1',
+        totemVersion: '0.0.0-test',
+      },
+      records: { classifier: {}, extractor: {} },
+    };
+  }
+
+  it('returns null when the replay fixture is absent (record has not run — cannot seal)', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-seal-'));
+    createdDirs.push(dir);
+    expect(await computeReplaySeal(path.join(dir, 'llm-replay.v1.json'))).toBeNull();
+  });
+
+  it('returns the computeArtifactHash of the frozen fixture (the same L2 hash the run re-verifies)', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-seal-'));
+    createdDirs.push(dir);
+    const artifact = makeReplayArtifact();
+    const replayPath = path.join(dir, 'llm-replay.v1.json');
+    fs.writeFileSync(replayPath, JSON.stringify(artifact), 'utf-8');
+    expect(await computeReplaySeal(replayPath)).toBe(computeArtifactHash(artifact));
   });
 });

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -248,7 +248,12 @@ export async function freezeCommand(opts: FreezeOptions): Promise<void> {
       (rawObj as { controls: { integrity: Record<string, unknown> } }).controls.integrity[
         'llmReplaySha'
       ] = computed;
-      fs.writeFileSync(lockPath, `${canonicalStringify(rawObj, 2)}\n`, 'utf-8');
+      // Atomic write (tmp + rename) — the lock is a critical artifact; a direct
+      // write interrupted mid-flush would corrupt it and break every downstream
+      // cert run (gemini). Mirrors materialize's `writeCanonical`.
+      const tmpLock = `${lockPath}.tmp`;
+      fs.writeFileSync(tmpLock, `${canonicalStringify(rawObj, 2)}\n`, 'utf-8');
+      fs.renameSync(tmpLock, lockPath);
       console.error(
         `[WindtunnelFreeze] Sealed controls.integrity.llmReplaySha = ${computed} ` +
           `(was ${current ?? 'absent'}) — lock updated; re-commit to refresh the freeze proof (C3).`,
@@ -277,8 +282,32 @@ export async function freezeCommand(opts: FreezeOptions): Promise<void> {
 export async function computeReplaySeal(replayPath: string): Promise<string | null> {
   if (!fs.existsSync(replayPath)) return null;
   const { computeArtifactHash, ReplayArtifactSchema } = await import('./spine-llm-replay.js');
-  const artifact = ReplayArtifactSchema.parse(JSON.parse(fs.readFileSync(replayPath, 'utf-8')));
-  return computeArtifactHash(artifact);
+  const { TotemError } = await import('@mmnto/totem');
+  // A malformed/stale fixture must fail loud + actionable, not propagate a raw
+  // SyntaxError/ZodError out of freeze (gemini/greptile). Use the spine family's
+  // TotemError('CONFIG_INVALID') — matching freeze's own lock-read + record's
+  // readJsonFile — not artifact-storage's TotemParseError.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fs.readFileSync(replayPath, 'utf-8'));
+  } catch (err) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `Wind-tunnel freeze: ${REPLAY_FILE} at ${replayPath} is unreadable or not valid JSON — cannot compute the llmReplaySha seal.`,
+      'Re-run `spine windtunnel record` to regenerate a valid llm-replay fixture.',
+      err,
+    );
+  }
+  const result = ReplayArtifactSchema.safeParse(parsed);
+  if (!result.success) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `Wind-tunnel freeze: ${REPLAY_FILE} failed llm-replay schema validation — the seal cannot be computed over a malformed fixture.`,
+      'Re-run `spine windtunnel record` to regenerate a schema-valid llm-replay fixture.',
+      result.error,
+    );
+  }
+  return computeArtifactHash(result.data);
 }
 
 // ─── run command ─────────────────────────────────────

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -10,6 +10,7 @@ import {
   buildReplayCorpusProvider,
   GROUND_TRUTH_FILE,
   PR_DIFFS_FILE,
+  REPLAY_FILE,
 } from './spine-cert-run-corpus.js';
 
 // ─── Named constants ─────────────────────────────────
@@ -37,7 +38,7 @@ export interface FreezeOptions {
  * the assertion is skipped with a loud warning.
  */
 export async function freezeCommand(opts: FreezeOptions): Promise<void> {
-  const { WindtunnelLockSchema, safeExec, resolveGitRoot, TotemError } =
+  const { WindtunnelLockSchema, safeExec, resolveGitRoot, TotemError, canonicalStringify } =
     await import('@mmnto/totem');
 
   const cwd = process.cwd();
@@ -224,8 +225,60 @@ export async function freezeCommand(opts: FreezeOptions): Promise<void> {
     );
   }
 
+  // #2237 papercut-2: auto-SEAL controls.integrity.llmReplaySha. The two-phase
+  // lock design (materialize comment: "freeze seals it post-record") makes freeze
+  // the sealer — `record` emits the hash but does NOT stamp the lock, so until now
+  // the operator had to hand-edit it. Compute the hash the SAME way the run verifies
+  // it (`computeArtifactHash` over the parsed `llm-replay.v1.json`, the EXTERNAL L2
+  // expected-hash `buildReplayAdapters` re-checks) and stamp it in. Unlike the other
+  // integrity fields (stamped by their producers — fixtureSha/prDiffsSha by
+  // materialize, corpusDispositionsSha by fetch, groundTruthSha by derive),
+  // llmReplaySha has no producer-side stamp, so freeze owns it.
+  const replayPath = path.join(path.dirname(lockPath), REPLAY_FILE);
+  const computed = await computeReplaySeal(replayPath);
+  if (computed !== null) {
+    const current = lock.controls.integrity.llmReplaySha;
+    if (current === computed) {
+      console.error(`[WindtunnelFreeze] llm-replay.v1.json hash verified + sealed: ${computed}`);
+    } else {
+      // Stamp into the RAW parsed object (not the Zod-parsed `lock`) so every field
+      // — incl. the top-level `schema` key — survives the round-trip; canonicalStringify
+      // sorts keys, so the new llmReplaySha lands in its sorted position (one-line diff)
+      // and the serialization is byte-identical to materialize's writer.
+      (rawObj as { controls: { integrity: Record<string, unknown> } }).controls.integrity[
+        'llmReplaySha'
+      ] = computed;
+      fs.writeFileSync(lockPath, `${canonicalStringify(rawObj, 2)}\n`, 'utf-8');
+      console.error(
+        `[WindtunnelFreeze] Sealed controls.integrity.llmReplaySha = ${computed} ` +
+          `(was ${current ?? 'absent'}) — lock updated; re-commit to refresh the freeze proof (C3).`,
+      );
+    }
+  } else if (lock.phase === 'certifying') {
+    // Mirror the prDiffsSha/groundTruthSha absent-on-certifying warnings: the run is
+    // replay-only and hard-requires the fixture + its sealed hash.
+    console.error(
+      `[WindtunnelFreeze] WARNING: ${REPLAY_FILE} is absent — cannot seal llmReplaySha; the certifying run will hard-fail. Run \`spine windtunnel record\` first.`,
+    );
+  }
+
   console.error(`[WindtunnelFreeze] DONE — lock at ${lockPath} is schema-valid.`);
   console.error(`  Commit the lock file to establish the freeze proof (C3).`);
+}
+
+/**
+ * #2237 papercut-2: compute the llm-replay seal hash `freeze` stamps into
+ * `controls.integrity.llmReplaySha`. Returns `computeArtifactHash` over the parsed
+ * `llm-replay.v1.json` at `replayPath` — byte-for-byte the SAME external L2 hash
+ * `buildReplayAdapters` re-verifies at run time — or `null` when the fixture is
+ * absent (record hasn't run yet). Pure: no lock write (freeze owns the stamp), so
+ * the hash derivation is unit-testable without a full lock/commit/clone setup.
+ */
+export async function computeReplaySeal(replayPath: string): Promise<string | null> {
+  if (!fs.existsSync(replayPath)) return null;
+  const { computeArtifactHash, ReplayArtifactSchema } = await import('./spine-llm-replay.js');
+  const artifact = ReplayArtifactSchema.parse(JSON.parse(fs.readFileSync(replayPath, 'utf-8')));
+  return computeArtifactHash(artifact);
 }
 
 // ─── run command ─────────────────────────────────────

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1855,7 +1855,13 @@ windtunnelCmd
         const { WindtunnelLockSchema } = await import('@mmnto/totem');
         const { recordCommand, buildLiveRecordDeps } =
           await import('./commands/spine-cert-record.js');
+        const { loadEnv } = await import('./utils.js');
         const cwd = process.cwd();
+        // #2237 papercut-1: load .env BEFORE buildLiveRecordDeps reads process.env
+        // for the provider credential — the spine commands (unlike ~18 others) did
+        // not loadEnv, so an `.env`-only ANTHROPIC_API_KEY fail-closed as "no
+        // credential resolved" until exported manually.
+        loadEnv(cwd);
         const lockPath = opts.lockPath ?? `${cwd}/.totem/spine/gate-1/windtunnel.lock.json`;
         const lock = WindtunnelLockSchema.parse(JSON.parse(fsm.readFileSync(lockPath, 'utf-8')));
         const deps = await buildLiveRecordDeps(lock, {


### PR DESCRIPTION
## What

Three CLI fix-forwards the **first end-to-end Gate-1 cert run** (strategy#709) surfaced — gaps that only showed up because the pipeline had never run live before. Part of the #2237 iteration backlog (papercuts 1–3; the 2 decisive-re-run levers + the PART-2b synthetic-negative capability stay tracked there, not addressed here).

## The three papercuts

1. **`record` now `loadEnv(cwd)`** — before `buildLiveRecordDeps` resolves the provider credential. The spine commands (unlike ~18 others) did not load `.env`, so an `.env`-only `ANTHROPIC_API_KEY` fail-closed as "no credential resolved" until exported by hand.
2. **`freeze` now auto-seals `controls.integrity.llmReplaySha`** — the two-phase lock's documented sealer (materialize omits it, record produces it, freeze seals it). The new `computeReplaySeal` helper computes the same `computeArtifactHash` the run re-verifies, so the operator no longer hand-edits the lock. An absent fixture on a certifying lock warns (mirroring the `prDiffsSha` / `groundTruthSha` heads-ups).
3. **The cert-run report persists per-firing detail** (rule, pr, file, matched-line) on **every** verdict — not just the `needsAdjudication` labelId hashes. A FAIL / honest-negative run's firings are now observable for blind-by-pattern adjudication (cert #1's 2 firings could not be re-surfaced without a re-run).

## Tests

- `computeReplaySeal`: returns `null` when the fixture is absent; returns the exact `computeArtifactHash` the run re-verifies.
- persist: firing detail is present on a `HONEST-NEGATIVE` report (the FAIL-path observability fix).
- Full suite for the 3 changed modules green (47 tests).

## Gate

- build (tsc) ✅ · ESLint `0 errors` ✅ · `format:check` ✅ · `totem lint --base main` PASS (0 errors) ✅ · changeset ✅ (`@mmnto/cli` patch)

## Scope

Operator-by-hand spine commands only; no product-surface change. The certifying `run` stays replay-only — no live path touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
