### PR TITLE
feat(doctor): --parity trust-readout — verdict rollup, coverage denominator, why-not, --json artifact, --strict honesty (#2327)

### DIFF
--- a/.changeset/parity-trust-readout.md
+++ b/.changeset/parity-trust-readout.md
@@ -1,0 +1,7 @@
+---
+'@mmnto/cli': minor
+---
+
+feat(doctor): `--parity` trust-readout — verdict rollup (per-seat + global), run-time coverage denominator (mechanical / attestation-only / honest-absent), why-not per non-PASS row at the senses level probed, `--json` verdict artifact, and the `--strict` declaredly-toothless honesty line (Prop 303 §5(a) spec-to-build, mmnto-ai/totem#2327).
+
+Consumer-impact: CLI surface — `totem doctor` gains a `--json` flag (valid only with `--parity`; `doctor --json` without it now errors explicitly instead of silently ignoring the flag), and `doctor --parity` output gains the trust-readout tail after the per-row lines. Exit-code semantics are unchanged (`--strict` still exits non-zero iff a blocking contract drifted). Scripts that parse `doctor --parity` stdout/stderr line-by-line should anchor on the per-row `[Parity]` lines, which are byte-compatible; the readout is additive.

--- a/.totem/specs/2327.md
+++ b/.totem/specs/2327.md
@@ -1,0 +1,161 @@
+### Problem Statement
+
+The `doctor --parity` command currently emits a flat per-row dump that lacks clear summary metrics and gating context. It must be refactored to emit a highly structured post-processed readout containing explicit verdict rollups (per-seat and global), precise coverage denominators, contextual "why-not" reasons for non-PASS rows, a `--json` artifact mode, and explicitly truthful `--strict` honesty bounds (declaring what it actually gates versus what is just an unenforced presence check).
+
+### Architectural Context
+
+None found in provided context that directly constrains this spec. (The `--strict` behavior extends the existing Proposal 273/279 semantics already present in `ParityCliOptions` to be more transparent about its true gating boundaries without adding new detectors).
+
+### Files to Examine
+
+1. `packages/cli/src/commands/doctor-parity.ts` — Contains `ParityCliOptions`, `checkParity`, and `doctorParityCliCommand`. This is where the schema definitions, mapping logic, and output formatting must be added.
+2. `packages/cli/src/ui.js` — (Reference only) To check available logging and formatting functions (`bold`, `errorColor`, `successColor`, `warnColor`) for the human-readable readout.
+3. `packages/cli/src/commands/__tests__/doctor-parity.test.ts` — The test file that must be updated to cover the new post-processing functions and CLI output modes.
+
+### Technical Approach & Contracts
+
+We will implement a map-reduce post-processor for the `ParityCheckResult` rows, separating the computation from the presentation layer to support both human-readable UI rendering and `--json` outputs deterministically.
+
+**1. Data Contracts (Zod Schemas & Types)**
+Add the following to `doctor-parity.ts` to govern the JSON output shape:
+
+```typescript
+import { z } from 'zod';
+
+export const ParityVerdictSchema = z.enum([
+  'pass',
+  'warn',
+  'skip',
+  'unknown',
+  'fail',
+  'skipped-not-gated',
+]);
+export const ParityCoverageTypeSchema = z.enum(['sensed', 'attested', 'absent']);
+
+export const ParityRowVerdictSchema = z.object({
+  id: z.string(),
+  seat: z.string().optional(),
+  verdict: ParityVerdictSchema,
+  coverageType: ParityCoverageTypeSchema,
+  probeLevel: z.enum(['declared', 'present', 'loaded', 'usable']),
+  whyNot: z.string().optional(),
+  attestationAge: z.number().optional(),
+  blocking: z.boolean().default(false),
+});
+
+export const ParityVerdictArtifactSchema = z.object({
+  coverage: z.object({
+    sensed: z.number(),
+    attested: z.number(),
+    absent: z.number(),
+    totalDeclared: z.number(),
+  }),
+  rollups: z.object({
+    global: z.record(ParityVerdictSchema, z.number()),
+    bySeat: z.record(z.string(), z.record(ParityVerdictSchema, z.number())),
+  }),
+  rows: z.array(ParityRowVerdictSchema),
+  strictGated: z.boolean(),
+  strictHonestyDisclaimer: z.string().optional(),
+});
+
+export type ParityVerdictArtifact = z.infer<typeof ParityVerdictArtifactSchema>;
+```
+
+Update `ParityCliOptions` to include `json?: boolean`.
+
+**2. Computation Logic (`buildVerdictArtifact`)**
+Create a pure function that takes `ParityCheckResult` and `options.strict`:
+
+- **Coverage Denominator:** Categorize and count rows into `sensed` (mechanically verified), `attested` (manual attestation age), or `absent`.
+- **Verdict Mapping:**
+  - If `strict` is true and a row is `warn` with `blocking: true` -> promote to `fail`.
+  - If a row is skipped due to scoping but has `blocking: true` -> map to `skipped-not-gated`.
+- **Why-Not Extraction:** Populate `whyNot` with the probe level (if non-PASS) or attestation age (if attested).
+- **Rollups:** Aggregate counters globally and group them by `row.seat`.
+- **Strict Honesty:** If `strict` is enabled but no `fail` or `skipped-not-gated` rows exist, populate `strictHonestyDisclaimer` with a "declaredly-toothless" statement.
+
+**3. Presentation & Execution Logic**
+
+- **JSON Mode:** If `options.json`, run `console.log(JSON.stringify(artifact, null, 2))`.
+- **Human Mode:**
+  - Print rows: Name, Verdict, Why-Not. (Do NOT render a presence-PASS as "enforced").
+  - Print Coverage Denominator exactly as: `X mechanically sensed / Y attestation-only / Z honest-absent`.
+  - Print Rollups (Per-seat block first, then Global).
+  - Print Honesty Disclaimer explicitly if generated.
+- **Exit Handling:** Check the artifact for any `fail` verdicts. Throw `TotemError` _only after_ the JSON/Human output is fully flushed to stdout.
+
+### Edge Cases & Traps
+
+- **JSON Output Mutilation:** If a `TotemError` is thrown before `console.log` completes, the `--json` output requirement is violated and the caller gets a stack trace instead of the diffable artifact. JSON output must precede throwing.
+- **Global Rollup Masking Skips:** A global summary might show `pass: 10, skip: 0` while a specific seat was entirely skipped. The by-seat rollup must explicitly be rendered to prevent masking broken consumer topologies.
+- **Silent Passes on Skipping:** Scoped out blocking detectors must emit `skipped-not-gated`, never `skip` or `pass`.
+- **Zero Denominators:** If there are 0 attested rows, the coverage string must still print `... / 0 attestation-only / ...` to assert the boundary claim.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Define Contracts and Options**
+  - **Files:** `packages/cli/src/commands/doctor-parity.ts`, `packages/cli/src/commands/__tests__/doctor-parity.test.ts`
+  - **Steps:**
+    - Update `ParityCliOptions` interface to include `json?: boolean`.
+    - Define and export `ParityVerdictSchema`, `ParityCoverageTypeSchema`, `ParityRowVerdictSchema`, and `ParityVerdictArtifactSchema`.
+  - > TEST DIRECTIVE: Before implementing, write a failing test named `exports ParityVerdictArtifactSchema and accepts json flag` that proves the schema exists and correctly parses a mock valid artifact object.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Build Post-Processing Pure Function**
+  - **Files:** `packages/cli/src/commands/doctor-parity.ts`, `packages/cli/src/commands/__tests__/doctor-parity.test.ts`
+  - **Steps:**
+    - Implement `export function buildVerdictArtifact(result: ParityCheckResult, isStrict: boolean): ParityVerdictArtifact`.
+    - Calculate coverage buckets (`sensed`, `attested`, `absent`).
+    - Map rows to final verdicts (handling strict `fail` promotion and `skipped-not-gated`).
+    - Generate global and per-seat rollups based on the mapped verdicts.
+  - > TEST DIRECTIVE: Before implementing, write a failing test named `buildVerdictArtifact computes coverage denominators and promotes strict failures` that proves strict `warn` with `blocking` becomes `fail`, and scoped skipping of blocking becomes `skipped-not-gated`.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Implement JSON Output & Safe Exit Flow**
+  - **Files:** `packages/cli/src/commands/doctor-parity.ts`, `packages/cli/src/commands/__tests__/doctor-parity.test.ts`
+  - **Steps:**
+    - In `doctorParityCliCommand`, invoke `buildVerdictArtifact`.
+    - If `options.json`, log the stringified JSON artifact to `console.log`.
+    - Evaluate if any global rollup mapped to `fail`. If true and `options.strict` is enabled, throw a `TotemError` _only after_ the JSON log has occurred.
+  - > TEST DIRECTIVE: Before implementing, write a failing test named `emits JSON artifact to stdout before throwing TotemError on strict fail` that spies on `console.log` to prove the order of operations prevents JSON mutilation.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Implement Human-Readable Rendering & Strict Honesty**
+  - **Files:** `packages/cli/src/commands/doctor-parity.ts`, `packages/cli/src/commands/__tests__/doctor-parity.test.ts`
+  - **Steps:**
+    - In `doctorParityCliCommand`, if `!options.json`, use `ui.js` colors to format the output.
+    - Loop over rows to print non-PASS verdicts with their `whyNot` strings.
+    - Print the precise Coverage Denominator line (X / Y / Z).
+    - Print the Rollups (iterating over `bySeat` first, then `global`).
+    - If `options.strict` was requested but `strictGated` is false, print the `strictHonestyDisclaimer`.
+  - > TEST DIRECTIVE: Before implementing, write a failing test named `renders human readable coverage denominator and strict honesty disclaimer` that asserts the exact strings "mechanically sensed", "attestation-only", and the honesty disclaimer are dispatched to the logger.
+  - write test → verify fails → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — AI-powered architectural review (~18s). Addresses any critical findings.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Strict Promotion:** Assert that a `warn` on a `blocking: true` row maps to a `fail` when `--strict` is enabled, ultimately throwing a `TotemError`.
+- **Skipped-Not-Gated:** Assert that a `skip` on a `blocking: true` row evaluates to `skipped-not-gated` and successfully registers in both the global and per-seat rollup aggregates.
+- **Coverage Denominator Completeness:** Assert that a mock array containing 2 sensed, 0 attested, and 1 absent row explicitly prints `2 mechanically sensed / 0 attestation-only / 1 honest-absent`.
+- **JSON Mutilation Safety:** Spy on `console.log` and verify it completely writes the JSON artifact before `doctorParityCliCommand` throws the `TotemError` during a `--strict --json` failure.
+- **Presence-PASS Exclusivity:** Assert that a row with `probeLevel: 'present'` and `verdict: 'pass'` does not append enforcement language in the human-readable `why-not` output.

--- a/.totem/specs/2327.md
+++ b/.totem/specs/2327.md
@@ -1,3 +1,5 @@
+> **As-built note:** point-in-time pre-build planning artifact — the shipped build deliberately diverges (no Zod schema on the output artifact; `skipped-not-gated` is NOT a verdict enum value, which would violate R1's no-second-enum). Truth lives in the merged spec (`doctrine/parity-manifest.md` § trust-readout) and `doctor-parity.ts`'s `buildParityReadout`.
+
 ### Problem Statement
 
 The `doctor --parity` command currently emits a flat per-row dump that lacks clear summary metrics and gating context. It must be refactored to emit a highly structured post-processed readout containing explicit verdict rollups (per-seat and global), precise coverage denominators, contextual "why-not" reasons for non-PASS rows, a `--json` artifact mode, and explicitly truthful `--strict` honesty bounds (declaring what it actually gates versus what is just an unenforced presence check).

--- a/packages/cli/src/commands/doctor-parity.test.ts
+++ b/packages/cli/src/commands/doctor-parity.test.ts
@@ -1443,6 +1443,19 @@ describe('buildParityReadout (#2327)', () => {
     expect(byId.get('mcp-corpus-indexing')!.reasonClass).toBe('honest-absent');
   });
 
+  it('R3: an unparseable consumer file yields unknown → detector-error (CR #2328 round 1)', async () => {
+    writeReadoutFixture();
+    // Unterminated flow mapping — the value-equality detector degrades to an
+    // honest `unknown` (equality unprovable either way), never a throw.
+    fs.writeFileSync(path.join(tmpDir, '.coderabbit.yaml'), 'reviews: {\n', 'utf-8');
+    const { results, blockingDriftIds, readout } = await checkParity(tmpDir);
+    const built = buildParityReadout(readout!, results, blockingDriftIds, false);
+    const row = built.rows.find((r) => r.id === 'cr-profile')!;
+    expect(row.verdict).toBe('unknown');
+    expect(row.reasonClass).toBe('detector-error');
+    expect(built.rollup.global.unknown).toBe(1);
+  });
+
   it('R5: a blocking contract skipped by scoping renders skipped-not-gated, and the declared blocking set drives gates-anything', async () => {
     writeReadoutFixture();
     const { results, blockingDriftIds, readout } = await checkParity(tmpDir);

--- a/packages/cli/src/commands/doctor-parity.test.ts
+++ b/packages/cli/src/commands/doctor-parity.test.ts
@@ -1492,6 +1492,19 @@ describe('buildParityReadout (#2327)', () => {
 });
 
 describe('doctorParityCliCommand — --json verdict artifact (#2327 R4)', () => {
+  /** Structural shape of the R4 artifact for typed assertion access (kebab-case keys per spec). */
+  interface JsonArtifact {
+    'readout-schema-version': number;
+    manifest: Record<string, unknown>;
+    rollup: {
+      global: Record<string, number>;
+      'per-seat': Record<string, Record<string, number>>;
+    };
+    denominator: Record<string, unknown>;
+    strict: Record<string, unknown>;
+    rows: Array<Record<string, unknown>>;
+  }
+
   function captureStdout(): { writes: string[]; restore: () => void } {
     const writes: string[] = [];
     const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
@@ -1509,10 +1522,10 @@ describe('doctorParityCliCommand — --json verdict artifact (#2327 R4)', () => 
     } finally {
       cap.restore();
     }
-    const artifact = JSON.parse(cap.writes.join('')) as Record<string, any>;
+    const artifact = JSON.parse(cap.writes.join('')) as JsonArtifact;
     expect(artifact['readout-schema-version']).toBe(1);
-    expect(artifact['manifest']).toEqual({ 'schema-version': 1, status: 'scaffold' });
-    expect(artifact['rollup']['global']).toEqual({
+    expect(artifact.manifest).toEqual({ 'schema-version': 1, status: 'scaffold' });
+    expect(artifact.rollup.global).toEqual({
       pass: 0,
       warn: 0,
       info: 1,
@@ -1520,21 +1533,19 @@ describe('doctorParityCliCommand — --json verdict artifact (#2327 R4)', () => 
       skip: 3,
       fail: 0,
     });
-    expect(artifact['rollup']['per-seat']['claude']).toBeDefined();
-    expect(artifact['denominator']).toEqual({
+    expect(artifact.rollup['per-seat']['claude']).toBeDefined();
+    expect(artifact.denominator).toEqual({
       mechanical: 1,
       'attestation-only': 1,
       'honest-absent': 2,
       'claim-boundary': expect.stringContaining('manifest-declared contract set'),
     });
-    expect(artifact['strict']).toEqual({
+    expect(artifact.strict).toEqual({
       armed: false,
       'blocking-ids': ['gate-config'],
       'gates-anything': true,
     });
-    const attested = (artifact['rows'] as Array<Record<string, unknown>>).find(
-      (r) => r['id'] === 'doctrine-currency',
-    )!;
+    const attested = artifact.rows.find((r) => r['id'] === 'doctrine-currency')!;
     expect(attested['verdict']).toBe('info');
     expect(attested['reason-class']).toBe('attestation');
     expect(attested['last-attested']).toBe('2026-07-01');
@@ -1550,10 +1561,10 @@ describe('doctorParityCliCommand — --json verdict artifact (#2327 R4)', () => 
     } finally {
       cap.restore();
     }
-    const artifact = JSON.parse(cap.writes.join('')) as Record<string, any>;
-    expect(artifact['manifest']).toEqual({ status: 'not-configured' });
-    expect(artifact['rows']).toEqual([]);
-    expect(artifact['strict']).toEqual({
+    const artifact = JSON.parse(cap.writes.join('')) as JsonArtifact;
+    expect(artifact.manifest).toEqual({ status: 'not-configured' });
+    expect(artifact.rows).toEqual([]);
+    expect(artifact.strict).toEqual({
       armed: false,
       'blocking-ids': [],
       'gates-anything': false,
@@ -1579,11 +1590,9 @@ describe('doctorParityCliCommand — --json verdict artifact (#2327 R4)', () => 
     } finally {
       cap.restore();
     }
-    const artifact = JSON.parse(cap.writes.join('')) as Record<string, any>;
-    expect(artifact['rollup']['global']['fail']).toBe(1);
-    const row = (artifact['rows'] as Array<Record<string, unknown>>).find(
-      (r) => r['id'] === 'cr-profile',
-    )!;
+    const artifact = JSON.parse(cap.writes.join('')) as JsonArtifact;
+    expect(artifact.rollup.global['fail']).toBe(1);
+    const row = artifact.rows.find((r) => r['id'] === 'cr-profile')!;
     expect(row['verdict']).toBe('fail');
   });
 });

--- a/packages/cli/src/commands/doctor-parity.test.ts
+++ b/packages/cli/src/commands/doctor-parity.test.ts
@@ -1421,6 +1421,27 @@ describe('buildParityReadout (#2327)', () => {
     });
   });
 
+  it('R1: an EMPTY vendor-adapter list counts as vendor-neutral, never dropped from every seat (spec-owner review on #2328)', async () => {
+    writeReadoutFixture(
+      READOUT_MANIFEST_YAML.replace(
+        '    tractability: manual-attestation\n',
+        '    tractability: manual-attestation\n    vendor-adapter: []\n',
+      ),
+    );
+    const { results, blockingDriftIds, readout } = await checkParity(tmpDir);
+    const built = buildParityReadout(readout!, results, blockingDriftIds, false);
+    // The [] row (doctrine-currency, info) still lands on the claude seat —
+    // excluded-from-every-seat-but-counted-globally is the R1 honesty hole.
+    expect(built.rollup.perSeat['claude']).toEqual({
+      pass: 0,
+      warn: 0,
+      info: 1,
+      unknown: 0,
+      skip: 3,
+      fail: 0,
+    });
+  });
+
   it('R2: the denominator counts CONTRACTS by coverage class, never one collapsed number', async () => {
     writeReadoutFixture();
     const { results, blockingDriftIds, readout } = await checkParity(tmpDir);

--- a/packages/cli/src/commands/doctor-parity.test.ts
+++ b/packages/cli/src/commands/doctor-parity.test.ts
@@ -23,7 +23,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { hashLockArtifact, normalizeLockArtifact } from '@mmnto/totem';
 
 import { cleanTmpDir } from '../test-utils.js';
-import { checkParity, doctorParityCliCommand } from './doctor-parity.js';
+import { buildParityReadout, checkParity, doctorParityCliCommand } from './doctor-parity.js';
 import {
   CLAUDE_SESSION_START,
   DISTRIBUTED_CLAUDE_SKILLS,
@@ -1290,5 +1290,300 @@ describe('checkParity - capability-probe routing (mmnto-ai/totem#2140)', () => {
     const line = results.find((r) => r.name.includes('knowledge-search-access'))!;
     expect(line.status).toBe('skip');
     expect(line.message).toMatch(/permits absence|not in consumers/i);
+  });
+});
+
+// ─── Trust-readout (mmnto-ai/totem#2327, Prop 303 §5(a)) ──────────
+
+// Four deterministic-in-a-tmpdir rows covering every coverage class + the
+// deltas raised against the spec (info in the vocabulary, rollup counts
+// verdict lines, `attestation` reason class):
+//   - doctrine-currency: manual-attestation, no package ⇒ always `info`
+//     (attestation-only coverage; carries last-attested for the age render).
+//   - cr-profile: value-equality, .coderabbit.yaml absent ⇒ deterministic
+//     scaffold `skip` (mechanical coverage, senses 'declared').
+//   - gate-config: consumers-scoped out of the tmpdir + blocking: true +
+//     unimplemented detector ⇒ scope skip, honest-absent coverage,
+//     skipped-not-gated (R5).
+//   - mcp-corpus-indexing: mechanical with no registered artifacts ⇒
+//     "not yet implemented" stub (honest-absent).
+const READOUT_MANIFEST_YAML = `schema-version: 1
+status: scaffold
+contracts:
+  - id: doctrine-currency
+    dimension: doctrine
+    canonical-source: mmnto-ai/totem-strategy
+    detection-method: human attestation
+    expected-value-or-derivation: doctrine current per last attestation
+    tractability: manual-attestation
+    tracking-issue: mmnto-ai/totem-strategy#482
+    last-attested: 2026-07-01
+  - id: cr-profile
+    dimension: bot-review-configs
+    canonical-source: mmnto-ai/totem-strategy
+    detection-method: .coderabbit.yaml reviews.profile equality
+    expected-value-or-derivation: assertive
+    tractability: mechanical
+    manifestation: value-equality
+    tracking-issue: mmnto-ai/totem-strategy#738
+    vendor-adapter: [claude]
+  - id: gate-config
+    dimension: enforcement
+    canonical-source: mmnto-ai/totem
+    detection-method: installed gates vs canonical gate set
+    expected-value-or-derivation: consumer installed gates == canonical
+    tractability: mechanical
+    tracking-issue: mmnto-ai/totem-strategy#482
+    blocking: true
+    consumers:
+      - mmnto-ai/totem
+  - id: mcp-corpus-indexing
+    dimension: knowledge-index
+    canonical-source: null
+    source-note: consumer-local capability
+    detection-method: .lancedb index present
+    expected-value-or-derivation: index present + fresh
+    tractability: mechanical
+    tracking-issue: mmnto-ai/totem#2018
+`;
+
+function writeReadoutFixture(manifestYaml: string = READOUT_MANIFEST_YAML): void {
+  writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: parity-manifest.yaml\n`);
+  writeManifest('parity-manifest.yaml', manifestYaml);
+}
+
+describe('checkParity — trust-readout inputs (#2327)', () => {
+  it('carries readout inputs + loadStatus ok on the manifest ok path', async () => {
+    writeReadoutFixture();
+    const { loadStatus, readout } = await checkParity(tmpDir);
+    expect(loadStatus).toBe('ok');
+    expect(readout).toBeDefined();
+    expect(readout!.manifest).toEqual({ schemaVersion: 1, status: 'scaffold' });
+    expect(readout!.contracts).toHaveLength(4);
+  });
+
+  it('classifies coverage per contract at the routing branch (R2: registry ∩ manifest)', async () => {
+    writeReadoutFixture();
+    const { readout } = await checkParity(tmpDir);
+    const meta = readout!.meta;
+    expect(meta['doctrine-currency']!.coverage).toBe('attestation-only');
+    expect(meta['cr-profile']).toEqual({ coverage: 'mechanical', sensesProbed: 'declared' });
+    // Scoped-out AND unimplemented: the registry has no gate detector, so the
+    // class is honest-absent regardless of the scope skip.
+    expect(meta['gate-config']!.coverage).toBe('honest-absent');
+    expect(meta['mcp-corpus-indexing']!.coverage).toBe('honest-absent');
+  });
+
+  it('degenerate load states carry loadStatus and no readout inputs', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: doctrine/missing.yaml\n`);
+    const missing = await checkParity(tmpDir);
+    expect(missing.loadStatus).toBe('not-found');
+    expect(missing.readout).toBeUndefined();
+
+    writeConfig(BASE_CONFIG);
+    const unconfigured = await checkParity(tmpDir);
+    expect(unconfigured.loadStatus).toBe('not-configured');
+    expect(unconfigured.readout).toBeUndefined();
+  });
+});
+
+describe('buildParityReadout (#2327)', () => {
+  it('R1: rollup counts rendered verdict lines in the full six-state vocabulary (info included — raised delta)', async () => {
+    writeReadoutFixture();
+    const { results, blockingDriftIds, readout } = await checkParity(tmpDir);
+    const built = buildParityReadout(readout!, results, blockingDriftIds, false);
+    expect(built.rollup.global).toEqual({
+      pass: 0,
+      warn: 0,
+      info: 1,
+      unknown: 0,
+      skip: 3,
+      fail: 0,
+    });
+    // The section summary line is not a contract row.
+    expect(built.rows).toHaveLength(4);
+  });
+
+  it('R1: per-seat rollup — vendor-neutral rows count toward every declared seat', async () => {
+    writeReadoutFixture();
+    const { results, blockingDriftIds, readout } = await checkParity(tmpDir);
+    const built = buildParityReadout(readout!, results, blockingDriftIds, false);
+    expect(Object.keys(built.rollup.perSeat)).toEqual(['claude']);
+    // All four rows land on the claude seat: cr-profile declares it, the rest
+    // are vendor-neutral (they manifest on every seat).
+    expect(built.rollup.perSeat['claude']).toEqual({
+      pass: 0,
+      warn: 0,
+      info: 1,
+      unknown: 0,
+      skip: 3,
+      fail: 0,
+    });
+  });
+
+  it('R2: the denominator counts CONTRACTS by coverage class, never one collapsed number', async () => {
+    writeReadoutFixture();
+    const { results, blockingDriftIds, readout } = await checkParity(tmpDir);
+    const built = buildParityReadout(readout!, results, blockingDriftIds, false);
+    expect(built.denominator).toEqual({ mechanical: 1, attestationOnly: 1, honestAbsent: 2 });
+  });
+
+  it('R3: reason classes — attestation / scoping-skip / honest-absent land per row; pass omits', async () => {
+    writeReadoutFixture();
+    const { results, blockingDriftIds, readout } = await checkParity(tmpDir);
+    const built = buildParityReadout(readout!, results, blockingDriftIds, false);
+    const byId = new Map(built.rows.map((r) => [r.id, r]));
+    expect(byId.get('doctrine-currency')!.verdict).toBe('info');
+    expect(byId.get('doctrine-currency')!.reasonClass).toBe('attestation');
+    expect(byId.get('doctrine-currency')!.lastAttested).toBe('2026-07-01');
+    expect(byId.get('cr-profile')!.reasonClass).toBe('scoping-skip');
+    expect(byId.get('cr-profile')!.sensesProbed).toBe('declared');
+    // Unimplemented detector dominates the scope skip for the class.
+    expect(byId.get('gate-config')!.reasonClass).toBe('honest-absent');
+    expect(byId.get('mcp-corpus-indexing')!.reasonClass).toBe('honest-absent');
+  });
+
+  it('R5: a blocking contract skipped by scoping renders skipped-not-gated, and the declared blocking set drives gates-anything', async () => {
+    writeReadoutFixture();
+    const { results, blockingDriftIds, readout } = await checkParity(tmpDir);
+    const built = buildParityReadout(readout!, results, blockingDriftIds, true);
+    const gateRow = built.rows.find((r) => r.id === 'gate-config')!;
+    expect(gateRow.verdict).toBe('skip');
+    expect(gateRow.skippedNotGated).toBe(true);
+    expect(built.strict).toEqual({
+      armed: true,
+      blockingIds: ['gate-config'],
+      gatesAnything: true,
+    });
+  });
+
+  it('R5: gates-anything is false when the manifest declares no blocking contracts', async () => {
+    writeReadoutFixture(READOUT_MANIFEST_YAML.replace('    blocking: true\n', ''));
+    const { results, blockingDriftIds, readout } = await checkParity(tmpDir);
+    const built = buildParityReadout(readout!, results, blockingDriftIds, false);
+    expect(built.strict).toEqual({ armed: false, blockingIds: [], gatesAnything: false });
+  });
+
+  it('R1/R4: a strict-promoted blocking drift counts as fail in the rollup and the row verdict', async () => {
+    // A blocking value-equality row with a real drifted value on disk — the
+    // deterministic warn → fail promotion path.
+    const drifted = READOUT_MANIFEST_YAML.replace(
+      '    tracking-issue: mmnto-ai/totem-strategy#738\n    vendor-adapter: [claude]',
+      '    tracking-issue: mmnto-ai/totem-strategy#738\n    vendor-adapter: [claude]\n    blocking: true',
+    );
+    writeReadoutFixture(drifted);
+    fs.writeFileSync(
+      path.join(tmpDir, '.coderabbit.yaml'),
+      'reviews:\n  profile: chill\n',
+      'utf-8',
+    );
+    const { results, blockingDriftIds, readout } = await checkParity(tmpDir);
+    expect(blockingDriftIds).toContain('cr-profile');
+    const built = buildParityReadout(readout!, results, blockingDriftIds, true);
+    const row = built.rows.find((r) => r.id === 'cr-profile')!;
+    expect(row.verdict).toBe('fail');
+    expect(row.reasonClass).toBe('drift');
+    expect(built.rollup.global.fail).toBe(1);
+    // Without strict the same drift stays a warn (sensor-not-gate).
+    const unarmed = buildParityReadout(readout!, results, blockingDriftIds, false);
+    expect(unarmed.rows.find((r) => r.id === 'cr-profile')!.verdict).toBe('warn');
+    expect(unarmed.rollup.global.warn).toBe(1);
+  });
+});
+
+describe('doctorParityCliCommand — --json verdict artifact (#2327 R4)', () => {
+  function captureStdout(): { writes: string[]; restore: () => void } {
+    const writes: string[] = [];
+    const spy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: unknown) => {
+      writes.push(String(chunk));
+      return true;
+    });
+    return { writes, restore: () => spy.mockRestore() };
+  }
+
+  it('emits the spec-fixed kebab-case shape on the ok path', async () => {
+    writeReadoutFixture();
+    const cap = captureStdout();
+    try {
+      await doctorParityCliCommand({ json: true, cwdForTest: tmpDir });
+    } finally {
+      cap.restore();
+    }
+    const artifact = JSON.parse(cap.writes.join('')) as Record<string, any>;
+    expect(artifact['readout-schema-version']).toBe(1);
+    expect(artifact['manifest']).toEqual({ 'schema-version': 1, status: 'scaffold' });
+    expect(artifact['rollup']['global']).toEqual({
+      pass: 0,
+      warn: 0,
+      info: 1,
+      unknown: 0,
+      skip: 3,
+      fail: 0,
+    });
+    expect(artifact['rollup']['per-seat']['claude']).toBeDefined();
+    expect(artifact['denominator']).toEqual({
+      mechanical: 1,
+      'attestation-only': 1,
+      'honest-absent': 2,
+      'claim-boundary': expect.stringContaining('manifest-declared contract set'),
+    });
+    expect(artifact['strict']).toEqual({
+      armed: false,
+      'blocking-ids': ['gate-config'],
+      'gates-anything': true,
+    });
+    const attested = (artifact['rows'] as Array<Record<string, unknown>>).find(
+      (r) => r['id'] === 'doctrine-currency',
+    )!;
+    expect(attested['verdict']).toBe('info');
+    expect(attested['reason-class']).toBe('attestation');
+    expect(attested['last-attested']).toBe('2026-07-01');
+    // R4 field names are fixed — internal render fields must not leak.
+    expect(attested['lineName']).toBeUndefined();
+  });
+
+  it('degenerate load states emit an honest empty artifact carrying the load status', async () => {
+    writeConfig(BASE_CONFIG);
+    const cap = captureStdout();
+    try {
+      await doctorParityCliCommand({ json: true, cwdForTest: tmpDir });
+    } finally {
+      cap.restore();
+    }
+    const artifact = JSON.parse(cap.writes.join('')) as Record<string, any>;
+    expect(artifact['manifest']).toEqual({ status: 'not-configured' });
+    expect(artifact['rows']).toEqual([]);
+    expect(artifact['strict']).toEqual({
+      armed: false,
+      'blocking-ids': [],
+      'gates-anything': false,
+    });
+  });
+
+  it('still throws PARITY_DRIFT_DETECTED under --strict after emitting the artifact (R5 exit contract)', async () => {
+    const drifted = READOUT_MANIFEST_YAML.replace(
+      '    tracking-issue: mmnto-ai/totem-strategy#738\n    vendor-adapter: [claude]',
+      '    tracking-issue: mmnto-ai/totem-strategy#738\n    vendor-adapter: [claude]\n    blocking: true',
+    );
+    writeReadoutFixture(drifted);
+    fs.writeFileSync(
+      path.join(tmpDir, '.coderabbit.yaml'),
+      'reviews:\n  profile: chill\n',
+      'utf-8',
+    );
+    const cap = captureStdout();
+    try {
+      await expect(
+        doctorParityCliCommand({ json: true, strict: true, cwdForTest: tmpDir }),
+      ).rejects.toThrow(/blocking drift/);
+    } finally {
+      cap.restore();
+    }
+    const artifact = JSON.parse(cap.writes.join('')) as Record<string, any>;
+    expect(artifact['rollup']['global']['fail']).toBe(1);
+    const row = (artifact['rows'] as Array<Record<string, unknown>>).find(
+      (r) => r['id'] === 'cr-profile',
+    )!;
+    expect(row['verdict']).toBe('fail');
   });
 });

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -1170,20 +1170,19 @@ function contractForLineName(
   return contracts.find((c) => name === `Parity: ${c.id}` || name.startsWith(`Parity: ${c.id} `));
 }
 
-// The core detectors' scope-guard message shapes (consumers scope self-guards +
-// seat scoping). Code-owned strings, pinned by test; a future optional
-// reasonClass on the core verdict type retires this coupling (flagged to
-// strategy in the 2026-07-09T2256Z deltas dispatch as an observation).
-const SCOPE_SKIP_RE = /cohort permits absence|cannot determine applicability|unavailable-for-seat/;
+// The CLI-side stubs' "not yet implemented" message shape — the one code-owned
+// string the classifier keys on. A future optional reasonClass on the core
+// verdict type retires this coupling (flagged to strategy in the
+// 2026-07-09T2256Z deltas dispatch as an observation).
 const HONEST_ABSENT_RE = /not yet implemented/;
 
 /**
- * R3 reason class for one verdict line. `pass` omits its class; `skip` splits
- * on the message shape (scope-guard strings vs "not yet implemented" stubs),
- * with the contract's coverage class as the tiebreak and scope-indeterminate
- * skips (e.g. applicable-but-missing scaffold skips) defaulting to
- * `scoping-skip` — never silently to `honest-absent`, which would understate
- * what the registry implements.
+ * R3 reason class for one verdict line. `pass` omits its class. A `skip` is
+ * `honest-absent` when the stub message or the contract's coverage class says
+ * the detector is unbuilt; every other skip — scope-guard skips and
+ * scope-indeterminate skips (e.g. applicable-but-missing scaffolds) alike —
+ * classifies `scoping-skip`, never silently `honest-absent`, which would
+ * understate what the registry implements.
  */
 function reasonClassFor(
   verdict: ParityLine['status'],
@@ -1202,7 +1201,6 @@ function reasonClassFor(
       return 'detector-error';
     case 'skip':
       if (HONEST_ABSENT_RE.test(message) || coverage === 'honest-absent') return 'honest-absent';
-      if (SCOPE_SKIP_RE.test(message)) return 'scoping-skip';
       return 'scoping-skip';
   }
 }

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -36,6 +36,15 @@
  * unconfigured → exactly one `skip` line; configured-but-missing / unparseable /
  * unsupported-schema → `warn`, never a crash. Dynamic-import `@mmnto/totem` to
  * keep core off the CLI cold-start graph, matching the other doctor checks.
+ *
+ * The **trust-readout** (mmnto-ai/totem#2327, Prop 303 §5(a)) post-processes
+ * the flat per-line dump into the doctor's aggregate output contract: verdict
+ * rollup (per-seat + global, R1), the run-time coverage denominator (R2),
+ * why-not per non-pass row at the level probed (R3), the `--json` verdict
+ * artifact (R4), and the `--strict` declaredly-toothless honesty line (R5).
+ * Spec: mmnto-ai/totem-strategy:doctrine/parity-manifest.md § "The
+ * trust-readout — the doctor's output contract"; deltas raise there, never
+ * silently diverge. Pure post-processing — zero probes added.
  */
 
 import * as path from 'node:path';
@@ -64,6 +73,53 @@ export interface ParityLine extends ParityContractVerdict {
   name: string;
 }
 
+// ─── Trust-readout types (mmnto-ai/totem#2327, Prop 303 §5(a)) ──────────
+// The spec half lives at mmnto-ai/totem-strategy:doctrine/parity-manifest.md
+// § "The trust-readout — the doctor's output contract" (R1–R5); build deltas
+// are raised against that section, never silently diverged. Three raised
+// deltas ride the 2026-07-09T2256Z totem-claude→strategy-claude dispatch:
+// `info` joins the R1/R4 vocabulary (the shipped manual-attestation state),
+// the rollup counts rendered verdict LINES while the R2 denominator counts
+// CONTRACTS, and `attestation` joins the R3 reason classes.
+
+/** Prop 296 §6(a)2 senses-ladder rung a detector actually probed. */
+export type SensesLevel = 'declared' | 'present' | 'loaded' | 'usable';
+
+/**
+ * R2 coverage class for one contract — derived per run from the detector
+ * registry ∩ the manifest (the yaml deliberately carries no per-row sensed
+ * flag; Tenet 20). A contract whose detector exists but was scope-skipped this
+ * run still classifies `mechanical` — the registry implements it; the skip is
+ * a run-time verdict the rollup + why-not carry separately.
+ */
+export type ReadoutCoverageClass = 'mechanical' | 'attestation-only' | 'honest-absent';
+
+/** R3 reason class for one verdict line (`pass` lines omit theirs; `attestation` is raised Delta 3). */
+export type ReadoutReasonClass =
+  | 'drift'
+  | 'scoping-skip'
+  | 'honest-absent'
+  | 'detector-error'
+  | 'attestation';
+
+/**
+ * Per-contract readout metadata, tagged at the routing branch that senses the
+ * contract (single source — never re-derived from a mirrored registry, which
+ * would be the Tenet 20 drift hazard).
+ */
+export interface ContractReadoutMeta {
+  coverage: ReadoutCoverageClass;
+  /** Absent when nothing was probed (attestation rows, honest-absent stubs). */
+  sensesProbed?: SensesLevel;
+}
+
+/** The trust-readout raw materials `checkParity` carries out of the manifest `ok` path. */
+export interface ParityReadoutInputs {
+  manifest: { schemaVersion: number; status: string };
+  contracts: ParityContract[];
+  meta: Record<string, ContractReadoutMeta>;
+}
+
 /**
  * Result of a parity check: the rendered `ParityLine`s plus the set of contract
  * ids that produced a drift `warn` AND are `blocking: true`. The command
@@ -83,6 +139,19 @@ export interface ParityCheckResult {
    * (mmnto-ai/totem#2085, mmnto-ai/totem-strategy#545 Half 2).
    */
   configured: boolean;
+  /**
+   * Manifest load status — the `--json` artifact's `manifest.status` on the
+   * degenerate paths, where there is no manifest-declared status to carry
+   * (mmnto-ai/totem#2327 R4).
+   */
+  loadStatus: 'ok' | 'not-configured' | 'not-found' | 'unparseable' | 'unsupported-schema';
+  /**
+   * Trust-readout raw materials (mmnto-ai/totem#2327) — present only on the
+   * manifest `ok` path. The CLI edge assembles the rollup / denominator /
+   * why-not via `buildParityReadout`; degenerate load states render no rollup
+   * (nothing to roll up) and `--json` carries `loadStatus` instead.
+   */
+  readout?: ParityReadoutInputs;
 }
 
 // ─── Mechanical artifact registry (CLI-side) ────────────
@@ -533,6 +602,7 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
           message: 'no parity manifest configured',
         },
         configured,
+        'not-configured',
       );
 
     case 'not-found': {
@@ -558,6 +628,7 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
           remediation,
         },
         configured,
+        'not-found',
       );
     }
 
@@ -570,6 +641,7 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
           remediation: 'Fix the manifest YAML / schema, then re-run totem doctor --parity.',
         },
         configured,
+        'unparseable',
       );
 
     case 'unsupported-schema':
@@ -581,6 +653,7 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
           remediation: 'Upgrade @mmnto/cli or align the manifest schema-version.',
         },
         configured,
+        'unsupported-schema',
       );
 
     case 'ok': {
@@ -659,6 +732,10 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
       const fallbackCmd = getFallbackCommand(gitRoot);
 
       const blockingDriftIds: string[] = [];
+      // Trust-readout per-contract metadata (mmnto-ai/totem#2327), tagged at the
+      // routing branch that owns each contract so the R2 coverage split derives
+      // from the run itself — never from a mirrored registry (Tenet 20).
+      const readoutMeta: Record<string, ContractReadoutMeta> = {};
       // The consumers-scope guard shared by the routing branches that don't
       // self-guard in core (mechanical + capability-probe): a scoped contract
       // must not emit drift in a repo that is not an intended consumer.
@@ -694,9 +771,19 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
         // NON-probe rungs (managed-block, version-pin, …) are informational —
         // they fall through to the existing tractability routing unchanged.
         if (c.manifestation === 'capability-probe') {
+          // Probe resolution BEFORE the scope guard is meta-only (pure switch, no
+          // probe executes): a scoped-out row still classifies by whether the
+          // registry implements it (#2327 R2).
+          const probes = capabilityProbesFor(c.id, gitRoot);
+          readoutMeta[c.id] =
+            probes === undefined
+              ? { coverage: 'honest-absent' }
+              : {
+                  coverage: 'mechanical',
+                  ...(probes[0] !== undefined ? { sensesProbed: probes[0].probedLevel } : {}),
+                };
           const scopeSkip = consumersSkip(c);
           if (scopeSkip !== undefined) return scopeSkip;
-          const probes = capabilityProbesFor(c.id, gitRoot);
           if (probes === undefined) {
             return [
               stub(c, `${c.dimension} (capability-probe) — probe not yet implemented for this row`),
@@ -731,6 +818,11 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
         // documented to avoid.
         if (c.manifestation === 'value-equality') {
           const fields = valueEqualityFieldsFor(c.id, gitRoot);
+          // The scalar read is a config-declaration probe (#2327 R3): 'declared'.
+          readoutMeta[c.id] =
+            fields === undefined
+              ? { coverage: 'honest-absent' }
+              : { coverage: 'mechanical', sensesProbed: 'declared' };
           if (fields === undefined) {
             return [
               stub(
@@ -761,6 +853,11 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
         // contract id at most ONCE for --strict so the count reflects contracts.
         if (c.manifestation === 'content-hash') {
           const packageDir = lockContentPackageDirFor(c.id, gitRoot);
+          // Installed-artifact hash equality probes on-disk content (#2327 R3): 'present'.
+          readoutMeta[c.id] =
+            packageDir === undefined
+              ? { coverage: 'honest-absent' }
+              : { coverage: 'mechanical', sensesProbed: 'present' };
           if (packageDir === undefined) {
             return [
               stub(
@@ -785,6 +882,7 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
           // Fail-loud PER ROW, never per manifest (the total-outage guard): an
           // unrecognized rung value surfaces verbatim instead of darking the
           // sensor or silently mis-routing.
+          readoutMeta[c.id] = { coverage: 'honest-absent' };
           return [
             stub(
               c,
@@ -801,10 +899,13 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
           // self-routes those to the toolchain reader (mmnto-ai/totem#2115). Only
           // stub a version-pinned row that's neither a deps package nor a toolchain.
           if (packageName === undefined && c.dimension !== TOOLCHAIN_DIMENSION) {
+            readoutMeta[c.id] = { coverage: 'honest-absent' };
             return [
               stub(c, `${c.dimension} (version-pinned) — drift detection not yet implemented`),
             ];
           }
+          // Pin-currency reads the consumer's dependency declaration (#2327 R3): 'declared'.
+          readoutMeta[c.id] = { coverage: 'mechanical', sensesProbed: 'declared' };
           const verdict = detectVersionPinnedContract(c, { cwd, gitRoot, repoId, packageName });
           if (verdict.status === 'warn' && c.blocking === true) blockingDriftIds.push(c.id);
           return [verdictToLine(c, verdict)];
@@ -812,6 +913,24 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
 
         // ── mechanical content-equality (mmnto-ai/totem#2073) ──
         if (c.tractability === 'mechanical') {
+          // Skills resolution is pure (no probe executes) — resolved BEFORE the
+          // scope guard so a scoped-out row still classifies by whether the
+          // registry implements it (#2327 R2); reused as `artifacts` below.
+          const skillArtifacts = mechanicalArtifactsFor(
+            c.id,
+            gitRoot,
+            extractManagedBlock,
+            skillTemplates,
+          );
+          const mechanicalImplemented =
+            c.id === 'git-hooks' ||
+            c.id === 'session-start-orientation' ||
+            skillArtifacts !== undefined;
+          // Content-equality probes on-disk artifacts (#2327 R3): 'present'.
+          readoutMeta[c.id] = mechanicalImplemented
+            ? { coverage: 'mechanical', sensesProbed: 'present' }
+            : { coverage: 'honest-absent' };
+
           // Honor the contract's `consumers` scope before sensing drift (mirrors
           // detectVersionPinnedContract, which self-guards). A scoped mechanical
           // contract must not emit drift — or, under --strict, fail — in a repo that
@@ -861,13 +980,9 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
             return lines;
           }
 
-          // skills: managed-block content equality against the in-process template.
-          const artifacts = mechanicalArtifactsFor(
-            c.id,
-            gitRoot,
-            extractManagedBlock,
-            skillTemplates,
-          );
+          // skills: managed-block content equality against the in-process template
+          // (resolved above, pre-scope-guard, for the readout classification).
+          const artifacts = skillArtifacts;
           if (artifacts === undefined) {
             return [
               stub(
@@ -901,6 +1016,9 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
         // `info` can't enter blockingDriftIds, so these contracts cannot fail even
         // under --strict (the manifest's "never fails" contract).
         if (c.tractability === 'manual-attestation') {
+          // Declared-covered but mechanically uncovered (#2327 R2 — human-asserted
+          // judgment is not code-verified truth); nothing is probed.
+          readoutMeta[c.id] = { coverage: 'attestation-only' };
           // The detector reads the sub-class discriminant (`c.package`) + the
           // canonical source directly off the contract. `package:` set ⇒ vendor-SDK
           // pin read; unset ⇒ doctrine-row pure-info surface. `attested` carries the
@@ -915,19 +1033,37 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
         }
 
         // ── anything else (a future tractability) → skip stub; the slice boundary stays observable ──
+        readoutMeta[c.id] = { coverage: 'honest-absent' };
         return [
           stub(c, `${c.dimension} (${c.tractability}) — drift detection not yet implemented`),
         ];
       });
 
-      return { results: [summary, ...perContract], blockingDriftIds, configured };
+      return {
+        results: [summary, ...perContract],
+        blockingDriftIds,
+        configured,
+        loadStatus: 'ok',
+        readout: {
+          manifest: {
+            schemaVersion: result.manifest.schemaVersion,
+            status: result.manifest.status,
+          },
+          contracts,
+          meta: readoutMeta,
+        },
+      };
     }
   }
 }
 
-/** Wrap a single summary line in the `ParityCheckResult` shape (no blocking ids). */
-function single(result: ParityLine, configured: boolean): ParityCheckResult {
-  return { results: [result], blockingDriftIds: [], configured };
+/** Wrap a single summary line in the `ParityCheckResult` shape (no blocking ids, no readout). */
+function single(
+  result: ParityLine,
+  configured: boolean,
+  loadStatus: ParityCheckResult['loadStatus'],
+): ParityCheckResult {
+  return { results: [result], blockingDriftIds: [], configured, loadStatus };
 }
 
 /** Map a core `ParityContractVerdict` to a `ParityLine` keyed by the contract id. */
@@ -970,6 +1106,276 @@ function rel(cwd: string, target: string): string {
   return r.length > 0 ? r : target;
 }
 
+// ─── Trust-readout assembly (mmnto-ai/totem#2327) ────────
+
+/** The `--json` artifact's own version stamp (`readout-schema-version`). */
+const READOUT_SCHEMA_VERSION = 1;
+
+/**
+ * R2 claim-boundary sentence — the readout states its own scope in its own
+ * output: an active-but-unmanifested surface (an undeclared MCP server, a
+ * user-global plugin) is outside the claim, stated not implied.
+ */
+const CLAIM_BOUNDARY =
+  'covers the manifest-declared contract set only; active-but-unmanifested surfaces are outside this claim';
+
+/** Counts over rendered verdict lines — the R1 rollup unit (raised Delta 2). */
+export type ReadoutCounts = Record<ParityLine['status'], number>;
+
+/** One `--json` `rows[]` entry — 1:1 with a rendered verdict line (ids repeat for multi-artifact contracts). */
+export interface ReadoutRow {
+  id: string;
+  /** Line verdict AFTER the strict blocking promotion, so the artifact matches the rendered output. */
+  verdict: ParityLine['status'];
+  sensesProbed?: SensesLevel;
+  reasonClass?: ReadoutReasonClass;
+  message: string;
+  lastAttested?: string;
+  /** Display name of the underlying verdict line (human render only — not a `--json` field; R4 names are fixed). */
+  lineName: string;
+  /** R5: a `blocking: true` contract's line skipped by scoping — rendered skipped-not-gated, never a silent pass. */
+  skippedNotGated: boolean;
+}
+
+/** The assembled trust-readout — everything R1–R5 render from. */
+export interface ParityReadout {
+  manifest: { schemaVersion: number; status: string };
+  rollup: { global: ReadoutCounts; perSeat: Record<string, ReadoutCounts> };
+  denominator: { mechanical: number; attestationOnly: number; honestAbsent: number };
+  strict: { armed: boolean; blockingIds: string[]; gatesAnything: boolean };
+  rows: ReadoutRow[];
+}
+
+/**
+ * Whether a verdict line belongs to a `--strict`-promotable contract. A
+ * contract's drift can render across MULTIPLE artifact lines (e.g.
+ * `Parity: claude-skills (signoff)`), so a line is promotable when its name is
+ * the `Parity: <id>` summary OR a `Parity: <id> (…)` artifact line — an
+ * exact-name Set would leave the artifact lines rendered as WARN while the
+ * command still exits non-zero (GCA review). The trailing space guards against
+ * a contract id that is a prefix of another. Shared by the CLI render and the
+ * readout builder so the two can't disagree on what promoted.
+ */
+function isPromotableLineName(name: string, blockingDriftIds: string[]): boolean {
+  return blockingDriftIds.some(
+    (id) => name === `Parity: ${id}` || name.startsWith(`Parity: ${id} `),
+  );
+}
+
+/** Resolve the contract a verdict line belongs to (same prefix rule as promotion). */
+function contractForLineName(
+  name: string,
+  contracts: ParityContract[],
+): ParityContract | undefined {
+  return contracts.find((c) => name === `Parity: ${c.id}` || name.startsWith(`Parity: ${c.id} `));
+}
+
+// The core detectors' scope-guard message shapes (consumers scope self-guards +
+// seat scoping). Code-owned strings, pinned by test; a future optional
+// reasonClass on the core verdict type retires this coupling (flagged to
+// strategy in the 2026-07-09T2256Z deltas dispatch as an observation).
+const SCOPE_SKIP_RE = /cohort permits absence|cannot determine applicability|unavailable-for-seat/;
+const HONEST_ABSENT_RE = /not yet implemented/;
+
+/**
+ * R3 reason class for one verdict line. `pass` omits its class; `skip` splits
+ * on the message shape (scope-guard strings vs "not yet implemented" stubs),
+ * with the contract's coverage class as the tiebreak and scope-indeterminate
+ * skips (e.g. applicable-but-missing scaffold skips) defaulting to
+ * `scoping-skip` — never silently to `honest-absent`, which would understate
+ * what the registry implements.
+ */
+function reasonClassFor(
+  verdict: ParityLine['status'],
+  message: string,
+  coverage: ReadoutCoverageClass | undefined,
+): ReadoutReasonClass | undefined {
+  switch (verdict) {
+    case 'pass':
+      return undefined;
+    case 'warn':
+    case 'fail':
+      return 'drift';
+    case 'info':
+      return 'attestation';
+    case 'unknown':
+      return 'detector-error';
+    case 'skip':
+      if (HONEST_ABSENT_RE.test(message) || coverage === 'honest-absent') return 'honest-absent';
+      if (SCOPE_SKIP_RE.test(message)) return 'scoping-skip';
+      return 'scoping-skip';
+  }
+}
+
+/**
+ * Assemble the trust-readout from `checkParity`'s raw materials — pure
+ * post-processing over the existing detector output (Prop 303 non-goal 2:
+ * zero probes added here).
+ */
+export function buildParityReadout(
+  inputs: ParityReadoutInputs,
+  results: ParityLine[],
+  blockingDriftIds: string[],
+  strict: boolean,
+): ParityReadout {
+  const { contracts, meta } = inputs;
+
+  const rows: ReadoutRow[] = [];
+  for (const line of results) {
+    const contract = contractForLineName(line.name, contracts);
+    // The section summary line (`Parity`) is not a contract row.
+    if (contract === undefined) continue;
+    const promoted =
+      strict && line.status === 'warn' && isPromotableLineName(line.name, blockingDriftIds);
+    const verdict: ParityLine['status'] = promoted ? 'fail' : line.status;
+    const m = meta[contract.id];
+    const reasonClass = reasonClassFor(verdict, line.message, m?.coverage);
+    rows.push({
+      id: contract.id,
+      verdict,
+      ...(m?.sensesProbed !== undefined ? { sensesProbed: m.sensesProbed } : {}),
+      ...(reasonClass !== undefined ? { reasonClass } : {}),
+      message: line.message,
+      ...(contract.lastAttested !== undefined ? { lastAttested: contract.lastAttested } : {}),
+      lineName: line.name,
+      skippedNotGated: verdict === 'skip' && contract.blocking === true,
+    });
+  }
+
+  const zero = (): ReadoutCounts => ({ pass: 0, warn: 0, info: 0, unknown: 0, skip: 0, fail: 0 });
+  const global = zero();
+  for (const r of rows) global[r.verdict] += 1;
+
+  // Seats = the sorted union of declared vendor-adapter values. A line counts
+  // toward seat S when its contract is vendor-neutral (no vendor-adapter — it
+  // manifests on every seat) or declares S. Per-seat exists precisely so a
+  // seat-scoped skip cannot hide inside the global number (R1).
+  const seats = [...new Set(contracts.flatMap((c) => c.vendorAdapter ?? []))].sort();
+  const perSeat: Record<string, ReadoutCounts> = {};
+  for (const seat of seats) perSeat[seat] = zero();
+  const adapterById = new Map(contracts.map((c) => [c.id, c.vendorAdapter]));
+  for (const r of rows) {
+    const adapter = adapterById.get(r.id);
+    for (const seat of seats) {
+      if (adapter === undefined || adapter.includes(seat)) perSeat[seat]![r.verdict] += 1;
+    }
+  }
+
+  // R2: the denominator counts CONTRACTS (registry ∩ manifest is contract-
+  // granular), while the rollup above counts rendered verdict LINES — two
+  // populations, named apart in the render (raised Delta 2).
+  const denominator = { mechanical: 0, attestationOnly: 0, honestAbsent: 0 };
+  for (const c of contracts) {
+    const cls = meta[c.id]?.coverage ?? 'honest-absent';
+    if (cls === 'mechanical') denominator.mechanical += 1;
+    else if (cls === 'attestation-only') denominator.attestationOnly += 1;
+    else denominator.honestAbsent += 1;
+  }
+
+  // R5: blocking-ids = the manifest's DECLARED `blocking: true` set, derived
+  // from the yaml at run time (never from prose — Tenet 20); gates-anything =
+  // that set is non-empty. Which blocking contracts actually drifted is
+  // visible as `fail` rows (strict) / promotable warns (default).
+  const blockingIds = contracts.filter((c) => c.blocking === true).map((c) => c.id);
+
+  return {
+    manifest: inputs.manifest,
+    rollup: { global, perSeat },
+    denominator,
+    strict: { armed: strict, blockingIds, gatesAnything: blockingIds.length > 0 },
+    rows,
+  };
+}
+
+/** One-line count rendering shared by the global + per-seat rollup lines. */
+function renderCounts(c: ReadoutCounts): string {
+  return `${c.pass} pass · ${c.warn} warn · ${c.info} info · ${c.unknown} unknown · ${c.skip} skip · ${c.fail} fail`;
+}
+
+/**
+ * R3 attestation-age fragment: days since `last-attested:` ("not recorded"
+ * when absent). Staleness refines the message, never the status (the existing
+ * manifest constraint, unchanged).
+ */
+function attestationAge(lastAttested: string | undefined): string {
+  if (lastAttested === undefined) return 'last attested: not recorded';
+  const t = Date.parse(lastAttested);
+  if (Number.isNaN(t)) return `last attested: ${lastAttested} (unparseable date)`;
+  const days = Math.max(0, Math.floor((Date.now() - t) / 86_400_000));
+  return `last attested ${days} day(s) ago`;
+}
+
+/**
+ * The `--json` verdict artifact (R4) — field names fixed by the spec section
+ * (kebab-case, no local envelope: the spec's top-level shape overrides the
+ * `json-output.ts` success/error wrapper). Emitted bare on stdout so the
+ * artifact is diffable (Prop 302 verdict-artifact discipline). On degenerate
+ * manifest-load states the artifact carries the load status and empty
+ * rollup/rows — the honest "nothing to roll up" shape.
+ */
+function readoutJsonArtifact(
+  readout: ParityReadout | undefined,
+  loadStatus: ParityCheckResult['loadStatus'],
+  strict: boolean,
+): Record<string, unknown> {
+  const countsJson = (c: ReadoutCounts): Record<string, number> => ({
+    pass: c.pass,
+    warn: c.warn,
+    info: c.info,
+    unknown: c.unknown,
+    skip: c.skip,
+    fail: c.fail,
+  });
+  if (readout === undefined) {
+    const zero: ReadoutCounts = { pass: 0, warn: 0, info: 0, unknown: 0, skip: 0, fail: 0 };
+    return {
+      'readout-schema-version': READOUT_SCHEMA_VERSION,
+      manifest: { status: loadStatus },
+      rollup: { global: countsJson(zero), 'per-seat': {} },
+      denominator: {
+        mechanical: 0,
+        'attestation-only': 0,
+        'honest-absent': 0,
+        'claim-boundary': CLAIM_BOUNDARY,
+      },
+      strict: { armed: strict, 'blocking-ids': [], 'gates-anything': false },
+      rows: [],
+    };
+  }
+  return {
+    'readout-schema-version': READOUT_SCHEMA_VERSION,
+    manifest: {
+      'schema-version': readout.manifest.schemaVersion,
+      status: readout.manifest.status,
+    },
+    rollup: {
+      global: countsJson(readout.rollup.global),
+      'per-seat': Object.fromEntries(
+        Object.entries(readout.rollup.perSeat).map(([seat, c]) => [seat, countsJson(c)]),
+      ),
+    },
+    denominator: {
+      mechanical: readout.denominator.mechanical,
+      'attestation-only': readout.denominator.attestationOnly,
+      'honest-absent': readout.denominator.honestAbsent,
+      'claim-boundary': CLAIM_BOUNDARY,
+    },
+    strict: {
+      armed: readout.strict.armed,
+      'blocking-ids': readout.strict.blockingIds,
+      'gates-anything': readout.strict.gatesAnything,
+    },
+    rows: readout.rows.map((r) => ({
+      id: r.id,
+      verdict: r.verdict,
+      ...(r.sensesProbed !== undefined ? { 'senses-probed': r.sensesProbed } : {}),
+      ...(r.reasonClass !== undefined ? { 'reason-class': r.reasonClass } : {}),
+      message: r.message,
+      ...(r.lastAttested !== undefined ? { 'last-attested': r.lastAttested } : {}),
+    })),
+  };
+}
+
 // ─── CLI entry ──────────────────────────────────────────
 
 // Same value as CHECK_NAME — aliased (not re-literal'd) so the two can't drift.
@@ -997,6 +1403,13 @@ export interface ParityCliOptions {
    * `doctor --parity` behavior, which still renders the honest-absent SKIP line.
    */
   onlyWhenConfigured?: boolean;
+  /**
+   * Emit the trust-readout as the schema'd `--json` verdict artifact
+   * (mmnto-ai/totem#2327 R4) on stdout INSTEAD of the human render — the
+   * artifact is diffable, so nothing else may share stdout. The `--strict`
+   * exit-code semantics are unchanged (artifact + non-zero exit both happen).
+   */
+  json?: boolean;
   /** Test seam — production callers omit and the command uses `process.cwd()`. */
   cwdForTest?: string;
 }
@@ -1028,7 +1441,13 @@ export async function doctorParityCliCommand(options: ParityCliOptions = {}): Pr
       .trim();
 
   const cwd = options.cwdForTest ?? process.cwd();
-  const { results, blockingDriftIds, configured } = await checkParity(cwd);
+  const {
+    results,
+    blockingDriftIds,
+    configured,
+    loadStatus,
+    readout: readoutInputs,
+  } = await checkParity(cwd);
 
   // Folded-into-`--strict` no-op: when this run is the strict fold (not an explicit
   // `doctor --parity`) and no repo-local manifest is configured, render and gate
@@ -1036,19 +1455,75 @@ export async function doctorParityCliCommand(options: ParityCliOptions = {}): Pr
   // fold. Explicit `--parity` (onlyWhenConfigured omitted) still shows the SKIP.
   if (options.onlyWhenConfigured && !configured) return;
 
-  // Under --strict, a blocking contract's drift `warn` is rendered + gated as a
-  // FAIL. A contract's drift can render across MULTIPLE artifact lines
-  // (e.g. `Parity: claude-skills (signoff)`), so a line is promotable when its
-  // name is the `Parity: <id>` summary OR a `Parity: <id> (…)` artifact line —
-  // an exact-name Set would leave the artifact lines rendered as WARN while the
-  // command still exits non-zero (GCA review on the PR). The trailing space
-  // guards against a contract id that is a prefix of another.
-  const isPromotable = (name: string): boolean =>
-    blockingDriftIds.some((id) => name === `Parity: ${id}` || name.startsWith(`Parity: ${id} `));
+  const strict = options.strict === true;
+  const readout =
+    readoutInputs !== undefined
+      ? buildParityReadout(readoutInputs, results, blockingDriftIds, strict)
+      : undefined;
+
+  // `--json` replaces the human render wholesale: the artifact owns stdout so
+  // it stays diffable (R4). The strict throw below still applies — artifact
+  // AND exit code, matching R5's "exits non-zero iff ≥1 fail".
+  if (options.json) {
+    process.stdout.write(
+      JSON.stringify(readoutJsonArtifact(readout, loadStatus, strict), null, 2) + '\n',
+    );
+  } else {
+    renderParityHuman(
+      results,
+      blockingDriftIds,
+      strict,
+      { log, bold, errorColor, successColor, warnColor },
+      render,
+    );
+    if (readout !== undefined) {
+      renderTrustReadout(readout, { log, bold }, render);
+    }
+  }
+
+  // Sensor-not-gate: drift is report-only by default (exit 0). Only `--strict`
+  // promotes a `blocking: true` contract's drift to a non-zero exit; non-blocking
+  // drift never gates, and `info`/`unknown` are never promoted. The detectors
+  // emit no raw `fail` status, so the gate is purely the strict+blocking
+  // promotion — the gating model for a future slice that DOES emit a `fail` is
+  // settled when that slice lands (CR review mmnto-ai/totem#2071: keep the gate from
+  // suggesting a non-strict path that would break sensor-not-gate).
+  if (options.strict && blockingDriftIds.length > 0) {
+    throw new TotemError(
+      'PARITY_DRIFT_DETECTED',
+      `${blockingDriftIds.length} parity contract(s) reported blocking drift under --strict.`,
+      'Reconcile each blocking contract against its canonical source, then re-run totem doctor --parity --strict.',
+    );
+  }
+}
+
+/** The ui.js pieces the human renderers borrow from the command scope. */
+interface ParityUi {
+  log: typeof import('../ui.js').log;
+  bold: (s: string) => string;
+  errorColor?: (s: string) => string;
+  successColor?: (s: string) => string;
+  warnColor?: (s: string) => string;
+}
+
+/** The pre-readout flat per-line render (unchanged output, extracted for the `--json` split). */
+function renderParityHuman(
+  results: ParityLine[],
+  blockingDriftIds: string[],
+  strict: boolean,
+  ui: ParityUi,
+  render: (text: string) => string,
+): void {
+  const { log, bold } = ui;
+  const errorColor = ui.errorColor ?? ((s: string) => s);
+  const successColor = ui.successColor ?? ((s: string) => s);
+  const warnColor = ui.warnColor ?? ((s: string) => s);
 
   for (const r of results) {
     const status =
-      options.strict && r.status === 'warn' && isPromotable(r.name) ? 'fail' : r.status;
+      strict && r.status === 'warn' && isPromotableLineName(r.name, blockingDriftIds)
+        ? 'fail'
+        : r.status;
     switch (status) {
       case 'pass':
         log.success(TAG, `${successColor(bold('PASS'))} — ${render(r.message)}`);
@@ -1080,19 +1555,81 @@ export async function doctorParityCliCommand(options: ParityCliOptions = {}): Pr
         break;
     }
   }
+}
 
-  // Sensor-not-gate: drift is report-only by default (exit 0). Only `--strict`
-  // promotes a `blocking: true` contract's drift to a non-zero exit; non-blocking
-  // drift never gates, and `info`/`unknown` are never promoted. The detectors
-  // emit no raw `fail` status, so the gate is purely the strict+blocking
-  // promotion — the gating model for a future slice that DOES emit a `fail` is
-  // settled when that slice lands (CR review mmnto-ai/totem#2071: keep the gate from
-  // suggesting a non-strict path that would break sensor-not-gate).
-  if (options.strict && blockingDriftIds.length > 0) {
-    throw new TotemError(
-      'PARITY_DRIFT_DETECTED',
-      `${blockingDriftIds.length} parity contract(s) reported blocking drift under --strict.`,
-      'Reconcile each blocking contract against its canonical source, then re-run totem doctor --parity --strict.',
+/**
+ * The trust-readout tail render (mmnto-ai/totem#2327 R1–R3, R5) — replaces the
+ * bare "N loaded" ending with the rollup, coverage denominator, why-not lines,
+ * and the `--strict` honesty statement. Verdict lines above stay untouched.
+ */
+function renderTrustReadout(
+  readout: ParityReadout,
+  ui: Pick<ParityUi, 'log' | 'bold'>,
+  render: (text: string) => string,
+): void {
+  const { log, bold } = ui;
+
+  log.info(TAG, bold('── trust-readout ──'));
+
+  // R1 — one vocabulary, two scopes. Units named (verdict lines ≠ contracts).
+  log.info(TAG, `rollup (verdict lines) — global: ${renderCounts(readout.rollup.global)}`);
+  const seats = Object.keys(readout.rollup.perSeat);
+  if (seats.length === 0) {
+    log.dim(TAG, 'rollup — no seat-scoped rows declared (per-seat = global)');
+  } else {
+    for (const seat of seats) {
+      log.info(
+        TAG,
+        `rollup — seat ${render(seat)}: ${renderCounts(readout.rollup.perSeat[seat]!)}`,
+      );
+    }
+  }
+
+  // R2 — three counts on their own line, never one "covered" number; the
+  // claim boundary stated in the readout's own words.
+  const d = readout.denominator;
+  log.info(
+    TAG,
+    `coverage (contracts) — ${d.mechanical} mechanically sensed · ${d.attestationOnly} attestation-only · ${d.honestAbsent} honest-absent`,
+  );
+  log.dim(TAG, `claim boundary: ${CLAIM_BOUNDARY}`);
+
+  // R3 — one why-not line per non-pass row, at the level actually probed
+  // (green-halo cap: nothing renders above what was probed).
+  const whyNot = readout.rows.filter((r) => r.verdict !== 'pass');
+  if (whyNot.length > 0) {
+    log.info(TAG, 'why-not (per non-pass row):');
+    for (const r of whyNot) {
+      const level = r.sensesProbed !== undefined ? ` at ${r.sensesProbed}` : '';
+      const reason = r.reasonClass !== undefined ? ` [${r.reasonClass}]` : '';
+      // R3 age-in-days for attestation rows. The detector message already
+      // carries the raw date / "not recorded" text — append the derived age
+      // only when a date exists to derive it from (no duplicate "not recorded").
+      const age =
+        r.reasonClass === 'attestation' && r.lastAttested !== undefined
+          ? ` · ${attestationAge(r.lastAttested)}`
+          : '';
+      const gate = r.skippedNotGated ? ' · blocking — skipped-not-gated, never a silent pass' : '';
+      log.dim(
+        TAG,
+        `  ${render(r.lineName)}: ${r.verdict.toUpperCase()}${level}${reason} — ${render(r.message)}${age}${gate}`,
+      );
+    }
+  }
+
+  // R5 — declaredly-toothless in the readout's own words; derived from the
+  // manifest's blocking set at run time, never from prose.
+  const s = readout.strict;
+  const armed = s.armed ? 'armed' : 'not armed';
+  if (!s.gatesAnything) {
+    log.info(
+      TAG,
+      `--strict (${armed}): currently gates nothing — the manifest declares no blocking: true contracts`,
+    );
+  } else {
+    log.info(
+      TAG,
+      `--strict (${armed}): gates ${s.blockingIds.length} blocking contract(s): ${s.blockingIds.map(render).join(', ')}`,
     );
   }
 }

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -1246,8 +1246,12 @@ export function buildParityReadout(
 
   // Seats = the sorted union of declared vendor-adapter values. A line counts
   // toward seat S when its contract is vendor-neutral (no vendor-adapter — it
-  // manifests on every seat) or declares S. Per-seat exists precisely so a
-  // seat-scoped skip cannot hide inside the global number (R1).
+  // manifests on every seat) or declares S. An EMPTY vendor-adapter list is
+  // treated as vendor-neutral too: the schema admits `[]`, and excluding such
+  // a row from every seat while counting it globally would reopen the exact
+  // per-seat honesty hole R1 exists to close (spec-owner review on #2328).
+  // Per-seat exists precisely so a seat-scoped skip cannot hide inside the
+  // global number (R1).
   const seats = [...new Set(contracts.flatMap((c) => c.vendorAdapter ?? []))].sort();
   const perSeat: Record<string, ReadoutCounts> = {};
   for (const seat of seats) perSeat[seat] = zero();
@@ -1255,7 +1259,9 @@ export function buildParityReadout(
   for (const r of rows) {
     const adapter = adapterById.get(r.id);
     for (const seat of seats) {
-      if (adapter === undefined || adapter.includes(seat)) perSeat[seat]![r.verdict] += 1;
+      if (adapter === undefined || adapter.length === 0 || adapter.includes(seat)) {
+        perSeat[seat]![r.verdict] += 1;
+      }
     }
   }
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1359,20 +1359,41 @@ program
     '--parity',
     'Run only the parity-drift sensor against the cohort parity manifest (mmnto-ai/totem-strategy#448)',
   )
+  .option(
+    '--json',
+    'With --parity: emit the trust-readout as a diffable JSON verdict artifact on stdout (mmnto-ai/totem#2327)',
+  )
   .action(
-    async (opts: {
-      pr?: boolean;
-      strict?: boolean;
-      claimDiscipline?: boolean;
-      scopeToDiff?: boolean;
-      parity?: boolean;
-    }) => {
+    async (
+      opts: {
+        pr?: boolean;
+        strict?: boolean;
+        claimDiscipline?: boolean;
+        scopeToDiff?: boolean;
+        parity?: boolean;
+        json?: boolean;
+      },
+      cmd: Command,
+    ) => {
       try {
+        // The program-level `--json` (top of file) swallows the flag when it
+        // appears after the subcommand (commander parent/child option collision,
+        // mmnto-ai/totem#2097, same fix as `totem mail --json`): merge both
+        // scopes so `totem doctor --parity --json` and `totem --json doctor
+        // --parity` agree.
+        opts.json = cmd.optsWithGlobals<{ json?: boolean }>().json;
         if (opts.claimDiscipline && opts.parity) {
           const { TotemConfigError } = await import('@mmnto/totem');
           throw new TotemConfigError(
             'Cannot combine --claim-discipline with --parity.',
             'Choose exactly one specialized doctor mode.',
+          );
+        }
+        if (opts.json && !opts.parity) {
+          const { TotemConfigError } = await import('@mmnto/totem');
+          throw new TotemConfigError(
+            '--json is the --parity trust-readout artifact (mmnto-ai/totem#2327).',
+            'Run totem doctor --parity --json.',
           );
         }
         if (opts.claimDiscipline) {
@@ -1386,7 +1407,7 @@ program
         }
         if (opts.parity) {
           const { doctorParityCliCommand } = await import('./commands/doctor-parity.js');
-          await doctorParityCliCommand({ strict: opts.strict });
+          await doctorParityCliCommand({ strict: opts.strict, json: opts.json });
           return;
         }
         const { doctorCommand } = await import('./commands/doctor.js');


### PR DESCRIPTION
Closes #2327

## What

Builds the `doctor --parity` **trust-readout** against the merged spec (Prop 303 §5(a); `doctrine/parity-manifest.md` § "The trust-readout — the doctor's output contract", `7fdb7ef`). Pure post-processing over the existing detector output — zero probes added (non-goal 2):

- **R1 — verdict rollup**, existing row vocabulary only, rendered global **and per-seat** (seats derived from `vendor-adapter`; vendor-neutral rows count toward every seat, so a seat-scoped skip can't hide in the global number).
- **R2 — coverage denominator** as its own lines: mechanically sensed / attestation-only / honest-absent, derived at run time from the routing branches themselves (each branch tags its contract's class — no mirrored registry, no manifest flag), plus the claim-boundary sentence in the readout's own words.
- **R3 — why-not** per non-PASS row: verdict, the `senses:` level actually probed (threaded per branch: value-equality/version-pin → `declared`, content-equality/content-hash → `present`, capability probes → their declared rung), reason class, attestation age in days.
- **R4 — `--json`** verdict artifact with the spec-fixed kebab-case field names, emitted bare on stdout (the spec's top-level shape overrides the local `json-output.ts` envelope). Routed through `optsWithGlobals` per the #2097 parent/child `--json` collision (same fix as `totem mail --json`).
- **R5 — `--strict` honesty**: `--strict (not armed): currently gates nothing — the manifest declares no blocking: true contracts` derived from the yaml at run time; a blocking row skipped by scoping renders `skipped-not-gated, never a silent pass`. Exit semantics unchanged.

## Deltas raised against the spec (not silently diverged)

Three source-level deltas went to the spec owner (strategy-claude, ECL dispatch `2026-07-09T2256Z`); the build uses these readings and **this PR holds for the spec owner's ack before merge**:

1. **`info` joins the vocabulary** — the shipped row states are six (`manual-attestation` rows render `info`); R1/R4 enumerate five. Mapping `info` into `skip`/`unknown` would launder an attested fork.
2. **Rollup counts rendered verdict lines; the denominator counts contracts** — multi-artifact contracts (e.g. `claude-skills`) render several lines with independent statuses; units are named apart in the output.
3. **`attestation` reason class** for `info` rows; `pass` rows omit `reason-class` (same omission convention as `last-attested?`).

One observation also flagged: reason-class for core-emitted skips derives from code-owned message shapes at the CLI edge (test-pinned); a future optional `reasonClass` on the core verdict type retires that coupling.

## Live validation

Driven against this repo's real manifest (36 contracts): coverage line reads **17 mechanically sensed · 6 attestation-only · 13 honest-absent** — exactly the census stated on #2327 (36 rows / 17 real detectors / 13 stubs / 6 info). Per-seat rows render for both live seats (claude, gemini); the `--json` artifact parses with the spec-fixed keys, 47 rows over 36 contracts (the delta-2 unit split, visible and labeled).

## Behavior notes

- `totem doctor --json` **without** `--parity` now errors explicitly ("--json is the --parity trust-readout artifact") instead of the flag being silently swallowed — fail-loud over silent-ignore.
- The per-row `[Parity]` output lines are byte-compatible; the readout is an additive tail. The `doctor --strict` parity fold is unchanged (no `json` threaded there).
- liquid-city CI's `doctor --strict` sees no behavior change (blocking set empty → the R5 toothless line, exit 0 — the fact the spec pointer called out).

## Verification

- 76/76 `doctor-parity` tests (63 existing untouched + 13 new: readout inputs/coverage classes, rollup units, per-seat, reason classes, skipped-not-gated, gates-anything both ways, strict fail-promotion in rows + rollup, JSON shape on ok/degenerate/strict-throw paths).
- Full CLI suite 3019/3019; full workspace build green; `totem lint --base main` 0 errors; `totem review` PASS (no findings); ESLint + prettier clean; pre-push battery green.
- Changeset: `@mmnto/cli` minor, carrying the first live `Consumer-impact: CLI surface` body tag per the release-planning doctrine (strategy#839).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
