### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine 0.1.17 -> 0.1.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "typescript-eslint": "^8.59.4"
   },
   "optionalDependencies": {
-    "@mmnto/strategy-doctrine": "0.1.17"
+    "@mmnto/strategy-doctrine": "0.1.18"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         version: 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
     optionalDependencies:
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.17
-        version: 0.1.17
+        specifier: 0.1.18
+        version: 0.1.18
 
   packages/cli:
     dependencies:
@@ -853,8 +853,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.17':
-    resolution: {integrity: sha512-dDJLVB0ZY/dJnpH+dWSjUwRiNmfCCSSBNXJKX759ZNExmVkN5OIvWyGmsKyVvhMFh66DbMsMo3YJK7zpDCMHtw==}
+  '@mmnto/strategy-doctrine@0.1.18':
+    resolution: {integrity: sha512-masjiEmeyTqoM0UhXpX4FFpGGufCQ4CrT1sOvgzvSHQ3vzDXMHlmcz6TRyf+8lMn/4Ys2IX+2i56ox+YvLUC8w==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3685,7 +3685,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.17':
+  '@mmnto/strategy-doctrine@0.1.18':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
Cohort pin sweep, totem leg: `@mmnto/strategy-doctrine` 0.1.17 → 0.1.18 — the cut ships the Prop 305 agent-bus operative contract (cohort-overlay §4) + the `agent-bus` parity row (mmnto-ai/totem-strategy#888 acceptance, mmnto-ai/totem-strategy#890 distribution). Lockfile regenerated + committed per this repo's tracked-lockfile policy. Installed version verified 0.1.18 post-install (the mmnto-ai/totem-strategy#630 optional-dep trap check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
