### PR TITLE
fix(cli): worktree-aware hooks dir — resolve the gitdir pointer instead of blind-joining .git/hooks

### DIFF
--- a/.changeset/worktree-gitdir-hooks-dir.md
+++ b/.changeset/worktree-gitdir-hooks-dir.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/cli': patch
+---
+
+`totem hook install` (and the `.totem/prepare.cjs` consumer wrapper that invokes it) no longer crashes with ENOTDIR in a linked git worktree (mmnto-ai/totem#2418). In a worktree `.git` is a `gitdir:` pointer FILE, and every hooks-path site blindly joined `.git/hooks` before `mkdir` — failing the consumer's whole `pnpm install` through the `prepare` lifecycle. A shared `resolveHooksDir()` now delegates to `git rev-parse --git-path hooks` (git's own worktree/`commondir` walk, which also honors `core.hooksPath`), so hooks install into the shared hooks directory git actually executes; `--check`, the silent pre-push upgrade, and the doctor `git-hooks` parity row read the same resolved location instead of wrongly reporting hooks missing from a worktree. An unparseable `.git` pointer file is now the declared skip the #2410 exit-code contract names (exit 0 with a truthful skip line), never a crash.

--- a/packages/cli/src/commands/doctor-parity.ts
+++ b/packages/cli/src/commands/doctor-parity.ts
@@ -357,18 +357,18 @@ interface GeneratedArtifact {
 
 /**
  * Resolve the four git-hook artifacts the `git-hooks` contract checks, each with a
- * per-repo regenerated canonical. Checks `.git/hooks/*` only — hook-manager installs
+ * per-repo regenerated canonical. `hooksDir` is the repo's RESOLVED hooks directory
+ * (worktree-aware — mmnto-ai/totem#2418). Checks git hooks only — hook-manager installs
  * (`.totem/hooks/*.sh` for husky / lefthook) are a follow-on (no cohort consumer uses
  * one today); the detector's present-without-marker → `skip` keeps a manager repo
  * honest in the meantime.
  */
 function gitHookArtifactsFor(
-  gitRoot: string,
+  hooksDir: string,
   tier: 'strict' | 'standard',
   fallbackCmd: string,
   builders: HookBuilderSource,
 ): GeneratedArtifact[] {
-  const hooksDir = path.join(gitRoot, '.git', 'hooks');
   const m = builders.markers;
   return [
     {
@@ -749,6 +749,7 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
         buildHookContent,
         buildPostCheckoutHookContent,
         getFallbackCommand,
+        resolveHooksDir,
         TOTEM_PRECOMMIT_MARKER,
         TOTEM_PREPUSH_MARKER,
         TOTEM_HOOK_MARKER,
@@ -1034,7 +1035,18 @@ export async function checkParity(cwd: string): Promise<ParityCheckResult> {
           let artifactLabel = 'artifact';
           let installCommand = 'totem init';
           if (c.id === 'git-hooks') {
-            generatedArtifacts = gitHookArtifactsFor(gitRoot, hookTier, fallbackCmd, hookBuilders);
+            // Worktree-aware hooks location (mmnto-ai/totem#2418): a linked
+            // worktree's hooks live behind the `.git` gitdir pointer, so a blind
+            // `.git/hooks` join would report every hook missing there. The
+            // read-only join fallback keeps the pre-#2418 behavior when even the
+            // resolver comes up empty.
+            const parityHooksDir = resolveHooksDir(gitRoot) ?? path.join(gitRoot, '.git', 'hooks');
+            generatedArtifacts = gitHookArtifactsFor(
+              parityHooksDir,
+              hookTier,
+              fallbackCmd,
+              hookBuilders,
+            );
             artifactLabel = 'git hook';
             // --force so the remediation actually repairs a stale hook: bare
             // `totem hook install` only drift-repairs a totem-OWNED whole file, but

--- a/packages/cli/src/commands/install-hooks-exit-contract.test.ts
+++ b/packages/cli/src/commands/install-hooks-exit-contract.test.ts
@@ -487,14 +487,16 @@ describe('hooksCommand in a linked worktree (mmnto-ai/totem#2418)', () => {
     expect(fs.statSync(path.join(wtDir, '.git')).isFile()).toBe(true);
     const resolved = resolveHooksDir(wtDir);
     expect(resolved).not.toBeNull();
-    // realpath both sides: tmpdir segments can differ by symlink/8.3 aliasing.
-    expect(fs.realpathSync(resolved!)).toBe(fs.realpathSync(sharedHooksDir()));
+    // realpathSync.native both sides: git prints the LONG form while os.tmpdir()
+    // can carry a Windows 8.3 alias (RUNNER~1 on GH runners) or a symlinked
+    // tmpdir (macOS /var → /private/var); only the native variant expands both.
+    expect(fs.realpathSync.native(resolved!)).toBe(fs.realpathSync.native(sharedHooksDir()));
   });
 
   it('resolveHooksDir in a plain checkout stays .git/hooks', () => {
     const resolved = resolveHooksDir(mainDir);
     expect(resolved).not.toBeNull();
-    expect(fs.realpathSync(resolved!)).toBe(fs.realpathSync(sharedHooksDir()));
+    expect(fs.realpathSync.native(resolved!)).toBe(fs.realpathSync.native(sharedHooksDir()));
   });
 
   it('exit 0: install from the worktree lands in the shared hooks dir (no ENOTDIR)', async () => {

--- a/packages/cli/src/commands/install-hooks-exit-contract.test.ts
+++ b/packages/cli/src/commands/install-hooks-exit-contract.test.ts
@@ -20,7 +20,7 @@
  * spy (the doctor.test.ts idiom); the session-hook matrix drives the pure
  * `regenerateManagedSessionHooks(cwd, force)` seam directly.
  */
-import { execSync } from 'node:child_process';
+import { execFileSync, execSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
@@ -40,6 +40,7 @@ import {
   hooksCommand,
   installHooksNonInteractive,
   regenerateManagedSessionHooks,
+  resolveHooksDir,
   TOTEM_PREPUSH_END,
   TOTEM_PREPUSH_MARKER,
 } from './install-hooks.js';
@@ -428,5 +429,140 @@ describe('installHooksNonInteractive (contract sanity)', () => {
 
   it('returns null outside a git repo (declared skip, exit 0 at the command edge)', () => {
     expect(installHooksNonInteractive(tmpDir)).toBeNull();
+  });
+});
+
+// ─── Worktree + gitdir-pointer resolution (mmnto-ai/totem#2418) ──────
+//
+// In a linked worktree `.git` is a FILE (`gitdir: <path>` pointer), so the
+// pre-fix blind `mkdir '.git/hooks'` crashed ENOTDIR and failed the consumer's
+// whole `pnpm install` through the prepare wrapper. The contract names the
+// worktree/submodule pointer cases: resolvable → install into the SHARED hooks
+// dir (what git actually executes); unparseable → declared skip, exit 0.
+
+describe('hooksCommand in a linked worktree (mmnto-ai/totem#2418)', () => {
+  let mainDir: string;
+  let wtParent: string;
+  let wtDir: string;
+  let originalCwd: string;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  const sharedHooksDir = () => path.join(mainDir, '.git', 'hooks');
+  const errorOutput = (): string =>
+    errorSpy.mock.calls
+      .map((c: unknown[]) => c.map((a: unknown) => String(a)).join(' '))
+      .join('\n');
+
+  beforeEach(() => {
+    mainDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-2418-main-'));
+    execSync('git init', { cwd: mainDir, stdio: 'ignore' });
+    // `git worktree add` needs a commit to branch from.
+    execSync(
+      'git -c user.name=totem -c user.email=totem@test.invalid commit --allow-empty -m init',
+      { cwd: mainDir, stdio: 'ignore' },
+    );
+    wtParent = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-2418-wt-'));
+    wtDir = path.join(wtParent, 'wt');
+    // Arg-array spawn — no shell, so the tmp path is never shell-interpreted.
+    execFileSync('git', ['worktree', 'add', wtDir], { cwd: mainDir, stdio: 'ignore' });
+
+    originalCwd = process.cwd();
+    process.chdir(wtDir);
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? 0}`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    vi.restoreAllMocks();
+    cleanTmpDir(wtParent);
+    cleanTmpDir(mainDir);
+  });
+
+  it('resolveHooksDir follows the gitdir pointer to the SHARED hooks dir', () => {
+    // The worktree's `.git` is a pointer FILE, not a directory.
+    expect(fs.statSync(path.join(wtDir, '.git')).isFile()).toBe(true);
+    const resolved = resolveHooksDir(wtDir);
+    expect(resolved).not.toBeNull();
+    // realpath both sides: tmpdir segments can differ by symlink/8.3 aliasing.
+    expect(fs.realpathSync(resolved!)).toBe(fs.realpathSync(sharedHooksDir()));
+  });
+
+  it('resolveHooksDir in a plain checkout stays .git/hooks', () => {
+    const resolved = resolveHooksDir(mainDir);
+    expect(resolved).not.toBeNull();
+    expect(fs.realpathSync(resolved!)).toBe(fs.realpathSync(sharedHooksDir()));
+  });
+
+  it('exit 0: install from the worktree lands in the shared hooks dir (no ENOTDIR)', async () => {
+    await expect(hooksCommand({})).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+    for (const hook of ['pre-commit', 'pre-push', 'post-merge', 'post-checkout']) {
+      expect(
+        fs.existsSync(path.join(sharedHooksDir(), hook)),
+        `${hook} missing from the shared hooks dir`,
+      ).toBe(true);
+    }
+    // The pointer file survives untouched — nothing tried to mkdir through it.
+    expect(fs.statSync(path.join(wtDir, '.git')).isFile()).toBe(true);
+  });
+
+  it('--check from the worktree sees the shared hooks (exit 0)', async () => {
+    await hooksCommand({});
+    errorSpy.mockClear();
+    await expect(hooksCommand({ check: true })).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(errorOutput()).toContain('All hooks installed');
+  });
+
+  it('installHooksNonInteractive from the worktree classifies all four hooks', () => {
+    const result = installHooksNonInteractive(wtDir);
+    expect(result).not.toBeNull();
+    expect(result!.preCommit).toBe('installed');
+    expect(result!.prePush).toBe('installed');
+    expect(result!.postMerge).toBe('installed');
+    expect(result!.postCheckout).toBe('installed');
+  });
+});
+
+describe('hooksCommand with an unparseable .git pointer file (declared skip)', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-2418-badptr-'));
+    // A `.git` FILE whose content is not a `gitdir:` pointer — git reports
+    // `fatal: invalid gitfile format` for it.
+    fs.writeFileSync(path.join(tmpDir, '.git'), 'not a gitdir pointer\n');
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`process.exit:${code ?? 0}`);
+    }) as never);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    vi.restoreAllMocks();
+    cleanTmpDir(tmpDir);
+  });
+
+  it('exit 0: install declares the skip instead of crashing prepare', async () => {
+    await expect(hooksCommand({})).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+    const out = errorSpy.mock.calls
+      .map((c: unknown[]) => c.map((a: unknown) => String(a)).join(' '))
+      .join('\n');
+    expect(out).toContain('not a directory or a resolvable gitdir pointer');
+  });
+
+  it('resolveHooksDir returns null for the unparseable pointer (never a blind join)', () => {
+    expect(resolveHooksDir(tmpDir)).toBeNull();
   });
 });

--- a/packages/cli/src/commands/install-hooks-exit-contract.test.ts
+++ b/packages/cli/src/commands/install-hooks-exit-contract.test.ts
@@ -301,6 +301,30 @@ describe('hooksCommand exit-code contract', () => {
     expect(exitSpy).not.toHaveBeenCalled();
   });
 
+  it('file-valued core.hooksPath: declares the git-hook skip, session hooks STILL repaired (exit 0)', async () => {
+    // CR #2422 round 2 falsifier: an unresolvable hooks dir (core.hooksPath at a
+    // non-directory — the hooks-disabled idiom) skips GIT hook installation with
+    // the truthful scoped line, while the managed session hooks — vendor
+    // artifacts independent of git-hook state (PR-A slice 3 / lc#806) — are
+    // still drift-repaired. Continuing past the git-hook skip is the contract,
+    // not a leak.
+    const notADir = path.join(tmpDir, 'hooks-disabled.txt');
+    fs.writeFileSync(notADir, 'not a directory\n');
+    execFileSync('git', ['config', 'core.hooksPath', notADir], { cwd: tmpDir });
+    const ssPath = path.join(tmpDir, '.claude', 'hooks', 'SessionStart.cjs');
+    fs.mkdirSync(path.dirname(ssPath), { recursive: true });
+    fs.writeFileSync(ssPath, `${TOTEM_FILE_MARKER}\nstale\n${TOTEM_FILE_END}\n`);
+    errorSpy.mockClear();
+
+    await expect(hooksCommand({})).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(errorOutput()).toContain('skipping git hook installation');
+    // The non-directory target never receives a write.
+    expect(fs.readFileSync(notADir, 'utf-8')).toBe('not a directory\n');
+    // The bounded session hook is still repaired after the git-hook skip.
+    expect(fs.readFileSync(ssPath, 'utf-8')).toBe(CLAUDE_SESSION_START);
+  });
+
   it('hook-manager repo STILL drift-repairs an existing bounded session hook (lc#806 guard)', async () => {
     // A git-hook manager (husky) means git hooks are the manager's job — a declared
     // skip for the git side. But the session hooks are Claude/Gemini artifacts,

--- a/packages/cli/src/commands/install-hooks-exit-contract.test.ts
+++ b/packages/cli/src/commands/install-hooks-exit-contract.test.ts
@@ -38,6 +38,7 @@ import {
 } from './init-templates.js';
 import {
   hooksCommand,
+  installHooksCommand,
   installHooksNonInteractive,
   regenerateManagedSessionHooks,
   resolveHooksDir,
@@ -565,6 +566,45 @@ describe('hooksCommand with an unparseable .git pointer file (declared skip)', (
   });
 
   it('resolveHooksDir returns null for the unparseable pointer (never a blind join)', () => {
+    expect(resolveHooksDir(tmpDir)).toBeNull();
+  });
+
+  it('legacy installHooksCommand declares the skip too — exit 0, never handleError (#2422 round)', async () => {
+    // The hidden `totem install-hooks` command routes here; pre-fix its callees
+    // let the resolveGitRoot throw reach handleError → exit 1, violating the
+    // #2410 declared-skip contract on that entry point.
+    await expect(installHooksCommand()).resolves.toBeUndefined();
+    expect(exitSpy).not.toHaveBeenCalled();
+    const out = errorSpy.mock.calls
+      .map((c: unknown[]) => c.map((a: unknown) => String(a)).join(' '))
+      .join('\n');
+    expect(out).toContain('not a directory or a resolvable gitdir pointer');
+  });
+
+  it('installHooksNonInteractive maps the bad pointer to the declared-skip null (direct API path)', () => {
+    expect(installHooksNonInteractive(tmpDir)).toBeNull();
+  });
+});
+
+describe('resolveHooksDir with core.hooksPath aimed at a non-directory (#2422 round)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-2418-hookspath-'));
+    execSync('git init', { cwd: tmpDir, stdio: 'ignore' });
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  it('returns null instead of a write-target that can never receive hooks', () => {
+    // The /dev/null hooks-disabled idiom, portably: point core.hooksPath at an
+    // existing FILE. `git rev-parse --git-path hooks` returns it verbatim; the
+    // resolver must classify it as the declared skip, not hand it to mkdir.
+    const notADir = path.join(tmpDir, 'hooks-disabled.txt');
+    fs.writeFileSync(notADir, 'not a directory\n');
+    execFileSync('git', ['config', 'core.hooksPath', notADir], { cwd: tmpDir });
     expect(resolveHooksDir(tmpDir)).toBeNull();
   });
 });

--- a/packages/cli/src/commands/install-hooks.ts
+++ b/packages/cli/src/commands/install-hooks.ts
@@ -3,6 +3,8 @@ import * as path from 'node:path';
 import { stdin as input, stdout as output } from 'node:process';
 import * as readline from 'node:readline/promises';
 
+import { safeExec } from '@mmnto/totem';
+
 import { resolveGitRoot } from '../git.js';
 
 export const TOTEM_HOOK_MARKER = '[totem] post-merge hook';
@@ -15,6 +17,61 @@ export const TOTEM_PREPUSH_MARKER = '[totem] pre-push hook';
 export const TOTEM_PREPUSH_END = '[totem] end pre-push';
 
 type HookManager = 'husky' | 'lefthook' | 'simple-git-hooks';
+
+// ─── Hooks-directory resolution (mmnto-ai/totem#2418) ─────────
+
+/**
+ * Resolve the git hooks directory for `gitRoot`. In a plain checkout this is
+ * `.git/hooks`, but in a linked worktree (or submodule) `.git` is a FILE
+ * (`gitdir: <path>` pointer) and hooks live under the resolved git dir — shared
+ * across worktrees via `commondir` — so a blind `.git/hooks` join makes
+ * `mkdirSync` crash with ENOTDIR (mmnto-ai/totem#2418; the owner-repo
+ * `tools/install-hooks.js` variant already discriminates). Resolution is
+ * delegated to `git rev-parse --git-path hooks` — git's own worktree/commondir
+ * walk, which also honors `core.hooksPath` — with a filesystem probe as the
+ * offline fallback for the plain-directory layout. Returns null when no hooks
+ * directory can be resolved: the #2410 declared-skip class — callers skip
+ * loudly instead of guessing a path.
+ */
+export function resolveHooksDir(gitRoot: string): string | null {
+  try {
+    const resolved = safeExec('git', ['rev-parse', '--git-path', 'hooks'], { cwd: gitRoot });
+    // git prints forward slashes even on Windows, and a repo-relative path in
+    // the common case — normalize and anchor at the git root.
+    if (resolved) return path.resolve(gitRoot, path.normalize(resolved));
+  } catch {
+    // git unavailable or the invocation failed — fall through to the probe.
+  }
+  const gitPath = path.join(gitRoot, '.git');
+  if (fs.existsSync(gitPath) && fs.statSync(gitPath).isDirectory()) {
+    return path.join(gitPath, 'hooks');
+  }
+  // `.git` is a pointer file git could not resolve for us — never guess.
+  return null;
+}
+
+/** Skip line shared by every caller that hits an unresolvable hooks directory. */
+const HOOKS_DIR_UNRESOLVED_MSG =
+  '[Totem] .git is not a directory or a resolvable gitdir pointer — skipping git hook installation.';
+
+/**
+ * Whether `err` (typically the TotemGitError thrown by `resolveGitRoot`) stems
+ * from a malformed `.git` pointer FILE — git's `fatal: invalid gitfile format`.
+ * This is the "unparseable gitdir pointer (worktree/submodule)" member of the
+ * #2410 declared-skip class: `totem hook install` must exit 0 on it, not
+ * propagate a crash into the consumer's `prepare` lifecycle
+ * (mmnto-ai/totem#2418). Walks the cause chain the same bounded way core's
+ * not-a-git-repo matcher does.
+ */
+function isUnparseableGitFileError(err: unknown): boolean {
+  let cursor: unknown = err;
+  for (let depth = 0; depth < 5 && cursor !== undefined && cursor !== null; depth++) {
+    const text = cursor instanceof Error ? cursor.message : String(cursor);
+    if (/invalid gitfile format/i.test(text)) return true;
+    cursor = cursor instanceof Error ? cursor.cause : undefined;
+  }
+  return false;
+}
 
 /**
  * Determine the package-manager fallback command for invoking totem.
@@ -250,7 +307,11 @@ export async function installPostMergeHook(
     return;
   }
 
-  const hooksDir = path.join(gitRoot, '.git', 'hooks');
+  const hooksDir = resolveHooksDir(gitRoot);
+  if (!hooksDir) {
+    console.log(HOOKS_DIR_UNRESOLVED_MSG);
+    return;
+  }
   const hookPath = path.join(hooksDir, 'post-merge');
 
   // Idempotency: check if already installed
@@ -614,8 +675,12 @@ export async function installEnforcementHooks(
     return skip;
   }
 
+  const hooksDir = resolveHooksDir(gitRoot);
+  if (!hooksDir) {
+    console.log(HOOKS_DIR_UNRESOLVED_MSG);
+    return skip;
+  }
   const fallbackCmd = getFallbackCommand(gitRoot);
-  const hooksDir = path.join(gitRoot, '.git', 'hooks');
 
   const preCommit = installGitHook(
     hooksDir,
@@ -660,8 +725,8 @@ export async function installHooksCommand(): Promise<void> {
 
     // Silently install post-checkout alongside post-merge (same guard — only if post-merge was accepted)
     const gitRoot = resolveGitRoot(cwd);
-    if (gitRoot && !detectHookManager(gitRoot)) {
-      const hooksDir = path.join(gitRoot, '.git', 'hooks');
+    const hooksDir = gitRoot ? resolveHooksDir(gitRoot) : null;
+    if (gitRoot && hooksDir && !detectHookManager(gitRoot)) {
       const postMerge = path.join(hooksDir, 'post-merge');
       const hasPostMerge =
         fs.existsSync(postMerge) && fs.readFileSync(postMerge, 'utf-8').includes(TOTEM_HOOK_MARKER);
@@ -716,7 +781,14 @@ export function installHooksNonInteractive(
     return null;
   }
 
-  const hooksDir = path.join(gitRoot, '.git', 'hooks');
+  const hooksDir = resolveHooksDir(gitRoot);
+  if (!hooksDir) {
+    // Unresolvable hooks dir (worktree/submodule pointer git could not follow) —
+    // the #2410 declared-skip class: report and exit 0, never mkdir '.git/hooks'
+    // blind (the mmnto-ai/totem#2418 ENOTDIR crash).
+    console.error(HOOKS_DIR_UNRESOLVED_MSG);
+    return null;
+  }
 
   const preCommit = installGitHook(
     hooksDir,
@@ -767,7 +839,11 @@ export function checkHooksInstalled(cwd: string): boolean {
   if (!gitRoot) {
     return false;
   }
-  const hooksDir = path.join(gitRoot, '.git', 'hooks');
+  const hooksDir = resolveHooksDir(gitRoot);
+  if (!hooksDir) {
+    console.error('[Totem] Git hooks directory could not be resolved — cannot check hooks.');
+    return false;
+  }
 
   const markers = [
     { file: 'pre-commit', marker: TOTEM_PRECOMMIT_MARKER },
@@ -806,7 +882,21 @@ export async function hooksCommand(opts: {
   const cwd = process.cwd();
 
   // Resolve git root once — guards both --check and install paths
-  const gitRoot = resolveGitRoot(cwd);
+  let gitRoot: string | null;
+  try {
+    gitRoot = resolveGitRoot(cwd);
+  } catch (err) {
+    // A malformed `.git` pointer FILE is the "unparseable gitdir pointer
+    // (worktree/submodule)" member of the #2410 declared-skip class: exit 0
+    // with a truthful skip line instead of crashing the consumer's `prepare`
+    // lifecycle (mmnto-ai/totem#2418). Every other resolution failure stays
+    // fail-loud.
+    if (isUnparseableGitFileError(err)) {
+      console.error(HOOKS_DIR_UNRESOLVED_MSG);
+      return;
+    }
+    throw err;
+  }
   if (!gitRoot) {
     console.error('[Totem] Not a git repository — skipping hook installation.');
     return;
@@ -1043,7 +1133,10 @@ export function upgradePrePushHookIfNeeded(cwd: string): boolean {
     const gitRoot = resolveGitRoot(cwd);
     if (!gitRoot) return false;
 
-    const hookPath = path.join(gitRoot, '.git', 'hooks', 'pre-push');
+    const hooksDir = resolveHooksDir(gitRoot);
+    if (!hooksDir) return false;
+
+    const hookPath = path.join(hooksDir, 'pre-push');
     if (!fs.existsSync(hookPath)) return false;
 
     const content = fs.readFileSync(hookPath, 'utf-8');

--- a/packages/cli/src/commands/install-hooks.ts
+++ b/packages/cli/src/commands/install-hooks.ts
@@ -1,9 +1,8 @@
+import { spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import { stdin as input, stdout as output } from 'node:process';
 import * as readline from 'node:readline/promises';
-
-import { safeExec } from '@mmnto/totem';
 
 import { resolveGitRoot } from '../git.js';
 
@@ -34,13 +33,17 @@ type HookManager = 'husky' | 'lefthook' | 'simple-git-hooks';
  * loudly instead of guessing a path.
  */
 export function resolveHooksDir(gitRoot: string): string | null {
-  try {
-    const resolved = safeExec('git', ['rev-parse', '--git-path', 'hooks'], { cwd: gitRoot });
+  // Raw spawnSync (the doctor.ts idiom): a builtin, so the heavy core barrel
+  // stays off the CLI cold-start graph, and a failed invocation reports via
+  // `status`/`error` instead of throwing — the probe below is the fallback.
+  const resolved = spawnSync('git', ['rev-parse', '--git-path', 'hooks'], {
+    cwd: gitRoot,
+    encoding: 'utf-8',
+  });
+  if (resolved.status === 0 && resolved.stdout && resolved.stdout.trim()) {
     // git prints forward slashes even on Windows, and a repo-relative path in
     // the common case — normalize and anchor at the git root.
-    if (resolved) return path.resolve(gitRoot, path.normalize(resolved));
-  } catch {
-    // git unavailable or the invocation failed — fall through to the probe.
+    return path.resolve(gitRoot, path.normalize(resolved.stdout.trim()));
   }
   const gitPath = path.join(gitRoot, '.git');
   if (fs.existsSync(gitPath) && fs.statSync(gitPath).isDirectory()) {

--- a/packages/cli/src/commands/install-hooks.ts
+++ b/packages/cli/src/commands/install-hooks.ts
@@ -43,7 +43,15 @@ export function resolveHooksDir(gitRoot: string): string | null {
   if (resolved.status === 0 && resolved.stdout && resolved.stdout.trim()) {
     // git prints forward slashes even on Windows, and a repo-relative path in
     // the common case — normalize and anchor at the git root.
-    return path.resolve(gitRoot, path.normalize(resolved.stdout.trim()));
+    const hooksDir = path.resolve(gitRoot, path.normalize(resolved.stdout.trim()));
+    // `core.hooksPath` can aim hooks at a non-directory (the /dev/null
+    // hooks-disabled idiom) — an existing non-directory can never receive hook
+    // files, so it joins the declared-skip class instead of crashing the write
+    // (#2422 review round).
+    if (fs.existsSync(hooksDir) && !fs.statSync(hooksDir).isDirectory()) {
+      return null;
+    }
+    return hooksDir;
   }
   const gitPath = path.join(gitRoot, '.git');
   if (fs.existsSync(gitPath) && fs.statSync(gitPath).isDirectory()) {
@@ -74,6 +82,26 @@ function isUnparseableGitFileError(err: unknown): boolean {
     cursor = cursor instanceof Error ? cursor.cause : undefined;
   }
   return false;
+}
+
+/**
+ * `resolveGitRoot` for hook-install paths: maps the malformed `.git` pointer
+ * FILE to `{ gitRoot: null, unparseablePointer: true }` instead of letting the
+ * throw reach `handleError` → exit 1 — EVERY hook-install entry point owes the
+ * #2410 declared skip on it, including the hidden legacy `totem install-hooks`
+ * command and the direct `installHooksNonInteractive` API (#2422 review round:
+ * only `hooksCommand` was guarded). All other failures stay fail-loud.
+ */
+function resolveGitRootForHookPath(cwd: string): {
+  gitRoot: string | null;
+  unparseablePointer: boolean;
+} {
+  try {
+    return { gitRoot: resolveGitRoot(cwd), unparseablePointer: false };
+  } catch (err) {
+    if (isUnparseableGitFileError(err)) return { gitRoot: null, unparseablePointer: true };
+    throw err;
+  }
 }
 
 /**
@@ -286,10 +314,16 @@ export async function installPostMergeHook(
   rl: readline.Interface,
   options?: { tier?: 'strict' | 'standard' },
 ): Promise<void> {
-  // Guard: must be a git repo — resolve root from any subdirectory
-  const gitRoot = resolveGitRoot(cwd);
+  // Guard: must be a git repo — resolve root from any subdirectory. A malformed
+  // `.git` pointer file is the same declared-skip class, not a crash (#2422 round:
+  // the legacy `totem install-hooks` path previously let it reach handleError).
+  const { gitRoot, unparseablePointer } = resolveGitRootForHookPath(cwd);
   if (!gitRoot) {
-    console.log('[Totem] Not a git repository — skipping hook installation.');
+    console.error(
+      unparseablePointer
+        ? HOOKS_DIR_UNRESOLVED_MSG
+        : '[Totem] Not a git repository — skipping hook installation.',
+    );
     return;
   }
 
@@ -312,7 +346,8 @@ export async function installPostMergeHook(
 
   const hooksDir = resolveHooksDir(gitRoot);
   if (!hooksDir) {
-    console.log(HOOKS_DIR_UNRESOLVED_MSG);
+    // stderr like every other skip/diagnostic line (#2422 round: stream parity).
+    console.error(HOOKS_DIR_UNRESOLVED_MSG);
     return;
   }
   const hookPath = path.join(hooksDir, 'post-merge');
@@ -656,8 +691,10 @@ export async function installEnforcementHooks(
 ): Promise<EnforcementHookResult> {
   const skip: EnforcementHookResult = { preCommit: 'skipped', prePush: 'skipped' };
 
-  // Guard: must be a git repo — resolve root from any subdirectory
-  const gitRoot = resolveGitRoot(cwd);
+  // Guard: must be a git repo — resolve root from any subdirectory. Both skip
+  // classes stay silent here: installPostMergeHook always runs next in the two
+  // callers (init + the legacy install-hooks command) and prints the one line.
+  const { gitRoot } = resolveGitRootForHookPath(cwd);
   if (!gitRoot) {
     return skip;
   }
@@ -680,7 +717,8 @@ export async function installEnforcementHooks(
 
   const hooksDir = resolveHooksDir(gitRoot);
   if (!hooksDir) {
-    console.log(HOOKS_DIR_UNRESOLVED_MSG);
+    // stderr like every other skip/diagnostic line (#2422 round: stream parity).
+    console.error(HOOKS_DIR_UNRESOLVED_MSG);
     return skip;
   }
   const fallbackCmd = getFallbackCommand(gitRoot);
@@ -726,8 +764,10 @@ export async function installHooksCommand(): Promise<void> {
     await installEnforcementHooks(cwd, rl);
     await installPostMergeHook(cwd, rl);
 
-    // Silently install post-checkout alongside post-merge (same guard — only if post-merge was accepted)
-    const gitRoot = resolveGitRoot(cwd);
+    // Silently install post-checkout alongside post-merge (same guard — only if
+    // post-merge was accepted). Bad-pointer skip stays silent: installPostMergeHook
+    // above already printed the line.
+    const { gitRoot } = resolveGitRootForHookPath(cwd);
     const hooksDir = gitRoot ? resolveHooksDir(gitRoot) : null;
     if (gitRoot && hooksDir && !detectHookManager(gitRoot)) {
       const postMerge = path.join(hooksDir, 'post-merge');
@@ -768,9 +808,13 @@ export function installHooksNonInteractive(
   force?: boolean,
   options?: { tier?: 'strict' | 'standard' },
 ): HooksCommandResult | null {
-  // Guard: must be a git repo — resolve root from any subdirectory
-  const gitRoot = resolveGitRoot(cwd);
+  // Guard: must be a git repo — resolve root from any subdirectory. Not-a-repo
+  // stays a silent null (the documented contract — callers print); the malformed
+  // pointer prints its declared-skip line here so a direct API caller honors the
+  // #2410 contract without hooksCommand's pre-guard (#2422 round).
+  const { gitRoot, unparseablePointer } = resolveGitRootForHookPath(cwd);
   if (!gitRoot) {
+    if (unparseablePointer) console.error(HOOKS_DIR_UNRESOLVED_MSG);
     return null;
   }
 
@@ -838,7 +882,10 @@ export function installHooksNonInteractive(
  * Check that all Totem hooks are installed. Returns true if all present.
  */
 export function checkHooksInstalled(cwd: string): boolean {
-  const gitRoot = resolveGitRoot(cwd);
+  // Malformed pointer → false like not-a-repo: a verify that cannot locate the
+  // hooks has nothing to certify (hooksCommand's pre-guard already declared the
+  // skip on the CLI --check path).
+  const { gitRoot } = resolveGitRootForHookPath(cwd);
   if (!gitRoot) {
     return false;
   }
@@ -884,24 +931,17 @@ export async function hooksCommand(opts: {
 }): Promise<void> {
   const cwd = process.cwd();
 
-  // Resolve git root once — guards both --check and install paths
-  let gitRoot: string | null;
-  try {
-    gitRoot = resolveGitRoot(cwd);
-  } catch (err) {
-    // A malformed `.git` pointer FILE is the "unparseable gitdir pointer
-    // (worktree/submodule)" member of the #2410 declared-skip class: exit 0
-    // with a truthful skip line instead of crashing the consumer's `prepare`
-    // lifecycle (mmnto-ai/totem#2418). Every other resolution failure stays
-    // fail-loud.
-    if (isUnparseableGitFileError(err)) {
-      console.error(HOOKS_DIR_UNRESOLVED_MSG);
-      return;
-    }
-    throw err;
-  }
+  // Resolve git root once — guards both --check and install paths. A malformed
+  // `.git` pointer FILE is the "unparseable gitdir pointer (worktree/submodule)"
+  // member of the #2410 declared-skip class: exit 0 with a truthful skip line
+  // instead of crashing the consumer's `prepare` lifecycle (mmnto-ai/totem#2418).
+  const { gitRoot, unparseablePointer } = resolveGitRootForHookPath(cwd);
   if (!gitRoot) {
-    console.error('[Totem] Not a git repository — skipping hook installation.');
+    console.error(
+      unparseablePointer
+        ? HOOKS_DIR_UNRESOLVED_MSG
+        : '[Totem] Not a git repository — skipping hook installation.',
+    );
     return;
   }
 

--- a/packages/pack-agent-security/test/repo-sweep.test.ts
+++ b/packages/pack-agent-security/test/repo-sweep.test.ts
@@ -237,6 +237,13 @@ const ALLOWLIST: AllowEntry[] = [
   },
   {
     hash: 'c2c09301bb56a02b',
+    file: 'packages/cli/src/commands/install-hooks.ts',
+    expectedCount: 1,
+    reason:
+      'resolveHooksDir invokes `spawnSync` for one git plumbing call (`rev-parse --git-path hooks`) to locate the worktree-aware hooks directory (mmnto-ai/totem#2418). Literal target, fixed args, cwd anchored at the resolved git root; raw spawnSync (the doctor.ts idiom) because a static safeExec import would pull the core barrel into CLI cold-start.',
+  },
+  {
+    hash: 'c2c09301bb56a02b',
     file: 'packages/cli/src/commands/add-lesson.ts',
     expectedCount: 1,
     reason:


### PR DESCRIPTION
Closes #2418

## Root cause

Every hooks-path site in `install-hooks.ts` computed `path.join(gitRoot, '.git', 'hooks')` and `installGitHook` ran `mkdirSync` on it. In a linked worktree `.git` is a `gitdir:` pointer FILE, so the mkdir crashes ENOTDIR and — through `.totem/prepare.cjs` → `totem hook install` → verbatim exit propagation — fails the consumer's entire `pnpm install`. The worktree case is named in the #2410 declared-skip contract; the shipped path missed it (the owner-repo `tools/install-hooks.js` variant already discriminated, per the issue's sharpening datum).

## Fix

- **`resolveHooksDir(gitRoot)`** (exported, `install-hooks.ts`): delegates to `git rev-parse --git-path hooks` — git's own worktree/`commondir` walk, which also honors `core.hooksPath` — via raw `spawnSync` (the doctor.ts idiom; keeps the core barrel off CLI cold-start). Filesystem probe as offline fallback for the plain `.git`-directory layout; **null** (never a blind join) when `.git` is a pointer file git could not resolve.
- Wired through all six sites: non-interactive install (the #2418 crash site), interactive post-merge/enforcement installs, the silent post-checkout install, `--check`, and the silent pre-push upgrade. In a worktree, hooks now land in the **shared** hooks dir — the location git actually executes — and `--check` reads the same place instead of wrongly reporting them missing.
- **Unparseable `.git` pointer file** (git's `fatal: invalid gitfile format`): now the declared skip the #2410 exit-code contract names — `hooksCommand` catches exactly that error class, prints a truthful skip line, exits 0. All other resolution failures stay fail-loud.
- **Doctor `git-hooks` parity row** (`doctor-parity.ts`): reads the resolved hooks dir, so a worktree checkout no longer reports all four hooks as absent drift (read-only `.git/hooks` join retained as last-resort fallback, pre-existing behavior).

## Verification

- 7 new cases in `install-hooks-exit-contract.test.ts` (real `git worktree add` + malformed-pointer fixtures): pointer resolution to the shared dir, install-from-worktree exit 0 with all four hooks landing shared-side, `--check` exit 0 from the worktree, `installHooksNonInteractive` classification, declared-skip exit 0 + message on the unparseable pointer. File total 33/33 green; full CLI suite 144 files / 3313 tests green.
- End-to-end with the built CLI: `hook install` from a real linked worktree → exit 0, hooks in `main/.git/hooks`, pointer file untouched; `--check` → exit 0; garbage `.git` file → declared-skip line, exit 0.

## Scope notes

- The `.totem/prepare.cjs` wrapper template is untouched — it spawns `hook install` and propagates the exit verbatim, so the fix rides the CLI. Consumers pick it up at the next cut; no reflex bump.
- Known-remaining same-class gap, deliberately out of scope: `eject.ts` scrubs `.git/hooks/<name>` blind, so ejecting from a worktree reports hooks "not found" (silent no-op; also debatable whether a worktree eject should touch shared hooks at all). Flagging rather than folding it in — can file a follow-up on ruling.
- Changeset: patch `@mmnto/cli`.

Found by strategy-claude during the strategy#894 propagation pass (repro: totem-strategy worktree, 1.101.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
