### PR TITLE
fix(config): indexIgnorePatterns — index-only exclusions split from lint scope + loud diff-filter disclosure (#1748 / 046)

### DIFF
--- a/.changeset/index-ignore-split-and-diff-disclosure.md
+++ b/.changeset/index-ignore-split-and-diff-disclosure.md
@@ -1,0 +1,14 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+---
+
+fix(config): `indexIgnorePatterns` — index-only exclusions split from lint/shield scope, plus loud disclosure when `ignorePatterns` drops files from a review diff (mmnto-ai/totem#1748, upstream-feedback/046).
+
+`config.ignorePatterns` is documented as index exclusion but was also silently merged into the lint/shield diff filter — an operator excluding paths from _indexing_ (e.g. `audits/**`, "keep on disk, out of the semantic index") silently disabled _lint_ on those paths (two live exhibits, including a staged lint that dropped audit files with no trace). Conservative composite, no behavior break:
+
+- New `indexIgnorePatterns` config key (core schema): excluded ONLY from indexing, never from lint/shield scope. Moving index-intent patterns here restores lint coverage immediately.
+- `ignorePatterns` keeps its dual scope for back-compat; its docstring now states the dual scope honestly. The full inheritance split (lint stops consuming `ignorePatterns`) is registered for 2.0.0 in mmnto-ai/totem#1746.
+- Tenet-4 floor at the diff boundary: every review/lint diff derivation now discloses `Filtered N file(s) from the diff per ignorePatterns/shieldIgnorePatterns: ...`, naming each dropped file (capped at 8 + overflow count), so un-migrated configs stop failing silently.
+
+Consumer-impact: config schema (additive key, no migration required) + lint/shield/review terminal output (new warning line whenever ignore patterns drop files from the derived diff; verdicts, exit codes, and diff contents are byte-identical for runs where the patterns drop nothing).

--- a/packages/cli/src/commands/docs.test.ts
+++ b/packages/cli/src/commands/docs.test.ts
@@ -80,6 +80,7 @@ function mockConfig(docs?: DocTarget[]): void {
     totemDir: '.totem',
     lanceDir: '.lancedb',
     ignorePatterns: [],
+    indexIgnorePatterns: [],
     shieldIgnorePatterns: [],
     shieldAutoLearn: false,
     contextWarningThreshold: 40_000,

--- a/packages/cli/src/commands/shield-learn.test.ts
+++ b/packages/cli/src/commands/shield-learn.test.ts
@@ -65,6 +65,7 @@ describe('learnFromVerdict', () => {
     totemDir: '.totem',
     lanceDir: '.lancedb',
     ignorePatterns: [],
+    indexIgnorePatterns: [],
     shieldIgnorePatterns: [],
     shieldAutoLearn: false,
     contextWarningThreshold: 40_000,

--- a/packages/cli/src/git.test.ts
+++ b/packages/cli/src/git.test.ts
@@ -191,6 +191,86 @@ describe('getDiffBetween', () => {
   });
 });
 
+// ─── ignore-filter disclosure (#1748) ─────────────────
+
+describe('getDiffForReview ignore-filter disclosure (#1748)', () => {
+  // Mirrors the live 046 exhibit: an index-intent `audits/**` pattern silently
+  // dropping a staged audit file from the lint diff.
+  const twoFileDiff = [
+    'diff --git a/audits/internal/report.md b/audits/internal/report.md',
+    '--- a/audits/internal/report.md',
+    '+++ b/audits/internal/report.md',
+    '@@ -1 +1 @@',
+    '+audited',
+    'diff --git a/src/kept.ts b/src/kept.ts',
+    '--- a/src/kept.ts',
+    '+++ b/src/kept.ts',
+    '@@ -1 +1 @@',
+    '+x',
+    '',
+  ].join('\n');
+
+  beforeEach(() => {
+    mockGetGitDiffRange.mockReset();
+    vi.mocked(uiMod.log.warn).mockClear();
+  });
+
+  it('names each file the ignore filter drops from review scope', async () => {
+    mockGetGitDiffRange.mockReturnValue(twoFileDiff);
+    const result = await getDiffForReview(
+      { diff: 'HEAD^..HEAD' },
+      { ignorePatterns: ['audits/**'] },
+      '/tmp',
+      'Lint',
+    );
+    expect(result).not.toBeNull();
+    expect(result!.diff).not.toContain('audits/internal/report.md');
+    expect(result!.diff).toContain('src/kept.ts');
+    expect(uiMod.log.warn).toHaveBeenCalledWith(
+      'Lint',
+      expect.stringContaining(
+        'Filtered 1 file(s) from the diff per ignorePatterns/shieldIgnorePatterns: audits/internal/report.md',
+      ),
+    );
+  });
+
+  it('stays silent when the filter drops nothing', async () => {
+    mockGetGitDiffRange.mockReturnValue(twoFileDiff);
+    await getDiffForReview(
+      { diff: 'HEAD^..HEAD' },
+      { ignorePatterns: ['nomatch/**'] },
+      '/tmp',
+      'Lint',
+    );
+    const warns = vi.mocked(uiMod.log.warn).mock.calls.map((call) => String(call[1]));
+    expect(warns.some((line) => line.includes('Filtered'))).toBe(false);
+  });
+
+  it('caps the disclosure list and counts the overflow', async () => {
+    const manyFiles = Array.from({ length: 10 }, (_, i) =>
+      [
+        `diff --git a/audits/f${i}.md b/audits/f${i}.md`,
+        `--- a/audits/f${i}.md`,
+        `+++ b/audits/f${i}.md`,
+        '@@ -1 +1 @@',
+        '+x',
+        '',
+      ].join('\n'),
+    ).join('');
+    mockGetGitDiffRange.mockReturnValue(manyFiles + twoFileDiff);
+    await getDiffForReview(
+      { diff: 'HEAD^..HEAD' },
+      { ignorePatterns: ['audits/**'] },
+      '/tmp',
+      'Lint',
+    );
+    expect(uiMod.log.warn).toHaveBeenCalledWith(
+      'Lint',
+      expect.stringMatching(/Filtered 11 file\(s\) from the diff .*\(\+3 more\)$/),
+    );
+  });
+});
+
 // ─── getDiffForReview --diff (#1717) ─────────────────
 
 describe('getDiffForReview --diff (#1717)', () => {

--- a/packages/cli/src/git.ts
+++ b/packages/cli/src/git.ts
@@ -275,6 +275,28 @@ export async function getDiffForReview(
 
   const allIgnore = [...config.ignorePatterns, ...(config.shieldIgnorePatterns ?? [])];
 
+  // Tenet-4 disclosure (mmnto-ai/totem#1748, upstream-feedback/046):
+  // `ignorePatterns` is documented as index exclusion but is merged into this
+  // review/lint diff filter (kept for back-compat until the 2.0.0 split,
+  // mmnto-ai/totem#1746) — so every file the filter drops from review scope
+  // is named loudly instead of vanishing. Both live 046 exhibits were silent
+  // lint-scope holes opened by index-intent patterns.
+  const filterDiffWithDisclosure = (rawDiff: string): string => {
+    const filtered = filterDiffByPatterns(rawDiff, allIgnore);
+    if (filtered === rawDiff) return filtered;
+    const kept = new Set(extractChangedFiles(filtered));
+    const dropped = extractChangedFiles(rawDiff).filter((file) => !kept.has(file));
+    if (dropped.length > 0) {
+      const shown = dropped.slice(0, 8).map((file) => sanitizeForTerminal(file));
+      const more = dropped.length > shown.length ? ` (+${dropped.length - shown.length} more)` : '';
+      log.warn(
+        tag,
+        `Filtered ${dropped.length} file(s) from the diff per ignorePatterns/shieldIgnorePatterns: ${shown.join(', ')}${more}`,
+      );
+    }
+    return filtered;
+  };
+
   // Definite-assignment asserted: every branch assigns both before use — the
   // shared `resolveBranchScope` closure hides that from TS2454's flow analysis.
   let diff!: string;
@@ -293,7 +315,7 @@ export async function getDiffForReview(
   // so diffScope + lineage record the true comparison.
   const resolveBranchScope = (base: string): void => {
     const branchResult = getGitBranchDiffResult(cwd, base);
-    diff = filterDiffByPatterns(branchResult.diff, allIgnore);
+    diff = filterDiffWithDisclosure(branchResult.diff);
     source = 'branch-vs-base';
     scopeBase = branchResult.resolvedBase;
   };
@@ -320,7 +342,7 @@ export async function getDiffForReview(
     // Explicit-range path — no fallback. getGitDiffRange rejects flag-injection
     // (leading `-`) and empty values; ignore patterns still apply per repo policy.
     log.info(tag, `Diff source: explicit range (${options.diff})`);
-    diff = filterDiffByPatterns(getGitDiffRange(cwd, options.diff), allIgnore);
+    diff = filterDiffWithDisclosure(getGitDiffRange(cwd, options.diff));
     source = 'explicit-range';
     // Finding 10: the raw selector form distinguishes `--diff main` from `--diff main..HEAD`.
     selectorForm = options.diff;
@@ -333,7 +355,7 @@ export async function getDiffForReview(
     const mode: 'staged' | 'all' = options.staged ? 'staged' : 'all';
     const sourceLabel: DiffForReviewSource = options.staged ? 'staged' : 'uncommitted';
     log.info(tag, `Diff source: ${sourceLabel}`);
-    diff = filterDiffByPatterns(getGitDiff(mode, cwd), allIgnore);
+    diff = filterDiffWithDisclosure(getGitDiff(mode, cwd));
     source = sourceLabel;
 
     if (!diff.trim()) {

--- a/packages/cli/src/git.ts
+++ b/packages/cli/src/git.ts
@@ -191,6 +191,14 @@ function resolveExplicitRangeRefs(range: string): { base?: string; head?: string
 export const REVIEW_DIFF_TRUNCATION_THRESHOLD = 50_000;
 
 /**
+ * Cap on file names printed by the ignore-filter disclosure line
+ * (mmnto-ai/totem#1748): enough to name every file in the observed exhibits
+ * while bounding terminal noise when a broad pattern drops a large set; the
+ * overflow is still counted (`+N more`).
+ */
+export const MAX_DISCLOSED_FILTERED_FILES = 8;
+
+/**
  * Shared diff-fetching logic used by both `shield` and `lint` commands.
  *
  * Resolution order:
@@ -287,7 +295,9 @@ export async function getDiffForReview(
     const kept = new Set(extractChangedFiles(filtered));
     const dropped = extractChangedFiles(rawDiff).filter((file) => !kept.has(file));
     if (dropped.length > 0) {
-      const shown = dropped.slice(0, 8).map((file) => sanitizeForTerminal(file));
+      const shown = dropped
+        .slice(0, MAX_DISCLOSED_FILTERED_FILES)
+        .map((file) => sanitizeForTerminal(file));
       const more = dropped.length > shown.length ? ` (+${dropped.length - shown.length} more)` : '';
       log.warn(
         tag,

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -544,6 +544,7 @@ describe('requireEmbedding', () => {
     totemDir: '.totem',
     lanceDir: '.lancedb',
     ignorePatterns: [],
+    indexIgnorePatterns: [],
     shieldIgnorePatterns: [],
     shieldAutoLearn: false,
     contextWarningThreshold: 40_000,

--- a/packages/cli/src/utils/pilot.test.ts
+++ b/packages/cli/src/utils/pilot.test.ts
@@ -22,6 +22,7 @@ function makeConfig(pilot?: TotemConfig['pilot']): TotemConfig {
     totemDir: '.totem',
     lanceDir: '.lancedb',
     ignorePatterns: [],
+    indexIgnorePatterns: [],
     shieldIgnorePatterns: [],
     contextWarningThreshold: 40_000,
     shieldAutoLearn: false,

--- a/packages/core/src/config-schema.test.ts
+++ b/packages/core/src/config-schema.test.ts
@@ -61,6 +61,21 @@ describe('TotemConfigSchema', () => {
     expect(result.success).toBe(false);
   });
 
+  it('defaults indexIgnorePatterns to an empty array (index-only exclusions, #1748)', () => {
+    const result = TotemConfigSchema.parse({ targets: BASE_TARGETS });
+    expect(result.indexIgnorePatterns).toEqual([]);
+  });
+
+  it('preserves indexIgnorePatterns independently of ignorePatterns', () => {
+    const result = TotemConfigSchema.parse({
+      targets: BASE_TARGETS,
+      indexIgnorePatterns: ['audits/**'],
+      ignorePatterns: ['dist/**'],
+    });
+    expect(result.indexIgnorePatterns).toEqual(['audits/**']);
+    expect(result.ignorePatterns).toEqual(['dist/**']);
+  });
+
   it('rejects absolute lanceDir (Unix)', () => {
     const result = TotemConfigSchema.safeParse({ targets: BASE_TARGETS, lanceDir: '/tmp/lancedb' });
     expect(result.success).toBe(false);

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -432,8 +432,24 @@ export const TotemConfigSchema = z.object({
     .default('.lancedb')
     .refine((p) => !/^(\/|\\|[A-Za-z]:)/.test(p), 'lanceDir must be a relative path'),
 
-  /** Optional: glob patterns to exclude from indexing */
+  /**
+   * Optional: glob patterns to exclude from indexing.
+   *
+   * Back-compat note (mmnto-ai/totem#1748): these patterns are ALSO merged
+   * into the lint/shield diff filter, so they remove files from review scope
+   * — the diff layer now discloses each drop loudly. For index-only intent
+   * ("keep on disk and lintable, out of the semantic index") use
+   * `indexIgnorePatterns`. The 2.0.0 split that removes this key from lint
+   * scope is registered in mmnto-ai/totem#1746.
+   */
   ignorePatterns: z.array(z.string()).default(DEFAULT_IGNORE_PATTERNS),
+
+  /**
+   * Optional: glob patterns excluded ONLY from indexing — never from
+   * lint/shield scope (mmnto-ai/totem#1748, upstream-feedback/046). This is
+   * the clean home for "don't embed this into the semantic index" intent.
+   */
+  indexIgnorePatterns: z.array(z.string()).optional().default([]),
 
   /** Optional: additional glob patterns to exclude from deterministic shield scanning (merged with ignorePatterns) */
   shieldIgnorePatterns: z.array(z.string()).optional().default([]),

--- a/packages/core/src/ingest/pipeline.ts
+++ b/packages/core/src/ingest/pipeline.ts
@@ -270,9 +270,16 @@ async function runSyncInner(
     incremental = false;
   }
 
-  // 3. Resolve files to process
+  // 3. Resolve files to process. Index exclusion unions both keys:
+  // `ignorePatterns` (legacy dual-scope) + `indexIgnorePatterns` (index-only,
+  // mmnto-ai/totem#1748) — only the former also gates lint/shield scope.
   const totemDir = path.join(projectRoot, config.totemDir);
-  const allFiles = resolveFiles(config.targets, projectRoot, config.ignorePatterns, log);
+  const allFiles = resolveFiles(
+    config.targets,
+    projectRoot,
+    [...config.ignorePatterns, ...config.indexIgnorePatterns],
+    log,
+  );
   let filesToProcess: ResolvedFile[];
   let deletedPaths: string[] = [];
 

--- a/packages/core/src/pack-manifest-writer.test.ts
+++ b/packages/core/src/pack-manifest-writer.test.ts
@@ -90,6 +90,7 @@ function makeConfig(extendsList: readonly string[] | undefined): TotemConfig {
     totemDir: '.totem',
     lanceDir: '.lancedb',
     ignorePatterns: [],
+    indexIgnorePatterns: [],
     shieldIgnorePatterns: [],
     contextWarningThreshold: 40_000,
     shieldAutoLearn: false,


### PR DESCRIPTION
## What

`config.ignorePatterns` is documented as index exclusion (`config-schema.ts`) but was silently merged into the lint/shield diff filter (`cli/git.ts` `allIgnore`) — so an operator excluding paths from *indexing* silently disabled *lint* on those paths. Routed from the mmnto-ai/totem-strategy#872 harmony round (dual-verified, two same-day live exhibits: the original upstream-feedback/046 case, and `audits/**` dropping a staged audit file from a lint run during the round's own codification PR, with the config comment proving indexing-only intent).

**Conservative composite** (the shape call the route-out delegated to this lane — the aggressive variant, lint-stops-inheriting-`ignorePatterns`, is a behavior change for every consumer and is deliberately NOT taken here):

1. **New `indexIgnorePatterns` config key** (core schema): excluded ONLY from indexing — the ingest pipeline unions it with `ignorePatterns`; lint/shield scope never sees it. Moving index-intent patterns (e.g. `audits/**`) here restores lint coverage immediately, keeping index exclusion.
2. **`ignorePatterns` keeps its dual scope** for back-compat; its docstring now states the dual scope honestly instead of claiming index-only (the tertiary docs fix, folded in).
3. **Tenet-4 disclosure floor**: `getDiffForReview` now warns `Filtered N file(s) from the diff per ignorePatterns/shieldIgnorePatterns: <files>` (capped at 8 names + overflow count, terminal-sanitized) on all three diff-resolution paths — so un-migrated configs stop failing *silently*. The #2090 narrow-scope advisory's shadow computation intentionally stays on the plain filter (no double-warn). Verdicts, exit codes, and diff contents are unchanged when nothing is dropped.
4. The full inheritance split (lint stops consuming `ignorePatterns`) is registered in the 2.0.0 deferred-breaking ledger (#1746) rather than shipped.

Classification: contract-bearing (additive config key + new output line), no obligated consumer moves; the strategy-repo `audits/**` migration is opt-in and immediate.

## Verification

- **Live end-to-end**: scratch repo reproducing the exhibit (3 staged files, one under `audits/**` with `ignorePatterns: ['audits/**']`) — the built CLI now prints `Filtered 1 file(s) from the diff per ignorePatterns/shieldIgnorePatterns: audits/internal/report.md` where it previously reported `Changed files (2)` with no trace.
- +5 tests: 2 schema (default + independence), 3 disclosure (names dropped files / silent when nothing dropped / caps at 8 with `+N more`), the disclosure fixture mirroring the live exhibit.
- Full gate: `pnpm -r build` ✓ · core 3,194/3,194 ✓ · cli 3,162/3,162 ✓ · `format:check` ✓ · ESLint ✓ · `totem lint` PASS (pre-push).

Closes #1748

🤖 Generated with [Claude Code](https://claude.com/claude-code)
