### PR TITLE
feat(spine): ADR-112 §8 Slice C2a id-unification — firingLabelId <- ruleId (strategy#591)

### DIFF
--- a/.changeset/adr112-c2a-id-unification.md
+++ b/.changeset/adr112-c2a-id-unification.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/totem': patch
+---
+
+ADR-112 §8/§9 Slice C2a — authored-rule id-unification (`firingLabelId ← ruleId`).
+
+An authored rule's compiled identity (`lessonHash`) now carries its persisted, minted `ruleId` instead of the `dslSource`-derived content hash, threaded from the record through `toCompileFeed` → `compileCandidate` via a new optional `CompileInputCandidate.ruleId`. This makes the wind-tunnel firing key (`firingLabelId` embeds it) and the §6 `controls.positive[].targetRuleId` join stable across a matcher edit — §8 excludes `dslSource` from identity precisely so tightening a matcher never orphans a rule's ground-truth labels or controls.
+
+Authored-only and inert: mined rules are byte-identical (no `ruleId` → the content hash stands), and authored rules remain Gate-1 advisory with no control emission yet (Slice C2b). The compiler fails loud if an authored candidate reaches it without its threaded `ruleId` (a threading regression would silently re-derive a `dslSource`-keyed identity and orphan the rule's controls).

--- a/packages/core/src/compiler-schema.ts
+++ b/packages/core/src/compiler-schema.ts
@@ -348,7 +348,18 @@ export type Legitimacy = z.infer<typeof LegitimacySchema>;
 // ─── Compiled rule schemas ──────────────────────────
 
 const CompiledRuleBaseSchema = z.object({
-  /** SHA-256 hash (first 16 hex chars) of heading + body — detects edits */
+  /**
+   * The rule's stable identity + wind-tunnel firing key.
+   * - MINED / lesson-compiled rules: SHA-256 (first 16 hex chars) of heading + body —
+   *   content-derived, detects edits.
+   * - AUTHORED rules (ADR-112 §8/§9): carries the PERSISTED, minted `ruleId` (set at
+   *   the compile seam from `CompileInputCandidate.ruleId`), NOT a content hash — the
+   *   `firingLabelId ← ruleId` id-unification, so a matcher (`dslSource`) edit never
+   *   orphans the rule's ground-truth labels / `controls.positive[].targetRuleId`. For
+   *   authored rules this is identity, NOT an edit-detector; it may carry a `-N`
+   *   collision suffix. (Authored rules are Gate-1 advisory and live only in the cert
+   *   corpus, never the product enforcement path that reads this as a content hash.)
+   */
   lessonHash: z.string(),
   /** Human-readable heading from the lesson (for diagnostics) */
   lessonHeading: z.string(),

--- a/packages/core/src/spine/authored-rule.ts
+++ b/packages/core/src/spine/authored-rule.ts
@@ -367,6 +367,11 @@ export function toCompileFeed(records: readonly AuthoredRuleRecord[]): AuthoredC
       // compiled under THAT engine — a regex-whitelisted rule whose dslSource parses
       // as ast-grep must fail loud, not silently re-route to a different engine.
       declaredEngine: record.declaredEngine,
+      // §8 id-unification: carry the persisted, minted ruleId so the compiler makes it
+      // the compiled rule's identity (`firingLabelId ← ruleId`) instead of the
+      // dslSource-derived hash — stable across a matcher edit, never orphaning the
+      // rule's wind-tunnel controls. Slice C2a.
+      ruleId: record.ruleId,
       unverified: true,
     });
     entries.push({

--- a/packages/core/src/spine/authored-rule.ts
+++ b/packages/core/src/spine/authored-rule.ts
@@ -86,7 +86,12 @@ export type AuthoredOrigin = z.infer<typeof AuthoredOriginSchema>;
 // mint-producible (#2259 CR: a looser `-\d+` admitted ids like `…-0`/`…-01` the mint can't
 // make). Pinned as a shared constant binding the SCHEMA boundary to the mint's codomain.
 const AUTHORED_RULE_ID_HEX_LEN = 16;
-const AUTHORED_RULE_ID_RE = new RegExp(`^[0-9a-f]{${AUTHORED_RULE_ID_HEX_LEN}}(?:-[1-9]\\d*)?$`);
+// Exported so the compile seam (the §8 identity selector) can assert an authored
+// candidate's ruleId is well-formed BEFORE enthroning it as the rule's identity —
+// the same shared boundary↔codomain constant, one home (Tenet 20).
+export const AUTHORED_RULE_ID_RE = new RegExp(
+  `^[0-9a-f]{${AUTHORED_RULE_ID_HEX_LEN}}(?:-[1-9]\\d*)?$`,
+);
 
 /**
  * ADR-112 §3 — the authored producer's sole output envelope. Parallel to

--- a/packages/core/src/spine/candidate-rule.ts
+++ b/packages/core/src/spine/candidate-rule.ts
@@ -50,6 +50,17 @@ export interface CompileInputCandidate {
    * `dslSource`-derived, so it carries no independent declaration to bind against.
    */
   declaredEngine?: 'regex' | 'ast' | 'ast-grep';
+  /**
+   * ADR-112 §8 — the persisted, minted rule identity (AUTHORED producer only;
+   * `mintAuthoredRuleId`, threaded from the record via `toCompileFeed`). When present,
+   * `compileCandidate` makes it the compiled rule's `lessonHash` so the wind-tunnel
+   * `firingLabelId` (and the §6 `controls.positive[].targetRuleId` it must match)
+   * embed it — the §8/§9 id-unification (`firingLabelId ← ruleId`, replacing the
+   * `dslSource`-derived hash). Stable across a matcher edit by construction, so
+   * tightening `dslSource` never orphans the rule's ground-truth labels. The MINED
+   * producer omits it — its identity is the `dslSource`-derived content hash.
+   */
+  ruleId?: string;
   unverified: true;
 }
 

--- a/packages/core/src/spine/compile.test.ts
+++ b/packages/core/src/spine/compile.test.ts
@@ -587,4 +587,31 @@ describe('runCompileStage — ADR-112 authored compile-feed', () => {
     };
     expect(() => compileCandidate(candidate, { now: NOW })).toThrow(/missing its persisted ruleId/);
   });
+
+  it('fails loud if a MINED candidate carries a ruleId — the authored-only contract is enforced, not assumed', () => {
+    // A mined candidate's identity stays the dslSource-derived hash; a stray ruleId
+    // (well-formed or not) must NOT silently re-key it. Gated on isAuthoredProvenance,
+    // not the permissive `?? hashLesson` (bot-round: gemini/greptile-P1/CR).
+    const candidate: CompileInputCandidate = {
+      ...candidateRule(7, REGEX_DSL),
+      ruleId: '0123456789abcdef', // well-formed, yet still rejected for a mined candidate
+    };
+    expect(() => compileCandidate(candidate, { now: NOW })).toThrow(/must not carry a ruleId/);
+  });
+
+  it('fails loud if an authored candidate carries a malformed ruleId — id-shape precondition (greptile-P2)', () => {
+    // The seam enthrones the ruleId as the firingLabelId basis, so a malformed id
+    // (would orphan controls.positive[].targetRuleId) is rejected at the use site,
+    // not just at the schema parse boundary.
+    const candidate: CompileInputCandidate = {
+      provenance: authored('alr-bad', REGEX_DSL).provenance,
+      classifierDisposition: 'structural',
+      classifierLedgerRef: 'authored:alr-bad',
+      dslSource: REGEX_DSL,
+      declaredEngine: 'regex',
+      ruleId: 'not-a-valid-rule-id',
+      unverified: true,
+    };
+    expect(() => compileCandidate(candidate, { now: NOW })).toThrow(/malformed ruleId/);
+  });
 });

