### PR TITLE
fix(hooks): emit SessionStart context via the documented hookSpecificOutput envelope

### DIFF
--- a/.claude/hooks/session-context.mjs
+++ b/.claude/hooks/session-context.mjs
@@ -3,7 +3,7 @@
  * SessionStart hook V2 — combines static filesystem context with
  * LanceDB vector search for relevant knowledge injection.
  *
- * stdout → agent context (JSON with additionalContext field)
+ * stdout → agent context (JSON: hookSpecificOutput.additionalContext envelope)
  * stderr → diagnostics only
  *
  * Budget: ~2-3k tokens max (ADR-013).
@@ -386,8 +386,13 @@ async function main() {
       ? combined.slice(0, MAX_TOTAL_CHARS) + '\n...(truncated)'
       : combined;
 
-  // Claude Code hook protocol: JSON with additionalContext field
-  const output = JSON.stringify({ additionalContext: fullContext });
+  // Claude Code hook protocol: SessionStart context is ingested ONLY from the
+  // hookSpecificOutput envelope. A top-level additionalContext key is not part
+  // of the protocol — the harness records hook_success, then silently injects
+  // nothing (mmnto-ai/totem#2522: every session 2026-07-17 → 07-29 booted cold).
+  const output = JSON.stringify({
+    hookSpecificOutput: { hookEventName: 'SessionStart', additionalContext: fullContext },
+  });
   process.stdout.write(output);
 }
 


### PR DESCRIPTION
## What

One-line protocol fix: the SessionStart hook now emits its context inside the documented `hookSpecificOutput` envelope (`{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":...}}`). Header and call-site comments corrected to match.

## Why

A top-level `additionalContext` key is not part of the hook protocol. The harness invokes the hook, records `hook_success`, captures the full stdout — and injects nothing. Transcript forensics on #2522: 25/25 sessions from 2026-07-17 → 2026-07-29 (harness 2.1.212 → 2.1.220) show `attachment.content=""` for this hook, while a sibling plain-text SessionStart hook ingested verbatim in the same sessions. Full evidence chain and docs quote on the issue.

## Verification

- Fixed script, degraded run (unbuilt worktree): exit 0, envelope `hookSpecificOutput.hookEventName="SessionStart"`, context present; graceful-degradation stderr paths unchanged by the diff.
- Fixed script, full run (against built workspace dist): exit 0, correct envelope, 10,015-char context — the ADR-013 10k budget cap engaged as designed.
- Prettier clean. `totem lint --base main` clean — the file is outside lint scope per `ignorePatterns`, and the filter is accounted in the lint output (`Filtered 1 file(s)`), not silently skipped.
- **Post-merge artifact (the issue's verification contract):** the first fresh session on merged main must show a SessionStart transcript record with `attachment.content.length > 0`. That artifact cannot be produced unless the fix works; to be verified at the next session start and recorded on #2522.

## ADR-115 §1 verdict

**Not in-boundary** — the diff changes only the repo-local Claude hook's stdout envelope (harness protocol surface); no runtime change to search / sync / init / dependency-installation / ECL-mail / release-plumbing surfaces (the hook consumes `pollMail`/`orient`, whose implementations are untouched).

## Release note

No changeset: repo-local `.claude/hooks/` tooling, not part of any published package.

Closes #2522
<!-- totem-close: #2522 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
