### PR TITLE
fix(cli): silence the lesson-staleness compile nag under the active rule-compilation freeze (#2463 slice B)

### DIFF
--- a/.changeset/freeze-nag-silence.md
+++ b/.changeset/freeze-nag-silence.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/cli': patch
+---
+
+Suppress the lesson-staleness `Run 'totem lesson compile'` advisory in `totem lint` while a rule-compilation freeze is active, since that command is on the freeze's do-not list (mmnto-ai/totem#2463 slice B). The nag is silenced only on a positive frozen=true; any freeze-state read failure falls through to showing the advisory as before.

--- a/packages/cli/src/commands/lint-staleness.ts
+++ b/packages/cli/src/commands/lint-staleness.ts
@@ -197,8 +197,10 @@ const REMEDIATION = "Run 'totem lesson compile' to update.";
  *   `(untracked)`, then "…and K more" when over the cap, then the remediation.
  *
  * The remediation intentionally points public consumers at `totem lesson
- * compile`; the cohort-side compile freeze is overlay-governed, not this
- * string's concern.
+ * compile`. This formatter stays freeze-agnostic — it always includes the
+ * remediation; the caller (`lint.ts`) suppresses the whole advisory while a
+ * rule-compilation freeze is active, since `totem lesson compile` is on that
+ * freeze's do-not list (mmnto-ai/totem#2463 slice B).
  */
 export function formatStalenessWarning(delta: LessonDelta, opts: FormatStalenessOptions): string {
   const total = delta.entries.length;

--- a/packages/cli/src/commands/lint.test.ts
+++ b/packages/cli/src/commands/lint.test.ts
@@ -57,6 +57,22 @@ vi.mock('../utils/bootstrap-engine.js', () => ({
     bootstrapEngineMock(config, projectRoot),
 }));
 
+// ─── Mock help-freeze (mmnto-ai/totem#2463 slice B) ─────
+// deriveRuleCompilationFrozen decides whether the staleness advisory is
+// silenced under an active rule-compilation freeze. Default `false` so every
+// pre-existing staleness test keeps its exact behavior; the freeze-suppression
+// block below drives it per-test (true / throw). Spread the real module so the
+// other export (isRootHelpInvocation) is untouched.
+
+const deriveRuleCompilationFrozenMock = vi.fn(async (..._args: unknown[]) => false);
+vi.mock('../help-freeze.js', async () => {
+  const actual = await vi.importActual<typeof import('../help-freeze.js')>('../help-freeze.js');
+  return {
+    ...actual,
+    deriveRuleCompilationFrozen: (...args: unknown[]) => deriveRuleCompilationFrozenMock(...args),
+  };
+});
+
 // ─── Helpers ────────────────────────────────────────────
 
 function makeTmpDir(): string {
@@ -179,6 +195,90 @@ describe('lintCommand staleness check', () => {
 
     // Should not throw — staleness check is wrapped in try/catch
     await expect(lintCommand({})).resolves.toBeUndefined();
+  });
+});
+
+// ─── Freeze-nag suppression (mmnto-ai/totem#2463 slice B) ──────
+// Under an active rule-compilation freeze, `totem lesson compile` is on the
+// freeze's do-not list, so the staleness advisory (which points there) must be
+// silenced. Info-preserving default: suppression fires ONLY on a positive
+// frozen=true — a freeze-state read failure still shows the advisory.
+
+describe('lintCommand staleness freeze suppression (mmnto-ai/totem#2463)', () => {
+  let tmpDir: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+    fs.writeFileSync(path.join(tmpDir, 'totem.config.ts'), 'export default {};', 'utf-8');
+    deriveRuleCompilationFrozenMock.mockReset();
+    deriveRuleCompilationFrozenMock.mockResolvedValue(false);
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    cleanTmpDir(tmpDir);
+    deriveRuleCompilationFrozenMock.mockReset();
+    deriveRuleCompilationFrozenMock.mockResolvedValue(false);
+    vi.restoreAllMocks();
+  });
+
+  // Scaffold a manifest, then add a second lesson so the aggregate input hash
+  // disagrees (stale) — the only state in which the advisory would fire.
+  function scaffoldStaleManifest(): void {
+    const { lessonsDir, rulesPath, manifestPath } = scaffold(tmpDir);
+    writeValidManifest(manifestPath, lessonsDir, rulesPath);
+    fs.writeFileSync(
+      path.join(lessonsDir, 'lesson-2.md'),
+      '# Lesson — New lesson\n\n**Tags:** new\n\nSomething new.\n',
+    );
+  }
+
+  it('suppresses the staleness advisory while the rule-compilation freeze is active', async () => {
+    scaffoldStaleManifest();
+    deriveRuleCompilationFrozenMock.mockResolvedValue(true);
+
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { lintCommand } = await import('./lint.js');
+    await lintCommand({});
+
+    const staleWarning = warnSpy.mock.calls.find((call) =>
+      String(call[0]).includes('Compile manifest is stale'),
+    );
+    expect(staleWarning).toBeUndefined();
+  });
+
+  it('shows the staleness advisory when no freeze is active', async () => {
+    scaffoldStaleManifest();
+    deriveRuleCompilationFrozenMock.mockResolvedValue(false);
+
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { lintCommand } = await import('./lint.js');
+    await lintCommand({});
+
+    const staleWarning = warnSpy.mock.calls.find((call) =>
+      String(call[0]).includes('Compile manifest is stale'),
+    );
+    expect(staleWarning).toBeDefined();
+  });
+
+  it('shows the staleness advisory when the freeze-state read throws', async () => {
+    scaffoldStaleManifest();
+    deriveRuleCompilationFrozenMock.mockRejectedValue(new Error('freeze.json corrupt'));
+
+    const warnSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { lintCommand } = await import('./lint.js');
+    await lintCommand({});
+
+    const staleWarning = warnSpy.mock.calls.find((call) =>
+      String(call[0]).includes('Compile manifest is stale'),
+    );
+    expect(staleWarning).toBeDefined();
   });
 });
 

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -74,6 +74,32 @@ function walkLessonMtimes(fs: FsModule, path: PathModule, lessonsDir: string): L
   return out;
 }
 
+// ─── Freeze-aware nag suppression (mmnto-ai/totem#2463 slice B) ─
+
+/**
+ * Whether an active rule-compilation freeze should SILENCE the compile-manifest
+ * staleness advisory (mmnto-ai/totem#2463 slice B).
+ *
+ * Under that freeze `totem lesson compile` sits on the freeze's do-not list, so
+ * the advisory would nag the reader toward a forbidden command. Suppression is
+ * INFO-PRESERVING by default: any failure reading freeze state resolves `false`
+ * (show the advisory) — the nag is silenced ONLY on a positive frozen=true, never
+ * on uncertainty. Freeze visibility itself lives in orient/status and the
+ * `[frozen]` help badge, not in this string.
+ *
+ * `absTotemDir` is the ABSOLUTE `.totem` path (`readEffectiveFreezes` joins it
+ * straight to the freeze-file path, so a repo-relative dir would misread).
+ */
+async function isStalenessNagFrozen(cwd: string, absTotemDir: string): Promise<boolean> {
+  try {
+    const { deriveRuleCompilationFrozen } = await import('../help-freeze.js');
+    return await deriveRuleCompilationFrozen(cwd, { totemDir: absTotemDir });
+    // totem-context: best-effort — an unreadable/corrupt freeze state degrades to showing the advisory (frozen=false), never suppresses on uncertainty (mmnto-ai/totem#2463)
+  } catch {
+    return false;
+  }
+}
+
 // ─── Types ──────────────────────────────────────────
 
 export interface LintOptions {
@@ -165,7 +191,16 @@ export async function lintCommand(options: LintOptions): Promise<void> {
       const manifest = readCompileManifest(manifestPath);
       const lessonsDir = path.join(cwd, config.totemDir, 'lessons');
       const currentInputHash = generateInputHash(lessonsDir, cwd);
-      if (currentInputHash !== manifest.input_hash) {
+      // Short-circuit the whole advisory (naming + git provenance spawns + the
+      // warn) when a rule-compilation freeze is active — it would nag toward the
+      // do-not-listed `totem lesson compile` (mmnto-ai/totem#2463 slice B). The
+      // freeze read only runs when the manifest is actually stale (`&&` order),
+      // and a throw resolves `false` inside the helper so the advisory still
+      // shows on any freeze-state read failure (info-preserving default).
+      if (
+        currentInputHash !== manifest.input_hash &&
+        !(await isStalenessNagFrozen(cwd, path.join(cwd, config.totemDir)))
+      ) {
         // Bounded best-effort: any git failure inside these helpers degrades to
         // the mtime fallback (or the generic line) rather than killing the warn.
         // The whole block stays inside the outer never-crash try/catch below.


### PR DESCRIPTION
## Context

Slice B of the Ask 2 retrieval gate (operator-ruled 2026-07-23). `totem lint` printed a lesson-staleness advisory ending in `Run 'totem lesson compile' to update.` on every pre-push — while the standing rule-compilation freeze's do-not list forbids exactly that command (the lc-seat finding from the pilot round).

## Changes

The lint staleness path now consults the existing `deriveRuleCompilationFrozen` helper and fully suppresses the advisory (warning + remediation, no replacement text) while the freeze is active — the ruled "silenced" disposition; freeze visibility stays with orient/status and the `[frozen]` help badge. Suppression fires only on a positive `frozen=true`: any freeze-state read failure shows the advisory as before (info-preserving default). The freeze read is short-circuited to run only when the manifest is actually stale. Lint exit code and all non-staleness output untouched; `verify-manifest` and `tools/pre-push` unchanged. The stale "not this string's concern" comment in `lint-staleness.ts` is updated to describe the caller-side suppression.

## Verification

Full workspace build clean; cli 3576/3576 tests (three new invariants: freeze-active → advisory absent; no freeze → byte-identical advisory; freeze read throws → advisory shown — with a positive control so the suppression assertion cannot pass vacuously); `format:check` clean; `totem lint --base origin/main` PASS 0 errors. Local two-lane review (sonnet + gemini flash): settled, 2/2 lanes, 0 findings. Changeset: `@mmnto/cli` patch.

Part of the mmnto-ai/totem#2463 retrieval-gate work (slice A carries the issue close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
