### PR TITLE
chore(lessons): postmerge extraction for #2646 + #2652 + #2654

### DIFF
--- a/.totem/lessons/lesson-268e8f45.md
+++ b/.totem/lessons/lesson-268e8f45.md
@@ -1,0 +1,6 @@
+## Lesson — Keep error details in message
+
+**Tags:** cli, errors, architecture
+**Scope:** packages/cli/src/adapters/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+When throwing errors in CLI adapters, place remediation details directly in the error message rather than relying solely on recovery hints, as downstream error envelopes may only surface the message. Additionally, reuse existing broad error codes rather than over-reaching and adding single-use members to core schema error code unions.

--- a/.totem/lessons/lesson-68425ca7.md
+++ b/.totem/lessons/lesson-68425ca7.md
@@ -1,0 +1,6 @@
+## Lesson — Validate fetched items against totalCount
+
+**Tags:** api, validation, github
+**Scope:** packages/cli/src/adapters/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+To prevent silent data truncation when fetching paginated resources, always compare the length of the fetched array against the API's total count field and fail loudly on any shortfall. Ensure the validation tolerates cases where the total count field is missing to remain compatible with older API versions.


### PR DESCRIPTION
Postmerge lesson extraction for today's second merge train: #2646 (orient board truncation guard + bot-round fold), #2652 (lesson-heading trailing-punctuation fix), #2654 (changesets/action v2 revert — the release-train regression).

- 2 lessons extracted (`totem lesson extract 2646 2652 2654 --yes`): the CLI error-envelope/message-vs-hint rung and the fetch-through-totalCount validation shape. The #2654 incident's durable lesson lives canonically in #2653 (the forward-path issue), so a thin extraction there is expected, not a miss.
- Compile NOT run — the rule-compilation freeze stands; extraction-only postmerge per precedent (#2650, #2594, …). `compiled-rules.json` and the manifest untouched.
- Staged surface: `.totem/lessons/` only; index re-synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
