### PR TITLE
chore(lessons): commit the TOTEM-SWEEP-001 lesson bank (12 lessons)

### DIFF
--- a/.totem/lessons/lesson-1f5e358d.md
+++ b/.totem/lessons/lesson-1f5e358d.md
@@ -1,0 +1,9 @@
+## Lesson — A declined bot finding must be excluded from lesson/rule
+
+**Tags:** review-learn, dispositions, training-data-hygiene, bot-review, genuine-domain
+
+**Applies-to:** boundary
+
+A declined bot finding must be excluded from lesson/rule extraction, retain its explicit disposition, and surface an auditable breadcrumb instead of being silently treated as resolved. (Sweep TOTEM-SWEEP-012; anchor: #2128 laundered declines, fixed @ af21102d.)
+
+**Source:** mcp (added at 2026-07-12T03:09:29.214Z)

--- a/.totem/lessons/lesson-27aecc7e.md
+++ b/.totem/lessons/lesson-27aecc7e.md
@@ -1,0 +1,9 @@
+## Lesson — Well-form every rule-authored or user-authored string
+
+**Tags:** sarif, unicode, serialization, ci, genuine-domain
+
+**Applies-to:** boundary
+
+Well-form every rule-authored or user-authored string embedded in SARIF; JSON serialization success alone does not guarantee that GitHub's SARIF re-serializer will accept unpaired UTF-16 surrogates. (Sweep TOTEM-SWEEP-006; anchor: #2296 silent rejections, fixed #2300 @ bb9d2215.)
+
+**Source:** mcp (added at 2026-07-12T03:08:26.740Z)

--- a/.totem/lessons/lesson-3785a3b8.md
+++ b/.totem/lessons/lesson-3785a3b8.md
@@ -1,0 +1,9 @@
+## Lesson — A current package/version pin does not prove distributed
+
+**Tags:** parity, packaging, content-integrity, doctor, genuine-domain
+
+**Applies-to:** boundary
+
+A current package/version pin does not prove distributed artifact content; verify packaged artifacts against their own lock first, then compare to a local canonical source only when that source exists, reporting each layer separately. (Sweep TOTEM-SWEEP-016; anchor: #2256 @ d0236efd — pin currency, packaged self-consistency, and optional canonical comparison are three separate parity dimensions.)
+
+**Source:** mcp (added at 2026-07-12T03:09:48.744Z)

--- a/.totem/lessons/lesson-4f7f1efd.md
+++ b/.totem/lessons/lesson-4f7f1efd.md
@@ -1,0 +1,9 @@
+## Lesson — A processed mark is collectable only after a declared,
+
+**Tags:** ecl, gc, compaction, completeness-proof, genuine-domain
+
+**Applies-to:** mutator
+
+A processed mark is collectable only after a declared, non-empty cohort roster is fully scanned and every relevant peer cursor/horizon proves the mark inert; truncation, warnings, collisions, or missing roster must close the gate rather than guess. (Sweep TOTEM-SWEEP-002; anchor: #2309 @ cad2f30e, roster correction #2315.)
+
+**Source:** mcp (added at 2026-07-12T03:08:06.199Z)

--- a/.totem/lessons/lesson-6551881c.md
+++ b/.totem/lessons/lesson-6551881c.md
@@ -1,0 +1,9 @@
+## Lesson — A certifying run and its freeze must verify the digest
+
+**Tags:** certification, integrity, digest-enforcement, spine, genuine-domain
+
+**Applies-to:** boundary, infrastructure
+
+A certifying run and its freeze must verify the digest of every mutable evidence input when consuming it; merely storing a digest in a lock is not enforcement. (Sweep TOTEM-SWEEP-009; anchors: #2227 @ df843869 for PR diffs, #2235 @ b07347e7 for ground-truth labels — the store-vs-enforce distinction recurred across both.)
+
+**Source:** mcp (added at 2026-07-12T03:08:56.988Z)

--- a/.totem/lessons/lesson-749e1864.md
+++ b/.totem/lessons/lesson-749e1864.md
@@ -1,0 +1,9 @@
+## Lesson — Deterministic replay must distinguish a missing key
+
+**Tags:** replay, fixtures, determinism, spine, genuine-domain
+
+**Applies-to:** infrastructure
+
+Deterministic replay must distinguish a missing key from a recorded empty/error-default result and must reject duplicate keys, wrong adapter kind, schema mismatch, and fixture-integrity mismatch before replaying. (Sweep TOTEM-SWEEP-008; anchor: #2209 pre-build findings, scaffold @ 5ced63b5.)
+
+**Source:** mcp (added at 2026-07-12T03:08:47.436Z)

--- a/.totem/lessons/lesson-9704df2b.md
+++ b/.totem/lessons/lesson-9704df2b.md
@@ -1,0 +1,9 @@
+## Lesson — Never accept persisted derived counts, labels, or rollups
+
+**Tags:** schema, derived-fields, anti-tamper, read-boundary, predictable-robustness
+
+**Applies-to:** boundary, aggregator
+
+Never accept persisted derived counts, labels, or rollups on trust; recompute them from the primitive arrays at schema parse/read time and reject any mismatch. (Sweep TOTEM-SWEEP-007, reclassed lesson-tier per strategy curation — not mechanically checkable; anchor: #2179 bot rounds, hardened @ edde219b. Same invariant independently re-derived for verdict artifacts in #2337.)
+
+**Source:** mcp (added at 2026-07-12T03:08:37.890Z)

--- a/.totem/lessons/lesson-c4aef73d.md
+++ b/.totem/lessons/lesson-c4aef73d.md
@@ -1,0 +1,9 @@
+## Lesson — When selecting the "most recent N" commits from Git
+
+**Tags:** git, topo-order, bounded-windows, predictable-robustness, advisory-rule-candidate
+
+**Applies-to:** infrastructure
+
+When selecting the "most recent N" commits from Git history, never rely on default commit-date order; request `git log --topo-order` and slice the ancestry-ordered list. Exception: unbounded queries over the complete reachable set, or windows explicitly defined by wall-clock dates. (Sweep TOTEM-SWEEP-010; anchor: #2197 @ 47a1fd39. Flagged for the ADR-111 mint path when the miner picks up candidates — its miss corpus must include explicitly wall-clock-defined windows.)
+
+**Source:** mcp (added at 2026-07-12T03:09:07.634Z)

--- a/.totem/lessons/lesson-c6cc02e1.md
+++ b/.totem/lessons/lesson-c6cc02e1.md
@@ -1,0 +1,9 @@
+## Lesson — Never emit an unqualified clean/pass verdict when any entry
+
+**Tags:** sensors, coverage-honesty, partial-verdict, denominators, predictable-robustness
+
+**Applies-to:** presentation, boundary
+
+Never emit an unqualified clean/pass verdict when any entry was unresolved or unscanned; state "partial," count the omissions, and list enough evidence to recover coverage. (Sweep TOTEM-SWEEP-014, reclassed lesson-tier per strategy curation — not mechanically checkable; anchor: #2330 @ f253f30d, the VP-PR cut sensor's visible-unscanned-entries defect. Clusters with lesson-708dd711 and lesson-eb931855 — Tenet-21 consolidation candidate when the cluster next surfaces.)
+
+**Source:** mcp (added at 2026-07-12T03:09:39.265Z)

--- a/.totem/lessons/lesson-cbe0ef9f.md
+++ b/.totem/lessons/lesson-cbe0ef9f.md
@@ -1,0 +1,9 @@
+## Lesson — Integration tests for failure sensors must assert
+
+**Tags:** testing, integration-tests, false-green, exit-codes, predictable-robustness
+
+**Applies-to:** boundary-test
+
+Integration tests for failure sensors must assert the intended semantic evidence and reject known wrong-reason errors before asserting the generic nonzero exit code; fixtures must seed all required configuration and enter through the current public command. (Sweep TOTEM-SWEEP-005; anchor: #2320 exhibit, fixed #2326 @ d1e9dc20.)
+
+**Source:** mcp (added at 2026-07-12T03:08:15.634Z)

--- a/.totem/lessons/lesson-ce13493d.md
+++ b/.totem/lessons/lesson-ce13493d.md
@@ -1,0 +1,9 @@
+## Lesson — An incremental index must derive deletions
+
+**Tags:** indexing, incremental-sync, reconciliation, orphans, predictable-robustness
+
+**Applies-to:** mutator, infrastructure
+
+An incremental index must derive deletions by reconciling indexed keys against the current target set; a diff window cannot recover deletes, renames, ignore changes, or de-targeting that occurred before its baseline, and purge-only runs must rebuild dependent indexes. (Sweep TOTEM-SWEEP-011; anchor: #2174 orphan chunks, fixed @ 7179daa2.)
+
+**Source:** mcp (added at 2026-07-12T03:09:18.219Z)

--- a/.totem/lessons/lesson-cec2e452.md
+++ b/.totem/lessons/lesson-cec2e452.md
@@ -1,0 +1,9 @@
+## Lesson — When a basename is reused as a shared handled-marker key,
+
+**Tags:** ecl, mail, identity, collision, genuine-domain
+
+**Applies-to:** boundary
+
+When a basename is reused as a shared handled-marker key, detect distinct writers before treating the basename as unique; derive writer identity from the owning outbox directory, not a forgeable `from:` field. (Sweep TOTEM-SWEEP-001; anchor: #2311 hazard, fixed #2321 @ 2b142281.)
+
+**Source:** mcp (added at 2026-07-12T03:07:56.572Z)


### PR DESCRIPTION
Commits the **TOTEM-SWEEP-001 lesson bank** — 12 lessons banked 2026-07-12 from the lesson-sweep-totem heavy-lift (strategy-claude contract → totem-codex proposals → totem-claude adjudication) that have sat untracked in the working tree for three sessions. Operator-ruled disposition: commit the bank, delete the working doc.

## Why commit

Untracked, the corpus is invisible to CI and to the index on any other clone, and one `git clean` away from loss. Several of these lessons are the exact incident classes later shipped as fixes (derived-counts-never-trusted → the verdict superRefine doctrine; basename-marker collisions → #2311/#2364; incremental-index deletion derivation → #2366), so they are the provenance record for live mechanism.

## The 12

| Lesson | Gist |
|---|---|
| `1f5e358d` | A declined bot finding must be excluded from lesson/rule extraction input |
| `27aecc7e` | Well-form every rule-authored or user-authored string |
| `3785a3b8` | A current package/version pin does not prove distributed state |
| `4f7f1efd` | A processed mark is collectable only after a declared, complete roster scan |
| `6551881c` | A certifying run and its freeze must verify the digest they certify |
| `749e1864` | Deterministic replay must distinguish a missing key from a null value |
| `9704df2b` | Never accept persisted derived counts, labels, or rollups on trust |
| `c4aef73d` | Selecting the "most recent N" commits from Git needs an explicit ordering contract |
| `c6cc02e1` | Never emit an unqualified clean/pass verdict when any entry was skipped |
| `cbe0ef9f` | Integration tests for failure sensors must assert the failure actually fires |
| `ce13493d` | An incremental index must derive deletions, not only additions |
| `cec2e452` | A basename reused as a shared handled-marker key silently shadows collisions |

## Freeze safety

Nothing here compiles. The rule-compilation freeze (2026-05-17) is untouched: these lessons were never run through `lesson compile`, appear in no compile-manifest input set, and serve the retrieval index as-is. The lint staleness sensor ("lessons changed since last compile") is advisory by design and remains an honest description of frozen state. No changeset — repo corpus, not published package content.

Also in this disposition (operator-named): `temp/lesson-sweep/totem.md` — the sweep's working document these 12 were distilled from — deleted from the working tree (it was never tracked, so it carries no diff here).

## Gates

Repo-wide prettier clean; `totem lint` no violations (the #2365 diff-filter disclosure names all 12 files as index-scoped, as designed); pre-push hook gate passed on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
