### PR TITLE
feat(cli,core): seat status-claude in the roster + sender-side dispatch subject-quoting guard

### DIFF
--- a/.changeset/routed-asks-mail-hygiene.md
+++ b/.changeset/routed-asks-mail-hygiene.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/cli': minor
+'@mmnto/totem': minor
+---
+
+Seat `status-claude` in the cohort roster and stop the unquoted-subject dispatch class at the sender.
+
+- `COHORT_AGENT_MAP` gains `status-claude` for `totem-status` (cohort-roles §1.1 roster ruling, mmnto-ai/totem-strategy#958): dispatches addressed to the seat now resolve via CLI polls even on checkouts where the gitignored seat dir is absent. The distributed signoff skill's agent-id table follows.
+- PreWriteShield (Claude) and BeforeTool (Gemini) gain Rule 3, the ECL dispatch frontmatter-quoting guard (routed ask from mmnto-ai/totem-status#123): an unquoted `: ` or trailing `:` in a `subject:`/`expected-action:` value under `.totem/orchestration/*/outbox/` blocks at write time, so strict-YAML mail consumers never de-sync from the lenient TS delivery path.

--- a/.changeset/routed-asks-mail-hygiene.md
+++ b/.changeset/routed-asks-mail-hygiene.md
@@ -6,4 +6,4 @@
 Seat `status-claude` in the cohort roster and stop the unquoted-subject dispatch class at the sender.
 
 - `COHORT_AGENT_MAP` gains `status-claude` for `totem-status` (cohort-roles §1.1 roster ruling, mmnto-ai/totem-strategy#958): dispatches addressed to the seat now resolve via CLI polls even on checkouts where the gitignored seat dir is absent. The distributed signoff skill's agent-id table follows.
-- PreWriteShield (Claude) and BeforeTool (Gemini) gain Rule 3, the ECL dispatch frontmatter-quoting guard (routed ask from mmnto-ai/totem-status#123): an unquoted `: ` or trailing `:` in a `subject:`/`expected-action:` value under `.totem/orchestration/*/outbox/` blocks at write time, so strict-YAML mail consumers never de-sync from the lenient TS delivery path.
+- PreWriteShield (Claude) and BeforeTool (Gemini) gain Rule 3, the ECL dispatch frontmatter-quoting guard (routed ask from mmnto-ai/totem-status#123): an unquoted `: ` or trailing `:` in a `subject:`/`expected-action:` value under `.totem/orchestration/*/outbox/` blocks at write time, keeping strict-YAML mail consumers aligned with the lenient TS delivery path.

--- a/.claude/skills/signoff/SKILL.md
+++ b/.claude/skills/signoff/SKILL.md
@@ -21,7 +21,7 @@ End-of-session wrap-up. Post-Proposal-282 (ADR-106), journals + handoffs live in
    | `totem-strategy`                                | `strategy-claude`                   | `strategy-gemini` | _(not seated)_    |
    | `liquid-city`                                   | `lc-claude`                         | `lc-gemini`       | _(not seated)_    |
    | `arhgap11`                                      | `arhgap11-claude`                   | `arhgap11-gemini` | _(not seated)_    |
-   | `totem-status`                                  | _(no Claude variant)_               | `status-gemini`   | _(not seated)_    |
+   | `totem-status`                                  | `status-claude`                     | `status-gemini`   | _(not seated)_    |
    | `totem-playground`                              | _(orphan stream — no native agent)_ | _(orphan stream)_ | _(orphan stream)_ |
 
    Seat discovery is dir-derived (mmnto-ai/totem#2141): any `.totem/orchestration/<agent-id>/` directory registers that seat for this repo, UNIONED with the basename map above so roster siblings stay visible on fresh clones where the gitignored tree is partial (precedence: `TOTEM_SELF_AGENT` env > `config.json` `host_agents` > seat dirs ∪ basename map). Override hook: a `host_agents: string[]` field in `.totem/orchestration/config.json` still **replaces** the derived answer — but omitting a PRESENT seat dir attaches a loud warning naming the omitted seat (the dir is the registration; config-exclusion is not a decommission mechanism). The returned list of agent-ids is used by consumers (e.g., `totem mail`) to filter cross-repo handoffs — messages addressed to any agent-id in the list belong to this repo's session.

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -244,14 +244,22 @@ function checkOutboxSubjectQuoting(toolName, toolInput) {
   if (typeof content !== 'string') return;
 
   const lines = content.split(/\\r?\\n/);
+  // Mode is TOOL-determined (CR round 1 on the introducing PR): write_file is a
+  // full-file write — scan ONLY a leading frontmatter block, and a
+  // frontmatter-less full write has nothing in scope (schema completeness is
+  // the mail consumer's concern, not this guard's). replace/edit_file are
+  // fragments: scan all lines, honoring the totem-context escape.
+  const fragment = toolName !== 'write_file';
   let start = 0;
   let end = lines.length;
-  let fragment = true;
-  if (lines.length > 0 && lines[0].trim() === '---') {
-    fragment = false;
-    start = 1;
-    end = start;
-    while (end < lines.length && lines[end].trim() !== '---') end++;
+  if (!fragment) {
+    if (lines.length > 0 && lines[0].trim() === '---') {
+      start = 1;
+      end = start;
+      while (end < lines.length && lines[end].trim() !== '---') end++;
+    } else {
+      end = 0;
+    }
   }
   const offenders = [];
   for (let i = start; i < end; i++) {
@@ -265,10 +273,17 @@ function checkOutboxSubjectQuoting(toolName, toolInput) {
     const value = m[2].trim();
     if (value === '') continue;
     const first = value.charAt(0);
-    // Quoted scalars are strict-YAML-safe as authored. Block scalars are exempt
-    // ONLY as a bare header (>, >-, |2, ...): a header with trailing text
-    // (e.g. ">note: x") is itself invalid YAML and falls through to the scan.
-    if (first === '"' || first === "'") continue;
+    // A quoted scalar is exempt ONLY when well-terminated (optional trailing
+    // comment): an unterminated or junk-tailed quote is itself invalid YAML
+    // (greptile P1 on the introducing PR). Block scalars are exempt ONLY as a
+    // bare header (>, >-, |2, ...): a header with trailing text (">note: x")
+    // is invalid YAML and falls through to the scan.
+    if (first === '"' || first === "'") {
+      if (first === '"' && /^"(?:[^"\\\\]|\\\\.)*"(\\s+#.*)?$/.test(value)) continue;
+      if (first === "'" && /^'(?:[^']|'')*'(\\s+#.*)?$/.test(value)) continue;
+      offenders.push(m[1]);
+      continue;
+    }
     if ((first === '>' || first === '|') && /^[>|][+-]?[0-9]*$/.test(value)) continue;
     if (value.indexOf(': ') !== -1 || value.charAt(value.length - 1) === ':') offenders.push(m[1]);
   }
@@ -508,14 +523,22 @@ process.stdin.on('end', () => {
   // first: a malformed dispatch is unreadable regardless of what its body says.
   if (OUTBOX_PATH_RE.test(filePath)) {
     const dLines = content.split(/\\r?\\n/);
+    // Mode is TOOL-determined (CR round 1 on the introducing PR): Write is a
+    // full-file write — scan ONLY a leading frontmatter block, and a
+    // frontmatter-less full write has nothing in scope (schema completeness is
+    // the mail consumer's concern, not this guard's). Edit is a fragment:
+    // scan all lines, honoring the totem-context escape.
+    const dFragment = toolName === 'Edit';
     let dStart = 0;
     let dEnd = dLines.length;
-    let dFragment = true;
-    if (dLines.length > 0 && dLines[0].trim() === '---') {
-      dFragment = false;
-      dStart = 1;
-      dEnd = dStart;
-      while (dEnd < dLines.length && dLines[dEnd].trim() !== '---') dEnd++;
+    if (!dFragment) {
+      if (dLines.length > 0 && dLines[0].trim() === '---') {
+        dStart = 1;
+        dEnd = dStart;
+        while (dEnd < dLines.length && dLines[dEnd].trim() !== '---') dEnd++;
+      } else {
+        dEnd = 0;
+      }
     }
     const offenders = [];
     for (let i = dStart; i < dEnd; i++) {
@@ -529,10 +552,17 @@ process.stdin.on('end', () => {
       const value = m[2].trim();
       if (value === '') continue;
       const first = value.charAt(0);
-      // Quoted scalars are strict-YAML-safe as authored. Block scalars are exempt
-      // ONLY as a bare header (>, >-, |2, ...): a header with trailing text
-      // (e.g. ">note: x") is itself invalid YAML and falls through to the scan.
-      if (first === '"' || first === "'") continue;
+      // A quoted scalar is exempt ONLY when well-terminated (optional trailing
+      // comment): an unterminated or junk-tailed quote is itself invalid YAML
+      // (greptile P1 on the introducing PR). Block scalars are exempt ONLY as a
+      // bare header (>, >-, |2, ...): a header with trailing text (">note: x")
+      // is invalid YAML and falls through to the scan.
+      if (first === '"' || first === "'") {
+        if (first === '"' && /^"(?:[^"\\\\]|\\\\.)*"(\\s+#.*)?$/.test(value)) continue;
+        if (first === "'" && /^'(?:[^']|'')*'(\\s+#.*)?$/.test(value)) continue;
+        offenders.push(m[1]);
+        continue;
+      }
       if ((first === '>' || first === '|') && /^[>|][+-]?[0-9]*$/.test(value)) continue;
       if (value.indexOf(': ') !== -1 || value.charAt(value.length - 1) === ':') offenders.push(m[1]);
     }

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -206,6 +206,9 @@ export const GEMINI_BEFORE_TOOL = `// [totem] auto-generated — Gemini CLI Befo
 //   Rule 2:  write_file/replace → block GitHub auto-close keywords adjacent to an
 //            issue ref in **/*.md (EXEMPT .github/**, .totem/**) — design of
 //            record mmnto-ai/totem#1762; sibling seal pending its own PR.
+//   Rule 3:  write_file/replace → block unquoted ': ' in dispatch frontmatter
+//            subject:/expected-action: values under .totem/orchestration/*/outbox/
+//            (strict-YAML consumers reject the dispatch; mmnto-ai/totem-status#123).
 const { execSync } = require('child_process');
 
 const BARE_REF_REGEX_SOURCE = ${JSON.stringify(BARE_REF_REGEX_SOURCE)};
@@ -220,6 +223,61 @@ const MD_PATH_RE = /\\.md$/i;
 // surface — verified on PR mmnto-ai/totem#2474); use totem-context there.
 const GITHUB_EXEMPT_RE = /(^|[\\\\\\/])\\.(github|totem)[\\\\\\/]/i;
 const SUPPRESS_DIRECTIVE_RE = /<!--\\s*totem-context:/;
+// ECL dispatch surface: .totem/orchestration/<seat>/outbox/*.md (either separator).
+const OUTBOX_PATH_RE = /(^|[\\\\\\/])\\.totem[\\\\\\/]orchestration[\\\\\\/][^\\\\\\/]+[\\\\\\/]outbox[\\\\\\/][^\\\\\\/]+\\.md$/i;
+const DISPATCH_KEY_RE = /^(subject|expected-action):\\s*(.*)$/;
+
+// Sender-side subject-quoting guard (routed ask, mmnto-ai/totem-status#123): an
+// unquoted ': ' (or trailing ':') inside a subject:/expected-action: value breaks
+// strict-YAML frontmatter parsers ("mapping values are not allowed in this
+// context") — the dispatch delivers only via lenient fallbacks, and sensor
+// parity across consumers is lost. Kill the class at write time, at the source.
+// Full-file writes scan the leading frontmatter block only (body prose about
+// the schema stays writable); fragment edits scan every line but honor the
+// totem-context escape.
+function checkOutboxSubjectQuoting(toolName, toolInput) {
+  if (toolName !== 'write_file' && toolName !== 'edit_file' && toolName !== 'replace') return;
+  const input = (typeof toolInput === 'object' && toolInput !== null) ? toolInput : {};
+  const filePath = String(input.file_path || input.path || '');
+  if (!OUTBOX_PATH_RE.test(filePath)) return;
+  const content = input.content !== undefined ? input.content : input.new_string;
+  if (typeof content !== 'string') return;
+
+  const lines = content.split(/\\r?\\n/);
+  let start = 0;
+  let end = lines.length;
+  let fragment = true;
+  if (lines.length > 0 && lines[0].trim() === '---') {
+    fragment = false;
+    start = 1;
+    end = start;
+    while (end < lines.length && lines[end].trim() !== '---') end++;
+  }
+  const offenders = [];
+  for (let i = start; i < end; i++) {
+    const line = lines[i];
+    if (fragment) {
+      const prev = i > 0 ? lines[i - 1] : '';
+      if (SUPPRESS_DIRECTIVE_RE.test(line) || SUPPRESS_DIRECTIVE_RE.test(prev)) continue;
+    }
+    const m = DISPATCH_KEY_RE.exec(line);
+    if (!m) continue;
+    const value = m[2].trim();
+    if (value === '') continue;
+    const first = value.charAt(0);
+    // Quoted scalars and block scalars (>- / |) are strict-YAML-safe as authored.
+    if (first === '"' || first === "'" || first === '>' || first === '|') continue;
+    if (value.indexOf(': ') !== -1 || value.charAt(value.length - 1) === ':') offenders.push(m[1]);
+  }
+  if (offenders.length === 0) return;
+
+  throw new Error(
+    '[totem BeforeTool] Unquoted ":" in dispatch frontmatter value(s) [' + offenders.join(', ') + '] in write to ' + filePath + '. ' +
+    'Strict-YAML mail consumers reject the whole dispatch ("mapping values are not allowed in this context"). ' +
+    'Quote the value, e.g. subject: "Re: your round -- topic". ' +
+    'Sender-side guard routed from mmnto-ai/totem-status#123 (lenient consumer parsing is the fallback, not the contract).',
+  );
+}
 
 // mmnto-ai/totem#1762: any close-keyword (close/fix/resolve inflections) adjacent
 // to an issue ref in narrative markdown can auto-close a linked issue when the
@@ -287,6 +345,7 @@ function checkXrepoQualifyRefs(toolName, toolInput) {
 }
 
 module.exports = function beforeTool(toolName, toolInput) {
+  checkOutboxSubjectQuoting(toolName, toolInput);
   checkAutoCloseKeywords(toolName, toolInput);
   checkXrepoQualifyRefs(toolName, toolInput);
 
@@ -355,6 +414,11 @@ export const CLAUDE_PRETOOLUSE_ENTRY = {
 // invariant, zero semantics, no negation parser. Shares @mmnto/totem's
 // AUTO_CLOSE_REGEX_SOURCE (the one shared evaluator).
 //
+// ALSO enforces the ECL dispatch frontmatter-quoting guard
+// (mmnto-ai/totem-status#123): an unquoted ': ' in a subject:/expected-action:
+// value under .totem/orchestration/*/outbox/ breaks strict-YAML mail consumers;
+// the write is blocked so the class dies sender-side, cohort-wide.
+//
 // Exit-code contract is load-bearing — see hook source for details.
 //
 // Per OQ 2 of mmnto-ai/totem#1846 design: this entry installs into
@@ -369,6 +433,8 @@ export const CLAUDE_PREWRITESHIELD = `// [totem] auto-generated — Claude Code 
 //         sealed in mmnto-ai/totem-strategy#145 (seal SHA c488888b).
 // Rule 2: GitHub auto-close keyword guard —
 //         design of record mmnto-ai/totem#1762; sibling seal pending its own PR.
+// Rule 3: ECL dispatch frontmatter-quoting guard (outbox subject:/expected-action:
+//         values must be strict-YAML-safe) — routed from mmnto-ai/totem-status#123.
 //
 // Mirrors the compiled rule pattern at lessonHash "xrepo-qualify-refs"
 // in mmnto-ai/totem-strategy:.totem/compiled-rules.json.
@@ -395,6 +461,9 @@ const AUTO_CLOSE_MD_RE = /\\.md$/i;
 // verified on PR mmnto-ai/totem#2474); the totem-context directive is the escape.
 const AUTO_CLOSE_GITHUB_RE = /(^|[\\\\\\/])\\.(github|totem)[\\\\\\/]/i;
 const SUPPRESS_DIRECTIVE_RE = /<!--\\s*totem-context:/;
+// ECL dispatch surface: .totem/orchestration/<seat>/outbox/*.md (either separator).
+const OUTBOX_PATH_RE = /(^|[\\\\\\/])\\.totem[\\\\\\/]orchestration[\\\\\\/][^\\\\\\/]+[\\\\\\/]outbox[\\\\\\/][^\\\\\\/]+\\.md$/i;
+const DISPATCH_KEY_RE = /^(subject|expected-action):\\s*(.*)$/;
 
 let stdin = '';
 process.stdin.setEncoding('utf-8');
@@ -425,6 +494,51 @@ process.stdin.on('end', () => {
   if (typeof content !== 'string') {
     process.stderr.write('[totem PreWriteShield] non-string content; allowing\\n');
     process.exit(0);
+  }
+
+  // ── Rule 3: dispatch frontmatter quoting (mmnto-ai/totem-status#123) ──
+  // Unquoted ': ' (or trailing ':') in a subject:/expected-action: value breaks
+  // strict-YAML frontmatter parsers; the dispatch then delivers only via lenient
+  // fallbacks and consumer sensor parity is lost. Full-file writes scan the
+  // leading frontmatter block only (body prose about the schema stays writable);
+  // fragment edits scan every line but honor the totem-context escape. Checked
+  // first: a malformed dispatch is unreadable regardless of what its body says.
+  if (OUTBOX_PATH_RE.test(filePath)) {
+    const dLines = content.split(/\\r?\\n/);
+    let dStart = 0;
+    let dEnd = dLines.length;
+    let dFragment = true;
+    if (dLines.length > 0 && dLines[0].trim() === '---') {
+      dFragment = false;
+      dStart = 1;
+      dEnd = dStart;
+      while (dEnd < dLines.length && dLines[dEnd].trim() !== '---') dEnd++;
+    }
+    const offenders = [];
+    for (let i = dStart; i < dEnd; i++) {
+      const dLine = dLines[i];
+      if (dFragment) {
+        const dPrev = i > 0 ? dLines[i - 1] : '';
+        if (SUPPRESS_DIRECTIVE_RE.test(dLine) || SUPPRESS_DIRECTIVE_RE.test(dPrev)) continue;
+      }
+      const m = DISPATCH_KEY_RE.exec(dLine);
+      if (!m) continue;
+      const value = m[2].trim();
+      if (value === '') continue;
+      const first = value.charAt(0);
+      // Quoted scalars and block scalars (>- / |) are strict-YAML-safe as authored.
+      if (first === '"' || first === "'" || first === '>' || first === '|') continue;
+      if (value.indexOf(': ') !== -1 || value.charAt(value.length - 1) === ':') offenders.push(m[1]);
+    }
+    if (offenders.length > 0) {
+      process.stderr.write(
+        '[totem PreWriteShield] Unquoted ":" in dispatch frontmatter value(s) [' + offenders.join(', ') + '] in write to ' + filePath + '\\n' +
+        'Strict-YAML mail consumers reject the whole dispatch ("mapping values are not allowed in this context").\\n' +
+        'Quote the value, e.g. subject: "Re: your round -- topic".\\n' +
+        'Sender-side guard routed from mmnto-ai/totem-status#123 (lenient consumer parsing is the fallback, not the contract).\\n',
+      );
+      process.exit(2);
+    }
   }
 
   // Suppression-directive bypass mirrors rule-engine.ts isSuppressed
@@ -1128,7 +1242,7 @@ End-of-session wrap-up. Post-Proposal-282 (ADR-106), journals + handoffs live in
    | \`totem-strategy\`                                | \`strategy-claude\`                   | \`strategy-gemini\` | _(not seated)_    |
    | \`liquid-city\`                                   | \`lc-claude\`                         | \`lc-gemini\`       | _(not seated)_    |
    | \`arhgap11\`                                      | \`arhgap11-claude\`                   | \`arhgap11-gemini\` | _(not seated)_    |
-   | \`totem-status\`                                  | _(no Claude variant)_               | \`status-gemini\`   | _(not seated)_    |
+   | \`totem-status\`                                  | \`status-claude\`                     | \`status-gemini\`   | _(not seated)_    |
    | \`totem-playground\`                              | _(orphan stream — no native agent)_ | _(orphan stream)_ | _(orphan stream)_ |
 
    Seat discovery is dir-derived (mmnto-ai/totem#2141): any \`.totem/orchestration/<agent-id>/\` directory registers that seat for this repo, UNIONED with the basename map above so roster siblings stay visible on fresh clones where the gitignored tree is partial (precedence: \`TOTEM_SELF_AGENT\` env > \`config.json\` \`host_agents\` > seat dirs ∪ basename map). Override hook: a \`host_agents: string[]\` field in \`.totem/orchestration/config.json\` still **replaces** the derived answer — but omitting a PRESENT seat dir attaches a loud warning naming the omitted seat (the dir is the registration; config-exclusion is not a decommission mechanism). The returned list of agent-ids is used by consumers (e.g., \`totem mail\`) to filter cross-repo handoffs — messages addressed to any agent-id in the list belong to this repo's session.

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -273,13 +273,17 @@ function checkOutboxSubjectQuoting(toolName, toolInput) {
     const value = m[2].trim();
     if (value === '') continue;
     const first = value.charAt(0);
-    // A quoted scalar is exempt ONLY when well-terminated (optional trailing
-    // comment): an unterminated or junk-tailed quote is itself invalid YAML
-    // (greptile P1 on the introducing PR). Block scalars are exempt ONLY as a
-    // bare header (>, >-, |2, ...): a header with trailing text (">note: x")
-    // is invalid YAML and falls through to the scan.
+    // A quoted scalar is exempt ONLY when well-terminated on THIS line with
+    // YAML-legal escapes (optional trailing comment): unterminated quotes,
+    // trailing junk, and invalid escapes like \\q are all strict-YAML errors
+    // (greptile P1 + CR round 2 on the introducing PR). Multi-line quoted
+    // scalars are YAML-valid but BLOCKED BY POLICY: the cohort's lenient
+    // line-oriented consumer (mmnto-ai/totem-status#123) cannot see them —
+    // single-physical-line values are the dispatch contract. Block scalars are
+    // exempt ONLY as a bare header (>, >-, |2, ...): a header with trailing
+    // text (">note: x") is invalid YAML and falls through to the scan.
     if (first === '"' || first === "'") {
-      if (first === '"' && /^"(?:[^"\\\\]|\\\\.)*"(\\s+#.*)?$/.test(value)) continue;
+      if (first === '"' && /^"(?:[^"\\\\]|\\\\(?:[0abtnvfre "/\\\\N_LP\\t]|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8}))*"(\\s+#.*)?$/.test(value)) continue;
       if (first === "'" && /^'(?:[^']|'')*'(\\s+#.*)?$/.test(value)) continue;
       offenders.push(m[1]);
       continue;
@@ -292,7 +296,7 @@ function checkOutboxSubjectQuoting(toolName, toolInput) {
   throw new Error(
     '[totem BeforeTool] Unquoted ":" in dispatch frontmatter value(s) [' + offenders.join(', ') + '] in write to ' + filePath + '. ' +
     'Strict-YAML mail consumers reject the whole dispatch ("mapping values are not allowed in this context"). ' +
-    'Quote the value, e.g. subject: "Re: your round -- topic". ' +
+    'Quote the value on ONE line with YAML-legal escapes only, e.g. subject: "Re: your round -- topic". ' +
     'Sender-side guard routed from mmnto-ai/totem-status#123 (lenient consumer parsing is the fallback, not the contract).',
   );
 }
@@ -552,13 +556,17 @@ process.stdin.on('end', () => {
       const value = m[2].trim();
       if (value === '') continue;
       const first = value.charAt(0);
-      // A quoted scalar is exempt ONLY when well-terminated (optional trailing
-      // comment): an unterminated or junk-tailed quote is itself invalid YAML
-      // (greptile P1 on the introducing PR). Block scalars are exempt ONLY as a
-      // bare header (>, >-, |2, ...): a header with trailing text (">note: x")
-      // is invalid YAML and falls through to the scan.
+      // A quoted scalar is exempt ONLY when well-terminated on THIS line with
+      // YAML-legal escapes (optional trailing comment): unterminated quotes,
+      // trailing junk, and invalid escapes like \\q are all strict-YAML errors
+      // (greptile P1 + CR round 2 on the introducing PR). Multi-line quoted
+      // scalars are YAML-valid but BLOCKED BY POLICY: the cohort's lenient
+      // line-oriented consumer (mmnto-ai/totem-status#123) cannot see them —
+      // single-physical-line values are the dispatch contract. Block scalars are
+      // exempt ONLY as a bare header (>, >-, |2, ...): a header with trailing
+      // text (">note: x") is invalid YAML and falls through to the scan.
       if (first === '"' || first === "'") {
-        if (first === '"' && /^"(?:[^"\\\\]|\\\\.)*"(\\s+#.*)?$/.test(value)) continue;
+        if (first === '"' && /^"(?:[^"\\\\]|\\\\(?:[0abtnvfre "/\\\\N_LP\\t]|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8}))*"(\\s+#.*)?$/.test(value)) continue;
         if (first === "'" && /^'(?:[^']|'')*'(\\s+#.*)?$/.test(value)) continue;
         offenders.push(m[1]);
         continue;
@@ -570,7 +578,7 @@ process.stdin.on('end', () => {
       process.stderr.write(
         '[totem PreWriteShield] Unquoted ":" in dispatch frontmatter value(s) [' + offenders.join(', ') + '] in write to ' + filePath + '\\n' +
         'Strict-YAML mail consumers reject the whole dispatch ("mapping values are not allowed in this context").\\n' +
-        'Quote the value, e.g. subject: "Re: your round -- topic".\\n' +
+        'Quote the value on ONE line with YAML-legal escapes only, e.g. subject: "Re: your round -- topic".\\n' +
         'Sender-side guard routed from mmnto-ai/totem-status#123 (lenient consumer parsing is the fallback, not the contract).\\n',
       );
       process.exit(2);

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -265,8 +265,11 @@ function checkOutboxSubjectQuoting(toolName, toolInput) {
     const value = m[2].trim();
     if (value === '') continue;
     const first = value.charAt(0);
-    // Quoted scalars and block scalars (>- / |) are strict-YAML-safe as authored.
-    if (first === '"' || first === "'" || first === '>' || first === '|') continue;
+    // Quoted scalars are strict-YAML-safe as authored. Block scalars are exempt
+    // ONLY as a bare header (>, >-, |2, ...): a header with trailing text
+    // (e.g. ">note: x") is itself invalid YAML and falls through to the scan.
+    if (first === '"' || first === "'") continue;
+    if ((first === '>' || first === '|') && /^[>|][+-]?[0-9]*$/.test(value)) continue;
     if (value.indexOf(': ') !== -1 || value.charAt(value.length - 1) === ':') offenders.push(m[1]);
   }
   if (offenders.length === 0) return;
@@ -526,8 +529,11 @@ process.stdin.on('end', () => {
       const value = m[2].trim();
       if (value === '') continue;
       const first = value.charAt(0);
-      // Quoted scalars and block scalars (>- / |) are strict-YAML-safe as authored.
-      if (first === '"' || first === "'" || first === '>' || first === '|') continue;
+      // Quoted scalars are strict-YAML-safe as authored. Block scalars are exempt
+      // ONLY as a bare header (>, >-, |2, ...): a header with trailing text
+      // (e.g. ">note: x") is itself invalid YAML and falls through to the scan.
+      if (first === '"' || first === "'") continue;
+      if ((first === '>' || first === '|') && /^[>|][+-]?[0-9]*$/.test(value)) continue;
       if (value.indexOf(': ') !== -1 || value.charAt(value.length - 1) === ':') offenders.push(m[1]);
     }
     if (offenders.length > 0) {

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1936,6 +1936,36 @@ describe('PreWriteShield runtime behavior', () => {
     expect(result.exitCode).toBe(2);
   });
 
+  it('exits 2 on an invalid double-quote escape ("Re: D:\\q" is not YAML)', () => {
+    const result = runHook({
+      tool_name: 'Write',
+      tool_input: { file_path: OUTBOX_MD, content: '---\nsubject: "Re: D:\\q"\n---\n' },
+    });
+    expect(result.exitCode).toBe(2);
+  });
+
+  it('exits 0 on YAML-legal escapes inside a quoted subject', () => {
+    const result = runHook({
+      tool_name: 'Write',
+      tool_input: {
+        file_path: OUTBOX_MD,
+        content: '---\nsubject: "tab \\t quote \\" backslash \\\\ ok"\n---\n',
+      },
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('exits 2 on a multi-line quoted subject (single-physical-line policy for the line-oriented lenient consumer)', () => {
+    const result = runHook({
+      tool_name: 'Write',
+      tool_input: {
+        file_path: OUTBOX_MD,
+        content: '---\nsubject: "Re: spans\n  two lines"\n---\n',
+      },
+    });
+    expect(result.exitCode).toBe(2);
+  });
+
   it('does NOT fire outside the outbox surface (same content at a .journal path)', () => {
     const result = runHook({
       tool_name: 'Write',
@@ -2222,6 +2252,14 @@ describe('GEMINI_BEFORE_TOOL auto-close runtime behavior (mmnto-ai/totem#1762)',
     const r = runBeforeTool('write_file', {
       file_path: '.totem/orchestration/totem-gemini/outbox/reply.md',
       content: '---\nsubject: "Re: round\n---\n',
+    });
+    expect(r.threw).toBe(true);
+  });
+
+  it('throws on an invalid double-quote escape at the Gemini call site too', () => {
+    const r = runBeforeTool('write_file', {
+      file_path: '.totem/orchestration/totem-gemini/outbox/reply.md',
+      content: '---\nsubject: "Re: D:\\q"\n---\n',
     });
     expect(r.threw).toBe(true);
   });

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1909,6 +1909,33 @@ describe('PreWriteShield runtime behavior', () => {
     expect(result.exitCode).toBe(0);
   });
 
+  it('exits 0 on a frontmatter-LESS full Write (mode is tool-determined, body is never scanned)', () => {
+    const result = runHook({
+      tool_name: 'Write',
+      tool_input: {
+        file_path: OUTBOX_MD,
+        content: 'Draft notes, no frontmatter yet.\nsubject: Re: unsafe-looking body line\n',
+      },
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('exits 2 on an UNTERMINATED quoted subject (a leading quote alone is not safety)', () => {
+    const result = runHook({
+      tool_name: 'Write',
+      tool_input: { file_path: OUTBOX_MD, content: '---\nsubject: "Re: round\n---\n' },
+    });
+    expect(result.exitCode).toBe(2);
+  });
+
+  it('exits 2 on trailing junk after a closed quote (also invalid YAML)', () => {
+    const result = runHook({
+      tool_name: 'Write',
+      tool_input: { file_path: OUTBOX_MD, content: '---\nsubject: "Re: round" oops\n---\n' },
+    });
+    expect(result.exitCode).toBe(2);
+  });
+
   it('does NOT fire outside the outbox surface (same content at a .journal path)', () => {
     const result = runHook({
       tool_name: 'Write',
@@ -2179,6 +2206,22 @@ describe('GEMINI_BEFORE_TOOL auto-close runtime behavior (mmnto-ai/totem#1762)',
     const r = runBeforeTool('edit_file', {
       file_path: '.totem/orchestration/totem-gemini/outbox/reply.md',
       new_string: 'subject: Re: legacy tool -- unquoted',
+    });
+    expect(r.threw).toBe(true);
+  });
+
+  it('does not throw on a frontmatter-less full write_file (tool-determined mode)', () => {
+    const r = runBeforeTool('write_file', {
+      file_path: '.totem/orchestration/totem-gemini/outbox/reply.md',
+      content: 'Draft notes, no frontmatter yet.\nsubject: Re: unsafe-looking body line\n',
+    });
+    expect(r.threw).toBe(false);
+  });
+
+  it('throws on an unterminated quoted subject (leading quote alone is not safety)', () => {
+    const r = runBeforeTool('write_file', {
+      file_path: '.totem/orchestration/totem-gemini/outbox/reply.md',
+      content: '---\nsubject: "Re: round\n---\n',
     });
     expect(r.threw).toBe(true);
   });

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1801,6 +1801,133 @@ describe('PreWriteShield runtime behavior', () => {
     });
     expect(result.exitCode).toBe(0);
   });
+
+  // ─── Dispatch frontmatter-quoting guard (mmnto-ai/totem-status#123) ────────
+
+  const OUTBOX_MD = '.totem/orchestration/totem-claude/outbox/2026-07-22T1200Z-reply.md';
+
+  it('exits 2 on an unquoted ": " in an outbox subject: value (strict-YAML breaker)', () => {
+    const result = runHook({
+      tool_name: 'Write',
+      tool_input: {
+        file_path: OUTBOX_MD,
+        content: '---\nschema: adr-098-v0.4\nsubject: Re: parity round -- positions\n---\nBody.',
+      },
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('subject');
+    expect(result.stderr).toMatch(/quote/i);
+    expect(result.stderr).toContain('mmnto-ai/totem-status#123');
+  });
+
+  it('exits 2 on an unquoted ": " in expected-action: (and names the offending key)', () => {
+    const result = runHook({
+      tool_name: 'Write',
+      tool_input: {
+        file_path: OUTBOX_MD,
+        content: '---\nsubject: "safe"\nexpected-action: reply by Friday: with positions\n---\n',
+      },
+    });
+    expect(result.exitCode).toBe(2);
+    expect(result.stderr).toContain('expected-action');
+  });
+
+  it('exits 2 on a TRAILING colon in an unquoted subject: value', () => {
+    const result = runHook({
+      tool_name: 'Write',
+      tool_input: { file_path: OUTBOX_MD, content: '---\nsubject: Re:\n---\n' },
+    });
+    expect(result.exitCode).toBe(2);
+  });
+
+  it('exits 2 at a Windows-backslash outbox path too', () => {
+    const result = runHook({
+      tool_name: 'Write',
+      tool_input: {
+        file_path: '.totem\\orchestration\\totem-claude\\outbox\\reply.md',
+        content: '---\nsubject: Re: broken -- title\n---\n',
+      },
+    });
+    expect(result.exitCode).toBe(2);
+  });
+
+  it('exits 0 on a double-quoted subject carrying colons', () => {
+    const result = runHook({
+      tool_name: 'Write',
+      tool_input: {
+        file_path: OUTBOX_MD,
+        content: '---\nsubject: "Re: parity round -- positions"\n---\nBody.',
+      },
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('exits 0 on a single-quoted value and on a block scalar (>-)', () => {
+    const single = runHook({
+      tool_name: 'Write',
+      tool_input: { file_path: OUTBOX_MD, content: "---\nsubject: 'Re: quoted'\n---\n" },
+    });
+    expect(single.exitCode).toBe(0);
+    const folded = runHook({
+      tool_name: 'Write',
+      tool_input: {
+        file_path: OUTBOX_MD,
+        content: '---\nsubject: >-\n  Re: folded -- safe\n---\n',
+      },
+    });
+    expect(folded.exitCode).toBe(0);
+  });
+
+  it('exits 0 on a colon-free unquoted subject (plain scalars stay legal)', () => {
+    const result = runHook({
+      tool_name: 'Write',
+      tool_input: { file_path: OUTBOX_MD, content: '---\nsubject: parity round positions\n---\n' },
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('scans the leading frontmatter block ONLY on full-file writes (body prose stays writable)', () => {
+    const result = runHook({
+      tool_name: 'Write',
+      tool_input: {
+        file_path: OUTBOX_MD,
+        content:
+          '---\nsubject: "safe"\n---\nsubject: unquoted: colon in body prose about the schema',
+      },
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('does NOT fire outside the outbox surface (same content at a .journal path)', () => {
+    const result = runHook({
+      tool_name: 'Write',
+      tool_input: {
+        file_path: '.journal/test.md',
+        content: '---\nsubject: Re: not a dispatch -- out of scope\n---\n',
+      },
+    });
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('exits 2 on an Edit fragment reintroducing an unquoted subject (fragment mode)', () => {
+    const result = runHook({
+      tool_name: 'Edit',
+      tool_input: { file_path: OUTBOX_MD, new_string: 'subject: Re: sharpened -- title' },
+    });
+    expect(result.exitCode).toBe(2);
+  });
+
+  it('honors the totem-context escape in fragment mode (schema discussion in a body edit)', () => {
+    const result = runHook({
+      tool_name: 'Edit',
+      tool_input: {
+        file_path: OUTBOX_MD,
+        new_string:
+          '<!-- totem-context: verbatim quotation of the malformed specimen -->\nsubject: Re: the specimen that broke strict YAML',
+      },
+    });
+    expect(result.exitCode).toBe(0);
+  });
 });
 
 describe('CLAUDE_SESSION_START runtime behavior (A.3.a ledger write)', () => {
@@ -2006,6 +2133,35 @@ describe('GEMINI_BEFORE_TOOL auto-close runtime behavior (mmnto-ai/totem#1762)',
       new_string: 'see mmnto-ai/totem#5',
     });
     expect(r.threw).toBe(false);
+  });
+
+  // ─── Dispatch frontmatter-quoting guard (mmnto-ai/totem-status#123) ────────
+
+  it('throws on an unquoted ": " in an outbox subject: value (parity with PreWriteShield)', () => {
+    const r = runBeforeTool('write_file', {
+      file_path: '.totem/orchestration/totem-gemini/outbox/reply.md',
+      content: '---\nsubject: Re: parity round -- positions\n---\nBody.',
+    });
+    expect(r.threw).toBe(true);
+    expect(r.message).toContain('[totem BeforeTool]');
+    expect(r.message).toContain('mmnto-ai/totem-status#123');
+  });
+
+  it('does not throw on a quoted outbox subject', () => {
+    const r = runBeforeTool('write_file', {
+      file_path: '.totem/orchestration/totem-gemini/outbox/reply.md',
+      content: '---\nsubject: "Re: parity round -- positions"\n---\nBody.',
+    });
+    expect(r.threw).toBe(false);
+  });
+
+  it('blocks the quoting guard via the real `replace` edit tool too', () => {
+    const r = runBeforeTool('replace', {
+      file_path: '.totem/orchestration/totem-gemini/outbox/reply.md',
+      new_string: 'subject: Re: reintroduced -- unquoted',
+    });
+    expect(r.threw).toBe(true);
+    expect(r.message).toMatch(/quote/i);
   });
 });
 

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -1862,6 +1862,17 @@ describe('PreWriteShield runtime behavior', () => {
     expect(result.exitCode).toBe(0);
   });
 
+  it('exits 2 on a fake block-scalar header with trailing text (">note: x" is not valid YAML)', () => {
+    const result = runHook({
+      tool_name: 'Write',
+      tool_input: {
+        file_path: OUTBOX_MD,
+        content: '---\nsubject: >note: this is not a block scalar\n---\n',
+      },
+    });
+    expect(result.exitCode).toBe(2);
+  });
+
   it('exits 0 on a single-quoted value and on a block scalar (>-)', () => {
     const single = runHook({
       tool_name: 'Write',

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -2163,6 +2163,14 @@ describe('GEMINI_BEFORE_TOOL auto-close runtime behavior (mmnto-ai/totem#1762)',
     expect(r.threw).toBe(true);
     expect(r.message).toMatch(/quote/i);
   });
+
+  it('blocks the quoting guard via the legacy `edit_file` gate (backward-safety branch)', () => {
+    const r = runBeforeTool('edit_file', {
+      file_path: '.totem/orchestration/totem-gemini/outbox/reply.md',
+      new_string: 'subject: Re: legacy tool -- unquoted',
+    });
+    expect(r.threw).toBe(true);
+  });
 });
 
 describe('scaffoldClaudeSkill (mmnto-ai/totem#1890 Phase C slice 3)', () => {

--- a/packages/core/src/orchestration-resolver.test.ts
+++ b/packages/core/src/orchestration-resolver.test.ts
@@ -302,11 +302,11 @@ describe('resolveSelfAgents — basename map (default precedence)', () => {
     expect(result.agents).toEqual(['lc-claude', 'lc-gemini']);
   });
 
-  it('returns single Gemini agent for `totem-status` (no Claude variant)', () => {
+  it('returns Claude + Gemini pair for `totem-status` (status-claude seated, cohort-roles §1.1)', () => {
     const statusRoot = mkDir(path.join(tmpRoot, 'totem-status'));
     const result = resolveSelfAgents(statusRoot, {});
     expect(result.source).toBe('map');
-    expect(result.agents).toEqual(['status-gemini']);
+    expect(result.agents).toEqual(['status-claude', 'status-gemini']);
   });
 
   it("returns source: 'none' and empty list for orphan-stream repo `totem-playground`", () => {

--- a/packages/core/src/orchestration-resolver.ts
+++ b/packages/core/src/orchestration-resolver.ts
@@ -165,7 +165,11 @@ const COHORT_AGENT_MAP: Readonly<Record<string, readonly string[]>> = Object.fre
   'totem-strategy': Object.freeze(['strategy-claude', 'strategy-gemini']),
   'liquid-city': Object.freeze(['lc-claude', 'lc-gemini']),
   arhgap11: Object.freeze(['arhgap11-claude', 'arhgap11-gemini']),
-  'totem-status': Object.freeze(['status-gemini']),
+  // status-claude seated per the cohort-roles §1.1 roster ruling
+  // (mmnto-ai/totem-strategy#958, 2026-07-22) — without the map entry,
+  // dispatches addressed `to: status-claude` are invisible to CLI polls on
+  // checkouts where the gitignored seat dir is absent.
+  'totem-status': Object.freeze(['status-claude', 'status-gemini']),
   'totem-playground': Object.freeze([]),
 });
 


### PR DESCRIPTION
## Context

Two of the three totem-lane asks routed from status-claude's sensor-trust round-close (2026-07-22T0252Z, relayed via strategy-claude's 0619Z dispatch). Related: mmnto-ai/totem#2204, mmnto-ai/totem#2017, mmnto-ai/totem-status#123.

## Changes

1. **`COHORT_AGENT_MAP`: `status-claude` joins `totem-status`** (`packages/core/src/orchestration-resolver.ts`). The seat is real, active, and ruled into the roster (cohort-roles §1.1, mmnto-ai/totem-strategy#958, merged 2026-07-22); until now, anything addressed `to: status-claude` was invisible to CLI polls on checkouts without the gitignored seat dir. The distributed signoff skill's agent-id table follows (constant + `.claude/skills/signoff/SKILL.md`, kept byte-identical per the source-of-truth invariant test).

2. **Sender-side dispatch subject-quoting guard (Rule 3)** in both distributed write shields (`CLAUDE_PREWRITESHIELD` + `GEMINI_BEFORE_TOOL`): a write to `.totem/orchestration/*/outbox/*.md` whose frontmatter `subject:`/`expected-action:` value is an unquoted scalar containing `: ` (or ending in `:`) blocks at write time. This is the class that produced 11 strict-YAML-unparseable dispatches (consumer-side lenient fallback shipped in mmnto-ai/totem-status#123; this kills the class at the source, cohort-wide). Scope discipline: full-file writes scan the leading frontmatter block only (body prose about the schema stays writable); fragment edits scan all lines but honor the `totem-context` escape. Quoted scalars and bare block-scalar headers (`>-`, `|2`) pass; a fake header with trailing text (`>note: x` — itself invalid YAML) does not.

**The third routed ask** (styleguide verbatim-quotation carve-out) routes back to the strategy lane with a premise correction: no CLI-distributed styleguide exists (`totem init` distributes hooks + skills only) — the canonical home is `mmnto-ai/totem-strategy:.gemini/styleguide.md`, which already carries the directive-guarded exemption but not the fixture-corpus class. Dispatch to strategy-claude follows this PR.

## Verification

- Full core suite 3360 passed; full CLI suite green with the new coverage (213 in `init.test.ts`: 12 Claude-shield + 4 Gemini-hook runtime cases for the new guard, resolver roster tests updated).
- `pnpm -r build` green; repo-wide `format:check` clean; ESLint 0 errors (the 1 warning in a touched file is pre-existing on main, verified via stash-baseline).
- `totem lint --base main`: PASS, 0 errors (9 advisory frozen-lesson warnings; the changeset voice-rule hit was fixed, the `toContain`-matcher warnings are the known test-scope false-positive class, mmnto-ai/totem#2063).
- Changeset: `@mmnto/cli` minor + `@mmnto/totem` minor.

## Local review lane (disclosure)

local-lane: aeb5467d round=1 settled=false lanes=1/2

Rounds 0–1 completed on the sonnet lane and every finding was absorbed to quiescence: round-0 WARN (per-hook duplication) declined — self-contained generated hooks are this file's established convention (Rules 1–2 are duplicated the same way) and cross-variant parity is pinned by runtime tests on both hooks; round-0 INFO fixed (legacy `edit_file` gate now covered); round-1 WARN fixed (block-scalar exemption tightened to a bare header, regression test added); round-1 INFO (nested `outbox/` subdirectories) declined as speculative — the ECL contract is flat single-writer outboxes, and widening the path gate would guard a surface that does not exist. The post-fix re-verify round could not complete: both lanes failed twice (claude-CLI fallback `invoke-timeout`, gemini CLI `invoke-process-exit`; failure artifacts recorded) — an environment-degraded lane, not an unsettled finding set. The 21-line delta since the last completed round is the block-scalar tightening plus its test, covered by the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
