### PR TITLE
feat(cli): totem ecl-gc — self-resolving ECL outbox-prune + signoff step (#2279)

### DIFF
--- a/.changeset/ecl-gc-outbox-prune.md
+++ b/.changeset/ecl-gc-outbox-prune.md
@@ -1,0 +1,7 @@
+---
+'@mmnto/cli': minor
+---
+
+Add `totem ecl-gc` — the binary-guaranteed, cohort-wide replacement for the interim `scripts/prune-outbox.mjs` (mmnto-ai/totem#2279; parent mmnto-ai/totem-strategy#700; doctrine/ecl-discipline.md § 4.4). It prunes the calling agent's OWN aged ECL outbox dispatches: `totem ecl-gc` self-resolves the single self-agent (reusing `resolveSelfSender`'s explicit > unambiguous-self > throw precedence) and prunes only `<repoRoot>/.totem/orchestration/<agent>/outbox/`, so a self-resolving binary structurally cannot prune a peer, `journal/`, or `processed/`.
+
+Dry-run by default (lists would-prune, deletes nothing); `--apply` deletes. Flags: `--retain-days <n>` (default 14), `--agent-id <id>` (visiting/orchestrator override), `--json` (structured stdout). Only `.md` dispatches with a parseable dual-form stamp (`YYYY-MM-DDTHHMMZ` or `…HHMMSSZ`) are eligible; the exact retention boundary is retained; non-file / non-`.md` / unparseable entries are surfaced and never deleted. Exit codes: 0 clean, 1 partial delete failure (janitorial sensor, non-blocking — Tenet 13), 2 usage error. The distributed `signoff` skill gains a prune step (step 5) wiring `totem ecl-gc --apply` into end-of-session cleanup. This train ships prune only; processed-mark compaction is a deferred follow-on, and `scripts/prune-outbox.mjs` is intentionally left in place.

--- a/.claude/skills/signoff/SKILL.md
+++ b/.claude/skills/signoff/SKILL.md
@@ -40,7 +40,11 @@ End-of-session wrap-up. Post-Proposal-282 (ADR-106), journals + handoffs live in
    done
    ```
 
-5. **Report:** what shipped, what's pending, what's next.
+5. **Prune your own outbox (ECL retention).** Delete your own `outbox/` dispatches older than the retention window (**N = 14 days**) per ECL outbox-retention doctrine (`mmnto-ai/totem-strategy:doctrine/ecl-discipline.md` § 4.4). The outbox is transport, not archive — a dispatch's durable content already lives in its home (rulings → ADRs / issues, work-state → the GH board, session history → `journal/`), so the aged courier file is disposable (gitignored + local). The operator should never have to janitor the mail substrate.
+
+   **Mechanism:** `totem ecl-gc --apply` — self-resolves your agent-id (same precedence as step 2a: `TOTEM_SELF_AGENT` env > `config.json` `host_agents` > seat-dir ∪ basename map) and prunes only `<repoRoot>/.totem/orchestration/<your-agent-id>/outbox/`, so a self-resolving binary structurally cannot prune a peer. Dry-run by default; `--apply` deletes. It **never** touches `journal/` or `processed/`. Report the pruned count in the Report step. A non-zero exit means some deletes failed (or the agent could not be resolved) — report the count but **do not block the seal**: the prune is a janitorial sensor, not a gate (Tenet 13).
+
+6. **Report:** what shipped, what's pending, what's next.
 
 **Cross-repo handoffs** (when you need to dispatch a message to another agent) write to your own `<repoRoot>/.totem/orchestration/<agent-id>/outbox/<YYYY-MM-DDTHHMMZ>-<your-agent-id>.md` with `to: <recipient-agent-id>` in the frontmatter. Recipients discover inbound handoffs by polling the single-level glob `<workspace>/*/.totem/orchestration/*/outbox/*.md` filtered by their own `to:` frontmatter match.
 

--- a/packages/cli/src/commands/ecl-gc.test.ts
+++ b/packages/cli/src/commands/ecl-gc.test.ts
@@ -1,0 +1,347 @@
+/**
+ * Tests for `totem ecl-gc` (mmnto-ai/totem#2279; parent mmnto-ai/totem-strategy#700).
+ *
+ * Filesystem-driven with an injected clock: every test builds a fresh
+ * `<tmp>/.totem/orchestration/<agent>/outbox/` tree, exercises `eclGc`, and
+ * asserts on the structured `EclGcResult` AND on the on-disk aftermath (which
+ * files survived). The safety rows (peer immunity, non-outbox trees untouched,
+ * ambiguity-throws-before-deletion, exact-boundary retention) are written to
+ * FAIL if their guard were removed — see the per-test non-vacuity notes.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { cleanTmpDir } from '../test-utils.js';
+import {
+  classifyEntry,
+  cutoffKey,
+  eclGc,
+  type EclGcOptions,
+  planPrune,
+  toStampKey,
+} from './ecl-gc.js';
+
+// `vi.spyOn` cannot rebind a frozen ESM module-namespace export (node:fs), so
+// the partial-delete-failure row drives a module mock instead: a hoisted
+// fail-set makes the mocked `unlinkSync` throw for named files and pass through
+// to the real implementation for everything else. All other fs calls stay real.
+const fsMockState = vi.hoisted(() => ({ failFor: new Set<string>() }));
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    default: actual,
+    unlinkSync: (p: fs.PathLike, ...rest: unknown[]): void => {
+      const name = String(p);
+      for (const suffix of fsMockState.failFor) {
+        if (name.endsWith(suffix)) {
+          throw new Error('EPERM: simulated locked file');
+        }
+      }
+      return (actual.unlinkSync as (target: fs.PathLike, ...r: unknown[]) => void)(p, ...rest);
+    },
+  };
+});
+
+// ─── Fixtures ───────────────────────────────────────────
+
+// Fixed clock so cutoffs are deterministic (Tenet 15). 14-day default window
+// puts the cutoff at 2026-06-21T12:00:00Z → key `20260621120000`.
+const NOW = new Date('2026-07-05T12:00:00.000Z');
+const nowFn = (): Date => NOW;
+const CUTOFF_KEY = '20260621120000';
+
+let tmpRoot: string;
+
+function mkDir(p: string): string {
+  fs.mkdirSync(p, { recursive: true });
+  return p;
+}
+
+function orchDir(agent: string, sub: string): string {
+  return path.join(tmpRoot, '.totem', 'orchestration', agent, sub);
+}
+
+/** Write named `.md`-ish files into `<agent>/<sub>/` with dispatch-shaped content. */
+function writeFiles(agent: string, sub: string, names: string[]): string {
+  const dir = mkDir(orchDir(agent, sub));
+  for (const name of names) {
+    fs.writeFileSync(path.join(dir, name), '---\nto: someone\n---\n\nbody\n', 'utf-8');
+  }
+  return dir;
+}
+
+function exists(agent: string, sub: string, name: string): boolean {
+  return fs.existsSync(path.join(orchDir(agent, sub), name));
+}
+
+function run(opts: EclGcOptions = {}): ReturnType<typeof eclGc> {
+  return eclGc({ repoRoot: tmpRoot, env: {}, now: nowFn, ...opts });
+}
+
+// Aged (< cutoff) and fresh (>= cutoff) stamp names for the default 14d window.
+const AGED_4 = '2026-06-01T1200Z-totem-gemini.md'; // 20260601120000 < cutoff
+const AGED_6 = '2026-06-01T120000Z-totem-gemini.md'; // dual-form, same instant, aged
+const AGED_2 = '2026-05-15T0930Z-strategy-claude.md'; // 20260515093000 < cutoff
+const FRESH_4 = '2026-07-01T1200Z-totem-gemini.md'; // 20260701120000 >= cutoff
+const BOUNDARY_KEEP = '2026-06-21T120000Z-totem-gemini.md'; // === cutoff → kept
+const BOUNDARY_PRUNE = '2026-06-21T115959Z-totem-gemini.md'; // 1s older → pruned
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-eclgc-'));
+});
+
+afterEach(() => {
+  fsMockState.failFor.clear();
+  vi.restoreAllMocks();
+  cleanTmpDir(tmpRoot);
+});
+
+// ─── Pure helpers ───────────────────────────────────────
+
+describe('pure helpers', () => {
+  it('toStampKey canonicalizes both stamp forms to a 14-digit key', () => {
+    expect(toStampKey('2026-06-01T1200Z')).toBe('20260601120000');
+    expect(toStampKey('2026-06-01T120000Z')).toBe('20260601120000');
+  });
+
+  it('cutoffKey derives now − retainDays as a 14-digit key', () => {
+    expect(cutoffKey(NOW, 14)).toBe(CUTOFF_KEY);
+    // retainDays 0 → cutoff is `now` itself.
+    expect(cutoffKey(NOW, 0)).toBe('20260705120000');
+  });
+
+  it('classifyEntry: file-type guard runs before the extension/stamp checks', () => {
+    // A directory that LOOKS aged + `.md` must still be skipped, never pruned.
+    expect(classifyEntry({ name: AGED_4, isFile: false }, CUTOFF_KEY)).toEqual({
+      action: 'skip',
+      reason: 'not a regular file',
+    });
+    expect(classifyEntry({ name: 'x.tmp', isFile: true }, CUTOFF_KEY)).toEqual({
+      action: 'skip',
+      reason: 'not a .md dispatch',
+    });
+    expect(classifyEntry({ name: 'not-a-stamp.md', isFile: true }, CUTOFF_KEY)).toEqual({
+      action: 'skip',
+      reason: 'unparseable stamp',
+    });
+    expect(classifyEntry({ name: AGED_4, isFile: true }, CUTOFF_KEY)).toEqual({ action: 'prune' });
+    expect(classifyEntry({ name: BOUNDARY_KEEP, isFile: true }, CUTOFF_KEY)).toEqual({
+      action: 'keep',
+    });
+  });
+
+  it('planPrune partitions a listing deterministically', () => {
+    const plan = planPrune(
+      [
+        { name: FRESH_4, isFile: true },
+        { name: AGED_4, isFile: true },
+        { name: 'x.tmp', isFile: true },
+        { name: 'sub', isFile: false },
+      ],
+      CUTOFF_KEY,
+    );
+    expect(plan.prune).toEqual([AGED_4]);
+    expect(plan.kept).toBe(1);
+    expect(plan.skipped).toEqual([
+      { file: 'sub', reason: 'not a regular file' },
+      { file: 'x.tmp', reason: 'not a .md dispatch' },
+    ]);
+  });
+});
+
+// ─── LOAD-BEARING safety rows ───────────────────────────
+
+describe('safety invariants (load-bearing)', () => {
+  it('row 1 — peer immunity: pruning seat A never touches seat B', () => {
+    writeFiles('seat-a', 'outbox', [AGED_4]);
+    writeFiles('seat-b', 'outbox', [AGED_2]);
+
+    const result = run({ apply: true, env: { TOTEM_SELF_AGENT: 'seat-a' } });
+
+    expect(result.agent).toBe('seat-a');
+    expect(result.pruned).toEqual([AGED_4]);
+    expect(exists('seat-a', 'outbox', AGED_4)).toBe(false);
+    // NON-VACUITY: seat-b's aged file must survive — if the target were the
+    // whole orchestration tree instead of the resolved seat, this would fail.
+    expect(exists('seat-b', 'outbox', AGED_2)).toBe(true);
+  });
+
+  it('row 2 — never touches journal/ processed/ inbox/', () => {
+    writeFiles('seat-a', 'outbox', [AGED_4]);
+    writeFiles('seat-a', 'journal', [AGED_2]);
+    writeFiles('seat-a', 'processed', [AGED_2]);
+    writeFiles('seat-a', 'inbox', [AGED_2]);
+
+    const result = run({ apply: true, env: { TOTEM_SELF_AGENT: 'seat-a' } });
+
+    // The outbox aged file IS pruned (prune actually ran)…
+    expect(result.pruned).toEqual([AGED_4]);
+    expect(exists('seat-a', 'outbox', AGED_4)).toBe(false);
+    // …but the sibling trees are untouched.
+    // NON-VACUITY: these fail if the scan ever walked a non-outbox dir.
+    expect(exists('seat-a', 'journal', AGED_2)).toBe(true);
+    expect(exists('seat-a', 'processed', AGED_2)).toBe(true);
+    expect(exists('seat-a', 'inbox', AGED_2)).toBe(true);
+  });
+
+  it('row 3 — self-ambiguity throws BEFORE any deletion', () => {
+    // Two registered seat dirs, no --agent-id, no TOTEM_SELF_AGENT → ambiguous.
+    writeFiles('seat-a', 'outbox', [AGED_4]);
+    writeFiles('seat-b', 'outbox', [AGED_2]);
+
+    expect(() => run({ apply: true })).toThrow(/cannot resolve a single agent/i);
+
+    // NON-VACUITY: nothing may be deleted on the throwing path.
+    expect(exists('seat-a', 'outbox', AGED_4)).toBe(true);
+    expect(exists('seat-b', 'outbox', AGED_2)).toBe(true);
+  });
+
+  it('row 4 — exact boundary retained; 1s older pruned', () => {
+    writeFiles('seat-a', 'outbox', [BOUNDARY_KEEP, BOUNDARY_PRUNE]);
+
+    const result = run({ apply: true, env: { TOTEM_SELF_AGENT: 'seat-a' } });
+
+    expect(result.cutoffKey).toBe(CUTOFF_KEY);
+    expect(result.pruned).toEqual([BOUNDARY_PRUNE]);
+    expect(result.kept).toBe(1);
+    // NON-VACUITY: a `<=` boundary would delete BOUNDARY_KEEP → this fails.
+    expect(exists('seat-a', 'outbox', BOUNDARY_KEEP)).toBe(true);
+    expect(exists('seat-a', 'outbox', BOUNDARY_PRUNE)).toBe(false);
+  });
+});
+
+// ─── Behavioral coverage ────────────────────────────────
+
+describe('behavior', () => {
+  it('row 5 — dry-run lists would-prune but deletes nothing', () => {
+    writeFiles('seat-a', 'outbox', [AGED_4, FRESH_4]);
+
+    const result = run({ env: { TOTEM_SELF_AGENT: 'seat-a' } });
+
+    expect(result.dryRun).toBe(true);
+    expect(result.pruned).toEqual([AGED_4]);
+    expect(result.failed).toEqual([]);
+    // Nothing deleted in dry-run.
+    expect(exists('seat-a', 'outbox', AGED_4)).toBe(true);
+    expect(exists('seat-a', 'outbox', FRESH_4)).toBe(true);
+  });
+
+  it('row 6 — --apply deletes only the aged files; fresh kept', () => {
+    writeFiles('seat-a', 'outbox', [AGED_4, AGED_2, FRESH_4]);
+
+    const result = run({ apply: true, env: { TOTEM_SELF_AGENT: 'seat-a' } });
+
+    expect(result.dryRun).toBe(false);
+    expect(result.pruned.sort()).toEqual([AGED_2, AGED_4].sort());
+    expect(result.kept).toBe(1);
+    expect(exists('seat-a', 'outbox', AGED_4)).toBe(false);
+    expect(exists('seat-a', 'outbox', AGED_2)).toBe(false);
+    expect(exists('seat-a', 'outbox', FRESH_4)).toBe(true);
+  });
+
+  it('row 7 — dual-form stamps (4-digit + 6-digit) both classify correctly', () => {
+    writeFiles('seat-a', 'outbox', [AGED_4, AGED_6, BOUNDARY_KEEP]);
+
+    const result = run({ apply: true, env: { TOTEM_SELF_AGENT: 'seat-a' } });
+
+    // Both aged forms pruned; the 6-digit boundary kept.
+    expect(result.pruned.sort()).toEqual([AGED_4, AGED_6].sort());
+    expect(result.kept).toBe(1);
+    expect(exists('seat-a', 'outbox', BOUNDARY_KEEP)).toBe(true);
+  });
+
+  it('row 8 — malformed / non-.md / non-file entries are skipped, never deleted', () => {
+    const outbox = writeFiles('seat-a', 'outbox', [AGED_4, '.gitkeep', 'x.tmp', 'not-a-stamp.md']);
+    // A directory named like an aged dispatch — must be skipped, not pruned.
+    mkDir(path.join(outbox, '2026-01-01T0000Z-olddir.md'));
+
+    const result = run({ apply: true, env: { TOTEM_SELF_AGENT: 'seat-a' } });
+
+    expect(result.pruned).toEqual([AGED_4]);
+    const skippedFiles = result.skipped.map((s) => s.file).sort();
+    expect(skippedFiles).toEqual([
+      '.gitkeep',
+      '2026-01-01T0000Z-olddir.md',
+      'not-a-stamp.md',
+      'x.tmp',
+    ]);
+    // NON-VACUITY: the aged-looking subdir survives (file-type guard held).
+    expect(fs.existsSync(path.join(outbox, '2026-01-01T0000Z-olddir.md'))).toBe(true);
+    expect(exists('seat-a', 'outbox', '.gitkeep')).toBe(true);
+    expect(exists('seat-a', 'outbox', 'x.tmp')).toBe(true);
+    expect(exists('seat-a', 'outbox', 'not-a-stamp.md')).toBe(true);
+  });
+
+  it('row 9a — explicit --agent-id override resolves an otherwise-ambiguous repo', () => {
+    writeFiles('seat-a', 'outbox', [AGED_4]);
+    writeFiles('seat-b', 'outbox', [AGED_2]);
+
+    const result = run({ apply: true, agentId: 'seat-a' });
+
+    expect(result.agent).toBe('seat-a');
+    expect(result.pruned).toEqual([AGED_4]);
+    expect(exists('seat-b', 'outbox', AGED_2)).toBe(true);
+  });
+
+  it('row 9b — env TOTEM_SELF_AGENT single-agent resolves', () => {
+    writeFiles('seat-a', 'outbox', [AGED_4]);
+
+    const result = run({ apply: true, env: { TOTEM_SELF_AGENT: 'seat-a' } });
+
+    expect(result.agent).toBe('seat-a');
+    expect(result.pruned).toEqual([AGED_4]);
+  });
+
+  it('row 10 — missing outbox dir yields a clean empty result, no throw', () => {
+    // No outbox created for seat-a at all.
+    const result = run({ apply: true, env: { TOTEM_SELF_AGENT: 'seat-a' } });
+
+    expect(result.agent).toBe('seat-a');
+    expect(result.pruned).toEqual([]);
+    expect(result.kept).toBe(0);
+    expect(result.skipped).toEqual([]);
+    expect(result.failed).toEqual([]);
+    expect(result.outbox).toBe(path.join(tmpRoot, '.totem', 'orchestration', 'seat-a', 'outbox'));
+  });
+
+  it('row 11 — invalid --retain-days (negative / non-integer) is a usage throw', () => {
+    writeFiles('seat-a', 'outbox', [AGED_4]);
+    expect(() => run({ retainDays: -1, env: { TOTEM_SELF_AGENT: 'seat-a' } })).toThrow(
+      /non-negative integer/i,
+    );
+    expect(() => run({ retainDays: 3.5, env: { TOTEM_SELF_AGENT: 'seat-a' } })).toThrow(
+      /non-negative integer/i,
+    );
+    // NON-VACUITY: the throw is a usage error raised before any scan.
+    expect(exists('seat-a', 'outbox', AGED_4)).toBe(true);
+  });
+
+  it('row 12 — a partial delete failure is captured; other files still pruned', () => {
+    writeFiles('seat-a', 'outbox', [AGED_4, AGED_2]);
+    // The mocked unlinkSync throws for AGED_4, passes through for AGED_2.
+    fsMockState.failFor.add(AGED_4);
+
+    const result = run({ apply: true, env: { TOTEM_SELF_AGENT: 'seat-a' } });
+
+    expect(result.pruned).toEqual([AGED_2]);
+    expect(result.failed).toHaveLength(1);
+    expect(result.failed[0]!.file).toBe(AGED_4);
+    expect(result.failed[0]!.error).toMatch(/EPERM/);
+    // The failed file remains on disk; the succeeding one is gone.
+    expect(exists('seat-a', 'outbox', AGED_4)).toBe(true);
+    expect(exists('seat-a', 'outbox', AGED_2)).toBe(false);
+  });
+
+  it('retainDays 0 prunes everything strictly before now', () => {
+    // With N=0 the cutoff is `now`; a fresh-but-past file becomes prunable.
+    writeFiles('seat-a', 'outbox', [FRESH_4]);
+    const result = run({ apply: true, retainDays: 0, env: { TOTEM_SELF_AGENT: 'seat-a' } });
+    expect(result.cutoffKey).toBe('20260705120000');
+    expect(result.pruned).toEqual([FRESH_4]);
+  });
+});

