### PR TITLE
fix(review): deterministic skip paths no longer stamp the push gate (#2466)

### DIFF
--- a/.changeset/quiet-moons-remain.md
+++ b/.changeset/quiet-moons-remain.md
@@ -1,0 +1,17 @@
+---
+'@mmnto/cli': minor
+---
+
+fix(review): deterministic skip paths no longer stamp the push-gate cache (#2466)
+
+`totem review` has three deterministic skip paths that drop the entire diff without examining it — all-non-code, no-code-remaining-after-filtering, and all-generated-artifacts. Each logged an informational "Deterministic fast-path" line and then called `writeReviewedContentHash(...)` before returning, so a run that reviewed nothing minted `.totem/cache/.reviewed-content-hash` — the marker PreToolUse hooks read as review authorization. A non-review both exited 0 and left behind a stamp claiming the tree was reviewed.
+
+The three paths are no longer equivalent in danger, which is why all three are fixed rather than only the reported one. `content-hash.sh` hashes only tracked files matching the review extensions (default `.ts`/`.tsx`/`.js`/`.jsx`), so for all-non-code and filtered-empty the hash is unchanged and the stamp was a no-op — the defect there is the dishonest clean-pass surface. The all-generated path is different: `.gitattributes linguist-generated` can mark a tracked `.ts` file as generated, so that path can drop a hashed source file, write a fresh stamp over the new hash, and authorize code no reviewer saw.
+
+All three now emit a `NON-REVIEW:` warning stating that nothing was examined and that the reviewed-content-hash was not stamped, and none of them stamp. The notice is single-sourced so the three sites cannot drift into describing the same guarantee differently, and its voice matches the existing worktree-drift notices — the other surface that declines to stamp. This mirrors the reasoning already applied to `--estimate` (an estimate is a forecast, not a passing review) and the standing repo rule against stamping the cache on non-reviews.
+
+Prose-only pushes are unaffected: the gate compares a hash over code files that a prose change does not touch, so it remains satisfied by the last genuine review.
+
+Bumped minor rather than patch on the slice-A precedent — push-gate authorization is user-visible behavior, and a consumer marking tracked sources as generated will now correctly be asked for a real review where one was previously minted for them.
+
+Sibling of #2452 slice A: that gate keys on lanes inside a verdict artifact, which these paths return before ever constructing, so it could not reach them. The remaining question — whether a total skip should also carry a distinct exit state rather than exiting 0 — is deliberately left open.

--- a/packages/cli/src/commands/shield-nonreview.test.ts
+++ b/packages/cli/src/commands/shield-nonreview.test.ts
@@ -1,0 +1,165 @@
+/**
+ * CLI-level deterministic-skip NON-REVIEW tests (mmnto-ai/totem#2466).
+ *
+ * `totem review` has three deterministic skip paths that drop the ENTIRE diff
+ * without examining it: all-non-code, no-code-after-filtering, and all-generated.
+ * Each used to call `writeReviewedContentHash(...)` before returning, minting the
+ * `.reviewed-content-hash` push-gate stamp for content nothing reviewed.
+ *
+ * The danger is not uniform, which is why all three are pinned here rather than
+ * only the reported one:
+ *
+ *   - all-non-code / filtered-empty fire only when no code file is in the diff,
+ *     so the hash is unchanged and the stamp was a no-op. The defect is the
+ *     dishonest clean-pass surface (Tenets 4/13).
+ *   - all-generated can drop a TRACKED, HASHED source file, because
+ *     `.gitattributes linguist-generated` can mark a `.ts` as generated. There the
+ *     stamp genuinely authorized never-reviewed code — a push-gate bypass.
+ *
+ * Mirrors `shield-covariate.test.ts`: its own file to avoid mock contamination,
+ * mocking the heavy seams (config, engine bootstrap, hook installer, git diff) so
+ * the skip branches are exercised without a real repo, config, or network invoke.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { TotemConfig } from '@mmnto/totem';
+
+import { cleanTmpDir } from '../test-utils.js';
+
+// ── Seams that MUST NOT run once a skip path is taken ──
+const bootstrapEngineSpy = vi.fn(async (..._args: unknown[]): Promise<void> => {});
+const upgradePrePushHookSpy = vi.fn((..._args: unknown[]): boolean => false);
+const getDiffForReviewSpy = vi.fn(async (..._args: unknown[]): Promise<unknown> => null);
+
+const TEST_CONFIG = {
+  totemDir: '.totem',
+  review: { sourceExtensions: ['.ts'] },
+} as unknown as TotemConfig;
+
+vi.mock('../utils/bootstrap-engine.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/bootstrap-engine.js')>();
+  return { ...actual, bootstrapEngine: bootstrapEngineSpy };
+});
+
+vi.mock('./install-hooks.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./install-hooks.js')>();
+  return { ...actual, upgradePrePushHookIfNeeded: upgradePrePushHookSpy };
+});
+
+vi.mock('../utils.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils.js')>();
+  return {
+    ...actual,
+    loadEnv: vi.fn(),
+    resolveConfigPath: (cwd: string) => path.join(cwd, 'totem.config.ts'),
+    loadConfig: vi.fn(async () => TEST_CONFIG),
+  };
+});
+
+vi.mock('../git.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../git.js')>();
+  return { ...actual, getDiffForReview: getDiffForReviewSpy };
+});
+
+/** A minimal single-file diff section for `file`. */
+function diffFor(file: string): string {
+  return [
+    `diff --git a/${file} b/${file}`,
+    'index 1111111..2222222 100644',
+    `--- a/${file}`,
+    `+++ b/${file}`,
+    '@@ -1 +1 @@',
+    '-old',
+    '+new',
+  ].join('\n');
+}
+
+describe('deterministic skip paths are NON-REVIEWS and never stamp (#2466)', () => {
+  let tmpDir: string;
+  let warnings: string[];
+
+  const stampPath = () => path.join(tmpDir, '.totem', 'cache', '.reviewed-content-hash');
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shield-nonreview-'));
+    warnings = [];
+    vi.spyOn(process, 'cwd').mockReturnValue(tmpDir);
+    vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map(String).join(' '));
+    });
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      warnings.push(args.map(String).join(' '));
+    });
+    bootstrapEngineSpy.mockClear();
+    getDiffForReviewSpy.mockClear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    // The non-skip case (mixed diff) runs into the LLM path and aborts on the
+    // unmocked embedding config, which can leave a handle open under the temp
+    // dir — Windows then EPERMs the recursive remove. That is a harness artifact
+    // of driving the real command, not a product behavior, and it must not fail
+    // a suite whose assertions are all about the stamp and the emitted output.
+    try {
+      cleanTmpDir(tmpDir);
+    } catch {
+      // Best-effort cleanup; the OS reclaims the temp dir.
+    }
+  });
+
+  /**
+   * Drive the real command with a diff whose files are all `files`.
+   *
+   * A run that does NOT take a skip path continues into the LLM review path and
+   * throws on the unmocked embedding config. That throw is expected and is itself
+   * evidence the skip did not fire, so it is swallowed here — every assertion
+   * below is made on the stamp and the emitted output, never on resolution.
+   */
+  async function runWithDiff(files: string[]): Promise<void> {
+    getDiffForReviewSpy.mockResolvedValueOnce({
+      diff: files.map(diffFor).join('\n'),
+      changedFiles: files,
+    });
+    const { shieldCommand } = await import('./shield.js');
+    try {
+      await shieldCommand({} as Parameters<typeof shieldCommand>[0]);
+    } catch {
+      // See doc comment — a non-skip run is expected to fail downstream.
+    }
+  }
+
+  it('all-non-code: does not stamp, and says so', async () => {
+    await runWithDiff(['docs/plan.md', 'README.md']);
+
+    // The load-bearing assertion: no push authorization was minted.
+    expect(fs.existsSync(stampPath())).toBe(false);
+    // And the skip is LOUD — a caller cannot read it as a clean review.
+    expect(warnings.join('\n')).toMatch(/NON-REVIEW/);
+    expect(warnings.join('\n')).toMatch(/does not authorize a push/);
+  });
+
+  it('all-generated: does not stamp — the path that could authorize real code', async () => {
+    // A lockfile is generated by default glob, so the whole diff drops.
+    await runWithDiff(['pnpm-lock.yaml']);
+
+    expect(fs.existsSync(stampPath())).toBe(false);
+    expect(warnings.join('\n')).toMatch(/NON-REVIEW/);
+    expect(warnings.join('\n')).toMatch(/does not authorize a push/);
+  });
+
+  it('mixed code + prose does NOT take a skip path (the skip must not over-fire)', async () => {
+    // Guards the inverse error: tightening the skip must not start skipping real
+    // code. A surviving `.ts` file means this is a review, not a non-review.
+    await runWithDiff(['docs/plan.md', 'src/index.ts']);
+
+    expect(warnings.join('\n')).not.toMatch(/NON-REVIEW/);
+    // It also must not stamp here — this run never completed a review either.
+    expect(fs.existsSync(stampPath())).toBe(false);
+  });
+});

