### PR TITLE
docs(readme): Where the Loop Stands — freeze-candor front-door surface + Node-floor rationale

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ When using LLMs on projects, I found that agents kept making the same architectu
 
 The cause is structural, not a prompt problem. Models are stateless. Every session starts from zero, and anything the last session learned is gone unless it lives somewhere durable. If project rules and lessons don't reside in the repository alongside the code, no amount of re-explaining fixes it for the next session.
 
-Totem is what I extracted to solve that friction. It's a file-based toolkit: plain markdown lessons, a queryable knowledge index derived from them, and compiled lint rules a zero-LLM linter enforces. The lint engine is deterministic; the index is local, derived, and rebuilt from your files at any time; the compiler and review commands are LLM-powered and opt-in. The structural pieces ship today. The discipline and telemetry layers are in active development; the [maturity page](docs/wiki/maturity.md) carries the honest split, machine-derived from committed data.
+Totem is what I extracted to solve that friction. It's a file-based toolkit: plain markdown lessons, a queryable knowledge index derived from them, and compiled lint rules a zero-LLM linter enforces. The lint engine is deterministic; the index is local, derived, and rebuilt from your files at any time; the compiler and review commands are LLM-powered and opt-in. The structural pieces ship today. Read the loop below with one composition note: the **enforcement floor** (deterministic lint, hooks, index) is the stable half this repo exercises on every push, while the **lesson-compiler** half is mid-replacement — rule compilation has been frozen since 2026-05-17 while its successor is built in the open, so new lessons currently accrue and stay queryable without compiling into new rules. The discipline and telemetry layers are in active development; the [maturity page](docs/wiki/maturity.md) carries the honest split, machine-derived from committed data.
 
 ---
 
@@ -137,6 +137,8 @@ pnpm dlx @mmnto/cli doctor --strict
 ```
 
 `doctor --strict` reports config, hooks, rules, and index wiring, and exits non-zero on fail-class diagnostics. Read and resolve its warnings before treating setup as complete; if an agent is running this setup for you, that is its checklist too.
+
+The npm packages declare `engines.node >= 24` deliberately: Node 24 (LTS since 2025-10) is the runtime CI actually tests and the one the publishing pipeline (npm 11 / OIDC) runs on — a floor we exercise rather than one we claim. On CI images pinned to older Node, use the Lite binary below instead.
 
 No Node.js? The **Totem Lite** standalone binary runs `init`, `lint`, and `hooks` fully offline: grab it from [Releases](https://github.com/mmnto-ai/totem/releases); platform commands in the [Installation Guide](docs/wiki/installation.md).
 

--- a/README.md
+++ b/README.md
@@ -17,12 +17,13 @@ When using LLMs on projects, I found that agents kept making the same architectu
 
 The cause is structural, not a prompt problem. Models are stateless. Every session starts from zero, and anything the last session learned is gone unless it lives somewhere durable. If project rules and lessons don't reside in the repository alongside the code, no amount of re-explaining fixes it for the next session.
 
-Totem is what I extracted to solve that friction. It's a file-based toolkit: plain markdown lessons, a queryable knowledge index derived from them, and compiled lint rules a zero-LLM linter enforces. The lint engine is deterministic; the index is local, derived, and rebuilt from your files at any time; the compiler and review commands are LLM-powered and opt-in. The structural pieces ship today. Read the loop below with one composition note: the **enforcement floor** (deterministic lint, hooks, index) is the stable half this repo exercises on every push, while the **lesson-compiler** half is mid-replacement — rule compilation has been frozen since 2026-05-17 while its successor is built in the open, so new lessons currently accrue and stay queryable without compiling into new rules. The discipline and telemetry layers are in active development; the [maturity page](docs/wiki/maturity.md) carries the honest split, machine-derived from committed data.
+Totem is what I extracted to solve that friction. It's a file-based toolkit: plain markdown lessons, a queryable knowledge index derived from them, and compiled lint rules a zero-LLM linter enforces. The lint engine is deterministic; the index is local, derived, and rebuilt from your files at any time; the compiler and review commands are LLM-powered and opt-in. The structural pieces ship today; [Where the Loop Stands](#where-the-loop-stands) says exactly which half is which. The discipline and telemetry layers are in active development; the [maturity page](docs/wiki/maturity.md) carries the honest split, machine-derived from committed data.
 
 ---
 
 - [Tripwires, Not Tracks](#tripwires-not-tracks)
 - [How Mistakes Become Rules](#how-mistakes-become-rules)
+- [Where the Loop Stands](#where-the-loop-stands)
 - [The Queryable Knowledge Index](#the-queryable-knowledge-index)
 - [What's in the Box](#whats-in-the-box)
 - [What Works and What Doesn't](#what-works-and-what-doesnt)
@@ -66,7 +67,7 @@ The core loop is simple. A mistake gets caught in a PR review, a bot nit, or a p
 
 ```mermaid
 graph LR
