### PR TITLE
feat(lint): compile-manifest staleness warning names the changed lessons + provenance

### DIFF
--- a/.changeset/staleness-warning-names-delta.md
+++ b/.changeset/staleness-warning-names-delta.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/cli': patch
+---
+
+fix(lint): compile-manifest staleness warning names the changed/added/removed lessons (capped) with last-commit provenance instead of a generic line
+
+`totem lint`'s non-blocking staleness advisory previously printed one fixed sentence that named nothing. It now diffs the lesson corpus against the commit that last wrote `compile-manifest.json` and reports which lessons changed / were added / were removed since the last compile — up to 5 by filename with their change kind, then "…and K more", each carrying the last-touching commit short-sha + author (one `git log -1` per named file via the shared safe git-exec helper). A lesson with no commit history renders `(untracked)`, distinguishing the mmnto-ai/totem#2113 class. The check stays inside its never-crash try/catch, degrades to an mtime-vs-`compiled_at` fallback when git has no anchor, and skips provenance above 500 lesson files so the naming logic never paces the lint hot path.
+
+Consumer-impact: warning TEXT change only — no behavior/exit-code change. The first line keeps the stable `Compile manifest is stale` prefix, so any consumer matching on that prefix (unlikely — it is a stderr advisory) keeps working; the remediation still points at `totem lesson compile`.

