### PR TITLE
feat(spine): ADR-112 authored exercised/C1 from the §6 emission channel (option (i))

### DIFF
--- a/.changeset/spine-authored-exercised-option-i.md
+++ b/.changeset/spine-authored-exercised-option-i.md
@@ -1,0 +1,6 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': patch
+---
+
+ADR-112 authored exercised/non-vacuity semantics — option (i) (operator ruling 2026-07-04, #2291): on the authored path, `positiveControlsExercised` is the §6 emission channel (`|authoredControls.positive|` — the §4 preimage-differential at emission IS the exercise proof), and the per-rule C1 positive-control verdict is differential-held-at-emission (`computeAuthoredPerRuleControlResults`, threaded from the §8 resolver through `ScoredRun` into persist) — never fire-on-window-diff, which is structurally unsatisfiable for strictly pre-window anchors (§5.2). Fixes the pre-existing authored-path double-fault: the mined-channel exercised count was structurally 0 (floor ⇒ permanent HONEST-NEGATIVE) and the projected targets could never fire (⇒ vacuous-positive FAIL). The mined lane is byte-unchanged; `verdict.nonVacuity` reads vacuously true on authored verdicts (the authored vacuity guards are the non-emission gate + the exercised floor).

--- a/packages/cli/src/commands/spine-cert-persist.test.ts
+++ b/packages/cli/src/commands/spine-cert-persist.test.ts
@@ -174,4 +174,44 @@ describe('persistCertifyingOutcome', () => {
     // Key is absent, not serialized-as-null — a mined run has no Gate-2 emission.
     expect('gate2' in report).toBe(false);
   });
+
+  it('option (i): a handed-in authored C1 map REPLACES the mined derivation and persists in the report', async () => {
+    // Authored shape: ZERO positive firings (pre-window anchors have no window
+    // substrate) — the emission-proven map alone must stamp the survivor AND
+    // survive into the durable report (greptile #2298 outside-diff: without it,
+    // an auditor cannot see WHY positiveControl read true without a re-run).
+    const perRuleControls = new Map([
+      [
+        'r1',
+        {
+          positiveControl: true,
+          negativeControl: true,
+          evidenceRefs: ['§6-emission:422:src/foo.rs:L10-L12'],
+        },
+      ],
+    ]);
+    const result = await persistCertifyingOutcome({
+      ...baseInput(makeVerdict('PASS')),
+      firings: [],
+      positiveControlTargets: [],
+      perRuleControls,
+    });
+    expect(result.persisted).toBe(true);
+    expect(result.stampedCount).toBe(1);
+    const report = JSON.parse(fs.readFileSync(result.reportPath, 'utf-8'));
+    expect(report.perRuleControls).toEqual({
+      r1: {
+        positiveControl: true,
+        negativeControl: true,
+        evidenceRefs: ['§6-emission:422:src/foo.rs:L10-L12'],
+      },
+    });
+  });
+
+  it('the mined lane also persists its (fire-on-target-derived) C1 map in the report', async () => {
+    const result = await persistCertifyingOutcome(baseInput(makeVerdict('PASS')));
+    const report = JSON.parse(fs.readFileSync(result.reportPath, 'utf-8'));
+    expect(report.perRuleControls.r1.positiveControl).toBe(true);
+    expect(report.perRuleControls.r1.evidenceRefs).toEqual(['label-r1-pos']);
+  });
 });

