### PR TITLE
chore(doctrine): pin @mmnto/strategy-doctrine 0.1.13 → 0.1.14 (content-hash row live; #2107)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "typescript-eslint": "^8.59.4"
   },
   "optionalDependencies": {
-    "@mmnto/strategy-doctrine": "0.1.13"
+    "@mmnto/strategy-doctrine": "0.1.14"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         version: 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
     optionalDependencies:
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.13
-        version: 0.1.13
+        specifier: 0.1.14
+        version: 0.1.14
 
   packages/cli:
     dependencies:
@@ -853,8 +853,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.13':
-    resolution: {integrity: sha512-4uU89+4YMRecjIPIPONevwjyTTvEOzPcbg7BbmpgNKeOKNQlsh58xV9k50N0DgIrUqWpwzOtdaHmfD9lnWPEGA==}
+  '@mmnto/strategy-doctrine@0.1.14':
+    resolution: {integrity: sha512-XEwjqxwMWp+FrhmEzOH+FSnQ5msSpsMUjLoBTdK0claTa4UwcUusrbNXLqxnPoIsdtZuQoGlnggRKbaZsGqjlg==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3685,7 +3685,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.13':
+  '@mmnto/strategy-doctrine@0.1.14':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
Pins `@mmnto/strategy-doctrine` 0.1.13 → 0.1.14 — consuming strategy#754's `strategy-doctrine-lock-content` row, now live in the 0.1.14 bundle. Activates totem's own content-hash sensing.

`totem doctor --parity` verified **LIVE** against 0.1.14:
- self-consistency **PASS ×3** (packaged artifacts match their lock hashes)
- vs-canonical **PASS ×3** (the 0.1.13→0.1.14 bump closes the `parity-manifest.yaml` currency gap — `838814af` matches lock + local canonical)
- pin-currency row **PASS** — installed 0.1.14 ≥ floor 0.1.14

The #2251/#2223 doctrine-pin pattern: 2-file chore (optionalDependencies + lockfile), **no changeset** → no release. Completes the totem-consumer side of #2107 (detector shipped in 1.78.0 via #2256; row in strategy#754 / strategy-doctrine@0.1.14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)