--- a/packages/cli/src/commands/shield-nonreview.test.ts
+++ b/packages/cli/src/commands/shield-nonreview.test.ts
@@ -122,10 +122,16 @@ describe('deterministic skip paths are NON-REVIEWS and never stamp (#2466)', () 
    * below is made on the stamp and the emitted output, never on resolution.
    */
   async function runWithDiff(files: string[]): Promise<void> {
-    getDiffForReviewSpy.mockResolvedValueOnce({
-      diff: files.map(diffFor).join('\n'),
-      changedFiles: files,
-    });
+    await runWithDiffRaw(files.map(diffFor).join('\n'), files);
+  }
+
+  /**
+   * Lower-level driver for cases where the diff BODY and the changed-file LIST
+   * must differ — the filtered-empty path needs a code file present in the list
+   * whose hunks are absent from the diff (a mode-only change has this shape).
+   */
+  async function runWithDiffRaw(diff: string, changedFiles: string[]): Promise<void> {
+    getDiffForReviewSpy.mockResolvedValueOnce({ diff, changedFiles });
     const { shieldCommand } = await import('./shield.js');
     try {
       await shieldCommand({} as Parameters<typeof shieldCommand>[0]);
@@ -150,6 +156,39 @@ describe('deterministic skip paths are NON-REVIEWS and never stamp (#2466)', () 
 
     expect(fs.existsSync(stampPath())).toBe(false);
     expect(warnings.join('\n')).toMatch(/NON-REVIEW/);
+    expect(warnings.join('\n')).toMatch(/does not authorize a push/);
+  });
+
+  it('all-generated via .gitattributes on a TRACKED .ts: does not stamp (the bypass case)', async () => {
+    // The scenario the default-glob lockfile test does NOT reach, and the only
+    // one where the old stamp could authorize genuinely-changed, hashed source:
+    // `linguist-generated` marks a real `.ts`, so the file is dropped from review
+    // while still counting toward the content hash the push gate compares.
+    fs.writeFileSync(
+      path.join(tmpDir, '.gitattributes'),
+      'src/generated-client.ts linguist-generated\n',
+    );
+
+    await runWithDiff(['src/generated-client.ts']);
+
+    expect(fs.existsSync(stampPath())).toBe(false);
+    // Assert the GENERATED-path wording specifically. A bare /NON-REVIEW/ match
+    // would also pass if this fell through to the all-non-code branch, which
+    // would mean the test proves nothing about the bypass it exists to cover.
+    expect(warnings.join('\n')).toMatch(/every changed file is a generated artifact/);
+    expect(warnings.join('\n')).toMatch(/does not authorize a push/);
+  });
+
+  it('filtered-empty: does not stamp when no code hunks survive filtering', async () => {
+    // Stage 2 fires when the diff is neither all-code nor all-non-code and the
+    // code side contributes no hunks — a mode-only change on a tracked source
+    // file has exactly this shape: listed as changed, absent from the diff body.
+    await runWithDiffRaw(diffFor('docs/plan.md'), ['docs/plan.md', 'src/index.ts']);
+
+    expect(fs.existsSync(stampPath())).toBe(false);
+    // Stage-2 wording specifically — distinguishes this from the Stage-1
+    // all-non-code branch, which a generic NON-REVIEW match would not.
+    expect(warnings.join('\n')).toMatch(/no code changes remain after filtering/);
     expect(warnings.join('\n')).toMatch(/does not authorize a push/);
   });
 

--- a/packages/cli/src/commands/shield.ts
+++ b/packages/cli/src/commands/shield.ts
@@ -468,6 +468,19 @@ export function formatVerdictForDisplay(verdict: ShieldStructuredVerdict, pass: 
 const LEGACY_REVIEW_SOURCE_EXTENSIONS: readonly string[] = ['.ts', '.tsx', '.js', '.jsx'];
 
 /**
+ * Shared tail for every deterministic skip that drops the ENTIRE diff
+ * (mmnto-ai/totem#2466). Such a run is a NON-REVIEW, not a pass: no lane ran and
+ * nothing was examined, so it must not stamp `.reviewed-content-hash` and must not
+ * read as a clean review.
+ *
+ * Single-sourced deliberately — the three skip sites must never drift into
+ * describing the same guarantee three different ways. Voice matches the existing
+ * worktree-drift notices, which are the other "NOT stamped" surface.
+ */
+const NO_STAMP_NOTICE =
+  'Nothing was examined, so the reviewed-content-hash was NOT stamped — this run does not authorize a push.';
+
+/**
  * Refresh `<totemDir>/review-extensions.txt` if its contents do not match
  * the supplied extension set (or the file is missing). Closes the stale-
  * canonical-file window when a user edits `totem.config.ts` but forgets to
@@ -622,10 +635,14 @@ export async function writeReviewedContentHashValue(
  * survives commits, amends, and rebases. Only breaks when source files change.
  *
  * Now a thin compose of the pure computer + explicit writer (Prop 304 R2): it
- * hashes the CURRENT tree and stamps it. Retained at its original signature
- * for the trivial fast-path stamps (no-changes / all-non-code / filtered-empty
- * — none of which open a mid-run LLM window) and `recordShieldOverride`, where
- * there is no drift race to guard. The LLM review path does NOT use this — it
+ * hashes the CURRENT tree and stamps it. Retained at its original signature for
+ * the no-changes stamp (an empty diff opens no mid-run LLM window) and
+ * `recordShieldOverride`, where there is no drift race to guard.
+ *
+ * NO LONGER used by the deterministic skip paths (all-non-code / filtered-empty /
+ * all-generated). Those drop the entire diff without examining it, so they are
+ * non-reviews and must not stamp — see `NO_STAMP_NOTICE` (mmnto-ai/totem#2466).
+ * The LLM review path does NOT use this — it
  * captures the hash pre-fan and compare-and-stamps in `shieldCommand` /
  * `handleVerdictResult` so a mid-review edit can never be authorized.
  */
@@ -1705,15 +1722,16 @@ export async function shieldCommand(options: ShieldOptions): Promise<void> {
       generatedArtifactSummary = buildGeneratedArtifactSection(generated.summaries);
 
       // All changed files were generated artifacts — nothing left to review.
-      // Deterministic PASS: the summary was already surfaced above (never a
-      // silent skip). The artifacts' correctness is a gate concern, not the LLM's.
+      // Not sending them to the LLM stays correct (their correctness is a gate
+      // concern, not the LLM's) but that does NOT extend to stamping the push
+      // gate on their behalf: this is the one skip path that can drop a TRACKED,
+      // HASHED source file, because `.gitattributes linguist-generated` can mark
+      // a `.ts` as generated. Stamping here would authorize code no reviewer saw
+      // (mmnto-ai/totem#2466).
       if (!diff.trim()) {
-        log.info(DISPLAY_TAG, 'Deterministic fast-path: all changed files are generated artifacts');
-        await writeReviewedContentHash(
-          cwd,
-          config.totemDir,
-          configRoot,
-          config.review.sourceExtensions,
+        log.warn(
+          DISPLAY_TAG,
+          `NON-REVIEW: every changed file is a generated artifact, so no lane ran. ${NO_STAMP_NOTICE}`,
         );
         return;
       }
@@ -1723,14 +1741,11 @@ export async function shieldCommand(options: ShieldOptions): Promise<void> {
   // Stage 1: Classify files — fast-path for non-code-only diffs
   const classification = classifyChangedFiles(changedFiles);
   if (classification.allNonCode) {
-    log.info(DISPLAY_TAG, 'Deterministic fast-path: all changed files are non-code');
-    log.dim(DISPLAY_TAG, `Skipped: ${changedFiles.join(', ')}`);
-    await writeReviewedContentHash(
-      cwd,
-      config.totemDir,
-      configRoot,
-      config.review.sourceExtensions,
+    log.warn(
+      DISPLAY_TAG,
+      `NON-REVIEW: every changed file is non-code, so no lane ran. ${NO_STAMP_NOTICE}`,
     );
+    log.dim(DISPLAY_TAG, `Skipped: ${changedFiles.join(', ')}`);
     return;
   }
 
@@ -1741,16 +1756,10 @@ export async function shieldCommand(options: ShieldOptions): Promise<void> {
     filteredDiff = await filterDiffByPatterns(diff, classification.nonCodeFiles);
     filteredFiles = classification.codeFiles;
     if (!filteredDiff.trim()) {
-      // After filtering, no code diff remains — fast-path PASS
-      log.info(
+      // After filtering non-code files, no code diff remains — nothing was examined.
+      log.warn(
         DISPLAY_TAG,
-        'Deterministic fast-path: no code changes after filtering non-code files',
-      );
-      await writeReviewedContentHash(
-        cwd,
-        config.totemDir,
-        configRoot,
-        config.review.sourceExtensions,
+        `NON-REVIEW: no code changes remain after filtering non-code files, so no lane ran. ${NO_STAMP_NOTICE}`,
       );
       return;
     }


### PR DESCRIPTION
Part of #2466 — **deliberately does not close it.** See "What this does not fix" below.

Three deterministic skip paths in `shieldCommand` drop the entire diff without examining it, then call `writeReviewedContentHash(...)` before returning — so a run that reviewed nothing minted `.totem/cache/.reviewed-content-hash`.

> **Premise correction (2026-07-20).** This PR was written believing that stamp is consumed as push authorization by a PreToolUse gate. **It is not, in this repo.** #2180 (merged 2026-06-15) decommissioned `review-gate.sh`; `tools/pre-push` now runs `totem review || exit 1` live, and nothing here reads `.reviewed-content-hash`. The hole this PR closes is therefore **dormant in totem and live for downstream consumers on old hooks**. The locally-live half of #2466 is the exit code, which this PR does not change. Detail in the disposition comment; #2472 tracks the stale doc that caused the error.

## The three are not equally dangerous

This is the part that changed the fix, and it is not visible from the field report. `.claude/hooks/content-hash.sh` — shared by the stamp writer and the gate verifier — hashes **only tracked files matching the review extensions** (default `.ts`/`.tsx`/`.js`/`.jsx`).

| Path | Fires when | Effect of its stamp |
|---|---|---|
| `1725` all-non-code | no code file in diff | hash unchanged → **no-op** |
| `1743` filtered-empty | no code survives filtering | hash unchanged → **no-op** |
| `1710` all-generated | diff is all generated | **can change the hash** |

For the first two the stamp authorized nothing that was not already authorized; the defect is the dishonest clean-pass surface (Tenets 4/13). The third is different: `.gitattributes linguist-generated` can mark a tracked `.ts` as generated (#2443), so that path can drop a hashed source file, stamp the new hash, and authorize code no reviewer saw.

**That inverts the obvious fix order.** The path carrying a stated "deterministic PASS" rationale (`shield.ts:1707–1709`) is the dangerous one. Not sending generated artifacts to the LLM stays correct — their correctness is a gate concern — but stamping the push gate on their behalf does not follow from it.

Reachability, stated plainly: not reachable in this repo today (no `generated` markers in `.gitattributes`, `dist/` untracked, default globs are lockfiles and `.totem/*.json`, none in the 658-file hash set). Reachable by design in any consumer, since marking generated files is what the feature is for.

## Change

None of the three stamp. Each emits a `NON-REVIEW:` warning naming what was skipped and stating that nothing was examined and no push is authorized. The notice is single-sourced as `NO_STAMP_NOTICE` so the three sites cannot drift into describing one guarantee three different ways, and its voice matches the existing worktree-drift notices — the other surface that declines to stamp.

Precedent this follows rather than invents: `shield-estimate.ts:50` already declines to stamp on empty-diff runs, for exactly this reason ("an estimate is a forecast, not a passing review"), and there is a standing compiled rule against stamping the cache on non-reviews.

**Prose-only pushes are unaffected.** The gate compares a hash over code files a prose change does not touch, so it stays satisfied by the last genuine review. No deadlock.

## What this does not fix

**The locally-live half of #2466.** Because `tools/pre-push` runs `totem review || exit 1`, a prose-only diff hits a fast path, returns, exits 0, and the push proceeds — a non-review passing the gate through its *exit code*. That is #2466's original framing, and for this repo it was the correct one.

This PR does not change any exit code. #2466 therefore stays **open** after this merges, for the exit-contract follow-up, which should use totem-codex's two-phase model: **admission/applicability** (`not-applicable` with a deterministic reason — `no-diff`, `all-non-code`, `filtered-empty`, `all-generated`) versus **fan execution** (`completed | abstained | failed`). A deterministic skip is not a fourth lane outcome and not an `InvokeFailureKind`; mapping it into #2452 slice B's taxonomy would erase the phase boundary and imply provider work that never occurred.

## Deliberately not in scope

- **The no-changes stamp (`1659`)** has a different premise — no diff at all, rather than a diff dropped after inspection. Arguably adjacent, but it is not what #2466 reports and widening a fix PR into it invites a review round about scope instead of correctness. Flagging rather than folding in.
- **`recordShieldOverride` (`696`)** is an explicit, ledgered operator override. Correct to stamp.
- **Exit state.** Whether a total skip should exit non-zero rather than 0 changes the error surface for every docs-only run, so it wants its own ruling. The honesty half — no stamp, loud notice — is what lands here, and it is the half that closes the authorization hole.

## Verification

- **Red/green proven.** Both stamp tests fail against the previous `shield.ts` and pass after; verified by stashing only the source change and re-running. The third test (mixed code+prose must not take a skip path) passes on both — it is a regression guard against over-firing, not a bug-encoder.
- Full workspace suite unfiltered: **147 files, 3455 tests, green**.
- `pnpm -r build` · `format:check` · ESLint · `totem doctor --strict` · `totem lint --base main` — all exit 0.

`totem lint` reports a stale compile manifest (73 lessons); that is the standing rule-compilation freeze, not drift from this PR.

## Process note

The auto-generated spec for this issue named four files to modify — `packages/core/src/review/engine.ts`, `.../review/types.ts`, `packages/cli/src/commands/review.ts`, `.../engine.test.ts` — and proposed a `ReviewVerdictSchema` extension, a `ReviewExitCode` enum, and an `--allow-empty` flag. **None of those files or symbols exist**; `packages/core/src/review/` is not a directory in this repo. The spec was discarded and not committed, since a spec describing an invented architecture would read as the design of record. Filed as an exhibit on #2465 (run artifact `3a98f965ad47…`).