--- a/packages/cli/src/commands/lint-staleness.test.ts
+++ b/packages/cli/src/commands/lint-staleness.test.ts
@@ -1,0 +1,239 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  classifyLessonsByMtime,
+  formatStalenessWarning,
+  type LessonDelta,
+  parseLessonNameStatus,
+  PROVENANCE_LESSON_FILE_CAP,
+  type ProvenanceValue,
+  STALE_LESSON_NAME_CAP,
+  UNTRACKED_PROVENANCE,
+} from './lint-staleness.js';
+
+// The whole point of these helpers is to be PURE — no real git repo, no temp
+// dir (the cohort's no-real-git-with-cwd=temp-on-Windows rule). The "git seam"
+// is `git diff --name-status` OUTPUT, fed here as synthetic strings.
+
+const LESSONS_PREFIX = '.totem/lessons';
+const basename = (p: string): string => p.split('/').pop() ?? p;
+
+describe('parseLessonNameStatus', () => {
+  it('classifies added / changed / removed lessons', () => {
+    const raw = [
+      'A\t.totem/lessons/lesson-added.md',
+      'M\t.totem/lessons/lesson-changed.md',
+      'D\t.totem/lessons/lesson-removed.md',
+    ].join('\n');
+
+    const delta = parseLessonNameStatus(raw, LESSONS_PREFIX);
+
+    expect(delta.entries).toEqual([
+      { path: '.totem/lessons/lesson-added.md', kind: 'added' },
+      { path: '.totem/lessons/lesson-changed.md', kind: 'changed' },
+      { path: '.totem/lessons/lesson-removed.md', kind: 'removed' },
+    ]);
+  });
+
+  it('treats a rename destination as changed and a copy destination as added', () => {
+    const raw = [
+      'R096\t.totem/lessons/old-name.md\t.totem/lessons/new-name.md',
+      'C100\t.totem/lessons/src.md\t.totem/lessons/copy.md',
+    ].join('\n');
+
+    const delta = parseLessonNameStatus(raw, LESSONS_PREFIX);
+
+    // Sorted by path: copy.md < new-name.md.
+    expect(delta.entries).toEqual([
+      { path: '.totem/lessons/copy.md', kind: 'added' },
+      { path: '.totem/lessons/new-name.md', kind: 'changed' },
+    ]);
+  });
+
+  it('maps a type-change (T) to changed', () => {
+    const delta = parseLessonNameStatus('T\t.totem/lessons/lesson-t.md', LESSONS_PREFIX);
+    expect(delta.entries).toEqual([{ path: '.totem/lessons/lesson-t.md', kind: 'changed' }]);
+  });
+
+  it('filters out non-.md files and paths outside the lessons prefix', () => {
+    const raw = [
+      'M\t.totem/lessons/lesson-keep.md',
+      'M\t.totem/lessons/notes.txt', // not .md
+      'M\t.totem/compiled-rules.json', // outside prefix
+      'M\tsrc/other/lesson-elsewhere.md', // outside prefix
+    ].join('\n');
+
+    const delta = parseLessonNameStatus(raw, LESSONS_PREFIX);
+
+    expect(delta.entries).toEqual([{ path: '.totem/lessons/lesson-keep.md', kind: 'changed' }]);
+  });
+
+  it('ignores unknown status letters (e.g. unmerged) rather than guessing', () => {
+    const raw = ['U\t.totem/lessons/lesson-unmerged.md', 'A\t.totem/lessons/lesson-real.md'].join(
+      '\n',
+    );
+
+    const delta = parseLessonNameStatus(raw, LESSONS_PREFIX);
+
+    expect(delta.entries).toEqual([{ path: '.totem/lessons/lesson-real.md', kind: 'added' }]);
+  });
+
+  it('is empty for empty/whitespace input and tolerates a trailing prefix slash', () => {
+    expect(parseLessonNameStatus('', LESSONS_PREFIX).entries).toEqual([]);
+    expect(parseLessonNameStatus('\n  \n', LESSONS_PREFIX).entries).toEqual([]);
+
+    const delta = parseLessonNameStatus('A\t.totem/lessons/x.md', `${LESSONS_PREFIX}/`);
+    expect(delta.entries).toEqual([{ path: '.totem/lessons/x.md', kind: 'added' }]);
+  });
+
+  it('sorts entries by path for deterministic output', () => {
+    const raw = [
+      'A\t.totem/lessons/zeta.md',
+      'A\t.totem/lessons/alpha.md',
+      'A\t.totem/lessons/mid.md',
+    ].join('\n');
+
+    const delta = parseLessonNameStatus(raw, LESSONS_PREFIX);
+
+    expect(delta.entries.map((e) => e.path)).toEqual([
+      '.totem/lessons/alpha.md',
+      '.totem/lessons/mid.md',
+      '.totem/lessons/zeta.md',
+    ]);
+  });
+});
+
+describe('classifyLessonsByMtime', () => {
+  const COMPILED_AT = 1_000;
+
+  it('names files whose mtime is strictly after the compile instant as changed', () => {
+    const delta = classifyLessonsByMtime(
+      [
+        { path: 'newer.md', mtimeMs: 2_000 },
+        { path: 'older.md', mtimeMs: 500 },
+        { path: 'equal.md', mtimeMs: 1_000 }, // not strictly after — excluded
+      ],
+      COMPILED_AT,
+    );
+
+    expect(delta.entries).toEqual([{ path: 'newer.md', kind: 'changed' }]);
+  });
+
+  it('returns an empty delta when compiledAt is not finite (unparseable date)', () => {
+    const delta = classifyLessonsByMtime([{ path: 'a.md', mtimeMs: 9_999 }], Number.NaN);
+    expect(delta.entries).toEqual([]);
+  });
+
+  it('sorts the fallback entries by path', () => {
+    const delta = classifyLessonsByMtime(
+      [
+        { path: 'b.md', mtimeMs: 5_000 },
+        { path: 'a.md', mtimeMs: 5_000 },
+      ],
+      COMPILED_AT,
+    );
+    expect(delta.entries.map((e) => e.path)).toEqual(['a.md', 'b.md']);
+  });
+});
+
+describe('formatStalenessWarning', () => {
+  const opts = (provenance: Map<string, ProvenanceValue> | null) => ({
+    nameCap: STALE_LESSON_NAME_CAP,
+    displayNameFor: basename,
+    provenance,
+  });
+
+  it('falls back to the generic line (stable prefix + remediation) when nothing is named', () => {
+    const msg = formatStalenessWarning({ entries: [] }, opts(null));
+    expect(msg).toBe(
+      "Compile manifest is stale — lessons changed since last compile. Run 'totem lesson compile' to update.",
+    );
+    // The stable prefix stays intact for any consumer matching on it.
+    expect(msg.startsWith('Compile manifest is stale')).toBe(true);
+  });
+
+  it('names lessons with their change kind and last-commit provenance', () => {
+    const delta: LessonDelta = {
+      entries: [
+        { path: '.totem/lessons/a.md', kind: 'added' },
+        { path: '.totem/lessons/b.md', kind: 'changed' },
+      ],
+    };
+    const provenance = new Map<string, ProvenanceValue>([
+      ['.totem/lessons/a.md', { shortSha: 'abc1234', author: 'Ada Lovelace' }],
+      ['.totem/lessons/b.md', { shortSha: 'def5678', author: 'Alan Turing' }],
+    ]);
+
+    const msg = formatStalenessWarning(delta, opts(provenance));
+
+    expect(msg).toBe(
+      [
+        'Compile manifest is stale — 2 lesson(s) changed since last compile.',
+        '  • a.md (added) — abc1234 by Ada Lovelace',
+        '  • b.md (changed) — def5678 by Alan Turing',
+        "Run 'totem lesson compile' to update.",
+      ].join('\n'),
+    );
+  });
+
+  it('marks a lesson with no commit history as (untracked) — the #2113 class', () => {
+    const delta: LessonDelta = { entries: [{ path: '.totem/lessons/scratch.md', kind: 'added' }] };
+    const provenance = new Map<string, ProvenanceValue>([
+      ['.totem/lessons/scratch.md', UNTRACKED_PROVENANCE],
+    ]);
+
+    const msg = formatStalenessWarning(delta, opts(provenance));
+
+    expect(msg).toContain('  • scratch.md (added) (untracked)');
+  });
+
+  it('renders name-only (no provenance suffix) when provenance is null', () => {
+    const delta: LessonDelta = { entries: [{ path: '.totem/lessons/a.md', kind: 'changed' }] };
+
+    const msg = formatStalenessWarning(delta, opts(null));
+    const namedLine = msg.split('\n').find((l) => l.startsWith('  • '));
+
+    // The named line carries the kind but NO ` — <sha> by <author>` provenance
+    // suffix (the header line legitimately keeps its em dash).
+    expect(namedLine).toBe('  • a.md (changed)');
+    expect(msg).not.toContain('(untracked)');
+  });
+
+  it('caps the named list and appends "…and K more"', () => {
+    const entries = Array.from({ length: STALE_LESSON_NAME_CAP + 3 }, (_, i) => ({
+      path: `.totem/lessons/lesson-${String(i).padStart(2, '0')}.md`,
+      kind: 'changed' as const,
+    }));
+
+    const msg = formatStalenessWarning({ entries }, opts(null));
+    const lines = msg.split('\n');
+
+    // 1 header + nameCap named + 1 "…and K more" + 1 remediation.
+    expect(lines).toHaveLength(STALE_LESSON_NAME_CAP + 3);
+    expect(lines[0]).toBe(
+      `Compile manifest is stale — ${STALE_LESSON_NAME_CAP + 3} lesson(s) changed since last compile.`,
+    );
+    const namedLines = lines.filter((l) => l.startsWith('  • '));
+    expect(namedLines).toHaveLength(STALE_LESSON_NAME_CAP);
+    expect(msg).toContain(`  …and 3 more.`);
+    expect(lines[lines.length - 1]).toBe("Run 'totem lesson compile' to update.");
+  });
+
+  it('does not append the "more" tail when the count is exactly at the cap', () => {
+    const entries = Array.from({ length: STALE_LESSON_NAME_CAP }, (_, i) => ({
+      path: `.totem/lessons/lesson-${i}.md`,
+      kind: 'added' as const,
+    }));
+
+    const msg = formatStalenessWarning({ entries }, opts(null));
+
+    expect(msg).not.toContain('more.');
+  });
+});
+
+describe('constants', () => {
+  it('exposes a positive name cap and a provenance file cap', () => {
+    expect(STALE_LESSON_NAME_CAP).toBeGreaterThan(0);
+    expect(PROVENANCE_LESSON_FILE_CAP).toBeGreaterThan(STALE_LESSON_NAME_CAP);
+  });
+});

