### PR TITLE
fix(hooks): ship Gemini BeforeTool as .cjs to stop the type-module fail-open

### DIFF
--- a/.changeset/gemini-beforetool-cjs-fail-open.md
+++ b/.changeset/gemini-beforetool-cjs-fail-open.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/cli': patch
+---
+
+Ship the Gemini CLI write-time guard as `.gemini/hooks/BeforeTool.cjs` instead of `.js` to stop a silent fail-open (the defect reported on mmnto-ai/totem#2481).
+
+The distributed hook body is CommonJS (top-level `require('child_process')`). In a consumer repo whose `package.json` declares `"type": "module"`, Node resolved the bare `.js` as ESM and threw `ReferenceError: require is not defined` before it could read the tool call — and Gemini CLI treats a crashed hook as a non-fatal warning, so the write-time guard fail-opened silently (the consumer believed it was armed while it never evaluated anything). A `.cjs` file is CommonJS regardless of the consumer's package `type`, mirroring the load-bearing `.cjs` extension on the Claude-side session hooks.
+
+`totem hook install` (which the `prepare` wrapper invokes on every install) and `totem init` now migrate an upgraded consumer: the legacy bounded totem-owned `.gemini/hooks/BeforeTool.js` is removed and the `.cjs` successor materialized, and an existing `.gemini/settings.json` BeforeTool command pointing at the `.js` is rewritten to the `.cjs`. The rewrite is idempotent, fail-soft on malformed settings (user content preserved), and never creates a registration where none exists. `totem eject` removes both the `.cjs` and the legacy `.js`. `SessionStart.js` is intentionally left as-is — the slice scopes to the write-time guard.

--- a/packages/cli/src/commands/eject.ts
+++ b/packages/cli/src/commands/eject.ts
@@ -16,6 +16,9 @@ const REFLEX_FILES = ['CLAUDE.md', '.cursorrules'];
 /** Files scaffolded by `totem init` that are fully owned by Totem. */
 const TOTEM_SCAFFOLDED_FILES = [
   '.gemini/hooks/SessionStart.js',
+  // Current (mmnto-ai/totem#2481) + the pre-migration `.js` it renamed — eject
+  // removes both so an upgraded-then-ejected consumer leaves no fail-open artifact.
+  '.gemini/hooks/BeforeTool.cjs',
   '.gemini/hooks/BeforeTool.js',
   '.gemini/skills/totem.md',
   '.totem/hooks/shield-gate.cjs',

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -1194,6 +1194,22 @@ export interface ManagedSessionHook {
   endMarker: string;
 }
 
+// The Gemini BeforeTool guard ships as `.cjs` (mmnto-ai/totem#2481). Its body is
+// CommonJS (top-level `require('child_process')`); a consumer `package.json` with
+// `"type": "module"` makes Node resolve a bare `.js` as ESM, so the guard throws
+// `ReferenceError: require is not defined` before it reads the tool call — and
+// Gemini CLI treats the crash as a non-fatal warning, so the write-time guard
+// fail-opens SILENTLY. The `.cjs` extension is load-bearing (CommonJS regardless of
+// the consumer's package `type`), mirroring the Claude-side `.cjs` session hooks.
+// SessionStart stays `.js` — the #2481 slice scopes to BeforeTool.
+export const GEMINI_BEFORE_TOOL_REL = '.gemini/hooks/BeforeTool.cjs';
+
+// The pre-#2481 path. A consumer upgraded from an earlier Totem still carries this
+// fail-open `.js` (and, if it registered the hook, a `.gemini/settings.json` command
+// pointing at it). The upgrade path migrates it to GEMINI_BEFORE_TOOL_REL via
+// LEGACY_MANAGED_SESSION_HOOKS below.
+export const GEMINI_BEFORE_TOOL_LEGACY_REL = '.gemini/hooks/BeforeTool.js';
+
 export const MANAGED_SESSION_HOOKS: ReadonlyArray<ManagedSessionHook> = [
   {
     rel: '.claude/hooks/PreWriteShield.cjs',
@@ -1220,7 +1236,7 @@ export const MANAGED_SESSION_HOOKS: ReadonlyArray<ManagedSessionHook> = [
     endMarker: TOTEM_FILE_END,
   },
   {
-    rel: '.gemini/hooks/BeforeTool.js',
+    rel: GEMINI_BEFORE_TOOL_REL,
     content: GEMINI_BEFORE_TOOL,
     marker: TOTEM_FILE_MARKER,
     endMarker: TOTEM_FILE_END,
@@ -1232,6 +1248,42 @@ export const MANAGED_SESSION_HOOKS: ReadonlyArray<ManagedSessionHook> = [
     // whole-file semantics apply.
     rel: PREPARE_SCRIPT_REL,
     content: PREPARE_WRAPPER,
+    marker: TOTEM_FILE_MARKER,
+    endMarker: TOTEM_FILE_END,
+  },
+];
+
+// ─── Legacy managed-artifact migration roster (mmnto-ai/totem#2481) ───
+//
+// Whole-file artifacts an EARLIER Totem distributed under a path this version has
+// since renamed. `migrateLegacyGeminiHooks` (install-hooks.ts) runs on the upgrade
+// path (`totem hook install`) and `totem init`: it materializes `successorRel` from
+// canonical `content` and removes the bounded totem-owned `legacyRel`. The SAME
+// ownership gate as the drift-repair path applies (markerOpensFile / isBoundedOwnedFile
+// — no NEW predicate), so a user-owned file that merely shares the legacy name is
+// never touched. `regenerateManagedSessionHooks` is regenerate-only-if-present and
+// would not create the renamed successor on upgrade; a PRESENT legacy artifact is
+// proof the repo already adopted the hook, so the successor is materialized here
+// rather than left for a fresh `totem init` (which the consumer may never re-run).
+
+export interface LegacyManagedHook {
+  /** Pre-rename repo-relative path, removed once migrated (POSIX separators). */
+  legacyRel: string;
+  /** Current repo-relative path, materialized from `content`. */
+  successorRel: string;
+  /** Canonical successor content — embeds `marker` at head and `endMarker` at tail. */
+  content: string;
+  /** Ownership/presence marker that must OPEN the legacy file to migrate it. */
+  marker: string;
+  /** End marker bounding the totem-owned region in the legacy file. */
+  endMarker: string;
+}
+
+export const LEGACY_MANAGED_SESSION_HOOKS: ReadonlyArray<LegacyManagedHook> = [
+  {
+    legacyRel: GEMINI_BEFORE_TOOL_LEGACY_REL,
+    successorRel: GEMINI_BEFORE_TOOL_REL,
+    content: GEMINI_BEFORE_TOOL,
     marker: TOTEM_FILE_MARKER,
     endMarker: TOTEM_FILE_END,
   },

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -446,7 +446,7 @@ describe('Gemini hook scaffolding', () => {
       '// [totem] auto-generated\ntest\n',
     );
     const beforeTool = scaffoldFile(
-      path.join(hooksDir, 'BeforeTool.js'),
+      path.join(hooksDir, 'BeforeTool.cjs'),
       '// [totem] auto-generated\ntest\n',
     );
     const skill = scaffoldFile(
@@ -2262,6 +2262,58 @@ describe('GEMINI_BEFORE_TOOL auto-close runtime behavior (mmnto-ai/totem#1762)',
       content: '---\nsubject: "Re: D:\\q"\n---\n',
     });
     expect(r.threw).toBe(true);
+  });
+});
+
+describe('GEMINI_BEFORE_TOOL ships as CJS for "type": "module" consumers (mmnto-ai/totem#2481)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-2481-typemodule-'));
+    // A consumer repo whose package.json declares ESM — the environment that makes a
+    // bare `.js` hook resolve as ESM and fail-open.
+    fs.writeFileSync(
+      path.join(tmpDir, 'package.json'),
+      JSON.stringify({ type: 'module' }, null, 2) + '\n',
+      'utf-8',
+    );
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  it('executes the distributed .cjs hook and the guard evaluates (no `require is not defined`)', () => {
+    const cjsPath = path.join(tmpDir, 'BeforeTool.cjs');
+    fs.writeFileSync(cjsPath, GEMINI_BEFORE_TOOL, 'utf-8');
+
+    // Require the shipped `.cjs` from a real node subprocess INSIDE the ESM consumer
+    // and drive the guard with a close-keyword write. A `.cjs` is CommonJS regardless
+    // of the enclosing package `type`, so `require` resolves and the guard BODY runs —
+    // proven by the guard throwing its own `[totem BeforeTool]` error rather than a
+    // `require is not defined` ReferenceError.
+    const driver = `require(${JSON.stringify(
+      cjsPath,
+    )})('write_file', { file_path: 'docs/x.md', content: 'Closes #5' })`;
+    const res = spawnSync(process.execPath, ['-e', driver], { cwd: tmpDir, encoding: 'utf-8' });
+
+    expect(res.stderr).not.toMatch(/require is not defined/);
+    expect(res.stderr).toContain('[totem BeforeTool]');
+    expect(res.status).not.toBe(0); // the guard blocked the write
+  });
+
+  it('proves the defect the .cjs fixes: the identical body as `.js` fail-opens as ESM', () => {
+    // Contrast fixture documenting WHY the extension is load-bearing. The identical
+    // hook body under a `.js` extension resolves as ESM in this consumer and throws
+    // `require is not defined` at the top-level `require('child_process')`, before it
+    // can read the tool call — the silent fail-open reported on mmnto-ai/totem#2481.
+    const jsPath = path.join(tmpDir, 'BeforeTool.js');
+    fs.writeFileSync(jsPath, GEMINI_BEFORE_TOOL, 'utf-8');
+
+    const res = spawnSync(process.execPath, [jsPath], { cwd: tmpDir, encoding: 'utf-8' });
+
+    expect(res.status).not.toBe(0);
+    expect(res.stderr).toMatch(/require is not defined/);
   });
 });
 

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -28,6 +28,7 @@ import {
   CLAUDE_SESSION_START_ENTRY,
   DISTRIBUTED_CLAUDE_SKILLS,
   GEMINI_BEFORE_TOOL,
+  GEMINI_BEFORE_TOOL_REL,
   GEMINI_SESSION_START,
   GEMINI_SKILL,
   isBoundedOwnedFile,
@@ -281,7 +282,9 @@ async function installGeminiHooks(cwd: string): Promise<HookInstallerResult[]> {
       endMarker: TOTEM_FILE_END,
     },
     {
-      rel: '.gemini/hooks/BeforeTool.js',
+      // Ships as `.cjs` — load-bearing in `"type": "module"` consumers
+      // (mmnto-ai/totem#2481); see GEMINI_BEFORE_TOOL_REL.
+      rel: GEMINI_BEFORE_TOOL_REL,
       content: GEMINI_BEFORE_TOOL,
       marker: TOTEM_FILE_MARKER,
       endMarker: TOTEM_FILE_END,
@@ -303,6 +306,33 @@ async function installGeminiHooks(cwd: string): Promise<HookInstallerResult[]> {
       file: rel,
       action: result.action === 'refreshed' ? 'merged' : result.action,
       ...(result.err ? { err: result.err } : {}),
+    });
+  }
+
+  // Legacy `.js`→`.cjs` migration (mmnto-ai/totem#2481). Runs on init too, not only
+  // the `totem hook install` upgrade path: a consumer re-running init after upgrading
+  // Totem carries the fail-open `.gemini/hooks/BeforeTool.js` (and possibly a
+  // `.gemini/settings.json` command pointing at it). Dynamic-imported to keep the
+  // migration co-located with the upgrade-path drift-repair machinery.
+  const { migrateGeminiHookRegistration, migrateLegacyGeminiHooks } =
+    await import('./install-hooks.js');
+  for (const { file, action } of await migrateLegacyGeminiHooks(cwd)) {
+    if (action === 'migrated') {
+      results.push({
+        file,
+        action: 'merged',
+        summaryActionOverride: 'Migrated legacy Gemini BeforeTool.js → .cjs',
+      });
+    }
+  }
+  const registration = migrateGeminiHookRegistration(cwd);
+  if (registration.err) {
+    results.push({ file: '.gemini/settings.json', action: 'merged', err: registration.err });
+  } else if (registration.changed) {
+    results.push({
+      file: '.gemini/settings.json',
+      action: 'merged',
+      summaryActionOverride: 'Migrated Gemini BeforeTool registration → .cjs',
     });
   }
 

