### PR TITLE
feat(spine): ADR-112 §6/§5.3 Slice D2.6 — window-wide answer-key deriver (authored producer, inert-until-D3)

### DIFF
--- a/.changeset/adr112-d26-window-answer-key.md
+++ b/.changeset/adr112-d26-window-answer-key.md
@@ -1,0 +1,14 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+---
+
+ADR-112 §6/§5.3 Slice D2.6 — window-wide answer-key deriver for the AUTHORED producer.
+
+Under `producerKind:'authored'`, the cert-run answer key (`ground-truth-labels.json`) must be derived WINDOW-WIDE (train ∪ held-out non-control), not held-out-only. Authored positive controls are train-side, so a held-out-only key leaves their corpus firings unlabeled → `needsAdjudication` → a run that can never PASS (permanent HONEST-NEGATIVE; totem-agy's D2 mechanical proof). This is the §6 follow-on split out of D2.5.
+
+- **`corpusWindowPrs(split)`** (`@mmnto/cli`, `spine-fetch-dispositions`): pure sibling of `corpusHeldOutPrs` = `(trainPrs ∪ heldOutPrs)` minus the positive/negative controls, deduped + ascending. `fetch-dispositions` branches on `producerKind` (authored → window-wide dispositions; mined → held-out-only, byte-unchanged) with a scope-aware empty-check message + log.
+- **`assembleAuthoredCertifyingCorpus(opts, lock)`** (`@mmnto/cli`, `spine-cert-run-corpus`): the derive-path sibling of `assembleCertifyingCorpus`. Loads the authored substrate with ground-truth SKIPPED (the deriver PRODUCES the key — circularity guard) while still hash-binding the scoring source (`prDiffsSha`), then builds via the existing `buildAuthoredCertifyingCorpus` (which owns the §8 ledger-sourced `judgedBy`). `loadAuthoredCertRunFixtures` gains an additive `skipGroundTruth` param (parity with the mined `loadCertRunFixtures`).
+- **`derive-labels`** (`@mmnto/cli`): producerKind-aware — an authored lock assembles via the authored sibling (window-wide firings over the authored substrate); a mined lock is byte-unchanged. Adds an injectable `totemDir` (defaults to the `.totem/spine/gate-1` convention).
+
+The RUN-path §8 single-home dispatch (`resolveCertifyingCorpusProvider`) is UNTOUCHED — the producer commands (`fetch-dispositions` / `derive-labels`) read `producerKind` at the command layer, mirroring how the mined deriver already bypasses the resolver (gemini single-home ruling holds; strategy 2026-07-01 additive-sibling ruling, no §8 re-decision owed). Contract settled in ADR-112 §6/§5.3 — no new core ruling. Still INERT until D3; no production authored lock exists. closingRefs [].

--- a/.totem/specs/adr112-d26.md
+++ b/.totem/specs/adr112-d26.md
@@ -1,0 +1,152 @@
+### Problem Statement
+
+We need to introduce a `producerKind`-aware `corpusWindowPrs` selector to compute the target PR window (train union heldOut minus controls) for disposition fetching, and implement a `skip-groundTruth` fast-path for `authored` corpora in `spine-derive-labels.ts`. This ensures authored windtunnel runs bypass unnecessary ground-truth label derivation while strictly preserving the existing single-home routing dispatch for corpus assembly.
+
+### Architectural Context
+
+None found in provided context regarding specific lessons, but existing code establishes a strong invariant: `resolveCertifyingCorpusProvider` in `spine-cert-run-corpus.ts` is the _single home_ for dispatching behavior based on `lock.producerKind ?? 'mined'`. The new `skip-groundTruth` path must respect this and not duplicate the dispatch logic.
+
+### Files to Examine
+
+1. `packages/cli/src/commands/spine-cert-run-corpus.ts` — Review `resolveCertifyingCorpusProvider` and `assembleCertifyingCorpus` to understand the Section-8 single-home dispatch and how `skipGroundTruth` is currently passed in `opts`.
+2. `packages/cli/src/commands/spine-derive-labels.ts` — Examine `deriveLabelsCommand` to see where the `skip-groundTruth` short-circuit must be injected.
+3. `packages/cli/src/commands/spine-fetch-dispositions.ts` (assumed path) — Locate `corpusHeldOutPrs` to implement `corpusWindowPrs(split, lock)` as a sibling.
+
+### Technical Approach & Contracts
+
+**1. The `corpusWindowPrs` Function Contract:**
+We will define a new pure function in `spine-fetch-dispositions.ts`.
+
+```typescript
+interface Split {
+  trainPrs: string[];
+  heldOutPrs: string[];
+  positiveControlPrs?: string[];
+  negativeControlPrs?: string[];
+}
+// Contract
+export function corpusWindowPrs(split: Split, lock: WindtunnelLock): string[];
+```
+
+_Logic:_
+
+- If `lock.producerKind === 'authored'`, branch accordingly (e.g., authored corpora might not use strict train/heldOut splits in the same way, or simply returns all non-control PRs).
+- For `mined` (default): Compute `(trainPrs ∪ heldOutPrs) \ (positiveControls ∪ negativeControls)`.
+
+**2. The `skip-groundTruth` Authored Assembly Path:**
+In `deriveLabelsCommand` (`spine-derive-labels.ts`), read `lock.producerKind`. If it resolves to `'authored'`, bypass the standard `deriveLabelsFromDispositions` execution. Instead, construct a fast-path that either yields an empty/passthrough label set or delegates directly to `assembleCertifyingCorpus` with `{ skipGroundTruth: true }`.
+
+**3. Gate Resolution (Section-8 Single-Home Resolver Dispatch):**
+_Does the skip-groundTruth authored assembly re-decide the section-8 single-home resolver dispatch?_
+**No.** It is an architectural trap to duplicate the `producerKind === 'authored'` check to instantiate providers directly in `spine-derive-labels.ts`.
+_Recommendation:_ `spine-derive-labels.ts` must pass `{ skipGroundTruth: true }` in the options downward into the core assembly pipeline. The dispatch logic at `spine-cert-run-corpus.ts:488-490` remains the _exclusive_ owner of determining which `CertifyingCorpusProvider` is constructed.
+
+### Edge Cases & Traps
+
+- **Nullish `producerKind`:** `lock.producerKind` is optional. The logic must always coalesce `lock.producerKind ?? 'mined'` before branching.
+- **Set Arithmetic Flaws:** When computing `union` minus `controls`, ensure you are doing strict string matching (or number matching if PRs are IDs). A `Set<string>` should be used to guarantee `O(1)` lookups for the subtraction phase to prevent subtle `O(n^2)` performance traps on massive corpora.
+- **Dangling Dispositions:** If `deriveLabelsCommand` skips ground truth, ensure the command still writes out a valid, schema-compliant `CorpusDispositions` or `MinerLedgers` file (even if empty/mocked) so downstream pipeline steps do not crash on missing files.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Implement `corpusWindowPrs` selector**
+  - Modify `packages/cli/src/commands/spine-fetch-dispositions.ts`.
+  - Add `corpusWindowPrs` sibling function to `corpusHeldOutPrs`.
+  - Coalesce `producerKind ?? 'mined'`.
+  - Implement the Set math: `Array.from(new Set([...train, ...heldOut].filter(pr => !controls.has(pr))))`.
+  - > TEST DIRECTIVE: Before implementing, write a failing test named `removes positive and negative controls from train and heldOut union` that proves the set math works correctly, and a second test `handles missing control arrays safely`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Wire `producerKind` awareness into `deriveLabelsCommand`**
+  - Modify `packages/cli/src/commands/spine-derive-labels.ts`.
+  - Extract `producerKind` from the parsed `WindtunnelLock`.
+  - Introduce an early branch: if `authored`, set `skipGroundTruth = true` and bypass `deriveLabelsFromDispositions`.
+  - Ensure the output contract matches what downstream steps expect (write out the necessary canonical json).
+  - > TEST DIRECTIVE: Before implementing, write a failing test named `bypasses deriveLabelsFromDispositions for authored producerKind` that mocks the lock to `authored` and verifies the derivation engine is not invoked.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Propagate `skipGroundTruth` through corpus assembly**
+  - Modify `packages/cli/src/commands/spine-cert-run-corpus.ts`.
+  - Ensure `assembleCertifyingCorpus` explicitly passes `skipGroundTruth: opts.skipGroundTruth` into `inputs` for `resolveCertifyingCorpusProvider`.
+  - Verify that `resolveCertifyingCorpusProvider` explicitly respects the flag for authored dispatch _without_ overriding the `producerKind === 'authored'` gateway.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Unit (Set Math):** Construct mock `split` objects with overlapping PRs in train/heldOut, and subset overlaps in controls. Assert `corpusWindowPrs` deduplicates and strictly subtracts all controls.
+- **Unit (Authored Branch):** Test `corpusWindowPrs` with `lock.producerKind = 'authored'` to ensure it returns the expected structural set for authored locks.
+- **Integration (Label Derivation):** Invoke `deriveLabelsCommand` with an `authored` lock. Assert that `deriveLabelsFromDispositions` is never called (via spies) and the command exits gracefully with a valid contract payload.
+- **Integration (Assembly Routing):** Call `assembleCertifyingCorpus` with `skipGroundTruth: true`. Assert that `resolveCertifyingCorpusProvider` correctly routes to the authored provider, proving the Section-8 single-home dispatch was not circumvented.
+
+---
+
+> ⚠ **Corrections to the auto-generated draft above (verified against source — do NOT act on the draft where it conflicts).** The `## Implementation Design` section below is the authoritative spec.
+>
+> 1. **PRs are `number[]`**, not `string[]` (`spine-fetch-dispositions.ts:44`). Set math is over numbers.
+> 2. **Authored does NOT bypass label derivation.** D2.6 exists _precisely so authored derives labels WINDOW-WIDE._ `skipGroundTruth` is the circularity guard (the deriver _produces_ `ground-truth-labels.json`, so it must not require the `groundTruthSha` that doesn't exist yet) — it is NOT a "skip derivation / empty label set" switch. The draft's Task 2 ("bypass `deriveLabelsFromDispositions`", "empty/passthrough label set") would reintroduce the permanent-HONEST-NEGATIVE bug this slice fixes.
+> 3. **`derive-labels` does not call `resolveCertifyingCorpusProvider`.** It calls `assembleCertifyingCorpus` directly (`:151`), which itself never calls the resolver. Routing the derive path _through_ the resolver would be the §8 re-decision to AVOID. The additive-sibling design is a new `assembleAuthoredCertifyingCorpus` sibling, resolver untouched.
+> 4. `corpusWindowPrs(split)` is a **pure split-only selector** (sibling of `corpusHeldOutPrs`); the _command_ reads `producerKind`, not the selector — mirrors the existing structure and keeps kind-reads at the command layer.
+
+## Implementation Design
+
+### Scope
+
+Make the two by-hand **producer** commands `producerKind`-aware so an `authored` cert corpus derives its answer key **window-wide** (train ∪ held-out, minus controls): `fetch-dispositions` freezes window-wide dispositions, and `derive-labels` enumerates window-wide firings via a new authored skip-groundTruth assembler. This will NOT modify `resolveCertifyingCorpusProvider` (the §8 RUN-path single-home dispatch), will NOT change any mined behavior (byte-identical), and will NOT touch the certifying-run engine, freeze, or persist paths.
+
+### Data model deltas
+
+- **`corpusWindowPrs(split): number[]`** (new export, `spine-fetch-dispositions.ts`). Pure sibling of `corpusHeldOutPrs`. Holds the window-wide corpus PR set `(trainPrs ∪ heldOutPrs) − (positiveControlPrs ∪ negativeControlPrs)`, deduped, ascending. Writer: none (pure). Reader: `fetchDispositionsCommand` (authored branch). Invariant: deterministic order, controls always excluded (same `Set` subtraction as `corpusHeldOutPrs`).
+- **`assembleAuthoredCertifyingCorpus(opts, lock): Promise<{corpus}>`** (new export, `spine-cert-run-corpus.ts`). Sibling of `assembleCertifyingCorpus` for the DERIVE path. Loads the authored substrate via `loadAuthoredCertRunFixtures(gate1Dir, {expectedPrDiffsSha, skipGroundTruth})` then calls the existing `buildAuthoredCertifyingCorpus`. Reader: `deriveLabelsCommand` (authored branch). Invariant: on `skipGroundTruth`, requires `prDiffsSha` (still hash-bind the scoring source) but NOT `groundTruthSha` (deriver produces it) — mirrors `assembleCertifyingCorpus`'s skip semantics.
+- **`skipGroundTruth?: boolean`** additive optional param on `loadAuthoredCertRunFixtures`'s opts (default `false` ⇒ resolver call byte-unchanged). Parity with `loadCertRunFixtures`, which already has it.
+- **No new lock fields, no new schema, no reserved keys.** `producerKind` is read (never written) at exactly two new command sites (`fetchDispositionsCommand`, `deriveLabelsCommand`), each coalescing `lock.producerKind ?? 'mined'`.
+
+### State lifecycle
+
+All state is **per-invocation** (CLI command scope). `corpusWindowPrs` is pure/stateless. The authored substrate (`split/prDiffs/groundTruth`) is loaded, consumed to build firings, and discarded within one `derive-labels` run. `groundTruthSha` is stamped into the lock exactly as today (read-modify-write, idempotent) — no lifecycle change. No cross-request or persistent state; no one-shot flags.
+
+### Failure modes
+
+| Failure                                                       | Category | Agent-facing surface                                                                | Recovery                                  |
+| ------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------- | ----------------------------------------- |
+| authored window empty (all window PRs are controls)           | runtime  | hard error `CONFIG_INVALID` (scope-aware msg: "window has no non-control PRs")      | fix split / re-materialize                |
+| authored lock missing `prDiffsSha` on derive                  | runtime  | hard error `CONFIG_INVALID` (existing precondition, reused)                         | re-materialize cert corpus                |
+| authored substrate absent / tampered (`prDiffs` sha mismatch) | runtime  | hard error `CONFIG_INVALID` (existing `loadAuthoredCertRunFixtures` integrity gate) | restore frozen fixtures                   |
+| empty authoring-ledger / rejected authored rules              | runtime  | hard error `GATE_INVALID` (existing `buildAuthoredCertifyingCorpus` gates)          | author rules first                        |
+| sparse answer key (few dispositions bind)                     | runtime  | **honest-negative, reported** (diagnostic density line) — NOT an error              | expected; never densify-to-PASS (Tenet 4) |
+
+No silent-degradation rows: every authored failure fails loud, reusing the existing hard-gate discipline. The only "empty-ish" outcome (sparse labels) is the intended honest-negative surfaced via diagnostics.
+
+### Invariants to lock in via tests
+
+- `corpusWindowPrs` = `(train ∪ heldOut) − controls`, deduped + ascending; a PR in both train and controls is excluded; a train-only non-control PR is INCLUDED (the held-out-only key would have dropped it — the D2.6 raison d'être).
+- `fetch-dispositions` picks `corpusWindowPrs` iff `producerKind==='authored'`, else `corpusHeldOutPrs` (mined byte-unchanged: mined fixture split yields the identical PR set as before).
+- `derive-labels` on an authored lock enumerates firings over the window-wide authored substrate and **derives real labels** (train-side positive-control firings become labeled, not `needsAdjudication`) — the anti-regression for the permanent-HONEST-NEGATIVE bug.
+- `assembleAuthoredCertifyingCorpus({skipGroundTruth:true})` requires `prDiffsSha`, tolerates absent `groundTruthSha`, and never reads `ground-truth-labels.json` (circularity guard).
+- `resolveCertifyingCorpusProvider` is unchanged — the RUN path still hard-requires `groundTruthSha` (authored run precondition intact).
+
+### Open questions
+
+- **Question:** Where does the authored skip-groundTruth substrate load live — a `skipGroundTruth` param added to `loadAuthoredCertRunFixtures`, or a thin deriver-local loader?
+  - **Options:** (a) add optional `skipGroundTruth` to `loadAuthoredCertRunFixtures` (parity with `loadCertRunFixtures`, one loader, resolver call unchanged by default); (b) a separate deriver-only authored loader (avoids touching the resolver's loader at all, but duplicates the integrity/parse logic).
+  - **Recommendation:** **(a)** — additive optional param, zero resolver-behavior change, no duplicated integrity discipline. This keeps the change purely additive and is the parity the mined loader already models.
+- **Question:** `totemDir` wiring — `deriveLabelsCommand` has `gate1Dir` but the authored assembler needs `.totem` (for the authoring-ledger). Derive it as `path.dirname(path.dirname(gate1Dir))` (gate-1 is `.totem/spine/gate-1`) or add an explicit `--totem-dir`/opt?
+  - **Options:** (a) derive from `gate1Dir` by convention; (b) add an injected opt (test-friendlier, explicit).
+  - **Recommendation:** **(b)** add an optional `totemDir` to `DeriveLabelsOptions` defaulting to the convention-derived path — explicit + injectable for tests, matches the file's existing `cwd`/`outputDir` injection style.

--- a/packages/cli/src/commands/spine-authored-cert-corpus.test.ts
+++ b/packages/cli/src/commands/spine-authored-cert-corpus.test.ts
@@ -20,7 +20,10 @@ import {
   buildAuthoredCertifyingCorpus,
   type BuildAuthoredCertifyingCorpusDeps,
 } from './spine-authored-cert-corpus.js';
-import { resolveCertifyingCorpusProvider } from './spine-cert-run-corpus.js';
+import {
+  assembleAuthoredCertifyingCorpus,
+  resolveCertifyingCorpusProvider,
+} from './spine-cert-run-corpus.js';
 
 // ─── Fixtures (mirror the slice-2/3/4 + authored-controls tests) ──────────────
 
@@ -397,6 +400,90 @@ describe('resolveCertifyingCorpusProvider — producerKind dispatch (D2 async si
     });
     await expect(resolveCertifyingCorpusProvider(authoredLock, inputs())).rejects.toThrow(
       /pr-diffs\.json integrity FAILED/,
+    );
+  });
+});
+
+// ─── 5. Slice D2.6 — the window-wide answer-key DERIVER's authored assembler ───
+//
+// `assembleAuthoredCertifyingCorpus` is the derive-path sibling of `assembleCertifyingCorpus`:
+// `derive-labels` calls it directly (NOT `resolveCertifyingCorpusProvider` — the §8 RUN-path
+// single home is untouched). It ALWAYS skips ground-truth (the deriver PRODUCES the key) yet
+// still hash-binds the scoring source (`prDiffsSha`).
+
+describe('assembleAuthoredCertifyingCorpus (D2.6 derive-path sibling)', () => {
+  let gate1Dir: string;
+  beforeEach(() => {
+    gate1Dir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-d26-gate1-'));
+  });
+  afterEach(() => {
+    fs.rmSync(gate1Dir, { recursive: true, force: true });
+  });
+
+  const lock = (overrides: Record<string, unknown>): WindtunnelLock =>
+    ({ controls: { integrity: {} }, ...overrides }) as unknown as WindtunnelLock;
+
+  const opts = (
+    extra: Partial<{ authoredControlsDeps: AuthoredControlsDeps }> = {},
+  ): Parameters<typeof assembleAuthoredCertifyingCorpus>[0] => ({
+    gate1Dir,
+    totemDir,
+    stage4: stage4(),
+    now: NOW,
+    ...extra,
+  });
+
+  it('fails loud when the authored lock has no `authored` block (require-when-authored)', async () => {
+    await expect(
+      assembleAuthoredCertifyingCorpus(opts(), lock({ producerKind: 'authored' })),
+    ).rejects.toThrow(/run-input block/);
+  });
+
+  it('fails loud when the lock is missing prDiffsSha (scoring source un-gated)', async () => {
+    await expect(
+      assembleAuthoredCertifyingCorpus(
+        opts(),
+        lock({ producerKind: 'authored', authored: { expectedSplitRef: SPLIT_REF } }),
+      ),
+    ).rejects.toThrow(/prDiffsSha/);
+  });
+
+  it('derives WITHOUT groundTruthSha and never reads the answer key (circularity guard)', async () => {
+    writeAuthoredYaml(totemDir);
+    // A NON-EMPTY ground-truth file on disk + NO groundTruthSha on the lock: the deriver must
+    // still succeed (it PRODUCES this key) and must NOT read it — skip ⇒ empty groundTruth.
+    const { prDiffsSha } = writeSubstrate(gate1Dir, { groundTruth: { 'stale:id': 'TP' } });
+    const authoredLock = lock({
+      producerKind: 'authored',
+      authored: { expectedSplitRef: SPLIT_REF },
+      controls: { integrity: { prDiffsSha } },
+    });
+    const { corpus } = await assembleAuthoredCertifyingCorpus(
+      opts({ authoredControlsDeps: diffDeps('differential-holds') }),
+      authoredLock,
+    );
+    // The authored pipeline ran (rules + §6 controls assembled from the substrate)…
+    expect(corpus.authoredControls).toBeDefined();
+    expect(corpus.authoredControls!.positive).toHaveLength(1);
+    // …and ground-truth was SKIPPED — the on-disk 'stale:id' entry was never read.
+    expect(corpus.groundTruth.size).toBe(0);
+  });
+
+  it('still hash-binds the SCORING source — a tampered pr-diffs.json fails loud', async () => {
+    writeAuthoredYaml(totemDir);
+    const { prDiffsSha } = writeSubstrate(gate1Dir); // sha over the pristine bytes
+    fs.writeFileSync(
+      path.join(gate1Dir, 'pr-diffs.json'),
+      JSON.stringify([{ pr: 1, diff: 'tampered', controlKind: 'corpus' }]),
+      'utf-8',
+    );
+    const authoredLock = lock({
+      producerKind: 'authored',
+      authored: { expectedSplitRef: SPLIT_REF },
+      controls: { integrity: { prDiffsSha } },
+    });
+    await expect(assembleAuthoredCertifyingCorpus(opts(), authoredLock)).rejects.toThrow(
+      /pr-diffs\.json integrity/,
     );
   });
 });

