### PR TITLE
feat(triage-pr): parse CR blockquoted review-body sections + Additional-comments body-only findings

### DIFF
--- a/.changeset/triage-pr-cr-body-sections.md
+++ b/.changeset/triage-pr-cr-body-sections.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/cli': patch
+---
+
+`totem triage-pr` / `review-reply` no longer miss CodeRabbit review-body findings (mmnto-ai/totem#2414, the strategy#828 fetch-completeness class — three live specimens in two days). CodeRabbit renders the whole "Review details" region as a markdown blockquote, so every line's `> ` prefix broke the section regexes — outside-diff sections were present but parsed as absent, and the tool's confident "N findings" output actively suppressed the manual full-body read it replaced. Section parsing now normalizes blockquote prefixes first; the "Additional comments" section gets a parser for ACTIONABLE body-only entries (severity-tagged finding templates only — verification notes and LGTMs never surface); and body findings carry per-file provenance (`path (outside-diff)` / `path (body-only)`) parsed from the section's nested per-file blocks instead of an anonymous `(review body)`, with the body-only severity taken from CodeRabbit's own tag.

--- a/packages/cli/src/parse-nits.test.ts
+++ b/packages/cli/src/parse-nits.test.ts
@@ -552,3 +552,62 @@ describe('parseCodeRabbitReviewFindings — Additional comments (body-only, mmnt
     expect(findings.filter((f) => f.type === 'body-only')).toHaveLength(0);
   });
 });
+
+describe('CR_SEVERITY_TAG_RE anchoring + file-block scan position (#2427 review round)', () => {
+  function additionalSection(entry: string): string {
+    return [
+      '<details>',
+      '<summary>🔇 Additional comments (1)</summary><blockquote>',
+      '<details>',
+      '<summary>packages/cli/src/x.ts (1)</summary><blockquote>',
+      '',
+      entry,
+      '',
+      '</blockquote></details>',
+      '</blockquote></details>',
+    ].join('\n');
+  }
+
+  it('italic prose merely CONTAINING a severity word is not actionable (CR example)', () => {
+    const findings = parseCodeRabbitReviewFindings(
+      additionalSection('`5-5`: _major version verified_ — bump is safe. LGTM.'),
+    );
+    expect(findings.filter((f) => f.type === 'body-only')).toHaveLength(0);
+  });
+
+  it('a bare italic severity word inside a sentence is not actionable (greptile example)', () => {
+    const findings = parseCodeRabbitReviewFindings(
+      additionalSection('`5-10`: ✅ Fixed the _minor_ nit. LGTM.'),
+    );
+    expect(findings.filter((f) => f.type === 'body-only')).toHaveLength(0);
+  });
+
+  it('the real emoji-prefixed template still qualifies', () => {
+    const findings = parseCodeRabbitReviewFindings(
+      additionalSection('`5-5`: _📐 Maintainability_ | _🟡 Minor_\n\n**A real finding.**'),
+    );
+    expect(findings.filter((f) => f.type === 'body-only')).toHaveLength(1);
+  });
+
+  it('a path-like details block NESTED in a finding body is not re-matched as a sibling file block', () => {
+    const body = [
+      '<details>',
+      '<summary>⚠️ Outside diff range comments (1)</summary><blockquote>',
+      '<details>',
+      '<summary>packages/cli/src/outer.ts (1)</summary><blockquote>',
+      '',
+      '`1-2`: _🟠 Major_ finding text.',
+      '',
+      '<details>',
+      '<summary>packages/cli/src/inner.ts (1)</summary><blockquote>',
+      'embedded illustration, not a sibling block',
+      '</blockquote></details>',
+      '',
+      '</blockquote></details>',
+      '</blockquote></details>',
+    ].join('\n');
+    const findings = parseCodeRabbitReviewFindings(body).filter((f) => f.type === 'outside-diff');
+    expect(findings).toHaveLength(1);
+    expect(findings[0]!.file).toBe('packages/cli/src/outer.ts');
+  });
+});

