### PR TITLE
docs: public-surface truth pass (Pass-2) — Tenet-19 softening, drift cleanup, package READMEs

### DIFF
--- a/docs/manual/why-totem.md
+++ b/docs/manual/why-totem.md
@@ -1,12 +1,14 @@
-## Why Totem
+# Why Totem
+
+AI coding agents lose context between sessions and repeat architectural mistakes. Most checks that would catch those mistakes put an LLM in the review path: slow, networked, non-deterministic. Totem splits the problem — LLMs help author rules and lessons, and enforcement runs as compiled rules with no LLM in the loop.
 
 - **Zero-LLM enforcement.** Compiled rules run in your git hooks with no API keys, no network, no AI in the loop. Works in air-gapped CI and locked-down enterprise environments.
-- **Shared memory across repos.** `totem link` connects repos to a shared knowledge index. A lesson learned in your API repo automatically protects your frontend repo. One memory across your whole stack.
-- **Works with any AI agent.** Claude, Gemini, Cursor, Copilot, Codex — Totem doesn't care who writes the code. It just gates the push.
+- **Shared memory across repos.** `totem link` connects repos to a shared knowledge index. A lesson recorded in your API repo is queryable from your frontend repo.
+- **Agent-agnostic.** Claude, Gemini, Cursor, Copilot, Codex — Totem doesn't care who writes the code. It gates the push.
 
-## How It Works — Sensors, Not Actuators
+## Sensors, Not Actuators
 
-Totem provides the **sensors** — your codebase's immune system. You wire the **actuators**.
+Totem provides the **sensors**. You wire the **actuators**.
 
 | What Totem Provides (Sensor)      | What You Wire (Actuator)     |
 | --------------------------------- | ---------------------------- |
@@ -31,18 +33,18 @@ Totem's enforcement layer is **100% deterministic** — no LLM, no API keys, no 
 | `totem review` (AI review)              |   Yes (LLM)    |
 | `totem spec` (planning)                 |   Yes (LLM)    |
 
-The AI helps you **write** rules. The rules enforce themselves.
+LLMs are used at rule-authoring time; enforcement runs without them.
 
 ## Totem Mesh — Shared Memory Across Repos
 
-Most governance tools are per-repo. Totem lets you connect repos into a shared knowledge mesh:
+Repos can be linked into a shared knowledge index:
 
 ```bash
 # In your frontend repo
 totem link ../api-server
 ```
 
-Now `totem spec` and `totem review` in your frontend repo can query lessons from your API repo. An architectural mistake in one codebase becomes a rule protecting all others.
+Now `totem spec` and `totem review` in your frontend repo can query lessons from your API repo.
 
 Configure cross-repo queries in `totem.config.ts`:
 
@@ -52,7 +54,7 @@ linkedIndexes: ['../api-server', '../shared-design-system'],
 
 ## Context Isolation — Scoped Search per Architecture Layer
 