--- a/packages/cli/src/commands/install-hooks-exit-contract.test.ts
+++ b/packages/cli/src/commands/install-hooks-exit-contract.test.ts
@@ -31,6 +31,9 @@ import { cleanTmpDir } from '../test-utils.js';
 import {
   CLAUDE_PREWRITESHIELD,
   CLAUDE_SESSION_START,
+  GEMINI_BEFORE_TOOL,
+  GEMINI_BEFORE_TOOL_LEGACY_REL,
+  GEMINI_BEFORE_TOOL_REL,
   GEMINI_SESSION_START,
   MANAGED_SESSION_HOOKS,
   TOTEM_FILE_END,
@@ -40,6 +43,8 @@ import {
   hooksCommand,
   installHooksCommand,
   installHooksNonInteractive,
+  migrateGeminiHookRegistration,
+  migrateLegacyGeminiHooks,
   regenerateManagedSessionHooks,
   resolveHooksDir,
   TOTEM_PREPUSH_END,
@@ -70,7 +75,9 @@ describe('MANAGED_SESSION_HOOKS roster invariant', () => {
         '.claude/hooks/PreWriteShield.cjs',
         '.claude/hooks/SessionStart.cjs',
         '.claude/hooks/gate-wrapper.cjs',
-        '.gemini/hooks/BeforeTool.js',
+        // BeforeTool ships as `.cjs` — load-bearing in `"type": "module"` consumers
+        // (mmnto-ai/totem#2481). SessionStart deliberately stays `.js` (scoped out).
+        '.gemini/hooks/BeforeTool.cjs',
         '.gemini/hooks/SessionStart.js',
         '.totem/prepare.cjs',
       ].sort(),
@@ -630,5 +637,140 @@ describe('resolveHooksDir with core.hooksPath aimed at a non-directory (#2422 ro
     fs.writeFileSync(notADir, 'not a directory\n');
     execFileSync('git', ['config', 'core.hooksPath', notADir], { cwd: tmpDir });
     expect(resolveHooksDir(tmpDir)).toBeNull();
+  });
+});
+
+// ─── Gemini BeforeTool .js→.cjs upgrade migration (mmnto-ai/totem#2481) ───
+
+describe('Gemini BeforeTool .js→.cjs migration', () => {
+  let tmpDir: string;
+
+  function writeFileRel(rel: string, content: string): void {
+    const p = path.join(tmpDir, ...rel.split('/'));
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, content, 'utf-8');
+  }
+  function readRel(rel: string): string {
+    return fs.readFileSync(path.join(tmpDir, ...rel.split('/')), 'utf-8');
+  }
+  function existsRel(rel: string): boolean {
+    return fs.existsSync(path.join(tmpDir, ...rel.split('/')));
+  }
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-2481-migrate-'));
+  });
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  it('converges a pre-migration consumer to exactly one .cjs registration + removes the stale .js', async () => {
+    // Fixture: a consumer that adopted the pre-#2481 hook — the fail-open `.js` file
+    // plus a `.gemini/settings.json` BeforeTool command pointing at it (nested
+    // matcher/hooks shape, alongside unrelated user keys).
+    writeFileRel(GEMINI_BEFORE_TOOL_LEGACY_REL, GEMINI_BEFORE_TOOL);
+    writeFileRel(
+      '.gemini/settings.json',
+      JSON.stringify(
+        {
+          mcpServers: { totem: { command: 'npx' } },
+          hooks: {
+            BeforeTool: [
+              {
+                matcher: '.*',
+                hooks: [
+                  { type: 'command', command: '$GEMINI_PROJECT_DIR/.gemini/hooks/BeforeTool.js' },
+                ],
+              },
+            ],
+          },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+
+    const fileResults = await migrateLegacyGeminiHooks(tmpDir);
+    const registration = migrateGeminiHookRegistration(tmpDir);
+
+    // Stale .js removed; .cjs successor materialized with canonical content.
+    expect(fileResults).toEqual([{ file: GEMINI_BEFORE_TOOL_LEGACY_REL, action: 'migrated' }]);
+    expect(existsRel(GEMINI_BEFORE_TOOL_LEGACY_REL)).toBe(false);
+    expect(existsRel(GEMINI_BEFORE_TOOL_REL)).toBe(true);
+    expect(readRel(GEMINI_BEFORE_TOOL_REL)).toBe(GEMINI_BEFORE_TOOL);
+
+    // Exactly one registration, now pointing at the .cjs — no `.js` ref survives
+    // anywhere in the file; unrelated user keys preserved.
+    expect(registration).toEqual({ changed: true });
+    const rawAfter = readRel('.gemini/settings.json');
+    expect(rawAfter).not.toMatch(/BeforeTool\.js(?!\w)/);
+    const settings = JSON.parse(rawAfter);
+    expect(settings.hooks.BeforeTool[0].hooks[0].command).toBe(
+      '$GEMINI_PROJECT_DIR/.gemini/hooks/BeforeTool.cjs',
+    );
+    expect(settings.mcpServers).toEqual({ totem: { command: 'npx' } });
+  });
+
+  it('is idempotent — a second pass is a no-op (flat command shape too)', async () => {
+    writeFileRel(GEMINI_BEFORE_TOOL_LEGACY_REL, GEMINI_BEFORE_TOOL);
+    writeFileRel(
+      '.gemini/settings.json',
+      JSON.stringify(
+        {
+          hooks: { BeforeTool: [{ type: 'command', command: 'node .gemini/hooks/BeforeTool.js' }] },
+        },
+        null,
+        2,
+      ) + '\n',
+    );
+
+    await migrateLegacyGeminiHooks(tmpDir);
+    expect(migrateGeminiHookRegistration(tmpDir)).toEqual({ changed: true });
+
+    // Second pass: nothing left to migrate on either seam.
+    expect(await migrateLegacyGeminiHooks(tmpDir)).toEqual([]);
+    expect(migrateGeminiHookRegistration(tmpDir)).toEqual({ changed: false });
+    const settings = JSON.parse(readRel('.gemini/settings.json'));
+    expect(settings.hooks.BeforeTool[0].command).toBe('node .gemini/hooks/BeforeTool.cjs');
+  });
+
+  it('never creates a registration where none exists (arming stays deferred)', () => {
+    expect(migrateGeminiHookRegistration(tmpDir)).toEqual({ changed: false });
+    expect(existsRel('.gemini/settings.json')).toBe(false);
+  });
+
+  it('fail-soft on malformed settings JSON: preserves user content, reports err', () => {
+    const raw = '{ this is not valid json ';
+    writeFileRel('.gemini/settings.json', raw);
+    const res = migrateGeminiHookRegistration(tmpDir);
+    expect(res.changed).toBe(false);
+    expect(res.err).toMatch(/invalid JSON/i);
+    expect(readRel('.gemini/settings.json')).toBe(raw); // untouched
+  });
+
+  it('leaves a user-owned BeforeTool.js (no Totem marker) untouched', async () => {
+    const userJs = '// my own hook\nmodule.exports = () => {};\n';
+    writeFileRel(GEMINI_BEFORE_TOOL_LEGACY_REL, userJs);
+    const results = await migrateLegacyGeminiHooks(tmpDir);
+    expect(results).toEqual([{ file: GEMINI_BEFORE_TOOL_LEGACY_REL, action: 'skipped' }]);
+    expect(readRel(GEMINI_BEFORE_TOOL_LEGACY_REL)).toBe(userJs);
+    expect(existsRel(GEMINI_BEFORE_TOOL_REL)).toBe(false);
+  });
+
+  it('declines a drifted-unbounded legacy .js without --force, migrates it under --force', async () => {
+    // Marker opens the file, but user content trails the end marker → not bounded.
+    writeFileRel(GEMINI_BEFORE_TOOL_LEGACY_REL, `${GEMINI_BEFORE_TOOL}\n// local customization\n`);
+
+    expect(await migrateLegacyGeminiHooks(tmpDir)).toEqual([
+      { file: GEMINI_BEFORE_TOOL_LEGACY_REL, action: 'declined' },
+    ]);
+    expect(existsRel(GEMINI_BEFORE_TOOL_LEGACY_REL)).toBe(true);
+    expect(existsRel(GEMINI_BEFORE_TOOL_REL)).toBe(false);
+
+    expect(await migrateLegacyGeminiHooks(tmpDir, true)).toEqual([
+      { file: GEMINI_BEFORE_TOOL_LEGACY_REL, action: 'migrated' },
+    ]);
+    expect(existsRel(GEMINI_BEFORE_TOOL_LEGACY_REL)).toBe(false);
+    expect(readRel(GEMINI_BEFORE_TOOL_REL)).toBe(GEMINI_BEFORE_TOOL);
   });
 });

--- a/packages/cli/src/commands/install-hooks.ts
+++ b/packages/cli/src/commands/install-hooks.ts
@@ -1041,6 +1041,12 @@ export async function hooksCommand(opts: {
   // and not-a-git-repo paths already returned above, so this never fires for the
   // read-only verify or the honest-skip. Regenerate-only-if-present: creation stays
   // with `totem init`; this verb repairs drift in artifacts the repo already adopted.
+  //
+  // The Gemini `.js`→`.cjs` migration (mmnto-ai/totem#2481) runs FIRST so the renamed
+  // successor is materialized before drift-repair walks the roster — a pre-migration
+  // consumer would otherwise be skipped by regenerate-only-if-present and keep its
+  // fail-open `.js`.
+  await printGeminiHookMigrationSummary(gitRoot, opts.force);
   await printManagedSessionHookSummary(gitRoot, opts.force);
 }
 
@@ -1163,6 +1169,188 @@ async function printManagedSessionHookSummary(cwd: string, force?: boolean): Pro
         console.error(`[Totem] ${file}: user-owned file (no Totem marker) — left untouched.`);
         break;
     }
+  }
+}
+
+// ─── Gemini BeforeTool .js→.cjs migration (mmnto-ai/totem#2481) ───
+//
+// A pre-#2481 Totem distributed the write-time guard as `.gemini/hooks/BeforeTool.js`.
+// In a `"type": "module"` consumer Node resolves that `.js` as ESM and the guard
+// throws `require is not defined` before reading the tool call — Gemini CLI treats
+// the crash as a warning, so the guard fail-opens SILENTLY. These two functions
+// migrate an upgraded consumer to the `.cjs` successor on the upgrade path
+// (`totem hook install`, which the prepare wrapper invokes) and on `totem init`.
+// Deliberately bounded (the #2478 OPTION 1 ruling routed the adoption/arming slice
+// OUT): rename + registration migration + legacy cleanup only — no arming-verification
+// and no NEW ownership predicate (reuses markerOpensFile / isBoundedOwnedFile).
+
+export interface GeminiHookMigrationResult {
+  /** Repo-relative legacy path acted on. */
+  file: string;
+  /** `migrated` — successor materialized + legacy removed; `declined` — drifted
+   *  unbounded, awaits `--force`; `skipped` — user-owned file, never touched. */
+  action: 'migrated' | 'declined' | 'skipped';
+}
+
+/**
+ * Rename-migrate the whole-file artifacts in {@link LEGACY_MANAGED_SESSION_HOOKS}:
+ * materialize each `successorRel` from canonical content and remove the bounded
+ * totem-owned `legacyRel`. Ownership gate mirrors {@link regenerateManagedSessionHooks}:
+ *
+ *   - Legacy missing                     → nothing to migrate (omitted from results).
+ *   - Marker does not OPEN the file      → `skipped` even under `--force` (a user file
+ *                                          that merely shares the name is never touched).
+ *   - Marker + bounded totem-owned whole file, OR `--force` → materialize successor +
+ *                                          remove legacy → `migrated`.
+ *   - Marker + drifted/unbounded (trailing user content), no `--force` → `declined`.
+ *
+ * A write/remove failure PROPAGATES (Tenet 4 — a migration the tool cannot complete
+ * fails loud, never silently reports success), matching the drift-repair path.
+ */
+export async function migrateLegacyGeminiHooks(
+  cwd: string,
+  force?: boolean,
+): Promise<GeminiHookMigrationResult[]> {
+  const { LEGACY_MANAGED_SESSION_HOOKS, isBoundedOwnedFile, markerOpensFile } =
+    await import('./init-templates.js');
+
+  const results: GeminiHookMigrationResult[] = [];
+  for (const {
+    legacyRel,
+    successorRel,
+    content,
+    marker,
+    endMarker,
+  } of LEGACY_MANAGED_SESSION_HOOKS) {
+    const legacyPath = path.join(cwd, ...legacyRel.split('/'));
+    if (!fs.existsSync(legacyPath)) continue;
+
+    const existing = fs.readFileSync(legacyPath, 'utf-8');
+    if (!markerOpensFile(existing, marker)) {
+      results.push({ file: legacyRel, action: 'skipped' });
+      continue;
+    }
+    if (!force && !isBoundedOwnedFile(existing, marker, endMarker)) {
+      results.push({ file: legacyRel, action: 'declined' });
+      continue;
+    }
+
+    // Materialize the successor (idempotent — canonical content) then remove the
+    // stale fail-open legacy file. Regenerate-only-if-present would not create the
+    // renamed successor on upgrade, but a present legacy artifact is proof of adoption.
+    const successorPath = path.join(cwd, ...successorRel.split('/'));
+    fs.mkdirSync(path.dirname(successorPath), { recursive: true });
+    fs.writeFileSync(successorPath, content, 'utf-8');
+    fs.rmSync(legacyPath);
+    results.push({ file: legacyRel, action: 'migrated' });
+  }
+  return results;
+}
+
+const GEMINI_LEGACY_HOOK_BASENAME_RE = /BeforeTool\.js(?!\w)/g;
+
+/**
+ * Idempotently rewrite an existing `.gemini/settings.json` hook registration whose
+ * command references the legacy `BeforeTool.js` basename to the `.cjs` successor.
+ *
+ * Rewrite-if-present ONLY: never CREATES a registration (arming the hook is the
+ * deferred adoption slice — #2478 OPTION 1), and fail-soft on unreadable/malformed
+ * JSON (preserve user content, mirroring `scaffoldMcpConfig`). Basename matching is
+ * separator- and prefix-agnostic, so `$GEMINI_PROJECT_DIR/.gemini/hooks/BeforeTool.js`,
+ * `node .gemini/hooks/BeforeTool.js`, and an absolute path all migrate. The rewrite is
+ * scoped to the `hooks` subtree, and the file is only rewritten when a change occurred
+ * (no churn / reformat on a no-op).
+ */
+export function migrateGeminiHookRegistration(cwd: string): { changed: boolean; err?: string } {
+  const settingsPath = path.join(cwd, '.gemini', 'settings.json');
+  if (!fs.existsSync(settingsPath)) return { changed: false };
+
+  let raw: string;
+  // Fail-soft is the contract (mmnto-ai/totem#2481): a settings file the tool cannot
+  // read/parse is user content and is never clobbered — the read/parse failure is
+  // surfaced as a returned `err`, mirroring scaffoldMcpConfig's IO posture.
+  try {
+    raw = fs.readFileSync(settingsPath, 'utf-8');
+    // totem-context: intentional cleanup — surface a read failure as a returned `err`, never a silent swallow.
+  } catch (err) {
+    return { changed: false, err: err instanceof Error ? err.message : String(err) };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+    // totem-context: intentional cleanup — a malformed settings file is user-owned content, preserved; surface the parse failure as a returned `err`.
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      changed: false,
+      err: `Could not parse .gemini/settings.json (invalid JSON): ${message}`,
+    };
+  }
+  if (typeof parsed !== 'object' || parsed === null) return { changed: false };
+
+  const settings = parsed as Record<string, unknown>;
+  const hooks = settings.hooks;
+  if (typeof hooks !== 'object' || hooks === null) return { changed: false };
+
+  let changed = false;
+  const rewrite = (node: unknown): unknown => {
+    if (typeof node === 'string') {
+      const next = node.replace(GEMINI_LEGACY_HOOK_BASENAME_RE, 'BeforeTool.cjs');
+      if (next !== node) changed = true;
+      return next;
+    }
+    if (Array.isArray(node)) return node.map(rewrite);
+    if (typeof node === 'object' && node !== null) {
+      const out: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(node as Record<string, unknown>)) {
+        out[key] = rewrite(value);
+      }
+      return out;
+    }
+    return node;
+  };
+
+  settings.hooks = rewrite(hooks);
+  if (!changed) return { changed: false };
+
+  try {
+    fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n', 'utf-8');
+    // totem-context: intentional cleanup — surface a write failure as a returned `err` for the caller to log; must not abort the hook-install lifecycle.
+  } catch (err) {
+    return { changed: false, err: err instanceof Error ? err.message : String(err) };
+  }
+  return { changed: true };
+}
+
+/**
+ * Run the Gemini `.js`→`.cjs` migration on the upgrade path and print one summary
+ * line per action. Runs BEFORE {@link printManagedSessionHookSummary} so the freshly
+ * materialized `.cjs` successor is reported as already-current by drift-repair.
+ */
+async function printGeminiHookMigrationSummary(cwd: string, force?: boolean): Promise<void> {
+  for (const { file, action } of await migrateLegacyGeminiHooks(cwd, force)) {
+    switch (action) {
+      case 'migrated':
+        console.error(`[Totem] Migrated ${file} → .cjs (ESM fail-open fix, mmnto-ai/totem#2481).`);
+        break;
+      case 'declined':
+        console.error(
+          `[Totem] ${file} has drifted but is not a bounded totem-owned region — run \`totem hook install --force\` to migrate it to .cjs.`,
+        );
+        break;
+      case 'skipped':
+        console.error(`[Totem] ${file}: user-owned file (no Totem marker) — left untouched.`);
+        break;
+    }
+  }
+  const registration = migrateGeminiHookRegistration(cwd);
+  if (registration.err) {
+    console.error(
+      `[Totem] .gemini/settings.json BeforeTool registration not migrated: ${registration.err}`,
+    );
+  } else if (registration.changed) {
+    console.error('[Totem] Migrated .gemini/settings.json BeforeTool registration → .cjs.');
   }
 }
 


