### PR TITLE
fix(hooks): regenerate tracked .gemini SessionStart.cjs at the #2625 template + parity-lock it (#2628)

### DIFF
--- a/.gemini/hooks/SessionStart.cjs
+++ b/.gemini/hooks/SessionStart.cjs
@@ -98,6 +98,43 @@ try {
   process.stderr.write('[SessionStart] totem-status refresh-gh unavailable (non-fatal): ' + (err instanceof Error ? err.message : String(err)) + '\n');
 }
 
+// ─── A.3.a: mint session ID + log session_start event ──────────
+// New with mmnto-ai/totem#2468: this template never took over the A.3.a duty
+// its Claude sibling carries, so Gemini-seat sessions had no session UUID and
+// no session_start denominator row — the selection-manifest join key and the
+// recorded-absence contract both need them. Same shape as the Claude template.
+// Fire-and-forget: a ledger failure must NOT block the briefing.
+let mintedSessionId = null;
+try {
+  const nodePath = require('path');
+  const { mkdirSync, writeFileSync, appendFileSync } = require('fs');
+  const { randomUUID } = require('crypto');
+  const ledgerDir = nodePath.join(process.cwd(), '.totem', 'ledger');
+  mkdirSync(ledgerDir, { recursive: true });
+  mintedSessionId = randomUUID();
+  writeFileSync(nodePath.join(ledgerDir, '.session-id'), mintedSessionId, 'utf-8');
+  const selfAgentEntry = (process.env.TOTEM_SELF_AGENT || '')
+    .split(',')
+    .map((s) => s.trim())
+    .find((s) => s.length > 0);
+  const event = {
+    timestamp: new Date().toISOString(),
+    type: 'session_start',
+    activity_name: 'SessionStart',
+    source: 'bot',
+    ...(selfAgentEntry ? { agent_source: selfAgentEntry } : {}),
+    justification: '',
+    session_id: mintedSessionId,
+  };
+  appendFileSync(nodePath.join(ledgerDir, 'events.ndjson'), JSON.stringify(event) + '\n', 'utf-8');
+} catch (err) {
+  process.stderr.write(
+    '[SessionStart] session-start telemetry unavailable (non-fatal): ' +
+      (err instanceof Error ? err.message : String(err)) +
+      '\n',
+  );
+}
+
 // Interactive Gemini ingests SessionStart CONTEXT only from the
 // hookSpecificOutput.additionalContext envelope — plain exit-0 stdout wraps as
 // systemMessage, which the interactive startup consumer never injects, so the
@@ -138,6 +175,11 @@ try {
   briefing += '[Totem] Briefing unavailable: ' + (err instanceof Error ? err.message : String(err)) + '\n';
 }
 
