### PR TITLE
feat(spine): ADR-112 §6 preimage-differential materializer — slice C1 inert primitive (strategy#591)

### DIFF
--- a/.changeset/adr-112-sliceC-preimage-differential.md
+++ b/.changeset/adr-112-sliceC-preimage-differential.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/totem': minor
+---
+
+feat(spine): ADR-112 §6 preimage-differential materializer — slice C1, the inert primitive (strategy#591)
+
+`evaluatePreimageDifferential(rule, fixture)` evaluates the §4 preimage-differential for one authored fixture against a compiled rule, switching on the fixture's declared `preimageSource.kind`. The lesson-anchored source (PRIMARY, for review-caught repos) fires the matcher on `badExample` and asserts silence on `goodExample` through the existing `runSmokeGate` engine entry point (regex + ast-grep, in-memory, no temp file). It reports the raw evidence (`firesOnPreimage`, `silentOnPostimage`, match counts) plus a differential-level `outcome` (`differential-holds` / `fix-shaped` / `over-match` / `vacuous-silent` / `needs-adjudication` / `unsupported-source`) — making visible the over-match escape the wind-tunnel scorer cannot catch on a synthetic exemplar (its positive-control check is fire-on-preimage only). The commit-pair source is a typed deferral to slice C2.
+
+Inert by design: it wires nothing into the cert path, mints no ADR-110 §5 run verdict, and emits no controls (slice C2 consumes it to gate control emission; slice D maps the differential to the §5 terminal vocabulary). `fix-shaped` (fires on the fixed form) is never a charitable pass — the literal Falsifying Metric §1(i).

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -848,6 +848,12 @@ export {
   identityKey,
   readAuthoringLedger,
 } from './spine/authoring-ledger.js';
+export type {
+  PreimageDifferentialDeps,
+  PreimageDifferentialOutcome,
+  PreimageDifferentialResult,
+} from './spine/preimage-differential.js';
+export { evaluatePreimageDifferential } from './spine/preimage-differential.js';
 export type { ProducerKind, RulePolicy } from './spine/rule-policy.js';
 export { getRulePolicy } from './spine/rule-policy.js';
 // `DraftCandidate` is intentionally NOT re-exported here — it is the transient

--- a/packages/core/src/spine/preimage-differential.test.ts
+++ b/packages/core/src/spine/preimage-differential.test.ts
@@ -240,6 +240,32 @@ describe('evaluatePreimageDifferential — needs-adjudication on engine refusal'
     expect(result.outcome).toBe('needs-adjudication');
     expect(result.reason).toBeDefined();
   });
+
+  it('a whitespace-only badExample → needs-adjudication, not a silent vacuous result', async () => {
+    // Direct (unparsed) construction can bypass the schema's non-empty refine; a
+    // whitespace preimage carries no evaluable code, so the preimage leg is null.
+    const result = await evaluatePreimageDifferential(
+      regexRule(),
+      lessonFixture('   \n  ', 'logger.info("ok")'),
+    );
+    expect(result.outcome).toBe('needs-adjudication');
+    expect(result.firesOnPreimage).toBeNull();
+    expect(result.reason).toContain('badExample');
+  });
+
+  it('a whitespace-only goodExample → needs-adjudication, NOT a false differential-holds (Greptile #2264)', async () => {
+    // The cert-critical case: the rule fires on the defect, and the postimage is
+    // whitespace. Pre-fix this read as differential-holds (silentOnPostimage true
+    // because there was nothing to match) — masking an unevaluable fixed side.
+    const result = await evaluatePreimageDifferential(
+      regexRule(),
+      lessonFixture('console.log("bad")', '   \n  '),
+    );
+    expect(result.outcome).toBe('needs-adjudication');
+    expect(result.outcome).not.toBe('differential-holds');
+    expect(result.silentOnPostimage).toBeNull();
+    expect(result.reason).toContain('goodExample');
+  });
 });
 
 // ─── commit-source deferral (typed non-pass, slice C2) ─

