### PR TITLE
fix(mail): enumerateOutboxes — dirent-filter the agent level, no-follow outbox probe (#2355)

### DIFF
--- a/.changeset/mail-scan-symlink-guard.md
+++ b/.changeset/mail-scan-symlink-guard.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/cli': patch
+---
+
+fix(mail): the ECL outbox scan no longer follows symlinked agent/outbox directories (mmnto-ai/totem#2355, sibling class to the #2354 ingest guard).
+
+`enumerateOutboxes` dirent-filtered the workspace and repo levels but the inner agent-level scan used a bare `readdirSync` + `existsSync` (both follow symlinks), so a symlinked `<agent>/` or `outbox/` directory was traversed during the mail poll. The agent level is now dirent-filtered like the outer levels (and like `orchestration-resolver.ts`, which is no-follow by design), and the outbox probe is an lstat-based no-follow directory check.
+
+Consumer-impact: `totem mail` scan enumeration only — symlinked agent/outbox directories under `.totem/orchestration/` are skipped instead of followed; regular directories scan identically. Severity was bounded to enumeration/display (not index persistence). No migration required.

--- a/packages/cli/src/commands/mail.test.ts
+++ b/packages/cli/src/commands/mail.test.ts
@@ -227,6 +227,65 @@ describe('pollMail — basic filter behavior', () => {
   });
 });
 
