### PR TITLE
chore(lessons): postmerge extraction for #2549 + #2557 + #2559

### DIFF
--- a/.totem/lessons/lesson-03668e61.md
+++ b/.totem/lessons/lesson-03668e61.md
@@ -1,0 +1,6 @@
+## Lesson — Strip leading slashes from lockfile keys
+
+**Tags:** pnpm, parser, regex
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Physical lockfile keys in pnpm can contain leading slashes (e.g., /ajv@8.18.0) which must be explicitly stripped during parsing to prevent mismatches against canonical package names.

--- a/.totem/lessons/lesson-03f1e679.md
+++ b/.totem/lessons/lesson-03f1e679.md
@@ -1,0 +1,6 @@
+## Lesson — Avoid detached spawns in Git worktrees
+
+**Tags:** git, windows, node, process
+**Scope:** packages/cli/src/commands/install-hooks.ts
+
+Spawning a detached child process on Windows holds a directory lock on the hook's working directory. In a linked Git worktree where .git is a file rather than a directory, this lock prevents worktree removal and causes EPERM errors.

--- a/.totem/lessons/lesson-15b7cbdf.md
+++ b/.totem/lessons/lesson-15b7cbdf.md
@@ -1,0 +1,6 @@
+## Lesson — Enforce section-aware lockfile parsing
+
+**Tags:** pnpm, parser
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Lockfile resolution checks must target specific sections like 'packages' or 'snapshots' to prevent metadata blocks (such as peerDependenciesMeta) from falsely satisfying resolution checks and masking dropped packages.