--- a/packages/cli/src/commands/spine-cert-run-corpus.test.ts
+++ b/packages/cli/src/commands/spine-cert-run-corpus.test.ts
@@ -370,4 +370,24 @@ describe('loadAuthoredCertRunFixtures (D2 authored scoring substrate)', () => {
     expect(authored.prDiffs).toEqual(mined.prDiffs);
     expect([...authored.groundTruth]).toEqual([...mined.groundTruth]);
   });
+
+  it('skipGroundTruth (D2.6): returns an empty answer key + needs no groundTruthSha', async () => {
+    // The window-wide DERIVER PRODUCES ground-truth-labels.json, so it passes skipGroundTruth
+    // and supplies no expectedGroundTruthSha; the scoring source (prDiffs) is still hash-bound.
+    const substrate = await loadAuthoredCertRunFixtures(gate1Dir, {
+      expectedPrDiffsSha: prDiffsHash(),
+      skipGroundTruth: true,
+    });
+    expect(substrate.groundTruth.size).toBe(0);
+    expect(substrate.prDiffs).toEqual([]);
+  });
+
+  it('skipGroundTruth loads even when ground-truth-labels.json is ABSENT (first derive)', async () => {
+    fs.rmSync(path.join(gate1Dir, 'ground-truth-labels.json')); // key does not exist yet
+    const substrate = await loadAuthoredCertRunFixtures(gate1Dir, {
+      expectedPrDiffsSha: prDiffsHash(),
+      skipGroundTruth: true,
+    });
+    expect(substrate.groundTruth.size).toBe(0);
+  });
 });