--- a/packages/cli/src/commands/spine-cert-persist.ts
+++ b/packages/cli/src/commands/spine-cert-persist.ts
@@ -6,6 +6,7 @@ import type {
   CompiledRule,
   Gate2Eligibility,
   LegitimacyProjectionSkip,
+  PerRuleControlResult,
   ProvenanceRecord,
   RuleFiring,
   WindtunnelVerdict,
@@ -47,6 +48,14 @@ export interface CertPersistInput {
    * durable artifact keeps the two altitudes legibly separate.
    */
   gate2?: Gate2Eligibility;
+  /**
+   * Option-(i) ruling (#2291, operator 2026-07-04) — the AUTHORED C1 map, computed
+   * at the §8 single home from the §4 differential HELD AT EMISSION. When present
+   * it REPLACES the mined fire-on-target derivation below (which is structurally
+   * unsatisfiable for pre-window anchors, §5.2). Absent on mined runs — the mined
+   * derivation stays byte-unchanged.
+   */
+  perRuleControls?: Map<string, PerRuleControlResult>;
 }
 
 export interface CertPersistResult {
@@ -98,11 +107,15 @@ export async function persistCertifyingOutcome(
     saveCompiledRulesFile,
   } = await import('@mmnto/totem');
 
-  const perRuleControls = computePerRuleControlResults({
-    firings: input.firings,
-    mintedRuleIds: input.mintedRuleIds,
-    positiveControlTargets: input.positiveControlTargets,
-  });
+  // Sibling-selection, data-driven (option (i)): an authored caller hands in the
+  // emission-proven C1 map; the mined derivation runs only when none was handed.
+  const perRuleControls =
+    input.perRuleControls ??
+    computePerRuleControlResults({
+      firings: input.firings,
+      mintedRuleIds: input.mintedRuleIds,
+      positiveControlTargets: input.positiveControlTargets,
+    });
 
   // fold-B — survivor-only, PASS-only legitimacy projection.
   const projection = projectLegitimacy({

--- a/packages/cli/src/commands/spine-cert-persist.ts
+++ b/packages/cli/src/commands/spine-cert-persist.ts
@@ -145,6 +145,14 @@ export async function persistCertifyingOutcome(
     // D4 (strategy Q2): verdict-inert Gate-2 eligibility, authored runs only. Top-level
     // sibling of `verdict` — derived from it, never part of it (mined runs omit the key).
     ...(input.gate2 ? { gate2: input.gate2 } : {}),
+    // #2298 (greptile outside-diff): the C1 per-rule control results, BOTH lanes —
+    // for an authored run this is the ONLY durable record of WHY a rule read
+    // positiveControl:true (the `§6-emission:` evidence never appears in `firings`);
+    // for a mined run it is derivable from `firings` but persisted for symmetry.
+    // Sorted by ruleId so the report is byte-stable across runs.
+    perRuleControls: Object.fromEntries(
+      [...perRuleControls.entries()].sort(([a], [b]) => a.localeCompare(b)),
+    ),
     persisted,
     stampedRuleIds: projection.stamped.map((r) => r.lessonHash),
     skips: projection.skips,

--- a/packages/cli/src/commands/spine-cert-run-corpus.ts
+++ b/packages/cli/src/commands/spine-cert-run-corpus.ts
@@ -743,8 +743,13 @@ export async function resolveCertifyingCorpusProvider(
 ): Promise<ResolvedCertifyingRun> {
   // Dynamic import (CLI lazy-load convention — CR #2285): @mmnto/totem is heavy; the scorers
   // are captured here (the resolver is async) and closed over by the sync `score` bundle below.
-  const { TotemError, scoreWindtunnel, scoreAuthoredWindtunnel, deriveGate2Eligibility } =
-    await import('@mmnto/totem');
+  const {
+    TotemError,
+    scoreWindtunnel,
+    scoreAuthoredWindtunnel,
+    computeAuthoredPerRuleControlResults,
+    deriveGate2Eligibility,
+  } = await import('@mmnto/totem');
   const producerKind = lock.producerKind ?? 'mined';
   if (producerKind === 'authored') {
     // require-when-authored (codex): the lock's `authored` run-input block is mandatory at
@@ -853,7 +858,16 @@ export async function resolveCertifyingCorpusProvider(
         // heldOutActivationsByRule; the intersection (+ §1(k) + the Q4 illegitimate-window
         // disqualifier) is derived here, verdict-inert.
         const gate2 = deriveGate2Eligibility({ mintedRuleIds: base.mintedRuleIds, verdict });
-        return { kind: 'authored', verdict, gate2 };
+        // Option-(i) ruling (#2291): the C1 per-rule positive-control verdict is the §4
+        // differential HELD AT EMISSION — computed HERE (the §8 single home) so persist
+        // stays kind-blind and the mined fire-on-target derivation is never consulted
+        // for an authored run (pre-window anchors have no window substrate, §5.2).
+        const perRuleControls = computeAuthoredPerRuleControlResults({
+          firings: base.firings,
+          mintedRuleIds: base.mintedRuleIds,
+          authoredControls,
+        });
+        return { kind: 'authored', verdict, gate2, perRuleControls };
       },
     };
   }

--- a/packages/cli/src/commands/spine-windtunnel.ts
+++ b/packages/cli/src/commands/spine-windtunnel.ts
@@ -375,6 +375,14 @@ export type ScoredRun =
       kind: 'authored';
       verdict: import('@mmnto/totem').AuthoredWindtunnelVerdict;
       gate2: import('@mmnto/totem').Gate2Eligibility;
+      /**
+       * The AUTHORED C1 map (option-(i) ruling, #2291): per-rule positive-control
+       * verdicts proven by the §4 differential AT EMISSION, computed in the
+       * resolver's score closure (the §8 single home). Persist consumes this
+       * INSTEAD of the mined fire-on-target derivation — data-driven, so no
+       * producer-kind branch ever reaches the persist path.
+       */
+      perRuleControls: Map<string, import('@mmnto/totem').PerRuleControlResult>;
     };
 
 /**
@@ -660,7 +668,12 @@ export async function runCommand(opts: RunOptions): Promise<void> {
       asOfCommit: lock.corpus.selectionRule.asOfCommit,
       // D4 (strategy Q2): persist the verdict-inert Gate-2 set into the durable report,
       // authored runs only (mined runs carry no gate2). Console emit above stays.
-      ...(scored.kind === 'authored' ? { gate2: scored.gate2 } : {}),
+      // Option-(i) ruling (#2291): the authored arm also carries the C1 map proven by
+      // the §4 differential at emission — persist consumes it instead of deriving
+      // fire-on-target results (unsatisfiable for pre-window anchors, §5.2).
+      ...(scored.kind === 'authored'
+        ? { gate2: scored.gate2, perRuleControls: scored.perRuleControls }
+        : {}),
     });
     console.error(
       `[WindtunnelRun] Cert-run report: ${persistResult.reportPath}` +

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1085,7 +1085,10 @@ export type {
   AuthoredScorerInput,
   AuthoredWindtunnelVerdict,
 } from './spine/windtunnel-scorer-authored.js';
-export { scoreAuthoredWindtunnel } from './spine/windtunnel-scorer-authored.js';
+export {
+  computeAuthoredPerRuleControlResults,
+  scoreAuthoredWindtunnel,
+} from './spine/windtunnel-scorer-authored.js';
 
 // ─── Layer-B cohort-capability ledger (totem-strategy#697) ───────────────────
 export type {

--- a/packages/core/src/spine/windtunnel-firing.ts
+++ b/packages/core/src/spine/windtunnel-firing.ts
@@ -37,11 +37,15 @@ export interface ResolvedPrDiff {
  * to stamp legitimacy per-rule, survivor-only.
  */
 export interface PerRuleControlResult {
-  /** True iff this rule fired its positive-control target (per-rule, not global). */
+  /** True iff this rule's positive control is proven (per-rule, not global): a target firing (mined) or a §4 differential held at emission (authored). */
   positiveControl: boolean;
   /** True iff this rule did NOT fire on any negative control (clean = passed). */
   negativeControl: boolean;
-  /** Evidence: the firingLabelIds that establish each control result. */
+  /**
+   * Evidence for the positive result: MINED — the establishing firingLabelIds;
+   * AUTHORED — `§6-emission:`-prefixed locus refs (option (i), #2291; see
+   * `computeAuthoredPerRuleControlResults`). Never both shapes in one map.
+   */
   evidenceRefs: string[];
 }
 

--- a/packages/core/src/spine/windtunnel-scorer-authored.test.ts
+++ b/packages/core/src/spine/windtunnel-scorer-authored.test.ts
@@ -4,7 +4,10 @@ import type { AuthoredNonEmission, AuthoredPositiveControl } from './authored-co
 import { firingLabelId } from './windtunnel-lock.js';
 import type { GroundTruthLabel, RuleFiring } from './windtunnel-scorer.js';
 import type { AuthoredScorerInput } from './windtunnel-scorer-authored.js';
-import { scoreAuthoredWindtunnel } from './windtunnel-scorer-authored.js';
+import {
+  computeAuthoredPerRuleControlResults,
+  scoreAuthoredWindtunnel,
+} from './windtunnel-scorer-authored.js';
 
 // ─── Helpers ─────────────────────────────────────────
 
@@ -432,5 +435,121 @@ describe('multi-rule window (gate is window-level, O3 keys isolated per rule)', 
     // (2) O3 key isolation: rule-a is keyed (from positive[]) and counts its 1 held-out
     // firing; rule-b fired on a held-out PR but has NO positive control → NOT a key.
     expect(result.heldOutActivationsByRule).toEqual({ 'rule-a': 1 });
+  });
+});
+
+// ─── Option-(i) exercised + non-vacuity semantics (#2291 ruling, 2026-07-04) ──
+
+describe('option-(i): the §6 emission channel is the exercise proof', () => {
+  const CERT1_CONTROLS = {
+    positive: [posControl('rule-a', 422), posControl('rule-b', 130), posControl('rule-c', 415)],
+    nonEmissions: [],
+  };
+
+  it('positiveControlsExercised = |emissions|, OVERRIDING the (mined-channel) input leg', () => {
+    // The named D4 masking regression: floors are REAL here (ratified floor 2, not 0).
+    // The input leg says 0 — the mined-substrate artifact — but 3 emissions clear it.
+    const result = scoreAuthoredWindtunnel(
+      baseInput({
+        mintedRuleIds: ['rule-a', 'rule-b', 'rule-c'],
+        authoredControls: CERT1_CONTROLS,
+        actualExposure: {
+          activeRulesEvaluated: 3,
+          filesTouchedInWindow: 5,
+          positiveControlsExercised: 0, // mined channel: structurally 0 on authored substrate
+        },
+        exposureFloors: {
+          activeRulesEvaluated: 2,
+          filesTouchedInWindow: 0,
+          positiveControlsExercised: 2, // the ratified floor
+        },
+      }),
+    );
+    expect(result.exposureTuple[2]).toBe(3);
+    expect(result.verdict).toBe('PASS');
+  });
+
+  it('zero positive FIRINGS is NOT a vacuous-FAIL — pre-window anchors have no window substrate', () => {
+    // The cert-1 shape: every anchor strictly pre-window ⇒ no controlKind:'positive'
+    // firing can ever exist. Under the pre-ruling wiring this was FAIL (vacuous);
+    // under option (i) the differential at emission IS the proof.
+    const result = scoreAuthoredWindtunnel(
+      baseInput({
+        mintedRuleIds: ['rule-a', 'rule-b', 'rule-c'],
+        authoredControls: CERT1_CONTROLS,
+        firings: [], // nothing fired anywhere in the window
+        exposureFloors: {
+          activeRulesEvaluated: 2,
+          filesTouchedInWindow: 0,
+          positiveControlsExercised: 2,
+        },
+        actualExposure: {
+          activeRulesEvaluated: 3,
+          filesTouchedInWindow: 5,
+          positiveControlsExercised: 0,
+        },
+      }),
+    );
+    expect(result.verdict).toBe('PASS');
+    expect(result.nonVacuity).toBe(true); // vacuously true — the authored guard is Move 2 + the floor
+  });
+
+  it('godot-builtin shape: no admissible fixture ⇒ exercised 0 ⇒ the floor demotes HONEST-NEGATIVE, never FAIL', () => {
+    const result = scoreAuthoredWindtunnel(
+      baseInput({
+        authoredControls: { positive: [], nonEmissions: [] },
+        exposureFloors: {
+          activeRulesEvaluated: 0,
+          filesTouchedInWindow: 0,
+          positiveControlsExercised: 2,
+        },
+      }),
+    );
+    expect(result.exposureTuple[2]).toBe(0);
+    expect(result.verdict).toBe('HONEST-NEGATIVE');
+    expect(result.precision).toBeNull();
+  });
+});
+
+describe('computeAuthoredPerRuleControlResults (the option-(i) C1 sibling)', () => {
+  it('positiveControl := differential-held at emission; evidence refs are §6-emission-shaped', () => {
+    const map = computeAuthoredPerRuleControlResults({
+      firings: [],
+      mintedRuleIds: ['rule-a', 'rule-b'],
+      authoredControls: { positive: [posControl('rule-a', 422)] },
+    });
+    expect(map.get('rule-a')).toEqual({
+      positiveControl: true,
+      negativeControl: true,
+      evidenceRefs: ['§6-emission:422:src/foo.ts:L1-L1'],
+    });
+    // A survivor with NO emission reads false — never inherited from a sibling.
+    expect(map.get('rule-b')).toEqual({
+      positiveControl: false,
+      negativeControl: true,
+      evidenceRefs: [],
+    });
+  });
+
+  it('a rule culled by a negative-control firing is not a survivor — never stamped (mined parity)', () => {
+    const map = computeAuthoredPerRuleControlResults({
+      firings: [makeFiring('rule-a', 10, 'negative')],
+      mintedRuleIds: ['rule-a', 'rule-b'],
+      authoredControls: { positive: [posControl('rule-a', 422)] },
+    });
+    expect(map.has('rule-a')).toBe(false);
+    expect(map.get('rule-b')?.negativeControl).toBe(true);
+  });
+
+  it('evidence refs never collide with the 64-hex firing labelId key space', () => {
+    const map = computeAuthoredPerRuleControlResults({
+      firings: [],
+      mintedRuleIds: ['rule-a'],
+      authoredControls: { positive: [posControl('rule-a', 422)] },
+    });
+    for (const ref of map.get('rule-a')!.evidenceRefs) {
+      expect(ref.startsWith('§6-emission:')).toBe(true);
+      expect(/^[0-9a-f]{64}$/.test(ref)).toBe(false);
+    }
   });
 });

--- a/packages/core/src/spine/windtunnel-scorer-authored.ts
+++ b/packages/core/src/spine/windtunnel-scorer-authored.ts
@@ -16,10 +16,18 @@
 //
 // The three reduction moves (converged 4-seat panel, design in
 // `.totem/specs/d3-authored-scorer.md`):
-//   1. Positive-target projection: `positiveControlTargets` is DERIVED from
-//      `authoredControls.positive[]` — only `differential-holds` fixtures reach
-//      that list (discharged at emission in authored-controls.ts), so the mined
-//      scorer never re-proves the postimage leg.
+//   1. [REVISED by the option-(i) ruling, operator 2026-07-04 (#2291) — the D3
+//      projection was structurally unsatisfiable]: the §4 preimage-differential
+//      recorded AT EMISSION is the authored exercise + non-vacuity proof — only
+//      `differential-holds` fixtures reach `positive[]` (discharged in
+//      authored-controls.ts). The mined target-must-FIRE machinery is the MINED
+//      sibling's proof and is never consulted here: authored anchors may be
+//      strictly pre-window (§5.2), whose diffs are not window substrate BY
+//      DESIGN, so a projected target could never fire (every authored run would
+//      vacuous-FAIL). `positiveControlsExercised` := |authoredControls.positive|
+//      (the §6 emission channel); `positiveControlTargets` passed to the mined
+//      cascade is [] — its Step-3 check is vacuously true, and the authored
+//      vacuity guard is Move 2 below plus the exercised floor.
 //   2. Non-emission gate (codex's load-bearing fold): a culled differential (empty
 //      `positive[]` + a recorded `nonEmissions[]`) must NOT reach the mined scorer
 //      as `positiveControlTargets: []` and silently PASS. An `illegitimate` class
@@ -36,7 +44,13 @@
 //      is DEFERRED to D4 (D3 emits only the raw metric).
 
 import type { AuthoredControls } from './authored-controls.js';
-import type { ScorerInput, WindtunnelVerdict, WindtunnelVerdictKind } from './windtunnel-scorer.js';
+import type { PerRuleControlResult } from './windtunnel-firing.js';
+import type {
+  RuleFiring,
+  ScorerInput,
+  WindtunnelVerdict,
+  WindtunnelVerdictKind,
+} from './windtunnel-scorer.js';
 import { scoreWindtunnel } from './windtunnel-scorer.js';
 
 // ─── Types ──────────────────────────────────────────
@@ -48,9 +62,11 @@ import { scoreWindtunnel } from './windtunnel-scorer.js';
  *
  * `firings` carries the MERGED train + held-out firings — a train-side FP fails the
  * whole window (a window-wide verdict), and `heldOutPrs` partitions them for the O3
- * metric only. `exposureFloors` / `actualExposure` pass straight through to the
- * mined scorer: D3 does not recompute exposure (the third leg counts train-side
- * positive controls only — held-out activations never inflate it).
+ * metric only. `exposureFloors` and the first two `actualExposure` legs pass straight
+ * through to the mined scorer; the THIRD leg (`positiveControlsExercised`) is
+ * OVERRIDDEN with |authoredControls.positive| (the option-(i) ruling — the §4
+ * differential at emission is the exercise proof; held-out activations never
+ * inflate it because they are not emissions).
  */
 export interface AuthoredScorerInput extends Omit<ScorerInput, 'positiveControlTargets'> {
   /** The §6 answer key from `deriveAuthoredControls` — the emitted positives + the kept non-emissions. */
@@ -116,22 +132,26 @@ export function scoreAuthoredWindtunnel(input: AuthoredScorerInput): AuthoredWin
     heldOutPrs,
   } = input;
 
-  // Move 1 — project the emitted positives into the mined scorer's target shape.
-  // Only `differential-holds` fixtures are in `positive[]`; the mined scorer takes
-  // the (pr, targetRuleId) pair and proves non-vacuity by the target firing.
-  const positiveControlTargets = authoredControls.positive.map((c) => ({
-    pr: c.pr,
-    targetRuleId: c.targetRuleId,
-  }));
-
+  // Move 1 (option-(i) ruling) — the §6 emission channel IS the exercise proof:
+  // `positiveControlsExercised` = |positive[]| (each entry is differential-held
+  // by construction). The input's exercised leg is a mined-lane artifact of the
+  // shared `ScorerInput` shape and is OVERRIDDEN here — the authored scorer owns
+  // this leg (Tenet-20 single source; a caller-supplied count would be a second
+  // home). No targets go to the mined cascade: its fire-on-window-diff proof is
+  // unsatisfiable for pre-window anchors (§5.2) — the run-level `nonVacuity`
+  // field therefore reads vacuously true on an authored verdict; the authored
+  // vacuity guards are the Move-2 non-emission gate + the exercised floor.
   const mined = scoreWindtunnel({
     firings,
     groundTruth,
-    positiveControlTargets,
+    positiveControlTargets: [],
     mintedRuleIds,
     cullRateThreshold,
     exposureFloors,
-    actualExposure,
+    actualExposure: {
+      ...actualExposure,
+      positiveControlsExercised: authoredControls.positive.length,
+    },
   });
 
   // Move 2 — the non-emission gate. Tally the classes, then combine the gate's
@@ -215,4 +235,49 @@ export function scoreAuthoredWindtunnel(input: AuthoredScorerInput): AuthoredWin
     heldOutActivationsByRule,
     authoredControlGate: { illegitimate, undecidable, deferred, effect },
   };
