### PR TITLE
chore: totem postmerge lessons for 2499

### DIFF
--- a/.totem/lessons/lesson-973b485e.md
+++ b/.totem/lessons/lesson-973b485e.md
@@ -1,0 +1,6 @@
+## Lesson — Bound filesystem walks past heavy subtrees
+
+**Tags:** performance, filesystem
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Broad glob matching walks can cause severe performance issues or resource exhaustion when traversing large directories. Explicitly skip heavy subtrees like dependency, build, or data directories (e.g., node_modules, .lancedb, dist) during filesystem scans.

--- a/.totem/lessons/lesson-a0b42430.md
+++ b/.totem/lessons/lesson-a0b42430.md
@@ -1,0 +1,6 @@
+## Lesson — Differentiate empty corpus from disarmed enforcement
+
+**Tags:** lint, architecture
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+A zero-rule load can represent an early-adoption repository, a legitimate all-archived lifecycle state, or a disarmed gate where a corpus exists but rules failed to load. Use a discriminator (like verifying source files) to distinguish legitimate empty states from enforcement failures. This reconciles two standing lessons that are each true in their own regime — "Gracefully skip linting on empty rules" (lesson-0fde21c0, the empty-corpus regime) and "Quality gate tools must never exit successfully" (.totem/lessons.md, the corpus-bearing regime); the on-disk corpus check is the boundary that decides which regime applies.

--- a/.totem/lessons/lesson-aa22dfe1.md
+++ b/.totem/lessons/lesson-aa22dfe1.md
@@ -1,0 +1,6 @@
+## Lesson — Capture and forward load warnings
+
+**Tags:** lint, error-handling
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Omitting error or warning callbacks when invoking underlying resource loaders leads to silent enforcement bypasses. Always wire loader warning hooks to the CLI's reporting or error handler at the call site.

--- a/.totem/lessons/lesson-e4df00c0.md
+++ b/.totem/lessons/lesson-e4df00c0.md
@@ -1,0 +1,6 @@
+## Lesson — Induce EISDIR by replacing a file with a directory
+
+**Tags:** testing, windows, portability
+**Scope:** packages/**/*.test.ts
+
+Portable induced I/O fault for tests: replace the target file with a directory so reads fail with EISDIR on both win32 and posix. Permission-bit tricks such as chmod do not port to Windows; a directory in place of a file fails readFileSync identically everywhere, giving induced-failure tests a cross-platform fault primitive.

--- a/.totem/lessons/lesson-f2724cb0.md
+++ b/.totem/lessons/lesson-f2724cb0.md
@@ -1,0 +1,6 @@
+## Lesson — Assert on joined spy arguments
+
+**Tags:** testing, logging
+**Scope:** packages/cli/src/commands/**/*.test.ts
+
+When asserting on console or stderr spies, join all call arguments instead of inspecting only the first element. This prevents assertions from silently passing or failing when logging utilities format or split tags into separate arguments.


### PR DESCRIPTION
Postmerge lesson extraction for the merged lint vacuous-pass triple (PR 2499, squash 6cd48473). Extraction-only under the standing rule-compilation freeze — lesson files only, matching the freeze-era precedent of mmnto-ai/totem#2469 and mmnto-ai/totem#2498. The referenced PRs are already merged; nothing here references any open issue.

## What

Five lesson files (four from `totem lesson extract 2499` on @mmnto/cli 1.105.0, one hand-added):

- `lesson-aa22dfe1` — Capture and forward load warnings (the producer-accounts/consumer-drops shape on the loader `onWarn` seam; mmnto-ai/totem-strategy#970 recurrence surface)
- `lesson-a0b42430` — Differentiate empty corpus from disarmed enforcement (edited post-extraction to name the reconciliation it encodes: `lesson-0fde21c0` "gracefully skip on empty rules" vs the lessons.md entry "quality gate tools must never exit successfully" — each true in its own regime; the on-disk corpus check is the boundary that decides which applies)
- `lesson-f2724cb0` — Assert on joined spy arguments (greptile inline finding, absorbed at b68bc69d)
- `lesson-973b485e` — Bound filesystem walks past heavy subtrees (the `.lancedb`/`dist` walk bound, absorbed at e459b440)
- `lesson-e4df00c0` — Induce EISDIR by replacing a file with a directory (hand-added: the portable induced-fault primitive from the PR's test suite, direct tooling for the hardening train's induced-failure-test mandate)

## Re-laundering guard (dispositions diff)

The extracted set was diffed against the review round's dispositions before banking:

- **Not banked:** the async-wrapper-over-sync-fs suggestion (declined on the file's 13-site lazy-import convention), the `LINT_LESSONS_FAILED` registration item (self-retracted by CodeRabbit and independently declined locally against `packages/core/src/errors.ts:25`), and any TOCTOU-as-defect framing (the race is accepted-by-design; only the document-the-seam half was absorbed).
- **Dedup verified against the existing corpus:** the five spy-adjacent lessons cover mock restoration and logger-contract concerns, not call-arg arity; the only walk-adjacent lesson is `require.resolve`-specific.

## Freeze note

Compile freeze ACTIVE — no `.totem/compiled-rules.json` or `compile-manifest.json` changes; these lessons compile when the spine lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
