### PR TITLE
chore(lessons): postmerge extraction for #2586

### DIFF
--- a/.totem/lessons/lesson-10aac95c.md
+++ b/.totem/lessons/lesson-10aac95c.md
@@ -1,0 +1,6 @@
+## Lesson — Avoid index writes in read-only Git
+
+**Tags:** git, concurrency
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Running Git commands without the `--no-optional-locks` flag can write to the index, violating read-only assumptions and causing issues in shared environments.

--- a/.totem/lessons/lesson-247a6545.md
+++ b/.totem/lessons/lesson-247a6545.md
@@ -1,0 +1,6 @@
+## Lesson — Validate dependent CLI flags
+
+**Tags:** cli, validation
+**Scope:** packages/cli/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Repeatable options that only make sense under specific modes must be validated at the CLI boundary to prevent invalid configurations from being silently ignored.

--- a/.totem/lessons/lesson-6aa3f22c.md
+++ b/.totem/lessons/lesson-6aa3f22c.md
@@ -1,0 +1,6 @@
+## Lesson — Handle Git merge-base exit code 128
+
+**Tags:** git, error-handling
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+An exit code of 128 from `git merge-base --is-ancestor` indicates an unscannable repository or missing reference rather than a simple negative ancestry result.

--- a/.totem/lessons/lesson-8ae6a68b.md
+++ b/.totem/lessons/lesson-8ae6a68b.md
@@ -1,0 +1,6 @@
+## Lesson — Squash merges break Git ancestry checks
+
+**Tags:** git, workflows
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Under squash-merge development workflows, Git ancestry checks cannot reliably prove a branch is merged, requiring external metadata or status snapshots to determine worktree staleness.


### PR DESCRIPTION
Post-merge lesson extraction for #2586 (the #2580 slice-1 estate sensor), extract-only under the standing rule-compilation freeze — no compile ran.

Four lessons, each verified against the shipped diff and the PR's disposition record before commit:

1. `git` commands need `--no-optional-locks` to be genuinely read-only (`git status` otherwise writes the index) — the round-1 falsification MAJOR, verified against git-status(1) § BACKGROUND REFRESH.
2. Squash-merge workflows make branch-merged underivable from ancestry — the sensor's honest-indeterminate state.
3. `merge-base --is-ancestor` exit 128 is a real failure, never a negative answer.
4. Mode-scoped repeatable CLI flags must be validated at the boundary, not silently discarded — the CR round fix.

Re-laundering check clean: the two findings declined on primaries in the PR round (porcelain path-quoting premise; sensor-catch advisory conversion) do NOT re-enter as lessons.

Part of the #2580 slice-1 arc; closes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
