### PR TITLE
fix(mail): own-broadcast exclusion — a seat's outbound broadcast is not its own unread (#2364)

### DIFF
--- a/.changeset/pollmail-own-broadcast-exclusion.md
+++ b/.changeset/pollmail-own-broadcast-exclusion.md
@@ -1,0 +1,11 @@
+---
+'@mmnto/cli': patch
+---
+
+fix(mail): a seat's own outbound broadcast no longer surfaces as its own unread (mmnto-ai/totem#2364).
+
+`pollMail` filtered by recipient only, so a seat that broadcast to the cohort read "1 unread" from its own outbox forever unless it hand-backfilled a `processed/_broadcast/` mark (live exhibit: a strategy-seat round-reply broadcast red in every one of that seat's orientations for 8 days). The unread scan now excludes a dispatch when its source outbox belongs to a SELF agent AND `to: broadcast` — keyed on the outbox-owner directory (single-writer filesystem truth, same doctrine as the basename-collision sensor), never the forgeable `from:` header.
+
+Scope guards: the `includeProcessed` discovery view (ecl-gc compaction, ADR-106 § A2.1) keeps the RAW addressed-inbound set — excluding own-broadcasts there would read existing self-marks as stale and collect marks that must be retained. Directed self-mail (`to:` a SELF agent from an own outbox) stays surfaced; broadcasts are the observed noise class.
+
+Consumer-impact: `totem mail` unread output + every `pollMail()` consumer (SessionStart hooks, MCP audits) stop counting the polling seat's own broadcasts as unread. Under a dirs-derived multi-seat union view (no `TOTEM_SELF_AGENT` scoping), broadcasts from any unioned seat are treated as "own" — consistent with that view's existing self-set semantics. No schema or flag changes.

--- a/packages/cli/src/commands/mail.test.ts
+++ b/packages/cli/src/commands/mail.test.ts
@@ -227,6 +227,67 @@ describe('pollMail — basic filter behavior', () => {
   });
 });
 
