### PR TITLE
chore(doctrine): pin @mmnto/strategy-doctrine 0.1.12 → 0.1.13 (strategy#743 value-equality flip)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "typescript-eslint": "^8.59.4"
   },
   "optionalDependencies": {
-    "@mmnto/strategy-doctrine": "0.1.12"
+    "@mmnto/strategy-doctrine": "0.1.13"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         version: 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
     optionalDependencies:
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.12
-        version: 0.1.12
+        specifier: 0.1.13
+        version: 0.1.13
 
   packages/cli:
     dependencies:
@@ -853,8 +853,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.12':
-    resolution: {integrity: sha512-Hn4PdmZ1TGMYYMAQ7Xj2rNpFpeHneSXRD5WF2WFJNvxZizY174FLgWTHyHOnS28GN1K8I/h/ITQC4g87YgJj9Q==}
+  '@mmnto/strategy-doctrine@0.1.13':
+    resolution: {integrity: sha512-4uU89+4YMRecjIPIPONevwjyTTvEOzPcbg7BbmpgNKeOKNQlsh58xV9k50N0DgIrUqWpwzOtdaHmfD9lnWPEGA==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3685,7 +3685,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.12':
+  '@mmnto/strategy-doctrine@0.1.13':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
## What

Pin `@mmnto/strategy-doctrine` **0.1.12 → 0.1.13** (the #2223 doctrine-pin pattern).

v0.1.13 carries the **strategy#743** bot-review-config **value-equality flip**: the 5 rows promoted `attestation → value-equality`, with `gca-on-demand` split into `gca-code-review` + `gca-summary` per the strategy#738 Q3 ruling.

## Why

Closes totem's **consumer side** of the #738 Slice A arc. The value-equality engine shipped in #2249/#2250 (`@mmnto/cli` 1.76.0); the canonical manifest flipped in strategy#743 (`a30e36b`) and published as the v0.1.13 bundle. This pin is what makes totem actually *sense* the flipped rows.

## Verification

`totem doctor --parity` now senses all 5 bot-config rows **green via the value-equality engine** (actual value comparison, not the old `attestation` stub):

```
PASS — reviews.profile = "assertive" matches canonical in .coderabbit.yaml        (cr-profile)
PASS — reviews.auto_review.enabled = false matches canonical in .coderabbit.yaml   (cr-on-demand)
PASS — code_review.pull_request_opened.code_review = false matches canonical        (gca-code-review)
PASS — code_review.pull_request_opened.summary = false matches canonical           (gca-summary)
PASS — skipReview = "AUTOMATIC" matches canonical in greptile.json                 (greptile-on-demand)
```

## Scope

- 2 files: `package.json` (the `optionalDependencies` pin) + `pnpm-lock.yaml` (regenerated).
- **No changeset** — `optionalDependencies` pin, non-publishing (same as #2223).

Context: strategy#738, strategy#743, #2249. (No closing keywords — strategy issues are cross-repo; #2249 already merged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
