### PR TITLE
chore: totem postmerge lessons for 2400 2401 2405 2406 2407

### DIFF
--- a/.totem/lessons/lesson-02e1fd0a.md
+++ b/.totem/lessons/lesson-02e1fd0a.md
@@ -1,0 +1,6 @@
+## Lesson — Propagate POSIX chmod failures during installation
+
+**Tags:** node, os, permissions
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Swallowing file permission errors during hook installation can mask failures to make files executable. Skip `chmod` explicitly on Windows, but let POSIX `chmod` failures propagate to prevent false-positive successes.

--- a/.totem/lessons/lesson-15fbe306.md
+++ b/.totem/lessons/lesson-15fbe306.md
@@ -1,0 +1,6 @@
+## Lesson — Prevent manifest desyncs in CLI hints
+
+**Tags:** cli, git, manifest
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+CLI error hints should not instruct users to revert individual compiled artifacts via Git, as this causes state desynchronization. Instead, guide users through the proper archive-in-place or regeneration workflow.

--- a/.totem/lessons/lesson-6acdc0a6.md
+++ b/.totem/lessons/lesson-6acdc0a6.md
@@ -1,0 +1,6 @@
+## Lesson — Resolve Git directory dynamically in hooks
+
+**Tags:** git, hooks, worktrees
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Hardcoding `.git` paths in Git hooks breaks in linked worktrees where `.git` is a file rather than a directory. Always resolve the directory dynamically at runtime using `git rev-parse --git-dir`.

--- a/.totem/lessons/lesson-7c2d8cf8.md
+++ b/.totem/lessons/lesson-7c2d8cf8.md
@@ -1,0 +1,6 @@
+## Lesson — Guard hook drift repair with end markers
+
+**Tags:** git, hooks, security
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Automatic drift-repair of hooks can silently overwrite user-appended scripts if ownership is not tightly bounded. Ensure all hook templates use explicit end-markers and abort no-force updates if trailing content is detected.

--- a/.totem/lessons/lesson-9b7886de.md
+++ b/.totem/lessons/lesson-9b7886de.md
@@ -1,0 +1,6 @@
+## Lesson — Place Git revisions before double-dash separator
+
+**Tags:** git, cli
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+When constructing `git diff` or other Git commands, place revision arguments before the `--` separator to prevent Git from misinterpreting them as pathspecs.

--- a/.totem/lessons/lesson-c8299cb2.md
+++ b/.totem/lessons/lesson-c8299cb2.md
@@ -1,0 +1,6 @@
+## Lesson — Guard against token prefix collisions
+
+**Tags:** regex, parsing, security
+**Scope:** packages/core/src/parity-detect.ts
+
+Using word boundaries (`\b`) to match custom comment markers can cause prefix collisions with longer sibling tokens (e.g., matching `agent-bus` inside `agent-bus-v2`). Instead, use a lookahead for whitespace or the closing tag delimiter to ensure exact matches.

--- a/.totem/lessons/lesson-e583eda9.md
+++ b/.totem/lessons/lesson-e583eda9.md
@@ -1,0 +1,6 @@
+## Lesson — Validate config docs against Zod schemas
+
+**Tags:** zod, configuration, documentation
+**Scope:** docs/wiki/**/*.md, README.md
+
+Documented configuration examples can be silently stripped by Zod if they use incorrect nesting, casing, or unsupported fields. Always verify that documentation matches the exact structure and types defined in the schema to prevent silent feature failures.

--- a/.totem/lessons/lesson-e7bb4808.md
+++ b/.totem/lessons/lesson-e7bb4808.md
@@ -1,0 +1,6 @@
+## Lesson — Sanitize terminal outputs at rendering seams
+
+**Tags:** security, terminal, sanitization
+**Scope:** packages/core/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Sanitize untrusted repository metadata at the terminal rendering seam rather than during parsing. This prevents ANSI escape sequence injection while preserving raw data fidelity for round-trip operations.

--- a/.totem/lessons/lesson-ea83dd38.md
+++ b/.totem/lessons/lesson-ea83dd38.md
@@ -1,0 +1,6 @@
+## Lesson — Avoid line numbers in documentation citations
+
+**Tags:** documentation, maintenance
+**Scope:** docs/**/*.md, README.md
+
+Hardcoded file-and-line citations quickly become stale as codebases evolve. Use file-level or symbol-level citations to ensure references remain drift-resistant.

--- a/.totem/lessons/lesson-f7771349.md
+++ b/.totem/lessons/lesson-f7771349.md
@@ -1,0 +1,6 @@
+## Lesson — Validate trimmed attribute values explicitly
+
+**Tags:** validation, parsing, security
+**Scope:** packages/core/src/parity-detect.ts
+
+Checking only for undefined attributes when parsing custom HTML/markdown markers allows empty (`role=""`) or whitespace-only values to slip through. Explicitly trim and verify attribute truthiness to prevent degenerate pass states from bypassing validation.


### PR DESCRIPTION
## What

Postmerge lesson extraction for the 1.100.0 train (#2400 #2401 #2405 #2406 #2407; the #2408 pin chore skipped — nothing to mine). 10 lessons: chmod-failure propagation, manifest-desyncing CLI hints, dynamic git-dir resolution in hooks, end-marker-bounded drift repair, `--`-terminated revisions, marker prefix-collision lookaheads, config-docs-vs-Zod silent-strip class, sanitize-at-the-rendering-seam, drift-resistant citations, trimmed-attribute validation.

Compile steps SKIPPED under the standing rule-compilation freeze (2026-05-17) — lessons land as inert corpus for the spine. Curation read done on all 10 (no inverted-extract or interim-proposal classes); two scopes hand-sharpened: the config-docs lesson re-homed from CLI source to `docs/wiki/** + README.md` (where its drift class actually lives), the citations lesson gained a docs scope. Bot rounds skipped per the #2392 precedent: lint ignores lesson files, the curation gate is the read above, and the compile path is frozen.

## Provenance

Extraction per the postmerge skill (wrap retired); staged paths named (`.totem/lessons/` only — no compiled-rules/manifest mutations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
