### PR TITLE
ci(smoke): file-on-red alert — a red smoke lands in the issue queue

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -54,6 +54,13 @@ jobs:
     if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # Serialize alert jobs (CR round 1): two overlapping runs must not both
+    # observe "no existing issue" and double-create. Classic group syntax only —
+    # an invalid concurrency key would not fail this job, it would invalidate
+    # the WHOLE workflow file and take the smoke itself dark. A replaced-pending
+    # alert needs >=3 simultaneous runs of a once-daily schedule; accepted.
+    concurrency:
+      group: ci-integration-file-on-red-alert
     permissions:
       issues: write
     steps:

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -41,3 +41,66 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+
+  # File-on-red (mmnto-ai/totem#2582): a red smoke must land in the triage
+  # surface the cohort already reads — the issue queue — not wait for someone
+  # to open the Actions tab (six consecutive scheduled reds went unseen,
+  # 2026-07-30 → 2026-08-04). One open issue deduped by exact title, a comment
+  # per subsequent red, and an auto-close comment on the next green. Runs on
+  # manual dispatches too, so a post-fix dispatch green closes the alert.
+  alert:
+    name: File-on-red alert
+    needs: smoke
+    if: ${{ always() && (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: File, bump, or close the alert issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          RESULT: ${{ needs.smoke.result }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          EVENT: ${{ github.event_name }}
+          TITLE: 'ci(smoke): Integration Smoke is red (file-on-red alert)'
+        run: |
+          set -euo pipefail
+          # Failures here are LOUD by design: nothing swallows an API error —
+          # a red alert job is visible in exactly the place a silent one is not.
+          # Exact-title match; `--search in:title` is fuzzy AND its open-state
+          # filter rides GitHub's eventually-consistent search index, so both
+          # title and state are re-checked precisely on the fresh JSON objects.
+          EXISTING="$(gh issue list --state open --search "\"$TITLE\" in:title" \
+            --json number,title,state \
+            --jq 'map(select(.title == env.TITLE and .state == "OPEN")) | map(.number) | join(" ")')"
+
+          if [ "$RESULT" = 'success' ]; then
+            # Close EVERY open alert, not just the first — a duplicate born of
+            # a race must not leak a permanently-open "red" issue that trains
+            # everyone to ignore the alert.
+            for n in $EXISTING; do
+              gh issue comment "$n" --body "Green again: $EVENT run $RUN_URL — closing."
+              gh issue close "$n"
+            done
+          elif [ "$RESULT" = 'skipped' ]; then
+            # The smoke never ran; nothing to claim in either direction.
+            :
+          else
+            # failure, cancelled, or any future state: anything that is not a
+            # proven green is RED for alerting purposes. `cancelled` is
+            # deliberately red — GitHub maps a `timeout-minutes` expiry (a hung
+            # provider API, the most characteristic smoke failure) to
+            # cancellation, and a mute arm there would be the silent-green
+            # delivery gap this job exists to close.
+            FIRST="${EXISTING%% *}"
+            if [ -n "$FIRST" ]; then
+              gh issue comment "$FIRST" --body "Still red ($RESULT): $EVENT run $RUN_URL"
+            else
+              gh issue create --title "$TITLE" --body "$(printf '%s\n\n%s\n\n%s' \
+                "The Integration Smoke matrix finished '$RESULT' on a $EVENT run: $RUN_URL" \
+                "This alert is filed automatically (mmnto-ai/totem#2582, permanently-red-sensor class): a red smoke that only lives in the Actions tab reads as coverage while delivering nothing. Subsequent reds comment here; the next green closes this issue automatically." \
+                "Triage: open the run, identify the failing provider leg, and check secret vintage first (the 2026-08 incident was an org-level key drained of credit — see mmnto-ai/totem#1956).")"
+            fi
+          fi


### PR DESCRIPTION
Closes #2582
<!-- totem-close: #2582 -->

## What

The file-on-red alert for the daily Integration Smoke (#2582 fix shape 1, as recommended): a new `alert` job on `ci-integration.yml` that lands a red smoke in the issue queue — the triage surface the cohort already reads — instead of leaving it in the Actions tab, where six consecutive scheduled reds (2026-07-30 → 2026-08-04) went unseen until unrelated release verification found them.

Mechanics: one open issue deduped by exact title (state re-checked on fresh JSON objects, not the eventually-consistent search index); a comment per subsequent red; on the next green, a comment-and-close of **every** open alert (a race-born duplicate must not leak a permanently-open "red" that trains everyone to ignore the alert). Runs on `schedule` and `workflow_dispatch`, so a post-fix manual green closes the alert. No new action dependencies — the job uses only the preinstalled `gh` with job-scoped `permissions: issues: write`.

## Failure-direction design (the point of the review pass)

A pre-PR falsification leg attacked the mechanics against GitHub's documented semantics — this path cannot be tested until it fires live:

- **Its blocker finding, folded:** GitHub maps a `timeout-minutes` expiry to *cancellation*, and the draft's `cancelled` arm was mute — a hung provider API (the most characteristic smoke red) would have been silent green, the exact #2334-class gap this issue exists to kill. The script now treats **anything that is not `success`/`skipped` as red**, so the aggregate-result mapping no longer matters.
- Also folded from the leg: the stale-search-index case (a red commenting on an already-closed alert while the open queue shows nothing — state is now re-checked precisely), the close-only-first leak, and the `|| true` that made a list failure read as "no existing issue". Every API failure is now loud — a red alert job is visible in exactly the place a silent one is not.
- Confirmed by the leg against primaries: matrix aggregation (`fail-fast: false` + no `continue-on-error` — no red leg can report green), `always()` gating, token capability on scheduled runs at job-level permissions (and permission failures fail loud), and the exact `gh` pipeline including quoting, run read-only against this repo with a positive and negative control.

Known accepted residue: a dispatch overlapping the 06:00 UTC schedule can transiently duplicate the issue (bounded by search-index lag); the close-all green path self-heals it.

## Verification

Workflow-only diff — no releasable surface, no changeset. Prettier clean, `totem lint` PASS 385 rules / 0 violations. The alert path itself first executes on the next scheduled run; its failure direction is red-and-visible by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
