### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine 0.1.18 -> 0.1.19

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "typescript-eslint": "^8.59.4"
   },
   "optionalDependencies": {
-    "@mmnto/strategy-doctrine": "0.1.18"
+    "@mmnto/strategy-doctrine": "0.1.19"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         version: 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
     optionalDependencies:
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.18
-        version: 0.1.18
+        specifier: 0.1.19
+        version: 0.1.19
 
   packages/cli:
     dependencies:
@@ -853,8 +853,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.18':
-    resolution: {integrity: sha512-masjiEmeyTqoM0UhXpX4FFpGGufCQ4CrT1sOvgzvSHQ3vzDXMHlmcz6TRyf+8lMn/4Ys2IX+2i56ox+YvLUC8w==}
+  '@mmnto/strategy-doctrine@0.1.19':
+    resolution: {integrity: sha512-XBsyF5J5lOVbgIz3gZaKnDIB4i+7kvbOWPGlRl/gumhkcWDv3QPFj2giOeKfwWmwAcSblFTgQib5j82Oavhxvw==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3685,7 +3685,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.18':
+  '@mmnto/strategy-doctrine@0.1.19':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
Routine restricted-pin bump for the 0.1.19 cut (internal-only, classified in advance on mmnto-ai/totem-strategy#897 — annotation/pointer corrections from the mmnto-ai/totem-strategy#893 premise sweep; no schema change, no init re-run). Post-bump `totem doctor --parity` verified on the resulting tree per the mmnto-ai/totem-strategy#630 rule: pin PASS at floor, lock-content vs-canonical clean, 0 fail. Lockfile regenerated (totem tracks it).

Opened by the strategy bus while totem-claude is parked (operator-announced); merge rides the same block authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)