### PR TITLE
fix(lint): corpus-bearing repos hard-error when compiled rules are unloadable (Prop 309 quota item)

### DIFF
--- a/.changeset/corpus-bearing-lint-hard-error.md
+++ b/.changeset/corpus-bearing-lint-hard-error.md
@@ -1,0 +1,13 @@
+---
+'@mmnto/cli': minor
+---
+
+fix(lint): corpus-bearing repos hard-error when compiled rules are unloadable
+
+`totem lint` passed vacuously when the compiled-rules manifest was missing, truncated, or unreadable: `loadCompiledRules` returns `[]` on a missing file, and on a JSON/`SyntaxError` or I/O fault (`EISDIR`/`EACCES`) it fired an optional `onWarn` and returned `[]` — but the lint call site omitted `onWarn`, so even the accounting line was dropped. A repo with a real lesson corpus and hundreds of compiled rules could therefore have its entire enforcement gate silently disarmed behind a green exit.
+
+The lint call site now threads an `onWarn` that both records and renders the load-time warning, and — when zero rules load — discriminates on whether the repo is **corpus-bearing** (does the loaded config declare lesson-kind ingest targets whose globs match real files on disk, a pure git-free filesystem derivation). A corpus-bearing repo whose manifest is missing or unloadable now throws a `TotemError` (non-zero exit) naming the lesson count, the manifest path, and the phrase "enforcement disarmed", with a `totem lesson compile` fix hint. A manifest that is present and valid but filtered to zero ACTIVE rules (all archived / pending-verification / untested-against-codebase) stays an honest info-skip that names the zero-active-rules lifecycle state.
+
+The empty-corpus / early-adoption skip is preserved exactly (mmnto-ai/totem#1831): a repo with no lesson files, or any caller that does not pass its config, keeps today's info-skip. `@mmnto/core`'s `loadCompiledRules` public API and its return-`[]` semantics are unchanged — the enforcement lives entirely at the CLI call site.
+
+First quota item of the Prop 309 hardening program (mmnto-ai/totem-strategy#971).

--- a/packages/cli/src/commands/lint.ts
+++ b/packages/cli/src/commands/lint.ts
@@ -325,6 +325,11 @@ export async function lintCommand(options: LintOptions): Promise<void> {
     ignorePatterns: allIgnore,
     tag: TAG,
     configRoot,
+    // Pass the loaded config so runCompiledRules can hard-error a corpus-bearing
+    // repo whose compiled-rules manifest is missing / unloadable, instead of
+    // passing vacuously behind a green exit (mmnto-ai/totem-strategy#971,
+    // Prop 309). Its lesson-kind targets drive the corpus-bearing check.
+    config,
     isStaged: !!options.staged,
     regexTimeoutMode: timeoutMode,
     astParseMode,

--- a/packages/cli/src/commands/run-compiled-rules.test.ts
+++ b/packages/cli/src/commands/run-compiled-rules.test.ts
@@ -1808,7 +1808,9 @@ describe('corpus-bearing zero-rules hard-error (mmnto-ai/totem-strategy#971)', (
 
       expect(result.rules).toHaveLength(0);
       expect(result.violations).toHaveLength(0);
-      const messages = stderrSpy.mock.calls.map((c) => c[0] as string);
+      // Join ALL args per call — coupling to log.info's internal arity would
+      // silently break this assertion if the tag and message ever split.
+      const messages = stderrSpy.mock.calls.map((c) => c.join(' '));
       expect(messages.find((m) => m.includes('zero ACTIVE rules'))).toBeDefined();
     } finally {
       stderrSpy.mockRestore();
@@ -1852,7 +1854,8 @@ describe('corpus-bearing zero-rules hard-error (mmnto-ai/totem-strategy#971)', (
 
       expect(result.rules).toHaveLength(0);
       expect(result.violations).toHaveLength(0);
-      const messages = stderrSpy.mock.calls.map((c) => String(c[0]));
+      // Join ALL args per call — see the arity note in the archived-rules control.
+      const messages = stderrSpy.mock.calls.map((c) => c.join(' '));
       expect(messages.find((m) => m.includes('Could not load compiled rules'))).toBeDefined();
     } finally {
       stderrSpy.mockRestore();

--- a/packages/cli/src/commands/run-compiled-rules.test.ts
+++ b/packages/cli/src/commands/run-compiled-rules.test.ts
@@ -1833,6 +1833,32 @@ describe('corpus-bearing zero-rules hard-error (mmnto-ai/totem-strategy#971)', (
     expect(JSON.parse(result.output).pass).toBe(true);
   });
 
+  it('control: a config-less caller with a truncated manifest surfaces the load warning but never hard-errors (the shield-estimate opt-out contract)', async () => {
+    writeLesson(tmpDir);
+    fs.writeFileSync(path.join(tmpDir, TOTEM_DIR, 'compiled-rules.json'), '{"version":1,"rules":[');
+
+    const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      // No `config` option — the caller opts out of the corpus-bearing hard
+      // error (e.g. `shield estimate`). The accounting line must still render:
+      // the opt-out covers the exit code, not the disclosure.
+      const result = await runCompiledRules({
+        diff: cleanDiff(),
+        cwd: tmpDir,
+        totemDir: TOTEM_DIR,
+        format: 'text',
+        tag: 'Test',
+      });
+
+      expect(result.rules).toHaveLength(0);
+      expect(result.violations).toHaveLength(0);
+      const messages = stderrSpy.mock.calls.map((c) => String(c[0]));
+      expect(messages.find((m) => m.includes('Could not load compiled rules'))).toBeDefined();
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
   it('hard-errors via a concrete (non-wildcard) lesson target — the aggregated .totem/lessons.md shape', async () => {
     // The production config declares BOTH a wildcard dir target and a concrete
     // aggregated-file target; this exercises the statSync existence branch (and

--- a/packages/cli/src/commands/run-compiled-rules.test.ts
+++ b/packages/cli/src/commands/run-compiled-rules.test.ts
@@ -1832,4 +1832,27 @@ describe('corpus-bearing zero-rules hard-error (mmnto-ai/totem-strategy#971)', (
     expect(result.violations).toHaveLength(0);
     expect(JSON.parse(result.output).pass).toBe(true);
   });
+
+  it('hard-errors via a concrete (non-wildcard) lesson target — the aggregated .totem/lessons.md shape', async () => {
+    // The production config declares BOTH a wildcard dir target and a concrete
+    // aggregated-file target; this exercises the statSync existence branch (and
+    // mixed-target iteration) that the wildcard-walk tests never reach.
+    fs.writeFileSync(path.join(tmpDir, TOTEM_DIR, 'lessons.md'), '# Lessons\n\n## One\n\nBody.\n');
+
+    await expect(
+      runCompiledRules({
+        diff: cleanDiff(),
+        cwd: tmpDir,
+        totemDir: TOTEM_DIR,
+        format: 'text',
+        tag: 'Test',
+        config: {
+          targets: [
+            { glob: '.totem/lessons/*.md', type: 'lesson', strategy: 'markdown-heading' },
+            { glob: '.totem/lessons.md', type: 'lesson', strategy: 'markdown-heading' },
+          ],
+        },
+      }),
+    ).rejects.toThrow(/enforcement disarmed/i);
+  });
 });

--- a/packages/cli/src/commands/run-compiled-rules.test.ts
+++ b/packages/cli/src/commands/run-compiled-rules.test.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { CompiledRule } from '@mmnto/totem';
+import type { CompiledRule, TotemConfig } from '@mmnto/totem';
 import * as totem from '@mmnto/totem';
 import { readLedgerEvents, saveCompiledRules, TotemError, TotemParseError } from '@mmnto/totem';
 
@@ -1671,5 +1671,165 @@ describe('--ast-parse-mode lenient', () => {
 
     expect(result.violations).toHaveLength(1);
     expect(result.output).not.toContain('Frozen-lesson');
+  });
+});
+
+// ─── Corpus-bearing zero-rules hard-error (mmnto-ai/totem-strategy#971, Prop 309) ──
+//
+// A repo that carries a lesson corpus but loads ZERO compiled rules has its
+// entire enforcement gate silently disarmed behind a green exit. `totem lint`
+// must fail loud in that case (induced-failure triple below), while still
+// preserving the legitimate empty-corpus skip (mmnto-ai/totem#1831) and the
+// archived-in-place zero-active-rules lifecycle state (the controls).
+describe('corpus-bearing zero-rules hard-error (mmnto-ai/totem-strategy#971)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-rcr-corpus-'));
+    fs.mkdirSync(path.join(tmpDir, TOTEM_DIR), { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  /** Write a real lesson `.md` under `.totem/lessons/` so the repo is corpus-bearing. */
+  function writeLesson(dir: string, name = 'baseline.md'): void {
+    const lessonsDir = path.join(dir, TOTEM_DIR, 'lessons');
+    fs.mkdirSync(lessonsDir, { recursive: true });
+    fs.writeFileSync(path.join(lessonsDir, name), '# A lesson\n\nBody.\n');
+  }
+
+  /** A config whose only lesson-kind target matches `.totem/lessons/*.md`. */
+  function lessonConfig(glob = '.totem/lessons/*.md'): Pick<TotemConfig, 'targets'> {
+    return { targets: [{ glob, type: 'lesson', strategy: 'markdown-heading' }] };
+  }
+
+  const cleanDiff = (): string => makeDiff('src/app.ts', '  const x = 1;');
+
+  // ── Induced-failure triple ──────────────────────────
+
+  it('hard-errors when the manifest is missing but the repo carries lessons', async () => {
+    writeLesson(tmpDir); // corpus-bearing; no compiled-rules.json written
+
+    await expect(
+      runCompiledRules({
+        diff: cleanDiff(),
+        cwd: tmpDir,
+        totemDir: TOTEM_DIR,
+        format: 'text',
+        tag: 'Test',
+        config: lessonConfig(),
+      }),
+    ).rejects.toThrow(/enforcement disarmed/i);
+  });
+
+  it('hard-errors on a truncated manifest instead of passing vacuously', async () => {
+    writeLesson(tmpDir);
+    // Truncated mid-array — JSON.parse throws SyntaxError, which core reports via
+    // onWarn and returns []. Unmodified code passes vacuously here; the fix throws.
+    fs.writeFileSync(path.join(tmpDir, TOTEM_DIR, 'compiled-rules.json'), '{"version":1,"rules":[');
+
+    await expect(
+      runCompiledRules({
+        diff: cleanDiff(),
+        cwd: tmpDir,
+        totemDir: TOTEM_DIR,
+        format: 'text',
+        tag: 'Test',
+        config: lessonConfig(),
+      }),
+    ).rejects.toThrow(/enforcement disarmed/i);
+  });
+
+  it('hard-errors on an EISDIR I/O fault and surfaces the load-warning accounting text', async () => {
+    writeLesson(tmpDir);
+    // Replace the manifest with a DIRECTORY at the same path — the portable,
+    // Windows-safe I/O fault (readFileSync throws EISDIR on win32 and posix).
+    fs.mkdirSync(path.join(tmpDir, TOTEM_DIR, 'compiled-rules.json'), { recursive: true });
+
+    let message = '';
+    try {
+      await runCompiledRules({
+        diff: cleanDiff(),
+        cwd: tmpDir,
+        totemDir: TOTEM_DIR,
+        format: 'text',
+        tag: 'Test',
+        config: lessonConfig(),
+      });
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+
+    expect(message).toMatch(/enforcement disarmed/i);
+    // The onWarn accounting text (dropped before the fix) is surfaced in the throw.
+    expect(message).toContain('Could not load compiled rules');
+  });
+
+  // ── Controls ────────────────────────────────────────
+
+  it('control: an empty-corpus repo (no lesson files) with a missing manifest still exits clean (mmnto-ai/totem#1831)', async () => {
+    // Config DECLARES a lesson target, but no lesson files exist on disk, so the
+    // discriminator treats the repo as empty-corpus — the info-skip is preserved.
+    const result = await runCompiledRules({
+      diff: cleanDiff(),
+      cwd: tmpDir,
+      totemDir: TOTEM_DIR,
+      format: 'text',
+      tag: 'Test',
+      config: lessonConfig(),
+    });
+
+    expect(result.violations).toHaveLength(0);
+    expect(result.rules).toHaveLength(0);
+    expect(result.output).toBe('');
+  });
+
+  it('control: a corpus-bearing repo whose manifest holds only archived rules exits clean with a zero-active-rules message', async () => {
+    writeLesson(tmpDir);
+    // Valid manifest, present and parseable, but every rule is inert (archived).
+    // loadCompiledRules filters it to [] with no warning — a legitimate lifecycle
+    // state, NOT a disarmed gate.
+    writeRules(tmpDir, [
+      makeRule('console\\.log', 'No console', 'No console', { status: 'archived' }),
+    ]);
+
+    const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const result = await runCompiledRules({
+        diff: cleanDiff(),
+        cwd: tmpDir,
+        totemDir: TOTEM_DIR,
+        format: 'text',
+        tag: 'Test',
+        config: lessonConfig(),
+      });
+
+      expect(result.rules).toHaveLength(0);
+      expect(result.violations).toHaveLength(0);
+      const messages = stderrSpy.mock.calls.map((c) => c[0] as string);
+      expect(messages.find((m) => m.includes('zero ACTIVE rules'))).toBeDefined();
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it('control: a repo with valid active rules is unaffected by the corpus-bearing gate', async () => {
+    writeLesson(tmpDir);
+    writeRules(tmpDir, [makeRule('neverMatchXYZ123', 'no match', 'No match rule')]);
+
+    const result = await runCompiledRules({
+      diff: cleanDiff(),
+      cwd: tmpDir,
+      totemDir: TOTEM_DIR,
+      format: 'json',
+      tag: 'Test',
+      config: lessonConfig(),
+    });
+
+    expect(result.rules).toHaveLength(1);
+    expect(result.violations).toHaveLength(0);
+    expect(JSON.parse(result.output).pass).toBe(true);
   });
 });

--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -129,8 +129,12 @@ async function countLessonCorpusFiles(
   const { matchesGlob } = await import('@mmnto/totem');
 
   const WILDCARD = /[*?{}[\]]/;
-  // Bound the walk so a broad lesson glob can never blow up on heavy trees.
-  const SKIP_DIRS = new Set(['.git', 'node_modules']);
+  // Bound the walk so a broad lesson glob can never blow up on heavy trees. A
+  // non-terminal wildcard (e.g. '.totem/*/lessons/*.md') collapses the static
+  // prefix to a shallow dir, so the heavy subtrees lessons never live in —
+  // embedding stores and build output — are skipped by name alongside the
+  // usual suspects.
+  const SKIP_DIRS = new Set(['.git', 'node_modules', '.lancedb', 'dist']);
   const toPosix = (p: string): string => p.replace(/\\/g, '/');
   const matched = new Set<string>();
 

--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -277,6 +277,11 @@ export async function runCompiledRules(
 
     if (lessonCount > 0) {
       const manifestRel = `${totemDir}/${COMPILED_RULES_FILE}`;
+      // This existsSync re-derives what loadCompiledRules saw internally
+      // (compiler.ts checks the same path). A manifest CREATED between the two
+      // reads would fall through to the zero-active-rules info-skip — an
+      // accepted single-shot-CLI race (mmnto-ai/totem#2499 review): the window
+      // is microseconds and a concurrent compile implies an imminent re-lint.
       if (!fs.existsSync(rulesPath)) {
         throw new TotemError(
           'LINT_LESSONS_FAILED',

--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -3,6 +3,7 @@ import type {
   RuleEventCallback,
   RuleTimeoutOutcome,
   TimeoutMode,
+  TotemConfig,
   TotemFinding,
   Violation,
 } from '@mmnto/totem';
@@ -42,6 +43,16 @@ export interface RunCompiledRulesOptions {
   tag: string;
   /** Absolute path to config root — used for cache paths instead of cwd */
   configRoot?: string;
+  /**
+   * Loaded totem config (mmnto-ai/totem-strategy#971, Prop 309). Only its
+   * `targets` are consumed — the lesson-kind ingest targets whose globs decide
+   * whether a zero-compiled-rules run is a legitimate empty-corpus skip
+   * (mmnto-ai/totem#1831) or a DISARMED enforcement gate that must fail loud.
+   * A caller that omits it opts out of the corpus-bearing hard-error and keeps
+   * the unconditional empty-corpus skip (e.g. `shield estimate`, whose forecast
+   * path is not the enforcement gate).
+   */
+  config?: Pick<TotemConfig, 'targets'>;
   /** True if we are linting staged changes only */
   isStaged?: boolean;
   /**
@@ -88,6 +99,87 @@ export interface RunCompiledRulesResult {
 // ─── Constants ──────────────────────────────────────
 
 const COMPILED_RULES_FILE = 'compiled-rules.json';
+
+// ─── Corpus-bearing derivation (mmnto-ai/totem-strategy#971, Prop 309) ─
+
+/**
+ * Count the lesson-corpus files a repo carries on disk: every existing file
+ * matched by a lesson-kind ingest target's glob in the loaded totem config,
+ * deduplicated across targets.
+ *
+ * This is the discriminator {@link runCompiledRules} uses when zero compiled
+ * rules load. A count > 0 means the repo genuinely HAS lessons, so a
+ * zero-rules run has silently disarmed the enforcement gate and must fail loud
+ * (mmnto-ai/totem-strategy#971, Prop 309). A count of 0 is a legitimate
+ * empty-corpus / early-adoption repo that skips (mmnto-ai/totem#1831).
+ *
+ * Config-driven — the lesson paths come from `config.targets`, never a
+ * hardcoded `.totem/lessons` (`totem describe`'s "Lessons: N" reads the fixed
+ * dir; this derivation honors a config that relocates the corpus). Pure
+ * filesystem scan with NO git spawn, so it stays Windows-temp-dir safe under
+ * test: each target's static path prefix bounds the walk, and candidate paths
+ * are matched with the shared glob matcher.
+ */
+async function countLessonCorpusFiles(
+  config: Pick<TotemConfig, 'targets'>,
+  projectRoot: string,
+): Promise<number> {
+  const fs = await import('node:fs');
+  const path = await import('node:path');
+  const { matchesGlob } = await import('@mmnto/totem');
+
+  const WILDCARD = /[*?{}[\]]/;
+  // Bound the walk so a broad lesson glob can never blow up on heavy trees.
+  const SKIP_DIRS = new Set(['.git', 'node_modules']);
+  const toPosix = (p: string): string => p.replace(/\\/g, '/');
+  const matched = new Set<string>();
+
+  for (const target of config.targets) {
+    if (target.type !== 'lesson') continue;
+    const glob = target.glob;
+
+    // Concrete path (no wildcard) — a direct existence check (e.g. a single
+    // aggregated `.totem/lessons.md`).
+    if (!WILDCARD.test(glob)) {
+      try {
+        if (fs.statSync(path.join(projectRoot, glob)).isFile()) matched.add(toPosix(glob));
+        // totem-context: best-effort — an absent concrete lesson path is simply not counted; ENOENT here is expected, never surfaced.
+      } catch {
+        // path absent — contributes nothing
+      }
+      continue;
+    }
+
+    // Wildcard glob — walk the static prefix directory (segments before the
+    // first wildcard segment) and match each candidate against the full config
+    // glob. The prefix scopes the walk to the lessons subtree.
+    const segments = glob.split('/');
+    const firstWildcard = segments.findIndex((s) => WILDCARD.test(s));
+    const baseRel = segments.slice(0, firstWildcard).join('/');
+    const stack: string[] = [baseRel ? path.join(projectRoot, baseRel) : projectRoot];
+    while (stack.length > 0) {
+      const dir = stack.pop()!;
+      let entries: import('node:fs').Dirent[];
+      try {
+        entries = fs.readdirSync(dir, { withFileTypes: true });
+        // totem-context: best-effort — an unreadable/absent lesson subtree contributes nothing rather than throwing; this cold-path scan must never crash lint.
+      } catch {
+        continue;
+      }
+      for (const entry of entries) {
+        const abs = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (!SKIP_DIRS.has(entry.name)) stack.push(abs);
+        } else if (entry.isFile()) {
+          const rel = toPosix(path.relative(projectRoot, abs));
+          if (matchesGlob(rel, glob)) matched.add(rel);
+        }
+      }
+    }
+  }
+
+  return matched.size;
+}
 
 // ─── Core logic ─────────────────────────────────────
 
@@ -145,21 +237,29 @@ export async function runCompiledRules(
   };
   const resolvedTotemDir = path.join(options.configRoot ?? cwd, totemDir);
 
-  // Load compiled rules
+  // Load compiled rules. Thread an `onWarn` that both RECORDS the load-time
+  // warning and RENDERS it (log.warn). The lint call site historically omitted
+  // onWarn, so a truncated / unreadable manifest dropped even the accounting
+  // line and lint passed vacuously (mmnto-ai/totem-strategy#971, Prop 309).
+  // Zod-shape errors still THROW from core (a corrupt SCHEMA is never a skip).
   const rulesPath = path.join(resolvedTotemDir, COMPILED_RULES_FILE);
-  const rules = loadCompiledRules(rulesPath);
+  let loadWarning: string | undefined;
+  const rules = loadCompiledRules(rulesPath, (msg) => {
+    loadWarning = msg;
+    log.warn(tag, msg);
+  });
 
-  // Empty corpus is a legitimate state for early-adoption / aspirational repos
-  // (mmnto-ai/totem#1831). Log + skip rather than throwing so CI does not fail
-  // on repos that have a valid lint configuration but no lessons compiled yet.
-  // Consumers that need a "rule count > 0" CI guardrail can check
-  // `compiled-rules.json` length directly in their pipeline.
   if (rules.length === 0) {
-    log.info(
-      tag,
-      `No compiled rules at ${totemDir}/${COMPILED_RULES_FILE} — skipping (empty-corpus repo). Run 'totem lesson compile' once you have lessons.`,
-    );
-    return {
+    // Zero rules can mean two very different things. An empty-corpus /
+    // early-adoption repo legitimately skips (mmnto-ai/totem#1831). But a repo
+    // that ACTUALLY carries a lesson corpus and still loads zero rules has its
+    // entire enforcement gate silently disarmed behind a green exit
+    // (mmnto-ai/totem-strategy#971, Prop 309) — a missing manifest, a
+    // truncated/unreadable one (onWarn fired above), or a manifest that
+    // filtered down to zero ACTIVE rules. Discriminate on corpus-bearing: does
+    // the config declare lesson-kind targets that match real files on disk?
+    const fs = await import('node:fs');
+    const emptyResult: RunCompiledRulesResult = {
       violations: [],
       findings: [],
       rules: [],
@@ -167,6 +267,49 @@ export async function runCompiledRules(
       regexTimeouts: [],
       astParseFailures: [],
     };
+    const lessonCount = options.config
+      ? await countLessonCorpusFiles(options.config, options.configRoot ?? cwd)
+      : 0;
+
+    if (lessonCount > 0) {
+      const manifestRel = `${totemDir}/${COMPILED_RULES_FILE}`;
+      if (!fs.existsSync(rulesPath)) {
+        throw new TotemError(
+          'LINT_LESSONS_FAILED',
+          `Enforcement disarmed: ${lessonCount} lesson file(s) present but no compiled-rules manifest at ${manifestRel} — 'totem lint' would pass every diff vacuously.`,
+          "Regenerate the manifest with 'totem lesson compile' so the compiled rules are enforced.",
+        );
+      }
+      if (loadWarning) {
+        throw new TotemError(
+          'LINT_LESSONS_FAILED',
+          `Enforcement disarmed: ${lessonCount} lesson file(s) present but the compiled-rules manifest at ${manifestRel} could not be loaded — ${loadWarning}. 'totem lint' would pass every diff vacuously.`,
+          "Repair or regenerate the manifest with 'totem lesson compile' so the compiled rules are enforced.",
+        );
+      }
+      // Manifest present and loaded validly, but every rule filtered out as
+      // inert (archived / pending-verification / untested-against-codebase).
+      // Archived-in-place rules preserve telemetry by design — a legitimate
+      // lifecycle state, NOT a disarmed gate — so this stays an info-skip, but
+      // one that NAMES the zero-active-rules condition instead of masquerading
+      // as an empty corpus.
+      log.info(
+        tag,
+        `${manifestRel} is present with zero ACTIVE rules (all archived / pending-verification / untested-against-codebase) — skipping. Legitimate lifecycle state, not a disarmed gate.`,
+      );
+      return emptyResult;
+    }
+
+    // Not corpus-bearing — preserve the mmnto-ai/totem#1831 empty-corpus skip
+    // exactly (early-adoption / aspirational repos with a valid lint config but
+    // no lessons compiled yet). Consumers that need a "rule count > 0" CI
+    // guardrail can check `compiled-rules.json` length directly in their
+    // pipeline.
+    log.info(
+      tag,
+      `No compiled rules at ${totemDir}/${COMPILED_RULES_FILE} — skipping (empty-corpus repo). Run 'totem lesson compile' once you have lessons.`,
+    );
+    return emptyResult;
   }
 
   log.info(tag, `Running ${rules.length} rules (zero LLM)...`);


### PR DESCRIPTION
## What

`totem lint` passed vacuously when the compiled-rules manifest was missing, truncated, or unreadable. `loadCompiledRules` returns `[]` on a missing file, and on a JSON `SyntaxError` or I/O fault (`EISDIR`/`EACCES`) it fired an optional `onWarn` and returned `[]` — but the lint call site omitted `onWarn`, so even the accounting line was dropped (the producer-accounts/consumer-drops shape of mmnto-ai/totem-strategy#970, on a new surface). In this repo that meant all 485 compiled rules could silently disarm behind a green exit — pre-push hook, CI "Totem Lint" job, and every consumer repo none the wiser.

## How

Enforcement lives entirely at the CLI call site — `@mmnto/core`'s `loadCompiledRules` public API and its return-`[]` semantics are unchanged:

- The lint call site threads an `onWarn` that records **and renders** the load-time warning.
- When zero rules load, a **corpus-bearing discriminator** (config-driven: do the config's lesson-kind targets match real files on disk? pure filesystem, no git spawn) decides between four states:
  - **Not corpus-bearing** → today's info-skip, byte-preserved (mmnto-ai/totem#1831 early-adoption semantics).
  - **Corpus-bearing + manifest missing** → `TotemError`, non-zero exit: "enforcement disarmed", naming lesson count + manifest path + fix hint.
  - **Corpus-bearing + manifest unloadable** (truncated JSON / EISDIR / IO) → `TotemError` including the recorded load warning.
  - **Corpus-bearing + manifest valid but zero ACTIVE rules** (all archived / pending-verification / untested-against-codebase) → honest info-skip that names the lifecycle state — archived-in-place rules preserve telemetry by design and are not a disarmed gate.
- Zod-shape errors continue to throw from core, unchanged.
- `shield estimate` (the other `runCompiledRules` caller) deliberately does not opt in — its forecast path is not the enforcement gate; the `config` option's doc comment states the opt-in contract.

## Tests (7 new — failure **and** control assertions, per the Prop 309 quota-item bar)

Induced-failure:

1. Lessons present + manifest deleted → throws "enforcement disarmed".
2. Lessons present + manifest truncated mid-array → throws (previously passed vacuously).
3. Lessons present + manifest replaced by a directory (EISDIR, Windows-portable) → throws, and the previously-dropped `onWarn` accounting text is asserted in the error.
4. Concrete (non-wildcard) lesson target — the production config's aggregated `.totem/lessons.md` shape — reaches the discriminator through the `statSync` branch and throws.

Controls:

5. Config declares a lesson target but no lesson files exist → clean info-skip (mmnto-ai/totem#1831 preserved).
6. Valid manifest, all rules archived → clean, with the zero-active-rules message.
7. Valid active rules → behavior unchanged.
8. Config-less caller (the `shield estimate` shape) + truncated manifest → resolves clean, and the accounting line still renders — the opt-out covers the exit code, not the disclosure.

## Local review loop (two-lane fan, settled at convergence)

Three rounds, each settling the prior round's findings. Absorbed: walk bound past `.lancedb`/`dist` (round 0 WARN), concrete-glob branch coverage (round 1 WARN), config-less opt-out contract test (round 2 WARN). Declined with evidence: load/exists TOCTOU (single-shot CLI, the only bad arm needs a concurrent manifest-create inside a microsecond window); `LINT_LESSONS_FAILED` registration (already a member of the code union at `packages/core/src/errors.ts:25`, used by `compile` and `lint-lessons`); further skip-list enumeration (cold path, same-shape recycle of an absorbed finding). Convergence named at round 2 on monotonically weaker sub-0.5 findings.

## Provenance

First quota item of the Prop 309 hardening program (mmnto-ai/totem-strategy#971, operator-ruled 2026-07-23; directed GO from the bus). Source defect verified 2026-07-23 against `compiler.ts:161/173-182` and `run-compiled-rules.ts:150/157`. This change also reconciles two standing corpus lessons that were in direct tension — "gracefully skip linting on empty rules" (`lesson-0fde21c0`) vs "quality gate tools must never exit successfully when required rules are missing" (`lessons.md`) — via the corpus-bearing discriminator: both are now true in their own regime.

Changeset: `@mmnto/cli` minor (user-visible exit-code change, mirroring the mmnto-ai/totem#2454 sibling's bump class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
