### PR TITLE
chore: totem postmerge lessons for 2443 2449 2450 2451 2454 2457

### DIFF
--- a/.totem/lessons/lesson-1062a314.md
+++ b/.totem/lessons/lesson-1062a314.md
@@ -1,0 +1,6 @@
+## Lesson — Leverage directory-union for zero-code registration
+
+**Tags:** architecture, extensibility, orchestration
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Designing orchestration layers with a directory-union pattern allows new vendors or seats to self-register dynamically via local directory creation, eliminating the need for resolver code changes.

--- a/.totem/lessons/lesson-23fb097e.md
+++ b/.totem/lessons/lesson-23fb097e.md
@@ -1,0 +1,6 @@
+## Lesson — Guard against newline-less slice truncation
+
+**Tags:** typescript, parsing, strings
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Using `string.slice(0, string.indexOf('\n'))` without guarding against `-1` chops off the last character of a newline-less string. Always handle the `-1` fallback to prevent silent data truncation in edge-case inputs.

--- a/.totem/lessons/lesson-2962242f.md
+++ b/.totem/lessons/lesson-2962242f.md
@@ -1,0 +1,6 @@
+## Lesson — Avoid silent defensive filtering on validated boundaries
+
+**Tags:** validation, architecture, security
+**Scope:** packages/core/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Avoid adding silent runtime type-guards deep within core logic if inputs are already validated at system boundaries. Silent filtering can lead to dangerous fail-soft behaviors, such as an invalid list filtering to empty and defaulting to a permissive state.

--- a/.totem/lessons/lesson-37a28e54.md
+++ b/.totem/lessons/lesson-37a28e54.md
@@ -1,0 +1,6 @@
+## Lesson — Handle null process exit codes gracefully
+
+**Tags:** node, process, validation
+**Scope:** packages/cli/**/*.ts, !**/*.test.*
+
+Node's child process close events can emit null exit codes and signals. Classifying these strictly as normal process exits can violate schema constraints and silently suppress failure logging.

--- a/.totem/lessons/lesson-5b162a82.md
+++ b/.totem/lessons/lesson-5b162a82.md
@@ -1,0 +1,6 @@
+## Lesson — Avoid quadratic string prepending in loops
+
+**Tags:** performance, typescript, string-manipulation
+**Scope:** packages/cli/**/*.ts, !**/*.test.*
+
+Prepending characters one-by-one in a loop to extract a string tail causes O(n²) allocations. Collect characters in reverse into an array and join them once to maintain linear performance.

--- a/.totem/lessons/lesson-60f1b157.md
+++ b/.totem/lessons/lesson-60f1b157.md
@@ -1,0 +1,6 @@
+## Lesson — Preserve preemptive delete in LRU cache sets
+
+**Tags:** caching, performance, patterns
+**Scope:** packages/core/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Retain the preemptive delete-before-set pattern in LRU cache implementations even if currently only called on cache misses. This canonical move-to-end idiom ensures correct MRU promotion if the setter is ever reused for upserts, preventing the cache's correctness from being coupled to a single call path.

--- a/.totem/lessons/lesson-70706c8c.md
+++ b/.totem/lessons/lesson-70706c8c.md
@@ -1,0 +1,6 @@
+## Lesson — Omit manual prefixes in custom errors
+
+**Tags:** errors, dx, formatting
+**Scope:** packages/cli/**/*.ts, !**/*.test.*
+
+Manually prepending error messages with system prefixes duplicates formatting when centralized handlers also apply them. Rely on the error class constructor or centralized formatter to normalize prefixes.

--- a/.totem/lessons/lesson-7fa1b476.md
+++ b/.totem/lessons/lesson-7fa1b476.md
@@ -1,0 +1,6 @@
+## Lesson — Measure CLI PATH probe duration
+
+**Tags:** telemetry, cli, performance
+**Scope:** packages/cli/**/*.ts, !**/*.test.*
+
+Hardcoding CLI availability check durations to zero hides PATH lookup stalls in slow environments. Always measure and record the actual elapsed time of PATH probes for honest telemetry.

--- a/.totem/lessons/lesson-86b5a025.md
+++ b/.totem/lessons/lesson-86b5a025.md
@@ -1,0 +1,6 @@
+## Lesson — Feed Claude CLI prompts via stdin
+
+**Tags:** cli, anthropic, claude
+**Scope:** packages/cli/**/*.ts, !**/*.test.*
+
+The Claude CLI interprets positional file arguments as the prompt text itself rather than a path to a file containing the prompt. Use stdin redirection to correctly pass file-based prompts.

--- a/.totem/lessons/lesson-88f58c62.md
+++ b/.totem/lessons/lesson-88f58c62.md
@@ -1,0 +1,6 @@
+## Lesson — Leverage Git-native attributes for configuration
+
+**Tags:** git, architecture, dx
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Using standard `.gitattributes` markers like `linguist-generated` avoids inventing proprietary configuration schemas. This provides an intuitive, Git-native escape hatch for developers to override default tool behaviors.

--- a/.totem/lessons/lesson-8e27cb66.md
+++ b/.totem/lessons/lesson-8e27cb66.md
@@ -1,0 +1,6 @@
+## Lesson — Match diff headers with trailing spaces
+
+**Tags:** git, parsing, regex
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Checking if a line starts with raw `+++` or `---` to identify diff headers can falsely match code lines like `++i;` or markdown headers. Always check for a trailing space (e.g., `+++ ` or `--- `) to safely distinguish metadata headers from code content.

--- a/.totem/lessons/lesson-8f8f1ad6.md
+++ b/.totem/lessons/lesson-8f8f1ad6.md
@@ -1,0 +1,6 @@
+## Lesson — Sequence validation gates before override blocks
+
+**Tags:** security, validation, override
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Validation gates for unsettled rounds must execute before override or cache-stamp blocks. This prevents override flags from falsely authorizing actions or minting push permissions on incomplete runs.

--- a/.totem/lessons/lesson-93f922e4.md
+++ b/.totem/lessons/lesson-93f922e4.md
@@ -1,0 +1,6 @@
+## Lesson — Label injected metadata to prevent LLM confusion
+
+**Tags:** llm, prompt-engineering, security
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Injected summaries or metadata can easily be mistaken by LLMs as actual file content or diffs. Wrapping these blocks in distinct XML tags with an explicit preamble prevents the model from misinterpreting metadata as code changes.

--- a/.totem/lessons/lesson-cc725634.md
+++ b/.totem/lessons/lesson-cc725634.md
@@ -1,0 +1,6 @@
+## Lesson — Derive error metrics from single source
+
+**Tags:** refactoring, dx, coherence
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+When constructing detailed error messages with status counts, always derive both the sub-counts and the total from the same validated collection. Mixing raw and parsed collections introduces structural inconsistency and risks drift during future refactors.

--- a/.totem/lessons/lesson-d993a68c.md
+++ b/.totem/lessons/lesson-d993a68c.md
@@ -1,0 +1,6 @@
+## Lesson — Match Prettier formatting in template literals
+
+**Tags:** formatting, prettier, testing, typescript
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Parity tests enforcing byte-identity between markdown files and TypeScript template literals can fail because Prettier formats standalone files but cannot reach inside TS string constants. To avoid this, manually align the template literal's formatting to match Prettier's output exactly.

--- a/.totem/lessons/lesson-f6a30456.md
+++ b/.totem/lessons/lesson-f6a30456.md
@@ -1,0 +1,6 @@
+## Lesson — Verify documentation against live CLI
+
+**Tags:** documentation, cli, testing
+**Scope:** docs/**/*.md
+
+When updating CLI references, verify command counts, subcommands, and flags directly against the built CLI's live help output rather than relying on static source code or existing docs. This guarantees accuracy and prevents circular documentation errors.

