### PR TITLE
ci: restore Integration Smoke Tests — explicit exec for bare vitest under pnpm 10+

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -33,7 +33,9 @@ jobs:
       - run: pnpm build
 
       - name: Run integration smoke tests + adversarial eval harness
-        run: pnpm --filter @mmnto/cli vitest run --config vitest.integration.config.ts
+        # pnpm 10+ removed the implicit exec fallback for filtered runs — bare
+        # `vitest` resolves as a (nonexistent) package script, so exec explicitly.
+        run: pnpm --filter @mmnto/cli exec vitest run --config vitest.integration.config.ts
         env:
           CI_INTEGRATION: 'true'
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}


### PR DESCRIPTION
## What

One-line workflow fix: make the exec explicit in `ci-integration.yml` so the Integration Smoke Tests actually run again under pnpm 11.

```diff
-        run: pnpm --filter @mmnto/cli vitest run --config vitest.integration.config.ts
+        run: pnpm --filter @mmnto/cli exec vitest run --config vitest.integration.config.ts
```

## Why

pnpm 10 removed the implicit exec fallback for filtered invocations — `pnpm --filter <pkg> <cmd>` is strictly a recursive script run now, and `packages/cli` has no `vitest` script. Since the pnpm `9.15.4 → 11.2.2` bump (`e4a24ec5`, #2023) every scheduled run has died in ~0.5 s with `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT` — 45 consecutive failures since 2026-05-24, both matrix legs, zero tests executed. Full evidence chain in the issue.

## Verification

- Broken form reproduced locally on pnpm 11.2.2 (same one-line error as CI).
- Fixed form verified locally: vitest launches in the package dir, 11 ungated integration tests pass, `CI_INTEGRATION`-gated live-API suites skip as designed.
- Real gate: `workflow_dispatch` of Integration Smoke Tests on this branch — result posted in comments.
- `totem lint --base main`: PASS (387 rules, 0 violations); repo-wide `format:check` clean.

CI-only change — no changeset (nothing releasable).

Closes #2317

🤖 Generated with [Claude Code](https://claude.com/claude-code)
