### PR TITLE
chore(lessons): postmerge extraction for #2569 + #2572

### DIFF
--- a/.totem/lessons/lesson-0a392022.md
+++ b/.totem/lessons/lesson-0a392022.md
@@ -1,0 +1,6 @@
+## Lesson — Safely parse nested API error details
+
+**Tags:** api, error-handling, gemini
+**Scope:** packages/core/src/embedders/**/*.ts, !**/*.test.*
+
+Ensure nested API error metadata entries are validated as non-null objects before accessing retry properties to prevent runtime crashes during rate-limit recovery.

--- a/.totem/lessons/lesson-1f809a85.md
+++ b/.totem/lessons/lesson-1f809a85.md
@@ -1,0 +1,5 @@
+## Lesson — Diagnose silent detached child failures
+
+**Tags:** node, process, observability
+
+To diagnose silent failures in detached processes with ignored stdio, write a stamp before spawning and pass the log file descriptor to the child. A stamp without subsequent child output proves the process failed or was reaped.

--- a/.totem/lessons/lesson-4b1299cb.md
+++ b/.totem/lessons/lesson-4b1299cb.md
@@ -1,0 +1,6 @@
+## Lesson — Validate effective embedder identity on resume
+
+**Tags:** embeddings, vector-database, security
+**Scope:** packages/core/src/embedders/**/*.ts, !**/*.test.*
+
+Silent fallbacks to local providers can mix incompatible vector spaces; always resolve and validate the effective serving configuration before resuming a cached sync epoch.

--- a/.totem/lessons/lesson-54c9e010.md
+++ b/.totem/lessons/lesson-54c9e010.md
@@ -1,0 +1,6 @@
+## Lesson — Order shell redirections left to right
+
+**Tags:** shell, posix, logging
+**Scope:** tools/post-merge, packages/cli/src/commands/install-hooks.ts
+
+Shell redirections are evaluated from left to right, meaning a stderr redirect like `2>/dev/null` must precede an append redirection to properly suppress errors if the log file is unwritable.

--- a/.totem/lessons/lesson-57930b5d.md
+++ b/.totem/lessons/lesson-57930b5d.md
@@ -1,0 +1,5 @@
+## Lesson — Store hook logs inside Git directory
+
+**Tags:** git, logging, architecture
+
+Storing local hook logs inside the `.git` directory ensures they are never tracked, guarantees write permissions where Git itself can write, and avoids creating untracked files for non-adopting consumers.

--- a/.totem/lessons/lesson-d56c1078.md
+++ b/.totem/lessons/lesson-d56c1078.md
@@ -1,0 +1,6 @@
+## Lesson — Prevent gutted stores with pre-reset checkpoints
+
+**Tags:** sync, state-management, lancedb
+**Scope:** packages/core/src/ingest/**/*.ts, !**/*.test.*
+
+Writing a dirty-marker checkpoint atomically before resetting a database store prevents crashes from leaving a gutted store that incremental syncs falsely report as complete.

--- a/.totem/lessons/lesson-dbcbef9c.md
+++ b/.totem/lessons/lesson-dbcbef9c.md
@@ -1,0 +1,6 @@
+## Lesson — Strip whitespace from command substitutions safely
+
+**Tags:** shell, posix, compatibility
+**Scope:** tools/post-merge, packages/cli/src/commands/install-hooks.ts
+
+`wc -c` output is padded with leading spaces on BSD/macOS, and whether a given POSIX sh's `test` accepts padded integers for `-gt` is implementation territory (our CI legs never combine padded-wc with dash — exactly where a defect would hide untested). Wrapping the substitution in arithmetic expansion `$(( ... ))` normalizes it to a clean integer on every POSIX shell and eliminates the class regardless.

--- a/.totem/lessons/lesson-f5e177c7.md
+++ b/.totem/lessons/lesson-f5e177c7.md
@@ -1,0 +1,6 @@
+## Lesson — Segregate pacing for batch and query embeds
+
+**Tags:** embeddings, rate-limiting, performance
+**Scope:** packages/core/src/embedders/**/*.ts, !**/*.test.*
+
+Pacing should only apply to multi-text batch ingestions to avoid rate limits, while single-text query embeds (such as search or MCP tools) must bypass pacing to maintain low latency.


### PR DESCRIPTION
Extract-only under the compile freeze (rule-compilation frozen since 2026-05-17). Eight lessons from the 1.110.0 train, curated against the shipped diffs and the #2569/#2572 disposition trails — one candidate corrected pre-index to avoid laundering an unverified bot premise (dash 'Illegal number') as fact. Content-only; no changeset (lessons are not published package surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)