### PR TITLE
feat(cli): totem ecl-gc roster from ecl.cohortRepos config — retire interim cohortRepos() (#2310)

### DIFF
--- a/.changeset/ecl-roster-config.md
+++ b/.changeset/ecl-roster-config.md
@@ -1,0 +1,14 @@
+---
+'@mmnto/cli': minor
+'@mmnto/totem': minor
+---
+
+Resolve the `totem ecl-gc --compact` A2.2 completeness roster from consumer config, and **retire the interim `cohortRepos()` core export** (mmnto-ai/totem#2310; contract ADR-106 § A2.2 + `ecl-discipline` § 4.5; roster ruling by strategy-claude on the issue).
+
+**New config surface — `ecl.cohortRepos`.** `TotemConfigSchema` gains an optional `ecl` sub-schema (`EclConfigSchema`) whose `cohortRepos: string[]` declares the cohort repos whose ECL outboxes a "provably-complete" poll must scan before a processed-mark may be collected. Values are bare workspace **directory** names (e.g. `totem`, `totem-strategy`), matched against the workspace root's siblings — not `owner/repo` slugs. This is **consumer-declared** config, not a baked product identity: `totem ecl-gc` ships, so an external consumer's cohort is THEIR repos (Tenet 16). Change-authority for our cohort's value stays mmnto-ai/totem-strategy#611.
+
+**Precedence** (mmnto-ai/totem#2310): an explicit `EclCompactOptions.expectedRepos` (programmatic callers / tests) wins over `config.ecl.cohortRepos`; when both are absent the roster is **undeclared** and compaction hard-aborts (`gateComplete=false`, exit 3, **not** `--force-incomplete`-waivable) — unchanged from the shipped no-roster arm. The CLI action reads config at the process boundary (`loadEclConfig`) and injects it, keeping `eclCompact` a pure, synchronously-testable function.
+
+**Empty array is a loud config error, not "undeclared."** `cohortRepos: []` violates Zod `.min(1)` and fails at config load; the ecl-gc path surfaces it loudly (exit 2) and never degrades a config bug into the undeclared gate-red arm (the config read narrows its swallow to `CONFIG_MISSING` only). A genuine single-repo consumer declares a roster of one (completeness-1).
+
+**BREAKING for the one-release-old interim export.** `@mmnto/totem` no longer exports `cohortRepos()`. It shipped in 1.90.0 explicitly marked **INTERIM / product-locked / do-not-depend** with config-ification tracked in this issue, so its removal is expected — but consumers on 1.90.0 that imported it must switch to the `ecl.cohortRepos` config surface (or pass `expectedRepos` programmatically). No other public surface changes; prune behavior (`totem ecl-gc` without `--compact`) is untouched.

--- a/docs/wiki/config-reference.md
+++ b/docs/wiki/config-reference.md
@@ -63,6 +63,19 @@ export default {
     },
   },
 
+  // ECL cohort completeness roster (mmnto-ai/totem#2310). Read only by
+  // `totem ecl-gc --compact`: the declared set of cohort repos whose ECL
+  // outboxes a "provably complete" poll must scan before a processed-mark is
+  // collected. Values are bare workspace DIRECTORY names (siblings of the
+  // workspace root), NOT `owner/repo` slugs. Omit the whole `ecl` block to
+  // leave the roster UNDECLARED — compaction then hard-aborts (exit 3,
+  // fail-loud), never a silent no-op. An EMPTY `cohortRepos: []` is a config
+  // ERROR (rejected at load), not a synonym for undeclared; a single-repo
+  // consumer declares a roster of one.
+  ecl: {
+    cohortRepos: ['totem', 'totem-strategy', 'totem-status', 'liquid-city'],
+  },
+
   // The `.totemignore` file at the repo root supports a parallel directive
   // syntax: lines of the form `# stage4-baseline: <glob>` are appended to
   // the resolved Stage 4 baseline at compile time. Use this for globs

--- a/packages/cli/src/commands/ecl-gc.test.ts
+++ b/packages/cli/src/commands/ecl-gc.test.ts
@@ -34,11 +34,14 @@ import {
 
 /** Build a real (schema-validated) `TotemConfig` for roster-resolution tests —
  *  optionally with an `ecl.cohortRepos` roster. No casts: exercises the actual
- *  schema so the fixture can never drift from the shipped shape. */
-function cfg(cohortRepos?: string[]): TotemConfig {
+ *  schema so the fixture can never drift from the shipped shape.
+ *  `emptyEclBlock` yields the DISTINCT block-present-key-omitted state
+ *  (`ecl: {}`) — schema-valid, still undeclared (greptile on PR #2315: the
+ *  no-ecl-key and empty-ecl-block states must each be exercised as named). */
+function cfg(cohortRepos?: string[], opts?: { emptyEclBlock?: boolean }): TotemConfig {
   return TotemConfigSchema.parse({
     targets: [{ glob: '**/*.md', type: 'spec' as const, strategy: 'markdown-heading' as const }],
-    ...(cohortRepos ? { ecl: { cohortRepos } } : {}),
+    ...(cohortRepos ? { ecl: { cohortRepos } } : opts?.emptyEclBlock === true ? { ecl: {} } : {}),
   });
 }
 
@@ -827,12 +830,14 @@ describe('compaction — cursor-coupled GC (A2.1–A2.4)', () => {
     ensureRepos(CROSTER);
     writeMark(CS, DIRECT_SWEPT);
 
-    // `cfg()` yields a valid config with NO `ecl` key → undeclared → hard-abort.
+    // The NAMED state: a schema-valid `ecl: {}` block with `cohortRepos`
+    // omitted → still undeclared → hard-abort. (The no-`ecl`-key-at-all state
+    // is a resolveExpectedRoster unit row; C18 covers no config object.)
     const r = eclCompact({
       repoRoot: compactRoot(),
       workspace: tmpRoot,
       env: { TOTEM_SELF_AGENT: CS },
-      config: cfg(),
+      config: cfg(undefined, { emptyEclBlock: true }),
       apply: true,
     });
 
@@ -853,6 +858,11 @@ describe('resolveExpectedRoster — explicit > config > undefined', () => {
   });
   it('undefined when a config has no ecl block', () => {
     expect(resolveExpectedRoster(undefined, cfg())).toBeUndefined();
+  });
+  it('undefined when the ecl block is present but cohortRepos is omitted', () => {
+    expect(
+      resolveExpectedRoster(undefined, cfg(undefined, { emptyEclBlock: true })),
+    ).toBeUndefined();
   });
   it('undefined when neither source is present', () => {
     expect(resolveExpectedRoster(undefined, undefined)).toBeUndefined();

--- a/packages/cli/src/commands/ecl-gc.test.ts
+++ b/packages/cli/src/commands/ecl-gc.test.ts
@@ -15,6 +15,8 @@ import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { type TotemConfig, TotemConfigError, TotemConfigSchema } from '@mmnto/totem';
+
 import { cleanTmpDir } from '../test-utils.js';
 import {
   classifyEntry,
@@ -23,10 +25,22 @@ import {
   type EclCompactOptions,
   eclGc,
   type EclGcOptions,
+  loadEclConfig,
   planPrune,
   resolveEclGcExitCode,
+  resolveExpectedRoster,
   toStampKey,
 } from './ecl-gc.js';
+
+/** Build a real (schema-validated) `TotemConfig` for roster-resolution tests —
+ *  optionally with an `ecl.cohortRepos` roster. No casts: exercises the actual
+ *  schema so the fixture can never drift from the shipped shape. */
+function cfg(cohortRepos?: string[]): TotemConfig {
+  return TotemConfigSchema.parse({
+    targets: [{ glob: '**/*.md', type: 'spec' as const, strategy: 'markdown-heading' as const }],
+    ...(cohortRepos ? { ecl: { cohortRepos } } : {}),
+  });
+}
 
 // `vi.spyOn` cannot rebind a frozen ESM module-namespace export (node:fs), so
 // the partial-delete-failure row drives a module mock instead: a hoisted
@@ -47,6 +61,23 @@ vi.mock('node:fs', async (importOriginal) => {
       }
       return (actual.unlinkSync as (target: fs.PathLike, ...r: unknown[]) => void)(p, ...rest);
     },
+  };
+});
+
+// `loadEclConfig` (the config-read seam) is the only path touching `../utils.js`;
+// override just its two functions (spread-actual passthrough keeps every other
+// utils export real, so the fs-driven prune/compact tests are unaffected). Lets
+// the missing-vs-invalid distinction be tested without a real config on disk.
+const utilsMock = vi.hoisted(() => ({
+  resolveConfigPath: vi.fn(),
+  loadConfig: vi.fn(),
+}));
+vi.mock('../utils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils.js')>();
+  return {
+    ...actual,
+    resolveConfigPath: utilsMock.resolveConfigPath,
+    loadConfig: utilsMock.loadConfig,
   };
 });
 
@@ -107,6 +138,8 @@ beforeEach(() => {
 
 afterEach(() => {
   fsMockState.failFor.clear();
+  utilsMock.resolveConfigPath.mockReset();
+  utilsMock.loadConfig.mockReset();
   vi.restoreAllMocks();
   cleanTmpDir(tmpRoot);
 });
@@ -723,6 +756,150 @@ describe('compaction — cursor-coupled GC (A2.1–A2.4)', () => {
     expect(r.gateReasons.some((x) => /unscannable/.test(x))).toBe(true);
     expect(r.collected).toEqual([]);
     expect(markExists(CS, DIRECT_SWEPT)).toBe(true);
+  });
+
+  it('C16 — config.ecl.cohortRepos drives the roster when expectedRepos is absent (mmnto-ai/totem#2310)', () => {
+    ensureRepos(CROSTER);
+    writeInbound('totem-strategy', 'strategy-claude', DIRECT_LIVE, CS);
+    writeMark(CS, DIRECT_LIVE);
+    writeMark(CS, DIRECT_SWEPT);
+
+    // No `expectedRepos` → the injected config roster reaches the A2.2 gate.
+    const r = eclCompact({
+      repoRoot: compactRoot(),
+      workspace: tmpRoot,
+      env: { TOTEM_SELF_AGENT: CS },
+      config: cfg(CROSTER),
+      apply: true,
+    });
+
+    expect(r.expectedRepos).toEqual([...CROSTER].sort());
+    expect(r.gateComplete).toBe(true);
+    expect(r.collected).toEqual([DIRECT_SWEPT]);
+    expect(markExists(CS, DIRECT_SWEPT)).toBe(false);
+    expect(markExists(CS, DIRECT_LIVE)).toBe(true);
+  });
+
+  it('C17 — explicit expectedRepos WINS over config.ecl.cohortRepos (precedence)', () => {
+    ensureRepos(CROSTER); // only the explicit roster's repos are present
+    writeMark(CS, DIRECT_SWEPT);
+
+    // Config declares an EXTRA repo that is absent from the workspace — if config
+    // won, the gate would go RED (missing repo). Explicit CROSTER (all present)
+    // must win → gate green.
+    const r = eclCompact({
+      repoRoot: compactRoot(),
+      workspace: tmpRoot,
+      env: { TOTEM_SELF_AGENT: CS },
+      expectedRepos: CROSTER,
+      config: cfg([...CROSTER, 'totem-absent']),
+      apply: true,
+    });
+
+    expect(r.expectedRepos).toEqual([...CROSTER].sort());
+    // NON-VACUITY: had the config roster been used, `totem-absent` would gate-red.
+    expect(r.gateComplete).toBe(true);
+    expect(r.collected).toEqual([DIRECT_SWEPT]);
+  });
+
+  it('C18 — no expectedRepos AND no config ⇒ undeclared hard-abort (exit-3 arm)', () => {
+    ensureRepos(CROSTER);
+    writeMark(CS, DIRECT_SWEPT);
+
+    // Neither source declared → the `?? []` fallback lands in the undeclared
+    // gate-red arm (parity with C12's explicit `expectedRepos: []`).
+    const r = eclCompact({
+      repoRoot: compactRoot(),
+      workspace: tmpRoot,
+      env: { TOTEM_SELF_AGENT: CS },
+      apply: true,
+    });
+
+    expect(r.expectedRepos).toEqual([]);
+    expect(r.rosterDeclared).toBe(false);
+    expect(r.gateComplete).toBe(false);
+    expect(r.gateReasons.some((x) => /no cohort roster declared/.test(x))).toBe(true);
+    expect(resolveEclGcExitCode({ failed: [] }, r)).toBe(3);
+    expect(markExists(CS, DIRECT_SWEPT)).toBe(true);
+  });
+
+  it('C19 — an ecl block without cohortRepos is undeclared (config present, key omitted)', () => {
+    ensureRepos(CROSTER);
+    writeMark(CS, DIRECT_SWEPT);
+
+    // `cfg()` yields a valid config with NO `ecl` key → undeclared → hard-abort.
+    const r = eclCompact({
+      repoRoot: compactRoot(),
+      workspace: tmpRoot,
+      env: { TOTEM_SELF_AGENT: CS },
+      config: cfg(),
+      apply: true,
+    });
+
+    expect(r.gateComplete).toBe(false);
+    expect(r.gateReasons.some((x) => /no cohort roster declared/.test(x))).toBe(true);
+    expect(markExists(CS, DIRECT_SWEPT)).toBe(true);
+  });
+});
+
+// ─── Roster resolution precedence (mmnto-ai/totem#2310) ──
+
+describe('resolveExpectedRoster — explicit > config > undefined', () => {
+  it('explicit expectedRepos wins over config', () => {
+    expect(resolveExpectedRoster(['a', 'b'], cfg(['c', 'd']))).toEqual(['a', 'b']);
+  });
+  it('config.ecl.cohortRepos is used when explicit is absent', () => {
+    expect(resolveExpectedRoster(undefined, cfg(['c', 'd']))).toEqual(['c', 'd']);
+  });
+  it('undefined when a config has no ecl block', () => {
+    expect(resolveExpectedRoster(undefined, cfg())).toBeUndefined();
+  });
+  it('undefined when neither source is present', () => {
+    expect(resolveExpectedRoster(undefined, undefined)).toBeUndefined();
+  });
+  it('explicit wins even over an undefined-roster config', () => {
+    expect(resolveExpectedRoster(['a'], cfg())).toEqual(['a']);
+  });
+});
+
+// ─── Config-read seam: loadEclConfig (mmnto-ai/totem#2310) ──
+
+describe('loadEclConfig — missing ⇒ undeclared, invalid ⇒ loud', () => {
+  it('returns undefined when NO config file exists (honest undeclared → gate-red)', async () => {
+    utilsMock.resolveConfigPath.mockImplementation(() => {
+      throw new TotemConfigError(
+        'No Totem configuration found.',
+        'run totem init',
+        'CONFIG_MISSING',
+      );
+    });
+
+    await expect(loadEclConfig('/nowhere')).resolves.toBeUndefined();
+    expect(utilsMock.loadConfig).not.toHaveBeenCalled();
+  });
+
+  it('RETHROWS a present-but-invalid config LOUD (never degraded to undeclared)', async () => {
+    // The empty-roster / any Zod failure path: loadConfig throws CONFIG_INVALID.
+    utilsMock.resolveConfigPath.mockReturnValue('/repo/totem.config.ts');
+    utilsMock.loadConfig.mockRejectedValue(
+      new TotemConfigError(
+        'Invalid configuration:\n  ecl.cohortRepos: Array must contain at least 1 element(s)',
+        'fix the fields listed above',
+        'CONFIG_INVALID',
+      ),
+    );
+
+    // NON-VACUITY: a catch-and-degrade (orient's pattern) would resolve undefined
+    // here, aliasing a config bug into the undeclared arm — this asserts it does NOT.
+    await expect(loadEclConfig('/repo')).rejects.toThrow(/Invalid configuration/);
+  });
+
+  it('returns the loaded config when present and valid', async () => {
+    const loaded = cfg(CROSTER);
+    utilsMock.resolveConfigPath.mockReturnValue('/repo/totem.config.ts');
+    utilsMock.loadConfig.mockResolvedValue(loaded);
+
+    await expect(loadEclConfig('/repo')).resolves.toBe(loaded);
   });
 });
 

--- a/packages/cli/src/commands/ecl-gc.ts
+++ b/packages/cli/src/commands/ecl-gc.ts
@@ -36,10 +36,11 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 import {
-  cohortRepos,
   getErrorMessage,
   isPathSafeAgentId,
   resolveTotemRepoRootSync,
+  type TotemConfig,
+  TotemConfigError,
   TotemError,
 } from '@mmnto/totem';
 
@@ -425,14 +426,25 @@ export interface EclCompactOptions {
   maxScan?: number;
   /**
    * Declared expected cohort repo roster for the A2.2 completeness gate — the
-   * yardstick the workspace glob is checked against (default: `cohortRepos()`,
-   * the strategy#611 interim constant pending config-ification, mmnto-ai/totem#2310).
-   * An EMPTY roster is the "undeclared" case: compaction HARD-ABORTS (fail-loud,
-   * exit 3), never "assume complete" and never a silent no-op — completeness is
-   * unprovable without a declared expectation (strategy#828 no-roster corollary).
-   * Tests inject explicitly.
+   * yardstick the workspace glob is checked against. Highest-precedence source
+   * (mmnto-ai/totem#2310): an explicit value here (programmatic callers / tests)
+   * WINS over `config.ecl.cohortRepos`. When BOTH are absent the roster is
+   * undeclared: compaction HARD-ABORTS (fail-loud, exit 3), never "assume
+   * complete" and never a silent no-op — completeness is unprovable without a
+   * declared expectation (strategy#828 no-roster corollary). Tests inject
+   * explicitly; the CLI action injects `config` (below) instead.
    */
   expectedRepos?: string[];
+  /**
+   * Loaded consumer config, the roster's second-precedence source
+   * (mmnto-ai/totem#2310): when `expectedRepos` is absent the gate reads
+   * `config.ecl.cohortRepos`. Injected by the CLI action (which loads config at
+   * the process boundary) so `eclCompact` stays a pure, synchronously-testable
+   * function — most tests inject `expectedRepos` directly and never touch this.
+   * A declared-but-EMPTY `cohortRepos` never reaches here: it is a Zod `.min(1)`
+   * violation caught loud at config load (a config bug ≠ an undeclared roster).
+   */
+  config?: TotemConfig;
   /**
    * Operator escape (`--force-incomplete`): proceed with compaction even when
    * the workspace glob is a strict subset of the declared roster (a cohort repo
@@ -494,6 +506,47 @@ export interface EclCompactResult {
 }
 
 /**
+ * Resolve the A2.2 completeness roster by precedence (mmnto-ai/totem#2310):
+ * explicit `expectedRepos` (programmatic callers / tests) → `config.ecl.cohortRepos`
+ * (consumer-declared) → `undefined` (the honest UNDECLARED state, which the gate
+ * maps to a hard-abort). Pure so the precedence is unit-testable in isolation.
+ * A declared-but-EMPTY array never reaches here: it is a Zod `.min(1)` violation
+ * caught loud at config load (`loadEclConfig`), so a config bug is never aliased
+ * into an undeclared roster.
+ */
+export function resolveExpectedRoster(
+  explicit: string[] | undefined,
+  config: TotemConfig | undefined,
+): string[] | undefined {
+  return explicit ?? config?.ecl?.cohortRepos;
+}
+
+/**
+ * Load the consumer's Totem config for the compaction roster read
+ * (mmnto-ai/totem#2310). A MISSING config file is the honest "undeclared" state —
+ * returns `undefined`, and the gate hard-aborts (exit 3) downstream. A
+ * PRESENT-but-INVALID config (e.g. `ecl.cohortRepos: []` → Zod `.min(1)`, or any
+ * other schema/parse error) throws LOUD: it is a config BUG and must NOT be
+ * caught into honest-absent, which would mask the bug as a normal undeclared
+ * roster (Tenet 4). Mirrors `orient`'s config read (`resolveProjectNumber`) but
+ * DELIBERATELY narrows the swallow to `CONFIG_MISSING` only — orient's catch-all
+ * would degrade an invalid config into "no board", the exact aliasing this gate
+ * must avoid.
+ */
+export async function loadEclConfig(cwd: string): Promise<TotemConfig | undefined> {
+  const { loadConfig, resolveConfigPath } = await import('../utils.js');
+  let configPath: string;
+  try {
+    configPath = resolveConfigPath(cwd);
+    // totem-context: a MISSING config file is honest-absent (undeclared roster → gate-red), NOT a failure; any OTHER error — and the present-but-invalid config surfaced by loadConfig below — propagates LOUD so a config bug never aliases into the undeclared arm.
+  } catch (err) {
+    if (err instanceof TotemConfigError && err.code === 'CONFIG_MISSING') return undefined;
+    throw err;
+  }
+  return loadConfig(configPath);
+}
+
+/**
  * Programmatic entry point for cursor-coupled processed-mark compaction. For a
  * single resolved seat, deletes `processed/` marks whose inbound dispatch is
  * absent from the RAW addressed-inbound set (A2.1) — but ONLY when discovery is
@@ -516,7 +569,7 @@ export function eclCompact(opts: EclCompactOptions = {}): EclCompactResult {
   const workspace = path.resolve(
     opts.workspace ?? env['TOTEM_WORKSPACE'] ?? path.dirname(repoRoot),
   );
-  const expectedRepos = [...(opts.expectedRepos ?? cohortRepos())].sort();
+  const expectedRepos = [...(resolveExpectedRoster(opts.expectedRepos, opts.config) ?? [])].sort();
 
   // Single-writer target (A2.3): resolve EXACTLY one seat. Ambiguous/zero self
   // is a usage error (parity with `eclGc`), thrown before any scan or delete.
@@ -554,14 +607,17 @@ export function eclCompact(opts: EclCompactOptions = {}): EclCompactResult {
   const allMarks = new Set([...directMarks, ...broadcastMarks]);
 
   // Safety corollary (codified contract strategy#828 / eb9ff5b — A2.2): an
-  // UNDECLARED (empty) roster gives the completeness gate nothing to assert
-  // against, so completeness cannot be proven. This is a HARD ABORT (fail-loud,
-  // non-zero exit — the caller maps `gateComplete=false` to exit 3), NOT a silent
-  // no-op that would let `processed/` accumulate unsignalled (Tenet 4). A genuine
-  // single-repo consumer opts into completeness-1 by DECLARING a 1-repo roster;
-  // the interim `cohortRepos()` default is non-empty for our cohort, so this
-  // guards the config-declared undeclared-consumer case (mmnto-ai/totem#2310).
-  // `rosterDeclared=false` is retained only to frame the operator message.
+  // UNDECLARED roster gives the completeness gate nothing to assert against, so
+  // completeness cannot be proven. This is a HARD ABORT (fail-loud, non-zero
+  // exit — the caller maps `gateComplete=false` to exit 3), NOT a silent no-op
+  // that would let `processed/` accumulate unsignalled (Tenet 4). The roster is
+  // resolved from consumer config (`ecl.cohortRepos`, mmnto-ai/totem#2310):
+  // omitting the key is the undeclared state that lands here (empty array after
+  // the `?? []` fallback). A declared-but-EMPTY `cohortRepos: []` never reaches
+  // this branch — it is a loud Zod `.min(1)` failure at config load, never
+  // aliased into undeclared. A genuine single-repo consumer opts into
+  // completeness-1 by DECLARING a 1-repo roster. `rosterDeclared=false` is
+  // retained only to frame the operator message.
   if (expectedRepos.length === 0) {
     return {
       agent,
@@ -594,8 +650,8 @@ export function eclCompact(opts: EclCompactOptions = {}): EclCompactResult {
   // roster entry the gate accepts but the scan would skip leaves its outbox
   // unscanned, re-opening the leak (CodeRabbit). `--force-incomplete` waives a
   // genuinely ABSENT repo, but never an unscannable-name declaration (that is a
-  // config error, not a known gap). Unreachable with the clean #611 roster
-  // today; hardens the config-declared future (mmnto-ai/totem#2310).
+  // config error, not a known gap). Unreachable with our own clean config-
+  // declared roster today; hardens the arbitrary-consumer case (mmnto-ai/totem#2310).
   const forced = opts.forceIncomplete === true;
   const missingRepos = expectedRepos.filter(
     (repo) =>

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -926,8 +926,14 @@ program
       // reported in the structured result. We do NOT call handleError (it exits
       // 1, colliding with the sensor codes). (Custom-exit precedent: index-lite.ts 78.)
       try {
-        const { eclGc, eclGcCommand, eclCompact, eclCompactCommand, resolveEclGcExitCode } =
-          await import('./commands/ecl-gc.js');
+        const {
+          eclGc,
+          eclGcCommand,
+          eclCompact,
+          eclCompactCommand,
+          loadEclConfig,
+          resolveEclGcExitCode,
+        } = await import('./commands/ecl-gc.js');
         const pruneResult = eclGc({
           apply,
           retainDays: retainDays !== undefined ? Number(retainDays) : undefined,
@@ -938,7 +944,14 @@ program
         // independent — but the doctrine sequences them within /signoff.
         let compactResult: ReturnType<typeof eclCompact> | undefined;
         if (compact === true) {
-          compactResult = eclCompact({ apply, agentId, forceIncomplete });
+          // Resolve the A2.2 completeness roster from consumer config
+          // (`ecl.cohortRepos`, mmnto-ai/totem#2310) at this process boundary and
+          // inject it. A MISSING config ⇒ undefined ⇒ the gate's undeclared
+          // hard-abort (exit 3). A PRESENT-but-INVALID config (e.g. an empty
+          // roster) throws here and is caught below as a usage error (exit 2,
+          // loud) — never silently degraded into the undeclared arm.
+          const config = await loadEclConfig(process.cwd());
+          compactResult = eclCompact({ apply, agentId, forceIncomplete, config });
         }
         if (json === true && compactResult !== undefined) {
           // Single combined document so a --json consumer parses one object

--- a/packages/core/src/config-schema.test.ts
+++ b/packages/core/src/config-schema.test.ts
@@ -177,6 +177,61 @@ describe('TotemConfigSchema', () => {
     });
     expect(whitespace.success).toBe(false);
   });
+
+  // ─── ecl.cohortRepos (mmnto-ai/totem#2310) ─────────────
+
+  it('accepts a declared ecl.cohortRepos roster (mmnto-ai/totem#2310)', () => {
+    const result = TotemConfigSchema.safeParse({
+      targets: BASE_TARGETS,
+      ecl: { cohortRepos: ['totem', 'totem-strategy'] },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.ecl?.cohortRepos).toEqual(['totem', 'totem-strategy']);
+    }
+  });
+
+  it('accepts a single-repo roster (completeness-1, the A2.2 line)', () => {
+    const result = TotemConfigSchema.safeParse({
+      targets: BASE_TARGETS,
+      ecl: { cohortRepos: ['solo-repo'] },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('treats ecl as undefined when omitted (the honest undeclared state)', () => {
+    const result = TotemConfigSchema.safeParse({ targets: BASE_TARGETS });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.ecl).toBeUndefined();
+    }
+  });
+
+  it('treats an ecl block without cohortRepos as undeclared (key optional)', () => {
+    const result = TotemConfigSchema.safeParse({ targets: BASE_TARGETS, ecl: {} });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.ecl?.cohortRepos).toBeUndefined();
+    }
+  });
+
+  it('rejects an EMPTY ecl.cohortRepos array (config bug, not undeclared — Zod .min(1))', () => {
+    // An empty roster must fail LOUD at load, never alias into the undeclared
+    // gate-red arm (mmnto-ai/totem#2310; strategy#828 Tenet-4 distinction).
+    const result = TotemConfigSchema.safeParse({
+      targets: BASE_TARGETS,
+      ecl: { cohortRepos: [] },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a blank/empty repo name inside ecl.cohortRepos (element .min(1))', () => {
+    const result = TotemConfigSchema.safeParse({
+      targets: BASE_TARGETS,
+      ecl: { cohortRepos: ['totem', ''] },
+    });
+    expect(result.success).toBe(false);
+  });
 });
 
 // ─── Orchestrator schema ─────────────────────────────

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -277,6 +277,39 @@ export const OrientConfigSchema = z.object({
 });
 
 /**
+ * `totem ecl-gc --compact` cohort completeness roster (mmnto-ai/totem#2310;
+ * ADR-106 § A2.2 + ecl-discipline § 4.5).
+ *
+ * `cohortRepos` is the declared expected-repo yardstick the compaction
+ * completeness gate checks the live workspace glob against: a `processed/` mark
+ * may be collected only against a PROVABLY-complete poll, and "complete"
+ * requires every expected outbox-holding repo present + scanned. A silently-
+ * absent cohort repo makes a live mark in its unscanned outbox look inert (the
+ * false-unread class), so the roster is the yardstick that makes an incomplete
+ * scan detectable.
+ *
+ * Values are bare workspace DIRECTORY names (e.g. `totem`, `totem-strategy`),
+ * matched against the sibling directories of the workspace root — NOT
+ * `owner/repo` slugs. This is CONSUMER-DECLARED config, not a baked product
+ * identity (Tenet 16 / the A2.2 contract): an external consumer's cohort is
+ * THEIR repos, so the roster cannot ship as a core constant. It replaces the
+ * interim `cohortRepos()` core constant (shipped 1.90.0, product-locked). The
+ * change-authority for OUR cohort's value stays mmnto-ai/totem-strategy#611.
+ *
+ * `.min(1)`: an EMPTY `cohortRepos: []` is a config BUG (loud Zod failure at
+ * load), NEVER a synonym for "undeclared". Omitting the `ecl` block (or the
+ * `cohortRepos` key) is the honest undeclared state → the compaction gate
+ * hard-aborts (exit 3, non-`--force-incomplete`-waivable). A genuine single-
+ * repo consumer declares a roster of one (completeness-1, the A2.2 line).
+ */
+export const EclConfigSchema = z.object({
+  /** Declared cohort repo roster (bare workspace dir names) for the `totem
+   *  ecl-gc --compact` A2.2 completeness gate. Optional: absent ⇒ undeclared ⇒
+   *  the gate hard-aborts. `.min(1)`: an empty array is a loud config error. */
+  cohortRepos: z.array(z.string().min(1)).min(1).optional(),
+});
+
+/**
  * Default source extensions used when computing the review content hash.
  * Historical hardcoded set, preserved for backward compatibility with
  * pre-#1527 consumers. Polyglot repos override via `review.sourceExtensions`.
@@ -490,6 +523,10 @@ export const TotemConfigSchema = z.object({
 
   /** Optional: `totem orient` settings (e.g. `{ projectNumber: 1 }` for the GH Project board). */
   orient: OrientConfigSchema.optional(),
+
+  /** Optional: `totem ecl-gc --compact` settings — the consumer-declared cohort
+   *  completeness roster (`{ cohortRepos: ['totem', ...] }`, mmnto-ai/totem#2310). */
+  ecl: EclConfigSchema.optional(),
 });
 
 /**
@@ -509,6 +546,7 @@ export type GarbageCollectionConfig = z.infer<typeof GarbageCollectionSchema>;
 export type DoctorConfig = z.infer<typeof DoctorConfigSchema>;
 export type DocTarget = z.infer<typeof DocTargetSchema>;
 export type OrientConfig = z.infer<typeof OrientConfigSchema>;
+export type EclConfig = z.infer<typeof EclConfigSchema>;
 export type TotemConfig = z.infer<typeof TotemConfigSchema>;
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,6 +62,7 @@ export type {
   ContentType,
   DocTarget,
   DoctorConfig,
+  EclConfig,
   EmbeddingProvider,
   GarbageCollectionConfig,
   IngestTarget,
@@ -79,6 +80,7 @@ export {
   DEFAULT_REVIEW_SOURCE_EXTENSIONS,
   DocTargetSchema,
   DoctorConfigSchema,
+  EclConfigSchema,
   EmbeddingProviderSchema,
   GarbageCollectionSchema,
   GeminiOrchestratorSchema,
@@ -675,7 +677,6 @@ export { resolveSubstratePaths } from './substrate-resolver.js';
 // frozen-archive read path while orchestration is the active read+write surface.
 export type { OrchestrationPaths, SelfAgentResolution } from './orchestration-resolver.js';
 export {
-  cohortRepos,
   isPathSafeAgentId,
   knownCohortAgents,
   resolveOrchestrationPaths,

--- a/packages/core/src/orchestration-resolver.test.ts
+++ b/packages/core/src/orchestration-resolver.test.ts
@@ -16,7 +16,6 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
-  cohortRepos,
   isPathSafeAgentId,
   knownCohortAgents,
   type OrchestrationPaths,
@@ -548,16 +547,12 @@ describe('knownCohortAgents — single-source recipient set', () => {
   });
 });
 
-describe('cohortRepos — declared roster for the ecl-gc A2.2 gate', () => {
-  it('is the strategy#611 frozen active set (interim; excludes arhgap11, not map-derived)', () => {
-    // The completeness gate's declared expectation (mmnto-ai/totem#2307). This is
-    // OUR config value pending config-ification (mmnto-ai/totem#2310), authority
-    // strategy#611 — deliberately NOT the COHORT_AGENT_MAP keys (which include
-    // arhgap11 / totem-playground). Lock the exact set so a drift is caught here.
-    expect(cohortRepos()).toEqual(['liquid-city', 'totem', 'totem-status', 'totem-strategy']);
-    expect(cohortRepos()).not.toContain('arhgap11');
-  });
-});
+// The `cohortRepos()` interim constant (shipped 1.90.0, product-locked) and its
+// lock-test were RETIRED in mmnto-ai/totem#2310: the ecl-gc A2.2 completeness
+// roster is now resolved from consumer config (`ecl.cohortRepos`), so OUR
+// cohort's frozen value lives in `totem.config.ts`, not a core constant. See
+// `packages/core/src/config-schema.test.ts` (schema) and
+// `packages/cli/src/commands/ecl-gc.test.ts` (resolution precedence).
 
 // ─── resolveSelfAgents — seat dirs (mmnto-ai/totem#2141) ───────────────────
 

--- a/packages/core/src/orchestration-resolver.ts
+++ b/packages/core/src/orchestration-resolver.ts
@@ -240,40 +240,6 @@ export function knownCohortAgents(workspace?: string): string[] {
 }
 
 /**
- * ⚠ INTERIM CONSTANT — product-lock: config-ify before any non-cohort consumer.
- *
- * The declared cohort REPO roster the ADR-106 § A2.2 compaction completeness
- * gate checks a workspace glob against: cursor-GC may delete a `processed/`
- * mark only against a PROVABLY-complete poll, and "complete" requires every
- * expected outbox-holding repo present + scanned (a silently-absent repo makes
- * a live mark look inert — the false-unread class). The glob (present dirs, the
- * mmnto-ai/totem#2141 dirs-are-state mechanism) is the discovery; this roster is
- * the yardstick that makes "incomplete scan" detectable.
- *
- * This value is the mmnto-ai/totem-strategy#611 frozen active set — OUR cohort's
- * config value — and its change-authority stays strategy#611 (skynet's return
- * flips it there; this follows in lockstep, no core edit). It deliberately
- * EXCLUDES `arhgap11` (not in the #611 active set) and is NOT derived from
- * `COHORT_AGENT_MAP` — reading the seat map as the roster would re-elevate it
- * from "bootstrap fallback" to "authority," contradicting the mmnto-ai/totem#2141
- * dirs-are-state ruling (contract-owner ruling, strategy-claude 2026-07-06).
- *
- * WHY A CONSTANT IS ONLY INTERIM (Tenet 16): `totem ecl-gc` is a SHIPPING core
- * command; an external consumer's cohort is THEIR repos, not ours. A hardcoded
- * roster is the product-vs-cohort lock Tenet 16 guards against — it would abort
- * compaction for every consumer whose workspace isn't our four repos. The
- * honest target is a CONSUMER-CONFIG-declared roster; this constant stands in
- * only because ECL has no external consumers yet. Config-ify tracked in
- * mmnto-ai/totem#2310. Until then the compaction gate's own safety corollary
- * holds the line: an empty/undeclared roster makes compaction HARD-ABORT
- * (fail-loud, non-zero exit), never a silent no-op and never "assume complete"
- * (codified strategy#828 / eb9ff5b).
- */
-export function cohortRepos(): string[] {
-  return ['liquid-city', 'totem', 'totem-status', 'totem-strategy'];
-}
-
-/**
  * True iff `id` is safe to use as a `.totem/orchestration/<id>/…` path segment
  * (or any filename token): a non-empty string with no path separators, null
  * byte, or `..` traversal, and no control/whitespace/win32-reserved characters

--- a/totem.config.ts
+++ b/totem.config.ts
@@ -80,6 +80,17 @@ const config: TotemConfig = {
     parityManifest: 'node_modules/@mmnto/strategy-doctrine/parity-manifest.yaml',
   },
 
+  // mmnto-ai/totem#2310: the `totem ecl-gc --compact` A2.2 completeness roster —
+  // the cohort repos whose ECL outboxes a provably-complete poll must scan before
+  // a processed-mark may be collected. Bare workspace directory names (not
+  // owner/repo slugs). This is OUR cohort's frozen active set; its VALUE
+  // change-authority is mmnto-ai/totem-strategy#611 (skynet's return flips it
+  // there; configs follow in lockstep). Omitting this key would gate-red the
+  // /signoff compaction step (exit 3, fail-loud) — declared here so it stays green.
+  ecl: {
+    cohortRepos: ['liquid-city', 'totem', 'totem-status', 'totem-strategy'],
+  },
+
   // mmnto-ai/totem#1710: the strategy linkedIndex is auto-injected by the
   // MCP context init via `resolveStrategyRoot`. Listing it here is no
   // longer required — the resolver handles env / config / sibling /


### PR DESCRIPTION
## Summary

Resolve the `totem ecl-gc --compact` A2.2 completeness roster from consumer config (`ecl.cohortRepos`), retiring the interim `cohortRepos()` core constant per the contract owner's ruling (strategy-claude, 2026-07-06/07 — full point-by-point on the issue). Contract: ADR-106 § A2.2 + ecl-discipline § 4.5 (mmnto-ai/totem-strategy#828 no-roster corollary).

Closes #2310

## The blessed shape (implemented as ruled)

1. **Key:** `ecl.cohortRepos: string[]` — new optional `EclConfigSchema` sub-schema on `TotemConfigSchema`. Values are bare workspace **directory** names, matched against the workspace root's siblings (consumer-declared, Tenet 16 — not a baked product identity).
2. **Precedence:** explicit `EclCompactOptions.expectedRepos` (programmatic/tests) → `config.ecl.cohortRepos` → undeclared ⇒ the shipped gate-red arm unchanged (`gateComplete=false`, `"no cohort roster declared"`, exit 3, not `--force-incomplete`-waivable).
3. **No env override in the binary** — config is the single source (ruled load-bearing; the programmatic option covers tests/CI).
4. **Empty array is a loud config error, not "undeclared":** `cohortRepos: []` violates Zod `.min(1)` at load. The ecl-gc config read (`loadEclConfig`) narrows its swallow to `CONFIG_MISSING` only — a present-but-invalid config throws loud (exit 2) and is never aliased into the undeclared gate-red arm.
5. This repo's `totem.config.ts` declares the four-repo set; value change-authority stays mmnto-ai/totem-strategy#611.

## Design

Config loads at the CLI action boundary (`loadEclConfig`, only when `--compact` is requested) and is injected via `EclCompactOptions.config`, keeping `eclCompact` pure and synchronously testable — the existing injection-driven test suite runs unchanged. Precedence lives in a pure exported `resolveExpectedRoster`. This deliberately diverges from `orient`'s catch-all config read: degrading an invalid config into honest-absent is the exact aliasing the A2.2 contract forbids.

## Breaking note (flagged in the changeset)

`@mmnto/totem` no longer exports `cohortRepos()`. It shipped in 1.90.0 explicitly marked INTERIM / product-locked / do-not-depend, with config-ification tracked in this issue. Consumers switch to `ecl.cohortRepos` config or pass `expectedRepos` programmatically. Changeset is **minor** for `@mmnto/cli` + `@mmnto/totem`.

## Tests + verification

- Schema rows: valid roster, single-repo roster (completeness-1), omitted key, **empty array rejected**, blank element rejected.
- Precedence suite for `resolveExpectedRoster`; compaction rows C16–C19 (config drives roster; explicit wins non-vacuously; no-source ⇒ exit-3 arm; `ecl` block without the key ⇒ undeclared); `loadEclConfig` rows (missing ⇒ undefined, invalid ⇒ loud rethrow, valid ⇒ config).
- Existing C12 + exit-code precedence suites green unchanged; full suites: cli 2,988 / core 3,088; `pnpm -r build`, prettier, ESLint, `totem lint` all pass.
- Live-verified against the built binary: from this repo the compact dry-run reports `roster 4 repo(s)` read from config (exit 0); from a config-less fixture, `no cohort roster declared — compaction HARD-ABORTS` (exit 3).
- Rebased onto main post-#2313 (shared `ecl-gc.ts` import block); both changes verified coexisting.

## Rollout (coupled follow-ups, owned downstream)

At the 1.91.0 release-cut broadcast: strategy-claude lands the `totem-strategy` / `totem-status` config blocks in lockstep (their lane, per the ruling); ecl-discipline § 4.5's source line gets sharpened to name `ecl.cohortRepos` on merge (theirs, Tenet 19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
