### PR TITLE
chore: totem postmerge lessons for 2433 2436 2434 2431 2440 2442

### DIFF
--- a/.totem/lessons/lesson-08813091.md
+++ b/.totem/lessons/lesson-08813091.md
@@ -1,0 +1,6 @@
+## Lesson — Avoid overriding honest zero counts
+
+**Tags:** cli, error-handling, testing
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Fallback mechanisms should trigger only when a primary data source is absent or unreadable, rather than whenever the active count is zero, to avoid masking legitimate empty states with stale fallback data.

--- a/.totem/lessons/lesson-19889a25.md
+++ b/.totem/lessons/lesson-19889a25.md
@@ -1,0 +1,6 @@
+## Lesson — Use unique temp paths for atomic writes
+
+**Tags:** fs, concurrency, atomicity
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Sharing a static temporary path like `${path}.tmp` for atomic temp-and-rename writes introduces race conditions under concurrency: two writers can delete each other's temp file and spuriously fail. Generate a unique temp path per invocation (e.g. a pid suffix). When concurrent writers carry identical content (idempotent marks/copies), a plain overwrite-on-rename is benign and no-clobber machinery is unnecessary — treat a rename failure with the destination now present as an idempotent success instead.

--- a/.totem/lessons/lesson-1f74ba6f.md
+++ b/.totem/lessons/lesson-1f74ba6f.md
@@ -1,0 +1,6 @@
+## Lesson — Fail toward flagging in lint gates
+
+**Tags:** security, linting, error-handling
+**Scope:** packages/core/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+When a scanner or parser fails to read file spans, it should degrade to returning no spans so that rules continue to flag violations rather than silently suppressing them.

--- a/.totem/lessons/lesson-20fb5dc6.md
+++ b/.totem/lessons/lesson-20fb5dc6.md
@@ -1,0 +1,6 @@
+## Lesson — Normalize both sides of filename comparisons
+
+**Tags:** fs, refactoring
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+When introducing filename sanitization, both the reader and the garbage collector must normalize filenames on both sides of any comparison. Failing to do so causes the compactor to misidentify sanitized marks as inert and prematurely collect them.

--- a/.totem/lessons/lesson-34208c29.md
+++ b/.totem/lessons/lesson-34208c29.md
@@ -1,0 +1,6 @@
+## Lesson — Hoist file reads to prevent redundant I/O
+
+**Tags:** performance, io
+**Scope:** packages/core/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Reading and parsing file spans per match instead of hoisting them per file causes redundant disk I/O and degrades performance during rule evaluation.

--- a/.totem/lessons/lesson-39a106d8.md
+++ b/.totem/lessons/lesson-39a106d8.md
@@ -1,0 +1,6 @@
+## Lesson — Isolate process exits at CLI edge
+
+**Tags:** cli, architecture, testing
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Command handlers should maintain a strict no-process-exit contract to ensure they remain fully unit-testable. Keep process gating and exit-code resolution isolated at the CLI entry points.

--- a/.totem/lessons/lesson-3c91c56d.md
+++ b/.totem/lessons/lesson-3c91c56d.md
@@ -1,0 +1,6 @@
+## Lesson — Correctly track escaped backslashes in strings
+
+**Tags:** parsing, lexing, string-handling
+**Scope:** packages/core/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Naive escape-character checks that only look at the preceding character fail to correctly terminate strings ending in an escaped backslash (e.g., "\\"), which can corrupt brace-depth tracking.

--- a/.totem/lessons/lesson-444e2407.md
+++ b/.totem/lessons/lesson-444e2407.md
@@ -1,0 +1,6 @@
+## Lesson — Align status counts with active filters
+
+**Tags:** cli, rules, filtering
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+When reporting rule counts, use the same loaders and active filters (such as excluding archived or unverified rules) as execution commands to prevent misleading discrepancies in status outputs.

--- a/.totem/lessons/lesson-5266515c.md
+++ b/.totem/lessons/lesson-5266515c.md
@@ -1,0 +1,6 @@
+## Lesson — Avoid silent process.cwd() fallbacks
+
+**Tags:** cli, path-resolution
+**Scope:** packages/core/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Relying on a silent fallback to `process.cwd()` can cause path resolution failures or incorrect file reads in multi-package or monorepo environments; explicit directory threading is preferred.

--- a/.totem/lessons/lesson-6a8563a8.md
+++ b/.totem/lessons/lesson-6a8563a8.md
@@ -1,0 +1,6 @@
+## Lesson — Defer heavy imports to error paths
+
+**Tags:** cli, performance, imports
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+To maintain fast CLI startup latency, avoid static imports of heavy dependencies or domain-specific errors in command handlers. Instead, load them via dynamic imports only when entering the error throw path.

