### PR TITLE
chore: totem postmerge lessons for 2390

### DIFF
--- a/.totem/lessons/lesson-68e4f543.md
+++ b/.totem/lessons/lesson-68e4f543.md
@@ -1,0 +1,6 @@
+## Lesson — Use sync anchors for inlined standalone code
+
+**Tags:** dx, refactoring, templates
+**Scope:** packages/cli/src/commands/init-templates.ts
+
+Standalone scaffolded hooks that cannot import external modules must inline their utility functions. To prevent logic drift, use named sync anchors in comments to link the inlined code to its upstream source, and back the anchor with an executable parity test that runs the rendered artifact against the shared implementation (mmnto-ai/totem#2390: hook-stamped seat asserted equal to `resolveSelfAgents(...).agents[0]`) so semantic drift fails a test instead of relying on review discipline.

--- a/.totem/lessons/lesson-7847684e.md
+++ b/.totem/lessons/lesson-7847684e.md
@@ -1,0 +1,6 @@
+## Lesson — Avoid closed enums in silent-skip parsers
+
+**Tags:** zod, validation, data-loss, ledger
+**Scope:** packages/core/**/*.ts, !**/*.test.*
+
+Using a closed Zod enum in a parser that silently skips schema-invalid lines causes silent data loss when new values are introduced. Widening the schema to an open, validated string preserves backward compatibility and prevents parsing failures.

--- a/.totem/lessons/lesson-91812deb.md
+++ b/.totem/lessons/lesson-91812deb.md
@@ -1,0 +1,6 @@
+## Lesson — Omit missing environment fields over guessing
+
+**Tags:** configuration, environment, best-practices
+**Scope:** packages/cli/**/*.ts, !**/*.test.*
+
+When an attribution field is derived from an environment variable, omit the field entirely if the variable is absent rather than guessing a default. This prevents incorrect fallback values and maintains strict data fidelity.


### PR DESCRIPTION
Post-merge lesson extraction for #2390 (`totem lesson extract 2390 --yes`), per the /postmerge sequence with the compile steps (3–4) skipped under the standing rule-compilation freeze (2026-05-17, pending the Convergent Spine).

## Lessons (3)

1. **`lesson-7847684e` — Avoid closed enums in silent-skip parsers** (core): a closed zod enum in a parser that silently skips invalid lines turns new legitimate values into silent data loss; widen to an open validated string.
2. **`lesson-68e4f543` — Use sync anchors for inlined standalone code** (init-templates): inlined utility logic in rendered standalone artifacts needs named sync-anchor comments AND an executable parity test against the shared implementation, so drift fails a test instead of relying on review discipline. (Body hand-sharpened post-extract to include the parity-test half of the merged PR's final state.)
3. **`lesson-91812deb` — Omit missing environment fields over guessing** (cli): env-derived attribution fields are omitted when the variable is absent, never defaulted.

No compile, no manifest mutation, no exports regenerated — lessons land as retrievable corpus only until the freeze lifts. Index sync ran as part of extraction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
