### PR TITLE
feat(spine): extractor-yield β (bot-review substrate + chrome normalization) + γ (RESOLVED-eligibility) — strategy#709 yield-fix PR-2

### DIFF
--- a/.changeset/spine-extractor-yield-beta-gamma.md
+++ b/.changeset/spine-extractor-yield-beta-gamma.md
@@ -1,0 +1,22 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+---
+
+spine: extractor-yield β (bot-review substrate + chrome normalization) + γ (RESOLVED-eligibility) — strategy#709 yield-fix PR-2
+
+Builds on slice α (the NO-DRAFT cause-tags that made the moat measurable). Strategy ruled the first Gate-1 cert run's honest-negative is a pipeline input-hygiene + class-coverage loss, not a thesis failure — these two levers address the dominant extract→draft leak. Both move `extractorInputKey`, so the cert-#1 fixture invalidates by design (one clean re-record is the decisive cert re-run).
+
+**β — bot-review substrate + chrome normalization (panel OQ-β1..β4):**
+
+- **`reviewBotIdentity`** (core, `selection-rule.ts`): a NEW allowlist predicate recognizing review-FINDING bots (`gemini-code-assist` / `coderabbitai`, with/without a `[bot]` suffix), kept DELIBERATELY SEPARATE from `isBotIdentity` (which still gates `[bot]`-authored corpus membership, unchanged). Allowlist-not-denylist: a not-yet-listed tool undercounts rather than laundering every future automation account in.
+- **`substantiveCommentCount`** (replaces `humanCommentCount`): counts human + recognized review-bot comments as substrate; still excludes unrecognized `[bot]` noise (renovate/dependabot) + empty bodies. For this bot-reviewed cert corpus, gemini/CR review comments ARE legitimate substrate.
+- **`normalizeReviewChrome`** (core, new `review-normalize.ts`): a deterministic, idempotent, audit-preserving strip of bot-review chrome (severity badges, `<details>` collapsibles, HTML comments) — raw `body` kept, `normalizedBody` added. The extractor prompt renders it and `extractorInputKey` digests it; `REVIEW_CHROME_NORMALIZER_VERSION` folds into the replay provenance, so a normalizer change re-keys (replay miss) AND flips the integrity hash → re-record forced (Tenet-15).
+- **`authorKind` + source-tag**: each `ReviewThreadComment` carries `authorKind`; each draft carries a `DraftSourceKind` (`human|bot|mixed`) computed from its eligible threads, serialized onto the §8 emission ledger (NOT the reused `ProvenanceRecord`) + the zero-draft drop — a non-FM Tenet-19 diagnostic that makes the bot-substrate share observable.
+
+**γ — RESOLVED unconditional (strategy class-coverage lever):**
+
+- **`eligibleThreads`** narrows from `!isResolved && !isOutdated` to `!isOutdated`: a RESOLVED thread is the highest-signal legitimacy marker (a defect a reviewer raised AND the author confirmed by fixing), so it is now ADMITTED; only OUTDATED (diff-hunk-stale) threads stay excluded. The core gate and the replay-key eligibility move in LOCKSTEP.
+- Drop-reason hygiene: `resolved-rejected` → `outdated-rejected` (the gate now drops only on outdated), and the zero-draft drop gets its own `no-draft` reason code (slice α had mislabeled a legitimate model decline as `unparseable`; `noDraftCause` carries the precise sub-reason).
+
+No FM falsifier is touched — `authorKind` / `sourceKind` / `noDraftCause` are all diagnostics, and the eligibility narrowing is a curation property. Test-first / mock-driven, zero live LLM in CI.

