### PR TITLE
chore(lessons): postmerge extraction for #2639 + #2641 + #2643

### DIFF
--- a/.totem/lessons/lesson-011ea342.md
+++ b/.totem/lessons/lesson-011ea342.md
@@ -1,0 +1,6 @@
+## Lesson — Validate seat identity before crown derivation
+
+**Tags:** security, governance, skills
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+In distributed signoff workflows, step 0 must validate that TOTEM_SELF_AGENT matches the current session's own seat before evaluating the primary= marker. If the identity is foreign or invalid, the procedure must fail closed to prevent unauthorized crown decisions or shared upkeep mutations.

--- a/.totem/lessons/lesson-1b65008e.md
+++ b/.totem/lessons/lesson-1b65008e.md
@@ -1,0 +1,6 @@
+## Lesson — Refuse foreign seats during identity resolution
+
+**Tags:** identity, security, mail
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+A foreign seat must be refused with the resolver's own diagnostics appended to prevent incorrect unread status. A foreign-anchored poll should answer 'ever addressed' rather than 'unread' to maintain correct accounting.

--- a/.totem/lessons/lesson-2d5aaf67.md
+++ b/.totem/lessons/lesson-2d5aaf67.md
@@ -1,0 +1,6 @@
+## Lesson — Avoid general assertion helpers in CLI options
+
+**Tags:** cli, validation, errors
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Using general validation helpers like `assertSafeAgentId` in the CLI layer can throw misleading error codes (e.g., `MAIL_SEND_FAILED` for a polling command). Use direct `TotemError` validation to ensure accurate error codes and diagnostics for specific CLI options.

--- a/.totem/lessons/lesson-4a897152.md
+++ b/.totem/lessons/lesson-4a897152.md
@@ -1,0 +1,6 @@
+## Lesson — Exclude volatile fields from record identities
+
+**Tags:** architecture, serialization, hashing
+**Scope:** packages/core/src/artifacts/**/*.ts, !**/*.test.*
+
+Excluding volatile metadata like timestamps and schema versions from content-addressed record hashes prevents minor upgrades from orphaning valid historical records.

--- a/.totem/lessons/lesson-68c4c731.md
+++ b/.totem/lessons/lesson-68c4c731.md
@@ -1,0 +1,6 @@
+## Lesson — Apply fail-closed defaults selectively to cohorts
+
+**Tags:** architecture, governance, cli
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+To prevent spamming external consumers, the crown gate ladder bypasses non-cohort repositories while enforcing a strict fail-closed 'crown vacant' default for cohort repositories lacking a declared marker.

--- a/.totem/lessons/lesson-7522792a.md
+++ b/.totem/lessons/lesson-7522792a.md
@@ -1,0 +1,6 @@
+## Lesson — Derive configuration hashes mechanically
+
+**Tags:** architecture, automation
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*
+
+Mechanically binding classifier tables and fallback rules into policy hashes ensures that configuration changes automatically invalidate older runs without relying on manual version bumps.

--- a/.totem/lessons/lesson-86508820.md
+++ b/.totem/lessons/lesson-86508820.md
@@ -1,0 +1,6 @@
+## Lesson — Do not leak untrusted filename tokens
+
+**Tags:** security, mail, privacy
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Filename tokens of unopened messages are untrusted for delivery truth and must not be leaked in warnings when mail is withheld. Withheld mail should only surface as a count to prevent accidental exposure of sensitive metadata.

--- a/.totem/lessons/lesson-a577cafe.md
+++ b/.totem/lessons/lesson-a577cafe.md
@@ -1,0 +1,6 @@
+## Lesson — Deduplicate and sort policy arrays
+
+**Tags:** cryptography, hashing, security
+**Scope:** packages/core/src/artifacts/**/*.ts, !**/*.test.*
+
+Deduplicating and sorting configuration arrays (such as globs and patterns) before computing policy hashes ensures that functionally equivalent policies produce identical signatures.

--- a/.totem/lessons/lesson-a8d4960d.md
+++ b/.totem/lessons/lesson-a8d4960d.md
@@ -1,0 +1,6 @@
+## Lesson — Secure default behavior over configuration
+
+**Tags:** security, architecture, cli
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+When a repository resolves to multiple identities, the default CLI behavior must be secure and restricted rather than relying on correct user configuration. Serving a union view by default exposes sensitive metadata across seats.

--- a/.totem/lessons/lesson-f26596dc.md
+++ b/.totem/lessons/lesson-f26596dc.md
@@ -1,0 +1,6 @@
+## Lesson — Do not stamp unreviewed skips as reviewed
+
+**Tags:** security, git-hooks, authorization
+**Scope:** packages/cli/**/*.ts, !**/*.test.*
+
+Stamping a content hash as 'reviewed' on deterministic skips (like docs-only changes) can inadvertently authorize unreviewed code to bypass push gates.

--- a/.totem/lessons/lesson-fdf3720a.md
+++ b/.totem/lessons/lesson-fdf3720a.md
@@ -1,0 +1,6 @@
+## Lesson — Bypass mismatched hook material during signon
+
+**Tags:** security, session, skills
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+If injected hook material identifies a seat other than the current seat during signon, the session must discard the material and fall back to a hook-less path. This prevents consuming foreign journal or mail data and ensures seat-anchored polling integrity.


### PR DESCRIPTION
Postmerge lesson extraction for the v1.117.0 → v1.118.0 train: #2639 (mail multi-seat identity gate), #2641 (#2473 admission-phase disposition contract), #2643 (R7 crown-marker normalization + crown-gate/S0 fold).

- 11 lessons extracted (`totem lesson extract 2639 2641 2643 --yes`); the semantic index re-synced (11 chunks from 11 files).
- Compile deliberately NOT run: the legacy rule-compilation path is under the standing freeze (`.totem/freeze.json` `rule-compilation`, since 2026-05-17, pending the Convergent Spine) — extraction-only postmerge per the post-freeze precedent (#2594, #2591, #2588, …). `compiled-rules.json` and the manifest are untouched.
- Staged surface: `.totem/lessons/` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