--- a/.totem/lessons/lesson-1ee2fe82.md
+++ b/.totem/lessons/lesson-1ee2fe82.md
@@ -1,0 +1,6 @@
+## Lesson — Thread custom installation hints for unmanaged surfaces
+
+**Tags:** cli, architecture
+**Scope:** packages/cli/**/*.ts, !**/*.test.*
+
+When a CLI doctor command detects drift on surfaces not managed by the default initializer, thread a custom `installHint` rather than pointing users to an inert initialization command.

--- a/.totem/lessons/lesson-37e19565.md
+++ b/.totem/lessons/lesson-37e19565.md
@@ -1,0 +1,6 @@
+## Lesson — Anchor hook assertions on executable code
+
+**Tags:** testing, mutant-testing
+**Scope:** packages/cli/src/commands/init.test.ts
+
+Anchoring ordering assertions on comment banners rather than actual executable code allows mutants to relocate code without failing tests. Assertions should target the functional spawn or execution statements directly.

--- a/.totem/lessons/lesson-531a3972.md
+++ b/.totem/lessons/lesson-531a3972.md
@@ -1,0 +1,6 @@
+## Lesson — Do not block on untracked files
+
+**Tags:** cli, git, dx
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Failing with a non-zero exit code when only untracked files are present blocks routine pre-push hooks where scratch files are common. Instead, loudly disclose their presence while returning exit code 0.

--- a/.totem/lessons/lesson-594a6bda.md
+++ b/.totem/lessons/lesson-594a6bda.md
@@ -1,0 +1,6 @@
+## Lesson — Gemini CLI requires directory form skills
+
+**Tags:** gemini, cli, discovery
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Gemini CLI scans both `.gemini/skills` and `.agents/skills` using a nested glob pattern, meaning it only discovers directory-form `*/SKILL.md` files and ignores flat `*.md` files.

--- a/.totem/lessons/lesson-5e603619.md
+++ b/.totem/lessons/lesson-5e603619.md
@@ -1,0 +1,6 @@
+## Lesson — Detect silent lockfile pin removal
+
+**Tags:** pnpm, ci, dependencies
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+A failed optional-dependency fetch can cause pnpm to silently drop lockfile entries for valid dependencies while returning exit code 0, bypassing frozen-lockfile checks. Implement a dedicated check to verify that packages removed from the lockfile are no longer declared in any workspace manifest.

--- a/.totem/lessons/lesson-7be55994.md
+++ b/.totem/lessons/lesson-7be55994.md
@@ -1,0 +1,6 @@
+## Lesson — Scope dependency checks to importers
+
+**Tags:** pnpm, monorepo, workspace
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Scanning every tracked package.json for dependency declarations can false-block on non-workspace fixtures. Instead, read declarations directly from the lockfile's own 'importers' set to scope the checks accurately.

--- a/.totem/lessons/lesson-baf7df0d.md
+++ b/.totem/lessons/lesson-baf7df0d.md
@@ -1,0 +1,6 @@
+## Lesson — Avoid string prefix failure classification
+
+**Tags:** refactoring, dx
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Classifying failure reasons or selecting recovery hints using string prefix matching on error messages is fragile. Use explicit, internal discriminants on the result object instead.

--- a/.totem/lessons/lesson-cd5286bd.md
+++ b/.totem/lessons/lesson-cd5286bd.md
@@ -1,0 +1,6 @@
+## Lesson — Omit windowsHide with detached processes
+
+**Tags:** windows, node, process
+**Scope:** packages/cli/src/commands/init-templates.ts
+
+On Windows, the CREATE_NO_WINDOW flag is ignored when a process is spawned with DETACHED_PROCESS. Consequently, setting windowsHide: true is redundant and inert when detached: true is enabled.

--- a/.totem/lessons/lesson-cdefe8a5.md
+++ b/.totem/lessons/lesson-cdefe8a5.md
@@ -1,0 +1,6 @@
+## Lesson — Keep CLI installation hints platform agnostic
+
+**Tags:** cli, windows, dx
+**Scope:** packages/cli/**/*.ts, !**/*.test.*
+
+Remediation and installation hints should avoid platform-specific shell commands like `cp` to prevent execution failures in Windows environments.


### PR DESCRIPTION
## What

Postmerge lesson extraction for the carried backlog: #2549 (lockfile pin-removal gate + untracked-file disclosure), #2557 (refresh-gh hook wiring), #2559 (vendor-neutral `.agents/skills` + parity detector). Extract-only under the rule-compilation freeze — no compile, no `compiled-rules.json` / manifest changes. Content-only diff: 12 new lesson files, 72 insertions.

## Curation

12 raw extractions; extractor dedup dropped 0; all 12 kept after per-claim verification against the PR dispositions and merged source (the #2425 laundering class is the check this pass exists for):

- **`windowsHide` inert alongside `detached: true`** — encodes #2557's leg finding F7 and the operator-verified **decline** of GCA's counter-claim (GCA's "Microsoft docs" quote does not appear in the actual Process Creation Flags page, which states CREATE_NO_WINDOW is ignored under DETACHED_PROCESS; GCA conceded in-round). Merged `init-templates.ts` spawn sites confirm.
- **Detached-spawn directory lock → linked-worktree EPERM** — #2557's primary-checkout gate rationale, reproduced empirically (5× EPERM in hook runtime tests).
- **Banner-anchored ordering assertions** — #2557 leg F1, mutant-proven.
- **Gemini glob semantics** (`["SKILL.md", "*/SKILL.md"]` over both `.gemini/skills` and `.agents/skills`; flat `*.md` never loads) — #2559's F1, leg-refuted-then-live-probed on CLI 0.53.0, owner re-verified both ways.
- **`installHint` threading + platform-agnostic remediation hints** — #2559 F2 (fixed) and the accepted GCA/CR cp-hint findings; both in merged `doctor-parity.ts`.
- **Six lockfile-gate lessons from #2549** — pin-removal detection, section-aware parsing (`peerDependenciesMeta` laundering vector), importer scoping, leading-slash canonicalization (`packageNameFromKey`), `failureClass` discriminant, untracked-files disclose-with-exit-0 — each verbatim-traceable to the PR body's hardening list or an accepted review finding, confirmed in merged `verify-lockfile-sync.ts`.

Index already synced (extraction runs the incremental sync inline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
