### PR TITLE
feat(spine): ADR-112 §5.3/§6/§8 Slice D3 — authored window-tunnel scorer (inert-until-D4)

### DIFF
--- a/.changeset/adr112-d3-authored-scorer.md
+++ b/.changeset/adr112-d3-authored-scorer.md
@@ -1,0 +1,13 @@
+---
+'@mmnto/totem': minor
+---
+
+ADR-112 §5.3/§6/§8 Slice D3 — the AUTHORED window-tunnel scorer (`scoreAuthoredWindtunnel`), inert-until-D4.
+
+The sibling scorer that consumes the §6 authored controls (built inert across D1–D2.6) and the window-wide answer key (D2.6) to produce a certifying verdict for an authored rule window. Per strategy's Q1 ruling (2026-07-01) it **reduces to the mined `scoreWindtunnel`, it does not fork it** — a fork would violate the §5.3 content-blind-scorer invariant + §9 one-PASS/FAIL-meaning. The mined cascade is reused byte-unchanged; the authored layer only normalizes the controls into a `ScorerInput`, applies a pre-scorer non-emission gate, and appends a verdict-inert O3 metric.
+
+- **Positive-target projection** — `positiveControlTargets` is derived from `authoredControls.positive[]` (only `differential-holds` fixtures reach that list, discharged at emission), so the mined scorer never re-proves the postimage leg.
+- **Non-emission gate** (the load-bearing fold) — a culled differential (empty `positive[]` + a recorded `nonEmissions[]`) can no longer reach the mined scorer as `positiveControlTargets: []` and pass silently. An `illegitimate` non-emission is a Gate-1 FAIL-equivalent; an `undecidable`/`deferred` one is not-certifiable (HONEST-NEGATIVE). The gate is demote-only and per-non-emission (a holding control does not launder an illegitimate sibling). Recorded in an `authoredControlGate` audit field (no silent skip, Tenet-4).
+- **O3 metric** (`heldOutActivationsByRule`, verdict-inert) — per authored rule under test, the count of its non-control (`corpus`) firings on held-out PRs. Keys are join-back-derived from the positive controls' `targetRuleId` (Tenet-20; a zero-activation rule still appears — the rare-defect case). Culled rules are excluded. The Gate-2-eligible SET derivation is deferred to D4.
+
+Pure function (no IO/clock/LLM; Tenet-15 deterministic), offline-unit-tested in `@mmnto/core` (14 cases). **Inert** — not wired into any cert run; `spine-windtunnel` stays on the mined scorer until slice D4 flips the authored path reachable (D4 owes the whole-path couple-on-merge: scorer + the no-mint gate + the §6 deriver, end-to-end).

