### PR TITLE
fix(eject): worktree-aware hook scrub — resolve the shared hooks dir, decline cross-worktree removal (closes the #2418-sibling silent no-op)

### DIFF
--- a/.changeset/eject-worktree-hooks.md
+++ b/.changeset/eject-worktree-hooks.md
@@ -1,0 +1,7 @@
+---
+'@mmnto/cli': patch
+---
+
+`totem eject` no longer silently no-ops on git hooks in a linked worktree, and now anchors hook removal at the git root when run from a subdirectory (mmnto-ai/totem#2426, sibling of #2422). The hook scrubber previously joined `<cwd>/.git/hooks/<name>` blind — but in a linked worktree `.git` is a `gitdir:` pointer FILE and the hooks git actually runs live in the shared common dir, so every hook reported "not found" and eject removed nothing. Eject now resolves the hooks directory through the SAME helpers `hook install` uses (`resolveGitRootForHookPath` + `resolveHooksDir`, git's own worktree/`commondir`/`core.hooksPath` walk).
+
+Because the resolved hooks directory is SHARED across every worktree of a repo, eject run from a linked worktree now **declines** to remove the git hooks (removing them would change hook behavior for the main checkout and every sibling worktree) and prints a line naming the shared location, directing you to run `totem eject` from the main working tree. All other eject cleanup (scaffolded files, settings entries, reflex blocks, `.totem/`, config) is per-working-tree and still runs from a worktree. Whether an eject from a worktree should instead scrub the shared hooks (symmetric with `hook install`) is left as an open policy question for a follow-up.

--- a/packages/cli/src/commands/eject.test.ts
+++ b/packages/cli/src/commands/eject.test.ts
@@ -686,38 +686,38 @@ describe('resolveEjectHooksContext', () => {
     cleanTmpDir(dir);
   });
 
-  it('plain checkout (.git DIRECTORY): resolves the hooks dir, not a worktree', () => {
+  it('plain checkout (.git DIRECTORY): resolves the hooks dir, not a worktree', async () => {
     fs.mkdirSync(path.join(dir, '.git', 'hooks'), { recursive: true });
-    const ctx = resolveEjectHooksContext(dir);
+    const ctx = await resolveEjectHooksContext(dir);
     expect(ctx.isLinkedWorktree).toBe(false);
     expect(ctx.hooksDir).toBe(path.join(dir, '.git', 'hooks'));
   });
 
-  it('linked worktree (.git POINTER FILE): flagged as shared across worktrees', () => {
+  it('linked worktree (.git POINTER FILE): flagged as shared across worktrees', async () => {
     // A `.git` FILE is the gitdir pointer git writes for a linked worktree.
     fs.writeFileSync(path.join(dir, '.git'), 'gitdir: /elsewhere/.git/worktrees/wt\n');
     // The shared hooks dir git would resolve for it (mocked — no real git walk).
     vi.mocked(resolveHooksDir).mockReturnValue('/elsewhere/.git/hooks');
-    const ctx = resolveEjectHooksContext(dir);
+    const ctx = await resolveEjectHooksContext(dir);
     expect(ctx.isLinkedWorktree).toBe(true);
     expect(ctx.hooksDir).toBe('/elsewhere/.git/hooks');
   });
 
-  it('not a git repo / unparseable pointer (null root): null hooks dir, not a worktree', () => {
+  it('not a git repo / unparseable pointer (null root): null hooks dir, not a worktree', async () => {
     vi.mocked(resolveGitRootForHookPath).mockReturnValue({
       gitRoot: null,
       unparseablePointer: true,
     });
-    const ctx = resolveEjectHooksContext(dir);
+    const ctx = await resolveEjectHooksContext(dir);
     expect(ctx.hooksDir).toBeNull();
     expect(ctx.isLinkedWorktree).toBe(false);
   });
 
-  it('best-effort: a resolver throw degrades to unresolvable, never propagates', () => {
+  it('best-effort: a resolver throw degrades to unresolvable, never propagates', async () => {
     vi.mocked(resolveGitRootForHookPath).mockImplementation(() => {
       throw new Error('git broke');
     });
-    const ctx = resolveEjectHooksContext(dir);
+    const ctx = await resolveEjectHooksContext(dir);
     expect(ctx.hooksDir).toBeNull();
     expect(ctx.isLinkedWorktree).toBe(false);
   });

--- a/packages/cli/src/commands/eject.test.ts
+++ b/packages/cli/src/commands/eject.test.ts
@@ -2,12 +2,47 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { cleanTmpDir } from '../test-utils.js';
 import type { EjectSummary } from './eject.js';
-import { ejectCommand, scrubPostCheckoutHook, scrubPostMergeHook } from './eject.js';
+import {
+  ejectCommand,
+  resolveEjectHooksContext,
+  scrubPostCheckoutHook,
+  scrubPostMergeHook,
+} from './eject.js';
 import { SKILL_MARKER_END, SKILL_MARKER_START } from './init-templates.js';
+import { resolveGitRootForHookPath, resolveHooksDir } from './install-hooks.js';
+
+// Mock the git seam (mmnto-ai/totem#2426): eject now resolves the git root +
+// hooks dir via the SAME #2422 helpers `hook install` uses. Tests must NOT spawn
+// real `git` with cwd inside a temp dir (leaves undeletable directories on
+// Windows AND, if TMPDIR happened to sit inside a repo, could scrub the OUTER
+// repo's hooks). So the two resolvers are mocked; the fixtures below are plain
+// filesystem `.git/hooks` trees. The `...actual` spread keeps every other export
+// real — and eject is the only module importing these two, so intra-module
+// install-hooks calls (init/hooks tests) are untouched.
+vi.mock('./install-hooks.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./install-hooks.js')>();
+  return {
+    ...actual,
+    resolveGitRootForHookPath: vi.fn(),
+    resolveHooksDir: vi.fn(),
+  };
+});
+
+// Default seam behavior for the plain-checkout fixtures every describe below
+// builds: git root = cwd, hooks dir = <root>/.git/hooks. Re-established before
+// EVERY test (file-scope hook runs before each describe-scope hook); the
+// worktree/anchoring/unresolvable cases override it in the test body.
+beforeEach(() => {
+  vi.mocked(resolveGitRootForHookPath).mockImplementation((c: string) => ({
+    gitRoot: c,
+    unparseablePointer: false,
+  }));
+  vi.mocked(resolveHooksDir).mockImplementation((root: string) => path.join(root, '.git', 'hooks'));
+});
 
 function makeTmpDir(): string {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'totem-eject-'));
@@ -423,7 +458,7 @@ fi
     );
 
     const summary: EjectSummary = { removed: [], scrubbed: [], skipped: [] };
-    scrubPostMergeHook(cwd, summary);
+    scrubPostMergeHook(path.join(cwd, '.git', 'hooks'), summary);
 
     expect(fs.existsSync(hookPath)).toBe(false);
     expect(summary.removed).toContain('.git/hooks/post-merge');
@@ -437,7 +472,7 @@ fi
     );
 
     const summary: EjectSummary = { removed: [], scrubbed: [], skipped: [] };
-    scrubPostMergeHook(cwd, summary);
+    scrubPostMergeHook(path.join(cwd, '.git', 'hooks'), summary);
 
     expect(fs.existsSync(hookPath)).toBe(false);
     expect(summary.removed).toContain('.git/hooks/post-merge');
@@ -460,7 +495,7 @@ fi
     );
 
     const summary: EjectSummary = { removed: [], scrubbed: [], skipped: [] };
-    scrubPostMergeHook(cwd, summary);
+    scrubPostMergeHook(path.join(cwd, '.git', 'hooks'), summary);
 
     expect(fs.existsSync(hookPath)).toBe(true);
     const content = fs.readFileSync(hookPath, 'utf-8');
@@ -506,7 +541,7 @@ fi
     );
 
     const summary: EjectSummary = { removed: [], scrubbed: [], skipped: [] };
-    scrubPostCheckoutHook(cwd, summary);
+    scrubPostCheckoutHook(path.join(cwd, '.git', 'hooks'), summary);
 
     expect(fs.existsSync(hookPath)).toBe(false);
     expect(summary.removed).toContain('.git/hooks/post-checkout');
@@ -533,7 +568,7 @@ fi
     );
 
     const summary: EjectSummary = { removed: [], scrubbed: [], skipped: [] };
-    scrubPostCheckoutHook(cwd, summary);
+    scrubPostCheckoutHook(path.join(cwd, '.git', 'hooks'), summary);
 
     expect(fs.existsSync(hookPath)).toBe(true);
     const content = fs.readFileSync(hookPath, 'utf-8');
@@ -631,5 +666,173 @@ describe('eject — distributed Claude skills (mmnto-ai/totem#1890 Phase C slice
     expect(fs.existsSync(path.join(cwd, '.claude', 'skills', 'signoff'))).toBe(false);
     expect(fs.existsSync(customSkill)).toBe(true);
     expect(fs.existsSync(path.join(cwd, '.claude', 'skills'))).toBe(true);
+  });
+});
+
+// ─── resolveEjectHooksContext (mmnto-ai/totem#2426) ─────────
+//
+// The seam eject uses to decide WHERE the git hooks are and whether they are
+// SHARED. Driven with the mocked resolvers (no real git); the `.git`-shape check
+// is a real filesystem probe on the fixtures.
+
+describe('resolveEjectHooksContext', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-2426-ctx-'));
+  });
+
+  afterEach(() => {
+    cleanTmpDir(dir);
+  });
+
+  it('plain checkout (.git DIRECTORY): resolves the hooks dir, not a worktree', () => {
+    fs.mkdirSync(path.join(dir, '.git', 'hooks'), { recursive: true });
+    const ctx = resolveEjectHooksContext(dir);
+    expect(ctx.isLinkedWorktree).toBe(false);
+    expect(ctx.hooksDir).toBe(path.join(dir, '.git', 'hooks'));
+  });
+
+  it('linked worktree (.git POINTER FILE): flagged as shared across worktrees', () => {
+    // A `.git` FILE is the gitdir pointer git writes for a linked worktree.
+    fs.writeFileSync(path.join(dir, '.git'), 'gitdir: /elsewhere/.git/worktrees/wt\n');
+    // The shared hooks dir git would resolve for it (mocked — no real git walk).
+    vi.mocked(resolveHooksDir).mockReturnValue('/elsewhere/.git/hooks');
+    const ctx = resolveEjectHooksContext(dir);
+    expect(ctx.isLinkedWorktree).toBe(true);
+    expect(ctx.hooksDir).toBe('/elsewhere/.git/hooks');
+  });
+
+  it('not a git repo / unparseable pointer (null root): null hooks dir, not a worktree', () => {
+    vi.mocked(resolveGitRootForHookPath).mockReturnValue({
+      gitRoot: null,
+      unparseablePointer: true,
+    });
+    const ctx = resolveEjectHooksContext(dir);
+    expect(ctx.hooksDir).toBeNull();
+    expect(ctx.isLinkedWorktree).toBe(false);
+  });
+
+  it('best-effort: a resolver throw degrades to unresolvable, never propagates', () => {
+    vi.mocked(resolveGitRootForHookPath).mockImplementation(() => {
+      throw new Error('git broke');
+    });
+    const ctx = resolveEjectHooksContext(dir);
+    expect(ctx.hooksDir).toBeNull();
+    expect(ctx.isLinkedWorktree).toBe(false);
+  });
+});
+
+// ─── ejectCommand git-hook resolution (mmnto-ai/totem#2426) ─────────
+//
+// The three behaviors the fix adds on top of the plain-checkout scrub the
+// existing suite already covers: the worktree SHARED-hooks decline (the
+// conservative semantics ruling), git-root anchoring from a subdirectory, and
+// the unresolvable-dir skip.
+
+describe('ejectCommand git-hook resolution (mmnto-ai/totem#2426)', () => {
+  let originalCwd: string;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  const errorOutput = (): string =>
+    errorSpy.mock.calls
+      .map((c: unknown[]) => c.map((a: unknown) => String(a)).join(' '))
+      .join('\n');
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    errorSpy.mockRestore();
+  });
+
+  it('DECLINES to scrub the SHARED hooks from a linked worktree, leaving them intact', async () => {
+    // Main checkout: a real `.git` DIRECTORY holding an installed totem post-merge hook.
+    const mainDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-2426-main-'));
+    const mainHooks = path.join(mainDir, '.git', 'hooks');
+    fs.mkdirSync(mainHooks, { recursive: true });
+    const sharedHook = path.join(mainHooks, 'post-merge');
+    fs.writeFileSync(
+      sharedHook,
+      '#!/bin/sh\n# [totem] post-merge hook — background re-index after pull/merge.\n\n# [totem] end post-merge\n',
+    );
+
+    // Worktree: `.git` is a POINTER FILE; its hooks RESOLVE to the shared dir.
+    const wtDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-2426-wt-'));
+    fs.writeFileSync(
+      path.join(wtDir, '.git'),
+      `gitdir: ${path.join(mainDir, '.git', 'worktrees', 'wt')}\n`,
+    );
+    vi.mocked(resolveHooksDir).mockReturnValue(mainHooks);
+
+    process.chdir(wtDir);
+    try {
+      await expect(ejectCommand({ force: true })).resolves.toBeUndefined();
+    } finally {
+      process.chdir(originalCwd);
+    }
+
+    // The shared hook is UNTOUCHED — eject declined rather than mutate shared state.
+    expect(fs.existsSync(sharedHook)).toBe(true);
+    const out = errorOutput();
+    expect(out).toContain('shared git directory');
+    expect(out).toContain('run `totem eject` from the main working tree');
+
+    cleanTmpDir(wtDir);
+    cleanTmpDir(mainDir);
+  });
+
+  it('anchors at the git root when run from a subdirectory (not the blind cwd/.git join)', async () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-2426-anchor-'));
+    const hooksDir = path.join(repoRoot, '.git', 'hooks');
+    fs.mkdirSync(hooksDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(hooksDir, 'post-merge'),
+      '#!/bin/sh\n# [totem] post-merge hook — background re-index after pull/merge.\n\n# [totem] end post-merge\n',
+    );
+    const subdir = path.join(repoRoot, 'packages', 'x');
+    fs.mkdirSync(subdir, { recursive: true });
+
+    // What real git does from a subdirectory: resolve UP to the repo root.
+    vi.mocked(resolveGitRootForHookPath).mockReturnValue({
+      gitRoot: repoRoot,
+      unparseablePointer: false,
+    });
+    vi.mocked(resolveHooksDir).mockReturnValue(hooksDir);
+
+    process.chdir(subdir);
+    try {
+      await ejectCommand({ force: true });
+    } finally {
+      process.chdir(originalCwd);
+    }
+
+    // The hook at the RESOLVED root is removed — not missed because cwd was a subdir.
+    expect(fs.existsSync(path.join(hooksDir, 'post-merge'))).toBe(false);
+
+    cleanTmpDir(repoRoot);
+  });
+
+  it('reports the hooks dir as unresolvable (not-a-repo / bad pointer) without crashing', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-2426-unres-'));
+    vi.mocked(resolveGitRootForHookPath).mockReturnValue({
+      gitRoot: null,
+      unparseablePointer: true,
+    });
+    vi.mocked(resolveHooksDir).mockReturnValue(null);
+
+    process.chdir(dir);
+    try {
+      await expect(ejectCommand({ force: true })).resolves.toBeUndefined();
+    } finally {
+      process.chdir(originalCwd);
+    }
+
+    expect(errorOutput()).toContain('git hooks directory could not be resolved');
+
+    cleanTmpDir(dir);
   });
 });

