### PR TITLE
docs: strategy#531 Pass-2 public-surface truth pass (V1-V7 verified, net -571 words)

### DIFF
--- a/docs/wiki/cli-reference.md
+++ b/docs/wiki/cli-reference.md
@@ -6,12 +6,12 @@ This document provides a detailed breakdown of the `totem` command-line interfac
 >
 > **Global Flags:** Every Totem command supports the `--json` flag to output structured JSON instead of human-readable text. This makes it trivial to pipe Totem into your own automation scripts or UI dashboards (e.g., `totem status --json`).
 
-> **Standalone Binary (Totem Lite):** If you are using the compiled standalone binary (no Node.js required), certain commands that require the LLM orchestrator or local Vector database are excluded to keep the binary small (~35MB).
+> **Standalone Binary (Totem Lite):** If you are using the compiled standalone binary (no Node.js required), commands that require the LLM orchestrator or local Vector database are excluded to keep the binary small.
 >
-> - **Available in Lite:** `init`, `lint`, `hooks`, `compile` (AST/Regex), `doctor`, `status`, `rule list`
-> - **Excluded in Lite:** `review`, `sync`, `extract`, `spec`, `triage`
+> - **Available in Lite:** `init`, `lint`, `hooks`, `doctor`, `status`, `rule list`
+> - **Excluded in Lite:** `review`, `sync`, `extract`, `spec`, `triage`, `lesson compile`, and the other orchestrator- or index-dependent commands
 >
-> Excluded commands will show a `[Totem Lite]` tag in the `--help` menu and will exit with status code `78` (Configuration Error) if invoked, prompting you to install the full Node.js package.
+> Excluded commands are tagged `[requires full install]` in the `--help` menu and exit with status code `78` (configuration error) if invoked, prompting you to install the full Node.js package.
 
 ---
 

--- a/docs/wiki/cloud-compilation.md
+++ b/docs/wiki/cloud-compilation.md
@@ -1,6 +1,6 @@
 # Cloud Compilation
 