--- a/.totem/specs/d3-authored-scorer.md
+++ b/.totem/specs/d3-authored-scorer.md
@@ -1,0 +1,119 @@
+# ADR-112 Slice D3 — the authored window-tunnel scorer (`scoreAuthoredWindtunnel`)
+
+**Status:** design pinned by the converged 4-seat pre-build panel (strategy 0754Z / codex 0821Z /
+agy 0840Z / gemini 0910Z, 2026-07-01). Build-inert, offline-unit-tested in `@mmnto/core`. NO CLI
+wiring — `spine-windtunnel.ts` stays on the mined scorer until D4 flips the authored path reachable.
+
+## What it is
+
+The sibling scorer that consumes the §6 authored controls (built inert across D1–D2.6) and the
+window-wide answer key (D2.6) to produce a certifying verdict for an **authored** rule window. Per
+strategy's Q1 ruling it **REDUCES to the mined `scoreWindtunnel`, never forks it** (a fork violates
+the §5.3 content-blind-scorer invariant + §9 one-PASS/FAIL-meaning — contract-illegal). The mined
+cascade is reused **byte-unchanged**; the authored layer only (a) normalizes its inputs into a
+`ScorerInput`, (b) applies a pre-scorer non-emission gate, and (c) appends a verdict-inert O3 metric.
+
+## Reduction (the three moves)
+
+1. **Positive-target projection.** `positiveControlTargets` for the mined scorer is DERIVED from
+   `authoredControls.positive[]` — project `{ pr, targetRuleId }`. Only `differential-holds`
+   fixtures reach `positive[]` (discharged at emission in `authored-controls.ts:373`), so the mined
+   scorer does NOT re-prove the postimage leg.
+
+2. **Non-emission gate (codex's load-bearing fold).** A culled differential (empty `positive[]` +
+   a recorded `nonEmissions[]` entry) must NOT reach the mined scorer as `positiveControlTargets: []`
+   and silently PASS. Consume `authoredControls.nonEmissions[]` BEFORE trusting the mined verdict:
+   - `class:'illegitimate'` (fix-shaped / over-match / vacuous-silent) → **Gate-1 FAIL-equivalent**.
+     The control is not a legitimate control; the window is not certifiable → **FAIL**.
+   - `class:'undecidable'` / `'deferred'` → **not-certifiable** → **HONEST-NEGATIVE**. Never a
+     silent skip (Tenet-4).
+   - The gate is **demote-only** (mirrors the mined scorer's "a guard may DEMOTE a would-be PASS,
+     never UPGRADE a FAIL"): it can only worsen the mined verdict, never improve it.
+   - **Per-non-emission, not per-empty-list** (codex's mixed case): a rule with one emitted (holding)
+     positive control AND one illegitimate non-emission still FAILs — the illegitimate entry must
+     not vanish behind the emitted control's global non-vacuity.
+
+3. **O3 held-out-activation metric (verdict-inert post-pass).** Emit
+   `heldOutActivationsByRule: Record<targetRuleId, count>` — per authored rule under test, the count
+   of its **non-control** (`controlKind === 'corpus'`) firings on **held-out** PRs. Keys are
+   **join-back-derived** from `authoredControls.positive[].targetRuleId` (Tenet-20 — never inlined
+   from the firings; a firing-only derivation would silently drop a rule with zero held-out
+   activations, the rare-defect case). **Culled** rules (fired a negative control) are excluded from
+   the metric AND its keys. Strategy Q2: this metric is **verdict-inert** — never consulted for the
+   verdict, and D3 emits ONLY the raw metric. The **Gate-2-eligible SET derivation is DEFERRED to
+   D4** (gemini report-shape ruling + strategy Q2) — no set at D3 means no set to wrongly admit a
+   zero-held-out rule into (sidesteps agy's §1(k) conflict).
+
+## Input / output
+
+```ts
+// Omit positiveControlTargets — it is DERIVED from authoredControls.positive.
+export interface AuthoredScorerInput extends Omit<ScorerInput, 'positiveControlTargets'> {
+  /** The §6 answer key from deriveAuthoredControls (positive + the kept non-emissions). */
+  authoredControls: Pick<AuthoredControls, 'positive' | 'nonEmissions'>;
+  /** Held-out (scored-slice) PR numbers — the O3 partition. From split.heldOutPrs at D4. */
+  heldOutPrs: ReadonlySet<number>;
+}
+
+export interface AuthoredWindtunnelVerdict extends WindtunnelVerdict {
+  /** O3 (verdict-inert): targetRuleId → held-out non-control activation count. Join-back keyed. */
+  heldOutActivationsByRule: Record<string, number>;
+  /** Audit trail for the non-emission gate — observable, never re-consulted (Tenet-4, no silent skip). */
+  authoredControlGate: {
+    illegitimate: number;
+    undecidable: number;
+    deferred: number;
+    effect: 'none' | 'fail-illegitimate' | 'honest-negative-not-certifiable';
+  };
+}
+```
+
+`firings` carries the MERGED train + held-out firings (train FP → window-wide FAIL, test (b));
+`heldOutPrs` partitions them for the O3 metric only. `exposureFloors` / `actualExposure` are passed
+straight through — D3 does not recompute exposure (train-side positive controls only; test (g)).
+
+## Verdict precedence (combining the mined verdict with the gate)
+
+From strongest, the effective verdict is:
+
+1. A real **FP FAIL** from the mined scorer (`verdict === 'FAIL'`, `precision !== null`) — the FP is a
+   real defect measurement; keep FAIL and keep the breaching precision (evidence).
+2. **illegitimate** non-emission present → **FAIL** (`precision: null`, `effect: 'fail-illegitimate'`).
+3. A structural **FAIL** from the mined scorer (vacuous positive control) — FAIL, precision null.
+4. **undecidable/deferred** non-emission present (no illegitimate, mined verdict not FAIL) →
+   **HONEST-NEGATIVE** (`precision: null`, `effect: 'honest-negative-not-certifiable'`).
+5. Otherwise the mined verdict passes through unchanged (`effect: 'none'`).
+
+### Build-altitude micro-decision to flag for strategy (couple-on-merge)
+
+When an **illegitimate non-emission co-occurs with a real FP FAIL** (tier 1 vs tier 2 both apply):
+this design keeps the FP's breaching precision (a real measurement survives a structural control
+defect — the FP is evidence about OTHER rules' firings, independent of the bad control). The
+alternative (null the precision because the certification apparatus is compromised) is defensible
+too. Both FAIL; only `precision` differs. Chosen: **keep the FP precision.** Flag this as a
+build-altitude sub-decision in the PR + couple-on-merge — strategy owns the §5.3/§9 precision-claim
+semantics and may rule the other way (a one-line flip if so).
+
+## Test matrix (agy (a)–(g) + codex ×2)
+
+- (a) rare-defect: valid train positive control fires → PASS, `heldOutActivationsByRule[rule] === 0`
+  (present with 0 — join-back key, NO Gate-2 exemption; the set defers to D4).
+- (b) train-slice FP → window-wide FAIL.
+- (c) a rule's own control firing (`controlKind !== 'corpus'`) is EXCLUDED from the held-out count.
+- (d) cull symmetry: a rule that fired a negative control is out of `heldOutActivationsByRule` (and
+  its keys) even with otherwise-valid held-out firings.
+- (e) window-wide unlabeled firing → HONEST-NEGATIVE (mined `needsAdjudication`).
+- (f) FP FAIL outranks generalization: a heavily-generalizing rule with an FP still FAILs; metric
+  stays inert.
+- (g) exposure counts train-side controls only — held-out activations do NOT inflate
+  `positiveControlsExercised`.
+- (codex-1) all-positives-non-emission (illegitimate) + no ordinary FP must NOT be PASS → FAIL.
+- (codex-2) mixed emitted + illegitimate: the illegitimate must not vanish behind the emitted
+  control's non-vacuity → FAIL.
+
+## Non-goals (held to D4)
+
+- Wiring `spine-windtunnel.ts` to the authored scorer (the inert→enforced flip; owes the whole-path
+  couple-on-merge — scorer + #793 no-mint gate + §6 deriver end-to-end).
+- Deriving the Gate-2-eligible SET (survivors ∩ held-out-exercised).
+- Any git / IO / clock / LLM — the scorer is a pure function (Tenet-15 deterministic).

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1050,6 +1050,13 @@ export type {
   WindtunnelVerdictKind,
 } from './spine/windtunnel-scorer.js';
 export { scoreWindtunnel } from './spine/windtunnel-scorer.js';
+export type {
+  AuthoredControlGate,
+  AuthoredControlGateEffect,
+  AuthoredScorerInput,
+  AuthoredWindtunnelVerdict,
+} from './spine/windtunnel-scorer-authored.js';
+export { scoreAuthoredWindtunnel } from './spine/windtunnel-scorer-authored.js';
 
 // ─── Layer-B cohort-capability ledger (totem-strategy#697) ───────────────────
 export type {

--- a/packages/core/src/spine/windtunnel-scorer-authored.test.ts
+++ b/packages/core/src/spine/windtunnel-scorer-authored.test.ts
@@ -1,0 +1,393 @@
+import { describe, expect, it } from 'vitest';
+
+import type { AuthoredNonEmission, AuthoredPositiveControl } from './authored-controls.js';
+import { firingLabelId } from './windtunnel-lock.js';
+import type { GroundTruthLabel, RuleFiring } from './windtunnel-scorer.js';
+import type { AuthoredScorerInput } from './windtunnel-scorer-authored.js';
+import { scoreAuthoredWindtunnel } from './windtunnel-scorer-authored.js';
+
+// ─── Helpers ─────────────────────────────────────────
+
+function makeFiring(
+  ruleId: string,
+  pr: number,
+  controlKind: RuleFiring['controlKind'],
+  matchedLine = 'const x = 1;',
+  filePath = 'src/foo.ts',
+): RuleFiring {
+  return {
+    ruleId,
+    pr,
+    filePath,
+    matchedLine,
+    controlKind,
+    labelId: firingLabelId(ruleId, pr, filePath, matchedLine),
+  };
+}
+
+function posControl(
+  targetRuleId: string,
+  pr: number,
+  overrides?: Partial<AuthoredPositiveControl>,
+): AuthoredPositiveControl {
+  return {
+    pr,
+    targetRuleId,
+    filePath: 'src/foo.ts',
+    matchedSpan: 'L1-L1',
+    ...overrides,
+  };
+}
+
+function nonEmission(
+  targetRuleId: string,
+  pr: number,
+  outcome: AuthoredNonEmission['outcome'],
+  cls: AuthoredNonEmission['class'],
+  reason?: string,
+): AuthoredNonEmission {
+  return {
+    targetRuleId,
+    pr,
+    outcome,
+    class: cls,
+    ...(reason !== undefined ? { reason } : {}),
+  };
+}
+
+/**
+ * A baseline authored input. Exposure floors are all 0 so a clean run reaches the
+ * mined scorer's PASS tier unless a test trips a specific guard; `actualExposure`
+ * mirrors the mined caller (train-side positive count in the third leg).
+ */
+function baseInput(overrides?: Partial<AuthoredScorerInput>): AuthoredScorerInput {
+  return {
+    firings: [],
+    groundTruth: new Map(),
+    mintedRuleIds: ['rule-a'],
+    cullRateThreshold: 0.5,
+    exposureFloors: {
+      activeRulesEvaluated: 0,
+      filesTouchedInWindow: 0,
+      positiveControlsExercised: 0,
+    },
+    actualExposure: {
+      activeRulesEvaluated: 1,
+      filesTouchedInWindow: 5,
+      positiveControlsExercised: 1,
+    },
+    authoredControls: { positive: [], nonEmissions: [] },
+    heldOutPrs: new Set<number>(),
+    ...overrides,
+  };
+}
+
+/** A TP-labeled ground truth for the given firings' labelIds. */
+function labelAll(firings: RuleFiring[], label: GroundTruthLabel): Map<string, GroundTruthLabel> {
+  return new Map(firings.map((f) => [f.labelId, label] as const));
+}
+
+// ─── Reduction baseline: a clean authored run reduces to a mined PASS ─────────
+
+describe('reduces to scoreWindtunnel (Q1: reduce, never fork)', () => {
+  it('a clean authored run (holding positive control, no FP) → PASS, gate effect none', () => {
+    const ctrl = makeFiring('rule-a', 10, 'positive');
+    const result = scoreAuthoredWindtunnel(
+      baseInput({
+        authoredControls: { positive: [posControl('rule-a', 10)], nonEmissions: [] },
+        firings: [ctrl],
+        groundTruth: labelAll([ctrl], 'TP'),
+        heldOutPrs: new Set([20]),
+      }),
+    );
+    expect(result.verdict).toBe('PASS');
+    expect(result.nonVacuity).toBe(true);
+    expect(result.authoredControlGate.effect).toBe('none');
+    // Join-back key present with 0 — rare-defect (a) shape, no held-out activation.
+    expect(result.heldOutActivationsByRule).toEqual({ 'rule-a': 0 });
+  });
+});
+
+// ─── (a) rare-defect: valid train control, zero held-out → PASS + key===0 ─────
+
+describe('(a) rare-defect: train control fires, heldOut===0, no Gate-2 exemption', () => {
+  it('PASS with heldOutActivationsByRule[rule]===0 (present, not omitted)', () => {
+    const ctrl = makeFiring('rule-a', 10, 'positive');
+    const result = scoreAuthoredWindtunnel(
+      baseInput({
+        authoredControls: { positive: [posControl('rule-a', 10)], nonEmissions: [] },
+        firings: [ctrl],
+        groundTruth: labelAll([ctrl], 'TP'),
+        heldOutPrs: new Set([20, 21]),
+      }),
+    );
+    expect(result.verdict).toBe('PASS');
+    expect(result.heldOutActivationsByRule).toEqual({ 'rule-a': 0 });
+  });
+});
+
+// ─── (b) train-slice FP → window-wide FAIL ───────────────────────────────────
+
+describe('(b) train-slice FP → window-wide FAIL', () => {
+  it('a corpus firing on a TRAIN pr labeled FP fails the whole window', () => {
+    const ctrl = makeFiring('rule-a', 10, 'positive');
+    const fp = makeFiring('rule-a', 10, 'corpus', 'bad(train);'); // train pr, not in heldOutPrs
+    const result = scoreAuthoredWindtunnel(
+      baseInput({
+        authoredControls: { positive: [posControl('rule-a', 10)], nonEmissions: [] },
+        firings: [ctrl, fp],
+        groundTruth: new Map<string, GroundTruthLabel>([
+          [ctrl.labelId, 'TP'],
+          [fp.labelId, 'FP'],
+        ]),
+        heldOutPrs: new Set([20]),
+      }),
+    );
+    expect(result.verdict).toBe('FAIL');
+    expect(result.precision).not.toBeNull();
+    expect(result.authoredControlGate.effect).toBe('none');
+  });
+});
+
+// ─── (c) own-control firing excluded from the held-out count ──────────────────
+
+describe('(c) O3 excludes a rule’s own control firing from the held-out count', () => {
+  it('only controlKind=corpus firings on held-out prs count', () => {
+    const ctrl = makeFiring('rule-a', 10, 'positive');
+    const heldCorpus = makeFiring('rule-a', 20, 'corpus', 'gen();');
+    const heldOwnControl = makeFiring('rule-a', 20, 'positive', 'ctrl-on-held();');
+    const result = scoreAuthoredWindtunnel(
+      baseInput({
+        authoredControls: { positive: [posControl('rule-a', 10)], nonEmissions: [] },
+        firings: [ctrl, heldCorpus, heldOwnControl],
+        groundTruth: labelAll([ctrl, heldCorpus], 'TP'),
+        heldOutPrs: new Set([20]),
+      }),
+    );
+    // The held-out control-kind firing is NOT counted; only the corpus one is.
+    expect(result.heldOutActivationsByRule).toEqual({ 'rule-a': 1 });
+  });
+});
+
+// ─── (d) cull symmetry: a culled rule is out of the metric + its keys ─────────
+
+describe('(d) negative-control cull symmetry', () => {
+  it('a culled rule is excluded from heldOutActivationsByRule even with valid held-out firings', () => {
+    const neg = makeFiring('rule-a', 99, 'negative', 'near-miss;');
+    const heldCorpus = makeFiring('rule-a', 20, 'corpus', 'gen();');
+    const result = scoreAuthoredWindtunnel(
+      baseInput({
+        authoredControls: { positive: [posControl('rule-a', 10)], nonEmissions: [] },
+        firings: [neg, heldCorpus],
+        groundTruth: labelAll([heldCorpus], 'TP'),
+        heldOutPrs: new Set([20]),
+        mintedRuleIds: ['rule-a'],
+      }),
+    );
+    expect(result.culledCount).toBe(1);
+    // rule-a is culled → excluded from the metric ENTIRELY (not even a 0 key).
+    expect(result.heldOutActivationsByRule).toEqual({});
+  });
+});
+
+// ─── (e) window-wide unlabeled → HONEST-NEGATIVE ──────────────────────────────
+
+describe('(e) window-wide unlabeled firing → HONEST-NEGATIVE', () => {
+  it('an unlabeled corpus firing routes to needsAdjudication → HN', () => {
+    const ctrl = makeFiring('rule-a', 10, 'positive');
+    const unlabeled = makeFiring('rule-a', 20, 'corpus', 'mystery();');
+    const result = scoreAuthoredWindtunnel(
+      baseInput({
+        authoredControls: { positive: [posControl('rule-a', 10)], nonEmissions: [] },
+        firings: [ctrl, unlabeled],
+        groundTruth: labelAll([ctrl], 'TP'), // unlabeled has no entry
+        heldOutPrs: new Set([20]),
+      }),
+    );
+    expect(result.verdict).toBe('HONEST-NEGATIVE');
+    expect(result.needsAdjudication).toContain(unlabeled.labelId);
+    expect(result.authoredControlGate.effect).toBe('none');
+  });
+});
+
+// ─── (f) FP FAIL outranks generalization ──────────────────────────────────────
+
+describe('(f) FP FAIL outranks generalization', () => {
+  it('a heavily generalizing rule with an FP still FAILs; metric stays inert', () => {
+    const ctrl = makeFiring('rule-a', 10, 'positive');
+    const g1 = makeFiring('rule-a', 20, 'corpus', 'gen-1();');
+    const g2 = makeFiring('rule-a', 21, 'corpus', 'gen-2();');
+    const g3fp = makeFiring('rule-a', 22, 'corpus', 'gen-3-bad();');
+    const result = scoreAuthoredWindtunnel(
+      baseInput({
+        authoredControls: { positive: [posControl('rule-a', 10)], nonEmissions: [] },
+        firings: [ctrl, g1, g2, g3fp],
+        groundTruth: new Map<string, GroundTruthLabel>([
+          [ctrl.labelId, 'TP'],
+          [g1.labelId, 'TP'],
+          [g2.labelId, 'TP'],
+          [g3fp.labelId, 'FP'],
+        ]),
+        heldOutPrs: new Set([20, 21, 22]),
+      }),
+    );
+    expect(result.verdict).toBe('FAIL');
+    // Metric is verdict-inert: it still reports all 3 held-out activations.
+    expect(result.heldOutActivationsByRule).toEqual({ 'rule-a': 3 });
+  });
+});
+
+// ─── (g) exposure counts train-side controls only ─────────────────────────────
+
+describe('(g) exposure floor counts train-side controls only', () => {
+  it('held-out activations do not inflate positiveControlsExercised', () => {
+    const ctrl = makeFiring('rule-a', 10, 'positive');
+    const held1 = makeFiring('rule-a', 20, 'corpus', 'gen-1();');
+    const held2 = makeFiring('rule-a', 21, 'corpus', 'gen-2();');
+    const result = scoreAuthoredWindtunnel(
+      baseInput({
+        authoredControls: { positive: [posControl('rule-a', 10)], nonEmissions: [] },
+        firings: [ctrl, held1, held2],
+        groundTruth: labelAll([ctrl, held1, held2], 'TP'),
+        heldOutPrs: new Set([20, 21]),
+        actualExposure: {
+          activeRulesEvaluated: 1,
+          filesTouchedInWindow: 5,
+          positiveControlsExercised: 1,
+        },
+      }),
+    );
+    // Third exposure leg stays the train-side control count (1), unaffected by the 2 held-out firings.
+    expect(result.exposureTuple[2]).toBe(1);
+    expect(result.heldOutActivationsByRule).toEqual({ 'rule-a': 2 });
+  });
+});
+
+// ─── (codex-1) all-positives-non-emission + no FP must NOT PASS ───────────────
+
+describe('(codex-1) all positive fixtures culled (illegitimate) + no FP → NOT PASS', () => {
+  it('empty positive[] with an illegitimate non-emission FAILs (not a silent PASS)', () => {
+    const result = scoreAuthoredWindtunnel(
+      baseInput({
+        authoredControls: {
+          positive: [],
+          nonEmissions: [nonEmission('rule-a', 10, 'fix-shaped', 'illegitimate')],
+        },
+        firings: [],
+        heldOutPrs: new Set([20]),
+      }),
+    );
+    expect(result.verdict).toBe('FAIL');
+    expect(result.precision).toBeNull();
+    expect(result.authoredControlGate.effect).toBe('fail-illegitimate');
+    expect(result.authoredControlGate.illegitimate).toBe(1);
+  });
+});
+
+// ─── (codex-2) mixed emitted + illegitimate must not vanish ───────────────────
+
+describe('(codex-2) mixed emitted + illegitimate control', () => {
+  it('the illegitimate non-emission FAILs even when another fixture emitted a holding control', () => {
+    const ctrl = makeFiring('rule-a', 10, 'positive');
+    const result = scoreAuthoredWindtunnel(
+      baseInput({
+        authoredControls: {
+          positive: [posControl('rule-a', 10)],
+          nonEmissions: [nonEmission('rule-a', 11, 'over-match', 'illegitimate')],
+        },
+        firings: [ctrl],
+        groundTruth: labelAll([ctrl], 'TP'),
+        heldOutPrs: new Set([20]),
+      }),
+    );
+    // Non-vacuity would be satisfied by the emitted control — the illegitimate must still poison it.
+    expect(result.nonVacuity).toBe(true);
+    expect(result.verdict).toBe('FAIL');
+    expect(result.authoredControlGate.effect).toBe('fail-illegitimate');
+  });
+});
+
+// ─── undecidable / deferred non-emission → HONEST-NEGATIVE (not-certifiable) ──
+
+describe('undecidable / deferred non-emission → HONEST-NEGATIVE (never a silent skip)', () => {
+  it('an undecidable non-emission demotes a would-be PASS to HN', () => {
+    const ctrl = makeFiring('rule-a', 10, 'positive');
+    const result = scoreAuthoredWindtunnel(
+      baseInput({
+        authoredControls: {
+          positive: [posControl('rule-a', 10)],
+          nonEmissions: [
+            nonEmission('rule-a', 11, 'needs-adjudication', 'undecidable', 'ambiguous'),
+          ],
+        },
+        firings: [ctrl],
+        groundTruth: labelAll([ctrl], 'TP'),
+        heldOutPrs: new Set([20]),
+      }),
+    );
+    expect(result.verdict).toBe('HONEST-NEGATIVE');
+    expect(result.precision).toBeNull();
+    expect(result.authoredControlGate.effect).toBe('honest-negative-not-certifiable');
+    expect(result.authoredControlGate.undecidable).toBe(1);
+  });
+
+  it('a deferred non-emission is not-certifiable (deferred source)', () => {
+    const ctrl = makeFiring('rule-a', 10, 'positive');
+    const result = scoreAuthoredWindtunnel(
+      baseInput({
+        authoredControls: {
+          positive: [posControl('rule-a', 10)],
+          nonEmissions: [nonEmission('rule-a', 11, 'unsupported-source', 'deferred')],
+        },
+        firings: [ctrl],
+        groundTruth: labelAll([ctrl], 'TP'),
+        heldOutPrs: new Set([20]),
+      }),
+    );
+    expect(result.verdict).toBe('HONEST-NEGATIVE');
+    expect(result.authoredControlGate.effect).toBe('honest-negative-not-certifiable');
+    expect(result.authoredControlGate.deferred).toBe(1);
+  });
+
+  it('illegitimate outranks undecidable when both are present (FAIL, not HN)', () => {
+    const result = scoreAuthoredWindtunnel(
+      baseInput({
+        authoredControls: {
+          positive: [],
+          nonEmissions: [
+            nonEmission('rule-a', 10, 'needs-adjudication', 'undecidable'),
+            nonEmission('rule-a', 11, 'vacuous-silent', 'illegitimate'),
+          ],
+        },
+        firings: [],
+        heldOutPrs: new Set([20]),
+      }),
+    );
+    expect(result.verdict).toBe('FAIL');
+    expect(result.authoredControlGate.effect).toBe('fail-illegitimate');
+  });
+});
+
+// ─── gate is demote-only: a real FP FAIL keeps its breaching precision ────────
+
+describe('the non-emission gate is demote-only (mirrors the mined FAIL-tier ordering)', () => {
+  it('a real FP FAIL co-occurring with an illegitimate non-emission keeps the FP precision', () => {
+    // Build-altitude micro-decision (flagged for strategy couple-on-merge): a structural
+    // control defect does not erase a real FP measurement — the run FAILs either way.
+    const fp = makeFiring('rule-a', 10, 'corpus', 'bad();');
+    const result = scoreAuthoredWindtunnel(
+      baseInput({
+        authoredControls: {
+          positive: [],
+          nonEmissions: [nonEmission('rule-a', 11, 'fix-shaped', 'illegitimate')],
+        },
+        firings: [fp],
+        groundTruth: new Map<string, GroundTruthLabel>([[fp.labelId, 'FP']]),
+        heldOutPrs: new Set([20]),
+      }),
+    );
+    expect(result.verdict).toBe('FAIL');
+    // FP measurement survives the structural gate (the chosen precedence).
+    expect(result.precision).not.toBeNull();
+  });
+});

--- a/packages/core/src/spine/windtunnel-scorer-authored.test.ts
+++ b/packages/core/src/spine/windtunnel-scorer-authored.test.ts
@@ -164,6 +164,10 @@ describe('(c) O3 excludes a rule’s own control firing from the held-out count'
         heldOutPrs: new Set([20]),
       }),
     );
+    // The unlabeled own-control firing on the held-out PR routes to needsAdjudication,
+    // so the run is HONEST-NEGATIVE — asserted explicitly so this O3-exclusion scenario's
+    // verdict is not silently assumed to PASS (greptile #2283).
+    expect(result.verdict).toBe('HONEST-NEGATIVE');
     // The held-out control-kind firing is NOT counted; only the corpus one is.
     expect(result.heldOutActivationsByRule).toEqual({ 'rule-a': 1 });
   });
@@ -389,5 +393,38 @@ describe('the non-emission gate is demote-only (mirrors the mined FAIL-tier orde
     expect(result.verdict).toBe('FAIL');
     // FP measurement survives the structural gate (the chosen precedence).
     expect(result.precision).not.toBeNull();
+  });
+});
+
+// ─── multi-rule window: gate is window-level + O3 keys isolated per rule ──────
+
+describe('multi-rule window (gate is window-level, O3 keys isolated per rule)', () => {
+  it('an illegitimate control on rule-b FAILs the window even though rule-a is clean, and O3 keys only rule-a', () => {
+    // rule-a: a clean, holding positive control that fires + generalizes on a held-out PR.
+    // rule-b: NO positive control (all fixtures illegitimate) — it must poison the WINDOW
+    // (not just its own rule) and must NOT leak into the O3 keys (join-back is from positive[]).
+    const ctrlA = makeFiring('rule-a', 10, 'positive');
+    const heldA = makeFiring('rule-a', 20, 'corpus', 'gen-a();');
+    const heldB = makeFiring('rule-b', 20, 'corpus', 'gen-b();');
+    const result = scoreAuthoredWindtunnel(
+      baseInput({
+        authoredControls: {
+          positive: [posControl('rule-a', 10)],
+          nonEmissions: [nonEmission('rule-b', 12, 'fix-shaped', 'illegitimate')],
+        },
+        firings: [ctrlA, heldA, heldB],
+        groundTruth: labelAll([ctrlA, heldA, heldB], 'TP'),
+        heldOutPrs: new Set([20]),
+        mintedRuleIds: ['rule-a', 'rule-b'],
+      }),
+    );
+    // (1) window-level: rule-a's control is clean, yet rule-b's illegitimate non-emission
+    // FAILs the whole window (the gate is not scoped to rules lacking a positive control).
+    expect(result.verdict).toBe('FAIL');
+    expect(result.authoredControlGate.effect).toBe('fail-illegitimate');
+    expect(result.authoredControlGate.illegitimate).toBe(1);
+    // (2) O3 key isolation: rule-a is keyed (from positive[]) and counts its 1 held-out
+    // firing; rule-b fired on a held-out PR but has NO positive control → NOT a key.
+    expect(result.heldOutActivationsByRule).toEqual({ 'rule-a': 1 });
   });
 });

