### PR TITLE
fix(review): zero-completed-lane fan hard-errors instead of exiting 0 (#2452 slice A)

### DIFF
--- a/.changeset/zealous-lanes-report.md
+++ b/.changeset/zealous-lanes-report.md
@@ -1,0 +1,12 @@
+---
+'@mmnto/cli': patch
+'@mmnto/totem': patch
+---
+
+fix(review): a review fan with zero completed verdict lanes hard-errors instead of exiting 0 (#2452 slice A)
+
+A `totem review` fan that finished with zero _completed_ verdict lanes could exit 0 when `--fail-on` was omitted: the all-lanes-failed gate keyed on `completed || abstained`, so an abstain-bearing fan (a lane that invoked but whose output was unextractable — sensor-down) skipped the hard-error and read like a pass. The verdict artifact was already honest (`settled=false`, `completedLaneCount=0`); only the process exit was wrong.
+
+The gate now keys on zero completed lanes (`hasNoCompletedLane`, exported from core), fired after the honest verdict is written and before the override/cache-stamp block — so `--override` can never mint a push authorization from a provider-unsettled round (Tenets 12/13). The hard-error message enumerates `completed=0/abstained=N/failed=M` instead of the old "failed to invoke" wording (dishonest for an abstained lane that did invoke). The fan report also splits diff-budget from total-prompt-budget so the two are never double-counted.
+
+Slice A of #2452 (the fan boundary); the CLI-fallback evidence + `invoke-error` taxonomy is slice B.

--- a/.changeset/zealous-lanes-report.md
+++ b/.changeset/zealous-lanes-report.md
@@ -1,6 +1,6 @@
 ---
-'@mmnto/cli': patch
-'@mmnto/totem': patch
+'@mmnto/cli': minor
+'@mmnto/totem': minor
 ---
 
 fix(review): a review fan with zero completed verdict lanes hard-errors instead of exiting 0 (#2452 slice A)

--- a/.totem/specs/2452.md
+++ b/.totem/specs/2452.md
@@ -1,0 +1,232 @@
+### Problem Statement
+
+When a `totem review` fan has zero completed verdict lanes (e.g., due to CLI fallback extraction failures resulting in implicit abstention, or outright lane execution failures), the process incorrectly exits 0 if `--fail-on` is omitted. Additionally, CLI fallback execution lacks diagnostic retention (stdout, stderr, exit status, timeouts) in the run artifact, leaving the system unable to distinguish between genuine extraction failures, authentication/quota errors, or process timeouts.
+
+### Architectural Context
+
+- **Strategy Tenets (12/13):** A provider-unsettled review (due to sensor-down / extraction failure) must not block deterministic publication when other checks (lint, tests, manual evidence) are green, but it must **never** be misrepresented as an external review pass. An exit contract of 0 under zero completed lanes violates this tenet.
+- **Prior Redesign Context:** This is a lane-reliability defect family related to the ongoing review orchestration refactoring (#2045, #2451).
+
+### Files to Examine
+
+1. `packages/cli/src/commands/review-fan.ts` — The primary entrypoint for review fan orchestration (`runReviewFan`), individual lane invocation (`runLane`), and rendering reports (`renderFanReport`).
+2. `packages/cli/src/commands/review-types.ts` (or similar type-definition file within the CLI package) — The source of truth for the verdict artifact and lane result schemas/Zod definitions.
+
+### Technical Approach & Contracts
+
+#### 1. Contract Extension (Zod & TS Definitions)
+
+Extend the existing lane results schema/type with a `fallbackDiagnostics` block to store rich telemetry without mutating primary functional properties:
+
+```typescript
+export interface CliFallbackDiagnostics {
+  stdout?: string;
+  stderr?: string;
+  exitCode?: number | null;
+  signal?: string | null;
+  timeout?: boolean;
+  extractionFailureReason?: string;
+  errorClassification?:
+    | 'auth_error'
+    | 'quota_limit'
+    | 'model_unavailable'
+    | 'process_spawn_failed'
+    | 'process_exit_error'
+    | 'timeout'
+    | 'unknown';
+}
+```
+
+#### 2. Extraction-Failure vs. Explicit Abstention Distinction
+
+- **Explicit Abstain:** The LLM successfully executed and returned a valid JSON structured verdict where the decision field is explicitly set to `"abstain"`. This is a _completed_ lane attempt.
+- **Implicit/Fallback Abstain:** The LLM produced output (or failed to output), but the JSON parsing cascade failed. Currently, this falls back to `ABSTAINED`. We must track this as an extraction failure via `fallbackDiagnostics.extractionFailureReason`.
+
+#### 3. Core Exit Logic Adjustment
+
+In `runReviewFan`, compute the count of _completed verdict lanes_ (lanes that successfully returned a valid, parsed structured verdict). If this count is `0`, the command must hard-error or exit with non-zero status code:
+
+```typescript
+const completedVerdictLanes = laneResults.filter(
+  (lane) => lane.status === 'success' && !lane.fallbackDiagnostics?.extractionFailureReason,
+);
+
+if (completedVerdictLanes.length === 0) {
+  throw new TotemError(
+    'Review fan completed with zero valid verdict lanes. All lanes failed or yielded unextractable output.',
+    { code: 'ZERO_COMPLETED_LANES', exitCode: 1 },
+  );
+}
+```
+
+#### 4. Classification Engine
+
+Implement an error classification helper within the fallback executor:
+
+- Parse known error codes or string tokens in `stderr` or the exception message.
+- Map `"429"`, `"quota exceeded"`, `"rate limit"` $\rightarrow$ `'quota_limit'`.
+- Map `"401"`, `"unauthorized"`, `"api key"` $\rightarrow$ `'auth_error'`.
+- Map `"ENOENT"` $\rightarrow$ `'process_spawn_failed'`.
+- Map timeout states (e.g., child process killed by `SIGTERM` on timeout or explicit wrapper timeout) $\rightarrow$ `'timeout'`.
+
+---
+
+### Edge Cases & Traps
+
+- **Zombie CLI Processes:** Ensure timeouts on CLI fallbacks explicitly kill any spawned child processes (or process groups) to avoid background thread leakage.
+- **Large Diff Truncation:** Ensure that capturing partial `stdout` / `stderr` does not exceed memory boundaries. Slice raw captures to a safe upper bound (e.g., 50KB) before saving to the artifact.
+- **Double Budget Counting:** Make sure the diff size (reported separately) is cleanly subtracted or clearly isolated from the absolute prompt size to avoid confusing developers on how their tokens were allocated.
+
+---
+
+### Implementation Tasks
+
+- [ ] **Task 1: Extend Artifact & Lane Contracts**
+  - Update schemas/types in `packages/cli/src/commands/review-fan.ts` (and relevant type files) to support the `fallbackDiagnostics` contract.
+  - Update `VERDICT_ARTIFACT_SCHEMA_VERSION` if a schema migration is required.
+  - write test (or update existing) → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Distinguish completed lanes & Enforce Exit Contract**
+  - Modify `runReviewFan` to calculate completed lanes, ignoring fallback lanes that suffered extraction failures.
+  - Implement the zero-completed-lane check and trigger a hard exit/throw.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `exits non-zero on zero completed lanes` that proves the regression is caught.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Capture and Classify CLI Fallback Telemetry**
+  - Refactor the CLI fallback invocation loop to capture stdout, stderr, process exit code, and timeout state.
+  - Implement the classification engine (`classifyInvokeError`) to map errors to `'auth_error'`, `'quota_limit'`, etc.
+  - Store this payload in `fallbackDiagnostics` on the lane result.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `retains raw stderr and timeout flag on CLI timeout` that proves the regression is caught.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Sonnet-5 Extraction Fixtures & Cascade Fallbacks**
+  - Introduce robust parsing regexes to safely strip chatty markdown wrapper text around JSON blocks emitted by Sonnet-5 CLI fallbacks.
+  - Add extraction fixture tests matching Sonnet-5 CLI output formatting.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `extracts valid structured verdict from chatty Sonnet-5 markdown` that proves the regression is caught.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 5: Refactor Budget Reporting in CLI Output**
+  - Update `renderFanReport` to calculate the diff size independently.
+  - Report both `Diff Budget` and `Prompt/Context Budget` as separate metrics on the console report.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `reports diff budget separately from prompt budget` that proves the regression is caught.
+  - write test → verify fails → implement → verify passes → lint
+
+---
+
+### Execution Flow
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+---
+
+### Verification (MANDATORY — do not skip)
+
+1. Run `totem lint` to ensure zero stylistic or structural rule violations.
+2. Run `totem review` to ensure the analyzer passes on the modified CLI command files themselves.
+
+---
+
+### Test Plan
+
+#### Integration & Unit Tests
+
+- **Exit Contracts Test Suite (`packages/cli/src/commands/__tests__/review-fan.test.ts`):**
+  - **Test Scenario 1 (Zero-Completed-Lanes):** Set up mock lanes where all either fail execution or result in extraction-failure abstentions. Ensure process exits with code `1`.
+  - **Test Scenario 2 (Explicit Abstain):** Set up mock lanes where one lane returns a valid structured verdict with an explicit `abstain` action. Verify the exit code.
+  - **Test Scenario 3 (Mixed Failure & Abstain):** Set up one lane that fails invocation and one that fails extraction. Ensure exit code is `1`.
+- **Telemetry & Classification Suite:**
+  - **Test Scenario 4 (Diagnostics Logging):** Mock a timed-out Claude CLI child execution and verify `fallbackDiagnostics` contains the exact stderr output and has `timeout: true` with classification `'timeout'`.
+  - **Test Scenario 5 (Extraction Robustness):** Feed Sonnet-5 style raw output (with markdown markers and conversational prefix/suffix) to the extraction cascade. Assert that the final parsed verdict is extracted perfectly and not classified as an extraction failure.
+
+---
+
+## Implementation Design (slice A — totem-claude)
+
+> **Provenance:** the auto-generated spec above frames the WHOLE #2452 family (A+B). Per the confirmed role-split (`.totem/orchestration/totem-codex/outbox/…0555Z…role-split…`), this design covers **only slice (A)** — the fan boundary. The spec's Tasks 1/3/4 (`fallbackDiagnostics` contract, CLI-fallback telemetry capture, invoke-error classification, Sonnet-5 extraction fixtures) are **codex's slice (B)** and are OUT OF SCOPE here.
+
+### Scope
+
+Slice (A) makes a review fan with **zero completed verdict lanes** exit non-zero on the DEFAULT (`--fail-on`-less) path, and splits diff-budget from total-prompt-budget in the fan report. It will **NOT** touch the orchestrator/CLI-fallback layer, add `fallbackDiagnostics`, classify invoke errors, add Sonnet-5 extraction fixtures, or introduce any explicit-abstain lane status — those are (B), consumed later via a follow-up (A) owns.
+
+### Data model deltas
+
+**None persisted.** The fix reuses the existing, already-validated `VerdictArtifact.completedLaneCount` (superRefine already binds it to `#completed lanes`) as the exit predicate. No new type, field, or state container. The verdict is ALREADY honest for a zero-completed fan (`settled=false`, `completedLaneCount=0`) — see `deriveSettled`/`everyLaneCompleted` in `core/src/artifacts/verdict.ts:360,387`. The defect is purely the process exit code.
+
+- Optional tiny exported predicate in `verdict.ts`: `hasNoCompletedLane(v) → completedLaneCount === 0` (single source of truth, mirrors the `deriveSettled` export pattern) — OR inline `verdict.completedLaneCount === 0` at the fan. Leaning exported helper (codex assigned me `verdict.ts` + tests; keeps the predicate testable in core).
+- Budget line is **display-only** (no persisted field) — see Open Q2.
+
+### State lifecycle
+
+No new state. The existing `laneResults` (per-fan, in-memory) and the freshly-saved `verdict` (persisted content-addressed artifact) are unchanged in lifecycle. The only change: the local `anyWithOutput` boolean (`review-fan.ts:1232`, single use at the `:1302` gate) is replaced by reading `verdict.completedLaneCount` AFTER `saveVerdictArtifact` — so the gate keys on the persisted count, not a pre-save local. The honest verdict is written FIRST (unchanged ordering), then the gate fires.
+
+### Failure modes
+
+| Failure                                                                         | Category | Agent-facing surface                                                                                                    | Recovery                                                                    |
+| ------------------------------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| Zero completed lanes — all-failed (existing G3 subset)                          | runtime  | **hard error** `SHIELD_FAILED`, exit non-zero; honest verdict written first                                             | fix provider keys/quota, re-run; artifact records `lanes=0/N settled=false` |
+| Zero completed lanes — ≥1 abstained (extraction-failure) ± failed (**the bug**) | runtime  | **hard error** `SHIELD_FAILED`, exit non-zero; honest verdict written first                                             | same; message enumerates completed=0/abstained=N/failed=M                   |
+| Zero configured lanes                                                           | init     | hard error (pre-attempt, no verdict) — UNCHANGED                                                                        | configure `review.lanes`                                                    |
+| ≥1 completed lane, findings present                                             | runtime  | UNCHANGED: default exit 0; `--fail-on` throws                                                                           | fix findings / `--override`                                                 |
+| `--override` on a zero-completed fan                                            | runtime  | **hard error still fires** — override does NOT convert to pass (Tenet 12/13: provider-unsettled is never a review pass) | not overridable; re-run with working providers                              |
+
+No row is "silent degradation" — every zero-completed path is loud (Tenet 4).
+
+### Invariants to lock in via tests (the five-shape exit matrix)
+
+1. **All lanes completed** → exit 0 (default), verdict `settled` per findings. (regression guard — unchanged path)
+2. **0 completed + ≥1 abstained (extraction-failure) + 0 failed** → exit non-zero; honest verdict written with `completedLaneCount=0, settled=false`. _(the exact repro — currently exits 0)_
+3. **0 completed + 1 abstained + 1 failed** → exit non-zero; verdict written.
+4. **All lanes failed to invoke** → exit non-zero (existing G3 still holds under the widened predicate).
+5. **`--override <reason>` + zero completed** → STILL exits non-zero (override-proof; provider-unsettled ≠ pass).
+6. The zero-completed hard-error fires **after** `saveVerdictArtifact` (artifact exists on disk before the throw).
+7. Budget: `renderFanReport` emits diff-chars and total-prompt-chars as two distinct numbers.
+8. A fan with ≥1 completed lane never triggers the new gate (no false hard-error on a partially-degraded but usable fan).
+
+### Open questions
+
+- **Q1 — exit mechanism: throw vs distinct non-pass exit code.**
+  - Options: (a) reuse the existing all-failed **hard-error** (throw `SHIELD_FAILED`), widening its predicate from all-failed to zero-completed + refining the message; (b) a new dedicated non-zero exit code distinct from a crash-class throw.
+  - **Recommendation: (a).** The acceptance criteria explicitly permits "hard-error like the existing all-lanes-failed gate." Minimal, symmetric, already the contract. Mitigate the "reads-as-crash" con with a message that states "no completed verdict lane — non-pass, not a crash; the honest verdict was written."
+- **Q2 — budget line: display-only vs persisted artifact field.**
+  - Options: (a) display-only in `renderFanReport`; (b) add optional `diffBudget`/`promptBudget` to the verdict artifact.
+  - **Recommendation: (a)** — keeps (A) schema-stable and independently landable; a persisted field is a follow-up if a downstream consumer needs it.
+- **Q3 — the A↔B seam (documented assumption, not a blocker): does an "explicit abstain" count as completed?**
+  - Today there is NO explicit-abstain path — every `abstained` lane is an extraction failure (sensor-down), correctly non-counting. When (B) lands the typed distinction, a valid `decision:abstain` verdict surfaces as `status:completed` (non-null structured verdict) with zero findings, so **(A)'s `completedLaneCount===0` predicate stays correct without change**.
+  - **Recommendation:** key (A) on `status==='completed'`; no (B) coupling now; the follow-up (A) owns is only consuming (B)'s richer `invoke-error` evidence for messaging, not changing the exit predicate.
+
+### Landing shape
+
+Independent of (B) — codex's own read (`review-fan.ts` owns fan exit + the `anyWithOutput` gate). (A) lands standalone; the (B) evidence contract is consumed in a follow-up (A) owns. Separate worktree; no shared files with (B).
+
+**Sensor note:** `mcp__totem-strategy__search_knowledge` was sensor-down this preflight (`No totem.config.ts in cwd` — the Node-spawned-cwd defect class, strategy#813 kin); strategy doctrine (Tenets 12/13, disposition #845) sourced from the spec's Architectural Context + the strategy-claude mail instead.
+
+### Panel outcome (2-lens design review, pre-code)
+
+Both lenses returned **SOUND-TO-IMPLEMENT**; the design is unchanged in shape. Refinements folded in:
+
+- **Exit-semantics lens (CONFIRMED):** the gate at `review-fan.ts:1302` swaps `!anyWithOutput` → `verdict.completedLaneCount === 0`; the widening is _monotone_ (new predicate ⊇ old all-failed G3). Placement is load-bearing: after `saveVerdictArtifact` (`:1297`) and **before** the `else if (override)` cache-stamp branch (`:1329`) — otherwise `--override` would stamp the reviewed-content-hash on a provider-unsettled round and falsely authorize a push (Tenet 12/13). Two non-optional obligations: (1) refine the `SHIELD_FAILED` message — the old "failed to invoke" is dishonest for abstained (extraction-failure) lanes that _did_ invoke; enumerate `completed=0/abstained=N/failed=M` + "non-pass, honest verdict written, not a crash"; (2) delete the now-dead `anyWithOutput` binding (`:1232-1234`).
+
+- **Test-matrix lens (GAPS-FOUND, all in-scope for A):** two EXISTING tests encode the buggy exit-0 and MUST change — `review-fan.test.ts:939` (single abstained → currently `resolves`; flip to `rejects`, preserve its finding-8 post-check-row assertion via `listVerdictArtifacts` after the rejection) and `:1015` (message-coupled `/All 2 review lane/`; update to the enumerated message). New shapes added below. Budget test must assert **containment** (`diffChars ≤ promptChars`, both labeled + distinct) to guard the double-counting trap, not a bare presence check.
+
+**Refined test list (implement in this order):**
+
+1. _(core `verdict.ts`)_ `hasNoCompletedLane`: true at `completedLaneCount===0`, false at `≥1`.
+2. _(inv 2 / repro — rewrite `:939`)_ single abstained lane → `rejects`; `listVerdictArtifacts` shows `completedLaneCount===0`, `settled=false`, abstained lane's decidable `review-structured-verdict` fail row preserved.
+3. _(inv 3)_ 1 abstained + 1 failed → `rejects`; verdict written; message enumerates `completed=0/abstained=1/failed=1`.
+4. _(inv 4 — update `:1015`)_ all failed → `rejects` with the enumerated message; keep verdict-written / `completedLaneCount===0` assertions (this is also the inv-6 witness).
+5. _(inv 5)_ override + zero completed → STILL `rejects`; assert NO `.reviewed-content-hash` stamp and no override ledger event.
+6. _(inv 8b — the sharp new guard)_ completed + **abstained** mix → default `resolves.toBeUndefined()`, `completedLaneCount===1`, no throw.
+7. _(gate-precedes-fail-on)_ abstained-only + `failOn:'critical'` → `rejects` with the _zero-completed_ message (not the fail-on message).
+8. _(inv 8a / inv 1)_ keep existing exit-0 tests (`:729` completed+failed, `:792` two completed, `:998` single completed).
+9. _(inv 7)_ `<git_diff>`-bearing prompt + `--out` → report has distinct diff-budget + prompt-budget numbers, `diffChars ≤ promptChars`.
+10. _(optional, low)_ abstained-only + drift seam → `rejects`, `reviewedState='drifted'`, no stamp.
+
+No scope leaks into (B): every test keys only on lane `status`, `completedLaneCount`, `options`, and `listVerdictArtifacts` — never on `fallbackDiagnostics`/extraction-typing (that is B).

--- a/packages/cli/src/commands/review-fan.test.ts
+++ b/packages/cli/src/commands/review-fan.test.ts
@@ -936,7 +936,7 @@ describe('runReviewFan', () => {
     expect(findLatestVerdictForLineage(tmpDir, lkB, noWarn)!.artifact.round.index).toBe(0);
   });
 
-  it('malformed lane output ⇒ abstained ⇒ not settled; abstained lane gets its decidable post-check fail row (finding 8)', async () => {
+  it('malformed lane output ⇒ abstained ⇒ ZERO completed lanes ⇒ hard-errors as a non-pass; honest verdict written first with the decidable post-check fail row (#2452, finding 8)', async () => {
     const invoker = mapInvoker({
       'anthropic:claude-a': completedInvocation({
         content: 'garbage, not a verdict',
@@ -946,13 +946,17 @@ describe('runReviewFan', () => {
       }),
     });
     const ctx = makeCtx(tmpDir, ['anthropic:claude-a'], invoker);
-    // Default sensor exit 0: an abstaining fan writes the verdict and does NOT throw.
-    await expect(runReviewFan(ctx)).resolves.toBeUndefined();
+    // #2452: the lone lane invoked but its output was unextractable ⇒ it ABSTAINED ⇒
+    // zero completed verdict lanes. That is a NON-PASS — the fan must hard-error, not
+    // exit 0. The message names the shape (abstained, not "failed to invoke").
+    await expect(runReviewFan(ctx)).rejects.toThrow(/completed=0, abstained=1, failed=0/);
+    // The honest verdict is written BEFORE the throw (#2452 / inv 6).
     const v = listVerdictArtifacts(tmpDir, noWarn)[0]!.artifact;
+    expect(v.completedLaneCount).toBe(0);
     expect(v.lanes[0]!.status).toBe('abstained');
     expect(v.settled).toBe(false);
-    // Finding 8: the abstained lane's unextractable output persists a decidable
-    // structured-output 'fail' row (post-checks now cover abstained lanes too).
+    // Finding 8 preserved: the abstained lane's unextractable output persists a decidable
+    // structured-output 'fail' row (post-checks cover abstained lanes too).
     const row = v.postChecks.find((r) => r.ruleName === 'review-structured-verdict');
     expect(row?.tier).toBe('decidable');
     expect(row?.verdict).toBe('fail');
@@ -1012,12 +1016,14 @@ describe('runReviewFan', () => {
     expect(v.settled).toBe(true);
   });
 
-  it('ALL lanes failing WRITES the honest verdict FIRST, then hard-errors (Gate G3)', async () => {
+  it('ALL lanes failing WRITES the honest verdict FIRST, then hard-errors (Gate G3, #2452 enumerated message)', async () => {
     const invoker: LaneInvoker = async () => {
       throw new Error('socket hang up');
     };
     const ctx = makeCtx(tmpDir, ['anthropic:claude-a', 'gemini:g'], invoker);
-    await expect(runReviewFan(ctx)).rejects.toThrow(/All 2 review lane/);
+    // #2452: the widened zero-completed gate subsumes the all-failed case; the message
+    // now enumerates the lane-status breakdown instead of "All N review lane(s)".
+    await expect(runReviewFan(ctx)).rejects.toThrow(/completed=0, abstained=0, failed=2/);
     // Gate G3: the honest verdict is written BEFORE the throw (all lanes failed).
     const verdicts = listVerdictArtifacts(tmpDir, noWarn);
     expect(verdicts).toHaveLength(1);
@@ -1027,6 +1033,156 @@ describe('runReviewFan', () => {
     expect(v.lanes.every((l) => l.status === 'failed')).toBe(true);
     expect(v.settled).toBe(false);
     expect(v.findings).toEqual([]);
+  });
+
+  // ── #2452 zero-completed exit contract: an abstain-bearing fan is a non-pass ──
+
+  it('abstained + failed (still zero completed) hard-errors; verdict written; message enumerates the mix (#2452 inv 3)', async () => {
+    const invoker = mapInvoker({
+      'anthropic:claude-a': completedInvocation({
+        content: 'garbage, not a verdict',
+        provider: 'anthropic',
+        model: 'claude-a',
+        seed: 'af-a',
+      }),
+      'gemini:g': async () => {
+        throw new Error('socket hang up');
+      },
+    });
+    const ctx = makeCtx(tmpDir, ['anthropic:claude-a', 'gemini:g'], invoker);
+    await expect(runReviewFan(ctx)).rejects.toThrow(/completed=0, abstained=1, failed=1/);
+    const v = listVerdictArtifacts(tmpDir, noWarn)[0]!.artifact;
+    expect(v.completedLaneCount).toBe(0);
+    expect(v.lanes.map((l) => l.status).sort()).toEqual(['abstained', 'failed']);
+    expect(v.settled).toBe(false);
+  });
+
+  it('completed + abstained mix (≥1 completed) still DEFAULT sensor exit 0 — the gate keys on completed lanes, not "any output" (#2452 inv 8b)', async () => {
+    const invoker = mapInvoker({
+      'anthropic:claude-a': completedInvocation({
+        content: wrapVerdict([]),
+        provider: 'anthropic',
+        model: 'claude-a',
+        seed: 'ca-a',
+      }),
+      'gemini:g': completedInvocation({
+        content: 'garbage, not a verdict',
+        provider: 'gemini',
+        model: 'g',
+        seed: 'ca-b',
+      }),
+    });
+    const ctx = makeCtx(tmpDir, ['anthropic:claude-a', 'gemini:g'], invoker);
+    // The shape whose meaning did NOT change under the old `anyWithOutput` (true both
+    // before and after): one usable lane makes the fan a pass-eligible result — the new
+    // gate must NOT fire on it.
+    await expect(runReviewFan(ctx)).resolves.toBeUndefined();
+    const v = listVerdictArtifacts(tmpDir, noWarn)[0]!.artifact;
+    expect(v.completedLaneCount).toBe(1);
+    expect(v.lanes.map((l) => l.status).sort()).toEqual(['abstained', 'completed']);
+  });
+
+  it('zero-completed fires BEFORE --fail-on: an abstained-only fan with --fail-on rejects with the zero-completed message, not the fail-on message (#2452 ordering)', async () => {
+    const invoker = mapInvoker({
+      'anthropic:claude-a': completedInvocation({
+        content: 'garbage, not a verdict',
+        provider: 'anthropic',
+        model: 'claude-a',
+        seed: 'fo-a',
+      }),
+    });
+    const ctx = makeCtx(tmpDir, ['anthropic:claude-a'], invoker, {
+      options: { failOn: 'critical' },
+    });
+    let err: unknown;
+    try {
+      await runReviewFan(ctx);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/completed=0, abstained=1, failed=0/);
+    // The --fail-on "lane coverage" message would only appear if the gate ran AFTER it.
+    expect((err as Error).message).not.toMatch(/lane coverage/);
+  });
+
+  it('--override on a zero-completed fan STILL hard-errors and NEVER stamps — override cannot mint a pass from a provider-unsettled round (#2452 inv 5, Tenets 12/13)', async () => {
+    const invoker = mapInvoker({
+      'anthropic:claude-a': completedInvocation({
+        content: 'garbage, not a verdict',
+        provider: 'anthropic',
+        model: 'claude-a',
+        seed: 'ov-a',
+      }),
+    });
+    // Matched tree (preFan === post-fan): under the OLD gate, --override on an abstained-only
+    // matched fan reached the ledgered stamp branch and wrote the reviewed-content-hash,
+    // falsely authorizing a push. The widened gate pre-empts that branch.
+    const ctx = makeCtx(tmpDir, ['anthropic:claude-a'], invoker, {
+      preFanContentHash: 'pre-hash-unsettled',
+      contentHash: async () => 'pre-hash-unsettled',
+      options: { override: 'operator insists — must still refuse a zero-completed pass' },
+    });
+    await expect(runReviewFan(ctx)).rejects.toThrow(/completed=0, abstained=1, failed=0/);
+    // No stamp authorizes a push from a zero-completed round, even under --override.
+    expect(fs.existsSync(path.join(tmpDir, '.totem', 'cache', '.reviewed-content-hash'))).toBe(
+      false,
+    );
+    const v = listVerdictArtifacts(tmpDir, noWarn)[0]!.artifact;
+    expect(v.completedLaneCount).toBe(0);
+    expect(v.settled).toBe(false);
+  });
+
+  it('drift + zero-completed still hard-errors; the drifted verdict is written and nothing is stamped (#2452, low)', async () => {
+    const invoker = mapInvoker({
+      'anthropic:claude-a': completedInvocation({
+        content: 'garbage, not a verdict',
+        provider: 'anthropic',
+        model: 'claude-a',
+        seed: 'dz-a',
+      }),
+    });
+    const ctx = makeCtx(tmpDir, ['anthropic:claude-a'], invoker, {
+      preFanContentHash: 'pre-hash-drift',
+      contentHash: async () => 'post-hash-different',
+    });
+    await expect(runReviewFan(ctx)).rejects.toThrow(/completed=0, abstained=1, failed=0/);
+    const v = listVerdictArtifacts(tmpDir, noWarn)[0]!.artifact;
+    expect(v.reviewedState).toBe('drifted');
+    expect(v.completedLaneCount).toBe(0);
+    expect(fs.existsSync(path.join(tmpDir, '.totem', 'cache', '.reviewed-content-hash'))).toBe(
+      false,
+    );
+  });
+
+  it('the fan report splits diff budget from total prompt budget (#2452 inv 7) — diff is a strict subset of the prompt', async () => {
+    const diff = 'diff --git a/x.ts b/x.ts\n@@ -1 +1 @@\n-const x = 0;\n+const x = 1;\n';
+    const prompt = `SYSTEM: review the following.\n<git_diff>\n${diff}\n</git_diff>\nEND INSTRUCTIONS — respond with a verdict.`;
+    const invoker = mapInvoker({
+      'anthropic:claude-a': completedInvocation({
+        content: wrapVerdict([]),
+        provider: 'anthropic',
+        model: 'claude-a',
+        seed: 'bud',
+      }),
+    });
+    const outPath = path.join(tmpDir, 'fan-report.txt');
+    const ctx = makeCtx(tmpDir, ['anthropic:claude-a'], invoker, {
+      prompt,
+      filteredDiff: diff,
+      options: { out: outPath },
+    });
+    await runReviewFan(ctx);
+    const report = fs.readFileSync(outPath, 'utf-8');
+    const m = report.match(/Budget: diff (\d+) chars, prompt (\d+) chars/);
+    expect(m).not.toBeNull();
+    const diffChars = Number(m![1]);
+    const promptChars = Number(m![2]);
+    // The diff is a strict subset of the assembled prompt (the prompt wraps it in
+    // template text), so both numbers report and diff < prompt — never the
+    // "my whole prompt is the diff" double-count.
+    expect(diffChars).toBeGreaterThan(0);
+    expect(diffChars).toBeLessThan(promptChars);
   });
 
   it('--continues on a mismatched lineage warns but proceeds, recording the current lineage', async () => {

--- a/packages/cli/src/commands/review-fan.ts
+++ b/packages/cli/src/commands/review-fan.ts
@@ -1088,6 +1088,12 @@ function renderFanReport(
   verdictHash: string,
   findings: readonly AttributedFinding[],
   cacheEligible: boolean,
+  // Budget split (mmnto-ai/totem#2452): the reviewed DIFF size vs the TOTAL assembled
+  // prompt/context size, in chars. The diff is a SUBSET of the prompt (the prompt wraps
+  // the `<git_diff>` block in template/grounding), so `diffChars <= promptChars` always
+  // — reporting them separately stops the "my whole prompt is the diff" double-count.
+  diffChars: number,
+  promptChars: number,
   // Threaded from `runReviewFan`'s single core import (rule 64) — this sync helper never
   // imports core itself.
   renderCovariateLine: (typeof import('@mmnto/totem'))['renderCovariateLine'],
@@ -1095,6 +1101,9 @@ function renderFanReport(
   const lines: string[] = [];
   lines.push(
     `Review fan — ${verdict.completedLaneCount}/${verdict.attemptedLaneCount} lane(s) completed`,
+  );
+  lines.push(
+    `Budget: diff ${diffChars} chars, prompt ${promptChars} chars total (diff is a subset of the prompt)`,
   );
   lines.push('');
   lines.push('Lanes:');
@@ -1150,6 +1159,7 @@ export async function runReviewFan(ctx: ReviewFanContext): Promise<void> {
     deriveCacheEligible,
     deriveLessonsConsulted,
     deriveSettled,
+    hasNoCompletedLane,
     maskSecrets,
     renderCovariateLine,
     TotemError,
@@ -1229,9 +1239,6 @@ export async function runReviewFan(ctx: ReviewFanContext): Promise<void> {
     }
   }
 
-  const anyWithOutput = laneResults.some(
-    (lr) => lr.lane.status === 'completed' || lr.lane.status === 'abstained',
-  );
   const createdAt = now();
 
   // ── Panel + post-checks (over completed AND abstained lanes; finding 8) ──
@@ -1296,14 +1303,25 @@ export async function runReviewFan(ctx: ReviewFanContext): Promise<void> {
   // the existing address).
   const verdictHash = saveVerdictArtifact(ctx.totemDirAbs, verdict).hash;
 
-  // ── ALL lanes terminal-failed (Gate G3): the honest verdict is now WRITTEN — hard-error ──
-  // (A pure boolean check — it does not widen the compare→stamp window, and an
-  // all-failed round is never cache-eligible nor override-stampable: the run ends here.)
-  if (!anyWithOutput) {
+  // ── ZERO completed verdict lanes (Gate G3, mmnto-ai/totem#2452): the honest verdict
+  // is now WRITTEN — hard-error ──
+  // Keyed on `hasNoCompletedLane` (⇔ `verdict.completedLaneCount === 0`, superRefine-bound):
+  // `completed` is the ONLY status carrying a usable structured verdict, so a fan with
+  // zero completed lanes is a non-pass whether the other lanes ABSTAINED (invoked but
+  // output unextractable — sensor-down) or FAILED (never invoked). Widened from the old
+  // all-failed-only predicate, which let an abstain-bearing fan skip this gate and exit 0
+  // (#2452). This MUST sit after the save (the artifact is on disk first) and BEFORE the
+  // override/cache-stamp block below: a zero-completed fan is never cache-eligible, so an
+  // `--override` would otherwise reach the ledgered stamp branch and falsely authorize a
+  // push on a provider-unsettled round (Tenets 12/13). A pure check — no compare→stamp
+  // window widening; the run ends here.
+  if (hasNoCompletedLane(verdict.lanes)) {
+    const abstained = laneResults.filter((lr) => lr.lane.status === 'abstained').length;
+    const failed = laneResults.filter((lr) => lr.lane.status === 'failed').length;
     throw new TotemError(
       'SHIELD_FAILED',
-      `All ${laneResults.length} review lane(s) failed to invoke — an honest verdict was written (all lanes failed, not settled), then the run hard-errors.`,
-      'Check backend API keys / quota, then re-run `totem review`.',
+      `Review produced no completed verdict lane (completed=0, abstained=${abstained}, failed=${failed} of ${laneResults.length}) — this is a non-pass, NOT a crash: an honest verdict was written (settled=false), then the run hard-errors. A provider-unsettled round never counts as a review pass and never authorizes a push (Tenets 12/13).`,
+      'Abstained lanes invoked but their output was not extractable; failed lanes did not invoke. Check backend API keys / quota and lane output, then re-run `totem review`.',
     );
   }
 
@@ -1375,6 +1393,12 @@ export async function runReviewFan(ctx: ReviewFanContext): Promise<void> {
         verdictHash,
         fanFindings,
         cacheEligible,
+        // Budget split (#2452): `diffSegment` is the masked `<git_diff>` block the lanes
+        // reviewed; `deliveredPrompt` is the full masked prompt that wraps it. Both are
+        // the exact bytes assembled above (lines ~1190-1192), so the report never
+        // recomputes or drifts from what was delivered.
+        diffSegment.length,
+        deliveredPrompt.length,
         renderCovariateLine,
       ),
       ctx.options.out,

--- a/packages/cli/src/commands/review-fan.ts
+++ b/packages/cli/src/commands/review-fan.ts
@@ -1316,8 +1316,11 @@ export async function runReviewFan(ctx: ReviewFanContext): Promise<void> {
   // push on a provider-unsettled round (Tenets 12/13). A pure check — no compare→stamp
   // window widening; the run ends here.
   if (hasNoCompletedLane(verdict.lanes)) {
-    const abstained = laneResults.filter((lr) => lr.lane.status === 'abstained').length;
-    const failed = laneResults.filter((lr) => lr.lane.status === 'failed').length;
+    // Count from `verdict.lanes` — the SAME validated collection the gate reads — so the
+    // enumerated message can never drift from the gate predicate under a future refactor
+    // (both derive from one source, not from `laneResults` in parallel).
+    const abstained = verdict.lanes.filter((l) => l.status === 'abstained').length;
+    const failed = verdict.lanes.filter((l) => l.status === 'failed').length;
     throw new TotemError(
       'SHIELD_FAILED',
       `Review produced no completed verdict lane (completed=0, abstained=${abstained}, failed=${failed} of ${laneResults.length}) — this is a non-pass, NOT a crash: an honest verdict was written (settled=false), then the run hard-errors. A provider-unsettled round never counts as a review pass and never authorizes a push (Tenets 12/13).`,

--- a/packages/cli/src/commands/review-fan.ts
+++ b/packages/cli/src/commands/review-fan.ts
@@ -1323,7 +1323,7 @@ export async function runReviewFan(ctx: ReviewFanContext): Promise<void> {
     const failed = verdict.lanes.filter((l) => l.status === 'failed').length;
     throw new TotemError(
       'SHIELD_FAILED',
-      `Review produced no completed verdict lane (completed=0, abstained=${abstained}, failed=${failed} of ${laneResults.length}) — this is a non-pass, NOT a crash: an honest verdict was written (settled=false), then the run hard-errors. A provider-unsettled round never counts as a review pass and never authorizes a push (Tenets 12/13).`,
+      `Review produced no completed verdict lane (completed=0, abstained=${abstained}, failed=${failed} of ${verdict.lanes.length}) — this is a non-pass, NOT a crash: an honest verdict was written (settled=false), then the run hard-errors. A provider-unsettled round never counts as a review pass and never authorizes a push (Tenets 12/13).`,
       'Abstained lanes invoked but their output was not extractable; failed lanes did not invoke. Check backend API keys / quota and lane output, then re-run `totem review`.',
     );
   }

--- a/packages/core/src/artifacts.ts
+++ b/packages/core/src/artifacts.ts
@@ -47,6 +47,7 @@ export {
   deriveLessonsConsulted,
   deriveSettled,
   findLatestVerdictForLineage,
+  hasNoCompletedLane,
   LaneIdSchema,
   LessonConsultedItemSchema,
   LessonsConsultedSchema,

--- a/packages/core/src/artifacts/verdict.test.ts
+++ b/packages/core/src/artifacts/verdict.test.ts
@@ -39,6 +39,7 @@ import {
   deriveLessonsConsulted,
   deriveSettled,
   findLatestVerdictForLineage,
+  hasNoCompletedLane,
   listVerdictArtifacts,
   loadVerdictArtifact,
   renderCovariateLine,
@@ -546,6 +547,38 @@ describe('deriveSettled / deriveCacheEligible (pure predicates)', () => {
     };
     expect(deriveSettled(drift)).toBe(false);
     expect(deriveCacheEligible(drift)).toBe(false);
+  });
+});
+
+// ─── hasNoCompletedLane — exit-contract non-pass gate (mmnto-ai/totem#2452) ───
+
+describe('hasNoCompletedLane (exit-contract non-pass gate, #2452)', () => {
+  it('is TRUE when zero lanes completed — the abstain-bearing shapes that used to exit 0', () => {
+    // A single abstained lane (the exact #2452 repro): output invoked but unextractable.
+    expect(hasNoCompletedLane([abstainedLane(0)])).toBe(true);
+    // Abstained + failed mix — still no usable verdict.
+    expect(hasNoCompletedLane([abstainedLane(0), failedLane(1)])).toBe(true);
+    // All lanes failed to invoke (the pre-existing all-failed case this predicate subsumes).
+    expect(hasNoCompletedLane([failedLane(0), failedLane(1)])).toBe(true);
+  });
+
+  it('is FALSE when at least one lane completed — a usable (even partially-degraded) fan', () => {
+    expect(hasNoCompletedLane([completedLane(0)])).toBe(false);
+    // The sharp guard: a completed + ABSTAINED mix must NOT trip the gate (completedLaneCount===1).
+    expect(hasNoCompletedLane([completedLane(0), abstainedLane(1)])).toBe(false);
+    expect(hasNoCompletedLane([completedLane(0), failedLane(1)])).toBe(false);
+  });
+
+  it('agrees with completedLaneCount === 0 by construction (the superRefine binds them)', () => {
+    for (const lanes of [
+      [completedLane(0)],
+      [abstainedLane(0)],
+      [completedLane(0), abstainedLane(1)],
+      [abstainedLane(0), failedLane(1)],
+    ]) {
+      const completedCount = lanes.filter((l) => l.status === 'completed').length;
+      expect(hasNoCompletedLane(lanes)).toBe(completedCount === 0);
+    }
   });
 });
 

--- a/packages/core/src/artifacts/verdict.ts
+++ b/packages/core/src/artifacts/verdict.ts
@@ -416,6 +416,26 @@ export function deriveCacheEligible(v: VerdictPredicateInput): boolean {
   );
 }
 
+/**
+ * The exit-contract's non-pass gate (mmnto-ai/totem#2452): a fan produced ZERO
+ * `completed` verdict lanes. `completed` is the ONLY lane status that carries a
+ * usable structured verdict — an `abstained` lane invoked but its output was not
+ * extractable (sensor-down), and a `failed` lane never produced one — so neither
+ * is a verdict. A zero-completed fan is therefore NEVER a review pass (Tenets
+ * 12/13: a provider-unsettled round is honest-absent, never an external pass);
+ * the CLI writes the honest verdict, then hard-errors on this predicate BEFORE
+ * any cache stamp so `--override` can never mint a push authorization from it.
+ *
+ * Expressed over `lanes` as the SINGLE SOURCE OF TRUTH the artifact's
+ * `completedLaneCount` is validated against (`VerdictArtifactSchema` superRefine
+ * binds `completedLaneCount === #completed`), so `hasNoCompletedLane(v.lanes)`
+ * and `v.completedLaneCount === 0` are equal by construction. An empty fan
+ * (guarded upstream as a distinct pre-attempt error) trivially has none.
+ */
+export function hasNoCompletedLane(lanes: readonly VerdictLane[]): boolean {
+  return !lanes.some((l) => l.status === 'completed');
+}
+
 // ─── Verdict artifact ──────────────────────────────────────────────────────
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -700,6 +700,7 @@ export {
   deriveLessonsConsulted,
   deriveSettled,
   findLatestVerdictForLineage,
+  hasNoCompletedLane,
   LaneIdSchema,
   LessonConsultedItemSchema,
   LessonsConsultedSchema,


### PR DESCRIPTION
## What & why

A `totem review` fan that finished with **zero completed verdict lanes** could exit **0** when `--fail-on` was omitted. The all-lanes-failed gate keyed on `completed || abstained`, so an **abstain-bearing** fan (a lane that invoked but whose output was unextractable — sensor-down) skipped the hard-error and read like a pass. The verdict artifact was already honest (`settled=false`, `completedLaneCount=0`) — **only the process exit code was wrong**. This is the exact shape observed while preparing #2451 (0/2 usable lanes, `settled=false`, exit 0).

This is **slice A of #2452** (the fan boundary), per the role-split with `@totem-codex`. Slice B (CLI-fallback evidence retention + `invoke-error` taxonomy + Sonnet-5 extraction fixtures) is codex's and lands separately; this slice was designed to land **independently** of it.

## The fix

- **Exit contract:** the gate now keys on **zero completed lanes** via a new exported core predicate `hasNoCompletedLane(lanes)` (⇔ `verdict.completedLaneCount === 0`, superRefine-bound). It fires **after** the honest verdict is saved and **before** the override/cache-stamp block — so `--override` can never mint a push authorization from a provider-unsettled round (**Tenets 12/13**; strategy #845). The widening is monotone: it subsumes the old all-failed gate.
- **Honest message:** enumerates `completed=0/abstained=N/failed=M` and states "non-pass, honest verdict written, not a crash" — the old "failed to invoke" wording was dishonest for an abstained lane that *did* invoke.
- **Budget split:** the fan report now reports diff-budget and total-prompt-budget as distinct numbers (`diff ⊆ prompt`), closing the double-count.

## Semver

**Minor** (both packages): the exit-code behavior is user-visible (a CI that exited 0 on an abstain-only fan now hard-errors — though that was a false pass), and core gains a new public export.

## Tests (the five-shape exit matrix + more)

New/changed coverage (`review-fan.test.ts`, `verdict.test.ts`):
- `hasNoCompletedLane` unit block (true/false shapes + agreement with `completedLaneCount`).
- **Flipped two existing tests that encoded the bug:** single-abstained (was `resolves` → now `rejects`, finding-8 post-check row preserved) and all-failed (message updated to the enumerated form).
- New: abstained+failed → rejects; **completed+abstained mix → still exit 0** (the sharp guard); `--fail-on` + zero-completed → zero-completed message wins (gate precedes fail-on); **`--override` + zero-completed → still rejects, no stamp** (override-proof); drift + zero-completed; budget-line containment.

## Gates

- `pnpm build` 5/5 · core **3271** tests · cli **3411** tests — all green
- `totem lint --base main` PASS (0 errors) · ESLint 0 errors · Prettier clean
- `totem review --base main`: **settled=true, 2/2 lanes, 0 critical / 0 warn** (dogfoods this fix); 2 INFO — one by-design (the intended behavior change), one addressed (message counts now read `verdict.lanes`, same collection as the gate).

## Provenance

Preflight design doc at `.totem/specs/2452.md`; a 2-lens pre-build design review (exit-semantics + test-matrix) returned SOUND-TO-IMPLEMENT and contributed the two existing-test flips and the containment assertion.

Part of #2452. Sibling: #2374 (worktree `.env`-cwd — needed to run the review lane here).