### PR TITLE
chore(freeze): re-sync local mirror do-not to the 0.1.21 scope ruling (strategy#906)

### DIFF
--- a/.totem/freeze.json
+++ b/.totem/freeze.json
@@ -9,7 +9,7 @@
       "reason": "CI-visible mirror of the cohort hold (see _note): parked pending the Convergent Spine replacement. The legacy `totem lesson compile` path cannot recompile (safe-regex2 ReDoS gate vs the xrepo-qualify-refs lookbehind; upstream fix declined, mmnto-ai/totem#1855 NOT_PLANNED).",
       "tracking": "Rule-compilation freeze (2026-05-17) — multi-gate lift status (GH Project board, orgs/mmnto-ai/projects/1)",
       "do-not": [
-        "edit .totem/lessons/**",
+        "edit COMPILE-INPUT lessons under .totem/lessons/** (scope ruled 2026-07-17, operator: the freeze governs the compile path only — index-only lessons added via add_lesson feed retrieval, never the frozen compiler, and are EXEMPT)",
         "run `totem lesson compile`",
         "hand-edit .totem/compiled-rules.json (Tenet 20 — it's a regenerable cache)"
       ]


### PR DESCRIPTION
## What

Re-syncs the `.totem/freeze.json` CI-visibility mirror's first do-not line to canonical: the 2026-07-17 operator scope ruling (mmnto-ai/totem-strategy#906, distributed in @mmnto/strategy-doctrine 0.1.21 via #2419) scopes the lessons do-not to **COMPILE-INPUT lessons only**, exempting index-only `add_lesson`. The mirror still carried the pre-ruling blanket wording — exactly the ambiguity class #906 dissolved (two seats read the old line oppositely), living on in the surface CI and doctrine-blind consumers read.

One line, byte-parity with the canonical registry's do-not string. Mirror framing (`_note`, `scope: local`, reason) untouched — change-authority stays with the cohort registry per the #2167 Q3 ruling.

## Why now

#2419 bumped the pin but not the mirror (its lane was the lockfile cut-through). Caught during post-merge verification of #2420. #2352 (freeze-mirror drift sensor) is the standing mechanism for this class; until it lands, parity is discipline-enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
