### PR TITLE
chore(deps): @mmnto/strategy-doctrine 0.1.33 -> 0.1.34 (overlay §6 measured-consumption canon)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "optionalDependencies": {
     "@mmnto/cli": "workspace:*",
-    "@mmnto/strategy-doctrine": "0.1.33"
+    "@mmnto/strategy-doctrine": "0.1.34"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.33
-        version: 0.1.33
+        specifier: 0.1.34
+        version: 0.1.34
 
   packages/cli:
     dependencies:
@@ -862,8 +862,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.33':
-    resolution: {integrity: sha512-LenEmOSgCihUpyjs0rQlyDy9IdmtQChXrvbO9kp9WBRhExf0VLhafRaKWeQ269msbkL/HwK4raq003eCPsiIQw==}
+  '@mmnto/strategy-doctrine@0.1.34':
+    resolution: {integrity: sha512-pVL/K3wC6Sy7ZCJX+J4uIAi7T3SCSDjX3ifLba6sjHI+EhgntmH+W5GHfmAqWu0Jpnx3kDsGdvhFmuN62i029w==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3694,7 +3694,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.33':
+  '@mmnto/strategy-doctrine@0.1.34':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
Pin bump + lockfile regen (tracked here) — 0.1.34 published 2026-08-12T21:25Z (cut PR mmnto-ai/totem-strategy#1056; canon: 7672c5e). Payload: cohort-overlay §6, the measured-consumption canon floor (binds tokens: derivation, cost comparisons, and mmnto-ai/totem-strategy#467 instrumented work — run precondition 5 needs this repo's lane on the canonical aggregation). Trivial mechanical diff: no bots per standing practice; merge at totem lane's or operator's convenience.

🤖 Generated with [Claude Code](https://claude.com/claude-code)