### PR TITLE
feat(release): VP-PR cut sensor — Consumer-impact tag scan + path classifier + sticky choreography comment (#2325)

### DIFF
--- a/.github/workflows/vp-pr-cut-sensor.yml
+++ b/.github/workflows/vp-pr-cut-sensor.yml
@@ -18,11 +18,24 @@ permissions:
   contents: read
   pull-requests: write
 
+# Serialize per PR: overlapping synchronize runs could both miss the sticky
+# marker in the list-then-upsert flow and post duplicates (CR round 1).
+concurrency:
+  group: vp-pr-cut-sensor-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   cut-sensor:
     name: Classify the pending cut
-    if: github.event.pull_request.head.ref == 'changeset-release/main'
+    # Branch name AND same-repo origin: a fork can name its branch
+    # changeset-release/main, and on pull_request the job would check out the
+    # merge commit's (attacker-editable) tools script (CR round 1). Fork-PR
+    # tokens are read-only regardless — this guard is defense-in-depth.
+    if: |
+      github.event.pull_request.head.ref == 'changeset-release/main' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v7
 

--- a/.github/workflows/vp-pr-cut-sensor.yml
+++ b/.github/workflows/vp-pr-cut-sensor.yml
@@ -1,0 +1,39 @@
+# VP-PR cut sensor (mmnto-ai/totem#2325) — the release-planning doctrine's
+# totem-lane tooling (mmnto-ai/totem-strategy#839, packaging-conventions.md
+# § "Release planning — the meaningful-cut discipline").
+#
+# Fires ONLY on the changesets Version-Packages PR and posts/updates one
+# sticky comment classifying the pending cut (internal-only vs
+# contract-bearing + choreography template). Advisory, never a required
+# check — the operator's cut word on the VP-PR merge remains the gate
+# (Tenet 13). The feature-PR path is untouched.
+name: VP-PR Cut Sensor
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  cut-sensor:
+    name: Classify the pending cut
+    if: github.event.pull_request.head.ref == 'changeset-release/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      # Dependency-free script (global fetch) — no pnpm install needed.
+      - name: Scan changesets + classify entry paths + upsert the comment
+        run: node tools/vp-pr-cut-sensor.mjs --pr "$PR_NUMBER"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "release": "pnpm build && node tools/publish-oidc.mjs",
     "docs:inject": "node tools/docs-inject.cjs",
     "test:docs": "node tools/docs-transforms.test.cjs",
-    "test:augment-headers": "node tools/augment-cohort-changelog-headers.test.mjs"
+    "test:augment-headers": "node tools/augment-cohort-changelog-headers.test.mjs",
+    "test:cut-sensor": "node --test tools/vp-pr-cut-sensor.test.mjs"
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.98.0",

--- a/tools/vp-pr-cut-sensor.mjs
+++ b/tools/vp-pr-cut-sensor.mjs
@@ -126,15 +126,23 @@ export function parseChangelogAdditions(addedLines) {
  *
  * @param {{ declared: Array<{ hash: string, tag: string }>,
  *           flagged: Array<{ hash: string, classes: Map<string, string[]> }>,
- *           scannedEntryCount: number }} input
+ *           scannedEntryCount: number,
+ *           unresolved?: string[] }} input
  */