--- a/packages/core/src/spine/compile.test.ts
+++ b/packages/core/src/spine/compile.test.ts
@@ -519,4 +519,72 @@ describe('runCompileStage — ADR-112 authored compile-feed', () => {
       ),
     ).rejects.toThrow(/duplicate classifierLedgerRef/);
   });
+
+  // ── ADR-112 §8/§9 id-unification: firingLabelId ← ruleId (slice C2a) ──
+  it('threads the persisted ruleId onto the compiled identity (lessonHash ← ruleId), not the dslSource hash', async () => {
+    const rec = authored('alr-id', REGEX_DSL);
+    const r = await runCompileStage(
+      toCompileFeed([rec]),
+      compileDeps({ 'src/a.ts': 'forbiddenCall()' }),
+    );
+    // The compiled rule's identity IS the minted ruleId — the wind-tunnel firingLabelId
+    // embeds it, and controls.positive[].targetRuleId joins on it (§6/§8).
+    expect(r.compiled[0]!.rule.lessonHash).toBe(rec.ruleId);
+  });
+
+  it('keeps the authored identity STABLE across a dslSource (matcher) edit — §8 no-orphan', () => {
+    // Same author + targetDefect → same minted ruleId; only the matcher changes.
+    const REGEX_DSL_EDITED = REGEX_DSL.replace('forbiddenCall\\(', 'forbiddenCall2\\(');
+    const before = authored('alr-stable', REGEX_DSL);
+    const after = authored('alr-stable', REGEX_DSL_EDITED);
+    expect(after.ruleId).toBe(before.ruleId); // the id does NOT derive from dslSource
+    const compiledBefore = compileCandidate(toCompileFeed([before]).candidates[0]!, { now: NOW });
+    const compiledAfter = compileCandidate(toCompileFeed([after]).candidates[0]!, { now: NOW });
+    expect(compiledBefore.kind).toBe('compiled');
+    expect(compiledAfter.kind).toBe('compiled');
+    if (compiledBefore.kind === 'compiled' && compiledAfter.kind === 'compiled') {
+      // A tightened matcher never orphans the rule's ground-truth labels / controls —
+      // the §8 reason dslSource is excluded from identity.
+      expect(compiledBefore.rule.lessonHash).toBe(before.ruleId);
+      expect(compiledAfter.rule.lessonHash).toBe(before.ruleId);
+    }
+  });
+
+  it('round-trips a collision-suffixed ruleId (-N) onto the identity verbatim', () => {
+    // A second rule by one author on one targetDefect mints `<seed>-1` (§8 disambiguation);
+    // the suffix must survive onto lessonHash so distinct matchers never share a firing key.
+    const rec: AuthoredRuleRecord = {
+      ...authored('alr-collide', REGEX_DSL),
+      ruleId: '0123456789abcdef-1',
+    };
+    const out = compileCandidate(toCompileFeed([rec]).candidates[0]!, { now: NOW });
+    expect(out.kind).toBe('compiled');
+    if (out.kind === 'compiled') expect(out.rule.lessonHash).toBe('0123456789abcdef-1');
+  });
+
+  it('leaves a MINED rule keyed on the content hash (no ruleId → dslSource-derived), unchanged', () => {
+    // The unification is authored-only: a mined candidate carries no ruleId, so its identity
+    // stays the content hash — byte-identical to pre-C2a, and never the authored ruleId.
+    const out = compileCandidate(candidateRule(1, REGEX_DSL), { now: NOW });
+    expect(out.kind).toBe('compiled');
+    if (out.kind === 'compiled') {
+      expect(out.rule.lessonHash).toMatch(/^[0-9a-f]{16}$/); // bare content hash, no -N suffix
+      expect(out.rule.lessonHash).not.toBe(authored('alr-id', REGEX_DSL).ruleId);
+    }
+  });
+
+  it('fails loud if an authored candidate reaches the compiler without its persisted ruleId (threading regression)', () => {
+    // toCompileFeed always threads it; a hand-built authored candidate missing it would
+    // silently re-derive a dslSource-keyed identity and orphan its controls — reject up front.
+    const candidate: CompileInputCandidate = {
+      provenance: authored('alr-missing', REGEX_DSL).provenance,
+      classifierDisposition: 'structural',
+      classifierLedgerRef: 'authored:alr-missing',
+      dslSource: REGEX_DSL,
+      declaredEngine: 'regex',
+      unverified: true,
+      // ruleId intentionally omitted
+    };
+    expect(() => compileCandidate(candidate, { now: NOW })).toThrow(/missing its persisted ruleId/);
+  });
 });

