### PR TITLE
chore(changeset): reword autoclose examples to non-firing shapes

### DIFF
--- a/.changeset/autoclose-seam-guard.md
+++ b/.changeset/autoclose-seam-guard.md
@@ -6,8 +6,8 @@
 feat(autoclose): GitHub auto-close enforcement-seam guard — D1 + D2-observe + C (#1762)
 
 Adds the ruled Layer-1 slice of the GitHub auto-close guard: a defense against a
-close-keyword adjacent to an issue reference (`Closes #131`, and — the confirmed
-#2471→#2466 incident — even a negated `Does not close #2466`) reaching a PR body
+close-keyword adjacent to an issue reference (`Closes #NNN` — and, per the confirmed
+#2471→#2466 incident, even a negated variant of that phrase) reaching a PR body
 or squash merge-commit body and auto-closing a linked issue.
 
 - **Core** ships `@mmnto/totem` `autoclose` — the ONE shared evaluator


### PR DESCRIPTION
## Summary

First catch of the newly-required D1 check: the Version Packages PR (#2474) went BLOCKED because the autoclose changeset's own illustrative examples used real ref shapes, which flow into the VP PR description via the changelog. This is the docs-quote friction class the falsifier review pinned as DELIBERATE over-fire — and the designed remedy is rewording the source.

Two-line reword of `.changeset/autoclose-seam-guard.md`: the example becomes digitless (`Closes #NNN`) and the negated literal becomes prose anchored by the `#2471→#2466` incident arrow. Meaning unchanged; neither the matcher nor GitHub's parser fires on the new shapes.

Note: no live closure risk existed — both examples were backtick-wrapped, which GitHub's parser ignores (the VP PR's `closingIssuesReferences` was empty throughout). D1 flags them anyway by presence-invariant design.

Refs #1762 · Unblocks #2474

🤖 Generated with [Claude Code](https://claude.com/claude-code)
