### PR TITLE
chore(lessons): postmerge extraction for #2583

### DIFF
--- a/.totem/lessons/lesson-10fa7ef8.md
+++ b/.totem/lessons/lesson-10fa7ef8.md
@@ -1,0 +1,6 @@
+## Lesson — Ship CommonJS hooks as CJS
+
+**Tags:** esm, commonjs, node, packaging
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Shipping CommonJS files with a `.js` extension causes runtime crashes (`require is not defined`) in ESM-configured (`"type": "module"`) environments. Explicitly using the `.cjs` extension prevents these fail-opens.

--- a/.totem/lessons/lesson-4da785ff.md
+++ b/.totem/lessons/lesson-4da785ff.md
@@ -1,0 +1,6 @@
+## Lesson — Guard successor paths during migrations
+
+**Tags:** migration, file-system, safety
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Unconditionally writing to a successor path during file migrations can silently overwrite pre-existing user-owned files. Always validate ownership and marker boundaries at the destination path before performing writes.

--- a/.totem/lessons/lesson-a01fdfeb.md
+++ b/.totem/lessons/lesson-a01fdfeb.md
@@ -1,0 +1,6 @@
+## Lesson — Verify markers before unlinking files
+
+**Tags:** eject, file-system, safety
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Relying on naive substring matching during eject or cleanup operations can accidentally delete user-modified files. Use robust marker verification to ensure only scaffolded files are removed.


### PR DESCRIPTION
Postmerge extraction for #2583 (merged `92e23179`). Extract-only under the rule-compilation freeze — index-only lessons (the exempt class per the 2026-07-17 scope ruling); no compile, no `compiled-rules.json` mutation.

Three lessons, each verified per-claim against the round dispositions and the merged source before commit:

1. **Ship CommonJS hooks as CJS** — the core `.js`-under-`"type": "module"` fail-open class the PR fixed.
2. **Guard successor paths during migrations** — encodes the falsification leg's MAJOR (the successor gate hole, executed repro) and its accepted fix: ownership + marker-boundary validation at the destination before any write.
3. **Verify markers before unlinking files** — encodes the CR rounds 1–2 accepted eject fix (prefix-anchored first-line ownership, not substring matching).

Re-laundering check performed: no lesson encodes a declined finding — the CWE-426 decline (routed to #2558) and the falsified "Gemini CLI degrades the crash" premise are absent by verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