+// Selection-manifest block boundary (mmnto-ai/totem#2468): everything in
+// `briefing` up to here is the describe leg — including its fail-soft note,
+// which IS injected payload when it fires.
+const describeBriefingEnd = briefing.length;
+
 // totem orient --session — live derived in-flight state, ADDITIVE to describe
 // (mmnto-ai/totem#2044 PR-3). Own try/catch; orient --session is itself boot-safe.
 try {
@@ -166,6 +208,59 @@ try {
   const orientMsg = err instanceof Error ? err.message : String(err);
   briefing += '[Totem] Orient briefing unavailable: ' + orientMsg + '\n';
   process.stderr.write('[SessionStart] orient briefing unavailable (non-fatal): ' + orientMsg + '\n');
+}
+
+// ─── selection manifest (mmnto-ai/totem#2468 M1) ────────────────
+// Inline append mirroring the A.3.a write above — this rendered hook runs
+// standalone in consumer repos with no access to @mmnto/totem's writer. The
+// row shape is BOUND to SelectionManifestRowSchema (strict): change both in
+// the same PR; the template contract test parses this row with the real
+// schema. A zero-byte block never becomes a candidate (nothing was injected).
+try {
+  const nodePath = require('path');
+  const { appendFileSync } = require('fs');
+  const { createHash } = require('crypto');
+  const measure = (id, content, reason) => {
+    const bytes = Buffer.byteLength(content, 'utf-8');
+    return {
+      id,
+      disposition: 'selected',
+      reason,
+      bytes,
+      approxTokens: Math.ceil(bytes / 4),
+      fingerprint: createHash('sha256').update(content, 'utf-8').digest('hex').slice(0, 16),
+    };
+  };
+  const selfAgent = (process.env.TOTEM_SELF_AGENT || '')
+    .split(',')
+    .map((s) => s.trim())
+    .find((s) => s.length > 0);
+  const row = {
+    schemaVersion: 1,
+    timestamp: new Date().toISOString(),
+    emitter: 'session-start',
+    ...(mintedSessionId ? { session_id: mintedSessionId } : {}),
+    ...(selfAgent ? { agent_source: selfAgent } : {}),
+    context: { template: 'gemini-managed' },
+    universe: 'managed-template blocks: describe + orient --session',
+    costBasis: { bytes: 'utf8-length', approxTokens: 'ceil(bytes/4) approximation' },
+    candidates: [
+      measure('describe', briefing.slice(0, describeBriefingEnd), 'always-injected briefing'),
+      measure('orient:session-block', briefing.slice(describeBriefingEnd), 'always-injected briefing'),
+    ].filter((c) => c.bytes > 0),
+    warnings: [],
+  };
+  appendFileSync(
+    nodePath.join(process.cwd(), '.totem', 'ledger', 'selection-manifests.ndjson'),
+    JSON.stringify(row) + '\n',
+    'utf-8',
+  );
+} catch (err) {
+  process.stderr.write(
+    '[SessionStart] selection manifest unavailable (non-fatal): ' +
+      (err instanceof Error ? err.message : String(err)) +
+      '\n',
+  );
 }
 
 process.stdout.write(JSON.stringify({

--- a/.totem/lessons/lesson-81133de4.md
+++ b/.totem/lessons/lesson-81133de4.md
@@ -1,0 +1,6 @@
+## Lesson — Isolate informational notices from gating channels
+
+**Tags:** logging, cli, monitoring
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Route informational notices through a dedicated channel rather than the main warnings channel to prevent non-critical logs from triggering strict quality gates or falsifying verification failures.

--- a/.totem/lessons/lesson-e3e37501.md
+++ b/.totem/lessons/lesson-e3e37501.md
@@ -1,0 +1,6 @@
+## Lesson — Scope GC verification to current-run deletions
+
+**Tags:** garbage-collection, validation
+**Scope:** packages/cli/src/commands/ecl-gc.ts
+
+Verify garbage collection against deletions performed in the current run rather than global states to prevent false-positive alerts when entities are suspended.

--- a/.totem/lessons/lesson-fd820eaf.md
+++ b/.totem/lessons/lesson-fd820eaf.md
@@ -1,0 +1,6 @@
+## Lesson — Implement fail-open-loud reads for markers
+
+**Tags:** architecture, resilience, lifecycle
+**Scope:** packages/core/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+When reading critical lifecycle markers, treat absent or corrupt files as active but emit loud warnings naming the file path to prevent lockouts while highlighting integrity issues.

--- a/packages/cli/src/commands/gemini-sessionstart-contract.test.ts
+++ b/packages/cli/src/commands/gemini-sessionstart-contract.test.ts
@@ -161,6 +161,25 @@ describe('rendered SessionStart.cjs — Gemini envelope contract (mmnto-ai/totem
   );
 });
 
+// ── tracked dogfood copy ⇄ published template parity lock (mmnto-ai/totem#2628) ──
+// The tracked .gemini/hooks/SessionStart.cjs is the copy THIS repo's Gemini
+// seat actually boots through, regenerated manually whenever the template
+// changes. #2621 regenerated it; #2625 did not — so the booting seat predated
+// the A.3.a mint block and could not self-identify (the parity-drift half of
+// the #2629 misattribution). Same mechanism as the distributed-skill locks
+// (init.test.ts, mmnto-ai/totem#1890): byte-equality fails CI, so the next
+// template change demands a regeneration instead of relying on vigilance.
+describe('tracked .gemini/hooks/SessionStart.cjs matches the published template (mmnto-ai/totem#2628)', () => {
+  it('is byte-identical to GEMINI_SESSION_START', () => {
+    const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+    const tracked = fs.readFileSync(
+      path.join(repoRoot, ...GEMINI_SESSION_START_REL.split('/')),
+      'utf-8',
+    );
+    expect(tracked).toBe(GEMINI_SESSION_START);
+  });
+});
+
 describe('rendered SessionStart.cjs — refresh-gh armed path stays out of the decision channel', () => {
   let tmpDir: string;
   let hookPath: string;


### PR DESCRIPTION
Closes #2628 <!-- totem-close: #2628 -->

## What

The tracked `.gemini/hooks/SessionStart.cjs` — the copy this repo's Gemini seat actually boots through — was regenerated at #2621 but not at #2625, so it predated the A.3.a mint block: no session UUID, no `session_start` denominator row, no selection-manifest row. That is the parity-drift half of the #2629 misattribution (live specimen 2026-08-12T06:00–06:47Z: a Gemini session's MCP activity recorded under a foreign seat's id).

- **Regeneration:** `.gemini/hooks/SessionStart.cjs` rewritten byte-identical from the published `GEMINI_SESSION_START` constant (verified `tracked === template` at write time). The diff is exactly the three template blocks added at #2625: the A.3.a session-ID mint + `session_start` ledger event, the describe-briefing boundary, and the selection-manifest row.
- **Parity lock:** new test in `gemini-sessionstart-contract.test.ts` binds the tracked copy to the template constant byte-for-byte — the same mechanism as the distributed-skill locks (#1890) — so the next template change trips CI instead of relying on a third manual regeneration. Mutation-verified: a one-byte perturbation of the tracked file trips the lock.
- **Riders:** three lessons from the #2627 postmerge extract (notices-channel isolation, GC this-run comparand, fail-open-loud markers) enter the corpus; `verify-manifest` accepts them as WARN-not-block under the standing rule-compilation freeze (no compile invoked).

## Gates

format:check, ESLint, full workspace build, 162 test files / 3993 tests, `totem lint --base main` (PASS — 3 advisory warnings, all suite-standard test idioms), `verify-manifest` PASS under freeze. The local advisory review fan ran (2 lanes); all 4 findings were verified against source and declined — the single CRITICAL inverted the fix direction (the template has carried these blocks since #2625; the tracked copy was regenerated from it), the rest describe #2625-template internals a regeneration must remain byte-identical to.

No changeset: test-only plus repo-local dogfood config; the published template is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