--- a/packages/cli/src/commands/lint-staleness.ts
+++ b/packages/cli/src/commands/lint-staleness.ts
@@ -1,0 +1,233 @@
+/**
+ * Compile-manifest staleness delta naming (mmnto-ai/totem#2399).
+ *
+ * The staleness check in `lint.ts` compares one AGGREGATE `input_hash` against
+ * the manifest and, on mismatch, warned with a fixed string that named nothing.
+ * This module turns that boolean "stale" verdict into a NAMED delta: which
+ * lesson files changed / were added / were removed since the last compile, so
+ * the consumer can tell whether the drift is theirs, rode in on a merge, or is
+ * the mmnto-ai/totem#2113 untracked-at-compile class.
+ *
+ * Every export here is PURE (no `node:fs`, no `child_process`): the classify
+ * and format logic is unit-tested without a real git repo or temp dir (the
+ * cohort's standing "no real `git` with cwd=temp on Windows" rule — it leaves
+ * undeletable temp dirs). `lint.ts` owns the impure gathering (the `git`
+ * name-status diff + `git log` provenance via the shared `safeExec` helper, and
+ * the `fs` mtime walk) and feeds the results to these helpers.
+ */
+
+// ─── Constants ──────────────────────────────────────
+
+/**
+ * Max lesson names printed in the warning before collapsing the tail to
+ * "…and K more". Keeps the advisory to a glanceable block and caps the number
+ * of per-file `git log` provenance spawns at exactly this many.
+ */
+export const STALE_LESSON_NAME_CAP = 5;
+
+/**
+ * Above this many lesson files, skip per-file provenance (name-only mode).
+ * Provenance is already bounded to at most {@link STALE_LESSON_NAME_CAP} `git
+ * log` calls, but the whole staleness check is a non-blocking advisory on the
+ * lint hot path: on a very large lesson corpus we decline to spawn git per
+ * named file at all rather than let the naming logic pace the run.
+ */
+export const PROVENANCE_LESSON_FILE_CAP = 500;
+
+// ─── Types ──────────────────────────────────────────
+
+export type LessonChangeKind = 'changed' | 'added' | 'removed';
+
+export interface LessonDeltaEntry {
+  /**
+   * Path of the changed lesson. Repo-root-relative forward-slash form when the
+   * delta came from `git diff --name-status`; lessons-dir-relative in the mtime
+   * fallback. Callers render a short display name via `path.basename`, so either
+   * basis reads correctly.
+   */
+  path: string;
+  kind: LessonChangeKind;
+}
+
+export interface LessonDelta {
+  /** Classified entries, sorted by path for deterministic output. */
+  entries: LessonDeltaEntry[];
+}
+
+/** Last-commit provenance for one named lesson. */
+export interface LessonProvenance {
+  /** Short commit sha of the last commit that touched the file. */
+  shortSha: string;
+  /** Author name of that commit. */
+  author: string;
+}
+
+/**
+ * Sentinel provenance for a lesson with no commit history — staged-but-never-
+ * committed / untracked. This is the mmnto-ai/totem#2113 class and is worth
+ * distinguishing from a real commit in the warning.
+ */
+export const UNTRACKED_PROVENANCE = 'untracked';
+
+export type ProvenanceValue = LessonProvenance | typeof UNTRACKED_PROVENANCE;
+
+export interface FormatStalenessOptions {
+  /** Max named lessons before the "…and K more" tail (usually {@link STALE_LESSON_NAME_CAP}). */
+  nameCap: number;
+  /** Map a delta `path` to the short display name shown in the warning. */
+  displayNameFor: (path: string) => string;
+  /**
+   * Per-path provenance keyed by the delta `path`. `null` disables provenance
+   * entirely (name-only mode — git unavailable, or above
+   * {@link PROVENANCE_LESSON_FILE_CAP}). When non-null, a path absent from the
+   * map simply renders without a provenance suffix.
+   */
+  provenance: Map<string, ProvenanceValue> | null;
+}
+
+// ─── Sort ────────────────────────────────────────────
+
+function sortEntries(entries: LessonDeltaEntry[]): LessonDeltaEntry[] {
+  return [...entries].sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+}
+
+// ─── Git name-status classifier (primary) ───────────
+
+/**
+ * Parse `git diff --name-status <anchor>` output into a classified lesson delta,
+ * keeping only `.md` files under `lessonsPrefix` (a repo-relative, forward-slash
+ * directory prefix such as `.totem/lessons`).
+ *
+ * Status letters map: `A`/`C` → added, `D` → removed, `M`/`T` → changed. A
+ * rename (`R`) reports its DESTINATION path as `changed` (a lesson whose path
+ * moved shifts the input hash because `generateInputHash` folds the relative
+ * path into the digest). Rename/copy lines carry `OLD<TAB>NEW`, so the current
+ * path is the third tab field; A/M/D carry `STATUS<TAB>PATH`. Unknown status
+ * letters (`U` unmerged, etc.) are ignored — best-effort naming, never a throw.
+ */
+export function parseLessonNameStatus(raw: string, lessonsPrefix: string): LessonDelta {
+  const prefix = lessonsPrefix.endsWith('/') ? lessonsPrefix : `${lessonsPrefix}/`;
+  const entries: LessonDeltaEntry[] = [];
+
+  for (const rawLine of raw.split('\n')) {
+    const line = rawLine.trim();
+    if (line.length === 0) continue;
+
+    const fields = line.split('\t');
+    const status = fields[0]?.[0];
+    if (!status) continue;
+
+    // Rename/copy carry `OLD<TAB>NEW`; the destination is the current path.
+    const isRenameOrCopy = status === 'R' || status === 'C';
+    const rawTarget = isRenameOrCopy ? fields[2] : fields[1];
+    if (!rawTarget) continue;
+
+    const target = rawTarget.replace(/\\/g, '/');
+    if (!target.startsWith(prefix) || !target.endsWith('.md')) continue;
+
+    let kind: LessonChangeKind;
+    switch (status) {
+      case 'A':
+      case 'C':
+        kind = 'added';
+        break;
+      case 'D':
+        kind = 'removed';
+        break;
+      case 'M':
+      case 'T':
+      case 'R':
+        kind = 'changed';
+        break;
+      default:
+        continue; // Unknown status (unmerged, etc.) — ignore, don't guess.
+    }
+    entries.push({ path: target, kind });
+  }
+
+  return { entries: sortEntries(entries) };
+}
+
+// ─── mtime classifier (fallback) ─────────────────────
+
+export interface LessonFileStat {
+  /** Lessons-dir-relative (or any stable) forward-slash path. */
+  path: string;
+  /** File mtime in epoch-milliseconds. */
+  mtimeMs: number;
+}
+
+/**
+ * Fallback classifier for when git is unavailable (no repo, or the manifest was
+ * never committed so there is no anchor): a lesson file whose mtime is strictly
+ * after the manifest's compile instant is reported as `changed`.
+ *
+ * mtime alone cannot recover added-vs-removed-vs-edited (a removed file has no
+ * mtime to observe; a freshly-written file is indistinguishable from an edit),
+ * so every hit is `changed` — the honest floor when there is no git baseline.
+ * A non-finite `compiledAtMs` (unparseable `compiled_at`) yields an empty delta
+ * rather than naming every file.
+ */
+export function classifyLessonsByMtime(
+  files: readonly LessonFileStat[],
+  compiledAtMs: number,
+): LessonDelta {
+  if (!Number.isFinite(compiledAtMs)) return { entries: [] };
+  const entries: LessonDeltaEntry[] = [];
+  for (const file of files) {
+    if (file.mtimeMs > compiledAtMs) entries.push({ path: file.path, kind: 'changed' });
+  }
+  return { entries: sortEntries(entries) };
+}
+
+// ─── Warning formatter ───────────────────────────────
+
+const REMEDIATION = "Run 'totem lesson compile' to update.";
+
+/**
+ * Build the single warn-block body for a stale manifest. One block, ready to
+ * hand to `uiLog.warn(TAG, …)`.
+ *
+ * - `total === 0` (nothing could be named — git unavailable and no mtime hit,
+ *   or an anchor miss): fall back to the generic advisory. The stable
+ *   `Compile manifest is stale` prefix is preserved so any consumer matching on
+ *   it keeps working, and we never assert "0 lesson(s) changed".
+ * - otherwise: a counted first line, up to `nameCap` named lessons with their
+ *   change kind and (when derivable) `— <sha> by <author>` provenance or
+ *   `(untracked)`, then "…and K more" when over the cap, then the remediation.
+ *
+ * The remediation intentionally points public consumers at `totem lesson
+ * compile`; the cohort-side compile freeze is overlay-governed, not this
+ * string's concern.
+ */
+export function formatStalenessWarning(delta: LessonDelta, opts: FormatStalenessOptions): string {
+  const total = delta.entries.length;
+  if (total === 0) {
+    return `Compile manifest is stale — lessons changed since last compile. ${REMEDIATION}`;
+  }
+
+  const lines: string[] = [
+    `Compile manifest is stale — ${total} lesson(s) changed since last compile.`,
+  ];
+
+  for (const entry of delta.entries.slice(0, opts.nameCap)) {
+    const name = opts.displayNameFor(entry.path);
+    let suffix = '';
+    if (opts.provenance) {
+      const prov = opts.provenance.get(entry.path);
+      if (prov === UNTRACKED_PROVENANCE) {
+        suffix = ' (untracked)';
+      } else if (prov) {
+        suffix = ` — ${prov.shortSha} by ${prov.author}`;
+      }
+    }
+    lines.push(`  • ${name} (${entry.kind})${suffix}`);
+  }
+
+  if (total > opts.nameCap) {
+    lines.push(`  …and ${total - opts.nameCap} more.`);
+  }
+
+  lines.push(REMEDIATION);
+  return lines.join('\n');
+}

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -1,6 +1,78 @@
 import type { TimeoutMode } from '@mmnto/totem';
 
