### PR TITLE
chore(deps): @mmnto/strategy-doctrine 0.1.25 — cohort-overlay §5 review-leg contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "optionalDependencies": {
     "@mmnto/cli": "workspace:*",
-    "@mmnto/strategy-doctrine": "0.1.24"
+    "@mmnto/strategy-doctrine": "0.1.25"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.24
-        version: 0.1.24
+        specifier: 0.1.25
+        version: 0.1.25
 
   packages/cli:
     dependencies:
@@ -862,8 +862,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.24':
-    resolution: {integrity: sha512-KXDE8D1FAR+gpBKd8K2qcJPWq9cR3WlDrm/TsWMapHbxGCL5JYVfS/pn2W5Bcx/OWj7e+7Ruj6kXEe+rBZAuzg==}
+  '@mmnto/strategy-doctrine@0.1.25':
+    resolution: {integrity: sha512-EY8bRRb2NEJjp4C/Mpp21GqI3frVlkaio8Q0e+2/J4r/yAiW9JRI1At3wZAPjEJvm1h69gU2dFzDdWNG3j8c6g==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3694,7 +3694,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.24':
+  '@mmnto/strategy-doctrine@0.1.25':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
Pin bump carrying the operator-ruled review-leg contract (cohort-overlay §5; canonical: mmnto-ai/totem-strategy:doctrine/model-tiering.md § Review legs, provenance mmnto-ai/totem-strategy#991). Install proven from node_modules at 0.1.25; lockfile regenerated and committed (tracked in this repo). Rework charter for the review LLM lanes: mmnto-ai/totem#2525.

🤖 Generated with [Claude Code](https://claude.com/claude-code)