### PR TITLE
fix(cli): soften the distributed "Before Implementation" spec reflex — retrieval input, never the contract

### DIFF
--- a/.changeset/reflex-spec-drift-softening.md
+++ b/.changeset/reflex-spec-drift-softening.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/cli': patch
+---
+
+Reflex template drift fix: the distributed "Before Implementation" step no longer instructs agents to run `totem spec` "to generate an architectural plan". Standing spec-usage doctrine is that spec output is one retrieval input, never the contract — the softened line says exactly that (optional retrieval; derive the design from primary sources). `REFLEX_VERSION` bumps 8 → 9 so existing consumers' next `totem init` detects the stale block and offers the upgrade. Template-constant fix only — no per-repo hand-edits; the full grounded spec/review redesign remains mmnto-ai/totem#2106.

--- a/packages/cli/src/commands/init-templates.ts
+++ b/packages/cli/src/commands/init-templates.ts
@@ -9,7 +9,7 @@ import type { ConfigFormat, EmbeddingTier } from './init-detect.js';
 // Bump REFLEX_VERSION whenever the AI_PROMPT_BLOCK content changes materially.
 // This allows `totem init` to detect stale blocks and offer upgrades.
 
-export const REFLEX_VERSION = 8;
+export const REFLEX_VERSION = 9;
 export const REFLEX_START = '<!-- totem:reflexes:start -->';
 export const REFLEX_END = '<!-- totem:reflexes:end -->';
 export const REFLEX_VERSION_RE = /<!-- totem:reflexes:version:(\d+) -->/;
@@ -45,7 +45,7 @@ When deciding where to store information or rules, use this decision tree:
 [FOR LOCAL CLI/TERMINAL AGENTS ONLY] Do not attempt to run these commands if you are a headless bot or operating in a cloud PR environment (e.g., Gemini Code Assist on GitHub).
 Totem provides CLI commands that map to your development lifecycle. Use them at these moments:
 1. **Start of Session:** The SessionStart hook automatically runs \`totem describe\` to emit the project-orientation banner (project, tier, rule/lesson counts, targets, hooks). For richer derived project state (recent merged PRs, current branch + uncommitted files, latest strategy journal pointer, package versions, rule/lesson counts), call the MCP \`describe_project\` tool — the derived view replaces the retired \`docs/active_work.md\` convention (state is observed, not declared). For a freshness check (manifest staleness, shield drift, review state), run \`totem status\`. Run \`totem triage\` if you need to pick a new task.
-2. **Before Implementation:** Run \`totem spec <issue-url-or-topic>\` to generate an architectural plan and review related context before writing code.
+2. **Before Implementation:** Optionally run \`totem spec <issue-url-or-topic>\` to retrieve related context (lessons, specs, code) before writing code. Treat any generated plan as one retrieval input, never the contract — derive the actual design from primary sources (the issue, the code, project doctrine).
 3. **Before Push:** Run \`totem lint\` — the deterministic enforcement floor (zero LLM, ~2s). **Before PR:** \`totem review\` runs supplementary AI lanes over the diff (~18s) — advisory sensors, not a merge gate; known limits are disclosed in the run output (LLM window truncation on large diffs; non-code files skipped). Your team's own review discipline decides what constitutes the review of record.
 4. **End of Session:** Run \`totem handoff\` to generate a snapshot for the next agent session with current progress and open threads.
 5. **Managed hooks self-repair:** \`totem init\` distributes \`.totem/prepare.cjs\` and wires \`package.json\` \`prepare\` to it only when no \`prepare\` script exists. The wrapper runs \`totem hook install\` on every \`pnpm install\`, drift-repairing the managed Claude/Gemini hooks — no manual re-install needed.


### PR DESCRIPTION
## What

Softens the distributed reflex block's "Before Implementation" step (`packages/cli/src/commands/init-templates.ts`, the `AI_PROMPT_BLOCK` template constant). The line instructed every consumer repo's agent to "Run `totem spec <issue-url-or-topic>` to generate an architectural plan … before writing code" — the retired ritual. The softened line matches standing spec-usage doctrine: optional retrieval, one input among several, never the contract; the design derives from primary sources.

`REFLEX_VERSION` bumps 8 → 9 so existing consumers' next `totem init` detects the stale block and offers the upgrade. Patch changeset for `@mmnto/cli` included.

## Why now

The status seat hit a hard fail running the distributed ritual verbatim (`totem spec <issue-url>` → `[Totem Error] No model specified` on a seat with no orchestrator defaultModel), which surfaced that the distributed text still teaches spec-as-plan. Reviewed at strategy signon 2026-08-08 (operator present); the fix was routed to this lane's template constants — source-of-truth discipline, no per-repo hand-edits. Disposition: patch-now over riding the full redesign; the grounded spec/review rework remains mmnto-ai/totem#2106 and supersedes this block when it lands, so the softening is deliberately minimal.

## Scope

- One template line + the mandated `REFLEX_VERSION` bump. No API, flag, or behavior changes.
- Tests are version-agnostic (floor/relative checks) — nothing pinned to v8 or the old line.

## Verification

- `pnpm build` 6/6 · repo-wide `format:check` clean · ESLint 0 errors · `totem lint` branch diff PASS (385 rules; 1 advisory warning — the frozen-lesson absolute-claims regex firing on the doctrinal phrase "never the contract" in the changeset text) · `@mmnto/cli` suite 155 files / 3816 tests green.

Refs mmnto-ai/totem#2106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
