### PR TITLE
chore: totem postmerge lessons for #2478

### DIFF
--- a/.totem/lessons/lesson-245c615e.md
+++ b/.totem/lessons/lesson-245c615e.md
@@ -1,0 +1,6 @@
+## Lesson — Avoid shell-parsing command interceptors
+
+**Tags:** security, cli, architecture
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Hand-rolled shell parsers designed to intercept and block CLI commands are highly prone to bypasses. Relying on server-side constraints, write-time guards, or repository configurations is a more robust approach to enforcing merge postures.

--- a/.totem/lessons/lesson-7bb27e1c.md
+++ b/.totem/lessons/lesson-7bb27e1c.md
@@ -1,0 +1,6 @@
+## Lesson — Use static argv arrays for CLI execution
+
+**Tags:** cli, security
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Hardcoding CLI execution arguments as static arrays structurally prevents users or downstream processes from overriding critical flags like commit bodies or subjects.

--- a/.totem/lessons/lesson-94e8ea29.md
+++ b/.totem/lessons/lesson-94e8ea29.md
@@ -1,0 +1,6 @@
+## Lesson — Pin merge commands to evaluated commits
+
+**Tags:** git, github-actions, security
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+When performing pre-merge validations, always pin the subsequent merge command to the evaluated snapshot using `--match-head-commit`. This prevents race conditions where the PR head changes between the evaluation and execution phases.


### PR DESCRIPTION
Postmerge lesson extraction for the #2478 arc (B-slice actuator + OPTION 1 strip). This PR does not close any issue.

## Lessons (3, extraction-only)

1. **Pin merge commands to evaluated commits** — pre-merge validation must bind the merge to the evaluated snapshot via `--match-head-commit` (from the fixed snapshot-drift findings).
2. **Use static argv arrays for CLI execution** — a hardcoded argv structurally prevents body/subject flags from entering the sanctioned merge path (B's asserted-by-test property).
3. **Avoid shell-parsing command interceptors** — the OPTION 1 conclusion: hand-rolled shell parsers intercepting CLI commands are bypass-prone; server-side config, write-time guards, and detection+undo sit at the right altitude.

## Checks

- **Laundering check:** diffed against the round's dispositions — none of the three restates a declined or mooted finding (TotemError conventions, backtick claim, matcher boundary-crossing, eslint-disable ticket ref); lesson 3 codifies the final ruling, not interim round framing.
- **Compile:** skipped — `rule-compilation` standing freeze (2026-05-17) remains active; lessons land as extraction-only (nursery), no compiled-rules/manifest deltas in this diff.
- Extraction stats: 3 novel lessons from 8 review threads after dedup against 10 existing context lessons; incremental index sync ran in the extraction step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
