### PR TITLE
chore(cli): D1 description re-cut — strategy#531 A1 tagline convergence

### DIFF
--- a/.changeset/d1-tagline-recut.md
+++ b/.changeset/d1-tagline-recut.md
@@ -1,0 +1,11 @@
+---
+'@mmnto/totem': patch
+'@mmnto/mcp': patch
+'@mmnto/cli': patch
+---
+
+chore(descriptions): D1 tagline re-cut, family-wide — the mmnto-ai/totem-strategy#531 A1 tagline convergence (blind-gate release comment 4979503772 + operator veto-edit 2026-07-15) supersedes the Prop 294 D1 headline across the published package family.
+
+New ruled core: "local-first toolkit that keeps AI-agent work queryable, enforceable, and derivable as plain files in your codebase". Retires "substrate" from public copy (plain-words ruling) and the em-dash (veto-edit) on every npm-visible description surface: the CLI's single-sourced constant (`--help` header + `@mmnto/cli` package.json), `@mmnto/totem` + `@mmnto/mcp` package.json descriptions, and all three per-package README ledes. Parity tests re-pin the new core and add substrate/em-dash regression guards.
+
+Consumer-impact: npm registry metadata and rendered README pages only; no runtime code paths change.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,6 +1,6 @@
 # @mmnto/cli
 
