### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine 0.1.34 -> 0.1.36 (freeze lift-target: record grammar)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "optionalDependencies": {
     "@mmnto/cli": "workspace:*",
-    "@mmnto/strategy-doctrine": "0.1.34"
+    "@mmnto/strategy-doctrine": "0.1.36"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.34
-        version: 0.1.34
+        specifier: 0.1.36
+        version: 0.1.36
 
   packages/cli:
     dependencies:
@@ -862,8 +862,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.34':
-    resolution: {integrity: sha512-pVL/K3wC6Sy7ZCJX+J4uIAi7T3SCSDjX3ifLba6sjHI+EhgntmH+W5GHfmAqWu0Jpnx3kDsGdvhFmuN62i029w==}
+  '@mmnto/strategy-doctrine@0.1.36':
+    resolution: {integrity: sha512-EK6RE8QcJZ7WEo7G4KxlGBTkbDKUj8kjUXC9pUEOCVdD89eqoMPE87QP4FMRDJwfc+prr0/YoHQbty3Wv0dLdA==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3694,7 +3694,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.34':
+  '@mmnto/strategy-doctrine@0.1.36':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
## What

Bump `@mmnto/strategy-doctrine` **0.1.34 → 0.1.36** — collapses two cuts (this repo skipped 0.1.35, which was cut earlier the same day):

- **0.1.36** — `freeze.json`: the `rule-compilation` cohort freeze's `tracking` line now names the replacement/lift target — the record grammar (ADR-103 Amendment 2026-08-19 + Proposal 310; mmnto-ai/totem-strategy#1080 / mmnto-ai/totem-strategy#1081). This repo's PARKED/FROZEN orientation picks up the lift target on next install.
- **0.1.35** — `parity-manifest.yaml`: the `ecl-self-agent-binding` row's probe note for the 1.117.0 identity-less-poll gate (exit-2-by-design; mmnto-ai/totem#2204).

Lockfile regenerated (tracked here); exact-pin style preserved (the internal-pin channel). Resolution verified post-install: lockfile carries `@mmnto/strategy-doctrine@0.1.36`, `node_modules` copy at 0.1.36.

## Trap firing observed during this bump

The mmnto-ai/totem-strategy#630 consumer-shape trap fired live on the first install attempt: the machine's npm token had expired, and `pnpm install` silently **dropped** the optional `@mmnto/strategy-doctrine` dep — exit 0, lockfile entry removed, `node_modules` emptied — instead of failing loud. Caught by post-install verification before anything was committed; token refreshed and the install re-verified. Evidence comment lands on mmnto-ai/totem-strategy#630.

## Sequencing

Rides the pre-run window ahead of the mmnto-ai/totem-strategy#467 run-1 baselines (the WS2 environment freeze records arm (a)'s payload version at run start).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