--- a/packages/core/src/spine/windtunnel-scorer-authored.test.ts
+++ b/packages/core/src/spine/windtunnel-scorer-authored.test.ts
@@ -393,6 +393,12 @@ describe('the non-emission gate is demote-only (mirrors the mined FAIL-tier orde
     expect(result.verdict).toBe('FAIL');
     // FP measurement survives the structural gate (the chosen precedence).
     expect(result.precision).not.toBeNull();
+    // The COUNT is the presence signal, NOT `effect`: the illegitimate non-emission is
+    // recorded even though the demote-only combine left the already-FAIL verdict unchanged
+    // (effect stays 'none'). Strategy's couple-on-merge ask + CR — this freezes the
+    // "a D4 consumer reads authoredControlGate.illegitimate, never `effect`" contract.
+    expect(result.authoredControlGate.illegitimate).toBe(1);
+    expect(result.authoredControlGate.effect).toBe('none');
   });
 });
 

--- a/packages/core/src/spine/windtunnel-scorer-authored.ts
+++ b/packages/core/src/spine/windtunnel-scorer-authored.ts
@@ -1,0 +1,199 @@
+// ─── ADR-112 §5.3/§6/§8 — the AUTHORED window-tunnel scorer (slice D3) ────────
+//
+// The sibling scorer for an AUTHORED rule window. Per strategy's Q1 ruling
+// (2026-07-01) it REDUCES to the mined `scoreWindtunnel`, it does NOT fork it — a
+// fork would violate the §5.3 content-blind-scorer invariant + §9 one-PASS/FAIL-
+// meaning (contract-illegal). The mined cascade is reused BYTE-UNCHANGED; this
+// layer only (a) normalizes the §6 authored controls into a `ScorerInput`, (b)
+// applies a pre-scorer non-emission gate, and (c) appends a verdict-inert O3
+// generalization metric.
+//
+// It is INERT like D1–D2.6: nothing here is wired into a cert run. The CLI
+// `spine-windtunnel` command stays on the mined scorer until slice D4 flips the
+// authored path reachable (D4 owes the whole-path couple-on-merge — scorer + the
+// #793 no-mint gate + the §6 deriver, end-to-end). D3 is the pure inert core,
+// offline-unit-tested in `@mmnto/core`.
+//
+// The three reduction moves (converged 4-seat panel, design in
+// `.totem/specs/d3-authored-scorer.md`):
+//   1. Positive-target projection: `positiveControlTargets` is DERIVED from
+//      `authoredControls.positive[]` — only `differential-holds` fixtures reach
+//      that list (discharged at emission in authored-controls.ts), so the mined
+//      scorer never re-proves the postimage leg.
+//   2. Non-emission gate (codex's load-bearing fold): a culled differential (empty
+//      `positive[]` + a recorded `nonEmissions[]`) must NOT reach the mined scorer
+//      as `positiveControlTargets: []` and silently PASS. An `illegitimate` class
+//      is a Gate-1 FAIL-equivalent; `undecidable`/`deferred` is not-certifiable
+//      (HONEST-NEGATIVE). The gate is DEMOTE-ONLY (mirrors the mined "a guard may
+//      demote a would-be PASS, never upgrade a FAIL") and PER-non-emission (a
+//      holding control on one fixture does not launder an illegitimate sibling).
+//   3. O3 metric (verdict-inert post-pass): `heldOutActivationsByRule` — per
+//      authored rule under test, the count of its non-control (`corpus`) firings on
+//      held-out PRs. Keys are JOIN-BACK-derived from the positive controls'
+//      `targetRuleId` (Tenet-20; a firing-only derivation would drop a rule with
+//      zero held-out activations — the rare-defect case). Strategy Q2: the metric
+//      is NEVER consulted for the verdict, and the Gate-2-eligible SET derivation
+//      is DEFERRED to D4 (D3 emits only the raw metric).
+
+import type { AuthoredControls } from './authored-controls.js';
+import type { ScorerInput, WindtunnelVerdict, WindtunnelVerdictKind } from './windtunnel-scorer.js';
+import { scoreWindtunnel } from './windtunnel-scorer.js';
+
+// ─── Types ──────────────────────────────────────────
+
+/**
+ * Input to the authored scorer. Extends the mined `ScorerInput` MINUS
+ * `positiveControlTargets` (that field is DERIVED here from `authoredControls`),
+ * plus the §6 answer key and the held-out partition for the O3 metric.
+ *
+ * `firings` carries the MERGED train + held-out firings — a train-side FP fails the
+ * whole window (a window-wide verdict), and `heldOutPrs` partitions them for the O3
+ * metric only. `exposureFloors` / `actualExposure` pass straight through to the
+ * mined scorer: D3 does not recompute exposure (the third leg counts train-side
+ * positive controls only — held-out activations never inflate it).
+ */
+export interface AuthoredScorerInput extends Omit<ScorerInput, 'positiveControlTargets'> {
+  /** The §6 answer key from `deriveAuthoredControls` — the emitted positives + the kept non-emissions. */
+  authoredControls: Pick<AuthoredControls, 'positive' | 'nonEmissions'>;
+  /** Held-out (scored-slice) PR numbers — the O3 partition. Supplied from `split.heldOutPrs` at D4. */
+  heldOutPrs: ReadonlySet<number>;
+}
+
+/** How the non-emission gate demoted the mined verdict ('none' = the mined verdict already met/exceeded the gate). */
+export type AuthoredControlGateEffect =
+  | 'none'
+  | 'fail-illegitimate'
+  | 'honest-negative-not-certifiable';
+
+/**
+ * The non-emission gate's audit record — observable so a consumed non-emission is
+ * NEVER a silent skip (Tenet-4). The counts report the raw `nonEmissions[]` tally
+ * regardless of `effect`; `effect` reports the demotion actually APPLIED to the
+ * mined verdict (so a more-severe mined FAIL can coexist with `effect: 'none'`
+ * while `illegitimate > 0` — the counts, not `effect`, are the presence signal).
+ */
+export interface AuthoredControlGate {
+  illegitimate: number;
+  undecidable: number;
+  deferred: number;
+  effect: AuthoredControlGateEffect;
+}
+
+/** The mined verdict + the two authored additions (both never re-consulted for the verdict). */
+export interface AuthoredWindtunnelVerdict extends WindtunnelVerdict {
+  /** O3 (verdict-inert): `targetRuleId → held-out non-control activation count`. Join-back keyed. */
+  heldOutActivationsByRule: Record<string, number>;
+  /** The non-emission gate's audit record (§6 fold). */
+  authoredControlGate: AuthoredControlGate;
+}
+
+// ─── Verdict-severity ladder (demote-only combination) ───────────────────────
+
+/** PASS < HONEST-NEGATIVE < FAIL. The gate may only raise severity, never lower it. */
+const VERDICT_SEVERITY: Record<WindtunnelVerdictKind, number> = {
+  PASS: 0,
+  'HONEST-NEGATIVE': 1,
+  FAIL: 2,
+};
+
+// ─── Public API ─────────────────────────────────────
+
+/**
+ * Score an AUTHORED wind-tunnel run. Pure function: no IO, no clock, no
+ * randomness, byte-identical across re-runs for identical inputs (Tenet-15).
+ * Reduces to `scoreWindtunnel` after normalizing the §6 controls, applies the
+ * non-emission gate (demote-only), and appends the verdict-inert O3 metric.
+ */
+export function scoreAuthoredWindtunnel(input: AuthoredScorerInput): AuthoredWindtunnelVerdict {
+  const {
+    firings,
+    groundTruth,
+    mintedRuleIds,
+    cullRateThreshold,
+    exposureFloors,
+    actualExposure,
+    authoredControls,
+    heldOutPrs,
+  } = input;
+
+  // Move 1 — project the emitted positives into the mined scorer's target shape.
+  // Only `differential-holds` fixtures are in `positive[]`; the mined scorer takes
+  // the (pr, targetRuleId) pair and proves non-vacuity by the target firing.
+  const positiveControlTargets = authoredControls.positive.map((c) => ({
+    pr: c.pr,
+    targetRuleId: c.targetRuleId,
+  }));
+
+  const mined = scoreWindtunnel({
+    firings,
+    groundTruth,
+    positiveControlTargets,
+    mintedRuleIds,
+    cullRateThreshold,
+    exposureFloors,
+    actualExposure,
+  });
+
+  // Move 2 — the non-emission gate. Tally the classes, then combine the gate's
+  // implied verdict with the mined verdict on the severity ladder (demote-only).
+  let illegitimate = 0;
+  let undecidable = 0;
+  let deferred = 0;
+  for (const ne of authoredControls.nonEmissions) {
+    if (ne.class === 'illegitimate') illegitimate += 1;
+    else if (ne.class === 'undecidable') undecidable += 1;
+    else deferred += 1; // 'deferred' — the enum is closed (illegitimate|undecidable|deferred)
+  }
+
+  // The gate's implied verdict: an illegitimate control is a Gate-1 FAIL-equivalent
+  // (outranks undecidable/deferred); an undecidable/deferred control is not-
+  // certifiable → HONEST-NEGATIVE. No blocking non-emission ⇒ no constraint.
+  let gateKind: WindtunnelVerdictKind | null = null;
+  let gateLabel: Exclude<AuthoredControlGateEffect, 'none'> | null = null;
+  if (illegitimate > 0) {
+    gateKind = 'FAIL';
+    gateLabel = 'fail-illegitimate';
+  } else if (undecidable + deferred > 0) {
+    gateKind = 'HONEST-NEGATIVE';
+    gateLabel = 'honest-negative-not-certifiable';
+  }
+
+  // Demote-only: the gate applies ONLY when strictly more severe than the mined
+  // verdict. When equal (e.g. an illegitimate non-emission co-occurring with a real
+  // FP FAIL), the mined verdict is kept — a structural control defect does not erase
+  // a real FP measurement (build-altitude micro-decision, flagged for strategy).
+  let verdict: WindtunnelVerdict = mined;
+  let effect: AuthoredControlGateEffect = 'none';
+  if (gateKind !== null && VERDICT_SEVERITY[gateKind] > VERDICT_SEVERITY[mined.verdict]) {
+    // A gate demotion is a structural, no-claim verdict → precision null (#2189):
+    // a 0 would falsely read as an all-FP measurement.
+    verdict = { ...mined, verdict: gateKind, precision: null };
+    effect = gateLabel!;
+  }
+
+  // Move 3 — the verdict-inert O3 metric. Keys are the authored rules under test
+  // (join-back from the positive controls), minus any culled rule. Values count each
+  // rule's non-control (`corpus`) firings on held-out PRs — 0 is a valid observable
+  // (the rare-defect case), so a keyed rule always appears even with no activation.
+  const culled = new Set(mined.cullLedger.map((e) => e.ruleId));
+  const heldOutActivationsByRule: Record<string, number> = {};
+  for (const c of authoredControls.positive) {
+    if (culled.has(c.targetRuleId)) continue; // (d) cull symmetry — out of the metric AND its keys
+    if (!Object.hasOwn(heldOutActivationsByRule, c.targetRuleId)) {
+      heldOutActivationsByRule[c.targetRuleId] = 0;
+    }
+  }
+  for (const f of firings) {
+    if (f.controlKind !== 'corpus') continue; // (c) a rule's own control firing is excluded
+    if (!heldOutPrs.has(f.pr)) continue; // held-out slice only
+    if (culled.has(f.ruleId)) continue; // (d) culled rule contributes nothing
+    if (!Object.hasOwn(heldOutActivationsByRule, f.ruleId)) continue; // only rules with a positive control
+    heldOutActivationsByRule[f.ruleId] += 1;
+  }
+
+  return {
+    ...verdict,
+    heldOutActivationsByRule,
+    authoredControlGate: { illegitimate, undecidable, deferred, effect },
+  };
+}