+}
+
+/**
+ * The AUTHORED sibling of `computePerRuleControlResults` (option-(i) ruling,
+ * operator 2026-07-04 / #2291): a rule's per-rule positive-control verdict is
+ * the §4 preimage-differential HELD AT EMISSION — the rule has ≥1 entry in
+ * `authoredControls.positive[]` (only `differential-holds` fixtures reach it) —
+ * never fire-on-window-diff (pre-window anchors have no window substrate by
+ * §5.2 design). The negative leg and the cull axis are IDENTICAL to the mined
+ * sibling: a rule firing on any negative control is culled (not a survivor,
+ * never stamped); survivors fired on none, so `negativeControl` is invariantly
+ * true. `evidenceRefs` carry §6-emission locus refs (`§6-emission:` prefixed) —
+ * record-only, deliberately NOT shaped like 64-hex firing labelIds so they can
+ * never be mistaken for (or joined against) the ground-truth key space.
+ */
+export function computeAuthoredPerRuleControlResults(input: {
+  firings: RuleFiring[];
+  mintedRuleIds: string[];
+  authoredControls: Pick<AuthoredControls, 'positive'>;
+}): Map<string, PerRuleControlResult> {
+  const { firings, mintedRuleIds, authoredControls } = input;
+
+  const culled = new Set<string>();
+  for (const f of firings) {
+    if (f.controlKind === 'negative') culled.add(f.ruleId);
+  }
+
+  const emissionRefsByRule = new Map<string, string[]>();
+  for (const c of authoredControls.positive) {
+    const refs = emissionRefsByRule.get(c.targetRuleId) ?? [];
+    refs.push(`§6-emission:${c.pr}:${c.filePath}:${c.matchedSpan}`);
+    emissionRefsByRule.set(c.targetRuleId, refs);
+  }
+
+  const result = new Map<string, PerRuleControlResult>();
+  for (const ruleId of mintedRuleIds) {
+    if (culled.has(ruleId)) continue; // not a survivor — never stamped (mined parity)
+    const refs = emissionRefsByRule.get(ruleId) ?? [];
+    result.set(ruleId, {
+      positiveControl: refs.length > 0,
+      negativeControl: true,
+      evidenceRefs: refs,
+    });
+  }
+  return result;
 }


