### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine 0.1.32 -> 0.1.33

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "optionalDependencies": {
     "@mmnto/cli": "workspace:*",
-    "@mmnto/strategy-doctrine": "0.1.32"
+    "@mmnto/strategy-doctrine": "0.1.33"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.32
-        version: 0.1.32
+        specifier: 0.1.33
+        version: 0.1.33
 
   packages/cli:
     dependencies:
@@ -862,8 +862,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.32':
-    resolution: {integrity: sha512-0Ff207TK6LxLGUXF94OUD/SoXbruJfsYn1zA7z2Qug2Pbuu+qW+b8flf9jb2zcZxOooOvV+hgmt4idoTgqBYMA==}
+  '@mmnto/strategy-doctrine@0.1.33':
+    resolution: {integrity: sha512-LenEmOSgCihUpyjs0rQlyDy9IdmtQChXrvbO9kp9WBRhExf0VLhafRaKWeQ269msbkL/HwK4raq003eCPsiIQw==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3694,7 +3694,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.32':
+  '@mmnto/strategy-doctrine@0.1.33':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
Cohort doctrine-pin sync (strategy-claude, non-LC sync owner): `@mmnto/strategy-doctrine` 0.1.32 -> 0.1.33, matching the floor cut in mmnto-ai/totem-strategy#1046 (parity: gemini-team-level-arming row).

- `package.json` optionalDependencies pin bumped (exact-pin convention unchanged)
- `pnpm-lock.yaml` regenerated (tracked in this repo)
- Verified: `cohort-doctrine-pins.cjs --verify-installed . 0.1.33` VERDICT ok; `totem doctor --parity` 0 fail (WARNs are worktree-env artifacts: no local `.claude` hooks / `.mcp.json` in the fresh worktree, plus the pre-existing gemini SessionStart drift row owned by the totem lane)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
