### PR TITLE
feat(spine): ADR-112 §8 Slice D2.5 — read-only no-mint precondition (authored cert producer)

### DIFF
--- a/.changeset/adr112-d25-no-mint-readonly.md
+++ b/.changeset/adr112-d25-no-mint-readonly.md
@@ -1,0 +1,14 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+---
+
+ADR-112 §8 Slice D2.5 — read-only / no-mint precondition on the authored cert-corpus producer (strategy ruling 2026-06-30, Q1–Q4).
+
+`buildAuthoredCertifyingCorpus` re-derives the authored records via `runRuleAuthor` (the writer) during cert-corpus assembly. D2's step-0 gate checks only that the authoring-ledger is NON-EMPTY — not that no rule is minted/revised — so a cert run over a stale `authored-rules.yaml` (a new or edited rule) would mint/revise it and certify its own mint (the CodeRabbit Major on #2274, deferred from D2). A cert run is NOT the first author.
+
+- **`runRuleAuthor` gains a `verifyOnly` mode** (`@mmnto/cli`): a cert-run re-derive runs Pass 1 (pure eligibility/identity/contentHash) and fails loud (`GATE_INVALID`, naming the rule(s) + `minted`/`revised`) BEFORE Pass 2's first ledger append if any current rule would be `minted` or `revised` — only `unchanged` passes (revise is forbidden identically to mint). Zero ledger writes on the throw (Tenet-4 no-drift). It is the read-side sibling of D2's §8 source-flip: the cert-run re-read writes nothing and asserts all-unchanged (Tenet-13 sensor-not-actuator).
+- **`buildAuthoredCertifyingCorpus` always calls `verifyOnly: true`** (`@mmnto/cli`) — the cert path is read-only against the authoring-ledger; the authoring path (`totem rule author`) is unchanged and still mints/revises (cert-path-only scope).
+- Composes with — does not replace — the producer's step-0 empty-ledger and step-3 judgedBy/split gates (layered: empty → no-mint stale → verdict/binding divergence).
+
+Couples strategy's ADR-112 §8 no-mint-precondition amendment (couple-on-merge, the #789⊕#2274 pattern). Still INERT until D3 (scoring ignores `authoredControls`); no production authored lock exists. The §6 window-wide answer-key deriver is a separate follow-on slice (D2.6). closingRefs [].

