### PR TITLE
feat(lint): Class 7 target-mismatch load-time guard + archive both corpus landmines (freeze exception, Prop 309)

### DIFF
--- a/.changeset/target-mismatched-rule-load-guard.md
+++ b/.changeset/target-mismatched-rule-load-guard.md
@@ -1,0 +1,18 @@
+---
+'@mmnto/totem': minor
+'@mmnto/cli': minor
+---
+
+fix(lint): target-mismatched AST rules fail loud at rule load instead of aborting a future lint
+
+An `ast-grep` (or `ast`) rule whose declared `fileGlobs` all point at extensions with no registered Tree-sitter language can never execute — and it did not fail quietly. `resolveAstGrepLangs` silently falls back to `Lang.Tsx` when no glob resolves, so the rule looked healthy at load; `rule-engine.ts` then threw `TotemParseError` the first time a diff happened to contain a file the rule's globs claimed, and that throw escaped the per-file loop and aborted the **entire** lint. The observed specimen was a rule scoped to four `.json` paths. Diff-dependent detonation is the worst property of the class: the gate reads green on every run until the one run where it doesn't.
+
+`totem lint` now validates every loaded AST rule at load time, adjacent to the corpus-bearing gate from mmnto-ai/totem#2499 and with the same fail-closed posture. A rule with non-empty `fileGlobs` whose positive globs all name concrete extensions, none of which resolves to a registered language, throws a `TotemError` naming each offending `lessonHash`, its engine, its globs, the unregistered extensions, and all three remedies (sync the pack that provides the language, archive the rule, or fix its globs/engine) alongside a snapshot of the currently-registered extensions. The check runs on every invocation regardless of the diff, and both `'ast-grep'` and `'ast'` rules are covered because `rule-engine.ts` aborts on the union of the two.
+
+The pre-existing `--ast-parse-mode lenient` operator escape (mmnto-ai/totem#1982) is honored: in lenient mode the guard renders the same accounting as a warning and lets the run continue, since the offending rules are inert either way. Without that branch the guard would remove the only way to lint a repo whose rules target a pack language it has not installed yet. The strict default is unchanged and still fails closed.
+
+Two shapes stay permitted: **globless** rules keep the documented `Lang.Tsx` fallback (unscoped pre-1.16 rules, which `rule-engine.ts` never throws for), and **extensionless positive globs** (`src/**`, `**/*.{ts,json}`) are treated as resolvable — they match `.ts` files at run time, so absence of a trailing extension is absence of evidence, not proof of mismatch. Lifecycle status needs no handling: `loadCompiledRules` already drops archived / pending-verification / untested-against-codebase rules before the guard sees them, which is what makes archiving a working remedy. Pack-contributed languages are honored — `bootstrapEngine` runs before the check, so a pack that registers `.rs` has already populated the registry.
+
+`@mmnto/totem` additionally exports `TRAILING_EXT_RE` so the guard extracts target extensions exactly the way `resolveAstGrepLangs` does; a divergent copy would make the guard disagree with the dispatcher it protects.
+
+Class 7 of the Prop 309 hardening program (mmnto-ai/totem-strategy#971).

--- a/.totem/compile-manifest.json
+++ b/.totem/compile-manifest.json
@@ -1,7 +1,7 @@
 {
-  "compiled_at": "2026-07-12T21:12:45.328Z",
+  "compiled_at": "2026-07-28T20:50:46.919Z",
   "model": "gemini-3-flash-preview",
   "input_hash": "887b20d48cfafd849ba15003866da2beba5be5d9352627300667375a3b36f60f",
-  "output_hash": "901efc0bbc0128268e73f9559f80ad15cbc9541ab16983c07fdbc4798071c340",
+  "output_hash": "be747bd824418ac8791b8fe0b79428bdd0bf80c75abfc32ee5942962efe78acf",
   "rule_count": 485
 }

--- a/.totem/compiled-rules.json
+++ b/.totem/compiled-rules.json
@@ -2229,7 +2229,9 @@
         "**/mcp*.json",
         "**/.cursor/mcp.json"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Target-mismatched verification: engine ast-grep with all-.json fileGlobs, but no Tree-sitter language registration exists for .json — the rule can never execute and instead aborts lint at first contact with a matching diff file. Enforcement of the class lives in the regex twin 5bc302726128eceb (same heading, severity error). Archived under the operator-confirmed narrow hand-edit + --refresh-manifest freeze exception (2026-07-28, recorded mmnto-ai/totem-strategy#974; adjudicated exception class per #2343)."
     },
     {
       "lessonHash": "3bb96274aa5aca93",
@@ -4814,7 +4816,9 @@
       "fileGlobs": [
         "packages/pack-agent-security/turbo.json"
       ],
-      "severity": "warning"
+      "severity": "warning",
+      "status": "archived",
+      "archivedReason": "Target-mismatched verification, specimen 2 of the class: engine ast-grep with a sole .json fileGlob (packages/pack-agent-security/turbo.json) — no Tree-sitter language registration exists for .json, so the rule can never execute and instead aborts the whole lint (rule-engine.ts TotemParseError, run-wide) at first contact with a diff touching that path. Found by the mechanical target-mismatch sweep run before building the Prop 309 Class 7 load-time guard; sibling of 1a7080ebf6162de3. Archived under the same operator-confirmed narrow hand-edit + --refresh-manifest freeze exception (ruled in-class + per-specimen operator confirm 2026-07-28, recorded mmnto-ai/totem-strategy#974; adjudicated exception class per #2343)."
     },
     {
       "lessonHash": "2f09502117f56a77",

--- a/docs/data/lint-receipt.json
+++ b/docs/data/lint-receipt.json
@@ -6,10 +6,12 @@
   "errors": 0,
   "warnings": 20,
   "llmCalls": 0,
+  "astParseMode": "lenient",
+  "targetMismatchGuardWarning": true,
   "apiKeysStripped": true,
-  "elapsedMs": 3570,
+  "elapsedMs": 3598,
   "platform": "win32-x64",
   "node": "24.16.0",
-  "cliVersion": "1.96.0",
-  "generatedAt": "2026-07-15T02:58:15.223Z"
+  "cliVersion": "1.105.0",
+  "generatedAt": "2026-07-28T23:05:49.001Z"
 }

--- a/docs/wiki/maturity.md
+++ b/docs/wiki/maturity.md
@@ -48,7 +48,7 @@ The legacy lesson→rule compiler has been parked under a standing freeze since 
 
 <!-- docs LINT_RECEIPT -->
 
-A real merged diff of this repository (`c14e90ab..ba8c591d`, 41 files) linted in **3570 ms** with **zero LLM calls** — the run executed with every provider API key stripped from the environment, so there was nothing to silently call. 387 rules evaluated; 0 errors, 20 warnings. Environment: win32-x64, node 24.16.0, CLI 1.96.0, generated 2026-07-15. CI recomputes this receipt on every pull request — the counts must match; timing is environment-labeled, never gated.
+A real merged diff of this repository (`c14e90ab..ba8c591d`, 41 files) linted in **3598 ms** with **zero LLM calls** — the run executed with every provider API key stripped from the environment, so there was nothing to silently call. 387 rules evaluated; 0 errors, 20 warnings. Environment: win32-x64, node 24.16.0, CLI 1.105.0, generated 2026-07-28. CI recomputes this receipt on every pull request — the counts must match; timing is environment-labeled, never gated. The replay runs with `--ast-parse-mode lenient` — the pinned corpus predates the current target-mismatch load guard — and the receipt records that posture (`astParseMode`) plus whether the guard fired (`targetMismatchGuardWarning: true`).
 
 <!-- /docs -->
 

--- a/packages/cli/src/commands/run-compiled-rules.test.ts
+++ b/packages/cli/src/commands/run-compiled-rules.test.ts
@@ -1,6 +1,7 @@
 import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -1359,10 +1360,18 @@ describe('--ast-parse-mode lenient', () => {
 
   // totem-context: helper has no OrExit suffix; the rule misclassifies test-fixture builders that return literal objects
   function makeAstRuleAndDiff() {
+    // fileGlobs target a REGISTERED extension on purpose. These tests mock
+    // `applyAstRulesToAdditions` wholesale — the fixture rule exists only to make
+    // `astRules.length > 0` so the mocked pipeline is reached, and the rust
+    // wording lives in the mocked error, not the rule. A `**/*.rs` glob would now
+    // be condemned by the rule-load target-mismatch guard
+    // (mmnto-ai/totem-strategy#971, Prop 309 Class 7) before the mock is ever
+    // consulted, which would test the guard instead of the parse-mode routing
+    // these cases exist for. The guard's own coverage lives in its describe block.
     const astRule = makeRule('', 'rust pattern', 'No unsafe', {
       engine: 'ast-grep',
       astGrepPattern: 'unsafe { $$$ }',
-      fileGlobs: ['**/*.rs'],
+      fileGlobs: ['**/*.ts'],
     });
     saveCompiledRules(path.join(tmpDir, TOTEM_DIR, 'compiled-rules.json'), [astRule]);
 
@@ -1883,5 +1892,365 @@ describe('corpus-bearing zero-rules hard-error (mmnto-ai/totem-strategy#971)', (
         },
       }),
     ).rejects.toThrow(/enforcement disarmed/i);
+  });
+});
+
+// ─── Target-mismatched rule hard-error (mmnto-ai/totem-strategy#971, Prop 309 Class 7) ──
+//
+// An AST rule whose declared `fileGlobs` ALL target extensions with no
+// registered Tree-sitter language can never execute. Worse, it does not fail
+// quietly: `rule-engine.ts` throws the moment a diff contains a file the rule's
+// globs claim, and that throw aborts the entire lint. Before this guard the
+// failure was diff-dependent — green on every run until the unlucky one. The
+// guard moves it to rule-LOAD time so it fires deterministically.
+describe('target-mismatched rule hard-error (mmnto-ai/totem-strategy#971, Prop 309 Class 7)', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-rcr-target-'));
+    fs.mkdirSync(path.join(tmpDir, TOTEM_DIR), { recursive: true });
+  });
+
+  afterEach(() => {
+    cleanTmpDir(tmpDir);
+  });
+
+  /** The observed specimen's shape: ast-grep scoped entirely to `.json` files. */
+  function mismatchedAstGrepRule(overrides: Partial<CompiledRule> = {}): CompiledRule {
+    return makeRule('', 'No inline secrets in agent config', 'No inline secrets', {
+      lessonHash: 'target-mismatch-astgrep',
+      engine: 'ast-grep',
+      astGrepPattern: 'pair($KEY, $VALUE)',
+      fileGlobs: ['**/.mcp.json', '**/.cursor/mcp.json'],
+      ...overrides,
+    });
+  }
+
+  const cleanDiff = (): string => makeDiff('src/app.ts', '  const x = 1;');
+
+  // ── Induced failure ─────────────────────────────────
+
+  it('hard-errors at load when every positive glob of an ast-grep rule targets an unregistered extension', async () => {
+    writeRules(tmpDir, [mismatchedAstGrepRule()]);
+
+    await expect(
+      runCompiledRules({
+        diff: cleanDiff(),
+        cwd: tmpDir,
+        totemDir: TOTEM_DIR,
+        format: 'text',
+        tag: 'Test',
+      }),
+    ).rejects.toThrow(/enforcement disarmed/i);
+  });
+
+  it('names the lessonHash, the engine, every glob, the unregistered extension, and the archive-or-fix remedy', async () => {
+    writeRules(tmpDir, [mismatchedAstGrepRule()]);
+
+    let message = '';
+    let hint = '';
+    try {
+      await runCompiledRules({
+        diff: cleanDiff(),
+        cwd: tmpDir,
+        totemDir: TOTEM_DIR,
+        format: 'text',
+        tag: 'Test',
+      });
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+      hint = err instanceof TotemError ? err.recoveryHint : '';
+    }
+
+    // Everything the operator needs to act without opening the manifest.
+    expect(message).toContain('target-mismatch-astgrep');
+    expect(message).toContain('No inline secrets');
+    expect(message).toContain("engine 'ast-grep'");
+    expect(message).toContain('**/.mcp.json');
+    expect(message).toContain('**/.cursor/mcp.json');
+    expect(message).toContain('.json');
+    // The detonation mechanism is named, not just the mismatch.
+    expect(message).toContain('abort the entire lint');
+    // Both remedies, plus the registry snapshot that makes "fix the globs" actionable.
+    expect(hint).toContain("status: 'archived'");
+    expect(hint).toContain('fileGlobs');
+    expect(hint).toContain('.tsx');
+  });
+
+  it("hard-errors for the engine:'ast' variant — the abort seam unions both AST engines", async () => {
+    // rule-engine.ts searches `allAstRules` (Tree-sitter 'ast' ∪ 'ast-grep') for
+    // a rule claiming the unparseable file, so an 'ast' rule arms the identical
+    // landmine and must be validated identically.
+    writeRules(tmpDir, [
+      makeRule('', 'No secrets in settings', 'No secrets in settings', {
+        lessonHash: 'target-mismatch-ast',
+        engine: 'ast',
+        astQuery: '(pair) @p',
+        fileGlobs: ['**/settings.json'],
+      }),
+    ]);
+
+    let message = '';
+    try {
+      await runCompiledRules({
+        diff: cleanDiff(),
+        cwd: tmpDir,
+        totemDir: TOTEM_DIR,
+        format: 'text',
+        tag: 'Test',
+      });
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+
+    expect(message).toMatch(/enforcement disarmed/i);
+    expect(message).toContain('target-mismatch-ast');
+    expect(message).toContain("engine 'ast'");
+  });
+
+  it("fires on a diff that touches NONE of the rule's globs — deterministic at load, not on first contact", async () => {
+    // The whole point of the hardening. The diff is a .ts file; the broken rule
+    // is scoped to .json. Pre-guard this run was green and the landmine stayed
+    // armed for whichever future diff happened to touch a .json file.
+    writeRules(tmpDir, [mismatchedAstGrepRule()]);
+
+    await expect(
+      runCompiledRules({
+        diff: makeDiff('src/unrelated.ts', '  const unrelated = true;'),
+        cwd: tmpDir,
+        totemDir: TOTEM_DIR,
+        format: 'json',
+        tag: 'Test',
+      }),
+    ).rejects.toThrow(/enforcement disarmed/i);
+  });
+
+  it('reports every offender in one deterministic failure rather than stopping at the first', async () => {
+    writeRules(tmpDir, [
+      mismatchedAstGrepRule({ lessonHash: 'offender-one' }),
+      mismatchedAstGrepRule({ lessonHash: 'offender-two', fileGlobs: ['config/*.yaml'] }),
+    ]);
+
+    let message = '';
+    try {
+      await runCompiledRules({
+        diff: cleanDiff(),
+        cwd: tmpDir,
+        totemDir: TOTEM_DIR,
+        format: 'text',
+        tag: 'Test',
+      });
+    } catch (err) {
+      message = err instanceof Error ? err.message : String(err);
+    }
+
+    expect(message).toContain('2 active AST rule(s)');
+    expect(message).toContain('offender-one');
+    expect(message).toContain('offender-two');
+    expect(message).toContain('.yaml');
+  });
+
+  // ── Operator escape (mmnto-ai/totem#1982) ───────────
+
+  it('degrades to a warning under --ast-parse-mode lenient instead of hard-erroring', async () => {
+    // Without this, the guard would remove the ONLY escape for a repo whose
+    // rules target a pack language it has not installed — `.rs` here, exactly
+    // the shape @mmnto/pack-rust-architecture provides.
+    writeRules(tmpDir, [
+      mismatchedAstGrepRule({ lessonHash: 'pack-language-rule', fileGlobs: ['**/*.rs'] }),
+    ]);
+
+    const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const result = await runCompiledRules({
+        diff: cleanDiff(),
+        cwd: tmpDir,
+        totemDir: TOTEM_DIR,
+        format: 'json',
+        tag: 'Test',
+        astParseMode: 'lenient',
+      });
+
+      expect(result.rules).toHaveLength(1);
+      expect(JSON.parse(result.output).pass).toBe(true);
+      // The disclosure survives the exit-code escape: lenient covers the failure,
+      // never the accounting.
+      const messages = stderrSpy.mock.calls.map((c) => c.join(' '));
+      const warning = messages.find((m) => m.includes('target-mismatched'));
+      expect(warning).toBeDefined();
+      expect(warning).toContain('pack-language-rule');
+      expect(warning).toContain('.rs');
+      expect(warning).toContain('totem sync --packs-only');
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it('strict mode is the default — an omitted astParseMode still hard-errors', async () => {
+    writeRules(tmpDir, [mismatchedAstGrepRule({ fileGlobs: ['**/*.rs'] })]);
+
+    await expect(
+      runCompiledRules({
+        diff: cleanDiff(),
+        cwd: tmpDir,
+        totemDir: TOTEM_DIR,
+        format: 'text',
+        tag: 'Test',
+      }),
+    ).rejects.toThrow(/enforcement disarmed/i);
+  });
+
+  // ── Negative controls ───────────────────────────────
+
+  it('control: the same rule with status:archived loads clean — archiving is the offered remedy', async () => {
+    // Closes the loop on the offered fix: loadCompiledRules drops inert rules
+    // before the guard ever sees them, so following the hint actually works.
+    writeRules(tmpDir, [mismatchedAstGrepRule({ status: 'archived' })]);
+
+    const stderrSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const result = await runCompiledRules({
+        diff: cleanDiff(),
+        cwd: tmpDir,
+        totemDir: TOTEM_DIR,
+        format: 'text',
+        tag: 'Test',
+      });
+      expect(result.rules).toHaveLength(0);
+      expect(result.violations).toHaveLength(0);
+    } finally {
+      stderrSpy.mockRestore();
+    }
+  });
+
+  it('control: a globless ast-grep rule loads clean — the documented Lang.Tsx fallback stays permitted', async () => {
+    // Unscoped pre-1.16 rules legitimately carry no fileGlobs, and
+    // rule-engine.ts only throws for a rule with non-empty globs, so a globless
+    // rule cannot arm the landmine.
+    writeRules(tmpDir, [
+      makeRule('', 'No foo log', 'No foo log', {
+        engine: 'ast-grep',
+        astGrepPattern: 'console.log("foo")',
+      }),
+    ]);
+
+    const result = await runCompiledRules({
+      diff: cleanDiff(),
+      cwd: tmpDir,
+      totemDir: TOTEM_DIR,
+      format: 'json',
+      tag: 'Test',
+    });
+
+    expect(result.rules).toHaveLength(1);
+    expect(JSON.parse(result.output).pass).toBe(true);
+  });
+
+  it('control: one resolvable glob among unresolvable ones loads clean', async () => {
+    // The rule CAN execute — the condemnation requires that not one positive
+    // glob resolves.
+    writeRules(tmpDir, [mismatchedAstGrepRule({ fileGlobs: ['**/*.json', '**/*.ts'] })]);
+
+    const result = await runCompiledRules({
+      diff: cleanDiff(),
+      cwd: tmpDir,
+      totemDir: TOTEM_DIR,
+      format: 'json',
+      tag: 'Test',
+    });
+
+    expect(result.rules).toHaveLength(1);
+    expect(JSON.parse(result.output).pass).toBe(true);
+  });
+
+  it('control: extensionless positive globs (src/**) load clean — absence of evidence is not proof of mismatch', async () => {
+    // TRAILING_EXT_RE extracts nothing from `src/**` or `**/*.{ts,json}`, but at
+    // run time both match .ts files and dispatch fine. Condemning them would
+    // hard-error legitimately broad rules.
+    writeRules(tmpDir, [
+      mismatchedAstGrepRule({ lessonHash: 'broad-one', fileGlobs: ['src/**'] }),
+      mismatchedAstGrepRule({ lessonHash: 'broad-two', fileGlobs: ['**/*.{ts,json}'] }),
+      mismatchedAstGrepRule({ lessonHash: 'broad-three', fileGlobs: ['packages/**/*'] }),
+    ]);
+
+    const result = await runCompiledRules({
+      diff: cleanDiff(),
+      cwd: tmpDir,
+      totemDir: TOTEM_DIR,
+      format: 'json',
+      tag: 'Test',
+    });
+
+    expect(result.rules).toHaveLength(3);
+    expect(JSON.parse(result.output).pass).toBe(true);
+  });
+
+  it('control: a REGEX rule scoped entirely to .json is untouched — the guard is AST-only', async () => {
+    // Regex rules never dispatch through the Tree-sitter language registry, so
+    // .json scoping is completely legitimate for them.
+    writeRules(tmpDir, [
+      makeRule('"apiKey"', 'No inline keys', 'No inline keys', {
+        fileGlobs: ['**/.mcp.json'],
+      }),
+    ]);
+
+    const result = await runCompiledRules({
+      diff: cleanDiff(),
+      cwd: tmpDir,
+      totemDir: TOTEM_DIR,
+      format: 'json',
+      tag: 'Test',
+    });
+
+    expect(result.rules).toHaveLength(1);
+    expect(JSON.parse(result.output).pass).toBe(true);
+  });
+
+  it('control: an all-negation glob list loads clean — it matches every file, including resolvable ones', async () => {
+    writeRules(tmpDir, [mismatchedAstGrepRule({ fileGlobs: ['!**/*.json'] })]);
+
+    const result = await runCompiledRules({
+      diff: cleanDiff(),
+      cwd: tmpDir,
+      totemDir: TOTEM_DIR,
+      format: 'json',
+      tag: 'Test',
+    });
+
+    expect(result.rules).toHaveLength(1);
+    expect(JSON.parse(result.output).pass).toBe(true);
+  });
+
+  // ── The real corpus ─────────────────────────────────
+
+  it("the repository's own .totem/compiled-rules.json loads clean through the guard", async () => {
+    // Regression anchor for the corpus itself: both known specimens are archived,
+    // so the live manifest must pass. Copied into the tmp dir so the run's metric
+    // and ledger writes never touch the real .totem.
+    const realManifest = fileURLToPath(
+      new URL('../../../../.totem/compiled-rules.json', import.meta.url),
+    );
+    // A missing fixture would make every assertion below vacuous — fail loudly
+    // instead of silently skipping.
+    expect(fs.existsSync(realManifest)).toBe(true);
+    fs.copyFileSync(realManifest, path.join(tmpDir, TOTEM_DIR, 'compiled-rules.json'));
+
+    // A .txt path no compiled rule scopes to, so the run exercises rule LOAD
+    // (where the guard lives) without dispatching AST rules against fixtures
+    // that do not exist in the tmp dir.
+    const result = await runCompiledRules({
+      diff: makeDiff('docs/example.txt', 'A plain note.'),
+      cwd: tmpDir,
+      totemDir: TOTEM_DIR,
+      format: 'json',
+      tag: 'Test',
+    });
+
+    // Non-vacuity: the guard actually had globbed AST rules to inspect.
+    const globbedAstRules = result.rules.filter(
+      (r) =>
+        (r.engine === 'ast-grep' || r.engine === 'ast') && r.fileGlobs && r.fileGlobs.length > 0,
+    );
+    expect(globbedAstRules.length).toBeGreaterThan(0);
   });
 });

