### PR TITLE
chore(pins): strategy-doctrine 0.1.21

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@anthropic-ai/sdk": "^0.98.0",
     "@changesets/cli": "^2.31.0",
     "@google/genai": "^2.6.0",
-    "@mmnto/cli": "workspace:*",
     "eslint": "^10.4.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-simple-import-sort": "^13.0.0",
@@ -35,6 +34,7 @@
     "typescript-eslint": "^8.59.4"
   },
   "optionalDependencies": {
-    "@mmnto/strategy-doctrine": "0.1.20"
+    "@mmnto/cli": "workspace:*",
+    "@mmnto/strategy-doctrine": "0.1.21"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@google/genai':
         specifier: ^2.6.0
         version: 2.6.0(@modelcontextprotocol/sdk@1.27.1(zod@3.25.76))
-      '@mmnto/cli':
-        specifier: workspace:*
-        version: link:packages/cli
       eslint:
         specifier: ^10.4.0
         version: 10.4.0(jiti@2.6.1)
@@ -45,9 +42,12 @@ importers:
         specifier: ^8.59.4
         version: 8.59.4(eslint@10.4.0(jiti@2.6.1))(typescript@5.9.3)
     optionalDependencies:
+      '@mmnto/cli':
+        specifier: workspace:*
+        version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.20
-        version: 0.1.20
+        specifier: 0.1.21
+        version: 0.1.21
 
   packages/cli:
     dependencies:
@@ -853,8 +853,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.20':
-    resolution: {integrity: sha512-OxOYAOeALLPdsnSExcDaSG5NEpnENWunnxPvnxWek05tSA6BH0iINCLm6vXV8owsH9zHOFjJvBpJrf+TjMS0QA==}
+  '@mmnto/strategy-doctrine@0.1.21':
+    resolution: {integrity: sha512-ARmdHhJl/15ACfCpw2eInlA4X1kAounAdts0zelgQL2Bihsq0/mP3Bgc754/DcxXA4VtQBrTy1GmDnIxjZGRwA==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3685,7 +3685,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.20':
+  '@mmnto/strategy-doctrine@0.1.21':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
Final slice of the mmnto-ai/totem-strategy#894 propagation pass (cohort-sync lane). @mmnto/strategy-doctrine 0.1.20 -> 0.1.21 (published tonight via OIDC, mmnto-ai/totem-strategy#911): the bundled freeze.json picks up the 2026-07-17 operator scope ruling on the rule-compilation freeze (compile-input lessons only; index-only add_lesson EXEMPT — mmnto-ai/totem-strategy#906). Lockfile regenerated in an **authed** shell via the explicit re-add (the mmnto-ai/totem-strategy#630 cut-through) — an unauthed `pnpm install` reproduces the silent-uninstall trap live and was caught + discarded before commit. No prepare change here: totem keeps its `tools/` owner-repo variant permanently per doctrine. Related: mmnto-ai/totem#2418 (consumer wrapper worktree crash, filed tonight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)