--- a/.totem/lessons/lesson-f7a3c2da.md
+++ b/.totem/lessons/lesson-f7a3c2da.md
@@ -1,0 +1,6 @@
+## Lesson — Frame curated documentation honestly
+
+**Tags:** documentation, dx, cli
+**Scope:** README.md, docs/**/*.md
+
+Instead of exhaustively duplicating a rapidly growing CLI command surface in the main README, maintain a curated list of high-priority commands combined with explicit signposting to the live help command. This prevents documentation rot and front-door skew while keeping the onboarding experience clean.


### PR DESCRIPTION
Postmerge lesson extraction for the PRs merged since the last batch (#2448), plus codex's #2457 extraction that was sitting unpushed on a local branch.

## Coverage

Derived by diffing merged PRs against the extraction batches, not from memory. The last batch (#2448) covered 2433 / 2436 / 2434 / 2431 / 2440 / 2442.

| PR | Lessons | Note |
|---|---|---|
| #2443 | ✅ | **merged the same minute as the #2448 batch and slipped its list** |
| #2449 | ✅ | |
| #2450 | ✅ | |
| #2451 | ✅ | |
| #2454 | ✅ | slice A |
| #2457 | ✅ | codex's extraction, cherry-picked from an unpushed local commit |
| #2461 | — | no review comments |
| #2467 | — | no review comments |

**17 lesson files: 5 from codex's #2457 commit, 12 newly extracted from 5 PRs.**

#2461 and #2467 were in the batch and returned nothing. Extraction is review-comment-driven and neither drew a bot round, so they are *honestly empty*, not skipped — recording that here so a future coverage audit doesn't read them as an uncovered gap.

Excluded: #2438 and #2455 (mechanical `Version Packages` cuts), and #2448 itself (an extraction PR).

## The freeze — compile is NOT run

The postmerge skill's steps 3–4 (`totem lesson compile --export` and the compiled-rule curation pass) are **deliberately skipped**. The `rule-compilation` freeze in `.totem/freeze.json` has been standing since 2026-05-17, pending the Convergent Spine replacement. This commit therefore touches **no** `compiled-rules.json`, `compile-manifest.json`, or AI-tool exports — lessons only.

`totem lint` continues to report a stale compile manifest (now 73 lessons rather than 56). That is the freeze, not drift introduced here.

## Disposition diff

Postmerge extraction has a known failure mode: it re-launders findings that were *declined* during the review round, converting a rejected bot claim into standing repo guidance. I diffed all 12 new lessons against their rounds' dispositions. All clear, and two are worth calling out because they descend directly from declines:

- **`lesson-2962242f`** (avoid silent defensive filtering on validated boundaries) ← CodeRabbit's `fileMatchesGlobs` `typeof` guard on #2451, which I **declined**. The lesson encodes my rationale — a silent filter is fail-soft, an all-invalid list would default-allow — not the finding.
- **`lesson-60f1b157`** (preserve preemptive delete in LRU sets) ← greptile's `BoundedRegexCache.set` no-op `delete` on #2451, also **declined**. Again the lesson carries the decline rationale: removing it couples `set()`'s correctness to its current single call path.

Both point the correct direction. For contrast, **`lesson-cc725634`** (single-source error metrics) traces to a greptile P2 that was **taken** in `916a0602`.

## Note on the extraction lane

The first extraction attempt failed with `SDK unavailable, falling back to gemini CLI` → exit 55. Cause was #2374's cwd-relative `.env` loading: the run happened in a git worktree, and `.env` is gitignored, so it never resolved. Copying it in fixed it. Worth knowing for anyone running postmerge outside the resident checkout.