--- a/packages/cli/src/commands/spine-cert-run-corpus.ts
+++ b/packages/cli/src/commands/spine-cert-run-corpus.ts
@@ -276,11 +276,17 @@ export async function loadCertRunFixtures(
  * producer-independent scoring substrate (split for the §5 leakage gate, prDiffs as the
  * scoring corpus, groundTruth as the frozen answer key). The same hard preconditions as
  * mined apply at the caller (prDiffsSha/groundTruthSha MUST be present on a certifying
- * run); `skipGroundTruth` is intentionally NOT exposed — D2's run wiring never derives.
+ * run). The DERIVER passes `skipGroundTruth` (D2.6) — see the opts note below.
  */
 export async function loadAuthoredCertRunFixtures(
   gate1Dir: string,
-  opts?: { expectedPrDiffsSha?: string; expectedGroundTruthSha?: string },
+  opts?: {
+    expectedPrDiffsSha?: string;
+    expectedGroundTruthSha?: string;
+    // Slice D2.6: the window-wide DERIVER passes this — it PRODUCES ground-truth-labels.json
+    // so it must not require/read it (circularity), exactly as the mined `loadCertRunFixtures`.
+    skipGroundTruth?: boolean;
+  },
 ): Promise<ScoringSubstrate> {
   return readAndVerifyScoringSubstrate(gate1Dir, opts);
 }
