### PR TITLE
feat(spine): ADR-112 §6/§8/§9 Slice D1 — authored corpus feed + controls (sibling assembler/provider, inert-until-D3) (strategy#591)

### DIFF
--- a/.changeset/adr112-d1-authored-corpus-feed.md
+++ b/.changeset/adr112-d1-authored-corpus-feed.md
@@ -1,0 +1,16 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+---
+
+ADR-112 §6/§8/§9 Slice D1 — wire the authored producer into the Gate-1 certifying corpus (inert-until-D3, strategy#591/#661).
+
+The authored producer (`runRuleAuthor` → `toCompileFeed` → `runCompileStage` → the inert `deriveAuthoredControls`) was fully built but unconnected to the cert corpus. D1 connects it via a SIBLING assembler + provider (not a branch in the mined path — the mined `buildCertifyingCorpus` stays byte-unchanged):
+
+- **`buildAuthoredCertifyingCorpus`** (new, `@mmnto/cli`) assembles an authored-provenance `CertifyingCorpus` from `.totem/spine/authored-rules.yaml`: `runRuleAuthor` (preserving the §3/§8 producer invariants — no ad-hoc records) → `rejected.length === 0` precondition → file/ledger **split-binding verification BEFORE compile** (every record's authoring-ledger `splitRef` must equal this run's split, with `authoredAfterSplit` + `heldOutNonInspectionAttestation` — the §5 leakage guard `deriveAuthoredControls`'s train-side check alone cannot cover) → `toCompileFeed` → `runCompileStage` (**authored compile-rejection = hard failure**) → homogeneous-authored assembly from the `c.provenance` sidecar → `deriveAuthoredControls`. Every gap fails loud (Tenet-4).
+- **`buildAuthoredCorpusProvider`** + **`resolveCertifyingCorpusProvider`** (new, `@mmnto/cli`) — the single dispatch home: pick the mined replay provider vs the authored sibling off the lock's `producerKind` (absent ⇒ mined), so no `kind` branch is scattered downstream. The mined branch is byte-unchanged.
+- **`CertifyingCorpus.authoredControls?`** (new channel, `@mmnto/cli`) — the §6 emission lists, present iff the corpus is authored-provenance (defined-with-empty-arrays for an authored corpus with no emitting fixtures; `undefined` for mined).
+- **`deriveAuthoredControls`** (`@mmnto/totem`) now reads provenance from a required `provenanceByRule` sidecar map, never `rule.legitimacy` (absent at the assembly seam — stamped only post-scoring).
+- **`WindtunnelLock.producerKind`** (`@mmnto/totem`) — additive-optional `'mined' | 'authored'` dispatch signal; absent ⇒ mined, so every existing lock parses + serializes byte-unchanged.
+
+INERT: nothing in scoring/persist/report consumes `authoredControls` yet (the engine reads only rules/prDiffs/groundTruth/provenanceByRule) — D3 (`scoreAuthoredWindtunnel`) + D4 (Gate-2 eligibility/report) consume it. The authored cert-run INPUT wiring (lock-sourced `judgedBy` / `splitRef` + an authored fixture-substrate loader) lands in D2; until then the resolver fails loud if a lock declares `producerKind: 'authored'` without authored deps.

--- a/.totem/specs/ADR-112-slice-D-scorer-gate2.md
+++ b/.totem/specs/ADR-112-slice-D-scorer-gate2.md
@@ -1,0 +1,240 @@
+### Problem Statement
+
+We need to implement Slice D of ADR-112, specifically "Gate 2" of the Windtunnel Scorer, which evaluates minted rules against ground truth and positive controls to determine if they meet the required precision (`cullRateThreshold`) and correctly fulfill the `differential-holds` preimage requirement.
+
+### Architectural Context
+
+From the provided Totem Knowledge, ADR-112 enforces a strict evaluation model for rule efficacy via the Windtunnel Scorer. We must utilize the `ScorerInput` interface from `windtunnel-scorer.ts` to evaluate `mintedRuleIds`. A critical architectural constraint explicitly stated in the types is that unlabeled firings strictly imply a `needsAdjudication` state—they must not be silently treated as true or false positives. Additionally, the system must evaluate whether the `PreimageDifferentialOutcome` is valid (the rule fires on the preimage but not on the postimage, avoiding the fix-shaped Falsifying Metric §1(i)).
+
+### Files to Examine
+
+1. `packages/core/src/spine/windtunnel-scorer.ts` — Contains the `ScorerInput` interface, which defines the inputs (`firings`, `groundTruth`, `cullRateThreshold`) Gate 2 will consume.
+2. `packages/core/src/spine/preimage-differential.ts` — Defines `PreimageDifferentialOutcome`, critical for understanding the positive control gating logic (`'differential-holds'`).
+3. `packages/core/src/spine/authored-controls.ts` — Provides context on how controls are derived prior to hitting the scorer.
+
+### Technical Approach & Contracts
+
+Implement `evaluateScorerGate2`, a pure function that processes `ScorerInput` and emits a `ScorerGate2Output`.
+
+**Data Contracts:**
+
+```typescript
+// Add to packages/core/src/spine/windtunnel-scorer.ts
+
+export type RuleGate2Status = 'passed' | 'culled' | 'needs_adjudication';
+
+export interface Gate2RuleResult {
+  ruleId: string;
+  status: RuleGate2Status;
+  falsePositiveRate: number;
+  unlabeledFiringsCount: number;
+  failedPositiveControls: boolean;
+  rejectionReasons: string[];
+}
+
+export interface ScorerGate2Output {
+  results: Map<string, Gate2RuleResult>;
+  summary: {
+    totalPassed: number;
+    totalCulled: number;
+    totalNeedsAdjudication: number;
+  };
+}
+```
+
+**Sequence Logic:**
+
+1. Initialize a result map for all `mintedRuleIds`.
+2. For each rule, cross-reference `firings` with `groundTruth`.
+3. Count True Positives (TP), False Positives (FP), and unlabeled firings.
+4. Verify the rule against `positiveControlTargets` to ensure `differential-holds` (it must successfully fire on its designated positive control preimages).
+5. Apply gating logic:
+   - If `unlabeledFiringsCount > 0`, status is `needs_adjudication` (Halt evaluation for this rule).
+   - If positive controls fail, status is `culled` (Reason: "Fails preimage differential").
+   - Calculate FP rate `(FP / (TP + FP))`. If `FP + TP === 0`, default to 0.
+   - If `FP rate > cullRateThreshold`, status is `culled`.
+   - Otherwise, status is `passed`.
+
+### Edge Cases & Traps
+
+- **Unlabeled Firings Trap:** As noted in the type definitions, any firing not explicitly mapped in `groundTruth` MUST flag the rule for adjudication. It cannot be assumed to be a False Positive or ignored, as this silently skews the `cullRateThreshold`.
+- **Division by Zero:** A rule might fire 0 times in the current corpus. The FP rate calculation must safely handle `0 / 0`, classifying it as a `0` FP rate, falling back entirely to the positive control check.
+- **Falsifying Metric §1(i) Trap:** A rule might fire on BOTH the preimage and postimage. The `preimage-differential.ts` context warns against "fix-shaped" evaluations. Gate 2 must ensure the rule does _not_ fire on the postimage (verifying the outcome is strictly `differential-holds`).
+
+### Implementation Tasks
+
+- [ ] **Task 1: Define ScorerGate2 Contracts**
+  - Modify `packages/core/src/spine/windtunnel-scorer.ts` to export `RuleGate2Status`, `Gate2RuleResult`, and `ScorerGate2Output` interfaces.
+  - No implementation logic yet, just types.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `exports ScorerGate2Output and related types` in `packages/core/src/spine/__tests__/windtunnel-scorer.test.ts` checking for type exports.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Implement Base evaluateScorerGate2 Function and Adjudication Trap**
+  - Implement the `evaluateScorerGate2(input: ScorerInput): ScorerGate2Output` function stub.
+  - Add logic to iterate over `mintedRuleIds` and check for unlabeled firings.
+    > TOTEM INVARIANT (Unlabeled Firings): Unlabeled firings ⇒ needsAdjudication. Never classify an unmapped ground truth ID as FP or TP.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `flags rule as needs_adjudication if any firing lacks ground truth label` proving the invariant.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Implement Positive Control Differential Gate**
+  - Update `evaluateScorerGate2` to verify that each rule successfully fires on its defined `positiveControlTargets`.
+  - If a rule fails to meet `differential-holds` (e.g. misses the preimage or hits the postimage), mark it `culled`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `culls rule if it fails positive control differential check` ensuring rules missing their designated controls are rejected.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Implement FP Cull Rate Threshold Gate**
+  - Update `evaluateScorerGate2` to calculate the FP rate and compare it to `cullRateThreshold`.
+  - Protect against Division by Zero when calculating `FP / (TP + FP)`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `culls rule when false positive rate exceeds cullRateThreshold` and `passes rule with zero firings gracefully without NaN`.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Scenario 1:** A rule with 100% true positive firings and passing positive controls returns `passed`.
+- **Scenario 2:** A rule with zero total firings but passing positive controls handles the 0/0 math safely and returns `passed`.
+- **Scenario 3:** A rule with an FP rate of 0.05 against a threshold of 0.02 returns `culled` with a specific rejection reason.
+- **Scenario 4:** A rule with 99 TPs and 1 firing missing from the `groundTruth` map returns `needs_adjudication`, bypassing the cull rate check entirely.
+- **Scenario 5:** A rule that fires on the postimage (fails `differential-holds`) returns `culled`.
+
+---
+
+> **NOTE (totem-claude, 2026-06-29):** The Gemini-generated body above is a generic first-pass and is **superseded** by the authoritative design below, which is built from (a) ADR-112 §5/§6/§9 (re-read at current merged state, strategy `2a4df9e`) and (b) a live surface map of the cert-run scorer. In particular the Gemini `evaluateScorerGate2`/`ScorerInput` shapes are **not** the real surface — the real owners are `scoreWindtunnel` / `deriveLabelsFromDispositions` / `buildCertifyingCorpus` / `persistCertifyingOutcome`.
+
+## Implementation Design
+
+### Scope (2 sentences)
+
+Slice D wires the inert `deriveAuthoredControls` emission into the Gate-1 cert run so an **authored-provenance** corpus can be scored at power: the §9 producer-kind switches (train-side positive controls, whole-window FP, train-side exposure) are applied, the §5.3 three-role scoring is implemented (non-vacuity ← train-side differential control; precision ← whole-window FP; per-rule generalization ← held-out activation gating **Gate-2 promotion, not Gate-1 survival**), and the ADR-110 §5 report gains `heldOutActivationsByRule` + the Gate-2-eligible set. It will **NOT** touch the miner path's behavior (mining stays held-out-shaped; every authored branch is `kind`-switched, never a global change), **NOT** introduce any blocking gate (Gate 1 still never blocks — §1 zero-enforcement), and **NOT** implement the `kind:'commit'` near-miss source (deferred per §6; cert-1 is lesson-anchored only).
+
+### Proposed decomposition (HEADLINE — this is the load-bearing decision)
+
+The surface map shows D spans ~6 subsystems, **three greenfield** (`heldOutActivationsByRule`, Gate-2 eligibility, whole-window labeling all absent from `src/`). That is too large for one PR and breaks the established ADR-112 inert-until-next slicing (A / B / C1 / C2a / C2b). Recommended cut, each shippable + gate-green, each inert until the next consumes it:
+
+- **D1 — corpus injection seam (inert).** Add an `authoredControls?: AuthoredControls` channel to `CertifyingCorpus`; `buildCertifyingCorpus` calls `deriveAuthoredControls({rules, split})` when the corpus provenance kind is `authored` (read from `provenanceByRule`). Assembled but **scored by nobody** — mirrors C1's inert-primitive pattern; ends `deriveAuthoredControls`'s zero-caller status without behavioral change.
+- **D2 — whole-window labeling.** `deriveLabelsFromDispositions` (+ the `spine-derive-labels` CLI) labels **every non-control firing in both slices** when policy `labelScope:'whole-window'` (authored), so a train-slice FP carries a label. Testable in isolation; still no authored scoring.
+- **D3 — §5.3 scoring + `heldOutActivationsByRule`.** `scoreWindtunnel` (kind-switched, or a sibling authored pass merged into the verdict) consumes `authoredControls`: non-vacuity from the differential-gated `positive[]`, whole-window FP (labels now span the window), negative silence-cull via `nearMissSource` join-back, and computes `heldOutActivationsByRule`. Verdict gains the activations map.
+- **D4 — Gate-2 eligibility + report (D goes live).** Gate-2-eligible set = survivors restricted to held-out-exercised rules; `exposureControlSide`-gated `positiveControlsExercised` (train-side); enriched §5 report via `persistCertifyingOutcome` + `legitimacy-projection`. This is where the cert runs at-power on an authored corpus.
+
+Alternative compressions: **2-slice** (D1+D2 plumbing / D3+D4 scorer) or **all-in-one**. My recommendation: **start with D1 this session** (smallest, de-risks the seam, fully inert, sets the `CertifyingCorpus` shape the rest hang off). Open question O1 below puts the cut to the operator + cohort.
+
+### Data model deltas
+
+- **`CertifyingCorpus.authoredControls?: AuthoredControls`** (`spine-windtunnel.ts:341-352`). Holds the emitted positive/negative/non-emission controls. **Writer:** `buildCertifyingCorpus` (D1). **Reader:** `scoreWindtunnel`/authored pass (D3). **Invariant:** present iff corpus provenance kind is `authored` (single-provenance §7); optional so the miner path is byte-unchanged. Guaranteed by the `provenanceByRule`-kind branch at assembly.
+- **`WindtunnelVerdict.heldOutActivationsByRule?: Map<ruleId, number>`** (`windtunnel-scorer.ts:25-48`). Per-rule count of held-out-slice activations. **Writer:** `scoreWindtunnel` (D3). **Reader:** Gate-2 eligibility (D4) + report. **Invariant:** keys = minted rule ids; a rule absent ⇒ 0 (explicit, not silent — see failure table).
+- **`WindtunnelVerdict.gate2EligibleRuleIds?: string[]`** (D4). Survivors ∩ held-out-exercised. **Writer:** scorer/D4. **Reader:** report. **Invariant:** ⊆ surviving set; a survivor with 0 held-out activations is **excluded but NOT failed** (§5.3 — `held-out-unexercised`).
+- **No new reserved keys / sentinels.** `positiveControlGate`/`positiveControlSide`/`labelScope`/`exposureControlSide` already exist in `rule-policy.ts` as frozen-enum DATA — D **reads** them (D2 reads `labelScope`, D3/D4 read `exposureControlSide`); it adds no policy fields. This is the §9 "data, not behavioral branch" discipline (Tenet 9).
+
+### State lifecycle
+
+All new state is **per-cert-run** (request-scoped), created during `runCertifyingEngine` (`spine-windtunnel.ts:497-585`), never persisted beyond the transient `windtunnel-cert-run.v1` report, never mutated after the verdict is sealed. `authoredControls` is created at corpus assembly (`buildCertifyingCorpus`) and read once by the scorer; `heldOutActivationsByRule`/`gate2EligibleRuleIds` are created in the scorer and read once by the report producer. **No state crosses a lifecycle boundary** (no session/server-lifetime flags) — the one-shot-flag bug class does not apply here.
+
+### Failure modes
+
+| Failure                                                                         | Category            | Agent-facing surface                                                           | Recovery                                                            |
+| ------------------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------- |
+| Authored corpus assembled but a positive `fixture.pr` is held-out (leakage)     | runtime / permanent | **hard error** (already thrown in `deriveAuthoredControls:305-313`)            | fix the split/fixture; run voided (§5 falsifier §1(c))              |
+| A train-slice firing has **no** ground-truth label (deriver didn't widen scope) | runtime / permanent | **hard error** at score time (a train FP must never silently escape — §6/§5.3) | D2 must label window-wide; absence = a real bug, fail loud not skip |
+| Rule with **zero held-out activations**                                         | runtime / expected  | **report status** `held-out-unexercised`, excluded from Gate-2 set             | not a failure — survives Gate 1 (§5.3); recorded, never culled      |
+| Negative `nearMissSource` join-back finds no matching fixture                   | runtime / permanent | **hard error** (Tenet-20 dangling pointer)                                     | fix the record; never charitably skip the silence check             |
+| Matcher fires on a negative near-miss exemplar                                  | runtime / expected  | **cull** (cullLedger, §3.3) — not a corpus FP                                  | working as designed (ADR-110 §5 verdict precedence)                 |
+| `positiveControlGate`/`Side` mismatch vs authored policy                        | init / permanent    | **hard error** (already asserted `:273-285`)                                   | producer/policy misconfig; surfaces at assembly                     |
+| Unlabeled non-control firing remains after whole-window derive                  | runtime / permanent | `needsAdjudication` → HONEST-NEGATIVE                                          | never charitably TP/FP (existing scorer discipline)                 |
+
+No row is "silent degradation." Every authored-path gap fails loud — the whole point of the leakage guard is mechanical, not charitable (Tenet 4 + ADR-112 §5).
+
+### Invariants to lock in via tests
+
+- An authored corpus's positive control scores non-vacuity from the **exemplar differential**, NEVER from the rule's landed PR diff (Tenet-20; the lc "review-caught defect never lands" case must PASS, not spuriously FAIL).
+- A **train-slice** false positive triggers FAIL (precision-1.0 floor spans the whole window — held-out-only scoring must not let it escape).
+- A non-vacuous, zero-FP rule with **zero held-out activations** SURVIVES Gate 1 and is EXCLUDED from the Gate-2-eligible set (the two are distinct verdicts — the codex break).
+- `exposureDenominator.positiveControlsExercised` counts **train-side** controls for an authored corpus (a rare-defect rule with no held-out activation still contributes to the exposure floor).
+- The miner path is **byte-unchanged**: a mined-provenance corpus produces an identical verdict + report before and after D (every authored behavior is `kind`-gated).
+- A duplicate/dangling control join-key fails loud (carry the C2b answer-key-uniqueness discipline into the consumer).
+
+### Open questions
+
+- **O1 — Decomposition + this-session scope.**
+  - **Options:** (a) 4 sub-slices D1–D4, start D1 now; (b) 2 sub-slices (plumbing / scorer); (c) one big D PR.
+  - **Recommendation:** (a) — start **D1** (inert corpus seam) this session. Matches the established inert-until-next discipline, keeps each PR reviewable, de-risks the `CertifyingCorpus` shape early. Cohort + operator to confirm.
+- **O2 — Scorer extension shape: kind-switch `scoreWindtunnel` vs. a sibling authored pass.**
+  - **Options:** (a) add `kind`-aware branches inside `scoreWindtunnel`; (b) a separate `scoreAuthoredWindtunnel` that produces the same `WindtunnelVerdict` shape, dispatched by provenance kind at the orchestration layer.
+  - **Recommendation:** (b) — a sibling pass keeps the miner scorer untouched (protects the byte-unchanged invariant) and isolates the authored logic; dispatch on kind in `runCertifyingEngine`. Build-altitude (mine) but worth a cohort lens. Defer the firm call to D3.
+- **O3 — Where `heldOutActivationsByRule` is computed (CONTRACT-ADJACENT → couple-on-D to strategy).**
+  - **Question:** Does "held-out activation" count any firing on a held-out-slice PR, or only **non-control** firings (excluding the rule's own controls)? The §5.3 intent is _generalization beyond what the author saw_ — controls are train-side under authored, so held-out firings are inherently non-control, but the precise denominator wants strategy's confirmation against §5.3.
+  - **Recommendation:** count held-out-slice **non-control** firings per rule; route to strategy-claude as the one genuinely contract-adjacent question (the rest are build-altitude per the ADR's altitude note).
+
+### Verification note
+
+The ADR's altitude clause is explicit: it fixes _invariants_ + _declared amendments_; the _mechanics_ (how `derive-labels` switches by kind, the exact firing-to-label join, id disambiguation) are **reconciled at build against live code**. O1/O2 are build-altitude (mine, cohort-reviewed); O3 is the one to couple-on-D with strategy.
+
+## Panel outcome — RESOLVED (folded 2026-06-29, pre-build cohort panel + couple-on-D)
+
+4-seat panel (codex contract / agy test-completeness / gemini tenet-arch / strategy couple-on-D). Convergent. Operator greenlit O1=(a), build D1 now.
+
+- **O1 → (a) 4 sub-slices, build D1 now.** Operator + gemini approved.
+- **O2 → (b) sibling `scoreAuthoredWindtunnel` pass.** gemini + me; protects miner-byte-unchanged + Tenet-9 at the boundary. Carry to D3.
+- **O3 → non-control held-out firings.** strategy RULED (2019Z): per rule, count firings on held-out-slice PRs **excluding the rule's own declared controls**; pin on the _principle_ ("generalization beyond what the author saw" — a control is definitionally what the author saw), not the train-side coincidence (that's today's corollary). Negatives never count. strategy lands a one-sentence §5.3 amendment **couple-on-merge with the Slice-D contract PR**. §9 switch-table CONFIRMED current (no axis moved).
+
+### D1 design REVISED per codex CONCERN (two required folds — both verified against source)
+
+1. **Call-shape reshape (REQUIRED).** The shipped `deriveAuthoredControls` reads `rule.legitimacy?.provenance` (`authored-controls.ts:231`) and hard-throws if absent. At the assembly seam the compiled rules carry **no** legitimacy — `rules = scored.map(c => c.rule)`; provenance lives in the `c.provenance` sidecar → `provenanceByRule` (`spine-cert-corpus.ts:105-108`); `legitimacy` is stamped only post-scoring (survivors-only, `legitimacy-projection.ts`). So `deriveAuthoredControls({rules, split})` as originally designed would throw at runtime. **Fold:** widen `deriveAuthoredControls` to read **sidecar provenance** — accept `provenanceByRule` (or `{rule, provenance}` pairs / `CompiledCandidate[]`); NEVER synthesize `rule.legitimacy` (it also carries control booleans, intentionally absent pre-verdict). Build-mechanic choice (param shape): lean **add `provenanceByRule: Map<string, ProvenanceRecord>` to the params**, since the seam already builds that map and it keeps a single provenance source-of-truth; update the C2b tests to pass it. This is the first real exercise of the inert C2b primitive — aligning its input contract to reality is part of D1.
+2. **Single-provenance enforced AT the seam (REQUIRED).** Don't treat §7 as upstream-guaranteed. Homogeneous pass over the scored set: require `provenanceByRule.get(rule.lessonHash)` for every rule (missing → hard error); derive kind via canonical `provenanceKind`; >1 kind → hard error (mixed-provenance, §7 out of scope); `mined` → omit `authoredControls`; `authored` → attach (even if arrays empty).
+
+## D1 RE-CUT — RESOLVED (panel round 2, 2026-06-30) — the producer is built-but-unwired
+
+A post-round-1 surface trace found the authored producer is **fully built but disconnected at three points** (none wired into the cert corpus): `runRuleAuthor`→`AuthoredRuleRecord[]` (only the `rule author` CLI calls it), `toCompileFeed`→`runCompileStage` authored branch (built, "one compiler, two producers", **zero production callers**), and `deriveAuthoredControls` (zero callers). `buildCertifyingCorpus` is mined-only. So round-1 D1 ("call deriveAuthoredControls") is **necessary-but-not-sufficient** — nothing feeds authored rules into the corpus. Round-2 cohort (codex contract / gemini arch / strategy couple-on-D) **convergent**:
+
+- **Architecture: SIBLING `buildAuthoredCertifyingCorpus` + new `buildAuthoredCorpusProvider`** (NOT a branch in the mined `buildCertifyingCorpus`). The mined assembler's `source/extractor/classifier/stage4` deps are irrelevant to authored; a branch = one function doing two disjoint jobs (Tenet-9 anti-shape). **Kind-dispatch single-home = provider RESOLUTION at the orchestration entry (`runCommand`), reading the producer kind off the `WindtunnelLock`/policy** (gemini) — instantiate the right provider once, pass the generic `CertifyingCorpusProvider` down; NO `if (kind==='authored')` scattered downstream. Mined path **byte-unchanged**.
+- **Scope: feed + controls = ONE inert D1 (option a).** Unanimous. Feed-only leaves the corpus without its present-iff-authored channel; controls-only leaves the production feed gap. Only acceptable split if ever forced: feed(D1)+controls(D1b), never controls-only.
+- **strategy scope ruling:** the producer→corpus feed is **in the Slice-D arc (D1)**, §8-legal as a sibling. strategy pins a one-line §8 clarification (sibling dispatched on kind) **couple-on-merge with the D-feed PR** (the sibling IS the seam). §7 single-provenance CONFIRMED (one run = wholly authored OR mined).
+
+### D1 build (resolved)
+
+1. **`buildAuthoredCorpusProvider`** (sibling to `buildReplayCorpusProvider`), selected by producer kind at provider resolution (the single dispatch home). Reads the lock/config to know the run is authored-primary.
+2. **`buildAuthoredCertifyingCorpus`** (sibling to `buildCertifyingCorpus`): authored records → compile → assemble + derive controls. Steps:
+   - obtain authored records via `runRuleAuthor(totemDir, {judgedBy})` **or a factored equivalent preserving ALL producer invariants** (strict authored-file shape incl. recursive producer-owned-key rejection, independent structural-eligibility re-check, stable id mint/reuse from the ledger, fail-loud dup-identity, ledger append/read-back, `judgedBy`≠author) — **NEVER ad-hoc record construction / raw YAML→record** (codex);
+   - **`rejected.length === 0` precondition** — fail the cert run if any authored record was rejected (never certify the eligible subset of a partially-invalid file);
+   - **verify the file/ledger split-binding BEFORE compile** — prove the authoring-ledger entries' `splitRef`/`authoredAfterSplit`/`heldOutNonInspectionAttestation` match the split used by THIS cert run; these are NOT on `AuthoredRuleRecord` (they're on the file/ledger), so extend the feed result or add a helper returning the authoring-run metadata/ledger refs (codex finding 4 — `deriveAuthoredControls`'s train-side check alone is insufficient for leakage);
+   - `toCompileFeed(records)` → `runCompileStage` → `CompiledCandidate[]`; **authored compile-rejection = HARD failure** (broken authored cert input, not mined noise — fail before emitting an incomplete controls set);
+   - assemble `rules` + `provenanceByRule` from `c.provenance` sidecar (no `rule.legitimacy`); enforce homogeneous authored provenance (mixed → throw);
+   - call the widened `deriveAuthoredControls({ rules, split, provenanceByRule })`; attach `authoredControls` (defined-with-empty-arrays if no fixtures).
+3. **`CertifyingCorpus.authoredControls?`** channel — if the return type bakes in mined ledgers, prefer a **tagged variant** over mined-placeholder fields (codex).
+4. **`deriveAuthoredControls` reshape** — read sidecar `provenanceByRule` param (the round-1 fold #1).
+5. **Inert:** no scorer/persist/report consumes `authoredControls` (D3/D4 do). The leakage/rejected/compile/duplicate throws are assembly contract guards (not flag-gated).
+
+### D1 tests (codex's required set + round-1 matrix)
+
+- **Production-path:** authored YAML → `runRuleAuthor` → `toCompileFeed` → `runCompileStage` → authored corpus with `rules` + `provenanceByRule` + `authoredControls` (exercise the REAL compile path, not mocked candidates — agy round-1 §4).
+- Rejected authored input (any `rejected`) fails the corpus build even if other records are eligible.
+- Authored compile-rejection fails the authored corpus build (not a partial corpus).
+- Split mismatch (file/ledger ↔ current cert split) fails BEFORE compile.
+- Mixed mined/authored provenance at assembly fails loud.
+- `deriveAuthoredControls` consumes sidecar provenance; requires no pre-verdict `rule.legitimacy`.
+- Existing mined `buildCertifyingCorpus` byte/shape-unchanged (no `authoredControls` on mined output).
+- 3-state channel matrix (mined→undefined / authored→populated / authored-empty→defined-empty-arrays).
+
+### Round-1 D1 channel + tests (folded codex + agy) — carried into the resolved build above
+
+- **Channel:** `CertifyingCorpus.authoredControls?: AuthoredControls` — **present iff `corpusKind === 'authored'`** (undefined for mined; **empty arrays, not undefined**, for an authored corpus with no fixtures — agy state 3). `AuthoredControls = { positive, negative, nonEmissions }`; positive = `{ pr, targetRuleId, filePath, matchedSpan }` (NO `contentHash`/`preimageSource` — correcting agy's example shape).
+- **Inertness:** the `deriveAuthoredControls` throws (leakage / policy-mismatch / duplicate-locus) stay as assembly contract guards — NOT hidden behind a flag (codex Q2). No second uniqueness algo; D1 propagates C2b's fail-loud (codex Q3).
+- **Tests (3-state matrix + regressions):** (1) mined → `authoredControls === undefined` + existing cert-corpus tests byte-unchanged; (2) authored w/ fixtures → channel populated, deep-structure asserted on the TRUE shape; (3) authored w/ empty fixtures → defined, empty arrays; (4) mixed-provenance → throws before partial derive; (5) missing provenance for a scored rule → throws; (6) authored path requires/adds no `rule.legitimacy`; (7) leakage/policy/duplicate-locus failures propagate through the seam.

--- a/packages/cli/src/commands/spine-authored-cert-corpus.test.ts
+++ b/packages/cli/src/commands/spine-authored-cert-corpus.test.ts
@@ -1,0 +1,320 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { stringify } from 'yaml';
+
+import type {
+  AuthoredControlsDeps,
+  PreimageDifferentialOutcome,
+  PreimageDifferentialResult,
+  SplitArtifact,
+  Stage4VerifierDeps,
+  WindtunnelLock,
+} from '@mmnto/totem';
+
+import {
+  buildAuthoredCertifyingCorpus,
+  type BuildAuthoredCertifyingCorpusDeps,
+} from './spine-authored-cert-corpus.js';
+import {
+  type ReplayCorpusProviderOptions,
+  resolveCertifyingCorpusProvider,
+} from './spine-cert-run-corpus.js';
+
+// ─── Fixtures (mirror the slice-2/3/4 + authored-controls tests) ──────────────
+
+const sha = (n: number): string => String(n).padStart(40, '0');
+const NOW = '2026-06-19T12:00:00.000Z';
+const SPLIT_REF = 'split-cert-1';
+const JUDGED_BY = 'static-whitelist@cert-1';
+const LESSON_REF = 'deadbeefdeadbeef';
+
+/** A regex DSL that compiles cleanly + fires on `forbiddenCall()`. */
+const REGEX_DSL = [
+  '**Pattern:** `forbiddenCall\\(`',
+  '**Engine:** regex',
+  '**Severity:** warning',
+  '',
+  '### Bad Example',
+  '```ts',
+  'forbiddenCall()',
+  '```',
+].join('\n');
+
+/** A regex DSL that PARSES but fails per-engine validation (unterminated group) → compile-rejected. */
+const BAD_REGEX_DSL = [
+  '**Pattern:** `(unclosed`',
+  '**Engine:** regex',
+  '**Severity:** warning',
+].join('\n');
+
+const SPLIT: SplitArtifact = {
+  asOfCommit: sha(100),
+  trainPrs: [1],
+  heldOutPrs: [],
+  excludedPrs: [],
+  positiveControlPrs: [],
+  negativeControlPrs: [],
+  splitRule: { predicate: 'code-touching non-bot', cutIndex: 1 },
+};
+
+interface AuthoredRuleInputLike {
+  author: string;
+  authoredAt: string;
+  targetDefect: string;
+  declaredEngine: string;
+  structuralClass: string;
+  dslSource: string;
+  positiveFixtures: unknown[];
+  negativeFixtures?: unknown[];
+}
+
+function posFixture(pr = 1, filePath = 'src/a.ts', matchedSpan = 'L1-L2') {
+  return {
+    pr,
+    preimageSource: {
+      kind: 'lesson',
+      lessonRef: LESSON_REF,
+      badExample: 'bad()',
+      goodExample: 'good()',
+    },
+    filePath,
+    matchedSpan,
+    contentHash: `ch-${pr}-${filePath}`,
+  };
+}
+
+function authoredRuleInput(overrides: Partial<AuthoredRuleInputLike> = {}): AuthoredRuleInputLike {
+  return {
+    author: 'agent-x',
+    authoredAt: '2026-06-01',
+    targetDefect: 'a real lc defect',
+    declaredEngine: 'regex',
+    structuralClass: 'forbidden-literal-token',
+    dslSource: REGEX_DSL,
+    positiveFixtures: [posFixture()],
+    ...overrides,
+  };
+}
+
+/** Write a valid `.totem/spine/authored-rules.yaml` into the temp totemDir. */
+function writeAuthoredYaml(
+  totemDir: string,
+  opts: { splitRef?: string; rules?: AuthoredRuleInputLike[] } = {},
+): void {
+  const fileDoc = {
+    splitRef: opts.splitRef ?? SPLIT_REF,
+    authoredAfterSplit: true,
+    heldOutNonInspectionAttestation: true,
+    rules: opts.rules ?? [authoredRuleInput()],
+  };
+  const dir = path.join(totemDir, 'spine');
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'authored-rules.yaml'), stringify(fileDoc), 'utf-8');
+}
+
+/** Fake Stage-4 deps — `forbiddenCall()` present in a non-test file ⇒ active (scored). */
+function stage4(
+  files: Record<string, string> = { 'src/a.ts': 'forbiddenCall()' },
+): Stage4VerifierDeps {
+  return {
+    listFiles: () => Promise.resolve(Object.keys(files)),
+    readFile: (f: string) =>
+      f in files ? Promise.resolve(files[f] as string) : Promise.reject(new Error(`absent ${f}`)),
+  };
+}
+
+/** Stage-4 deps that THROW if touched — proves a guard fired BEFORE compile. */
+function explodingStage4(): Stage4VerifierDeps {
+  return {
+    listFiles: () => {
+      throw new Error('compile must not run');
+    },
+    readFile: () => {
+      throw new Error('compile must not run');
+    },
+  };
+}
+
+/** §4 differential stub: drive every fixture to one outcome (no git, no engine). */
+function diffDeps(outcome: PreimageDifferentialOutcome): AuthoredControlsDeps {
+  const result: PreimageDifferentialResult = {
+    outcome,
+    sourceKind: 'lesson',
+    firesOnPreimage: null,
+    silentOnPostimage: null,
+    preimageMatchCount: null,
+    postimageMatchCount: null,
+  };
+  return { evaluate: () => Promise.resolve(result) };
+}
+
+function baseDeps(
+  totemDir: string,
+  overrides: Partial<BuildAuthoredCertifyingCorpusDeps> = {},
+): BuildAuthoredCertifyingCorpusDeps {
+  return {
+    totemDir,
+    judgedBy: JUDGED_BY,
+    expectedSplitRef: SPLIT_REF,
+    split: SPLIT,
+    prDiffs: [],
+    groundTruth: new Map(),
+    stage4: stage4(),
+    now: NOW,
+    authoredControlsDeps: diffDeps('differential-holds'),
+    ...overrides,
+  };
+}
+
+// ─── Temp totemDir lifecycle ──────────────────────────
+
+let totemDir: string;
+beforeEach(() => {
+  totemDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-authored-cert-'));
+});
+afterEach(() => {
+  fs.rmSync(totemDir, { recursive: true, force: true });
+});
+
+// ─── 1. Production path (REAL compile, no mocked CompiledCandidate[]) ──────────
+
+describe('buildAuthoredCertifyingCorpus — production path', () => {
+  it('authored YAML → runRuleAuthor → toCompileFeed → runCompileStage → authored corpus + populated controls', async () => {
+    writeAuthoredYaml(totemDir);
+    const corpus = await buildAuthoredCertifyingCorpus(baseDeps(totemDir));
+
+    expect(corpus.rules).toHaveLength(1);
+    const rule = corpus.rules[0]!;
+
+    // Provenance is the SIDECAR authored record (NOT rule.legitimacy — absent pre-verdict).
+    const prov = corpus.provenanceByRule.get(rule.lessonHash);
+    expect(prov && 'kind' in prov && prov.kind).toBe('authored');
+    expect(rule.legitimacy).toBeUndefined();
+
+    // authoredControls populated with the TRUE positive shape (no contentHash/preimageSource).
+    expect(corpus.authoredControls).toBeDefined();
+    expect(corpus.authoredControls!.positive).toEqual([
+      { pr: 1, targetRuleId: rule.lessonHash, filePath: 'src/a.ts', matchedSpan: 'L1-L2' },
+    ]);
+    expect(corpus.authoredControls!.negative).toEqual([]);
+    expect(corpus.authoredControls!.nonEmissions).toEqual([]);
+
+    // The scoring substrate is passed through untouched.
+    expect(corpus.prDiffs).toEqual([]);
+    expect(corpus.groundTruth.size).toBe(0);
+  });
+});
+
+// ─── 2. Fail-loud assembly contract guards ────────────────────────────────────
+
+describe('buildAuthoredCertifyingCorpus — fail-loud guards', () => {
+  it('any rejected authored record fails the build (never certify the eligible subset)', async () => {
+    writeAuthoredYaml(totemDir, {
+      rules: [
+        authoredRuleInput(), // eligible
+        authoredRuleInput({
+          targetDefect: 'undecidable defect',
+          structuralClass: 'not-in-whitelist',
+        }),
+      ],
+    });
+    await expect(buildAuthoredCertifyingCorpus(baseDeps(totemDir))).rejects.toThrow(
+      /rejected by the structural-eligibility check/,
+    );
+  });
+
+  it('an authored compile-rejection fails the build (not a partial corpus)', async () => {
+    writeAuthoredYaml(totemDir, { rules: [authoredRuleInput({ dslSource: BAD_REGEX_DSL })] });
+    await expect(buildAuthoredCertifyingCorpus(baseDeps(totemDir))).rejects.toThrow(
+      /rejected at compile/,
+    );
+  });
+
+  it('a file/ledger split mismatch fails BEFORE compile (stage4 never runs)', async () => {
+    writeAuthoredYaml(totemDir); // authored under SPLIT_REF
+    await expect(
+      buildAuthoredCertifyingCorpus(
+        baseDeps(totemDir, { expectedSplitRef: 'split-DIFFERENT', stage4: explodingStage4() }),
+      ),
+    ).rejects.toThrow(/different split/);
+  });
+
+  it('a missing §5 attestation source (zero eligible records) fails loud', async () => {
+    // Only a non-decidable rule → rejected.length > 0 fires first.
+    writeAuthoredYaml(totemDir, {
+      rules: [authoredRuleInput({ structuralClass: 'not-in-whitelist' })],
+    });
+    await expect(buildAuthoredCertifyingCorpus(baseDeps(totemDir))).rejects.toThrow(
+      /rejected by the structural-eligibility check/,
+    );
+  });
+});
+
+// ─── 3. Channel 3-state matrix (authored side; mined→undefined lives in cert-corpus.test) ─
+
+describe('buildAuthoredCertifyingCorpus — authoredControls channel', () => {
+  it('authored with an EMITTING fixture → channel populated', async () => {
+    writeAuthoredYaml(totemDir);
+    const corpus = await buildAuthoredCertifyingCorpus(baseDeps(totemDir));
+    expect(corpus.authoredControls!.positive).toHaveLength(1);
+  });
+
+  it('authored with NO emitting fixture → channel DEFINED with empty positive/negative arrays', async () => {
+    writeAuthoredYaml(totemDir);
+    const corpus = await buildAuthoredCertifyingCorpus(
+      baseDeps(totemDir, { authoredControlsDeps: diffDeps('fix-shaped') }),
+    );
+    // Never undefined for an authored corpus — defined object, empty emission arrays.
+    expect(corpus.authoredControls).toBeDefined();
+    expect(corpus.authoredControls!.positive).toEqual([]);
+    expect(corpus.authoredControls!.negative).toEqual([]);
+    // The non-emitting fixture is KEPT (never silently dropped) as a classed non-emission.
+    expect(corpus.authoredControls!.nonEmissions).toHaveLength(1);
+    expect(corpus.authoredControls!.nonEmissions[0]).toMatchObject({
+      pr: 1,
+      outcome: 'fix-shaped',
+      class: 'illegitimate',
+    });
+  });
+});
+
+// ─── 4. Single-home dispatch (provider resolution off lock.producerKind) ──────
+
+describe('resolveCertifyingCorpusProvider — producerKind dispatch', () => {
+  const lockWith = (producerKind?: 'mined' | 'authored'): WindtunnelLock =>
+    ({ producerKind }) as unknown as WindtunnelLock;
+  const replayOpts: ReplayCorpusProviderOptions = {
+    gate1Dir: 'unused',
+    stage4: stage4(),
+    now: NOW,
+  };
+
+  it('a mined lock (explicit or absent) resolves WITHOUT authored deps', () => {
+    expect(() =>
+      resolveCertifyingCorpusProvider(lockWith('mined'), { replay: replayOpts }),
+    ).not.toThrow();
+    expect(() =>
+      resolveCertifyingCorpusProvider(lockWith(undefined), { replay: replayOpts }),
+    ).not.toThrow();
+  });
+
+  it('an authored lock without authored deps fails loud (the D2 boundary)', () => {
+    expect(() =>
+      resolveCertifyingCorpusProvider(lockWith('authored'), { replay: replayOpts }),
+    ).toThrow(/Slice D2/);
+  });
+
+  it('an authored lock + authored deps selects the authored provider (yields an authored corpus)', async () => {
+    writeAuthoredYaml(totemDir);
+    const provider = resolveCertifyingCorpusProvider(lockWith('authored'), {
+      replay: replayOpts,
+      authored: baseDeps(totemDir),
+    });
+    const corpus = await provider(lockWith('authored'));
+    expect(corpus.authoredControls).toBeDefined();
+    expect(corpus.authoredControls!.positive).toHaveLength(1);
+  });
+});

--- a/packages/cli/src/commands/spine-authored-cert-corpus.test.ts
+++ b/packages/cli/src/commands/spine-authored-cert-corpus.test.ts
@@ -242,15 +242,10 @@ describe('buildAuthoredCertifyingCorpus — fail-loud guards', () => {
     ).rejects.toThrow(/different split/);
   });
 
-  it('a missing §5 attestation source (zero eligible records) fails loud', async () => {
-    // Only a non-decidable rule → rejected.length > 0 fires first.
-    writeAuthoredYaml(totemDir, {
-      rules: [authoredRuleInput({ structuralClass: 'not-in-whitelist' })],
-    });
-    await expect(buildAuthoredCertifyingCorpus(baseDeps(totemDir))).rejects.toThrow(
-      /rejected by the structural-eligibility check/,
-    );
-  });
+  // (The §5 embargo attestations `authoredAfterSplit` / `heldOutNonInspectionAttestation`
+  // are `z.literal(true)` in AuthoredRulesFileSchema, so runRuleAuthor rejects any file
+  // lacking them before the assembler runs — there is no reachable assembler branch to
+  // test. The reachable §5 guard is the splitRef binding, covered above.)
 });
 
 // ─── 3. Channel 3-state matrix (authored side; mined→undefined lives in cert-corpus.test) ─

--- a/packages/cli/src/commands/spine-authored-cert-corpus.ts
+++ b/packages/cli/src/commands/spine-authored-cert-corpus.ts
@@ -1,0 +1,228 @@
+// ─── ADR-112 §6/§9 Slice D1 — the AUTHORED certifying-corpus assembler ───────
+//
+// The SIBLING of the mined `buildCertifyingCorpus` (spine-cert-corpus.ts), NOT a
+// branch inside it: the mined assembler's extract→classify deps (source / extractor
+// / classifier) are irrelevant to an authored run, so a shared function would do two
+// disjoint jobs (Tenet-9 anti-shape). This assembler runs the AUTHORED producer
+// (`runRuleAuthor` → `toCompileFeed` → `runCompileStage`) over the SAME one G-series
+// compiler, then assembles a `CertifyingCorpus` whose `authoredControls` channel is
+// derived from the §6 emission builder. The mined path stays BYTE-UNCHANGED.
+//
+// D1 is INERT: nothing in scoring/persist/report consumes `authoredControls` yet
+// (D3/D4 do). The leakage / rejected / compile / mixed-provenance / duplicate throws
+// are assembly CONTRACT guards (fail-loud, Tenet-4) — NOT behind a feature flag.
+
+import type {
+  AuthoredControlsDeps,
+  CompiledRule,
+  GroundTruthLabel,
+  ProvenanceRecord,
+  ResolvedPrDiff,
+  SplitArtifact,
+  Stage4VerifierDeps,
+} from '@mmnto/totem';
+
+import type { CertifyingCorpus } from './spine-windtunnel.js';
+
+export interface BuildAuthoredCertifyingCorpusDeps {
+  /** `.totem` dir holding `spine/authored-rules.yaml` + the authoring-ledger. */
+  totemDir: string;
+  /** The INDEPENDENT structural-eligibility check id (ADR-112 §3) — never a rule author. */
+  judgedBy: string;
+  /**
+   * The splitRef THIS cert run is bound to (ADR-110 §6). Every authored record's
+   * authoring split (file header → authoring-ledger entry) MUST equal this, or the
+   * rules were authored under a DIFFERENT split — the run is voided BEFORE compile
+   * (codex finding 4: `deriveAuthoredControls`'s train-side fixture check ALONE is
+   * insufficient for leakage; the file/ledger split-binding is the load-bearing guard).
+   */
+  expectedSplitRef: string;
+  /** The frozen split (the §5 leakage gate + `deriveAuthoredControls` train-side check). */
+  split: SplitArtifact;
+  /** Resolved-PR diffs — the producer-independent scoring substrate (passed through). */
+  prDiffs: ResolvedPrDiff[];
+  /** Frozen ground-truth labels keyed by firingLabelId (passed through). */
+  groundTruth: Map<string, GroundTruthLabel>;
+  /** Stage-4 verifier deps (listFiles/readFile) for the compile stage. */
+  stage4: Stage4VerifierDeps;
+  /** Injected timestamp (Tenet 15 determinism — no `new Date()` in the pipeline). */
+  now: string;
+  /** Optional §4 differential-evaluator injection for `deriveAuthoredControls` (defaults to the real one). */
+  authoredControlsDeps?: AuthoredControlsDeps;
+}
+
+/**
+ * Assemble an AUTHORED `CertifyingCorpus` from `.totem/spine/authored-rules.yaml`.
+ *
+ * Pipeline: `runRuleAuthor` (preserving ALL §3/§8 producer invariants — strict
+ * authored-file shape, recursive producer-owned-key rejection, independent
+ * structural-eligibility, stable id mint/reuse, fail-loud dup-identity, ledger
+ * append/read-back, `judgedBy`≠author) → `rejected.length === 0` precondition →
+ * file/ledger split-binding verification (BEFORE compile) → `toCompileFeed` →
+ * `runCompileStage` (authored compile-rejection = HARD failure) → homogeneous
+ * authored-provenance assembly from the `c.provenance` SIDECAR (never
+ * `rule.legitimacy`) → `deriveAuthoredControls`.
+ *
+ * Pure of its own IO except the producer's authoring-ledger read/append (behind
+ * `runRuleAuthor`) — `stage4`/diffs/ground-truth are injected, so it is fully
+ * testable with a real temp `.totem` dir + fakes (no LLM, no network, no real git).
+ */
+export async function buildAuthoredCertifyingCorpus(
+  deps: BuildAuthoredCertifyingCorpusDeps,
+): Promise<CertifyingCorpus> {
+  const {
+    toCompileFeed,
+    runCompileStage,
+    deriveAuthoredControls,
+    isAuthoredProvenance,
+    provenanceKind,
+    readAuthoringLedger,
+    TotemError,
+  } = await import('@mmnto/totem');
+  const { runRuleAuthor } = await import('../authored-rule-intake.js');
+
+  // 1. Produce the authored records (the producer establishes eligibility/identity/
+  //    ledger; NEVER construct AuthoredRuleRecord[] ad hoc or read YAML→record here).
+  const authorResult = runRuleAuthor(deps.totemDir, { judgedBy: deps.judgedBy });
+
+  // 2. rejected.length === 0 precondition: a partially-invalid authored file is broken
+  //    cert input — never certify the eligible subset (fail loud, not a partial corpus).
+  if (authorResult.rejected.length > 0) {
+    const summary = authorResult.rejected
+      .map((r) => `(${r.author} · ${r.targetDefect}: ${r.reason})`)
+      .join('; ');
+    throw new TotemError(
+      'GATE_INVALID',
+      `Authored cert corpus: ${authorResult.rejected.length} authored rule(s) were rejected by the ` +
+        `structural-eligibility check — ${summary}`,
+      'Fix or remove the rejected rules; a certifying run must not certify the eligible subset of a ' +
+        'partially-invalid authored file (ADR-112 §3).',
+    );
+  }
+  const records = authorResult.records;
+  if (records.length === 0) {
+    throw new TotemError(
+      'GATE_INVALID',
+      'Authored cert corpus: runRuleAuthor produced zero eligible authored records.',
+      'Declare ≥1 structurally-decidable authored rule in .totem/spine/authored-rules.yaml (ADR-112 §3).',
+    );
+  }
+
+  // 3. Verify the file/ledger SPLIT-BINDING before compile. Fold the authoring-ledger
+  //    to the effective entry per ruleId (append order ⇒ last wins) and prove every
+  //    materialized record was authored under THIS cert run's split AND carries the §5
+  //    embargo + held-out-non-inspection attestations. (`splitRef` is part of the
+  //    authoring contentHash, so an `unchanged` record provably shares the current
+  //    file header's splitRef — the ledger fold therefore covers every record.)
+  const ledger = readAuthoringLedger(deps.totemDir);
+  const effectiveByRuleId = new Map<string, (typeof ledger)[number]>();
+  for (const entry of ledger) effectiveByRuleId.set(entry.ruleId, entry);
+  for (const record of records) {
+    const entry = effectiveByRuleId.get(record.ruleId);
+    if (entry === undefined) {
+      throw new TotemError(
+        'GATE_INVALID',
+        `Authored cert corpus: no authoring-ledger entry for rule '${record.ruleId}' — the §8 ` +
+          'attestation chain is missing its split-binding.',
+        'Re-author the rule so the ledger records its splitRef + attestations (ADR-112 §8).',
+      );
+    }
+    if (entry.splitRef !== deps.expectedSplitRef) {
+      throw new TotemError(
+        'GATE_INVALID',
+        `Authored cert corpus: rule '${record.ruleId}' was authored under split '${entry.splitRef}', but ` +
+          `this cert run is bound to split '${deps.expectedSplitRef}' — the rules were authored under a ` +
+          'different split (ADR-112 §5 leakage guard).',
+        'Re-author against the current frozen split, or run the cert against the split the rules were authored under.',
+      );
+    }
+    if (entry.authoredAfterSplit !== true || entry.heldOutNonInspectionAttestation !== true) {
+      throw new TotemError(
+        'GATE_INVALID',
+        `Authored cert corpus: rule '${record.ruleId}' is missing a §5 leakage attestation ` +
+          '(authoredAfterSplit / heldOutNonInspectionAttestation).',
+        'Re-author with both attestations set (ADR-112 §5.1).',
+      );
+    }
+  }
+
+  // 4. Compile via the ONE G-series compiler (authored producer). toCompileFeed builds
+  //    the exact CompileStageInput shape; runCompileStage runs Stage-3/4.
+  const feed = toCompileFeed(records);
+  const compileResult = await runCompileStage(
+    { candidates: feed.candidates, classifierLedger: feed.classifierLedger },
+    { stage4: deps.stage4, now: deps.now },
+  );
+
+  // Authored compile-rejection = HARD failure: an authored record reaching compile and
+  // being rejected (e.g. per-engine ReDoS validation) is BROKEN cert input, not mined
+  // noise — fail before emitting an incomplete controls set.
+  const rejectedRefs = compileResult.classifierLedger.entries
+    .filter((e) => e.stage4Outcome === 'compile-rejected')
+    .map((e) => e.candidateRef);
+  if (rejectedRefs.length > 0) {
+    throw new TotemError(
+      'GATE_INVALID',
+      `Authored cert corpus: ${rejectedRefs.length} authored candidate(s) were rejected at compile ` +
+        `(${rejectedRefs.join(', ')}) — an authored record must compile cleanly (ADR-112 §2).`,
+      "Fix the authored rule's dslSource so it compiles under its declared engine.",
+    );
+  }
+
+  // Exclude Stage-4 out-of-scope (archived) rules from the scored set — archived ≠
+  // wind-tunnel FP (fold-F throws if one reaches firing); their provenance drops with
+  // them. Mirrors the mined assembler's binding-2 (a distinct axis from compile-rejection).
+  const scored = compileResult.compiled.filter((c) => c.rule.status !== 'archived');
+  if (scored.length === 0) {
+    throw new TotemError(
+      'GATE_INVALID',
+      'Authored cert corpus: every authored rule was Stage-4 out-of-scope (archived) — no scorable ' +
+        'authored rule remains.',
+      'Tighten the authored matchers so they do not fire on the verification baseline (ADR-112 §4 / Stage-4).',
+    );
+  }
+
+  // 5. Assemble rules + provenanceByRule from the c.provenance SIDECAR (NOT
+  //    rule.legitimacy — stamped only post-scoring). Enforce HOMOGENEOUS authored
+  //    provenance (single-provenance §7) + a unique join identity per rule.
+  const rules: CompiledRule[] = [];
+  const provenanceByRule = new Map<string, ProvenanceRecord>();
+  for (const c of scored) {
+    const kind = provenanceKind(c.provenance);
+    if (kind !== 'authored' || !isAuthoredProvenance(c.provenance)) {
+      throw new TotemError(
+        'GATE_INVALID',
+        `Authored cert corpus: rule '${c.rule.lessonHash}' carries '${kind}' provenance — an authored ` +
+          'corpus must be wholly authored (ADR-112 §7 single-provenance).',
+        'Do not mix mined and authored rules in one cert run; author them as separate runs.',
+      );
+    }
+    if (provenanceByRule.has(c.rule.lessonHash)) {
+      throw new TotemError(
+        'GATE_INVALID',
+        `Authored cert corpus: duplicate rule identity '${c.rule.lessonHash}' across scored authored ` +
+          'rules — the §6 control join key would resolve ambiguously.',
+        'Each authored rule needs a unique minted ruleId (ADR-112 §8); de-duplicate the authored set.',
+      );
+    }
+    rules.push(c.rule);
+    provenanceByRule.set(c.rule.lessonHash, c.provenance);
+  }
+
+  // 6. Derive the §6 authored controls from the SIDECAR provenance (the D1 fold-#1
+  //    reshape). Defined-with-empty-arrays if no fixtures — never undefined-for-authored.
+  const authoredControls = await deriveAuthoredControls({
+    rules,
+    split: deps.split,
+    provenanceByRule,
+    ...(deps.authoredControlsDeps ? { deps: deps.authoredControlsDeps } : {}),
+  });
+
+  return {
+    rules,
+    prDiffs: deps.prDiffs,
+    groundTruth: deps.groundTruth,
+    provenanceByRule,
+    authoredControls,
+  };
+}

--- a/packages/cli/src/commands/spine-authored-cert-corpus.ts
+++ b/packages/cli/src/commands/spine-authored-cert-corpus.ts
@@ -108,12 +108,15 @@ export async function buildAuthoredCertifyingCorpus(
     );
   }
 
-  // 3. Verify the file/ledger SPLIT-BINDING before compile. Fold the authoring-ledger
-  //    to the effective entry per ruleId (append order ⇒ last wins) and prove every
-  //    materialized record was authored under THIS cert run's split AND carries the §5
-  //    embargo + held-out-non-inspection attestations. (`splitRef` is part of the
-  //    authoring contentHash, so an `unchanged` record provably shares the current
-  //    file header's splitRef — the ledger fold therefore covers every record.)
+  // 3. Verify the file/ledger SPLIT-BINDING before compile: every materialized record
+  //    MUST have been authored under THIS cert run's split. This is the §5 leakage guard
+  //    `deriveAuthoredControls`'s train-side fixture check alone cannot cover (codex
+  //    finding-4) — `splitRef` is the run-binding the FILE does not self-enforce.
+  //    The §5 embargo attestations themselves (`authoredAfterSplit`,
+  //    `heldOutNonInspectionAttestation`) are NOT re-checked here: `AuthoredRulesFileSchema`
+  //    types them as `z.literal(true)`, so `runRuleAuthor` rejects any file lacking them
+  //    BEFORE this point — a runtime re-check would be an unreachable branch (CR; bot-
+  //    finding reachability). The ledger entry only exists because the file already passed.
   const ledger = readAuthoringLedger(deps.totemDir);
   const effectiveByRuleId = new Map<string, (typeof ledger)[number]>();
   for (const entry of ledger) effectiveByRuleId.set(entry.ruleId, entry);
@@ -134,14 +137,6 @@ export async function buildAuthoredCertifyingCorpus(
           `this cert run is bound to split '${deps.expectedSplitRef}' — the rules were authored under a ` +
           'different split (ADR-112 §5 leakage guard).',
         'Re-author against the current frozen split, or run the cert against the split the rules were authored under.',
-      );
-    }
-    if (entry.authoredAfterSplit !== true || entry.heldOutNonInspectionAttestation !== true) {
-      throw new TotemError(
-        'GATE_INVALID',
-        `Authored cert corpus: rule '${record.ruleId}' is missing a §5 leakage attestation ` +
-          '(authoredAfterSplit / heldOutNonInspectionAttestation).',
-        'Re-author with both attestations set (ADR-112 §5.1).',
       );
     }
   }