-When multiple AI agents (or one agent across packages) share a knowledge index, you can restrict search results to specific boundaries. This prevents a frontend agent from hallucinating based on backend database schemas.
+When multiple AI agents (or one agent across packages) share a knowledge index, you can restrict search results to specific boundaries. This keeps backend context out of a frontend agent's search results.
 
 ```typescript
 // totem.config.ts
@@ -73,7 +75,7 @@ Results are restricted to `packages/mcp/` files. Unknown boundary names fall bac
 
 ## Performance
 
-`totem lint` runs **147 compiled rules in under 2 seconds** on a 7,400-line, 105-file PR. Zero LLM inference. Pure AST classification + regex matching.
+Benchmark, measured when the compiled set held 147 rules: `totem lint` ran all of them in under 2 seconds on a 7,400-line, 105-file PR. Zero LLM inference. Pure AST classification + regex matching.
 
 | Metric         | Value                        |
 | -------------- | ---------------------------- |
@@ -83,13 +85,15 @@ Results are restricted to `packages/mcp/` files. Unknown boundary names fall bac
 | Execution time | **1.75s**                    |
 | LLM calls      | **0**                        |
 
-This runs inside a `pre-push` git hook. Your AI agent's push is blocked until every violation is resolved — with the exact file, line, and fix guidance needed to self-correct in one cycle.
+The rule set grows as lessons are compiled; as of 1.89.0 this repo carries 485 compiled rules, 394 of them non-archived.
+
+This runs inside a `pre-push` git hook. The push is blocked until every violation is resolved; each finding reports the file, line, and fix guidance.
 
 ## Try It
 
 [![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mmnto-ai/totem-playground)
 
-The [Totem Playground](https://github.com/mmnto-ai/totem-playground) is a pre-broken Next.js app with several common architectural violations. Open it in Codespaces, run `totem lint --staged`, and watch Totem catch every one.
+The [Totem Playground](https://github.com/mmnto-ai/totem-playground) is a pre-broken Next.js app with several common architectural violations. Open it in Codespaces, run `totem lint --staged`, and read what it reports.
 
 Or run locally:
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -367,7 +367,7 @@ Totem supports three explicit capability tiers, auto-detected from the environme
 
 | Tier         | Requirements                               | Available Commands                                                                                                                                            |
 | ------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Lite**     | Zero API keys                              | `init`, `hooks`, `add-lesson`, `link`, `install`, `rule promote`, `eject`, `lint`, `lesson compile`, `test`, `explain`, `handoff --lite`, `sync --packs-only` |
+| **Lite**     | Zero API keys                              | `init`, `hooks`, `lesson add`, `link`, `install`, `rule promote`, `eject`, `lint`, `lesson compile`, `test`, `explain`, `handoff --lite`, `sync --packs-only` |
 | **Standard** | Embedding key (`OPENAI_API_KEY` or Ollama) | Lite + `sync`, `sync --index-only`, `search`, `stats`, `doctor`                                                                                               |
 | **Full**     | Embedding + Orchestrator                   | All commands (`spec`, `review`, `triage`, `handoff`, `lesson extract`, `docs`, `proposal new`, `adr new`)                                                     |
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -365,10 +365,10 @@ A stdio-based server for LLM integration providing primary tools and strict acce
 
 Totem supports three explicit capability tiers, auto-detected from the environment during `totem init`. The available command list is audited to prune stale commands:
 
-| Tier         | Requirements                               | Available Commands                                                                                                                                     |
-| ------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Tier         | Requirements                               | Available Commands                                                                                                                                            |
+| ------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Lite**     | Zero API keys                              | `init`, `hooks`, `add-lesson`, `link`, `install`, `rule promote`, `eject`, `lint`, `lesson compile`, `test`, `explain`, `handoff --lite`, `sync --packs-only` |
-| **Standard** | Embedding key (`OPENAI_API_KEY` or Ollama) | Lite + `sync`, `sync --index-only`, `search`, `stats`, `doctor`                                                                                        |
+| **Standard** | Embedding key (`OPENAI_API_KEY` or Ollama) | Lite + `sync`, `sync --index-only`, `search`, `stats`, `doctor`                                                                                               |
 | **Full**     | Embedding + Orchestrator                   | All commands (`spec`, `review`, `triage`, `handoff`, `lesson extract`, `docs`, `proposal new`, `adr new`)                                                     |
 
 A lite-tier standalone WASM binary provides core CLI functions with zero native dependencies. The embedding field in configuration files is optional; when omitted, operations default to the Lite tier boundary constraints.

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -2,7 +2,7 @@
 
 Totem is a local-first CLI and MCP server that compiles project knowledge into deterministic enforcement rules. By default it operates entirely within the consuming project with no outbound network calls or telemetry. Cloud embedding and orchestrator providers make outbound API calls only when explicitly configured. Licensed under Apache 2.0.
 
-It is designed as an "Invisible Exoskeleton" for development teams and AI agents — not a static tool, but a continuous, self-healing loop that converts institutional knowledge into deterministic physical constraints. The diagrams below present several views of that architecture, from the high-level workflow loop down to the structural layer separation in the codebase itself.
+It runs as a loop: code-review findings become markdown lessons (`totem lesson extract`), lessons compile into regex/AST rules (`totem lesson compile`), and `totem lint` enforces those rules in git hooks and CI. Bypasses land in a trap ledger that `totem doctor --pr` reads to retune rules. The diagrams below present several views of that architecture, from the workflow loop down to the layer separation in the codebase itself.
 
 ---
 
@@ -10,7 +10,7 @@ It is designed as an "Invisible Exoskeleton" for development teams and AI agents
 
 ### 1. The Flywheel (Observe → Learn → Enforce)
 
-The core functional loop. Friction identified during code review is systematically converted into a fast, local guardrail.
+The core functional loop. Friction identified during code review is converted into a fast, local guardrail.
 
 ```mermaid
 graph TD
@@ -27,7 +27,7 @@ graph TD
     end
 
     subgraph "2. The Brain (Learn)"
-        Extract[totem extract<br/>Capture Markdown Lesson]:::learn
+        Extract[totem lesson extract<br/>Capture Markdown Lesson]:::learn
         Compile[totem lesson compile<br/>Generate Regex/AST]:::learn
     end
 
@@ -50,7 +50,7 @@ graph TD
 
 ### 2. The Agent Governance Pipeline
 
-How Totem "weaponizes" project management to govern autonomous AI agents (like Claude Code or Gemini CLI), preventing them from reinventing wheels or suffering from "Session Start Amnesia."
+How Totem uses project-management artifacts (ADRs, proposals, compiled rules) to govern autonomous AI agents like Claude Code or Gemini CLI. Goal: agents stop reinventing existing helpers and start each session with project context already loaded.
 
 ```mermaid
 sequenceDiagram
@@ -81,7 +81,7 @@ sequenceDiagram
 
 ### 3. The Self-Healing Engine
 
-Totem assumes LLMs will hallucinate and developers will get frustrated. The Trap Ledger turns a developer bypassing a guardrail into actionable telemetry that automatically tunes the system.
+Totem assumes LLMs will hallucinate and developers will get frustrated. Each bypass is logged to the Trap Ledger; `totem doctor --pr` reads that telemetry, downgrades rules that exceed the bypass-rate threshold from error to warning, and surfaces upgrade candidates.
 
 ```mermaid
 graph LR
