### PR TITLE
docs(wiki): recut 'under 60 seconds' to the structural register

### DIFF
--- a/docs/wiki/it-never-happens-again.md
+++ b/docs/wiki/it-never-happens-again.md
@@ -4,7 +4,7 @@ When a reviewer (human or AI) spots an architectural mistake, like a static impo
 
 Two days later, an agent or a junior developer makes the exact same mistake in a different file. The cycle repeats. Knowledge is trapped in merged PRs.
 
-Totem breaks this cycle with a three-step loop: **Extract → Compile → Enforce.** You turn a PR mistake into a permanent, mechanically enforced rule in under 60 seconds.
+Totem breaks this cycle with a three-step loop: **Extract → Compile → Enforce.** You turn a PR mistake into a permanent, mechanically enforced rule in two commands — from then on, enforcement is automatic.
 
 ## 1. Extract the Lesson
 


### PR DESCRIPTION
Closes #2386

## What

Recuts the one wall-clock speed claim on `docs/wiki/it-never-happens-again.md` to the structural-only register ruled in the mmnto-ai/totem-strategy#531 marketing round (speed expressed as structure — steps, commands, determinism — never wall-clock numbers).

**Before:** "You turn a PR mistake into a permanent, mechanically enforced rule in under 60 seconds."

**After:** "You turn a PR mistake into a permanent, mechanically enforced rule in two commands — from then on, enforcement is automatic."

"Two commands" is verifiable against the page's own content (`totem lesson extract`, `totem lesson compile`; step 3 is the hook firing on its own) and harmonizes with the gate-released A1 register in the README ("one lesson file, one command"). Swept the rest of the page for the same claim class: no other wall-clock or absolute claims present (the `394 rules (zero LLM)` line is structural).

Docs-only — no changeset (the wiki is a GitHub surface, not a packaged artifact). Claim-discipline gate: PASS on the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
