### PR TITLE
feat(cli): doctor --strict=warn tier — machine-checkable all-wiring oracle

### DIFF
--- a/.changeset/doctor-strict-warn-tier.md
+++ b/.changeset/doctor-strict-warn-tier.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/cli': patch
+---
+
+`totem doctor --strict=warn` — a strict-warn tier for the doctor gate. Warn-class diagnostics (Compiled Rules, Git Hooks, Index wiring) now exit non-zero alongside fail-class ones, giving CI and agents a single machine-checkable all-wiring oracle instead of parsing prose. Bare `--strict` is unchanged (fail-class only), and `--strict=<unknown>` fails loud with the valid tier list. Closes #2385.

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Then verify the wiring:
 pnpm dlx @mmnto/cli doctor --strict
 ```
 
-`doctor --strict` reports config, hooks, rules, and index wiring, and exits non-zero on fail-class diagnostics. Read and resolve its warnings before treating setup as complete; if an agent is running this setup for you, that is its checklist too.
+`doctor --strict` reports config, hooks, rules, and index wiring, and exits non-zero on fail-class diagnostics. Read and resolve its warnings before treating setup as complete; if an agent is running this setup for you, that is its checklist too. For a machine-checkable all-wiring oracle in CI, `--strict=warn` also exits non-zero on warn-class diagnostics.
 
 The npm packages declare `engines.node >= 24` deliberately: Node 24 (LTS since 2025-10) is the runtime CI actually tests and the one the publishing pipeline (npm 11 / OIDC) runs on — a floor we exercise rather than one we claim. On CI images pinned to older Node, use the Lite binary below instead.
 

--- a/docs/wiki/cli-reference.md
+++ b/docs/wiki/cli-reference.md
@@ -45,7 +45,7 @@ Outputs a structured description of the project's governance parameters for MCP 
 Runs a battery of automated health checks to verify config bloat, index health, hook wiring, and secret hygiene.
 
 - **Flags:**
-  - `--strict`: Exits non-zero when critical checks fail.
+  - `--strict [tier]`: Exits non-zero when critical checks fail. `--strict=warn` also gates on warn-class diagnostics, giving CI a single machine-checkable all-wiring oracle (bare `--strict` keeps the fail-only contract).
   - `--pr`: Analyzes the Trap Ledger and downgrades rules with a >30% bypass rate, staging the changes as a GitHub Pull Request for review (the rule-tuning loop).
 
 ### `totem status` / `totem check`

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -27,11 +27,13 @@ import {
   checkUpgradeCandidates,
   CLAUDE_MD_REDIRECT_MAX_BYTES,
   doctorCommand,
+  doctorGateFailed,
   findLegacyGrandfatheredRules,
   findStaleRules,
   MIN_CONTEXT_EVENTS,
   MIN_EVENTS,
   NON_CODE_THRESHOLD,
+  resolveStrictTier,
   runSelfHealing,
   V_1_13_0_SHIP_DATE_ISO,
 } from './doctor.js';
@@ -609,6 +611,60 @@ describe('doctorCommand strict mode contract', () => {
     expect(resultsStrict.map((r: DiagnosticResult) => r.name)).toEqual(
       resultsLoose.map((r: DiagnosticResult) => r.name),
     );
+  });
+});
+
+// ─── Strict-warn tier (mmnto-ai/totem#2385) ─────────────
+//
+// `--strict=warn` upgrades the CLI-edge gate so warn-class diagnostics also
+// exit non-zero — the machine-checkable all-wiring oracle. These helpers are
+// pure; the exit-code mapping itself stays at the CLI edge.
+
+describe('resolveStrictTier', () => {
+  it('returns undefined when strict mode is off', () => {
+    expect(resolveStrictTier(undefined)).toBeUndefined();
+    expect(resolveStrictTier(false)).toBeUndefined();
+  });
+
+  it('maps the bare flag and the explicit fail tier to fail', () => {
+    expect(resolveStrictTier(true)).toBe('fail');
+    expect(resolveStrictTier('fail')).toBe('fail');
+  });
+
+  it('maps the warn tier', () => {
+    expect(resolveStrictTier('warn')).toBe('warn');
+  });
+
+  it('throws fail-loud on an unknown tier', () => {
+    expect(() => resolveStrictTier('banana')).toThrow('Unknown --strict tier "banana"');
+    expect(() => resolveStrictTier('')).toThrow('Unknown --strict tier');
+  });
+});
+
+describe('doctorGateFailed', () => {
+  const clean: DiagnosticResult[] = [
+    { name: 'A', status: 'pass', message: '' },
+    { name: 'B', status: 'skip', message: '' },
+  ];
+  const withWarn: DiagnosticResult[] = [...clean, { name: 'C', status: 'warn', message: '' }];
+  const withFail: DiagnosticResult[] = [...clean, { name: 'D', status: 'fail', message: '' }];
+
+  it('fail tier gates on fail only (pre-#2385 contract)', () => {
+    expect(doctorGateFailed(clean, 'fail')).toBe(false);
+    expect(doctorGateFailed(withWarn, 'fail')).toBe(false);
+    expect(doctorGateFailed(withFail, 'fail')).toBe(true);
+  });
+
+  it('warn tier gates on warn and fail (all-wiring oracle)', () => {
+    expect(doctorGateFailed(clean, 'warn')).toBe(false);
+    expect(doctorGateFailed(withWarn, 'warn')).toBe(true);
+    expect(doctorGateFailed(withFail, 'warn')).toBe(true);
+  });
+
+  it('skip never gates in either tier', () => {
+    const onlySkip: DiagnosticResult[] = [{ name: 'S', status: 'skip', message: '' }];
+    expect(doctorGateFailed(onlySkip, 'fail')).toBe(false);
+    expect(doctorGateFailed(onlySkip, 'warn')).toBe(false);
   });
 });
 

--- a/packages/cli/src/commands/doctor.test.ts
+++ b/packages/cli/src/commands/doctor.test.ts
@@ -621,23 +621,23 @@ describe('doctorCommand strict mode contract', () => {
 // pure; the exit-code mapping itself stays at the CLI edge.
 
 describe('resolveStrictTier', () => {
-  it('returns undefined when strict mode is off', () => {
-    expect(resolveStrictTier(undefined)).toBeUndefined();
-    expect(resolveStrictTier(false)).toBeUndefined();
+  it('returns undefined when strict mode is off', async () => {
+    await expect(resolveStrictTier(undefined)).resolves.toBeUndefined();
+    await expect(resolveStrictTier(false)).resolves.toBeUndefined();
   });
 
-  it('maps the bare flag and the explicit fail tier to fail', () => {
-    expect(resolveStrictTier(true)).toBe('fail');
-    expect(resolveStrictTier('fail')).toBe('fail');
+  it('maps the bare flag and the explicit fail tier to fail', async () => {
+    await expect(resolveStrictTier(true)).resolves.toBe('fail');
+    await expect(resolveStrictTier('fail')).resolves.toBe('fail');
   });
 
-  it('maps the warn tier', () => {
-    expect(resolveStrictTier('warn')).toBe('warn');
+  it('maps the warn tier', async () => {
+    await expect(resolveStrictTier('warn')).resolves.toBe('warn');
   });
 
-  it('throws fail-loud on an unknown tier', () => {
-    expect(() => resolveStrictTier('banana')).toThrow('Unknown --strict tier "banana"');
-    expect(() => resolveStrictTier('')).toThrow('Unknown --strict tier');
+  it('throws fail-loud on an unknown tier', async () => {
+    await expect(resolveStrictTier('banana')).rejects.toThrow('Unknown --strict tier "banana"');
+    await expect(resolveStrictTier('')).rejects.toThrow('Unknown --strict tier');
   });
 });
 

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -4,6 +4,8 @@ import * as path from 'node:path';
 
 import pc from 'picocolors';
 
+import { TotemConfigError } from '@mmnto/totem';
+
 import { resolveGitRoot } from '../git.js';
 import { CONFIG_FILES } from '../utils.js';
 
@@ -16,6 +18,48 @@ export interface DiagnosticResult {
   status: CheckStatus;
   message: string;
   remediation?: string;
+}
+
+// ─── Strict-gate tiers (mmnto-ai/totem#2385) ────────────
+
+/**
+ * Gating tiers for `totem doctor --strict [tier]`:
+ * - `fail` (bare `--strict`): exit non-zero on fail-class diagnostics only —
+ *   the pre-#2385 boolean contract.
+ * - `warn`: exit non-zero on warn- OR fail-class diagnostics — the
+ *   machine-checkable all-wiring oracle for CI / agent consumers.
+ *
+ * `skip` never gates in either tier: it marks checks that are intentionally
+ * inapplicable (e.g. unconfigured optional wiring), not gaps.
+ */
+export type StrictTier = 'fail' | 'warn';
+
+export const STRICT_TIERS: readonly StrictTier[] = ['fail', 'warn'];
+
+/**
+ * Resolve the raw commander `--strict [tier]` value into a StrictTier.
+ * `true` (bare flag) maps to `'fail'`. Returns `undefined` when strict mode
+ * is off. Throws on an unknown tier (fail-loud, Tenet 4 — a silently ignored
+ * tier would let a consumer believe it gated on more than it did).
+ */
+export function resolveStrictTier(strict: boolean | string | undefined): StrictTier | undefined {
+  if (strict === undefined || strict === false) return undefined;
+  if (strict === true || strict === 'fail') return 'fail';
+  if (strict === 'warn') return 'warn';
+  throw new TotemConfigError(
+    `Unknown --strict tier "${strict}".`,
+    `Valid tiers: ${STRICT_TIERS.join(', ')} (bare --strict selects the fail tier).`,
+    'CONFIG_INVALID',
+  );
+}
+
+/**
+ * The gate predicate the CLI edge applies to `doctorCommand` results. Kept
+ * pure and exported so the edge stays thin and the semantics stay unit-tested
+ * (the exit-code decision itself lives at the CLI edge — see DoctorOptions).
+ */
+export function doctorGateFailed(results: readonly DiagnosticResult[], tier: StrictTier): boolean {
+  return results.some((r) => r.status === 'fail' || (tier === 'warn' && r.status === 'warn'));
 }
 
 // ─── Secret leak patterns ───────────────────────────────
@@ -1415,15 +1459,18 @@ export async function checkGrandfatheredRules(
 export interface DoctorOptions {
   pr?: boolean;
   /**
-   * When true, callers should treat any `fail` diagnostic as a gating
-   * condition (exit non-zero). The flag itself doesn't change what
-   * `doctorCommand` returns — the exit-code decision lives at the CLI edge
-   * so this function stays composable and free of process-exit side effects.
+   * Raw commander `--strict [tier]` value (`true` for the bare flag, a string
+   * for `--strict=<tier>`). When set, callers should treat gate-class
+   * diagnostics as a gating condition (exit non-zero) — resolve via
+   * `resolveStrictTier` and apply `doctorGateFailed` at the CLI edge. The flag
+   * itself doesn't change what `doctorCommand` returns — the exit-code
+   * decision lives at the CLI edge so this function stays composable and free
+   * of process-exit side effects.
    *
    * Reference: mmnto-ai/totem#1908 (Proposal 273 § 6 Q2 / § 7 routing matrix
-   * row 5).
+   * row 5); mmnto-ai/totem#2385 (warn tier — the all-wiring oracle).
    */
-  strict?: boolean;
+  strict?: boolean | string;
 }
 
 // ─── Self-healing flow ──────────────────────────────────

--- a/packages/cli/src/commands/doctor.ts
+++ b/packages/cli/src/commands/doctor.ts
@@ -4,8 +4,6 @@ import * as path from 'node:path';
 
 import pc from 'picocolors';
 
-import { TotemConfigError } from '@mmnto/totem';
-
 import { resolveGitRoot } from '../git.js';
 import { CONFIG_FILES } from '../utils.js';
 
@@ -41,11 +39,16 @@ export const STRICT_TIERS: readonly StrictTier[] = ['fail', 'warn'];
  * `true` (bare flag) maps to `'fail'`. Returns `undefined` when strict mode
  * is off. Throws on an unknown tier (fail-loud, Tenet 4 — a silently ignored
  * tier would let a consumer believe it gated on more than it did).
+ * Async solely so the error class rides the dynamic-import convention (no
+ * static `@mmnto/totem` import in command handlers — CLI startup latency).
  */
-export function resolveStrictTier(strict: boolean | string | undefined): StrictTier | undefined {
+export async function resolveStrictTier(
+  strict: boolean | string | undefined,
+): Promise<StrictTier | undefined> {
   if (strict === undefined || strict === false) return undefined;
   if (strict === true || strict === 'fail') return 'fail';
   if (strict === 'warn') return 'warn';
+  const { TotemConfigError } = await import('@mmnto/totem');
   throw new TotemConfigError(
     `Unknown --strict tier "${strict}".`,
     `Valid tiers: ${STRICT_TIERS.join(', ')} (bare --strict selects the fail tier).`,

--- a/packages/cli/src/index-lite.ts
+++ b/packages/cli/src/index-lite.ts
@@ -198,7 +198,7 @@ program
     try {
       const { doctorCommand, doctorGateFailed, resolveStrictTier } =
         await import('./commands/doctor.js');
-      const strictTier = resolveStrictTier(opts.strict);
+      const strictTier = await resolveStrictTier(opts.strict);
       const results = await doctorCommand(opts);
       if (strictTier && doctorGateFailed(results, strictTier)) {
         process.exitCode = 1;

--- a/packages/cli/src/index-lite.ts
+++ b/packages/cli/src/index-lite.ts
@@ -191,14 +191,16 @@ program
   .description('Run workspace health diagnostics')
   .option('--pr', 'Auto-downgrade noisy rules and open a PR')
   .option(
-    '--strict',
-    'Exit non-zero if any check reports a `fail` status (gating mode for hooks / CI)',
+    '--strict [tier]',
+    'Exit non-zero on fail-class diagnostics (gating mode for hooks / CI); --strict=warn also gates on warn-class diagnostics — the machine-checkable all-wiring oracle (mmnto-ai/totem#2385)',
   )
-  .action(async (opts: { pr?: boolean; strict?: boolean }) => {
+  .action(async (opts: { pr?: boolean; strict?: boolean | string }) => {
     try {
-      const { doctorCommand } = await import('./commands/doctor.js');
+      const { doctorCommand, doctorGateFailed, resolveStrictTier } =
+        await import('./commands/doctor.js');
+      const strictTier = resolveStrictTier(opts.strict);
       const results = await doctorCommand(opts);
-      if (opts.strict && results.some((r) => r.status === 'fail')) {
+      if (strictTier && doctorGateFailed(results, strictTier)) {
         process.exitCode = 1;
       }
     } catch (err) {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1382,8 +1382,8 @@ program
   .description('Run workspace health diagnostics')
   .option('--pr', 'Auto-downgrade noisy rules and open a PR')
   .option(
-    '--strict',
-    'Exit non-zero if any check reports a `fail` status (gating mode for hooks / CI)',
+    '--strict [tier]',
+    'Exit non-zero on fail-class diagnostics (gating mode for hooks / CI); --strict=warn also gates on warn-class diagnostics — the machine-checkable all-wiring oracle (mmnto-ai/totem#2385)',
   )
   .option(
     '--claim-discipline',
@@ -1409,7 +1409,7 @@ program
     async (
       opts: {
         pr?: boolean;
-        strict?: boolean;
+        strict?: boolean | string;
         claimDiscipline?: boolean;
         scopeToDiff?: boolean;
         parity?: boolean;
@@ -1425,6 +1425,11 @@ program
         // scopes so `totem doctor --parity --json` and `totem --json doctor
         // --parity` agree.
         opts.json = cmd.optsWithGlobals<{ json?: boolean }>().json;