--- a/packages/cli/src/commands/ecl-gc.test.ts
+++ b/packages/cli/src/commands/ecl-gc.test.ts
@@ -201,6 +201,18 @@ describe('safety invariants (load-bearing)', () => {
     expect(exists('seat-b', 'outbox', AGED_2)).toBe(true);
   });
 
+  it('row 3b — an unsafe resolved agent-id is rejected BEFORE any deletion', () => {
+    // resolveSelfSender returns an explicit --agent-id verbatim, so a caller
+    // could hand in an id that escapes the `<orchestration>/<agent>/outbox`
+    // segment. The isPathSafeAgentId guard must reject it before any scan/delete.
+    writeFiles('seat-a', 'outbox', [AGED_4]);
+
+    expect(() => run({ apply: true, agentId: '../seat-a' })).toThrow(/invalid agent-id/i);
+
+    // NON-VACUITY: nothing may be deleted on the guard-throw path.
+    expect(exists('seat-a', 'outbox', AGED_4)).toBe(true);
+  });
+
   it('row 4 — exact boundary retained; 1s older pruned', () => {
     writeFiles('seat-a', 'outbox', [BOUNDARY_KEEP, BOUNDARY_PRUNE]);
 

--- a/packages/cli/src/commands/ecl-gc.ts
+++ b/packages/cli/src/commands/ecl-gc.ts
@@ -1,0 +1,349 @@
+/**
+ * `totem ecl-gc` — ECL outbox retention prune (mmnto-ai/totem#2279; parent
+ * mmnto-ai/totem-strategy#700 / doctrine/ecl-discipline.md § 4.4).
+ *
+ * The binary-guaranteed cohort-wide replacement for the interim
+ * `scripts/prune-outbox.mjs`: it deletes an agent's OWN outbox dispatches once
+ * they age past the retention window N (default 14 days). Outbox dispatches are
+ * TRANSPORT, not archive — the durable record of whatever a dispatch carried
+ * lives in its home (rulings → ADRs / issues, work-state → the GH board,
+ * session history → `journal/`), so an aged courier file is disposable.
+ *
+ * SINGLE-WRITER INVARIANT (ADR-106): each agent prunes only its OWN
+ * `<repoRoot>/.totem/orchestration/<agent-id>/outbox/` — never a peer's, never
+ * the operator's chore. Self-resolution (Tenet-21 reuse of `resolveSelfSender`)
+ * makes pruning a peer structurally unreachable: the target path is composed
+ * from the resolved single agent-id and nothing else. This command NEVER reads
+ * or touches `journal/` (bounded-past record + MCP-indexed) or `processed/`
+ * (the handled-state cursor — erasing it makes consumed backlog re-read as
+ * unread) or any inbox / other seat. Scope is `outbox/` only.
+ *
+ * Safe by default: dry-run (list only) unless `--apply` is passed. This train
+ * ships PRUNE ONLY — processed-mark compaction is a deferred follow-on and is
+ * deliberately NOT built here.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+import { getErrorMessage, isPathSafeAgentId, TotemError } from '@mmnto/totem';
+
+import { resolveSelfSender } from './mail.js';
+
+// ─── Constants ──────────────────────────────────────────
+
+const TAG = 'EclGc';
+
+/**
+ * Doctrine-ratified retention window (ecl-discipline.md § 4.4). A grace window,
+ * not a correctness boundary — durable content already lives in homes; N only
+ * bounds how long the courier lingers. 14d comfortably covers infrequent-
+ * session (operator-run vendor) seats so a prune never clips a dispatch a slow
+ * peer hasn't read.
+ */
+const DEFAULT_RETAIN_DAYS = 14;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Dual-form stamp acceptance ported verbatim from `scripts/prune-outbox.mjs`:
+ * the cohort emits both `YYYY-MM-DDTHHMMZ` (4-digit) and `YYYY-MM-DDTHHMMSSZ`
+ * (6-digit, `date -u +%Y-%m-%dT%H%M%SZ`). Matching only one form would silently
+ * skip the other (the verify-absence trap).
+ */
+const STAMP_RE = /^(\d{4}-\d{2}-\d{2}T\d{4}(?:\d{2})?Z)/;
+
+// ─── Types ──────────────────────────────────────────────
+
+export interface EclGcOptions {
+  /** Actually delete (default: dry-run — list would-prune, delete nothing). */
+  apply?: boolean;
+  /** Retention window in days (default 14). Must be a non-negative integer. */
+  retainDays?: number;
+  /**
+   * Override the self-resolved agent-id (visiting / orchestrator case only).
+   * NOT used by the signoff step — that path self-resolves.
+   */
+  agentId?: string;
+  /** Emit the structured result as JSON to stdout instead of human text. */
+  json?: boolean;
+  /** Repo root override (default: `process.cwd()`). Test injection point. */
+  repoRoot?: string;
+  /** Env override (default: `process.env`). Test injection point. */
+  env?: Record<string, string | undefined>;
+  /** Clock injection for deterministic cutoffs in tests (default: `new Date()`). */
+  now?: () => Date;
+}
+
+/**
+ * Structured prune result. Also the `--json` payload. `pruned` lists the files
+ * actually removed under `--apply` (or the would-prune set in dry-run);
+ * `failed` captures per-file delete failures (never fatal); `skipped` surfaces
+ * every entry left untouched together with WHY (non-file, non-`.md`,
+ * unparseable stamp).
+ */
+export interface EclGcResult {
+  agent: string;
+  retainDays: number;
+  dryRun: boolean;
+  outbox: string;
+  cutoffKey: string;
+  pruned: string[];
+  // eslint-disable-next-line id-match -- 'error' is the JSON result field name here (the `--json` payload contract), not a catch binding (mmnto-ai/totem#2279)
+  failed: { file: string; error: string }[];
+  kept: number;
+  skipped: { file: string; reason: string }[];
+  warnings: string[];
+}
+
+// ─── Pure helpers ───────────────────────────────────────
+
+/**
+ * Canonicalize either stamp form to a 14-digit `YYYYMMDDHHMMSS` key (seconds
+ * default to `00`) so mixed-length stamps compare correctly. Ported from
+ * `scripts/prune-outbox.mjs:toKey`.
+ */
+export function toStampKey(stamp: string): string {
+  const digits = stamp.replace(/\D/g, '');
+  return digits.length === 12 ? `${digits}00` : digits;
+}
+
+/**
+ * Cutoff = `now − retainDays`, as a comparable 14-digit `YYYYMMDDHHMMSS` key.
+ * Derives from the injected `now` for determinism (Tenet 15). Ported from
+ * `scripts/prune-outbox.mjs:cutoffKey`.
+ */
+export function cutoffKey(now: Date, retainDays: number): string {
+  const iso = new Date(now.getTime() - retainDays * MS_PER_DAY).toISOString();
+  // iso = 2026-06-16T22:13:32.088Z -> 20260616221332
+  return (
+    iso.slice(0, 4) +
+    iso.slice(5, 7) +
+    iso.slice(8, 10) +
+    iso.slice(11, 13) +
+    iso.slice(14, 16) +
+    iso.slice(17, 19)
+  );
+}
+
+/** A directory entry reduced to the classification inputs (pure-helper seam). */
+export interface DirEntryLike {
+  name: string;
+  isFile: boolean;
+}
+
+/** The per-entry verdict a classifier returns. */
+export type PruneClass =
+  | { action: 'prune' }
+  | { action: 'keep' }
+  | { action: 'skip'; reason: string };
+
+/**
+ * Classify a single directory entry against the cutoff. Safe-direction bias:
+ * anything whose age is not derivable from an eligible filename is KEPT +
+ * surfaced, never deleted (auto-deleting an un-ageable file is worse than
+ * letting it linger — mmnto-ai/totem-strategy#700 by-design). Non-file entries
+ * are checked FIRST so a directory named `*.md` can never reach a delete.
+ */
+export function classifyEntry(entry: DirEntryLike, cutoff: string): PruneClass {
+  if (!entry.isFile) {
+    return { action: 'skip', reason: 'not a regular file' };
+  }
+  // Extension gate (spec-narrowed vs the port): only `.md` dispatches are
+  // prune-eligible; a `.tmp` / `.gitkeep` / other stray is surfaced, never
+  // deleted.
+  if (!entry.name.endsWith('.md')) {
+    return { action: 'skip', reason: 'not a .md dispatch' };
+  }
+  const m = STAMP_RE.exec(entry.name);
+  if (m === null) {
+    return { action: 'skip', reason: 'unparseable stamp' };
+  }
+  // Exact boundary is RETAINED: `< cutoff` prunes, `>= cutoff` keeps.
+  return toStampKey(m[1]!) < cutoff ? { action: 'prune' } : { action: 'keep' };
+}
+
+/** The classification plan for a whole directory listing. */
+export interface PrunePlan {
+  prune: string[];
+  kept: number;
+  skipped: { file: string; reason: string }[];
+}
+
+/**
+ * Pure prune-plan classification: given a directory listing + a cutoff key,
+ * partition entries into prune / keep / skip. Deterministic order (filename
+ * sort) so the reported lists are stable across platforms.
+ */
+export function planPrune(entries: DirEntryLike[], cutoff: string): PrunePlan {
+  const prune: string[] = [];
+  const skipped: { file: string; reason: string }[] = [];
+  let kept = 0;
+  const ordered = [...entries].sort((a, b) => a.name.localeCompare(b.name));
+  for (const entry of ordered) {
+    const verdict = classifyEntry(entry, cutoff);
+    if (verdict.action === 'prune') {
+      prune.push(entry.name);
+    } else if (verdict.action === 'keep') {
+      kept += 1;
+    } else {
+      skipped.push({ file: entry.name, reason: verdict.reason });
+    }
+  }
+  return { prune, kept, skipped };
+}
+
+// ─── Core prune ─────────────────────────────────────────
+
+/**
+ * Programmatic entry point. Resolves the single self-agent, validates inputs,
+ * scans that agent's OWN outbox, and (under `--apply`) deletes the aged
+ * dispatches. Returns a structured `EclGcResult`.
+ *
+ * Throws ONLY on usage errors (unresolvable/ambiguous self, unsafe agent-id,
+ * invalid `--retain-days`), and always BEFORE any directory scan or deletion.
+ * Filesystem failures are NEVER thrown — a per-file delete failure is captured
+ * into `result.failed` (janitorial sensor, not a gate — Tenet 13).
+ */
+export function eclGc(opts: EclGcOptions = {}): EclGcResult {
+  const env = opts.env ?? process.env;
+  const repoRoot = path.resolve(opts.repoRoot ?? process.cwd());
+  const now = (opts.now ?? (() => new Date()))();
+
+  // Retain-days validation (usage error) — evaluated before any scan.
+  const retainDays = opts.retainDays ?? DEFAULT_RETAIN_DAYS;
+  if (!Number.isInteger(retainDays) || retainDays < 0) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `--retain-days must be a non-negative integer (got: ${String(retainDays)})`,
+      'pass --retain-days <n> with a whole number of days ≥ 0.',
+    );
+  }
+
+  // Self-resolution (Tenet-21 reuse — panel-mandated). `resolveSelfSender`
+  // picks the single writer (explicit > unambiguous self > throw). Its native
+  // message talks about "outbound dispatch"; rewrap into a prune-shaped usage
+  // error. Resolution + validation happen BEFORE any directory scan/deletion.
+  let agent: string;
+  try {
+    agent = resolveSelfSender(repoRoot, env, opts.agentId);
+  } catch (err) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `cannot resolve a single agent whose outbox to prune: ${getErrorMessage(err)}`,
+      'set TOTEM_SELF_AGENT or pass --agent-id <agent-id>.',
+      err,
+    );
+  }
+  // Defense-in-depth on a destructive path: the resolved id is a path segment
+  // in `.totem/orchestration/<agent>/outbox`. Reject anything that could escape
+  // it (traversal, separators, control/whitespace/win32-reserved chars).
+  if (!isPathSafeAgentId(agent)) {
+    throw new TotemError(
+      'CONFIG_INVALID',
+      `invalid agent-id ${JSON.stringify(agent)} (path traversal, unsafe characters, or empty)`,
+      'pass a plain agent-id such as "totem-claude" (no path separators, "..", whitespace, or control characters).',
+    );
+  }
+
+  const dryRun = opts.apply !== true;
+  const outbox = path.join(repoRoot, '.totem', 'orchestration', agent, 'outbox');
+  const cutoff = cutoffKey(now, retainDays);
+  const warnings: string[] = [];
+
+  const result: EclGcResult = {
+    agent,
+    retainDays,
+    dryRun,
+    outbox,
+    cutoffKey: cutoff,
+    pruned: [],
+    failed: [],
+    kept: 0,
+    skipped: [],
+    warnings,
+  };
+
+  // Missing outbox is the routine "nothing to prune" signal — clean empty
+  // result, never an error (the seat simply hasn't sent mail from this repo).
+  if (!fs.existsSync(outbox)) {
+    return result;
+  }
+
+  let dirents: fs.Dirent[];
+  try {
+    dirents = fs.readdirSync(outbox, { withFileTypes: true });
+    // totem-context: intentional cleanup — an unreadable outbox (EACCES, raced removal) is surfaced as a warning and degrades to an empty prune rather than throwing; the prune is a janitorial sensor, not a gate (Tenet 13).
+  } catch (err) {
+    warnings.push(`outbox read failed (${outbox}): ${getErrorMessage(err)}`);
+    return result;
+  }
+
+  const plan = planPrune(
+    dirents.map((d) => ({ name: d.name, isFile: d.isFile() })),
+    cutoff,
+  );
+  result.kept = plan.kept;
+  result.skipped = plan.skipped;
+
+  // Dry-run: report the would-prune set, delete nothing.
+  if (dryRun) {
+    result.pruned = plan.prune;
+    return result;
+  }
+
+  // Apply: unlink each aged dispatch. A single failed delete (EPERM, raced
+  // removal) is captured with per-item accounting and the loop continues —
+  // one bad file must never abort the prune (fail-soft, Tenet 4).
+  for (const file of plan.prune) {
+    try {
+      fs.unlinkSync(path.join(outbox, file));
+      result.pruned.push(file);
+      // totem-context: intentional cleanup — a per-file unlink failure is captured into result.failed and the loop continues; the wrapper turns a non-empty failed[] into exit 1 (partial-prune sensor), never a throw.
+    } catch (err) {
+      result.failed.push({ file, error: getErrorMessage(err) });
+    }
+  }
+  return result;
+}
+
+// ─── CLI wrapper ────────────────────────────────────────
+
+/**
+ * Render an `EclGcResult`. With `json`, the structured result goes to stdout
+ * (hook-friendly clean stream). Otherwise a human summary goes to stderr via
+ * the standard CLI logger (agent, mode, pruned/kept counts, skipped-with-
+ * reasons, failed count) — mirrors `mail.ts`'s stderr `log` usage.
+ */
+export async function eclGcCommand(result: EclGcResult, json: boolean): Promise<EclGcResult> {
+  if (json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+    return result;
+  }
+
+  const { log } = await import('../ui.js');
+  const mode = result.dryRun ? 'dry-run (list only — re-run with --apply to delete)' : 'apply';
+  const verb = result.dryRun ? 'would prune' : 'pruned';
+  log.info(
+    TAG,
+    `agent: ${result.agent} · retention ${result.retainDays}d · cutoff < ${result.cutoffKey}`,
+  );
+  log.info(TAG, `mode: ${mode}`);
+  log.info(TAG, `${verb} ${result.pruned.length}; kept ${result.kept}`);
+  if (result.skipped.length > 0) {
+    log.warn(TAG, `skipped ${result.skipped.length} non-dispatch entr(y/ies) — left untouched:`);
+    for (const s of result.skipped) {
+      log.warn(TAG, `  - ${s.file}: ${s.reason}`);
+    }
+  }
+  if (result.failed.length > 0) {
+    log.error(TAG, `FAILED ${result.failed.length} delete(s) — surfaced, non-blocking:`);
+    for (const f of result.failed) {
+      log.error(TAG, `  - ${f.file}: ${f.error}`);
+    }
+  }
+  for (const w of result.warnings) {
+    log.warn(TAG, w);
+  }
+  return result;
+}

