### PR TITLE
feat(review): lessonsConsulted — the round's lesson-recall record on the verdict contract (#2363)

### DIFF
--- a/.changeset/verdict-lessons-consulted.md
+++ b/.changeset/verdict-lessons-consulted.md
@@ -1,0 +1,15 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+---
+
+feat(review): `lessonsConsulted` — the round's lesson-recall record on the verdict-artifact contract (mmnto-ai/totem#2363, strategy#474 grounding lever).
+
+Premise correction recorded with the build: lesson recall is ALREADY live on the review-fan path — the fan is dispatched from the standard shield path after `retrieveContext`/`assemblePrompt`, so every lane's prompt carries the lesson checklist and every lane's run artifact carries lesson grounding. What was missing is the CONTRACT line: the verdict artifact had no recall record, so a consumer couldn't read recall status without chasing per-lane run artifacts, and a future runner change could silently drop retrieval without violating any contract.
+
+- Verdict schema 1.1.0 (additive-optional, F1): `lessonsConsulted` — `{ status: 'hit' | 'empty', items: [{ contentHash, filePath, sourceRepo? }] }`, identity-only (mirrors grounding-item semantics, no content bytes). Three observable states: field ABSENT = producer performed no retrieval (pre-1.1 artifacts — honest-absent, never fabricated); `empty` = retrieval ran, zero lessons (the visibly-ungrounded state the strategy#474 abstain-on-empty rule needs to be checkable); `hit` = identities carried. `status` ⟺ `items` enforced in the artifact superRefine (never mirrored on trust).
+- One field per VERDICT, not per lane — identical-kit discipline makes recall a round-level fact; per-lane provenance stays one hop away in each lane's run-artifact bundle.
+- `deriveLessonsConsulted(bundle)` exported from core (root barrel + `@mmnto/totem/artifacts`): the single home for the bundle→record mapping; the fan derives, never hand-builds.
+- The fan now emits the field on every verdict (derived from the same grounding bundle its lanes carry). Lane-blindness key-set structural test updated deliberately (the new key is recall telemetry, not a runner discriminator).
+
+Consumer-impact: verdict-artifact schema (additive-optional field; 1.x readers unaffected, written version 1.0.0 → 1.1.0) + new core exports. Existing artifacts parse unchanged.

--- a/packages/cli/src/commands/review-fan.test.ts
+++ b/packages/cli/src/commands/review-fan.test.ts
@@ -642,6 +642,35 @@ describe('assembleVerdict', () => {
     expect(verdict.reviewedState).toBe('drifted');
     expect(verdict.settled).toBe(false);
   });
+
+  it('carries lessonsConsulted when supplied and omits the key when absent (mmnto-ai/totem#2363)', () => {
+    const base = {
+      diffScope: { source: 'staged' as const, diffHash: hex('d') },
+      laneResults: [lane('a', []), lane('b', [])],
+      panelAndChecks: { postChecks: [] },
+      round: { index: 0, lineageKey: 'lk' },
+      reviewedState: 'matched' as const,
+      createdAt: '2026-07-10T00:00:00.000Z',
+    };
+    const withRecall = assembleVerdict(
+      {
+        ...base,
+        lessonsConsulted: {
+          status: 'hit',
+          items: [{ contentHash: hex('l'), filePath: '.totem/lessons/x.md' }],
+        },
+      },
+      deriveSettled,
+      VERDICT_ARTIFACT_SCHEMA_VERSION,
+    );
+    expect(withRecall.lessonsConsulted).toEqual({
+      status: 'hit',
+      items: [{ contentHash: hex('l'), filePath: '.totem/lessons/x.md' }],
+    });
+    // Absent input ⇒ the KEY is omitted (honest-absent), never an empty object.
+    const without = assembleVerdict(base, deriveSettled, VERDICT_ARTIFACT_SCHEMA_VERSION);
+    expect('lessonsConsulted' in without).toBe(false);
+  });
 });
 
 // ─── runReviewFan (end-to-end — gates 4, 5, 7 wiring) ─────────────────────────
