### PR TITLE
fix(core): lesson-heading cut no longer keeps attached trailing punctuation

### DIFF
--- a/.changeset/heading-trailing-punct.md
+++ b/.changeset/heading-trailing-punct.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/totem': patch
+---
+
+`generateLessonHeading` / `truncateHeading`: the word-boundary cut no longer leaves punctuation attached to the final word (the strategy#1060 GCA-mined exhibit — a heading ending "…contamination class,"). Trailing commas/semicolons/colons/dashes strip iteratively inside the fragment-trim loop, so a stripped comma that exposes a dangling conjunction ("…runs, and,") collapses cleanly too.

--- a/packages/core/src/lesson-format.test.ts
+++ b/packages/core/src/lesson-format.test.ts
@@ -111,6 +111,28 @@ describe('truncateHeading', () => {
     expect(truncateHeading(long).length).toBeLessThanOrEqual(HEADING_MAX_CHARS);
   });
 
+  it('strips punctuation the word-boundary cut leaves attached (strategy#1060 exhibit shape)', () => {
+    // slice(0,60) cuts inside "and"; the boundary keeps "class," WITH its comma.
+    expect(
+      truncateHeading(
+        'Baseline readings exclude the contaminated session class, and rows stamped in that window',
+      ),
+    ).toBe('Baseline readings exclude the contaminated session class');
+  });
+
+  it('iterates when a stripped comma exposes a dangling word', () => {
+    // "…runs, and," → strip comma → dangling "and" → strip → "…runs," → strip comma.
+    expect(truncateHeading('Reset state snapshots between runs, and,')).toBe(
+      'Reset state snapshots between runs',
+    );
+  });
+
+  it('strips a trailing colon or semicolon without touching interior punctuation', () => {
+    expect(truncateHeading('Guard the shared ledger root; single-writer:')).toBe(
+      'Guard the shared ledger root; single-writer',
+    );
+  });
+
   it('handles heading that is exactly at the limit', () => {
     const exact = 'x'.repeat(HEADING_MAX_CHARS);
     expect(truncateHeading(exact)).toBe(exact);

--- a/packages/core/src/lesson-format.ts
+++ b/packages/core/src/lesson-format.ts
@@ -97,14 +97,23 @@ function trimIncompleteClause(text: string): string {
 }
 
 /**
+ * Punctuation a word-boundary cut can leave attached to the final word
+ * ("…contamination class," — the boundary keeps the word WITH its comma).
+ * Stripped iteratively below because removing it can expose a dangling
+ * word ("…runs, and," → "…runs, and" → "…runs," → "…runs").
+ */
+const TRAILING_PUNCT_RE = /[\s,;:–—-]+$/;
+
+/**
  * Iteratively trim trailing fragments that leave a heading mid-clause.
- * Chains the existing dangling-tail strip with the clause-incomplete strip
- * so multi-word tails ("to enable auditable") collapse cleanly.
+ * Chains the cut-exposed punctuation strip, the dangling-tail strip, and
+ * the clause-incomplete strip so multi-word tails ("to enable auditable")
+ * and punctuation-masked tails ("and,") collapse cleanly.
  */
 function trimTrailingFragments(text: string): string {
   let prev = text;
   for (;;) {
-    let next = prev;
+    let next = prev.replace(TRAILING_PUNCT_RE, '');
     if (DANGLING_TAIL_RE.test(next)) {
       next = next.replace(DANGLING_TAIL_RE, '').trimEnd();
     }
@@ -120,8 +129,11 @@ function trimTrailingFragments(text: string): string {
  * Strips trailing ellipsis/periods added by LLMs before enforcing the limit.
  * Also trims dangling prepositions/articles/conjunctions that leave the
  * heading feeling incomplete (e.g. "must be tested against the" → "must be tested"),
- * and clause-internal-cut tails where a verb/adjective follows a preposition
- * (e.g. "to prevent" → drop both, per mmnto-ai/totem#1872).
+ * clause-internal-cut tails where a verb/adjective follows a preposition
+ * (e.g. "to prevent" → drop both, per mmnto-ai/totem#1872), and punctuation
+ * the word-boundary cut leaves attached to the final word (e.g.
+ * "…contamination class," → "…contamination class" — the strategy#1060
+ * GCA-mined exhibit).
  */
 export function truncateHeading(heading: string): string {
   // Strip trailing ellipsis (…) or triple-dot (...) that LLMs love to add


### PR DESCRIPTION
## What

Batch item 2 from the bus's 2026-08-14T1836Z pooled dispatch (GCA-mined on mmnto-ai/totem-strategy#1060): `add_lesson` headings can end mid-phrase with attached punctuation — exhibit: `lesson-08a3fa50`'s heading ending "…contamination class,". Generator-side fix as the dispatch prescribed (the hand-edit was declined repo-side: content-hash filename + generator ownership).

## Cause and fix

`truncateHeading`'s word-boundary cut keeps the final word WITH whatever punctuation is attached to it — `lastIndexOf(' ')` lands after `"class,"` and nothing stripped trailing commas (only ellipsis/triple-dot and word-class dangling tails were handled). Fix: a `TRAILING_PUNCT_RE` strip runs iteratively inside the `trimTrailingFragments` loop, so removing punctuation can expose a further dangling-word trim ("…runs, and," → "…runs, and" → "…runs," → "…runs") and each pass keeps the existing `MIN_WORD_BREAK` conservatism.

## Tests

3 new cases in the `truncateHeading` suite: the exhibit shape (a cut that lands on a comma-attached word), the punctuation-exposes-dangling-word iteration, and trailing-colon strip with interior punctuation untouched. 46/46 pass (43 pre-existing unchanged — no expectation relied on surviving trailing punctuation).

## Verification

Full gate green: `pnpm -r build`, `totem lint` (385 rules, 0 violations), repo-wide `format:check`, ESLint. Changeset: patch `@mmnto/totem`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
