### PR TITLE
chore(lessons): postmerge extraction for #2589 + #2590

### DIFF
--- a/.totem/lessons/lesson-5be0f6a1.md
+++ b/.totem/lessons/lesson-5be0f6a1.md
@@ -1,0 +1,6 @@
+## Lesson — Treat non-success states as workflow failures
+
+**Tags:** github-actions, ci, monitoring
+**Scope:** .github/workflows/**/*.yml
+
+GitHub Actions maps timeout expiries to cancellation rather than failure, meaning a hung job could resolve silently. Alert scripts must treat any state other than success or skipped as red to prevent silent failures.

--- a/.totem/lessons/lesson-94e05ebe.md
+++ b/.totem/lessons/lesson-94e05ebe.md
@@ -1,0 +1,6 @@
+## Lesson — Validate search results against fresh API state
+
+**Tags:** github-api, ci, monitoring
+**Scope:** .github/workflows/**/*.yml
+
+GitHub's search index is eventually consistent and can return stale issue states. Always re-verify issue titles and open states directly on the retrieved JSON objects to prevent duplicate alerts.

--- a/.totem/lessons/lesson-aa69b895.md
+++ b/.totem/lessons/lesson-aa69b895.md
@@ -1,0 +1,6 @@
+## Lesson — Avoid unverified workflow concurrency syntax
+
+**Tags:** github-actions, ci, concurrency
+**Scope:** .github/workflows/**/*.yml
+
+Using unverified GitHub Actions concurrency properties like `queue: max` can invalidate the entire workflow syntax and prevent it from loading. Stick to classic concurrency groups to ensure critical workflows do not silently go dark.


### PR DESCRIPTION
Post-merge lesson extraction for #2589 (file-on-red alert) and #2590 (maturity data refresh), extract-only under the standing rule-compilation freeze.

Three lessons, all from the #2589 arc, each verified against the falsification-leg record and the CR round dispositions before commit: (1) unverified Actions concurrency syntax can invalidate a whole workflow file — classic groups only for load-bearing workflows; (2) Actions maps timeout expiries to *cancellation*, so alert logic must treat everything except success/skipped as red; (3) GitHub's search index is eventually consistent — re-verify state on the retrieved objects, never trust the index's open-state filter.

Re-laundering check clean: both declined finding halves from the #2589 round (`queue: max` adoption; paginated lookup) are absent — the concurrency lesson carries the decline's rationale, not the declined recommendation. #2590 correctly yielded zero lessons (mechanical regeneration).

Closes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
