### PR TITLE
feat(cli): hooksCommand exit-code contract + managed session-hook bounded drift-repair (#2410 PR-A)

### DIFF
--- a/.changeset/2410-session-hook-drift-repair-contract.md
+++ b/.changeset/2410-session-hook-drift-repair-contract.md
@@ -1,0 +1,11 @@
+---
+'@mmnto/cli': minor
+---
+
+feat(cli): hooksCommand exit-code contract + managed session-hook bounded drift-repair.
+
+- **Exit-code contract test block (mmnto-ai/totem#2410 slice 2):** a dedicated falsifying test locks `totem hook install`'s 0/1 semantics (Tenet 19) — exit 0 ⟺ {fresh install, already-current, bounded drift-repair (git hook AND session hook), declared skips (not-a-git-repo, hook-manager-detected)}, exit ≠0 ⟺ a genuine hook-write failure propagates, and `--check` is exactly 0/1 on all-present-with-marker vs missing/markerless.
+- **Managed session-hook regeneration (slice 3):** the marker-headed whole-file `.claude/hooks/*.cjs` + `.gemini/hooks/*.js` artifacts gain the mmnto-ai/totem#2406 bounded-ownership end marker (`// [totem] end auto-generated`) and are now drift-repaired in place by `totem hook install` via the new `MANAGED_SESSION_HOOKS` roster (regenerate-only-if-present — creation stays with `totem init`; a user-owned file carrying no Totem marker is never touched, even under `--force`). `totem init`'s `scaffoldFile` picks up the same bounded self-repair (new `refreshed` action).
+- **Truthful messages:** a bare drift-repair now prints `Drift-repaired … (totem-owned bounded region)`; `Force-overwritten …` prints only when `--force` was actually passed (was previously the misleading force text on every in-place repair). The `--check` failure remedy now names `totem hook install` (not the deprecated `totem hooks`).
+
+Consumer-impact: existing marker-headed session hooks (`.claude/hooks/*.cjs`, `.gemini/hooks/*.js`) each need one `totem hook install --force` after upgrade to adopt the end marker, after which bare `totem hook install` self-repairs their drift (identical to the shipped mmnto-ai/totem#2406 git-hook migration).

--- a/.totem/specs/2410-prepare-contract.md
+++ b/.totem/specs/2410-prepare-contract.md
@@ -1,0 +1,141 @@
+# Spec: #2410 — prepare-script contract build slice (strategy#894 Option B)
+
+> Provenance: hand-authored from mmnto-ai/totem#2410, the strategy#894 ruling
+> (comment 5000993265), and source reads of install-hooks.ts / init.ts /
+> init-templates.ts / doctor-parity.ts. The `totem spec` generation for this
+> slug produced an unrelated hallucinated task (ParityContract utility) and was
+> discarded — recorded as a spec-lane datapoint on mmnto-ai/totem#2106.
+
+### Problem statement
+
+Three slices, landing as two PRs (A = slices 2+3, fork-independent of the
+convention text strategy is authoring concurrently; B = slice 1, carries the
+couple-on-merge gate):
+
+1. **(PR-B)** `totem init` distributes a managed `.cjs` prepare wrapper;
+   consumer `package.json` `prepare` invokes it. ENOENT → declared skip 0;
+   CLI present → `totem hook install`; genuine failure → exit 1.
+2. **(PR-A)** Dedicated exit-code contract test block on `hooksCommand`.
+3. **(PR-A)** Managed session-hook regeneration: marker-headed whole-file
+   artifacts (`.claude/hooks/*.cjs`, `.gemini/hooks/*.js`) gain the #2406
+   bounded drift-repair semantics, reachable via `totem hook install`.
+
+### Ground truth (verified at source, 1.100.0)
+
+- `hooksCommand` (install-hooks.ts:800): not-a-git-repo → stderr notice +
+  return **0**; hook-manager detected → guidance + **0**; `--check` ok → **0**,
+  missing → `process.exit(1)`; install path throws → `handleError` → **≠0**.
+- install-hooks.ts:820 `--check` failure remedy still names the deprecated
+  plural `totem hooks`.
+- `installGitHook` classes: `installed | exists | appended | skipped-non-shell |
+overwritten`; bare drift-repair requires bounded ownership
+  (`isTotemOwnedWholeFile`: marker opens file, end marker present, nothing after).
+- `hooksCommand` prints "Force-overwritten" for `overwritten` even when the
+  write was a bare (no-force) drift-repair.
+- `scaffoldFile` (init.ts:95): marker present → `exists`, never refreshes —
+  the lc#806 stale-SessionStart mechanism. Session-hook templates carry a
+  header marker (`TOTEM_FILE_MARKER`) but **no end marker** today.
+- Eject's `TOTEM_SCAFFOLDED_FILES` enumerates the fully-totem-owned artifacts.
+
+## Implementation Design
+
+### Scope
+
+PR-A freezes `hooksCommand`'s exit-code contract in tests, fixes the stale
+remedy verb and the misleading bare-repair message, and extends bounded
+drift-repair to managed session hooks behind `totem hook install`. PR-B adds
+the init-distributed prepare wrapper + package.json wiring + a doctor parity
+row. NOT in scope: convention text (strategy's lane), consumer-repo
+propagation, totem's own `tools/` byte-identity variant, `--check` growing
+session-hook coverage (doctor `--parity` stays the drift sensor), any change
+to skills/settings.json distribution.
+
+### Data model deltas
+
+- **`MANAGED_SESSION_HOOKS: ReadonlyArray<{rel: string; content: string; marker: string; endMarker: string}>`**
+  (new, init-templates.ts) — the regeneration roster: `.claude/hooks/{PreWriteShield,SessionStart,gate-wrapper}.cjs`,
+  `.gemini/hooks/{SessionStart,BeforeTool}.js`. Written at module load from
+  existing template constants; read by init's installers, `hook install`, and
+  the tools-parity test. Invariant: every entry's `content` embeds its own
+  `marker` + `endMarker` (locked by test).
+- **End markers on session-hook templates** (new constants, e.g.
+  `TOTEM_FILE_END = '// [totem] end auto-generated'`) — appended to each
+  template. Same collision rules as #2406 git-hook end markers.
+- **`scaffoldFile` return union gains `'refreshed'`** (init.ts) — emitted only
+  on bounded drift-repair. Callers mapping to `HookInstallerResult` map
+  `refreshed → 'merged'` (mirrors scaffoldClaudeSkill's mapping).
+- **PR-B: `PREPARE_WRAPPER` template** (init-templates.ts) — dependency-free
+  `.cjs`, distributed to `.totem/prepare.cjs`, marker-headed + end-marker-bounded,
+  member of the regeneration roster. Resolves the CLI via
+  `require.resolve('@mmnto/cli/package.json')` → bin path, spawns
+  `process.execPath [bin, 'hook', 'install']` (never a shell — Windows
+  quoting class, #2351); `MODULE_NOT_FOUND` → declared-skip notice + exit 0;
+  child exit code propagated verbatim.
+- No new config fields. No reserved keys.
+
+### State lifecycle
+
+All artifacts are persistent committed files in the consumer repo, owned at
+write time by whichever verb ran (`init` or `hook install`) — single-writer
+per invocation, no runtime state containers. The wrapper is stateless per
+`pnpm install` run. Roster constants are module-lifetime immutables.
+
+### Failure modes
+
+| Failure                                                                         | Category               | Agent-facing surface                                                                                             | Recovery                                                   |
+| ------------------------------------------------------------------------------- | ---------------------- | ---------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `hook install` outside a git repo                                               | init                   | stderr notice, exit 0 (declared skip — contract-frozen)                                                          | run inside a repo                                          |
+| `--check` with missing/markerless hooks                                         | runtime                | stderr + exit 1 (contract-frozen); remedy now names `totem hook install`                                         | run `totem hook install`                                   |
+| Hook write throws (perms/FS)                                                    | runtime                | thrown → `handleError` → exit ≠0                                                                                 | fix FS state, rerun                                        |
+| Session hook exists, marker-headed, **no end marker** (all current deployments) | permanent-until-forced | `exists` + one-line notice naming `--force` (mirrors #2406 legacy path; doctor `--parity` already prescribes it) | one `totem hook install --force`, then bounded self-repair |
+| Session hook user-owned (no marker / content after end marker)                  | permanent              | `skipped`/`exists`, never overwritten without `--force`                                                          | user merges manually or forces                             |
+| Wrapper: CLI unresolvable                                                       | init                   | stderr declared-skip notice, exit 0 (strategy#630 class)                                                         | install @mmnto/cli, reinstall                              |
+| Wrapper: CLI resolvable but `hook install` fails                                | runtime                | child's stderr, exit code propagated ≠0 — **prepare fails loud** (the #894 Tenet-4 core)                         | fix underlying failure                                     |
+| PR-B: `package.json` has a different existing `prepare`                         | permanent              | init declines + prints the canonical line to add (no overwrite of user-owned content)                            | user wires manually                                        |
+| PR-B: `package.json` unparseable                                                | runtime                | init error surface (existing readJson posture)                                                                   | fix JSON                                                   |
+
+No silent-degradation rows.
+
+### Invariants to lock in via tests (the slice-2 contract block)
+
+- Exit 0 ⟺ {fresh install, already-current, bounded drift-repair, declared
+  skips (non-repo, hook-manager)}; exit ≠0 ⟺ genuine failure; `--check` is
+  exactly 0/1 on all-present-with-marker vs not.
+- Bare install never mutates a file that is not a bounded totem-owned whole
+  file (git hook OR session hook); `--force` is the only unbounded write.
+- A legacy marker-headed session hook without an end marker is never bare-repaired.
+- Regenerated artifacts always carry marker + end marker (roster invariant),
+  so post-`--force` files are self-repairing.
+- `overwritten` via bare repair and via `--force` print distinct messages
+  ("Drift-repaired…" vs "Force-overwritten…").
+- Wrapper: exit code is 0 on MODULE_NOT_FOUND, equals child exit otherwise;
+  never spawns through a shell.
+- PR-B init: `prepare` entry is added only when absent or already-canonical.
+
+### Open questions
+
+1. **Question:** Session-hook end-marker migration means every existing
+   deployment (including totem's own and lc's) declines bare repair until one
+   `--force`. Accept?
+   **Options:** (a) accept — identical to the shipped #2406 git-hook migration,
+   doctor remedy already prescribes `--force`; (b) grandfather markerless files
+   into bare repair — violates the bounded-ownership lesson (clobbers appended
+   user content).
+   **Recommendation:** (a).
+2. **Question:** Wrapper home path. **Options:** `.totem/prepare.cjs`
+   (neutral, beside `.totem/hooks/` precedent); `tools/` (collides with
+   totem-repo-only convention). **Recommendation:** `.totem/prepare.cjs`.
+3. **Question:** Should `hook install` (not just init) also distribute the
+   wrapper file itself? **Options:** (a) no — init distributes, hook install
+   regenerates roster members it finds present; (b) yes — hook install creates
+   it too. **Recommendation:** (a): creation is an adoption decision (init),
+   regeneration is maintenance (hook install); avoids surprise file creation
+   in repos that opted out.
+
+### Verification
+
+Per slice: failing test first → implement → `pnpm -r build && pnpm -r test` →
+full-branch `totem lint --base main` → repo-wide `format:check` + ESLint →
+changeset (minor, @mmnto/cli; consumer-impact tag shape) → PR. PR-B merge
+additionally gated on: poll `totem mail` + re-read strategy#894 convention
+state (couple-on-merge).

--- a/packages/cli/src/commands/gate-install.test.ts
+++ b/packages/cli/src/commands/gate-install.test.ts
@@ -11,7 +11,7 @@ import { ejectCommand } from './eject.js';
 import { gateInstallCommand, resolveGateEvents } from './gate.js';
 import { commandInstallsGate, GATE_WRAPPER_REL, installGates } from './gate-install.js';
 import { initCommand } from './init.js';
-import { CLAUDE_GATE_WRAPPER } from './init-templates.js';
+import { CLAUDE_GATE_WRAPPER, TOTEM_FILE_END, TOTEM_FILE_MARKER } from './init-templates.js';
 
 /**
  * CLI-seam tests for `totem gate install` + the parameterized gate wrapper
@@ -94,6 +94,20 @@ describe('installGates / gate install (settings merge)', () => {
     // wrapper scaffold + one entry merge
     expect(results.some((r) => r.file === GATE_WRAPPER_REL && r.action === 'created')).toBe(true);
     expect(fs.existsSync(path.join(cwd, '.claude', 'hooks', 'gate-wrapper.cjs'))).toBe(true);
+    expect(gateEntryCount(cwd, 'freeze-check')).toBe(1);
+  });
+
+  it('drift-repairs a bounded stale gate-wrapper during install (refreshed → merged, mmnto-ai/totem#2413)', () => {
+    // Plant a bounded-but-stale wrapper: marker opens it, end marker present, body drifted.
+    const wrapperPath = path.join(cwd, '.claude', 'hooks', 'gate-wrapper.cjs');
+    fs.mkdirSync(path.dirname(wrapperPath), { recursive: true });
+    fs.writeFileSync(wrapperPath, `${TOTEM_FILE_MARKER}\nstale\n${TOTEM_FILE_END}\n`, 'utf-8');
+
+    const results = installGates(cwd, ['freeze-check']);
+    // gate install now threads the end marker, so scaffoldFile drift-repairs the bounded
+    // wrapper (`refreshed`) and gate-install maps that to `merged` (a write happened).
+    expect(results.find((r) => r.file === GATE_WRAPPER_REL)!.action).toBe('merged');
+    expect(fs.readFileSync(wrapperPath, 'utf-8')).toBe(CLAUDE_GATE_WRAPPER);
     expect(gateEntryCount(cwd, 'freeze-check')).toBe(1);
   });
 

--- a/packages/cli/src/commands/gate-install.ts
+++ b/packages/cli/src/commands/gate-install.ts
@@ -137,7 +137,16 @@ export function installGates(
   const wrapperResult = scaffoldFile(wrapperPath, CLAUDE_GATE_WRAPPER, TOTEM_FILE_MARKER);
   results.push({
     file: GATE_WRAPPER_REL,
-    action: wrapperResult.action === 'exists' ? 'skipped' : wrapperResult.action,
+    // `exists` normalizes to `skipped` (no write, no change); a `refreshed`
+    // drift-repair (scaffoldFile's new bounded-repair action, mmnto-ai/totem#2410 —
+    // unreachable here since this call threads no end marker, but kept type-safe)
+    // maps to `merged` (a write happened). `created` passes through.
+    action:
+      wrapperResult.action === 'exists'
+        ? 'skipped'
+        : wrapperResult.action === 'refreshed'
+          ? 'merged'
+          : wrapperResult.action,
     err: wrapperResult.err,
   });
 

--- a/packages/cli/src/commands/gate-install.ts
+++ b/packages/cli/src/commands/gate-install.ts
@@ -5,6 +5,7 @@ import { scaffoldFile } from './init.js';
 import {
   CLAUDE_GATE_WRAPPER,
   CLAUDE_GATE_WRAPPER_ENTRY,
+  TOTEM_FILE_END,
   TOTEM_FILE_MARKER,
 } from './init-templates.js';
 
@@ -134,12 +135,18 @@ export function installGates(
   //    GateInstallResult.action stays within created|merged|skipped (both mean
   //    "no write happened, no change") — see GateInstallResult below.
   const wrapperPath = path.join(cwd, '.claude', 'hooks', 'gate-wrapper.cjs');
-  const wrapperResult = scaffoldFile(wrapperPath, CLAUDE_GATE_WRAPPER, TOTEM_FILE_MARKER);
+  // Thread the end marker (mmnto-ai/totem#2413) so a bounded drifted gate-wrapper is
+  // actually drift-repaired (`refreshed`) during gate install, not left stale.
+  const wrapperResult = scaffoldFile(
+    wrapperPath,
+    CLAUDE_GATE_WRAPPER,
+    TOTEM_FILE_MARKER,
+    TOTEM_FILE_END,
+  );
   results.push({
     file: GATE_WRAPPER_REL,
     // `exists` normalizes to `skipped` (no write, no change); a `refreshed`
-    // drift-repair (scaffoldFile's new bounded-repair action, mmnto-ai/totem#2410 —
-    // unreachable here since this call threads no end marker, but kept type-safe)
+    // bounded drift-repair (scaffoldFile's bounded-repair action, mmnto-ai/totem#2410)
     // maps to `merged` (a write happened). `created` passes through.
     action:
       wrapperResult.action === 'exists'

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -63,6 +63,20 @@ ${REFLEX_END}
 
 export const TOTEM_FILE_MARKER = '// [totem] auto-generated';
 
+/**
+ * The end marker that CLOSES every managed whole-file session hook template
+ * (`.claude/hooks/*.cjs`, `.gemini/hooks/*.js`). Mirrors the #2406 git-hook
+ * bounded-ownership semantics (`TOTEM_HOOK_END` et al.) for the JS/CJS hook
+ * family: a marker-headed file whose end marker is present with nothing after
+ * it is a bounded totem-OWNED whole file, safe to drift-repair without
+ * `--force`. A LEGACY file written by a pre-#2410 template carries no in-file
+ * end marker → not bounded → declines bare repair and takes one
+ * `totem hook install --force` (identical to the shipped #2406 git-hook
+ * migration). Collision-free against {@link TOTEM_FILE_MARKER}: the `end `
+ * infix means the start marker is never a substring of the end marker.
+ */
+export const TOTEM_FILE_END = '// [totem] end auto-generated';
+
 // ─── Bare-ref regex (xrepo-qualify-refs sealed at mmnto-ai/totem-strategy#145) ───
 //
 // Mirrors the compiled rule pattern at lessonHash "xrepo-qualify-refs"
@@ -120,6 +134,7 @@ try {
   // surface a NON-fatal breadcrumb (matches the Claude-side hook) rather than swallow.
   process.stderr.write('[SessionStart] orient briefing unavailable (non-fatal): ' + (err instanceof Error ? err.message : String(err)) + '\\n');
 }
+${TOTEM_FILE_END}
 `;
 
 export const GEMINI_BEFORE_TOOL = `// [totem] auto-generated — Gemini CLI BeforeTool hook
@@ -175,6 +190,7 @@ module.exports = function beforeTool(toolName, toolInput) {
     throw new Error('[Totem Error] Shield check failed. Fix violations before pushing.\\n' + err.message);
   }
 };
+${TOTEM_FILE_END}
 `;
 
 export const GEMINI_SKILL = `<!-- [totem] auto-generated — Totem Architect skill -->
@@ -309,6 +325,7 @@ process.stdin.on('end', () => {
   );
   process.exit(2);
 });
+${TOTEM_FILE_END}
 `;
 
 export const CLAUDE_PREWRITESHIELD_ENTRY = {
@@ -461,6 +478,7 @@ try {
       '\\n',
   );
 }
+${TOTEM_FILE_END}
 `;
 
 export const CLAUDE_SESSION_START_ENTRY = {
@@ -689,6 +707,7 @@ process.stdin.on('end', () => {
   );
   process.exit(2);
 });
+${TOTEM_FILE_END}
 `;
 
 // The PreToolUse entry constant for the freeze-check gate. The \`--event\`
@@ -715,6 +734,69 @@ export const CLAUDE_GATE_WRAPPER_ENTRY = {
     },
   ],
 };
+
+// ─── Managed session-hook regeneration roster (mmnto-ai/totem#2410 PR-A) ───
+//
+// The whole-file, marker-headed `.cjs` / `.js` hook artifacts that `totem init`
+// distributes and `totem hook install` regenerates-if-present. Each entry pairs
+// the repo-relative path with its canonical content + the marker/end-marker that
+// bound the totem-OWNED region (the #2406 git-hook semantics, generalized to the
+// JS/CJS hook family). Read by init's installers, `hook install`'s
+// `regenerateManagedSessionHooks`, and the roster-invariant test.
+//
+// INVARIANT (locked by test): every entry's `content` embeds its own `marker`
+// AND `endMarker`, so a regenerated artifact is always bounded-owned and thus
+// self-repairing on the next bare `totem hook install`.
+//
+// Not the git hooks (`.git/hooks/*` — those ride `installGitHook`), and not the
+// distributed skills (marker-block REPLACE, a different ownership model). The
+// gate-wrapper is a roster member because it is a marker-headed whole file even
+// though its creation is owned by `gate install` / `init --gates=` rather than
+// the default Claude installer.
+
+export interface ManagedSessionHook {
+  /** Repo-relative install path (POSIX separators). */
+  rel: string;
+  /** Canonical whole-file content — embeds `marker` at the head and `endMarker` at the tail. */
+  content: string;
+  /** Ownership/presence marker that must OPEN the file. */
+  marker: string;
+  /** End marker that must CLOSE the bounded totem-owned region. */
+  endMarker: string;
+}
+
+export const MANAGED_SESSION_HOOKS: ReadonlyArray<ManagedSessionHook> = [
+  {
+    rel: '.claude/hooks/PreWriteShield.cjs',
+    content: CLAUDE_PREWRITESHIELD,
+    marker: TOTEM_FILE_MARKER,
+    endMarker: TOTEM_FILE_END,
+  },
+  {
+    rel: '.claude/hooks/SessionStart.cjs',
+    content: CLAUDE_SESSION_START,
+    marker: TOTEM_FILE_MARKER,
+    endMarker: TOTEM_FILE_END,
+  },
+  {
+    rel: '.claude/hooks/gate-wrapper.cjs',
+    content: CLAUDE_GATE_WRAPPER,
+    marker: TOTEM_FILE_MARKER,
+    endMarker: TOTEM_FILE_END,
+  },
+  {
+    rel: '.gemini/hooks/SessionStart.js',
+    content: GEMINI_SESSION_START,
+    marker: TOTEM_FILE_MARKER,
+    endMarker: TOTEM_FILE_END,
+  },
+  {
+    rel: '.gemini/hooks/BeforeTool.js',
+    content: GEMINI_BEFORE_TOOL,
+    marker: TOTEM_FILE_MARKER,
+    endMarker: TOTEM_FILE_END,
+  },
+];
 
 // ─── Claude Code skill distribution (mmnto-ai/totem#1890 Phase C slice 3) ───
 //

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -77,6 +77,45 @@ export const TOTEM_FILE_MARKER = '// [totem] auto-generated';
  */
 export const TOTEM_FILE_END = '// [totem] end auto-generated';
 
+/**
+ * Whether the totem `marker` OPENS the file — only whitespace may precede it. The
+ * ownership GATE for the session-hook family (`.claude/hooks/*.cjs`,
+ * `.gemini/hooks/*.js` — no shebang preamble): a user-owned file that merely QUOTES
+ * the marker string somewhere in its body is NOT marker-headed and must never be
+ * regenerated or overwritten, not even under `--force` (mmnto-ai/totem#2413 — the
+ * `includes(marker)` false-positive that let a quoting user file be clobbered).
+ * Distinct from install-hooks' `isTotemOwnedWholeFile`, which additionally tolerates
+ * a `#!`-shebang preamble that is legitimate for git hooks but never appears here.
+ */
+export function markerOpensFile(content: string, marker: string): boolean {
+  const idx = content.indexOf(marker);
+  if (idx === -1) return false;
+  return content.slice(0, idx).trim().length === 0;
+}
+
+/**
+ * Whether a marker-headed session-hook file is a bounded totem-OWNED whole file —
+ * the precondition for a no-force drift-repair (mmnto-ai/totem#2410). The single
+ * shared ownership checker for the session-hook family, consumed by both init's
+ * `scaffoldFile` and install-hooks' `regenerateManagedSessionHooks`
+ * (mmnto-ai/totem#2413 — was two divergent twins). The session-hook analog of
+ * install-hooks' git-hook `isTotemOwnedWholeFile`, minus the shebang preamble the
+ * JS/CJS family never carries:
+ *   - the marker must OPEN the file (only whitespace before it — no user content);
+ *   - the `endMarker` must be present;
+ *   - nothing but trailing whitespace may follow the end marker (else a whole-file
+ *     rewrite would clobber appended user content).
+ */
+export function isBoundedOwnedFile(content: string, marker: string, endMarker: string): boolean {
+  const idx = content.indexOf(marker);
+  if (idx === -1) return false;
+  if (content.slice(0, idx).trim().length !== 0) return false;
+  const end = content.indexOf(endMarker, idx + marker.length);
+  if (end === -1) return false;
+  if (content.slice(end + endMarker.length).trim().length !== 0) return false;
+  return true;
+}
+
 // ─── Bare-ref regex (xrepo-qualify-refs sealed at mmnto-ai/totem-strategy#145) ───
 //
 // Mirrors the compiled rule pattern at lessonHash "xrepo-qualify-refs"

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -218,6 +218,21 @@ describe('scaffoldFile', () => {
     expect(fs.readFileSync(filePath, 'utf-8')).toContain('user custom hook');
   });
 
+  it('skips a user file that merely QUOTES the marker (marker not at start), never exists', () => {
+    // Positional ownership gate (mmnto-ai/totem#2413): a user-owned file that quotes
+    // the marker string in its body is NOT marker-headed → `skipped` (not `exists`),
+    // and never written (even with an end marker threaded, i.e. via `--force` callers).
+    const filePath = path.join(tmpDir, 'hook.js');
+    const quotesMarker = `// user hook\n// see: ${MARKER}\nconsole.log("mine");\n`;
+    fs.writeFileSync(filePath, quotesMarker, 'utf-8');
+
+    expect(scaffoldFile(filePath, CONTENT, MARKER, '// [totem] end auto-generated')).toEqual({
+      action: 'skipped',
+    });
+    // Byte-untouched.
+    expect(fs.readFileSync(filePath, 'utf-8')).toBe(quotesMarker);
+  });
+
   it('is idempotent — double invoke produces same result', () => {
     const filePath = path.join(tmpDir, 'hook.js');
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -37,6 +37,7 @@ import {
   REFLEX_VERSION_RE,
   SKILL_MARKER_END,
   SKILL_MARKER_START,
+  TOTEM_FILE_END,
   TOTEM_FILE_MARKER,
 } from './init-templates.js';
 
@@ -89,18 +90,63 @@ export async function probeOllamaFloor(): Promise<{
 }
 
 /**
- * Scaffold a file with idempotency — skips if the marker is already present.
- * Creates parent directories as needed.
+ * Whether a marker-headed session-hook file is a bounded totem-OWNED whole file,
+ * the precondition for a no-force drift-repair (mmnto-ai/totem#2410; mirrors
+ * install-hooks' `isTotemOwnedWholeFile` for the git-hook family, minus the shebang
+ * preamble the JS/CJS hooks never carry):
+ *   - the marker must OPEN the file (only whitespace may precede it — no user content);
+ *   - the `endMarker` must be present;
+ *   - nothing but trailing whitespace may follow the end marker (else a whole-file
+ *     rewrite would clobber appended user content).
+ */
+function isBoundedOwnedFile(content: string, marker: string, endMarker: string): boolean {
+  const idx = content.indexOf(marker);
+  if (idx === -1) return false;
+  if (content.slice(0, idx).trim().length !== 0) return false;
+  const end = content.indexOf(endMarker, idx + marker.length);
+  if (end === -1) return false;
+  if (content.slice(end + endMarker.length).trim().length !== 0) return false;
+  return true;
+}
+
+/**
+ * Scaffold a file with idempotency — skips if a user-owned file (no marker) is
+ * present. When the caller threads an `endMarker`, a marker-headed whole file that
+ * is a bounded totem-owned region (marker opens it, end marker present, nothing
+ * after) and whose content has DRIFTED from canonical is repaired in place
+ * (`refreshed`) — the #2406 git-hook bounded drift-repair, generalized to the
+ * session-hook family (mmnto-ai/totem#2410, the lc#806 stale-SessionStart fix). A
+ * marker-headed file that is NOT bounded (legacy template with no end marker, or
+ * user content after the end marker) keeps the pre-#2410 `exists` behavior and
+ * emits a one-line notice naming `totem hook install --force`. Creates parent
+ * directories as needed.
  */
 export function scaffoldFile(
   filePath: string,
   content: string,
   marker: string = TOTEM_FILE_MARKER,
-): { action: 'created' | 'exists' | 'skipped'; err?: string } {
+  endMarker?: string,
+): { action: 'created' | 'exists' | 'skipped' | 'refreshed'; err?: string } {
   try {
     if (fs.existsSync(filePath)) {
       const existing = fs.readFileSync(filePath, 'utf-8');
       if (existing.includes(marker)) {
+        if (existing === content) {
+          return { action: 'exists' };
+        }
+        // Content drifted. Bounded drift-repair only when the caller threaded an end
+        // marker AND the on-disk file is a bounded totem-owned whole file.
+        if (endMarker !== undefined && isBoundedOwnedFile(existing, marker, endMarker)) {
+          fs.writeFileSync(filePath, content, 'utf-8');
+          return { action: 'refreshed' };
+        }
+        // Marker present but the region is unbounded (legacy no-end-marker file, or
+        // user content after the end marker): decline bare repair, name --force. The
+        // regenerated (post-force) artifact carries the end marker, so subsequent bare
+        // self-repair works.
+        console.error(
+          `[Totem] ${path.basename(filePath)} has drifted but is not a bounded totem-owned file — run \`totem hook install --force\` to regenerate.`,
+        );
         return { action: 'exists' };
       }
       return { action: 'skipped' };
@@ -123,13 +169,22 @@ export function scaffoldFile(
 
 async function installGeminiHooks(cwd: string): Promise<HookInstallerResult[]> {
   const results: HookInstallerResult[] = [];
-  const files: Array<{ rel: string; content: string; marker: string }> = [
+  // The two whole-file hooks carry the managed end marker (mmnto-ai/totem#2410) so a
+  // drifted-but-bounded artifact self-repairs on re-init; the skill is marker-block
+  // replace territory (no end marker threaded here).
+  const files: Array<{ rel: string; content: string; marker: string; endMarker?: string }> = [
     {
       rel: '.gemini/hooks/SessionStart.js',
       content: GEMINI_SESSION_START,
       marker: TOTEM_FILE_MARKER,
+      endMarker: TOTEM_FILE_END,
     },
-    { rel: '.gemini/hooks/BeforeTool.js', content: GEMINI_BEFORE_TOOL, marker: TOTEM_FILE_MARKER },
+    {
+      rel: '.gemini/hooks/BeforeTool.js',
+      content: GEMINI_BEFORE_TOOL,
+      marker: TOTEM_FILE_MARKER,
+      endMarker: TOTEM_FILE_END,
+    },
     {
       rel: '.gemini/skills/totem.md',
       content: GEMINI_SKILL,
@@ -137,10 +192,17 @@ async function installGeminiHooks(cwd: string): Promise<HookInstallerResult[]> {
     },
   ];
 
-  for (const { rel, content, marker } of files) {
+  for (const { rel, content, marker, endMarker } of files) {
     const filePath = path.join(cwd, rel);
-    const result = scaffoldFile(filePath, content, marker);
-    results.push({ file: rel, ...result });
+    const result = scaffoldFile(filePath, content, marker, endMarker);
+    // Map the scaffold action onto HookInstallerResult: a bounded drift-repair
+    // (`refreshed`) surfaces as `merged` (file mutated) for installer summary parity
+    // with scaffoldClaudeSkill's mapping.
+    results.push({
+      file: rel,
+      action: result.action === 'refreshed' ? 'merged' : result.action,
+      ...(result.err ? { err: result.err } : {}),
+    });
   }
 
   return results;
@@ -239,11 +301,19 @@ async function installClaudeHooks(
   const settingsPath = path.join(cwd, '.claude', 'settings.json');
 
   // 1. Scaffold the PreWriteShield hook script (committed to .claude/hooks/).
+  //    Threads the managed end marker (mmnto-ai/totem#2410) so a drifted-but-bounded
+  //    artifact self-repairs on re-init; `refreshed` maps to `merged` (file mutated).
   const preWritePath = path.join(cwd, '.claude', 'hooks', 'PreWriteShield.cjs');
-  const preWriteResult = scaffoldFile(preWritePath, CLAUDE_PREWRITESHIELD, TOTEM_FILE_MARKER);
+  const preWriteResult = scaffoldFile(
+    preWritePath,
+    CLAUDE_PREWRITESHIELD,
+    TOTEM_FILE_MARKER,
+    TOTEM_FILE_END,
+  );
   results.push({
     file: '.claude/hooks/PreWriteShield.cjs',
-    ...preWriteResult,
+    action: preWriteResult.action === 'refreshed' ? 'merged' : preWriteResult.action,
+    ...(preWriteResult.err ? { err: preWriteResult.err } : {}),
   });
 
   // 2. Scaffold the SessionStart hook script (committed to .claude/hooks/).
@@ -253,10 +323,12 @@ async function installClaudeHooks(
     sessionStartPath,
     CLAUDE_SESSION_START,
     TOTEM_FILE_MARKER,
+    TOTEM_FILE_END,
   );
   results.push({
     file: '.claude/hooks/SessionStart.cjs',
-    ...sessionStartResult,
+    action: sessionStartResult.action === 'refreshed' ? 'merged' : sessionStartResult.action,
+    ...(sessionStartResult.err ? { err: sessionStartResult.err } : {}),
   });
 
   // 3. Merge the PreWriteShield PreToolUse entry into committed

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -30,7 +30,9 @@ import {
   GEMINI_BEFORE_TOOL,
   GEMINI_SESSION_START,
   GEMINI_SKILL,
+  isBoundedOwnedFile,
   LEGACY_SENTINEL,
+  markerOpensFile,
   REFLEX_END,
   REFLEX_START,
   REFLEX_VERSION,
@@ -90,36 +92,17 @@ export async function probeOllamaFloor(): Promise<{
 }
 
 /**
- * Whether a marker-headed session-hook file is a bounded totem-OWNED whole file,
- * the precondition for a no-force drift-repair (mmnto-ai/totem#2410; mirrors
- * install-hooks' `isTotemOwnedWholeFile` for the git-hook family, minus the shebang
- * preamble the JS/CJS hooks never carry):
- *   - the marker must OPEN the file (only whitespace may precede it — no user content);
- *   - the `endMarker` must be present;
- *   - nothing but trailing whitespace may follow the end marker (else a whole-file
- *     rewrite would clobber appended user content).
- */
-function isBoundedOwnedFile(content: string, marker: string, endMarker: string): boolean {
-  const idx = content.indexOf(marker);
-  if (idx === -1) return false;
-  if (content.slice(0, idx).trim().length !== 0) return false;
-  const end = content.indexOf(endMarker, idx + marker.length);
-  if (end === -1) return false;
-  if (content.slice(end + endMarker.length).trim().length !== 0) return false;
-  return true;
-}
-
-/**
- * Scaffold a file with idempotency — skips if a user-owned file (no marker) is
- * present. When the caller threads an `endMarker`, a marker-headed whole file that
- * is a bounded totem-owned region (marker opens it, end marker present, nothing
- * after) and whose content has DRIFTED from canonical is repaired in place
- * (`refreshed`) — the #2406 git-hook bounded drift-repair, generalized to the
- * session-hook family (mmnto-ai/totem#2410, the lc#806 stale-SessionStart fix). A
- * marker-headed file that is NOT bounded (legacy template with no end marker, or
- * user content after the end marker) keeps the pre-#2410 `exists` behavior and
- * emits a one-line notice naming `totem hook install --force`. Creates parent
- * directories as needed.
+ * Scaffold a file with idempotency — skips any file the totem `marker` does NOT
+ * OPEN (a user-owned file, or one that merely QUOTES the marker in its body — the
+ * positional ownership gate shared with `regenerateManagedSessionHooks`,
+ * mmnto-ai/totem#2413). When the caller threads an `endMarker`, a marker-headed
+ * whole file that is a bounded totem-owned region (marker opens it, end marker
+ * present, nothing after) and whose content has DRIFTED from canonical is repaired
+ * in place (`refreshed`) — the #2406 git-hook bounded drift-repair, generalized to
+ * the session-hook family (mmnto-ai/totem#2410, the lc#806 stale-SessionStart fix).
+ * A marker-headed file that is NOT bounded (legacy template with no end marker, or
+ * user content after the end marker) keeps the pre-#2410 `exists` behavior and emits
+ * a one-line notice. Creates parent directories as needed.
  */
 export function scaffoldFile(
   filePath: string,
@@ -130,7 +113,10 @@ export function scaffoldFile(
   try {
     if (fs.existsSync(filePath)) {
       const existing = fs.readFileSync(filePath, 'utf-8');
-      if (existing.includes(marker)) {
+      // Positional ownership gate (mmnto-ai/totem#2413): the marker must OPEN the file.
+      // A file that merely quotes the marker string is user-owned → `skipped`, never
+      // written (harmonized with regenerateManagedSessionHooks; both non-destructive).
+      if (markerOpensFile(existing, marker)) {
         if (existing === content) {
           return { action: 'exists' };
         }
@@ -140,13 +126,24 @@ export function scaffoldFile(
           fs.writeFileSync(filePath, content, 'utf-8');
           return { action: 'refreshed' };
         }
-        // Marker present but the region is unbounded (legacy no-end-marker file, or
-        // user content after the end marker): decline bare repair, name --force. The
-        // regenerated (post-force) artifact carries the end marker, so subsequent bare
-        // self-repair works.
-        console.error(
-          `[Totem] ${path.basename(filePath)} has drifted but is not a bounded totem-owned file — run \`totem hook install --force\` to regenerate.`,
-        );
+        // Marker opens the file but we are not refreshing it. Two distinct causes,
+        // two distinct notices (mmnto-ai/totem#2413 accuracy fix — the old message
+        // asserted "unbounded" even when the caller simply withheld the end marker):
+        if (endMarker === undefined) {
+          // This caller did not request a bounded refresh (e.g. the Gemini skill,
+          // which is marker-block replace territory, not whole-file regeneration).
+          console.error(
+            `[Totem] ${path.basename(filePath)} differs from canonical, but this installer does not manage its whole-file refresh — run \`totem hook install --force\` to regenerate a managed hook.`,
+          );
+        } else {
+          // The caller threaded an end marker but the on-disk region is genuinely
+          // unbounded (legacy no-end-marker file, or user content after the end
+          // marker). The regenerated (post-force) artifact carries the end marker, so
+          // subsequent bare self-repair works.
+          console.error(
+            `[Totem] ${path.basename(filePath)} has drifted but is not a bounded totem-owned region — run \`totem hook install --force\` to regenerate.`,
+          );
+        }
         return { action: 'exists' };
       }
       return { action: 'skipped' };

--- a/packages/cli/src/commands/install-hooks-exit-contract.test.ts
+++ b/packages/cli/src/commands/install-hooks-exit-contract.test.ts
@@ -282,6 +282,26 @@ describe('hooksCommand exit-code contract', () => {
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
+  it('hook-manager repo STILL drift-repairs an existing bounded session hook (lc#806 guard)', async () => {
+    // A git-hook manager (husky) means git hooks are the manager's job — a declared
+    // skip for the git side. But the session hooks are Claude/Gemini artifacts,
+    // independent of the manager, so they must still be regenerated: the fix for the
+    // hook-manager early-return that otherwise recreates the lc#806 stale class.
+    fs.mkdirSync(path.join(tmpDir, '.husky'), { recursive: true });
+    const ssPath = path.join(tmpDir, '.claude', 'hooks', 'SessionStart.cjs');
+    fs.mkdirSync(path.dirname(ssPath), { recursive: true });
+    fs.writeFileSync(ssPath, `${TOTEM_FILE_MARKER}\nstale\n${TOTEM_FILE_END}\n`);
+    errorSpy.mockClear();
+
+    await expect(hooksCommand({})).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+    // The bounded session hook is drift-repaired even though git hooks were skipped.
+    expect(fs.readFileSync(ssPath, 'utf-8')).toBe(CLAUDE_SESSION_START);
+    expect(errorOutput()).toContain(
+      'Drift-repaired .claude/hooks/SessionStart.cjs session hook (totem-owned bounded region).',
+    );
+  });
+
   // ── exit ≠0: genuine failure ────────────────────────────────────
 
   it('exit ≠0: a genuine hook-write failure propagates as a thrown error', async () => {
@@ -319,6 +339,21 @@ describe('hooksCommand exit-code contract', () => {
     fs.writeFileSync(path.join(hooksDir(), 'pre-push'), '#!/bin/sh\necho "no marker"\n');
     await expect(hooksCommand({ check: true })).rejects.toThrow('process.exit:1');
     expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('--check is read-only: it does NOT mutate a drifted session hook', async () => {
+    // Install git hooks so --check passes on the git side (exit 0), then plant a
+    // drifted-but-bounded session hook. --check is a verify-only path and returns
+    // before session-hook regeneration, so the drifted hook must be left untouched.
+    await hooksCommand({});
+    const ssPath = path.join(tmpDir, '.claude', 'hooks', 'SessionStart.cjs');
+    fs.mkdirSync(path.dirname(ssPath), { recursive: true });
+    const drifted = `${TOTEM_FILE_MARKER}\nstale\n${TOTEM_FILE_END}\n`;
+    fs.writeFileSync(ssPath, drifted);
+
+    await expect(hooksCommand({ check: true })).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(fs.readFileSync(ssPath, 'utf-8')).toBe(drifted);
   });
 
   // ── the two `overwritten` messages are distinct ─────────────────

--- a/packages/cli/src/commands/install-hooks-exit-contract.test.ts
+++ b/packages/cli/src/commands/install-hooks-exit-contract.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Exit-code contract for `totem hook install` (`hooksCommand`) + the managed
+ * session-hook bounded drift-repair (mmnto-ai/totem#2410 PR-A, slices 2+3).
+ *
+ * This is the dedicated falsifying test for the contract #2406 stabilized and
+ * strategy#894 froze (Tenet 19). It locks:
+ *   - exit 0 ⟺ {fresh install, already-current, bounded drift-repair (git hook AND
+ *     session hook), declared skips (not-a-git-repo, hook-manager-detected)};
+ *   - exit ≠0 ⟺ genuine failure (a hook write throws → propagates → handleError);
+ *   - `--check` is exactly 0/1 (all-present-with-marker vs missing/markerless);
+ *   - a bare install never mutates a non-bounded file (git hook OR session hook);
+ *     `--force` is the only unbounded write; a legacy markerless-end session hook is
+ *     never bare-repaired; a no-marker user file is never touched even under --force;
+ *   - regenerated artifacts always carry marker + end marker (so they self-repair);
+ *   - the two `overwritten` messages are distinct ("Drift-repaired…" vs
+ *     "Force-overwritten…").
+ *
+ * `hooksCommand` reads `process.cwd()` and gates via `process.exit` on `--check`
+ * failure, so the exit-code cases drive it under `process.chdir` + a `process.exit`
+ * spy (the doctor.test.ts idiom); the session-hook matrix drives the pure
+ * `regenerateManagedSessionHooks(cwd, force)` seam directly.
+ */
+import { execSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { cleanTmpDir } from '../test-utils.js';
+import {
+  CLAUDE_PREWRITESHIELD,
+  CLAUDE_SESSION_START,
+  GEMINI_SESSION_START,
+  MANAGED_SESSION_HOOKS,
+  TOTEM_FILE_END,
+  TOTEM_FILE_MARKER,
+} from './init-templates.js';
+import {
+  hooksCommand,
+  installHooksNonInteractive,
+  regenerateManagedSessionHooks,
+  TOTEM_PREPUSH_END,
+  TOTEM_PREPUSH_MARKER,
+} from './install-hooks.js';
+
+// ─── Roster invariant (locked contract, mmnto-ai/totem#2410) ─────────
+
+describe('MANAGED_SESSION_HOOKS roster invariant', () => {
+  it('every entry embeds its own marker AND end marker (so regenerated artifacts self-repair)', () => {
+    expect(MANAGED_SESSION_HOOKS.length).toBeGreaterThan(0);
+    for (const { rel, content, marker, endMarker } of MANAGED_SESSION_HOOKS) {
+      expect(content.includes(marker), `${rel} content is missing its marker`).toBe(true);
+      expect(content.includes(endMarker), `${rel} content is missing its end marker`).toBe(true);
+      // The marker must OPEN the file (only whitespace before it) — the ownership
+      // precondition for bounded drift-repair.
+      expect(content.trimStart().startsWith(marker), `${rel} marker must open the file`).toBe(true);
+      // The end marker must CLOSE the region (nothing but whitespace after it).
+      const endIdx = content.indexOf(endMarker);
+      expect(content.slice(endIdx + endMarker.length).trim()).toBe('');
+    }
+  });
+
+  it('covers the five distributed session-hook artifacts', () => {
+    const rels = MANAGED_SESSION_HOOKS.map((h) => h.rel).sort();
+    expect(rels).toEqual(
+      [
+        '.claude/hooks/PreWriteShield.cjs',
+        '.claude/hooks/SessionStart.cjs',
+        '.claude/hooks/gate-wrapper.cjs',
+        '.gemini/hooks/BeforeTool.js',
+        '.gemini/hooks/SessionStart.js',
+      ].sort(),
+    );
+  });
+});
+
+// ─── Managed session-hook bounded drift-repair (slice 3) ─────────────
+
+describe('regenerateManagedSessionHooks — bounded drift-repair matrix', () => {
+  let tmpDir: string;
+  const CLAUDE_SS = '.claude/hooks/SessionStart.cjs';
+
+  function writeHook(rel: string, content: string): string {
+    const p = path.join(tmpDir, ...rel.split('/'));
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, content, 'utf-8');
+    return p;
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-2410-sess-'));
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  it('does NOT create a missing session hook (regenerate-only-if-present)', async () => {
+    const results = await regenerateManagedSessionHooks(tmpDir);
+    expect(results).toEqual([]);
+    expect(fs.existsSync(path.join(tmpDir, ...CLAUDE_SS.split('/')))).toBe(false);
+  });
+
+  it('returns exists for a present, byte-identical session hook (already current)', async () => {
+    writeHook(CLAUDE_SS, CLAUDE_SESSION_START);
+    const results = await regenerateManagedSessionHooks(tmpDir);
+    const r = results.find((x) => x.file === CLAUDE_SS)!;
+    expect(r.action).toBe('exists');
+    expect(fs.readFileSync(path.join(tmpDir, ...CLAUDE_SS.split('/')), 'utf-8')).toBe(
+      CLAUDE_SESSION_START,
+    );
+  });
+
+  it('bare drift-repairs a bounded totem-owned session hook (overwritten, no force)', async () => {
+    const p = writeHook(CLAUDE_SS, `${TOTEM_FILE_MARKER}\nstale body\n${TOTEM_FILE_END}\n`);
+    const results = await regenerateManagedSessionHooks(tmpDir);
+    const r = results.find((x) => x.file === CLAUDE_SS)!;
+    expect(r.action).toBe('overwritten');
+    // Regenerated to canonical — and canonical carries marker + end marker.
+    const written = fs.readFileSync(p, 'utf-8');
+    expect(written).toBe(CLAUDE_SESSION_START);
+    expect(written.includes(TOTEM_FILE_MARKER)).toBe(true);
+    expect(written.includes(TOTEM_FILE_END)).toBe(true);
+  });
+
+  it('does NOT bare-repair a legacy marker-headed session hook missing the end marker', async () => {
+    const legacy = `${TOTEM_FILE_MARKER} — Claude Code SessionStart hook\nstale legacy body\n`;
+    const p = writeHook(CLAUDE_SS, legacy);
+    const results = await regenerateManagedSessionHooks(tmpDir);
+    const r = results.find((x) => x.file === CLAUDE_SS)!;
+    expect(r.action).toBe('declined');
+    // Untouched — takes one `totem hook install --force`.
+    expect(fs.readFileSync(p, 'utf-8')).toBe(legacy);
+  });
+
+  it('--force overwrites a legacy markerless-end session hook (the migration path)', async () => {
+    const legacy = `${TOTEM_FILE_MARKER} — Claude Code SessionStart hook\nstale legacy body\n`;
+    const p = writeHook(CLAUDE_SS, legacy);
+    const results = await regenerateManagedSessionHooks(tmpDir, true);
+    const r = results.find((x) => x.file === CLAUDE_SS)!;
+    expect(r.action).toBe('overwritten');
+    expect(fs.readFileSync(p, 'utf-8')).toBe(CLAUDE_SESSION_START);
+  });
+
+  it('does NOT repair a bounded hook with user content AFTER the end marker (bare declines)', async () => {
+    const withTrailingUser = `${TOTEM_FILE_MARKER}\nstale\n${TOTEM_FILE_END}\nconsole.log("mine");\n`;
+    const p = writeHook(CLAUDE_SS, withTrailingUser);
+    const results = await regenerateManagedSessionHooks(tmpDir);
+    expect(results.find((x) => x.file === CLAUDE_SS)!.action).toBe('declined');
+    expect(fs.readFileSync(p, 'utf-8')).toBe(withTrailingUser);
+  });
+
+  it('never touches a user-owned file with NO totem marker, even under --force (skipped)', async () => {
+    const userOwned = '// my own SessionStart hook\nconsole.log("mine");\n';
+    const p = writeHook(CLAUDE_SS, userOwned);
+
+    const bare = await regenerateManagedSessionHooks(tmpDir);
+    expect(bare.find((x) => x.file === CLAUDE_SS)!.action).toBe('skipped');
+    expect(fs.readFileSync(p, 'utf-8')).toBe(userOwned);
+
+    const forced = await regenerateManagedSessionHooks(tmpDir, true);
+    expect(forced.find((x) => x.file === CLAUDE_SS)!.action).toBe('skipped');
+    expect(fs.readFileSync(p, 'utf-8')).toBe(userOwned);
+  });
+
+  it('repairs each vendor family independently (claude + gemini)', async () => {
+    writeHook(
+      '.claude/hooks/PreWriteShield.cjs',
+      `${TOTEM_FILE_MARKER}\nstale\n${TOTEM_FILE_END}\n`,
+    );
+    writeHook('.gemini/hooks/SessionStart.js', GEMINI_SESSION_START); // already current
+    const results = await regenerateManagedSessionHooks(tmpDir);
+
+    expect(results.find((x) => x.file === '.claude/hooks/PreWriteShield.cjs')!.action).toBe(
+      'overwritten',
+    );
+    expect(
+      fs.readFileSync(path.join(tmpDir, '.claude', 'hooks', 'PreWriteShield.cjs'), 'utf-8'),
+    ).toBe(CLAUDE_PREWRITESHIELD);
+    expect(results.find((x) => x.file === '.gemini/hooks/SessionStart.js')!.action).toBe('exists');
+  });
+});
+
+// ─── hooksCommand exit-code contract (slice 2) ───────────────────────
+
+describe('hooksCommand exit-code contract', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  const hooksDir = () => path.join(tmpDir, '.git', 'hooks');
+  const errorOutput = (): string =>
+    errorSpy.mock.calls
+      .map((c: unknown[]) => c.map((a: unknown) => String(a)).join(' '))
+      .join('\n');
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-2410-cmd-'));
+    execSync('git init', { cwd: tmpDir, stdio: 'ignore' });
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    // A throwing process.exit surfaces a --check failure as a rejection (the CLI
+    // edge would exit non-zero); the install path must never reach it.
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? 0}`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    vi.restoreAllMocks();
+    cleanTmpDir(tmpDir);
+  });
+
+  // ── exit 0 classes ──────────────────────────────────────────────
+
+  it('exit 0: fresh install (no throw, no process.exit)', async () => {
+    await expect(hooksCommand({})).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(fs.existsSync(path.join(hooksDir(), 'pre-push'))).toBe(true);
+  });
+
+  it('exit 0: already-current (second install is a no-op)', async () => {
+    await hooksCommand({});
+    errorSpy.mockClear();
+    await expect(hooksCommand({})).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(errorOutput()).toContain('already installed');
+  });
+
+  it('exit 0: bare git-hook drift-repair prints "Drift-repaired", not "Force-overwritten"', async () => {
+    await hooksCommand({});
+    // Corrupt pre-push to a stale-but-bounded totem-owned whole file.
+    fs.writeFileSync(
+      path.join(hooksDir(), 'pre-push'),
+      `#!/bin/sh\n# ${TOTEM_PREPUSH_MARKER}\nstale\n# ${TOTEM_PREPUSH_END}\n`,
+    );
+    errorSpy.mockClear();
+    await expect(hooksCommand({})).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+    const out = errorOutput();
+    expect(out).toContain('Drift-repaired pre-push hook (totem-owned bounded region).');
+    expect(out).not.toContain('Force-overwritten pre-push');
+  });
+
+  it('exit 0: bare session-hook drift-repair prints "Drift-repaired"', async () => {
+    fs.mkdirSync(path.join(tmpDir, '.claude', 'hooks'), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, '.claude', 'hooks', 'SessionStart.cjs'),
+      `${TOTEM_FILE_MARKER}\nstale\n${TOTEM_FILE_END}\n`,
+    );
+    errorSpy.mockClear();
+    await expect(hooksCommand({})).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(errorOutput()).toContain(
+      'Drift-repaired .claude/hooks/SessionStart.cjs session hook (totem-owned bounded region).',
+    );
+    expect(
+      fs.readFileSync(path.join(tmpDir, '.claude', 'hooks', 'SessionStart.cjs'), 'utf-8'),
+    ).toBe(CLAUDE_SESSION_START);
+  });
+
+  it('exit 0: declared skip — not a git repository', async () => {
+    const nonGit = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-2410-nogit-'));
+    process.chdir(nonGit);
+    try {
+      await expect(hooksCommand({})).resolves.toBeUndefined();
+      expect(exitSpy).not.toHaveBeenCalled();
+      expect(errorOutput()).toContain('Not a git repository');
+    } finally {
+      process.chdir(tmpDir);
+      cleanTmpDir(nonGit);
+    }
+  });
+
+  it('exit 0: declared skip — hook manager detected', async () => {
+    fs.mkdirSync(path.join(tmpDir, '.husky'), { recursive: true });
+    await expect(hooksCommand({})).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  // ── exit ≠0: genuine failure ────────────────────────────────────
+
+  it('exit ≠0: a genuine hook-write failure propagates as a thrown error', async () => {
+    // Make the first-installed hook PATH a directory: the installer's read/write of it
+    // throws EISDIR — a genuine FS failure that must PROPAGATE (fail-loud, Tenet 4),
+    // not be swallowed into a false `installed`. (A directory-at-path fault is
+    // cross-platform, unlike an ESM fs spy — vitest cannot redefine fs namespace exports.)
+    fs.mkdirSync(path.join(hooksDir(), 'pre-commit'), { recursive: true });
+    await expect(hooksCommand({})).rejects.toThrow();
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  // ── --check: exactly 0/1 ────────────────────────────────────────
+
+  it('--check exit 0: all hooks present with markers', async () => {
+    await hooksCommand({});
+    errorSpy.mockClear();
+    await expect(hooksCommand({ check: true })).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(errorOutput()).toContain('All hooks installed');
+  });
+
+  it('--check exit 1: hooks missing (and the remedy names `totem hook install`)', async () => {
+    await expect(hooksCommand({ check: true })).rejects.toThrow('process.exit:1');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const out = errorOutput();
+    expect(out).toContain('Some hooks are missing');
+    expect(out).toContain('totem hook install');
+    expect(out).not.toContain('Run `totem hooks`');
+  });
+
+  it('--check exit 1: hook present but missing the Totem marker', async () => {
+    // Install, then strip the marker from one hook (markerless → not counted).
+    await hooksCommand({});
+    fs.writeFileSync(path.join(hooksDir(), 'pre-push'), '#!/bin/sh\necho "no marker"\n');
+    await expect(hooksCommand({ check: true })).rejects.toThrow('process.exit:1');
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  // ── the two `overwritten` messages are distinct ─────────────────
+
+  it('bare drift-repair and --force overwrite print DISTINCT messages', async () => {
+    await hooksCommand({});
+    const staleBounded = `#!/bin/sh\n# ${TOTEM_PREPUSH_MARKER}\nstale\n# ${TOTEM_PREPUSH_END}\n`;
+
+    // Bare (no --force) bounded drift-repair.
+    fs.writeFileSync(path.join(hooksDir(), 'pre-push'), staleBounded);
+    errorSpy.mockClear();
+    await hooksCommand({});
+    const bareMsg = errorOutput()
+      .split('\n')
+      .find((l) => l.includes('pre-push hook'))!;
+
+    // --force overwrite of the same stale-bounded file.
+    fs.writeFileSync(path.join(hooksDir(), 'pre-push'), staleBounded);
+    errorSpy.mockClear();
+    await hooksCommand({ force: true });
+    const forceMsg = errorOutput()
+      .split('\n')
+      .find((l) => l.includes('pre-push hook'))!;
+
+    expect(bareMsg).toContain('Drift-repaired');
+    expect(forceMsg).toContain('Force-overwritten');
+    expect(bareMsg).not.toBe(forceMsg);
+  });
+
+  // ── bare install never mutates a non-bounded git hook ───────────
+
+  it('bare install never mutates a user hook with an appended totem block (non-bounded)', async () => {
+    const userThenTotem = `#!/bin/sh\nrun_my_tests\n# ${TOTEM_PREPUSH_MARKER}\nstale\n# ${TOTEM_PREPUSH_END}\n`;
+    fs.mkdirSync(hooksDir(), { recursive: true });
+    fs.writeFileSync(path.join(hooksDir(), 'pre-push'), userThenTotem);
+    await expect(hooksCommand({})).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+    // User content preserved — only --force may overwrite an unbounded file.
+    expect(fs.readFileSync(path.join(hooksDir(), 'pre-push'), 'utf-8')).toBe(userThenTotem);
+  });
+});
+
+// ─── sanity: installHooksNonInteractive still classifies a fresh repo ─
+
+describe('installHooksNonInteractive (contract sanity)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-2410-ni-'));
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  it('returns null outside a git repo (declared skip, exit 0 at the command edge)', () => {
+    expect(installHooksNonInteractive(tmpDir)).toBeNull();
+  });
+});

--- a/packages/cli/src/commands/install-hooks-exit-contract.test.ts
+++ b/packages/cli/src/commands/install-hooks-exit-contract.test.ts
@@ -164,6 +164,22 @@ describe('regenerateManagedSessionHooks — bounded drift-repair matrix', () => 
     expect(fs.readFileSync(p, 'utf-8')).toBe(userOwned);
   });
 
+  it('never touches a user file that merely QUOTES the marker (marker not at start), even under --force', async () => {
+    // A user-owned hook that quotes the marker string in a comment/string is NOT
+    // marker-headed (positional gate, mmnto-ai/totem#2413). The old `includes(marker)`
+    // gate would treat it as owned and let --force clobber it.
+    const quotesMarker = `// my own hook\n// I copied this line: ${TOTEM_FILE_MARKER}\nconsole.log("mine");\n`;
+    const p = writeHook(CLAUDE_SS, quotesMarker);
+
+    const bare = await regenerateManagedSessionHooks(tmpDir);
+    expect(bare.find((x) => x.file === CLAUDE_SS)!.action).toBe('skipped');
+    expect(fs.readFileSync(p, 'utf-8')).toBe(quotesMarker);
+
+    const forced = await regenerateManagedSessionHooks(tmpDir, true);
+    expect(forced.find((x) => x.file === CLAUDE_SS)!.action).toBe('skipped');
+    expect(fs.readFileSync(p, 'utf-8')).toBe(quotesMarker);
+  });
+
   it('repairs each vendor family independently (claude + gemini)', async () => {
     writeHook(
       '.claude/hooks/PreWriteShield.cjs',

--- a/packages/cli/src/commands/install-hooks.ts
+++ b/packages/cli/src/commands/install-hooks.ts
@@ -850,55 +850,60 @@ export async function hooksCommand(opts: {
 
   const result = installHooksNonInteractive(cwd, opts.force, { tier });
 
-  if (!result) {
-    // Hook manager detected — guidance already printed by installHooksNonInteractive
-    return;
-  }
+  // The git-hook summary prints ONLY when git hooks were actually written. A null
+  // result means a hook manager (husky/lefthook) was detected and
+  // installHooksNonInteractive already printed its guidance — but this MUST NOT
+  // early-return: the managed session hooks below are Claude/Gemini artifacts,
+  // independent of any git-hook manager, and must still be regenerated (a
+  // hook-manager repo otherwise recreates the lc#806 stale-session-hook class).
+  if (result) {
+    const actions = [
+      { name: 'pre-commit', status: result.preCommit },
+      { name: 'pre-push', status: result.prePush },
+      { name: 'post-merge', status: result.postMerge },
+      { name: 'post-checkout', status: result.postCheckout },
+    ];
 
-  const actions = [
-    { name: 'pre-commit', status: result.preCommit },
-    { name: 'pre-push', status: result.prePush },
-    { name: 'post-merge', status: result.postMerge },
-    { name: 'post-checkout', status: result.postCheckout },
-  ];
-
-  for (const { name, status } of actions) {
-    switch (status) {
-      case 'installed':
-        console.error(`[Totem] Installed ${name} hook.`);
-        break;
-      case 'appended':
-        console.error(`[Totem] Appended Totem to existing ${name} hook.`);
-        break;
-      case 'exists':
-        console.error(`[Totem] ${name} hook already installed.`);
-        break;
-      case 'overwritten':
-        // `installGitHook` returns `overwritten` for BOTH a forced overwrite and a
-        // bare (no-force) drift-repair of a totem-owned bounded region. Print the
-        // truthful cause: "Force-overwritten" ONLY when --force was actually passed,
-        // "Drift-repaired" for the bare bounded self-repair (mmnto-ai/totem#2410 —
-        // fixes the misleading always-"Force-overwritten" message).
-        console.error(
-          opts.force
-            ? `[Totem] Force-overwritten ${name} hook.`
-            : `[Totem] Drift-repaired ${name} hook (totem-owned bounded region).`,
-        );
-        break;
-      case 'skipped-non-shell':
-        console.error(
-          `[Totem] Warning: ${name} hook uses a non-shell interpreter. Integrate manually.`,
-        );
-        break;
+    for (const { name, status } of actions) {
+      switch (status) {
+        case 'installed':
+          console.error(`[Totem] Installed ${name} hook.`);
+          break;
+        case 'appended':
+          console.error(`[Totem] Appended Totem to existing ${name} hook.`);
+          break;
+        case 'exists':
+          console.error(`[Totem] ${name} hook already installed.`);
+          break;
+        case 'overwritten':
+          // `installGitHook` returns `overwritten` for BOTH a forced overwrite and a
+          // bare (no-force) drift-repair of a totem-owned bounded region. Print the
+          // truthful cause: "Force-overwritten" ONLY when --force was actually passed,
+          // "Drift-repaired" for the bare bounded self-repair (mmnto-ai/totem#2410 —
+          // fixes the misleading always-"Force-overwritten" message).
+          console.error(
+            opts.force
+              ? `[Totem] Force-overwritten ${name} hook.`
+              : `[Totem] Drift-repaired ${name} hook (totem-owned bounded region).`,
+          );
+          break;
+        case 'skipped-non-shell':
+          console.error(
+            `[Totem] Warning: ${name} hook uses a non-shell interpreter. Integrate manually.`,
+          );
+          break;
+      }
     }
   }
 
   // ── Managed session-hook regeneration (mmnto-ai/totem#2410 PR-A slice 3) ──
-  // Independent of the git-hook manager branch above: the `.claude/hooks/*.cjs`
-  // and `.gemini/hooks/*.js` artifacts are Claude/Gemini hooks, not git hooks, so
-  // they are regenerated whether or not a git-hook manager (husky/lefthook) is in
-  // play. Regenerate-only-if-present: creation stays with `totem init`; this verb
-  // repairs drift in artifacts the repo already adopted.
+  // Runs on BOTH the manager and no-manager paths (the `if (result)` above only
+  // gates the git-hook summary): the `.claude/hooks/*.cjs` and `.gemini/hooks/*.js`
+  // artifacts are Claude/Gemini hooks, not git hooks, so they are regenerated
+  // whether or not a git-hook manager (husky/lefthook) is in play. The `--check`
+  // and not-a-git-repo paths already returned above, so this never fires for the
+  // read-only verify or the honest-skip. Regenerate-only-if-present: creation stays
+  // with `totem init`; this verb repairs drift in artifacts the repo already adopted.
   await printManagedSessionHookSummary(gitRoot, opts.force);
 }
 

--- a/packages/cli/src/commands/install-hooks.ts
+++ b/packages/cli/src/commands/install-hooks.ts
@@ -941,7 +941,8 @@ export interface ManagedSessionHookResult {
  *                               (`overwritten`), or `--force` → `overwritten`.
  *   - Marker + drifted, unbounded (legacy no-end-marker / trailing user content):
  *                               bare → `declined`; `--force` → `overwritten`.
- *   - No totem marker at all  → `skipped` even under `--force` (never clobber a
+ *   - Marker does not OPEN the file (no marker, or a merely-quoted marker) →
+ *                               `skipped` even under `--force` (never clobber a
  *                               user-owned file).
  *
  * Regenerate-only-if-present, single-writer per invocation. A write failure
@@ -952,10 +953,13 @@ export async function regenerateManagedSessionHooks(
   cwd: string,
   force?: boolean,
 ): Promise<ManagedSessionHookResult[]> {
-  // Dynamic-import the roster (large canonical template strings) so init-templates
-  // stays off the CLI cold-start graph (packages/cli lazy-load guideline; mirrors
-  // doctor-parity.ts's own init-templates import).
-  const { MANAGED_SESSION_HOOKS } = await import('./init-templates.js');
+  // Dynamic-import the roster (large canonical template strings) + the shared
+  // ownership helpers so init-templates stays off the CLI cold-start graph
+  // (packages/cli lazy-load guideline; mirrors doctor-parity.ts's own import).
+  // `isBoundedOwnedFile` is the single shared session-hook ownership checker
+  // (mmnto-ai/totem#2413 — was a divergent twin of init's local copy).
+  const { MANAGED_SESSION_HOOKS, isBoundedOwnedFile, markerOpensFile } =
+    await import('./init-templates.js');
 
   const results: ManagedSessionHookResult[] = [];
   for (const { rel, content, marker, endMarker } of MANAGED_SESSION_HOOKS) {
@@ -966,8 +970,12 @@ export async function regenerateManagedSessionHooks(
     }
     const existing = fs.readFileSync(filePath, 'utf-8');
 
-    if (!existing.includes(marker)) {
-      // User-owned file with no totem marker — never touched, not even under --force.
+    // Positional ownership gate (mmnto-ai/totem#2413): the marker must OPEN the file.
+    // A user-owned file with NO marker — or one that merely QUOTES the marker string in
+    // a comment/string — is never touched, not even under --force. (The old
+    // `includes(marker)` gate let a quoting user file be clobbered by --force, breaking
+    // the "no marker → never touched, even forced" contract.)
+    if (!markerOpensFile(existing, marker)) {
       results.push({ file: rel, action: 'skipped' });
       continue;
     }
@@ -977,9 +985,9 @@ export async function regenerateManagedSessionHooks(
       continue;
     }
 
-    // Content differs. --force overwrites any marker-bearing file (bounded or not);
+    // Content differs. --force overwrites any marker-headed file (bounded or not);
     // a bare run repairs only a bounded totem-OWNED whole file, and declines the rest.
-    if (force || isTotemOwnedWholeFile(existing, marker, endMarker)) {
+    if (force || isBoundedOwnedFile(existing, marker, endMarker)) {
       fs.writeFileSync(filePath, content, 'utf-8');
       results.push({ file: rel, action: 'overwritten' });
     } else {

--- a/packages/cli/src/commands/install-hooks.ts
+++ b/packages/cli/src/commands/install-hooks.ts
@@ -817,7 +817,7 @@ export async function hooksCommand(opts: {
     if (ok) {
       console.error('[Totem] All hooks installed.');
     } else {
-      console.error('[Totem] Some hooks are missing. Run `totem hooks` to install.');
+      console.error('[Totem] Some hooks are missing. Run `totem hook install` to install.');
       process.exit(1);
     }
     return;
@@ -874,12 +874,143 @@ export async function hooksCommand(opts: {
         console.error(`[Totem] ${name} hook already installed.`);
         break;
       case 'overwritten':
-        console.error(`[Totem] Force-overwritten ${name} hook.`);
+        // `installGitHook` returns `overwritten` for BOTH a forced overwrite and a
+        // bare (no-force) drift-repair of a totem-owned bounded region. Print the
+        // truthful cause: "Force-overwritten" ONLY when --force was actually passed,
+        // "Drift-repaired" for the bare bounded self-repair (mmnto-ai/totem#2410 —
+        // fixes the misleading always-"Force-overwritten" message).
+        console.error(
+          opts.force
+            ? `[Totem] Force-overwritten ${name} hook.`
+            : `[Totem] Drift-repaired ${name} hook (totem-owned bounded region).`,
+        );
         break;
       case 'skipped-non-shell':
         console.error(
           `[Totem] Warning: ${name} hook uses a non-shell interpreter. Integrate manually.`,
         );
+        break;
+    }
+  }
+
+  // ── Managed session-hook regeneration (mmnto-ai/totem#2410 PR-A slice 3) ──
+  // Independent of the git-hook manager branch above: the `.claude/hooks/*.cjs`
+  // and `.gemini/hooks/*.js` artifacts are Claude/Gemini hooks, not git hooks, so
+  // they are regenerated whether or not a git-hook manager (husky/lefthook) is in
+  // play. Regenerate-only-if-present: creation stays with `totem init`; this verb
+  // repairs drift in artifacts the repo already adopted.
+  await printManagedSessionHookSummary(gitRoot, opts.force);
+}
+
+// ─── Managed session-hook regeneration (mmnto-ai/totem#2410 PR-A) ─────
+
+/**
+ * The action taken on one managed session-hook artifact by
+ * {@link regenerateManagedSessionHooks}:
+ *   - `exists`      — present, marker-headed, already byte-identical to canonical (no write).
+ *   - `overwritten` — regenerated: a bare bounded drift-repair OR a `--force` overwrite.
+ *   - `declined`    — marker present but the region is NOT bounded-owned (legacy file
+ *                     with no end marker, or user content after the end marker) and no
+ *                     `--force`: left untouched, takes one `totem hook install --force`.
+ *   - `skipped`     — a user-owned file carrying NO totem marker at all: never touched,
+ *                     not even under `--force`.
+ */
+export type ManagedSessionHookAction = 'exists' | 'overwritten' | 'declined' | 'skipped';
+
+export interface ManagedSessionHookResult {
+  /** Repo-relative path of the artifact. */
+  file: string;
+  action: ManagedSessionHookAction;
+}
+
+/**
+ * Walk the {@link MANAGED_SESSION_HOOKS} roster and regenerate the whole-file
+ * session-hook artifacts (`.claude/hooks/*.cjs`, `.gemini/hooks/*.js`) that EXIST
+ * under `cwd`, applying the #2406 bounded-ownership semantics generalized to the
+ * JS/CJS hook family:
+ *
+ *   - Missing file            → not created (creation is `totem init`'s job); omitted
+ *                               from the results entirely.
+ *   - Marker + identical      → `exists` (already current).
+ *   - Marker + drifted, bounded totem-owned whole file → bare drift-repair
+ *                               (`overwritten`), or `--force` → `overwritten`.
+ *   - Marker + drifted, unbounded (legacy no-end-marker / trailing user content):
+ *                               bare → `declined`; `--force` → `overwritten`.
+ *   - No totem marker at all  → `skipped` even under `--force` (never clobber a
+ *                               user-owned file).
+ *
+ * Regenerate-only-if-present, single-writer per invocation. A write failure
+ * (perms/FS) PROPAGATES (Tenet 4 — a hook the tool cannot write must fail loud,
+ * never silently report success), mirroring `installGitHook`.
+ */
+export async function regenerateManagedSessionHooks(
+  cwd: string,
+  force?: boolean,
+): Promise<ManagedSessionHookResult[]> {
+  // Dynamic-import the roster (large canonical template strings) so init-templates
+  // stays off the CLI cold-start graph (packages/cli lazy-load guideline; mirrors
+  // doctor-parity.ts's own init-templates import).
+  const { MANAGED_SESSION_HOOKS } = await import('./init-templates.js');
+
+  const results: ManagedSessionHookResult[] = [];
+  for (const { rel, content, marker, endMarker } of MANAGED_SESSION_HOOKS) {
+    const filePath = path.join(cwd, ...rel.split('/'));
+    if (!fs.existsSync(filePath)) {
+      // Regenerate-only-if-present: never create a session hook the repo opted out of.
+      continue;
+    }
+    const existing = fs.readFileSync(filePath, 'utf-8');
+
+    if (!existing.includes(marker)) {
+      // User-owned file with no totem marker — never touched, not even under --force.
+      results.push({ file: rel, action: 'skipped' });
+      continue;
+    }
+
+    if (existing === content) {
+      results.push({ file: rel, action: 'exists' });
+      continue;
+    }
+
+    // Content differs. --force overwrites any marker-bearing file (bounded or not);
+    // a bare run repairs only a bounded totem-OWNED whole file, and declines the rest.
+    if (force || isTotemOwnedWholeFile(existing, marker, endMarker)) {
+      fs.writeFileSync(filePath, content, 'utf-8');
+      results.push({ file: rel, action: 'overwritten' });
+    } else {
+      results.push({ file: rel, action: 'declined' });
+    }
+  }
+  return results;
+}
+
+/**
+ * Regenerate the managed session hooks and print one summary line per artifact,
+ * mirroring the git-hook summary. The `overwritten` line distinguishes a forced
+ * overwrite from a bare bounded drift-repair (same truthful split the git-hook
+ * summary uses).
+ */
+async function printManagedSessionHookSummary(cwd: string, force?: boolean): Promise<void> {
+  const results = await regenerateManagedSessionHooks(cwd, force);
+  for (const { file, action } of results) {
+    switch (action) {
+      case 'exists':
+        console.error(`[Totem] ${file} session hook already current.`);
+        break;
+      case 'overwritten':
+        console.error(
+          force
+            ? `[Totem] Force-overwritten ${file} session hook.`
+            : `[Totem] Drift-repaired ${file} session hook (totem-owned bounded region).`,
+        );
+        break;
+      case 'declined':
+        console.error(
+          `[Totem] ${file} session hook has drifted but is not a bounded totem-owned region — run \`totem hook install --force\` to regenerate.`,
+        );
+        break;
+      case 'skipped':
+        console.error(`[Totem] ${file}: user-owned file (no Totem marker) — left untouched.`);
         break;
     }
   }


### PR DESCRIPTION
Part of mmnto-ai/totem#2410 (PR-A: slices 2+3 — the fork-independent half; slice 1's init-distributed prepare wrapper follows as PR-B).

## What

**Slice 2 — exit-code contract test block (Tenet 19).** `install-hooks-exit-contract.test.ts` (25 tests) freezes `totem hook install`'s semantics: exit 0 ⟺ {fresh install, already-current, bounded drift-repair (git hook AND session hook), declared skips (not-a-git-repo, hook-manager-detected)}; genuine hook-write failure propagates; `--check` is exactly 0/1 and read-only (asserted byte-untouched on a drifted hook).

**Slice 3 — managed session-hook regeneration.** The five marker-headed whole-file artifacts (`.claude/hooks/{PreWriteShield,SessionStart,gate-wrapper}.cjs`, `.gemini/hooks/{SessionStart,BeforeTool}.js`) gain end markers and the #2406 bounded-ownership matrix, generalized via a new `MANAGED_SESSION_HOOKS` roster (locked by an invariant test: every entry embeds its own marker + end marker):

- marker + bounded + drifted → bare drift-repair (`totem hook install`, no force)
- legacy marker-headed, no end marker → declines with a notice naming `--force` (identical migration to the shipped #2406 git-hook change; doctor `--parity` already prescribes it)
- no totem marker → never touched, even under `--force`
- missing file → not created (creation stays with `totem init`; regenerate-only-if-present)

`scaffoldFile` picks up the same bounded self-repair (new `refreshed` action), so interactive `totem init` also stops skipping stale marker-headed hooks — this closes the lc datapoint (mmnto-ai/liquid-city#806) on both the init and the headless path. Regeneration deliberately survives the hook-manager (husky/lefthook) early return: session hooks are Claude/Gemini artifacts, independent of git-hook management (guarded by a dedicated lc#806 test).

**Truthful messages.** Bare drift-repair prints `Drift-repaired … (totem-owned bounded region)`; `Force-overwritten` only under `--force` (previously the force text printed on every in-place repair). The `--check` failure remedy now names `totem hook install`, not the deprecated `totem hooks`.

## Consumer impact

Existing marker-headed session hooks need one `totem hook install --force` after upgrade to adopt the end marker; bare `totem hook install` self-repairs thereafter (changeset carries the Consumer-impact tag).

## Gates

Full `pnpm -r build && pnpm -r test` green (CLI 143 files / 3274 tests), repo ESLint 0 errors, `format:check` clean, full-branch `totem lint --base main` PASS (0 errors; warnings are the pre-existing `console.error`-in-CLI advisory pattern this file already uses). Built by an Opus subagent against the approved design doc (committed at `.totem/specs/2410-prepare-contract.md`); coordinator-verified at source, including one caught-and-fixed control-flow discrepancy (the hook-manager early return, second commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
