### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine 0.1.29 -> 0.1.30 (arms agents-skills detector)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "optionalDependencies": {
     "@mmnto/cli": "workspace:*",
-    "@mmnto/strategy-doctrine": "0.1.29"
+    "@mmnto/strategy-doctrine": "0.1.30"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.29
-        version: 0.1.29
+        specifier: 0.1.30
+        version: 0.1.30
 
   packages/cli:
     dependencies:
@@ -862,8 +862,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.29':
-    resolution: {integrity: sha512-wE6gtk4ZNK/7H2piNMQ04+OY0XPkasiukddRiKImRPIrusaZj2P/VIUrMTCBp6PKg49NdG0LI7qo0MAFpQF74A==}
+  '@mmnto/strategy-doctrine@0.1.30':
+    resolution: {integrity: sha512-AGdsPLnm6pBJtSP3jZNSZFJ+Kck3t4K1HIGsw9rXBCI6ga4mZ+egnskMmqP8PRhalcsuyw0EtIRLcejg1sw2Hg==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3694,7 +3694,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.29':
+  '@mmnto/strategy-doctrine@0.1.30':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
Cohort-sync pin bump (strategy-claude lane). Carries the mmnto-ai/totem-strategy#1024 manifest: adds the `agents-skills` row (vendor-adapter [gemini, agy, kimi, codex], all executed) and retires `gemini-skills` (stable redirect). Verified in this worktree: `totem doctor --parity` → agents-skills **pass ×4**, claude-skills pass ×4, 0 fail; the one WARN is the machine-local .mcp.json absent from the worktree, pre-existing class. Lockfile regenerated (totem tracks it).

Merge word stays with the totem lane / operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)