### PR TITLE
feat(cli): init-distributed prepare wrapper — .totem/prepare.cjs + package.json wiring + doctor row (#2410 PR-B)

### DIFF
--- a/.changeset/2410-init-distributed-prepare-wrapper.md
+++ b/.changeset/2410-init-distributed-prepare-wrapper.md
@@ -1,0 +1,11 @@
+---
+'@mmnto/cli': minor
+---
+
+feat(cli): init-distributed prepare wrapper — `.totem/prepare.cjs` + package.json wiring + doctor parity row (mmnto-ai/totem#2410 PR-B).
+
+- **`.totem/prepare.cjs` wrapper (`PREPARE_WRAPPER`):** `totem init` now distributes a dependency-free CommonJS wrapper and wires the consumer's `package.json` `prepare` script to invoke it (`node .totem/prepare.cjs`), so every `pnpm install` runs `totem hook install` and the managed hooks self-repair. All logic runs in Node — never a shell (the Windows quoting class, mmnto-ai/totem#2351). It resolves the CLI via a manual `node_modules` walk (the real `@mmnto/cli` `exports` map declares only an `import` condition and no `./package.json` subpath, so `require.resolve` throws `ERR_PACKAGE_PATH_NOT_EXPORTED` from a CommonJS file), reads the `bin` off the resolved manifest, and `spawnSync`s `node <bin> hook install`. CLI not installed → one stderr skip line + exit 0 (strategy#630 declared-skip class); CLI present → the child's exit code is propagated verbatim (a genuine `hook install` failure fails `prepare` loud, exit ≠0). The wrapper is marker-headed + end-marker-bounded and a `MANAGED_SESSION_HOOKS` roster member, so bare `totem hook install` drift-repairs it for adopters.
+- **package.json wiring (`wirePreparePackageJson`):** absent `prepare` → set the canonical command; already-canonical → unchanged; a DIFFERENT existing `prepare` (or non-string value) → left byte-identical with a decline notice naming the line to add manually (no overwrite of user-owned content, Prop 289).
+- **Doctor sensor (`checkPrepareWrapper`):** a new `totem doctor` row senses wrapper presence + marker-heading + canonical content + `prepare` wiring — pass when installed+wired, `warn` (never gates; `--strict` gates only on `fail`) with `totem init` / bare `totem hook install` remedies when absent/miswired/drifted, and `skip` for the owner-repo exception (a user-managed `prepare`) and user-owned wrapper files.
+
+Consumer-impact: consumers adopt the prepare wrapper via `totem init`, which scaffolds `.totem/prepare.cjs` and wires `package.json` `prepare` to `node .totem/prepare.cjs` only when no `prepare` script exists; an existing different `prepare` script is never modified (init prints the canonical line to add manually).

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -417,6 +417,7 @@ const EXPECTED_DIAGNOSTIC_NAMES = [
   'Config',
   'Compiled Rules',
   'Git Hooks',
+  'Prepare Wrapper',
   'Embedding',
   'Ollama',
   'Index',

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -185,6 +185,8 @@ export async function checkPrepareWrapper(cwd: string): Promise<DiagnosticResult
     PREPARE_SCRIPT_REL,
     PREPARE_SCRIPT_COMMAND,
     TOTEM_FILE_MARKER,
+    TOTEM_FILE_END,
+    isBoundedOwnedFile,
     markerOpensFile,
   } = await import('./init-templates.js');
 
@@ -210,19 +212,20 @@ export async function checkPrepareWrapper(cwd: string): Promise<DiagnosticResult
     typeof prepareValue === 'string' && prepareValue.trim() === PREPARE_SCRIPT_COMMAND;
   const prepareDifferent = prepareValue !== undefined && !wiredCanonical;
 
-  // Wrapper file state.
+  // Wrapper file state. A file that EXISTS but cannot be read is a distinct signal
+  // from a missing / user-owned file — capture the read error so the present-wrapper
+  // branch can surface it (mmnto-ai/totem#2416 F2) instead of misreading it as "no marker".
   const wrapperPresent = fs.existsSync(wrapperPath);
   let wrapperContent: string | undefined;
+  let wrapperReadError: string | undefined;
   if (wrapperPresent) {
     try {
       wrapperContent = fs.readFileSync(wrapperPath, 'utf-8');
-      // totem-context: intentional cleanup — best-effort sensor read; an unreadable wrapper file degrades the doctor check honestly (Tenet 13) rather than crashing the diagnostic pipeline, mirroring checkGitHooks.
-    } catch {
-      wrapperContent = undefined;
+      // totem-context: intentional cleanup — best-effort sensor read; an unreadable wrapper file surfaces as a `warn` (below) rather than crashing the diagnostic pipeline (Tenet 13), mirroring checkGitHooks.
+    } catch (err) {
+      wrapperReadError = err instanceof Error ? err.message : String(err);
     }
   }
-  const wrapperMarkerHeaded =
-    wrapperContent !== undefined && markerOpensFile(wrapperContent, TOTEM_FILE_MARKER);
 
   // ── absent wrapper ──
   if (!wrapperPresent) {
@@ -254,7 +257,16 @@ export async function checkPrepareWrapper(cwd: string): Promise<DiagnosticResult
   }
 
   // ── present wrapper ──
-  if (!wrapperMarkerHeaded) {
+  // Present-but-unreadable → warn with the read-failure detail (never a silent skip
+  // that misreports the file as user-owned; mmnto-ai/totem#2416 F2).
+  if (wrapperContent === undefined) {
+    return {
+      name,
+      status: 'warn',
+      message: `could not read ${PREPARE_SCRIPT_REL} (${wrapperReadError ?? 'unknown error'}) — the wired prepare lifecycle may be broken`,
+    };
+  }
+  if (!markerOpensFile(wrapperContent, TOTEM_FILE_MARKER)) {
     return {
       name,
       status: 'skip',
@@ -262,19 +274,29 @@ export async function checkPrepareWrapper(cwd: string): Promise<DiagnosticResult
     };
   }
   if (wrapperContent !== PREPARE_WRAPPER) {
+    // A marker-headed drifted wrapper: bare `totem hook install` only bounded-repairs a
+    // BOUNDED totem-owned file (PR-A semantics). An unbounded one (no end marker / trailing
+    // user content) needs `--force` (mmnto-ai/totem#2416 F3).
+    const bounded = isBoundedOwnedFile(wrapperContent, TOTEM_FILE_MARKER, TOTEM_FILE_END);
     return {
       name,
       status: 'warn',
       message: `${PREPARE_SCRIPT_REL} has drifted from canonical`,
-      remediation: 'totem hook install',
+      remediation: bounded ? 'totem hook install' : 'totem hook install --force',
     };
   }
   if (!wiredCanonical) {
+    // The canonical wrapper is present but the prepare lifecycle does not invoke it.
+    // If a DIFFERENT `prepare` already exists, `totem init` deliberately declines to touch
+    // it (Prop 289), so `totem init` cannot resolve this — name the manual line instead
+    // (mmnto-ai/totem#2416 F4). With no prepare at all, `totem init` wires it.
     return {
       name,
       status: 'warn',
       message: `prepare wrapper present but package.json \`prepare\` is not wired to \`${PREPARE_SCRIPT_COMMAND}\``,
-      remediation: 'totem init',
+      remediation: prepareDifferent
+        ? `add or chain \`${PREPARE_SCRIPT_COMMAND}\` into your package.json \`prepare\` script`
+        : 'totem init',
     };
   }
   return {

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -160,6 +160,130 @@ export function checkGitHooks(cwd: string): DiagnosticResult {
   };
 }
 
+/**
+ * Sense the init-distributed prepare wrapper (mmnto-ai/totem#2410 PR-B): whether
+ * `.totem/prepare.cjs` is present + marker-headed + canonical AND the consumer's
+ * `package.json` `prepare` invokes it. A SENSOR, never a gate — every non-pass state
+ * is `warn`/`skip` (doctor `--strict` gates only on `fail`), so this can never block CI.
+ *
+ * Remedies follow the PR-A/PR-B semantics:
+ *   - absent / wired-but-file-missing → `totem init` (adoption / scaffolding).
+ *   - present, marker-headed, but DRIFTED from canonical → `totem hook install`
+ *     (bare — the wrapper is a bounded roster member, so bare self-repair suffices).
+ *   - present + canonical but `prepare` not wired → `totem init`.
+ *
+ * Honest-absent (Tenet 14), so it stays quiet where absence is legitimate:
+ *   - no `package.json` → `skip`.
+ *   - wrapper absent AND a DIFFERENT user-managed `prepare` exists (the owner-repo
+ *     exception — totem itself runs `tools/install-hooks.js`) → `skip`, never a nudge.
+ *   - a user-owned `.totem/prepare.cjs` with no totem marker → `skip` (left as-is).
+ */
+export async function checkPrepareWrapper(cwd: string): Promise<DiagnosticResult> {
+  const name = 'Prepare Wrapper';
+  const {
+    PREPARE_WRAPPER,
+    PREPARE_SCRIPT_REL,
+    PREPARE_SCRIPT_COMMAND,
+    TOTEM_FILE_MARKER,
+    markerOpensFile,
+  } = await import('./init-templates.js');
+
+  const wrapperPath = path.join(cwd, ...PREPARE_SCRIPT_REL.split('/'));
+  const pkgPath = path.join(cwd, 'package.json');
+
+  // Read the package.json `prepare` state (best-effort — an unreadable/invalid
+  // manifest is honest-absent for wiring, not a crash).
+  const hasPkg = fs.existsSync(pkgPath);
+  let prepareValue: unknown;
+  if (hasPkg) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(pkgPath, 'utf-8')) as {
+        scripts?: Record<string, unknown>;
+      };
+      prepareValue = parsed.scripts?.prepare;
+      // totem-context: intentional cleanup — best-effort sensor read; a doctor check degrades honestly (Tenet 13, unreadable/invalid package.json → treated as unwired) rather than crashing the diagnostic pipeline, mirroring checkGitHooks / readConfigFile.
+    } catch {
+      prepareValue = undefined;
+    }
+  }
+  const wiredCanonical =
+    typeof prepareValue === 'string' && prepareValue.trim() === PREPARE_SCRIPT_COMMAND;
+  const prepareDifferent = prepareValue !== undefined && !wiredCanonical;
+
+  // Wrapper file state.
+  const wrapperPresent = fs.existsSync(wrapperPath);
+  let wrapperContent: string | undefined;
+  if (wrapperPresent) {
+    try {
+      wrapperContent = fs.readFileSync(wrapperPath, 'utf-8');
+      // totem-context: intentional cleanup — best-effort sensor read; an unreadable wrapper file degrades the doctor check honestly (Tenet 13) rather than crashing the diagnostic pipeline, mirroring checkGitHooks.
+    } catch {
+      wrapperContent = undefined;
+    }
+  }
+  const wrapperMarkerHeaded =
+    wrapperContent !== undefined && markerOpensFile(wrapperContent, TOTEM_FILE_MARKER);
+
+  // ── absent wrapper ──
+  if (!wrapperPresent) {
+    if (!hasPkg) {
+      return { name, status: 'skip', message: 'no package.json — nothing to wire' };
+    }
+    if (wiredCanonical) {
+      return {
+        name,
+        status: 'warn',
+        message: `package.json \`prepare\` points at ${PREPARE_SCRIPT_REL} but the wrapper file is missing`,
+        remediation: 'totem init',
+      };
+    }
+    if (prepareDifferent) {
+      // Owner-repo exception / user-managed prepare — absence is legitimate here.
+      return {
+        name,
+        status: 'skip',
+        message: 'prepare is a user-managed script (not the Totem wrapper) — left as-is',
+      };
+    }
+    return {
+      name,
+      status: 'warn',
+      message: 'init-distributed prepare wrapper not installed',
+      remediation: 'totem init',
+    };
+  }
+
+  // ── present wrapper ──
+  if (!wrapperMarkerHeaded) {
+    return {
+      name,
+      status: 'skip',
+      message: `user-owned ${PREPARE_SCRIPT_REL} (no Totem marker) — left as-is`,
+    };
+  }
+  if (wrapperContent !== PREPARE_WRAPPER) {
+    return {
+      name,
+      status: 'warn',
+      message: `${PREPARE_SCRIPT_REL} has drifted from canonical`,
+      remediation: 'totem hook install',
+    };
+  }
+  if (!wiredCanonical) {
+    return {
+      name,
+      status: 'warn',
+      message: `prepare wrapper present but package.json \`prepare\` is not wired to \`${PREPARE_SCRIPT_COMMAND}\``,
+      remediation: 'totem init',
+    };
+  }
+  return {
+    name,
+    status: 'pass',
+    message: `installed and wired (\`prepare\` → ${PREPARE_SCRIPT_COMMAND})`,
+  };
+}
+
 /** Check if a config file content has an embedding provider configured. */
 function hasEmbeddingProvider(content: string): boolean {
   return /provider:\s*['"]?(openai|gemini|ollama)['"]?/.test(content);
@@ -1789,6 +1913,7 @@ export async function doctorCommand(options: DoctorOptions = {}): Promise<Diagno
     checkConfig(cwd),
     checkCompiledRules(cwd),
     checkGitHooks(cwd),
+    await checkPrepareWrapper(cwd),
     checkEmbeddingConfig(cwd),
     await checkOllama(loadedConfig),
     checkIndex(cwd),

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -9,7 +9,7 @@ import type { ConfigFormat, EmbeddingTier } from './init-detect.js';
 // Bump REFLEX_VERSION whenever the AI_PROMPT_BLOCK content changes materially.
 // This allows `totem init` to detect stale blocks and offer upgrades.
 
-export const REFLEX_VERSION = 6;
+export const REFLEX_VERSION = 7;
 export const REFLEX_START = '<!-- totem:reflexes:start -->';
 export const REFLEX_END = '<!-- totem:reflexes:end -->';
 export const REFLEX_VERSION_RE = /<!-- totem:reflexes:version:(\d+) -->/;
@@ -48,6 +48,7 @@ Totem provides CLI commands that map to your development lifecycle. Use them at 
 2. **Before Implementation:** Run \`totem spec <issue-url-or-topic>\` to generate an architectural plan and review related context before writing code.
 3. **Before Push:** Run \`totem lint\` for a fast compiled-rules check (zero LLM, ~2s). **Before PR:** Run \`totem review\` for a full AI-powered code review against project knowledge (~18s).
 4. **End of Session:** Run \`totem handoff\` to generate a snapshot for the next agent session with current progress and open threads.
+5. **Managed hooks self-repair:** \`totem init\` distributes \`.totem/prepare.cjs\` and wires \`package.json\` \`prepare\` to it only when no \`prepare\` script exists. The wrapper runs \`totem hook install\` on every \`pnpm install\`, drift-repairing the managed Claude/Gemini hooks — no manual re-install needed.
 
 ### Cloud / PR Review Bots
 [FOR CLOUD BOTS ONLY — e.g., Gemini Code Assist, GitHub Copilot PR Review]

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -774,6 +774,126 @@ export const CLAUDE_GATE_WRAPPER_ENTRY = {
   ],
 };
 
+// ─── Init-distributed prepare wrapper (mmnto-ai/totem#2410 PR-B) ─────────
+//
+// `totem init` distributes this dependency-free CommonJS wrapper to
+// `.totem/prepare.cjs` and wires the consumer's `package.json` `prepare` script
+// to invoke it (`node .totem/prepare.cjs`). On every `pnpm install` (the npm
+// `prepare` lifecycle) it runs `totem hook install`, so a consumer repo's managed
+// hooks self-repair without a manual step. It is a MANAGED_SESSION_HOOKS roster
+// member (below), so `totem hook install` itself drift-repairs it for adopters.
+//
+// The repo-relative install path + the canonical `prepare` script command, shared
+// by init's wiring and the doctor parity sensor so both key off one source of truth.
+export const PREPARE_SCRIPT_REL = '.totem/prepare.cjs';
+export const PREPARE_SCRIPT_COMMAND = 'node .totem/prepare.cjs';
+
+// Wrapper semantics (strategy#894 Option B, Tenet-4 core):
+//   - ALL logic runs in Node — NEVER a shell (the Windows quoting class, mmnto-ai/totem#2351).
+//   - CLI RESOLUTION: `@mmnto/cli` ships an `exports` map declaring only an `import`
+//     condition and NO `./package.json` subpath, so from this CommonJS wrapper BOTH
+//     `require.resolve('@mmnto/cli/package.json')` AND `require.resolve('@mmnto/cli')`
+//     throw ERR_PACKAGE_PATH_NOT_EXPORTED (verified against the real manifest at
+//     packages/cli/package.json, mmnto-ai/totem#2410 PR-B). The working alternative:
+//     a manual node_modules walk from the wrapper's own dir + the install cwd, reading
+//     package.json directly off disk — it bypasses the exports gate entirely.
+//   - NOT INSTALLED: the walk finds no `@mmnto/cli` → ONE stderr line naming the
+//     declared-skip class (CLI absent → hooks skipped; strategy#630 class) → exit 0.
+//   - INSTALLED: spawn `node <bin> hook install` (stdio inherited) and propagate the
+//     child's exit code VERBATIM — a genuine `hook install` failure fails `prepare`
+//     LOUD (exit != 0); the CLI's OWN declared skips are exit 0 and pass through. A
+//     spawn-level error (child.error set) → print + exit 1.
+//
+// Marker-headed (opens the file) + end-marker-bounded, so a bare `totem hook install`
+// bounded-repairs it and a user-owned `.totem/prepare.cjs` is never clobbered.
+export const PREPARE_WRAPPER = `${TOTEM_FILE_MARKER} — Totem init-distributed prepare wrapper (mmnto-ai/totem#2410)
+// Runs \`totem hook install\` on \`pnpm install\` (the npm \`prepare\` lifecycle) so a
+// consumer repo's managed hooks self-repair without a manual step. Dependency-free
+// CommonJS by design — Node execs a \`.cjs\` via plain \`node\`, no build step. ALL
+// logic is in Node, NEVER a shell (the Windows quoting class, mmnto-ai/totem#2351).
+//
+// CLI resolution note: @mmnto/cli's \`exports\` map declares only an \`import\` condition
+// and no \`./package.json\` subpath, so \`require.resolve\` (both the package and its
+// package.json) throws ERR_PACKAGE_PATH_NOT_EXPORTED from this CommonJS file. The
+// working alternative is a manual node_modules walk that reads package.json off disk.
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+// Walk up from each start dir looking for node_modules/@mmnto/cli/package.json.
+// Bypasses the exports gate that blocks require.resolve from a CommonJS wrapper.
+function findCliPackageJson(startDirs) {
+  for (const start of startDirs) {
+    if (typeof start !== 'string' || start.length === 0) continue;
+    let dir = start;
+    while (true) {
+      const candidate = path.join(dir, 'node_modules', '@mmnto', 'cli', 'package.json');
+      if (fs.existsSync(candidate)) return candidate;
+      const parent = path.dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+  }
+  return null;
+}
+
+const pkgJsonPath = findCliPackageJson([__dirname, process.cwd()]);
+if (pkgJsonPath === null) {
+  // Declared skip (strategy#630 class): the CLI is not a dependency here, so there
+  // is nothing to install — exit 0 so \`prepare\` (and thus \`pnpm install\`) succeeds.
+  process.stderr.write(
+    '[totem prepare] @mmnto/cli is not installed — skipping hook install ' +
+      '(managed hooks will be set up once the CLI is a dependency).\\n',
+  );
+  process.exit(0);
+}
+
+// Read the bin entry off the resolved manifest and resolve it to an absolute path.
+let binJs;
+try {
+  const pkg = JSON.parse(fs.readFileSync(pkgJsonPath, 'utf8'));
+  const bin = pkg && pkg.bin;
+  let binRel = null;
+  if (typeof bin === 'string') {
+    binRel = bin;
+  } else if (bin && typeof bin === 'object') {
+    binRel = bin.totem || bin[Object.keys(bin)[0]] || null;
+  }
+  if (typeof binRel !== 'string' || binRel.length === 0) {
+    process.stderr.write(
+      '[totem prepare] @mmnto/cli is installed but declares no usable bin — ' +
+        'cannot run hook install. Reinstall @mmnto/cli.\\n',
+    );
+    process.exit(1);
+  }
+  binJs = path.resolve(path.dirname(pkgJsonPath), binRel);
+} catch (err) {
+  process.stderr.write(
+    '[totem prepare] could not read @mmnto/cli package.json: ' +
+      (err && err.message ? err.message : String(err)) +
+      '\\n',
+  );
+  process.exit(1);
+}
+
+// Spawn \`node <bin> hook install\` — never a shell (the Windows quoting class).
+const child = spawnSync(process.execPath, [binJs, 'hook', 'install'], { stdio: 'inherit' });
+if (child.error) {
+  process.stderr.write(
+    '[totem prepare] failed to spawn totem hook install: ' +
+      (child.error.message || String(child.error)) +
+      '\\n',
+  );
+  process.exit(1);
+}
+// Propagate the child's exit code verbatim: a genuine hook-install failure fails
+// prepare loud; the CLI's own declared skips already exit 0.
+process.exit(child.status == null ? 1 : child.status);
+${TOTEM_FILE_END}
+`;
+
 // ─── Managed session-hook regeneration roster (mmnto-ai/totem#2410 PR-A) ───
 //
 // The whole-file, marker-headed `.cjs` / `.js` hook artifacts that `totem init`
@@ -832,6 +952,16 @@ export const MANAGED_SESSION_HOOKS: ReadonlyArray<ManagedSessionHook> = [
   {
     rel: '.gemini/hooks/BeforeTool.js',
     content: GEMINI_BEFORE_TOOL,
+    marker: TOTEM_FILE_MARKER,
+    endMarker: TOTEM_FILE_END,
+  },
+  {
+    // The init-distributed prepare wrapper (mmnto-ai/totem#2410 PR-B). A roster member
+    // so `totem hook install` drift-repairs it for adopters (init creates it; this verb
+    // regenerates-if-present). Not a session hook per se, but the same bounded-ownership
+    // whole-file semantics apply.
+    rel: PREPARE_SCRIPT_REL,
+    content: PREPARE_WRAPPER,
     marker: TOTEM_FILE_MARKER,
     endMarker: TOTEM_FILE_END,
   },

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -33,6 +33,9 @@ import {
   isBoundedOwnedFile,
   LEGACY_SENTINEL,
   markerOpensFile,
+  PREPARE_SCRIPT_COMMAND,
+  PREPARE_SCRIPT_REL,
+  PREPARE_WRAPPER,
   REFLEX_END,
   REFLEX_START,
   REFLEX_VERSION,
@@ -160,6 +163,83 @@ export function scaffoldFile(
     const message = err instanceof Error ? err.message : String(err);
     return { action: 'skipped', err: `[Totem Error] ${message}` };
   }
+}
+
+/**
+ * Wire a consumer `package.json`'s `prepare` script to the init-distributed prepare
+ * wrapper (mmnto-ai/totem#2410 PR-B). User-owned content is never overwritten (Prop 289):
+ *
+ *   - No `prepare` script            → set `"prepare": "node .totem/prepare.cjs"` (`wired`).
+ *   - `prepare` already exactly that → `exists` (no write; the file is left byte-identical).
+ *   - A DIFFERENT existing `prepare` (or a non-string value) → `declined` (NO write, byte-
+ *     identical): the caller prints the canonical line to add manually.
+ *   - No `package.json`              → `missing` (nothing to wire).
+ *   - Unreadable / invalid JSON      → `unparseable` (surfaced, never a crash).
+ *
+ * On the `wired` path the file is rewritten with 2-space JSON + a trailing newline
+ * (mirrors `scaffoldMcpConfig`, the repo's package.json-edit precedent); existing keys
+ * keep their order and `prepare` is appended within `scripts` (stable key order).
+ */
+export function wirePreparePackageJson(pkgPath: string): {
+  action: 'wired' | 'exists' | 'declined' | 'missing' | 'unparseable';
+  /** The different existing `prepare` value, for the decline notice (present only when a string). */
+  existing?: string;
+  err?: string;
+} {
+  if (!fs.existsSync(pkgPath)) {
+    return { action: 'missing' };
+  }
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(pkgPath, 'utf-8');
+    // totem-context: intentional cleanup — surface a read failure as a returned result (the `err` field the caller logs), never a silent swallow; the established scaffoldMcpConfig IO posture.
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { action: 'unparseable', err: `Could not read ${path.basename(pkgPath)}: ${message}` };
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(raw) as Record<string, unknown>;
+    // totem-context: intentional cleanup — surface invalid package.json as a returned result (`err`), the established scaffoldMcpConfig parse posture; init logs it and declines rather than crashing.
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      action: 'unparseable',
+      err: `Could not parse ${path.basename(pkgPath)} (invalid JSON): ${message}`,
+    };
+  }
+
+  const scriptsRaw = parsed.scripts;
+  const scripts =
+    scriptsRaw !== undefined && typeof scriptsRaw === 'object' && !Array.isArray(scriptsRaw)
+      ? (scriptsRaw as Record<string, unknown>)
+      : undefined;
+  const existingPrepare = scripts ? scripts.prepare : undefined;
+
+  if (existingPrepare !== undefined) {
+    if (typeof existingPrepare === 'string' && existingPrepare.trim() === PREPARE_SCRIPT_COMMAND) {
+      return { action: 'exists' };
+    }
+    // A different `prepare` (or a non-string value) is user-owned — never overwrite it.
+    return {
+      action: 'declined',
+      ...(typeof existingPrepare === 'string' ? { existing: existingPrepare } : {}),
+    };
+  }
+
+  // No `prepare` script — set it, appending `prepare` at the end of `scripts` (or
+  // creating `scripts` at the end of the object) so existing key order is preserved.
+  parsed.scripts = { ...(scripts ?? {}), prepare: PREPARE_SCRIPT_COMMAND };
+  try {
+    fs.writeFileSync(pkgPath, JSON.stringify(parsed, null, 2) + '\n', 'utf-8');
+    // totem-context: intentional cleanup — surface a write failure as a returned result (`err`) for the caller to log, never a silent swallow; the established scaffoldMcpConfig IO posture.
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { action: 'unparseable', err: `Could not write ${path.basename(pkgPath)}: ${message}` };
+  }
+  return { action: 'wired' };
 }
 
 // --- Gemini CLI hook installer ---
@@ -1295,6 +1375,48 @@ export default {
           }
         }
       }
+
+      // --- Always run: init-distributed prepare wrapper (mmnto-ai/totem#2410 PR-B) ---
+      // Scaffold .totem/prepare.cjs (managed, marker + end-marker bounded — a roster
+      // member so `totem hook install` drift-repairs it) and wire the consumer's
+      // package.json `prepare` to invoke it, so every `pnpm install` self-repairs the
+      // managed hooks. A DIFFERENT existing `prepare` is never overwritten (Prop 289):
+      // init declines and prints the canonical line to add manually.
+      const preparePath = path.join(cwd, ...PREPARE_SCRIPT_REL.split('/'));
+      const prepareScaffold = scaffoldFile(
+        preparePath,
+        PREPARE_WRAPPER,
+        TOTEM_FILE_MARKER,
+        TOTEM_FILE_END,
+      );
+      if (prepareScaffold.err) {
+        log.error('Totem Error', `Prepare wrapper scaffolding failed: ${prepareScaffold.err}`); // totem-ignore — internal scaffold error, not LLM output
+      } else if (prepareScaffold.action === 'created') {
+        summary.push({
+          file: PREPARE_SCRIPT_REL,
+          action: 'Scaffolded init-distributed prepare wrapper',
+        });
+      } else if (prepareScaffold.action === 'refreshed') {
+        summary.push({ file: PREPARE_SCRIPT_REL, action: 'Drift-repaired prepare wrapper' });
+      }
+
+      const prepareWiring = wirePreparePackageJson(path.join(cwd, 'package.json'));
+      if (prepareWiring.action === 'wired') {
+        summary.push({
+          file: 'package.json',
+          action: `Wired \`prepare\` → ${PREPARE_SCRIPT_COMMAND}`,
+        });
+      } else if (prepareWiring.action === 'declined') {
+        log.warn(
+          'Totem',
+          `package.json already defines a different \`prepare\` script — leaving it unchanged. ` +
+            `To run the Totem hook installer on install, add "prepare": "${PREPARE_SCRIPT_COMMAND}" ` +
+            `(or chain it into your existing prepare script).`,
+        );
+      } else if (prepareWiring.action === 'unparseable' && prepareWiring.err) {
+        log.warn('Totem', prepareWiring.err);
+      }
+      // 'exists' (already canonical) and 'missing' (no package.json) are silent no-ops.
 
       // --- Always run: enforcement hooks (pre-commit + pre-push) ---
       const hookTier = options?.strict ? 'strict' : undefined;

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -174,14 +174,18 @@ export function scaffoldFile(
  *   - A DIFFERENT existing `prepare` (or a non-string value) → `declined` (NO write, byte-
  *     identical): the caller prints the canonical line to add manually.
  *   - No `package.json`              → `missing` (nothing to wire).
- *   - Unreadable / invalid JSON      → `unparseable` (surfaced, never a crash).
+ *   - Unreadable / invalid JSON / a non-object root / a present-but-non-object
+ *     `scripts` → `unparseable` (surfaced, never a crash; a non-object `scripts` is
+ *     user content we must NOT silently replace — the decline posture, not a clobber).
+ *   - A write that throws (perms/FS) → `write-failed` (distinct from a parse/shape
+ *     problem, so the caller can tell "couldn't read your file" from "couldn't save it").
  *
  * On the `wired` path the file is rewritten with 2-space JSON + a trailing newline
  * (mirrors `scaffoldMcpConfig`, the repo's package.json-edit precedent); existing keys
  * keep their order and `prepare` is appended within `scripts` (stable key order).
  */
 export function wirePreparePackageJson(pkgPath: string): {
-  action: 'wired' | 'exists' | 'declined' | 'missing' | 'unparseable';
+  action: 'wired' | 'exists' | 'declined' | 'missing' | 'unparseable' | 'write-failed';
   /** The different existing `prepare` value, for the decline notice (present only when a string). */
   existing?: string;
   err?: string;
@@ -199,9 +203,9 @@ export function wirePreparePackageJson(pkgPath: string): {
     return { action: 'unparseable', err: `Could not read ${path.basename(pkgPath)}: ${message}` };
   }
 
-  let parsed: Record<string, unknown>;
+  let parsedRoot: unknown;
   try {
-    parsed = JSON.parse(raw) as Record<string, unknown>;
+    parsedRoot = JSON.parse(raw);
     // totem-context: intentional cleanup — surface invalid package.json as a returned result (`err`), the established scaffoldMcpConfig parse posture; init logs it and declines rather than crashing.
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
@@ -211,11 +215,31 @@ export function wirePreparePackageJson(pkgPath: string): {
     };
   }
 
+  // The root must be a plain object. `JSON.parse` also yields `null`, arrays, and
+  // scalars (`null`/`5`/`"x"`/`[]`) — dereferencing `.scripts` on those either throws
+  // (null) or reads garbage, and we must never write a wrapper into a non-object root.
+  if (parsedRoot === null || typeof parsedRoot !== 'object' || Array.isArray(parsedRoot)) {
+    return {
+      action: 'unparseable',
+      err: `${path.basename(pkgPath)} is not a JSON object — cannot wire a prepare script.`,
+    };
+  }
+  const parsed = parsedRoot as Record<string, unknown>;
+
   const scriptsRaw = parsed.scripts;
-  const scripts =
-    scriptsRaw !== undefined && typeof scriptsRaw === 'object' && !Array.isArray(scriptsRaw)
-      ? (scriptsRaw as Record<string, unknown>)
-      : undefined;
+  // A PRESENT `scripts` that is not a plain object (a string, array, number, null) is
+  // user content — replacing it would clobber it, violating the decline posture. Surface
+  // it as unparseable rather than silently overwriting (mmnto-ai/totem#2416 F1).
+  if (
+    scriptsRaw !== undefined &&
+    (scriptsRaw === null || typeof scriptsRaw !== 'object' || Array.isArray(scriptsRaw))
+  ) {
+    return {
+      action: 'unparseable',
+      err: `${path.basename(pkgPath)} "scripts" is not an object — leaving it unchanged.`,
+    };
+  }
+  const scripts = scriptsRaw as Record<string, unknown> | undefined;
   const existingPrepare = scripts ? scripts.prepare : undefined;
 
   if (existingPrepare !== undefined) {
@@ -237,7 +261,7 @@ export function wirePreparePackageJson(pkgPath: string): {
     // totem-context: intentional cleanup — surface a write failure as a returned result (`err`) for the caller to log, never a silent swallow; the established scaffoldMcpConfig IO posture.
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    return { action: 'unparseable', err: `Could not write ${path.basename(pkgPath)}: ${message}` };
+    return { action: 'write-failed', err: `Could not write ${path.basename(pkgPath)}: ${message}` };
   }
   return { action: 'wired' };
 }
@@ -1413,7 +1437,10 @@ export default {
             `To run the Totem hook installer on install, add "prepare": "${PREPARE_SCRIPT_COMMAND}" ` +
             `(or chain it into your existing prepare script).`,
         );
-      } else if (prepareWiring.action === 'unparseable' && prepareWiring.err) {
+      } else if (
+        (prepareWiring.action === 'unparseable' || prepareWiring.action === 'write-failed') &&
+        prepareWiring.err
+      ) {
         log.warn('Totem', prepareWiring.err);
       }
       // 'exists' (already canonical) and 'missing' (no package.json) are silent no-ops.

--- a/packages/cli/src/commands/install-hooks-exit-contract.test.ts
+++ b/packages/cli/src/commands/install-hooks-exit-contract.test.ts
@@ -61,7 +61,7 @@ describe('MANAGED_SESSION_HOOKS roster invariant', () => {
     }
   });
 
-  it('covers the five distributed session-hook artifacts', () => {
+  it('covers the six distributed managed artifacts (incl. the PR-B prepare wrapper)', () => {
     const rels = MANAGED_SESSION_HOOKS.map((h) => h.rel).sort();
     expect(rels).toEqual(
       [
@@ -70,6 +70,7 @@ describe('MANAGED_SESSION_HOOKS roster invariant', () => {
         '.claude/hooks/gate-wrapper.cjs',
         '.gemini/hooks/BeforeTool.js',
         '.gemini/hooks/SessionStart.js',
+        '.totem/prepare.cjs',
       ].sort(),
     );
   });

--- a/packages/cli/src/commands/prepare-wrapper.test.ts
+++ b/packages/cli/src/commands/prepare-wrapper.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Init-distributed prepare wrapper (mmnto-ai/totem#2410 PR-B).
+ *
+ * Three surfaces:
+ *   - PREPARE_WRAPPER behavior: write the template to a temp dir + execute it with
+ *     `process.execPath` against a hermetic fake `@mmnto/cli` (mkdtemp + cleanup;
+ *     nothing global mocked). Exit-code contract: MODULE_NOT_FOUND → 0 + skip line;
+ *     child exit propagated verbatim; a corrupt/missing bin → 1.
+ *   - wirePreparePackageJson: absent → set; canonical → unchanged; different →
+ *     untouched (byte-identical); missing / unparseable manifests.
+ *   - checkPrepareWrapper (doctor row): present+wired → pass; absent / miswired /
+ *     drifted → warn with the right remedy; owner-repo / user-owned → skip.
+ *
+ * The wrapper spawns are short-lived synchronous `node` invocations with cwd pinned
+ * to the hermetic temp dir (so resolution never leaks to the real repo's node_modules);
+ * every temp dir is torn down in afterEach.
+ */
+import { spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { cleanTmpDir } from '../test-utils.js';
+import { checkPrepareWrapper } from './doctor.js';
+import { wirePreparePackageJson } from './init.js';
+import { PREPARE_SCRIPT_COMMAND, PREPARE_WRAPPER, TOTEM_FILE_MARKER } from './init-templates.js';
+
+// ─── PREPARE_WRAPPER: exit-code behavior ─────────────────────────────
+
+describe('PREPARE_WRAPPER — exit-code contract', () => {
+  let tmpDir: string;
+  let wrapperPath: string;
+
+  const cliDir = () => path.join(tmpDir, 'node_modules', '@mmnto', 'cli');
+
+  /** Plant a fake `@mmnto/cli` with the given bin filename + body (undefined body = no bin file). */
+  function plantFakeCli(binFile: string, binBody: string | undefined): void {
+    fs.mkdirSync(cliDir(), { recursive: true });
+    fs.writeFileSync(
+      path.join(cliDir(), 'package.json'),
+      JSON.stringify({ name: '@mmnto/cli', version: '0.0.0', bin: { totem: `./${binFile}` } }),
+    );
+    if (binBody !== undefined) {
+      fs.writeFileSync(path.join(cliDir(), binFile), binBody);
+    }
+  }
+
+  /** Run the wrapper with cwd pinned to the hermetic temp dir. */
+  function runWrapper(): { status: number | null; stderr: string } {
+    const r = spawnSync(process.execPath, [wrapperPath], { cwd: tmpDir, encoding: 'utf8' });
+    return { status: r.status, stderr: r.stderr ?? '' };
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-2410b-wrap-'));
+    wrapperPath = path.join(tmpDir, 'prepare.cjs');
+    fs.writeFileSync(wrapperPath, PREPARE_WRAPPER, 'utf-8');
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  it('(a) @mmnto/cli not resolvable → exit 0 + a declared-skip stderr line', () => {
+    const { status, stderr } = runWrapper();
+    expect(status).toBe(0);
+    expect(stderr).toContain('@mmnto/cli is not installed');
+    expect(stderr).toContain('skipping hook install');
+  });
+
+  it('(b) fake @mmnto/cli whose bin exits 0 → wrapper exits 0', () => {
+    plantFakeCli('cli-bin.js', 'process.exit(0);\n');
+    expect(runWrapper().status).toBe(0);
+  });
+
+  it('(c) fake bin exits 3 → wrapper propagates 3 (a genuine hook-install failure fails prepare loud)', () => {
+    plantFakeCli('cli-bin.js', 'process.exit(3);\n');
+    expect(runWrapper().status).toBe(3);
+  });
+
+  it('(d) resolution ok but the bin file is missing (corrupt install) → exit 1', () => {
+    // package.json resolves + declares a bin, but the bin JS does not exist → the
+    // spawned `node <missing>` exits 1, which the wrapper propagates verbatim.
+    plantFakeCli('missing-bin.js', undefined);
+    expect(runWrapper().status).toBe(1);
+  });
+
+  it('never spawns through a shell (spawnSync argv form; no shell:true) — the marker opens the file', () => {
+    // Structural guard: the emitted wrapper drives node via an argv array, not a
+    // shell string (the Windows quoting class, mmnto-ai/totem#2351).
+    expect(PREPARE_WRAPPER.trimStart().startsWith(TOTEM_FILE_MARKER)).toBe(true);
+    expect(PREPARE_WRAPPER).toContain("spawnSync(process.execPath, [binJs, 'hook', 'install']");
+    expect(PREPARE_WRAPPER).not.toContain('shell: true');
+    expect(PREPARE_WRAPPER).not.toContain('execSync');
+  });
+});
+
+// ─── wirePreparePackageJson: wiring matrix ───────────────────────────
+
+describe('wirePreparePackageJson — wiring matrix', () => {
+  let tmpDir: string;
+  const pkgPath = () => path.join(tmpDir, 'package.json');
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-2410b-wire-'));
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  it('no prepare script → sets it (wired)', () => {
+    fs.writeFileSync(
+      pkgPath(),
+      JSON.stringify({ name: 'consumer', scripts: { build: 'tsc' } }, null, 2) + '\n',
+    );
+    const r = wirePreparePackageJson(pkgPath());
+    expect(r.action).toBe('wired');
+    const parsed = JSON.parse(fs.readFileSync(pkgPath(), 'utf-8'));
+    expect(parsed.scripts.prepare).toBe(PREPARE_SCRIPT_COMMAND);
+    // Existing key order preserved; prepare appended after build.
+    expect(Object.keys(parsed.scripts)).toEqual(['build', 'prepare']);
+    // Trailing newline preserved.
+    expect(fs.readFileSync(pkgPath(), 'utf-8').endsWith('}\n')).toBe(true);
+  });
+
+  it('no scripts block at all → creates scripts with prepare (wired)', () => {
+    fs.writeFileSync(pkgPath(), JSON.stringify({ name: 'consumer' }, null, 2) + '\n');
+    const r = wirePreparePackageJson(pkgPath());
+    expect(r.action).toBe('wired');
+    expect(JSON.parse(fs.readFileSync(pkgPath(), 'utf-8')).scripts.prepare).toBe(
+      PREPARE_SCRIPT_COMMAND,
+    );
+  });
+
+  it('prepare already exactly canonical → unchanged (exists), byte-identical', () => {
+    const raw =
+      JSON.stringify({ name: 'consumer', scripts: { prepare: PREPARE_SCRIPT_COMMAND } }, null, 2) +
+      '\n';
+    fs.writeFileSync(pkgPath(), raw);
+    const r = wirePreparePackageJson(pkgPath());
+    expect(r.action).toBe('exists');
+    expect(fs.readFileSync(pkgPath(), 'utf-8')).toBe(raw);
+  });
+
+  it('a DIFFERENT existing prepare → declined + byte-identical (no overwrite of user content)', () => {
+    const raw =
+      JSON.stringify({ name: 'consumer', scripts: { prepare: 'husky install' } }, null, 2) + '\n';
+    fs.writeFileSync(pkgPath(), raw);
+    const r = wirePreparePackageJson(pkgPath());
+    expect(r.action).toBe('declined');
+    expect(r.existing).toBe('husky install');
+    // The whole file is preserved verbatim.
+    expect(fs.readFileSync(pkgPath(), 'utf-8')).toBe(raw);
+  });
+
+  it('a non-string prepare value → declined + byte-identical (never clobber weird user content)', () => {
+    const raw =
+      JSON.stringify({ name: 'consumer', scripts: { prepare: { weird: true } } }, null, 2) + '\n';
+    fs.writeFileSync(pkgPath(), raw);
+    const r = wirePreparePackageJson(pkgPath());
+    expect(r.action).toBe('declined');
+    expect(fs.readFileSync(pkgPath(), 'utf-8')).toBe(raw);
+  });
+
+  it('no package.json → missing (nothing to wire)', () => {
+    expect(wirePreparePackageJson(pkgPath()).action).toBe('missing');
+  });
+
+  it('invalid JSON → unparseable (surfaced, never a crash), byte-identical', () => {
+    const raw = '{ not valid json ]';
+    fs.writeFileSync(pkgPath(), raw);
+    const r = wirePreparePackageJson(pkgPath());
+    expect(r.action).toBe('unparseable');
+    expect(r.err).toBeDefined();
+    expect(fs.readFileSync(pkgPath(), 'utf-8')).toBe(raw);
+  });
+});
+
+// ─── checkPrepareWrapper: doctor sensor row ──────────────────────────
+
+describe('checkPrepareWrapper — doctor parity row (sensor, never gates)', () => {
+  let tmpDir: string;
+
+  const wrapperPath = () => path.join(tmpDir, '.totem', 'prepare.cjs');
+  const pkgPath = () => path.join(tmpDir, 'package.json');
+
+  function writeWrapper(content: string): void {
+    fs.mkdirSync(path.dirname(wrapperPath()), { recursive: true });
+    fs.writeFileSync(wrapperPath(), content, 'utf-8');
+  }
+  function writePkg(pkg: unknown): void {
+    fs.writeFileSync(pkgPath(), JSON.stringify(pkg, null, 2) + '\n');
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-2410b-doc-'));
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  it('present + canonical + wired → pass', async () => {
+    writeWrapper(PREPARE_WRAPPER);
+    writePkg({ name: 'consumer', scripts: { prepare: PREPARE_SCRIPT_COMMAND } });
+    const r = await checkPrepareWrapper(tmpDir);
+    expect(r.status).toBe('pass');
+  });
+
+  it('wrapper absent + no prepare → warn, remedy names totem init', async () => {
+    writePkg({ name: 'consumer', scripts: { build: 'tsc' } });
+    const r = await checkPrepareWrapper(tmpDir);
+    expect(r.status).toBe('warn');
+    expect(r.remediation).toBe('totem init');
+  });
+
+  it('wrapper present + canonical but prepare NOT wired → warn (miswired), remedy totem init', async () => {
+    writeWrapper(PREPARE_WRAPPER);
+    writePkg({ name: 'consumer', scripts: {} });
+    const r = await checkPrepareWrapper(tmpDir);
+    expect(r.status).toBe('warn');
+    expect(r.remediation).toBe('totem init');
+    expect(r.message).toContain('not wired');
+  });
+
+  it('wrapper present + marker-headed but DRIFTED → warn, remedy is bare totem hook install', async () => {
+    writeWrapper(
+      `${TOTEM_FILE_MARKER} — drifted\nconsole.log("stale");\n// [totem] end auto-generated\n`,
+    );
+    writePkg({ name: 'consumer', scripts: { prepare: PREPARE_SCRIPT_COMMAND } });
+    const r = await checkPrepareWrapper(tmpDir);
+    expect(r.status).toBe('warn');
+    expect(r.remediation).toBe('totem hook install');
+    expect(r.message).toContain('drifted');
+  });
+
+  it('owner-repo exception: wrapper absent + a DIFFERENT user-managed prepare → skip (no nudge)', async () => {
+    writePkg({ name: 'owner', scripts: { prepare: 'node tools/install-hooks.js' } });
+    const r = await checkPrepareWrapper(tmpDir);
+    expect(r.status).toBe('skip');
+  });
+
+  it('user-owned .totem/prepare.cjs (no Totem marker) → skip (left as-is)', async () => {
+    writeWrapper('// my own prepare helper\nconsole.log("mine");\n');
+    writePkg({ name: 'consumer', scripts: { prepare: 'node .totem/prepare.cjs' } });
+    const r = await checkPrepareWrapper(tmpDir);
+    expect(r.status).toBe('skip');
+  });
+
+  it('no package.json → skip (nothing to wire)', async () => {
+    const r = await checkPrepareWrapper(tmpDir);
+    expect(r.status).toBe('skip');
+  });
+
+  it('wired canonical but wrapper file missing → warn, remedy totem init', async () => {
+    writePkg({ name: 'consumer', scripts: { prepare: PREPARE_SCRIPT_COMMAND } });
+    const r = await checkPrepareWrapper(tmpDir);
+    expect(r.status).toBe('warn');
+    expect(r.remediation).toBe('totem init');
+    expect(r.message).toContain('missing');
+  });
+});

--- a/packages/cli/src/commands/prepare-wrapper.test.ts
+++ b/packages/cli/src/commands/prepare-wrapper.test.ts
@@ -25,7 +25,12 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { cleanTmpDir } from '../test-utils.js';
 import { checkPrepareWrapper } from './doctor.js';
 import { wirePreparePackageJson } from './init.js';
-import { PREPARE_SCRIPT_COMMAND, PREPARE_WRAPPER, TOTEM_FILE_MARKER } from './init-templates.js';
+import {
+  PREPARE_SCRIPT_COMMAND,
+  PREPARE_WRAPPER,
+  TOTEM_FILE_END,
+  TOTEM_FILE_MARKER,
+} from './init-templates.js';
 
 // ─── PREPARE_WRAPPER: exit-code behavior ─────────────────────────────
 
@@ -177,6 +182,47 @@ describe('wirePreparePackageJson — wiring matrix', () => {
     expect(r.err).toBeDefined();
     expect(fs.readFileSync(pkgPath(), 'utf-8')).toBe(raw);
   });
+
+  // F1 (mmnto-ai/totem#2416): a non-object JSON root must not crash at `.scripts` or be
+  // written into — validate the shape and decline as unparseable.
+  it.each([
+    ['null root', 'null'],
+    ['scalar root', '5'],
+    ['string root', '"hi"'],
+    ['array root', '[]'],
+  ])('%s → unparseable + byte-identical (never dereferenced or written)', (_label, raw) => {
+    fs.writeFileSync(pkgPath(), raw);
+    const r = wirePreparePackageJson(pkgPath());
+    expect(r.action).toBe('unparseable');
+    expect(r.err).toBeDefined();
+    expect(fs.readFileSync(pkgPath(), 'utf-8')).toBe(raw);
+  });
+
+  it('a present-but-non-object `scripts` → unparseable + byte-identical (never clobbered)', () => {
+    // The pre-fix bug: a non-object `scripts` fell through to the wire branch and was
+    // silently REPLACED by `{ prepare: ... }`. It must be declined as unparseable.
+    const raw = JSON.stringify({ name: 'consumer', scripts: 'oops-a-string' }, null, 2) + '\n';
+    fs.writeFileSync(pkgPath(), raw);
+    const r = wirePreparePackageJson(pkgPath());
+    expect(r.action).toBe('unparseable');
+    expect(fs.readFileSync(pkgPath(), 'utf-8')).toBe(raw);
+  });
+
+  // F5 (mmnto-ai/totem#2416): a write that throws is a DISTINCT discriminant from a
+  // read/parse/shape problem.
+  it('a write failure → write-failed (distinct from unparseable)', () => {
+    const raw = JSON.stringify({ name: 'consumer' }, null, 2) + '\n';
+    fs.writeFileSync(pkgPath(), raw);
+    fs.chmodSync(pkgPath(), 0o444); // read-only → read+parse succeed, writeFileSync throws (EPERM/EACCES)
+    try {
+      const r = wirePreparePackageJson(pkgPath());
+      expect(r.action).toBe('write-failed');
+      expect(r.err).toBeDefined();
+    } finally {
+      // Restore write perms so cleanup can remove the temp dir.
+      fs.chmodSync(pkgPath(), 0o644);
+    }
+  });
 });
 
 // ─── checkPrepareWrapper: doctor sensor row ──────────────────────────
@@ -226,15 +272,47 @@ describe('checkPrepareWrapper — doctor parity row (sensor, never gates)', () =
     expect(r.message).toContain('not wired');
   });
 
-  it('wrapper present + marker-headed but DRIFTED → warn, remedy is bare totem hook install', async () => {
-    writeWrapper(
-      `${TOTEM_FILE_MARKER} — drifted\nconsole.log("stale");\n// [totem] end auto-generated\n`,
-    );
+  it('wrapper present + marker-headed + BOUNDED but drifted → warn, remedy is bare totem hook install', async () => {
+    writeWrapper(`${TOTEM_FILE_MARKER} — drifted\nconsole.log("stale");\n${TOTEM_FILE_END}\n`);
     writePkg({ name: 'consumer', scripts: { prepare: PREPARE_SCRIPT_COMMAND } });
     const r = await checkPrepareWrapper(tmpDir);
     expect(r.status).toBe('warn');
     expect(r.remediation).toBe('totem hook install');
     expect(r.message).toContain('drifted');
+  });
+
+  // F3 (mmnto-ai/totem#2416): a marker-headed but UNBOUNDED drifted wrapper (no end
+  // marker) is not bare-repairable — the remedy must name --force.
+  it('wrapper present + marker-headed but UNBOUNDED drifted → warn, remedy is totem hook install --force', async () => {
+    writeWrapper(`${TOTEM_FILE_MARKER} — drifted, no end marker\nconsole.log("stale");\n`);
+    writePkg({ name: 'consumer', scripts: { prepare: PREPARE_SCRIPT_COMMAND } });
+    const r = await checkPrepareWrapper(tmpDir);
+    expect(r.status).toBe('warn');
+    expect(r.remediation).toBe('totem hook install --force');
+    expect(r.message).toContain('drifted');
+  });
+
+  // F2 (mmnto-ai/totem#2416): a wrapper that EXISTS but cannot be read must warn with the
+  // read-failure detail, not fall through to the user-owned skip. A directory-at-path makes
+  // existsSync true while readFileSync throws EISDIR (cross-platform).
+  it('wrapper present but unreadable (EISDIR) → warn naming the read failure, not a user-owned skip', async () => {
+    fs.mkdirSync(path.join(tmpDir, '.totem', 'prepare.cjs'), { recursive: true });
+    writePkg({ name: 'consumer', scripts: { prepare: PREPARE_SCRIPT_COMMAND } });
+    const r = await checkPrepareWrapper(tmpDir);
+    expect(r.status).toBe('warn');
+    expect(r.message).toContain('could not read');
+    expect(r.message).not.toContain('user-owned');
+  });
+
+  // F4 (mmnto-ai/totem#2416): canonical wrapper present but a DIFFERENT prepare exists —
+  // `totem init` deliberately declines that, so the remedy must be the manual line.
+  it('wrapper present + canonical but a DIFFERENT prepare → warn, remedy is the manual line (not totem init)', async () => {
+    writeWrapper(PREPARE_WRAPPER);
+    writePkg({ name: 'consumer', scripts: { prepare: 'husky install' } });
+    const r = await checkPrepareWrapper(tmpDir);
+    expect(r.status).toBe('warn');
+    expect(r.remediation).toContain('add or chain');
+    expect(r.remediation).not.toBe('totem init');
   });
 
   it('owner-repo exception: wrapper absent + a DIFFERENT user-managed prepare → skip (no nudge)', async () => {


### PR DESCRIPTION
Closes #2410 (PR-B, slice 1 — the final slice; PR-A #2413 delivered slices 2+3).

## What

The strategy#894 Option-B consumer shape: `totem init` distributes a managed, dependency-free `.totem/prepare.cjs` and wires `package.json`'s `prepare` to `node .totem/prepare.cjs` — only when no `prepare` exists. An existing different `prepare` is **never modified** (init prints the canonical line to add manually; Prop 289 no-overwrite-of-user-owned).

**Wrapper semantics** (all logic in node, never a shell — the Windows quoting class #2351):

- `@mmnto/cli` unresolvable → one stderr line + **exit 0** (the strategy#630 declared-skip class: `pnpm install` succeeds in repos that haven't adopted the CLI).
- CLI present → `spawnSync(process.execPath, [binJs, 'hook', 'install'], {stdio:'inherit'})`; child exit **propagated verbatim** — a genuine hook-install failure fails `prepare` loud (the #894 Tenet-4 core), while the CLI's own declared skips stay 0.
- Spawn error / unusable bin → exit 1.

The wrapper is marker-headed + end-marker-bounded and joins the `MANAGED_SESSION_HOOKS` roster, so `totem hook install` (which the wrapper itself invokes) drift-repairs it for adopters via the PR-A path. Totem's own repo keeps `tools/install-hooks.js` (owner-repo exception) — no `.totem/prepare.cjs` here, and regenerate-only-if-present guarantees it stays that way.

**Doctor sensor:** new `Prepare Wrapper` diagnostic row (present+wired → pass; missing/miswired → warn with `totem init` adoption remedy, or bare `totem hook install` for a bounded-drifted wrapper; owner-repo shape → skip, keeping totem's own doctor quiet). Sensor-only — `--strict` gates only on `fail`.

## Resolution note reviewers should see

The design called for `require.resolve('@mmnto/cli/package.json')`. That is **unusable**: the real package's `exports` map declares only an `import` condition and no `./package.json` subpath, so both resolve forms throw `ERR_PACKAGE_PATH_NOT_EXPORTED` from a CommonJS wrapper (verified empirically). The wrapper instead walks `node_modules` from `[__dirname, process.cwd()]` and reads the manifest off disk — `exports` gates module resolution, not fs reads. Documented in the template comment.

## Tests

20 new tests (`prepare-wrapper.test.ts`): the wrapper executed for real against fake `@mmnto/cli` fixtures (absent → 0+skip line; bin exits 0 → 0; bin exits 3 → 3; corrupt → 1; no-shell structural guard), the `wirePreparePackageJson` matrix (absent/no-scripts → wired; canonical → byte-identical; different/non-string/invalid-JSON → byte-identical + declined/unparseable), and the doctor row states. Roster invariant auto-covers the new entry (coverage test 5→6).

## Gates

Full `pnpm -r build && pnpm -r test` green (3297 CLI tests), repo ESLint 0 errors, `format:check` clean, full-branch `totem lint --base main` PASS (0 errors; new result-surface catches carry `totem-context` directives matching the established scaffoldMcpConfig posture). Built by an Opus subagent against the approved design (`.totem/specs/2410-prepare-contract.md`); coordinator-verified at source. Deviation from design, accepted: the doctor row lives in `doctor.ts` (free-standing diagnostic pattern) rather than `doctor-parity.ts`, which is entirely parity-manifest-driven from the doctrine package — a standalone row there would be dead code until strategy ships a manifest contract.

Merge gate note: this PR carries the #2410 couple-on-merge check — strategy#894's convention is being authored against the build issue concurrently; mail + convention state get re-read before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
