### PR TITLE
feat(core): generic fallback chunker — fourth-language-layer Stage 1 (Rust/GDScript index lockout)

### DIFF
--- a/.changeset/generic-chunker-fallback.md
+++ b/.changeset/generic-chunker-fallback.md
@@ -1,0 +1,7 @@
+---
+'@mmnto/totem': patch
+---
+
+Add a `generic` built-in chunk strategy — the chunker's fourth-language-layer Stage 1 (Proposal 256 Option A, mmnto-ai/totem#2387). A language-agnostic, fixed-size line-window chunker (with overlap) that gives retrieval-index coverage to source with no dedicated chunker yet (Rust, GDScript), closing the non-TypeScript index lockout.
+
+Selection is explicit-opt-in only (mmnto-ai/totem#2308): consumers reach it by naming `strategy: 'generic'` on a `totem.config.ts` target. It is a normal registered built-in, never an implicit catch-all — `createChunker` still fail-louds on an unknown/misspelled strategy per Tenet 4. Precision-poor by design; superseded per-language by the Stage 2 AST chunkers as they ship.

--- a/.changeset/generic-chunker-fallback.md
+++ b/.changeset/generic-chunker-fallback.md
@@ -4,4 +4,4 @@
 
 Add a `generic` built-in chunk strategy — the chunker's fourth-language-layer Stage 1 (Proposal 256 Option A, mmnto-ai/totem#2387). A language-agnostic, fixed-size line-window chunker (with overlap) that gives retrieval-index coverage to source with no dedicated chunker yet (Rust, GDScript), closing the non-TypeScript index lockout.
 
-Selection is explicit-opt-in only (mmnto-ai/totem#2308): consumers reach it by naming `strategy: 'generic'` on a `totem.config.ts` target. It is a normal registered built-in, never an implicit catch-all — `createChunker` still fail-louds on an unknown/misspelled strategy per Tenet 4. Precision-poor by design; superseded per-language by the Stage 2 AST chunkers as they ship.
+Selection is explicit-opt-in only (mmnto-ai/totem#2308): consumers reach it by naming `strategy: 'generic'` on a `totem.config.ts` target. It is a normal registered built-in rather than an implicit catch-all — `createChunker` still fail-louds on an unknown/misspelled strategy per Tenet 4. Precision-poor by design; superseded per-language by the Stage 2 AST chunkers as they ship.

--- a/packages/core/src/chunkers/chunker-registry.test.ts
+++ b/packages/core/src/chunkers/chunker-registry.test.ts
@@ -4,7 +4,7 @@
  * Covers invariants 4-9 + 11 (chunker side) from
  * `.totem/specs/pack-substrate-bundle.md`:
  *
- * - All five built-in chunkers self-register at module load.
+ * - All six built-in chunkers self-register at module load.
  * - Pack-style registration adds new entries.
  * - Re-registration of the same name throws.
  * - Registering a built-in name throws (immutable).
@@ -49,16 +49,19 @@ afterEach(() => {
 });
 
 describe('chunker-registry built-ins', () => {
-  it('registers all five built-in chunkers at module load', () => {
+  it('registers all six built-in chunkers at module load', () => {
     expect(lookup('session-log')).toBeDefined();
     expect(lookup('markdown-heading')).toBeDefined();
     expect(lookup('typescript-ast')).toBeDefined();
     expect(lookup('schema-file')).toBeDefined();
     expect(lookup('test-file')).toBeDefined();
+    // Fourth-language layer, Stage 1 (mmnto-ai/totem#2387, #2308).
+    expect(lookup('generic')).toBeDefined();
   });
 
   it('exposes registered names sorted alphabetically', () => {
     expect(registeredNames()).toEqual([
+      'generic',
       'markdown-heading',
       'schema-file',
       'session-log',
@@ -70,6 +73,7 @@ describe('chunker-registry built-ins', () => {
   it('marks built-ins as built-in', () => {
     expect(isBuiltin('markdown-heading')).toBe(true);
     expect(isBuiltin('typescript-ast')).toBe(true);
+    expect(isBuiltin('generic')).toBe(true);
     expect(isBuiltin('not-a-real-strategy')).toBe(false);
   });
 });

--- a/packages/core/src/chunkers/chunker-registry.ts
+++ b/packages/core/src/chunkers/chunker-registry.ts
@@ -19,6 +19,7 @@
  */
 
 import type { Chunker } from './chunker.js';
+import { GenericChunker } from './generic-chunker.js';
 import { MarkdownChunker } from './markdown-chunker.js';
 import { SchemaFileChunker } from './schema-file-chunker.js';
 import { SessionLogChunker } from './session-log-chunker.js';
@@ -152,6 +153,10 @@ function registerBuiltins(): void {
   registerBuiltin('typescript-ast', TypeScriptChunker);
   registerBuiltin('schema-file', SchemaFileChunker);
   registerBuiltin('test-file', TestFileChunker);
+  // Fourth-language layer, Stage 1: the language-agnostic generic fallback
+  // (mmnto-ai/totem#2387, Prop 256 Option A). Explicit-opt-in only — a normal
+  // built-in a consumer selects by name; never an implicit catch-all (#2308).
+  registerBuiltin('generic', GenericChunker);
 }
 
 registerBuiltins();

--- a/packages/core/src/chunkers/generic-chunker.test.ts
+++ b/packages/core/src/chunkers/generic-chunker.test.ts
@@ -91,6 +91,32 @@ func _ready():
     expect(chunks[1]!.endLine).toBe(61);
   });
 
+  it('trailing newline does not inflate endLine or mint a phantom window (greptile P1, #2442)', () => {
+    // Real source files end with a newline. A 60-line file + trailing \n splits
+    // into 61 elements; pre-fix the EOF check missed at 60-vs-61 and a second
+    // window [51-61] shipped with endLine one beyond the real last line.
+    const sixtyWithNewline =
+      Array.from({ length: 60 }, (_, i) => `line ${i + 1}`).join('\n') + '\n';
+    const chunks = chunker.chunk(sixtyWithNewline, 'x.rs', 'code');
+    expect(chunks.length).toBe(1);
+    expect(chunks[0]!.endLine).toBe(60);
+
+    // 61 real lines + trailing newline: same shape as the no-newline 61-line
+    // case — two windows, endLine 61, no phantom 62.
+    const sixtyOneWithNewline =
+      Array.from({ length: 61 }, (_, i) => `line ${i + 1}`).join('\n') + '\n';
+    const chunks61 = chunker.chunk(sixtyOneWithNewline, 'x.gd', 'code');
+    expect(chunks61.length).toBe(2);
+    expect(chunks61[1]!.endLine).toBe(61);
+
+    // A REAL run of trailing blank lines is not the phantom: only the single
+    // newline artifact is stripped; blank-window dropping handles the rest.
+    const withRealBlanks = 'line 1\nline 2\n\n\n';
+    const blankChunks = chunker.chunk(withRealBlanks, 'y.rs', 'code');
+    expect(blankChunks.length).toBe(1);
+    expect(blankChunks[0]!.content).toBe('line 1\nline 2\n\n');
+  });
+
   it('yields no chunks for empty content', () => {
     expect(chunker.chunk('', 'empty.rs', 'code')).toEqual([]);
   });

--- a/packages/core/src/chunkers/generic-chunker.test.ts
+++ b/packages/core/src/chunkers/generic-chunker.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for the generic fallback chunker — the fourth-language layer's Stage 1
+ * (mmnto-ai/totem#2387, `totem-strategy` Proposal 256 Option A; contract:
+ * mmnto-ai/totem#2308).
+ *
+ * Covers:
+ * - Language-agnostic chunking of the lockout cases (Rust, GDScript).
+ * - Fixed-size line windows with overlap + full coverage, no duplicate tail.
+ * - Empty / whitespace-only input yields zero chunks.
+ * - Regression-lock: registering `generic` does not degrade or hijack the
+ *   existing TS routing, and `createChunker` still fail-louds on an unknown
+ *   strategy (the #2308 explicit-opt-in / Tenet-4 constraint).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { createChunker } from './chunker.js';
+import { GenericChunker } from './generic-chunker.js';
+
+describe('GenericChunker', () => {
+  const chunker = new GenericChunker();
+
+  it('reports the generic strategy', () => {
+    expect(chunker.strategy).toBe('generic');
+  });
+
+  it('chunks Rust source (the index-lockout case) language-agnostically', () => {
+    const rust = `fn main() {
+    println!("hello, world");
+}`;
+    const chunks = chunker.chunk(rust, 'src/main.rs', 'code');
+
+    expect(chunks.length).toBe(1);
+    expect(chunks[0]!.strategy).toBe('generic');
+    expect(chunks[0]!.type).toBe('code');
+    expect(chunks[0]!.filePath).toBe('src/main.rs');
+    expect(chunks[0]!.content).toContain('fn main');
+    expect(chunks[0]!.startLine).toBe(1);
+    expect(chunks[0]!.endLine).toBe(3);
+    expect(chunks[0]!.label).toBe('src/main.rs:1-3');
+    expect(chunks[0]!.contextPrefix).toBe('File: src/main.rs | Lines: 1-3');
+  });
+
+  it('chunks GDScript source language-agnostically', () => {
+    const gd = `extends Node
+
+func _ready():
+    print("hi")`;
+    const chunks = chunker.chunk(gd, 'player.gd', 'code');
+
+    expect(chunks.length).toBe(1);
+    expect(chunks[0]!.strategy).toBe('generic');
+    expect(chunks[0]!.content).toContain('func _ready');
+    expect(chunks[0]!.startLine).toBe(1);
+    expect(chunks[0]!.endLine).toBe(4);
+  });
+
+  it('produces overlapping fixed-size windows with full coverage for large files', () => {
+    // 130 lines → windows of 60 advancing by 50: [1-60], [51-110], [101-130].
+    const lines = Array.from({ length: 130 }, (_, i) => `L${i + 1}`);
+    const content = lines.join('\n');
+    const chunks = chunker.chunk(content, 'big.rs', 'code');
+
+    expect(chunks.length).toBe(3);
+
+    expect(chunks[0]!.startLine).toBe(1);
+    expect(chunks[0]!.endLine).toBe(60);
+    expect(chunks[1]!.startLine).toBe(51);
+    expect(chunks[1]!.endLine).toBe(110);
+    expect(chunks[2]!.startLine).toBe(101);
+    expect(chunks[2]!.endLine).toBe(130);
+
+    // Adjacent windows overlap (share boundary context).
+    expect(chunks[1]!.startLine).toBeLessThanOrEqual(chunks[0]!.endLine);
+    expect(chunks[2]!.startLine).toBeLessThanOrEqual(chunks[1]!.endLine);
+
+    // Full coverage: first line through last line, all strategy 'generic'.
+    expect(chunks[0]!.content).toContain('L1');
+    expect(chunks[2]!.content).toContain('L130');
+    for (const c of chunks) {
+      expect(c.strategy).toBe('generic');
+    }
+  });
+
+  it('emits the final partial window exactly once (no duplicate tail chunk)', () => {
+    // 61 lines → [1-60] then [51-61]; the second window reaches EOF and stops.
+    const content = Array.from({ length: 61 }, (_, i) => `line ${i + 1}`).join('\n');
+    const chunks = chunker.chunk(content, 'x.rs', 'code');
+
+    expect(chunks.length).toBe(2);
+    expect(chunks[1]!.endLine).toBe(61);
+  });
+
+  it('yields no chunks for empty content', () => {
+    expect(chunker.chunk('', 'empty.rs', 'code')).toEqual([]);
+  });
+
+  it('yields no chunks for whitespace-only content', () => {
+    expect(chunker.chunk('\n\n   \n\t\n', 'blank.rs', 'code')).toEqual([]);
+  });
+});
+
+describe('GenericChunker registration (regression-lock)', () => {
+  it('createChunker routes the generic strategy to GenericChunker', () => {
+    const c = createChunker('generic');
+    expect(c).toBeInstanceOf(GenericChunker);
+    expect(c.strategy).toBe('generic');
+  });
+
+  it('does not hijack TS routing — typescript-ast still yields unchanged chunk counts', () => {
+    const tsChunker = createChunker('typescript-ast');
+    expect(tsChunker.strategy).toBe('typescript-ast');
+    expect(tsChunker).not.toBeInstanceOf(GenericChunker);
+
+    const code = `export function greet(name: string): string {
+  return \`Hello, \${name}\`;
+}
+`;
+    // Unchanged: a single function still chunks to exactly one chunk.
+    expect(tsChunker.chunk(code, 'src/utils.ts', 'code').length).toBe(1);
+  });
+
+  it('preserves fail-loud — an unknown strategy still throws (never a silent fallback)', () => {
+    // The generic chunker is explicit-opt-in only (mmnto-ai/totem#2308); a
+    // typo names a real misconfiguration and must NOT degrade to line-windows.
+    expect(() => createChunker('typo-strategy')).toThrowError(/Unknown chunk strategy/);
+  });
+});

--- a/packages/core/src/chunkers/generic-chunker.ts
+++ b/packages/core/src/chunkers/generic-chunker.ts
@@ -46,7 +46,17 @@ export class GenericChunker implements Chunker {
   readonly strategy: ChunkStrategy = 'generic';
 
   chunk(content: string, filePath: string, type: ContentType): Chunk[] {
-    const lines = content.split('\n');
+    const rawLines = content.split('\n');
+    // A file ending in a newline (the norm for real source) splits into a
+    // phantom empty final element — without stripping it, the EOF check misses
+    // by one and the final window over-reports `endLine` past the real last
+    // line (greptile P1 on #2442). Strip exactly ONE trailing empty element:
+    // it is the artifact of the final newline; further empties are REAL blank
+    // lines.
+    const lines =
+      rawLines.length > 0 && rawLines[rawLines.length - 1] === ''
+        ? rawLines.slice(0, -1)
+        : rawLines;
     const chunks: Chunk[] = [];
 
     for (let start = 0; start < lines.length; start += GENERIC_STEP_LINES) {

--- a/packages/core/src/chunkers/generic-chunker.ts
+++ b/packages/core/src/chunkers/generic-chunker.ts
@@ -1,0 +1,85 @@
+import type { ChunkStrategy, ContentType } from '../config-schema.js';
+import type { Chunk } from '../types.js';
+import type { Chunker } from './chunker.js';
+
+/**
+ * Generic Fallback Chunker — the fourth-language layer's Stage 1
+ * (mmnto-ai/totem#2387, `totem-strategy` Proposal 256 Option A).
+ *
+ * A language-agnostic, fixed-size line-window chunker with overlap. It carries
+ * no per-language semantics and does no AST parsing; it exists so that source
+ * with no dedicated chunker yet (Rust, GDScript, …) can be indexed for
+ * retrieval AT ALL instead of being locked out of the index. The embedding
+ * model carries the semantic resolution — this strategy is precision-poor by
+ * design (Tenet 19 consumer-impact framing) and is superseded per-language by
+ * the Stage 2 AST chunkers (`rust-ast`, …) as they ship.
+ *
+ * Selection is EXPLICIT-OPT-IN ONLY (mmnto-ai/totem#2308): a consumer reaches
+ * this strategy by NAMING `'generic'` on a target in `totem.config.ts`. It is
+ * a normal registered built-in like any other — it is NEVER an implicit
+ * catch-all. `createChunker('typo-strategy')` still fail-louds per Tenet 4; a
+ * misspelled strategy names a real misconfiguration and must not silently
+ * degrade to line-windows.
+ *
+ * Windowing: a sliding window of {@link GENERIC_WINDOW_LINES} lines advancing
+ * by {@link GENERIC_STEP_LINES} (window minus {@link GENERIC_OVERLAP_LINES}),
+ * so adjacent chunks share their boundary context. The final partial window is
+ * emitted exactly once and terminates the walk — no duplicate overlap-only
+ * tail chunk. Blank/whitespace-only windows are dropped so trailing newlines
+ * never yield empty chunks.
+ */
+
+/** Lines per window. Precision-poor by design; the embedder resolves semantics. */
+const GENERIC_WINDOW_LINES = 60;
+
+/** Lines shared between adjacent windows so boundary context is not severed. */
+const GENERIC_OVERLAP_LINES = 10;
+
+/**
+ * Window advance per step. Must be > 0 (i.e. overlap < window) or the walk
+ * would never terminate; the invariant holds by construction for the constants
+ * above and is the reason overlap is defined as strictly less than the window.
+ */
+const GENERIC_STEP_LINES = GENERIC_WINDOW_LINES - GENERIC_OVERLAP_LINES;
+
+export class GenericChunker implements Chunker {
+  readonly strategy: ChunkStrategy = 'generic';
+
+  chunk(content: string, filePath: string, type: ContentType): Chunk[] {
+    const lines = content.split('\n');
+    const chunks: Chunk[] = [];
+
+    for (let start = 0; start < lines.length; start += GENERIC_STEP_LINES) {
+      const end = Math.min(start + GENERIC_WINDOW_LINES, lines.length);
+      const windowLines = lines.slice(start, end);
+      const text = windowLines.join('\n');
+
+      // Drop empty / whitespace-only windows (e.g. a run of trailing blank
+      // lines) so we never embed an empty chunk.
+      if (text.trim()) {
+        const startLine = start + 1;
+        const endLine = end; // 0-indexed exclusive `end` == 1-indexed inclusive last line
+        const label = `${filePath}:${startLine}-${endLine}`;
+
+        chunks.push({
+          content: text,
+          contextPrefix: `File: ${filePath} | Lines: ${startLine}-${endLine}`,
+          filePath,
+          type,
+          strategy: this.strategy,
+          label,
+          startLine,
+          endLine,
+          metadata: {},
+        });
+      }
+
+      // The window reached the end of the file — the final (possibly partial)
+      // window has been emitted; stop so we never append a duplicate tail that
+      // is fully contained in the window just produced.
+      if (end >= lines.length) break;
+    }
+
+    return chunks;
+  }
+}

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -21,6 +21,10 @@ export const BUILTIN_CHUNK_STRATEGIES = [
   'session-log',
   'schema-file',
   'test-file',
+  // Fourth-language layer, Stage 1: language-agnostic generic fallback for
+  // source with no dedicated chunker yet (Rust/GDScript). Explicit-opt-in
+  // only (mmnto-ai/totem#2387, #2308; Prop 256 Option A).
+  'generic',
 ] as const;
 
 /**


### PR DESCRIPTION
Closes #2387

## What (Prop 256 Option A, Stage 1)

A `generic` built-in chunk strategy — language-agnostic sliding line-window (60 lines, 10 overlap, named constants) — so source with no dedicated chunker (Rust, GDScript, …) can be indexed for retrieval at all instead of being locked out. Precision-poor by design; the embedder carries semantic resolution; Stage 2 per-language AST chunkers supersede it per-language as they ship (deferred per Option A's own phasing).

## The #2308 relationship: composed, not forked

This is the Stage-1 slice of #2308's direction, honoring its critical constraint verbatim: **explicit-opt-in only** — the strategy is a normal registered built-in a consumer reaches by NAMING `'generic'` on a target in `totem.config.ts`. It is never an implicit catch-all: nothing auto-routes unknown extensions to it, and `createChunker('typo-strategy')` still fail-louds (regression-locked). The strategy name follows Prop 256 (`generic`); #2308 had left the name open. #2308's contract appears satisfied by this implementation — its closure is left to the operator's call rather than a close keyword here.

## Verification

- 10 new tests (`generic-chunker.test.ts`): Rust + GDScript chunking (the lockout cases from the issue), overlap + full-coverage on a 130-line file, single-emit final partial window, empty/whitespace-only → zero chunks, and regression-locks — TS chunker routing and counts unchanged, unknown strategy still throws. Registry enumeration assertions updated (five → six built-ins).
- Full workspace gates: build PASS; `pnpm test` PASS (core 3232 → 3242); `format:check` PASS; workspace ESLint PASS 0 errors; `totem lint --base main` PASS 0 errors (freeze-era warning + 4 disclosed heuristic-lesson false-positives on test `toContain` idioms).

Changeset: patch `@mmnto/totem` (core). No `@mmnto/cli` changeset — zero CLI/MCP consumers of the strategy list; the CLI surface is unchanged.

Window/overlap defaults (60/10) are an engineering choice — neither the issue nor the proposal specifies numbers; they live in named constants for tuning.

Provenance: implemented by an Opus 4.8 builder under totem-claude orchestration (2026-07-18 quota-stretch distribution); Option-A conformance, #2308-composition evidence, diff, and gates reviewed by totem-claude before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