--- a/packages/cli/src/commands/eject.ts
+++ b/packages/cli/src/commands/eject.ts
@@ -75,12 +75,12 @@ export async function resolveEjectHooksContext(cwd: string): Promise<EjectHooksC
   // (the same dynamic-import pattern `scrubClaudeSkills`/`ejectCommand` use).
   const { resolveGitRootForHookPath, resolveHooksDir } = await import('./install-hooks.js');
   let gitRoot: string | null;
-  // totem-context: intentional cleanup — eject is best-effort per Tenet 4's
-  // cleanup carve-out; a genuine git failure degrades to "unresolvable", never a
-  // crash of the whole eject. (Not-a-repo / unparseable pointer already return a
-  // null root without throwing; this guards the residual "git broke" class.)
   try {
     ({ gitRoot } = resolveGitRootForHookPath(cwd));
+    // totem-context: intentional cleanup — eject is best-effort per Tenet 4's
+    // cleanup carve-out; a genuine git failure (NOT not-a-repo / unparseable
+    // pointer, which return a null root without throwing) degrades to
+    // "unresolvable" rather than crashing the whole eject.
   } catch {
     return { hooksDir: null, isLinkedWorktree: false };
   }

--- a/packages/cli/src/commands/eject.ts
+++ b/packages/cli/src/commands/eject.ts
@@ -1,6 +1,8 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
+import { resolveGitRootForHookPath, resolveHooksDir } from './install-hooks.js';
+
 // ─── Constants ──────────────────────────────────────────
 
 const TAG = 'Eject';
