### PR TITLE
fix(core): widen agent_source to seat-id space per amended ADR-078

### DIFF
--- a/.changeset/ledger-agent-source-seat-space.md
+++ b/.changeset/ledger-agent-source-seat-space.md
@@ -1,0 +1,6 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+---
+
+Reconcile `agent_source` with amended ADR-078 (value space = seat-id ∪ {human}, strategy#879 / #2362 fold-1). Core: widen the `LedgerEventSchema` field from the closed vendor enum (`claude`/`gemini`/`human`) to an open trimmed non-empty string — the seat roster is open-ended, and `readLedgerEvents` silently skips schema-invalid lines, so a closed set turns seat-attributed events into data loss. CLI: the scaffolded Claude SessionStart hook now stamps the env-derived seat from `TOTEM_SELF_AGENT` (first non-empty comma entry, matching the MCP producer's parse) instead of the hardcoded vendor literal `'claude'`, and omits the field when the env var is absent (Tenet 4: stamp absence, never guess). Legacy vendor-class values from pre-amendment writers remain parseable; no migration needed. (#2389)

--- a/docs/wiki/trap-ledger.md
+++ b/docs/wiki/trap-ledger.md
@@ -57,12 +57,12 @@ The NDJSON records contain high-fidelity context about the friction event.
 }
 ```
 
-(MCP `agent_source` attribution lands in A.3.c via orchestrator → MCP correlation propagation; `session_start` events emitted by the Claude hook DO carry `agent_source: "claude"` today.)
+(MCP `agent_source` attribution lands in A.3.c via orchestrator → MCP correlation propagation; `session_start` events emitted by the Claude hook carry the env-derived seat from `TOTEM_SELF_AGENT` when it is set, and omit the field otherwise.)
 
 The canonical schema (with field-level descriptions, optionality, and discriminator semantics) lives in `packages/core/src/ledger.ts` (`LedgerEventSchema`). Two orthogonal axes worth calling out:
 
 - `source` — emitting subsystem (`lint` | `shield` | `bot`)
-- `agent_source` — agent runtime that produced the event (`claude` | `gemini` | `human`)
+- `agent_source` — agent identity that produced the event: a cohort seat-id or `human` (e.g. `strategy-claude`, `lc-codex`, `human`), per ADR-078 § Event Attribution as amended 2026-07-15. A vendor class projects mechanically from a seat (`strategy-claude` → `claude`); the reverse projection does not exist. Legacy vendor-class values (`claude` | `gemini`) from pre-amendment writers remain parseable.
 
 Per ADR-078 § Event Attribution: agent attribution lives in `agent_source`; `source` identifies which Totem subsystem fired the event. Pre-A.3.a events have no `agent_source` field and are forward-compatible (the field is optional).
 

--- a/packages/cli/src/commands/compile.ts
+++ b/packages/cli/src/commands/compile.ts
@@ -505,9 +505,9 @@ export async function compileCommand(
   // SessionStart-hook'd runs get cross-event correlation; CI / hookless runs
   // emit without it (matches `logMcpCall` in packages/mcp/src/ledger-writer.ts).
   // agent_source is intentionally omitted — compile.ts has no reliable way to
-  // attribute its caller to claude/gemini/human until A.3.c wires the
-  // orchestrator → telemetry correlation. Schema (compile_run) shipped in
-  // Proposal 278 § Action 3 (vi).
+  // attribute its caller to a seat (seat-id ∪ {human}, amended ADR-078) until
+  // A.3.c wires the orchestrator → telemetry correlation. Schema (compile_run)
+  // shipped in Proposal 278 § Action 3 (vi).
   const logCompileRun = (totemDir: string): void => {
     try {
       const provider = config.orchestrator?.provider ?? 'unknown';

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -370,10 +370,14 @@ try {
   const sessionId = randomUUID();
   writeFileSync(join(ledgerDir, '.session-id'), sessionId, 'utf-8');
   // Amended ADR-078 (2026-07-15): agent_source is the env-carried seat-id
-  // (TOTEM_SELF_AGENT, first non-empty comma entry — same parse as the MCP
-  // producer), never a vendor class ('claude' has no reverse projection to
-  // a seat). Omitted entirely when the env var is absent: stamp absence,
-  // never guess (Tenet 4).
+  // (TOTEM_SELF_AGENT, first non-empty comma entry), never a vendor class
+  // ('claude' has no reverse projection to a seat). Omitted entirely when
+  // the env var is absent: stamp absence, never guess (Tenet 4). The parse
+  // deliberately mirrors deriveSearchLogAttribution (packages/mcp/src/
+  // search-log.ts) and parseEnvAgentList (packages/core/src/
+  // orchestration-resolver.ts) — inlined because this rendered .cjs hook
+  // runs standalone in consumer repos with no access to those modules; if
+  // the shared parse semantics change, change this template in the same PR.
   const selfAgent = (process.env.TOTEM_SELF_AGENT || '')
     .split(',')
     .map((s) => s.trim())

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -369,12 +369,21 @@ try {
   mkdirSync(ledgerDir, { recursive: true });
   const sessionId = randomUUID();
   writeFileSync(join(ledgerDir, '.session-id'), sessionId, 'utf-8');
+  // Amended ADR-078 (2026-07-15): agent_source is the env-carried seat-id
+  // (TOTEM_SELF_AGENT, first non-empty comma entry — same parse as the MCP
+  // producer), never a vendor class ('claude' has no reverse projection to
+  // a seat). Omitted entirely when the env var is absent: stamp absence,
+  // never guess (Tenet 4).
+  const selfAgent = (process.env.TOTEM_SELF_AGENT || '')
+    .split(',')
+    .map((s) => s.trim())
+    .find((s) => s.length > 0);
   const event = {
     timestamp: new Date().toISOString(),
     type: 'session_start',
     activity_name: 'SessionStart',
     source: 'bot',
-    agent_source: 'claude',
+    ...(selfAgent ? { agent_source: selfAgent } : {}),
     justification: '',
     session_id: sessionId,
   };

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1436,11 +1436,14 @@ describe('CLAUDE_SESSION_START template', () => {
     expect(CLAUDE_SESSION_START).toContain('appendFileSync');
   });
 
-  it('stamps agent_source: claude on the Claude-specific hook', () => {
-    // Claude hook knows its origin — populating agent_source here is the
-    // minimal-coupling alternative to waiting for A.3.c correlation
-    // propagation.
-    expect(CLAUDE_SESSION_START).toContain("agent_source: 'claude'");
+  it('derives agent_source from TOTEM_SELF_AGENT instead of stamping a vendor literal', () => {
+    // Amended ADR-078 (strategy#879): agent_source is seat-id ∪ {human};
+    // 'claude' is a vendor class with no reverse projection to a seat. The
+    // hook stamps the env-carried seat and omits the field when unset
+    // (Tenet 4: stamp absence, never guess).
+    expect(CLAUDE_SESSION_START).toContain('TOTEM_SELF_AGENT');
+    expect(CLAUDE_SESSION_START).toContain('agent_source: selfAgent');
+    expect(CLAUDE_SESSION_START).not.toContain("agent_source: 'claude'");
   });
 
   it('keeps the session-start writer fire-and-forget (no rethrow)', () => {

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -6,6 +6,7 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { IngestTarget } from '@mmnto/totem';
+import { LedgerEventSchema, resolveSelfAgents } from '@mmnto/totem';
 
 import {
   UNIVERSAL_BASELINE_LESSONS,
@@ -1675,6 +1676,86 @@ describe('PreWriteShield runtime behavior', () => {
       tool_input: { command: 'echo "see #247"' },
     });
     expect(result.exitCode).toBe(0);
+  });
+});
+
+describe('CLAUDE_SESSION_START runtime behavior (A.3.a ledger write)', () => {
+  let tmpDir: string;
+  let hookPath: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-sessionstart-runtime-'));
+    hookPath = path.join(tmpDir, 'SessionStart.cjs');
+    fs.writeFileSync(hookPath, CLAUDE_SESSION_START, 'utf-8');
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  /**
+   * Execute the rendered hook in tmpDir with a controlled TOTEM_SELF_AGENT
+   * and return the latest session_start event it appended. `undefined`
+   * removes the variable so the test is hermetic even when the host shell
+   * exports a seat.
+   */
+  function runHook(selfAgent?: string): Record<string, unknown> {
+    const env = { ...process.env };
+    delete env['TOTEM_SELF_AGENT'];
+    if (selfAgent !== undefined) env['TOTEM_SELF_AGENT'] = selfAgent;
+    const result = spawnSync(process.execPath, [hookPath], {
+      cwd: tmpDir,
+      env,
+      encoding: 'utf-8',
+    });
+    expect(result.status).toBe(0);
+    const ndjson = fs.readFileSync(path.join(tmpDir, '.totem', 'ledger', 'events.ndjson'), 'utf-8');
+    const lines = ndjson.trim().split('\n');
+    return JSON.parse(lines[lines.length - 1]!) as Record<string, unknown>;
+  }
+
+  it('omits agent_source entirely when TOTEM_SELF_AGENT is unset (Tenet 4: stamp absence)', () => {
+    const event = runHook();
+    expect('agent_source' in event).toBe(false);
+    expect(event.type).toBe('session_start');
+    expect(typeof event.session_id).toBe('string');
+  });
+
+  it('omits agent_source when TOTEM_SELF_AGENT is empty or comma/whitespace noise', () => {
+    for (const value of ['', '   ', ' , ,']) {
+      const event = runHook(value);
+      expect('agent_source' in event).toBe(false);
+    }
+  });
+
+  it('stamps the first trimmed non-empty entry from a comma-separated roster', () => {
+    const event = runHook(' , strategy-claude , lc-codex ');
+    expect(event['agent_source']).toBe('strategy-claude');
+  });
+
+  it('stays in parity with resolveSelfAgents env parsing (sync-anchor drift sensor)', () => {
+    // The template inlines the comma-split/trim/first-non-empty parse because
+    // the rendered standalone .cjs cannot import @mmnto/totem. This parity
+    // check is the automated drift sensor behind the sync-anchor comment: if
+    // the shared env-parse semantics ever change, this test forces the
+    // template to change in the same PR.
+    const roster = ' , strategy-claude , lc-codex ';
+    const event = runHook(roster);
+    const resolved = resolveSelfAgents(tmpDir, { TOTEM_SELF_AGENT: roster });
+    expect(resolved.source).toBe('env');
+    expect(event['agent_source']).toBe(resolved.agents[0]);
+  });
+
+  it('emits an event that parses under the widened schema with a seat-id value', () => {
+    // The end-to-end regression this PR fixes: under the old vendor enum a
+    // seat-valued session_start would fail safeParse and readLedgerEvents
+    // would silently drop it.
+    const event = runHook('totem-claude');
+    const parsed = LedgerEventSchema.safeParse(event);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      expect(parsed.data.agent_source).toBe('totem-claude');
+    }
   });
 });
 

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1680,6 +1680,11 @@ describe('PreWriteShield runtime behavior', () => {
 });
 
 describe('CLAUDE_SESSION_START runtime behavior (A.3.a ledger write)', () => {
+  // Fail-fast guard for the spawned hook process, matching the 30s timeout
+  // the hook's own internal spawnSync uses — a stalled child must fail the
+  // test, not hang the runner (CR round 2).
+  const HOOK_SPAWN_TIMEOUT_MS = 30_000;
+
   let tmpDir: string;
   let hookPath: string;
 
@@ -1707,6 +1712,7 @@ describe('CLAUDE_SESSION_START runtime behavior (A.3.a ledger write)', () => {
       cwd: tmpDir,
       env,
       encoding: 'utf-8',
+      timeout: HOOK_SPAWN_TIMEOUT_MS,
     });
     expect(result.status).toBe(0);
     const ndjson = fs.readFileSync(path.join(tmpDir, '.totem', 'ledger', 'events.ndjson'), 'utf-8');

--- a/packages/core/src/capability/schema.ts
+++ b/packages/core/src/capability/schema.ts
@@ -72,7 +72,9 @@ export type CapabilityProvenance = z.infer<typeof CapabilityProvenanceSchema>;
  * An append-only output-time claim. `agentSource` is a STABLE Layer-B actor-id (a
  * cohort seat id or a review-backend catalog id); model/backend identity is NEVER
  * folded into it (kept as separate optional `payload` metadata) so the hit-rate
- * aggregates across model swaps (#697 fold 5; ADR-078 `agent_source` is NOT amended).
+ * aggregates across model swaps (#697 fold 5 left ADR-078 untouched; ADR-078
+ * `agent_source` has since converged on the same seat-id space — amended
+ * 2026-07-15, strategy#879).
  */
 export const CapabilityClaimSchema = z.object({
   claimId: nonEmpty('claimId'),

--- a/packages/core/src/ledger.test.ts
+++ b/packages/core/src/ledger.test.ts
@@ -136,7 +136,14 @@ describe('LedgerEventSchema', () => {
     // seat-id ∪ {human} per ADR-078 (amended 2026-07-15, strategy#879); legacy
     // vendor-class values from pre-amendment writers must remain parseable
     // because readLedgerEvents silently skips invalid lines.
-    for (const value of ['totem-claude', 'strategy-claude', 'lc-codex', 'human', 'claude']) {
+    for (const value of [
+      'totem-claude',
+      'strategy-claude',
+      'lc-codex',
+      'human',
+      'claude',
+      'gemini',
+    ]) {
       const event = makeActivityEvent({ agent_source: value });
       const result = LedgerEventSchema.safeParse(event);
       expect(result.success).toBe(true);

--- a/packages/core/src/ledger.test.ts
+++ b/packages/core/src/ledger.test.ts
@@ -38,7 +38,7 @@ function makeActivityEvent(overrides: Partial<LedgerEvent> = {}): LedgerEvent {
     type: 'mcp_call',
     justification: '',
     source: 'bot',
-    agent_source: 'claude',
+    agent_source: 'totem-claude',
     session_id: '550e8400-e29b-41d4-a716-446655440000',
     activity_name: 'search_knowledge',
     ...overrides,
@@ -92,7 +92,7 @@ describe('LedgerEventSchema', () => {
     expect(result.success).toBe(true);
     if (result.success) {
       expect(result.data.type).toBe('mcp_call');
-      expect(result.data.agent_source).toBe('claude');
+      expect(result.data.agent_source).toBe('totem-claude');
       expect(result.data.session_id).toBe('550e8400-e29b-41d4-a716-446655440000');
       expect(result.data.activity_name).toBe('search_knowledge');
       expect(result.data.ruleId).toBeUndefined();
@@ -132,21 +132,23 @@ describe('LedgerEventSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('accepts all three agent_source values', () => {
-    for (const value of ['claude', 'gemini', 'human'] as const) {
+  it('accepts the amended ADR-078 value space: seat-ids, human, and legacy vendor classes', () => {
+    // seat-id ∪ {human} per ADR-078 (amended 2026-07-15, strategy#879); legacy
+    // vendor-class values from pre-amendment writers must remain parseable
+    // because readLedgerEvents silently skips invalid lines.
+    for (const value of ['totem-claude', 'strategy-claude', 'lc-codex', 'human', 'claude']) {
       const event = makeActivityEvent({ agent_source: value });
       const result = LedgerEventSchema.safeParse(event);
       expect(result.success).toBe(true);
     }
   });
 
-  it('rejects an unknown agent_source value', () => {
-    const event = makeActivityEvent({
-      // @ts-expect-error — intentionally invalid for the test
-      agent_source: 'cursor',
-    });
-    const result = LedgerEventSchema.safeParse(event);
-    expect(result.success).toBe(false);
+  it('rejects an empty or whitespace-only agent_source', () => {
+    for (const value of ['', '   ']) {
+      const event = makeActivityEvent({ agent_source: value });
+      const result = LedgerEventSchema.safeParse(event);
+      expect(result.success).toBe(false);
+    }
   });
 
   it('rejects a malformed session_id UUID', () => {
@@ -191,14 +193,14 @@ describe('LedgerEventSchema', () => {
     const event = makeEvent({
       type: 'override',
       source: 'shield',
-      agent_source: 'claude',
+      agent_source: 'totem-claude',
       session_id: '550e8400-e29b-41d4-a716-446655440000',
       correlation_id: '6ba7b810-9dad-11d1-80b4-00c04fd430c8',
     });
     const result = LedgerEventSchema.safeParse(event);
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.agent_source).toBe('claude');
+      expect(result.data.agent_source).toBe('totem-claude');
       expect(result.data.correlation_id).toBe('6ba7b810-9dad-11d1-80b4-00c04fd430c8');
     }
   });
@@ -337,9 +339,10 @@ describe('test-fixture per-branch field presence (factory output validation)', (
   });
 
   it('session_start events carry agent_source + session_id', () => {
-    // session_start is what the SessionStart hook emits; agent_source identifies
-    // the orchestrator vendor (hook knows its own origin), session_id is the
-    // freshly-minted UUID that subsequent events correlate against.
+    // session_start is what the SessionStart hook emits; agent_source is the
+    // env-carried seat-id (TOTEM_SELF_AGENT, amended ADR-078 — omitted when
+    // the env var is absent), session_id is the freshly-minted UUID that
+    // subsequent events correlate against.
     expectWriterCarriesFields(
       makeActivityEvent({ type: 'session_start', activity_name: 'SessionStart' }),
       ['agent_source', 'session_id'],
@@ -492,7 +495,7 @@ describe('readLedgerEvents', () => {
       type: 'override',
       source: 'shield',
       ruleId: 'rule-xyz',
-      agent_source: 'claude',
+      agent_source: 'totem-claude',
       session_id: sessionId,
     });
 

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -72,14 +72,22 @@ export const LedgerEventSchema = z.object({
    */
   immutable: z.boolean().optional(),
   /**
-   * Agent runtime that produced the event. Orthogonal to `source`
+   * Agent identity that produced the event. Orthogonal to `source`
    * (which identifies the emitting subsystem). Optional for
    * backward-compat with pre-A.3.a events; required by writer for
-   * activity events. Per ADR-078 § Event Attribution, with the
-   * field renamed from `source` to disambiguate against the
-   * load-bearing emitter identifier already in production code.
+   * activity events. Per ADR-078 § Event Attribution (amended
+   * 2026-07-15, strategy#879 / #2362 fold-1): the value space is
+   * seat-id ∪ {`human`} (e.g. `strategy-claude`, `lc-codex`,
+   * `human`), env-carried as `TOTEM_SELF_AGENT`. A vendor class
+   * projects mechanically from a seat (`strategy-claude` → `claude`);
+   * the reverse projection does not exist, so vendor literals must
+   * never be stamped. Open string, not an enum: the seat roster is
+   * open-ended, and `readLedgerEvents` silently skips schema-invalid
+   * lines — a closed set here turns new seats into data loss.
+   * Legacy vendor-class values (`claude`/`gemini`/`human`) from
+   * pre-amendment writers remain parseable.
    */
-  agent_source: z.enum(['claude', 'gemini', 'human']).optional(),
+  agent_source: z.string().trim().min(1).optional(),
   /**
    * Session UUID minted at SessionStart hook fire (24h TTL, rotates on
    * subsequent SessionStart). Persisted to `.totem/ledger/.session-id`


### PR DESCRIPTION
Closes #2389

## What

Reconciles `agent_source` with [ADR-078 § Event Attribution as amended 2026-07-15](https://github.com/mmnto-ai/totem-strategy/pull/879) ([#2362 fold-1 ruling](https://github.com/mmnto-ai/totem/pull/2362#issuecomment-4978753454)): the value space is **seat-id ∪ {`human`}** (e.g. `strategy-claude`, `lc-codex`, `human`), env-carried as `TOTEM_SELF_AGENT`. A vendor class projects mechanically from a seat (`strategy-claude` → `claude`); the reverse projection does not exist. The amendment named the zod enum in `packages/core/src/ledger.ts` as the diverging surface at amendment time — this PR is that totem-lane follow-up.

## Changes

1. **`LedgerEventSchema.agent_source`** (`packages/core/src/ledger.ts`): closed vendor enum `z.enum(['claude','gemini','human'])` → open `z.string().trim().min(1)`. Open string, not a wider enum: the seat roster is open-ended, and `readLedgerEvents` silently skips schema-invalid lines — a closed set turns seat-attributed events into data loss for every ledger consumer. Legacy vendor-class values remain parseable (pure widening, no migration).
2. **`CLAUDE_SESSION_START` template** (`packages/cli/src/commands/init-templates.ts`): the scaffolded SessionStart hook stamps the env-derived seat from `TOTEM_SELF_AGENT` (first non-empty comma entry, mirroring `deriveSearchLogAttribution` / `parseEnvAgentList` — inlined because the rendered standalone `.cjs` cannot import those modules; sync anchors named in the comment) instead of hardcoded `agent_source: 'claude'`. Field omitted when the env var is absent (Tenet 4: stamp absence, never guess).
3. **Tests**: ledger schema tests move to the amended value space (seat-ids + `human` + legacy vendor values accepted; rejection test moves from unknown-vendor to empty/whitespace-only); init template test asserts seat derivation and the absence of the vendor literal.
4. **Stale vocabulary**: `compile.ts` attribution comment, `capability/schema.ts` "ADR-078 is NOT amended" parenthetical (true at #697 fold-5 time, false since strategy#879), `docs/wiki/trap-ledger.md` value-space and hook-claim lines.

## Not changed (already conformant)

- `packages/mcp/src/search-log.ts` — env-derived seat stamp, null-honest (shipped in #2362).
- `totem doctor --compliance` reader — open `string | null` with `unattributed` bucket (shipped in #2379).
- No production code pattern-matches the old literal union: the only `.agent_source` reads outside the diff are in `doctor-compliance.ts` (already open-string); workspace-wide strict `tsc` passes, ruling out type-level breaks. Existing consumer repos keep their scaffolded hook until re-init (hook-template versioning is #1854); their legacy `'claude'` stamps stay parseable.

## Gates

- `pnpm -r build` clean; core 3209/3209, cli 3210/3210 (incl. updated suites)
- `totem lint --base main`: PASS — 0 errors, 5 advisory warnings (known #2063 idiom false-positive class: quoted doctrine "never" in changeset prose, template-content `toContain` assertions matching the surrounding suite, and the zod rule firing on its own recommended `.trim().min(1)` form)
- `prettier --check .` clean; ESLint 0 errors (7 pre-existing warnings elsewhere in cli, none in touched files)
- `totem review --base main` (2-lane fan): 0 critical, 1 warn (parse duplication — addressed by naming the sync anchors in the template comment; structurally forced for a standalone hook), 1 info (out-of-diff union consumers — verified none exist, see above)
- Changeset: minor `@mmnto/totem` + `@mmnto/cli`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