-export function composeComment({ declared, flagged, scannedEntryCount }) {
+export function composeComment({ declared, flagged, scannedEntryCount, unresolved = [] }) {
   const lines = [COMMENT_MARKER, '## Release-cut sensor (mmnto-ai/totem#2325)', ''];
 
   if (declared.length === 0 && flagged.length === 0) {
+    // An unscanned entry means the clean verdict is PARTIAL — say so rather
+    // than let "cut freely" overclaim (no silent coverage caps; CR round 1).
+    const qualifier =
+      unresolved.length > 0
+        ? ` **Partial verdict:** ${unresolved.length} entr${unresolved.length === 1 ? 'y' : 'ies'} could not be scanned (see below).`
+        : '';
     lines.push(
       '**Verdict: `internal-only: cut freely`** — no `Consumer-impact:` tags declared and no contract-shaped paths flagged across ' +
-        `${scannedEntryCount} changelog entr${scannedEntryCount === 1 ? 'y' : 'ies'}.`,
+        `${scannedEntryCount} changelog entr${scannedEntryCount === 1 ? 'y' : 'ies'}.` +
+        qualifier,
       '',
     );
   } else {
@@ -173,6 +181,15 @@ export function composeComment({ declared, flagged, scannedEntryCount }) {
     );
   }
 
+  // Unscanned entries render in EVERY verdict shape — a coverage gap the
+  // reader can see beats a clean-looking comment that quietly skipped work.
+  if (unresolved.length > 0) {
+    lines.push(
+      `**⚠ Unscanned entries** (commit unresolvable — classify by hand before trusting the verdict): ${unresolved.map((h) => `\`${h}\``).join(', ')}`,
+      '',
+    );
+  }
+
   lines.push(
     '---',
     "_Advisory only (Tenet 13) — the cut gate is unchanged: the operator's merge word on this VP-PR remains the gate. " +
@@ -184,13 +201,21 @@ export function composeComment({ declared, flagged, scannedEntryCount }) {
 
 // ─── GitHub API (dependency-free) ────────────────────────
 
+/** Per-request cap — a hung fetch fails fast instead of eating the job timeout. */
+const REQUEST_TIMEOUT_MS = 30_000;
+
 async function gh(token, url, init = {}) {
   const res = await fetch(`https://api.github.com${url}`, {
     ...init,
+    signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     headers: {
       authorization: `Bearer ${token}`,
       accept: 'application/vnd.github+json',
       'x-github-api-version': '2022-11-28',
+      // The REST contract wants an explicit JSON content-type on bodied
+      // requests; Node fetch would otherwise default a string body to
+      // text/plain (GCA + greptile round 1).
+      ...(init.body !== undefined ? { 'content-type': 'application/json' } : {}),
       ...(init.headers ?? {}),
     },
   });
