### PR TITLE
chore(hooks): owner-repo end-marker migration for 1.101.0 (.gemini SessionStart)

### DIFF
--- a/.gemini/hooks/SessionStart.js
+++ b/.gemini/hooks/SessionStart.js
@@ -28,3 +28,4 @@ try {
   // surface a NON-fatal breadcrumb (matches the Claude-side hook) rather than swallow.
   process.stderr.write('[SessionStart] orient briefing unavailable (non-fatal): ' + (err instanceof Error ? err.message : String(err)) + '\n');
 }
+// [totem] end auto-generated


### PR DESCRIPTION
The one `totem hook install --force` the 1.101.0 cut choreography prescribes, run in the owner repo: `.gemini/hooks/SessionStart.js` adopts the end marker (one-line diff; bare self-repair armed). `BeforeTool.js` correctly declined as user-owned (repo-customized ADR-063 phase-gate content — the new positional ownership gate working as designed on real data); no distributed `.claude` hooks exist here; `tools/install-hooks.js` stays per the strategy#904 owner-repo exception. Git hooks force-regenerated in place (untracked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)