--- a/packages/cli/src/commands/spine-cert-corpus.test.ts
+++ b/packages/cli/src/commands/spine-cert-corpus.test.ts
@@ -37,7 +37,7 @@ function content(pr: number): ReviewThreadContent {
     threads: [
       {
         path: 'src/a.ts',
-        comments: [{ author: 'Jane', body: 'note' }],
+        comments: [{ author: 'Jane', body: 'note', authorKind: 'human', normalizedBody: 'note' }],
         isResolved: false,
         isOutdated: false,
       },

--- a/packages/cli/src/commands/spine-cert-e2e.test.ts
+++ b/packages/cli/src/commands/spine-cert-e2e.test.ts
@@ -53,7 +53,7 @@ function content(pr: number): ReviewThreadContent {
     threads: [
       {
         path: 'src/a.ts',
-        comments: [{ author: 'Jane', body: 'note' }],
+        comments: [{ author: 'Jane', body: 'note', authorKind: 'human', normalizedBody: 'note' }],
         isResolved: false,
         isOutdated: false,
       },

--- a/packages/cli/src/commands/spine-cert-record.test.ts
+++ b/packages/cli/src/commands/spine-cert-record.test.ts
@@ -43,7 +43,7 @@ function content(pr: number): ReviewThreadContent {
     threads: [
       {
         path: 'src/a.ts',
-        comments: [{ author: 'Jane', body: 'note' }],
+        comments: [{ author: 'Jane', body: 'note', authorKind: 'human', normalizedBody: 'note' }],
         isResolved: false,
         isOutdated: false,
       },

--- a/packages/cli/src/commands/spine-cert-record.ts
+++ b/packages/cli/src/commands/spine-cert-record.ts
@@ -262,7 +262,7 @@ export async function buildLiveRecordDeps(
   config: LiveRecordConfig,
 ): Promise<RecordDeps> {
   const { createOrchestrator } = await import('../orchestrators/orchestrator.js');
-  const { TotemError } = await import('@mmnto/totem');
+  const { TotemError, REVIEW_CHROME_NORMALIZER_VERSION } = await import('@mmnto/totem');
   const {
     LiveDraftExtractor,
     LiveDraftClassifier,
@@ -329,6 +329,7 @@ export async function buildLiveRecordDeps(
       temperature: 0,
       orchestratorVersion: config.totemVersion,
       totemVersion: config.totemVersion,
+      normalizerVersion: REVIEW_CHROME_NORMALIZER_VERSION,
     }),
   };
 }

--- a/packages/cli/src/commands/spine-cert-run-corpus.test.ts
+++ b/packages/cli/src/commands/spine-cert-run-corpus.test.ts
@@ -74,7 +74,7 @@ function content(pr: number): ReviewThreadContent {
     threads: [
       {
         path: 'src/a.ts',
-        comments: [{ author: 'Jane', body: 'note' }],
+        comments: [{ author: 'Jane', body: 'note', authorKind: 'human', normalizedBody: 'note' }],
         isResolved: false,
         isOutdated: false,
       },

--- a/packages/cli/src/commands/spine-cert-run-corpus.ts
+++ b/packages/cli/src/commands/spine-cert-run-corpus.ts
@@ -96,7 +96,10 @@ export async function loadCertRunFixtures(
     skipGroundTruth?: boolean;
   },
 ): Promise<CertRunFixtureInputs> {
-  const { SplitArtifactSchema, TotemError } = await import('@mmnto/totem');
+  const { SplitArtifactSchema, TotemError, classifyAuthorKind, normalizeReviewChrome } =
+    await import('@mmnto/totem');
+  const { enrichComment } = await import('./spine-review-thread-source.js');
+  const enrich = { classifyAuthorKind, normalizeReviewChrome };
 
   const readRaw = (file: string): string => {
     try {
@@ -126,9 +129,23 @@ export async function loadCertRunFixtures(
 
   const split = SplitArtifactSchema.parse(loadJson(path.join(gate1Dir, SPLIT_FILE)));
   const artifact = ReplayArtifactSchema.parse(loadJson(path.join(gate1Dir, REPLAY_FILE)));
-  const content = z
+  // The committed content.json stores RAW comments (author + body + flags). ENRICH
+  // each comment with `authorKind` + `normalizedBody` (slice β) via the SAME
+  // `enrichComment` the live adapter uses, RE-DERIVED with the CURRENT normalizer —
+  // so the replay-time `extractorInputKey` (keyed on `normalizedBody`) matches what
+  // record stamped, and a normalizer change re-keys → a MISS forces a re-record
+  // (Tenet-15). Any `authorKind`/`normalizedBody` already in the JSON is ignored
+  // (the schema parses the raw shape), so a stale stored value can never be served.
+  const rawContent = z
     .array(ReviewThreadContentSchema)
     .parse(loadJson(path.join(gate1Dir, CONTENT_FILE)));
+  const content: ReviewThreadContent[] = rawContent.map((c) => ({
+    ...c,
+    threads: c.threads.map((t) => ({
+      ...t,
+      comments: t.comments.map((cm) => enrichComment(enrich, cm.author, cm.body)),
+    })),
+  }));
 
   // #2225 (#709 fold-2): verify-then-parse the SCORING source on a SINGLE read — the
   // digest must cover the exact bytes that get parsed + scored, not a separate read

--- a/packages/cli/src/commands/spine-llm-adapters.test.ts
+++ b/packages/cli/src/commands/spine-llm-adapters.test.ts
@@ -3,8 +3,18 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 // Type-only from the barrel (erased). The canonical `wrapUntrustedXml` VALUE is
 // imported below for the parity test — tests are off the CLI-startup path, so a
 // barrel value import here is fine (unlike the production module).
-import type { ExtractStageResult, ReviewThread, ReviewThreadContent } from '@mmnto/totem';
-import { wrapUntrustedXml } from '@mmnto/totem';
+import type {
+  ExtractStageResult,
+  ReviewThread,
+  ReviewThreadComment,
+  ReviewThreadContent,
+} from '@mmnto/totem';
+import {
+  classifyAuthorKind,
+  normalizeReviewChrome,
+  REVIEW_CHROME_NORMALIZER_VERSION,
+  wrapUntrustedXml,
+} from '@mmnto/totem';
 
 import type { InvokeOrchestrator } from '../orchestrators/orchestrator.js';
 import {
@@ -96,6 +106,16 @@ function makeClassifier(
   });
 }
 
+function comment(author: string, body: string): ReviewThreadComment {
+  const authorKind = classifyAuthorKind(author);
+  return {
+    author,
+    body,
+    authorKind,
+    normalizedBody: authorKind === 'bot' ? normalizeReviewChrome(body) : body,
+  };
+}
+
 function content(opts?: { pr?: number; threads?: ReviewThread[] }): ReviewThreadContent {
   return {
     pr: opts?.pr ?? 100,
@@ -105,7 +125,7 @@ function content(opts?: { pr?: number; threads?: ReviewThread[] }): ReviewThread
         path: 'a.ts',
         isResolved: false,
         isOutdated: false,
-        comments: [{ author: 'jane', body: 'no exec' }],
+        comments: [comment('jane', 'no exec')],
       },
     ],
   };
@@ -115,6 +135,7 @@ function draft(dslSource = '**Pattern:** no-foo'): DraftCandidate {
   return {
     provenance: { mergedPr: 100, reviewThread: 'pulls/100/comments', commitSha: MERGE_SHA },
     dslSource,
+    sourceKind: 'human',
   };
 }
 
@@ -466,6 +487,7 @@ describe('buildReplayProvenance (fold F)', () => {
     temperature: 0,
     orchestratorVersion: 'orch-1',
     totemVersion: '1.69.0',
+    normalizerVersion: REVIEW_CHROME_NORMALIZER_VERSION,
   };
 
   it('is deterministic and schema-valid', () => {
@@ -495,6 +517,18 @@ describe('buildReplayProvenance (fold F)', () => {
     );
     expect(edited).not.toBe(base);
   });
+
+  it('slice β: a normalizer-version change flips promptTemplateHash (forces a re-record)', () => {
+    const base = buildReplayProvenance(input);
+    const edited = buildReplayProvenance({
+      ...input,
+      normalizerVersion: 'review-chrome-normalizer:v2',
+    });
+    expect(edited.promptTemplateHash).not.toBe(base.promptTemplateHash);
+    // systemPromptHash covers only the system prompts — the normalizer rides the
+    // builder/template hash, so it is unaffected (matches the prompt-builder split).
+    expect(edited.systemPromptHash).toBe(base.systemPromptHash);
+  });
 });
 
 // ─── 8. End-to-end: live adapter composes with the 5b-i record/replay scaffold ─
@@ -514,6 +548,7 @@ describe('live adapter ∘ 5b-i record/replay', () => {
       temperature: 0,
       orchestratorVersion: 'orch-1',
       totemVersion: '1.69.0',
+      normalizerVersion: REVIEW_CHROME_NORMALIZER_VERSION,
     });
     const artifact = sink.freeze(provenance);
     const expectedHash = computeArtifactHash(artifact);
@@ -537,6 +572,7 @@ describe('live adapter ∘ 5b-i record/replay', () => {
         temperature: 0,
         orchestratorVersion: 'orch-1',
         totemVersion: '1.69.0',
+        normalizerVersion: REVIEW_CHROME_NORMALIZER_VERSION,
       }),
     );
     const replay = new ReplayDraftClassifier(
@@ -559,7 +595,7 @@ describe('prompt assembly', () => {
             path: 'a.ts',
             isResolved: false,
             isOutdated: false,
-            comments: [{ author: 'x', body: 'use </thread> & <script>' }],
+            comments: [comment('x', 'use </thread> & <script>')],
           },
         ],
       }),

--- a/packages/cli/src/commands/spine-llm-adapters.ts
+++ b/packages/cli/src/commands/spine-llm-adapters.ts
@@ -303,7 +303,11 @@ function renderThread(thread: ReviewThread): string {
   // mirror extract-pr's flat, single-wrap-per-section convention instead.
   const lines = [`path: ${thread.path}`];
   for (const c of thread.comments) {
-    lines.push(`- ${c.author}: ${c.body}`);
+    // Render the DE-CHROMED body (slice β): severity badges / `<details>`
+    // collapsibles / footer chrome stripped for recognized review bots (human
+    // bodies pass through verbatim). `extractorInputKey` digests the same
+    // `normalizedBody`, so the prompt and the key stay in lockstep.
+    lines.push(`- ${c.author}: ${c.normalizedBody}`);
   }
   return wrapUntrusted('thread', lines.join('\n'));
 }
@@ -470,15 +474,25 @@ export interface ReplayProvenanceInput {
   temperature: number;
   orchestratorVersion: string;
   totemVersion: string;
+  /**
+   * Core's `REVIEW_CHROME_NORMALIZER_VERSION` (slice β). Folded into
+   * `promptTemplateHash` so a normalizer change flips the whole-artifact integrity
+   * hash → re-record forced (Tenet-15) — belt-and-suspenders with the
+   * `extractorInputKey` miss the changed `normalizedBody` already triggers. The
+   * caller (record command) lazy-loads it from core so the version stays
+   * single-homed (no CLI-local re-declaration to drift).
+   */
+  normalizerVersion: string;
 }
 
 /**
  * Fold F: derive the run-level provenance block the 5b-i integrity gate covers.
  * `systemPromptHash` hashes BOTH frozen system prompts; `promptTemplateHash`
- * folds the prompt-BUILDER version in too, so EITHER a prompt edit OR a
- * user-prompt-assembly change flips a hash → the whole-artifact integrity hash
- * changes → the stale fixture is rejected until re-recorded (a prompt change can
- * never silently shift the canonical verdict). Deterministic + git-independent.
+ * folds the prompt-BUILDER version AND the slice-β chrome-normalizer version in
+ * too, so a prompt edit, a user-prompt-assembly change, OR a normalizer change
+ * flips a hash → the whole-artifact integrity hash changes → the stale fixture is
+ * rejected until re-recorded (none of them can silently shift the canonical
+ * verdict). Deterministic + git-independent.
  */
 export function buildReplayProvenance(input: ReplayProvenanceInput): ReplayProvenance {
   const systemPromptHash = sha256Hex(
@@ -487,6 +501,7 @@ export function buildReplayProvenance(input: ReplayProvenanceInput): ReplayProve
   const promptTemplateHash = sha256Hex(
     canonicalJson({
       builder: PROMPT_BUILDER_VERSION,
+      normalizer: input.normalizerVersion,
       extract: input.extractSystemPrompt,
       classify: input.classifySystemPrompt,
     }),

--- a/packages/cli/src/commands/spine-llm-replay.test.ts
+++ b/packages/cli/src/commands/spine-llm-replay.test.ts
@@ -2,10 +2,13 @@ import { describe, expect, it } from 'vitest';
 
 import {
   type ClassifierResult,
+  classifyAuthorKind,
   type DraftResult,
   DraftResultSchema,
   type ExtractStageResult,
+  normalizeReviewChrome,
   type ReviewThread,
+  type ReviewThreadComment,
   type ReviewThreadContent,
 } from '@mmnto/totem';
 
@@ -65,8 +68,14 @@ class StubClassifier {
 const MERGE_SHA_A = 'a'.repeat(40);
 const MERGE_SHA_B = 'b'.repeat(40);
 
-function comment(author: string, body: string) {
-  return { author, body };
+function comment(author: string, body: string): ReviewThreadComment {
+  const authorKind = classifyAuthorKind(author);
+  return {
+    author,
+    body,
+    authorKind,
+    normalizedBody: authorKind === 'bot' ? normalizeReviewChrome(body) : body,
+  };
 }
 
 function thread(opts?: Partial<ReviewThread>): ReviewThread {
@@ -98,6 +107,7 @@ function draft(opts?: { pr?: number; commitSha?: string; dslSource?: string }): 
       commitSha: opts?.commitSha ?? MERGE_SHA_A,
     },
     dslSource: opts?.dslSource ?? '**Pattern:** no-foo',
+    sourceKind: 'human',
   };
 }
 
@@ -399,12 +409,36 @@ describe('extractorInputKey (fold D)', () => {
     expect(forward).toBe(reversed);
   });
 
-  it('excludes resolved/outdated threads from the key (the port never sees them)', () => {
+  it('excludes only OUTDATED threads from the key; RESOLVED now affects it (slice γ)', () => {
     const eligible = thread({ path: 'a.ts', comments: [comment('al', 'keep')] });
-    const resolved = thread({ path: 'z.ts', isResolved: true, comments: [comment('zo', 'drop')] });
+    // γ: an OUTDATED thread is still excluded from the eligible set → no key effect.
+    const outdated = thread({ path: 'z.ts', isOutdated: true, comments: [comment('zo', 'drop')] });
+    const withOutdated = extractorInputKey(content({ threads: [eligible, outdated] }));
+    const withoutOutdated = extractorInputKey(content({ threads: [eligible] }));
+    expect(withOutdated).toBe(withoutOutdated);
+
+    // γ: a RESOLVED thread is now ADMITTED → it IS part of the eligible set the
+    // extractor sees, so it MUST change the key (the slice-5a exclusion is reversed).
+    const resolved = thread({ path: 'z.ts', isResolved: true, comments: [comment('zo', 'keep2')] });
     const withResolved = extractorInputKey(content({ threads: [eligible, resolved] }));
-    const withoutResolved = extractorInputKey(content({ threads: [eligible] }));
-    expect(withResolved).toBe(withoutResolved);
+    expect(withResolved).not.toBe(withoutOutdated);
+  });
+
+  it('digests the DE-CHROMED normalizedBody, not the raw body (slice β)', () => {
+    // Two bot comments with DIFFERENT chrome but the SAME de-chromed body must key
+    // identically (the LLM saw the same normalizedBody); a human comment whose raw
+    // body equals that normalized text keys identically too (author aside).
+    const chromeA = thread({
+      path: 'a.ts',
+      comments: [comment('coderabbitai[bot]', '![high](https://x/a.svg)\nguard the divisor')],
+    });
+    const chromeB = thread({
+      path: 'a.ts',
+      comments: [comment('coderabbitai[bot]', '<!-- id:1 -->guard the divisor')],
+    });
+    expect(extractorInputKey(content({ threads: [chromeA] }))).toBe(
+      extractorInputKey(content({ threads: [chromeB] })),
+    );
   });
 });
 

--- a/packages/cli/src/commands/spine-llm-replay.ts
+++ b/packages/cli/src/commands/spine-llm-replay.ts
@@ -50,7 +50,6 @@ import type {
   DraftResult,
   ExtractStageResult,
   ReviewThread,
-  ReviewThreadComment,
   ReviewThreadContent,
 } from '@mmnto/totem';
 
@@ -183,29 +182,37 @@ function sha256Hex(input: string): string {
 // ─── inputKey derivation (fold D — the `deriveClaimId` pattern) ───────────────
 
 /**
- * Normalize a single review thread to its STABLE identity: sort comments by
- * (body, author) and carry only the resolution flags + path. Provider/array
- * order must not change the key, so comments are sorted by a stable tuple before
- * hashing. Resolved/outdated flags ARE part of the identity (the eligible-thread
- * set the extractor was actually handed depends on them).
+ * Normalize a single review thread to its STABLE identity: project each comment to
+ * `{ author, normalizedBody }`, sort by `(normalizedBody, author)`, and carry the
+ * resolution flags + path. The key digests the DE-CHROMED `normalizedBody` (slice
+ * β) — exactly what the extractor's prompt renders — NOT the raw `body` (chrome the
+ * LLM never saw) nor `authorKind` (a pure function of `author`, so redundant). A
+ * normalizer-version change re-derives `normalizedBody` → the key shifts → a replay
+ * MISS forces a re-record (Tenet-15), the same lever the provenance hash pulls.
+ * Provider/array order must not change the key, so comments are sorted by a stable
+ * tuple before hashing. The resolution flags are carried as thread identity; post-γ
+ * only `isOutdated` gates the eligible set (resolved threads are now admitted), but
+ * both remain stable per-thread facts.
  */
 function normalizeThread(thread: ReviewThread): {
   path: string;
   isResolved: boolean;
   isOutdated: boolean;
-  comments: ReviewThreadComment[];
+  comments: { author: string; normalizedBody: string }[];
 } {
-  const comments = [...thread.comments].sort((a, b) =>
-    a.body !== b.body
-      ? a.body < b.body
-        ? -1
-        : 1
-      : a.author < b.author
-        ? -1
-        : a.author > b.author
-          ? 1
-          : 0,
-  );
+  const comments = thread.comments
+    .map((c) => ({ author: c.author, normalizedBody: c.normalizedBody }))
+    .sort((a, b) =>
+      a.normalizedBody !== b.normalizedBody
+        ? a.normalizedBody < b.normalizedBody
+          ? -1
+          : 1
+        : a.author < b.author
+          ? -1
+          : a.author > b.author
+            ? 1
+            : 0,
+    );
   return {
     path: thread.path,
     isResolved: thread.isResolved,
@@ -235,14 +242,16 @@ function normalizeThreads(threads: readonly ReviewThread[]): ReturnType<typeof n
 }
 
 /**
- * Filter to the EXACT eligible set the extractor is handed: non-resolved,
- * non-outdated threads (mirrors core's `eligibleThreads`). The inputKey is a
+ * Filter to the EXACT eligible set the extractor is handed: non-outdated threads
+ * (slice γ — mirrors core's `eligibleThreads` in LOCKSTEP; RESOLVED threads are now
+ * admitted). Keeping this identical to core is REQUIRED: a divergence would make a
+ * replay miss/false-hit indistinguishable from model drift. The inputKey is a
  * function of what the port ACTUALLY saw, so eligibility must be applied before
- * normalizing — two contents that differ only in resolved/outdated threads
- * (which the extractor never sees) still key identically.
+ * normalizing — two contents that differ only in outdated threads (which the
+ * extractor never sees) still key identically.
  */
 function eligibleThreads(threads: readonly ReviewThread[]): ReviewThread[] {
-  return threads.filter((t) => !t.isResolved && !t.isOutdated);
+  return threads.filter((t) => !t.isOutdated);
 }
 
 /**

--- a/packages/cli/src/commands/spine-review-thread-source.test.ts
+++ b/packages/cli/src/commands/spine-review-thread-source.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
+import { classifyAuthorKind, normalizeReviewChrome } from '@mmnto/totem';
+
 import {
   buildReviewThreadsQuery,
+  type CommentEnrichers,
   type GhExec,
   mapThreads,
   ReviewThreadSourceAdapter,
@@ -12,6 +15,9 @@ import {
 const OWNER = 'mmnto-ai';
 const NAME = 'totem';
 const MERGE_OID = 'a'.repeat(40);
+
+/** The real core enrichers (slice β) — tests exercise the shipped classification. */
+const enrich: CommentEnrichers = { classifyAuthorKind, normalizeReviewChrome };
 
 /** A well-formed GraphQL response payload (string, as `gh` returns). */
 function okPayload(opts?: {
@@ -113,26 +119,29 @@ describe('ReviewThreadSourceAdapter — query-spy through fetch', () => {
 
 describe('mapThreads', () => {
   it('surfaces per-thread isResolved/isOutdated flags (does not filter)', () => {
-    const mapped = mapThreads([
-      {
-        isResolved: true,
-        isOutdated: false,
-        path: 'a.ts',
-        comments: {
-          pageInfo: { hasNextPage: false },
-          nodes: [{ author: { login: 'jane' }, body: 'x' }],
+    const mapped = mapThreads(
+      [
+        {
+          isResolved: true,
+          isOutdated: false,
+          path: 'a.ts',
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [{ author: { login: 'jane' }, body: 'x' }],
+          },
         },
-      },
-      {
-        isResolved: false,
-        isOutdated: true,
-        path: 'b.ts',
-        comments: {
-          pageInfo: { hasNextPage: false },
-          nodes: [{ author: { login: 'john' }, body: 'y' }],
+        {
+          isResolved: false,
+          isOutdated: true,
+          path: 'b.ts',
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [{ author: { login: 'john' }, body: 'y' }],
+          },
         },
-      },
-    ]);
+      ],
+      enrich,
+    );
     // BOTH threads are present — nothing filtered out (surface, not filter).
     expect(mapped).toHaveLength(2);
     expect(mapped[0]).toMatchObject({ path: 'a.ts', isResolved: true, isOutdated: false });
@@ -140,19 +149,54 @@ describe('mapThreads', () => {
   });
 
   it('coerces a null author (deleted/ghost) to an empty login', () => {
-    const mapped = mapThreads([
-      {
-        isResolved: false,
-        isOutdated: false,
-        path: 'a.ts',
-        comments: {
-          pageInfo: { hasNextPage: false },
-          nodes: [{ author: null, body: 'ghost note' }],
+    const mapped = mapThreads(
+      [
+        {
+          isResolved: false,
+          isOutdated: false,
+          path: 'a.ts',
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [{ author: null, body: 'ghost note' }],
+          },
         },
-      },
-    ]);
+      ],
+      enrich,
+    );
     expect(mapped[0]!.comments[0]!.author).toBe('');
     expect(mapped[0]!.comments[0]!.body).toBe('ghost note');
+  });
+
+  it('slice β: stamps authorKind + de-chromed normalizedBody (bot stripped, human verbatim)', () => {
+    const mapped = mapThreads(
+      [
+        {
+          isResolved: false,
+          isOutdated: false,
+          path: 'a.ts',
+          comments: {
+            pageInfo: { hasNextPage: false },
+            nodes: [
+              {
+                author: { login: 'coderabbitai[bot]' },
+                body: '![high](https://x/high.svg)\nguard the divisor',
+              },
+              { author: { login: 'jane' }, body: 'the human rationale' },
+            ],
+          },
+        },
+      ],
+      enrich,
+    );
+    const [bot, human] = mapped[0]!.comments;
+    // Recognized review bot → authorKind 'bot' + chrome stripped from normalizedBody
+    // (raw body retained for audit).
+    expect(bot!.authorKind).toBe('bot');
+    expect(bot!.body).toContain('![high]');
+    expect(bot!.normalizedBody).toBe('guard the divisor');
+    // Human → authorKind 'human' + normalizedBody verbatim.
+    expect(human!.authorKind).toBe('human');
+    expect(human!.normalizedBody).toBe('the human rationale');
   });
 });
 

--- a/packages/cli/src/commands/spine-review-thread-source.ts
+++ b/packages/cli/src/commands/spine-review-thread-source.ts
@@ -29,7 +29,13 @@ import { z } from 'zod';
 // to keep CLI startup fast — the core barrel pulls in heavy deps (LanceDB,
 // apache-arrow). Matches the spine-windtunnel.ts convention. Type-only imports
 // are erased at compile, so they stay static.
-import type { FetchResult, ReviewThread, ReviewThreadSource } from '@mmnto/totem';
+import type {
+  AuthorKind,
+  FetchResult,
+  ReviewThread,
+  ReviewThreadComment,
+  ReviewThreadSource,
+} from '@mmnto/totem';
 
 // ─── Named constants ─────────────────────────────────
 
@@ -148,22 +154,60 @@ async function loadDefaultExec(cwd: string): Promise<GhExec> {
 // ─── Mapping ─────────────────────────────────────────
 
 /**
- * Map a validated GraphQL response to the surviving `ReviewThread[]` with their
- * resolution flags surfaced. Pure — exported for the mapping test. A null author
- * (deleted/ghost) coerces to '' (`isBotIdentity('')` is false, so it stays a
- * human-author '' that core's empty-body / count logic handles correctly; the
- * body still gates inclusion).
+ * The two CORE-homed comment classifiers `mapThreads` stamps onto each comment
+ * (slice β). Injected — the LOGIC + version live in core (`classifyAuthorKind`,
+ * `normalizeReviewChrome`; panel OQ-β1/β3), the adapter is only the mapping-
+ * boundary call site, so the inputKey can never drift from the provenance. The
+ * real `fetch` resolves these by lazy-loading core (the barrel is loaded anyway
+ * for `safeExec`); tests pass the real core fns directly.
  */
-export function mapThreads(nodes: z.infer<typeof GqlReviewThreadSchema>[]): ReviewThread[] {
+export interface CommentEnrichers {
+  classifyAuthorKind: (author: string) => AuthorKind;
+  normalizeReviewChrome: (body: string) => string;
+}
+
+/**
+ * Slice-β comment enrichment (the SHARED single home): stamp `authorKind` (via core
+ * `classifyAuthorKind`) + `normalizedBody` (the de-chromed text the extractor
+ * consumes — `normalizeReviewChrome(body)` for a recognized review bot, else the raw
+ * body verbatim; chrome is stripped ONLY for bot comments so human prose is never
+ * altered). BOTH the live `mapThreads` AND the replay-time `frozenSourceFrom` loader
+ * (`spine-cert-run-corpus`) call THIS, so the de-chromed body they feed the
+ * extractor — hence the `extractorInputKey` — can never diverge between record and
+ * replay (a divergence would be indistinguishable from model drift).
+ */
+export function enrichComment(
+  enrich: CommentEnrichers,
+  author: string,
+  body: string,
+): ReviewThreadComment {
+  const authorKind = enrich.classifyAuthorKind(author);
+  return {
+    author,
+    body,
+    authorKind,
+    normalizedBody: authorKind === 'bot' ? enrich.normalizeReviewChrome(body) : body,
+  };
+}
+
+/**
+ * Map a validated GraphQL response to the surviving `ReviewThread[]` with their
+ * resolution flags surfaced and each comment slice-β-ENRICHED (see `enrichComment`).
+ * Pure given `enrich` — exported for the mapping test. A null author (deleted/ghost)
+ * coerces to '' (`reviewBotIdentity('')` is false → `authorKind: 'human'`, and
+ * `isBotIdentity('')` is false, so core's count keeps it; the body still gates
+ * inclusion).
+ */
+export function mapThreads(
+  nodes: z.infer<typeof GqlReviewThreadSchema>[],
+  enrich: CommentEnrichers,
+): ReviewThread[] {
   return nodes.map((t) => ({
     path: t.path,
     // SURFACE the flags — never filter on them here (core decides).
     isResolved: t.isResolved,
     isOutdated: t.isOutdated,
-    comments: t.comments.nodes.map((c) => ({
-      author: c.author?.login ?? '',
-      body: c.body,
-    })),
+    comments: t.comments.nodes.map((c) => enrichComment(enrich, c.author?.login ?? '', c.body)),
   }));
 }
 
@@ -177,6 +221,12 @@ export interface ReviewThreadSourceAdapterOptions {
   cwd?: string;
   /** Injectable exec seam (tests). Defaults to a `gh`-backed `safeExec`. */
   exec?: GhExec;
+  /**
+   * Injectable slice-β comment enrichers (tests). Defaults to a lazy-load of core's
+   * `classifyAuthorKind` + `normalizeReviewChrome` (the barrel is loaded anyway for
+   * `safeExec`). Tests pass the real core fns so the mapping is exercised end-to-end.
+   */
+  enrich?: CommentEnrichers;
 }
 
 /**
@@ -196,12 +246,17 @@ export class ReviewThreadSourceAdapter implements ReviewThreadSource {
    * guard (CR #2207 — was benign since dynamic import is idempotent, now explicit).
    */
   private execPromise: Promise<GhExec> | undefined;
+  /** Injected slice-β enrichers (tests); when absent the default lazy-loads core once via `enrichPromise`. */
+  private readonly injectedEnrich: CommentEnrichers | undefined;
+  /** Memoized lazy-load of core's `classifyAuthorKind` + `normalizeReviewChrome` (real runs) — see `execPromise`. */
+  private enrichPromise: Promise<CommentEnrichers> | undefined;
 
   constructor(opts: ReviewThreadSourceAdapterOptions) {
     this.owner = opts.owner;
     this.name = opts.name;
     this.cwd = opts.cwd ?? process.cwd();
     this.injectedExec = opts.exec;
+    this.injectedEnrich = opts.enrich;
   }
 
   /** Resolve the exec seam: the injected one (tests), else the memoized lazy-loaded default. */
@@ -209,6 +264,16 @@ export class ReviewThreadSourceAdapter implements ReviewThreadSource {
     if (this.injectedExec) return Promise.resolve(this.injectedExec);
     this.execPromise ??= loadDefaultExec(this.cwd);
     return this.execPromise;
+  }
+
+  /** Resolve the slice-β enrichers: the injected ones (tests), else a memoized lazy-load of core. */
+  private resolveEnrich(): Promise<CommentEnrichers> {
+    if (this.injectedEnrich) return Promise.resolve(this.injectedEnrich);
+    this.enrichPromise ??= (async () => {
+      const { classifyAuthorKind, normalizeReviewChrome } = await import('@mmnto/totem');
+      return { classifyAuthorKind, normalizeReviewChrome };
+    })();
+    return this.enrichPromise;
   }
 
   async fetch(pr: number): Promise<FetchResult> {
@@ -289,7 +354,8 @@ export class ReviewThreadSourceAdapter implements ReviewThreadSource {
       }
     }
 
-    const threads = mapThreads(pull.reviewThreads.nodes);
+    const enrich = await this.resolveEnrich();
+    const threads = mapThreads(pull.reviewThreads.nodes, enrich);
     return {
       kind: 'ok',
       content: { pr, mergeCommitSha, threads },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -843,6 +843,7 @@ export { deriveLabelsFromDispositions } from './spine/derive-labels.js';
 export type { DispositionClass, DispositionComment } from './spine/disposition-taxonomy.js';
 export { classifyDisposition, dispositionToLabel } from './spine/disposition-taxonomy.js';
 export type {
+  AuthorKind,
   DraftExtractor,
   DraftResult,
   ExtractStageDeps,
@@ -853,7 +854,7 @@ export type {
   ReviewThreadContent,
   ReviewThreadSource,
 } from './spine/extract.js';
-export { DraftResultSchema, runExtractStage } from './spine/extract.js';
+export { classifyAuthorKind, DraftResultSchema, runExtractStage } from './spine/extract.js';
 export type {
   ApiFetchSlice,
   ApiUsageLedger,
@@ -861,6 +862,7 @@ export type {
   ClassifierLedger,
   ClassifierLedgerEntry,
   DispositionSource,
+  DraftSourceKind,
   DropLedger,
   DropLedgerEntry,
   DropReasonCode,
@@ -878,6 +880,7 @@ export {
   ClassifierLedgerEntrySchema,
   ClassifierLedgerSchema,
   DispositionSourceSchema,
+  DraftSourceKindSchema,
   DropLedgerEntrySchema,
   DropLedgerSchema,
   DropReasonCodeSchema,
@@ -896,6 +899,10 @@ export type {
 export { buildCertifiedRulesFile, projectLegitimacy } from './spine/legitimacy-projection.js';
 export type { FalsificationResult, FmClause, FmViolation } from './spine/miner-harness.js';
 export { checkParsedLedgers, runFalsificationHarness } from './spine/miner-harness.js';
+export {
+  normalizeReviewChrome,
+  REVIEW_CHROME_NORMALIZER_VERSION,
+} from './spine/review-normalize.js';
 export type {
   CodePathClassifier,
   PrMeta,
@@ -910,6 +917,7 @@ export {
   parseRevertSha,
   prSetsEqual,
   resolveSelectionRule,
+  reviewBotIdentity,
   SelectionRuleParseError,
   selectionRulePredicate,
 } from './spine/selection-rule.js';

--- a/packages/core/src/spine/classify.test.ts
+++ b/packages/core/src/spine/classify.test.ts
@@ -9,15 +9,23 @@ import {
   runClassifyStage,
 } from './classify.js';
 import type { DraftCandidate, ExtractStageResult } from './extract.js';
-import type { MinerLedgers, SplitLedger } from './ledgers.js';
+import type { DraftSourceKind, MinerLedgers, SplitLedger } from './ledgers.js';
 import { type FmClause, runFalsificationHarness } from './miner-harness.js';
 
 const sha = (n: number): string => String(n).padStart(40, '0');
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
-function draft(pr: number, dslSource: string): DraftCandidate {
-  return { provenance: { mergedPr: pr, reviewThread: `rt-${pr}`, commitSha: sha(pr) }, dslSource };
+function draft(
+  pr: number,
+  dslSource: string,
+  sourceKind: DraftSourceKind = 'human',
+): DraftCandidate {
+  return {
+    provenance: { mergedPr: pr, reviewThread: `rt-${pr}`, commitSha: sha(pr) },
+    dslSource,
+    sourceKind,
+  };
 }
 
 const STRUCT = '**Pattern:** no-foo'; // marker the dsl-keyed fixture classifier reads as structural
@@ -124,6 +132,7 @@ describe('runClassifyStage — mint + ledgers', () => {
         routing: 'compile',
         classifierLedgerRef: 'clr-1-0',
         unverified: true,
+        sourceKind: 'human', // slice β: carried from the draft (default human here)
       },
     ]);
     expect(r.classifierLedger.entries).toEqual([
@@ -142,6 +151,17 @@ describe('runClassifyStage — mint + ledgers', () => {
     });
     expect(r.candidates[0].classifierDisposition).toBe('behavioral');
     expect(r.emissionLedger.entries[0].routing).toBe('rag-only');
+  });
+
+  it('slice β: the draft sourceKind is serialized onto its emission row (panel OQ-β4)', async () => {
+    const r = await runClassifyStage(
+      extractResult({
+        drafts: [draft(1, STRUCT, 'bot'), draft(2, BEHAVE, 'mixed')],
+      }),
+      splitLedger(),
+      { classifier: always(asStructural) },
+    );
+    expect(r.emissionLedger.entries.map((e) => e.sourceKind)).toEqual(['bot', 'mixed']);
   });
 
   it('join holds: every emission classifierLedgerRef resolves to a classifier entry with the same disposition', async () => {
@@ -287,6 +307,7 @@ describe('runClassifyStage — fail-loud provenance re-check', () => {
     const forged: DraftCandidate = {
       provenance: { mergedPr: 1, reviewThread: 'rt-1', commitSha: sha(99) },
       dslSource: STRUCT,
+      sourceKind: 'human',
     };
     await expect(
       runClassifyStage(extractResult({ drafts: [forged] }), splitLedger(), {

--- a/packages/core/src/spine/classify.ts
+++ b/packages/core/src/spine/classify.ts
@@ -222,6 +222,9 @@ export async function runClassifyStage(
       routing,
       classifierLedgerRef,
       unverified: true,
+      // Carry the slice-β substrate provenance from the draft onto its §8 emission
+      // row (panel OQ-β4 — the emission ledger is its persisted home, single hop).
+      sourceKind: draft.sourceKind,
     });
     classifierEntries.push({
       // The classifier entry's own ref = the join key the emission entry points to.

--- a/packages/core/src/spine/compile.test.ts
+++ b/packages/core/src/spine/compile.test.ts
@@ -348,7 +348,11 @@ const asStructural: ClassifierResult = {
 const structuralClassifier: DraftClassifier = { classify: () => Promise.resolve(asStructural) };
 
 function draft(pr: number, dslSource: string): DraftCandidate {
-  return { provenance: { mergedPr: pr, reviewThread: `rt-${pr}`, commitSha: sha(pr) }, dslSource };
+  return {
+    provenance: { mergedPr: pr, reviewThread: `rt-${pr}`, commitSha: sha(pr) },
+    dslSource,
+    sourceKind: 'human',
+  };
 }
 
 function extractResultOf(drafts: DraftCandidate[]): ExtractStageResult {

--- a/packages/core/src/spine/extract.test.ts
+++ b/packages/core/src/spine/extract.test.ts
@@ -1,20 +1,39 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  classifyAuthorKind,
   type DraftExtractor,
   type DraftResult,
   type ExtractStageResult,
   type FetchResult,
   type ReviewThread,
+  type ReviewThreadComment,
   type ReviewThreadContent,
   type ReviewThreadSource,
   runExtractStage,
 } from './extract.js';
+import { normalizeReviewChrome } from './review-normalize.js';
 import { type SplitArtifact, SplitArtifactSchema } from './split.js';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────
 
 const sha = (n: number): string => String(n).padStart(40, '0');
+
+/**
+ * Build a slice-β-enriched comment exactly as the CLI mapping boundary does:
+ * `authorKind` via core `classifyAuthorKind`, `normalizedBody` = de-chromed for a
+ * recognized review bot, else the raw body. Keeps test comments honest w.r.t. the
+ * shipped classification rather than hand-stamping fields.
+ */
+function comment(author: string, body: string): ReviewThreadComment {
+  const authorKind = classifyAuthorKind(author);
+  return {
+    author,
+    body,
+    authorKind,
+    normalizedBody: authorKind === 'bot' ? normalizeReviewChrome(body) : body,
+  };
+}
 
 function split(overrides?: Partial<SplitArtifact>): SplitArtifact {
   return SplitArtifactSchema.parse({
@@ -54,7 +73,7 @@ function content(pr: number, overrides?: Partial<ReviewThreadContent>): ReviewTh
     threads: [
       {
         path: 'packages/core/src/x.ts',
-        comments: [{ author: 'Jane Doe', body: 'a real review note' }],
+        comments: [comment('Jane Doe', 'a real review note')],
         isResolved: false,
         isOutdated: false,
       },
@@ -71,7 +90,7 @@ function thread(
 ): ReviewThread {
   return {
     path: 'packages/core/src/x.ts',
-    comments: [{ author, body }],
+    comments: [comment(author, body)],
     isResolved: flags?.isResolved ?? false,
     isOutdated: flags?.isOutdated ?? false,
   };
@@ -203,12 +222,14 @@ describe('runExtractStage — drop reason codes', () => {
     expect(dropsFor(r, 1)[0]!.reasonCode).toBe('truncated');
   });
 
-  it('truncated: a bot-only thread does not satisfy ≥1 human comment (fold 5)', async () => {
+  it('truncated: a NOISE-bot-only thread does not satisfy ≥1 substantive comment (slice β denylist)', async () => {
+    // dependabot/renovate are NOT in the review-finding allowlist → still excluded
+    // (unlike gemini/CR, which now count — see the slice-β substrate tests).
     const botThread = content(1, {
       threads: [
         {
           path: 'x.ts',
-          comments: [{ author: 'coderabbitai[bot]', body: 'nit: rename this' }],
+          comments: [comment('dependabot[bot]', 'bump lodash to 4.17.21')],
           isResolved: false,
           isOutdated: false,
         },
@@ -226,7 +247,7 @@ describe('runExtractStage — drop reason codes', () => {
       threads: [
         {
           path: 'x.ts',
-          comments: [{ author: 'Jane Doe', body: '   ' }],
+          comments: [comment('Jane Doe', '   ')],
           isResolved: false,
           isOutdated: false,
         },
@@ -278,17 +299,21 @@ describe('runExtractStage — drop reason codes', () => {
     expect(r.drafts).toEqual([]);
   });
 
-  it('unparseable: the extractor produced no draft from a complete thread — records the NO-DRAFT cause', async () => {
+  it('no-draft: the extractor produced no draft from a complete thread — records cause + sourceKind (slice β)', async () => {
     const r = await runExtractStage(
       solo(),
       deps(spySource([1]), fixtureExtractor(new Map([[1, []]]))),
     );
     const drop = dropsFor(r, 1)[0]!;
-    expect(drop.reasonCode).toBe('unparseable');
+    // Slice β: the zero-draft drop is now its own `no-draft` reason code (was the
+    // misnamed `unparseable`), with the precise sub-cause + the substrate tag.
+    expect(drop.reasonCode).toBe('no-draft');
     // The Tenet-19 diagnostic is carried onto the drop (fixtureExtractor tags an
     // empty list 'all-filtered') — never silently dropped as a bare [].
     expect(drop.noDraftCause).toBe('all-filtered');
     expect(drop.detail).toContain('all-filtered');
+    // The default `content(1)` thread is a single human comment → human substrate.
+    expect(drop.sourceKind).toBe('human');
   });
 
   it('boundary-parse fails loud on a contract-violating DraftResult (empty-without-cause)', async () => {
@@ -429,61 +454,61 @@ function recordingExtractor(byPr?: Map<number, string[]>): DraftExtractor & {
   };
 }
 
-describe('runExtractStage — resolution-eligibility gate (slice 5a)', () => {
-  it('all-resolved-but-had-human-content drops resolved-rejected (not truncated)', async () => {
-    const allResolved = content(1, {
+describe('runExtractStage — eligibility gate (slice γ: RESOLVED admitted, only OUTDATED excluded)', () => {
+  it('a RESOLVED thread is now ADMITTED (drafts; reaches the extractor input)', async () => {
+    const resolved = content(1, {
+      threads: [thread('Jane Doe', 'a real review note', { isResolved: true })],
+    });
+    const extractor = recordingExtractor();
+    const r = await runExtractStage(
+      solo(),
+      deps(spySource([1], new Map([[1, { kind: 'ok', content: resolved }]])), extractor),
+    );
+    expect(r.drafts).toHaveLength(1);
+    expect(dropsFor(r, 1)).toEqual([]);
+    // γ: the resolved thread is no longer pre-filtered — the extractor saw it.
+    expect(extractor.seen[0]!.threads).toHaveLength(1);
+    expect(extractor.seen[0]!.threads[0]!.isResolved).toBe(true);
+  });
+
+  it('all-OUTDATED-but-had-substantive-content drops outdated-rejected (not truncated)', async () => {
+    const allOutdated = content(1, {
       threads: [
-        thread('Jane Doe', 'a real review note', { isResolved: true }),
+        thread('Jane Doe', 'a real review note', { isOutdated: true }),
         thread('John Roe', 'another note', { isOutdated: true }),
       ],
     });
     const r = await runExtractStage(
       solo(),
       deps(
-        spySource([1], new Map([[1, { kind: 'ok', content: allResolved }]])),
+        spySource([1], new Map([[1, { kind: 'ok', content: allOutdated }]])),
         fixtureExtractor(),
       ),
     );
-    expect(dropsFor(r, 1)[0]!.reasonCode).toBe('resolved-rejected');
+    const drop = dropsFor(r, 1)[0]!;
+    expect(drop.reasonCode).toBe('outdated-rejected');
+    expect(drop.detail).toContain('2 of 2 threads outdated');
+    expect(drop.detail).toContain('0 eligible substantive comments remain');
     expect(r.drafts).toEqual([]);
   });
 
-  it('the resolved-rejected drop detail carries concrete resolution evidence', async () => {
-    const allResolved = content(1, {
-      threads: [
-        thread('Jane Doe', 'a real review note', { isResolved: true }),
-        thread('John Roe', 'another note', { isOutdated: true }),
-      ],
+  it('thin-to-begin-with (0 substantive comments before the gate) stays truncated, not outdated-rejected', async () => {
+    // A noise-bot-only outdated thread — the gate is not what emptied it; it was
+    // already thin (dependabot is not a recognized review bot). Keep `truncated`.
+    const botOutdated = content(1, {
+      threads: [thread('dependabot[bot]', 'bump dep', { isOutdated: true })],
     });
     const r = await runExtractStage(
       solo(),
       deps(
-        spySource([1], new Map([[1, { kind: 'ok', content: allResolved }]])),
-        fixtureExtractor(),
-      ),
-    );
-    const detail = dropsFor(r, 1)[0]!.detail ?? '';
-    expect(detail).toContain('2 of 2 threads resolved/outdated');
-    expect(detail).toContain('0 eligible human comments remain');
-  });
-
-  it('thin-to-begin-with (0 human comments before the gate) stays truncated, not resolved-rejected', async () => {
-    // A resolved thread that ALSO had no human comment — the resolution gate is
-    // not what emptied it; it was already thin. Keep the existing truncated path.
-    const botResolved = content(1, {
-      threads: [thread('coderabbitai[bot]', 'nit: rename this', { isResolved: true })],
-    });
-    const r = await runExtractStage(
-      solo(),
-      deps(
-        spySource([1], new Map([[1, { kind: 'ok', content: botResolved }]])),
+        spySource([1], new Map([[1, { kind: 'ok', content: botOutdated }]])),
         fixtureExtractor(),
       ),
     );
     expect(dropsFor(r, 1)[0]!.reasonCode).toBe('truncated');
   });
 
-  it('partial resolution: survivors are processed; resolved threads excluded from the draft input', async () => {
+  it('partial: OUTDATED threads excluded from the draft input; resolved + fresh survive', async () => {
     const mixed = content(1, {
       threads: [
         thread('Jane Doe', 'eligible note A'),
@@ -496,38 +521,71 @@ describe('runExtractStage — resolution-eligibility gate (slice 5a)', () => {
       solo(),
       deps(spySource([1], new Map([[1, { kind: 'ok', content: mixed }]])), extractor),
     );
-    // The PR is processed (a draft, no drop).
     expect(r.drafts).toHaveLength(1);
     expect(dropsFor(r, 1)).toEqual([]);
-    // The extractor only saw the ONE eligible thread — resolved/outdated excluded.
-    expect(extractor.seen).toHaveLength(1);
+    // The extractor saw the two NON-outdated threads (incl. the resolved one); only
+    // the outdated thread was excluded (γ inverts the slice-5a resolved exclusion).
     const seenThreads = extractor.seen[0]!.threads;
-    expect(seenThreads).toHaveLength(1);
-    expect(seenThreads[0]!.comments[0]!.body).toBe('eligible note A');
-    expect(seenThreads.every((t) => !t.isResolved && !t.isOutdated)).toBe(true);
-  });
-
-  it('partial resolution: resolved threads do not count toward the human-comment threshold', async () => {
-    // The single eligible thread is bot-only; the resolved thread is the only one
-    // with a human comment. Survivors have 0 human comments → resolved-rejected.
-    const mixed = content(1, {
-      threads: [
-        thread('coderabbitai[bot]', 'nit: rename', { isResolved: false }),
-        thread('Jane Doe', 'a real human note', { isResolved: true }),
-      ],
-    });
-    const r = await runExtractStage(
-      solo(),
-      deps(spySource([1], new Map([[1, { kind: 'ok', content: mixed }]])), fixtureExtractor()),
-    );
-    expect(dropsFor(r, 1)[0]!.reasonCode).toBe('resolved-rejected');
-    expect(r.drafts).toEqual([]);
+    expect(seenThreads).toHaveLength(2);
+    expect(seenThreads.every((t) => !t.isOutdated)).toBe(true);
+    expect(seenThreads.map((t) => t.comments[0]!.body).sort()).toEqual([
+      'eligible note A',
+      'resolved note B',
+    ]);
   });
 
   it('a fully-eligible thread is unaffected by the gate (no regression)', async () => {
     const r = await runExtractStage(solo(), deps(spySource([1]), fixtureExtractor()));
     expect(r.drafts).toHaveLength(1);
     expect(dropsFor(r, 1)).toEqual([]);
+  });
+});
+
+// ─── Slice β: bot-review substrate + sourceKind diagnostic ────────────────────
+
+describe('runExtractStage — slice β (bot-review substrate + sourceKind)', () => {
+  it('a RECOGNIZED review-bot (coderabbitai) comment now COUNTS as substrate → drafts', async () => {
+    const crOnly = content(1, {
+      threads: [thread('coderabbitai[bot]', 'Potential issue: guard against NaN here')],
+    });
+    const r = await runExtractStage(
+      solo(),
+      deps(spySource([1], new Map([[1, { kind: 'ok', content: crOnly }]])), fixtureExtractor()),
+    );
+    expect(r.drafts).toHaveLength(1);
+    expect(dropsFor(r, 1)).toEqual([]);
+    expect(r.drafts[0]!.sourceKind).toBe('bot');
+  });
+
+  it('gemini-code-assist (no [bot] suffix) counts as substrate', async () => {
+    const gca = content(1, {
+      threads: [thread('gemini-code-assist', 'require is_finite() before the divide')],
+    });
+    const r = await runExtractStage(
+      solo(),
+      deps(spySource([1], new Map([[1, { kind: 'ok', content: gca }]])), fixtureExtractor()),
+    );
+    expect(r.drafts).toHaveLength(1);
+    expect(r.drafts[0]!.sourceKind).toBe('bot');
+  });
+
+  it('sourceKind is human for a human-only thread', async () => {
+    const r = await runExtractStage(solo(), deps(spySource([1]), fixtureExtractor()));
+    expect(r.drafts[0]!.sourceKind).toBe('human');
+  });
+
+  it('sourceKind is mixed when human + review-bot comments both survive', async () => {
+    const mixed = content(1, {
+      threads: [
+        thread('Jane Doe', 'the human rationale'),
+        thread('coderabbitai[bot]', 'the bot finding'),
+      ],
+    });
+    const r = await runExtractStage(
+      solo(),
+      deps(spySource([1], new Map([[1, { kind: 'ok', content: mixed }]])), fixtureExtractor()),
+    );
+    expect(r.drafts[0]!.sourceKind).toBe('mixed');
   });
 });
 
@@ -546,9 +604,9 @@ describe('runExtractStage — determinism', () => {
     expect(await run()).toEqual(await run());
   });
 
-  it('identical inputs are deterministic across the resolution gate (drafts + drops + ledgers)', async () => {
-    // PR 1: a partial-resolution mix (one eligible survivor → a draft).
-    // PR 2: all-resolved-but-had-human-content → a resolved-rejected drop.
+  it('identical inputs are deterministic across the eligibility gate (drafts + drops + ledgers)', async () => {
+    // PR 1: a partial mix (resolved + fresh both survive → a draft).
+    // PR 2: all-outdated-but-had-substantive-content → an outdated-rejected drop.
     const pr1 = content(1, {
       threads: [
         thread('Jane Doe', 'eligible note', { isResolved: false }),
@@ -575,6 +633,6 @@ describe('runExtractStage — determinism', () => {
     const a = await run();
     const b = await run();
     expect(a).toEqual(b);
-    expect(dropsFor(a, 2)[0]!.reasonCode).toBe('resolved-rejected');
+    expect(dropsFor(a, 2)[0]!.reasonCode).toBe('outdated-rejected');
   });
 });

--- a/packages/core/src/spine/extract.test.ts
+++ b/packages/core/src/spine/extract.test.ts
@@ -574,6 +574,19 @@ describe('runExtractStage — slice β (bot-review substrate + sourceKind)', () 
     expect(r.drafts[0]!.sourceKind).toBe('human');
   });
 
+  it('a badge-ONLY review-bot comment is NOT substantive — de-chromed empty → truncated, not no-draft (greptile #2242)', async () => {
+    const badgeOnly = content(1, {
+      threads: [thread('coderabbitai[bot]', '![high](https://x/high.svg)')],
+    });
+    const r = await runExtractStage(
+      solo(),
+      deps(spySource([1], new Map([[1, { kind: 'ok', content: badgeOnly }]])), fixtureExtractor()),
+    );
+    // normalizedBody strips to '' → not substantive → thin from the start.
+    expect(dropsFor(r, 1)[0]!.reasonCode).toBe('truncated');
+    expect(r.drafts).toEqual([]);
+  });
+
   it('sourceKind is mixed when human + review-bot comments both survive', async () => {
     const mixed = content(1, {
       threads: [

--- a/packages/core/src/spine/extract.ts
+++ b/packages/core/src/spine/extract.ts
@@ -42,13 +42,14 @@ import { extractManualPattern } from '../lesson-pattern.js';
 import type {
   ApiUsageLedger,
   ApiUsageLedgerEntry,
+  DraftSourceKind,
   DropLedger,
   DropLedgerEntry,
   DropReasonCode,
   NoDraftCause,
 } from './ledgers.js';
 import { NoDraftCauseSchema } from './ledgers.js';
-import { isBotIdentity } from './selection-rule.js';
+import { isBotIdentity, reviewBotIdentity } from './selection-rule.js';
 import type { SplitArtifact } from './split.js';
 
 // ── Parsed review-thread content (the fetch port's payload) ───────────────────
@@ -56,8 +57,31 @@ import type { SplitArtifact } from './split.js';
 /** A single parsed review-thread comment (provider-neutral; mirrors the CLI `groupIntoThreads` shape). */
 export interface ReviewThreadComment {
   author: string;
+  /** The RAW comment body, kept verbatim for audit (slice β: `normalizedBody` is the de-chromed twin). */
   body: string;
+  /**
+   * Author classification (slice β, strategy#709). `'bot'` iff the author is a
+   * recognized review-FINDING bot (`reviewBotIdentity` — gemini-code-assist /
+   * coderabbitai); `'human'` otherwise (a human author OR an unrecognized
+   * automation account — the latter is excluded from the substantive count by the
+   * separate `isBotIdentity` denylist check, and is rare on inline review threads).
+   * Set at the CLI mapping boundary via core's `classifyAuthorKind`; the count +
+   * source-tag READ it (its single classification home).
+   */
+  authorKind: AuthorKind;
+  /**
+   * The de-chromed body the extractor actually consumes (slice β). For a `'bot'`
+   * comment this is `normalizeReviewChrome(body)` (severity badges / `<details>`
+   * collapsibles / footer chrome stripped); for a `'human'` comment it equals the
+   * raw `body` (CRLF→LF + trim only — human prose carries no review-bot chrome).
+   * The extractor prompt renders THIS, and `extractorInputKey` digests THIS (not
+   * the raw body), so the key reflects exactly what the LLM saw (panel OQ-β3).
+   */
+  normalizedBody: string;
 }
+
+/** Recognized-review-bot (`'bot'`) vs human/unrecognized (`'human'`) — see `ReviewThreadComment.authorKind`. */
+export type AuthorKind = 'bot' | 'human';
 
 /**
  * A single review thread on a file path.
@@ -74,7 +98,13 @@ export interface ReviewThreadComment {
 export interface ReviewThread {
   path: string;
   comments: ReviewThreadComment[];
-  /** GitHub `reviewThreads.isResolved` — the author marked this thread resolved. */
+  /**
+   * GitHub `reviewThreads.isResolved` — the author marked this thread resolved.
+   * Slice γ (strategy#709): RESOLVED no longer excludes a thread — a resolved
+   * thread is the highest-signal LEGITIMACY marker (a defect the reviewer raised
+   * AND the author confirmed by fixing). Surfaced for audit/identity; `isOutdated`
+   * is now the SOLE eligibility filter. See `eligibleThreads`.
+   */
   isResolved: boolean;
   /** GitHub `reviewThreads.isOutdated` — the thread's diff hunk no longer matches HEAD. */
   isOutdated: boolean;
@@ -123,6 +153,15 @@ export interface DraftCandidate {
    * `**Pattern:**` / yaml rule by the syntactic preflight.
    */
   dslSource: string;
+  /**
+   * The SUBSTRATE provenance (slice β, strategy#709): whether the eligible threads
+   * this PR drafted from carried `human`, `bot` (recognized review-bot), or `mixed`
+   * comments. A TRANSIENT diagnostic (Tenet-19, not an FM falsifier) carried to
+   * Classify, which serializes it onto the §8 emission ledger (panel OQ-β4 — NOT
+   * the reused `ProvenanceRecord`/legitimacy stamp). PR-level coarse-grained (a
+   * single draft can derive from a mix), so a per-candidate tag mirrors its PR.
+   */
+  sourceKind: DraftSourceKind;
 }
 
 // ── Injected ports (core-defined, CLI-implemented — the Stage4VerifierDeps DI) ─
@@ -210,32 +249,85 @@ export interface ExtractStageResult {
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
- * Count HUMAN review comments (fold 5): bot comments (CodeRabbit / Greptile /
- * Renovate / dependabot, via the shared `isBotIdentity`) and empty/whitespace
- * bodies do NOT count toward §6's "≥1 review comment" threshold — a bot-only or
- * empty thread is content-thin and must take the loud-drop path, never seed a
- * hallucinated draft.
+ * Classify a comment author (slice β, strategy#709). `'bot'` iff it is a recognized
+ * review-FINDING bot (`reviewBotIdentity` allowlist — gemini/CR); `'human'`
+ * otherwise. The SINGLE classification home: the CLI mapping boundary stamps each
+ * comment's `authorKind` via this, and the count + source-tag read that field.
  */
-function humanCommentCount(threads: readonly ReviewThread[]): number {
+export function classifyAuthorKind(author: string): AuthorKind {
+  return reviewBotIdentity(author) ? 'bot' : 'human';
+}
+
+/**
+ * Is this comment SUBSTANTIVE mining substrate (slice β)? Counts toward §6's
+ * "≥1 review comment" completeness threshold iff its body is non-empty AND it is
+ * either a recognized review-finding bot (`authorKind === 'bot'`) OR a human.
+ *
+ * The slice-β substrate flip (panel OQ-β2, ALLOWLIST): for this bot-reviewed cert
+ * corpus, gemini/CR review comments ARE legitimate substrate — they count. But an
+ * UNRECOGNIZED `[bot]` automation account (renovate / dependabot) is still excluded
+ * via the `isBotIdentity` denylist, so future automation noise can never launder
+ * itself in as a substantive reviewer. Empty/whitespace bodies never count.
+ */
+function isSubstantiveComment(comment: ReviewThreadComment): boolean {
+  if (comment.body.trim().length === 0) return false;
+  if (comment.authorKind === 'bot') return true;
+  return !isBotIdentity(comment.author);
+}
+
+/**
+ * Count SUBSTANTIVE review comments across threads (slice β — replaces the old
+ * `humanCommentCount`). A thread set with zero substantive comments is content-thin
+ * and must take the loud-drop path, never seed a hallucinated draft.
+ */
+function substantiveCommentCount(threads: readonly ReviewThread[]): number {
   let count = 0;
   for (const thread of threads) {
     for (const comment of thread.comments) {
-      if (comment.body.trim().length > 0 && !isBotIdentity(comment.author)) count++;
+      if (isSubstantiveComment(comment)) count++;
     }
   }
   return count;
 }
 
 /**
- * The resolution-eligibility gate (slice 5a, mmnto-ai/totem#2201). A thread is
- * INELIGIBLE if the author resolved it OR its diff hunk went outdated — either
- * marks it as superseded review discussion, contamination the miner must not
- * draft from. The adapter SURFACES `isResolved`/`isOutdated` (it never
- * pre-filters); core decides here so the rejection is ledgered (§8). Returns the
+ * The substrate provenance of a thread set (slice β, panel OQ-β4): `human` /
+ * `bot` / `mixed` over its SUBSTANTIVE comments only (recognized review-bot vs
+ * human; unrecognized-bot noise is excluded, exactly as the count excludes it).
+ * Called only when ≥1 substantive comment survives the gate, so at least one axis
+ * is non-zero. A non-FM Tenet-19 diagnostic carried onto each draft + the
+ * zero-draft drop.
+ */
+function computeSourceKind(threads: readonly ReviewThread[]): DraftSourceKind {
+  let human = 0;
+  let bot = 0;
+  for (const thread of threads) {
+    for (const comment of thread.comments) {
+      if (!isSubstantiveComment(comment)) continue;
+      if (comment.authorKind === 'bot') bot++;
+      else human++;
+    }
+  }
+  if (bot > 0 && human > 0) return 'mixed';
+  return bot > 0 ? 'bot' : 'human';
+}
+
+/**
+ * The eligibility gate. Slice γ (strategy#709) NARROWS this from slice-5a's
+ * `!isResolved && !isOutdated` to `!isOutdated` — RESOLVED threads are now ADMITTED.
+ *
+ * The slice-5a rationale (resolved == superseded contamination) was REVERSED by the
+ * Gate-1 cert finding: a RESOLVED thread is the highest-signal LEGITIMACY marker —
+ * a defect a reviewer raised AND the author confirmed real by fixing — so excluding
+ * it discarded the very evidence the miner wants (exhibit: lc#532's fail-open-on-
+ * non-finite, dropped solely for being resolved). Only OUTDATED stays excluded: an
+ * outdated thread's diff hunk no longer matches HEAD, so its invariant may have been
+ * refactored away — that IS stale. The adapter SURFACES both flags (it never
+ * pre-filters); core decides here so every rejection is ledgered (§8). Returns the
  * eligible (surviving) threads only.
  */
 function eligibleThreads(threads: readonly ReviewThread[]): ReviewThread[] {
-  return threads.filter((t) => !t.isResolved && !t.isOutdated);
+  return threads.filter((t) => !t.isOutdated);
 }
 
 /**
@@ -295,13 +387,13 @@ function buildProvenance(
  * CI-locked with a fixture extractor + a strict-spy fetch source.
  *
  * Per train PR (and ONLY train PRs): log the fetch → fetch → on unreachable /
- * unparseable-at-source, loud-drop → resolution-eligibility gate (slice 5a: drop
- * `resolved-rejected` when the resolution gate empties an otherwise-human thread,
- * else `truncated` when thin to begin with) → completeness-check (≥1 human
- * comment on the survivors) → build provenance → draft zero-or-more bodies from
- * the SURVIVING threads only → preflight each → carry a `DraftCandidate` or
- * loud-drop. Every train PR ends with at least one draft or one drop (FM i,
- * slice-2 half).
+ * unparseable-at-source, loud-drop → eligibility gate (slice γ: drop
+ * `outdated-rejected` when the outdated filter empties an otherwise-substantive
+ * thread, else `truncated` when thin to begin with) → completeness-check (≥1
+ * substantive comment on the survivors) → build provenance → draft zero-or-more
+ * bodies from the SURVIVING threads only → preflight each → carry a
+ * `DraftCandidate` or loud-drop. Every train PR ends with at least one draft or
+ * one drop (FM i, slice-2 half).
  */
 export async function runExtractStage(
   split: SplitArtifact,
@@ -317,8 +409,15 @@ export async function runExtractStage(
     reasonCode: DropReasonCode,
     detail: string,
     noDraftCause?: NoDraftCause,
+    sourceKind?: DraftSourceKind,
   ): void => {
-    dropEntries.push({ sourcePr, reasonCode, detail, ...(noDraftCause ? { noDraftCause } : {}) });
+    dropEntries.push({
+      sourcePr,
+      reasonCode,
+      detail,
+      ...(noDraftCause ? { noDraftCause } : {}),
+      ...(sourceKind ? { sourceKind } : {}),
+    });
   };
 
   // Iterate the TRAIN slice ONLY — held-out / control / excluded PRs are never
@@ -354,30 +453,30 @@ export async function runExtractStage(
       continue;
     }
 
-    // Resolution-eligibility gate (slice 5a, mmnto-ai/totem#2201) — BEFORE the
-    // completeness check. The adapter surfaced per-thread `isResolved`/`isOutdated`
-    // (it never pre-filters); core decides + ledgers here so every resolution
-    // rejection is auditable (§8). Filter to eligible (non-resolved, non-outdated)
-    // threads and recount human comments on the SURVIVORS only.
-    const preFilterHumanCount = humanCommentCount(content.threads);
+    // Eligibility gate (slice γ) — BEFORE the completeness check. The adapter
+    // surfaced per-thread `isOutdated` (it never pre-filters); core decides +
+    // ledgers here so every rejection is auditable (§8). Filter to eligible
+    // (non-outdated; RESOLVED is now admitted) threads and recount SUBSTANTIVE
+    // comments (slice β: human + recognized review-bot) on the SURVIVORS only.
+    const preFilterSubstantiveCount = substantiveCommentCount(content.threads);
     const survivingThreads = eligibleThreads(content.threads);
-    const survivorHumanCount = humanCommentCount(survivingThreads);
+    const survivorSubstantiveCount = substantiveCommentCount(survivingThreads);
 
-    if (survivorHumanCount < 1) {
-      if (preFilterHumanCount >= 1) {
-        // The thread carried human content, but the resolution gate is what
-        // emptied it → `resolved-rejected` (an eligibility rejection, not thin
-        // content). Carry the concrete resolution evidence in the detail.
+    if (survivorSubstantiveCount < 1) {
+      if (preFilterSubstantiveCount >= 1) {
+        // The thread carried substantive content, but the OUTDATED filter is what
+        // emptied it → `outdated-rejected` (an eligibility rejection, not thin
+        // content). Carry the concrete outdated evidence in the detail.
         const ineligible = content.threads.length - survivingThreads.length;
         drop(
           pr,
-          'resolved-rejected',
-          `${ineligible} of ${content.threads.length} threads resolved/outdated; ${survivorHumanCount} eligible human comments remain`,
+          'outdated-rejected',
+          `${ineligible} of ${content.threads.length} threads outdated; ${survivorSubstantiveCount} eligible substantive comments remain`,
         );
       } else {
-        // Thin to begin with (0 human comments BEFORE the resolution gate) — the
-        // existing `truncated` path, NOT a resolution rejection.
-        drop(pr, 'truncated', 'no non-empty human review comment after bot filtering');
+        // Thin to begin with (0 substantive comments BEFORE the gate) — the
+        // existing `truncated` path, NOT an eligibility rejection.
+        drop(pr, 'truncated', 'no non-empty substantive review comment after bot filtering');
       }
       continue;
     }
@@ -397,6 +496,9 @@ export async function runExtractStage(
     // catches its own LLM/network errors) — so the core needs no swallowing catch
     // (Tenet 4). An empty list is a loud drop below, not a silent skip.
     const eligibleContent: ReviewThreadContent = { ...content, threads: survivingThreads };
+    // The substrate provenance (slice β, Tenet-19 diagnostic) of THIS PR's eligible
+    // threads — carried onto every draft + the zero-draft drop (panel OQ-β4).
+    const sourceKind = computeSourceKind(survivingThreads);
     // Parse the port result at the boundary (mirrors ClassifierResultSchema.parse in
     // classify.ts): a contract-violating DraftResult (empty-without-cause or
     // cause-without-empty from a buggy adapter) fails loud HERE, before the ledger.
@@ -405,17 +507,21 @@ export async function runExtractStage(
 
     if (draftBodies.length === 0) {
       // A complete thread that yields no draft is a loud drop (keeps the train PR
-      // creditable under FM i), not a silent skip. The NO-DRAFT cause (Tenet-19
-      // diagnostic) is recorded so a parser/format/transient failure is never
-      // conflated with a legitimate model decline.
+      // creditable under FM i), not a silent skip. Reason code `no-draft` (slice β,
+      // strategy β-watch): the slice-α empty-draft drop reused `unparseable`, which
+      // was semantically wrong for a legitimate model decline (`none-sentinel`) —
+      // the coarse code now NAMES the no-draft case while `noDraftCause` (Tenet-19
+      // diagnostic) carries the precise sub-reason, so a parser/format/transient
+      // failure is never conflated with the model judging nothing mintable.
       drop(
         pr,
-        'unparseable',
+        'no-draft',
         // The boundary parse above + the "cause iff empty" refine guarantee
         // `noDraftCause` is present in this empty-drafts branch — assert it rather
         // than defend with a `?? 'unknown'` fallback that can never fire.
         `extractor produced no draft from a complete thread (cause: ${draftResult.noDraftCause!})`,
         draftResult.noDraftCause,
+        sourceKind,
       );
       continue;
     }
@@ -425,7 +531,7 @@ export async function runExtractStage(
         drop(pr, 'unparseable', 'draft is empty or carries no usable **Pattern:**/yaml DSL');
         continue;
       }
-      drafts.push({ provenance: provenance.value, dslSource: body });
+      drafts.push({ provenance: provenance.value, dslSource: body, sourceKind });
     }
   }
 

--- a/packages/core/src/spine/extract.ts
+++ b/packages/core/src/spine/extract.ts
@@ -270,7 +270,14 @@ export function classifyAuthorKind(author: string): AuthorKind {
  * itself in as a substantive reviewer. Empty/whitespace bodies never count.
  */
 function isSubstantiveComment(comment: ReviewThreadComment): boolean {
-  if (comment.body.trim().length === 0) return false;
+  // Gate on what the extractor ACTUALLY consumes (greptile #2242): for a review
+  // bot that is the de-chromed `normalizedBody`, so a badge-ONLY comment (non-empty
+  // raw `body`, but `normalizedBody === ''` after the strip) is correctly thin —
+  // it would otherwise clear the gate yet hand the extractor an empty body and
+  // mislead a `no-draft` drop where `truncated` is the truth. Human bodies are
+  // never chrome-stripped, so `normalizedBody === body` for them.
+  const effectiveBody = comment.authorKind === 'bot' ? comment.normalizedBody : comment.body;
+  if (effectiveBody.trim().length === 0) return false;
   if (comment.authorKind === 'bot') return true;
   return !isBotIdentity(comment.author);
 }

--- a/packages/core/src/spine/ledgers.ts
+++ b/packages/core/src/spine/ledgers.ts
@@ -65,6 +65,18 @@ export const Stage4LedgerOutcomeSchema = z.enum([
 ]);
 export type Stage4LedgerOutcome = z.infer<typeof Stage4LedgerOutcomeSchema>;
 
+/**
+ * The SUBSTRATE provenance of a draft / zero-draft drop (slice β, strategy#709,
+ * panel OQ-β4): whether the eligible review threads it derived from carried
+ * `human`, `bot` (recognized review-finding bot — gemini/CR), or `mixed` comments.
+ * `human|bot|mixed` not a binary — a single PR's draft can derive from both. A
+ * non-FM Tenet-19 DIAGNOSTIC (like `dispositionSource` / `noDraftCause`): it makes
+ * the bot-review-substrate share OBSERVABLE on the §8 emission ledger for this
+ * bot-reviewed cert corpus, with NO falsifying-metric weight.
+ */
+export const DraftSourceKindSchema = z.enum(['human', 'bot', 'mixed']);
+export type DraftSourceKind = z.infer<typeof DraftSourceKindSchema>;
+
 // ── 1. Emission ledger ──────────────────────────────────────────────────────
 
 export const EmissionLedgerEntrySchema = z.object({
@@ -74,6 +86,13 @@ export const EmissionLedgerEntrySchema = z.object({
   routing: RoutingSchema,
   classifierLedgerRef: nonEmpty('classifierLedgerRef'),
   unverified: z.literal(true),
+  /**
+   * Substrate provenance of the draft (slice β, panel OQ-β4) — `human|bot|mixed`,
+   * threaded transiently on `DraftCandidate` from the exact extractor input and
+   * serialized HERE (NOT on the reused `ProvenanceRecord`/legitimacy stamp, which a
+   * diagnostic would pollute). Additive-OPTIONAL so pre-β emission ledgers parse.
+   */
+  sourceKind: DraftSourceKindSchema.optional(),
 });
 export type EmissionLedgerEntry = z.infer<typeof EmissionLedgerEntrySchema>;
 
@@ -94,18 +113,27 @@ export const DropReasonCodeSchema = z.enum([
   'truncated',
   'unparseable',
   'incomplete-provenance',
-  // 'resolved-rejected' (slice 5a, mmnto-ai/totem#2201) — an ELIGIBILITY
-  // rejection, semantically distinct from the four above. The content WAS
-  // fetched (not `unreachable`), CAN be complete (not `truncated`), and PARSES
-  // (not `unparseable`); its provenance is intact (not `incomplete-provenance`).
-  // It is dropped because every human comment lived on review threads whose
-  // resolution status (`isResolved || isOutdated`) marks them contamination: a
-  // resolved/outdated thread reflects a discussion the author already closed, so
-  // mining it would launder superseded review noise into a candidate rule. The
-  // §6 resolution gate (in `runExtractStage`) emptied the eligible-human-comment
-  // set — every such rejection is ledgered here (never silently pre-filtered by
-  // the adapter), satisfying §8 "every rejection ledgered" + the FM.
-  'resolved-rejected',
+  // 'outdated-rejected' (slice γ, strategy#709 — renamed from slice-5a's
+  // 'resolved-rejected') — an ELIGIBILITY rejection, semantically distinct from
+  // the four above. The content WAS fetched (not `unreachable`), CAN be complete
+  // (not `truncated`), and PARSES (not `unparseable`); its provenance is intact
+  // (not `incomplete-provenance`). It is dropped because every substantive comment
+  // lived on OUTDATED review threads (`isOutdated`): an outdated thread's diff hunk
+  // no longer matches HEAD, so its invariant may have been refactored away. NOTE
+  // (slice γ): RESOLVED threads are NO LONGER rejected — a resolved thread is the
+  // highest-signal legitimacy marker (the Gate-1 cert finding), so it is now
+  // ADMITTED; only OUTDATED stays excluded. The §6 eligibility gate (in
+  // `runExtractStage`) emptied the eligible-substantive set — every such rejection
+  // is ledgered here (never silently pre-filtered by the adapter), satisfying §8.
+  'outdated-rejected',
+  // 'no-draft' (slice β, strategy β-watch) — the extractor returned ZERO drafts
+  // for an otherwise-complete thread. Slice α reused `unparseable` for this, which
+  // mislabeled a legitimate model decline (`none-sentinel`) as a parse failure;
+  // this code NAMES the no-draft case while the row's `noDraftCause` carries the
+  // precise sub-reason (invoke-error / empty-output / none-sentinel / …). Distinct
+  // from `unparseable`, which now means ONLY a source-fetch or per-body DSL parse
+  // failure.
+  'no-draft',
 ]);
 export type DropReasonCode = z.infer<typeof DropReasonCodeSchema>;
 
@@ -157,11 +185,18 @@ export const DropLedgerEntrySchema = z.object({
   detail: z.string().optional(),
   /**
    * The extract-stage NO-DRAFT diagnostic (Tenet-19). Present ONLY on the
-   * extractor-produced empty-draft drop (`reasonCode: 'unparseable'`, detail
+   * extractor-produced empty-draft drop (`reasonCode: 'no-draft'`, detail
    * "extractor produced no draft…") — absent on every other drop. Additive-
    * optional so older ledgers (no cause recorded) still parse.
    */
   noDraftCause: NoDraftCauseSchema.optional(),
+  /**
+   * Substrate provenance (slice β, panel OQ-β4) of the eligible threads on a
+   * ZERO-DRAFT (`reasonCode: 'no-draft'`) drop — `human|bot|mixed`, so the §8
+   * report can ask "what KIND of substrate did the model decline?". Present only on
+   * the no-draft drop; additive-OPTIONAL so other drops + older ledgers parse.
+   */
+  sourceKind: DraftSourceKindSchema.optional(),
 });
 export type DropLedgerEntry = z.infer<typeof DropLedgerEntrySchema>;
 

--- a/packages/core/src/spine/review-normalize.test.ts
+++ b/packages/core/src/spine/review-normalize.test.ts
@@ -51,6 +51,22 @@ describe('normalizeReviewChrome — strips presentational chrome', () => {
     expect(normalizeReviewChrome(body)).toBe(body);
   });
 
+  it('preserves chrome-looking tokens INSIDE a fence; strips them outside (CR #2242)', () => {
+    const body = [
+      '![high](https://x/high.svg)', // chrome OUTSIDE → stripped
+      'Forbid this exact snippet:',
+      '```md',
+      '<!-- keep -->', // chrome INSIDE fence → preserved (the literal invariant)
+      '![inline](img.png)',
+      '```',
+    ].join('\n');
+    const out = normalizeReviewChrome(body);
+    expect(out).not.toContain('![high]'); // outside badge stripped
+    expect(out).toContain('Forbid this exact snippet:');
+    expect(out).toContain('<!-- keep -->'); // inside HTML comment preserved
+    expect(out).toContain('![inline](img.png)'); // inside image preserved
+  });
+
   it('is IDEMPOTENT: normalize(normalize(x)) === normalize(x)', () => {
     const heavy = [
       '![high](https://x/high.svg)',

--- a/packages/core/src/spine/review-normalize.test.ts
+++ b/packages/core/src/spine/review-normalize.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeReviewChrome, REVIEW_CHROME_NORMALIZER_VERSION } from './review-normalize.js';
+
+describe('normalizeReviewChrome — strips presentational chrome', () => {
+  it('strips a markdown severity badge image', () => {
+    const body =
+      '![high](https://www.gstatic.com/codereviewagent/high-priority.svg)\nrequire is_finite()';
+    expect(normalizeReviewChrome(body)).toBe('require is_finite()');
+  });
+
+  it('strips an HTML <img> severity badge', () => {
+    const body = '<img src="https://example.com/critical.svg" alt="critical"> guard the divisor';
+    expect(normalizeReviewChrome(body)).toBe('guard the divisor');
+  });
+
+  it('strips a <details> collapsible (analysis chain / AI-prompt / tool dump)', () => {
+    const body = [
+      'Potential issue: missing finite guard.',
+      '',
+      '<details>',
+      '<summary>🤖 Prompt for AI Agents</summary>',
+      '',
+      'In packages/x: add an is_finite() check before dividing.',
+      '</details>',
+    ].join('\n');
+    expect(normalizeReviewChrome(body)).toBe('Potential issue: missing finite guard.');
+  });
+
+  it('strips HTML comments', () => {
+    expect(normalizeReviewChrome('keep this <!-- tracking-id: abc123 --> text')).toBe(
+      'keep this  text',
+    );
+  });
+
+  it('collapses runaway blank lines and trims', () => {
+    expect(normalizeReviewChrome('line one\n\n\n\n\nline two\n\n')).toBe('line one\n\nline two');
+  });
+
+  it('normalizes CRLF to LF', () => {
+    expect(normalizeReviewChrome('a\r\nb')).toBe('a\nb');
+  });
+
+  it('leaves chrome-free human prose unchanged (apart from trim)', () => {
+    const human = 'Please extract this into a helper and add a finite-check.';
+    expect(normalizeReviewChrome(`  ${human}  `)).toBe(human);
+  });
+
+  it('preserves fenced code blocks (never over-strips the asserted invariant)', () => {
+    const body = ['Use execFile:', '```ts', 'execFile("ls", args)', '```'].join('\n');
+    expect(normalizeReviewChrome(body)).toBe(body);
+  });
+
+  it('is IDEMPOTENT: normalize(normalize(x)) === normalize(x)', () => {
+    const heavy = [
+      '![high](https://x/high.svg)',
+      '### Critical Bug:',
+      'divisor may be zero',
+      '',
+      '<details><summary>Analysis chain</summary>',
+      'long tool dump',
+      '</details>',
+      '',
+      '',
+      '',
+      'trailing',
+    ].join('\n');
+    const once = normalizeReviewChrome(heavy);
+    expect(normalizeReviewChrome(once)).toBe(once);
+  });
+});
+
+describe('REVIEW_CHROME_NORMALIZER_VERSION', () => {
+  it('is a stable, non-empty version pin (folded into replay provenance — Tenet-15)', () => {
+    expect(REVIEW_CHROME_NORMALIZER_VERSION).toBe('review-chrome-normalizer:v1');
+  });
+});

--- a/packages/core/src/spine/review-normalize.ts
+++ b/packages/core/src/spine/review-normalize.ts
@@ -51,25 +51,49 @@ const DETAILS_RE = /<details\b[\s\S]*?<\/details>/gi;
 const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g;
 /** 3+ consecutive blank lines → collapsed to a single blank line (stable whitespace). */
 const EXCESS_BLANKS_RE = /\n{3,}/g;
+/**
+ * A triple-backtick fenced code block (non-greedy). Used to PARTITION the body so
+ * the chrome strips run ONLY on the prose BETWEEN fences — a fence body may
+ * legitimately contain chrome-looking tokens (`<!-- -->`, `![…](…)`, `<img>`,
+ * `<details>`) that are the very invariant the extractor mines, so they must
+ * survive verbatim (CR #2242 — the "never touch fenced code blocks" contract).
+ */
+const FENCED_CODE_BLOCK_RE = /```[\s\S]*?```/g;
+
+/** Apply every chrome strip to ONE prose segment (never a fenced-code segment). */
+function stripChrome(segment: string): string {
+  return segment
+    .replace(DETAILS_RE, '')
+    .replace(HTML_COMMENT_RE, '')
+    .replace(MD_IMAGE_RE, '')
+    .replace(HTML_IMG_RE, '');
+}
 
 /**
  * Strip presentational review-bot chrome from a comment body, returning the
  * de-chromed text. DETERMINISTIC + IDEMPOTENT + AUDIT-PRESERVING (the caller
  * retains the raw body). Removes severity badges (markdown + HTML images),
  * `<details>` collapsibles, and HTML comments, then normalizes line endings and
- * collapses runaway blank runs. It deliberately does NOT touch fenced code blocks
- * or the reviewer's prose — over-stripping would drop the very invariant the
- * extractor mines. A body with no chrome (e.g. a human comment) is returned
- * unchanged apart from CRLF→LF + trim.
+ * collapses runaway blank runs.
+ *
+ * FENCED CODE BLOCKS ARE PRESERVED VERBATIM (CR #2242): the body is partitioned on
+ * triple-backtick fences and the strips run ONLY on the prose between them, so a
+ * chrome-looking token INSIDE a code fence (the reviewer's literal example) is
+ * never deleted. It also does not touch the reviewer's prose words — over-stripping
+ * would drop the very invariant the extractor mines. A body with no chrome (e.g. a
+ * human comment) is returned unchanged apart from CRLF→LF + trim.
  */
 export function normalizeReviewChrome(body: string): string {
-  return body
-    .replace(/\r\n/g, '\n')
-    .replace(/\r/g, '\n')
-    .replace(DETAILS_RE, '')
-    .replace(HTML_COMMENT_RE, '')
-    .replace(MD_IMAGE_RE, '')
-    .replace(HTML_IMG_RE, '')
-    .replace(EXCESS_BLANKS_RE, '\n\n')
-    .trim();
+  const lf = body.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+  let out = '';
+  let cursor = 0;
+  // Strip chrome from each prose run; copy each fenced block through untouched.
+  for (const match of lf.matchAll(FENCED_CODE_BLOCK_RE)) {
+    const start = match.index ?? 0;
+    out += stripChrome(lf.slice(cursor, start));
+    out += match[0];
+    cursor = start + match[0].length;
+  }
+  out += stripChrome(lf.slice(cursor));
+  return out.replace(EXCESS_BLANKS_RE, '\n\n').trim();
 }

--- a/packages/core/src/spine/review-normalize.ts
+++ b/packages/core/src/spine/review-normalize.ts
@@ -1,0 +1,75 @@
+// ─── ADR-111 Stage-1 Extract (slice β): review-bot chrome normalization ───────
+//
+// strategy#709 yield-fix β. The Gate-1 cert corpus is a BOT-REVIEWED repo: its
+// highest-signal review comments come from `gemini-code-assist` / `coderabbitai`,
+// whose bodies are wrapped in heavy presentational MARKDOWN CHROME — severity
+// image badges, `<details>` "analysis chain" collapsibles, AI-agent-prompt
+// footers — that dilutes the extractor's signal (the mechanically-checkable
+// invariant the reviewer asserted) with noise the LLM must wade through.
+//
+// `normalizeReviewChrome` is a DETERMINISTIC, AUDIT-PRESERVING strip of that
+// chrome. AUDIT-PRESERVING: the caller KEEPS the raw `body` and ADDS a
+// `normalizedBody` (extract.ts) — the raw text is never destroyed, so a frozen
+// corpus stays fully re-derivable. DETERMINISTIC: pure string→string, no IO / no
+// `Date` / no locale; identical input → identical output, and IDEMPOTENT
+// (`normalize(normalize(x)) === normalize(x)`) so a double-application can never
+// drift the extractorInputKey.
+//
+// PROVENANCE (Tenet-15): `REVIEW_CHROME_NORMALIZER_VERSION` is folded into the
+// replay provenance block (the CLI `buildReplayProvenance`), so a normalizer
+// change flips the whole-artifact integrity hash AND the extractorInputKey
+// (the key digests `normalizedBody`, not the raw body) — EITHER path forces a
+// re-record; a changed normalizer can never silently serve stale frozen outputs.
+//
+// SCOPE (panel OQ-β3 — normalization lives in CORE, not the adapter): the LOGIC
+// + VERSION are single-homed here so the CLI adapter (which only INVOKES this at
+// the mapping boundary) cannot drift the inputKey from the provenance. The strip
+// is intentionally CONSERVATIVE — it removes presentational wrappers (badges,
+// collapsibles, HTML comments) but never code fences or the reviewer's prose, so
+// the asserted invariant survives for the extractor.
+
+/**
+ * Normalizer schema version (mirrors `PROMPT_BUILDER_VERSION`). Bump on ANY change
+ * to the strip rules below → the replay provenance hash flips → a re-record is
+ * forced (Tenet-15). The version is BOTH a human-readable pin and an integrity
+ * lever; never edit a rule without bumping it.
+ */
+export const REVIEW_CHROME_NORMALIZER_VERSION = 'review-chrome-normalizer:v1';
+
+// Presentational-chrome patterns, applied in order. Each is a GLOBAL replace, so
+// after one pass no match remains → a second pass is a no-op (idempotence). None
+// of these can match a fenced code body's interior in a way that re-triggers, so
+// the pass order is irrelevant to the fixed point.
+
+/** Markdown image (severity badge): `![alt](url)` — gemini/CR render severity as an SVG badge. */
+const MD_IMAGE_RE = /!\[[^\]]*\]\([^)]*\)/g;
+/** HTML `<img …>` badge (the non-markdown severity-image form). */
+const HTML_IMG_RE = /<img\b[^>]*>/gi;
+/** `<details>…</details>` collapsible (analysis-chain / AI-prompt / tool-dump chrome). Non-greedy. */
+const DETAILS_RE = /<details\b[\s\S]*?<\/details>/gi;
+/** HTML comment `<!-- … -->` (tracking / tool chrome). */
+const HTML_COMMENT_RE = /<!--[\s\S]*?-->/g;
+/** 3+ consecutive blank lines → collapsed to a single blank line (stable whitespace). */
+const EXCESS_BLANKS_RE = /\n{3,}/g;
+
+/**
+ * Strip presentational review-bot chrome from a comment body, returning the
+ * de-chromed text. DETERMINISTIC + IDEMPOTENT + AUDIT-PRESERVING (the caller
+ * retains the raw body). Removes severity badges (markdown + HTML images),
+ * `<details>` collapsibles, and HTML comments, then normalizes line endings and
+ * collapses runaway blank runs. It deliberately does NOT touch fenced code blocks
+ * or the reviewer's prose — over-stripping would drop the very invariant the
+ * extractor mines. A body with no chrome (e.g. a human comment) is returned
+ * unchanged apart from CRLF→LF + trim.
+ */
+export function normalizeReviewChrome(body: string): string {
+  return body
+    .replace(/\r\n/g, '\n')
+    .replace(/\r/g, '\n')
+    .replace(DETAILS_RE, '')
+    .replace(HTML_COMMENT_RE, '')
+    .replace(MD_IMAGE_RE, '')
+    .replace(HTML_IMG_RE, '')
+    .replace(EXCESS_BLANKS_RE, '\n\n')
+    .trim();
+}

--- a/packages/core/src/spine/selection-rule.test.ts
+++ b/packages/core/src/spine/selection-rule.test.ts
@@ -9,6 +9,7 @@ import {
   parseRevertSha,
   prSetsEqual,
   resolveSelectionRule,
+  reviewBotIdentity,
   SelectionRuleParseError,
   selectionRulePredicate,
 } from './selection-rule.js';
@@ -111,6 +112,43 @@ describe('isBotIdentity — [bot] suffix only', () => {
   it('tolerates trailing CR/whitespace', () => {
     expect(isBotIdentity('dependabot[bot]\r')).toBe(true);
     expect(isBotIdentity('  dependabot[bot]  ')).toBe(true);
+  });
+});
+
+// ─── reviewBotIdentity (slice β allowlist) ───────────
+
+describe('reviewBotIdentity — recognized review-finding bots only (allowlist)', () => {
+  it('recognizes gemini-code-assist / coderabbitai with or without a [bot] suffix or email', () => {
+    expect(reviewBotIdentity('gemini-code-assist')).toBe(true); // no [bot] suffix
+    expect(reviewBotIdentity('gemini-code-assist[bot]')).toBe(true);
+    expect(reviewBotIdentity('coderabbitai')).toBe(true);
+    expect(reviewBotIdentity('coderabbitai[bot]')).toBe(true);
+    expect(reviewBotIdentity('coderabbitai[bot] <bot@coderabbit.ai>')).toBe(true);
+    expect(reviewBotIdentity('CodeRabbitAI')).toBe(true); // case-insensitive
+  });
+
+  it('does NOT recognize generic / noise automation accounts (denylist stays separate)', () => {
+    expect(reviewBotIdentity('dependabot[bot]')).toBe(false);
+    expect(reviewBotIdentity('renovate[bot]')).toBe(false);
+    expect(reviewBotIdentity('some-future-bot[bot]')).toBe(false);
+  });
+
+  it('does NOT recognize humans', () => {
+    expect(reviewBotIdentity('Jane Doe')).toBe(false);
+    expect(reviewBotIdentity('Jane Doe <jane@example.com>')).toBe(false);
+    expect(reviewBotIdentity('')).toBe(false);
+  });
+
+  it('is DISJOINT from isBotIdentity for the review bots (the OQ-β1 separation)', () => {
+    // The whole point: GCA/CR carry NO [bot] suffix, so isBotIdentity misses them
+    // (they would have been counted as "human" pre-β) — reviewBotIdentity is the
+    // dedicated classifier that admits them as substrate without coupling to the
+    // commit-author corpus-membership gate.
+    expect(isBotIdentity('gemini-code-assist')).toBe(false);
+    expect(reviewBotIdentity('gemini-code-assist')).toBe(true);
+    // …and a noise [bot] is the inverse: a bot to isBotIdentity, not a review bot.
+    expect(isBotIdentity('dependabot[bot]')).toBe(true);
+    expect(reviewBotIdentity('dependabot[bot]')).toBe(false);
   });
 });
 

--- a/packages/core/src/spine/selection-rule.test.ts
+++ b/packages/core/src/spine/selection-rule.test.ts
@@ -124,6 +124,7 @@ describe('reviewBotIdentity — recognized review-finding bots only (allowlist)'
     expect(reviewBotIdentity('coderabbitai')).toBe(true);
     expect(reviewBotIdentity('coderabbitai[bot]')).toBe(true);
     expect(reviewBotIdentity('coderabbitai[bot] <bot@coderabbit.ai>')).toBe(true);
+    expect(reviewBotIdentity('coderabbitai [bot]')).toBe(true); // space before suffix → trimmed (greptile #2242)
     expect(reviewBotIdentity('CodeRabbitAI')).toBe(true); // case-insensitive
   });
 

--- a/packages/core/src/spine/selection-rule.ts
+++ b/packages/core/src/spine/selection-rule.ts
@@ -170,6 +170,38 @@ export function isBotIdentity(author: string): boolean {
   return name.endsWith('[bot]') || /\[bot\]@/.test(a);
 }
 
+/**
+ * The ALLOWLIST of recognized review-FINDING bots (strategy#709 yield-fix β). Their
+ * inline review comments are legitimate mining SUBSTRATE for a bot-reviewed cert
+ * corpus — UNLIKE generic `[bot]` automation accounts (renovate / dependabot),
+ * whose PR-level noise must never count as a substantive review comment. Logins are
+ * the GitHub `author.login` form (NO `[bot]` suffix for GCA/CR app comments), so a
+ * `[bot]`-suffixed variant of the same tool is matched too. Lowercased identities.
+ */
+const REVIEW_FINDING_BOT_LOGINS = new Set(['gemini-code-assist', 'coderabbitai', 'coderabbit']);
+
+/**
+ * Recognize an ALLOWLISTED review-finding bot (gemini-code-assist / coderabbitai),
+ * with or without a `[bot]` suffix and with or without a trailing ` <email>`.
+ *
+ * DELIBERATELY SEPARATE from `isBotIdentity` (panel OQ-β1): `isBotIdentity` gates
+ * CORPUS MEMBERSHIP (it excludes `[bot]`-AUTHORED PRs) and stays unchanged —
+ * coupling review-comment substrate to commit-author exclusion would be the wrong
+ * dependency. This predicate is a NEW review-comment classifier used ONLY for
+ * `authorKind` tagging, the substantive-comment count, and chrome normalization.
+ *
+ * ALLOWLIST not denylist (panel OQ-β2): it fails CONSERVATIVE — a not-yet-listed
+ * review tool undercounts (drops to "no substrate") rather than laundering every
+ * future automation account in as a substantive reviewer. `isBotIdentity('gemini-
+ * code-assist')` stays `false` (no `[bot]` suffix); `reviewBotIdentity` returns
+ * `true` for it; `reviewBotIdentity('dependabot[bot]')` returns `false`.
+ */
+export function reviewBotIdentity(author: string): boolean {
+  const a = author.replace(/\r/g, '').trim().toLowerCase();
+  const name = a.replace(/\s*<[^>]*>\s*$/, '').replace(/\[bot\]$/, '');
+  return REVIEW_FINDING_BOT_LOGINS.has(name);
+}
+
 const REVERT_BODY_REGEX = /^This reverts commit ([0-9a-f]{7,40})\b/im;
 
 /** Extract the reverted target SHA from a `This reverts commit <sha>` body line. */

--- a/packages/core/src/spine/selection-rule.ts
+++ b/packages/core/src/spine/selection-rule.ts
@@ -178,7 +178,7 @@ export function isBotIdentity(author: string): boolean {
  * the GitHub `author.login` form (NO `[bot]` suffix for GCA/CR app comments), so a
  * `[bot]`-suffixed variant of the same tool is matched too. Lowercased identities.
  */
-const REVIEW_FINDING_BOT_LOGINS = new Set(['gemini-code-assist', 'coderabbitai', 'coderabbit']);
+const REVIEW_FINDING_BOT_LOGINS = new Set(['gemini-code-assist', 'coderabbitai']);
 
 /**
  * Recognize an ALLOWLISTED review-finding bot (gemini-code-assist / coderabbitai),
@@ -198,7 +198,13 @@ const REVIEW_FINDING_BOT_LOGINS = new Set(['gemini-code-assist', 'coderabbitai',
  */
 export function reviewBotIdentity(author: string): boolean {
   const a = author.replace(/\r/g, '').trim().toLowerCase();
-  const name = a.replace(/\s*<[^>]*>\s*$/, '').replace(/\[bot\]$/, '');
+  // `.trim()` after the `[bot]` strip mirrors `isBotIdentity`: a `'coderabbitai
+  // [bot]'` form (space before the suffix) would otherwise leave a trailing space
+  // and miss the allowlist (greptile #2242).
+  const name = a
+    .replace(/\s*<[^>]*>\s*$/, '')
+    .replace(/\[bot\]$/, '')
+    .trim();
   return REVIEW_FINDING_BOT_LOGINS.has(name);
 }
 


### PR DESCRIPTION
## What

strategy#709 yield-fix **PR-2 (β + γ)** — the engineering levers against the first Gate-1 cert run's honest-negative. Builds on slice α (#2240, the NO-DRAFT cause-tags that made the moat measurable). Strategy ruled the loss is **pipeline input-hygiene + class-coverage**, not a thesis failure; β + γ address the dominant extract→draft leak (7/18 train PRs returned `[]` on threads carrying mintable classes).

Design is **3/3 cohort-panel-ratified** (codex contract / agy build / gemini tenet); every open question resolved. Both levers move `extractorInputKey`, so the cert-#1 fixture invalidates **by design** — one clean re-record afterward is the decisive cert re-run.

## β — bot-review substrate + chrome normalization

- **`reviewBotIdentity`** (core `selection-rule.ts`): a NEW allowlist predicate for review-FINDING bots (`gemini-code-assist` / `coderabbitai`, ±`[bot]`), **deliberately separate** from `isBotIdentity` (which still gates `[bot]`-authored corpus membership, unchanged). Allowlist-not-denylist: a not-yet-listed tool undercounts rather than laundering every future automation account in. _(OQ-β1, OQ-β2)_
- **`substantiveCommentCount`** replaces `humanCommentCount`: counts human + recognized review-bot comments as substrate; still excludes unrecognized `[bot]` noise (renovate/dependabot) + empty bodies. For this bot-reviewed cert corpus, gemini/CR comments **are** legitimate substrate.
- **`normalizeReviewChrome`** + **`REVIEW_CHROME_NORMALIZER_VERSION`** (core, new `review-normalize.ts`): deterministic, idempotent, audit-preserving strip of bot chrome (badges / `<details>` / HTML comments). Raw `body` kept, `normalizedBody` added — the prompt renders it and `extractorInputKey` digests it; the version folds into replay provenance so a normalizer change re-keys (replay miss) **and** flips the integrity hash → re-record forced (Tenet-15). _(OQ-β3)_
- **`authorKind`** on each `ReviewThreadComment`; **`DraftSourceKind`** (`human|bot|mixed`) per draft, serialized onto the §8 **emission ledger** (not the reused `ProvenanceRecord`) + the zero-draft drop — non-FM Tenet-19 diagnostics. _(OQ-β4)_

## γ — RESOLVED unconditional

- **`eligibleThreads`** narrows `!isResolved && !isOutdated` → `!isOutdated`: a RESOLVED thread is the highest-signal **legitimacy** marker (a defect a reviewer raised AND the author confirmed by fixing), so it is now ADMITTED; only OUTDATED (diff-hunk-stale) stays excluded. The core gate and the replay-key eligibility move in **lockstep**.
- Drop hygiene: `resolved-rejected` → `outdated-rejected`; the zero-draft drop gets its own **`no-draft`** reason code (α had mislabeled a legitimate model decline as `unparseable`; `noDraftCause` carries the precise sub-reason — the strategy α-contract β-watch).

## Why it's safe

- **No FM falsifier touched** — `authorKind` / `sourceKind` / `noDraftCause` are all diagnostics (Tenet-19), and the eligibility narrowing is a curation property. FM(i) creditability, FM(h) held-out-fetch=0, FM(f) seed-blindness all unchanged.
- **Test-first / mock-driven, zero live LLM in CI** (fold-H guard holds).
- A shared **`enrichComment`** is the single home for `authorKind` + `normalizedBody`, called by BOTH the live adapter and the replay-time loader — so the de-chromed body they feed the extractor (hence the inputKey) can't diverge between record and replay.

## Note for review

`authorKind` is binary `'bot'|'human'` per the ratified design. The substantive-count needs a three-way distinction (human / review-bot / noise-bot); it's realized via `authorKind` (recognized review-bot axis) + the separate `isBotIdentity` denylist check, documented in `extract.ts`.

## Gate

build (core+cli tsc) · core **2803** + cli **2765** tests · ESLint **0 errors** · repo `format:check` clean · `totem lint --base main` **PASS (0 errors)** · changeset (minor).

Tracks mmnto-ai/totem#2237 (Gate-1 iteration backlog — stays open). Refs strategy#709.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
