### PR TITLE
feat(core): supported subpath entry points — /config /packs /lessons /artifacts (#2336 slice A)

### DIFF
--- a/.changeset/core-supported-entry-points.md
+++ b/.changeset/core-supported-entry-points.md
@@ -1,0 +1,16 @@
+---
+'@mmnto/totem': minor
+---
+
+feat(core): supported subpath entry points over the legacy `@mmnto/totem` barrel (mmnto-ai/totem#2336 — ADR-084 / Proposal 294).
+
+`packages/core/src/index.ts` is a 1,167-line barrel that, as a public surface, makes no per-symbol semver promise — consumers can't tell which exports are contract and which are lab. This mints a small, curated, semver-tracked surface ALONGSIDE the barrel via `package.json` `exports` subpaths (each a thin `tsc`-built aggregator re-exporting a subset already public on the root barrel). The barrel is unchanged (zero removals, zero reordering) and marked legacy/compatibility in prose; subtraction is deferred to a future major.
+
+New supported entry points:
+
+- `@mmnto/totem/config` — `TotemConfig` + the config-schema surface (schemas, tiers, defaults). This is the one hard cross-repo cohort contract: the only barrel import cohort repos take today is `import type { TotemConfig } from '@mmnto/totem'`.
+- `@mmnto/totem/packs` — `PackRegistrationAPI`, `loadInstalledPacks`, `loadedPacks`, `isEngineSealed`, `resolveEngineVersion`, and the `installed-packs.json` manifest schema/type (ADR-097 § 5 Q5 / § 10, ADR-099 semver surfaces; the entry third-party packs bind to).
+- `@mmnto/totem/lessons` — lesson read/write, ADR-070 frontmatter parse/build, the lesson role + frontmatter schema contracts, the role-applicability filter, and the retirement ledger (bounded — not the frozen rule compiler).
+- `@mmnto/totem/artifacts` — the Prop 302 verdict-artifact schema, the content-address-verified loader, the schema-version constants, and the derived settle/cache + lineage helpers.
+
+Consumer-impact: additive package exports only. Four new `@mmnto/totem/*` subpath entries are added to the `exports` map; the root `.` barrel is byte-compatible (unchanged `import`/`types` targets, no symbols removed or reordered). No obligated consumer move — existing `import … from '@mmnto/totem'` is unaffected, and consumers MAY migrate to the narrower subpaths at their own pace. `@mmnto/cli` and `@mmnto/mcp` version-bump alongside `@mmnto/totem` via the changesets `fixed` group but ship no behavior change.

--- a/packages/cli/src/build-lite.test.ts
+++ b/packages/cli/src/build-lite.test.ts
@@ -33,8 +33,14 @@ function run(
 ): { stdout: string; stderr: string; status: number } {
   // cross-spawn spawns binaries under paths with spaces (node.exe in "Program
   // Files") and win32 `.cmd` shims WITHOUT a shell — same argv array on both
-  // platforms, no manual quoting (repo safe-exec convention).
-  const res = spawnSync(cmd, [...args], { cwd: opts.cwd, encoding: 'utf-8' });
+  // platforms, no manual quoting (repo safe-exec convention). The child-level
+  // `timeout` is the ONLY effective bound here: spawnSync blocks the event
+  // loop, so vitest's test timeout cannot fire while the child hangs.
+  const res = spawnSync(cmd, [...args], {
+    cwd: opts.cwd,
+    encoding: 'utf-8',
+    timeout: LITE_BUILD_TIMEOUT_MS,
+  });
   if (res.error) {
     throw new Error(`spawn failed for \`${cmd}\`: ${res.error.message}`);
   }

--- a/packages/cli/src/build-lite.test.ts
+++ b/packages/cli/src/build-lite.test.ts
@@ -11,17 +11,19 @@
  * `node build/esbuild-lite.mjs`.
  */
 
-import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { sync as spawnSync } from 'cross-spawn';
 import { describe, expect, it } from 'vitest';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const CLI_ROOT = path.resolve(HERE, '..');
 const CORE_ROOT = path.resolve(CLI_ROOT, '..', 'core');
 const LITE_BUILD_TIMEOUT_MS = 180_000;
+/** Status reported when the child never yielded an exit code (spawn-level failure). */
+const SPAWN_FAILURE_STATUS = -1;
 
 /** Run a child process, failing loud with captured output. */
 function run(
@@ -29,19 +31,18 @@ function run(
   args: readonly string[],
   opts: { cwd: string },
 ): { stdout: string; stderr: string; status: number } {
-  // win32/Node 24: route through the shell with manual quoting (node.exe lives
-  // under a path with a space); posix spawns directly.
-  const res =
-    process.platform === 'win32'
-      ? spawnSync(
-          [cmd, ...args].map((a) => (/[\s"]/.test(a) ? `"${a.replace(/"/g, '""')}"` : a)).join(' '),
-          { cwd: opts.cwd, encoding: 'utf-8', shell: true },
-        )
-      : spawnSync(cmd, [...args], { cwd: opts.cwd, encoding: 'utf-8', shell: false });
+  // cross-spawn spawns binaries under paths with spaces (node.exe in "Program
+  // Files") and win32 `.cmd` shims WITHOUT a shell — same argv array on both
+  // platforms, no manual quoting (repo safe-exec convention).
+  const res = spawnSync(cmd, [...args], { cwd: opts.cwd, encoding: 'utf-8' });
   if (res.error) {
     throw new Error(`spawn failed for \`${cmd}\`: ${res.error.message}`);
   }
-  return { stdout: res.stdout ?? '', stderr: res.stderr ?? '', status: res.status ?? -1 };
+  return {
+    stdout: res.stdout ?? '',
+    stderr: res.stderr ?? '',
+    status: res.status ?? SPAWN_FAILURE_STATUS,
+  };
 }
 
 describe('build:lite gate (#2336)', () => {

--- a/packages/cli/src/build-lite.test.ts
+++ b/packages/cli/src/build-lite.test.ts
@@ -1,0 +1,73 @@
+/**
+ * `build:lite` gate (mmnto-ai/totem#2336).
+ *
+ * The lite binary is an esbuild bundle of `src/index-lite.ts` with native/WASM
+ * deps aliased to shims (`@ast-grep/napi` → WASM shim, `@lancedb/lancedb` →
+ * stub). Those aliases are resolver-sensitive, so any change to the core
+ * package's module/exports shape can silently break the bundle. This test
+ * asserts the lite artifact still builds green and emits a non-empty bundle.
+ *
+ * Windows-CI note: no git seam is touched — the only child process is
+ * `node build/esbuild-lite.mjs`.
+ */
+
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CLI_ROOT = path.resolve(HERE, '..');
+const CORE_ROOT = path.resolve(CLI_ROOT, '..', 'core');
+const LITE_BUILD_TIMEOUT_MS = 180_000;
+
+/** Run a child process, failing loud with captured output. */
+function run(
+  cmd: string,
+  args: readonly string[],
+  opts: { cwd: string },
+): { stdout: string; stderr: string; status: number } {
+  // win32/Node 24: route through the shell with manual quoting (node.exe lives
+  // under a path with a space); posix spawns directly.
+  const res =
+    process.platform === 'win32'
+      ? spawnSync(
+          [cmd, ...args].map((a) => (/[\s"]/.test(a) ? `"${a.replace(/"/g, '""')}"` : a)).join(' '),
+          { cwd: opts.cwd, encoding: 'utf-8', shell: true },
+        )
+      : spawnSync(cmd, [...args], { cwd: opts.cwd, encoding: 'utf-8', shell: false });
+  if (res.error) {
+    throw new Error(`spawn failed for \`${cmd}\`: ${res.error.message}`);
+  }
+  return { stdout: res.stdout ?? '', stderr: res.stderr ?? '', status: res.status ?? -1 };
+}
+
+describe('build:lite gate (#2336)', () => {
+  it(
+    'bundles the lite binary green with the core exports shape',
+    () => {
+      // The lite bundle resolves `@mmnto/totem` to core's built dist, so core
+      // must be built first. Turbo's `test` task `dependsOn: ["build"]` (and
+      // the gate flow `pnpm -r build`) guarantees this; assert rather than
+      // rebuild to avoid racing a sibling package's concurrent core build.
+      if (!fs.existsSync(path.join(CORE_ROOT, 'dist', 'index.js'))) {
+        throw new Error(
+          'core dist/index.js is missing — build core first (`pnpm -r build`; turbo builds before test in CI).',
+        );
+      }
+
+      const res = run(process.execPath, ['build/esbuild-lite.mjs'], { cwd: CLI_ROOT });
+      expect(
+        res.status,
+        `build:lite exited non-zero\nstdout:\n${res.stdout}\nstderr:\n${res.stderr}`,
+      ).toBe(0);
+
+      const bundle = path.join(CLI_ROOT, 'dist', 'lite', 'totem-lite.mjs');
+      expect(fs.existsSync(bundle), 'lite bundle emitted').toBe(true);
+      expect(fs.statSync(bundle).size, 'lite bundle non-empty').toBeGreaterThan(0);
+    },
+    LITE_BUILD_TIMEOUT_MS,
+  );
+});

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -20,6 +20,31 @@ import { LanceStore, createEmbedder, createChunker } from '@mmnto/totem';
 
 See the [architecture reference](https://github.com/mmnto-ai/totem/blob/main/docs/reference/architecture.md) for how the pieces fit together.
 
+## Entry points
+
+The package root (`.`) is a compatibility barrel: it re-exports the full core
+module graph and makes no per-symbol semver promise. It is retained unchanged
+for backward compatibility.
+
+For new code, prefer the supported subpath entry points. Each is a curated,
+semver-tracked subset of the barrel:
+
+| Entry point              | Surface                                                                                     |
+| ------------------------ | ------------------------------------------------------------------------------------------- |
+| `@mmnto/totem/config`    | `TotemConfig` and the config-schema surface (schemas, tiers, defaults).                     |
+| `@mmnto/totem/packs`     | Pack registration + load: `PackRegistrationAPI`, `loadInstalledPacks`, the manifest schema. |
+| `@mmnto/totem/lessons`   | Lesson read/write, frontmatter parse/build, and the role/frontmatter schema contracts.      |
+| `@mmnto/totem/artifacts` | The verdict-artifact schema, its content-address-verified loader, and version constants.    |
+
+```typescript
+import type { TotemConfig } from '@mmnto/totem/config';
+import { loadInstalledPacks } from '@mmnto/totem/packs';
+```
+
+Symbols on the supported subpaths are also present on the root barrel; the
+subpaths narrow that surface to an intentional set. Subtraction from the barrel
+is deferred to a future major (mmnto-ai/totem#2336).
+
 ## Docs
 
 - Repository: <https://github.com/mmnto-ai/totem>

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -12,6 +12,22 @@
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./config": {
+      "import": "./dist/config.js",
+      "types": "./dist/config.d.ts"
+    },
+    "./lessons": {
+      "import": "./dist/lessons.js",
+      "types": "./dist/lessons.d.ts"
+    },
+    "./artifacts": {
+      "import": "./dist/artifacts.js",
+      "types": "./dist/artifacts.d.ts"
+    },
+    "./packs": {
+      "import": "./dist/packs.js",
+      "types": "./dist/packs.d.ts"
     }
   },
   "scripts": {

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -1,0 +1,64 @@
+/**
+ * `@mmnto/totem/artifacts` — supported verdict-artifact entry point.
+ *
+ * Curated, semver-tracked re-export of the Prop 302 verdict-artifact surface:
+ * the `VerdictArtifactSchema`, the content-address-verified loader
+ * (`loadVerdictArtifact`), the schema-version constants, the derived
+ * settle/cache predicates, the lineage-key + content-hash helpers, and the
+ * verdict store read/write helpers. This is the lane-convergence artifact
+ * consumers of `.totem/artifacts/verdicts/` bind to.
+ *
+ * Deliberately scoped to the verdict artifact. The broader run-artifact /
+ * grounding / panel / post-check schemas (also under `./artifacts/**` in the
+ * barrel) are a larger, less-settled surface and stay off this supported
+ * entry for now to keep the promise narrow — they remain reachable via the
+ * legacy root barrel (`.`).
+ *
+ * Every name here is also re-exported from the legacy root barrel (`.`).
+ * Additive per mmnto-ai/totem#2336 (ADR-084 / Proposal 294). The root barrel
+ * is unchanged; nothing is removed from it in this cut.
+ */
+
+// Verdict-artifact types (Prop 302 / 304 R2, mmnto-ai/totem#2106).
+export type {
+  LineageKeyInput,
+  SaveVerdictArtifactResult,
+  VerdictArtifact,
+  VerdictDiffScope,
+  VerdictDiffSource,
+  VerdictFinding,
+  VerdictFindingSeverity,
+  VerdictLane,
+  VerdictLaneFailureReason,
+  VerdictLaneSummary,
+  VerdictPredicateInput,
+  VerdictRound,
+  VerdictWithAddress,
+} from './artifacts/verdict.js';
+
+// Verdict-artifact schemas, version constants, derived predicates,
+// lineage/hash helpers, and the content-address-verified store surface.
+export {
+  computeLineageKey,
+  computeVerdictArtifactContentHash,
+  deriveCacheEligible,
+  deriveSettled,
+  findLatestVerdictForLineage,
+  LaneIdSchema,
+  listVerdictArtifacts,
+  loadVerdictArtifact,
+  renderCovariateLine,
+  saveVerdictArtifact,
+  VERDICT_ARTIFACT_KNOWN_MAJOR,
+  VERDICT_ARTIFACT_SCHEMA_VERSION,
+  VERDICT_DIFF_SOURCES,
+  VERDICT_LANE_FAILURE_REASONS,
+  VerdictArtifactSchema,
+  VerdictDiffScopeSchema,
+  VerdictFindingSchema,
+  VerdictFindingSeveritySchema,
+  VerdictLaneSchema,
+  VerdictLaneSummarySchema,
+  VerdictRoundSchema,
+  verdictsDir,
+} from './artifacts/verdict.js';

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,0 +1,64 @@
+/**
+ * `@mmnto/totem/config` — supported config-schema entry point.
+ *
+ * Curated, semver-tracked re-export of the `TotemConfig` type and the
+ * config-schema surface (schemas, tiers, defaults). This is the ONE hard
+ * cross-repo cohort contract: the only barrel import cohort repos take today
+ * is `import type { TotemConfig } from '@mmnto/totem'`, and this subpath is
+ * its supported home.
+ *
+ * Every name here is also re-exported from the legacy root barrel (`.`) for
+ * backward compatibility; this aggregator narrows that surface to an
+ * intentional, curated subset. Config-schema names the barrel deliberately
+ * omits (e.g. `OpenAIOrchestratorSchema`, `Stage4BaselineConfigSchema`,
+ * `BUILTIN_CHUNK_STRATEGIES`) stay off this surface on purpose.
+ *
+ * Additive per mmnto-ai/totem#2336 (ADR-084 / Proposal 294). The root barrel
+ * is unchanged; nothing is removed from it in this cut.
+ */
+
+// Config-schema types — `TotemConfig` plus every transitive config-schema
+// type alias it composes (all `z.infer` aliases exported by config-schema.ts).
+export type {
+  ChunkStrategy,
+  ConfigTier,
+  ContentType,
+  DocTarget,
+  DoctorConfig,
+  EclConfig,
+  EmbeddingProvider,
+  GarbageCollectionConfig,
+  IngestTarget,
+  Orchestrator,
+  OrientConfig,
+  TotemConfig,
+} from './config-schema.js';
+
+// Config-schema values — schemas, tier helpers, and shipped defaults.
+export {
+  AnthropicOrchestratorSchema,
+  ChunkStrategySchema,
+  CONFIG_FILES,
+  ConfigTierSchema,
+  ContentTypeSchema,
+  DEFAULT_IGNORE_PATTERNS,
+  DEFAULT_REVIEW_SOURCE_EXTENSIONS,
+  DocTargetSchema,
+  DoctorConfigSchema,
+  EclConfigSchema,
+  EmbeddingProviderSchema,
+  GarbageCollectionSchema,
+  GeminiOrchestratorSchema,
+  GeminiProviderSchema,
+  getConfigTier,
+  IngestTargetSchema,
+  OllamaProviderSchema,
+  OpenAIProviderSchema,
+  OrchestratorSchema,
+  OrientConfigSchema,
+  requireEmbedding,
+  ReviewConfigSchema,
+  ReviewSourceExtensionSchema,
+  ShellOrchestratorSchema,
+  TotemConfigSchema,
+} from './config-schema.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,21 @@
+/**
+ * `@mmnto/totem` (`.`) — legacy / compatibility barrel.
+ *
+ * This root barrel re-exports the full core module graph and makes no
+ * per-symbol semver promise: consumers cannot tell which exports are stable
+ * contract and which are lab surface. It is retained unchanged for backward
+ * compatibility (zero removals, zero reordering).
+ *
+ * Prefer the curated, semver-tracked subpath entry points for new code:
+ *   - `@mmnto/totem/config`    — `TotemConfig` + config-schema surface
+ *   - `@mmnto/totem/packs`     — pack registration + load (ADR-097/099)
+ *   - `@mmnto/totem/lessons`   — lesson read/write + frontmatter + role/schema
+ *   - `@mmnto/totem/artifacts` — Prop 302 verdict-artifact schema/loader
+ *
+ * Subtraction from this barrel is deferred to a future major (mmnto-ai/totem#2336,
+ * ADR-084 / Proposal 294).
+ */
+
 // Unified findings model (ADR-071)
 export type { FindingCategory, FindingSeverity, FindingSource, TotemFinding } from './finding.js';
 export { findingToViolation, violationToFinding } from './finding.js';

--- a/packages/core/src/lessons.ts
+++ b/packages/core/src/lessons.ts
@@ -27,7 +27,13 @@ export {
   writeLessonFileAsync,
 } from './lesson-io.js';
 
-// Parsed-lesson shape — the element type `readAllLessons` returns.
+// Parsed-lesson shape — the element type `readAllLessons` returns. Sourced
+// from drift-detector.ts because that module OWNS the type today (lesson-io
+// imports it from there; the root barrel exports it from there) — this entry
+// mirrors the established owner rather than minting a second source. If the
+// type ever moves to a dedicated types module, re-point this ONE re-export;
+// the `@mmnto/totem/lessons` surface (the semver promise) is unchanged by
+// where the type lives internally.
 export type { ParsedLesson } from './drift-detector.js';
 
 // Frontmatter parse/build (ADR-070).

--- a/packages/core/src/lessons.ts
+++ b/packages/core/src/lessons.ts
@@ -1,0 +1,53 @@
+/**
+ * `@mmnto/totem/lessons` — supported lesson read/write entry point.
+ *
+ * Curated, semver-tracked re-export of the bounded lesson-authoring surface:
+ * directory-based lesson I/O, ADR-070 frontmatter parse/build, the lesson
+ * role + frontmatter schema contracts, the role-applicability filter, and the
+ * retirement ledger. `ParsedLesson` is included so `readAllLessons`' return
+ * type is nameable by consumers.
+ *
+ * Deliberately bounded: this is the read/write + frontmatter + role/schema
+ * surface, NOT the rule compiler. The frozen legacy compiler
+ * (`compileLesson`, `compiler.js`) is not exposed as a new public contract
+ * here — see mmnto-ai/totem#2336. Lesson formatting/linting helpers
+ * (`lesson-format`, `lesson-linter`) also stay off this surface to keep the
+ * promise small.
+ *
+ * Every name here is also re-exported from the legacy root barrel (`.`).
+ * Additive per mmnto-ai/totem#2336 (ADR-084 / Proposal 294). The root barrel
+ * is unchanged; nothing is removed from it in this cut.
+ */
+
+// Directory-based lesson I/O.
+export {
+  lessonFileName,
+  readAllLessons,
+  writeLessonFile,
+  writeLessonFileAsync,
+} from './lesson-io.js';
+
+// Parsed-lesson shape — the element type `readAllLessons` returns.
+export type { ParsedLesson } from './drift-detector.js';
+
+// Frontmatter parse/build (ADR-070).
+export type { FrontmatterParseResult } from './lesson-frontmatter.js';
+export { buildFrontmatterFromLegacy, extractFrontmatter } from './lesson-frontmatter.js';
+
+// Lesson role + frontmatter schema contracts.
+export type { LessonFrontmatter, LessonRole } from './types.js';
+export { LessonFrontmatterSchema, LessonRoleSchema } from './types.js';
+
+// Role-applicability filter.
+export type { LessonWithAppliesTo } from './lesson-role-filter.js';
+export { filterLessonsByRole } from './lesson-role-filter.js';
+
+// Retirement ledger (#1165) — lesson lifecycle read/write.
+export type { RetiredLesson } from './retired-lessons.js';
+export {
+  isRetiredHeading,
+  readRetiredLessons,
+  RETIRED_LESSONS_FILE,
+  retireLesson,
+  writeRetiredLessons,
+} from './retired-lessons.js';

--- a/packages/core/src/packaged-exports.test.ts
+++ b/packages/core/src/packaged-exports.test.ts
@@ -116,13 +116,13 @@ beforeAll(() => {
   run('tar', ['-xzf', tarballRel, '-C', 'node_modules/@mmnto/totem', '--strip-components=1'], {
     cwd: sandbox,
   });
-});
+}, INTEGRATION_TIMEOUT_MS);
 
 afterAll(() => {
   if (sandbox) {
     fs.rmSync(sandbox, { recursive: true, force: true, maxRetries: 5 });
   }
-});
+}, INTEGRATION_TIMEOUT_MS);
 
 describe('@mmnto/totem packaged subpath exports (#2336)', () => {
   it(

--- a/packages/core/src/packaged-exports.test.ts
+++ b/packages/core/src/packaged-exports.test.ts
@@ -1,0 +1,306 @@
+/**
+ * Packed-tarball supported-subpath contract (mmnto-ai/totem#2336).
+ *
+ * These tests exercise the PUBLISHED package shape, not the workspace source
+ * graph: they `pnpm pack` the core package, extract the tarball into an
+ * isolated `node_modules/@mmnto/totem` sandbox, and then resolve every
+ * supported subpath (`./config`, `./lessons`, `./artifacts`, `./packs`)
+ * through the exports map — as Node ESM at runtime AND as TypeScript type
+ * resolution — plus an ADR-097 synchronous-CJS `register.cjs` pack proving
+ * registration works through that published shape.
+ *
+ * The sandbox lives under core's own `node_modules/` for two reasons: it is
+ * git- and prettier-ignored there, and the extracted package's transitive
+ * deps (`zod`, `remark-*`, `semver`, …) resolve via core's `node_modules`
+ * ancestor without a network install.
+ *
+ * Windows-CI note: no test here spawns real `git`; the only child processes
+ * are `tsc` (core build), `pnpm pack`, `tar`, and `node`/`tsc` over the
+ * sandbox — none touch a git seam.
+ */
+
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import { createRequire } from 'node:module';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CORE_ROOT = path.resolve(HERE, '..');
+const INTEGRATION_TIMEOUT_MS = 180_000;
+
+/** The supported (curated, semver-tracked) subpaths minted by #2336. */
+const SUPPORTED_SUBPATHS = ['./config', './lessons', './artifacts', './packs'] as const;
+
+/** Absolute path to the workspace `tsc` (typescript is a core dependency). */
+const TSC_BIN = require.resolve('typescript/bin/tsc');
+
+let sandbox = '';
+let installedPkgDir = '';
+
+/** Run a child process, failing loud (never fail-open) with captured output. */
+function run(
+  cmd: string,
+  args: readonly string[],
+  opts: { cwd: string },
+): { stdout: string; stderr: string } {
+  // Node 24 on win32 refuses to spawn `.cmd` shims (e.g. `pnpm`) without a
+  // shell, and `node.exe` itself lives under a path with a space ("Program
+  // Files"). Route win32 through the shell with manual quoting; posix spawns
+  // directly so no shell quoting is involved.
+  const res =
+    process.platform === 'win32'
+      ? spawnSync(
+          [cmd, ...args].map((a) => (/[\s"]/.test(a) ? `"${a.replace(/"/g, '""')}"` : a)).join(' '),
+          { cwd: opts.cwd, encoding: 'utf-8', shell: true },
+        )
+      : spawnSync(cmd, [...args], { cwd: opts.cwd, encoding: 'utf-8', shell: false });
+  if (res.error) {
+    throw new Error(`spawn failed for \`${cmd}\`: ${res.error.message}`);
+  }
+  if (res.status !== 0) {
+    throw new Error(
+      `\`${cmd} ${args.join(' ')}\` exited ${String(res.status)}\n` +
+        `stdout:\n${res.stdout ?? ''}\nstderr:\n${res.stderr ?? ''}`,
+    );
+  }
+  return { stdout: res.stdout ?? '', stderr: res.stderr ?? '' };
+}
+
+beforeAll(() => {
+  // 1. Require a current build. Turbo's `test` task `dependsOn: ["build"]`, so
+  //    dist is fresh before tests run; the gate flow (`pnpm -r build` first)
+  //    guarantees the same. We assert rather than rebuild here so this test
+  //    never races a concurrent `tsc -p core` from a sibling package's test.
+  for (const rel of [
+    'dist/index.js',
+    'dist/config.js',
+    'dist/lessons.js',
+    'dist/artifacts.js',
+    'dist/packs.js',
+  ]) {
+    if (!fs.existsSync(path.join(CORE_ROOT, rel))) {
+      throw new Error(
+        `core dist/${rel} is missing — build core first (\`pnpm -r build\`; turbo builds before test in CI).`,
+      );
+    }
+  }
+
+  // 2. Isolated sandbox under core's node_modules (git/prettier-ignored;
+  //    transitive deps resolve via the core node_modules ancestor).
+  sandbox = fs.mkdtempSync(path.join(CORE_ROOT, 'node_modules', '.totem-packtest-'));
+
+  // 3. Pack the core package into the sandbox.
+  const packDest = path.join(sandbox, 'tgz');
+  fs.mkdirSync(packDest, { recursive: true });
+  run('pnpm', ['pack', '--pack-destination', packDest], { cwd: CORE_ROOT });
+  const tarball = fs
+    .readdirSync(packDest)
+    .filter((f) => f.endsWith('.tgz'))
+    .map((f) => path.join(packDest, f))[0];
+  if (!tarball) {
+    throw new Error(`pnpm pack produced no .tgz in ${packDest}`);
+  }
+
+  // 4. Extract into node_modules/@mmnto/totem (strip the `package/` prefix).
+  //    Pass RELATIVE, forward-slash paths with cwd=sandbox so no drive-letter
+  //    colon reaches tar — GNU tar (MSYS) otherwise reads `D:\…` as a remote
+  //    `host:path`, and bsdtar rejects `--force-local`, so relative paths are
+  //    the only form both accept.
+  installedPkgDir = path.join(sandbox, 'node_modules', '@mmnto', 'totem');
+  fs.mkdirSync(installedPkgDir, { recursive: true });
+  const tarballRel = path.relative(sandbox, tarball).replace(/\\/g, '/');
+  run('tar', ['-xzf', tarballRel, '-C', 'node_modules/@mmnto/totem', '--strip-components=1'], {
+    cwd: sandbox,
+  });
+});
+
+afterAll(() => {
+  if (sandbox) {
+    fs.rmSync(sandbox, { recursive: true, force: true, maxRetries: 5 });
+  }
+});
+
+describe('@mmnto/totem packaged subpath exports (#2336)', () => {
+  it(
+    'declares every supported subpath in the packed exports map with existing targets',
+    () => {
+      const pkg = JSON.parse(
+        fs.readFileSync(path.join(installedPkgDir, 'package.json'), 'utf-8'),
+      ) as { exports?: Record<string, { import?: string; types?: string }> };
+      const exportsMap = pkg.exports ?? {};
+
+      // The legacy root barrel stays present and byte-compatible.
+      expect(exportsMap['.']).toEqual({
+        import: './dist/index.js',
+        types: './dist/index.d.ts',
+      });
+
+      for (const subpath of SUPPORTED_SUBPATHS) {
+        const entry = exportsMap[subpath];
+        expect(entry, `exports["${subpath}"] present`).toBeDefined();
+        expect(entry?.import, `${subpath} import condition`).toMatch(/^\.\/dist\/.+\.js$/);
+        expect(entry?.types, `${subpath} types condition`).toMatch(/^\.\/dist\/.+\.d\.ts$/);
+        expect(
+          fs.existsSync(path.join(installedPkgDir, entry?.import ?? '')),
+          `${subpath} import target exists in tarball`,
+        ).toBe(true);
+        expect(
+          fs.existsSync(path.join(installedPkgDir, entry?.types ?? '')),
+          `${subpath} types target exists in tarball`,
+        ).toBe(true);
+      }
+    },
+    INTEGRATION_TIMEOUT_MS,
+  );
+
+  it(
+    'imports every supported subpath from the packed artifact as Node ESM (via the package specifier)',
+    () => {
+      const consumer = path.join(sandbox, 'esm-consumer.mjs');
+      fs.writeFileSync(
+        consumer,
+        [
+          "import * as config from '@mmnto/totem/config';",
+          "import * as lessons from '@mmnto/totem/lessons';",
+          "import * as artifacts from '@mmnto/totem/artifacts';",
+          "import * as packs from '@mmnto/totem/packs';",
+          'const report = {',
+          '  config: typeof config.TotemConfigSchema !== "undefined" && typeof config.getConfigTier === "function",',
+          '  lessons: typeof lessons.lessonFileName === "function" && typeof lessons.LessonRoleSchema !== "undefined",',
+          '  artifacts: typeof artifacts.VerdictArtifactSchema !== "undefined" && artifacts.VERDICT_ARTIFACT_SCHEMA_VERSION === "1.0.0",',
+          '  packs: typeof packs.loadInstalledPacks === "function" && typeof packs.isEngineSealed === "function" && typeof packs.InstalledPacksManifestSchema !== "undefined",',
+          '};',
+          'process.stdout.write(JSON.stringify(report));',
+          '',
+        ].join('\n'),
+      );
+
+      const { stdout } = run(process.execPath, [consumer], { cwd: sandbox });
+      const report = JSON.parse(stdout) as Record<string, boolean>;
+      expect(report).toEqual({
+        config: true,
+        lessons: true,
+        artifacts: true,
+        packs: true,
+      });
+    },
+    INTEGRATION_TIMEOUT_MS,
+  );
+
+  it(
+    'resolves every supported subpath through the packed types condition (tsc node16)',
+    () => {
+      fs.writeFileSync(
+        path.join(sandbox, 'type-consumer.ts'),
+        [
+          "import type { TotemConfig } from '@mmnto/totem/config';",
+          "import type { LessonRole, LessonFrontmatter } from '@mmnto/totem/lessons';",
+          "import type { VerdictArtifact } from '@mmnto/totem/artifacts';",
+          "import type { PackRegistrationAPI, InstalledPacksManifest } from '@mmnto/totem/packs';",
+          '// Referencing the imported types forces full type resolution through',
+          '// the exports map; an unresolved specifier fails tsc with TS2307.',
+          'export type Probe = [',
+          '  TotemConfig,',
+          '  LessonRole,',
+          '  LessonFrontmatter,',
+          '  VerdictArtifact,',
+          '  PackRegistrationAPI,',
+          '  InstalledPacksManifest,',
+          '];',
+          '',
+        ].join('\n'),
+      );
+      fs.writeFileSync(
+        path.join(sandbox, 'tsconfig.json'),
+        JSON.stringify(
+          {
+            compilerOptions: {
+              module: 'node16',
+              moduleResolution: 'node16',
+              target: 'ES2022',
+              strict: true,
+              noEmit: true,
+              skipLibCheck: true,
+              types: [],
+            },
+            files: ['type-consumer.ts'],
+          },
+          null,
+          2,
+        ),
+      );
+
+      // Exits 0 only if all four supported subpaths resolve their `types`
+      // condition through the packed exports map.
+      run(process.execPath, [TSC_BIN, '-p', 'tsconfig.json'], { cwd: sandbox });
+    },
+    INTEGRATION_TIMEOUT_MS,
+  );
+
+  it(
+    'registers a synchronous CJS register.cjs pack through the published /packs shape (ADR-097)',
+    () => {
+      // Fixture pack: a synchronous CommonJS `register.cjs` exporting the
+      // ADR-097 CJS-friendly named `register` callback.
+      const fixtureDir = path.join(sandbox, 'fixture-pack');
+      fs.mkdirSync(fixtureDir, { recursive: true });
+      const registerCjs = path.join(fixtureDir, 'register.cjs');
+      fs.writeFileSync(
+        registerCjs,
+        [
+          '// Synchronous CJS pack registration entry (ADR-097 § 5 Q5).',
+          'module.exports.register = function register(api) {',
+          "  api.registerChunkStrategy('adr097-cjs-fixture', class FixtureChunker {});",
+          '};',
+          '',
+        ].join('\n'),
+      );
+
+      // installed-packs.json pointing at the fixture's absolute register.cjs.
+      const projectRoot = path.join(sandbox, 'project');
+      fs.mkdirSync(path.join(projectRoot, '.totem'), { recursive: true });
+      fs.writeFileSync(
+        path.join(projectRoot, '.totem', 'installed-packs.json'),
+        JSON.stringify(
+          {
+            version: 1,
+            packs: [
+              {
+                name: 'adr097-cjs-fixture-pack',
+                resolvedPath: registerCjs,
+                declaredEngineRange: '*',
+              },
+            ],
+          },
+          null,
+          2,
+        ),
+      );
+
+      // Load through the PUBLISHED package specifier (not workspace src).
+      const consumer = path.join(sandbox, 'adr097-consumer.mjs');
+      fs.writeFileSync(
+        consumer,
+        [
+          "import { loadInstalledPacks } from '@mmnto/totem/packs';",
+          `const loaded = loadInstalledPacks(${JSON.stringify({
+            projectRoot,
+            totemDir: '.totem',
+            engineVersion: '1.0.0',
+          })});`,
+          'process.stdout.write(JSON.stringify(loaded.map((p) => p.name)));',
+          '',
+        ].join('\n'),
+      );
+
+      const { stdout } = run(process.execPath, [consumer], { cwd: sandbox });
+      const names = JSON.parse(stdout) as string[];
+      expect(names).toContain('adr097-cjs-fixture-pack');
+    },
+    INTEGRATION_TIMEOUT_MS,
+  );
+});

--- a/packages/core/src/packaged-exports.test.ts
+++ b/packages/core/src/packaged-exports.test.ts
@@ -51,8 +51,14 @@ function run(
 ): { stdout: string; stderr: string } {
   // cross-spawn resolves win32 `.cmd` shims (e.g. `pnpm`) and binaries under
   // paths with spaces WITHOUT a shell, so both platforms spawn the same argv
-  // array — no cmd.exe, no manual quoting (repo safe-exec convention).
-  const res = spawnSync(cmd, [...args], { cwd: opts.cwd, encoding: 'utf-8' });
+  // array — no cmd.exe, no manual quoting (repo safe-exec convention). The
+  // child-level `timeout` is the ONLY effective bound here: spawnSync blocks
+  // the event loop, so vitest's hook/test timeouts cannot fire mid-hang.
+  const res = spawnSync(cmd, [...args], {
+    cwd: opts.cwd,
+    encoding: 'utf-8',
+    timeout: INTEGRATION_TIMEOUT_MS,
+  });
   if (res.error) {
     throw new Error(`spawn failed for \`${cmd}\`: ${res.error.message}`);
   }

--- a/packages/core/src/packaged-exports.test.ts
+++ b/packages/core/src/packaged-exports.test.ts
@@ -19,13 +19,15 @@
  * sandbox — none touch a git seam.
  */
 
-import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import { createRequire } from 'node:module';
 import * as path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
+import { sync as spawnSync } from 'cross-spawn';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { VERDICT_ARTIFACT_SCHEMA_VERSION } from './artifacts.js';
 
 const require = createRequire(import.meta.url);
 const HERE = path.dirname(fileURLToPath(import.meta.url));
@@ -47,17 +49,10 @@ function run(
   args: readonly string[],
   opts: { cwd: string },
 ): { stdout: string; stderr: string } {
-  // Node 24 on win32 refuses to spawn `.cmd` shims (e.g. `pnpm`) without a
-  // shell, and `node.exe` itself lives under a path with a space ("Program
-  // Files"). Route win32 through the shell with manual quoting; posix spawns
-  // directly so no shell quoting is involved.
-  const res =
-    process.platform === 'win32'
-      ? spawnSync(
-          [cmd, ...args].map((a) => (/[\s"]/.test(a) ? `"${a.replace(/"/g, '""')}"` : a)).join(' '),
-          { cwd: opts.cwd, encoding: 'utf-8', shell: true },
-        )
-      : spawnSync(cmd, [...args], { cwd: opts.cwd, encoding: 'utf-8', shell: false });
+  // cross-spawn resolves win32 `.cmd` shims (e.g. `pnpm`) and binaries under
+  // paths with spaces WITHOUT a shell, so both platforms spawn the same argv
+  // array — no cmd.exe, no manual quoting (repo safe-exec convention).
+  const res = spawnSync(cmd, [...args], { cwd: opts.cwd, encoding: 'utf-8' });
   if (res.error) {
     throw new Error(`spawn failed for \`${cmd}\`: ${res.error.message}`);
   }
@@ -118,9 +113,11 @@ beforeAll(() => {
   });
 }, INTEGRATION_TIMEOUT_MS);
 
+const CLEANUP_MAX_RETRIES = 5;
+
 afterAll(() => {
   if (sandbox) {
-    fs.rmSync(sandbox, { recursive: true, force: true, maxRetries: 5 });
+    fs.rmSync(sandbox, { recursive: true, force: true, maxRetries: CLEANUP_MAX_RETRIES });
   }
 }, INTEGRATION_TIMEOUT_MS);
 
@@ -139,17 +136,28 @@ describe('@mmnto/totem packaged subpath exports (#2336)', () => {
         types: './dist/index.d.ts',
       });
 
+      // Exact per-subpath targets: a lazy exports map pointing every subpath
+      // at dist/index.js would satisfy shape regexes AND the ESM-import test
+      // (the barrel is a superset), silently republishing the full unsupported
+      // surface at each curated subpath. Pin the exact aggregator targets.
+      const expectedTargets: Record<string, { import: string; types: string }> = {
+        './config': { import: './dist/config.js', types: './dist/config.d.ts' },
+        './lessons': { import: './dist/lessons.js', types: './dist/lessons.d.ts' },
+        './artifacts': { import: './dist/artifacts.js', types: './dist/artifacts.d.ts' },
+        './packs': { import: './dist/packs.js', types: './dist/packs.d.ts' },
+      };
+
       for (const subpath of SUPPORTED_SUBPATHS) {
-        const entry = exportsMap[subpath];
-        expect(entry, `exports["${subpath}"] present`).toBeDefined();
-        expect(entry?.import, `${subpath} import condition`).toMatch(/^\.\/dist\/.+\.js$/);
-        expect(entry?.types, `${subpath} types condition`).toMatch(/^\.\/dist\/.+\.d\.ts$/);
+        const expected = expectedTargets[subpath];
+        expect(expected, `expectedTargets["${subpath}"] declared`).toBeDefined();
+        if (!expected) continue;
+        expect(exportsMap[subpath], `exports["${subpath}"]`).toEqual(expected);
         expect(
-          fs.existsSync(path.join(installedPkgDir, entry?.import ?? '')),
+          fs.existsSync(path.join(installedPkgDir, expected.import)),
           `${subpath} import target exists in tarball`,
         ).toBe(true);
         expect(
-          fs.existsSync(path.join(installedPkgDir, entry?.types ?? '')),
+          fs.existsSync(path.join(installedPkgDir, expected.types)),
           `${subpath} types target exists in tarball`,
         ).toBe(true);
       }
@@ -171,7 +179,11 @@ describe('@mmnto/totem packaged subpath exports (#2336)', () => {
           'const report = {',
           '  config: typeof config.TotemConfigSchema !== "undefined" && typeof config.getConfigTier === "function",',
           '  lessons: typeof lessons.lessonFileName === "function" && typeof lessons.LessonRoleSchema !== "undefined",',
-          '  artifacts: typeof artifacts.VerdictArtifactSchema !== "undefined" && artifacts.VERDICT_ARTIFACT_SCHEMA_VERSION === "1.0.0",',
+          // Deliberate contract pin, derived not hardcoded: the packed artifact's
+          // exported schema version must equal the workspace source constant. A
+          // legit version bump moves both sides together; a mismatch means the
+          // packed tarball drifted from source.
+          `  artifacts: typeof artifacts.VerdictArtifactSchema !== "undefined" && artifacts.VERDICT_ARTIFACT_SCHEMA_VERSION === ${JSON.stringify(VERDICT_ARTIFACT_SCHEMA_VERSION)},`,
           '  packs: typeof packs.loadInstalledPacks === "function" && typeof packs.isEngineSealed === "function" && typeof packs.InstalledPacksManifestSchema !== "undefined",',
           '};',
           'process.stdout.write(JSON.stringify(report));',

--- a/packages/core/src/packs.ts
+++ b/packages/core/src/packs.ts
@@ -1,0 +1,38 @@
+/**
+ * `@mmnto/totem/packs` — supported pack-discovery entry point.
+ *
+ * Curated, semver-tracked re-export of the pack registration + load surface
+ * ADR-097 (§ 5 Q5, § 10) and ADR-099 classify as true semver contracts: the
+ * `PackRegistrationAPI` a pack's `register` callback receives, the boot-time
+ * `loadInstalledPacks()` loader, the sealed-engine predicates, and the
+ * `installed-packs.json` manifest schema/type. Third-party packs bind to this
+ * surface, so it carries the most external weight of the supported entries.
+ *
+ * Every name here is also re-exported from the legacy root barrel (`.`).
+ * Scope is deliberately the `pack-discovery` module only: the manifest
+ * *writer* (`resolveInstalledPacks` / `writeInstalledPacksManifest`) and the
+ * stale-manifest detector are `totem sync` producer internals, not the pack
+ * registration contract, and stay off this surface pending a first external
+ * consumer. Test-only helpers (`__resetForTests`) are never exported here.
+ *
+ * Additive per mmnto-ai/totem#2336 (ADR-084 / Proposal 294). The root barrel
+ * is unchanged; nothing is removed from it in this cut.
+ */
+
+// Registration + load + manifest types.
+export type {
+  InstalledPacksManifest,
+  LoadedPack,
+  LoadInstalledPacksOptions,
+  PackRegisterCallback,
+  PackRegistrationAPI,
+} from './pack-discovery.js';
+
+// Manifest schema, loader, engine-seal predicates, and engine-version resolver.
+export {
+  InstalledPacksManifestSchema,
+  isEngineSealed,
+  loadedPacks,
+  loadInstalledPacks,
+  resolveEngineVersion,
+} from './pack-discovery.js';


### PR DESCRIPTION
## Mechanical Root Cause

`packages/core/src/index.ts` is a 1,167-line barrel re-exporting the full core module graph as the only public entry of `@mmnto/totem` — consumers cannot tell contract from lab surface, so the package makes no credible per-symbol semver promise (#2336 fact 1; 4-seat panel converged on the fix shape).

## Fix Applied

Four thin, curated `tsc`-built aggregators wired as `exports`-map subpaths — additive only:

- **`@mmnto/totem/config`** — `TotemConfig` + all 12 transitive config-schema type aliases + schema values. Carries the ONE verified hard cohort contract (the only cross-repo barrel import in the npm-consuming cohort).
- **`@mmnto/totem/packs`** — `PackRegistrationAPI`, `loadInstalledPacks`, `loadedPacks`, `isEngineSealed` + manifest schema/types (ADR-097/099 semver surfaces; heaviest external weight).
- **`@mmnto/totem/lessons`** — bounded lesson lifecycle (io / frontmatter / role-filter / retirement). Deliberately excludes the frozen compiler.
- **`@mmnto/totem/artifacts`** — Prop 302 verdict-artifact schema + content-address-verified loader surface.

Root `.` barrel is **byte-compatible** (leading JSDoc block only — zero export changes; independently diff-verified) and marked legacy in JSDoc + README. Every subpath re-exports a strict subset of what `.` already exposes — no new leakage.

**`/search`: skipped this cut** (panel-sanctioned): the only query seam is the full `LanceStore` index engine (native-coupled, mutating) — a coherent `/search` needs a read-only query facade first. **`/rules` + `/lint`: not minted** per the impl ruling (ambiguous ownership seam; no ambiguous promises).

## Out of Scope

Root-barrel narrowing (rides a major / #1746 ledger), the `/search` facade, `/rules`-`/lint` ownership resolution, and a pre-existing hygiene find: core''s `tsc` emits compiled `*.test.js` into `dist/` which `files: ["dist"]` publishes — existing main behavior, now tracked in #2353.

## Tests Added/Updated

- [x] Added/updated automated tests covering the root-cause mechanism

`packaged-exports.test.ts` proves the **packed artifact**, not the workspace graph: `pnpm pack` → sandboxed install → (1) exports-map shape, (2) Node ESM import of all four subpaths, (3) tsc `node16` type resolution, (4) ADR-097 synchronous-CJS `register.cjs` registration through the published `/packs` shape. Plus a `build:lite` gate (resolver-sensitive WASM aliases). All independently re-run by the orchestrator seat post-build.

Gates: `pnpm -r build` OK · full `totem lint` 387/0 · `totem lint --base main` 0 errors · prettier clean · ESLint 0 errors · core 3169/3169. Changeset: `@mmnto/totem` minor (fixed-group cascade covers cli/mcp; no behavior change there).

Provenance: Opus 4.8 builder in an isolated worktree from the 4-seat panel spec; diff + decisive gates independently verified.

## Related Tickets

Part of #2336 (slice B — CLI one-liner + help tiering — closes it). Panel record: #2336 comments + panel dispatches, 2026-07-12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
