### PR TITLE
feat(spine): ADR-112 §5.3/§6/§8 Slice D4 — the inert→ENFORCED reachable flip

### DIFF
--- a/.changeset/adr-112-d4-reachable-flip.md
+++ b/.changeset/adr-112-d4-reachable-flip.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/totem': minor
+---
+
+feat(spine): ADR-112 §5.3/§6/§8 Slice D4 — the inert→ENFORCED reachable flip. The authored certifying path now executes end-to-end. `resolveCertifyingCorpusProvider` binds the producer-kind scorer at the §8 single dispatch home (an unconditional `score(base)` at the score step; the mined branch stays byte-unchanged), so no `producerKind` branch is scattered downstream. On an authored run the D2.5 no-mint `verifyOnly` gate now fires reachably (fail-loud `GATE_INVALID` before any scorer call or ledger write — never falls back to the mined scorer), `scoreAuthoredWindtunnel` scores the authored corpus with positives derived internally (the D3 reduction's threading guard), and the verdict-inert Gate-2-eligible set (`survivors ∩ {rule : heldOutActivationsByRule[rule] > 0}`, §1(k)-guarded + the illegitimate-window disqualifier keyed on the COUNT never `.effect`) is derived downstream of the scorer and persisted as a top-level report field sibling to the verdict. The dead `buildAuthoredCorpusProvider` is removed (the resolver eager-builds the authored corpus at resolution).

--- a/.totem/specs/d4-reachable-flip.md
+++ b/.totem/specs/d4-reachable-flip.md
@@ -17,12 +17,14 @@ Whole-path couple-on-merge owed to strategy. Binding carry (D3 couple, pinned `1
 ## Grounded wiring inputs (confirmed against source)
 
 The authored scorer signature (D3):
+
 ```
 scoreAuthoredWindtunnel(input: Omit<ScorerInput,'positiveControlTargets'> & {
   authoredControls: Pick<AuthoredControls,'positive'|'nonEmissions'>;  // §6 answer key
   heldOutPrs: ReadonlySet<number>;                                     // O3 partition
 }): AuthoredWindtunnelVerdict   // = WindtunnelVerdict + heldOutActivationsByRule + authoredControlGate
 ```
+
 - **`authoredControls`** — ALREADY surfaced on the corpus: `spine-windtunnel.ts:362` carries `authoredControls?: AuthoredControls` (undefined ⇒ mined ⇒ byte-unchanged). Computed upstream by `deriveAuthoredControls` (`spine-authored-cert-corpus.ts:273`). **D4 threads it; does NOT recompute.**
 - **`heldOutPrs`** — `new Set(split.heldOutPrs)` (`split.ts:38`, `heldOutPrs: PrNumber[]`). The split lives in the authored assembly; **WIRING TODO: surface `heldOutPrs` (or the split) to the score step** — today the corpus carries `authoredControls` but not the split. Candidate: add it beside `authoredControls?` on the authored corpus object.
 - **`firings`** — `engineResult.firings` (the MERGED train∪held-out window firings; `heldOutPrs` partitions them for the O3 metric only). Pass-through: `exposureFloors` / `actualExposure` unchanged (D3 does not recompute exposure).
@@ -42,7 +44,7 @@ export function deriveGate2EligibleSet(input: {
   mintedRuleIds: readonly string[];
   cullLedger: readonly CullLedgerEntry[];
   heldOutActivationsByRule: Readonly<Record<string, number>>;
-  authoredControlGate: Pick<AuthoredControlGate, 'illegitimate'>;     // Q4 ruling — window-level disqualifier
+  authoredControlGate: Pick<AuthoredControlGate, 'illegitimate'>; // Q4 ruling — window-level disqualifier
 }): string[] {
   // Q4 (strategy 2318Z): a window with illegitimate > 0 is FAIL-equivalent — NO survivor is
   // Gate-2-eligible, EVEN WHEN effect === 'none' (a co-severe mined FP FAIL masked it, 1a80655e).
@@ -50,15 +52,17 @@ export function deriveGate2EligibleSet(input: {
   if (input.authoredControlGate.illegitimate > 0) return [];
   const culled = new Set(input.cullLedger.map((e) => e.ruleId));
   return input.mintedRuleIds
-    .filter((id) => !culled.has(id))                                  // survivors = minted \ culled
-    .filter((id) => (input.heldOutActivationsByRule[id] ?? 0) > 0);   // held-out-exercised; NEVER `?? 1`/defaulted-in
+    .filter((id) => !culled.has(id)) // survivors = minted \ culled
+    .filter((id) => (input.heldOutActivationsByRule[id] ?? 0) > 0); // held-out-exercised; NEVER `?? 1`/defaulted-in
 }
 ```
+
 This pure logic is stable regardless of Q1 (seam) / Q2 (emit-or-inert + artifact home). **Held for Q2:** whether the set is EMITTED (report field / Gate-2 ledger) or computed-but-inert, and its home (report vs separate ledger). Unit tests (fork-independent): (a) survivor with held-out>0 → admitted; (b) survivor absent from map → excluded; (c) survivor with explicit 0 → excluded; (d) culled rule with held-out>0 → excluded (not a survivor).
 
 ## The contested seam — HELD for strategy Q1
 
 How to route to `scoreAuthoredWindtunnel` WITHOUT opening a second producer-kind home (§8 single-home, gemini `a66a981`/#786):
+
 - **(a) provider-carried scorer** — the `:507` resolver (already reads producerKind) surfaces the authored inputs + selects the scorer; `:524` stays a single unconditional `corpusProvider.score(...)`. My read: preserves the single home.
 - **(b) score-step branch** — `if (authored) scoreAuthoredWindtunnel else scoreWindtunnel` at `:524`, argued legal because engineResult is already single-provenance (§7). Note: the corpus ALREADY carries `authoredControls?` (undefined⇒mined), so the branch signal exists on the corpus — Q1 is whether READING it at `:524` is a second home or a legal downstream read.
 
@@ -97,21 +101,25 @@ How to route to `scoreAuthoredWindtunnel` WITHOUT opening a second producer-kind
 Three lens seats replied; **strongly convergent**. strategy-claude (contract owner) has NOT ruled — mid-#796 BLIND round; operator nudging. Build stays gated on strategy Q1/Q2.
 
 **Q1 seam — panel PRE-CONVERGED on (a) provider-carried scorer (gemini + codex), pending strategy's formal ruling.**
+
 - gemini: branching at `:524` leaks `producerKind` out of the resolver → violates §8 single-home + Tenet 9. Resolver at `:507` (already knows kind + assembles inputs) bundles the scoring fn; `:524` stays unconditional `corpusProvider.score(...)`.
 - codex: keep the flip a CONSUMER of the existing authored corpus surface. **Fail-loud, not fallback:** producerKind `authored` with missing `corpus.authoredControls` must THROW, NEVER fall back to the mined scorer (the one D4-specific way to break the D3 reduction).
 
 **Q2 Gate-2 altitude — UNANIMOUS: downstream deriver, NOT in the scorer (gemini + codex + agy).** Scorer emits raw signal (`heldOutActivationsByRule` + `cullLedger`); the intersection lives at report/consumer altitude (Tenet-20 join-back-once; don't overload the evaluator). The pure `deriveGate2EligibleSet` (above) is that downstream fn. **Still strategy's Q2:** emit-vs-inert + artifact home/shape (report field vs Gate-2 ledger).
 
 **gemini Q3 — flip-last guards to ADD:**
+
 1. **Strict Non-Interference:** assert an absent/`'mined'` producerKind is provably insulated from authored logic/overhead (mined path byte-unchanged) — a regression assertion, not just a byte-diff hope.
 2. **Lineage/audit marker:** the Gate-2 emission carries `producerKind: 'authored'` (or equiv) so downstream + post-mortems deterministically trace the derivation path. No silent fallbacks.
 
 **codex — three contract-critical D4 assertions (required):**
+
 1. **§6 cull reaches scorer un-broken:** a D4 test where the differential evaluator returns `fix-shaped` → scorer sees `positive: []`, `nonEmissions[0].class === 'illegitimate'`, and the run must NOT become a mined PASS via `positiveControlTargets: []`.
 2. **no-mint ordering (run/provider boundary, not just `runRuleAuthor`):** a stale/first-time authored rule (`minted`/`revised`) → command throws `GATE_INVALID`, a **scorer spy is NOT called**, authoring ledger **byte-unchanged**. (`runRuleAuthor` Pass-1 computes pending writes IO-free; verifyOnly throws before the Pass-2 append loop → precedes first scorer call + any ledger write.)
 3. **Gate-2 on the COUNT:** `(count ?? 0) > 0` over survivors — never `effect`, never truthiness/`?? 1`.
 
 **agy — matrix + altitude + fixtures:**
+
 - **+2 rows:** (vi) Cross-partition leakage guard — `split.heldOutPrs ∩ trainPrs = ∅`; a train-only-activating rule → zero held-out → excluded from Gate-2. (vii) Unlabeled-demotion partition — valid positive controls train-side + an unlabeled firing held-out-side → clean `HONEST-NEGATIVE` demotion, no training-signal leak, no FP.
 - **Altitude:** Row (i) happy-path e2e → **CLI** (`spine-windtunnel.test.ts`); (ii) no-mint fires → **CLI**; (iii) Gate-2 exclusion → **Core**; (iv) illegitimate-count FP → **Core**; (v) mined regression → **CLI**.
 - **Fixtures:** REUSE D3 authored-control + split fixtures for Row (i) (avoid bot-tax); for Row (ii) **dynamically mutate in-memory** (flip a rule to `minted`/`revised`) rather than commit a new static fixture.
@@ -123,7 +131,8 @@ Three lens seats replied; **strongly convergent**. strategy-claude (contract own
 ## STRATEGY RULING — 2318Z, ALL FOUR RULED (supersedes the open questions above; build UNBLOCKED)
 
 **Q1 — RULED: single-home EXTENDS to the scorer = (a) provider-carried scorer. My read + panel converged. CONFIRMED.**
-- A `producerKind` branch at `:524` is a §8 VIOLATION (a second kind-read; two reads can diverge → score an authored corpus with the mined scorer → silently PASS a culled differential — the codex hole D3 closed). §7 single-provenance of `engineResult` is necessary-not-sufficient (the hazard is provenance-of-*scorer*, not of inputs).
+
+- A `producerKind` branch at `:524` is a §8 VIOLATION (a second kind-read; two reads can diverge → score an authored corpus with the mined scorer → silently PASS a culled differential — the codex hole D3 closed). §7 single-provenance of `engineResult` is necessary-not-sufficient (the hazard is provenance-of-_scorer_, not of inputs).
 - **Shape:** resolver at `:507` returns a scorer bound at resolution time to the authored substrate. `:524` = unconditional `corpusProvider.score(base)`. Mined ⇒ `(base) => scoreWindtunnel(base)`; authored ⇒ `(base) => scoreAuthoredWindtunnel({ ...base, authoredControls, heldOutPrs })`.
 - **THREADING GUARD (contract-relevant):** the authored scorer's `positiveControlTargets` MUST come from `authoredControls.positive` (D3 derives internally at `windtunnel-scorer-authored.ts:122`). Do NOT thread `engineResult.positiveControlTargets` into the authored `.score()` input — double-sourcing reopens the postimage re-proof the D3 reduction discharged. **`base` handed to the authored scorer must EXCLUDE engineResult's positive-target field.**
 
@@ -132,6 +141,7 @@ Three lens seats replied; **strongly convergent**. strategy-claude (contract own
 **Q3 — RULED: arming = reachability only, NO new gate code; NO enforce step beyond D2.5's fail-loud.** BUT a one-line §8 **currency pin IS owed** (not a contract change): §8 line 168 says "INERT until Slice D3" — stale; D4 is the flip that arms it → "INERT until Slice **D4**". **Strategy lands it LOCKSTEP with my D4 PR (couple-on-merge, #793 pattern) — no §8 change lands before my build.**
 
 **Q4 — RULED: whole-path couple END-TO-END (4 seams); route the D4 PR to strategy.** Seams strategy reviews: (1) authored corpus resolution (Q1 single-home); (2) the no-mint `verifyOnly` gate FIRING (verifies it executes + fails loud, not just scorer math); (3) `scoreAuthoredWindtunnel` invocation (inputs threaded per Q1 guard); (4) the Gate-2 set emit (verdict-inert, (k)-guarded).
+
 - **`.illegitimate`-count carry RE-AFFIRMED + verified in D3 code → REFINES the Gate-2 deriver (folded above):** a window with `authoredControlGate.illegitimate > 0` is FAIL-equivalent; NO survivor is Gate-2-eligible, **even when `effect === 'none'`** (a co-severe mined FP FAIL masked it). Disqualify on `.illegitimate > 0`, NEVER on `.effect` — a set built off `.effect` silently admits rules from a masked-illegitimate window. (Added the `authoredControlGate` param + the early-`return []` to the deriver sketch above.)
 
 **Currency confirm:** nothing moved on §5.3/§6/§8 since D3 (§8 reads through #793 `135b84a`); strategy's clone = `origin/main 53c9779` (what I re-pulled). Clean.
@@ -151,15 +161,18 @@ Facts: `CertifyingCorpusProvider = (lock) => CertifyingCorpus` (a fn); the corpu
 // authored ⇒ EAGER-build the corpus once (fires the no-mint gate + derives authoredControls at
 // resolve, before engine + score — codex Q2 satisfied EARLIEST), capture the substrate, bind.
 type ScoredRun =
-  | { kind: 'mined';    verdict: WindtunnelVerdict }
+  | { kind: 'mined'; verdict: WindtunnelVerdict }
   | { kind: 'authored'; verdict: AuthoredWindtunnelVerdict; gate2: Gate2Eligibility };
-interface ResolvedCertifyingRun { provider: CertifyingCorpusProvider; score: (base: ScorerInput) => ScoredRun; }
+interface ResolvedCertifyingRun {
+  provider: CertifyingCorpusProvider;
+  score: (base: ScorerInput) => ScoredRun;
+}
 
 // authored closure (substrate captured at resolve):
 score = (base) => {
-  const { positiveControlTargets: _drop, ...rest } = base;              // Q1 guard: never double-source positives
+  const { positiveControlTargets: _drop, ...rest } = base; // Q1 guard: never double-source positives
   const verdict = scoreAuthoredWindtunnel({ ...rest, authoredControls, heldOutPrs });
-  const gate2 = deriveGate2Eligibility({ mintedRuleIds: base.mintedRuleIds, verdict });  // downstream of scorer
+  const gate2 = deriveGate2Eligibility({ mintedRuleIds: base.mintedRuleIds, verdict }); // downstream of scorer
   return { kind: 'authored', verdict, gate2 };
 };
 // mined closure: (base) => ({ kind: 'mined', verdict: scoreWindtunnel(base) })  // byte-unchanged

--- a/.totem/specs/d4-reachable-flip.md
+++ b/.totem/specs/d4-reachable-flip.md
@@ -1,0 +1,173 @@
+# ADR-112 Slice D4 — the inert→ENFORCED reachable flip (preflight design)
+
+**Status:** PRE-BUILD — panel out (`2026-07-01T2120Z` × 4), build GATED on strategy Q1. No code on the contested seam.
+**Base:** origin/main `3d0a177a` (1.88.0). Strategy ADR-112 @ `origin/main 53c9779` (§8 pins through #793).
+**Prior slices:** D1 sibling assembler · D2 input binding · D2.5 no-mint verifyOnly gate · D2.6 window answer-key · D3 `scoreAuthoredWindtunnel` (inert core, `3a6048d3`).
+
+## Goal
+
+D4 makes the authored cert path REACHABLE — the first slice that executes the authored producer end-to-end. Three coupled pieces:
+
+1. **Flip the scorer.** Route the authored path to D3's `scoreAuthoredWindtunnel` at the score step (`spine-windtunnel.ts:524`; mined `scoreWindtunnel` unconditional today; producer-kind dispatch home = `resolveCertifyingCorpusProvider` at `:507`).
+2. **Derive + emit the Gate-2-eligible set** = `survivors ∩ {rule : heldOutActivationsByRule[rule] > 0}`.
+3. **No-mint gate becomes reachable** — the D2.5 `verifyOnly` gate now fires end-to-end (no new gate code; reachability IS the flip).
+
+Whole-path couple-on-merge owed to strategy. Binding carry (D3 couple, pinned `1a80655e`): consumers key on `authoredControlGate.illegitimate` (COUNT), NEVER `.effect`.
+
+## Grounded wiring inputs (confirmed against source)
+
+The authored scorer signature (D3):
+```
+scoreAuthoredWindtunnel(input: Omit<ScorerInput,'positiveControlTargets'> & {
+  authoredControls: Pick<AuthoredControls,'positive'|'nonEmissions'>;  // §6 answer key
+  heldOutPrs: ReadonlySet<number>;                                     // O3 partition
+}): AuthoredWindtunnelVerdict   // = WindtunnelVerdict + heldOutActivationsByRule + authoredControlGate
+```
+- **`authoredControls`** — ALREADY surfaced on the corpus: `spine-windtunnel.ts:362` carries `authoredControls?: AuthoredControls` (undefined ⇒ mined ⇒ byte-unchanged). Computed upstream by `deriveAuthoredControls` (`spine-authored-cert-corpus.ts:273`). **D4 threads it; does NOT recompute.**
+- **`heldOutPrs`** — `new Set(split.heldOutPrs)` (`split.ts:38`, `heldOutPrs: PrNumber[]`). The split lives in the authored assembly; **WIRING TODO: surface `heldOutPrs` (or the split) to the score step** — today the corpus carries `authoredControls` but not the split. Candidate: add it beside `authoredControls?` on the authored corpus object.
+- **`firings`** — `engineResult.firings` (the MERGED train∪held-out window firings; `heldOutPrs` partitions them for the O3 metric only). Pass-through: `exposureFloors` / `actualExposure` unchanged (D3 does not recompute exposure).
+- **`positiveControlTargets`** — NOT supplied on the authored path; the scorer DERIVES it from `authoredControls.positive[]` (Omit in the signature).
+
+## Fork-INDEPENDENT: the Gate-2-eligible set deriver (build now; home is Q2)
+
+Survivors are NOT a verdict field — the verdict exposes `survivingRuleCount` (count), `cullLedger[].ruleId` (culled), and the input `mintedRuleIds`. So **survivors = `mintedRuleIds` \ `cullLedger[].ruleId`**. Keys align: `mintedRuleIds` = the authored `ruleId` (C2a `firingLabelId ← ruleId`); `heldOutActivationsByRule` is join-back-keyed on `positive[].targetRuleId` = the same `ruleId`.
+
+```ts
+// Falsifier (k): a survivor with ZERO held-out activations is NEVER admitted
+// (agy's rare-defect exemption resolved AGAINST at D3). CODEX CORRECTION: D3 records a
+// non-culled rule with a valid positive control + zero held-out firings as an EXPLICIT
+// `heldOutActivationsByRule[rule] = 0` (the common case), NOT absent-from-map — so the
+// guard must handle BOTH explicit-0 and absent identically: `(map[id] ?? 0) > 0`.
+export function deriveGate2EligibleSet(input: {
+  mintedRuleIds: readonly string[];
+  cullLedger: readonly CullLedgerEntry[];
+  heldOutActivationsByRule: Readonly<Record<string, number>>;
+  authoredControlGate: Pick<AuthoredControlGate, 'illegitimate'>;     // Q4 ruling — window-level disqualifier
+}): string[] {
+  // Q4 (strategy 2318Z): a window with illegitimate > 0 is FAIL-equivalent — NO survivor is
+  // Gate-2-eligible, EVEN WHEN effect === 'none' (a co-severe mined FP FAIL masked it, 1a80655e).
+  // Disqualify on the COUNT, NEVER on `.effect === 'fail-illegitimate'`.
+  if (input.authoredControlGate.illegitimate > 0) return [];
+  const culled = new Set(input.cullLedger.map((e) => e.ruleId));
+  return input.mintedRuleIds
+    .filter((id) => !culled.has(id))                                  // survivors = minted \ culled
+    .filter((id) => (input.heldOutActivationsByRule[id] ?? 0) > 0);   // held-out-exercised; NEVER `?? 1`/defaulted-in
+}
+```
+This pure logic is stable regardless of Q1 (seam) / Q2 (emit-or-inert + artifact home). **Held for Q2:** whether the set is EMITTED (report field / Gate-2 ledger) or computed-but-inert, and its home (report vs separate ledger). Unit tests (fork-independent): (a) survivor with held-out>0 → admitted; (b) survivor absent from map → excluded; (c) survivor with explicit 0 → excluded; (d) culled rule with held-out>0 → excluded (not a survivor).
+
+## The contested seam — HELD for strategy Q1
+
+How to route to `scoreAuthoredWindtunnel` WITHOUT opening a second producer-kind home (§8 single-home, gemini `a66a981`/#786):
+- **(a) provider-carried scorer** — the `:507` resolver (already reads producerKind) surfaces the authored inputs + selects the scorer; `:524` stays a single unconditional `corpusProvider.score(...)`. My read: preserves the single home.
+- **(b) score-step branch** — `if (authored) scoreAuthoredWindtunnel else scoreWindtunnel` at `:524`, argued legal because engineResult is already single-provenance (§7). Note: the corpus ALREADY carries `authoredControls?` (undefined⇒mined), so the branch signal exists on the corpus — Q1 is whether READING it at `:524` is a second home or a legal downstream read.
+
+**Do not build the seam until strategy rules.** Build (a)-shaped scaffolding only if the ruling lands (a).
+
+## No-mint reachability (codex Q2) + the §6 cull invariant (codex Q1)
+
+- **No-mint:** D2.5's `verifyOnly` gate (in `buildAuthoredCertifyingCorpus`/`runRuleAuthor`) fails loud `GATE_INVALID` on `minted`/`revised`. D4 adds NO new gate code — reachability is the flip. Verify `GATE_INVALID` precedes the first scorer call AND any ledger write (first run that actually reaches it).
+- **§6 cull (must-not-break):** only `differential-holds` (`authored-controls.ts:69` `EMITTING_OUTCOME`) reaches `positive[]`; postimage-firing controls are culled to `nonEmissions[]` BEFORE `positive[]` (the `differential-holds` gate ~`:373`). D4 feeds the REAL culled `authoredControls` to the scorer for the first time — confirm no path lets an un-culled control reach `positive[]`.
+
+## Test matrix (agy Q1 — refine on reply)
+
+(i) authored HAPPY PATH e2e (fixture-backed real run: corpus → no-mint gate → authored scorer → Gate-2 set), not a mocked scorer · (ii) no-mint FIRES: `minted`/`revised` ⇒ `GATE_INVALID` before score + before ledger write · (iii) Gate-2 EXCLUSION: zero-held-out survivor excluded (falsifier (k)) · (iv) `.illegitimate`-COUNT-not-`.effect` under a co-occurring FP-FAIL · (v) MINED path regression: producerKind absent ⇒ byte-unchanged. Seam altitude (CLI vs core) + fixture reuse pending agy Q2/Q3.
+
+## Open questions held for the panel
+
+- **strategy Q1** — scorer dispatch home (a vs b). GATES the wiring.
+- **strategy Q2** — Gate-2 set emit-or-inert + artifact shape/home. GATES the deriver's home.
+- **strategy Q3/Q4** — no-mint arming semantics; whole-path couple scope.
+- **wiring** — surface `heldOutPrs`/split to the score step; confirm survivors-from-(minted\culled) is the intended source.
+- **gemini** — (a)/(b) Tenet-9/20; Gate-2 derivation altitude (scorer vs downstream); flip-last tenet guard.
+- **codex** — §6 cull reaches scorer un-broken; GATE_INVALID ordering; absent≡0≡excluded on the COUNT.
+
+## Gate + release (D4 IS releasable)
+
+`pnpm -r build && pnpm test` (full workspace, chained not piped) · `totem lint` · ESLint `pnpm --filter @mmnto/totem lint` (distinct) · prettier CHANGED-only · changeset `@mmnto/totem` minor (fixed group bumps all 5). Preflight w/ short spec slug (this file).
+
+## Fable #697 trial (folds in)
+
+**Candidate CONFIRMED (agy Q4): Row (iii) — Gate-2 exclusion under falsifier (k).** Isolated mathematical boundary (`survivors ∩ {rule : heldOutActivationsByRule[rule] > 0}`); Fable drafts the core unit cases, I verify assertion-strength against the live core reducer + the source contract (not just green), log survived-quality + token/latency to strategy#697. Per my #796 reply, the verify leg = contract-check.
+
+---
+
+## PANEL CONVERGENCE — folded 2026-07-01 (codex 2209Z · gemini 2145Z · agy 2203Z; strategy Q1/Q2 still the GATE)
+
+Three lens seats replied; **strongly convergent**. strategy-claude (contract owner) has NOT ruled — mid-#796 BLIND round; operator nudging. Build stays gated on strategy Q1/Q2.
+
+**Q1 seam — panel PRE-CONVERGED on (a) provider-carried scorer (gemini + codex), pending strategy's formal ruling.**
+- gemini: branching at `:524` leaks `producerKind` out of the resolver → violates §8 single-home + Tenet 9. Resolver at `:507` (already knows kind + assembles inputs) bundles the scoring fn; `:524` stays unconditional `corpusProvider.score(...)`.
+- codex: keep the flip a CONSUMER of the existing authored corpus surface. **Fail-loud, not fallback:** producerKind `authored` with missing `corpus.authoredControls` must THROW, NEVER fall back to the mined scorer (the one D4-specific way to break the D3 reduction).
+
+**Q2 Gate-2 altitude — UNANIMOUS: downstream deriver, NOT in the scorer (gemini + codex + agy).** Scorer emits raw signal (`heldOutActivationsByRule` + `cullLedger`); the intersection lives at report/consumer altitude (Tenet-20 join-back-once; don't overload the evaluator). The pure `deriveGate2EligibleSet` (above) is that downstream fn. **Still strategy's Q2:** emit-vs-inert + artifact home/shape (report field vs Gate-2 ledger).
+
+**gemini Q3 — flip-last guards to ADD:**
+1. **Strict Non-Interference:** assert an absent/`'mined'` producerKind is provably insulated from authored logic/overhead (mined path byte-unchanged) — a regression assertion, not just a byte-diff hope.
+2. **Lineage/audit marker:** the Gate-2 emission carries `producerKind: 'authored'` (or equiv) so downstream + post-mortems deterministically trace the derivation path. No silent fallbacks.
+
+**codex — three contract-critical D4 assertions (required):**
+1. **§6 cull reaches scorer un-broken:** a D4 test where the differential evaluator returns `fix-shaped` → scorer sees `positive: []`, `nonEmissions[0].class === 'illegitimate'`, and the run must NOT become a mined PASS via `positiveControlTargets: []`.
+2. **no-mint ordering (run/provider boundary, not just `runRuleAuthor`):** a stale/first-time authored rule (`minted`/`revised`) → command throws `GATE_INVALID`, a **scorer spy is NOT called**, authoring ledger **byte-unchanged**. (`runRuleAuthor` Pass-1 computes pending writes IO-free; verifyOnly throws before the Pass-2 append loop → precedes first scorer call + any ledger write.)
+3. **Gate-2 on the COUNT:** `(count ?? 0) > 0` over survivors — never `effect`, never truthiness/`?? 1`.
+
+**agy — matrix + altitude + fixtures:**
+- **+2 rows:** (vi) Cross-partition leakage guard — `split.heldOutPrs ∩ trainPrs = ∅`; a train-only-activating rule → zero held-out → excluded from Gate-2. (vii) Unlabeled-demotion partition — valid positive controls train-side + an unlabeled firing held-out-side → clean `HONEST-NEGATIVE` demotion, no training-signal leak, no FP.
+- **Altitude:** Row (i) happy-path e2e → **CLI** (`spine-windtunnel.test.ts`); (ii) no-mint fires → **CLI**; (iii) Gate-2 exclusion → **Core**; (iv) illegitimate-count FP → **Core**; (v) mined regression → **CLI**.
+- **Fixtures:** REUSE D3 authored-control + split fixtures for Row (i) (avoid bot-tax); for Row (ii) **dynamically mutate in-memory** (flip a rule to `minted`/`revised`) rather than commit a new static fixture.
+
+**Net build shape (once strategy rules Q1=(a) / Q2):** (1) resolver at `:507` bundles `scoreAuthoredWindtunnel` + threads `authoredControls` (already on corpus) + `heldOutPrs` (new: surface split to score step) → `:524` unconditional `corpusProvider.score(...)`; (2) new core `deriveGate2EligibleSet` (pure, downstream) + its 4 units + the 2 partition rows; (3) fail-loud on missing authored controls; (4) non-interference + lineage-marker guards; (5) the 3 codex assertions; (6) reuse/mutate fixtures per agy. Fable drafts Row (iii).
+
+---
+
+## STRATEGY RULING — 2318Z, ALL FOUR RULED (supersedes the open questions above; build UNBLOCKED)
+
+**Q1 — RULED: single-home EXTENDS to the scorer = (a) provider-carried scorer. My read + panel converged. CONFIRMED.**
+- A `producerKind` branch at `:524` is a §8 VIOLATION (a second kind-read; two reads can diverge → score an authored corpus with the mined scorer → silently PASS a culled differential — the codex hole D3 closed). §7 single-provenance of `engineResult` is necessary-not-sufficient (the hazard is provenance-of-*scorer*, not of inputs).
+- **Shape:** resolver at `:507` returns a scorer bound at resolution time to the authored substrate. `:524` = unconditional `corpusProvider.score(base)`. Mined ⇒ `(base) => scoreWindtunnel(base)`; authored ⇒ `(base) => scoreAuthoredWindtunnel({ ...base, authoredControls, heldOutPrs })`.
+- **THREADING GUARD (contract-relevant):** the authored scorer's `positiveControlTargets` MUST come from `authoredControls.positive` (D3 derives internally at `windtunnel-scorer-authored.ts:122`). Do NOT thread `engineResult.positiveControlTargets` into the authored `.score()` input — double-sourcing reopens the postimage re-proof the D3 reduction discharged. **`base` handed to the authored scorer must EXCLUDE engineResult's positive-target field.**
+
+**Q2 — RULED: EMIT the Gate-2 set, verdict-inert.** A report FIELD sibling to `heldOutActivationsByRule` (co-located; same authored verdict); NOT a separate ledger (avoids a second persisted artifact + its own drift-prone SHA, §8 single-source); never consulted by Gate-1 (§5.3:133 — Gate-2-eligibility only). Set = `survivors ∩ {rule : heldOutActivationsByRule[rule] > 0}`; **falsifier §1(k) enforced AT this derivation**, exclusion OBSERVABLE (don't silently drop). Shape is build-altitude: minimal = eligible rule-id set; richer `Record<ruleId,{heldOutCount,gate2Eligible}>` makes the (k) exclusion legible (shows zero-held-out survivors considered-and-excluded). Contract requires: **emitted · verdict-inert · (k)-guarded · derived-not-mirrored**.
+
+**Q3 — RULED: arming = reachability only, NO new gate code; NO enforce step beyond D2.5's fail-loud.** BUT a one-line §8 **currency pin IS owed** (not a contract change): §8 line 168 says "INERT until Slice D3" — stale; D4 is the flip that arms it → "INERT until Slice **D4**". **Strategy lands it LOCKSTEP with my D4 PR (couple-on-merge, #793 pattern) — no §8 change lands before my build.**
+
+**Q4 — RULED: whole-path couple END-TO-END (4 seams); route the D4 PR to strategy.** Seams strategy reviews: (1) authored corpus resolution (Q1 single-home); (2) the no-mint `verifyOnly` gate FIRING (verifies it executes + fails loud, not just scorer math); (3) `scoreAuthoredWindtunnel` invocation (inputs threaded per Q1 guard); (4) the Gate-2 set emit (verdict-inert, (k)-guarded).
+- **`.illegitimate`-count carry RE-AFFIRMED + verified in D3 code → REFINES the Gate-2 deriver (folded above):** a window with `authoredControlGate.illegitimate > 0` is FAIL-equivalent; NO survivor is Gate-2-eligible, **even when `effect === 'none'`** (a co-severe mined FP FAIL masked it). Disqualify on `.illegitimate > 0`, NEVER on `.effect` — a set built off `.effect` silently admits rules from a masked-illegitimate window. (Added the `authoredControlGate` param + the early-`return []` to the deriver sketch above.)
+
+**Currency confirm:** nothing moved on §5.3/§6/§8 since D3 (§8 reads through #793 `135b84a`); strategy's clone = `origin/main 53c9779` (what I re-pulled). Clean.
+
+**All gates cleared. Build to Q1's single-home shape; route the PR to strategy for the 4-seam couple; strategy pins the §8 D3→D4 currency fix lockstep on merge. Fable drafts Row (iii) for #697.**
+
+---
+
+## STEP-2 SEAM — FINALIZED design (grounded in `resolveCertifyingCorpusProvider` + `runCertifyingEngine`)
+
+Facts: `CertifyingCorpusProvider = (lock) => CertifyingCorpus` (a fn); the corpus carries `authoredControls?` but NOT the split. The resolver (`spine-cert-run-corpus.ts:621`) reads `producerKind` (the §8 single home), and for authored already loads the split via `loadAuthoredCertRunFixtures` (⇒ `heldOutPrs` available at resolve). The authored provider (`buildAuthoredCorpusProvider`) ignores the lock and defers to `buildAuthoredCertifyingCorpus` (which runs the no-mint `verifyOnly` gate + derives `authoredControls`). `runCertifyingEngine:1192` calls `corpusProvider(lock)` then returns `EngineResult` (no authoredControls). Score step at `:524` builds a `ScorerInput` `base` from `engineResult`.
+
+**Design — resolver returns a bundle `{ provider, score }`; the scorer is bound at the §8 single home; `:524` unconditional.**
+
+```ts
+// Resolved at the ONE home (resolver), off producerKind. mined ⇒ lazy provider + mined score;
+// authored ⇒ EAGER-build the corpus once (fires the no-mint gate + derives authoredControls at
+// resolve, before engine + score — codex Q2 satisfied EARLIEST), capture the substrate, bind.
+type ScoredRun =
+  | { kind: 'mined';    verdict: WindtunnelVerdict }
+  | { kind: 'authored'; verdict: AuthoredWindtunnelVerdict; gate2: Gate2Eligibility };
+interface ResolvedCertifyingRun { provider: CertifyingCorpusProvider; score: (base: ScorerInput) => ScoredRun; }
+
+// authored closure (substrate captured at resolve):
+score = (base) => {
+  const { positiveControlTargets: _drop, ...rest } = base;              // Q1 guard: never double-source positives
+  const verdict = scoreAuthoredWindtunnel({ ...rest, authoredControls, heldOutPrs });
+  const gate2 = deriveGate2Eligibility({ mintedRuleIds: base.mintedRuleIds, verdict });  // downstream of scorer
+  return { kind: 'authored', verdict, gate2 };
+};
+// mined closure: (base) => ({ kind: 'mined', verdict: scoreWindtunnel(base) })  // byte-unchanged
+```
+
+- **:524** → `const scored = resolved.score(base)` — UNCONDITIONAL. No second `producerKind` read (the kind is resolved ONCE; `scored.kind` is a derived discriminant carried FROM the single home, Tenet-20 derive-not-mirror — this IS gemini's Q3 lineage marker).
+- **Gate-2 emit:** the print/persist step reads `scored.gate2` under `scored.kind === 'authored'` (a discriminant branch on the RESOLVED result, not a lock re-read) → emit as a report field sibling to `heldOutActivationsByRule`.
+- **Mined byte-unchanged:** mined provider stays lazy; `scoreWindtunnel(base)` with the full `base` (keeps `positiveControlTargets`). gemini Q3 non-interference: assert absent/'mined' producerKind → `kind:'mined'`, no authored overhead.
+- **`heldOutPrs`:** `new Set(split.heldOutPrs)`, captured in the authored closure at resolve (split already loaded there).
+- **Caller change (`:507`):** `const { provider, score } = await resolveCertifyingCorpusProvider(...)`; pass `provider` to the engine; use `score` at `:524`. Contained — the resolver has one real run-path caller.
+- **Couple flag for strategy:** the authored path EAGER-builds the corpus at resolve (vs lazy at engine-call). Behavior-equivalent for a single run (built once, cached, reused by the engine); moves the no-mint gate firing earlier (still before score + ledger write). Flag in the PR for seam-1/2 review.

--- a/.totem/specs/d4-reachable-flip.md
+++ b/.totem/specs/d4-reachable-flip.md
@@ -184,3 +184,19 @@ score = (base) => {
 - **`heldOutPrs`:** `new Set(split.heldOutPrs)`, captured in the authored closure at resolve (split already loaded there).
 - **Caller change (`:507`):** `const { provider, score } = await resolveCertifyingCorpusProvider(...)`; pass `provider` to the engine; use `score` at `:524`. Contained — the resolver has one real run-path caller.
 - **Couple flag for strategy:** the authored path EAGER-builds the corpus at resolve (vs lazy at engine-call). Behavior-equivalent for a single run (built once, cached, reused by the engine); moves the no-mint gate firing earlier (still before score + ledger write). Flag in the PR for seam-1/2 review.
+
+---
+
+## D4 COUPLE RESOLUTION — strategy CONDITIONAL PASS (0102Z) → clean bless owed on one row
+
+Strategy's independent-source-read couple verdict on #2285: **4 seams CONFORM** (Q1 single-home, Q3 no-mint firing, Q1 threading guard, Q2/Q4 Gate-2 emit); both build-altitude flags **APPROVED** (eager-build called "better, not just equivalent"). One row OWED before clean bless:
+
+- **Row (viii) — §6 cull-unbroken (codex assertion #1; greptile P2 @ `:492`):** ADDED. A `fix-shaped` differential ⇒ `authoredControls.positive: []` + an `illegitimate` non-emission ⇒ the run FAILs (precision null), `authoredControlGate.illegitimate === 1` / `effect === 'fail-illegitimate'`, `gate2.windowDisqualified`, and CRUCIALLY it does **not** degenerate to a mined PASS via `positiveControlTargets: []`. Core-altitude sibling: `windtunnel-scorer-authored.test.ts` codex-1.
+
+**Bot findings (strategy: my lane, behavior correct, style/perf) — FIXED, not declined (convention-consistency, kills re-review churn):**
+- **CR Major (`:19` static import):** the scorers are now dynamic-`import('@mmnto/totem')`ed at the resolver top (the file's own convention; the sync `score` closure closes over the captured refs). Static value import removed.
+- **greptile P2 (`:691` dropped lock param):** the authored provider's `_lock: WindtunnelLock` param restored (CertifyingCorpusProvider signature parity + self-documented intentional ignore).
+
+**Build-altitude (b) hardening (strategy non-blocking note) — DEFERRED-WITH-RATIONALE (noted here, not guarded):** an assert that an injected `certifyingCorpus` carries no `authoredControls` would make the mined-only invariant structural vs by-convention. NOT added: the path is production-unreachable (authored flows only through the resolver's eager build), and adding a check to the mined `score` branch would risk the mined-byte-unchanged property this slice guarantees. The by-construction invariant holds; a structural guard is a future defense-in-depth item, not a D4 blocker.
+
+**§8 D3→D4 currency pin:** strategy lands it LOCKSTEP on the operator's named `merge #2285` (#793 pattern, grep-sweeping the whole ADR). Merge is operator-gated.

--- a/.totem/specs/d4-reachable-flip.md
+++ b/.totem/specs/d4-reachable-flip.md
@@ -194,6 +194,7 @@ Strategy's independent-source-read couple verdict on #2285: **4 seams CONFORM** 
 - **Row (viii) — §6 cull-unbroken (codex assertion #1; greptile P2 @ `:492`):** ADDED. A `fix-shaped` differential ⇒ `authoredControls.positive: []` + an `illegitimate` non-emission ⇒ the run FAILs (precision null), `authoredControlGate.illegitimate === 1` / `effect === 'fail-illegitimate'`, `gate2.windowDisqualified`, and CRUCIALLY it does **not** degenerate to a mined PASS via `positiveControlTargets: []`. Core-altitude sibling: `windtunnel-scorer-authored.test.ts` codex-1.
 
 **Bot findings (strategy: my lane, behavior correct, style/perf) — FIXED, not declined (convention-consistency, kills re-review churn):**
+
 - **CR Major (`:19` static import):** the scorers are now dynamic-`import('@mmnto/totem')`ed at the resolver top (the file's own convention; the sync `score` closure closes over the captured refs). Static value import removed.
 - **greptile P2 (`:691` dropped lock param):** the authored provider's `_lock: WindtunnelLock` param restored (CertifyingCorpusProvider signature parity + self-documented intentional ignore).
 

--- a/packages/cli/src/commands/spine-authored-cert-corpus.test.ts
+++ b/packages/cli/src/commands/spine-authored-cert-corpus.test.ts
@@ -721,4 +721,47 @@ describe('ADR-112 D4 — reachable flip: resolved.score(base) end-to-end', () =>
     // The O3 metric is label-independent (verdict-inert): the unlabeled held-out firing still counts.
     expect(scored.verdict.heldOutActivationsByRule).toEqual({ [ruleId]: 1 });
   });
+
+  it('(viii) §6 cull-unbroken: a fix-shaped differential ⇒ positive:[] + illegitimate non-emission ⇒ FAIL, never a mined PASS via empty positives (codex assertion #1)', async () => {
+    writeAuthoredYaml(totemDir);
+    const split: SplitArtifact = { ...SPLIT, trainPrs: [1], heldOutPrs: [2] };
+    const { prDiffsSha, groundTruthSha } = writeSubstrate(gate1Dir, { split });
+    const alock = authoredLock(prDiffsSha, groundTruthSha);
+    // fix-shaped: the §4 differential culls every fixture to an illegitimate non-emission —
+    // NOTHING reaches positive[]. resolveAuthored is not reusable here (it reads positive[0]).
+    const resolved = await resolveCertifyingCorpusProvider(
+      alock,
+      inputs({ authoredControlsDeps: diffDeps('fix-shaped') }),
+    );
+    const corpus = await resolved.provider(alock);
+
+    // The §6 cull holds end-to-end: a fix-shaped fixture lands in nonEmissions, never positive[].
+    expect(corpus.authoredControls!.positive).toEqual([]);
+    expect(corpus.authoredControls!.nonEmissions).toHaveLength(1);
+    expect(corpus.authoredControls!.nonEmissions[0]!.class).toBe('illegitimate');
+
+    const ruleId = corpus.rules[0]!.lessonHash;
+    // The hazard codex assertion #1 guards: an empty positive control MUST NOT let the run
+    // degenerate to a mined PASS via positiveControlTargets:[] — the illegitimate non-emission
+    // FAILs the whole window. (Core-altitude sibling: windtunnel-scorer-authored.test.ts codex-1.)
+    const scored = resolved.score(
+      baseScorerInput({
+        firings: [],
+        groundTruth: new Map(),
+        mintedRuleIds: [ruleId],
+        positiveControlTargets: [],
+      }),
+    );
+
+    expect(scored.kind).toBe('authored');
+    if (scored.kind !== 'authored') throw new Error('unreachable');
+    // NOT a silent mined PASS — a structural, no-claim FAIL (precision null, never 0).
+    expect(scored.verdict.verdict).toBe('FAIL');
+    expect(scored.verdict.precision).toBeNull();
+    expect(scored.verdict.authoredControlGate.illegitimate).toBe(1);
+    expect(scored.verdict.authoredControlGate.effect).toBe('fail-illegitimate');
+    // Gate-2: illegitimate > 0 ⇒ window disqualified ⇒ no survivor eligible (Q4).
+    expect(scored.gate2.windowDisqualified).toBe(true);
+    expect(scored.gate2.eligibleRuleIds).toEqual([]);
+  });
 });

--- a/packages/cli/src/commands/spine-authored-cert-corpus.test.ts
+++ b/packages/cli/src/commands/spine-authored-cert-corpus.test.ts
@@ -334,13 +334,12 @@ describe('resolveCertifyingCorpusProvider — producerKind dispatch (D2 async si
   const lock = (overrides: Record<string, unknown>): WindtunnelLock =>
     ({ controls: { integrity: {} }, ...overrides }) as unknown as WindtunnelLock;
 
-  it('a mined lock (explicit or absent) resolves to a provider with no authored block', async () => {
-    await expect(
-      resolveCertifyingCorpusProvider(lock({ producerKind: 'mined' }), inputs()),
-    ).resolves.toBeTypeOf('function');
-    await expect(resolveCertifyingCorpusProvider(lock({}), inputs())).resolves.toBeTypeOf(
-      'function',
-    );
+  it('a mined lock (explicit or absent) resolves to a { provider, score } bundle', async () => {
+    for (const overrides of [{ producerKind: 'mined' }, {}]) {
+      const resolved = await resolveCertifyingCorpusProvider(lock(overrides), inputs());
+      expect(resolved.provider).toBeTypeOf('function');
+      expect(resolved.score).toBeTypeOf('function');
+    }
   });
 
   it('an authored lock WITHOUT an `authored` block fails loud (require-when-authored)', async () => {
@@ -377,10 +376,12 @@ describe('resolveCertifyingCorpusProvider — producerKind dispatch (D2 async si
       authored: { expectedSplitRef: SPLIT_REF },
       controls: { integrity: { prDiffsSha, groundTruthSha } },
     });
-    const provider = await resolveCertifyingCorpusProvider(
+    const { provider, score } = await resolveCertifyingCorpusProvider(
       authoredLock,
       inputs({ authoredControlsDeps: diffDeps('differential-holds') }),
     );
+    // D4: the §8 single home also binds the producer-kind scorer alongside the provider.
+    expect(score).toBeTypeOf('function');
     const corpus = await provider(authoredLock);
     expect(corpus.authoredControls).toBeDefined();
     expect(corpus.authoredControls!.positive).toHaveLength(1);

--- a/packages/cli/src/commands/spine-authored-cert-corpus.test.ts
+++ b/packages/cli/src/commands/spine-authored-cert-corpus.test.ts
@@ -8,12 +8,16 @@ import { stringify } from 'yaml';
 
 import type {
   AuthoredControlsDeps,
+  GroundTruthLabel,
   PreimageDifferentialOutcome,
   PreimageDifferentialResult,
+  RuleFiring,
+  ScorerInput,
   SplitArtifact,
   Stage4VerifierDeps,
   WindtunnelLock,
 } from '@mmnto/totem';
+import { firingLabelId, scoreWindtunnel } from '@mmnto/totem';
 
 import { runRuleAuthor } from '../authored-rule-intake.js';
 import {
@@ -486,5 +490,235 @@ describe('assembleAuthoredCertifyingCorpus (D2.6 derive-path sibling)', () => {
     await expect(assembleAuthoredCertifyingCorpus(opts(), authoredLock)).rejects.toThrow(
       /pr-diffs\.json integrity/,
     );
+  });
+});
+
+// ─── 6. Slice D4 — the reachable flip: resolved.score(base) end-to-end ─────────
+//
+// The whole-path couple strategy reviews (ruling 2318Z, Q4 — 4 seams): (1) authored
+// corpus resolution (§8 single-home), (2) the no-mint verifyOnly gate FIRING, (3)
+// scoreAuthoredWindtunnel invocation (Q1 threading guard), (4) the Gate-2 emit
+// (verdict-inert, §1(k)-guarded). These rows drive a REAL resolve → real scorer
+// (never a mock) → real deriveGate2Eligibility, reusing the D1–D3 fixtures.
+
+describe('ADR-112 D4 — reachable flip: resolved.score(base) end-to-end', () => {
+  let gate1Dir: string;
+  beforeEach(() => {
+    gate1Dir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-d4-gate1-'));
+  });
+  afterEach(() => {
+    fs.rmSync(gate1Dir, { recursive: true, force: true });
+  });
+
+  const inputs = (
+    extra: Partial<{ authoredControlsDeps: AuthoredControlsDeps }> = {},
+  ): Parameters<typeof resolveCertifyingCorpusProvider>[1] => ({
+    gate1Dir,
+    stage4: stage4(),
+    now: NOW,
+    totemDir,
+    ...extra,
+  });
+
+  const lock = (overrides: Record<string, unknown>): WindtunnelLock =>
+    ({ controls: { integrity: {} }, ...overrides }) as unknown as WindtunnelLock;
+
+  /** An authored lock bound to a substrate's integrity shas. */
+  const authoredLock = (prDiffsSha: string, groundTruthSha: string): WindtunnelLock =>
+    lock({
+      producerKind: 'authored',
+      authored: { expectedSplitRef: SPLIT_REF },
+      controls: { integrity: { prDiffsSha, groundTruthSha } },
+    });
+
+  /** A ScorerInput `base` (exposure floors 0 so a clean run reaches PASS). The authored
+   *  closure strips `positiveControlTargets` (Q1 guard); the mined closure keeps it. */
+  const baseScorerInput = (over: Partial<ScorerInput>): ScorerInput => ({
+    firings: [],
+    groundTruth: new Map(),
+    positiveControlTargets: [],
+    mintedRuleIds: [],
+    cullRateThreshold: 0.5,
+    exposureFloors: {
+      activeRulesEvaluated: 0,
+      filesTouchedInWindow: 0,
+      positiveControlsExercised: 0,
+    },
+    actualExposure: {
+      activeRulesEvaluated: 1,
+      filesTouchedInWindow: 5,
+      positiveControlsExercised: 1,
+    },
+    ...over,
+  });
+
+  const firing = (
+    ruleId: string,
+    pr: number,
+    controlKind: RuleFiring['controlKind'],
+    matchedLine = 'gen();',
+    filePath = 'src/a.ts',
+  ): RuleFiring => ({
+    ruleId,
+    pr,
+    filePath,
+    matchedLine,
+    controlKind,
+    labelId: firingLabelId(ruleId, pr, filePath, matchedLine),
+  });
+
+  /** Resolve an authored run over a split with held-out prs, then read the minted ruleId
+   *  the real corpus derived (the Gate-2 join-back key). */
+  const resolveAuthored = async (
+    split: SplitArtifact,
+  ): Promise<{
+    resolved: Awaited<ReturnType<typeof resolveCertifyingCorpusProvider>>;
+    ruleId: string;
+  }> => {
+    writeAuthoredYaml(totemDir);
+    const { prDiffsSha, groundTruthSha } = writeSubstrate(gate1Dir, { split });
+    const alock = authoredLock(prDiffsSha, groundTruthSha);
+    const resolved = await resolveCertifyingCorpusProvider(
+      alock,
+      inputs({ authoredControlsDeps: diffDeps('differential-holds') }),
+    );
+    const corpus = await resolved.provider(alock);
+    const ruleId = corpus.authoredControls!.positive[0]!.targetRuleId;
+    return { resolved, ruleId };
+  };
+
+  it('(i) authored happy path: resolve → real scoreAuthoredWindtunnel → PASS + Gate-2 eligible', async () => {
+    const split: SplitArtifact = { ...SPLIT, trainPrs: [1], heldOutPrs: [2] };
+    const { resolved, ruleId } = await resolveAuthored(split);
+
+    const ctrl = firing(ruleId, 1, 'positive', 'ctrl();'); // train-side positive control
+    const heldCorpus = firing(ruleId, 2, 'corpus', 'gen();'); // held-out generalization
+    const scored = resolved.score(
+      baseScorerInput({
+        firings: [ctrl, heldCorpus],
+        groundTruth: new Map<string, GroundTruthLabel>([
+          [ctrl.labelId, 'TP'],
+          [heldCorpus.labelId, 'TP'],
+        ]),
+        mintedRuleIds: [ruleId],
+        positiveControlTargets: [{ pr: 1, targetRuleId: ruleId }],
+      }),
+    );
+
+    expect(scored.kind).toBe('authored');
+    if (scored.kind !== 'authored') throw new Error('unreachable');
+    expect(scored.verdict.verdict).toBe('PASS');
+    // O3 metric: the held-out corpus firing counts; the train-side control does not.
+    expect(scored.verdict.heldOutActivationsByRule).toEqual({ [ruleId]: 1 });
+    // Gate-2: a non-disqualified window's survivor with heldOut>0 is eligible (§1(k) satisfied).
+    expect(scored.gate2.windowDisqualified).toBe(false);
+    expect(scored.gate2.eligibleRuleIds).toEqual([ruleId]);
+  });
+
+  it('(ii) no-mint gate FIRES: a would-be-minted rule ⇒ GATE_INVALID at resolve, scorer unreachable, ledger byte-unchanged', async () => {
+    writeAuthoredYaml(totemDir); // seeds YAML + ledger (rule → `unchanged` on re-read)
+    const { prDiffsSha, groundTruthSha } = writeSubstrate(gate1Dir);
+    const ledgerPath = path.join(totemDir, 'spine', 'authoring-ledger.ndjson');
+    const ledgerBefore = fs.readFileSync(ledgerPath, 'utf-8');
+
+    // agy's dynamic in-memory mutate: rewrite ONLY the YAML to add a SECOND (unledgered)
+    // rule — the cert re-derive would MINT it. Do NOT re-seed the ledger (no runRuleAuthor).
+    fs.writeFileSync(
+      path.join(totemDir, 'spine', 'authored-rules.yaml'),
+      stringify({
+        splitRef: SPLIT_REF,
+        authoredAfterSplit: true,
+        heldOutNonInspectionAttestation: true,
+        rules: [
+          authoredRuleInput(),
+          authoredRuleInput({ targetDefect: 'a SECOND distinct defect' }),
+        ],
+      }),
+      'utf-8',
+    );
+
+    // The gate throws during the resolver's EAGER build — before `score` is returned (a
+    // stronger guarantee than a scorer spy: the closure never exists to be called).
+    await expect(
+      resolveCertifyingCorpusProvider(
+        authoredLock(prDiffsSha, groundTruthSha),
+        inputs({ authoredControlsDeps: diffDeps('differential-holds') }),
+      ),
+    ).rejects.toThrow(/would be authored \(minted\/revised\)/);
+
+    // §8 no-mint: the cert re-derive is read-only — the gate fired before Pass-2 append.
+    expect(fs.readFileSync(ledgerPath, 'utf-8')).toBe(ledgerBefore);
+  });
+
+  it('(v) mined path regression: producerKind absent ⇒ kind mined, NO gate2 key, verdict byte-identical to scoreWindtunnel', async () => {
+    const resolved = await resolveCertifyingCorpusProvider(lock({}), inputs());
+
+    const ctrl = firing('mined-rule', 1, 'positive', 'ctrl();');
+    const base = baseScorerInput({
+      firings: [ctrl],
+      groundTruth: new Map<string, GroundTruthLabel>([[ctrl.labelId, 'TP']]),
+      mintedRuleIds: ['mined-rule'],
+      positiveControlTargets: [{ pr: 1, targetRuleId: 'mined-rule' }],
+    });
+    const scored = resolved.score(base);
+
+    expect(scored.kind).toBe('mined');
+    // The mined bundle carries NO Gate-2 surface at all (not an empty one).
+    expect('gate2' in scored).toBe(false);
+    // Byte-identity: the mined closure is a pass-through to the real scoreWindtunnel.
+    expect(scored.verdict).toEqual(scoreWindtunnel(base));
+  });
+
+  it('(vi) cross-partition leakage guard: a train-only-activating rule → zero held-out → excluded from Gate-2 despite PASS', async () => {
+    const split: SplitArtifact = { ...SPLIT, trainPrs: [1], heldOutPrs: [2] };
+    // Structural guard: the partitions the metric keys off are disjoint (heldOut ∩ train = ∅).
+    expect(split.heldOutPrs.some((pr) => split.trainPrs.includes(pr))).toBe(false);
+    const { resolved, ruleId } = await resolveAuthored(split);
+
+    const ctrl = firing(ruleId, 1, 'positive', 'ctrl();'); // train-side ONLY — no held-out corpus firing
+    const scored = resolved.score(
+      baseScorerInput({
+        firings: [ctrl],
+        groundTruth: new Map<string, GroundTruthLabel>([[ctrl.labelId, 'TP']]),
+        mintedRuleIds: [ruleId],
+        positiveControlTargets: [{ pr: 1, targetRuleId: ruleId }],
+      }),
+    );
+
+    expect(scored.kind).toBe('authored');
+    if (scored.kind !== 'authored') throw new Error('unreachable');
+    // Clean rare-defect window: the verdict PASSES…
+    expect(scored.verdict.verdict).toBe('PASS');
+    expect(scored.verdict.heldOutActivationsByRule).toEqual({ [ruleId]: 0 });
+    // …yet Gate-2 excludes the rule (survivor recorded, ineligible at zero held-out).
+    expect(scored.gate2.survivors).toEqual([
+      { ruleId, heldOutActivations: 0, gate2Eligible: false },
+    ]);
+    expect(scored.gate2.eligibleRuleIds).toEqual([]);
+  });
+
+  it('(vii) unlabeled-demotion partition: held-out UNLABELED corpus firing ⇒ HONEST-NEGATIVE, no FP, metric verdict-inert', async () => {
+    const split: SplitArtifact = { ...SPLIT, trainPrs: [1], heldOutPrs: [2] };
+    const { resolved, ruleId } = await resolveAuthored(split);
+
+    const ctrl = firing(ruleId, 1, 'positive', 'ctrl();'); // train-side, TP-labeled
+    const unlabeled = firing(ruleId, 2, 'corpus', 'gen();'); // held-out, NO ground-truth entry
+    const scored = resolved.score(
+      baseScorerInput({
+        firings: [ctrl, unlabeled],
+        groundTruth: new Map<string, GroundTruthLabel>([[ctrl.labelId, 'TP']]),
+        mintedRuleIds: [ruleId],
+        positiveControlTargets: [{ pr: 1, targetRuleId: ruleId }],
+      }),
+    );
+
+    expect(scored.kind).toBe('authored');
+    if (scored.kind !== 'authored') throw new Error('unreachable');
+    // Clean demotion — needs adjudication, NOT a FAIL/FP.
+    expect(scored.verdict.verdict).toBe('HONEST-NEGATIVE');
+    expect(scored.verdict.needsAdjudication).toContain(unlabeled.labelId);
+    expect(scored.gate2.windowDisqualified).toBe(false);
+    // The O3 metric is label-independent (verdict-inert): the unlabeled held-out firing still counts.
+    expect(scored.verdict.heldOutActivationsByRule).toEqual({ [ruleId]: 1 });
   });
 });

--- a/packages/cli/src/commands/spine-cert-persist.test.ts
+++ b/packages/cli/src/commands/spine-cert-persist.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import type {
   CompiledRule,
+  Gate2Eligibility,
   ProvenanceRecord,
   RuleFiring,
   WindtunnelVerdict,
@@ -147,5 +148,30 @@ describe('persistCertifyingOutcome', () => {
   it('the report filename embeds the injected timestamp slug + a run-identity hash', async () => {
     const result = await persistCertifyingOutcome(baseInput(makeVerdict('PASS')));
     expect(path.basename(result.reportPath)).toMatch(/^run-20260620T235959-[0-9a-f]{12}\.json$/);
+  });
+
+  it('authored run ⟹ the verdict-inert gate2 set persists as a TOP-LEVEL report field, not folded into verdict (D4 Q2)', async () => {
+    const gate2: Gate2Eligibility = {
+      eligibleRuleIds: ['r1'],
+      survivors: [
+        { ruleId: 'r1', heldOutActivations: 3, gate2Eligible: true },
+        { ruleId: 'r2', heldOutActivations: 0, gate2Eligible: false },
+      ],
+      windowDisqualified: false,
+    };
+    const result = await persistCertifyingOutcome({ ...baseInput(makeVerdict('PASS')), gate2 });
+
+    const report = JSON.parse(fs.readFileSync(result.reportPath, 'utf-8'));
+    // Serialized in full (shape, not just presence) as a top-level sibling of `verdict`.
+    expect(report.gate2).toEqual(gate2);
+    // Altitude separation: gate2 is DERIVED from the verdict, never part of it.
+    expect('gate2' in report.verdict).toBe(false);
+  });
+
+  it('mined/default run ⟹ the report OMITS the gate2 key entirely (not null)', async () => {
+    const result = await persistCertifyingOutcome(baseInput(makeVerdict('PASS')));
+    const report = JSON.parse(fs.readFileSync(result.reportPath, 'utf-8'));
+    // Key is absent, not serialized-as-null — a mined run has no Gate-2 emission.
+    expect('gate2' in report).toBe(false);
   });
 });

--- a/packages/cli/src/commands/spine-cert-persist.ts
+++ b/packages/cli/src/commands/spine-cert-persist.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 
 import type {
   CompiledRule,
+  Gate2Eligibility,
   LegitimacyProjectionSkip,
   ProvenanceRecord,
   RuleFiring,
@@ -38,6 +39,14 @@ export interface CertPersistInput {
   nowIso: string;
   /** Corpus identity for the report (the lock's asOfCommit). */
   asOfCommit: string;
+  /**
+   * ADR-112 §5.3 Slice D4 (strategy Q2) — the downstream, VERDICT-INERT Gate-2-eligible
+   * set for an authored run (`survivors ∩ {heldOut>0}`, §1(k)-guarded + illegitimate-window
+   * disqualifier). Absent on mined runs. Persisted as a top-level report field (a sibling of
+   * `verdict`, NOT folded into it): it is DERIVED from the verdict, never part of it, so the
+   * durable artifact keeps the two altitudes legibly separate.
+   */
+  gate2?: Gate2Eligibility;
 }
 
 export interface CertPersistResult {
@@ -120,6 +129,9 @@ export async function persistCertifyingOutcome(
     generatedAt: input.nowIso,
     asOfCommit: input.asOfCommit,
     verdict: input.verdict,
+    // D4 (strategy Q2): verdict-inert Gate-2 eligibility, authored runs only. Top-level
+    // sibling of `verdict` — derived from it, never part of it (mined runs omit the key).
+    ...(input.gate2 ? { gate2: input.gate2 } : {}),
     persisted,
     stampedRuleIds: projection.stamped.map((r) => r.lessonHash),
     skips: projection.skips,

--- a/packages/cli/src/commands/spine-cert-run-corpus.ts
+++ b/packages/cli/src/commands/spine-cert-run-corpus.ts
@@ -21,10 +21,7 @@ import { deriveGate2Eligibility, scoreAuthoredWindtunnel, scoreWindtunnel } from
 /** Local alias for the core git exec port (mirrors spine-windtunnel.ts / spine-cert-materialize.ts). */
 type SafeExecFn = typeof import('@mmnto/totem').safeExec;
 
-import {
-  buildAuthoredCertifyingCorpus,
-  type BuildAuthoredCertifyingCorpusDeps,
-} from './spine-authored-cert-corpus.js';
+import { buildAuthoredCertifyingCorpus } from './spine-authored-cert-corpus.js';
 import { buildCertifyingCorpus } from './spine-cert-corpus.js';
 import { buildReplayAdapters } from './spine-cert-record.js';
 import { type ReplayArtifact, ReplayArtifactSchema } from './spine-llm-replay.js';
@@ -479,22 +476,6 @@ export function buildReplayCorpusProvider(
 
     return corpus;
   };
-}
-
-/**
- * ADR-112 §6/§9 Slice D1 — the AUTHORED `CertifyingCorpusProvider`, the sibling of
- * `buildReplayCorpusProvider`. A thin adapter over `buildAuthoredCertifyingCorpus`
- * (authored records → compile → §6 controls). It ignores the `lock`: the authored
- * corpus is PRODUCER-driven, and the producer-independent scoring substrate
- * (split / prDiffs / groundTruth) is supplied explicitly via `deps`. The lock-driven
- * sourcing of that substrate (D2) lives in `resolveCertifyingCorpusProvider`, which
- * builds these `deps` from `loadAuthoredCertRunFixtures` + the lock's `authored` block.
- */
-export function buildAuthoredCorpusProvider(
-  deps: BuildAuthoredCertifyingCorpusDeps,
-): CertifyingCorpusProvider {
-  return async (_lock: WindtunnelLock): Promise<CertifyingCorpus> =>
-    buildAuthoredCertifyingCorpus(deps);
 }
 
 /** Injected inputs for the AUTHORED window-wide answer-key deriver's assembly (D2.6). */

--- a/packages/cli/src/commands/spine-cert-run-corpus.ts
+++ b/packages/cli/src/commands/spine-cert-run-corpus.ts
@@ -11,10 +11,12 @@ import type {
   ResolvedPrDiff,
   ReviewThreadContent,
   ReviewThreadSource,
+  ScorerInput,
   SplitLedger,
   Stage4VerifierDeps,
   WindtunnelLock,
 } from '@mmnto/totem';
+import { deriveGate2Eligibility, scoreAuthoredWindtunnel, scoreWindtunnel } from '@mmnto/totem';
 
 /** Local alias for the core git exec port (mirrors spine-windtunnel.ts / spine-cert-materialize.ts). */
 type SafeExecFn = typeof import('@mmnto/totem').safeExec;
@@ -26,7 +28,12 @@ import {
 import { buildCertifyingCorpus } from './spine-cert-corpus.js';
 import { buildReplayAdapters } from './spine-cert-record.js';
 import { type ReplayArtifact, ReplayArtifactSchema } from './spine-llm-replay.js';
-import type { CertifyingCorpus, CertifyingCorpusProvider } from './spine-windtunnel.js';
+import type {
+  CertifyingCorpus,
+  CertifyingCorpusProvider,
+  ResolvedCertifyingRun,
+  ScoredRun,
+} from './spine-windtunnel.js';
 
 // ─── Fixture file names under the gate-1 dir ─────────
 
@@ -621,7 +628,7 @@ export interface ResolveCorpusProviderInputs {
 export async function resolveCertifyingCorpusProvider(
   lock: WindtunnelLock,
   inputs: ResolveCorpusProviderInputs,
-): Promise<CertifyingCorpusProvider> {
+): Promise<ResolvedCertifyingRun> {
   const producerKind = lock.producerKind ?? 'mined';
   if (producerKind === 'authored') {
     const { TotemError } = await import('@mmnto/totem');
@@ -666,7 +673,12 @@ export async function resolveCertifyingCorpusProvider(
       expectedGroundTruthSha: groundTruthSha,
     });
 
-    return buildAuthoredCorpusProvider({
+    // §8 single home (D4 reachable flip): EAGER-build the authored corpus HERE so the scorer
+    // binds to THIS run's authored substrate (authoredControls + heldOutPrs) at resolution
+    // time. This also runs the D2.5 no-mint `verifyOnly` gate at the EARLIEST point — before
+    // the engine, before any scorer call or ledger write (codex Q2). Built once; the provider
+    // hands the SAME corpus to the engine, so the firings score the corpus that was built.
+    const authoredCorpus = await buildAuthoredCertifyingCorpus({
       totemDir: inputs.totemDir,
       // NO judgedBy — it is the §8 single source in the authoring-ledger, derived inside
       // buildAuthoredCertifyingCorpus (strategy (iii)); the lock must not be a second source.
@@ -678,15 +690,50 @@ export async function resolveCertifyingCorpusProvider(
       now: inputs.now,
       ...(inputs.authoredControlsDeps ? { authoredControlsDeps: inputs.authoredControlsDeps } : {}),
     });
+
+    // Fail-loud, NEVER fall back to the mined scorer (codex Q1): an authored corpus MUST carry
+    // its §6 controls (defined-with-empty-arrays for a no-fixture author, never undefined). A
+    // missing substrate scored by the mined scorer would silently PASS a culled differential.
+    if (!authoredCorpus.authoredControls) {
+      throw new TotemError(
+        'GATE_INVALID',
+        'Certifying run (authored): the authored corpus produced no `authoredControls` — the §6 ' +
+          'emission substrate is unbound. Refusing to score an authored corpus with the mined scorer ' +
+          '(ADR-112 §5.3 D4 — that would silently PASS a culled differential).',
+        'Re-derive the authored controls (`spine windtunnel derive-labels`) and re-freeze the cert corpus.',
+      );
+    }
+    const authoredControls = authoredCorpus.authoredControls;
+    const heldOutPrs: ReadonlySet<number> = new Set(split.heldOutPrs);
+
+    return {
+      provider: async (): Promise<CertifyingCorpus> => authoredCorpus,
+      score: (base: ScorerInput): ScoredRun => {
+        // Q1 threading guard: positives are derived INSIDE scoreAuthoredWindtunnel from
+        // `authoredControls.positive` — never double-source `engineResult.positiveControlTargets`
+        // (that reopens the postimage re-proof the D3 reduction discharged).
+        const { positiveControlTargets: _minedPositives, ...rest } = base;
+        const verdict = scoreAuthoredWindtunnel({ ...rest, authoredControls, heldOutPrs });
+        // Gate-2 eligibility is DOWNSTREAM of the scorer (Q2): the scorer emits raw
+        // heldOutActivationsByRule; the intersection (+ §1(k) + the Q4 illegitimate-window
+        // disqualifier) is derived here, verdict-inert.
+        const gate2 = deriveGate2Eligibility({ mintedRuleIds: base.mintedRuleIds, verdict });
+        return { kind: 'authored', verdict, gate2 };
+      },
+    };
   }
 
-  return buildReplayCorpusProvider({
-    gate1Dir: inputs.gate1Dir,
-    stage4: inputs.stage4,
-    now: inputs.now,
-    ...(inputs.seedClassesProvided !== undefined
-      ? { seedClassesProvided: inputs.seedClassesProvided }
-      : {}),
-    ...(inputs.onLedgers ? { onLedgers: inputs.onLedgers } : {}),
-  });
+  return {
+    provider: buildReplayCorpusProvider({
+      gate1Dir: inputs.gate1Dir,
+      stage4: inputs.stage4,
+      now: inputs.now,
+      ...(inputs.seedClassesProvided !== undefined
+        ? { seedClassesProvided: inputs.seedClassesProvided }
+        : {}),
+      ...(inputs.onLedgers ? { onLedgers: inputs.onLedgers } : {}),
+    }),
+    // Mined path byte-unchanged: the mined scorer, no authored overhead (gemini Q3 non-interference).
+    score: (base: ScorerInput): ScoredRun => ({ kind: 'mined', verdict: scoreWindtunnel(base) }),
+  };
 }

--- a/packages/cli/src/commands/spine-cert-run-corpus.ts
+++ b/packages/cli/src/commands/spine-cert-run-corpus.ts
@@ -16,7 +16,6 @@ import type {
   Stage4VerifierDeps,
   WindtunnelLock,
 } from '@mmnto/totem';
-import { deriveGate2Eligibility, scoreAuthoredWindtunnel, scoreWindtunnel } from '@mmnto/totem';
 
 /** Local alias for the core git exec port (mirrors spine-windtunnel.ts / spine-cert-materialize.ts). */
 type SafeExecFn = typeof import('@mmnto/totem').safeExec;
@@ -610,10 +609,12 @@ export async function resolveCertifyingCorpusProvider(
   lock: WindtunnelLock,
   inputs: ResolveCorpusProviderInputs,
 ): Promise<ResolvedCertifyingRun> {
+  // Dynamic import (CLI lazy-load convention — CR #2285): @mmnto/totem is heavy; the scorers
+  // are captured here (the resolver is async) and closed over by the sync `score` bundle below.
+  const { TotemError, scoreWindtunnel, scoreAuthoredWindtunnel, deriveGate2Eligibility } =
+    await import('@mmnto/totem');
   const producerKind = lock.producerKind ?? 'mined';
   if (producerKind === 'authored') {
-    const { TotemError } = await import('@mmnto/totem');
-
     // require-when-authored (codex): the lock's `authored` run-input block is mandatory at
     // cert resolve. The schema enforces only the reject-unless direction (a stray block on a
     // mined lock) — a producerKind:'authored' lock can predate its inputs, so the *require*
@@ -688,7 +689,10 @@ export async function resolveCertifyingCorpusProvider(
     const heldOutPrs: ReadonlySet<number> = new Set(split.heldOutPrs);
 
     return {
-      provider: async (): Promise<CertifyingCorpus> => authoredCorpus,
+      // The lock is accepted (CertifyingCorpusProvider contract) but intentionally ignored:
+      // the corpus is eager-built + captured at resolve, so provider-call time needs nothing
+      // from it (greptile #2285 P2 — signature parity + self-documented intentional ignore).
+      provider: async (_lock: WindtunnelLock): Promise<CertifyingCorpus> => authoredCorpus,
       score: (base: ScorerInput): ScoredRun => {
         // Q1 threading guard: positives are derived INSIDE scoreAuthoredWindtunnel from
         // `authoredControls.positive` — never double-source `engineResult.positiveControlTargets`

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -362,6 +362,34 @@ export interface CertifyingCorpus {
   authoredControls?: import('@mmnto/totem').AuthoredControls;
 }
 
+/**
+ * ADR-112 §5.3/§8 Slice D4 — the scored run, discriminated by producer kind. The
+ * `kind` is a lineage marker (gemini Q3): it is DERIVED once at the §8 single home
+ * (`resolveCertifyingCorpusProvider`) and carried on the result — never re-read from
+ * the lock downstream (Tenet-20 derive-not-mirror). The authored arm carries the
+ * verdict-inert Gate-2 eligibility emission (§5.3, §1(k)-guarded).
+ */
+export type ScoredRun =
+  | { kind: 'mined'; verdict: import('@mmnto/totem').WindtunnelVerdict }
+  | {
+      kind: 'authored';
+      verdict: import('@mmnto/totem').AuthoredWindtunnelVerdict;
+      gate2: import('@mmnto/totem').Gate2Eligibility;
+    };
+
+/**
+ * ADR-112 §8 Slice D4 — what the §8 single dispatch home resolves: the corpus
+ * provider PLUS the producer-kind-bound scorer. Binding the scorer at the resolver
+ * (not branching at the score step) keeps `producerKind` read in ONE place — a
+ * second read at the score step could drift to the mined scorer over an authored
+ * corpus, silently PASSing a culled differential (strategy Q1 ruling 2026-07-01).
+ */
+export interface ResolvedCertifyingRun {
+  provider: CertifyingCorpusProvider;
+  /** Bound to this run's producer kind (+ authored substrate). `score(base)` is unconditional at the score step. */
+  score: (base: import('@mmnto/totem').ScorerInput) => ScoredRun;
+}
+
 /** Internal shape the run command's scorer + persist step consume (engine-agnostic). */
 interface EngineResult {
   mintedRuleIds: string[];
@@ -492,24 +520,33 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   const runNowIso = new Date().toISOString();
   // Certifying phase: use the injected corpus (tests) or build the REPLAY-mode
   // provider from the committed cert-run fixtures under the gate-1 dir (5c-ii).
+  // The scorer defaults to MINED (the harness mock + the injected 5c-i corpus seam, which is
+  // mined-only). The §8 single home (`resolveCertifyingCorpusProvider`) is the ONLY place that
+  // may bind the AUTHORED scorer — so authored-vs-mined is selected in exactly one location, and
+  // the score step below never re-reads `producerKind` (strategy D4 Q1: a second read could drift
+  // an authored corpus onto the mined scorer, silently PASSing a culled differential).
   let corpusProvider = opts.certifyingCorpus;
+  let score: ResolvedCertifyingRun['score'] = (base) => ({
+    kind: 'mined',
+    verdict: scoreWindtunnel(base),
+  });
   if (lock.phase === 'certifying' && !corpusProvider) {
     const gate1Dir = path.dirname(lockPath);
     const asOf = lock.corpus.selectionRule.asOfCommit;
     // Shared Stage-4 constructor (the deriver builds it the same way — no drift).
     const stage4 = buildGate1Stage4Deps(lcDir, asOf, safeExec);
-    // Single dispatch home (D1/D2): resolve mined-vs-authored off the lock's producerKind.
+    // Single dispatch home (D1/D2/D4): resolve mined-vs-authored off the lock's producerKind.
     // The caller passes raw run-context UNCONDITIONALLY (no `if (producerKind)` branch here —
     // that would leak the dispatch, gemini §8 single-home ruling); the resolver alone reads
-    // the kind. Mined (absent ⇒ mined) is byte-unchanged. Authored (D2) loads its scoring
-    // substrate + reads the lock's `authored` block inside the (now async) resolver. totemDir
-    // is the authored producer's `.totem` (authored path only; ignored on the mined path).
-    corpusProvider = await resolveCertifyingCorpusProvider(lock, {
+    // the kind, and returns BOTH the corpus provider AND the producer-kind-bound scorer (D4).
+    const resolved = await resolveCertifyingCorpusProvider(lock, {
       gate1Dir,
       stage4,
       now: runNowIso,
       totemDir: path.join(repoRoot, '.totem'),
     });
+    corpusProvider = resolved.provider;
+    score = resolved.score;
   }
 
   const engineResult =
@@ -520,8 +557,9 @@ export async function runCommand(opts: RunOptions): Promise<void> {
   const { mintedRuleIds, firings, groundTruth, positiveControlTargets, filesTouchedInWindow } =
     engineResult;
 
-  // Score
-  const verdict = scoreWindtunnel({
+  // Score — `score(base)` is UNCONDITIONAL (§8 single home): the producer-kind branch already
+  // happened at the resolver, never here. `scored.kind` is the derived lineage marker (gemini Q3).
+  const scored = score({
     firings,
     groundTruth,
     positiveControlTargets,
@@ -538,6 +576,7 @@ export async function runCommand(opts: RunOptions): Promise<void> {
       positiveControlsExercised: positiveControlTargets.length,
     },
   });
+  const verdict = scored.verdict;
 
   // Print verdict — exposure tuple never collapsed
   console.log(`WindtunnelVerdict: ${verdict.verdict}`);
@@ -572,6 +611,27 @@ export async function runCommand(opts: RunOptions): Promise<void> {
     for (const id of verdict.needsAdjudication) {
       console.log(`    • ${id}`);
     }
+  }
+
+  // ADR-112 §5.3 Slice D4 — the authored emissions (verdict-inert): the O3 held-out
+  // activation metric + the Gate-2-eligible set. Emitted, not hidden (Tenet-4; the §1(k)
+  // exclusions are legible), never consulted by the Gate-1 verdict printed above.
+  if (scored.kind === 'authored') {
+    const { verdict: authoredVerdict, gate2 } = scored;
+    const gate = authoredVerdict.authoredControlGate;
+    console.log(
+      `  authoredControlGate:  illegitimate=${gate.illegitimate} undecidable=${gate.undecidable} ` +
+        `deferred=${gate.deferred} effect=${gate.effect}`,
+    );
+    console.log(
+      `  heldOutActivations:   ${JSON.stringify(authoredVerdict.heldOutActivationsByRule)}`,
+    );
+    const gate2Summary = gate2.windowDisqualified
+      ? '(none — WINDOW DISQUALIFIED: illegitimate > 0)'
+      : gate2.eligibleRuleIds.length > 0
+        ? gate2.eligibleRuleIds.join(', ')
+        : '(none — no survivor had held-out activations)';
+    console.log(`  gate2Eligible (${gate2.eligibleRuleIds.length}): ${gate2Summary}`);
   }
 
   // 5c-ii: certifying-phase persistence — fold-B project → fold-C parse-before-write

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -653,6 +653,9 @@ export async function runCommand(opts: RunOptions): Promise<void> {
       reportDir: path.join(gate1Dir, 'run-reports'),
       nowIso: runNowIso,
       asOfCommit: lock.corpus.selectionRule.asOfCommit,
+      // D4 (strategy Q2): persist the verdict-inert Gate-2 set into the durable report,
+      // authored runs only (mined runs carry no gate2). Console emit above stays.
+      ...(scored.kind === 'authored' ? { gate2: scored.gate2 } : {}),
     });
     console.error(
       `[WindtunnelRun] Cert-run report: ${persistResult.reportPath}` +

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -948,6 +948,8 @@ export type {
   ReviewThreadSource,
 } from './spine/extract.js';
 export { classifyAuthorKind, DraftResultSchema, runExtractStage } from './spine/extract.js';
+export type { Gate2Eligibility, Gate2SurvivorRecord } from './spine/gate2-eligibility.js';
+export { deriveGate2Eligibility } from './spine/gate2-eligibility.js';
 export type {
   ApiFetchSlice,
   ApiUsageLedger,

--- a/packages/core/src/spine/gate2-eligibility.test.ts
+++ b/packages/core/src/spine/gate2-eligibility.test.ts
@@ -1,0 +1,293 @@
+// ─── ADR-112 §5.3 / §1(k) — Gate-2 eligibility derivation (slice D4) tests ────
+//
+// Pins the strategy D4 Q1/Q2/Q4 ruling (2026-07-01):
+//   • §1(k): a survivor with ZERO held-out activations (absent-from-map ≡ explicit
+//     0) is EXCLUDED — never admitted "as if held-out-certified".
+//   • Q4: `authoredControlGate.illegitimate > 0` disqualifies the WHOLE window,
+//     keyed on the COUNT, never on `.effect` (a co-severe mined FP FAIL can mask
+//     the illegitimate control: `effect: 'none'` while `illegitimate > 0`).
+//   • Culled rules are never survivors, even with held-out activations.
+//   • Deterministic: output preserves `mintedRuleIds` input order (Tenet-15).
+//
+// Drafted via a Fable draft-then-verify trial (model-tiering #697), verified
+// assertion-by-assertion against the source contract before landing.
+
+import { describe, expect, it } from 'vitest';
+
+import { deriveGate2Eligibility } from './gate2-eligibility.js';
+import type { CullLedgerEntry } from './windtunnel-scorer.js';
+import type {
+  AuthoredControlGate,
+  AuthoredWindtunnelVerdict,
+} from './windtunnel-scorer-authored.js';
+
+// ─── Helpers ─────────────────────────────────────────
+
+type Gate2Verdict = Pick<
+  AuthoredWindtunnelVerdict,
+  'cullLedger' | 'heldOutActivationsByRule' | 'authoredControlGate'
+>;
+
+/**
+ * A baseline verdict Pick: clean window (illegitimate 0, effect 'none'), nothing
+ * culled, no held-out entries. Each test overrides only what it exercises.
+ */
+function makeVerdict(overrides?: {
+  cullLedger?: CullLedgerEntry[];
+  heldOutActivationsByRule?: Record<string, number>;
+  authoredControlGate?: Partial<AuthoredControlGate>;
+}): Gate2Verdict {
+  return {
+    cullLedger: overrides?.cullLedger ?? [],
+    heldOutActivationsByRule: overrides?.heldOutActivationsByRule ?? {},
+    authoredControlGate: {
+      illegitimate: 0,
+      undecidable: 0,
+      deferred: 0,
+      effect: 'none',
+      ...overrides?.authoredControlGate,
+    },
+  };
+}
+
+function cullEntry(ruleId: string, pr = 10): CullLedgerEntry {
+  return {
+    ruleId,
+    pr,
+    filePath: 'src/foo.ts',
+    matchedLine: 'const x = 1;',
+    reason: 'negative-control-fired',
+  };
+}
+
+// ─── §5.3: a survivor with held-out activations in a clean window ─────────────
+
+describe('§5.3 eligibility: survivors with held-out activations in a clean window', () => {
+  it('a survivor with heldOutActivations > 0 in a non-disqualified window is eligible', () => {
+    const result = deriveGate2Eligibility({
+      mintedRuleIds: ['r1'],
+      verdict: makeVerdict({ heldOutActivationsByRule: { r1: 3 } }),
+    });
+    expect(result).toEqual({
+      eligibleRuleIds: ['r1'],
+      survivors: [{ ruleId: 'r1', heldOutActivations: 3, gate2Eligible: true }],
+      windowDisqualified: false,
+    });
+  });
+});
+
+// ─── §1(k): zero held-out activations — never admitted "as if certified" ──────
+
+describe('§1(k): zero held-out activations are never admitted', () => {
+  it('§1(k): a survivor absent from heldOutActivationsByRule reports 0 and is excluded', () => {
+    const result = deriveGate2Eligibility({
+      mintedRuleIds: ['r1'],
+      verdict: makeVerdict(),
+    });
+    expect(result.eligibleRuleIds).toEqual([]);
+    expect(result.survivors).toEqual([
+      { ruleId: 'r1', heldOutActivations: 0, gate2Eligible: false },
+    ]);
+    expect(result.windowDisqualified).toBe(false);
+  });
+
+  it('§1(k): an explicit 0 entry (the common shape) is excluded, identical to absent', () => {
+    const explicit = deriveGate2Eligibility({
+      mintedRuleIds: ['r1'],
+      verdict: makeVerdict({ heldOutActivationsByRule: { r1: 0 } }),
+    });
+    expect(explicit.eligibleRuleIds).toEqual([]);
+    expect(explicit.survivors).toEqual([
+      { ruleId: 'r1', heldOutActivations: 0, gate2Eligible: false },
+    ]);
+
+    // Absent-from-map ≡ explicit 0 — the two shapes produce an identical emission.
+    const absent = deriveGate2Eligibility({
+      mintedRuleIds: ['r1'],
+      verdict: makeVerdict({ heldOutActivationsByRule: {} }),
+    });
+    expect(explicit).toEqual(absent);
+  });
+});
+
+// ─── Cull exclusion: a culled rule is never a survivor (codex case (d)) ───────
+
+describe('cull exclusion: culled rules are not survivors', () => {
+  it('a culled rule is not a survivor even with heldOutActivations > 0', () => {
+    const result = deriveGate2Eligibility({
+      mintedRuleIds: ['r1'],
+      verdict: makeVerdict({
+        cullLedger: [cullEntry('r1')],
+        heldOutActivationsByRule: { r1: 5 },
+      }),
+    });
+    // Absent from BOTH survivors[] and eligibleRuleIds — not merely ineligible.
+    expect(result).toEqual({
+      eligibleRuleIds: [],
+      survivors: [],
+      windowDisqualified: false,
+    });
+  });
+
+  it('multiple cull entries for one rule exclude it once, without disturbing others', () => {
+    const result = deriveGate2Eligibility({
+      mintedRuleIds: ['r1', 'r2'],
+      verdict: makeVerdict({
+        cullLedger: [cullEntry('r1', 10), cullEntry('r1', 11)],
+        heldOutActivationsByRule: { r1: 4, r2: 1 },
+      }),
+    });
+    expect(result).toEqual({
+      eligibleRuleIds: ['r2'],
+      survivors: [{ ruleId: 'r2', heldOutActivations: 1, gate2Eligible: true }],
+      windowDisqualified: false,
+    });
+  });
+});
+
+// ─── Q4: window disqualifier — keyed on the illegitimate COUNT, never .effect ─
+
+describe('Q4: window disqualifier keys on the illegitimate count, never on effect', () => {
+  it("Q4: illegitimate > 0 empties eligibility EVEN WHEN effect === 'none'", () => {
+    // The masked-control case (`1a80655e`): a co-severe mined FP FAIL absorbed the
+    // gate, so `effect` stayed 'none' while `illegitimate > 0`.
+    const heldOutActivationsByRule = { r1: 2 };
+    const disqualified = deriveGate2Eligibility({
+      mintedRuleIds: ['r1'],
+      verdict: makeVerdict({
+        heldOutActivationsByRule,
+        authoredControlGate: { illegitimate: 1, effect: 'none' },
+      }),
+    });
+    expect(disqualified.windowDisqualified).toBe(true);
+    expect(disqualified.eligibleRuleIds).toEqual([]);
+    // The audit trail stays legible: the survivor row reports the TRUE count, ineligible.
+    expect(disqualified.survivors).toEqual([
+      { ruleId: 'r1', heldOutActivations: 2, gate2Eligible: false },
+    ]);
+
+    // Companion: the SAME survivors with illegitimate === 0 (and the SAME effect)
+    // ARE eligible — the COUNT drives disqualification, not `.effect`.
+    const clean = deriveGate2Eligibility({
+      mintedRuleIds: ['r1'],
+      verdict: makeVerdict({
+        heldOutActivationsByRule,
+        authoredControlGate: { illegitimate: 0, effect: 'none' },
+      }),
+    });
+    expect(clean.windowDisqualified).toBe(false);
+    expect(clean.eligibleRuleIds).toEqual(['r1']);
+    expect(clean.survivors).toEqual([{ ruleId: 'r1', heldOutActivations: 2, gate2Eligible: true }]);
+  });
+
+  it('Q4: only the illegitimate count disqualifies — not undecidable/deferred/effect', () => {
+    // Reachable state: undecidable non-emissions demote to honest-negative while
+    // illegitimate === 0. The window is NOT disqualified for Gate-2 purposes.
+    const result = deriveGate2Eligibility({
+      mintedRuleIds: ['r1'],
+      verdict: makeVerdict({
+        heldOutActivationsByRule: { r1: 1 },
+        authoredControlGate: {
+          illegitimate: 0,
+          undecidable: 2,
+          deferred: 1,
+          effect: 'honest-negative-not-certifiable',
+        },
+      }),
+    });
+    expect(result.windowDisqualified).toBe(false);
+    expect(result.eligibleRuleIds).toEqual(['r1']);
+    expect(result.survivors).toEqual([
+      { ruleId: 'r1', heldOutActivations: 1, gate2Eligible: true },
+    ]);
+  });
+});
+
+// ─── Order / determinism (Tenet-15) ───────────────────────────────────────────
+
+describe('order / determinism (Tenet-15)', () => {
+  it('preserves mintedRuleIds input order in eligibleRuleIds and survivors', () => {
+    // Input order differs from sorted order — a sorted (or Set-iterated) impl fails.
+    const result = deriveGate2Eligibility({
+      mintedRuleIds: ['r3', 'r1', 'r2'],
+      verdict: makeVerdict({ heldOutActivationsByRule: { r1: 1, r2: 2, r3: 3 } }),
+    });
+    expect(result.eligibleRuleIds).toEqual(['r3', 'r1', 'r2']);
+    expect(result.survivors).toEqual([
+      { ruleId: 'r3', heldOutActivations: 3, gate2Eligible: true },
+      { ruleId: 'r1', heldOutActivations: 1, gate2Eligible: true },
+      { ruleId: 'r2', heldOutActivations: 2, gate2Eligible: true },
+    ]);
+  });
+
+  it('a mid-list cull removes its rule without disturbing the order of the rest', () => {
+    const result = deriveGate2Eligibility({
+      mintedRuleIds: ['r3', 'r1', 'r2'],
+      verdict: makeVerdict({
+        cullLedger: [cullEntry('r1')],
+        heldOutActivationsByRule: { r2: 2, r3: 3 },
+      }),
+    });
+    expect(result.eligibleRuleIds).toEqual(['r3', 'r2']);
+    expect(result.survivors.map((s) => s.ruleId)).toEqual(['r3', 'r2']);
+  });
+});
+
+// ─── Mixed window: the exact partition ────────────────────────────────────────
+
+describe('mixed window', () => {
+  it('partitions culled / eligible / zero-held-out rules exactly', () => {
+    const result = deriveGate2Eligibility({
+      mintedRuleIds: ['r1', 'r2', 'r3', 'r4', 'r5'],
+      verdict: makeVerdict({
+        // r2 is culled DESPITE held-out activations; r3 is an explicit 0; r4 is
+        // absent-from-map; r1/r5 are eligible.
+        cullLedger: [cullEntry('r2')],
+        heldOutActivationsByRule: { r1: 3, r2: 7, r3: 0, r5: 1 },
+      }),
+    });
+    expect(result).toEqual({
+      eligibleRuleIds: ['r1', 'r5'],
+      survivors: [
+        { ruleId: 'r1', heldOutActivations: 3, gate2Eligible: true },
+        { ruleId: 'r3', heldOutActivations: 0, gate2Eligible: false },
+        { ruleId: 'r4', heldOutActivations: 0, gate2Eligible: false },
+        { ruleId: 'r5', heldOutActivations: 1, gate2Eligible: true },
+      ],
+      windowDisqualified: false,
+    });
+  });
+});
+
+// ─── Empty window + non-minted inputs ─────────────────────────────────────────
+
+describe('empty window and non-minted inputs', () => {
+  it('empty mintedRuleIds → empty eligible set, empty survivors, not disqualified', () => {
+    const result = deriveGate2Eligibility({ mintedRuleIds: [], verdict: makeVerdict() });
+    expect(result).toEqual({ eligibleRuleIds: [], survivors: [], windowDisqualified: false });
+  });
+
+  it('empty mintedRuleIds still reports windowDisqualified when illegitimate > 0', () => {
+    // The Q4 flag is a window-level fact — reported even with nothing minted.
+    const result = deriveGate2Eligibility({
+      mintedRuleIds: [],
+      verdict: makeVerdict({ authoredControlGate: { illegitimate: 1 } }),
+    });
+    expect(result).toEqual({ eligibleRuleIds: [], survivors: [], windowDisqualified: true });
+  });
+
+  it('held-out keys and cull entries for non-minted rules never reach the output', () => {
+    const result = deriveGate2Eligibility({
+      mintedRuleIds: ['r1'],
+      verdict: makeVerdict({
+        cullLedger: [cullEntry('ghost-culled')],
+        heldOutActivationsByRule: { r1: 1, 'ghost-held-out': 5 },
+      }),
+    });
+    expect(result).toEqual({
+      eligibleRuleIds: ['r1'],
+      survivors: [{ ruleId: 'r1', heldOutActivations: 1, gate2Eligible: true }],
+      windowDisqualified: false,
+    });
+  });
+});

--- a/packages/core/src/spine/gate2-eligibility.ts
+++ b/packages/core/src/spine/gate2-eligibility.ts
@@ -1,0 +1,86 @@
+// ─── ADR-112 §5.3 — the Gate-2-eligible set (slice D4) ───────────────────────
+//
+// A DOWNSTREAM, verdict-inert derivation over the authored window-tunnel verdict.
+// It answers one question per surviving authored rule: is it eligible for Gate 2
+// (hard-enforce)? Per strategy's D4 Q1/Q2 ruling (2026-07-01, couple-on-merge):
+//
+//   • Q2 — this lives DOWNSTREAM of the scorer, NOT inside it (gemini/codex/agy +
+//     strategy unanimous, Tenet-20 join-back-once): `scoreAuthoredWindtunnel`
+//     emits the raw signal (`heldOutActivationsByRule` + `cullLedger`); THIS fn
+//     performs the intersection. It never re-scores and never touches the Gate-1
+//     verdict — the eligible set "affects only Gate-2 eligibility" (§5.3).
+//   • §1(k) is enforced HERE: a survivor with ZERO held-out activations is
+//     EXCLUDED — never admitted "as if held-out-certified". Absent-from-map ≡ an
+//     explicit `0` ≡ ineligible (codex: D3 records a non-culled rule with a valid
+//     positive control + zero held-out firings as an explicit `0`, not absent).
+//   • Q4 — a window with `authoredControlGate.illegitimate > 0` is FAIL-equivalent:
+//     NO survivor is eligible, EVEN WHEN `effect === 'none'` (a co-severe mined FP
+//     FAIL masked the illegitimate control — the equal-severity demote-only branch,
+//     `1a80655e`). We disqualify on the `illegitimate` COUNT, NEVER on `.effect`.
+//
+// Emitted, not hidden (§5.3, Tenet-4): a computed-but-hidden set is a silent
+// artifact. The per-survivor `survivors[]` record shows every survivor
+// considered + why excluded, so the (k) exclusion is auditable, not inferred.
+
+import type { AuthoredWindtunnelVerdict } from './windtunnel-scorer-authored.js';
+
+/** Per-survivor Gate-2 legibility — one row per surviving (non-culled) authored rule. */
+export interface Gate2SurvivorRecord {
+  ruleId: string;
+  /** Held-out non-control activation count (the §5.3 O3 metric). Absent-from-map is reported as 0. */
+  heldOutActivations: number;
+  /** Eligible ⟺ NOT window-disqualified AND `heldOutActivations > 0` (§1(k)). */
+  gate2Eligible: boolean;
+}
+
+/** The Gate-2 eligibility emission — a report field sibling to `heldOutActivationsByRule` (Q2). */
+export interface Gate2Eligibility {
+  /** The eligible rule ids — survivors with > 0 held-out activations in a non-disqualified window. */
+  eligibleRuleIds: string[];
+  /** Every survivor considered (the audit trail; (k) exclusions are legible here, not silent). */
+  survivors: Gate2SurvivorRecord[];
+  /** True ⟺ `authoredControlGate.illegitimate > 0` — the whole window is FAIL-equivalent (Q4). */
+  windowDisqualified: boolean;
+}
+
+/**
+ * Derive the Gate-2-eligible set from a scored authored verdict + the run's minted
+ * rule ids. Pure + deterministic (Tenet-15): output preserves `mintedRuleIds` order;
+ * no Set/Map iteration leaks into the result.
+ *
+ * `mintedRuleIds` is NOT a verdict field (the verdict carries only `mintedRuleCount`)
+ * — it is the run's minted set, threaded from the engine result. Keys align: an
+ * authored rule's `mintedRuleId` IS its `heldOutActivationsByRule` key (both are the
+ * persisted `ruleId`; C2a `firingLabelId ← ruleId`).
+ */
+export function deriveGate2Eligibility(input: {
+  mintedRuleIds: readonly string[];
+  verdict: Pick<
+    AuthoredWindtunnelVerdict,
+    'cullLedger' | 'heldOutActivationsByRule' | 'authoredControlGate'
+  >;
+}): Gate2Eligibility {
+  const { mintedRuleIds, verdict } = input;
+
+  // Q4: window-level disqualifier — keyed on the COUNT, never `.effect` (a co-severe
+  // mined FP FAIL can mask an illegitimate control: `effect: 'none'` while `illegitimate > 0`).
+  const windowDisqualified = verdict.authoredControlGate.illegitimate > 0;
+
+  const culledRuleIds = new Set(verdict.cullLedger.map((entry) => entry.ruleId));
+
+  // Survivors = minted \ culled. A culled rule is never Gate-2-eligible, even if it
+  // had held-out activations (codex case (d)).
+  const survivors: Gate2SurvivorRecord[] = mintedRuleIds
+    .filter((ruleId) => !culledRuleIds.has(ruleId))
+    .map((ruleId) => {
+      const heldOutActivations = verdict.heldOutActivationsByRule[ruleId] ?? 0;
+      const gate2Eligible = !windowDisqualified && heldOutActivations > 0;
+      return { ruleId, heldOutActivations, gate2Eligible };
+    });
+
+  const eligibleRuleIds = survivors
+    .filter((survivor) => survivor.gate2Eligible)
+    .map((survivor) => survivor.ruleId);
+
+  return { eligibleRuleIds, survivors, windowDisqualified };
+}


### PR DESCRIPTION
## ADR-112 §5.3/§6/§8 Slice D4 — the inert→ENFORCED reachable flip

D4 makes the authored certifying path **reachable** — the first slice that executes the authored producer end-to-end. Built to strategy's D4 contract ruling (`2026-07-01T2318Z`, Q1–Q4). The mined path is byte-unchanged.

### Whole-path couple — the 4 seams strategy reviews (Q4 ruling)

1. **Authored corpus resolution (§8 single-home, Q1).** `resolveCertifyingCorpusProvider` returns a `{ provider, score }` bundle; the producer-kind scorer is bound at the ONE dispatch home. The score step is an unconditional `resolved.score(base)` — no second `producerKind` read downstream (`scored.kind` is the derived discriminant, Tenet-20 derive-not-mirror = gemini's lineage marker). Mined ⇒ `scoreWindtunnel(base)`; authored ⇒ `scoreAuthoredWindtunnel({ ...base, authoredControls, heldOutPrs })`.
2. **No-mint `verifyOnly` gate FIRING (Q3).** On an authored run the D2.5 gate now fires reachably: a would-be `minted`/`revised` rule throws `GATE_INVALID` during the resolver's eager build — **before any scorer call or ledger write**, and fail-loud (never falls back to the mined scorer on a missing `authoredControls`, which would silently PASS a culled differential). No new gate code — reachability IS the flip.
3. **`scoreAuthoredWindtunnel` invocation (Q1 threading guard).** The `base` handed to the authored scorer **excludes** `engineResult.positiveControlTargets` — positives are derived inside the scorer from `authoredControls.positive` (never double-sourced; that would reopen the postimage re-proof the D3 reduction discharged).
4. **Gate-2 emit (Q2, verdict-inert).** The Gate-2-eligible set = `survivors ∩ {rule : heldOutActivationsByRule[rule] > 0}` is derived **downstream** of the scorer (`deriveGate2Eligibility`), §1(k)-guarded, with the Q4 illegitimate-window disqualifier keyed on the **COUNT never `.effect`**. Persisted as a **top-level report field** sibling to `verdict` (derived-not-mirrored; mined runs omit the key), never consulted by the Gate-1 verdict.

### §8 currency pin — lands LOCKSTEP on merge (#793 pattern)

§8 line 168 reads `"INERT until Slice D3"` — stale; D4 is the flip that arms it. Per strategy's Q3 ruling, **strategy lands the D3→D4 currency fix lockstep with this merge** (couple-on-merge). Nothing in §8 lands before this build; the pin lands WITH the PR. Re-verified at PR time: ADR-112 §5.3/§6/§8 is unchanged on strategy `origin/main` since the build basis (`53c9779`, §8 through #793 `135b84a`).

### Two build-altitude decisions flagged for review (seam 1/2)

- **Eager-build authored corpus at resolve** (vs lazy at engine-call): behavior-equivalent for a single run (built once, cached, reused by the engine), and it moves the no-mint gate firing earlier — still before score + ledger write.
- **The injected `certifyingCorpus` seam is mined-only by construction**: authored corpora go through the single home's eager build, never the injected path.

### Tests

D4 e2e matrix in `spine-authored-cert-corpus.test.ts` — real resolve → real `scoreAuthoredWindtunnel` → real `deriveGate2Eligibility`, reusing the D1–D3 fixtures (no mocked scorer):
- **(i)** authored happy-path ⇒ PASS + Gate-2 eligible;
- **(ii)** no-mint gate FIRES ⇒ `GATE_INVALID` at resolve, scorer structurally unreachable, ledger byte-unchanged;
- **(v)** mined regression ⇒ `kind:'mined'`, no `gate2`, byte-identical to `scoreWindtunnel`;
- **(vi)** cross-partition leakage ⇒ a train-only rule has 0 held-out ⇒ excluded from Gate-2 despite PASS;
- **(vii)** unlabeled-demotion ⇒ HONEST-NEGATIVE, metric verdict-inert.

Plus (iii) Gate-2 exclusion + (iv) illegitimate-count-not-effect at core altitude (`gate2-eligibility.test.ts`), and +2 persist-report Gate-2 field tests.

### Gate

`pnpm -r build` + full-workspace test green (core 3023 · cli 2886 · mcp 183 · packs 24) · `tsc` · ESLint (`@mmnto/cli` + `@mmnto/totem`) · `totem lint` PASS (0 errors) · changeset `@mmnto/totem` minor (fixed group).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
