### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine 0.1.22 -> 0.1.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "optionalDependencies": {
     "@mmnto/cli": "workspace:*",
-    "@mmnto/strategy-doctrine": "0.1.22"
+    "@mmnto/strategy-doctrine": "0.1.24"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.22
-        version: 0.1.22
+        specifier: 0.1.24
+        version: 0.1.24
 
   packages/cli:
     dependencies:
@@ -853,8 +853,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.22':
-    resolution: {integrity: sha512-wEEW3wYgXP70mdm8PE2lZmD8BPpnwEfToYijQocHr60Z6Ot63hH8IxcKqzwMDT5sX5XmRi/+Lmgw1tUisyboHg==}
+  '@mmnto/strategy-doctrine@0.1.24':
+    resolution: {integrity: sha512-KXDE8D1FAR+gpBKd8K2qcJPWq9cR3WlDrm/TsWMapHbxGCL5JYVfS/pn2W5Bcx/OWj7e+7Ruj6kXEe+rBZAuzg==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3685,7 +3685,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.22':
+  '@mmnto/strategy-doctrine@0.1.24':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
Cohort sync for `@mmnto/strategy-doctrine` `0.1.22` → `0.1.24` (cohort floor moved to 0.1.24 at mmnto-ai/totem-strategy@07f2e34; this repo flagged behind by the strategy-side pin-currency sensor).

## What's in the bump (diffed the published tarballs, not the release notes)

Three files differ between 0.1.22 and 0.1.24; one carries content:

| File | Change |
|---|---|
| `parity-manifest.yaml` | **+94 lines, 0 removed** — three new repo-posture rows + the canonical-source flip |
| `strategy-doctrine.lock` | version/published stamps + `last-published-sha` pointers |
| `package.json` | version only |

The three new rows (0.1.23, mmnto-ai/totem-strategy#963): `repo-merge-posture`, `repo-required-checks-posture`, `repo-branch-protection-posture` — all `capability-probe` manifestation, probe-class `network-read-only` per Prop 296 §14 (offline/unauthed ⇒ cannot-verify, never drift). The 0.1.24 delta (mmnto-ai/totem-strategy#966, round-pre-authorized mmnto-ai/totem-strategy#964): `repo-required-checks-posture.canonical-source` now points at this repo's own `.totem/rulesets/main.json` declaration (landed mmnto-ai/totem#2484) instead of interim manifest prose.

## Verification

- Registry read resolved 0.1.24 from this repo's env **before** the bump (the mmnto-ai/totem-strategy#630 silent-optional-drop class — pre-checked; registry is public npmjs for this package, so the per-env 404 variant doesn't apply here)
- Post-install: `node_modules/@mmnto/strategy-doctrine` verified at `0.1.24` (no silent uninstall)
- `totem doctor --parity` (strategy root resolvable): `PASS — installed 0.1.24 ≥ cohort floor 0.1.24 (canonical-source)`
- Lockfile regenerated and committed (this repo tracks `pnpm-lock.yaml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
