### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine 0.1.19 -> 0.1.20

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
     "typescript-eslint": "^8.59.4"
   },
   "optionalDependencies": {
-    "@mmnto/strategy-doctrine": "0.1.19"
+    "@mmnto/strategy-doctrine": "0.1.20"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         version: 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
     optionalDependencies:
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.19
-        version: 0.1.19
+        specifier: 0.1.20
+        version: 0.1.20
 
   packages/cli:
     dependencies:
@@ -853,8 +853,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.19':
-    resolution: {integrity: sha512-XBsyF5J5lOVbgIz3gZaKnDIB4i+7kvbOWPGlRl/gumhkcWDv3QPFj2giOeKfwWmwAcSblFTgQib5j82Oavhxvw==}
+  '@mmnto/strategy-doctrine@0.1.20':
+    resolution: {integrity: sha512-OxOYAOeALLPdsnSExcDaSG5NEpnENWunnxPvnxWek05tSA6BH0iINCLm6vXV8owsH9zHOFjJvBpJrf+TjMS0QA==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3685,7 +3685,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.19':
+  '@mmnto/strategy-doctrine@0.1.20':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
Cohort doctrine floor moved to 0.1.20 mid-session (published by the strategy seat; surfaced here as 3 parity WARNs — pin currency + the two lock-content rows). Canonical exact-pin shape, two files only.

Verified: installed snapshot 0.1.20 · lockfile entry intact (the #630 silent-uninstall class did not fire) · `totem doctor --parity` rollup 25 pass / 0 warn / 0 fail with the pin row `PASS — installed 0.1.20 >= cohort floor 0.1.20`. Note the new prepare script (from #2406) fired on install and correctly installed canonical hooks — first live exercise of the stomp-loop fix.

Part of the 1.100.0 train: rides ahead of the Version Packages cut so the release ships against current doctrine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
