### PR TITLE
fix: Tenet-16 corollary — drop ambient defaultModel; fail-loud cloud-compile model (CLI + worker halves)

### DIFF
--- a/.changeset/t16-cloud-compile-model.md
+++ b/.changeset/t16-cloud-compile-model.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/cli': patch
+---
+
+fix(compile): cloud compile fails loud when no model is resolvable instead of silently substituting a hardcoded vendor default (Tenet-16 corollary, mmnto-ai/totem-strategy#800 item 1).
+
+The `--cloud` request body's `model` field fell back to a concrete `'gemini-3-flash-preview'` where the three manifest-provenance sibling sites fall back to `'unknown'`. Unlike those provenance stamps, this is a live request parameter sent to the cloud worker — so the fix is not `'unknown'` but a loud `CONFIG_INVALID` error before any token exec or network call when neither `--model` nor `orchestrator.defaultModel` resolves.
+
+Consumer-impact: CLI surface — `totem lesson compile --cloud` invoked with no `--model` and no `orchestrator.defaultModel` now errors loudly instead of silently compiling via an undeclared vendor model. Cloud runs with an explicitly resolved model are byte-identical; the local compile path is untouched.

--- a/packages/cli/src/commands/compile-cloud-model.test.ts
+++ b/packages/cli/src/commands/compile-cloud-model.test.ts
@@ -1,0 +1,121 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { cleanTmpDir } from '../test-utils.js';
+import { compileCommand } from './compile.js';
+
+// ─── Helpers ─────────────────────────────────────────
+//
+// These tests exercise the cloud-compile model resolution: the model POSTed
+// to the cloud worker is a live request parameter, so it must come from
+// --model or `orchestrator.defaultModel` — absence fails loud BEFORE any
+// token exec or network call, never silently substituting a vendor default
+// (Tenet-16 corollary, mmnto-ai/totem-strategy#800 item 1).
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'totem-compile-cloud-'));
+}
+
+/** Build a valid `## Lesson —` markdown block that readAllLessons can parse. */
+function lessonMarkdown(heading: string, body: string): string {
+  return `## Lesson — ${heading}\n\n**Tags:** test\n\n${body}\n`;
+}
+
+function setupWorkspace(tmpDir: string, options: { defaultModel?: string }): void {
+  // Full-tier config with a shell orchestrator so compileCommand enters the
+  // compilation branch. The shell command never runs under --cloud; the only
+  // knob under test is the presence of `defaultModel`.
+  fs.writeFileSync(
+    path.join(tmpDir, 'totem.config.ts'),
+    [
+      'export default {',
+      '  targets: [{ glob: "**/*.ts", type: "code", strategy: "typescript-ast" }],',
+      '  totemDir: ".totem",',
+      '  orchestrator: {',
+      '    provider: "shell",',
+      '    command: "echo should-never-run",',
+      ...(options.defaultModel !== undefined
+        ? [`    defaultModel: "${options.defaultModel}",`]
+        : []),
+      '  },',
+      '};',
+      '',
+    ].join('\n'),
+    'utf-8',
+  );
+
+  const totemDir = path.join(tmpDir, '.totem');
+  const lessonsDir = path.join(totemDir, 'lessons');
+  fs.mkdirSync(lessonsDir, { recursive: true });
+  // One fresh lesson (absent from compiled-rules.json) so the cloud branch
+  // has a non-manual lesson to send.
+  fs.writeFileSync(
+    path.join(lessonsDir, 'use-err.md'),
+    lessonMarkdown('Use err in catch', 'Do not use the identifier "error" in catch blocks.'),
+    'utf-8',
+  );
+  fs.writeFileSync(
+    path.join(totemDir, 'compiled-rules.json'),
+    JSON.stringify({ version: 1, rules: [], nonCompilable: [] }, null, 2) + '\n',
+    'utf-8',
+  );
+}
+
+describe('compileCommand --cloud model resolution', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+    // Short-circuit the Cloud Run token resolution: without this, the run
+    // spawns `gcloud` with cwd inside tmpDir, whose child process can hold
+    // the directory handle past afterEach on Windows (EPERM on rmSync).
+    vi.stubEnv('TOTEM_CLOUD_TOKEN', 'test-token');
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    cleanTmpDir(tmpDir);
+    vi.unstubAllGlobals();
+    vi.unstubAllEnvs();
+  });
+
+  it('fails loud before any network call when neither --model nor defaultModel is set', async () => {
+    setupWorkspace(tmpDir, {});
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    await expect(compileCommand({ cloud: 'http://127.0.0.1:9/compile' })).rejects.toThrow(
+      /No model specified for cloud compile/,
+    );
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('sends the configured defaultModel as the request model — never a hardcoded vendor fallback', async () => {
+    setupWorkspace(tmpDir, { defaultModel: 'cfg-cloud-model' });
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        results: [],
+        stats: { elapsed_seconds: 0, succeeded: 0, failed: 0 },
+      }),
+    });
+    vi.stubGlobal('fetch', fetchSpy);
+
+    // Post-fetch result processing is not under test — the lesson has no
+    // matching result row, so the run may complete or reject; either way the
+    // request body already carries the assertion target.
+    await compileCommand({ cloud: 'http://127.0.0.1:9/compile' }).catch(() => undefined);
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const body = JSON.parse((fetchSpy.mock.calls[0]?.[1] as { body: string }).body) as {
+      model: string;
+    };
+    expect(body.model).toBe('cfg-cloud-model');
+  });
+});

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -1419,6 +1419,20 @@ export async function compileCommand(
             `${newRules.length} rules — ${compiled} compiled${failed > 0 ? `, ${failed} failed` : ''} (all manual, no cloud call needed)`,
           );
         } else {
+          // Tenet-16 corollary (mmnto-ai/totem-strategy#800 item 1): the model
+          // sent to the cloud worker must come from the caller or config —
+          // never a hardcoded vendor default (the three manifest-provenance
+          // sibling sites fall back to 'unknown'; this one is a live request
+          // parameter, so absence fails loud instead).
+          const cloudModel = options.model ?? config.orchestrator?.defaultModel;
+          if (!cloudModel) {
+            throw new TotemConfigError(
+              'No model specified for cloud compile.',
+              "Provide one with --model, or set a 'defaultModel' in your orchestrator config.",
+              'CONFIG_INVALID',
+            );
+          }
+
           log.info(TAG, `Cloud compile: ${cloudLessons.length} lessons → ${cloudUrl}`);
 
           // Resolve auth token for Cloud Run (uses gcloud identity token or TOTEM_CLOUD_TOKEN env)
@@ -1450,7 +1464,7 @@ export async function compileCommand(
             body: JSON.stringify({
               lessons: scrubbedLessons,
               prompt: COMPILER_SYSTEM_PROMPT,
-              model: options.model ?? config.orchestrator?.defaultModel ?? 'gemini-3-flash-preview',
+              model: cloudModel,
               concurrency: CLOUD_CONCURRENCY,
             }),
           });