+        // Resolve the strict tier up front so an unknown `--strict=<tier>`
+        // errors identically across every doctor mode (mmnto-ai/totem#2385).
+        const { doctorCommand, doctorGateFailed, resolveStrictTier } =
+          await import('./commands/doctor.js');
+        const strictTier = resolveStrictTier(opts.strict);
         const specializedModes = [
           opts.claimDiscipline && '--claim-discipline',
           opts.parity && '--parity',
@@ -1448,14 +1453,14 @@ program
           const { doctorClaimDisciplineCliCommand } =
             await import('./commands/doctor-claim-discipline.js');
           await doctorClaimDisciplineCliCommand({
-            strict: opts.strict,
+            strict: strictTier !== undefined,
             scopeToDiff: opts.scopeToDiff,
           });
           return;
         }
         if (opts.parity) {
           const { doctorParityCliCommand } = await import('./commands/doctor-parity.js');
-          await doctorParityCliCommand({ strict: opts.strict, json: opts.json });
+          await doctorParityCliCommand({ strict: strictTier !== undefined, json: opts.json });
           return;
         }
         if (opts.compliance) {
@@ -1466,9 +1471,8 @@ program
           await doctorComplianceCliCommand();
           return;
         }
-        const { doctorCommand } = await import('./commands/doctor.js');
         const results = await doctorCommand(opts);
