### PR TITLE
chore: totem postmerge lessons for 2421 2422

### DIFF
--- a/.totem/lessons/lesson-894dba1b.md
+++ b/.totem/lessons/lesson-894dba1b.md
@@ -1,0 +1,6 @@
+## Lesson — Never assume .git is a directory
+
+**Tags:** git, worktree, cli
+**Scope:** packages/cli/**/*.ts, !**/*.test.*
+
+In linked Git worktrees, `.git` is a pointer file rather than a directory, meaning path joins like `.git/hooks` will fail with `ENOTDIR`. Query `git rev-parse --git-path hooks` to resolve the actual hooks directory dynamically.

--- a/.totem/lessons/lesson-d17a9ca5.md
+++ b/.totem/lessons/lesson-d17a9ca5.md
@@ -1,0 +1,6 @@
+## Lesson — Verify resolved Git paths are directories
+
+**Tags:** git, validation, fs
+**Scope:** packages/cli/**/*.ts, !**/*.test.*
+
+Git configuration values like `core.hooksPath` may resolve to non-directory paths (e.g., `/dev/null`). Always verify that the resolved path is a directory before attempting writes to prevent silent failures or crashes.

--- a/.totem/lessons/lesson-def04bff.md
+++ b/.totem/lessons/lesson-def04bff.md
@@ -1,0 +1,6 @@
+## Lesson — Fail loud on unexpected Git errors
+
+**Tags:** error-handling, git
+**Scope:** packages/cli/**/*.ts, !**/*.test.*
+
+While known benign issues like unparseable gitfiles should be handled gracefully as skips, other unexpected Git resolution failures must remain fail-loud to prevent silent configuration drift.


### PR DESCRIPTION
## What

Postmerge lesson extraction for today's second train: #2421, #2422. 3 lessons committed.

Per-PR yield:

- **#2421** (freeze-mirror re-sync) — 0 lessons (no review content; extractor skipped).
- **#2422** (worktree hooks-dir fix) — 5 extracted, **3 committed, 2 CUT pre-commit as laundered DECLINED findings**:
  - Kept: `.git` is a pointer file in linked worktrees (`--git-path` resolution); verify resolved git paths are directories (`core.hooksPath` → `/dev/null`); declared-skip vs fail-loud split on git resolution errors.
  - Cut: "Distinguish unresolved paths from skipped states" — codifies CR's round-2 finding **declined on the PR** with a falsifying test (the git-hook-skip / session-hook independence is the lc#806 contract, not a leak); "Lazy load child process imports" — codifies the lazy-import finding **declined with house precedent** (Node builtin ≠ the heavy-barrel class; doctor.ts:1). Committing either would launder refuted claims into the corpus — a live specimen for the #1834 lane (consult decline-rationale to filter polluted PR-review input).

## Freeze conformance

`rule-compilation` freeze untouched: extraction only, no compile, no compiled-rules/manifest/export changes — the sanctioned freeze-era accrual shape (#2409, #2392, #2420). `totem sync` reconciled the index (cut extractions' chunks purged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
