### PR TITLE
fix(700): prune-outbox fail-soft readdir honest exit-1 — re-sync to source-of-truth (strategy#794)

### DIFF
--- a/scripts/prune-outbox.mjs
+++ b/scripts/prune-outbox.mjs
@@ -144,17 +144,21 @@ const cutoff = cutoffKey(args.days);
 let kept = 0;
 const pruned = [];
 const skipped = []; // not a regular file, or no derivable age from filename — never touched
-const failed = []; // unlink errors — surfaced, never abort signoff
+const failed = []; // unlink + non-ENOENT readdir errors — surfaced, drive the honest exit-1
 
 if (existsSync(outbox)) {
-  // Fail-soft read (Tenet 4): a raced removal or EACCES between existsSync and
-  // the read must not throw uncaught — that would skip the whole report, the
-  // opposite of the per-item fail-soft the unlinkSync path guarantees below.
+  // Fail-soft read: a read failure must not throw uncaught — that would skip the
+  // whole report. But stay HONEST (Tenet 4): a raced removal (ENOENT — the outbox
+  // vanished between the existsSync check and the read) is benign (nothing to
+  // prune → exit 0); any other failure (EACCES / permission drift) is pushed to
+  // `failed` so the honest exit surfaces it with code 1 — symmetric with the
+  // unlinkSync path below. Either way the report still emits (GCA, mmnto-ai/totem-strategy#794).
   let dirents = [];
   try {
     dirents = readdirSync(outbox, { withFileTypes: true });
   } catch (err) {
-    process.stderr.write(`prune: failed to read outbox ${outbox}: ${err.message}\n`);
+    process.stderr.write(`prune: failed to read outbox ${outbox}: ${err?.message ?? err}\n`);
+    if (err?.code !== 'ENOENT') failed.push(`readdir:${err?.code || 'UNKNOWN'}`);
   }
   for (const dirent of dirents) {
     const f = dirent.name;


### PR DESCRIPTION
## What

Re-syncs totem's copy of `scripts/prune-outbox.mjs` to the cohort **source-of-truth** on the `readdir` catch block. totem's merged copy (from totem#2278) trailed after strategy landed the GCA-caught refinement in `mmnto-ai/totem-strategy#794` (`89ae834`) + `mmnto-ai/totem-status#87` (`0ccc551`).

## Why

The trailing catch swallowed a **non-ENOENT** read failure (EACCES / ENOTDIR / permission drift) to stderr and **still exited 0** — breaking the honest-exit symmetry the `unlinkSync` path already guarantees (Tenet 4). A prune that can't read its outbox should not report success.

## Change (byte-parity with the merged source)

```js
} catch (err) {
  process.stderr.write(`prune: failed to read outbox ${outbox}: ${err?.message ?? err}\n`);
  if (err?.code !== 'ENOENT') failed.push(`readdir:${err?.code || 'UNKNOWN'}`);
}
```

- **ENOENT stays soft** — a raced removal (outbox vanished between `existsSync` and the read) is benign → nothing to prune → exit 0.
- **Any other code** → `failed.push('readdir:'+code)` → the report still emits → **exit 1**.
- **Optional-chained `err`** (`err?.message ?? err` / `err?.code`) so a pathological non-Error throw can't `TypeError` inside the catch and defeat the fail-soft (a catch that can itself throw is a hole in a never-abort script).
- `failed` decl + fail-soft comments updated to the source wording (qualified issue ref).

## Verification

- **ENOTDIR** (outbox path is a file, so `existsSync` true but `readdirSync` throws) → `FAILED 1` report + **exit 1**. ✅
- **Benign ENOENT** → exit 0. ✅
- **Dry-run** on a healthy outbox → exit 0. ✅
- `prettier --check` clean; `format:check` covers scripts/. No package touched → **no changeset** (symmetric to strategy#794, which merged with only this file and no changeset).

## Scope

Single file, functional region **byte-identical** to `strategy#794 89ae834`. Closes the last trailing copy in the strategy#700 script-propagation loop (that cross-repo tracking issue is strategy-owned; no closing keyword here).