+// ─── Own-broadcast exclusion (mmnto-ai/totem#2364) ──────
+
+describe('pollMail — own-broadcast exclusion (mmnto-ai/totem#2364)', () => {
+  it('excludes a broadcast whose source outbox belongs to a SELF agent', () => {
+    writeOutbox('totem', 'totem-claude', [
+      { name: '2026-07-06T2326Z-broadcast-round-reply.md', to: 'broadcast', subject: 'own round' },
+    ]);
+    const result = poll();
+    expect(result.mail).toEqual([]);
+  });
+
+  it("still surfaces another seat's broadcast", () => {
+    writeOutbox('totem', 'totem-claude', [
+      { name: '2026-07-06T2326Z-broadcast-own.md', to: 'broadcast', subject: 'own' },
+    ]);
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: '2026-07-06T2330Z-broadcast-theirs.md', to: 'broadcast', subject: 'theirs' },
+    ]);
+    const result = poll();
+    expect(result.mail).toHaveLength(1);
+    expect(result.mail[0]!.subject).toBe('theirs');
+  });
+
+  it('keys on the outbox-owner seat, not the forgeable from: header', () => {
+    // A foreign-outbox broadcast forging `from: totem-claude` is NOT ours —
+    // it must still surface (single-writer filesystem truth, as the
+    // collision sensor).
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      {
+        name: '2026-07-06T2331Z-broadcast-forged.md',
+        to: 'broadcast',
+        from: 'totem-claude',
+        subject: 'forged sender',
+      },
+    ]);
+    const result = poll();
+    expect(result.mail).toHaveLength(1);
+    expect(result.mail[0]!.subject).toBe('forged sender');
+  });
+
+  it('directed self-mail from an own outbox stays surfaced (out of scope)', () => {
+    writeOutbox('totem', 'totem-claude', [
+      { name: '2026-07-06T2332Z-totem-claude-note-to-self.md', to: 'totem-claude' },
+    ]);
+    const result = poll();
+    expect(result.mail).toHaveLength(1);
+  });
+
+  it('includeProcessed keeps the own broadcast in the RAW addressed-inbound set (ADR-106 § A2.1)', () => {
+    // The ecl-gc compaction key is `processed ∩ raw-addressed-inbound`;
+    // excluding own-broadcasts there would read an existing self-mark as
+    // stale and collect a mark that must be retained.
+    writeOutbox('totem', 'totem-claude', [
+      { name: '2026-07-06T2326Z-broadcast-own.md', to: 'broadcast', subject: 'own round' },
+    ]);
+    const result = poll({ includeProcessed: true });
+    expect(result.mail).toHaveLength(1);
+    expect(result.mail[0]!.to).toBe('broadcast');
+  });
+});
+
 // ─── Symlink guard (mmnto-ai/totem#2355) ────────────────
 
 describe('pollMail — symlinked agent/outbox dirs are not traversed (mmnto-ai/totem#2355)', () => {

--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -664,6 +664,20 @@ export function pollMail(opts: MailCommandOptions = {}): MailPollResult {
     }
     if (toLower !== 'broadcast' && !selfLower.has(toLower)) continue;
     const senderSeat = slot.agent.toLowerCase();
+    // Own-broadcast exclusion (mmnto-ai/totem#2364): a seat's outbound
+    // broadcast is not its own inbound — without this, a broadcasting seat
+    // reads "1 unread" from its own outbox forever unless it hand-backfills a
+    // `processed/_broadcast/` mark. Keyed on the OUTBOX-OWNER seat
+    // (`slot.agent`, single-writer filesystem truth — same doctrine as the
+    // collision sensor below), never the forgeable `from:` header. Reader
+    // path only: the `includeProcessed` compaction discovery (ADR-106 § A2.1)
+    // must keep the RAW addressed-inbound set, or existing self-broadcast
+    // marks would read as stale and be collected — the false-unread bomb.
+    // Directed self-mail (`to:` a SELF agent) stays surfaced; broadcasts are
+    // the observed noise class.
+    if (opts.includeProcessed !== true && toLower === 'broadcast' && selfLower.has(senderSeat)) {
+      continue;
+    }
     let seats = collisionsByBasename.get(file);
     if (seats === undefined) {
       seats = new Map();


### PR DESCRIPTION
Closes #2364

## Defect

`pollMail` filters by recipient only — nothing excludes a dispatch whose **source outbox is the polling seat itself**. A seat that broadcasts therefore reads "1 unread" from its own outbox forever, unless it hand-backfills a `processed/_broadcast/` mark (live exhibit in the ticket: strategy-claude's 2026-07-06 ecl-31 round-reply broadcast, red in every strategy-seat orientation for 8 days).

## Fix

One guard in the scan loop, exactly as the ticket proposes: skip when `to: broadcast` **and** the outbox-owner seat is in the resolved SELF set.

- **Keyed on `slot.agent`** (the outbox directory — single-writer filesystem truth, the same doctrine the adjacent basename-collision sensor documents), never the forgeable `from:` header. A foreign-outbox broadcast forging `from: <me>` still surfaces (test pins it).
- **Reader path only.** The `includeProcessed` discovery view (ecl-gc compaction, ADR-106 § A2.1) keeps the RAW addressed-inbound set: its cursor-GC key is `processed ∩ raw-addressed-inbound`, so excluding own-broadcasts there would read existing self-broadcast marks (e.g. strategy's backfills) as stale and collect marks that must be retained — the false-unread bomb A2.1 names. Test pins the invariant.
- **Directed self-mail stays surfaced** (`to:` a SELF agent from an own outbox) — the ticket scopes the exclusion to the observed broadcast noise class.
- **Union-view semantics (noted, unchanged):** under dirs-derived multi-seat resolution (no `TOTEM_SELF_AGENT`), broadcasts from any unioned seat count as "own" and are excluded — consistent with how that view already treats every unioned seat's `processed/` marks as its own. Seat-scoped polls (`TOTEM_SELF_AGENT=<seat>`) are unaffected in precision.

## Tests

Five new cases in `mail.test.ts` (own-broadcast excluded; other-seat broadcast surfaces; forge-defense; directed self-mail surfaces; `includeProcessed` RAW-set invariant). The two behavior-changing cases **verified failing against unfixed code** (stash-and-rerun); the three invariant pins correctly pass both sides.

## Gates

Full `mail.test.ts` 113/113; full `@mmnto/cli` suite 3186/3186; workspace build green; repo-wide prettier clean; ESLint 0 errors; `totem lint` PASS (one advisory word-matcher warning on the new test's describe-string — the #2063 test-idiom class). Changeset: patch, `@mmnto/cli`.

Every `pollMail()` consumer inherits the fix (CLI, SessionStart hooks, MCP audits) — strategy-claude's standing phantom-unread clears on their next version bump after this rides a cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
