### PR TITLE
docs(reference): gemini-2.5 rows past their June 17 deprecation — relabel legacy, point to current models

### DIFF
--- a/docs/reference/supported-models.md
+++ b/docs/reference/supported-models.md
@@ -14,15 +14,15 @@ Used by `totem review`, `totem spec`, `totem triage`, `totem lesson extract`, et
 
 ### Google Gemini
 
-| Role                | Model ID                         | Notes                                                                                                                                            |
-| ------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Flagship (agentic)  | `gemini-3.5-flash`               | GA flagship — coding/agentic; **Totem's default for all Gemini roles since 2026-07-14** ($1.50/$9 flat; beats 3.1 Pro on coding/agentic)         |
-| Previous default    | `gemini-3-flash-preview`         | Preview — superseded as Totem default by `gemini-3.5-flash`                                                                                      |
-| Pro (complex tasks) | `gemini-3.1-pro-preview`         | Replaced `gemini-3-pro-preview` (March 2026). Still preview-only; $2/$12 (→$4/$18 >200k). Fallback if Flash prose quality regresses on docs/spec |
-| Image generation    | `gemini-3.1-flash-image-preview` | Flash variant optimized for image tasks                                                                                                          |
-| Fast-lite (newest)  | `gemini-3.1-flash-lite`          | 2.5x faster TTFT than Flash, lowest cost                                                                                                         |
-| Stable fast         | `gemini-2.5-flash`               | GA — **deprecating June 17, 2026**                                                                                                               |
-| Stable pro          | `gemini-2.5-pro`                 | GA — **deprecating June 17, 2026**                                                                                                               |
+| Role                     | Model ID                         | Notes                                                                                                                                            |
+| ------------------------ | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Flagship (agentic)       | `gemini-3.5-flash`               | GA flagship — coding/agentic; **Totem's default for all Gemini roles since 2026-07-14** ($1.50/$9 flat; beats 3.1 Pro on coding/agentic)         |
+| Previous default         | `gemini-3-flash-preview`         | Preview — superseded as Totem default by `gemini-3.5-flash`                                                                                      |
+| Pro (complex tasks)      | `gemini-3.1-pro-preview`         | Replaced `gemini-3-pro-preview` (March 2026). Still preview-only; $2/$12 (→$4/$18 >200k). Fallback if Flash prose quality regresses on docs/spec |
+| Image generation         | `gemini-3.1-flash-image-preview` | Flash variant optimized for image tasks                                                                                                          |
+| Fast-lite (newest)       | `gemini-3.1-flash-lite`          | 2.5x faster TTFT than Flash, lowest cost                                                                                                         |
+| Legacy fast (deprecated) | `gemini-2.5-flash`               | **Deprecated June 17, 2026** — do not target for new work; use `gemini-3.5-flash`                                                                |
+| Legacy pro (deprecated)  | `gemini-2.5-pro`                 | **Deprecated June 17, 2026** — do not target for new work; use `gemini-3.1-pro-preview`                                                          |
 
 **Listing API:** `GET https://generativelanguage.googleapis.com/v1beta/models?key=$GEMINI_API_KEY`
 


### PR DESCRIPTION
## What

`docs/reference/supported-models.md` still listed `gemini-2.5-flash` ("Stable fast") and `gemini-2.5-pro` ("Stable pro") as GA recommendations with "deprecating June 17, 2026" — a month past the boundary. This relabels both rows Legacy (deprecated), states the deprecation as past, and points to the current replacements (`gemini-3.5-flash` / `gemini-3.1-pro-preview`).

## Why now

Surfaced by strategy's tier-3 premise sweep today (mmnto-ai/totem-strategy#639, comment 5001426712); Prop 297 L112 had flagged the flash row "should not wait" back in mid-June.

## Scope notes

- Docs-only; no changeset (no releasable surface). Prettier re-aligned the table, hence the 9-line diff for a 2-row change.
- Other `gemini-2.5` references were swept and deliberately left: compiled-lesson/export surfaces (frozen under rule-compilation), test fixtures (arbitrary IDs), and two code remedy-text examples (`packages/cli/src/utils.ts:703`, `packages/cli/src/orchestrators/orchestrator.ts:232`) — the utils.ts remedy text is already implicated by the lc spec model-UX datapoint staged to the #2106 lane, so it routes with that work rather than this doc fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
