### PR TITLE
feat(config): opt totem into the review.lanes fan (Prop 304 R2 dogfood)

### DIFF
--- a/totem.config.ts
+++ b/totem.config.ts
@@ -44,6 +44,16 @@ const config: TotemConfig = {
     junie: '.junie/skills/totem-rules/rules.md',
   },
 
+  // mmnto-ai/totem#2106 (Prop 304 R2): opt totem itself into the multi-lane
+  // review fan — two vendor-distinct lanes over the one masked diff, converging
+  // on verdict artifacts under `.totem/artifacts/verdicts/`. First dogfood of
+  // the runner on its own repo (Prop 302 T2 evidence source). Explicit
+  // `totem review --model ...` stays a one-lane invocation; omit `lanes` to
+  // fall back to the legacy single-lane path.
+  review: {
+    lanes: ['anthropic:claude-sonnet-4-6', 'gemini:gemini-3.1-pro-preview'],
+  },
+
   docs: [
     { path: 'docs/wiki/roadmap.md', description: 'Strategic roadmap with phase progress' },
     {


### PR DESCRIPTION
Configures `review.lanes` on totem itself — the natural first exercise of the R2 runner shipped in #2337, and the first warm evidence toward the Prop 302 T2 falsifier (mmnto-ai/totem#2106 track).

## What ran (live, this branch''s diff)

- Two vendor-distinct lanes (`anthropic:claude-sonnet-4-6`, `gemini:gemini-3.1-pro-preview`) over the one pre-masked payload.
- **2/2 lanes completed** (3.1s / 4.6s), 0 findings each; `local-lane: 3f717da3 round=0 settled=true lanes=2/2`.
- Verdict artifact landed content-addressed under `.totem/artifacts/verdicts/` (gitignored, local-only) and round-trips through the verifying loader (`totem review --covariate` renders from the loaded artifact).

## Precision note (no overclaim)

This is two warm **model lanes** emitting one schema-valid verdict from the same fixture — the T2 falsifier''s full form ("works with your agent") wants >=2 warm **agents**; that leg stays open until a second agent seat emits schema-valid verdicts from the same fixture.

Gates: `totem lint --base main` PASS (387 rules, 0 violations), repo-wide `format:check` clean. No changeset — repo-local config, nothing rides a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)