+import type { LessonDelta, LessonFileStat, ProvenanceValue } from './lint-staleness.js';
 import type { ShieldFormat } from './shield.js';
+
+// ─── Staleness naming helpers (mmnto-ai/totem#2399) ─
+
+/**
+ * Timeout for each git spawn in the non-blocking staleness delta. Bounded so a
+ * hung git can never stall the lint hot path — the whole check is advisory and
+ * degrades to name-only / the generic line on any git failure.
+ */
+const STALENESS_GIT_TIMEOUT_MS = 5_000;
+
+type FsModule = typeof import('node:fs');
+type PathModule = typeof import('node:path');
+
+/**
+ * Recursively count `.md` files under `lessonsDir` (readdir only, never reads
+ * file content) so the caller can gate provenance on corpus size. Returns 0
+ * when the directory is unreadable — a safe floor that does not force the skip.
+ */
+function countLessonMdFiles(fs: FsModule, path: PathModule, lessonsDir: string): number {
+  let entries: import('node:fs').Dirent[];
+  try {
+    entries = fs.readdirSync(lessonsDir, { withFileTypes: true });
+    // totem-context: best-effort — an unreadable lessons dir yields 0 (does not force provenance-skip); this advisory-only count must never crash lint (mmnto-ai/totem#2399)
+  } catch {
+    return 0;
+  }
+  let count = 0;
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      count += countLessonMdFiles(fs, path, path.join(lessonsDir, entry.name));
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+/**
+ * Walk `.md` files under `lessonsDir` and return each one's mtime (ms), keyed by
+ * a lessons-dir-relative forward-slash path. Feeds the mtime fallback classifier
+ * when git has no anchor. Best-effort: an unreadable subtree contributes nothing
+ * rather than throwing.
+ */
+function walkLessonMtimes(fs: FsModule, path: PathModule, lessonsDir: string): LessonFileStat[] {
+  const out: LessonFileStat[] = [];
+  const walk = (dir: string): void => {
+    let entries: import('node:fs').Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+      // totem-context: best-effort — an unreadable subtree is skipped so this advisory-only mtime walk never crashes lint (mmnto-ai/totem#2399)
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.isFile() && entry.name.endsWith('.md')) {
+        try {
+          const rel = path.relative(lessonsDir, full).replace(/\\/g, '/');
+          out.push({ path: rel, mtimeMs: fs.statSync(full).mtimeMs });
+          // totem-context: best-effort — an unstattable file is omitted so this advisory-only mtime walk never crashes lint (mmnto-ai/totem#2399)
+        } catch {
+          continue;
+        }
+      }
+    }
+  };
+  walk(lessonsDir);
+  return out;
+}
 
 // ─── Types ──────────────────────────────────────────
 