-    Catch["Catch a mistake"] -->|write a lesson| Compile["totem lesson compile"]
+    Catch["Catch a mistake"] -->|write a lesson| Compile["totem lesson compile (frozen)"]
     Compile -->|generates rule| Enforce["totem lint"]
     Enforce -->|catches next attempt| Catch
 
@@ -75,9 +76,25 @@ graph LR
     style Enforce fill:#1a4d2e,stroke:#34a853,color:#fff
 ```
 
+The compile step is frozen today; [Where the Loop Stands](#where-the-loop-stands), next, says why and what still runs.
+
 When a rule matches comments or string literals instead of actual code, `totem doctor` flags it as noisy, and `totem lesson compile --upgrade` re-runs the compiler with a precision-targeted prompt. I'd rather have 300 precise rules than 1,000 noisy ones.
 
 Want to watch the whole loop run on a committed fixture? [`examples/proof-kit/`](examples/proof-kit/) is a tiny repo where a real mistake, its lesson, and the compiled rule that blocks the recurrence are all committed. CI re-proves the block on every push and writes a [receipt](examples/proof-kit/receipt.json) with its parameters.
+
+## Where the Loop Stands
+
+The loop above is the design. Here is where it stands today.
+
+**Enforcement is stable.** Compiled rules run on every diff: deterministic, offline, zero LLM.
+
+**Lessons are live.** They bank, index, and surface to agents today. They advise; they do not yet compile.
+
+**The compiler is frozen on purpose, since 2026-05-17.** We hit a soundness problem in the lesson-to-rule path and froze it fail-closed: a corrupt [freeze file](.totem/freeze.json) throws rather than bypassing itself. Fewer rules we trust beat more rules we do not.
+
+**The path back is gated, not dated.** The replacement compiler ships only after it passes held-out validation on real work; status lives on the [maturity page](docs/wiki/maturity.md).
+
+What this means today: existing rules keep enforcing, new lessons bank and advise, and new-rule compilation waits for the gate. If that trade is wrong for you, we would rather you know now.
 
 ## The Queryable Knowledge Index
 


### PR DESCRIPTION
## What

Two surfaces, one slice:

1. **"Where the Loop Stands" — the freeze promoted to the front of the story.** Executes the 2026-07-18 operator ruling (routed via strategy 0206Z; framing brief at mmnto-ai/totem-strategy#531 comment 5009361256, superseding-extending the kimi one-sentence item this PR originally carried). New section after the loop description per the framing contract: enforcement stable · lessons live-but-advisory · compiler frozen on purpose with the fail-closed mechanism stated (verified at source: `core/src/freeze.ts` throws `TotemConfigError` on a corrupt freeze file — "must never silently bypass itself") · path back gated-not-dated · what-it-means-today with the walk-away line. The loop diagram's compile node is annotated `(frozen)` with a pointer line under it; the intro paragraph links the section. Voice constraints held: no em dashes in the section, no internal jargon, mechanism-class present tense, ~130 words against the ≤120 target, freeze date from the repo's own `freeze.json`, links to in-repo surfaces only.
2. **Node ≥24 floor — declined-with-stated-reason (kimi item 2):** deliberate floor — Node 24 (LTS since 2025-10) is the runtime CI actually tests and the publishing pipeline (npm 11 / OIDC, #1991/#2013) runs on; sentence sits above the Totem Lite paragraph, which is the older-CI escape hatch.

Kimi item 3 (glob matcher vs picomatch) dispositioned on the record at #2428 — no README change.

## Notes

- README-only; the WWND claim-discipline gate ran scope-to-diff on both pushes and passed.
- GCA was invoked before the rework landed; its round may reference the superseded one-sentence shape (commit `e4856fba`) — current content is `0c50140b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