@@ -256,12 +256,12 @@ flowchart TD
     - _Embeddings:_ Utilizes Gemini as the primary embedder. It features hybrid search combining Full-Text Search and vector similarity.
     - _Resilience:_ Auto-detects and falls back to Ollama if the primary provider fails. Automatic syncs trigger on configuration changes, while filesystem locks prevent race conditions.
 - **Security & Maintenance:**
-  - **Filtering:** Includes adversarial content scrubbing and DLP secret masking at every LLM boundary. A dedicated lesson ContentType ensures precise vector retrieval.
-  - **Drift Detection:** A self-cleaning sync engine purges orphaned vectors when source files are deleted. Path containment checks and ingestion hardening establish firm trust boundaries.
+  - **Filtering:** Includes adversarial content scrubbing and DLP secret masking at every LLM boundary. A dedicated lesson ContentType provides scoped retrieval primitives; recall is the caller's responsibility.
+  - **Drift Detection:** A self-cleaning sync engine purges orphaned vectors when source files are deleted. Path containment checks and ingestion hardening establish trust boundaries.
 
 ### 2. The CLI (`@mmnto/cli`)
 
-All commands feature proper `--help` output documentation.
+All commands document their flags via `--help`.
 
 - **Setup & Infrastructure:**
   - **Initialization:** Scaffolds configs, hooks, and tools with an onboarding workflow. It supports a bare flag, ordered provider detection, and local configuration ingestion.
@@ -275,13 +275,13 @@ All commands feature proper `--help` output documentation.
   - **Planning & Orchestration:**
     - _Workflows:_ Orchestrates tasks with human approval gates. It supports configurable issue sources and mandatory execution verification.
     - _Automation:_ Structures capabilities using directory-based skill files to scope execution context. Automation removes stale commands for a leaner toolset.
-    - _Hooks:_ Enforces lifecycle events via verification hooks. Phase-gate enforcement actively blocks commits lacking proper preflight checks.
+    - _Hooks:_ Enforces lifecycle events via verification hooks. Phase-gate enforcement blocks commits lacking preflight checks.
   - **Review & Quality:**
-    - **`totem lint`**: Runs compiled rules against diffs. Zero LLM, fast, and recommended for pre-push hooks and CI organically supporting SARIF outputs.
+    - **`totem lint`**: Runs compiled rules against diffs. Zero LLM; recommended for pre-push hooks and CI. Supports SARIF output.
     - **`totem review`**: Conducts AI-powered code review using LanceDB context before PRs. It enriches context with full file contents for small files and supports audited bypass flags.
     - **`totem explain`**: Looks up the specific lesson behind a rule violation to provide immediate developer context.
-  - **Documentation:** Automates transactional document syncs using a validator to prevent partial updates. It actively strips known-not-shipped references from generated content.
-  - **Telemetry & Triage:** A categorized triage inbox maps finding severities directly. The trap ledger maintains append-only telemetry locally, allowing the system to automatically downgrade noisy rules and archive stale data.
+  - **Documentation:** Automates transactional document syncs using a validator to prevent partial updates. It strips known-not-shipped references from generated content.
+  - **Telemetry & Triage:** A categorized triage inbox maps finding severities directly. The trap ledger maintains append-only telemetry locally, allowing `totem doctor --pr` to downgrade noisy rules and archive stale data.
 - **Rule Testing & Extraction:**
   - **Capture & Extraction:** Enables inline capture and batch lesson extraction strictly validated before disk writes. A retirement ledger tracks intentionally removed lessons to prevent re-extraction.
   - **Harness Verification:** Serves as a compiled rule testing harness to measure regex false positives. It includes inline hit/miss verification examples for rule unit testing.
@@ -289,7 +289,7 @@ All commands feature proper `--help` output documentation.
 
 ### 3. Deterministic Compiler & Zero-LLM Lint
 
-`totem lesson compile` translates structural constraints into rules. It incorporates a strict lesson file linter acting as a pre-compilation gate to ensure structural integrity. A self-suppression guard actively rejects patterns that match engine suppression directives. The compilation process integrates manifest signing to establish a secure provenance chain.
+`totem lesson compile` translates structural constraints into rules. It incorporates a strict lesson file linter acting as a pre-compilation gate to ensure structural integrity. A self-suppression guard rejects patterns that match engine suppression directives. The compilation process integrates manifest signing to establish a secure provenance chain.
 
 **Compound ast-grep rules.** Beyond flat single-pattern matchers, compiled rules can carry full `NapiConfig`-shape structural rules in an `astGrepYamlRule` field. Compound rules express containment relationships using `inside`, `has`, and `not` combinators, eliminating the structural false positives that flat patterns produce when they cannot encode "inside a loop", "empty catch", or "outside an import statement". The schema enforces mutual exclusion between flat (`astGrepPattern`) and compound (`astGrepYamlRule`) shapes, and the manifest hash uses a canonical key-sorted serialisation so semantically-identical compound rules produce byte-identical hashes regardless of LLM key order.
 
