### PR TITLE
fix(release): register pack-agent-workflow in publish-oidc PKG_ORDER

### DIFF
--- a/tools/publish-oidc.mjs
+++ b/tools/publish-oidc.mjs
@@ -43,10 +43,18 @@ const PACKAGES_DIR = join(REPO_ROOT, 'packages');
 
 // Topological order: @mmnto/totem (packages/core) has no workspace deps among
 // published packages; cli + mcp depend on it; pack-rust-architecture is
-// independent. Private packages (pack-agent-security) are skipped at runtime
-// by the `pkg.private` check, but must still appear in PKG_ORDER so the
-// "new unknown package" guard below trips when packages are added.
-const PKG_ORDER = ['core', 'cli', 'mcp', 'pack-agent-security', 'pack-rust-architecture'];
+// independent. Private packages (pack-agent-security, pack-agent-workflow) are
+// skipped at runtime by the `pkg.private` check, but must still appear in
+// PKG_ORDER so the "new unknown package" guard below trips when packages are
+// added.
+const PKG_ORDER = [
+  'core',
+  'cli',
+  'mcp',
+  'pack-agent-security',
+  'pack-agent-workflow',
+  'pack-rust-architecture',
+];
 
 // Guard: fail loudly if a new package is added to packages/ but not listed
 // above, so the publish order is reviewed instead of silently fallen-through.


### PR DESCRIPTION
## Summary

The 1.106.0 Release run (30432982422) failed closed at the publish step: `tools/publish-oidc.mjs`'s new-package guard tripped on `pack-agent-workflow`, which #2508 added to `packages/` without the `PKG_ORDER` registration the guard exists to force. This PR adds the registration.

The pack is `private: true` with no workspace dependencies, so — like `pack-agent-security` — it is skipped at publish time by the `pkg.private` check and its list position is inert; it only needs to be enumerated so the guard's discovered-vs-listed comparison passes.

## Verified

- Zero partial publish occurred before the failure: npm serves 1.105.0 for all four public packages, no 1.106.0 tags, no 1.106.0 GitHub releases — the guard fired before any mutation (fail-closed working as designed).
- Guard replay after the fix: discovered set (`cli, core, mcp, pack-agent-security, pack-agent-workflow, pack-rust-architecture`) equals the listed set, unknown `[]`.
- `node --check` passes; format + `format:check` clean; ESLint 0 errors; `totem lint --base main` PASS, 0 violations.
- No changeset: `tools/` is repo CI tooling, not a versioned package.

## Effect of merging

The merge push re-fires the Release workflow; the publish script is idempotent (skips versions already on npm), so it publishes all four public packages at 1.106.0, tags, and creates the GitHub releases — completing the cut that #2514 staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