--- a/packages/core/src/spine/preimage-differential.test.ts
+++ b/packages/core/src/spine/preimage-differential.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AuthoredFixture, CompiledRule } from '../compiler-schema.js';
+import { evaluatePreimageDifferential } from './preimage-differential.js';
+
+// ─── Rule helpers (mirror compile-smoke-gate.test.ts) ─
+
+function regexRule(overrides: Partial<CompiledRule> = {}): CompiledRule {
+  return {
+    lessonHash: 'deadbeef1234',
+    lessonHeading: 'No console.log',
+    pattern: 'console\\.log',
+    message: 'Do not use console.log',
+    engine: 'regex',
+    compiledAt: '2026-04-13T12:00:00Z',
+    ...overrides,
+  };
+}
+
+function astGrepRule(overrides: Partial<CompiledRule> = {}): CompiledRule {
+  return {
+    lessonHash: 'cafeface5678',
+    lessonHeading: 'No debugger',
+    pattern: '',
+    message: 'Do not commit debugger statements',
+    engine: 'ast-grep',
+    astGrepPattern: 'debugger',
+    compiledAt: '2026-04-13T12:00:00Z',
+    ...overrides,
+  };
+}
+
+function emptyCatchRule(overrides: Partial<CompiledRule> = {}): CompiledRule {
+  return {
+    lessonHash: 'beefcafe9abc',
+    lessonHeading: 'Empty catch',
+    pattern: '',
+    message: 'Empty catch swallows errors',
+    engine: 'ast-grep',
+    astGrepYamlRule: {
+      rule: {
+        kind: 'catch_clause',
+        not: {
+          has: {
+            kind: 'statement_block',
+            has: {
+              any: [
+                { kind: 'expression_statement' },
+                { kind: 'variable_declaration' },
+                { kind: 'if_statement' },
+                { kind: 'return_statement' },
+                { kind: 'throw_statement' },
+              ],
+              stopBy: 'end',
+            },
+          },
+        },
+      },
+    },
+    compiledAt: '2026-04-13T12:00:00Z',
+    ...overrides,
+  };
+}
+
+// ─── Fixture helpers ────────────────────────────────
+
+function lessonFixture(badExample: string, goodExample: string): AuthoredFixture {
+  return {
+    pr: 130,
+    preimageSource: { kind: 'lesson', lessonRef: 'deadbeefdeadbeef', badExample, goodExample },
+    filePath: 'src/sim/level.rs',
+    matchedSpan: 'L10-L12',
+    contentHash: 'abc123def456',
+  };
+}
+
+function commitFixture(): AuthoredFixture {
+  return {
+    pr: 130,
+    preimageSource: {
+      kind: 'commit',
+      preimageCommitSha: 'a'.repeat(40),
+      mergeCommitSha: 'b'.repeat(40),
+    },
+    filePath: 'src/sim/level.rs',
+    matchedSpan: 'L10-L12',
+    contentHash: 'abc123def456',
+  };
+}
+
+// ─── differential-holds (the legitimate control) ─────
+
+describe('evaluatePreimageDifferential — differential-holds', () => {
+  it('regex: fires on the preimage and is silent on the postimage', async () => {
+    const result = await evaluatePreimageDifferential(
+      regexRule(),
+      lessonFixture('console.log("debug")', 'logger.info("ok")'),
+    );
+    expect(result.outcome).toBe('differential-holds');
+    // Non-vacuity: BOTH legs must hold. If the classifier checked only
+    // firesOnPreimage, the over-match case below would also read as "holds".
+    expect(result.firesOnPreimage).toBe(true);
+    expect(result.silentOnPostimage).toBe(true);
+    expect(result.preimageMatchCount).toBeGreaterThanOrEqual(1);
+    expect(result.postimageMatchCount).toBe(0);
+    expect(result.sourceKind).toBe('lesson');
+  });
+
+  it('ast-grep: fires on the preimage and is silent on the postimage (TS exemplar)', async () => {
+    const result = await evaluatePreimageDifferential(
+      astGrepRule(),
+      lessonFixture('debugger;\n', 'const x = 1;\n'),
+    );
+    expect(result.outcome).toBe('differential-holds');
+    expect(result.firesOnPreimage).toBe(true);
+    expect(result.silentOnPostimage).toBe(true);
+    expect(result.preimageMatchCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('ast-grep compound (multi-line exemplar): fires on empty catch, silent on a catch with a body', async () => {
+    // Locks multi-line exemplar faithfulness — the differential must survive a
+    // real multi-line snippet, not just a single token.
+    const result = await evaluatePreimageDifferential(
+      emptyCatchRule(),
+      lessonFixture(
+        'try {\n  work();\n} catch (err) {\n}\n',
+        'try {\n  work();\n} catch (err) {\n  log(err);\n}\n',
+      ),
+    );
+    expect(result.outcome).toBe('differential-holds');
+    expect(result.firesOnPreimage).toBe(true);
+    expect(result.silentOnPostimage).toBe(true);
+  });
+});
+
+// ─── fix-shaped (the literal Falsifying Metric §1(i)) ─
+
+describe('evaluatePreimageDifferential — fix-shaped is never a charitable pass (FM §1(i))', () => {
+  it('regex: a matcher that fires on the FIXED form and is silent on the defect is fix-shaped', async () => {
+    // pattern matches the GOOD form (logger.info), not the defect (console.log).
+    const result = await evaluatePreimageDifferential(
+      regexRule({ pattern: 'logger\\.info' }),
+      lessonFixture('console.log("bad")', 'logger.info("fixed")'),
+    );
+    expect(result.outcome).toBe('fix-shaped');
+    expect(result.outcome).not.toBe('differential-holds');
+    // Non-vacuity: the classification must rest on BOTH legs being wrong, not
+    // just one. fix-shaped (here) and vacuous-silent (below) share
+    // firesOnPreimage=false but differ on silentOnPostimage — so the silent leg
+    // is load-bearing.
+    expect(result.firesOnPreimage).toBe(false);
+    expect(result.silentOnPostimage).toBe(false);
+  });
+
+  it('ast-grep: silent on the defect, fires on the fixed form → fix-shaped', async () => {
+    const result = await evaluatePreimageDifferential(
+      astGrepRule(),
+      lessonFixture('const x = 1;\n', 'debugger;\n'),
+    );
+    expect(result.outcome).toBe('fix-shaped');
+    expect(result.firesOnPreimage).toBe(false);
+    expect(result.silentOnPostimage).toBe(false);
+  });
+});
+
+// ─── over-match (the scorer-invisible escape, contract §4/§5.3) ─
+
+describe('evaluatePreimageDifferential — over-match is surfaced (the silent-on-postimage leg)', () => {
+  it('regex: a matcher that fires on BOTH the defect and the fixed form is over-match, not holds', async () => {
+    const result = await evaluatePreimageDifferential(
+      regexRule(),
+      lessonFixture('console.log("bad")', 'console.log("still here in the fix")'),
+    );
+    expect(result.outcome).toBe('over-match');
+    // The cert-critical assertion: this MUST NOT read as differential-holds.
+    expect(result.outcome).not.toBe('differential-holds');
+    expect(result.firesOnPreimage).toBe(true);
+    // Non-vacuity: if the code ignored the postimage, silentOnPostimage would be
+    // true and this would be misclassified as holds — the escape the scorer
+    // cannot catch on a synthetic exemplar.
+    expect(result.silentOnPostimage).toBe(false);
+    expect(result.postimageMatchCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('ast-grep: fires on both sides → over-match', async () => {
+    const result = await evaluatePreimageDifferential(
+      astGrepRule(),
+      lessonFixture('debugger;\n', 'debugger;\nconst x = 1;\n'),
+    );
+    expect(result.outcome).toBe('over-match');
+    expect(result.silentOnPostimage).toBe(false);
+  });
+});
+
+// ─── vacuous-silent (fires on neither) ──────────────
+
+describe('evaluatePreimageDifferential — vacuous-silent (fires on neither)', () => {
+  it('regex: a matcher silent on both sides catches nothing', async () => {
+    const result = await evaluatePreimageDifferential(
+      regexRule(),
+      lessonFixture('const x = 1;', 'const y = 2;'),
+    );
+    expect(result.outcome).toBe('vacuous-silent');
+    expect(result.firesOnPreimage).toBe(false);
+    expect(result.silentOnPostimage).toBe(true);
+    // Contrast with fix-shaped (same firesOnPreimage=false): proves the silent
+    // leg distinguishes the two and is not ignored.
+  });
+});
+
+// ─── needs-adjudication (engine refusal, fail-loud) ──
+
+describe('evaluatePreimageDifferential — needs-adjudication on engine refusal', () => {
+  it('invalid regex pattern → needs-adjudication with a reason, not a silent clean result', async () => {
+    const result = await evaluatePreimageDifferential(
+      regexRule({ pattern: '(unclosed' }),
+      lessonFixture('console.log("x")', 'logger.info("ok")'),
+    );
+    expect(result.outcome).toBe('needs-adjudication');
+    expect(result.reason).toBeDefined();
+    expect(result.reason).toContain('invalid');
+    // The preimage leg could not be evaluated → null, not a false "silent".
+    expect(result.firesOnPreimage).toBeNull();
+  });
+
+  it('ast-grep rule that throws at runtime (invalid kind) → needs-adjudication', async () => {
+    const result = await evaluatePreimageDifferential(
+      emptyCatchRule({ astGrepYamlRule: { rule: { kind: '!!!INVALID_KIND!!!' } } }),
+      lessonFixture('try {\n} catch (e) {\n}\n', 'const x = 1;\n'),
+    );
+    expect(result.outcome).toBe('needs-adjudication');
+    expect(result.reason).toBeDefined();
+  });
+
+  it('an engine the smoke gate does not cover (tree-sitter ast) → needs-adjudication', async () => {
+    const result = await evaluatePreimageDifferential(
+      regexRule({ engine: 'ast', pattern: '' }),
+      lessonFixture('whatever', 'something else'),
+    );
+    expect(result.outcome).toBe('needs-adjudication');
+    expect(result.reason).toBeDefined();
+  });
+});
+
+// ─── commit-source deferral (typed non-pass, slice C2) ─
+
+describe('evaluatePreimageDifferential — commit source is a typed deferral (slice C2)', () => {
+  it('commit-pair fixture → unsupported-source, never a passing control', async () => {
+    const result = await evaluatePreimageDifferential(astGrepRule(), commitFixture());
+    expect(result.outcome).toBe('unsupported-source');
+    expect(result.outcome).not.toBe('differential-holds');
+    expect(result.sourceKind).toBe('commit');
+    expect(result.firesOnPreimage).toBeNull();
+    expect(result.silentOnPostimage).toBeNull();
+    expect(result.reason).toContain('slice C2');
+  });
+});
+
+// ─── determinism (Tenet-15) ─────────────────────────
+
+describe('evaluatePreimageDifferential — determinism', () => {
+  it('is a pure function of (rule, fixture): identical inputs yield identical results', async () => {
+    const rule = astGrepRule();
+    const fixture = lessonFixture('debugger;\n', 'const x = 1;\n');
+    const a = await evaluatePreimageDifferential(rule, fixture);
+    const b = await evaluatePreimageDifferential(rule, fixture);
+    expect(a).toEqual(b);
+  });
+});

--- a/packages/core/src/spine/preimage-differential.ts
+++ b/packages/core/src/spine/preimage-differential.ts
@@ -1,0 +1,203 @@
+/**
+ * ADR-112 §4/§6 — the preimage-differential materializer (slice C1: the inert primitive).
+ *
+ * An authored rule is only a legitimate positive control if its matcher **fires
+ * on the defect preimage** and is **silent on the fixed postimage** (§4). A
+ * matcher that fires on the *fixed* form is "fix-shaped" — the exact failure
+ * mode the miner's honest-negative is made of — and must never be admitted as a
+ * legitimate control (Falsifying Metric §1(i)).
+ *
+ * This module evaluates that differential against a fixture's declared
+ * `preimageSource` (lesson-anchored PRIMARY / commit-pair FALLBACK) and reports
+ * the raw evidence + a differential-level classification. It is deliberately
+ * INERT: it wires nothing into the cert path, mints no §5 run verdict, and emits
+ * no controls. Slice C2 consumes this to gate control emission; slice D maps the
+ * differential to the ADR-110 §5 terminal vocabulary (PASS / FAIL /
+ * HONEST-NEGATIVE). The boundary is load-bearing — `over-match` / `vacuous` here
+ * are DIFFERENTIAL outcomes, NOT run verdicts (the scorer owns that).
+ *
+ * Seam (Tenet-21 reuse): firing goes through `runSmokeGate`, the same
+ * role-agnostic engine entry point the compiler's #1408 under-match / #1580
+ * over-match checks use — regex and ast-grep, in-memory, no temp file, no diff
+ * fabrication, no `firingLabelId` minted here. The lesson source evaluates
+ * against the in-record `badExample`/`goodExample` exemplars (contract §5.4), so
+ * the lesson path is pure and hermetic — no clock, no network, no filesystem.
+ */
+
+import { runSmokeGate } from '../compile-smoke-gate.js';
+import type { AuthoredFixture, CompiledRule, PreimageSource } from '../compiler-schema.js';
+
+// ─── Types ──────────────────────────────────────────
+
+/**
+ * Differential-level classification of a single fixture's preimage/postimage
+ * evaluation. NOT an ADR-110 §5 run verdict (PASS/FAIL/HONEST-NEGATIVE) — the
+ * scorer (slice D) maps these to that vocabulary. Keep the boundary explicit.
+ */
+export type PreimageDifferentialOutcome =
+  /** Fires on the preimage, silent on the postimage — the legitimate positive control (§4). */
+  | 'differential-holds'
+  /**
+   * Fires on the postimage (the fixed form) and NOT on the preimage — fix-shaped,
+   * the literal Falsifying Metric §1(i). Never a charitable pass.
+   */
+  | 'fix-shaped'
+  /**
+   * Fires on BOTH the preimage and the postimage. The matcher establishes no
+   * differential. This is the cert-critical escape the scorer cannot catch on a
+   * synthetic exemplar (its positive-control check is fire-on-preimage only, and
+   * a single-occurrence defect's fixed form never appears in the real window) —
+   * so the silent-on-postimage leg here is the ONLY signal that surfaces it
+   * (contract review, ADR-112 §4/§5.3). C2 must gate on it.
+   */
+  | 'over-match'
+  /** Fires on NEITHER side — the matcher catches nothing (a vacuous control). */
+  | 'vacuous-silent'
+  /**
+   * The engine refused to execute on at least one side (invalid regex, ast-grep
+   * runtime throw, an unparseable exemplar, or an engine the smoke gate does not
+   * cover) — the differential could not be established. Fail-loud, distinct from
+   * a clean no-match; routes to operator adjudication, never a silent pass.
+   */
+  | 'needs-adjudication'
+  /**
+   * The fixture declares a `commit`-pair preimage source — deferred to slice C2
+   * (the land-then-fix fallback; lc cert-#1 is lesson-anchored). A typed
+   * non-pass that keeps the union total; never treated as a passing control.
+   */
+  | 'unsupported-source';
+
+export interface PreimageDifferentialResult {
+  /** The differential-level classification (see `PreimageDifferentialOutcome`). */
+  outcome: PreimageDifferentialOutcome;
+  /** The fixture's declared preimage-source kind. */
+  sourceKind: PreimageSource['kind'];
+  /**
+   * The matcher fired on the defect preimage. `null` when the preimage could not
+   * be evaluated (engine refusal, or an unsupported `commit` source).
+   */
+  firesOnPreimage: boolean | null;
+  /**
+   * The matcher stayed silent on the fixed postimage. `null` when the postimage
+   * could not be evaluated (engine refusal, or an unsupported `commit` source).
+   */
+  silentOnPostimage: boolean | null;
+  /** Engine match count on the preimage exemplar (evidence). `null` when not evaluated. */
+  preimageMatchCount: number | null;
+  /** Engine match count on the postimage exemplar (evidence). `null` when not evaluated. */
+  postimageMatchCount: number | null;
+  /** First-line engine/defer reason — present for `needs-adjudication` / `unsupported-source`. */
+  reason?: string;
+}
+
+/**
+ * Injection port for the COMMIT-pair preimage source (slice C2). The lesson
+ * source (C1) needs none of this — it evaluates against in-record exemplars and
+ * stays I/O-free. Declared here so C2's git-tree reads inject through an explicit
+ * port (mirroring the cert corpus builder's `Stage4VerifierDeps`) and core never
+ * does filesystem/git directly. `evaluatePreimageDifferential` is already async
+ * so wiring this in C2 is a non-breaking, additive change.
+ */
+export interface PreimageDifferentialDeps {
+  /** Read a file's content as of a given commit SHA (the pre-fix / post-fix tree). */
+  readFileAtCommit(commitSha: string, filePath: string): Promise<string>;
+}
+
+// ─── Classification ─────────────────────────────────
+
+function classifyDifferential(
+  firesOnPreimage: boolean,
+  silentOnPostimage: boolean,
+): PreimageDifferentialOutcome {
+  if (firesOnPreimage && silentOnPostimage) return 'differential-holds';
+  if (firesOnPreimage && !silentOnPostimage) return 'over-match';
+  if (!firesOnPreimage && silentOnPostimage) return 'vacuous-silent';
+  return 'fix-shaped';
+}
+
+// ─── Lesson-anchored differential (C1) ──────────────
+
+function evaluateLessonDifferential(
+  rule: CompiledRule,
+  source: Extract<PreimageSource, { kind: 'lesson' }>,
+): PreimageDifferentialResult {
+  const pre = runSmokeGate(rule, source.badExample);
+  const post = runSmokeGate(rule, source.goodExample);
+
+  // `reason` is present only when the engine REFUSED to execute (invalid regex,
+  // ast-grep throw, unparseable exemplar, uncovered engine) — never when it ran
+  // and simply didn't match. A refusal on either side means the differential
+  // cannot be established → fail-loud to adjudication, not a silent clean result.
+  const engineReason = pre.reason ?? post.reason;
+  if (engineReason !== undefined) {
+    return {
+      outcome: 'needs-adjudication',
+      sourceKind: 'lesson',
+      firesOnPreimage: pre.reason !== undefined ? null : pre.matched,
+      silentOnPostimage: post.reason !== undefined ? null : !post.matched,
+      preimageMatchCount: pre.reason !== undefined ? null : pre.matchCount,
+      postimageMatchCount: post.reason !== undefined ? null : post.matchCount,
+      reason: engineReason,
+    };
+  }
+
+  const firesOnPreimage = pre.matched;
+  const silentOnPostimage = !post.matched;
+  return {
+    outcome: classifyDifferential(firesOnPreimage, silentOnPostimage),
+    sourceKind: 'lesson',
+    firesOnPreimage,
+    silentOnPostimage,
+    preimageMatchCount: pre.matchCount,
+    postimageMatchCount: post.matchCount,
+  };
+}
+
+function deferredCommitResult(): PreimageDifferentialResult {
+  return {
+    outcome: 'unsupported-source',
+    sourceKind: 'commit',
+    firesOnPreimage: null,
+    silentOnPostimage: null,
+    preimageMatchCount: null,
+    postimageMatchCount: null,
+    reason:
+      'commit-pair preimage source is deferred to slice C2 (land-then-fix fallback); lc cert-#1 is lesson-anchored',
+  };
+}
+
+// ─── Public API ─────────────────────────────────────
+
+/**
+ * Evaluate the ADR-112 §4 preimage-differential for one authored fixture against
+ * a compiled rule, switching on the fixture's declared `preimageSource.kind`.
+ *
+ * Returns the raw evidence (`firesOnPreimage`, `silentOnPostimage`, match counts)
+ * plus a differential-level `outcome`. It does NOT mint a §5 run verdict and does
+ * NOT emit controls — those are slice C2/D. The `commit` source is a typed
+ * non-pass (`unsupported-source`) deferred to C2; the union stays total.
+ *
+ * Async-from-the-start so C2 can inject `PreimageDifferentialDeps` for git-tree
+ * reads without a breaking signature change; the C1 lesson path resolves
+ * synchronously under the hood (pure, hermetic).
+ */
+export async function evaluatePreimageDifferential(
+  rule: CompiledRule,
+  fixture: AuthoredFixture,
+): Promise<PreimageDifferentialResult> {
+  const source = fixture.preimageSource;
+  switch (source.kind) {
+    case 'lesson':
+      return evaluateLessonDifferential(rule, source);
+    case 'commit':
+      return deferredCommitResult();
+    default: {
+      // Exhaustiveness backstop: a future `PreimageSource` kind must be handled
+      // explicitly, never silently admitted as a passing control.
+      const _exhaustive: never = source;
+      throw new Error(
+        `[Totem Error] evaluatePreimageDifferential: unknown preimageSource kind '${String((_exhaustive as PreimageSource).kind)}'`,
+      );
+    }
+  }
+}

--- a/packages/core/src/spine/preimage-differential.ts
+++ b/packages/core/src/spine/preimage-differential.ts
@@ -124,20 +124,35 @@ function evaluateLessonDifferential(
   const pre = runSmokeGate(rule, source.badExample);
   const post = runSmokeGate(rule, source.goodExample);
 
-  // `reason` is present only when the engine REFUSED to execute (invalid regex,
-  // ast-grep throw, unparseable exemplar, uncovered engine) — never when it ran
-  // and simply didn't match. A refusal on either side means the differential
-  // cannot be established → fail-loud to adjudication, not a silent clean result.
-  const engineReason = pre.reason ?? post.reason;
-  if (engineReason !== undefined) {
+  // An exemplar with no evaluable code cannot establish a differential. Two
+  // ways that happens: (1) the engine REFUSES to run — invalid regex, ast-grep
+  // throw, uncovered engine — which `runSmokeGate` reports via `reason`; (2) the
+  // exemplar is empty/whitespace-only, which `runSmokeGate` instead reports as a
+  // CLEAN no-match (no `reason`) — and that would vacuously read as
+  // silent-on-postimage / fires-on-neither, masking that one side had nothing to
+  // evaluate (an empty postimage falsely reading as `differential-holds` is the
+  // dishonest control this primitive exists to catch). The schema enforces
+  // non-empty exemplars, but this is a public primitive reachable by direct
+  // (unparsed) construction, so it defends its own contract: either condition on
+  // either side → `needs-adjudication`, fail-loud, never a silent clean result.
+  const preUnevaluable = source.badExample.trim().length === 0 || pre.reason !== undefined;
+  const postUnevaluable = source.goodExample.trim().length === 0 || post.reason !== undefined;
+  if (preUnevaluable || postUnevaluable) {
+    const reason =
+      (source.badExample.trim().length === 0
+        ? 'badExample (the defect preimage) is empty or whitespace-only — no evaluable code to establish the differential'
+        : pre.reason) ??
+      (source.goodExample.trim().length === 0
+        ? 'goodExample (the fixed postimage) is empty or whitespace-only — no evaluable code to establish the differential'
+        : post.reason);
     return {
       outcome: 'needs-adjudication',
       sourceKind: 'lesson',
-      firesOnPreimage: pre.reason !== undefined ? null : pre.matched,
-      silentOnPostimage: post.reason !== undefined ? null : !post.matched,
-      preimageMatchCount: pre.reason !== undefined ? null : pre.matchCount,
-      postimageMatchCount: post.reason !== undefined ? null : post.matchCount,
-      reason: engineReason,
+      firesOnPreimage: preUnevaluable ? null : pre.matched,
+      silentOnPostimage: postUnevaluable ? null : !post.matched,
+      preimageMatchCount: preUnevaluable ? null : pre.matchCount,
+      postimageMatchCount: postUnevaluable ? null : post.matchCount,
+      reason,
     };
   }
 


### PR DESCRIPTION
## What

ADR-112 §6 preimage-differential materializer — **slice C1, the inert primitive**. `evaluatePreimageDifferential(rule, fixture)` evaluates the §4 preimage-differential for one authored fixture against a compiled rule, switching on the fixture's declared `preimageSource.kind`.

- **Lesson-anchored source (PRIMARY, review-caught repos):** fires the matcher on `badExample`, asserts silence on `goodExample`, through the existing `runSmokeGate` engine entry point (regex + ast-grep, in-memory, no temp file).
- **Commit-pair source (FALLBACK):** a typed deferral (`unsupported-source`) to slice C2 — lc cert-#1 is lesson-anchored.

It reports raw evidence (`firesOnPreimage`, `silentOnPostimage`, match counts) plus a **differential-level** `outcome` — `differential-holds` / `fix-shaped` / `over-match` / `vacuous-silent` / `needs-adjudication` / `unsupported-source`. This is **not** an ADR-110 §5 run verdict (the scorer mints that in slice D); the boundary is deliberate.

## Why it matters (the cert-critical bits)

- **`fix-shaped` is never a charitable pass** — the literal Falsifying Metric §1(i). A matcher that fires on the *fixed* form and is silent on the defect is classified `fix-shaped`, full stop.
- **`over-match` is surfaced.** The wind-tunnel scorer's positive-control check is fire-on-preimage *only*, and a synthetic `goodExample` never appears in the real window, so an over-matching rule (fires on **both** sides) escapes the scorer. The `silent-on-postimage` leg here is the only signal that catches it — slice C2 gates on it.

## Inert by design

Wires nothing into the cert path, mints no §5 verdict, emits no controls. Slice C2 consumes this to gate control emission; slice D maps it to the §5 vocabulary. So C1 is independent of the open ADR-112 contract questions (the `lessonHash↔mintedRuleId` unification, the negativeFixtures schema, the silent-on-good gate) — those gate **C2**, not this PR.

## Pre-build cohort panel (3 lenses, source-verified) reshaped the slice

- **tenet/arch:** the differential already exists as `runSmokeGate` — use it (Tenet-21), not a synthetic `DiffAddition[]` through the diff engine (which would mint `firingLabelId`s and create a second firing-home). Emit evidence, not a verdict.
- **build/test:** "pure in-memory" holds (ast-grep parses content strings). ast-grep mechanics tested on a TS exemplar; Rust/GDScript ast-grep capability (Windows-fragile) deferred to the cert run. Non-parseable exemplar → `needs-adjudication` (fail-loud).
- **contract:** over-match escapes the scorer → silent-on-good must gate (C2); control emission is coupled to the `lessonHash↔mintedRuleId` unification → split to C2.

## Tests

13 red tests with vacuity contrasts — `over-match` and `fix-shaped` each prove **both** legs of the differential are load-bearing (regex + ast-grep + multi-line compound + engine-refusal + commit-deferral + determinism).

## Gate

Full-workspace `pnpm -r build` (core→cli ripple) · core ESLint · prettier · `totem lint` PASS (0 violations) · new tests 13/13. Full core suite: 2952 pass + 1 pre-existing/environmental failure (`missing-sdk.test.ts` — pnpm-vs-npm temp-dir detection on the dev box; verified identical on the clean tree; CI runs pnpm). Changeset: `@mmnto/totem` minor (fixed group → 1.81.0).

## Coupling

ADR-112 §6 / `mmnto-ai/totem-strategy#591`. Requesting strategy's couple-on-merge — C1 is inert (no §6 contract surface consumed), so it's low-coupling, but ADR-112 is theirs. Their Q1–Q3 ruling gates C2, not this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