@@ -297,7 +297,7 @@ All commands feature proper `--help` output documentation.
 
 The compiler supports manual pattern definitions and reverse-compiles curated rules. It includes a backfill of body text for 938 core architectural lessons to enrich rule context. An integrated WASM ast-grep engine targets complex imports and restricted properties alongside regex capabilities. These AST query engines implement graceful degradation and strictly manage process exits. Rules are stored in `.totem/compiled-rules.json`, extended with advanced telemetry fields.
 
-The compilation process reads files directly from disk instead of parsing staged diffs to prevent false positives. It also supports an `--upgrade <hash>` flow path that targets a specific rule, evicts it from the cache, and recompiles it through Sonnet using telemetry-driven directives. Developers can bypass false positives using audited inline suppression directives. Rules are scoped using directory-rooted glob matching to prevent leaks outside specified directories. The system relies on a curated 455-rule set for baseline enforcement.
+The compilation process reads files directly from disk instead of parsing staged diffs to prevent false positives. It also supports an `--upgrade <hash>` flow path that targets a specific rule, evicts it from the cache, and recompiles it through Sonnet using telemetry-driven directives. Developers can bypass false positives using audited inline suppression directives. Rules are scoped using directory-rooted glob matching to prevent leaks outside specified directories. As of 1.89.0, this repo's `.totem/compiled-rules.json` holds 485 compiled rules, of which 394 are non-archived (`totem lint` skips archived rules).
 
 `totem lint` applies these compiled rules against additions with zero LLM calls. It shares a core execution engine with review commands for execution consistency. This process supports importing external configurations natively, translating flat configuration structures into deterministic rules without LLM usage. It also permits direct cross-repository rule sharing.
 
@@ -349,27 +349,27 @@ Packs distribute compiled rules and extension surfaces across the Totem ecosyste
 A stdio-based server for LLM integration providing primary tools and strict access boundaries:
 
 - **Core Tools:**
-  - **Search:** Semantic retrieval of codebase context scoped via boundary parameters. Telemetry actively measures agent retrieval behaviors.
+  - **Search:** Semantic retrieval of codebase context scoped via boundary parameters. Telemetry records agent retrieval behavior.
   - **Knowledge:** Appends lessons with descriptive headings. Employs a sync-pending debounce mechanism and filesystem locks to prevent write race conditions.
-  - **Enforcement:** Direct check tools empower agents to self-validate deterministic rules. This includes execution verification capabilities to test generated code against invariants.
+  - **Enforcement:** Direct check tools let agents self-validate against deterministic rules. This includes execution verification capabilities to test generated code against invariants.
 - **Security & Permissions:**
   - **Sanitization:** XML-delimits all MCP responses and sanitizes persisted content. It strips quotes from loaded environment variables.
   - **Access Control:** Implements an authentication model with strict trust boundaries and explicit payload capacity caps. This prevents unbounded memory consumption.
-  - **Context Limits:** Agent instruction files are structurally governed using a recency sandwich pattern. Strict length limits and a lean root router pattern maintain context focus.
+  - **Context Limits:** Agent instruction files are structurally governed using a recency sandwich pattern. Strict length limits and a lean root router pattern keep instruction files short.
 - **Integrations & Lifecycle:**
-  - **IDE Hooks:** Agent hooks exist for Claude Code, Gemini CLI, and Junie. Integrates deep workflow automation.
+  - **IDE Hooks:** Agent hooks exist for Claude Code, Gemini CLI, and Junie.
   - **Session Management:** Utilizes a health check first-query gate to prevent silent search failures at startup. It advises users to rebuild when indexes are broken.
   - **Stability:** Reaps zombie MCP processes via heartbeat timeouts to resolve connection failures. Handles dimension mismatches dynamically during retrieval queries.
 
 ## Configuration Tiers
 
-Totem supports three explicit capability tiers, auto-detected from the environment during `totem init`. The available command list is audited to prune stale tasks and preserve a streamlined interface:
+Totem supports three explicit capability tiers, auto-detected from the environment during `totem init`. The available command list is audited to prune stale commands:
 
 | Tier         | Requirements                               | Available Commands                                                                                                                                     |
 | ------------ | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| **Lite**     | Zero API keys                              | `init`, `hooks`, `add-lesson`, `link`, `install`, `rule promote`, `eject`, `lint`, `compile`, `test`, `explain`, `handoff --lite`, `sync --packs-only` |
+| **Lite**     | Zero API keys                              | `init`, `hooks`, `add-lesson`, `link`, `install`, `rule promote`, `eject`, `lint`, `lesson compile`, `test`, `explain`, `handoff --lite`, `sync --packs-only` |
 | **Standard** | Embedding key (`OPENAI_API_KEY` or Ollama) | Lite + `sync`, `sync --index-only`, `search`, `stats`, `doctor`                                                                                        |
-| **Full**     | Embedding + Orchestrator                   | All commands (`spec`, `review`, `triage`, `handoff`, `extract`, `docs`, `proposal new`, `adr new`)                                                     |
+| **Full**     | Embedding + Orchestrator                   | All commands (`spec`, `review`, `triage`, `handoff`, `lesson extract`, `docs`, `proposal new`, `adr new`)                                                     |
 
 A lite-tier standalone WASM binary provides core CLI functions with zero native dependencies. The embedding field in configuration files is optional; when omitted, operations default to the Lite tier boundary constraints.
 
