### PR TITLE
fix(sync): incremental sync reconciles ignore-pattern removals — exclusion-set hash + newly-eligible enqueue (#2366)

### DIFF
--- a/.changeset/sync-ignore-removal-reconciliation.md
+++ b/.changeset/sync-ignore-removal-reconciliation.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/totem': patch
+---
+
+fix(sync): incremental sync now reconciles ignore-pattern REMOVALS, not just additions (mmnto-ai/totem#2366).
+
+Removing a pattern from `ignorePatterns` / `indexIgnorePatterns` makes previously-excluded files index-eligible, but incremental sync only re-embedded files the git diff reported as changed — so a newly-eligible file whose bytes were unchanged since the last sync stayed out of the index until a full sync or an unrelated edit. The addition direction already self-healed via orphan reconciliation; this adds the symmetric mechanism. Sync state now persists an order-normalized hash of the effective exclusion set, and on the next incremental sync a hash change (or its absence, for state written before this fix) enqueues the newly-eligible set (live files not yet indexed), reusing the indexed-path read the orphan pass already performs. Reordering patterns is not treated as a change, and an unchanged exclusion set adds no extra work.
+
+Consumer-impact: incremental sync only — after an ignore-pattern edit, files that became eligible are re-indexed on the next sync instead of lagging until a full rebuild. The `.totem/cache/sync-state.json` file gains an optional `indexExclusionHash` field; older state without it is read normally (treated as a one-time exclusion-set mismatch, which is a near-empty enqueue for an up-to-date index). No migration required.

--- a/packages/core/src/ingest/pipeline.test.ts
+++ b/packages/core/src/ingest/pipeline.test.ts
@@ -9,7 +9,9 @@ import { TotemConfigSchema } from '../config-schema.js';
 import { cleanTmpDir } from '../test-utils.js';
 import {
   buildIndexManifest,
+  computeNewlyEligiblePaths,
   computeOrphanPaths,
+  hashIndexExclusionSet,
   INDEX_MANIFEST_SCHEMA,
   runSync,
 } from './pipeline.js';
@@ -111,6 +113,70 @@ describe('orphan reconciliation (computeOrphanPaths)', () => {
     // The inputs are the indexed set and the working tree, never changedPaths,
     // so an empty diff window cannot hide an orphan.
     expect(computeOrphanPaths(['src/orphan.ts'], ['src/kept.ts'])).toEqual(['src/orphan.ts']);
+  });
+});
+
+describe('index-exclusion hash (hashIndexExclusionSet) — #2366', () => {
+  it('(d) reordering patterns does NOT change the hash (order-normalized)', () => {
+    // A config reorder must not read as an exclusion-set change and trigger a
+    // spurious newly-eligible re-enqueue.
+    expect(hashIndexExclusionSet(['a/**', 'b/**', 'c/**'])).toBe(
+      hashIndexExclusionSet(['c/**', 'a/**', 'b/**']),
+    );
+  });
+
+  it('a membership change (a removed pattern) DOES change the hash', () => {
+    expect(hashIndexExclusionSet(['dist/**', 'vendor/**'])).not.toBe(
+      hashIndexExclusionSet(['dist/**']),
+    );
+  });
+
+  it('an empty set hashes stably and differs from any non-empty set', () => {
+    expect(hashIndexExclusionSet([])).toBe(hashIndexExclusionSet([]));
+    expect(hashIndexExclusionSet([])).not.toBe(hashIndexExclusionSet(['dist/**']));
+  });
+});
+
+describe('newly-eligible reconciliation (computeNewlyEligiblePaths) — #2366', () => {
+  it('(a) a previously-ignored file that is now live but not indexed is enqueued', () => {
+    // vendor/lib.ts was excluded → never indexed; the pattern was removed → it is
+    // now in the live set. Its bytes are unchanged (absent from the git diff), so
+    // only the membership pass recovers it.
+    expect(computeNewlyEligiblePaths(['src/a.ts', 'vendor/lib.ts'], ['src/a.ts'])).toEqual([
+      'vendor/lib.ts',
+    ]);
+  });
+
+  it('(b) hash match → the reconciliation branch never runs; an up-to-date index yields nothing new', () => {
+    const patterns = ['dist/**', 'vendor/**'];
+    // Same effective set across syncs → hashes equal → runSync guards the branch off.
+    expect(hashIndexExclusionSet(patterns)).toBe(hashIndexExclusionSet([...patterns]));
+    // And even if it were evaluated, an up-to-date index (live ⊆ indexed) adds nothing.
+    expect(computeNewlyEligiblePaths(['src/a.ts', 'src/b.ts'], ['src/a.ts', 'src/b.ts'])).toEqual(
+      [],
+    );
+  });
+
+  it('(c) an absent stored hash is treated as a mismatch; on an up-to-date index the enqueue is empty', () => {
+    // Sync state predating #2366 has no indexExclusionHash; runSync compares
+    // `undefined !== currentHash`, which is a mismatch and triggers the pass.
+    const storedHash: string | undefined = undefined;
+    expect(storedHash !== hashIndexExclusionSet(['dist/**'])).toBe(true);
+    // The enqueue (live − indexed) is near-empty because everything is already indexed.
+    expect(computeNewlyEligiblePaths(['src/a.ts', 'src/b.ts'], ['src/a.ts', 'src/b.ts'])).toEqual(
+      [],
+    );
+  });
+
+  it('separator-normalized like the orphan pass: a backslash-indexed live file is not re-enqueued', () => {
+    expect(computeNewlyEligiblePaths(['src/live.ts'], ['src\\live.ts'])).toEqual([]);
+  });
+
+  it('returns raw live paths so the caller re-embeds via the resolved file record', () => {
+    expect(computeNewlyEligiblePaths(['docs/new.md', 'src/a.ts'], [])).toEqual([
+      'docs/new.md',
+      'src/a.ts',
+    ]);
   });
 });
 