--- a/.totem/specs/adr-112-d2-5-authored-cert-runnable.md
+++ b/.totem/specs/adr-112-d2-5-authored-cert-runnable.md
@@ -1,0 +1,57 @@
+### Problem Statement
+The certification corpus assembly for authored rules (`buildAuthoredCertifyingCorpus`) must be strictly read-only against the authoring-ledger; it must fail loud and synchronously, before certification, if any current rule would be minted or revised during assembly (a cert run is NOT the first author). Additionally, under `producerKind:'authored'` the ground-truth label derivation must span the whole window (train + held-out non-control), per ADR-112 §6, so a train-slice false positive cannot escape the precision measure.
+
+### Files (source-verified this session)
+1. `packages/cli/src/commands/spine-authored-cert-corpus.ts` — `buildAuthoredCertifyingCorpus`; step 1 calls `runRuleAuthor` (the writer). This is where the no-mint gate binds.
+2. `packages/cli/src/authored-rule-intake.ts` — `runRuleAuthor`: Pass 1 (PURE: eligibility/identity/contentHash → per-rule `action ∈ {minted,revised,unchanged}`), Pass 2 (IO: `appendAuthoringLedgerEntry` for `action !== 'unchanged'`). Already returns `{records, minted, revised, unchanged, rejected}`.
+3. `packages/cli/src/commands/spine-derive-labels.ts` — `deriveLabelsFromDispositions` → the TP|FP answer key.
+4. `packages/cli/src/commands/spine-fetch-dispositions.ts` — `corpusHeldOutPrs(split)` (held-out minus controls); the window-wide scope (§6) changes this under authored-primary.
+
+---
+
+## Implementation Design
+
+### Scope (2 sentences)
+**DECISION 2026-06-30 (operator): D2.5 ships P2 only; P1 splits to a follow-on D2.6.** P1 (window-wide answer-key derivation) proved materially larger than scoped — `assembleCertifyingCorpus` (the deriver's path) is mined-only (`llmReplaySha`-gated), so P1 requires a producerKind-aware deriver + skip-ground-truth authored assembly, a correctness-critical slice deserving its own design pass (the design doc's Q4 criterion: bundle only if the deriver change is small — it is not).
+
+**D2.5 (this slice) = P2 only:** a **read-only / no-mint** gate so `buildAuthoredCertifyingCorpus` is side-effect-free against the authoring-ledger — it consumes only already-recorded, **unchanged** rules and fails loud (before certification, zero writes) if any current rule would be `minted`/`revised`. It will NOT add a second compiler, NOT touch the authoring path (`totem rule author` stays the writer), NOT score `authoredControls` (D3), and NOT re-decide the §8 identity/`judgedBy` single-source (D2-shipped).
+
+**D2.6 (follow-on) = P1:** the §6 window-wide label scope — `fetch-dispositions` (window-wide non-control corpus PRs) + a producerKind-aware `derive-labels` (authored substrate, skip-ground-truth on first-derive) span the **whole window (train + held-out non-control)** under `producerKind:'authored'`. Contract-settled in §6/§5.3 (no new ruling owed); deferred only for size. The D2.5 NOTE at `spine-cert-run-corpus.ts:530` already marks the plug-in point.
+
+### Data model deltas
+- **`RuleAuthorOptions.verifyOnly?: boolean`** (new optional field on `runRuleAuthor`'s opts; default `false`).
+  - *Holds:* whether this call is a cert-run re-derive (read-only) vs. an authoring write.
+  - *Writes:* the caller — `buildAuthoredCertifyingCorpus` passes `true`; `totem rule author` omits it (`false`).
+  - *Reads:* `runRuleAuthor` Pass 2 — when `true`, **skips the `appendAuthoringLedgerEntry` IO entirely** and instead throws if any `pending[].action !== 'unchanged'`.
+  - *Invariant:* `verifyOnly:true` ⇒ **zero** ledger writes on every path (success or throw); guaranteed by gating Pass 2's append behind it and throwing *before* the loop. Optional field, but the **cert producer must always set it** (the production-runnability precondition).
+- **No new error class** — reuse `TotemError('GATE_INVALID', …)` matching the existing step-0/step-3 cert gates (the auto-spec's `TotemRuleMutationError` is rejected; the codebase uses `TotemError` codes, not branded subclasses).
+- **No `windowLabels` field** — P1 changes the **derivation scope** (which PRs `corpusHeldOutPrs`/the firing enumeration cover), not a new field.
+- **Possible P1 delta (open question):** a window-wide variant of `corpusHeldOutPrs(split)` — e.g. `corpusWindowPrs(split)` returning `(trainPrs ∪ heldOutPrs) − controls` — selected when `producerKind:'authored'`.
+
+### State lifecycle
+- `verifyOnly` is a **per-call** parameter (no container, no persistence). Created at each `runRuleAuthor` invocation, never mutated, never crosses a boundary. Ownership: the caller decides; `runRuleAuthor` only reads it. This deliberately avoids the "one-shot flag consumed before its work succeeded" hazard — there is no stored flag, and the throw precedes any IO.
+- The authoring-ledger itself is **persistent** (`.totem/spine/authoring-ledger`), append-only, owned by `appendAuthoringLedgerEntry`. P2's guarantee is that the **cert path never mutates it** (Tenet-13 sensor-not-actuator).
+
+### Failure modes
+| Failure | Category | Agent-facing surface | Recovery |
+| --- | --- | --- | --- |
+| Cert run, a current rule would be `minted` (no ledger entry for its identity) | runtime | hard error `GATE_INVALID`, names the rule(s) + `minted` | Run `totem rule author` to record the rule (with §3 judgedBy) **before** the cert run; a cert run is not the first author |
+| Cert run, a current rule would be `revised` (YAML diverged from recorded `contentHash`) | runtime | hard error `GATE_INVALID`, names the rule(s) + `revised` | Re-author to record the revision, or revert the YAML to the recorded form, then re-run cert |
+| (existing, retained) empty ledger | runtime | hard error `GATE_INVALID` (step 0) | unchanged |
+| (existing, retained) judgedBy divergence / split mismatch | runtime | hard error `GATE_INVALID` (steps 0/3) | unchanged |
+| P1: a train-slice corpus firing has no disposition to label | runtime | **must fail loud or be a deliberate `unlabeled` class** — NOT silent (else a train FP escapes precision, §5.3) | covered by the deriver's existing `unlabeledByReason` diagnostics; verify window-wide firings are dispositioned |
+
+No row is "silent degradation." The no-mint gate is **fail-loud-before-write**; the P1 label-scope explicitly closes the "train FP escapes" silent hole §6 names.
+
+### Invariants to lock in via tests
+- A cert-run re-derive (`verifyOnly:true`) over a ledger whose entries exactly match the current YAML returns the records and **appends zero rows** (read the ledger file byte-before == byte-after).
+- A cert run where the YAML adds a **new** rule (would mint) throws `GATE_INVALID` naming that rule, **and the ledger is unmutated** (no partial append).
+- A cert run where an existing rule's YAML changed (would revise) throws `GATE_INVALID` naming that rule, ledger unmutated.
+- The **authoring** path (`verifyOnly` unset/false) still mints/revises exactly as today (no regression to `totem rule author`).
+- P1: `deriveLabelsFromDispositions` produces a label for every **non-control** corpus firing across **both** slices under authored-primary (no train-slice firing silently unlabeled).
+
+### Open questions
+- **Q1 (contract, →strategy):** Is the no-mint gate a **`verifyOnly` mode on `runRuleAuthor`** (single source of the mint/revise decision — the sibling of D2's §8 source-flip, line 167), or a **separate producer pre-check**? *Recommendation:* mode-on-`runRuleAuthor` — DRY, one source of truth for the action decision; a separate pre-check duplicates the contentHash/identity logic and creates a second source (a Tenet-20 mirror smell).
+- **Q2 (contract, →strategy):** Is **`revised` forbidden identically to `minted`**? *Recommendation:* yes — a revised rule means the YAML diverged from the recorded entry since authoring, i.e. the author is editing during the cert run, which the "a cert run is NOT the first author" invariant forbids exactly as minting does.
+- **Q3 (contract, →strategy):** Frame the property as **side-effect-free against the authoring-ledger + assert-all-unchanged** (Tenet-13 + Tenet-4), composing with (not replacing) the existing step-0 empty-ledger and step-3 judgedBy/split gates — confirm no §8 separation conflict.
+- **Q4 (build, mine):** flag name (`verifyOnly` vs `mode:'cert'`), and whether P1's window-wide selection lands this slice or splits to its own PR — leaning `verifyOnly` + bundling P1 if the deriver scope change is small.

--- a/.totem/specs/adr-112-d2-5-authored-cert-runnable.md
+++ b/.totem/specs/adr-112-d2-5-authored-cert-runnable.md
@@ -1,7 +1,9 @@
 ### Problem Statement
+
 The certification corpus assembly for authored rules (`buildAuthoredCertifyingCorpus`) must be strictly read-only against the authoring-ledger; it must fail loud and synchronously, before certification, if any current rule would be minted or revised during assembly (a cert run is NOT the first author). Additionally, under `producerKind:'authored'` the ground-truth label derivation must span the whole window (train + held-out non-control), per ADR-112 §6, so a train-slice false positive cannot escape the precision measure.
 
 ### Files (source-verified this session)
+
 1. `packages/cli/src/commands/spine-authored-cert-corpus.ts` — `buildAuthoredCertifyingCorpus`; step 1 calls `runRuleAuthor` (the writer). This is where the no-mint gate binds.
 2. `packages/cli/src/authored-rule-intake.ts` — `runRuleAuthor`: Pass 1 (PURE: eligibility/identity/contentHash → per-rule `action ∈ {minted,revised,unchanged}`), Pass 2 (IO: `appendAuthoringLedgerEntry` for `action !== 'unchanged'`). Already returns `{records, minted, revised, unchanged, rejected}`.
 3. `packages/cli/src/commands/spine-derive-labels.ts` — `deriveLabelsFromDispositions` → the TP|FP answer key.
@@ -12,6 +14,7 @@ The certification corpus assembly for authored rules (`buildAuthoredCertifyingCo
 ## Implementation Design
 
 ### Scope (2 sentences)
+
 **DECISION 2026-06-30 (operator): D2.5 ships P2 only; P1 splits to a follow-on D2.6.** P1 (window-wide answer-key derivation) proved materially larger than scoped — `assembleCertifyingCorpus` (the deriver's path) is mined-only (`llmReplaySha`-gated), so P1 requires a producerKind-aware deriver + skip-ground-truth authored assembly, a correctness-critical slice deserving its own design pass (the design doc's Q4 criterion: bundle only if the deriver change is small — it is not).
 
 **D2.5 (this slice) = P2 only:** a **read-only / no-mint** gate so `buildAuthoredCertifyingCorpus` is side-effect-free against the authoring-ledger — it consumes only already-recorded, **unchanged** rules and fails loud (before certification, zero writes) if any current rule would be `minted`/`revised`. It will NOT add a second compiler, NOT touch the authoring path (`totem rule author` stays the writer), NOT score `authoredControls` (D3), and NOT re-decide the §8 identity/`judgedBy` single-source (D2-shipped).
@@ -19,31 +22,35 @@ The certification corpus assembly for authored rules (`buildAuthoredCertifyingCo
 **D2.6 (follow-on) = P1:** the §6 window-wide label scope — `fetch-dispositions` (window-wide non-control corpus PRs) + a producerKind-aware `derive-labels` (authored substrate, skip-ground-truth on first-derive) span the **whole window (train + held-out non-control)** under `producerKind:'authored'`. Contract-settled in §6/§5.3 (no new ruling owed); deferred only for size. The D2.5 NOTE at `spine-cert-run-corpus.ts:530` already marks the plug-in point.
 
 ### Data model deltas
+
 - **`RuleAuthorOptions.verifyOnly?: boolean`** (new optional field on `runRuleAuthor`'s opts; default `false`).
-  - *Holds:* whether this call is a cert-run re-derive (read-only) vs. an authoring write.
-  - *Writes:* the caller — `buildAuthoredCertifyingCorpus` passes `true`; `totem rule author` omits it (`false`).
-  - *Reads:* `runRuleAuthor` Pass 2 — when `true`, **skips the `appendAuthoringLedgerEntry` IO entirely** and instead throws if any `pending[].action !== 'unchanged'`.
-  - *Invariant:* `verifyOnly:true` ⇒ **zero** ledger writes on every path (success or throw); guaranteed by gating Pass 2's append behind it and throwing *before* the loop. Optional field, but the **cert producer must always set it** (the production-runnability precondition).
+  - _Holds:_ whether this call is a cert-run re-derive (read-only) vs. an authoring write.
+  - _Writes:_ the caller — `buildAuthoredCertifyingCorpus` passes `true`; `totem rule author` omits it (`false`).
+  - _Reads:_ `runRuleAuthor` Pass 2 — when `true`, **skips the `appendAuthoringLedgerEntry` IO entirely** and instead throws if any `pending[].action !== 'unchanged'`.
+  - _Invariant:_ `verifyOnly:true` ⇒ **zero** ledger writes on every path (success or throw); guaranteed by gating Pass 2's append behind it and throwing _before_ the loop. Optional field, but the **cert producer must always set it** (the production-runnability precondition).
 - **No new error class** — reuse `TotemError('GATE_INVALID', …)` matching the existing step-0/step-3 cert gates (the auto-spec's `TotemRuleMutationError` is rejected; the codebase uses `TotemError` codes, not branded subclasses).
 - **No `windowLabels` field** — P1 changes the **derivation scope** (which PRs `corpusHeldOutPrs`/the firing enumeration cover), not a new field.
 - **Possible P1 delta (open question):** a window-wide variant of `corpusHeldOutPrs(split)` — e.g. `corpusWindowPrs(split)` returning `(trainPrs ∪ heldOutPrs) − controls` — selected when `producerKind:'authored'`.
 
 ### State lifecycle
+
 - `verifyOnly` is a **per-call** parameter (no container, no persistence). Created at each `runRuleAuthor` invocation, never mutated, never crosses a boundary. Ownership: the caller decides; `runRuleAuthor` only reads it. This deliberately avoids the "one-shot flag consumed before its work succeeded" hazard — there is no stored flag, and the throw precedes any IO.
 - The authoring-ledger itself is **persistent** (`.totem/spine/authoring-ledger`), append-only, owned by `appendAuthoringLedgerEntry`. P2's guarantee is that the **cert path never mutates it** (Tenet-13 sensor-not-actuator).
 
 ### Failure modes
-| Failure | Category | Agent-facing surface | Recovery |
-| --- | --- | --- | --- |
-| Cert run, a current rule would be `minted` (no ledger entry for its identity) | runtime | hard error `GATE_INVALID`, names the rule(s) + `minted` | Run `totem rule author` to record the rule (with §3 judgedBy) **before** the cert run; a cert run is not the first author |
-| Cert run, a current rule would be `revised` (YAML diverged from recorded `contentHash`) | runtime | hard error `GATE_INVALID`, names the rule(s) + `revised` | Re-author to record the revision, or revert the YAML to the recorded form, then re-run cert |
-| (existing, retained) empty ledger | runtime | hard error `GATE_INVALID` (step 0) | unchanged |
-| (existing, retained) judgedBy divergence / split mismatch | runtime | hard error `GATE_INVALID` (steps 0/3) | unchanged |
-| P1: a train-slice corpus firing has no disposition to label | runtime | **must fail loud or be a deliberate `unlabeled` class** — NOT silent (else a train FP escapes precision, §5.3) | covered by the deriver's existing `unlabeledByReason` diagnostics; verify window-wide firings are dispositioned |
+
+| Failure                                                                                 | Category | Agent-facing surface                                                                                           | Recovery                                                                                                                  |
+| --------------------------------------------------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Cert run, a current rule would be `minted` (no ledger entry for its identity)           | runtime  | hard error `GATE_INVALID`, names the rule(s) + `minted`                                                        | Run `totem rule author` to record the rule (with §3 judgedBy) **before** the cert run; a cert run is not the first author |
+| Cert run, a current rule would be `revised` (YAML diverged from recorded `contentHash`) | runtime  | hard error `GATE_INVALID`, names the rule(s) + `revised`                                                       | Re-author to record the revision, or revert the YAML to the recorded form, then re-run cert                               |
+| (existing, retained) empty ledger                                                       | runtime  | hard error `GATE_INVALID` (step 0)                                                                             | unchanged                                                                                                                 |
+| (existing, retained) judgedBy divergence / split mismatch                               | runtime  | hard error `GATE_INVALID` (steps 0/3)                                                                          | unchanged                                                                                                                 |
+| P1: a train-slice corpus firing has no disposition to label                             | runtime  | **must fail loud or be a deliberate `unlabeled` class** — NOT silent (else a train FP escapes precision, §5.3) | covered by the deriver's existing `unlabeledByReason` diagnostics; verify window-wide firings are dispositioned           |
 
 No row is "silent degradation." The no-mint gate is **fail-loud-before-write**; the P1 label-scope explicitly closes the "train FP escapes" silent hole §6 names.
 
 ### Invariants to lock in via tests
+
 - A cert-run re-derive (`verifyOnly:true`) over a ledger whose entries exactly match the current YAML returns the records and **appends zero rows** (read the ledger file byte-before == byte-after).
 - A cert run where the YAML adds a **new** rule (would mint) throws `GATE_INVALID` naming that rule, **and the ledger is unmutated** (no partial append).
 - A cert run where an existing rule's YAML changed (would revise) throws `GATE_INVALID` naming that rule, ledger unmutated.
@@ -51,7 +58,8 @@ No row is "silent degradation." The no-mint gate is **fail-loud-before-write**; 
 - P1: `deriveLabelsFromDispositions` produces a label for every **non-control** corpus firing across **both** slices under authored-primary (no train-slice firing silently unlabeled).
 
 ### Open questions
-- **Q1 (contract, →strategy):** Is the no-mint gate a **`verifyOnly` mode on `runRuleAuthor`** (single source of the mint/revise decision — the sibling of D2's §8 source-flip, line 167), or a **separate producer pre-check**? *Recommendation:* mode-on-`runRuleAuthor` — DRY, one source of truth for the action decision; a separate pre-check duplicates the contentHash/identity logic and creates a second source (a Tenet-20 mirror smell).
-- **Q2 (contract, →strategy):** Is **`revised` forbidden identically to `minted`**? *Recommendation:* yes — a revised rule means the YAML diverged from the recorded entry since authoring, i.e. the author is editing during the cert run, which the "a cert run is NOT the first author" invariant forbids exactly as minting does.
+
+- **Q1 (contract, →strategy):** Is the no-mint gate a **`verifyOnly` mode on `runRuleAuthor`** (single source of the mint/revise decision — the sibling of D2's §8 source-flip, line 167), or a **separate producer pre-check**? _Recommendation:_ mode-on-`runRuleAuthor` — DRY, one source of truth for the action decision; a separate pre-check duplicates the contentHash/identity logic and creates a second source (a Tenet-20 mirror smell).
+- **Q2 (contract, →strategy):** Is **`revised` forbidden identically to `minted`**? _Recommendation:_ yes — a revised rule means the YAML diverged from the recorded entry since authoring, i.e. the author is editing during the cert run, which the "a cert run is NOT the first author" invariant forbids exactly as minting does.
 - **Q3 (contract, →strategy):** Frame the property as **side-effect-free against the authoring-ledger + assert-all-unchanged** (Tenet-13 + Tenet-4), composing with (not replacing) the existing step-0 empty-ledger and step-3 judgedBy/split gates — confirm no §8 separation conflict.
 - **Q4 (build, mine):** flag name (`verifyOnly` vs `mode:'cert'`), and whether P1's window-wide selection lands this slice or splits to its own PR — leaning `verifyOnly` + bundling P1 if the deriver scope change is small.

--- a/packages/cli/src/authored-rule-intake.ts
+++ b/packages/cli/src/authored-rule-intake.ts
@@ -119,7 +119,10 @@ interface PendingRule {
  * the authoring-ledger. `judgedBy` names the independent check (NEVER the author)
  * recorded on every eligibility verdict. Pure + deterministic except the ledger IO.
  */
-export function runRuleAuthor(totemDir: string, opts: { judgedBy: string }): RuleAuthorResult {
+export function runRuleAuthor(
+  totemDir: string,
+  opts: { judgedBy: string; verifyOnly?: boolean },
+): RuleAuthorResult {
   // Normalize at the PRODUCER boundary (CR re-review): the command trims `--judged-by`, but this
   // function is exported + callable directly, so an untrimmed `' Alice '` must not bypass the
   // §3 independence guard against `author: 'Alice'`. Trim once, use everywhere downstream; a blank
@@ -308,7 +311,35 @@ export function runRuleAuthor(totemDir: string, opts: { judgedBy: string }): Rul
     pending.push({ record, entry, write: action !== 'unchanged', action });
   }
 
-  // ── Pass 2 (IO): append ledger rows fail-loud (pass 1 already proved every record valid) ──
+  // ── verifyOnly (ADR-112 §8 no-mint precondition — strategy ruling 2026-06-30, Q1–Q4) ──
+  // A cert-run re-derive (`buildAuthoredCertifyingCorpus`, always verifyOnly) is side-effect-free
+  // against the authoring-ledger and asserts every current rule already has an `unchanged` recorded
+  // entry: any `minted`/`revised` action fails loud BEFORE a single append (a cert run is NOT the
+  // first author — Q2: revise is forbidden identically to mint; only `unchanged` passes). This is
+  // the read-side sibling of D2's §8 source-flip (line 167): the cert-run re-read writes nothing.
+  // Tenet-13 sensor-not-actuator ⊕ Tenet-4 fail-loud-no-drift. Gate placement = the writer itself
+  // (Q1: single source of the mint/revise decision; a separate pre-check would be a second source,
+  // the Tenet-20 mirror strategy#787 closed). Composes with — never replaces — the producer's step-0
+  // empty-ledger and step-3 judgedBy/split gates (Q3). The authoring path leaves verifyOnly unset
+  // and still mints/revises below (Q4: cert-path-only).
+  if (opts.verifyOnly) {
+    const wouldAuthor = pending.filter((p) => p.write);
+    if (wouldAuthor.length > 0) {
+      const summary = wouldAuthor.map((p) => `${p.record.ruleId} (${p.action})`).join(', ');
+      throw new TotemError(
+        'GATE_INVALID',
+        `Authored cert corpus: ${wouldAuthor.length} authored rule(s) would be authored ` +
+          `(minted/revised) during cert-run assembly — ${summary}. A cert run consumes only ` +
+          `already-recorded, unchanged ledger entries; it is NOT the first author (ADR-112 §8).`,
+        'Run `totem rule author` to record/revise the rule(s) into the ledger BEFORE the cert run, ' +
+          'then re-run the cert. The ledger entry must pre-exist and match the current authored YAML.',
+      );
+    }
+  }
+
+  // ── Pass 2 (IO): append ledger rows fail-loud (pass 1 already proved every record valid).
+  //    Under verifyOnly the gate above already threw on any `p.write`, so every append here is a
+  //    no-op (all `unchanged`) — the cert path writes zero rows. ──
   let minted = 0;
   let revised = 0;
   let unchanged = 0;

--- a/packages/cli/src/commands/rule-author.test.ts
+++ b/packages/cli/src/commands/rule-author.test.ts
@@ -293,3 +293,57 @@ describe('runRuleAuthor — codex/agy diff-review folds', () => {
     expect(ledger[1]?.structuralEligibility.judgedBy).toBe('check-b');
   });
 });
+
+describe('runRuleAuthor — verifyOnly no-mint precondition (ADR-112 §8, strategy ruling Q1–Q4)', () => {
+  const JUDGED_BY = 'static-whitelist@test';
+  const verify = () => runRuleAuthor(totemDir, { judgedBy: JUDGED_BY, verifyOnly: true });
+  const snapshot = () => JSON.stringify(readAuthoringLedger(totemDir));
+
+  it('a re-derive of an UNCHANGED ledger passes read-only: records returned, ZERO rows appended', () => {
+    writeYaml([decidableRule()]);
+    const id = run().records[0]?.ruleId; // author first (cert run is NOT the first author)
+    const before = snapshot();
+    const res = verify();
+    expect(res.unchanged).toBe(1);
+    expect(res.minted).toBe(0);
+    expect(res.revised).toBe(0);
+    expect(res.records[0]?.ruleId).toBe(id);
+    expect(snapshot()).toBe(before); // side-effect-free against the authoring-ledger (Tenet-13)
+  });
+
+  it('a would-MINT rule (no prior ledger entry) fails loud BEFORE any write; ledger stays empty (Q2 minted)', () => {
+    writeYaml([decidableRule()]);
+    expect(readAuthoringLedger(totemDir)).toHaveLength(0); // nothing authored yet
+    expect(verify).toThrow(/NOT the first author/i);
+    expect(verify).toThrow(/\(minted\)/); // the action is named explicitly
+    expect(readAuthoringLedger(totemDir)).toHaveLength(0); // zero writes on the throw (no drift, Tenet-4)
+  });
+
+  it('a would-REVISE rule (dslSource edit since authoring) fails loud identically to mint; ledger unmutated (Q2 revised)', () => {
+    writeYaml([decidableRule()]);
+    run(); // author the original
+    const before = snapshot();
+    writeYaml([decidableRule({ dslSource: 'console\\.error' })]); // YAML diverged from the recorded entry
+    expect(verify).toThrow(/\(revised\)/); // revise is forbidden identically to mint (Q2)
+    expect(snapshot()).toBe(before); // no revision row appended (read-only)
+  });
+
+  it('a mixed run (one unchanged + one new) fails loud on the new rule and writes NOTHING (no partial append)', () => {
+    writeYaml([decidableRule()]);
+    run(); // author rule #1
+    const before = snapshot();
+    writeYaml([
+      decidableRule(),
+      decidableRule({ targetDefect: 'another defect', dslSource: 'TODO' }),
+    ]);
+    expect(verify).toThrow(/NOT the first author/i);
+    expect(snapshot()).toBe(before); // the unchanged rule did not mask the new one; zero writes overall
+  });
+
+  it('verifyOnly defaults off — the authoring path (totem rule author) still mints (Q4: cert-path-only)', () => {
+    writeYaml([decidableRule()]);
+    const res = runRuleAuthor(totemDir, { judgedBy: JUDGED_BY }); // no verifyOnly → writer
+    expect(res.minted).toBe(1);
+    expect(readAuthoringLedger(totemDir)).toHaveLength(1);
+  });
+});

--- a/packages/cli/src/commands/spine-authored-cert-corpus.ts
+++ b/packages/cli/src/commands/spine-authored-cert-corpus.ts
@@ -123,11 +123,15 @@ export async function buildAuthoredCertifyingCorpus(
   }
   const judgedBy = [...judgedBys][0]!;
 
-  // 1. Produce the authored records under the LEDGER-SOURCED judgedBy (idempotent re-derive —
-  //    the ledger already records this verdict, so an equal contentHash ⇒ no new row). The
-  //    producer establishes eligibility/identity/ledger; NEVER construct AuthoredRuleRecord[]
-  //    ad hoc or read YAML→record here.
-  const authorResult = runRuleAuthor(deps.totemDir, { judgedBy });
+  // 1. Re-derive the authored records under the LEDGER-SOURCED judgedBy in verifyOnly mode
+  //    (ADR-112 §8 no-mint precondition — strategy ruling 2026-06-30, Q4 cert-path-only). The
+  //    re-derive is read-only against the authoring-ledger: it asserts every current rule already
+  //    has an `unchanged` recorded entry and fails loud (zero writes) if any would be minted/revised
+  //    — a cert run is NOT the first author. This is the gate the empty-ledger step-0 above does not
+  //    cover (non-empty-but-stale): step-0 empty → no-mint stale → step-3 verdict/binding (Q3 layered).
+  //    The producer establishes eligibility/identity; NEVER construct AuthoredRuleRecord[] ad hoc or
+  //    read YAML→record here.
+  const authorResult = runRuleAuthor(deps.totemDir, { judgedBy, verifyOnly: true });
 
   // 2. rejected.length === 0 precondition: a partially-invalid authored file is broken
   //    cert input — never certify the eligible subset (fail loud, not a partial corpus).


### PR DESCRIPTION
## ADR-112 §8 Slice D2.5 — read-only / no-mint precondition on the authored cert producer

Hardens the deferred CodeRabbit Major from #2274 (D2): `buildAuthoredCertifyingCorpus` re-derives the authored records via `runRuleAuthor` (the writer) during cert-corpus assembly, and D2's step-0 gate checks only that the authoring-ledger is **non-empty** — not that no rule is **minted/revised**. A cert run over a stale `authored-rules.yaml` (a new or edited rule) would mint/revise it and certify its own mint. **A cert run is NOT the first author.**

### What changed
- **`runRuleAuthor` gains a `verifyOnly` mode** — the cert-run re-derive runs Pass 1 (pure eligibility/identity/contentHash) and fails loud (`GATE_INVALID`, naming the rule + `minted`/`revised`) **before** Pass 2's first ledger append if any current rule would be `minted` or `revised`. Only `unchanged` passes (revise forbidden identically to mint). **Zero ledger writes on the throw** (Tenet-4 no-drift). The read-side sibling of D2's §8 source-flip (Tenet-13 sensor-not-actuator).
- **`buildAuthoredCertifyingCorpus` always calls `verifyOnly: true`** — the cert path is read-only against the authoring-ledger; the authoring path (`totem rule author`) is unchanged and still mints/revises (cert-path-only scope).
- Composes with — does not replace — the step-0 empty-ledger and step-3 judgedBy/split gates (layered: empty → no-mint stale → verdict/binding divergence).

### Contract (strategy couple-on-merge)
Built on strategy-claude's ADR-112 §8 ruling (2026-06-30, Q1–Q4 all blessed): gate placement = `verifyOnly` on the writer (single source, no second-source mirror); revise = mint; layered composition; cert-path-only. Strategy authors the §8 no-mint-precondition amendment and lands it **lockstep with this merge** (the #789 ⊕ #2274 pattern). **Couple-on-merge is strategy's.**

### Scope
- **INERT until D3** — scoring still ignores `authoredControls`; no production authored lock exists. The gate hardens the producer ahead of the surface it protects (the production-runnable altitude).
- **P1 (§6 window-wide answer-key deriver) split to a follow-on D2.6** — it proved materially larger (a producerKind-aware `derive-labels` + skip-ground-truth authored assembly; `assembleCertifyingCorpus` is mined-only today). Contract-settled in §6/§5.3; deferred only for size. The plug-in point is already marked at `spine-cert-run-corpus.ts:530`.

### Gate
cli 2867 tests · tsc full-workspace build · prettier · eslint 0-err · `totem lint` PASS · `totem review` PASS. 5 new `verifyOnly` tests (unchanged→zero-writes · would-mint→throw+unmutated · would-revise→throw+unmutated · mixed-run no-partial-append · cert-path-only regression).

closingRefs []. Refs #2274 (D2), strategy#591 / strategy#787 / strategy#789.