--- a/packages/core/src/spine/windtunnel-scorer-authored.ts
+++ b/packages/core/src/spine/windtunnel-scorer-authored.ts
@@ -140,9 +140,28 @@ export function scoreAuthoredWindtunnel(input: AuthoredScorerInput): AuthoredWin
   let undecidable = 0;
   let deferred = 0;
   for (const ne of authoredControls.nonEmissions) {
-    if (ne.class === 'illegitimate') illegitimate += 1;
-    else if (ne.class === 'undecidable') undecidable += 1;
-    else deferred += 1; // 'deferred' — the enum is closed (illegitimate|undecidable|deferred)
+    switch (ne.class) {
+      case 'illegitimate':
+        illegitimate += 1;
+        break;
+      case 'undecidable':
+        undecidable += 1;
+        break;
+      case 'deferred':
+        deferred += 1;
+        break;
+      default: {
+        // Exhaustiveness guard (Tenet-4; mirrors authored-controls.ts's
+        // NON_EMISSION_CLASS_BY_OUTCOME Record-over-Exclude). A future 4th class
+        // breaks THIS build instead of silently laundering into `deferred` → a
+        // spurious HONEST-NEGATIVE. The Zod boundary rejects it at runtime; the
+        // `never` binding makes a schema addition a COMPILE error here.
+        const _exhaustive: never = ne.class;
+        throw new Error(
+          `[Totem Error] scoreAuthoredWindtunnel: unhandled non-emission class '${String(_exhaustive)}'`,
+        );
+      }
+    }
   }
 
   // The gate's implied verdict: an illegitimate control is a Gate-1 FAIL-equivalent