--- a/packages/core/src/ingest/pipeline.test.ts
+++ b/packages/core/src/ingest/pipeline.test.ts
@@ -157,12 +157,15 @@ describe('newly-eligible reconciliation (computeNewlyEligiblePaths) — #2366', 
     );
   });
 
-  it('(c) an absent stored hash is treated as a mismatch; on an up-to-date index the enqueue is empty', () => {
+  it('(c) an absent stored hash is treated as a mismatch — the first-run scan recovers unindexed files and is benign when up to date', () => {
     // Sync state predating #2366 has no indexExclusionHash; runSync compares
-    // `undefined !== currentHash`, which is a mismatch and triggers the pass.
-    const storedHash: string | undefined = undefined;
-    expect(storedHash !== hashIndexExclusionSet(['dist/**'])).toBe(true);
-    // The enqueue (live − indexed) is near-empty because everything is already indexed.
+    // `undefined !== currentHash` → mismatch → the newly-eligible pass runs.
+    // On a partially-unindexed tree that one-time scan recovers exactly the gap…
+    expect(computeNewlyEligiblePaths(['src/a.ts', 'docs/uncovered.md'], ['src/a.ts'])).toEqual([
+      'docs/uncovered.md',
+    ]);
+    // …and on an up-to-date index (live ⊆ indexed) the enqueue is empty, so the
+    // absent-hash mismatch costs existing consumers nothing.
     expect(computeNewlyEligiblePaths(['src/a.ts', 'src/b.ts'], ['src/a.ts', 'src/b.ts'])).toEqual(
       [],
     );

--- a/packages/core/src/ingest/pipeline.ts
+++ b/packages/core/src/ingest/pipeline.ts
@@ -249,6 +249,8 @@ export function computeOrphanPaths(
  * convention shared with run artifacts.
  */
 export function hashIndexExclusionSet(patterns: string[]): string {
+  // calculateDeterministicHash treats array order as significant — the .sort()
+  // here IS the order-independence invariant. Do not remove or move it.
   return calculateDeterministicHash([...patterns].sort());
 }
 

--- a/packages/core/src/ingest/pipeline.ts
+++ b/packages/core/src/ingest/pipeline.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { calculateDeterministicHash } from '../artifacts/hash.js';
 import { createChunker } from '../chunkers/chunker.js';
 import type { TotemConfig } from '../config-schema.js';
 import { requireEmbedding } from '../config-schema.js';
@@ -238,6 +239,36 @@ export function computeOrphanPaths(
   return indexedRawPaths.filter((raw) => !live.has(normalizeRel(raw)));
 }
 
+/**
+ * Order-normalized content hash of the effective index-exclusion set
+ * (`ignorePatterns` ∪ `indexIgnorePatterns`). Patterns are sorted before hashing
+ * so reordering the config is not a spurious mismatch — only a membership change
+ * (a pattern added or removed) moves the hash. Persisted in sync state to detect
+ * ignore-pattern REMOVALS between incremental syncs (mmnto-ai/totem#2366), which
+ * the git-diff window alone never surfaces. Uses the one deterministic-hash
+ * convention shared with run artifacts.
+ */
+export function hashIndexExclusionSet(patterns: string[]): string {
+  return calculateDeterministicHash([...patterns].sort());
+}
+
+/**
+ * Files that are index-eligible now but absent from the index — the symmetric
+ * complement of {@link computeOrphanPaths} (mmnto-ai/totem#2366). Removing an
+ * ignore pattern makes files eligible without changing their bytes, so the git
+ * diff window never reports them; this recovers them by membership alone
+ * (live-vs-indexed), independent of the diff. Compares on a separator-normalized
+ * key like the orphan pass but RETURNS THE RAW live relative path (the caller
+ * re-embeds via the resolved file record).
+ */
+export function computeNewlyEligiblePaths(
+  liveRelativePaths: string[],
+  indexedRawPaths: string[],
+): string[] {
+  const indexed = new Set(indexedRawPaths.map(normalizeRel));
+  return liveRelativePaths.filter((rel) => !indexed.has(normalizeRel(rel)));
+}
+
 async function runSyncInner(
   config: TotemConfig,
   options: SyncOptions,
@@ -274,24 +305,24 @@ async function runSyncInner(
   // `ignorePatterns` (legacy dual-scope) + `indexIgnorePatterns` (index-only,
   // mmnto-ai/totem#1748) — only the former also gates lint/shield scope.
   const totemDir = path.join(projectRoot, config.totemDir);
-  const allFiles = resolveFiles(
-    config.targets,
-    projectRoot,
-    [...config.ignorePatterns, ...config.indexIgnorePatterns],
-    log,
-  );
+  const exclusionPatterns = [...config.ignorePatterns, ...config.indexIgnorePatterns];
+  const allFiles = resolveFiles(config.targets, projectRoot, exclusionPatterns, log);
+  // Order-normalized hash of the effective exclusion set — persisted below and
+  // compared on the next incremental sync to catch pattern REMOVALS (#2366).
+  const indexExclusionHash = hashIndexExclusionSet(exclusionPatterns);
   let filesToProcess: ResolvedFile[];
   let deletedPaths: string[] = [];
 
   if (incremental) {
+    // Persisted sync state carries both the diff baseline (lastSyncSha) and the
+    // exclusion-set hash used for removal reconciliation (mmnto-ai/totem#2366).
+    const syncState = readSyncState(totemDir, log);
+
     // Determine the ref to diff against: saved sync state > fallback HEAD~1
     let sinceRef = 'HEAD~1';
-    if (!options.changedFiles) {
-      const syncState = readSyncState(totemDir, log);
-      if (syncState) {
-        sinceRef = syncState.lastSyncSha;
-        log(`Resuming from last sync at ${sinceRef.slice(0, 8)}...`);
-      }
+    if (!options.changedFiles && syncState) {
+      sinceRef = syncState.lastSyncSha;
+      log(`Resuming from last sync at ${sinceRef.slice(0, 8)}...`);
     }
 
     const changedPaths = options.changedFiles ?? getChangedFiles(projectRoot, sinceRef, log);
@@ -302,20 +333,34 @@ async function runSyncInner(
       log(`Full sync (fallback): ${filesToProcess.length} files to process`);
     } else {
       const changedSet = new Set(changedPaths);
+      let newlyEligible = new Set<string>();
 
-      // Re-embed stays diff-scoped: only changed files that still exist.
-      filesToProcess = allFiles.filter((f) => changedSet.has(f.relativePath));
-
-      // Deletion is reconciliation-based, NOT diff-derived (mmnto-ai/totem#2151):
-      // purge any indexed path no longer in the working tree, regardless of the
-      // git diff window — self-heals deletions, renames-into-ignored, and
-      // de-targeted files even after the baseline advanced past them. On read
-      // failure, skip the purge this run (warn, no false purge); a later sync heals.
+      // Reconciliation is NOT diff-derived (mmnto-ai/totem#2151, #2366): both the
+      // orphan purge and the newly-eligible enqueue below read the indexed set
+      // once and compare against the live tree, independent of the git diff
+      // window. On a getDistinctPaths read failure, skip BOTH this run (warn, no
+      // false purge / no spurious enqueue); a later sync reconciles.
       try {
-        deletedPaths = computeOrphanPaths(
-          await store.getDistinctPaths(),
-          allFiles.map((f) => f.relativePath),
-        );
+        const indexedPaths = await store.getDistinctPaths();
+        const liveRelPaths = allFiles.map((f) => f.relativePath);
+
+        // Deletion (ADDITION direction): purge any indexed path no longer in the
+        // working tree — self-heals deletions, renames-into-ignored, and
+        // de-targeted / newly-ignored files even after the baseline advanced past
+        // them.
+        deletedPaths = computeOrphanPaths(indexedPaths, liveRelPaths);
+
+        // Ignore-pattern REMOVAL reconciliation: symmetric to the orphan pass. A
+        // pattern removed from the exclusion set makes files index-eligible
+        // without changing their bytes, so the diff window never surfaces them. A
+        // change in the stored order-normalized exclusion hash — or its ABSENCE
+        // (state predating #2366) — enqueues the newly-eligible set (live −
+        // indexed). The union naturally reduces to the diff alone when the
+        // exclusion set is unchanged, and on a pure ADDITION the newly-eligible
+        // files are all already in the changed set.
+        if (syncState?.indexExclusionHash !== indexExclusionHash) {
+          newlyEligible = new Set(computeNewlyEligiblePaths(liveRelPaths, indexedPaths));
+        }
         // totem-context: intentional warn+skip on a getDistinctPaths read failure (mmnto-ai/totem#2151 Q3, cohort-endorsed) — never a false purge; a later sync reconciles, and the Warning below means it is not silent degradation.
       } catch (err) {
         log(
@@ -323,8 +368,20 @@ async function runSyncInner(
         );
       }
 
+      // Re-embed the changed files (diff-scoped) UNION the newly-eligible set an
+      // ignore-pattern removal exposed (#2366); every path in either set still
+      // exists (both derive from allFiles / the live tree).
+      filesToProcess = allFiles.filter(
+        (f) => changedSet.has(f.relativePath) || newlyEligible.has(f.relativePath),
+      );
+
+      // Count only the extras the exclusion-set change pulled back in (those not
+      // already surfaced by the diff), so the log reports honest reconciliation work.
+      const reconciledCount = [...newlyEligible].filter((rel) => !changedSet.has(rel)).length;
+
       log(
-        `Incremental sync: ${filesToProcess.length} changed files` +
+        `Incremental sync: ${filesToProcess.length} file(s) to process` +
+          (reconciledCount > 0 ? `, ${reconciledCount} newly-eligible` : '') +
           (deletedPaths.length > 0 ? `, ${deletedPaths.length} orphan candidate(s)` : '') +
           ` (of ${allFiles.length} total)`,
       );
@@ -453,9 +510,10 @@ async function runSyncInner(
     );
   }
 
-  // Persist sync state so next incremental sync knows where to diff from
+  // Persist sync state so the next incremental sync knows where to diff from and
+  // can detect an ignore-pattern change (including a removal) via the hash (#2366).
   if (headSha) {
-    writeSyncState(totemDir, { lastSyncSha: headSha, timestamp: Date.now() });
+    writeSyncState(totemDir, { lastSyncSha: headSha, timestamp: Date.now(), indexExclusionHash });
   }
 
   // Persist index metadata for dimension mismatch detection

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -138,6 +138,16 @@ export interface SyncOptions {
 export interface SyncState {
   lastSyncSha: string;
   timestamp: number;
+  /**
+   * Order-normalized content hash of the effective index-exclusion set
+   * (`ignorePatterns` ∪ `indexIgnorePatterns`) at the last sync. A change on the
+   * next incremental sync means the patterns moved — including a REMOVAL, which
+   * the git-diff window cannot surface — so the newly-eligible files are
+   * re-enqueued (mmnto-ai/totem#2366). Optional: absent in state written before
+   * #2366; readers treat absence as a mismatch (benign — the enqueue is
+   * near-empty for an up-to-date index).
+   */
+  indexExclusionHash?: string;
 }
 
 /**


### PR DESCRIPTION
Fixes #2366.

Incremental sync reconciled ignore-pattern **additions** (orphan purge, #2151) but not **removals**: a file that became index-eligible without a byte change was invisible to the git-diff window and stayed unindexed until a full sync.

## Mechanism (option B from the issue)

- `SyncState` gains an optional `indexExclusionHash` — an order-normalized content hash of `[...ignorePatterns, ...indexIgnorePatterns]`, computed with the existing `calculateDeterministicHash` (no new hashing primitive).
- On incremental sync, a hash mismatch — or an absent stored hash (state predating the field) — enqueues `computeNewlyEligiblePaths(live, indexed)`, the symmetric complement of `computeOrphanPaths`, reusing the same guarded `getDistinctPaths()` read the orphan pass already performs. On a read failure both reconciliations skip together (warn, never a false purge or spurious enqueue).
- The union reduces to the plain diff when the exclusion set is unchanged; pattern **reordering** is provably not a change (sorted before hashing); a pure pattern **addition** cannot cause a re-embed storm (live − indexed is near-empty on an up-to-date index).
- The hash persists in the same `writeSyncState` call both modes share. Older sync state reads normally — absence is a benign one-time mismatch. No migration.

## Verification

- 9 new tests (hash order-normalization, membership-change sensitivity, newly-eligible enqueue, hash-match no-op, absent-hash semantics, separator normalization, raw-path return). Pure-helper tests — no git spawned, no temp dirs.
- Full core suite 3209/3209; `pnpm -r build` green across all five packages; repo-wide format, ESLint, and `totem lint --base main` clean; pre-push hook suite (6651 tests) passed on push.
- Changeset: patch bump for `@mmnto/totem` with consumer-impact notes.

Implementation by an Opus 4.8 subagent under Fable drive; reviewed, gated, and pushed by totem-claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