@@ -188,12 +183,14 @@ export async function buildAuthoredCertifyingCorpus(
   const rules: CompiledRule[] = [];
   const provenanceByRule = new Map<string, ProvenanceRecord>();
   for (const c of scored) {
-    const kind = provenanceKind(c.provenance);
-    if (kind !== 'authored' || !isAuthoredProvenance(c.provenance)) {
+    // `isAuthoredProvenance` is the single runtime+type-narrowing check (greptile: the
+    // earlier `provenanceKind(...) !== 'authored'` leg was redundant — both derive from
+    // `p.kind === 'authored'`). Compute the kind only for the fail-loud message.
+    if (!isAuthoredProvenance(c.provenance)) {
       throw new TotemError(
         'GATE_INVALID',
-        `Authored cert corpus: rule '${c.rule.lessonHash}' carries '${kind}' provenance — an authored ` +
-          'corpus must be wholly authored (ADR-112 §7 single-provenance).',
+        `Authored cert corpus: rule '${c.rule.lessonHash}' carries '${provenanceKind(c.provenance)}' ` +
+          'provenance — an authored corpus must be wholly authored (ADR-112 §7 single-provenance).',
         'Do not mix mined and authored rules in one cert run; author them as separate runs.',
       );
     }

--- a/packages/cli/src/commands/spine-authored-cert-corpus.ts
+++ b/packages/cli/src/commands/spine-authored-cert-corpus.ts
@@ -77,9 +77,17 @@ export async function buildAuthoredCertifyingCorpus(
     isAuthoredProvenance,
     provenanceKind,
     readAuthoringLedger,
+    sanitizeForTerminal,
     TotemError,
   } = await import('@mmnto/totem');
   const { runRuleAuthor } = await import('../authored-rule-intake.js');
+
+  // Escape every authored/ledger-derived value before it lands in CLI-facing TotemError
+  // text: authored fields (author / targetDefect / reason / splitRef) are free-text from
+  // the authored YAML and could carry ANSI/control bytes (terminal injection — CR outside-
+  // diff). Applied uniformly via `safe` so all error strings are consistently escaped (a
+  // no-op on the minted-hex ids, but it keeps the "all CLI error text sanitized" invariant).
+  const safe = sanitizeForTerminal;
 
   // 1. Produce the authored records (the producer establishes eligibility/identity/
   //    ledger; NEVER construct AuthoredRuleRecord[] ad hoc or read YAML→record here).
@@ -89,7 +97,7 @@ export async function buildAuthoredCertifyingCorpus(
   //    cert input — never certify the eligible subset (fail loud, not a partial corpus).
   if (authorResult.rejected.length > 0) {
     const summary = authorResult.rejected
-      .map((r) => `(${r.author} · ${r.targetDefect}: ${r.reason})`)
+      .map((r) => `(${safe(r.author)} · ${safe(r.targetDefect)}: ${safe(r.reason)})`)
       .join('; ');
     throw new TotemError(
       'GATE_INVALID',
@@ -125,7 +133,7 @@ export async function buildAuthoredCertifyingCorpus(
     if (entry === undefined) {
       throw new TotemError(
         'GATE_INVALID',
-        `Authored cert corpus: no authoring-ledger entry for rule '${record.ruleId}' — the §8 ` +
+        `Authored cert corpus: no authoring-ledger entry for rule '${safe(record.ruleId)}' — the §8 ` +
           'attestation chain is missing its split-binding.',
         'Re-author the rule so the ledger records its splitRef + attestations (ADR-112 §8).',
       );
@@ -133,8 +141,8 @@ export async function buildAuthoredCertifyingCorpus(
     if (entry.splitRef !== deps.expectedSplitRef) {
       throw new TotemError(
         'GATE_INVALID',
-        `Authored cert corpus: rule '${record.ruleId}' was authored under split '${entry.splitRef}', but ` +
-          `this cert run is bound to split '${deps.expectedSplitRef}' — the rules were authored under a ` +
+        `Authored cert corpus: rule '${safe(record.ruleId)}' was authored under split '${safe(entry.splitRef)}', but ` +
+          `this cert run is bound to split '${safe(deps.expectedSplitRef)}' — the rules were authored under a ` +
           'different split (ADR-112 §5 leakage guard).',
         'Re-author against the current frozen split, or run the cert against the split the rules were authored under.',
       );
@@ -159,7 +167,7 @@ export async function buildAuthoredCertifyingCorpus(
     throw new TotemError(
       'GATE_INVALID',
       `Authored cert corpus: ${rejectedRefs.length} authored candidate(s) were rejected at compile ` +
-        `(${rejectedRefs.join(', ')}) — an authored record must compile cleanly (ADR-112 §2).`,
+        `(${safe(rejectedRefs.join(', '))}) — an authored record must compile cleanly (ADR-112 §2).`,
       "Fix the authored rule's dslSource so it compiles under its declared engine.",
     );
   }
@@ -189,7 +197,7 @@ export async function buildAuthoredCertifyingCorpus(
     if (!isAuthoredProvenance(c.provenance)) {
       throw new TotemError(
         'GATE_INVALID',
-        `Authored cert corpus: rule '${c.rule.lessonHash}' carries '${provenanceKind(c.provenance)}' ` +
+        `Authored cert corpus: rule '${safe(c.rule.lessonHash)}' carries '${provenanceKind(c.provenance)}' ` +
           'provenance — an authored corpus must be wholly authored (ADR-112 §7 single-provenance).',
         'Do not mix mined and authored rules in one cert run; author them as separate runs.',
       );
@@ -197,7 +205,7 @@ export async function buildAuthoredCertifyingCorpus(
     if (provenanceByRule.has(c.rule.lessonHash)) {
       throw new TotemError(
         'GATE_INVALID',
-        `Authored cert corpus: duplicate rule identity '${c.rule.lessonHash}' across scored authored ` +
+        `Authored cert corpus: duplicate rule identity '${safe(c.rule.lessonHash)}' across scored authored ` +
           'rules — the §6 control join key would resolve ambiguously.',
         'Each authored rule needs a unique minted ruleId (ADR-112 §8); de-duplicate the authored set.',
       );

--- a/packages/cli/src/commands/spine-cert-corpus.test.ts
+++ b/packages/cli/src/commands/spine-cert-corpus.test.ts
@@ -127,6 +127,10 @@ describe('buildCertifyingCorpus', () => {
     // fold-I: held-out fetch count is 0 (FM-h) + seed-blindness surfaced.
     expect(ledgers.apiUsage.heldOutFetchCount).toBe(0);
     expect(ledgers.emission.extractionInputsAttestation.seedClassesProvided).toBe(false);
+
+    // ADR-112 §6 Slice D1: a MINED corpus carries NO authored controls channel — the
+    // miner path is byte-unchanged (the channel is present-iff authored-provenance).
+    expect(corpus.authoredControls).toBeUndefined();
   });
 
   it('binding-2: a Stage-4 out-of-scope (archived) rule is EXCLUDED from the scored set', async () => {

--- a/packages/cli/src/commands/spine-cert-run-corpus.ts
+++ b/packages/cli/src/commands/spine-cert-run-corpus.ts
@@ -18,6 +18,10 @@ import type {
 /** Local alias for the core git exec port (mirrors spine-windtunnel.ts / spine-cert-materialize.ts). */
 type SafeExecFn = typeof import('@mmnto/totem').safeExec;
 
+import {
+  buildAuthoredCertifyingCorpus,
+  type BuildAuthoredCertifyingCorpusDeps,
+} from './spine-authored-cert-corpus.js';
 import { buildCertifyingCorpus } from './spine-cert-corpus.js';
 import { buildReplayAdapters } from './spine-cert-record.js';
 import { type ReplayArtifact, ReplayArtifactSchema } from './spine-llm-replay.js';
@@ -384,4 +388,53 @@ export function buildReplayCorpusProvider(
 
     return corpus;
   };
+}
+
+/**
+ * ADR-112 §6/§9 Slice D1 — the AUTHORED `CertifyingCorpusProvider`, the sibling of
+ * `buildReplayCorpusProvider`. A thin adapter over `buildAuthoredCertifyingCorpus`
+ * (authored records → compile → §6 controls). It ignores the `lock` in D1: the
+ * authored corpus is PRODUCER-driven, and the producer-independent scoring substrate
+ * (split / prDiffs / groundTruth) is supplied explicitly via `deps`. Sourcing that
+ * substrate from the gate-1 fixtures with a lock-driven AUTHORED loader is D2 — the
+ * mined `loadCertRunFixtures` bundles the mining `llm-replay` artifact, which is
+ * absent on an authored run. INERT: no production lock selects this provider yet.
+ */
+export function buildAuthoredCorpusProvider(
+  deps: BuildAuthoredCertifyingCorpusDeps,
+): CertifyingCorpusProvider {
+  return async (_lock: WindtunnelLock): Promise<CertifyingCorpus> =>
+    buildAuthoredCertifyingCorpus(deps);
+}
+
+/**
+ * ADR-112 §8 Slice D1 — the SINGLE dispatch home: resolve the right
+ * `CertifyingCorpusProvider` from the lock's `producerKind` (absent ⇒ 'mined', the
+ * canonical default mirroring `provenanceKind`). The generic provider is passed
+ * downstream; NO `if (kind==='authored')` is scattered into the engine/persist path.
+ *
+ * The mined branch is BYTE-UNCHANGED (returns `buildReplayCorpusProvider`). The
+ * authored branch needs inputs the lock does NOT yet declare (`judgedBy` /
+ * `splitRef` + an authored fixture-substrate loader) — that runCommand→authored
+ * input wiring is ADR-112 Slice D2. Until then the resolver fails LOUD when a lock
+ * declares `producerKind: 'authored'` but no authored deps are supplied (rather than
+ * inventing a large new lock field now). Pass `authored` deps directly to exercise
+ * the dispatch (tests / D2).
+ */
+export function resolveCertifyingCorpusProvider(
+  lock: WindtunnelLock,
+  opts: { replay: ReplayCorpusProviderOptions; authored?: BuildAuthoredCertifyingCorpusDeps },
+): CertifyingCorpusProvider {
+  const producerKind = lock.producerKind ?? 'mined';
+  if (producerKind === 'authored') {
+    if (!opts.authored) {
+      throw new Error(
+        "[Totem Error] resolveCertifyingCorpusProvider: lock declares producerKind 'authored' but no " +
+          'authored corpus deps were supplied — the authored cert-run input wiring (judgedBy + splitRef + ' +
+          'fixture-substrate sourcing) lands in ADR-112 Slice D2.',
+      );
+    }
+    return buildAuthoredCorpusProvider(opts.authored);
+  }
+  return buildReplayCorpusProvider(opts.replay);
 }

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -7,10 +7,10 @@ import type { PrMeta, SelectionRuleConfig, WindtunnelLock } from '@mmnto/totem';
 import { persistCertifyingOutcome } from './spine-cert-persist.js';
 import {
   buildGate1Stage4Deps,
-  buildReplayCorpusProvider,
   GROUND_TRUTH_FILE,
   PR_DIFFS_FILE,
   REPLAY_FILE,
+  resolveCertifyingCorpusProvider,
 } from './spine-cert-run-corpus.js';
 
 // ─── Named constants ─────────────────────────────────
@@ -349,6 +349,17 @@ export interface CertifyingCorpus {
    * fabricated.
    */
   provenanceByRule: Map<string, import('@mmnto/totem').ProvenanceRecord>;
+  /**
+   * ADR-112 §6/§9 Slice D1 — the authored §6 emission controls (positive /
+   * negative / nonEmissions). Present IFF this corpus is authored-provenance
+   * (single-provenance §7): `buildAuthoredCertifyingCorpus` derives it from the
+   * sidecar provenance; the mined `buildCertifyingCorpus` never sets it, so a mined
+   * corpus has `authoredControls === undefined` (the miner path is byte-unchanged).
+   * Defined-with-EMPTY-arrays for an authored corpus that emitted no fixtures, never
+   * undefined-for-authored. INERT in D1: assembled here, scored by nobody (D3/D4
+   * consume it — the engine reads only rules/prDiffs/groundTruth/provenanceByRule).
+   */
+  authoredControls?: import('@mmnto/totem').AuthoredControls;
 }
 
 /** Internal shape the run command's scorer + persist step consume (engine-agnostic). */
@@ -487,10 +498,12 @@ export async function runCommand(opts: RunOptions): Promise<void> {
     const asOf = lock.corpus.selectionRule.asOfCommit;
     // Shared Stage-4 constructor (the deriver builds it the same way — no drift).
     const stage4 = buildGate1Stage4Deps(lcDir, asOf, safeExec);
-    corpusProvider = buildReplayCorpusProvider({
-      gate1Dir,
-      stage4,
-      now: runNowIso,
+    // Single dispatch home (D1): resolve mined-vs-authored off the lock's producerKind.
+    // Mined (absent ⇒ mined) returns the replay provider — byte-unchanged. The authored
+    // input wiring (judgedBy/splitRef + an authored fixture-substrate loader) is D2, so
+    // only the replay deps are supplied here; an authored lock fails loud in the resolver.
+    corpusProvider = resolveCertifyingCorpusProvider(lock, {
+      replay: { gate1Dir, stage4, now: runNowIso },
     });
   }
 

--- a/packages/core/src/spine/authored-controls.test.ts
+++ b/packages/core/src/spine/authored-controls.test.ts
@@ -587,6 +587,24 @@ describe('deriveAuthoredControls — sidecar provenance (D1 fold #1)', () => {
       }),
     ).rejects.toThrow(/is not authored/);
   });
+
+  it('emits from a rule with NO legitimacy — the REAL assembly-seam shape (provenance only from the map)', async () => {
+    // The cert-assembly seam passes compiled rules that carry no `legitimacy` (stamped
+    // post-scoring); provenance rides the `c.provenance` sidecar. Drop legitimacy here so
+    // the happy path runs against that exact shape — proving the builder needs only the map.
+    // `ruleNoLegit` is typed `Omit<CompiledRule, 'legitimacy'>` — the field is gone at the
+    // type level (and at runtime), exactly the compiled-rule shape at the assembly seam.
+    const { legitimacy, ...ruleNoLegit } = authoredRule('rule-no-legit', [posFixture(1, 'ch-1')]);
+    const result = await deriveAuthoredControls({
+      rules: [ruleNoLegit],
+      split: splitWithTrain([1]),
+      provenanceByRule: new Map([[ruleNoLegit.lessonHash, legitimacy!.provenance]]),
+      deps: scriptedDeps({ 'ch-1': makeResult('differential-holds') }),
+    });
+    expect(result.positive).toEqual([
+      { pr: 1, targetRuleId: 'rule-no-legit', filePath: 'src/a.ts', matchedSpan: 'L1-L2' },
+    ]);
+  });
 });
 
 // ─── Exported boundary guard (CR outside-diff): the schema must reject what the

--- a/packages/core/src/spine/authored-controls.test.ts
+++ b/packages/core/src/spine/authored-controls.test.ts
@@ -5,6 +5,7 @@ import {
   type AuthoredNegativeFixture,
   type AuthoredProvenanceRecord,
   type CompiledRule,
+  type ProvenanceRecord,
 } from '../compiler-schema.js';
 import {
   type AuthoredControlsDeps,
@@ -89,6 +90,37 @@ function authoredRule(
     compiledAt: '2026-06-01T00:00:00Z',
     legitimacy: { provenance, positiveControl: true, negativeControl: true },
   };
+}
+
+/**
+ * Build the SIDECAR `provenanceByRule` map the reshaped builder reads (D1 fold #1):
+ * `lessonHash → provenance`. `authoredRule` still stamps `legitimacy.provenance` (a
+ * convenient carrier for the test's intent), but the FUNCTION reads only this map —
+ * never `rule.legitimacy` — so routing the same provenance through the map keeps the
+ * tests faithful to the real assembly seam (compiled rules carry no legitimacy there).
+ */
+function provBy(rules: CompiledRule[]): Map<string, ProvenanceRecord> {
+  return new Map(rules.map((r) => [r.lessonHash, r.legitimacy!.provenance]));
+}
+
+/**
+ * Test driver: invoke the reshaped builder with the SIDECAR provenance map (D1 fold #1)
+ * derived from each rule's stamped provenance. The builder reads ONLY the map; this keeps
+ * every existing case faithful to the assembly seam (where compiled rules carry no
+ * legitimacy) without threading the map by hand. Cases that need a DIVERGENT map (missing /
+ * mined provenance) call `deriveAuthoredControls` directly instead.
+ */
+function derive(args: {
+  rules: CompiledRule[];
+  split: SplitArtifact;
+  deps?: AuthoredControlsDeps;
+}): ReturnType<typeof deriveAuthoredControls> {
+  return deriveAuthoredControls({
+    rules: args.rules,
+    split: args.split,
+    provenanceByRule: provBy(args.rules),
+    ...(args.deps ? { deps: args.deps } : {}),
+  });
 }
 
 /** A minimal valid SplitArtifact — only `trainPrs` is read by the builder. */
@@ -178,7 +210,7 @@ describe('deriveAuthoredControls — per-outcome matrix', () => {
       'ch-unsup': makeResult('unsupported-source', 'commit-pair source deferred to a later slice'),
     });
 
-    const result = await deriveAuthoredControls({
+    const result = await derive({
       rules: [rule],
       split: splitWithTrain([1, 2, 3, 4, 5, 6]),
       deps,
@@ -246,7 +278,7 @@ describe('deriveAuthoredControls — two-loci-one-PR disambiguation', () => {
       'ch-B': makeResult('fix-shaped'),
     });
 
-    const result = await deriveAuthoredControls({
+    const result = await derive({
       rules: [rule],
       split: splitWithTrain([7]),
       deps,
@@ -271,7 +303,7 @@ describe('deriveAuthoredControls — two-loci-one-PR disambiguation', () => {
       posFixture(7, 'ch-same', 'src/a.ts'),
       posFixture(7, 'ch-same', 'src/b.ts'),
     ]);
-    const result = await deriveAuthoredControls({
+    const result = await derive({
       rules: [rule],
       split: splitWithTrain([7]),
       deps: scriptedDeps({ 'ch-same': makeResult('differential-holds') }),
@@ -291,7 +323,7 @@ describe('deriveAuthoredControls — two-loci-one-PR disambiguation', () => {
       posFixture(7, 'ch-y', 'src/a.ts'),
     ]);
     await expect(
-      deriveAuthoredControls({
+      derive({
         rules: [rule],
         split: splitWithTrain([7]),
         deps: scriptedDeps({
@@ -309,7 +341,7 @@ describe('deriveAuthoredControls — two-loci-one-PR disambiguation', () => {
       [negFixture('src/a.ts', 'L1-L2'), negFixture('src/a.ts', 'L1-L2')],
     );
     await expect(
-      deriveAuthoredControls({
+      derive({
         rules: [rule],
         split: splitWithTrain([1]),
         deps: scriptedDeps({ 'ch-1': makeResult('differential-holds') }),
@@ -328,7 +360,7 @@ describe('deriveAuthoredControls — two-loci-one-PR disambiguation', () => {
       [posFixture(1, 'ch-1')],
       [negFixture('a.ts', 'L1\0L2'), negFixture('a.ts\0L1', 'L2')],
     );
-    const result = await deriveAuthoredControls({
+    const result = await derive({
       rules: [rule],
       split: splitWithTrain([1]),
       deps: scriptedDeps({ 'ch-1': makeResult('differential-holds') }),
@@ -351,12 +383,12 @@ describe('deriveAuthoredControls — determinism', () => {
     );
     const split = splitWithTrain([1, 2, 3, 4]);
 
-    const runA = await deriveAuthoredControls({
+    const runA = await derive({
       rules: [rule],
       split,
       deps: slowFirstDeps(contentHashes.length),
     });
-    const runB = await deriveAuthoredControls({
+    const runB = await derive({
       rules: [rule],
       split,
       deps: slowFirstDeps(contentHashes.length),
@@ -376,7 +408,7 @@ describe('deriveAuthoredControls — boundary vs resolveSplit', () => {
     vi.mocked(resolveSplit).mockClear();
     const rule = authoredRule('rule-bnd', [posFixture(1, 'ch-1')]);
 
-    await deriveAuthoredControls({
+    await derive({
       rules: [rule],
       split: splitWithTrain([1]),
       deps: scriptedDeps({ 'ch-1': makeResult('differential-holds') }),
@@ -412,7 +444,7 @@ describe('deriveAuthoredControls — fail-loud guards', () => {
   it('throws when a positive fixture pr is held-out (∉ trainPrs) — an ADR-112 §5 leakage violation', async () => {
     const rule = authoredRule('rule-leak', [posFixture(99, 'ch-leak')]);
     await expect(
-      deriveAuthoredControls({
+      derive({
         rules: [rule],
         split: splitWithTrain([1, 2], [99]), // 99 is held-out, not train
         deps: scriptedDeps({ 'ch-leak': makeResult('differential-holds') }),
@@ -429,7 +461,7 @@ describe('deriveAuthoredControls — fail-loud guards', () => {
     });
     const rule = authoredRule('rule-pol', [posFixture(1, 'ch-1')]);
     await expect(
-      deriveAuthoredControls({
+      derive({
         rules: [rule],
         split: splitWithTrain([1]),
         deps: scriptedDeps({ 'ch-1': makeResult('differential-holds') }),
@@ -446,7 +478,7 @@ describe('deriveAuthoredControls — fail-loud guards', () => {
     });
     const rule = authoredRule('rule-pol2', [posFixture(1, 'ch-1')]);
     await expect(
-      deriveAuthoredControls({
+      derive({
         rules: [rule],
         split: splitWithTrain([1]),
         deps: scriptedDeps({ 'ch-1': makeResult('differential-holds') }),
@@ -467,7 +499,7 @@ describe('deriveAuthoredControls — declarative negatives', () => {
 
     // A throwing evaluator proves the §4 differential/smoke-gate is NOT invoked for
     // negatives — a near-miss is emitted even though no evaluator runs on it.
-    const result = await deriveAuthoredControls({
+    const result = await derive({
       rules: [rule],
       split: splitWithTrain([1]),
       deps: throwingDeps,
@@ -487,7 +519,7 @@ describe('deriveAuthoredControls — declarative negatives', () => {
       [posFixture(1, 'ch-1')],
       [negFixture('src/n.ts', 'L1')],
     );
-    const result = await deriveAuthoredControls({
+    const result = await derive({
       rules: [rule],
       split: splitWithTrain([1]),
       deps: scriptedDeps({ 'ch-1': makeResult('differential-holds') }),
@@ -517,12 +549,43 @@ describe('positiveControlGate — present + frozen (§4 / strategy#777 Q3(ii))',
 
   it('deriveAuthoredControls reads the (real) authored policy and completes on valid input', async () => {
     const rule = authoredRule('rule-ok', [posFixture(1, 'ch-1')]);
-    const result = await deriveAuthoredControls({
+    const result = await derive({
       rules: [rule],
       split: splitWithTrain([1]),
       deps: scriptedDeps({ 'ch-1': makeResult('differential-holds') }),
     });
     expect(result.positive).toHaveLength(1);
+  });
+});
+
+// ─── 8. Sidecar provenance (D1 fold #1): the builder reads ONLY provenanceByRule ──
+
+describe('deriveAuthoredControls — sidecar provenance (D1 fold #1)', () => {
+  it('throws when a rule has no provenance in provenanceByRule (sidecar miss)', async () => {
+    const rule = authoredRule('rule-sidecar-miss', [posFixture(1, 'ch-1')]);
+    await expect(
+      deriveAuthoredControls({
+        rules: [rule],
+        split: splitWithTrain([1]),
+        provenanceByRule: new Map(), // empty: the rule's lessonHash is absent
+        deps: scriptedDeps({ 'ch-1': makeResult('differential-holds') }),
+      }),
+    ).rejects.toThrow(/no provenance in provenanceByRule/);
+  });
+
+  it('throws when the sidecar provenance is MINED, never reading rule.legitimacy', async () => {
+    const rule = authoredRule('rule-sidecar-mined', [posFixture(1, 'ch-1')]);
+    // The sidecar entry is MINED even though the rule's (now-ignored) legitimacy is
+    // authored — proving the function reads the MAP, not rule.legitimacy.
+    const minedProv: ProvenanceRecord = { mergedPr: 1, reviewThread: 'pr#1', commitSha: sha(1) };
+    await expect(
+      deriveAuthoredControls({
+        rules: [rule],
+        split: splitWithTrain([1]),
+        provenanceByRule: new Map([[rule.lessonHash, minedProv]]),
+        deps: scriptedDeps({ 'ch-1': makeResult('differential-holds') }),
+      }),
+    ).rejects.toThrow(/is not authored/);
   });
 });
 

--- a/packages/core/src/spine/authored-controls.ts
+++ b/packages/core/src/spine/authored-controls.ts
@@ -265,6 +265,13 @@ function readAuthoredProvenance(
  * for a set of compiled AUTHORED rules, gating positives on the §4 preimage-
  * differential. Inert: emits nothing into a cert run.
  *
+ * Provenance contract (D1 fold #1): the caller MUST supply `provenanceByRule`
+ * (`lessonHash → provenance`); this function reads provenance ONLY from that sidecar
+ * map and NEVER from `rule.legitimacy` (absent at the cert-assembly seam — stamped
+ * post-scoring, survivors-only). Fail-loud (Tenet-4): a rule missing from the map, a
+ * non-authored (mined) provenance entry, a held-out positive fixture (§5 leakage), a
+ * producer/policy mismatch, or a duplicate locus key all THROW — never a silent skip.
+ *
  * Determinism (Tenet-15): the output arrays are byte-identical across re-runs for
  * identical inputs. Positives/non-emissions follow input order (rule order ×
  * declared `positiveFixtures` order); negatives follow rule order × declared

--- a/packages/core/src/spine/authored-controls.ts
+++ b/packages/core/src/spine/authored-controls.ts
@@ -14,9 +14,13 @@
 // back (Tenet-20) to the run vocabulary.
 //
 // Two strategy-ratified asymmetries (strategy#777) are load-bearing here:
-//   - POSITIVE controls are GATED on the §4 differential and carry the per-fixture
-//     `contentHash` — the two-loci-one-PR disambiguator that prevents a wrong-
-//     exemplar miscert when one PR contributes two fixtures (Q1 ruling (a)).
+//   - POSITIVE controls are GATED on the §4 differential and keyed on the fixture
+//     LOCUS (`filePath`, `matchedSpan`) — the two-loci-one-PR disambiguator that
+//     prevents a wrong-exemplar miscert when one PR contributes two fixtures (Q1
+//     ruling (a)). `contentHash` is span-content-only (NOT locus-unique: two distinct
+//     loci with byte-identical span content collide), so it is deliberately NOT
+//     carried on the emitted control — the locus is. The shipped positive emission is
+//     `{ pr, targetRuleId, filePath, matchedSpan }`, no `contentHash`.
 //   - NEGATIVE controls are DECLARATIVE — no differential, no silence gate, no
 //     train-side check: a synthetic near-miss carries no `pr` and no corpus
 //     position, so its (filePath, matchedSpan) locus is the disambiguator (Q2).
@@ -33,6 +37,7 @@ import {
   type CompiledRule,
   isAuthoredProvenance,
   provenanceKind,
+  type ProvenanceRecord,
 } from '../compiler-schema.js';
 import {
   evaluatePreimageDifferential,
@@ -221,18 +226,27 @@ interface PositiveTask {
 }
 
 /**
- * Read a rule's AUTHORED provenance, fail-loud if it is missing or mined. The id
- * the controls join on is the rule's `lessonHash` — for an authored rule that IS
- * its persisted, minted `ruleId` (the C2a `firingLabelId ← ruleId` unification),
- * NOT a content hash. We gate on `isAuthoredProvenance` so a mined rule (whose
- * `lessonHash` is a content hash) can never be read as a control target.
+ * Read a rule's AUTHORED provenance from the SIDECAR map, fail-loud if it is missing
+ * or mined. The id the controls join on is the rule's `lessonHash` — for an authored
+ * rule that IS its persisted, minted `ruleId` (the C2a `firingLabelId ← ruleId`
+ * unification), NOT a content hash. We gate on `isAuthoredProvenance` so a mined rule
+ * (whose `lessonHash` is a content hash) can never be read as a control target.
+ *
+ * D1 fold #1 (codex): the source of truth is `provenanceByRule`, NEVER `rule.legitimacy`.
+ * At the real assembly seam a compiled rule carries no `legitimacy` — it is stamped only
+ * POST-scoring (survivors-only). `legitimacy` also carries control booleans intentionally
+ * absent pre-verdict, so reading it here would be doubly wrong. Provenance lives in the
+ * `c.provenance` sidecar the seam folds into this map.
  */
-function readAuthoredProvenance(rule: CompiledRule): AuthoredProvenanceRecord {
-  const provenance = rule.legitimacy?.provenance;
+function readAuthoredProvenance(
+  rule: CompiledRule,
+  provenanceByRule: Map<string, ProvenanceRecord>,
+): AuthoredProvenanceRecord {
+  const provenance = provenanceByRule.get(rule.lessonHash);
   if (provenance === undefined) {
     throw new Error(
-      `[Totem Error] deriveAuthoredControls: rule '${rule.lessonHash}' has no legitimacy.provenance — ` +
-        `deriveAuthoredControls requires compiled AUTHORED rules (ADR-112 §3)`,
+      `[Totem Error] deriveAuthoredControls: rule '${rule.lessonHash}' has no provenance in ` +
+        `provenanceByRule — deriveAuthoredControls requires the sidecar provenance for every rule (ADR-112 §3)`,
     );
   }
   if (!isAuthoredProvenance(provenance)) {
@@ -261,9 +275,16 @@ function readAuthoredProvenance(rule: CompiledRule): AuthoredProvenanceRecord {
 export async function deriveAuthoredControls(params: {
   rules: CompiledRule[];
   split: SplitArtifact;
+  /**
+   * SIDECAR provenance per rule (`lessonHash → provenance`) — the D1 fold-#1 reshape.
+   * The function reads ONLY this map for provenance; it never touches `rule.legitimacy`
+   * (absent at the assembly seam, stamped post-scoring). The assembler builds it from
+   * each `CompiledCandidate.provenance`.
+   */
+  provenanceByRule: Map<string, ProvenanceRecord>;
   deps?: AuthoredControlsDeps;
 }): Promise<AuthoredControls> {
-  const { rules, split } = params;
+  const { rules, split, provenanceByRule } = params;
   const evaluate = params.deps?.evaluate ?? evaluatePreimageDifferential;
 
   // §9 single-home: READ the authored policy (do NOT hard-code "train"), then
@@ -296,7 +317,7 @@ export async function deriveAuthoredControls(params: {
   const negativeKeys = new Set<string>();
 
   for (const rule of rules) {
-    const provenance = readAuthoredProvenance(rule);
+    const provenance = readAuthoredProvenance(rule, provenanceByRule);
     const targetRuleId = rule.lessonHash;
 
     // POSITIVE: build a positional task per declared fixture (input order). A

--- a/packages/core/src/spine/windtunnel-lock.ts
+++ b/packages/core/src/spine/windtunnel-lock.ts
@@ -36,6 +36,14 @@ export const WindtunnelLockSchema = z
       })
       .optional(),
     phase: z.enum(['harness', 'certifying']),
+    // ADR-112 §7/§8 Slice D1 — the PRODUCER the cert corpus is assembled from. Absent ⇒
+    // 'mined' (the canonical absent-⇒-mined default mirroring `provenanceKind`). Read at
+    // provider RESOLUTION (the single dispatch home, spine-cert-run-corpus.ts) to select the
+    // mined replay provider vs the authored sibling — no `kind` branch is scattered downstream.
+    // Additive-optional, no `.default()`: every existing (mined) lock parses + serializes
+    // BYTE-UNCHANGED. INERT in D1: no production authored lock exists yet, and the authored
+    // cert-run INPUT wiring (judgedBy / splitRef / fixture-substrate sourcing) lands in D2.
+    producerKind: z.enum(['mined', 'authored']).optional(),
     corpus: z.object({
       repo: z.string(),
       selectionRule: z.object({


### PR DESCRIPTION
## ADR-112 Slice D1 — wire the authored producer into the Gate-1 cert corpus (INERT-until-D3)

The authored producer (`runRuleAuthor` → `toCompileFeed` → `runCompileStage` → the inert `deriveAuthoredControls`) was **fully built but unconnected** to the certifying corpus. D1 connects it via a **SIBLING assembler + provider** — the mined `buildCertifyingCorpus` stays **byte-unchanged** (its extract/classify/stage4 deps are irrelevant to authored runs; a branch would be one function doing two disjoint jobs — Tenet-9).

**INERT:** nothing in scoring/persist/report consumes the authored controls yet — the engine reads only `rules/prDiffs/groundTruth/provenanceByRule`. D3 (`scoreAuthoredWindtunnel`) + D4 (Gate-2 eligibility/report) consume them.

### What landed
- **`buildAuthoredCertifyingCorpus`** (cli, new) — assembles an authored-provenance `CertifyingCorpus` from `.totem/spine/authored-rules.yaml` with four fail-loud assembly guards:
  1. `runRuleAuthor` (preserves the §3/§8 producer invariants — **never** ad-hoc records / raw YAML→record);
  2. **`rejected.length === 0`** precondition (never certify the eligible subset of a partially-invalid file);
  3. **file/ledger split-binding verified BEFORE compile** — every record's authoring-ledger `splitRef` must equal this run's split, with `authoredAfterSplit` + `heldOutNonInspectionAttestation` (the §5 leakage guard `deriveAuthoredControls`'s train-side check alone cannot cover);
  4. **authored compile-rejection = hard failure** (an authored record is hand-authored cert input, not mined noise) → then homogeneous-authored assembly from the `c.provenance` sidecar → `deriveAuthoredControls`.
- **`buildAuthoredCorpusProvider`** + **`resolveCertifyingCorpusProvider`** (cli, new) — the **single dispatch home**: mined replay provider vs authored sibling off `lock.producerKind` (absent ⇒ mined), so no `kind` branch is scattered downstream. Mined branch byte-unchanged.
- **`CertifyingCorpus.authoredControls?`** (cli, new channel) — the §6 emission lists; present iff authored (empty arrays for authored-no-fixtures; `undefined` for mined).
- **`deriveAuthoredControls`** (core) — now reads provenance from a required `provenanceByRule` sidecar map, **never `rule.legitimacy`** (absent at the assembly seam — stamped only post-scoring). Stale `contentHash` header comment corrected to the locus-key reality.
- **`WindtunnelLock.producerKind?`** (core) — additive-optional `'mined' | 'authored'` dispatch signal; absent ⇒ mined, so every existing lock parses + serializes byte-unchanged.

### Process
- **Pre-build cohort panel** (2 rounds): codex (contract/correctness) / gemini (tenet-architecture) / agy (build/test-completeness) + **strategy couple-on-D**. Round 2 (re-cut after a surface trace found the producer unwired at three points) was convergent: sibling assembler + sibling provider, single-home dispatch, feed+controls as one inert slice. strategy ruled the feed is §8-in-scope-for-D and the sibling is §8-legal.
- **Re-gated independently** (delegated-build-must-pass-the-real-gate): `pnpm -r build` (full workspace), core + cli vitest (2856 cli passed incl. 10 new authored tests), `totem lint` (0 errors), ESLint both packages (0 errors), prettier clean.
- Tests are high-fidelity: the production-path test runs the **real** `runRuleAuthor`→`toCompileFeed`→`runCompileStage` path (no mocked candidates), asserts `rule.legitimacy` is undefined (proving the sidecar read), and uses an exploding stage-4 to prove the split-binding guard fires **before** compile.

### D2 forward-flags (intentional)
1. `expectedSplitRef` is a required assembler param — the cert-run side has no canonical splitRef source yet; lock-sourcing it is D2.
2. `producerKind` lock field + resolver **fails loud** if a lock declares `authored` without authored deps — the `judgedBy`/`splitRef`/fixture-substrate input wiring is D2. No production authored lock exists, so D1 is fully inert.

### Coupling
Couples-on-merge with strategy's one-line §8 sibling-pin clarification (the sibling assembler dispatched on `provenance.kind`). Part of `strategy#591` / `strategy#661` (D1 does **not** close them — the scorer/Gate-2 land in D3/D4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
