### PR TITLE
fix(spine): ADR-112 §5.4 — author sandbox fail-loud NON-OPTIONAL under a frozen binding

### DIFF
--- a/.changeset/spine-s54-sandbox-non-optional.md
+++ b/.changeset/spine-s54-sandbox-non-optional.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/cli': patch
+---
+
+`totem rule author`: the ADR-112 §5.4 author sandbox is now fail-loud NON-OPTIONAL when the authoring header names a frozen split artifact — omitting `--lc-dir` under a content-addressed `splitRef` throws `GATE_INVALID` at binding-engagement instead of silently skipping the sandbox reachability proof (the independence axiom forbids an author-owned knob whose omission disables the guard; found by the #2294 couple verification). The legacy free-text `splitRef` lane binds nothing and is byte-unaffected.

--- a/packages/cli/src/commands/rule-author-command.test.ts
+++ b/packages/cli/src/commands/rule-author-command.test.ts
@@ -47,11 +47,11 @@ const fixture = (pr: number) => ({
   matchedSpan: 'L1',
   contentHash: 'h'.repeat(8),
 });
-const writeYaml = (rules: unknown[]) => {
+const writeYaml = (rules: unknown[], splitRef = 's') => {
   fs.writeFileSync(
     path.join(root, '.totem', 'spine', 'authored-rules.yaml'),
     yamlStringify({
-      splitRef: 's',
+      splitRef,
       authoredAfterSplit: true,
       heldOutNonInspectionAttestation: true,
       rules,
@@ -79,6 +79,32 @@ describe('ruleAuthorCommand (CLI entry — rejected-loud + non-zero exit, strate
   });
   it('leaves process.exitCode untouched and does not warn on an all-decidable run', async () => {
     writeYaml([decidable()]);
+    await ruleAuthorCommand({});
+    expect(process.exitCode).toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  // §5.4 is NON-OPTIONAL under a content-addressed binding (#2294 couple): the
+  // gate fires at binding-engagement, BEFORE the proof machinery loads, so no
+  // artifact/git fixture is needed to exercise it.
+  it('throws GATE_INVALID naming §5.4 when a content-addressed splitRef engages without --lc-dir', async () => {
+    writeYaml([decidable()], `split:${'f'.repeat(64)}`);
+    await expect(ruleAuthorCommand({})).rejects.toMatchObject({
+      name: 'TotemError',
+      code: 'GATE_INVALID',
+    });
+    await expect(ruleAuthorCommand({})).rejects.toThrow(/§5\.4 author sandbox is NON-OPTIONAL/);
+  });
+
+  it('treats a whitespace-only --lc-dir as missing under a content-addressed splitRef', async () => {
+    writeYaml([decidable()], `split:${'f'.repeat(64)}`);
+    await expect(ruleAuthorCommand({ lcDir: '   ' })).rejects.toMatchObject({
+      code: 'GATE_INVALID',
+    });
+  });
+
+  it('legacy free-text splitRef stays lcDir-free (binds nothing, no §5.4 gate)', async () => {
+    writeYaml([decidable()]); // splitRef 's' — the pre-R1 adherence-class shape
     await ruleAuthorCommand({});
     expect(process.exitCode).toBeUndefined();
     expect(warnSpy).not.toHaveBeenCalled();

--- a/packages/cli/src/commands/rule-author-command.test.ts
+++ b/packages/cli/src/commands/rule-author-command.test.ts
@@ -89,11 +89,12 @@ describe('ruleAuthorCommand (CLI entry — rejected-loud + non-zero exit, strate
   // artifact/git fixture is needed to exercise it.
   it('throws GATE_INVALID naming §5.4 when a content-addressed splitRef engages without --lc-dir', async () => {
     writeYaml([decidable()], `split:${'f'.repeat(64)}`);
+    // Single invocation, all three facets on the one rejection (greptile #2295).
     await expect(ruleAuthorCommand({})).rejects.toMatchObject({
       name: 'TotemError',
       code: 'GATE_INVALID',
+      message: expect.stringContaining('§5.4 author sandbox is NON-OPTIONAL'),
     });
-    await expect(ruleAuthorCommand({})).rejects.toThrow(/§5\.4 author sandbox is NON-OPTIONAL/);
   });
 
   it('treats a whitespace-only --lc-dir as missing under a content-addressed splitRef', async () => {
@@ -106,6 +107,9 @@ describe('ruleAuthorCommand (CLI entry — rejected-loud + non-zero exit, strate
   it('legacy free-text splitRef stays lcDir-free (binds nothing, no §5.4 gate)', async () => {
     writeYaml([decidable()]); // splitRef 's' — the pre-R1 adherence-class shape
     await ruleAuthorCommand({});
+    // What distinguishes this from the all-decidable test above (greptile #2295):
+    // the partition itself — the run completed WITHOUT engaging the freeze binding.
+    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('freeze binding verified'));
     expect(process.exitCode).toBeUndefined();
     expect(warnSpy).not.toHaveBeenCalled();
   });

--- a/packages/cli/src/commands/rule-author-teardown.test.ts
+++ b/packages/cli/src/commands/rule-author-teardown.test.ts
@@ -1,0 +1,132 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { stringify as yamlStringify } from 'yaml';
+
+import { ruleAuthorCommand } from './rule-author.js';
+
+// ── The §5.4 finally-teardown branches (CR #2295): the sandbox path is
+// unconditional under a binding, so both teardown-failure branches are on the
+// certifying hot path. The proof + sandbox + intake modules are mocked — the
+// branches under test are the command's own control flow, not the seams'.
+vi.mock('../utils.js', () => ({
+  resolveConfigPath: (cwd: string) => path.join(cwd, 'totem.config.json'),
+  loadConfig: async () => ({ totemDir: '.totem' }),
+}));
+vi.mock('../spine-freeze-proof.js', () => ({
+  resolveFrozenSplitByRef: vi.fn(() => ({
+    artifact: { splitRef: `split:${'a'.repeat(64)}`, freezeCommitment: 'c'.repeat(64) },
+  })),
+  verifySharedFrozenSplit: vi.fn(),
+}));
+vi.mock('../author-sandbox.js', () => ({
+  prepareAuthorSandbox: vi.fn(() => ({
+    root: '/fake/sandbox-root',
+    cutBoundarySha: 'd'.repeat(40),
+  })),
+  removeAuthorSandbox: vi.fn(),
+}));
+vi.mock('../authored-rule-intake.js', async (importOriginal) => {
+  const real = await importOriginal<typeof import('../authored-rule-intake.js')>();
+  return {
+    ...real,
+    runRuleAuthor: vi.fn(() => ({
+      records: [],
+      minted: 0,
+      revised: 0,
+      unchanged: 0,
+      rejected: [],
+    })),
+  };
+});
+// resolveGitRoot spawns a real `git` with cwd = the temp root; its result only
+// feeds the (mocked) proof seam here, and on Windows the spawn leaves the temp
+// dir undeletable for the whole worker lifetime (EPERM in afterEach) — so pin
+// it to the temp root instead of spawning.
+vi.mock('@mmnto/totem', async (importOriginal) => {
+  const real = await importOriginal<typeof import('@mmnto/totem')>();
+  return { ...real, resolveGitRoot: vi.fn((cwd: string) => cwd) };
+});
+
+import { removeAuthorSandbox } from '../author-sandbox.js';
+import { runRuleAuthor } from '../authored-rule-intake.js';
+
+let root: string;
+let cwdSpy: ReturnType<typeof vi.spyOn>;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+let logSpy: ReturnType<typeof vi.spyOn>;
+const savedExitCode = process.exitCode;
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-ruleauthor-teardown-'));
+  fs.mkdirSync(path.join(root, '.totem', 'spine'), { recursive: true });
+  fs.writeFileSync(
+    path.join(root, '.totem', 'spine', 'authored-rules.yaml'),
+    yamlStringify({
+      splitRef: `split:${'a'.repeat(64)}`,
+      authoredAfterSplit: true,
+      heldOutNonInspectionAttestation: true,
+      rules: [],
+    }),
+    'utf-8',
+  );
+  cwdSpy = vi.spyOn(process, 'cwd').mockReturnValue(root);
+  warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  process.exitCode = undefined;
+  vi.mocked(removeAuthorSandbox).mockReset();
+  vi.mocked(runRuleAuthor).mockReset();
+  vi.mocked(runRuleAuthor).mockReturnValue({
+    records: [],
+    minted: 0,
+    revised: 0,
+    unchanged: 0,
+    rejected: [],
+  });
+});
+afterEach(() => {
+  cwdSpy.mockRestore();
+  warnSpy.mockRestore();
+  logSpy.mockRestore();
+  process.exitCode = savedExitCode;
+  fs.rmSync(root, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+});
+
+describe('ruleAuthorCommand §5.4 teardown-failure branches (the finally-shadow contract, GCA #2293 r4)', () => {
+  it('throws the teardown error when teardown fails with NO primary error in flight', async () => {
+    const teardownErr = new Error('sandbox rm failed');
+    vi.mocked(removeAuthorSandbox).mockImplementation(() => {
+      throw teardownErr;
+    });
+    // The intake succeeded and was reported, but the run still fails loudly —
+    // a leaked sandbox root is never a silent success.
+    await expect(ruleAuthorCommand({ lcDir: '/some/lc' })).rejects.toBe(teardownErr);
+    expect(vi.mocked(runRuleAuthor)).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the PRIMARY error and warns (never shadows) when teardown also fails', async () => {
+    const primaryErr = new Error('intake exploded');
+    vi.mocked(runRuleAuthor).mockImplementation(() => {
+      throw primaryErr;
+    });
+    vi.mocked(removeAuthorSandbox).mockImplementation(() => {
+      throw new Error('sandbox rm failed too');
+    });
+    await expect(ruleAuthorCommand({ lcDir: '/some/lc' })).rejects.toBe(primaryErr);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('sandbox teardown failed after a primary error'),
+    );
+    // The kept root is named in the warning — the operator can clean it up.
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('/fake/sandbox-root'));
+  });
+
+  it('tears down exactly once on the success path (no teardown error, clean return)', async () => {
+    await ruleAuthorCommand({ lcDir: '/some/lc' });
+    expect(vi.mocked(removeAuthorSandbox)).toHaveBeenCalledTimes(1);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(process.exitCode).toBeUndefined();
+  });
+});

--- a/packages/cli/src/commands/rule-author.ts
+++ b/packages/cli/src/commands/rule-author.ts
@@ -16,7 +16,7 @@ export async function ruleAuthorCommand(opts: {
   const path = await import('node:path');
   const { loadConfig, resolveConfigPath } = await import('../utils.js');
   const { AUTHORED_RULES_REL, runRuleAuthor } = await import('../authored-rule-intake.js');
-  const { resolveGitRoot, safeExec, SPLIT_REF_RE } = await import('@mmnto/totem');
+  const { resolveGitRoot, safeExec, SPLIT_REF_RE, TotemError } = await import('@mmnto/totem');
 
   const cwd = process.cwd();
   const config = await loadConfig(resolveConfigPath(cwd));
@@ -36,7 +36,21 @@ export async function ruleAuthorCommand(opts: {
     const m = /^splitRef:\s*["']?(\S+?)["']?\s*$/m.exec(fs.readFileSync(yamlPath, 'utf-8'));
     declaredSplitRef = m?.[1];
   }
+  const judgedBy = opts.judgedBy?.trim() || 'static-whitelist@cert-1';
   if (declaredSplitRef !== undefined && SPLIT_REF_RE.test(declaredSplitRef)) {
+    // The §5.4 sandbox is NON-OPTIONAL under a content-addressed binding (#2294
+    // couple): a flag whose omission skips the guard is an author-owned knob,
+    // which the independence axiom forbids. Gate BEFORE the proof machinery
+    // loads — nothing is verified or partially engaged on failure. The legacy
+    // free-text lane below binds nothing and is byte-unaffected.
+    const lcDir = opts.lcDir?.trim();
+    if (lcDir === undefined || lcDir === '') {
+      throw new TotemError(
+        'GATE_INVALID',
+        'rule author: the authoring header names a frozen split artifact (content-addressed splitRef), so the §5.4 author sandbox is NON-OPTIONAL — --lc-dir is missing.',
+        'Pass --lc-dir <path-to-lc-clone> (env: TOTEM_LC_DIR); the sandbox root derives from the frozen artifact alone and its reachability proof must run before intake.',
+      );
+    }
     const { resolveFrozenSplitByRef, verifySharedFrozenSplit } =
       await import('../spine-freeze-proof.js');
     const repoRoot = resolveGitRoot(cwd) ?? cwd;
@@ -47,46 +61,42 @@ export async function ruleAuthorCommand(opts: {
       `[RuleAuthor] freeze binding verified: ${resolved.artifact.splitRef} ` +
         `(commitment ${resolved.artifact.freezeCommitment.slice(0, 12)}…, shared-history proof passed)`,
     );
-    if (opts.lcDir) {
-      // §5.4: materialize + tear down the derived sandbox to PROVE the boundary sha
-      // is reachable from this clone. The root derives from the artifact alone —
-      // no author-supplied root/allowlist exists on this surface (independence axiom).
-      const { prepareAuthorSandbox, removeAuthorSandbox } = await import('../author-sandbox.js');
-      const sandbox = prepareAuthorSandbox({
-        lcDir: opts.lcDir,
-        totemDir,
-        artifact: resolved.artifact,
-        safeExec,
-      });
-      console.log(
-        `[RuleAuthor] §5.4 author sandbox verified: train tree as of ${sandbox.cutBoundarySha.slice(0, 12)} (derived root, torn down after intake)`,
-      );
-      let primaryErr: unknown;
+    // §5.4: materialize + tear down the derived sandbox to PROVE the boundary sha
+    // is reachable from this clone. The root derives from the artifact alone —
+    // no author-supplied root/allowlist exists on this surface (independence axiom).
+    const { prepareAuthorSandbox, removeAuthorSandbox } = await import('../author-sandbox.js');
+    const sandbox = prepareAuthorSandbox({
+      lcDir,
+      totemDir,
+      artifact: resolved.artifact,
+      safeExec,
+    });
+    console.log(
+      `[RuleAuthor] §5.4 author sandbox verified: train tree as of ${sandbox.cutBoundarySha.slice(0, 12)} (derived root, torn down after intake)`,
+    );
+    let primaryErr: unknown;
+    try {
+      const result = runRuleAuthor(totemDir, { judgedBy, freezeBinding });
+      reportRuleAuthor(result);
+      return;
+    } catch (err) {
+      primaryErr = err;
+      throw err;
+    } finally {
       try {
-        const judgedByEarly = opts.judgedBy?.trim() || 'static-whitelist@cert-1';
-        const result = runRuleAuthor(totemDir, { judgedBy: judgedByEarly, freezeBinding });
-        reportRuleAuthor(result);
-        return;
-      } catch (err) {
-        primaryErr = err;
-        throw err;
-      } finally {
-        try {
-          removeAuthorSandbox({ lcDir: opts.lcDir, root: sandbox.root, safeExec });
-        } catch (teardownErr) {
-          // A throw in `finally` SHADOWS the in-flight error (GCA #2293 round 4):
-          // with no primary in flight the teardown failure IS the error (throw);
-          // with one, surface the teardown loudly beside it — never replace it.
-          if (primaryErr === undefined) throw teardownErr;
-          console.warn(
-            `[RuleAuthor] WARNING: sandbox teardown failed after a primary error (root kept at ${sandbox.root}): ${teardownErr instanceof Error ? teardownErr.message : String(teardownErr)}`,
-          );
-        }
+        removeAuthorSandbox({ lcDir, root: sandbox.root, safeExec });
+      } catch (teardownErr) {
+        // A throw in `finally` SHADOWS the in-flight error (GCA #2293 round 4):
+        // with no primary in flight the teardown failure IS the error (throw);
+        // with one, surface the teardown loudly beside it — never replace it.
+        if (primaryErr === undefined) throw teardownErr;
+        console.warn(
+          `[RuleAuthor] WARNING: sandbox teardown failed after a primary error (root kept at ${sandbox.root}): ${teardownErr instanceof Error ? teardownErr.message : String(teardownErr)}`,
+        );
       }
     }
   }
 
-  const judgedBy = opts.judgedBy?.trim() || 'static-whitelist@cert-1';
   const result = runRuleAuthor(totemDir, { judgedBy, freezeBinding });
   reportRuleAuthor(result);
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1682,7 +1682,7 @@ ruleCmd
   )
   .option(
     '--lc-dir <path>',
-    'lc clone for §5.4 sandbox verification when the splitRef is a frozen artifact (env: TOTEM_LC_DIR)',
+    'lc clone for the §5.4 author sandbox — REQUIRED when the splitRef names a frozen artifact (env: TOTEM_LC_DIR)',
     process.env['TOTEM_LC_DIR'],
   )
   .action(async (opts: { judgedBy?: string; lcDir?: string }) => {


### PR DESCRIPTION
## Mechanical Root Cause

`totem rule author` treats `--lc-dir` as optional (`rule-author.ts` — `lcDir?: string`), and the entire ADR-112 §5.4 sandbox materialize/prove/teardown sits inside `if (opts.lcDir)`. Under a **content-addressed `splitRef`** the command verifies the freeze binding + shared-history proof, then — with the flag omitted — silently falls through to bare intake with **no sandbox engagement at all**. Nothing downstream asserts the proof happened (`authored-rule-intake.ts` has zero sandbox/lcDir references).

A flag whose *omission* disables the guard is an author-owned knob. The R1 build sheet's independence axiom says the author command accepts **no** root/allowlist knobs — the §5.4 guard must not be author-skippable.

Found by strategy-claude's couple verification on #2294 (the named pre-authoring condition); premise re-verified against source before building.

## Fix Applied

- **Gate at binding-engagement, before the proof machinery loads:** when the authoring header names a content-addressed `splitRef` and `--lc-dir` is absent or blank, throw `GATE_INVALID` naming the §5.4 requirement. Nothing is verified, written, or partially engaged on failure (the same cheapest-gate-first, writes-nothing idiom as the freeze gates).
- **The sandbox path is now unconditional under a binding** — the `if (opts.lcDir)` wrapper is gone; materialize → prove → intake → teardown always runs when a freeze binding engages. The teardown-shadow handling (GCA #2293 round 4) is unchanged.
- **Legacy free-text lane byte-unaffected:** a non-content-addressed `splitRef` binds nothing and never sees the gate — the same content-addressed/legacy partition R1 uses everywhere else.
- `--lc-dir` help text updated to say REQUIRED under a frozen-artifact splitRef.

## Out of Scope

- #2294 itself (data-only freeze artifact — this gap lives in already-merged #2293 code and only becomes reachable after that merge lifts the authoring embargo).
- Any change to `authored-rule-intake.ts` — the gate belongs at the command boundary where the binding engages; intake stays git-free.

## Tests Added/Updated

Three new tests in `rule-author-command.test.ts` (no git fixture needed — the gate fires before proof-machinery load):

1. content-addressed `splitRef` + no `--lc-dir` ⇒ rejects with `TotemError` / `GATE_INVALID`, message names the §5.4 non-optionality
2. whitespace-only `--lc-dir` ⇒ same gate (trim edge)
3. legacy free-text `splitRef` with no `--lc-dir` still runs clean (partition pinned)

Full cli suite: 2912 passed. Workspace build green (exit-checked), ESLint 0 errors, repo-wide format green, `totem lint` PASS (0 errors; 8 advisory warnings — the flagged `console.warn`/`||` constructs pre-existed this diff and are command-surface UI, not library code).

## Sequencing

Merge-ready independently of #2294, but it **gates lc Tier-1 authoring**: per the couple's condition it must be live before the first real `totem rule author` run against the frozen split.

Changeset: `@mmnto/cli` patch.

Refs #2291

🤖 Generated with [Claude Code](https://claude.com/claude-code)