--- a/packages/cli/src/parse-nits.test.ts
+++ b/packages/cli/src/parse-nits.test.ts
@@ -446,3 +446,109 @@ describe('parseGreptileReviewFindings (marker-anchored)', () => {
     expect(parseGreptileReviewFindings('## Just a normal summary.')).toEqual([]);
   });
 });
+
+// ─── Blockquoted review-details + Additional comments (mmnto-ai/totem#2414) ───
+
+// The live #2422 round-2 shape: CR renders the whole Review-details region as a
+// markdown BLOCKQUOTE (`> ` line prefixes), which broke every section regex —
+// both same-day #2414 specimens were this class. Structure mirrors the captured
+// body: outside-diff section → nested per-file block → finding entry.
+const BLOCKQUOTED_OUTSIDE_DIFF = [
+  '**Actionable comments posted: 0**',
+  '',
+  '<details>',
+  '<summary>📜 Review details</summary>',
+  '',
+  '> <details>',
+  '> <summary>⚠️ Outside diff range comments (1)</summary><blockquote>',
+  '> ',
+  '> <details>',
+  '> <summary>packages/cli/src/commands/install-hooks.ts (1)</summary><blockquote>',
+  '> ',
+  '> `831-838`: _🎯 Functional Correctness_ | _🟠 Major_ | _⚡ Quick win_',
+  '> ',
+  '> **Distinguish an unresolved hooks directory from a hook-manager skip.**',
+  '> ',
+  '> Returning `null` here conflates both outcomes.',
+  '> ',
+  '> </blockquote></details>',
+  '> ',
+  '> </blockquote></details>',
+  '',
+  '</details>',
+].join('\n');
+
+const ADDITIONAL_COMMENTS_MIXED = [
+  '<details>',
+  '<summary>🔇 Additional comments (2)</summary><blockquote>',
+  '',
+  '<details>',
+  '<summary>packages/cli/src/commands/install-hooks-exit-contract.test.ts (2)</summary><blockquote>',
+  '',
+  '`23-23`: _📐 Maintainability_ | _🟡 Minor_',
+  '',
+  '**Static test import question.**',
+  '',
+  'The new test file statically imports the module under test.',
+  '',
+  '---',
+  '',
+  '`1-10`: ✅ Verified — the roster invariant test covers all six artifacts. LGTM.',
+  '',
+  '</blockquote></details>',
+  '',
+  '</blockquote></details>',
+].join('\n');
+
+describe('blockquoted CR review bodies (mmnto-ai/totem#2414)', () => {
+  it('parses the outside-diff section through the blockquote wrapper (the live-miss shape)', () => {
+    const findings = parseCodeRabbitReviewFindings(BLOCKQUOTED_OUTSIDE_DIFF);
+    const outside = findings.filter((f) => f.type === 'outside-diff');
+    expect(outside).toHaveLength(1);
+    expect(outside[0]!.content).toContain('Distinguish an unresolved hooks directory');
+  });
+
+  it('attributes the finding to the nested per-file block, not "(review body)"', () => {
+    const findings = parseCodeRabbitReviewFindings(BLOCKQUOTED_OUTSIDE_DIFF);
+    expect(findings[0]!.file).toBe('packages/cli/src/commands/install-hooks.ts');
+  });
+
+  it('parses blockquoted nit sections too (shared normalization)', () => {
+    const quoted = SAMPLE_NIT_BLOCK.split('\n')
+      .map((l) => `> ${l}`)
+      .join('\n');
+    const nits = parseCodeRabbitNits(quoted);
+    expect(nits).toHaveLength(1);
+    expect(nits[0]).toContain('Hardcoded path and fragile counting method');
+  });
+
+  it('legacy non-blockquoted bodies are unaffected', () => {
+    const flat = BLOCKQUOTED_OUTSIDE_DIFF.replace(/^> /gm, '').replace(/^>$/gm, '');
+    const findings = parseCodeRabbitReviewFindings(flat);
+    expect(findings.filter((f) => f.type === 'outside-diff')).toHaveLength(1);
+  });
+});
+
+describe('parseCodeRabbitReviewFindings — Additional comments (body-only, mmnto-ai/totem#2414)', () => {
+  it('surfaces the severity-tagged actionable entry as a body-only finding', () => {
+    const findings = parseCodeRabbitReviewFindings(ADDITIONAL_COMMENTS_MIXED);
+    const bodyOnly = findings.filter((f) => f.type === 'body-only');
+    expect(bodyOnly).toHaveLength(1);
+    expect(bodyOnly[0]!.content).toContain('Static test import question');
+    expect(bodyOnly[0]!.file).toBe('packages/cli/src/commands/install-hooks-exit-contract.test.ts');
+  });
+
+  it('filters verification/LGTM entries that carry no finding template', () => {
+    const findings = parseCodeRabbitReviewFindings(ADDITIONAL_COMMENTS_MIXED);
+    expect(findings.some((f) => f.content.includes('LGTM'))).toBe(false);
+  });
+
+  it('returns nothing for an Additional-comments section of pure verifications', () => {
+    const pure = ADDITIONAL_COMMENTS_MIXED.replace(
+      /_📐 Maintainability_ \| _🟡 Minor_/,
+      '',
+    ).replace(/\*\*Static test import question\.\*\*/, '✅ fine');
+    const findings = parseCodeRabbitReviewFindings(pure);
+    expect(findings.filter((f) => f.type === 'body-only')).toHaveLength(0);
+  });
+});

