### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine 0.1.21 -> 0.1.22

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,6 @@
   },
   "optionalDependencies": {
     "@mmnto/cli": "workspace:*",
-    "@mmnto/strategy-doctrine": "0.1.21"
+    "@mmnto/strategy-doctrine": "0.1.22"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.21
-        version: 0.1.21
+        specifier: 0.1.22
+        version: 0.1.22
 
   packages/cli:
     dependencies:
@@ -853,8 +853,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.21':
-    resolution: {integrity: sha512-ARmdHhJl/15ACfCpw2eInlA4X1kAounAdts0zelgQL2Bihsq0/mP3Bgc754/DcxXA4VtQBrTy1GmDnIxjZGRwA==}
+  '@mmnto/strategy-doctrine@0.1.22':
+    resolution: {integrity: sha512-wEEW3wYgXP70mdm8PE2lZmD8BPpnwEfToYijQocHr60Z6Ot63hH8IxcKqzwMDT5sX5XmRi/+Lmgw1tUisyboHg==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3685,7 +3685,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.21':
+  '@mmnto/strategy-doctrine@0.1.22':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
Bumps the cohort doctrine pin to the release `strategy-claude` cut at `0.1.22` (published `2026-07-20T03:17:34Z`, two minutes after `mmnto-ai/totem-strategy#939` merged at `e490fe03`).

## What actually changed in 0.1.22

Diffed the two published tarballs rather than reading the release notes. Three files differ, and only one carries content:

| File | Change |
|---|---|
| `parity-manifest.yaml` | **+83 lines** — four new `lesson-federation` rows |
| `strategy-doctrine.lock` | version/published stamps + `last-published-sha` pointers |
| `package.json` | version only |

The four new rows — `lesson-federation-snapshot-pin`, `-tier-filter`, `-acceptance-record`, `-drift-sensors` — declare the Prop 306 §9.2 sensing contract. Every one is `Goal:`-class / honest-absent: the detectors are totem-side build trackers #2444 / #2445 / #2446 / #2447, none of which have landed. Confirmed against `doctor --strict` on this branch — all four surface as `SKIP [honest-absent]`, which is the row behaving as designed, not a gap.

## Freeze safety

The bump moves the doctrine snapshot, so I checked the freeze explicitly:

- `freeze.json` content-hash `0cb5e663…` — **byte-identical to 0.1.21**. The rule-compilation freeze is untouched.
- `cohort-overlay.md` content-hash — also unchanged.
- Only `last-published-sha` pointers moved (`f27bc659` → `e490fe03`).

So this bump cannot lift, narrow, or otherwise perturb the standing freeze. `totem lint` still reports the 56-lesson stale manifest on this branch; that is the freeze, not drift from this change.

## Consumer-shape check (#630)

The failure mode for an optional-dep bump is the silent uninstall — a failed fetch that exits 0 while the lockfile entry vanishes. Verified positively rather than assuming:

- `pnpm-lock.yaml` carries specifier `0.1.22`, a resolved version, an integrity hash, and the `optional: true` entry.
- `node_modules/@mmnto/strategy-doctrine` **materialized on disk** at version `0.1.22` with all four artifacts present.

## Gates

`pnpm -r build` · `pnpm format:check` · `pnpm lint` (ESLint) · `totem doctor --strict` · `totem lint --base main` — all exit 0 on the full workspace, unfiltered.

No changeset: the root package is private and no published package changes.

Refs #2444, #2445, #2446, #2447.