--- a/packages/core/src/spine/compile.ts
+++ b/packages/core/src/spine/compile.ts
@@ -26,6 +26,7 @@ import { engineFields, hashLesson, sanitizeFileGlobs, validateRegex } from '../c
 import {
   type CompiledRule,
   CompiledRuleSchema,
+  isAuthoredProvenance,
   type ProvenanceRecord,
 } from '../compiler-schema.js';
 import { extractManualPattern, type ManualPattern } from '../lesson-pattern.js';
@@ -37,6 +38,7 @@ import {
   type Stage4VerifierDeps,
   verifyAgainstCodebase,
 } from '../stage4-verifier.js';
+import { AUTHORED_RULE_ID_RE } from './authored-rule.js';
 import type { CompileInputCandidate } from './candidate-rule.js';
 import type { ClassifierLedger, Stage4LedgerOutcome } from './ledgers.js';
 
@@ -140,17 +142,37 @@ export function compileCandidate(
   // `dslSource`-derived `hashLesson`. The hash is the FORBIDDEN authored-identity
   // basis (§8): it drifts on a matcher edit, and because `firingLabelId` embeds the
   // id, any drift orphans the rule's ground-truth labels + `controls.positive[].
-  // targetRuleId`. Carrying the persisted `ruleId` here keeps every downstream join
+  // targetRuleId`. Carrying the persisted `ruleId` keeps every downstream join
   // (firing key, `mintedRuleIds`, legitimacy-projection, cert-corpus) consistent off
   // one field, and lets an author tighten `dslSource` without orphaning the rule.
-  // MINED candidates carry no `ruleId` → the content hash stands, byte-identical.
-  if (candidate.provenance.kind === 'authored' && candidate.ruleId === undefined) {
-    throw new Error(
-      `[Totem Error] compileCandidate: authored candidate '${candidate.classifierLedgerRef}' is missing its persisted ruleId — the ADR-112 §8 firingLabelId←ruleId unification requires it threaded through toCompileFeed (a threading regression would silently re-derive a dslSource-keyed identity and orphan its controls)`,
-    );
+  // This seam OWNS identity selection, so it fail-loud asserts its preconditions
+  // (Tenet 4): the authored-only `ruleId` is PRESENT + WELL-FORMED for an authored
+  // candidate, and ABSENT for a mined one (mined stay content-keyed, byte-identical).
+  // `isAuthoredProvenance` is the canonical discriminator (Tenet-20 single-home —
+  // absence ⇒ mined via `provenanceKind`), not a raw `.kind` read.
+  let lessonHash: string;
+  if (isAuthoredProvenance(candidate.provenance)) {
+    if (candidate.ruleId === undefined) {
+      throw new Error(
+        `[Totem Error] compileCandidate: authored candidate '${candidate.classifierLedgerRef}' is missing its persisted ruleId — the ADR-112 §8 firingLabelId←ruleId unification requires it threaded through toCompileFeed (a threading regression would silently re-derive a dslSource-keyed identity and orphan its controls)`,
+      );
+    }
+    if (!AUTHORED_RULE_ID_RE.test(candidate.ruleId)) {
+      throw new Error(
+        `[Totem Error] compileCandidate: authored candidate '${candidate.classifierLedgerRef}' has a malformed ruleId '${candidate.ruleId}' — must be a minted authored rule id (16 hex + optional -<n> suffix, ADR-112 §3/§8); a malformed id becomes the firingLabelId basis and would orphan its controls.positive[].targetRuleId`,
+      );
+    }
+    lessonHash = candidate.ruleId;
+  } else {
+    if (candidate.ruleId !== undefined) {
+      throw new Error(
+        `[Totem Error] compileCandidate: non-authored candidate '${candidate.classifierLedgerRef}' must not carry a ruleId — mined identities stay dslSource-derived (ADR-112 §8 authored-only contract)`,
+      );
+    }
+    lessonHash = hashLesson(heading, candidate.dslSource);
   }
   const rule = CompiledRuleSchema.parse({
-    lessonHash: candidate.ruleId ?? hashLesson(heading, candidate.dslSource),
+    lessonHash,
     lessonHeading: heading,
     message: mp.message ?? heading,
     engine: mp.engine,

--- a/packages/core/src/spine/compile.ts
+++ b/packages/core/src/spine/compile.ts
@@ -112,6 +112,38 @@ export function compileCandidate(
       `[Totem Error] compileCandidate: behavioral candidate '${candidate.classifierLedgerRef}' must never be compiled (FM(c))`,
     );
   }
+
+  // ADR-112 §8/§9 id-unification (AUTHORED producer): an authored rule's compiled
+  // identity IS its persisted, minted `ruleId` (`firingLabelId ← ruleId`), NOT the
+  // `dslSource`-derived `hashLesson`. The hash is the FORBIDDEN authored-identity
+  // basis (§8): it drifts on a matcher edit, and because `firingLabelId` embeds the
+  // id, any drift orphans the rule's ground-truth labels + `controls.positive[].
+  // targetRuleId`. The authored-only `ruleId` must be PRESENT + WELL-FORMED for an
+  // authored candidate and ABSENT for a mined one (mined stay content-keyed,
+  // byte-identical). This is a PRODUCER-CONTRACT precondition (like the behavioral
+  // guard above), so it is asserted UP FRONT — before DSL parse/validation — so a
+  // violation ALWAYS fails loud and is never masked by a coincidental parse error /
+  // `rejected` outcome (CR). `isAuthoredProvenance` is the canonical discriminator
+  // (Tenet-20 single-home — absence ⇒ mined via `provenanceKind`), not a raw `.kind`.
+  let authoredLessonHash: string | undefined;
+  if (isAuthoredProvenance(candidate.provenance)) {
+    if (candidate.ruleId === undefined) {
+      throw new Error(
+        `[Totem Error] compileCandidate: authored candidate '${candidate.classifierLedgerRef}' is missing its persisted ruleId — the ADR-112 §8 firingLabelId←ruleId unification requires it threaded through toCompileFeed (a threading regression would silently re-derive a dslSource-keyed identity and orphan its controls)`,
+      );
+    }
+    if (!AUTHORED_RULE_ID_RE.test(candidate.ruleId)) {
+      throw new Error(
+        `[Totem Error] compileCandidate: authored candidate '${candidate.classifierLedgerRef}' has a malformed ruleId '${candidate.ruleId}' — must be a minted authored rule id (16 hex + optional -<n> suffix, ADR-112 §3/§8); a malformed id becomes the firingLabelId basis and would orphan its controls.positive[].targetRuleId`,
+      );
+    }
+    authoredLessonHash = candidate.ruleId;
+  } else if (candidate.ruleId !== undefined) {
+    throw new Error(
+      `[Totem Error] compileCandidate: non-authored candidate '${candidate.classifierLedgerRef}' must not carry a ruleId — mined identities stay dslSource-derived (ADR-112 §8 authored-only contract)`,
+    );
+  }
+
   // May throw TotemParseError (e.g. a yaml fence under a non-ast-grep engine) — that
   // propagates loudly as a producer bug; it would also have been dropped at extract.
   const mp: ManualPattern | null = extractManualPattern(candidate.dslSource);
@@ -137,42 +169,10 @@ export function compileCandidate(
 
   const heading = candidateHeading(candidate);
   const ef = engineFields(mp.engine, mp.astGrepYamlRule ?? mp.pattern);
-  // ADR-112 §8/§9 id-unification (AUTHORED producer): an authored rule's compiled
-  // identity IS its persisted, minted `ruleId` (`firingLabelId ← ruleId`), NOT the
-  // `dslSource`-derived `hashLesson`. The hash is the FORBIDDEN authored-identity
-  // basis (§8): it drifts on a matcher edit, and because `firingLabelId` embeds the
-  // id, any drift orphans the rule's ground-truth labels + `controls.positive[].
-  // targetRuleId`. Carrying the persisted `ruleId` keeps every downstream join
-  // (firing key, `mintedRuleIds`, legitimacy-projection, cert-corpus) consistent off
-  // one field, and lets an author tighten `dslSource` without orphaning the rule.
-  // This seam OWNS identity selection, so it fail-loud asserts its preconditions
-  // (Tenet 4): the authored-only `ruleId` is PRESENT + WELL-FORMED for an authored
-  // candidate, and ABSENT for a mined one (mined stay content-keyed, byte-identical).
-  // `isAuthoredProvenance` is the canonical discriminator (Tenet-20 single-home —
-  // absence ⇒ mined via `provenanceKind`), not a raw `.kind` read.
-  let lessonHash: string;
-  if (isAuthoredProvenance(candidate.provenance)) {
-    if (candidate.ruleId === undefined) {
-      throw new Error(
-        `[Totem Error] compileCandidate: authored candidate '${candidate.classifierLedgerRef}' is missing its persisted ruleId — the ADR-112 §8 firingLabelId←ruleId unification requires it threaded through toCompileFeed (a threading regression would silently re-derive a dslSource-keyed identity and orphan its controls)`,
-      );
-    }
-    if (!AUTHORED_RULE_ID_RE.test(candidate.ruleId)) {
-      throw new Error(
-        `[Totem Error] compileCandidate: authored candidate '${candidate.classifierLedgerRef}' has a malformed ruleId '${candidate.ruleId}' — must be a minted authored rule id (16 hex + optional -<n> suffix, ADR-112 §3/§8); a malformed id becomes the firingLabelId basis and would orphan its controls.positive[].targetRuleId`,
-      );
-    }
-    lessonHash = candidate.ruleId;
-  } else {
-    if (candidate.ruleId !== undefined) {
-      throw new Error(
-        `[Totem Error] compileCandidate: non-authored candidate '${candidate.classifierLedgerRef}' must not carry a ruleId — mined identities stay dslSource-derived (ADR-112 §8 authored-only contract)`,
-      );
-    }
-    lessonHash = hashLesson(heading, candidate.dslSource);
-  }
   const rule = CompiledRuleSchema.parse({
-    lessonHash,
+    // §8 id-unification: authored identity is the validated, minted ruleId (asserted
+    // up front, above); a mined candidate stays the dslSource-derived content hash.
+    lessonHash: authoredLessonHash ?? hashLesson(heading, candidate.dslSource),
     lessonHeading: heading,
     message: mp.message ?? heading,
     engine: mp.engine,

--- a/packages/core/src/spine/compile.ts
+++ b/packages/core/src/spine/compile.ts
@@ -135,8 +135,22 @@ export function compileCandidate(
 
   const heading = candidateHeading(candidate);
   const ef = engineFields(mp.engine, mp.astGrepYamlRule ?? mp.pattern);
+  // ADR-112 §8/§9 id-unification (AUTHORED producer): an authored rule's compiled
+  // identity IS its persisted, minted `ruleId` (`firingLabelId ← ruleId`), NOT the
+  // `dslSource`-derived `hashLesson`. The hash is the FORBIDDEN authored-identity
+  // basis (§8): it drifts on a matcher edit, and because `firingLabelId` embeds the
+  // id, any drift orphans the rule's ground-truth labels + `controls.positive[].
+  // targetRuleId`. Carrying the persisted `ruleId` here keeps every downstream join
+  // (firing key, `mintedRuleIds`, legitimacy-projection, cert-corpus) consistent off
+  // one field, and lets an author tighten `dslSource` without orphaning the rule.
+  // MINED candidates carry no `ruleId` → the content hash stands, byte-identical.
+  if (candidate.provenance.kind === 'authored' && candidate.ruleId === undefined) {
+    throw new Error(
+      `[Totem Error] compileCandidate: authored candidate '${candidate.classifierLedgerRef}' is missing its persisted ruleId — the ADR-112 §8 firingLabelId←ruleId unification requires it threaded through toCompileFeed (a threading regression would silently re-derive a dslSource-keyed identity and orphan its controls)`,
+    );
+  }
   const rule = CompiledRuleSchema.parse({
-    lessonHash: hashLesson(heading, candidate.dslSource),
+    lessonHash: candidate.ruleId ?? hashLesson(heading, candidate.dslSource),
     lessonHeading: heading,
     message: mp.message ?? heading,
     engine: mp.engine,


### PR DESCRIPTION
## ADR-112 §8/§9 Slice C2a — authored-rule id-unification (`firingLabelId ← ruleId`)

First slice of **ADR-112 Slice C2** (the contract-coupled wiring). This is the **inert id-unification** the "no control emission before unification" invariant (§8) requires *before* any control emission — it ships dark and changes nothing for consumers.

### What it does
An authored rule's compiled identity (`lessonHash`) now carries its **persisted, minted `ruleId`** instead of the `dslSource`-derived content hash, threaded from the record through a new optional `CompileInputCandidate.ruleId` and set at the compile seam (`compileCandidate`). So the wind-tunnel `firingLabelId` (which embeds the rule id) and the §6 `controls.positive[].targetRuleId` join key on the **stable minted id**, not the matcher — §8 excludes `dslSource` from identity precisely so tightening a matcher never orphans a rule's ground-truth labels or controls.

- **Authored-only and inert.** Mined rules are **byte-identical** (no `ruleId` → the content hash stands). Authored rules remain Gate-1 advisory with **no control emission yet** (Slice C2b).
- **Fail-loud** if an authored candidate reaches the compiler without its threaded `ruleId` (a threading regression would silently re-derive a `dslSource`-keyed identity and orphan the rule's controls).

### Why option (a) — set `lessonHash = ruleId` at compile, not a separate accessor
A 3-lens pre-build cohort panel (contract / build-test / tenet, source-verified) split on the mechanism. Resolved as a build call per §9.174 (the firing-to-label join is the build's):
- `lessonHash` carries two semantics — **identity** (firing/`mintedRuleIds`/legitimacy-projection/cert-corpus join) and **content-hash-detects-edits** (`compile-cache`, `first-lint-promote`). The cert-join sites want the `ruleId`; the content-hash sites are **product-enforcement** paths authored rules never reach (Gate-1 advisory, cert-corpus only).
- Option (a) makes one write site and keeps every join site consistent off one field; a separate-accessor approach would need the accessor threaded across 4 sites in 2 packages — any miss = a silent mismatch. The schema comment on `lessonHash` documents the authored exception so the field semantic isn't silently overloaded.

### The real gate — all green
- `pnpm -r build` — clean across core + cli + mcp + packs (no ripple)
- core tests — **2960 passed**, incl. 5 new id-unification tests (identity ← ruleId; §8 stability across a matcher edit; `-N` collision-suffix round-trip; mined-unchanged contrast; fail-loud on a missing threaded id) and zero fallout to `finding` / `pack-merge` / `rule-policy`
- ESLint core clean; prettier clean on changed files; `totem lint` exit 0
- changeset: `@mmnto/totem: patch` (cli auto-bumps)

### `totem lint` advisory dispositions (exit 0, §1 non-blocking — all false-positive in context)
- *async test callback* — `runCompileStage` is genuinely async and awaited (same pattern as the existing `:476` test).
- *"don't `new Error` for SDK-retry normalization"* — N/A; mine is a fail-loud producer-contract assert, not retry logic.
- *"thrown errors need the `[Totem Error]` prefix"* — already present in the message.

### Scope / sequence
- This is **PR-1 of 3** for C2. Next: PR-2 = `negativeFixtures` silence-only `nearMissSource` schema (couple-on strategy#770, carries the §5-ledger nuance); PR-3 = C2b train-side differential-gated control emission (gated on this + the strategy Q-A/Q-B emission-shape ruling).
- Part of the ADR-112 authored-rule producer (mmnto-ai/totem-strategy#591); provenance discriminator tracking mmnto-ai/totem#2183. Closes nothing — one slice of a multi-PR build.
