### PR TITLE
chore: totem postmerge lessons for 2411 2413 2416 2417

### DIFF
--- a/.totem/lessons/lesson-379fc29e.md
+++ b/.totem/lessons/lesson-379fc29e.md
@@ -1,0 +1,6 @@
+## Lesson — Avoid require.resolve for package.json
+
+**Tags:** node, commonjs, esm, dependencies
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Using `require.resolve` on a package's `package.json` fails with `ERR_PACKAGE_PATH_NOT_EXPORTED` if the target's `exports` map only defines an `import` condition. To read the manifest safely, manually walk `node_modules` and read the file directly from disk, as `exports` maps do not restrict direct filesystem reads.

--- a/.totem/lessons/lesson-80d9c896.md
+++ b/.totem/lessons/lesson-80d9c896.md
@@ -1,0 +1,6 @@
+## Lesson — Anchor ownership markers to file starts
+
+**Tags:** cli, security, file-io
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Ownership verification checks must require the marker to be at the file's opening position rather than simply existing in the content. This prevents accidental overwrites of user-owned files that contain quoted or nested references to the marker.

--- a/.totem/lessons/lesson-8712f719.md
+++ b/.totem/lessons/lesson-8712f719.md
@@ -1,0 +1,6 @@
+## Lesson — Separate artifact creation from regeneration
+
+**Tags:** cli, dx, architecture
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Regeneration tasks should only update existing files and never create missing ones, leaving initial creation to initialization commands. This prevents installation scripts from unexpectedly polluting workspaces with unwanted configuration files.

--- a/.totem/lessons/lesson-87628b70.md
+++ b/.totem/lessons/lesson-87628b70.md
@@ -1,0 +1,6 @@
+## Lesson — Decouple session hooks from git managers
+
+**Tags:** git, cli, hooks
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Session hook regeneration must execute independently of Git hook managers like Husky or Lefthook. Because session hooks are environment-specific artifacts, their lifecycle must not be bypassed when Git hook management returns early.

--- a/.totem/lessons/lesson-bd91cf1f.md
+++ b/.totem/lessons/lesson-bd91cf1f.md
@@ -1,0 +1,6 @@
+## Lesson — Execute child processes without a shell wrapper
+
+**Tags:** cli, process, cross-platform
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+When wrapping CLI commands in a lifecycle script, spawn the child process directly via `process.execPath` rather than using a shell to prevent Windows quoting issues, and propagate its exit code verbatim to maintain correct pipeline failure semantics.


### PR DESCRIPTION
## What

Postmerge lesson extraction for the 2026-07-17 train: #2411, #2413, #2416, #2417 (VP #2415 excluded per convention). 5 lessons committed.

Per-PR yield:

- **#2411** (gemini-2.5 docs relabel) — 0 lessons (no review content; extractor skipped).
- **#2413** (hooksCommand exit-code contract + bounded drift-repair) — 3 lessons: session-hook regeneration independent of git hook managers (the coordinator-verify catch); positional ownership markers anchored to file start (quoted-marker user files never clobbered); regeneration updates-only-never-creates (creation belongs to init).
- **#2416** (consumer prepare wrapper) — 2 lessons: `require.resolve('pkg/package.json')` ERR_PACKAGE_PATH_NOT_EXPORTED premise correction (walk node_modules, read manifest off disk); shell-less `process.execPath` spawn + verbatim exit-code propagation.
- **#2417** (owner-repo end-marker migration) — 1 extraction **dropped pre-commit**: it restated the #2413 positional-ownership-gate lesson (outcome-phrased duplicate of `lesson-80d9c896`; #2417 was the PR where that gate proved itself, so the extractor re-derived it — dedup missed the paraphrase).

## Freeze conformance

`rule-compilation` freeze (2026-05-17) untouched: no `totem lesson compile`, no compiled-rules/manifest/export changes — this PR is lesson files only, the sanctioned freeze-era accrual path (same shape as #2409, #2392). Lesson-side input drift is the class verify-manifest WARN-downgrades under the freeze by design.

`totem sync` run post-extraction (index reconciled, dropped extraction's chunk purged).

Note kept-as-is: `lesson-379fc29e` phrases the ERR_PACKAGE_PATH_NOT_EXPORTED cause via the import-only-condition instance rather than the general subpath-not-exported class; remediation payload is correct, left unedited under the freeze.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