@@ -482,6 +488,83 @@ export function buildAuthoredCorpusProvider(
 ): CertifyingCorpusProvider {
   return async (_lock: WindtunnelLock): Promise<CertifyingCorpus> =>
     buildAuthoredCertifyingCorpus(deps);
+}
+
+/** Injected inputs for the AUTHORED window-wide answer-key deriver's assembly (D2.6). */
+export interface AuthoredCorpusAssemblyOptions {
+  /** The `.totem/spine/gate-1` dir holding the committed authored scoring substrate. */
+  gate1Dir: string;
+  /** The `.totem` dir holding the authored producer's `spine/authored-rules.yaml` + ledger. */
+  totemDir: string;
+  /** Stage-4 verifier deps (listFiles/readFile) for the compile stage. */
+  stage4: Stage4VerifierDeps;
+  /** Injected timestamp (Tenet 15 determinism). */
+  now: string;
+  /** Optional §4 differential-evaluator injection (defaults to the real one). */
+  authoredControlsDeps?: AuthoredControlsDeps;
+}
+
+/**
+ * ADR-112 §6/§5.3 Slice D2.6 — assemble the AUTHORED `CertifyingCorpus` for the
+ * window-wide answer-key DERIVER: the authored sibling of `assembleCertifyingCorpus`'s
+ * skip-ground-truth path. `derive-labels` calls this directly — NOT
+ * `resolveCertifyingCorpusProvider` (the RUN-path §8 single home; gemini's single-home
+ * ruling is untouched). The deriver is a by-hand producer step that enumerates firings
+ * over the authored substrate, not a run resolving a provider, so it mirrors the mined
+ * deriver's direct `assembleCertifyingCorpus` call rather than re-homing onto the resolver.
+ *
+ * Ground-truth is ALWAYS skipped: the deriver PRODUCES `ground-truth-labels.json`, so it
+ * must not require/read it (circularity). The SCORING source is still hash-bound
+ * (`prDiffsSha`) — a tampered pr-diffs.json would corrupt every derived label. The §8
+ * ledger-sourced `judgedBy` stays owned by `buildAuthoredCertifyingCorpus` (strategy (iii)).
+ * Returns only `{ corpus }` — an authored run mints no miner ledgers.
+ */
+export async function assembleAuthoredCertifyingCorpus(
+  opts: AuthoredCorpusAssemblyOptions,
+  lock: WindtunnelLock,
+): Promise<{ corpus: CertifyingCorpus }> {
+  const { TotemError } = await import('@mmnto/totem');
+
+  // require-when-authored (mirrors resolveCertifyingCorpusProvider): the lock's `authored`
+  // block (expectedSplitRef) is the split-binding every derived label is bound to.
+  if (!lock.authored) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      "derive-labels (authored): lock declares producerKind 'authored' but has no `authored` " +
+        'run-input block (expectedSplitRef) — the authored split binding is unbound (ADR-112 §8/D2).',
+      'Add the `authored: { expectedSplitRef }` block to the lock, or derive against a mined lock.',
+    );
+  }
+
+  const { prDiffsSha } = lock.controls.integrity;
+  if (!prDiffsSha) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      'derive-labels (authored): lock is missing controls.integrity.prDiffsSha — the pr-diffs.json ' +
+        'scoring source cannot be integrity-checked.',
+      'Re-materialize the cert corpus with `spine windtunnel materialize`.',
+    );
+  }
+
+  const { split, prDiffs, groundTruth } = await loadAuthoredCertRunFixtures(opts.gate1Dir, {
+    expectedPrDiffsSha: prDiffsSha,
+    skipGroundTruth: true,
+  });
+
+  const corpus = await buildAuthoredCertifyingCorpus({
+    totemDir: opts.totemDir,
+    // NO judgedBy — the §8 single source is derived from the authoring-ledger INSIDE
+    // buildAuthoredCertifyingCorpus (strategy (iii)); the lock must not be a second source.
+    expectedSplitRef: lock.authored.expectedSplitRef,
+    split,
+    prDiffs,
+    groundTruth,
+    stage4: opts.stage4,
+    now: opts.now,
+    ...(opts.authoredControlsDeps ? { authoredControlsDeps: opts.authoredControlsDeps } : {}),
+  });
+
+  return { corpus };
 }
 
 /** The raw run-context the SINGLE dispatch home consumes to assemble EITHER provider —

--- a/packages/cli/src/commands/spine-derive-labels.test.ts
+++ b/packages/cli/src/commands/spine-derive-labels.test.ts
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { type CompiledRule, deriveLabelsFromDispositions, type ResolvedPrDiff } from '@mmnto/totem';
 
-import { deriveLabelsCommand } from './spine-derive-labels.js';
+import { deriveLabelsCommand, resolveAuthoredTotemDir } from './spine-derive-labels.js';
 import { buildCertifyingFirings } from './spine-windtunnel.js';
 
 const SHA40 = (n: number): string => n.toString(16).padStart(40, '0');
@@ -175,5 +175,22 @@ describe('deriveLabelsCommand — integrity gates', () => {
         cwd: dir,
       }),
     ).rejects.toThrow(/integrity FAILED/i);
+  });
+});
+
+describe('resolveAuthoredTotemDir (D2.6 authoring-ledger anchor)', () => {
+  const cwd = path.resolve('/proj');
+
+  it('anchors to the lock’s `.totem`, independent of a custom output dir (greptile fix)', () => {
+    // gate1Dir may be repointed by --output-dir, but the authoring-ledger stays under the
+    // lock’s `.totem` — three dirs up from `.totem/spine/gate-1/windtunnel.lock.json`.
+    const lockPath = path.join(cwd, '.totem', 'spine', 'gate-1', 'windtunnel.lock.json');
+    expect(resolveAuthoredTotemDir(lockPath, cwd)).toBe(path.join(cwd, '.totem'));
+  });
+
+  it('honors an explicit totemDir override, resolved against cwd', () => {
+    expect(resolveAuthoredTotemDir(path.join('/anywhere', 'lock.json'), cwd, 'custom/.totem')).toBe(
+      path.resolve(cwd, 'custom/.totem'),
+    );
   });
 });

--- a/packages/cli/src/commands/spine-derive-labels.ts
+++ b/packages/cli/src/commands/spine-derive-labels.ts
@@ -38,12 +38,31 @@ export interface DeriveLabelsOptions {
   outputDir?: string;
   /**
    * The `.totem` dir holding the authored producer's `spine/authored-rules.yaml` + ledger
-   * (authored producer only). Defaults to the convention `<gate1Dir>/../..` (gate-1 lives at
-   * `.totem/spine/gate-1`). Injected explicitly for tests + non-conventional layouts (D2.6).
+   * (authored producer only). Defaults to the lock-anchored `.totem` (see
+   * `resolveAuthoredTotemDir` — stable under `--output-dir`). Injected explicitly for tests +
+   * fully-decoupled layouts (D2.6).
    */
   totemDir?: string;
   /** Working dir (default `process.cwd()`; injected for tests). */
   cwd?: string;
