### PR TITLE
docs(claim-discipline): strategy#531 seam-repair burn-down — package-family D1 alignment + public-surface register fixes

### DIFF
--- a/.changeset/claim-discipline-seam-repair.md
+++ b/.changeset/claim-discipline-seam-repair.md
@@ -1,0 +1,14 @@
+---
+'@mmnto/totem': patch
+'@mmnto/mcp': patch
+'@mmnto/cli': patch
+---
+
+docs(claim-discipline): strategy#531 seam-repair burn-down — package-family description alignment + public-surface register fixes (mmnto-ai/totem#1950 residual class).
+
+The published package family disagreed with itself: `@mmnto/cli` carries the ruled D1 self-description (mmnto-ai/totem#2336 / mmnto-ai/totem#2349) while `@mmnto/totem` and `@mmnto/mcp` still advertised the retired "persistent memory and context layer" category. Public docs also carried autonomy framing ahead of the mechanism ("automatically heal itself", "takes autonomous action", "no extra setup").
+
+- `@mmnto/totem` + `@mmnto/mcp` `package.json` descriptions and per-package READMEs re-cut on the D1 descriptive core; drift-locked by per-package parity tests mirroring the CLI's (`description.test.ts` in each package).
+- README + wiki register fixes: canonical plain-file sources vs derived LanceDB index no longer conflated; the IDE-level MCP registration step is named instead of "no extra setup"; `totem spec`'s catch claim is first-person, not a product guarantee; `totem doctor --pr` copy states the real mechanism — telemetry-derived downgrades staged as a PR a human merges — replacing "Self-Healing"/"autonomous" framing; "provides the hard guarantee" residual (mmnto-ai/totem#1950 class) reworded to the mechanical claim.
+
+Consumer-impact: npm registry metadata (`description` fields) and rendered README/docs pages only; no runtime code paths change (the two new files are tests).

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ When a rule matches comments or string literals instead of actual code, `totem d
 
 AI agents are stateless by default. Every new session starts from zero, with no record of prior incidents or the shared helpers you've already written. You end up re-explaining the same context over and over.
 
-Totem's approach is to ship a queryable knowledge index that holds your lessons and ADRs in a local semantic store (Tree-sitter + LanceDB). The index lives in your repo as plain files, so there's no cloud dependency and no vendor lock-in.
+Totem's approach: your lessons and ADRs live in your repo as plain markdown files — those files are the canonical source. `totem sync` derives a local semantic index from them (Tree-sitter + LanceDB) so they become queryable. The derived store stays on your machine and rebuilds from the files at any time, so there's no cloud dependency and no vendor lock-in.
 
-Any MCP-compatible agent can query it. Before your agent writes a line of code, it can ask "what patterns are banned in this codebase?" or "what's the architecture of the auth system?" and get a real set of ranked candidates from your project's actual history (the agent still has to read them and synthesize — a queryable index returns candidates, not pre-synthesized answers). Whether an agent actually issues that query before deriving from scratch is currently an agent-discipline question — see [What Works and What Doesn't](#what-works-and-what-doesnt).
+MCP-compatible agents query it through the bundled MCP server. Registering that server with your agent is a one-time, per-agent configuration step — `totem init` scaffolds it for the agents it detects; for anything else, see [MCP Server Setup](docs/wiki/mcp-setup.md). Once registered, before your agent writes a line of code, it can ask "what patterns are banned in this codebase?" or "what's the architecture of the auth system?" and get a real set of ranked candidates from your project's actual history (the agent still has to read them and synthesize — a queryable index returns candidates, not pre-synthesized answers). Whether an agent actually issues that query before deriving from scratch is currently an agent-discipline question — see [What Works and What Doesn't](#what-works-and-what-doesnt).
 
 With [Cross-Repo Mesh](docs/wiki/cross-repo-mesh.md), federation across sibling repos is supported via the opt-in `linkedIndexes` config — one repo's lessons become queryable from all linked repos when cohorts opt in, so context doesn't stop at the repo boundary.
 
@@ -104,7 +104,7 @@ Totem is a set of CLI tools, not a framework. Building blocks you wire into what
 | `totem sync`           | Rebuild the semantic index from your lessons and docs.                                                         |
 | `totem hook install`   | Install Git hooks (`pre-push` lint gate).                                                                      |
 
-The built-in MCP server exposes the knowledge base to any compatible agent. It's the same index, with no extra setup.
+The built-in MCP server exposes the same index to MCP-compatible agents, once it's registered in your agent's MCP config — an IDE-level step; see [MCP Server Setup](docs/wiki/mcp-setup.md).
 
 ## CI/CD and GitHub Integration
 
@@ -123,7 +123,7 @@ The same `--format sarif` flag works on the standalone `totem-lite` binary for C
 Totem has three layers, and I want to be honest about where each one stands:
 
 1. **The enforcement layer works.** Compiled rules and Git hooks catch violations mechanically and offline, in under 2 seconds. This is the load-bearing floor that everything else stands on. Nothing on that floor touches the network, so it runs natively in air-gapped environments. No source code leaves your machine.
-2. **The planning layer works too, to my surprise.** Before the agent writes any code, `totem spec` pulls the GitHub issue body and queries the knowledge base for relevant lessons and ADRs. It writes a structured implementation spec to `.totem/specs/<issue>.md`. The spec includes architectural context, files to examine, edge cases the issue description missed, and task-by-task TDD directives with retrieved lessons injected inline as invariants. None of this is a hard tripwire. The agent could write a vague spec and ignore the retrieved context. But in practice the structured prompt reliably catches "I'm about to reinvent a helper that already exists" before the agent commits to an approach. A meaningful chunk of the velocity and architectural consistency I've been getting comes from this upstream gate, more than I expected when I first added it.
+2. **The planning layer works too, to my surprise.** Before the agent writes any code, `totem spec` pulls the GitHub issue body and queries the knowledge base for relevant lessons and ADRs. It writes a structured implementation spec to `.totem/specs/<issue>.md`. The spec includes architectural context, files to examine, edge cases the issue description missed, and task-by-task TDD directives with retrieved lessons injected inline as invariants. None of this is a hard tripwire. The agent could write a vague spec and ignore the retrieved context. But in practice — in my own use of it — the structured prompt has repeatedly caught "I'm about to reinvent a helper that already exists" before the agent commits to an approach. A meaningful chunk of the velocity and architectural consistency I've been getting comes from this upstream gate, more than I expected when I first added it.
 3. **The knowledge index is real infrastructure.** The index exists. It's portable across repos, and any MCP agent can query it. But whether an agent _consistently acts_ on the context it retrieves is an open question I'm actively working through. Availability is deterministic. The agent's discipline is not.
 
 I built the enforcement layer because the upstream layers aren't enough on their own. An agent can have a clean spec, relevant lessons in context, and still drift when it gets deep into a task. The tripwires catch what the planning layer and the knowledge index miss. That's the whole point of keeping them as three distinct layers rather than one: each catches a different class of failure, at a different stage of the workflow.
@@ -170,7 +170,7 @@ See the Wiki for how to use Totem to govern your workflows:
 
 - [**It Never Happens Again:**](https://github.com/mmnto-ai/totem/blob/main/docs/wiki/it-never-happens-again.md) How to turn a PR mistake into a permanent project law in 60 seconds.
 - [**Governing AI Agents:**](https://github.com/mmnto-ai/totem/blob/main/docs/wiki/governing-ai-agents.md) How to use hooks and MCP tools to enforce project rules on Claude and Gemini from Turn 1.
-- [**It Stops Crying Wolf:**](https://github.com/mmnto-ai/totem/blob/main/docs/wiki/it-stops-crying-wolf.md) How the Self-Healing Loop automatically downgrades noisy rules based on developer frustration.
+- [**It Stops Crying Wolf:**](https://github.com/mmnto-ai/totem/blob/main/docs/wiki/it-stops-crying-wolf.md) How override telemetry flags noisy rules for downgrade — proposed as a PR, merged by a human.
 
 ### Deep Dives
 
@@ -181,7 +181,7 @@ See the Wiki for how to use Totem to govern your workflows:
 
 ## Open Source Commitment
 
-The core toolkit (enforcement engine, `totem lesson compile`, MCP server, and self-healing loop) is Apache 2.0. If federation, hosted services, or centralized telemetry are introduced later, they are intended to be separate products, while the local toolkit remains Apache 2.0.
+The core toolkit (enforcement engine, `totem lesson compile`, MCP server, and the rule-tuning loop) is Apache 2.0. If federation, hosted services, or centralized telemetry are introduced later, they are intended to be separate products, while the local toolkit remains Apache 2.0.
 
 See [`COVENANT.md`](https://github.com/mmnto-ai/totem/blob/main/COVENANT.md) for details.
 

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -43,7 +43,7 @@ graph TD
     Compile -->|Emits Rule| Lint
     Lint -->|Blocked by| Hooks
 
-    %% The Self-Healing Path
+    %% The Rule-Tuning Path
     Hooks -.->|Developer Bypass| Ledger[(Trap Ledger)]:::core
     Ledger -.->|totem doctor --pr| Compile
 ```
@@ -55,7 +55,7 @@ How Totem uses project-management artifacts (ADRs, proposals, compiled rules) to
 ```mermaid
 sequenceDiagram
     participant Dev as Human / Architect
-    participant Strategy as Strategy Repo (Governance OS)
+    participant Strategy as Strategy Repo (ADRs & proposals)
     participant Agent as Local AI Agent
     participant Product as Main Codebase
 
@@ -79,9 +79,9 @@ sequenceDiagram
     Product-->>Agent: git commit success
 ```
 
-### 3. The Self-Healing Engine
+### 3. The Rule-Tuning Engine
 
-Totem assumes LLMs will hallucinate and developers will get frustrated. Each bypass is logged to the Trap Ledger; `totem doctor --pr` reads that telemetry, downgrades rules that exceed the bypass-rate threshold from error to warning, and surfaces upgrade candidates.
+Totem assumes LLMs will hallucinate and developers will get frustrated. Each bypass is logged to the Trap Ledger; `totem doctor --pr` reads that telemetry, downgrades rules that exceed the bypass-rate threshold from error to warning, and surfaces upgrade candidates — staged as a pull request for human review.
 
 ```mermaid
 graph LR
@@ -103,12 +103,12 @@ graph LR
     Override -->|Logs justification| Ledger
     Doctor -->|Analyzes| Ledger
     Doctor -->|Detects High Bypass Rate| Nursery
-    Nursery -->|Auto-Downgrades to Warning| Lint
+    Nursery -->|Downgrade PR, human-merged| Lint
 ```
 
 ### 4. Structural Layers (Deep Dive)
 
-The separation of concerns within the codebase itself: the fuzzy semantic layer, the rigid deterministic layer, and the persistent memory mesh.
+The separation of concerns within the codebase itself: the fuzzy semantic layer, the rigid deterministic layer, and the file-anchored knowledge substrate.
 
 ```mermaid
 graph TD

--- a/docs/wiki/advanced-configuration.md
+++ b/docs/wiki/advanced-configuration.md
@@ -157,7 +157,7 @@ By default, the MCP integration runs via `npx -y @mmnto/mcp`, which always fetch
 
 ## Auto-Learning (shieldAutoLearn)
 
-You can configure Totem to automatically prompt for lesson extraction whenever a `totem review` (shield) fails. This accelerates the Self-Healing Loop. Every violation becomes an immediate opportunity to improve the ruleset.
+You can configure Totem to automatically prompt for lesson extraction whenever a `totem review` (shield) fails. This accelerates the extract → compile → enforce loop. Every violation becomes an immediate opportunity to improve the ruleset.
 
 ```typescript
 // totem.config.ts

--- a/docs/wiki/annotation-system.md
+++ b/docs/wiki/annotation-system.md
@@ -15,8 +15,8 @@ Totem relies on a semantic annotation system to guide the review pipeline and pr
 2. **Injection:**
    The extracted context is injected into the `=== SMART REVIEW HINTS ===` section of the LLM review prompt. This prevents the AI from blindly flagging acceptable deviations from the architecture.
 
-3. **Telemetry & Self-Healing:**
-   Every time a `totem-context` directive is encountered by `totem lint` or `totem review`, it is recorded as an `override` event in `.totem/ledger/events.ndjson`. If a rule accumulates too many exceptions, the self-healing loop (`totem doctor --pr`) will propose downgrading the rule.
+3. **Telemetry & Rule Tuning:**
+   Every time a `totem-context` directive is encountered by `totem lint` or `totem review`, it is recorded as an `override` event in `.totem/ledger/events.ndjson`. If a rule accumulates too many exceptions, the rule-tuning loop (`totem doctor --pr`) will propose downgrading the rule.
 
 4. **Linting vs. Review:**
    `totem-context` suppresses the deterministic lint errors for the following block of code AND provides context to the review AI. It is different from `// totem-ignore`, which is a hard suppression without providing context to the reviewer.

--- a/docs/wiki/cli-reference.md
+++ b/docs/wiki/cli-reference.md
@@ -46,7 +46,7 @@ Runs a battery of automated health checks to verify config bloat, index health, 
 
 - **Flags:**
   - `--ci`: Exits with a non-zero status code if critical checks fail.
-  - `--pr`: Analyzes the Trap Ledger and auto-downgrades rules with a >30% bypass rate by generating a GitHub Pull Request (Self-Healing Loop).
+  - `--pr`: Analyzes the Trap Ledger and downgrades rules with a >30% bypass rate, staging the changes as a GitHub Pull Request for review (the rule-tuning loop).
 
 ### `totem status` / `totem check`
 
@@ -266,7 +266,7 @@ The classifier is a fixed table over the four-axis cube `(severityBucket × roun
 
 ### `totem review-learn <pr-number>`
 
-Extracts systemic lessons from resolved bot review comments on a merged PR. The other half of the Self-Healing Loop.
+Extracts systemic lessons from resolved bot review comments on a merged PR. The input half of the extract → compile → enforce loop.
 
 ### `totem spec <issue-ids...>`
 

--- a/docs/wiki/config-reference.md
+++ b/docs/wiki/config-reference.md
@@ -88,7 +88,7 @@ export default {
   // Defines the baseline level of strictness and overhead.
   tier: 'Standard',
 
-  // Self-Healing Loop
+  // Lesson-extraction prompt on review failure
   shieldAutoLearn: true, // Auto-triggers lesson extraction on FAIL verdicts
 
   // Targets Configuration

--- a/docs/wiki/enforcement-model.md
+++ b/docs/wiki/enforcement-model.md
@@ -38,7 +38,7 @@ Sometimes, breaking an architectural rule is the correct technical decision. Use
 globalThis.__legacyAPIState = {};
 ```
 
-Every override is recorded in the local **Trap Ledger**. If a rule is overridden frequently, `totem doctor --pr` will automatically downgrade it to a warning. Totem learns from your context and steps out of your way.
+Every override is recorded in the local **Trap Ledger**. If a rule is overridden frequently, `totem doctor --pr` derives an error → warning downgrade from that telemetry and opens a PR proposing it. Your justifications become the evidence for tuning the rule — and a human reviews every change.
 
 ## Unified Findings Model
 

--- a/docs/wiki/governing-ai-agents.md
+++ b/docs/wiki/governing-ai-agents.md
@@ -29,7 +29,7 @@ The agent now sees whether the manifest is fresh, whether the review stamp is st
 
 ## 2. Deterministic Enforcement (Pre-Push Hook)
 
-Context injection helps agents make better decisions, but it cannot guarantee compliance. The pre-push Git hook provides the hard guarantee:
+Context injection helps agents make better decisions, but it cannot guarantee compliance. The pre-push Git hook enforces the compiled rules mechanically at push time:
 
 ```bash
 $ git push

--- a/docs/wiki/metrics.md
+++ b/docs/wiki/metrics.md
@@ -1,6 +1,6 @@
 # Architecture & Metrics
 
-Totem tracks telemetry on rule execution to identify false positives and drive the self-healing loop.
+Totem tracks telemetry on rule execution to identify false positives and drive the rule-tuning loop (`totem doctor --pr`).
 
 ## RuleMetric schema
 

--- a/docs/wiki/override-directives.md
+++ b/docs/wiki/override-directives.md
@@ -11,7 +11,7 @@ This is the **Semantic Overlay**. It is the unified, primary mechanism for overr
 When you use `totem-context:`, you are telling the system: _"I know this breaks a rule, and here is my exact architectural reasoning for why it is necessary."_
 
 - **Rule Engine:** It strictly suppresses the deterministic `totem lint` error for the following block of code.
-- **Telemetry:** It writes a `suppress` event into the **Trap Ledger**, capturing your reason. If a rule accumulates too many of these contexts, Totem will automatically downgrade the rule via `totem doctor --pr`.
+- **Telemetry:** It writes a `suppress` event into the **Trap Ledger**, capturing your reason. If a rule accumulates too many of these contexts, `totem doctor --pr` will propose downgrading it in a PR you review and merge.
 - **Review Layer:** During an AI-powered `totem review`, the LLM reads your context as a semantic hint and incorporates your logic into its evaluation, rather than blindly flagging the violation.
 
 **Example:**

--- a/docs/wiki/trap-ledger.md
+++ b/docs/wiki/trap-ledger.md
@@ -1,8 +1,8 @@
-# Trap Ledger & Self-Healing Rules
+# Trap Ledger & Rule Tuning
 
 Architectural enforcement is the floor. On top of that floor, Totem adapts rules from telemetry.
 
-If a compiled rule is too strict or hallucinates false positives, it will cause developer friction. Instead of forcing developers to manually edit configuration files or blindly bypass the system, Totem uses developer friction as data to automatically heal itself.
+If a compiled rule is too strict or hallucinates false positives, it will cause developer friction. Instead of forcing developers to manually edit configuration files or blindly bypass the system, Totem records that friction as telemetry — and `totem doctor --pr` turns the telemetry into reviewable rule changes.
 
 ## 1. The Trap Ledger
 
@@ -68,11 +68,11 @@ Per ADR-078 § Event Attribution: agent attribution lives in `agent_source`; `so
 
 ---
 
-## 2. The Self-Healing Loop (`totem doctor --pr`)
+## 2. The Rule-Tuning Loop (`totem doctor --pr`)
 
 The Trap Ledger provides the raw telemetry, but the **Doctor** provides the cure.
 
-By running `totem doctor --pr`, you initiate the self-healing sequence. The command aggregates the local telemetry, calculates bypass rates for every compiled rule, and takes autonomous action.
+Running `totem doctor --pr` starts the tuning sequence: the command aggregates the local telemetry, calculates bypass rates for every compiled rule, and stages the resulting changes as a pull request for human review.
 
 ### The Algorithm
 
@@ -83,7 +83,7 @@ By running `totem doctor --pr`, you initiate the self-healing sequence. The comm
 
 ### The Full Cycle
 
-This creates an autonomous, self-regulating ecosystem:
+The full cycle — every change lands through a human-reviewed PR:
 
 1. **Developer writes code.**
 2. **`totem lint` catches a violation.**

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # @mmnto/cli
 
-Command-line interface for [Totem](https://github.com/mmnto-ai/totem), a persistent memory and context layer for AI coding agents. Installs the `totem` binary.
+Command-line interface for [Totem](https://github.com/mmnto-ai/totem) — a local-first, file-anchored substrate that makes AI-agent work queryable, enforceable, and derivable in your codebase. Installs the `totem` binary.
 
 ## Install
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # @mmnto/totem
 
-Core engine for [Totem](https://github.com/mmnto-ai/totem), a persistent memory and context layer for AI agents. This is the library that [`@mmnto/cli`](https://www.npmjs.com/package/@mmnto/cli) and [`@mmnto/mcp`](https://www.npmjs.com/package/@mmnto/mcp) build on; most users want one of those instead.
+Core engine for [Totem](https://github.com/mmnto-ai/totem) — a local-first, file-anchored substrate that makes AI-agent work queryable, enforceable, and derivable in your codebase. This is the library that [`@mmnto/cli`](https://www.npmjs.com/package/@mmnto/cli) and [`@mmnto/mcp`](https://www.npmjs.com/package/@mmnto/mcp) build on; most users want one of those instead.
 
 It contains the lesson parsing and compilation substrate, the deterministic rule engine (regex, Tree-sitter AST classification, ast-grep), the LanceDB-backed vector store, chunkers and embedders, and pack manifest helpers.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mmnto/totem",
   "version": "1.96.0",
-  "description": "Persistent memory and context layer for AI agents",
+  "description": "Core engine for Totem — a local-first, file-anchored substrate that makes AI-agent work queryable, enforceable, and derivable in your codebase",
   "type": "module",
   "engines": {
     "node": ">=24"

--- a/packages/core/src/description.test.ts
+++ b/packages/core/src/description.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+// Family parity with the CLI's single-sourced self-description (mmnto-ai/totem#2336 D1,
+// pattern from mmnto-ai/totem#2349): every published @mmnto package carries the ruled
+// descriptive core and never regresses to the retired category label.
+describe('package self-description parity (mmnto-ai/totem#2336 D1 family alignment)', () => {
+  it('package.json description carries the ruled descriptive core', () => {
+    const pkgUrl = new URL('../package.json', import.meta.url);
+    const pkg = JSON.parse(readFileSync(pkgUrl, 'utf-8')) as {
+      name: string;
+      description: string;
+    };
+    expect(pkg.name).toBe('@mmnto/totem');
+    expect(pkg.description).toContain(
+      'a local-first, file-anchored substrate that makes AI-agent work queryable, enforceable, and derivable in your codebase',
+    );
+    // Guards against a regression to the retired category.
+    expect(pkg.description).not.toContain('persistent memory and context layer');
+  });
+});

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,6 +1,6 @@
 # @mmnto/mcp
 
-MCP (Model Context Protocol) server for [Totem](https://github.com/mmnto-ai/totem), a persistent memory and context layer for AI coding agents. A stdio-based server that exposes a Totem project's knowledge index to any MCP-compatible agent. Installs the `totem-mcp` binary.
+MCP (Model Context Protocol) server for [Totem](https://github.com/mmnto-ai/totem) — a local-first, file-anchored substrate that makes AI-agent work queryable, enforceable, and derivable in your codebase. A stdio-based server that exposes a Totem project's knowledge index to MCP-compatible agents. Installs the `totem-mcp` binary.
 
 ## Setup
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mmnto/mcp",
   "version": "1.96.0",
-  "description": "MCP server for Totem — AI persistent memory and context layer",
+  "description": "MCP server for Totem — a local-first, file-anchored substrate that makes AI-agent work queryable, enforceable, and derivable in your codebase",
   "type": "module",
   "engines": {
     "node": ">=24"

--- a/packages/mcp/src/description.test.ts
+++ b/packages/mcp/src/description.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+
+import { describe, expect, it } from 'vitest';
+
+// Family parity with the CLI's single-sourced self-description (mmnto-ai/totem#2336 D1,
+// pattern from mmnto-ai/totem#2349): every published @mmnto package carries the ruled
+// descriptive core and never regresses to the retired category label.
+describe('package self-description parity (mmnto-ai/totem#2336 D1 family alignment)', () => {
+  it('package.json description carries the ruled descriptive core', () => {
+    const pkgUrl = new URL('../package.json', import.meta.url);
+    const pkg = JSON.parse(readFileSync(pkgUrl, 'utf-8')) as {
+      name: string;
+      description: string;
+    };
+    expect(pkg.name).toBe('@mmnto/mcp');
+    expect(pkg.description).toContain(
+      'a local-first, file-anchored substrate that makes AI-agent work queryable, enforceable, and derivable in your codebase',
+    );
+    // Guards against a regression to the retired category.
+    expect(pkg.description).not.toContain('persistent memory and context layer');
+  });
+});


### PR DESCRIPTION
Executes the five-item seam-repair burn-down routed to the totem lane by the strategy#531 ruling (ruling record: mmnto-ai/totem-strategy#531 comment 4974679759; synthesis 4974601985 + addendum 4974641309). This is the gate for the A1 README carve at the strategy seat.

Closes #1950

## Item 1 — #1950 "guarantees compliance" (public wiki)

Ground truth first: the ticketed exhibit (`docs/wiki/governing-ai-agents.md:58`) was **already fixed** by the Phase-1 honesty pass (#2084, confirmed via `git log -S`). What survived is the same-class sibling on the same page — line 32's "The pre-push Git hook provides the **hard guarantee**" — now reworded to the mechanical claim ("enforces the compiled rules mechanically at push time"). A repo-wide sweep found no other affirmative `guarantee` on public doc surfaces. The two advisory `totem lint` warnings that remain on this line are the word-matchers sensing "**cannot** guarantee" — the negated, claim-disciplined half that #1950's own issue body called the correct framing (the #2063 intent-blind-matcher class; warning-tier, excluded from exit code, pre-existing).

## Item 2 — package-family description alignment (D1, #2349 pattern)

`@mmnto/totem` and `@mmnto/mcp` still advertised the retired "persistent memory and context layer" category while `@mmnto/cli` carries the ruled D1 core — the family disagreed with itself (codex's exhibit in the round).

- Both `package.json` descriptions re-cut on the D1 descriptive core ("a local-first, file-anchored substrate that makes AI-agent work queryable, enforceable, and derivable in your codebase").
- Per-package npm READMEs (`packages/{core,cli,mcp}/README.md` lead paragraphs) carried the same retired category — re-cut in the same pass.
- Drift-locked with per-package `description.test.ts` parity tests mirroring the CLI's (#2349): description must contain the D1 core, must not contain the retired category. (No dead runtime constant added in core/mcp — `package.json` is their only description surface, so the tests assert it directly; the CLI keeps its single-sourced constant because it feeds three runtime surfaces.)

## Item 3 — README seams

- **(a) canonical vs derived conflated:** the knowledge-index section said "the index lives in your repo as plain files." Now states the true split: lessons/ADRs are canonical plain markdown in the repo; `totem sync` derives the local LanceDB store from them; the derived store is machine-local and rebuildable.
- **(b) "no extra setup" / "any MCP-compatible agent":** both occurrences removed. Copy now names the IDE-level, per-agent MCP registration step honestly (`totem init` scaffolds it for detected agents — verified against `init.ts scaffoldMcpConfig`, which writes per-tool `mcpServers` entries), pointing at the MCP Setup guide. lc's lived `.mcp.json` re-add/collision seam is **already ticketed** as #2163 (idempotency keyed on entry name) and #2008 (init scope-creep on already-initialized repos) — no new mint, per verify-before-creating.
- **(c) "reliably catches":** now first-person and past-observed ("in my own use of it — the structured prompt has repeatedly caught…"), never a product guarantee.

## Item 4 — auto-healing register (with one grounded deviation from the ruling's letter)

The dispatch says demote auto-healing framing to `Goal:`/roadmap register. Ground truth check first (Tenet 20): `runSelfHealing` in `doctor.ts` is **shipped, working code** — it derives downgrades from bypass telemetry, stages `compiled-rules.json` (+ manifest when touched), and opens a PR with the numeric rationale for a human to merge. Demoting that to `Goal:` would under-claim a live mechanism. So the fix applied is **register-correction, not demotion**: every "automatically heal itself / takes autonomous action / autonomous self-regulating ecosystem / will automatically downgrade" is replaced with the true mechanism — telemetry-derived changes staged as a PR a human reviews and merges. The purge-listed "Self-Healing" branding is renamed to **rule-tuning loop** across public docs (trap-ledger, cli-reference, config-reference, annotation-system, metrics, architecture, README ×2, advanced-configuration → extract→compile→enforce loop). Also swept under the same purge list: "Governance OS" label and "persistent memory mesh" in `architecture.md`. Deliberately **not** rewritten: `docs/wiki/roadmap.md` history entries (dated record register, which the ruling explicitly allows) and the `[Auto-Healing]` console tag in `doctor.ts` (runtime string, out of copy-burn-down scope — flagged for the A3 pass if wanted). No heading anchors break (grep: zero inbound anchor links).

## Item 5 — split-register constraint (#2363)

Standing check applied to every touched surface: no copy claims lesson-grounded review for the new review lanes. The only review-adjacent line touched (`annotation-system.md` §3) describes `totem-context` hint injection, not lesson retrieval. Constraint holds until #2363 builds.

## Gates

Full workspace build green; both new parity tests pass; repo-wide `prettier --check` clean; ESLint 0 errors (7 pre-existing warnings, none in changed files); full `totem lint` PASS (387 rules; 2 advisory warnings explained under Item 1); changeset included (patch ×3 — registry metadata + rendered README/docs only, no runtime change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