@@ -245,23 +270,27 @@ async function main() {
 
   const declared = [];
   const flagged = [];
+  const unresolved = [];
   for (const [hash, entry] of entries) {
     for (const tag of entry.tags) declared.push({ hash, tag });
     if (entry.tags.length > 0) continue; // declaration carries intent; no double-flag
     // Path classification via the entry's squash commit (best-effort: a
-    // garbage-collected or ambiguous shorthash degrades to unclassified —
-    // the sensor reports what it could scan, never crashes the job).
+    // garbage-collected or ambiguous shorthash degrades to UNSCANNED — carried
+    // into the comment so the coverage gap is visible, never a silent drop).
     try {
       const commit = await gh(token, `/repos/${repo}/commits/${hash}`);
       const paths = (commit.files ?? []).map((f) => f.filename);
       const classes = classifyPaths(paths);
       if (classes.size > 0) flagged.push({ hash, classes });
     } catch (err) {
-      console.error(`[cut-sensor] commit ${hash} unresolvable — skipped: ${String(err)}`);
+      console.error(
+        `[cut-sensor] commit ${hash} unresolvable — reported unscanned: ${String(err)}`,
+      );
+      unresolved.push(hash);
     }
   }
 
-  const body = composeComment({ declared, flagged, scannedEntryCount: entries.size });
+  const body = composeComment({ declared, flagged, scannedEntryCount: entries.size, unresolved });
 
   if (dryRun) {
     console.log(body);

--- a/tools/vp-pr-cut-sensor.mjs
+++ b/tools/vp-pr-cut-sensor.mjs
@@ -1,0 +1,296 @@
+#!/usr/bin/env node
+/**
+ * VP-PR cut sensor (mmnto-ai/totem#2325) — the totem-lane tooling half of the
+ * release-planning doctrine (mmnto-ai/totem-strategy#839,
+ * doctrine/packaging-conventions.md § "Release planning — the meaningful-cut
+ * discipline", § Mechanism items 1–3).
+ *
+ * Runs ONLY against a Version-Packages PR (the changesets release branch) and
+ * posts/updates ONE sticky comment classifying the pending cut:
+ *
+ *   1. `Consumer-impact:` body-tag scan over the VP-PR's ADDED CHANGELOG lines
+ *      (at VP-PR time the changesets are consumed; the added-CHANGELOG side is
+ *      exactly what ships to consumers).
+ *   2. Path-heuristic classifier: each changelog entry leads with its squash
+ *      commit's shorthash (`- abc1234: …`); the commit's changed paths are
+ *      matched against the contract-bearing seam table so UNTAGGED
+ *      contract-shaped entries get flagged.
+ *   3. One sticky comment (marker + update-in-place): `internal-only: cut
+ *      freely`, or `contract-bearing: <classes>` + the choreography template.
+ *
+ * NO new gate (Tenet 13, sensors-not-actuators): the comment is advisory; the
+ * operator's cut word on the VP-PR merge remains the gate. Heuristics will
+ * over-flag and miss by design — declaration carries intent, the sensor
+ * catches the miss; grow the seam table by mining real misses at real cuts.
+ *
+ * Usage: node tools/vp-pr-cut-sensor.mjs --pr <number> [--dry-run]
+ * Env:   GITHUB_TOKEN (posting + API reads), GITHUB_REPOSITORY (owner/repo)
+ */
+
+import * as process from 'node:process';
+import { pathToFileURL } from 'node:url';
+
+/** Sticky-comment marker — the upsert key. Keep stable across versions. */
+export const COMMENT_MARKER = '<!-- totem:vp-pr-cut-sensor -->';
+
+/**
+ * Contract-bearing seam table, seeded from the doctrine's class catalog
+ * (mmnto-ai/totem#2325). Path heuristics only — the weakest classes
+ * (gate-coupled warnings) carry no path signal and rely on declaration.
+ * Root package.json is a two-class collision (toolchain floors ∪
+ * restricted-pin bumps); flagged under one merged label rather than guessed.
+ */
+export const SEAM_RULES = [
+  {
+    cls: 'consumer config schema',
+    test: (p) => p === 'packages/core/src/config-schema.ts',
+  },
+  {
+    cls: 'ECL / file / wire formats',
+    test: (p) =>
+      /^packages\/(cli|core)\/src\/(commands\/)?(mail|ecl-)/.test(p) ||
+      p === 'packages/core/src/compiler-schema.ts',
+  },
+  {
+    cls: 'init-distributed content',
+    test: (p) => /^packages\/cli\/src\/commands\/init/.test(p),
+  },
+  {
+    cls: 'CLI surface',
+    test: (p) => p === 'packages/cli/src/index.ts',
+  },
+  {
+    cls: 'machine surfaces',
+    test: (p) => p === 'action.yml' || p.startsWith('packages/mcp/src/'),
+  },
+  {
+    cls: 'toolchain floors / restricted-pin (root manifest)',
+    test: (p) => p === 'package.json' || p === 'pnpm-workspace.yaml',
+  },
+];
+
+/**
+ * Classify one commit's changed paths against the seam table. Test files are
+ * excluded up front — a contract change ships in product source; test-only
+ * churn against a seam path is not a consumer obligation.
+ */
+export function classifyPaths(paths) {
+  const productPaths = paths.filter((p) => !/\.test\.(ts|tsx|mjs|cjs|js)$/.test(p));
+  const hits = new Map();
+  for (const rule of SEAM_RULES) {
+    const matched = productPaths.filter((p) => rule.test(p));
+    if (matched.length > 0) hits.set(rule.cls, matched);
+  }
+  return hits;
+}
+
+/**
+ * Parse the VP-PR's ADDED changelog lines into per-entry records.
+ *
+ * An entry opens at `- <shorthash>: …`; a `Consumer-impact: <text>` line
+ * belongs to the entry it appears under (the changeset body ships into the
+ * entry's own body). `Updated dependencies [<hash>]` lines repeat entry
+ * hashes for downstream packages — deduped, never opening a new tag scope.
+ *
+ * @param {string[]} addedLines lines added in CHANGELOG.md hunks (no '+' prefix)
+ * @returns {{ entries: Map<string, { tags: string[] }> }}
+ */
+export function parseChangelogAdditions(addedLines) {
+  const entries = new Map();
+  let current;
+  for (const line of addedLines) {
+    const open = /^- ([0-9a-f]{7,12}): /.exec(line);
+    if (open) {
+      current = open[1];
+      if (!entries.has(current)) entries.set(current, { tags: [] });
+      continue;
+    }
+    const dep = /^- Updated dependencies \[([0-9a-f]{7,12})\]/.exec(line);
+    if (dep) {
+      if (!entries.has(dep[1])) entries.set(dep[1], { tags: [] });
+      // A dependency-echo line is not a tag scope — the body that follows
+      // belongs to no entry.
+      current = undefined;
+      continue;
+    }
+    const tag = /Consumer-impact:\s*(.+)/.exec(line);
+    if (tag && current !== undefined) {
+      entries.get(current).tags.push(tag[1].trim());
+    }
+  }
+  return { entries };
+}
+
+/**
+ * Compose the sticky comment body.
+ *
+ * @param {{ declared: Array<{ hash: string, tag: string }>,
+ *           flagged: Array<{ hash: string, classes: Map<string, string[]> }>,
+ *           scannedEntryCount: number }} input
+ */
+export function composeComment({ declared, flagged, scannedEntryCount }) {
+  const lines = [COMMENT_MARKER, '## Release-cut sensor (mmnto-ai/totem#2325)', ''];
+
+  if (declared.length === 0 && flagged.length === 0) {
+    lines.push(
+      '**Verdict: `internal-only: cut freely`** — no `Consumer-impact:` tags declared and no contract-shaped paths flagged across ' +
+        `${scannedEntryCount} changelog entr${scannedEntryCount === 1 ? 'y' : 'ies'}.`,
+      '',
+    );
+  } else {
+    const classSet = new Set();
+    for (const d of declared) classSet.add(d.tag);
+    for (const f of flagged)
+      for (const cls of f.classes.keys()) classSet.add(`${cls} (untagged ⚠)`);
+    lines.push(
+      `**Verdict: \`contract-bearing\`** — ${[...classSet].map((c) => `\`${c}\``).join(' · ')}`,
+      '',
+    );
+    if (declared.length > 0) {
+      lines.push('**Declared (`Consumer-impact:` tags):**', '');
+      for (const d of declared) lines.push(`- \`${d.hash}\`: ${d.tag}`);
+      lines.push('');
+    }
+    if (flagged.length > 0) {
+      lines.push(
+        '**⚠ Untagged contract-shaped entries** (path heuristics — verify each, then tag the changeset entry or dismiss here):',
+        '',
+      );
+      for (const f of flagged) {
+        for (const [cls, paths] of f.classes) {
+          lines.push(`- \`${f.hash}\`: ${cls} — \`${paths.join('`, `')}\``);
+        }
+      }
+      lines.push('');
+    }
+    lines.push(
+      '### Choreography (fill before the cut word)',
+      '',
+      '- **Which consumers move:** _…_',
+      '- **In what order:** _…_',
+      '- **Who owns which half:** _…_',
+      '',
+    );
+  }
+
+  lines.push(
+    '---',
+    "_Advisory only (Tenet 13) — the cut gate is unchanged: the operator's merge word on this VP-PR remains the gate. " +
+      'Doctrine: `packaging-conventions.md` § "Release planning — the meaningful-cut discipline" (mmnto-ai/totem-strategy#839). ' +
+      'Heuristic misses are seam-table mining input, not sensor failures._',
+  );
+  return lines.join('\n');
+}
+
+// ─── GitHub API (dependency-free) ────────────────────────
+
+async function gh(token, url, init = {}) {
+  const res = await fetch(`https://api.github.com${url}`, {
+    ...init,
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: 'application/vnd.github+json',
+      'x-github-api-version': '2022-11-28',
+      ...(init.headers ?? {}),
+    },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `GitHub API ${init.method ?? 'GET'} ${url} → ${res.status}: ${await res.text()}`,
+    );
+  }
+  return res.json();
+}
+
+/** All pages of a list endpoint (per_page=100). */
+async function ghPaged(token, url) {
+  const all = [];
+  for (let page = 1; ; page++) {
+    const sep = url.includes('?') ? '&' : '?';
+    const batch = await gh(token, `${url}${sep}per_page=100&page=${page}`);
+    all.push(...batch);
+    if (batch.length < 100) return all;
+  }
+}
+
+/** Extract added lines from CHANGELOG.md patches on the VP-PR. */
+export function addedChangelogLines(files) {
+  const lines = [];
+  for (const f of files) {
+    if (!f.filename.endsWith('CHANGELOG.md') || typeof f.patch !== 'string') continue;
+    for (const raw of f.patch.split('\n')) {
+      if (raw.startsWith('+') && !raw.startsWith('+++')) lines.push(raw.slice(1));
+    }
+  }
+  return lines;
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const prIdx = args.indexOf('--pr');
+  const prNumber = prIdx >= 0 ? Number(args[prIdx + 1]) : NaN;
+  const dryRun = args.includes('--dry-run');
+  const token = process.env.GITHUB_TOKEN;
+  const repo = process.env.GITHUB_REPOSITORY;
+  if (!Number.isInteger(prNumber) || !token || !repo) {
+    console.error(
+      'usage: GITHUB_TOKEN=… GITHUB_REPOSITORY=owner/repo node tools/vp-pr-cut-sensor.mjs --pr <number> [--dry-run]',
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  const files = await ghPaged(token, `/repos/${repo}/pulls/${prNumber}/files`);
+  const { entries } = parseChangelogAdditions(addedChangelogLines(files));
+
+  const declared = [];
+  const flagged = [];
+  for (const [hash, entry] of entries) {
+    for (const tag of entry.tags) declared.push({ hash, tag });
+    if (entry.tags.length > 0) continue; // declaration carries intent; no double-flag
+    // Path classification via the entry's squash commit (best-effort: a
+    // garbage-collected or ambiguous shorthash degrades to unclassified —
+    // the sensor reports what it could scan, never crashes the job).
+    try {
+      const commit = await gh(token, `/repos/${repo}/commits/${hash}`);
+      const paths = (commit.files ?? []).map((f) => f.filename);
+      const classes = classifyPaths(paths);
+      if (classes.size > 0) flagged.push({ hash, classes });
+    } catch (err) {
+      console.error(`[cut-sensor] commit ${hash} unresolvable — skipped: ${String(err)}`);
+    }
+  }
+
+  const body = composeComment({ declared, flagged, scannedEntryCount: entries.size });
+
+  if (dryRun) {
+    console.log(body);
+    return;
+  }
+
+  const comments = await ghPaged(token, `/repos/${repo}/issues/${prNumber}/comments`);
+  const existing = comments.find(
+    (c) => typeof c.body === 'string' && c.body.includes(COMMENT_MARKER),
+  );
+  if (existing) {
+    await gh(token, `/repos/${repo}/issues/comments/${existing.id}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ body }),
+    });
+    console.error(`[cut-sensor] updated comment ${existing.id} on PR #${prNumber}`);
+  } else {
+    await gh(token, `/repos/${repo}/issues/${prNumber}/comments`, {
+      method: 'POST',
+      body: JSON.stringify({ body }),
+    });
+    console.error(`[cut-sensor] posted comment on PR #${prNumber}`);
+  }
+}
+
+// Only run main() when executed directly (not when imported by tests).
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error(`[cut-sensor] ${String(err)}`);
+    process.exitCode = 1;
+  });
+}

