### PR TITLE
test(integration): re-author shield-eval deterministic trap test against totem lint (#2320)

### DIFF
--- a/.totem/specs/2320.md
+++ b/.totem/specs/2320.md
@@ -1,6 +1,6 @@
 ### Problem Statement
 
-The deterministic `shield` integration test is masking a config resolution failure because it relies on a loose `exit(1)` assertion that passes when a missing-config error occurs, instead of failing on the intended planted traps. We need to explicitly seed a minimal `totem.config.json` in the test fixture, bypass the deprecated redirect chain by calling `totem lint` directly, and tighten the assertions to guarantee the exit code stems from trap detection.
+The deterministic `shield` integration test is masking a config resolution failure because it relies on a loose `exit(1)` assertion that passes when a missing-config error occurs, instead of failing on the intended planted traps. We need to explicitly seed a minimal `totem.config.ts` in the test fixture, bypass the deprecated redirect chain by calling `totem lint` directly, and tighten the assertions to guarantee the exit code stems from trap detection.
 
 ### Architectural Context
 
@@ -13,14 +13,14 @@ This drift is a consequence of the zero-trust substrate and compile-hardening in
 ### Technical Approach & Contracts
 
 1. **Assertion Tightening:** Reorder the test assertions so that stdout/stderr is evaluated _before_ the exit code. We must explicitly assert that the output contains the expected traps (`TRAP-001`) and does _not_ contain the config error (`No Totem configuration found`).
-2. **Configuration Seeding:** Before executing the subprocess in the test block, write a minimal `totem.config.json` (e.g., `{}`) to the adversarial fixture's root. Review the sibling Gemini test (around line 327) to copy the exact minimal JSON payload it uses to satisfy the config parser.
+2. **Configuration Seeding:** Before executing the subprocess in the test block, write a minimal `totem.config.ts` (a TypeScript module — `export default { targets: [...] }`; an empty object fails the schema, which requires at least one target) to the adversarial fixture's root. Review the sibling Gemini test (around line 327) to copy the exact minimal payload shape it uses to satisfy the config parser.
 3. **Bypass Deprecation:** Update the child process command to invoke `node dist/index.js lint --staged` directly, rather than relying on `shield --deterministic --staged`.
 
 ### Edge Cases & Traps
 
 - **Process Throw on Non-Zero Exit:** When using shell execution (like `safeExec` or `execSync`), an exit code of 1 will throw. The test must catch the error and extract `stdout`/`stderr` from the error object to run the assertions, rather than assuming a successful return.
 - **Assertion Ordering:** If `expect(exitCode).toBe(1)` occurs before output assertions, a test failure due to missing config will result in a confusing diff on the secondary assertion. Always assert the specific output _first_.
-- **Asynchronous File Writes:** Ensure the `totem.config.json` write is synchronous (`fs.writeFileSync`) or explicitly awaited before spawning the CLI process to prevent race conditions.
+- **Asynchronous File Writes:** Ensure the `totem.config.ts` write is synchronous (`fs.writeFileSync`) or explicitly awaited before spawning the CLI process to prevent race conditions.
 
 ### Implementation Tasks
 
@@ -32,7 +32,7 @@ This drift is a consequence of the zero-trust substrate and compile-hardening in
 
 - [ ] **Task 2: Seed Configuration & Update Command**
   - Modify `packages/cli/src/commands/shield-eval.integration.test.ts`.
-  - Within the test block (or extending `scaffoldAdversarialRepo` if it safely applies to all tests), synchronously write a minimal `totem.config.json` to the temporary directory. Copy the schema used by the sibling Gemini test (e.g., `fs.writeFileSync(path.join(tmpDir, 'totem.config.json'), '{}')`).
+  - Within the test block (or extending `scaffoldAdversarialRepo` if it safely applies to all tests), synchronously write a minimal `totem.config.ts` to the temporary directory. Copy the shape used by the sibling Gemini test, minus the optional `orchestrator` block (e.g., `fs.writeFileSync(path.join(tmpDir, 'totem.config.ts'), "export default { targets: [{ glob: 'src/**/*.ts', type: 'code', strategy: 'typescript-ast' }], totemDir: '.totem', lanceDir: '.lancedb' }")`).
   - Update the subprocess execution command from `shield --deterministic --staged` to `lint --staged`.
   - write test (or update existing) → verify fails → implement → verify passes → lint
 

--- a/.totem/specs/2320.md
+++ b/.totem/specs/2320.md
@@ -1,20 +1,25 @@
 ### Problem Statement
+
 The deterministic `shield` integration test is masking a config resolution failure because it relies on a loose `exit(1)` assertion that passes when a missing-config error occurs, instead of failing on the intended planted traps. We need to explicitly seed a minimal `totem.config.json` in the test fixture, bypass the deprecated redirect chain by calling `totem lint` directly, and tighten the assertions to guarantee the exit code stems from trap detection.
 
 ### Architectural Context
+
 This drift is a consequence of the zero-trust substrate and compile-hardening introduced in the `1.14.x` / `1.15.0` releases. `totem lint` (which `shield --deterministic` redirects to) now mandates an explicit configuration to resolve the project context. The redirect chain masked this new constraint until the smoke sensor was revived.
 
 ### Files to Examine
+
 1. `packages/cli/src/commands/shield-eval.integration.test.ts` — Contains the failing test (lines 307-320) and the adversarial fixture setup (`scaffoldAdversarialRepo`).
 
 ### Technical Approach & Contracts
-1. **Assertion Tightening:** Reorder the test assertions so that stdout/stderr is evaluated *before* the exit code. We must explicitly assert that the output contains the expected traps (`TRAP-001`) and does *not* contain the config error (`No Totem configuration found`). 
+
+1. **Assertion Tightening:** Reorder the test assertions so that stdout/stderr is evaluated _before_ the exit code. We must explicitly assert that the output contains the expected traps (`TRAP-001`) and does _not_ contain the config error (`No Totem configuration found`).
 2. **Configuration Seeding:** Before executing the subprocess in the test block, write a minimal `totem.config.json` (e.g., `{}`) to the adversarial fixture's root. Review the sibling Gemini test (around line 327) to copy the exact minimal JSON payload it uses to satisfy the config parser.
 3. **Bypass Deprecation:** Update the child process command to invoke `node dist/index.js lint --staged` directly, rather than relying on `shield --deterministic --staged`.
 
 ### Edge Cases & Traps
+
 - **Process Throw on Non-Zero Exit:** When using shell execution (like `safeExec` or `execSync`), an exit code of 1 will throw. The test must catch the error and extract `stdout`/`stderr` from the error object to run the assertions, rather than assuming a successful return.
-- **Assertion Ordering:** If `expect(exitCode).toBe(1)` occurs before output assertions, a test failure due to missing config will result in a confusing diff on the secondary assertion. Always assert the specific output *first*.
+- **Assertion Ordering:** If `expect(exitCode).toBe(1)` occurs before output assertions, a test failure due to missing config will result in a confusing diff on the secondary assertion. Always assert the specific output _first_.
 - **Asynchronous File Writes:** Ensure the `totem.config.json` write is synchronous (`fs.writeFileSync`) or explicitly awaited before spawning the CLI process to prevent race conditions.
 
 ### Implementation Tasks
@@ -22,7 +27,7 @@ This drift is a consequence of the zero-trust substrate and compile-hardening in
 - [ ] **Task 1: Tighten Assertions (Failing State)**
   - Modify `packages/cli/src/commands/shield-eval.integration.test.ts`.
   - Locate the test: `deterministic shield exits 1 and catches planted traps via subprocess` (around line 307).
-  > TEST DIRECTIVE: Before implementing the fix, update the test to assert `expect(output).not.toContain('No Totem configuration found')` and `expect(output).toContain('TRAP-001')` BEFORE the `expect(exitCode).toBe(1)` assertion.
+    > TEST DIRECTIVE: Before implementing the fix, update the test to assert `expect(output).not.toContain('No Totem configuration found')` and `expect(output).toContain('TRAP-001')` BEFORE the `expect(exitCode).toBe(1)` assertion.
   - write test (or update existing) → verify fails → implement (Task 2) → verify passes → lint
 
 - [ ] **Task 2: Seed Configuration & Update Command**
@@ -32,6 +37,7 @@ This drift is a consequence of the zero-trust substrate and compile-hardening in
   - write test (or update existing) → verify fails → implement → verify passes → lint
 
 ### Execution Flow (structural constraint)
+
 ```dot
 digraph workflow {
   spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
@@ -43,12 +49,15 @@ digraph workflow {
 ```
 
 ### Verification (MANDATORY — do not skip)
+
 Every implementation MUST end with these steps:
+
 1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
 2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
 3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
 
 ### Test Plan
+
 - Run `pnpm test shield-eval.integration.test.ts`.
 - The test must pass, validating that `totem lint --staged` correctly identifies `TRAP-001` in the adversarial fixture.
 - Temporarily sabotage the planted trap file in `scaffoldAdversarialRepo`; the test should fail because `TRAP-001` is not found in the output, proving the assertions are robust. Undo the sabotage.

--- a/.totem/specs/2320.md
+++ b/.totem/specs/2320.md
@@ -1,0 +1,54 @@
+### Problem Statement
+The deterministic `shield` integration test is masking a config resolution failure because it relies on a loose `exit(1)` assertion that passes when a missing-config error occurs, instead of failing on the intended planted traps. We need to explicitly seed a minimal `totem.config.json` in the test fixture, bypass the deprecated redirect chain by calling `totem lint` directly, and tighten the assertions to guarantee the exit code stems from trap detection.
+
+### Architectural Context
+This drift is a consequence of the zero-trust substrate and compile-hardening introduced in the `1.14.x` / `1.15.0` releases. `totem lint` (which `shield --deterministic` redirects to) now mandates an explicit configuration to resolve the project context. The redirect chain masked this new constraint until the smoke sensor was revived.
+
+### Files to Examine
+1. `packages/cli/src/commands/shield-eval.integration.test.ts` — Contains the failing test (lines 307-320) and the adversarial fixture setup (`scaffoldAdversarialRepo`).
+
+### Technical Approach & Contracts
+1. **Assertion Tightening:** Reorder the test assertions so that stdout/stderr is evaluated *before* the exit code. We must explicitly assert that the output contains the expected traps (`TRAP-001`) and does *not* contain the config error (`No Totem configuration found`). 
+2. **Configuration Seeding:** Before executing the subprocess in the test block, write a minimal `totem.config.json` (e.g., `{}`) to the adversarial fixture's root. Review the sibling Gemini test (around line 327) to copy the exact minimal JSON payload it uses to satisfy the config parser.
+3. **Bypass Deprecation:** Update the child process command to invoke `node dist/index.js lint --staged` directly, rather than relying on `shield --deterministic --staged`.
+
+### Edge Cases & Traps
+- **Process Throw on Non-Zero Exit:** When using shell execution (like `safeExec` or `execSync`), an exit code of 1 will throw. The test must catch the error and extract `stdout`/`stderr` from the error object to run the assertions, rather than assuming a successful return.
+- **Assertion Ordering:** If `expect(exitCode).toBe(1)` occurs before output assertions, a test failure due to missing config will result in a confusing diff on the secondary assertion. Always assert the specific output *first*.
+- **Asynchronous File Writes:** Ensure the `totem.config.json` write is synchronous (`fs.writeFileSync`) or explicitly awaited before spawning the CLI process to prevent race conditions.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Tighten Assertions (Failing State)**
+  - Modify `packages/cli/src/commands/shield-eval.integration.test.ts`.
+  - Locate the test: `deterministic shield exits 1 and catches planted traps via subprocess` (around line 307).
+  > TEST DIRECTIVE: Before implementing the fix, update the test to assert `expect(output).not.toContain('No Totem configuration found')` and `expect(output).toContain('TRAP-001')` BEFORE the `expect(exitCode).toBe(1)` assertion.
+  - write test (or update existing) → verify fails → implement (Task 2) → verify passes → lint
+
+- [ ] **Task 2: Seed Configuration & Update Command**
+  - Modify `packages/cli/src/commands/shield-eval.integration.test.ts`.
+  - Within the test block (or extending `scaffoldAdversarialRepo` if it safely applies to all tests), synchronously write a minimal `totem.config.json` to the temporary directory. Copy the schema used by the sibling Gemini test (e.g., `fs.writeFileSync(path.join(tmpDir, 'totem.config.json'), '{}')`).
+  - Update the subprocess execution command from `shield --deterministic --staged` to `lint --staged`.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+Every implementation MUST end with these steps:
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+- Run `pnpm test shield-eval.integration.test.ts`.
+- The test must pass, validating that `totem lint --staged` correctly identifies `TRAP-001` in the adversarial fixture.
+- Temporarily sabotage the planted trap file in `scaffoldAdversarialRepo`; the test should fail because `TRAP-001` is not found in the output, proving the assertions are robust. Undo the sabotage.

--- a/packages/cli/src/commands/shield-eval.integration.test.ts
+++ b/packages/cli/src/commands/shield-eval.integration.test.ts
@@ -284,6 +284,7 @@ describe('Adversarial Eval — Deterministic', () => {
 // ─── LLM evaluation (nightly, requires API keys) ────
 
 const EVAL_TIMEOUT_MS = 120_000; // 2 min — LLM can be slow
+const LINT_TIMEOUT_MS = 30_000; // deterministic lint is local-only (~1.5s typical) — fail fast on hangs
 
 describe.runIf(process.env['CI_INTEGRATION'] === 'true')(
   'Adversarial Eval — LLM Model Drift',
@@ -307,6 +308,7 @@ describe.runIf(process.env['CI_INTEGRATION'] === 'true')(
     function runCli(
       args: string[],
       env: Record<string, string> = {},
+      timeoutMs: number = EVAL_TIMEOUT_MS,
     ): { stdout: string; stderr: string; exitCode: number } {
       const cliEntry = path.resolve('dist/index.js');
       const cmd = `node ${cliEntry} ${args.join(' ')}`;
@@ -315,7 +317,7 @@ describe.runIf(process.env['CI_INTEGRATION'] === 'true')(
         const stdout = execSync(cmd, {
           cwd: tmpDir,
           encoding: 'utf-8',
-          timeout: EVAL_TIMEOUT_MS,
+          timeout: timeoutMs,
           env: {
             ...process.env,
             ...env,
@@ -349,7 +351,7 @@ describe.runIf(process.env['CI_INTEGRATION'] === 'true')(
         `;
         fs.writeFileSync(path.join(tmpDir, 'totem.config.ts'), config);
 
-        const { exitCode, stdout, stderr } = runCli(['lint', '--staged']);
+        const { exitCode, stdout, stderr } = runCli(['lint', '--staged'], {}, LINT_TIMEOUT_MS);
         const output = stdout + stderr;
 
         // Output assertions first: a config-resolution failure also exits 1,
@@ -362,7 +364,7 @@ describe.runIf(process.env['CI_INTEGRATION'] === 'true')(
         expect(output).toContain('TRAP-004');
         expect(exitCode).toBe(1);
       },
-      EVAL_TIMEOUT_MS,
+      LINT_TIMEOUT_MS,
     );
 
     // Gemini model drift test

--- a/packages/cli/src/commands/shield-eval.integration.test.ts
+++ b/packages/cli/src/commands/shield-eval.integration.test.ts
@@ -2,8 +2,9 @@
  * Adversarial Evaluation Harness — Model Drift Detection
  *
  * Sets up a real git repository with planted architectural violations
- * and corresponding Totem lessons, then runs `totem shield` to verify
- * that both deterministic and LLM modes catch the planted traps.
+ * and corresponding Totem lessons, then runs the CLI (`totem lint` for
+ * the deterministic leg, `totem shield` for LLM modes) to verify that
+ * both catch the planted traps.
  *
  * Deterministic tests run on every CI run (no API keys needed).
  * LLM tests are gated behind CI_INTEGRATION=true (nightly only).
@@ -41,6 +42,26 @@ import { parseVerdict } from './shield.js';
 
 // ─── Adversarial Fixtures ────────────────────────────
 
+/**
+ * Synthetic legitimacy stamp for the trap rules. mmnto-ai/totem#2181 demoted
+ * un-stamped regex rules to advisory (printed, excluded from exit 1), so a
+ * BLOCKING regex rule must carry the ADR-110 §3 stamp: `legitimacy` with both
+ * controls passed plus the derived `ruleClass: 'hard'` — the pair is
+ * parse-enforced by the #2183 superRefine, which this fixture exercises via
+ * subprocess. Provenance values are schema-valid placeholders; the fixture is
+ * synthetic by design.
+ */
+const FIXTURE_LEGITIMACY = {
+  provenance: {
+    mergedPr: 196,
+    reviewThread:
+      'synthetic adversarial fixture — mmnto-ai/totem#196 harness, re-authored in #2320',
+    commitSha: '0000000000000000000000000000000000000000',
+  },
+  positiveControl: true,
+  negativeControl: true,
+};
+
 /** Planted trap rules that map to specific violations in the bad code. */
 const TRAP_RULES: CompiledRule[] = [
   {
@@ -50,6 +71,8 @@ const TRAP_RULES: CompiledRule[] = [
     message: 'TRAP-001: Never import fs directly — use fs/promises for async safety',
     engine: 'regex' as const,
     compiledAt: new Date().toISOString(),
+    legitimacy: FIXTURE_LEGITIMACY,
+    ruleClass: 'hard' as const,
   },
   {
     lessonHash: hashLesson('No console.log in library code', 'TRAP-002'),
@@ -58,6 +81,8 @@ const TRAP_RULES: CompiledRule[] = [
     message: 'TRAP-002: Use structured logger, not console.log, in library code',
     engine: 'regex' as const,
     compiledAt: new Date().toISOString(),
+    legitimacy: FIXTURE_LEGITIMACY,
+    ruleClass: 'hard' as const,
   },
   {
     lessonHash: hashLesson('Catch blocks use err not error', 'TRAP-003'),
@@ -66,6 +91,8 @@ const TRAP_RULES: CompiledRule[] = [
     message: 'TRAP-003: Use err (not error) in catch blocks — project convention',
     engine: 'regex' as const,
     compiledAt: new Date().toISOString(),
+    legitimacy: FIXTURE_LEGITIMACY,
+    ruleClass: 'hard' as const,
   },
   {
     lessonHash: hashLesson('No sync file reads', 'TRAP-004'),
@@ -74,6 +101,8 @@ const TRAP_RULES: CompiledRule[] = [
     message: 'TRAP-004: Use async readFile, not readFileSync, in request handlers',
     engine: 'regex' as const,
     compiledAt: new Date().toISOString(),
+    legitimacy: FIXTURE_LEGITIMACY,
+    ruleClass: 'hard' as const,
   },
 ];
 
@@ -271,15 +300,16 @@ describe.runIf(process.env['CI_INTEGRATION'] === 'true')(
     });
 
     /**
-     * Run shield as a subprocess against the adversarial repo.
+     * Run the CLI as a subprocess against the adversarial repo. Args
+     * include the subcommand (e.g. `['lint', '--staged']`).
      * Returns stdout, stderr, and exit code.
      */
-    function runShield(
+    function runCli(
       args: string[],
       env: Record<string, string> = {},
     ): { stdout: string; stderr: string; exitCode: number } {
       const cliEntry = path.resolve('dist/index.js');
-      const cmd = `node ${cliEntry} shield ${args.join(' ')}`;
+      const cmd = `node ${cliEntry} ${args.join(' ')}`;
 
       try {
         const stdout = execSync(cmd, {
@@ -305,16 +335,32 @@ describe.runIf(process.env['CI_INTEGRATION'] === 'true')(
     }
 
     it(
-      'deterministic shield exits 1 and catches planted traps via subprocess',
+      'deterministic lint exits 1 and catches planted traps via subprocess',
       () => {
-        const { exitCode, stdout, stderr } = runShield(['--deterministic', '--staged']);
+        // `totem lint` hard-requires a config before scanning
+        // (mmnto-ai/totem#2320) — same shape as the LLM tests below, minus
+        // the orchestrator (optional; deterministic lint never invokes an LLM).
+        const config = `
+          export default {
+            targets: [{ glob: 'src/**/*.ts', type: 'code', strategy: 'typescript-ast' }],
+            totemDir: '.totem',
+            lanceDir: '.lancedb',
+          };
+        `;
+        fs.writeFileSync(path.join(tmpDir, 'totem.config.ts'), config);
+
+        const { exitCode, stdout, stderr } = runCli(['lint', '--staged']);
         const output = stdout + stderr;
 
-        expect(exitCode).toBe(1);
+        // Output assertions first: a config-resolution failure also exits 1,
+        // so the exit code alone cannot prove the traps were scanned
+        // (mmnto-ai/totem#2320).
+        expect(output).not.toContain('No Totem configuration found');
         expect(output).toContain('TRAP-001');
         expect(output).toContain('TRAP-002');
         expect(output).toContain('TRAP-003');
         expect(output).toContain('TRAP-004');
+        expect(exitCode).toBe(1);
       },
       EVAL_TIMEOUT_MS,
     );
@@ -334,7 +380,7 @@ describe.runIf(process.env['CI_INTEGRATION'] === 'true')(
         `;
         fs.writeFileSync(path.join(tmpDir, 'totem.config.ts'), config);
 
-        const { exitCode, stdout, stderr } = runShield(['--staged', '--mode=structural'], {
+        const { exitCode, stdout, stderr } = runCli(['shield', '--staged', '--mode=structural'], {
           GEMINI_API_KEY: process.env['GEMINI_API_KEY']!,
         });
         const output = stdout + stderr;
@@ -363,7 +409,7 @@ describe.runIf(process.env['CI_INTEGRATION'] === 'true')(
         `;
         fs.writeFileSync(path.join(tmpDir, 'totem.config.ts'), config);
 
-        const { exitCode, stdout, stderr } = runShield(['--staged', '--mode=structural'], {
+        const { exitCode, stdout, stderr } = runCli(['shield', '--staged', '--mode=structural'], {
           ANTHROPIC_API_KEY: process.env['ANTHROPIC_API_KEY']!,
         });
         const output = stdout + stderr;
@@ -391,7 +437,7 @@ describe.runIf(process.env['CI_INTEGRATION'] === 'true')(
         `;
         fs.writeFileSync(path.join(tmpDir, 'totem.config.ts'), config);
 
-        const { exitCode, stdout, stderr } = runShield(['--staged', '--mode=structural'], {
+        const { exitCode, stdout, stderr } = runCli(['shield', '--staged', '--mode=structural'], {
           OPENAI_API_KEY: process.env['OPENAI_API_KEY']!,
         });
         const output = stdout + stderr;


### PR DESCRIPTION
Closes #2320

## What

Re-authors the shield-eval deterministic subprocess test against the current CLI surface. The revived Integration Smoke Tests workflow (#2317 / PR #2318) exposed this as its sole remaining red: the test drove the doubly-deprecated `shield --deterministic` → `review` → `lint` redirect chain, died at config resolution in CI, and its loose `expect(exitCode).toBe(1)` passed **for the wrong reason** (config error, not trap findings) while the trap assertions failed.

Two distinct drifts had accrued in the 6-week dead-sensor window — the issue documented the first; the re-author surfaced the second live:

1. **Config hard-requirement.** The lint path calls `resolveConfigPath(cwd)` before any scanning; the tmpdir fixture has no config and CI runners have no global `~/.totem` fallback → `CONFIG_MISSING` hard error.
2. **Regex-advisory demotion (#2181/#2183).** Un-stamped regex rules are now advisory — printed but excluded from the exit-1 tally. With only drift 1 fixed, all four `TRAP-*` messages appear in output but lint exits **0**: the planted traps no longer blocked.

## How

- **Drive `totem lint --staged` directly** instead of the deprecated redirect chain (the issue's recommended option) — the deterministic trap-catching surface is lint; the eval should exercise it without riding two deprecation shims.
- **Seed a minimal `totem.config.ts` in the fixture** (same shape as the sibling LLM tests, minus the optional `orchestrator` — deterministic lint never invokes an LLM). This also makes the test hermetic: on a dev box with a global `~/.totem` profile the old test silently took the global-fallback arm instead of erroring.
- **Stamp the four trap rules with ADR-110 §3 legitimacy + `ruleClass: 'hard'`** so they block under the #2181 demotion. The stamp pair is parse-enforced by the #2183 superRefine inside `loadCompiledRules`, so the subprocess now also exercises that tamper-evident boundary; provenance values are schema-valid synthetic placeholders, documented as such.
- **Tighten assertions**: `not.toContain('No Totem configuration found')` plus all four `TRAP-*` assertions run **before** the exit-code assertion, so a config-resolution failure (or any non-scan exit 1) can no longer satisfy the test.
- Generalized the `runShield` helper to `runCli` (args carry the subcommand); the three LLM call sites now pass `shield` explicitly. No behavior change for the LLM legs.

## Verification

- `CI_INTEGRATION=true pnpm --filter @mmnto/cli exec vitest run -c vitest.integration.config.ts shield-eval` → 5 passed, 3 LLM legs skipped (no keys).
- Sabotage check: with config seeding disabled, the test fails loudly at the trap assertion instead of passing on exit code (locally the no-config state falls back to the global profile — the CI config-error arm was proven RED live in run 28909703371, which the new `not.toContain` assertion targets directly).
- Intermediate state proof: before the hard-stamp change, the run failed at `expect(exitCode).toBe(1)` with exit 0 while all four traps printed — drift 2's exact signature.
- Gates: `totem lint --base main` PASS (0 errors), `totem review` PASS (no findings), ESLint 0 errors, repo-wide `format:check` clean, full workspace build green, pre-push hook battery (6362 unit tests) green.

## Notes

- Test-only change — no changeset (no consumer-facing surface moves).
- Once merged, the Integration Smoke Tests workflow should post its first fully-green scheduled run since 2026-05-24; suggest a `workflow_dispatch` verification on this branch before merge (mirrors the #2318 verification pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
