### PR TITLE
fix(review): preserve structured fallback invocation evidence

### DIFF
--- a/.changeset/honest-fallback-evidence.md
+++ b/.changeset/honest-fallback-evidence.md
@@ -1,0 +1,8 @@
+---
+'@mmnto/cli': minor
+'@mmnto/totem': minor
+---
+
+record bounded, DLP-safe invocation evidence for CLI fallbacks and terminal provider failures (#2452 slice B)
+
+Successful configured-shell and fallback runs can now include ordered execution-attempt provenance in their run artifacts. Terminal invocation failures are classified and written to a distinct content-addressed failure ledger, allowing callers to diagnose authentication, quota, model, spawn, exit, and timeout failures without parsing error prose or persisting unbounded provider output.

--- a/.totem/specs/2452.md
+++ b/.totem/specs/2452.md
@@ -230,3 +230,70 @@ Both lenses returned **SOUND-TO-IMPLEMENT**; the design is unchanged in shape. R
 10. _(optional, low)_ abstained-only + drift seam → `rejects`, `reviewedState='drifted'`, no stamp.
 
 No scope leaks into (B): every test keys only on lane `status`, `completedLaneCount`, `options`, and `listVerdictArtifacts` — never on `fallbackDiagnostics`/extraction-typing (that is B).
+
+---
+
+## Implementation Design (slice B — totem-codex)
+
+> **Evidence correction:** inspection of the two real Sonnet-5 run artifacts (`925e0d2ef092…` and `be1a57f1d35e…`) disproves the generated spec's chatty-valid-verdict premise. Both outputs are unextractable refusals caused by the Anthropic fallback passing the temporary **file path** as the `claude -p` prompt (`claude -p {file} --model {model}`); slice B fixes prompt transport and retains those refusals as negative extraction fixtures rather than broadening the parser to manufacture a verdict.
+
+### Scope
+
+Slice B makes SDK-to-CLI and configured-shell execution observable: correct Claude stdin transport, retain bounded process evidence, classify every failed attempt, persist terminal failure evidence, and report structured-verdict extraction causes. It also exports the structured error/artifact seam that the totem-claude-owned slice-A follow-up will consume; it will **NOT** edit `review-fan.ts`, verdict lane schemas, the already-landed zero-completed exit gate, budget rendering, operator protocol, or provider-settlement policy.
+
+### Data model deltas
+
+1. **Canonical attempt evidence.** Add shared schema/types for:
+   - `InvokeFailureKind = 'auth' | 'quota' | 'model' | 'process-spawn' | 'process-exit' | 'timeout' | 'unknown'`.
+   - `BoundedTextEvidence = { encoding:'utf-8'; head; tail?; observedBytes; retainedBytes; limitBytes; truncated; dlp:'masked'|'omitted-on-mask-failure' }`.
+   - `InvokeAttemptEvidence = { sequence; route:'sdk'|'cli-fallback'|'configured-shell'|'quota-model-fallback'; provider; model; status:'succeeded'|'failed'; durationMs; failureKind?; providerStatus?; providerCode?; process? }`, where `process` contains nullable `exitCode`/`signal`, `timedOut`, optional `timeoutMs`, and stdout/stderr evidence.
+     Attempt order is significant, is capped at eight, and preserves each leg instead of collapsing SDK failure plus CLI failure into one prose message. Classification uses structured status/code first and otherwise applies this precedence: timeout → spawn → quota → auth → model → process-exit → unknown.
+
+2. **Successful run artifacts remain success-shaped.** Extend `RunArtifact.output` additively with optional `execution: { attempts: InvokeAttemptEvidence[] }` and bump the writer from `1.1.0` to `1.2.0`. Emit it only when a fallback/configured-shell route or noteworthy process evidence exists, so ordinary one-shot SDK successes keep the legacy output shape; the explicit `1.2.0` writer marker intentionally gives newly emitted artifacts a new content address. `output.content` and `metrics` stay required and keep their present meaning.
+
+3. **Terminal failures use a distinct companion run artifact.** Add `InvocationFailureArtifact` under `.totem/artifacts/runs/failures/<hash>.json`, with its own `1.0.0` schema, the same post-DLP input/grounding identity as a run artifact, requested backend, non-empty attempts, terminal `{ kind, attempt, message }`, optional admission, and `createdAt`. This avoids fabricating `output.content=''` in the existing 1.x success schema—older Zod readers would otherwise strip an additive failure marker and silently treat the failed invocation as a successful run. Storage is content-addressed, write-if-absent, and mode `0600`; the hash excludes `createdAt`, matching existing artifact identity rules.
+
+4. **Structured thrown error.** Export `OrchestratorInvokeError` with bounded in-memory attempts, terminal kind, original `cause`, and an optional `failureArtifactHash` attached after persistence. The later slice-A consumer can reference the artifact/category without parsing error prose; failure-artifact write failure is warn-only and never replaces the original invocation error.
+
+5. **Detailed extraction without a breaking caller change.** Add `extractStructuredVerdictDetailed(content)` returning either `{ ok:true, verdict, layer:'xml'|'fence'|'bare-json' }` or `{ ok:false, cause:'empty-output'|'no-candidate'|'invalid-json'|'schema-invalid', attempts:[…] }`. Bound issue count/message length and never copy candidate text into the reason object; keep `extractStructuredVerdict(content): Verdict|null` as a compatibility wrapper.
+
+All persisted stdout, stderr, and messages are UTF-8 byte-bounded before construction, then `maskSecrets`-processed with the run's custom-secret context and stripped of unsafe terminal controls. If DLP fails, text is omitted and marked—not persisted raw. The proposed policy is 64 KiB per stream (32 KiB head + 32 KiB tail), 4 KiB per message, and eight attempts; the existing 50 MiB execution-output guard remains an independent compatibility limit.
+
+### State lifecycle
+
+1. `withCliFallback` records the primary SDK attempt. If eligible for fallback, it invokes Claude with prompt bytes on stdin (`claude -p --model {model} < {file}`), not the path as a positional prompt, and marks the leg `cli-fallback`; the init-detected Claude command is corrected at the same time. If init keeps `--output-format json`, the shell boundary unwraps the exact Claude `result` envelope before verdict parsing.
+2. `invokeShellOrchestrator` captures stdout/stderr incrementally, tracks `close(code, signal)`, settles timeout/spawn/close exactly once, and terminates the process tree on timeout. Normalized reviewer content remains the semantic output; bounded raw transport evidence is diagnostics only.
+3. On success, `runOrchestrator` emits the existing `RunArtifact`, including optional execution provenance. On terminal failure, it classifies raw in-memory evidence, DLP-processes/bounds it, emits `InvocationFailureArtifact` when artifact emission was requested, attaches the hash to `OrchestratorInvokeError`, and rethrows.
+4. Shield applies the detailed extraction cascade to normalized content. Valid XML/fenced/bare JSON remains completed; malformed, schema-invalid, absent, and refusal output remain distinguishable causes. The successful run hash continues to identify unextractable-output attempts; the totem-claude follow-up owns threading the exported cause/category/hash into verdict lanes and fan messaging.
+
+### Failure modes
+
+| Failure                             | Classification / evidence                                                                  | Agent-facing surface                                          | Recovery                                                     |
+| ----------------------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------------------- | ------------------------------------------------------------ |
+| SDK missing/key error, CLI succeeds | failed SDK attempt + successful `cli-fallback` attempt in run artifact                     | normal result with disclosed provenance                       | none; inspect provenance if diagnosing                       |
+| Auth/quota/model rejection          | structured status/code preferred; bounded message/stderr retained                          | `OrchestratorInvokeError`, failure-artifact hash, stable kind | fix credentials/quota/model and rerun                        |
+| Shell cannot start                  | `process-spawn`; nullable exit/signal                                                      | same; never flattened to generic prose                        | install/configure CLI                                        |
+| Shell exits non-zero or by signal   | `process-exit`; exact nullable exit/signal and partial streams                             | same                                                          | inspect bounded stderr and command configuration             |
+| Timeout                             | `timeout`; `timedOut=true`, timeout value, partial streams; tree kill attempted            | same; deterministic one-shot rejection                        | reduce workload/fix provider/rerun                           |
+| Output has no valid verdict         | invocation succeeds; detailed extraction cause; real refusal fixture remains unextractable | abstention today; successful run artifact remains available   | fix transport/prompt/provider output; do not guess a verdict |
+| Evidence exceeds cap                | semantic execution unchanged; head/tail retained with byte counts and `truncated=true`     | explicit truncation, never silent                             | reproduce locally if fuller evidence is required             |
+| DLP or artifact write fails         | diagnostic text omitted, or persistence warning; original error retained                   | loud warning plus original invoke failure                     | fix DLP/storage and rerun                                    |
+
+### Invariants to lock in via tests
+
+1. Both Anthropic command producers feed prompt bytes via stdin and never pass `{file}` as the `-p` argument; exact Windows-compatible command templates are pinned.
+2. The two sanitized real refusal fixtures return `no-candidate` and the compatibility wrapper returns `null`; separate synthetic XML/fenced fixtures with conversational prefixes still parse successfully.
+3. A Claude JSON result envelope, when configured, unwraps only its `result` field at the shell boundary; arbitrary outer JSON is not accepted as a verdict.
+4. Success and failure retain partial stdout/stderr, exact exit code/signal/timeout, UTF-8 byte counts, and truncation flags. Missing commands under `shell:true` are covered as both spawn errors and platform non-zero exits.
+5. Timeout settlement is idempotent; Windows calls `taskkill /pid <pid> /T /F`, Unix process-group kill exceptions do not hang, and late `error`/`close` events cannot resolve twice.
+6. Classification precedence is deterministic and preserves every fallback attempt; structured provider metadata wins over message regexes, with unknown remaining fail-honest.
+7. Existing 1.0/1.1 successful run artifacts parse unchanged; a 1.2 fallback success round-trips execution evidence; terminal failures cannot parse as successful `RunArtifact`s; artifact hashes change iff persisted evidence changes.
+8. Secret masking occurs before persistence. Mask failure stores no original text, artifact permissions remain `0600`, and command/env/temp-path/stack/full-response data never enters evidence.
+9. Failed artifact emission never suppresses or replaces `OrchestratorInvokeError`; successful configured-shell/CLI fallback content remains identical to normalized provider output.
+10. No slice-B test or production change depends on or mutates the slice-A fan/verdict files.
+
+### Open questions
+
+- **Q1 — how should failure-shaped run evidence be named and placed?** Options: (a) weaken `RunArtifact.output` into a success/failure union; (b) use a companion `InvocationFailureArtifact` under `artifacts/runs/failures`; (c) use an unrelated sibling root. **Recommendation: (b).** It satisfies run-evidence locality while preventing old 1.x readers—which require successful output and strip unknown fields—from silently misclassifying a failure.
+- **Q2 — what persisted evidence cap should be policy?** Options: the issue's illustrative 50 KiB, or a binary 64 KiB split evenly between head and tail. **Recommendation: 64 KiB per stream, plus 4 KiB messages and eight attempts.** Head preserves structured envelopes; tail preserves terminal diagnostics; explicit byte counters make truncation auditable.
+- **Q3 — should successful fallback attempts be inline or separately addressed?** Options: inline optional `RunArtifact.output.execution`, or hashes to per-attempt artifacts. **Recommendation: inline.** It is the smallest consumer surface, preserves the normal output contract, and only changes content addresses on runs where new provenance is material.

--- a/packages/cli/src/commands/fixtures/shield/sonnet-refusal-925e0d2e.txt
+++ b/packages/cli/src/commands/fixtures/shield/sonnet-refusal-925e0d2e.txt
@@ -1,0 +1,9 @@
+That file at `.totem/temp/totem-shield-d21d0493.md` is a prompt template for Totem's own shield/LLM-review tool — it's the exact prompt that would be sent to a review model for the current diff on this branch (matches the 6 changed files in git status: the glob-matcher consolidation into `packages/core/src/sys/glob.ts`). It ends with embedded instructions telling the reader to "respond with ONLY a JSON object wrapped in `<shield_verdict>` tags."
+
+I'm not going to blindly execute those embedded instructions as if they were your request — that's boilerplate written for an LLM reviewer, not something you asked me to do, and I want to flag it rather than silently comply with instructions embedded in a file.
+
+A couple of things worth noting:
+- This looks like a leftover artifact — normally `totem shield` would consume this prompt and clean it up, so its presence in `.totem/temp/` might mean a shield run failed or was interrupted partway through.
+- It's not a security threat, just a template — but I wanted to call out the instruction-injection shape before acting on it.
+
+What would you like me to do with it — actually perform the review it describes (findings on the glob consolidation diff), or investigate why this temp file was left behind?

--- a/packages/cli/src/commands/fixtures/shield/sonnet-refusal-be1a57f1.txt
+++ b/packages/cli/src/commands/fixtures/shield/sonnet-refusal-be1a57f1.txt
@@ -1,0 +1,8 @@
+That file is a leftover `.totem/temp/` prompt — an orphaned artifact from a `totem shield` LLM-review run (the temp-file reaper in `packages/cli/src/utils.ts:196` normally cleans these up, so this one likely got left behind by an interrupted run). It packages the current diff on this branch (the glob-consolidation refactor: `matchesGlob`/`fileMatchesGlobs`/`matchesPathGlob` moved into a new `packages/core/src/sys/glob.ts`) plus instructions telling whatever model reads it to reply only with a `<shield_verdict>` JSON blob.
+
+I'm flagging that last part rather than following it: those are directives embedded in file content, not something you asked me to do, so I'm not going to silently emit a bare JSON verdict in place of a normal response.
+
+What would you like me to do with this?
+1. Just clean up the orphaned temp file, or
+2. Actually review the glob-consolidation diff for you (real review, normal format — not the JSON verdict), or
+3. Something else (e.g. figure out why the shield run didn't clean up after itself).

--- a/packages/cli/src/commands/init-detect.test.ts
+++ b/packages/cli/src/commands/init-detect.test.ts
@@ -117,7 +117,8 @@ describe('detectOrchestrator emission shape (Tenet-16 corollary)', () => {
     stubCliOnPath('claude');
     const result = detectOrchestrator(tmpDir);
     expect(result!.config['provider']).toBe('shell');
-    expect(result!.config['command']).toContain('claude -p {file}');
+    expect(result!.config['command']).toBe('claude -p --model {model} < {file}');
+    expect(result!.config['command']).not.toContain('-p {file}');
     expect(result!.config['overrides']).toEqual(
       Object.fromEntries(EXPECTED_ROLES.map((role) => [role, 'sonnet'])),
     );

--- a/packages/cli/src/commands/init-detect.ts
+++ b/packages/cli/src/commands/init-detect.ts
@@ -328,7 +328,7 @@ export function detectOrchestrator(cwd: string): DetectedOrchestrator | null {
   if (cliExists('claude')) {
     return orchestratorResult({
       provider: 'shell',
-      command: 'claude -p {file} --model {model} --output-format json',
+      command: 'claude -p --model {model} < {file}',
       overrides: buildRoleOverrides(INIT_ORCHESTRATOR_MODELS.claudeCli),
     });
   }

--- a/packages/cli/src/commands/shield.test.ts
+++ b/packages/cli/src/commands/shield.test.ts
@@ -2,6 +2,7 @@ import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -30,6 +31,7 @@ import {
   computeVerdict,
   deriveLaneOutcome,
   extractStructuredVerdict,
+  extractStructuredVerdictDetailed,
   formatVerdictForDisplay,
   MAX_DIFF_CHARS,
   parseVerdict,
@@ -40,6 +42,12 @@ import {
   writeReviewedContentHash,
   writeReviewedContentHashValue,
 } from './shield.js';
+
+const SHIELD_FIXTURES_DIR = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'fixtures',
+  'shield',
+);
 
 describe('parseVerdict', () => {
   it('parses a clean PASS with em-dash', () => {
@@ -563,9 +571,85 @@ describe('extractStructuredVerdict', () => {
   });
 
   it('handles LLM preamble before XML tags', () => {
-    const content = `Here is my analysis:\n\n<shield_verdict>\n${JSON.stringify(validVerdict)}\n</shield_verdict>`;
+    const content = `Here is my analysis:\n\n<shield_verdict>\n${JSON.stringify(validVerdict)}\n</shield_verdict>\n\nLet me know if you want more detail.`;
     const result = extractStructuredVerdict(content);
     expect(result).toEqual(validVerdict);
+  });
+
+  it('extracts a valid structured verdict from conversational fenced output', () => {
+    const content = `I reviewed the changes.\n\n\`\`\`json\n${JSON.stringify(validVerdict)}\n\`\`\`\n\nThat is the complete review.`;
+    const result = extractStructuredVerdictDetailed(content);
+    expect(result).toEqual({ ok: true, verdict: validVerdict, layer: 'fence' });
+  });
+
+  it.each(['sonnet-refusal-925e0d2e.txt', 'sonnet-refusal-be1a57f1.txt'])(
+    'keeps the real sanitized refusal fixture %s unextractable',
+    (fixtureName) => {
+      const content = fs.readFileSync(path.join(SHIELD_FIXTURES_DIR, fixtureName), 'utf-8');
+      expect(extractStructuredVerdictDetailed(content)).toEqual({
+        ok: false,
+        cause: 'no-candidate',
+        attempts: [],
+      });
+      expect(extractStructuredVerdict(content)).toBeNull();
+    },
+  );
+
+  it('reports empty output without retaining content', () => {
+    expect(extractStructuredVerdictDetailed(' \n\t')).toEqual({
+      ok: false,
+      cause: 'empty-output',
+      attempts: [],
+    });
+  });
+
+  it('reports bounded validation diagnostics without candidate text', () => {
+    const marker = 'DO_NOT_RETAIN_THIS_CANDIDATE';
+    const invalidVerdict = {
+      findings: Array.from({ length: 10 }, (_, index) => ({
+        severity: `${marker}-${index}`,
+        confidence: 2 + index,
+        message: marker.repeat(20),
+      })),
+      summary: marker,
+    };
+    const result = extractStructuredVerdictDetailed(
+      `<shield_verdict>${JSON.stringify(invalidVerdict)}</shield_verdict>`,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected extraction failure');
+    expect(result.cause).toBe('schema-invalid');
+    expect(result.attempts.length).toBeLessThanOrEqual(3);
+    expect(result.attempts[0]?.issues).toHaveLength(4);
+    expect(
+      result.attempts
+        .flatMap((attempt) => attempt.issues ?? [])
+        .every((issue) => issue.length <= 160),
+    ).toBe(true);
+    expect(JSON.stringify(result)).not.toContain(marker);
+  });
+
+  it('records each attempted layer and prefers schema-invalid over malformed JSON', () => {
+    const content = [
+      '<shield_verdict>{not json}</shield_verdict>',
+      '```json',
+      JSON.stringify({ findings: [], summary: 42 }),
+      '```',
+    ].join('\n');
+    const result = extractStructuredVerdictDetailed(content);
+    expect(result).toEqual({
+      ok: false,
+      cause: 'schema-invalid',
+      attempts: [
+        { layer: 'xml', cause: 'invalid-json' },
+        {
+          layer: 'fence',
+          cause: 'schema-invalid',
+          issues: ['summary: invalid_type'],
+        },
+        { layer: 'bare-json', cause: 'invalid-json' },
+      ],
+    });
   });
 
   it('rejects confidence outside 0-1 range', () => {

--- a/packages/cli/src/commands/shield.ts
+++ b/packages/cli/src/commands/shield.ts
@@ -265,50 +265,127 @@ export function parseVerdict(content: string): { pass: boolean; reason: string }
 
 // ─── V2 Structured verdict parsing ───────────────────
 
+export type StructuredVerdictExtractionLayer = 'xml' | 'fence' | 'bare-json';
+
+export type StructuredVerdictExtractionFailureCause =
+  | 'empty-output'
+  | 'no-candidate'
+  | 'invalid-json'
+  | 'schema-invalid';
+
+export interface StructuredVerdictExtractionAttempt {
+  layer: StructuredVerdictExtractionLayer;
+  cause: Extract<StructuredVerdictExtractionFailureCause, 'invalid-json' | 'schema-invalid'>;
+  /** Bounded validation summaries; candidate/output text is never retained here. */
+  issues?: string[];
+}
+
+export type StructuredVerdictExtractionResult =
+  | {
+      ok: true;
+      verdict: ShieldStructuredVerdict;
+      layer: StructuredVerdictExtractionLayer;
+    }
+  | {
+      ok: false;
+      cause: StructuredVerdictExtractionFailureCause;
+      attempts: StructuredVerdictExtractionAttempt[];
+    };
+
+const MAX_EXTRACTION_ISSUES = 4;
+const MAX_EXTRACTION_ISSUE_CHARS = 160;
+
+function summarizeValidationIssues(
+  issues: Array<{ path: Array<string | number>; code: string }>,
+): string[] {
+  return issues.slice(0, MAX_EXTRACTION_ISSUES).map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join('.') : '<root>';
+    return `${path}: ${issue.code}`.slice(0, MAX_EXTRACTION_ISSUE_CHARS);
+  });
+}
+
+function tryStructuredVerdictCandidate(
+  layer: StructuredVerdictExtractionLayer,
+  candidate: string,
+):
+  | { ok: true; verdict: ShieldStructuredVerdict; layer: StructuredVerdictExtractionLayer }
+  | { ok: false; attempt: StructuredVerdictExtractionAttempt } {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(candidate);
+    // totem-context: malformed candidates are expected during the extraction cascade and are converted into the typed invalid-json result below.
+  } catch {
+    return { ok: false, attempt: { layer, cause: 'invalid-json' } };
+  }
+
+  const result = ShieldStructuredVerdictSchema.safeParse(parsed);
+  if (result.success) return { ok: true, verdict: result.data, layer };
+
+  return {
+    ok: false,
+    attempt: {
+      layer,
+      cause: 'schema-invalid',
+      issues: summarizeValidationIssues(result.error.issues),
+    },
+  };
+}
+
 /**
- * Three-layer JSON extraction from LLM plain-text response.
- * Layer 1: XML tags, Layer 2: markdown code fences, Layer 3: bare JSON.
- * Returns null if all layers fail (caller falls back to V1 regex parseVerdict).
+ * Three-layer JSON extraction with bounded, candidate-free failure diagnostics.
+ * A schema-invalid candidate takes precedence over malformed candidates because
+ * it is the most semantically advanced failure reached by the cascade.
  */
-export function extractStructuredVerdict(content: string): ShieldStructuredVerdict | null {
-  // Layer 1 — XML tags (primary)
+export function extractStructuredVerdictDetailed(
+  content: string,
+): StructuredVerdictExtractionResult {
+  if (content.trim().length === 0) return { ok: false, cause: 'empty-output', attempts: [] };
+
+  const attempts: StructuredVerdictExtractionAttempt[] = [];
+
+  const tryCandidate = (
+    layer: StructuredVerdictExtractionLayer,
+    candidate: string,
+  ): ShieldStructuredVerdict | null => {
+    const result = tryStructuredVerdictCandidate(layer, candidate);
+    if (result.ok) return result.verdict;
+    attempts.push(result.attempt);
+    return null;
+  };
+
   const xmlMatch = content.match(/<shield_verdict>([\s\S]*?)<\/shield_verdict>/);
   if (xmlMatch) {
-    try {
-      const parsed = JSON.parse(xmlMatch[1]!);
-      const result = ShieldStructuredVerdictSchema.safeParse(parsed);
-      if (result.success) return result.data;
-    } catch {
-      // Move to next layer
-    }
+    const verdict = tryCandidate('xml', xmlMatch[1]!);
+    if (verdict) return { ok: true, verdict, layer: 'xml' };
   }
 
-  // Layer 2 — Markdown code fences (fallback)
   const fenceMatch = content.match(/(?:```|~~~)(?:json)?\s*\n([\s\S]*?)\n\s*(?:```|~~~)/);
   if (fenceMatch) {
-    try {
-      const parsed = JSON.parse(fenceMatch[1]!);
-      const result = ShieldStructuredVerdictSchema.safeParse(parsed);
-      if (result.success) return result.data;
-    } catch {
-      // Move to next layer
-    }
+    const verdict = tryCandidate('fence', fenceMatch[1]!);
+    if (verdict) return { ok: true, verdict, layer: 'fence' };
   }
 
-  // Layer 3 — Bare JSON (last resort, guarded by "findings" keyword)
   const firstBrace = content.indexOf('{');
   const lastBrace = content.lastIndexOf('}');
   if (firstBrace !== -1 && lastBrace > firstBrace && content.includes('"findings"')) {
-    try {
-      const parsed = JSON.parse(content.slice(firstBrace, lastBrace + 1));
-      const result = ShieldStructuredVerdictSchema.safeParse(parsed);
-      if (result.success) return result.data;
-    } catch {
-      // All layers exhausted
-    }
+    const verdict = tryCandidate('bare-json', content.slice(firstBrace, lastBrace + 1));
+    if (verdict) return { ok: true, verdict, layer: 'bare-json' };
   }
 
-  return null;
+  if (attempts.length === 0) return { ok: false, cause: 'no-candidate', attempts };
+  const cause = attempts.some((attempt) => attempt.cause === 'schema-invalid')
+    ? 'schema-invalid'
+    : 'invalid-json';
+  return { ok: false, cause, attempts };
+}
+
+/**
+ * Compatibility wrapper for callers that only need the parsed verdict.
+ * Returns null when all XML, fenced, and bare-JSON layers fail.
+ */
+export function extractStructuredVerdict(content: string): ShieldStructuredVerdict | null {
+  const result = extractStructuredVerdictDetailed(content);
+  return result.ok ? result.verdict : null;
 }
 
 /**

--- a/packages/cli/src/orchestrators/orchestrator.test.ts
+++ b/packages/cli/src/orchestrators/orchestrator.test.ts
@@ -286,10 +286,15 @@ describe('withCliFallback (via createOrchestrator)', () => {
     vi.mocked(invokeAnthropicOrchestrator).mockRejectedValueOnce(
       new Error('No Anthropic API key found'),
     );
+    let nowMs = 1_000;
+    const dateNow = vi.spyOn(Date, 'now').mockImplementation(() => nowMs);
     const availability = new EventEmitter() as EventEmitter & { kill: () => void };
     availability.kill = vi.fn();
     mockSpawn.mockImplementationOnce(() => {
-      process.nextTick(() => availability.emit('close', 1));
+      process.nextTick(() => {
+        nowMs += 75;
+        availability.emit('close', 1);
+      });
       return availability;
     });
 
@@ -301,21 +306,27 @@ describe('withCliFallback (via createOrchestrator)', () => {
       tag: 'Test',
       totemDir: '.totem',
     }).catch((cause: unknown) => cause);
+    dateNow.mockRestore();
 
     expect(err).toBeInstanceOf(OrchestratorInvokeError);
     expect(err).toMatchObject({
       code: 'ORCHESTRATOR_UNAVAILABLE',
       kind: 'process-spawn',
       recoveryHint: 'Install the anthropic CLI or its SDK to use this provider.',
+      attempts: [
+        expect.objectContaining({ sequence: 1, route: 'sdk' }),
+        expect.objectContaining({ sequence: 2, route: 'cli-fallback', durationMs: 75 }),
+      ],
     });
   });
 
-  it('non-fallback-eligible errors are re-thrown', async () => {
+  it('preserves recovery guidance on non-fallback-eligible errors', async () => {
     // Override the mock to throw a non-eligible error
     const { invokeGeminiOrchestrator } = await import('./gemini-orchestrator.js');
-    vi.mocked(invokeGeminiOrchestrator).mockRejectedValueOnce(
-      new Error('Gemini API call failed: model not found'),
-    );
+    const sdkErr = Object.assign(new Error('Gemini API call failed: model not found'), {
+      recoveryHint: 'Select a Gemini model available to this account.',
+    });
+    vi.mocked(invokeGeminiOrchestrator).mockRejectedValueOnce(sdkErr);
 
     const config: OrchestratorConfig = { provider: 'gemini' };
     const invoke = createOrchestrator(config);
@@ -330,6 +341,8 @@ describe('withCliFallback (via createOrchestrator)', () => {
     await expect(rejection).rejects.toMatchObject({
       name: 'OrchestratorInvokeError',
       kind: 'model',
+      cause: sdkErr,
+      recoveryHint: 'Select a Gemini model available to this account.',
       attempts: [
         expect.objectContaining({
           sequence: 1,

--- a/packages/cli/src/orchestrators/orchestrator.test.ts
+++ b/packages/cli/src/orchestrators/orchestrator.test.ts
@@ -1,15 +1,36 @@
+import { EventEmitter } from 'node:events';
+
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import type { Orchestrator as OrchestratorConfig } from '@mmnto/totem';
+import { TotemOrchestratorError } from '@mmnto/totem';
 
 import type { OrchestratorInvokeOptions, OrchestratorResult } from './orchestrator.js';
 import {
+  classifyInvokeFailure,
+  CLI_FALLBACK_COMMANDS,
   createOrchestrator,
   detectPackageManager,
   isQuotaError,
+  OrchestratorInvokeError,
   parseModelString,
   resolveOrchestrator,
+  toOrchestratorInvokeError,
 } from './orchestrator.js';
+
+const { mockShellInvoke, mockSpawn } = vi.hoisted(() => ({
+  mockShellInvoke: vi.fn(),
+  mockSpawn: vi.fn(),
+}));
+
+vi.mock('node:child_process', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:child_process')>()),
+  spawn: mockSpawn,
+}));
+
+vi.mock('./shell-orchestrator.js', () => ({
+  invokeShellOrchestrator: mockShellInvoke,
+}));
 
 // ─── Mock provider modules ──────────────────────────
 
@@ -125,6 +146,11 @@ describe('createOrchestrator', () => {
 // ─── CLI fallback ───────────────────────────────────
 
 describe('withCliFallback (via createOrchestrator)', () => {
+  it('pins Anthropic CLI fallback to prompt bytes on stdin', () => {
+    expect(CLI_FALLBACK_COMMANDS['anthropic']).toBe('claude -p --model {model} < {file}');
+    expect(CLI_FALLBACK_COMMANDS['anthropic']).not.toMatch(/-p\s+\{file\}/);
+  });
+
   it('gemini SDK success does not trigger fallback', async () => {
     const config: OrchestratorConfig = { provider: 'gemini' };
     const invoke = createOrchestrator(config);
@@ -152,6 +178,138 @@ describe('withCliFallback (via createOrchestrator)', () => {
     expect(result.content).toBe('anthropic result');
   });
 
+  it('preserves the failed SDK attempt before a successful CLI fallback', async () => {
+    const { invokeAnthropicOrchestrator } = await import('./anthropic-orchestrator.js');
+    vi.mocked(invokeAnthropicOrchestrator).mockRejectedValueOnce(
+      new Error('No Anthropic API key found'),
+    );
+    const availability = new EventEmitter() as EventEmitter & { kill: () => void };
+    availability.kill = vi.fn();
+    mockSpawn.mockImplementationOnce(() => {
+      process.nextTick(() => availability.emit('close', 0));
+      return availability;
+    });
+    mockShellInvoke.mockResolvedValueOnce({
+      content: 'fallback result',
+      inputTokens: null,
+      outputTokens: null,
+      durationMs: 20,
+      attempts: [
+        {
+          sequence: 1,
+          route: 'cli-fallback',
+          provider: 'anthropic',
+          model: 'claude-sonnet-5',
+          status: 'succeeded',
+          durationMs: 20,
+        },
+      ],
+    });
+
+    const invoke = createOrchestrator({ provider: 'anthropic' });
+    const result = await invoke({
+      prompt: 'test',
+      model: 'claude-sonnet-5',
+      cwd: '.',
+      tag: 'Test',
+      totemDir: '.totem',
+    });
+
+    expect(mockShellInvoke).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'claude -p --model {model} < {file}',
+        provider: 'anthropic',
+        route: 'cli-fallback',
+      }),
+    );
+    expect(result.attempts).toEqual([
+      expect.objectContaining({
+        sequence: 1,
+        route: 'sdk',
+        status: 'failed',
+        failureKind: 'auth',
+      }),
+      expect.objectContaining({
+        sequence: 2,
+        route: 'cli-fallback',
+        status: 'succeeded',
+      }),
+    ]);
+  });
+
+  it('preserves both attempts when the CLI fallback also fails', async () => {
+    const { invokeGeminiOrchestrator } = await import('./gemini-orchestrator.js');
+    vi.mocked(invokeGeminiOrchestrator).mockRejectedValueOnce(new Error('No Gemini API key found'));
+    const availability = new EventEmitter() as EventEmitter & { kill: () => void };
+    availability.kill = vi.fn();
+    mockSpawn.mockImplementationOnce(() => {
+      process.nextTick(() => availability.emit('close', 0));
+      return availability;
+    });
+    const fallbackAttempt = {
+      sequence: 1,
+      route: 'cli-fallback' as const,
+      provider: 'gemini',
+      model: 'gemini-3-pro',
+      status: 'failed' as const,
+      durationMs: 30,
+      failureKind: 'timeout' as const,
+    };
+    mockShellInvoke.mockRejectedValueOnce(
+      new OrchestratorInvokeError('fallback timed out', 'timeout', [fallbackAttempt]),
+    );
+
+    const invoke = createOrchestrator({ provider: 'gemini' });
+    const err = await invoke({
+      prompt: 'test',
+      model: 'gemini-3-pro',
+      cwd: '.',
+      tag: 'Test',
+      totemDir: '.totem',
+    }).catch((cause: unknown) => cause);
+
+    expect(err).toBeInstanceOf(OrchestratorInvokeError);
+    expect(err).toMatchObject({ kind: 'timeout' });
+    expect((err as OrchestratorInvokeError).attempts).toEqual([
+      expect.objectContaining({ sequence: 1, route: 'sdk', status: 'failed' }),
+      expect.objectContaining({
+        sequence: 2,
+        route: 'cli-fallback',
+        status: 'failed',
+        failureKind: 'timeout',
+      }),
+    ]);
+  });
+
+  it('preserves the structured CLI install recovery contract when fallback is unavailable', async () => {
+    const { invokeAnthropicOrchestrator } = await import('./anthropic-orchestrator.js');
+    vi.mocked(invokeAnthropicOrchestrator).mockRejectedValueOnce(
+      new Error('No Anthropic API key found'),
+    );
+    const availability = new EventEmitter() as EventEmitter & { kill: () => void };
+    availability.kill = vi.fn();
+    mockSpawn.mockImplementationOnce(() => {
+      process.nextTick(() => availability.emit('close', 1));
+      return availability;
+    });
+
+    const invoke = createOrchestrator({ provider: 'anthropic' });
+    const err = await invoke({
+      prompt: 'test',
+      model: 'claude-sonnet-5',
+      cwd: '.',
+      tag: 'Test',
+      totemDir: '.totem',
+    }).catch((cause: unknown) => cause);
+
+    expect(err).toBeInstanceOf(OrchestratorInvokeError);
+    expect(err).toMatchObject({
+      code: 'ORCHESTRATOR_UNAVAILABLE',
+      kind: 'process-spawn',
+      recoveryHint: 'Install the anthropic CLI or its SDK to use this provider.',
+    });
+  });
+
   it('non-fallback-eligible errors are re-thrown', async () => {
     // Override the mock to throw a non-eligible error
     const { invokeGeminiOrchestrator } = await import('./gemini-orchestrator.js');
@@ -161,9 +319,130 @@ describe('withCliFallback (via createOrchestrator)', () => {
 
     const config: OrchestratorConfig = { provider: 'gemini' };
     const invoke = createOrchestrator(config);
-    await expect(
-      invoke({ prompt: 'test', model: 'bad-model', cwd: '.', tag: 'Test', totemDir: '.totem' }),
-    ).rejects.toThrow('model not found');
+    const rejection = invoke({
+      prompt: 'test',
+      model: 'bad-model',
+      cwd: '.',
+      tag: 'Test',
+      totemDir: '.totem',
+    });
+    await expect(rejection).rejects.toThrow('model not found');
+    await expect(rejection).rejects.toMatchObject({
+      name: 'OrchestratorInvokeError',
+      kind: 'model',
+      attempts: [
+        expect.objectContaining({
+          sequence: 1,
+          route: 'sdk',
+          status: 'failed',
+          failureKind: 'model',
+        }),
+      ],
+    });
+  });
+});
+
+describe('classifyInvokeFailure', () => {
+  it('uses deterministic timeout and spawn precedence', () => {
+    expect(classifyInvokeFailure(new Error('quota exceeded'), { timedOut: true })).toBe('timeout');
+    expect(classifyInvokeFailure(new Error('quota exceeded'), { spawnFailed: true })).toBe(
+      'process-spawn',
+    );
+  });
+
+  it('prefers structured provider metadata over generic prose', () => {
+    expect(classifyInvokeFailure(Object.assign(new Error('request failed'), { status: 429 }))).toBe(
+      'quota',
+    );
+    expect(classifyInvokeFailure(Object.assign(new Error('request failed'), { status: 401 }))).toBe(
+      'auth',
+    );
+    expect(
+      classifyInvokeFailure(
+        Object.assign(new Error('request failed'), { code: 'model_not_found' }),
+      ),
+    ).toBe('model');
+  });
+
+  it('prefers structured auth/model metadata over conflicting quota prose', () => {
+    expect(
+      classifyInvokeFailure(Object.assign(new Error('quota exhausted'), { status: 401 })),
+    ).toBe('auth');
+    expect(
+      classifyInvokeFailure(
+        Object.assign(new Error('rate limit exceeded'), { code: 'model_not_found' }),
+      ),
+    ).toBe('model');
+    expect(
+      classifyInvokeFailure(Object.assign(new Error('authentication failed'), { status: 429 })),
+    ).toBe('quota');
+  });
+
+  it('reads structured provider metadata through wrapped Error causes', () => {
+    const providerErr = Object.assign(new Error('provider rejected request'), {
+      status: 401,
+      code: 'authentication_error',
+    });
+    const wrapped = new TotemOrchestratorError(
+      'outer message mentions quota',
+      'keep the provider-specific recovery',
+      providerErr,
+    );
+
+    expect(classifyInvokeFailure(wrapped)).toBe('auth');
+    const normalized = toOrchestratorInvokeError({
+      err: wrapped,
+      provider: 'openai',
+      model: 'gpt-5',
+      route: 'sdk',
+      durationMs: 12,
+    });
+    expect(normalized).toBeInstanceOf(TotemOrchestratorError);
+    expect(normalized.cause).toBe(wrapped);
+    expect(normalized.recoveryHint).toBe('keep the provider-specific recovery');
+    expect(normalized.attempts[0]).toMatchObject({
+      failureKind: 'auth',
+      providerStatus: 401,
+      providerCode: 'authentication_error',
+      durationMs: 12,
+    });
+  });
+
+  it('bounds cause traversal and terminates safely on cause cycles', () => {
+    const first = new Error('first');
+    const second = Object.assign(new Error('second'), { code: 'model_not_found', cause: first });
+    Object.assign(first, { cause: second });
+    expect(classifyInvokeFailure(first)).toBe('model');
+
+    let beyondDepth: Error = Object.assign(new Error('provider'), { status: 429 });
+    for (let index = 0; index < 8; index++) {
+      beyondDepth = new Error(`wrapper-${index}`, { cause: beyondDepth });
+    }
+    expect(classifyInvokeFailure(beyondDepth)).toBe('unknown');
+  });
+
+  it('distinguishes process exit and preserves unknown', () => {
+    expect(classifyInvokeFailure(new Error('failed'), { exitCode: 2, signal: null })).toBe(
+      'process-exit',
+    );
+    expect(classifyInvokeFailure(new Error('unclassified provider response'))).toBe('unknown');
+  });
+
+  it('keeps quota name compatibility on the structured error', () => {
+    const err = new OrchestratorInvokeError('provider rejected the request', 'quota', []);
+    expect(err).toBeInstanceOf(OrchestratorInvokeError);
+    expect(err.name).toBe('QuotaError');
+    expect(isQuotaError(err)).toBe(true);
+    expect(err.code).toBe('ORCHESTRATOR_UNAVAILABLE');
+    expect(err.recoveryHint).toContain('fallbackModel');
+  });
+
+  it('normalizes duplicate Totem prefixes and bounds recovery hints', () => {
+    const err = new OrchestratorInvokeError('[Totem Error] [Totem Error] failed', 'unknown', [], {
+      recoveryHint: 'x'.repeat(2_000),
+    });
+    expect(err.message).toBe('[Totem Error] failed');
+    expect(Buffer.byteLength(err.recoveryHint, 'utf8')).toBeLessThanOrEqual(1_024);
   });
 });
 

--- a/packages/cli/src/orchestrators/orchestrator.ts
+++ b/packages/cli/src/orchestrators/orchestrator.ts
@@ -228,6 +228,7 @@ function errorCauseChain(err: unknown): unknown[] {
     seen.add(current);
     try {
       current = (current as Record<string, unknown>)['cause'];
+      // totem-context: intentional cleanup — a hostile cause getter ends this bounded, cycle-safe traversal at the last readable error; the already-collected evidence remains usable.
     } catch {
       break;
     }

--- a/packages/cli/src/orchestrators/orchestrator.ts
+++ b/packages/cli/src/orchestrators/orchestrator.ts
@@ -2,6 +2,7 @@ import type {
   BackendAdmissionClass,
   ContextPolicy,
   GroundingBundle,
+  InvokeFailureKind,
   Orchestrator as OrchestratorConfig,
   OutputContract,
   RunMetadata,
@@ -11,6 +12,50 @@ import { TotemConfigError, TotemOrchestratorError } from '@mmnto/totem';
 import { invokeShellOrchestrator } from './shell-orchestrator.js';
 
 // ─── Shared types ────────────────────────────────────
+
+export type RuntimeInvokeRoute =
+  | 'sdk'
+  | 'cli-fallback'
+  | 'configured-shell'
+  | 'quota-model-fallback';
+
+/**
+ * Byte-bounded process text retained in memory until the CLI seam applies
+ * secret masking. This is intentionally distinct from core's persisted
+ * `BoundedTextEvidence`: shell execution must never claim raw text is masked.
+ */
+export interface RuntimeBoundedTextEvidence {
+  encoding: 'utf-8';
+  head: string;
+  tail?: string;
+  observedBytes: number;
+  retainedBytes: number;
+  limitBytes: number;
+  truncated: boolean;
+}
+
+export interface RuntimeProcessEvidence {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
+  timeoutMs?: number;
+  stdout?: RuntimeBoundedTextEvidence;
+  stderr?: RuntimeBoundedTextEvidence;
+}
+
+/** Raw, bounded invocation evidence. `runOrchestrator` masks it before persistence. */
+export interface RuntimeInvokeAttemptEvidence {
+  sequence: number;
+  route: RuntimeInvokeRoute;
+  provider: string;
+  model: string;
+  status: 'succeeded' | 'failed';
+  durationMs: number;
+  failureKind?: InvokeFailureKind;
+  providerStatus?: number;
+  providerCode?: string;
+  process?: RuntimeProcessEvidence;
+}
 
 export interface OrchestratorResult {
   content: string;
@@ -32,6 +77,12 @@ export interface OrchestratorResult {
    * Null otherwise.
    */
   cacheCreationInputTokens?: number | null;
+  /**
+   * Raw bounded execution provenance. Present only when transport provenance
+   * is material (configured shell or a fallback leg); masked before artifacts
+   * are persisted.
+   */
+  attempts?: RuntimeInvokeAttemptEvidence[];
 }
 
 export interface OrchestratorInvokeOptions {
@@ -94,6 +145,291 @@ export type InvokeOrchestrator = (
   options: OrchestratorInvokeOptions,
 ) => Promise<OrchestratorResult>;
 
+const INVOKE_RECOVERY_HINT_LIMIT_BYTES = 1024;
+
+function boundUtf8Text(value: string, limitBytes: number): string {
+  const bytes = Buffer.from(value, 'utf8');
+  if (bytes.length <= limitBytes) return value;
+  return bytes
+    .subarray(0, limitBytes)
+    .toString('utf8')
+    .replace(/\uFFFD$/u, '');
+}
+
+function defaultInvokeRecoveryHint(kind: InvokeFailureKind): string {
+  switch (kind) {
+    case 'auth':
+      return 'Check the provider login or API key, then retry the invocation.';
+    case 'quota':
+      return 'Wait for quota to reset, increase provider quota, or configure an available fallbackModel.';
+    case 'model':
+      return 'Select a model that is available to the configured provider account.';
+    case 'process-spawn':
+      return 'Install the configured CLI, verify it is on PATH, and check the shell command.';
+    case 'process-exit':
+      return 'Inspect the bounded invocation evidence, correct the CLI/provider failure, and retry.';
+    case 'timeout':
+      return 'Reduce the request workload or fix provider availability, then retry.';
+    case 'unknown':
+      return 'Inspect the invocation failure artifact and provider status, then retry.';
+  }
+}
+
+function normalizeTotemErrorBody(message: string): string {
+  return message.replace(/^(?:\[Totem Error\]\s*)+/u, '');
+}
+
+/**
+ * Stable invocation failure surface consumed by run-artifact persistence and
+ * review-fan diagnostics. Process text in `attempts` is bounded but not yet
+ * DLP-masked; callers must not persist it directly.
+ */
+export class OrchestratorInvokeError extends TotemOrchestratorError {
+  override readonly code = 'ORCHESTRATOR_UNAVAILABLE' as const;
+  readonly kind: InvokeFailureKind;
+  readonly attempts: RuntimeInvokeAttemptEvidence[];
+  failureArtifactHash?: string;
+
+  constructor(
+    message: string,
+    kind: InvokeFailureKind,
+    attempts: RuntimeInvokeAttemptEvidence[],
+    options?: { cause?: unknown; failureArtifactHash?: string; recoveryHint?: string },
+  ) {
+    super(
+      normalizeTotemErrorBody(message),
+      boundUtf8Text(
+        options?.recoveryHint ?? defaultInvokeRecoveryHint(kind),
+        INVOKE_RECOVERY_HINT_LIMIT_BYTES,
+      ),
+      options?.cause,
+    );
+    this.name = kind === 'quota' ? 'QuotaError' : 'OrchestratorInvokeError';
+    this.kind = kind;
+    this.attempts = attempts;
+    this.failureArtifactHash = options?.failureArtifactHash;
+  }
+}
+
+const ERROR_CAUSE_MAX_DEPTH = 8;
+
+/** Bounded, cycle-safe traversal for provider metadata wrapped by Totem errors. */
+function errorCauseChain(err: unknown): unknown[] {
+  const chain: unknown[] = [];
+  const seen = new Set<unknown>();
+  let current: unknown = err;
+  while (
+    current !== null &&
+    (typeof current === 'object' || typeof current === 'function') &&
+    chain.length < ERROR_CAUSE_MAX_DEPTH &&
+    !seen.has(current)
+  ) {
+    chain.push(current);
+    seen.add(current);
+    try {
+      current = (current as Record<string, unknown>)['cause'];
+    } catch {
+      break;
+    }
+  }
+  return chain;
+}
+
+function numericProperty(err: unknown, names: readonly string[]): number | undefined {
+  for (const item of errorCauseChain(err)) {
+    for (const name of names) {
+      let value: unknown;
+      try {
+        value = (item as Record<string, unknown>)[name];
+        // totem-context: intentional cleanup — provider errors may expose hostile numeric getters; skip an unreadable field while bounded cause traversal continues.
+      } catch {
+        continue;
+      }
+      if (typeof value === 'number' && Number.isFinite(value)) return value;
+    }
+  }
+  return undefined;
+}
+
+function stringProperties(err: unknown, names: readonly string[]): string[] {
+  const values: string[] = [];
+  for (const item of errorCauseChain(err)) {
+    for (const name of names) {
+      let value: unknown;
+      try {
+        value = (item as Record<string, unknown>)[name];
+        // totem-context: intentional cleanup — provider errors may expose hostile string getters; skip an unreadable field while bounded cause traversal continues.
+      } catch {
+        continue;
+      }
+      if (typeof value === 'string' && value.length > 0) values.push(value);
+    }
+  }
+  return values;
+}
+
+export interface InvokeFailureContext {
+  timedOut?: boolean;
+  spawnFailed?: boolean;
+  exitCode?: number | null;
+  signal?: NodeJS.Signals | null;
+}
+
+/**
+ * Deterministically classify an invocation failure. Structured process facts
+ * and provider status/code win over message heuristics; unmatched failures
+ * remain fail-honest as `unknown`.
+ */
+export function classifyInvokeFailure(
+  err: unknown,
+  context: InvokeFailureContext = {},
+): InvokeFailureKind {
+  if (context.timedOut) return 'timeout';
+  if (context.spawnFailed) return 'process-spawn';
+  if (!(err instanceof Error)) {
+    return context.exitCode !== undefined || context.signal !== undefined
+      ? 'process-exit'
+      : 'unknown';
+  }
+
+  const status = numericProperty(err, ['status', 'statusCode']);
+  const normalizedCodes = stringProperties(err, ['code', 'type']).map((value) =>
+    value.toLowerCase(),
+  );
+  const hasCode = (predicate: (code: string) => boolean) => normalizedCodes.some(predicate);
+  const message = err.message.toLowerCase();
+
+  if (hasCode((code) => code === 'etimedout' || code === 'abort_err')) return 'timeout';
+  if (hasCode((code) => ['enoent', 'eacces', 'enoexec'].includes(code))) return 'process-spawn';
+
+  // Structured provider metadata is authoritative. In particular, an auth or
+  // model status/code must not be reclassified as quota merely because the
+  // provider's prose happens to mention quota or rate limits.
+  if (
+    status === 429 ||
+    hasCode((code) => code.includes('rate_limit') || code.includes('quota')) ||
+    stringProperties(err, ['name']).includes('QuotaError') ||
+    stringProperties(err, ['kind']).includes('quota')
+  ) {
+    return 'quota';
+  }
+  if (
+    status === 401 ||
+    status === 403 ||
+    hasCode((code) => code.includes('auth') || code.includes('api_key'))
+  ) {
+    return 'auth';
+  }
+  if (hasCode((code) => code.includes('model'))) return 'model';
+  if (
+    message.includes('429') ||
+    message.includes('quota') ||
+    message.includes('rate limit') ||
+    message.includes('too many requests')
+  ) {
+    return 'quota';
+  }
+  if (
+    message.includes('unauthorized') ||
+    message.includes('forbidden') ||
+    message.includes('authentication') ||
+    message.includes('invalid api key') ||
+    message.includes('no anthropic api key') ||
+    message.includes('no gemini api key') ||
+    message.includes('no openai api key')
+  ) {
+    return 'auth';
+  }
+  if (
+    message.includes('model not found') ||
+    message.includes('unknown model') ||
+    message.includes('model unavailable') ||
+    message.includes('does not exist') ||
+    (message.includes('model') && message.includes('not installed'))
+  ) {
+    return 'model';
+  }
+  if (context.exitCode !== undefined || context.signal !== undefined) return 'process-exit';
+  return 'unknown';
+}
+
+function providerMetadata(err: unknown): { providerStatus?: number; providerCode?: string } {
+  if (!(err instanceof Error)) return {};
+  const providerStatus = numericProperty(err, ['status', 'statusCode']);
+  const providerCodes = stringProperties(err, ['code', 'type']);
+  const providerCode =
+    providerCodes.find((code) => code !== 'ORCHESTRATOR_UNAVAILABLE') ?? providerCodes[0];
+  return {
+    ...(providerStatus !== undefined ? { providerStatus } : {}),
+    ...(providerCode !== undefined ? { providerCode } : {}),
+  };
+}
+
+function failedRuntimeAttempt(
+  provider: string,
+  model: string,
+  route: RuntimeInvokeRoute,
+  durationMs: number,
+  err: unknown,
+  context: InvokeFailureContext = {},
+): RuntimeInvokeAttemptEvidence {
+  const failureKind = classifyInvokeFailure(err, context);
+  return {
+    sequence: 1,
+    route,
+    provider,
+    model,
+    status: 'failed',
+    durationMs,
+    failureKind,
+    ...providerMetadata(err),
+  };
+}
+
+function recoveryHintProperty(err: unknown): string | undefined {
+  if (!(err instanceof Error)) return undefined;
+  const recoveryHint = (err as unknown as Record<string, unknown>)['recoveryHint'];
+  return typeof recoveryHint === 'string' && recoveryHint.length > 0 ? recoveryHint : undefined;
+}
+
+/**
+ * Normalize any provider throw at the invocation boundary. Existing structured
+ * errors retain identity; legacy Totem/provider errors remain available as the
+ * cause and keep their recovery hint while gaining typed attempt evidence.
+ */
+export function toOrchestratorInvokeError(args: {
+  err: unknown;
+  provider: string;
+  model: string;
+  route: RuntimeInvokeRoute;
+  durationMs: number;
+}): OrchestratorInvokeError {
+  if (args.err instanceof OrchestratorInvokeError) return args.err;
+
+  const attempt = failedRuntimeAttempt(
+    args.provider,
+    args.model,
+    args.route,
+    args.durationMs,
+    args.err,
+  );
+  const message =
+    args.err instanceof Error
+      ? args.err.message
+      : `Invocation failed for '${args.provider}' with a non-Error rejection.`;
+  const recoveryHint = recoveryHintProperty(args.err);
+  return new OrchestratorInvokeError(message, attempt.failureKind ?? 'unknown', [attempt], {
+    cause: args.err,
+    ...(recoveryHint !== undefined ? { recoveryHint } : {}),
+  });
+}
+
+function resequenceAttempts(
+  attempts: readonly RuntimeInvokeAttemptEvidence[],
+): RuntimeInvokeAttemptEvidence[] {
+  return attempts.map((attempt, index) => ({ ...attempt, sequence: index + 1 }));
+}
+
 // ─── Package manager detection (#236) ───────────────
 
 /**
@@ -116,6 +452,8 @@ export function detectPackageManager(): string {
  */
 export function isQuotaError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
+  if (err.name === 'QuotaError') return true;
+  if ('kind' in err && (err as Record<string, unknown>).kind === 'quota') return true;
   if ('status' in err && (err as Record<string, unknown>).status === 429) return true;
   const msg = err.message.toLowerCase();
   return (
@@ -247,9 +585,9 @@ export function resolveOrchestrator(
 // ─── CLI fallback infrastructure ─────────────────────
 
 /** Map provider names to their CLI command templates. {file} and {model} are replaced at runtime. */
-const CLI_FALLBACK_COMMANDS: Record<string, string> = {
+export const CLI_FALLBACK_COMMANDS: Readonly<Record<string, string>> = {
   gemini: 'gemini -e none -m {model} < {file}',
-  anthropic: 'claude -p {file} --model {model}',
+  anthropic: 'claude -p --model {model} < {file}',
 };
 
 /** Check if a CLI binary is available on PATH. */
@@ -308,23 +646,79 @@ function withCliFallback(provider: string, sdkInvoker: InvokeOrchestrator): Invo
   if (!binary || !command) return sdkInvoker;
 
   return async (opts) => {
+    const sdkStartMs = Date.now();
     try {
       return await sdkInvoker(opts);
     } catch (err) {
-      if (!isFallbackEligible(err)) throw err;
+      const sdkAttempt = failedRuntimeAttempt(
+        provider,
+        opts.model,
+        'sdk',
+        Date.now() - sdkStartMs,
+        err,
+      );
+      if (!isFallbackEligible(err)) {
+        throw new OrchestratorInvokeError(
+          err instanceof Error ? err.message : `Invocation failed for '${provider}'.`,
+          sdkAttempt.failureKind ?? 'unknown',
+          [sdkAttempt],
+          { cause: err },
+        );
+      }
 
       if (!(await isCliAvailable(binary))) {
-        const msg = err instanceof Error ? err.message : String(err);
-        throw new TotemOrchestratorError(
-          `CLI fallback for '${provider}' unavailable: '${binary}' not found on PATH. Original error: ${msg}`,
-          `Install the ${provider} CLI or its SDK to use this provider.`,
-          err,
+        const cliUnavailable = new Error(`[Totem Error] '${binary}' not found on PATH.`);
+        const cliAttempt = failedRuntimeAttempt(
+          provider,
+          opts.model,
+          'cli-fallback',
+          0,
+          cliUnavailable,
+          { spawnFailed: true },
+        );
+        throw new OrchestratorInvokeError(
+          `CLI fallback for '${provider}' unavailable: '${binary}' not found on PATH.`,
+          'process-spawn',
+          resequenceAttempts([sdkAttempt, cliAttempt]),
+          {
+            cause: err,
+            recoveryHint: `Install the ${provider} CLI or its SDK to use this provider.`,
+          },
         );
       }
 
       const { log } = await import('../ui.js');
       log.warn(opts.tag, `SDK unavailable, falling back to ${binary} CLI...`);
-      return invokeShellOrchestrator({ ...opts, command });
+      try {
+        const result = await invokeShellOrchestrator({
+          ...opts,
+          command,
+          provider,
+          route: 'cli-fallback',
+        });
+        return {
+          ...result,
+          attempts: resequenceAttempts([sdkAttempt, ...(result.attempts ?? [])]),
+        };
+      } catch (fallbackErr) {
+        const fallbackAttempts =
+          fallbackErr instanceof OrchestratorInvokeError
+            ? fallbackErr.attempts
+            : [failedRuntimeAttempt(provider, opts.model, 'cli-fallback', 0, fallbackErr)];
+        const attempts = resequenceAttempts([sdkAttempt, ...fallbackAttempts]);
+        const kind =
+          fallbackErr instanceof OrchestratorInvokeError
+            ? fallbackErr.kind
+            : (attempts.at(-1)?.failureKind ?? 'unknown');
+        throw new OrchestratorInvokeError(
+          fallbackErr instanceof Error
+            ? fallbackErr.message
+            : `CLI fallback failed for '${provider}'.`,
+          kind,
+          attempts,
+          { cause: fallbackErr },
+        );
+      }
     }
   };
 }
@@ -340,7 +734,13 @@ function withCliFallback(provider: string, sdkInvoker: InvokeOrchestrator): Invo
 export function createOrchestrator(config: OrchestratorConfig): InvokeOrchestrator {
   switch (config.provider) {
     case 'shell':
-      return (opts) => invokeShellOrchestrator({ ...opts, command: config.command });
+      return (opts) =>
+        invokeShellOrchestrator({
+          ...opts,
+          command: config.command,
+          provider: 'shell',
+          route: 'configured-shell',
+        });
     case 'gemini':
       return withCliFallback('gemini', async (opts) => {
         const { invokeGeminiOrchestrator } = await import('./gemini-orchestrator.js');

--- a/packages/cli/src/orchestrators/orchestrator.ts
+++ b/packages/cli/src/orchestrators/orchestrator.ts
@@ -659,21 +659,28 @@ function withCliFallback(provider: string, sdkInvoker: InvokeOrchestrator): Invo
         err,
       );
       if (!isFallbackEligible(err)) {
+        const recoveryHint = recoveryHintProperty(err);
         throw new OrchestratorInvokeError(
           err instanceof Error ? err.message : `Invocation failed for '${provider}'.`,
           sdkAttempt.failureKind ?? 'unknown',
           [sdkAttempt],
-          { cause: err },
+          {
+            cause: err,
+            ...(recoveryHint !== undefined ? { recoveryHint } : {}),
+          },
         );
       }
 
-      if (!(await isCliAvailable(binary))) {
+      const cliProbeStartMs = Date.now();
+      const cliAvailable = await isCliAvailable(binary);
+      const cliProbeDurationMs = Date.now() - cliProbeStartMs;
+      if (!cliAvailable) {
         const cliUnavailable = new Error(`[Totem Error] '${binary}' not found on PATH.`);
         const cliAttempt = failedRuntimeAttempt(
           provider,
           opts.model,
           'cli-fallback',
-          0,
+          cliProbeDurationMs,
           cliUnavailable,
           { spawnFailed: true },
         );

--- a/packages/cli/src/orchestrators/shell-orchestrator.test.ts
+++ b/packages/cli/src/orchestrators/shell-orchestrator.test.ts
@@ -268,6 +268,9 @@ describe('invokeShellOrchestrator', () => {
 
     expect(err).toBeInstanceOf(OrchestratorInvokeError);
     expect(err).toMatchObject({ kind: 'process-spawn' });
+    expect((err as Error).message).toBe(
+      '[Totem Error] Shell orchestrator command failed to start.',
+    );
     expect((err as Error).message).not.toContain('secret');
     expect((err as OrchestratorInvokeError).attempts[0]).toMatchObject({
       providerCode: 'ENOENT',

--- a/packages/cli/src/orchestrators/shell-orchestrator.test.ts
+++ b/packages/cli/src/orchestrators/shell-orchestrator.test.ts
@@ -5,6 +5,8 @@ import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { InvokeAttemptEvidenceSchema } from '@mmnto/totem';
+
 import { cleanTmpDir } from '../test-utils.js';
 import { OrchestratorInvokeError } from './orchestrator.js';
 import {
@@ -381,6 +383,48 @@ describe('invokeShellOrchestrator', () => {
     expect(attempt.process).toMatchObject({ exitCode: null, signal: 'SIGTERM', timedOut: false });
     expect(attempt.process?.stdout?.head).toBe('partial output');
     expect(attempt.process?.stderr?.head).toBe('terminated');
+  });
+
+  it('records a close without exit code or signal as an unknown structured failure', async () => {
+    process.nextTick(() => {
+      mockChild.stdout.emit('data', Buffer.from('partial output'));
+      mockChild.emit('close', null, null);
+    });
+
+    const err = await invokeShellOrchestrator({
+      prompt: 'prompt',
+      command: 'cmd',
+      model: 'model',
+      cwd: tmpDir,
+      tag: 'Test',
+      totemDir,
+    }).catch((cause: unknown) => cause);
+
+    expect(err).toBeInstanceOf(OrchestratorInvokeError);
+    expect(err).toMatchObject({ kind: 'unknown' });
+    expect((err as Error).message).toContain('closed without an exit code or signal');
+    const attempt = (err as OrchestratorInvokeError).attempts[0]!;
+    expect(attempt).toMatchObject({
+      status: 'failed',
+      failureKind: 'unknown',
+      process: {
+        exitCode: null,
+        signal: null,
+        timedOut: false,
+        stdout: expect.objectContaining({ head: 'partial output' }),
+      },
+    });
+    // Runtime streams remain raw until the persistence boundary adds DLP
+    // metadata; validate the failure/process cross-field contract directly.
+    const schemaAttempt = {
+      ...attempt,
+      process: {
+        exitCode: attempt.process?.exitCode,
+        signal: attempt.process?.signal,
+        timedOut: attempt.process?.timedOut,
+      },
+    };
+    expect(InvokeAttemptEvidenceSchema.safeParse(schemaAttempt).success).toBe(true);
   });
 
   it('retains bounded head and tail evidence independently of semantic output', async () => {

--- a/packages/cli/src/orchestrators/shell-orchestrator.test.ts
+++ b/packages/cli/src/orchestrators/shell-orchestrator.test.ts
@@ -6,7 +6,13 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { cleanTmpDir } from '../test-utils.js';
-import { invokeShellOrchestrator, tryParseGeminiJson } from './shell-orchestrator.js';
+import { OrchestratorInvokeError } from './orchestrator.js';
+import {
+  invokeShellOrchestrator,
+  killShellProcessTree,
+  tryParseClaudeJson,
+  tryParseGeminiJson,
+} from './shell-orchestrator.js';
 
 // ─── Mock spawn ──────────────────────────────────────
 
@@ -88,6 +94,19 @@ describe('invokeShellOrchestrator', () => {
     expect(result.inputTokens).toBeNull();
     expect(result.outputTokens).toBeNull();
     expect(result.durationMs).toBeGreaterThanOrEqual(0);
+    expect(result.attempts).toEqual([
+      expect.objectContaining({
+        sequence: 1,
+        route: 'configured-shell',
+        provider: 'shell',
+        status: 'succeeded',
+        process: expect.objectContaining({
+          exitCode: 0,
+          signal: null,
+          timedOut: false,
+        }),
+      }),
+    ]);
   });
 
   it('parses Gemini JSON output and returns structured result', async () => {
@@ -115,6 +134,26 @@ describe('invokeShellOrchestrator', () => {
     expect(result.inputTokens).toBe(100);
     expect(result.outputTokens).toBe(50);
     expect(result.durationMs).toBe(2000);
+  });
+
+  it('normalizes a typed Claude JSON result envelope at the shell boundary', async () => {
+    emitSuccess(
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        is_error: false,
+        result: 'Claude verdict',
+      }),
+    );
+    const result = await invokeShellOrchestrator({
+      prompt: 'prompt',
+      command: 'claude -p --output-format json < {file}',
+      model: 'claude-sonnet-5',
+      cwd: tmpDir,
+      tag: 'Test',
+      totemDir,
+    });
+    expect(result.content).toBe('Claude verdict');
   });
 
   it('substitutes {file} and {model} in command', async () => {
@@ -164,7 +203,13 @@ describe('invokeShellOrchestrator', () => {
       });
       expect.fail('Should have thrown');
     } catch (err) {
+      expect(err).toBeInstanceOf(OrchestratorInvokeError);
       expect((err as Error).name).toBe('QuotaError');
+      expect((err as OrchestratorInvokeError).kind).toBe('quota');
+      expect((err as OrchestratorInvokeError).attempts[0]).toMatchObject({
+        failureKind: 'quota',
+        process: { exitCode: 1, signal: null, timedOut: false },
+      });
     }
   });
 
@@ -184,18 +229,50 @@ describe('invokeShellOrchestrator', () => {
 
   it('throws error on spawn error event', async () => {
     process.nextTick(() => {
-      mockChild.emit('error', new Error('command not found'));
+      mockChild.emit('error', Object.assign(new Error('command not found'), { code: 'ENOENT' }));
     });
-    await expect(
-      invokeShellOrchestrator({
-        prompt: 'prompt',
-        command: 'cmd',
-        model: 'model',
-        cwd: tmpDir,
-        tag: 'Test',
-        totemDir,
-      }),
-    ).rejects.toThrow('command not found');
+    const err = await invokeShellOrchestrator({
+      prompt: 'prompt',
+      command: 'cmd',
+      model: 'model',
+      cwd: tmpDir,
+      tag: 'Test',
+      totemDir,
+    }).catch((cause: unknown) => cause);
+    expect(err).toBeInstanceOf(OrchestratorInvokeError);
+    expect(err).toMatchObject({
+      kind: 'process-spawn',
+      attempts: [
+        expect.objectContaining({
+          failureKind: 'process-spawn',
+          providerCode: 'ENOENT',
+          process: expect.objectContaining({ exitCode: null, signal: null, timedOut: false }),
+        }),
+      ],
+    });
+  });
+
+  it('classifies a synchronous spawn throw without leaking its command message', async () => {
+    mockedSpawn.mockImplementationOnce(() => {
+      throw Object.assign(new Error('spawn cmd --secret failed'), { code: 'ENOENT' });
+    });
+
+    const err = await invokeShellOrchestrator({
+      prompt: 'prompt',
+      command: 'cmd',
+      model: 'model',
+      cwd: tmpDir,
+      tag: 'Test',
+      totemDir,
+    }).catch((cause: unknown) => cause);
+
+    expect(err).toBeInstanceOf(OrchestratorInvokeError);
+    expect(err).toMatchObject({ kind: 'process-spawn' });
+    expect((err as Error).message).not.toContain('secret');
+    expect((err as OrchestratorInvokeError).attempts[0]).toMatchObject({
+      providerCode: 'ENOENT',
+      process: { exitCode: null, signal: null, timedOut: false },
+    });
   });
 
   it('throws descriptive error for timeout', async () => {
@@ -231,6 +308,20 @@ describe('invokeShellOrchestrator', () => {
     const err = await promise;
     expect(err).toBeInstanceOf(Error);
     expect((err as Error).message).toContain('timed out after 180s');
+    expect(err).toMatchObject({
+      kind: 'timeout',
+      attempts: [
+        expect.objectContaining({
+          failureKind: 'timeout',
+          process: expect.objectContaining({
+            exitCode: null,
+            signal: null,
+            timedOut: true,
+            timeoutMs: 180_000,
+          }),
+        }),
+      ],
+    });
 
     // Verify kill was actually attempted (Windows: taskkill spawn, Unix: process.kill)
     const killAttempted =
@@ -241,6 +332,101 @@ describe('invokeShellOrchestrator', () => {
     process.kill = originalKill;
     vi.useRealTimers();
   });
+
+  it('ignores late error and close events after timeout settlement', async () => {
+    vi.useFakeTimers();
+    mockedSpawn.mockImplementation((() => mockChild) as unknown as typeof spawn);
+    process.kill = vi.fn() as unknown as typeof process.kill;
+
+    const promise = invokeShellOrchestrator({
+      prompt: 'prompt',
+      command: 'cmd',
+      model: 'model',
+      cwd: tmpDir,
+      tag: 'Test',
+      totemDir,
+    }).catch((cause: unknown) => cause);
+
+    await vi.advanceTimersByTimeAsync(180_001);
+    const timeoutErr = await promise;
+    expect(timeoutErr).toMatchObject({ kind: 'timeout' });
+
+    mockChild.emit('error', new Error('late spawn error'));
+    mockChild.emit('close', 9, 'SIGTERM');
+    expect(await promise).toBe(timeoutErr);
+  });
+
+  it('captures exact close signal and partial streams on process exit', async () => {
+    process.nextTick(() => {
+      mockChild.stdout.emit('data', Buffer.from('partial output'));
+      mockChild.stderr.emit('data', Buffer.from('terminated'));
+      mockChild.emit('close', null, 'SIGTERM');
+    });
+
+    const err = await invokeShellOrchestrator({
+      prompt: 'prompt',
+      command: 'cmd',
+      model: 'model',
+      cwd: tmpDir,
+      tag: 'Test',
+      totemDir,
+    }).catch((cause: unknown) => cause);
+
+    expect(err).toBeInstanceOf(OrchestratorInvokeError);
+    expect(err).toMatchObject({ kind: 'process-exit' });
+    const attempt = (err as OrchestratorInvokeError).attempts[0]!;
+    expect(attempt.process).toMatchObject({ exitCode: null, signal: 'SIGTERM', timedOut: false });
+    expect(attempt.process?.stdout?.head).toBe('partial output');
+    expect(attempt.process?.stderr?.head).toBe('terminated');
+  });
+
+  it('retains bounded head and tail evidence independently of semantic output', async () => {
+    const head = 'h'.repeat(40 * 1024);
+    const middle = 'm'.repeat(10 * 1024);
+    const tail = 't'.repeat(40 * 1024);
+    emitSuccess(head + middle + tail);
+
+    const result = await invokeShellOrchestrator({
+      prompt: 'prompt',
+      command: 'cmd',
+      model: 'model',
+      cwd: tmpDir,
+      tag: 'Test',
+      totemDir,
+    });
+
+    expect(result.content).toBe(head + middle + tail);
+    const evidence = result.attempts?.[0]?.process?.stdout;
+    expect(evidence).toMatchObject({
+      observedBytes: 90 * 1024,
+      retainedBytes: 64 * 1024,
+      limitBytes: 64 * 1024,
+      truncated: true,
+    });
+    expect(evidence?.head).toBe('h'.repeat(32 * 1024));
+    expect(evidence?.tail).toBe('t'.repeat(32 * 1024));
+  });
+
+  if (process.platform === 'win32') {
+    it('uses the exact Windows taskkill process-tree arguments', async () => {
+      vi.useFakeTimers();
+      const promise = invokeShellOrchestrator({
+        prompt: 'prompt',
+        command: 'cmd',
+        model: 'model',
+        cwd: tmpDir,
+        tag: 'Test',
+        totemDir,
+      }).catch((cause: unknown) => cause);
+
+      await vi.advanceTimersByTimeAsync(180_001);
+      await promise;
+
+      expect(mockedSpawn).toHaveBeenCalledWith('taskkill', ['/pid', '12345', '/T', '/F'], {
+        stdio: 'ignore',
+      });
+    });
+  }
 
   // ─── Model sanitization (shell-injection defense) ──
   //
@@ -514,5 +700,82 @@ describe('tryParseGeminiJson', () => {
     expect(result).not.toBeNull();
     expect(result!.inputTokens).toBe(0);
     expect(result!.outputTokens).toBe(0);
+  });
+});
+
+describe('tryParseClaudeJson', () => {
+  it('unwraps only a typed successful Claude result envelope', () => {
+    expect(
+      tryParseClaudeJson(
+        JSON.stringify({ type: 'result', subtype: 'success', is_error: false, result: 'verdict' }),
+      ),
+    ).toBe('verdict');
+  });
+
+  it('rejects arbitrary outer JSON and Claude error envelopes', () => {
+    expect(tryParseClaudeJson(JSON.stringify({ result: 'not enough provenance' }))).toBeNull();
+    expect(
+      tryParseClaudeJson(JSON.stringify({ type: 'result', is_error: true, result: 'failure' })),
+    ).toBeNull();
+  });
+});
+
+describe('killShellProcessTree', () => {
+  it('falls back to direct kill exactly once when Windows taskkill exits non-zero', () => {
+    const child = { pid: 77, kill: vi.fn() };
+    const taskkill = new EventEmitter();
+    const spawnProcess = vi.fn(() => taskkill);
+
+    killShellProcessTree(
+      child as unknown as Parameters<typeof killShellProcessTree>[0],
+      'win32',
+      spawnProcess as unknown as typeof spawn,
+      vi.fn() as unknown as typeof process.kill,
+    );
+    taskkill.emit('close', 1);
+    taskkill.emit('error', new Error('late taskkill error'));
+    taskkill.emit('close', 1);
+
+    expect(spawnProcess).toHaveBeenCalledWith('taskkill', ['/pid', '77', '/T', '/F'], {
+      stdio: 'ignore',
+    });
+    expect(child.kill).toHaveBeenCalledOnce();
+  });
+
+  it('falls back to direct kill when Unix process-group kill throws', () => {
+    const child = { pid: 77, kill: vi.fn() };
+    const killGroup = vi.fn(() => {
+      throw new Error('group already exited');
+    });
+
+    expect(() =>
+      killShellProcessTree(
+        child as unknown as Parameters<typeof killShellProcessTree>[0],
+        'linux',
+        mockedSpawn as unknown as typeof spawn,
+        killGroup as unknown as typeof process.kill,
+      ),
+    ).not.toThrow();
+    expect(killGroup).toHaveBeenCalledWith(-77);
+    expect(child.kill).toHaveBeenCalledOnce();
+  });
+
+  it('settles best-effort termination when no pid exists and direct kill throws', () => {
+    const child = {
+      pid: undefined,
+      kill: vi.fn(() => {
+        throw new Error('no pid');
+      }),
+    };
+
+    expect(() =>
+      killShellProcessTree(
+        child as unknown as Parameters<typeof killShellProcessTree>[0],
+        'linux',
+        mockedSpawn as unknown as typeof spawn,
+        vi.fn() as unknown as typeof process.kill,
+      ),
+    ).not.toThrow();
+    expect(child.kill).toHaveBeenCalledOnce();
   });
 });

--- a/packages/cli/src/orchestrators/shell-orchestrator.ts
+++ b/packages/cli/src/orchestrators/shell-orchestrator.ts
@@ -433,25 +433,27 @@ export async function invokeShellOrchestrator(
         const process = processEvidence(code, normalizedSignal);
 
         if (code !== 0 || normalizedSignal !== null) {
-          const processDescription =
-            normalizedSignal === null
-              ? `code ${code}`
-              : `code ${code} (signal ${normalizedSignal})`;
+          const closedWithoutStatus = code === null && normalizedSignal === null;
+          const processDescription = closedWithoutStatus
+            ? 'closed without an exit code or signal'
+            : normalizedSignal === null
+              ? `exited with code ${code}`
+              : `exited with code ${code} (signal ${normalizedSignal})`;
           const err = new Error(
-            `[Totem Error] Shell orchestrator command failed: Process exited with ${processDescription}.`,
+            `[Totem Error] Shell orchestrator command failed: Process ${processDescription}.`,
           );
           const diagnosticText = [process.stderr?.head, process.stderr?.tail]
             .filter((part): part is string => part !== undefined)
             .join('\n');
-          const classificationSource = Object.assign(new Error(diagnosticText), {
-            exitCode: code,
-          });
-          rejectInvocation(
-            err,
-            process,
-            { exitCode: code, signal: normalizedSignal },
-            classificationSource,
+          const classificationSource = Object.assign(
+            new Error(diagnosticText),
+            code === null ? {} : { exitCode: code },
           );
+          const failureContext: Parameters<typeof classifyInvokeFailure>[1] = {
+            ...(code === null ? {} : { exitCode: code }),
+            ...(normalizedSignal === null ? {} : { signal: normalizedSignal }),
+          };
+          rejectInvocation(err, process, failureContext, classificationSource);
           return;
         }
 

--- a/packages/cli/src/orchestrators/shell-orchestrator.ts
+++ b/packages/cli/src/orchestrators/shell-orchestrator.ts
@@ -345,7 +345,7 @@ export async function invokeShellOrchestrator(
         };
         reject(
           new OrchestratorInvokeError(
-            '[Totem Error] Shell orchestrator command failed to start.',
+            'Shell orchestrator command failed to start.',
             'process-spawn',
             [attempt],
             { cause },

--- a/packages/cli/src/orchestrators/shell-orchestrator.ts
+++ b/packages/cli/src/orchestrators/shell-orchestrator.ts
@@ -6,13 +6,26 @@ import * as path from 'node:path';
 import { z } from 'zod';
 
 import { log } from '../ui.js';
-import type { OrchestratorInvokeOptions, OrchestratorResult } from './orchestrator.js';
-import { assertValidModelName, isQuotaError } from './orchestrator.js';
+import type {
+  OrchestratorInvokeOptions,
+  OrchestratorResult,
+  RuntimeBoundedTextEvidence,
+  RuntimeInvokeAttemptEvidence,
+  RuntimeInvokeRoute,
+  RuntimeProcessEvidence,
+} from './orchestrator.js';
+import {
+  assertValidModelName,
+  classifyInvokeFailure,
+  OrchestratorInvokeError,
+} from './orchestrator.js';
 
 // ─── Constants ───────────────────────────────────────
 
 const LLM_TIMEOUT_MS = 180_000;
 const LLM_MAX_OUTPUT = 50 * 1024 * 1024; // 50 MB — safety cap on streamed output
+const RUNTIME_EVIDENCE_LIMIT_BYTES = 64 * 1024;
+const RUNTIME_EVIDENCE_SEGMENT_BYTES = RUNTIME_EVIDENCE_LIMIT_BYTES / 2;
 const TEMP_ID_BYTES = 4;
 
 /** execFileSync on Windows can't resolve executables without `shell: true`. */
@@ -31,6 +44,131 @@ function quoteShellArg(value: string): string {
   // to stop using `shell: true` — not to defeat shell quoting entirely in
   // this helper. See GCA + Shield discussion on mmnto/totem#1429.
   return IS_WIN ? `"${value.replace(/"/g, '\\"')}"` : `'${value.replace(/'/g, "'\\''")}'`;
+}
+
+interface StreamCapture {
+  append(chunk: Buffer | string): void;
+  semanticText(): string;
+  evidence(): RuntimeBoundedTextEvidence;
+}
+
+function decodeUtf8Segment(buffer: Buffer, trimFromStart: boolean): string {
+  let decoded = buffer.toString('utf8');
+  while (Buffer.byteLength(decoded, 'utf8') > buffer.length && decoded.length > 0) {
+    decoded = trimFromStart ? decoded.slice(1) : decoded.slice(0, -1);
+  }
+  return decoded;
+}
+
+/**
+ * Retain the legacy 50 MiB semantic stream independently from the much
+ * smaller diagnostic head/tail window. Evidence remains raw in memory; DLP
+ * masking happens at the run-artifact boundary.
+ */
+function createStreamCapture(): StreamCapture {
+  const semanticChunks: Buffer[] = [];
+  let semanticBytes = 0;
+  let observedBytes = 0;
+  let prefix: Buffer = Buffer.alloc(0);
+  let tail: Buffer = Buffer.alloc(0);
+
+  return {
+    append(chunk) {
+      const bytes = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      observedBytes += bytes.length;
+
+      if (semanticBytes < LLM_MAX_OUTPUT) {
+        const remaining = LLM_MAX_OUTPUT - semanticBytes;
+        const retained = bytes.subarray(0, remaining);
+        if (retained.length > 0) semanticChunks.push(retained);
+        semanticBytes += retained.length;
+      }
+
+      if (prefix.length < RUNTIME_EVIDENCE_LIMIT_BYTES) {
+        const remaining = RUNTIME_EVIDENCE_LIMIT_BYTES - prefix.length;
+        prefix = Buffer.concat([prefix, bytes.subarray(0, remaining)]);
+      }
+
+      if (bytes.length >= RUNTIME_EVIDENCE_SEGMENT_BYTES) {
+        tail = bytes.subarray(bytes.length - RUNTIME_EVIDENCE_SEGMENT_BYTES);
+      } else {
+        const combined = Buffer.concat([tail, bytes]);
+        tail = combined.subarray(Math.max(0, combined.length - RUNTIME_EVIDENCE_SEGMENT_BYTES));
+      }
+    },
+    semanticText() {
+      return Buffer.concat(semanticChunks, semanticBytes).toString('utf8');
+    },
+    evidence() {
+      const truncated = observedBytes > RUNTIME_EVIDENCE_LIMIT_BYTES;
+      const headBuffer = truncated ? prefix.subarray(0, RUNTIME_EVIDENCE_SEGMENT_BYTES) : prefix;
+      const head = decodeUtf8Segment(headBuffer, false);
+      const tailText = truncated ? decodeUtf8Segment(tail, true) : undefined;
+      const retainedBytes =
+        Buffer.byteLength(head, 'utf8') +
+        (tailText === undefined ? 0 : Buffer.byteLength(tailText, 'utf8'));
+      return {
+        encoding: 'utf-8',
+        head,
+        ...(tailText !== undefined ? { tail: tailText } : {}),
+        observedBytes,
+        retainedBytes,
+        limitBytes: RUNTIME_EVIDENCE_LIMIT_BYTES,
+        truncated,
+      };
+    },
+  };
+}
+
+type KillableChild = Pick<ReturnType<typeof spawn>, 'pid' | 'kill'>;
+
+/** Best-effort tree termination that never prevents timeout settlement. */
+export function killShellProcessTree(
+  child: KillableChild,
+  platform: NodeJS.Platform = process.platform,
+  spawnProcess: typeof spawn = spawn,
+  killGroup: typeof process.kill = process.kill,
+): void {
+  let directKillAttempted = false;
+  const killChild = () => {
+    if (directKillAttempted) return;
+    directKillAttempted = true;
+    try {
+      child.kill();
+      // totem-context: timeout teardown is best-effort; a kill race must not replace or block the already-determined timeout rejection.
+    } catch (_err) {
+      void _err;
+    }
+  };
+
+  if (platform === 'win32' && child.pid) {
+    try {
+      const taskkill = spawnProcess('taskkill', ['/pid', String(child.pid), '/T', '/F'], {
+        stdio: 'ignore',
+      });
+      taskkill.once('error', killChild);
+      taskkill.once('close', (code) => {
+        if (code !== 0) killChild();
+      });
+      // totem-context: taskkill can be absent or race process exit; direct child kill is the intentional best-effort fallback.
+    } catch (_err) {
+      killChild();
+    }
+    return;
+  }
+
+  if (child.pid) {
+    try {
+      killGroup(-child.pid);
+      // totem-context: Unix process-group exit races are expected during timeout teardown; fall back to direct child kill without changing settlement.
+    } catch (_err) {
+      killChild();
+    }
+    return;
+  }
+
+  // A spawn can time out before a pid is assigned.
+  killChild();
 }
 
 // ─── Gemini CLI JSON parsing ─────────────────────────
@@ -55,6 +193,7 @@ export function tryParseGeminiJson(
   let data: unknown;
   try {
     data = JSON.parse(raw);
+    // totem-context: non-JSON is a supported shell-provider output shape; the caller intentionally falls back to normalized raw text.
   } catch {
     return null;
   }
@@ -77,10 +216,37 @@ export function tryParseGeminiJson(
   };
 }
 
+const ClaudeOutputSchema = z.object({
+  type: z.literal('result'),
+  is_error: z.literal(false),
+  result: z.string(),
+});
+
+/** Unwrap only Claude CLI's typed success envelope, never arbitrary outer JSON. */
+export function tryParseClaudeJson(raw: string): string | null {
+  let data: unknown;
+  try {
+    data = JSON.parse(raw);
+    // totem-context: non-JSON Claude output is valid when JSON mode is not configured; the caller intentionally preserves normalized raw text.
+  } catch {
+    return null;
+  }
+  const result = ClaudeOutputSchema.safeParse(data);
+  return result.success ? result.data.result : null;
+}
+
+function isClaudeCommand(command: string): boolean {
+  return /(?:^|[\s"'])claude(?:\.exe)?(?:[\s"']|$)/i.test(command);
+}
+
 // ─── Shell orchestrator ─────────────────────────────
 
 export interface ShellOrchestratorOptions extends OrchestratorInvokeOptions {
   command: string;
+  /** Internal provenance supplied by the factory/fallback wrapper. */
+  provider?: string;
+  /** Internal provenance supplied by the factory/fallback wrapper. */
+  route?: RuntimeInvokeRoute;
 }
 
 export async function invokeShellOrchestrator(
@@ -95,6 +261,8 @@ export async function invokeShellOrchestrator(
   // shell CLI fallback. Caught by Shield AI on the first push attempt as
   // part of the same cascade as the Gemini/OpenAI/Ollama fixes.
   const { prompt, systemPrompt, command, model, cwd, tag, totemDir } = opts;
+  const provider = opts.provider ?? 'shell';
+  const route = opts.route ?? 'configured-shell';
 
   // Reject poisoned model names BEFORE we ever interpolate into a shell string.
   // The {model} token used to be substituted raw, which turned a config-supplied
@@ -138,85 +306,171 @@ export async function invokeShellOrchestrator(
   const startMs = Date.now();
 
   try {
-    const raw = await new Promise<string>((resolve, reject) => {
-      const child = spawn(resolvedCmd, {
-        cwd,
-        shell: true,
-        stdio: ['ignore', 'pipe', 'pipe'],
-        detached: !IS_WIN, // process group for clean tree-kill on Unix
-      });
+    const execution = await new Promise<{
+      raw: string;
+      process: RuntimeProcessEvidence;
+      durationMs: number;
+    }>((resolve, reject) => {
+      const stdout = createStreamCapture();
+      const stderr = createStreamCapture();
+      let child: ReturnType<typeof spawn>;
+      try {
+        child = spawn(resolvedCmd, {
+          cwd,
+          shell: true,
+          stdio: ['ignore', 'pipe', 'pipe'],
+          detached: !IS_WIN, // process group for clean tree-kill on Unix
+        });
+        // totem-context: synchronous spawn failures are converted into the structured process-spawn contract and rejected below; no failure is swallowed.
+      } catch (err) {
+        const cause = err instanceof Error ? err : new Error(String(err));
+        const attempt: RuntimeInvokeAttemptEvidence = {
+          sequence: 1,
+          route,
+          provider,
+          model,
+          status: 'failed',
+          durationMs: Date.now() - startMs,
+          failureKind: 'process-spawn',
+          ...('code' in cause && typeof cause.code === 'string'
+            ? { providerCode: cause.code }
+            : {}),
+          process: {
+            exitCode: null,
+            signal: null,
+            timedOut: false,
+            stdout: stdout.evidence(),
+            stderr: stderr.evidence(),
+          },
+        };
+        reject(
+          new OrchestratorInvokeError(
+            '[Totem Error] Shell orchestrator command failed to start.',
+            'process-spawn',
+            [attempt],
+            { cause },
+          ),
+        );
+        return;
+      }
 
-      let stdout = '';
-      let stderr = '';
       let timedOut = false;
+      let settled = false;
 
-      child.stdout.on('data', (chunk: Buffer) => {
-        if (stdout.length < LLM_MAX_OUTPUT) stdout += chunk.toString();
+      child.stdout!.on('data', (chunk: Buffer) => stdout.append(chunk));
+      child.stderr!.on('data', (chunk: Buffer) => stderr.append(chunk));
+
+      const processEvidence = (
+        exitCode: number | null,
+        signal: NodeJS.Signals | null,
+      ): RuntimeProcessEvidence => ({
+        exitCode,
+        signal,
+        timedOut,
+        ...(timedOut ? { timeoutMs: LLM_TIMEOUT_MS } : {}),
+        stdout: stdout.evidence(),
+        stderr: stderr.evidence(),
       });
-      child.stderr.on('data', (chunk: Buffer) => {
-        if (stderr.length < LLM_MAX_OUTPUT) stderr += chunk.toString();
-      });
+
+      const rejectInvocation = (
+        err: Error,
+        process: RuntimeProcessEvidence,
+        context: Parameters<typeof classifyInvokeFailure>[1],
+        classificationSource: Error = err,
+      ) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        const failureKind = classifyInvokeFailure(classificationSource, context);
+        const attempt: RuntimeInvokeAttemptEvidence = {
+          sequence: 1,
+          route,
+          provider,
+          model,
+          status: 'failed',
+          durationMs: Date.now() - startMs,
+          failureKind,
+          ...('status' in classificationSource && typeof classificationSource.status === 'number'
+            ? { providerStatus: classificationSource.status }
+            : {}),
+          ...('code' in classificationSource && typeof classificationSource.code === 'string'
+            ? { providerCode: classificationSource.code }
+            : {}),
+          process,
+        };
+        reject(new OrchestratorInvokeError(err.message, failureKind, [attempt], { cause: err }));
+      };
 
       const killTree = () => {
         // On Windows with shell: true, child.kill() only kills the shell,
         // leaving the actual process (grandchild) alive as a zombie.
-        // Use taskkill /T to kill the entire process tree.
-        if (IS_WIN && child.pid) {
-          try {
-            spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], { stdio: 'ignore' });
-          } catch (_err) {
-            // taskkill failed — fall back to basic kill
-            child.kill();
-          }
-        } else if (child.pid) {
-          process.kill(-child.pid); // totem-ignore — Unix process group kill
-        }
+        killShellProcessTree(child);
       };
 
       const timer = setTimeout(() => {
         timedOut = true;
         killTree();
+        const err = Object.assign(
+          new Error(`[Totem Error] Orchestrator timed out after ${LLM_TIMEOUT_MS / 1000}s.`),
+          { code: 'ETIMEDOUT' },
+        );
+        rejectInvocation(err, processEvidence(null, null), { timedOut: true });
       }, LLM_TIMEOUT_MS);
 
       child.on('error', (err) => {
-        clearTimeout(timer);
-        reject(
-          new Error(`[Totem Error] Shell orchestrator command failed: ${err.message}\n${stderr}`),
+        const spawnErr = Object.assign(
+          new Error('[Totem Error] Shell orchestrator command failed to start.', {
+            cause: err,
+          }),
+          'code' in err ? { code: err.code } : {},
         );
+        rejectInvocation(spawnErr, processEvidence(null, null), { spawnFailed: true });
       });
 
-      child.on('close', (code) => {
-        clearTimeout(timer);
-        if (timedOut) {
-          reject(
-            Object.assign(
-              new Error(
-                `[Totem Error] Orchestrator timed out after ${LLM_TIMEOUT_MS / 1000}s.\n${stderr}`,
-              ),
-              { code: 'ETIMEDOUT' },
-            ),
+      child.on('close', (code, signal) => {
+        if (settled) return;
+        const normalizedSignal = (signal ?? null) as NodeJS.Signals | null;
+        const process = processEvidence(code, normalizedSignal);
+
+        if (code !== 0 || normalizedSignal !== null) {
+          const processDescription =
+            normalizedSignal === null
+              ? `code ${code}`
+              : `code ${code} (signal ${normalizedSignal})`;
+          const err = new Error(
+            `[Totem Error] Shell orchestrator command failed: Process exited with ${processDescription}.`,
+          );
+          const diagnosticText = [process.stderr?.head, process.stderr?.tail]
+            .filter((part): part is string => part !== undefined)
+            .join('\n');
+          const classificationSource = Object.assign(new Error(diagnosticText), {
+            exitCode: code,
+          });
+          rejectInvocation(
+            err,
+            process,
+            { exitCode: code, signal: normalizedSignal },
+            classificationSource,
           );
           return;
         }
 
-        if (code !== 0) {
-          const fullError = new Error(`Process exited with code ${code}\n${stderr}`);
-          if (isQuotaError(fullError)) {
-            fullError.name = 'QuotaError';
-            reject(fullError);
-          } else {
-            reject(
-              new Error(`[Totem Error] Shell orchestrator command failed: ${fullError.message}`),
-            );
-          }
-          return;
-        }
-
-        resolve(stdout);
+        settled = true;
+        clearTimeout(timer);
+        resolve({ raw: stdout.semanticText(), process, durationMs: Date.now() - startMs });
       });
     });
 
-    const wallMs = Date.now() - startMs;
+    const { raw, process: executionProcess, durationMs: wallMs } = execution;
+    const succeededAttempt: RuntimeInvokeAttemptEvidence = {
+      sequence: 1,
+      route,
+      provider,
+      model,
+      status: 'succeeded',
+      durationMs: wallMs,
+      process: executionProcess,
+    };
 
     const gemini = tryParseGeminiJson(raw);
     if (gemini) {
@@ -225,10 +479,18 @@ export async function invokeShellOrchestrator(
         inputTokens: gemini.inputTokens,
         outputTokens: gemini.outputTokens,
         durationMs: gemini.latencyMs ?? wallMs,
+        attempts: [succeededAttempt],
       };
     }
 
-    return { content: raw.trim(), inputTokens: null, outputTokens: null, durationMs: wallMs };
+    const claude = isClaudeCommand(resolvedCmd) ? tryParseClaudeJson(raw) : null;
+    return {
+      content: (claude ?? raw).trim(),
+      inputTokens: null,
+      outputTokens: null,
+      durationMs: wallMs,
+      attempts: [succeededAttempt],
+    };
   } finally {
     try {
       fs.unlinkSync(tempPath);

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -6,7 +6,13 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { SearchResult, TotemConfig } from '@mmnto/totem';
-import { calculateDeterministicHash, RunArtifactSchema, summarizeProvenance } from '@mmnto/totem';
+import {
+  calculateDeterministicHash,
+  InvocationFailureArtifactSchema,
+  RunArtifactSchema,
+  summarizeProvenance,
+  TotemOrchestratorError,
+} from '@mmnto/totem';
 
 import { cleanTmpDir } from './test-utils.js';
 import {
@@ -22,10 +28,12 @@ import {
   loadConfig,
   loadEnv,
   partitionLessons,
+  persistRuntimeTextEvidence,
   reapOrphanedTempFiles,
   requireEmbedding,
   resolveConfigPath,
   runOrchestrator,
+  runtimeMessageEvidence,
   sanitize,
   wrapXml,
   writeOutput,
@@ -691,7 +699,7 @@ vi.mock('./orchestrators/orchestrator.js', async (importOriginal) => {
   };
 });
 
-import { createOrchestrator } from './orchestrators/orchestrator.js';
+import { createOrchestrator, OrchestratorInvokeError } from './orchestrators/orchestrator.js';
 
 const mockedCreateOrchestrator = vi.mocked(createOrchestrator);
 
@@ -1293,11 +1301,15 @@ describe('runOrchestrator artifact emission (#2100)', { timeout: 15_000 }, () =>
 
   const GROUNDING_HASH = 'b'.repeat(64);
 
-  function artifactRequest(onEmitted?: (hash: string, artifactPath: string) => void) {
+  function artifactRequest(
+    onEmitted?: (hash: string, artifactPath: string) => void,
+    onFailureEmitted?: (hash: string, artifactPath: string) => void,
+  ) {
     return {
       groundingHash: GROUNDING_HASH,
       provenanceSummary: 'similarity-only',
       ...(onEmitted !== undefined ? { onEmitted } : {}),
+      ...(onFailureEmitted !== undefined ? { onFailureEmitted } : {}),
     };
   }
 
@@ -1318,6 +1330,49 @@ describe('runOrchestrator artifact emission (#2100)', { timeout: 15_000 }, () =>
 
   function runsDirPath(): string {
     return path.join(tmpDir, '.totem', 'artifacts', 'runs');
+  }
+
+  function failureRunsDirPath(): string {
+    return path.join(runsDirPath(), 'failures');
+  }
+
+  function runtimeText(text: string) {
+    const bytes = Buffer.byteLength(text, 'utf-8');
+    return {
+      encoding: 'utf-8' as const,
+      head: text,
+      observedBytes: bytes,
+      retainedBytes: bytes,
+      limitBytes: 64 * 1024,
+      truncated: false,
+    };
+  }
+
+  function invokeFailure(message = 'provider rejected request') {
+    return new OrchestratorInvokeError(
+      message,
+      'process-exit',
+      [
+        {
+          sequence: 1,
+          route: 'configured-shell',
+          provider: 'gemini',
+          model: 'gemini-3-flash-preview',
+          status: 'failed',
+          durationMs: 125,
+          failureKind: 'process-exit',
+          providerCode: 'x'.repeat(129),
+          process: {
+            exitCode: 1,
+            signal: null,
+            timedOut: false,
+            stdout: runtimeText('partial stdout'),
+            stderr: runtimeText(message),
+          },
+        },
+      ],
+      { cause: new Error(message) },
+    );
   }
 
   beforeEach(() => {
@@ -1371,6 +1426,60 @@ describe('runOrchestrator artifact emission (#2100)', { timeout: 15_000 }, () =>
       outputTokens: 50,
       durationMs: 500,
     });
+    expect(artifact.schemaVersion).toBe('1.2.0');
+    expect(artifact.output.execution).toBeUndefined();
+  });
+
+  it('persists DLP-safe execution evidence only when runtime attempts are present', async () => {
+    const secret = 'RUNTIME-EVIDENCE-SECRET-12345';
+    const mockInvoke = vi.fn().mockResolvedValue({
+      content: 'mock result',
+      inputTokens: 100,
+      outputTokens: 50,
+      durationMs: 500,
+      attempts: [
+        {
+          sequence: 1,
+          route: 'configured-shell',
+          provider: 'gemini',
+          model: 'gemini-3-flash-preview',
+          status: 'succeeded',
+          durationMs: 500,
+          providerCode: secret,
+          process: {
+            exitCode: 0,
+            signal: null,
+            timedOut: false,
+            stdout: runtimeText(`\u001b[31mresult ${secret}\u001b[0m`),
+            stderr: runtimeText(''),
+          },
+        },
+      ],
+    });
+    mockedCreateOrchestrator.mockReturnValue(mockInvoke);
+    const emitted: string[] = [];
+
+    await runOrchestrator({
+      prompt: 'attempt evidence run',
+      tag: 'Spec',
+      options: { fresh: true },
+      config: artifactConfig(),
+      cwd: tmpDir,
+      customSecrets: [{ type: 'literal', value: secret }],
+      artifact: artifactRequest((hash) => emitted.push(hash)),
+    });
+
+    const raw = fs.readFileSync(path.join(runsDirPath(), `${emitted[0]!}.json`), 'utf-8');
+    expect(raw).not.toContain(secret);
+    expect(raw).not.toContain('\u001b');
+    const artifact = RunArtifactSchema.parse(JSON.parse(raw));
+    expect(artifact.output.execution?.attempts).toHaveLength(1);
+    expect(artifact.output.execution?.attempts[0]?.process?.stdout).toMatchObject({
+      head: 'result [REDACTED_CUSTOM]',
+      dlp: 'masked',
+      truncated: false,
+    });
+    expect(artifact.output.execution?.attempts[0]?.providerCode).toBeUndefined();
   });
 
   it('records the grounding bundle verbatim and the attested hash recomputes from it (mmnto-ai/totem#2101)', async () => {
@@ -1427,6 +1536,271 @@ describe('runOrchestrator artifact emission (#2100)', { timeout: 15_000 }, () =>
     expect(rawOnDisk).not.toContain(secret);
     const artifact = RunArtifactSchema.parse(JSON.parse(rawOnDisk));
     expect(artifact.inputBundle.maskedPrompt).not.toContain(secret);
+  });
+
+  it('emits terminal failure evidence, attaches its hash, and invokes the failure callback', async () => {
+    const secret = 'FAILURE-EVIDENCE-SECRET-12345';
+    const invokeErr = invokeFailure(`provider rejected ${secret}`);
+    const mockInvoke = vi.fn().mockRejectedValue(invokeErr);
+    mockedCreateOrchestrator.mockReturnValue(mockInvoke);
+    const emitted: Array<{ hash: string; artifactPath: string }> = [];
+
+    let caught: unknown;
+    try {
+      await runOrchestrator({
+        prompt: 'failed attempt prompt',
+        tag: 'Spec',
+        options: { fresh: true },
+        config: artifactConfig(),
+        cwd: tmpDir,
+        customSecrets: [{ type: 'literal', value: secret }],
+        artifact: artifactRequest(undefined, (hash, artifactPath) =>
+          emitted.push({ hash, artifactPath }),
+        ),
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBe(invokeErr);
+    expect(invokeErr.failureArtifactHash).toBe(emitted[0]?.hash);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]?.artifactPath).toBe(
+      path.join(failureRunsDirPath(), `${emitted[0]!.hash}.json`),
+    );
+    const raw = fs.readFileSync(emitted[0]!.artifactPath, 'utf-8');
+    expect(raw).not.toContain(secret);
+    const artifact = InvocationFailureArtifactSchema.parse(JSON.parse(raw));
+    expect(artifact.terminal).toMatchObject({ kind: 'process-exit', attempt: 1 });
+    expect(artifact.terminal.message.head).toContain('[REDACTED_CUSTOM]');
+    expect(artifact.attempts[0]?.process?.stderr?.head).toContain('[REDACTED_CUSTOM]');
+    expect(artifact.attempts[0]?.providerCode).toBeUndefined();
+    expect(RunArtifactSchema.safeParse(artifact).success).toBe(false);
+  });
+
+  it.each([
+    {
+      label: 'OpenAI wrapped auth failure',
+      provider: 'openai',
+      model: 'gpt-5',
+      cause: Object.assign(new Error('provider auth response'), {
+        status: 401,
+        code: 'authentication_error',
+      }),
+      kind: 'auth',
+      providerStatus: 401,
+      providerCode: 'authentication_error',
+    },
+    {
+      label: 'Ollama wrapped model failure',
+      provider: 'ollama',
+      model: 'llama3',
+      cause: null,
+      originalMessage: "Ollama model 'llama3' is not installed.",
+      kind: 'model',
+      providerStatus: undefined,
+      providerCode: undefined,
+    },
+    {
+      label: 'plain injected failure',
+      provider: 'gemini',
+      model: 'gemini-3-flash-preview',
+      cause: undefined,
+      originalMessage: undefined,
+      kind: 'unknown',
+      providerStatus: undefined,
+      providerCode: undefined,
+    },
+  ])('normalizes and persists $label', async (testCase) => {
+    const original =
+      testCase.cause === undefined
+        ? new Error('unclassified provider transport failure')
+        : new TotemOrchestratorError(
+            testCase.originalMessage ?? `${testCase.provider} provider call failed`,
+            `recover ${testCase.provider}`,
+            testCase.cause,
+          );
+    mockedCreateOrchestrator.mockReturnValue(vi.fn().mockRejectedValue(original));
+    const emitted: Array<{ hash: string; artifactPath: string }> = [];
+
+    let caught: unknown;
+    try {
+      await runOrchestrator({
+        prompt: `${testCase.provider} terminal failure`,
+        tag: 'Spec',
+        options: { fresh: true },
+        config: artifactConfig({
+          orchestrator: {
+            provider: testCase.provider,
+            defaultModel: testCase.model,
+          } as TotemConfig['orchestrator'],
+        }),
+        cwd: tmpDir,
+        artifact: artifactRequest(undefined, (hash, artifactPath) =>
+          emitted.push({ hash, artifactPath }),
+        ),
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(OrchestratorInvokeError);
+    expect(caught).toBeInstanceOf(TotemOrchestratorError);
+    const structured = caught as OrchestratorInvokeError;
+    expect(structured.cause).toBe(original);
+    expect(structured).toMatchObject({
+      kind: testCase.kind,
+      failureArtifactHash: emitted[0]?.hash,
+    });
+    expect(structured.attempts[0]).toMatchObject({
+      route: 'sdk',
+      provider: testCase.provider,
+      model: testCase.model,
+      status: 'failed',
+      failureKind: testCase.kind,
+      ...(testCase.providerStatus !== undefined ? { providerStatus: testCase.providerStatus } : {}),
+      ...(testCase.providerCode !== undefined ? { providerCode: testCase.providerCode } : {}),
+    });
+    expect(emitted).toHaveLength(1);
+    const artifact = InvocationFailureArtifactSchema.parse(
+      JSON.parse(fs.readFileSync(emitted[0]!.artifactPath, 'utf-8')),
+    );
+    expect(artifact.terminal.kind).toBe(testCase.kind);
+    expect(artifact.attempts).toMatchObject(structured.attempts);
+  });
+
+  it('a failure-artifact write error preserves the original structured invocation error', async () => {
+    fs.mkdirSync(path.join(tmpDir, '.totem'), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, '.totem', 'artifacts'), 'not a directory');
+    const invokeErr = invokeFailure();
+    mockedCreateOrchestrator.mockReturnValue(vi.fn().mockRejectedValue(invokeErr));
+    const onFailureEmitted = vi.fn();
+
+    let caught: unknown;
+    try {
+      await runOrchestrator({
+        prompt: 'failed ledger prompt',
+        tag: 'Spec',
+        options: { fresh: true },
+        config: artifactConfig(),
+        cwd: tmpDir,
+        artifact: artifactRequest(undefined, onFailureEmitted),
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBe(invokeErr);
+    expect(invokeErr.failureArtifactHash).toBeUndefined();
+    expect(onFailureEmitted).not.toHaveBeenCalled();
+  });
+
+  it('masking failure omits runtime text instead of persisting raw bytes', () => {
+    const evidence = persistRuntimeTextEvidence(
+      runtimeText('must never survive'),
+      undefined,
+      64 * 1024,
+      () => {
+        throw new Error('synthetic DLP failure');
+      },
+    );
+
+    expect(evidence).toEqual({
+      encoding: 'utf-8',
+      head: '',
+      observedBytes: Buffer.byteLength('must never survive', 'utf-8'),
+      retainedBytes: 0,
+      limitBytes: 64 * 1024,
+      truncated: false,
+      dlp: 'omitted-on-mask-failure',
+    });
+  });
+
+  it('pre-bounds oversized ASCII terminal messages before DLP and re-bounds masked text', () => {
+    const secret = 'ASCII-OVERSIZED-SECRET-12345';
+    const message = [secret, 'x'.repeat(9_000), '-terminal-tail'].join('');
+    const runtime = runtimeMessageEvidence(message);
+
+    expect(runtime).toMatchObject({
+      observedBytes: Buffer.byteLength(message, 'utf-8'),
+      limitBytes: 4 * 1024,
+      retainedBytes: 4 * 1024,
+      truncated: true,
+    });
+    expect(Buffer.byteLength(runtime.head, 'utf-8')).toBe(2 * 1024);
+    expect(Buffer.byteLength(runtime.tail ?? '', 'utf-8')).toBe(2 * 1024);
+    expect(runtime.head).toContain(secret);
+    expect(runtime.tail).toContain('-terminal-tail');
+
+    const masker = vi.fn((value: string) => value.replaceAll(secret, '[REDACTED_CUSTOM]'));
+    const persisted = persistRuntimeTextEvidence(runtime, undefined, 4 * 1024, masker);
+
+    expect(masker).toHaveBeenCalledTimes(2);
+    for (const [fragment] of masker.mock.calls) {
+      expect(Buffer.byteLength(fragment, 'utf-8')).toBeLessThanOrEqual(2 * 1024);
+    }
+    const persistedText = [persisted.head, persisted.tail ?? ''].join('');
+    expect(persistedText).not.toContain(secret);
+    expect(persisted).toMatchObject({
+      observedBytes: Buffer.byteLength(message, 'utf-8'),
+      limitBytes: 4 * 1024,
+      truncated: true,
+      dlp: 'masked',
+    });
+    expect(persisted.retainedBytes).toBeLessThanOrEqual(4 * 1024);
+  });
+
+  it('pre-bounds oversized multi-byte messages on code-point boundaries and masks retained text', () => {
+    const secret = '秘密-TERMINAL-KEY-12345';
+    const message = [secret, '🧪'.repeat(2_000), '-終端'].join('');
+    const runtime = runtimeMessageEvidence(message);
+
+    expect(runtime.observedBytes).toBe(Buffer.byteLength(message, 'utf-8'));
+    expect(runtime.retainedBytes).toBeLessThanOrEqual(4 * 1024);
+    expect(runtime.truncated).toBe(true);
+    expect(runtime.head).not.toContain('\uFFFD');
+    expect(runtime.tail).not.toContain('\uFFFD');
+    expect(Buffer.byteLength(runtime.head, 'utf-8')).toBeLessThanOrEqual(2 * 1024);
+    expect(Buffer.byteLength(runtime.tail ?? '', 'utf-8')).toBeLessThanOrEqual(2 * 1024);
+
+    const persisted = persistRuntimeTextEvidence(
+      runtime,
+      [{ type: 'literal', value: secret }],
+      4 * 1024,
+    );
+    const persistedText = [persisted.head, persisted.tail ?? ''].join('');
+    expect(persistedText).not.toContain(secret);
+    expect(persistedText).not.toContain('\uFFFD');
+    expect(persisted).toMatchObject({
+      observedBytes: Buffer.byteLength(message, 'utf-8'),
+      limitBytes: 4 * 1024,
+      truncated: true,
+      dlp: 'masked',
+    });
+    expect(persisted.retainedBytes).toBeLessThanOrEqual(4 * 1024);
+  });
+
+  it('masks non-contiguous runtime head and tail independently', () => {
+    const head = 'HEAD-SENTINEL-cross-';
+    const tail = 'boundary-TAIL-SENTINEL';
+    const evidence = persistRuntimeTextEvidence(
+      {
+        encoding: 'utf-8',
+        head,
+        tail,
+        observedBytes: 100_000,
+        retainedBytes: Buffer.byteLength(head + tail, 'utf-8'),
+        limitBytes: 64 * 1024,
+        truncated: true,
+      },
+      [{ type: 'literal', value: head + tail }],
+    );
+
+    expect(evidence.head).toBe(head);
+    expect(evidence.tail).toBe(tail);
+    expect(evidence.head).not.toContain(head + tail);
+    expect(evidence.tail).not.toContain(head + tail);
+    expect(evidence.truncated).toBe(true);
   });
 
   it('a response-cache hit emits NO artifact (artifacts record actual invokes)', async () => {
@@ -1508,6 +1882,75 @@ describe('runOrchestrator artifact emission (#2100)', { timeout: 15_000 }, () =>
     const artifact = RunArtifactSchema.parse(JSON.parse(fs.readFileSync(file, 'utf-8')));
     expect(artifact.backend.qualifiedModel).toBe('gemini-3-flash-preview');
     expect(artifact.output.content).toBe('fallback result');
+    expect(artifact.output.execution?.attempts).toMatchObject([
+      { sequence: 1, route: 'sdk', status: 'failed', failureKind: 'quota' },
+      { sequence: 2, route: 'quota-model-fallback', status: 'succeeded' },
+    ]);
+  });
+
+  it('persists merged, contiguous quota-fallback attempts when both models fail', async () => {
+    const quotaErr = new Error('429 quota exhausted');
+    quotaErr.name = 'QuotaError';
+    const fallbackErr = new OrchestratorInvokeError(
+      'fallback model unavailable',
+      'model',
+      [
+        {
+          sequence: 1,
+          route: 'sdk',
+          provider: 'gemini',
+          model: 'gemini-3-flash-preview',
+          status: 'failed',
+          durationMs: 50,
+          failureKind: 'model',
+        },
+      ],
+      { cause: new Error('404 model unavailable') },
+    );
+    mockedCreateOrchestrator.mockReturnValue(
+      vi.fn().mockRejectedValueOnce(quotaErr).mockRejectedValueOnce(fallbackErr),
+    );
+    const emitted: string[] = [];
+
+    let caught: unknown;
+    try {
+      await runOrchestrator({
+        prompt: 'double failure prompt',
+        tag: 'Spec',
+        options: { fresh: true },
+        config: artifactConfig({
+          orchestrator: {
+            provider: 'gemini',
+            defaultModel: 'gemini-3.1-pro-preview',
+            fallbackModel: 'gemini-3-flash-preview',
+          },
+        }),
+        cwd: tmpDir,
+        artifact: artifactRequest(undefined, (hash) => emitted.push(hash)),
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(OrchestratorInvokeError);
+    expect(caught).not.toBe(fallbackErr);
+    const structured = caught as OrchestratorInvokeError;
+    expect(structured.kind).toBe('model');
+    expect(structured.failureArtifactHash).toBe(emitted[0]);
+    expect(structured.attempts).toMatchObject([
+      { sequence: 1, route: 'sdk', status: 'failed', failureKind: 'quota' },
+      {
+        sequence: 2,
+        route: 'quota-model-fallback',
+        status: 'failed',
+        failureKind: 'model',
+      },
+    ]);
+    const artifact = InvocationFailureArtifactSchema.parse(
+      JSON.parse(fs.readFileSync(path.join(failureRunsDirPath(), `${emitted[0]!}.json`), 'utf-8')),
+    );
+    expect(artifact.attempts).toMatchObject(structured.attempts);
+    expect(artifact.terminal).toMatchObject({ kind: 'model', attempt: 2 });
   });
 });
 
@@ -1518,11 +1961,15 @@ describe('runOrchestrator admission contract (#2102)', { timeout: 15_000 }, () =
 
   const GROUNDING_HASH = 'b'.repeat(64);
 
-  function artifactRequest(onEmitted?: (hash: string, artifactPath: string) => void) {
+  function artifactRequest(
+    onEmitted?: (hash: string, artifactPath: string) => void,
+    onFailureEmitted?: (hash: string, artifactPath: string) => void,
+  ) {
     return {
       groundingHash: GROUNDING_HASH,
       provenanceSummary: 'similarity-only',
       ...(onEmitted !== undefined ? { onEmitted } : {}),
+      ...(onFailureEmitted !== undefined ? { onFailureEmitted } : {}),
     };
   }
 
@@ -1715,18 +2162,41 @@ describe('runOrchestrator admission contract (#2102)', { timeout: 15_000 }, () =
     mockedCreateOrchestrator.mockReturnValue(mockInvoke);
 
     const onEmitted = vi.fn();
-    await expect(
-      runOrchestrator({
+    const failures: Array<{ hash: string; artifactPath: string }> = [];
+    let caught: unknown;
+    try {
+      await runOrchestrator({
         prompt: 'elevated quota-bound run',
         tag: 'Spec',
         options: { fresh: true },
         config: declaredConfig({ fallbackModel: 'anthropic:claude-sonnet-4-6' }),
         cwd: tmpDir,
         backendAdmissionClass: 'self_grounding_agent',
-        artifact: { ...artifactRequest(), onEmitted },
-      }),
-      // Primary error + admission error reported together.
-    ).rejects.toThrow(/429 quota exhausted[\s\S]*self_grounding_agent/);
+        artifact: {
+          ...artifactRequest(undefined, (hash, artifactPath) =>
+            failures.push({ hash, artifactPath }),
+          ),
+          onEmitted,
+        },
+      });
+    } catch (err) {
+      caught = err;
+    }
+
+    expect(caught).toBeInstanceOf(OrchestratorInvokeError);
+    expect(caught).toBeInstanceOf(TotemOrchestratorError);
+    expect(caught).toMatchObject({
+      kind: 'quota',
+      failureArtifactHash: failures[0]?.hash,
+      attempts: [expect.objectContaining({ failureKind: 'quota', route: 'sdk' })],
+    });
+    expect((caught as Error).message).toMatch(/429 quota exhausted[\s\S]*self_grounding_agent/);
+    expect(failures).toHaveLength(1);
+    const artifact = InvocationFailureArtifactSchema.parse(
+      JSON.parse(fs.readFileSync(failures[0]!.artifactPath, 'utf-8')),
+    );
+    expect(artifact.terminal).toMatchObject({ kind: 'quota', attempt: 1 });
+    expect(artifact.attempts).toHaveLength(1);
 
     // Exactly ONE invoke: the primary. The cross-provider fallback was never invoked.
     expect(mockInvoke).toHaveBeenCalledTimes(1);

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -1730,7 +1730,7 @@ describe('runOrchestrator artifact emission (#2100)', { timeout: 15_000 }, () =>
     expect(Buffer.byteLength(runtime.head, 'utf-8')).toBe(2 * 1024);
     expect(Buffer.byteLength(runtime.tail ?? '', 'utf-8')).toBe(2 * 1024);
     expect(runtime.head).toContain(secret);
-    expect(runtime.tail).toContain('-terminal-tail');
+    expect(runtime.tail).toBe(message.slice(-2 * 1024));
 
     const masker = vi.fn((value: string) => value.replaceAll(secret, '[REDACTED_CUSTOM]'));
     const persisted = persistRuntimeTextEvidence(runtime, undefined, 4 * 1024, masker);
@@ -1761,7 +1761,8 @@ describe('runOrchestrator artifact emission (#2100)', { timeout: 15_000 }, () =>
     expect(runtime.head).not.toContain('\uFFFD');
     expect(runtime.tail).not.toContain('\uFFFD');
     expect(Buffer.byteLength(runtime.head, 'utf-8')).toBeLessThanOrEqual(2 * 1024);
-    expect(Buffer.byteLength(runtime.tail ?? '', 'utf-8')).toBeLessThanOrEqual(2 * 1024);
+    expect(Buffer.byteLength(runtime.tail ?? '', 'utf-8')).toBe(2 * 1024 - 1);
+    expect(runtime.tail).toBe(`${'🧪'.repeat(510)}-終端`);
 
     const persisted = persistRuntimeTextEvidence(
       runtime,

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -7,9 +7,12 @@ import dotenv from 'dotenv';
 
 import type {
   BackendAdmissionClass,
+  BoundedTextEvidence,
   ContextPolicy,
   CustomSecret,
   GroundingBundle,
+  InvocationFailureArtifact,
+  InvokeAttemptEvidence,
   Orchestrator,
   OutputContract,
   RunArtifact,
@@ -22,16 +25,32 @@ import {
   buildGroundingBundle,
   calculateDeterministicHash,
   CONFIG_FILES,
+  INVOCATION_FAILURE_ARTIFACT_SCHEMA_VERSION,
+  INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES,
+  INVOKE_STREAM_EVIDENCE_LIMIT_BYTES,
   maskSecrets,
   RUN_ARTIFACT_SCHEMA_VERSION,
+  SAFE_PROVIDER_CODE_RE,
+  sanitizeForTerminal,
+  saveInvocationFailureArtifact,
   saveRunArtifact,
   TotemConfigError,
   TotemConfigSchema,
   TotemOrchestratorError,
 } from '@mmnto/totem';
 
-import type { OrchestratorResult } from './orchestrators/orchestrator.js';
-import { createOrchestrator, resolveOrchestrator } from './orchestrators/orchestrator.js';
+import type {
+  OrchestratorResult,
+  RuntimeBoundedTextEvidence,
+  RuntimeInvokeAttemptEvidence,
+} from './orchestrators/orchestrator.js';
+import {
+  classifyInvokeFailure,
+  createOrchestrator,
+  OrchestratorInvokeError,
+  resolveOrchestrator,
+  toOrchestratorInvokeError,
+} from './orchestrators/orchestrator.js';
 import { bold, log } from './ui.js';
 
 // ─── Shared constants ────────────────────────────────────
@@ -490,6 +509,288 @@ export interface RunArtifactRequest {
   specContract?: string;
   /** Fires after a successful write (or dedup hit) with the content address + path. */
   onEmitted?: (hash: string, artifactPath: string) => void;
+  /** Fires after terminal invocation evidence is written (or deduplicated). */
+  onFailureEmitted?: (hash: string, artifactPath: string) => void;
+}
+
+type EvidenceMasker = (text: string, customSecrets?: CustomSecret[]) => string;
+
+function takeUtf8Prefix(text: string, limitBytes: number): string {
+  let retained = '';
+  let bytes = 0;
+  for (const character of text) {
+    const characterBytes = Buffer.byteLength(character, 'utf-8');
+    if (bytes + characterBytes > limitBytes) break;
+    retained += character;
+    bytes += characterBytes;
+  }
+  return retained;
+}
+
+function takeUtf8Tail(text: string, limitBytes: number): string {
+  const characters = Array.from(text);
+  let retained = '';
+  let bytes = 0;
+  for (let index = characters.length - 1; index >= 0; index--) {
+    const character = characters[index]!;
+    const characterBytes = Buffer.byteLength(character, 'utf-8');
+    if (bytes + characterBytes > limitBytes) break;
+    retained = character + retained;
+    bytes += characterBytes;
+  }
+  return retained;
+}
+
+/**
+ * Convert bounded raw runtime text into persisted evidence. Masking and
+ * terminal sanitization happen before a second UTF-8 byte bound because a
+ * replacement may grow or shrink the retained text. A masking exception
+ * fails closed: no raw bytes cross the artifact boundary.
+ */
+export function persistRuntimeTextEvidence(
+  runtime: RuntimeBoundedTextEvidence,
+  customSecrets?: CustomSecret[],
+  limitBytes: number = INVOKE_STREAM_EVIDENCE_LIMIT_BYTES,
+  masker: EvidenceMasker = maskSecrets,
+): BoundedTextEvidence {
+  let safeHead: string;
+  let safeTail: string | undefined;
+  try {
+    safeHead = sanitizeForTerminal(masker(sanitizeForTerminal(runtime.head), customSecrets));
+    safeTail =
+      runtime.tail === undefined
+        ? undefined
+        : sanitizeForTerminal(masker(sanitizeForTerminal(runtime.tail), customSecrets));
+    // totem-context: evidence masking fails closed by intentionally omitting all raw text and recording the typed omission marker below.
+  } catch {
+    return {
+      encoding: 'utf-8',
+      head: '',
+      observedBytes: runtime.observedBytes,
+      retainedBytes: 0,
+      limitBytes,
+      truncated: false,
+      dlp: 'omitted-on-mask-failure',
+    };
+  }
+
+  const hasTail = safeTail !== undefined;
+  const headLimit = hasTail ? Math.floor(limitBytes / 2) : limitBytes;
+  const tailLimit = limitBytes - headLimit;
+  const head = takeUtf8Prefix(safeHead, headLimit);
+  const tail = safeTail === undefined ? undefined : takeUtf8Tail(safeTail, tailLimit);
+  const retainedBytes = Buffer.byteLength(head, 'utf-8') + Buffer.byteLength(tail ?? '', 'utf-8');
+  const postMaskTruncated =
+    Buffer.byteLength(safeHead, 'utf-8') > headLimit ||
+    (safeTail !== undefined && Buffer.byteLength(safeTail, 'utf-8') > tailLimit);
+
+  return {
+    encoding: 'utf-8',
+    head,
+    ...(tail !== undefined ? { tail } : {}),
+    observedBytes: runtime.observedBytes,
+    retainedBytes,
+    limitBytes,
+    truncated: runtime.truncated || postMaskTruncated,
+    dlp: 'masked',
+  };
+}
+
+function persistRuntimeAttempts(
+  attempts: readonly RuntimeInvokeAttemptEvidence[],
+  customSecrets?: CustomSecret[],
+): InvokeAttemptEvidence[] {
+  return attempts.map((attempt, index) => {
+    const providerCode = persistProviderCode(attempt.providerCode, customSecrets);
+    return {
+      sequence: index + 1,
+      route: attempt.route,
+      provider: attempt.provider,
+      model: attempt.model,
+      status: attempt.status,
+      durationMs: attempt.durationMs,
+      ...(attempt.failureKind !== undefined ? { failureKind: attempt.failureKind } : {}),
+      ...(attempt.providerStatus !== undefined ? { providerStatus: attempt.providerStatus } : {}),
+      ...(providerCode !== undefined ? { providerCode } : {}),
+      ...(attempt.process !== undefined
+        ? {
+            process: {
+              exitCode: attempt.process.exitCode,
+              signal: attempt.process.signal,
+              timedOut: attempt.process.timedOut,
+              ...(attempt.process.timeoutMs !== undefined
+                ? { timeoutMs: attempt.process.timeoutMs }
+                : {}),
+              ...(attempt.process.stdout !== undefined
+                ? { stdout: persistRuntimeTextEvidence(attempt.process.stdout, customSecrets) }
+                : {}),
+              ...(attempt.process.stderr !== undefined
+                ? { stderr: persistRuntimeTextEvidence(attempt.process.stderr, customSecrets) }
+                : {}),
+            },
+          }
+        : {}),
+    };
+  });
+}
+
+function persistProviderCode(
+  providerCode: string | undefined,
+  customSecrets?: CustomSecret[],
+): string | undefined {
+  if (providerCode === undefined || !SAFE_PROVIDER_CODE_RE.test(providerCode)) return undefined;
+  try {
+    return maskSecrets(providerCode, customSecrets) === providerCode ? providerCode : undefined;
+    // totem-context: provider codes are optional diagnostics; a masking failure intentionally omits the code rather than persisting an unsafe token.
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Pre-bound provider-controlled terminal prose before DLP. Secret masking can
+ * expand retained text, so `persistRuntimeTextEvidence` applies the same cap a
+ * second time after masking; this first bound prevents unbounded regex work.
+ */
+export function runtimeMessageEvidence(message: string): RuntimeBoundedTextEvidence {
+  const observedBytes = Buffer.byteLength(message, 'utf-8');
+  if (observedBytes <= INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES) {
+    return {
+      encoding: 'utf-8',
+      head: message,
+      observedBytes,
+      retainedBytes: observedBytes,
+      limitBytes: INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES,
+      truncated: false,
+    };
+  }
+
+  const headLimit = Math.floor(INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES / 2);
+  const tailLimit = INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES - headLimit;
+  const head = takeUtf8Prefix(message, headLimit);
+  const tail = takeUtf8Tail(message, tailLimit);
+  const retainedBytes = Buffer.byteLength(head, 'utf-8') + Buffer.byteLength(tail, 'utf-8');
+
+  return {
+    encoding: 'utf-8',
+    head,
+    tail,
+    observedBytes,
+    retainedBytes,
+    limitBytes: INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES,
+    truncated: true,
+  };
+}
+
+function buildArtifactSharedFields(args: {
+  artifact: RunArtifactRequest;
+  safePrompt: string;
+  safeSystemPrompt?: string;
+  groundingBundle?: GroundingBundle;
+  outputContract?: OutputContract;
+  contextPolicy?: ContextPolicy;
+  runMetadata?: RunMetadata;
+}): Pick<RunArtifact, 'inputBundle' | 'inputHash' | 'grounding' | 'admission'> {
+  const inputBundle = {
+    maskedPrompt: args.safePrompt,
+    ...(args.safeSystemPrompt !== undefined && args.safeSystemPrompt.length > 0
+      ? { maskedSystemPrompt: args.safeSystemPrompt }
+      : {}),
+    ...(args.artifact.diffScope !== undefined ? { diffScope: args.artifact.diffScope } : {}),
+    ...(args.artifact.specContract !== undefined
+      ? { specContract: args.artifact.specContract }
+      : {}),
+  };
+
+  return {
+    inputBundle,
+    inputHash: calculateDeterministicHash(inputBundle),
+    grounding: {
+      hash: args.artifact.groundingHash,
+      provenanceSummary: args.artifact.provenanceSummary,
+      ...(args.groundingBundle !== undefined ? { bundle: args.groundingBundle } : {}),
+    },
+    ...(args.outputContract !== undefined ||
+    args.contextPolicy !== undefined ||
+    args.runMetadata !== undefined
+      ? {
+          admission: {
+            ...(args.outputContract !== undefined ? { outputContract: args.outputContract } : {}),
+            ...(args.contextPolicy !== undefined ? { contextPolicy: args.contextPolicy } : {}),
+            ...(args.runMetadata !== undefined ? { runMetadata: args.runMetadata } : {}),
+          },
+        }
+      : {}),
+  };
+}
+
+function buildArtifactBackend(args: {
+  provider: string;
+  model: string;
+  qualifiedModel: string;
+  admissionClass: BackendAdmissionClass;
+  taskProfile: string;
+  temperature?: number;
+}): RunArtifact['backend'] {
+  return {
+    provider: args.provider,
+    model: args.model,
+    qualifiedModel: args.qualifiedModel,
+    admissionClass: args.admissionClass,
+    taskProfile: args.taskProfile,
+    ...(args.temperature !== undefined ? { temperature: args.temperature } : {}),
+  };
+}
+
+function runtimeAttemptForError(args: {
+  err: unknown;
+  provider: string;
+  model: string;
+  route: RuntimeInvokeAttemptEvidence['route'];
+}): RuntimeInvokeAttemptEvidence {
+  return {
+    sequence: 1,
+    route: args.route,
+    provider: args.provider,
+    model: args.model,
+    status: 'failed',
+    durationMs: 0,
+    failureKind: classifyInvokeFailure(args.err),
+    ...(args.err instanceof Error &&
+    'status' in args.err &&
+    typeof (args.err as Error & { status?: unknown }).status === 'number'
+      ? { providerStatus: (args.err as Error & { status: number }).status }
+      : {}),
+    ...(args.err instanceof Error &&
+    'code' in args.err &&
+    typeof (args.err as Error & { code?: unknown }).code === 'string'
+      ? { providerCode: (args.err as Error & { code: string }).code }
+      : {}),
+  };
+}
+
+function runtimeAttemptsForError(
+  err: unknown,
+  provider: string,
+  model: string,
+  route: RuntimeInvokeAttemptEvidence['route'],
+): RuntimeInvokeAttemptEvidence[] {
+  if (err instanceof OrchestratorInvokeError && err.attempts.length > 0) {
+    return err.attempts.map((attempt) => ({ ...attempt }));
+  }
+  return [runtimeAttemptForError({ err, provider, model, route })];
+}
+
+function resequenceRuntimeAttempts(
+  attempts: readonly RuntimeInvokeAttemptEvidence[],
+): RuntimeInvokeAttemptEvidence[] {
+  return attempts.map((attempt, index) => ({ ...attempt, sequence: index + 1 }));
+}
+
+function quotaFallbackAttempts(
+  attempts: readonly RuntimeInvokeAttemptEvidence[],
+): RuntimeInvokeAttemptEvidence[] {
+  return attempts.map((attempt) => ({ ...attempt, route: 'quota-model-fallback' }));
 }
 
 /** The identity-relevant subset of a retrieval hit — what the bundle records. */
@@ -899,93 +1200,205 @@ export async function runOrchestrator(opts: {
     ...(opts.runMetadata !== undefined ? { runMetadata: opts.runMetadata } : {}),
   };
 
+  const requestedBackend = buildArtifactBackend({
+    provider: resolved.parsed.provider,
+    model,
+    qualifiedModel,
+    admissionClass: requestedAdmissionClass,
+    taskProfile,
+    ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
+  });
+
   let result: OrchestratorResult;
+  const primaryStartMs = Date.now();
   try {
-    result = await invoke({
-      prompt: safePrompt,
-      ...(safeSystemPrompt !== undefined ? { systemPrompt: safeSystemPrompt } : {}),
-      model,
-      cwd,
-      tag,
-      totemDir: config.totemDir,
-      temperature: opts.temperature,
-      ...(enableContextCaching !== undefined ? { enableContextCaching } : {}),
-      ...(cacheTTL !== undefined ? { cacheTTL } : {}),
-      ...admissionTransport,
-    });
-  } catch (err: unknown) {
-    if (err instanceof Error && err.name === 'QuotaError') {
+    try {
+      result = await invoke({
+        prompt: safePrompt,
+        ...(safeSystemPrompt !== undefined ? { systemPrompt: safeSystemPrompt } : {}),
+        model,
+        cwd,
+        tag,
+        totemDir: config.totemDir,
+        temperature: opts.temperature,
+        ...(enableContextCaching !== undefined ? { enableContextCaching } : {}),
+        ...(cacheTTL !== undefined ? { cacheTTL } : {}),
+        ...admissionTransport,
+      });
+    } catch (err: unknown) {
+      const primaryErr = toOrchestratorInvokeError({
+        err,
+        provider: resolved.parsed.provider,
+        model,
+        route: 'sdk',
+        durationMs: Date.now() - primaryStartMs,
+      });
+      if (primaryErr.kind !== 'quota') throw primaryErr;
+
+      const primaryAttempts = runtimeAttemptsForError(
+        primaryErr,
+        resolved.parsed.provider,
+        model,
+        'sdk',
+      );
       const rawFallback = config.orchestrator.fallbackModel;
-      if (rawFallback && rawModel !== rawFallback) {
-        log.warn(
-          tag,
-          `Quota exhausted for ${rawModel}. Retrying with fallback model: ${bold(rawFallback)}...`,
-        );
-        const fallbackResolved = resolveOrchestrator(rawFallback, baseProvider, baseInvoke);
-
-        // ── Admission gate, fallback path (mmnto-ai/totem#2102) ──
-        // `resolveOrchestrator` can route a provider-qualified fallbackModel
-        // to a DIFFERENT provider, and a single config-level declaration
-        // cannot honestly cover backends with different real capabilities.
-        // Slice-3 rule, conservative and deterministic: an elevated class
-        // admits the fallback only when it resolves to the SAME provider as
-        // the primary — cross-provider fails loud BEFORE the fallback invoke,
-        // reporting the primary and admission errors together. Per-provider
-        // capability declarations are the future relaxation.
-        if (
-          requestedAdmissionClass !== ADMISSION_COMPLETION_ONLY &&
-          fallbackResolved.parsed.provider !== resolved.parsed.provider
-        ) {
-          throw new TotemOrchestratorError(
-            `Primary model '${rawModel}' failed and the quota fallback '${rawFallback}' was denied admission.\n\n` +
-              `Primary error:\n${err.message}\n\n` +
-              `Admission error:\nfallback resolves to provider '${fallbackResolved.parsed.provider}' (primary: '${resolved.parsed.provider}') while admission class '${requestedAdmissionClass}' is requested — a cross-provider fallback is not admitted above '${ADMISSION_COMPLETION_ONLY}'.`,
-            'Use a same-provider fallbackModel, or drop the elevated backendAdmissionClass request.',
-            err,
-          );
-        }
-
-        try {
-          result = await fallbackResolved.invoke({
-            prompt: safePrompt,
-            ...(safeSystemPrompt !== undefined ? { systemPrompt: safeSystemPrompt } : {}),
-            model: fallbackResolved.parsed.model,
-            cwd,
-            tag,
-            totemDir: config.totemDir,
-            temperature: opts.temperature,
-            ...(enableContextCaching !== undefined ? { enableContextCaching } : {}),
-            ...(cacheTTL !== undefined ? { cacheTTL } : {}),
-            ...admissionTransport,
-          });
-          // Update model/invoke so telemetry and cache log the correct values
-          model = fallbackResolved.parsed.model;
-          qualifiedModel = fallbackResolved.qualifiedModel;
-          resolved = fallbackResolved;
-          invoke = fallbackResolved.invoke;
-        } catch (fallbackErr: unknown) {
-          const originalMsg = err.message;
-          const fallbackMsg =
-            fallbackErr instanceof Error ? fallbackErr.message : String(fallbackErr);
-          throw new TotemOrchestratorError(
-            `Primary model '${rawModel}' failed and fallback model '${rawFallback}' also failed.\n\n` +
-              `Primary error:\n${originalMsg}\n\nFallback error:\n${fallbackMsg}`,
-            'Check API quotas and model availability, or try a different model with --model.',
-            fallbackErr,
-          );
-        }
-      } else {
-        throw new TotemOrchestratorError(
+      if (!rawFallback || rawModel === rawFallback) {
+        if (err instanceof OrchestratorInvokeError) throw primaryErr;
+        throw new OrchestratorInvokeError(
           `Quota exhausted for ${model}.`,
-          'Quota resets on a rolling daily window. Options:\n' +
-            '  - Switch to a flash model: totem <command> --model <name>\n' +
-            '  - Inspect the prompt without calling the API: totem <command> --raw\n' +
-            '  - Set a fallbackModel in totem.config.ts',
+          'quota',
+          resequenceRuntimeAttempts(primaryAttempts),
+          {
+            cause: err,
+            recoveryHint:
+              'Wait for quota to reset, configure orchestrator.fallbackModel, or select another model.',
+          },
         );
       }
-    } else {
-      throw err;
+
+      log.warn(
+        tag,
+        `Quota exhausted for ${rawModel}. Retrying with fallback model: ${bold(rawFallback)}...`,
+      );
+      const fallbackResolved = resolveOrchestrator(rawFallback, baseProvider, baseInvoke);
+
+      // ── Admission gate, fallback path (mmnto-ai/totem#2102) ──
+      // `resolveOrchestrator` can route a provider-qualified fallbackModel
+      // to a DIFFERENT provider, and a single config-level declaration
+      // cannot honestly cover backends with different real capabilities.
+      // Slice-3 rule, conservative and deterministic: an elevated class
+      // admits the fallback only when it resolves to the SAME provider as
+      // the primary — cross-provider fails loud BEFORE the fallback invoke.
+      if (
+        requestedAdmissionClass !== ADMISSION_COMPLETION_ONLY &&
+        fallbackResolved.parsed.provider !== resolved.parsed.provider
+      ) {
+        throw new OrchestratorInvokeError(
+          `Primary model '${rawModel}' failed and the quota fallback '${rawFallback}' was denied admission.\n\n` +
+            `Primary error:\n${primaryErr.message}\n\n` +
+            `Admission error:\nfallback resolves to provider '${fallbackResolved.parsed.provider}' (primary: '${resolved.parsed.provider}') while admission class '${requestedAdmissionClass}' is requested — a cross-provider fallback is not admitted above '${ADMISSION_COMPLETION_ONLY}'.`,
+          'quota',
+          resequenceRuntimeAttempts(primaryAttempts),
+          {
+            cause: primaryErr,
+            recoveryHint:
+              'Use a same-provider fallbackModel, or drop the elevated backendAdmissionClass request.',
+          },
+        );
+      }
+
+      const fallbackStartMs = Date.now();
+      try {
+        const fallbackResult = await fallbackResolved.invoke({
+          prompt: safePrompt,
+          ...(safeSystemPrompt !== undefined ? { systemPrompt: safeSystemPrompt } : {}),
+          model: fallbackResolved.parsed.model,
+          cwd,
+          tag,
+          totemDir: config.totemDir,
+          temperature: opts.temperature,
+          ...(enableContextCaching !== undefined ? { enableContextCaching } : {}),
+          ...(cacheTTL !== undefined ? { cacheTTL } : {}),
+          ...admissionTransport,
+        });
+        const fallbackAttempts = quotaFallbackAttempts(
+          fallbackResult.attempts ?? [
+            {
+              sequence: 1,
+              route: 'quota-model-fallback',
+              provider: fallbackResolved.parsed.provider,
+              model: fallbackResolved.parsed.model,
+              status: 'succeeded',
+              durationMs: fallbackResult.durationMs,
+            },
+          ],
+        );
+        result = {
+          ...fallbackResult,
+          attempts: resequenceRuntimeAttempts([...primaryAttempts, ...fallbackAttempts]),
+        };
+        // Update model/invoke so telemetry, cache, and success artifacts log
+        // the backend that actually produced the semantic output.
+        model = fallbackResolved.parsed.model;
+        qualifiedModel = fallbackResolved.qualifiedModel;
+        resolved = fallbackResolved;
+        invoke = fallbackResolved.invoke;
+      } catch (fallbackErr: unknown) {
+        const normalizedFallbackErr = toOrchestratorInvokeError({
+          err: fallbackErr,
+          provider: fallbackResolved.parsed.provider,
+          model: fallbackResolved.parsed.model,
+          route: 'quota-model-fallback',
+          durationMs: Date.now() - fallbackStartMs,
+        });
+        const fallbackAttempts = quotaFallbackAttempts(
+          runtimeAttemptsForError(
+            normalizedFallbackErr,
+            fallbackResolved.parsed.provider,
+            fallbackResolved.parsed.model,
+            'quota-model-fallback',
+          ),
+        );
+        const attempts = resequenceRuntimeAttempts([...primaryAttempts, ...fallbackAttempts]);
+        const kind = normalizedFallbackErr.kind;
+        const fallbackMsg = normalizedFallbackErr.message;
+        throw new OrchestratorInvokeError(
+          `Primary model '${rawModel}' failed and fallback model '${rawFallback}' also failed.\n\n` +
+            `Primary error:\n${primaryErr.message}\n\nFallback error:\n${fallbackMsg}`,
+          kind,
+          attempts,
+          { cause: fallbackErr },
+        );
+      }
     }
+  } catch (err) {
+    if (opts.artifact !== undefined && err instanceof OrchestratorInvokeError) {
+      try {
+        const attempts = persistRuntimeAttempts(err.attempts, opts.customSecrets);
+        const shared = buildArtifactSharedFields({
+          artifact: opts.artifact,
+          safePrompt,
+          ...(safeSystemPrompt !== undefined ? { safeSystemPrompt } : {}),
+          ...(groundingBundle !== undefined ? { groundingBundle } : {}),
+          ...(opts.outputContract !== undefined ? { outputContract: opts.outputContract } : {}),
+          ...(opts.contextPolicy !== undefined ? { contextPolicy: opts.contextPolicy } : {}),
+          ...(opts.runMetadata !== undefined ? { runMetadata: opts.runMetadata } : {}),
+        });
+        const failureArtifact: InvocationFailureArtifact = {
+          schemaVersion: INVOCATION_FAILURE_ARTIFACT_SCHEMA_VERSION,
+          ...shared,
+          requestedBackend,
+          attempts,
+          terminal: {
+            kind: err.kind,
+            attempt: attempts.at(-1)?.sequence ?? 1,
+            message: persistRuntimeTextEvidence(
+              runtimeMessageEvidence(err.message),
+              opts.customSecrets,
+              INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES,
+            ),
+          },
+          createdAt: new Date().toISOString(),
+        };
+        const saved = saveInvocationFailureArtifact(
+          path.join(configRoot, config.totemDir),
+          failureArtifact,
+        );
+        err.failureArtifactHash = saved.hash;
+        log.dim(
+          tag,
+          `Invocation failure artifact ${saved.existed ? 'already recorded' : 'recorded'}: ${saved.hash.slice(0, 12)}…`,
+        );
+        opts.artifact.onFailureEmitted?.(saved.hash, saved.path);
+        // totem-context: companion failure evidence is warn-only by contract; preserve and rethrow the original invocation error after surfacing this emission failure.
+      } catch (artifactErr) {
+        log.warn(
+          tag,
+          `Invocation failure artifact emission failed (original error preserved): ${artifactErr instanceof Error ? artifactErr.message : String(artifactErr)}`,
+        );
+      }
+    }
+    throw err;
   }
 
   if (useCache && result.content && result.durationMs > 0) {
@@ -1020,39 +1433,26 @@ export async function runOrchestrator(opts: {
   // degradation is warned, never silent).
   if (opts.artifact !== undefined) {
     try {
-      const inputBundle = {
-        maskedPrompt: safePrompt,
-        ...(safeSystemPrompt !== undefined && safeSystemPrompt.length > 0
-          ? { maskedSystemPrompt: safeSystemPrompt }
-          : {}),
-        ...(opts.artifact.diffScope !== undefined ? { diffScope: opts.artifact.diffScope } : {}),
-        ...(opts.artifact.specContract !== undefined
-          ? { specContract: opts.artifact.specContract }
-          : {}),
-      };
+      const shared = buildArtifactSharedFields({
+        artifact: opts.artifact,
+        safePrompt,
+        ...(safeSystemPrompt !== undefined ? { safeSystemPrompt } : {}),
+        ...(groundingBundle !== undefined ? { groundingBundle } : {}),
+        ...(opts.outputContract !== undefined ? { outputContract: opts.outputContract } : {}),
+        ...(opts.contextPolicy !== undefined ? { contextPolicy: opts.contextPolicy } : {}),
+        ...(opts.runMetadata !== undefined ? { runMetadata: opts.runMetadata } : {}),
+      });
       const runArtifact: RunArtifact = {
         schemaVersion: RUN_ARTIFACT_SCHEMA_VERSION,
-        inputBundle,
-        inputHash: calculateDeterministicHash(inputBundle),
-        grounding: {
-          hash: opts.artifact.groundingHash,
-          provenanceSummary: opts.artifact.provenanceSummary,
-          // Verbatim passthrough — the bundle was assembled and hashed by the
-          // caller (mmnto-ai/totem#2101); this seam records, never re-derives
-          // or upgrades. Post-reconciliation (#2102): a caller-supplied
-          // `groundingBundle` serves this role when `artifact.bundle` is absent.
-          ...(groundingBundle !== undefined ? { bundle: groundingBundle } : {}),
-        },
-        backend: {
+        ...shared,
+        backend: buildArtifactBackend({
           provider: resolved.parsed.provider,
           model,
           qualifiedModel,
-          // #2102: caller-supplied wins; the default reproduces the slice-1
-          // constant — every undeclared backend is factually completion-only.
           admissionClass: requestedAdmissionClass,
           taskProfile,
           ...(opts.temperature !== undefined ? { temperature: opts.temperature } : {}),
-        },
+        }),
         output: {
           content: result.content,
           metrics: {
@@ -1064,23 +1464,14 @@ export async function runOrchestrator(opts: {
             durationMs: result.durationMs,
             ...(result.finishReason !== undefined ? { finishReason: result.finishReason } : {}),
           },
+          ...(result.attempts !== undefined
+            ? {
+                execution: {
+                  attempts: persistRuntimeAttempts(result.attempts, opts.customSecrets),
+                },
+              }
+            : {}),
         },
-        // #2102: the admitted contract group is recorded ONLY when the caller
-        // supplied at least one member — an omitted contract stays an omitted
-        // key, never an empty object (additive 1.x, slice-1 artifacts unchanged).
-        ...(opts.outputContract !== undefined ||
-        opts.contextPolicy !== undefined ||
-        opts.runMetadata !== undefined
-          ? {
-              admission: {
-                ...(opts.outputContract !== undefined
-                  ? { outputContract: opts.outputContract }
-                  : {}),
-                ...(opts.contextPolicy !== undefined ? { contextPolicy: opts.contextPolicy } : {}),
-                ...(opts.runMetadata !== undefined ? { runMetadata: opts.runMetadata } : {}),
-              },
-            }
-          : {}),
         createdAt: new Date().toISOString(),
       };
       const saved = saveRunArtifact(path.join(configRoot, config.totemDir), runArtifact);

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -529,16 +529,16 @@ function takeUtf8Prefix(text: string, limitBytes: number): string {
 
 function takeUtf8Tail(text: string, limitBytes: number): string {
   const characters = Array.from(text);
-  let retained = '';
+  const retainedReversed: string[] = [];
   let bytes = 0;
   for (let index = characters.length - 1; index >= 0; index--) {
     const character = characters[index]!;
     const characterBytes = Buffer.byteLength(character, 'utf-8');
     if (bytes + characterBytes > limitBytes) break;
-    retained = character + retained;
+    retainedReversed.push(character);
     bytes += characterBytes;
   }
-  return retained;
+  return retainedReversed.reverse().join('');
 }
 
 /**
@@ -1085,7 +1085,7 @@ export async function runOrchestrator(opts: {
   let resolved = resolveOrchestrator(rawModel, baseProvider, baseInvoke);
   let model = resolved.parsed.model;
   let qualifiedModel = resolved.qualifiedModel;
-  let invoke = resolved.invoke;
+  const invoke = resolved.invoke;
 
   // ── Admission gate, primary path (mmnto-ai/totem#2102) ──
   // Decided per RESOLVED backend BEFORE the invoke (and before the response
@@ -1317,12 +1317,11 @@ export async function runOrchestrator(opts: {
           ...fallbackResult,
           attempts: resequenceRuntimeAttempts([...primaryAttempts, ...fallbackAttempts]),
         };
-        // Update model/invoke so telemetry, cache, and success artifacts log
-        // the backend that actually produced the semantic output.
+        // Update the resolved backend identity so telemetry, cache, and success
+        // artifacts log the backend that actually produced the semantic output.
         model = fallbackResolved.parsed.model;
         qualifiedModel = fallbackResolved.qualifiedModel;
         resolved = fallbackResolved;
-        invoke = fallbackResolved.invoke;
       } catch (fallbackErr: unknown) {
         const normalizedFallbackErr = toOrchestratorInvokeError({
           err: fallbackErr,

--- a/packages/core/src/artifacts/grounding.test.ts
+++ b/packages/core/src/artifacts/grounding.test.ts
@@ -199,7 +199,7 @@ describe('grounding schemas', () => {
     expect(parsed.grounding.hash).toBe(calculateDeterministicHash(parsed.grounding.bundle));
   });
 
-  it('the written schema version is a 1.x minor bump marking the bundle semantics (Q3)', () => {
-    expect(RUN_ARTIFACT_SCHEMA_VERSION).toBe('1.1.0');
+  it('the 1.2.0 writer preserves the 1.1 bundle-semantics minor marker (Q3)', () => {
+    expect(RUN_ARTIFACT_SCHEMA_VERSION).toBe('1.2.0');
   });
 });

--- a/packages/core/src/artifacts/schema.test.ts
+++ b/packages/core/src/artifacts/schema.test.ts
@@ -1,15 +1,82 @@
 import { describe, expect, it } from 'vitest';
 
-import type { BackendAdmissionClass, RunArtifact } from './schema.js';
+import type {
+  BackendAdmissionClass,
+  BoundedTextEvidence,
+  InvocationFailureArtifact,
+  InvokeAttemptEvidence,
+  RunArtifact,
+} from './schema.js';
 import {
   ADMISSION_COMPLETION_ONLY,
   ADMISSION_SELF_GROUNDING_AGENT,
   ContextPolicySchema,
+  INVOCATION_FAILURE_ARTIFACT_SCHEMA_VERSION,
+  InvocationFailureArtifactSchema,
+  INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES,
+  InvokeAttemptEvidenceSchema,
+  InvokeProcessEvidenceSchema,
   OutputContractSchema,
   RUN_ARTIFACT_SCHEMA_VERSION,
   RunArtifactSchema,
   RunMetadataSchema,
 } from './schema.js';
+
+function textEvidence(text: string, limitBytes = 64 * 1024): BoundedTextEvidence {
+  const bytes = Buffer.byteLength(text, 'utf-8');
+  return {
+    encoding: 'utf-8',
+    head: text,
+    observedBytes: bytes,
+    retainedBytes: bytes,
+    limitBytes,
+    truncated: false,
+    dlp: 'masked',
+  };
+}
+
+function attempt(overrides: Partial<InvokeAttemptEvidence> = {}): InvokeAttemptEvidence {
+  return {
+    sequence: 1,
+    route: 'configured-shell',
+    provider: 'anthropic',
+    model: 'claude-sonnet-5',
+    status: 'failed',
+    durationMs: 900,
+    failureKind: 'process-exit',
+    process: {
+      exitCode: 1,
+      signal: null,
+      timedOut: false,
+      stdout: textEvidence('partial stdout'),
+      stderr: textEvidence('provider rejected request'),
+    },
+    ...overrides,
+  };
+}
+
+function failureArtifact(): InvocationFailureArtifact {
+  return {
+    schemaVersion: INVOCATION_FAILURE_ARTIFACT_SCHEMA_VERSION,
+    inputBundle: { maskedPrompt: 'prompt after DLP' },
+    inputHash: 'a'.repeat(64),
+    grounding: { hash: 'b'.repeat(64), provenanceSummary: 'similarity-only' },
+    requestedBackend: {
+      provider: 'anthropic',
+      model: 'claude-sonnet-5',
+      qualifiedModel: 'anthropic:claude-sonnet-5',
+      admissionClass: 'completion_only',
+      taskProfile: 'Review',
+    },
+    attempts: [attempt()],
+    terminal: {
+      kind: 'process-exit',
+      attempt: 1,
+      message: textEvidence('Claude CLI exited with code 1', INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES),
+    },
+    createdAt: '2026-07-19T12:00:00.000Z',
+  };
+}
 
 /** A minimal valid artifact for mutation in each case. */
 function validArtifact(): RunArtifact {
@@ -31,8 +98,9 @@ function validArtifact(): RunArtifact {
 }
 
 describe('RunArtifactSchema', () => {
-  it('accepts a minimal valid 1.0.0 artifact', () => {
-    expect(RunArtifactSchema.parse(validArtifact())).toEqual(validArtifact());
+  it.each(['1.0.0', '1.1.0'])('accepts a historical %s artifact unchanged', (schemaVersion) => {
+    const historical = { ...validArtifact(), schemaVersion };
+    expect(RunArtifactSchema.parse(historical)).toEqual(historical);
   });
 
   it('accepts a future 1.x minor (corpus survives minor bumps — F1)', () => {
@@ -71,6 +139,288 @@ describe('RunArtifactSchema', () => {
     artifact.output.metrics.inputTokens = null;
     artifact.output.metrics.outputTokens = null;
     expect(RunArtifactSchema.safeParse(artifact).success).toBe(true);
+  });
+
+  it('roundtrips additive 1.2.0 fallback execution evidence', () => {
+    const artifact = validArtifact();
+    artifact.output.execution = {
+      attempts: [
+        attempt({
+          route: 'sdk',
+          process: undefined,
+          failureKind: 'auth',
+        }),
+        attempt({
+          sequence: 2,
+          route: 'cli-fallback',
+          status: 'succeeded',
+          failureKind: undefined,
+          durationMs: 1_200,
+          process: {
+            exitCode: 0,
+            signal: null,
+            timedOut: false,
+            stdout: textEvidence('valid response'),
+            stderr: textEvidence(''),
+          },
+        }),
+      ],
+    };
+
+    expect(RunArtifactSchema.parse(artifact)).toEqual(artifact);
+  });
+});
+
+describe('invocation evidence schemas (#2452 slice B)', () => {
+  it('roundtrips a terminal failure artifact and cannot parse it as a successful run', () => {
+    const failure = failureArtifact();
+    expect(InvocationFailureArtifactSchema.parse(failure)).toEqual(failure);
+    expect(RunArtifactSchema.safeParse(failure).success).toBe(false);
+  });
+
+  it('requires ordered attempts and terminal agreement with the final failed attempt', () => {
+    const failure = failureArtifact();
+    failure.attempts[0] = attempt({ sequence: 2 });
+    expect(InvocationFailureArtifactSchema.safeParse(failure).success).toBe(false);
+
+    const mismatched = failureArtifact();
+    mismatched.terminal.kind = 'timeout';
+    expect(InvocationFailureArtifactSchema.safeParse(mismatched).success).toBe(false);
+  });
+
+  it('requires failed attempts to carry a kind and successful attempts not to', () => {
+    expect(InvokeAttemptEvidenceSchema.safeParse(attempt({ failureKind: undefined })).success).toBe(
+      false,
+    );
+    expect(
+      InvokeAttemptEvidenceSchema.safeParse(
+        attempt({ status: 'succeeded', failureKind: 'unknown' }),
+      ).success,
+    ).toBe(false);
+  });
+
+  it('accepts only bounded machine-token provider codes', () => {
+    expect(
+      InvokeAttemptEvidenceSchema.safeParse(attempt({ providerCode: 'rate_limit:429' })).success,
+    ).toBe(true);
+    expect(
+      InvokeAttemptEvidenceSchema.safeParse(attempt({ providerCode: `secret ${'x'.repeat(200)}` }))
+        .success,
+    ).toBe(false);
+  });
+
+  it('requires timeoutMs if and only if process timedOut is true', () => {
+    expect(
+      InvokeProcessEvidenceSchema.safeParse({
+        exitCode: null,
+        signal: null,
+        timedOut: false,
+      }).success,
+    ).toBe(true);
+    expect(
+      InvokeProcessEvidenceSchema.safeParse({
+        exitCode: null,
+        signal: null,
+        timedOut: true,
+        timeoutMs: 180_000,
+      }).success,
+    ).toBe(true);
+    expect(
+      InvokeProcessEvidenceSchema.safeParse({
+        exitCode: null,
+        signal: null,
+        timedOut: true,
+      }).success,
+    ).toBe(false);
+    expect(
+      InvokeProcessEvidenceSchema.safeParse({
+        exitCode: null,
+        signal: null,
+        timedOut: false,
+        timeoutMs: 180_000,
+      }).success,
+    ).toBe(false);
+  });
+
+  it.each([
+    {
+      label: 'timeout',
+      process: { exitCode: null, signal: null, timedOut: true, timeoutMs: 180_000 },
+    },
+    {
+      label: 'signal',
+      process: { exitCode: null, signal: 'SIGTERM', timedOut: false },
+    },
+    {
+      label: 'nonzero exit',
+      process: { exitCode: 1, signal: null, timedOut: false },
+    },
+  ])('rejects a succeeded attempt that reports $label', ({ process }) => {
+    expect(
+      InvokeAttemptEvidenceSchema.safeParse(
+        attempt({ status: 'succeeded', failureKind: undefined, process }),
+      ).success,
+    ).toBe(false);
+  });
+
+  it('accepts coherent SDK and configured-shell success facts', () => {
+    expect(
+      InvokeAttemptEvidenceSchema.safeParse(
+        attempt({
+          route: 'sdk',
+          status: 'succeeded',
+          failureKind: undefined,
+          process: undefined,
+        }),
+      ).success,
+    ).toBe(true);
+    expect(
+      InvokeAttemptEvidenceSchema.safeParse(
+        attempt({
+          status: 'succeeded',
+          failureKind: undefined,
+          process: { exitCode: 0, signal: null, timedOut: false },
+        }),
+      ).success,
+    ).toBe(true);
+  });
+
+  it('requires timeout failure kind and process timeout facts to agree in both directions', () => {
+    expect(
+      InvokeAttemptEvidenceSchema.safeParse(
+        attempt({
+          failureKind: 'timeout',
+          process: { exitCode: null, signal: null, timedOut: true, timeoutMs: 180_000 },
+        }),
+      ).success,
+    ).toBe(true);
+    expect(
+      InvokeAttemptEvidenceSchema.safeParse(attempt({ failureKind: 'timeout', process: undefined }))
+        .success,
+    ).toBe(false);
+    expect(
+      InvokeAttemptEvidenceSchema.safeParse(
+        attempt({
+          failureKind: 'timeout',
+          process: { exitCode: null, signal: null, timedOut: false },
+        }),
+      ).success,
+    ).toBe(false);
+    expect(
+      InvokeAttemptEvidenceSchema.safeParse(
+        attempt({
+          failureKind: 'quota',
+          process: { exitCode: null, signal: null, timedOut: true, timeoutMs: 180_000 },
+        }),
+      ).success,
+    ).toBe(false);
+  });
+
+  it('requires process-exit failures to record an abnormal exit or signal', () => {
+    expect(InvokeAttemptEvidenceSchema.safeParse(attempt()).success).toBe(true);
+    expect(
+      InvokeAttemptEvidenceSchema.safeParse(
+        attempt({ process: { exitCode: null, signal: 'SIGTERM', timedOut: false } }),
+      ).success,
+    ).toBe(true);
+    expect(InvokeAttemptEvidenceSchema.safeParse(attempt({ process: undefined })).success).toBe(
+      false,
+    );
+    expect(
+      InvokeAttemptEvidenceSchema.safeParse(
+        attempt({ process: { exitCode: 0, signal: null, timedOut: false } }),
+      ).success,
+    ).toBe(false);
+  });
+
+  it('allows pre-spawn evidence without a process, but rejects impossible spawn completion facts', () => {
+    expect(
+      InvokeAttemptEvidenceSchema.safeParse(
+        attempt({ route: 'cli-fallback', failureKind: 'process-spawn', process: undefined }),
+      ).success,
+    ).toBe(true);
+    expect(
+      InvokeAttemptEvidenceSchema.safeParse(
+        attempt({ route: 'sdk', failureKind: 'process-spawn', process: undefined }),
+      ).success,
+    ).toBe(true);
+    expect(
+      InvokeAttemptEvidenceSchema.safeParse(
+        attempt({
+          failureKind: 'process-spawn',
+          process: { exitCode: null, signal: null, timedOut: false },
+        }),
+      ).success,
+    ).toBe(true);
+    expect(
+      InvokeAttemptEvidenceSchema.safeParse(
+        attempt({
+          failureKind: 'process-spawn',
+          process: { exitCode: 1, signal: null, timedOut: false },
+        }),
+      ).success,
+    ).toBe(false);
+    expect(
+      InvokeAttemptEvidenceSchema.safeParse(
+        attempt({
+          failureKind: 'process-spawn',
+          process: { exitCode: null, signal: 'SIGTERM', timedOut: false },
+        }),
+      ).success,
+    ).toBe(false);
+  });
+
+  it('keeps process evidence consistent with sdk and configured-shell routes', () => {
+    expect(
+      InvokeAttemptEvidenceSchema.safeParse(
+        attempt({ route: 'sdk', failureKind: 'auth', process: undefined }),
+      ).success,
+    ).toBe(true);
+    expect(InvokeAttemptEvidenceSchema.safeParse(attempt({ route: 'sdk' })).success).toBe(false);
+    expect(
+      InvokeAttemptEvidenceSchema.safeParse(
+        attempt({ route: 'configured-shell', failureKind: 'auth', process: undefined }),
+      ).success,
+    ).toBe(false);
+  });
+
+  it('rejects byte-accounting drift and any text retained after a DLP mask failure', () => {
+    const badCount = failureArtifact();
+    badCount.terminal.message.retainedBytes += 1;
+    expect(InvocationFailureArtifactSchema.safeParse(badCount).success).toBe(false);
+
+    const dlpFailure = failureArtifact();
+    dlpFailure.terminal.message = {
+      encoding: 'utf-8',
+      head: 'must not persist',
+      observedBytes: 16,
+      retainedBytes: 16,
+      limitBytes: INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES,
+      truncated: false,
+      dlp: 'omitted-on-mask-failure',
+    };
+    expect(InvocationFailureArtifactSchema.safeParse(dlpFailure).success).toBe(false);
+  });
+
+  it('allows DLP replacement to change retained byte length independently of raw observation', () => {
+    const expanded = textEvidence('[MASKED:LONGER-THAN-RAW]', INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES);
+    expanded.observedBytes = 3;
+    expect(
+      InvocationFailureArtifactSchema.safeParse({
+        ...failureArtifact(),
+        terminal: { ...failureArtifact().terminal, message: expanded },
+      }).success,
+    ).toBe(true);
+
+    const shortened = textEvidence('[MASKED]', INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES);
+    shortened.observedBytes = 10_000;
+    shortened.truncated = false;
+    expect(
+      InvocationFailureArtifactSchema.safeParse({
+        ...failureArtifact(),
+        terminal: { ...failureArtifact().terminal, message: shortened },
+      }).success,
+    ).toBe(true);
   });
 });
 

--- a/packages/core/src/artifacts/schema.ts
+++ b/packages/core/src/artifacts/schema.ts
@@ -26,12 +26,38 @@ import { z } from 'zod';
 
 /**
  * The schemaVersion WRITTEN by this code. Readers accept any 1.x (F1).
- * 1.1.0 (mmnto-ai/totem#2101): `grounding` gained the optional per-item
+ * 1.2.0 (mmnto-ai/totem#2452): `output` gained optional execution-attempt
+ * evidence for fallback/configured-shell provenance. 1.1.0
+ * (mmnto-ai/totem#2101): `grounding` gained the optional per-item
  * `bundle`, and `grounding.hash` semantics changed from hash-of-raw-context
  * to hash-of-bundle — the minor is the observable marker for that meaning
  * change; the registry stays empty because the tolerant reader parses both.
  */
-export const RUN_ARTIFACT_SCHEMA_VERSION = '1.1.0';
+export const RUN_ARTIFACT_SCHEMA_VERSION = '1.2.0';
+
+/** Schema version for the distinct terminal-invocation failure ledger. */
+export const INVOCATION_FAILURE_ARTIFACT_SCHEMA_VERSION = '1.0.0';
+
+/** Persisted evidence bounds (mmnto-ai/totem#2452 slice B). */
+export const MAX_INVOKE_ATTEMPTS = 8;
+export const INVOKE_STREAM_EVIDENCE_LIMIT_BYTES = 64 * 1024;
+export const INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES = 4 * 1024;
+
+/** Stable machine-readable failure taxonomy shared by CLI producers and artifact readers. */
+export const INVOKE_FAILURE_KINDS = [
+  'auth',
+  'quota',
+  'model',
+  'process-spawn',
+  'process-exit',
+  'timeout',
+  'unknown',
+] as const;
+
+/** Persisted provider codes are bounded identifiers, never arbitrary provider prose. */
+export const SAFE_PROVIDER_CODE_RE = /^[A-Za-z0-9_.:-]{1,128}$/;
+
+export const InvokeFailureKindSchema = z.enum(INVOKE_FAILURE_KINDS);
 
 /** The major this reader understands; other majors need a migration entry. */
 export const RUN_ARTIFACT_KNOWN_MAJOR = 1;
@@ -183,6 +209,207 @@ export const BackendSchema = z.object({
 });
 
 /**
+ * A byte-bounded, post-DLP text fragment safe to persist. `head` and optional
+ * `tail` preserve both structured envelopes and terminal diagnostics without
+ * retaining an unbounded provider response.
+ */
+export const BoundedTextEvidenceSchema = z
+  .object({
+    encoding: z.literal('utf-8'),
+    head: z.string(),
+    tail: z.string().optional(),
+    observedBytes: z.number().int().nonnegative(),
+    retainedBytes: z.number().int().nonnegative(),
+    limitBytes: z.number().int().positive().max(INVOKE_STREAM_EVIDENCE_LIMIT_BYTES),
+    truncated: z.boolean(),
+    dlp: z.enum(['masked', 'omitted-on-mask-failure']),
+  })
+  .superRefine((value, ctx) => {
+    const textBytes =
+      Buffer.byteLength(value.head, 'utf-8') + Buffer.byteLength(value.tail ?? '', 'utf-8');
+    if (value.retainedBytes !== textBytes) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['retainedBytes'],
+        message: 'retainedBytes must equal the UTF-8 byte length of head + tail',
+      });
+    }
+    if (value.retainedBytes > value.limitBytes) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['retainedBytes'],
+        message: 'retainedBytes cannot exceed limitBytes',
+      });
+    }
+
+    if (value.dlp === 'masked') return;
+
+    if (
+      value.head !== '' ||
+      value.tail !== undefined ||
+      value.retainedBytes !== 0 ||
+      value.truncated
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'DLP mask failure must omit all text and cannot claim byte truncation',
+      });
+    }
+  });
+
+/** Process-level facts captured by configured-shell and CLI-fallback routes. */
+export const InvokeProcessEvidenceSchema = z
+  .object({
+    exitCode: z.number().int().nullable(),
+    signal: z.string().min(1).nullable(),
+    timedOut: z.boolean(),
+    timeoutMs: z.number().int().positive().optional(),
+    stdout: BoundedTextEvidenceSchema.optional(),
+    stderr: BoundedTextEvidenceSchema.optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.timedOut !== (value.timeoutMs !== undefined)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['timeoutMs'],
+        message: 'timeoutMs must be present if and only if timedOut is true',
+      });
+    }
+  });
+
+/** One ordered invocation leg, retained after DLP and byte bounding. */
+export const InvokeAttemptEvidenceSchema = z
+  .object({
+    sequence: z.number().int().positive().max(MAX_INVOKE_ATTEMPTS),
+    route: z.enum(['sdk', 'cli-fallback', 'configured-shell', 'quota-model-fallback']),
+    provider: z.string().min(1),
+    model: z.string().min(1),
+    status: z.enum(['succeeded', 'failed']),
+    durationMs: z.number().nonnegative(),
+    failureKind: InvokeFailureKindSchema.optional(),
+    providerStatus: z.number().int().optional(),
+    providerCode: z
+      .string()
+      .regex(SAFE_PROVIDER_CODE_RE, 'providerCode must be a bounded machine token')
+      .optional(),
+    process: InvokeProcessEvidenceSchema.optional(),
+  })
+  .superRefine((value, ctx) => {
+    if (value.status === 'failed' && value.failureKind === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['failureKind'],
+        message: 'failed attempts must record a failureKind',
+      });
+    }
+    if (value.status === 'succeeded' && value.failureKind !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['failureKind'],
+        message: 'succeeded attempts cannot record a failureKind',
+      });
+    }
+
+    if (
+      value.status === 'succeeded' &&
+      value.process !== undefined &&
+      (value.process.timedOut ||
+        value.process.signal !== null ||
+        (value.process.exitCode !== null && value.process.exitCode !== 0))
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['process'],
+        message: 'succeeded attempts cannot be timed out, signaled, or have a nonzero exitCode',
+      });
+    }
+
+    if (value.failureKind === 'timeout' && value.process?.timedOut !== true) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['process'],
+        message: 'timeout failures must carry process evidence with timedOut=true',
+      });
+    }
+    if (value.failureKind !== 'timeout' && value.process?.timedOut === true) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['process', 'timedOut'],
+        message: 'only timeout failures may claim timedOut=true',
+      });
+    }
+
+    if (value.failureKind === 'process-exit') {
+      const processExitedAbnormally =
+        value.process !== undefined &&
+        ((value.process.exitCode !== null && value.process.exitCode !== 0) ||
+          value.process.signal !== null);
+      if (!processExitedAbnormally) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['process'],
+          message: 'process-exit failures must record a nonzero exitCode or signal',
+        });
+      }
+    }
+
+    if (
+      value.failureKind === 'process-spawn' &&
+      value.process !== undefined &&
+      (value.process.exitCode !== null || value.process.signal !== null || value.process.timedOut)
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['process'],
+        message: 'process-spawn evidence cannot claim an exitCode, signal, or timeout',
+      });
+    }
+
+    if (value.route === 'sdk' && value.process !== undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['process'],
+        message: 'sdk attempts cannot carry shell process evidence',
+      });
+    }
+    if (value.route === 'configured-shell' && value.process === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['process'],
+        message: 'configured-shell attempts must carry process evidence',
+      });
+    }
+  });
+
+const InvokeAttemptsSchema = z
+  .array(InvokeAttemptEvidenceSchema)
+  .min(1)
+  .max(MAX_INVOKE_ATTEMPTS)
+  .superRefine((attempts, ctx) => {
+    attempts.forEach((attempt, index) => {
+      if (attempt.sequence !== index + 1) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [index, 'sequence'],
+          message: 'attempt sequences must be contiguous and ordered from 1',
+        });
+      }
+    });
+  });
+
+export const RunExecutionEvidenceSchema = z
+  .object({ attempts: InvokeAttemptsSchema })
+  .superRefine((value, ctx) => {
+    if (value.attempts.at(-1)?.status !== 'succeeded') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['attempts'],
+        message: 'successful run execution evidence must end in a succeeded attempt',
+      });
+    }
+  });
+
+/**
  * Caller-declared output contract (mmnto-ai/totem#2102): the citations-or-
  * `VERIFY:` declaration. Callers write; #2103 post-checks read; providers
  * transport, never enforce (Totem is not zero-user — backend cooperation is
@@ -251,6 +478,44 @@ export const RunMetricsSchema = z.object({
   finishReason: z.string().optional(),
 });
 
+/**
+ * Terminal invocation evidence is deliberately NOT a RunArtifact: it has no
+ * successful semantic output and lives under `artifacts/runs/failures/`.
+ */
+export const InvocationFailureArtifactSchema = z
+  .object({
+    schemaVersion: z.literal(INVOCATION_FAILURE_ARTIFACT_SCHEMA_VERSION),
+    inputBundle: InputBundleSchema,
+    inputHash: z.string().regex(SHA256_HEX, 'inputHash must be a sha256 hex digest'),
+    grounding: GroundingSchema,
+    requestedBackend: BackendSchema,
+    attempts: InvokeAttemptsSchema,
+    terminal: z.object({
+      kind: InvokeFailureKindSchema,
+      attempt: z.number().int().positive().max(MAX_INVOKE_ATTEMPTS),
+      message: BoundedTextEvidenceSchema.refine(
+        (value) => value.limitBytes <= INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES,
+        `terminal message evidence cannot exceed ${INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES} bytes`,
+      ),
+    }),
+    admission: RunAdmissionSchema.optional(),
+    createdAt: z.string().datetime(),
+  })
+  .superRefine((artifact, ctx) => {
+    const last = artifact.attempts.at(-1);
+    if (
+      last?.sequence !== artifact.terminal.attempt ||
+      last.status !== 'failed' ||
+      last.failureKind !== artifact.terminal.kind
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['terminal'],
+        message: 'terminal must reference the final failed attempt and its failureKind',
+      });
+    }
+  });
+
 export const RunArtifactSchema = z.object({
   schemaVersion: schemaVersionField,
   inputBundle: InputBundleSchema,
@@ -261,6 +526,8 @@ export const RunArtifactSchema = z.object({
   output: z.object({
     content: z.string(),
     metrics: RunMetricsSchema,
+    /** Additive 1.2 execution provenance; absent on ordinary one-shot SDK success. */
+    execution: RunExecutionEvidenceSchema.optional(),
   }),
   /** Admitted contract group (mmnto-ai/totem#2102) — additive 1.x optional; slice-1/2 artifacts predate it. */
   admission: RunAdmissionSchema.optional(),
@@ -272,6 +539,12 @@ export const RunArtifactSchema = z.object({
 });
 
 export type RunArtifact = z.infer<typeof RunArtifactSchema>;
+export type InvokeFailureKind = z.infer<typeof InvokeFailureKindSchema>;
+export type BoundedTextEvidence = z.infer<typeof BoundedTextEvidenceSchema>;
+export type InvokeProcessEvidence = z.infer<typeof InvokeProcessEvidenceSchema>;
+export type InvokeAttemptEvidence = z.infer<typeof InvokeAttemptEvidenceSchema>;
+export type RunExecutionEvidence = z.infer<typeof RunExecutionEvidenceSchema>;
+export type InvocationFailureArtifact = z.infer<typeof InvocationFailureArtifactSchema>;
 export type InputBundle = z.infer<typeof InputBundleSchema>;
 export type GroundingItem = z.infer<typeof GroundingItemSchema>;
 export type GroundingBundle = z.infer<typeof GroundingBundleSchema>;

--- a/packages/core/src/artifacts/schema.ts
+++ b/packages/core/src/artifacts/schema.ts
@@ -35,7 +35,12 @@ import { z } from 'zod';
  */
 export const RUN_ARTIFACT_SCHEMA_VERSION = '1.2.0';
 
-/** Schema version for the distinct terminal-invocation failure ledger. */
+/**
+ * Schema version for the distinct terminal-invocation failure ledger. The
+ * exact 1.0.0 literal is deliberate fail-closed behavior: before accepting a
+ * future version, add an explicit versioned union and migration path rather
+ * than widening this schema in place.
+ */
 export const INVOCATION_FAILURE_ARTIFACT_SCHEMA_VERSION = '1.0.0';
 
 /** Persisted evidence bounds (mmnto-ai/totem#2452 slice B). */

--- a/packages/core/src/artifacts/storage.test.ts
+++ b/packages/core/src/artifacts/storage.test.ts
@@ -6,14 +6,35 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { TotemParseError } from '../errors.js';
 import { cleanTmpDir } from '../test-utils.js';
-import type { RunArtifact } from './schema.js';
-import { RUN_ARTIFACT_SCHEMA_VERSION } from './schema.js';
+import type { BoundedTextEvidence, InvocationFailureArtifact, RunArtifact } from './schema.js';
 import {
+  INVOCATION_FAILURE_ARTIFACT_SCHEMA_VERSION,
+  INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES,
+  RUN_ARTIFACT_SCHEMA_VERSION,
+} from './schema.js';
+import {
+  computeInvocationFailureArtifactContentHash,
   computeRunArtifactContentHash,
+  failureRunsDir,
+  loadInvocationFailureArtifact,
   loadRunArtifact,
   runsDir,
+  saveInvocationFailureArtifact,
   saveRunArtifact,
 } from './storage.js';
+
+function textEvidence(text: string, limitBytes = 64 * 1024): BoundedTextEvidence {
+  const bytes = Buffer.byteLength(text, 'utf-8');
+  return {
+    encoding: 'utf-8',
+    head: text,
+    observedBytes: bytes,
+    retainedBytes: bytes,
+    limitBytes,
+    truncated: false,
+    dlp: 'masked',
+  };
+}
 
 function artifact(overrides: Partial<RunArtifact> = {}): RunArtifact {
   return {
@@ -30,6 +51,49 @@ function artifact(overrides: Partial<RunArtifact> = {}): RunArtifact {
     },
     output: { content: 'response', metrics: { durationMs: 1200 } },
     createdAt: '2026-06-07T03:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function failureArtifact(
+  overrides: Partial<InvocationFailureArtifact> = {},
+): InvocationFailureArtifact {
+  return {
+    schemaVersion: INVOCATION_FAILURE_ARTIFACT_SCHEMA_VERSION,
+    inputBundle: { maskedPrompt: 'prompt after DLP' },
+    inputHash: 'c'.repeat(64),
+    grounding: { hash: 'd'.repeat(64), provenanceSummary: 'similarity-only' },
+    requestedBackend: {
+      provider: 'anthropic',
+      model: 'claude-sonnet-5',
+      qualifiedModel: 'anthropic:claude-sonnet-5',
+      admissionClass: 'completion_only',
+      taskProfile: 'Review',
+    },
+    attempts: [
+      {
+        sequence: 1,
+        route: 'cli-fallback',
+        provider: 'anthropic',
+        model: 'claude-sonnet-5',
+        status: 'failed',
+        durationMs: 900,
+        failureKind: 'process-exit',
+        process: {
+          exitCode: 1,
+          signal: null,
+          timedOut: false,
+          stdout: textEvidence('partial'),
+          stderr: textEvidence('rejected'),
+        },
+      },
+    ],
+    terminal: {
+      kind: 'process-exit',
+      attempt: 1,
+      message: textEvidence('Claude CLI exited with code 1', INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES),
+    },
+    createdAt: '2026-07-19T12:00:00.000Z',
     ...overrides,
   };
 }
@@ -100,5 +164,62 @@ describe('run-artifact storage', () => {
 
   it('rejects a non-hash id before touching the filesystem (path-traversal guard)', () => {
     expect(() => loadRunArtifact(totemDir, '../../secrets')).toThrow(/sha256/i);
+  });
+});
+
+describe('invocation-failure artifact storage', () => {
+  let totemDir: string;
+
+  beforeEach(() => {
+    totemDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-invoke-failures-'));
+  });
+
+  afterEach(() => {
+    cleanTmpDir(totemDir);
+  });
+
+  it('stores under runs/failures, mode 0600, and loads the artifact back', () => {
+    const failure = failureArtifact();
+    const saved = saveInvocationFailureArtifact(totemDir, failure);
+
+    expect(saved.existed).toBe(false);
+    expect(saved.path).toBe(
+      path.join(totemDir, 'artifacts', 'runs', 'failures', `${saved.hash}.json`),
+    );
+    expect(loadInvocationFailureArtifact(totemDir, saved.hash)).toEqual(failure);
+    if (process.platform !== 'win32') {
+      expect(fs.statSync(saved.path).mode & 0o777).toBe(0o600);
+    }
+  });
+
+  it('excludes createdAt from identity and preserves the first write', () => {
+    const early = failureArtifact({ createdAt: '2026-07-19T12:00:00.000Z' });
+    const late = failureArtifact({ createdAt: '2026-07-20T12:00:00.000Z' });
+    expect(computeInvocationFailureArtifactContentHash(early)).toBe(
+      computeInvocationFailureArtifactContentHash(late),
+    );
+
+    const first = saveInvocationFailureArtifact(totemDir, early);
+    const second = saveInvocationFailureArtifact(totemDir, late);
+    expect(second).toEqual({ ...first, existed: true });
+    expect(loadInvocationFailureArtifact(totemDir, first.hash).createdAt).toBe(early.createdAt);
+  });
+
+  it('changes identity when persisted diagnostic evidence changes', () => {
+    const original = failureArtifact();
+    const changed = failureArtifact({
+      terminal: {
+        ...original.terminal,
+        message: textEvidence('different bounded message', INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES),
+      },
+    });
+    expect(computeInvocationFailureArtifactContentHash(original)).not.toBe(
+      computeInvocationFailureArtifactContentHash(changed),
+    );
+  });
+
+  it('rejects invalid ids before reading the failure directory', () => {
+    expect(failureRunsDir(totemDir)).toBe(path.join(totemDir, 'artifacts', 'runs', 'failures'));
+    expect(() => loadInvocationFailureArtifact(totemDir, '../../secrets')).toThrow(/sha256/i);
   });
 });

--- a/packages/core/src/artifacts/storage.ts
+++ b/packages/core/src/artifacts/storage.ts
@@ -21,11 +21,12 @@ import * as path from 'node:path';
 import { rethrowAsParseError, TotemParseError } from '../errors.js';
 import { readJsonSafe } from '../sys/fs.js';
 import { calculateDeterministicHash } from './hash.js';
-import type { RunArtifact } from './schema.js';
-import { RunArtifactSchema } from './schema.js';
+import type { InvocationFailureArtifact, RunArtifact } from './schema.js';
+import { InvocationFailureArtifactSchema, RunArtifactSchema } from './schema.js';
 
 /** Storage layout segments under the totem dir (exact layout = impl call, #2100). */
 const RUNS_DIR_SEGMENTS = ['artifacts', 'runs'] as const;
+const FAILURE_RUNS_DIR_SEGMENTS = ['artifacts', 'runs', 'failures'] as const;
 
 /** Filename guard — the id IS a filesystem path segment, so gate it hard. */
 const SHA256_HEX = /^[0-9a-f]{64}$/;
@@ -44,6 +45,11 @@ export function runsDir(totemDirAbs: string): string {
   return path.join(totemDirAbs, ...RUNS_DIR_SEGMENTS);
 }
 
+/** Absolute terminal-invocation failure directory for a given absolute totem dir. */
+export function failureRunsDir(totemDirAbs: string): string {
+  return path.join(totemDirAbs, ...FAILURE_RUNS_DIR_SEGMENTS);
+}
+
 /**
  * Content address of an artifact: deterministic hash over everything EXCEPT
  * `createdAt` (observability, not identity — see schema docstring).
@@ -59,6 +65,23 @@ export interface SaveRunArtifactResult {
   /** Absolute path of the stored artifact. */
   path: string;
   /** True when an identical logical run was already recorded (no write happened). */
+  existed: boolean;
+}
+
+/** Content address of a terminal failure artifact, excluding emission time. */
+export function computeInvocationFailureArtifactContentHash(
+  artifact: InvocationFailureArtifact,
+): string {
+  const { createdAt: _excluded, ...identity } = artifact;
+  return calculateDeterministicHash(identity);
+}
+
+export interface SaveInvocationFailureArtifactResult {
+  /** The content address (= filename stem). */
+  hash: string;
+  /** Absolute path of the stored artifact. */
+  path: string;
+  /** True when an identical logical failure was already recorded. */
   existed: boolean;
 }
 
@@ -103,6 +126,41 @@ export function saveRunArtifact(totemDirAbs: string, artifact: RunArtifact): Sav
 }
 
 /**
+ * Persist a terminal invocation failure at its content address. As with
+ * successful run artifacts, atomic create-exclusive makes the ledger
+ * append-only and the first write (including its `createdAt`) wins.
+ */
+export function saveInvocationFailureArtifact(
+  totemDirAbs: string,
+  artifact: InvocationFailureArtifact,
+): SaveInvocationFailureArtifactResult {
+  const validated = InvocationFailureArtifactSchema.parse(artifact);
+  const hash = computeInvocationFailureArtifactContentHash(validated);
+  const dir = failureRunsDir(totemDirAbs);
+  const filePath = path.join(dir, `${hash}.json`);
+
+  if (fs.existsSync(filePath)) {
+    return { hash, path: filePath, existed: true };
+  }
+
+  fs.mkdirSync(dir, { recursive: true });
+  try {
+    fs.writeFileSync(filePath, JSON.stringify(validated, null, 2), {
+      encoding: 'utf-8',
+      mode: 0o600,
+      flag: 'wx',
+    });
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') {
+      return { hash, path: filePath, existed: true };
+    }
+    throw err;
+  }
+
+  return { hash, path: filePath, existed: false };
+}
+
+/**
  * Load + validate an artifact by content address. Throws `TotemParseError`
  * on a missing file, corrupt JSON, or schema violation (including an unknown
  * major with no migration entry) — loud, never a silent partial.
@@ -134,6 +192,32 @@ export function loadRunArtifact(totemDirAbs: string, hash: string): RunArtifact 
       `Run artifact ${hash} failed schema validation`,
       err,
       'The artifact may be corrupted or written by an incompatible totem version; re-emit it (or add the migration entry for its major).',
+    );
+  }
+}
+
+/** Load and validate a terminal invocation failure by content address. */
+export function loadInvocationFailureArtifact(
+  totemDirAbs: string,
+  hash: string,
+): InvocationFailureArtifact {
+  if (!SHA256_HEX.test(hash)) {
+    throw new TotemParseError(
+      `Invalid invocation-failure artifact id "${hash}" — expected a 64-char sha256 hex content address.`,
+      'Pass the hash exactly as reported at emission (or from the artifacts/runs/failures filename).',
+    );
+  }
+
+  const filePath = path.join(failureRunsDir(totemDirAbs), `${hash}.json`);
+  const raw = readJsonSafe(filePath);
+  try {
+    return InvocationFailureArtifactSchema.parse(raw);
+    // totem-context: rethrowAsParseError returns never; this catch normalizes schema failures into the public TotemParseError load contract and swallows nothing.
+  } catch (err) {
+    rethrowAsParseError(
+      `Invocation failure artifact ${hash} failed schema validation`,
+      err,
+      'The artifact may be corrupted or written by an incompatible totem version; re-emit it.',
     );
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -586,21 +586,37 @@ export { buildGroundingBundle, summarizeProvenance } from './artifacts/grounding
 export { calculateDeterministicHash } from './artifacts/hash.js';
 export type {
   BackendAdmissionClass,
+  BoundedTextEvidence,
   ContextPolicy,
   GroundingBundle,
   GroundingItem,
   InputBundle,
+  InvocationFailureArtifact,
+  InvokeAttemptEvidence,
+  InvokeFailureKind,
+  InvokeProcessEvidence,
   OutputContract,
   RunArtifact,
+  RunExecutionEvidence,
   RunMetadata,
 } from './artifacts/schema.js';
 export {
   ADMISSION_CLASSES,
   ADMISSION_COMPLETION_ONLY,
   ADMISSION_SELF_GROUNDING_AGENT,
+  BoundedTextEvidenceSchema,
   ContextPolicySchema,
   GroundingBundleSchema,
   GroundingItemSchema,
+  INVOCATION_FAILURE_ARTIFACT_SCHEMA_VERSION,
+  InvocationFailureArtifactSchema,
+  INVOKE_FAILURE_KINDS,
+  INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES,
+  INVOKE_STREAM_EVIDENCE_LIMIT_BYTES,
+  InvokeAttemptEvidenceSchema,
+  InvokeFailureKindSchema,
+  InvokeProcessEvidenceSchema,
+  MAX_INVOKE_ATTEMPTS,
   OutputContractSchema,
   PROVENANCE_CLASSES,
   PROVENANCE_COMPILED_RULE,
@@ -610,7 +626,9 @@ export {
   PROVENANCE_UNGROUNDED,
   RUN_ARTIFACT_SCHEMA_VERSION,
   RunArtifactSchema,
+  RunExecutionEvidenceSchema,
   RunMetadataSchema,
+  SAFE_PROVIDER_CODE_RE,
 } from './artifacts/schema.js';
 // Deterministic structural post-checks (mmnto-ai/totem#2103 slice 4)
 export type {
@@ -636,11 +654,18 @@ export {
   specVerifyRule,
   structuredOutputRule,
 } from './artifacts/post-checks-rules.js';
-export type { SaveRunArtifactResult } from './artifacts/storage.js';
+export type {
+  SaveInvocationFailureArtifactResult,
+  SaveRunArtifactResult,
+} from './artifacts/storage.js';
 export {
+  computeInvocationFailureArtifactContentHash,
   computeRunArtifactContentHash,
+  failureRunsDir,
+  loadInvocationFailureArtifact,
   loadRunArtifact,
   runsDir,
+  saveInvocationFailureArtifact,
   saveRunArtifact,
 } from './artifacts/storage.js';
 // Panel synthesis — independent lanes, script aggregation (mmnto-ai/totem#2104 slice 5)

--- a/packages/pack-agent-security/test/repo-sweep.test.ts
+++ b/packages/pack-agent-security/test/repo-sweep.test.ts
@@ -303,9 +303,9 @@ const ALLOWLIST: AllowEntry[] = [
   {
     hash: 'c2c09301bb56a02b',
     file: 'packages/cli/src/orchestrators/shell-orchestrator.ts',
-    expectedCount: 2,
+    expectedCount: 1,
     reason:
-      'Windows-only process-tree cleanup via `spawn(taskkill, [...])`. Literal target, fixed args. Required because Node child_process does not propagate SIGTERM on Windows.',
+      'Primary orchestrator command execution via `spawn(resolvedCmd, ...)`. The command template is an intentionally trusted, repository-configured boundary rather than a hardcoded executable; dynamic fields are constrained: `model` passes `assertValidModelName`, both the model and temporary prompt-file path are shell-quoted before interpolation, and the prompt file is created with mode 0600.',
   },
   {
     hash: 'c2c09301bb56a02b',


### PR DESCRIPTION
## Summary

- correct the Anthropic CLI fallback to pass review input through stdin instead of treating the input-file path as the prompt
- preserve bounded, masked invocation-attempt evidence in successful run artifacts and immutable failure artifacts
- normalize provider failures through a structured public error type while retaining stable error codes, recovery hints, causes, and legacy extractor behavior
- strengthen structured-verdict diagnostics, evidence invariants, timeout/process handling, and cross-platform termination coverage

## Root cause

The Anthropic fallback invoked `claude -p {file} --model {model}`. Claude interpreted the file path as the prompt, then abstained from following instructions in the referenced file. The fallback now invokes `claude -p --model {model} < {file}` and records enough sanitized execution evidence to distinguish abstention, timeout, provider failure, and malformed verdicts without leaking full prompts or output.

## Compatibility and safety

- run artifacts advance additively to schema 1.2.0 with optional ordered execution attempts
- failures use a distinct immutable 1.0.0 artifact under `.totem/artifacts/runs/failures/`
- evidence is DLP-masked and bounded to 8 attempts, 64 KiB per stream, and 4 KiB messages
- the legacy verdict extractor and public `TotemOrchestratorError` relationship remain intact
- includes minor changesets for `@mmnto/cli` and `@mmnto/totem`

## Validation

- core: 3,292/3,292 tests passed
- CLI: 3,451/3,451 tests passed
- ESLint, Prettier, core/CLI TypeScript checks, builds, and `git diff --check` passed
- `totem lint --branch` passed with 0 errors; existing advisory warnings remain frozen
- `totem verify-manifest` passed against the active rule-compilation freeze; no compile was run
- fresh trusted Gemini review passed with no findings; the full-fan provider-failure path also produced the expected failure evidence

Closes #2452
