### PR TITLE
chore(deps): @mmnto/strategy-doctrine 0.1.26 — cohort-overlay §4 crown clause (Prop 305 §8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "optionalDependencies": {
     "@mmnto/cli": "workspace:*",
-    "@mmnto/strategy-doctrine": "0.1.25"
+    "@mmnto/strategy-doctrine": "0.1.26"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.25
-        version: 0.1.25
+        specifier: 0.1.26
+        version: 0.1.26
 
   packages/cli:
     dependencies:
@@ -862,8 +862,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.25':
-    resolution: {integrity: sha512-EY8bRRb2NEJjp4C/Mpp21GqI3frVlkaio8Q0e+2/J4r/yAiW9JRI1At3wZAPjEJvm1h69gU2dFzDdWNG3j8c6g==}
+  '@mmnto/strategy-doctrine@0.1.26':
+    resolution: {integrity: sha512-ZpK3AYKPG7jUoVNX7+/p7SeeKbyH2VZ5ZyZhBwaHjgomykR5ERrMA51qdU46WWGTq/ZJrHBmtlrpYlKJOB0SFg==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3694,7 +3694,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.25':
+  '@mmnto/strategy-doctrine@0.1.26':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
Doctrine-pin sweep for the 0.1.26 cut (mmnto-ai/totem-strategy#997 crown landing): overlay §4 gains the crown clause (marker primary= attribute, blocking pre-transfer gate, vacant-crown state, vehicle-neutral totem orient cold-start fallback). Exact-pin convention preserved; lockfile regenerated. Safe-harbor class: pre-registered policy-tag / dependency-pin bump — no leg owed per the review-leg contract.

Cohort-sync lane (strategy-claude), worktree vehicle — main checkout untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)