### PR TITLE
fix(triage-pr): marker-anchored greptile Comments-Outside-Diff + confidence + never under-report (#2192)

### DIFF
--- a/.changeset/triage-pr-greptile-summary-surface.md
+++ b/.changeset/triage-pr-greptile-summary-surface.md
@@ -2,18 +2,23 @@
 '@mmnto/cli': patch
 ---
 
-fix(triage-pr): surface review-bot summary issue-comments + never under-report "Nothing to triage"
+fix(triage-pr): surface greptile's Comments-Outside-Diff + confidence, and never under-report "Nothing to triage"
 
 `totem triage-pr` (and the shared bot-review extractor) now fetch the PR
 issue-comment surface via `gh api` — which preserves the `[bot]` login suffix
 and `user.type` that `gh pr view` strips — so a review bot's standing summary
-comment (where greptile posts its "Comments Outside Diff" findings, edited in
-place across review rounds) is recognized as bot material instead of being
-silently dropped.
+comment is recognized as bot material instead of silently dropped.
+
+Greptile's out-of-diff findings are extracted from its summary by the canonical
+`<!-- greptile_other_comments_section -->` marker (mmnto-ai/totem-strategy#690),
+not a sampled `<details>` shape: greptile edits its summary in place, so the
+findings are only present mid-review and the marker is the reliable anchor. The
+findings render via the existing bot-agnostic triage table. Greptile's documented
+Confidence Score (`N/5`) is surfaced as a triage context signal.
 
 The empty-state guard no longer prints a bare "Nothing to triage" when comments
 were fetched: when raw comments exist but none are bot-authored it reports the
 per-surface counts, and a bot summary being present (even if it parsed no
-discrete findings) always keeps the PR in triage. Adds a provisional greptile
-summary parser, modeled on the CodeRabbit outside-diff parser, to be refined
-against a captured live sample (mmnto-ai/totem#2192).
+discrete findings) always keeps the PR in triage. This makes the tool the
+mechanical enforcement of the "read every surface, in full" review-reply
+discipline (mmnto-ai/totem#2192).

--- a/.changeset/triage-pr-greptile-summary-surface.md
+++ b/.changeset/triage-pr-greptile-summary-surface.md
@@ -1,0 +1,19 @@
+---
+'@mmnto/cli': patch
+---
+
+fix(triage-pr): surface review-bot summary issue-comments + never under-report "Nothing to triage"
+
+`totem triage-pr` (and the shared bot-review extractor) now fetch the PR
+issue-comment surface via `gh api` — which preserves the `[bot]` login suffix
+and `user.type` that `gh pr view` strips — so a review bot's standing summary
+comment (where greptile posts its "Comments Outside Diff" findings, edited in
+place across review rounds) is recognized as bot material instead of being
+silently dropped.
+
+The empty-state guard no longer prints a bare "Nothing to triage" when comments
+were fetched: when raw comments exist but none are bot-authored it reports the
+per-surface counts, and a bot summary being present (even if it parsed no
+discrete findings) always keeps the PR in triage. Adds a provisional greptile
+summary parser, modeled on the CodeRabbit outside-diff parser, to be refined
+against a captured live sample (mmnto-ai/totem#2192).

--- a/.totem/specs/2192.md
+++ b/.totem/specs/2192.md
@@ -1,20 +1,25 @@
 ### Problem Statement
+
 The `totem triage-pr` command currently fails to surface actionable bot review findings because it only fetches inline diff comments, ignoring PR review bodies and issue-comments, and its bot-author classifier omits modern AI bots like `greptile-apps[bot]`. Furthermore, the command outputs a misleading "Nothing to triage" message even when raw inline comments were detected but filtered out by the incomplete classifier.
 
 ### Architectural Context
-- **CLI Lazy-Import Policy:** Per mmnto-ai/totem#1729 CR R1, all files matching `packages/cli/src/commands/**` must use dynamic imports (`await import(...)`) for their dependencies to ensure fast CLI startup. 
+
+- **CLI Lazy-Import Policy:** Per mmnto-ai/totem#1729 CR R1, all files matching `packages/cli/src/commands/**` must use dynamic imports (`await import(...)`) for their dependencies to ensure fast CLI startup.
 - **Bot-Tax Circuit Breaker Workflow:** The `triage-pr` command is expected to group findings into push-based rounds using `gh api repos/.../pulls/N/reviews`, but the current implementation is falling short.
 
 ### Files to Examine
+
 1. `packages/cli/src/commands/triage-pr.ts` — Contains the `triagePrCommand` function, the early-exit output logic, and the bot classification filtering.
 2. `packages/cli/src/adapters/github-cli-pr.ts` — The data access layer. Needs to be inspected to see how it currently fetches inline comments and augmented to fetch review bodies and issue comments.
 3. `packages/cli/src/commands/triage-pr.test.ts` (or equivalent test file) — To verify test patterns for mocking GitHub CLI output and console assertions.
 
 ### Technical Approach & Contracts
+
 We will unify the three GitHub API feedback surfaces (Inline Comments, Review Bodies, and Issue Comments) into a single actionable format before classification.
 
 **1. Data Contracts:**
 Define new TypeScript interfaces/Zod schemas in the adapter to represent the additional API payloads:
+
 ```typescript
 interface GitHubReview {
   id: number;
@@ -43,13 +48,14 @@ interface UnifiedBotFinding {
 Extend `GitHubCliPrAdapter` to include `getReviews(prNumber: string)` and `getIssueComments(prNumber: string)`. These MUST use the shared `safeExec` helper to call `gh api --paginate repos/{owner}/{repo}/pulls/{n}/reviews` and `.../issues/{n}/comments`.
 
 **3. Bot Classifier & Payload Parsing:**
-Update the bot author allowlist to match `greptile-apps[bot]`, `coderabbitai[bot]`, and `gemini-code-assist[bot]`. 
+Update the bot author allowlist to match `greptile-apps[bot]`, `coderabbitai[bot]`, and `gemini-code-assist[bot]`.
 In `triage-pr.ts`, parse Greptile's specific "Comments Outside Diff" by extracting content from `<details><summary>Comments Outside Diff</summary>...</details>` blocks within issue-comment bodies.
 
 **4. Output Logic Adjustment:**
 Track the `totalRawCommentsFetched` across all three surfaces. If `totalRawCommentsFetched > 0` but `classifiedBotComments === 0`, print: `"Found X comments across PR surfaces, but none were classified as bot findings. Check your bot classifier rules."` Never output "Nothing to triage" if the raw count > 0.
 
 ### Edge Cases & Traps
+
 - **Pagination Drop:** GitHub API truncates lists to 30 items by default. The `gh api` calls MUST include the `--paginate` flag so heavily commented PRs don't drop findings.
 - **Lazy Imports:** You MUST NOT add top-level `import { safeExec } from ...` in `triage-pr.ts`. It must be dynamically imported inside the command function.
 - **Fragile HTML Parsing:** Greptile injects HTML `<details>` blocks for outside-diff comments. Use a non-greedy regex with the `s` (dotall) flag to extract this safely: `/<details>\s*<summary>.*?Comments Outside Diff.*?<\/summary>(.*?)<\/details>/is`.
@@ -88,6 +94,7 @@ Track the `totalRawCommentsFetched` across all three surfaces. If `totalRawComme
   - write test → verify fails → implement → verify passes → lint
 
 ### Execution Flow (structural constraint)
+
 ```dot
 digraph workflow {
   spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
@@ -99,12 +106,15 @@ digraph workflow {
 ```
 
 ### Verification (MANDATORY — do not skip)
+
 Every implementation MUST end with these steps:
+
 1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
 2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
 3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
 
 ### Test Plan
+
 1. **Adapter Test:** Mock `safeExec` to return paginated GitHub API JSON for PR reviews and issue comments. Verify the adapter parses them into the correct interfaces.
 2. **Classifier Test:** Pass mock API payloads from `greptile-apps[bot]`, `user.type="Bot"` but name `"coderabbitai"`, and verify they are flagged as bot findings.
 3. **Surface Unification Test:** Provide a mocked PR with 0 inline comments, 1 CodeRabbit review body summary, and 1 Greptile issue-comment containing a `<details>` block. Verify `triage-pr` surfaces exactly 2 actionable findings.
@@ -117,37 +127,44 @@ Every implementation MUST end with these steps:
 > **Authored against ground truth (live GitHub payloads + code map), not the issue's stated premise.** The spec above is the LLM-generated skeleton; this section corrects it where empirical reality diverges. Two premises in the issue/spec are **empirically false** and are dropped (see Negative Scope).
 
 ### What 1.75.1 already fixed (so this is NOT the scope)
+
 PR #2244 (`5289be67`) already shipped greptile **inline** recognition (`isBotComment`/`detectBot`/`parseGreptileSeverity`), greptile in the core enums (`RecurrenceToolSchema`, `RetrospectFindingToolSchema`, `toSeverityBucket`), and CodeRabbit review-body parsing is already wired (`extractReviewBodyFindings` → `parseCodeRabbitReviewFindings` → nits + **Comments Outside Diff**). The original #2190 bug ("greptile P1/P2 inline dropped → Nothing to triage") is **fixed**.
 
 ### Empirical corrections to the issue's premise (verified on PRs #2190/#2244)
-1. **Greptile does NOT use a "Comments Outside Diff" `<details>` block.** That is a **CodeRabbit** construct, posted in the CR *review body* (`pulls/{n}/reviews`) and already parsed. Greptile's review body is **empty** (`state: COMMENTED`, `body: ""`).
-2. **Greptile's only out-of-diff surface is its summary issue-comment** ("Greptile Summary" + Confidence Score + an "Important Files Changed" *table*). The table's Overview prose is descriptive, occasionally embedding a finding (#2190: *"`filesTouchedInWindow`… silently never checked in Step 2"*) but is not a clean findings list. Mining it as discrete findings = noise (violates `feedback_derived_summary_not_source_verify`).
+
+1. **Greptile does NOT use a "Comments Outside Diff" `<details>` block.** That is a **CodeRabbit** construct, posted in the CR _review body_ (`pulls/{n}/reviews`) and already parsed. Greptile's review body is **empty** (`state: COMMENTED`, `body: ""`).
+2. **Greptile's only out-of-diff surface is its summary issue-comment** ("Greptile Summary" + Confidence Score + an "Important Files Changed" _table_). The table's Overview prose is descriptive, occasionally embedding a finding (#2190: _"`filesTouchedInWindow`… silently never checked in Step 2"_) but is not a clean findings list. Mining it as discrete findings = noise (violates `feedback_derived_summary_not_source_verify`).
 3. **`gh pr view --json comments/reviews` strips the `[bot]` suffix** (`greptile-apps`, `coderabbitai`), so `isBotComment`'s greptile regex (deliberately `[bot]`-required since #2244 R2, to reject humans like `alice-greptile`) fails on `gh pr view` data. The `gh api .../issues/{n}/comments` route preserves `greptile-apps[bot]` **and** returns `user.type: "Bot"` — a suffix-independent signal.
 
 ### Scope (2 sentences)
+
 Make `triage-pr` fetch the **issue-comment surface** via `gh api` (suffix- + type-preserving), surface each recognized bot's **summary as a context line** (e.g. greptile "Confidence 5/5"), and fix the **misleading empty-state output** so "Nothing to triage" is never printed when bot-authored material was fetched. It will **NOT** mine summaries/tables for discrete findings, **NOT** build a greptile `<details>`/Outside-Diff parser (empirically absent), and **NOT** parse greptile review bodies (empirically empty).
 
 ### Data model deltas
+
 - **`StandardIssueComment`** (new, `pr-adapter.ts`) — `{ author: string /* with [bot] */, authorType: string /* 'Bot'|'User'|'Organization' */, body: string, createdAt?: string }`. Written by the adapter; read by triage-pr (and reusable by recurrence-stats/retrospect later, out of scope here). Invariant: `author` preserves the `[bot]` suffix (guaranteed by sourcing from `gh api`, not `gh pr view`).
 - **`fetchIssueComments(prNumber): StandardIssueComment[]`** (new optional method on `PrAdapter`, implemented in `github-cli-pr.ts`) — `gh api repos/{nwo}/issues/{n}/comments --paginate`; Zod `GhIssueCommentSchema`. Optional on the interface (mirrors `fetchReviews?`) so test/mocks needn't implement it.
 - **`BotSummarySignal`** (new, parser helper) — `{ tool: BotTool, signal: string }` (e.g. `{tool:'greptile', signal:'Confidence 5/5 — safe to merge'}`). NOT a `NormalizedBotFinding` — it is context, never categorized/triaged/replied-to. Greptile confidence parsed via `/Confidence Score:\s*([0-5])\s*\/\s*5/i`; absent → no signal for that bot.
 - **No new reserved keys / sentinels.** No change to `NormalizedBotFinding`, the core enums, or persisted schemas. `(review body)` sentinel file stays as-is.
 
 ### State lifecycle
+
 All state is **per-invocation** (one `triage-pr` run): fetched arrays + the `rawBotMaterialCount` tally are local to `triagePrCommand`, created on fetch, read once for output, never persisted or shared. No cross-lifecycle flags, no module-level state, no singletons. Ownership: `triagePrCommand` owns the tally; the adapter owns fetch; the parser helper is pure.
 
 ### Failure modes
-| Failure | Category | Agent-facing surface | Recovery |
-| --- | --- | --- | --- |
-| `gh api issues/{n}/comments` non-zero exit / network | transient/runtime | **warning** ("could not fetch issue-comments: <err>; triaging inline + review-body only") + continue | inline/review surfaces still triage; named degradation (Tenet-4 compliant — not silent) |
-| Malformed JSON from gh api | runtime | warning (same as above); Zod parse error message included | continue degraded |
-| Issue-comment body has no parseable confidence score | permanent (expected) | silent — no context line for that bot | n/a (absence of a signal is not a finding) |
-| Pagination truncation (>30 comments) | permanent if unhandled | — | `--paginate` flag (mandatory) prevents it |
-| Bot login lacks `[bot]` (e.g. via a future `gh pr view` path) | permanent | recognized anyway via `authorType==='Bot'` fallback at the issue-comment seam | robust by design |
+
+| Failure                                                       | Category               | Agent-facing surface                                                                                 | Recovery                                                                                |
+| ------------------------------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `gh api issues/{n}/comments` non-zero exit / network          | transient/runtime      | **warning** ("could not fetch issue-comments: <err>; triaging inline + review-body only") + continue | inline/review surfaces still triage; named degradation (Tenet-4 compliant — not silent) |
+| Malformed JSON from gh api                                    | runtime                | warning (same as above); Zod parse error message included                                            | continue degraded                                                                       |
+| Issue-comment body has no parseable confidence score          | permanent (expected)   | silent — no context line for that bot                                                                | n/a (absence of a signal is not a finding)                                              |
+| Pagination truncation (>30 comments)                          | permanent if unhandled | —                                                                                                    | `--paginate` flag (mandatory) prevents it                                               |
+| Bot login lacks `[bot]` (e.g. via a future `gh pr view` path) | permanent              | recognized anyway via `authorType==='Bot'` fallback at the issue-comment seam                        | robust by design                                                                        |
 
 The one "degradation" row (fetch failure → warn+continue) is justified vs Tenet-4: a hard error would **regress** the already-working inline triage for an additive surface; the failure is named on stderr, not dropped.
 
 ### Invariants to lock in via tests
+
 - "Nothing to triage" is printed **only** when zero bot material was fetched across **all** surfaces (inline + review-body findings + bot issue-comments). When raw bot material > 0 but categorized findings == 0, a diagnostic (count + summary signals) is printed instead.
 - A greptile summary issue-comment (`greptile-apps[bot]`, `type:Bot`) is recognized as bot material and its `Confidence N/5` surfaces as a context line; a human issue-comment (`type:User`) is not counted as bot material.
 - Issue-comment recognition holds with the `[bot]` suffix present (gh api shape) **and** via `authorType==='Bot'` when a login substring alone wouldn't match the conservative greptile regex.
@@ -156,6 +173,7 @@ The one "degradation" row (fetch failure → warn+continue) is justified vs Tene
 - Issue-comment fetch failure emits a named warning and does not abort inline/review triage.
 
 ### Open questions
+
 - **Q1 — Issue-comment summaries: context-line vs mined-findings?**
   - Options: (A) count toward the output guard only; (B) **also surface a one-line context signal per bot** (confidence/verdict); (C) mine summary prose/table for discrete findings.
   - Recommendation: **B.** Closes the issue's "the summary was also not surfaced" without the noise/false-positive risk of C (the derived-summary-not-source trap). A is the lighter fallback if you want the smallest diff.
@@ -172,27 +190,33 @@ The one "degradation" row (fetch failure → warn+continue) is justified vs Tene
 Live capture (lc#617, greptile mid-review) + operator domain knowledge corrected the design. The greptile "Comments Outside Diff" `<details>` parser targets a structure **greptile does not use** (it is a CodeRabbit-only construct) — dropped. The real value is surfacing the **status signals an operator actually reads**, and ensuring nothing is under-reported, so the PR can be **read in full**.
 
 ### Per-bot status model (THIS repo's config — auto-invocation + CR summary feature DISABLED)
+
 - **Greptile** — live-updated **summary comment** (edited in place across rounds): `<h3>Greptile Summary</h3>` · **`Confidence Score: N/5`** · Important Files Changed table · diagram. Confidence is the headline signal. Out-of-scope/deferral findings post **inline** (already handled), not in a `<details>`.
 - **CodeRabbit** — summary-page feature is **disabled here**, so CR does NOT maintain a standing updated summary (it does when auto-invocation is on — behavior is config-dependent). CR status = its review body (`pulls/reviews`, parsed) + inline + reactions. No confidence-style signal.
 - **GCA** — no summary page; **its last comment is its status**. Read the most-recent GCA comment + reactions.
 - **All three** acknowledge a tag/invocation with a **👀 reaction**; a **👍 reaction = action taken**. Grounded: lc#617 invocation → GCA 👀, greptile 👍 (via `issues/comments/{id}/reactions`, which carries reactor login + emoji).
 
 ### Design conclusion
+
 Because bot status is **per-bot AND config-dependent**, hard-coded per-bot summary parsing is fragile. Favor robust, universal, simple signals + completeness, then read in full:
+
 1. **Empty-state guard** (done) — never under-report; bot-agnostic.
 2. **Reaction status on the latest invocation** (👀 ack / 👍 acted), per bot, via the `/reactions` endpoint — universal, config-independent, attributable.
 3. **Greptile Confidence Score** (N/5) — stable, greptile-specific, parsed from the summary already fetched.
 4. **Drop** `parseGreptileOutsideDiff` (dead structure; the clever-scan anti-pattern). Leave the CR review-body parser untouched (CR genuinely uses it).
 
 ### New surface needed
+
 - `fetchCommentReactions(commentId)` (or batched) → `{ reactor, emoji }[]` via `repos/{nwo}/issues/comments/{id}/reactions` (`--paginate`). Used to compute a per-bot `👀/👍/—` status line for the latest invocation comment(s).
 
 ### Official-docs grounding (3-bot research, 2026-06-24 — cited in journal)
+
 Confirms/corrects the model from the bots' own docs (not forensics):
+
 - **Reactions are DOCUMENTED for greptile, observed-only for CR/GCA.** Greptile has a dedicated Emoji Guide: **👀 = seen/in-progress (ack), 👍 = review done, 😕 = review FAILED** (`greptile.com/docs/code-review-bot/emoji-reactions`). CR's 👀-on-command-start and GCA's reactions are **undocumented** (observed implementation details). ⇒ greptile reactions are contractual; CR/GCA best-effort, coded defensively. **`😕 = greptile review failed` is a new must-surface signal** (a failed review is the exact false-green the guard exists to catch).
 - **Greptile Confidence Score is DOCUMENTED: integer `N/5`** — 5 production-ready · 4 minor-polish · 3 impl-issues · 2 significant-bugs · 0–1 critical (`/docs/code-review/first-pr-review`). Parse `Confidence Score: N/5` (NOT a percentage).
 - **"Comments Outside Diff" is CR-only — officially confirmed.** CR docs: `Outside diff range comments (N)` in the review body for findings that can't post inline. Greptile docs have **no** such `<details>` container (verified absent). ⇒ keep `parseCodeRabbitOutsideDiff`, **drop** `parseGreptileOutsideDiff`. Settled by docs, not just the live capture.
-- **Greptile 👍 is overloaded** — 👍 on its summary/trigger comment = "done"; 👍 on an *inline* comment = a human feedback vote. Disambiguate by object + reactor login.
+- **Greptile 👍 is overloaded** — 👍 on its summary/trigger comment = "done"; 👍 on an _inline_ comment = a human feedback vote. Disambiguate by object + reactor login.
 - **Severity (documented):** CR 🔴Critical/🟠Major/🟡Minor/🔵Trivial/⚪Info; GCA Critical/High/Medium/Low (SVG icon names undocumented — our `parseGCASeverity` keys on observed artifacts); greptile **P0/P1/P2** (P3 is undocumented — keep defensively).
 - **Summary-disable config (confirms operator's "we disabled CR summary"):** CR `reviews.high_level_summary: false`; GCA `code_review.pull_request_opened.summary` default **false**; greptile `statusCommentsEnabled` / `updateExistingSummaryComment` / `shouldUpdateDescription`. Per-bot + config-dependent — confirmed.
 - **Invocation (for parsing expectations only — operator triggers, not the CLI):** CR `@coderabbitai review|full review|summary|pause|resume`; GCA `/gemini review|summary`; greptile bare `@greptileai` (no `review` subcommand).
@@ -204,20 +228,24 @@ Confirms/corrects the model from the bots' own docs (not forensics):
 The earlier "greptile has no Comments-Outside-Diff — drop `parseGreptileOutsideDiff`" conclusion was **WRONG**, twice over (merged-PR forensics + a docs pass that found it undocumented). A 3-agent forensic sweep of our own session transcripts + reading strategy#689's live structure corrected it:
 
 - **Greptile DOES emit a Comments-Outside-Diff section**, anchored by the HTML-comment marker **`<!-- greptile_other_comments_section -->`**, rendered **below the flowchart**, above the `<sub>Reviews (N):…</sub>` footer (canonical per strategy#690). It is **edited away post-resolution**, so a merged/closed PR shows the marker with empty content — which is exactly why merged-PR forensics (and the official docs, which don't document it) read "absent." The marker is the empirical proof; key the parser on the **marker**, never a sampled PR shape.
-- **The failure is real, cross-agent, recurring** — transcript sweep found ~24 genuine misses (lc-claude ~12, strategy-claude ~6, totem-claude ~6) where an agent declared a PR "clean/done" and the operator had to surface a greptile/CR out-of-diff finding (incl. a 🔴 Critical on totem#2178). The operator caught nearly every one; agents almost never self-caught. **Doctrine alone did not hold** (recurred after banking + strategy#690): agents coped by *bypassing* the broken `triage-pr`, which is itself the defect. ⇒ the durable fix is **mechanical**: make the tool surface it so no one has to bypass it.
+- **The failure is real, cross-agent, recurring** — transcript sweep found ~24 genuine misses (lc-claude ~12, strategy-claude ~6, totem-claude ~6) where an agent declared a PR "clean/done" and the operator had to surface a greptile/CR out-of-diff finding (incl. a 🔴 Critical on totem#2178). The operator caught nearly every one; agents almost never self-caught. **Doctrine alone did not hold** (recurred after banking + strategy#690): agents coped by _bypassing_ the broken `triage-pr`, which is itself the defect. ⇒ the durable fix is **mechanical**: make the tool surface it so no one has to bypass it.
 
 ### Implemented (this PR)
+
 1. **Empty-state guard** (`evaluateTriageEmptyState`) — never "Nothing to triage" when bot material was fetched (kills the false-green every miss rode).
 2. **`fetchIssueComments`** (gh api — preserves `[bot]` + `user.type`) → greptile's summary is fetched.
 3. **Marker-anchored `parseGreptileOutsideDiff`** — extract from `<!-- greptile_other_comments_section -->` to the `<sub>` footer, surface as greptile findings via the existing bot-agnostic `| Bot |` table (no new render surface, per strategy 2047Z/2217Z). FIXED, not dropped.
 4. **`parseGreptileConfidence`** — surface greptile's documented `N/5` merge-readiness score as triage context (5 prod-ready … 0–1 critical; `<5` flags likely-unaddressed findings).
 
 ### Deferred (strategy-cleared splits)
+
 - **Reactions** (👀 seen / 👍 done / 😕 review-failed) — greptile's are docs-backed, CR/GCA's are observed-only. Needs a separate `/reactions` fetch + per-bot attribution; folds into the **cross-bot status Prop-096 sub-slice** (bound to strategy#474), NOT #2192. **Build from docs, never from a guessed model** (operator constraint).
 - Greptile severity: docs are **P0/P1/P2** (no P3 — keep P3 defensively). CR/GCA SVG/emoji severity = observed artifacts.
 
 ### Validate-on-capture
+
 The exact rendering of findings UNDER the marker is unvalidated (every reachable greptile sample is post-resolution/empty). The extractor surfaces the whole block (anti-glance over-surface) and is validated against the first live greptile out-of-diff section (this PR's own review or the next).
 
 ### Blast radius (merge-time, cross-agent)
+
 Fixing the tool makes the banked workaround-memories stale across all 3 agents (totem-claude `feedback_pr_review_reply_hygiene`, lc-claude `feedback_pr_bot_comments_three_surfaces`, strategy-claude memory + `bot-protocols.md` + `review-reply/SKILL.md`). On merge: REFRAME (not delete — the fix is partial) + couple to the merge-ping (strategy lands the doctrine PR; each agent reframes its own memory). See `feedback_tool_fix_memory_blast_radius`.

--- a/.totem/specs/2192.md
+++ b/.totem/specs/2192.md
@@ -164,3 +164,60 @@ The one "degradation" row (fetch failure → warn+continue) is justified vs Tene
   - Recommendation: **A (leave as-is), note as a follow-up.** CR still matches by substring (`coderabbitai` ⊃ `coderabbit`) and greptile review bodies are empty, so there's no live miss today; switching widens the diff for no current behavior change. Flag it in the PR description.
 - **Q3 — Cohort pre-build panel, or inline?**
   - This slice is one-package (cli) + one adapter method, below the spine-slice bar; the load-bearing decisions are product choices (Q1/Q2) for you, not deep architecture. Recommendation: **inline build + external bot pass**, skip the cohort panel unless you want it.
+
+---
+
+## Revised Approach (post-live-capture + operator status-model — SUPERSEDES the greptile `<details>` parser above)
+
+Live capture (lc#617, greptile mid-review) + operator domain knowledge corrected the design. The greptile "Comments Outside Diff" `<details>` parser targets a structure **greptile does not use** (it is a CodeRabbit-only construct) — dropped. The real value is surfacing the **status signals an operator actually reads**, and ensuring nothing is under-reported, so the PR can be **read in full**.
+
+### Per-bot status model (THIS repo's config — auto-invocation + CR summary feature DISABLED)
+- **Greptile** — live-updated **summary comment** (edited in place across rounds): `<h3>Greptile Summary</h3>` · **`Confidence Score: N/5`** · Important Files Changed table · diagram. Confidence is the headline signal. Out-of-scope/deferral findings post **inline** (already handled), not in a `<details>`.
+- **CodeRabbit** — summary-page feature is **disabled here**, so CR does NOT maintain a standing updated summary (it does when auto-invocation is on — behavior is config-dependent). CR status = its review body (`pulls/reviews`, parsed) + inline + reactions. No confidence-style signal.
+- **GCA** — no summary page; **its last comment is its status**. Read the most-recent GCA comment + reactions.
+- **All three** acknowledge a tag/invocation with a **👀 reaction**; a **👍 reaction = action taken**. Grounded: lc#617 invocation → GCA 👀, greptile 👍 (via `issues/comments/{id}/reactions`, which carries reactor login + emoji).
+
+### Design conclusion
+Because bot status is **per-bot AND config-dependent**, hard-coded per-bot summary parsing is fragile. Favor robust, universal, simple signals + completeness, then read in full:
+1. **Empty-state guard** (done) — never under-report; bot-agnostic.
+2. **Reaction status on the latest invocation** (👀 ack / 👍 acted), per bot, via the `/reactions` endpoint — universal, config-independent, attributable.
+3. **Greptile Confidence Score** (N/5) — stable, greptile-specific, parsed from the summary already fetched.
+4. **Drop** `parseGreptileOutsideDiff` (dead structure; the clever-scan anti-pattern). Leave the CR review-body parser untouched (CR genuinely uses it).
+
+### New surface needed
+- `fetchCommentReactions(commentId)` (or batched) → `{ reactor, emoji }[]` via `repos/{nwo}/issues/comments/{id}/reactions` (`--paginate`). Used to compute a per-bot `👀/👍/—` status line for the latest invocation comment(s).
+
+### Official-docs grounding (3-bot research, 2026-06-24 — cited in journal)
+Confirms/corrects the model from the bots' own docs (not forensics):
+- **Reactions are DOCUMENTED for greptile, observed-only for CR/GCA.** Greptile has a dedicated Emoji Guide: **👀 = seen/in-progress (ack), 👍 = review done, 😕 = review FAILED** (`greptile.com/docs/code-review-bot/emoji-reactions`). CR's 👀-on-command-start and GCA's reactions are **undocumented** (observed implementation details). ⇒ greptile reactions are contractual; CR/GCA best-effort, coded defensively. **`😕 = greptile review failed` is a new must-surface signal** (a failed review is the exact false-green the guard exists to catch).
+- **Greptile Confidence Score is DOCUMENTED: integer `N/5`** — 5 production-ready · 4 minor-polish · 3 impl-issues · 2 significant-bugs · 0–1 critical (`/docs/code-review/first-pr-review`). Parse `Confidence Score: N/5` (NOT a percentage).
+- **"Comments Outside Diff" is CR-only — officially confirmed.** CR docs: `Outside diff range comments (N)` in the review body for findings that can't post inline. Greptile docs have **no** such `<details>` container (verified absent). ⇒ keep `parseCodeRabbitOutsideDiff`, **drop** `parseGreptileOutsideDiff`. Settled by docs, not just the live capture.
+- **Greptile 👍 is overloaded** — 👍 on its summary/trigger comment = "done"; 👍 on an *inline* comment = a human feedback vote. Disambiguate by object + reactor login.
+- **Severity (documented):** CR 🔴Critical/🟠Major/🟡Minor/🔵Trivial/⚪Info; GCA Critical/High/Medium/Low (SVG icon names undocumented — our `parseGCASeverity` keys on observed artifacts); greptile **P0/P1/P2** (P3 is undocumented — keep defensively).
+- **Summary-disable config (confirms operator's "we disabled CR summary"):** CR `reviews.high_level_summary: false`; GCA `code_review.pull_request_opened.summary` default **false**; greptile `statusCommentsEnabled` / `updateExistingSummaryComment` / `shouldUpdateDescription`. Per-bot + config-dependent — confirmed.
+- **Invocation (for parsing expectations only — operator triggers, not the CLI):** CR `@coderabbitai review|full review|summary|pause|resume`; GCA `/gemini review|summary`; greptile bare `@greptileai` (no `review` subcommand).
+
+---
+
+## FINAL (corrected) — greptile DOES emit Comments-Outside-Diff; the fix is mechanical (SUPERSEDES the "drop the parser" sections above)
+
+The earlier "greptile has no Comments-Outside-Diff — drop `parseGreptileOutsideDiff`" conclusion was **WRONG**, twice over (merged-PR forensics + a docs pass that found it undocumented). A 3-agent forensic sweep of our own session transcripts + reading strategy#689's live structure corrected it:
+
+- **Greptile DOES emit a Comments-Outside-Diff section**, anchored by the HTML-comment marker **`<!-- greptile_other_comments_section -->`**, rendered **below the flowchart**, above the `<sub>Reviews (N):…</sub>` footer (canonical per strategy#690). It is **edited away post-resolution**, so a merged/closed PR shows the marker with empty content — which is exactly why merged-PR forensics (and the official docs, which don't document it) read "absent." The marker is the empirical proof; key the parser on the **marker**, never a sampled PR shape.
+- **The failure is real, cross-agent, recurring** — transcript sweep found ~24 genuine misses (lc-claude ~12, strategy-claude ~6, totem-claude ~6) where an agent declared a PR "clean/done" and the operator had to surface a greptile/CR out-of-diff finding (incl. a 🔴 Critical on totem#2178). The operator caught nearly every one; agents almost never self-caught. **Doctrine alone did not hold** (recurred after banking + strategy#690): agents coped by *bypassing* the broken `triage-pr`, which is itself the defect. ⇒ the durable fix is **mechanical**: make the tool surface it so no one has to bypass it.
+
+### Implemented (this PR)
+1. **Empty-state guard** (`evaluateTriageEmptyState`) — never "Nothing to triage" when bot material was fetched (kills the false-green every miss rode).
+2. **`fetchIssueComments`** (gh api — preserves `[bot]` + `user.type`) → greptile's summary is fetched.
+3. **Marker-anchored `parseGreptileOutsideDiff`** — extract from `<!-- greptile_other_comments_section -->` to the `<sub>` footer, surface as greptile findings via the existing bot-agnostic `| Bot |` table (no new render surface, per strategy 2047Z/2217Z). FIXED, not dropped.
+4. **`parseGreptileConfidence`** — surface greptile's documented `N/5` merge-readiness score as triage context (5 prod-ready … 0–1 critical; `<5` flags likely-unaddressed findings).
+
+### Deferred (strategy-cleared splits)
+- **Reactions** (👀 seen / 👍 done / 😕 review-failed) — greptile's are docs-backed, CR/GCA's are observed-only. Needs a separate `/reactions` fetch + per-bot attribution; folds into the **cross-bot status Prop-096 sub-slice** (bound to strategy#474), NOT #2192. **Build from docs, never from a guessed model** (operator constraint).
+- Greptile severity: docs are **P0/P1/P2** (no P3 — keep P3 defensively). CR/GCA SVG/emoji severity = observed artifacts.
+
+### Validate-on-capture
+The exact rendering of findings UNDER the marker is unvalidated (every reachable greptile sample is post-resolution/empty). The extractor surfaces the whole block (anti-glance over-surface) and is validated against the first live greptile out-of-diff section (this PR's own review or the next).
+
+### Blast radius (merge-time, cross-agent)
+Fixing the tool makes the banked workaround-memories stale across all 3 agents (totem-claude `feedback_pr_review_reply_hygiene`, lc-claude `feedback_pr_bot_comments_three_surfaces`, strategy-claude memory + `bot-protocols.md` + `review-reply/SKILL.md`). On merge: REFRAME (not delete — the fix is partial) + couple to the merge-ping (strategy lands the doctrine PR; each agent reframes its own memory). See `feedback_tool_fix_memory_blast_radius`.

--- a/.totem/specs/2192.md
+++ b/.totem/specs/2192.md
@@ -1,0 +1,166 @@
+### Problem Statement
+The `totem triage-pr` command currently fails to surface actionable bot review findings because it only fetches inline diff comments, ignoring PR review bodies and issue-comments, and its bot-author classifier omits modern AI bots like `greptile-apps[bot]`. Furthermore, the command outputs a misleading "Nothing to triage" message even when raw inline comments were detected but filtered out by the incomplete classifier.
+
+### Architectural Context
+- **CLI Lazy-Import Policy:** Per mmnto-ai/totem#1729 CR R1, all files matching `packages/cli/src/commands/**` must use dynamic imports (`await import(...)`) for their dependencies to ensure fast CLI startup. 
+- **Bot-Tax Circuit Breaker Workflow:** The `triage-pr` command is expected to group findings into push-based rounds using `gh api repos/.../pulls/N/reviews`, but the current implementation is falling short.
+
+### Files to Examine
+1. `packages/cli/src/commands/triage-pr.ts` — Contains the `triagePrCommand` function, the early-exit output logic, and the bot classification filtering.
+2. `packages/cli/src/adapters/github-cli-pr.ts` — The data access layer. Needs to be inspected to see how it currently fetches inline comments and augmented to fetch review bodies and issue comments.
+3. `packages/cli/src/commands/triage-pr.test.ts` (or equivalent test file) — To verify test patterns for mocking GitHub CLI output and console assertions.
+
+### Technical Approach & Contracts
+We will unify the three GitHub API feedback surfaces (Inline Comments, Review Bodies, and Issue Comments) into a single actionable format before classification.
+
+**1. Data Contracts:**
+Define new TypeScript interfaces/Zod schemas in the adapter to represent the additional API payloads:
+```typescript
+interface GitHubReview {
+  id: number;
+  user: { login: string; type: string };
+  body: string;
+  state: string;
+  commit_id: string;
+}
+
+interface GitHubIssueComment {
+  id: number;
+  user: { login: string; type: string };
+  body: string;
+}
+
+// Unified interface for the CLI to process
+interface UnifiedBotFinding {
+  source: 'inline' | 'review' | 'issue_comment';
+  author: string;
+  body: string;
+  url?: string;
+}
+```
+
+**2. Adapter Enhancement:**
+Extend `GitHubCliPrAdapter` to include `getReviews(prNumber: string)` and `getIssueComments(prNumber: string)`. These MUST use the shared `safeExec` helper to call `gh api --paginate repos/{owner}/{repo}/pulls/{n}/reviews` and `.../issues/{n}/comments`.
+
+**3. Bot Classifier & Payload Parsing:**
+Update the bot author allowlist to match `greptile-apps[bot]`, `coderabbitai[bot]`, and `gemini-code-assist[bot]`. 
+In `triage-pr.ts`, parse Greptile's specific "Comments Outside Diff" by extracting content from `<details><summary>Comments Outside Diff</summary>...</details>` blocks within issue-comment bodies.
+
+**4. Output Logic Adjustment:**
+Track the `totalRawCommentsFetched` across all three surfaces. If `totalRawCommentsFetched > 0` but `classifiedBotComments === 0`, print: `"Found X comments across PR surfaces, but none were classified as bot findings. Check your bot classifier rules."` Never output "Nothing to triage" if the raw count > 0.
+
+### Edge Cases & Traps
+- **Pagination Drop:** GitHub API truncates lists to 30 items by default. The `gh api` calls MUST include the `--paginate` flag so heavily commented PRs don't drop findings.
+- **Lazy Imports:** You MUST NOT add top-level `import { safeExec } from ...` in `triage-pr.ts`. It must be dynamically imported inside the command function.
+- **Fragile HTML Parsing:** Greptile injects HTML `<details>` blocks for outside-diff comments. Use a non-greedy regex with the `s` (dotall) flag to extract this safely: `/<details>\s*<summary>.*?Comments Outside Diff.*?<\/summary>(.*?)<\/details>/is`.
+- **Bot Suffix Inconsistency:** Sometimes the GitHub API payload's `user.login` lacks the `[bot]` suffix, but `user.type` is `"Bot"`. The classifier must check both the known name list AND `user.type === 'Bot'`.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Update GitHub API Adapter Contracts & Fetchers**
+  - Modify `packages/cli/src/adapters/github-cli-pr.ts`.
+  - Add `getReviews` and `getIssueComments` methods using `safeExec`.
+  - Ensure the `--paginate` flag is passed to the `gh api` arguments.
+  - > TEST DIRECTIVE: Before implementing, write a failing test named `fetches reviews and issue comments using safeExec with paginate flag` in the adapter's test file.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Expand Bot Classifier Logic**
+  - Modify the bot classification logic (likely a helper function or regex in `triage-pr.ts` or a shared utility).
+  - Add `greptile-apps[bot]`, `greptile`, `coderabbitai[bot]`, `coderabbitai`, and `gemini-code-assist[bot]` to the allowlist.
+  - Ensure it checks `user.type === 'Bot'` as a fallback or strict condition.
+  - > TEST DIRECTIVE: Before implementing, write a failing test named `classifies greptile, coderabbit, and gemini bots correctly even without bot suffix`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Unify Feedback Surfaces in CLI Command**
+  - Modify `packages/cli/src/commands/triage-pr.ts`.
+  - > TOTEM INVARIANT (Lazy-Import Policy): Dependencies in CLI commands must be dynamically imported inside the command function. Do not add top-level imports.
+  - Dynamically import the adapter and call all three fetch methods (`getInlineComments`, `getReviews`, `getIssueComments`).
+  - Implement the Regex extraction for `<details>` blocks specifically targeting Greptile's "Comments Outside Diff" inside the issue-comment processing map.
+  - Map all results to the `UnifiedBotFinding` interface.
+  - > TEST DIRECTIVE: Before implementing, write a failing test named `extracts findings from inline comments, review bodies, and hidden outside-diff details blocks`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Fix Misleading Empty State Output**
+  - Modify the output formatting logic in `packages/cli/src/commands/triage-pr.ts`.
+  - Remove the hardcoded "No bot review comments found. Nothing to triage." string if raw comments > 0.
+  - Add logic to check `totalFetched > 0 && classified === 0` to print the warning about checking bot classifier rules.
+  - > TEST DIRECTIVE: Before implementing, write a failing test named `warns about unclassified comments instead of reporting nothing to triage when raw comments exist`.
+  - write test → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+Every implementation MUST end with these steps:
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+1. **Adapter Test:** Mock `safeExec` to return paginated GitHub API JSON for PR reviews and issue comments. Verify the adapter parses them into the correct interfaces.
+2. **Classifier Test:** Pass mock API payloads from `greptile-apps[bot]`, `user.type="Bot"` but name `"coderabbitai"`, and verify they are flagged as bot findings.
+3. **Surface Unification Test:** Provide a mocked PR with 0 inline comments, 1 CodeRabbit review body summary, and 1 Greptile issue-comment containing a `<details>` block. Verify `triage-pr` surfaces exactly 2 actionable findings.
+4. **Output Test:** Mock 2 inline comments from a human (`user.type="User"`). Run `triage-pr`. Assert the console output reads `Found 2 comments... but none were classified as bot findings` and DOES NOT output `Nothing to triage`.
+
+---
+
+## Implementation Design
+
+> **Authored against ground truth (live GitHub payloads + code map), not the issue's stated premise.** The spec above is the LLM-generated skeleton; this section corrects it where empirical reality diverges. Two premises in the issue/spec are **empirically false** and are dropped (see Negative Scope).
+
+### What 1.75.1 already fixed (so this is NOT the scope)
+PR #2244 (`5289be67`) already shipped greptile **inline** recognition (`isBotComment`/`detectBot`/`parseGreptileSeverity`), greptile in the core enums (`RecurrenceToolSchema`, `RetrospectFindingToolSchema`, `toSeverityBucket`), and CodeRabbit review-body parsing is already wired (`extractReviewBodyFindings` → `parseCodeRabbitReviewFindings` → nits + **Comments Outside Diff**). The original #2190 bug ("greptile P1/P2 inline dropped → Nothing to triage") is **fixed**.
+
+### Empirical corrections to the issue's premise (verified on PRs #2190/#2244)
+1. **Greptile does NOT use a "Comments Outside Diff" `<details>` block.** That is a **CodeRabbit** construct, posted in the CR *review body* (`pulls/{n}/reviews`) and already parsed. Greptile's review body is **empty** (`state: COMMENTED`, `body: ""`).
+2. **Greptile's only out-of-diff surface is its summary issue-comment** ("Greptile Summary" + Confidence Score + an "Important Files Changed" *table*). The table's Overview prose is descriptive, occasionally embedding a finding (#2190: *"`filesTouchedInWindow`… silently never checked in Step 2"*) but is not a clean findings list. Mining it as discrete findings = noise (violates `feedback_derived_summary_not_source_verify`).
+3. **`gh pr view --json comments/reviews` strips the `[bot]` suffix** (`greptile-apps`, `coderabbitai`), so `isBotComment`'s greptile regex (deliberately `[bot]`-required since #2244 R2, to reject humans like `alice-greptile`) fails on `gh pr view` data. The `gh api .../issues/{n}/comments` route preserves `greptile-apps[bot]` **and** returns `user.type: "Bot"` — a suffix-independent signal.
+
+### Scope (2 sentences)
+Make `triage-pr` fetch the **issue-comment surface** via `gh api` (suffix- + type-preserving), surface each recognized bot's **summary as a context line** (e.g. greptile "Confidence 5/5"), and fix the **misleading empty-state output** so "Nothing to triage" is never printed when bot-authored material was fetched. It will **NOT** mine summaries/tables for discrete findings, **NOT** build a greptile `<details>`/Outside-Diff parser (empirically absent), and **NOT** parse greptile review bodies (empirically empty).
+
+### Data model deltas
+- **`StandardIssueComment`** (new, `pr-adapter.ts`) — `{ author: string /* with [bot] */, authorType: string /* 'Bot'|'User'|'Organization' */, body: string, createdAt?: string }`. Written by the adapter; read by triage-pr (and reusable by recurrence-stats/retrospect later, out of scope here). Invariant: `author` preserves the `[bot]` suffix (guaranteed by sourcing from `gh api`, not `gh pr view`).
+- **`fetchIssueComments(prNumber): StandardIssueComment[]`** (new optional method on `PrAdapter`, implemented in `github-cli-pr.ts`) — `gh api repos/{nwo}/issues/{n}/comments --paginate`; Zod `GhIssueCommentSchema`. Optional on the interface (mirrors `fetchReviews?`) so test/mocks needn't implement it.
+- **`BotSummarySignal`** (new, parser helper) — `{ tool: BotTool, signal: string }` (e.g. `{tool:'greptile', signal:'Confidence 5/5 — safe to merge'}`). NOT a `NormalizedBotFinding` — it is context, never categorized/triaged/replied-to. Greptile confidence parsed via `/Confidence Score:\s*([0-5])\s*\/\s*5/i`; absent → no signal for that bot.
+- **No new reserved keys / sentinels.** No change to `NormalizedBotFinding`, the core enums, or persisted schemas. `(review body)` sentinel file stays as-is.
+
+### State lifecycle
+All state is **per-invocation** (one `triage-pr` run): fetched arrays + the `rawBotMaterialCount` tally are local to `triagePrCommand`, created on fetch, read once for output, never persisted or shared. No cross-lifecycle flags, no module-level state, no singletons. Ownership: `triagePrCommand` owns the tally; the adapter owns fetch; the parser helper is pure.
+
+### Failure modes
+| Failure | Category | Agent-facing surface | Recovery |
+| --- | --- | --- | --- |
+| `gh api issues/{n}/comments` non-zero exit / network | transient/runtime | **warning** ("could not fetch issue-comments: <err>; triaging inline + review-body only") + continue | inline/review surfaces still triage; named degradation (Tenet-4 compliant — not silent) |
+| Malformed JSON from gh api | runtime | warning (same as above); Zod parse error message included | continue degraded |
+| Issue-comment body has no parseable confidence score | permanent (expected) | silent — no context line for that bot | n/a (absence of a signal is not a finding) |
+| Pagination truncation (>30 comments) | permanent if unhandled | — | `--paginate` flag (mandatory) prevents it |
+| Bot login lacks `[bot]` (e.g. via a future `gh pr view` path) | permanent | recognized anyway via `authorType==='Bot'` fallback at the issue-comment seam | robust by design |
+
+The one "degradation" row (fetch failure → warn+continue) is justified vs Tenet-4: a hard error would **regress** the already-working inline triage for an additive surface; the failure is named on stderr, not dropped.
+
+### Invariants to lock in via tests
+- "Nothing to triage" is printed **only** when zero bot material was fetched across **all** surfaces (inline + review-body findings + bot issue-comments). When raw bot material > 0 but categorized findings == 0, a diagnostic (count + summary signals) is printed instead.
+- A greptile summary issue-comment (`greptile-apps[bot]`, `type:Bot`) is recognized as bot material and its `Confidence N/5` surfaces as a context line; a human issue-comment (`type:User`) is not counted as bot material.
+- Issue-comment recognition holds with the `[bot]` suffix present (gh api shape) **and** via `authorType==='Bot'` when a login substring alone wouldn't match the conservative greptile regex.
+- Existing greptile/CR/GCA **inline** categorization is unchanged (no regression) — issue-comment summaries never enter the categorized-findings path.
+- `fetchIssueComments` issues a `--paginate`d `gh api` call and preserves `[bot]` in `author`.
+- Issue-comment fetch failure emits a named warning and does not abort inline/review triage.
+
+### Open questions
+- **Q1 — Issue-comment summaries: context-line vs mined-findings?**
+  - Options: (A) count toward the output guard only; (B) **also surface a one-line context signal per bot** (confidence/verdict); (C) mine summary prose/table for discrete findings.
+  - Recommendation: **B.** Closes the issue's "the summary was also not surfaced" without the noise/false-positive risk of C (the derived-summary-not-source trap). A is the lighter fallback if you want the smallest diff.
+- **Q2 — Switch triage-pr's review-body source from `pr.reviews` (`gh pr view`, strips `[bot]`) to `fetchReviews` (`gh api`, keeps `[bot]`) for consistency with retrospect?**
+  - Options: (A) leave as-is; (B) switch.
+  - Recommendation: **A (leave as-is), note as a follow-up.** CR still matches by substring (`coderabbitai` ⊃ `coderabbit`) and greptile review bodies are empty, so there's no live miss today; switching widens the diff for no current behavior change. Flag it in the PR description.
+- **Q3 — Cohort pre-build panel, or inline?**
+  - This slice is one-package (cli) + one adapter method, below the spine-slice bar; the load-bearing decisions are product choices (Q1/Q2) for you, not deep architecture. Recommendation: **inline build + external bot pass**, skip the cohort panel unless you want it.

--- a/packages/cli/src/adapters/github-cli-pr.test.ts
+++ b/packages/cli/src/adapters/github-cli-pr.test.ts
@@ -202,6 +202,70 @@ describe('GitHubCliPrAdapter', () => {
     });
   });
 
+  describe('fetchIssueComments', () => {
+    it('maps gh API output to StandardIssueComment, preserving the [bot] suffix + user.type', () => {
+      // First call: getRepoNwo
+      mockedExec.mockReturnValueOnce('mmnto-ai/totem\n');
+      // Second call: paginated issue comments
+      mockedExec.mockReturnValueOnce(
+        JSON.stringify([
+          {
+            id: 200,
+            user: { login: 'greptile-apps[bot]', type: 'Bot' },
+            body: '<h3>Greptile Summary</h3>...',
+            created_at: '2026-06-24T00:18:06Z',
+          },
+          {
+            id: 201,
+            user: { login: 'satur8d', type: 'User' },
+            body: '/gemini review',
+            created_at: '2026-06-24T00:20:00Z',
+          },
+          {
+            id: 202,
+            user: null, // deleted/ghost account — surfaces as '' author
+            body: 'orphaned',
+          },
+        ]),
+      );
+
+      const result = adapter.fetchIssueComments(42);
+      expect(result).toEqual([
+        {
+          author: 'greptile-apps[bot]',
+          authorType: 'Bot',
+          body: '<h3>Greptile Summary</h3>...',
+          createdAt: '2026-06-24T00:18:06Z',
+        },
+        {
+          author: 'satur8d',
+          authorType: 'User',
+          body: '/gemini review',
+          createdAt: '2026-06-24T00:20:00Z',
+        },
+        { author: '', authorType: '', body: 'orphaned', createdAt: undefined },
+      ]);
+    });
+
+    it('uses the paginated issues/{n}/comments endpoint', () => {
+      mockedExec.mockReturnValueOnce('mmnto-ai/totem\n');
+      mockedExec.mockReturnValueOnce('[]');
+      adapter.fetchIssueComments(7);
+      // safeExec('gh', args, opts) — args array is the 2nd positional. Last call
+      // is the API fetch. Assert the issues-comments endpoint + --paginate via a
+      // substring (the mocked nwo is untrimmed, unlike the real trimmed safeExec).
+      const lastCallArgs = mockedExec.mock.calls.at(-1)?.[1] as string[];
+      expect(lastCallArgs.some((a) => a.includes('issues/7/comments'))).toBe(true);
+      expect(lastCallArgs).toContain('--paginate');
+    });
+
+    it('returns empty array when no issue comments', () => {
+      mockedExec.mockReturnValueOnce('mmnto-ai/totem\n');
+      mockedExec.mockReturnValueOnce('[]');
+      expect(adapter.fetchIssueComments(99)).toEqual([]);
+    });
+  });
+
   describe('fetchCodeScanningAlerts', () => {
     it('maps gh API output to StandardCodeScanAlert format', () => {
       // First call: getRepoNwo

--- a/packages/cli/src/adapters/github-cli-pr.ts
+++ b/packages/cli/src/adapters/github-cli-pr.ts
@@ -9,6 +9,7 @@ import { ghExec, ghFetchAndParse, handleGhError } from './gh-utils.js';
 import type {
   PrAdapter,
   StandardCodeScanAlert,
+  StandardIssueComment,
   StandardPr,
   StandardPrListItem,
   StandardPrReviewSubmission,
@@ -85,6 +86,17 @@ const GhPrReviewSchema = z.object({
 // concrete adapter implementation. Callers MUST null-guard `user_login` before
 // passing to `isBotComment` (deleted/ghost accounts surface as null per the
 // GitHub API).
+
+// Subset of `repos/<owner>/<repo>/issues/<N>/comments`. Sourced via `gh api`
+// (not `gh pr view`) so `user.login` keeps its `[bot]` suffix and `user.type`
+// is available — both needed to recognize a review bot's summary comment. `user`
+// is nullable for deleted/ghost accounts (mirrors the review schemas).
+const GhIssueCommentSchema = z.object({
+  id: z.number(),
+  user: z.object({ login: z.string(), type: z.string() }).nullable(),
+  body: z.string(),
+  created_at: z.string().optional(),
+});
 
 const GhCodeScanAlertSchema = z
   .object({
@@ -194,6 +206,35 @@ export class GitHubCliPrAdapter implements PrAdapter {
       submitted_at: r.submitted_at ?? undefined,
       state: r.state,
       body: r.body ?? '',
+    }));
+  }
+
+  /**
+   * Fetch PR-level issue comments (the conversation tab) via the paginated
+   * `repos/<owner>/<repo>/issues/<N>/comments` endpoint. Unlike `fetchPr`
+   * (which reads `gh pr view --json comments` and loses the `[bot]` suffix),
+   * this preserves the suffix and surfaces `user.type` so review-bot summary
+   * comments — where greptile posts its "Comments Outside Diff" findings, edited
+   * in place across rounds — are recognizable as bot material.
+   *
+   * Read-only. No GitHub mutation.
+   */
+  fetchIssueComments(prNumber: number): StandardIssueComment[] {
+    const nwo = this.getRepoNwo();
+    const comments = ghFetchAndParse(
+      ['api', `repos/${nwo}/issues/${prNumber}/comments`, '--paginate'],
+      z.array(GhIssueCommentSchema),
+      `issue comments for PR #${prNumber}`,
+      this.cwd,
+    );
+    return comments.map((c) => ({
+      // `user` may be null for deleted/ghost accounts; coerce to '' so the
+      // `StandardIssueComment.author: string` contract holds and `isBotComment('')`
+      // correctly returns false.
+      author: c.user?.login ?? '',
+      authorType: c.user?.type ?? '',
+      body: c.body,
+      createdAt: c.created_at,
     }));
   }
 

--- a/packages/cli/src/adapters/pr-adapter.ts
+++ b/packages/cli/src/adapters/pr-adapter.ts
@@ -76,6 +76,28 @@ export interface StandardPrReviewSubmission {
   body: string;
 }
 
+/**
+ * A PR-level issue comment (the "conversation" tab), as returned by
+ * `repos/<owner>/<repo>/issues/<N>/comments`. Distinct from inline review
+ * comments and from review submissions: this is where review bots post their
+ * standing **summary** comment (greptile's "Greptile Summary" / "Comments
+ * Outside Diff", CR's walkthrough), which they EDIT IN PLACE across rounds.
+ *
+ * Sourced via `gh api` (NOT `gh pr view --json comments`) on purpose: the REST
+ * route preserves the `[bot]` login suffix and exposes `user.type`, whereas
+ * `gh pr view` strips `[bot]` — which makes the conservative greptile bot-login
+ * regex miss the summary author. See `GitHubCliPrAdapter.fetchIssueComments`.
+ */
+export interface StandardIssueComment {
+  /** Login WITH the `[bot]` suffix preserved (gh api shape), or '' for ghost accounts. */
+  author: string;
+  /** GitHub account type: 'Bot' | 'User' | 'Organization' | '' — a suffix-independent bot signal. */
+  authorType: string;
+  body: string;
+  /** ISO 8601 timestamp. */
+  createdAt?: string;
+}
+
 export interface PrAdapter {
   fetchOpenPRs(): StandardPrListItem[];
   fetchPr(prNumber: number): StandardPr;
@@ -86,6 +108,13 @@ export interface PrAdapter {
    * existing adapters that only consume `fetchPr` need not implement it.
    */
   fetchReviews?(prNumber: number): StandardPrReviewSubmission[];
+  /**
+   * Fetch PR-level issue comments (the conversation tab) via `gh api`, with the
+   * `[bot]` suffix and `user.type` preserved so review-bot summary comments
+   * (greptile "Comments Outside Diff", CR walkthrough) are recognizable.
+   * Optional so existing adapters that only consume `fetchPr` need not implement it.
+   */
+  fetchIssueComments?(prNumber: number): StandardIssueComment[];
   fetchCodeScanningAlerts?(prNumber: number): StandardCodeScanAlert[];
   createIssue(params: {
     title: string;

--- a/packages/cli/src/commands/triage-pr.test.ts
+++ b/packages/cli/src/commands/triage-pr.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import type { CategorizedFinding } from '../parsers/triage-types.js';
-import { formatTriageOutput } from './triage-pr.js';
+import { evaluateTriageEmptyState, formatTriageOutput } from './triage-pr.js';
 
 // ─── Identity color functions (no ANSI for test assertions) ──
 
@@ -267,5 +267,56 @@ describe('formatTriageOutput', () => {
     expect(output).toContain('(review body)');
     expect(output).toContain('[1]');
     expect(output).toContain('[2]');
+  });
+});
+
+describe('evaluateTriageEmptyState (mmnto-ai/totem#2192)', () => {
+  const zero = {
+    botThreads: 0,
+    bodyFindings: 0,
+    botIssueComments: 0,
+    inlineComments: 0,
+    reviews: 0,
+    issueComments: 0,
+  };
+
+  it('is NOT empty when an inline bot thread exists', () => {
+    expect(evaluateTriageEmptyState({ ...zero, botThreads: 1, inlineComments: 1 }).empty).toBe(
+      false,
+    );
+  });
+
+  it('is NOT empty when only a body/summary finding exists', () => {
+    expect(evaluateTriageEmptyState({ ...zero, bodyFindings: 1, reviews: 1 }).empty).toBe(false);
+  });
+
+  it('is NOT empty when a bot summary issue-comment exists but parsed 0 findings', () => {
+    // The greptile-summary-present-but-unparsed case: must still triage, never
+    // silently return — the #2190 miss this command exists to catch.
+    expect(evaluateTriageEmptyState({ ...zero, botIssueComments: 1, issueComments: 1 }).empty).toBe(
+      false,
+    );
+  });
+
+  it('is empty with a bare message when truly nothing was fetched', () => {
+    const r = evaluateTriageEmptyState(zero);
+    expect(r.empty).toBe(true);
+    expect(r.surfaced).toBe(false);
+    expect(r.message).toContain('no comments');
+  });
+
+  it('surfaces fetched counts (never a bare "Nothing to triage") when raw comments exist but no bot authored them', () => {
+    const r = evaluateTriageEmptyState({
+      ...zero,
+      inlineComments: 2,
+      reviews: 1,
+      issueComments: 3,
+    });
+    expect(r.empty).toBe(true);
+    expect(r.surfaced).toBe(true);
+    // The whole point of #2192: surface WHAT was fetched, not a bare dismissal.
+    expect(r.message).toContain('2 inline comment(s)');
+    expect(r.message).toContain('1 review(s)');
+    expect(r.message).toContain('3 issue-comment(s)');
   });
 });

--- a/packages/cli/src/commands/triage-pr.ts
+++ b/packages/cli/src/commands/triage-pr.ts
@@ -373,14 +373,19 @@ export async function triagePrCommand(
   //     which preserves the `[bot]` suffix + `user.type` that `gh pr view` strips,
   //     so the conservative greptile bot-login regex actually matches the summary.
   const { extractReviewBodyFindings } = await import('../parsers/bot-review-parser.js');
+  const { greptileOutsideDiffSectionHasContent, parseGreptileReviewFindings } =
+    await import('../parse-nits.js');
   const reviewBodyFindings = extractReviewBodyFindings(pr.reviews);
 
   // `fetchIssueComments` is optional on the adapter interface — guard for adapters
   // and test doubles that don't implement it.
   const issueComments = adapter.fetchIssueComments?.(num) ?? [];
-  const botIssueComments = issueComments.filter(
-    (c) => c.authorType === 'Bot' || isBotComment(c.author),
-  );
+  // Filter to RECOGNIZED review bots only. The `gh api` route preserves the
+  // `[bot]` suffix, so `isBotComment` matches CR/GCA/greptile reliably — using
+  // the broad `authorType === 'Bot'` would pull in non-review automation
+  // (dependabot/renovate/github-actions), falsely suppressing "Nothing to triage"
+  // and mislabeling them `unknown` (gemini + CR + greptile review on #2246).
+  const botIssueComments = issueComments.filter((c) => isBotComment(c.author));
   const issueCommentFindings = extractReviewBodyFindings(
     botIssueComments.map((c) => ({ author: c.author, body: c.body })),
   );
@@ -434,16 +439,24 @@ export async function triagePrCommand(
   if (botThreads.length > 0) {
     log.info(TAG, `Found ${botThreads.length} bot review thread(s)`);
   }
-  // Surface bot summaries even when they yielded no parsed findings (e.g. a
-  // greptile summary present but the provisional parser matched nothing). This is
-  // a parser-COVERAGE signal, not an all-clear (Tenet 4: fetch>0 + parse==0 is a
-  // possible parser gap, never a clean empty state) — per strategy-claude on #2192.
-  if (botIssueComments.length > 0 && issueCommentFindings.length === 0) {
-    const tools = [...new Set(botIssueComments.map((c) => detectBot(c.author)))].join(', ');
+  // Parser-gap signal — narrowed to a GENUINE regression. The
+  // `greptile_other_comments_section` marker is a permanent structural element on
+  // every greptile summary (present even on a clean 5/5), and CR/GCA summaries
+  // are descriptive — so the old "any bot summary + 0 findings" check fired on
+  // virtually every clean PR, training operators to ignore it and masking real
+  // gaps (greptile P1 on #2246). Fire ONLY when greptile's out-of-diff section
+  // has actual content that extraction failed to surface — which can't happen on
+  // a clean/empty summary, only on a real parser regression.
+  const greptileParseGap = botIssueComments.some(
+    (c) =>
+      detectBot(c.author) === 'greptile' &&
+      greptileOutsideDiffSectionHasContent(c.body) &&
+      parseGreptileReviewFindings(c.body).length === 0,
+  );
+  if (greptileParseGap) {
     log.info(
       TAG,
-      `${botIssueComments.length} bot summary issue-comment(s) fetched (${tools}) but 0 parsed — ` +
-        `possible parser gap; review the PR summary directly.`,
+      'greptile posted an out-of-diff section that could not be parsed — read the PR summary directly.',
     );
   }
 
@@ -467,8 +480,11 @@ export async function triagePrCommand(
   log.info(TAG, `${categorized.length} distinct finding(s) after dedup`);
 
   // 8. Render output to stdout
-  // Count bot comments (not all review comments) + summary bodies with findings
-  const bodiesWithFindings = bodyFindings.length > 0 ? 1 : 0;
+  // Count bot comments (not all review comments) + the review-body and
+  // issue-comment summary surfaces SEPARATELY — folding both into one undercounts
+  // when CR's review body and greptile's summary both carry findings (CR on #2246).
+  const bodiesWithFindings =
+    (reviewBodyFindings.length > 0 ? 1 : 0) + (issueCommentFindings.length > 0 ? 1 : 0);
   const botCommentCount =
     reviewComments.filter((c) => isBotComment(c.author)).length + bodiesWithFindings;
   const output = formatTriageOutput(num, categorized, botCommentCount, {

--- a/packages/cli/src/commands/triage-pr.ts
+++ b/packages/cli/src/commands/triage-pr.ts
@@ -373,8 +373,6 @@ export async function triagePrCommand(
   //     which preserves the `[bot]` suffix + `user.type` that `gh pr view` strips,
   //     so the conservative greptile bot-login regex actually matches the summary.
   const { extractReviewBodyFindings } = await import('../parsers/bot-review-parser.js');
-  const { greptileOutsideDiffSectionHasContent, parseGreptileReviewFindings } =
-    await import('../parse-nits.js');
   const reviewBodyFindings = extractReviewBodyFindings(pr.reviews);
 
   // `fetchIssueComments` is optional on the adapter interface — guard for adapters
@@ -452,26 +450,11 @@ export async function triagePrCommand(
   if (botThreads.length > 0) {
     log.info(TAG, `Found ${botThreads.length} bot review thread(s)`);
   }
-  // Parser-gap signal — narrowed to a GENUINE regression. The
-  // `greptile_other_comments_section` marker is a permanent structural element on
-  // every greptile summary (present even on a clean 5/5), and CR/GCA summaries
-  // are descriptive — so the old "any bot summary + 0 findings" check fired on
-  // virtually every clean PR, training operators to ignore it and masking real
-  // gaps (greptile P1 on #2246). Fire ONLY when greptile's out-of-diff section
-  // has actual content that extraction failed to surface — which can't happen on
-  // a clean/empty summary, only on a real parser regression.
-  const greptileParseGap = botIssueComments.some(
-    (c) =>
-      detectBot(c.author) === 'greptile' &&
-      greptileOutsideDiffSectionHasContent(c.body) &&
-      parseGreptileReviewFindings(c.body).length === 0,
-  );
-  if (greptileParseGap) {
-    log.info(
-      TAG,
-      'greptile posted an out-of-diff section that could not be parsed — read the PR summary directly.',
-    );
-  }
+  // (No "parser gap" warning: the marker-anchored parser always surfaces whatever
+  // sits under the marker — falling back to the whole block — so a content-present
+  // /findings-empty "gap" is logically impossible (gemini High + greptile P1 on
+  // #2246). Anti-glance is carried by the empty-state guard, which counts a bot
+  // summary as material, plus the greptile Confidence line above.)
 
   // 6. Normalize into findings
   const findings = normalizeBotFindings(
@@ -494,12 +477,15 @@ export async function triagePrCommand(
 
   // 8. Render output to stdout
   // Count bot comments (not all review comments) + the review-body and
-  // issue-comment summary surfaces SEPARATELY — folding both into one undercounts
-  // when CR's review body and greptile's summary both carry findings (CR on #2246).
-  const bodiesWithFindings =
-    (reviewBodyFindings.length > 0 ? 1 : 0) + (issueCommentFindings.length > 0 ? 1 : 0);
+  // issue-comment summary surfaces SEPARATELY. The issue-comment surface counts
+  // when a bot summary was PRESENT (botIssueComments), not only when it parsed
+  // findings — otherwise a summary-present-but-0-findings PR renders "0 comments"
+  // right after the empty-state guard (which counts the same surface as material)
+  // intentionally kept it in triage (CR Outside-diff on #2246).
+  const bodySummarySurfaces =
+    (reviewBodyFindings.length > 0 ? 1 : 0) + (botIssueComments.length > 0 ? 1 : 0);
   const botCommentCount =
-    reviewComments.filter((c) => isBotComment(c.author)).length + bodiesWithFindings;
+    reviewComments.filter((c) => isBotComment(c.author)).length + bodySummarySurfaces;
   const output = formatTriageOutput(num, categorized, botCommentCount, {
     red: pc.default.red,
     yellow: pc.default.yellow,

--- a/packages/cli/src/commands/triage-pr.ts
+++ b/packages/cli/src/commands/triage-pr.ts
@@ -178,6 +178,59 @@ function formatLocation(finding: CategorizedFinding): string {
   return finding.file;
 }
 
+/** Surface counts feeding the empty-state decision. */
+export interface TriageSurfaceCounts {
+  /** Inline comment threads whose root author is a recognized review bot. */
+  botThreads: number;
+  /** Findings parsed from review-bodies + bot issue-comment summaries. */
+  bodyFindings: number;
+  /** Bot-authored issue comments fetched (summaries), regardless of parsed findings. */
+  botIssueComments: number;
+  /** Total inline review comments fetched (any author). */
+  inlineComments: number;
+  /** Total review submissions fetched (any author). */
+  reviews: number;
+  /** Total issue comments fetched (any author). */
+  issueComments: number;
+}
+
+/**
+ * Decide whether there is anything to triage, and — when not — what to report.
+ *
+ * Invariant (mmnto-ai/totem#2192): triage is "empty" ONLY when zero bot material
+ * was found across every surface (inline bot threads + parsed body/summary
+ * findings + bot summary issue-comments). When raw comments WERE fetched but none
+ * came from a recognized bot, the message surfaces the counts rather than a bare
+ * "Nothing to triage", so a stale/incomplete classifier can never masquerade as a
+ * clean PR (the #2190 miss). Pure + exported for testing.
+ */
+export function evaluateTriageEmptyState(counts: TriageSurfaceCounts): {
+  empty: boolean;
+  message?: string;
+  /** True when raw material existed (→ log visibly), false when the PR was truly bare. */
+  surfaced?: boolean;
+} {
+  const botMaterial = counts.botThreads + counts.bodyFindings + counts.botIssueComments;
+  if (botMaterial > 0) return { empty: false };
+
+  const rawFetched = counts.inlineComments + counts.reviews + counts.issueComments;
+  if (rawFetched === 0) {
+    return {
+      empty: true,
+      surfaced: false,
+      message: 'Nothing to triage — no comments, reviews, or issue-comments on this PR.',
+    };
+  }
+  return {
+    empty: true,
+    surfaced: true,
+    message:
+      `Fetched ${counts.inlineComments} inline comment(s), ${counts.reviews} review(s), ` +
+      `${counts.issueComments} issue-comment(s) — none from a recognized review bot. ` +
+      `Nothing to triage (no bot findings).`,
+  };
+}
+
 /**
  * Format the complete triage output. Exported for testing.
  */
@@ -308,19 +361,30 @@ export async function triagePrCommand(
   const reviewComments = adapter.fetchReviewComments(num);
   log.info(TAG, `Found ${reviewComments.length} inline review comments`);
 
-  // 3b. Extract findings from CodeRabbit review bodies (outside-diff + nits)
+  // 3b. Extract findings from review-bot SUMMARY surfaces:
+  //   - review submission bodies (CodeRabbit outside-diff + nits) from `pr.reviews`
+  //   - PR issue comments (greptile "Comments Outside Diff" summary) via `gh api`,
+  //     which preserves the `[bot]` suffix + `user.type` that `gh pr view` strips,
+  //     so the conservative greptile bot-login regex actually matches the summary.
   const { extractReviewBodyFindings } = await import('../parsers/bot-review-parser.js');
   const reviewBodyFindings = extractReviewBodyFindings(pr.reviews);
-  if (reviewBodyFindings.length > 0) {
-    log.info(TAG, `Found ${reviewBodyFindings.length} finding(s) in review bodies`);
+
+  // `fetchIssueComments` is optional on the adapter interface — guard for adapters
+  // and test doubles that don't implement it.
+  const issueComments = adapter.fetchIssueComments?.(num) ?? [];
+  const botIssueComments = issueComments.filter(
+    (c) => c.authorType === 'Bot' || isBotComment(c.author),
+  );
+  const issueCommentFindings = extractReviewBodyFindings(
+    botIssueComments.map((c) => ({ author: c.author, body: c.body })),
+  );
+
+  const bodyFindings = [...reviewBodyFindings, ...issueCommentFindings];
+  if (bodyFindings.length > 0) {
+    log.info(TAG, `Found ${bodyFindings.length} finding(s) in review/issue-comment bodies`);
   }
 
-  if (reviewComments.length === 0 && reviewBodyFindings.length === 0) {
-    log.dim(TAG, 'No review comments found. Nothing to triage.');
-    return;
-  }
-
-  // 4. Group into threads
+  // 4. Group inline comments into threads
   const threads = groupIntoThreads(reviewComments);
 
   // 5. Filter to threads starting with bot comments
@@ -328,12 +392,38 @@ export async function triagePrCommand(
     (t) => t.comments.length > 0 && isBotComment(t.comments[0]!.author),
   );
 
-  if (botThreads.length === 0 && reviewBodyFindings.length === 0) {
-    log.dim(TAG, 'No bot review comments found. Nothing to triage.');
+  // 5b. Empty-state guard (mmnto-ai/totem#2192): NEVER print a bare "Nothing to
+  // triage" when bot material was actually fetched. `triage-pr` runs live
+  // mid-review, when a bot's standing summary is in its findings-rich state;
+  // returning silently would reproduce the exact #2190 miss this command exists
+  // to catch. Bot issue-comments count as material even if the (provisional)
+  // summary parser extracted no discrete findings from them.
+  const emptyState = evaluateTriageEmptyState({
+    botThreads: botThreads.length,
+    bodyFindings: bodyFindings.length,
+    botIssueComments: botIssueComments.length,
+    inlineComments: reviewComments.length,
+    reviews: pr.reviews.length,
+    issueComments: issueComments.length,
+  });
+  if (emptyState.empty) {
+    if (emptyState.surfaced) log.info(TAG, emptyState.message!);
+    else log.dim(TAG, emptyState.message!);
     return;
   }
   if (botThreads.length > 0) {
     log.info(TAG, `Found ${botThreads.length} bot review thread(s)`);
+  }
+  // Surface bot summaries even when they yielded no parsed findings (e.g. a
+  // greptile summary present but the provisional parser matched nothing) — the
+  // operator must know a bot engaged, never see a bare "nothing".
+  if (botIssueComments.length > 0 && issueCommentFindings.length === 0) {
+    const tools = [...new Set(botIssueComments.map((c) => detectBot(c.author)))].join(', ');
+    log.info(
+      TAG,
+      `${botIssueComments.length} bot summary issue-comment(s) present (${tools}) — ` +
+        `no discrete findings parsed; review the PR summary directly.`,
+    );
   }
 
   // 6. Normalize into findings
@@ -346,8 +436,8 @@ export async function triagePrCommand(
     extractSuggestion,
   );
 
-  // Append review body findings
-  findings.push(...reviewBodyFindings);
+  // Append review-body + issue-comment summary findings
+  findings.push(...bodyFindings);
 
   log.info(TAG, `Normalized ${findings.length} bot finding(s)`);
 
@@ -356,10 +446,10 @@ export async function triagePrCommand(
   log.info(TAG, `${categorized.length} distinct finding(s) after dedup`);
 
   // 8. Render output to stdout
-  // Count bot comments (not all review comments) + review bodies with findings
-  const reviewBodiesWithFindings = reviewBodyFindings.length > 0 ? 1 : 0;
+  // Count bot comments (not all review comments) + summary bodies with findings
+  const bodiesWithFindings = bodyFindings.length > 0 ? 1 : 0;
   const botCommentCount =
-    reviewComments.filter((c) => isBotComment(c.author)).length + reviewBodiesWithFindings;
+    reviewComments.filter((c) => isBotComment(c.author)).length + bodiesWithFindings;
   const output = formatTriageOutput(num, categorized, botCommentCount, {
     red: pc.default.red,
     yellow: pc.default.yellow,

--- a/packages/cli/src/commands/triage-pr.ts
+++ b/packages/cli/src/commands/triage-pr.ts
@@ -7,7 +7,7 @@
  * and renders a compact inbox to stdout.
  */
 
-import type { StandardReviewComment } from '../adapters/pr-adapter.js';
+import type { StandardIssueComment, StandardReviewComment } from '../adapters/pr-adapter.js';
 import type { BotTool, NormalizedBotFinding } from '../parsers/bot-review-parser.js';
 import type { CategorizedFinding, TriageCategory } from '../parsers/triage-types.js';
 
@@ -378,8 +378,21 @@ export async function triagePrCommand(
   const reviewBodyFindings = extractReviewBodyFindings(pr.reviews);
 
   // `fetchIssueComments` is optional on the adapter interface — guard for adapters
-  // and test doubles that don't implement it.
-  const issueComments = adapter.fetchIssueComments?.(num) ?? [];
+  // and test doubles that don't implement it. Wrap the call so an issue-comment
+  // fetch failure (network / rate-limit / creds) DEGRADES GRACEFULLY — warn and
+  // continue with inline + review-body triage rather than crashing the whole
+  // command (Tenet 4 + the failure-recovery design in .totem/specs/2192.md;
+  // gemini High on #2246).
+  let issueComments: StandardIssueComment[] = [];
+  if (adapter.fetchIssueComments) {
+    try {
+      issueComments = adapter.fetchIssueComments(num);
+      // totem-context: intentional fail-soft-but-named (Tenet 4) — logged loudly via log.warn then continue with inline + review-body triage; never silent. Re-throwing would crash the command on a non-critical surface (gemini High #2246; failure-recovery design in 2192.md).
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.warn(TAG, `Could not fetch issue-comments: ${msg}; triaging inline + review-body only.`);
+    }
+  }
   // Filter to RECOGNIZED review bots only. The `gh api` route preserves the
   // `[bot]` suffix, so `isBotComment` matches CR/GCA/greptile reliably — using
   // the broad `authorType === 'Bot'` would pull in non-review automation

--- a/packages/cli/src/commands/triage-pr.ts
+++ b/packages/cli/src/commands/triage-pr.ts
@@ -334,8 +334,14 @@ export async function triagePrCommand(
   const { TotemConfigError } = await import('@mmnto/totem');
   const { GitHubCliPrAdapter } = await import('../adapters/github-cli-pr.js');
   const { log } = await import('../ui.js');
-  const { isBotComment, detectBot, parseSeverityForTool, stripHtmlWrappers, extractSuggestion } =
-    await import('../parsers/bot-review-parser.js');
+  const {
+    isBotComment,
+    detectBot,
+    parseSeverityForTool,
+    stripHtmlWrappers,
+    extractSuggestion,
+    parseGreptileConfidence,
+  } = await import('../parsers/bot-review-parser.js');
   const { deduplicateFindings } = await import('../parsers/triage-dedup.js');
 
   // 1. Parse and validate PR number
@@ -382,6 +388,20 @@ export async function triagePrCommand(
   const bodyFindings = [...reviewBodyFindings, ...issueCommentFindings];
   if (bodyFindings.length > 0) {
     log.info(TAG, `Found ${bodyFindings.length} finding(s) in review/issue-comment bodies`);
+  }
+
+  // Surface greptile's documented merge-readiness Confidence Score (N/5) as a
+  // triage CONTEXT signal — an operator reads it directly (5 = production-ready
+  // … 0–1 = critical). Context, not a finding; it never enters the categorized set.
+  for (const c of botIssueComments) {
+    if (detectBot(c.author) !== 'greptile') continue;
+    const score = parseGreptileConfidence(c.body);
+    if (score !== undefined) {
+      log.info(
+        TAG,
+        `greptile Confidence Score: ${score}/5${score < 5 ? ' (below 5 — unaddressed findings likely)' : ''}`,
+      );
+    }
   }
 
   // 4. Group inline comments into threads

--- a/packages/cli/src/commands/triage-pr.ts
+++ b/packages/cli/src/commands/triage-pr.ts
@@ -415,14 +415,15 @@ export async function triagePrCommand(
     log.info(TAG, `Found ${botThreads.length} bot review thread(s)`);
   }
   // Surface bot summaries even when they yielded no parsed findings (e.g. a
-  // greptile summary present but the provisional parser matched nothing) — the
-  // operator must know a bot engaged, never see a bare "nothing".
+  // greptile summary present but the provisional parser matched nothing). This is
+  // a parser-COVERAGE signal, not an all-clear (Tenet 4: fetch>0 + parse==0 is a
+  // possible parser gap, never a clean empty state) — per strategy-claude on #2192.
   if (botIssueComments.length > 0 && issueCommentFindings.length === 0) {
     const tools = [...new Set(botIssueComments.map((c) => detectBot(c.author)))].join(', ');
     log.info(
       TAG,
-      `${botIssueComments.length} bot summary issue-comment(s) present (${tools}) — ` +
-        `no discrete findings parsed; review the PR summary directly.`,
+      `${botIssueComments.length} bot summary issue-comment(s) fetched (${tools}) but 0 parsed — ` +
+        `possible parser gap; review the PR summary directly.`,
     );
   }
 

--- a/packages/cli/src/parse-nits.test.ts
+++ b/packages/cli/src/parse-nits.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  greptileOutsideDiffSectionHasContent,
   parseCodeRabbitNits,
   parseCodeRabbitOutsideDiff,
   parseCodeRabbitReviewFindings,
@@ -378,6 +379,74 @@ describe('parseGreptileOutsideDiff (marker-anchored)', () => {
 
   it('returns empty array for empty string', () => {
     expect(parseGreptileOutsideDiff('')).toEqual([]);
+  });
+
+  it('splits multiple findings on `---` rules outside code fences (CR #2246)', () => {
+    const body = [
+      '<!-- greptile_other_comments_section -->',
+      '',
+      '`src/a.ts`: first finding.',
+      '',
+      '---',
+      '',
+      '`src/b.ts`: second finding.',
+      '',
+      '<sub>Reviews (2): Last reviewed commit … | Re-trigger Greptile</sub>',
+    ].join('\n');
+    expect(parseGreptileOutsideDiff(body)).toEqual([
+      '`src/a.ts`: first finding.',
+      '`src/b.ts`: second finding.',
+    ]);
+  });
+
+  it('preserves fenced code blocks and does NOT split on an in-fence `---` (gemini #2246)', () => {
+    const fence = '```';
+    const body = [
+      '<!-- greptile_other_comments_section -->',
+      '',
+      'Suggested fix:',
+      `${fence}ts`,
+      'const x = 1;',
+      '---', // a rule-looking line INSIDE the fence must not split
+      'const y = 2;',
+      fence,
+      '',
+      '<sub>Reviews (1): … | Re-trigger Greptile</sub>',
+    ].join('\n');
+    const results = parseGreptileOutsideDiff(body);
+    expect(results).toHaveLength(1); // not split by the in-fence `---`
+    expect(results[0]).toContain('const x = 1;'); // code preserved, not stripped
+    expect(results[0]).toContain('const y = 2;');
+    expect(results[0]).toContain(fence);
+  });
+
+  it('anchors footer removal to the Reviews footer, preserving an inner <sub> (CR #2246)', () => {
+    const body = [
+      '<!-- greptile_other_comments_section -->',
+      '',
+      'Finding with an inline <sub>subscript</sub> that must survive.',
+      '',
+      '<sub>Reviews (1): … | Re-trigger Greptile</sub>',
+    ].join('\n');
+    const results = parseGreptileOutsideDiff(body);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toContain('subscript');
+    expect(results[0]).not.toMatch(/Re-trigger Greptile/);
+  });
+});
+
+describe('greptileOutsideDiffSectionHasContent (#2192 parser-gap scoping)', () => {
+  it('is true when the marker section has content', () => {
+    expect(greptileOutsideDiffSectionHasContent(GREPTILE_WITH_OUTSIDE_DIFF)).toBe(true);
+  });
+
+  it('is false when the marker is present but the section is empty (clean 5/5)', () => {
+    // The common clean case — must NOT register as a parser gap (greptile P1 #2246).
+    expect(greptileOutsideDiffSectionHasContent(GREPTILE_RESOLVED)).toBe(false);
+  });
+
+  it('is false when the marker is absent', () => {
+    expect(greptileOutsideDiffSectionHasContent('<h3>Greptile Summary</h3>\n\n5/5')).toBe(false);
   });
 });
 

--- a/packages/cli/src/parse-nits.test.ts
+++ b/packages/cli/src/parse-nits.test.ts
@@ -318,47 +318,60 @@ ${SAMPLE_OUTSIDE_DIFF_BLOCK}`;
   });
 });
 
-// ─── Greptile summary parser (PROVISIONAL — mmnto-ai/totem#2192) ──────────
+// ─── Greptile summary parser (marker-anchored — mmnto-ai/totem#2192) ──────────
 //
-// These fixtures model the GitHub `<details><summary>` convention greptile is
-// expected to use for its "Comments Outside Diff" summary block (doctrine
-// pr-review-reply-hygiene). They are NOT a captured live sample — greptile edits
-// its summary in place, so the findings-state structure cannot be recovered from
-// closed PRs. Replace/augment with a real capture from this fix's own PR review
-// before treating the matcher as load-bearing.
+// Anchored on the canonical `<!-- greptile_other_comments_section -->` marker
+// (mmnto-ai/totem-strategy#690), NOT a sampled <details> shape — greptile edits
+// its summary in place, so a closed PR shows the marker with content removed
+// post-resolution. The marker placement (below the flowchart, above the
+// `<sub>Reviews>` footer) mirrors the real strategy#689 structure; the exact
+// rendering of findings UNDER the marker is validated against a live out-of-diff
+// sample (this fix's own PR or the next one).
 
-const PROVISIONAL_GREPTILE_OUTSIDE_DIFF = `<h3>Greptile Summary</h3>
+const GREPTILE_WITH_OUTSIDE_DIFF = `<h3>Greptile Summary</h3>
 
 Some prose summary.
 
-<details>
-<summary>Comments Outside Diff</summary>
+<h3>Flowchart</h3>
+
+\`\`\`mermaid
+flowchart TD
+  A --> B
+\`\`\`
+
+<!-- greptile_other_comments_section -->
 
 \`src/scorer.ts\`: the exposure floor is accepted but never checked in Step 2.
 
-</details>`;
+<sub>Reviews (2): Last reviewed commit … | Re-trigger Greptile</sub>`;
 
-describe('parseGreptileOutsideDiff (provisional)', () => {
-  it('extracts a "Comments Outside Diff" block from a greptile summary body', () => {
-    const results = parseGreptileOutsideDiff(PROVISIONAL_GREPTILE_OUTSIDE_DIFF);
+const GREPTILE_RESOLVED = `<h3>Greptile Summary</h3>
+
+Confidence Score: 5/5 — safe to merge.
+
+<!-- greptile_other_comments_section -->
+
+<sub>Reviews (3): Last reviewed commit … | Re-trigger Greptile</sub>`;
+
+describe('parseGreptileOutsideDiff (marker-anchored)', () => {
+  it('extracts the section under the greptile_other_comments_section marker', () => {
+    const results = parseGreptileOutsideDiff(GREPTILE_WITH_OUTSIDE_DIFF);
     expect(results).toHaveLength(1);
     expect(results[0]).toContain('exposure floor');
-    expect(results[0]).not.toMatch(/<\/?details>/);
   });
 
-  it('matches the "outside the diff" phrasing variant case-insensitively', () => {
-    const body = `<details>
-<summary>Findings OUTSIDE THE DIFF</summary>
-
-An out-of-diff observation.
-
-</details>`;
-    const results = parseGreptileOutsideDiff(body);
-    expect(results).toHaveLength(1);
-    expect(results[0]).toContain('out-of-diff observation');
+  it('drops the trailing <sub>Reviews</sub> footer from the extracted section', () => {
+    const results = parseGreptileOutsideDiff(GREPTILE_WITH_OUTSIDE_DIFF);
+    expect(results[0]).not.toMatch(/Re-trigger Greptile/);
+    expect(results[0]).not.toMatch(/<sub\b/i);
   });
 
-  it('returns empty array for a summary with no outside-diff block', () => {
+  it('returns empty when the marker is present but the section is resolved/empty', () => {
+    // The post-resolution state: marker remains, content edited away.
+    expect(parseGreptileOutsideDiff(GREPTILE_RESOLVED)).toEqual([]);
+  });
+
+  it('returns empty when the marker is absent', () => {
     const body = `<h3>Greptile Summary</h3>\n\nConfidence Score: 5/5\n\nSafe to merge.`;
     expect(parseGreptileOutsideDiff(body)).toEqual([]);
   });
@@ -368,15 +381,15 @@ An out-of-diff observation.
   });
 });
 
-describe('parseGreptileReviewFindings (provisional)', () => {
-  it('types extracted blocks as outside-diff findings', () => {
-    const findings = parseGreptileReviewFindings(PROVISIONAL_GREPTILE_OUTSIDE_DIFF);
+describe('parseGreptileReviewFindings (marker-anchored)', () => {
+  it('types the extracted section as outside-diff findings', () => {
+    const findings = parseGreptileReviewFindings(GREPTILE_WITH_OUTSIDE_DIFF);
     expect(findings).toHaveLength(1);
     expect(findings[0]!.type).toBe('outside-diff');
     expect(findings[0]!.content).toContain('exposure floor');
   });
 
-  it('returns empty array when nothing matches', () => {
+  it('returns empty array when the marker section is absent', () => {
     expect(parseGreptileReviewFindings('## Just a normal summary.')).toEqual([]);
   });
 });

--- a/packages/cli/src/parse-nits.test.ts
+++ b/packages/cli/src/parse-nits.test.ts
@@ -4,6 +4,8 @@ import {
   parseCodeRabbitNits,
   parseCodeRabbitOutsideDiff,
   parseCodeRabbitReviewFindings,
+  parseGreptileOutsideDiff,
+  parseGreptileReviewFindings,
 } from './parse-nits.js';
 
 // ─── Sample CodeRabbit nit block ─────────────────────────
@@ -313,5 +315,68 @@ ${SAMPLE_OUTSIDE_DIFF_BLOCK}`;
     const findings = parseCodeRabbitReviewFindings(SAMPLE_OUTSIDE_DIFF_BLOCK);
     expect(findings.every((f) => f.type === 'outside-diff')).toBe(true);
     expect(findings).toHaveLength(1);
+  });
+});
+
+// ─── Greptile summary parser (PROVISIONAL — mmnto-ai/totem#2192) ──────────
+//
+// These fixtures model the GitHub `<details><summary>` convention greptile is
+// expected to use for its "Comments Outside Diff" summary block (doctrine
+// pr-review-reply-hygiene). They are NOT a captured live sample — greptile edits
+// its summary in place, so the findings-state structure cannot be recovered from
+// closed PRs. Replace/augment with a real capture from this fix's own PR review
+// before treating the matcher as load-bearing.
+
+const PROVISIONAL_GREPTILE_OUTSIDE_DIFF = `<h3>Greptile Summary</h3>
+
+Some prose summary.
+
+<details>
+<summary>Comments Outside Diff</summary>
+
+\`src/scorer.ts\`: the exposure floor is accepted but never checked in Step 2.
+
+</details>`;
+
+describe('parseGreptileOutsideDiff (provisional)', () => {
+  it('extracts a "Comments Outside Diff" block from a greptile summary body', () => {
+    const results = parseGreptileOutsideDiff(PROVISIONAL_GREPTILE_OUTSIDE_DIFF);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toContain('exposure floor');
+    expect(results[0]).not.toMatch(/<\/?details>/);
+  });
+
+  it('matches the "outside the diff" phrasing variant case-insensitively', () => {
+    const body = `<details>
+<summary>Findings OUTSIDE THE DIFF</summary>
+
+An out-of-diff observation.
+
+</details>`;
+    const results = parseGreptileOutsideDiff(body);
+    expect(results).toHaveLength(1);
+    expect(results[0]).toContain('out-of-diff observation');
+  });
+
+  it('returns empty array for a summary with no outside-diff block', () => {
+    const body = `<h3>Greptile Summary</h3>\n\nConfidence Score: 5/5\n\nSafe to merge.`;
+    expect(parseGreptileOutsideDiff(body)).toEqual([]);
+  });
+
+  it('returns empty array for empty string', () => {
+    expect(parseGreptileOutsideDiff('')).toEqual([]);
+  });
+});
+
+describe('parseGreptileReviewFindings (provisional)', () => {
+  it('types extracted blocks as outside-diff findings', () => {
+    const findings = parseGreptileReviewFindings(PROVISIONAL_GREPTILE_OUTSIDE_DIFF);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.type).toBe('outside-diff');
+    expect(findings[0]!.content).toContain('exposure floor');
+  });
+
+  it('returns empty array when nothing matches', () => {
+    expect(parseGreptileReviewFindings('## Just a normal summary.')).toEqual([]);
   });
 });

--- a/packages/cli/src/parse-nits.test.ts
+++ b/packages/cli/src/parse-nits.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  greptileOutsideDiffSectionHasContent,
   parseCodeRabbitNits,
   parseCodeRabbitOutsideDiff,
   parseCodeRabbitReviewFindings,
@@ -432,21 +431,6 @@ describe('parseGreptileOutsideDiff (marker-anchored)', () => {
     expect(results).toHaveLength(1);
     expect(results[0]).toContain('subscript');
     expect(results[0]).not.toMatch(/Re-trigger Greptile/);
-  });
-});
-
-describe('greptileOutsideDiffSectionHasContent (#2192 parser-gap scoping)', () => {
-  it('is true when the marker section has content', () => {
-    expect(greptileOutsideDiffSectionHasContent(GREPTILE_WITH_OUTSIDE_DIFF)).toBe(true);
-  });
-
-  it('is false when the marker is present but the section is empty (clean 5/5)', () => {
-    // The common clean case — must NOT register as a parser gap (greptile P1 #2246).
-    expect(greptileOutsideDiffSectionHasContent(GREPTILE_RESOLVED)).toBe(false);
-  });
-
-  it('is false when the marker is absent', () => {
-    expect(greptileOutsideDiffSectionHasContent('<h3>Greptile Summary</h3>\n\n5/5')).toBe(false);
   });
 });
 

--- a/packages/cli/src/parse-nits.ts
+++ b/packages/cli/src/parse-nits.ts
@@ -122,52 +122,53 @@ export function parseCodeRabbitOutsideDiff(body: string): string[] {
   return results;
 }
 
+/** The HTML-comment marker greptile emits to anchor its out-of-diff section. */
+const GREPTILE_OUTSIDE_DIFF_MARKER = '<!-- greptile_other_comments_section -->';
+
 /**
- * Extract "Comments Outside Diff" findings from a greptile SUMMARY comment body.
+ * Extract greptile's "Comments Outside Diff" findings from its SUMMARY comment.
  *
- * PROVISIONAL — best-effort pending a captured live findings-state sample
- * (mmnto-ai/totem#2192). Greptile EDITS its standing summary comment in place
- * across review rounds, so a merged/closed PR shows the post-resolution state
- * with this block already collapsed/removed — i.e. the structure cannot be
- * reverse-engineered from closed PRs (GitHub `userContentEdits` exposes edit
- * metadata, not prior bodies). This matcher is modeled on the GitHub
- * `<details><summary>` convention greptile shares with CodeRabbit, per doctrine
- * `pr-review-reply-hygiene` ("greptile 'Comments Outside Diff' (SUMMARY
- * `<details>`)"). Refine the summary-matcher against a real capture before
- * treating it as load-bearing. Mirrors {@link parseCodeRabbitOutsideDiff}.
+ * Greptile renders out-of-diff findings in the standing summary comment, BELOW
+ * the flowchart, anchored by the HTML-comment marker
+ * `<!-- greptile_other_comments_section -->` and trailed by a `<sub>Reviews (N):
+ * …</sub>` footer (mmnto-ai/totem-strategy#690; the canonical anchor). We key on
+ * the MARKER — not a sampled `<details>`/header shape — because greptile EDITS
+ * this comment in place: a merged/closed PR shows the marker with the content
+ * already removed post-resolution, so the live findings-state cannot be
+ * reverse-engineered from a closed PR (GitHub `userContentEdits` exposes edit
+ * metadata, not prior bodies). The exact rendering of findings UNDER the marker
+ * is validated against a live out-of-diff sample; until then we surface the whole
+ * block (anti-glance: over-surface beats silently dropping — the failure class
+ * this fixes). Returns [] when the section is absent or empty (resolved/none).
  */
 export function parseGreptileOutsideDiff(body: string): string[] {
   if (!body) return [];
-  // Strip fenced code blocks to avoid extracting fake matches from examples
-  const stripped = body.replace(/```[\s\S]*?```/g, '');
-  const results: string[] = [];
-  const outsideDiffRe =
-    /<details>\s*<summary>[^<]*(?:comments?\s+outside\s+(?:the\s+)?diff|outside\s+(?:the\s+)?diff(?:\s+range)?)[^<]*<\/summary>/gi;
-  let match: RegExpExecArray | null;
+  const markerIdx = body.indexOf(GREPTILE_OUTSIDE_DIFF_MARKER);
+  if (markerIdx === -1) return [];
 
-  while ((match = outsideDiffRe.exec(stripped)) !== null) {
-    const afterSummary = match.index + match[0].length;
-    const innerContent = extractNestedBlock(stripped, afterSummary);
-    if (innerContent) {
-      const cleaned = stripWrapperTags(innerContent);
-      if (cleaned) {
-        const parts = cleaned
-          .split(/\r?\n---\r?\n/)
-          .map((p) => p.trim())
-          .filter(Boolean);
-        results.push(...parts);
-      }
-    }
-  }
+  let section = body.slice(markerIdx + GREPTILE_OUTSIDE_DIFF_MARKER.length);
+  // Drop the trailing "<sub>Reviews (N): … | Re-trigger Greptile</sub>" footer.
+  const footerIdx = section.search(/<sub\b/i);
+  if (footerIdx !== -1) section = section.slice(0, footerIdx);
 
-  return results;
+  // Strip fenced code blocks to avoid splitting on `---` inside examples, then
+  // unwrap the known HTML wrappers.
+  const cleaned = stripWrapperTags(section.replace(/```[\s\S]*?```/g, '')).trim();
+  if (!cleaned) return [];
+
+  // Greptile may render multiple out-of-diff findings; split on `---` rules when
+  // present, else surface the whole block as one (refine on a live sample).
+  const parts = cleaned
+    .split(/\r?\n---\r?\n/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+  return parts.length ? parts : [cleaned];
 }
 
 /**
- * Combined parser for greptile SUMMARY-comment findings. PROVISIONAL — see
- * {@link parseGreptileOutsideDiff}. Currently only the outside-diff block is
- * extracted (greptile's per-line findings post inline, already handled by the
- * thread path); refine on a captured sample.
+ * Combined parser for greptile SUMMARY-comment findings — the marker-anchored
+ * "Comments Outside Diff" section (greptile's per-line findings post inline and
+ * are handled by the thread path). See {@link parseGreptileOutsideDiff}.
  */
 export function parseGreptileReviewFindings(
   body: string,

--- a/packages/cli/src/parse-nits.ts
+++ b/packages/cli/src/parse-nits.ts
@@ -124,6 +124,30 @@ export function parseCodeRabbitOutsideDiff(body: string): string[] {
 
 /** The HTML-comment marker greptile emits to anchor its out-of-diff section. */
 const GREPTILE_OUTSIDE_DIFF_MARKER = '<!-- greptile_other_comments_section -->';
+/**
+ * The documented greptile summary footer ("Reviews (N): … | Re-trigger
+ * Greptile"). Anchor footer removal to THIS shape, not the first `<sub>`
+ * anywhere — a greptile finding may legitimately contain an HTML subscript, and
+ * truncating at it would drop the rest of the finding (CR review on #2246).
+ */
+const GREPTILE_REVIEWS_FOOTER = /<sub\b[^>]*>\s*Reviews\b/i;
+
+/**
+ * The cleaned content of greptile's out-of-diff section — everything between the
+ * `greptile_other_comments_section` marker and the Reviews footer, HTML wrappers
+ * stripped. Returns '' when the marker is absent or the section is empty
+ * (resolved/clean). Shared by {@link parseGreptileOutsideDiff} and
+ * {@link greptileOutsideDiffSectionHasContent}.
+ */
+function greptileOutsideDiffSection(body: string): string {
+  if (!body) return '';
+  const markerIdx = body.indexOf(GREPTILE_OUTSIDE_DIFF_MARKER);
+  if (markerIdx === -1) return '';
+  let section = body.slice(markerIdx + GREPTILE_OUTSIDE_DIFF_MARKER.length);
+  const footerIdx = section.search(GREPTILE_REVIEWS_FOOTER);
+  if (footerIdx !== -1) section = section.slice(0, footerIdx);
+  return stripWrapperTags(section).trim();
+}
 
 /**
  * Extract greptile's "Comments Outside Diff" findings from its SUMMARY comment.
@@ -136,32 +160,29 @@ const GREPTILE_OUTSIDE_DIFF_MARKER = '<!-- greptile_other_comments_section -->';
  * this comment in place: a merged/closed PR shows the marker with the content
  * already removed post-resolution, so the live findings-state cannot be
  * reverse-engineered from a closed PR (GitHub `userContentEdits` exposes edit
- * metadata, not prior bodies). The exact rendering of findings UNDER the marker
- * is validated against a live out-of-diff sample; until then we surface the whole
- * block (anti-glance: over-surface beats silently dropping — the failure class
- * this fixes). Returns [] when the section is absent or empty (resolved/none).
+ * metadata, not prior bodies). Returns [] when the section is absent or empty
+ * (resolved/none).
  */
 export function parseGreptileOutsideDiff(body: string): string[] {
-  if (!body) return [];
-  const markerIdx = body.indexOf(GREPTILE_OUTSIDE_DIFF_MARKER);
-  if (markerIdx === -1) return [];
-
-  let section = body.slice(markerIdx + GREPTILE_OUTSIDE_DIFF_MARKER.length);
-  // Drop the trailing "<sub>Reviews (N): … | Re-trigger Greptile</sub>" footer.
-  const footerIdx = section.search(/<sub\b/i);
-  if (footerIdx !== -1) section = section.slice(0, footerIdx);
-
-  // Strip fenced code blocks to avoid splitting on `---` inside examples, then
-  // unwrap the known HTML wrappers.
-  const cleaned = stripWrapperTags(section.replace(/```[\s\S]*?```/g, '')).trim();
+  const cleaned = greptileOutsideDiffSection(body);
   if (!cleaned) return [];
 
-  // Greptile may render multiple out-of-diff findings; split on `---` rules when
-  // present, else surface the whole block as one (refine on a live sample).
-  const parts = cleaned
-    .split(/\r?\n---\r?\n/)
-    .map((p) => p.trim())
-    .filter(Boolean);
+  // Greptile may render multiple out-of-diff findings separated by `---` rules.
+  // Split on `---` ONLY outside fenced code blocks: greptile findings embed code
+  // examples/suggestions, and stripping or splitting through fences deletes that
+  // content from the surfaced finding (gemini review on #2246). Toggle on ```.
+  const FENCE = '```';
+  const groups: string[][] = [[]];
+  let inFence = false;
+  for (const line of cleaned.split(/\r?\n/)) {
+    if (line.trimStart().startsWith(FENCE)) inFence = !inFence;
+    if (!inFence && line.trim() === '---') {
+      groups.push([]);
+    } else {
+      groups[groups.length - 1]!.push(line);
+    }
+  }
+  const parts = groups.map((g) => g.join('\n').trim()).filter(Boolean);
   return parts.length ? parts : [cleaned];
 }
 
@@ -174,6 +195,18 @@ export function parseGreptileReviewFindings(
   body: string,
 ): Array<{ type: 'outside-diff'; content: string }> {
   return parseGreptileOutsideDiff(body).map((content) => ({ type: 'outside-diff', content }));
+}
+
+/**
+ * Whether greptile's out-of-diff section has actual content the parser should
+ * have extracted. The marker is a PERMANENT structural element on every greptile
+ * summary (present even on a clean 5/5), so "a bot summary is present but we
+ * parsed 0 findings" cried wolf on every clean PR (greptile P1 on #2246). This
+ * narrows a genuine parser gap to: the section has content yet extraction yielded
+ * nothing — a real regression, never the routine empty/clean case.
+ */
+export function greptileOutsideDiffSectionHasContent(body: string): boolean {
+  return greptileOutsideDiffSection(body).length > 0;
 }
 
 /**

--- a/packages/cli/src/parse-nits.ts
+++ b/packages/cli/src/parse-nits.ts
@@ -123,6 +123,59 @@ export function parseCodeRabbitOutsideDiff(body: string): string[] {
 }
 
 /**
+ * Extract "Comments Outside Diff" findings from a greptile SUMMARY comment body.
+ *
+ * PROVISIONAL — best-effort pending a captured live findings-state sample
+ * (mmnto-ai/totem#2192). Greptile EDITS its standing summary comment in place
+ * across review rounds, so a merged/closed PR shows the post-resolution state
+ * with this block already collapsed/removed — i.e. the structure cannot be
+ * reverse-engineered from closed PRs (GitHub `userContentEdits` exposes edit
+ * metadata, not prior bodies). This matcher is modeled on the GitHub
+ * `<details><summary>` convention greptile shares with CodeRabbit, per doctrine
+ * `pr-review-reply-hygiene` ("greptile 'Comments Outside Diff' (SUMMARY
+ * `<details>`)"). Refine the summary-matcher against a real capture before
+ * treating it as load-bearing. Mirrors {@link parseCodeRabbitOutsideDiff}.
+ */
+export function parseGreptileOutsideDiff(body: string): string[] {
+  if (!body) return [];
+  // Strip fenced code blocks to avoid extracting fake matches from examples
+  const stripped = body.replace(/```[\s\S]*?```/g, '');
+  const results: string[] = [];
+  const outsideDiffRe =
+    /<details>\s*<summary>[^<]*(?:comments?\s+outside\s+(?:the\s+)?diff|outside\s+(?:the\s+)?diff(?:\s+range)?)[^<]*<\/summary>/gi;
+  let match: RegExpExecArray | null;
+
+  while ((match = outsideDiffRe.exec(stripped)) !== null) {
+    const afterSummary = match.index + match[0].length;
+    const innerContent = extractNestedBlock(stripped, afterSummary);
+    if (innerContent) {
+      const cleaned = stripWrapperTags(innerContent);
+      if (cleaned) {
+        const parts = cleaned
+          .split(/\r?\n---\r?\n/)
+          .map((p) => p.trim())
+          .filter(Boolean);
+        results.push(...parts);
+      }
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Combined parser for greptile SUMMARY-comment findings. PROVISIONAL — see
+ * {@link parseGreptileOutsideDiff}. Currently only the outside-diff block is
+ * extracted (greptile's per-line findings post inline, already handled by the
+ * thread path); refine on a captured sample.
+ */
+export function parseGreptileReviewFindings(
+  body: string,
+): Array<{ type: 'outside-diff'; content: string }> {
+  return parseGreptileOutsideDiff(body).map((content) => ({ type: 'outside-diff', content }));
+}
+
+/**
  * Combined parser that extracts both nitpick and outside-diff findings
  * from a CodeRabbit review body, returning typed results.
  */

--- a/packages/cli/src/parse-nits.ts
+++ b/packages/cli/src/parse-nits.ts
@@ -198,18 +198,6 @@ export function parseGreptileReviewFindings(
 }
 
 /**
- * Whether greptile's out-of-diff section has actual content the parser should
- * have extracted. The marker is a PERMANENT structural element on every greptile
- * summary (present even on a clean 5/5), so "a bot summary is present but we
- * parsed 0 findings" cried wolf on every clean PR (greptile P1 on #2246). This
- * narrows a genuine parser gap to: the section has content yet extraction yielded
- * nothing — a real regression, never the routine empty/clean case.
- */
-export function greptileOutsideDiffSectionHasContent(body: string): boolean {
-  return greptileOutsideDiffSection(body).length > 0;
-}
-
-/**
  * Combined parser that extracts both nitpick and outside-diff findings
  * from a CodeRabbit review body, returning typed results.
  */

--- a/packages/cli/src/parsers/bot-review-parser.test.ts
+++ b/packages/cli/src/parsers/bot-review-parser.test.ts
@@ -616,4 +616,30 @@ describe('decline taxonomy (mmnto-ai/totem#2124)', () => {
     expect(findings).toHaveLength(1);
     expect(findings[0]!.disposition).toBeUndefined();
   });
+
+  it('extractReviewBodyFindings: dispatches the greptile branch for a greptile summary (mmnto-ai/totem#2192, provisional)', () => {
+    // Sourced via gh api → author keeps the [bot] suffix the greptile regex needs.
+    const body = [
+      '<h3>Greptile Summary</h3>',
+      '',
+      '<details>',
+      '<summary>Comments Outside Diff</summary>',
+      '',
+      '`src/scorer.ts`: exposure floor accepted but never checked.',
+      '',
+      '</details>',
+    ].join('\n');
+    const findings = extractReviewBodyFindings([{ author: 'greptile-apps[bot]', body }]);
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.tool).toBe('greptile');
+    expect(findings[0]!.body).toContain('exposure floor');
+    expect(findings[0]!.file).toBe('(review body)');
+  });
+
+  it('extractReviewBodyFindings: ignores a greptile summary with no outside-diff block', () => {
+    const findings = extractReviewBodyFindings([
+      { author: 'greptile-apps[bot]', body: '<h3>Greptile Summary</h3>\n\nConfidence Score: 5/5' },
+    ]);
+    expect(findings).toEqual([]);
+  });
 });

--- a/packages/cli/src/parsers/bot-review-parser.test.ts
+++ b/packages/cli/src/parsers/bot-review-parser.test.ts
@@ -11,6 +11,7 @@ import {
   isThreadResolved,
   parseCRSeverity,
   parseGCASeverity,
+  parseGreptileConfidence,
   parseGreptileSeverity,
   parseSeverityForTool,
   stripHtmlWrappers,
@@ -617,17 +618,17 @@ describe('decline taxonomy (mmnto-ai/totem#2124)', () => {
     expect(findings[0]!.disposition).toBeUndefined();
   });
 
-  it('extractReviewBodyFindings: dispatches the greptile branch for a greptile summary (mmnto-ai/totem#2192, provisional)', () => {
+  it('extractReviewBodyFindings: dispatches the greptile branch via the outside-diff marker (mmnto-ai/totem#2192)', () => {
     // Sourced via gh api → author keeps the [bot] suffix the greptile regex needs.
+    // Marker-anchored (strategy#690), mirroring the real greptile summary shape.
     const body = [
       '<h3>Greptile Summary</h3>',
       '',
-      '<details>',
-      '<summary>Comments Outside Diff</summary>',
+      '<!-- greptile_other_comments_section -->',
       '',
       '`src/scorer.ts`: exposure floor accepted but never checked.',
       '',
-      '</details>',
+      '<sub>Reviews (1): Last reviewed commit … | Re-trigger Greptile</sub>',
     ].join('\n');
     const findings = extractReviewBodyFindings([{ author: 'greptile-apps[bot]', body }]);
     expect(findings).toHaveLength(1);
@@ -641,5 +642,17 @@ describe('decline taxonomy (mmnto-ai/totem#2124)', () => {
       { author: 'greptile-apps[bot]', body: '<h3>Greptile Summary</h3>\n\nConfidence Score: 5/5' },
     ]);
     expect(findings).toEqual([]);
+  });
+
+  it('parseGreptileConfidence: extracts the N/5 score (mmnto-ai/totem#2192)', () => {
+    expect(parseGreptileConfidence('<h3>Confidence Score: 4/5</h3>\n\nMinor polish.')).toBe(4);
+    expect(parseGreptileConfidence('Confidence Score: 5 / 5')).toBe(5);
+    expect(parseGreptileConfidence('Confidence Score: 0/5')).toBe(0);
+  });
+
+  it('parseGreptileConfidence: returns undefined when no score is present', () => {
+    expect(parseGreptileConfidence('<h3>Greptile Summary</h3>\n\nSafe to merge.')).toBeUndefined();
+    // Not a percentage — must be N/5.
+    expect(parseGreptileConfidence('Confidence: 90%')).toBeUndefined();
   });
 });

--- a/packages/cli/src/parsers/bot-review-parser.test.ts
+++ b/packages/cli/src/parsers/bot-review-parser.test.ts
@@ -655,4 +655,10 @@ describe('decline taxonomy (mmnto-ai/totem#2124)', () => {
     // Not a percentage — must be N/5.
     expect(parseGreptileConfidence('Confidence: 90%')).toBeUndefined();
   });
+
+  it('parseGreptileConfidence: does not misread `5/50` as `5/5` (CR #2246)', () => {
+    // The `(?!\d)` denominator boundary prevents a false merge-readiness signal.
+    expect(parseGreptileConfidence('Confidence Score: 5/50')).toBeUndefined();
+    expect(parseGreptileConfidence('Confidence Score: 4/55')).toBeUndefined();
+  });
 });

--- a/packages/cli/src/parsers/bot-review-parser.ts
+++ b/packages/cli/src/parsers/bot-review-parser.ts
@@ -7,7 +7,7 @@
  * developer actually fixed.
  */
 
-import { parseCodeRabbitReviewFindings } from '../parse-nits.js';
+import { parseCodeRabbitReviewFindings, parseGreptileReviewFindings } from '../parse-nits.js';
 
 // ─── Types ──────────────────────────────────────────
 
@@ -232,8 +232,13 @@ export function isThreadResolved(thread: CommentThread): boolean {
  * Only returns findings from threads that were resolved positively.
  */
 /**
- * Extract findings from CodeRabbit review bodies (outside-diff + nits).
- * Shared by triage-pr and review-learn to avoid duplication.
+ * Extract findings from review-bot SUMMARY bodies (CodeRabbit outside-diff + nits,
+ * greptile "Comments Outside Diff"). Surface-agnostic: callers pass review
+ * submission bodies (`fetchReviews`/`pr.reviews`) AND PR issue comments
+ * (`fetchIssueComments`) — bots post these standing summaries on different
+ * surfaces (CR in the review body, greptile in the issue-comment summary) and
+ * edit them in place across rounds. Overlap between surfaces is collapsed
+ * downstream by `deduplicateFindings`. Shared by triage-pr and review-learn.
  */
 export function extractReviewBodyFindings(
   reviews: Array<{ author: string; body: string }>,
@@ -245,9 +250,12 @@ export function extractReviewBodyFindings(
     const tool = detectBot(review.author);
     let parsed: Array<{ type: 'nitpick' | 'outside-diff'; content: string }> = [];
 
-    // Only CodeRabbit parser is implemented for now
     if (tool === 'coderabbit') {
       parsed = parseCodeRabbitReviewFindings(review.body);
+    } else if (tool === 'greptile') {
+      // PROVISIONAL greptile summary parser (mmnto-ai/totem#2192) — see
+      // `parseGreptileOutsideDiff`. Refine against a captured live sample.
+      parsed = parseGreptileReviewFindings(review.body);
     }
 
     for (const finding of parsed) {

--- a/packages/cli/src/parsers/bot-review-parser.ts
+++ b/packages/cli/src/parsers/bot-review-parser.ts
@@ -147,6 +147,18 @@ export function parseGreptileSeverity(body: string): string {
 }
 
 /**
+ * Extract greptile's documented merge-readiness Confidence Score (`N/5`, integer
+ * 0–5) from its summary comment — 5 production-ready … 0–1 critical problems
+ * (greptile docs: code-review/first-pr-review). A status signal surfaced as
+ * triage context (NOT a finding); returns `undefined` when no score is present.
+ * Parsed as `N/5`, never a percentage.
+ */
+export function parseGreptileConfidence(body: string): number | undefined {
+  const m = body.match(/Confidence Score:\s*([0-5])\s*\/\s*5/i);
+  return m ? Number(m[1]) : undefined;
+}
+
+/**
  * Single source of truth for "which severity parser applies to which bot".
  * Keeps the per-tool dispatch in one place so adding a bot does not require
  * touching every finding-normalizer (triage-pr, extractResolved, extractPushback).

--- a/packages/cli/src/parsers/bot-review-parser.ts
+++ b/packages/cli/src/parsers/bot-review-parser.ts
@@ -154,7 +154,9 @@ export function parseGreptileSeverity(body: string): string {
  * Parsed as `N/5`, never a percentage.
  */
 export function parseGreptileConfidence(body: string): number | undefined {
-  const m = body.match(/Confidence Score:\s*([0-5])\s*\/\s*5/i);
+  // `(?!\d)` bounds the denominator so `Confidence Score: 5/50` is not misread
+  // as `5/5` (a false merge-readiness signal) — CR review on #2246.
+  const m = body.match(/Confidence Score:\s*([0-5])\s*\/\s*5(?!\d)/i);
   return m ? Number(m[1]) : undefined;
 }
 


### PR DESCRIPTION
## What

Makes `totem triage-pr` **mechanically surface** the bot-review surfaces agents have been glancing past — so the tool, not willpower, enforces the "read every surface, in full" discipline.

- **Empty-state guard** (`evaluateTriageEmptyState`) — never prints "Nothing to triage" when bot material was fetched. When raw comments exist but none are bot-authored it reports per-surface counts; a bot summary present always keeps the PR in triage. This kills the premature-"clean" false-green.
- **`fetchIssueComments`** — fetches the PR issue-comment surface via `gh api` (preserving the `[bot]` suffix + `user.type` that `gh pr view` strips), so a review bot's standing summary is recognized as bot material.
- **Marker-anchored greptile Comments-Outside-Diff** (`parseGreptileOutsideDiff`) — extracts from the `<!-- greptile_other_comments_section -->` marker to the `<sub>Reviews>` footer, surfaced via the **existing** bot-agnostic triage table (no new render surface). Keyed on the durable marker, not a sampled `<details>` shape — greptile edits its summary in place, so a closed PR shows the marker with content already removed.
- **`parseGreptileConfidence`** — greptile's documented `N/5` merge-readiness score surfaced as triage context (`< 5` flags likely-unaddressed findings).

## Why

A 3-agent forensic sweep of our own session transcripts found **~24 genuine cross-agent misses** (lc-claude ~12, strategy-claude ~6, totem-claude ~6) where an agent declared a PR "clean/done" and the operator had to surface a greptile/CR out-of-diff finding — including a 🔴 Critical workflow template-injection on #2178. Doctrine + memory helped but **didn't hold** (recurred after banking); agents coped by *bypassing* the broken tool, which is itself the defect. This is the **mechanical complement** to the merged `mmnto-ai/totem-strategy#690` "read to the end of the body" doctrine — so no one has to remember to bypass `triage-pr`.

## Scope (Tenet 5)

- **In:** empty-state guard · greptile summary fetch · marker-anchored Comments-Outside-Diff · greptile confidence `N/5`.
- **Deferred** (strategy-cleared → Prop-096 sub-slice, bound to `mmnto-ai/totem-strategy#474`): reactions (greptile 👀/👍/😕 documented; CR/GCA observed-only) · the cross-bot status model · cross-bot finding-identity dedup.

CodeRabbit's own "Outside diff range comments" parser is untouched (CR genuinely uses a `<details>` block). recurrence-stats/retrospect stay triage-only (`mmnto-ai/totem-strategy#739`).

## Validate-on-capture

Every reachable greptile sample is post-resolution (marker present, content edited away), so the exact rendering *under* the marker is unvalidated. The extractor over-surfaces the whole block (anti-glance — over-surface beats silently dropping); it will be tightened against the first live greptile out-of-diff section.

## Coordination / blast radius

Part of #2192. On merge, the cross-agent workaround-memories get **reframed, not deleted** (coupled to the merge, since each is only obsolete once the fix is in): totem-claude `feedback_pr_review_reply_hygiene` + lc-claude `feedback_pr_bot_comments_three_surfaces` + the `bot-protocols.md` / `review-reply` doctrine PR (`mmnto-ai/totem-strategy#690` lane).

## Test / gate

build · full cli suite (2800) · ESLint 0-err · prettier · `totem lint` PASS · changeset. New tests cover `fetchIssueComments`, the marker-anchored parser, `parseGreptileConfidence`, and the empty-state guard.

Design doc + full forensic evidence: `.totem/specs/2192.md`.
