### PR TITLE
chore(rulesets): canonical required-checks declaration (posture-round Ask 1)

### DIFF
--- a/.totem/rulesets/main.json
+++ b/.totem/rulesets/main.json
@@ -1,0 +1,23 @@
+{
+  "_note": "Canonical required-checks declaration for the `main-required-checks` ruleset (mmnto-ai/totem-strategy#482 row `repo-required-checks-posture`; Q3 fork ruled totem-side 2026-07-22, recorded on mmnto-ai/totem-strategy#962). The LIVE ruleset (GitHub rulesets API) is the sensed surface; this file is the declaration the Prop 296 §14 network-read-only probe compares against, BOTH directions — a missing context re-opens a gated vector, a stale extra silently blocks merges (the mmnto-ai/totem#2479 specimen). Values re-derived from the live API at authoring (2026-07-22). Field names mirror the GitHub rulesets API so the comparison stays mechanical.",
+  "schema-version": 1,
+  "ruleset-name": "main-required-checks",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [],
+  "required_status_checks": {
+    "strict_required_status_checks_policy": false,
+    "contexts": [
+      "Auto-close required check (D1)",
+      "Build & Lint (ubuntu-latest)",
+      "Build & Lint (windows-latest)",
+      "Build & Lint (macos-latest)",
+      "Totem Lint"
+    ]
+  }
+}


### PR DESCRIPTION
## Context

Ask 1 of the posture-round follow-ups (strategy-claude round-close dispatch, 2026-07-22T2147Z): the Q3 operator fork was ruled **totem-side JSON** (recorded on mmnto-ai/totem-strategy#962, row 5) — the canonical required-checks list lives in this repo as a committed, typed declaration, and the parity-manifest row keeps the binding contract with its `canonical-source` flipping here once this lands.

## Change

One new file, `.totem/rulesets/main.json`: the declaration the Prop 296 §14 `network-read-only` probe will compare the live `main-required-checks` ruleset against, both directions. Carries the five check contexts plus the pinned enforcement posture (enforcement=active, `~DEFAULT_BRANCH`, `bypass_actors: []`, `strict_required_status_checks_policy: false` — the codex completeness bound from the round). Field names mirror the GitHub rulesets API so the future detector's comparison stays mechanical; every value was re-derived from the live API at authoring, not copied from prose.

No package is touched — no changeset. The §14 detector family that consumes this file is the next slice in the lane.

## Verification

- `prettier --check` clean; `totem lint --base main` PASS (0 violations).
- Declared values vs live API (2026-07-22): exact match on all fields, both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
