### PR TITLE
feat(cli): pollMail cross-sender basename-collision sensor (#2311)

### DIFF
--- a/.changeset/mail-collision-sensor.md
+++ b/.changeset/mail-collision-sensor.md
@@ -1,0 +1,11 @@
+---
+'@mmnto/cli': minor
+---
+
+`totem mail` gains a cross-sender basename-collision sensor (mmnto-ai/totem#2311; read-side half of mmnto-ai/totem-strategy#827).
+
+**What it detects.** ECL dispatch filenames don't encode the sender and `processed/` dedupe is basename-only — so when two distinct seats converge on one addressed-inbound basename in a single poll, a single mark would silently shadow BOTH dispatches (the second never surfaces as unread). `pollMail` now emits one structured warning per colliding basename, naming every `repo/agent` sender path, into the existing `warnings` array.
+
+**Composition, not plumbing.** Because `totem ecl-gc --compact` arms its A2.2 completeness gate on `poll.warnings.length === 0` (mmnto-ai/totem#2309) and its discovery poll reads through marks (`includeProcessed`, A2.1), a live collision automatically blocks mark-compaction during exactly the coexistence window in which compaction could strand a dispatch — zero new gate surface.
+
+**Sensor, not actuator (Tenet 13).** Warn-only: both dispatches still surface as unread mail; nothing is renamed, moved, or deleted. Sender identity keys on the outbox-owner seat (filesystem truth under single-writer discipline), never the forgeable `from:` header — one seat's broadcast fan-out copies across repos never fire it. No `MailPollResult` shape change; JSON consumers see the new message in the existing `warnings` field. Encoding `<sender>` into the filename convention remains the escalation path on mmnto-ai/totem-strategy#827 if this sensor ever fires on a real drop.

--- a/.totem/specs/2311-mail-collision-sensor.md
+++ b/.totem/specs/2311-mail-collision-sensor.md
@@ -1,0 +1,187 @@
+### Problem Statement
+
+The `mail` command currently polls for agent messages but blindly processes the inbox state without awareness of structural conflicts, such as multiple active mail files targeting the same resource or identical queued tasks. We must implement a "mail collision sensor" to detect and report these conflicts deterministically during the poll phase.
+
+### Architectural Context
+
+- **Sensors, Not Actuators (docs/manual/why-totem.md):** Totem's core tenet dictates it is a governance platform, not an orchestrator. The collision sensor must strictly _detect_ and _report_ mail collisions in the output payload. It is strictly forbidden from attempting to resolve the collision (e.g., no deleting duplicates, no applying file locks, no renaming files). You wire the actuator; Totem only provides the sensor.
+
+### Files to Examine
+
+1. `packages/cli/src/commands/mail.ts` — Core logic for mail polling. Contains `MailPollResult`, `pollMail`, and `formatTextResult`. Needs structural updates to support collision reporting.
+2. `docs/manual/why-totem.md` — Explains the architectural boundary between sensing (what this task does) and actuating (what this task must avoid).
+
+### Technical Approach & Contracts
+
+1. **Define the Data Contract:**
+   Update `packages/cli/src/commands/mail.ts` to include a new collision contract.
+
+   ```typescript
+   export type CollisionType = 'duplicate_task' | 'target_overlap' | 'malformed_entry';
+
+   export interface MailCollision {
+     type: CollisionType;
+     description: string;
+     affectedFiles: string[];
+   }
+   ```
+
+2. **Extend Existing Interfaces:**
+   Modify `MailPollResult` to optionally include the sensor's findings:
+   ```typescript
+   export interface MailPollResult {
+     // ... existing fields (workspace, selfAgents)
+     collisions: MailCollision[]; // Guarantee array, empty if clean
+   }
+   ```
+3. **Implement the Sensor Logic:**
+   Create a pure function `detectMailCollisions(mailFiles: string[]): MailCollision[]` that reads mail configurations (using `readJsonSafe` from `@mmnto/totem` shared helpers to prevent parsing crashes) and evaluates them for overlapping criteria.
+4. **Format the Output:**
+   Update `formatTextResult` to append collision data if `result.collisions.length > 0`. Outputting clear warnings allows the user's external actuators (like a CI pipeline or git hook) to fail or halt.
+
+### Edge Cases & Traps
+
+- **The Actuator Trap:** The developer might be tempted to move or delete colliding files. This violates the `Sensors, Not Actuators` invariant. Only read and report.
+- **Malformed Mail Files:** A collision sensor that crashes on invalid JSON defeats the purpose. You MUST use the shared helper `readJsonSafe` wrapped in a try/catch, treating parsing failures as a `malformed_entry` collision rather than throwing a fatal process error.
+- **Transient Files:** Exclude `.tmp` or `.lock` files from collision detection to prevent false positives caused by agents currently writing to the inbox.
+- **Empty Inbox Race Condition:** Polling an empty inbox must safely return `{ ..., collisions: [] }` without erroring out.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Update Data Contracts**
+  - Modify `packages/cli/src/commands/mail.ts` to export `MailCollision` and `CollisionType` types.
+  - Update `MailPollResult` to require `collisions: MailCollision[]`.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `MailPollResult initialization requires empty collisions array` in the relevant test file to ensure the type checker enforces the new contract.
+  - Update any existing mocks or fixtures in the test suite to include `collisions: []`.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Implement Sensor Logic**
+  - Create `detectMailCollisions` function in `packages/cli/src/commands/mail.ts` (or a sibling utility if the file is too large).
+    > TOTEM INVARIANT (Sensors, Not Actuators): The `detectMailCollisions` function must only read files (using `readJsonSafe`) and return metadata. It must not invoke `fs.unlinkSync`, `fs.renameSync`, or any state-mutating operations.
+  - Filter out `.tmp` and `.lock` files before processing.
+  - Detect overlapping targets and capture parsing failures via `readJsonSafe` as `malformed_entry` collisions.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `detectMailCollisions returns target_overlap without modifying filesystem` that mocks two mail files targeting the same agent and verifies the returned collision array.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Integrate with pollMail and Output Formatter**
+  - Inside `pollMail`, invoke `detectMailCollisions` and attach the result to the returned `MailPollResult`.
+  - Update `formatTextResult` in `packages/cli/src/commands/mail.ts`. If `collisions` exist, append a prominent warning block (e.g., `[!] Collisions Detected: \n - Target Overlap in file A and file B`).
+    > TEST DIRECTIVE: Before implementing, write a failing test named `formatTextResult appends warning block when collisions exist` to ensure text reporting correctly surfaces the sensor data.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Contract Test:** Ensure `MailPollResult` strict typing blocks compilations where `collisions` is omitted.
+- **Transient File Test:** Create a `.tmp` file and verify `detectMailCollisions` ignores it completely.
+- **Overlap Detection Test:** Provide two valid JSON mail files targeting the same self-agent. Verify `collisions` array has length 1 with type `target_overlap`.
+- **Malformed Entry Test:** Provide one valid mail file and one corrupt JSON file. Verify `readJsonSafe` safely catches the error and generates a `malformed_entry` collision.
+- **Formatter Test:** Pass a synthetic `MailPollResult` with 2 collisions to `formatTextResult` and assert the resulting string contains the formatted warning messages.
+
+## Implementation Design
+
+> **Supersedes the generated body above.** The generated spec hallucinated a
+> `MailCollision`/`CollisionType` typed contract, `readJsonSafe` JSON parsing,
+> and `.tmp`/`.lock` filtering — none of it matches the system (mail files are
+> markdown frontmatter, parsed by `parseHeader`), and a separate `collisions`
+> field would NOT compose with the A2.2 compaction gate, which arms on
+> `poll.warnings.length === 0` (#2309). The authoritative shape is the #2311
+> issue body — the blessed read-side half of mmnto-ai/totem-strategy#827
+> (owner disposition re-verified current 2026-07-07; doctrine half is
+> strategy#829, not this PR).
+
+### Scope
+
+Add cross-sender basename-collision detection inside `pollMail`
+(`packages/cli/src/commands/mail.ts`): when the same addressed-inbound
+basename is seen from ≥2 distinct sender agent-ids in one poll, push one
+structured warning per colliding basename into the EXISTING `warnings` array.
+NOT in scope: any new field on `MailPollResult`, filename-convention or
+`mail send` changes, `totem-status` parsing, compaction-key semantics (A2.1
+basename dedupe unchanged), doctrine text (strategy#829), and any actuation —
+sensor only (Tenet 13).
+
+### Data model deltas
+
+None on any exported type. `MailPollResult.warnings: string[]` is the
+existing channel; the JSON payload and `formatTextResult` (`Warning:` lines)
+already render it. One new function-local container inside `pollMail`:
+
+- `collisions: Map<string, Map<string, string>>` — basename → (sender-id
+  lowercased → display path `repo/agent`). Written only by the post-parse
+  loop; read once after the loop to emit warnings; never escapes the call.
+  Bounded by scan size (≤ MAX_SCAN entries).
+
+Sender identity = the **outbox-owner seat** (`slot.agent`, compared
+case-insensitively, parity with `selfLower`) — deliberately NOT the
+`header.from ?? slot.agent` display semantics of `MailEntry.from`: under
+single-writer discipline the outbox directory is filesystem truth, while
+`from:` is a forgeable self-declaration (see the frontmatter-forge-defense
+test class). Keying on seat, not outbox path string, is load-bearing:
+broadcast fan-out (one seat, same basename, several repos) must not fire.
+
+### State lifecycle
+
+Per-call only: the map is created at `pollMail` entry, populated during the
+in-scope parse loop (after the `to:` self/broadcast filter — addressed-inbound
+entries only), drained into `warnings` before return, and garbage-collected
+with the call frame. No module state, no persistence, no cross-call carry.
+
+### Failure modes
+
+| Failure                                                               | Category                      | Agent-facing surface                                                                                                                                              | Recovery                                                                                                                                        |
+| --------------------------------------------------------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| ≥2 distinct senders, same addressed-inbound basename                  | runtime (the detected hazard) | warning: `cross-sender basename collision: <name> from <repo/agentA> and <repo/agentB> — a single processed/ mark would shadow both`                              | operator/sender renames or consumes both before marking; compaction auto-blocked meanwhile via the existing warnings arm                        |
+| Collision where one file is already `processed/`-marked               | runtime                       | plain poll cannot see it (mark filters both at pass 1) — but the compaction discovery poll runs `includeProcessed: true`, sees both, fires the warning → gate red | bounded by design: issue's stated coverage (coexistence window + compaction-poll visibility); staggered class bounded by mark-compaction itself |
+| Colliding file beyond MAX_SCAN horizon                                | transient                     | not detected by this sensor; existing truncation warning fires and independently reds the gate                                                                    | rerun with higher `maxScan`; gate stays closed until un-truncated                                                                               |
+| Same sender, same basename, multiple repos (broadcast fan-out)        | — (non-failure)               | silent non-fire BY DESIGN: the copies are one dispatch; one mark shadowing all copies is correct handled-semantics                                                | n/a — justified vs Tenet 4: nothing is lost                                                                                                     |
+| Collision arises between compaction discovery and A2.4 verify re-poll | transient                     | `verifyComplete=false` (existing verify arm counts warnings) — loud hard-failure signal                                                                           | re-run compaction; gate now red at discovery                                                                                                    |
+
+No new I/O and no new throw paths: detection is pure bookkeeping over
+already-parsed entries.
+
+### Invariants to lock in via tests
+
+- Two distinct senders, same basename, both addressed to self → exactly ONE
+  warning, naming the basename and both `repo/agent` paths.
+- Broadcast+directed mix counts: sender A `to: broadcast`, sender B `to: <self>`,
+  same basename → fires (both are addressed-inbound for this seat).
+- Same sender, same basename, two repos → NO warning (agent-id keying).
+- Distinct senders, same basename, neither addressed to self → NO warning
+  (not this seat's shadow hazard).
+- Three senders, one basename → still ONE warning listing all three paths.
+- `includeProcessed: true` poll sees a collision even when one side is
+  marked → warning present → `eclCompact` gate red (composition test at the
+  ecl-gc level, no new gate plumbing).
+- Plain-poll result contract unchanged: no new fields, `warnings` ordering of
+  pre-existing classes untouched (collision warnings append after the scan).
+
+### Open questions
+
+- **Question:** Run a fresh pre-build cohort panel, or treat the upstream
+  bless as the panel?
+- **Options:** (a) panel now — cohort seats each review the shape; (b) skip —
+  the shape was already consulted and blessed on strategy#827 (owner
+  disposition) and this issue IS the agreed read-side contract; external-bot
+  PR review remains as the secondary pass.
+- **Recommendation:** (b) skip — a fresh panel re-litigates a settled
+  contract; bots still review the PR.

--- a/packages/cli/src/commands/ecl-gc.test.ts
+++ b/packages/cli/src/commands/ecl-gc.test.ts
@@ -845,6 +845,29 @@ describe('compaction — cursor-coupled GC (A2.1–A2.4)', () => {
     expect(r.gateReasons.some((x) => /no cohort roster declared/.test(x))).toBe(true);
     expect(markExists(CS, DIRECT_SWEPT)).toBe(true);
   });
+
+  it('C20 — a cross-sender basename collision reds the gate and blocks all deletes (mmnto-ai/totem#2311)', () => {
+    ensureRepos(CROSTER);
+    // Two DISTINCT seats converge on one addressed-inbound basename; one side
+    // is already marked. The mark shadows both in the reader view, but the
+    // `includeProcessed` discovery poll sees both, the #2311 sensor warns, and
+    // the existing warnings arm (C4 class) holds compaction shut during
+    // exactly the window a compact could strand the unshadowed dispatch.
+    const COLLIDING = '2026-07-06T1717Z-totem-agy-blind-reply.md';
+    writeInbound('totem-strategy', 'strategy-gemini', COLLIDING, CS);
+    writeInbound('totem-strategy', 'strategy-agy', COLLIDING, CS);
+    writeMark(CS, COLLIDING);
+    writeMark(CS, DIRECT_SWEPT);
+
+    const r = runCompact({ apply: true });
+
+    expect(r.gateComplete).toBe(false);
+    expect(r.gateReasons.some((x) => /cross-sender basename collision/.test(x))).toBe(true);
+    expect(r.collected).toEqual([]);
+    // NON-VACUITY: the genuinely-swept mark ALSO survives — uncertain ⇒ retain.
+    expect(markExists(CS, DIRECT_SWEPT)).toBe(true);
+    expect(markExists(CS, COLLIDING)).toBe(true);
+  });
 });
 
 // ─── Roster resolution precedence (mmnto-ai/totem#2310) ──

--- a/packages/cli/src/commands/mail.test.ts
+++ b/packages/cli/src/commands/mail.test.ts
@@ -282,6 +282,103 @@ describe('pollMail — processed/ exclusion', () => {
   });
 });
 
+// ─── Cross-sender basename-collision sensor ─────────────
+
+describe('pollMail — cross-sender basename-collision sensor (mmnto-ai/totem#2311)', () => {
+  const NAME = '2026-07-06T1717Z-totem-claude-blind-reply.md';
+
+  it('warns once when two distinct senders converge on one addressed-inbound basename', () => {
+    writeOutbox('totem-strategy', 'strategy-gemini', [{ name: NAME, to: 'totem-claude' }]);
+    writeOutbox('totem-strategy', 'strategy-agy', [{ name: NAME, to: 'totem-claude' }]);
+    const result = poll();
+    const collisionWarnings = result.warnings.filter((w) =>
+      w.startsWith('cross-sender basename collision'),
+    );
+    expect(collisionWarnings).toHaveLength(1);
+    expect(collisionWarnings[0]).toContain(NAME);
+    expect(collisionWarnings[0]).toContain('totem-strategy/strategy-gemini');
+    expect(collisionWarnings[0]).toContain('totem-strategy/strategy-agy');
+    // Sensor, not actuator (Tenet 13): both dispatches still surface as mail.
+    expect(result.mail).toHaveLength(2);
+  });
+
+  it('fires on a broadcast + directed mix (both are addressed-inbound for this seat)', () => {
+    writeOutbox('totem-strategy', 'strategy-claude', [{ name: NAME, to: 'broadcast' }]);
+    writeOutbox('liquid-city', 'lc-claude', [{ name: NAME, to: 'totem-claude' }]);
+    const result = poll();
+    expect(
+      result.warnings.filter((w) => w.startsWith('cross-sender basename collision')),
+    ).toHaveLength(1);
+  });
+
+  it('does NOT fire on same-sender copies across repos (broadcast fan-out reads)', () => {
+    // One dispatch, fanned out by the SAME seat into two repos: a single mark
+    // shadowing all copies is correct handled-semantics, not a drop hazard.
+    writeOutbox('totem-strategy', 'strategy-claude', [{ name: NAME, to: 'broadcast' }]);
+    writeOutbox('liquid-city', 'strategy-claude', [{ name: NAME, to: 'broadcast' }]);
+    const result = poll();
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('keys the sender on the outbox-owner seat, not the forgeable from: field', () => {
+    // Same outbox owner, divergent from: headers — still ONE writer (single-
+    // writer discipline), so no collision. The inverse (distinct owners with
+    // an identical forged from:) must still fire.
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: NAME, to: 'totem-claude', from: 'someone-else' },
+    ]);
+    writeOutbox('liquid-city', 'strategy-claude', [{ name: NAME, to: 'totem-claude' }]);
+    expect(poll().warnings).toEqual([]);
+
+    writeOutbox('totem-status', 'status-claude', [
+      { name: NAME, to: 'totem-claude', from: 'strategy-claude' },
+    ]);
+    writeOutbox('skynet-sports', 'skynet-claude', [
+      { name: NAME, to: 'totem-claude', from: 'strategy-claude' },
+    ]);
+    expect(
+      poll().warnings.filter((w) => w.startsWith('cross-sender basename collision')),
+    ).toHaveLength(1);
+  });
+
+  it('does NOT fire when neither same-basename dispatch is addressed to this seat', () => {
+    writeOutbox('totem-strategy', 'strategy-gemini', [{ name: NAME, to: 'lc-claude' }]);
+    writeOutbox('totem-strategy', 'strategy-agy', [{ name: NAME, to: 'lc-claude' }]);
+    const result = poll();
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('emits ONE warning naming all sender paths when three seats collide', () => {
+    writeOutbox('totem-strategy', 'strategy-gemini', [{ name: NAME, to: 'totem-claude' }]);
+    writeOutbox('totem-strategy', 'strategy-agy', [{ name: NAME, to: 'totem-claude' }]);
+    writeOutbox('liquid-city', 'lc-claude', [{ name: NAME, to: 'totem-claude' }]);
+    const result = poll();
+    const collisionWarnings = result.warnings.filter((w) =>
+      w.startsWith('cross-sender basename collision'),
+    );
+    expect(collisionWarnings).toHaveLength(1);
+    expect(collisionWarnings[0]).toContain('totem-strategy/strategy-gemini');
+    expect(collisionWarnings[0]).toContain('totem-strategy/strategy-agy');
+    expect(collisionWarnings[0]).toContain('liquid-city/lc-claude');
+  });
+
+  it('a processed/ mark hides the coexistence window from the READER poll but not from the compaction view', () => {
+    // The reader poll filters BOTH files by basename at pass 1 — the exact
+    // shadow this sensor exists to catch, detectable only while both are
+    // unread. The compaction discovery poll (`includeProcessed`, ADR-106
+    // § A2.1) sees through marks, so the warning fires there and reds the
+    // A2.2 gate via the existing `warnings.length === 0` arm (#2309).
+    writeOutbox('totem-strategy', 'strategy-gemini', [{ name: NAME, to: 'totem-claude' }]);
+    writeOutbox('totem-strategy', 'strategy-agy', [{ name: NAME, to: 'totem-claude' }]);
+    writeProcessed('totem', 'totem-claude', [NAME]);
+    expect(poll().warnings).toEqual([]);
+    const raw = poll({ includeProcessed: true });
+    expect(
+      raw.warnings.filter((w) => w.startsWith('cross-sender basename collision')),
+    ).toHaveLength(1);
+  });
+});
+
 // ─── Sort + metadata ────────────────────────────────────
 
 describe('pollMail — sort + metadata', () => {

--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -632,7 +632,12 @@ export function pollMail(opts: MailCommandOptions = {}): MailPollResult {
   // live collision blocks mark-compaction during exactly the coexistence
   // window in which one mark could strand the other dispatch, with zero new
   // gate plumbing. (Its `includeProcessed` discovery poll sees through marks,
-  // so a half-marked collision still reds the gate.)
+  // so a half-marked collision still reds the gate.) Detection is bounded by
+  // the scan window: a colliding file beyond the maxScan horizon is never
+  // parsed, so this sensor is reliable only within the scanned set — not an
+  // absolute guarantee. Truncation itself warns above and independently reds
+  // the compaction gate, so the bounded view never silently green-lights a
+  // compact.
   for (const [name, seats] of collisionsByBasename) {
     if (seats.size < 2) continue;
     const paths = [...seats.values()];

--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -573,6 +573,15 @@ export function pollMail(opts: MailCommandOptions = {}): MailPollResult {
   }
 
   const mail: MailEntry[] = [];
+  // Cross-sender basename-collision sensor (mmnto-ai/totem#2311, read-side
+  // half of mmnto-ai/totem-strategy#827): dispatch filenames don't encode the
+  // sender and `processed/` dedupe is basename-only, so two seats converging
+  // on one addressed-inbound basename means a single mark silently shadows
+  // BOTH dispatches. Keyed on the OUTBOX-OWNER seat (`slot.agent` —
+  // single-writer filesystem truth), never the forgeable `from:` header, so
+  // one seat's broadcast fan-out copies across repos can never fire it.
+  // basename → (owner-seat lowercased → `repo/agent` display path).
+  const collisionsByBasename = new Map<string, Map<string, string>>();
   const inScope = ordered.length > maxScan ? ordered.slice(0, maxScan) : ordered;
   for (const { slot, file } of inScope) {
     scanned += 1;
@@ -598,6 +607,13 @@ export function pollMail(opts: MailCommandOptions = {}): MailPollResult {
     const header = parsed.header;
     const toLower = header.to.toLowerCase();
     if (toLower !== 'broadcast' && !selfLower.has(toLower)) continue;
+    const senderSeat = slot.agent.toLowerCase();
+    let seats = collisionsByBasename.get(file);
+    if (seats === undefined) {
+      seats = new Map();
+      collisionsByBasename.set(file, seats);
+    }
+    if (!seats.has(senderSeat)) seats.set(senderSeat, `${slot.repo}/${slot.agent}`);
     mail.push({
       file,
       repo: slot.repo,
@@ -607,6 +623,22 @@ export function pollMail(opts: MailCommandOptions = {}): MailPollResult {
       subject: header.subject ?? '(no subject)',
       filePath: path.join(slot.outbox, file),
     });
+  }
+
+  // Warn once per colliding basename, naming every seat path. Sensor, not
+  // actuator (Tenet 13): both dispatches still surface as mail above. Riding
+  // the `warnings` channel is load-bearing — `ecl-gc --compact` arms its A2.2
+  // completeness gate on `warnings.length === 0` (mmnto-ai/totem#2309), so a
+  // live collision blocks mark-compaction during exactly the coexistence
+  // window in which one mark could strand the other dispatch, with zero new
+  // gate plumbing. (Its `includeProcessed` discovery poll sees through marks,
+  // so a half-marked collision still reds the gate.)
+  for (const [name, seats] of collisionsByBasename) {
+    if (seats.size < 2) continue;
+    const paths = [...seats.values()];
+    warnings.push(
+      `cross-sender basename collision: ${name} from ${paths.join(' and ')} — a single processed/ mark would shadow ${seats.size === 2 ? 'both' : `all ${seats.size}`}`,
+    );
   }
 
   // Re-sort the surviving mail by frontmatter date when available (filename


### PR DESCRIPTION
## What

Cross-sender basename-collision sensor in `pollMail` — the read-side half of mmnto-ai/totem-strategy#827, shape as blessed on the issue (owner disposition re-verified unmoved before build; doctrine half is strategy#829, not this PR).

When two **distinct sender seats** converge on one **addressed-inbound basename** in a single poll, emit one structured warning per colliding basename naming every `repo/agent` sender path:

```
cross-sender basename collision: <name> from <repo/agentA> and <repo/agentB> — a single processed/ mark would shadow both
```

## Design points

- **Existing `warnings` channel, no new contract.** No `MailPollResult` shape change. This is load-bearing: `ecl-gc --compact` arms its A2.2 completeness gate on `poll.warnings.length === 0` (#2309) and its discovery poll reads through marks (`includeProcessed`, A2.1) — so a live collision automatically blocks mark-compaction during exactly the coexistence window in which a compact could strand the shadowed dispatch. Zero new gate plumbing (C20 locks the composition).
- **Keyed on the outbox-owner seat, not `from:`.** Under single-writer discipline the outbox dir is filesystem truth; `from:` is a forgeable self-declaration. One seat's broadcast fan-out copies across repos never fire it (a single mark shadowing copies of one dispatch is correct handled-semantics); two seats with an identical forged `from:` still do.
- **Sensor, not actuator (Tenet 13).** Warn-only; both dispatches still surface as unread. Reader-poll coverage is the coexistence window by design (a mark hides both at pass 1) — the compaction view stays collision-aware regardless, and encode-`<sender>`-in-filename remains the escalation path on strategy#827.
- Detection is pure bookkeeping over already-parsed entries: no new I/O, no new throw paths, function-local state only.

Full design doc (data model, lifecycle, failure-mode table, invariants) in `.totem/specs/2311-mail-collision-sensor.md`, which also documents why the generated spec's `MailCollision` typed-contract approach was rejected (it would bypass the gate composition).

## Verification

- TDD: 7 new `pollMail` tests written first (RED: 5 failed pre-implementation), now green — fire, broadcast+directed mix, same-seat fan-out non-fire, forge-defense keying both directions, not-addressed non-fire, 3-seat single-warning, reader-vs-compaction visibility boundary.
- `ecl-gc` C20 composition test: planted collision with one side marked → gate red, all deletes blocked, swept mark retained (uncertain ⇒ retain).
- Full workspace: `pnpm build` ✓, `pnpm test` ✓ (10/10 tasks), `format:check` ✓, `pnpm lint` (ESLint) ✓.
- `totem lint --base main`: PASS, 0 errors (26 warn-tier hits, all the #2063 test-idiom/changeset-prose false-positive class). `totem review`: PASS, no findings.
- Live end-to-end: planted a two-seat collision in a scratch workspace, drove `totem mail` via the built CLI — warning renders on the text surface and both dispatches still list as unread.

Changeset: `@mmnto/cli` minor.

Closes #2311

🤖 Generated with [Claude Code](https://claude.com/claude-code)
