### PR TITLE
feat(parity): value-equality detector for bot-review-config rows (strategy#738 Slice A)

### DIFF
--- a/.changeset/value-equality-parity-738.md
+++ b/.changeset/value-equality-parity-738.md
@@ -1,0 +1,8 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+---
+
+feat(parity): value-equality detector for bot-review-config rows (strategy#738 Slice A)
+
+Adds `detectValueEqualityContract` (core) + a `manifestation: value-equality` route and `valueEqualityFieldsFor` registry (CLI `doctor --parity`), promoting the `bot-review-configs` manifest rows from `attestation` to a present-level mechanical scalar check. Reads a scalar at a dotted path in the consumer's on-disk config (`.coderabbit.yaml` / `.gemini/config.yaml` / `greptile.json`) and compares it — typed (never blanket-stringified), zero-network — against the row's own `expected-value-or-derivation`. Honest-absent taxonomy: file-absent → `skip` (scaffold), path-absent/mismatch → `warn`, unparseable → `unknown`. Adds the `value-equality` rung to the §6(a)2 ladder. The strategy-owned manifest row flip couples to this engine on merge.

--- a/packages/cli/src/commands/doctor-parity.test.ts
+++ b/packages/cli/src/commands/doctor-parity.test.ts
@@ -407,6 +407,23 @@ describe('checkParity — value-equality wiring (strategy#738 Slice A)', () => {
     expect(line.status).toBe('skip');
     expect(line.message).toMatch(/not yet implemented/i);
   });
+
+  it('SKIP — not a consumer comes from the core self-guard (no CLI consumersSkip)', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    // Scope the row to a different repo; this tmpDir repo is not in `consumers`.
+    const scoped = VALUE_EQUALITY_MANIFEST_YAML.replace(
+      'tracking-issue: mmnto-ai/totem-strategy#501\n',
+      'tracking-issue: mmnto-ai/totem-strategy#501\n    consumers:\n      - some-other-repo\n',
+    );
+    writeManifest('m.yaml', scoped);
+    writeCoderabbit('chill'); // would be a drift warn if this repo were a consumer
+
+    const { results, blockingDriftIds } = await checkParity(tmpDir);
+    const line = results.find((r) => r.name === 'Parity: cr-profile')!;
+    expect(line.status).toBe('skip');
+    expect(line.message).toMatch(/not in consumers|repo id unresolvable/i);
+    expect(blockingDriftIds).toHaveLength(0);
+  });
 });
 
 // ─── mechanical skills detection wiring (#2073) ─────────

--- a/packages/cli/src/commands/doctor-parity.test.ts
+++ b/packages/cli/src/commands/doctor-parity.test.ts
@@ -316,6 +316,99 @@ describe('checkParity — version-pinned wiring', () => {
   });
 });
 
+// ─── value-equality detection wiring (strategy#738 Slice A) ─────────
+
+/** A manifest with the cr-profile value-equality contract (no consumers = applies). */
+const VALUE_EQUALITY_MANIFEST_YAML = `schema-version: 1
+status: scaffold
+contracts:
+  - id: cr-profile
+    dimension: bot-review-configs
+    canonical-source: mmnto-ai/totem-strategy:.coderabbit.yaml#reviews.profile
+    detection-method: file-value-equality
+    expected-value-or-derivation: assertive
+    tractability: mechanical
+    manifestation: value-equality
+    tracking-issue: mmnto-ai/totem-strategy#501
+`;
+
+/** Same row marked blocking — exercises the --strict promotion seam through value-equality routing. */
+const BLOCKING_VALUE_EQUALITY_MANIFEST_YAML = VALUE_EQUALITY_MANIFEST_YAML.replace(
+  'tracking-issue: mmnto-ai/totem-strategy#501\n',
+  'tracking-issue: mmnto-ai/totem-strategy#501\n    blocking: true\n',
+);
+
+/** A value-equality manifest naming an id the registry does not handle → routing stub. */
+const UNHANDLED_VALUE_EQUALITY_MANIFEST_YAML = VALUE_EQUALITY_MANIFEST_YAML.replace(
+  'id: cr-profile',
+  'id: not-a-real-bot-row',
+);
+
+/** Write a `.coderabbit.yaml` with a given reviews.profile scalar. */
+function writeCoderabbit(profile: string): void {
+  fs.writeFileSync(
+    path.join(tmpDir, '.coderabbit.yaml'),
+    `reviews:\n  profile: ${profile}\n`,
+    'utf-8',
+  );
+}
+
+describe('checkParity — value-equality wiring (strategy#738 Slice A)', () => {
+  it('PASS — on-disk scalar matches the manifest expected', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', VALUE_EQUALITY_MANIFEST_YAML);
+    writeCoderabbit('assertive');
+
+    const { results, blockingDriftIds } = await checkParity(tmpDir);
+    const line = results.find((r) => r.name === 'Parity: cr-profile')!;
+    expect(line.status).toBe('pass');
+    expect(blockingDriftIds).toHaveLength(0);
+  });
+
+  it('WARN — scalar drift, no blocking promotion on a non-blocking row', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', VALUE_EQUALITY_MANIFEST_YAML);
+    writeCoderabbit('chill');
+
+    const { results, blockingDriftIds } = await checkParity(tmpDir);
+    const line = results.find((r) => r.name === 'Parity: cr-profile')!;
+    expect(line.status).toBe('warn');
+    expect(line.message).toContain('assertive'); // expected surfaced
+    expect(blockingDriftIds).toHaveLength(0);
+  });
+
+  it('a blocking value-equality drift tags blockingDriftIds (the --strict seam)', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', BLOCKING_VALUE_EQUALITY_MANIFEST_YAML);
+    writeCoderabbit('chill');
+
+    const { results, blockingDriftIds } = await checkParity(tmpDir);
+    const line = results.find((r) => r.name === 'Parity: cr-profile')!;
+    expect(line.status).toBe('warn'); // the check itself never fails
+    expect(blockingDriftIds).toEqual(['cr-profile']);
+  });
+
+  it('SKIP — file wholly absent is the applicable-but-missing scaffold skip', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', VALUE_EQUALITY_MANIFEST_YAML);
+    // No .coderabbit.yaml written.
+
+    const { results } = await checkParity(tmpDir);
+    const line = results.find((r) => r.name === 'Parity: cr-profile')!;
+    expect(line.status).toBe('skip');
+  });
+
+  it('an unhandled value-equality row id → routing stub, not a crash', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
+    writeManifest('m.yaml', UNHANDLED_VALUE_EQUALITY_MANIFEST_YAML);
+
+    const { results } = await checkParity(tmpDir);
+    const line = results.find((r) => r.name === 'Parity: not-a-real-bot-row')!;
+    expect(line.status).toBe('skip');
+    expect(line.message).toMatch(/not yet implemented/i);
+  });
+});
+
 // ─── mechanical skills detection wiring (#2073) ─────────
 
 /** A manifest with the claude-skills mechanical contract (all distributed skills). */

