### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine 0.1.14 -> 0.1.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
     "typescript-eslint": "^8.59.4"
   },
   "optionalDependencies": {
-    "@mmnto/strategy-doctrine": "0.1.14"
+    "@mmnto/strategy-doctrine": "0.1.15"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         version: 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
     optionalDependencies:
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.14
-        version: 0.1.14
+        specifier: 0.1.15
+        version: 0.1.15
 
   packages/cli:
     dependencies:
@@ -853,8 +853,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.14':
-    resolution: {integrity: sha512-XEwjqxwMWp+FrhmEzOH+FSnQ5msSpsMUjLoBTdK0claTa4UwcUusrbNXLqxnPoIsdtZuQoGlnggRKbaZsGqjlg==}
+  '@mmnto/strategy-doctrine@0.1.15':
+    resolution: {integrity: sha512-TcoGEEybIzQMm89EzmDQn9PVFoEoBznz1DN7/mU+oPe0LgQbfe3wYD8vDmd5FSjVoq/HWBdFmeyygMWidHKbdw==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3685,7 +3685,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.14':
+  '@mmnto/strategy-doctrine@0.1.15':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
## What

Bump totem's `@mmnto/strategy-doctrine` consumer pin `0.1.14 → 0.1.15` — the published cohort floor (the mmnto-ai/totem-strategy#766 required-extensions parity-dimension cut, published 2026-07-03).

## Why

`totem doctor --parity` was WARNing on stale strategy-doctrine currency:

> WARN — @mmnto/strategy-doctrine pin stale — declared 0.1.14, installed 0.1.14 < cohort floor 0.1.15

Cohort-sync sweep — totem, totem-status, and liquid-city were all one patch behind. This is the non-LC half (strategy-Claude's cohort-sync lane); liquid-city rides its own bundled bump.

## Verification

- `0.1.15` resolves + installs locally (registry read-auth confirmed for the restricted scope)
- `pnpm-lock.yaml` diff is strategy-doctrine-only (new integrity hash for 0.1.15); no unrelated churn
- `totem doctor --parity` now **PASS** on both the currency row and the lock-content row (previously WARN)

Non-breaking — the doctor only WARNs on this row (Tenet 13, sensor-not-gate). No merge without an explicit go.
