### PR TITLE
chore: totem postmerge lessons for #2475 #2476 #2477

### DIFF
--- a/.totem/lessons/lesson-15f12d31.md
+++ b/.totem/lessons/lesson-15f12d31.md
@@ -1,0 +1,6 @@
+## Lesson — Treat all close-keyword references as active
+
+**Tags:** github, git, regex
+**Scope:** packages/core/src/autoclose/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+GitHub's auto-close parser matches issue references adjacent to close keywords regardless of negation, quotes, or emphasis. Matchers must treat all such occurrences as active anomalies rather than attempting to parse negation.

--- a/.totem/lessons/lesson-16fe1f80.md
+++ b/.totem/lessons/lesson-16fe1f80.md
@@ -1,0 +1,6 @@
+## Lesson — Distinguish admission from execution failures
+
+**Tags:** cli, diagnostics, ux
+**Scope:** packages/cli/**/*.ts, !**/*.test.*
+
+Conflating admission-phase configuration errors with execution-phase failures in user diagnostics misleads operators. Ensure error messages clearly distinguish between lanes that failed to invoke and those that failed during execution.

--- a/.totem/lessons/lesson-2f1fbaae.md
+++ b/.totem/lessons/lesson-2f1fbaae.md
@@ -1,0 +1,6 @@
+## Lesson — Design additive schema updates for reader tolerance
+
+**Tags:** schema, compatibility, serialization
+**Scope:** packages/core/**/*.ts, !**/*.test.*
+
+When widening enums or adding metadata to serialized artifacts, make changes purely additive and optional to ensure older readers can parse new formats without breaking.

--- a/.totem/lessons/lesson-46535f6f.md
+++ b/.totem/lessons/lesson-46535f6f.md
@@ -1,0 +1,6 @@
+## Lesson — Use digitless placeholders for issue examples
+
+**Tags:** changesets, github-actions, automation
+**Scope:** .changeset/*.md
+
+Even when wrapped in backticks, real issue reference shapes in changesets can propagate to release PR descriptions and trigger automated closure checks. Use digitless placeholders like `Closes #NNN` to prevent false-positive blocks without altering the illustrative meaning.

--- a/.totem/lessons/lesson-474c02db.md
+++ b/.totem/lessons/lesson-474c02db.md
@@ -1,0 +1,6 @@
+## Lesson — Guard LLM-specific replace tools
+
+**Tags:** llm, security, git-hooks
+**Scope:** packages/cli/src/commands/init-templates.ts
+
+LLM write-time guards must intercept specific tool operations, such as Gemini's `replace` tool, rather than just raw file writes to prevent agents from bypassing bare-reference checks during automated edits.

--- a/.totem/lessons/lesson-828a001c.md
+++ b/.totem/lessons/lesson-828a001c.md
@@ -1,0 +1,6 @@
+## Lesson — Use GraphQL for repository merge settings
+
+**Tags:** github-api, graphql, workflows
+**Scope:** tools/**/*.mjs
+
+The GitHub REST API omits merge-policy fields for non-admin callers (such as standard GitHub Actions tokens), whereas the GraphQL API allows reading these settings with a plain read-only token.

--- a/.totem/lessons/lesson-9a435589.md
+++ b/.totem/lessons/lesson-9a435589.md
@@ -1,0 +1,6 @@
+## Lesson — Avoid circular authorization via closingIssuesReferences
+
+**Tags:** github-api, security, workflows
+**Scope:** packages/core/src/autoclose/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Do not use GitHub's `closingIssuesReferences` API field to authorize issue closures in PR checks, as GitHub derives this field from the same body keywords, creating a circular authorization vulnerability. Use explicit, out-of-band markers instead.


### PR DESCRIPTION
Post-merge lesson extraction over the enforcement-seam Layer-1 arc (PRs 2475 / 2476 / 2477 and the 1.103.0 release). Seven lessons: admission-vs-execution diagnostic separation, additive-only serialized-schema widening, the negation-blind auto-close parser, the `closingIssuesReferences` circularity, the REST-vs-GraphQL merge-policy token-class gap, LLM write-guard tool-name coverage (Gemini `replace`), and digitless placeholder shapes for changeset examples.

Extractions were diffed against the review round's dispositions: the two declined findings from that round (the `unexpected-body` exit-code preference and the changeset-path exemption) are not restated here.

Rule compilation intentionally skipped — the `rule-compilation` freeze (2026-05-17) is still standing, so this PR carries lessons only: no compiled-rules, manifest, or export deltas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
