### PR TITLE
chore(cohort): seat totem-kimi — fifth vendor lane in the signoff basename map (operator ruling, cohort-roles §1.4)

### DIFF
--- a/.changeset/kimi-fifth-vendor-seat.md
+++ b/.changeset/kimi-fifth-vendor-seat.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/cli': patch
+---
+
+The signoff skill's repo→agent-id basename map gains a Kimi vendor column (`totem-kimi` seated in `totem`; other repos marked not-seated) — the fifth vendor lane per the 2026-07-18 operator ruling recorded in cohort-roles §1.4 (mmnto-ai/totem-strategy#930). Constant and the distributed copy in this repo updated in byte-sync; other repos pick the table up on their next `totem init` refresh. Seat discovery itself needed no code change — `.totem/orchestration/totem-kimi/` self-registers via the dirs-union layer (the #2141 vendor+1 invariant, live-tested by this seating).

--- a/.claude/skills/signoff/SKILL.md
+++ b/.claude/skills/signoff/SKILL.md
@@ -15,14 +15,14 @@ End-of-session wrap-up. Post-Proposal-282 (ADR-106), journals + handoffs live in
 
    a. **Identify your agent-id** from the current repo's basename. The hardcoded map (Proposal 282 § Scope item 3 — keep in sync with the ADR-106 cohort list):
 
