### PR TITLE
chore: totem postmerge lessons for 2424 2427 2429

### DIFF
--- a/.totem/lessons/lesson-30a0d97d.md
+++ b/.totem/lessons/lesson-30a0d97d.md
@@ -1,0 +1,6 @@
+## Lesson — Advance RegExp lastIndex past nested blocks
+
+**Tags:** regex, javascript, parsing
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+When iteratively parsing nested blocks using a global RegExp, failing to advance `lastIndex` past the extracted block can cause the scanner to resume inside the block content, leading to duplicate extractions or incorrect attribution.

--- a/.totem/lessons/lesson-6adb0f0f.md
+++ b/.totem/lessons/lesson-6adb0f0f.md
@@ -1,0 +1,6 @@
+## Lesson — Track per-seat counts for broadcasts
+
+**Tags:** architecture, state, concurrency
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Using a flat union to track processed broadcast messages leads to a first-consumer-wins trap in multi-seat environments. Tracking distinct per-seat mark counts ensures shared broadcasts are not prematurely hidden from other active seats.

--- a/.totem/lessons/lesson-9825b397.md
+++ b/.totem/lessons/lesson-9825b397.md
@@ -1,0 +1,6 @@
+## Lesson — Deduplicate agent IDs at boundaries
+
+**Tags:** cli, performance, io
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Failing to deduplicate agent lists before processing causes redundant directory reads and inflates seat counts. Deduplicating at the boundary ensures that seat counts accurately reflect the unique entities that can hold marks.

--- a/.totem/lessons/lesson-b00a46a2.md
+++ b/.totem/lessons/lesson-b00a46a2.md
@@ -1,0 +1,6 @@
+## Lesson — Fail closed on corrupt freeze files
+
+**Tags:** compiler, security, error-handling
+**Scope:** packages/core/src/freeze.ts
+
+The local freeze-file read must throw an explicit error (such as `TotemConfigError`) upon encountering a corrupt freeze file rather than silently bypassing itself. This ensures that security boundaries and frozen states are strictly enforced without silent failures. The distributed cohort-channel read is the deliberate exception: it never throws and instead degrades to `status: 'corrupt'` with zero visible entries, so every consumer stays conservative (gates keep blocking) — do not "fix" that divergence to match the local fail-closed contract.

--- a/.totem/lessons/lesson-c17e353c.md
+++ b/.totem/lessons/lesson-c17e353c.md
@@ -1,0 +1,6 @@
+## Lesson — Normalize markdown blockquotes
+
+**Tags:** markdown, parsing, html
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Markdown blockquote prefixes (e.g., `> `) on every line can break regexes designed to match multiline HTML tags like `<details>` and `<summary>`. Stripping blockquote prefixes prior to parsing ensures robust tag matching.

--- a/.totem/lessons/lesson-dddf43b4.md
+++ b/.totem/lessons/lesson-dddf43b4.md
@@ -1,0 +1,6 @@
+## Lesson — Align engine floors with CI runtimes
+
+**Tags:** node, ci-cd, dependencies
+**Scope:** package.json
+
+Establish a strict Node.js engine floor that matches the active CI testing and publishing pipeline environments to prevent runtime mismatches. Provide a lightweight escape hatch for consumers running older CI environments.

--- a/.totem/lessons/lesson-f6f30b02.md
+++ b/.totem/lessons/lesson-f6f30b02.md
@@ -1,0 +1,6 @@
+## Lesson — Anchor severity regexes to templates
+
+**Tags:** regex, parsing, coderabbit
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Broad regexes matching italicized severity keywords can falsely trigger on verification prose like '_major version verified_'. Anchoring patterns to specific template structures, such as emoji-prefixed severity tags, prevents false-positive findings.


### PR DESCRIPTION
Postmerge lesson extraction for the merged train #2424 / #2427 / #2429 (the #2423 Version-Packages merge excluded). Freeze-era shape, same as #2420 and #2425: **extraction only — no compile, no `compiled-rules.json` or manifest touch** (rule-compilation freeze, since 2026-05-17).

## What's in

7 novel lessons (extractor dedup against the existing corpus ran):

- **#2424 (2):** per-seat broadcast mark counts over the flat first-consumer-wins union; dedup agent IDs at the poll boundary (the accepted GCA invariant-hygiene finding, in its dispositioned framing — redundant reads + "seats counted = seats that can hold marks" invariant, not the over-claimed correctness path).
- **#2427 (3):** blockquote normalization ahead of CR section regexes; severity-tag regexes anchored to the concrete template (both reviewers' accepted finding); global-RegExp `lastIndex` advanced past extracted nested blocks (greptile's accepted finding).
- **#2429 (2):** local freeze-file read fails closed (throws `TotemConfigError` on corrupt); Node engine floor matched to the CI/publish runtime with the Lite binary as the older-CI hatch (the decline *rationale* side, on the record in #2429's body).

## Disposition diff (the #2425 laundering check)

Re-read every round surface (PR bodies, GCA review bodies + inline, CR + greptile inline, my disposition comments, #2428) before committing. **Zero lessons cut this round** — all bot findings on this train were *accepted* (#2424 GCA hygiene; #2427 CR+greptile ×2), and the round's two declines (picomatch adoption → dispositioned at #2428; Node-floor pushback → declined-with-stated-reason in #2429's body) are not restated by any extracted lesson.

**One narrow precision edit, disclosed:** `lesson-b00a46a2` as extracted claimed the freeze mechanism "must throw on corrupt" universally and scoped to a non-existent path (`core/src/freeze.ts`). Verified at source: `packages/core/src/freeze.ts` deliberately splits the contract — the local read throws (fail-closed), the distributed cohort-channel read never throws and degrades to `status: 'corrupt'` so consumers stay conservative. The lesson now states both halves and the corrected path, so it can't be cited to "fix" the deliberate never-throws channel.

## Mechanics

- Incremental sync ran (index matches the edited content); the 7 new files prettier-formatted; repo-wide `format:check` green; `totem lint --base main` shows only the standing freeze-era stale-manifest warning (33 uncompiled lessons accumulating by design until the Convergent Spine lifts the freeze).
- No changeset — lessons-only, not a releasable slice (matches #2425).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
