### PR TITLE
test(mail): Prop 309 P2 entry E4 — induced-failure tests for mail poll completeness

### DIFF
--- a/packages/cli/src/commands/mail-degraded-e4.test.ts
+++ b/packages/cli/src/commands/mail-degraded-e4.test.ts
@@ -207,9 +207,13 @@ describe('E4 fault 2 — own-broadcast suppression is never silent (mmnto-ai/tot
       writeOutbox('totem', 'totem-claude', [
         { name: BCAST, to: 'broadcast', subject: 'cohort note' },
       ]);
-      // Sanity: the fixture resolves BOTH resident seats on the default path.
+      // No sanity assertion in this body, deliberately: `test.fails` is
+      // satisfied by ANY failure, so an extra assertion here would let an
+      // unrelated seat-resolution regression keep the marker green without
+      // the #2509 assertion ever running (CR round-1 catch). The two-seat
+      // resolution is asserted by the positive control below on the same
+      // fixture shape, where a regression fails loudly as a real failure.
       const result = pollTwoSeat();
-      expect(result.selfAgents.agents).toEqual(['totem-claude', 'totem-gemini']);
 
       // Pack 1 + 2 — accounting fires / degraded envelope: the poll must
       // either render the dispatch (to the non-sender seat) or name the

--- a/packages/cli/src/commands/mail-degraded-e4.test.ts
+++ b/packages/cli/src/commands/mail-degraded-e4.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Prop 309 P2 degraded-mode test pack — entry E4 (induced-failure).
+ *
+ * Boundary (verbatim scope): ECL/mail poll completeness. Induced faults →
+ * required behavior: "basename collision · own-broadcast exclusion · glob
+ * failure → surfaced or LOUDLY accounted, never silent narrowing."
+ *
+ * Pack contract — every induced-failure test carries three assertions:
+ *   1. The accounting fires (degraded output announces itself — never output
+ *      indistinguishable from a clean poll).
+ *   2. The backstop throws. `totem mail` is a READ-ONLY path, so per
+ *      ADR-115 § 2 the requirement is a DEGRADED/UNVERIFIED-style envelope in
+ *      rendered output — the structured `warnings` channel (rendered as
+ *      `Warning: …` lines by `formatTextResult`) IS that envelope — not a
+ *      nonzero exit. Where this pack pins an exit code it is pinning the
+ *      deliberate exit-0-with-envelope contract, never blessing silence.
+ *   3. Recovery/control: a positive control (healthy fixture poll renders
+ *      everything it should) AND fault-removed-returns-to-green.
+ *
+ * Framing defects:
+ *   - mmnto-ai/totem#2462 — "silent mail-suppression class": the own-broadcast
+ *     exclusion at mail.ts (`if (opts.includeProcessed !== true && toLower ===
+ *     'broadcast' && selfLower.has(senderSeat)) continue;`) assumes SELF is one
+ *     seat; post-dirs-union the default poll resolves ALL resident seats, so a
+ *     resident sender's broadcast is suppressed from every seat's default
+ *     render — silently, no accounting line.
+ *   - mmnto-ai/totem#2509 — the accounting-line gap: the default render gives
+ *     no account of items dropped by the exclusion; the required fix is a
+ *     rendered accounting line when suppression drops files mark-absent for
+ *     ≥1 resident non-sender seat. NOT yet implemented — the required-behavior
+ *     assertion below is `test.fails` with this issue ref (repo rule:
+ *     suppressions carry a ticket-ref comment), written against the REQUIRED
+ *     behavior so it EXECUTES every run and flips the moment the fix lands
+ *     (vitest 4 dropped `test.fixme`; `test.fails` is the in-repo vitest's
+ *     expected-fail primitive — green while the defect stands, loudly red
+ *     once the assertions pass and the marker must be removed).
+ *
+ * Filesystem-driven, hermetic (fresh tmp workspace per test), same fixture
+ * idiom as mail.test.ts. Assertions target the structured `MailPollResult`
+ * (the durable hook contract); the text formatter is human-only.
+ */
+
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
+
+// Mock node:fs so spyOn works in ESM — same pattern as core's session-id.test.ts.
+// Passthrough spread: every call behaves identically to real fs until a test
+// installs a targeted spy (and restores it in `finally`).
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return { ...actual, default: actual };
+});
+
+import * as fs from 'node:fs';
+
+import { cleanTmpDir } from '../test-utils.js';
+import { pollMail, resolveMailExitCode } from './mail.js';
+
+// ─── Fixture helpers ────────────────────────────────────
+
+let tmpRoot: string;
+let workspace: string;
+
+function mkDir(p: string): string {
+  fs.mkdirSync(p, { recursive: true });
+  return p;
+}
+
+interface OutboxFile {
+  name: string;
+  to: string;
+  from?: string;
+  subject?: string;
+  date?: string;
+}
+
+/** `<repo>/.totem/orchestration/<senderAgent>/outbox/<file>.md` — same shape as mail.test.ts. */
+function writeOutbox(repo: string, senderAgent: string, files: OutboxFile[]): void {
+  const outbox = path.join(workspace, repo, '.totem', 'orchestration', senderAgent, 'outbox');
+  mkDir(outbox);
+  for (const f of files) {
+    const content = [
+      '---',
+      `from: ${f.from ?? senderAgent}`,
+      `to: ${f.to}`,
+      `date: ${f.date ?? '2026-07-20T1700Z'}`,
+      `subject: ${f.subject ?? '(no subject)'}`,
+      '---',
+      '',
+      'Body text.',
+      '',
+    ].join('\n');
+    fs.writeFileSync(path.join(outbox, f.name), content, 'utf-8');
+  }
+}
+
+/**
+ * The `totem` basename pre-resolves to [totem-claude, totem-gemini] via the
+ * cohort map; materializing the seat dirs puts resolution on the
+ * post-dirs-union DEFAULT path (source 'dirs', no env override) — the exact
+ * multi-seat condition of mmnto-ai/totem#2462: the default poll resolves ALL
+ * resident seats, and the own-broadcast exclusion assumes SELF is one seat.
+ */
+function selfRepoRootWithSeats(seats: string[]): string {
+  const root = mkDir(path.join(workspace, 'totem'));
+  // The #2312 walk-up needs a `.totem` marker to anchor the repo root on.
+  const orchDir = mkDir(path.join(root, '.totem', 'orchestration'));
+  for (const seat of seats) mkDir(path.join(orchDir, seat));
+  return root;
+}
+
+beforeEach(() => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-mail-e4-'));
+  workspace = mkDir(path.join(tmpRoot, 'workspace'));
+});
+
+afterEach(() => {
+  cleanTmpDir(tmpRoot);
+});
+
+// ─── Fault 1: basename collision ────────────────────────
+// Two seats converge on one addressed-inbound basename. Required: surface
+// both or loudly account — never silently narrow/merge/drop one.
+
+describe('E4 fault 1 — basename collision is surfaced AND loudly accounted', () => {
+  const NAME = '2026-07-20T1717Z-totem-claude-round-reply.md';
+
+  it('both colliding dispatches surface AND the collision warning names every seat path (regression lock)', () => {
+    // Cross-repo variant: distinct outbox-owner seats in distinct repos.
+    writeOutbox('totem-strategy', 'strategy-claude', [{ name: NAME, to: 'totem-claude' }]);
+    writeOutbox('liquid-city', 'lc-claude', [{ name: NAME, to: 'totem-claude' }]);
+
+    const result = pollMail({ repoRoot: selfRepoRootWithSeats([]), workspace, env: {} });
+
+    // Pack 1 — the accounting fires: the degraded envelope announces itself.
+    const collisionWarnings = result.warnings.filter((w) =>
+      w.startsWith('cross-sender basename collision'),
+    );
+    expect(collisionWarnings).toHaveLength(1);
+    expect(collisionWarnings[0]).toContain(NAME);
+    expect(collisionWarnings[0]).toContain('totem-strategy/strategy-claude');
+    expect(collisionWarnings[0]).toContain('liquid-city/lc-claude');
+    // Pack 2 — backstop for a read-only path (ADR-115 § 2): no silent
+    // narrowing — BOTH dispatches render; the warnings envelope (not an exit
+    // code) is the loud announcement. Load-bearing downstream: the same
+    // warnings channel reds the `ecl-gc --compact` A2.2 completeness gate
+    // (`warnings.length === 0` arm, mmnto-ai/totem#2309).
+    expect(result.mail).toHaveLength(2);
+    expect(result.mail.map((m) => m.file)).toEqual([NAME, NAME]);
+  });
+
+  it('positive control + fault-removed: distinct basenames render clean with zero warnings', () => {
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: '2026-07-20T1717Z-totem-claude-round-reply.md', to: 'totem-claude' },
+    ]);
+    writeOutbox('liquid-city', 'lc-claude', [
+      { name: '2026-07-20T1718Z-totem-claude-lane-note.md', to: 'totem-claude' },
+    ]);
+
+    const result = pollMail({ repoRoot: selfRepoRootWithSeats([]), workspace, env: {} });
+
+    expect(result.mail).toHaveLength(2);
+    expect(result.warnings).toEqual([]);
+    expect(resolveMailExitCode(result)).toBe(0);
+  });
+});
+
+// ─── Fault 2: own-broadcast exclusion ───────────────────
+// A broadcast from a RESIDENT sender seat, unread for a non-sender resident
+// seat. Required: render it, or print an accounting line naming the
+// suppression (mmnto-ai/totem#2509 — unimplemented today).
+
+describe('E4 fault 2 — own-broadcast suppression is never silent (mmnto-ai/totem#2462, #2509)', () => {
+  const BCAST = '2026-07-20T2326Z-broadcast-cohort-note.md';
+  const RESIDENT_SEATS = ['totem-claude', 'totem-gemini'];
+
+  /** Default-resolution poll (no env override) over the two-seat fixture. */
+  function pollTwoSeat(opts: Parameters<typeof pollMail>[0] = {}) {
+    return pollMail({
+      repoRoot: selfRepoRootWithSeats(RESIDENT_SEATS),
+      workspace,
+      env: {},
+      ...opts,
+    });
+  }
+
+  // RED ROW — required behavior, unimplemented. `test.fails` carries the
+  // ticket ref per the repo rule (suppressions need a ticket-ref comment);
+  // the body is written against the REQUIRED behavior so it EXECUTES every
+  // run (an expected failure while #2509 stands) and flips the run loudly
+  // red the moment the fix lands and the marker must be removed. (vitest 4
+  // dropped `test.fixme`; `test.fails` is this repo's vitest's expected-fail
+  // primitive.)
+  //
+  // Today's actual behavior (regression-documented, NOT locked): mail.ts's
+  // own-broadcast exclusion hits `continue` with no warning and no accounting
+  // line, so the default two-seat poll returns `mail: []`, `warnings: []` —
+  // rendered as "No unread mail addressed to totem-claude, totem-gemini or
+  // broadcast." That is the #2462 silent-suppression class: the dispatch is
+  // mark-absent for the resident NON-sender seat (totem-gemini), yet the
+  // render is indistinguishable from a genuinely clean inbox.
+  test.fails(
+    'REQUIRED (mmnto-ai/totem#2509): a resident-sender broadcast unread for a non-sender seat is rendered OR loudly accounted — never silently dropped',
+    () => {
+      writeOutbox('totem', 'totem-claude', [
+        { name: BCAST, to: 'broadcast', subject: 'cohort note' },
+      ]);
+      // Sanity: the fixture resolves BOTH resident seats on the default path.
+      const result = pollTwoSeat();
+      expect(result.selfAgents.agents).toEqual(['totem-claude', 'totem-gemini']);
+
+      // Pack 1 + 2 — accounting fires / degraded envelope: the poll must
+      // either render the dispatch (to the non-sender seat) or name the
+      // suppression in the warnings channel — the read-only path's
+      // DEGRADED-style announcement per ADR-115 § 2. The exact accounting
+      // wording is #2509's to define; the assertion keys on the suppressed
+      // basename so any honest accounting line satisfies it.
+      const renderedToNonSender = result.mail.some((m) => m.file === BCAST);
+      const accounted = result.warnings.some((w) => w.includes(BCAST));
+      expect(renderedToNonSender || accounted).toBe(true);
+    },
+  );
+
+  it('positive control: a NON-resident sender broadcast surfaces to the same two-seat default poll', () => {
+    // Healthy-fixture control: the same poll renders everything it should
+    // when the sender is NOT a resident seat (the exclusion arm cannot fire).
+    writeOutbox('totem-strategy', 'strategy-claude', [
+      { name: BCAST, to: 'broadcast', subject: 'theirs' },
+    ]);
+    const result = pollTwoSeat();
+    expect(result.selfAgents.agents).toEqual(['totem-claude', 'totem-gemini']);
+    expect(result.mail).toHaveLength(1);
+    expect(result.mail[0]!.file).toBe(BCAST);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it('fault-removed control: removing the sender from the resident set surfaces the identical broadcast', () => {
+    // Same dispatch, same fixture — but SELF is restricted to the non-sender
+    // seat, so the exclusion arm (`selfLower.has(senderSeat)`) cannot fire.
+    // Proves the dispatch is deliverable and the suppression is specifically
+    // the resident-sender arm, not a fixture artifact.
+    writeOutbox('totem', 'totem-claude', [{ name: BCAST, to: 'broadcast' }]);
+    const result = pollMail({
+      repoRoot: selfRepoRootWithSeats(RESIDENT_SEATS),
+      workspace,
+      env: { TOTEM_SELF_AGENT: 'totem-gemini' },
+    });
+    expect(result.mail).toHaveLength(1);
+    expect(result.mail[0]!.file).toBe(BCAST);
+  });
+
+  it('over-correction guard: a single-seat poll where SELF IS the sender still excludes its own broadcast (mmnto-ai/totem#2364, intended)', () => {
+    // The #2509 fix must not over-correct into surfacing a seat's OWN
+    // broadcast back to the sender itself — that exclusion is the shipped
+    // #2364 behavior. Lock it so the accounting-line fix stays scoped to
+    // non-sender seats.
+    writeOutbox('totem', 'totem-claude', [{ name: BCAST, to: 'broadcast' }]);
+    const result = pollMail({
+      repoRoot: selfRepoRootWithSeats(RESIDENT_SEATS),
+      workspace,
+      env: { TOTEM_SELF_AGENT: 'totem-claude' },
+    });
+    expect(result.mail).toEqual([]);
+  });
+});
+
+// ─── Fault 3: glob/scan failure ─────────────────────────
+// The scan resolves zero repos/dirs while dispatches exist on disk.
+// Required: refuse a silently-clean inbox over an incomplete scan — announce
+// the degradation.
+
+describe('E4 fault 3 — scan failure announces itself, never a silent clean inbox', () => {
+  const MAIL_A = '2026-07-20T1800Z-totem-claude-from-strategy.md';
+  const MAIL_B = '2026-07-20T1801Z-totem-claude-from-lc.md';
+
+  function writeHealthyFixture(): void {
+    writeOutbox('totem-strategy', 'strategy-claude', [{ name: MAIL_A, to: 'totem-claude' }]);
+    writeOutbox('liquid-city', 'lc-claude', [{ name: MAIL_B, to: 'totem-claude' }]);
+  }
+
+  it('workspace scan root unresolvable (ENOTDIR) with dispatches on disk → degraded envelope, empty mail, exit 0', () => {
+    writeHealthyFixture();
+    // Positive control (pack 3): the healthy fixture renders everything.
+    const healthy = pollMail({ repoRoot: selfRepoRootWithSeats([]), workspace, env: {} });
+    expect(healthy.mail).toHaveLength(2);
+    expect(healthy.warnings).toEqual([]);
+
+    // Induce: point the scan root at a FILE — fs.existsSync passes,
+    // readdirSync throws ENOTDIR, enumerateOutboxes resolves ZERO repos while
+    // the dispatches exist on disk under the real workspace. No mocks: the
+    // real errno drives the real catch arm.
+    const brokenRoot = path.join(tmpRoot, 'workspace-as-file');
+    fs.writeFileSync(brokenRoot, 'not a directory', 'utf-8');
+    const degraded = pollMail({
+      repoRoot: selfRepoRootWithSeats([]),
+      workspace: brokenRoot,
+      env: {},
+    });
+
+    // Pack 1 — the accounting fires: the scan failure is named in the
+    // warnings channel, so the rendered output carries `Warning: workspace
+    // scan failed: …` lines and is distinguishable from a clean poll.
+    expect(degraded.warnings.some((w) => w.startsWith('workspace scan failed'))).toBe(true);
+    // Pack 2 — backstop for a read-only path (ADR-115 § 2): the envelope is
+    // the announcement; the exit code stays 0 by the deliberate
+    // `resolveMailExitCode` contract (only an UNRESOLVED self is exit 2 — a
+    // scan failure still resolved self, and the warnings channel is the
+    // DEGRADED envelope). Pinning exit 0 here pins that contract, not the
+    // silence. The poll also asserts nothing it cannot back: no mail entries
+    // are fabricated over the incomplete scan.
+    expect(degraded.mail).toEqual([]);
+    expect(degraded.scanned).toBe(0);
+    expect(resolveMailExitCode(degraded)).toBe(0);
+
+    // Fault-removed-returns-to-green (pack 3): repoint at the healthy scan
+    // root and the same fixture polls clean.
+    const recovered = pollMail({ repoRoot: selfRepoRootWithSeats([]), workspace, env: {} });
+    expect(recovered.mail).toHaveLength(2);
+    expect(recovered.warnings).toEqual([]);
+  });
+
+  it('one repo orchestration scan fails (EACCES) → failure named, healthy sibling still surfaces; fault-removed returns to green', () => {
+    writeHealthyFixture();
+    // Induce: targeted readdirSync failure on ONE repo's orchestration dir —
+    // the exact path mail.ts scans (`<workspace>/totem-strategy/.totem/
+    // orchestration`). Path-conditional passthrough keeps every other fs call
+    // real. (fs spy pattern: core session-id.test.ts.)
+    const brokenMarker = path.join('totem-strategy', '.totem', 'orchestration');
+    const realReaddirSync = fs.readdirSync;
+    const spy = vi.spyOn(fs, 'readdirSync').mockImplementation((target, options) => {
+      if (String(target).endsWith(brokenMarker)) {
+        const err = new Error(
+          `EACCES: permission denied, scandir '${String(target)}'`,
+        ) as NodeJS.ErrnoException;
+        err.code = 'EACCES';
+        throw err;
+      }
+      return realReaddirSync(target, options as never) as never;
+    });
+    try {
+      const degraded = pollMail({ repoRoot: selfRepoRootWithSeats([]), workspace, env: {} });
+      // Pack 1 — the accounting fires: the failed repo is NAMED.
+      expect(
+        degraded.warnings.some((w) => w.startsWith('orchestration scan failed (totem-strategy)')),
+      ).toBe(true);
+      // Pack 2 — backstop: skip-don't-abort, never silent narrowing — the
+      // healthy sibling repo's dispatch still surfaces, and the failed repo's
+      // absence is announced (above) rather than folded into a fake-clean
+      // inbox. Exit stays 0 per the read-only degraded-envelope contract.
+      expect(degraded.mail.map((m) => m.file)).toEqual([MAIL_B]);
+      expect(resolveMailExitCode(degraded)).toBe(0);
+    } finally {
+      spy.mockRestore();
+    }
+
+    // Pack 3 — fault-removed-returns-to-green: with the scan healthy again,
+    // BOTH dispatches surface with zero warnings.
+    const recovered = pollMail({ repoRoot: selfRepoRootWithSeats([]), workspace, env: {} });
+    expect(recovered.mail.map((m) => m.file).sort()).toEqual([MAIL_A, MAIL_B].sort());
+    expect(recovered.warnings).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Mechanical Root Cause

Prop 309's ruled specimen class is *degraded paths presenting as success*. The ECL/mail poll boundary carried that class live: the own-broadcast exclusion (`mail.ts`, post-dirs-union multi-seat SELF) silently drops a resident sender's broadcast from every resident non-sender seat's default render — "No unread mail" over waiting mail (#2462, first-party specimen #2509). The boundary had no induced-failure test asserting that poll degradation is **surfaced or loudly accounted, never silently narrowing**. This PR is P2 degraded-mode test pack **entry E4** (seed registry: mmnto-ai/totem-strategy#974 index comment).

## Fix Applied

Test-only PR — no production code changed. Adds `packages/cli/src/commands/mail-degraded-e4.test.ts` (8 tests) covering the three chartered faults against the structured `MailPollResult` (the durable hook contract):

1. **Basename collision** — regression lock: current code surfaces BOTH colliding dispatches AND emits a `cross-sender basename collision` warning naming every seat path. Cross-repo variant (the in-repo same-repo case is covered in `mail.test.ts`).
2. **Own-broadcast exclusion** — the **red row**: `test.fails` written against the REQUIRED #2509 behavior (render the broadcast to the non-sender seat OR account for the suppression in the warnings channel). It executes every run — suite green while the defect stands, loudly red the day the fix lands, forcing marker removal. (`test.fails` because vitest 4 dropped `test.fixme`; ticket ref in title + comments per repo rule.) Also pins: positive control (non-resident sender broadcast surfaces), fault-removed control (`TOTEM_SELF_AGENT` scoping surfaces the identical dispatch), and an over-correction guard (a seat's OWN broadcast stays excluded per shipped #2364 behavior — the #2509 fix must not over-correct).
3. **Glob/scan failure** — ENOTDIR workspace root (no mocks; real errno drives the real catch arm) and EACCES on one repo's orchestration dir (path-conditional fs spy): the failure is NAMED in the warnings channel, healthy siblings still surface, no mail fabricated over an incomplete scan, and the deliberate exit-0-with-envelope contract is pinned per ADR-115 §2 (read-only degraded paths announce in rendered output; the `warnings` channel IS that envelope). Fault-removed-returns-to-green asserted in both.

## Out of Scope

- The #2509 accounting-line fix itself (totem lane; the red row is written to receive it).
- The verdict-line question (poll still prints `No unread mail addressed to …` after `Warning:` lines on an incomplete scan — judged ADR-115 §2-compliant as-is; unticketed hardening candidate, flagged for the lane).
- The other five P2 seed entries (E1–E3, E5, E6 — per-lane, indexed on mmnto-ai/totem-strategy#974).

## Tests Added/Updated

- [x] Added/updated automated tests covering the root-cause mechanism — `mail-degraded-e4.test.ts` (8 tests; 7 green + 1 expected-failure). Local: new file 8/8; mail suite 154/154; full `@mmnto/cli` suite 3592/3592. prettier/eslint/tsc clean.

## Related Tickets

Refs #2462 · Refs #2509 · pack index: mmnto-ai/totem-strategy#974 · program: mmnto-ai/totem-strategy Proposal 309 / ADR-115

Reviewer flag: @totem-claude — per the bus disposition (strategy ECL 2026-07-28T1936Z), this lane owns review/merge; the PR vehicle keeps single-writer intact.