### PR DESCRIPTION
## What

Slice **D3** of ADR-112: the sibling scorer **`scoreAuthoredWindtunnel`** for an AUTHORED rule window — the consumer that the §6 authored-controls machinery (D1–D2.6) was built inert to feed. Per strategy's **Q1 ruling** it **REDUCES to the mined `scoreWindtunnel`, it does not fork it** (a fork would violate the §5.3 content-blind-scorer invariant + §9 one-PASS/FAIL-meaning). The mined cascade is reused **byte-unchanged**.

Build plan locked by the **converged 4-seat pre-build panel** (strategy 0754Z / codex 0821Z / agy 0840Z / gemini 0910Z). Design doc: `.totem/specs/d3-authored-scorer.md`.

## The three reduction moves

1. **Positive-target projection** — `positiveControlTargets` is derived from `authoredControls.positive[]` (only `differential-holds` fixtures reach that list; the postimage leg is discharged at emission, so the mined scorer never re-proves it).
2. **Non-emission gate** (codex's load-bearing fold) — a culled differential (empty `positive[]` + a recorded `nonEmissions[]`) can no longer reach the mined scorer as `positiveControlTargets: []` and pass silently. `illegitimate` → Gate-1 FAIL-equivalent; `undecidable`/`deferred` → not-certifiable (HONEST-NEGATIVE). **Demote-only** + **per-non-emission** (a holding control does not launder an illegitimate sibling). Recorded in an `authoredControlGate` audit field (no silent skip, Tenet-4).
3. **O3 metric** — `heldOutActivationsByRule` (verdict-inert): per authored rule, the count of its non-control (`corpus`) firings on held-out PRs, **join-back-keyed** on `positive[].targetRuleId` (Tenet-20; a zero-activation rule still appears — the rare-defect case). Culled rules excluded. The **Gate-2-eligible SET derivation defers to D4** (strategy Q2 + gemini report-shape).

## Scope / inertness

- Pure function (no IO / clock / LLM; Tenet-15 deterministic), **14 offline unit tests** (the agy (a)–(g) matrix + codex ×2 + the fold's HN/precedence cases).
- **INERT** — not wired into any cert run. `spine-windtunnel` stays on the mined scorer until **slice D4** flips the authored path reachable; D4 owes the **whole-path couple-on-merge** (scorer + the #793 no-mint gate + the §6 deriver, end-to-end).
- Core-only (`@mmnto/totem`), new exported API re-exported from the barrel. `minor` changeset (fixed group). **closingRefs [].**

## ⚠ One build-altitude micro-decision to flag (couple-on-merge → strategy)

When an **illegitimate non-emission co-occurs with a real FP FAIL**, this build **keeps the FP's breaching precision** (a structural control defect does not erase a real measurement — the FP is evidence about *other* rules' firings). The alternative (null the precision because the apparatus is compromised) is defensible too; both FAIL, only `precision` differs. A one-line flip if strategy rules the other way. See the design doc's precedence table.

## Gate

`pnpm build` (5/5) · `pnpm test` (10/10 turbo, 2879 + 14 new) · `totem lint` PASS · ESLint clean · prettier (changed-files) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)