### PR TITLE
fix(triage-pr): recognize greptile-apps[bot] across the bot-review pipeline (#2192)

### DIFF
--- a/.changeset/triage-pr-greptile-classifier.md
+++ b/.changeset/triage-pr-greptile-classifier.md
@@ -1,4 +1,5 @@
 ---
+'@mmnto/totem': patch
 '@mmnto/cli': patch
 ---
 
@@ -7,8 +8,8 @@ fix(triage-pr): recognize `greptile-apps[bot]` across the bot-review pipeline (m
 `totem triage-pr` silently dropped greptile findings. The shared bot-author classifier (`isBotComment` / `detectBot`) only matched `coderabbit` / `gemini-code-assist`, so `greptile-apps[bot]` inline comments fell through as non-bot and the command printed "No bot review comments found. Nothing to triage." even when greptile had posted actionable findings.
 
 - **Classifier**: `isBotComment` / `detectBot` now recognize greptile (substring match — a future `greptile-enterprise[bot]` is surfaced rather than dropped; the deliberate divergence from core `review-catch.ts`'s exact-match attribution scheme is documented inline).
-- **Severity**: new `parseGreptileSeverity` (P1/P2/P3 → high/medium/low) plus a single `parseSeverityForTool` dispatch that replaces the per-tool severity ternary previously triplicated across `triage-pr`, `recurrence-stats`, and `retrospect` — so adding the next bot is a one-place change.
-- **Attribution / aggregation**: greptile renders as `GT/<severity>` in triage output and is counted by `recurrence-stats`. (`retrospect`'s tool-distribution _label_ rolls greptile under `unknown` for now — widening the persisted core `RetrospectReportSchema` enum is out of scope here and tracked as a #2192 follow-on; greptile findings are still ingested and severity-bucketed.)
+- **Severity**: new `parseGreptileSeverity` (P0/P1/P2/P3 → critical/high/medium/low) plus a single `parseSeverityForTool` dispatch that replaces the per-tool severity ternary previously triplicated across `triage-pr`, `recurrence-stats`, and `retrospect` — so adding the next bot is a one-place change. P0 is greptile's blocking level; without it a `P0` finding would silently bucket as `info`.
+- **First-class attribution**: greptile is added to the persisted core enums (`RecurrenceToolSchema`, `RetrospectFindingToolSchema`) and the shared `toSeverityBucket`, so it is attributed as its own tool in both `recurrence-stats` and `retrospect` output (not collapsed to `unknown`). Renders as `GT/<severity>` in triage output.
 - **Deferred** (noted on the issue): greptile review-body / issue-comment "Comments Outside Diff" surfacing, which needs a distinct greptile body-parser + a new fetch path.
 
-Pure recognition fix — the widened `BotTool` union and `parseSeverityForTool` make greptile a peer of CR/GCA wherever the CLI ingests bot review comments.
+The widened `BotTool` union, `parseSeverityForTool`, and the core enum additions make greptile a peer of CR/GCA wherever the CLI ingests bot review comments.

--- a/.changeset/triage-pr-greptile-classifier.md
+++ b/.changeset/triage-pr-greptile-classifier.md
@@ -1,0 +1,14 @@
+---
+'@mmnto/cli': patch
+---
+
+fix(triage-pr): recognize `greptile-apps[bot]` across the bot-review pipeline (mmnto-ai/totem#2192)
+
+`totem triage-pr` silently dropped greptile findings. The shared bot-author classifier (`isBotComment` / `detectBot`) only matched `coderabbit` / `gemini-code-assist`, so `greptile-apps[bot]` inline comments fell through as non-bot and the command printed "No bot review comments found. Nothing to triage." even when greptile had posted actionable findings.
+
+- **Classifier**: `isBotComment` / `detectBot` now recognize greptile (substring match — a future `greptile-enterprise[bot]` is surfaced rather than dropped; the deliberate divergence from core `review-catch.ts`'s exact-match attribution scheme is documented inline).
+- **Severity**: new `parseGreptileSeverity` (P1/P2/P3 → high/medium/low) plus a single `parseSeverityForTool` dispatch that replaces the per-tool severity ternary previously triplicated across `triage-pr`, `recurrence-stats`, and `retrospect` — so adding the next bot is a one-place change.
+- **Attribution / aggregation**: greptile renders as `GT/<severity>` in triage output and is counted by `recurrence-stats`. (`retrospect`'s tool-distribution _label_ rolls greptile under `unknown` for now — widening the persisted core `RetrospectReportSchema` enum is out of scope here and tracked as a #2192 follow-on; greptile findings are still ingested and severity-bucketed.)
+- **Deferred** (noted on the issue): greptile review-body / issue-comment "Comments Outside Diff" surfacing, which needs a distinct greptile body-parser + a new fetch path.
+
+Pure recognition fix — the widened `BotTool` union and `parseSeverityForTool` make greptile a peer of CR/GCA wherever the CLI ingests bot review comments.

--- a/packages/cli/src/commands/recurrence-stats.ts
+++ b/packages/cli/src/commands/recurrence-stats.ts
@@ -11,6 +11,8 @@
  * No LLM. No GitHub API writes. Stateless per invocation.
  */
 
+import type { RecurrenceSeverityBucket } from '@mmnto/totem';
+
 import type { NormalizedBotFinding } from '../parsers/bot-review-parser.js';
 
 // totem-context: type-only imports above are erased at compile time and don't
@@ -48,8 +50,9 @@ interface AnnotatedFinding {
 // `toSeverityBucket` is the shared core helper (`@mmnto/totem`), imported in
 // `runRecurrenceStats` — single source of truth across the bot-tax cluster so
 // the coderabbit/gca/greptile mappings can't drift (CR on mmnto-ai/totem#2244;
-// retrospect already consumes the same helper).
-type SeverityBucket = 'critical' | 'high' | 'medium' | 'low' | 'nit';
+// retrospect already consumes the same helper). `SeverityBucket` likewise
+// aliases the core `RecurrenceSeverityBucket` so the union isn't duplicated.
+type SeverityBucket = RecurrenceSeverityBucket;
 
 // ─── Main entrypoint ────────────────────────────────
 

--- a/packages/cli/src/commands/recurrence-stats.ts
+++ b/packages/cli/src/commands/recurrence-stats.ts
@@ -45,35 +45,11 @@ interface AnnotatedFinding {
 
 // ─── Severity bucket mapping ────────────────────────
 
+// `toSeverityBucket` is the shared core helper (`@mmnto/totem`), imported in
+// `runRecurrenceStats` — single source of truth across the bot-tax cluster so
+// the coderabbit/gca/greptile mappings can't drift (CR on mmnto-ai/totem#2244;
+// retrospect already consumes the same helper).
 type SeverityBucket = 'critical' | 'high' | 'medium' | 'low' | 'nit';
-
-function toSeverityBucket(
-  tool: NormalizedBotFinding['tool'] | 'override',
-  severity: string,
-): SeverityBucket {
-  const s = severity.toLowerCase();
-  if (tool === 'override') return 'medium';
-  if (tool === 'coderabbit') {
-    if (s === 'critical') return 'critical';
-    if (s === 'major') return 'high';
-    if (s === 'minor') return 'medium';
-    return 'low';
-  }
-  if (tool === 'gca' || tool === 'greptile') {
-    // greptile shares gca's high/medium/low scale; P0 → 'critical' (gca never emits it).
-    if (s === 'critical') return 'critical';
-    if (s === 'high') return 'high';
-    if (s === 'medium') return 'medium';
-    if (s === 'low') return 'low';
-    return 'low';
-  }
-  // unknown tool / synthesized review-body
-  if (s === 'critical') return 'critical';
-  if (s === 'high' || s === 'major') return 'high';
-  if (s === 'medium' || s === 'minor' || s === 'warning') return 'medium';
-  if (s === 'low' || s === 'info') return 'low';
-  return 'nit';
-}
 
 // ─── Main entrypoint ────────────────────────────────
 
@@ -100,6 +76,7 @@ export async function runRecurrenceStats(options: RunRecurrenceStatsOptions = {}
     loadCompiledRules,
     normalizeFindingBody,
     readLedgerEvents,
+    toSeverityBucket,
     tokenizeForJaccard,
   } = await import('@mmnto/totem');
   const { loadConfig, resolveConfigPath } = await import('../utils.js');

--- a/packages/cli/src/commands/recurrence-stats.ts
+++ b/packages/cli/src/commands/recurrence-stats.ts
@@ -60,7 +60,8 @@ function toSeverityBucket(
     return 'low';
   }
   if (tool === 'gca' || tool === 'greptile') {
-    // greptile shares gca's high/medium/low scale (parseGreptileSeverity maps P1/P2/P3).
+    // greptile shares gca's high/medium/low scale; P0 → 'critical' (gca never emits it).
+    if (s === 'critical') return 'critical';
     if (s === 'high') return 'high';
     if (s === 'medium') return 'medium';
     if (s === 'low') return 'low';

--- a/packages/cli/src/commands/recurrence-stats.ts
+++ b/packages/cli/src/commands/recurrence-stats.ts
@@ -59,7 +59,8 @@ function toSeverityBucket(
     if (s === 'minor') return 'medium';
     return 'low';
   }
-  if (tool === 'gca') {
+  if (tool === 'gca' || tool === 'greptile') {
+    // greptile shares gca's high/medium/low scale (parseGreptileSeverity maps P1/P2/P3).
     if (s === 'high') return 'high';
     if (s === 'medium') return 'medium';
     if (s === 'low') return 'low';
@@ -87,8 +88,7 @@ export async function runRecurrenceStats(options: RunRecurrenceStatsOptions = {}
   const {
     isBotComment,
     detectBot,
-    parseCRSeverity,
-    parseGCASeverity,
+    parseSeverityForTool,
     stripHtmlWrappers,
     extractSuggestion,
     extractReviewBodyFindings,
@@ -174,12 +174,7 @@ export async function runRecurrenceStats(options: RunRecurrenceStatsOptions = {}
         const botComment = thread.comments[0];
         if (!botComment) continue;
         const tool = detectBot(botComment.author);
-        const severity =
-          tool === 'coderabbit'
-            ? parseCRSeverity(botComment.body)
-            : tool === 'gca'
-              ? parseGCASeverity(botComment.body)
-              : 'info';
+        const severity = parseSeverityForTool(tool, botComment.body);
 
         const body = stripHtmlWrappers(botComment.body);
         const suggestion = extractSuggestion(botComment.body);
@@ -255,7 +250,7 @@ export async function runRecurrenceStats(options: RunRecurrenceStatsOptions = {}
   // 5. Cluster by signature
   interface MutableCluster {
     signature: string;
-    tools: Set<'coderabbit' | 'gca' | 'sarif' | 'override' | 'unknown'>;
+    tools: Set<'coderabbit' | 'gca' | 'greptile' | 'sarif' | 'override' | 'unknown'>;
     severityBuckets: SeverityBucket[];
     occurrences: number;
     prs: Set<string>;
@@ -327,7 +322,7 @@ export async function runRecurrenceStats(options: RunRecurrenceStatsOptions = {}
   // 7. Materialize patterns
   const allPatterns: Array<{
     signature: string;
-    tool: 'coderabbit' | 'gca' | 'sarif' | 'override' | 'mixed' | 'unknown';
+    tool: 'coderabbit' | 'gca' | 'greptile' | 'sarif' | 'override' | 'mixed' | 'unknown';
     severityBucket: SeverityBucket;
     occurrences: number;
     prs: string[];

--- a/packages/cli/src/commands/retrospect.ts
+++ b/packages/cli/src/commands/retrospect.ts
@@ -346,12 +346,16 @@ export async function runRetrospect(options: RunRetrospectOptions): Promise<void
     const normalized = normalizeFindingBody(a.finding.body);
     if (normalized.length === 0) continue;
     const signature = computeSignature(normalized);
-    // greptile is recognized + severity-bucketed upstream (parseSeverityForTool), but the
-    // distribution's tool LABEL stays in core's RetrospectReportSchema union — widening that
-    // persisted-artifact enum is out of scope for this CLI fix, so greptile rolls up under
-    // 'unknown' here (mmnto-ai/totem#2192 follow-on).
-    const tool: 'coderabbit' | 'gca' | 'sarif' | 'override' | 'unknown' =
-      a.finding.tool === 'coderabbit' ? 'coderabbit' : a.finding.tool === 'gca' ? 'gca' : 'unknown';
+    // greptile is a first-class tool in the persisted RetrospectFindingToolSchema, so
+    // preserve its attribution (CR Major on mmnto-ai/totem#2244) rather than collapsing it.
+    const tool: 'coderabbit' | 'gca' | 'greptile' | 'sarif' | 'override' | 'unknown' =
+      a.finding.tool === 'coderabbit'
+        ? 'coderabbit'
+        : a.finding.tool === 'gca'
+          ? 'gca'
+          : a.finding.tool === 'greptile'
+            ? 'greptile'
+            : 'unknown';
     const severityBucket = toSeverityBucket(tool, a.finding.severity);
 
     // Cross-PR recurrence — count of OTHER PRs (target excluded by construction).

--- a/packages/cli/src/commands/retrospect.ts
+++ b/packages/cli/src/commands/retrospect.ts
@@ -83,8 +83,7 @@ export async function runRetrospect(options: RunRetrospectOptions): Promise<void
   const {
     isBotComment,
     detectBot,
-    parseCRSeverity,
-    parseGCASeverity,
+    parseSeverityForTool,
     stripHtmlWrappers,
     extractReviewBodyFindings,
   } = await import('../parsers/bot-review-parser.js');
@@ -200,12 +199,7 @@ export async function runRetrospect(options: RunRetrospectOptions): Promise<void
   }> = [];
   for (const c of inlineBotComments) {
     const tool = detectBot(c.author);
-    const severity =
-      tool === 'coderabbit'
-        ? parseCRSeverity(c.body)
-        : tool === 'gca'
-          ? parseGCASeverity(c.body)
-          : 'info';
+    const severity = parseSeverityForTool(tool, c.body);
     const body = stripHtmlWrappers(c.body);
     const hunkMatch = c.diffHunk.match(/@@ .+?\+(\d+)/);
     const line = hunkMatch ? Number.parseInt(hunkMatch[1]!, 10) : undefined;
@@ -352,6 +346,10 @@ export async function runRetrospect(options: RunRetrospectOptions): Promise<void
     const normalized = normalizeFindingBody(a.finding.body);
     if (normalized.length === 0) continue;
     const signature = computeSignature(normalized);
+    // greptile is recognized + severity-bucketed upstream (parseSeverityForTool), but the
+    // distribution's tool LABEL stays in core's RetrospectReportSchema union — widening that
+    // persisted-artifact enum is out of scope for this CLI fix, so greptile rolls up under
+    // 'unknown' here (mmnto-ai/totem#2192 follow-on).
     const tool: 'coderabbit' | 'gca' | 'sarif' | 'override' | 'unknown' =
       a.finding.tool === 'coderabbit' ? 'coderabbit' : a.finding.tool === 'gca' ? 'gca' : 'unknown';
     const severityBucket = toSeverityBucket(tool, a.finding.severity);

--- a/packages/cli/src/commands/triage-pr.test.ts
+++ b/packages/cli/src/commands/triage-pr.test.ts
@@ -112,6 +112,31 @@ describe('formatTriageOutput', () => {
     expect(output).toContain('GCA/medium');
   });
 
+  it('shows greptile attribution as GT (mmnto-ai/totem#2192)', () => {
+    const findings: CategorizedFinding[] = [
+      makeFinding({
+        triageCategory: 'architecture',
+        tool: 'greptile',
+        severity: 'high',
+        body: 'Possible null dereference',
+        mergedWith: [
+          {
+            tool: 'greptile',
+            severity: 'medium',
+            file: 'src/lock.ts',
+            line: 20,
+            body: 'Possible null dereference',
+          },
+        ],
+      }),
+    ];
+
+    const output = formatTriageOutput(953, findings, 2, noColor);
+
+    expect(output).toContain('GT/high');
+    expect(output).toContain('GT/medium');
+  });
+
   it('handles empty categories', () => {
     // Only convention findings — security/architecture/nit should not appear
     const findings: CategorizedFinding[] = [

--- a/packages/cli/src/commands/triage-pr.ts
+++ b/packages/cli/src/commands/triage-pr.ts
@@ -8,7 +8,7 @@
  */
 
 import type { StandardReviewComment } from '../adapters/pr-adapter.js';
-import type { NormalizedBotFinding } from '../parsers/bot-review-parser.js';
+import type { BotTool, NormalizedBotFinding } from '../parsers/bot-review-parser.js';
 import type { CategorizedFinding, TriageCategory } from '../parsers/triage-types.js';
 
 // ─── Constants ───────────────────────────────────────
@@ -63,9 +63,8 @@ function groupIntoThreads(comments: StandardReviewComment[]): CommentThread[] {
 function normalizeBotFindings(
   threads: CommentThread[],
   isBotComment: (author: string) => boolean,
-  detectBot: (author: string) => 'coderabbit' | 'gca' | 'unknown',
-  parseCRSeverity: (body: string) => string,
-  parseGCASeverity: (body: string) => string,
+  detectBot: (author: string) => BotTool,
+  parseSeverityForTool: (tool: BotTool, body: string) => string,
   stripHtmlWrappers: (html: string) => string,
   extractSuggestion: (body: string) => string | undefined,
 ): NormalizedBotFinding[] {
@@ -76,12 +75,7 @@ function normalizeBotFindings(
     if (!botComment || !isBotComment(botComment.author)) continue;
 
     const tool = detectBot(botComment.author);
-    const severity =
-      tool === 'coderabbit'
-        ? parseCRSeverity(botComment.body)
-        : tool === 'gca'
-          ? parseGCASeverity(botComment.body)
-          : 'info';
+    const severity = parseSeverityForTool(tool, botComment.body);
 
     const body = stripHtmlWrappers(botComment.body);
     const suggestion = extractSuggestion(botComment.body);
@@ -127,19 +121,31 @@ const CATEGORY_CONFIG: Record<TriageCategory, CategoryConfig> = {
   nit: { emoji: '\u26AA', label: 'NITS', colorFn: 'gray' },
 };
 
+/** Compact display abbreviation for a bot tool (`??` for an unrecognized one). */
+function toolAbbrev(tool: BotTool): string {
+  switch (tool) {
+    case 'coderabbit':
+      return 'CR';
+    case 'gca':
+      return 'GCA';
+    case 'greptile':
+      return 'GT';
+    default:
+      return '??';
+  }
+}
+
 /** Format bot attribution string like [CR/minor, GCA/medium] */
 function formatBotAttribution(finding: CategorizedFinding): string {
   const entries: string[] = [];
 
   // Primary finding
-  const toolAbbrev = finding.tool === 'coderabbit' ? 'CR' : finding.tool === 'gca' ? 'GCA' : '??';
-  entries.push(`${toolAbbrev}/${finding.severity}`);
+  entries.push(`${toolAbbrev(finding.tool)}/${finding.severity}`);
 
   // Merged findings
   if (finding.mergedWith) {
     for (const m of finding.mergedWith) {
-      const mAbbrev = m.tool === 'coderabbit' ? 'CR' : m.tool === 'gca' ? 'GCA' : '??';
-      entries.push(`${mAbbrev}/${m.severity}`);
+      entries.push(`${toolAbbrev(m.tool)}/${m.severity}`);
     }
   }
 
@@ -275,14 +281,8 @@ export async function triagePrCommand(
   const { TotemConfigError } = await import('@mmnto/totem');
   const { GitHubCliPrAdapter } = await import('../adapters/github-cli-pr.js');
   const { log } = await import('../ui.js');
-  const {
-    isBotComment,
-    detectBot,
-    parseCRSeverity,
-    parseGCASeverity,
-    stripHtmlWrappers,
-    extractSuggestion,
-  } = await import('../parsers/bot-review-parser.js');
+  const { isBotComment, detectBot, parseSeverityForTool, stripHtmlWrappers, extractSuggestion } =
+    await import('../parsers/bot-review-parser.js');
   const { deduplicateFindings } = await import('../parsers/triage-dedup.js');
 
   // 1. Parse and validate PR number
@@ -341,8 +341,7 @@ export async function triagePrCommand(
     botThreads,
     isBotComment,
     detectBot,
-    parseCRSeverity,
-    parseGCASeverity,
+    parseSeverityForTool,
     stripHtmlWrappers,
     extractSuggestion,
   );
@@ -398,7 +397,6 @@ export async function triagePrCommand(
 
   // Build selection options from categorized findings
   const optionsList = categorized.map((f, i) => {
-    const toolAbbrev = f.tool === 'coderabbit' ? 'CR' : f.tool === 'gca' ? 'GCA' : '??';
     const location = f.line != null ? `${f.file}:${f.line}` : f.file;
     const summary =
       f.body
@@ -407,7 +405,7 @@ export async function triagePrCommand(
         ?.slice(0, 60) ?? f.body.slice(0, 60);
     return {
       value: i,
-      label: `[${toolAbbrev}/${f.severity}] ${location}`,
+      label: `[${toolAbbrev(f.tool)}/${f.severity}] ${location}`,
       hint: summary.replace(/\n/g, ' '),
     };
   });
@@ -590,9 +588,17 @@ export async function triagePrCommand(
           const pathMod = await import('node:path');
           const lessonsDir = pathMod.join(cwd, cfg.totemDir, 'lessons');
 
-          const toolAbbrev =
-            finding.tool === 'coderabbit' ? 'CR' : finding.tool === 'gca' ? 'GCA' : finding.tool;
-          const tags = [finding.triageCategory, toolAbbrev.toLowerCase(), 'bot-review'];
+          // Lesson tag wants a readable tool id (unknown → 'unknown', not the
+          // display helper's '??'), so it keeps its own mapping.
+          const toolTag =
+            finding.tool === 'coderabbit'
+              ? 'CR'
+              : finding.tool === 'gca'
+                ? 'GCA'
+                : finding.tool === 'greptile'
+                  ? 'GT'
+                  : finding.tool;
+          const tags = [finding.triageCategory, toolTag.toLowerCase(), 'bot-review'];
           const lessonEntry = `## Lesson — ${
             finding.body
               .split('\n')

--- a/packages/cli/src/parsers/bot-review-parser.test.ts
+++ b/packages/cli/src/parsers/bot-review-parser.test.ts
@@ -11,6 +11,8 @@ import {
   isThreadResolved,
   parseCRSeverity,
   parseGCASeverity,
+  parseGreptileSeverity,
+  parseSeverityForTool,
   stripHtmlWrappers,
 } from './bot-review-parser.js';
 
@@ -23,6 +25,10 @@ describe('detectBot', () => {
 
   it('identifies gemini-code-assist[bot]', () => {
     expect(detectBot('gemini-code-assist[bot]')).toBe('gca');
+  });
+
+  it('identifies greptile-apps[bot] (mmnto-ai/totem#2192)', () => {
+    expect(detectBot('greptile-apps[bot]')).toBe('greptile');
   });
 
   it('returns unknown for human authors', () => {
@@ -40,6 +46,17 @@ describe('isBotComment', () => {
 
   it('returns true for GCA bot', () => {
     expect(isBotComment('gemini-code-assist[bot]')).toBe(true);
+  });
+
+  it('returns true for greptile bot (mmnto-ai/totem#2192)', () => {
+    expect(isBotComment('greptile-apps[bot]')).toBe(true);
+  });
+
+  it('recognizes a future greptile variant as a bot (substring match — surface, never drop)', () => {
+    // Unlike core review-catch.ts (exact-match for hit-rate attribution), triage matches
+    // by substring so a new variant is still surfaced rather than silently dropped.
+    expect(isBotComment('greptile-enterprise[bot]')).toBe(true);
+    expect(detectBot('greptile-enterprise[bot]')).toBe('greptile');
   });
 
   it('returns false for human authors', () => {
@@ -94,6 +111,50 @@ describe('parseGCASeverity', () => {
 
   it('returns info when no SVG marker present', () => {
     expect(parseGCASeverity('Plain comment without severity')).toBe('info');
+  });
+});
+
+// ─── parseGreptileSeverity (mmnto-ai/totem#2192) ────────
+
+describe('parseGreptileSeverity', () => {
+  it('maps P1 → high', () => {
+    expect(parseGreptileSeverity('**P1** This dereferences a possibly-null value')).toBe('high');
+  });
+
+  it('maps P2 → medium', () => {
+    expect(parseGreptileSeverity('P2: schema gap — missing field')).toBe('medium');
+  });
+
+  it('maps P3 → low', () => {
+    expect(parseGreptileSeverity('p3 nit: rename for clarity')).toBe('low');
+  });
+
+  it('returns info when no priority token is present', () => {
+    expect(parseGreptileSeverity('Consider extracting this into a helper')).toBe('info');
+  });
+
+  it('does not match a priority token embedded mid-identifier', () => {
+    expect(parseGreptileSeverity('the GP1X register is set here')).toBe('info');
+  });
+});
+
+// ─── parseSeverityForTool (single per-tool dispatch) ────
+
+describe('parseSeverityForTool', () => {
+  it('dispatches coderabbit to the CR parser', () => {
+    expect(parseSeverityForTool('coderabbit', '\u{1F534} Critical: overflow')).toBe('critical');
+  });
+
+  it('dispatches gca to the GCA parser', () => {
+    expect(parseSeverityForTool('gca', '![](https://img/medium-priority.svg)')).toBe('medium');
+  });
+
+  it('dispatches greptile to the greptile parser', () => {
+    expect(parseSeverityForTool('greptile', '**P1** null deref')).toBe('high');
+  });
+
+  it('returns info for an unknown tool', () => {
+    expect(parseSeverityForTool('unknown', 'anything')).toBe('info');
   });
 });
 
@@ -304,6 +365,25 @@ describe('extractResolvedBotFindings', () => {
     expect(findings[1]!.severity).toBe('medium');
     expect(findings[1]!.suggestion).toBeUndefined();
   });
+
+  it('normalizes a resolved greptile finding (mmnto-ai/totem#2192)', () => {
+    const threads: CommentThread[] = [
+      {
+        path: 'src/windtunnel-scorer.ts',
+        diffHunk: '@@ -1,3 +1,5 @@',
+        comments: [
+          { author: 'greptile-apps[bot]', body: '**P1** Possible null dereference on `cfg`' },
+          { author: 'dev', body: 'Fixed in abc1234' },
+        ],
+      },
+    ];
+
+    const findings = extractResolvedBotFindings(threads);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.tool).toBe('greptile');
+    expect(findings[0]!.severity).toBe('high');
+    expect(findings[0]!.disposition).toBe('accepted');
+  });
 });
 
 // ─── extractPushbackFindings ──────────────────────────
@@ -421,6 +501,25 @@ describe('extractPushbackFindings', () => {
     expect(findings).toHaveLength(1);
     expect(findings[0]!.tool).toBe('gca');
     expect(findings[0]!.severity).toBe('high');
+  });
+
+  it('handles greptile bot findings (mmnto-ai/totem#2192)', () => {
+    const threads: CommentThread[] = [
+      {
+        path: 'src/windtunnel-lock.ts',
+        diffHunk: '@@ -10,3 +20,5 @@',
+        comments: [
+          { author: 'greptile-apps[bot]', body: '**P2** Schema gap on the lock digest' },
+          { author: 'dev', body: 'Intentional — validated upstream' },
+        ],
+      },
+    ];
+
+    const findings = extractPushbackFindings(threads);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.tool).toBe('greptile');
+    expect(findings[0]!.severity).toBe('medium');
+    expect(findings[0]!.line).toBe(20);
   });
 });
 

--- a/packages/cli/src/parsers/bot-review-parser.test.ts
+++ b/packages/cli/src/parsers/bot-review-parser.test.ts
@@ -117,6 +117,10 @@ describe('parseGCASeverity', () => {
 // ─── parseGreptileSeverity (mmnto-ai/totem#2192) ────────
 
 describe('parseGreptileSeverity', () => {
+  it('maps P0 → critical (greptile P0 = blocking; mmnto-ai/totem#2244)', () => {
+    expect(parseGreptileSeverity('**P0** SQL injection')).toBe('critical');
+  });
+
   it('maps P1 → high', () => {
     expect(parseGreptileSeverity('**P1** This dereferences a possibly-null value')).toBe('high');
   });
@@ -151,6 +155,7 @@ describe('parseSeverityForTool', () => {
 
   it('dispatches greptile to the greptile parser', () => {
     expect(parseSeverityForTool('greptile', '**P1** null deref')).toBe('high');
+    expect(parseSeverityForTool('greptile', '**P0** rce')).toBe('critical');
   });
 
   it('returns info for an unknown tool', () => {

--- a/packages/cli/src/parsers/bot-review-parser.test.ts
+++ b/packages/cli/src/parsers/bot-review-parser.test.ts
@@ -52,11 +52,14 @@ describe('isBotComment', () => {
     expect(isBotComment('greptile-apps[bot]')).toBe(true);
   });
 
-  it('recognizes a future greptile variant as a bot (substring match — surface, never drop)', () => {
-    // Unlike core review-catch.ts (exact-match for hit-rate attribution), triage matches
-    // by substring so a new variant is still surfaced rather than silently dropped.
+  it('matches greptile bot variants by login shape, not a bare substring (CR Major #2244)', () => {
+    // A future bot variant is still surfaced …
     expect(isBotComment('greptile-enterprise[bot]')).toBe(true);
     expect(detectBot('greptile-enterprise[bot]')).toBe('greptile');
+    // … but a human whose login merely contains 'greptile' is NOT a bot
+    // (a bare-substring match would hide their replies / ingest them as findings).
+    expect(isBotComment('alice-greptile')).toBe(false);
+    expect(detectBot('alice-greptile')).toBe('unknown');
   });
 
   it('returns false for human authors', () => {

--- a/packages/cli/src/parsers/bot-review-parser.ts
+++ b/packages/cli/src/parsers/bot-review-parser.ts
@@ -127,9 +127,12 @@ export function parseGCASeverity(body: string): string {
  * Best-effort: greptile's inline format is less structured than CR's emoji or
  * GCA's SVG marker, so when no explicit priority token is present this returns
  * `info` and the body-keyword categorizer does the real bucketing. Word-bounded
- * so `P1`/`p1` matches but a mid-token `GP1X` does not.
+ * so `P1`/`p1` matches but a mid-token `GP1X` does not. P0 is greptile's
+ * critical/blocking level (greptile review on mmnto-ai/totem#2244) — without it,
+ * a `P0` finding would silently fall through to `info`, the opposite of safe.
  */
 export function parseGreptileSeverity(body: string): string {
+  if (/\bP0\b/i.test(body)) return 'critical';
   if (/\bP1\b/i.test(body)) return 'high';
   if (/\bP2\b/i.test(body)) return 'medium';
   if (/\bP3\b/i.test(body)) return 'low';

--- a/packages/cli/src/parsers/bot-review-parser.ts
+++ b/packages/cli/src/parsers/bot-review-parser.ts
@@ -19,8 +19,9 @@ import { parseCodeRabbitReviewFindings } from '../parse-nits.js';
  * NOTE: `gca` is triage's local id for `gemini-code-assist` — it intentionally
  * diverges from the core actor-id scheme in `@mmnto/totem`'s `resolveActorId`
  * (which uses `gemini-code-assist` and EXACT-login matching for hit-rate
- * attribution). Triage's goal is broad recognition (surface every finding), so
- * it uses substring matching and a compact display id; the two schemes serve
+ * attribution). Triage's goal is broad recognition (surface every finding) with
+ * a compact display id; it matches coderabbit/gca by substring and greptile by
+ * its bot-login shape (see `GREPTILE_BOT_LOGIN`). The two schemes serve
  * different purposes and are deliberately not coupled.
  */
 export type BotTool = 'coderabbit' | 'gca' | 'greptile' | 'unknown';
@@ -56,18 +57,24 @@ export interface CommentThread {
 
 // ─── Bot Detection ──────────────────────────────────
 
-// The three active paid review bots, by the substring that identifies each in a
-// GitHub author login. Canonical exact-login map lives in `@mmnto/totem`'s
-// `review-catch.ts` (`REVIEW_BOT_ACTOR_IDS`); triage matches by substring
-// instead so a future variant (e.g. `greptile-enterprise[bot]`) is still
-// recognized as a bot and surfaced rather than silently dropped — see the
-// {@link BotTool} note on why the two schemes differ.
+// greptile is matched by its bot-login SHAPE — `greptile[bot]`,
+// `greptile-apps[bot]`, `greptile-enterprise[bot]` — rather than a bare
+// `greptile` substring, so a human account like `alice-greptile` is NOT
+// misclassified as a bot (which would hide real human replies in
+// `isThreadResolved` and ingest human comments as bot findings — CR Major on
+// mmnto-ai/totem#2244), while future bot variants are still surfaced. The
+// reviewer's suggested regex carried a trailing `\b` that fails right after the
+// closing `]` (non-word char at end-of-string), so it is dropped here.
+// coderabbit / gca keep their established bare-substring match (canonical
+// exact-login map lives in `@mmnto/totem`'s `review-catch.ts`).
+const GREPTILE_BOT_LOGIN = /\bgreptile(?:-[^[]+)?\[bot\]/i;
+
 export function isBotComment(author: string): boolean {
   const lower = author.toLowerCase();
   return (
     lower.includes('coderabbit') ||
     lower.includes('gemini-code-assist') ||
-    lower.includes('greptile')
+    GREPTILE_BOT_LOGIN.test(author)
   );
 }
 
@@ -75,7 +82,7 @@ export function detectBot(author: string): BotTool {
   const lower = author.toLowerCase();
   if (lower.includes('coderabbit')) return 'coderabbit';
   if (lower.includes('gemini-code-assist')) return 'gca';
-  if (lower.includes('greptile')) return 'greptile';
+  if (GREPTILE_BOT_LOGIN.test(author)) return 'greptile';
   return 'unknown';
 }
 

--- a/packages/cli/src/parsers/bot-review-parser.ts
+++ b/packages/cli/src/parsers/bot-review-parser.ts
@@ -11,8 +11,22 @@ import { parseCodeRabbitReviewFindings } from '../parse-nits.js';
 
 // ─── Types ──────────────────────────────────────────
 
+/**
+ * The review bots whose comment formats triage-pr knows how to parse, plus
+ * `unknown` for an unrecognized author. Adding a bot is a single-place change
+ * here + its severity parser in {@link parseSeverityForTool}.
+ *
+ * NOTE: `gca` is triage's local id for `gemini-code-assist` — it intentionally
+ * diverges from the core actor-id scheme in `@mmnto/totem`'s `resolveActorId`
+ * (which uses `gemini-code-assist` and EXACT-login matching for hit-rate
+ * attribution). Triage's goal is broad recognition (surface every finding), so
+ * it uses substring matching and a compact display id; the two schemes serve
+ * different purposes and are deliberately not coupled.
+ */
+export type BotTool = 'coderabbit' | 'gca' | 'greptile' | 'unknown';
+
 export interface NormalizedBotFinding {
-  tool: 'coderabbit' | 'gca' | 'unknown';
+  tool: BotTool;
   severity: string;
   file: string;
   line?: number;
@@ -42,15 +56,26 @@ export interface CommentThread {
 
 // ─── Bot Detection ──────────────────────────────────
 
+// The three active paid review bots, by the substring that identifies each in a
+// GitHub author login. Canonical exact-login map lives in `@mmnto/totem`'s
+// `review-catch.ts` (`REVIEW_BOT_ACTOR_IDS`); triage matches by substring
+// instead so a future variant (e.g. `greptile-enterprise[bot]`) is still
+// recognized as a bot and surfaced rather than silently dropped — see the
+// {@link BotTool} note on why the two schemes differ.
 export function isBotComment(author: string): boolean {
   const lower = author.toLowerCase();
-  return lower.includes('coderabbit') || lower.includes('gemini-code-assist');
+  return (
+    lower.includes('coderabbit') ||
+    lower.includes('gemini-code-assist') ||
+    lower.includes('greptile')
+  );
 }
 
-export function detectBot(author: string): 'coderabbit' | 'gca' | 'unknown' {
+export function detectBot(author: string): BotTool {
   const lower = author.toLowerCase();
   if (lower.includes('coderabbit')) return 'coderabbit';
   if (lower.includes('gemini-code-assist')) return 'gca';
+  if (lower.includes('greptile')) return 'greptile';
   return 'unknown';
 }
 
@@ -90,6 +115,43 @@ export function parseGCASeverity(body: string): string {
   if (body.includes('medium-priority.svg')) return 'medium';
   if (body.includes('low-priority.svg')) return 'low';
   return 'info';
+}
+
+// ─── Greptile Parser ────────────────────────────────
+
+/**
+ * Extract severity from a greptile inline comment body via its P1/P2/P3
+ * priority label (greptile's severity vocabulary), mapped onto the shared
+ * high/medium/low scale that {@link mapToTriageCategory} consumes.
+ *
+ * Best-effort: greptile's inline format is less structured than CR's emoji or
+ * GCA's SVG marker, so when no explicit priority token is present this returns
+ * `info` and the body-keyword categorizer does the real bucketing. Word-bounded
+ * so `P1`/`p1` matches but a mid-token `GP1X` does not.
+ */
+export function parseGreptileSeverity(body: string): string {
+  if (/\bP1\b/i.test(body)) return 'high';
+  if (/\bP2\b/i.test(body)) return 'medium';
+  if (/\bP3\b/i.test(body)) return 'low';
+  return 'info';
+}
+
+/**
+ * Single source of truth for "which severity parser applies to which bot".
+ * Keeps the per-tool dispatch in one place so adding a bot does not require
+ * touching every finding-normalizer (triage-pr, extractResolved, extractPushback).
+ */
+export function parseSeverityForTool(tool: BotTool, body: string): string {
+  switch (tool) {
+    case 'coderabbit':
+      return parseCRSeverity(body);
+    case 'gca':
+      return parseGCASeverity(body);
+    case 'greptile':
+      return parseGreptileSeverity(body);
+    default:
+      return 'info';
+  }
 }
 
 // ─── Resolution Filter ──────────────────────────────
@@ -216,12 +278,7 @@ export function extractPushbackFindings(threads: CommentThread[]): NormalizedBot
     if (!pushbackReply) continue;
 
     const tool = detectBot(botComment.author);
-    const severity =
-      tool === 'coderabbit'
-        ? parseCRSeverity(botComment.body)
-        : tool === 'gca'
-          ? parseGCASeverity(botComment.body)
-          : 'info';
+    const severity = parseSeverityForTool(tool, botComment.body);
 
     const body = stripHtmlWrappers(botComment.body);
     const hunkMatch = thread.diffHunk.match(/@@ .+?\+(\d+)/);
@@ -252,12 +309,7 @@ export function extractResolvedBotFindings(threads: CommentThread[]): Normalized
 
     const botComment = thread.comments[0]!;
     const tool = detectBot(botComment.author);
-    const severity =
-      tool === 'coderabbit'
-        ? parseCRSeverity(botComment.body)
-        : tool === 'gca'
-          ? parseGCASeverity(botComment.body)
-          : 'info';
+    const severity = parseSeverityForTool(tool, botComment.body);
 
     const body = stripHtmlWrappers(botComment.body);
     const suggestion = extractSuggestion(botComment.body);

--- a/packages/core/src/recurrence-stats.test.ts
+++ b/packages/core/src/recurrence-stats.test.ts
@@ -7,6 +7,7 @@ import {
   RecurrencePatternSchema,
   RecurrenceStatsSchema,
   tokenizeForJaccard,
+  toSeverityBucket,
 } from './recurrence-stats.js';
 
 // ─── RecurrencePatternSchema ───────────────────────────
@@ -67,6 +68,33 @@ describe('RecurrencePatternSchema', () => {
       coveredByRule: false,
     });
     expect(result.success).toBe(false);
+  });
+
+  it('accepts greptile as a first-class tool (mmnto-ai/totem#2244)', () => {
+    const result = RecurrencePatternSchema.safeParse({
+      signature: 'abc123def4567890',
+      tool: 'greptile',
+      severityBucket: 'critical',
+      occurrences: 1,
+      prs: ['101'],
+      sampleBodies: ['possible null dereference'],
+      firstSeen: '2026-01-01T00:00:00.000Z',
+      lastSeen: '2026-01-01T00:00:00.000Z',
+      paths: ['src/a.ts'],
+      coveredByRule: false,
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ─── toSeverityBucket (greptile; mmnto-ai/totem#2244) ──
+
+describe('toSeverityBucket — greptile', () => {
+  it('maps greptile P0→critical through high/medium/low like gca', () => {
+    expect(toSeverityBucket('greptile', 'critical')).toBe('critical');
+    expect(toSeverityBucket('greptile', 'high')).toBe('high');
+    expect(toSeverityBucket('greptile', 'medium')).toBe('medium');
+    expect(toSeverityBucket('greptile', 'low')).toBe('low');
   });
 });
 

--- a/packages/core/src/recurrence-stats.ts
+++ b/packages/core/src/recurrence-stats.ts
@@ -22,6 +22,7 @@ import { z } from 'zod';
 export const RecurrenceToolSchema = z.enum([
   'coderabbit',
   'gca',
+  'greptile',
   'sarif',
   'override',
   'mixed',
@@ -42,7 +43,7 @@ export type RecurrenceSeverityBucket = z.infer<typeof RecurrenceSeverityBucketSc
  *
  * Tool inputs:
  * - `'coderabbit'`: `critical` / `major` / `minor` / `*` → `critical` / `high` / `medium` / `low`
- * - `'gca'`: `high` / `medium` / `low` → identical buckets; default `low`
+ * - `'gca'` / `'greptile'`: `critical` / `high` / `medium` / `low` → identical buckets; default `low` (greptile P0 → `critical`)
  * - `'sarif'`: SARIF level vocabulary (`error` / `warning` / `note` / `none`) → `high` / `medium` / `low` / `low`
  * - `'override'`: trap-ledger override events surface as `medium`
  * - any other tool (`'unknown'`, `undefined`): keyword-mapped from the raw severity string
@@ -67,7 +68,10 @@ export function toSeverityBucket(
     if (s === 'minor') return 'medium';
     return 'low';
   }
-  if (tool === 'gca') {
+  if (tool === 'gca' || tool === 'greptile') {
+    // greptile shares gca's high/medium/low scale; P0 maps to 'critical' upstream
+    // (parseGreptileSeverity), which gca never emits but greptile can.
+    if (s === 'critical') return 'critical';
     if (s === 'high') return 'high';
     if (s === 'medium') return 'medium';
     if (s === 'low') return 'low';

--- a/packages/core/src/retrospect.test.ts
+++ b/packages/core/src/retrospect.test.ts
@@ -218,6 +218,40 @@ describe('RetrospectReportSchema', () => {
     };
     expect(RetrospectReportSchema.safeParse(bad).success).toBe(false);
   });
+
+  it('accepts a greptile-tool finding (first-class attribution; mmnto-ai/totem#2244)', () => {
+    const report: RetrospectReport = {
+      version: 1,
+      prNumber: '2244',
+      prState: 'open',
+      generatedAt: '2026-06-24T00:00:00.000Z',
+      threshold: 5,
+      substrateAvailable: false,
+      compiledRulesAvailable: false,
+      rounds: [],
+      totalFindings: 1,
+      dedupRate: 0,
+      findingDistribution: { byTool: { greptile: 1 }, bySeverity: {}, byClassification: {} },
+      routeOutCandidates: [],
+      inPrFixes: [
+        {
+          signature: 'abc123def4567890',
+          tool: 'greptile',
+          severityBucket: 'critical',
+          bodyExcerpt: 'possible null dereference',
+          file: 'src/a.ts',
+          roundNumber: 1,
+          crossPrRecurrence: 0,
+          coveredByRule: false,
+          classification: 'in-pr-fix',
+        },
+      ],
+      undetermined: [],
+      stopConditions: [],
+      overrideEventsObserved: 0,
+    };
+    expect(RetrospectReportSchema.safeParse(report).success).toBe(true);
+  });
 });
 
 // ─── toRoundPosition / toCrossPrBucket ─────────────────

--- a/packages/core/src/retrospect.ts
+++ b/packages/core/src/retrospect.ts
@@ -46,7 +46,14 @@ export const RetrospectClassificationSchema = z.enum(['route-out', 'in-pr-fix', 
 export type RetrospectClassification = z.infer<typeof RetrospectClassificationSchema>;
 
 /** Source classification of a finding (mirror of `RecurrenceTool` minus `'mixed'`). */
-const RetrospectFindingToolSchema = z.enum(['coderabbit', 'gca', 'sarif', 'override', 'unknown']);
+const RetrospectFindingToolSchema = z.enum([
+  'coderabbit',
+  'gca',
+  'greptile',
+  'sarif',
+  'override',
+  'unknown',
+]);
 
 /**
  * Closed catalog of `route-out` reasons. The Zod-side mirror of


### PR DESCRIPTION
## What

Teaches the CLI's bot-review pipeline to recognize `greptile-apps[bot]`. The shared classifier (`isBotComment` / `detectBot`) only matched `coderabbit` / `gemini-code-assist`, so greptile inline review comments fell through as non-bot — `totem triage-pr` then printed "No bot review comments found. Nothing to triage." even when greptile had posted findings (the #2190 repro: 2 greptile inline findings surfaced as zero).

## Changes

- **Classifier** (`bot-review-parser.ts`): `isBotComment` / `detectBot` recognize greptile. Substring match (not exact) so a future `greptile-enterprise[bot]` is surfaced, not dropped — the deliberate divergence from core `review-catch.ts`'s exact-match attribution scheme (hit-rate accuracy) is documented inline.
- **Severity**: new `parseGreptileSeverity` (P0/P1/P2/P3 → critical/high/medium/low) + a single `parseSeverityForTool` dispatch that replaces the per-tool severity ternary previously **triplicated** across `triage-pr`, `recurrence-stats`, and `retrospect`. Adding the next bot is now a one-place change — the maintainability root-cause the issue names.
- **First-class attribution**: greptile is added to the persisted core enums (`RecurrenceToolSchema`, `RetrospectFindingToolSchema`) and the shared `toSeverityBucket`, so it's attributed as its own tool in **both** `recurrence-stats` and `retrospect` (not collapsed to `unknown`). Renders as `GT/<severity>` in triage output.
- **Tests**: greptile coverage for `detectBot` / `isBotComment` (+ the `greptile-enterprise` variant), `parseGreptileSeverity`, `parseSeverityForTool`, `extractResolvedBotFindings` / `extractPushbackFindings`, and `GT/…` attribution in `formatTriageOutput`.

## Scope / deferred (Refs #2192)

This addresses the titled defect (classifier miss → false "nothing to triage"). One piece is **consciously deferred**, so #2192 stays OPEN for the remaining surface:

1. **greptile review-body / issue-comment "Comments Outside Diff" surfacing** — needs a distinct greptile body-parser (today only CodeRabbit's `parseCodeRabbitReviewFindings` exists) + a new `issues/{n}/comments` fetch path.

## Gate

typecheck clean · core 2808 + cli 2781 tests pass · ESLint 0 errors · prettier clean · `totem lint --base main` PASS · changeset (`@mmnto/totem` + `@mmnto/cli` patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