+// ─── Symlink guard (mmnto-ai/totem#2355) ────────────────
+
+describe('pollMail — symlinked agent/outbox dirs are not traversed (mmnto-ai/totem#2355)', () => {
+  /**
+   * Portable directory symlink: 'junction' needs no elevation on Windows and
+   * the type argument is ignored on POSIX (plain symlink). Junction targets
+   * must be absolute — all fixture paths are tmpRoot-absolute.
+   */
+  function symlinkDir(target: string, linkPath: string): void {
+    fs.symlinkSync(target, linkPath, 'junction');
+  }
+
+  function writeRogueMail(dir: string, name: string): void {
+    fs.writeFileSync(
+      path.join(dir, name),
+      '---\nfrom: rogue-agent\nto: totem-claude\ndate: 2026-07-14T0000Z\nsubject: exfil\n---\n\nBody.\n',
+      'utf-8',
+    );
+  }
+
+  it('skips a symlinked agent dir during the outbox scan', () => {
+    const outside = mkDir(path.join(tmpRoot, 'outside', 'rogue-agent', 'outbox'));
+    writeRogueMail(outside, '2026-07-14T0000Z-rogue.md');
+    const orchDir = mkDir(path.join(workspace, 'totem-strategy', '.totem', 'orchestration'));
+    symlinkDir(path.join(tmpRoot, 'outside', 'rogue-agent'), path.join(orchDir, 'rogue-agent'));
+
+    const result = poll();
+    expect(result.mail).toEqual([]);
+    expect(result.scanned).toBe(0);
+  });
+
+  it('skips a symlinked outbox dir under a real agent dir', () => {
+    const loot = mkDir(path.join(tmpRoot, 'loot'));
+    writeRogueMail(loot, '2026-07-14T0001Z-loot.md');
+    const agentDir = mkDir(
+      path.join(workspace, 'totem-strategy', '.totem', 'orchestration', 'sneaky-agent'),
+    );
+    symlinkDir(loot, path.join(agentDir, 'outbox'));
+
+    const result = poll();
+    expect(result.mail).toEqual([]);
+    expect(result.scanned).toBe(0);
+  });
+
+  it('still scans a real sibling outbox alongside a symlinked agent dir', () => {
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: '2026-07-14T0002Z.md', to: 'totem-claude', subject: 'real mail' },
+    ]);
+    const outside = mkDir(path.join(tmpRoot, 'outside2', 'rogue-agent', 'outbox'));
+    writeRogueMail(outside, '2026-07-14T0003Z.md');
+    const orchDir = path.join(workspace, 'totem-strategy', '.totem', 'orchestration');
+    symlinkDir(path.join(tmpRoot, 'outside2', 'rogue-agent'), path.join(orchDir, 'rogue-agent'));
+
+    const result = poll();
+    expect(result.mail).toHaveLength(1);
+    expect(result.mail[0]!.subject).toBe('real mail');
+  });
+});
+
 // ─── Processed/ exclusion ───────────────────────────────
 
 describe('pollMail — processed/ exclusion', () => {

--- a/packages/cli/src/commands/mail.test.ts
+++ b/packages/cli/src/commands/mail.test.ts
@@ -271,6 +271,17 @@ describe('pollMail — symlinked agent/outbox dirs are not traversed (mmnto-ai/t
     expect(result.scanned).toBe(0);
   });
 
+  it('skips a symlinked orchestration dir under a real repo', () => {
+    const outside = mkDir(path.join(tmpRoot, 'orch-target', 'rogue-agent', 'outbox'));
+    writeRogueMail(outside, '2026-07-14T0004Z-orch.md');
+    const totemDir = mkDir(path.join(workspace, 'totem-strategy', '.totem'));
+    symlinkDir(path.join(tmpRoot, 'orch-target'), path.join(totemDir, 'orchestration'));
+
+    const result = poll();
+    expect(result.mail).toEqual([]);
+    expect(result.scanned).toBe(0);
+  });
+
   it('still scans a real sibling outbox alongside a symlinked agent dir', () => {
     writeOutbox('totem-strategy', 'strategy-claude', [
       { name: '2026-07-14T0002Z.md', to: 'totem-claude', subject: 'real mail' },

--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -401,7 +401,11 @@ function enumerateOutboxes(
   }
 
   const visit = (repoLabel: string, orchDir: string): void => {
-    if (!fs.existsSync(orchDir)) return;
+    // No-follow both remaining path hops (greptile round on this PR):
+    // `existsSync` follows symlinks, so a symlinked `.totem/` or
+    // `orchestration/` inside a real repo would swing the whole agent scan
+    // into the link target. `path.dirname(orchDir)` is the `.totem` hop.
+    if (!isRealDirectory(path.dirname(orchDir)) || !isRealDirectory(orchDir)) return;
     let agents: string[];
     try {
       // Dirent-filter the agent level like the workspace/repo levels above:

--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -364,6 +364,7 @@ function isRealDirectory(p: string): boolean {
   // totem-context: intentional cleanup — a raced/ENOENT lstat degrades to "not a directory" and skips this slot, matching the scan's skip-don't-abort posture (same idiom as the #2356 ingest guard).
   try {
     return fs.lstatSync(p).isDirectory();
+    // totem-context: intentional cleanup — see directive above the try; dual placement so the rule fires on either the catch-keyword line or the catch-body line.
   } catch {
     return false;
   }

--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -356,6 +356,20 @@ interface OutboxSlot {
 }
 
 /**
+ * No-follow directory probe for the outbox level: `fs.existsSync` follows
+ * symlinks, so a symlinked `outbox/` would pull outside-tree content into the
+ * mail scan (mmnto-ai/totem#2355, sibling class to the #2354 ingest guard).
+ */
+function isRealDirectory(p: string): boolean {
+  // totem-context: intentional cleanup — a raced/ENOENT lstat degrades to "not a directory" and skips this slot, matching the scan's skip-don't-abort posture (same idiom as the #2356 ingest guard).
+  try {
+    return fs.lstatSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Enumerate outbox directories under `<workspace>/<repo>/.totem/orchestration/<agent>/outbox`.
  * Single-level by default; recursive mode walks `<workspace>/**` (capped at MAX_SCAN
  * to bound runtime on deep trees).
@@ -389,7 +403,14 @@ function enumerateOutboxes(
     if (!fs.existsSync(orchDir)) return;
     let agents: string[];
     try {
-      agents = fs.readdirSync(orchDir).sort();
+      // Dirent-filter the agent level like the workspace/repo levels above:
+      // a symlinked `<agent>/` dir must not be followed into the mail scan
+      // (mmnto-ai/totem#2355; orchestration-resolver.ts is no-follow by design).
+      agents = fs
+        .readdirSync(orchDir, { withFileTypes: true })
+        .filter((d) => d.isDirectory())
+        .map((d) => d.name)
+        .sort();
       // totem-context: intentional cleanup — per-repo readdir failure skips this slot, emits a structured warning, and lets sibling repos continue; one inaccessible orchestration tree must not block the rest of the scan.
     } catch (err) {
       warnings.push(`orchestration scan failed (${repoLabel}): ${String(err)}`);
@@ -397,7 +418,7 @@ function enumerateOutboxes(
     }
     for (const agent of agents) {
       const outbox = path.join(orchDir, agent, 'outbox');
-      if (fs.existsSync(outbox)) {
+      if (isRealDirectory(outbox)) {
         slots.push({ repo: repoLabel, agent, outbox });
       }
     }


### PR DESCRIPTION
## What

`enumerateOutboxes` (`packages/cli/src/commands/mail.ts`) dirent-filters the workspace and repo levels, but the inner agent-level scan used a bare `readdirSync` + `fs.existsSync` — both follow symlinks — so a symlinked `<agent>/` or `outbox/` directory under `.totem/orchestration/` was traversed during the ECL mail scan.

Fix, exactly as scoped in the issue:

- The agent level is now dirent-filtered (`withFileTypes` + `isDirectory()`), matching the outer levels and `orchestration-resolver.ts` (no-follow by design).
- The outbox probe becomes an lstat-based no-follow directory check (`isRealDirectory`), since `existsSync` follows symlinks; the raced/ENOENT lstat degrades to skip-this-slot, same idiom as the #2356 ingest guard.

Severity was bounded to cohort-mail enumeration/display (not index persistence) — this is the defense-in-depth/consistency half of the #2354 class, and the last unbuilt item from that security-mint batch.

## Verification

- +3 regression tests: symlinked agent dir skipped, symlinked outbox skipped, real sibling outbox still scanned. Junction-based dir symlinks (no elevation needed on Windows; type arg ignored on POSIX). **All three fail against the unfixed scan** (verified by stashing the fix and re-running).
- Full gate: `pnpm -r build` ✓ · cli suite 3,162/3,162 ✓ · `format:check` ✓ · ESLint ✓ · `totem lint --base main` PASS via pre-push hook.

Closes mmnto-ai/totem#2355

🤖 Generated with [Claude Code](https://claude.com/claude-code)