--- a/.totem/lessons/lesson-7ce9bbbb.md
+++ b/.totem/lessons/lesson-7ce9bbbb.md
@@ -1,0 +1,6 @@
+## Lesson — Destructure CLI options before passing to core
+
+**Tags:** typescript, cli, dx
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+CLI-specific options should be destructured and removed from options objects before passing them to core functions. This maintains strict TypeScript type safety and prevents unexpected CLI-only flags from leaking into core APIs.

--- a/.totem/lessons/lesson-7e2e131d.md
+++ b/.totem/lessons/lesson-7e2e131d.md
@@ -1,0 +1,6 @@
+## Lesson — Always resolve repository root dynamically
+
+**Tags:** cli, path-resolution
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Defaulting the repository root to process.cwd() fails when CLI commands are run from subdirectories. Using a walk-up resolver ensures consistent repository-relative path resolution regardless of the current working directory.

--- a/.totem/lessons/lesson-d14a30bc.md
+++ b/.totem/lessons/lesson-d14a30bc.md
@@ -1,0 +1,6 @@
+## Lesson — Support nested block comments in parsers
+
+**Tags:** parsing, lexing, comments
+**Scope:** packages/core/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Rust block comments can be nested, so using a simple index-of search for the comment terminator will prematurely end the skip block and corrupt brace-depth tracking.

--- a/.totem/lessons/lesson-e33a5ac3.md
+++ b/.totem/lessons/lesson-e33a5ac3.md
@@ -1,0 +1,6 @@
+## Lesson — Sanitize colons to prevent NTFS corruption
+
+**Tags:** fs, windows, ntfs
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Colons in filenames act as NTFS Alternate Data Stream separators on Windows, causing file writes to silently succeed into invisible streams that readdirSync cannot list. Stripping colons from basenames ensures cross-platform compatibility and prevents persistent unread states.

--- a/.totem/lessons/lesson-ebf7e282.md
+++ b/.totem/lessons/lesson-ebf7e282.md
@@ -1,0 +1,6 @@
+## Lesson — Distinguish Rust lifetimes from char literals
+
+**Tags:** rust, parsing, lexing
+**Scope:** packages/core/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Treating Rust lifetime ticks as character literals can cause brace-matching scanners to swallow braces and over-extend spans, leading to silent over-exemption of lint rules.

--- a/.totem/lessons/lesson-f3e60b54.md
+++ b/.totem/lessons/lesson-f3e60b54.md
@@ -1,0 +1,6 @@
+## Lesson — Guard against trailing newline split artifacts
+
+**Tags:** typescript, parsing, testing
+**Scope:** packages/core/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Splitting file content on newlines produces a phantom empty element for files ending with a trailing newline, causing off-by-one errors in line calculations. Test fixtures should explicitly include trailing newlines to prevent this edge case from going undetected.


### PR DESCRIPTION
Postmerge lesson extraction for the six-PR merged train: #2433, #2436, #2434, #2431, #2440, #2442 (#2430 lessons-PR and #2423/#2438 VP excluded). Freeze-era shape: **extraction only — no compile, no `compiled-rules.json`/manifest touch.**

## What's in

16 novel lessons (#2433 yielded zero after corpus dedup): the NTFS colon/ADS class, the Rust scanner's three edge-classes (lifetimes, nested comments, escaped backslashes), the trailing-newline phantom element, two-sided normalization incl. the compactor, walk-up root resolution vs `process.cwd()` (both layers), per-file span hoisting, same-loader count parity, presence-authoritative fallback semantics, span-read fail-toward-flagging, the no-process-exit CLI-edge contract, dynamic-import startup discipline, and CLI-flag destructuring before core calls.

## Disposition diff (the laundering check)

All six rounds' dispositions re-checked against every lesson. **Zero cuts** — the extractor did not restate the train's declined findings (no lexer-rewrite lesson, no post-image-span lesson, no reply/mark "atomicity" overclaim). **One precision edit, disclosed:** `lesson-19889a25` as extracted recommended "no-clobber renames" — the exact half of the #2431 concurrency machinery that was DECLINED on that round (the shipped design is plain overwrite-on-rename, benign because concurrent writers carry identical bytes, with destination-present-on-failure treated as idempotent success). The lesson now states the accepted form and the reasoning, so it can't be cited to re-litigate the decline.

## Mechanics

Index re-synced after the edit; files formatted; repo-wide `format:check` green. No changeset (lessons-only, matches #2430/#2425).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