### PR DESCRIPTION
## Context

The routed follow-up from the mmnto-ai/totem#2478 OPTION 1 strip: the distributed Gemini write-time guard `.gemini/hooks/BeforeTool.js` is CommonJS content with a `.js` extension, so a `"type": "module"` consumer resolves it as ESM and it throws before reading the tool call — Gemini CLI treats the crash as a warning, and the guard fail-opens silently.

Closes mmnto-ai/totem#2481

<!-- totem-close: mmnto-ai/totem#2481 -->

## Changes (bounded per the issue's recorded scope warning)

1. **Ship the hook as `.gemini/hooks/BeforeTool.cjs`** (`GEMINI_BEFORE_TOOL_REL`); the managed-hook roster and the locked six-artifact contract test follow.
2. **Legacy migration on both paths** (`totem hook install` — which the prepare wrapper invokes — and `totem init`): a present totem-owned legacy `.js` is proof of adoption, so the `.cjs` successor is materialized and the fail-open `.js` removed, reusing the existing ownership predicates (`markerOpensFile`/`isBoundedOwnedFile`) — no new predicate. Drifted-unbounded legacy declines without `--force`; a markerless user file is never touched, even forced.
3. **Registration migration, rewrite-if-present only:** an existing `.gemini/settings.json` hooks entry referencing `BeforeTool.js` is rewritten to `.cjs` (basename-matched, separator/prefix-agnostic, idempotent, fail-soft on malformed JSON — user content is never clobbered). It never *creates* a registration.
4. `totem eject` removes both the `.cjs` and the legacy `.js`.

