### PR TITLE
test(mcp): explicit 30s hook timeout on the search-knowledge beforeEach (#2608)

### DIFF
--- a/packages/mcp/src/tools/search-knowledge.test.ts
+++ b/packages/mcp/src/tools/search-knowledge.test.ts
@@ -322,7 +322,11 @@ describe('search_knowledge', () => {
     }));
 
     handle = await setupFresh();
-  });
+    // 30s, not vitest's 10s default: this hook pays the cold module-graph
+    // re-import behind `vi.resetModules()`, and the FIRST test's instance blew
+    // 10s on a loaded windows-latest CI runner with the test body never run
+    // (mmnto-ai/totem#2608 — the suite's known load-flake class).
+  }, 30_000);
 
   // --- A.3.a — Trap Ledger writer wiring ---
 


### PR DESCRIPTION
Closes #2608 <!-- totem-close: #2608 -->

One-line hardening from the live flake on the #2606 run (windows-latest): the suite-wide `beforeEach` does `vi.resetModules()` + full re-mock, so the FIRST test in the file pays the cold module-graph re-import — 10,017ms on a loaded runner, blowing vitest's 10s hook default with the test body never executed. All 51 other tests in the file passed; the rerun was green. 30s absorbs runner load without masking a genuine hang (the hook does no I/O beyond imports).

Test-only change — no changeset (nothing releasable moves).

🤖 Generated with [Claude Code](https://claude.com/claude-code)