### PR TITLE
fix(orient): board fetch through totalCount — deliberately-complete limit + loud truncation guard (#2644)

### DIFF
--- a/.changeset/board-truncation-guard.md
+++ b/.changeset/board-truncation-guard.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/cli': patch
+---
+
+`totem orient`: the board section no longer silently truncates GH Project boards above 200 cards. The board fetch now uses a deliberately complete `--limit 1000` and validates the response against the board's own `totalCount` — any shortfall surfaces as a loud per-section `{ error }` (and propagates to the coherence sensor) instead of rendering a partial board as complete. (mmnto-ai/totem#2644)

--- a/.totem/specs/2644.md
+++ b/.totem/specs/2644.md
@@ -1,0 +1,139 @@
+### Problem Statement
+
+Prevent silent truncation of project board items fetched from GitHub via the CLI adapter, and establish a clear, structured truncation behavior for CLI reporting when board sizes exceed readable limits without breaking underlying coherence/drift checks.
+
+### Architectural Context
+
+- **CLI Command Reference > Context & Workflow**: Board orientation needs to run with zero LLM calls, meaning any truncation calculation or report rendering must be fast and deterministic.
+- **Shared Helpers**: Safe execution of CLI commands must use the `@mmnto/totem` `safeExec` wrapper rather than raw `child_process` methods to ensure consistent execution, timeout handling, and cross-platform safety.
+
+### Files to Examine
+
+1.  `packages/cli/src/adapters/github-cli-project.ts` — The source of board item fetching. This is where default truncation limits of the GitHub CLI (typically 30 or 100 items) are encountered.
+2.  `packages/cli/src/commands/orient.ts` — Renders the `OrientReport` and manages the presentation of the project board items.
+3.  `packages/cli/src/commands/orient-coherence.ts` — Runs the drift check (`flagBoardIssueDrift`) between local issues and board items.
+
+### Technical Approach & Contracts
+
+We will implement a two-tier solution to resolve the truncation issue:
+
+1.  **Adapter Tier (Fetching):** Ensure the adapter fetches up to a reliable maximum (e.g., 1000 items) by explicitly declaring `--limit` options in the GitHub CLI command execution. This prevents silent silent data omission.
+2.  **Presentation Tier (Reporting):** Safely truncate the visual list inside `OrientReport` if it exceeds a user-friendly size (e.g., 25 items per column status), appending truncation metadata (`BoardTruncationMeta`) so the user knows they are seeing a summarized view.
+
+#### Required Data Contract Changes
+
+Update `BoardItem` or introduce a wrapping structure for reporting inside `packages/cli/src/commands/orient.ts`:
+
+```typescript
+export interface BoardTruncationMeta {
+  totalCount: number;
+  displayedCount: number;
+  isTruncated: boolean;
+}
+
+export interface TruncatedBoardSection {
+  items: BoardItem[];
+  meta: BoardTruncationMeta;
+}
+```
+
+#### Comparison of Approaches
+
+- _Approach A (Pagination Loops):_ Recursively paginate through the GitHub CLI API.
+  - _Trade-off:_ High network overhead, slow execution time during synchronous `orient` commands.
+- _Approach B (Explicit High Limit with UI Summarization — RECOMMENDED):_ Request a high item limit (`--limit 1000`) in a single fast call via `safeExec`, then slice the data strictly in the presentation layer.
+  - _Trade-off:_ Minimizes network roundtrips, ensures drift checks use the complete dataset, and keeps presentation clean and predictable.
+
+---
+
+### Edge Cases & Traps
+
+- **Drift Check Degradation:** If the presentation layer truncates the array _before_ passing it to `flagBoardIssueDrift`, the drift logic will incorrectly report that issues are missing from the board (false-positive drift). The drift algorithm must receive the _raw, untruncated_ dataset.
+- **Shell Buffer Overflow:** Fetching large datasets via `safeExec` returns large JSON strings. The parsing wrapper must handle potential JSON parse exceptions gracefully using `readJsonSafe` (or matching safe patterns) to avoid hard CLI crashes on corrupted payloads.
+- **Draft Cards with No Content Numbers:** Draft cards on GitHub project boards do not have `contentNumber` values. Truncation and grouping logic must not crash or misalign when these values are undefined.
+
+---
+
+### Implementation Tasks
+
+- [ ] **Task 1: Configure Explicit Limits in the Adapter**
+  - Modify `packages/cli/src/adapters/github-cli-project.ts` to add an explicit `--limit 1000` argument to the `gh project item-list` execution command.
+    > TOTEM INVARIANT (safeExec): Every shell execution of the GitHub CLI must use the `safeExec` shared helper. Do not use raw child_process modules.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `uses explicit high limit in CLI arguments` to verify `--limit` is always present.
+  - Write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Implement UI Truncation Logic**
+  - Create a truncation helper function in `packages/cli/src/commands/orient.ts` that limits the array of `BoardItem` instances to a configurable maximum (default 25) for display purposes only.
+  - Populate the `BoardTruncationMeta` contract to track the total items vs. displayed items.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `truncates visual lists without discarding items from source array` to assert data safety.
+  - Write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Bind Drift Coherence Check to Untruncated Data**
+  - Edit the pipeline execution inside `packages/cli/src/commands/orient.ts`.
+  - Ensure the input passed to `flagBoardIssueDrift` is the untruncated `BoardItem[]` collection, while the printed report schema maps to the truncated representation.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `calculates drift correctly on visually truncated datasets` to prove truncation doesn't lead to false-positive drift alerts.
+  - Write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 4: Update Orient Report Rendering**
+  - Modify the console output renderer in `packages/cli/src/commands/orient.ts` to print a visible truncation indicator (e.g., `... and X more items in this column`) when `isTruncated` is true.
+  - Write test → verify fails → implement → verify passes → lint
+
+---
+
+### Execution Flow
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — supplementary AI lanes over the diff (~18s, advisory). Address critical findings.
+
+---
+
+### Test Plan
+
+#### Automated Scenarios
+
+1. **Fetch Limits Verification:**
+   - Test that calls to fetch board items construct a CLI query containing `--limit 1000`.
+2. **Deterministic UI Truncation:**
+   - Provide a list of 50 mocked board items to the formatter.
+   - Assert the returned output renders exactly 25 items and features a clear metadata indication that 25 items were hidden.
+3. **Drift Alignment:**
+   - Provide a list of 50 board items and 50 corresponding local open issues.
+   - Truncate the display array to 5 items.
+   - Verify that `flagBoardIssueDrift` reports 0 issues drifting, confirming the check used the complete dataset.
+
+---
+
+### Divergence note (implementation of record — the governing spec is the issue)
+
+The sections above are LLM-generated from the issue body; the governing acceptance
+shape is mmnto-ai/totem#2644 itself (lc-codex's recommendation, carried as filed).
+The implementation diverges from the generated text as follows:
+
+- **KEPT:** the deliberately-complete `--limit 1000` (Approach B) — permitted by the
+  issue ("pagination or a deliberately complete limit"); `gh` pagination stops at the
+  board's real card count, so small boards pay nothing.
+- **ADDED (generated spec missed the issue's core):** `totalCount` parsed from the
+  response (optional — older gh omits it) and a truncation guard — any
+  `items.length < totalCount` throws into `orient`'s existing per-section `{ error }`
+  envelope, and the coherence sensor propagates the error instead of false-flagging
+  over a partial card set. Truncation must never read as completeness (Tenet 4).
+- **DROPPED (invention, not in the issue):** the "UI truncation to 25 per column" /
+  `BoardTruncationMeta` presentation layer (Tasks 2–4 above). The board section
+  renders active items only; re-introducing display truncation would rebuild the
+  defect one layer up. No `TruncatedBoardSection` type exists.
+- **Corrected premise:** the truncation cause was `BOARD_ITEM_LIMIT = 200` in
+  `github-cli-project.ts`, not gh's "default 30/100" limits.

--- a/packages/cli/src/adapters/github-cli-project.test.ts
+++ b/packages/cli/src/adapters/github-cli-project.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { safeExec } from '@mmnto/totem';
+
+import { fetchBoardItems } from './github-cli-project.js';
+
+// Mock `safeExec` at the `@mmnto/totem` boundary (same rationale as
+// gh-utils.test.ts): these tests verify the adapter's call signature and
+// parsing contract, not safeExec's passthrough layer.
+vi.mock('@mmnto/totem', async () => {
+  const actual = await vi.importActual<typeof import('@mmnto/totem')>('@mmnto/totem');
+  return {
+    ...actual,
+    safeExec: vi.fn(),
+  };
+});
+
+const mockedExec = vi.mocked(safeExec);
+
+/**
+ * Build a `gh project item-list --format json` response of `count` cards.
+ * The TAIL card (the one a 200-capped fetch would drop, mmnto-ai/totem#2644)
+ * is an active In Progress issue card; one mid-board card is a draft card
+ * with no `content` (the shape gh emits for drafts).
+ */
+function boardResponse(count: number, totalCount?: number): string {
+  const items = Array.from({ length: count }, (_, idx) => {
+    const n = idx + 1;
+    if (n === 3) {
+      // Draft card: no linked content at all.
+      return { status: 'Todo', title: `draft card ${n}` };
+    }
+    const isTail = n === count;
+    return {
+      status: isTail ? 'In Progress' : 'Done',
+      title: `card ${n}`,
+      content: { number: n, repository: 'mmnto-ai/totem', type: 'Issue' },
+    };
+  });
+  return JSON.stringify(totalCount === undefined ? { items } : { items, totalCount });
+}
+
+describe('fetchBoardItems', () => {
+  beforeEach(() => {
+    mockedExec.mockReset();
+  });
+
+  it('requests a deliberately complete --limit (not the old 200 cap)', () => {
+    mockedExec.mockReturnValue(boardResponse(5, 5));
+    fetchBoardItems('mmnto-ai', 1, '/repo');
+    const args = mockedExec.mock.calls[0]?.[1] as string[];
+    const limitValue = args[args.indexOf('--limit') + 1];
+    // Pinned on purpose: changing the page budget must be a conscious edit here
+    // too — the fixture below only proves completeness up to this budget.
+    expect(limitValue).toBe('1000');
+  });
+
+  it('parses a >200-card board in full — the active tail card survives (#2644)', () => {
+    mockedExec.mockReturnValue(boardResponse(227, 227));
+    const items = fetchBoardItems('mmnto-ai', 1, '/repo');
+    expect(items).toHaveLength(227);
+    const tail = items[226];
+    expect(tail).toMatchObject({
+      status: 'In Progress',
+      title: 'card 227',
+      contentNumber: 227,
+      contentRepo: 'mmnto-ai/totem',
+      contentType: 'Issue',
+    });
+    // Draft card maps with all content fields honestly absent.
+    expect(items[2]).toMatchObject({ title: 'draft card 3' });
+    expect(items[2].contentNumber).toBeUndefined();
+    expect(items[2].contentType).toBeUndefined();
+  });
+
+  it('fails loud when the response is truncated (items < totalCount)', () => {
+    mockedExec.mockReturnValue(boardResponse(3, 227));
+    expect(() => fetchBoardItems('mmnto-ai', 1, '/repo')).toThrow(
+      /truncated: fetched 3 of 227 cards/,
+    );
+  });
+
+  it('tolerates an absent totalCount (older gh) — no truncation signal, no throw', () => {
+    mockedExec.mockReturnValue(boardResponse(2));
+    const items = fetchBoardItems('mmnto-ai', 1, '/repo');
+    expect(items).toHaveLength(2);
+  });
+});

--- a/packages/cli/src/adapters/github-cli-project.test.ts
+++ b/packages/cli/src/adapters/github-cli-project.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { safeExec } from '@mmnto/totem';
+import { safeExec, TotemError } from '@mmnto/totem';
 
 import { fetchBoardItems } from './github-cli-project.js';
 
@@ -78,6 +78,9 @@ describe('fetchBoardItems', () => {
     expect(() => fetchBoardItems('mmnto-ai', 1, '/repo')).toThrow(
       /truncated: fetched 3 of 227 cards/,
     );
+    // Layer idiom (PR #2646 GCA round): the guard throws the adapter's
+    // structured error type, same family as every other fetch failure here.
+    expect(() => fetchBoardItems('mmnto-ai', 1, '/repo')).toThrow(TotemError);
   });
 
   it('tolerates an absent totalCount (older gh) — no truncation signal, no throw', () => {

--- a/packages/cli/src/adapters/github-cli-project.ts
+++ b/packages/cli/src/adapters/github-cli-project.ts
@@ -38,9 +38,13 @@ const GhProjectItemSchema = z
   })
   .passthrough();
 
+// `totalCount` is the board's full card count regardless of `--limit` — the
+// truncation signal the #2644 guard compares against. Optional: older gh
+// versions omit it, and without it there is no signal to check.
 const GhProjectItemListSchema = z
   .object({
     items: z.array(GhProjectItemSchema),
+    totalCount: z.number().optional(),
   })
   .passthrough();
 
@@ -57,14 +61,21 @@ export interface BoardItem {
   contentType?: string;
 }
 
-const BOARD_ITEM_LIMIT = 200;
+// Deliberately-complete page budget (mmnto-ai/totem#2644): the previous 200
+// silently truncated >200-card boards — active tail cards vanished and the
+// board section read as complete. `gh` paginates up to `--limit` and stops at
+// the board's real card count, so a high limit costs nothing on small boards;
+// the totalCount guard below keeps any board past this budget loud.
+const BOARD_ITEM_LIMIT = 1000;
 
 /**
  * Read the in-flight items of a GH Project board for `owner` / `projectNumber`.
  *
  * Throws (via `ghFetchAndParse` → `handleGhError`) when the board is
- * inaccessible / the project is absent / the JSON shape is unexpected; the
- * `orient` command catches that and renders a per-section `{ error }` envelope.
+ * inaccessible / the project is absent / the JSON shape is unexpected — and
+ * directly when the response is truncated (`items.length < totalCount`,
+ * mmnto-ai/totem#2644); the `orient` command catches that and renders a
+ * per-section `{ error }` envelope.
  */
 export function fetchBoardItems(owner: string, projectNumber: number, cwd: string): BoardItem[] {
   const parsed = ghFetchAndParse(
@@ -83,6 +94,16 @@ export function fetchBoardItems(owner: string, projectNumber: number, cwd: strin
     `GH Project board ${owner}/${projectNumber}`,
     cwd,
   );
+  // Truncation guard (Tenet 4, mmnto-ai/totem#2644): the board section presents
+  // itself as the full in-flight set, so a short fetch must never read as
+  // completeness — fail loud into the caller's { error } envelope instead.
+  if (parsed.totalCount !== undefined && parsed.items.length < parsed.totalCount) {
+    throw new Error(
+      `GH Project board ${owner}/${projectNumber} truncated: fetched ${parsed.items.length} of ` +
+        `${parsed.totalCount} cards (--limit ${BOARD_ITEM_LIMIT}) — raise BOARD_ITEM_LIMIT; ` +
+        `a partial board must not derive orientation`,
+    );
+  }
   return parsed.items.map((i) => ({
     status: i.status,
     title: i.title,

--- a/packages/cli/src/adapters/github-cli-project.ts
+++ b/packages/cli/src/adapters/github-cli-project.ts
@@ -2,6 +2,8 @@
 
 import { z } from 'zod';
 
+import { TotemError } from '@mmnto/totem';
+
 import { ghFetchAndParse } from './gh-utils.js';
 
 // ─── Board (GH Project) reader ──────────────────────────
@@ -98,10 +100,15 @@ export function fetchBoardItems(owner: string, projectNumber: number, cwd: strin
   // itself as the full in-flight set, so a short fetch must never read as
   // completeness — fail loud into the caller's { error } envelope instead.
   if (parsed.totalCount !== undefined && parsed.items.length < parsed.totalCount) {
-    throw new Error(
+    // 'SHIELD_FAILED' is this adapter's existing fetch-failure code (the
+    // handleGhError fallthrough). The remediation stays in the message too:
+    // orient's { error } envelope surfaces .message only, never recoveryHint.
+    throw new TotemError(
+      'SHIELD_FAILED',
       `GH Project board ${owner}/${projectNumber} truncated: fetched ${parsed.items.length} of ` +
         `${parsed.totalCount} cards (--limit ${BOARD_ITEM_LIMIT}) — raise BOARD_ITEM_LIMIT; ` +
         `a partial board must not derive orientation`,
+      'Raise BOARD_ITEM_LIMIT in github-cli-project.ts so one fetch covers the whole board, then re-run `totem orient`.',
     );
   }
   return parsed.items.map((i) => ({

--- a/packages/cli/src/commands/orient.test.ts
+++ b/packages/cli/src/commands/orient.test.ts
@@ -363,7 +363,7 @@ describe('orient fail-loud on truncated board fetch', () => {
     process.env['TOTEM_ORIENT_PROJECT'] = '1';
     mockFetchBoardItems.mockImplementation(() => {
       throw new Error(
-        'GH Project board mmnto-ai/1 truncated: fetched 200 of 227 cards (--limit 200)',
+        'GH Project board mmnto-ai/1 truncated: fetched 200 of 227 cards (--limit 1000)',
       );
     });
     await runJson();

--- a/packages/cli/src/commands/orient.test.ts
+++ b/packages/cli/src/commands/orient.test.ts
@@ -352,6 +352,33 @@ describe('orient fail-loud on invalid board config', () => {
   });
 });
 
+// ─── Fail loud on a truncated board fetch (mmnto-ai/totem#2644) ──
+//
+// The adapter throws when `gh` returns fewer cards than the board's totalCount;
+// that must surface as a loud board { error } — never as a shorter board that
+// reads as complete — and coherence must propagate the error rather than
+// false-flag against a partial card set.
+describe('orient fail-loud on truncated board fetch', () => {
+  it('a truncation throw becomes a board { error } envelope and coherence carries it', async () => {
+    process.env['TOTEM_ORIENT_PROJECT'] = '1';
+    mockFetchBoardItems.mockImplementation(() => {
+      throw new Error(
+        'GH Project board mmnto-ai/1 truncated: fetched 200 of 227 cards (--limit 200)',
+      );
+    });
+    await runJson();
+    const r = parseJson();
+    expect(r.board).toHaveProperty('error', expect.stringMatching(/truncated: fetched 200 of 227/));
+    expect(r.boardConfigured).toBe(true);
+    // Coherence can't be computed over a partial card set — the error propagates
+    // (orient.ts deriveCoherence), it never renders as a clean empty flag list.
+    expect(r.coherence).toHaveProperty(
+      'error',
+      expect.stringMatching(/truncated: fetched 200 of 227/),
+    );
+  });
+});
+
 // ─── --json and human render share board filter + coherence ─
 
 describe('orient --json and human render parity', () => {


### PR DESCRIPTION
## What

`totem orient`'s board section silently truncated GH Project boards above 200 cards — `BOARD_ITEM_LIMIT = 200`, one non-paginated `gh project item-list`, no completeness check. Active tail cards vanished and the board section read as complete (sensor-trust class: every seat's session-start derive consumes this surface).

## How (the issue's acceptance shape, carried as filed)

1. **Fetch through `totalCount`** — deliberately-complete `--limit 1000` (`gh` paginates up to the limit and stops at the board's real card count, so small boards pay nothing extra).
2. **`totalCount` parsed from the response** (optional in the schema — older `gh` versions omit it; without it there is no truncation signal to check).
3. **Loud on any shortfall** — `items.length < totalCount` throws into `orient`'s existing per-section `{ error }` envelope (Tenet 4), and the coherence sensor propagates the error instead of false-flagging drift over a partial card set. Truncation can never read as completeness again, including any future board past the new budget.

## Tests

- New adapter suite (`github-cli-project.test.ts`, `safeExec` boundary mock per the gh-utils idiom): pinned `--limit 1000` arg; **227-card fixture with an active tail card** parsed in full (draft-card mapping asserted); truncated response (3 of 227) throws with both counts; absent `totalCount` tolerated.
- Command level (`orient.test.ts`): a truncation throw renders as a board `{ error }` envelope with `boardConfigured: true`, and coherence carries the error (never a clean empty flag list).

## Verification

- Full gate: `pnpm -r build`, `totem lint` (one advisory on the new test's `async` callback — `runJson()` is genuinely async, file-wide idiom), repo-wide `format:check`, ESLint — all green; 42/42 tests pass.
- **Live-fired** against the real org board (totalCount 192 today): board section derives fully in ~8s wall (well inside the 15s gh timeout), guard evaluates with `totalCount` present and does not false-fire — the field name and top-level placement are confirmed against the live `gh` response, not just the fixture.
- Spec `.totem/specs/2644.md` carries a divergence note: the generated spec's invented "UI truncation to 25 per column" presentation layer was dropped (not in the issue — it would rebuild the defect one layer up), and the `totalCount` guard the generation missed was added. The governing spec is the issue.

Closes #2644 <!-- totem-close: #2644 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