### PR DESCRIPTION
## Mechanical Root Cause

The authored cert-run path **double-faults structurally** — independent of rule quality:

1. **Exercised count is always 0.** The run command computes `actualExposure.positiveControlsExercised = engineResult.positiveControlTargets.length` (`spine-windtunnel.ts`), and `buildFirings` collects targets only from prDiff rows with `controlKind:'positive'` (`windtunnel-firing.ts:235`) — but the authored materializer marks **every** substrate row `'corpus'` by design (roles are the run-derived §6 channel). With the ratified floor of 2: **every authored run → HONEST-NEGATIVE.**
2. **The D3 Move-1 projection can never fire.** `scoreAuthoredWindtunnel` projected `authoredControls.positive` into the mined scorer's `positiveControlTargets`, whose Step-3 non-vacuity check requires a `controlKind:'positive'` **firing** on the target's PR. Authored anchors may be strictly pre-window (§5.2) — their diffs are not window substrate **by design** — so the check is unsatisfiable: **every authored run with ≥1 emission → vacuous-positive FAIL** (which outranks the floor).

D4's e2e was green only because its test floors were 0 — that masking is now pinned as a named regression with the ratified floor.

Found while executing strategy's "verify the §6 chain tolerates" item on #2297; confirmed independently by strategy's chain verification; **ruled option (i) by the operator (2026-07-04, recorded on #2291)** — whose contracts-lane grounding is that §5.3's exposure-coherence paragraph and the §9 exposure row already declare these semantics: this PR implements a declared amendment, not new semantics.

## Fix Applied (option (i) as ruled)

- **`scoreAuthoredWindtunnel` (core):** `positiveControlsExercised := |authoredControls.positive|` — the §4 preimage-differential at emission IS the exercise proof (only `differential-holds` fixtures reach `positive[]`). The mined cascade receives **zero targets**: its fire-on-window-diff proof is the MINED sibling's; the authored vacuity guards are the Move-2 non-emission gate + the exercised floor. `verdict.nonVacuity` therefore reads vacuously true on authored verdicts (documented at the field's consumers).
- **New `computeAuthoredPerRuleControlResults` (core):** the C1 per-rule positive-control verdict = differential-held at emission; cull axis and negative leg identical to the mined sibling; evidence refs are `§6-emission:`-prefixed locus strings, deliberately not shaped like 64-hex labelIds so they can never join against the ground-truth key space.
- **Sibling-selection, no kind-branch (the flagged subtlety):** the §8 resolver's authored score closure computes the C1 map and carries it on `ScoredRun`; the run command passes it through; `persistCertifyingOutcome` consumes `input.perRuleControls ?? <mined derivation>` — data-driven, so no `producerKind` read ever reaches the persist path. **Mined lane byte-unchanged** (zero edits to `scoreWindtunnel` / `computePerRuleControlResults` / any mined call site).

