### PR TITLE
chore(hooks): adopt the managed-hook regeneration — PreWriteShield + SessionStart wiring, Gemini MCP registration

### DIFF
--- a/.claude/hooks/PreWriteShield.cjs
+++ b/.claude/hooks/PreWriteShield.cjs
@@ -1,0 +1,185 @@
+// [totem] auto-generated — Claude Code PreWriteShield hook
+// Rule 1: xrepo-qualify-refs (bare cross-repo refs) —
+//         sealed in mmnto-ai/totem-strategy#145 (seal SHA c488888b).
+// Rule 2: GitHub auto-close keyword guard —
+//         design of record mmnto-ai/totem#1762; sibling seal pending its own PR.
+// Rule 3: ECL dispatch frontmatter-quoting guard (outbox subject:/expected-action:
+//         values must be strict-YAML-safe) — routed from mmnto-ai/totem-status#123.
+//
+// Mirrors the compiled rule pattern at lessonHash "xrepo-qualify-refs"
+// in mmnto-ai/totem-strategy:.totem/compiled-rules.json.
+//
+// Exit-code contract (LOAD-BEARING — preserves the rule encoded as numbers):
+//   0 = allow (no violation, out of scope, or hook-internal failure → fail-soft)
+//   1 = hook-internal error (distinguish from intentional block)
+//   2 = block (Claude Code blocking convention; bare ref detected in scoped path)
+//
+// Fail-soft on parse errors / non-string content: `totem lint` at
+// commit-time remains the hard gate. The hook tightens the loop where
+// it can; it does not weaken the existing commit-time guarantee.
+'use strict';
+
+const BARE_REF_REGEX_SOURCE = "(?<!\\b[\\w-]+/[\\w-]+)#(\\d+)(?![-\\w])";
+// Single-sourced from @mmnto/totem's AUTO_CLOSE_REGEX_SOURCE (mmnto-ai/totem#1762);
+// inlined for the rendered standalone .cjs the way BARE_REF_REGEX_SOURCE is.
+const AUTO_CLOSE_REGEX_SOURCE = "\\b(?:closed|closes|close|fixed|fixes|fix|resolved|resolves|resolve)\\b(?:\\s*:\\s*|\\s+)(?:https?://github\\.com/([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)/(?:issues|pull)/(\\d+)|([A-Za-z0-9._-]+/[A-Za-z0-9._-]+)#(\\d+)|#(\\d+))";
+const SCOPED_PATH_RE = /(\.handoff[\\\/]|\.journal[\\\/]|\.md$)/i;
+const AUTO_CLOSE_MD_RE = /\.md$/i;
+// EXEMPT .github/** (intentional close keywords) and .totem/** (tool/agent-authored
+// content — never a GitHub auto-close surface). NOT .changeset/**: changeset prose
+// is composed into the Version-Packages PR DESCRIPTION (an auto-close surface —
+// verified on PR mmnto-ai/totem#2474); the totem-context directive is the escape.
+const AUTO_CLOSE_GITHUB_RE = /(^|[\\\/])\.(github|totem)[\\\/]/i;
+const SUPPRESS_DIRECTIVE_RE = /<!--\s*totem-context:/;
+// ECL dispatch surface: .totem/orchestration/<seat>/outbox/*.md (either separator).
+const OUTBOX_PATH_RE = /(^|[\\\/])\.totem[\\\/]orchestration[\\\/][^\\\/]+[\\\/]outbox[\\\/][^\\\/]+\.md$/i;
+const DISPATCH_KEY_RE = /^(subject|expected-action):\s*(.*)$/;
+
+let stdin = '';
+process.stdin.setEncoding('utf-8');
+process.stdin.on('data', (chunk) => {
+  stdin += chunk;
+});
+process.stdin.on('end', () => {
+  let parsed;
+  try {
+    parsed = stdin ? JSON.parse(stdin) : {};
+  } catch (err) {
+    process.stderr.write('[totem PreWriteShield] could not parse stdin JSON; allowing\n');
+    process.exit(0);
+  }
+
+  const toolName = parsed.tool_name;
+  if (toolName !== 'Write' && toolName !== 'Edit') {
+    process.exit(0);
+  }
+
+  const input = (typeof parsed.tool_input === 'object' && parsed.tool_input !== null) ? parsed.tool_input : {};
+  const filePath = String(input.file_path || '');
+  if (!SCOPED_PATH_RE.test(filePath)) {
+    process.exit(0);
+  }
+
+  const content = input.content !== undefined ? input.content : input.new_string;
+  if (typeof content !== 'string') {
+    process.stderr.write('[totem PreWriteShield] non-string content; allowing\n');
+    process.exit(0);
+  }
+
+  // ── Rule 3: dispatch frontmatter quoting (mmnto-ai/totem-status#123) ──
+  // Unquoted ': ' (or trailing ':') in a subject:/expected-action: value breaks
+  // strict-YAML frontmatter parsers; the dispatch then delivers only via lenient
+  // fallbacks and consumer sensor parity is lost. Full-file writes scan the
+  // leading frontmatter block only (body prose about the schema stays writable);
+  // fragment edits scan every line but honor the totem-context escape. Checked
+  // first: a malformed dispatch is unreadable regardless of what its body says.
+  if (OUTBOX_PATH_RE.test(filePath)) {
+    const dLines = content.split(/\r?\n/);
+    // Mode is TOOL-determined (CR round 1 on the introducing PR): Write is a
+    // full-file write — scan ONLY a leading frontmatter block, and a
+    // frontmatter-less full write has nothing in scope (schema completeness is
+    // the mail consumer's concern, not this guard's). Edit is a fragment:
+    // scan all lines, honoring the totem-context escape.
+    const dFragment = toolName === 'Edit';
+    let dStart = 0;
+    let dEnd = dLines.length;
+    if (!dFragment) {
+      if (dLines.length > 0 && dLines[0].trim() === '---') {
+        dStart = 1;
+        dEnd = dStart;
+        while (dEnd < dLines.length && dLines[dEnd].trim() !== '---') dEnd++;
+      } else {
+        dEnd = 0;
+      }
+    }
+    const offenders = [];
+    for (let i = dStart; i < dEnd; i++) {
+      const dLine = dLines[i];
+      if (dFragment) {
+        const dPrev = i > 0 ? dLines[i - 1] : '';
+        if (SUPPRESS_DIRECTIVE_RE.test(dLine) || SUPPRESS_DIRECTIVE_RE.test(dPrev)) continue;
+      }
+      const m = DISPATCH_KEY_RE.exec(dLine);
+      if (!m) continue;
+      const value = m[2].trim();
+      if (value === '') continue;
+      const first = value.charAt(0);
+      // A quoted scalar is exempt ONLY when well-terminated on THIS line with
+      // YAML-legal escapes (optional trailing comment): unterminated quotes,
+      // trailing junk, and invalid escapes like \q are all strict-YAML errors
+      // (greptile P1 + CR round 2 on the introducing PR). Multi-line quoted
+      // scalars are YAML-valid but BLOCKED BY POLICY: the cohort's lenient
+      // line-oriented consumer (mmnto-ai/totem-status#123) cannot see them —
+      // single-physical-line values are the dispatch contract. Block scalars are
+      // exempt ONLY as a bare header (>, >-, |2, ...): a header with trailing
+      // text (">note: x") is invalid YAML and falls through to the scan.
+      if (first === '"' || first === "'") {
+        if (first === '"' && /^"(?:[^"\\]|\\(?:[0abtnvfre "/\\N_LP\t]|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}|U[0-9A-Fa-f]{8}))*"(\s+#.*)?$/.test(value)) continue;
+        if (first === "'" && /^'(?:[^']|'')*'(\s+#.*)?$/.test(value)) continue;
+        offenders.push(m[1]);
+        continue;
+      }
+      if ((first === '>' || first === '|') && /^[>|][+-]?[0-9]*$/.test(value)) continue;
+      if (value.indexOf(': ') !== -1 || value.charAt(value.length - 1) === ':') offenders.push(m[1]);
+    }
+    if (offenders.length > 0) {
+      process.stderr.write(
+        '[totem PreWriteShield] Unquoted ":" in dispatch frontmatter value(s) [' + offenders.join(', ') + '] in write to ' + filePath + '\n' +
+        'Strict-YAML mail consumers reject the whole dispatch ("mapping values are not allowed in this context").\n' +
+        'Quote the value on ONE line with YAML-legal escapes only, e.g. subject: "Re: your round -- topic".\n' +
+        'Sender-side guard routed from mmnto-ai/totem-status#123 (lenient consumer parsing is the fallback, not the contract).\n',
+      );
+      process.exit(2);
+    }
+  }
+
+  // Suppression-directive bypass mirrors rule-engine.ts isSuppressed
+  // (line + preceding-line window).
+  const lines = content.split(/\r?\n/);
+  const filtered = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const prev = i > 0 ? lines[i - 1] : '';
+    if (SUPPRESS_DIRECTIVE_RE.test(line) || SUPPRESS_DIRECTIVE_RE.test(prev)) continue;
+    filtered.push(line);
+  }
+
+  const joined = filtered.join('\n');
+
+  // ── Auto-close keyword guard (mmnto-ai/totem#1762): **/*.md, EXEMPT .github/**, .totem/** ──
+  // Presence invariant, zero semantics: any close-keyword adjacent to an issue
+  // ref (genuine OR negated) is blocked. Checked before the bare-ref arm because
+  // accidental upstream-issue closure is the higher-blast-radius failure.
+  if (AUTO_CLOSE_MD_RE.test(filePath) && !AUTO_CLOSE_GITHUB_RE.test(filePath)) {
+    const acRe = new RegExp(AUTO_CLOSE_REGEX_SOURCE, 'gi');
+    const acMatches = [...joined.matchAll(acRe)];
+    if (acMatches.length > 0) {
+      // Group layout: 1+2 = URL owner/repo+N; 3+4 = qualified owner/repo+N; 5 = bare N.
+      const acRefs = acMatches.slice(0, 5).map((m) => (m[1] ? m[1] + '#' + m[2] : m[3] ? m[3] + '#' + m[4] : '#' + m[5])).join(', ');
+      process.stderr.write(
+        '[totem PreWriteShield] GitHub auto-close keyword adjacent to issue ref in write to ' + filePath + ': ' + acRefs + '\n' +
+        'GitHub auto-closes linked issues from a PR body / commit message carrying this pattern (even under negation).\n' +
+        'Rephrase to a non-keyword form (`references` / `see` / `tracks`).\n' +
+        'For verbatim quotation, prefix with a `<!-- totem-context: <reason> -->` directive on the preceding line.\n' +
+        'mmnto-ai/totem#1762.\n',
+      );
+      process.exit(2);
+    }
+  }
+
+  const re = new RegExp(BARE_REF_REGEX_SOURCE, 'g');
+  const matches = [...joined.matchAll(re)];
+  if (matches.length === 0) {
+    process.exit(0);
+  }
+
+  const refs = matches.slice(0, 5).map((m) => '#' + m[1]).join(', ');
+  process.stderr.write(
+    '[totem PreWriteShield] Bare PR/issue reference(s) in write to ' + filePath + ': ' + refs + '\n' +
+    'Qualify each as `<owner>/<repo>#NNN` before writing (e.g., `mmnto-ai/totem#1234`).\n' +
+    'For verbatim quotation, prefix with a `<!-- totem-context: <reason> -->` directive on the preceding line.\n' +
+    'Sealed in mmnto-ai/totem-strategy#145.\n',
+  );
+  process.exit(2);
+});
+// [totem] end auto-generated

--- a/.claude/hooks/SessionStart.cjs
+++ b/.claude/hooks/SessionStart.cjs
@@ -1,0 +1,273 @@
+// [totem] auto-generated — Claude Code SessionStart hook
+// Runs `@mmnto/cli describe` at the start of every Claude Code session.
+// Mirrors `.gemini/hooks/SessionStart.cjs`. `.cjs` extension because
+// package.json may have "type": "module" — Claude Code execs hooks via
+// plain `node`, which would otherwise treat `.js` as ESM.
+//
+// A.3.a: mints a session UUID, persists to .totem/ledger/.session-id,
+// and appends a `session_start` event to .totem/ledger/events.ndjson
+// BEFORE running `totem describe`. Subsequent MCP calls within the
+// session correlate via session_id (ADR-029 § Session Heuristic).
+// Fire-and-forget: any ledger failure must NOT block the briefing.
+const { spawnSync } = require('child_process');
+const { existsSync, mkdirSync, writeFileSync, appendFileSync } = require('fs');
+const { randomUUID } = require('crypto');
+const { join } = require('path');
+
+// ─── A.3.a: mint session ID + log session_start event ──────────
+// Hoisted so the selection-manifest row below (mmnto-ai/totem#2468) can carry
+// the same session UUID as its join key.
+let mintedSessionId = null;
+try {
+  const ledgerDir = join(process.cwd(), '.totem', 'ledger');
+  mkdirSync(ledgerDir, { recursive: true });
+  const sessionId = randomUUID();
+  mintedSessionId = sessionId;
+  writeFileSync(join(ledgerDir, '.session-id'), sessionId, 'utf-8');
+  // Amended ADR-078 (2026-07-15): agent_source is the env-carried seat-id
+  // (TOTEM_SELF_AGENT, first non-empty comma entry), never a vendor class
+  // ('claude' has no reverse projection to a seat). Omitted entirely when
+  // the env var is absent: stamp absence, never guess (Tenet 4). The parse
+  // deliberately mirrors deriveSearchLogAttribution (packages/mcp/src/
+  // search-log.ts) and parseEnvAgentList (packages/core/src/
+  // orchestration-resolver.ts) — inlined because this rendered .cjs hook
+  // runs standalone in consumer repos with no access to those modules; if
+  // the shared parse semantics change, change this template in the same PR.
+  const selfAgent = (process.env.TOTEM_SELF_AGENT || '')
+    .split(',')
+    .map((s) => s.trim())
+    .find((s) => s.length > 0);
+  const event = {
+    timestamp: new Date().toISOString(),
+    type: 'session_start',
+    activity_name: 'SessionStart',
+    source: 'bot',
+    ...(selfAgent ? { agent_source: selfAgent } : {}),
+    justification: '',
+    session_id: sessionId,
+  };
+  appendFileSync(join(ledgerDir, 'events.ndjson'), JSON.stringify(event) + '\n', 'utf-8');
+} catch (err) {
+  // Fire-and-forget; ledger failures must not block the briefing. A lightweight
+  // stderr breadcrumb makes hook misconfigurations diagnosable in consumer repos
+  // (CR R1 catch — empty catch suppresses all signal). stderr (not stdout) so
+  // the briefing path remains clean for Claude's prompt context.
+  process.stderr.write(
+    '[SessionStart] Session-start telemetry unavailable (non-fatal): ' +
+      (err instanceof Error ? err.message : String(err)) +
+      '\n',
+  );
+}
+
+// ─── totem-status refresh-gh — GH-federation snapshot refresh ───
+// (mmnto-ai/totem-status#127 C3 residual; tracking mmnto-ai/totem#2556.)
+// Spawn-and-forget, detached+unref, fired BEFORE the synchronous describe/orient
+// briefings so it overlaps them: session start must never block on it
+// (mmnto-ai/totem#2059 measured ~3s of synchronous gh calls here). The verb's
+// exit-0-or-nothing contract (single-flight, atomic rename, no-clobber when gh
+// is missing) makes blind firing safe. ENOENT = the sidecar is not adopted in
+// this repo (the common non-cohort case) — zero noise; any other spawn failure
+// keeps a non-fatal stderr breadcrumb.
+// PRIMARY checkout only (.git must be a DIRECTORY): in a linked worktree .git is a
+// pointer FILE, and a detached child inheriting the worktree cwd holds a Windows
+// directory lock that breaks worktree removal; the primary's hooks + the daemon
+// cover the workspace-level snapshot (single-flight makes extra fires redundant).
+// A non-git cwd has no refresh moment at all. The stat is cwd-anchored, not a
+// walk-up: both host runtimes launch session hooks with cwd = project root, so a
+// subdirectory cwd (which would skip) does not occur in practice — and adding a
+// git walk would cost a synchronous process on the very path this block keeps free.
+try {
+  const nodePath = require('path');
+  const { statSync } = require('fs');
+  let primaryCheckout = false;
+  try {
+    primaryCheckout = statSync(nodePath.join(process.cwd(), '.git')).isDirectory();
+  } catch {
+    // not a git checkout (or .git unreadable) — no refresh moment here
+  }
+  if (primaryCheckout) {
+    const { spawn } = require('child_process');
+    // Observability leg (mmnto-ai/totem#2570, routed from the status seat's
+    // 2026-08-03 silent no-write): under stdio:'ignore' plus the verb's
+    // exit-0-or-nothing contract, a reaped or dying child leaves NO trace
+    // (Windows detached is not job-object breakaway — a hook-harness
+    // tree-kill takes the child mid-run). Each firing stamps a workspace-root
+    // log and hands the child the same fd, so the verb's own success line
+    // lands after the stamp; a stamp with nothing after it means the child
+    // never finished. Log failures degrade to the previous blind firing —
+    // the stamp must never block or break the spawn.
+    const { openSync, closeSync, appendFileSync, existsSync, writeFileSync } = require('fs');
+    // REPO-LOCAL log, inside .git (falsification round: the primary-checkout
+    // gate just proved .git is a directory; never tracked, dies with the
+    // clone, writable wherever git itself writes, and per-repo so concurrent
+    // firings from sibling repos never interleave). A workspace-parent path
+    // would grow an un-gitignorable file OUTSIDE the repo tree for every
+    // consumer of these published templates — including non-adopters, whose
+    // ENOENT firing still stamps.
+    const logPath = nodePath.join(process.cwd(), '.git', 'totem-status-refresh-hook.log');
+    // Control characters are scrubbed from path-derived fields before they
+    // reach the log (terminal-injection guideline: a crafted checkout path
+    // must not forge stamp lines or inject terminal controls).
+    const scrub = (v) => String(v).replace(/[\x00-\x1f\x7f]/g, '?');
+    let stdio = 'ignore';
+    let logFd = null;
+    try {
+      try {
+        // 1 MiB self-cap: the log truncates rather than growing forever.
+        if (statSync(logPath).size > 1048576) writeFileSync(logPath, '');
+      } catch {
+        // no log yet — nothing to cap
+      }
+      appendFileSync(logPath, '[' + new Date().toISOString() + '] claude spawn cwd=' + scrub(process.cwd()) + ' path-has-go-bin=' + /go[\\/]bin/i.test(process.env.PATH || '') + ' cwd-shadow-exe=' + existsSync(nodePath.join(process.cwd(), 'totem-status.exe')) + '\n');
+      logFd = openSync(logPath, 'a');
+      stdio = ['ignore', logFd, logFd];
+    } catch {
+      // log unavailable — refresh still fires blind, as before
+    }
+    const refresh = spawn('totem-status', ['refresh-gh'], {
+      detached: true,
+      stdio,
+    });
+    refresh.on('error', (err) => {
+      try {
+        appendFileSync(logPath, '[' + new Date().toISOString() + '] claude spawn-error code=' + ((err && err.code) || 'unknown') + '\n');
+      } catch {
+        // log write failed — fall through to the stderr breadcrumb
+      }
+      if (err && err.code === 'ENOENT') return;
+      process.stderr.write('[SessionStart] totem-status refresh-gh spawn failed (non-fatal): ' + (err instanceof Error ? err.message : String(err)) + '\n');
+    });
+    refresh.unref();
+    // The child holds its own copy of the fd from spawn time; release the parent's.
+    if (logFd !== null) {
+      try {
+        closeSync(logFd);
+      } catch {
+        // nothing to release
+      }
+    }
+  }
+} catch (err) {
+  process.stderr.write('[SessionStart] totem-status refresh-gh unavailable (non-fatal): ' + (err instanceof Error ? err.message : String(err)) + '\n');
+}
+
+// ─── totem describe briefing (existing behavior) ────────────────
+// Captured (mmnto-ai/totem#2468): the injected block is the selection-manifest
+// candidate below — the not-installed notice is a notice, not a briefing.
+let describeText = '';
+try {
+  const cliPath = join(process.cwd(), 'node_modules', '@mmnto', 'cli', 'dist', 'index.js');
+  if (existsSync(cliPath)) {
+    const result = spawnSync(process.execPath, [cliPath, 'describe'], {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    if (result.error) {
+      throw result.error;
+    }
+    // Totem CLI writes diagnostic output to stderr; route to stdout so the
+    // session-start context lands in Claude's prompt rather than user-visible noise.
+    describeText = (result.stdout || '') + (result.stderr || '');
+    process.stdout.write(describeText);
+  } else {
+    process.stdout.write(
+      '[Totem] @mmnto/cli not installed. Run `pnpm install` (or your package manager equivalent) to enable session-start orientation.\n',
+    );
+  }
+} catch (err) {
+  process.stdout.write(
+    '[Totem] Briefing unavailable: ' +
+      (err instanceof Error ? err.message : String(err)) +
+      '\n',
+  );
+}
+
+// ─── totem orient --session — live derived in-flight state (mmnto-ai/totem#2044 PR-3) ──
+// ADDITIVE to describe (Tenet 13: describe = static identity sensor — scope/tier/
+// counts; orient = live in-flight sensor — open PRs/issues/board/freeze). Append,
+// never replace. Its OWN try/catch so an orient failure never disturbs the describe
+// briefing or the boot; `orient --session` is itself boot-safe (emits nothing when
+// nothing is high-signal, never exits non-zero, degrades to honest "could not derive").
+let orientText = '';
+try {
+  const orientCliPath = join(process.cwd(), 'node_modules', '@mmnto', 'cli', 'dist', 'index.js');
+  if (existsSync(orientCliPath)) {
+    const orientResult = spawnSync(process.execPath, [orientCliPath, 'orient', '--session'], {
+      encoding: 'utf-8',
+      timeout: 30000,
+    });
+    // spawnSync sets .error (it does NOT throw) on a spawn-level failure; re-throw so
+    // it surfaces through the catch breadcrumb below rather than writing '' silently.
+    if (orientResult.error) {
+      throw orientResult.error;
+    }
+    orientText = (orientResult.stdout || '') + (orientResult.stderr || '');
+    process.stdout.write(orientText);
+  }
+} catch (err) {
+  // Boot-safe: orient is additive to describe (already emitted), so a failure never
+  // blocks session start — but surface a NON-fatal breadcrumb to stderr (not stdout,
+  // to keep the prompt clean) for debuggability rather than swallowing silently.
+  process.stderr.write(
+    '[SessionStart] orient briefing unavailable (non-fatal): ' +
+      (err instanceof Error ? err.message : String(err)) +
+      '\n',
+  );
+}
+
+// ─── selection manifest (mmnto-ai/totem#2468 M1) ────────────────
+// Inline append mirroring the session_start write above — this rendered hook
+// runs standalone in consumer repos with no access to @mmnto/totem's writer.
+// The row shape is BOUND to SelectionManifestRowSchema (strict): change both
+// in the same PR; the template contract test parses this row with the real
+// schema. A zero-byte block never becomes a candidate (nothing was injected).
+try {
+  const { createHash } = require('crypto');
+  const measure = (id, content, reason) => {
+    const bytes = Buffer.byteLength(content, 'utf-8');
+    return {
+      id,
+      disposition: 'selected',
+      reason,
+      bytes,
+      approxTokens: Math.ceil(bytes / 4),
+      fingerprint: createHash('sha256').update(content, 'utf-8').digest('hex').slice(0, 16),
+    };
+  };
+  const selfAgent = (process.env.TOTEM_SELF_AGENT || '')
+    .split(',')
+    .map((s) => s.trim())
+    .find((s) => s.length > 0);
+  const row = {
+    schemaVersion: 1,
+    timestamp: new Date().toISOString(),
+    emitter: 'session-start',
+    ...(mintedSessionId ? { session_id: mintedSessionId } : {}),
+    ...(selfAgent ? { agent_source: selfAgent } : {}),
+    // mmnto-ai/totem#2629: provenance disclosed on every row (ruled item 1).
+    // Self-minted row — the minting seat IS this process's env read, so the
+    // core conflict probe is structurally inapplicable; only the two-value
+    // provenance enum rides. Mirrors senseAgentAttribution's biconditional.
+    agent_source_provenance: selfAgent ? 'env' : 'absent',
+    context: { template: 'claude-managed' },
+    universe: 'managed-template blocks: describe + orient --session',
+    costBasis: { bytes: 'utf8-length', approxTokens: 'ceil(bytes/4) approximation' },
+    candidates: [
+      measure('describe', describeText, 'always-injected briefing'),
+      measure('orient:session-block', orientText, 'always-injected briefing'),
+    ].filter((c) => c.bytes > 0),
+    warnings: [],
+  };
+  appendFileSync(
+    join(process.cwd(), '.totem', 'ledger', 'selection-manifests.ndjson'),
+    JSON.stringify(row) + '\n',
+    'utf-8',
+  );
+} catch (err) {
+  process.stderr.write(
+    '[SessionStart] selection manifest unavailable (non-fatal): ' +
+      (err instanceof Error ? err.message : String(err)) +
+      '\n',
+  );
+}
+// [totem] end auto-generated

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,21 +1,32 @@
 {
-  "permissions": {
-    "allow": [
-      "Bash(npm view *)",
-      "Bash(gdlint *)",
-      "Bash(gh search *)",
-      "mcp__totem-dev__search_knowledge",
-      "mcp__totem-strategy__search_knowledge"
-    ]
-  },
   "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/PreWriteShield.cjs"
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
-        "matcher": "",
         "hooks": [
           {
             "type": "command",
             "command": "node .claude/hooks/session-context.mjs"
+          }
+        ],
+        "matcher": ""
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/SessionStart.cjs",
+            "timeout": 30000
           }
         ]
       }
@@ -41,6 +52,15 @@
           }
         ]
       }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "Bash(npm view *)",