+}
+
+/**
+ * The authored producer's `.totem` dir (holds `spine/authored-rules.yaml` + the authoring
+ * ledger). Anchored to the LOCK's location — the lock sits at
+ * `.totem/spine/gate-1/windtunnel.lock.json`, so `.totem` is three dirs up — NOT to `gate1Dir`,
+ * which `--output-dir` can repoint at a custom artifact sink (greptile: deriving it from a
+ * custom output dir would look for the authored rules under the wrong parent). Overridable via
+ * `opts.totemDir` for fully-decoupled layouts.
+ */
+export function resolveAuthoredTotemDir(
+  lockPath: string,
+  cwd: string,
+  totemDirOpt?: string,
+): string {
+  return totemDirOpt
+    ? path.resolve(cwd, totemDirOpt)
+    : path.dirname(path.dirname(path.dirname(lockPath)));
 }
 
 export async function deriveLabelsCommand(opts: DeriveLabelsOptions): Promise<void> {
@@ -166,11 +185,7 @@ export async function deriveLabelsCommand(opts: DeriveLabelsOptions): Promise<vo
       ? await assembleAuthoredCertifyingCorpus(
           {
             gate1Dir,
-            // gate-1 lives at `.totem/spine/gate-1` → `.totem` is two dirs up (convention),
-            // overridable for tests / non-standard layouts.
-            totemDir: opts.totemDir
-              ? path.resolve(cwd, opts.totemDir)
-              : path.dirname(path.dirname(gate1Dir)),
+            totemDir: resolveAuthoredTotemDir(lockPath, cwd, opts.totemDir),
             stage4,
             now,
           },

--- a/packages/cli/src/commands/spine-derive-labels.ts
+++ b/packages/cli/src/commands/spine-derive-labels.ts
@@ -19,6 +19,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import {
+  assembleAuthoredCertifyingCorpus,
   assembleCertifyingCorpus,
   buildGate1Stage4Deps,
   CORPUS_DISPOSITIONS_FILE,
@@ -35,6 +36,12 @@ export interface DeriveLabelsOptions {
   lcDir?: string;
   /** Gate-1 output dir (default: the lock's dir). */
   outputDir?: string;
+  /**
+   * The `.totem` dir holding the authored producer's `spine/authored-rules.yaml` + ledger
+   * (authored producer only). Defaults to the convention `<gate1Dir>/../..` (gate-1 lives at
+   * `.totem/spine/gate-1`). Injected explicitly for tests + non-conventional layouts (D2.6).
+   */
+  totemDir?: string;
   /** Working dir (default `process.cwd()`; injected for tests). */
   cwd?: string;
 }
@@ -148,10 +155,28 @@ export async function deriveLabelsCommand(opts: DeriveLabelsOptions): Promise<vo
   // — it does not enter rule compilation or the content-based labelId — so it cannot break
   // the byte-identical guarantee even if a future run set it. Thread it through both the
   // run and the deriver together if it ever becomes a real RunOption.
-  const { corpus } = await assembleCertifyingCorpus(
-    { gate1Dir, stage4, now, skipGroundTruth: true },
-    lock,
-  );
+  // ADR-112 §6 D2.6: an AUTHORED lock assembles the corpus from the authored substrate
+  // (window-wide, via the derive-path sibling); a MINED lock keeps the byte-unchanged replay
+  // assembly. Both skip ground-truth (the deriver PRODUCES it). The producerKind read lives
+  // here in the producer command — the RUN-path §8 single home (resolveCertifyingCorpusProvider)
+  // is untouched (gemini single-home ruling); the mined deriver already bypasses it likewise.
+  const producerKind = lock.producerKind ?? 'mined';
+  const { corpus } =
+    producerKind === 'authored'
+      ? await assembleAuthoredCertifyingCorpus(
+          {
+            gate1Dir,
+            // gate-1 lives at `.totem/spine/gate-1` → `.totem` is two dirs up (convention),
+            // overridable for tests / non-standard layouts.
+            totemDir: opts.totemDir
+              ? path.resolve(cwd, opts.totemDir)
+              : path.dirname(path.dirname(gate1Dir)),
+            stage4,
+            now,
+          },
+          lock,
+        )
+      : await assembleCertifyingCorpus({ gate1Dir, stage4, now, skipGroundTruth: true }, lock);
   const built = await buildCertifyingFirings({
     rules: corpus.rules,
     prDiffs: corpus.prDiffs,

--- a/packages/cli/src/commands/spine-fetch-dispositions.test.ts
+++ b/packages/cli/src/commands/spine-fetch-dispositions.test.ts
@@ -10,6 +10,7 @@ import type { CorpusDisposition } from '@mmnto/totem';
 import {
   type CorpusDispositionSource,
   corpusHeldOutPrs,
+  corpusWindowPrs,
   fetchDispositionsCommand,
 } from './spine-fetch-dispositions.js';
 
@@ -28,6 +29,41 @@ describe('corpusHeldOutPrs', () => {
     expect(
       corpusHeldOutPrs({ heldOutPrs: [7, 11], positiveControlPrs: [7], negativeControlPrs: [11] }),
     ).toEqual([]);
+  });
+});
+
+describe('corpusWindowPrs (D2.6 authored window)', () => {
+  it('is (train ∪ heldOut) minus controls, deduped + ascending', () => {
+    expect(
+      corpusWindowPrs({
+        trainPrs: [3, 5],
+        heldOutPrs: [3, 7, 9, 11], // 3 also in train → deduped
+        positiveControlPrs: [7],
+        negativeControlPrs: [11],
+      }),
+    ).toEqual([3, 5, 9]);
+  });
+
+  it('keeps a TRAIN-side non-control PR that corpusHeldOutPrs drops (the D2.6 reason)', () => {
+    const split = {
+      trainPrs: [3],
+      heldOutPrs: [5, 7, 9],
+      positiveControlPrs: [7],
+      negativeControlPrs: [9],
+    };
+    expect(corpusWindowPrs(split)).toEqual([3, 5]); // window keeps the train-side 3
+    expect(corpusHeldOutPrs(split)).toEqual([5]); // held-out-only drops it
+  });
+
+  it('excludes a train PR that is itself a control', () => {
+    expect(
+      corpusWindowPrs({
+        trainPrs: [7],
+        heldOutPrs: [5],
+        positiveControlPrs: [7],
+        negativeControlPrs: [],
+      }),
+    ).toEqual([5]);
   });
 });
 
@@ -129,6 +165,24 @@ describe('fetchDispositionsCommand', () => {
     // heldOut [5,7,9], controls {7,9} → only PR 5 is a corpus disposition.
     expect(written.map((d: CorpusDisposition) => d.pr)).toEqual([5]);
     expect(written[0].threads[0].diffHunk).toBe('@@ pr5 @@\n+line');
+  });
+
+  it('an AUTHORED lock freezes WINDOW-WIDE dispositions (train ∪ held-out non-control: 3 and 5)', async () => {
+    // Flip the fixture lock to producerKind:authored (fetch-dispositions reads only the kind).
+    const lock = JSON.parse(fs.readFileSync(path.join(dir, 'windtunnel.lock.json'), 'utf-8'));
+    lock.producerKind = 'authored';
+    lock.authored = { expectedSplitRef: 'split-cert-1' };
+    fs.writeFileSync(path.join(dir, 'windtunnel.lock.json'), JSON.stringify(lock, null, 2));
+    await fetchDispositionsCommand({
+      lockPath: path.join(dir, 'windtunnel.lock.json'),
+      cwd: dir,
+      source: fakeSource,
+    });
+    const written = JSON.parse(
+      fs.readFileSync(path.join(dir, 'corpus-dispositions.json'), 'utf-8'),
+    );
+    // split train [3] ∪ heldOut [5,7,9] minus controls {7,9} → [3,5] (mined would be [5]).
+    expect(written.map((d: CorpusDisposition) => d.pr)).toEqual([3, 5]);
   });
 
   it('stamps corpusDispositionsSha = sha256 of the exact on-disk bytes', async () => {

--- a/packages/cli/src/commands/spine-fetch-dispositions.ts
+++ b/packages/cli/src/commands/spine-fetch-dispositions.ts
@@ -49,6 +49,27 @@ export function corpusHeldOutPrs(split: {
   return split.heldOutPrs.filter((pr) => !controls.has(pr)).sort((a, b) => a - b);
 }
 
+/**
+ * ADR-112 §6/§5.3 Slice D2.6 — the WINDOW-WIDE corpus PRs for an AUTHORED producer:
+ * `(trainPrs ∪ heldOutPrs)` minus the positive/negative controls, deduped + ascending.
+ * The authored analogue of `corpusHeldOutPrs`: authored positive controls are TRAIN-side,
+ * so a held-out-only answer key leaves their corpus firings unlabeled → permanent
+ * HONEST-NEGATIVE (a run that can never PASS; totem-agy's D2 mechanical proof). The window
+ * spans train + held-out so those train-side firings get a disposition to label against.
+ * Pure split-math (no `producerKind` read here — the command picks the selector).
+ */
+export function corpusWindowPrs(split: {
+  trainPrs: number[];
+  heldOutPrs: number[];
+  positiveControlPrs: number[];
+  negativeControlPrs: number[];
+}): number[] {
+  const controls = new Set([...split.positiveControlPrs, ...split.negativeControlPrs]);
+  return [...new Set([...split.trainPrs, ...split.heldOutPrs])]
+    .filter((pr) => !controls.has(pr))
+    .sort((a, b) => a - b);
+}
+
 export async function fetchDispositionsCommand(opts: FetchDispositionsOptions): Promise<void> {
   const {
     WindtunnelLockSchema,
@@ -91,12 +112,19 @@ export async function fetchDispositionsCommand(opts: FetchDispositionsOptions): 
   const lock = WindtunnelLockSchema.parse(readJsonFile(lockPath));
   const split = SplitArtifactSchema.parse(readJsonFile(path.join(gate1Dir, 'split.json')));
 
-  const prs = corpusHeldOutPrs(split);
+  // ADR-112 §6 D2.6: an AUTHORED producer needs a WINDOW-WIDE disposition set (train +
+  // held-out non-control) so its train-side positive controls get labeled; a MINED
+  // producer keeps the held-out-only scope (byte-unchanged). The kind-read lives here at
+  // the command layer, not in the pure selector (mirrors corpusHeldOutPrs/corpusWindowPrs).
+  const producerKind = lock.producerKind ?? 'mined';
+  const prs = producerKind === 'authored' ? corpusWindowPrs(split) : corpusHeldOutPrs(split);
   if (prs.length === 0) {
     throw new TotemError(
       'CONFIG_INVALID',
-      'fetch-dispositions: the split has no held-out CORPUS PRs (all held-out PRs are controls).',
-      'A cert corpus needs ≥1 non-control held-out PR for the answer key to label.',
+      producerKind === 'authored'
+        ? 'fetch-dispositions: the split has no non-control window PRs (every train ∪ held-out PR is a control).'
+        : 'fetch-dispositions: the split has no held-out CORPUS PRs (all held-out PRs are controls).',
+      'A cert corpus needs ≥1 non-control PR for the answer key to label.',
     );
   }
 
@@ -156,7 +184,9 @@ export async function fetchDispositionsCommand(opts: FetchDispositionsOptions): 
 
   const threadCount = validated.reduce((n, d) => n + d.threads.length, 0);
   console.error(`[FetchDispositions] gate1Dir: ${gate1Dir}`);
-  console.error(`  held-out corpus PRs: ${prs.length} · review threads: ${threadCount}`);
+  console.error(
+    `  ${producerKind === 'authored' ? 'window' : 'held-out'} corpus PRs: ${prs.length} · review threads: ${threadCount}`,
+  );
   console.error(
     `  corpusDispositionsSha: ${corpusDispositionsSha} (stamped into ${path.basename(lockPath)})`,
   );


### PR DESCRIPTION
## What
Under `producerKind:'authored'`, the cert-run answer key (`ground-truth-labels.json`) is now derived **window-wide** (train ∪ held-out non-control), not held-out-only. Mined behavior is **byte-unchanged**.

- **`corpusWindowPrs(split)`** (`spine-fetch-dispositions`) — pure sibling of `corpusHeldOutPrs` = `(trainPrs ∪ heldOutPrs)` − controls, deduped + ascending. `fetch-dispositions` branches on `producerKind` (scope-aware empty-check + log).
- **`assembleAuthoredCertifyingCorpus(opts, lock)`** (`spine-cert-run-corpus`) — the derive-path sibling of `assembleCertifyingCorpus`. Loads the authored substrate with **ground-truth skipped** (the deriver PRODUCES the key — circularity guard) while still hash-binding the scoring source (`prDiffsSha`); builds via the existing `buildAuthoredCertifyingCorpus`. `loadAuthoredCertRunFixtures` gains an additive `skipGroundTruth` param (parity with mined `loadCertRunFixtures`).
- **`derive-labels`** — producerKind-aware + injectable `totemDir` (defaults to the `.totem/spine/gate-1` convention).

## Why
Authored positive controls are **train-side**. A held-out-only answer key leaves their corpus firings unlabeled → `needsAdjudication` → a run that can **never PASS** (permanent HONEST-NEGATIVE; totem-agy's D2 mechanical proof). §6/§5.3 requires window-wide derivation. The §6 follow-on split out of D2.5.

## §8 gate — additive sibling, resolver untouched
The RUN-path §8 single-home dispatch (`resolveCertifyingCorpusProvider`) is **not modified**. The producer commands (`fetch-dispositions`, `derive-labels`) read `producerKind` at the command layer, mirroring how the mined deriver already bypasses the resolver. Confirmed against the gemini single-home ruling; strategy's 2026-07-01 ruling named this exact shape as additive-sibling with **no §8 re-decision owed**. Contract settled in ADR-112 §6/§5.3 — no new core ruling.

## Tests (45 pass across the affected suites)
- `corpusWindowPrs` set-math incl. the anti-regression: a train-side non-control PR the held-out-only key drops.
- `fetch-dispositions` authored → window-wide `[3,5]` vs mined `[5]`.
- `assembleAuthoredCertifyingCorpus`: derives WITHOUT `groundTruthSha` + never reads the key (circularity), still hash-binds pr-diffs, require-when-authored + missing-prDiffsSha guards.
- `loadAuthoredCertRunFixtures` skipGroundTruth (tolerates absent key, first-derive).

## Scope
Still **INERT until D3** (scoring ignores `authoredControls`; no production authored lock exists). Full gate green: `pnpm -r build`, `totem lint` (PASS), ESLint (0 errors), prettier, changeset (fixed-group minor).

Part of ADR-112 (Convergent Spine). closingRefs []. Couple-on-merge available to strategy (additive sibling — no §8 pin owed).
