### PR TITLE
fix(parity): sanitize fork-marker owner/attested before terminal interpolation

### DIFF
--- a/.changeset/fork-marker-owner-attested-sanitize.md
+++ b/.changeset/fork-marker-owner-attested-sanitize.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/totem': patch
+---
+
+fork-marker owner/attested (repo content) sanitized before terminal interpolation — same class as the #2400 role/seat fix.
+
+`parseForkMarker`'s `owner`/`attested` attributes are repository content; a hostile `totem:fork` marker could embed ANSI/control sequences and spoof the parity readout. Route both through core `sanitize()` at the `formatForkMeta` interpolation seam (parse output stays raw), mirroring the #2400 role/seat fix; regression test injects CSI sequences into owner/attested and asserts the rendered message is clean.
+
+Consumer-impact: output-sanitization hardening, no behavior change for clean markers.

--- a/packages/core/src/parity-detect.test.ts
+++ b/packages/core/src/parity-detect.test.ts
@@ -924,6 +924,21 @@ describe('detectMechanicalContract', () => {
     expect(v.message).toContain('2026-06-03');
   });
 
+  it('intentional-fork message strips ANSI/control sequences from repo-provided owner/attested (mmnto-ai/totem#2403)', () => {
+    const ESC = String.fromCharCode(27);
+    const consumerPath = writeArtifact(
+      '.claude/skills/x/SKILL.md',
+      skillFile('DRIFTED BODY', {
+        fork: `<!-- totem:fork reason="x" owner="${ESC}[31msatur8d" attested="2026${ESC}[0m-06-03" -->`,
+      }),
+    );
+    const v = detectMechanicalContract(mechCtx({ consumerPath }));
+    expect(v.status).toBe('info');
+    expect(v.message).not.toContain(ESC);
+    expect(v.message).toContain('owner satur8d');
+    expect(v.message).toContain('attested 2026-06-03');
+  });
+
   it('pass — a fork marker present but content actually matching is still pass (no false fork)', () => {
     const consumerPath = writeArtifact(
       '.claude/skills/x/SKILL.md',

--- a/packages/core/src/parity-detect.ts
+++ b/packages/core/src/parity-detect.ts
@@ -1093,9 +1093,11 @@ export function hashManagedBlock(normalized: string): string {
 
 /** Format a fork marker's attested/owner attributes as a message suffix. */
 function formatForkMeta(fork: ForkMarker): string {
+  // attested/owner are repository content: strip ANSI/control sequences so a
+  // hostile marker cannot spoof terminal output (CR round 2, mmnto-ai/totem#2400).
   return (
-    (fork.attested !== undefined ? `, attested ${fork.attested}` : '') +
-    (fork.owner !== undefined ? `, owner ${fork.owner}` : '')
+    (fork.attested !== undefined ? `, attested ${sanitize(fork.attested)}` : '') +
+    (fork.owner !== undefined ? `, owner ${sanitize(fork.owner)}` : '')
   );
 }
 


### PR DESCRIPTION
## What

Closes #2403 — `fork.owner` / `fork.attested` are repository content and were interpolated into parity output unsanitized (the same ANSI/control terminal-spoofing class CodeRabbit caught on the new declared-marker path in #2400, fixed there for `role`/`seat`).

Fix applied at `formatForkMeta` — verified as the **sole** interpolation seam for fork-marker attrs (all 5 callers route through it); `fork.reason` is parsed but never rendered anywhere, so no seam exists for it. Sanitization happens at the seam, not at parse time, mirroring #2400 and preserving parse round-trip fidelity. CSI-injection regression test follows the #2400 test pattern.

## Gate

`pnpm -r build` 0 · full suites: core 3224 / cli 3219 tests green · `totem lint` PASS (2 warnings on the diff: the known test-idiom `toContain` false-positive class, #2063 — same decline precedent as the #2400 round; exact-string `toBe` would be brittle against the message's embedded content hashes) · ESLint 0 errors · prettier clean. Changeset: `@mmnto/totem` patch, Consumer-impact tagged.

## Provenance

Banked from CR round 2 on #2400 as the pre-existing sibling of the fixed finding; part of the 1.100.0 release shape (operator-greenlit 2026-07-16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