@@ -71,20 +143,110 @@ export async function lintCommand(options: LintOptions): Promise<void> {
   const { bootstrapEngine } = await import('../utils/bootstrap-engine.js');
   await bootstrapEngine(config, configRoot);
 
-  // Non-blocking staleness check — warn if compile manifest is stale
+  // Non-blocking staleness check — warn if compile manifest is stale, and NAME
+  // the delta (which lessons changed/added/removed since last compile, with
+  // last-commit provenance) so the advisory is actionable (mmnto-ai/totem#2399).
   try {
     const fs = await import('node:fs');
     const manifestPath = path.join(cwd, config.totemDir, 'compile-manifest.json');
     if (fs.existsSync(manifestPath)) {
-      const { readCompileManifest, generateInputHash } = await import('@mmnto/totem');
+      const { readCompileManifest, generateInputHash, safeExec, findRepoRootSync } =
+        await import('@mmnto/totem');
       const { log: uiLog } = await import('../ui.js');
+      const {
+        STALE_LESSON_NAME_CAP,
+        PROVENANCE_LESSON_FILE_CAP,
+        UNTRACKED_PROVENANCE,
+        parseLessonNameStatus,
+        classifyLessonsByMtime,
+        formatStalenessWarning,
+      } = await import('./lint-staleness.js');
+
       const manifest = readCompileManifest(manifestPath);
       const lessonsDir = path.join(cwd, config.totemDir, 'lessons');
       const currentInputHash = generateInputHash(lessonsDir, cwd);
       if (currentInputHash !== manifest.input_hash) {
+        // Bounded best-effort: any git failure inside these helpers degrades to
+        // the mtime fallback (or the generic line) rather than killing the warn.
+        // The whole block stays inside the outer never-crash try/catch below.
+        const toPosix = (p: string): string => p.replace(/\\/g, '/');
+        const repoRoot = findRepoRootSync(cwd);
+
+        // Primary: classify from a `--name-status` diff against the commit that
+        // last wrote the manifest — the lesson drift since that anchor is exactly
+        // what makes the aggregate input hash disagree.
+        let delta: LessonDelta | null = null;
+        let deltaFromGit = false;
+        if (repoRoot) {
+          const lessonsPrefix = toPosix(path.relative(repoRoot, lessonsDir));
+          try {
+            const anchor = safeExec(
+              'git',
+              ['log', '-1', '--format=%H', '--', toPosix(path.relative(repoRoot, manifestPath))],
+              { cwd: repoRoot, timeout: STALENESS_GIT_TIMEOUT_MS },
+            );
+            if (anchor.length > 0 && lessonsPrefix.length > 0) {
+              const nameStatus = safeExec(
+                'git',
+                ['diff', '--name-status', anchor, '--', lessonsPrefix],
+                { cwd: repoRoot, timeout: STALENESS_GIT_TIMEOUT_MS },
+              );
+              delta = parseLessonNameStatus(nameStatus, lessonsPrefix);
+              deltaFromGit = true;
+            }
+            // totem-context: best-effort — git unavailable/errored degrades to the mtime fallback below; this advisory-only naming must never crash lint (mmnto-ai/totem#2399)
+          } catch {
+            delta = null;
+          }
+        }
+
+        // Fallback: name lessons whose mtime is after the manifest's compile
+        // instant (no git anchor available). Every hit is reported as 'changed'.
+        if (!deltaFromGit) {
+          const compiledAtMs = Date.parse(manifest.compiled_at);
+          delta = classifyLessonsByMtime(walkLessonMtimes(fs, path, lessonsDir), compiledAtMs);
+        }
+
+        const namedDelta = delta ?? { entries: [] };
+
+        // Provenance only for the git-derived delta (its paths are repo-relative,
+        // so a per-file `log -1` lookup resolves against repoRoot). Skipped
+        // entirely on a very large lesson corpus (PROVENANCE_LESSON_FILE_CAP) so
+        // the naming logic never paces the lint hot path.
+        let provenance: Map<string, ProvenanceValue> | null = null;
+        if (deltaFromGit && repoRoot && namedDelta.entries.length > 0) {
+          if (countLessonMdFiles(fs, path, lessonsDir) <= PROVENANCE_LESSON_FILE_CAP) {
+            provenance = new Map<string, ProvenanceValue>();
+            for (const entry of namedDelta.entries.slice(0, STALE_LESSON_NAME_CAP)) {
+              try {
+                const out = safeExec('git', ['log', '-1', '--format=%h|%an', '--', entry.path], {
+                  cwd: repoRoot,
+                  timeout: STALENESS_GIT_TIMEOUT_MS,
+                });
+                if (out.length === 0) {
+                  // No commit history — staged-but-uncommitted / untracked (mmnto-ai/totem#2113).
+                  provenance.set(entry.path, UNTRACKED_PROVENANCE);
+                  continue;
+                }
+                const sep = out.indexOf('|');
+                const shortSha = sep === -1 ? out : out.slice(0, sep);
+                const author = sep === -1 ? '' : out.slice(sep + 1);
+                provenance.set(entry.path, { shortSha, author });
+                // totem-context: best-effort — a per-file provenance lookup that errors leaves the entry unset (renders name-only); this advisory must never crash lint (mmnto-ai/totem#2399)
+              } catch {
+                provenance.delete(entry.path);
+              }
+            }
+          }
+        }
+
         uiLog.warn(
           TAG,
-          "Compile manifest is stale — lessons changed since last compile. Run 'totem lesson compile' to update.",
+          formatStalenessWarning(namedDelta, {
+            nameCap: STALE_LESSON_NAME_CAP,
+            displayNameFor: (p) => path.basename(p),
+            provenance,
+          }),
         );
       }
     }


### PR DESCRIPTION
## What

Closes #2399 — the compile-manifest staleness warning names its delta instead of the fixed generic line. On aggregate `input_hash` mismatch, lint now prints:

```
Compile manifest is stale — 15 lesson(s) changed since last compile.
  • lesson-1f5e358d.md (added)
  • lesson-27aecc7e.md (added)
  … (cap 5) …and 10 more.
Run 'totem lesson compile' to update.
```

(That block is the live output on this repo, whose manifest is genuinely stale under the compile freeze.)

## Design note — issue premise corrected

#2399 assumed the manifest carries per-lesson hashes; `CompileManifestSchema` carries only the aggregate (and `compiled-rules.json`'s `lessonHash` is section-granular with no source path, so it can't name files). The shipped classifier instead diffs `git name-status` against the commit that last wrote `compile-manifest.json` (real added/changed/removed, same tracked-file scope as `generateInputHash`, 2 bounded git calls via the sanctioned `safeExec` helper), degrading to mtime-vs-`compiled_at` when git is unavailable. Per-file provenance (last commit short-sha + author; `(untracked)` for the #2113 class) attaches to the ≤5 named lessons and is skipped entirely above a 500-file hot-path guard — which fires on this repo (1384 lessons), a live demonstration of the bound.

Never-crash posture preserved: everything stays inside the existing sanctioned try/catch; the stable `Compile manifest is stale` prefix is unchanged for anything matching on it.

## Gate

`pnpm -r build` 0 · full suites: cli 3236 / core 3223 green (17 new unit tests on the pure classify/format module — git-free, per the no-real-git-in-temp rule) · `totem lint` PASS 0 errors (1 advisory: the git-adapter lesson matching the sanctioned `safeExec('git', …)` idiom `status.ts` already uses) · ESLint 0 errors · prettier clean. Changeset: `@mmnto/cli` patch.

## Provenance

lc-codex DX batch item 4 of 4 (routed 2026-07-16); 1.100.0 release shape (operator-greenlit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