-   | Repo (`git rev-parse --show-toplevel` basename) | Claude agent-id                     | Gemini agent-id   |
-   | ----------------------------------------------- | ----------------------------------- | ----------------- |
-   | `totem`                                         | `totem-claude`                      | `totem-gemini`    |
-   | `totem-strategy`                                | `strategy-claude`                   | `strategy-gemini` |
-   | `liquid-city`                                   | `lc-claude`                         | `lc-gemini`       |
-   | `arhgap11`                                      | `arhgap11-claude`                   | `arhgap11-gemini` |
-   | `totem-status`                                  | _(no Claude variant)_               | `status-gemini`   |
-   | `totem-playground`                              | _(orphan stream — no native agent)_ | _(orphan stream)_ |
+   | Repo (`git rev-parse --show-toplevel` basename) | Claude agent-id                     | Gemini agent-id   | Kimi agent-id     |
+   | ----------------------------------------------- | ----------------------------------- | ----------------- | ----------------- |
+   | `totem`                                         | `totem-claude`                      | `totem-gemini`    | `totem-kimi`      |
+   | `totem-strategy`                                | `strategy-claude`                   | `strategy-gemini` | _(not seated)_    |
+   | `liquid-city`                                   | `lc-claude`                         | `lc-gemini`       | _(not seated)_    |
+   | `arhgap11`                                      | `arhgap11-claude`                   | `arhgap11-gemini` | _(not seated)_    |
+   | `totem-status`                                  | _(no Claude variant)_               | `status-gemini`   | _(not seated)_    |
+   | `totem-playground`                              | _(orphan stream — no native agent)_ | _(orphan stream)_ | _(orphan stream)_ |
 
    Seat discovery is dir-derived (mmnto-ai/totem#2141): any `.totem/orchestration/<agent-id>/` directory registers that seat for this repo, UNIONED with the basename map above so roster siblings stay visible on fresh clones where the gitignored tree is partial (precedence: `TOTEM_SELF_AGENT` env > `config.json` `host_agents` > seat dirs ∪ basename map). Override hook: a `host_agents: string[]` field in `.totem/orchestration/config.json` still **replaces** the derived answer — but omitting a PRESENT seat dir attaches a loud warning naming the omitted seat (the dir is the registration; config-exclusion is not a decommission mechanism). The returned list of agent-ids is used by consumers (e.g., `totem mail`) to filter cross-repo handoffs — messages addressed to any agent-id in the list belong to this repo's session.
 

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -1011,14 +1011,14 @@ End-of-session wrap-up. Post-Proposal-282 (ADR-106), journals + handoffs live in
 
    a. **Identify your agent-id** from the current repo's basename. The hardcoded map (Proposal 282 § Scope item 3 — keep in sync with the ADR-106 cohort list):
 
-   | Repo (\`git rev-parse --show-toplevel\` basename) | Claude agent-id                     | Gemini agent-id   |
-   | ----------------------------------------------- | ----------------------------------- | ----------------- |
-   | \`totem\`                                         | \`totem-claude\`                      | \`totem-gemini\`    |
-   | \`totem-strategy\`                                | \`strategy-claude\`                   | \`strategy-gemini\` |
-   | \`liquid-city\`                                   | \`lc-claude\`                         | \`lc-gemini\`       |
-   | \`arhgap11\`                                      | \`arhgap11-claude\`                   | \`arhgap11-gemini\` |
-   | \`totem-status\`                                  | _(no Claude variant)_               | \`status-gemini\`   |
-   | \`totem-playground\`                              | _(orphan stream — no native agent)_ | _(orphan stream)_ |
+   | Repo (\`git rev-parse --show-toplevel\` basename) | Claude agent-id                     | Gemini agent-id   | Kimi agent-id     |
+   | ----------------------------------------------- | ----------------------------------- | ----------------- | ----------------- |
+   | \`totem\`                                         | \`totem-claude\`                      | \`totem-gemini\`    | \`totem-kimi\`      |
+   | \`totem-strategy\`                                | \`strategy-claude\`                   | \`strategy-gemini\` | _(not seated)_    |
+   | \`liquid-city\`                                   | \`lc-claude\`                         | \`lc-gemini\`       | _(not seated)_    |
+   | \`arhgap11\`                                      | \`arhgap11-claude\`                   | \`arhgap11-gemini\` | _(not seated)_    |
+   | \`totem-status\`                                  | _(no Claude variant)_               | \`status-gemini\`   | _(not seated)_    |
+   | \`totem-playground\`                              | _(orphan stream — no native agent)_ | _(orphan stream)_ | _(orphan stream)_ |
 
    Seat discovery is dir-derived (mmnto-ai/totem#2141): any \`.totem/orchestration/<agent-id>/\` directory registers that seat for this repo, UNIONED with the basename map above so roster siblings stay visible on fresh clones where the gitignored tree is partial (precedence: \`TOTEM_SELF_AGENT\` env > \`config.json\` \`host_agents\` > seat dirs ∪ basename map). Override hook: a \`host_agents: string[]\` field in \`.totem/orchestration/config.json\` still **replaces** the derived answer — but omitting a PRESENT seat dir attaches a loud warning naming the omitted seat (the dir is the registration; config-exclusion is not a decommission mechanism). The returned list of agent-ids is used by consumers (e.g., \`totem mail\`) to filter cross-repo handoffs — messages addressed to any agent-id in the list belong to this repo's session.
 


### PR DESCRIPTION
Executes the totem-side wiring of the 2026-07-18 operator seating ruling (canonical: mmnto-ai/totem-strategy cohort-roles §1.4 via strategy PR 930; relayed by strategy-claude 2226Z).

- **Signoff agent table** gains a Kimi vendor column at its source of truth (the \SIGNOFF_SKILL_CONTENT\ constant): \	otem-kimi\ seated in \	otem\; other repos \_(not seated)_\; playground stays orphan. The repo-local distributed \.claude/skills/signoff/SKILL.md\ is updated in the same commit — the #1890 parity test enforces byte-identity between constant and copy, and no headless single-skill \init\ refresh exists (#2222). Other repos pick the table up on their next \	otem init\.
- **Seat dirs** (\.totem/orchestration/totem-kimi/{outbox,processed,journal}\) are created locally (gitignored) — the #2141 dirs-union layer self-registers them with **zero resolver changes needed**, which live-validates the vendor+1 invariant. Recorded here as the product finding the relay asked for: mkdir sufficed.
- Recovery note: the first commit attempt tripped the #1890 parity test — prettier realigns the markdown table in the distributed file but cannot reach inside the TS template literal; the constant now matches prettier's output exactly. The parity test caught precisely what it exists to catch.

Changeset: patch \@mmnto/cli\. Gates: build, full tests 10/10 (3405 cli), format:check, workspace ESLint 0 errors, totem lint via the push gate.

Provenance: totem-claude inline (home-seat wiring lane per the strategy dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)