## Out of Scope

- No substrate/schema change (pr-diffs.json stays window-only, all rows `'corpus'` — option (ii) was not taken).
- The strategy-side §814 Deferred-row flip lands lockstep on this merge (their fold).

## Tests Added/Updated

- **The named D4-masking regression:** 3 emissions + ratified floor 2 + mined-channel leg reading 0 → `exposureTuple[2] = 3`, verdict **PASS** — an authored run can now actually pass.
- **The cert-1 shape:** zero positive firings anywhere + 3 emissions → **not** vacuous-FAIL (`nonVacuity` vacuously true).
- **godot-builtin shape:** no admissible fixture → exercised 0 → floor demotes **HONEST-NEGATIVE, never FAIL**, precision null.
- **C1 sibling unit rows:** emission-proven positive leg · no-emission survivor reads false (never inherited) · culled rule never stamped (mined parity) · evidence refs cannot collide with the labelId key space.
- All 15 pre-existing authored-scorer tests pass unchanged; mined scorer suites untouched and green (the byte-identical regression).

Full suites: core 3072 · cli 2926 · ESLint 0 errors · `totem lint` PASS (0 errors) · workspace build green.

## Sequencing

Gates **R3 (the cert run)** — lc's authoring intake is already open and unaffected. Strategy couples on this PR; their #814 Deferred-row flip is lockstep. Window note: strategy asks this land inside **Jul 4–6** (the Fable runway, their #815 cost gate).

Changeset: `@mmnto/totem` minor / `@mmnto/cli` patch.

Refs #2291

🤖 Generated with [Claude Code](https://claude.com/claude-code)
