### PR TITLE
feat(mail): outbox roster-validation sensor — unresolvable to: addresses warn (#2335)

### DIFF
--- a/.changeset/mail-roster-sensor.md
+++ b/.changeset/mail-roster-sensor.md
@@ -1,0 +1,11 @@
+---
+'@mmnto/cli': patch
+---
+
+feat(mail): `totem mail` gains an outbox roster-validation sensor (mmnto-ai/totem#2335; write-side sibling of the #2311 basename-collision sensor).
+
+**What it detects.** A dispatch whose frontmatter `to:` resolves to no roster agent is invisible to every seat-scoped poll — it "looks sent forever" and is never discoverable as unread (live exhibit: a verdict deposited with `to: cohort`, a non-roster literal). During its existing workspace scan `pollMail` now checks each parsed dispatch's `to:` against the roster and emits one structured `unresolvable outbox address:` warning per stranded file, naming the `repo/agent/file` path and the offending address, into the existing `warnings` array. The roster reuses the send-side actuator's `knownCohortAgents` set (the hardcoded-map audit is mmnto-ai/totem#2017) UNIONed with the polling repo's resolved self agents, so an env/config self-id outside the cohort map is never false-flagged. The no-`to:` / non-ADR-098 mail-shaped reject is the same undeliverable class but is already surfaced loudly by the existing `no to: field in frontmatter` parse warning, so the sensor does not double-warn it; non-mail-shaped strays stay silent per the #2118 unclearable-noise invariant.
+
+**Sensor, not actuator (Tenet 13).** Warn-only: unread counting is untouched and nothing is renamed, moved, or deleted. The check runs before the self-filter because an unresolvable address is undeliverable to every seat, not just the poller. As with #2311, because `totem ecl-gc --compact` arms its A2.2 completeness gate on `poll.warnings.length === 0` (mmnto-ai/totem#2309) and its discovery poll reads through marks (`includeProcessed`), a live unresolvable dispatch also holds mark-compaction shut with zero new gate surface.
+
+Consumer-impact: CLI surface — additive `totem mail` sensor output only. `pollMail` emits new `unresolvable outbox address:` lines on the existing `warnings` channel (text output and `--json`); no `MailPollResult` shape change and no change to `mail`/`scanned` counting semantics. No obligated consumer move — a workspace with only roster-valid `to:` addresses sees byte-identical output; scripts parsing warnings should treat the new class like any other warning line.

--- a/.changeset/mail-roster-sensor.md
+++ b/.changeset/mail-roster-sensor.md
@@ -1,5 +1,5 @@
 ---
-'@mmnto/cli': patch
+'@mmnto/cli': minor
 ---
 
 feat(mail): `totem mail` gains an outbox roster-validation sensor (mmnto-ai/totem#2335; write-side sibling of the #2311 basename-collision sensor).

--- a/packages/cli/src/commands/mail.test.ts
+++ b/packages/cli/src/commands/mail.test.ts
@@ -379,6 +379,97 @@ describe('pollMail — cross-sender basename-collision sensor (mmnto-ai/totem#23
   });
 });
 
+// ─── Outbox roster-validation sensor (mmnto-ai/totem#2335) ──────────────
+
+describe('pollMail — outbox roster-validation sensor (mmnto-ai/totem#2335)', () => {
+  const UNRESOLVABLE_PREFIX = 'unresolvable outbox address';
+
+  it('warns on the `to: cohort` exhibit — a non-roster literal invisible to every seat-scoped poll', () => {
+    // The live exhibit: a verdict deposited with `to: cohort` matched no seat,
+    // so it never surfaced as unread and "looked sent forever."
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: '2026-07-11T0900Z-cohort-verdict.md', to: 'cohort', subject: 'r2 verdict' },
+    ]);
+    const result = poll();
+    const rosterWarnings = result.warnings.filter((w) => w.startsWith(UNRESOLVABLE_PREFIX));
+    expect(rosterWarnings).toHaveLength(1);
+    expect(rosterWarnings[0]).toContain('2026-07-11T0900Z-cohort-verdict.md');
+    expect(rosterWarnings[0]).toContain('cohort');
+    // Sensor, not gate (Tenet 13): unread counting is untouched — the file is
+    // (correctly) not addressed to this seat, so it stays out of `mail`; the
+    // warning is the only surface it appears on.
+    expect(result.mail).toEqual([]);
+  });
+
+  it('warns on any unresolvable `to:` address, naming the file and the address', () => {
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: '2026-07-11T1000Z-typo.md', to: 'totem-claud', subject: 'fat-fingered recipient' },
+    ]);
+    const rosterWarnings = poll().warnings.filter((w) => w.startsWith(UNRESOLVABLE_PREFIX));
+    expect(rosterWarnings).toHaveLength(1);
+    expect(rosterWarnings[0]).toContain('2026-07-11T1000Z-typo.md');
+    expect(rosterWarnings[0]).toContain('totem-claud');
+  });
+
+  it('does NOT warn on a valid roster recipient — including one addressed to another seat', () => {
+    // Roster ≠ this seat's self-set: a dispatch to lc-claude (a cohort-map
+    // agent, not self) is deliverable and must not warn, even though it is
+    // filtered OUT of this seat's mail. broadcast is a routing literal, valid too.
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: 'a.md', to: 'totem-claude', subject: 'to me' },
+      { name: 'b.md', to: 'lc-claude', subject: 'to a peer seat' },
+      { name: 'c.md', to: 'broadcast', subject: 'cohort-wide' },
+    ]);
+    expect(poll().warnings.filter((w) => w.startsWith(UNRESOLVABLE_PREFIX))).toEqual([]);
+  });
+
+  it('never false-flags an env/config self-id that sits outside the cohort map (#2141 union)', () => {
+    // A self-id resolved from TOTEM_SELF_AGENT (not the hardcoded map) is a
+    // valid recipient here; the roster unions it so self-addressed mail is
+    // never reported unresolvable.
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: 'x.md', to: 'custom-id', subject: 'env self' },
+    ]);
+    const result = poll({ env: { TOTEM_SELF_AGENT: 'custom-id' } });
+    expect(result.warnings.filter((w) => w.startsWith(UNRESOLVABLE_PREFIX))).toEqual([]);
+    expect(result.mail).toHaveLength(1);
+  });
+
+  it('a mail-shaped file with no `to:` keeps its distinct parse-fail message; the roster sensor does not re-warn it', () => {
+    // Same undeliverable class, different surface: the no-`to:` reject is
+    // already loud via the parse-fail path ("no to: field in frontmatter"), so
+    // the roster sensor must not double-warn it.
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: 'noto.md', to: 'unused', raw: '---\nfrom: strategy-claude\n---\n' },
+    ]);
+    const result = poll();
+    expect(
+      result.warnings.some((w) => w.startsWith('mail parse failed') && w.includes('no to: field')),
+    ).toBe(true);
+    expect(result.warnings.filter((w) => w.startsWith(UNRESOLVABLE_PREFIX))).toEqual([]);
+    expect(result.mail).toEqual([]);
+  });
+
+  it('stays silent on a non-mail-shaped stray (no `---` opener) — the #2118 unclearable-noise invariant', () => {
+    // The roster sensor runs only on successfully-parsed dispatches; a stray
+    // .md that isn't mail-shaped must not draw a permanent, unclearable warning.
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: 'stray.md', to: 'unused', raw: 'to: cohort\njust a note\n' },
+    ]);
+    expect(poll().warnings).toEqual([]);
+  });
+
+  it('warns once per unresolvable dispatch (per-file, not basename-deduped)', () => {
+    // Distinct from the #2311 basename sensor (which dedupes by basename): each
+    // stranded dispatch is independently undeliverable, so each is named.
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: '2026-07-11T1100Z-cohort-1.md', to: 'cohort', subject: 'one' },
+      { name: '2026-07-11T1200Z-cohort-2.md', to: 'cohort', subject: 'two' },
+    ]);
+    expect(poll().warnings.filter((w) => w.startsWith(UNRESOLVABLE_PREFIX))).toHaveLength(2);
+  });
+});
+
 // ─── Sort + metadata ────────────────────────────────────
 
 describe('pollMail — sort + metadata', () => {

--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -572,6 +572,25 @@ export function pollMail(opts: MailCommandOptions = {}): MailPollResult {
     }
   }
 
+  // Roster-validation sensor (mmnto-ai/totem#2335, write-side sibling of the
+  // #2311 basename-collision sensor below): a dispatch whose `to:` names no
+  // roster agent is invisible to EVERY seat-scoped poll — it "looks sent
+  // forever" and is never discoverable as unread (live exhibit: a verdict
+  // deposited with `to: cohort`, a non-roster literal). The roster is the SAME
+  // set the send-side actuator validates recipients against —
+  // `knownCohortAgents` reused, not re-derived (the hardcoded-map audit is
+  // mmnto-ai/totem#2017) — UNIONed with this repo's resolved self agents,
+  // because an env/config self-id (mmnto-ai/totem#2141) can sit outside the
+  // cohort map yet is a valid recipient here (never false-flag self-addressed
+  // mail). The no-`to:` / mail-shaped-reject sub-class is the same
+  // undeliverable class but is already surfaced loudly by the parse-fail
+  // warning above (`no to: field in frontmatter`), so this sensor deliberately
+  // does not re-warn it; non-mail-shaped strays stay silent by the #2118
+  // design (a warning there is permanent, unclearable noise).
+  const rosterLower = new Set(
+    [...knownCohortAgents(workspace), ...selfResolution.agents].map((a) => a.toLowerCase()),
+  );
+
   const mail: MailEntry[] = [];
   // Cross-sender basename-collision sensor (mmnto-ai/totem#2311, read-side
   // half of mmnto-ai/totem-strategy#827): dispatch filenames don't encode the
@@ -606,6 +625,17 @@ export function pollMail(opts: MailCommandOptions = {}): MailPollResult {
     }
     const header = parsed.header;
     const toLower = header.to.toLowerCase();
+    // Roster check runs HERE — before the self-filter below — because an
+    // unresolvable `to:` is undeliverable to EVERY seat, not just this one, and
+    // the whole-workspace scan is the only place the file is ever seen (Tenet
+    // 13: warn, don't gate). `broadcast` is a routing literal, not an agent, so
+    // it is a valid target. `header.to` is already control-byte-escaped by
+    // `parseHeader`, so interpolating it into the warning is display-safe.
+    if (toLower !== 'broadcast' && !rosterLower.has(toLower)) {
+      warnings.push(
+        `unresolvable outbox address: ${slot.repo}/${slot.agent}/${file} — to: "${header.to}" matches no roster agent; invisible to every seat-scoped poll`,
+      );
+    }
     if (toLower !== 'broadcast' && !selfLower.has(toLower)) continue;
     const senderSeat = slot.agent.toLowerCase();
     let seats = collisionsByBasename.get(file);


### PR DESCRIPTION
## Mechanical Root Cause

A dispatch whose frontmatter `to:` resolves to no roster agent is structurally undiscoverable: every seat-scoped poll filters on `to:` matching the polling seat, so a non-roster address matches no seat, ever — the file "looks sent forever" from the sender's side and no reader can surface it as unread. The write side had no validation and the read side had no sensor for this class (live exhibit: a Prop 304 BLIND-round verdict deposited with `to: cohort`, a non-roster literal, invisible until an operator relay). Write-side sibling of the #2311 read-side basename-collision sensor.

## Fix Applied

During the existing `pollMail` workspace scan, each parsed dispatch's `to:` is checked against the roster and one structured `unresolvable outbox address:` warning is emitted per stranded file, naming the `repo/agent/file` and the offending address.

- **Roster = the send-side actuator's set** (`knownCohortAgents`, the #2017 audit target) **unioned with resolved self agents** (#2141) — an env/config self-id outside the cohort map is never false-flagged.
- **Runs before the self-filter** — an unresolvable address is undeliverable to *every* seat, and the whole-workspace scan is the only place the file is seen. `broadcast` stays a valid routing literal.
- **Warn, not gate** (Tenet 13): rides the existing `warnings` channel, zero `MailPollResult` shape change, unread counting untouched. Composes with `ecl-gc --compact`'s A2.2 gate exactly as #2311 does (verified no existing compaction test flips).

## Out of Scope

- Mail-shaped files with no `to:` keep their existing loud parse-fail warning (no double-warn from this sensor).
- Non-mail-shaped strays stay silent per the #2118 unclearable-noise invariant — flagging those would be a deliberate reversal of that invariant and is left as a separate decision.
- The hardcoded cohort-map audit (#2017) and seat-selector ergonomics (#2204) are adjacent trackers, untouched.

## Tests Added/Updated

- [x] Added/updated automated tests covering the root-cause mechanism

7 tests in a dedicated describe block: the `to: cohort` exhibit; arbitrary unresolvable addresses (file + address named); valid roster recipients including other seats (no warning); env/config self-ids outside the cohort map (no false flag); the no-`to:` parse-fail non-double-warn; the non-mail-shaped silence invariant; per-file (non-basename-deduped) warning granularity.

Provenance: implementation by an Opus 4.8 subagent in an isolated worktree; independently verified — diff read in full, targeted tests re-run (7/7), `totem lint --base main` PASS 0 errors, `format:check` clean. Full gate run: `pnpm -r build` green, 3130/3130 CLI tests, workspace ESLint 0 errors. Local review fan (2 vendor-distinct lanes) on this diff: 0 findings, verdict `ac06b957` settled=true. Changeset: `@mmnto/cli` **minor** (sibling #2311 precedent); `Consumer-impact:` declares additive-output-only, no obligated consumer move.

## Related Tickets

Fixes #2335

🤖 Generated with [Claude Code](https://claude.com/claude-code)