-Command-line interface for [Totem](https://github.com/mmnto-ai/totem) — a local-first, file-anchored substrate that makes AI-agent work queryable, enforceable, and derivable in your codebase. Installs the `totem` binary.
+Command-line interface for [Totem](https://github.com/mmnto-ai/totem), the local-first toolkit that keeps AI-agent work queryable, enforceable, and derivable as plain files in your codebase. Installs the `totem` binary.
 
 ## Install
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mmnto/cli",
   "version": "1.98.0",
-  "description": "Totem — a local-first, file-anchored substrate that makes AI-agent work queryable, enforceable, and derivable in your codebase",
+  "description": "Totem: local-first toolkit that keeps AI-agent work queryable, enforceable, and derivable as plain files in your codebase",
   "type": "module",
   "engines": {
     "node": ">=24"

--- a/packages/cli/src/description.test.ts
+++ b/packages/cli/src/description.test.ts
@@ -17,13 +17,17 @@ describe('CLI self-description parity (mmnto-ai/totem#2336 D1)', () => {
     expect(pkg.description).toBe(TOTEM_DESCRIPTION);
   });
 
-  it('carries the ruled descriptive core (Prop 294 D1 headline)', () => {
-    // The exact ruled string; the product-name prefix is permitted, the core is not.
+  it('carries the ruled descriptive core (strategy#531 A1 tagline convergence)', () => {
+    // The exact ruled string (mmnto-ai/totem-strategy#531 gate release comment
+    // 4979503772 + operator veto-edit 2026-07-15, superseding the Prop 294 D1
+    // headline); the product-name prefix is permitted, the core is not.
     expect(TOTEM_DESCRIPTION).toContain(
-      'a local-first, file-anchored substrate that makes AI-agent work queryable, enforceable, and derivable in your codebase',
+      'local-first toolkit that keeps AI-agent work queryable, enforceable, and derivable as plain files in your codebase',
     );
-    // Guards against a regression to the retired category.
+    // Guards against regressions to retired vocabulary.
     expect(TOTEM_DESCRIPTION).not.toContain('persistent memory and context layer');
+    expect(TOTEM_DESCRIPTION).not.toContain('substrate');
+    expect(TOTEM_DESCRIPTION).not.toContain('—');
   });
 
   it('root help renders the constant as its header', () => {

--- a/packages/cli/src/description.ts
+++ b/packages/cli/src/description.ts
@@ -4,11 +4,13 @@
  * and the root `--help` header. A deterministic parity test (description.test.ts)
  * pins the package.json field === this constant so the surfaces never drift.
  *
- * Descriptive core sourced from Prop 294 D1 headline (ruled 2026-07-12; strategy
- * verdict on mmnto-ai/totem#2336 comment 4953017531). This is a drift-repair off
- * the retired "persistent memory and context layer" category, NOT freeform copy
- * authoring — if D1 ratification amends the wording, the re-cut is THIS one
- * constant. GitHub "About" is out of code reach; keep it in manual parity.
+ * Descriptive core re-cut per the mmnto-ai/totem-strategy#531 A1 tagline
+ * convergence (blind-gate release: mmnto-ai/totem-strategy#531 comment
+ * 4979503772; operator veto-edit 2026-07-15 removed the em-dash and retired
+ * "substrate" from public copy per the plain-words ruling). Supersedes the
+ * Prop 294 D1 headline cut (mmnto-ai/totem#2336 comment 4953017531). If a
+ * future ratification amends the wording, the re-cut is THIS one constant.
+ * GitHub "About" is out of code reach; keep it in manual parity.
  */
 export const TOTEM_DESCRIPTION =
-  'Totem — a local-first, file-anchored substrate that makes AI-agent work queryable, enforceable, and derivable in your codebase';
+  'Totem: local-first toolkit that keeps AI-agent work queryable, enforceable, and derivable as plain files in your codebase';

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,6 @@
 # @mmnto/totem
 
-Core engine for [Totem](https://github.com/mmnto-ai/totem) — a local-first, file-anchored substrate that makes AI-agent work queryable, enforceable, and derivable in your codebase. This is the library that [`@mmnto/cli`](https://www.npmjs.com/package/@mmnto/cli) and [`@mmnto/mcp`](https://www.npmjs.com/package/@mmnto/mcp) build on; most users want one of those instead.
+Core engine for [Totem](https://github.com/mmnto-ai/totem), the local-first toolkit that keeps AI-agent work queryable, enforceable, and derivable as plain files in your codebase. This is the library that [`@mmnto/cli`](https://www.npmjs.com/package/@mmnto/cli) and [`@mmnto/mcp`](https://www.npmjs.com/package/@mmnto/mcp) build on; most users want one of those instead.
 
 It contains the lesson parsing and compilation substrate, the deterministic rule engine (regex, Tree-sitter AST classification, ast-grep), the LanceDB-backed vector store, chunkers and embedders, and pack manifest helpers.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mmnto/totem",
   "version": "1.98.0",
-  "description": "Core engine for Totem — a local-first, file-anchored substrate that makes AI-agent work queryable, enforceable, and derivable in your codebase",
+  "description": "Core engine for Totem, the local-first toolkit that keeps AI-agent work queryable, enforceable, and derivable as plain files in your codebase",
   "type": "module",
   "engines": {
     "node": ">=24"

--- a/packages/core/src/description.test.ts
+++ b/packages/core/src/description.test.ts
@@ -14,9 +14,11 @@ describe('package self-description parity (mmnto-ai/totem#2336 D1 family alignme
     };
     expect(pkg.name).toBe('@mmnto/totem');
     expect(pkg.description).toContain(
-      'a local-first, file-anchored substrate that makes AI-agent work queryable, enforceable, and derivable in your codebase',
+      'local-first toolkit that keeps AI-agent work queryable, enforceable, and derivable as plain files in your codebase',
     );
-    // Guards against a regression to the retired category.
+    // Guards against regressions to retired vocabulary.
     expect(pkg.description).not.toContain('persistent memory and context layer');
+    expect(pkg.description).not.toContain('substrate');
+    expect(pkg.description).not.toContain('—');
   });
 });

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,6 +1,6 @@
 # @mmnto/mcp
 
-MCP (Model Context Protocol) server for [Totem](https://github.com/mmnto-ai/totem) — a local-first, file-anchored substrate that makes AI-agent work queryable, enforceable, and derivable in your codebase. A stdio-based server that exposes a Totem project's knowledge index to MCP-compatible agents. Installs the `totem-mcp` binary.
+MCP (Model Context Protocol) server for [Totem](https://github.com/mmnto-ai/totem), the local-first toolkit that keeps AI-agent work queryable, enforceable, and derivable as plain files in your codebase. A stdio-based server that exposes a Totem project's knowledge index to MCP-compatible agents. Installs the `totem-mcp` binary.
 
 ## Setup
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@mmnto/mcp",
   "version": "1.98.0",
-  "description": "MCP server for Totem — a local-first, file-anchored substrate that makes AI-agent work queryable, enforceable, and derivable in your codebase",
+  "description": "MCP server for Totem, the local-first toolkit that keeps AI-agent work queryable, enforceable, and derivable as plain files in your codebase",
   "type": "module",
   "engines": {
     "node": ">=24"

--- a/packages/mcp/src/description.test.ts
+++ b/packages/mcp/src/description.test.ts
@@ -14,9 +14,11 @@ describe('package self-description parity (mmnto-ai/totem#2336 D1 family alignme
     };
     expect(pkg.name).toBe('@mmnto/mcp');
     expect(pkg.description).toContain(
-      'a local-first, file-anchored substrate that makes AI-agent work queryable, enforceable, and derivable in your codebase',
+      'local-first toolkit that keeps AI-agent work queryable, enforceable, and derivable as plain files in your codebase',
     );
-    // Guards against a regression to the retired category.
+    // Guards against regressions to retired vocabulary.
     expect(pkg.description).not.toContain('persistent memory and context layer');
+    expect(pkg.description).not.toContain('substrate');
+    expect(pkg.description).not.toContain('—');
   });
 });


### PR DESCRIPTION
## What

The D1 description re-cut of the mmnto-ai/totem-strategy#531 A1 tagline convergence: one constant (`packages/cli/src/description.ts`), its parity pins, and the package.json field that follows it.

> Totem: local-first toolkit that keeps AI-agent work queryable, enforceable, and derivable as plain files in your codebase

## Why

The A1 blind-gate round judged the three discovery one-liners (README tagline, GitHub About, this constant) as ONE coherence set (release: mmnto-ai/totem-strategy#531 comment 4979503772). This surface carried the two retired elements: "substrate" (the plain-words ruling removed it from public copy) and the em-dash (operator veto-edit 2026-07-15). Supersedes the Prop 294 D1 headline cut (mmnto-ai/totem#2336 comment 4953017531) per the amendment procedure in the constant's own header.

## Mechanism

- The parity test re-pins the new ruled core and adds regression guards: `not.toContain('substrate')`, `not.toContain('—')`, retired-category guard kept. 3/3 pass locally.
- package.json `description` follows the constant (asserted by the same test).
- Ships in the same window as the README re-carve (mmnto-ai/totem#2382) and the GitHub About flip (manual parity, operator-gated) so the three surfaces never publicly disagree.

Refs (no auto-close): mmnto-ai/totem-strategy#531.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
