### PR TITLE
feat(core,mcp): retrieval envelope — relevance through fusion, floor + no_useful_hits, FTS fallback (#2463 slice A)

### DIFF
--- a/.changeset/retrieval-envelope-relevance-floor.md
+++ b/.changeset/retrieval-envelope-relevance-floor.md
@@ -1,0 +1,9 @@
+---
+'@mmnto/totem': minor
+'@mmnto/mcp': minor
+---
+
+Retrieval envelope: carry true relevance through fusion, add a relevance floor with an honest `no_useful_hits` state, and degrade loudly to keyword-only search when the embedder is unavailable (mmnto-ai/totem#2463, slice A).
+
+- **core:** `SearchResult` now carries `relevance` (vector-leg similarity `1/(1+distance)`, 0..1; absent for keyword-only hits) and `searchMethod` (`hybrid` | `vector` | `fts`). `rowToSearchResult` populates `relevance`; both the intra-store `rrfMerge` and the MCP federation merge preserve it while still overwriting `score` with the RRF rank artifact, so ordering is byte-identical. New opt-in `SearchOptions.allowFtsFallback` degrades to the existing FTS-only path when the embedder cannot resolve and an FTS index exists (only the no-embedder failure class is caught; all other errors propagate). New flat config key `searchRelevanceFloor` (`z.number().min(0).max(1).default(0.25)`).
+- **mcp:** `search_knowledge` gains an optional `min_relevance` input (overrides the config floor), emits a machine-parsable `<retrieval-envelope status method bestRelevance floor hits />` line directly below `<index-meta>`, floors on the true relevance (not the RRF rank artifact) with `bestRelevance` empty-safe, reports `status="no_useful_hits"` with a compact below-floor candidate disclosure instead of a silent drop, passes `allowFtsFallback: true` on all store searches and prepends a loud keyword-only warning when the fallback engages, renders a per-hit `Relevance:` field, and records best relevance in the search log.

--- a/docs/wiki/cross-repo-mesh.md
+++ b/docs/wiki/cross-repo-mesh.md
@@ -62,6 +62,25 @@ This is a simplified form of Reciprocal Rank Fusion. The textbook RRF formula su
 
 This mathematical normalization eliminates score-scale bias. It ensures that a highly relevant hit from a purely vector-based linked store isn't outranked by a mediocre hit from a hybrid-search primary store just because their absolute scoring scales differ. The visible `Score:` field in the agent's results displays this normalized RRF value.
 
+### Relevance vs. Score, and the retrieval envelope
+
+The `Score:` field is an RRF **rank** artifact — in hybrid and federated modes it is `1 / (60 + rank)` (≈ 0.016 for a rank-1 hit) **by construction**, so it encodes ordering but destroys the underlying relevance magnitude. Do not floor or threshold on it: every fused hit looks like noise.
+
+Each result therefore also carries a `Relevance:` field: the true per-hit signal `1 / (1 + distance)` (roughly 0.5–0.95) from the vector leg, carried through both RRF fusion sites untouched. A keyword-only hit (FTS leg, no vector leg) shows `Relevance: n/a (keyword match)` — an **absent** signal, distinct from a low one.
+
+Every `search_knowledge` response also emits a machine-parsable `<retrieval-envelope>` line directly below the `<index-meta>` line, e.g.:
+
+```
+<retrieval-envelope status="ok" method="hybrid" bestRelevance="0.831" floor="0.250" hits="5" />
+```
+
+- `status` is `ok`, `no_useful_hits`, or `empty`. `no_useful_hits` means results exist but the best relevance fell below the floor — the below-floor candidates are still disclosed (path + relevance, no content) rather than silently dropped; `empty` means zero rows. The two are kept programmatically distinct.
+- `method` is `hybrid`, `vector`, or `fts` (the last indicating the embedder was unavailable and search degraded to keyword-only — a loud system warning accompanies it).
+- `bestRelevance` is the max per-hit relevance (or `n/a` when no hit carried a relevance signal — in which case the floor does not fire).
+- `floor` is the effective relevance floor for the call: the config `searchRelevanceFloor` (default `0.25`), overridable per call via the `min_relevance` input.
+
+The envelope parses with a single regular expression, so wrapper agents can route on retrieval confidence without scraping the prose body.
+
 ## Targeted Queries (Boundary Routing)
 
 Agents can explicitly route queries to specific boundaries to isolate context:

--- a/packages/cli/src/commands/docs.test.ts
+++ b/packages/cli/src/commands/docs.test.ts
@@ -84,6 +84,7 @@ function mockConfig(docs?: DocTarget[]): void {
     shieldIgnorePatterns: [],
     shieldAutoLearn: false,
     contextWarningThreshold: 40_000,
+    searchRelevanceFloor: 0.25,
     review: { sourceExtensions: ['.ts', '.tsx', '.js', '.jsx'] },
   });
 }

