### PR TITLE
feat(parity): declare the agent-bus binding + sense manifestation 'declared' (Prop 305 §3)

### DIFF
--- a/.changeset/agent-bus-declared-cli.md
+++ b/.changeset/agent-bus-declared-cli.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/cli': minor
+---
+
+feat(doctor): `totem doctor --parity` now senses `manifestation: declared` (the `agent-bus` row).
+
+Wires the CLI-side declaration registry (`declarationMarkersFor`, `agent-bus` → the repo's own `AGENTS.md` + the `totem:agent-bus` marker token) and routes `declared` rows to `detectDeclaredContract` before the unrecognized-manifestation guard. The `agent-bus` row now PASSes — naming the `role → seat` binding — when the repo declares a `totem:agent-bus` marker, and stays an honest-absent SKIP ("honest-absent until a repo declares") when it does not. An unknown `declared` contract id gets a registry-gap stub, mirroring an unwired capability probe. Never warns on absence.
+
+Consumer-impact: new additive sensing surface on `totem doctor --parity`; no behavior change for repos without the marker (the row stays a skip), never affects exit codes. No breaking changes.

--- a/.changeset/agent-bus-declared-core.md
+++ b/.changeset/agent-bus-declared-core.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/totem': minor
+---
+
+feat(parity): sense `manifestation: declared` (Prop 305 §3 agent-bus) in the parity detector.
+
+Adds `detectDeclaredContract` (+ `parseDeclarationMarker`), a declaration-surface sensor: it reads a repo-authored `<!-- totem:<token> role="…" seat="…" -->` HTML-comment marker and returns `pass` when a well-formed role→seat binding is present, or an honest-absent `skip` (never `warn`/`fail`) when the file or marker is absent, or when the marker is missing `role`/`seat` (the why-not names the missing attribute, Tenet 4). The sensor claims DECLARATION PRESENCE ONLY — never duty execution (adherence-class, Tenet 19 / Prop 305 §3.5). `'declared'` is added to `PARITY_MANIFESTATIONS` so the routing edge recognizes the rung. The marker regex is linear (ReDoS-safe), mirroring `parseForkMarker`.
+
+Consumer-impact: new additive sensing on the manifestation ladder; no behavior change for repos without the marker (they stay honest-absent skip). No breaking changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Totem: Agent Instructions
 
-Canonical source of truth for how AI coding agents (Claude Code, Gemini CLI, Cursor, Windsurf, Copilot, etc.) behave in this repo. Per [Totem ADR-038](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-038-agents-md-standard.md), `mmnto-ai/totem` consolidates tool-specific instruction files into this single `AGENTS.md`. Thin `CLAUDE.md` / `GEMINI.md` redirect files exist only so each tool finds its way here.
+Canonical source of truth for how AI coding agents (Claude Code, Gemini CLI, Cursor, etc.) behave in this repo. Per Totem ADR-038 (`mmnto-ai/totem-strategy:adr/adr-038-agents-md-standard.md`), `mmnto-ai/totem` consolidates tool-specific instruction files into this single `AGENTS.md`. Thin `CLAUDE.md` / `GEMINI.md` redirects point each tool here.
 
 ## What Totem is
 
@@ -9,7 +9,7 @@ Totem is a **deterministic, git-native governance toolkit** — _rules you enfor
 ## Session Start Protocol (MANDATORY)
 
 1. Run `totem status` for health; read the active milestone for momentum.
-2. **NEVER GUESS ARCHITECTURE.** Before modifying any core system (hooks, orchestrator, compiler, extract pipeline), run `totem search <system_name>`.
+2. **NEVER GUESS ARCHITECTURE.** Before modifying any core system, run `totem search <system_name>`.
 3. Before writing code, call `search_knowledge` describing what you're changing.
 4. Before planning, query `totem-strategy:search_knowledge` for ADRs.
 5. Don't push speculative fixes. Run `totem lint` locally — front-load all checks before the first push.
@@ -30,7 +30,7 @@ Not mechanically enforced. Follow because they reduce PR bot noise.
 
 - **Before coding:** `/preflight <issue>`. Create a feature branch.
 - **Before pushing:** `pnpm run format` → `totem lint` → `totem review` → verify compile manifest is current.
-- **After merging a PR:** `totem lesson extract <pr> --yes`, then `totem docs` if releasing. Lessons: `totem lesson extract <prs>` → `totem lesson compile`.
+- **After merging a PR:** `totem lesson extract <pr> --yes`, then `totem docs` if releasing.
 - **NEVER bypass quality gates without a ticket.** No `--no-verify`, `totem-ignore`, `eslint-disable`, `@ts-ignore`, skipped tests, or CI-pacifying ignore patterns. Suppressions need a ticket-ref comment.
 - **Open PRs Ready, not Draft.** Ready signals review-readiness for the operator's trigger word (strategy#622).
 - **Vendor routing.** Claude is the default code executor; Gemini stays strategic (proposals, ADRs, audits). Cross-vendor second-opinion fine both ways; "Gemini implement" is not the default.
@@ -49,17 +49,17 @@ Before posting ANY PR comment, replying to ANY bot, or running `gh pr comment` /
 
 <!-- totem:cr-disclaimer: cross-repo doctrine refs into private cohort repos (e.g., mmnto-ai/totem-strategy) remain canonical even when CR's URL-accessibility check returns 404 from the bot account — this is an access-class signal per doctrine § 2.4, not a link-class signal -->
 
-1. **Read** [`mmnto-ai/totem-strategy:doctrine/bot-protocols.md`](https://github.com/mmnto-ai/totem-strategy/blob/main/doctrine/bot-protocols.md) if you haven't this session.
+1. **Read** `mmnto-ai/totem-strategy:doctrine/bot-protocols.md` if you haven't this session.
 2. **Apply** the round SOP (doctrine § 8.1) — ONE dispositions comment per round, tag only bots with a role; triggers separate (see 3).
 3. **Invocation is operator-gated; bots are on-demand** (strategy#622): post a trigger only on the operator's per-invocation word — surface _"ready: invoke X, or merge as-is"_ first. Triggers are standalone, triggers-only comments (embedded ⟹ CR chat-mode, totem#2150; Windows: Git-Bash mangles leading `/` — send via PowerShell).
 4. **Never** combine `@gemini-code-assist` + `/gemini review` in one comment (XOR, § 1.2); **never** cite a SHA before pushing (§ 1.1).
 5. **Prefer `/review-reply`** — it operationalizes the SOP end-to-end.
 
-Enforcement stack per [ADR-105](https://github.com/mmnto-ai/totem-strategy/blob/main/adr/adr-105-bot-protocol-centralization.md): skill instructions → **this AGENTS.md** (baseline for all vendor sessions) → auto-memory pointer. (The #1900 hook layer was retired in the 2026-06-01 amendment.)
+Enforcement stack per ADR-105: skill instructions → **this AGENTS.md** (baseline for all vendor sessions) → auto-memory pointer.
 
 ## Skills
 
-Claude Code skills live under `.claude/skills/`; invoke via `/<skill-name>`. Gemini CLI equivalents (when present) live under `.gemini/skills/`. Each `SKILL.md` is the authoritative definition.
+Claude Code skills live under `.claude/skills/` (invoke `/<name>`); Gemini CLI equivalents (when present) under `.gemini/skills/`. Each `SKILL.md` is authoritative.
 
 - `/preflight <issue>` — spec + search before coding
 - `/prepush` — format + lint + review before push
@@ -69,7 +69,7 @@ Claude Code skills live under `.claude/skills/`; invoke via `/<skill-name>`. Gem
 
 ## Context Decay Prevention (Proposal 213)
 
-After >15 turns of code changes: run `totem status`, re-query strategy ADRs for the system you're modifying, and state your architectural assumption before proceeding.
+After >15 turns of code changes: run `totem status`, re-query strategy ADRs for the system you're modifying, and state your architectural assumption.
 
 ## Agent Discipline (ADR-063)
 
@@ -79,18 +79,8 @@ After >15 turns of code changes: run `totem status`, re-query strategy ADRs for 
 
 <!-- totem:agent-bus role="bus" seat="totem-claude" declared="2026-07-16" -->
 
-This repo implements the cohort's judgment-bus contract ([Proposal 305 §3](https://github.com/mmnto-ai/totem-strategy/blob/main/proposals/active/305-agent-bus-pattern.md) — a private cohort-doctrine ref; the access-class note in § Bot-Protocol Gate applies):
+Role `bus` → seat `totem-claude`; judgment-density file classes: cohort defaults + `AGENTS.md` · `docs/wiki/**` · `.claude/skills/**`. Lane table: mmnto-ai/totem-strategy#697 (pointer, not a copy). Duties + fail-closed succession: Prop 305 §3 + the mmnto-ai/totem-strategy#639 operating spec. The `agent-bus` parity row senses declaration presence only; duty execution is adherence-class (Tenet 19).
 
-1. **Binding:** role `bus` → seat `totem-claude` (a seat-id, never a model). Bus seat down ⇒ automated lanes stage-only; no automatic succession — the operator rules the work directly or explicitly binds one acting bus, recorded on the work.
-2. **Judgment-density file classes** — cohort defaults inherited (public-copy floor: README · repo About · package descriptions · wiki); local additions: `AGENTS.md` · `docs/wiki/**` · `.claude/skills/**`. Class labels are routing hints; density is derived fresh at routing time.
-3. **Lane table:** the [mmnto-ai/totem-strategy#697 capability ledger](https://github.com/mmnto-ai/totem-strategy/issues/697) — pointer only, never a local copy.
-4. **Drift duties:** in-repo premise sweep per the [mmnto-ai/totem-strategy#639 operating spec](https://github.com/mmnto-ai/totem-strategy/issues/639#issuecomment-4994756249) · event-driven couplings on governed pages · the Monday world-claims re-verify step.
-5. **Manifestation** is sensed by the `agent-bus` parity row of `totem doctor --parity` (declaration present / honest-absent); whether the bus _executes_ these duties is adherence-class, never inferred from the row.
+## Detailed Docs
 
-## Detailed Docs (read when relevant)
-
-- [Architecture context](.claude/docs/architecture.md)
-- [Contributing rules](.claude/docs/contributing.md)
-- [Agent workflow](.claude/docs/agent-workflow.md)
-- [Gemini styleguide](.gemini/styleguide.md)
-- Strategy ADRs: query `mcp__totem-strategy__search_knowledge`
+- [Architecture](.claude/docs/architecture.md) · [Contributing](.claude/docs/contributing.md) · [Agent workflow](.claude/docs/agent-workflow.md) · [Gemini styleguide](.gemini/styleguide.md) · strategy ADRs via `mcp__totem-strategy__search_knowledge`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,18 @@ After >15 turns of code changes: run `totem status`, re-query strategy ADRs for 
 
 **Controller, not implementer.** Delegate code+test tasks to background agents. Keep this thread for decisions. Prefer Monitor over Bash `sleep` loops; use `/loop <prompt>` self-paced for poll-and-react.
 
+## Agent-bus binding (Proposal 305)
+
+<!-- totem:agent-bus role="bus" seat="totem-claude" declared="2026-07-16" -->
+
+This repo implements the cohort's judgment-bus contract ([Proposal 305 §3](https://github.com/mmnto-ai/totem-strategy/blob/main/proposals/active/305-agent-bus-pattern.md) — a private cohort-doctrine ref; the access-class note in § Bot-Protocol Gate applies):
+
+1. **Binding:** role `bus` → seat `totem-claude` (a seat-id, never a model). Bus seat down ⇒ automated lanes stage-only; no automatic succession — the operator rules the work directly or explicitly binds one acting bus, recorded on the work.
+2. **Judgment-density file classes** — cohort defaults inherited (public-copy floor: README · repo About · package descriptions · wiki); local additions: `AGENTS.md` · `docs/wiki/**` · `.claude/skills/**`. Class labels are routing hints; density is derived fresh at routing time.
+3. **Lane table:** the [mmnto-ai/totem-strategy#697 capability ledger](https://github.com/mmnto-ai/totem-strategy/issues/697) — pointer only, never a local copy.
+4. **Drift duties:** in-repo premise sweep per the [mmnto-ai/totem-strategy#639 operating spec](https://github.com/mmnto-ai/totem-strategy/issues/639#issuecomment-4994756249) · event-driven couplings on governed pages · the Monday world-claims re-verify step.
+5. **Manifestation** is sensed by the `agent-bus` parity row of `totem doctor --parity` (declaration present / honest-absent); whether the bus _executes_ these duties is adherence-class, never inferred from the row.
+
 ## Detailed Docs (read when relevant)
 
 - [Architecture context](.claude/docs/architecture.md)

--- a/packages/cli/src/commands/doctor-parity.test.ts
+++ b/packages/cli/src/commands/doctor-parity.test.ts
@@ -1350,6 +1350,83 @@ describe('checkParity - capability-probe routing (mmnto-ai/totem#2140)', () => {
   });
 });
 
+// ─── declared routing (Prop 305 §3 agent-bus) ──────────────
+const DECLARED_MANIFEST_YAML = `schema-version: 1
+status: active
+contracts:
+  - id: agent-bus
+    dimension: coordination
+    canonical-source: mmnto-ai/totem-strategy:proposals/active/305-agent-bus-pattern.md
+    detection-method: repo declares the Prop 305 §3 bus contract in agent config / AGENTS.md; honest-absent until a repo declares
+    expected-value-or-derivation: contract manifestation declared per Prop 305 §3
+    tractability: mechanical
+    manifestation: declared
+    senses: present
+    tracking-issue: mmnto-ai/totem-strategy#482
+`;
+
+describe('checkParity - declared routing (Prop 305 §3 agent-bus)', () => {
+  it('declared + a present totem:agent-bus marker → pass naming the role→seat binding', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: parity-manifest.yaml\n`);
+    writeManifest('parity-manifest.yaml', DECLARED_MANIFEST_YAML);
+    fs.writeFileSync(
+      path.join(tmpDir, 'AGENTS.md'),
+      '# AGENTS\n<!-- totem:agent-bus role="bus" seat="totem-claude" declared="2026-07-16" -->\n',
+      'utf-8',
+    );
+    const { results } = await checkParity(tmpDir);
+    const line = results.find((r) => r.name.includes('agent-bus'))!;
+    expect(line.status).toBe('pass');
+    expect(line.message).toContain('role "bus"');
+    expect(line.message).toContain('seat "totem-claude"');
+    expect(line.message).toContain('AGENTS.md');
+    expect(line.message).not.toContain('not yet implemented');
+  });
+
+  it('declared + no marker → honest-absent skip (never warns on absence)', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: parity-manifest.yaml\n`);
+    writeManifest('parity-manifest.yaml', DECLARED_MANIFEST_YAML);
+    // No AGENTS.md written into the tmp repo at all.
+    const { results } = await checkParity(tmpDir);
+    const line = results.find((r) => r.name.includes('agent-bus'))!;
+    expect(line.status).toBe('skip');
+    expect(line.message).toContain('honest-absent until a repo declares');
+  });
+
+  it('declared + an unknown contract id → registry-gap stub (mirrors an unwired probe)', async () => {
+    const unwired = DECLARED_MANIFEST_YAML.replace('id: agent-bus', 'id: some-future-declared-row');
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: parity-manifest.yaml\n`);
+    writeManifest('parity-manifest.yaml', unwired);
+    const { results } = await checkParity(tmpDir);
+    const line = results.find((r) => r.name.includes('some-future-declared-row'))!;
+    expect(line.status).toBe('skip');
+    expect(line.message).toContain('no declaration marker wired for this row');
+  });
+
+  it('classifies coverage: mechanical/present when wired + present, honest-absent when unwired', async () => {
+    writeConfig(`${BASE_CONFIG}orient:\n  parityManifest: parity-manifest.yaml\n`);
+    writeManifest('parity-manifest.yaml', DECLARED_MANIFEST_YAML);
+    fs.writeFileSync(
+      path.join(tmpDir, 'AGENTS.md'),
+      '<!-- totem:agent-bus role="bus" seat="totem-claude" -->\n',
+      'utf-8',
+    );
+    const wired = await checkParity(tmpDir);
+    expect(wired.readout!.meta['agent-bus']).toEqual({
+      coverage: 'mechanical',
+      sensesProbed: 'present',
+    });
+
+    const unwiredYaml = DECLARED_MANIFEST_YAML.replace(
+      'id: agent-bus',
+      'id: some-future-declared-row',
+    );
+    writeManifest('parity-manifest.yaml', unwiredYaml);
+    const unwired = await checkParity(tmpDir);
+    expect(unwired.readout!.meta['some-future-declared-row']!.coverage).toBe('honest-absent');
+  });
+});
+
 // ─── Trust-readout (mmnto-ai/totem#2327, Prop 303 §5(a)) ──────────
 
 // Four deterministic-in-a-tmpdir rows covering every coverage class + the

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -498,6 +498,41 @@ function capabilityProbesFor(
   }
 }
 
+// ─── Declared-contract registry (CLI-side, Prop 305 §3 agent-bus) ──
+
+/**
+ * One declaration surface a `manifestation: declared` contract maps to: the file
+ * that carries the `<!-- totem:<token> role="…" seat="…" -->` marker plus the
+ * bare marker token to sense it under. Mirrors {@link capabilityProbesFor}: the
+ * CLI owns the wiring (which file, which token per contract-id), core owns the
+ * verdict (`detectDeclaredContract`).
+ */
+interface DeclarationMarkerTarget {
+  filePath: string;
+  markerToken: string;
+}
+
+/**
+ * Resolve the declaration surface a `declared` contract senses, or `undefined`
+ * when this build wires no marker for the row (→ honest-absent stub, mirroring
+ * how `capabilityProbesFor` handles an unknown probe id). Today only `agent-bus`
+ * (Prop 305 §3): its role→seat binding is declared in the repo's own AGENTS.md.
+ */
+function declarationMarkersFor(
+  contractId: string,
+  gitRoot: string,
+): DeclarationMarkerTarget | undefined {
+  switch (contractId) {
+    case 'agent-bus':
+      return {
+        filePath: path.join(gitRoot, 'AGENTS.md'),
+        markerToken: 'totem:agent-bus',
+      };
+    default:
+      return undefined;
+  }
+}
+
 /**
  * Resolve the running `@mmnto/cli`'s version + install path for the req-#5
  * binary self-report (the Stale-Doctor-Paradox guard — surface WHICH binary
@@ -542,6 +577,7 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
   const {
     deriveCohortRepoId,
     detectCapabilityProbeContract,
+    detectDeclaredContract,
     detectGeneratedArtifactContract,
     detectLockContentContract,
     detectManualAttestationContract,
@@ -886,6 +922,40 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
           });
           if (blockingDrift) blockingDriftIds.push(c.id);
           return lines;
+        }
+
+        // ── declared routing (Prop 305 §3 agent-bus) ──
+        // Routes on `manifestation` BEFORE the tractability dispatch (like the
+        // other promoted rungs). A declaration SURFACE: the repo authors a
+        // `<!-- totem:<token> role="…" seat="…" -->` marker in its OWN agent
+        // config (AGENTS.md); the detector senses marker PRESENCE only, never
+        // duty execution (adherence-class, Tenet 19 / Prop 305 §3.5). The registry
+        // supplies the file + token; an unwired contract id gets an honest-absent
+        // stub (mirrors capability-probe). NEVER warns on absence — an undeclared
+        // repo is "honest-absent until a repo declares", not drift, so the class
+        // never enters blockingDriftIds (cannot gate even under --strict).
+        if (c.manifestation === 'declared') {
+          // Registry resolution BEFORE the scope guard is meta-only (pure switch,
+          // no read): a scoped-out row still classifies by whether the registry
+          // wires it (mmnto-ai/totem#2327 R2).
+          const target = declarationMarkersFor(c.id, gitRoot);
+          // A declaration-presence probe reads the repo's own config (mmnto-ai/totem#2327 R3): 'present'.
+          readoutMeta[c.id] =
+            target === undefined
+              ? { coverage: 'honest-absent' }
+              : { coverage: 'mechanical', sensesProbed: 'present' };
+          const scopeSkip = consumersSkip(c);
+          if (scopeSkip !== undefined) return scopeSkip;
+          if (target === undefined) {
+            return [
+              stub(c, `${c.dimension} (declared) — no declaration marker wired for this row`),
+            ];
+          }
+          const verdict = detectDeclaredContract({
+            filePath: target.filePath,
+            markerToken: target.markerToken,
+          });
+          return [verdictToLine(c, verdict)];
         }
 
         if (

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -774,8 +774,10 @@ export {
 export type {
   CapabilityProbeKind,
   CohortFloorStatus,
+  DeclarationMarker,
   DeriveCohortRepoIdOptions,
   DetectCapabilityProbeContext,
+  DetectDeclaredContext,
   DetectGeneratedArtifactContext,
   DetectLockContentContext,
   DetectManualAttestationContext,
@@ -796,6 +798,7 @@ export type {
 export {
   deriveCohortRepoId,
   detectCapabilityProbeContract,
+  detectDeclaredContract,
   detectGeneratedArtifactContract,
   detectLockContentContract,
   detectManualAttestationContract,
@@ -808,6 +811,7 @@ export {
   normalizeLockArtifact,
   normalizeManagedBlock,
   packageNameForContract,
+  parseDeclarationMarker,
   parseForkMarker,
   parseStrategyDoctrineLock,
   resolveCohortFloor,

--- a/packages/core/src/parity-detect.test.ts
+++ b/packages/core/src/parity-detect.test.ts
@@ -25,6 +25,7 @@ import { TotemConfigError } from './errors.js';
 import {
   deriveCohortRepoId,
   detectCapabilityProbeContract,
+  detectDeclaredContract,
   type DetectGeneratedArtifactContext,
   detectGeneratedArtifactContract,
   type DetectManualAttestationContext,
@@ -39,6 +40,7 @@ import {
   normalizeManagedBlock,
   type PackageJsonShape,
   packageNameForContract,
+  parseDeclarationMarker,
   parseForkMarker,
   resolveCohortFloor,
   type ValueEqualityField,
@@ -712,6 +714,133 @@ describe('parseForkMarker', () => {
       reason: 'multi line',
       owner: 'me',
     });
+  });
+});
+
+describe('parseDeclarationMarker', () => {
+  it('parses role/seat/declared, whitespace-tolerant, token with a colon matched literally', () => {
+    expect(
+      parseDeclarationMarker(
+        'preamble\n<!--  totem:agent-bus   role="bus"  seat="totem-claude" declared="2026-07-16" -->\ntrailer',
+        'totem:agent-bus',
+      ),
+    ).toEqual({ role: 'bus', seat: 'totem-claude', declared: '2026-07-16' });
+  });
+
+  it('returns an empty object for a bare marker, undefined when the token is absent', () => {
+    expect(parseDeclarationMarker('<!-- totem:agent-bus -->', 'totem:agent-bus')).toEqual({});
+    expect(parseDeclarationMarker('no marker here', 'totem:agent-bus')).toBeUndefined();
+    // A DIFFERENT totem marker is not this token — no cross-token match.
+    expect(
+      parseDeclarationMarker('<!-- totem:fork reason="x" -->', 'totem:agent-bus'),
+    ).toBeUndefined();
+  });
+
+  it('does not prefix-match a longer sibling token (agent-bus vs agent-bus-v2)', () => {
+    // The post-token lookahead (whitespace or `-->`) — not `\b` — is what makes
+    // this fail: `\b` would match between the `s` and the `-` of `-v2`.
+    expect(
+      parseDeclarationMarker('<!-- totem:agent-bus-v2 role="bus" -->', 'totem:agent-bus'),
+    ).toBeUndefined();
+    // Bare marker (token directly against `-->`) still parses.
+    expect(parseDeclarationMarker('<!-- totem:agent-bus-->', 'totem:agent-bus')).toEqual({});
+  });
+
+  it('matches a marker authored across multiple lines (dotAll)', () => {
+    expect(
+      parseDeclarationMarker(
+        '<!-- totem:agent-bus\n  role="bus"\n  seat="totem-claude"\n-->',
+        'totem:agent-bus',
+      ),
+    ).toEqual({ role: 'bus', seat: 'totem-claude' });
+  });
+
+  it('stays linear on a pathological unterminated input (ReDoS-safe, no catastrophic backtrack)', () => {
+    // A very long run with no closing `-->`: the non-greedy `.*?` bounded by the
+    // first `-->` cannot backtrack catastrophically. Guard on wall-clock so a
+    // regression to a nested quantifier is caught, mirroring the marker family.
+    const pathological = `<!-- totem:agent-bus ${'role="bus" '.repeat(50_000)}`;
+    const start = Date.now();
+    expect(parseDeclarationMarker(pathological, 'totem:agent-bus')).toBeUndefined();
+    expect(Date.now() - start).toBeLessThan(1_000);
+  });
+});
+
+describe('detectDeclaredContract', () => {
+  const AGENTS_PATH = path.join('repo', 'AGENTS.md');
+  const AGENTS =
+    (body: string) =>
+    (p: string): string | undefined =>
+      p === AGENTS_PATH ? body : undefined;
+
+  it('pass — marker present with role + seat names the binding + the file', () => {
+    const verdict = detectDeclaredContract({
+      filePath: AGENTS_PATH,
+      markerToken: 'totem:agent-bus',
+      readFile: AGENTS(
+        '<!-- totem:agent-bus role="bus" seat="totem-claude" declared="2026-07-16" -->',
+      ),
+    });
+    expect(verdict.status).toBe('pass');
+    expect(verdict.message).toContain('agent-bus declared');
+    expect(verdict.message).toContain('role "bus"');
+    expect(verdict.message).toContain('seat "totem-claude"');
+    expect(verdict.message).toContain('AGENTS.md');
+  });
+
+  it('skip (honest-absent) — no marker in an otherwise-present file, never warn', () => {
+    const verdict = detectDeclaredContract({
+      filePath: AGENTS_PATH,
+      markerToken: 'totem:agent-bus',
+      readFile: AGENTS('# AGENTS\n\nno declaration here\n'),
+    });
+    expect(verdict.status).toBe('skip');
+    expect(verdict.message).toContain('honest-absent until a repo declares');
+  });
+
+  it('skip (honest-absent) — file absent, never warn', () => {
+    const verdict = detectDeclaredContract({
+      filePath: AGENTS_PATH,
+      markerToken: 'totem:agent-bus',
+      readFile: () => undefined,
+    });
+    expect(verdict.status).toBe('skip');
+    expect(verdict.message).toContain('no AGENTS.md present');
+  });
+
+  it('skip — a marker missing the seat attr is not a valid declaration, names the missing attr (fail loud)', () => {
+    const verdict = detectDeclaredContract({
+      filePath: AGENTS_PATH,
+      markerToken: 'totem:agent-bus',
+      readFile: AGENTS('<!-- totem:agent-bus role="bus" -->'),
+    });
+    expect(verdict.status).toBe('skip');
+    expect(verdict.message).toContain('missing seat');
+    expect(verdict.message).not.toContain('missing role');
+  });
+
+  it('skip — a marker missing the role attr names role in the why-not', () => {
+    const verdict = detectDeclaredContract({
+      filePath: AGENTS_PATH,
+      markerToken: 'totem:agent-bus',
+      readFile: AGENTS('<!-- totem:agent-bus seat="totem-claude" -->'),
+    });
+    expect(verdict.status).toBe('skip');
+    expect(verdict.message).toContain('missing role');
+  });
+
+  it('never throws — a throwing reader degrades to honest-absent skip', () => {
+    const verdict = detectDeclaredContract({
+      filePath: AGENTS_PATH,
+      markerToken: 'totem:agent-bus',
+      readFile: () => {
+        throw new Error('boom');
+      },
+    });
+    // The default readFileText swallows read failures; an injected thrower is the
+    // never-throw contract at the CLI seam — but detectDeclaredContract calls the
+    // reader directly, so a thrower here would surface. Guard the honest degrade.
+    expect(verdict.status).toBe('skip');
   });
 });
 

--- a/packages/core/src/parity-detect.test.ts
+++ b/packages/core/src/parity-detect.test.ts
@@ -829,6 +829,27 @@ describe('detectDeclaredContract', () => {
     expect(verdict.message).toContain('missing role');
   });
 
+  it('skip — an empty-string role is a degenerate binding, counts as missing (greptile P2, mmnto-ai/totem#2400)', () => {
+    const verdict = detectDeclaredContract({
+      filePath: AGENTS_PATH,
+      markerToken: 'totem:agent-bus',
+      readFile: AGENTS('<!-- totem:agent-bus role="" seat="totem-claude" -->'),
+    });
+    expect(verdict.status).toBe('skip');
+    expect(verdict.message).toContain('missing role');
+    expect(verdict.message).not.toContain('missing role + seat');
+  });
+
+  it('skip — a whitespace-only seat counts as missing', () => {
+    const verdict = detectDeclaredContract({
+      filePath: AGENTS_PATH,
+      markerToken: 'totem:agent-bus',
+      readFile: AGENTS('<!-- totem:agent-bus role="bus" seat="   " -->'),
+    });
+    expect(verdict.status).toBe('skip');
+    expect(verdict.message).toContain('missing seat');
+  });
+
   it('never throws — a throwing reader degrades to honest-absent skip', () => {
     const verdict = detectDeclaredContract({
       filePath: AGENTS_PATH,

--- a/packages/core/src/parity-detect.test.ts
+++ b/packages/core/src/parity-detect.test.ts
@@ -850,6 +850,21 @@ describe('detectDeclaredContract', () => {
     expect(verdict.message).toContain('missing seat');
   });
 
+  it('pass message strips ANSI/control sequences from repo-provided role/seat (CR round 2, mmnto-ai/totem#2400)', () => {
+    const ESC = String.fromCharCode(27);
+    const verdict = detectDeclaredContract({
+      filePath: AGENTS_PATH,
+      markerToken: 'totem:agent-bus',
+      readFile: AGENTS(
+        `<!-- totem:agent-bus role="${ESC}[31mbus" seat="totem${ESC}[0m-claude" -->`,
+      ),
+    });
+    expect(verdict.status).toBe('pass');
+    expect(verdict.message).not.toContain(ESC);
+    expect(verdict.message).toContain('role "bus"');
+    expect(verdict.message).toContain('seat "totem-claude"');
+  });
+
   it('never throws — a throwing reader degrades to honest-absent skip', () => {
     const verdict = detectDeclaredContract({
       filePath: AGENTS_PATH,

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -45,6 +45,7 @@ import { z } from 'zod';
 
 import { PARITY_SENSES, type ParityContract, type ParitySense } from './parity-manifest.js';
 import { escapeRegex } from './regex-utils.js';
+import { sanitize } from './sanitize.js';
 import {
   resolveStrategyRoot,
   type StrategyResolverOptions,
@@ -1856,9 +1857,11 @@ export function detectDeclaredContract(ctx: DetectDeclaredContext): ParityContra
 
   // Presence claim ONLY — the declaration is present + well-formed. This is NOT a
   // claim that the bus executes its duties (adherence-class, Tenet 19 / §3.5).
+  // role/seat are repository content: strip ANSI/control sequences so a
+  // hostile marker cannot spoof terminal output (CR round 2, mmnto-ai/totem#2400).
   return {
     status: 'pass',
-    message: `${declarationName} declared — role "${role}" → seat "${seat}" in ${fileLabel}`,
+    message: `${declarationName} declared — role "${sanitize(role)}" → seat "${sanitize(seat)}" in ${fileLabel}`,
   };
 }
 

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -1833,12 +1833,19 @@ export function detectDeclaredContract(ctx: DetectDeclaredContext): ParityContra
 
   // A marker missing role OR seat is NOT a valid declaration: name the missing
   // attribute (fail loud, Tenet 4) but stay honest-absent (`skip`) — a malformed
-  // marker is still "not yet declared", never drift.
+  // marker is still "not yet declared", never drift. Blank counts as missing:
+  // role="" / seat="  " would mint a degenerate binding with no real referent
+  // (greptile P2 on mmnto-ai/totem#2400).
   const { role, seat } = marker;
   const missing: string[] = [];
-  if (role === undefined) missing.push('role');
-  if (seat === undefined) missing.push('seat');
-  if (role === undefined || seat === undefined) {
+  if (role === undefined || role.trim().length === 0) missing.push('role');
+  if (seat === undefined || seat.trim().length === 0) missing.push('seat');
+  if (
+    role === undefined ||
+    role.trim().length === 0 ||
+    seat === undefined ||
+    seat.trim().length === 0
+  ) {
     return {
       status: 'skip',
       message: `${declarationName}: ${ctx.markerToken} marker in ${fileLabel} is missing ${missing.join(

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -44,6 +44,7 @@ import { parse as parseYaml } from 'yaml';
 import { z } from 'zod';
 
 import { PARITY_SENSES, type ParityContract, type ParitySense } from './parity-manifest.js';
+import { escapeRegex } from './regex-utils.js';
 import {
   resolveStrategyRoot,
   type StrategyResolverOptions,
@@ -1717,6 +1718,141 @@ export function detectCapabilityProbeContract(
     ctx,
     `governance floor not suppressed in ${path.basename(ctx.consumerPath)}`,
   );
+}
+
+// ─── Declared-contract detector (Prop 305 §3 agent-bus) ──
+
+/**
+ * A parsed `<!-- totem:<token> role="…" seat="…" declared="…" -->` declaration
+ * marker (Prop 305 §3 agent-bus class). Every attribute is independently
+ * optional at PARSE time; the VALIDITY rule (a real declaration binds BOTH a
+ * role and a seat) lives in {@link detectDeclaredContract} so a missing
+ * attribute surfaces as a NAMED why-not, never a silent drop (fail loud, Tenet 4).
+ */
+export interface DeclarationMarker {
+  role?: string;
+  seat?: string;
+  /** ISO-8601 date the declaration was authored (as authored; not validated here). */
+  declared?: string;
+}
+
+/**
+ * Parse a `<!-- totem:<token> key="value" … -->` declaration marker from
+ * anywhere in `content`. Modeled on {@link parseForkMarker}: dotAll + whitespace
+ * tolerant, `.*?` non-greedy + bounded by the first `-->` (linear, no nested
+ * quantifiers → ReDoS-safe). `token` is the full bare marker name (e.g.
+ * `totem:agent-bus`) and is regex-escaped via the shared `escapeRegex`, so a
+ * `:` or any metachar is matched as a literal, never as a live pattern (the
+ * token is code-owned by the CLI registry, but escaping keeps it robust
+ * regardless). The FIRST marker for `token` wins — duplicates are ignored, the
+ * same single-match posture as {@link parseForkMarker}. The token must be
+ * followed by whitespace or `-->` (a lookahead, not `\b`), so a token never
+ * prefix-matches a longer sibling (`totem:agent-bus` vs `totem:agent-bus-v2`)
+ * and non-word-char-ending tokens need no special casing. Returns undefined
+ * when no marker for `token` is present.
+ */
+export function parseDeclarationMarker(
+  content: string,
+  token: string,
+): DeclarationMarker | undefined {
+  const markerRe = new RegExp(`<!--\\s*${escapeRegex(token)}(?=\\s|-->)(.*?)-->`, 'is');
+  const markerMatch = markerRe.exec(content);
+  if (markerMatch === null) return undefined;
+  const attrsText = markerMatch[1] ?? '';
+  const marker: DeclarationMarker = {};
+  // matchAll (not a single match()) so a safe prefix pair cannot shadow later
+  // pairs — the security lesson parseForkMarker documents; attributes are
+  // unordered + each independently optional.
+  for (const pair of attrsText.matchAll(/(\w+)\s*=\s*"([^"]*)"/g)) {
+    const value = pair[2] ?? '';
+    if (pair[1] === 'role') marker.role = value;
+    else if (pair[1] === 'seat') marker.seat = value;
+    else if (pair[1] === 'declared') marker.declared = value;
+  }
+  return marker;
+}
+
+/** Inputs + test seams for {@link detectDeclaredContract}. */
+export interface DetectDeclaredContext {
+  /** Absolute path of the file that carries the declaration marker (AGENTS.md). */
+  filePath: string;
+  /** The bare `totem:<token>` marker name the declaration is authored under (e.g. `totem:agent-bus`). */
+  markerToken: string;
+  /** Test seam — override the file read. Production callers omit it. */
+  readFile?: (absPath: string) => string | undefined;
+}
+
+/**
+ * Detect ONE `manifestation: declared` contract (Prop 305 §3 agent-bus class).
+ * A declaration SURFACE — the repo AUTHORS the binding itself in a file
+ * (AGENTS.md) via a `<!-- totem:<token> role="…" seat="…" -->` HTML-comment
+ * marker rather than installing a managed block. This sensor claims DECLARATION
+ * PRESENCE ONLY; whether the declared bus actually EXECUTES its duties is
+ * adherence-class (Tenet 19 / Prop 305 §3.5) and is NEVER inferred from this row.
+ *
+ * Deterministic, local-read-only, NEVER networks, NEVER throws, NEVER emits
+ * `fail` (CLI edge owns promotion), and NEVER `warn`/`fail` on absence — an
+ * undeclared repo is honest-absent (`skip`), the row's own "honest-absent until
+ * a repo declares" semantics, not drift.
+ *
+ *   - `pass` — marker present with BOTH role + seat parsed (a well-formed binding).
+ *   - `skip` — file absent, marker absent, or the marker is missing role/seat
+ *              (the why-not names the missing attribute — fail loud, Tenet 4).
+ */
+export function detectDeclaredContract(ctx: DetectDeclaredContext): ParityContractVerdict {
+  const readFile = ctx.readFile ?? readFileText;
+  const fileLabel = path.basename(ctx.filePath);
+  // The human declaration name is the marker token minus the `totem:` namespace
+  // (e.g. `totem:agent-bus` → `agent-bus`), so the message reads as the contract.
+  const declarationName = ctx.markerToken.startsWith('totem:')
+    ? ctx.markerToken.slice('totem:'.length)
+    : ctx.markerToken;
+
+  // File absent / unreadable → honest-absent (NEVER warn on absence).
+  let content: string | undefined;
+  try {
+    content = readFile(ctx.filePath);
+    // totem-context: the default readFileText already degrades a missing / unreadable file to undefined; wrapping the call treats a throwing INJECTED reader as the same honest-absent signal, so a degraded read can NEVER crash the doctor pipeline (the never-throws invariant, mirroring readJsonResult).
+  } catch {
+    content = undefined;
+  }
+  if (content === undefined) {
+    return {
+      status: 'skip',
+      message: `${declarationName}: no ${fileLabel} present — honest-absent until a repo declares`,
+    };
+  }
+
+  const marker = parseDeclarationMarker(content, ctx.markerToken);
+  if (marker === undefined) {
+    return {
+      status: 'skip',
+      message: `${declarationName}: no ${ctx.markerToken} declaration marker in ${fileLabel} — honest-absent until a repo declares`,
+    };
+  }
+
+  // A marker missing role OR seat is NOT a valid declaration: name the missing
+  // attribute (fail loud, Tenet 4) but stay honest-absent (`skip`) — a malformed
+  // marker is still "not yet declared", never drift.
+  const { role, seat } = marker;
+  const missing: string[] = [];
+  if (role === undefined) missing.push('role');
+  if (seat === undefined) missing.push('seat');
+  if (role === undefined || seat === undefined) {
+    return {
+      status: 'skip',
+      message: `${declarationName}: ${ctx.markerToken} marker in ${fileLabel} is missing ${missing.join(
+        ' + ',
+      )} — not a valid declaration (honest-absent until a repo declares)`,
+    };
+  }
+
+  // Presence claim ONLY — the declaration is present + well-formed. This is NOT a
+  // claim that the bus executes its duties (adherence-class, Tenet 19 / §3.5).
+  return {
+    status: 'pass',
+    message: `${declarationName} declared — role "${role}" → seat "${seat}" in ${fileLabel}`,
+  };
 }
 
 // ─── Value-equality detector (mmnto-ai/totem-strategy#738 Slice A, Proposal 296 §13) ──

--- a/packages/core/src/parity-manifest.ts
+++ b/packages/core/src/parity-manifest.ts
@@ -89,6 +89,14 @@ export const PARITY_MANIFESTATIONS = [
   'content-hash',
   'attestation',
   'capability-probe',
+  // `declared` (Prop 305 §3 agent-bus): a declaration SURFACE — the repo authors
+  // a `<!-- totem:<token> role="…" seat="…" -->` marker in its agent config; the
+  // detector (`detectDeclaredContract`) senses marker PRESENCE only, never duty
+  // execution (adherence-class, Tenet 19). NB the same `declared` token also
+  // exists on the INDEPENDENT `PARITY_SENSES` scale (below) as the sensed-state
+  // floor — same string, two orthogonal axes (manifestation vs sensed-state),
+  // intentional. Order is cosmetic (routing narrows on membership, not index).
+  'declared',
 ] as const;
 export type ParityManifestation = (typeof PARITY_MANIFESTATIONS)[number];
 


### PR DESCRIPTION
## What

Two halves of one contract, shipped together so the PR self-verifies:

1. **Declaration (AGENTS.md):** totem's Prop 305 §3 judgment-bus binding — role `bus` → seat `totem-claude` — via the `<!-- totem:agent-bus … -->` marker + the 5-point contract section (binding & fail-closed succession, judgment-density file classes with cohort defaults, lane-table pointer to mmnto-ai/totem-strategy#697, drift duties per the mmnto-ai/totem-strategy#639 operating spec, parity-row sensing note).
2. **Sensor (`totem doctor --parity`):** the `declared` manifestation class, previously the fail-loud stub ("manifestation 'declared' unrecognized by this doctor"). New `detectDeclaredContract` + `parseDeclarationMarker` in core (modeled on the `totem:fork` marker parser: linear/ReDoS-safe, matchAll attr loop, shared `escapeRegex`), a `declarationMarkersFor` registry + routing branch in the CLI ahead of the unrecognized-manifestation guard.

## Semantics (the row's own contract)

- Marker present with `role` + `seat` → **PASS**, naming the binding.
- File absent / marker absent / marker missing role or seat → **SKIP, honest-absent** with a named why-not — an undeclared repo is "honest-absent until a repo declares", never drift; the class can never gate, even under `--strict`.
- The sensor claims **declaration presence only**; whether the bus executes its duties is adherence-class (Tenet 19 / Prop 305 §3.5), never inferred from the row.

## Evidence

On this branch, `totem doctor --parity` flips the row on this very repo:

```
PASS — agent-bus declared — role "bus" → seat "totem-claude" in AGENTS.md
rollup — global: 25 pass · 0 warn · 6 info · 0 unknown · 19 skip · 0 fail
```

Tests: core parity-detect 143 passed (12 new: marker parse incl. prefix-collision `agent-bus` vs `agent-bus-v2` + pathological-input wall-clock guard; detector pass/absent/malformed/never-throws), CLI doctor-parity 90 passed (4 new routing tests; the existing unrecognized-manifestation stub test still passes — `declared` is recognized, unknowns still stub loud). Full gate: `pnpm -r build` 0 · `totem lint` PASS · ESLint 0 · `prettier --check` clean. Local review fan settled at round 1 (0 critical / 0 warn); its round-0 findings absorbed: escape helper consolidated onto the shared `regex-utils.escapeRegex`, first-marker-wins documented, `\b` replaced with a whitespace/`-->` lookahead (kills the sibling-token prefix-match class).

Lint warnings on the diff dispositioned: AGENTS.md "absolute claims" ×3 declined (contract language mirroring the sibling declarations; the over-broad voice-rule glob is mmnto-ai/totem#2034), test-idiom false-positives declined (toContain-on-why-not-text, tmpDir AGENTS.md fixture matched as a `.git/hooks` write, non-LLM suite timeout, boolean `=== undefined ||` matched as coalescing-candidate — the mmnto-ai/totem#2063 class).

## Provenance

Prop 305 §4.6 next-session charter (distribution rode the strategy-doctrine 0.1.18/0.1.19 pins, mmnto-ai/totem#2394/#2395); declaration pattern mirrors mmnto-ai/totem-strategy#892 and mmnto-ai/totem-status#107. Adoption tracking: mmnto-ai/totem-strategy#482. Changesets: `@mmnto/totem` minor + `@mmnto/cli` minor, `Consumer-impact:` tagged (additive sensing; no behavior change for repos without the marker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