--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -185,6 +185,138 @@ async function countLessonCorpusFiles(
   return matched.size;
 }
 
+// ─── Target-mismatch derivation (mmnto-ai/totem-strategy#971, Prop 309 Class 7) ─
+
+/**
+ * Hard-error when a loaded AST rule can never execute because NONE of its
+ * declared `fileGlobs` targets an extension the engine has a registered
+ * Tree-sitter language for (mmnto-ai/totem-strategy#971, Prop 309 Class 7).
+ *
+ * The failure this closes: `resolveAstGrepLangs` (ast-grep-query.ts) silently
+ * falls back to `Lang.Tsx` when no glob resolves, so a target-mismatched rule
+ * looks healthy at load. It then detonates at RUN time — `rule-engine.ts`'s
+ * language check throws `TotemParseError` the first time a diff happens to
+ * contain a file the rule's globs match, and that throw escapes the per-file
+ * loop and aborts the WHOLE lint. The observed specimen was an `ast-grep` rule
+ * whose four globs all pointed at `.json` files, which no language registration
+ * covers. Diff-dependent detonation is the worst property: the gate is green on
+ * every run until the one run where it isn't.
+ *
+ * The guard converts that into a deterministic load-time failure. It runs on
+ * EVERY invocation regardless of the diff, and — unlike the corpus-bearing gate
+ * above — it is deliberately NOT gated on `options.config`. That opt-out exists
+ * because zero-rules is genuinely ambiguous (empty-corpus repo vs disarmed gate)
+ * and the config is the only discriminator. Target-mismatch is unambiguous from
+ * the manifest alone: no discriminator is needed, so there is nothing to opt out
+ * of and `shield estimate` gets the same protection. The one escape is the
+ * pre-existing `--ast-parse-mode lenient` operator flag (see the branch below),
+ * which is opt-in and leaves the strict default fail-closed.
+ *
+ * Scope matches the abort seam exactly. `rule-engine.ts` searches the
+ * `allAstRules` union (Tree-sitter `'ast'` ∪ `'ast-grep'`) for a rule whose
+ * globs claim the unparseable file, so BOTH engines are validated here.
+ *
+ * Two shapes stay permitted:
+ *
+ *   - **Globless rules** (`fileGlobs` absent or empty). The documented
+ *     `Lang.Tsx` fallback is their intended behavior — many pre-1.16 rules ship
+ *     unscoped — and `rule-engine.ts` only throws for a rule with non-empty
+ *     `fileGlobs`, so a globless rule cannot arm the landmine.
+ *   - **Extensionless positive globs** — a recursive `src/**`, a bare-star
+ *     leaf, or a brace-set leaf like `.{ts,json}` (glob literals are omitted
+ *     here because a star-slash pair would close this comment).
+ *     `TRAILING_EXT_RE` extracts nothing from these, but at run time they can
+ *     and do match `.ts` files and dispatch correctly. Absence of a trailing
+ *     extension is absence of evidence, not proof of mismatch — treating it as
+ *     unresolvable would hard-error legitimately broad rules. A rule is only
+ *     condemned when EVERY positive glob names a concrete extension and NOT ONE
+ *     of those extensions resolves.
+ *
+ * Lifecycle status needs no filtering here: `loadCompiledRules` has already
+ * dropped `archived` / `untested-against-codebase` / `pending-verification`
+ * (compiler.ts), so an archived specimen never reaches this function — which is
+ * exactly why archiving is the offered remedy.
+ *
+ * Pack-contributed languages are honored: CLI commands call `bootstrapEngine`
+ * (→ `loadInstalledPacks`) before this point, so a pack that registers `.rs`
+ * has already populated the registry when the check reads it.
+ */
+async function assertRulesCanTargetTheirGlobs(
+  rules: readonly CompiledRule[],
+  astParseMode: TimeoutMode,
+  onWarn: (msg: string) => void,
+): Promise<void> {
+  const { extensionToLanguage, registeredExtensions, TotemError, TRAILING_EXT_RE } =
+    await import('@mmnto/totem');
+
+  const offenders: Array<{ rule: CompiledRule; globs: string[]; extensions: string[] }> = [];
+
+  for (const rule of rules) {
+    if (rule.engine !== 'ast-grep' && rule.engine !== 'ast') continue;
+    const globs = rule.fileGlobs;
+    if (!globs || globs.length === 0) continue;
+
+    // Negations describe files the rule must NOT match, so they never carry a
+    // dispatch target — same skip `resolveAstGrepLangs` performs.
+    const positive = globs.filter((g) => typeof g === 'string' && !g.startsWith('!'));
+    // An all-negation glob list matches every file (see the zero-match
+    // derivation below, where `positive.length === 0` matches unconditionally),
+    // so it necessarily reaches resolvable files. Permitted.
+    if (positive.length === 0) continue;
+
+    const extensions: string[] = [];
+    let resolvable = false;
+    for (const glob of positive) {
+      const match = glob.match(TRAILING_EXT_RE);
+      if (!match) {
+        // Extensionless positive glob — unprovable, therefore permitted.
+        resolvable = true;
+        break;
+      }
+      const ext = `.${match[1]!.toLowerCase()}`;
+      if (extensionToLanguage(ext)) {
+        resolvable = true;
+        break;
+      }
+      if (!extensions.includes(ext)) extensions.push(ext);
+    }
+    if (!resolvable) offenders.push({ rule, globs: positive, extensions });
+  }
+
+  if (offenders.length === 0) return;
+
+  // Deterministic detail line per offender — corpus order, every field the
+  // operator needs to act without opening the manifest.
+  const detail = offenders
+    .map(
+      (o) =>
+        `'${o.rule.lessonHash}' (${o.rule.lessonHeading}) engine '${o.rule.engine}' fileGlobs [${o.globs.join(', ')}] → unregistered extension(s) ${o.extensions.join(', ')}`,
+    )
+    .join('; ');
+
+  const summary = `${offenders.length} active AST rule(s) declare fileGlobs whose extensions have no registered Tree-sitter language, so they can never match and instead abort the entire lint on first contact with a file they claim — ${detail}.`;
+  // Three remedies, deliberately un-ranked: the manifest alone cannot tell a
+  // permanently-broken rule (`.json`, which no pack will ever register) from an
+  // incomplete environment (`.rs`, which a pack provides but which has not been
+  // installed/synced here). Leading with "archive it" would misdiagnose the
+  // second case, which `rule-engine.ts`'s STALE_MANIFEST path handles well.
+  const remedy = `Install or sync the pack that provides the language ('totem sync --packs-only'), archive each rule (set status: 'archived'), or correct its fileGlobs/engine so at least one positive glob targets a registered extension. Registered now: ${registeredExtensions().join(', ')}.`;
+
+  if (astParseMode === 'lenient') {
+    // Honor the operator escape (mmnto-ai/totem#1982). `--ast-parse-mode lenient`
+    // already means "an AST language the engine cannot parse degrades this run
+    // instead of failing it", and a target-mismatched rule is exactly that class
+    // — it simply fails at load rather than at dispatch. Without this branch the
+    // guard would REMOVE the only escape for a repo whose rules target a pack
+    // language it has not installed, leaving the operator no way to lint at all.
+    // The rules stay inert either way, so lenient loses no enforcement it had.
+    onWarn(`AST rules target-mismatched (--ast-parse-mode lenient): ${summary} ${remedy}`);
+    return;
+  }
+
+  throw new TotemError('LINT_LESSONS_FAILED', `Enforcement disarmed: ${summary}`, remedy);
+}
+
 // ─── Core logic ─────────────────────────────────────
 
 /**
@@ -320,6 +452,20 @@ export async function runCompiledRules(
     );
     return emptyResult;
   }
+
+  // mmnto-ai/totem#1982. Resolved here rather than at the AST dispatch site
+  // because the rule-load guard below shares the mode (CLI flag > env > strict).
+  const effectiveAstParseMode: TimeoutMode =
+    astParseMode ??
+    // totem-context: reading Node's process.env (cleaned by the runtime), not parsing a custom .env file; CRLF/quote-stripping rule doesn't apply.
+    (process.env['TOTEM_LINT_AST_PARSE_MODE'] === 'lenient' ? 'lenient' : 'strict');
+
+  // Rule-LOAD validation (mmnto-ai/totem-strategy#971, Prop 309 Class 7). Runs
+  // before any diff is touched so a rule whose engine cannot process ANY of its
+  // declared globs fails on every run, not on the unlucky run whose diff happens
+  // to contain a file it claims. Ordered AFTER the corpus-bearing block so a
+  // missing/unloadable manifest still reports its own (more fundamental) cause.
+  await assertRulesCanTargetTheirGlobs(rules, effectiveAstParseMode, (msg) => log.warn(tag, msg));
 
   log.info(tag, `Running ${rules.length} rules (zero LLM)...`);
 
@@ -480,12 +626,8 @@ export async function runCompiledRules(
   const astRules = rules.filter((r) => r.engine === 'ast' || r.engine === 'ast-grep');
   let astViolations: Violation[] = [];
   const astParseFailures: AstParseFailureOutcome[] = [];
-  // mmnto-ai/totem#1982. Resolve effective mode with env override (matches
-  // the operator escape pattern: CLI flag > env var > default 'strict').
-  const effectiveAstParseMode: TimeoutMode =
-    astParseMode ??
-    // totem-context: reading Node's process.env (cleaned by the runtime), not parsing a custom .env file; CRLF/quote-stripping rule doesn't apply.
-    (process.env['TOTEM_LINT_AST_PARSE_MODE'] === 'lenient' ? 'lenient' : 'strict');
+  // `effectiveAstParseMode` (mmnto-ai/totem#1982) is resolved above the rule-load
+  // guard, which shares the same operator escape.
   if (astRules.length > 0) {
     log.dim(tag, `Running ${astRules.length} AST rule(s)...`);
     try {

--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -246,8 +246,13 @@ async function assertRulesCanTargetTheirGlobs(
   astParseMode: TimeoutMode,
   onWarn: (msg: string) => void,
 ): Promise<void> {
-  const { extensionToLanguage, registeredExtensions, TotemError, TRAILING_EXT_RE } =
-    await import('@mmnto/totem');
+  const {
+    extensionToLanguage,
+    registeredExtensions,
+    sanitizeForTerminal,
+    TotemError,
+    TRAILING_EXT_RE,
+  } = await import('@mmnto/totem');
 
   const offenders: Array<{ rule: CompiledRule; globs: string[]; extensions: string[] }> = [];
 
@@ -294,7 +299,14 @@ async function assertRulesCanTargetTheirGlobs(
     )
     .join('; ');
 
-  const summary = `${offenders.length} active AST rule(s) declare fileGlobs whose extensions have no registered Tree-sitter language, so they can never match and instead abort the entire lint on first contact with a file they claim — ${detail}.`;
+  // Manifest-derived fields (lessonHash, lessonHeading, fileGlobs) are
+  // repo-controlled text reaching operator terminals and CI logs — sanitize the
+  // whole rendered summary so a corrupted or hostile manifest cannot inject
+  // control sequences through the guard's own report. The remedy line is
+  // engine-derived only and needs no sanitizing.
+  const summary = sanitizeForTerminal(
+    `${offenders.length} active AST rule(s) declare fileGlobs whose extensions have no registered Tree-sitter language, so they can never match and instead abort the entire lint on first contact with a file they claim — ${detail}.`,
+  );
   // Three remedies, deliberately un-ranked: the manifest alone cannot tell a
   // permanently-broken rule (`.json`, which no pack will ever register) from an
   // incomplete environment (`.rs`, which a pack provides but which has not been

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -347,7 +347,17 @@ export { matchAstQueriesBatch, matchAstQuery } from './ast-query.js';
 
 // ast-grep query engine
 export type { AstGrepMatch, AstGrepRule } from './ast-grep-query.js';
-export { matchAstGrepPattern, matchAstGrepPatternsBatch } from './ast-grep-query.js';
+// `TRAILING_EXT_RE` is the single source of truth for extracting a target
+// extension out of a `fileGlobs` entry. Exported at the package boundary
+// (mmnto-ai/totem-strategy#971, Prop 309 Class 7) so the CLI's rule-load
+// target-mismatch guard extracts extensions EXACTLY the way
+// `resolveAstGrepLangs` does — a divergent copy of this regex would make the
+// guard disagree with the dispatcher it is protecting.
+export {
+  matchAstGrepPattern,
+  matchAstGrepPatternsBatch,
+  TRAILING_EXT_RE,
+} from './ast-grep-query.js';
 
 // Exporter
 export {

--- a/tools/docs-transforms.cjs
+++ b/tools/docs-transforms.cjs
@@ -335,6 +335,19 @@ function renderLintReceipt(receiptPath) {
   // ADR-115 §2 envelope: a downgraded validation posture must be visible on the
   // rendered surface, not only inside the receipt JSON. Pure function of the
   // receipt fields — absent fields (pre-posture receipts) render nothing.
+  // Posture fields fail loud like every other rendered field: an unknown mode
+  // must not silently hide the posture, and a lenient receipt without the
+  // guard boolean must not interpolate `undefined` into the page.
+  if (r.astParseMode !== undefined && r.astParseMode !== 'strict' && r.astParseMode !== 'lenient') {
+    throw new Error(
+      `[Totem Error] LINT_RECEIPT transform failed: invalid astParseMode: ${String(r.astParseMode)}`,
+    );
+  }
+  if (r.astParseMode === 'lenient' && typeof r.targetMismatchGuardWarning !== 'boolean') {
+    throw new Error(
+      '[Totem Error] LINT_RECEIPT transform failed: lenient receipt missing boolean targetMismatchGuardWarning.',
+    );
+  }
   const posture =
     r.astParseMode === 'lenient'
       ? ` The replay runs with \`--ast-parse-mode lenient\` — the pinned corpus predates the ` +

--- a/tools/docs-transforms.cjs
+++ b/tools/docs-transforms.cjs
@@ -332,13 +332,24 @@ function renderLintReceipt(receiptPath) {
     );
   }
   const range = `${r.baseSha.slice(0, 8)}..${r.headSha.slice(0, 8)}`;
+  // ADR-115 §2 envelope: a downgraded validation posture must be visible on the
+  // rendered surface, not only inside the receipt JSON. Pure function of the
+  // receipt fields — absent fields (pre-posture receipts) render nothing.
+  const posture =
+    r.astParseMode === 'lenient'
+      ? ` The replay runs with \`--ast-parse-mode lenient\` — the pinned corpus predates the ` +
+        `current target-mismatch load guard — and the receipt records that posture ` +
+        `(\`astParseMode\`) plus whether the guard fired (\`targetMismatchGuardWarning: ` +
+        `${r.targetMismatchGuardWarning}\`).`
+      : '';
   return (
     `A real merged diff of this repository (\`${range}\`, ${r.filesChanged} files) linted in ` +
     `**${r.elapsedMs} ms** with **zero LLM calls** — the run executed with every provider API key ` +
     `stripped from the environment, so there was nothing to silently call. ${r.rules} rules evaluated; ` +
     `${r.errors} errors, ${r.warnings} warnings. Environment: ${r.platform}, node ${r.node}, ` +
     `CLI ${r.cliVersion}, generated ${String(r.generatedAt).slice(0, 10)}. CI recomputes this receipt ` +
-    `on every pull request — the counts must match; timing is environment-labeled, never gated.`
+    `on every pull request — the counts must match; timing is environment-labeled, never gated.` +
+    posture
   );
 }
 

--- a/tools/docs-transforms.test.cjs
+++ b/tools/docs-transforms.test.cjs
@@ -266,6 +266,56 @@ test('LINT_RECEIPT renders the zero-LLM claim only from an attesting receipt', (
   assert.throws(() => transforms._renderLintReceipt(undefinedField), /missing platform/);
 });
 
+test('LINT_RECEIPT posture fields render disclosed, absent, or fail loud — never undefined', () => {
+  const base = {
+    baseSha: 'a'.repeat(40),
+    headSha: 'b'.repeat(40),
+    filesChanged: 1,
+    rules: 1,
+    errors: 0,
+    warnings: 0,
+    elapsedMs: 1,
+    llmCalls: 0,
+    apiKeysStripped: true,
+    platform: 'test-x64',
+    node: '24.0.0',
+    cliVersion: '0.0.0',
+    generatedAt: '2026-07-15T00:00:00.000Z',
+  };
+  // Legacy receipt (no posture fields): renders, with no posture sentence.
+  const legacy = transforms._renderLintReceipt(writeTmpJson('legacy-receipt.json', base));
+  assert.ok(!legacy.includes('ast-parse-mode'), 'legacy receipt must not render a posture clause');
+  // Lenient + boolean: posture disclosed on the page, value interpolated.
+  const lenient = transforms._renderLintReceipt(
+    writeTmpJson('lenient-receipt.json', {
+      ...base,
+      astParseMode: 'lenient',
+      targetMismatchGuardWarning: true,
+    }),
+  );
+  assert.ok(
+    lenient.includes('--ast-parse-mode lenient') &&
+      lenient.includes('targetMismatchGuardWarning: true'),
+    'lenient receipt must disclose the posture and the guard outcome',
+  );
+  // Unknown mode: fail loud, never silently hide the posture.
+  assert.throws(
+    () =>
+      transforms._renderLintReceipt(
+        writeTmpJson('badmode-receipt.json', { ...base, astParseMode: 'permissive' }),
+      ),
+    /invalid astParseMode/,
+  );
+  // Lenient without the guard boolean: fail loud, never interpolate undefined.
+  assert.throws(
+    () =>
+      transforms._renderLintReceipt(
+        writeTmpJson('noflag-receipt.json', { ...base, astParseMode: 'lenient' }),
+      ),
+    /missing boolean targetMismatchGuardWarning/,
+  );
+});
+
 test('maturity asOf rejects impossible calendar dates without consulting the clock', () => {
   const badDate = writeTmpJson('bad-date.json', {
     asOf: '2026-02-31',

--- a/tools/gen-lint-receipt.mjs
+++ b/tools/gen-lint-receipt.mjs
@@ -86,9 +86,29 @@ function computeReceipt() {
     }
 
     const started = process.hrtime.bigint();
+    // --ast-parse-mode lenient: this is a REPLAY of a pinned historical tree,
+    // and the current CLI's load-time target-mismatch guard (Prop 309 Class 7)
+    // judges that tree's committed .totem/compiled-rules.json by present-day
+    // rules — the pinned corpus predates the archive of two target-mismatched
+    // specimens, so the strict default would hard-error before lint emits JSON.
+    // Lenient degrades the guard to a stderr accounting warning without
+    // touching any pinned count, which is the honest posture for an archival
+    // reproduction: the receipt attests what that range linted to, not that
+    // the historical corpus passes current load validation.
     const run = spawnSync(
       process.execPath,
-      [CLI_DIST, 'lint', '--base', BASE_SHA, '--format', 'json', '--out', outFile],
+      [
+        CLI_DIST,
+        'lint',
+        '--base',
+        BASE_SHA,
+        '--format',
+        'json',
+        '--out',
+        outFile,
+        '--ast-parse-mode',
+        'lenient',
+      ],
       { cwd: WORKTREE, env, encoding: 'utf-8' },
     );
     const elapsedMs = Number((process.hrtime.bigint() - started) / 1_000_000n);

--- a/tools/gen-lint-receipt.mjs
+++ b/tools/gen-lint-receipt.mjs
@@ -33,6 +33,9 @@ const PINNED_FIELDS = [
   'errors',
   'warnings',
   'llmCalls',
+  // The parse mode the counts were produced under is part of the attestation
+  // contract — a receipt that silently changed modes is not a reproduction.
+  'astParseMode',
 ];
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -43,6 +46,24 @@ const WORKTREE = path.join(ROOT, '.totem', 'temp', 'a3-receipt-worktree');
 function fail(message) {
   console.error(`[Totem Error] gen-lint-receipt: ${message}`);
   process.exit(1);
+}
+
+/**
+ * Best-effort worktree dir removal. On Windows the just-exited lint child (or
+ * an AV scanner) can hold a lingering handle that EPERMs rmSync — and a
+ * cleanup failure must never fail a receipt run whose real work already
+ * succeeded. The leftover lives under gitignored .totem/temp/ and the next
+ * run's pre-clean sweeps it.
+ */
+function removeWorktreeDir() {
+  try {
+    fs.rmSync(WORKTREE, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 });
+  } catch (err) {
+    console.error(
+      `[gen-lint-receipt] warning: could not remove temp worktree (${err.code ?? err.message}); ` +
+        `leftover at ${WORKTREE} is gitignored and swept by the next run.`,
+    );
+  }
 }
 
 function git(args, opts = {}) {
@@ -70,7 +91,7 @@ function computeReceipt() {
   // tree (including its own .totem/compiled-rules.json as of that commit).
   if (fs.existsSync(WORKTREE)) {
     spawnSync('git', ['worktree', 'remove', '--force', WORKTREE], { cwd: ROOT });
-    fs.rmSync(WORKTREE, { recursive: true, force: true });
+    removeWorktreeDir();
   }
   fs.mkdirSync(path.dirname(WORKTREE), { recursive: true });
   git(['worktree', 'add', '--detach', WORKTREE, HEAD_SHA]);
@@ -134,6 +155,15 @@ function computeReceipt() {
       fs.readFileSync(path.join(ROOT, 'packages', 'cli', 'package.json'), 'utf-8'),
     ).version;
 
+    // The lenient downgrade must be visible IN the artifact, not only on
+    // stderr — a receipt that renders indistinguishably from a strict pass
+    // while validation was relaxed is the ADR-115 §2 defect class. The guard
+    // warning is detected from the child's output streams; lint's JSON
+    // carries load-time warnings nowhere today.
+    const targetMismatchGuardWarning = /target-mismatched/.test(
+      `${run.stdout ?? ''}${run.stderr ?? ''}`,
+    );
+
     return {
       baseSha: BASE_SHA,
       headSha: HEAD_SHA,
@@ -142,6 +172,8 @@ function computeReceipt() {
       errors: lint.errors,
       warnings: lint.warnings,
       llmCalls,
+      astParseMode: 'lenient',
+      targetMismatchGuardWarning,
       apiKeysStripped: true,
       elapsedMs,
       platform: `${os.platform()}-${os.arch()}`,
@@ -151,7 +183,7 @@ function computeReceipt() {
     };
   } finally {
     spawnSync('git', ['worktree', 'remove', '--force', WORKTREE], { cwd: ROOT });
-    fs.rmSync(WORKTREE, { recursive: true, force: true });
+    removeWorktreeDir();
   }
 }
 


### PR DESCRIPTION
## Summary

Two commits, one class, closed at both ends:

1. **`fix(corpus)`** — both target-mismatched landmines archived in place under the operator-confirmed narrow hand-edit + `--refresh-manifest` freeze exception (recorded on mmnto-ai/totem-strategy#974, 2026-07-28; adjudicated class per #2343). `1a7080ebf6162de3` (4 `.json` globs) and `ae4d3065e5548794` (sole glob `packages/pack-agent-security/turbo.json`) are `engine: ast-grep` rules with no resolvable Tree-sitter language — they could never execute, and instead armed a **run-wide lint abort** (`rule-engine.ts` `TotemParseError`) on first diff contact with a file their globs claim. Specimen 2 was found by a mechanical target-mismatch sweep of all three corpora (485 corpus + 5 + 1 pack rules) run before building the guard; the operator confirmed it in-class per-specimen. One re-seal covers both edits (`output_hash be747bd8`). Enforcement of the secret-exposure class stays with the regex twin `5bc302726128eceb` (severity `error`).

2. **`feat(lint)`** — the Prop 309 **Class 7 load-time guard**: `assertRulesCanTargetTheirGlobs()` at the #2499 seam converts the diff-dependent detonation into a deterministic load-time failure on every invocation, naming each offender's lessonHash, globs, unregistered extensions, and three deliberately un-ranked remedies (the manifest alone cannot distinguish a permanently-broken rule from an uninstalled pack language).

## Design decisions

- **Fail-closed by default, with the pre-existing escape**: strict `--ast-parse-mode` (the default) throws; `lenient` degrades to a warning with full accounting. Rationale: a repo whose rules target a pack language it hasn't installed (e.g. `.rs` without the rust pack) is target-mismatched by environment, not by corpus rot — and `lenient` already means exactly "unparseable AST language degrades this run". An unconditional guard would remove that documented escape.
- **Both engines covered** (`ast` ∪ `ast-grep`) — matching the `allAstRules` union that feeds the abort seam.
- **Permitted shapes**: globless rules (documented `Lang.Tsx` fallback, cannot arm the abort) and extensionless positive globs (`src/**` legitimately dispatches `.ts` at runtime — absence of a trailing extension is absence of evidence, not proof of mismatch). A rule is condemned only when **every** positive glob names a concrete extension and **none** resolves.
- **`TRAILING_EXT_RE` exported from `@mmnto/totem`** so the guard and the dispatcher it protects share one regex and cannot silently disagree.

## Verification

- **14 induced-failure + control tests** colocated with the #2499 suite: hard-error message contract, `engine:'ast'` variant, fires-on-unrelated-diff (the determinism property), multi-offender accounting, lenient/strict routing, and negative controls (archived specimen, globless, one-resolvable-among-unresolvable, extensionless/brace-set globs, regex-engine `.json` rule, all-negation glob list) + a real-corpus anchor with a non-vacuity assertion (191 globbed AST rules actually inspected).
- **Out-of-suite falsifier run**: un-archived both real specimens in a corpus copy and ran the built dist — the guard threw naming both hashes, all five globs, `.json`, and the remedies. It catches the actual landmines, not just synthetic fixtures.
- **Gate**: `pnpm -r build` 0 · `pnpm -r test` 0 (7,278 tests / 303 files) · `format:check` 0 · `pnpm run lint` 0 · `totem lint` PASS 0 errors. Post-archive active-rule count drops 387 → 385, visible in the branch lint verdict.

## ADR-115 §1 in-boundary verdict

**Not in-boundary.** The diff touches the lint rule-load path and the rule corpus; none of the six named boundaries (`search` · `sync` · `init` · `dependency-installation` · `ECL/mail` · `release plumbing`) is implemented by the touched code. Stated per §1 so the default does not have to fire.

**ADR-115 §4 quota**: this PR is the Class 7 qualifying-item candidate for the next Version-Packages train. Evidence chain for the mmnto-ai/totem-strategy#974 row: the sweep artifact (scan of 491 rules across 3 corpora, 2 live specimens found), both archive edits with curated `archivedReason`s, the 14-test induced-failure suite, and the out-of-suite falsifier run above.

## Known residual (disclosed, not silently dropped)

Rule `fea10369daa04c98` is a **partial** mismatch: globs include `**/*.mts`, and `.mts` has no registered language (built-ins register `.mjs`/`.cjs` but not `.mts`/`.cts`). The guard correctly permits it — one glob resolves — but a diff touching a `.mts` file still arms the original run-wide abort. Class 7 as specified covers total mismatch only. Follow-up candidate: register `.mts`/`.cts` as built-ins (same grammars as the registered pair; their absence reads as an oversight) or extend the guard to warn on partial mismatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