--- a/packages/cli/src/commands/ecl-gc.ts
+++ b/packages/cli/src/commands/ecl-gc.ts
@@ -65,8 +65,6 @@ export interface EclGcOptions {
    * NOT used by the signoff step — that path self-resolves.
    */
   agentId?: string;
-  /** Emit the structured result as JSON to stdout instead of human text. */
-  json?: boolean;
   /** Repo root override (default: `process.cwd()`). Test injection point. */
   repoRoot?: string;
   /** Env override (default: `process.env`). Test injection point. */
@@ -337,9 +335,9 @@ export async function eclGcCommand(result: EclGcResult, json: boolean): Promise<
     }
   }
   if (result.failed.length > 0) {
-    log.error(TAG, `FAILED ${result.failed.length} delete(s) — surfaced, non-blocking:`);
+    log.error('Totem Error', `FAILED ${result.failed.length} delete(s) — surfaced, non-blocking:`);
     for (const f of result.failed) {
-      log.error(TAG, `  - ${f.file}: ${f.error}`);
+      log.error('Totem Error', `  - ${f.file}: ${f.error}`);
     }
   }
   for (const w of result.warnings) {

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -770,7 +770,11 @@ End-of-session wrap-up. Post-Proposal-282 (ADR-106), journals + handoffs live in
    done
    \`\`\`
 
-5. **Report:** what shipped, what's pending, what's next.
+5. **Prune your own outbox (ECL retention).** Delete your own \`outbox/\` dispatches older than the retention window (**N = 14 days**) per ECL outbox-retention doctrine (\`mmnto-ai/totem-strategy:doctrine/ecl-discipline.md\` § 4.4). The outbox is transport, not archive — a dispatch's durable content already lives in its home (rulings → ADRs / issues, work-state → the GH board, session history → \`journal/\`), so the aged courier file is disposable (gitignored + local). The operator should never have to janitor the mail substrate.
+
+   **Mechanism:** \`totem ecl-gc --apply\` — self-resolves your agent-id (same precedence as step 2a: \`TOTEM_SELF_AGENT\` env > \`config.json\` \`host_agents\` > seat-dir ∪ basename map) and prunes only \`<repoRoot>/.totem/orchestration/<your-agent-id>/outbox/\`, so a self-resolving binary structurally cannot prune a peer. Dry-run by default; \`--apply\` deletes. It **never** touches \`journal/\` or \`processed/\`. Report the pruned count in the Report step. A non-zero exit means some deletes failed (or the agent could not be resolved) — report the count but **do not block the seal**: the prune is a janitorial sensor, not a gate (Tenet 13).
+
+6. **Report:** what shipped, what's pending, what's next.
 
 **Cross-repo handoffs** (when you need to dispatch a message to another agent) write to your own \`<repoRoot>/.totem/orchestration/<agent-id>/outbox/<YYYY-MM-DDTHHMMZ>-<your-agent-id>.md\` with \`to: <recipient-agent-id>\` in the frontmatter. Recipients discover inbound handoffs by polling the single-level glob \`<workspace>/*/.totem/orchestration/*/outbox/*.md\` filtered by their own \`to:\` frontmatter match.
 

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1956,6 +1956,24 @@ describe('Distributed skill constants match source-of-truth (mmnto-ai/totem#1890
     expect(SIGNOFF_SKILL_CONTENT).toBe(source);
   });
 
+  // ECL outbox-prune step (mmnto-ai/totem#2279): a new step 5 (prune) inserted
+  // after branch-cleanup, with the old Report step renumbered to 6.
+  it('SIGNOFF_SKILL_CONTENT carries the ecl-gc prune step and renumbers Report to 6', () => {
+    // The prune step names the self-resolving mechanism.
+    expect(SIGNOFF_SKILL_CONTENT).toContain('totem ecl-gc --apply');
+    // It is step 5 (inserted after branch-cleanup).
+    expect(SIGNOFF_SKILL_CONTENT).toContain('5. **Prune your own outbox (ECL retention).**');
+    // The prune step must promise it never touches the non-outbox trees.
+    expect(SIGNOFF_SKILL_CONTENT).toContain('**never** touches `journal/` or `processed/`');
+    // The Report step is now step 6, and step 5 is no longer Report.
+    expect(SIGNOFF_SKILL_CONTENT).toContain('6. **Report:**');
+    expect(SIGNOFF_SKILL_CONTENT).not.toContain('5. **Report:**');
+    // Ordering invariant: the prune step precedes the (renumbered) Report step.
+    expect(SIGNOFF_SKILL_CONTENT.indexOf('5. **Prune your own outbox')).toBeLessThan(
+      SIGNOFF_SKILL_CONTENT.indexOf('6. **Report:**'),
+    );
+  });
+
   it('SIGNON_SKILL_CONTENT matches .claude/skills/signon/SKILL.md', () => {
     const source = fs.readFileSync(
       path.join(repoRoot, '.claude', 'skills', 'signon', 'SKILL.md'),

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -30,6 +30,11 @@ if (reexecStatus !== undefined) {
 const RETROSPECT_DEFAULT_THRESHOLD = 5;
 const RETROSPECT_MIN_THRESHOLD = 1;
 
+// ECL outbox retention default (doctrine/ecl-discipline.md § 4.4) — help-text
+// mirror only; the authoritative default lives in `commands/ecl-gc.ts`
+// (lazy-loaded), so passing `retainDays: undefined` still resolves to it.
+const DEFAULT_ECL_RETAIN_DAYS = 14;
+
 function requireGhCli(): void {
   try {
     execSync('gh --version', { stdio: 'ignore', timeout: 3000 });
@@ -850,6 +855,62 @@ mailCmd
         // totem-context: handleError is the CLI error boundary (returns `never` — prints + process.exit), identical to every sibling command action; nothing is swallowed.
       } catch (err) {
         handleError(err);
+      }
+    },
+  );
+
+// ECL outbox retention prune (mmnto-ai/totem#2279; parent mmnto-ai/totem-strategy#700;
+// doctrine/ecl-discipline.md § 4.4). The binary-guaranteed cohort-wide replacement
+// for `scripts/prune-outbox.mjs` — self-resolves the caller's agent so a seat can
+// only ever prune its OWN `<repoRoot>/.totem/orchestration/<agent>/outbox/`, never a
+// peer's, never journal/ or processed/. Dry-run by default; --apply deletes.
+program
+  .command('ecl-gc')
+  .description('Prune your own aged ECL outbox dispatches (self-resolving; dry-run unless --apply)')
+  .option('--apply', 'Actually delete aged dispatches (default: dry-run — list only)')
+  .option(
+    '--retain-days <n>',
+    `Retention window in days (default ${DEFAULT_ECL_RETAIN_DAYS}; doctrine § 4.4)`,
+  )
+  .option(
+    '--agent-id <id>',
+    'Override the self-resolved agent whose outbox to prune (visiting/orchestrator case)',
+  )
+  .option('--json', 'Emit the structured result as JSON to stdout instead of human text')
+  .action(
+    async (
+      _opts: { apply?: boolean; retainDays?: string; agentId?: string; json?: boolean },
+      cmd: Command,
+    ) => {
+      // optsWithGlobals() merges the program-level `--json` (top of file) with the
+      // subcommand scope, same collision fix as `mail` (mmnto-ai/totem#2097).
+      const { apply, retainDays, agentId, json } = cmd.optsWithGlobals<{
+        apply?: boolean;
+        retainDays?: string;
+        agentId?: string;
+        json?: boolean;
+      }>();
+      // Custom exit-code contract (AGENTS.md: throw in lib, wrapper decides exit).
+      // eclGc throws ONLY on usage errors (self-resolution failure, invalid
+      // --retain-days); fs failures land in result.failed, never thrown. So:
+      // 0 = clean, 1 = partial delete failure (sensor), 2 = usage error. We do
+      // NOT call handleError here — it exits 1, which would collide with the
+      // partial-failure code. (Custom-exit precedent: index-lite.ts uses 78.)
+      try {
+        const { eclGc, eclGcCommand } = await import('./commands/ecl-gc.js');
+        const result = eclGc({
+          apply,
+          retainDays: retainDays !== undefined ? Number(retainDays) : undefined,
+          agentId,
+          json,
+        });
+        await eclGcCommand(result, json === true);
+        if (result.failed.length > 0) process.exitCode = 1;
+        // totem-context: the catch below is the deliberate CLI exit-code boundary, not a silent swallow — eclGc throws ONLY usage errors, which are printed LOUDLY via log.error and mapped to exit 2 (handleError is intentionally NOT used here: it exits 1, colliding with the partial-delete-failure sensor code).
+      } catch (err) {
+        const { log } = await import('./ui.js');
+        log.error('EclGc', err instanceof Error ? err.message : String(err));
+        process.exitCode = 2;
       }
     },
   );

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -902,14 +902,13 @@ program
           apply,
           retainDays: retainDays !== undefined ? Number(retainDays) : undefined,
           agentId,
-          json,
         });
         await eclGcCommand(result, json === true);
         if (result.failed.length > 0) process.exitCode = 1;
         // totem-context: the catch below is the deliberate CLI exit-code boundary, not a silent swallow — eclGc throws ONLY usage errors, which are printed LOUDLY via log.error and mapped to exit 2 (handleError is intentionally NOT used here: it exits 1, colliding with the partial-delete-failure sensor code).
       } catch (err) {
         const { log } = await import('./ui.js');
-        log.error('EclGc', err instanceof Error ? err.message : String(err));
+        log.error('Totem Error', err instanceof Error ? err.message : String(err));
         process.exitCode = 2;
       }
     },


### PR DESCRIPTION
## What

Adds `totem ecl-gc` — the binary-guaranteed, cohort-wide replacement for the interim `scripts/prune-outbox.mjs` — and wires an outbox-prune step into the distributed `signoff` skill. Parent totem-strategy#700; doctrine `ecl-discipline.md` §4.4.

This train ships **prune only**; processed-mark compaction is a deferred follow-on gated on strategy's cursor-preservation contract (totem-strategy#700). `scripts/prune-outbox.mjs` is intentionally left in place — cohort-wide retirement is a coordinated follow-on, not this PR.

## Design (per the 4/4 cohort pre-build panel)

- **Self-resolving single-writer.** Reuses `resolveSelfSender` (explicit `--agent-id` > unambiguous self > throw). A self-resolving binary structurally *cannot* prune a peer — the target path is composed from the one resolved agent-id and nothing else. Scope is `<repoRoot>/.totem/orchestration/<agent>/outbox/` only; it never reads or touches `journal/`, `processed/`, an inbox, or another seat.
- **Ported prune semantics** (from the interim script; not imported — the script has top-level argv + `process.exit`): dual-form stamp (`YYYY-MM-DDTHHMMZ` / `…HHMMSSZ`), `< cutoff` prunes / `>= cutoff` keeps (exact boundary retained), N=14 default. Only `.md` dispatches are eligible; non-file / non-`.md` / unparseable entries are surfaced and never deleted (the non-file check runs first, so a directory named `*.md` can never reach a delete).
- **Safe by default** — dry-run (lists would-prune); `--apply` deletes. Injected clock for deterministic boundary tests (Tenet 15).
- **Exit contract:** `0` clean, `1` partial delete failure (janitorial sensor, non-blocking — Tenet 13), `2` usage error. Usage errors throw before any scan; fs failures are captured into `result.failed`, never thrown.
- **Distribution:** `SIGNOFF_SKILL_CONTENT` gains a prune step (step 5, Report renumbered to 6) wiring self-resolved `totem ecl-gc --apply`; `init.test.ts` covers it and byte-locks the constant against `.claude/skills/signoff/SKILL.md`.

## Tests

18 tests, including the load-bearing safety rows that assert **on-disk aftermath** (non-vacuous): peer immunity (seat B's aged file survives), `journal/`+`processed/`+inbox untouched under `--apply`, self-ambiguity throws *before any deletion*, exact-boundary-retained, and malformed/non-file/non-`.md` skip (an aged-looking subdirectory survives).

## Gate

Full workspace build (5/5), test (cli 2948 + workspace suites), repo-wide `format:check`, ESLint (0 errors), `totem lint` (0 errors). Changeset: `@mmnto/cli` minor.

Closes #2279