@@ -724,6 +753,40 @@ describe('runReviewFan', () => {
     await expect(runReviewFan(ctx)).rejects.toThrow(/lane coverage 1\/2/);
     // The honest verdict is still written before the throw.
     expect(listVerdictArtifacts(tmpDir, noWarn)[0]!.artifact.completedLaneCount).toBe(1);
+  });
+
+  it("the persisted verdict records the round's lesson recall from the delivered bundle (mmnto-ai/totem#2363)", async () => {
+    const lessonItem = {
+      provenance: 'similarity-only',
+      contentHash: 'c'.repeat(64),
+      sourceType: 'lesson',
+      filePath: '.totem/lessons/no-child-process.md',
+    };
+    const codeItem = {
+      provenance: 'similarity-only',
+      contentHash: 'e'.repeat(64),
+      sourceType: 'code',
+      filePath: 'src/x.ts',
+    };
+    const ctx = makeCtx(tmpDir, ['anthropic:claude-a'], oneFailedOnePassing(), {
+      groundingBundle: { items: [lessonItem, codeItem] },
+    });
+    await runReviewFan(ctx);
+    const v = listVerdictArtifacts(tmpDir, noWarn)[0]!.artifact;
+    // Round-level recall: lesson-partition identity only, code items excluded.
+    expect(v.lessonsConsulted).toEqual({
+      status: 'hit',
+      items: [{ contentHash: 'c'.repeat(64), filePath: '.totem/lessons/no-child-process.md' }],
+    });
+  });
+
+  it("a zero-lesson bundle records the visibly-ungrounded 'empty' state, never absent (mmnto-ai/totem#2363)", async () => {
+    // makeCtx's default bundle is empty — the fan still emits the field, so a
+    // consumer can distinguish "retrieval ran, zero lessons" from a pre-1.1 artifact.
+    const ctx = makeCtx(tmpDir, ['anthropic:claude-a'], oneFailedOnePassing());
+    await runReviewFan(ctx);
+    const v = listVerdictArtifacts(tmpDir, noWarn)[0]!.artifact;
+    expect(v.lessonsConsulted).toEqual({ status: 'empty', items: [] });
   });
 
   it('two completed lanes assemble a panel from usable lanes only', async () => {

--- a/packages/cli/src/commands/review-fan.ts
+++ b/packages/cli/src/commands/review-fan.ts
@@ -34,6 +34,7 @@
 // inside an async entry point and threaded down to the sync helpers.
 import type {
   GroundingBundle,
+  LessonsConsulted,
   LineageKeyInput,
   PersistedPostCheckFinding,
   PostCheckReport,
@@ -814,6 +815,15 @@ export interface VerdictAssemblyInputs {
   /** Post-fan tree compare (codex rev-2 fold 1) — recorded AND fed into `settled`. */
   reviewedState: 'matched' | 'drifted';
   createdAt: string;
+  /**
+   * The round's lesson-recall record (mmnto-ai/totem#2363) — derived from the
+   * shared grounding bundle via core's `deriveLessonsConsulted`, never
+   * hand-built. Optional in the INPUTS (additive 1.x — structural callers
+   * predate it); the production fan always supplies it, so every fan verdict
+   * carries recall state (`hit`/`empty`). Absent ⇒ the field is omitted from
+   * the artifact (honest-absent), never fabricated as `empty`.
+   */
+  lessonsConsulted?: LessonsConsulted;
 }
 
 /**
@@ -859,6 +869,7 @@ export function assembleVerdict(
     ...(inputs.panelAndChecks.diversity !== undefined
       ? { diversity: inputs.panelAndChecks.diversity }
       : {}),
+    ...(inputs.lessonsConsulted !== undefined ? { lessonsConsulted: inputs.lessonsConsulted } : {}),
     round: inputs.round,
     reviewedState: inputs.reviewedState,
     settled,
@@ -1137,6 +1148,7 @@ export async function runReviewFan(ctx: ReviewFanContext): Promise<void> {
   const { log } = await import('../ui.js');
   const {
     deriveCacheEligible,
+    deriveLessonsConsulted,
     deriveSettled,
     maskSecrets,
     renderCovariateLine,
@@ -1271,6 +1283,10 @@ export async function runReviewFan(ctx: ReviewFanContext): Promise<void> {
       round: roundRes.round,
       reviewedState,
       createdAt,
+      // The round's lesson-recall record (mmnto-ai/totem#2363): derived from the
+      // SAME bundle every lane's run artifact carries — the fan's identical-kit
+      // discipline makes this a round-level fact, recorded once on the verdict.
+      lessonsConsulted: deriveLessonsConsulted(ctx.groundingBundle),
     },
     deriveSettled,
     VERDICT_ARTIFACT_SCHEMA_VERSION,

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -21,6 +21,8 @@
 
 // Verdict-artifact types (Prop 302 / 304 R2, mmnto-ai/totem#2106).
 export type {
+  LessonConsultedItem,
+  LessonsConsulted,
   LineageKeyInput,
   SaveVerdictArtifactResult,
   VerdictArtifact,
@@ -42,9 +44,12 @@ export {
   computeLineageKey,
   computeVerdictArtifactContentHash,
   deriveCacheEligible,
+  deriveLessonsConsulted,
   deriveSettled,
   findLatestVerdictForLineage,
   LaneIdSchema,
+  LessonConsultedItemSchema,
+  LessonsConsultedSchema,
   listVerdictArtifacts,
   loadVerdictArtifact,
   renderCovariateLine,

--- a/packages/core/src/artifacts/verdict.test.ts
+++ b/packages/core/src/artifacts/verdict.test.ts
@@ -36,6 +36,7 @@ import {
   computeLineageKey,
   computeVerdictArtifactContentHash,
   deriveCacheEligible,
+  deriveLessonsConsulted,
   deriveSettled,
   findLatestVerdictForLineage,
   listVerdictArtifacts,
@@ -655,6 +656,97 @@ describe('renderCovariateLine (gate G4, format v1)', () => {
   });
 });
 
+// ─── lessonsConsulted (mmnto-ai/totem#2363) ─────────────────────────────────
+
+describe('lessonsConsulted — round-level recall record (mmnto-ai/totem#2363)', () => {
+  const item = (seed: string) => ({
+    contentHash: seed.repeat(64).slice(0, 64),
+    filePath: `.totem/lessons/${seed}.md`,
+  });
+
+  it('accepts an absent field (pre-1.1 artifacts / no-retrieval producers)', () => {
+    expect(VerdictArtifactSchema.safeParse(verdict()).success).toBe(true);
+  });
+
+  it("accepts 'hit' with items and 'empty' with none", () => {
+    expect(
+      VerdictArtifactSchema.safeParse(
+        verdict({ lessonsConsulted: { status: 'hit', items: [item('a')] } }),
+      ).success,
+    ).toBe(true);
+    expect(
+      VerdictArtifactSchema.safeParse(verdict({ lessonsConsulted: { status: 'empty', items: [] } }))
+        .success,
+    ).toBe(true);
+  });
+
+  it("rejects a mirrored-on-trust status: 'hit' with zero items and 'empty' with items", () => {
+    const hitNoItems = VerdictArtifactSchema.safeParse(
+      verdict({ lessonsConsulted: { status: 'hit', items: [] } }),
+    );
+    expect(hitNoItems.success).toBe(false);
+    const emptyWithItems = VerdictArtifactSchema.safeParse(
+      verdict({ lessonsConsulted: { status: 'empty', items: [item('b')] } }),
+    );
+    expect(emptyWithItems.success).toBe(false);
+  });
+
+  it('rejects a non-sha256 contentHash', () => {
+    const bad = VerdictArtifactSchema.safeParse(
+      verdict({
+        lessonsConsulted: {
+          status: 'hit',
+          items: [{ contentHash: 'not-a-hash', filePath: '.totem/lessons/x.md' }],
+        },
+      }),
+    );
+    expect(bad.success).toBe(false);
+  });
+
+  it('deriveLessonsConsulted filters the lesson partition and passes identity through', () => {
+    const lessonItem = {
+      provenance: 'similarity-only',
+      contentHash: 'c'.repeat(64),
+      sourceType: 'lesson',
+      filePath: '.totem/lessons/no-child-process.md',
+    };
+    const crossRepoLesson = {
+      provenance: 'similarity-only',
+      contentHash: 'd'.repeat(64),
+      sourceType: 'lesson',
+      filePath: '.totem/lessons/remote.md',
+      sourceRepo: 'linked-repo',
+    };
+    const codeItem = {
+      provenance: 'similarity-only',
+      contentHash: 'e'.repeat(64),
+      sourceType: 'code',
+      filePath: 'src/x.ts',
+    };
+    const derived = deriveLessonsConsulted({ items: [lessonItem, codeItem, crossRepoLesson] });
+    expect(derived.status).toBe('hit');
+    expect(derived.items).toEqual([
+      { contentHash: 'c'.repeat(64), filePath: '.totem/lessons/no-child-process.md' },
+      {
+        contentHash: 'd'.repeat(64),
+        filePath: '.totem/lessons/remote.md',
+        sourceRepo: 'linked-repo',
+      },
+    ]);
+  });
+
+  it("deriveLessonsConsulted yields 'empty' when the bundle has no lesson items", () => {
+    const codeOnly = {
+      provenance: 'similarity-only',
+      contentHash: 'e'.repeat(64),
+      sourceType: 'code',
+      filePath: 'src/x.ts',
+    };
+    expect(deriveLessonsConsulted({ items: [codeOnly] })).toEqual({ status: 'empty', items: [] });
+    expect(deriveLessonsConsulted({ items: [] })).toEqual({ status: 'empty', items: [] });
+  });
+});
+
 // ─── LANE-BLINDNESS structural test (Prop 302) ──────────────────────────────
 
 describe('lane-blindness: no runner/lane-mode discriminator (Prop 302)', () => {
@@ -664,6 +756,10 @@ describe('lane-blindness: no runner/lane-mode discriminator (Prop 302)', () => {
       ...verdict({ lanes: [completedLane(0), completedLane(1, 'anthropic')] }),
       panelArtifactHash: 'e'.repeat(64),
       diversity: classifyDiversity(['gemini', 'anthropic']),
+      lessonsConsulted: {
+        status: 'hit' as const,
+        items: [{ contentHash: 'f'.repeat(64), filePath: '.totem/lessons/x.md' }],
+      },
     };
     expect(VerdictArtifactSchema.safeParse(full).success).toBe(true);
     const topKeys = Object.keys(full).sort();
@@ -675,6 +771,7 @@ describe('lane-blindness: no runner/lane-mode discriminator (Prop 302)', () => {
       'diversity',
       'findings',
       'lanes',
+      'lessonsConsulted',
       'panelArtifactHash',
       'postChecks',
       'reviewedState',

--- a/packages/core/src/artifacts/verdict.ts
+++ b/packages/core/src/artifacts/verdict.ts
@@ -52,11 +52,17 @@ import {
   type PersistedPostCheckFinding,
   PersistedPostCheckFindingSchema,
 } from './panel.js';
+import type { GroundingBundle } from './schema.js';
 
 // ─── Schema version (mirrors RunArtifact / Panel F1) ────────────────────────
 
-/** The verdict schemaVersion WRITTEN by this code. Readers accept any 1.x (F1). */
-export const VERDICT_ARTIFACT_SCHEMA_VERSION = '1.0.0';
+/**
+ * The verdict schemaVersion WRITTEN by this code. Readers accept any 1.x (F1).
+ * 1.1.0 (mmnto-ai/totem#2363): additive-optional `lessonsConsulted` — the
+ * round's lesson-recall record. The minor is the observable marker; the
+ * registry stays empty because the tolerant reader parses both.
+ */
+export const VERDICT_ARTIFACT_SCHEMA_VERSION = '1.1.0';
 
 /** The major this reader understands; other majors need a migration entry. */
 export const VERDICT_ARTIFACT_KNOWN_MAJOR = 1;
@@ -257,6 +263,65 @@ export const VerdictFindingSchema = z.object({
 });
 export type VerdictFinding = z.infer<typeof VerdictFindingSchema>;
 
+// ─── Lessons consulted (mmnto-ai/totem#2363) ─────────────────────────────────
+
+/**
+ * One lesson delivered into the round's shared lane prompt — identity only
+ * (`contentHash` over the delivered snippet + repo-relative `filePath`,
+ * mirroring {@link GroundingItemSchema} identity semantics), never content
+ * bytes. `sourceRepo` names a linked index for cross-repo hits; ABSENT = the
+ * run's own repo.
+ */
+export const LessonConsultedItemSchema = z.object({
+  contentHash: Sha256HexSchema,
+  filePath: z.string().trim().min(1),
+  sourceRepo: z.string().trim().min(1).optional(),
+});
+export type LessonConsultedItem = z.infer<typeof LessonConsultedItemSchema>;
+
+/**
+ * The round's lesson-recall record (mmnto-ai/totem#2363, strategy#474
+ * grounding lever): which lessons the retrieval delivered into the shared
+ * per-lane prompt, and whether recall hit at all. One field per VERDICT, not
+ * per lane — identical-kit discipline means every lane received the same
+ * retrieval, so a per-lane copy would be a mirrored count.
+ *
+ * Three observable states, honest-absent by construction:
+ *   - field ABSENT — the producer performed no lesson retrieval (pre-1.1
+ *     artifacts, or a path without index retrieval); never fabricated.
+ *   - `status: 'empty'` — retrieval RAN and returned zero lessons: the
+ *     visibly-ungrounded state the strategy#474 abstain-on-empty rule needs
+ *     to be checkable.
+ *   - `status: 'hit'` — ≥1 lesson delivered; `items` carries identities.
+ *
+ * `status` ⟺ `items` consistency is enforced in the artifact `superRefine`
+ * (never mirrored on trust). Per-lane delivery provenance stays one hop away
+ * in each lane's run-artifact grounding bundle; this field is the round-level
+ * contract line so recall can never silently drop out of the redesign.
+ */
+export const LessonsConsultedSchema = z.object({
+  status: z.enum(['hit', 'empty']),
+  items: z.array(LessonConsultedItemSchema),
+});
+export type LessonsConsulted = z.infer<typeof LessonsConsultedSchema>;
+
+/**
+ * Derive the round-level recall record from the grounding bundle the runner
+ * delivered to its lanes (single home for the mapping — every future runner
+ * derives, never hand-builds). `lesson`-partition items only; identity fields
+ * pass through verbatim.
+ */
+export function deriveLessonsConsulted(bundle: GroundingBundle): LessonsConsulted {
+  const items = bundle.items
+    .filter((i) => i.sourceType === 'lesson')
+    .map((i) => ({
+      contentHash: i.contentHash,
+      filePath: i.filePath,
+      ...(i.sourceRepo !== undefined ? { sourceRepo: i.sourceRepo } : {}),
+    }));
+  return { status: items.length > 0 ? 'hit' : 'empty', items };
+}
+
 // ─── Round / lineage ─────────────────────────────────────────────────────────
 
 /**
@@ -390,6 +455,13 @@ export const VerdictArtifactSchema = z
     findings: z.array(VerdictFindingSchema),
     /** A SINGLE top-level panel-diversity summary (classifyDiversity output) — present only with a panel; NEVER mirrored per finding. */
     diversity: PanelDiversitySchema.optional(),
+    /**
+     * The round's lesson-recall record (mmnto-ai/totem#2363) — see
+     * {@link LessonsConsultedSchema}. Additive-optional 1.x (F1): pre-1.1
+     * artifacts predate it, and a producer that performed no retrieval omits
+     * it (honest-absent) rather than fabricating an `empty`.
+     */
+    lessonsConsulted: LessonsConsultedSchema.optional(),
     round: VerdictRoundSchema,
     /**
      * Post-fan tree compare against the PRE-fan content hash (codex rev-2 fold 1):
@@ -492,6 +564,19 @@ export const VerdictArtifactSchema = z
         path: ['round', 'priorVerdictHash'],
         message: `round ${a.round.index} (>0) requires priorVerdictHash linking the prior round in the chain`,
       });
+    }
+
+    // ── mmnto-ai/totem#2363: lessonsConsulted status ⟺ items (never mirrored on trust) ──
+    if (a.lessonsConsulted !== undefined) {
+      const hasItems = a.lessonsConsulted.items.length > 0;
+      const claimsHit = a.lessonsConsulted.status === 'hit';
+      if (claimsHit !== hasItems) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['lessonsConsulted', 'status'],
+          message: `lessonsConsulted.status "${a.lessonsConsulted.status}" must match items (${a.lessonsConsulted.items.length}) — 'hit' ⟺ at least one item; the status is never mirrored on trust`,
+        });
+      }
     }
 
     // ── Finding 5: the persisted boundary re-derives `settled`, never trusts it ──

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -677,6 +677,8 @@ export {
 } from './artifacts/panel.js';
 // Verdict artifact — the single lane-convergence point (mmnto-ai/totem#2106, Prop 302/304 R2)
 export type {
+  LessonConsultedItem,
+  LessonsConsulted,
   LineageKeyInput,
   SaveVerdictArtifactResult,
   VerdictArtifact,
@@ -695,9 +697,12 @@ export {
   computeLineageKey,
   computeVerdictArtifactContentHash,
   deriveCacheEligible,
+  deriveLessonsConsulted,
   deriveSettled,
   findLatestVerdictForLineage,
   LaneIdSchema,
+  LessonConsultedItemSchema,
+  LessonsConsultedSchema,
   listVerdictArtifacts,
   loadVerdictArtifact,
   renderCovariateLine,


### PR DESCRIPTION
Closes #2363 · Part of #2106 (Prop 302 verdict contract) · strategy#474 grounding lever

## Premise correction, recorded first

The ticket (and my own journal from the 1821Z triage) claimed the redesigned runner has no lesson recall — "the legacy grounding silently drops out of the redesign." **That premise is falsified at HEAD**: the fan is dispatched from inside the standard shield path *after* `retrieveContext` → `assemblePrompt` (`shield.ts:1738–1798`), so every lane's prompt already carries the lesson checklist section, and every lane's run artifact already records lesson grounding (`buildRetrievalGroundingBundle` classes `sourceType: 'lesson'`). The original claim over-read a file-scoped grep of `review-fan.ts` into a path-scoped conclusion — the retrieval lives one call above, in the shared path.

What remains true — and is what this PR builds: the verdict **contract** had no recall line. A consumer couldn't read recall status off the verdict without chasing per-lane run artifacts, and a future runner change could drop retrieval without violating any contract. The ticket's four benefits all attach to the contract pin, so the requirement stands; the implementation is a **derivation**, not a retrieval port.

## What ships

- **Verdict schema 1.1.0** (additive-optional per the F1 evolution policy; the minor is the observable marker, mirroring run-artifact 1.1.0): `lessonsConsulted: { status: 'hit' | 'empty', items: [{ contentHash, filePath, sourceRepo? }] }` — identity-only, mirroring grounding-item semantics; no content bytes.
- **Three observable states, honest-absent:** field ABSENT = producer performed no retrieval (pre-1.1 artifacts; never fabricated) · `empty` = retrieval ran, zero lessons — the visibly-ungrounded state that makes the strategy#474 abstain-on-empty rule checkable · `hit` = identities carried.
- **`status` ⟺ `items` enforced in the artifact `superRefine`** — never mirrored on trust, same doctrine as the count checks.
- **One field per verdict, not per lane** — identical-kit discipline makes recall a round-level fact; per-lane delivery provenance stays one hop away via `lanes[].runArtifactHash`.
- **`deriveLessonsConsulted(bundle)`** exported from core (root barrel + `@mmnto/totem/artifacts`): single home for the bundle→record mapping. The fan derives it from the same `groundingBundle` its lanes carry and emits it on every verdict.
- **Lane-blindness key-set structural test updated deliberately** — the new key is recall telemetry with a backend-free vocabulary (`hit`/`empty` + content identities); it carries no runner-mode channel.

## Tests

Core: key-set update; hit/empty/absent acceptance; mirrored-status rejection (both directions); sha256 guard; `deriveLessonsConsulted` partition-filter + identity-passthrough + empty units. CLI: `assembleVerdict` carries/omits the field (honest-absent, key omitted — not an empty object); two e2e runs assert the **persisted** verdict records `hit` (lesson items only, code excluded) and `empty` (zero-lesson bundle still emits the field). The three behavior tests **verified failing against unfixed code** (stash-and-rerun).

## Gates

Full core suite 3200/3200; full cli suite 3189/3189; workspace build green; repo-wide prettier clean; ESLint 0 errors; `totem lint` PASS 0 errors (5 advisory warning-tier matcher hits on new lines — the #2063 imprecise-matcher class, incl. the zod `.min` matcher firing on the already-compliant `.trim().min(1)` form). Changeset: minor ×2.

## Downstream note (531 copy constraint)

The standing #531 split-register copy constraint ("review-lanes lesson-retrieval is NOT live until #2363 builds") was premised on the falsified claim above. With recall verified live on the fan path AND now contract-pinned, the conformance-review mechanism claim upgrades on both halves once this merges — I'll dispatch the correction to strategy-claude, whose A1 draft consumes that constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