--- a/tools/vp-pr-cut-sensor.test.mjs
+++ b/tools/vp-pr-cut-sensor.test.mjs
@@ -1,0 +1,105 @@
+/**
+ * Tests for the VP-PR cut sensor's pure functions (mmnto-ai/totem#2325).
+ * Run: node --test tools/vp-pr-cut-sensor.test.mjs (root script test:cut-sensor).
+ */
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  addedChangelogLines,
+  classifyPaths,
+  COMMENT_MARKER,
+  composeComment,
+  parseChangelogAdditions,
+} from './vp-pr-cut-sensor.mjs';
+
+test('addedChangelogLines: only CHANGELOG.md additions, +++ header excluded', () => {
+  const files = [
+    {
+      filename: 'packages/cli/CHANGELOG.md',
+      patch:
+        '+++ b/packages/cli/CHANGELOG.md\n+## 1.92.0\n+- abc1234: feat: thing\n-old line\n context',
+    },
+    { filename: 'packages/cli/package.json', patch: '+  "version": "1.92.0",' },
+    { filename: '.changeset/some-entry.md', patch: '-Consumer-impact: CLI surface' },
+  ];
+  assert.deepEqual(addedChangelogLines(files), ['## 1.92.0', '- abc1234: feat: thing']);
+});
+
+test('parseChangelogAdditions: tags bind to their opening entry; dependency echoes never scope', () => {
+  const { entries } = parseChangelogAdditions([
+    '- abc1234: feat(cli): tagged thing',
+    '',
+    '  Some body prose.',
+    '',
+    '  Consumer-impact: CLI surface — new flag',
+    '- def5678: fix(core): untagged thing',
+    '- Updated dependencies [abc1234]',
+    '  - @mmnto/totem@1.92.0',
+    '  Consumer-impact: orphaned tag outside any entry scope',
+  ]);
+  assert.deepEqual([...entries.keys()], ['abc1234', 'def5678']);
+  assert.deepEqual(entries.get('abc1234').tags, ['CLI surface — new flag']);
+  assert.deepEqual(entries.get('def5678').tags, []);
+});
+
+test('classifyPaths: seam table hits with matched paths; non-seam paths silent', () => {
+  const hits = classifyPaths([
+    'packages/core/src/config-schema.ts',
+    'packages/cli/src/commands/mail.ts',
+    'packages/cli/src/commands/shield-eval.integration.test.ts',
+    'docs/reference/architecture.md',
+  ]);
+  assert.deepEqual([...hits.keys()], ['consumer config schema', 'ECL / file / wire formats']);
+  assert.deepEqual(hits.get('ECL / file / wire formats'), ['packages/cli/src/commands/mail.ts']);
+});
+
+test('classifyPaths: test files never flag, even on seam paths', () => {
+  const hits = classifyPaths([
+    'packages/cli/src/commands/mail.test.ts',
+    'packages/cli/src/commands/ecl-gc.test.ts',
+    'packages/core/src/config-schema.test.ts',
+  ]);
+  assert.equal(hits.size, 0);
+});
+
+test('classifyPaths: machine surfaces + root manifest classes', () => {
+  const hits = classifyPaths(['action.yml', 'packages/mcp/src/tools/search.ts', 'package.json']);
+  assert.deepEqual(
+    [...hits.keys()],
+    ['machine surfaces', 'toolchain floors / restricted-pin (root manifest)'],
+  );
+  assert.deepEqual(hits.get('machine surfaces'), [
+    'action.yml',
+    'packages/mcp/src/tools/search.ts',
+  ]);
+});
+
+test('composeComment: internal-only shape when nothing declared or flagged', () => {
+  const body = composeComment({ declared: [], flagged: [], scannedEntryCount: 3 });
+  assert.ok(body.startsWith(COMMENT_MARKER));
+  assert.match(body, /internal-only: cut freely/);
+  assert.match(body, /3 changelog entries/);
+  assert.match(body, /Advisory only \(Tenet 13\)/);
+  assert.doesNotMatch(body, /Choreography/);
+});
+
+test('composeComment: contract-bearing shape carries declared tags, untagged flags, and the choreography template', () => {
+  const body = composeComment({
+    declared: [{ hash: 'abc1234', tag: 'CLI surface — new flag' }],
+    flagged: [
+      {
+        hash: 'def5678',
+        classes: new Map([['ECL / file / wire formats', ['packages/cli/src/commands/mail.ts']]]),
+      },
+    ],
+    scannedEntryCount: 2,
+  });
+  assert.match(body, /contract-bearing/);
+  assert.match(body, /`abc1234`: CLI surface — new flag/);
+  assert.match(body, /untagged ⚠/);
+  assert.match(body, /`def5678`: ECL \/ file \/ wire formats/);
+  assert.match(body, /Which consumers move/);
+  assert.match(body, /operator's merge word on this VP-PR remains the gate/);
+});

--- a/tools/vp-pr-cut-sensor.test.mjs
+++ b/tools/vp-pr-cut-sensor.test.mjs
@@ -85,6 +85,26 @@ test('composeComment: internal-only shape when nothing declared or flagged', () 
   assert.doesNotMatch(body, /Choreography/);
 });
 
