### PR TITLE
feat(review): thread slice-B invoke-failure kinds into verdict lane surfacing (#2452 A-side follow-up)

### DIFF
--- a/.changeset/thread-invoke-failure-kinds.md
+++ b/.changeset/thread-invoke-failure-kinds.md
@@ -1,0 +1,36 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+---
+
+thread slice-B invoke-failure kinds into the verdict lane surface (#2459)
+
+Slice B (#2457) produces a structured `OrchestratorInvokeError` — a bounded `kind`
+(`auth | quota | model | process-spawn | process-exit | timeout | unknown`), ordered
+attempt evidence, and an optional content-addressed `failureArtifactHash` — but slice
+A's verdict-lane surface collapsed every execution failure into the single coarse
+`invoke-error`. This threads B's evidence through to the verdict and the operator.
+
+Core (`@mmnto/totem`): `VerdictLaneFailureReason` is widened additively with the
+execution-phase invoke kinds (`invoke-auth`, `invoke-model`, `invoke-process-spawn`,
+`invoke-process-exit`, `invoke-timeout`); `quota` and `unknown` reuse the pre-existing
+`quota-exhausted` / `invoke-error`, so the mapping is 1:1 and nothing collapses. A
+`failed` lane gains an optional `failureArtifactHash` that reaches B's bounded evidence
+one hop away, mirroring how a completed lane reaches its run artifact via
+`runArtifactHash`; when recorded it resolves via `loadInvocationFailureArtifact`. The
+verdict-artifact schema version bumps `1.1.0 → 1.2.0` — a minor and reader-tolerance
+step per the 1.x F1 policy: the widening is purely additive (new enum members plus an
+optional field), so every prior 1.x verdict still parses unchanged.
+
+CLI (`@mmnto/cli`): `classifyRejectedLane` consumes the structured
+`OrchestratorInvokeError` (its `kind` and `failureArtifactHash`) instead of inferring
+the category from error prose, and records the evidence hash on the failed lane. Per the
+#2471 gate-semantics boundary, an admission-phase `TotemConfigError` maps to
+`config-error` — it never reached execution, so it is never mapped to a widened
+`invoke-*` kind. The zero-completed hard-error message now names the per-lane failure
+categories (e.g. `failed by category: invoke-auth (1), invoke-timeout (1)`) so a
+provider-unsettled round shows the operator auth vs quota vs timeout, not just counts.
+
+The merged slice-A zero-completed exit contract is unchanged: the five-shape exit matrix
+still passes, and the `completed=0, abstained=N, failed=M` count line is preserved
+verbatim.

--- a/.changeset/thread-invoke-failure-kinds.md
+++ b/.changeset/thread-invoke-failure-kinds.md
@@ -24,8 +24,8 @@ optional field), so every prior 1.x verdict still parses unchanged.
 
 CLI (`@mmnto/cli`): `classifyRejectedLane` consumes the structured
 `OrchestratorInvokeError` (its `kind` and `failureArtifactHash`) instead of inferring
-the category from error prose, and records the evidence hash on the failed lane. Per the
-#2471 gate-semantics boundary, an admission-phase `TotemConfigError` maps to
+the category from error prose, and records the evidence hash on the failed lane. Per
+the #2471 gate-semantics boundary, an admission-phase `TotemConfigError` maps to
 `config-error` — it never reached execution, so it is never mapped to a widened
 `invoke-*` kind. The zero-completed hard-error message now names the per-lane failure
 categories (e.g. `failed by category: invoke-auth (1), invoke-timeout (1)`) so a

--- a/packages/cli/src/commands/review-fan.test.ts
+++ b/packages/cli/src/commands/review-fan.test.ts
@@ -11,6 +11,7 @@ import {
   deriveCacheEligible,
   deriveSettled,
   findLatestVerdictForLineage,
+  type InvokeFailureKind,
   listVerdictArtifacts,
   readLedgerEvents,
   renderCovariateLine,
@@ -18,9 +19,11 @@ import {
   type TotemConfig,
   TotemConfigError,
   VERDICT_ARTIFACT_SCHEMA_VERSION,
+  type VerdictLaneFailureReason,
 } from '@mmnto/totem';
 
 import { EMPTY_SHARED } from '../exemptions/exemption-schema.js';
+import { OrchestratorInvokeError } from '../orchestrators/orchestrator.js';
 import { cleanTmpDir } from '../test-utils.js';
 import {
   assembleVerdict,
@@ -466,6 +469,71 @@ describe('runLane', () => {
     expect(classified.lane.status).toBe('failed');
     if (classified.lane.status === 'failed')
       expect(classified.lane.typedReason).toBe('invoke-error');
+  });
+});
+
+// ─── #2459: classifyRejectedLane consumes slice-B's structured OrchestratorInvokeError ──
+
+describe('classifyRejectedLane — slice-B invoke-failure kinds (mmnto-ai/totem#2459)', () => {
+  it('maps EACH OrchestratorInvokeError.kind to a DISTINGUISHABLE reason (no auth/timeout/spawn collapse)', async () => {
+    const cases: Array<[InvokeFailureKind, VerdictLaneFailureReason]> = [
+      ['auth', 'invoke-auth'],
+      ['quota', 'quota-exhausted'],
+      ['model', 'invoke-model'],
+      ['process-spawn', 'invoke-process-spawn'],
+      ['process-exit', 'invoke-process-exit'],
+      ['timeout', 'invoke-timeout'],
+      ['unknown', 'invoke-error'],
+    ];
+    for (const [kind, expected] of cases) {
+      // The structured kind is consumed directly — NOT inferred from the message prose
+      // (the message here is deliberately unrelated to the kind).
+      const err = new OrchestratorInvokeError(`lane rejected on ${kind}`, kind, []);
+      const classified = await classifyRejectedLane(0, 'anthropic:claude-x', err);
+      expect(classified.lane.status).toBe('failed');
+      if (classified.lane.status === 'failed') expect(classified.lane.typedReason).toBe(expected);
+    }
+    // The mapping is fully INJECTIVE: all seven kinds land on seven distinct reasons
+    // (quota/unknown reuse the legacy `quota-exhausted`/`invoke-error`, which are still
+    // distinct from each other and from the five `invoke-*` values) — nothing collapses.
+    expect(new Set(cases.map(([, r]) => r)).size).toBe(7);
+  });
+
+  it('threads the failureArtifactHash from the structured error onto the failed lane', async () => {
+    const hash = 'b'.repeat(64);
+    const err = new OrchestratorInvokeError('timed out', 'timeout', [], {
+      failureArtifactHash: hash,
+    });
+    const classified = await classifyRejectedLane(1, 'anthropic:claude-x', err);
+    expect(classified.lane.status).toBe('failed');
+    if (classified.lane.status === 'failed') {
+      expect(classified.lane.typedReason).toBe('invoke-timeout');
+      expect(classified.lane.failureArtifactHash).toBe(hash);
+    }
+  });
+
+  it('omits failureArtifactHash when the error carries none (never a dangling reference)', async () => {
+    const err = new OrchestratorInvokeError('auth failed', 'auth', []);
+    const classified = await classifyRejectedLane(0, 'anthropic:claude-x', err);
+    expect(classified.lane.status).toBe('failed');
+    if (classified.lane.status === 'failed')
+      expect('failureArtifactHash' in classified.lane).toBe(false);
+  });
+
+  it('an ADMISSION-phase TotemConfigError maps to config-error, NOT a widened invoke kind (#2471 boundary)', async () => {
+    // A pre-invoke admission denial never reached execution, so it is not a lane
+    // invoke-failure: it maps to config-error and carries no invoke-evidence hash.
+    const admissionErr = new TotemConfigError(
+      "Admission denied: requested backend admission class 'self_grounding_agent' is not declared.",
+      'Declare the class in your orchestrator config, or drop the request.',
+      'CONFIG_INVALID',
+    );
+    const classified = await classifyRejectedLane(0, 'anthropic:claude-x', admissionErr);
+    expect(classified.lane.status).toBe('failed');
+    if (classified.lane.status === 'failed') {
+      expect(classified.lane.typedReason).toBe('config-error');
+      expect('failureArtifactHash' in classified.lane).toBe(false);
+    }
   });
 });
 
@@ -1055,6 +1123,41 @@ describe('runReviewFan', () => {
     expect(v.completedLaneCount).toBe(0);
     expect(v.lanes.map((l) => l.status).sort()).toEqual(['abstained', 'failed']);
     expect(v.settled).toBe(false);
+  });
+
+  it('the zero-completed hard-error NAMES the per-lane failure categories, not just counts (#2459 task 4)', async () => {
+    // Two lanes fail on DISTINCT structured kinds; the operator must see auth vs timeout
+    // (the diagnosis a provider-unsettled round needs), not an undifferentiated failed=2.
+    const invoker = mapInvoker({
+      'anthropic:claude-a': async () => {
+        throw new OrchestratorInvokeError('key rejected', 'auth', []);
+      },
+      'gemini:g': async () => {
+        throw new OrchestratorInvokeError('deadline exceeded', 'timeout', []);
+      },
+    });
+    const ctx = makeCtx(tmpDir, ['anthropic:claude-a', 'gemini:g'], invoker);
+    let err: unknown;
+    try {
+      await runReviewFan(ctx);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(Error);
+    const msg = (err as Error).message;
+    // The slice-A count contract is preserved VERBATIM (five-shape matrix unchanged)...
+    expect(msg).toMatch(/completed=0, abstained=0, failed=2/);
+    // ...and the categories are named (task 4).
+    expect(msg).toContain('failed by category:');
+    expect(msg).toContain('invoke-auth (1)');
+    expect(msg).toContain('invoke-timeout (1)');
+    // The honest verdict written first carries the DISTINGUISHED reasons (no collapse).
+    const v = listVerdictArtifacts(tmpDir, noWarn)[0]!.artifact;
+    const reasons = v.lanes
+      .map((l) => (l.status === 'failed' ? l.typedReason : ''))
+      .filter((r) => r !== '')
+      .sort();
+    expect(reasons).toEqual(['invoke-auth', 'invoke-timeout']);
   });
 
   it('completed + abstained mix (≥1 completed) still DEFAULT sensor exit 0 — the gate keys on completed lanes, not "any output" (#2452 inv 8b)', async () => {

--- a/packages/cli/src/commands/review-fan.ts
+++ b/packages/cli/src/commands/review-fan.ts
@@ -1401,7 +1401,7 @@ export async function runReviewFan(ctx: ReviewFanContext): Promise<void> {
     throw new TotemError(
       'SHIELD_FAILED',
       `Review produced no completed verdict lane (completed=0, abstained=${abstained}, failed=${failed} of ${verdict.lanes.length}) — ${describeFanFailureCategories(verdict.lanes)} — this is a non-pass, NOT a crash: an honest verdict was written (settled=false), then the run hard-errors. A provider-unsettled round never counts as a review pass and never authorizes a push (Tenets 12/13).`,
-      'Abstained lanes invoked but their output was not extractable; failed lanes did not invoke — the categories above distinguish auth / quota / model / spawn / exit / timeout, and each failed lane carries a failureArtifactHash to B’s bounded evidence when one was persisted. Check backend API keys / quota and lane output, then re-run `totem review`.',
+      'Abstained lanes invoked but their output was not extractable; failed lanes did not produce a usable verdict — the categories above distinguish admission config-error from auth / quota / model / spawn / exit / timeout execution failures, and each failed lane carries a failureArtifactHash to B’s bounded evidence when one was persisted. Check the reported category and failure artifact, then re-run `totem review`.',
     );
   }
 

--- a/packages/cli/src/commands/review-fan.ts
+++ b/packages/cli/src/commands/review-fan.ts
@@ -34,6 +34,7 @@
 // inside an async entry point and threaded down to the sync helpers.
 import type {
   GroundingBundle,
+  InvokeFailureKind,
   LessonsConsulted,
   LineageKeyInput,
   PersistedPostCheckFinding,
@@ -45,6 +46,7 @@ import type {
   VerdictArtifact,
   VerdictDiffScope,
   VerdictLane,
+  VerdictLaneFailureReason,
   VerdictPredicateInput,
   VerdictRound,
 } from '@mmnto/totem';
@@ -436,24 +438,36 @@ export async function runLane(
 
 /**
  * Map a REJECTED lane promise to a `failed` lane record (finding 13): an invoker throw
- * is classified (quota vs generic invoke error) and lands in the verdict as a terminal
- * `failed` lane — a lane is never lost to a rejection. The laneId uses the CONFIGURED
- * lane (a rejection means no backend resolved).
+ * is classified and lands in the verdict as a terminal `failed` lane — a lane is never
+ * lost to a rejection. The laneId uses the CONFIGURED lane (a rejection means no backend
+ * resolved).
+ *
+ * The classification consumes slice-B's STRUCTURED `OrchestratorInvokeError` (its
+ * `kind` and `failureArtifactHash`) rather than inferring the category from error prose
+ * (mmnto-ai/totem#2459). When the error carries a persisted failure-evidence hash, it is
+ * recorded on the lane so the verdict reaches B's bounded evidence ONE HOP away —
+ * mirroring how a completed lane carries `runArtifactHash`.
  */
 export async function classifyRejectedLane(
   index: number,
   laneModel: string,
   reason: unknown,
 ): Promise<LaneRunResult> {
-  const typedReason = await classifyInvokeFailure(reason);
+  const classified = await classifyInvokeFailure(reason);
   return {
     // rev-6 item 3: a rejected lane resolved no backend — the laneId suffix binds to the
     // configured lane, persisted here so the schema can validate that binding.
     lane: {
       status: 'failed',
       laneId: laneId(index, laneModel),
-      typedReason,
+      typedReason: classified.typedReason,
       configuredLane: laneModel,
+      // #2459: only present when slice-B persisted the terminal failure evidence — the
+      // reference resolves via `loadInvocationFailureArtifact`. Omitted (never a dangling
+      // hash) for admission-phase / pre-invoke rejections that emit no artifact.
+      ...(classified.failureArtifactHash !== undefined
+        ? { failureArtifactHash: classified.failureArtifactHash }
+        : {}),
     },
     filteredFindings: [],
   };
@@ -476,10 +490,73 @@ function tallyFindings(findings: readonly ShieldFinding[]): {
   return { critical, warn, info };
 }
 
-/** Classify an invoke throw as a typed `failed` reason (quota vs generic invoke error). */
-async function classifyInvokeFailure(err: unknown): Promise<'quota-exhausted' | 'invoke-error'> {
-  const { isQuotaError } = await import('../orchestrators/orchestrator.js');
-  return isQuotaError(err) ? 'quota-exhausted' : 'invoke-error';
+/** A classified lane rejection: the typed reason plus B's evidence hash when one exists. */
+interface ClassifiedInvokeFailure {
+  typedReason: VerdictLaneFailureReason;
+  /** Present only for an execution-phase failure whose evidence B persisted (#2459). */
+  failureArtifactHash?: string;
+}
+
+/**
+ * Map slice-B's `InvokeFailureKind` to a distinguishable verdict-lane failure reason
+ * (mmnto-ai/totem#2459). The mapping is 1:1 and total — no two distinct kinds collapse
+ * to one reason (auth / model / spawn / exit / timeout each land on their own value).
+ * `quota` and `unknown` route to the pre-existing `quota-exhausted` / `invoke-error`
+ * (reused, not renamed), so the widening stays additive. The exhaustive `switch` makes
+ * a future `InvokeFailureKind` member a compile error here, not a silent collapse.
+ */
+function invokeFailureKindToReason(kind: InvokeFailureKind): VerdictLaneFailureReason {
+  switch (kind) {
+    case 'auth':
+      return 'invoke-auth';
+    case 'quota':
+      return 'quota-exhausted';
+    case 'model':
+      return 'invoke-model';
+    case 'process-spawn':
+      return 'invoke-process-spawn';
+    case 'process-exit':
+      return 'invoke-process-exit';
+    case 'timeout':
+      return 'invoke-timeout';
+    case 'unknown':
+      return 'invoke-error';
+  }
+}
+
+/**
+ * Classify a lane rejection into a typed `failed` reason (mmnto-ai/totem#2459).
+ *
+ * Precedence, EXECUTION-phase first:
+ *   1. `OrchestratorInvokeError` — a lane that reached invoke and terminally failed.
+ *      Its STRUCTURED `kind` maps to a distinguishable reason (no prose inference), and
+ *      its `failureArtifactHash` (present iff B persisted the bounded evidence) is
+ *      threaded onto the lane so the verdict reaches that evidence one hop away.
+ *   2. `TotemConfigError` — an ADMISSION-phase / pre-invoke denial (the #2471
+ *      gate-semantics boundary). This never reached execution, so it is NOT a lane
+ *      invoke-failure and maps to `config-error`, never a widened `invoke-*` kind.
+ *   3. Any other (unstructured) throw — the legacy prose probe stays as a defensive
+ *      fallback (production invoke failures are structured `OrchestratorInvokeError`s;
+ *      this only catches an unexpected raw throw).
+ */
+async function classifyInvokeFailure(err: unknown): Promise<ClassifiedInvokeFailure> {
+  const { OrchestratorInvokeError, isQuotaError } =
+    await import('../orchestrators/orchestrator.js');
+  if (err instanceof OrchestratorInvokeError) {
+    return {
+      typedReason: invokeFailureKindToReason(err.kind),
+      ...(err.failureArtifactHash !== undefined
+        ? { failureArtifactHash: err.failureArtifactHash }
+        : {}),
+    };
+  }
+  // Admission-phase / pre-invoke config denial (#2471): not an execution failure.
+  const { TotemConfigError } = await import('@mmnto/totem');
+  if (err instanceof TotemConfigError) {
+    return { typedReason: 'config-error' };
+  }
+  // Defensive prose fallback for an unstructured throw (never the production path).
+  return { typedReason: isQuotaError(err) ? 'quota-exhausted' : 'invoke-error' };
 }
 
 // ─── Diff scope + lineage (item 5, item 7 diffHash) ──────────────────────────
@@ -1323,8 +1400,8 @@ export async function runReviewFan(ctx: ReviewFanContext): Promise<void> {
     const failed = verdict.lanes.filter((l) => l.status === 'failed').length;
     throw new TotemError(
       'SHIELD_FAILED',
-      `Review produced no completed verdict lane (completed=0, abstained=${abstained}, failed=${failed} of ${verdict.lanes.length}) — this is a non-pass, NOT a crash: an honest verdict was written (settled=false), then the run hard-errors. A provider-unsettled round never counts as a review pass and never authorizes a push (Tenets 12/13).`,
-      'Abstained lanes invoked but their output was not extractable; failed lanes did not invoke. Check backend API keys / quota and lane output, then re-run `totem review`.',
+      `Review produced no completed verdict lane (completed=0, abstained=${abstained}, failed=${failed} of ${verdict.lanes.length}) — ${describeFanFailureCategories(verdict.lanes)} — this is a non-pass, NOT a crash: an honest verdict was written (settled=false), then the run hard-errors. A provider-unsettled round never counts as a review pass and never authorizes a push (Tenets 12/13).`,
+      'Abstained lanes invoked but their output was not extractable; failed lanes did not invoke — the categories above distinguish auth / quota / model / spawn / exit / timeout, and each failed lane carries a failureArtifactHash to B’s bounded evidence when one was persisted. Check backend API keys / quota and lane output, then re-run `totem review`.',
     );
   }
 
@@ -1547,6 +1624,33 @@ function describeFailOnFailure(
   }
   if (!cacheEligible) parts.push(describeIneligibility(verdict));
   return parts.length > 0 ? parts.join('; ') : `findings at or above ${failOn}`;
+}
+
+/**
+ * Enumerate WHY a zero-completed fan produced no verdict lane, PER CATEGORY
+ * (mmnto-ai/totem#2459) — so the operator sees `invoke-auth` vs `quota-exhausted` vs
+ * `invoke-timeout`, not just an undifferentiated `failed=M`. Failed lanes are grouped by
+ * their typed invoke-failure reason (counted); abstained lanes surface as a single
+ * extraction-failure bucket (they invoked but their output was unextractable). Reads
+ * `verdict.lanes` — the SAME validated collection the zero-completed gate keys on — so
+ * the enumerated categories can never drift from the gate predicate.
+ */
+function describeFanFailureCategories(lanes: readonly VerdictLane[]): string {
+  const parts: string[] = [];
+  const failed = lanes.filter(
+    (l): l is Extract<VerdictLane, { status: 'failed' }> => l.status === 'failed',
+  );
+  if (failed.length > 0) {
+    const counts = new Map<VerdictLaneFailureReason, number>();
+    for (const l of failed) counts.set(l.typedReason, (counts.get(l.typedReason) ?? 0) + 1);
+    const rendered = [...counts.entries()].map(([reason, n]) => `${reason} (${n})`).join(', ');
+    parts.push(`failed by category: ${rendered}`);
+  }
+  const abstained = lanes.filter((l) => l.status === 'abstained').length;
+  if (abstained > 0) {
+    parts.push(`abstained — invoked but output not extractable (${abstained})`);
+  }
+  return parts.length > 0 ? parts.join('; ') : 'no lane categories recorded';
 }
 
 /** sha256 hex of a UTF-8 string (the masked-diff payload identity). */

--- a/packages/core/src/artifacts/verdict.test.ts
+++ b/packages/core/src/artifacts/verdict.test.ts
@@ -32,6 +32,12 @@ import { TotemError, TotemParseError } from '../errors.js';
 import { cleanTmpDir } from '../test-utils.js';
 import { calculateDeterministicHash } from './hash.js';
 import { classifyDiversity } from './panel.js';
+import type { BoundedTextEvidence, InvocationFailureArtifact } from './schema.js';
+import {
+  INVOCATION_FAILURE_ARTIFACT_SCHEMA_VERSION,
+  INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES,
+} from './schema.js';
+import { loadInvocationFailureArtifact, saveInvocationFailureArtifact } from './storage.js';
 import {
   computeLineageKey,
   computeVerdictArtifactContentHash,
@@ -45,12 +51,66 @@ import {
   renderCovariateLine,
   saveVerdictArtifact,
   VERDICT_ARTIFACT_SCHEMA_VERSION,
+  VERDICT_LANE_FAILURE_REASONS,
   type VerdictArtifact,
   VerdictArtifactSchema,
   type VerdictLane,
+  type VerdictLaneFailureReason,
   type VerdictPredicateInput,
   verdictsDir,
 } from './verdict.js';
+
+/** Minimal valid BoundedTextEvidence for a failure-artifact fixture (mirrors storage.test). */
+function boundedTextEvidence(text: string, limitBytes = 64 * 1024): BoundedTextEvidence {
+  const bytes = Buffer.byteLength(text, 'utf-8');
+  return {
+    encoding: 'utf-8',
+    head: text,
+    observedBytes: bytes,
+    retainedBytes: bytes,
+    limitBytes,
+    truncated: false,
+    dlp: 'masked',
+  };
+}
+
+/** A valid terminal `InvocationFailureArtifact` (slice B) for the lane→artifact resolve test. */
+function invocationFailureArtifact(
+  overrides: Partial<InvocationFailureArtifact> = {},
+): InvocationFailureArtifact {
+  return {
+    schemaVersion: INVOCATION_FAILURE_ARTIFACT_SCHEMA_VERSION,
+    inputBundle: { maskedPrompt: 'prompt after DLP' },
+    inputHash: 'c'.repeat(64),
+    grounding: { hash: 'd'.repeat(64), provenanceSummary: 'similarity-only' },
+    requestedBackend: {
+      provider: 'anthropic',
+      model: 'claude-sonnet-5',
+      qualifiedModel: 'anthropic:claude-sonnet-5',
+      admissionClass: 'completion_only',
+      taskProfile: 'Review',
+    },
+    attempts: [
+      {
+        sequence: 1,
+        route: 'cli-fallback',
+        provider: 'anthropic',
+        model: 'claude-sonnet-5',
+        status: 'failed',
+        durationMs: 900,
+        failureKind: 'timeout',
+        process: { exitCode: null, signal: 'SIGTERM', timedOut: true, timeoutMs: 60_000 },
+      },
+    ],
+    terminal: {
+      kind: 'timeout',
+      attempt: 1,
+      message: boundedTextEvidence('Claude CLI timed out', INVOKE_MESSAGE_EVIDENCE_LIMIT_BYTES),
+    },
+    createdAt: '2026-07-19T12:00:00.000Z',
+    ...overrides,
+  };
+}
 
 // ─── Fixtures ──────────────────────────────────────────────────────────────
 //
@@ -89,6 +149,25 @@ function failedLane(index: number, configured = 'openai:gpt-model'): VerdictLane
     typedReason: 'quota-exhausted',
     // rev-6 item 3: the configured lane the id suffix binds to (present even pre-resolution).
     configuredLane: configured,
+  };
+}
+
+/**
+ * A concrete `failed`-lane record (NOT the union) so tests can add `typedReason` /
+ * `failureArtifactHash` without tripping excess-property checks on a spread of the
+ * status-discriminated union (mmnto-ai/totem#2459). `laneId` binds to `configuredLane`.
+ */
+function failedLaneRecord(
+  index: number,
+  overrides: Partial<Extract<VerdictLane, { status: 'failed' }>> = {},
+): Extract<VerdictLane, { status: 'failed' }> {
+  const configured = overrides.configuredLane ?? 'openai:gpt-model';
+  return {
+    status: 'failed',
+    laneId: `lane-${index}:${configured}`,
+    typedReason: 'quota-exhausted',
+    configuredLane: configured,
+    ...overrides,
   };
 }
 
@@ -854,6 +933,89 @@ describe('schema-version tolerance (F1)', () => {
   });
 });
 
+// ─── #2459: slice-B invoke-failure kinds + failed-lane evidence hash ─────────
+
+describe('failed-lane invoke-failure kinds + evidence (mmnto-ai/totem#2459)', () => {
+  it('the writer stamps the 1.2.0 widening marker', () => {
+    expect(VERDICT_ARTIFACT_SCHEMA_VERSION).toBe('1.2.0');
+  });
+
+  it('accepts EACH widened failure reason on a failed lane — no auth/timeout/spawn collapse', () => {
+    // Every InvokeFailureKind must have a DISTINGUISHABLE reason: the exported set is the
+    // 4 legacy values PLUS the 5 execution-phase invoke kinds (quota/unknown reuse the
+    // legacy `quota-exhausted`/`invoke-error`), and each is a legal `typedReason`.
+    expect([...VERDICT_LANE_FAILURE_REASONS]).toEqual([
+      'invoke-error',
+      'quota-exhausted',
+      'missing-artifact-emission',
+      'config-error',
+      'invoke-auth',
+      'invoke-model',
+      'invoke-process-spawn',
+      'invoke-process-exit',
+      'invoke-timeout',
+    ]);
+    for (const typedReason of VERDICT_LANE_FAILURE_REASONS) {
+      const v = verdict({ lanes: [failedLaneRecord(0, { typedReason })] });
+      expect(VerdictArtifactSchema.safeParse(v).success).toBe(true);
+    }
+    // The five auth/model/spawn/exit/timeout reasons are pairwise distinct (no collapse).
+    const invokeKinds: VerdictLaneFailureReason[] = [
+      'invoke-auth',
+      'invoke-model',
+      'invoke-process-spawn',
+      'invoke-process-exit',
+      'invoke-timeout',
+    ];
+    expect(new Set(invokeKinds).size).toBe(invokeKinds.length);
+  });
+
+  it('records an OPTIONAL failureArtifactHash on a failed lane; absent is the honest default', () => {
+    const hash = 'e'.repeat(64);
+    const withHash = verdict({
+      lanes: [failedLaneRecord(0, { typedReason: 'invoke-timeout', failureArtifactHash: hash })],
+    });
+    const parsed = VerdictArtifactSchema.safeParse(withHash);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      const lane = parsed.data.lanes[0]!;
+      expect(lane.status === 'failed' && lane.failureArtifactHash).toBe(hash);
+    }
+    // Absent by default — pre-1.2 artifacts and admission-phase failures never carry one.
+    const parsedDefault = VerdictArtifactSchema.parse(verdict({ lanes: [failedLane(0)] }));
+    expect('failureArtifactHash' in parsedDefault.lanes[0]!).toBe(false);
+  });
+
+  it('rejects a non-sha256 failureArtifactHash (a recorded reference is a real address)', () => {
+    const bad = verdict({ lanes: [failedLaneRecord(0, { failureArtifactHash: 'not-a-hash' })] });
+    expect(VerdictArtifactSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it('a pre-widening 1.1.0 verdict (legacy typedReason, no failureArtifactHash) STILL parses', () => {
+    // Structural version-tolerance (acceptance criterion): an artifact written before the
+    // widening — a legacy `typedReason`, no `failureArtifactHash` — parses unchanged under
+    // the 1.2.0 reader. The widening is additive; nothing existing is invalidated.
+    const legacy = verdict({
+      schemaVersion: '1.1.0',
+      lanes: [
+        {
+          status: 'failed',
+          laneId: 'lane-0:openai:gpt-model',
+          typedReason: 'invoke-error',
+          configuredLane: 'openai:gpt-model',
+        },
+      ],
+    });
+    const parsed = VerdictArtifactSchema.safeParse(legacy);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) {
+      const lane = parsed.data.lanes[0]!;
+      expect(lane.status).toBe('failed');
+      expect('failureArtifactHash' in lane).toBe(false);
+    }
+  });
+});
+
 // ─── computeLineageKey ──────────────────────────────────────────────────────
 
 describe('computeLineageKey — source-discriminated selector, injection-proof', () => {
@@ -978,6 +1140,35 @@ describe('verdict storage (mirrors run/panel storage)', () => {
     expect(loaded.artifact).toEqual(v);
     // rev-6 item 1: the load carries the verified stored address (= the filename stem).
     expect(loaded.contentHash).toBe(saved.hash);
+  });
+
+  it("a failed lane's failureArtifactHash RESOLVES to its InvocationFailureArtifact (mmnto-ai/totem#2459)", () => {
+    // Acceptance criterion: if `failureArtifactHash` is recorded, the lane→artifact
+    // reference must resolve. Persist B's terminal failure evidence, record its hash on
+    // the failed lane, round-trip the verdict, then dereference the hash one hop away.
+    const failure = invocationFailureArtifact();
+    const savedFailure = saveInvocationFailureArtifact(totemDir, failure);
+
+    const v = verdict({
+      lanes: [
+        failedLaneRecord(0, {
+          typedReason: 'invoke-timeout',
+          failureArtifactHash: savedFailure.hash,
+        }),
+      ],
+    });
+    const savedVerdict = saveVerdictArtifact(totemDir, v);
+    const reloaded = loadVerdictArtifact(totemDir, savedVerdict.hash).artifact;
+
+    const lane = reloaded.lanes[0]!;
+    expect(lane.status).toBe('failed');
+    if (lane.status === 'failed') {
+      expect(lane.failureArtifactHash).toBe(savedFailure.hash);
+      // The reference resolves — no dangling hash.
+      const resolved = loadInvocationFailureArtifact(totemDir, lane.failureArtifactHash!);
+      expect(resolved.terminal.kind).toBe('timeout');
+      expect(resolved).toEqual(failure);
+    }
   });
 
   it('content address excludes createdAt — identical rounds dedup across time', () => {

--- a/packages/core/src/artifacts/verdict.ts
+++ b/packages/core/src/artifacts/verdict.ts
@@ -59,10 +59,16 @@ import type { GroundingBundle } from './schema.js';
 /**
  * The verdict schemaVersion WRITTEN by this code. Readers accept any 1.x (F1).
  * 1.1.0 (mmnto-ai/totem#2363): additive-optional `lessonsConsulted` — the
- * round's lesson-recall record. The minor is the observable marker; the
- * registry stays empty because the tolerant reader parses both.
+ * round's lesson-recall record.
+ * 1.2.0 (mmnto-ai/totem#2459): additive widening of {@link VERDICT_LANE_FAILURE_REASONS}
+ * with slice-B invoke-failure kinds (auth/model/spawn/exit/timeout) + the
+ * additive-optional failed-lane `failureArtifactHash`. Purely additive within the
+ * major (new enum members + an optional field), so the minor is the observable
+ * marker and the migration registry stays empty — the tolerant reader parses every
+ * prior 1.x artifact unchanged (existing `typedReason` values and absent
+ * `failureArtifactHash` remain valid).
  */
-export const VERDICT_ARTIFACT_SCHEMA_VERSION = '1.1.0';
+export const VERDICT_ARTIFACT_SCHEMA_VERSION = '1.2.0';
 
 /** The major this reader understands; other majors need a migration entry. */
 export const VERDICT_ARTIFACT_KNOWN_MAJOR = 1;
@@ -138,12 +144,33 @@ export type VerdictDiffScope = z.infer<typeof VerdictDiffScopeSchema>;
  * handed to `assemblePanelArtifact` and never stamps the cache. NOTE (Prop 302
  * lane-blindness): these classify the FAILURE, never the runner lane — none of
  * them names warm/cold.
+ *
+ * ── EXECUTION-PHASE INVOKE KINDS (mmnto-ai/totem#2459, slice-B A-side follow-up) ──
+ * The first block is the original coarse set. The `invoke-*` block widens it so an
+ * EXECUTION-phase lane failure records the exact slice-B category (from
+ * `OrchestratorInvokeError.kind`) instead of collapsing auth / model / spawn / exit /
+ * timeout into the single `invoke-error`. The mapping is 1:1 with `InvokeFailureKind`:
+ * `auth→invoke-auth`, `quota→quota-exhausted`, `model→invoke-model`,
+ * `process-spawn→invoke-process-spawn`, `process-exit→invoke-process-exit`,
+ * `timeout→invoke-timeout`, `unknown→invoke-error`. `quota-exhausted` and
+ * `invoke-error` predate this widening and are reused, so the change is purely
+ * additive (F1): every prior 1.x artifact's `typedReason` still validates.
+ *
+ * ADMISSION vs EXECUTION (the #2471 gate-semantics boundary): a pre-invoke ADMISSION
+ * denial is NOT a lane invoke-failure — it never reached execution, so it maps to
+ * `config-error`, never to one of these `invoke-*` kinds. Only execution-phase
+ * failures (a thrown `OrchestratorInvokeError`) reach the widened kinds.
  */
 export const VERDICT_LANE_FAILURE_REASONS = [
   'invoke-error',
   'quota-exhausted',
   'missing-artifact-emission',
   'config-error',
+  'invoke-auth',
+  'invoke-model',
+  'invoke-process-spawn',
+  'invoke-process-exit',
+  'invoke-timeout',
 ] as const;
 export type VerdictLaneFailureReason = (typeof VERDICT_LANE_FAILURE_REASONS)[number];
 
@@ -236,6 +263,19 @@ export const VerdictLaneSchema = z.discriminatedUnion('status', [
      * (stable at lane creation), never to this field.
      */
     resolvedBackend: z.string().min(1).optional(),
+    /**
+     * OPTIONAL (mmnto-ai/totem#2459, additive 1.2.0): the content address of slice-B's
+     * `InvocationFailureArtifact` for this lane's terminal EXECUTION-phase invoke
+     * failure. It reaches B's bounded evidence — classified `kind`, bounded
+     * stdout/stderr, exit code / signal, timeout state — ONE HOP away, mirroring how a
+     * `completed` lane reaches its run artifact via `runArtifactHash`. Present only
+     * when the orchestrator persisted the failure evidence (an `OrchestratorInvokeError`
+     * carrying a `failureArtifactHash`); ABSENT for admission-phase / pre-invoke
+     * failures that never produced one, and honest-absent on pre-1.2 artifacts. When
+     * present it MUST resolve via `loadInvocationFailureArtifact` (the reference is a
+     * real, loadable content address — never a dangling hash).
+     */
+    failureArtifactHash: Sha256HexSchema.optional(),
   }),
 ]);
 export type VerdictLane = z.infer<typeof VerdictLaneSchema>;


### PR DESCRIPTION
## Summary

Threads slice-B's structured invoke-failure evidence (#2457 family) into the verdict-lane surface that slice A (#2454) left coarse: a lane that failed on auth, a spawn error, or a timeout no longer collapses into the single `invoke-error`.

- **Core** (`@mmnto/totem`, verdict artifact 1.1.0 → 1.2.0, purely additive): `VerdictLaneFailureReason` widened with `invoke-auth` / `invoke-model` / `invoke-process-spawn` / `invoke-process-exit` / `invoke-timeout` (the `InvokeFailureKind` → reason mapping is a total 7-way bijection — nothing collapses; `quota`/`unknown` reuse the pre-existing values). A `failed` lane optionally carries `failureArtifactHash`, reaching slice-B's bounded evidence one hop away, mirroring a completed lane's `runArtifactHash`.
- **CLI** (`@mmnto/cli`): `classifyRejectedLane` consumes the structured `OrchestratorInvokeError` (`kind` + `failureArtifactHash`) instead of inferring from error prose. An admission-phase `TotemConfigError` maps to `config-error`, never a widened invoke kind (the #2471 admission-vs-execution boundary). The zero-completed hard error now names per-lane categories (`failed by category: invoke-auth (1), invoke-timeout (1)`) while preserving the slice-A `completed=0, abstained=N, failed=M` line verbatim.

## Notes

- The issue body places `OrchestratorInvokeError` in core; it actually lives in the CLI (`packages/cli/src/orchestrators/orchestrator.ts`) — core exports the types it carries (`InvokeFailureKind`, `InvokeAttemptEvidence`). No contract change needed.
- Issue tasks 2/3, both options resolved: widening chosen over a lossy mapping (the acceptance criteria require distinguishable reasons), and `failureArtifactHash` implemented as required-to-resolve-when-present, with the resolution test.

## Verification

- Full workspace build; core 3298 / cli 3462 tests green; repo-wide `format:check` clean; ESLint 0 errors; `totem lint --base origin/main` PASS.
- The merged slice-A five-shape exit matrix is untouched — the test diff is purely additive.
- Structural version-tolerance test: a 1.1.0 verdict artifact still parses unchanged.
- Changeset: `@mmnto/totem` minor + `@mmnto/cli` minor.

Refs #2459 · Family: #2452 (A: #2454 · B: #2457)

<!-- totem-close: #2459 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