--- a/packages/cli/src/commands/shield-learn.test.ts
+++ b/packages/cli/src/commands/shield-learn.test.ts
@@ -69,6 +69,7 @@ describe('learnFromVerdict', () => {
     shieldIgnorePatterns: [],
     shieldAutoLearn: false,
     contextWarningThreshold: 40_000,
+    searchRelevanceFloor: 0.25,
     review: { sourceExtensions: ['.ts', '.tsx', '.js', '.jsx'] },
   };
 

--- a/packages/cli/src/utils.test.ts
+++ b/packages/cli/src/utils.test.ts
@@ -556,6 +556,7 @@ describe('requireEmbedding', () => {
     shieldIgnorePatterns: [],
     shieldAutoLearn: false,
     contextWarningThreshold: 40_000,
+    searchRelevanceFloor: 0.25,
     review: { sourceExtensions: ['.ts', '.tsx', '.js', '.jsx'] },
   };
 

--- a/packages/cli/src/utils/pilot.test.ts
+++ b/packages/cli/src/utils/pilot.test.ts
@@ -25,6 +25,7 @@ function makeConfig(pilot?: TotemConfig['pilot']): TotemConfig {
     indexIgnorePatterns: [],
     shieldIgnorePatterns: [],
     contextWarningThreshold: 40_000,
+    searchRelevanceFloor: 0.25,
     shieldAutoLearn: false,
     review: { sourceExtensions: ['.ts', '.tsx', '.js', '.jsx'] },
     pilot,

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -428,6 +428,14 @@ export const ReviewConfigSchema = z
   .passthrough()
   .default({});
 
+/**
+ * Default `searchRelevanceFloor` (mmnto-ai/totem#2463). Exported as the single
+ * source shared by the schema default below and the MCP guard that re-applies
+ * it for unvalidated configs — retuning one can never silently strand the
+ * other on a stale floor.
+ */
+export const DEFAULT_SEARCH_RELEVANCE_FLOOR = 0.25;
+
 export const TotemConfigSchema = z.object({
   /** Glob patterns and chunking strategies for each ingest target */
   targets: z.array(IngestTargetSchema).min(1),
@@ -483,7 +491,7 @@ export const TotemConfigSchema = z.object({
    * per-call `min_relevance` MCP input overrides this; the retrieval-envelope
    * always discloses the effective floor. Default 0.25 (pilot-calibrated).
    */
-  searchRelevanceFloor: z.number().min(0).max(1).default(0.25),
+  searchRelevanceFloor: z.number().min(0).max(1).default(DEFAULT_SEARCH_RELEVANCE_FLOOR),
 
   /** Optional: documents to auto-update via `totem docs` */
   docs: z.array(DocTargetSchema).optional(),

--- a/packages/core/src/config-schema.ts
+++ b/packages/core/src/config-schema.ts
@@ -475,6 +475,16 @@ export const TotemConfigSchema = z.object({
   /** Character count threshold for MCP context payload warnings (~4 chars ≈ 1 token). Default: 40,000 (~10k tokens). */
   contextWarningThreshold: z.number().int().positive().default(40_000),
 
+  /**
+   * Minimum per-hit relevance (vector-leg similarity, 0..1) below which the
+   * `search_knowledge` tool reports `status="no_useful_hits"` rather than
+   * returning noise-floor matches (mmnto-ai/totem#2463). Floors on the true
+   * relevance signal, NOT the RRF rank artifact in the displayed `score`. The
+   * per-call `min_relevance` MCP input overrides this; the retrieval-envelope
+   * always discloses the effective floor. Default 0.25 (pilot-calibrated).
+   */
+  searchRelevanceFloor: z.number().min(0).max(1).default(0.25),
+
   /** Optional: documents to auto-update via `totem docs` */
   docs: z.array(DocTargetSchema).optional(),
 

--- a/packages/core/src/embedders/embedder.ts
+++ b/packages/core/src/embedders/embedder.ts
@@ -97,6 +97,16 @@ export function createEmbedder(
 }
 
 /**
+ * The terminal "no embedder anywhere" failure message. Exported as the single
+ * source of truth because `LanceStore.isNoEmbedderError` keys its opt-in FTS
+ * degradation on recognizing exactly this failure (mmnto-ai/totem#2463) — a
+ * wording change here propagates to the detector instead of silently
+ * decoupling it.
+ */
+export const NO_EMBEDDER_AVAILABLE_MESSAGE =
+  'No embedding provider available. The configured provider failed and Ollama is not running.';
+
+/**
  * Lazy embedder that resolves the real provider on first embed() call.
  * If the configured provider fails (missing SDK / API key), falls back to Ollama.
  * Dimensions are optimistic — set to the configured provider's default.
@@ -136,7 +146,7 @@ class LazyEmbedder implements Embedder {
       const available = await isOllamaAvailable();
       if (!available) {
         throw new TotemConfigError(
-          'No embedding provider available. The configured provider failed and Ollama is not running.',
+          NO_EMBEDDER_AVAILABLE_MESSAGE,
           "Either: (1) Install the SDK and set the API key for your configured provider, (2) Install and start Ollama: https://ollama.com, or (3) Set provider: 'ollama' in totem.config.ts.",
           'CONFIG_MISSING',
         );

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -96,6 +96,7 @@ export {
   ContentTypeSchema,
   DEFAULT_IGNORE_PATTERNS,
   DEFAULT_REVIEW_SOURCE_EXTENSIONS,
+  DEFAULT_SEARCH_RELEVANCE_FLOOR,
   DocTargetSchema,
   DoctorConfigSchema,
   EclConfigSchema,

--- a/packages/core/src/pack-manifest-writer.test.ts
+++ b/packages/core/src/pack-manifest-writer.test.ts
@@ -93,6 +93,7 @@ function makeConfig(extendsList: readonly string[] | undefined): TotemConfig {
     indexIgnorePatterns: [],
     shieldIgnorePatterns: [],
     contextWarningThreshold: 40_000,
+    searchRelevanceFloor: 0.25,
     shieldAutoLearn: false,
     extends: extendsList ? [...extendsList] : undefined,
     review: {

--- a/packages/core/src/store/lance-search.test.ts
+++ b/packages/core/src/store/lance-search.test.ts
@@ -660,3 +660,130 @@ describe('source context tagging', () => {
     expect(results[0]!.sourceRepo).toBeUndefined();
   });
 });
+
+// ─── relevance + searchMethod (mmnto-ai/totem#2463) ───────
+//
+// `relevance` carries the true vector-leg similarity through fusion so the
+// MCP floor can distinguish weak retrieval from the RRF rank artifact in
+// `score`; `searchMethod` labels which path produced each hit. These tests
+// lock: (1) vector rows get relevance == score; (2) FTS-only rows never get
+// relevance; (3) rrfMerge PRESERVES the vector leg's relevance while still
+// overwriting score with RRF; (4) relevance NEVER perturbs the sort.
+
+describe('relevance + searchMethod (mmnto-ai/totem#2463)', () => {
+  it('runVectorSearch: relevance == 1/(1+distance) and searchMethod is "vector"', async () => {
+    const table = mockTable({
+      vectorRows: [fakeRow('a', { _distance: 0.25 }), fakeRow('b', { _distance: 1.0 })],
+    });
+
+    const results = await runVectorSearch(
+      table as never,
+      mockEmbedder(),
+      'query',
+      undefined,
+      5,
+      DEFAULT_CTX,
+    );
+
+    expect(results[0]!.relevance).toBeCloseTo(1 / 1.25, 6);
+    expect(results[0]!.relevance).toBeCloseTo(results[0]!.score, 6);
+    expect(results[0]!.searchMethod).toBe('vector');
+    expect(results[1]!.relevance).toBeCloseTo(1 / 2.0, 6);
+    expect(results[1]!.searchMethod).toBe('vector');
+  });
+
+  it('runVectorSearch: a null _distance yields no relevance signal (absent, not zero)', async () => {
+    const table = mockTable({ vectorRows: [fakeRow('x', { _distance: null })] });
+    const results = await runVectorSearch(
+      table as never,
+      mockEmbedder(),
+      'query',
+      undefined,
+      5,
+      DEFAULT_CTX,
+    );
+    expect(results[0]!.relevance).toBeUndefined();
+    expect(results[0]!.score).toBe(0);
+  });
+
+  it('runFtsSearch: FTS-only rows carry no relevance and searchMethod is "fts"', async () => {
+    const table = mockTable({
+      ftsRows: [
+        fakeRow('a', { _distance: undefined, _score: 3.1 }),
+        fakeRow('b', { _distance: undefined, _score: 1.4 }),
+      ],
+    });
+    const results = await runFtsSearch(
+      table as never,
+      () => {},
+      'query',
+      undefined,
+      5,
+      DEFAULT_CTX,
+    );
+
+    expect(results).toHaveLength(2);
+    for (const r of results) {
+      expect(r.relevance).toBeUndefined();
+      expect(r.searchMethod).toBe('fts');
+    }
+  });
+
+  it('runHybridSearch: rrfMerge preserves the vector leg relevance and stamps "hybrid"', async () => {
+    // 'a' is in BOTH legs; the vector row (retained first) has _distance 0.9,
+    // the fts row a different _distance — the merged relevance must come from
+    // the VECTOR leg (0.9 → ~0.526), never the fts row (~0.909).
+    const vectorRows = [fakeRow('a', { _distance: 0.9 }), fakeRow('b', { _distance: 0.0 })];
+    const ftsRows = [
+      fakeRow('a', { _distance: 0.1 }),
+      fakeRow('c', { _distance: undefined, _score: 5 }),
+    ];
+    const table = mockTable({ vectorRows, ftsRows });
+
+    const results = await runHybridSearch(
+      table as never,
+      mockEmbedder(),
+      () => {},
+      'query',
+      undefined,
+      10,
+      DEFAULT_CTX,
+    );
+
+    const a = results.find((r) => r.content === 'content-a')!;
+    const c = results.find((r) => r.content === 'content-c')!;
+
+    // Vector-leg relevance survived fusion (NOT the fts row's 1/1.1 ≈ 0.909).
+    expect(a.relevance).toBeCloseTo(1 / 1.9, 6);
+    // score was still overwritten with RRF (2/61 for a doc in both legs).
+    expect(a.score).toBeCloseTo(2 / 61, 6);
+    expect(a.searchMethod).toBe('hybrid');
+    // 'c' appeared only in the FTS leg (no vector row) → no relevance.
+    expect(c.relevance).toBeUndefined();
+    expect(c.searchMethod).toBe('hybrid');
+  });
+
+  it('runHybridSearch: relevance never perturbs RRF ordering (sort is score-only)', async () => {
+    // 'a' (both legs → RRF 2/61) has LOWER relevance (~0.526) than 'b'
+    // (vector-only rank 2 → RRF 1/62) which has relevance 1.0. If relevance
+    // leaked into the sort key, 'b' would jump ahead — it must not.
+    const vectorRows = [fakeRow('a', { _distance: 0.9 }), fakeRow('b', { _distance: 0.0 })];
+    const ftsRows = [fakeRow('a', { _distance: 0.9 })];
+    const table = mockTable({ vectorRows, ftsRows });
+
+    const results = await runHybridSearch(
+      table as never,
+      mockEmbedder(),
+      () => {},
+      'query',
+      undefined,
+      10,
+      DEFAULT_CTX,
+    );
+
+    expect(results.map((r) => r.content)).toEqual(['content-a', 'content-b']);
+    expect(results[0]!.score).toBeGreaterThan(results[1]!.score);
+    // The higher-relevance doc is deliberately ranked SECOND.
+    expect(results[1]!.relevance).toBeGreaterThan(results[0]!.relevance!);
+  });
+});

--- a/packages/core/src/store/lance-search.ts
+++ b/packages/core/src/store/lance-search.ts
@@ -40,7 +40,10 @@ export async function runVectorSearch(
   if (whereClause) q = q.where(whereClause);
 
   const results = await q.toArray();
-  return results.map((row) => rowToSearchResult(row, sourceContext));
+  return results.map((row) => ({
+    ...rowToSearchResult(row, sourceContext),
+    searchMethod: 'vector' as const,
+  }));
 }
 
 /**
@@ -108,6 +111,9 @@ export async function runFtsSearch(
     if (row['_score'] == null) {
       result.score = 1 / rank;
     }
+    // FTS-only path carries no vector leg — `relevance` stays absent
+    // (mmnto-ai/totem#2463); stamp the method so callers can label provenance.
+    result.searchMethod = 'fts';
     return result;
   });
 }
@@ -184,10 +190,16 @@ function rowToSearchResult(
   row: Record<string, unknown>,
   sourceContext: SourceContext,
 ): SearchResult {
-  // Vector search returns _distance (lower = better); FTS returns _score (higher = better)
+  // Vector search returns _distance (lower = better); FTS returns _score (higher = better).
+  // The vector-derived `1/(1+_distance)` similarity is ALSO the true relevance
+  // signal (mmnto-ai/totem#2463): captured into `relevance` here so it survives
+  // the RRF fusion that later overwrites `score` with a rank artifact. FTS rows
+  // (only `_score`, an incomparable BM25 magnitude) carry no `relevance`.
   let score = 0;
+  let relevance: number | undefined;
   if (row['_distance'] != null) {
-    score = 1 / (1 + (row['_distance'] as number));
+    relevance = 1 / (1 + (row['_distance'] as number));
+    score = relevance;
   } else if (row['_score'] != null) {
     score = row['_score'] as number;
   }
@@ -205,6 +217,10 @@ function rowToSearchResult(
     score,
     metadata: JSON.parse((row['metadata'] as string) || '{}') as Record<string, string>,
   };
+
+  if (relevance !== undefined) {
+    result.relevance = relevance;
+  }
 
   if (sourceContext.sourceRepo) {
     result.sourceRepo = sourceContext.sourceRepo;
@@ -233,8 +249,18 @@ function rrfMerge(
     }
   }
 
+  // `rowToSearchResult` recomputes `relevance` from the RETAINED row. Because
+  // the vector leg (listA) is iterated first, a doc present in both legs keeps
+  // its vector row here, so the spread carries the vector-leg `relevance`
+  // through untouched while `score` is overwritten with the RRF value that
+  // drives ordering (mmnto-ai/totem#2463). Ordering is byte-identical to the
+  // pre-#2463 behavior — `relevance`/`searchMethod` never enter the sort key.
   return [...scores.values()]
     .sort((a, b) => b.score - a.score)
     .slice(0, limit)
-    .map(({ score, row }) => ({ ...rowToSearchResult(row, sourceContext), score }));
+    .map(({ score, row }) => ({
+      ...rowToSearchResult(row, sourceContext),
+      score,
+      searchMethod: 'hybrid' as const,
+    }));
 }

--- a/packages/core/src/store/lance-store.test.ts
+++ b/packages/core/src/store/lance-store.test.ts
@@ -5,6 +5,7 @@ import * as path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import type { Embedder } from '../embedders/embedder.js';
+import { TotemConfigError } from '../errors.js';
 import { cleanTmpDir } from '../test-utils.js';
 import type { Chunk } from '../types.js';
 import { escapeSqlString, LanceStore } from './lance-store.js';
@@ -322,6 +323,89 @@ describe('LanceStore', () => {
 
       const results = await store.search({ query: 'gamma', boundary: '', maxResults: 10 });
       expect(results.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('allowFtsFallback (mmnto-ai/totem#2463)', () => {
+    /** Throws the exact no-embedder error that LazyEmbedder.doResolve raises. */
+    class NoEmbedder implements Embedder {
+      readonly dimensions = 8;
+      async embed(): Promise<number[][]> {
+        throw new TotemConfigError(
+          'No embedding provider available. The configured provider failed and Ollama is not running.',
+          'hint',
+          'CONFIG_MISSING',
+        );
+      }
+    }
+
+    /** Throws a NON-embedder error — must always propagate, never degrade. */
+    class BrokenEmbedder implements Embedder {
+      readonly dimensions = 8;
+      async embed(): Promise<number[][]> {
+        throw new Error('LanceDB vector search exploded');
+      }
+    }
+
+    it('degrades to FTS-only when embedder is unavailable, FTS exists, and the flag is set', async () => {
+      // Seed the index + FTS with a working embedder (the outer `store`).
+      await store.insert([
+        makeChunk({ content: 'handles user authentication and login', label: 'auth' }),
+        makeChunk({ content: 'renders the dashboard component', label: 'dash' }),
+      ]);
+      await store.createFtsIndex();
+
+      // A second store over the SAME dir whose embedder cannot resolve.
+      const degraded = new LanceStore(tmpDir, new NoEmbedder(), { absolutePathRoot: tmpDir });
+      await degraded.connect();
+
+      const results = await degraded.search({
+        query: 'authentication',
+        allowFtsFallback: true,
+      });
+
+      expect(results.length).toBeGreaterThan(0);
+      // Success-shaped, method fts, and NO relevance signal on keyword hits.
+      for (const r of results) {
+        expect(r.searchMethod).toBe('fts');
+        expect(r.relevance).toBeUndefined();
+      }
+    });
+
+    it('rethrows the embedder failure when the flag is OFF (today behavior)', async () => {
+      await store.insert([makeChunk({ content: 'authentication content', label: 'auth' })]);
+      await store.createFtsIndex();
+
+      const degraded = new LanceStore(tmpDir, new NoEmbedder(), { absolutePathRoot: tmpDir });
+      await degraded.connect();
+
+      await expect(degraded.search({ query: 'authentication' })).rejects.toThrow(
+        'No embedding provider available',
+      );
+    });
+
+    it('rethrows the embedder failure when the flag is set but NO FTS index exists', async () => {
+      // Seed WITHOUT createFtsIndex → hybrid path off, vector-only, no fallback.
+      await store.insert([makeChunk({ content: 'authentication content', label: 'auth' })]);
+
+      const degraded = new LanceStore(tmpDir, new NoEmbedder(), { absolutePathRoot: tmpDir });
+      await degraded.connect();
+
+      await expect(
+        degraded.search({ query: 'authentication', allowFtsFallback: true }),
+      ).rejects.toThrow('No embedding provider available');
+    });
+
+    it('propagates a NON-embedder error even with the flag set and FTS present', async () => {
+      await store.insert([makeChunk({ content: 'authentication content', label: 'auth' })]);
+      await store.createFtsIndex();
+
+      const broken = new LanceStore(tmpDir, new BrokenEmbedder(), { absolutePathRoot: tmpDir });
+      await broken.connect();
+
+      await expect(
+        broken.search({ query: 'authentication', allowFtsFallback: true }),
+      ).rejects.toThrow('LanceDB vector search exploded');
     });
   });
 

--- a/packages/core/src/store/lance-store.test.ts
+++ b/packages/core/src/store/lance-store.test.ts
@@ -4,8 +4,8 @@ import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
-import { NO_EMBEDDER_AVAILABLE_MESSAGE } from '../embedders/embedder.js';
 import type { Embedder } from '../embedders/embedder.js';
+import { NO_EMBEDDER_AVAILABLE_MESSAGE } from '../embedders/embedder.js';
 import { TotemConfigError } from '../errors.js';
 import { cleanTmpDir } from '../test-utils.js';
 import type { Chunk } from '../types.js';

--- a/packages/core/src/store/lance-store.test.ts
+++ b/packages/core/src/store/lance-store.test.ts
@@ -373,6 +373,40 @@ describe('LanceStore', () => {
       }
     });
 
+    it('invokes onFtsFallback when the degradation engages (out-of-band signal for the zero-row case)', async () => {
+      await store.insert([makeChunk({ content: 'authentication content', label: 'auth' })]);
+      await store.createFtsIndex();
+
+      const degraded = new LanceStore(tmpDir, new NoEmbedder(), { absolutePathRoot: tmpDir });
+      await degraded.connect();
+
+      let fired = false;
+      await degraded.search({
+        query: 'authentication',
+        allowFtsFallback: true,
+        onFtsFallback: () => {
+          fired = true;
+        },
+      });
+      expect(fired).toBe(true);
+    });
+
+    it('does not invoke onFtsFallback on a healthy search', async () => {
+      await store.insert([makeChunk({ content: 'authentication content', label: 'auth' })]);
+      await store.createFtsIndex();
+
+      let fired = false;
+      const results = await store.search({
+        query: 'authentication',
+        allowFtsFallback: true,
+        onFtsFallback: () => {
+          fired = true;
+        },
+      });
+      expect(results.length).toBeGreaterThan(0);
+      expect(fired).toBe(false);
+    });
+
     it('rethrows the embedder failure when the flag is OFF (today behavior)', async () => {
       await store.insert([makeChunk({ content: 'authentication content', label: 'auth' })]);
       await store.createFtsIndex();

--- a/packages/core/src/store/lance-store.test.ts
+++ b/packages/core/src/store/lance-store.test.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { NO_EMBEDDER_AVAILABLE_MESSAGE } from '../embedders/embedder.js';
 import type { Embedder } from '../embedders/embedder.js';
 import { TotemConfigError } from '../errors.js';
 import { cleanTmpDir } from '../test-utils.js';
@@ -327,15 +328,15 @@ describe('LanceStore', () => {
   });
 
   describe('allowFtsFallback (mmnto-ai/totem#2463)', () => {
-    /** Throws the exact no-embedder error that LazyEmbedder.doResolve raises. */
+    /**
+     * Throws the exact no-embedder error that LazyEmbedder.doResolve raises —
+     * via the shared constant, so a wording change at the throw site cannot
+     * silently decouple this suite from the detector it exercises.
+     */
     class NoEmbedder implements Embedder {
       readonly dimensions = 8;
       async embed(): Promise<number[][]> {
-        throw new TotemConfigError(
-          'No embedding provider available. The configured provider failed and Ollama is not running.',
-          'hint',
-          'CONFIG_MISSING',
-        );
+        throw new TotemConfigError(NO_EMBEDDER_AVAILABLE_MESSAGE, 'hint', 'CONFIG_MISSING');
       }
     }
 

--- a/packages/core/src/store/lance-store.ts
+++ b/packages/core/src/store/lance-store.ts
@@ -4,6 +4,7 @@ import * as fs from 'node:fs';
 import * as lancedb from '@lancedb/lancedb';
 
 import type { ContentType } from '../config-schema.js';
+import { NO_EMBEDDER_AVAILABLE_MESSAGE } from '../embedders/embedder.js';
 import type { Embedder } from '../embedders/embedder.js';
 import { TotemConfigError } from '../errors.js';
 import type {
@@ -74,12 +75,14 @@ function closeReadSnapshot(db: lancedb.Connection, onWarn: (msg: string) => void
  * Ollama fallback probe also fails (mmnto-ai/totem#2463). This is the ONLY
  * error class the opt-in FTS fallback is allowed to catch — every other error
  * (LanceDB faults, network blips on a healthy embedder, etc.) must propagate.
- * The message match narrows past the broader `CONFIG_MISSING` code, which also
- * tags unrelated config errors; the `TotemError` constructor prepends
- * `[Totem Error] ` so we substring-match rather than compare exactly.
+ * The match keys on the shared `NO_EMBEDDER_AVAILABLE_MESSAGE` constant (single
+ * source of truth at the throw site), narrowing past the broader
+ * `CONFIG_MISSING` code, which also tags unrelated config errors; the
+ * `TotemError` constructor prepends `[Totem Error] ` so we substring-match
+ * rather than compare exactly.
  */
 function isNoEmbedderError(err: unknown): boolean {
-  return err instanceof TotemConfigError && err.message.includes('No embedding provider available');
+  return err instanceof TotemConfigError && err.message.includes(NO_EMBEDDER_AVAILABLE_MESSAGE);
 }
 
 export class LanceStore {

--- a/packages/core/src/store/lance-store.ts
+++ b/packages/core/src/store/lance-store.ts
@@ -4,8 +4,8 @@ import * as fs from 'node:fs';
 import * as lancedb from '@lancedb/lancedb';
 
 import type { ContentType } from '../config-schema.js';
-import { NO_EMBEDDER_AVAILABLE_MESSAGE } from '../embedders/embedder.js';
 import type { Embedder } from '../embedders/embedder.js';
+import { NO_EMBEDDER_AVAILABLE_MESSAGE } from '../embedders/embedder.js';
 import { TotemConfigError } from '../errors.js';
 import type {
   Chunk,

--- a/packages/core/src/store/lance-store.ts
+++ b/packages/core/src/store/lance-store.ts
@@ -343,6 +343,7 @@ export class LanceStore {
         // than hard-erroring into zero retrieval. Any OTHER error, or a missing
         // flag / FTS index, re-throws unchanged.
         if (options.allowFtsFallback === true && snapshot.hasFtsIndex && isNoEmbedderError(err)) {
+          options.onFtsFallback?.();
           return await runFtsSearch(
             snapshot.table,
             this.onWarn,

--- a/packages/core/src/store/lance-store.ts
+++ b/packages/core/src/store/lance-store.ts
@@ -5,6 +5,7 @@ import * as lancedb from '@lancedb/lancedb';
 
 import type { ContentType } from '../config-schema.js';
 import type { Embedder } from '../embedders/embedder.js';
+import { TotemConfigError } from '../errors.js';
 import type {
   Chunk,
   HealthCheckResult,
@@ -65,6 +66,20 @@ function closeReadSnapshot(db: lancedb.Connection, onWarn: (msg: string) => void
     const msg = err instanceof Error ? err.message : String(err);
     onWarn(`LanceDB read-snapshot close failed: ${msg}`);
   }
+}
+
+/**
+ * Recognize the specific "embedder could not resolve" failure that
+ * `LazyEmbedder.doResolve` throws when the configured provider fails and the
+ * Ollama fallback probe also fails (mmnto-ai/totem#2463). This is the ONLY
+ * error class the opt-in FTS fallback is allowed to catch — every other error
+ * (LanceDB faults, network blips on a healthy embedder, etc.) must propagate.
+ * The message match narrows past the broader `CONFIG_MISSING` code, which also
+ * tags unrelated config errors; the `TotemError` constructor prepends
+ * `[Totem Error] ` so we substring-match rather than compare exactly.
+ */
+function isNoEmbedderError(err: unknown): boolean {
+  return err instanceof TotemConfigError && err.message.includes('No embedding provider available');
 }
 
 export class LanceStore {
@@ -295,28 +310,48 @@ export class LanceStore {
       const boundary = options.boundary;
       const useHybrid = (options.hybrid ?? true) && snapshot.hasFtsIndex;
 
-      if (useHybrid) {
-        return await runHybridSearch(
+      try {
+        if (useHybrid) {
+          return await runHybridSearch(
+            snapshot.table,
+            this.embedder,
+            this.onWarn,
+            options.query,
+            options.typeFilter as ContentType | undefined,
+            maxResults,
+            this.sourceContext,
+            boundary,
+          );
+        }
+
+        return await runVectorSearch(
           snapshot.table,
           this.embedder,
-          this.onWarn,
           options.query,
           options.typeFilter as ContentType | undefined,
           maxResults,
           this.sourceContext,
           boundary,
         );
+      } catch (err) {
+        // Opt-in keyword-only degradation (mmnto-ai/totem#2463). When the
+        // embedder cannot resolve AND the caller allowed it AND an FTS index
+        // exists, fall back to FTS-only search (which needs no embedder) rather
+        // than hard-erroring into zero retrieval. Any OTHER error, or a missing
+        // flag / FTS index, re-throws unchanged.
+        if (options.allowFtsFallback === true && snapshot.hasFtsIndex && isNoEmbedderError(err)) {
+          return await runFtsSearch(
+            snapshot.table,
+            this.onWarn,
+            options.query,
+            options.typeFilter as ContentType | undefined,
+            maxResults,
+            this.sourceContext,
+            boundary,
+          );
+        }
+        throw err;
       }
-
-      return await runVectorSearch(
-        snapshot.table,
-        this.embedder,
-        options.query,
-        options.typeFilter as ContentType | undefined,
-        maxResults,
-        this.sourceContext,
-        boundary,
-      );
     } finally {
       closeReadSnapshot(snapshot.db, this.onWarn);
     }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -112,6 +112,24 @@ export interface SearchResult {
   type: ContentType;
   label: string;
   score: number;
+  /**
+   * True per-hit relevance signal in the 0..1 range — the vector-leg
+   * cosine similarity `1/(1+_distance)` (mmnto-ai/totem#2463). Distinct from
+   * `score`, which in hybrid/federated modes is an RRF rank artifact
+   * (`1/(60+rank)` ≈ 0.016) that carries ordering but destroys the relevance
+   * magnitude. Populated by `rowToSearchResult` for vector-derived rows and
+   * preserved (never overwritten) through both RRF fusion sites. ABSENT iff
+   * the hit had no vector leg (FTS-only), so downstream floor logic can tell
+   * "weak signal" from "no signal at all".
+   */
+  relevance?: number;
+  /**
+   * Which retrieval path produced this hit (mmnto-ai/totem#2463): `'hybrid'`
+   * (vector + FTS with RRF), `'vector'` (vector-only), or `'fts'` (keyword-only
+   * fallback when the embedder is unavailable). Lets agent-facing surfaces
+   * label provenance and route on it.
+   */
+  searchMethod?: 'hybrid' | 'vector' | 'fts';
   metadata: Record<string, string>;
 }
 
@@ -161,6 +179,16 @@ export interface SearchOptions {
   hybrid?: boolean;
   /** File path prefix(es) to restrict results to an architectural boundary. Accepts a single prefix or an array for multi-prefix partitions. */
   boundary?: string | string[];
+  /**
+   * Opt-in keyword-only degradation (mmnto-ai/totem#2463). When true AND the
+   * embedder cannot resolve (the no-embedder `TotemConfigError`) AND an FTS
+   * index exists, `search` degrades to the FTS-only path (results stamped
+   * `searchMethod: 'fts'`, no `relevance`) instead of throwing. When false or
+   * absent, or when no FTS index exists, the embedder failure propagates
+   * unchanged. Only the embedder-resolution failure class is caught — all
+   * other errors propagate untouched.
+   */
+  allowFtsFallback?: boolean;
 }
 
 /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -189,6 +189,14 @@ export interface SearchOptions {
    * other errors propagate untouched.
    */
   allowFtsFallback?: boolean;
+  /**
+   * Invoked when the `allowFtsFallback` degradation actually engages
+   * (mmnto-ai/totem#2463 round 2). Out-of-band on purpose: a fallback that
+   * returns ZERO rows leaves no fts-stamped result to infer from, and callers
+   * (the MCP envelope) must still report the outage rather than a healthy
+   * empty search.
+   */
+  onFtsFallback?: () => void;
 }
 
 /**

--- a/packages/mcp/src/search-log.ts
+++ b/packages/mcp/src/search-log.ts
@@ -9,6 +9,14 @@ export interface SearchLogEntry {
   resultCount: number;
   durationMs: number;
   topScore: number | null;
+  /**
+   * Best per-hit relevance (vector-leg similarity, 0..1) for this query, or
+   * `null` when no hit carried a relevance signal (mmnto-ai/totem#2463).
+   * Recorded alongside `topScore` because `topScore` is an RRF rank artifact in
+   * hybrid/federated modes — `topRelevance` is the calibratable retrieval-quality
+   * signal the pilot floor tuning reads. Optional: absent on pre-#2463 entries.
+   */
+  topRelevance?: number | null;
   error?: string; // eslint-disable-line id-match -- interface property, not a catch binding
   /**
    * A.3.a schema extension (ADR-029 flight-readiness note; ruled in on

--- a/packages/mcp/src/tools/search-knowledge.test.ts
+++ b/packages/mcp/src/tools/search-knowledge.test.ts
@@ -19,6 +19,10 @@ let mockSearchResults: Array<{
   absoluteFilePath?: string;
   score: number;
   content: string;
+  // mmnto-ai/totem#2463: optional relevance + searchMethod so tests can
+  // exercise the floor / envelope / fallback paths.
+  relevance?: number;
+  searchMethod?: 'hybrid' | 'vector' | 'fts';
 }> = [];
 
 let mockHealthCheckResult: {
@@ -66,6 +70,8 @@ let mockLinkedStoreInitErrors: Map<string, string> = new Map();
  * verifies the call site fires with the correct activity_name.
  */
 let mockLogMcpCall: ReturnType<typeof vi.fn>;
+/** mmnto-ai/totem#2463: captured logSearch spy so tests can assert topRelevance. */
+let mockLogSearch: ReturnType<typeof vi.fn>;
 
 vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
   McpServer: class {},
@@ -89,6 +95,7 @@ vi.mock('../context.js', () => ({
         totemDir: '.totem',
         lanceDir: '.totem/.lance',
         contextWarningThreshold: 50_000,
+        searchRelevanceFloor: 0.4,
         partitions: { core: ['packages/core/'] },
       },
       store: {
@@ -201,6 +208,7 @@ describe('search_knowledge', () => {
     mockLinkedStores = new Map();
     mockLinkedStoreInitErrors = new Map();
     mockLogMcpCall = vi.fn(async () => {});
+    mockLogSearch = vi.fn();
 
     // Reset modules to clear the firstHealthCheckDone flag
     vi.resetModules();
@@ -228,6 +236,7 @@ describe('search_knowledge', () => {
             totemDir: '.totem',
             lanceDir: '.totem/.lance',
             contextWarningThreshold: 50_000,
+            searchRelevanceFloor: 0.4,
             partitions: { core: ['packages/core/'] },
           },
           store: {
@@ -285,7 +294,7 @@ describe('search_knowledge', () => {
     }));
 
     vi.doMock('../search-log.js', () => ({
-      logSearch: vi.fn(),
+      logSearch: mockLogSearch,
       setLogDir: vi.fn(),
     }));
 
@@ -1525,6 +1534,271 @@ describe('search_knowledge', () => {
       expect(result.isError).toBeUndefined();
       expect(result.content[0]!.text).toContain('<index-meta status="mocked" />');
       expect(result.content[0]!.text).toContain('No results found');
+    });
+  });
+
+  // --- Retrieval envelope + relevance floor (mmnto-ai/totem#2463) ---
+
+  describe('retrieval envelope + relevance floor (mmnto-ai/totem#2463)', () => {
+    // The whole outcome must parse from the response text with ONE regex
+    // (the wrapper-agent contract).
+    const ENVELOPE_RE =
+      /<retrieval-envelope status="(\w+)" method="(\w+)" bestRelevance="([^"]+)" floor="([^"]+)" hits="(\d+)" \/>/;
+
+    it('emits status="ok" with bestRelevance, floor, and per-hit Relevance', async () => {
+      mockSearchResults = [
+        {
+          label: 'A',
+          type: 'code',
+          filePath: 'src/a.ts',
+          score: 0.016,
+          relevance: 0.83,
+          searchMethod: 'hybrid',
+          content: 'alpha body',
+        },
+        {
+          label: 'B',
+          type: 'code',
+          filePath: 'src/b.ts',
+          score: 0.016,
+          relevance: 0.61,
+          searchMethod: 'hybrid',
+          content: 'beta body',
+        },
+      ];
+
+      const result = (await handle({ query: 'test' })) as {
+        content: Array<{ type: string; text: string }>;
+      };
+      const text = result.content[0]!.text;
+
+      const m = text.match(ENVELOPE_RE);
+      expect(m).not.toBeNull();
+      expect(m![1]).toBe('ok');
+      expect(m![2]).toBe('hybrid');
+      expect(m![3]).toBe('0.830'); // max over hit relevances
+      expect(m![4]).toBe('0.400'); // configured floor (mock config)
+      expect(m![5]).toBe('2');
+
+      // Both Score (RRF, ordering) and Relevance (true signal) are rendered.
+      expect(text).toContain('**Relevance:** 0.830');
+      expect(text).toContain('**Relevance:** 0.610');
+      // status=ok returns full content.
+      expect(text).toContain('alpha body');
+    });
+
+    it('emits the retrieval-envelope directly below the <index-meta> line', async () => {
+      mockSearchResults = [
+        {
+          label: 'A',
+          type: 'code',
+          filePath: 'src/a.ts',
+          score: 0.016,
+          relevance: 0.9,
+          searchMethod: 'hybrid',
+          content: 'body',
+        },
+      ];
+
+      const result = (await handle({ query: 'test' })) as {
+        content: Array<{ type: string; text: string }>;
+      };
+      const text = result.content[0]!.text;
+
+      const idxMeta = text.indexOf('<index-meta');
+      const idxEnv = text.indexOf('<retrieval-envelope');
+      expect(idxMeta).toBeGreaterThanOrEqual(0);
+      expect(idxEnv).toBeGreaterThan(idxMeta);
+      // Only whitespace separates the two envelope lines.
+      const between = text.slice(text.indexOf('/>', idxMeta) + 2, idxEnv);
+      expect(between.trim()).toBe('');
+    });
+
+    it('reports no_useful_hits and discloses below-floor candidates (path + relevance, NO content)', async () => {
+      mockSearchResults = [
+        {
+          label: 'Weak A',
+          type: 'code',
+          filePath: 'src/a.ts',
+          score: 0.016,
+          relevance: 0.2,
+          searchMethod: 'hybrid',
+          content: 'SECRET_BODY_A',
+        },
+        {
+          label: 'Weak B',
+          type: 'code',
+          filePath: 'src/b.ts',
+          score: 0.016,
+          relevance: 0.15,
+          searchMethod: 'hybrid',
+          content: 'SECRET_BODY_B',
+        },
+      ];
+
+      const result = (await handle({ query: 'test' })) as {
+        content: Array<{ type: string; text: string }>;
+      };
+      const text = result.content[0]!.text;
+
+      const m = text.match(ENVELOPE_RE);
+      expect(m![1]).toBe('no_useful_hits');
+      expect(m![3]).toBe('0.200'); // best of the below-floor set
+      expect(m![5]).toBe('2');
+
+      // Candidates disclosed by path + relevance — never silently dropped.
+      expect(text).toContain('/fake/project/src/a.ts');
+      expect(text).toContain('relevance 0.200');
+      expect(text).toContain('relevance 0.150');
+      // ...but their content is withheld.
+      expect(text).not.toContain('SECRET_BODY_A');
+      expect(text).not.toContain('SECRET_BODY_B');
+    });
+
+    it('never fires the floor when no hit carries a relevance signal (bestRelevance n/a)', async () => {
+      // Low RRF score but NO relevance signal → must NOT become no_useful_hits.
+      mockSearchResults = [
+        {
+          label: 'K',
+          type: 'code',
+          filePath: 'src/k.ts',
+          score: 0.016,
+          searchMethod: 'fts',
+          content: 'keyword body',
+        },
+      ];
+
+      const result = (await handle({ query: 'test' })) as {
+        content: Array<{ type: string; text: string }>;
+      };
+      const text = result.content[0]!.text;
+
+      const m = text.match(ENVELOPE_RE);
+      expect(m![1]).toBe('ok');
+      expect(m![3]).toBe('n/a');
+      expect(text).toContain('keyword body'); // content returned, not withheld
+    });
+
+    it('min_relevance overrides the configured floor in both directions', async () => {
+      mockSearchResults = [
+        {
+          label: 'Mid',
+          type: 'code',
+          filePath: 'src/m.ts',
+          score: 0.016,
+          relevance: 0.3,
+          searchMethod: 'hybrid',
+          content: 'mid body',
+        },
+      ];
+
+      // Config floor 0.4 → 0.3 is below → no_useful_hits, floor reported 0.400.
+      const strict = (await handle({ query: 'test' })) as {
+        content: Array<{ type: string; text: string }>;
+      };
+      const ms = strict.content[0]!.text.match(ENVELOPE_RE);
+      expect(ms![1]).toBe('no_useful_hits');
+      expect(ms![4]).toBe('0.400');
+
+      // Override to 0.1 → 0.3 clears the bar → ok, floor reported 0.100.
+      const loose = (await handle({ query: 'test', min_relevance: 0.1 })) as {
+        content: Array<{ type: string; text: string }>;
+      };
+      const ml = loose.content[0]!.text.match(ENVELOPE_RE);
+      expect(ml![1]).toBe('ok');
+      expect(ml![4]).toBe('0.100');
+      expect(loose.content[0]!.text).toContain('mid body');
+    });
+
+    it('preserves relevance through the federation RRF merge (second fusion site)', async () => {
+      mockSearchResults = [
+        {
+          label: 'P',
+          type: 'code',
+          filePath: 'src/p.ts',
+          score: 0.95,
+          relevance: 0.88,
+          searchMethod: 'hybrid',
+          content: 'primary body',
+        },
+      ];
+      mockLinkedStores.set('strategy', {
+        search: vi.fn(async () => [
+          {
+            label: 'S',
+            type: 'spec',
+            filePath: 'adr/s.md',
+            absoluteFilePath: '/abs/strategy/adr/s.md',
+            sourceRepo: 'strategy',
+            score: 0.5,
+            relevance: 0.72,
+            searchMethod: 'hybrid',
+            content: 'strategy body',
+          },
+        ]),
+        reconnect: vi.fn(async () => {}),
+      });
+
+      const result = (await handle({ query: 'test' })) as {
+        content: Array<{ type: string; text: string }>;
+      };
+      const text = result.content[0]!.text;
+
+      // Federation overwrites score with RRF but must carry relevance through.
+      expect(text).toContain('**Relevance:** 0.880');
+      expect(text).toContain('**Relevance:** 0.720');
+      const m = text.match(ENVELOPE_RE);
+      expect(m![3]).toBe('0.880'); // max across federated hits
+    });
+
+    it('degraded embedder: fts-stamped hits surface a keyword-only warning and method="fts"', async () => {
+      mockSearchResults = [
+        {
+          label: 'K1',
+          type: 'code',
+          filePath: 'src/k.ts',
+          score: 1.0,
+          searchMethod: 'fts',
+          content: 'keyword hit body',
+        },
+      ];
+
+      const result = (await handle({ query: 'test' })) as {
+        content: Array<{ type: string; text: string }>;
+        isError?: boolean;
+      };
+      const text = result.content[0]!.text;
+
+      expect(result.isError).toBeUndefined();
+      const m = text.match(ENVELOPE_RE);
+      expect(m![2]).toBe('fts');
+      // Loud, honest degradation warning.
+      expect(text).toContain('[SYSTEM WARNING]');
+      expect(text).toContain('KEYWORD-ONLY');
+      // Keyword hits render Relevance as an explicit n/a note.
+      expect(text).toContain('**Relevance:** n/a (keyword match)');
+    });
+
+    it('logs topRelevance alongside topScore', async () => {
+      mockSearchResults = [
+        {
+          label: 'A',
+          type: 'code',
+          filePath: 'src/a.ts',
+          score: 0.016,
+          relevance: 0.77,
+          searchMethod: 'hybrid',
+          content: 'body',
+        },
+      ];
+
+      await handle({ query: 'test' });
+
+      const call = mockLogSearch.mock.calls.find(
+        (c) => (c[0] as { query?: string }).query === 'test',
+      );
+      expect(call).toBeTruthy();
+      expect((call![0] as { topRelevance?: number | null }).topRelevance).toBeCloseTo(0.77, 3);
     });
   });
 });

--- a/packages/mcp/src/tools/search-knowledge.test.ts
+++ b/packages/mcp/src/tools/search-knowledge.test.ts
@@ -38,6 +38,13 @@ let mockSearchThrows = false;
 let mockSearchThrowsOnce = false;
 let mockReconnectCalled = false;
 /**
+ * mmnto-ai/totem#2494 round 2: when true, the mocked primary `search` invokes
+ * `options.onFtsFallback` before returning — simulating LanceStore's keyword-
+ * only degradation engaging (including the zero-row case, where no fts-stamped
+ * result exists to infer engagement from).
+ */
+let mockSimulateFtsFallback = false;
+/**
  * mmnto/totem#1295 CR minor: number of upcoming `getContext()` calls
  * that should throw before getContext starts returning normally.
  * Decremented on each throw. The test for the one-shot flag fix sets
@@ -99,13 +106,16 @@ vi.mock('../context.js', () => ({
         partitions: { core: ['packages/core/'] },
       },
       store: {
-        search: vi.fn(async () => {
+        search: vi.fn(async (options: Record<string, unknown> = {}) => {
           if (mockSearchThrows) {
             throw new Error('LanceDB search failed');
           }
           if (mockSearchThrowsOnce) {
             mockSearchThrowsOnce = false;
             throw new Error('Stale handle error');
+          }
+          if (mockSimulateFtsFallback) {
+            (options as { onFtsFallback?: () => void }).onFtsFallback?.();
           }
           // Fill in absoluteFilePath from the fake projectRoot when the
           // test didn't set one explicitly — mirrors real LanceStore.
@@ -204,6 +214,7 @@ describe('search_knowledge', () => {
     mockSearchThrows = false;
     mockSearchThrowsOnce = false;
     mockReconnectCalled = false;
+    mockSimulateFtsFallback = false;
     mockGetContextFailuresRemaining = 0;
     mockLinkedStores = new Map();
     mockLinkedStoreInitErrors = new Map();
@@ -240,13 +251,16 @@ describe('search_knowledge', () => {
             partitions: { core: ['packages/core/'] },
           },
           store: {
-            search: vi.fn(async () => {
+            search: vi.fn(async (options: Record<string, unknown> = {}) => {
               if (mockSearchThrows) {
                 throw new Error('LanceDB search failed');
               }
               if (mockSearchThrowsOnce) {
                 mockSearchThrowsOnce = false;
                 throw new Error('Stale handle error');
+              }
+              if (mockSimulateFtsFallback) {
+                (options as { onFtsFallback?: () => void }).onFtsFallback?.();
               }
               // Fill in absoluteFilePath from the fake projectRoot when
               // the test didn't set one explicitly — mirrors LanceStore.
@@ -1644,7 +1658,7 @@ describe('search_knowledge', () => {
       const m = text.match(ENVELOPE_RE);
       expect(m![1]).toBe('no_useful_hits');
       expect(m![3]).toBe('0.200'); // best of the below-floor set
-      expect(m![5]).toBe('2');
+      expect(m![5]).toBe('0'); // hits counts RETURNED hits — candidates are disclosed, not returned
 
       // Candidates disclosed by path + relevance — never silently dropped.
       expect(text).toContain('/fake/project/src/a.ts');
@@ -1653,6 +1667,69 @@ describe('search_knowledge', () => {
       // ...but their content is withheld.
       expect(text).not.toContain('SECRET_BODY_A');
       expect(text).not.toContain('SECRET_BODY_B');
+    });
+
+    it('returns floor-exempt keyword hits from a mixed batch and discloses only the withheld signal-bearing ones', async () => {
+      // greptile P1 (mmnto-ai/totem#2494 round 2): a keyword-only hit has no
+      // comparable relevance signal — it must never be withheld because a
+      // vector-leg sibling scored below the floor.
+      mockSearchResults = [
+        {
+          label: 'Keyword hit',
+          type: 'code',
+          filePath: 'src/k.ts',
+          score: 0.016,
+          searchMethod: 'fts',
+          content: 'KEYWORD_BODY',
+        },
+        {
+          label: 'Weak vector hit',
+          type: 'code',
+          filePath: 'src/w.ts',
+          score: 0.016,
+          relevance: 0.2,
+          searchMethod: 'hybrid',
+          content: 'WEAK_VECTOR_BODY',
+        },
+      ];
+
+      const result = (await handle({ query: 'test' })) as {
+        content: Array<{ type: string; text: string }>;
+      };
+      const text = result.content[0]!.text;
+
+      const m = text.match(ENVELOPE_RE);
+      expect(m![1]).toBe('ok'); // exempt hits ARE returned
+      expect(m![3]).toBe('0.200'); // bestRelevance still reports the below-floor max
+      expect(m![5]).toBe('1'); // hits counts RETURNED hits (the exempt subset)
+
+      // The keyword hit's content is returned...
+      expect(text).toContain('KEYWORD_BODY');
+      // ...the below-floor vector hit is disclosed (path + relevance), content withheld.
+      expect(text).toContain('/fake/project/src/w.ts');
+      expect(text).toContain('relevance 0.200');
+      expect(text).not.toContain('WEAK_VECTOR_BODY');
+    });
+
+    it('reports method="fts" + the keyword-only warning when the fallback returns zero rows', async () => {
+      // greptile P1 (mmnto-ai/totem#2494 round 2): a zero-row fallback leaves
+      // no fts-stamped hit — engagement must surface via the out-of-band
+      // callback, or an embedder outage masquerades as a healthy empty search.
+      mockSimulateFtsFallback = true;
+      mockSearchResults = [];
+
+      const result = (await handle({ query: 'test' })) as {
+        content: Array<{ type: string; text: string }>;
+        isError?: boolean;
+      };
+      const text = result.content[0]!.text;
+
+      expect(result.isError).toBeUndefined();
+      const m = text.match(ENVELOPE_RE);
+      expect(m![1]).toBe('empty');
+      expect(m![2]).toBe('fts'); // NOT "hybrid" — the outage is visible
+      expect(text).toContain('KEYWORD-ONLY');
+      expect(text).toContain('No results found');
     });
 
     it('never fires the floor when no hit carries a relevance signal (bestRelevance n/a)', async () => {

--- a/packages/mcp/src/tools/search-knowledge.ts
+++ b/packages/mcp/src/tools/search-knowledge.ts
@@ -186,11 +186,16 @@ function formatResult(r: SearchResult, index: number): string {
   const labelWithTag = r.sourceRepo ? `[${r.sourceRepo}] ` + r.label : r.label;
   // mmnto-ai/totem#2463: surface the true relevance signal alongside the
   // ordering `score`. `score` stays (RRF rank artifact — drives display order);
-  // `relevance` is the vector-leg similarity, or an explicit keyword-match note
-  // when the hit had no vector leg (FTS-only), so the agent never mistakes an
-  // absent signal for a low one.
+  // `relevance` is the vector-leg similarity, so the agent never mistakes an
+  // absent signal for a low one. The "keyword match" note is reserved for
+  // fts-stamped hits — a vector/hybrid hit that (defensively) lacks relevance
+  // shows a bare "n/a" rather than being mislabeled as a keyword match.
   const relevanceField =
-    typeof r.relevance === 'number' ? r.relevance.toFixed(3) : 'n/a (keyword match)';
+    typeof r.relevance === 'number'
+      ? r.relevance.toFixed(3)
+      : r.searchMethod === 'fts'
+        ? 'n/a (keyword match)'
+        : 'n/a';
   // mmnto/totem#1295 CR MAJOR: ALWAYS display the absolute path. The whole
   // point of `absoluteFilePath` on `SearchResult` is to give agents an
   // unambiguous Read/Edit target. Falling back to the relative `filePath`
@@ -266,6 +271,7 @@ async function federatedSearch(
               maxResults: perStoreLimit,
               allowFtsFallback: true,
             });
+            // totem-context: mmnto-ai/totem#1295 — the catch below is not a silent swallow; the failure is recorded in `failures.primary` and surfaced to the agent as a per-query system warning.
           } catch (retryErr) {
             const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
             const combinedMsg = `search failed (initial: ${firstMsg}; reconnect+retry: ${retryMsg})`;

--- a/packages/mcp/src/tools/search-knowledge.ts
+++ b/packages/mcp/src/tools/search-knowledge.ts
@@ -4,7 +4,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
 
 import type { ContentType, HealthCheckResult, SearchResult } from '@mmnto/totem';
-import { ContentTypeSchema } from '@mmnto/totem';
+import { ContentTypeSchema, DEFAULT_SEARCH_RELEVANCE_FLOOR } from '@mmnto/totem';
 
 import { getContext, reconnectStore } from '../context.js';
 import { logMcpCall } from '../ledger-writer.js';
@@ -241,6 +241,7 @@ async function federatedSearch(
   perStoreLimit: number,
   finalLimit: number,
   failures: FailureLog,
+  onFtsFallback: () => void,
 ): Promise<SearchResult[]> {
   const { store: primaryStore, linkedStores } = await getContext();
 
@@ -260,7 +261,13 @@ async function federatedSearch(
   const hasLinkedStores = linkedStores.size > 0;
   const primaryPromise = hasLinkedStores
     ? primaryStore
-        .search({ query, typeFilter, maxResults: perStoreLimit, allowFtsFallback: true })
+        .search({
+          query,
+          typeFilter,
+          maxResults: perStoreLimit,
+          allowFtsFallback: true,
+          onFtsFallback,
+        })
         .catch(async (err: unknown) => {
           const firstMsg = err instanceof Error ? err.message : String(err);
           try {
@@ -270,6 +277,7 @@ async function federatedSearch(
               typeFilter,
               maxResults: perStoreLimit,
               allowFtsFallback: true,
+              onFtsFallback,
             });
             // totem-context: mmnto-ai/totem#1295 — the catch below is not a silent swallow; the failure is recorded in `failures.primary` and surfaced to the agent as a per-query system warning.
           } catch (retryErr) {
@@ -287,7 +295,13 @@ async function federatedSearch(
             return [] as SearchResult[];
           }
         })
-    : primaryStore.search({ query, typeFilter, maxResults: perStoreLimit, allowFtsFallback: true });
+    : primaryStore.search({
+        query,
+        typeFilter,
+        maxResults: perStoreLimit,
+        allowFtsFallback: true,
+        onFtsFallback,
+      });
 
   // Linked stores: catch per-store failures so one broken linked index
   // doesn't break the overall query. On failure, attempt targeted
@@ -297,7 +311,13 @@ async function federatedSearch(
   // can try again (the transient issue may have cleared).
   const linkedPromises = Array.from(linkedStores.entries()).map(([name, ls]) =>
     ls
-      .search({ query, typeFilter, maxResults: perStoreLimit, allowFtsFallback: true })
+      .search({
+        query,
+        typeFilter,
+        maxResults: perStoreLimit,
+        allowFtsFallback: true,
+        onFtsFallback,
+      })
       .catch(async (err) => {
         const firstMsg = err instanceof Error ? err.message : String(err);
         try {
@@ -307,6 +327,7 @@ async function federatedSearch(
             typeFilter,
             maxResults: perStoreLimit,
             allowFtsFallback: true,
+            onFtsFallback,
           });
           // totem-context: mmnto-ai/totem#1295 — the catch below is not a silent swallow; the failure is recorded in `failures.linked` and surfaced to the agent as a per-query system warning.
         } catch (retryErr) {
@@ -388,7 +409,9 @@ function deriveSearchMethod(results: SearchResult[]): 'hybrid' | 'vector' | 'fts
  * below the `<index-meta>` line and shares its self-closing XML-attribute shape
  * so a wrapper agent can read the whole outcome with one regex. Every attribute
  * value is a closed enum or a formatted number — no user input — so no XML
- * escaping is required.
+ * escaping is required. `hits` counts RETURNED hits: 0 for `no_useful_hits`
+ * (candidates are disclosed, not returned) and the floor-exempt subset for a
+ * mixed below-floor batch.
  */
 export function formatRetrievalEnvelope(params: {
   status: 'ok' | 'no_useful_hits' | 'empty';
@@ -463,6 +486,14 @@ async function performSearch(
   // hits. The agent would think it's querying the linked repo but get
   // local results — exactly the "silent drift" pattern Tenet 4 forbids.
   // Shield AI catch on mmnto/totem#1294 Phase 2 review.
+  // Out-of-band FTS-fallback signal (greptile P1, mmnto-ai/totem#2494 round 2):
+  // a fallback that returns ZERO rows leaves no fts-stamped result to infer
+  // from, so engagement is captured via callback — the envelope must report
+  // the embedder outage even on an empty keyword result set.
+  let ftsFallbackEngaged = false;
+  const onFtsFallback = (): void => {
+    ftsFallbackEngaged = true;
+  };
   let results: SearchResult[];
   if (boundary !== undefined && config.partitions?.[boundary]) {
     // Case 1: local partition — primary only, prefix filter
@@ -473,6 +504,7 @@ async function performSearch(
       maxResults: finalLimit,
       boundary: config.partitions[boundary],
       allowFtsFallback: true,
+      onFtsFallback,
     });
   } else if (boundary !== undefined && linkedStores.has(boundary)) {
     // Case 2: linked store name — route ONLY to that linked store.
@@ -491,6 +523,7 @@ async function performSearch(
         typeFilter,
         maxResults: finalLimit,
         allowFtsFallback: true,
+        onFtsFallback,
       });
       // totem-context: mmnto-ai/totem#1295 — the catch below is not a silent swallow; a fully-failed targeted boundary (initial AND reconnect+retry throw) is surfaced to the agent as an isError ToolResult.
     } catch (err) {
@@ -502,7 +535,9 @@ async function performSearch(
           typeFilter,
           maxResults: finalLimit,
           allowFtsFallback: true,
+          onFtsFallback,
         });
+        // totem-context: mmnto-ai/totem#1295 — the catch below is not a silent swallow; the double failure (initial AND reconnect+retry) is surfaced to the agent as an isError ToolResult.
       } catch (retryErr) {
         const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
         const errorText = formatSystemWarning(
@@ -547,13 +582,21 @@ async function performSearch(
       maxResults: finalLimit,
       boundary,
       allowFtsFallback: true,
+      onFtsFallback,
     });
   } else {
     // Case 5: no boundary → federated search across primary + all linked.
     // Pass the `failures` log so the federation path can populate it on
     // store errors without mutating global state. Primary lives in a
     // dedicated slot to avoid colliding with linked-store names.
-    results = await federatedSearch(query, typeFilter, finalLimit, finalLimit, failures);
+    results = await federatedSearch(
+      query,
+      typeFilter,
+      finalLimit,
+      finalLimit,
+      failures,
+      onFtsFallback,
+    );
   }
 
   // Build the runtime-failures warning (if any) once so we can decide
@@ -629,13 +672,18 @@ async function performSearch(
   // every fused hit as noise. The envelope discloses the outcome machine-
   // readably beside the existing <index-meta> line.
   const configuredFloor =
-    typeof config.searchRelevanceFloor === 'number' ? config.searchRelevanceFloor : 0.25;
+    typeof config.searchRelevanceFloor === 'number'
+      ? config.searchRelevanceFloor
+      : DEFAULT_SEARCH_RELEVANCE_FLOOR;
   const effectiveFloor = minRelevance !== undefined ? minRelevance : configuredFloor;
-  const method = deriveSearchMethod(results);
+  // A zero-row fallback leaves nothing fts-stamped — the callback flag keeps
+  // the envelope method honest for an empty keyword-only result set
+  // (greptile P1, mmnto-ai/totem#2494 round 2).
+  const method = results.length === 0 && ftsFallbackEngaged ? 'fts' : deriveSearchMethod(results);
 
-  // Loud degradation notice (Tenet 4 — fail honest): any fts-stamped hit means
-  // a store's embedder was unavailable and search fell back to keyword-only.
-  const fallbackEngaged = results.some((r) => r.searchMethod === 'fts');
+  // Loud degradation notice (Tenet 4 — fail honest): fallback engagement is
+  // signaled out-of-band (zero-row case) OR inferred from any fts-stamped hit.
+  const fallbackEngaged = ftsFallbackEngaged || results.some((r) => r.searchMethod === 'fts');
   const fallbackWarning = fallbackEngaged
     ? formatSystemWarning(
         [
@@ -689,37 +737,72 @@ async function performSearch(
   }
 
   // Floor fires ONLY when a real relevance signal exists — a pure-FTS corpus
-  // (no vector relevance to report) is never demoted to no_useful_hits.
+  // (no vector relevance to report) is never demoted to no_useful_hits. And it
+  // judges ONLY the hits that carry a signal: keyword-only hits have no
+  // comparable relevance and are floor-EXEMPT — a mixed batch must never
+  // withhold them because their vector-leg siblings scored weak (greptile P1,
+  // mmnto-ai/totem#2494 round 2).
   if (hasRelevanceSignal && bestRelevance !== null && bestRelevance < effectiveFloor) {
-    const belowFloorEnvelope = formatRetrievalEnvelope({
-      status: 'no_useful_hits',
-      method,
-      bestRelevance,
-      floor: effectiveFloor,
-      hits: results.length,
-    });
-    // Disclose every below-floor candidate compactly (path + relevance, NO
-    // content) — exclusion is disclosed, never silently dropped (Prop 308 F1).
-    const candidateLines = results.map((r, i) => {
+    const floorExempt = results.filter((r) => typeof r.relevance !== 'number');
+    const withheld = results.filter((r) => typeof r.relevance === 'number');
+    // Disclose every withheld below-floor candidate compactly (path +
+    // relevance, NO content) — exclusion is disclosed, never silently
+    // dropped (Prop 308 F1).
+    const candidateLines = withheld.map((r, i) => {
       const rel = typeof r.relevance === 'number' ? r.relevance.toFixed(3) : 'n/a';
       const label = r.sourceRepo ? `[${r.sourceRepo}] ` + r.absoluteFilePath : r.absoluteFilePath;
       return `${i + 1}. ${label} — relevance ${rel}`;
     });
-    const body = formatXmlResponse(
-      'knowledge',
-      [
-        `No results met the relevance floor of ${effectiveFloor.toFixed(3)} (best relevance ${bestRelevance.toFixed(3)}).`,
-        '',
-        'Below-floor candidates (disclosed, not returned — path + relevance only):',
-        ...candidateLines,
-      ].join('\n'),
-    );
+    const disclosure = [
+      `Below-floor candidates (disclosed, not returned — path + relevance only; floor ${effectiveFloor.toFixed(3)}, best relevance ${bestRelevance.toFixed(3)}):`,
+      ...candidateLines,
+    ].join('\n');
+
+    if (floorExempt.length === 0) {
+      // Every hit carried a below-floor signal → honest no_useful_hits.
+      const belowFloorEnvelope = formatRetrievalEnvelope({
+        status: 'no_useful_hits',
+        method,
+        bestRelevance,
+        floor: effectiveFloor,
+        hits: 0,
+      });
+      const body = formatXmlResponse(
+        'knowledge',
+        [
+          `No results met the relevance floor of ${effectiveFloor.toFixed(3)} (best relevance ${bestRelevance.toFixed(3)}).`,
+          '',
+          disclosure,
+        ].join('\n'),
+      );
+      const text = composeResponseText({
+        fallbackWarning,
+        runtimeWarning,
+        staleWarning,
+        indexEnvelope,
+        retrievalEnvelope: belowFloorEnvelope,
+        body,
+      }); // totem-ignore mmnto-ai/totem#1294 — composed from system-generated + XML-wrapped pieces
+      return { content: [{ type: 'text' as const, text }] };
+    }
+
+    // Mixed batch: return the floor-exempt keyword hits, disclose the
+    // withheld signal-bearing ones alongside.
+    const mixedEnvelope = formatRetrievalEnvelope({
+      status: 'ok',
+      method,
+      bestRelevance,
+      floor: effectiveFloor,
+      hits: floorExempt.length,
+    });
+    const formattedExempt = floorExempt.map((r, i) => formatResult(r, i)).join('\n\n---\n\n');
+    const body = formatXmlResponse('knowledge', formattedExempt + '\n\n---\n\n' + disclosure);
     const text = composeResponseText({
       fallbackWarning,
       runtimeWarning,
       staleWarning,
       indexEnvelope,
-      retrievalEnvelope: belowFloorEnvelope,
+      retrievalEnvelope: mixedEnvelope,
       body,
     }); // totem-ignore mmnto-ai/totem#1294 — composed from system-generated + XML-wrapped pieces
     return { content: [{ type: 'text' as const, text }] };
@@ -859,6 +942,7 @@ export function registerSearchKnowledge(server: McpServer): void {
         try {
           const { projectRoot, config } = await getContext();
           setLogDir(path.join(projectRoot, config.totemDir));
+          // totem-context: best-effort log-dir init — the catch below records the failure via logSearch and must not block the tool call.
         } catch (err) {
           // Non-fatal — logging just won't write to disk. Record the failure.
           logSearch({

--- a/packages/mcp/src/tools/search-knowledge.ts
+++ b/packages/mcp/src/tools/search-knowledge.ts
@@ -184,6 +184,13 @@ function formatResult(r: SearchResult, index: number): string {
   // joined with explicit `+` rather than two adjacent template placeholders
   // (which the concat-without-delimiter lint rule flags).
   const labelWithTag = r.sourceRepo ? `[${r.sourceRepo}] ` + r.label : r.label;
+  // mmnto-ai/totem#2463: surface the true relevance signal alongside the
+  // ordering `score`. `score` stays (RRF rank artifact — drives display order);
+  // `relevance` is the vector-leg similarity, or an explicit keyword-match note
+  // when the hit had no vector leg (FTS-only), so the agent never mistakes an
+  // absent signal for a low one.
+  const relevanceField =
+    typeof r.relevance === 'number' ? r.relevance.toFixed(3) : 'n/a (keyword match)';
   // mmnto/totem#1295 CR MAJOR: ALWAYS display the absolute path. The whole
   // point of `absoluteFilePath` on `SearchResult` is to give agents an
   // unambiguous Read/Edit target. Falling back to the relative `filePath`
@@ -191,7 +198,7 @@ function formatResult(r: SearchResult, index: number): string {
   // exactly the bug that field was added to fix.
   return (
     `### ${index + 1}. ${labelWithTag} (${r.type})\n` +
-    `**File:** ${r.absoluteFilePath} | **Score:** ${r.score.toFixed(3)}\n\n` +
+    `**File:** ${r.absoluteFilePath} | **Score:** ${r.score.toFixed(3)} | **Relevance:** ${relevanceField}\n\n` +
     r.content
   );
 }
@@ -248,12 +255,17 @@ async function federatedSearch(
   const hasLinkedStores = linkedStores.size > 0;
   const primaryPromise = hasLinkedStores
     ? primaryStore
-        .search({ query, typeFilter, maxResults: perStoreLimit })
+        .search({ query, typeFilter, maxResults: perStoreLimit, allowFtsFallback: true })
         .catch(async (err: unknown) => {
           const firstMsg = err instanceof Error ? err.message : String(err);
           try {
             await primaryStore.reconnect();
-            return await primaryStore.search({ query, typeFilter, maxResults: perStoreLimit });
+            return await primaryStore.search({
+              query,
+              typeFilter,
+              maxResults: perStoreLimit,
+              allowFtsFallback: true,
+            });
           } catch (retryErr) {
             const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
             const combinedMsg = `search failed (initial: ${firstMsg}; reconnect+retry: ${retryMsg})`;
@@ -269,7 +281,7 @@ async function federatedSearch(
             return [] as SearchResult[];
           }
         })
-    : primaryStore.search({ query, typeFilter, maxResults: perStoreLimit });
+    : primaryStore.search({ query, typeFilter, maxResults: perStoreLimit, allowFtsFallback: true });
 
   // Linked stores: catch per-store failures so one broken linked index
   // doesn't break the overall query. On failure, attempt targeted
@@ -278,26 +290,34 @@ async function federatedSearch(
   // mutated here — the store stays in `linkedStores` so the next query
   // can try again (the transient issue may have cleared).
   const linkedPromises = Array.from(linkedStores.entries()).map(([name, ls]) =>
-    ls.search({ query, typeFilter, maxResults: perStoreLimit }).catch(async (err) => {
-      const firstMsg = err instanceof Error ? err.message : String(err);
-      try {
-        await ls.reconnect();
-        return await ls.search({ query, typeFilter, maxResults: perStoreLimit });
-      } catch (retryErr) {
-        const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
-        const combinedMsg = `search failed (initial: ${firstMsg}; reconnect+retry: ${retryMsg})`;
-        logSearch({
-          timestamp: new Date().toISOString(),
-          query: `internal:linked-store-search:${name}`,
-          resultCount: 0,
-          durationMs: 0,
-          topScore: null,
-          error: `Linked store "${name}" ${combinedMsg}`,
-        });
-        failures.linked.set(name, combinedMsg);
-        return [] as SearchResult[];
-      }
-    }),
+    ls
+      .search({ query, typeFilter, maxResults: perStoreLimit, allowFtsFallback: true })
+      .catch(async (err) => {
+        const firstMsg = err instanceof Error ? err.message : String(err);
+        try {
+          await ls.reconnect();
+          return await ls.search({
+            query,
+            typeFilter,
+            maxResults: perStoreLimit,
+            allowFtsFallback: true,
+          });
+          // totem-context: mmnto-ai/totem#1295 — the catch below is not a silent swallow; the failure is recorded in `failures.linked` and surfaced to the agent as a per-query system warning.
+        } catch (retryErr) {
+          const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
+          const combinedMsg = `search failed (initial: ${firstMsg}; reconnect+retry: ${retryMsg})`;
+          logSearch({
+            timestamp: new Date().toISOString(),
+            query: `internal:linked-store-search:${name}`,
+            resultCount: 0,
+            durationMs: 0,
+            topScore: null,
+            error: `Linked store "${name}" ${combinedMsg}`,
+          });
+          failures.linked.set(name, combinedMsg);
+          return [] as SearchResult[];
+        }
+      }),
   );
 
   const [primaryResults, ...linkedResults] = await Promise.all([primaryPromise, ...linkedPromises]);
@@ -328,6 +348,11 @@ async function federatedSearch(
   //
   // RRF k=60 matches the constant used inside `LanceStore.rrfMerge` for
   // intra-store hybrid fusion, for consistency.
+  //
+  // mmnto-ai/totem#2463: the `{ ...r }` spread carries each hit's `relevance`
+  // and `searchMethod` through untouched — this second fusion site overwrites
+  // ONLY `score`, exactly as the intra-store `rrfMerge` does, so the true
+  // relevance signal survives federation just as it survives single-store mode.
   const RRF_K_FEDERATION = 60;
   const reranked: SearchResult[] = [];
   for (const bucket of buckets) {
@@ -339,11 +364,46 @@ async function federatedSearch(
   return reranked.slice(0, finalLimit);
 }
 
+/**
+ * Which retrieval path the returned hits came from, for the envelope's
+ * `method` attribute (mmnto-ai/totem#2463). Any fts-stamped hit means a store
+ * degraded to keyword-only, so `fts` is reported to keep the envelope method in
+ * lockstep with the loud fallback warning. All hits vector-only → `vector`;
+ * otherwise (default / mixed / empty) → `hybrid`.
+ */
+function deriveSearchMethod(results: SearchResult[]): 'hybrid' | 'vector' | 'fts' {
+  if (results.some((r) => r.searchMethod === 'fts')) return 'fts';
+  if (results.length > 0 && results.every((r) => r.searchMethod === 'vector')) return 'vector';
+  return 'hybrid';
+}
+
+/**
+ * Machine-parsable retrieval outcome line (mmnto-ai/totem#2463). Sits directly
+ * below the `<index-meta>` line and shares its self-closing XML-attribute shape
+ * so a wrapper agent can read the whole outcome with one regex. Every attribute
+ * value is a closed enum or a formatted number — no user input — so no XML
+ * escaping is required.
+ */
+export function formatRetrievalEnvelope(params: {
+  status: 'ok' | 'no_useful_hits' | 'empty';
+  method: 'hybrid' | 'vector' | 'fts';
+  bestRelevance: number | null;
+  floor: number;
+  hits: number;
+}): string {
+  const best = params.bestRelevance !== null ? params.bestRelevance.toFixed(3) : 'n/a';
+  return (
+    `<retrieval-envelope status="${params.status}" method="${params.method}" ` +
+    `bestRelevance="${best}" floor="${params.floor.toFixed(3)}" hits="${params.hits}" />`
+  );
+}
+
 async function performSearch(
   query: string,
   typeFilter?: ContentType,
   maxResults?: number,
   boundary?: string,
+  minRelevance?: number,
 ): Promise<ToolResult> {
   const { config, linkedStores, linkedStoreInitErrors, projectRoot } = await getContext();
   const finalLimit = maxResults ?? 5;
@@ -406,6 +466,7 @@ async function performSearch(
       typeFilter,
       maxResults: finalLimit,
       boundary: config.partitions[boundary],
+      allowFtsFallback: true,
     });
   } else if (boundary !== undefined && linkedStores.has(boundary)) {
     // Case 2: linked store name — route ONLY to that linked store.
@@ -419,12 +480,23 @@ async function performSearch(
     // real outage as an absence of relevant knowledge.
     const linked = linkedStores.get(boundary)!;
     try {
-      results = await linked.search({ query, typeFilter, maxResults: finalLimit });
+      results = await linked.search({
+        query,
+        typeFilter,
+        maxResults: finalLimit,
+        allowFtsFallback: true,
+      });
+      // totem-context: mmnto-ai/totem#1295 — the catch below is not a silent swallow; a fully-failed targeted boundary (initial AND reconnect+retry throw) is surfaced to the agent as an isError ToolResult.
     } catch (err) {
       const firstMsg = err instanceof Error ? err.message : String(err);
       try {
         await linked.reconnect();
-        results = await linked.search({ query, typeFilter, maxResults: finalLimit });
+        results = await linked.search({
+          query,
+          typeFilter,
+          maxResults: finalLimit,
+          allowFtsFallback: true,
+        });
       } catch (retryErr) {
         const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
         const errorText = formatSystemWarning(
@@ -468,6 +540,7 @@ async function performSearch(
       typeFilter,
       maxResults: finalLimit,
       boundary,
+      allowFtsFallback: true,
     });
   } else {
     // Case 5: no boundary → federated search across primary + all linked.
@@ -542,6 +615,40 @@ async function performSearch(
     failures.primary !== null &&
     failures.linked.size === linkedStores.size;
 
+  // ─── Retrieval envelope + relevance floor (mmnto-ai/totem#2463) ──
+  //
+  // Floor on the TRUE relevance signal (`r.relevance`, vector-leg similarity),
+  // NEVER on the displayed `score` — that is an RRF rank artifact (≈0.016 by
+  // construction in hybrid/federated modes), so a floor over it would classify
+  // every fused hit as noise. The envelope discloses the outcome machine-
+  // readably beside the existing <index-meta> line.
+  const configuredFloor =
+    typeof config.searchRelevanceFloor === 'number' ? config.searchRelevanceFloor : 0.25;
+  const effectiveFloor = minRelevance !== undefined ? minRelevance : configuredFloor;
+  const method = deriveSearchMethod(results);
+
+  // Loud degradation notice (Tenet 4 — fail honest): any fts-stamped hit means
+  // a store's embedder was unavailable and search fell back to keyword-only.
+  const fallbackEngaged = results.some((r) => r.searchMethod === 'fts');
+  const fallbackWarning = fallbackEngaged
+    ? formatSystemWarning(
+        [
+          'Embedding provider unavailable — search degraded to KEYWORD-ONLY (FTS) results.',
+          '',
+          'These matches carry NO semantic relevance signal (relevance is n/a); vector-similarity ranking is disabled until the embedder is restored. Fix the configured provider/API key or start Ollama, then retry for semantic results. (mmnto-ai/totem#2463)',
+        ].join('\n'),
+      )
+    : null;
+
+  // Best relevance = max over hits that CARRY a relevance signal. Empty-safe:
+  // only spread into Math.max when non-empty (else it yields -Infinity). `null`
+  // encodes "no hit carried a relevance signal" — the floor never fires then.
+  const relevances = results
+    .map((r) => r.relevance)
+    .filter((x): x is number => typeof x === 'number');
+  const hasRelevanceSignal = relevances.length > 0;
+  const bestRelevance = hasRelevanceSignal ? Math.max(...relevances) : null;
+
   if (results.length === 0) {
     if (allFederatedStoresFailed) {
       return {
@@ -550,26 +657,86 @@ async function performSearch(
             type: 'text' as const,
             text:
               runtimeWarning ??
-              '[Totem Error] Federated search failed: every queried store errored.', // totem-ignore #1294 — system-generated + XML-wrapped
+              '[Totem Error] Federated search failed: every queried store errored.', // totem-ignore mmnto-ai/totem#1294 — system-generated + XML-wrapped
           },
         ],
         isError: true,
       };
     }
+    const emptyEnvelope = formatRetrievalEnvelope({
+      status: 'empty',
+      method,
+      bestRelevance,
+      floor: effectiveFloor,
+      hits: 0,
+    });
     const body = formatXmlResponse('knowledge', 'No results found.');
-    const text = composeResponseText({ runtimeWarning, staleWarning, indexEnvelope, body }); // totem-ignore #1294 — composed from system-generated + XML-wrapped pieces
+    const text = composeResponseText({
+      fallbackWarning,
+      runtimeWarning,
+      staleWarning,
+      indexEnvelope,
+      retrievalEnvelope: emptyEnvelope,
+      body,
+    }); // totem-ignore mmnto-ai/totem#1294 — composed from system-generated + XML-wrapped pieces
     return { content: [{ type: 'text' as const, text }] };
   }
 
+  // Floor fires ONLY when a real relevance signal exists — a pure-FTS corpus
+  // (no vector relevance to report) is never demoted to no_useful_hits.
+  if (hasRelevanceSignal && bestRelevance !== null && bestRelevance < effectiveFloor) {
+    const belowFloorEnvelope = formatRetrievalEnvelope({
+      status: 'no_useful_hits',
+      method,
+      bestRelevance,
+      floor: effectiveFloor,
+      hits: results.length,
+    });
+    // Disclose every below-floor candidate compactly (path + relevance, NO
+    // content) — exclusion is disclosed, never silently dropped (Prop 308 F1).
+    const candidateLines = results.map((r, i) => {
+      const rel = typeof r.relevance === 'number' ? r.relevance.toFixed(3) : 'n/a';
+      const label = r.sourceRepo ? `[${r.sourceRepo}] ` + r.absoluteFilePath : r.absoluteFilePath;
+      return `${i + 1}. ${label} — relevance ${rel}`;
+    });
+    const body = formatXmlResponse(
+      'knowledge',
+      [
+        `No results met the relevance floor of ${effectiveFloor.toFixed(3)} (best relevance ${bestRelevance.toFixed(3)}).`,
+        '',
+        'Below-floor candidates (disclosed, not returned — path + relevance only):',
+        ...candidateLines,
+      ].join('\n'),
+    );
+    const text = composeResponseText({
+      fallbackWarning,
+      runtimeWarning,
+      staleWarning,
+      indexEnvelope,
+      retrievalEnvelope: belowFloorEnvelope,
+      body,
+    }); // totem-ignore mmnto-ai/totem#1294 — composed from system-generated + XML-wrapped pieces
+    return { content: [{ type: 'text' as const, text }] };
+  }
+
+  const okEnvelope = formatRetrievalEnvelope({
+    status: 'ok',
+    method,
+    bestRelevance,
+    floor: effectiveFloor,
+    hits: results.length,
+  });
   const formatted = results.map((r, i) => formatResult(r, i)).join('\n\n---\n\n');
 
   const knowledgeBody = formatXmlResponse('knowledge', formatted);
   let text = composeResponseText({
+    fallbackWarning,
     runtimeWarning,
     staleWarning,
     indexEnvelope,
+    retrievalEnvelope: okEnvelope,
     body: knowledgeBody,
-  }); // totem-ignore #1294 — composed from system-generated + XML-wrapped pieces
+  }); // totem-ignore mmnto-ai/totem#1294 — composed from system-generated + XML-wrapped pieces
 
   // Append a system warning when the payload is large enough to risk context pressure
   if (text.length > config.contextWarningThreshold) {
@@ -588,24 +755,31 @@ async function performSearch(
  * Compose the final response text by stacking diagnostics on top of the
  * knowledge body. Order (outermost → innermost):
  *
- *   1. runtime warning (per-call store failures from federatedSearch)
- *   2. STALE warning (knowledge index >7 days old; mmnto-ai/totem#2029)
- *   3. index-meta envelope (always-present freshness metadata)
- *   4. body (the wrapped `<knowledge>` block OR "no results")
+ *   1. fallback warning (embedder down → keyword-only; mmnto-ai/totem#2463)
+ *   2. runtime warning (per-call store failures from federatedSearch)
+ *   3. STALE warning (knowledge index >7 days old; mmnto-ai/totem#2029)
+ *   4. index-meta envelope (always-present freshness metadata)
+ *   5. retrieval envelope (machine-parsable outcome; mmnto-ai/totem#2463) —
+ *      emitted directly below <index-meta> so both parse as adjacent XML lines
+ *   6. body (the wrapped `<knowledge>` block OR "no results")
  *
  * Pieces are joined by blank lines so each is its own logical block in
  * the agent's view. Null pieces are omitted; the body is required.
  */
 function composeResponseText(parts: {
+  fallbackWarning: string | null;
   runtimeWarning: string | null;
   staleWarning: string | null;
   indexEnvelope: string;
+  retrievalEnvelope: string;
   body: string;
 }): string {
   const blocks: string[] = [];
+  if (parts.fallbackWarning) blocks.push(parts.fallbackWarning);
   if (parts.runtimeWarning) blocks.push(parts.runtimeWarning);
   if (parts.staleWarning) blocks.push(parts.staleWarning);
   blocks.push(parts.indexEnvelope);
+  blocks.push(parts.retrievalEnvelope);
   blocks.push(parts.body);
   return blocks.join('\n\n');
 }
@@ -641,12 +815,26 @@ export function registerSearchKnowledge(server: McpServer): void {
           .describe(
             'Partition name, linked-index name, or file path prefix to scope results. Resolution order: (1) configured partition names (e.g., "core", "cli", "mcp") → primary index, prefix-filtered; (2) linked-index names from linkedIndexes config (e.g., "strategy") → routes only to that cross-repo index; (3) raw path prefixes (e.g., "src/components/") → primary, prefix-filtered. When omitted, search federates across primary + all linked indexes, merging by semantic score. Blank or whitespace-only values are normalized to "omitted" (federated default).',
           ),
+        // mmnto-ai/totem#2463: per-call relevance floor override. Floors on the
+        // true vector-leg relevance (0..1), NOT the displayed RRF score. Below
+        // it, the tool reports status="no_useful_hits" and discloses the
+        // below-floor candidates instead of returning noise. Overrides the
+        // config `searchRelevanceFloor`; the retrieval-envelope always reports
+        // the effective floor.
+        min_relevance: z
+          .number()
+          .min(0)
+          .max(1)
+          .optional()
+          .describe(
+            'Minimum per-hit relevance (0..1, vector-leg similarity) to treat results as useful. Overrides the configured searchRelevanceFloor. Below it, status is "no_useful_hits" with the below-floor candidates disclosed.',
+          ),
       },
       annotations: {
         readOnlyHint: true,
       },
     },
-    async ({ query, type_filter, max_results, boundary }) => {
+    async ({ query, type_filter, max_results, boundary, min_relevance }) => {
       const start = Date.now();
       // A.3.a: emit `mcp_call` activity event to the Trap Ledger. Fire-and-forget;
       // the ledger write must not block or break the tool call (Tenet 4 + sensor
@@ -697,13 +885,14 @@ export function registerSearchKnowledge(server: McpServer): void {
 
         let result: ToolResult;
         try {
-          result = await performSearch(query, type_filter, max_results, boundary);
+          result = await performSearch(query, type_filter, max_results, boundary, min_relevance);
+          // totem-context: the catch below is not a silent swallow; a failed reconnect+retry is surfaced to the agent as an isError ToolResult.
         } catch (originalErr) {
           // Any LanceDB error could indicate a stale handle (e.g. files deleted
           // during a full sync rebuild). Reconnect and retry once before failing.
           try {
             await reconnectStore();
-            result = await performSearch(query, type_filter, max_results, boundary);
+            result = await performSearch(query, type_filter, max_results, boundary, min_relevance);
           } catch (retryErr) {
             // Retry failed — report both errors for diagnostics
             const originalMessage =
@@ -737,6 +926,18 @@ export function registerSearchKnowledge(server: McpServer): void {
         const scoreMatches = [...resultText.matchAll(/\*\*Score:\*\* ([\d.]+)/g)];
         const topScore = scoreMatches.length > 0 ? parseFloat(scoreMatches[0]![1]!) : null;
 
+        // mmnto-ai/totem#2463: record best relevance alongside topScore. Parsed
+        // from the retrieval-envelope's bestRelevance attribute (same derive-
+        // from-response-text pattern as topScore); "n/a" → null (no signal).
+        const relevanceMatch = resultText.match(
+          /<retrieval-envelope[^>]*\bbestRelevance="([^"]+)"/,
+        );
+        const bestRelevanceRaw = relevanceMatch?.[1];
+        const topRelevance =
+          bestRelevanceRaw !== undefined && bestRelevanceRaw !== 'n/a'
+            ? parseFloat(bestRelevanceRaw)
+            : null;
+
         // Log error responses (e.g., the broken-linked-boundary path at
         // performSearch Case 3) as errors instead of zero-result successes,
         // so routing failures are visible in search-log.jsonl. Without this
@@ -762,6 +963,7 @@ export function registerSearchKnowledge(server: McpServer): void {
             resultCount: scoreMatches.length,
             durationMs: Date.now() - start,
             topScore,
+            topRelevance,
           });
         }
 


### PR DESCRIPTION
## Context

Slice A of the Ask 2 retrieval gate (pilot conditional-ship set, operator-ruled 2026-07-23; design at `.totem/specs/2463.md`). Preflight overturned the issue's premise: the uniform 0.016 is not a noise floor — it is the RRF rank artifact `1/(60+rank)`, minted at BOTH fusion sites (intra-store `rrfMerge` and the MCP federation re-rank), with the true vector-leg relevance signal discarded before display. A floor over displayed scores would classify every fused hit as noise forever; this PR floors on the true signal instead.

## Changes

**core:** `SearchResult.relevance` (vector-leg `1/(1+distance)`, absent for keyword-only hits) + `SearchResult.searchMethod`; `rrfMerge` preserves relevance while overwriting `score` (ordering byte-identical); opt-in `allowFtsFallback` on `LanceStore.search` degrades to the existing FTS-only path when the embedder cannot resolve — only the no-embedder error class is caught, keyed on the new shared `NO_EMBEDDER_AVAILABLE_MESSAGE` constant (single source at the throw site, detector, and test stub); config key `searchRelevanceFloor` (0..1, default 0.25 — pilot day 0–1 calibrates from `search-log.jsonl`).

**mcp (`search_knowledge`):** new `min_relevance` input overriding the config floor; a machine-parsable `<retrieval-envelope status method bestRelevance floor hits />` line beside `<index-meta>`; floor fires only when a hit carries relevance signal — below-floor returns `status="no_useful_hits"` with every candidate disclosed compactly (path + relevance, no content), never silently dropped; keyword-only degradation is loud (system warning + `method="fts"`); per-hit `Relevance:` display (the "keyword match" note reserved for fts-stamped hits); `logSearch` records `topRelevance`.

**docs:** `cross-repo-mesh.md` documents Relevance vs Score and the envelope line.

Weak retrieval, absent retrieval, and outage are now three programmatically distinct states — all three acceptance criteria of the linked issue.

## Verification

Full workspace build clean; core 3400/3400, mcp 198/198 (+1 skip); `format:check` clean; `totem lint --base origin/main` PASS 0 errors. Local two-lane review (sonnet + gemini flash): round 0 — 0 critical, 2 warns, both fixed in `7590b89d` (shared no-embedder constant; honest `n/a` label branch); round 1 — 0 critical, residuals dispositioned: `allowFtsFallback:true` on every MCP call site is the ruled offline-gate design (core's flag is caller-opt-in; the MCP surface is the caller, opting in deliberately with the loud degradation warning); `min_relevance` schema wiring verified present (schema/handler/threading); the distance-metric coupling on the relevance transform is recorded in the spec as a pilot-calibration watch-item.

<!-- totem-context: intentional D1 close declaration for this repo's issue -->
<!-- totem-close: #2463 -->
<!-- totem-context: intentional close keyword, declared above via totem-close marker -->
Closes #2463

🤖 Generated with [Claude Code](https://claude.com/claude-code)