--- a/services/compile-worker/src/index.ts
+++ b/services/compile-worker/src/index.ts
@@ -69,6 +69,12 @@ app.post('/compile', async (c) => {
     return c.json({ err: 'Missing lessons or prompt' }, 400);
   }
 
+  // Tenet-16 corollary (mmnto-ai/totem-strategy#800 item 1): the model is the
+  // caller's to name — no silent vendor default on the server half either.
+  if (!body.model) {
+    return c.json({ err: 'Missing model' }, 400);
+  }
+
   // Request validation — prevent abuse
   const MAX_LESSONS = 1000;
   const MAX_PAYLOAD_CHARS = 10_000_000; // ~10MB
@@ -80,7 +86,7 @@ app.post('/compile', async (c) => {
     return c.json({ err: `Payload too large (max ${MAX_PAYLOAD_CHARS} chars)` }, 400);
   }
 
-  const model = body.model ?? 'gemini-3-flash-preview';
+  const model = body.model;
   const concurrency = Math.min(body.concurrency ?? 50, 100);
 
   const startTime = Date.now();

--- a/totem.config.ts
+++ b/totem.config.ts
@@ -23,13 +23,19 @@ const config: TotemConfig = {
 
   orchestrator: {
     provider: 'gemini',
-    defaultModel: 'gemini-3-flash-preview',
+    // Tenet-16 corollary (mmnto-ai/totem-strategy#800 item 1, cohort sweep
+    // 2026-07-14): no ambient `defaultModel` — every LLM-backed role this repo
+    // runs is named per-role below instead. `extract`/`reviewlearn` pin what
+    // the dropped default resolved to, so behavior is identical. Siblings:
+    // mmnto-ai/totem-status#97, mmnto-ai/totem-strategy#870.
     overrides: {
       compile: 'anthropic:claude-sonnet-4-6', // totem-context: valid model ID — verified via SDK, shield false-positive (predates Claude 4.6 release)
       docs: 'gemini-3.1-pro-preview',
       spec: 'gemini-3.1-pro-preview',
       shield: 'gemini-3.1-pro-preview',
       triage: 'gemini-3.1-pro-preview',
+      extract: 'gemini-3-flash-preview',
+      reviewlearn: 'gemini-3-flash-preview',
     },
     // mmnto/totem#1291 Phase 3: dogfood prompt caching against our own
     // compile path. Sonnet 4.6 caches the static compiler template (~50KB


### PR DESCRIPTION
## What

Tenet-16 corollary sweep, totem repo half (config names roles, not ambient model IDs — mmnto-ai/totem-strategy#800 item 1; cohort siblings: mmnto-ai/totem-status#97, mmnto-ai/totem-strategy#870). Three changes, one seam:

1. **`totem.config.ts`** — drop the committed `orchestrator.defaultModel: 'gemini-3-flash-preview'`. The two roles that actually rode the ambient default (`extract`, `reviewlearn` — verified by enumerating every `runOrchestrator` tag against the `overrides` map) are now named per-role in `overrides`, pinned to exactly what the dropped default resolved to. Behavior-identical; every LLM-backed role this repo runs is now explicit.
2. **`packages/cli/src/commands/compile.ts`** — the `--cloud` request body's `model` fell back to a hardcoded `'gemini-3-flash-preview'` where the three manifest-provenance sibling sites (476/1280/1924) fall back to `'unknown'`. Unlike those, this is a **live wire parameter** sent to the cloud worker — so the fix is not `'unknown'` but a loud `CONFIG_INVALID` before any token exec or network call when neither `--model` nor `orchestrator.defaultModel` resolves. The all-manual early-exit (no cloud call needed) is unaffected — the guard sits inside the branch that actually calls out.
3. **`services/compile-worker`** — the server half carried the same silent default (`body.model ?? 'gemini-3-flash-preview'`). `model` is now a required request field (400 on absence, mirroring the adjacent lessons/prompt guard). The only in-repo client always sends it after (2).

New `compile-cloud-model.test.ts` covers the two CLI seams: throw-before-network when nothing resolves, and the configured model landing in the request body.

## Decision record (local review lane, 2 lanes × 2 rounds)

The gemini lane raised (both rounds): *cloud resolution should check `overrides.compile` before `defaultModel`, else `--cloud` without `--model` now throws in this repo despite a configured compile override.* **Declined — decline-substantive, with evidence:** the worker (`services/compile-worker/src/index.ts`) is Gemini-only (`@google/genai` `generateContent`); this repo's `overrides.compile` is `anthropic:claude-sonnet-4-6`, so wiring overrides into the cloud site would send a provider-qualified Anthropic ID straight to the Gemini API and fail at runtime with a far worse error than the loud, guidance-bearing config error this PR ships. An overrides-aware cloud resolution needs the worker to declare a model contract first — adjacent to the existing worker debt (mmnto-ai/totem#1695), not this seam. The anthropic lane returned clean both rounds.

## Out of scope

- **`init-detect.ts`** emitting concrete `defaultModel` values into generated consumer configs — the T0-vs-T1 product judgment the sweep flagged separately; ruling pending, deliberately not folded in.
- Cloud-path override-precedence design (above) and worker auth (mmnto-ai/totem#1695).
- The compile path remains under the rule-compilation freeze; nothing here runs it — source-only changes, verified against the freeze do-not list.

## Consumer impact

Declared in the changeset (`@mmnto/cli` patch): `lesson compile --cloud` with no `--model` and no `orchestrator.defaultModel` now errors loudly instead of silently compiling via an undeclared vendor model. Explicitly-modeled cloud runs are byte-identical; the local compile path is untouched. The worker's `model` field becoming required is a private-service contract change with a single in-repo client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