## Two findings surfaced during the build (disclosed, not silently absorbed)

- **The issue's fix-shape #3 presupposed a settings-registration writer that does not exist**: the #2478 arming machinery was stripped under OPTION 1 and never re-landed, so nothing in this codebase writes a Gemini hooks registration. Consequence: after this fix a *fresh* `totem init` produces a CJS-safe hook **file** but no registration — the guard stays dormant until the deferred adoption/arming slice lands. This PR completes the issue's own acceptance scope (CJS-safe execution + pre-migration convergence); it deliberately does not restore arming.
- **`.gemini/hooks/SessionStart.js` carries the same latent ESM fail-open** (top-level `require` in a type-module consumer). Deliberately out of this slice per the issue's scope; lower severity (briefing hook, not a guard). Follow-up candidate.

## Verification

- New tests (8): the type-module acceptance pair (the `.cjs` evaluates; the identical body as `.js` provably fail-opens — the defect is pinned, not assumed), pre-migration convergence to exactly one `.cjs` registration, idempotency, never-creates-registration, malformed-settings fail-soft, user-owned skip, drifted-unbounded decline/--force.
- Full CLI suite 3558/3558; workspace build green; `format:check` clean; ESLint 0 errors (warnings identical to the main baseline); `totem lint --base main` PASS, 0 errors.
- Changeset: `@mmnto/cli` patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
