### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine 0.1.31 -> 0.1.32 (workspace-estate bullet verb-owned)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "optionalDependencies": {
     "@mmnto/cli": "workspace:*",
-    "@mmnto/strategy-doctrine": "0.1.31"
+    "@mmnto/strategy-doctrine": "0.1.32"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.31
-        version: 0.1.31
+        specifier: 0.1.32
+        version: 0.1.32
 
   packages/cli:
     dependencies:
@@ -862,8 +862,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.31':
-    resolution: {integrity: sha512-lv/OPjifBdj3CKTdG0+AnUWPxQIBi16DgdhSyTo62ANz7CbJoM5dZEsRpxxI0r6LitRFv95iEOQf455j9zmHmw==}
+  '@mmnto/strategy-doctrine@0.1.32':
+    resolution: {integrity: sha512-0Ff207TK6LxLGUXF94OUD/SoXbruJfsYn1zA7z2Qug2Pbuu+qW+b8flf9jb2zcZxOooOvV+hgmt4idoTgqBYMA==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3694,7 +3694,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.31':
+  '@mmnto/strategy-doctrine@0.1.32':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
Routine doctrine-pin currency bump, operator-requested 2026-08-08.

## What 0.1.32 carries (tarball-diffed 0.1.31 → 0.1.32)

One substantive change: the cohort-overlay's **workspace-estate hygiene bullet is rewritten verb-owned** — the worktree lifecycle is now `totem wt create|remove|list` (`@mmnto/cli` ≥1.113.0, the mmnto-ai/totem#2580 slice-2 ship), with the mechanism detail and the raw-git exit-0 removal trap re-homed to `tool-usage-nuances.md` § Git (one rendering, pointer from the overlay). It also pins the registry-protection clarification: a worktree still in `git worktree list` is live regardless of `worktrees.json` absence. This is the doctrine render of strategy-claude's 2026-08-08 broadcast correction (plain `git worktree remove` does NOT refuse untracked residue), from mmnto-ai/totem-strategy#1039.

`parity-manifest.yaml` and `freeze.json` are byte-identical to 0.1.31 (lock hashes confirm; only the overlay hash moved).

## Verification

- `pnpm -r build` 6/6 green · `prettier --check .` clean · ESLint clean · `totem lint` 385 rules PASS (0 violations on the 2-file diff)
- `totem orient` smoke: freeze row reads the snapshot at `strategy-doctrine 0.1.32` — reader consumes the new pin cleanly
- No changeset: root-workspace optionalDependency pin, not a releasable slice (same shape as #2581, #2561)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
