### PR TITLE
chore(lessons): postmerge extraction for #2592

### DIFF
--- a/.totem/lessons/lesson-1c979261.md
+++ b/.totem/lessons/lesson-1c979261.md
@@ -1,0 +1,6 @@
+## Lesson — Restrict path absence checks
+
+**Tags:** filesystem, security, error-handling
+**Scope:** packages/core/**/*.ts, !**/*.test.*
+
+Only treat ENOENT and ENOTDIR as path absence. Treating other errors like EACCES or I/O failures as absence can lead to premature registry deletion of existing files.

--- a/.totem/lessons/lesson-2912a0ca.md
+++ b/.totem/lessons/lesson-2912a0ca.md
@@ -1,0 +1,6 @@
+## Lesson — Sanitize registry strings before console output
+
+**Tags:** security, cli, terminal
+**Scope:** packages/cli/**/*.ts, !**/*.test.*
+
+Always pass registry-controlled strings through a rendering helper before console interpolation to prevent ANSI escape sequences or newlines from manipulating terminal output.

--- a/.totem/lessons/lesson-49fb0391.md
+++ b/.totem/lessons/lesson-49fb0391.md
@@ -1,0 +1,6 @@
+## Lesson — Manually expand tilde paths before resolution
+
+**Tags:** filesystem, cli, ux
+**Scope:** packages/cli/**/*.ts, !**/*.test.*
+
+Standard path resolution helpers do not expand leading tildes (~); manually resolve them against the user's home directory, or a shell-quoted `~` mints a literal `~` directory under the cwd — and anything derived from it (recorded roots, registry paths) persists the mistake.

--- a/.totem/lessons/lesson-6df0d3db.md
+++ b/.totem/lessons/lesson-6df0d3db.md
@@ -1,0 +1,6 @@
+## Lesson — Verify resource absence independently of exit codes
+
+**Tags:** git, filesystem, reliability
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Do not rely on Git exit codes to guarantee clean worktree removal; always perform independent post-removal filesystem checks to ensure no residue remains.

--- a/.totem/lessons/lesson-8435fa4a.md
+++ b/.totem/lessons/lesson-8435fa4a.md
@@ -1,0 +1,6 @@
+## Lesson — Write registry records before executing commands
+
+**Tags:** architecture, state-management, git
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Creating a registry record before running external setup commands (like git worktree creation) prevents unrecorded resources if the command fails or is interrupted — a phantom record fails visible in a listing, while a created-but-unrecorded resource fails invisible.


### PR DESCRIPTION
Postmerge extraction for PR #2592 (the #2580 slice-2 wt verbs). Extraction-only under the standing rule-compilation freeze — no compile, no rule changes (the #2591 precedent).

Five lessons, each verified against the PR's disposition record before commit: record-first intent records, exit-code distrust with independent absence verification, fail-closed existence probes (ENOENT/ENOTDIR only), registry-string sanitization before terminal output, and manual tilde expansion. None launders the round-2 declined finding. Two extractor imprecisions were hand-corrected at commit time (husk/unrecorded conflation in the record-first lesson; the tilde lesson's consequence framing) — both noted in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
