### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine 0.1.15 -> 0.1.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "typescript-eslint": "^8.59.4"
   },
   "optionalDependencies": {
-    "@mmnto/strategy-doctrine": "0.1.15"
+    "@mmnto/strategy-doctrine": "0.1.16"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         version: 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
     optionalDependencies:
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.15
-        version: 0.1.15
+        specifier: 0.1.16
+        version: 0.1.16
 
   packages/cli:
     dependencies:
@@ -853,8 +853,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.15':
-    resolution: {integrity: sha512-TcoGEEybIzQMm89EzmDQn9PVFoEoBznz1DN7/mU+oPe0LgQbfe3wYD8vDmd5FSjVoq/HWBdFmeyygMWidHKbdw==}
+  '@mmnto/strategy-doctrine@0.1.16':
+    resolution: {integrity: sha512-TDfIEOEM7K1o3l00PxXcYJDwyrtVaXOji93rOUgioMHipcnPOLaLFcxDkFG5gDvwh0iaaiqXnNsmFeLGprtXcQ==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3685,7 +3685,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.15':
+  '@mmnto/strategy-doctrine@0.1.16':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
Cohort doctrine-pin sync: `@mmnto/strategy-doctrine` 0.1.15 → 0.1.16 (the gemini-skills parity-row cut, `mmnto-ai/totem-strategy@27a94ac`, published via OIDC 2026-07-09T18:50Z).

Verified post-install on this branch: doctrine **present** at 0.1.16 in `node_modules` (the mmnto-ai/totem-strategy#630 silent-uninstall check — the first attempt at this bump fired that trap on a dead npm token; evidence banked, token refreshed, clean run) and `totem doctor --parity` renders the pin row **PASS — installed 0.1.16 ≥ cohort floor 0.1.16**.

Root-manifest-only (private monorepo root, no published package surface) — no changeset. The three `git-hooks` WARNs in the doctor output predate this diff (only `package.json` + `pnpm-lock.yaml` change here).

Sibling bumps: totem-status (same bump, no lockfile — gitignored there) lands in parallel; liquid-city is nudged via ECL (self-handles per convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
