### PR TITLE
fix(ci): PAT-actored checkout + SHA-pin release.yml actions — VP-PR runs auto-run again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,18 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - uses: actions/checkout@v7
+      # token: makes ALL git operations in this job PAT-actored — including the
+      # changesets action's fallback `git push` of changeset-release/main. The
+      # 2026-07-08 actor flip (#2331) happened because the push path degraded
+      # to the checkout-persisted default GITHUB_TOKEN: bot-actored pushes put
+      # every VP-PR pull_request run into action_required (GitHub's stock
+      # posture), stalling cuts behind a manual approval click. The PAT keeps
+      # runs auto-running as they did from 2026-03-03 (433fc92d) to 2026-07-08.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          token: ${{ secrets.RELEASE_TOKEN }}
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
       # Node 24 ships with npm 11.x natively, which supports OIDC trusted
       # publishing (added in npm 11.5.1). Node 22 ships with npm 10.9.x and
@@ -28,7 +37,7 @@ jobs:
       # No registry-url: it writes an .npmrc with _authToken=${NODE_AUTH_TOKEN},
       # which blocks npm's OIDC trusted-publishing negotiation. See #1180 +
       # #1182 history.
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
           cache: pnpm
@@ -42,7 +51,7 @@ jobs:
 
       - name: Create Release PR (version-only)
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1
         with:
           version: pnpm run version
           # No `publish` parameter: `changeset publish` does not propagate


### PR DESCRIPTION
Closes #2331

## Mechanical Root Cause

The manual-approval "gate" on VP-PR runs was never a configured decision. Forensic chain (each link verified):

- Runs on `changeset-release/main` were actored by the RELEASE_TOKEN user (satur8d) and auto-ran green through 2026-07-08T02:38Z; from 22:08Z every run is `action_required`, actored by `github-actions[bot]`.
- Between those refreshes: **no repo commit** touched `release.yml`, **no changesets/action release** moved the floating `@v1` tag (latest v1.x: v1.9.0, 2026-06-03), **no environment protection rules** exist (one env, zero rules), and the **PAT stayed API-valid** — every VP-PR incl. #2346 is still satur8d-authored.
- Only the branch-**push** credential degraded: `actions/checkout@v7` carries no `token:`, so the persisted git credential was always the bot-shaped default `GITHUB_TOKEN`; when the action''s PAT-actored push path stopped applying, the fallback `git push` made runs bot-actored — and GitHub''s stock posture holds bot-actored `pull_request` runs for approval.
- The auto-running state everyone relied on was deliberately created 2026-03-03 (`433fc92d`, "use RELEASE_TOKEN PAT for changesets action") and held for four months.

## Fix Applied

- `token: ${{ secrets.RELEASE_TOKEN }}` on the checkout step — every git operation in the job, including any fallback push, is PAT-actored. Restores the pre-2026-07-08 behavior; removes no protection anyone chose.
- All four `uses:` refs SHA-pinned with `# vX` trailing comments (#1988 partial — release.yml only; the floating `@v1` was a legitimate suspect during diagnosis and stays frozen now).

## Out of Scope

- SHA-pinning the remaining workflows (#1988 stays open for the sweep).
- The 30+ stale `action_required` runs accumulated on `changeset-release/main` — swept separately (queue hygiene, no code).

## Tests Added/Updated

- [x] N/A (explain why verification logic is not applicable) — CI workflow change; the falsifier is live: the **next VP-PR refresh after a changeset lands** must show PAT-actored runs with no `action_required` hold. If it holds again, reopen #2331 with the new run''s `triggering_actor`.

## Related Tickets

Closes #2331. Kin: #1988 (SHA-pin sweep), #1956 (credential-hygiene family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)