-> **Status (1.25.0):** Cloud compilation is **off the recommended path**. The cloud worker currently routes through Gemini Pro, which benchmarked lower for compile correctness than Claude Sonnet (73% vs 90% per Strategy #73). It also does not benefit from the prompt-caching layer that local Anthropic compile uses. Migration of the cloud worker to Claude Sonnet is tracked as [mmnto-ai/totem#1221](https://github.com/mmnto-ai/totem/issues/1221) and remains open. Use local compilation (the default) for production work.
+> **Status (2026-07-12):** Cloud compilation is **off the recommended path**. The cloud worker routes through Gemini Pro, which benchmarked lower for compile correctness than Claude Sonnet (73% vs 90% per Strategy #73), and does not benefit from the prompt-caching layer that local Anthropic compile uses. A migration of the cloud worker to Claude Sonnet was considered and declined ([mmnto-ai/totem#1221](https://github.com/mmnto-ai/totem/issues/1221), closed not-planned 2026-05-11). Use local compilation (the default) for production work.
 
 Totem supports offloading rule compilation to a self-hosted Cloud Run worker for parallel fan-out. This is optional infrastructure for teams that want bulk-compile throughput at the cost of compile quality. Local compilation works out of the box with no additional infrastructure and is the canonical path.
 
@@ -46,7 +46,3 @@ gcloud auth login
 | Full recompile (300+ rules) | ~30 min cache-warm      | ~2 min                      |
 
 The cloud worker exists for environments where wall-clock matters more than per-rule precision. For most teams the local Sonnet path is faster end to end once you account for the iteration cost of fixing noisy rules that the lower-correctness cloud worker emits.
-
-## When the Cloud Worker Becomes Recommended
-
-The cloud-vs-local recommendation flips when [mmnto-ai/totem#1221](https://github.com/mmnto-ai/totem/issues/1221) ships and the cloud worker routes through Claude Sonnet. At that point cloud will combine Sonnet's correctness with parallel fan-out throughput. This document will get updated when the migration lands.

--- a/docs/wiki/governing-ai-agents.md
+++ b/docs/wiki/governing-ai-agents.md
@@ -39,7 +39,7 @@ $ git push
 [Lint] Verdict: FAIL — Fix violations before pushing.
 ```
 
-The agent cannot bypass this. When the lint gate fails, the push is rejected, and the agent is forced to fix the violation before trying again. The agent learns the architecture through mechanical failure, not by reading documentation.
+When the lint gate fails, the push is rejected until the agent fixes the violation. The agent learns the architecture through mechanical failure, not by reading documentation. Bypassing the hook takes an explicit `git push --no-verify` — and CI re-runs the same gates against the pushed tree, so the violation still surfaces in the PR checks.
 
 ## 3. MCP Knowledge Base
 

--- a/docs/wiki/it-never-happens-again.md
+++ b/docs/wiki/it-never-happens-again.md
@@ -33,7 +33,7 @@ Markdown is readable by humans but not enforceable by machines.
 totem lesson compile
 ```
 
-Totem's compiler reads the lesson and generates a deterministic AST or regex rule tailored to your codebase. The rule is saved to `.totem/compiled-rules.json`.
+Totem's compiler reads the lesson and generates a deterministic AST or regex rule tailored to your codebase. The rule is saved to `.totem/compiled-rules.json`. Structural lessons compile this way; behavioral and process lessons stay as retrievable context for AI review instead — that boundary is measured, not aspirational (ADR-091).
 
 From this point forward, no LLM is involved in enforcement.
 
@@ -55,4 +55,4 @@ No review comment. No back-and-forth. The violation is caught before the code le
 
 ## The Result
 
-The mistake happened once. It was extracted, compiled, and enforced. The same class of error is now mechanically impossible to merge, regardless of whether the author is a human, Claude, Gemini, or Cursor.
+The mistake happened once. It was extracted, compiled, and enforced. The same compiled pattern can't ship past the linter once the hook or CI runs and the rule matches — regardless of whether the author is a human, Claude, Gemini, or Cursor.

--- a/docs/wiki/it-never-happens-again.md
+++ b/docs/wiki/it-never-happens-again.md
@@ -33,7 +33,7 @@ Markdown is readable by humans but not enforceable by machines.
 totem lesson compile
 ```
 
-Totem's compiler reads the lesson and generates a deterministic AST or regex rule tailored to your codebase. The rule is saved to `.totem/compiled-rules.json`. Structural lessons compile this way; behavioral and process lessons stay as retrievable context for AI review instead — that boundary is measured, not aspirational (ADR-091).
+Totem's compiler reads the lesson and generates a deterministic AST or regex rule tailored to your codebase. The rule is saved to `.totem/compiled-rules.json`. Structural lessons compile this way; behavioral and process lessons stay as retrievable context for AI review instead (ADR-091's measured boundary).
 
 From this point forward, no LLM is involved in enforcement.
 

--- a/docs/wiki/metrics.md
+++ b/docs/wiki/metrics.md
@@ -1,6 +1,6 @@
 # Architecture & Metrics
 
-Totem tracks advanced telemetry on rule execution to identify false positives and drive the self-healing loop.
+Totem tracks telemetry on rule execution to identify false positives and drive the self-healing loop.
 
 ## RuleMetric schema
 

--- a/docs/wiki/override-directives.md
+++ b/docs/wiki/override-directives.md
@@ -11,7 +11,7 @@ This is the **Semantic Overlay**. It is the unified, primary mechanism for overr
 When you use `totem-context:`, you are telling the system: _"I know this breaks a rule, and here is my exact architectural reasoning for why it is necessary."_
 
 - **Rule Engine:** It strictly suppresses the deterministic `totem lint` error for the following block of code.
-- **Telemetry:** It writes an `exception` event into the **Trap Ledger**, capturing your reason. If a rule accumulates too many of these contexts, Totem will automatically downgrade the rule via `totem doctor --pr`.
+- **Telemetry:** It writes a `suppress` event into the **Trap Ledger**, capturing your reason. If a rule accumulates too many of these contexts, Totem will automatically downgrade the rule via `totem doctor --pr`.
 - **Review Layer:** During an AI-powered `totem review`, the LLM reads your context as a semantic hint and incorporates your logic into its evaluation, rather than blindly flagging the violation.
 
 **Example:**

--- a/docs/wiki/pipeline-engine.md
+++ b/docs/wiki/pipeline-engine.md
@@ -2,7 +2,7 @@
 
 Totem 1.9.0 introduces the Pipeline Engine, the core subsystem that governs how institutional knowledge (lessons) becomes deterministically enforced code constraints (rules).
 
-The Pipeline Engine is built around the **Create → Enforce Lifecycle**. It moves Totem from a simple linter to a structural governance platform.
+The Pipeline Engine is built around the **Create → Enforce Lifecycle**.
 
 ## The Pipelines (P1–P5)
 
@@ -92,7 +92,7 @@ Totem will leverage the LLM (P3) to infer the exact structural constraint from y
 
 ### Pipeline 4: Importing Rules
 
-Instantly ingest your team's historical ESLint restrictions into the fast, deterministic Totem engine:
+Ingest your team's historical ESLint restrictions into the fast, deterministic Totem engine:
 
 ```bash
 totem import --from-eslint ./eslint.config.mjs

--- a/docs/wiki/roadmap.md
+++ b/docs/wiki/roadmap.md
@@ -1,54 +1,14 @@
 # Totem Roadmap
 
-This document outlines the strategic milestones for the Totem project.
+Totem is a standard library for codebase governance — deterministic primitives that let teams enforce architectural boundaries on AI agents without opinionated workflows.
 
-Totem is a standard library for codebase governance — deterministic primitives that let teams enforce architectural boundaries on AI agents without opinionated workflows. The roadmap below tracks the active progression of enforcement primitives, platform validation, and rule distribution.
+This page keeps the dated history of what has shipped. Current and planned work is not mirrored here — it lives in the trackers:
 
----
+- [Releases](https://github.com/mmnto-ai/totem/releases) — what shipped, when.
+- [GitHub Project: Convergent Spine](https://github.com/orgs/mmnto-ai/projects/1) — in-flight work.
+- [Open issues](https://github.com/mmnto-ai/totem/issues) — the backlog.
 
-## 1.26.0: Pack Ecosystem Graduation (Active)
-
-**Theme:** Close the Pack v0.1 alpha pilot by closing the remaining language-pack publish-and-wire arc and starting the convention-rule deterministic substrate that replaces LLM-prose enforcement (Tenet 15 violations surfaced by drift firing across multiple agents and repos).
-
-The strategic frame is **publishing without runtime-wiring is incomplete; ship gates require both**. The substrate-wiring gap shipped in `mmnto-ai/totem#1795` (1.25.0) closed the runtime-completeness leg of the alpha-pilot graduation gate.
-
-> **Note on bot packs.** A "Bot Interpretive Pack" graduation arc previously sat under this milestone (publish `@mmnto/pack-bot-coderabbit` + `@mmnto/pack-bot-gemini-code-assist`, wire into session hooks, refactor agent memory to point at packs). It was retired on 2026-05-12 per [ADR-105 (Bot-Protocol Centralization)](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-105-bot-protocol-centralization.md). Bot-interaction protocols now live as canonical doctrine at `mmnto-ai/totem-strategy:doctrine/bot-protocols.md`; mechanical enforcement is tracked at [`mmnto-ai/totem#1900`](https://github.com/mmnto-ai/totem/issues/1900).
-
-- **Headline Work — Pack v0.1 graduation:**
-  - [ ] **LC un-quarantine validation.** Pattern-quality review per `mmnto-ai/totem#1793` BEFORE un-quarantining the 4-rule `.rs` cohort (3 from upstream-014, 1 from upstream-048). End-to-end validation that PR #1795's substrate-wiring fix unblocks the LC PR-C cascade is the load-bearing signal that closes the alpha-pilot gate.
-
-- **Headline Work — Substrate hardening (Tenet 15):**
-
-  Convention rules currently encoded only as LLM-prose in CR `.coderabbit.yaml` and GCA `.gemini/styleguide.md`. Drift firing across multiple agents and repos documented in `mmnto-ai/totem-strategy/upstream-feedback/049`. Strategic posture: replace LLM-prose enforcement with regex / AST / schema enforcement wherever the rule has a deterministic shape.
-  - [ ] **Built-in lint pack architecture (`mmnto-ai/totem#1800`).** Tier-1, broader Option B from `upstream-feedback/049`. Lift the convention-rules-as-deterministic-substrate primitive to a built-in lint pack so cross-repo consumers inherit deterministic enforcement of styleguide rules without local pack maintenance.
-  - [ ] **`@mmnto/pack-voice` (`mmnto-ai/totem#1798`).** Tier-2, scope: core, domain: architecture. Compile voice rules from `voice-tuning-dataset.md` (em-dash detection, banned-vocab list, "Not X, but Y" patterns) into a deterministic pack with regex / ast-grep rules. First concrete instance of the `#1800` architecture; solves the cross-repo voice-rules access path problem.
-  - [ ] **upstream-feedback/049 substrate response.** Local lint pack in totem-strategy for doubled-slug variants, bare-ref forms, section-link enforcement, and truncation residues. Lifts to `@mmnto/pack-governance` after false-positive rate stays low.
-  - [ ] **`mmnto-ai/totem#1796` cwd/configRoot harmonization.** Tier-3. Mirror the eager `repoRoot` resolution pattern from PR #1787's `first-lint-promote-runner.ts` into `compile.ts:663` and `test-rules.ts`. Same monorepo-subpackage class of bug as PR #1787 fixed in T6.
-  - [ ] **`mmnto-ai/totem#1801` batched embedding requests.** Tier-2. Substrate gap surfaced by upstream-feedback/050 — the `totem sync` provider currently issues one embedding request per chunk; batching reduces token-rate pressure on Gemini and Ollama.
-
-- **Bundled Cleanup / Validation:**
-  - [ ] **`mmnto-ai/totem#1685`** — `totem doctor` Stage 4 UX. T4 of #1684. Surface verification-outcomes state to operators.
-  - [ ] **`mmnto-ai/totem#1686`** — Stage 4 perf hardening. T5 of #1684.
-  - [ ] **`mmnto-ai/totem#1226`** — SARIF hex escape fix.
-  - [ ] **`mmnto-ai/totem#1802`** — Tier-3 `config-schema.ts` comment alignment, surfaced from PR #1799 R1 Major.
-
----
-
-## Backlog: Horizon 3+
-
-Strategic research not currently scoped to 1.26.0:
-
-- **Strategy #6** — Adversarial trap corpus: evaluation suite to test the deterministic engine against evasion techniques.
-- **Model-specific prompt adapters** (Strategy #62) — partially addressed by `#1220` rewrite.
-- **Formal model routing matrix** (Strategy #64) — partially addressed by `#73` benchmark.
-- **`#1236`** — Revisit 6 upgrade-target lessons silenced during 1.13.0 cleanup.
-
-Carried over and de-prioritized for 1.26.0:
-
-- **ADR-091 non-Stage-4 ingestion work.** Classifier gate (Stage 2), GHAS / SARIF Extraction (Strategy #50, gated on ADR-086), Lint Warning Extraction (Strategy #51 ↔ #1253), ADR-mining extractor.
-- **ADR-090 Substrate DX.** `mmnto-ai/totem#1497` (rich `describe_project` MCP), `mmnto-ai/totem#1498` (`totem init` agent-runtime auto-detect). Likely 1.27.0 or later.
-- **`mmnto-ai/totem#1414`** — Pipeline 1 smoke-gate flip after 136-lesson Bad Example backfill. Mechanism shipped in `#1415`; hard enforcement deferred until the curation sweep.
-- **`mmnto-ai/totem#1419`** — Cryptographic attestation for the Trap Ledger (SOX compliance gap, Proposal 225 enterprise pitch).
+**Goal (as of 2026-07):** the Convergent Spine — a certified path from merged-PR lessons to deterministic rules, validated by catching real defects that external review bots miss.
 
 ---
 

--- a/docs/wiki/trap-ledger.md
+++ b/docs/wiki/trap-ledger.md
@@ -1,6 +1,6 @@
 # Trap Ledger & Self-Healing Rules
 
-Architectural enforcement is the floor. Totem's real advantage is **telemetry-driven adaptation** on top of that floor.
+Architectural enforcement is the floor. On top of that floor, Totem adapts rules from telemetry.
 
 If a compiled rule is too strict or hallucinates false positives, it will cause developer friction. Instead of forcing developers to manually edit configuration files or blindly bypass the system, Totem uses developer friction as data to automatically heal itself.
 
@@ -78,7 +78,7 @@ By running `totem doctor --pr`, you initiate the self-healing sequence. The comm
 
 1.  **Thresholds:** The Doctor looks for rules that have been evaluated a minimum number of times (e.g., 5 events) and have a **Bypass Rate > 30%**.
 2.  **Downgrade:** If a rule is bypassed that frequently, it is deemed mathematically noisy. The Doctor modifies `compiled-rules.json`, downgrading the rule's severity from `error` to `warning`, or archiving stale rules.
-3.  **Upgrade:** The Doctor upgrades regex rules to ast-grep when context telemetry shows >20% of matches landing in non-code contexts. The `compileCommand({ upgrade })` is invoked in-process from `runSelfHealing`.
+3.  **Upgrade:** The Doctor upgrades regex rules to ast-grep when context telemetry shows >20% of matches landing in non-code contexts. The `compileCommand({ upgradeBatch })` is invoked in-process from `runSelfHealing`.
 4.  **Human Review:** Per **ADR-027 (Rule Lifecycle)**, Totem won't auto-delete rules or forcefully alter the architecture without human review. The Doctor creates a new git branch, commits the downgrade or upgrade, and opens a Pull Request with the exact numeric rationale in the body (e.g., _"Rule X has a 42% bypass rate"_).
 
 ### The Full Cycle

--- a/packages/pack-agent-security/README.md
+++ b/packages/pack-agent-security/README.md
@@ -4,7 +4,7 @@ Zero-Trust Agent Governance security pack for Totem. Flagship consumer of the To
 
 ## Status
 
-Scaffolding only. The pack ships with an empty rules array at this stage. Rule content lands in follow-up PRs that implement the four attack surfaces defined in ADR-089:
+The pack ships five immutable rules (severity `error`, non-downgradable) covering the four attack surfaces defined in ADR-089:
 
 1. Unauthorized process spawning outside known build paths.
 2. Dynamic code evaluation with non-literal arguments.
@@ -21,7 +21,7 @@ Future releases expand coverage as attack vectors evolve. Language coverage star
 
 ## Install
 
-Will land with `totem install pack/agent-security` once the pack resolver ships. See `mmnto-ai/totem#1491`.
+Not yet published to npm. The pack resolver (`totem install pack/<name>`) shipped in 1.15.0; publication of this pack is gated on signed-pack verification (`mmnto-ai/totem#1492`, tracked at `mmnto-ai/totem#1609`).
 
 ## License
 


### PR DESCRIPTION
Executes the ratified strategy#531 Pass-2 package (ledger: mmnto-ai/totem-strategy#531 comment 4949564460, ratification 4949570871): one net-negative PR carrying the §4 fix list, with every shipped-state wording adjudicated against source first (§5 V-rows).

## Kill-guard

**Net word delta: −571** (headline: roadmap.md structural cut). +23/−67 lines across 10 files. `README.md` certified as-is — zero edits.

## V1–V7 shipped-state verification (adjudicated at `e32575b9`, 1.93.0)

| Row | Question | Verdict | Consequence in this PR |
|---|---|---|---|
| V1 | `doctor --pr` full self-healing loop? | **PASS** — bypass-rate calc (`ledger-analyzer.ts:28-59`), auto-downgrade (`rule-mutator.ts:23-48`), branch+PR with numeric rationale (`doctor.ts:1539-1672`), reachable from the flag | Self-healing absolutes keep present tense; two terminology fixes ride (`upgradeBatch`, `suppress`-not-`exception`) |
| V2 | Consumer `lesson compile` path end-to-end? | **PASS** — freeze is cohort-internal (`verify-manifest` only, zero refs in compile); default model routings all current | Compile instructions stand unchanged |
| V3 | `--no-verify` visible in the Trap Ledger? | **FAIL** — zero ledger events on bypass; ledger is local + gitignored; no CI reconciliation | Bypass claim rewritten to the real backstop: CI re-runs the same gates on the pushed tree |
| V4 | `totem install pack/agent-security` works? | **FAIL** — pack is `private: true`, unpublished (gated on #1492 / #1609); the documented target also resolves to the wrong npm name (`agent-security` bare) | README states the true gate instead of the stale "once the resolver ships"; stale "scaffolding only / empty rules array" corrected to the five shipped immutable rules |
| V5 | #1221 live status? | **Closed NOT_PLANNED** (2026-05-11) — the Sonnet migration was declined, not shipped | Dead-gate promise section cut; status callout re-dated with the declined migration; promise-to-update deleted |
| V6 | `totem status` still emits `Shield:`? | **YES** — permanently red (2 readers, 0 writers), reproduced live at 1.93.0 | Live product drift; stays with #2334 (see evidence comment there), not this docs pass. The docs example accurately shows shipped output, so it is untouched here |
| V7 | cli-reference Totem-Lite exit-78 rows current? | **SPLIT** — exit 78 current; `compile` wrongly listed as Lite-available (it's an exit-78 stub); help tag is `[requires full install]`, not `[Totem Lite]`; ~35MB size claim contradicts shipped binary sizes | All three corrected |

## Fix-list coverage (ledger §4)

1. roadmap.md structural cut → live-tracker pointers + dated `Goal:`; dated shipped-history retained; dead #1900 pointer retired ✓
2. it-never-happens-again.md:58 → README's corrected enforcement form + one compile-boundary sentence (ADR-091) ✓ *(voice-bearing — operator veto-edit before merge)*
3. governing-ai-agents.md:42 → scoped per V3 ✓
4. Self-healing absolutes → kept per V1; terminology nits fixed ✓
5. trap-ledger.md:3 self-ranking dropped ✓
6. metrics.md:3 "advanced telemetry" → "telemetry" ✓
7. pipeline-engine.md:5 self-ranking cut; :95 "Instantly ingest" → "Ingest" ✓
8. pack-agent-security README → true gate per V4 ✓
9. cloud-compilation.md → dead-gate treatment per V5 ✓
10. README.md → zero edits ✓

## Notes

- **No changeset:** docs-only; the one package file touched is a README in an unpublished `private: true` package — nothing consumer-visible rides a release.
- **Out-of-scope, routed to trackers:** V6 product fix → #2334; V4 install-target name-mismatch seam → noted on #1609; governing-ai-agents.md:32 "hard guarantee" phrasing → already tracked at #1950.
- Gates: full `totem lint` + `totem lint --base main` (387 rules, 0 violations), repo-wide `format:check`, workspace ESLint — all green.

Part of mmnto-ai/totem-strategy#531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
