### PR TITLE
feat(init): per-role model emission — no ambient defaultModel + current-gen IDs (t16 corollary follow-on)

### DIFF
--- a/.changeset/init-per-role-model-emission.md
+++ b/.changeset/init-per-role-model-emission.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/cli': minor
+---
+
+feat(init): generated configs name models per-role — no ambient `defaultModel` — and stamp current-generation IDs (Tenet-16 corollary follow-on, mmnto-ai/totem-strategy#800 item 1).
+
+`totem init`'s orchestrator detection was the generator of the ambient-default violation class cohort-wide: every generated config committed a concrete `orchestrator.defaultModel`, and the stamped IDs (`gemini-3-flash-preview` / `claude-sonnet-4-6` / `gpt-5.4-mini`) were stale after the 2026-07-14 model refresh. Detection itself is legitimate local-environment resolution at genesis, so it stays; the emitted shape changes to per-role `overrides` covering every LLM-backed role tag (compile/docs/spec/shield/triage/extract/reviewlearn) with current IDs: `gemini-3.5-flash` (Gemini CLI + API branches), `claude-sonnet-5` (Anthropic API), `gpt-5.6-terra` (OpenAI API), the `sonnet` tier alias (claude CLI), `gemma4` (Ollama). The TS-template block is now rendered from the same object serialized into YAML/TOML configs, so the two emission surfaces cannot drift.
+
+Consumer-impact: `totem init` generated-config surface only — newly generated configs get the per-role shape and current model IDs; existing configs are never rewritten. One behavioral edge: a freshly generated config no longer feeds `totem lesson compile --cloud`'s `defaultModel` fallback, so `--cloud` without `--model` fails loud (CONFIG_INVALID) instead of silently riding the previously-generated vendor default — consistent with the mmnto-ai/totem#2357 ruling. No migration required.

--- a/docs/reference/supported-models.md
+++ b/docs/reference/supported-models.md
@@ -127,7 +127,7 @@ Current defaults configured in `totem.config.ts` (this repo) and stamped into
 generated consumer configs by `totem init`
 (`packages/cli/src/commands/init-detect.ts`):
 
-```
+```text
 Embedding:    Gemini gemini-embedding-2-preview  (or OpenAI text-embedding-3-small, Ollama nomic-embed-text)
 Orchestrator: per-role overrides (no ambient default — Tenet-16 corollary):
               gemini-3.5-flash for docs/spec/shield/triage/extract/reviewlearn,

--- a/docs/reference/supported-models.md
+++ b/docs/reference/supported-models.md
@@ -1,6 +1,6 @@
 # Supported Models & AI Tools Reference
 
-> **Last validated:** 2026-07-14 (model-refresh PR: Gemini, Anthropic, and OpenAI orchestrator tiers re-validated against published provider docs; Totem defaults moved to `gemini-3.5-flash` / `claude-sonnet-5`; sampling-param stripping now handled at the orchestrator boundary).
+> **Last validated:** 2026-07-14 (model-refresh PR: Gemini, Anthropic, and OpenAI orchestrator tiers re-validated against published provider docs; Totem defaults moved to `gemini-3.5-flash` / `claude-sonnet-5`; sampling-param stripping now handled at the orchestrator boundary. Same day, follow-on: `totem init` generated configs moved to the per-role-overrides shape with the same current-generation IDs).
 
 Totem supports four LLM provider families for orchestration, and exports project
 knowledge to all major AI coding tools. This document tracks model IDs, tool
@@ -123,7 +123,9 @@ Used by `totem sync` for indexing chunks into LanceDB.
 
 ## Totem Defaults
 
-Current defaults configured in `totem.config.ts` and `packages/cli/src/commands/init.ts`:
+Current defaults configured in `totem.config.ts` (this repo) and stamped into
+generated consumer configs by `totem init`
+(`packages/cli/src/commands/init-detect.ts`):
 
 ```
 Embedding:    Gemini gemini-embedding-2-preview  (or OpenAI text-embedding-3-small, Ollama nomic-embed-text)
@@ -131,6 +133,12 @@ Orchestrator: per-role overrides (no ambient default — Tenet-16 corollary):
               gemini-3.5-flash for docs/spec/shield/triage/extract/reviewlearn,
               anthropic:claude-sonnet-5 for compile;
               review.lanes: anthropic:claude-sonnet-5 + gemini:gemini-3.5-flash
+totem init:   emitted per detected environment, every role named, no ambient defaultModel:
+              gemini CLI / GEMINI_API_KEY → gemini-3.5-flash
+              claude CLI                  → 'sonnet' (the CLI's own tier alias)
+              ANTHROPIC_API_KEY           → claude-sonnet-5
+              OPENAI_API_KEY              → gpt-5.6-terra
+              ollama                      → gemma4
 ```
 
 ### Updating Defaults

--- a/packages/cli/src/commands/init-detect.test.ts
+++ b/packages/cli/src/commands/init-detect.test.ts
@@ -1,0 +1,167 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock the CLI-probe seam (cliExists → safeExec) so branch selection is
+// host-independent: no real `where`/`which` spawns, no PATH sensitivity.
+vi.mock('@mmnto/totem', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@mmnto/totem')>();
+  return {
+    ...actual,
+    safeExec: vi.fn(() => {
+      throw new Error('not on PATH');
+    }),
+  };
+});
+
+import { safeExec } from '@mmnto/totem';
+
+import {
+  buildRoleOverrides,
+  detectOrchestrator,
+  INIT_ORCHESTRATOR_MODELS,
+  INIT_ORCHESTRATOR_ROLES,
+  renderOrchestratorBlock,
+} from './init-detect.js';
+
+const API_KEY_VARS = ['GEMINI_API_KEY', 'GOOGLE_API_KEY', 'ANTHROPIC_API_KEY', 'OPENAI_API_KEY'];
+
+/** Make cliExists() succeed only for the given binary names. */
+function stubCliOnPath(...names: string[]): void {
+  vi.mocked(safeExec).mockImplementation(((_cmd: string, args?: string[]) => {
+    if (args && names.includes(args[0]!)) return '';
+    throw new Error('not on PATH');
+  }) as typeof safeExec);
+}
+
+describe('detectOrchestrator emission shape (Tenet-16 corollary)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-initdetect-'));
+    // Neutralize host API keys so only per-test .env content drives detection.
+    for (const v of API_KEY_VARS) vi.stubEnv(v, '');
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.mocked(safeExec).mockImplementation(() => {
+      throw new Error('not on PATH');
+    });
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeEnv(content: string): void {
+    fs.writeFileSync(path.join(tmpDir, '.env'), content);
+  }
+
+  it('returns null when no CLI or API key is present', () => {
+    expect(detectOrchestrator(tmpDir)).toBeNull();
+  });
+
+  it.each([
+    ['GEMINI_API_KEY', 'gemini', INIT_ORCHESTRATOR_MODELS.gemini],
+    ['GOOGLE_API_KEY', 'gemini', INIT_ORCHESTRATOR_MODELS.gemini],
+    ['ANTHROPIC_API_KEY', 'anthropic', INIT_ORCHESTRATOR_MODELS.anthropic],
+    ['OPENAI_API_KEY', 'openai', INIT_ORCHESTRATOR_MODELS.openai],
+  ])('%s → provider %s with every role on %s', (envKey, provider, model) => {
+    writeEnv(`${envKey}=test-key\n`);
+    const result = detectOrchestrator(tmpDir);
+    expect(result).not.toBeNull();
+    expect(result!.config['provider']).toBe(provider);
+    expect(result!.config['overrides']).toEqual(buildRoleOverrides(model));
+  });
+
+  it('gemini CLI on PATH wins over API keys and emits the shell provider', () => {
+    stubCliOnPath('gemini');
+    writeEnv('ANTHROPIC_API_KEY=test-key\n');
+    const result = detectOrchestrator(tmpDir);
+    expect(result!.config['provider']).toBe('shell');
+    expect(result!.config['command']).toContain('gemini --model {model}');
+    expect(result!.config['overrides']).toEqual(
+      buildRoleOverrides(INIT_ORCHESTRATOR_MODELS.geminiCli),
+    );
+  });
+
+  it('claude CLI branch emits the tier alias, not a dated pin', () => {
+    stubCliOnPath('claude');
+    const result = detectOrchestrator(tmpDir);
+    expect(result!.config['provider']).toBe('shell');
+    expect(result!.config['command']).toContain('claude -p {file}');
+    expect(result!.config['overrides']).toEqual(buildRoleOverrides('sonnet'));
+  });
+
+  it('ollama branch emits gemma4 per-role', () => {
+    stubCliOnPath('ollama');
+    const result = detectOrchestrator(tmpDir);
+    expect(result!.config['provider']).toBe('ollama');
+    expect(result!.config['overrides']).toEqual(
+      buildRoleOverrides(INIT_ORCHESTRATOR_MODELS.ollama),
+    );
+  });
+
+  it('no branch emits an ambient defaultModel, in the config object or the rendered block', () => {
+    const branches: Array<() => void> = [
+      () => stubCliOnPath('gemini'),
+      () => stubCliOnPath('claude'),
+      () => stubCliOnPath('ollama'),
+      () => writeEnv('GEMINI_API_KEY=test-key\n'),
+      () => writeEnv('ANTHROPIC_API_KEY=test-key\n'),
+      () => writeEnv('OPENAI_API_KEY=test-key\n'),
+    ];
+    for (const arm of branches) {
+      vi.mocked(safeExec).mockImplementation(() => {
+        throw new Error('not on PATH');
+      });
+      fs.rmSync(path.join(tmpDir, '.env'), { force: true });
+      arm();
+      const result = detectOrchestrator(tmpDir);
+      expect(result).not.toBeNull();
+      expect(Object.keys(result!.config)).not.toContain('defaultModel');
+      expect(result!.block).not.toContain('defaultModel');
+      expect(Object.keys(result!.config['overrides'] as Record<string, string>).sort()).toEqual(
+        [...INIT_ORCHESTRATOR_ROLES].sort(),
+      );
+    }
+  });
+});
+
+describe('buildRoleOverrides', () => {
+  it('maps every emitted role to the given model', () => {
+    const overrides = buildRoleOverrides('some-model');
+    expect(Object.keys(overrides)).toEqual([...INIT_ORCHESTRATOR_ROLES]);
+    expect(new Set(Object.values(overrides))).toEqual(new Set(['some-model']));
+  });
+});
+
+describe('renderOrchestratorBlock', () => {
+  it('renders the TS block from the same object serialized to YAML/TOML (no drift)', () => {
+    const config = {
+      provider: 'gemini',
+      overrides: buildRoleOverrides(INIT_ORCHESTRATOR_MODELS.gemini),
+    };
+    const block = renderOrchestratorBlock(config);
+    expect(block.startsWith('  orchestrator: {')).toBe(true);
+    expect(block.endsWith('  },')).toBe(true);
+    expect(block).toContain("    provider: 'gemini',");
+    for (const role of INIT_ORCHESTRATOR_ROLES) {
+      expect(block).toContain(`      ${role}: '${INIT_ORCHESTRATOR_MODELS.gemini}',`);
+    }
+  });
+
+  it('renders shell-provider blocks with the command line before overrides', () => {
+    const config = {
+      provider: 'shell',
+      command: 'gemini --model {model} -o json -e none < {file}',
+      overrides: buildRoleOverrides('m'),
+    };
+    const block = renderOrchestratorBlock(config);
+    const commandIdx = block.indexOf('command:');
+    const overridesIdx = block.indexOf('overrides:');
+    expect(commandIdx).toBeGreaterThan(-1);
+    expect(overridesIdx).toBeGreaterThan(commandIdx);
+    expect(block).toContain("    command: 'gemini --model {model} -o json -e none < {file}',");
+  });
+});