+      "Bash(gdlint *)",
+      "Bash(gh search *)",
+      "mcp__totem-dev__search_knowledge",
+      "mcp__totem-strategy__search_knowledge"
     ]
   }
 }

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -15,12 +15,7 @@
   "mcpServers": {
     "totem": {
       "command": "cmd",
-      "args": [
-        "/c",
-        "npx",
-        "-y",
-        "@mmnto/mcp"
-      ]
+      "args": ["/c", "npx", "-y", "@mmnto/mcp"]
     }
   }
 }

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -11,5 +11,16 @@
         ]
       }
     ]
+  },
+  "mcpServers": {
+    "totem": {
+      "command": "cmd",
+      "args": [
+        "/c",
+        "npx",
+        "-y",
+        "@mmnto/mcp"
+      ]
+    }
   }
 }


### PR DESCRIPTION
## What

Adopts the keep-half of totem-agy's uncommitted `totem init -y` run (2026-08-19T01:40:28Z, seat journal `gemini-0034`), which sat as unattributed dirty state on the shared tree for two days:

- **`.claude/hooks/PreWriteShield.cjs`** + PreToolUse wiring — blocks bare cross-repo refs (sealed mmnto-ai/totem-strategy#145), auto-close keyword misuse (mmnto-ai/totem#1762), and unsafe ECL frontmatter quoting (mmnto-ai/totem-status#123) at Write/Edit time. Fail-soft; `totem lint` remains the hard gate.
- **`.claude/hooks/SessionStart.cjs`** + wiring — session provenance: mints a session UUID, appends the ADR-078 `session_start` ledger event with the env-carried seat id, writes the mmnto-ai/totem#2468 selection-manifest row, runs the `totem describe` banner. Load-bearing for the mmnto-ai/totem-strategy#467 run preconditions (P2 verifies against exactly this row class).
- **`.gemini/settings.json`** — registers the Totem MCP server for Gemini-CLI seats (prettier-normalized in the follow-up commit).

## What is deliberately NOT here (reverted from the same run)

- Reflexes-v10 injection into the four ADR-038 redirect files (`CLAUDE.md`, `GEMINI.md`, copilot, junie) — AGENTS.md is canonical since mmnto-ai/totem#1904 and no reflexes block was ever committed to them (`git log -S` empty).
- `.totem/lessons/baseline.md` — the generic 59-lesson starter pack, wrong for a 1,536-lesson curated corpus on an indexed target path.
- `.totem/prepare.cjs` — distributed unwired (this repo has its own `prepare`).

The underlying init idempotence gap is filed as mmnto-ai/totem#2658.

## Verification

- Both hooks live-fired in the current session before adoption: SessionStart produced the orientation banner; PreWriteShield correctly blocked a bare `#NNN` write and passed it after qualification.
- Full-branch `totem lint`: PASS (1 advisory warning on the MCP `command` key pattern — a generic hook-command lesson rule pattern-matching `"command": "cmd"`; no error).
- Repo-wide `format:check`: green.
- No package source touched — no changeset (not a releasable slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
