### PR TITLE
chore: postmerge for the day train — field-shy lesson + D1 marker doc gap

### DIFF
--- a/.claude/docs/contributing.md
+++ b/.claude/docs/contributing.md
@@ -3,7 +3,7 @@
 ## Git Conventions
 
 - Never amend commits on feature branches — create new commits.
-- Use `Closes #NNN` in PR descriptions to auto-close issues.
+- Use `Closes #NNN` in PR descriptions to auto-close issues, and declare each intended close with a `<!-- totem-close: #NNN -->` body marker — the D1 required check fails undeclared close keywords.
 - Squash merge to main (user preference).
 
 ## PR Review Bot Protocol

--- a/.junie/guidelines.md
+++ b/.junie/guidelines.md
@@ -4,7 +4,7 @@
 
 - `main` is protected. Always use feature branches + PRs.
 - Never amend commits on feature branches — create new commits.
-- Use `Closes #NNN` in PR descriptions.
+- Use `Closes #NNN` in PR descriptions, and declare each intended close with a `<!-- totem-close: #NNN -->` body marker — the D1 required check fails undeclared close keywords.
 
 ## Environment
 

--- a/.totem/lessons/lesson-8dc2ce4f.md
+++ b/.totem/lessons/lesson-8dc2ce4f.md
@@ -1,0 +1,5 @@
+## Lesson — Field-shy external-API responses are auth-class, never safe
+
+**Tags:** manual
+
+Field-shy external-API responses are auth-class, never safe defaults. When a sensor or detector consumes fetched data, an absent field (bypass_actors, a strict-policy flag, a non-array list body) must degrade the verdict to cannot-verify/unknown - treating absence as the safe value (empty list, skipped comparison, empty union) lets the sensor certify a posture it never observed. Split observed problems (real drift, warn) from unobserved fields (auth-class, unknown), and let observed drift outrank the observability gap. Ground: four same-class findings on PR mmnto-ai/totem#2486 (the Prop 296 s14 posture probes), fixed in commit 2c4d6057.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Totem is a **deterministic, git-native governance toolkit** — _rules you enfor
 ## Essentials
 
 - **pnpm only** (never npm/yarn). Use `pnpm dlx` (never `npx`). TypeScript strict mode.
-- `main` is protected. Feature branches + PRs. Never amend commits on feature branches. Use `Closes #NNN` in PR descriptions.
+- `main` is protected. Feature branches + PRs. Never amend commits on feature branches. Use `Closes #NNN` in PR descriptions, and declare each intended close with a `<!-- totem-close: #NNN -->` body marker — the D1 required check fails undeclared close keywords (the marker is the sole authorizing channel).
 - `kebab-case.ts` files, `err` (never `error`) in catch blocks, no empty catches.
 - Named constants for magic numbers. Zod at system boundaries only.
 - Run `pnpm run format` before committing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Totem is a **deterministic, git-native governance toolkit** — _rules you enfor
 ## Essentials
 
 - **pnpm only** (never npm/yarn). Use `pnpm dlx` (never `npx`). TypeScript strict mode.
-- `main` is protected. Feature branches + PRs. Never amend commits on feature branches. Use `Closes #NNN` in PR descriptions, and declare each intended close with a `<!-- totem-close: #NNN -->` body marker — the D1 required check fails undeclared close keywords (the marker is the sole authorizing channel).
+- `main` is protected. Feature branches + PRs. Never amend commits on feature branches. Use `Closes #NNN` in PR descriptions.
 - `kebab-case.ts` files, `err` (never `error`) in catch blocks, no empty catches.
 - Named constants for magic numbers. Zod at system boundaries only.
 - Run `pnpm run format` before committing.

--- a/docs/wiki/maintainer-policy.md
+++ b/docs/wiki/maintainer-policy.md
@@ -23,7 +23,7 @@
 - All PRs must pass CI: unit tests, `totem lint`, `totem review`, format check.
 - Core package changes require Lead Maintainer review.
 - Merge policy: squash merge after approval and green CI.
-- `Closes #NNN` keyword required in PR body for auto-close.
+- `Closes #NNN` keyword required in PR body for auto-close, paired with a `<!-- totem-close: #NNN -->` body marker (the D1 required check fails undeclared close keywords).
 
 ## Security
 


### PR DESCRIPTION
## Context

The postmerge slice for today's train (mmnto-ai/totem#2483 / #2484 / #2485 / #2486, all merged 2026-07-22/23). Extraction-only under the standing compile freeze.

## Changes

1. **Lesson `8dc2ce4f`** (via `totem lesson add`): field-shy external-API responses are auth-class, never safe defaults — the one class behind all four round-1 findings on mmnto-ai/totem#2486, laundering-checked against the round dispositions (an ACCEPTED-and-fixed class, no declined findings restated).
2. **The D1 marker doc gap**, surfaced when D1 bounced its own author's PR (mmnto-ai/totem#2485): the author-facing surfaces that instruct `Closes #NNN` now also name the `totem-close` body marker D1 requires — `.junie/guidelines.md`, `.claude/docs/contributing.md`, `docs/wiki/maintainer-policy.md`. **AGENTS.md deliberately not extended:** it sits ~16 characters under its FMEA-001 6000-char budget, so no meaningful clause fits without cutting other canonical content — an operator judgment, not mine; flagging it here. The tested `Use `Closes #NNN`` shared-rule substrings are preserved everywhere.

## Verification

Config-drift suite 47/47 (char budgets + shared-rules parity), `format:check` clean on touched files, `totem lint --base main` PASS 0 violations. Docs + lessons only — no package touched, no changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