--- a/packages/cli/src/commands/init-detect.test.ts
+++ b/packages/cli/src/commands/init-detect.test.ts
@@ -28,6 +28,27 @@ import {
 
 const API_KEY_VARS = ['GEMINI_API_KEY', 'GOOGLE_API_KEY', 'ANTHROPIC_API_KEY', 'OPENAI_API_KEY'];
 
+// Independent contract fixtures (mmnto-ai/totem#2360 review round): pinned as
+// literals so an accidental edit to the production constants fails here
+// instead of flowing through derived expectations and staying green.
+const EXPECTED_ROLES = [
+  'compile',
+  'docs',
+  'spec',
+  'shield',
+  'triage',
+  'extract',
+  'reviewlearn',
+] as const;
+const EXPECTED_MODELS = {
+  geminiCli: 'gemini-3.5-flash',
+  claudeCli: 'sonnet',
+  gemini: 'gemini-3.5-flash',
+  anthropic: 'claude-sonnet-5',
+  openai: 'gpt-5.6-terra',
+  ollama: 'gemma4',
+} as const;
+
 /** Make cliExists() succeed only for the given binary names. */
 function stubCliOnPath(...names: string[]): void {
   vi.mocked(safeExec).mockImplementation(((_cmd: string, args?: string[]) => {
@@ -61,17 +82,24 @@ describe('detectOrchestrator emission shape (Tenet-16 corollary)', () => {
     expect(detectOrchestrator(tmpDir)).toBeNull();
   });
 
+  it('production constants match the pinned contract fixtures', () => {
+    expect([...INIT_ORCHESTRATOR_ROLES]).toEqual([...EXPECTED_ROLES]);
+    expect(INIT_ORCHESTRATOR_MODELS).toEqual(EXPECTED_MODELS);
+  });
+
   it.each([
-    ['GEMINI_API_KEY', 'gemini', INIT_ORCHESTRATOR_MODELS.gemini],
-    ['GOOGLE_API_KEY', 'gemini', INIT_ORCHESTRATOR_MODELS.gemini],
-    ['ANTHROPIC_API_KEY', 'anthropic', INIT_ORCHESTRATOR_MODELS.anthropic],
-    ['OPENAI_API_KEY', 'openai', INIT_ORCHESTRATOR_MODELS.openai],
+    ['GEMINI_API_KEY', 'gemini', EXPECTED_MODELS.gemini],
+    ['GOOGLE_API_KEY', 'gemini', EXPECTED_MODELS.gemini],
+    ['ANTHROPIC_API_KEY', 'anthropic', EXPECTED_MODELS.anthropic],
+    ['OPENAI_API_KEY', 'openai', EXPECTED_MODELS.openai],
   ])('%s → provider %s with every role on %s', (envKey, provider, model) => {
     writeEnv(`${envKey}=test-key\n`);
     const result = detectOrchestrator(tmpDir);
     expect(result).not.toBeNull();
     expect(result!.config['provider']).toBe(provider);
-    expect(result!.config['overrides']).toEqual(buildRoleOverrides(model));
+    expect(result!.config['overrides']).toEqual(
+      Object.fromEntries(EXPECTED_ROLES.map((role) => [role, model])),
+    );
   });
 
   it('gemini CLI on PATH wins over API keys and emits the shell provider', () => {
@@ -81,7 +109,7 @@ describe('detectOrchestrator emission shape (Tenet-16 corollary)', () => {
     expect(result!.config['provider']).toBe('shell');
     expect(result!.config['command']).toContain('gemini --model {model}');
     expect(result!.config['overrides']).toEqual(
-      buildRoleOverrides(INIT_ORCHESTRATOR_MODELS.geminiCli),
+      Object.fromEntries(EXPECTED_ROLES.map((role) => [role, EXPECTED_MODELS.geminiCli])),
     );
   });
 
@@ -90,7 +118,9 @@ describe('detectOrchestrator emission shape (Tenet-16 corollary)', () => {
     const result = detectOrchestrator(tmpDir);
     expect(result!.config['provider']).toBe('shell');
     expect(result!.config['command']).toContain('claude -p {file}');
-    expect(result!.config['overrides']).toEqual(buildRoleOverrides('sonnet'));
+    expect(result!.config['overrides']).toEqual(
+      Object.fromEntries(EXPECTED_ROLES.map((role) => [role, 'sonnet'])),
+    );
   });
 
   it('ollama branch emits gemma4 per-role', () => {
@@ -98,7 +128,7 @@ describe('detectOrchestrator emission shape (Tenet-16 corollary)', () => {
     const result = detectOrchestrator(tmpDir);
     expect(result!.config['provider']).toBe('ollama');
     expect(result!.config['overrides']).toEqual(
-      buildRoleOverrides(INIT_ORCHESTRATOR_MODELS.ollama),
+      Object.fromEntries(EXPECTED_ROLES.map((role) => [role, 'gemma4'])),
     );
   });
 
@@ -122,7 +152,7 @@ describe('detectOrchestrator emission shape (Tenet-16 corollary)', () => {
       expect(Object.keys(result!.config)).not.toContain('defaultModel');
       expect(result!.block).not.toContain('defaultModel');
       expect(Object.keys(result!.config['overrides'] as Record<string, string>).sort()).toEqual(
-        [...INIT_ORCHESTRATOR_ROLES].sort(),
+        [...EXPECTED_ROLES].sort(),
       );
     }
   });
@@ -131,7 +161,7 @@ describe('detectOrchestrator emission shape (Tenet-16 corollary)', () => {
 describe('buildRoleOverrides', () => {
   it('maps every emitted role to the given model', () => {
     const overrides = buildRoleOverrides('some-model');
-    expect(Object.keys(overrides)).toEqual([...INIT_ORCHESTRATOR_ROLES]);
+    expect(Object.keys(overrides)).toEqual([...EXPECTED_ROLES]);
     expect(new Set(Object.values(overrides))).toEqual(new Set(['some-model']));
   });
 });
@@ -149,6 +179,28 @@ describe('renderOrchestratorBlock', () => {
     for (const role of INIT_ORCHESTRATOR_ROLES) {
       expect(block).toContain(`      ${role}: '${INIT_ORCHESTRATOR_MODELS.gemini}',`);
     }
+  });
+
+  it('escapes single quotes and backslashes in string values (no silent syntax break)', () => {
+    const block = renderOrchestratorBlock({
+      provider: 'shell',
+      command: "echo 'it''s' \\ done",
+      overrides: { compile: "model'with\\quirks" },
+    });
+    expect(block).toContain("    command: 'echo \\'it\\'\\'s\\' \\\\ done',");
+    expect(block).toContain("      compile: 'model\\'with\\\\quirks',");
+  });
+
+  it('renders booleans, numbers, and arrays instead of silently omitting them', () => {
+    const block = renderOrchestratorBlock({
+      provider: 'gemini',
+      enableContextCaching: true,
+      maxRetries: 3,
+      lanes: ['anthropic:claude-sonnet-5', 'gemini:gemini-3.5-flash'],
+    });
+    expect(block).toContain('    enableContextCaching: true,');
+    expect(block).toContain('    maxRetries: 3,');
+    expect(block).toContain('    lanes: ["anthropic:claude-sonnet-5","gemini:gemini-3.5-flash"],');
   });
 
   it('renders shell-provider blocks with the command line before overrides', () => {

--- a/packages/cli/src/commands/init-detect.ts
+++ b/packages/cli/src/commands/init-detect.ts
@@ -217,9 +217,80 @@ export function detectEmbeddingTier(cwd: string): EmbeddingTier {
   return 'none';
 }
 
+// ─── Orchestrator emission (Tenet-16 corollary) ──────────
+
+/**
+ * Every LLM-backed role tag (lowercased `runOrchestrator` tag) a generated
+ * config names explicitly. Emitted configs assign a model per role instead of
+ * committing an ambient `orchestrator.defaultModel` — config names roles, not
+ * one ambient vendor default (Tenet-16 corollary, mmnto-ai/totem-strategy#800
+ * item 1). A role absent from this list fails loud at invocation ("No model
+ * specified") instead of silently riding a vendor default.
+ */
+export const INIT_ORCHESTRATOR_ROLES = [
+  'compile',
+  'docs',
+  'spec',
+  'shield',
+  'triage',
+  'extract',
+  'reviewlearn',
+] as const;
+
+/**
+ * Model IDs stamped into generated consumer configs, one per detection branch
+ * (docs/reference/supported-models.md § Updating Defaults, location 3).
+ * `claudeCli` is the claude CLI's own tier alias, which tracks that CLI's
+ * current Sonnet instead of pinning a dated ID.
+ */
+export const INIT_ORCHESTRATOR_MODELS = {
+  geminiCli: 'gemini-3.5-flash',
+  claudeCli: 'sonnet',
+  gemini: 'gemini-3.5-flash',
+  anthropic: 'claude-sonnet-5',
+  openai: 'gpt-5.6-terra',
+  ollama: 'gemma4',
+} as const;
+
+/** Map every emitted role to the same model ID (uniform per-provider default). */
+export function buildRoleOverrides(model: string): Record<string, string> {
+  return Object.fromEntries(INIT_ORCHESTRATOR_ROLES.map((role) => [role, model]));
+}
+
+/**
+ * Render the TS-template orchestrator block from the same object that gets
+ * serialized into YAML/TOML configs, so the two surfaces cannot drift.
+ */
+export function renderOrchestratorBlock(config: Record<string, unknown>): string {
+  const lines = ['  orchestrator: {'];
+  for (const [key, value] of Object.entries(config)) {
+    if (typeof value === 'string') {
+      lines.push(`    ${key}: '${value}',`);
+    } else if (value && typeof value === 'object') {
+      lines.push(`    ${key}: {`);
+      for (const [role, model] of Object.entries(value as Record<string, string>)) {
+        lines.push(`      ${role}: '${model}',`);
+      }
+      lines.push('    },');
+    }
+  }
+  lines.push('  },');
+  return lines.join('\n');
+}
+
+function orchestratorResult(config: Record<string, unknown>): DetectedOrchestrator {
+  return { config, block: renderOrchestratorBlock(config) };
+}
+
 /**
  * Auto-detect the best orchestrator from the environment.
- * Priority: gemini CLI → claude CLI → API keys (GEMINI → ANTHROPIC → OPENAI) → null.
+ * Priority: gemini CLI → claude CLI → API keys (GEMINI → ANTHROPIC → OPENAI) → ollama → null.
+ *
+ * Detection resolves the consumer's local environment at genesis; the emitted
+ * block names a model per role rather than committing an ambient
+ * `defaultModel`. Note `totem lesson compile --cloud` deliberately resolves
+ * from `--model` / `defaultModel` only (mmnto-ai/totem#2357), so it stays
+ * fail-loud under this shape.
  */
 export function detectOrchestrator(cwd: string): DetectedOrchestrator | null {
   // Read .env file once (loadEnv may not have run yet)
@@ -233,105 +304,50 @@ export function detectOrchestrator(cwd: string): DetectedOrchestrator | null {
 
   // 1. Gemini CLI on PATH → shell provider
   if (cliExists('gemini')) {
-    const config = {
+    return orchestratorResult({
       provider: 'shell',
       command: 'gemini --model {model} -o json -e none < {file}',
-      defaultModel: 'gemini-3-flash-preview',
-      overrides: {
-        spec: 'gemini-3.1-pro-preview',
-        shield: 'gemini-3.1-pro-preview',
-        triage: 'gemini-3.1-pro-preview',
-      },
-    };
-    return {
-      config,
-      block: `  orchestrator: {
-    provider: 'shell',
-    command: 'gemini --model {model} -o json -e none < {file}',
-    defaultModel: 'gemini-3-flash-preview',
-    overrides: {
-      'spec': 'gemini-3.1-pro-preview',
-      'shield': 'gemini-3.1-pro-preview',
-      'triage': 'gemini-3.1-pro-preview',
-    },
-  },`,
-    };
+      overrides: buildRoleOverrides(INIT_ORCHESTRATOR_MODELS.geminiCli),
+    });
   }
 
   // 2. Claude CLI on PATH → shell provider (anthropic)
   if (cliExists('claude')) {
-    const config = {
+    return orchestratorResult({
       provider: 'shell',
       command: 'claude -p {file} --model {model} --output-format json',
-      defaultModel: 'sonnet',
-    };
-    return {
-      config,
-      block: `  orchestrator: {
-    provider: 'shell',
-    command: 'claude -p {file} --model {model} --output-format json',
-    defaultModel: 'sonnet',
-  },`,
-    };
+      overrides: buildRoleOverrides(INIT_ORCHESTRATOR_MODELS.claudeCli),
+    });
   }
 
   // 3. API keys → native SDK providers
   if (hasKey(envContent, 'GEMINI_API_KEY', 'GOOGLE_API_KEY')) {
-    const config = {
+    return orchestratorResult({
       provider: 'gemini',
-      defaultModel: 'gemini-3-flash-preview',
-      overrides: {
-        spec: 'gemini-3.1-pro-preview',
-        shield: 'gemini-3.1-pro-preview',
-        triage: 'gemini-3.1-pro-preview',
-      },
-    };
-    return {
-      config,
-      block: `  orchestrator: {
-    provider: 'gemini',
-    defaultModel: 'gemini-3-flash-preview',
-    overrides: {
-      'spec': 'gemini-3.1-pro-preview',
-      'shield': 'gemini-3.1-pro-preview',
-      'triage': 'gemini-3.1-pro-preview',
-    },
-  },`,
-    };
+      overrides: buildRoleOverrides(INIT_ORCHESTRATOR_MODELS.gemini),
+    });
   }
 
   if (hasKey(envContent, 'ANTHROPIC_API_KEY')) {
-    const config = { provider: 'anthropic', defaultModel: 'claude-sonnet-4-6' };
-    return {
-      config,
-      block: `  orchestrator: {
-    provider: 'anthropic',
-    defaultModel: 'claude-sonnet-4-6',
-  },`,
-    };
+    return orchestratorResult({
+      provider: 'anthropic',
+      overrides: buildRoleOverrides(INIT_ORCHESTRATOR_MODELS.anthropic),
+    });
   }
 
   if (hasKey(envContent, 'OPENAI_API_KEY')) {
-    const config = { provider: 'openai', defaultModel: 'gpt-5.4-mini' };
-    return {
-      config,
-      block: `  orchestrator: {
-    provider: 'openai',
-    defaultModel: 'gpt-5.4-mini',
-  },`,
-    };
+    return orchestratorResult({
+      provider: 'openai',
+      overrides: buildRoleOverrides(INIT_ORCHESTRATOR_MODELS.openai),
+    });
   }
 
   // 4. Ollama running locally → use gemma4 (free, fast, air-gappable)
   if (cliExists('ollama')) {
-    const config = { provider: 'ollama', defaultModel: 'gemma4' };
-    return {
-      config,
-      block: `  orchestrator: {
-    provider: 'ollama',
-    defaultModel: 'gemma4',
-  },`,
-    };
+    return orchestratorResult({
+      provider: 'ollama',
+      overrides: buildRoleOverrides(INIT_ORCHESTRATOR_MODELS.ollama),
+    });
   }
 
   // 5. Nothing found → omit orchestrator (Lite/Standard tier)

--- a/packages/cli/src/commands/init-detect.ts
+++ b/packages/cli/src/commands/init-detect.ts
@@ -257,19 +257,32 @@ export function buildRoleOverrides(model: string): Record<string, string> {
   return Object.fromEntries(INIT_ORCHESTRATOR_ROLES.map((role) => [role, model]));
 }
 
+/** Escape a value for embedding in a single-quoted TS string literal, so a
+ *  future model ID or shell command containing `'` or `\` cannot emit a
+ *  syntactically broken consumer config (mmnto-ai/totem#2360 review round). */
+function escapeTsString(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
 /**
  * Render the TS-template orchestrator block from the same object that gets
  * serialized into YAML/TOML configs, so the two surfaces cannot drift.
+ * Handles every JSON-shaped value type; `null`/`undefined` render as an
+ * absent key (optional-key semantics, matching the YAML/TOML serializers).
  */
 export function renderOrchestratorBlock(config: Record<string, unknown>): string {
   const lines = ['  orchestrator: {'];
   for (const [key, value] of Object.entries(config)) {
     if (typeof value === 'string') {
-      lines.push(`    ${key}: '${value}',`);
+      lines.push(`    ${key}: '${escapeTsString(value)}',`);
+    } else if (typeof value === 'boolean' || typeof value === 'number') {
+      lines.push(`    ${key}: ${String(value)},`);
+    } else if (Array.isArray(value)) {
+      lines.push(`    ${key}: ${JSON.stringify(value)},`);
     } else if (value && typeof value === 'object') {
       lines.push(`    ${key}: {`);
       for (const [role, model] of Object.entries(value as Record<string, string>)) {
-        lines.push(`      ${role}: '${model}',`);
+        lines.push(`      ${role}: '${escapeTsString(model)}',`);
       }
       lines.push('    },');
     }


### PR DESCRIPTION
## What

`totem init`'s orchestrator detection was the cohort-wide *generator* of the ambient-default violation class (Tenet-16 corollary, mmnto-ai/totem-strategy#800 item 1): every generated consumer config committed a concrete `orchestrator.defaultModel`, and the stamped IDs (`gemini-3-flash-preview` / `claude-sonnet-4-6` / `gpt-5.4-mini`) went stale after the #2358 model refresh.

This settles the T0-vs-T1 judgment the t16 dispatch left to this lane, plus the deferred ID refresh (`supported-models.md` § Updating Defaults, location 3):

- **Detection stays** — probing the local environment (CLIs on PATH, API keys) is legitimate local-env resolution at genesis, not a config-layer provider-lock.
- **The emitted shape changes** — per-role `overrides` covering every LLM-backed role tag (`compile`/`docs`/`spec`/`shield`/`triage`/`extract`/`reviewlearn`), no ambient `defaultModel`. An unnamed role fails loud at invocation (`No model specified`, `utils.ts` resolution chain) instead of silently riding a vendor default.
- **IDs refreshed** to the 2026-07-14 set: `gemini-3.5-flash` (Gemini CLI + API), `claude-sonnet-5` (Anthropic API), `gpt-5.6-terra` (OpenAI API — the balanced tier, the sonnet-5 analog of its family), `sonnet` tier alias (claude CLI, self-current), `gemma4` (Ollama, unchanged).
- **Anti-drift**: the TS-template block is now rendered from the same object serialized into YAML/TOML configs (`renderOrchestratorBlock`), so the two emission surfaces cannot diverge.

## Behavior notes

- Existing configs are never rewritten — `totem init` generated-config surface only.
- A freshly generated config no longer feeds `totem lesson compile --cloud`'s `defaultModel` fallback, so `--cloud` without `--model` fails loud (CONFIG_INVALID). That is the #2357-adjudicated behavior (the cloud worker is Gemini-only and deliberately does not consume role overrides); previously the generated ambient default silently fed it.

## Context

- Follow-on to #2357 (repo-config + fail-loud halves) and #2358 (model refresh); carries the init-detect residual from the strategy-claude t16 dispatch (2026-07-14T0505Z).
- Refs (no auto-close intended): mmnto-ai/totem-strategy#800.

## Verification

- 12 new unit tests (`init-detect.test.ts`): branch selection with the CLI-probe seam mocked, no-`defaultModel` assertion across all six branches, role-coverage equality against `INIT_ORCHESTRATOR_ROLES`, block/object parity.
- Full gate: `pnpm -r build` ✓ · cli suite 3,171/3,171 ✓ · `format:check` ✓ · ESLint ✓ · `totem lint --base main` PASS (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
