### PR TITLE
chore: postmerge lessons for the Ask 2 retrieval gate (#2494 + #2495)

### DIFF
--- a/.totem/lessons/lesson-15609d4d.md
+++ b/.totem/lessons/lesson-15609d4d.md
@@ -1,0 +1,6 @@
+## Lesson — Scope fallback catches to specific errors
+
+**Tags:** error-handling, search, resilience
+**Scope:** packages/core/src/store/**/*.ts, !**/*.test.*
+
+When falling back to keyword search (FTS) during embedder outages, only catch the specific no-embedder error class. Swallowing broader errors can mask other critical failures in the search pipeline.

--- a/.totem/lessons/lesson-2a596435.md
+++ b/.totem/lessons/lesson-2a596435.md
@@ -1,0 +1,6 @@
+## Lesson — Default to info-preserving on state read failures
+
+**Tags:** cli, error-handling, ux
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+When suppressing warnings based on dynamic state checks, default to showing the warning if the state read fails to prevent silently hiding critical information.

--- a/.totem/lessons/lesson-54138074.md
+++ b/.totem/lessons/lesson-54138074.md
@@ -1,0 +1,6 @@
+## Lesson — Preserve true relevance during RRF fusion
+
+**Tags:** search, rrf, relevance
+**Scope:** packages/core/src/store/**/*.ts, !**/*.test.*
+
+Reciprocal Rank Fusion (RRF) scores represent rank order rather than absolute semantic match strength. To implement a reliable relevance floor, preserve the true vector-leg relevance signal separately from the RRF score during fusion.

--- a/.totem/lessons/lesson-e32bb46e.md
+++ b/.totem/lessons/lesson-e32bb46e.md
@@ -1,0 +1,5 @@
+## Lesson — Align local linting with CI steps
+
+**Tags:** ci, eslint, dx
+
+A local pre-push gate can miss import-sorting failures if it skips the workspace-level ESLint step executed by CI (`pnpm lint` is distinct from `totem lint`). Ensure local validation runs the exact same linting suite as the remote pipeline — including on inline fix-round commits, not only on the initial build.

--- a/.totem/lessons/lesson-f1f1c9bd.md
+++ b/.totem/lessons/lesson-f1f1c9bd.md
@@ -1,0 +1,6 @@
+## Lesson — Use positive controls in suppression tests
+
+**Tags:** testing, qa
+**Scope:** packages/**/*.test.ts, packages/**/*.spec.ts
+
+When writing assertions to verify that an advisory or warning is suppressed, always include a positive control test to ensure the suppression assertion cannot pass vacuously.


### PR DESCRIPTION
## Context

Postmerge slice for the Ask 2 retrieval gate (mmnto-ai/totem#2494 + mmnto-ai/totem#2495, both merged 2026-07-23). **Extraction-only under the standing rule-compilation freeze** — no compile, no export, no rule curation, same shape as the mmnto-ai/totem#2489 postmerge.

## Lessons (6 extracted → 5 kept)

1. **Preserve true relevance during RRF fusion** — RRF scores are rank order, not match strength; the floor must ride the vector-leg signal (slice A's core insight).
2. **Scope fallback catches to specific errors** — the FTS fallback catches only the no-embedder class; broader catches mask pipeline failures.
3. **Align local linting with CI steps** — the workspace ESLint step is distinct from `totem lint` and must run on inline fix-round commits too (grounded in this round's CI bounce; wording hand-tightened from the extractor's "pre-commit").
4. **Default to info-preserving on state read failures** — suppression fires only on a positive state read (slice B's design).
5. **Use positive controls in suppression tests** — suppression assertions must not be able to pass vacuously. **Scope hand-fixed:** the extractor emitted a scope that *excluded* test files on a testing lesson (the mmnto-ai/totem#2063 mis-scope class) — corrected to target `**/*.test.ts` / `**/*.spec.ts`.

**Cut:** one generic defer-expensive-reads lesson — no trap behind it, pure corpus mass (the mmnto-ai/totem#467 concern).

**Laundering check:** diffed against both PRs' review-round dispositions — no declined finding restated (fallback-always-on, metric-coupling watch-item, comment-placement, and issue-ref residuals all stayed out).

## Verification

`totem lint-lessons`: 1711 validated, 0 errors, new files clean. Lessons only — no package code, no changeset. Compile-manifest untouched (input-hash drift from new lessons is the freeze-tolerated staleness class; `verify-manifest` WARN-downgrades under the active freeze).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