-        if (opts.strict && results.some((r) => r.status === 'fail')) {
+        if (strictTier && doctorGateFailed(results, strictTier)) {
           process.exitCode = 1;
         }
         // S0 (mmnto-ai/totem#2085, mmnto-ai/totem-strategy#545 Half 2): fold parity
@@ -1479,7 +1483,7 @@ program
         // never configured a manifest — zero churn for non-adopters. Per ADR-109 /
         // Tenet 13 the throw-gate lives here at the CLI edge, not inside the composable
         // doctorCommand. The `--parity` branch returned above, so this never double-runs.
-        if (opts.strict) {
+        if (strictTier) {
           const { doctorParityCliCommand } = await import('./commands/doctor-parity.js');
           await doctorParityCliCommand({ strict: true, onlyWhenConfigured: true });
         }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1429,7 +1429,7 @@ program
         // errors identically across every doctor mode (mmnto-ai/totem#2385).
         const { doctorCommand, doctorGateFailed, resolveStrictTier } =
           await import('./commands/doctor.js');
-        const strictTier = resolveStrictTier(opts.strict);
+        const strictTier = await resolveStrictTier(opts.strict);
         const specializedModes = [
           opts.claimDiscipline && '--claim-discipline',
           opts.parity && '--parity',


### PR DESCRIPTION
## Summary

Implements the strict-warn tier from #2385: `totem doctor --strict=warn` exits non-zero when **warn-class** diagnostics (Compiled Rules, Git Hooks, Index wiring) fire alongside fail-class ones — a single falsifiable all-wiring exit condition CI and agents can consume as an oracle, instead of parsing prose.

Chose the strict-warn tier over the `--gate <classes>` shape (the issue allows either): it extends the existing `--strict` pattern directly, needs no new class-naming registry, and delivers the issue's primary ask ("everything wired" as one exit code) with the smallest surface.

## Semantics

| Invocation | Gate |
|---|---|
| `totem doctor` | sensor only, always exit 0 (unchanged) |
| `totem doctor --strict` | exit 1 on fail-class only (unchanged) |
| `totem doctor --strict=fail` | same as bare `--strict` |
| `totem doctor --strict=warn` | exit 1 on warn- **or** fail-class — the all-wiring oracle |
| `totem doctor --strict=<other>` | fail-loud usage error listing valid tiers (Tenet 4) |

`skip` never gates in either tier — it marks intentionally inapplicable checks, not gaps.

## Design

- Gating stays at the CLI edge (`index.ts`, `index-lite.ts`); `doctorCommand` keeps its no-process-exit contract (existing test suite at `doctor.test.ts` "strict mode contract" locks this).
- New pure, exported helpers in `doctor.ts`: `resolveStrictTier` (commander value → tier, fail-loud on unknown) and `doctorGateFailed(results, tier)` — both unit-tested.
- Specialized modes (`--claim-discipline`, `--parity`) keep their existing boolean strict semantics; any armed tier coerces to `strict: true` there. Extending warn-tier semantics into those sensors is out of scope for this issue.
- `TotemConfigError` loads via dynamic import on the throw path only — no static `@mmnto/totem` import in command handlers (CLI startup-latency rule, caught by `totem lint` in review-fix commit 2).
- Default behavior unchanged (Tenet 13 — doctor stays a sensor; the gate is opt-in reference wiring, same pattern as the existing `--strict`).

## Gates (full workspace, branch `feat/2385-doctor-gate`)

- `pnpm -r build` — clean
- `pnpm test` — 10/10 turbo tasks green (run pre- and post-review-fix); the doctor suite itself is 114/114
- `pnpm run format:check` — clean
- `pnpm exec totem lint --base main` — PASS (0 errors; 9 advisory warnings, all false-positive classes: boolean `||` in guards flagged by the numeric-defaults `??` lesson, genuinely-async test callbacks, non-orchestrator suites)
- Live smoke: bare `--strict` → exit 0 with warnings present; `--strict=warn` → exit 1 on those warnings; `--strict=banana` → usage error + recovery hint

Docs: README quickstart line + `docs/wiki/cli-reference.md` flag entry updated. Patch changeset for `@mmnto/cli` included.

Closes #2385
