### PR TITLE
feat(spine): ADR-112 §4 preimage-source-pluggable — preimageSource union (strategy#591)

### DIFF
--- a/.changeset/adr-112-preimage-source-union.md
+++ b/.changeset/adr-112-preimage-source-union.md
@@ -1,0 +1,15 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': patch
+---
+
+feat(spine): ADR-112 §4 — preimage-differential source-pluggable (`preimageSource` union)
+
+Reframes the authored-rule fixture's preimage anchor from a fixed commit-pair to a per-fixture **`preimageSource` discriminated union** (strategy#591 / ADR-112 §4, coupling mmnto-ai/totem-strategy#767):
+
+- **`{ kind: 'lesson', lessonRef, badExample, goodExample }` (PRIMARY)** — for **review-caught** repos that fold the fix into the introducing commit, so the defect structurally almost never lands on `main` (lc: 18 `fix(` of 433). The positive control fires on the lesson `badExample` and stays silent on `goodExample`. `lessonRef` is bound to the immutable 16-hex `hashLesson` codomain (never a path or mutable alias — §8 identity discipline).
+- **`{ kind: 'commit', preimageCommitSha, mergeCommitSha }` (FALLBACK)** — the prior commit-pair binding, now scoped to **land-then-fix** repos.
+
+`AuthoredFixtureSchema` is the single home (auto-threads to `AuthoredProvenanceRecordSchema` + the YAML-input `AuthoredRuleInput`); the new `PreimageSourceSchema` / `PreimageSource` are exported. Built as `z.discriminatedUnion` with each branch `.strict()`, so a cross-branch key fails loud (FM(d)). The `totem rule author` YAML input contract changes accordingly (authors declare a `preimageSource` instead of flat commit fields); the recursive producer-key scan walks the new union depth.
+
+No data migration is owed — there is no persisted authored-rule set, and the flat schema was never released (it ships first in this same union'd version). The §4 preimage-differential itself (fire-on-preimage / silent-on-postimage) materializes in Slices C/D; this slice is the schema + producer + tests.

--- a/packages/cli/src/commands/rule-author-command.test.ts
+++ b/packages/cli/src/commands/rule-author-command.test.ts
@@ -38,8 +38,11 @@ afterEach(() => {
 
 const fixture = (pr: number) => ({
   pr,
-  mergeCommitSha: 'a'.repeat(40),
-  preimageCommitSha: 'b'.repeat(40),
+  preimageSource: {
+    kind: 'commit',
+    preimageCommitSha: 'b'.repeat(40),
+    mergeCommitSha: 'a'.repeat(40),
+  },
   filePath: 'src/x.ts',
   matchedSpan: 'L1',
   contentHash: 'h'.repeat(8),

--- a/packages/cli/src/commands/rule-author.test.ts
+++ b/packages/cli/src/commands/rule-author.test.ts
@@ -23,10 +23,23 @@ afterEach(() => {
 
 const SHA_A = 'a'.repeat(40);
 const SHA_B = 'b'.repeat(40);
+// §4 FALLBACK: a commit-pair preimageSource (land-then-fix).
 const fixture = (pr: number) => ({
   pr,
-  mergeCommitSha: SHA_A,
-  preimageCommitSha: SHA_B,
+  preimageSource: { kind: 'commit', preimageCommitSha: SHA_B, mergeCommitSha: SHA_A },
+  filePath: 'src/x.ts',
+  matchedSpan: 'L1-L2',
+  contentHash: 'h'.repeat(8),
+});
+// §4 PRIMARY: a lesson-anchored preimageSource (review-caught) — the cert-#1 path.
+const lessonFixture = (pr: number) => ({
+  pr,
+  preimageSource: {
+    kind: 'lesson',
+    lessonRef: 'a1b2c3d4e5f60718',
+    badExample: 'console.log("dbg")',
+    goodExample: 'logger.debug("dbg")',
+  },
   filePath: 'src/x.ts',
   matchedSpan: 'L1-L2',
   contentHash: 'h'.repeat(8),
@@ -87,6 +100,19 @@ describe('runRuleAuthor — FM(d) reject-loud at the reader (the trust boundary)
   });
   it('rejects a producer-owned key nested inside origin', () => {
     writeYaml([decidableRule({ origin: { kind: 'from-scratch', ruleId: 'x'.repeat(16) } })]);
+    expect(() => run()).toThrow(/producer-owned key/i);
+  });
+  it('rejects a producer-owned key nested inside preimageSource (recursive scan walks the §4 union — FM(d))', () => {
+    writeYaml([
+      decidableRule({
+        positiveFixtures: [
+          {
+            ...fixture(101),
+            preimageSource: { ...fixture(101).preimageSource, ruleId: 'x'.repeat(16) },
+          },
+        ],
+      }),
+    ]);
     expect(() => run()).toThrow(/producer-owned key/i);
   });
 });
@@ -173,11 +199,21 @@ describe('runRuleAuthor — fail-loud IO', () => {
 
 describe('runRuleAuthor — codex/agy diff-review folds', () => {
   it('the ledger binds BOTH positive AND negative fixture PRs (codex)', () => {
-    writeYaml([decidableRule({ negativeFixtures: [fixture(202)] })]);
+    // Mixed §4 sources: a commit-pair positive + a lesson-anchored negative — the reader
+    // accepts both kinds and binds their PRs (the §4 union threads through the whole intake).
+    writeYaml([decidableRule({ negativeFixtures: [lessonFixture(202)] })]);
     run();
     const ledger = readAuthoringLedger(totemDir);
     expect(ledger[0]?.positiveFixturePrs).toEqual([101]);
     expect(ledger[0]?.negativeFixturePrs).toEqual([202]);
+  });
+  it('authors a lesson-anchored (PRIMARY, review-caught) positive fixture end-to-end (§4 cert-#1 path)', () => {
+    writeYaml([decidableRule({ positiveFixtures: [lessonFixture(101)] })]);
+    const res = run();
+    expect(res.minted).toBe(1);
+    const src = res.records[0]?.provenance.positiveFixtures[0]?.preimageSource;
+    expect(src?.kind).toBe('lesson');
+    if (src?.kind === 'lesson') expect(src.lessonRef).toBe('a1b2c3d4e5f60718');
   });
   it('a revision appends a row carrying the NEW contentHash under the SAME ruleId (agy)', () => {
     writeYaml([decidableRule()]);

--- a/packages/core/src/compiler-schema.test.ts
+++ b/packages/core/src/compiler-schema.test.ts
@@ -4,6 +4,7 @@ import { canonicalStringify } from './compile-manifest.js';
 import type { RuleEventCallback } from './compiler-schema.js';
 import {
   AstGrepYamlRuleSchema,
+  AuthoredFixtureSchema,
   AuthoredProvenanceRecordSchema,
   CompiledRuleSchema,
   CompilerOutputSchema,
@@ -17,6 +18,7 @@ import {
   NonCompilableEntryReadSchema,
   NonCompilableEntryWriteSchema,
   NonCompilableReasonCodeSchema,
+  PreimageSourceSchema,
   provenanceKind,
   ProvenanceRecordSchema,
   shouldWriteToLedger,
@@ -990,8 +992,30 @@ describe('legitimacy / ruleClass marker (mmnto-ai/totem#2183)', () => {
       positiveFixtures: [
         {
           pr: 100,
-          mergeCommitSha: 'b'.repeat(40),
-          preimageCommitSha: 'c'.repeat(40),
+          // §4 FALLBACK source — commit-pair (land-then-fix).
+          preimageSource: {
+            kind: 'commit' as const,
+            preimageCommitSha: 'c'.repeat(40),
+            mergeCommitSha: 'b'.repeat(40),
+          },
+          filePath: 'src/physics/step.ts',
+          matchedSpan: 'L10-L12',
+          contentHash: 'deadbeefcafe',
+        },
+      ],
+    };
+    // §4 PRIMARY source — lesson-anchored (review-caught); same fixture, lesson preimageSource.
+    const authoredLesson = {
+      ...authored,
+      positiveFixtures: [
+        {
+          pr: 100,
+          preimageSource: {
+            kind: 'lesson' as const,
+            lessonRef: 'a1b2c3d4e5f60718', // 16-hex hashLesson codomain
+            badExample: 'if (a == b) { applyImpulse(); }',
+            goodExample: 'if (Math.abs(a - b) < EPS) { applyImpulse(); }',
+          },
           filePath: 'src/physics/step.ts',
           matchedSpan: 'L10-L12',
           contentHash: 'deadbeefcafe',
@@ -1064,13 +1088,134 @@ describe('legitimacy / ruleClass marker (mmnto-ai/totem#2183)', () => {
       }
     });
 
-    it('rejects a fixture with a malformed preimage/merge SHA', () => {
+    it('accepts both §4 preimageSource kinds and preserves the discriminator + branch fields', () => {
+      const commit = AuthoredProvenanceRecordSchema.parse(authored);
+      const lesson = AuthoredProvenanceRecordSchema.parse(authoredLesson);
+      const cSrc = commit.positiveFixtures[0].preimageSource;
+      const lSrc = lesson.positiveFixtures[0].preimageSource;
+      expect(cSrc.kind).toBe('commit');
+      if (cSrc.kind === 'commit') expect(cSrc.preimageCommitSha).toBe('c'.repeat(40));
+      expect(lSrc.kind).toBe('lesson');
+      if (lSrc.kind === 'lesson') {
+        expect(lSrc.lessonRef).toBe('a1b2c3d4e5f60718');
+        expect(lSrc.badExample).toBe('if (a == b) { applyImpulse(); }');
+      }
+    });
+
+    // The §4 commit branch carries TWO SHAs; the old flat test only guarded preimageCommitSha.
+    // Each malformed-SHA case keeps the OTHER SHA valid so the rejection can ONLY be the regex
+    // under test — not a missing-field throw (the rewrap landmine: a top-level preimageCommitSha
+    // override would be STRIPPED by the non-strict outer object and the test would silently pass).
+    it('rejects a commit preimageSource with a malformed preimageCommitSha (other SHA valid)', () => {
       expect(() =>
-        AuthoredProvenanceRecordSchema.parse({
-          ...authored,
-          positiveFixtures: [{ ...authored.positiveFixtures[0], preimageCommitSha: 'nope' }],
+        AuthoredFixtureSchema.parse({
+          ...authored.positiveFixtures[0],
+          preimageSource: {
+            kind: 'commit',
+            preimageCommitSha: 'nope',
+            mergeCommitSha: 'b'.repeat(40),
+          },
         }),
       ).toThrow();
+    });
+
+    it('rejects a commit preimageSource with a malformed mergeCommitSha (other SHA valid)', () => {
+      expect(() =>
+        AuthoredFixtureSchema.parse({
+          ...authored.positiveFixtures[0],
+          preimageSource: {
+            kind: 'commit',
+            preimageCommitSha: 'c'.repeat(40),
+            mergeCommitSha: 'nope',
+          },
+        }),
+      ).toThrow();
+    });
+
+    it('rejects a lesson preimageSource whose lessonRef is a path or mutable alias (immutable 16-hex id only)', () => {
+      for (const badRef of [
+        'docs/lessons/foo.md',
+        'latest',
+        'a1b2c3d4e5f60718x',
+        'A1B2C3D4E5F60718',
+      ]) {
+        expect(() =>
+          PreimageSourceSchema.parse({
+            kind: 'lesson',
+            lessonRef: badRef,
+            badExample: 'x == y',
+            goodExample: 'abs(x - y) < EPS',
+          }),
+        ).toThrow();
+      }
+    });
+
+    it('rejects a lesson preimageSource with a whitespace-only badExample or goodExample (vacuous control)', () => {
+      const base = { kind: 'lesson' as const, lessonRef: 'a1b2c3d4e5f60718' };
+      expect(() =>
+        PreimageSourceSchema.parse({ ...base, badExample: '   ', goodExample: 'ok' }),
+      ).toThrow();
+      expect(() =>
+        PreimageSourceSchema.parse({ ...base, badExample: 'bad', goodExample: '  ' }),
+      ).toThrow();
+    });
+
+    it('rejects a fixture missing preimageSource entirely (§4 source is required)', () => {
+      const { preimageSource: _omit, ...noSource } = authored.positiveFixtures[0];
+      void _omit;
+      expect(() => AuthoredFixtureSchema.parse(noSource)).toThrow();
+    });
+
+    it('rejects a preimageSource with a missing or unknown kind (discriminated union)', () => {
+      const validLessonBody = {
+        lessonRef: 'a1b2c3d4e5f60718',
+        badExample: 'x == y',
+        goodExample: 'abs(x - y) < EPS',
+      };
+      // No kind at all, and a bogus kind on an otherwise-valid lesson body — both fail the discriminator.
+      expect(() => PreimageSourceSchema.parse(validLessonBody)).toThrow();
+      expect(() => PreimageSourceSchema.parse({ kind: 'bogus', ...validLessonBody })).toThrow();
+    });
+
+    it('rejects a cross-branch leak — a lesson key under kind:commit (strict branch, FM(d))', () => {
+      expect(() =>
+        PreimageSourceSchema.parse({
+          kind: 'commit',
+          preimageCommitSha: 'c'.repeat(40),
+          mergeCommitSha: 'b'.repeat(40),
+          badExample: 'x == y', // foreign key — strict branch fails LOUD, never silently stripped
+        }),
+      ).toThrow();
+    });
+
+    it('does not mutate whitespace-padded (but non-empty) lesson exemplars (non-mutating validator)', () => {
+      const padded = '  if (a == b) {}  ';
+      const parsed = PreimageSourceSchema.parse({
+        kind: 'lesson',
+        lessonRef: 'a1b2c3d4e5f60718',
+        badExample: padded,
+        goodExample: padded,
+      });
+      if (parsed.kind === 'lesson') {
+        expect(parsed.badExample).toBe(padded);
+        expect(parsed.goodExample).toBe(padded);
+      }
+    });
+
+    it('threads the union through negativeFixtures (same shape, lesson kind)', () => {
+      const withNeg = AuthoredProvenanceRecordSchema.parse({
+        ...authored,
+        negativeFixtures: authoredLesson.positiveFixtures,
+      });
+      expect(withNeg.negativeFixtures?.[0].preimageSource.kind).toBe('lesson');
+    });
+
+    it('round-trips a fixture-bearing authored record byte-identically (manifest-hash safe)', () => {
+      for (const rec of [authored, authoredLesson]) {
+        const before = canonicalStringify(rec);
+        const after = canonicalStringify(AuthoredProvenanceRecordSchema.parse(rec));
+        expect(after).toBe(before);
+      }
     });
 
     it('does not let an authored record masquerade as mined (kind required on authored branch)', () => {

--- a/packages/core/src/compiler-schema.test.ts
+++ b/packages/core/src/compiler-schema.test.ts
@@ -1144,6 +1144,36 @@ describe('legitimacy / ruleClass marker (mmnto-ai/totem#2183)', () => {
       ).toThrow();
     });
 
+    // ANTI-VACUITY fast-fail (GCA finding; strategy#767-blessed). Identical preimage/postimage sides
+    // are an UNCONDITIONALLY vacuous control — rejected at intake. This is NOT the §4 differential
+    // (that's C/D); it only catches the degenerate identical-sides case (zero-false-positive).
+    it('rejects a lesson fixture whose badExample equals its goodExample (vacuous — identical sides)', () => {
+      expect(() =>
+        AuthoredFixtureSchema.parse({
+          ...authoredLesson.positiveFixtures[0],
+          preimageSource: {
+            kind: 'lesson',
+            lessonRef: 'a1b2c3d4e5f60718',
+            badExample: 'if (a == b) {}',
+            goodExample: '  if (a == b) {}  ', // trim-equal → still vacuous (non-mutating compare)
+          },
+        }),
+      ).toThrow(/identical sides|must differ/i);
+    });
+
+    it('rejects a commit fixture whose preimageCommitSha equals its mergeCommitSha (vacuous — identical sides)', () => {
+      expect(() =>
+        AuthoredFixtureSchema.parse({
+          ...authored.positiveFixtures[0],
+          preimageSource: {
+            kind: 'commit',
+            preimageCommitSha: 'a'.repeat(40),
+            mergeCommitSha: 'a'.repeat(40),
+          },
+        }),
+      ).toThrow(/identical pre\/post commit|must differ/i);
+    });
+
     it('rejects a lesson preimageSource whose lessonRef is a path or mutable alias (immutable 16-hex id only)', () => {
       for (const badRef of [
         'docs/lessons/foo.md',

--- a/packages/core/src/compiler-schema.test.ts
+++ b/packages/core/src/compiler-schema.test.ts
@@ -1104,8 +1104,9 @@ describe('legitimacy / ruleClass marker (mmnto-ai/totem#2183)', () => {
 
     // The §4 commit branch carries TWO SHAs; the old flat test only guarded preimageCommitSha.
     // Each malformed-SHA case keeps the OTHER SHA valid so the rejection can ONLY be the regex
-    // under test — not a missing-field throw (the rewrap landmine: a top-level preimageCommitSha
-    // override would be STRIPPED by the non-strict outer object and the test would silently pass).
+    // under test — not a missing-field throw (the rewrap landmine: a bad value must live INSIDE
+    // preimageSource; a top-level leftover SHA is now rejected by the strict outer object too).
+    // The asserted message text is the GCA-requested regression guard (the message is wired).
     it('rejects a commit preimageSource with a malformed preimageCommitSha (other SHA valid)', () => {
       expect(() =>
         AuthoredFixtureSchema.parse({
@@ -1116,7 +1117,7 @@ describe('legitimacy / ruleClass marker (mmnto-ai/totem#2183)', () => {
             mergeCommitSha: 'b'.repeat(40),
           },
         }),
-      ).toThrow();
+      ).toThrow(/preimageCommitSha must be a 40-character lowercase hex commit SHA/);
     });
 
     it('rejects a commit preimageSource with a malformed mergeCommitSha (other SHA valid)', () => {
@@ -1128,6 +1129,17 @@ describe('legitimacy / ruleClass marker (mmnto-ai/totem#2183)', () => {
             preimageCommitSha: 'c'.repeat(40),
             mergeCommitSha: 'nope',
           },
+        }),
+      ).toThrow(/mergeCommitSha must be a 40-character lowercase hex commit SHA/);
+    });
+
+    it('rejects a fixture carrying a leftover flat SHA alongside preimageSource (strict outer — CR outside-diff)', () => {
+      // A partial migration (preimageSource added but a stale flat mergeCommitSha left behind) must
+      // fail LOUD under `.strict()`, never validate-and-silently-strip the leftover key (FM(d)).
+      expect(() =>
+        AuthoredFixtureSchema.parse({
+          ...authored.positiveFixtures[0],
+          mergeCommitSha: 'b'.repeat(40), // leftover flat field — unknown to the strict fixture
         }),
       ).toThrow();
     });

--- a/packages/core/src/compiler-schema.ts
+++ b/packages/core/src/compiler-schema.ts
@@ -181,9 +181,13 @@ export const PreimageSourceSchema = z.discriminatedUnion('kind', [
     .object({
       kind: z.literal('commit'),
       /** The PARENT (pre-fix) commit where the DEFECT is present — the matcher must FIRE on this (ADR-112 §4). */
-      preimageCommitSha: z.string().regex(COMMIT_SHA_RE),
+      preimageCommitSha: z.string().regex(COMMIT_SHA_RE, {
+        message: 'preimageCommitSha must be a 40-character lowercase hex commit SHA',
+      }),
       /** The PR's merge/squash commit — the post-fix (defect-absent) anchor; the matcher must stay SILENT on this. */
-      mergeCommitSha: z.string().regex(COMMIT_SHA_RE),
+      mergeCommitSha: z.string().regex(COMMIT_SHA_RE, {
+        message: 'mergeCommitSha must be a 40-character lowercase hex commit SHA',
+      }),
     })
     .strict(),
 ]);
@@ -198,24 +202,29 @@ export type PreimageSource = z.infer<typeof PreimageSourceSchema>;
  * possible. `matchedSpan` + `contentHash` are the line-drift-stable locus
  * (cf. `firingLabelId`), not just the file.
  */
-export const AuthoredFixtureSchema = z.object({
-  /** The PR where the defect was caught/introduced (the in-corpus anchor). */
-  pr: z.number().int().positive(),
-  /** The §4 preimage-differential source — lesson-anchored (PRIMARY) or commit-pair (FALLBACK). */
-  preimageSource: PreimageSourceSchema,
-  /** File the defect locus lives in. */
-  filePath: z.string().refine((s) => s.trim().length > 0, {
-    message: 'filePath must be a non-empty reference',
-  }),
-  /** Line-range or AST-node path — the defect locus, not just the file. */
-  matchedSpan: z.string().refine((s) => s.trim().length > 0, {
-    message: 'matchedSpan must be a non-empty locus',
-  }),
-  /** Span content hash, line-drift-stable (cf. `firingLabelId`). */
-  contentHash: z.string().refine((s) => s.trim().length > 0, {
-    message: 'contentHash must be a non-empty hash',
-  }),
-});
+export const AuthoredFixtureSchema = z
+  .object({
+    /** The PR where the defect was caught/introduced (the in-corpus anchor). */
+    pr: z.number().int().positive(),
+    /** The §4 preimage-differential source — lesson-anchored (PRIMARY) or commit-pair (FALLBACK). */
+    preimageSource: PreimageSourceSchema,
+    /** File the defect locus lives in. */
+    filePath: z.string().refine((s) => s.trim().length > 0, {
+      message: 'filePath must be a non-empty reference',
+    }),
+    /** Line-range or AST-node path — the defect locus, not just the file. */
+    matchedSpan: z.string().refine((s) => s.trim().length > 0, {
+      message: 'matchedSpan must be a non-empty locus',
+    }),
+    /** Span content hash, line-drift-stable (cf. `firingLabelId`). */
+    contentHash: z.string().refine((s) => s.trim().length > 0, {
+      message: 'contentHash must be a non-empty hash',
+    }),
+  })
+  // `.strict()` (CR outside-diff): the outer fixture closes too, not just the union branches —
+  // a partially-migrated fixture carrying `preimageSource` AND a leftover flat `mergeCommitSha`/
+  // `preimageCommitSha` must fail LOUD, never validate-and-silently-strip the stale key (FM(d)).
+  .strict();
 
 export type AuthoredFixture = z.infer<typeof AuthoredFixtureSchema>;
 

--- a/packages/core/src/compiler-schema.ts
+++ b/packages/core/src/compiler-schema.ts
@@ -224,7 +224,35 @@ export const AuthoredFixtureSchema = z
   // `.strict()` (CR outside-diff): the outer fixture closes too, not just the union branches —
   // a partially-migrated fixture carrying `preimageSource` AND a leftover flat `mergeCommitSha`/
   // `preimageCommitSha` must fail LOUD, never validate-and-silently-strip the stale key (FM(d)).
-  .strict();
+  .strict()
+  // ANTI-VACUITY FAST-FAIL (GCA finding; strategy#767-blessed defense-in-depth). This is NOT the
+  // §4 preimage-differential — that is the load-bearing C/D materializer (fire-on-preimage /
+  // silent-on-postimage). This only rejects the DEGENERATE case where the two sides are IDENTICAL:
+  // an identical preimage/postimage is an UNCONDITIONALLY vacuous control (a matcher cannot fire on
+  // one and stay silent on the other), so it is zero-false-positive to reject at intake — distinct
+  // from "does the differential hold", which two *different* sides still must prove in C/D.
+  // Non-mutating (compares trimmed, never transforms) — manifest-hash stability. A `superRefine` on
+  // the OUTER fixture (not a branch `.refine`, which would wrap a `discriminatedUnion` member in a
+  // ZodEffects and break discriminator extraction).
+  .superRefine((fixture, ctx) => {
+    const src = fixture.preimageSource;
+    if (src.kind === 'lesson' && src.badExample.trim() === src.goodExample.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'badExample and goodExample must differ — identical sides are a vacuous preimage-differential control (ADR-112 §4)',
+        path: ['preimageSource', 'goodExample'],
+      });
+    }
+    if (src.kind === 'commit' && src.preimageCommitSha === src.mergeCommitSha) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'preimageCommitSha and mergeCommitSha must differ — an identical pre/post commit is a vacuous preimage-differential control (ADR-112 §4)',
+        path: ['preimageSource', 'mergeCommitSha'],
+      });
+    }
+  });
 
 export type AuthoredFixture = z.infer<typeof AuthoredFixtureSchema>;
 

--- a/packages/core/src/compiler-schema.ts
+++ b/packages/core/src/compiler-schema.ts
@@ -50,6 +50,17 @@ export type AstGrepYamlRule = NapiConfig;
 const COMMIT_SHA_RE = /^[0-9a-f]{40}$/;
 
 /**
+ * ADR-112 §4/§8 — the codomain of an IMMUTABLE lesson reference: the 16-hex
+ * `hashLesson` id (`compile-lesson.ts`). A `lessonRef` MUST be this immutable id,
+ * never a path (`docs/lessons/foo.md`) or a mutable alias (`latest`) — a drifting
+ * anchor would break the §4 preimage-differential's identity discipline. Pinned
+ * to the codomain so a path/alias fails LOUD at the schema boundary. NOTE
+ * (couple-on-merge, strategy#767): bound to the current 16-hex `hashLesson` form;
+ * widen here if the lesson-id codomain ever changes.
+ */
+const LESSON_REF_RE = /^[0-9a-f]{16}$/;
+
+/**
  * ISO-8601 shape for an authoring date — a calendar date (`YYYY-MM-DD`) or a full
  * timestamp with optional fractional seconds + `Z`/offset. Shape only; the calendar
  * validity is enforced by `isIso8601CalendarDate` (#2259 — GCA-high + CR).
@@ -120,19 +131,78 @@ export const MinedProvenanceWireSchema = z.object({
 export type MinedProvenanceRecord = z.infer<typeof MinedProvenanceWireSchema>;
 
 /**
+ * ADR-112 §4 — the preimage-differential SOURCE for one fixture, a discriminated
+ * union on `kind` (declared PER FIXTURE; not a fixed binding to landed commits).
+ * The materializer (slice C/D) fires the matcher on the preimage and asserts it
+ * is SILENT on the postimage — a matcher that fires only on the fixed form is
+ * fix-shaped and is NOT a legitimate positive control (FM(i)):
+ *   - `lesson` (PRIMARY, review-caught repos): the lesson corpus' `badExample`
+ *     (preimage — fire) / `goodExample` (postimage — silent). `lessonRef` is an
+ *     IMMUTABLE lesson id/hash (the `hashLesson` codomain, `LESSON_REF_RE`),
+ *     never a path/mutable alias (§8 identity discipline).
+ *   - `commit` (FALLBACK, land-then-fix repos): the pre-fix parent
+ *     (`preimageCommitSha` — fire) / post-fix merge (`mergeCommitSha` — silent).
+ *
+ * `z.discriminatedUnion` (not `z.union`): both branches carry a REQUIRED literal
+ * `kind`, so Zod routes a parse error to the matched branch instead of emitting
+ * "no union member matched" noise (cf. `cert-corpus-seed.ts`'s `window`). The
+ * OPTIONAL-discriminator round-trip reason `ProvenanceRecordSchema` documents for
+ * its `z.union` does NOT apply — `preimageSource` is a new field with no persisted
+ * authored set. Each branch is `.strict()` so a cross-branch key (e.g. a
+ * `badExample` under `kind:'commit'`) fails LOUD (FM(d) posture) rather than being
+ * silently stripped. All refines are NON-mutating (no `.trim()`) to preserve the
+ * manifest-hash stability discipline.
+ */
+export const PreimageSourceSchema = z.discriminatedUnion('kind', [
+  z
+    .object({
+      kind: z.literal('lesson'),
+      /** IMMUTABLE lesson id/hash (the 16-hex `hashLesson` codomain) — never a path/mutable alias (§4/§8). */
+      lessonRef: z.string().regex(LESSON_REF_RE, {
+        message:
+          'lessonRef must be an immutable lesson id (16-hex hashLesson codomain), not a path or mutable alias',
+      }),
+      /**
+       * The defect PREIMAGE exemplar the matcher must FIRE on (§4). This is a lesson
+       * corpus `badExample` — distinct from `CompiledRuleBaseSchema.badExample` (an
+       * optional human-readable code snippet on a compiled rule); here it is the
+       * load-bearing positive-control preimage, so non-empty is required.
+       */
+      badExample: z.string().refine((s) => s.trim().length > 0, {
+        message: 'badExample (the defect preimage the matcher must fire on) must be non-empty',
+      }),
+      /** The fixed POSTIMAGE exemplar the matcher must stay SILENT on (§4) — a lesson `goodExample`. */
+      goodExample: z.string().refine((s) => s.trim().length > 0, {
+        message: 'goodExample (the fixed form the matcher must stay silent on) must be non-empty',
+      }),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal('commit'),
+      /** The PARENT (pre-fix) commit where the DEFECT is present — the matcher must FIRE on this (ADR-112 §4). */
+      preimageCommitSha: z.string().regex(COMMIT_SHA_RE),
+      /** The PR's merge/squash commit — the post-fix (defect-absent) anchor; the matcher must stay SILENT on this. */
+      mergeCommitSha: z.string().regex(COMMIT_SHA_RE),
+    })
+    .strict(),
+]);
+
+export type PreimageSource = z.infer<typeof PreimageSourceSchema>;
+
+/**
  * ADR-112 §3 — one real lc instance an authored rule claims to catch. ALL such
  * fixtures are TRAIN-side (the §5 leakage guard); the preimage-differential
- * (§4) is evaluated in slice C/D, but the record must CARRY both commits + the
- * defect locus here so derivation is possible. `matchedSpan` + `contentHash`
- * are the line-drift-stable locus (cf. `firingLabelId`), not just the file.
+ * (§4) is evaluated in slice C/D, but the record CARRIES the declared
+ * `preimageSource` (lesson | commit) + the defect locus here so derivation is
+ * possible. `matchedSpan` + `contentHash` are the line-drift-stable locus
+ * (cf. `firingLabelId`), not just the file.
  */
 export const AuthoredFixtureSchema = z.object({
-  /** The PR whose merge introduced the fix (the in-corpus anchor). */
+  /** The PR where the defect was caught/introduced (the in-corpus anchor). */
   pr: z.number().int().positive(),
-  /** The PR's merge/squash commit — the post-fix (defect-absent) anchor. */
-  mergeCommitSha: z.string().regex(COMMIT_SHA_RE),
-  /** The PARENT (pre-fix) commit where the DEFECT is present (ADR-112 §4). */
-  preimageCommitSha: z.string().regex(COMMIT_SHA_RE),
+  /** The §4 preimage-differential source — lesson-anchored (PRIMARY) or commit-pair (FALLBACK). */
+  preimageSource: PreimageSourceSchema,
   /** File the defect locus lives in. */
   filePath: z.string().refine((s) => s.trim().length > 0, {
     message: 'filePath must be a non-empty reference',

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -68,6 +68,8 @@ export {
   NonCompilableEntryReadSchema,
   NonCompilableEntryWriteSchema,
   NonCompilableReasonCodeSchema,
+  type PreimageSource,
+  PreimageSourceSchema,
   provenanceKind,
   ProvenanceRecordSchema,
   shouldWriteToLedger,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -263,6 +263,8 @@ export {
   NonCompilableEntryWriteSchema,
   NonCompilableReasonCodeSchema,
   parseCompilerResponse,
+  type PreimageSource,
+  PreimageSourceSchema,
   provenanceKind,
   ProvenanceRecordSchema,
   type RegexValidation,

--- a/packages/core/src/spine/authored-rule.test.ts
+++ b/packages/core/src/spine/authored-rule.test.ts
@@ -90,8 +90,11 @@ describe('AuthoredRuleRecord schema (ADR-112 §3)', () => {
       positiveFixtures: [
         {
           pr: 100,
-          mergeCommitSha: 'b'.repeat(40),
-          preimageCommitSha: 'c'.repeat(40),
+          preimageSource: {
+            kind: 'commit' as const,
+            preimageCommitSha: 'c'.repeat(40),
+            mergeCommitSha: 'b'.repeat(40),
+          },
           filePath: 'src/physics/step.ts',
           matchedSpan: 'L10-L12',
           contentHash: 'deadbeefcafe',
@@ -228,8 +231,11 @@ describe('toCompileFeed (ADR-112 §2/§8 — authored → compile-stage input)',
       positiveFixtures: [
         {
           pr: 1,
-          mergeCommitSha: 'a'.repeat(40),
-          preimageCommitSha: 'b'.repeat(40),
+          preimageSource: {
+            kind: 'commit' as const,
+            preimageCommitSha: 'b'.repeat(40),
+            mergeCommitSha: 'a'.repeat(40),
+          },
           filePath: 'src/a.ts',
           matchedSpan: 'L1',
           contentHash: 'h1',

--- a/packages/core/src/spine/authoring-ledger.test.ts
+++ b/packages/core/src/spine/authoring-ledger.test.ts
@@ -158,5 +158,21 @@ describe('authoringContentHash (§8 revision detection — material-only)', () =
     ).toBe(
       authoringContentHash({ ...material, positiveFixtures: [{ pr: 1, matchedSpan: 'a\nb' }] }),
     );
+    // and a string nested INSIDE the §4 preimageSource union (deeper than matchedSpan) is
+    // normalized too — the deep-normalize must reach the new union depth, not just the fixture top.
+    const lessonFix = (badExample: string) => [
+      {
+        pr: 1,
+        preimageSource: {
+          kind: 'lesson',
+          lessonRef: 'a1b2c3d4e5f60718',
+          badExample,
+          goodExample: 'ok',
+        },
+      },
+    ];
+    expect(
+      authoringContentHash({ ...material, positiveFixtures: lessonFix('bad-a\r\nbad-b') }),
+    ).toBe(authoringContentHash({ ...material, positiveFixtures: lessonFix('bad-a\nbad-b') }));
   });
 });

--- a/packages/core/src/spine/compile.test.ts
+++ b/packages/core/src/spine/compile.test.ts
@@ -450,8 +450,11 @@ describe('runCompileStage — ADR-112 authored compile-feed', () => {
       positiveFixtures: [
         {
           pr: 1,
-          mergeCommitSha: sha(1),
-          preimageCommitSha: sha(2),
+          preimageSource: {
+            kind: 'commit' as const,
+            preimageCommitSha: sha(2),
+            mergeCommitSha: sha(1),
+          },
           filePath: 'src/a.ts',
           matchedSpan: 'L1',
           contentHash: 'h1',


### PR DESCRIPTION
## ADR-112 §4 — preimage-differential source-pluggable (`preimageSource` union)

Reframes the authored-rule fixture's preimage anchor from a fixed commit-pair to a per-fixture **`preimageSource` discriminated union**, per ADR-112 §4 (coupling `mmnto-ai/totem-strategy#767`, strategy#591). This is the gating follow-up to Slice B B1 (#2261): lc is a **review-caught** repo (defects fixed in review, ~18 `fix(` of 433 commits), so a flat-only commit-pair preimage can't author lc's own cert target — the union unblocks cert-#1.

### The shape
```ts
preimageSource:
    { kind: 'lesson', lessonRef, badExample, goodExample }   // PRIMARY — review-caught
  | { kind: 'commit', preimageCommitSha, mergeCommitSha }     // FALLBACK — land-then-fix
```
- **lesson (PRIMARY):** fire on the lesson `badExample`, silent on `goodExample`. `lessonRef` bound to the immutable 16-hex `hashLesson` codomain — never a path or mutable alias (§8 identity discipline).
- **commit (FALLBACK):** the prior commit-pair binding, now scoped to land-then-fix repos.

### Change surface (schema + producer + tests — single-home)
`AuthoredFixtureSchema` (`packages/core/src/compiler-schema.ts`) is the single home — the union auto-threads to both `AuthoredProvenanceRecordSchema` and the YAML-input `AuthoredRuleInput`. New `PreimageSourceSchema` / `PreimageSource` exported. Built as `z.discriminatedUnion('kind', …)` with each branch `.strict()` so a cross-branch key fails **loud** (FM(d)); the reader's recursive producer-key scan walks the new union depth. The reader itself is unchanged (it passes fixtures through opaquely — only reads `.pr`).

**No data migration owed** — there is no persisted authored-rule set, and the flat schema was *never released* (it ships first in this same union'd version, via the held VP #2262).

### Reviewed before code — pre-build cohort panel (3 lenses, 3/3 PASS-WITH-FIXES)
Independent contract / build-test / tenet lenses verified against source and caught, before a line was written:
- **The rewrap landmine** — `AuthoredFixtureSchema` is non-strict, so a top-level `preimageCommitSha:'nope'` override on the migrated bad-SHA test would be *stripped*, not rejected → the `.toThrow()` would silently invert to a false-green. Fixed by nesting the bad value inside `preimageSource` with the other SHA valid.
- **A missed 5th test file** (`spine/compile.test.ts`) that also constructs a flat fixture.
- **The `lessonRef` bound** — a bare non-empty refine would admit `docs/lessons/foo.md` (path) and `latest` (alias); bound to the hex codomain instead.

### Gate
- `pnpm -r build` (full workspace: core, cli, mcp, packs) ✅
- Full suites: core **2937** passed, cli **2846** passed ✅
- ESLint `@mmnto/totem` + `@mmnto/cli` ✅ (0 errors; cli's 7 `unused eslint-disable` warnings are pre-existing, untouched files)
- `prettier --check` (changed files) ✅ · `totem lint` **PASS** (2 advisory orchestrator-timeout warnings on a sub-100ms non-orchestrator test file, dispositioned as-is) ✅
- Changeset: `@mmnto/totem: minor` + `@mmnto/cli: patch` (the `fixed` group bumps lockstep; honest per-package CHANGELOG attribution).

### For couple-on-merge (strategy)
- **`lessonRef` bound = `/^[0-9a-f]{16}$/`** (the current `hashLesson` codomain). Flagged for confirmation — widen if the lesson-id codomain differs.
- The §4 preimage-**differential** (fire-on-preimage / silent-on-postimage materializer) is **Slice C/D**, not this PR. This slice is the schema + producer + tests; the materializer will switch on `preimageSource.kind` (fail-loud default).

### Release
Folds into the **held** Version Packages PR (#2262) — release stays held until this lands, so Slice A + B + the union ship as one union'd version (no flat-then-union churn).

Refs: ADR-112 §4 · `mmnto-ai/totem-strategy#767` · strategy#591 · builds on #2261
