### PR TITLE
feat(spine): extractor NO-DRAFT cause-tags — DraftResult port + replay migration (strategy#709 yield-fix α)

### DIFF
--- a/.changeset/spine-extractor-cause-tags.md
+++ b/.changeset/spine-extractor-cause-tags.md
@@ -1,0 +1,15 @@
+---
+'@mmnto/totem': minor
+---
+
+spine: extractor NO-DRAFT cause-tags (strategy#709 yield-fix slice α) — make the moat measurable
+
+The first Gate-1 cert run was honest-negative, dominated by the extract→draft step returning `[]` on threads carrying mintable classes. A bare `[]` conflated ≥6 distinct causes (model declined / parser rejected a valid draft / transient invoke failure) that the frozen replay discarded at record time, so the loss was un-diagnosable.
+
+This slice widens the `DraftExtractor` port to a `DraftResult` (`{ drafts, noDraftCause? }`) — the extract-stage twin of the classifier's `dispositionSource`, a non-FM Tenet-19 diagnostic:
+
+- **`NoDraftCause`** (core): a pinned-order, mutually-exclusive partition over every empty path — `invoke-error` (adapter) / `empty-output` / `none-sentinel` / `unparseable-shape` / `non-array` / `all-filtered` (parser) — plus a replay-migration-only `legacy-unknown`.
+- **Boundary parse** in `runExtractStage` (mirrors `ClassifierResultSchema.parse`): a contract-violating result (cause-without-empty / empty-without-cause) fails loud; the recorded `noDraftCause` lands on the empty-draft drop-ledger entry.
+- **Replay** records the full `DraftResult`; a backward-compatible union reader keeps pre-cause-tag fixtures (bare `string[]`) loadable + byte-identical, normalizing them on read (empty → `legacy-unknown`).
+
+Pure instrumentation — no behavior change to drafts or drops; the NO-DRAFT cause becomes observable on the next re-record. Observability-first prerequisite for the β (normalization) and γ (RESOLVED-eligibility) yield levers.

--- a/packages/cli/src/commands/spine-cert-corpus.test.ts
+++ b/packages/cli/src/commands/spine-cert-corpus.test.ts
@@ -55,8 +55,8 @@ function fakeSource(): ReviewThreadSource {
 
 function fakeExtractor(dsls: string[]): DraftExtractor {
   return {
-    async draft(): Promise<string[]> {
-      return dsls;
+    async draft() {
+      return dsls.length === 0 ? { drafts: dsls, noDraftCause: 'all-filtered' } : { drafts: dsls };
     },
   };
 }

--- a/packages/cli/src/commands/spine-cert-e2e.test.ts
+++ b/packages/cli/src/commands/spine-cert-e2e.test.ts
@@ -71,8 +71,8 @@ function frozenSource(): ReviewThreadSource {
 
 function liveExtractor(): DraftExtractor {
   return {
-    async draft(): Promise<string[]> {
-      return [REGEX_DSL];
+    async draft() {
+      return { drafts: [REGEX_DSL] };
     },
   };
 }

--- a/packages/cli/src/commands/spine-cert-record.test.ts
+++ b/packages/cli/src/commands/spine-cert-record.test.ts
@@ -59,8 +59,8 @@ function fakeDeps(): RecordDeps {
       },
     } satisfies ReviewThreadSource,
     liveExtractor: {
-      async draft(): Promise<string[]> {
-        return [REGEX_DSL];
+      async draft() {
+        return { drafts: [REGEX_DSL] };
       },
     } satisfies DraftExtractor,
     liveClassifier: {

--- a/packages/cli/src/commands/spine-cert-run-corpus.test.ts
+++ b/packages/cli/src/commands/spine-cert-run-corpus.test.ts
@@ -91,8 +91,8 @@ function fakeSource(): ReviewThreadSource {
 }
 function fakeExtractor(): DraftExtractor {
   return {
-    async draft(): Promise<string[]> {
-      return [REGEX_DSL];
+    async draft() {
+      return { drafts: [REGEX_DSL] };
     },
   };
 }

--- a/packages/cli/src/commands/spine-llm-adapters.test.ts
+++ b/packages/cli/src/commands/spine-llm-adapters.test.ts
@@ -120,35 +120,68 @@ function draft(dslSource = '**Pattern:** no-foo'): DraftCandidate {
 
 // ─── 1. Extractor output parse ────────────────────────
 
-describe('parseExtractorOutput', () => {
-  it('parses a JSON array of DSL bodies', () => {
-    expect(parseExtractorOutput('["**Pattern:** a", "**Pattern:** b"]')).toEqual([
-      '**Pattern:** a',
-      '**Pattern:** b',
-    ]);
-  });
-
-  it('treats the NONE sentinel (any case) as an empty draft', () => {
-    expect(parseExtractorOutput('NONE')).toEqual([]);
-    expect(parseExtractorOutput('  none  ')).toEqual([]);
-  });
-
-  it('returns [] on empty / non-JSON / non-array output (fail-soft, never throws)', () => {
-    expect(parseExtractorOutput('')).toEqual([]);
-    expect(parseExtractorOutput('here are some lessons:')).toEqual([]);
-    expect(parseExtractorOutput('{"disposition":"structural"}')).toEqual([]);
-    expect(parseExtractorOutput('42')).toEqual([]);
+describe('parseExtractorOutput → DraftResult (NoDraftCause taxonomy)', () => {
+  it('parses a JSON array of DSL bodies (drafts, no cause)', () => {
+    expect(parseExtractorOutput('["**Pattern:** a", "**Pattern:** b"]')).toEqual({
+      drafts: ['**Pattern:** a', '**Pattern:** b'],
+    });
   });
 
   it('strips a markdown code fence and parses the inner JSON', () => {
-    expect(parseExtractorOutput('```json\n["**Pattern:** x"]\n```')).toEqual(['**Pattern:** x']);
+    expect(parseExtractorOutput('```json\n["**Pattern:** x"]\n```')).toEqual({
+      drafts: ['**Pattern:** x'],
+    });
   });
 
-  it('filters non-string / empty / whitespace elements and trims', () => {
-    expect(parseExtractorOutput('["**Pattern:** a", 7, "", "   ", "  **Pattern:** b  "]')).toEqual([
-      '**Pattern:** a',
-      '**Pattern:** b',
-    ]);
+  it('filters non-string / empty / whitespace elements and trims (≥1 survivor → no cause)', () => {
+    // A filtered-out sibling element does NOT tag the result — the cause is a
+    // no-draft diagnostic, not a partial-quality ledger (codex).
+    expect(parseExtractorOutput('["**Pattern:** a", 7, "", "   ", "  **Pattern:** b  "]')).toEqual({
+      drafts: ['**Pattern:** a', '**Pattern:** b'],
+    });
+  });
+
+  // One branch per NoDraftCause — the pinned-order, mutually-exclusive partition
+  // (codex/agy panel; the order is the disjointness contract).
+  it('empty raw output → empty-output', () => {
+    expect(parseExtractorOutput('')).toEqual({ drafts: [], noDraftCause: 'empty-output' });
+    expect(parseExtractorOutput('   ')).toEqual({ drafts: [], noDraftCause: 'empty-output' });
+  });
+
+  it('the NONE sentinel (any case) → none-sentinel', () => {
+    expect(parseExtractorOutput('NONE')).toEqual({ drafts: [], noDraftCause: 'none-sentinel' });
+    expect(parseExtractorOutput('  none  ')).toEqual({ drafts: [], noDraftCause: 'none-sentinel' });
+  });
+
+  it('malformed JSON (SyntaxError) → unparseable-shape (fail-soft, never throws)', () => {
+    expect(parseExtractorOutput('here are some lessons:')).toEqual({
+      drafts: [],
+      noDraftCause: 'unparseable-shape',
+    });
+    expect(parseExtractorOutput('[unterminated')).toEqual({
+      drafts: [],
+      noDraftCause: 'unparseable-shape',
+    });
+  });
+
+  it('valid JSON but not an array → non-array', () => {
+    expect(parseExtractorOutput('{"disposition":"structural"}')).toEqual({
+      drafts: [],
+      noDraftCause: 'non-array',
+    });
+    expect(parseExtractorOutput('42')).toEqual({ drafts: [], noDraftCause: 'non-array' });
+  });
+
+  it('an array that filters to empty → all-filtered (NOT empty-output — panel adjudication)', () => {
+    // [""] / arrays-of-blanks parse to an array then filter to [] → all-filtered;
+    // empty-output is reserved for raw-text-empty BEFORE the parse (codex; corrects
+    // the agy panel-reply expectation).
+    expect(parseExtractorOutput('[]')).toEqual({ drafts: [], noDraftCause: 'all-filtered' });
+    expect(parseExtractorOutput('[""]')).toEqual({ drafts: [], noDraftCause: 'all-filtered' });
+    expect(parseExtractorOutput('["   ", 7]')).toEqual({
+      drafts: [],
+      noDraftCause: 'all-filtered',
+    });
   });
 });
 
@@ -231,21 +264,29 @@ describe('fail-loud on unexpected (non-SyntaxError) parse errors', () => {
 describe('LiveDraftExtractor', () => {
   it('drafts parsed DSL bodies from the LLM and counts a success', async () => {
     const ext = makeExtractor(stubInvoke('["**Pattern:** no-exec"]'));
-    await expect(ext.draft(content())).resolves.toEqual(['**Pattern:** no-exec']);
+    await expect(ext.draft(content())).resolves.toEqual({ drafts: ['**Pattern:** no-exec'] });
     expect(ext.attempts).toBe(1);
     expect(ext.succeeded).toBe(1);
   });
 
-  it('returns [] and counts a failure when the live invoke throws (per-PR fail-soft)', async () => {
+  it('tags invoke-error and counts a failure when the live invoke throws (per-PR fail-soft)', async () => {
     const ext = makeExtractor(throwingInvoke());
-    await expect(ext.draft(content())).resolves.toEqual([]);
+    await expect(ext.draft(content())).resolves.toEqual({
+      drafts: [],
+      noDraftCause: 'invoke-error',
+    });
     expect(ext.attempts).toBe(1);
     expect(ext.succeeded).toBe(0);
   });
 
-  it('a successful-but-empty (NONE) call still counts as succeeded (genuine sparsity ≠ failure)', async () => {
+  it('a successful-but-empty (NONE) call counts as succeeded + tags none-sentinel (sparsity ≠ failure)', async () => {
     const ext = makeExtractor(stubInvoke('NONE'));
-    await expect(ext.draft(content())).resolves.toEqual([]);
+    await expect(ext.draft(content())).resolves.toEqual({
+      drafts: [],
+      noDraftCause: 'none-sentinel',
+    });
+    // A genuine model decline is a SUCCESS (the invoke returned) — only invoke-error
+    // increments the failure counter, so the dead-provider floor stays a true signal.
     expect(ext.succeeded).toBe(1);
   });
 
@@ -259,8 +300,11 @@ describe('LiveDraftExtractor', () => {
           : '["**Pattern:** ok"]',
       ),
     );
-    await expect(ext.draft(content({ pr: 1 }))).resolves.toEqual(['**Pattern:** ok']);
-    await expect(ext.draft(content({ pr: 666 }))).resolves.toEqual([]);
+    await expect(ext.draft(content({ pr: 1 }))).resolves.toEqual({ drafts: ['**Pattern:** ok'] });
+    await expect(ext.draft(content({ pr: 666 }))).resolves.toEqual({
+      drafts: [],
+      noDraftCause: 'invoke-error',
+    });
     expect(ext.attempts).toBe(2);
     expect(ext.succeeded).toBe(1);
   });

--- a/packages/cli/src/commands/spine-llm-adapters.test.ts
+++ b/packages/cli/src/commands/spine-llm-adapters.test.ts
@@ -185,6 +185,38 @@ describe('parseExtractorOutput → DraftResult (NoDraftCause taxonomy)', () => {
   });
 });
 
+describe('legacy-unknown is replay-migration-only (never emitted by the live path)', () => {
+  // greptile #2240: the "REPLAY-MIGRATION ONLY" invariant on `legacy-unknown` is
+  // doc-only at the shared runExtractStage boundary (which MUST accept it, since the
+  // ReplayDraftExtractor legitimately produces it for a legacy bare-string[] row).
+  // Lock the invariant where it IS enforceable — the LIVE parse/adapter, which mint
+  // it nowhere by construction.
+  it('parseExtractorOutput never returns legacy-unknown for any input class', () => {
+    const inputs = [
+      '',
+      '   ',
+      'NONE',
+      'prose not json',
+      '[unterminated',
+      '{"disposition":"structural"}',
+      '42',
+      '[]',
+      '[""]',
+      '["**Pattern:** a"]',
+    ];
+    for (const raw of inputs) {
+      expect(parseExtractorOutput(raw).noDraftCause).not.toBe('legacy-unknown');
+    }
+  });
+
+  it('LiveDraftExtractor never tags legacy-unknown (invoke-error / decline / drafted)', async () => {
+    for (const inv of [throwingInvoke(), stubInvoke('NONE'), stubInvoke('["**Pattern:** a"]')]) {
+      const ext = makeExtractor(inv);
+      expect((await ext.draft(content())).noDraftCause).not.toBe('legacy-unknown');
+    }
+  });
+});
+
 // ─── 2. Classifier output parse (fold G — closed set) ─
 
 describe('parseClassifierOutput (fold G)', () => {

--- a/packages/cli/src/commands/spine-llm-adapters.ts
+++ b/packages/cli/src/commands/spine-llm-adapters.ts
@@ -56,6 +56,7 @@ import { z } from 'zod';
 // Type-only (erased at compile — no runtime barrel load; GCA #2209).
 import type {
   ClassifierResult,
+  DraftResult,
   ExtractStageResult,
   ReviewThread,
   ReviewThreadContent,
@@ -325,16 +326,20 @@ function stripCodeFence(raw: string): string {
 }
 
 /**
- * Parse the extractor's raw LLM text → `string[]` of candidate DSL bodies.
- * Contract: a strict JSON array of non-empty strings, or the `NONE` sentinel.
- * Anything else (prose, invalid JSON, non-array) → `[]` (fail-SOFT: a per-PR
+ * Parse the extractor's raw LLM text → a `DraftResult` (candidate DSL bodies, or
+ * an empty list WITH the NO-DRAFT cause). Contract: a strict JSON array of
+ * non-empty strings, or the `NONE` sentinel. Anything else is fail-SOFT (a per-PR
  * shape failure is a creditable empty draft, never a throw — core then loud-drops
- * each body that is not usable DSL via `isUsableDsl`).
+ * via the cause-tagged ledger). The cause partition is evaluated in the pinned
+ * order (empty → NONE → SyntaxError → non-array → all-filtered) so each `[]` path
+ * is mutually-exclusive (`NoDraftCauseSchema` in core). A parsed array with ≥1
+ * usable body returns drafts and NO cause — the cause is a no-draft diagnostic,
+ * not a partial-quality ledger (a filtered-out sibling element does not tag it).
  */
-export function parseExtractorOutput(raw: string): string[] {
+export function parseExtractorOutput(raw: string): DraftResult {
   const text = stripCodeFence(raw);
-  if (text.length === 0) return [];
-  if (text.toUpperCase() === NONE_SENTINEL) return [];
+  if (text.length === 0) return { drafts: [], noDraftCause: 'empty-output' };
+  if (text.toUpperCase() === NONE_SENTINEL) return { drafts: [], noDraftCause: 'none-sentinel' };
   let parsed: unknown;
   try {
     parsed = JSON.parse(text);
@@ -344,12 +349,13 @@ export function parseExtractorOutput(raw: string): string[] {
     // a JSON SyntaxError: an unexpected error is a real bug and must fail loud
     // (Tenet 4), mirroring core's `isUsableDsl`.
     if (!(err instanceof SyntaxError)) throw err;
-    return [];
+    return { drafts: [], noDraftCause: 'unparseable-shape' };
   }
-  if (!Array.isArray(parsed)) return [];
-  return parsed
+  if (!Array.isArray(parsed)) return { drafts: [], noDraftCause: 'non-array' };
+  const drafts = parsed
     .filter((x): x is string => typeof x === 'string' && x.trim().length > 0)
     .map((s) => s.trim());
+  return drafts.length === 0 ? { drafts, noDraftCause: 'all-filtered' } : { drafts };
 }
 
 /**
@@ -578,14 +584,14 @@ export class LiveDraftExtractor {
     return this._attempts - this._failures;
   }
 
-  async draft(content: ReviewThreadContent): Promise<string[]> {
+  async draft(content: ReviewThreadContent): Promise<DraftResult> {
     this._attempts += 1;
     // Per-PR fail-soft via `.catch` (a call, not a try/catch clause): ANY live-invoke
-    // failure → a creditable empty draft, NEVER a throw (a throw aborts the whole train
-    // sweep). Only a failed INVOKE increments `_failures` — parse failures don't (the
-    // parser is itself fail-soft) — so the assertPipelineProductive floor stays a true
-    // dead-provider signal. GLOBAL failure is caught loudly up front
-    // (verifyLlmAdapterConfig) + by the floor, never here.
+    // failure → a creditable empty draft tagged `invoke-error`, NEVER a throw (a throw
+    // aborts the whole train sweep). Only a failed INVOKE increments `_failures` —
+    // parse failures don't (the parser is itself fail-soft, and names its own cause) —
+    // so the assertPipelineProductive floor stays a true dead-provider signal. GLOBAL
+    // failure is caught loudly up front (verifyLlmAdapterConfig) + by the floor.
     const result = await Promise.resolve()
       .then(() =>
         this.invoke({
@@ -601,7 +607,7 @@ export class LiveDraftExtractor {
       .catch(() => undefined);
     if (result === undefined) {
       this._failures += 1;
-      return [];
+      return { drafts: [], noDraftCause: 'invoke-error' };
     }
     return parseExtractorOutput(result.content);
   }

--- a/packages/cli/src/commands/spine-llm-replay.test.ts
+++ b/packages/cli/src/commands/spine-llm-replay.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 
 import {
   type ClassifierResult,
+  type DraftResult,
+  DraftResultSchema,
   type ExtractStageResult,
   type ReviewThread,
   type ReviewThreadContent,
@@ -11,6 +13,7 @@ import {
   classifierInputKey,
   ClassifierResultLocalSchema,
   computeArtifactHash,
+  DraftResultLocalSchema,
   DuplicateRecordError,
   extractorInputKey,
   FixtureIntegrityError,
@@ -33,11 +36,14 @@ type DraftCandidate = ExtractStageResult['drafts'][number];
 
 // ─── Stub ports (in-memory, deterministic — NO network, NO LLM) ──────────────
 
-/** A canned `DraftExtractor`: returns a fixed `string[]` keyed by PR (default to a 1-elem draft). */
+/** A canned `DraftExtractor`: returns a fixed `DraftResult` keyed by PR (default to a 1-elem draft). */
 class StubExtractor {
   constructor(private readonly byPr: Map<number, string[]>) {}
-  draft(content: ReviewThreadContent): Promise<string[]> {
-    return Promise.resolve(this.byPr.get(content.pr) ?? [`draft for PR ${content.pr}`]);
+  draft(content: ReviewThreadContent): Promise<DraftResult> {
+    const drafts = this.byPr.get(content.pr) ?? [`draft for PR ${content.pr}`];
+    return Promise.resolve(
+      drafts.length === 0 ? { drafts, noDraftCause: 'all-filtered' } : { drafts },
+    );
   }
 }
 
@@ -146,7 +152,7 @@ describe('record → replay determinism (FM-a)', () => {
     expect(await replayExtractor.draft(c)).toEqual(recordedDrafts);
     expect(await replayClassifier.classify(d)).toEqual(recordedClass);
     // And the recorded values are exactly what the stub produced.
-    expect(recordedDrafts).toEqual(['draft-A', 'draft-B']);
+    expect(recordedDrafts).toEqual({ drafts: ['draft-A', 'draft-B'] });
     expect(recordedClass).toEqual({ disposition: 'behavioral', dispositionSource: 'classified' });
   });
 
@@ -246,7 +252,7 @@ describe('replay miss red craft', () => {
     // NOT resolve to a safe-default [] (the whole point of the no-fallback rule).
     const missContent = content({ pr: 999 });
     await expect(replay.draft(missContent)).rejects.toBeInstanceOf(ReplayMissError);
-    let resolvedTo: string[] | undefined;
+    let resolvedTo: DraftResult | undefined;
     await replay.draft(missContent).then(
       (v) => {
         resolvedTo = v;
@@ -274,16 +280,20 @@ describe('replay miss red craft', () => {
 // ─── 4. Recorded-empty vs miss ───────────────────────
 
 describe('recorded-empty vs miss (real rows, distinguishable from absence)', () => {
-  it('replays a recorded [] (extractor) as [] — a real row, not a miss', async () => {
+  it('replays a recorded empty DraftResult as that exact value (a real row, not a miss)', async () => {
     const sink = new ReplayRecordSink();
     const rec = new RecordingDraftExtractor(new StubExtractor(new Map([[100, []]])), sink);
     const recorded = await rec.draft(content({ pr: 100 }));
-    expect(recorded).toEqual([]);
+    expect(recorded).toEqual({ drafts: [], noDraftCause: 'all-filtered' });
 
     const artifact = sink.freeze(STUB_PROVENANCE);
     const replay = new ReplayDraftExtractor(artifact, computeArtifactHash(artifact));
-    // HIT on a recorded [] — returns [], does NOT throw ReplayMissError.
-    await expect(replay.draft(content({ pr: 100 }))).resolves.toEqual([]);
+    // HIT on a recorded empty result — returns the cause-tagged DraftResult, does
+    // NOT throw ReplayMissError.
+    await expect(replay.draft(content({ pr: 100 }))).resolves.toEqual({
+      drafts: [],
+      noDraftCause: 'all-filtered',
+    });
   });
 
   it('replays a recorded {behavioral, error-default} (classifier) as that exact value', async () => {
@@ -330,7 +340,7 @@ describe('duplicate (adapterKind, inputKey) → DuplicateRecordError', () => {
   it('does NOT collide two different sections sharing a coincidental key value', () => {
     // extractor + classifier maps are independent; the same string in both is fine.
     const sink = new ReplayRecordSink();
-    sink.recordExtractor('shared-key', ['e']);
+    sink.recordExtractor('shared-key', { drafts: ['e'] });
     expect(() =>
       sink.recordClassifier('shared-key', {
         disposition: 'structural',
@@ -420,6 +430,59 @@ describe('ClassifierResultLocalSchema parity with core (GCA #2209, option a)', (
   });
 });
 
+describe('DraftResultLocalSchema parity with core (α cause-tags; GCA #2209)', () => {
+  it('accepts / rejects EXACTLY what core DraftResultSchema does', () => {
+    const cases: unknown[] = [
+      { drafts: ['a', 'b'] }, // valid (drafts, no cause)
+      { drafts: [] }, // invalid — empty WITHOUT a cause (cause-iff-empty refine)
+      { drafts: [], noDraftCause: 'invoke-error' }, // valid
+      { drafts: [], noDraftCause: 'all-filtered' }, // valid
+      { drafts: [], noDraftCause: 'legacy-unknown' }, // valid (replay-migration cause)
+      { drafts: ['a'], noDraftCause: 'none-sentinel' }, // invalid — cause WITH drafts
+      { drafts: [], noDraftCause: 'bogus' }, // enum → invalid
+      { noDraftCause: 'empty-output' }, // missing drafts → invalid
+    ];
+    for (const c of cases) {
+      expect(DraftResultLocalSchema.safeParse(c).success).toBe(
+        DraftResultSchema.safeParse(c).success,
+      );
+    }
+  });
+});
+
+describe('ReplayDraftExtractor backward-compat (α legacy string[] migration)', () => {
+  // The committed cert-#1 fixture stored BARE string[] extractor rows (pre-cause-tag).
+  // The union schema must still load them (so the fixture parses + hashes identically)
+  // and the replay must normalize them to a DraftResult on read.
+  function legacyArtifact(rows: Record<string, string[]>): ReplayArtifact {
+    return ReplayArtifactSchema.parse({
+      kind: REPLAY_ARTIFACT_KIND,
+      provenance: STUB_PROVENANCE,
+      records: { extractor: rows, classifier: {} },
+    });
+  }
+
+  it('normalizes a legacy non-empty string[] row → { drafts } (no fabricated cause)', async () => {
+    const c = content({ pr: 100 });
+    const artifact = legacyArtifact({ [extractorInputKey(c)]: ['legacy-draft'] });
+    const replay = new ReplayDraftExtractor(artifact, computeArtifactHash(artifact));
+    await expect(replay.draft(c)).resolves.toEqual({ drafts: ['legacy-draft'] });
+  });
+
+  it('normalizes a legacy EMPTY string[] row → legacy-unknown (never a fabricated real cause)', async () => {
+    const c = content({ pr: 100 });
+    const artifact = legacyArtifact({ [extractorInputKey(c)]: [] });
+    const replay = new ReplayDraftExtractor(artifact, computeArtifactHash(artifact));
+    await expect(replay.draft(c)).resolves.toEqual({ drafts: [], noDraftCause: 'legacy-unknown' });
+  });
+
+  it('a legacy bare-array fixture parses + hashes (the union keeps the cert-#1 fixture loadable)', () => {
+    const c = content({ pr: 100 });
+    const artifact = legacyArtifact({ [extractorInputKey(c)]: ['x'] });
+    expect(() => computeArtifactHash(artifact)).not.toThrow();
+  });
+});
+
 describe('classifierInputKey (fold D)', () => {
   it('is stable for the same provenance + dslSource + draftRef', () => {
     const d = draft({ pr: 100, dslSource: 'body' });
@@ -484,7 +547,7 @@ describe('serialization hygiene', () => {
     const parsed = JSON.parse(serialized) as ReplayArtifact;
     // Each record VALUE is strictly the port's output shape — nothing else.
     const extractorVal = Object.values(parsed.records.extractor)[0];
-    expect(extractorVal).toEqual(['only-the-output']);
+    expect(extractorVal).toEqual({ drafts: ['only-the-output'] });
     const classifierVal = Object.values(parsed.records.classifier)[0];
     expect(Object.keys(classifierVal as object).sort()).toEqual([
       'disposition',

--- a/packages/cli/src/commands/spine-llm-replay.ts
+++ b/packages/cli/src/commands/spine-llm-replay.ts
@@ -346,9 +346,10 @@ export const ClassifierResultLocalSchema = z
  * artifact schema is a CLI-layer concern"): a LOCAL Zod schema rather than a static
  * runtime import of core's `DraftResultSchema` (which would pull the heavy
  * `@mmnto/totem` barrel onto the CLI-startup path). Mirrors core's shape AND its
- * "cause iff empty" refinement (the `NoDraftCauseSchema` enum, including the
- * replay-migration-only `legacy-unknown`); a test asserts parity with core so this
- * duplication can't silently drift if core's `DraftResult` changes.
+ * "cause iff empty" refinement LOGIC (the `NoDraftCauseSchema` enum, including the
+ * replay-migration-only `legacy-unknown`). Parity is accept/reject EQUIVALENCE,
+ * locked by a test — the local ZodError `message`/`path` stay intentionally concise
+ * (matching the `ClassifierResultLocalSchema` sibling), not byte-identical to core.
  */
 export const DraftResultLocalSchema = z
   .object({
@@ -546,8 +547,9 @@ function assertFixtureIntegrity(artifact: ReplayArtifact, expectedHash: string):
 /**
  * PURE replay of `DraftExtractor` — zero live LLM / network calls. Computes the
  * inputKey for the requested content, looks it up in the frozen records:
- *   - HIT  → return the recorded `string[]` (including a recorded `[]` — a real row);
- *   - MISS → throw `ReplayMissError` (NEVER fall back to `[]`).
+ *   - HIT  → return the recorded `DraftResult` (a recorded empty result is a real
+ *            row; a legacy bare-`string[]` row is normalized to a `DraftResult`);
+ *   - MISS → throw `ReplayMissError` (NEVER fall back to an empty result).
  *
  * Integrity (fold B + F): the constructor takes the EXTERNAL expected content-
  * hash, computes the actual WHOLE-ARTIFACT hash (records + provenance), and throws

--- a/packages/cli/src/commands/spine-llm-replay.ts
+++ b/packages/cli/src/commands/spine-llm-replay.ts
@@ -47,6 +47,7 @@ import { z } from 'zod';
 // runtime `ClassifierResultSchema`.
 import type {
   ClassifierResult,
+  DraftResult,
   ExtractStageResult,
   ReviewThread,
   ReviewThreadComment,
@@ -340,9 +341,45 @@ export const ClassifierResultLocalSchema = z
     message: "dispositionSource 'error-default' requires disposition 'behavioral'",
   });
 
+/**
+ * CLI-side validation of a recorded `DraftResult` (GCA #2209 + the panel's "replay
+ * artifact schema is a CLI-layer concern"): a LOCAL Zod schema rather than a static
+ * runtime import of core's `DraftResultSchema` (which would pull the heavy
+ * `@mmnto/totem` barrel onto the CLI-startup path). Mirrors core's shape AND its
+ * "cause iff empty" refinement (the `NoDraftCauseSchema` enum, including the
+ * replay-migration-only `legacy-unknown`); a test asserts parity with core so this
+ * duplication can't silently drift if core's `DraftResult` changes.
+ */
+export const DraftResultLocalSchema = z
+  .object({
+    drafts: z.array(z.string()),
+    noDraftCause: z
+      .enum([
+        'invoke-error',
+        'empty-output',
+        'none-sentinel',
+        'unparseable-shape',
+        'non-array',
+        'all-filtered',
+        'legacy-unknown',
+      ])
+      .optional(),
+  })
+  .refine((r) => (r.drafts.length === 0) === (r.noDraftCause !== undefined), {
+    message: 'noDraftCause must be present iff drafts is empty',
+  });
+
 export const ReplayRecordsSchema = z.object({
-  /** `inputKey → DraftExtractor.draft()` return (a `string[]`; `[]` is a real row). */
-  extractor: z.record(z.array(z.string())),
+  /**
+   * `inputKey → DraftExtractor.draft()` return — a `DraftResult` (`{drafts, noDraftCause?}`);
+   * a recorded `{drafts:[], noDraftCause}` is a real row. BACKWARD-COMPAT (the α
+   * cause-tag migration): a legacy fixture stored a bare `string[]` (pre-cause-tag),
+   * accepted via the union so the committed cert-#1 fixture still parses + hashes
+   * IDENTICALLY (the bare-array branch returns it unchanged). `ReplayDraftExtractor`
+   * normalizes a legacy row to a `DraftResult` on read (empty → `legacy-unknown`);
+   * fresh recordings always write the object form.
+   */
+  extractor: z.record(z.union([z.array(z.string()), DraftResultLocalSchema])),
   /** `inputKey → DraftClassifier.classify()` return (a `ClassifierResult`). */
   classifier: z.record(ClassifierResultLocalSchema),
 });
@@ -413,10 +450,10 @@ function hashParsedArtifact(parsed: ReplayArtifact): string {
  * the recording run must surface, not absorb).
  */
 export class ReplayRecordSink {
-  private readonly extractor = new Map<string, string[]>();
+  private readonly extractor = new Map<string, DraftResult>();
   private readonly classifier = new Map<string, ClassifierResult>();
 
-  recordExtractor(inputKey: string, output: string[]): void {
+  recordExtractor(inputKey: string, output: DraftResult): void {
     if (this.extractor.has(inputKey)) throw new DuplicateRecordError('extractor', inputKey);
     this.extractor.set(inputKey, output);
   }
@@ -447,18 +484,19 @@ export class ReplayRecordSink {
 // ─── Recording decorators (generic over the port) ─────
 
 /**
- * Records every `DraftExtractor.draft()` call's inputKey → raw `string[]` output
- * into the sink, then passes the value THROUGH unchanged. The recorded value is
- * the PORT's return (pre-core-funnel) — a recorded `[]` is a real row. A
- * duplicate inputKey throws (via the sink).
+ * Records every `DraftExtractor.draft()` call's inputKey → raw `DraftResult` output
+ * into the sink, then passes the value THROUGH unchanged. The recorded value is the
+ * PORT's return (pre-core-funnel) — a recorded `{drafts:[], noDraftCause}` is a real
+ * row that freezes the NO-DRAFT cause for the replay. A duplicate inputKey throws
+ * (via the sink).
  */
 export class RecordingDraftExtractor {
   constructor(
-    private readonly wrapped: { draft(content: ReviewThreadContent): Promise<string[]> },
+    private readonly wrapped: { draft(content: ReviewThreadContent): Promise<DraftResult> },
     private readonly sink: ReplayRecordSink,
   ) {}
 
-  async draft(content: ReviewThreadContent): Promise<string[]> {
+  async draft(content: ReviewThreadContent): Promise<DraftResult> {
     const output = await this.wrapped.draft(content);
     this.sink.recordExtractor(extractorInputKey(content), output);
     return output;
@@ -526,17 +564,26 @@ export class ReplayDraftExtractor {
   }
 
   // `async` so a MISS surfaces as a REJECTED promise (the port contract is
-  // `Promise<string[]>`; a consumer awaits it). A synchronous `throw` would
+  // `Promise<DraftResult>`; a consumer awaits it). A synchronous `throw` would
   // escape an `await`-less caller's `.catch`, so the rejection path is uniform.
-  async draft(content: ReviewThreadContent): Promise<string[]> {
+  async draft(content: ReviewThreadContent): Promise<DraftResult> {
     const inputKey = extractorInputKey(content);
-    // `Object.prototype.hasOwnProperty`-style presence check, NOT truthiness: a
-    // recorded `[]` is a real HIT (falsy-but-present), distinct from an absent
-    // key (a MISS).
+    // Presence check, NOT truthiness: a recorded empty result is a real HIT,
+    // distinct from an absent key (a MISS).
     if (!Object.prototype.hasOwnProperty.call(this.records, inputKey)) {
       throw new ReplayMissError('extractor', inputKey);
     }
-    return this.records[inputKey];
+    const rec = this.records[inputKey];
+    // Backward-compat (α migration): a legacy fixture row is a bare `string[]`
+    // (pre-cause-tag) → normalize to a `DraftResult`. An EMPTY legacy row gets
+    // `legacy-unknown` — NOT a fabricated real cause; it honestly signals "this
+    // fixture predates cause-tags, re-record before cause-rate reporting." A
+    // non-empty legacy row carries its drafts and no cause. A fresh row is already
+    // a `DraftResult` and passes through unchanged.
+    if (Array.isArray(rec)) {
+      return rec.length === 0 ? { drafts: rec, noDraftCause: 'legacy-unknown' } : { drafts: rec };
+    }
+    return rec;
   }
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -844,6 +844,7 @@ export type { DispositionClass, DispositionComment } from './spine/disposition-t
 export { classifyDisposition, dispositionToLabel } from './spine/disposition-taxonomy.js';
 export type {
   DraftExtractor,
+  DraftResult,
   ExtractStageDeps,
   ExtractStageResult,
   FetchResult,
@@ -852,7 +853,7 @@ export type {
   ReviewThreadContent,
   ReviewThreadSource,
 } from './spine/extract.js';
-export { runExtractStage } from './spine/extract.js';
+export { DraftResultSchema, runExtractStage } from './spine/extract.js';
 export type {
   ApiFetchSlice,
   ApiUsageLedger,
@@ -866,6 +867,7 @@ export type {
   EmissionLedger,
   EmissionLedgerEntry,
   MinerLedgers,
+  NoDraftCause,
   Routing,
   SplitLedger,
 } from './spine/ledgers.js';
@@ -882,6 +884,7 @@ export {
   EmissionLedgerEntrySchema,
   EmissionLedgerSchema,
   MinerLedgersSchema,
+  NoDraftCauseSchema,
   RoutingSchema,
   SplitLedgerSchema,
 } from './spine/ledgers.js';

--- a/packages/core/src/spine/extract.test.ts
+++ b/packages/core/src/spine/extract.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import {
   type DraftExtractor,
+  type DraftResult,
   type ExtractStageResult,
   type FetchResult,
   type ReviewThread,
@@ -101,11 +102,16 @@ function spySource(
   };
 }
 
-/** Fixture extractor: per-PR draft bodies from a map (default: one usable body). Async. */
+/**
+ * Fixture extractor: per-PR draft bodies from a map (default: one usable body). Async.
+ * Wraps the bare `string[]` into a `DraftResult`, tagging an empty list with a
+ * representative `all-filtered` cause so the "cause iff empty" invariant holds.
+ */
 function fixtureExtractor(byPr?: Map<number, string[]>): DraftExtractor {
   return {
-    async draft(c: ReviewThreadContent): Promise<string[]> {
-      return byPr?.get(c.pr) ?? [USABLE_DSL];
+    async draft(c: ReviewThreadContent): Promise<DraftResult> {
+      const drafts = byPr?.get(c.pr) ?? [USABLE_DSL];
+      return drafts.length === 0 ? { drafts, noDraftCause: 'all-filtered' } : { drafts };
     },
   };
 }
@@ -272,23 +278,46 @@ describe('runExtractStage — drop reason codes', () => {
     expect(r.drafts).toEqual([]);
   });
 
-  it('unparseable: the extractor produced no draft from a complete thread', async () => {
+  it('unparseable: the extractor produced no draft from a complete thread — records the NO-DRAFT cause', async () => {
     const r = await runExtractStage(
       solo(),
       deps(spySource([1]), fixtureExtractor(new Map([[1, []]]))),
     );
-    expect(dropsFor(r, 1)[0]!.reasonCode).toBe('unparseable');
+    const drop = dropsFor(r, 1)[0]!;
+    expect(drop.reasonCode).toBe('unparseable');
+    // The Tenet-19 diagnostic is carried onto the drop (fixtureExtractor tags an
+    // empty list 'all-filtered') — never silently dropped as a bare [].
+    expect(drop.noDraftCause).toBe('all-filtered');
+    expect(drop.detail).toContain('all-filtered');
+  });
+
+  it('boundary-parse fails loud on a contract-violating DraftResult (empty-without-cause)', async () => {
+    // A buggy adapter returning { drafts: [] } with no cause violates the
+    // "cause iff empty" invariant; DraftResultSchema.parse must reject it at the
+    // core boundary (Tenet 4), not silently drop-ledger a causeless empty.
+    const badExtractor: DraftExtractor = {
+      async draft(): Promise<DraftResult> {
+        // Type-VALID (noDraftCause is optional in the static type) but RUNTIME-invalid:
+        // the schema's "cause iff empty" refine requires a cause when drafts is empty,
+        // so the core boundary parse rejects this — exactly the buggy-adapter case.
+        return { drafts: [] };
+      },
+    };
+    await expect(runExtractStage(solo(), deps(spySource([1]), badExtractor))).rejects.toThrow(
+      /noDraftCause must be present iff drafts is empty/,
+    );
   });
 
   it('a contract-violating extractor throw propagates (fail-loud, not swallowed)', async () => {
-    // The port contract is: return [] on a per-PR failure (the CLI adapter catches
-    // its own IO errors). A throw VIOLATES that contract and must NOT be silently
-    // swallowed — it propagates (Tenet 4). Per-PR resilience is the adapter's job;
-    // the []-returns path is covered by "extractor produced no draft" above.
+    // The port contract is: return { drafts: [], noDraftCause } on a per-PR failure
+    // (the CLI adapter catches its own IO errors → 'invoke-error'). A throw VIOLATES
+    // that contract and must NOT be silently swallowed — it propagates (Tenet 4).
+    // Per-PR resilience is the adapter's job; the empty-result path is covered by
+    // "extractor produced no draft" above.
     const throwingExtractor: DraftExtractor = {
       async draft(c) {
         if (c.pr === 1) throw new Error('boom');
-        return [USABLE_DSL];
+        return { drafts: [USABLE_DSL] };
       },
     };
     await expect(
@@ -392,9 +421,10 @@ function recordingExtractor(byPr?: Map<number, string[]>): DraftExtractor & {
   const seen: ReviewThreadContent[] = [];
   return {
     seen,
-    async draft(c: ReviewThreadContent): Promise<string[]> {
+    async draft(c: ReviewThreadContent): Promise<DraftResult> {
       seen.push(c);
-      return byPr?.get(c.pr) ?? [USABLE_DSL];
+      const drafts = byPr?.get(c.pr) ?? [USABLE_DSL];
+      return drafts.length === 0 ? { drafts, noDraftCause: 'all-filtered' } : { drafts };
     },
   };
 }

--- a/packages/core/src/spine/extract.ts
+++ b/packages/core/src/spine/extract.ts
@@ -34,6 +34,8 @@
 // Pipeline-1 trust class: every draft body is `unverified` and Stage-4-gated by
 // the slice-4 compiler, never a manual-rule trust bypass.
 
+import { z } from 'zod';
+
 import { type ProvenanceRecord, ProvenanceRecordSchema } from '../compiler-schema.js';
 import { TotemParseError } from '../errors.js';
 import { extractManualPattern } from '../lesson-pattern.js';
@@ -43,7 +45,9 @@ import type {
   DropLedger,
   DropLedgerEntry,
   DropReasonCode,
+  NoDraftCause,
 } from './ledgers.js';
+import { NoDraftCauseSchema } from './ledgers.js';
 import { isBotIdentity } from './selection-rule.js';
 import type { SplitArtifact } from './split.js';
 
@@ -134,23 +138,47 @@ export interface ReviewThreadSource {
 }
 
 /**
+ * The `DraftExtractor` port's return: the zero-or-more draft bodies PLUS, when the
+ * list is empty, WHY (`noDraftCause`). The cause is the extract-stage twin of the
+ * classifier's `dispositionSource` (a non-FM Tenet-19 diagnostic) — a bare `[]`
+ * conflated ≥6 causes (model declined / parser rejected a valid draft / transient
+ * invoke failure) the funnel could not tell apart. INVARIANT (refined): a cause is
+ * present IFF `drafts` is empty — a non-empty result carries drafts and no cause;
+ * an empty result MUST name its cause. Parsed at the core boundary so a
+ * contract-violating port (cause-without-empty, or empty-without-cause) fails loud
+ * before the drop ledger, exactly as `ClassifierResultSchema.parse` guards classify.
+ */
+export const DraftResultSchema = z
+  .object({
+    drafts: z.array(z.string()),
+    noDraftCause: NoDraftCauseSchema.optional(),
+  })
+  .refine((r) => (r.drafts.length === 0) === (r.noDraftCause !== undefined), {
+    message:
+      'noDraftCause must be present iff drafts is empty (the extract-stage diagnostic invariant)',
+    path: ['noDraftCause'],
+  });
+export type DraftResult = z.infer<typeof DraftResultSchema>;
+
+/**
  * Injected draft-DSL extractor port. ASYNC: the CLI impl wraps the LLM call
  * (network IO). List-shaped (fold 1): one thread can carry multiple structural
- * invariants, so it returns ZERO-or-more draft bodies. The LLM lives behind this
- * at the CLI layer (draft-only, Tenet-15); a deterministic fixture impl drives
- * tests. The miner is BLIND to seed classes (§7 / FM f): the port is never
- * handed one.
+ * invariants, so it returns ZERO-or-more draft bodies in `DraftResult.drafts`. The
+ * LLM lives behind this at the CLI layer (draft-only, Tenet-15); a deterministic
+ * fixture impl drives tests. The miner is BLIND to seed classes (§7 / FM f): the
+ * port is never handed one.
  *
- * Error contract: returns `[]` when it cannot draft from the thread — INCLUDING
- * on its own internal/transient failure (the CLI adapter catches its LLM/network
- * errors and surfaces `[]`). It MUST NOT throw for a per-PR content failure: an
- * empty list is a loud drop below (FM-i-creditable), whereas a throw would abort
- * the whole mining run. Keeping per-PR error handling in the adapter keeps the
- * core orchestrator Tenet-4-clean (no swallowing catch); a contract-violating
- * throw therefore propagates loudly rather than being silently absorbed.
+ * Error contract: returns `{ drafts: [], noDraftCause }` when it cannot draft —
+ * INCLUDING on its own internal/transient failure (the CLI adapter catches its
+ * LLM/network errors and surfaces `{ drafts: [], noDraftCause: 'invoke-error' }`).
+ * It MUST NOT throw for a per-PR content failure: an empty list is a loud,
+ * cause-tagged drop below (FM-i-creditable), whereas a throw would abort the whole
+ * mining run. Keeping per-PR error handling in the adapter keeps the core
+ * orchestrator Tenet-4-clean (no swallowing catch); a contract-violating throw
+ * therefore propagates loudly rather than being silently absorbed.
  */
 export interface DraftExtractor {
-  draft(content: ReviewThreadContent): Promise<string[]>;
+  draft(content: ReviewThreadContent): Promise<DraftResult>;
 }
 
 /** Dependencies for a single Extract-stage run. */
@@ -284,8 +312,13 @@ export async function runExtractStage(
   const dropEntries: DropLedgerEntry[] = [];
   const apiEntries: ApiUsageLedgerEntry[] = [];
 
-  const drop = (sourcePr: number, reasonCode: DropReasonCode, detail: string): void => {
-    dropEntries.push({ sourcePr, reasonCode, detail });
+  const drop = (
+    sourcePr: number,
+    reasonCode: DropReasonCode,
+    detail: string,
+    noDraftCause?: NoDraftCause,
+  ): void => {
+    dropEntries.push({ sourcePr, reasonCode, detail, ...(noDraftCause ? { noDraftCause } : {}) });
   };
 
   // Iterate the TRAIN slice ONLY — held-out / control / excluded PRs are never
@@ -364,12 +397,23 @@ export async function runExtractStage(
     // catches its own LLM/network errors) — so the core needs no swallowing catch
     // (Tenet 4). An empty list is a loud drop below, not a silent skip.
     const eligibleContent: ReviewThreadContent = { ...content, threads: survivingThreads };
-    const draftBodies = await deps.extractor.draft(eligibleContent);
+    // Parse the port result at the boundary (mirrors ClassifierResultSchema.parse in
+    // classify.ts): a contract-violating DraftResult (empty-without-cause or
+    // cause-without-empty from a buggy adapter) fails loud HERE, before the ledger.
+    const draftResult = DraftResultSchema.parse(await deps.extractor.draft(eligibleContent));
+    const draftBodies = draftResult.drafts;
 
     if (draftBodies.length === 0) {
       // A complete thread that yields no draft is a loud drop (keeps the train PR
-      // creditable under FM i), not a silent skip.
-      drop(pr, 'unparseable', 'extractor produced no draft from a complete thread');
+      // creditable under FM i), not a silent skip. The NO-DRAFT cause (Tenet-19
+      // diagnostic) is recorded so a parser/format/transient failure is never
+      // conflated with a legitimate model decline.
+      drop(
+        pr,
+        'unparseable',
+        `extractor produced no draft from a complete thread (cause: ${draftResult.noDraftCause ?? 'unknown'})`,
+        draftResult.noDraftCause,
+      );
       continue;
     }
 

--- a/packages/core/src/spine/extract.ts
+++ b/packages/core/src/spine/extract.ts
@@ -411,7 +411,10 @@ export async function runExtractStage(
       drop(
         pr,
         'unparseable',
-        `extractor produced no draft from a complete thread (cause: ${draftResult.noDraftCause ?? 'unknown'})`,
+        // The boundary parse above + the "cause iff empty" refine guarantee
+        // `noDraftCause` is present in this empty-drafts branch — assert it rather
+        // than defend with a `?? 'unknown'` fallback that can never fire.
+        `extractor produced no draft from a complete thread (cause: ${draftResult.noDraftCause!})`,
         draftResult.noDraftCause,
       );
       continue;

--- a/packages/core/src/spine/ledgers.ts
+++ b/packages/core/src/spine/ledgers.ts
@@ -109,6 +109,41 @@ export const DropReasonCodeSchema = z.enum([
 ]);
 export type DropReasonCode = z.infer<typeof DropReasonCodeSchema>;
 
+/**
+ * Why the extractor returned ZERO drafts for an otherwise-complete thread — the
+ * extract-stage twin of the classifier's `dispositionSource` (a non-FM Tenet-19
+ * diagnostic). A bare `[]` from the `DraftExtractor` port conflates ≥6 distinct
+ * causes with opposite fixes; recording WHICH one keeps a parser/format/transient
+ * failure from masquerading as "the model judged nothing mintable" (a legitimate
+ * decline). Set ONLY on the extractor-produced empty-draft `unparseable` drop —
+ * never on a source-`unparseable` fetch failure or a per-body `isUsableDsl` drop.
+ *
+ * PARSE ORDER is the disjointness contract (evaluate in this order — the adapter
+ * sets the first, `parseExtractorOutput` the rest):
+ *   - `invoke-error`       — the live LLM invoke rejected (caught in the adapter).
+ *   - `empty-output`       — the stripped RAW output was empty (pre-parse).
+ *   - `none-sentinel`      — the stripped raw output equals the `NONE` sentinel.
+ *   - `unparseable-shape`  — `JSON.parse` threw a `SyntaxError` (malformed JSON).
+ *   - `non-array`          — JSON parsed, but not to an array.
+ *   - `all-filtered`       — parsed to an array, but zero non-empty string bodies
+ *                            survived (`[]`, blanks, non-strings) — NOT `empty-output`.
+ *   - `legacy-unknown`     — REPLAY-MIGRATION ONLY: a pre-cause-tag fixture stored a
+ *                            bare `string[]` empty row, so the cause was never
+ *                            recorded. Never produced by a live parse; signals
+ *                            "re-record needed before cause-rate reporting."
+ * Not an FM falsifier — a done-criterion diagnostic, like `dispositionSource`.
+ */
+export const NoDraftCauseSchema = z.enum([
+  'invoke-error',
+  'empty-output',
+  'none-sentinel',
+  'unparseable-shape',
+  'non-array',
+  'all-filtered',
+  'legacy-unknown',
+]);
+export type NoDraftCause = z.infer<typeof NoDraftCauseSchema>;
+
 export const DropLedgerEntrySchema = z.object({
   /**
    * Source PR of the dropped candidate. REQUIRED — the funnel always knows which
@@ -120,6 +155,13 @@ export const DropLedgerEntrySchema = z.object({
   sourcePr: PrNumber,
   reasonCode: DropReasonCodeSchema,
   detail: z.string().optional(),
+  /**
+   * The extract-stage NO-DRAFT diagnostic (Tenet-19). Present ONLY on the
+   * extractor-produced empty-draft drop (`reasonCode: 'unparseable'`, detail
+   * "extractor produced no draft…") — absent on every other drop. Additive-
+   * optional so older ledgers (no cause recorded) still parse.
+   */
+  noDraftCause: NoDraftCauseSchema.optional(),
 });
 export type DropLedgerEntry = z.infer<typeof DropLedgerEntrySchema>;
 


### PR DESCRIPTION
## What

Slice **α** of the strategy#709 extractor-yield fix — **observability-first**. Makes the Gate-1 extract→draft loss *measurable* before any yield change.

The first Gate-1 cert run was honest-negative, dominated by the extractor returning `[]` on threads carrying mintable classes (518/519/520/537/553). A bare `[]` conflated ≥6 distinct causes with opposite fixes — and the frozen replay stored only the parsed `[]`, discarding the cause at record time. We can't tune what we can't see.

This widens the `DraftExtractor` port to a **`DraftResult` (`{ drafts, noDraftCause? }`)** — the extract-stage twin of the classifier's `dispositionSource` (a **non-FM Tenet-19 diagnostic**).

## Changes

- **`NoDraftCause`** (`ledgers.ts`): a pinned-order, mutually-exclusive partition over every empty path — `invoke-error` (adapter) / `empty-output` / `none-sentinel` / `unparseable-shape` / `non-array` / `all-filtered` (parser) — plus a replay-migration-only `legacy-unknown`. `DropLedgerEntry.noDraftCause` is additive-optional.
- **`DraftResultSchema`** (`extract.ts`): `{ drafts, noDraftCause? }` with a "cause **iff** empty" refine. `runExtractStage` parses the port result at the boundary (mirrors `ClassifierResultSchema.parse`) — a contract-violating result fails loud; the cause lands on the empty-draft drop.
- **Adapter** (`spine-llm-adapters.ts`): `parseExtractorOutput` returns the cause per branch; `LiveDraftExtractor.draft` tags `invoke-error` on a caught invoke failure.
- **Replay** (`spine-llm-replay.ts`): records the full `DraftResult`; a **backward-compatible union reader** (`string[] | DraftResult`) keeps the committed cert-#1 fixture loadable + byte-identical, normalizing a legacy row on read (empty → `legacy-unknown`).

Pure instrumentation — **no behavior change** to drafts or drops. The NO-DRAFT cause becomes observable on the next re-record.

## Provenance

Panel-ratified **3/3 PASS-to-build** (codex contract / agy build / gemini tenet). Folds incorporated: separate `reviewBotIdentity` axis (deferred to β), the pinned cause-order, the `[""]`→`all-filtered` adjudication, the legacy-`string[]` union reader, and the local↔core parity test.

## Gate

build (core+cli) · core 2785 / cli 2760 tests (incl. one red/green per `NoDraftCause` branch + the local↔core schema parity test + the legacy-fixture migration test) · ESLint 0 errors · `totem lint --base main` PASS · format:check · changeset (minor).

Part of #2237 — that issue stays open (β normalization + γ RESOLVED-eligibility follow; the single live re-record lands after γ).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