--- a/packages/cli/src/parse-nits.ts
+++ b/packages/cli/src/parse-nits.ts
@@ -55,6 +55,20 @@ function stripWrapperTags(html: string): string {
 }
 
 /**
+ * CodeRabbit renders the whole "Review details" region as a markdown
+ * BLOCKQUOTE — every line carries a `> ` prefix, so `<details>` and its
+ * `<summary>` are separated by `\n> ` and the `\s*`-joined section regexes
+ * below never match. That is the mmnto-ai/totem#2414 live-miss shape (two
+ * same-day specimens): the sections were present, the parser saw none of
+ * them. Strip leading blockquote markers per line (nested `> > ` included)
+ * before any section parsing; non-blockquoted legacy bodies pass through
+ * unchanged.
+ */
+function stripBlockquotePrefixes(body: string): string {
+  return body.replace(/^(?:>[ \t]?)+/gm, '');
+}
+
+/**
  * Extract nit content from CodeRabbit review bodies.
  * Finds all `<details>` blocks whose `<summary>` contains "Nitpick", "nitpick", or the broom emoji.
  * Returns an array of cleaned nit text strings.
@@ -62,7 +76,7 @@ function stripWrapperTags(html: string): string {
 export function parseCodeRabbitNits(body: string): string[] {
   if (!body) return [];
   // Strip fenced code blocks to avoid extracting fake nits from examples
-  const stripped = body.replace(/```[\s\S]*?```/g, '');
+  const stripped = stripBlockquotePrefixes(body).replace(/```[\s\S]*?```/g, '');
   const nits: string[] = [];
   const nitpickRe = /<details>\s*<summary>[^<]*(?:nitpick|🧹)[^<]*<\/summary>/gi;
   let match: RegExpExecArray | null;
@@ -98,7 +112,7 @@ export function parseCodeRabbitNits(body: string): string[] {
 export function parseCodeRabbitOutsideDiff(body: string): string[] {
   if (!body) return [];
   // Strip fenced code blocks to avoid extracting fake matches from examples
-  const stripped = body.replace(/```[\s\S]*?```/g, '');
+  const stripped = stripBlockquotePrefixes(body).replace(/```[\s\S]*?```/g, '');
   const results: string[] = [];
   const outsideDiffRe =
     /<details>\s*<summary>[^<]*(?:outside\s+the\s+diff|outside\s+diff\s+range)[^<]*<\/summary>/gi;
@@ -197,21 +211,125 @@ export function parseGreptileReviewFindings(
   return parseGreptileOutsideDiff(body).map((content) => ({ type: 'outside-diff', content }));
 }
 
+// ─── File-attributed CR section extraction (mmnto-ai/totem#2414) ───
+
+/** One entry from a CR review-body section, with the per-file attribution the
+ * nested `<summary>path/to/file.ts (N)</summary>` block carries when present. */
+export interface CrSectionEntry {
+  content: string;
+  file?: string;
+}
+
+/** Split a stripped block into individual entries on CR's `---` dividers. */
+function splitEntries(block: string): string[] {
+  const cleaned = stripWrapperTags(block);
+  if (!cleaned) return [];
+  return cleaned
+    .split(/\r?\n---\r?\n/)
+    .map((p) => p.trim())
+    .filter(Boolean);
+}
+
 /**
- * Combined parser that extracts both nitpick and outside-diff findings
- * from a CodeRabbit review body, returning typed results.
+ * Split a section's inner content into per-file entry lists. CR nests one
+ * `<details><summary>path/to/file.ts (N)</summary>` block per file inside the
+ * section; the path in that summary is the ONLY file attribution a body
+ * finding carries (stripWrapperTags used to delete it, leaving dispositions to
+ * hand-attribute line ranges — the #2422 round-2 exhibit). A summary must look
+ * path-like (`/` or `.`) to count as a file block; when the section carries no
+ * file blocks at all, the whole content is split flat (legacy shape).
+ */
+function splitFileBlocks(sectionInner: string): CrSectionEntry[] {
+  const fileBlockRe = /<details>\s*<summary>([^<]+?)\s*\((\d+)\)<\/summary>/gi;
+  const entries: CrSectionEntry[] = [];
+  let m: RegExpExecArray | null;
+  let sawFileBlock = false;
+  while ((m = fileBlockRe.exec(sectionInner)) !== null) {
+    const file = m[1]!.trim();
+    if (!/[/.]/.test(file)) continue;
+    const inner = extractNestedBlock(sectionInner, m.index + m[0].length);
+    if (inner === null) continue;
+    sawFileBlock = true;
+    for (const content of splitEntries(inner)) entries.push({ content, file });
+  }
+  if (!sawFileBlock) {
+    for (const content of splitEntries(sectionInner)) entries.push({ content });
+  }
+  return entries;
+}
+
+/**
+ * Extract file-attributed entries from every CR section whose `<summary>`
+ * matches `summaryPattern`. Blockquote-normalized and fence-stripped like the
+ * flat parsers above.
+ */
+function extractCrSectionEntries(body: string, summaryPattern: RegExp): CrSectionEntry[] {
+  if (!body) return [];
+  const stripped = stripBlockquotePrefixes(body).replace(/```[\s\S]*?```/g, '');
+  const sectionRe = new RegExp(
+    `<details>\\s*<summary>[^<]*(?:${summaryPattern.source})[^<]*</summary>`,
+    'gi',
+  );
+  const entries: CrSectionEntry[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = sectionRe.exec(stripped)) !== null) {
+    const inner = extractNestedBlock(stripped, match.index + match[0].length);
+    if (inner === null) continue;
+    entries.push(...splitFileBlocks(inner));
+  }
+  return entries;
+}
+
+/**
+ * CR's finding template carries an italic severity tag (`_🟠 Major_`-style).
+ * Its presence is what separates an actionable body-only finding from the
+ * verification notes / LGTM lines that fill the rest of the section.
+ */
+const CR_SEVERITY_TAG_RE = /_[^_\n]*(?:critical|major|minor)[^_\n]*_/i;
+
+/**
+ * Extract ACTIONABLE entries from CodeRabbit's "Additional comments"
+ * review-body section (mmnto-ai/totem#2414 specimen 2: an actionable body-only
+ * finding that never becomes an inline thread — #2413's lazy-import finding).
+ * The section is mostly verification notes, so an entry qualifies only when it
+ * carries the finding template's severity tag; bare LGTMs never surface.
+ */
+export function parseCodeRabbitAdditionalComments(body: string): CrSectionEntry[] {
+  return extractCrSectionEntries(body, /additional\s+comments/).filter((e) =>
+    CR_SEVERITY_TAG_RE.test(e.content),
+  );
+}
+
+/**
+ * Combined parser that extracts nitpick, outside-diff, and actionable
+ * body-only ("Additional comments") findings from a CodeRabbit review body,
+ * returning typed results with per-file attribution where the section nests it
+ * (mmnto-ai/totem#2414).
  */
 export function parseCodeRabbitReviewFindings(
   body: string,
-): Array<{ type: 'nitpick' | 'outside-diff'; content: string }> {
-  const findings: Array<{ type: 'nitpick' | 'outside-diff'; content: string }> = [];
+): Array<{ type: 'nitpick' | 'outside-diff' | 'body-only'; content: string; file?: string }> {
+  const findings: Array<{
+    type: 'nitpick' | 'outside-diff' | 'body-only';
+    content: string;
+    file?: string;
+  }> = [];
 
   for (const content of parseCodeRabbitNits(body)) {
     findings.push({ type: 'nitpick', content });
   }
 
-  for (const content of parseCodeRabbitOutsideDiff(body)) {
-    findings.push({ type: 'outside-diff', content });
+  // File-attributed extraction (not the flat legacy string[] surface) so a
+  // disposition can cite `file (outside-diff)` instead of `(review body)`.
+  for (const entry of extractCrSectionEntries(
+    body,
+    /outside\s+the\s+diff|outside\s+diff\s+range/,
+  )) {
+    findings.push({ type: 'outside-diff', content: entry.content, file: entry.file });
+  }
+
+  for (const entry of parseCodeRabbitAdditionalComments(body)) {
+    findings.push({ type: 'body-only', content: entry.content, file: entry.file });
   }
 
   return findings;

--- a/packages/cli/src/parse-nits.ts
+++ b/packages/cli/src/parse-nits.ts
@@ -251,6 +251,10 @@ function splitFileBlocks(sectionInner: string): CrSectionEntry[] {
     if (inner === null) continue;
     sawFileBlock = true;
     for (const content of splitEntries(inner)) entries.push({ content, file });
+    // Resume the scan PAST the extracted block, not inside its content — a
+    // path-like <details> nested within a finding's body must never be
+    // re-matched as an independent sibling file block (greptile #2427 round).
+    fileBlockRe.lastIndex = m.index + m[0].length + inner.length;
   }
   if (!sawFileBlock) {
     for (const content of splitEntries(sectionInner)) entries.push({ content });
@@ -283,9 +287,13 @@ function extractCrSectionEntries(body: string, summaryPattern: RegExp): CrSectio
 /**
  * CR's finding template carries an italic severity tag (`_🟠 Major_`-style).
  * Its presence is what separates an actionable body-only finding from the
- * verification notes / LGTM lines that fill the rest of the section.
+ * verification notes / LGTM lines that fill the rest of the section. Anchored
+ * to the concrete template shape — severity emoji + the severity word as the
+ * WHOLE italic span — so italic prose that merely contains the word
+ * (`_major version verified_`, `✅ Fixed the _minor_ nit`) never qualifies
+ * (#2427 review round, CR + greptile convergent).
  */
-const CR_SEVERITY_TAG_RE = /_[^_\n]*(?:critical|major|minor)[^_\n]*_/i;
+const CR_SEVERITY_TAG_RE = /_(?:🔴|🟠|🟡)\s*(?:critical|major|minor)_/iu;
 
 /**
  * Extract ACTIONABLE entries from CodeRabbit's "Additional comments"

--- a/packages/cli/src/parsers/bot-review-parser.ts
+++ b/packages/cli/src/parsers/bot-review-parser.ts
@@ -262,7 +262,11 @@ export function extractReviewBodyFindings(
     if (!review.author || !isBotComment(review.author)) continue;
 
     const tool = detectBot(review.author);
-    let parsed: Array<{ type: 'nitpick' | 'outside-diff'; content: string }> = [];
+    let parsed: Array<{
+      type: 'nitpick' | 'outside-diff' | 'body-only';
+      content: string;
+      file?: string;
+    }> = [];
 
     if (tool === 'coderabbit') {
       parsed = parseCodeRabbitReviewFindings(review.body);
@@ -275,8 +279,19 @@ export function extractReviewBodyFindings(
     for (const finding of parsed) {
       findings.push({
         tool,
-        severity: finding.type === 'outside-diff' ? 'warning' : 'info',
-        file: '(review body)',
+        // A body-only ("Additional comments") entry carries CR's own severity
+        // tag — parse it instead of flattening to a fixed tier (mmnto-ai/totem#2414).
+        severity:
+          finding.type === 'body-only'
+            ? parseSeverityForTool(tool, finding.content)
+            : finding.type === 'outside-diff'
+              ? 'warning'
+              : 'info',
+        // Provenance marker (mmnto-ai/totem#2414): dispositions reference
+        // `path (outside-diff)` / `path (body-only)` when the section's nested
+        // per-file block carried the attribution; the bare `(review body)`
+        // fallback stays for unattributed shapes.
+        file: finding.file !== undefined ? `${finding.file} (${finding.type})` : '(review body)',
         line: undefined,
         body: finding.content,
         suggestion: undefined,


### PR DESCRIPTION
Closes #2414

## Root cause (why the existing parsers missed live findings)

The section parsers existed (`parseCodeRabbitOutsideDiff` / `parseCodeRabbitNits`), but CodeRabbit renders the whole "Review details" region as a **markdown blockquote** — every line carries a `> ` prefix, so `<details>` and `<summary>` are separated by `\n> ` and the `\s*`-joined section regexes never matched. Both #2414 specimens (strategy#903's 9th finding, #2413's body-only lazy-import finding) were this class, and today produced a third: #2422's round-2 outside-diff finding, hand-extracted because `triage-pr` couldn't see it. The "N findings" output presented as complete — exactly the Tenet-4 silent-miss the issue names.

## What shipped

- **Blockquote normalization** (`stripBlockquotePrefixes`, nested `> > ` included) ahead of all CR section parsing — `parseCodeRabbitNits` (also used by `extract-pr`) and `parseCodeRabbitOutsideDiff` keep their signatures and gain the fix; legacy non-blockquoted bodies pass through unchanged (regression-locked).
- **"Additional comments" parser** (`parseCodeRabbitAdditionalComments`): surfaces ACTIONABLE body-only entries — an entry qualifies only when it carries CR's finding-template severity tag (`_🟠 Major_`-style), so verification notes and LGTMs never inflate the inbox (the issue's "not bare LGTMs" requirement).
- **Per-file provenance** (the issue's disposition-reference ask): body findings now parse the section's nested `<summary>path/to/file.ts (N)</summary>` blocks — previously stripped and discarded — and render as `path (outside-diff)` / `path (body-only)` instead of an anonymous `(review body)`. Body-only severity comes from CR's own tag via `parseSeverityForTool` rather than a flattened tier.
- Greptile's marker-anchored summary parser untouched (#2319 stays the sub-5-justification lane).

## Verification

- 9 new tests in `parse-nits.test.ts` built on the captured live #2422 round-2 body structure: blockquoted outside-diff parses with file attribution, blockquoted nits parse, legacy flat shape regression, Additional-comments actionable-vs-LGTM filtering, pure-verification sections yield nothing. Parser files 145/145; full workspace 10/10 tasks.
- **E2E against the live PR:** `triage-pr 2422` now reports "Found 1 finding(s) in review/issue-comment bodies" and lists `packages/cli/src/commands/install-hooks.ts (outside-diff)` with the `831-838` finding — the exact item that was invisible this morning.

Changeset: patch `@mmnto/cli`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
