### PR TITLE
feat(doctor): sense the pnpm-engine-version parity row — packageManager toolchain reader (#2115)

### DIFF
--- a/.changeset/toolchain-packagemanager-reader-2115.md
+++ b/.changeset/toolchain-packagemanager-reader-2115.md
@@ -1,0 +1,12 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+---
+
+feat(doctor): sense the pnpm-engine-version parity row — packageManager-field toolchain reader (#2115)
+
+Teaches the `version-pinned` detector a toolchain sub-class: a `toolchain-version` row that resolves no deps package (e.g. `pnpm-engine-version`) now reads the consumer's `packageManager` field (`pnpm@11.2.2+sha512…`) instead of a `dependencies` range. `detectVersionPinnedContract` self-routes those rows to a new `detectPackageManagerToolchain`; the CLI no longer stubs them as "drift detection not yet implemented".
+
+The floor comes from the row's own `expected-value-or-derivation` (`pnpm@<floor>` — there is no `packages/*/package.json` to glob, `canonical-source` is null). Reads the DECLARATION only (`senses: declared`), never probes the installed binary. Parses `<name>@<version>(+<hash>)?` tolerantly, compares `version >= floor`, and surfaces a note when the pin is hashless (corepack integrity not pinned — strategy#566). Honest-absent on a missing field, a different engine (the floor doesn't apply), an unparseable pin, or a non-derivable floor; never networks, never throws. A `toolchain-version` row that DOES resolve a deps package (`mmnto-cli-version`) stays on the existing deps floor path.
+
+Empirically: `totem doctor --parity` flips the `pnpm-engine-version` row from `SKIP` to `PASS — pnpm engine pin current — packageManager 11.2.2 ≥ cohort floor 11.2.2`.

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -454,6 +454,7 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
     PARITY_MANIFESTATIONS,
     resolveGitRoot,
     SUPPORTED_PARITY_SCHEMA_VERSION,
+    TOOLCHAIN_DIMENSION,
   } = await import('@mmnto/totem');
 
   // Read the config best-effort: a missing/corrupt config is the honest-absent
@@ -752,7 +753,7 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
           // consumer's `packageManager` field; detectVersionPinnedContract
           // self-routes those to the toolchain reader (mmnto-ai/totem#2115). Only
           // stub a version-pinned row that's neither a deps package nor a toolchain.