+test('composeComment: unresolved entries render in the comment and qualify a clean verdict as partial', () => {
+  const clean = composeComment({
+    declared: [],
+    flagged: [],
+    scannedEntryCount: 2,
+    unresolved: ['dead1234'],
+  });
+  assert.match(clean, /internal-only: cut freely/);
+  assert.match(clean, /Partial verdict/);
+  assert.match(clean, /Unscanned entries.*`dead1234`/);
+
+  const bearing = composeComment({
+    declared: [{ hash: 'abc1234', tag: 'CLI surface' }],
+    flagged: [],
+    scannedEntryCount: 2,
+    unresolved: ['dead1234'],
+  });
+  assert.match(bearing, /Unscanned entries.*`dead1234`/);
+});
+
 test('composeComment: contract-bearing shape carries declared tags, untagged flags, and the choreography template', () => {
   const body = composeComment({
     declared: [{ hash: 'abc1234', tag: 'CLI surface — new flag' }],


### PR DESCRIPTION
Closes #2325

## What

The totem-lane tooling half of the release-planning doctrine (couples to [mmnto-ai/totem-strategy#839](https://github.com/mmnto-ai/totem-strategy/pull/839), `packaging-conventions.md` § "Release planning — the meaningful-cut discipline", § Mechanism items 1–3):

- **`tools/vp-pr-cut-sensor.mjs`** — dependency-free (global fetch, Node 24): scans the VP-PR's **added CHANGELOG lines** for `Consumer-impact:` body tags (the added-CHANGELOG side is exactly what ships to consumers); for **untagged** entries, resolves each entry's squash commit by its leading shorthash and classifies its changed paths against the doctrine-seeded seam table; composes ONE sticky comment (`<!-- totem:vp-pr-cut-sensor -->`, update-in-place) — `internal-only: cut freely`, or `contract-bearing: <classes>` + the choreography template + `⚠ untagged` rows.
- **`.github/workflows/vp-pr-cut-sensor.yml`** — fires only when `head.ref == 'changeset-release/main'` (the changesets VP-PR; the release workflow's `RELEASE_TOKEN` push means the event does fire). Advisory job, never a required check.
- Pure functions exported and covered by `pnpm run test:cut-sensor` (node --test, 7 passing), following the `test:docs`/`test:augment-headers` tools pattern.

## Doctrine invariants held

- **Zero new gate** (Tenet 13): the comment is advisory; the operator's cut word on the VP-PR merge remains the gate. Internal-only path adds one comment and nothing else; the feature-PR path is untouched.
- **Declaration carries intent; the sensor catches the miss**: tagged entries are never double-flagged; heuristic misses are named seam-table mining input in the comment's own footer.
- Test files are excluded from seam matching (test-only churn on a seam path is not a consumer obligation).
- Root `package.json` is a two-class path collision (toolchain floors ∪ restricted-pin) — flagged under one merged label rather than guessed.

## Live validation

Dry-run against the **open VP-PR #2322**: verdict `contract-bearing`, flagging `2b14228` (the #2321 pollMail cross-sender collision sensor) as untagged `ECL / file / wire formats` via `packages/cli/src/commands/mail.ts` — which is exactly right: that entry is the doctrine's own **gate-coupled warnings** exhibit and predates the tag convention. The first tagged exercise arrives with #2328's changeset, which carries a live `Consumer-impact: CLI surface` line.

## Verification

- 7/7 unit tests (`pnpm run test:cut-sensor`); `totem lint --base main` PASS (0 errors); prettier clean; pre-push battery green (6362 unit tests).
- `totem review` raised one CRITICAL that is a **verified false positive**: the review pipeline's secret-redaction rewrote `process.env.GITHUB_TOKEN` to `REDACTED` before the model saw the diff, and the model flagged the placeholder as an undefined variable (its own remediation text names the correct code that is already there; the script also executed live twice). Filed as #2329 with the exhibit — declined here with that evidence.
- No changeset: repo-internal release tooling (workflow + tools script), no consumer package surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