--- a/packages/cli/src/commands/doctor-parity.test.ts
+++ b/packages/cli/src/commands/doctor-parity.test.ts
@@ -410,7 +410,11 @@ describe('checkParity — value-equality wiring (strategy#738 Slice A)', () => {
 
   it('SKIP — not a consumer comes from the core self-guard (no CLI consumersSkip)', async () => {
     writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: m.yaml\n`);
-    // Scope the row to a different repo; this tmpDir repo is not in `consumers`.
+    // Pin a resolvable repo id ('consumer-repo' via package.json name) so the skip
+    // provably comes from the consumers branch, NOT from an unresolvable id (CR
+    // review on #2249).
+    writeConsumerDeps({});
+    // Scope the row to a different repo; 'consumer-repo' is not in `consumers`.
     const scoped = VALUE_EQUALITY_MANIFEST_YAML.replace(
       'tracking-issue: mmnto-ai/totem-strategy#501\n',
       'tracking-issue: mmnto-ai/totem-strategy#501\n    consumers:\n      - some-other-repo\n',
@@ -421,7 +425,9 @@ describe('checkParity — value-equality wiring (strategy#738 Slice A)', () => {
     const { results, blockingDriftIds } = await checkParity(tmpDir);
     const line = results.find((r) => r.name === 'Parity: cr-profile')!;
     expect(line.status).toBe('skip');
-    expect(line.message).toMatch(/not in consumers|repo id unresolvable/i);
+    // Specifically the consumers branch — names the resolved id, so an unresolvable
+    // id would fail this assertion rather than pass on a different skip reason.
+    expect(line.message).toMatch(/consumer-repo not in consumers/i);
     expect(blockingDriftIds).toHaveLength(0);
   });
 });

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -40,7 +40,12 @@
 
 import * as path from 'node:path';
 
-import type { ManagedBlockMarkers, ParityContract, ParityContractVerdict } from '@mmnto/totem';
+import type {
+  ManagedBlockMarkers,
+  ParityContract,
+  ParityContractVerdict,
+  ValueEqualityField,
+} from '@mmnto/totem';
 
 // init-templates (large canonical strings) + the node:url / node:module builtins
 // are dynamic-imported inside checkParity per the packages/cli lazy-load
@@ -139,6 +144,74 @@ function mechanicalArtifactsFor(
           markers,
           canonicalBlock: extract(templates.reviewReplyContent, markers),
           lineName: 'Parity: review-reply-skill-content',
+        },
+      ];
+    default:
+      return undefined;
+  }
+}
+
+// ─── Value-equality field registry (CLI-side, mmnto-ai/totem-strategy#738 Slice A) ──
+
+/**
+ * Resolve the on-disk config field(s) a `manifestation: value-equality` contract
+ * checks, or `undefined` when this slice doesn't handle the id (→ a `skip` stub).
+ * Each entry carries WHERE to look (file + dotted-path SEGMENTS + parse format);
+ * the EXPECTED value is read by the detector from the contract's own
+ * `expectedValueOrDerivation` (strategy#738 Q1 — the manifest field is the
+ * canonical, no second source). Paths are pre-verified against the live cohort
+ * config shapes: GCA nests its switches under a top-level `code_review:` block
+ * (`code_review.pull_request_opened.*`), and `gca-on-demand` is split into two
+ * independent rows per the strategy#738 Q3 ruling (each switch drifts on its own).
+ */
+function valueEqualityFieldsFor(
+  contractId: string,
+  gitRoot: string,
+): ValueEqualityField[] | undefined {
+  switch (contractId) {
+    case 'cr-profile':
+      return [
+        {
+          consumerPath: path.join(gitRoot, '.coderabbit.yaml'),
+          pathSegments: ['reviews', 'profile'],
+          format: 'yaml',
+          lineName: 'Parity: cr-profile',
+        },
+      ];
+    case 'cr-on-demand':
+      return [
+        {
+          consumerPath: path.join(gitRoot, '.coderabbit.yaml'),
+          pathSegments: ['reviews', 'auto_review', 'enabled'],
+          format: 'yaml',
+          lineName: 'Parity: cr-on-demand',
+        },
+      ];
+    case 'gca-code-review':
+      return [
+        {
+          consumerPath: path.join(gitRoot, '.gemini', 'config.yaml'),
+          pathSegments: ['code_review', 'pull_request_opened', 'code_review'],
+          format: 'yaml',
+          lineName: 'Parity: gca-code-review',
+        },
+      ];
+    case 'gca-summary':
+      return [
+        {
+          consumerPath: path.join(gitRoot, '.gemini', 'config.yaml'),
+          pathSegments: ['code_review', 'pull_request_opened', 'summary'],
+          format: 'yaml',
+          lineName: 'Parity: gca-summary',
+        },
+      ];
+    case 'greptile-on-demand':
+      return [
+        {
+          consumerPath: path.join(gitRoot, 'greptile.json'),
+          pathSegments: ['skipReview'],
+          format: 'json',
+          lineName: 'Parity: greptile-on-demand',
         },
       ];
     default:
@@ -373,6 +446,7 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
     detectGeneratedArtifactContract,
     detectManualAttestationContract,
     detectMechanicalContract,
+    detectValueEqualityContract,
     detectVersionPinnedContract,
     extractManagedBlock,
     loadParityManifest,
@@ -607,6 +681,38 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
           if (blockingDrift) blockingDriftIds.push(c.id);
           return lines;
         }
+
+        // ── value-equality routing (mmnto-ai/totem-strategy#738 Slice A) ──
+        // Routes on `manifestation` BEFORE the tractability dispatch (same as
+        // capability-probe): these bot-review-config rows are `tractability:
+        // mechanical` but sense a SCALAR at a dotted path, not artifact content-
+        // equality. The expected value is the contract's own
+        // `expectedValueOrDerivation` (the canonical); the registry supplies only
+        // the file + path + format.
+        if (c.manifestation === 'value-equality') {
+          const scopeSkip = consumersSkip(c);
+          if (scopeSkip !== undefined) return scopeSkip;
+          const fields = valueEqualityFieldsFor(c.id, gitRoot);
+          if (fields === undefined) {
+            return [
+              stub(
+                c,
+                `${c.dimension} (value-equality) — drift detection not yet implemented for this row`,
+              ),
+            ];
+          }
+          // A row maps to ≥1 field (the gca two-row split shares one file); tag the
+          // contract id at most ONCE for --strict so the count reflects contracts.
+          let blockingDrift = false;
+          const lines = fields.map((field) => {
+            const verdict = detectValueEqualityContract(c, { repoId, field });
+            if (verdict.status === 'warn' && c.blocking === true) blockingDrift = true;
+            return lineFor(field.lineName, verdict);
+          });
+          if (blockingDrift) blockingDriftIds.push(c.id);
+          return lines;
+        }
+
         if (
           c.manifestation !== undefined &&
           !(PARITY_MANIFESTATIONS as readonly string[]).includes(c.manifestation)

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -688,10 +688,12 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
         // mechanical` but sense a SCALAR at a dotted path, not artifact content-
         // equality. The expected value is the contract's own
         // `expectedValueOrDerivation` (the canonical); the registry supplies only
-        // the file + path + format.
+        // the file + path + format. No `consumersSkip` here — like
+        // detectVersionPinnedContract, detectValueEqualityContract SELF-guards the
+        // consumers scope in core (greptile review on #2249); a second CLI guard
+        // would be the dead-letter / message-divergence risk consumersSkip is
+        // documented to avoid.
         if (c.manifestation === 'value-equality') {
-          const scopeSkip = consumersSkip(c);
-          if (scopeSkip !== undefined) return scopeSkip;
           const fields = valueEqualityFieldsFor(c.id, gitRoot);
           if (fields === undefined) {
             return [

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -695,11 +695,14 @@ export type {
   DetectGeneratedArtifactContext,
   DetectManualAttestationContext,
   DetectMechanicalContext,
+  DetectValueEqualityContext,
   DetectVersionPinnedContext,
   ForkMarker,
   ManagedBlockMarkers,
   PackageJsonShape,
   ParityContractVerdict,
+  ValueEqualityField,
+  ValueEqualityFormat,
 } from './parity-detect.js';
 export {
   deriveCohortRepoId,
@@ -707,6 +710,7 @@ export {
   detectGeneratedArtifactContract,
   detectManualAttestationContract,
   detectMechanicalContract,
+  detectValueEqualityContract,
   detectVersionPinnedContract,
   extractManagedBlock,
   hashManagedBlock,

--- a/packages/core/src/parity-detect.test.ts
+++ b/packages/core/src/parity-detect.test.ts
@@ -1634,4 +1634,31 @@ describe('detectValueEqualityContract', () => {
     expect(v.status).toBe('pass');
     expect(v.message).not.toMatch(/enforc|on-demand|loaded|disabled/i);
   });
+
+  it('unknown — unsupported format (a JS caller / registry typo, never a silent YAML parse)', () => {
+    const v = detectValueEqualityContract(veContract(), {
+      field: veField({ format: 'xml' as unknown as ValueEqualityField['format'] }),
+      readFile: reader({ [CR_YAML]: 'reviews:\n  profile: assertive\n' }),
+    });
+    expect(v.status).toBe('unknown');
+    expect(v.message).toMatch(/unsupported value-equality format/i);
+  });
+
+  it('unknown — the unparseable message carries the parser error detail', () => {
+    const v = detectValueEqualityContract(
+      veContract({ id: 'greptile-on-demand', expectedValueOrDerivation: 'AUTOMATIC' }),
+      {
+        field: veField({
+          consumerPath: GREPTILE_JSON,
+          pathSegments: ['skipReview'],
+          format: 'json',
+          lineName: 'Parity: greptile-on-demand',
+        }),
+        readFile: reader({ [GREPTILE_JSON]: '{ "skipReview": ' }), // truncated JSON
+      },
+    );
+    expect(v.status).toBe('unknown');
+    // The detail suffix (`: <parser first line>`) follows the format label.
+    expect(v.message).toMatch(/unparseable JSON: \S/);
+  });
 });

--- a/packages/core/src/parity-detect.test.ts
+++ b/packages/core/src/parity-detect.test.ts
@@ -31,6 +31,7 @@ import {
   detectManualAttestationContract,
   type DetectMechanicalContext,
   detectMechanicalContract,
+  detectValueEqualityContract,
   type DetectVersionPinnedContext,
   detectVersionPinnedContract,
   extractManagedBlock,
@@ -40,6 +41,7 @@ import {
   packageNameForContract,
   parseForkMarker,
   resolveCohortFloor,
+  type ValueEqualityField,
 } from './parity-detect.js';
 import type { ParityContract } from './parity-manifest.js';
 import { cleanTmpDir } from './test-utils.js';
@@ -1404,5 +1406,232 @@ describe('declared-min fallback rendering', () => {
     expect(v.message).toMatch(/declared/i);
     expect(v.message).toContain('^0.98.0');
     expect(v.message).not.toMatch(/installed 0\.98\.0/);
+  });
+});
+
+// ─── detectValueEqualityContract (mmnto-ai/totem-strategy#738 Slice A) ──
+
+describe('detectValueEqualityContract', () => {
+  /** A value-equality bot-review-config contract (defaults to the cr-profile shape). */
+  function veContract(over: Partial<ParityContract> = {}): ParityContract {
+    return {
+      id: 'cr-profile',
+      dimension: 'bot-review-configs',
+      canonicalSource: 'mmnto-ai/totem-strategy:.coderabbit.yaml#reviews.profile',
+      detectionMethod: 'file-value-equality',
+      expectedValueOrDerivation: 'assertive',
+      tractability: 'mechanical',
+      trackingIssue: 'mmnto-ai/totem-strategy#501',
+      manifestation: 'value-equality',
+      senses: 'present',
+      ...over,
+    };
+  }
+
+  function veField(over: Partial<ValueEqualityField> = {}): ValueEqualityField {
+    return {
+      consumerPath: '/repo/.coderabbit.yaml',
+      pathSegments: ['reviews', 'profile'],
+      format: 'yaml',
+      lineName: 'Parity: cr-profile',
+      ...over,
+    };
+  }
+
+  /** An injected read seam backed by a fixed path→content map (undefined = absent). */
+  function reader(map: Record<string, string>): (p: string) => string | undefined {
+    return (p) => map[p];
+  }
+
+  const CR_YAML = '/repo/.coderabbit.yaml';
+  const GCA_YAML = '/repo/.gemini/config.yaml';
+  const GREPTILE_JSON = '/repo/greptile.json';
+
+  it('pass — string scalar matches the expected', () => {
+    const v = detectValueEqualityContract(veContract(), {
+      field: veField(),
+      readFile: reader({ [CR_YAML]: 'reviews:\n  profile: assertive\n' }),
+    });
+    expect(v.status).toBe('pass');
+    expect(v.message).toContain('reviews.profile');
+  });
+
+  it('warn — present-but-mismatched string scalar', () => {
+    const v = detectValueEqualityContract(veContract(), {
+      field: veField(),
+      readFile: reader({ [CR_YAML]: 'reviews:\n  profile: chill\n' }),
+    });
+    expect(v.status).toBe('warn');
+    expect(v.message).toMatch(/found "chill", expected assertive/);
+  });
+
+  it('pass — YAML boolean false matches expected token "false" (typed compare)', () => {
+    const v = detectValueEqualityContract(
+      veContract({ id: 'cr-on-demand', expectedValueOrDerivation: 'false' }),
+      {
+        field: veField({
+          pathSegments: ['reviews', 'auto_review', 'enabled'],
+          lineName: 'Parity: cr-on-demand',
+        }),
+        readFile: reader({ [CR_YAML]: 'reviews:\n  auto_review:\n    enabled: false\n' }),
+      },
+    );
+    expect(v.status).toBe('pass');
+  });
+
+  it('warn — the STRING "false" does not match a boolean expected (no laundering)', () => {
+    const v = detectValueEqualityContract(
+      veContract({ id: 'cr-on-demand', expectedValueOrDerivation: 'false' }),
+      {
+        field: veField({
+          pathSegments: ['reviews', 'auto_review', 'enabled'],
+          lineName: 'Parity: cr-on-demand',
+        }),
+        // Quoted → YAML parses a STRING "false", not the boolean.
+        readFile: reader({ [CR_YAML]: 'reviews:\n  auto_review:\n    enabled: "false"\n' }),
+      },
+    );
+    expect(v.status).toBe('warn');
+  });
+
+  it('skip — file wholly absent is applicable-but-missing (scaffold hedge)', () => {
+    const v = detectValueEqualityContract(veContract(), {
+      field: veField(),
+      readFile: reader({}),
+    });
+    expect(v.status).toBe('skip');
+    expect(v.message).toMatch(/not present.*scaffold/i);
+  });
+
+  it('warn — path absent on a present file', () => {
+    const v = detectValueEqualityContract(veContract(), {
+      field: veField(),
+      readFile: reader({ [CR_YAML]: 'reviews: {}\n' }),
+    });
+    expect(v.status).toBe('warn');
+    expect(v.message).toMatch(/not declared/i);
+  });
+
+  it('warn — traversal through a non-object yields path-absent drift', () => {
+    const v = detectValueEqualityContract(veContract(), {
+      field: veField(),
+      // `reviews` is a scalar, so `reviews.profile` cannot resolve.
+      readFile: reader({ [CR_YAML]: 'reviews: assertive\n' }),
+    });
+    expect(v.status).toBe('warn');
+    expect(v.message).toMatch(/not declared/i);
+  });
+
+  it('unknown — present-but-unparseable file (not a config-validity detector)', () => {
+    const v = detectValueEqualityContract(
+      veContract({ id: 'greptile-on-demand', expectedValueOrDerivation: 'AUTOMATIC' }),
+      {
+        field: veField({
+          consumerPath: GREPTILE_JSON,
+          pathSegments: ['skipReview'],
+          format: 'json',
+          lineName: 'Parity: greptile-on-demand',
+        }),
+        readFile: reader({ [GREPTILE_JSON]: '{ "skipReview": ' }), // truncated JSON
+      },
+    );
+    expect(v.status).toBe('unknown');
+    expect(v.message).toMatch(/unparseable JSON/i);
+  });
+
+  it('pass — JSON greptile skipReview string scalar', () => {
+    const v = detectValueEqualityContract(
+      veContract({ id: 'greptile-on-demand', expectedValueOrDerivation: 'AUTOMATIC' }),
+      {
+        field: veField({
+          consumerPath: GREPTILE_JSON,
+          pathSegments: ['skipReview'],
+          format: 'json',
+          lineName: 'Parity: greptile-on-demand',
+        }),
+        readFile: reader({ [GREPTILE_JSON]: '{ "skipReview": "AUTOMATIC" }' }),
+      },
+    );
+    expect(v.status).toBe('pass');
+  });
+
+  it('pass — gca switch nested under the top-level code_review block', () => {
+    const gca =
+      'code_review:\n  pull_request_opened:\n    summary: false\n    code_review: false\n';
+    const v = detectValueEqualityContract(
+      veContract({ id: 'gca-summary', expectedValueOrDerivation: 'false' }),
+      {
+        field: veField({
+          consumerPath: GCA_YAML,
+          pathSegments: ['code_review', 'pull_request_opened', 'summary'],
+          lineName: 'Parity: gca-summary',
+        }),
+        readFile: reader({ [GCA_YAML]: gca }),
+      },
+    );
+    expect(v.status).toBe('pass');
+  });
+
+  it('pass — CRLF in a YAML string value is normalized before compare', () => {
+    const v = detectValueEqualityContract(veContract(), {
+      field: veField(),
+      // win32 checkout: CRLF line endings must not change a scalar read.
+      readFile: reader({ [CR_YAML]: 'reviews:\r\n  profile: assertive\r\n' }),
+    });
+    expect(v.status).toBe('pass');
+  });
+
+  it('skip — not a consumer (scoped out)', () => {
+    const v = detectValueEqualityContract(veContract({ consumers: ['totem-status'] }), {
+      repoId: 'liquid-city',
+      field: veField(),
+      readFile: reader({ [CR_YAML]: 'reviews:\n  profile: chill\n' }),
+    });
+    expect(v.status).toBe('skip');
+    expect(v.message).toMatch(/cohort permits absence/i);
+  });
+
+  it('skip — repo id unresolvable under a consumers scope', () => {
+    const v = detectValueEqualityContract(veContract({ consumers: ['totem'] }), {
+      field: veField(),
+      readFile: reader({ [CR_YAML]: 'reviews:\n  profile: chill\n' }),
+    });
+    expect(v.status).toBe('skip');
+    expect(v.message).toMatch(/repo id unresolvable/i);
+  });
+
+  it('skip — no expected value declared', () => {
+    const v = detectValueEqualityContract(veContract({ expectedValueOrDerivation: '   ' }), {
+      field: veField(),
+      readFile: reader({ [CR_YAML]: 'reviews:\n  profile: assertive\n' }),
+    });
+    expect(v.status).toBe('skip');
+    expect(v.message).toMatch(/no expected value/i);
+  });
+
+  it('never emits fail (the CLI edge owns --strict promotion)', () => {
+    const statuses = new Set<string>();
+    for (const content of [
+      'reviews:\n  profile: assertive\n',
+      'reviews:\n  profile: chill\n',
+      'reviews: {}\n',
+    ]) {
+      statuses.add(
+        detectValueEqualityContract(veContract(), {
+          field: veField(),
+          readFile: reader({ [CR_YAML]: content }),
+        }).status,
+      );
+    }
+    expect(statuses.has('fail')).toBe(false);
+  });
+
+  it('claim-class bound — a pass never asserts enforcement/loaded behavior', () => {
+    const v = detectValueEqualityContract(veContract(), {
+      field: veField(),
+      readFile: reader({ [CR_YAML]: 'reviews:\n  profile: assertive\n' }),
+    });
+    expect(v.status).toBe('pass');
+    expect(v.message).not.toMatch(/enforc|on-demand|loaded|disabled/i);
   });
 });

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -38,6 +38,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import semver from 'semver';
+import { parse as parseYaml } from 'yaml';
 
 import { PARITY_SENSES, type ParityContract, type ParitySense } from './parity-manifest.js';
 import { safeExec } from './sys/exec.js';
@@ -1504,6 +1505,227 @@ export function detectCapabilityProbeContract(
     ctx,
     `governance floor not suppressed in ${path.basename(ctx.consumerPath)}`,
   );
+}
+
+// ─── Value-equality detector (mmnto-ai/totem-strategy#738 Slice A, Proposal 296 §13) ──
+
+/**
+ * The parse mode for a value-equality field's on-disk config file. Declared per
+ * row in the CLI registry (`valueEqualityFieldsFor`) — derive-not-guess, so an
+ * unrecognized format yields `unknown`, never a silent mis-parse.
+ */
+export type ValueEqualityFormat = 'yaml' | 'json';
+
+/**
+ * One value-equality field spec, resolved by the CLI registry from a contract id.
+ * The EXPECTED value is deliberately NOT carried here — it is read from the
+ * contract's own `expectedValueOrDerivation` (strategy#738 Q1: the manifest field
+ * is the canonical, derived LOCALLY per Tenet 6). The registry supplies only WHERE
+ * to look, never WHAT to expect (no second source of truth).
+ */
+export interface ValueEqualityField {
+  /** Absolute path to the consumer config file (e.g. `<root>/.coderabbit.yaml`). */
+  consumerPath: string;
+  /**
+   * The dotted config path as discrete SEGMENTS (`['reviews', 'profile']`), NOT a
+   * pre-split string — a literal key containing a `.` would be mis-split otherwise
+   * (totem-codex panel, strategy#738). The CLI registry owns the segments.
+   */
+  pathSegments: string[];
+  /** Parse mode for {@link consumerPath}. */
+  format: ValueEqualityFormat;
+  /** Display name for the verdict line. */
+  lineName: string;
+}
+
+/** Inputs + test seams for {@link detectValueEqualityContract}. */
+export interface DetectValueEqualityContext {
+  /** Current repo's cohort id for `consumers` applicability (verbatim parity with the other detectors). */
+  repoId?: string;
+  /** The field spec (file + path + format) the CLI registry resolved for this contract. */
+  field: ValueEqualityField;
+  /** Test seam — override the consumer file read. Production callers omit it. */
+  readFile?: (absPath: string) => string | undefined;
+}
+
+/**
+ * The typed expected scalar a value-equality row asserts. Only the exact tokens
+ * `true` / `false` become booleans; every other token stays a string (exact,
+ * case-sensitive). Numeric / set-semantic comparison is explicitly OUT of Slice A
+ * — it would be a registry-declared expected-kind, never global coercion (the
+ * `false` vs `"false"`, `0` vs `"0"`, `null` vs `"null"` over-claim class the
+ * totem-codex panel flagged against a blanket `String(value)` compare).
+ */
+type ExpectedScalar = boolean | string;
+
+/** Parse the manifest's `expected-value-or-derivation` token into a typed scalar. */
+function parseExpectedScalar(rawTrimmed: string): ExpectedScalar {
+  if (rawTrimmed === 'true') return true;
+  if (rawTrimmed === 'false') return false;
+  return rawTrimmed;
+}
+
+/**
+ * Navigate discrete path segments through a parsed YAML/JSON document. Returns
+ * `found: false` when any segment is absent OR when traversal hits a non-object
+ * (array / scalar / null) before consuming every segment — both are "the field is
+ * not declared at this path" (a drift `warn` per the totem-codex panel), distinct
+ * from a present-but-mismatched value. Uses `hasOwnProperty` so an inherited
+ * prototype key (e.g. `constructor`) can't masquerade as a declared field.
+ */
+function navigateConfigPath(
+  root: unknown,
+  segments: string[],
+): { found: true; value: unknown } | { found: false } {
+  let cursor: unknown = root;
+  for (const segment of segments) {
+    if (typeof cursor !== 'object' || cursor === null || Array.isArray(cursor)) {
+      return { found: false };
+    }
+    if (!Object.prototype.hasOwnProperty.call(cursor, segment)) {
+      return { found: false };
+    }
+    cursor = (cursor as Record<string, unknown>)[segment];
+  }
+  return { found: true, value: cursor };
+}
+
+/**
+ * Whether a parsed on-disk value equals the typed expected scalar. Boolean
+ * expected ⟹ the actual must be a boolean and strictly equal (YAML `false` the
+ * bool matches; the STRING `"false"` does NOT — value-equality must not launder
+ * an ambiguous string into a boolean config claim). String expected ⟹ the actual
+ * must be a string and exactly equal after a CRLF/trim normalize (win32-checkout
+ * safe; these scalar config values carry no meaningful surrounding whitespace).
+ */
+function valueMatchesExpected(actual: unknown, expected: ExpectedScalar): boolean {
+  if (typeof expected === 'boolean') return actual === expected;
+  return typeof actual === 'string' && actual.replace(/\r\n?/g, '\n').trim() === expected;
+}
+
+/** Render a parsed value for a verdict message (strings quoted; bool/number/null inline; else JSON). */
+function renderConfigValue(value: unknown): string {
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'boolean' || typeof value === 'number' || value === null) {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+    // totem-context: a value that can't be JSON-stringified (a cycle is impossible from a freshly parsed YAML/JSON doc, but be defensive) degrades to String() for the message only — rendering must never throw inside a verdict.
+  } catch {
+    return String(value);
+  }
+}
+
+/**
+ * Detect drift for ONE `manifestation: value-equality` contract (strategy#738
+ * Slice A, the Proposal 296 §13 promotion of the bot-review-config rows up from
+ * `attestation`). Reads a scalar at a dotted path in the consumer's on-disk
+ * config file and compares it — typed, never blanket-stringified — against the
+ * row's own `expectedValueOrDerivation` (the canonical, read LOCALLY; NEVER
+ * networks). Honors the verdict-state split + the honest-absent taxonomy the
+ * cohort panel settled (strategy#738):
+ *
+ *   - `pass`    — the path resolves and the value equals the expected scalar.
+ *   - `warn`    — present-but-mismatched, OR the path is absent on a present file
+ *                 (incl. traversal through a non-object): applicable drift.
+ *   - `unknown` — the file is present but unparseable: equality is unprovable
+ *                 either way (value-equality is NOT a config-validity detector).
+ *   - `skip`    — not-a-consumer / repo-id-unresolvable-under-scope / the file is
+ *                 wholly absent (applicable-but-missing scaffold hedge, mirroring
+ *                 detectVersionPinnedContract — flips to a drift `warn` once the
+ *                 consumers lists are verified) / no expected declared.
+ *
+ * NEVER emits `fail` (the CLI edge owns `--strict` promotion). NEVER throws
+ * (reads/parses degrade to skip/unknown). NEVER networks. Claim-class bound: a
+ * `pass` asserts ONLY "this dotted path holds this scalar" — never that the bot
+ * is on-demand, that the vendor loads it, or that the surface is enforced (those
+ * are loaded/usable claims outside Slice A).
+ */
+export function detectValueEqualityContract(
+  contract: ParityContract,
+  ctx: DetectValueEqualityContext,
+): ParityContractVerdict {
+  // ── Applicability: consumers scope (verbatim parity with detectVersionPinnedContract) ──
+  if (contract.consumers !== undefined) {
+    if (ctx.repoId === undefined) {
+      return {
+        status: 'skip',
+        message: `cannot determine applicability — repo id unresolvable; contract is scoped to consumers [${contract.consumers.join(', ')}]`,
+      };
+    }
+    if (!contract.consumers.includes(ctx.repoId)) {
+      return {
+        status: 'skip',
+        message: `cohort permits absence here (${ctx.repoId} not in consumers)`,
+      };
+    }
+  }
+
+  const { field } = ctx;
+  const fileLabel = path.basename(field.consumerPath);
+  const pathLabel = field.pathSegments.join('.');
+
+  // ── Expected scalar from the manifest's own field (strategy#738 Q1; zero-network) ──
+  const rawExpected = contract.expectedValueOrDerivation.trim();
+  if (rawExpected.length === 0) {
+    return {
+      status: 'skip',
+      message: `${contract.id}: no expected value declared (expected-value-or-derivation is empty)`,
+    };
+  }
+  const expected = parseExpectedScalar(rawExpected);
+
+  // ── Read the consumer config file ──
+  // Wholly-absent is the applicable-but-missing case: held as a scaffold skip
+  // (mirroring detectVersionPinnedContract) — these rows carry no `consumers`, so
+  // it flips to a drift `warn` once the cohort's per-repo applicability is
+  // verified. Kept DISTINCT from the not-a-consumer skip above.
+  const readFile = ctx.readFile ?? readFileText;
+  const raw = readFile(field.consumerPath);
+  if (raw === undefined) {
+    return {
+      status: 'skip',
+      message: `${fileLabel} not present — applicable-but-missing (scaffold: skip; becomes a drift warn once consumers are verified)`,
+      remediation: `Add ${pathLabel}: ${rawExpected} to ${fileLabel}, or scope this contract's consumers to exclude repos that legitimately omit ${fileLabel}.`,
+    };
+  }
+
+  // ── Parse (unparseable → unknown; do NOT smuggle in a config-validity detector) ──
+  let doc: unknown;
+  try {
+    doc = field.format === 'json' ? JSON.parse(raw) : parseYaml(raw);
+    // totem-context: a malformed consumer config degrades to an honest `unknown` (equality unprovable either way) — never a throw that would sink the doctor pipeline, and never a `warn`/`pass` that would over-claim on unparseable bytes.
+  } catch {
+    return {
+      status: 'unknown',
+      message: `${fileLabel} is unparseable ${field.format.toUpperCase()} — value-equality for ${pathLabel} is unprovable either way`,
+      remediation: `Fix the ${fileLabel} syntax, then re-run totem doctor --parity.`,
+    };
+  }
+
+  // ── Navigate the dotted path (absent / through-non-object → drift warn) ──
+  const nav = navigateConfigPath(doc, field.pathSegments);
+  if (!nav.found) {
+    return {
+      status: 'warn',
+      message: `${pathLabel} not declared in ${fileLabel} — expected ${rawExpected}`,
+      remediation: `Set ${pathLabel}: ${rawExpected} in ${fileLabel}, or update the contract if the cohort canonical changed.`,
+    };
+  }
+
+  // ── Compare (typed; never blanket String()) ──
+  if (valueMatchesExpected(nav.value, expected)) {
+    return {
+      status: 'pass',
+      message: `${pathLabel} = ${renderConfigValue(nav.value)} matches the cohort canonical in ${fileLabel}`,
+    };
+  }
+  return {
+    status: 'warn',
+    message: `${pathLabel} drift in ${fileLabel} — found ${renderConfigValue(nav.value)}, expected ${rawExpected}`,
+    remediation: `Reconcile ${pathLabel} to ${rawExpected} in ${fileLabel}, or update the contract if the cohort canonical changed.`,
+  };
 }
 
 // ─── Shared filesystem helpers ──────────────────────────

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -1610,7 +1610,11 @@ function renderConfigValue(value: unknown): string {
     return String(value);
   }
   try {
-    return JSON.stringify(value);
+    // `JSON.stringify` returns `undefined` (not a string) for undefined / function /
+    // symbol inputs — none arise from parsed YAML/JSON at today's call sites, but the
+    // helper takes `unknown`, so coalesce to keep the `: string` contract total (GCA
+    // review on #2249). `??` not `||` (a valid "" / "0" render must survive).
+    return JSON.stringify(value) ?? String(value);
     // totem-context: a value that can't be JSON-stringified (a cycle is impossible from a freshly parsed YAML/JSON doc, but be defensive) degrades to String() for the message only — rendering must never throw inside a verdict.
   } catch {
     return String(value);

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -1691,15 +1691,33 @@ export function detectValueEqualityContract(
     };
   }
 
+  // ── Guard the format up front (public-core-surface contract) ──
+  // This detector is exported, so a JS caller (no compile-time check) or a future
+  // registry typo can pass an unsupported format. Enforce the docblock's
+  // unknown-not-mis-parse contract HERE rather than letting a non-`json` value
+  // fall through to the YAML parser (a silent mis-parse that could mint a false
+  // pass/warn) — and it keeps the unparseable label off a maybe-non-string value
+  // (CodeRabbit review on #2249).
+  if (field.format !== 'json' && field.format !== 'yaml') {
+    return {
+      status: 'unknown',
+      message: `${fileLabel}: unsupported value-equality format '${String(field.format)}' — value-equality for ${pathLabel} is unprovable`,
+      remediation: `Declare a supported format (yaml | json) for ${pathLabel} in the value-equality registry.`,
+    };
+  }
+
   // ── Parse (unparseable → unknown; do NOT smuggle in a config-validity detector) ──
   let doc: unknown;
   try {
     doc = field.format === 'json' ? JSON.parse(raw) : parseYaml(raw);
     // totem-context: a malformed consumer config degrades to an honest `unknown` (equality unprovable either way) — never a throw that would sink the doctor pipeline, and never a `warn`/`pass` that would over-claim on unparseable bytes.
-  } catch {
+  } catch (err) {
+    // Surface the parser's OWN first line (split on \n only — a YAML/JSON error can
+    // carry a `.`-laden path) so a syntax issue is locatable (GCA review on #2249).
+    const detail = err instanceof Error ? `: ${err.message.split('\n')[0]}` : '';
     return {
       status: 'unknown',
-      message: `${fileLabel} is unparseable ${field.format.toUpperCase()} — value-equality for ${pathLabel} is unprovable either way`,
+      message: `${fileLabel} is unparseable ${field.format === 'json' ? 'JSON' : 'YAML'}${detail} — value-equality for ${pathLabel} is unprovable either way`,
       remediation: `Fix the ${fileLabel} syntax, then re-run totem doctor --parity.`,
     };
   }

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -1590,17 +1590,27 @@ function navigateConfigPath(
   return { found: true, value: cursor };
 }
 
+/** CRLF/lone-CR → LF + trim — the CRLF-insensitive normalize applied to BOTH compare sides. */
+function normalizeScalarString(s: string): string {
+  return s.replace(/\r\n?/g, '\n').trim();
+}
+
 /**
  * Whether a parsed on-disk value equals the typed expected scalar. Boolean
  * expected ⟹ the actual must be a boolean and strictly equal (YAML `false` the
  * bool matches; the STRING `"false"` does NOT — value-equality must not launder
  * an ambiguous string into a boolean config claim). String expected ⟹ the actual
- * must be a string and exactly equal after a CRLF/trim normalize (win32-checkout
- * safe; these scalar config values carry no meaningful surrounding whitespace).
+ * must be a string and exactly equal after a CRLF/trim normalize applied to BOTH
+ * sides — symmetric so the compare is genuinely CRLF-insensitive (win32-checkout
+ * safe). The YAML parser already LF-normalizes scalar content (spec §5.4) and the
+ * manifest value is single-line, so normalizing `expected` is belt-and-suspenders,
+ * but symmetry removes the half-normalized smell (GCA review on #2249).
  */
 function valueMatchesExpected(actual: unknown, expected: ExpectedScalar): boolean {
   if (typeof expected === 'boolean') return actual === expected;
-  return typeof actual === 'string' && actual.replace(/\r\n?/g, '\n').trim() === expected;
+  return (
+    typeof actual === 'string' && normalizeScalarString(actual) === normalizeScalarString(expected)
+  );
 }
 
 /** Render a parsed value for a verdict message (strings quoted; bool/number/null inline; else JSON). */

--- a/packages/core/src/parity-manifest.ts
+++ b/packages/core/src/parity-manifest.ts
@@ -75,6 +75,12 @@ export const PARITY_MANIFESTATIONS = [
   'correct-by-construction',
   'managed-block',
   'version-pin',
+  // `value-equality` (strategy#738 Slice A): a present-level mechanical scalar
+  // check — stronger than `attestation`, weaker than the byte-exact managed-block
+  // rung — promoting the bot-review-config rows. Order is cosmetic (routing
+  // narrows on membership, not index), but kept ahead of `attestation` to read as
+  // the promotion target.
+  'value-equality',
   'attestation',
   'capability-probe',
 ] as const;


### PR DESCRIPTION
## What

**Slice A of the Proposal 296 §13 bot-config promotion** (mmnto-ai/totem-strategy#738): a new `value-equality` parity detector that promotes the `bot-review-configs` manifest rows from `attestation` to a present-level **mechanical scalar check**.

- **`detectValueEqualityContract`** (core, `parity-detect.ts`) — reads a scalar at a dotted path in the consumer's on-disk config and compares it, **typed** (never blanket-stringified) and **zero-network**, against the row's own `expected-value-or-derivation` (the canonical, per the #738 Q1 ruling).
- **CLI route + `valueEqualityFieldsFor` registry** (`doctor-parity.ts`) — routes on `manifestation: value-equality` *before* the tractability dispatch (the capability-probe pattern); the registry supplies file + path-**segments** + format, never the expected value.
- **`value-equality` rung** added to the §6(a)2 ladder (`PARITY_MANIFESTATIONS`).

5 rows after the #738 Q3 two-row gca split: `cr-profile`, `cr-on-demand`, `gca-code-review`, `gca-summary`, `greptile-on-demand` (over `.coderabbit.yaml` / `.gemini/config.yaml` / `greptile.json`).

## Design (cohort panel + settled rulings)

Pre-build cohort panel — **totem-codex (contract), totem-agy (build/test), totem-gemini (tenet/arch) — all PASS**; folds applied:
- **Typed expected, never blanket `String()`** (codex): `true`/`false` → boolean, else string. YAML `enabled: false` (bool) matches `"false"`; the *string* `"false"` correctly **warns** (no laundering an ambiguous string into a bool claim).
- **Honest-absent taxonomy:** file-absent → `skip` (applicable-but-missing scaffold, mirroring `detectVersionPinnedContract`; flips to `warn` once consumers are verified) · path-absent / traversal-through-non-object / mismatch → `warn` · unparseable → `unknown` (not a config-validity detector) · match → `pass`.
- **Path segments, not split strings** (codex) — avoids a key-with-dot ambiguity.
- **GCA shape corrected:** verified against the live config — the switches nest under a **top-level `code_review:` block** (`code_review.pull_request_opened.{code_review,summary}`), not the bare `pull_request_opened.*` a panel fixture assumed.

Claim-class bound: a `pass` asserts only "this dotted path holds this scalar" — never enforcement / loaded / on-demand. Never emits `fail` (the CLI edge owns `--strict`); never networks (Tenet 6).

## Coupling

Single-writer split (strategy#738): this engine is the totem-core lane. The **manifest row flip** (`attestation → value-equality`) is strategy's lane in `doctrine/parity-manifest.yaml`, **coupled to this PR's merge** so the manifest never names a rung the engine hasn't shipped (the #2192 doctrine-coupling shape). I send the merge-ping when this is approved.

## Verify

- Build: `pnpm build` green (10/10 turbo tasks).
- Tests: full suite green — **+17 core** detector cases (typed compare, the 5 rows, honest-absent taxonomy, CRLF, unparseable→unknown, consumers-scope, never-fail, claim-class) **+5 CLI** wiring cases (pass/warn/blocking-tag/skip/unhandled-stub).
- `pnpm format:check` clean · ESLint 0 errors · `totem lint --base main` PASS (0 errors).
- Changeset included (minor, core + cli).

Scope: **Slice A only.** B (managed-block shared-clause), C (`copilot-instructions.md` generated path), D (capability-probe Yellow) follow as strategy authors their rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