-          if (packageName === undefined && c.dimension !== 'toolchain-version') {
+          if (packageName === undefined && c.dimension !== TOOLCHAIN_DIMENSION) {
             return [
               stub(c, `${c.dimension} (version-pinned) — drift detection not yet implemented`),
             ];

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -748,7 +748,11 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
         // ── version-pinned deps (PR-1) ──
         if (c.tractability === 'version-pinned') {
           const packageName = packageNameForContract(c, gitRoot);
-          if (packageName === undefined) {
+          // A toolchain-version row with no deps package pins its engine via the
+          // consumer's `packageManager` field; detectVersionPinnedContract
+          // self-routes those to the toolchain reader (mmnto-ai/totem#2115). Only
+          // stub a version-pinned row that's neither a deps package nor a toolchain.
+          if (packageName === undefined && c.dimension !== 'toolchain-version') {
             return [
               stub(c, `${c.dimension} (version-pinned) — drift detection not yet implemented`),
             ];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -718,6 +718,7 @@ export {
   packageNameForContract,
   parseForkMarker,
   resolveCohortFloor,
+  TOOLCHAIN_DIMENSION,
 } from './parity-detect.js';
 
 // Semgrep adapter (Pipeline 4 — import rules from Semgrep YAML)

--- a/packages/core/src/parity-detect.test.ts
+++ b/packages/core/src/parity-detect.test.ts
@@ -524,6 +524,107 @@ describe('detectVersionPinnedContract', () => {
   });
 });
 
+// ─── packageManager toolchain reader (mmnto-ai/totem#2115) ──
+
+describe('detectVersionPinnedContract — packageManager toolchain (#2115)', () => {
+  /** A toolchain-version row that pins via packageManager (no deps package). */
+  function toolchainContract(over: Partial<ParityContract> = {}): ParityContract {
+    return depsContract({
+      id: 'pnpm-engine-version',
+      dimension: 'toolchain-version',
+      canonicalSource: null,
+      expectedValueOrDerivation: 'pnpm@11.2.2 floor; pin >= floor',
+      ...over,
+    });
+  }
+  /** Context whose consumer package.json declares `packageManager: pm` (undefined → no field). */
+  function ctxWithPackageManager(pm: string | undefined): DetectVersionPinnedContext {
+    return baseCtx({ readPackageJson: () => (pm === undefined ? {} : { packageManager: pm }) });
+  }
+
+  it('PASS — packageManager pnpm pin ≥ cohort floor', () => {
+    const v = detectVersionPinnedContract(
+      toolchainContract(),
+      ctxWithPackageManager('pnpm@11.2.2+sha512abc'),
+    );
+    expect(v.status).toBe('pass');
+    expect(v.message).toContain('11.2.2');
+    expect(v.message).not.toContain('hashless');
+  });
+
+  it('WARN — packageManager pnpm pin < cohort floor (stale)', () => {
+    const v = detectVersionPinnedContract(
+      toolchainContract(),
+      ctxWithPackageManager('pnpm@11.1.0+sha512abc'),
+    );
+    expect(v.status).toBe('warn');
+    expect(v.message).toContain('stale');
+    expect(v.message).toContain('11.1.0');
+  });
+
+  it('surfaces a hashless-pin note (strategy#566 — corepack integrity not pinned)', () => {
+    const v = detectVersionPinnedContract(
+      toolchainContract(),
+      ctxWithPackageManager('pnpm@11.2.2'),
+    );
+    expect(v.status).toBe('pass');
+    expect(v.message).toContain('hashless');
+  });
+
+  it('SKIP — no packageManager field (honest-absent)', () => {
+    const v = detectVersionPinnedContract(toolchainContract(), ctxWithPackageManager(undefined));
+    expect(v.status).toBe('skip');
+    expect(v.message).toContain('no packageManager field');
+  });
+
+  it('SKIP — a different engine: the pnpm floor does not apply', () => {
+    const v = detectVersionPinnedContract(toolchainContract(), ctxWithPackageManager('yarn@4.0.0'));
+    expect(v.status).toBe('skip');
+    expect(v.message).toContain('does not apply');
+  });
+
+  it('SKIP — unparseable packageManager pin', () => {
+    const v = detectVersionPinnedContract(
+      toolchainContract(),
+      ctxWithPackageManager('not-a-valid-pin'),
+    );
+    expect(v.status).toBe('skip');
+    expect(v.message).toContain('not a parseable');
+  });
+
+  it('SKIP — floor not derivable from a prose-only expected-value', () => {
+    const v = detectVersionPinnedContract(
+      toolchainContract({ expectedValueOrDerivation: 'see the rider for the floor' }),
+      ctxWithPackageManager('pnpm@11.2.2+sha512abc'),
+    );
+    expect(v.status).toBe('skip');
+    expect(v.message).toContain('floor not derivable');
+  });
+
+  it('never throws on adversarial packageManager input', () => {
+    for (const pm of ['', '@', 'pnpm@', '@1.2.3', 'pnpm@@@', 'pnpm@notsemver']) {
+      expect(() =>
+        detectVersionPinnedContract(toolchainContract(), ctxWithPackageManager(pm)),
+      ).not.toThrow();
+    }
+  });
+
+  it('a toolchain-version row WITH a deps package stays on the deps floor path (mmnto-cli-version)', () => {
+    // dimension is toolchain-version but the id resolves @mmnto/totem → the deps
+    // path owns it; the packageManager reader must NOT intercept it.
+    writeSelfInTree(tmpRoot, '1.50.0');
+    writeConsumerPkg(tmpRoot, { '@mmnto/totem': '^1.50.0' });
+    writeInstalled(tmpRoot, '@mmnto/totem', '1.53.3');
+    const v = detectVersionPinnedContract(
+      depsContract({ dimension: 'toolchain-version' }),
+      baseCtx({ repoId: 'totem' }),
+    );
+    expect(v.status).toBe('pass');
+    expect(v.message).toContain('cohort floor');
+    expect(v.message).not.toContain('engine pin');
+  });
+});
+
 // ─── Mechanical content-equality detector (mmnto-ai/totem#2073) ──
 
 const MARKERS = { start: '<!-- totem:skill-start -->', end: '<!-- totem:skill-end -->' };

--- a/packages/core/src/parity-detect.test.ts
+++ b/packages/core/src/parity-detect.test.ts
@@ -552,7 +552,7 @@ describe('detectVersionPinnedContract — packageManager toolchain (#2115)', () 
     expect(v.message).not.toContain('hashless');
   });
 
-  it('WARN — packageManager pnpm pin < cohort floor (stale)', () => {
+  it('WARN — packageManager pnpm pin < cohort floor (stale); remediation is EXACT, never a range', () => {
     const v = detectVersionPinnedContract(
       toolchainContract(),
       ctxWithPackageManager('pnpm@11.1.0+sha512abc'),
@@ -560,6 +560,21 @@ describe('detectVersionPinnedContract — packageManager toolchain (#2115)', () 
     expect(v.status).toBe('warn');
     expect(v.message).toContain('stale');
     expect(v.message).toContain('11.1.0');
+    // corepack rejects a range in `packageManager`, so the hint must be exact (GCA #2254).
+    expect(v.remediation).toContain('pnpm@11.2.2');
+    expect(v.remediation).not.toContain('>=');
+  });
+
+  it('SKIP — a malformed packageManager with trailing junk does NOT pass off a leading-token match (greptile #2254)', () => {
+    for (const pm of [
+      'pnpm@11.2.2 trailing-junk',
+      'pnpm@11.2.2+sha512 garbage',
+      'pnpm@11.2.2 ; rm -rf',
+    ]) {
+      const v = detectVersionPinnedContract(toolchainContract(), ctxWithPackageManager(pm));
+      expect(v.status).toBe('skip');
+      expect(v.message).toContain('not a parseable');
+    }
   });
 
   it('surfaces a hashless-pin note (strategy#566 — corepack integrity not pinned)', () => {

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -76,7 +76,7 @@ const SIBLING_STRATEGY_DIRNAME = 'totem-strategy';
  * (mmnto-ai/totem#2115). `mmnto-cli-version` shares this dimension but resolves
  * `@mmnto/cli`, so it stays on the deps path.
  */
-const TOOLCHAIN_DIMENSION = 'toolchain-version';
+export const TOOLCHAIN_DIMENSION = 'toolchain-version';
 
 /** Bounded git-command timeout for the origin-remote probe (matches `sys/git.ts`). */
 const GIT_REMOTE_TIMEOUT_MS = 15_000;
@@ -639,17 +639,30 @@ interface PackageManagerSpec {
 }
 
 /**
- * Parse the LEADING `<name>@<version>(+<hash>)?` token out of a corepack-shaped
- * string. Tolerant of trailing prose so it reads BOTH a `packageManager` field
- * (`pnpm@11.2.2+sha512…`) and a manifest floor expressed as
- * `pnpm@11.2.2 floor; pin >= floor`. Returns undefined when no leading spec
- * token is present. Pure + total — never throws (mmnto-ai/totem#2115).
+ * Parse a `<name>@<version>(+<hash>)?` corepack spec.
+ *
+ * Two modes (greptile review mmnto-ai/totem#2254):
+ *   - `anchored: false` (default) — match the LEADING token, tolerating trailing
+ *     prose. For the manifest FLOOR, expressed as `pnpm@11.2.2 floor; pin >= floor`.
+ *   - `anchored: true` — the WHOLE trimmed value must match. For the consumer's
+ *     `packageManager` field: corepack requires the entire value to be a valid
+ *     `<name>@<version>[+<hash>]`, so a declaration like `pnpm@11.2.2 garbage`
+ *     is MALFORMED — doctor must not report it current off a leading-token match.
+ *
+ * Returns undefined when no spec matches. Pure + total — never throws (mmnto-ai/totem#2115).
  */
-function parsePackageManagerSpec(raw: string | undefined | null): PackageManagerSpec | undefined {
+function parsePackageManagerSpec(
+  raw: string | undefined | null,
+  opts: { anchored?: boolean } = {},
+): PackageManagerSpec | undefined {
   if (typeof raw !== 'string') return undefined;
   // <name> = a package-manager slug; <version> = a semver core (+ optional
-  // prerelease/build that stops at whitespace or the `+hash` delimiter).
-  const m = raw.trim().match(/^([a-z][a-z0-9-]*)@(\d+\.\d+\.\d+[^\s+]*)(\+\S+)?/i);
+  // prerelease/build that stops at whitespace or the `+hash` delimiter). Under
+  // `anchored`, a trailing `$` rejects anything after the (optional) hash.
+  const pattern = opts.anchored
+    ? /^([a-z][a-z0-9-]*)@(\d+\.\d+\.\d+[^\s+]*)(\+\S+)?$/i
+    : /^([a-z][a-z0-9-]*)@(\d+\.\d+\.\d+[^\s+]*)(\+\S+)?/i;
+  const m = raw.trim().match(pattern);
   if (m?.[1] === undefined || m[2] === undefined) return undefined;
   return { name: m[1], version: m[2], hash: m[3] !== undefined ? m[3].slice(1) : undefined };
 }
@@ -690,7 +703,10 @@ function detectPackageManagerToolchain(
     };
   }
 
-  const pin = parsePackageManagerSpec(pmField);
+  // Anchored: the WHOLE field must be a valid corepack pin — a malformed
+  // declaration (trailing junk after the version/hash) must not pass off a
+  // leading-token match (greptile mmnto-ai/totem#2254).
+  const pin = parsePackageManagerSpec(pmField, { anchored: true });
   if (pin === undefined) {
     return {
       status: 'skip',
@@ -726,7 +742,7 @@ function detectPackageManagerToolchain(
   return {
     status: 'warn',
     message: `${pin.name} engine pin stale — packageManager ${pin.version} < cohort floor ${floorSpec.version}${hashNote}`,
-    remediation: `Bump the packageManager field to ${pin.name}@>=${floorSpec.version} (corepack auto-selects per pin), then re-run totem doctor --parity.`,
+    remediation: `Bump the packageManager field to ${pin.name}@${floorSpec.version} (or a newer EXACT version — corepack requires an exact pin, not a range), then re-run totem doctor --parity.`,
   };
 }
 

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -69,6 +69,15 @@ const SIBLING_TOTEM_DIRNAME = 'totem';
  */
 const SIBLING_STRATEGY_DIRNAME = 'totem-strategy';
 
+/**
+ * Parity dimension for toolchain-version rows. A row in this dimension that
+ * resolves NO deps package (e.g. `pnpm-engine-version`) pins its engine via the
+ * consumer's `packageManager` field instead — the toolchain reader senses it
+ * (mmnto-ai/totem#2115). `mmnto-cli-version` shares this dimension but resolves
+ * `@mmnto/cli`, so it stays on the deps path.
+ */
+const TOOLCHAIN_DIMENSION = 'toolchain-version';
+
 /** Bounded git-command timeout for the origin-remote probe (matches `sys/git.ts`). */
 const GIT_REMOTE_TIMEOUT_MS = 15_000;
 
@@ -468,6 +477,8 @@ export interface PackageJsonShape {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
   optionalDependencies?: Record<string, string>;
+  /** Corepack engine pin (`<name>@<version>(+<hash>)?`) — read by the toolchain reader (mmnto-ai/totem#2115). */
+  packageManager?: string;
 }
 
 /**
@@ -515,6 +526,12 @@ export function detectVersionPinnedContract(
   // standalone callers (tests). gitRoot is the floorRoot for a path locator.
   const packageName = ctx.packageName ?? packageNameForContract(contract, ctx.gitRoot);
   if (packageName === undefined) {
+    // A toolchain-version row with no deps package pins its engine via the
+    // consumer's `packageManager` field (e.g. pnpm-engine-version) — route it to
+    // the packageManager reader rather than skipping (mmnto-ai/totem#2115).
+    if (contract.dimension === TOOLCHAIN_DIMENSION) {
+      return detectPackageManagerToolchain(contract, ctx);
+    }
     return {
       status: 'skip',
       message: `not a deps version-pinned contract this slice handles (${contract.id})`,
@@ -608,6 +625,108 @@ export function detectVersionPinnedContract(
     status: 'warn',
     message: `${packageName} pin stale — declared ${declaredRange}, installed ${installed} < cohort floor ${floor.version} (${floor.source})`,
     remediation: `Bump the ${packageName} dependency to >= ${floor.version} and reinstall, then re-run totem doctor --parity.`,
+  };
+}
+
+// ─── detectPackageManagerToolchain ──────────────────────
+
+/** A parsed corepack `packageManager` spec: `<name>@<version>(+<hash>)?`. */
+interface PackageManagerSpec {
+  name: string;
+  version: string;
+  /** The corepack integrity hash (after `+`), or undefined for a hashless pin. */
+  hash: string | undefined;
+}
+
+/**
+ * Parse the LEADING `<name>@<version>(+<hash>)?` token out of a corepack-shaped
+ * string. Tolerant of trailing prose so it reads BOTH a `packageManager` field
+ * (`pnpm@11.2.2+sha512…`) and a manifest floor expressed as
+ * `pnpm@11.2.2 floor; pin >= floor`. Returns undefined when no leading spec
+ * token is present. Pure + total — never throws (mmnto-ai/totem#2115).
+ */
+function parsePackageManagerSpec(raw: string | undefined | null): PackageManagerSpec | undefined {
+  if (typeof raw !== 'string') return undefined;
+  // <name> = a package-manager slug; <version> = a semver core (+ optional
+  // prerelease/build that stops at whitespace or the `+hash` delimiter).
+  const m = raw.trim().match(/^([a-z][a-z0-9-]*)@(\d+\.\d+\.\d+[^\s+]*)(\+\S+)?/i);
+  if (m?.[1] === undefined || m[2] === undefined) return undefined;
+  return { name: m[1], version: m[2], hash: m[3] !== undefined ? m[3].slice(1) : undefined };
+}
+
+/**
+ * Sense a toolchain-version row that pins its engine via the consumer's
+ * `packageManager` field (e.g. `pnpm-engine-version`). The manifest row carries
+ * the floor in `expected-value-or-derivation` (`<engine>@<floor>` — there is no
+ * `packages/*​/package.json` to glob, `canonical-source` is null). Reads the
+ * DECLARATION only (`senses: declared`) — never probes the installed binary.
+ *
+ * Verdicts (claim-class bound to pin currency, mirroring the deps path):
+ *   - **pass** — consumer's `packageManager` engine matches + version ≥ floor.
+ *   - **warn** — engine matches but version < floor (stale).
+ *   - **skip** — no floor derivable / no `packageManager` field / unparseable pin
+ *     / a DIFFERENT engine (the floor doesn't apply) / invalid versions.
+ * NEVER throws, NEVER networks (mmnto-ai/totem#2115).
+ */
+function detectPackageManagerToolchain(
+  contract: ParityContract,
+  ctx: DetectVersionPinnedContext,
+): ParityContractVerdict {
+  const floorSpec = parsePackageManagerSpec(contract.expectedValueOrDerivation);
+  if (floorSpec === undefined) {
+    return {
+      status: 'skip',
+      message: `${contract.id}: cohort floor not derivable from expected-value "${contract.expectedValueOrDerivation}"`,
+    };
+  }
+
+  const readPkg = ctx.readPackageJson ?? readPackageJson;
+  const consumerPkg = readPkg(path.join(ctx.cwd, 'package.json'));
+  const pmField = consumerPkg?.packageManager;
+  if (typeof pmField !== 'string' || pmField.trim().length === 0) {
+    return {
+      status: 'skip',
+      message: `${contract.id}: no packageManager field declared (honest-absent)`,
+    };
+  }
+
+  const pin = parsePackageManagerSpec(pmField);
+  if (pin === undefined) {
+    return {
+      status: 'skip',
+      message: `${contract.id}: packageManager "${pmField}" is not a parseable <name>@<version> pin`,
+    };
+  }
+
+  // A different engine → this row's floor simply doesn't apply here.
+  if (pin.name !== floorSpec.name) {
+    return {
+      status: 'skip',
+      message: `${contract.id}: consumer pins ${pin.name}@${pin.version}, not ${floorSpec.name} — cohort floor does not apply`,
+    };
+  }
+
+  if (semver.valid(pin.version) === null || semver.valid(floorSpec.version) === null) {
+    return {
+      status: 'skip',
+      message: `${contract.id}: unparseable version (pin "${pin.version}", floor "${floorSpec.version}")`,
+    };
+  }
+
+  // Hashless pins lose corepack integrity verification — surfaced as a note, not
+  // a failure (strategy#566 Greptile P2: hashless pins are a derive-before-authoring smell).
+  const hashNote =
+    pin.hash === undefined ? ' (pin is hashless — corepack integrity not pinned)' : '';
+  if (semver.gte(pin.version, floorSpec.version)) {
+    return {
+      status: 'pass',
+      message: `${pin.name} engine pin current — packageManager ${pin.version} ≥ cohort floor ${floorSpec.version}${hashNote}`,
+    };
+  }
+  return {
+    status: 'warn',
+    message: `${pin.name} engine pin stale — packageManager ${pin.version} < cohort floor ${floorSpec.version}${hashNote}`,
+    remediation: `Bump the packageManager field to ${pin.name}@>=${floorSpec.version} (corepack auto-selects per pin), then re-run totem doctor --parity.`,
   };
 }
 

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -642,9 +642,9 @@ interface PackageManagerSpec {
  * Parse a `<name>@<version>(+<hash>)?` corepack spec.
  *
  * Two modes (greptile review mmnto-ai/totem#2254):
- *   - `anchored: false` (default) — match the LEADING token, tolerating trailing
+ *   - `exact: false` (default) — match the LEADING token, tolerating trailing
  *     prose. For the manifest FLOOR, expressed as `pnpm@11.2.2 floor; pin >= floor`.
- *   - `anchored: true` — the WHOLE trimmed value must match. For the consumer's
+ *   - `exact: true` — the WHOLE trimmed value must match. For the consumer's
  *     `packageManager` field: corepack requires the entire value to be a valid
  *     `<name>@<version>[+<hash>]`, so a declaration like `pnpm@11.2.2 garbage`
  *     is MALFORMED — doctor must not report it current off a leading-token match.
@@ -653,13 +653,13 @@ interface PackageManagerSpec {
  */
 function parsePackageManagerSpec(
   raw: string | undefined | null,
-  opts: { anchored?: boolean } = {},
+  opts: { exact?: boolean } = {},
 ): PackageManagerSpec | undefined {
   if (typeof raw !== 'string') return undefined;
   // <name> = a package-manager slug; <version> = a semver core (+ optional
   // prerelease/build that stops at whitespace or the `+hash` delimiter). Under
-  // `anchored`, a trailing `$` rejects anything after the (optional) hash.
-  const pattern = opts.anchored
+  // `exact`, a trailing `$` rejects anything after the (optional) hash.
+  const pattern = opts.exact
     ? /^([a-z][a-z0-9-]*)@(\d+\.\d+\.\d+[^\s+]*)(\+\S+)?$/i
     : /^([a-z][a-z0-9-]*)@(\d+\.\d+\.\d+[^\s+]*)(\+\S+)?/i;
   const m = raw.trim().match(pattern);
@@ -703,10 +703,10 @@ function detectPackageManagerToolchain(
     };
   }
 
-  // Anchored: the WHOLE field must be a valid corepack pin — a malformed
+  // Exact match: the WHOLE field must be a valid corepack pin — a malformed
   // declaration (trailing junk after the version/hash) must not pass off a
   // leading-token match (greptile mmnto-ai/totem#2254).
-  const pin = parsePackageManagerSpec(pmField, { anchored: true });
+  const pin = parsePackageManagerSpec(pmField, { exact: true });
   if (pin === undefined) {
     return {
       status: 'skip',


### PR DESCRIPTION
## What

Continues the parity-engine hardening cluster (after #2252). Teaches the `version-pinned` detector a **toolchain sub-class**: a `toolchain-version` row that resolves no deps package (e.g. `pnpm-engine-version`) now reads the consumer's **`packageManager`** field (`pnpm@11.2.2+sha512…`) instead of a `dependencies` range.

- `detectVersionPinnedContract` self-routes such rows to a new `detectPackageManagerToolchain` (core `parity-detect.ts`); the CLI (`doctor-parity.ts`) no longer stubs `toolchain-version` rows as *"drift detection not yet implemented"*.
- **Floor source:** the row's own `expected-value-or-derivation` (`pnpm@<floor>`) — there's no `packages/*/package.json` to glob, `canonical-source` is null. Reads the **declaration** only (`senses: declared`), never probes the installed binary.
- Parses `<name>@<version>(+<hash>)?` tolerantly (handles both the `packageManager` field and the prose floor), compares `version >= floor`, and surfaces a **hashless-pin note** (corepack integrity not pinned — strategy#566 Greptile P2).
- **Honest-absent** on a missing field, a different engine (the floor doesn't apply), an unparseable pin, or a non-derivable floor. Never networks, never throws.
- A `toolchain-version` row that DOES resolve a deps package (`mmnto-cli-version`) stays on the existing deps floor path (regression-guarded).

## Empirical proof

`totem doctor --parity` on totem (root pins `pnpm@11.2.2+sha512…`) — the row that was SKIP now reads:

```
PASS — pnpm engine pin current — packageManager 11.2.2 ≥ cohort floor 11.2.2
```

## Tests

`parity-detect.test.ts` +9: PASS/WARN, hashless note, no-field skip, different-engine skip, unparseable-pin skip, non-derivable-floor skip, adversarial-never-throws, and the deps-package-stays-on-deps-path guard.

## Gate

`tsc` clean · core+cli suites pass · ESLint 0 errors · `totem lint` PASS · changeset (minor · core + cli).

Closes #2115.