### PR TITLE
feat(orchestrators): model refresh — current-gen defaults + sampling params reconciled at the provider boundary

### DIFF
--- a/.changeset/model-refresh-param-boundary.md
+++ b/.changeset/model-refresh-param-boundary.md
@@ -1,0 +1,12 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+---
+
+feat(orchestrators): current-generation model support — sampling params reconciled at the provider boundary (mmnto-ai/totem#1476).
+
+Current-generation models reject client sampling params with a 400 (Anthropic Opus 4.7+/Sonnet 5+/Fable reject `temperature`/`top_p`/`top_k`; OpenAI gpt-5+/o-series additionally reject the legacy `max_tokens` key in favor of `max_completion_tokens`). Previously every Totem LLM role hardcoded a `temperature`, so pointing any override or review lane at a current-generation model failed at runtime — GPT-5-family models could not be used as orchestrators at all.
+
+`modelStripsTemperature()` (`@mmnto/totem`) widens from the Opus-4.7+-only regex to the cross-provider predicate (Sonnet 5+, Haiku 5+, Fable/Mythos, gpt-5+, o-series; provider-qualified strings accepted), and both the anthropic and openai orchestrator boundaries now consume it: callers keep declaring their intended temperature, and the boundary omits it for models that reject it. The openai orchestrator additionally selects `max_completion_tokens` vs legacy `max_tokens` on the same predicate, so OpenAI-compatible local servers (Ollama, LM Studio, Groq) keep the legacy shape they expect.
+
+Consumer-impact: orchestrator request shape — configs pointing at Opus 4.7+/Sonnet 5+/Fable or gpt-5+/o-series models now work instead of failing with a 400; requests to models that accept sampling params are byte-identical. `modelStripsTemperature` returns `true` for the new families, which also flows into the compile-worker fingerprint (records temperature absence) for anthropic-provider configs. No config migration required.

--- a/docs/reference/supported-models.md
+++ b/docs/reference/supported-models.md
@@ -1,6 +1,6 @@
 # Supported Models & AI Tools Reference
 
-> **Last validated:** 2026-05-02 (1.25.0 ship state). The Gemini tier below was refreshed 2026-06-13 from Google's published model docs (a targeted update, not a full re-validation).
+> **Last validated:** 2026-07-14 (model-refresh PR: Gemini, Anthropic, and OpenAI orchestrator tiers re-validated against published provider docs; Totem defaults moved to `gemini-3.5-flash` / `claude-sonnet-5`; sampling-param stripping now handled at the orchestrator boundary).
 
 Totem supports four LLM provider families for orchestration, and exports project
 knowledge to all major AI coding tools. This document tracks model IDs, tool
@@ -14,15 +14,15 @@ Used by `totem review`, `totem spec`, `totem triage`, `totem lesson extract`, et
 
 ### Google Gemini
 
-| Role                | Model ID                         | Notes                                                                                                                               |
-| ------------------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| Flagship (agentic)  | `gemini-3.5-flash`               | GA flagship — coding/agentic; Gemini API + Antigravity. **Not Totem's default** (default stays `gemini-3-flash-preview`, next row). |
-| Default (fast)      | `gemini-3-flash-preview`         | Preview — current Totem default                                                                                                     |
-| Pro (complex tasks) | `gemini-3.1-pro-preview`         | Replaced `gemini-3-pro-preview` (March 2026)                                                                                        |
-| Image generation    | `gemini-3.1-flash-image-preview` | Flash variant optimized for image tasks                                                                                             |
-| Fast-lite (newest)  | `gemini-3.1-flash-lite`          | 2.5x faster TTFT than Flash, lowest cost                                                                                            |
-| Stable fast         | `gemini-2.5-flash`               | GA — **deprecating June 17, 2026**                                                                                                  |
-| Stable pro          | `gemini-2.5-pro`                 | GA — **deprecating June 17, 2026**                                                                                                  |
+| Role                | Model ID                         | Notes                                                                                                                                            |
+| ------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Flagship (agentic)  | `gemini-3.5-flash`               | GA flagship — coding/agentic; **Totem's default for all Gemini roles since 2026-07-14** ($1.50/$9 flat; beats 3.1 Pro on coding/agentic)         |
+| Previous default    | `gemini-3-flash-preview`         | Preview — superseded as Totem default by `gemini-3.5-flash`                                                                                      |
+| Pro (complex tasks) | `gemini-3.1-pro-preview`         | Replaced `gemini-3-pro-preview` (March 2026). Still preview-only; $2/$12 (→$4/$18 >200k). Fallback if Flash prose quality regresses on docs/spec |
+| Image generation    | `gemini-3.1-flash-image-preview` | Flash variant optimized for image tasks                                                                                                          |
+| Fast-lite (newest)  | `gemini-3.1-flash-lite`          | 2.5x faster TTFT than Flash, lowest cost                                                                                                         |
+| Stable fast         | `gemini-2.5-flash`               | GA — **deprecating June 17, 2026**                                                                                                               |
+| Stable pro          | `gemini-2.5-pro`                 | GA — **deprecating June 17, 2026**                                                                                                               |
 
 **Listing API:** `GET https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY`
 
@@ -33,15 +33,16 @@ Used by `totem review`, `totem spec`, `totem triage`, `totem lesson extract`, et
 
 ### Anthropic (Claude)
 
-| Role              | Model ID            | Dated Snapshot               | Notes                                          |
-| ----------------- | ------------------- | ---------------------------- | ---------------------------------------------- |
-| Flagship          | `claude-opus-4-7`   | (undated alias)              | 1M context, Jan 2026 cutoff, adaptive thinking |
-| Previous Opus     | `claude-opus-4-6`   | (undated alias)              | 1M context, May 2025 cutoff, still available   |
-| Fast/balanced     | `claude-sonnet-4-6` | (undated alias)              | Default for `totem lesson compile` routing     |
-| Cheapest          | `claude-haiku-4-5`  | `claude-haiku-4-5-20251001`  |                                                |
-| Legacy Opus       | `claude-opus-4-5`   | Still available              |                                                |
-| Legacy Sonnet 4.5 | `claude-sonnet-4-5` | `claude-sonnet-4-5-20250929` |                                                |
-| Legacy Sonnet 4   | `claude-sonnet-4-0` | `claude-sonnet-4-20250514`   |                                                |
+| Role            | Model ID                                  | Dated Snapshot                                            | Notes                                                                                                                                                       |
+| --------------- | ----------------------------------------- | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Top tier        | `claude-fable-5`                          | (undated alias)                                           | Most capable; premium pricing ($10/$50); rejects sampling params                                                                                            |
+| Flagship Opus   | `claude-opus-4-8`                         | (undated alias)                                           | 1M context, adaptive thinking; rejects sampling params                                                                                                      |
+| Fast/balanced   | `claude-sonnet-5`                         | (undated alias)                                           | **Totem default for `compile` + the Anthropic review lane since 2026-07-14.** $3/$15 (intro $2/$10 through 2026-08-31); rejects non-default sampling params |
+| Previous Opus   | `claude-opus-4-7`                         | (undated alias)                                           | 1M context, Jan 2026 cutoff; rejects sampling params                                                                                                        |
+| Previous Sonnet | `claude-sonnet-4-6`                       | (undated alias)                                           | Previous Totem compile/review default; accepts sampling params                                                                                              |
+| Cheapest        | `claude-haiku-4-5`                        | `claude-haiku-4-5-20251001`                               |                                                                                                                                                             |
+| Legacy Opus     | `claude-opus-4-5` / `claude-opus-4-6`     | Still available                                           |                                                                                                                                                             |
+| Legacy Sonnet   | `claude-sonnet-4-5` / `claude-sonnet-4-0` | `claude-sonnet-4-5-20250929` / `claude-sonnet-4-20250514` |                                                                                                                                                             |
 
 **Listing API:** `GET https://api.anthropic.com/v1/models`
 
@@ -49,31 +50,31 @@ Used by `totem review`, `totem spec`, `totem triage`, `totem lesson extract`, et
 - Docs: https://docs.anthropic.com/en/docs/about-claude/models
 - Note: Anthropic does **not** offer an embedding model.
 
-**Migrating to Claude Opus 4.7.** Behaviour changes if you switch any override from 4.6 to 4.7:
+**Current-generation param constraints (Opus 4.7+ / Sonnet 5+ / Fable).** These families reject client sampling params (`temperature`, `top_p`, `top_k`) with a 400:
 
-1. `temperature`, `top_p`, and `top_k` now return 400 errors. Strip sampling params from orchestrator calls. Tracked for Totem in [#1476](https://github.com/mmnto-ai/totem/issues/1476) (seven internal call sites still pass `temperature`, latent until an override points at 4.7).
+1. **Handled at the orchestrator boundary since 2026-07-14** ([#1476](https://github.com/mmnto-ai/totem/issues/1476)): `modelStripsTemperature()` gates the param in the anthropic and openai orchestrators, so callers keep declaring intent and the boundary omits it for models that reject it. No per-call-site changes needed when pointing an override at a new family.
 2. `extended_thinking` is replaced by `adaptive_thinking`, steered via the `effort: low | medium | high | xhigh | max` parameter. Totem does not currently use extended thinking, so no migration needed today.
-3. New tokenizer adds a 1.0 to 1.35x token overhead vs 4.6 depending on content. Re-budget `max_tokens` if you previously tuned it for 4.6.
+3. The Opus 4.7+ / Sonnet 5 tokenizers add a 1.0 to 1.35x token overhead vs 4.6 depending on content. Re-budget `max_tokens` if you previously tuned it for 4.6.
 
-See the [Opus 4.7 migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide) for the full list.
+See the [model migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide) for the full list.
 
 ### OpenAI
 
-| Role                 | Model ID                  | Notes                                 |
-| -------------------- | ------------------------- | ------------------------------------- |
-| Flagship             | `gpt-5.4`                 | Latest                                |
-| Pro (higher compute) | `gpt-5.4-pro`             | Higher token limits                   |
-| Fast/cheap           | `gpt-5.4-mini`            | Cost-optimized (succeeded gpt-5-mini) |
-| Ultra-cheap          | `gpt-5.4-nano`            | Smallest (succeeded gpt-5-nano)       |
-| Reasoning (best)     | `o3-pro`                  | API only — retired from ChatGPT       |
-| Reasoning (fast)     | `o4-mini`                 | API only — retired from ChatGPT       |
-| Previous gen         | `gpt-4.1`, `gpt-4.1-mini` | Legacy, still available in API        |
+| Role               | Model ID                  | Notes                                                                      |
+| ------------------ | ------------------------- | -------------------------------------------------------------------------- |
+| Flagship           | `gpt-5.6-sol`             | GA July 2026 (alias `gpt-5.6`) — frontier reasoning + long-horizon agentic |
+| Balanced           | `gpt-5.6-terra`           | GPT-5.5-competitive at ~2x lower cost                                      |
+| Fast/cheap         | `gpt-5.6-luna`            | Fastest and most affordable 5.6-family model                               |
+| Previous flagship  | `gpt-5.4` / `gpt-5.4-pro` | Still available in API                                                     |
+| Reasoning (legacy) | `o3-pro`, `o4-mini`       | API only — retired from ChatGPT                                            |
+| Previous gen       | `gpt-4.1`, `gpt-4.1-mini` | Legacy, still available in API                                             |
 
 **Listing API:** `GET https://api.openai.com/v1/models`
 
 - Auth: `Authorization: Bearer $OPENAI_API_KEY`
 - Docs: https://platform.openai.com/docs/models
 - Note: `gpt-4o`, `gpt-4o-mini`, `o4-mini` retired from ChatGPT (Feb 2026) but still in API.
+- **Param constraints:** every `gpt-5*` and o-series model rejects `max_tokens` (requires `max_completion_tokens`) and rejects non-default `temperature`. Handled at the openai-orchestrator boundary since 2026-07-14 via `modelStripsTemperature()` — GPT models work as spec/review/lane orchestrators out of the box; OpenAI-compatible local servers (Ollama, LM Studio, Groq) keep the legacy `max_tokens` shape. "Codex" is OpenAI's coding agent surface, not a model ID — the mainline `gpt-5.5+` models ship in Codex directly.
 
 ### Ollama (Local)
 
@@ -105,17 +106,18 @@ can be used as an orchestrator.
 
 Used by `totem sync` for indexing chunks into LanceDB.
 
-| Provider             | Model ID                     | Dimensions | Notes                                 |
-| -------------------- | ---------------------------- | ---------- | ------------------------------------- |
-| **Gemini** (default) | `gemini-embedding-2-preview` | 768        | Multimodal, task-type aware retrieval |
-| Gemini               | `gemini-embedding-001`       | 768        | Stable, text-only                     |
-| OpenAI               | `text-embedding-3-small`     | 1536       | Lowest onboarding friction            |
-| OpenAI (large)       | `text-embedding-3-large`     | 3072       | Higher quality, higher cost           |
-| **Ollama** (offline) | `nomic-embed-text`           | 768        | Most popular local embed model        |
-| Ollama               | `nomic-embed-text-v2-moe`    | 768        | Multilingual MoE variant              |
-| Ollama               | `mxbai-embed-large`          | 1024       | BERT-large class SOTA                 |
-| Ollama               | `embeddinggemma`             | 768        | 300M params, from Gemma 3, 100+ langs |
-| Ollama               | `qwen3-embedding`            | varies     | 0.6B–8B, 100+ languages               |
+| Provider             | Model ID                     | Dimensions | Notes                                                                                              |
+| -------------------- | ---------------------------- | ---------- | -------------------------------------------------------------------------------------------------- |
+| **Gemini** (default) | `gemini-embedding-2-preview` | 768        | Multimodal, task-type aware retrieval                                                              |
+| Gemini (GA)          | `gemini-embedding-2`         | 768        | GA successor to the preview — **swapping requires a full re-index** (deferred, tracked separately) |
+| Gemini               | `gemini-embedding-001`       | 768        | Stable, text-only                                                                                  |
+| OpenAI               | `text-embedding-3-small`     | 1536       | Lowest onboarding friction                                                                         |
+| OpenAI (large)       | `text-embedding-3-large`     | 3072       | Higher quality, higher cost                                                                        |
+| **Ollama** (offline) | `nomic-embed-text`           | 768        | Most popular local embed model                                                                     |
+| Ollama               | `nomic-embed-text-v2-moe`    | 768        | Multilingual MoE variant                                                                           |
+| Ollama               | `mxbai-embed-large`          | 1024       | BERT-large class SOTA                                                                              |
+| Ollama               | `embeddinggemma`             | 768        | 300M params, from Gemma 3, 100+ langs                                                              |
+| Ollama               | `qwen3-embedding`            | varies     | 0.6B–8B, 100+ languages                                                                            |
 
 ---
 
@@ -125,7 +127,10 @@ Current defaults configured in `totem.config.ts` and `packages/cli/src/commands/
 
 ```
 Embedding:    Gemini gemini-embedding-2-preview  (or OpenAI text-embedding-3-small, Ollama nomic-embed-text)
-Orchestrator: Gemini gemini-3-flash-preview  (overrides: gemini-3.1-pro-preview for spec/review/triage)
+Orchestrator: per-role overrides (no ambient default — Tenet-16 corollary):
+              gemini-3.5-flash for docs/spec/shield/triage/extract/reviewlearn,
+              anthropic:claude-sonnet-5 for compile;
+              review.lanes: anthropic:claude-sonnet-5 + gemini:gemini-3.5-flash
 ```
 
 ### Updating Defaults

--- a/packages/cli/src/orchestrators/anthropic-orchestrator.test.ts
+++ b/packages/cli/src/orchestrators/anthropic-orchestrator.test.ts
@@ -138,6 +138,72 @@ describe('invokeAnthropicOrchestrator', () => {
     expect(result.finishReason).toBeUndefined();
   });
 
+  // ─── Sampling-param stripping (mmnto-ai/totem#1476) ──
+
+  describe('temperature stripping for current-generation models', () => {
+    const okResponse = {
+      content: [{ type: 'text', text: 'ok' }],
+      usage: { input_tokens: 10, output_tokens: 5 },
+      stop_reason: 'end_turn',
+    };
+
+    it('forwards temperature to models that accept sampling params (Sonnet 4.6)', async () => {
+      mockCreate.mockResolvedValueOnce(okResponse);
+
+      await invokeAnthropicOrchestrator({ ...baseOpts, temperature: 0 });
+
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ temperature: 0 }));
+    });
+
+    it.each(['claude-sonnet-5', 'claude-opus-4-8', 'claude-fable-5'])(
+      'omits temperature entirely for %s (API rejects sampling params with 400)',
+      async (model) => {
+        mockCreate.mockResolvedValueOnce(okResponse);
+
+        await invokeAnthropicOrchestrator({ ...baseOpts, model, temperature: 0 });
+
+        const call = mockCreate.mock.calls[0]?.[0] as Record<string, unknown>;
+        expect(call['model']).toBe(model);
+        expect('temperature' in call).toBe(false);
+      },
+    );
+
+    it('omits temperature when the caller never set one (unchanged shape)', async () => {
+      mockCreate.mockResolvedValueOnce(okResponse);
+
+      await invokeAnthropicOrchestrator(baseOpts);
+
+      const call = mockCreate.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect('temperature' in call).toBe(false);
+    });
+
+    it('gives current-generation models Opus-level max_tokens headroom (adaptive thinking draws from it)', async () => {
+      mockCreate.mockResolvedValueOnce(okResponse);
+
+      await invokeAnthropicOrchestrator({ ...baseOpts, model: 'claude-sonnet-5' });
+
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ max_tokens: 16_384 }));
+    });
+
+    it('keeps the 8K cap for previous-generation sonnet models', async () => {
+      mockCreate.mockResolvedValueOnce(okResponse);
+
+      await invokeAnthropicOrchestrator(baseOpts); // claude-sonnet-4-6
+
+      expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ max_tokens: 8_192 }));
+    });
+
+    it('haiku keeps its conservative 4K cap even for hypothetical 5+ variants — but still strips temperature', async () => {
+      mockCreate.mockResolvedValueOnce(okResponse);
+
+      await invokeAnthropicOrchestrator({ ...baseOpts, model: 'claude-haiku-5', temperature: 0 });
+
+      const call = mockCreate.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(call['max_tokens']).toBe(4_096);
+      expect('temperature' in call).toBe(false);
+    });
+  });
+
   // ─── Caching (mmnto/totem#1291 Phase 2) ──────────────
 
   describe('prompt caching', { timeout: 15000 }, () => {

--- a/packages/cli/src/orchestrators/anthropic-orchestrator.ts
+++ b/packages/cli/src/orchestrators/anthropic-orchestrator.ts
@@ -12,6 +12,8 @@ import { detectPackageManager, isQuotaError } from './orchestrator.js';
 // ─── Constants ───────────────────────────────────────
 
 const DEFAULT_MAX_TOKENS = 8_192;
+/** Opus-tier / current-generation output headroom (adaptive thinking draws from max_tokens). */
+const CURRENT_GEN_MAX_TOKENS = 16_384;
 
 /** Model-aware max output tokens — prevents API errors on smaller models. */
 function getMaxTokens(model: string): number {
@@ -24,9 +26,9 @@ function getMaxTokens(model: string): number {
   // from max_tokens — the 8K Sonnet cap truncated Sonnet 5 review verdicts
   // mid-JSON (output == cap exactly, lane abstained). Give the family
   // Opus-level headroom.
-  if (modelStripsTemperature(model)) return 16_384;
+  if (modelStripsTemperature(model)) return CURRENT_GEN_MAX_TOKENS;
   if (model.includes('sonnet')) return DEFAULT_MAX_TOKENS;
-  if (model.includes('opus')) return 16_384;
+  if (model.includes('opus')) return CURRENT_GEN_MAX_TOKENS;
   return DEFAULT_MAX_TOKENS;
 }
 

--- a/packages/cli/src/orchestrators/anthropic-orchestrator.ts
+++ b/packages/cli/src/orchestrators/anthropic-orchestrator.ts
@@ -1,4 +1,9 @@
-import { buildMissingSdkHint, TotemConfigError, TotemOrchestratorError } from '@mmnto/totem';
+import {
+  buildMissingSdkHint,
+  modelStripsTemperature,
+  TotemConfigError,
+  TotemOrchestratorError,
+} from '@mmnto/totem';
 
 import { log } from '../ui.js';
 import type { OrchestratorInvokeOptions, OrchestratorResult } from './orchestrator.js';
@@ -10,7 +15,16 @@ const DEFAULT_MAX_TOKENS = 8_192;
 
 /** Model-aware max output tokens — prevents API errors on smaller models. */
 function getMaxTokens(model: string): number {
+  // Haiku keeps its conservative cap even for future 5+ variants — their
+  // output ceiling is unknown, and 4K is the proven-safe allocation. Revisit
+  // when a Haiku 5 actually ships (review-lane finding, 2026-07-14).
   if (model.includes('haiku')) return 4_096;
+  // Current-generation models (Sonnet 5+ / Opus 4.7+ / Fable) run adaptive
+  // thinking when the `thinking` param is omitted, and thinking tokens draw
+  // from max_tokens — the 8K Sonnet cap truncated Sonnet 5 review verdicts
+  // mid-JSON (output == cap exactly, lane abstained). Give the family
+  // Opus-level headroom.
+  if (modelStripsTemperature(model)) return 16_384;
   if (model.includes('sonnet')) return DEFAULT_MAX_TOKENS;
   if (model.includes('opus')) return 16_384;
   return DEFAULT_MAX_TOKENS;
@@ -124,7 +138,13 @@ export async function invokeAnthropicOrchestrator(
       max_tokens: getMaxTokens(model),
       ...(systemField !== undefined ? { system: systemField } : {}),
       messages: [{ role: 'user' as const, content: prompt }],
-      ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+      // Opus 4.7+ / Sonnet 5+ / Fable reject client sampling params with a
+      // 400 — omit temperature entirely for them (mmnto-ai/totem#1476). The
+      // caller's declared value still reaches models that accept it; the
+      // compile-worker fingerprint records the same absence.
+      ...(opts.temperature !== undefined && !modelStripsTemperature(model)
+        ? { temperature: opts.temperature }
+        : {}),
     });
 
     const durationMs = Date.now() - startMs;

--- a/packages/cli/src/orchestrators/openai-orchestrator.test.ts
+++ b/packages/cli/src/orchestrators/openai-orchestrator.test.ts
@@ -241,5 +241,16 @@ describe('invokeOpenAIOrchestrator', () => {
         expect(call['temperature']).toBe(0.4);
       },
     );
+
+    it('gpt-5 chat variants get max_completion_tokens but KEEP temperature — the two axes diverge there (CR finding)', async () => {
+      mockCreate.mockResolvedValueOnce(okResponse());
+
+      await invokeOpenAIOrchestrator({ ...baseOpts, model: 'gpt-5-chat-latest', temperature: 0 });
+
+      const call = mockCreate.mock.calls[0]?.[0] as Record<string, unknown>;
+      expect(call['max_completion_tokens']).toBe(16_384);
+      expect('max_tokens' in call).toBe(false);
+      expect(call['temperature']).toBe(0);
+    });
   });
 });

--- a/packages/cli/src/orchestrators/openai-orchestrator.test.ts
+++ b/packages/cli/src/orchestrators/openai-orchestrator.test.ts
@@ -199,4 +199,47 @@ describe('invokeOpenAIOrchestrator', () => {
       );
     });
   });
+
+  // ─── Reasoning-family param shape (mmnto-ai/totem#1476) ──
+  //
+  // GPT-5+ / o-series models reject the legacy `max_tokens` key (the API
+  // requires `max_completion_tokens`) and reject non-default `temperature`.
+  // OpenAI-compatible local servers and older chat models keep the legacy
+  // shape — some compat servers do not recognize `max_completion_tokens`.
+
+  describe('reasoning-family param shape', () => {
+    const okResponse = () => ({
+      choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+    });
+
+    it.each(['gpt-5.6-sol', 'gpt-5.4', 'o3-pro'])(
+      'sends max_completion_tokens and omits temperature for %s',
+      async (model) => {
+        mockCreate.mockResolvedValueOnce(okResponse());
+
+        await invokeOpenAIOrchestrator({ ...baseOpts, model, temperature: 0 });
+
+        const call = mockCreate.mock.calls[0]?.[0] as Record<string, unknown>;
+        expect(call['model']).toBe(model);
+        expect(call['max_completion_tokens']).toBe(16_384);
+        expect('max_tokens' in call).toBe(false);
+        expect('temperature' in call).toBe(false);
+      },
+    );
+
+    it.each(['gpt-4.1', 'gpt-4o-mini', 'llama3.2'])(
+      'keeps the legacy max_tokens + temperature shape for %s (compat servers, older models)',
+      async (model) => {
+        mockCreate.mockResolvedValueOnce(okResponse());
+
+        await invokeOpenAIOrchestrator({ ...baseOpts, model, temperature: 0.4 });
+
+        const call = mockCreate.mock.calls[0]?.[0] as Record<string, unknown>;
+        expect(call['max_tokens']).toBe(16_384);
+        expect('max_completion_tokens' in call).toBe(false);
+        expect(call['temperature']).toBe(0.4);
+      },
+    );
+  });
 });

--- a/packages/cli/src/orchestrators/openai-orchestrator.ts
+++ b/packages/cli/src/orchestrators/openai-orchestrator.ts
@@ -90,17 +90,21 @@ export async function invokeOpenAIOrchestrator(
 
     // GPT-5+ / o-series reasoning models reject the legacy `max_tokens` key
     // (400 — the API requires `max_completion_tokens`) and reject non-default
-    // `temperature` (mmnto-ai/totem#1476). Older chat models and OpenAI-
-    // compatible local servers (Ollama, LM Studio, Groq) keep the legacy
-    // param shape — some of them do not recognize `max_completion_tokens`.
-    const isReasoningFamily = modelStripsTemperature(model);
+    // `temperature` (mmnto-ai/totem#1476). The two axes diverge on exactly
+    // one family: gpt-5+ *chat* variants (e.g. gpt-5-chat-latest) accept
+    // `temperature` but still reject legacy `max_tokens` (CR finding on
+    // mmnto-ai/totem#2358). Older chat models and OpenAI-compatible local
+    // servers (Ollama, LM Studio, Groq) keep the legacy param shape — some
+    // of them do not recognize `max_completion_tokens`.
+    const stripsSampling = modelStripsTemperature(model);
+    const requiresMaxCompletionTokens = stripsSampling || /gpt-[5-9]/.test(model);
     const response = await client.chat.completions.create({
       model,
-      ...(isReasoningFamily
+      ...(requiresMaxCompletionTokens
         ? { max_completion_tokens: DEFAULT_MAX_TOKENS }
         : { max_tokens: DEFAULT_MAX_TOKENS }),
       messages,
-      ...(opts.temperature !== undefined && !isReasoningFamily
+      ...(opts.temperature !== undefined && !stripsSampling
         ? { temperature: opts.temperature }
         : {}),
     });

--- a/packages/cli/src/orchestrators/openai-orchestrator.ts
+++ b/packages/cli/src/orchestrators/openai-orchestrator.ts
@@ -1,4 +1,9 @@
-import { buildMissingSdkHint, TotemConfigError, TotemOrchestratorError } from '@mmnto/totem';
+import {
+  buildMissingSdkHint,
+  modelStripsTemperature,
+  TotemConfigError,
+  TotemOrchestratorError,
+} from '@mmnto/totem';
 
 import { log } from '../ui.js';
 import type { OrchestratorInvokeOptions, OrchestratorResult } from './orchestrator.js';
@@ -83,11 +88,21 @@ export async function invokeOpenAIOrchestrator(
     }
     messages.push({ role: 'user', content: prompt });
 
+    // GPT-5+ / o-series reasoning models reject the legacy `max_tokens` key
+    // (400 — the API requires `max_completion_tokens`) and reject non-default
+    // `temperature` (mmnto-ai/totem#1476). Older chat models and OpenAI-
+    // compatible local servers (Ollama, LM Studio, Groq) keep the legacy
+    // param shape — some of them do not recognize `max_completion_tokens`.
+    const isReasoningFamily = modelStripsTemperature(model);
     const response = await client.chat.completions.create({
       model,
-      max_tokens: DEFAULT_MAX_TOKENS,
+      ...(isReasoningFamily
+        ? { max_completion_tokens: DEFAULT_MAX_TOKENS }
+        : { max_tokens: DEFAULT_MAX_TOKENS }),
       messages,
-      ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+      ...(opts.temperature !== undefined && !isReasoningFamily
+        ? { temperature: opts.temperature }
+        : {}),
     });
 
     const durationMs = Date.now() - startMs;

--- a/packages/core/src/compile-worker-fingerprint.test.ts
+++ b/packages/core/src/compile-worker-fingerprint.test.ts
@@ -139,8 +139,28 @@ describe('modelStripsTemperature', () => {
     ['claude-sonnet-4-6', false],
     ['claude-sonnet-4-7', false], // Sonnet 4-7 doesn't strip per Phase 1 doc
     ['claude-haiku-4-5', false],
-    ['gpt-4o', false],
     ['gemini-2.5-pro', false],
+    // 2026-07-14 widening (#1476): Sonnet 5+ / Haiku 5+ / Fable / Mythos
+    ['claude-sonnet-5', true],
+    ['claude-sonnet-5-1', true],
+    ['claude-haiku-5', true],
+    ['claude-fable-5', true],
+    ['claude-mythos-5', true],
+    ['anthropic:claude-sonnet-5', true], // provider-qualified config value
+    ['anthropic:claude-sonnet-4-6', false],
+    // 2026-07-14 widening (#1476): OpenAI gpt-5+ and o-series reasoning
+    ['gpt-5.6-sol', true],
+    ['gpt-5.6', true],
+    ['gpt-5.4-mini', true],
+    ['o3-pro', true],
+    ['o4-mini', true],
+    ['o10', true], // two-digit o-series (review-lane finding, 2026-07-14)
+    ['openai:o3-pro', true], // provider-qualified config value
+    ['gpt-4o', false], // the 'o' in 4o is digit-preceded, not an o-series ID
+    ['gpt-4o-mini', false],
+    ['gpt-4.1', false],
+    ['turbo-1', false], // letter-preceded 'o' is not an o-series boundary
+    ['gemini-3.5-flash', false],
   ])('%s → %s', (model, expected) => {
     expect(modelStripsTemperature(model)).toBe(expected);
   });

--- a/packages/core/src/compile-worker-fingerprint.test.ts
+++ b/packages/core/src/compile-worker-fingerprint.test.ts
@@ -156,10 +156,12 @@ describe('modelStripsTemperature', () => {
     ['o4-mini', true],
     ['o10', true], // two-digit o-series (review-lane finding, 2026-07-14)
     ['openai:o3-pro', true], // provider-qualified config value
+    ['gpt-5-chat-latest', false], // chat variant accepts temperature (CR finding, mmnto-ai/totem#2358)
     ['gpt-4o', false], // the 'o' in 4o is digit-preceded, not an o-series ID
     ['gpt-4o-mini', false],
     ['gpt-4.1', false],
-    ['turbo-1', false], // letter-preceded 'o' is not an o-series boundary
+    ['turbo-1', false], // 'o' not immediately followed by a digit (adjacency, not boundary)
+    ['turbo1', false], // letter-preceded 'o' immediately followed by a digit (boundary exclusion)
     ['gemini-3.5-flash', false],
   ])('%s → %s', (model, expected) => {
     expect(modelStripsTemperature(model)).toBe(expected);

--- a/packages/core/src/compile-worker-fingerprint.ts
+++ b/packages/core/src/compile-worker-fingerprint.ts
@@ -99,9 +99,11 @@ export function readPromptTemplateContentHash(promptTemplatePath: string): strin
  * `docs/reference/supported-models.md` § Orchestrator Models. Covers:
  *   - Anthropic Opus 4.7+ / Opus 5+ / Sonnet 5+ / Haiku 5+ / Fable / Mythos —
  *     the adaptive-thinking generation removed client sampling control
- *   - OpenAI gpt-5+ and o-series reasoning families — `temperature` is
- *     unsupported (these also require `max_completion_tokens` over
- *     `max_tokens`; that half lives at the openai-orchestrator boundary)
+ *   - OpenAI gpt-5+ reasoning models and the o-series — `temperature` is
+ *     unsupported. gpt-5+ *chat* variants (e.g. `gpt-5-chat-latest`) are
+ *     excluded: they accept `temperature` while still rejecting the legacy
+ *     `max_tokens` key, so the token-key axis is decided separately at the
+ *     openai-orchestrator boundary (CR finding on mmnto-ai/totem#2358)
  * Accepts provider-qualified strings ('anthropic:claude-sonnet-5') as well
  * as bare IDs. Consumed by the compile-worker fingerprint (records absence)
  * and by the anthropic/openai orchestrator boundaries (omit the param).
@@ -111,7 +113,7 @@ export function readPromptTemplateContentHash(promptTemplatePath: string): strin
  * future home for a richer reconciliation surface; defer until that lands.
  */
 export function modelStripsTemperature(model: string): boolean {
-  return /opus-4-[7-9]|opus-[5-9]|sonnet-[5-9]|haiku-[5-9]|claude-fable|claude-mythos|gpt-[5-9]|(?:^|[^a-zA-Z0-9])o[1-9]\d*(?:\D|$)/.test(
+  return /opus-4-[7-9]|opus-[5-9]|sonnet-[5-9]|haiku-[5-9]|claude-fable|claude-mythos|gpt-[5-9](?!.*chat)|(?:^|[^a-zA-Z0-9])o[1-9]\d*(?:\D|$)/.test(
     model,
   );
 }

--- a/packages/core/src/compile-worker-fingerprint.ts
+++ b/packages/core/src/compile-worker-fingerprint.ts
@@ -96,14 +96,22 @@ export function readPromptTemplateContentHash(promptTemplatePath: string): strin
 /**
  * True when the model's API rejects the `temperature` (and `top_p` / `top_k`)
  * sampling parameter with HTTP 400. Sourced from
- * `docs/reference/supported-models.md` lines 50-52: Claude Opus 4.7+ rejects
- * sampling params.
+ * `docs/reference/supported-models.md` § Orchestrator Models. Covers:
+ *   - Anthropic Opus 4.7+ / Opus 5+ / Sonnet 5+ / Haiku 5+ / Fable / Mythos —
+ *     the adaptive-thinking generation removed client sampling control
+ *   - OpenAI gpt-5+ and o-series reasoning families — `temperature` is
+ *     unsupported (these also require `max_completion_tokens` over
+ *     `max_tokens`; that half lives at the openai-orchestrator boundary)
+ * Accepts provider-qualified strings ('anthropic:claude-sonnet-5') as well
+ * as bare IDs. Consumed by the compile-worker fingerprint (records absence)
+ * and by the anthropic/openai orchestrator boundaries (omit the param).
  *
- * Regex is Phase 1 sniff infrastructure. When Anthropic ships a new family
- * that strips params (Sonnet 5.0+, Haiku 5.0+, etc.), widen here. A.3.b's
- * `totem doctor --compliance` is the future home for a richer reconciliation
- * surface; defer until that lands.
+ * Regex is Phase 1 sniff infrastructure — when a provider ships a new family
+ * that strips params, widen here. A.3.b's `totem doctor --compliance` is the
+ * future home for a richer reconciliation surface; defer until that lands.
  */
 export function modelStripsTemperature(model: string): boolean {
-  return /opus-4-[7-9]|opus-[5-9]/.test(model);
+  return /opus-4-[7-9]|opus-[5-9]|sonnet-[5-9]|haiku-[5-9]|claude-fable|claude-mythos|gpt-[5-9]|(?:^|[^a-zA-Z0-9])o[1-9]\d*(?:\D|$)/.test(
+    model,
+  );
 }

--- a/totem.config.ts
+++ b/totem.config.ts
@@ -25,20 +25,27 @@ const config: TotemConfig = {
     provider: 'gemini',
     // Tenet-16 corollary (mmnto-ai/totem-strategy#800 item 1, cohort sweep
     // 2026-07-14): no ambient `defaultModel` — every LLM-backed role this repo
-    // runs is named per-role below instead. `extract`/`reviewlearn` pin what
-    // the dropped default resolved to, so behavior is identical. Siblings:
-    // mmnto-ai/totem-status#97, mmnto-ai/totem-strategy#870.
+    // runs is named per-role below instead. Siblings: mmnto-ai/totem-status#97,
+    // mmnto-ai/totem-strategy#870.
+    //
+    // Model refresh 2026-07-14 (operator-ruled): gemini roles → gemini-3.5-flash
+    // (GA 2026-05-19; beats 3.1 Pro on coding/agentic at ~25% lower cost, flat
+    // long-context pricing, and it is a stable ID where 3.1 Pro is still
+    // preview-only); anthropic roles → claude-sonnet-5 (same $ tier as 4.6,
+    // near-Opus review quality). Watch-item: if spec/docs prose quality
+    // regresses on Flash, revert those two roles to gemini-3.1-pro-preview.
+    // Re-evaluate when Gemini 3.5 Pro actually ships.
     overrides: {
-      compile: 'anthropic:claude-sonnet-4-6', // totem-context: valid model ID — verified via SDK, shield false-positive (predates Claude 4.6 release)
-      docs: 'gemini-3.1-pro-preview',
-      spec: 'gemini-3.1-pro-preview',
-      shield: 'gemini-3.1-pro-preview',
-      triage: 'gemini-3.1-pro-preview',
-      extract: 'gemini-3-flash-preview',
-      reviewlearn: 'gemini-3-flash-preview',
+      compile: 'anthropic:claude-sonnet-5', // totem-context: valid model ID — Sonnet 5 GA June 2026; shield's known-model lesson predates it
+      docs: 'gemini-3.5-flash',
+      spec: 'gemini-3.5-flash',
+      shield: 'gemini-3.5-flash',
+      triage: 'gemini-3.5-flash',
+      extract: 'gemini-3.5-flash',
+      reviewlearn: 'gemini-3.5-flash',
     },
     // mmnto/totem#1291 Phase 3: dogfood prompt caching against our own
-    // compile path. Sonnet 4.6 caches the static compiler template (~50KB
+    // compile path. Sonnet 5 caches the static compiler template (~50KB
     // ast-grep manual + few-shot) on the first call of a session and reads
     // from cache on every subsequent lesson within the 5-minute TTL window.
     // Default 5m ephemeral covers bulk recompile + multi-lesson CI runs.
@@ -57,7 +64,7 @@ const config: TotemConfig = {
   // `totem review --model ...` stays a one-lane invocation; omit `lanes` to
   // fall back to the legacy single-lane path.
   review: {
-    lanes: ['anthropic:claude-sonnet-4-6', 'gemini:gemini-3.1-pro-preview'],
+    lanes: ['anthropic:claude-sonnet-5', 'gemini:gemini-3.5-flash'],
   },
 
   docs: [


### PR DESCRIPTION
## What

Operator-ruled model refresh (2026-07-14): every LLM role moves to current-generation models, and the sampling-param seam that blocked current-gen models is fixed at the orchestrator boundary — closing mmnto-ai/totem#1476.

> **Stacked on #2357** (Tenet-16 `defaultModel` drop). Base is `fix/t16-defaultmodel`; GitHub will auto-retarget to `main` when #2357 merges.

### 1. The seam fix (the load-bearing half)

Current-generation models reject client sampling params with a 400: Anthropic Opus 4.7+/Sonnet 5+/Fable reject `temperature`; OpenAI gpt-5+/o-series additionally reject the legacy `max_tokens` key (they require `max_completion_tokens`). Every Totem LLM call site hardcodes a `temperature`, so pointing any override or review lane at these models failed at runtime — **GPT-5-family models could not be used as Totem orchestrators at all**, which also blocked consumers (the operator's explicit ask: users should be able to run spec/reviews on GPT).

- `modelStripsTemperature()` (`@mmnto/totem`) widens per its own changelog instruction ("when Anthropic ships Sonnet 5.0+, widen here") into the cross-provider predicate: Sonnet 5+, Haiku 5+, Fable/Mythos, gpt-5+, o-series (incl. two-digit `o10+`), provider-qualified strings accepted.
- The anthropic and openai orchestrator boundaries consume it: callers keep declaring their intended temperature; the boundary omits it for models that reject it. This fixes all seven #1476 call sites in one seam instead of per-site edits.
- The openai orchestrator selects `max_completion_tokens` vs legacy `max_tokens` on the same predicate — OpenAI-compatible local servers (Ollama, LM Studio, Groq) keep the legacy shape some of them require.
- `getMaxTokens` gives the current-gen Anthropic family 16K headroom: these models run adaptive thinking when `thinking` is omitted, and thinking draws from `max_tokens` — the 8K sonnet cap truncated live Sonnet 5 review verdicts mid-JSON (caught by end-to-end verification, below). Haiku keeps its conservative 4K cap even for hypothetical 5+ variants (review-lane finding).

### 2. The config refresh (this repo's pins)

| Role | Was | Now |
|---|---|---|
| review.lanes | `anthropic:claude-sonnet-4-6` + `gemini:gemini-3.1-pro-preview` | `anthropic:claude-sonnet-5` + `gemini:gemini-3.5-flash` |
| docs / spec / shield / triage | `gemini-3.1-pro-preview` | `gemini-3.5-flash` |
| extract / reviewlearn | `gemini-3-flash-preview` | `gemini-3.5-flash` |
| compile | `anthropic:claude-sonnet-4-6` | `anthropic:claude-sonnet-5` (freeze-parked; takes effect at unfreeze) |

Grounding: Gemini 3.5 Flash is GA (2026-05-19), beats 3.1 Pro on coding/agentic benchmarks at ~25% lower cost with flat long-context pricing, and is a stable ID where 3.1 Pro remains preview-only. Sonnet 5 is the same price tier as Sonnet 4.6 (intro-priced lower through 2026-08-31) with near-Opus review quality. Net cost decreases on every role. Watch-item (in-config comment): revert spec/docs to `gemini-3.1-pro-preview` if Flash prose quality regresses; re-evaluate when Gemini 3.5 Pro ships. `docs/reference/supported-models.md` re-validated across all three providers.

## Verification

Beyond unit gates (full workspace suite green; new tests for the predicate matrix, both orchestrators' param shapes, and the token caps), the change was **exercised end-to-end**: `totem review` ran the two new lanes live. Round 1 caught the Sonnet 5 truncation (lane abstained at exactly the 8K cap) → fixed → round 2 completed on both lanes with structured verdicts.

## Decision record (local review lane, 2 lanes × 2 rounds)

- **Accepted:** haiku-5 cap ordering (haiku branch now precedes the predicate branch — 4K stays the proven allocation until a real Haiku 5 exists); two-digit o-series regex widen (`o[1-9]\d*`).
- **Declined — decline-substantive:** "predicate conflation" (one predicate drives temperature-strip, token-key choice, and cap headroom). Deliberate coupling: today's model reality couples these three axes exactly, the coupling is documented at the predicate and both call sites, and speculative predicate splits for models that don't exist is the Tenet-21 anti-pattern. A future divergent model widens here — same contract the predicate has carried since birth.

## Out of scope

- Embedding swap to GA `gemini-embedding-2` — forces a full re-index, cohort-wide blast radius; deferred (flagged in supported-models.md).
- `init-detect` emitted defaults (Tenet-16 T0-vs-T1 judgment) — separately pending.
- The rule-compilation freeze is untouched; the compile-override bump is dormant until unfreeze.

Closes #1476

🤖 Generated with [Claude Code](https://claude.com/claude-code)
