### PR TITLE
docs(maturity): data refresh — 81 days under freeze, receipt stamps to 1.112.0

### DIFF
--- a/docs/data/lint-receipt.json
+++ b/docs/data/lint-receipt.json
@@ -9,9 +9,9 @@
   "astParseMode": "lenient",
   "targetMismatchGuardWarning": true,
   "apiKeysStripped": true,
-  "elapsedMs": 3598,
+  "elapsedMs": 3908,
   "platform": "win32-x64",
   "node": "24.16.0",
-  "cliVersion": "1.105.0",
-  "generatedAt": "2026-07-28T23:05:49.001Z"
+  "cliVersion": "1.112.0",
+  "generatedAt": "2026-08-06T03:35:34.671Z"
 }

--- a/docs/data/maturity.json
+++ b/docs/data/maturity.json
@@ -1,5 +1,5 @@
 {
-  "asOf": "2026-07-15",
+  "asOf": "2026-08-06",
   "rows": [
     {
       "id": "deterministic-lint",

--- a/docs/wiki/maturity.md
+++ b/docs/wiki/maturity.md
@@ -40,7 +40,7 @@ Three claims we would rather prove than assert.
 
 <!-- docs DAYS_UNDER_FREEZE -->
 
-The legacy lesson→rule compiler has been parked under a standing freeze since **2026-05-17** — **59 days** as of this page's last data refresh (2026-07-15). Rather than keep running a compiler we no longer trust, the rule corpus is enforced read-only until its replacement passes held-out validation. We hold our own line the way we ask your repo to hold its own.
+The legacy lesson→rule compiler has been parked under a standing freeze since **2026-05-17** — **81 days** as of this page's last data refresh (2026-08-06). Rather than keep running a compiler we no longer trust, the rule corpus is enforced read-only until its replacement passes held-out validation. We hold our own line the way we ask your repo to hold its own.
 
 <!-- /docs -->
 
@@ -48,7 +48,7 @@ The legacy lesson→rule compiler has been parked under a standing freeze since 
 
 <!-- docs LINT_RECEIPT -->
 
-A real merged diff of this repository (`c14e90ab..ba8c591d`, 41 files) linted in **3598 ms** with **zero LLM calls** — the run executed with every provider API key stripped from the environment, so there was nothing to silently call. 387 rules evaluated; 0 errors, 20 warnings. Environment: win32-x64, node 24.16.0, CLI 1.105.0, generated 2026-07-28. CI recomputes this receipt on every pull request — the counts must match; timing is environment-labeled, never gated. The replay runs with `--ast-parse-mode lenient` — the pinned corpus predates the current target-mismatch load guard — and the receipt records that posture (`astParseMode`) plus whether the guard fired (`targetMismatchGuardWarning: true`).
+A real merged diff of this repository (`c14e90ab..ba8c591d`, 41 files) linted in **3908 ms** with **zero LLM calls** — the run executed with every provider API key stripped from the environment, so there was nothing to silently call. 387 rules evaluated; 0 errors, 20 warnings. Environment: win32-x64, node 24.16.0, CLI 1.112.0, generated 2026-08-06. CI recomputes this receipt on every pull request — the counts must match; timing is environment-labeled, never gated. The replay runs with `--ast-parse-mode lenient` — the pinned corpus predates the current target-mismatch load guard — and the receipt records that posture (`astParseMode`) plus whether the guard fired (`targetMismatchGuardWarning: true`).
 
 <!-- /docs -->
 


### PR DESCRIPTION
Data refresh for the public maturity surface — the operator noticed two things on the rendered page and this closes both.

**What changed (3 files, ±6 lines, all machine-generated):**
- `docs/data/maturity.json` `asOf` → 2026-08-06 (the committed stamp the wall-clock-free `DAYS_UNDER_FREEZE` transform derives from).
- `docs/wiki/maturity.md` freeze-days block: 59 days / as-of 2026-07-15 → **81 days / as-of 2026-08-06** (arithmetic verified against `.totem/freeze.json` `since: 2026-05-17`).
- `docs/data/lint-receipt.json` + the receipt block: regenerated via `tools/gen-lint-receipt.mjs` — the pinned replay **reproduces unchanged** (387 rules / 0 errors / 20 warnings on `c14e90ab..ba8c591d`; the corpus is replayed at the pinned SHA by design, so #2512's later archives don't alter it); only environment stamps move (3908 ms, CLI 1.112.0, generated 2026-08-06).

**Side effect that motivated the timing:** this commit becomes the new last-touch commit in the `maturity.md` file header on github.com, replacing `c79cfbf` — whose three *cancelled* (superseded, not failed) Actions check suites were rendering a red ❌ atop the public page.

**Review class:** mechanical regeneration by the repo's own ruled generators, drift-gated in CI (the docs governance gate re-derives every block and fails on mismatch) — safe-harbor per the review-leg contract, no leg owed. Owner verification: each changed number re-derived against its primary (freeze.json, the receipt replay output, the day arithmetic).

Known residue, disclosed: the generator's temp worktree hit the exit-0-with-residue EPERM class (#2580's subject) — it self-deregistered, the leftover dir is gitignored and swept by the next run; `git worktree list` is clean.

Closes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