@@ -37,18 +39,67 @@ export interface EjectSummary {
 }
 
 /**
+ * Resolved git-hook context for eject (mmnto-ai/totem#2426).
+ *
+ * `.git` is a DIRECTORY in a plain checkout / main working tree and a POINTER
+ * FILE in a linked worktree (or submodule), where the hooks git actually runs
+ * live in the SHARED common dir — so a blind `.git/hooks` join from `cwd` (the
+ * pre-fix behavior) silently no-oped in a worktree AND missed the git root when
+ * eject was run from a subdirectory.
+ */
+export interface EjectHooksContext {
+  /**
+   * The resolved git hooks directory (via the #2422 `resolveHooksDir` helper —
+   * worktree/`commondir`/`core.hooksPath`-aware), or `null` when no repo/hooks
+   * dir could be resolved (not-a-repo, unparseable `.git` pointer).
+   */
+  hooksDir: string | null;
+  /**
+   * `.git` is a POINTER FILE — a linked worktree (or submodule) whose resolved
+   * hooks dir is SHARED across every worktree of the repo.
+   */
+  isLinkedWorktree: boolean;
+}
+
+/**
+ * Resolve where eject should look for git hooks, reusing the SAME helpers every
+ * `hook install` entry point uses (mmnto-ai/totem#2426, sibling of #2422): the
+ * git root via `resolveGitRootForHookPath` (anchors from a subdirectory; maps an
+ * unparseable pointer to a null root) and the hooks dir via `resolveHooksDir`
+ * (git's own worktree/`commondir` walk). Best-effort per Tenet 4's eject
+ * cleanup carve-out — a genuine git failure is reported as unresolvable, never a
+ * crash of the whole eject.
+ */
+export function resolveEjectHooksContext(cwd: string): EjectHooksContext {
+  let gitRoot: string | null;
+  try {
+    ({ gitRoot } = resolveGitRootForHookPath(cwd));
+  } catch {
+    return { hooksDir: null, isLinkedWorktree: false };
+  }
+  if (!gitRoot) {
+    return { hooksDir: null, isLinkedWorktree: false };
+  }
+  const dotGit = path.join(gitRoot, '.git');
+  const isLinkedWorktree = fs.existsSync(dotGit) && fs.statSync(dotGit).isFile();
+  return { hooksDir: resolveHooksDir(gitRoot), isLinkedWorktree };
+}
+
+/**
  * Generic hook scrubber — removes Totem block from a git hook file.
  * Uses deterministic end marker when present, falls back to heuristic for old format.
+ * `hooksDir` is the RESOLVED git hooks directory (mmnto-ai/totem#2426), not a
+ * blind `<cwd>/.git/hooks` join.
  */
 function scrubHook(
-  cwd: string,
+  hooksDir: string,
   summary: EjectSummary,
   hookName: string,
   startMarker: string,
   endMarker: string,
 ): void {
   const hookFileName = `.git/hooks/${hookName}`;
-  const hookPath = path.join(cwd, hookFileName);
+  const hookPath = path.join(hooksDir, hookName);
   if (!fs.existsSync(hookPath)) {
     summary.skipped.push(`${hookFileName} (not found)`);
     return;
@@ -113,17 +164,19 @@ function scrubHook(
 /**
  * Remove the Totem section from the post-merge git hook.
  * Deletes the file entirely if it only contains the Totem hook.
+ * `hooksDir` is the resolved git hooks directory (mmnto-ai/totem#2426).
  */
-export function scrubPostMergeHook(cwd: string, summary: EjectSummary): void {
-  scrubHook(cwd, summary, 'post-merge', TOTEM_HOOK_MARKER, TOTEM_HOOK_END);
+export function scrubPostMergeHook(hooksDir: string, summary: EjectSummary): void {
+  scrubHook(hooksDir, summary, 'post-merge', TOTEM_HOOK_MARKER, TOTEM_HOOK_END);
 }
 
 /**
  * Remove the Totem section from the post-checkout git hook.
  * Deletes the file entirely if it only contains the Totem hook.
+ * `hooksDir` is the resolved git hooks directory (mmnto-ai/totem#2426).
  */
-export function scrubPostCheckoutHook(cwd: string, summary: EjectSummary): void {
-  scrubHook(cwd, summary, 'post-checkout', TOTEM_CHECKOUT_MARKER, TOTEM_CHECKOUT_END);
+export function scrubPostCheckoutHook(hooksDir: string, summary: EjectSummary): void {
+  scrubHook(hooksDir, summary, 'post-checkout', TOTEM_CHECKOUT_MARKER, TOTEM_CHECKOUT_END);
 }
 
 /**
@@ -493,9 +546,41 @@ export async function ejectCommand(options: EjectOptions): Promise<void> {
 
   const summary: EjectSummary = { removed: [], scrubbed: [], skipped: [] };
 
-  // 1. Scrub git hooks
-  scrubPostMergeHook(cwd, summary);
-  scrubPostCheckoutHook(cwd, summary);
+  // 1. Scrub git hooks — worktree-aware (mmnto-ai/totem#2426). The pre-fix code
+  //    blind-joined `<cwd>/.git/hooks/<name>`, so in a linked worktree (where
+  //    `.git` is a gitdir POINTER FILE and hooks live in the shared common dir)
+  //    every hook reported "not found" and the eject silently no-oped. Resolve
+  //    the real hooks dir via the #2422 helpers instead.
+  const hooks = resolveEjectHooksContext(cwd);
+  if (hooks.isLinkedWorktree) {
+    // Conservative decline (mmnto-ai/totem#2426 semantics question, left
+    // deliberately UNRESOLVED by the issue): the resolved hooks dir is SHARED
+    // across every worktree of this repo, so scrubbing it from one linked
+    // worktree silently changes hook behavior for the main checkout and every
+    // sibling worktree. Rather than take that cross-worktree destructive action
+    // on a bug-fix — or invent the "eject-from-worktree removes shared hooks"
+    // policy (symmetric with install, but the issue flags it as owing its own
+    // ruling) — decline the git-hook removal and point at the main working tree.
+    // Everything else eject removes below is per-working-tree, so it still runs.
+    const sharedLoc = hooks.hooksDir ? ` (${hooks.hooksDir})` : '';
+    for (const name of ['post-merge', 'post-checkout']) {
+      summary.skipped.push(
+        `.git/hooks/${name} (shared across worktrees — run \`totem eject\` from the main working tree to remove)`,
+      );
+    }
+    log.warn(
+      TAG,
+      `Git hooks live in the shared git directory${sharedLoc}, used by every worktree of this repo — skipping hook removal. Run \`totem eject\` from the main working tree to remove them.`,
+    );
+  } else if (!hooks.hooksDir) {
+    // Not a git repo, or an unparseable `.git` pointer — nothing to resolve.
+    for (const name of ['post-merge', 'post-checkout']) {
+      summary.skipped.push(`.git/hooks/${name} (git hooks directory could not be resolved)`);
+    }
+  } else {
+    scrubPostMergeHook(hooks.hooksDir, summary);
+    scrubPostCheckoutHook(hooks.hooksDir, summary);
+  }
 
   // 2. Remove scaffolded Gemini/Claude hook files
   removeScaffoldedFiles(cwd, summary);

--- a/packages/cli/src/commands/eject.ts
+++ b/packages/cli/src/commands/eject.ts
@@ -77,10 +77,10 @@ export async function resolveEjectHooksContext(cwd: string): Promise<EjectHooksC
   let gitRoot: string | null;
   try {
     ({ gitRoot } = resolveGitRootForHookPath(cwd));
-    // totem-context: intentional cleanup — eject is best-effort per Tenet 4's
-    // cleanup carve-out; a genuine git failure (NOT not-a-repo / unparseable
-    // pointer, which return a null root without throwing) degrades to
-    // "unresolvable" rather than crashing the whole eject.
+    // Eject is best-effort per Tenet 4's cleanup carve-out: a genuine git failure
+    // (NOT not-a-repo / unparseable pointer, which return a null root WITHOUT
+    // throwing) degrades to "unresolvable" rather than crashing the whole eject.
+    // totem-context: intentional cleanup — best-effort git resolution for eject.
   } catch {
     return { hooksDir: null, isLinkedWorktree: false };
   }

--- a/packages/cli/src/commands/eject.ts
+++ b/packages/cli/src/commands/eject.ts
@@ -1,8 +1,6 @@
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 
-import { resolveGitRootForHookPath, resolveHooksDir } from './install-hooks.js';
-
 // ─── Constants ──────────────────────────────────────────
 
 const TAG = 'Eject';
@@ -66,12 +64,21 @@ export interface EjectHooksContext {
  * `hook install` entry point uses (mmnto-ai/totem#2426, sibling of #2422): the
  * git root via `resolveGitRootForHookPath` (anchors from a subdirectory; maps an
  * unparseable pointer to a null root) and the hooks dir via `resolveHooksDir`
- * (git's own worktree/`commondir` walk). Best-effort per Tenet 4's eject
+ * (git's own worktree/`commondir` walk — the rev-parse root resolution the
+ * hardcode-`.git/hooks` lesson prescribes). Best-effort per Tenet 4's eject
  * cleanup carve-out — a genuine git failure is reported as unresolvable, never a
  * crash of the whole eject.
  */
-export function resolveEjectHooksContext(cwd: string): EjectHooksContext {
+export async function resolveEjectHooksContext(cwd: string): Promise<EjectHooksContext> {
+  // Lazy-load the hook-path resolvers: they pull the core git barrel, so keeping
+  // them off the static graph preserves this command file's cold-start discipline
+  // (the same dynamic-import pattern `scrubClaudeSkills`/`ejectCommand` use).
+  const { resolveGitRootForHookPath, resolveHooksDir } = await import('./install-hooks.js');
   let gitRoot: string | null;
+  // totem-context: intentional cleanup — eject is best-effort per Tenet 4's
+  // cleanup carve-out; a genuine git failure degrades to "unresolvable", never a
+  // crash of the whole eject. (Not-a-repo / unparseable pointer already return a
+  // null root without throwing; this guards the residual "git broke" class.)
   try {
     ({ gitRoot } = resolveGitRootForHookPath(cwd));
   } catch {
@@ -80,6 +87,10 @@ export function resolveEjectHooksContext(cwd: string): EjectHooksContext {
   if (!gitRoot) {
     return { hooksDir: null, isLinkedWorktree: false };
   }
+  // Worktree detection: git resolved the root, so the root itself is trusted;
+  // `.git` here is only probed for its SHAPE — a pointer FILE marks a linked
+  // worktree whose hooks are shared — not used to locate the root (that came
+  // from rev-parse above).
   const dotGit = path.join(gitRoot, '.git');
   const isLinkedWorktree = fs.existsSync(dotGit) && fs.statSync(dotGit).isFile();
   return { hooksDir: resolveHooksDir(gitRoot), isLinkedWorktree };
@@ -551,7 +562,7 @@ export async function ejectCommand(options: EjectOptions): Promise<void> {
   //    `.git` is a gitdir POINTER FILE and hooks live in the shared common dir)
   //    every hook reported "not found" and the eject silently no-oped. Resolve
   //    the real hooks dir via the #2422 helpers instead.
-  const hooks = resolveEjectHooksContext(cwd);
+  const hooks = await resolveEjectHooksContext(cwd);
   if (hooks.isLinkedWorktree) {
     // Conservative decline (mmnto-ai/totem#2426 semantics question, left
     // deliberately UNRESOLVED by the issue): the resolved hooks dir is SHARED

--- a/packages/cli/src/commands/gate-install.test.ts
+++ b/packages/cli/src/commands/gate-install.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { knownGateEvents, TotemError } from '@mmnto/totem';
 
@@ -12,6 +12,29 @@ import { gateInstallCommand, resolveGateEvents } from './gate.js';
 import { commandInstallsGate, GATE_WRAPPER_REL, installGates } from './gate-install.js';
 import { initCommand } from './init.js';
 import { CLAUDE_GATE_WRAPPER, TOTEM_FILE_END, TOTEM_FILE_MARKER } from './init-templates.js';
+import { resolveGitRootForHookPath, resolveHooksDir } from './install-hooks.js';
+
+// The eject-parity tests below drive `ejectCommand`, which (mmnto-ai/totem#2426)
+// now resolves the git root + hooks dir via the #2422 helpers. Mock that seam so
+// no real `git` is spawned in a temp dir; only eject imports these two exports,
+// so the gate/init tests here are unaffected. Default: git root = cwd, hooks dir
+// = <root>/.git/hooks (matching the plain `.git/hooks` fixtures these tests build).
+vi.mock('./install-hooks.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./install-hooks.js')>();
+  return {
+    ...actual,
+    resolveGitRootForHookPath: vi.fn(),
+    resolveHooksDir: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.mocked(resolveGitRootForHookPath).mockImplementation((c: string) => ({
+    gitRoot: c,
+    unparseablePointer: false,
+  }));
+  vi.mocked(resolveHooksDir).mockImplementation((root: string) => path.join(root, '.git', 'hooks'));
+});
 
 /**
  * CLI-seam tests for `totem gate install` + the parameterized gate wrapper

--- a/packages/cli/src/commands/install-hooks.ts
+++ b/packages/cli/src/commands/install-hooks.ts
@@ -91,8 +91,12 @@ function isUnparseableGitFileError(err: unknown): boolean {
  * #2410 declared skip on it, including the hidden legacy `totem install-hooks`
  * command and the direct `installHooksNonInteractive` API (#2422 review round:
  * only `hooksCommand` was guarded). All other failures stay fail-loud.
+ *
+ * Exported so the hook-REMOVAL path (`eject`) resolves the git root the SAME way
+ * every install entry point does, instead of hand-rolling a second resolver
+ * (mmnto-ai/totem#2426).
  */
-function resolveGitRootForHookPath(cwd: string): {
+export function resolveGitRootForHookPath(cwd: string): {
   gitRoot: string | null;
   unparseablePointer: boolean;
 } {


### PR DESCRIPTION
Closes #2426

## Root cause (the #2418 sibling)

The eject hook scrubber blind-joined `<cwd>/.git/hooks/<name>`. In a linked worktree `.git` is a `gitdir:` pointer FILE and the hooks git actually runs live in the shared common dir — so every hook reported "not found" and eject silently no-oped (the Tenet-4 silent-miss the issue names). The same blind join also missed the git root when eject ran from a subdirectory.

## Fix

- Eject now resolves the hooks directory through the SAME helpers every `hook install` entry point uses since #2422: `resolveGitRootForHookPath` (exported from install-hooks.ts rather than duplicated — anchors from subdirectories, maps an unparseable `.git` pointer to a null root) + `resolveHooksDir` (git's own worktree/`commondir`/`core.hooksPath` walk). No second resolver.
- `scrubHook`/`scrubPostMergeHook`/`scrubPostCheckoutHook` take the resolved `hooksDir` instead of `cwd`.
- Three honest branches in `ejectCommand`: plain/main checkout → scrub via the resolved dir; unresolvable (not-a-repo / unparseable pointer) → declared skip with reason; **linked worktree → conservative decline** — the resolved dir is shared across the main checkout and every sibling worktree, so hook removal is skipped with a prominent warning naming the shared location and directing to the main working tree. All other eject cleanup is per-working-tree and still runs from a worktree.

**The decline-vs-scrub policy is deliberately NOT ruled here** — the issue flagged it as owing its own ruling. Follow-up venue: #2432 (flipping to install-symmetric scrub is a one-branch change if ruled that way). What this PR guarantees either way: no more silent no-op.

## Verification

- 7 new tests (eject.test.ts 28 → 35): resolver unit cases (subdirectory anchoring, unparseable pointer → null, pointer-file → worktree) + command cases (worktree decline leaves shared hooks INTACT, unresolvable-dir declared skip). New/touched tests mock the git seam — no real `git` spawned in temp dirs; gate-install.test.ts got the same mock so its eject-parity tests don't transitively spawn git.
- Full workspace gates: `pnpm -r build` PASS; full `pnpm test` PASS (3342 tests, 10 tasks); repo-wide `format:check` PASS; `totem lint --base main` 0 errors (57 warnings: the freeze-era stale-manifest exempt class + heuristic-lesson over-matches on standard test/hook idioms identical to what the existing test files already carry). Both real lint findings fixed during the build: fail-open-catch annotated per the compile.ts precedent, static barrel import moved to the file's own lazy-load discipline.

Branch is 4 commits (core fix + three lint-placement iterations, unamended per AGENTS.md); squash-merge collapses them.

Changeset: patch `@mmnto/cli`.

Provenance: implemented by an Opus 4.8 builder under totem-claude orchestration (2026-07-18 quota-stretch directive); diff, resolver-reuse, decline semantics, and gates reviewed by totem-claude before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
