### PR TITLE
fix(mail): broadcast processed-marks are per-seat — stop the flat-union first-consumer-wins subtraction

### DIFF
--- a/.changeset/mail-broadcast-per-seat-marks.md
+++ b/.changeset/mail-broadcast-per-seat-marks.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/cli': patch
+---
+
+`totem mail` no longer hides a live broadcast from a multi-seat poll after a single seat consumes it (mmnto-ai/totem#2412, first-consumer-wins). The unread filter previously drained every resolved seat's `processed/` marks into one flat basename union — so under multi-seat self-resolution (unscoped polls, `config.json` host_agents), one seat's broadcast mark subtracted the broadcast for every other seat, silently. Broadcasts are per-seat consumable by design (ecl-gc keeps per-seat `_broadcast` stores): a broadcast-named dispatch now subtracts only when EVERY resolved seat holds the mark, so a multi-seat poll truthfully asserts "unread for at least one of my seats". Directed mail keeps the any-seat union, and single-seat (`TOTEM_SELF_AGENT`-scoped) polls are bit-identical to before. A `to: broadcast` dispatch without the positional `broadcast` filename token stays on the union rule (subtraction runs pre-parse; the ecl filename discipline makes the token standard).

--- a/packages/cli/src/commands/mail.test.ts
+++ b/packages/cli/src/commands/mail.test.ts
@@ -462,6 +462,17 @@ describe('pollMail — broadcast marks are per-seat, not union (mmnto-ai/totem#2
     expect(poll({ env: { TOTEM_SELF_AGENT: 'totem-claude' } }).mail).toEqual([]);
   });
 
+  it('duplicate seat ids are normalized — the requirement counts DISTINCT seats (GCA #2424)', () => {
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: BROADCAST_FILE, to: 'broadcast', subject: 'consumers move' },
+    ]);
+    writeProcessed('totem', 'totem-claude', [BROADCAST_FILE]);
+    writeProcessed('totem', 'totem-gemini', [BROADCAST_FILE]);
+    // Both distinct seats hold marks; the duplicated id must not raise the bar to 3.
+    const dupes = { TOTEM_SELF_AGENT: 'totem-claude,totem-claude,totem-gemini' };
+    expect(poll({ env: dupes }).mail).toEqual([]);
+  });
+
   it('legacy broadcast WITHOUT the filename token stays on the union rule (disclosed residual)', () => {
     // Subtraction runs pre-parse, so the broadcast rule keys on the positional
     // filename token; a tokenless `to: broadcast` dispatch keeps the historical

--- a/packages/cli/src/commands/mail.test.ts
+++ b/packages/cli/src/commands/mail.test.ts
@@ -413,6 +413,77 @@ describe('pollMail — processed/ exclusion', () => {
   });
 });
 
