### PR TITLE
fix(core): Gemini SDK-missing triggers Ollama fallback (symmetric with openai) (#1859)

### DIFF
--- a/.changeset/gemini-sdk-missing-fallback.md
+++ b/.changeset/gemini-sdk-missing-fallback.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/totem': patch
+---
+
+Fix the Gemini provider not falling back to Ollama when the `@google/genai` SDK is missing (mmnto-ai/totem#1859). `LazyEmbedder` falls back to Ollama when the configured provider fails to **construct**, and the OpenAI provider fails at construction because `openai-embedder.ts` statically imports its SDK. `GeminiEmbedder`, by contrast, loads its SDK lazily (dynamic import inside `embed()`), so an absent `@google/genai` slipped past construction and hard-errored at embed() time — **past the fallback boundary**, asymmetric with OpenAI (a Tenet-16 crossing). `tryBuildEmbedder` now verifies the Gemini SDK resolves at construction (the explicit analog of OpenAI's top-level import), so a missing SDK triggers the documented Ollama fallback like every other provider failure. Behavior is unchanged when the SDK is present; the probe reuses the existing single-home `importGeminiSdk` and its import is cached.

--- a/packages/core/src/embedders/embedder.test.ts
+++ b/packages/core/src/embedders/embedder.test.ts
@@ -19,6 +19,16 @@ vi.mock('./openai-embedder.js', () => ({
   },
 }));
 
+// ─── Mock the @google/genai SDK as ABSENT ──────────
+// mmnto-ai/totem#1859: simulate the optional peer dep being uninstalled so the
+// gemini construction path (importGeminiSdk) rejects — the SDK-missing trigger
+// for the Ollama fallback, distinct from the missing-API-key trigger the other
+// gemini tests exercise. Inert for those key-missing tests: they throw at the
+// constructor's key check, before tryBuildEmbedder reaches importGeminiSdk.
+vi.mock('@google/genai', () => {
+  throw new Error("Cannot find package '@google/genai'");
+});
+
 // ─── Tests ─────────────────────────────────────────
 
 describe('createEmbedder', () => {
@@ -94,8 +104,9 @@ describe('LazyEmbedder concurrency', () => {
 // is also unreachable, callers MUST get the documented 3-step
 // `TotemConfigError`. Regressing this contract pushes consumers back toward
 // vendor-coupling workarounds (mmnto-ai/totem-status#8 → upstream-feedback/064 →
-// mmnto-ai/totem#1851). The Gemini SDK-missing path is asymmetric and tracked
-// separately as mmnto-ai/totem#1859.
+// mmnto-ai/totem#1851). Both fallback triggers are covered below: a missing API
+// key (constructor throw) and a missing provider SDK (construction-time probe,
+// mmnto-ai/totem#1859).
 describe('LazyEmbedder fallback chain — regression contract (mmnto-ai/totem#1851)', () => {
   let originalGeminiKey: string | undefined;
   let originalGoogleKey: string | undefined;
@@ -186,5 +197,41 @@ describe('LazyEmbedder fallback chain — regression contract (mmnto-ai/totem#18
     const allWarns = warns.join('\n');
     expect(allWarns).toContain('Falling back to Ollama');
     expect(allWarns).toContain('Using Ollama fallback embedder');
+  });
+
+  // mmnto-ai/totem#1859: the SDK-missing trigger (distinct from missing-key above).
+  // The API key IS present, so GeminiEmbedder constructs cleanly; only the mocked-
+  // absent @google/genai SDK is missing. This asserts the construction-time SDK
+  // probe: without it, importGeminiSdk() would throw inside embed() — PAST the
+  // fallback boundary — surfacing the raw "Gemini SDK is not installed" error with
+  // no fallback attempt (empty warns, no "No embedding provider available"). Both
+  // discriminating assertions below fail on the pre-fix code, so this is non-vacuous.
+  it('falls back to Ollama when the Gemini SDK is missing but the API key is present (mmnto-ai/totem#1859)', async () => {
+    process.env['GEMINI_API_KEY'] = 'test-gemini-key';
+    // Force isOllamaAvailable() → false so the fallback terminates at CONFIG_MISSING.
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(
+      Object.assign(new Error('connect ECONNREFUSED'), { code: 'ECONNREFUSED' }),
+    );
+
+    const warns: string[] = [];
+    const config: EmbeddingProvider = { provider: 'gemini', model: 'gemini-embedding-2-preview' };
+    const embedder = createEmbedder(config, (msg) => warns.push(msg));
+
+    let caught: unknown;
+    try {
+      await embedder.embed(['x']);
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(TotemConfigError);
+    const err = caught as TotemConfigError;
+    expect(err.code).toBe('CONFIG_MISSING');
+    expect(err.message).toContain('No embedding provider available');
+
+    // The fallback was attempted (breadcrumb) rather than the raw SDK error escaping.
+    const allWarns = warns.join('\n');
+    expect(allWarns).toContain('unavailable');
+    expect(allWarns).toContain('Falling back to Ollama');
   });
 });

--- a/packages/core/src/embedders/embedder.test.ts
+++ b/packages/core/src/embedders/embedder.test.ts
@@ -228,6 +228,12 @@ describe('LazyEmbedder fallback chain — regression contract (mmnto-ai/totem#18
     const err = caught as TotemConfigError;
     expect(err.code).toBe('CONFIG_MISSING');
     expect(err.message).toContain('No embedding provider available');
+    // Full contract parity with the missing-key test above: the terminal error must
+    // carry the documented 3-step remediation, so a refactor can't silently strip the
+    // user-facing guidance while this test still passes (greptile P2, #2302).
+    expect(err.recoveryHint).toContain('(1) Install the SDK');
+    expect(err.recoveryHint).toContain('(2) Install and start Ollama');
+    expect(err.recoveryHint).toContain("(3) Set provider: 'ollama'");
 
     // The fallback was attempted (breadcrumb) rather than the raw SDK error escaping.
     const allWarns = warns.join('\n');

--- a/packages/core/src/embedders/embedder.ts
+++ b/packages/core/src/embedders/embedder.ts
@@ -55,8 +55,17 @@ async function tryBuildEmbedder(config: EmbeddingProvider): Promise<Embedder> {
     return new OpenAIEmbedder(config.model, config.dimensions);
   }
   if (config.provider === 'gemini') {
-    const { GeminiEmbedder } = await import('./gemini-embedder.js');
-    return new GeminiEmbedder(config.model, config.dimensions);
+    const { GeminiEmbedder, importGeminiSdk } = await import('./gemini-embedder.js');
+    const embedder = new GeminiEmbedder(config.model, config.dimensions);
+    // mmnto-ai/totem#1859: verify the @google/genai SDK resolves at construction —
+    // the explicit analog of openai-embedder.ts's top-level `import OpenAI`, whose
+    // resolution failure already makes tryBuildEmbedder throw (and LazyEmbedder fall
+    // back to Ollama) when that SDK is absent. GeminiEmbedder loads SDK-free by design
+    // (dynamic import inside embed()), so without this probe a missing SDK slips past
+    // construction and hard-errors at embed() time — past the fallback boundary. This
+    // restores provider symmetry (the Tenet-16 asymmetry #1859 reported).
+    await importGeminiSdk();
+    return embedder;
   }
   throw new TotemConfigError(
     `Unknown embedding provider: ${config.provider}`,

--- a/packages/core/src/embedders/embedder.ts
+++ b/packages/core/src/embedders/embedder.ts
@@ -56,16 +56,17 @@ async function tryBuildEmbedder(config: EmbeddingProvider): Promise<Embedder> {
   }
   if (config.provider === 'gemini') {
     const { GeminiEmbedder, importGeminiSdk } = await import('./gemini-embedder.js');
-    const embedder = new GeminiEmbedder(config.model, config.dimensions);
-    // mmnto-ai/totem#1859: verify the @google/genai SDK resolves at construction —
-    // the explicit analog of openai-embedder.ts's top-level `import OpenAI`, whose
-    // resolution failure already makes tryBuildEmbedder throw (and LazyEmbedder fall
-    // back to Ollama) when that SDK is absent. GeminiEmbedder loads SDK-free by design
+    // mmnto-ai/totem#1859: resolve the @google/genai SDK BEFORE constructing — the
+    // explicit analog of openai-embedder.ts's top-level `import OpenAI`, which resolves
+    // the SDK before its constructor runs. GeminiEmbedder loads SDK-free by design
     // (dynamic import inside embed()), so without this probe a missing SDK slips past
-    // construction and hard-errors at embed() time — past the fallback boundary. This
-    // restores provider symmetry (the Tenet-16 asymmetry #1859 reported).
+    // construction and hard-errors at embed() time — past the fallback boundary, so
+    // LazyEmbedder never gets to fall back to Ollama. Probing first (ahead of the
+    // constructor's API-key check) gives full parity with openai: when both the SDK and
+    // the key are absent, the SDK-missing error surfaces first, exactly as openai's
+    // static import fails ahead of its own key check.
     await importGeminiSdk();
-    return embedder;
+    return new GeminiEmbedder(config.model, config.dimensions);
   }
   throw new TotemConfigError(
     `Unknown embedding provider: ${config.provider}`,

--- a/packages/core/src/embedders/gemini-embedder.ts
+++ b/packages/core/src/embedders/gemini-embedder.ts
@@ -45,7 +45,7 @@ interface GeminiAI {
  * Dynamically import the @google/genai SDK.
  * It's an optional peer dep in @mmnto/totem — only required when provider is 'gemini'.
  */
-async function importGeminiSdk(): Promise<{
+export async function importGeminiSdk(): Promise<{
   GoogleGenAI: new (opts: { apiKey: string }) => GeminiAI;
 }> {
   try {


### PR DESCRIPTION
## What

Fixes the Gemini provider not falling back to Ollama when the `@google/genai` SDK is missing — a Tenet-16 asymmetry with the OpenAI provider (mmnto-ai/totem#1859).

## Root cause

`LazyEmbedder` falls back to Ollama when the configured provider fails **at construction** (`doResolve` wraps `tryBuildEmbedder` in the fallback try/catch — `embedder.ts:116-144`). The OpenAI provider fails there because `openai-embedder.ts` statically imports its SDK (`import OpenAI from 'openai'`), so `await import('./openai-embedder.js')` rejects when the SDK is absent.

`GeminiEmbedder`, by contrast, loads its SDK **lazily** — a dynamic `import('@google/genai')` inside `embed()` (`gemini-embedder.ts:99`) — and its constructor checks only the API key (`:84-94`). So with a valid key but the SDK uninstalled, `tryBuildEmbedder` *succeeds*, no fallback is registered, and the hard error surfaces later at `embed()` time — **past the fallback boundary**. A Gemini consumer with a missing optional peer dep hard-errors instead of degrading to Ollama, unlike every other provider.

## Fix

`tryBuildEmbedder`'s gemini branch now `await`s `importGeminiSdk()` at construction — the explicit analog of what OpenAI's top-level import does implicitly — so a missing SDK throws during construction and triggers the documented Ollama fallback. Reuses the single-home `importGeminiSdk` (now exported); its import is cached, and behavior is unchanged when the SDK is present.

## Test

Adds a regression test to the existing fallback-contract suite (`embedder.test.ts`) covering the SDK-missing-but-key-present path, alongside the existing missing-key coverage. **Verified non-vacuous**: with the probe removed, the raw `Gemini SDK … is not installed` error escapes `embed()` and both discriminating assertions (`No embedding provider available` + the `Falling back to Ollama` breadcrumb) fail; with the fix they pass. The existing missing-key tests are unaffected — they throw at the constructor's key check before the SDK probe is reached.

## Gate

Full-workspace build + test (cli 2929, core embedders 21), repo-wide `format:check`, ESLint (0 errors), `totem lint` (0 errors), `totem review` (Gemini shield — no findings). Changeset: `@mmnto/totem` patch.

Closes #1859
