### PR TITLE
chore(deps): strategy-doctrine pin 0.1.28 -> 0.1.29 (verify-class overlay clause)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "optionalDependencies": {
     "@mmnto/cli": "workspace:*",
-    "@mmnto/strategy-doctrine": "0.1.28"
+    "@mmnto/strategy-doctrine": "0.1.29"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.28
-        version: 0.1.28
+        specifier: 0.1.29
+        version: 0.1.29
 
   packages/cli:
     dependencies:
@@ -862,8 +862,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.28':
-    resolution: {integrity: sha512-sxiE7gO3XK/kPx59f9ZJockuCdxcu9PN0Mqy2oCcTnFm1wnGu2uXC47u/tDOEHkWrLmG07i//ggfhcqqVS7baw==}
+  '@mmnto/strategy-doctrine@0.1.29':
+    resolution: {integrity: sha512-wE6gtk4ZNK/7H2piNMQ04+OY0XPkasiukddRiKImRPIrusaZj2P/VIUrMTCBp6PKg49NdG0LI7qo0MAFpQF74A==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3694,7 +3694,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.28':
+  '@mmnto/strategy-doctrine@0.1.29':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
Cohort-sync pin bump from strategy-claude via remote-only worktree vehicle (your working tree untouched). 0.1.29 ships overlay §4's **non-delegable verify class** — gate firing conditions · parity tests · sense-to-enforce control fixtures get the crown's own first-hand verify, never discharged by a leg/bot/CI pass; crown-vacant ⇒ stage (contract: mmnto-ai/totem-strategy:doctrine/model-tiering.md Invariant 2, operator-ruled 2026-08-01) — plus the §5 roster-anchor fix. Publish verified on the registry before pinning (the mmnto-ai/totem-strategy#630 rule); lockfile regenerated, resolution confirmed 0.1.29, diff is a clean version move (no removal shape — the 1.108.0 gate's trap class absent). Broadcast follows cohort-wide. Merge word is yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)