+// ─── Broadcast processed-mark union subtraction ─────────
+// mmnto-ai/totem#2412 (first-consumer-wins): under multi-seat self-resolution
+// the flat union let ONE seat's broadcast mark hide the broadcast from every
+// other seat in the poll. Broadcasts are per-seat consumable (ecl-gc keeps
+// per-seat `_broadcast` stores), so a broadcast-named file subtracts only when
+// EVERY resolved seat holds the mark; directed mail keeps the any-seat union.
+
+describe('pollMail — broadcast marks are per-seat, not union (mmnto-ai/totem#2412)', () => {
+  const BROADCAST_FILE = '2026-07-16T2213Z-broadcast-seat-attribution.md';
+  const TWO_SEATS = { TOTEM_SELF_AGENT: 'totem-claude,totem-gemini' };
+
+  it("one seat's mark does NOT hide the broadcast from a multi-seat poll (the live repro)", () => {
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: BROADCAST_FILE, to: 'broadcast', subject: 'consumers move' },
+    ]);
+    // Mark in processed/ ROOT (not _broadcast/) — the exact live-specimen shape.
+    writeProcessed('totem', 'totem-gemini', [BROADCAST_FILE]);
+    const result = poll({ env: TWO_SEATS });
+    expect(result.mail).toHaveLength(1);
+    expect(result.mail[0]!.file).toBe(BROADCAST_FILE);
+  });
+
+  it('subtracts the broadcast once EVERY resolved seat holds a mark (either location)', () => {
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: BROADCAST_FILE, to: 'broadcast', subject: 'consumers move' },
+    ]);
+    // Mixed locations both count: one seat marks in processed/ root, the other
+    // in processed/_broadcast/.
+    writeProcessed('totem', 'totem-gemini', [BROADCAST_FILE]);
+    writeBroadcastProcessed('totem', 'totem-claude', [BROADCAST_FILE]);
+    expect(poll({ env: TWO_SEATS }).mail).toEqual([]);
+  });
+
+  it('directed mail keeps the any-seat union subtraction (unchanged)', () => {
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: '2026-07-16T2214Z-totem-gemini-directed-item.md', to: 'totem-gemini' },
+    ]);
+    writeProcessed('totem', 'totem-gemini', ['2026-07-16T2214Z-totem-gemini-directed-item.md']);
+    expect(poll({ env: TWO_SEATS }).mail).toEqual([]);
+  });
+
+  it('single-seat poll is bit-identical to the pre-fix behavior (own mark subtracts)', () => {
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: BROADCAST_FILE, to: 'broadcast', subject: 'consumers move' },
+    ]);
+    writeProcessed('totem', 'totem-claude', [BROADCAST_FILE]);
+    expect(poll({ env: { TOTEM_SELF_AGENT: 'totem-claude' } }).mail).toEqual([]);
+  });
+
+  it('legacy broadcast WITHOUT the filename token stays on the union rule (disclosed residual)', () => {
+    // Subtraction runs pre-parse, so the broadcast rule keys on the positional
+    // filename token; a tokenless `to: broadcast` dispatch keeps the historical
+    // union subtraction — no worse than before the fix.
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: '2026-05-17T0103Z.md', to: 'broadcast', subject: 'legacy name' },
+    ]);
+    writeProcessed('totem', 'totem-gemini', ['2026-05-17T0103Z.md']);
+    expect(poll({ env: TWO_SEATS }).mail).toEqual([]);
+  });
+
+  it('includeProcessed still returns the RAW set — an all-seats-consumed broadcast stays visible to compaction', () => {
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: BROADCAST_FILE, to: 'broadcast', subject: 'consumers move' },
+    ]);
+    writeBroadcastProcessed('totem', 'totem-claude', [BROADCAST_FILE]);
+    writeBroadcastProcessed('totem', 'totem-gemini', [BROADCAST_FILE]);
+    expect(poll({ env: TWO_SEATS }).mail).toEqual([]);
+    expect(poll({ env: TWO_SEATS, includeProcessed: true }).mail).toHaveLength(1);
+  });
+});
+
 // ─── Cross-sender basename-collision sensor ─────────────
 
 describe('pollMail — cross-sender basename-collision sensor (mmnto-ai/totem#2311)', () => {

--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -312,22 +312,33 @@ function readHeaderWindow(filePath: string): HeaderWindowRead {
 }
 
 /**
- * Build the set of basenames that should be skipped because they have
- * already been actioned. Drains `processed/` and `processed/_broadcast/`
- * for each SELF_AGENT in the calling repo.
+ * Per-basename count of RESOLVED SELF seats holding a processed mark (in
+ * `processed/` or `processed/_broadcast/` — both locations count; the live
+ * mmnto-ai/totem#2412 specimen sat in the root). Directed mail subtracts on ANY
+ * seat's mark (the historical flat union). A broadcast is per-seat consumable —
+ * ecl-gc stores and collects `_broadcast` marks per seat — so it subtracts only
+ * when EVERY resolved seat holds the mark: the flat union collapsed exactly
+ * that, letting one seat's consumption hide a live broadcast from every other
+ * seat in a multi-seat poll (first-consumer-wins, mmnto-ai/totem#2412). A
+ * multi-seat poll's unread line then truthfully asserts "unread for at least
+ * one of my seats" — the only claim it can make.
  */
-function buildProcessedSet(
+function buildProcessedMarkCounts(
   repoRoot: string,
   selfAgents: string[],
   warnings: string[],
-): Set<string> {
-  const processed = new Set<string>();
+): Map<string, number> {
+  const counts = new Map<string, number>();
   for (const agent of selfAgents) {
     const agentDir = path.join(repoRoot, '.totem', 'orchestration', agent, 'processed');
-    drainProcessedDir(agentDir, processed, warnings);
-    drainProcessedDir(path.join(agentDir, '_broadcast'), processed, warnings);
+    const seatMarks = new Set<string>();
+    drainProcessedDir(agentDir, seatMarks, warnings);
+    drainProcessedDir(path.join(agentDir, '_broadcast'), seatMarks, warnings);
+    for (const name of seatMarks) {
+      counts.set(name, (counts.get(name) ?? 0) + 1);
+    }
   }
-  return processed;
+  return counts;
 }
 
 function drainProcessedDir(dir: string, into: Set<string>, warnings: string[]): void {
@@ -513,13 +524,14 @@ export function pollMail(opts: MailCommandOptions = {}): MailPollResult {
   }
 
   // `includeProcessed` (ADR-106 § A2.1) yields the RAW addressed-inbound set:
-  // an empty processed set makes the `processedNames.has(file)` filter below a
-  // no-op, so nothing is subtracted. The reader default stays `inbound −
-  // processed`; the compaction path opts in to the pre-dedupe view.
-  const processedNames =
+  // an empty mark-count map makes the subtraction below a no-op, so nothing is
+  // subtracted. The reader default stays `inbound − processed`; the compaction
+  // path opts in to the pre-dedupe view.
+  const processedMarkCounts =
     opts.includeProcessed !== true && selfResolution.agents.length > 0
-      ? buildProcessedSet(repoRoot, selfResolution.agents, warnings)
-      : new Set<string>();
+      ? buildProcessedMarkCounts(repoRoot, selfResolution.agents, warnings)
+      : new Map<string, number>();
+  const selfSeatCount = selfResolution.agents.length;
 
   const slots = enumerateOutboxes(workspace, opts.recursive === true, warnings);
 
@@ -531,6 +543,26 @@ export function pollMail(opts: MailCommandOptions = {}): MailPollResult {
   // (per GCA review on mmnto-ai/totem#1971); without the self-first bucket,
   // other-recipient volume crowds self mail out of the horizon
   // (mmnto-ai/totem#2144).
+  // Compact-stamp prefix shared by the subtraction discriminator below and the
+  // self-priority bucket further down.
+  const stampPrefix = /^\d{4}-\d{2}-\d{2}T\d{4}Z-/;
+
+  // Positional broadcast token — the same zero-I/O filename signal the
+  // self-priority bucket trusts (mmnto-ai/totem#2144): `broadcast` immediately
+  // after the compact stamp. Subtraction runs pre-parse (the scan cap must not
+  // be spent opening consumed files), so this token also selects the
+  // subtraction rule: a broadcast-named file needs EVERY resolved seat's mark
+  // (per-seat consumable, mmnto-ai/totem#2412); anything else keeps the
+  // historical any-seat union. A `to: broadcast` dispatch WITHOUT the filename
+  // token (legacy names) stays on the union rule — no worse than before, and
+  // the ecl filename discipline makes the token standard on new dispatches.
+  const isBroadcastNamed = (file: string): boolean => {
+    const stamp = stampPrefix.exec(file);
+    if (stamp === null) return false;
+    const rest = file.slice(stamp[0].length).toLowerCase();
+    return rest === 'broadcast.md' || rest.startsWith('broadcast-');
+  };
+
   const unread: Array<{ slot: OutboxSlot; file: string }> = [];
   for (const slot of slots) {
     let files: string[];
@@ -542,7 +574,11 @@ export function pollMail(opts: MailCommandOptions = {}): MailPollResult {
       continue;
     }
     for (const file of files) {
-      if (processedNames.has(file)) continue;
+      // `max(seats, 1)` keeps the zero-resolution poll (empty map, seats = 0)
+      // from vacuously treating every broadcast as consumed, and makes a
+      // single-seat poll bit-identical to the pre-#2412 behavior.
+      const required = isBroadcastNamed(file) ? Math.max(selfSeatCount, 1) : 1;
+      if ((processedMarkCounts.get(file) ?? 0) >= required) continue;
       unread.push({ slot, file });
     }
   }
@@ -562,7 +598,6 @@ export function pollMail(opts: MailCommandOptions = {}): MailPollResult {
   // today's scan would (codex F2 — a mislabeled filename carrying `to: self`
   // inside). The token grants priority only; delivery truth stays the parsed
   // `to:` field.
-  const stampPrefix = /^\d{4}-\d{2}-\d{2}T\d{4}Z-/;
   const selfTokens = [...selfLower, 'broadcast'];
   const hasSelfToken = (file: string): boolean => {
     const stamp = stampPrefix.exec(file);

--- a/packages/cli/src/commands/mail.ts
+++ b/packages/cli/src/commands/mail.ts
@@ -527,11 +527,17 @@ export function pollMail(opts: MailCommandOptions = {}): MailPollResult {
   // an empty mark-count map makes the subtraction below a no-op, so nothing is
   // subtracted. The reader default stays `inbound − processed`; the compaction
   // path opts in to the pre-dedupe view.
+  // Normalize duplicate ids once (env/config can carry them): a duplicated seat
+  // would double-drain its marks AND inflate the broadcast requirement in
+  // lockstep — behavior-equivalent today by symmetry, but the equality between
+  // "seats counted" and "seats that can hold marks" is load-bearing for the
+  // per-seat broadcast rule, so it is enforced rather than assumed (GCA #2424).
+  const selfAgents = [...new Set(selfResolution.agents)];
   const processedMarkCounts =
-    opts.includeProcessed !== true && selfResolution.agents.length > 0
-      ? buildProcessedMarkCounts(repoRoot, selfResolution.agents, warnings)
+    opts.includeProcessed !== true && selfAgents.length > 0
+      ? buildProcessedMarkCounts(repoRoot, selfAgents, warnings)
       : new Map<string, number>();
-  const selfSeatCount = selfResolution.agents.length;
+  const selfSeatCount = selfAgents.length;
 
   const slots = enumerateOutboxes(workspace, opts.recursive === true, warnings);
 


### PR DESCRIPTION
Closes #2412

## Root cause (confirmed forensically on the issue)

`buildProcessedSet` drained `processed/` ∪ `processed/_broadcast/` for **every resolved self agent** into one flat basename set, and the unread filter subtracted by bare basename globally. Under multi-seat self-resolution (unscoped polls, `config.json` `host_agents`), one seat's broadcast consumption put its mark in the union and hid the broadcast from every other seat — **first-consumer-wins**. The live specimen: strategy-codex's 2026-07-16T22:48:45Z mark made the 2213Z broadcast invisible to strategy-claude's 4-seat poll while their seat-scoped SessionStart poll correctly listed it.

## Fix (the shape confirmed on-issue)

- `buildProcessedMarkCounts` replaces the flat union with a per-basename **count of distinct seats** holding a mark (either `processed/` root or `_broadcast/` — both count; the live specimen sat in the root).
- **Broadcast-named files** subtract only when the count reaches **every resolved seat** — broadcasts are per-seat consumable by design (ecl-gc keeps per-seat `_broadcast` stores), and a multi-seat poll's unread line then truthfully asserts "unread for at least one of my seats", the only claim it can make.
- **Directed mail** keeps the any-seat union (per-recipient nuances stay in the #2311 basename-collision lane, per the issue).
- **Single-seat polls** (`TOTEM_SELF_AGENT`-scoped, the recommended shape per #2204) are bit-identical: `required = max(seats, 1)` collapses to 1.
- Discriminator is the **positional `broadcast` filename token** — the same zero-I/O signal the self-priority bucket already trusts (#2144). Subtraction runs pre-parse so the scan cap isn't spent opening consumed files. Disclosed residual: a `to: broadcast` dispatch **without** the filename token stays on the union rule — no worse than before, and the ecl filename discipline makes the token standard on new dispatches (locked by a test).

## Verification

- 6 new tests in `mail.test.ts` (file now 119/119): the live-repro shape (one seat's root-mark, multi-seat poll → still unread), all-seats-marked subtraction across mixed mark locations, directed-union unchanged, single-seat bit-identity, the tokenless-legacy residual, and `includeProcessed` still returning the RAW set for compaction (ADR-106 § A2.1).
- **Live specimen flipped end-to-end:** the 2213Z broadcast is still preserved in `totem-claude`'s outbox with 2 of strategy's 4 seats holding marks. The pinned 1.101.0 unscoped strategy poll shows 4 unread (broadcast invisible); the fixed build's identical poll shows 5 unread including the broadcast.
- Full workspace suite green (10/10 tasks).

Changeset: patch `@mmnto/cli`. Durable-fix note: the mass-collection sensor (#2323) and consume-atomicity (#2396) lanes are untouched by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