@@ -381,7 +381,7 @@ The CLI orchestrator supports multiple provider types via a discriminated union 
 
 ### Shell Provider (default)
 
-Pipes prompts to any CLI tool via placeholders. Handled timeouts and strict taskkill mitigations ensure processes do not cause memory leaks:
+Pipes prompts to any CLI tool via placeholders. Timeout handling and taskkill mitigations guard against leaked processes:
 
 ```typescript
 orchestrator: {
@@ -442,7 +442,7 @@ orchestrator: {
 
 ### Shared Configuration
 
-All orchestrator providers support standardizing complex configurations via centralized logic:
+All orchestrator providers share centralized configuration handling:
 
 - **Routing & Resolution:** Centralized provider routing prioritizes explicit model flags over overrides and defaults. Supports cross-provider fallback configurations.
 - **Customization:** Supports system prompts for per-command instructions and cache TTLs for performance tuning.
@@ -450,9 +450,9 @@ All orchestrator providers support standardizing complex configurations via cent
 
 ## The `.totem/` Directory
 
-The `.totem/lessons/` directory acts as an explicit version-controlled ledger of architectural decisions. Extracted lessons are safely strictly validated, auto-committed, and automatically re-indexed during syncs.
+The `.totem/lessons/` directory acts as an explicit version-controlled ledger of architectural decisions. Extracted lessons are validated before disk writes, auto-committed, and re-indexed during syncs.
 
-Users are offered an optional Universal Baseline during initialization. These foundational lessons feature audience tags and include fix guidance to resolve architectural violations. Language packs proactively provide baseline lessons tailored for specific programming environments. This solves the cold-start problem where a fresh install has no initial knowledge to retrieve.
+Users are offered an optional Universal Baseline during initialization. These foundational lessons feature audience tags and include fix guidance to resolve architectural violations. Language packs provide baseline lessons tailored for specific programming environments. This solves the cold-start problem where a fresh install has no initial knowledge to retrieve.
 
 ## The Strategy Repo (Configurable Root)
 

--- a/docs/reference/llm-parameters.md
+++ b/docs/reference/llm-parameters.md
@@ -17,7 +17,7 @@ The compilation step is not a creative task; it is a translation task. The goal 
 
 ## 2. Extraction: The Analytical Path
 
-**Target Command:** `totem extract`
+**Target Command:** `totem lesson extract`
 **Ideal Temperature:** `0.4`
 
 Extraction requires the model to read a sprawling, messy GitHub Pull Request thread and synthesize it into a cohesive, single-sentence lesson.

--- a/docs/reference/supported-models.md
+++ b/docs/reference/supported-models.md
@@ -10,7 +10,7 @@ config paths, and strategies for keeping everything current.
 
 ## Orchestrator Models (LLM Calls)
 
-Used by `totem review`, `totem spec`, `totem triage`, `totem extract`, etc.
+Used by `totem review`, `totem spec`, `totem triage`, `totem lesson extract`, etc.
 
 ### Google Gemini
 
@@ -37,7 +37,7 @@ Used by `totem review`, `totem spec`, `totem triage`, `totem extract`, etc.
 | ----------------- | ------------------- | ---------------------------- | ---------------------------------------------- |
 | Flagship          | `claude-opus-4-7`   | (undated alias)              | 1M context, Jan 2026 cutoff, adaptive thinking |
 | Previous Opus     | `claude-opus-4-6`   | (undated alias)              | 1M context, May 2025 cutoff, still available   |
-| Fast/balanced     | `claude-sonnet-4-6` | (undated alias)              | Default for `totem compile` routing            |
+| Fast/balanced     | `claude-sonnet-4-6` | (undated alias)              | Default for `totem lesson compile` routing     |
 | Cheapest          | `claude-haiku-4-5`  | `claude-haiku-4-5-20251001`  |                                                |
 | Legacy Opus       | `claude-opus-4-5`   | Still available              |                                                |
 | Legacy Sonnet 4.5 | `claude-sonnet-4-5` | `claude-sonnet-4-5-20250929` |                                                |
@@ -143,7 +143,7 @@ When a provider releases new stable models, update these locations:
 
 ## AI Coding Tools (Export Targets)
 
-Totem exports compiled lessons to AI coding tool config files via `totem compile --export`. Each tool reads its own file on startup.
+Totem exports compiled lessons to AI coding tool config files via `totem lesson compile --export`. Each tool reads its own file on startup.
 
 | Tool                   | Config File                       | Export Key | Totem Support           |
 | ---------------------- | --------------------------------- | ---------- | ----------------------- |

--- a/docs/reference/workflow-automation.md
+++ b/docs/reference/workflow-automation.md
@@ -78,14 +78,14 @@ Exempt branches (commit gate only): `main`, `master`, `hotfix/*`, `docs/*`, deta
 
 ## Skills (User-Invoked)
 
-| Skill                | Usage                    | Steps                                                           |
-| -------------------- | ------------------------ | --------------------------------------------------------------- |
-| `/preflight <issue>` | Before starting a ticket | `totem spec` → `search_knowledge`                               |
-| `/prepush`           | Before pushing code      | `format` → `totem lint` → `totem review`                        |
+| Skill                | Usage                    | Steps                                                                   |
+| -------------------- | ------------------------ | ----------------------------------------------------------------------- |
+| `/preflight <issue>` | Before starting a ticket | `totem spec` → `search_knowledge`                                       |
+| `/prepush`           | Before pushing code      | `format` → `totem lint` → `totem review`                                |
 | `/postmerge <prs>`   | After merging PRs        | `totem lesson extract` → `totem sync` → `totem lesson compile --export` |
-| `/triage`            | Pick next work           | `totem triage --fresh`                                          |
-| `/release-prep`      | Before cutting a release | `totem lesson extract` → changeset → `pnpm run version` → `totem docs` |
-| `/signoff`           | End of session           | update memory → journal                                         |
+| `/triage`            | Pick next work           | `totem triage --fresh`                                                  |
+| `/release-prep`      | Before cutting a release | `totem lesson extract` → changeset → `pnpm run version` → `totem docs`  |
+| `/signoff`           | End of session           | update memory → journal                                                 |
 
 ## Agent Delegation (Subagent Patterns)
 

--- a/docs/reference/workflow-automation.md
+++ b/docs/reference/workflow-automation.md
@@ -49,7 +49,7 @@ The agent optimizes for speed over process, skipping steps like `totem spec` and
 ### Phase 6: After PR Merge
 
 **What should happen:** Extract lessons from the merged PR(s), re-sync the index, compile new rules locally, review the resulting rules by hand.
-**Commands:** `totem lesson extract <prs> --yes`, `totem sync`, `totem lesson compile --export`, `git checkout HEAD -- .totem/compiled-rules.json`
+**Commands:** `totem lesson extract <prs> --yes`, `totem sync`, `totem lesson compile --export`
 **Skill:** `/postmerge <pr-numbers>`
 **Note:** `totem wrap` is retired pending [mmnto-ai/totem#1361](https://github.com/mmnto-ai/totem/issues/1361) because its `totem docs` step silently overwrote hand-crafted committed documentation. Run the individual commands directly.
 
@@ -78,14 +78,14 @@ Exempt branches (commit gate only): `main`, `master`, `hotfix/*`, `docs/*`, deta
 
 ## Skills (User-Invoked)
 
-| Skill                | Usage                    | Steps                                                                   |
-| -------------------- | ------------------------ | ----------------------------------------------------------------------- |
-| `/preflight <issue>` | Before starting a ticket | `totem spec` → `search_knowledge`                                       |
-| `/prepush`           | Before pushing code      | `format` → `totem lint` → `totem review`                                |
-| `/postmerge <prs>`   | After merging PRs        | `totem lesson extract` → `totem sync` → `totem lesson compile --export` |
-| `/triage`            | Pick next work           | `totem triage --fresh`                                                  |
-| `/release-prep`      | Before cutting a release | `totem lesson extract` → changeset → `pnpm run version` → `totem docs`  |
-| `/signoff`           | End of session           | update memory → journal                                                 |
+| Skill                | Usage                    | Steps                                                                               |
+| -------------------- | ------------------------ | ----------------------------------------------------------------------------------- |
+| `/preflight <issue>` | Before starting a ticket | `totem spec` → `search_knowledge`                                                   |
+| `/prepush`           | Before pushing code      | `format` → `totem lint` → `totem review`                                            |
+| `/postmerge <prs>`   | After merging PRs        | `totem lesson extract <prs> --yes` → `totem sync` → `totem lesson compile --export` |
+| `/triage`            | Pick next work           | `totem triage --fresh`                                                              |
+| `/release-prep`      | Before cutting a release | `totem lesson extract` → changeset → `pnpm run version` → `totem docs`              |
+| `/signoff`           | End of session           | update memory → journal                                                             |
 
 ## Agent Delegation (Subagent Patterns)
 

--- a/docs/reference/workflow-automation.md
+++ b/docs/reference/workflow-automation.md
@@ -57,7 +57,7 @@ The agent optimizes for speed over process, skipping steps like `totem spec` and
 
 **What should happen:** Verify tickets are closed, extract from all PRs since last release, version bump, then docs.
 **Order matters:** extract → changeset → `pnpm run version` → `totem docs` (docs must run _after_ version bump so the LLM sees the correct version in git tags)
-**Commands:** `totem extract`, `pnpm run version`, `totem docs`
+**Commands:** `totem lesson extract`, `pnpm run version`, `totem docs`
 **Skill:** `/release-prep`
 
 ### Phase 8: End of Session
@@ -82,9 +82,9 @@ Exempt branches (commit gate only): `main`, `master`, `hotfix/*`, `docs/*`, deta
 | -------------------- | ------------------------ | --------------------------------------------------------------- |
 | `/preflight <issue>` | Before starting a ticket | `totem spec` → `search_knowledge`                               |
 | `/prepush`           | Before pushing code      | `format` → `totem lint` → `totem review`                        |
-| `/postmerge <prs>`   | After merging PRs        | `totem extract` → `totem sync` → `totem compile --export`       |
+| `/postmerge <prs>`   | After merging PRs        | `totem lesson extract` → `totem sync` → `totem lesson compile --export` |
 | `/triage`            | Pick next work           | `totem triage --fresh`                                          |
-| `/release-prep`      | Before cutting a release | `totem extract` → changeset → `pnpm run version` → `totem docs` |
+| `/release-prep`      | Before cutting a release | `totem lesson extract` → changeset → `pnpm run version` → `totem docs` |
 | `/signoff`           | End of session           | update memory → journal                                         |
 
 ## Agent Delegation (Subagent Patterns)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -23,7 +23,7 @@ totem sync             # rebuild the semantic index (needs an embedding key)
 totem --help           # full command list
 ```
 
-`totem init`, `totem lint`, and the git hooks run with no API keys. LLM-backed commands (`lesson compile`, `review`, `spec`) use the orchestrator configured in `totem.config.ts`; the Anthropic, OpenAI, and Google SDKs are optional peer dependencies loaded only when configured.
+`totem init`, `totem lint`, and the git hooks run with no API keys. LLM-backed commands (`lesson compile`, `lesson extract`, `review`, `spec`) use the orchestrator configured in `totem.config.ts`; the Anthropic, OpenAI, and Google SDKs are optional peer dependencies loaded only when configured.
 
 ## Docs
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,34 @@
+# @mmnto/cli
+
+Command-line interface for [Totem](https://github.com/mmnto-ai/totem), a persistent memory and context layer for AI coding agents. Installs the `totem` binary.
+
+## Install
+
+```bash
+pnpm add -D @mmnto/cli
+# or run without installing
+pnpm dlx @mmnto/cli init
+```
+
+Requires Node >= 24.
+
+## Usage
+
+```bash
+totem init             # scaffold totem.config.ts, git hooks, and baseline rules
+totem lint             # run compiled rules against your changes (zero LLM, offline)
+totem lesson compile   # compile markdown lessons into regex/AST rules (needs an LLM key)
+totem lesson extract   # extract lessons from PR reviews (needs an LLM key)
+totem sync             # rebuild the semantic index (needs an embedding key)
+totem --help           # full command list
+```
+
+`totem init`, `totem lint`, and the git hooks run with no API keys. LLM-backed commands (`lesson compile`, `review`, `spec`) use the orchestrator configured in `totem.config.ts`; the Anthropic, OpenAI, and Google SDKs are optional peer dependencies loaded only when configured.
+
+## Docs
+
+- Repository: <https://github.com/mmnto-ai/totem>
+- Architecture: [docs/reference/architecture.md](https://github.com/mmnto-ai/totem/blob/main/docs/reference/architecture.md)
+- CLI reference: [docs/wiki/cli-reference.md](https://github.com/mmnto-ai/totem/blob/main/docs/wiki/cli-reference.md)
+
+Apache-2.0.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,27 @@
+# @mmnto/totem
+
+Core engine for [Totem](https://github.com/mmnto-ai/totem), a persistent memory and context layer for AI agents. This is the library that [`@mmnto/cli`](https://www.npmjs.com/package/@mmnto/cli) and [`@mmnto/mcp`](https://www.npmjs.com/package/@mmnto/mcp) build on; most users want one of those instead.
+
+It contains the lesson parsing and compilation substrate, the deterministic rule engine (regex, Tree-sitter AST classification, ast-grep), the LanceDB-backed vector store, chunkers and embedders, and pack manifest helpers.
+
+## Install
+
+```bash
+pnpm add @mmnto/totem
+```
+
+Requires Node >= 24. `@google/genai` is an optional peer dependency, used when Gemini is configured as the embedder.
+
+## Usage
+
+```typescript
+import { LanceStore, createEmbedder, createChunker } from '@mmnto/totem';
+```
+
+See the [architecture reference](https://github.com/mmnto-ai/totem/blob/main/docs/reference/architecture.md) for how the pieces fit together.
+
+## Docs
+
+- Repository: <https://github.com/mmnto-ai/totem>
+
+Apache-2.0.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,38 @@
+# @mmnto/mcp
+
+MCP (Model Context Protocol) server for [Totem](https://github.com/mmnto-ai/totem), a persistent memory and context layer for AI coding agents. A stdio-based server that exposes a Totem project's knowledge index to any MCP-compatible agent. Installs the `totem-mcp` binary.
+
+## Setup
+
+Add it to your agent's MCP configuration (`npx` fetches it on demand):
+
+```json
+{
+  "mcpServers": {
+    "totem": {
+      "command": "npx",
+      "args": ["-y", "@mmnto/mcp"]
+    }
+  }
+}
+```
+
+On Windows, wrap the command: `"command": "cmd", "args": ["/c", "npx", "-y", "@mmnto/mcp"]`.
+
+Requires Node >= 24 and a Totem-initialized project (`totem init` from [`@mmnto/cli`](https://www.npmjs.com/package/@mmnto/cli)).
+
+## Tools
+
+| Tool               | What it does                                                                                              |
+| ------------------ | --------------------------------------------------------------------------------------------------------- |
+| `search_knowledge` | Semantic search over the project's knowledge index (code, lessons, specs, session logs)                   |
+| `add_lesson`       | Persist a lesson to `.totem/lessons/`; an incremental re-index runs automatically                          |
+| `describe_project` | Structured JSON summary of project governance scope (rules, lessons, config tier, targets, hooks); no LLM |
+| `verify_execution` | Run deterministic lint checks against current changes; returns PASS or FAIL with violations; zero LLM     |
+
+## Docs
+
+- Repository: <https://github.com/mmnto-ai/totem>
+- Setup guide: [docs/wiki/mcp-setup.md](https://github.com/mmnto-ai/totem/blob/main/docs/wiki/mcp-setup.md)
+
+Apache-2.0.

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -26,7 +26,7 @@ Requires Node >= 24 and a Totem-initialized project (`totem init` from [`@mmnto/
 | Tool               | What it does                                                                                              |
 | ------------------ | --------------------------------------------------------------------------------------------------------- |
 | `search_knowledge` | Semantic search over the project's knowledge index (code, lessons, specs, session logs)                   |
-| `add_lesson`       | Persist a lesson to `.totem/lessons/`; an incremental re-index runs automatically                          |
+| `add_lesson`       | Persist a lesson to `.totem/lessons/`; an incremental re-index runs automatically                         |
 | `describe_project` | Structured JSON summary of project governance scope (rules, lessons, config tier, targets, hooks); no LLM |
 | `verify_execution` | Run deterministic lint checks against current changes; returns PASS or FAIL with violations; zero LLM     |
 


### PR DESCRIPTION
## What this is

Pass-2 of the public-surface truth pass (mmnto-ai/totem-strategy#531) — the structural / reference / mechanical chunk, with the operator's ratified dispositions applied. Pass-1 (mechanical inventory) found the README voice-lede already honest, so it is untouched. **F1 wiki-dedupe is deliberately held for its own pass** (it spans the separate `.wiki` repo, a different mechanism).

**Authoring:** Fable-drafted → Opus-verified. The diff was checked line-by-line against code canon (not the drafter's prose): `doctor.ts` downgrade logic, `index.ts` command registration, `packages/core` exports, `.totem/compiled-rules.json` counts. One drafter override of the brief was adopted *because* it was code-accurate (FLAG 1 below).

## Findings addressed

| # | Surface | Change |
|---|---------|--------|
| F5 | `docs/reference/architecture.md` | Soften aspirational self-framing → mechanism claims; "weaponizes"-adjacent adherence half moved behind `Goal:` (Tenet-19); ~20 claim-verb subtractions |
| F2 | `docs/manual/launch-metrics.md` → `why-totem.md` | Reframe mislabeled pitch page; all 3 data tables kept verbatim; sell prose stripped |
| F3 | architecture / workflow-automation / supported-models / llm-parameters | Bare `totem compile`/`extract` (hidden/deprecated) → canonical `totem lesson compile`/`extract` |
| F6 | architecture.md + why-totem.md | Measured **485 compiled / 394 non-archived** @ 1.89.0; 147-vs-394 reconciled as same-metric-different-time |
| F4 | `packages/{cli,core,mcp}/README.md` | Created (npm pages were blank); facts from each `package.json` + verified exports |

Net **−101 lines** on existing surfaces; +4 new files.

## Reviewer flags (for totem-claude — you have the authoritative what-ships view)

1. **`architecture.md` §3 now states `doctor --pr` auto-downgrades rules past the 30% bypass threshold** — this is code-accurate (`doctor.ts:1331-1375` calls `downgradeRuleToWarning`), which is why the brief's "surfaces tuning candidates" wording was *not* used. It's user-invoked (`doctor --pr`), so no Tenet-13 breach — but confirm the framing reads right to you.
2. **"The Self-Healing Engine" §3 heading kept** — "self-healing" is established vocab in `README.md`/`COVENANT.md` (out of scope here). Candidate to reconcile in the README/wiki voice pass, not piecemeal.
3. **`architecture.md` §4 SonarQube/CodeQL/Dependabot/CodeRabbit "evaluating" claim left untouched** — ambiguous whether those are running or under evaluation. Your call.
4. **Tier table lists `lesson compile` under Lite (zero API keys)** — pre-existing placement, only renamed. Confirm base `lesson compile` is genuinely zero-LLM (vs the `--upgrade`/Sonnet path).
5. **F6 nuance:** 7 of the 394 non-archived are `untested-against-codebase`; if `totem lint` skips those, "394" slightly overstates the enforced count.
6. **`packages/mcp/README.md`** documents the `npx -y @mmnto/mcp` + Windows `cmd /c` setup snippet (copied from `docs/wiki/mcp-setup.md`). Consistent with the existing setup doc; the init-time MCP-registration portability question (mmnto-ai/totem-strategy#611 carryforward) is a separate `totem init` track, not this docs PR.
7. **Out of scope, handed to the F1 wiki pass:** stale "455" in `docs/wiki/cloud-compilation.md:15`; bare-command hits in several `docs/wiki/*` + generated surfaces (`.github/copilot-instructions.md` etc. — regenerate via `totem lesson compile --export`, don't hand-edit). Main `README.md` badge says `node >= 20` but all packages require `>= 24`.

## Bot review

Docs-only. Per bot-protocol (on-demand, operator-gated), no bot invoked. **Ready: invoke a bot, or merge as-is.**
