### PR TITLE
feat(core): record lowering, compiled homes, runtime eval (Prop 310 slice 2)

### DIFF
--- a/.changeset/record-grammar-lowering-slice2.md
+++ b/.changeset/record-grammar-lowering-slice2.md
@@ -1,0 +1,5 @@
+---
+'@mmnto/totem': minor
+---
+
+Lower parsed Prop 310 rule records into compiled rules, add their compiled homes on `CompiledRuleSchema` (`excludeGlobs`, `requires`, `examples`, `language`, `verificationShadow`, `recoveryHint`, `curation` — all optional), and evaluate the § Design 7 two-array glob scope and § Design 8 `requires` two-pass at lint time (slice 2 of the Prop 310 build).

--- a/packages/cli/src/commands/run-compiled-rules.test.ts
+++ b/packages/cli/src/commands/run-compiled-rules.test.ts
@@ -783,7 +783,7 @@ describe('runCompiledRules', () => {
         .spyOn(totem, 'safeExec')
         .mockImplementation((cmd: string, args?: string[]) => {
           if (!args) return '';
-          if (args[0] === 'ls-files' && args[1] === '--recurse-submodules' && args[2] === '-s') {
+          if (args[0] === 'ls-files' && args[1] === '-s') {
             return '100644 hash 0\tsrc/app.ts\n';
           }
           if (args[0] === 'show') {
@@ -937,7 +937,7 @@ describe('runCompiledRules', () => {
         .spyOn(totem, 'safeExec')
         .mockImplementation((cmd: string, args?: string[]) => {
           if (!args) return '';
-          if (args[0] === 'ls-files' && args[1] === '--recurse-submodules' && args[2] === '-s') {
+          if (args[0] === 'ls-files' && args[1] === '-s') {
             return '120000 hash 0\tsrc/app.ts\n'; // Symlink
           }
           if (args[0] === 'show') {
@@ -980,7 +980,7 @@ describe('runCompiledRules', () => {
         .spyOn(totem, 'safeExec')
         .mockImplementation((cmd: string, args?: string[]) => {
           if (!args) return '';
-          if (args[0] === 'ls-files' && args[1] === '--recurse-submodules' && args[2] === '-s') {
+          if (args[0] === 'ls-files' && args[1] === '-s') {
             return '100644 hash 0\tsrc/app.ts\n';
           }
           if (args[0] === 'show') {
@@ -1034,7 +1034,7 @@ describe('runCompiledRules', () => {
         .spyOn(totem, 'safeExec')
         .mockImplementation((cmd: string, args?: string[]) => {
           if (!args) return '';
-          if (args[0] === 'ls-files' && args[1] === '--recurse-submodules' && args[2] === '-s') {
+          if (args[0] === 'ls-files' && args[1] === '-s') {
             return '100644 hash 0\tsrc/app.ts\n';
           }
           if (args[0] === 'show') {
@@ -1129,7 +1129,7 @@ describe('runCompiledRules', () => {
         .spyOn(totem, 'safeExec')
         .mockImplementation((cmd: string, args?: string[]) => {
           if (!args) return '';
-          if (args[0] === 'ls-files' && args[1] === '--recurse-submodules' && args[2] === '-s') {
+          if (args[0] === 'ls-files' && args[1] === '-s') {
             return '100644 hash 0\tsrc/app.ts\n';
           }
           if (args[0] === 'show') {

--- a/packages/cli/src/commands/run-compiled-rules.test.ts
+++ b/packages/cli/src/commands/run-compiled-rules.test.ts
@@ -820,6 +820,106 @@ describe('runCompiledRules', () => {
       mockExec.mockRestore();
     });
 
+    // ─── Prop 310 § Design 8 — the staged read decides the REGEX verdict ─────
+    //
+    // The wiring this pins: `readStrategy` used to be built inside the AST block,
+    // so the regex dispatcher never received it and a record rule's
+    // `requires: {scope: file}` was judged against the WORKTREE while `--staged`
+    // was judging the index. That is fail-open in the direction that matters —
+    // a required context deleted in the staged edit but still on disk would
+    // satisfy the requirement and let the staged violation through the
+    // pre-commit gate. The fixtures below make the two sources DISAGREE, so only
+    // the source that actually decides can produce the observed verdict.
+    describe('Prop 310 record rule with a file-scoped requirement', () => {
+      /** A record-shaped rule: `examples` present ⇒ the Prop 310 runtime applies. */
+      function requiresRule(): CompiledRule {
+        return makeRule('\\bgit\\s+log\\b', 'pin LC_ALL=C', 'LC_ALL pin', {
+          fileGlobs: ['**/*.sh'],
+          examples: [{ bad: 'git log --oneline', good: 'LC_ALL=C git log --oneline' }],
+          requires: { pattern: 'LC_ALL=C', scope: 'file' },
+        });
+      }
+
+      /** Worktree SATISFIES the requirement; the index (git show) does NOT. */
+      function stageDivergence(stagedContent: string) {
+        fs.mkdirSync(path.join(tmpDir, 'scripts'), { recursive: true });
+        fs.writeFileSync(
+          path.join(tmpDir, 'scripts', 'x.sh'),
+          ['export LC_ALL=C', 'git log --oneline'].join('\n'),
+          'utf-8',
+        );
+        const mockResolveGitRoot = vi.spyOn(totem, 'resolveGitRoot').mockReturnValue(tmpDir);
+        const mockExec = vi
+          .spyOn(totem, 'safeExec')
+          .mockImplementation((_cmd: string, args?: string[]) => {
+            if (!args) return '';
+            if (args[0] === 'ls-files') return '100644 hash 0\tscripts/x.sh\n';
+            if (args[0] === 'show') return stagedContent;
+            return '';
+          });
+        return () => {
+          mockResolveGitRoot.mockRestore();
+          mockExec.mockRestore();
+        };
+      }
+
+      async function violationCount(isStaged: boolean): Promise<number> {
+        try {
+          const result = await runCompiledRules({
+            diff: makeDiff('scripts/x.sh', 'git log --oneline'),
+            cwd: tmpDir,
+            totemDir: TOTEM_DIR,
+            format: 'json',
+            tag: 'Test',
+            isStaged,
+          });
+          return result.violations.length;
+        } catch (err: unknown) {
+          if (
+            err instanceof Error &&
+            err.name === 'TotemError' &&
+            err.message.includes('Violations detected')
+          ) {
+            return 1;
+          }
+          throw err;
+        }
+      }
+
+      it('FIRES under --staged when the index drops the required context', async () => {
+        writeRules(tmpDir, [requiresRule()]);
+        const restore = stageDivergence('git log --oneline\n');
+        try {
+          expect(await violationCount(true)).toBe(1);
+        } finally {
+          restore();
+        }
+      });
+
+      it('stays SILENT without --staged, where the worktree is the source of truth', async () => {
+        // Same manifest, same diff, same disk — only the read source changes.
+        // If the regex path had ignored the staged reader, both arms would agree
+        // and the test above could not distinguish them.
+        writeRules(tmpDir, [requiresRule()]);
+        const restore = stageDivergence('git log --oneline\n');
+        try {
+          expect(await violationCount(false)).toBe(0);
+        } finally {
+          restore();
+        }
+      });
+
+      it('stays SILENT under --staged when the index KEEPS the required context', async () => {
+        writeRules(tmpDir, [requiresRule()]);
+        const restore = stageDivergence('export LC_ALL=C\ngit log --oneline\n');
+        try {
+          expect(await violationCount(true)).toBe(0);
+        } finally {
+          restore();
+        }
+      });
+    });
+
     it('filters symlinks via the underlying index check mode 120000', async () => {
       const rules = [
         makeRule('console\\.log\\("foo"\\)', 'No foo log', 'No foo log', {

--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -606,6 +606,54 @@ export async function runCompiledRules(
       );
     }
   };
+  // Staged-content reader, hoisted above BOTH dispatchers (Prop 310 slice 2,
+  // falsification round 2026-08-21). It was previously defined inside the AST
+  // block, so the regex path had no way to reach it — and a Prop 310
+  // `requires: {scope: file}` check evaluated there would have read the WORKTREE
+  // while `--staged` was judging the index. That is fail-open in the direction
+  // that matters: a required context deleted in the staged edit but still on
+  // disk would satisfy the requirement and let the staged violation through the
+  // pre-commit gate. One reader, both paths, same bytes.
+  let stagedReadStrategy: ((filePath: string) => Promise<string | null>) | undefined = undefined;
+  if (isStaged && repoRoot) {
+    stagedReadStrategy = async (filePath: string) => {
+      try {
+        // totem-context: false positive — comment mentions `git ls-files`; the actual call below already uses --recurse-submodules
+        // 1. Detect symlinks explicitly (git ls-files -s returns mode 120000).
+        //    The `--` separator prevents filePath values starting with `-` from
+        //    being interpreted as git options.
+        const lsOutput = safeExec(
+          'git',
+          ['ls-files', '--recurse-submodules', '-s', '--', filePath],
+          { cwd: repoRoot, env: { ...process.env, LC_ALL: 'C' } },
+        );
+        if (lsOutput.startsWith('120000 ')) {
+          return null; // Explicitly exclude symlinks from AST checks
+        }
+
+        // 2. Read staged content
+        const content = safeExec('git', ['show', `:${filePath}`], {
+          cwd: repoRoot,
+          trim: false,
+          env: { ...process.env, LC_ALL: 'C' },
+        });
+
+        // 3. Normalize CRLF to LF specifically for the staged callback
+        // totem-context: Invariant #4 refers to an internal invariant number, not an issue ref
+        // Disk-read callback preserves existing behavior per Invariant #4.
+        return content.replace(/\r\n/g, '\n');
+      } catch (err) {
+        // Explicit throw per Failure Mode 1 decision
+        throw new TotemError(
+          'STAGED_READ_FAILED',
+          `Failed to read staged content for ${filePath}`,
+          `git show :${filePath} failed. The file may not exist in the index or may be staged for deletion. Ensure --staged is used correctly.`,
+          { cause: err },
+        );
+      }
+    };
+  }
+
   const regexEvaluator = new RegexEvaluator({}, writeRegexTelemetry);
   let regexViolations: Violation[] = [];
   const regexTimeouts: RuleTimeoutOutcome[] = [];
@@ -618,6 +666,10 @@ export async function runCompiledRules(
         evaluator: regexEvaluator,
         timeoutMode: effectiveTimeoutMode,
         repoRoot: repoRoot ?? cwd,
+        // Prop 310 § Design 8 — a file-scoped requirement reads the same bytes
+        // the lint is judging (the index under `--staged`, the worktree
+        // otherwise). Undefined outside staged mode ⇒ worktree read.
+        readStrategy: stagedReadStrategy,
       },
       ruleEventCallback,
     );
@@ -644,48 +696,8 @@ export async function runCompiledRules(
     log.dim(tag, `Running ${astRules.length} AST rule(s)...`);
     try {
       const workingDirectory = repoRoot ?? cwd;
-      let readStrategy: ((filePath: string) => Promise<string | null>) | undefined = undefined;
-
-      if (isStaged) {
-        if (repoRoot) {
-          readStrategy = async (filePath: string) => {
-            try {
-              // totem-context: false positive — comment mentions `git ls-files`; the actual call below already uses --recurse-submodules
-              // 1. Detect symlinks explicitly (git ls-files -s returns mode 120000).
-              //    The `--` separator prevents filePath values starting with `-` from
-              //    being interpreted as git options.
-              const lsOutput = safeExec(
-                'git',
-                ['ls-files', '--recurse-submodules', '-s', '--', filePath],
-                { cwd: repoRoot, env: { ...process.env, LC_ALL: 'C' } },
-              );
-              if (lsOutput.startsWith('120000 ')) {
-                return null; // Explicitly exclude symlinks from AST checks
-              }
-
-              // 2. Read staged content
-              const content = safeExec('git', ['show', `:${filePath}`], {
-                cwd: repoRoot,
-                trim: false,
-                env: { ...process.env, LC_ALL: 'C' },
-              });
-
-              // 3. Normalize CRLF to LF specifically for the staged callback
-              // totem-context: Invariant #4 refers to an internal invariant number, not an issue ref
-              // Disk-read callback preserves existing behavior per Invariant #4.
-              return content.replace(/\r\n/g, '\n');
-            } catch (err) {
-              // Explicit throw per Failure Mode 1 decision
-              throw new TotemError(
-                'STAGED_READ_FAILED',
-                `Failed to read staged content for ${filePath}`,
-                `git show :${filePath} failed. The file may not exist in the index or may be staged for deletion. Ensure --staged is used correctly.`,
-                { cause: err },
-              );
-            }
-          };
-        }
-      }
+      // Defined once above both dispatchers — see the hoist comment there.
+      const readStrategy = stagedReadStrategy;
 
       astViolations = await applyAstRulesToAdditions(
         ruleCtx,

--- a/packages/cli/src/commands/run-compiled-rules.ts
+++ b/packages/cli/src/commands/run-compiled-rules.ts
@@ -618,15 +618,22 @@ export async function runCompiledRules(
   if (isStaged && repoRoot) {
     stagedReadStrategy = async (filePath: string) => {
       try {
-        // totem-context: false positive — comment mentions `git ls-files`; the actual call below already uses --recurse-submodules
         // 1. Detect symlinks explicitly (git ls-files -s returns mode 120000).
         //    The `--` separator prevents filePath values starting with `-` from
         //    being interpreted as git options.
-        const lsOutput = safeExec(
-          'git',
-          ['ls-files', '--recurse-submodules', '-s', '--', filePath],
-          { cwd: repoRoot, env: { ...process.env, LC_ALL: 'C' } },
-        );
+        //
+        //    `--recurse-submodules` is deliberately ABSENT: combining it with
+        //    `-s` requires Git ≥2.36, this project declares no minimum Git
+        //    version, and on an older Git the flag makes the whole staged read
+        //    fail as `STAGED_READ_FAILED` — turning a supported setup into a
+        //    hard error. It bought nothing here either: the staged content is
+        //    read by `git show :<file>` below, which the flag does not affect,
+        //    so its only role was this symlink probe. Do not re-add it without
+        //    also declaring a minimum Git version.
+        const lsOutput = safeExec('git', ['ls-files', '-s', '--', filePath], {
+          cwd: repoRoot,
+          env: { ...process.env, LC_ALL: 'C' },
+        });
         if (lsOutput.startsWith('120000 ')) {
           return null; // Explicitly exclude symlinks from AST checks
         }

--- a/packages/core/src/compiler-schema.ts
+++ b/packages/core/src/compiler-schema.ts
@@ -611,6 +611,127 @@ const CompiledRuleBaseSchema = z.object({
    * reader falls back to the legacy engine-type proxy.
    */
   ruleClass: z.enum(['hard', 'advisory']).optional(),
+
+  // ─── Prop 310 V1 record-grammar compiled homes (§ Design 12) ───────────────
+  //
+  // The four homes the Existing-Surface Coupling table's lint-runtime row names
+  // as V1-BLOCKING build items (`excludeGlobs`, `requires`, `examples`,
+  // `language`), plus the verbatim `verificationShadow` carry (§ Design 9 /
+  // Amendment R4) and the two §§ Design 4 constructs total lowering forces a home
+  // for (`recoveryHint`, `curation` — see `record-lower.ts`'s contract comment).
+  //
+  // EVERY addition is OPTIONAL, and that is load-bearing, not stylistic: the 485
+  // mined/legacy rules in `.totem/compiled-rules.json` carry none of them, the
+  // rule-compilation freeze means nothing regenerates that file, and a required
+  // addition would fail the whole frozen corpus at `loadCompiledRules`. The
+  // mined-path byte-identity guard (`record-lower.test.ts`) is the proof: the
+  // shipped manifest re-validates unchanged under the extended schema, and zero
+  // of its rules carry any field added here.
+  //
+  // Absence is also the RECORD-PATH DISCRIMINATOR the runtime reads (see
+  // `isRecordPathRule` in `spine/record-runtime.ts`): a rule carrying any of
+  // these came from the Prop 310 path and gets the § Design 7 glob dialect;
+  // everything else keeps the shipped matcher byte-for-byte.
+  /**
+   * Prop 310 § Design 7 / mmnto-ai/totem#1574 — first-class structural
+   * exclusions. Entries are POSITIVE-form globs applied as exclusions: a file is
+   * in scope iff it matches some `fileGlobs` entry AND no `excludeGlobs` entry
+   * (`positiveMatch && !excludeMatch`). `!`-negation is a parse error in the
+   * record grammar, so an entry here never carries one.
+   */
+  excludeGlobs: z.array(z.string()).optional(),
+  /**
+   * Prop 310 § Design 8 — the absence / must-contain block. The rule fires on a
+   * target match at locus L iff `pattern` does NOT match within the declared
+   * scope containing L. `pattern` is a safe-regex2-gated regex evaluated
+   * TEXTUALLY, independent of `engine`; V1 carries exactly one block.
+   *
+   * The scope enum MIRRORS `RequiresScopeSchema` (`spine/rule-record.ts`) rather
+   * than importing it — `compiler-schema.ts` is an import-graph LEAF (zod only)
+   * and `spine/rule-record.ts` transitively imports it, so an import here would
+   * close a cycle. The two are COUPLED by an equality test in
+   * `record-lower.test.ts`, never left to drift on inspection. `block` is
+   * reserved-unimplemented at the grammar (§ Design 8) and therefore can never
+   * reach a compiled rule.
+   */
+  requires: z
+    .object({
+      pattern: z.string(),
+      scope: z.enum(['line', 'file']),
+    })
+    .optional(),
+  /**
+   * Prop 310 § Design 5 / § Design 10 — certification's PRIMARY PREIMAGE SOURCE
+   * (ADR-112 §4), and per Amendment 1 the record's block is the hand-editable
+   * home (the fixture envelope derives). Carried verbatim, in ordinal order: the
+   * `(ruleId, ordinal)` join key is positional, so a reorder is a re-pair.
+   *
+   * Deliberately NOT projected onto the legacy `badExample`/`goodExample` pair —
+   * that would be Tenet 20's prohibited mirror (two hand-editable homes for one
+   * object). Consumers that need a single exemplar read `examples[0]`.
+   */
+  examples: z
+    .array(
+      z.object({
+        bad: z.string(),
+        good: z.string(),
+      }),
+    )
+    .optional(),
+  /**
+   * Prop 310 § Design 6 — the rule's grammar binding: the single declared
+   * language the ast-grep payload was validated under, resolved against the
+   * Map-backed `extensionToLanguage` registry at compile (built-ins + pack
+   * contributions), never a spec-frozen enum. Present only for record-path
+   * ast-grep rules; the record grammar FORBIDS `language` for regex.
+   */
+  language: z.string().optional(),
+  /**
+   * Prop 310 § Design 9 (Amendment R4) — the classification block, carried
+   * VERBATIM and **NEVER EVALUATED at V1**. Evaluation is gated by the ADR-103
+   * Amendment's proof-required-for-enforcement ruling (and any OPA wiring by
+   * Amendment R1's Q2 perf probe); when SMT lands, the verification result binds
+   * to the emitted artifact via the Amendment's R2 certificate chain. Any reader
+   * that starts EXECUTING this field has crossed the R4 gate — a doctrine change,
+   * not a code change.
+   *
+   * The record key keeps its shipped snake_case name (`verification_shadow`, a
+   * named § Design 4 exception); the COMPILED home is camelCase like every other
+   * field here — the rename happens exactly once, at lowering.
+   */
+  verificationShadow: z
+    .object({
+      type: z.string(),
+      source: z.string(),
+    })
+    .optional(),
+  /**
+   * Prop 310 § Design 4 — the optional author-supplied recovery hint. Compiled
+   * home added under § Design 12's total-lowering obligation: the parser admits
+   * the construct, so it either lands here or fails compile loud, and failing
+   * loud on a legal § Design 4 field is not an option. See `record-lower.ts`
+   * § "Total lowering, mechanically".
+   */
+  recoveryHint: z.string().optional(),
+  /**
+   * Prop 310 § Design 4 (R8) — Prop 270 §8's curation-provenance block, carried
+   * under the § Design 4 collision rename (`curation`, not `provenance` — that
+   * name is the ADR-112 producer's own output field). Compiled home added under
+   * § Design 12's total-lowering obligation, same grounds as `recoveryHint`.
+   *
+   * Shape mirrors `RuleCurationSchema` (`spine/rule-record.ts`) for the same
+   * import-graph-leaf reason as `requires.scope` above, and is coupled by test.
+   * The grammar's all-or-none process-trio refinement is a PARSE-stage rule; a
+   * compiled rule only ever carries a record that already satisfied it.
+   */
+  curation: z
+    .object({
+      sourceLesson: z.string(),
+      curatedBy: z.string().optional(),
+      curatedAt: z.string().optional(),
+      baseline5Phase: z.number().int().optional(),
+    })
+    .optional(),
 });
 
 /**

--- a/packages/core/src/compiler.ts
+++ b/packages/core/src/compiler.ts
@@ -11,7 +11,6 @@
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
 
-import safeRegex from 'safe-regex2';
 import { z } from 'zod';
 
 import type {
@@ -20,7 +19,6 @@ import type {
   CompiledRulesFile,
   CompilerOutput,
   NonCompilableEntry,
-  RegexValidation,
 } from './compiler-schema.js';
 import {
   CompiledRulesFileSchema,
@@ -105,23 +103,12 @@ export function hashLesson(heading: string, body: string): string {
 
 // ─── Regex validation ───────────────────────────────
 
-/**
- * Validate that a pattern string is a syntactically valid RegExp
- * and is not vulnerable to ReDoS (catastrophic backtracking).
- */
-export function validateRegex(pattern: string): RegexValidation {
-  try {
-    new RegExp(pattern);
-  } catch {
-    return { valid: false, reason: 'invalid syntax' };
-  }
-
-  if (!safeRegex(pattern)) {
-    return { valid: false, reason: 'ReDoS vulnerability detected' };
-  }
-
-  return { valid: true };
-}
+// Re-exported, not defined here: the rule engine needs this same gate at
+// dispatcher altitude (Prop 310 § Design 8), and `compiler.ts` imports
+// `rule-engine.ts`, so the definition moved to the leaf `regex-validation.ts` to
+// avoid a cycle. Every existing `import { validateRegex } from './compiler.js'`
+// is unchanged, and there is still exactly ONE implementation of the check.
+export { validateRegex } from './regex-validation.js';
 
 // ─── File I/O ───────────────────────────────────────
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1339,6 +1339,7 @@ export {
 } from './spine/record-lower.js';
 export type { RequiresScopeText } from './spine/record-runtime.js';
 export {
+  assertNoTornRecordRules,
   isRecordPathRule,
   RECORD_COMPILED_HOME_KEYS,
   recordScopeMatchesFile,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1329,6 +1329,23 @@ export {
   normalizeReviewChrome,
   REVIEW_CHROME_NORMALIZER_VERSION,
 } from './spine/review-normalize.js';
+// Spine: Prop 310 V1 record grammar — lowering + runtime evaluation (slice 2)
+export type { CompileRuleRecordOptions, RecordLanguageResolution } from './spine/record-lower.js';
+export {
+  compileRuleRecord,
+  languageProbeGlobs,
+  resolveRecordLanguage,
+  V1_INEXPRESSIBLE_NAPI_KEYS,
+} from './spine/record-lower.js';
+export type { RequiresScopeText } from './spine/record-runtime.js';
+export {
+  isRecordPathRule,
+  RECORD_COMPILED_HOME_KEYS,
+  recordScopeMatchesFile,
+  requiresContextPresent,
+  requiresSuppressesMatch,
+  ruleAppliesToFile,
+} from './spine/record-runtime.js';
 // Spine: Prop 310 V1 record grammar — the `.totem/rules/*.rule.yaml` parser (slice 1)
 export type {
   GlobDialectRule,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1338,8 +1338,12 @@ export {
   V1_INEXPRESSIBLE_NAPI_KEYS,
 } from './spine/record-lower.js';
 export type { RequiresScopeText } from './spine/record-runtime.js';
+export type { RuleScopeFields } from './spine/record-runtime.js';
 export {
+  assertNoAstGrepLineScope,
   assertNoTornRecordRules,
+  assertRequiresPatternsSafe,
+  isInsideRoot,
   isRecordPathRule,
   RECORD_COMPILED_HOME_KEYS,
   recordScopeMatchesFile,

--- a/packages/core/src/regex-safety/apply-rules-bounded.ts
+++ b/packages/core/src/regex-safety/apply-rules-bounded.ts
@@ -32,7 +32,11 @@ import {
 } from '../rule-engine.js';
 // Prop 310 slice 2 — the record-grammar runtime semantics, shared with
 // `rule-engine.ts` so both regex dispatchers scope and gate identically.
-import { requiresSuppressesMatch, ruleAppliesToFile } from '../spine/record-runtime.js';
+import {
+  assertNoTornRecordRules,
+  requiresSuppressesMatch,
+  ruleAppliesToFile,
+} from '../spine/record-runtime.js';
 import type { RegexEvaluator } from './evaluator.js';
 import { redactPath } from './telemetry.js';
 
@@ -80,6 +84,9 @@ export async function applyRulesToAdditionsBounded(
   if (additions.length === 0 || rules.length === 0) {
     return { violations, timeoutOutcomes };
   }
+
+  // Prop 310 § Design 12 — torn-manifest guard (see `assertNoTornRecordRules`).
+  assertNoTornRecordRules(rules);
 
   const regexRules = rules.filter((r) => r.engine === 'regex' || !r.engine);
 

--- a/packages/core/src/regex-safety/apply-rules-bounded.ts
+++ b/packages/core/src/regex-safety/apply-rules-bounded.ts
@@ -30,7 +30,9 @@ import {
   isSuppressed,
   type RuleEngineContext,
 } from '../rule-engine.js';
-import { fileMatchesGlobs } from '../sys/glob.js';
+// Prop 310 slice 2 — the record-grammar runtime semantics, shared with
+// `rule-engine.ts` so both regex dispatchers scope and gate identically.
+import { requiresSuppressesMatch, ruleAppliesToFile } from '../spine/record-runtime.js';
 import type { RegexEvaluator } from './evaluator.js';
 import { redactPath } from './telemetry.js';
 
@@ -47,6 +49,17 @@ export interface BoundedApplyOptions {
   evaluator: RegexEvaluator;
   timeoutMode: TimeoutMode;
   repoRoot: string;
+  /**
+   * Prop 310 § Design 8 — whole-file reader for a `requires: {scope: file}`
+   * check. Same shape as the ast path's shipped `readStrategy` 7th parameter, so
+   * `totem lint --staged` threads the SAME `git show :<file>` reader into both
+   * dispatchers and the requirement is evaluated against the bytes being
+   * committed. Omitted ⇒ the worktree file is read.
+   *
+   * Reached only after a record-path rule with a file-scoped requirement has
+   * matched its target, so it adds no IO to the legacy corpus.
+   */
+  readStrategy?: (filePath: string) => Promise<string | null>;
 }
 
 export interface BoundedApplyResult {
@@ -86,15 +99,47 @@ export async function applyRulesToAdditionsBounded(
     }
   };
 
+  // Prop 310 § Design 8 — whole-file text for a `requires: {scope: file}` check,
+  // memoized per invocation. Prefers the caller's `readStrategy` (staged mode's
+  // `git show :<file>`) so the requirement is judged against the same bytes as
+  // the rest of the lint; a read failure yields `null`, which the evaluator
+  // treats as "context absent" and therefore FIRES — the safe direction.
+  const fileTextCache = new Map<string, string | null>();
+  const getFileText = async (file: string): Promise<string | null> => {
+    if (fileTextCache.has(file)) return fileTextCache.get(file) ?? null;
+    let text: string | null = null;
+    if (options.readStrategy) {
+      // DELIBERATELY unwrapped: the caller's reader owns its own failure
+      // contract. Staged mode's reader throws `STAGED_READ_FAILED` precisely so
+      // an unreadable index entry surfaces instead of silently degrading, and a
+      // catch here would convert that loud failure into a quiet one. A reader
+      // that means "absent" returns `null`, which is handled below.
+      text = await options.readStrategy(file);
+    } else {
+      try {
+        text = await fs.promises.readFile(path.resolve(options.repoRoot, file), 'utf-8');
+        // totem-context: read failure yields no required-context evidence → the requirement is UNMET → the rule still FIRES; fails toward flagging, never toward suppression.
+      } catch {
+        text = null;
+      }
+    }
+    fileTextCache.set(file, text);
+    return text;
+  };
+
   for (const rule of regexRules) {
     // Partition additions by file so the evaluator can batch one rule per
     // file at a time. File granularity matches the fileGlobs scoping and
     // keeps timeout isolation per rule-file pair.
     const byFile = new Map<string, DiffAddition[]>();
     for (const addition of additions) {
-      if (rule.fileGlobs && rule.fileGlobs.length > 0) {
-        if (!fileMatchesGlobs(addition.file, rule.fileGlobs)) continue;
-      }
+      // Prop 310 § Design 7 — the two-array scope rule for record-path rules,
+      // the shipped `fileMatchesGlobs` predicate for every legacy rule. This
+      // dispatcher is the one `totem lint` uses for regex rules, so without the
+      // shared predicate a record rule's `excludeGlobs` would be ignored here
+      // and its `*.ts` silently promoted tree-wide — the scope WIDENING the
+      // grammar exists to prevent (falsification round, 2026-08-21).
+      if (!ruleAppliesToFile(rule, addition.file)) continue;
       const bucket = byFile.get(addition.file) ?? [];
       bucket.push(addition);
       byFile.set(addition.file, bucket);
@@ -139,6 +184,19 @@ export async function applyRulesToAdditionsBounded(
       for (const matchedIndex of result.matchedIndices) {
         const addition = fileAdditions[matchedIndex];
         if (!addition) continue;
+
+        // Prop 310 § Design 8 — pass two, ahead of every other per-match check:
+        // the requirement is part of the MATCH PREDICATE, so a locus whose
+        // required context is present is not a match at all and emits neither a
+        // violation nor a `suppress` event. The file text is resolved here rather
+        // than lazily because this dispatcher is async and `requiresSuppressesMatch`
+        // is a pure sync predicate; `line` scope never triggers the read.
+        if (rule.requires !== undefined) {
+          const fileText = rule.requires.scope === 'file' ? await getFileText(file) : null;
+          if (requiresSuppressesMatch(rule, { line: addition.line, file: () => fileText })) {
+            continue;
+          }
+        }
 
         // Exempt matches inside inline Rust test modules for production-only Rust rules
         if (isProductionRustRule(rule)) {

--- a/packages/core/src/regex-safety/apply-rules-bounded.ts
+++ b/packages/core/src/regex-safety/apply-rules-bounded.ts
@@ -34,6 +34,8 @@ import {
 // `rule-engine.ts` so both regex dispatchers scope and gate identically.
 import {
   assertNoTornRecordRules,
+  assertRequiresPatternsSafe,
+  isInsideRoot,
   requiresSuppressesMatch,
   ruleAppliesToFile,
 } from '../spine/record-runtime.js';
@@ -85,8 +87,10 @@ export async function applyRulesToAdditionsBounded(
     return { violations, timeoutOutcomes };
   }
 
-  // Prop 310 § Design 12 — torn-manifest guard (see `assertNoTornRecordRules`).
+  // Prop 310 § Design 12 — torn-manifest guard, and § Design 8's safe-regex2 gate
+  // on every `requires.pattern` before any of them is executed.
   assertNoTornRecordRules(rules);
+  assertRequiresPatternsSafe(rules);
 
   const regexRules = rules.filter((r) => r.engine === 'regex' || !r.engine);
 
@@ -122,7 +126,7 @@ export async function applyRulesToAdditionsBounded(
       // catch here would convert that loud failure into a quiet one. A reader
       // that means "absent" returns `null`, which is handled below.
       text = await options.readStrategy(file);
-    } else {
+    } else if (isInsideRoot(options.repoRoot, file)) {
       try {
         text = await fs.promises.readFile(path.resolve(options.repoRoot, file), 'utf-8');
         // totem-context: read failure yields no required-context evidence → the requirement is UNMET → the rule still FIRES; fails toward flagging, never toward suppression.
@@ -130,6 +134,8 @@ export async function applyRulesToAdditionsBounded(
         text = null;
       }
     }
+    // Out-of-root paths fall through as unreadable ⇒ requirement unmet ⇒ the rule
+    // FIRES. Diff-supplied paths are attacker-shaped; see `isInsideRoot`.
     fileTextCache.set(file, text);
     return text;
   };

--- a/packages/core/src/regex-validation.ts
+++ b/packages/core/src/regex-validation.ts
@@ -1,0 +1,36 @@
+// ─── The safe-regex2 gate, as an import-graph LEAF ───────────────────────────
+//
+// `validateRegex` was defined in `compiler.ts` and is still re-exported from
+// there, so every shipped consumer's import is unchanged. It lives here because
+// `compiler.ts` imports `rule-engine.ts`, and the rule engine now needs this
+// gate at dispatcher altitude (Prop 310 § Design 8's runtime `requires.pattern`
+// check) — importing it back out of `compiler.ts` would close a cycle
+// (`rule-engine` → `spine/record-runtime` → `compiler` → `rule-engine`).
+//
+// This module imports only `safe-regex2` and a type, so it can be pulled from
+// anywhere. Moving the function rather than duplicating the check is the point:
+// the compile gate and the runtime gate MUST be the same predicate, or a pattern
+// the compiler refuses becomes one the runtime happily executes.
+
+import safeRegex from 'safe-regex2';
+
+import type { RegexValidation } from './compiler-schema.js';
+
+/**
+ * Validate that a pattern string is a syntactically valid RegExp
+ * and is not vulnerable to ReDoS (catastrophic backtracking).
+ */
+export function validateRegex(pattern: string): RegexValidation {
+  try {
+    new RegExp(pattern);
+    // totem-context: not a swallow — the failure is REPORTED as this function's return value (`{valid:false}`), which every caller checks and fails loud on. Converting the throw into a checked result is the whole contract; re-throwing would make the gate uncallable as a predicate. Byte-identical to the pre-existing `compiler.ts` implementation this moved from.
+  } catch {
+    return { valid: false, reason: 'invalid syntax' };
+  }
+
+  if (!safeRegex(pattern)) {
+    return { valid: false, reason: 'ReDoS vulnerability detected' };
+  }
+
+  return { valid: true };
+}

--- a/packages/core/src/rule-engine.ts
+++ b/packages/core/src/rule-engine.ts
@@ -560,6 +560,16 @@ function resolveAstMatchSuppression(
  *   on trigger / suppress / failure events.
  * @param workingDirectory - Optional working directory for resolving files on disk
  *   when parsing spans.
+ * @param readFileText - Optional SYNC reader for whole-file content, consulted
+ *   only by a Prop 310 `requires: {scope: file}` check. Returns `null` when the
+ *   file cannot be resolved; when omitted, the disk is read directly.
+ *
+ *   SYNC, unlike the ast path's async `readStrategy`, because this function is
+ *   synchronous and four shipped callers depend on that. The async staged reader
+ *   is threaded instead through `applyRulesToAdditionsBounded`, which is the
+ *   dispatcher `totem lint` actually uses for regex rules and is already async —
+ *   so the staged guarantee lands where staged mode exists (falsification round,
+ *   2026-08-21).
  * @returns All regex-based violations found.
  */
 export function applyRulesToAdditions(
@@ -568,6 +578,7 @@ export function applyRulesToAdditions(
   additions: DiffAddition[],
   onRuleEvent?: RuleEventCallback,
   workingDirectory?: string,
+  readFileText?: (filePath: string) => string | null,
 ): Violation[] {
   if (additions.length === 0 || rules.length === 0) return [];
 
@@ -596,16 +607,30 @@ export function applyRulesToAdditions(
   // Memoized per invocation, and reached ONLY when a record-path rule with a
   // file-scoped requirement has already matched its target: no legacy rule
   // carries `requires`, so this adds zero IO to the shipped path.
+  //
+  // `readFileText` (when supplied) is what makes the check see the SAME bytes the
+  // rest of the lint is judging. Reading the worktree while the caller is judging
+  // the index is FAIL-OPEN in the direction that matters: a required context
+  // deleted in the staged edit but still present on disk would satisfy the
+  // requirement and silence a real staged violation.
   const fileTextCache = new Map<string, string | null>();
   const getFileTextSync = (file: string, workDir: string): string | null => {
     const cached = fileTextCache.get(file);
     if (cached !== undefined || fileTextCache.has(file)) return cached ?? null;
     let text: string | null = null;
-    try {
-      text = fs.readFileSync(path.resolve(workDir, file), 'utf-8');
-      // totem-context: read failure yields no required-context evidence → the requirement is UNMET → the rule still FIRES; like the span exemption above, this fails toward flagging, never toward suppression.
-    } catch {
-      text = null;
+    if (readFileText) {
+      // DELIBERATELY unwrapped: the caller's reader owns its own failure
+      // contract (a staged reader throws so an unreadable index entry surfaces
+      // rather than degrading quietly). A reader that means "absent" returns
+      // `null`, which is handled below.
+      text = readFileText(file);
+    } else {
+      try {
+        text = fs.readFileSync(path.resolve(workDir, file), 'utf-8');
+        // totem-context: read failure yields no required-context evidence → the requirement is UNMET → the rule still FIRES; like the span exemption above, this fails toward flagging, never toward suppression.
+      } catch {
+        text = null;
+      }
     }
     fileTextCache.set(file, text);
     return text;
@@ -761,7 +786,12 @@ export async function applyAstRulesToAdditions(
   // compiled rule carries `requires` — pinned by the byte-identity guard), so
   // this is a fail-loud backstop against a hand-edited manifest, never a path a
   // well-formed pipeline can take.
-  const treeSitterWithRequires = treeSitterRules.find((r) => r.requires !== undefined);
+  // Searched over ALL rules, not over `treeSitterRules` — that list is already
+  // filtered on `astQuery` being present, so a hand-edited `{engine: 'ast',
+  // requires, no astQuery}` rule would slip past the throw and have its
+  // `requires` silently unevaluated, which is precisely the hole this backstop
+  // exists to close (falsification round, 2026-08-21).
+  const treeSitterWithRequires = rules.find((r) => r.engine === 'ast' && r.requires !== undefined);
   if (treeSitterWithRequires) {
     throw new TotemParseError(
       `Rule ${treeSitterWithRequires.lessonHash} (${treeSitterWithRequires.lessonHeading}) carries a \`requires\` block on the tree-sitter ('ast') engine, which has no two-pass evaluator.`,

--- a/packages/core/src/rule-engine.ts
+++ b/packages/core/src/rule-engine.ts
@@ -18,7 +18,10 @@ import { TotemParseError } from './errors.js';
 // scope, § Design 8 `requires` two-pass). Every entry point is gated on
 // `isRecordPathRule`, so the legacy corpus's matching is untouched.
 import {
+  assertNoAstGrepLineScope,
   assertNoTornRecordRules,
+  assertRequiresPatternsSafe,
+  isInsideRoot,
   requiresSuppressesMatch,
   ruleAppliesToFile,
 } from './spine/record-runtime.js';
@@ -588,7 +591,10 @@ export function applyRulesToAdditions(
 
   // Prop 310 § Design 12 — a rule that is neither classifiable as a record nor
   // as legacy is a torn manifest; fail loud rather than drop its constructs.
+  // § Design 8 — and no `requires.pattern` is executed before it clears the same
+  // safe-regex2 gate the compile path applies.
   assertNoTornRecordRules(rules);
+  assertRequiresPatternsSafe(rules);
 
   const violations: Violation[] = [];
 
@@ -632,7 +638,7 @@ export function applyRulesToAdditions(
       // rather than degrading quietly). A reader that means "absent" returns
       // `null`, which is handled below.
       text = readFileText(file);
-    } else {
+    } else if (isInsideRoot(workDir, file)) {
       try {
         text = fs.readFileSync(path.resolve(workDir, file), 'utf-8');
         // totem-context: read failure yields no required-context evidence → the requirement is UNMET → the rule still FIRES; like the span exemption above, this fails toward flagging, never toward suppression.
@@ -640,6 +646,9 @@ export function applyRulesToAdditions(
         text = null;
       }
     }
+    // An out-of-root path falls through with `text === null` — treated as
+    // unreadable, so the requirement is unmet and the rule FIRES. Same direction
+    // as a read failure; see `isInsideRoot`.
     fileTextCache.set(file, text);
     return text;
   };
@@ -776,9 +785,12 @@ export async function applyAstRulesToAdditions(
   onWarn?: (msg: string) => void,
   readStrategy?: (filePath: string) => Promise<string | null>,
 ): Promise<Violation[]> {
-  // Prop 310 § Design 12 — torn-manifest guard, same altitude as the tree-sitter
-  // `requires` backstop below.
+  // Prop 310 § Design 12 / § Design 8 — torn-manifest guard, the safe-regex2
+  // gate, and the ast-grep span-vs-line backstop, all at the same altitude as the
+  // tree-sitter `requires` backstop below.
   assertNoTornRecordRules(rules);
+  assertRequiresPatternsSafe(rules);
+  assertNoAstGrepLineScope(rules);
 
   const treeSitterRules = rules.filter((r) => r.engine === 'ast' && r.astQuery);
   // Widen to include compound rules (mmnto/totem#1408). A rule is runnable

--- a/packages/core/src/rule-engine.ts
+++ b/packages/core/src/rule-engine.ts
@@ -17,7 +17,11 @@ import { TotemParseError } from './errors.js';
 // Prop 310 slice 2 — the record-grammar runtime semantics (§ Design 7 two-array
 // scope, § Design 8 `requires` two-pass). Every entry point is gated on
 // `isRecordPathRule`, so the legacy corpus's matching is untouched.
-import { requiresSuppressesMatch, ruleAppliesToFile } from './spine/record-runtime.js';
+import {
+  assertNoTornRecordRules,
+  requiresSuppressesMatch,
+  ruleAppliesToFile,
+} from './spine/record-runtime.js';
 import { detectStaleManifest, staleManifestError } from './stale-manifest.js';
 import { fileMatchesGlobs, matchesGlob } from './sys/glob.js';
 
@@ -582,6 +586,10 @@ export function applyRulesToAdditions(
 ): Violation[] {
   if (additions.length === 0 || rules.length === 0) return [];
 
+  // Prop 310 § Design 12 — a rule that is neither classifiable as a record nor
+  // as legacy is a torn manifest; fail loud rather than drop its constructs.
+  assertNoTornRecordRules(rules);
+
   const violations: Violation[] = [];
 
   // Only process regex-engine rules — AST rules have pattern: '' which would match everything
@@ -768,6 +776,10 @@ export async function applyAstRulesToAdditions(
   onWarn?: (msg: string) => void,
   readStrategy?: (filePath: string) => Promise<string | null>,
 ): Promise<Violation[]> {
+  // Prop 310 § Design 12 — torn-manifest guard, same altitude as the tree-sitter
+  // `requires` backstop below.
+  assertNoTornRecordRules(rules);
+
   const treeSitterRules = rules.filter((r) => r.engine === 'ast' && r.astQuery);
   // Widen to include compound rules (mmnto/totem#1408). A rule is runnable
   // when EITHER `astGrepPattern` (string) or `astGrepYamlRule` (NapiConfig

--- a/packages/core/src/rule-engine.ts
+++ b/packages/core/src/rule-engine.ts
@@ -14,6 +14,10 @@ import type {
 } from './compiler-schema.js';
 import { extractAddedLines } from './diff-parser.js';
 import { TotemParseError } from './errors.js';
+// Prop 310 slice 2 — the record-grammar runtime semantics (§ Design 7 two-array
+// scope, § Design 8 `requires` two-pass). Every entry point is gated on
+// `isRecordPathRule`, so the legacy corpus's matching is untouched.
+import { requiresSuppressesMatch, ruleAppliesToFile } from './spine/record-runtime.js';
 import { detectStaleManifest, staleManifestError } from './stale-manifest.js';
 import { fileMatchesGlobs, matchesGlob } from './sys/glob.js';
 
@@ -588,6 +592,25 @@ export function applyRulesToAdditions(
     }
   };
 
+  // Prop 310 § Design 8 — whole-file text for a `requires: {scope: file}` check.
+  // Memoized per invocation, and reached ONLY when a record-path rule with a
+  // file-scoped requirement has already matched its target: no legacy rule
+  // carries `requires`, so this adds zero IO to the shipped path.
+  const fileTextCache = new Map<string, string | null>();
+  const getFileTextSync = (file: string, workDir: string): string | null => {
+    const cached = fileTextCache.get(file);
+    if (cached !== undefined || fileTextCache.has(file)) return cached ?? null;
+    let text: string | null = null;
+    try {
+      text = fs.readFileSync(path.resolve(workDir, file), 'utf-8');
+      // totem-context: read failure yields no required-context evidence → the requirement is UNMET → the rule still FIRES; like the span exemption above, this fails toward flagging, never toward suppression.
+    } catch {
+      text = null;
+    }
+    fileTextCache.set(file, text);
+    return text;
+  };
+
   for (const rule of regexRules) {
     let re: RegExp;
     try {
@@ -609,9 +632,27 @@ export function applyRulesToAdditions(
     }
 
     for (const addition of additions) {
-      // Skip if rule has fileGlobs and this file doesn't match
-      if (rule.fileGlobs && rule.fileGlobs.length > 0) {
-        if (!fileMatchesGlobs(addition.file, rule.fileGlobs)) continue;
+      // Scope: Prop 310 § Design 7's two-array rule for record-path rules
+      // (`positiveMatch && !excludeMatch` under the normative dialect), the
+      // shipped `fileMatchesGlobs` predicate — including its unscoped-rule
+      // include-everything behaviour — for every legacy rule.
+      if (!ruleAppliesToFile(rule, addition.file)) continue;
+
+      // Prop 310 § Design 8 — pass two. The requirement is part of the MATCH
+      // PREDICATE (the rule fires iff the target matched AND the required
+      // context is absent), so it is evaluated BEFORE suppression and before any
+      // telemetry: a locus whose required context is PRESENT is not a match at
+      // all, and must emit neither a violation nor a `suppress` event. Guarded on
+      // `rule.requires` so no legacy rule pays the second `re.test`.
+      if (
+        rule.requires !== undefined &&
+        re.test(addition.line) &&
+        requiresSuppressesMatch(rule, {
+          line: addition.line,
+          file: () => getFileTextSync(addition.file, workingDirectory || process.cwd()),
+        })
+      ) {
+        continue;
       }
 
       // Skip if suppressed via inline directive
@@ -711,6 +752,23 @@ export async function applyAstRulesToAdditions(
   const astGrepRules = rules.filter(
     (r) => r.engine === 'ast-grep' && (r.astGrepPattern || r.astGrepYamlRule),
   );
+
+  // Prop 310 § Design 8 / § Design 12 — `requires` has no evaluator on the
+  // tree-sitter branch, and leaving it unevaluated would be exactly the
+  // accept-then-silently-drop class § Design 12 bans. UNREACHABLE from the record
+  // path by construction (the V1 authoring enum is `ast-grep | regex`; `ast` is
+  // dropped per § Design 6/R16) and unreachable from the legacy corpus (no
+  // compiled rule carries `requires` — pinned by the byte-identity guard), so
+  // this is a fail-loud backstop against a hand-edited manifest, never a path a
+  // well-formed pipeline can take.
+  const treeSitterWithRequires = treeSitterRules.find((r) => r.requires !== undefined);
+  if (treeSitterWithRequires) {
+    throw new TotemParseError(
+      `Rule ${treeSitterWithRequires.lessonHash} (${treeSitterWithRequires.lessonHeading}) carries a \`requires\` block on the tree-sitter ('ast') engine, which has no two-pass evaluator.`,
+      "Prop 310 § Design 6 drops 'ast' from the V1 authoring surface, so no rule record can produce this combination — the manifest was hand-edited or written by a bypassed producer. Re-compile the rule, or move it to the 'regex' or 'ast-grep' engine where `requires` is evaluated.",
+    );
+  }
+
   if ((treeSitterRules.length === 0 && astGrepRules.length === 0) || additions.length === 0) {
     return [];
   }
@@ -746,8 +804,14 @@ export async function applyAstRulesToAdditions(
     // mechanism for adding language support.
     const ext = path.extname(file);
     if (!extensionToLanguage(ext)) {
+      // The `fileGlobs.length > 0` prefix is load-bearing and NOT folded into
+      // `ruleAppliesToFile`: an UNSCOPED rule must not trigger this fail-loud
+      // guard (no rule cares about the file ⇒ a silent skip is correct), while
+      // `ruleAppliesToFile` answers "does this rule apply", for which an unscoped
+      // rule applies everywhere. Record-path rules always carry ≥1 glob (min-1 at
+      // parse), so the prefix never excludes one.
       const ruleExpectingThisFile = allAstRules.find(
-        (r) => r.fileGlobs && r.fileGlobs.length > 0 && fileMatchesGlobs(file, r.fileGlobs),
+        (r) => r.fileGlobs && r.fileGlobs.length > 0 && ruleAppliesToFile(r, file),
       );
       if (ruleExpectingThisFile) {
         // mmnto-ai/totem#1811 (ADR-101): before re-throwing the raw
@@ -789,12 +853,7 @@ export async function applyAstRulesToAdditions(
 
     // ── Tree-sitter S-expression rules ────────────────
     if (treeSitterRules.length > 0) {
-      const applicableTreeSitter = treeSitterRules.filter((rule) => {
-        if (rule.fileGlobs && rule.fileGlobs.length > 0) {
-          return fileMatchesGlobs(file, rule.fileGlobs);
-        }
-        return true;
-      });
+      const applicableTreeSitter = treeSitterRules.filter((rule) => ruleAppliesToFile(rule, file));
 
       if (applicableTreeSitter.length > 0) {
         // Path containment check — prevent traversal outside the project.
@@ -898,12 +957,7 @@ export async function applyAstRulesToAdditions(
 
     // ── ast-grep structural pattern rules ─────────────
     if (astGrepRules.length > 0) {
-      const applicableAstGrep = astGrepRules.filter((rule) => {
-        if (rule.fileGlobs && rule.fileGlobs.length > 0) {
-          return fileMatchesGlobs(file, rule.fileGlobs);
-        }
-        return true;
-      });
+      const applicableAstGrep = astGrepRules.filter((rule) => ruleAppliesToFile(rule, file));
 
       if (applicableAstGrep.length > 0) {
         // Read file content once for all ast-grep rules on this file
@@ -929,6 +983,9 @@ export async function applyAstRulesToAdditions(
           // Fall through — content stays null for standard file read failures
         }
         if (content) {
+          // Bound once so the § Design 8 `file`-scope resolver below closes over a
+          // narrowed `string` rather than the outer `string | null` binding.
+          const fileText = content;
           // Batch: parse file once, run all patterns.
           // Each rule carries either astGrepPattern (string) or astGrepYamlRule
           // (NapiConfig object); the batch helper polymorphically dispatches on
@@ -961,6 +1018,21 @@ export async function applyAstRulesToAdditions(
             const matches = batchResults[i] ?? [];
 
             for (const match of matches) {
+              // Prop 310 § Design 8 — pass two, ahead of every other per-match
+              // check for the same reason as the regex path: a locus whose
+              // required context is PRESENT is not a match, so it emits neither a
+              // violation nor a `suppress` event. The requirement is a REGEX
+              // evaluated textually even here — § Design 8 makes it independent of
+              // the target engine ("a context check, not a second matcher").
+              if (
+                requiresSuppressesMatch(rule, {
+                  line: match.lineText,
+                  file: () => fileText,
+                })
+              ) {
+                continue;
+              }
+
               // Exempt matches inside inline Rust test modules (#2397).
               if (
                 isProductionRustRule(rule) &&

--- a/packages/core/src/spine/record-exemplars.fixture.ts
+++ b/packages/core/src/spine/record-exemplars.fixture.ts
@@ -1,0 +1,62 @@
+// ─── Prop 310's two spec exemplars, transcribed ONCE ─────────────────────────
+//
+// § Design 4's coherent record and § Design 8's `requires:` record are the
+// spec's own worked examples, and § Design 14's normativity flip makes them
+// normative: an implementation that cannot round-trip them is the bug. Both the
+// lowering suite and the runtime suite exercise them, so they are single-homed
+// here rather than transcribed twice (Tenet 20 — two hand-maintained copies of a
+// normative fixture is how one silently drifts from the spec).
+//
+// NOT a test file (`*.fixture.ts` is outside vitest's `src/**\/*.test.ts`
+// include) and deliberately NOT barrel-exported: this is conformance material,
+// not public API. It is a plain module rather than a test-file export so that
+// importing it cannot re-register another suite's `describe` blocks.
+//
+// Comments are stripped and YAML block scalars are resolved to their parsed
+// values, since these are the PARSED shapes; slice 1's suite carries the same
+// two records in their literal YAML form.
+
+/** Prop 310 § Design 4's exemplar — a compound ast-grep record with every optional block. */
+export function design4ExemplarRecord(): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    severity: 'error',
+    message: 'Catch blocks must re-throw or route the error — fail-open catch is banned.',
+    recoveryHint: 'Re-throw after logging, or route to the error channel.',
+    target: {
+      type: 'ast-grep',
+      language: 'typescript',
+      rule: { kind: 'catch_clause', not: { has: { kind: 'throw_statement', stopBy: 'end' } } },
+      scope: { fileGlobs: ['packages/**/*.ts'], excludeGlobs: ['**/*.test.ts'] },
+    },
+    examples: [
+      {
+        bad: 'try { risky() } catch (e) { log(e) }',
+        good: 'try { risky() } catch (e) { log(e); throw e }',
+      },
+    ],
+    curation: {
+      sourceLesson: 'lesson-77c5e668389fb1a2',
+      curatedBy: 'strategy-gemini',
+      curatedAt: '2026-06-15T14:00:00Z',
+      baseline5Phase: 3,
+    },
+    verification_shadow: { type: 'rego', source: 'package totem.rules.example\n' },
+  };
+}
+
+/** Prop 310 § Design 8's exemplar — the absence / must-contain shape (the census's rule (c)). */
+export function design8ExemplarRecord(): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    severity: 'warning',
+    message: 'git output-consuming commands must pin LC_ALL=C on the same line.',
+    target: {
+      type: 'regex',
+      pattern: '\\bgit\\s+(log|diff|status)\\b',
+      scope: { fileGlobs: ['**/*.sh', '**/*.cjs'] },
+    },
+    requires: { pattern: 'LC_ALL=C', scope: 'line' },
+    examples: [{ bad: 'git log --oneline', good: 'LC_ALL=C git log --oneline' }],
+  };
+}

--- a/packages/core/src/spine/record-lower.test.ts
+++ b/packages/core/src/spine/record-lower.test.ts
@@ -17,7 +17,7 @@ import { stringify as yamlStringify } from 'yaml';
 import { extensionToLanguage } from '../ast-classifier.js';
 import { extensionToLang, resolveAstGrepLangs } from '../ast-grep-query.js';
 import { canonicalStringify } from '../compile-manifest.js';
-import { sanitizeFileGlobs } from '../compiler.js';
+import { fileMatchesGlobs, sanitizeFileGlobs } from '../compiler.js';
 import { CompiledRuleSchema, CompiledRulesFileSchema } from '../compiler-schema.js';
 import { design4ExemplarRecord, design8ExemplarRecord } from './record-exemplars.fixture.js';
 import {
@@ -26,7 +26,11 @@ import {
   resolveRecordLanguage,
   V1_INEXPRESSIBLE_NAPI_KEYS,
 } from './record-lower.js';
-import { isRecordPathRule, RECORD_COMPILED_HOME_KEYS } from './record-runtime.js';
+import {
+  isRecordPathRule,
+  RECORD_COMPILED_HOME_KEYS,
+  ruleAppliesToFile,
+} from './record-runtime.js';
 import {
   type ParsedRuleRecord,
   parseRuleRecord,
@@ -162,6 +166,38 @@ describe('CompiledRuleSchema additions — the § Design 12 compiled homes', () 
     ).toBe(true);
     // And every rule this slice lowers carries it.
     expect(isRecordPathRule(lowerOk(regexRecord()))).toBe(true);
+  });
+
+  it('CORPUS SWEEP: every legacy rule scopes IDENTICALLY under the shared predicate', () => {
+    // The reviewer's sweep, promoted to a standing test. `ruleAppliesToFile` is
+    // now the single scope predicate for both lint dispatchers, Stage 4, and the
+    // wind tunnel, so "legacy behaviour is byte-identical" has to be a measured
+    // property of the whole shipped corpus, not a claim about one code path.
+    const compiled = CompiledRulesFileSchema.parse(rawManifest).rules;
+    const paths = [
+      'a.ts',
+      'src/a.ts',
+      'packages/core/src/a.ts',
+      'packages/core/src/a.test.ts',
+      'scripts/x.sh',
+      'deep/nest/mod.rs',
+      'README.md',
+      'src/a.tsx',
+      '.github/workflows/ci.yml',
+      'packages/cli/src/index.cjs',
+    ];
+    let compared = 0;
+    for (const rule of compiled) {
+      for (const filePath of paths) {
+        const shipped =
+          rule.fileGlobs && rule.fileGlobs.length > 0
+            ? fileMatchesGlobs(filePath, rule.fileGlobs)
+            : true;
+        expect(ruleAppliesToFile(rule, filePath)).toBe(shipped);
+        compared += 1;
+      }
+    }
+    expect(compared).toBe(compiled.length * paths.length);
   });
 
   it('accepts a rule carrying NONE of the additions (every one is optional)', () => {

--- a/packages/core/src/spine/record-lower.test.ts
+++ b/packages/core/src/spine/record-lower.test.ts
@@ -40,6 +40,14 @@ import {
 } from './rule-record.js';
 
 const FILE = '.totem/rules/fail-open-catch.rule.yaml';
+/**
+ * The size of the shipped legacy corpus. A CONSTANT, not a floor, because the
+ * `rule-compilation` freeze means nothing regenerates `.totem/compiled-rules.json`
+ * — so this number cannot drift while the freeze stands. When the freeze lifts and
+ * the corpus is regenerated or migrated, this updates ONCE, deliberately, and the
+ * update is the signal that the corpus moved.
+ */
+const SHIPPED_RULE_COUNT = 485;
 /** A well-formed ADR-112 §8 minted id (16 lowercase hex, no collision suffix). */
 const RULE_ID = '0123456789abcdef';
 const NOW = '2026-08-21T00:00:00.000Z';
@@ -112,6 +120,14 @@ describe('CompiledRuleSchema additions — the § Design 12 compiled homes', () 
     rules: Record<string, unknown>[];
   };
 
+  it('reads a NON-EMPTY corpus at the expected size (the floor the sweeps stand on)', () => {
+    // Without this, every assertion below is self-referentially vacuous: an empty
+    // or truncated `rules` array satisfies "all rules re-validate", "no rule
+    // carries a record field", and "every rule scopes identically" trivially, and
+    // the suite would go green on a corpus that had silently disappeared.
+    expect(rawManifest.rules.length).toBe(SHIPPED_RULE_COUNT);
+  });
+
   it('re-validates the shipped 485-rule manifest BYTE-IDENTICALLY under the extended schema', () => {
     // The freeze-compatibility proof (Amendment R11 / § Data model deltas): the
     // additions are optional, so the frozen corpus parses unchanged — and
@@ -119,7 +135,7 @@ describe('CompiledRuleSchema additions — the § Design 12 compiled homes', () 
     // which is the identity that actually matters to `verify-manifest`. A
     // required addition, or one that introduced a default, would move every hash.
     const parsed = CompiledRulesFileSchema.parse(rawManifest);
-    expect(parsed.rules.length).toBe(rawManifest.rules.length);
+    expect(parsed.rules.length).toBe(SHIPPED_RULE_COUNT);
     expect(canonicalStringify(parsed.rules)).toBe(canonicalStringify(rawManifest.rules));
   });
 
@@ -128,6 +144,7 @@ describe('CompiledRuleSchema additions — the § Design 12 compiled homes', () 
     // is what makes "legacy rules keep their matching behaviour byte-for-byte" a
     // fact rather than an intention. If a future writer ever puts one of these
     // fields on a mined rule, this fails before the matcher silently changes.
+    expect(rawManifest.rules.length).toBe(SHIPPED_RULE_COUNT);
     const carriers = rawManifest.rules.filter((rule) =>
       RECORD_COMPILED_HOME_KEYS.some((key) => rule[key] !== undefined),
     );
@@ -174,6 +191,7 @@ describe('CompiledRuleSchema additions — the § Design 12 compiled homes', () 
     // wind tunnel, so "legacy behaviour is byte-identical" has to be a measured
     // property of the whole shipped corpus, not a claim about one code path.
     const compiled = CompiledRulesFileSchema.parse(rawManifest).rules;
+    expect(compiled.length).toBe(SHIPPED_RULE_COUNT);
     const paths = [
       'a.ts',
       'src/a.ts',
@@ -249,7 +267,7 @@ describe('CompiledRuleSchema additions — the § Design 12 compiled homes', () 
 
   it('couples the compiled `examples` and `curation` shapes to the grammar’s schemas', () => {
     expect(Object.keys(RuleRecordExampleSchema.shape).sort()).toEqual(['bad', 'good']);
-    expect(Object.keys(RuleCurationSchema._def.schema.shape).sort()).toEqual([
+    expect(Object.keys(RuleCurationSchema.innerType().shape).sort()).toEqual([
       'baseline5Phase',
       'curatedAt',
       'curatedBy',

--- a/packages/core/src/spine/record-lower.test.ts
+++ b/packages/core/src/spine/record-lower.test.ts
@@ -14,6 +14,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { stringify as yamlStringify } from 'yaml';
 
+import { extensionToLanguage } from '../ast-classifier.js';
 import { extensionToLang, resolveAstGrepLangs } from '../ast-grep-query.js';
 import { canonicalStringify } from '../compile-manifest.js';
 import { sanitizeFileGlobs } from '../compiler.js';
@@ -129,6 +130,38 @@ describe('CompiledRuleSchema additions — the § Design 12 compiled homes', () 
     expect(carriers).toEqual([]);
     const compiled = CompiledRulesFileSchema.parse(rawManifest).rules;
     expect(compiled.filter(isRecordPathRule)).toEqual([]);
+  });
+
+  it('keys the record path on `examples` ALONE — a cosmetic field never flips a matcher', () => {
+    // `examples` is the EXACT discriminator: § Design 5 makes it non-omittable
+    // and the lowering emits it unconditionally. A wider "any compiled home"
+    // test would let a legacy-shaped rule that merely gained a `recoveryHint`
+    // silently switch matchers — flipping the same `*.ts` glob from the shipped
+    // tree-wide reading to the record dialect's root-only one.
+    const base = {
+      lessonHash: 'fedcba9876543210',
+      lessonHeading: 'legacy',
+      pattern: 'x',
+      message: 'm',
+      engine: 'regex' as const,
+      compiledAt: NOW,
+      fileGlobs: ['*.ts'],
+    };
+    expect(isRecordPathRule(CompiledRuleSchema.parse(base))).toBe(false);
+    expect(
+      isRecordPathRule(CompiledRuleSchema.parse({ ...base, recoveryHint: 'try harder' })),
+    ).toBe(false);
+    expect(
+      isRecordPathRule(
+        CompiledRuleSchema.parse({ ...base, verificationShadow: { type: 'rego', source: 'p' } }),
+      ),
+    ).toBe(false);
+    // The deliberate contract: `examples` present ⇒ record path.
+    expect(
+      isRecordPathRule(CompiledRuleSchema.parse({ ...base, examples: [{ bad: 'b', good: 'g' }] })),
+    ).toBe(true);
+    // And every rule this slice lowers carries it.
+    expect(isRecordPathRule(lowerOk(regexRecord()))).toBe(true);
   });
 
   it('accepts a rule carrying NONE of the additions (every one is optional)', () => {
@@ -262,25 +295,98 @@ describe('§ Design 6 — the declared language resolves against the registry', 
     }
   });
 
-  it('validates under the DECLARED language, not the glob-derived one (the “moves” row)', () => {
+  it('validates under the DECLARED language, not a permissive fallback (the “moves” row)', () => {
     // `type_alias_declaration` exists in the TypeScript/TSX grammars and not in
-    // JavaScript. The shipped try-each-glob-derived-Lang validator would resolve
-    // TypeScript from `**/*.ts` and ACCEPT this payload; the record path resolves
-    // ONLY the declared `javascript` and must reject it. This is the
-    // mmnto-ai/totem#1654 cross-grammar acceptance being retired on this path.
-    const record = astGrepRecord();
-    const target = record.target as Record<string, unknown>;
-    target.rule = { kind: 'type_alias_declaration' };
-    target.scope = { fileGlobs: ['**/*.ts'] };
+    // JavaScript. The shipped validator falls back to `Lang.Tsx` — its most
+    // permissive parser — whenever a glob carries no registered extension, and
+    // accepts a pattern under ANY resolved Lang; the record path resolves ONLY
+    // the declared language and validates under exactly it. Since the language⇄
+    // glob floor now requires the scope to agree with the declaration, the globs
+    // co-vary — but they never reach the validator, which sees only the
+    // language-derived probe.
+    const typescript = astGrepRecord();
+    const tsTarget = typescript.target as Record<string, unknown>;
+    tsTarget.rule = { kind: 'type_alias_declaration' };
+    tsTarget.scope = { fileGlobs: ['**/*.ts'] };
+    expect(lower(typescript).kind).toBe('compiled');
 
-    target.language = 'typescript';
-    expect(lower(record).kind).toBe('compiled');
-
-    target.language = 'javascript';
-    const reason = lowerRejected(record);
-    expect(reason).toContain('§ Design 6');
+    const javascript = astGrepRecord();
+    const jsTarget = javascript.target as Record<string, unknown>;
+    jsTarget.language = 'javascript';
+    jsTarget.rule = { kind: 'type_alias_declaration' };
+    jsTarget.scope = { fileGlobs: ['**/*.js'] };
+    const reason = lowerRejected(javascript);
+    // The PAYLOAD gate rejected it — not the consistency floor. That distinction
+    // is what makes this a language-pinning test rather than a scope test.
+    expect(reason).toContain('target.rule failed ast-grep validation');
     expect(reason).toContain("declared language 'javascript'");
     expect(reason).toContain('try-each-glob-derived-Lang');
+  });
+});
+
+// ─── § Design 6 — the language⇄glob consistency floor ────────────────────────
+
+describe('§ Design 6 — an ast-grep scope must agree with its declared language', () => {
+  function astGrepScoped(language: string, fileGlobs: string[], excludeGlobs?: string[]) {
+    const record = astGrepRecord();
+    const target = record.target as Record<string, unknown>;
+    target.language = language;
+    target.scope = { fileGlobs, ...(excludeGlobs ? { excludeGlobs } : {}) };
+    return record;
+  }
+
+  it('rejects a scope whose extension resolves to a DIFFERENT language', () => {
+    // The demonstrated gap: this lowered clean before the floor, and the runtime
+    // — which dispatches ast-grep by file extension — would then evaluate a
+    // TypeScript-validated payload under the JavaScript grammar.
+    const reason = lowerRejected(astGrepScoped('typescript', ['**/*.js']));
+    expect(reason).toContain('§ Design 6');
+    expect(reason).toContain("targets language 'javascript'");
+    expect(reason).toContain("declares 'typescript'");
+    expect(reason).toContain('N records');
+  });
+
+  it('rejects `.tsx` under `language: typescript` — the registry says they are different grammars', () => {
+    // `extensionToLanguage('.tsx')` is `'tsx'`, a distinct SupportedLanguage with
+    // its own WASM loader and its own napi `Lang`. Admitting it under
+    // `typescript` would reopen exactly the gap this floor closes, so the
+    // mechanical rule governs: a `.tsx` scope declares `language: tsx`.
+    expect(extensionToLanguage('.tsx')).toBe('tsx');
+    const reason = lowerRejected(astGrepScoped('typescript', ['**/*.ts', '**/*.tsx']));
+    expect(reason).toContain("targets language 'tsx'");
+    expect(lower(astGrepScoped('tsx', ['**/*.tsx', '**/*.jsx'])).kind).toBe('compiled');
+  });
+
+  it('accepts MULTIPLE globs that all resolve to the declared language', () => {
+    expect(
+      lower(astGrepScoped('typescript', ['**/*.ts', '**/*.mts', 'packages/**/*.cts'])).kind,
+    ).toBe('compiled');
+  });
+
+  it('rejects an EXTENSION-LESS glob on an ast-grep target', () => {
+    const reason = lowerRejected(astGrepScoped('typescript', ['packages/**']));
+    expect(reason).toContain('carries no file extension');
+    expect(reason).toContain('§ Design 6');
+  });
+
+  it('rejects an UNREGISTERED extension it cannot confirm', () => {
+    const reason = lowerRejected(astGrepScoped('typescript', ['**/*.rs']));
+    expect(reason).toContain("extension '.rs', which is not registered");
+  });
+
+  it('EXEMPTS excludeGlobs — an exclusion only ever narrows', () => {
+    const outcome = lower(
+      astGrepScoped('typescript', ['packages/**/*.ts'], ['**/*.test.js', 'vendor/**']),
+    );
+    expect(outcome.kind).toBe('compiled');
+  });
+
+  it('leaves REGEX targets unchecked — a regex payload has no grammar binding', () => {
+    const record = regexRecord();
+    (record.target as Record<string, unknown>).scope = {
+      fileGlobs: ['**/*.js', 'packages/**', '**/*.rs'],
+    };
+    expect(lower(record).kind).toBe('compiled');
   });
 });
 
@@ -304,6 +410,32 @@ describe('§ Design 12 — a construct that cannot lower fails compile LOUD', ()
     });
     expect(reason).toContain('§ Design 8');
     expect(reason).toContain('independent of target.type');
+  });
+
+  it('rejects `requires.scope: line` on an ast-grep target (span-vs-line ruling)', () => {
+    // An ast-grep match is a SPAN. Reading it as its start line makes the verdict
+    // depend on how the author wrapped the source, and § Design 8 reserves
+    // `block` — the span's natural unit — as unimplemented, so V1 rejects rather
+    // than shipping a formatting-dependent semantic.
+    const reason = lowerRejected({
+      ...astGrepRecord(),
+      requires: { pattern: 'LC_ALL=C', scope: 'line' },
+    });
+    expect(reason).toContain('§ Design 8');
+    expect(reason).toContain('an ast-grep match is a SPAN');
+    expect(reason).toContain('`block`');
+  });
+
+  it('keeps `line` valid on regex and `file` valid on BOTH engines', () => {
+    expect(lower({ ...regexRecord(), requires: { pattern: 'x', scope: 'line' } }).kind).toBe(
+      'compiled',
+    );
+    expect(lower({ ...regexRecord(), requires: { pattern: 'x', scope: 'file' } }).kind).toBe(
+      'compiled',
+    );
+    expect(lower({ ...astGrepRecord(), requires: { pattern: 'x', scope: 'file' } }).kind).toBe(
+      'compiled',
+    );
   });
 
   it('rejects an unresolvable `language`', () => {
@@ -361,10 +493,13 @@ describe('§ Design 12 — a construct that cannot lower fails compile LOUD', ()
     );
   });
 
-  it('THROWS on an engine-binding divergence (the assert is NOT tautological)', () => {
-    // § Design 3: the two sides originate differently — the record's `target.type`
-    // and the payload's actual compilation path. Tamper with one and the assert
-    // must still fire, which is exactly what makes the derivation safe.
+  it('THROWS on an engine-binding divergence — the tamper guard fires (defence in depth)', () => {
+    // Honest scope, per the falsification round: this divergence is UNREACHABLE
+    // from any parse-valid record, because slice 1's `RuleTargetSchema` already
+    // kills the payload/type mismatch class at parse (pattern XOR rule, per
+    // type). The assert is therefore defence in depth against a future lowering
+    // edit or a hand-built `ParsedRuleRecord`, NOT a live § Design 3 gate — and
+    // what this test demonstrates is that the guard fires on tampered input.
     const parsed = parseRuleRecord(yamlStringify(regexRecord()), FILE);
     const tampered = { ...parsed, derivedEngine: 'ast-grep' } as unknown as ParsedRuleRecord;
     expect(() => compileRuleRecord(tampered, { ruleId: RULE_ID, now: NOW })).toThrow(

--- a/packages/core/src/spine/record-lower.test.ts
+++ b/packages/core/src/spine/record-lower.test.ts
@@ -1,0 +1,478 @@
+// ─── Prop 310 § Design 14 — conformance suite, slice 2: LOWERING ─────────────
+//
+// Slice 1's suite pins what the parser ADMITS; this one pins what lowering DOES
+// with what was admitted. The § Design 12 obligation under test is total
+// lowering: "every construct the parser admits either lands on the compiled
+// record or fails compile LOUD — no construct is accepted at parse and dropped at
+// compile." Each cannot-lower construct class gets a negative fixture, each
+// verbatim carry gets a positive one, and the freeze boundary gets a guard that
+// fails the moment the record path starts sanitizing (or the legacy path stops).
+
+import * as fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+import { stringify as yamlStringify } from 'yaml';
+
+import { extensionToLang, resolveAstGrepLangs } from '../ast-grep-query.js';
+import { canonicalStringify } from '../compile-manifest.js';
+import { sanitizeFileGlobs } from '../compiler.js';
+import { CompiledRuleSchema, CompiledRulesFileSchema } from '../compiler-schema.js';
+import { design4ExemplarRecord, design8ExemplarRecord } from './record-exemplars.fixture.js';
+import {
+  compileRuleRecord,
+  languageProbeGlobs,
+  resolveRecordLanguage,
+  V1_INEXPRESSIBLE_NAPI_KEYS,
+} from './record-lower.js';
+import { isRecordPathRule, RECORD_COMPILED_HOME_KEYS } from './record-runtime.js';
+import {
+  type ParsedRuleRecord,
+  parseRuleRecord,
+  RequiresScopeSchema,
+  RuleCurationSchema,
+  RuleRecordExampleSchema,
+} from './rule-record.js';
+
+const FILE = '.totem/rules/fail-open-catch.rule.yaml';
+/** A well-formed ADR-112 §8 minted id (16 lowercase hex, no collision suffix). */
+const RULE_ID = '0123456789abcdef';
+const NOW = '2026-08-21T00:00:00.000Z';
+
+function lower(record: Record<string, unknown>, ruleId = RULE_ID) {
+  const parsed = parseRuleRecord(yamlStringify(record), FILE);
+  return compileRuleRecord(parsed, { ruleId, now: NOW });
+}
+
+/** Lower and assert success, returning the compiled rule (a rejection fails loudly, with its reason). */
+function lowerOk(record: Record<string, unknown>, ruleId = RULE_ID) {
+  const outcome = lower(record, ruleId);
+  if (outcome.kind !== 'compiled') {
+    throw new Error(`expected a compiled outcome, got rejected: ${outcome.reason}`);
+  }
+  return outcome.rule;
+}
+
+/** Lower and assert rejection, returning the reason (a compile fails loudly). */
+function lowerRejected(record: Record<string, unknown>): string {
+  const outcome = lower(record);
+  if (outcome.kind !== 'rejected') {
+    throw new Error('expected a rejected outcome, got a compiled rule');
+  }
+  return outcome.reason;
+}
+
+/** A minimal dialect-clean ast-grep record (compound tree payload). */
+function astGrepRecord(): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    severity: 'error',
+    message: 'Catch blocks must re-throw or route the error.',
+    target: {
+      type: 'ast-grep',
+      language: 'typescript',
+      rule: { kind: 'catch_clause' },
+      scope: { fileGlobs: ['packages/**/*.ts'] },
+    },
+    examples: [
+      {
+        bad: 'try { risky() } catch (e) { log(e) }',
+        good: 'try { risky() } catch (e) { throw e }',
+      },
+    ],
+  };
+}
+
+/** A minimal dialect-clean regex record. */
+function regexRecord(): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    severity: 'warning',
+    message: 'git output-consuming commands must pin LC_ALL=C on the same line.',
+    target: {
+      type: 'regex',
+      pattern: '\\bgit\\s+(log|diff|status)\\b',
+      scope: { fileGlobs: ['**/*.sh'] },
+    },
+    examples: [{ bad: 'git log --oneline', good: 'LC_ALL=C git log --oneline' }],
+  };
+}
+
+// ─── A. The compiled homes (§ Design 12) + mined-path byte identity ──────────
+
+describe('CompiledRuleSchema additions — the § Design 12 compiled homes', () => {
+  const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url));
+  const manifestPath = `${repoRoot}.totem/compiled-rules.json`;
+  const rawManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8')) as {
+    rules: Record<string, unknown>[];
+  };
+
+  it('re-validates the shipped 485-rule manifest BYTE-IDENTICALLY under the extended schema', () => {
+    // The freeze-compatibility proof (Amendment R11 / § Data model deltas): the
+    // additions are optional, so the frozen corpus parses unchanged — and
+    // "unchanged" is checked on the MANIFEST-HASH basis (canonical, key-sorted),
+    // which is the identity that actually matters to `verify-manifest`. A
+    // required addition, or one that introduced a default, would move every hash.
+    const parsed = CompiledRulesFileSchema.parse(rawManifest);
+    expect(parsed.rules.length).toBe(rawManifest.rules.length);
+    expect(canonicalStringify(parsed.rules)).toBe(canonicalStringify(rawManifest.rules));
+  });
+
+  it('leaves every legacy rule OUTSIDE the record path — the discriminator cannot flip one', () => {
+    // The runtime reads field PRESENCE as the record-path discriminator, so this
+    // is what makes "legacy rules keep their matching behaviour byte-for-byte" a
+    // fact rather than an intention. If a future writer ever puts one of these
+    // fields on a mined rule, this fails before the matcher silently changes.
+    const carriers = rawManifest.rules.filter((rule) =>
+      RECORD_COMPILED_HOME_KEYS.some((key) => rule[key] !== undefined),
+    );
+    expect(carriers).toEqual([]);
+    const compiled = CompiledRulesFileSchema.parse(rawManifest).rules;
+    expect(compiled.filter(isRecordPathRule)).toEqual([]);
+  });
+
+  it('accepts a rule carrying NONE of the additions (every one is optional)', () => {
+    const minimal = CompiledRuleSchema.parse({
+      lessonHash: 'abcdef0123456789',
+      lessonHeading: 'legacy',
+      pattern: 'foo',
+      message: 'no',
+      engine: 'regex',
+      compiledAt: NOW,
+    });
+    for (const key of RECORD_COMPILED_HOME_KEYS) {
+      expect(minimal[key]).toBeUndefined();
+    }
+  });
+
+  it('couples the compiled `requires.scope` enum to the grammar’s RequiresScopeSchema', () => {
+    // `compiler-schema.ts` is an import-graph leaf and cannot import the grammar
+    // (it would close a cycle), so the two enums are mirrored in source and
+    // COUPLED here. `block` stays reserved-unimplemented on both sides.
+    const rule = lowerOk({ ...regexRecord(), requires: { pattern: 'x', scope: 'file' } });
+    expect(RequiresScopeSchema.options).toEqual(['line', 'file']);
+    expect(rule.requires?.scope).toBe('file');
+    for (const scope of RequiresScopeSchema.options) {
+      expect(
+        CompiledRuleSchema.safeParse({
+          lessonHash: RULE_ID,
+          lessonHeading: 'h',
+          pattern: 'p',
+          message: 'm',
+          engine: 'regex',
+          compiledAt: NOW,
+          requires: { pattern: 'x', scope },
+        }).success,
+      ).toBe(true);
+    }
+    expect(
+      CompiledRuleSchema.safeParse({
+        lessonHash: RULE_ID,
+        lessonHeading: 'h',
+        pattern: 'p',
+        message: 'm',
+        engine: 'regex',
+        compiledAt: NOW,
+        requires: { pattern: 'x', scope: 'block' },
+      }).success,
+    ).toBe(false);
+  });
+
+  it('couples the compiled `examples` and `curation` shapes to the grammar’s schemas', () => {
+    expect(Object.keys(RuleRecordExampleSchema.shape).sort()).toEqual(['bad', 'good']);
+    expect(Object.keys(RuleCurationSchema._def.schema.shape).sort()).toEqual([
+      'baseline5Phase',
+      'curatedAt',
+      'curatedBy',
+      'sourceLesson',
+    ]);
+    const rule = lowerOk(design4ExemplarRecord());
+    expect(Object.keys(rule.examples![0]!).sort()).toEqual(['bad', 'good']);
+    expect(Object.keys(rule.curation!).sort()).toEqual([
+      'baseline5Phase',
+      'curatedAt',
+      'curatedBy',
+      'sourceLesson',
+    ]);
+  });
+});
+
+// ─── B. The freeze boundary (§ Design 7 conformance scope) ───────────────────
+
+describe('freeze guard — sanitizeFileGlobs is untouched and never runs on the record path', () => {
+  it('keeps the legacy brace EXPANSION byte-for-byte', () => {
+    expect(sanitizeFileGlobs(['**/*.{ts,js}'])).toEqual(['**/*.ts', '**/*.js']);
+    expect(sanitizeFileGlobs(['src/*.{ts,tsx,js}'])).toEqual(['src/*.ts', 'src/*.tsx', 'src/*.js']);
+  });
+
+  it('keeps the legacy shallow-glob PROMOTION byte-for-byte', () => {
+    expect(sanitizeFileGlobs(['*.ts'])).toEqual(['**/*.ts']);
+    expect(sanitizeFileGlobs(['*'])).toEqual(['**/*']);
+    expect(sanitizeFileGlobs(['!*.ts'])).toEqual(['!**/*.ts']);
+    expect(sanitizeFileGlobs(['src/*.ts'])).toEqual(['src/*.ts']);
+  });
+
+  it('carries record globs VERBATIM — no promotion, no expansion, no trimming', () => {
+    // The negative half of the two guards above: the same `*.ts` the sanitizer
+    // promotes tree-wide survives lowering unchanged. Braces never reach here
+    // (a parse error), so the only observable transform would be promotion.
+    const record = regexRecord();
+    (record.target as Record<string, unknown>).scope = {
+      fileGlobs: ['*.ts', 'src/*.ts', '**/*.sh'],
+      excludeGlobs: ['**/*.test.ts'],
+    };
+    const rule = lowerOk(record);
+    expect(rule.fileGlobs).toEqual(['*.ts', 'src/*.ts', '**/*.sh']);
+    expect(rule.excludeGlobs).toEqual(['**/*.test.ts']);
+  });
+});
+
+// ─── C. § Design 6 — language resolution moves to the declared language ──────
+
+describe('§ Design 6 — the declared language resolves against the registry', () => {
+  it('resolves a registered language and reports its representative extension', () => {
+    const resolution = resolveRecordLanguage('typescript');
+    expect(resolution.resolved).toBe(true);
+    if (!resolution.resolved) return;
+    expect(resolution.language).toBe('typescript');
+    expect(['.cts', '.mts', '.ts']).toContain(resolution.extension);
+  });
+
+  it('fails loud on an unresolvable language, naming the registry as the authority', () => {
+    const resolution = resolveRecordLanguage('rust');
+    expect(resolution.resolved).toBe(false);
+    if (resolution.resolved) return;
+    expect(resolution.reason).toContain('§ Design 6');
+    expect(resolution.reason).toContain('extensionToLanguage registry');
+    expect(resolution.reason).toContain('typescript');
+  });
+
+  it('pins the validator probe to EXACTLY one Lang (coupling guard on resolveAstGrepLangs)', () => {
+    // The record path pins `validateAstGrepPattern` to one grammar by handing it
+    // a probe glob carrying one registered extension. That indirection is only
+    // safe while the shipped derivation still maps one extension to one Lang —
+    // so this asserts the coupling instead of trusting it.
+    for (const language of ['typescript', 'tsx', 'javascript']) {
+      const resolution = resolveRecordLanguage(language);
+      expect(resolution.resolved).toBe(true);
+      if (!resolution.resolved) continue;
+      const langs = resolveAstGrepLangs(languageProbeGlobs(resolution.extension));
+      expect(langs).toEqual([extensionToLang(resolution.extension)]);
+      expect(langs).toHaveLength(1);
+    }
+  });
+
+  it('validates under the DECLARED language, not the glob-derived one (the “moves” row)', () => {
+    // `type_alias_declaration` exists in the TypeScript/TSX grammars and not in
+    // JavaScript. The shipped try-each-glob-derived-Lang validator would resolve
+    // TypeScript from `**/*.ts` and ACCEPT this payload; the record path resolves
+    // ONLY the declared `javascript` and must reject it. This is the
+    // mmnto-ai/totem#1654 cross-grammar acceptance being retired on this path.
+    const record = astGrepRecord();
+    const target = record.target as Record<string, unknown>;
+    target.rule = { kind: 'type_alias_declaration' };
+    target.scope = { fileGlobs: ['**/*.ts'] };
+
+    target.language = 'typescript';
+    expect(lower(record).kind).toBe('compiled');
+
+    target.language = 'javascript';
+    const reason = lowerRejected(record);
+    expect(reason).toContain('§ Design 6');
+    expect(reason).toContain("declared language 'javascript'");
+    expect(reason).toContain('try-each-glob-derived-Lang');
+  });
+});
+
+// ─── D. Cannot-lower negatives, one per construct class ──────────────────────
+
+describe('§ Design 12 — a construct that cannot lower fails compile LOUD', () => {
+  it('rejects a bad regex in `requires.pattern` (gated on EVERY engine)', () => {
+    const reason = lowerRejected({
+      ...regexRecord(),
+      requires: { pattern: '(a+)+$', scope: 'line' },
+    });
+    expect(reason).toContain('§ Design 8');
+    expect(reason).toContain('requires.pattern');
+    expect(reason).toContain('ReDoS');
+  });
+
+  it('gates `requires.pattern` on an ast-grep rule too — the check is engine-independent', () => {
+    const reason = lowerRejected({
+      ...astGrepRecord(),
+      requires: { pattern: '(a+)+$', scope: 'file' },
+    });
+    expect(reason).toContain('§ Design 8');
+    expect(reason).toContain('independent of target.type');
+  });
+
+  it('rejects an unresolvable `language`', () => {
+    const record = astGrepRecord();
+    (record.target as Record<string, unknown>).language = 'brainfuck';
+    const reason = lowerRejected(record);
+    expect(reason).toContain('§ Design 6');
+    expect(reason).toContain("'brainfuck' is not registered");
+  });
+
+  it('rejects a malformed ast-grep tree at the engine gate', () => {
+    const record = astGrepRecord();
+    (record.target as Record<string, unknown>).rule = { notARule: 1 };
+    const reason = lowerRejected(record);
+    expect(reason).toContain('§ Design 6');
+    expect(reason).toContain('target.rule failed ast-grep validation');
+  });
+
+  it('rejects a bad regex in `target.pattern`', () => {
+    const record = regexRecord();
+    (record.target as Record<string, unknown>).pattern = '(';
+    const reason = lowerRejected(record);
+    expect(reason).toContain('§ Design 6');
+    expect(reason).toContain('invalid syntax');
+  });
+
+  it('rejects V1-inexpressible NapiConfig siblings smuggled into the rule tree', () => {
+    for (const key of V1_INEXPRESSIBLE_NAPI_KEYS) {
+      const record = astGrepRecord();
+      (record.target as Record<string, unknown>).rule = { kind: 'catch_clause', [key]: {} };
+      const reason = lowerRejected(record);
+      expect(reason).toContain('operator ruling 2026-08-21');
+      expect(reason).toContain(`'${key}' is a NapiConfig SIBLING`);
+      expect(reason).toContain('construct-gap');
+    }
+  });
+
+  it('THROWS on a malformed ruleId — identity is a producer contract, not authored content', () => {
+    expect(() => lower(regexRecord(), 'not-a-minted-id')).toThrow(/malformed ruleId/);
+    expect(() => lower(regexRecord(), '')).toThrow(/malformed ruleId/);
+    // A 16-hex base with the mint's own collision suffix is well-formed.
+    expect(lowerOk(regexRecord(), '0123456789abcdef-2').lessonHash).toBe('0123456789abcdef-2');
+  });
+
+  it('THROWS on a record key with no defined lowering (the runtime totality check)', () => {
+    // A key that got past the parser — via a cast, a schema/table desync, or a
+    // future grammar edit that forgot this file — must never be silently dropped.
+    const parsed = parseRuleRecord(yamlStringify(regexRecord()), FILE);
+    const smuggled = {
+      ...parsed,
+      record: { ...parsed.record, futureConstruct: 'x' },
+    } as unknown as ParsedRuleRecord;
+    expect(() => compileRuleRecord(smuggled, { ruleId: RULE_ID, now: NOW })).toThrow(
+      /record key 'futureConstruct' has no defined lowering/,
+    );
+  });
+
+  it('THROWS on an engine-binding divergence (the assert is NOT tautological)', () => {
+    // § Design 3: the two sides originate differently — the record's `target.type`
+    // and the payload's actual compilation path. Tamper with one and the assert
+    // must still fire, which is exactly what makes the derivation safe.
+    const parsed = parseRuleRecord(yamlStringify(regexRecord()), FILE);
+    const tampered = { ...parsed, derivedEngine: 'ast-grep' } as unknown as ParsedRuleRecord;
+    expect(() => compileRuleRecord(tampered, { ruleId: RULE_ID, now: NOW })).toThrow(
+      /declared target.type 'ast-grep' but its payload compiled as 'regex'/,
+    );
+  });
+});
+
+// ─── E. Identity, verbatim carries, and the tree-form ruling ─────────────────
+
+describe('lowering — identity, verbatim carries, and the derived NapiConfig wrapper', () => {
+  it('takes identity as an INPUT: lessonHash ← ruleId, never a dslSource hash', () => {
+    const rule = lowerOk(regexRecord());
+    expect(rule.lessonHash).toBe(RULE_ID);
+    expect(rule.lessonHeading).toBe(`Prop 310 rule record (${RULE_ID})`);
+    // The heading is NOT a copy of the author's message (Tenet 20 — one home).
+    expect(rule.lessonHeading).not.toBe(rule.message);
+  });
+
+  it('mints Yellow: unverified true, legitimacy and ruleClass absent', () => {
+    const rule = lowerOk(regexRecord());
+    expect(rule.unverified).toBe(true);
+    expect(rule.legitimacy).toBeUndefined();
+    expect(rule.ruleClass).toBeUndefined();
+    expect(rule.compiledAt).toBe(NOW);
+    expect(rule.createdAt).toBe(NOW);
+  });
+
+  it('carries every § Design 4 construct verbatim onto the compiled rule', () => {
+    const record = design4ExemplarRecord();
+    const rule = lowerOk(record);
+    expect(rule.severity).toBe('error');
+    expect(rule.message).toBe(record.message);
+    expect(rule.recoveryHint).toBe(record.recoveryHint);
+    expect(rule.examples).toEqual(record.examples);
+    expect(rule.curation).toEqual(record.curation);
+    expect(rule.fileGlobs).toEqual(['packages/**/*.ts']);
+    expect(rule.excludeGlobs).toEqual(['**/*.test.ts']);
+    expect(rule.language).toBe('typescript');
+    expect(rule.engine).toBe('ast-grep');
+  });
+
+  it('renames `verification_shadow` → `verificationShadow` exactly once, verbatim', () => {
+    const record = design4ExemplarRecord();
+    const rule = lowerOk(record);
+    expect(rule.verificationShadow).toEqual(record.verification_shadow);
+    // The snake_case record key never survives onto the compiled artifact.
+    expect((rule as Record<string, unknown>).verification_shadow).toBeUndefined();
+  });
+
+  it('derives the NapiConfig wrapper from the rule TREE (operator ruling 2026-08-21)', () => {
+    const record = design4ExemplarRecord();
+    const rule = lowerOk(record);
+    const tree = (record.target as Record<string, unknown>).rule;
+    // `{rule: <tree>}` plus the napi language derived from the RESOLVED
+    // `target.language` — so the record carries no duplicate language home.
+    expect(rule.astGrepYamlRule).toEqual({ rule: tree, language: extensionToLang('.ts') });
+    expect(rule.astGrepPattern).toBeUndefined();
+    expect(rule.pattern).toBe('');
+  });
+
+  it('routes a FLAT ast-grep payload to astGrepPattern, still language-pinned', () => {
+    const record = astGrepRecord();
+    const target = record.target as Record<string, unknown>;
+    delete target.rule;
+    target.pattern = 'console.log($A)';
+    const rule = lowerOk(record);
+    expect(rule.astGrepPattern).toBe('console.log($A)');
+    expect(rule.astGrepYamlRule).toBeUndefined();
+    expect(rule.language).toBe('typescript');
+  });
+
+  it('omits `language` for a regex rule — the grammar forbids it there', () => {
+    const rule = lowerOk(regexRecord());
+    expect(rule.language).toBeUndefined();
+    expect(rule.pattern).toBe('\\bgit\\s+(log|diff|status)\\b');
+  });
+
+  it('omits every optional home the record did not declare', () => {
+    const rule = lowerOk(regexRecord());
+    expect(rule.excludeGlobs).toBeUndefined();
+    expect(rule.requires).toBeUndefined();
+    expect(rule.curation).toBeUndefined();
+    expect(rule.verificationShadow).toBeUndefined();
+    expect(rule.recoveryHint).toBeUndefined();
+  });
+
+  it('does NOT mirror examples onto the legacy badExample/goodExample pair', () => {
+    // Amendment 1 makes the record's `examples` the single hand-editable home;
+    // projecting it onto the legacy pair would be a second copy (Tenet 20).
+    const rule = lowerOk(design4ExemplarRecord());
+    expect(rule.badExample).toBeUndefined();
+    expect(rule.goodExample).toBeUndefined();
+    expect(rule.examples).toHaveLength(1);
+  });
+
+  it('is deterministic — the same record and inputs lower to a deep-equal rule', () => {
+    expect(lowerOk(design4ExemplarRecord())).toEqual(lowerOk(design4ExemplarRecord()));
+  });
+
+  it('lowers BOTH Prop 310 exemplars (slice 1 parse → slice 2 compile)', () => {
+    const design4 = lowerOk(design4ExemplarRecord());
+    expect(design4.engine).toBe('ast-grep');
+
+    const design8 = lowerOk(design8ExemplarRecord());
+    expect(design8.engine).toBe('regex');
+    expect(design8.requires).toEqual({ pattern: 'LC_ALL=C', scope: 'line' });
+    expect(design8.fileGlobs).toEqual(['**/*.sh', '**/*.cjs']);
+    expect(design8.severity).toBe('warning');
+  });
+});

--- a/packages/core/src/spine/record-lower.ts
+++ b/packages/core/src/spine/record-lower.ts
@@ -57,7 +57,7 @@
 // untouched — the freeze covers that path and nothing regenerates it.
 
 import { extensionToLanguage, registeredExtensions } from '../ast-classifier.js';
-import { extensionToLang } from '../ast-grep-query.js';
+import { extensionToLang, TRAILING_EXT_RE } from '../ast-grep-query.js';
 import { validateAstGrepPattern } from '../compile-lesson.js';
 import { engineFields, validateRegex } from '../compiler.js';
 import { CompiledRuleSchema } from '../compiler-schema.js';
@@ -135,6 +135,65 @@ export function resolveRecordLanguage(language: string): RecordLanguageResolutio
  */
 export function languageProbeGlobs(extension: string): string[] {
   return [`**/*${extension}`];
+}
+
+// ── The language⇄glob consistency floor ──────────────────────────────────────
+//
+// OPERATOR-CONSISTENT RULING (falsification round, 2026-08-21): for a
+// `type: ast-grep` record, EVERY `target.scope.fileGlobs` entry must end in a
+// registered extension that resolves — via `extensionToLanguage`, the same
+// § Design 6 authority — to the DECLARED `target.language`. Otherwise the record
+// is rejected.
+//
+// Grounds. § Design 6 fixes ONE declared language per record and the options
+// table spells out the consequence: "a multi-language ast-grep rule is N
+// records". Without this floor a record could declare `language: typescript`
+// and scope itself to `**\/*.js`, and the runtime — which dispatches ast-grep by
+// FILE EXTENSION, not by the rule's compiled `language` — would then evaluate it
+// under a grammar it was never validated against. The review demonstrated both
+// halves of that gap: a compound payload fails inertly per file (a silent
+// non-firing rule), and a flat pattern FIRES under the wrong grammar. Neither is
+// visible to the author. With the floor, validated-as-declared and
+// evaluated-by-extension agree BY CONSTRUCTION, so the runtime needs no
+// language gate of its own.
+//
+// Scope of the floor, precisely:
+//   - `fileGlobs` only. `excludeGlobs` entries are EXEMPT: they only ever narrow
+//     an already-consistent positive scope, so an exclusion written against a
+//     different extension can widen nothing.
+//   - `type: regex` records are UNCHECKED — a regex payload has no grammar
+//     binding at all (`target.language` is forbidden there, § Design 4), and the
+//     match is textual, so the same globs are legitimate.
+//   - An EXTENSION-LESS glob (`packages/**`) rejects under the same rule: a
+//     scope that cannot be pinned to a language cannot be validated as it will
+//     be evaluated, and silently admitting it would reopen the gap for every
+//     file the directory happens to contain.
+
+/**
+ * Check the § Design 6 one-declared-language rule against a record's positive
+ * globs. Returns `null` when the scope is consistent, or the rejection reason.
+ * ast-grep targets only — the caller does not invoke it for regex.
+ */
+export function checkLanguageGlobConsistency(
+  language: string,
+  fileGlobs: readonly string[],
+): string | null {
+  const advice = `§ Design 6 fixes ONE declared language per record — "a multi-language ast-grep rule is N records". Split the rule per language, or correct the glob. (The runtime dispatches ast-grep by FILE EXTENSION, so a scope the declared language does not cover would be evaluated under a grammar the payload was never validated against.)`;
+  for (const glob of fileGlobs) {
+    const match = TRAILING_EXT_RE.exec(glob);
+    if (match === null) {
+      return `Prop 310 § Design 6: target.scope.fileGlobs entry '${glob}' carries no file extension, so its scope cannot be pinned to the declared language '${language}'. ${advice}`;
+    }
+    const extension = `.${match[1]!.toLowerCase()}`;
+    const globLanguage = extensionToLanguage(extension);
+    if (globLanguage === undefined) {
+      return `Prop 310 § Design 6: target.scope.fileGlobs entry '${glob}' targets extension '${extension}', which is not registered, so it cannot be confirmed to match the declared language '${language}'. ${advice}`;
+    }
+    if (globLanguage !== language) {
+      return `Prop 310 § Design 6: target.scope.fileGlobs entry '${glob}' targets language '${globLanguage}' but the record declares '${language}'. ${advice}`;
+    }
+  }
+  return null;
 }
 
 // ── The tree-form gate (operator ruling 2026-08-21) ──────────────────────────
@@ -316,6 +375,26 @@ export function compileRuleRecord(
         reason: `Prop 310 § Design 8: requires.pattern is not a usable regex (${v.reason ?? 'invalid regex pattern'}) — the requirement is a safe-regex2-gated regex evaluated textually at the declared scope, independent of target.type.`,
       };
     }
+    // RULING (falsification round, 2026-08-21): `requires.scope: line` is
+    // REJECTED on an ast-grep target. An ast-grep match is a SPAN, not a line,
+    // so "the line containing L" has no engine-defined answer: the runtime reads
+    // the span's START line, which makes the verdict depend on how the author
+    // wrapped their source — the review measured a rule firing once when its
+    // subject was split across lines and not at all when it was written on one.
+    // A formatting-dependent verdict is not a semantic. § Design 8 already
+    // reserves `block` — the span's natural unit — as unimplemented pending a
+    // language adapter's boundary definition, so the honest V1 answer is to
+    // reject the combination rather than ship a line reading that only
+    // coincidentally agrees with the author's intent. `file` scope stays valid
+    // on ast-grep (whole-file text is unambiguous), and `line` stays valid on
+    // regex targets (a regex match IS line-local by construction).
+    if (record.target.type === 'ast-grep' && record.requires.scope === 'line') {
+      return {
+        kind: 'rejected',
+        reason:
+          "Prop 310 § Design 8: `requires.scope: line` is not available on an `ast-grep` target — an ast-grep match is a SPAN, and reading it as its start line makes the verdict depend on source formatting rather than on the rule. Use `scope: file` (unambiguous on any engine), move the requirement into the payload's own `not:`/`has:` combinators (§ Design 8: node-scoped absence stays payload-owned), or wait for the reserved `block` unit, which is the span's natural scope and is unimplemented at V1.",
+      };
+    }
   }
 
   let payloadFields: {
@@ -343,6 +422,14 @@ export function compileRuleRecord(
     const resolution = resolveRecordLanguage(target.language!);
     if (!resolution.resolved) return { kind: 'rejected', reason: resolution.reason };
     resolvedLanguage = resolution.language;
+
+    // The language⇄glob consistency floor, BEFORE the payload gate: a scope that
+    // will be evaluated under a different grammar than the payload is validated
+    // under is a defect in the record, and the author should be told that rather
+    // than being handed a payload error for a payload that is fine.
+    const inconsistent = checkLanguageGlobConsistency(resolution.language, target.scope.fileGlobs);
+    if (inconsistent !== null) return { kind: 'rejected', reason: inconsistent };
+
     const probeGlobs = languageProbeGlobs(resolution.extension);
 
     if (target.rule !== undefined) {

--- a/packages/core/src/spine/record-lower.ts
+++ b/packages/core/src/spine/record-lower.ts
@@ -261,7 +261,13 @@ function assertKeysDispositioned(
   at: string,
 ): void {
   for (const key of Object.keys(value)) {
-    if (table[key] === undefined) {
+    // `Object.hasOwn`, not `table[key] === undefined`: a key named `constructor`
+    // or `toString` would otherwise resolve up the prototype chain and read as
+    // "dispositioned". Slice 1's prototype floor already rejects those at parse,
+    // so nothing reaching here through `parseRuleRecord` can carry one — this is
+    // defence in depth for a hand-constructed `ParsedRuleRecord`, which is
+    // exactly the caller class this whole assertion exists for.
+    if (!Object.hasOwn(table, key)) {
       throw new Error(
         `[Totem Error] compileRuleRecord: record key '${at}${key}' has no defined lowering — Prop 310 § Design 12 forbids accepting a construct at parse and dropping it at compile. Give it a compiled home (and a disposition in record-lower.ts) or reject it at parse.`,
       );

--- a/packages/core/src/spine/record-lower.ts
+++ b/packages/core/src/spine/record-lower.ts
@@ -1,0 +1,430 @@
+// ─── Prop 310 V1 record grammar — the LOWERING (slice 2 of the V1 build) ──────
+//
+// Slice 1 (`rule-record.ts`) turns record bytes into a validated
+// `ParsedRuleRecord`. This module turns that value into a `CompiledRule`. It is
+// the § Design 1 seam replacement for records: the record path does NOT go
+// through `extractManualPattern` or `CompileInputCandidate.dslSource`, because
+// the record is ALREADY parsed — re-serializing it into lesson markdown just to
+// re-parse it would reintroduce the incumbent grammar this proposal supersedes.
+// What is reused is the VALIDATORS (`validateRegex`, `validateAstGrepPattern`)
+// and the field builder (`engineFields`), never the parser and never the frozen
+// `LessonInput` actuator.
+//
+// § Design 12 (R2) is this slice's charter: **every construct the parser admits
+// either lands on the compiled record or fails compile LOUD.** No construct is
+// accepted at parse and dropped at compile. That obligation is enforced
+// mechanically here, not by inspection — see § "Total lowering, mechanically".
+//
+// ── OPERATOR RULING 2026-08-21 (tree-form) ───────────────────────────────────
+//
+// `target.rule` is the ast-grep RULE TREE, not a whole NapiConfig — the
+// exemplar-faithful reading of § Design 4's "NapiConfig subset" (its exemplar
+// shows `rule: {kind: catch_clause, not: {...}}`, a rule tree, with `language`
+// living one level up at `target.language`).
+//
+//   - LOWERING DERIVES the NapiConfig wrapper: `{rule: <tree>, language: <napi
+//     language derived from the resolved `target.language`>}`. The record
+//     therefore never carries a duplicate language home (§ Design 3's no-mirror
+//     discipline; Tenet 20) and no language COLLISION between the payload
+//     interior and `target.language` is representable.
+//   - `constraints` / `utils` are INEXPRESSIBLE at V1 (censused: zero of the 19
+//     compound corpus rules use them). Demand becomes a typed `construct-gap` at
+//     the R14 trial plus a grammar version bump giving each its own SIBLING home
+//     under `target:` — never a silent smuggle inside the rule tree, which is
+//     why the tree gate below names them explicitly instead of leaving them to
+//     napi's generic unknown-field error.
+//
+// Grounds of record: the spec-normative exemplar (§ Design 14's normativity
+// flip), language-collision avoidance, and zero corpus cost.
+//
+// ── Identity ─────────────────────────────────────────────────────────────────
+//
+// Identity is an INPUT, never minted here (§ Design 3 / R17): the ADR-112 §8
+// producer mints `ruleId` at the intake seam and slice 3 threads it in. This
+// function asserts it is well-formed and makes it the compiled identity
+// (`lessonHash ← ruleId`, the §8/§9 `firingLabelId ← ruleId` unification), and
+// NEVER hashes `dslSource` — there is no `dslSource` on this path, and a
+// content-derived id would orphan the rule's ground-truth labels on every
+// matcher edit.
+//
+// ── Freeze boundary ──────────────────────────────────────────────────────────
+//
+// `sanitizeFileGlobs` is NEVER called here. The record's globs were validated at
+// parse against § Design 7's strict dialect and are carried BYTE-VERBATIM:
+// brace expansion and shallow-glob promotion are exactly the silent transforms
+// the grammar kills (§ Design 7's conformance-scope paragraph), while the
+// sanitizer's tolerant behaviour for the FROZEN legacy lesson corpus is
+// untouched — the freeze covers that path and nothing regenerates it.
+
+import { extensionToLanguage, registeredExtensions } from '../ast-classifier.js';
+import { extensionToLang } from '../ast-grep-query.js';
+import { validateAstGrepPattern } from '../compile-lesson.js';
+import { engineFields, validateRegex } from '../compiler.js';
+import { CompiledRuleSchema } from '../compiler-schema.js';
+import { AUTHORED_RULE_ID_RE } from './authored-rule.js';
+import type { CompileOutcome } from './compile.js';
+import type { ParsedRuleRecord, RuleRecord, RuleScope, RuleTarget } from './rule-record.js';
+
+// ── § Design 6 — language resolution ─────────────────────────────────────────
+//
+// The Existing-Surface Coupling table's language-resolution row says this seam
+// **moves**: V1 validates the payload under the SINGLE declared `language:`
+// instead of trying every glob-derived Lang, and the Map-backed registry
+// (built-ins + pack contributions) stays the resolution authority. The shipped
+// try-each-Lang cross-grammar acceptance (mmnto-ai/totem#1654) is what that
+// replaces — on the RECORD path only; the legacy path keeps it verbatim.
+
+/** A `target.language` token resolved against the registry, or the reason it did not. */
+export type RecordLanguageResolution =
+  | {
+      resolved: true;
+      /** The declared token, confirmed registered. Resolution is MEMBERSHIP, so this equals `target.language`. */
+      language: string;
+      /**
+       * A registered extension mapping to `language`, used to pin the ast-grep
+       * validator to exactly this grammar (see `languageProbeGlobs`).
+       */
+      extension: string;
+    }
+  | { resolved: false; reason: string };
+
+/**
+ * Resolve `target.language` against the registry, using `extensionToLanguage` as
+ * the authority verbatim (§ Design 6). Deterministic: `registeredExtensions()`
+ * returns a sorted snapshot, so the representative extension for a language with
+ * several (`.ts`/`.mts`/`.cts` → `typescript`) is always the same one — and every
+ * extension of one language maps to the same napi grammar anyway, so the pick
+ * cannot change the validation verdict, only the diagnostic.
+ *
+ * An unresolvable language FAILS LOUD (§ Design 6 / § Failure modes: "Unresolvable
+ * `language:` at compile — hard error"). It is surfaced as a `rejected` outcome
+ * rather than a throw, matching the incumbent's treatment of every other
+ * authored-content validation failure: `rejected` is a counted, reported,
+ * NON-silent state, while throws are reserved for producer-contract violations
+ * (a malformed id, a payload/type divergence) — see `compileRuleRecord`.
+ */
+export function resolveRecordLanguage(language: string): RecordLanguageResolution {
+  const extensions = registeredExtensions();
+  const extension = extensions.find((ext) => extensionToLanguage(ext) === language);
+  if (extension === undefined) {
+    const known = [...new Set(extensions.map((ext) => extensionToLanguage(ext)))]
+      .filter((lang): lang is string => lang !== undefined)
+      .sort();
+    return {
+      resolved: false,
+      reason: `Prop 310 § Design 6: target.language '${language}' is not registered — the resolution authority is the Map-backed extensionToLanguage registry (built-ins + pack contributions), never a spec-frozen enum. Registered languages: ${known.join(', ') || '(none)'}. Install the pack that provides this language, or correct the record.`,
+    };
+  }
+  return { resolved: true, language, extension };
+}
+
+/**
+ * The glob list handed to `validateAstGrepPattern` so it resolves to EXACTLY the
+ * declared language.
+ *
+ * The shipped validator's language input is a glob list (`resolveAstGrepLangs`
+ * derives Langs from trailing extensions), so pinning it to one grammar means
+ * handing it one glob carrying one registered extension. These globs are a
+ * VALIDATOR PROBE and nothing else — they are never the record's globs, never
+ * reach the compiled rule, and never touch `sanitizeFileGlobs`.
+ *
+ * The coupling to `resolveAstGrepLangs`' derivation is pinned by a conformance
+ * test (`record-lower.test.ts`: the probe resolves to exactly one Lang, and that
+ * Lang equals `extensionToLang(extension)`), so a change to the shipped
+ * derivation fails loud here instead of silently un-pinning the record path.
+ */
+export function languageProbeGlobs(extension: string): string[] {
+  return [`**/*${extension}`];
+}
+
+// ── The tree-form gate (operator ruling 2026-08-21) ──────────────────────────
+
+/**
+ * NapiConfig siblings of `rule` that V1 cannot express. Named explicitly so the
+ * author is told the truth — a typed construct-gap awaiting a version bump with
+ * its own sibling home under `target:` — instead of napi's generic
+ * "unknown field" error, which would read as a typo in the rule tree.
+ */
+export const V1_INEXPRESSIBLE_NAPI_KEYS = ['constraints', 'utils'] as const;
+
+// ── Total lowering, mechanically (§ Design 12) ───────────────────────────────
+//
+// The obligation is "every construct the parser admits either lands on the
+// compiled record or fails compile loud". Enforcing that by inspection is how a
+// construct gets silently dropped three schema edits from now, so it is enforced
+// twice over:
+//
+//   1. COMPILE TIME — the tables below are `Record<keyof T, ...>` over the parsed
+//      types, so adding a grammar key without giving it a disposition is a
+//      TypeScript error in this file.
+//   2. RUN TIME — `assertTotalLowering` checks the actual parsed object's keys
+//      against the tables and THROWS on any key without a disposition, so a
+//      schema/table desync introduced through a cast still fails loud.
+//
+// A disposition of `'compiled'` means the construct reaches the `CompiledRule`;
+// `'consumed-at-parse'` means the construct's whole effect is spent inside the
+// parser and nothing downstream can observe its loss. Exactly one key qualifies
+// for the latter — `schemaVersion`, which answers "whose grammar rules apply"
+// and is the gate that admitted the document in the first place.
+
+type LoweringDisposition = 'compiled' | 'consumed-at-parse';
+
+const RECORD_KEY_LOWERING: Record<keyof RuleRecord, LoweringDisposition> = {
+  schemaVersion: 'consumed-at-parse',
+  severity: 'compiled',
+  message: 'compiled',
+  recoveryHint: 'compiled',
+  target: 'compiled',
+  examples: 'compiled',
+  requires: 'compiled',
+  curation: 'compiled',
+  verification_shadow: 'compiled',
+};
+
+const TARGET_KEY_LOWERING: Record<keyof RuleTarget, LoweringDisposition> = {
+  // `type` lowers to `engine` — and is re-derived INDEPENDENTLY from the payload's
+  // compilation path for the § Design 3 engine-binding assert.
+  type: 'compiled',
+  language: 'compiled',
+  pattern: 'compiled',
+  rule: 'compiled',
+  scope: 'compiled',
+};
+
+const SCOPE_KEY_LOWERING: Record<keyof RuleScope, LoweringDisposition> = {
+  fileGlobs: 'compiled',
+  excludeGlobs: 'compiled',
+};
+
+function assertKeysDispositioned(
+  value: object,
+  table: Record<string, LoweringDisposition>,
+  at: string,
+): void {
+  for (const key of Object.keys(value)) {
+    if (table[key] === undefined) {
+      throw new Error(
+        `[Totem Error] compileRuleRecord: record key '${at}${key}' has no defined lowering — Prop 310 § Design 12 forbids accepting a construct at parse and dropping it at compile. Give it a compiled home (and a disposition in record-lower.ts) or reject it at parse.`,
+      );
+    }
+  }
+}
+
+/** § Design 12 — the runtime half of the total-lowering proof (see above). */
+function assertTotalLowering(record: RuleRecord): void {
+  assertKeysDispositioned(record, RECORD_KEY_LOWERING, '');
+  assertKeysDispositioned(record.target, TARGET_KEY_LOWERING, 'target.');
+  assertKeysDispositioned(record.target.scope, SCOPE_KEY_LOWERING, 'target.scope.');
+}
+
+// ── The compiled engine, re-derived from the payload ─────────────────────────
+
+/**
+ * Derive the engine from the fields `engineFields` actually produced. This is
+ * the INDEPENDENT second side of the § Design 3 engine-binding assert: one side
+ * is the record's `target.type` (via `derivedEngine`), the other is the payload's
+ * actual compilation path. § Design 3 is explicit that the derivation must not
+ * make the shipped assert tautological, and it does not — a payload routed
+ * through the wrong `engineFields` branch diverges here and fails loud.
+ */
+function engineFromCompiledFields(fields: {
+  pattern: string;
+  astGrepPattern?: string;
+  astGrepYamlRule?: unknown;
+}): 'regex' | 'ast-grep' | 'unknown' {
+  const hasAstGrep =
+    (typeof fields.astGrepPattern === 'string' && fields.astGrepPattern.length > 0) ||
+    fields.astGrepYamlRule !== undefined;
+  if (hasAstGrep) return 'ast-grep';
+  if (fields.pattern.length > 0) return 'regex';
+  return 'unknown';
+}
+
+/**
+ * A stable, deterministic diagnostic label for a record-compiled rule.
+ *
+ * `CompiledRule.lessonHeading` is a required diagnostic field on a schema built
+ * for lesson-compiled rules; the record grammar has no heading construct and
+ * § Design 4's key space is closed against inventing one. Deriving the label
+ * from the identity mirrors the shipped authored-path idiom
+ * (`compile.ts: candidateHeading`) and deliberately does NOT copy `message` —
+ * two homes for the author's one sentence is Tenet 20's prohibited mirror, and
+ * a heading that drifts from the message would be worse than a generic one.
+ */
+function recordHeading(ruleId: string): string {
+  return `Prop 310 rule record (${ruleId})`;
+}
+
+/** Inputs the lowering needs that the record deliberately does not carry (§ Design 1/§ Design 3). */
+export interface CompileRuleRecordOptions {
+  /**
+   * The ADR-112 §8 producer-minted rule id, supplied at the intake seam. NEVER
+   * minted here and never author-set — identity is producer-owned (R17).
+   */
+  ruleId: string;
+  /** Injected timestamp — no `new Date()` in core (Tenet 15 determinism). */
+  now: string;
+}
+
+/**
+ * Lower a parsed Prop 310 record into a `CompiledRule`.
+ *
+ * PURE (no IO). Returns a `CompileOutcome`:
+ *   - `{kind: 'compiled'}` — the record lowered totally.
+ *   - `{kind: 'rejected', reason}` — an authored-content gate failed (bad regex
+ *     in the target or in `requires`, an unresolvable `language`, a malformed
+ *     ast-grep tree, a V1-inexpressible NapiConfig key). Loud and counted, never
+ *     silent; the reason names the governing § so the author is sent to the spec.
+ *
+ * THROWS on a producer-contract violation — a missing/malformed `ruleId`, a key
+ * with no defined lowering, or an engine-binding divergence. These are bugs in
+ * the code that CALLED this function, not defects in the author's record, and
+ * they carry the incumbent's fail-loud idiom (`compile.ts: compileCandidate`)
+ * verbatim: assert up front, before any validation work, so a violation can
+ * never be masked by a coincidental `rejected` outcome.
+ */
+export function compileRuleRecord(
+  parsed: ParsedRuleRecord,
+  opts: CompileRuleRecordOptions,
+): CompileOutcome {
+  // ── Identity precondition, asserted UP FRONT (ADR-112 §8/§9) ──
+  if (!AUTHORED_RULE_ID_RE.test(opts.ruleId)) {
+    throw new Error(
+      `[Totem Error] compileRuleRecord: malformed ruleId '${opts.ruleId}' — identity is minted by the ADR-112 §8 producer at the intake seam and threaded in (16 hex + optional -<n> suffix, ADR-112 §3/§8). The record grammar makes 'ruleId' INEXPRESSIBLE in-record (Prop 310 § Design 3/R17), so a malformed value here is a producer/threading bug; enthroning it would orphan the rule's controls.positive[].targetRuleId.`,
+    );
+  }
+
+  const record = parsed.record;
+
+  // ── § Design 12 — no construct is accepted at parse and dropped at compile ──
+  assertTotalLowering(record);
+
+  const target = record.target;
+
+  // ── Engine gates (§ Design 12: fail loud, never accept-then-drop) ──
+  //
+  // `requires.pattern` is gated on EVERY engine, not just regex: § Design 8 makes
+  // it "a safe-regex2-gated regex evaluated textually … independent of
+  // `target.type`", so an ast-grep rule's requirement is subject to the same
+  // ReDoS gate as a regex rule's target. Gated BEFORE the target payload so the
+  // author gets the first defect in a fixed, deterministic order.
+  if (record.requires !== undefined) {
+    const v = validateRegex(record.requires.pattern);
+    if (!v.valid) {
+      return {
+        kind: 'rejected',
+        reason: `Prop 310 § Design 8: requires.pattern is not a usable regex (${v.reason ?? 'invalid regex pattern'}) — the requirement is a safe-regex2-gated regex evaluated textually at the declared scope, independent of target.type.`,
+      };
+    }
+  }
+
+  let payloadFields: {
+    pattern: string;
+    astGrepPattern?: string;
+    astGrepYamlRule?: unknown;
+  };
+  let resolvedLanguage: string | undefined;
+
+  if (target.type === 'regex') {
+    // The record grammar guarantees `pattern` present and `rule`/`language` absent
+    // for `type: regex`; the non-null assertion is the schema's contract, not an
+    // assumption (`RuleTargetSchema.superRefine`).
+    const pattern = target.pattern!;
+    const v = validateRegex(pattern);
+    if (!v.valid) {
+      return {
+        kind: 'rejected',
+        reason: `Prop 310 § Design 6: target.pattern is not a usable regex (${v.reason ?? 'invalid regex pattern'}).`,
+      };
+    }
+    payloadFields = engineFields('regex', pattern);
+  } else {
+    // ── ast-grep: resolve the language FIRST, then validate under exactly it ──
+    const resolution = resolveRecordLanguage(target.language!);
+    if (!resolution.resolved) return { kind: 'rejected', reason: resolution.reason };
+    resolvedLanguage = resolution.language;
+    const probeGlobs = languageProbeGlobs(resolution.extension);
+
+    if (target.rule !== undefined) {
+      const inexpressible = V1_INEXPRESSIBLE_NAPI_KEYS.find((key) => key in target.rule!);
+      if (inexpressible !== undefined) {
+        return {
+          kind: 'rejected',
+          reason: `Prop 310 § Design 4 (operator ruling 2026-08-21, tree-form): 'target.rule' is the ast-grep RULE TREE, and '${inexpressible}' is a NapiConfig SIBLING of the rule — inexpressible at V1 (zero of the 19 compound corpus rules use it). Demand is typed as a construct-gap at the § Design 15 trial and lands by grammar version bump with its own home under 'target:', never smuggled inside the tree.`,
+        };
+      }
+      // The tree-form ruling's derivation: the record carries the TREE, the
+      // lowering builds the wrapper. `language` is derived from the resolved
+      // `target.language`, so the record never carries a duplicate language home.
+      const napiConfig = {
+        rule: target.rule,
+        language: extensionToLang(resolution.extension),
+      };
+      const v = validateAstGrepPattern(napiConfig, probeGlobs);
+      if (!v.valid) {
+        return {
+          kind: 'rejected',
+          reason: `Prop 310 § Design 6: target.rule failed ast-grep validation under the declared language '${resolvedLanguage}' (${v.reason ?? 'invalid ast-grep rule'}). V1 validates under exactly the declared grammar — the shipped try-each-glob-derived-Lang cross-grammar acceptance does not apply on the record path.`,
+        };
+      }
+      payloadFields = engineFields('ast-grep', napiConfig);
+    } else {
+      const pattern = target.pattern!;
+      const v = validateAstGrepPattern(pattern, probeGlobs);
+      if (!v.valid) {
+        return {
+          kind: 'rejected',
+          reason: `Prop 310 § Design 6: target.pattern failed ast-grep validation under the declared language '${resolvedLanguage}' (${v.reason ?? 'invalid ast-grep pattern'}). V1 validates under exactly the declared grammar — the shipped try-each-glob-derived-Lang cross-grammar acceptance does not apply on the record path.`,
+        };
+      }
+      payloadFields = engineFields('ast-grep', pattern);
+    }
+  }
+
+  // ── § Design 3 engine binding, asserted on two INDEPENDENTLY-derived sides ──
+  const payloadEngine = engineFromCompiledFields(payloadFields);
+  if (payloadEngine !== parsed.derivedEngine) {
+    throw new Error(
+      `[Totem Error] compileRuleRecord: record declared target.type '${parsed.derivedEngine}' but its payload compiled as '${payloadEngine}' — the two sides originate differently (the record's target.type vs the payload's actual compilation path), so this divergence is a lowering bug, not an authoring one (Prop 310 § Design 3, ADR-112 §3).`,
+    );
+  }
+
+  const heading = recordHeading(opts.ruleId);
+  const rule = CompiledRuleSchema.parse({
+    // ADR-112 §8/§9 id-unification: the compiled identity IS the minted ruleId.
+    lessonHash: opts.ruleId,
+    lessonHeading: heading,
+    message: record.message,
+    engine: parsed.derivedEngine,
+    ...payloadFields,
+    // § Design 7 — VERBATIM. `sanitizeFileGlobs` never runs on this path: the
+    // strict dialect already validated these at parse, and expansion/promotion
+    // are the silent transforms the grammar exists to kill.
+    fileGlobs: [...record.target.scope.fileGlobs],
+    ...(record.target.scope.excludeGlobs !== undefined
+      ? { excludeGlobs: [...record.target.scope.excludeGlobs] }
+      : {}),
+    severity: record.severity,
+    ...(record.recoveryHint !== undefined ? { recoveryHint: record.recoveryHint } : {}),
+    examples: record.examples.map((example) => ({ bad: example.bad, good: example.good })),
+    ...(record.requires !== undefined
+      ? { requires: { pattern: record.requires.pattern, scope: record.requires.scope } }
+      : {}),
+    ...(record.curation !== undefined ? { curation: { ...record.curation } } : {}),
+    // § Design 9 / Amendment R4 — carried VERBATIM, never evaluated at V1. The
+    // record key's named snake_case exception is renamed exactly here, once.
+    ...(record.verification_shadow !== undefined
+      ? { verificationShadow: { ...record.verification_shadow } }
+      : {}),
+    ...(resolvedLanguage !== undefined ? { language: resolvedLanguage } : {}),
+    compiledAt: opts.now,
+    createdAt: opts.now,
+    // Yellow / sensor-only, exactly as the authored path (§ Design "State-surface
+    // backing": every rule minted from this grammar enters unverified, ADR-112
+    // §1). `legitimacy`/`ruleClass` stay ABSENT — the sense→enforce crossing is
+    // priced by the Amendment's proof-required ruling, never by this lowering.
+    unverified: true,
+  });
+
+  return { kind: 'compiled', rule };
+}

--- a/packages/core/src/spine/record-runtime.test.ts
+++ b/packages/core/src/spine/record-runtime.test.ts
@@ -37,7 +37,10 @@ import { matchesRecordGlob } from '../sys/glob.js';
 import { design4ExemplarRecord, design8ExemplarRecord } from './record-exemplars.fixture.js';
 import { compileRuleRecord } from './record-lower.js';
 import {
+  assertNoAstGrepLineScope,
   assertNoTornRecordRules,
+  assertRequiresPatternsSafe,
+  isInsideRoot,
   isRecordPathRule,
   recordScopeMatchesFile,
   requiresSuppressesMatch,
@@ -672,6 +675,148 @@ describe('§ Design 12 — a rule that is neither record nor legacy fails LOUD',
   });
 });
 
+// ─── Runtime safety gates on a hand-edited manifest ──────────────────────────
+
+describe('§ Design 8 — runtime gates on a torn manifest', () => {
+  /** A record-shaped rule (carries `examples`) with a hand-set requires block. */
+  function handEdited(requires: Record<string, unknown>, engine = 'regex'): CompiledRule {
+    return CompiledRuleSchema.parse({
+      lessonHash: 'fedcba9876543210',
+      lessonHeading: 'hand-edited rule',
+      pattern: 'console\\.log',
+      message: 'x',
+      engine,
+      compiledAt: NOW,
+      fileGlobs: ['**/*.ts'],
+      examples: [{ bad: 'b', good: 'g' }],
+      ...(engine === 'ast-grep' ? { astGrepPattern: 'console.log($A)' } : {}),
+      requires,
+    });
+  }
+
+  it('rejects a ReDoS-shaped requires.pattern BEFORE evaluating it', () => {
+    // The compile gate runs safe-regex2 on this exact field, so an unsafe pattern
+    // here means a bypassed producer. At `scope: file` it would run unbounded
+    // against whole-file text on the pre-commit path.
+    const unsafe = handEdited({ pattern: '(a+)+$', scope: 'file' });
+    expect(() => assertRequiresPatternsSafe([unsafe])).toThrow(/ReDoS/);
+    expect(() =>
+      applyRulesToAdditions(ctx(), [unsafe], [addition('src/a.ts', 'console.log(1)')]),
+    ).toThrow(/unusable `requires.pattern`/);
+  });
+
+  it('rejects an uncompilable requires.pattern at the same gate', () => {
+    expect(() => assertRequiresPatternsSafe([handEdited({ pattern: '(', scope: 'line' })])).toThrow(
+      /invalid syntax/,
+    );
+  });
+
+  it('passes a safe pattern and every legacy rule untouched', () => {
+    expect(() =>
+      assertRequiresPatternsSafe([handEdited({ pattern: 'LC_ALL=C', scope: 'line' })]),
+    ).not.toThrow();
+    expect(() => assertRequiresPatternsSafe([legacyRule(['**/*.ts'])])).not.toThrow();
+  });
+
+  it('rejects `ast-grep` + `requires.scope: line` — the span-vs-line backstop', async () => {
+    // The lowering refuses this combination; a hand-edited manifest can still
+    // carry it, and the ast dispatcher would evaluate `match.lineText`.
+    const offender = handEdited({ pattern: 'LC_ALL=C', scope: 'line' }, 'ast-grep');
+    expect(() => assertNoAstGrepLineScope([offender])).toThrow(
+      /`requires\.scope: line` on the `ast-grep` engine/,
+    );
+    // The span-vs-line GROUNDS travel with the error, in its recovery hint.
+    try {
+      assertNoAstGrepLineScope([offender]);
+      expect.unreachable('expected the backstop to throw');
+    } catch (err) {
+      expect((err as { recoveryHint?: string }).recoveryHint).toContain(
+        'an ast-grep match is a SPAN',
+      );
+    }
+    await expect(
+      applyAstRulesToAdditions(
+        ctx(),
+        [offender],
+        [addition('src/a.ts', 'console.log(1)')],
+        os.tmpdir(),
+        undefined,
+        undefined,
+        async () => 'console.log(1)',
+      ),
+    ).rejects.toThrow(/`requires\.scope: line` on the `ast-grep` engine/);
+  });
+
+  it('leaves `ast-grep` + `file` and `regex` + `line` alone', () => {
+    expect(() =>
+      assertNoAstGrepLineScope([handEdited({ pattern: 'x', scope: 'file' }, 'ast-grep')]),
+    ).not.toThrow();
+    expect(() =>
+      assertNoAstGrepLineScope([handEdited({ pattern: 'x', scope: 'line' })]),
+    ).not.toThrow();
+  });
+});
+
+describe('§ Design 8 — the whole-file readers stay inside the root', () => {
+  it('treats an out-of-root path as unreadable, so the rule FIRES', () => {
+    // Diff-supplied paths are attacker-shaped on any lint over contributed
+    // changes. Containment yields "unreadable", which keeps the documented
+    // fail-toward-flagging direction rather than inventing a new failure mode.
+    expect(isInsideRoot(os.tmpdir(), '../outside.sh')).toBe(false);
+    expect(isInsideRoot(os.tmpdir(), 'nested/inside.sh')).toBe(true);
+    // A sibling-directory prefix must NOT pass — the reason for `path.relative`
+    // over a `startsWith` string test.
+    expect(isInsideRoot('/app', '../app-secrets/x.sh')).toBe(false);
+
+    const rule = compile({
+      ...design8ExemplarRecord(),
+      requires: { pattern: 'LC_ALL=C', scope: 'file' },
+    });
+    const violations = applyRulesToAdditions(
+      ctx(),
+      [rule],
+      [addition('../escape/x.sh', 'git log --oneline')],
+      undefined,
+      os.tmpdir(),
+    );
+    expect(violations).toHaveLength(1);
+  });
+
+  it('applies containment on the bounded dispatcher too', async () => {
+    const evaluator = new RegexEvaluator();
+    try {
+      const rule = compile({
+        ...design8ExemplarRecord(),
+        requires: { pattern: 'LC_ALL=C', scope: 'file' },
+      });
+      const result = await applyRulesToAdditionsBounded(
+        ctx(),
+        [rule],
+        [addition('../escape/x.sh', 'git log --oneline')],
+        { evaluator, timeoutMode: 'strict', repoRoot: os.tmpdir() },
+      );
+      expect(result.violations).toHaveLength(1);
+    } finally {
+      await evaluator.dispose();
+    }
+  });
+});
+
+describe('§ Design 8 — the compiled requires pattern is cached, not recompiled', () => {
+  it('returns identical verdicts across repeated evaluation (cache is transparent)', () => {
+    const rule = compile(design8ExemplarRecord());
+    const absent = { line: 'git log --oneline', file: () => null };
+    const present = { line: 'LC_ALL=C git log --oneline', file: () => null };
+    // Repeated because the cache is only exercised from the second call on, and a
+    // stateful `lastIndex` bug (a cached /g/ regex) would surface as an
+    // ALTERNATING verdict rather than a constant one.
+    for (let i = 0; i < 5; i += 1) {
+      expect(requiresSuppressesMatch(rule, absent)).toBe(false);
+      expect(requiresSuppressesMatch(rule, present)).toBe(true);
+    }
+  });
+});
+
 // ─── Certification seams — Stage 4 and the wind tunnel ───────────────────────
 
 describe('Stage 4 — record scope is visible, and “unscoped” does not invert', () => {
@@ -716,7 +861,16 @@ describe('Stage 4 — record scope is visible, and “unscoped” does not inver
       emptyBaseline,
       deps('packages/core/src/a.ts', 'console.log(1)\n'),
     );
-    expect(result.outcome).not.toBe('no-matches');
+    // EXACT outcome, not merely "not no-matches": `candidate-debt` is the ceiling
+    // a record rule can reach today. `in-scope-bad-example` requires the matched
+    // line to equal `rule.badExample`, and the lowering deliberately does NOT
+    // mirror `examples[0].bad` onto that legacy field (Tenet 20 — one editable
+    // home), so `lineMatchesBadExample` returns false for every record rule and
+    // the outcome always lands here. That carries a real consequence downstream:
+    // `candidate-debt` forces `severity: 'warning'`, so a record rule cannot be
+    // Stage-4-promoted to high confidence until intake supplies a badExample
+    // derivation (slice 3). Pinned so that change is visible when it lands.
+    expect(result.outcome).toBe('candidate-debt');
     expect(result.baselineMatches).toEqual([]);
   });
 
@@ -726,8 +880,10 @@ describe('Stage 4 — record scope is visible, and “unscoped” does not inver
       emptyBaseline,
       deps('src/a.ts', 'console.log(1)\n'),
     );
-    expect(result.outcome).not.toBe('no-matches');
-    expect(result.outcome).not.toBe('out-of-scope');
+    // Same exact-outcome discipline: this fixture carries no `badExample`
+    // either, so `candidate-debt` is the shipped answer and any drift shows up
+    // here rather than passing a loose negative assertion.
+    expect(result.outcome).toBe('candidate-debt');
   });
 });
 

--- a/packages/core/src/spine/record-runtime.test.ts
+++ b/packages/core/src/spine/record-runtime.test.ts
@@ -1,0 +1,451 @@
+// ─── Prop 310 § Design 14 — conformance suite, slice 2: RUNTIME EVALUATION ───
+//
+// What a lowered record MEANS when `totem lint` runs. Three obligations:
+//
+//   § Design 7 — the two-array scope rule AND the dialect's own matching
+//                semantics, including the "no silent promotion" clause slice 1
+//                deferred to this slice: `*.ts` is ROOT-LEVEL, tree-wide is
+//                written `**\/*.ts`. Slice 1 could only pin that a glob is
+//                CARRIED verbatim; only a matcher can pin what it MEANS.
+//   § Design 8 — the `requires:` two-pass, at both implemented scopes, positive
+//                and negative, plus the end-to-end differential over the spec's
+//                own exemplar (fire on `bad`, silent on `good` — ADR-112 §4).
+//   Non-regression — the legacy corpus keeps the shipped matcher byte-for-byte.
+//                    The record dialect is reachable ONLY through the § Design 12
+//                    compiled homes, and the promotion tests below assert BOTH
+//                    directions: promoted on the legacy path, not on the record
+//                    path, from the same glob string.
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { stringify as yamlStringify } from 'yaml';
+
+import { type CompiledRule, CompiledRuleSchema, type DiffAddition } from '../compiler-schema.js';
+import {
+  applyAstRulesToAdditions,
+  applyRulesToAdditions,
+  matchesGlob,
+  type RuleEngineContext,
+} from '../rule-engine.js';
+import { matchesRecordGlob } from '../sys/glob.js';
+import { design4ExemplarRecord, design8ExemplarRecord } from './record-exemplars.fixture.js';
+import { compileRuleRecord } from './record-lower.js';
+import {
+  isRecordPathRule,
+  recordScopeMatchesFile,
+  requiresSuppressesMatch,
+  ruleAppliesToFile,
+} from './record-runtime.js';
+import { parseRuleRecord } from './rule-record.js';
+
+const FILE = '.totem/rules/exemplar.rule.yaml';
+const RULE_ID = '0123456789abcdef';
+const NOW = '2026-08-21T00:00:00.000Z';
+
+function ctx(): RuleEngineContext {
+  return { logger: { warn: () => {} }, state: { hasWarnedShieldContext: false } };
+}
+
+/** Parse (slice 1) → lower (slice 2). Throws on a rejection so a fixture defect is loud. */
+function compile(record: Record<string, unknown>): CompiledRule {
+  const outcome = compileRuleRecord(parseRuleRecord(yamlStringify(record), FILE), {
+    ruleId: RULE_ID,
+    now: NOW,
+  });
+  if (outcome.kind !== 'compiled') throw new Error(`fixture did not lower: ${outcome.reason}`);
+  return outcome.rule;
+}
+
+function addition(file: string, line: string, lineNumber = 1): DiffAddition {
+  return { file, line, lineNumber, precedingLine: null };
+}
+
+/** A record-path regex rule scoped to exactly the globs given. */
+function scopedRegexRecord(fileGlobs: string[], excludeGlobs?: string[]): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    severity: 'error',
+    message: 'no console.log',
+    target: {
+      type: 'regex',
+      pattern: 'console\\.log',
+      scope: { fileGlobs, ...(excludeGlobs ? { excludeGlobs } : {}) },
+    },
+    examples: [{ bad: 'console.log(1)', good: 'logger.info(1)' }],
+  };
+}
+
+/** A LEGACY-shaped compiled rule: carries none of the § Design 12 homes. */
+function legacyRule(fileGlobs: string[]): CompiledRule {
+  return CompiledRuleSchema.parse({
+    lessonHash: 'fedcba9876543210',
+    lessonHeading: 'legacy rule',
+    pattern: 'console\\.log',
+    message: 'no console.log',
+    engine: 'regex',
+    severity: 'error',
+    compiledAt: NOW,
+    fileGlobs,
+  });
+}
+
+// ─── F. § Design 7 — dialect semantics, and the silent-promotion half ────────
+
+describe('§ Design 7 — the record dialect means what the glob says', () => {
+  it('matches `*.ts` at ROOT LEVEL ONLY (no silent promotion)', () => {
+    expect(matchesRecordGlob('a.ts', '*.ts')).toBe(true);
+    expect(matchesRecordGlob('src/a.ts', '*.ts')).toBe(false);
+    expect(matchesRecordGlob('packages/core/src/a.ts', '*.ts')).toBe(false);
+  });
+
+  it('matches `**\\/*.ts` TREE-WIDE, including the root', () => {
+    expect(matchesRecordGlob('a.ts', '**/*.ts')).toBe(true);
+    expect(matchesRecordGlob('src/a.ts', '**/*.ts')).toBe(true);
+    expect(matchesRecordGlob('packages/core/src/a.ts', '**/*.ts')).toBe(true);
+    expect(matchesRecordGlob('src/a.js', '**/*.ts')).toBe(false);
+  });
+
+  it('keeps the LEGACY matcher’s promotion byte-for-byte (the non-regression half)', () => {
+    // Same glob string, opposite meaning, and that is the point: the shipped
+    // rule-engine profile promotes a shallow glob tree-wide, which is exactly the
+    // silent semantic rewrite § Design 7 removes — on the record path ONLY.
+    expect(matchesGlob('src/a.ts', '*.ts')).toBe(true);
+    expect(matchesGlob('a.ts', '*.ts')).toBe(true);
+  });
+
+  it('anchors segments: `**` is whole-segment and `packages/**` is a subtree', () => {
+    expect(matchesRecordGlob('packages/core/src/a.ts', 'packages/**/*.ts')).toBe(true);
+    expect(matchesRecordGlob('packages/a.ts', 'packages/**/*.ts')).toBe(true);
+    expect(matchesRecordGlob('other/core/a.ts', 'packages/**/*.ts')).toBe(false);
+    expect(matchesRecordGlob('packages/core/src/a.ts', 'packages/**')).toBe(true);
+    expect(matchesRecordGlob('packages', 'packages/**')).toBe(false);
+    // `*` never crosses a separator.
+    expect(matchesRecordGlob('src/core/a.ts', 'src/*/a.ts')).toBe(true);
+    expect(matchesRecordGlob('src/core/deep/a.ts', 'src/*/a.ts')).toBe(false);
+  });
+
+  it('is CASE-SENSITIVE against path names, regardless of host case-folding', () => {
+    expect(matchesRecordGlob('a.ts', '*.TS')).toBe(false);
+    expect(matchesRecordGlob('SRC/a.ts', 'src/*.ts')).toBe(false);
+    expect(matchesRecordGlob('src/a.ts', 'src/*.ts')).toBe(true);
+  });
+
+  it('normalizes HOST separators on the path before evaluating', () => {
+    // Records use `/` exclusively (a backslash in a glob is a parse error), and
+    // "matchers normalize host separators before evaluation" — so a Windows-shaped
+    // path still matches a `/`-written glob.
+    expect(matchesRecordGlob('src\\a.ts', 'src/*.ts')).toBe(true);
+    expect(matchesRecordGlob('packages\\core\\src\\a.ts', 'packages/**/*.ts')).toBe(true);
+  });
+
+  it('admits NO brace expansion (a hand-edited manifest cannot smuggle one in)', () => {
+    expect(matchesRecordGlob('a.ts', '*.{ts,js}')).toBe(false);
+    expect(matchesRecordGlob('a.{ts,js}', '*.{ts,js}')).toBe(true);
+  });
+});
+
+// ─── G. § Design 7 — the two-array scope rule ────────────────────────────────
+
+describe('§ Design 7 — a file is in scope iff it matches a positive and NO exclusion', () => {
+  it('applies exclusions as POSITIVE-form globs (`positiveMatch && !excludeMatch`)', () => {
+    const rule = compile(design4ExemplarRecord());
+    expect(rule.excludeGlobs).toEqual(['**/*.test.ts']);
+    expect(ruleAppliesToFile(rule, 'packages/core/src/a.ts')).toBe(true);
+    expect(ruleAppliesToFile(rule, 'packages/core/src/a.test.ts')).toBe(false);
+    expect(ruleAppliesToFile(rule, 'scripts/a.ts')).toBe(false);
+  });
+
+  it('needs a positive match first — an exclusion alone never widens scope', () => {
+    expect(recordScopeMatchesFile('src/a.ts', ['src/*.ts'], ['**/*.test.ts'])).toBe(true);
+    expect(recordScopeMatchesFile('src/a.test.ts', ['src/*.ts'], ['**/*.test.ts'])).toBe(false);
+    expect(recordScopeMatchesFile('other/a.ts', ['src/*.ts'], undefined)).toBe(false);
+    // Empty positives match NOTHING on the record path — never everything.
+    expect(recordScopeMatchesFile('src/a.ts', [], undefined)).toBe(false);
+    expect(recordScopeMatchesFile('src/a.ts', undefined, undefined)).toBe(false);
+  });
+
+  it('carries the no-promotion rule THROUGH the engine, not just the matcher', () => {
+    // The end-to-end half of slice 1's deferred silent-promotion fixture: a
+    // COMPILED `*.ts` scopes a real lint dispatch to the repo root, and the same
+    // rule written `**\/*.ts` scopes it tree-wide. Same source line, same engine,
+    // two globs — the only difference is what the dialect says they mean.
+    const shallow = compile(scopedRegexRecord(['*.ts']));
+    const deep = compile(scopedRegexRecord(['**/*.ts']));
+    const hit = 'console.log(1)';
+
+    expect(applyRulesToAdditions(ctx(), [shallow], [addition('a.ts', hit)])).toHaveLength(1);
+    expect(applyRulesToAdditions(ctx(), [shallow], [addition('src/a.ts', hit)])).toEqual([]);
+    expect(applyRulesToAdditions(ctx(), [deep], [addition('a.ts', hit)])).toHaveLength(1);
+    expect(applyRulesToAdditions(ctx(), [deep], [addition('src/a.ts', hit)])).toHaveLength(1);
+
+    // The legacy path from the SAME glob string still promotes — non-regression.
+    expect(
+      applyRulesToAdditions(ctx(), [legacyRule(['*.ts'])], [addition('src/a.ts', hit)]),
+    ).toHaveLength(1);
+  });
+
+  it('applies exclusions through the engine as well as the predicate', () => {
+    const rule = compile(scopedRegexRecord(['**/*.ts'], ['**/*.test.ts']));
+    const hit = 'console.log(1)';
+    expect(applyRulesToAdditions(ctx(), [rule], [addition('src/a.ts', hit)])).toHaveLength(1);
+    expect(applyRulesToAdditions(ctx(), [rule], [addition('src/a.test.ts', hit)])).toEqual([]);
+  });
+
+  it('routes a LEGACY rule through the shipped predicate, `!`-negation included', () => {
+    const legacy = legacyRule(['**/*.ts', '!**/*.test.ts']);
+    expect(isRecordPathRule(legacy)).toBe(false);
+    expect(ruleAppliesToFile(legacy, 'src/a.ts')).toBe(true);
+    expect(ruleAppliesToFile(legacy, 'src/a.test.ts')).toBe(false);
+    // Shipped unscoped behaviour: a rule with no globs applies everywhere.
+    expect(ruleAppliesToFile(legacyRule([]), 'anything.rs')).toBe(true);
+  });
+});
+
+// ─── H. § Design 8 — the requires two-pass ───────────────────────────────────
+
+describe('§ Design 8 — requires fires on ABSENT context and stays silent on PRESENT', () => {
+  const lineRule = compile(design8ExemplarRecord());
+  const fileRule = compile({
+    ...design8ExemplarRecord(),
+    requires: { pattern: 'LC_ALL=C', scope: 'file' },
+  });
+
+  it('line scope — absent context suppresses nothing, present context suppresses', () => {
+    expect(requiresSuppressesMatch(lineRule, { line: 'git log --oneline', file: () => null })).toBe(
+      false,
+    );
+    expect(
+      requiresSuppressesMatch(lineRule, {
+        line: 'LC_ALL=C git log --oneline',
+        file: () => null,
+      }),
+    ).toBe(true);
+  });
+
+  it('line scope is LINE-local — the same token elsewhere in the file does not count', () => {
+    const elsewhere = ['LC_ALL=C echo hi', 'git log --oneline'].join('\n');
+    expect(
+      requiresSuppressesMatch(lineRule, {
+        line: 'git log --oneline',
+        file: () => elsewhere,
+      }),
+    ).toBe(false);
+  });
+
+  it('file scope — the requirement is satisfied ANYWHERE in the file', () => {
+    const elsewhere = ['export LC_ALL=C', 'git log --oneline'].join('\n');
+    expect(
+      requiresSuppressesMatch(fileRule, { line: 'git log --oneline', file: () => elsewhere }),
+    ).toBe(true);
+    expect(
+      requiresSuppressesMatch(fileRule, {
+        line: 'git log --oneline',
+        file: () => 'git log --oneline',
+      }),
+    ).toBe(false);
+  });
+
+  it('file scope with an UNREADABLE file fails toward FLAGGING, never suppression', () => {
+    expect(requiresSuppressesMatch(fileRule, { line: 'git log --oneline', file: () => null })).toBe(
+      false,
+    );
+  });
+
+  it('never suppresses a rule that carries no requires block (every legacy rule)', () => {
+    expect(
+      requiresSuppressesMatch(legacyRule(['**/*.ts']), { line: 'anything', file: () => 'x' }),
+    ).toBe(false);
+  });
+
+  it('fails LOUD on an uncompilable requires.pattern (a hand-edited manifest)', () => {
+    const tampered = CompiledRuleSchema.parse({
+      ...lineRule,
+      requires: { pattern: '(', scope: 'line' },
+    });
+    expect(() => requiresSuppressesMatch(tampered, { line: 'x', file: () => null })).toThrow(
+      /invalid `requires.pattern`/,
+    );
+  });
+});
+
+// ─── I. End-to-end through the rule engine ───────────────────────────────────
+
+describe('end-to-end — parse → lower → evaluate (§ Design 8 exemplar, regex path)', () => {
+  const rule = compile(design8ExemplarRecord());
+
+  it('FIRES on its own `bad` example and stays SILENT on its `good`', () => {
+    const bad = applyRulesToAdditions(
+      ctx(),
+      [rule],
+      [addition('scripts/x.sh', 'git log --oneline')],
+    );
+    expect(bad).toHaveLength(1);
+    expect(bad[0]!.rule.lessonHash).toBe(RULE_ID);
+
+    const good = applyRulesToAdditions(
+      ctx(),
+      [rule],
+      [addition('scripts/x.sh', 'LC_ALL=C git log --oneline')],
+    );
+    expect(good).toEqual([]);
+  });
+
+  it('emits NO rule event when the required context is present — silence, not suppression', () => {
+    // § Design 8 makes the requirement part of the MATCH PREDICATE: a locus with
+    // its context present is not a match, so it is neither a violation nor a
+    // `suppress` telemetry row (which would misreport it as a directive escape).
+    const events: string[] = [];
+    applyRulesToAdditions(
+      ctx(),
+      [rule],
+      [addition('scripts/x.sh', 'LC_ALL=C git log --oneline')],
+      (kind) => events.push(kind),
+    );
+    expect(events).toEqual([]);
+
+    const firing: string[] = [];
+    applyRulesToAdditions(ctx(), [rule], [addition('scripts/x.sh', 'git log --oneline')], (kind) =>
+      firing.push(kind),
+    );
+    expect(firing).toEqual(['trigger']);
+  });
+
+  it('respects the record dialect at dispatch — `**\\/*.sh` matches, other extensions do not', () => {
+    expect(
+      applyRulesToAdditions(ctx(), [rule], [addition('scripts/x.ts', 'git log --oneline')]),
+    ).toEqual([]);
+    expect(
+      applyRulesToAdditions(ctx(), [rule], [addition('deep/nest/x.cjs', 'git log --oneline')]),
+    ).toHaveLength(1);
+  });
+});
+
+describe('end-to-end — a file-scoped requires reads the real file', () => {
+  let workDir: string;
+
+  beforeAll(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-p310-'));
+    fs.mkdirSync(path.join(workDir, 'scripts'), { recursive: true });
+    fs.writeFileSync(
+      path.join(workDir, 'scripts', 'pinned.sh'),
+      ['export LC_ALL=C', 'git log --oneline'].join('\n'),
+      'utf-8',
+    );
+    fs.writeFileSync(
+      path.join(workDir, 'scripts', 'unpinned.sh'),
+      ['git log --oneline'].join('\n'),
+      'utf-8',
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  const rule = compile({
+    ...design8ExemplarRecord(),
+    requires: { pattern: 'LC_ALL=C', scope: 'file' },
+  });
+
+  it('stays silent when the requirement is satisfied elsewhere in the file', () => {
+    const violations = applyRulesToAdditions(
+      ctx(),
+      [rule],
+      [addition('scripts/pinned.sh', 'git log --oneline', 2)],
+      undefined,
+      workDir,
+    );
+    expect(violations).toEqual([]);
+  });
+
+  it('fires when the file never satisfies the requirement', () => {
+    const violations = applyRulesToAdditions(
+      ctx(),
+      [rule],
+      [addition('scripts/unpinned.sh', 'git log --oneline')],
+      undefined,
+      workDir,
+    );
+    expect(violations).toHaveLength(1);
+  });
+
+  it('fires when the file cannot be read at all (fails toward flagging)', () => {
+    const violations = applyRulesToAdditions(
+      ctx(),
+      [rule],
+      [addition('scripts/absent.sh', 'git log --oneline')],
+      undefined,
+      workDir,
+    );
+    expect(violations).toHaveLength(1);
+  });
+});
+
+describe('end-to-end — parse → lower → evaluate (§ Design 4 exemplar, ast-grep path)', () => {
+  const rule = compile(design4ExemplarRecord());
+  const example = design4ExemplarRecord().examples as { bad: string; good: string }[];
+  const bad = example[0]!.bad;
+  const good = example[0]!.good;
+
+  async function run(file: string, source: string) {
+    return applyAstRulesToAdditions(
+      ctx(),
+      [rule],
+      [addition(file, source)],
+      os.tmpdir(),
+      undefined,
+      undefined,
+      async () => source,
+    );
+  }
+
+  it('FIRES on its own `bad` example (ADR-112 §4 fire-on-preimage)', async () => {
+    const violations = await run('packages/core/src/a.ts', bad);
+    expect(violations).toHaveLength(1);
+    expect(violations[0]!.rule.lessonHash).toBe(RULE_ID);
+    expect(violations[0]!.rule.message).toContain('fail-open catch is banned');
+  });
+
+  it('stays SILENT on its own `good` example (silent-on-postimage)', async () => {
+    expect(await run('packages/core/src/a.ts', good)).toEqual([]);
+  });
+
+  it('honours `excludeGlobs` at dispatch — the same bad source in a test file is out of scope', async () => {
+    expect(await run('packages/core/src/a.test.ts', bad)).toEqual([]);
+  });
+
+  it('honours the positive glob — the same bad source outside `packages/` is out of scope', async () => {
+    expect(await run('scripts/a.ts', bad)).toEqual([]);
+  });
+});
+
+// ─── Fail-loud backstop on the unevaluated branch ────────────────────────────
+
+describe('§ Design 12 — `requires` is never silently unevaluated', () => {
+  it('throws when a tree-sitter rule carries a requires block', async () => {
+    const astRule = CompiledRuleSchema.parse({
+      lessonHash: 'fedcba9876543210',
+      lessonHeading: 'hand-edited ast rule',
+      pattern: '',
+      message: 'x',
+      engine: 'ast',
+      astQuery: '(call_expression) @c',
+      compiledAt: NOW,
+      requires: { pattern: 'LC_ALL=C', scope: 'line' },
+    });
+    await expect(
+      applyAstRulesToAdditions(
+        ctx(),
+        [astRule],
+        [addition('src/a.ts', 'foo()')],
+        os.tmpdir(),
+        undefined,
+        undefined,
+        async () => 'foo()',
+      ),
+    ).rejects.toThrow(/has no two-pass evaluator/);
+  });
+});

--- a/packages/core/src/spine/record-runtime.test.ts
+++ b/packages/core/src/spine/record-runtime.test.ts
@@ -32,16 +32,19 @@ import {
   matchesGlob,
   type RuleEngineContext,
 } from '../rule-engine.js';
+import { verifyAgainstCodebase } from '../stage4-verifier.js';
 import { matchesRecordGlob } from '../sys/glob.js';
 import { design4ExemplarRecord, design8ExemplarRecord } from './record-exemplars.fixture.js';
 import { compileRuleRecord } from './record-lower.js';
 import {
+  assertNoTornRecordRules,
   isRecordPathRule,
   recordScopeMatchesFile,
   requiresSuppressesMatch,
   ruleAppliesToFile,
 } from './record-runtime.js';
 import { parseRuleRecord } from './rule-record.js';
+import { buildFirings } from './windtunnel-firing.js';
 
 const FILE = '.totem/rules/exemplar.rule.yaml';
 const RULE_ID = '0123456789abcdef';
@@ -606,6 +609,168 @@ describe('applyRulesToAdditionsBounded — the record semantics reach the lint p
   });
 });
 
+// ─── Torn-manifest guard (§ Design 12) ───────────────────────────────────────
+
+describe('§ Design 12 — a rule that is neither record nor legacy fails LOUD', () => {
+  function tornRule(extra: Record<string, unknown>): CompiledRule {
+    return CompiledRuleSchema.parse({
+      lessonHash: 'fedcba9876543210',
+      lessonHeading: 'hand-edited torn rule',
+      pattern: 'console\\.log',
+      message: 'x',
+      engine: 'regex',
+      compiledAt: NOW,
+      fileGlobs: ['**/*.ts'],
+      ...extra,
+    });
+  }
+
+  it('throws on a record home with no `examples` — the dropped constructs get a signal', () => {
+    for (const extra of [
+      { excludeGlobs: ['**/*.test.ts'] },
+      { requires: { pattern: 'x', scope: 'line' } },
+      { language: 'typescript' },
+      { verificationShadow: { type: 'rego', source: 'p' } },
+    ]) {
+      expect(() => assertNoTornRecordRules([tornRule(extra)])).toThrow(
+        /carries Prop 310 record field\(s\).*but no `examples`/s,
+      );
+    }
+  });
+
+  it('names the offending homes so the operator knows what would have been dropped', () => {
+    expect(() =>
+      assertNoTornRecordRules([
+        tornRule({ excludeGlobs: ['**/*.test.ts'], language: 'typescript' }),
+      ]),
+    ).toThrow(/excludeGlobs, language/);
+  });
+
+  it('leaves a clean LEGACY rule and a clean RECORD rule untouched', () => {
+    expect(() => assertNoTornRecordRules([legacyRule(['**/*.ts'])])).not.toThrow();
+    expect(() => assertNoTornRecordRules([compile(design4ExemplarRecord())])).not.toThrow();
+    expect(() => assertNoTornRecordRules([])).not.toThrow();
+  });
+
+  it('fires at DISPATCHER altitude on every regex path', async () => {
+    const torn = tornRule({ excludeGlobs: ['**/*.test.ts'] });
+    const hit = addition('src/a.ts', 'console.log(1)');
+    expect(() => applyRulesToAdditions(ctx(), [torn], [hit])).toThrow(/no `examples`/);
+
+    const evaluator = new RegexEvaluator();
+    try {
+      await expect(
+        applyRulesToAdditionsBounded(ctx(), [torn], [hit], {
+          evaluator,
+          timeoutMode: 'strict',
+          repoRoot: os.tmpdir(),
+        }),
+      ).rejects.toThrow(/no `examples`/);
+    } finally {
+      await evaluator.dispose();
+    }
+  });
+});
+
+// ─── Certification seams — Stage 4 and the wind tunnel ───────────────────────
+
+describe('Stage 4 — record scope is visible, and “unscoped” does not invert', () => {
+  // An EMPTY baseline, so every classification below is the RULE's scope talking
+  // and nothing else. Regex engine on purpose: this is a scope-classification
+  // test, and routing it through ast-grep would add a parser to the equation.
+  const emptyBaseline = {
+    excludeFileGlobs: [],
+    extendedFromIgnoreFile: [],
+    extendedFromConfig: [],
+    excludedFromConfig: [],
+  };
+  const record = compile(scopedRegexRecord(['packages/**/*.ts'], ['**/*.test.ts']));
+
+  function deps(file: string, content: string) {
+    return {
+      listFiles: async () => [file],
+      readFile: async () => content,
+      workingDirectory: os.tmpdir(),
+    };
+  }
+
+  it('classifies an EXCLUDED file as out-of-scope instead of over-broad firing', async () => {
+    // Passing bare `rule.fileGlobs` made `excludeGlobs` structurally invisible
+    // here, so a hit on a file the rule's own scope EXCLUDES read as an in-scope
+    // match — the rule looked over-broad because of a scope it never had.
+    const result = await verifyAgainstCodebase(
+      record,
+      emptyBaseline,
+      deps('packages/core/src/a.test.ts', 'console.log(1)\n'),
+    );
+    expect(result.outcome).toBe('out-of-scope');
+  });
+
+  it('still finds an IN-SCOPE match — the strip does not zero the record path', async () => {
+    // The inversion this guards: `runRuleAgainstAllFiles` expresses "fires
+    // everywhere" as ABSENT `fileGlobs`, which means include-all on the legacy
+    // matcher and match-NOTHING on the record dialect. Unfixed, every record rule
+    // Stage 4 ever verified would have reported `no-matches`.
+    const result = await verifyAgainstCodebase(
+      record,
+      emptyBaseline,
+      deps('packages/core/src/a.ts', 'console.log(1)\n'),
+    );
+    expect(result.outcome).not.toBe('no-matches');
+    expect(result.baselineMatches).toEqual([]);
+  });
+
+  it('leaves a LEGACY rule’s classification byte-identical', async () => {
+    const result = await verifyAgainstCodebase(
+      legacyRule(['**/*.ts']),
+      emptyBaseline,
+      deps('src/a.ts', 'console.log(1)\n'),
+    );
+    expect(result.outcome).not.toBe('no-matches');
+    expect(result.outcome).not.toBe('out-of-scope');
+  });
+});
+
+describe('wind tunnel — a file-scoped requirement reads the POST-IMAGE', () => {
+  const rule = compile({
+    ...design8ExemplarRecord(),
+    requires: { pattern: 'LC_ALL=C', scope: 'file' },
+  });
+  const diff = [
+    'diff --git a/scripts/x.sh b/scripts/x.sh',
+    '--- a/scripts/x.sh',
+    '+++ b/scripts/x.sh',
+    '@@ -1,1 +1,1 @@',
+    '+git log --oneline',
+    '',
+  ].join('\n');
+
+  async function fire(postImage: string) {
+    return buildFirings({
+      rules: [rule],
+      prDiffs: [{ pr: 1, diff, controlKind: 'corpus' as const }],
+      cwd: os.tmpdir(),
+      readStrategy: async () => postImage,
+      ruleEngineCtx: ctx(),
+    });
+  }
+
+  it('stays silent when the POST-IMAGE satisfies the requirement', async () => {
+    const result = await fire(['export LC_ALL=C', 'git log --oneline'].join('\n'));
+    expect(result.firings).toEqual([]);
+  });
+
+  it('fires when the POST-IMAGE does not — the local worktree never decides', async () => {
+    // The seam this closes: `applyRulesToAdditions` was called with five args, so
+    // the requirement was judged against whatever happened to be on the
+    // certifying machine's disk rather than the PR's post-image — the same class
+    // of divergence as the staged-read hole, in the certification corpus.
+    const result = await fire('git log --oneline');
+    expect(result.firings).toHaveLength(1);
+    expect(result.firings[0]!.ruleId).toBe(RULE_ID);
+  });
+});
+
 // ─── Fail-loud backstop on the unevaluated branch ────────────────────────────
 
 describe('§ Design 12 — `requires` is never silently unevaluated', () => {
@@ -618,6 +783,10 @@ describe('§ Design 12 — `requires` is never silently unevaluated', () => {
       engine: 'ast',
       astQuery: '(call_expression) @c',
       compiledAt: NOW,
+      // `examples` present, so this is a well-formed RECORD-shaped rule on the
+      // wrong engine — it reaches the tree-sitter backstop rather than being
+      // caught upstream as a torn manifest.
+      examples: [{ bad: 'b', good: 'g' }],
       requires: { pattern: 'LC_ALL=C', scope: 'line' },
     });
     await expect(
@@ -645,6 +814,7 @@ describe('§ Design 12 — `requires` is never silently unevaluated', () => {
       message: 'x',
       engine: 'ast',
       compiledAt: NOW,
+      examples: [{ bad: 'b', good: 'g' }],
       requires: { pattern: 'LC_ALL=C', scope: 'file' },
     });
     await expect(

--- a/packages/core/src/spine/record-runtime.test.ts
+++ b/packages/core/src/spine/record-runtime.test.ts
@@ -24,6 +24,8 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { stringify as yamlStringify } from 'yaml';
 
 import { type CompiledRule, CompiledRuleSchema, type DiffAddition } from '../compiler-schema.js';
+import { applyRulesToAdditionsBounded } from '../regex-safety/apply-rules-bounded.js';
+import { RegexEvaluator } from '../regex-safety/evaluator.js';
 import {
   applyAstRulesToAdditions,
   applyRulesToAdditions,
@@ -422,6 +424,188 @@ describe('end-to-end — parse → lower → evaluate (§ Design 4 exemplar, ast
   });
 });
 
+// ─── Cure 1 — the requirement reads the bytes the lint is judging ────────────
+
+describe('§ Design 8 — a file-scoped requirement honours the caller’s read seam', () => {
+  let workDir: string;
+  const rule = compile({
+    ...design8ExemplarRecord(),
+    requires: { pattern: 'LC_ALL=C', scope: 'file' },
+  });
+  const hit = addition('scripts/x.sh', 'git log --oneline');
+
+  beforeAll(() => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-p310-seam-'));
+    fs.mkdirSync(path.join(workDir, 'scripts'), { recursive: true });
+    // The WORKTREE satisfies the requirement.
+    fs.writeFileSync(
+      path.join(workDir, 'scripts', 'x.sh'),
+      ['export LC_ALL=C', 'git log --oneline'].join('\n'),
+      'utf-8',
+    );
+  });
+
+  afterAll(() => {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('FAIL-OPEN COUNTEREXAMPLE: context deleted in the staged edit is not excused by the worktree', () => {
+    // Without the seam this is the hole: the requirement is satisfied on disk,
+    // so the staged violation is suppressed and the commit passes. With the
+    // staged reader threaded, the requirement is judged on the staged bytes and
+    // the rule fires.
+    expect(applyRulesToAdditions(ctx(), [rule], [hit], undefined, workDir)).toEqual([]);
+    const staged = applyRulesToAdditions(
+      ctx(),
+      [rule],
+      [hit],
+      undefined,
+      workDir,
+      () => 'git log --oneline',
+    );
+    expect(staged).toHaveLength(1);
+  });
+
+  it('the inverse direction too: context added in the staged edit silences the rule', () => {
+    const worktreeOnly = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-p310-inv-'));
+    try {
+      fs.mkdirSync(path.join(worktreeOnly, 'scripts'), { recursive: true });
+      fs.writeFileSync(path.join(worktreeOnly, 'scripts', 'x.sh'), 'git log --oneline', 'utf-8');
+      expect(applyRulesToAdditions(ctx(), [rule], [hit], undefined, worktreeOnly)).toHaveLength(1);
+      expect(
+        applyRulesToAdditions(ctx(), [rule], [hit], undefined, worktreeOnly, () =>
+          ['export LC_ALL=C', 'git log --oneline'].join('\n'),
+        ),
+      ).toEqual([]);
+    } finally {
+      fs.rmSync(worktreeOnly, { recursive: true, force: true });
+    }
+  });
+
+  it('a reader that reports the file absent still FIRES (direction unchanged)', () => {
+    expect(
+      applyRulesToAdditions(ctx(), [rule], [hit], undefined, workDir, () => null),
+    ).toHaveLength(1);
+  });
+
+  it('a reader that THROWS propagates — its failure contract is not swallowed', () => {
+    // Staged mode's reader throws `STAGED_READ_FAILED` precisely so an unreadable
+    // index entry surfaces; converting that to "context absent" would turn a loud
+    // failure into a quiet one.
+    expect(() =>
+      applyRulesToAdditions(ctx(), [rule], [hit], undefined, workDir, () => {
+        throw new Error('STAGED_READ_FAILED');
+      }),
+    ).toThrow(/STAGED_READ_FAILED/);
+  });
+
+  it('never consults the reader for a LINE-scoped requirement', () => {
+    const lineRule = compile(design8ExemplarRecord());
+    let calls = 0;
+    applyRulesToAdditions(ctx(), [lineRule], [hit], undefined, workDir, () => {
+      calls += 1;
+      return null;
+    });
+    expect(calls).toBe(0);
+  });
+});
+
+// ─── Cure 1 (extended) — the dispatcher `totem lint` actually uses ───────────
+
+describe('applyRulesToAdditionsBounded — the record semantics reach the lint path', () => {
+  it('applies the § Design 7 two-array scope, not the legacy predicate', async () => {
+    // This dispatcher — not `applyRulesToAdditions` — is what `totem lint` runs
+    // regex rules through. Without the shared predicate a record rule's
+    // `excludeGlobs` is ignored here and its `*.ts` is promoted tree-wide: a
+    // silent scope WIDENING on the only path that ships.
+    const evaluator = new RegexEvaluator();
+    try {
+      const rule = compile(scopedRegexRecord(['*.ts'], ['**/*.test.ts']));
+      const result = await applyRulesToAdditionsBounded(
+        ctx(),
+        [rule],
+        [
+          addition('a.ts', 'console.log(1)'),
+          addition('src/a.ts', 'console.log(1)'),
+          addition('a.test.ts', 'console.log(1)'),
+        ],
+        { evaluator, timeoutMode: 'strict', repoRoot: os.tmpdir() },
+      );
+      expect(result.violations.map((v) => v.file)).toEqual(['a.ts']);
+    } finally {
+      await evaluator.dispose();
+    }
+  });
+
+  it('applies the § Design 8 two-pass, at line scope', async () => {
+    const evaluator = new RegexEvaluator();
+    try {
+      const rule = compile(design8ExemplarRecord());
+      const result = await applyRulesToAdditionsBounded(
+        ctx(),
+        [rule],
+        [
+          addition('scripts/a.sh', 'git log --oneline'),
+          addition('scripts/b.sh', 'LC_ALL=C git log --oneline'),
+        ],
+        { evaluator, timeoutMode: 'strict', repoRoot: os.tmpdir() },
+      );
+      expect(result.violations.map((v) => v.file)).toEqual(['scripts/a.sh']);
+    } finally {
+      await evaluator.dispose();
+    }
+  });
+
+  it('threads the staged reader into a FILE-scoped requirement', async () => {
+    const evaluator = new RegexEvaluator();
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-p310-bnd-'));
+    try {
+      fs.mkdirSync(path.join(dir, 'scripts'), { recursive: true });
+      fs.writeFileSync(
+        path.join(dir, 'scripts', 'x.sh'),
+        ['export LC_ALL=C', 'git log --oneline'].join('\n'),
+        'utf-8',
+      );
+      const rule = compile({
+        ...design8ExemplarRecord(),
+        requires: { pattern: 'LC_ALL=C', scope: 'file' },
+      });
+      const additions = [addition('scripts/x.sh', 'git log --oneline')];
+      const opts = { evaluator, timeoutMode: 'strict' as const, repoRoot: dir };
+
+      // Worktree read: the requirement is satisfied → silent.
+      const worktree = await applyRulesToAdditionsBounded(ctx(), [rule], additions, opts);
+      expect(worktree.violations).toEqual([]);
+
+      // Staged read: the requirement is gone from the index → fires.
+      const staged = await applyRulesToAdditionsBounded(ctx(), [rule], additions, {
+        ...opts,
+        readStrategy: async () => 'git log --oneline',
+      });
+      expect(staged.violations).toHaveLength(1);
+    } finally {
+      await evaluator.dispose();
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('leaves a LEGACY rule on the shipped predicate byte-for-byte', async () => {
+    const evaluator = new RegexEvaluator();
+    try {
+      const result = await applyRulesToAdditionsBounded(
+        ctx(),
+        [legacyRule(['*.ts'])],
+        [addition('src/a.ts', 'console.log(1)')],
+        { evaluator, timeoutMode: 'strict', repoRoot: os.tmpdir() },
+      );
+      // Shallow-glob promotion survives on the legacy path.
+      expect(result.violations).toHaveLength(1);
+    } finally {
+      await evaluator.dispose();
+    }
+  });
+});
+
 // ─── Fail-loud backstop on the unevaluated branch ────────────────────────────
 
 describe('§ Design 12 — `requires` is never silently unevaluated', () => {
@@ -435,6 +619,33 @@ describe('§ Design 12 — `requires` is never silently unevaluated', () => {
       astQuery: '(call_expression) @c',
       compiledAt: NOW,
       requires: { pattern: 'LC_ALL=C', scope: 'line' },
+    });
+    await expect(
+      applyAstRulesToAdditions(
+        ctx(),
+        [astRule],
+        [addition('src/a.ts', 'foo()')],
+        os.tmpdir(),
+        undefined,
+        undefined,
+        async () => 'foo()',
+      ),
+    ).rejects.toThrow(/has no two-pass evaluator/);
+  });
+
+  it('throws even when the ast rule carries NO astQuery (the widened search)', async () => {
+    // The backstop searched `treeSitterRules`, which is pre-filtered on
+    // `astQuery` being present — so this shape slipped past the throw and had its
+    // `requires` silently unevaluated, which is the exact hole the backstop
+    // exists to close.
+    const astRule = CompiledRuleSchema.parse({
+      lessonHash: 'fedcba9876543210',
+      lessonHeading: 'hand-edited ast rule, no query',
+      pattern: '',
+      message: 'x',
+      engine: 'ast',
+      compiledAt: NOW,
+      requires: { pattern: 'LC_ALL=C', scope: 'file' },
     });
     await expect(
       applyAstRulesToAdditions(

--- a/packages/core/src/spine/record-runtime.ts
+++ b/packages/core/src/spine/record-runtime.ts
@@ -55,12 +55,30 @@ export const RECORD_COMPILED_HOME_KEYS = [
 
 /**
  * True when a compiled rule came from the Prop 310 record path — i.e. when the
- * § Design 7 dialect, the § Design 7 two-array scope rule, and the § Design 8
- * two-pass apply to it. False for every legacy/mined rule, which keeps the
- * shipped matcher unchanged.
+ * § Design 7 dialect and its two-array scope rule apply to it. False for every
+ * legacy/mined rule, which keeps the shipped matcher unchanged.
+ *
+ * The test is `examples !== undefined` ALONE, deliberately narrower than "any
+ * § Design 12 home" (falsification round, 2026-08-21). `examples` is the EXACT
+ * discriminator, not merely a sufficient one:
+ *   - § Design 5 makes it non-omittable and min-1, so EVERY record carries it;
+ *   - `compileRuleRecord` emits it unconditionally, so every lowered rule has it;
+ *   - it is the one home no other construct can be present without.
+ *
+ * The wider seven-key disjunction was demonstrated to be UNSAFE in the other
+ * direction: a legacy-shaped rule that ever gained just a `recoveryHint` — a
+ * plausible future addition to the mined path, and a purely cosmetic one — would
+ * silently flip from the shipped tree-wide matcher to the record dialect's
+ * root-only reading of the same `*.ts` glob, narrowing its scope with no signal.
+ * Keying on the field that MEANS "this is a record" removes that coupling
+ * between a diagnostic field and a matcher semantic.
+ *
+ * `RECORD_COMPILED_HOME_KEYS` remains the full home set for the corpus guard
+ * (which asserts the legacy manifest carries NONE of them — a stronger claim
+ * than this predicate needs, and the right one for a freeze check).
  */
 export function isRecordPathRule(rule: CompiledRule): boolean {
-  return RECORD_COMPILED_HOME_KEYS.some((key) => rule[key] !== undefined);
+  return rule.examples !== undefined;
 }
 
 /**

--- a/packages/core/src/spine/record-runtime.ts
+++ b/packages/core/src/spine/record-runtime.ts
@@ -1,0 +1,177 @@
+// ─── Prop 310 V1 record grammar — RUNTIME EVALUATION (slice 2 of the V1 build) ─
+//
+// The § Design 12 lowering says what a construct BECOMES on the compiled rule;
+// this module says what it MEANS when `totem lint` runs. Two constructs need a
+// runtime semantic the shipped engine does not have:
+//
+//   § Design 7 — the two-array scope rule. A file is in scope iff it matches some
+//                `fileGlobs` entry AND matches no `excludeGlobs` entry. Exclusion
+//                is STRUCTURAL: entries are positive-form globs applied as
+//                exclusions, never `!`-negation (a parse error in the grammar).
+//   § Design 8 — the `requires:` two-pass. On a target match at locus L the rule
+//                FIRES iff `requires.pattern` does NOT match within the declared
+//                scope containing L.
+//
+// FREEZE / NON-REGRESSION BOUNDARY (binding): the legacy corpus (485 compiled
+// rules, `.totem/compiled-rules.json`, frozen by `rule-compilation`) must keep
+// matching BYTE-FOR-BYTE. Every function here is therefore gated on
+// `isRecordPathRule`, and the mined-path byte-identity guard in
+// `record-lower.test.ts` proves zero of the 485 legacy rules can reach a record
+// branch. Nothing in this module runs `sanitizeFileGlobs`, and it never imports
+// the frozen actuator.
+//
+// Purity: no IO, no clock, no module state. The `requires` evaluator takes the
+// file text as a LAZY resolver so the caller owns the read (and so a `line`-scope
+// requirement never forces one).
+
+import type { CompiledRule } from '../compiler-schema.js';
+import { TotemParseError } from '../errors.js';
+import { fileMatchesGlobs, matchesRecordGlob } from '../sys/glob.js';
+
+/**
+ * The Prop 310 compiled homes, as a runtime-readable list. A rule carrying ANY
+ * of them came from the record path; a rule carrying NONE is legacy.
+ *
+ * DERIVED, never mirrored (Tenet 20): the discriminator is the presence of the
+ * § Design 12 homes themselves, not a separate `dialect:` marker field — a marker
+ * would be a second, drift-capable statement of what the fields already say, and
+ * § Design 4's key space is closed against inventing one.
+ *
+ * The derivation is SAFE because nothing but the record path can write these
+ * fields: they were added to `CompiledRuleSchema` by this slice, and the only
+ * other writer (the legacy lesson-compile actuator) is under the standing
+ * `rule-compilation` freeze and does not regenerate. The byte-identity guard
+ * asserts the empirical half — zero of the shipped 485 rules carries any of them.
+ */
+export const RECORD_COMPILED_HOME_KEYS = [
+  'excludeGlobs',
+  'requires',
+  'examples',
+  'language',
+  'verificationShadow',
+  'recoveryHint',
+  'curation',
+] as const satisfies readonly (keyof CompiledRule)[];
+
+/**
+ * True when a compiled rule came from the Prop 310 record path — i.e. when the
+ * § Design 7 dialect, the § Design 7 two-array scope rule, and the § Design 8
+ * two-pass apply to it. False for every legacy/mined rule, which keeps the
+ * shipped matcher unchanged.
+ */
+export function isRecordPathRule(rule: CompiledRule): boolean {
+  return RECORD_COMPILED_HOME_KEYS.some((key) => rule[key] !== undefined);
+}
+
+/**
+ * § Design 7 — the two-array scope rule for a RECORD-path rule:
+ * `positiveMatch && !excludeMatch`, both arrays evaluated under the normative
+ * dialect (`matchesRecordGlob`).
+ *
+ * `fileGlobs` is min-1 at parse, so the empty-positive case cannot arise from a
+ * well-formed record; a hand-edited manifest that produced one would match
+ * NOTHING here rather than everything. That direction is deliberate — the
+ * shipped `fileMatchesGlobs` treats "no positive globs" as include-everything,
+ * which for a record-path rule would silently WIDEN a scope the grammar requires
+ * to be declared. A rule that fires nowhere is visible; one that fires everywhere
+ * is the fail-open class § Design 2 exists to kill.
+ */
+export function recordScopeMatchesFile(
+  filePath: string,
+  fileGlobs: readonly string[] | undefined,
+  excludeGlobs: readonly string[] | undefined,
+): boolean {
+  const positives = fileGlobs ?? [];
+  if (!positives.some((glob) => matchesRecordGlob(filePath, glob))) return false;
+  if (excludeGlobs === undefined) return true;
+  return !excludeGlobs.some((glob) => matchesRecordGlob(filePath, glob));
+}
+
+/**
+ * The ONE scope predicate the rule engine asks: does this rule apply to this
+ * file? Record-path rules get § Design 7's dialect + two-array rule; every other
+ * rule gets the shipped `fileMatchesGlobs` predicate verbatim, including its
+ * "unscoped rule applies to everything" behaviour.
+ *
+ * Single-homed on purpose: the engine had four separate copies of the
+ * `rule.fileGlobs && rule.fileGlobs.length > 0 ? fileMatchesGlobs(...) : true`
+ * expression, and four copies of a dialect fork is how a rule silently gets one
+ * scope at dispatch and a different one at the fail-loud guard.
+ */
+export function ruleAppliesToFile(rule: CompiledRule, filePath: string): boolean {
+  if (isRecordPathRule(rule)) {
+    return recordScopeMatchesFile(filePath, rule.fileGlobs, rule.excludeGlobs);
+  }
+  if (rule.fileGlobs && rule.fileGlobs.length > 0) {
+    return fileMatchesGlobs(filePath, rule.fileGlobs);
+  }
+  return true;
+}
+
+/**
+ * The text the § Design 8 scopes resolve to at a target-match locus L.
+ *
+ * `file` is a LAZY resolver returning `null` when the file cannot be read: the
+ * caller owns the IO, a `line`-scope requirement never triggers a read, and the
+ * unreadable case gets an explicit, documented direction below rather than an
+ * exception thrown from inside a matcher.
+ */
+export interface RequiresScopeText {
+  /** L's line — the text of the line the target matched on. */
+  line: string;
+  /** The whole file containing L, or `null` when unreadable. */
+  file: () => string | null;
+}
+
+/**
+ * § Design 8 — pass two. Returns TRUE when the required context is PRESENT
+ * within the declared scope containing L, i.e. when the rule must stay SILENT.
+ * The rule fires iff the target matched AND this returns false.
+ *
+ * `requires.pattern` is a regex evaluated TEXTUALLY, independent of the target
+ * engine — "the requirement is a context check, not a second matcher" — so an
+ * ast-grep rule's requirement is still a plain regex over the scope text.
+ *
+ * UNREADABLE FILE (`scope: file` only) ⇒ context ABSENT ⇒ the rule FIRES. The
+ * safe direction for a lint gate is toward flagging: a false positive is visible
+ * and disputable, a suppressed real violation is silent. This mirrors the shipped
+ * Rust test-span exemption, whose read failure likewise yields no exemption
+ * (`rule-engine.ts`: "the exemption fails toward flagging, never toward
+ * suppression").
+ *
+ * A `requires.pattern` that will not compile means the compile-stage gate was
+ * bypassed or the manifest was hand-edited. Fail LOUD — the same treatment
+ * `applyRulesToAdditions` gives an uncompilable `rule.pattern`; silently treating
+ * it as "context absent" would turn a broken rule into a firing one.
+ */
+export function requiresContextPresent(
+  rule: CompiledRule,
+  requires: NonNullable<CompiledRule['requires']>,
+  text: RequiresScopeText,
+): boolean {
+  let re: RegExp;
+  try {
+    re = new RegExp(requires.pattern);
+  } catch (err) {
+    throw new TotemParseError(
+      `Rule ${rule.lessonHash} has an invalid \`requires.pattern\` and cannot be evaluated (Prop 310 § Design 8).`,
+      `The record-path compile gate validates this pattern with the same safe-regex2 check it applies to the target, so an invalid one here means the manifest was hand-edited or written by a bypassed producer. Re-compile the rule record. Pattern: ${JSON.stringify(requires.pattern)}`,
+      err,
+    );
+  }
+  if (requires.scope === 'line') return re.test(text.line);
+  const fileText = text.file();
+  if (fileText === null) return false;
+  return re.test(fileText);
+}
+
+/**
+ * § Design 8 applied to one target match: TRUE when the rule must stay silent at
+ * this locus because its required context is present. Always false for a rule
+ * carrying no `requires` block — which is every legacy rule, so the shipped
+ * evaluation path is untouched by construction.
+ */
+export function requiresSuppressesMatch(rule: CompiledRule, text: RequiresScopeText): boolean {
+  if (rule.requires === undefined) return false;
+  return requiresContextPresent(rule, rule.requires, text);
+}

--- a/packages/core/src/spine/record-runtime.ts
+++ b/packages/core/src/spine/record-runtime.ts
@@ -24,9 +24,12 @@
 // file text as a LAZY resolver so the caller owns the read (and so a `line`-scope
 // requirement never forces one).
 
+import * as path from 'node:path';
+
 import type { CompiledRule } from '../compiler-schema.js';
 import { TotemParseError } from '../errors.js';
-import { fileMatchesGlobs, matchesRecordGlob } from '../sys/glob.js';
+import { validateRegex } from '../regex-validation.js';
+import { BoundedRegexCache, fileMatchesGlobs, matchesRecordGlob } from '../sys/glob.js';
 
 /**
  * The Prop 310 compiled homes, as a runtime-readable list. A rule carrying ANY
@@ -77,9 +80,17 @@ export const RECORD_COMPILED_HOME_KEYS = [
  * (which asserts the legacy manifest carries NONE of them — a stronger claim
  * than this predicate needs, and the right one for a freeze check).
  */
-export function isRecordPathRule(rule: CompiledRule): boolean {
+export function isRecordPathRule(rule: RuleScopeFields): boolean {
   return rule.examples !== undefined;
 }
+
+/**
+ * Exactly the fields the scope predicates READ. Structural rather than the whole
+ * `CompiledRule` so callers holding a projection — Stage 4's `classifyFile`
+ * takes one — pass it directly instead of casting a narrower object back to the
+ * full type. A cast there would have been a lie the compiler stopped checking.
+ */
+export type RuleScopeFields = Pick<CompiledRule, 'fileGlobs' | 'excludeGlobs' | 'examples'>;
 
 /**
  * § Design 12 — fail loud on a TORN record rule: one carrying a Prop 310
@@ -148,7 +159,7 @@ export function recordScopeMatchesFile(
  * expression, and four copies of a dialect fork is how a rule silently gets one
  * scope at dispatch and a different one at the fail-loud guard.
  */
-export function ruleAppliesToFile(rule: CompiledRule, filePath: string): boolean {
+export function ruleAppliesToFile(rule: RuleScopeFields, filePath: string): boolean {
   if (isRecordPathRule(rule)) {
     return recordScopeMatchesFile(filePath, rule.fileGlobs, rule.excludeGlobs);
   }
@@ -171,6 +182,92 @@ export interface RequiresScopeText {
   line: string;
   /** The whole file containing L, or `null` when unreadable. */
   file: () => string | null;
+}
+
+/**
+ * Compiled `requires.pattern` instances, LRU-bounded and shared across every
+ * dispatcher. Keyed by pattern SOURCE, so two rules declaring the same
+ * requirement share one compilation and a manifest reload does not leak.
+ */
+const REQUIRES_PATTERN_CACHE_CAPACITY = 512;
+const requiresPatternCache = new BoundedRegexCache(REQUIRES_PATTERN_CACHE_CAPACITY);
+
+/**
+ * Path-containment check for the § Design 8 whole-file readers.
+ *
+ * The paths handed to these readers come out of a DIFF, which is
+ * attacker-shaped input on any path where a lint runs over untrusted contributed
+ * changes — a `../` prefix would otherwise read outside the repo. `path.relative`
+ * rather than `startsWith` on purpose: the string form admits the
+ * sibling-directory bypass (`/app-secrets` passing a `/app` prefix test), which
+ * is the same reasoning the shipped ast-path containment checks use.
+ *
+ * An out-of-root path is reported as UNREADABLE, not as an error: the requirement
+ * is then unmet and the rule FIRES, preserving the fail-toward-flagging direction
+ * every other read failure on this path takes.
+ */
+export function isInsideRoot(root: string, filePath: string): boolean {
+  const resolvedRoot = path.resolve(root);
+  const relative = path.relative(resolvedRoot, path.resolve(resolvedRoot, filePath));
+  return relative !== '' && !relative.startsWith('..') && !path.isAbsolute(relative);
+}
+
+/** Evaluate a compiled requirement against the declared § Design 8 scope. */
+function matchesInScope(re: RegExp, scope: 'line' | 'file', text: RequiresScopeText): boolean {
+  if (scope === 'line') return re.test(text.line);
+  const fileText = text.file();
+  if (fileText === null) return false;
+  return re.test(fileText);
+}
+
+/**
+ * § Design 8 — gate every `requires.pattern` in the loaded manifest through the
+ * SAME safe-regex2 check the compile path applies, before any of them is
+ * evaluated.
+ *
+ * The lowering already gates this, so a pattern reaching here unsafe means the
+ * manifest was hand-edited or written by a bypassed producer. Left ungated it is
+ * a live ReDoS surface, and a worse one than the target pattern's: at
+ * `scope: file` the requirement runs against WHOLE-FILE text, unbounded, on the
+ * pre-commit path. `validateRegex` is the same single-homed check the compile
+ * gate uses, so the two can never drift.
+ *
+ * Dispatcher altitude, once per invocation — the same reason as
+ * `assertNoTornRecordRules`: a per-match check would re-report one defect on
+ * every line of every file.
+ */
+export function assertRequiresPatternsSafe(rules: readonly CompiledRule[]): void {
+  for (const rule of rules) {
+    if (rule.requires === undefined) continue;
+    const validation = validateRegex(rule.requires.pattern);
+    if (validation.valid) continue;
+    throw new TotemParseError(
+      `Rule ${rule.lessonHash} (${rule.lessonHeading}) has an unusable \`requires.pattern\` (${validation.reason ?? 'invalid regex pattern'}) and cannot be evaluated (Prop 310 § Design 8).`,
+      `The record-path compile gate runs this exact safe-regex2 check, so a pattern that fails it here means the manifest was hand-edited or written by a bypassed producer. Re-compile the rule record. At \`scope: file\` this pattern would run against whole-file text. Pattern: ${JSON.stringify(rule.requires.pattern)}`,
+    );
+  }
+}
+
+/**
+ * § Design 8 — fail loud on `ast-grep` + `requires.scope: line`.
+ *
+ * The lowering REJECTS this combination (an ast-grep match is a span, and
+ * reading it as its start line makes the verdict depend on source formatting),
+ * but a hand-edited manifest can still carry it, and the ast dispatcher would
+ * silently evaluate `match.lineText` — shipping exactly the formatting-dependent
+ * semantic the ruling refused. Mirrors the tree-sitter `requires` backstop:
+ * unreachable from any compiled record, unreachable from the legacy corpus,
+ * live only against a torn manifest.
+ */
+export function assertNoAstGrepLineScope(rules: readonly CompiledRule[]): void {
+  const offender = rules.find(
+    (rule) => rule.engine === 'ast-grep' && rule.requires?.scope === 'line',
+  );
+  if (offender === undefined) return;
+  throw new TotemParseError(
+    `Rule ${offender.lessonHash} (${offender.lessonHeading}) carries \`requires.scope: line\` on the \`ast-grep\` engine, a combination the record lowering rejects.`,
+    "Prop 310 § Design 8: an ast-grep match is a SPAN, and reading it as its start line makes the verdict depend on source formatting rather than on the rule. No rule record can compile to this shape, so the manifest was hand-edited or written by a bypassed producer. Use `scope: file`, move the requirement into the payload's own `not:`/`has:` combinators, or wait for the reserved `block` unit.",
+  );
 }
 
 /**
@@ -199,9 +296,18 @@ export function requiresContextPresent(
   requires: NonNullable<CompiledRule['requires']>,
   text: RequiresScopeText,
 ): boolean {
-  let re: RegExp;
+  // Compiled once per distinct pattern, not once per MATCH: this runs on every
+  // target hit of every requires-carrying rule, and at `scope: file` against
+  // whole-file text. The pattern set is manifest-bounded, and the LRU bound keeps
+  // a long-lived process (the MCP server, a watch loop) from growing a map keyed
+  // by rule content.
+  let re = requiresPatternCache.get(requires.pattern);
+  if (re !== undefined) {
+    return matchesInScope(re, requires.scope, text);
+  }
   try {
     re = new RegExp(requires.pattern);
+    requiresPatternCache.set(requires.pattern, re);
   } catch (err) {
     throw new TotemParseError(
       `Rule ${rule.lessonHash} has an invalid \`requires.pattern\` and cannot be evaluated (Prop 310 § Design 8).`,
@@ -209,10 +315,7 @@ export function requiresContextPresent(
       err,
     );
   }
-  if (requires.scope === 'line') return re.test(text.line);
-  const fileText = text.file();
-  if (fileText === null) return false;
-  return re.test(fileText);
+  return matchesInScope(re, requires.scope, text);
 }
 
 /**

--- a/packages/core/src/spine/record-runtime.ts
+++ b/packages/core/src/spine/record-runtime.ts
@@ -82,6 +82,38 @@ export function isRecordPathRule(rule: CompiledRule): boolean {
 }
 
 /**
+ * § Design 12 — fail loud on a TORN record rule: one carrying a Prop 310
+ * compiled home but no `examples`.
+ *
+ * Such a rule cannot exist downstream of the lowering (`examples` is min-1 at
+ * parse and emitted unconditionally) nor in the frozen legacy corpus (which
+ * carries no home at all), so this only ever catches a hand-edited manifest or
+ * a bypassed producer. Left unchecked, `isRecordPathRule` would class it LEGACY
+ * and its `excludeGlobs` and `requires` would be dropped — a scope silently
+ * widened and a requirement silently unevaluated. The drop direction is toward
+ * flagging, so it is not fail-open, but § Design 12's ban on accepting a
+ * construct and dropping it is a ban on the SILENCE, not just on the unsafe
+ * direction. Fail loud instead.
+ *
+ * Called at dispatcher altitude, once per invocation — the same altitude as the
+ * tree-sitter `requires` backstop, and for the same reason: a per-file check
+ * would re-report the same defect on every file.
+ */
+export function assertNoTornRecordRules(rules: readonly CompiledRule[]): void {
+  const torn = rules.find(
+    (rule) =>
+      rule.examples === undefined &&
+      RECORD_COMPILED_HOME_KEYS.some((key) => rule[key] !== undefined),
+  );
+  if (torn === undefined) return;
+  const homes = RECORD_COMPILED_HOME_KEYS.filter((key) => torn[key] !== undefined);
+  throw new TotemParseError(
+    `Rule ${torn.lessonHash} (${torn.lessonHeading}) carries Prop 310 record field(s) [${homes.join(', ')}] but no \`examples\`, so it can be classified neither as a record rule nor as a legacy one.`,
+    'Prop 310 § Design 5 makes `examples` non-omittable and the record lowering always emits it, so this manifest was hand-edited or written by a bypassed producer. Re-compile the rule record. Left unclassified, its `excludeGlobs` would be ignored and its `requires` never evaluated.',
+  );
+}
+
+/**
  * § Design 7 — the two-array scope rule for a RECORD-path rule:
  * `positiveMatch && !excludeMatch`, both arrays evaluated under the normative
  * dialect (`matchesRecordGlob`).

--- a/packages/core/src/spine/rule-record.test.ts
+++ b/packages/core/src/spine/rule-record.test.ts
@@ -526,6 +526,14 @@ describe('§ Design 7 — the normative glob dialect', () => {
     ['regex-syntax', 'src/a|b/*.ts'],
     ['regex-syntax', 'src/^foo/*.ts'],
     ['regex-syntax', 'src/foo$/*.ts'],
+    // Same masking cure applied to the CLOSING halves. `src/[abc]/*.ts` and
+    // `src/(a|b)/*.ts` above contain BOTH members of their pair, so `]` and `)`
+    // were only ever rejected by their opening partner's blacklist entry — drop
+    // `]` or `)` from the set and every fixture above still passed. These pin
+    // each one alone (Prop 310 Amendment 2's strict set is ruled spec text, so
+    // every member needs its own fixture).
+    ['regex-syntax', 'src/abc]/*.ts'],
+    ['regex-syntax', 'src/ab)/*.ts'],
     ['separator', 'packages\\core\\*.ts'],
     ['absolute-path', '/packages/core/*.ts'],
     ['drive-letter', 'C:/packages/core/*.ts'],
@@ -587,6 +595,29 @@ describe('§ Design 7 — the normative glob dialect', () => {
     'docs/release.notes.md',
   ])('admits the dialect-clean glob %j', (glob) => {
     expect(checkGlobDialect(glob)).toBeNull();
+  });
+
+  // Per-character LEGAL NEAR-MISS: the same glob shape with the banned character
+  // removed and nothing else changed. Without these, the negative fixtures above
+  // are satisfiable by a validator that rejects far too much — every one of them
+  // would still pass if `checkGlobDialect` simply refused any glob containing a
+  // letter from `abc`. Pairing each rejection with the minimally-different
+  // acceptance is what makes the boundary a boundary rather than a wall.
+  it.each([
+    ['[', 'src/[abc]/*.ts', 'src/abc/*.ts'],
+    [']', 'src/abc]/*.ts', 'src/abc/*.ts'],
+    ['(', 'src/(ab/*.ts', 'src/ab/*.ts'],
+    [')', 'src/ab)/*.ts', 'src/ab/*.ts'],
+    ['?', 'src/?.ts', 'src/a.ts'],
+    ['+', 'src/a+/*.ts', 'src/a/*.ts'],
+    ['|', 'src/a|b/*.ts', 'src/ab/*.ts'],
+    ['^', 'src/^foo/*.ts', 'src/foo/*.ts'],
+    ['$', 'src/foo$/*.ts', 'src/foo/*.ts'],
+  ])('bans %j but admits the construct-free literal beside it', (char, banned, clean) => {
+    const violation = checkGlobDialect(banned);
+    expect(violation?.rule).toBe('regex-syntax');
+    expect(violation?.message).toContain(`'${char}'`);
+    expect(checkGlobDialect(clean)).toBeNull();
   });
 
   it('never rewrites a glob — the validator is a pure predicate', () => {

--- a/packages/core/src/spine/rule-record.ts
+++ b/packages/core/src/spine/rule-record.ts
@@ -309,8 +309,26 @@ export interface GlobDialectViolation {
 }
 
 // `.` is DELIBERATELY absent — extension forms (`*.ts`) are the dialect's own
-// allowed shape. `|`, `^`, and `$` are regex constructs a glob never means, and
-// admitting them would let a regex-shaped glob silently match nothing.
+// allowed shape.
+//
+// The GROUNDS for banning the rest, per Prop 310 Amendment 2 (which promoted this
+// strict set to ruled spec text): the dialect's no-silent-transform discipline,
+// extended to AMBIGUITY AVOIDANCE. A character that reads as a regex construct
+// to an author, and as a literal to this matcher, is a glob whose meaning depends
+// on which of the two the reader has in mind — and that is precisely the class
+// § Design 7 exists to remove, whether or not the glob would have matched
+// anything.
+//
+// Match-impossibility is claimed for NO character here. `$types.ts` and
+// `(legacy)/util.ts` are perfectly ordinary path names, so a `$` or `(` glob can
+// and does match real trees; an earlier framing of this comment said otherwise
+// and over-claimed. The ban is not "this can never match" — it is "this must not
+// mean two things".
+//
+// The escape hatch is a FUTURE QUOTING CONSTRUCT arriving by `schemaVersion`
+// bump, never a silent literal reading of a banned character. Until then, a path
+// that genuinely contains one of these is out of the dialect's reach, and that
+// cost is named rather than papered over.
 const REGEX_SYNTAX_CHARS = ['[', ']', '(', ')', '?', '+', '|', '^', '$'] as const;
 const DRIVE_LETTER_RE = /^[A-Za-z]:/;
 // The relative-navigation segments a git-tracked, repo-relative path NAME never

--- a/packages/core/src/spine/windtunnel-firing.ts
+++ b/packages/core/src/spine/windtunnel-firing.ts
@@ -250,12 +250,38 @@ export async function buildFirings(input: BuildFiringsInput): Promise<BuildFirin
     // SAME post-image content the AST engine will parse (S1).
     await enrichWithAstContext(additions, { cwd, readStrategy, onWarn });
 
+    // Prop 310 § Design 8 — the regex engine's file-scoped requirement must read
+    // the SAME post-image content this function already mandates for every other
+    // reader (S1), not the local worktree. `applyRulesToAdditions` is SYNC, so
+    // the async post-image reader is pre-resolved into a lookup here.
+    //
+    // Gated on a rule actually declaring a file-scoped requirement: no legacy or
+    // mined rule carries `requires`, so the 485-rule certification corpus does
+    // exactly as much IO as before this line existed.
+    let postImageText: ((file: string) => string | null) | undefined = undefined;
+    if (rules.some((r) => r.requires?.scope === 'file')) {
+      const resolved = new Map<string, string | null>();
+      for (const file of new Set(additions.map((a) => a.file))) {
+        // The reader's own failure contract is preserved: a throw propagates
+        // rather than being degraded into "context absent".
+        resolved.set(file, await readStrategy(file));
+      }
+      postImageText = (file: string) => resolved.get(file) ?? null;
+    }
+
     // Both engines receive the FULL rule set and self-filter by `rule.engine`
     // into DISJOINT partitions — applyRulesToAdditions takes `engine === 'regex'
     // || !engine`; applyAstRulesToAdditions takes `engine === 'ast' | 'ast-grep'`
     // (rule-engine.ts). No rule is processed by both, so double-processing can
     // never manufacture a same-rule labelId self-collision at the A1 gate. (CR #2215.)
-    const regexViolations = applyRulesToAdditions(ruleEngineCtx, rules, additions, undefined, cwd);
+    const regexViolations = applyRulesToAdditions(
+      ruleEngineCtx,
+      rules,
+      additions,
+      undefined,
+      cwd,
+      postImageText,
+    );
     // AST / ast-grep violations (whole post-image via the shared readStrategy).
     const astViolations = await applyAstRulesToAdditions(
       ruleEngineCtx,

--- a/packages/core/src/spine/windtunnel-firing.ts
+++ b/packages/core/src/spine/windtunnel-firing.ts
@@ -3,6 +3,7 @@ import type { CompiledRule, DiffAddition, Violation } from '../compiler-schema.j
 import { extractAddedLines } from '../diff-parser.js';
 import type { RuleEngineContext } from '../rule-engine.js';
 import { applyAstRulesToAdditions, applyRulesToAdditions } from '../rule-engine.js';
+import { ruleAppliesToFile } from './record-runtime.js';
 import { firingLabelId } from './windtunnel-lock.js';
 import type { RuleFiring } from './windtunnel-scorer.js';
 
@@ -259,9 +260,16 @@ export async function buildFirings(input: BuildFiringsInput): Promise<BuildFirin
     // mined rule carries `requires`, so the 485-rule certification corpus does
     // exactly as much IO as before this line existed.
     let postImageText: ((file: string) => string | null) | undefined = undefined;
-    if (rules.some((r) => r.requires?.scope === 'file')) {
+    const fileScoped = rules.filter((r) => r.requires?.scope === 'file');
+    if (fileScoped.length > 0) {
       const resolved = new Map<string, string | null>();
       for (const file of new Set(additions.map((a) => a.file))) {
+        // Narrowed to files at least one file-scoped rule is actually SCOPED to:
+        // a PR touching hundreds of files would otherwise pay a post-image read
+        // for every one of them to answer a question no rule asks about most.
+        // An unread file resolves to `null` below, which only ever reaches a rule
+        // that is out of scope for it — so no verdict changes.
+        if (!fileScoped.some((rule) => ruleAppliesToFile(rule, file))) continue;
         // The reader's own failure contract is preserved: a throw propagates
         // rather than being degraded into "context absent".
         resolved.set(file, await readStrategy(file));

--- a/packages/core/src/stage4-verifier.ts
+++ b/packages/core/src/stage4-verifier.ts
@@ -52,6 +52,7 @@ import {
   applyRulesToAdditions,
   fileMatchesGlobs,
 } from './rule-engine.js';
+import { isRecordPathRule, ruleAppliesToFile } from './spine/record-runtime.js';
 
 // ─── Types ──────────────────────────────────────────
 
@@ -290,16 +291,33 @@ export function parseStage4BaselineDirectives(content: string): string[] {
  * earlier local regex-conversion matcher had a substring hole
  * (`**\/tests/**` would match `src/contests/foo.ts`) which the
  * pattern-specific matcher in rule-engine fixes by construction.
+ *
+ * The RULE-scope half now delegates one level up, to `ruleAppliesToFile`
+ * (Prop 310 slice 2) — the same predicate both lint dispatchers use. Taking
+ * the whole `rule` rather than a bare glob array is what makes a record
+ * rule's `excludeGlobs` visible here at all: passing `rule.fileGlobs` alone
+ * structurally discarded them, so a Stage-4 verification would judge a
+ * record rule over-broad on files its own scope excludes. Legacy behaviour
+ * is byte-identical by construction — for a rule carrying no Prop 310
+ * homes, `ruleAppliesToFile` IS `fileGlobs.length ? fileMatchesGlobs(...) :
+ * true`, which is exactly the expression it replaces.
+ *
+ * The BASELINE half below deliberately still calls `fileMatchesGlobs`
+ * directly: those globs are Stage-4 configuration (`baseline.excludeFileGlobs`,
+ * consumer-supplied, `!`-negation-bearing), not the rule's scope, so the
+ * question they answer — "is this file baseline-excluded" — is not the
+ * question `ruleAppliesToFile` answers. The same reasoning holds for the R3
+ * subtraction: only a rule's POSITIVE globs can claim a baseline entry back,
+ * and a record rule's `excludeGlobs` never claim anything.
  */
 function classifyFile(
   filePath: string,
-  ruleFileGlobs: readonly string[] | undefined,
+  rule: Pick<CompiledRule, 'fileGlobs' | 'excludeGlobs' | 'examples'>,
   baseline: Stage4Baseline,
 ): 'in-scope' | 'baseline' {
-  // Rule has explicit fileGlobs and this file doesn't match → baseline (out-of-scope).
-  if (ruleFileGlobs && ruleFileGlobs.length > 0) {
-    if (!fileMatchesGlobs(filePath, ruleFileGlobs)) return 'baseline';
-  }
+  const ruleFileGlobs = rule.fileGlobs;
+  // File is outside the rule's declared scope → baseline (out-of-scope).
+  if (!ruleAppliesToFile(rule as CompiledRule, filePath)) return 'baseline';
   // File matches rule scope (or rule has no scope). Now check baseline overrides.
   //
   // Subtract rule-declared scope from the baseline first (CR mmnto-ai/totem#1766 R3).
@@ -399,7 +417,29 @@ async function runRuleAgainstAllFiles(
   ctx: RuleEngineContext,
   workingDirectory: string | undefined,
 ): Promise<Violation[]> {
-  const ruleNoScope: CompiledRule = { ...rule, fileGlobs: undefined };
+  // "Unscoped" has to be expressed differently in the two dialects, and getting
+  // it wrong here INVERTS Stage 4 for record rules (Prop 310 slice 2).
+  //
+  // The legacy expression of "fires everywhere" is ABSENT `fileGlobs`, because
+  // `fileMatchesGlobs` treats an empty positive set as include-all. The record
+  // dialect deliberately does the opposite — `recordScopeMatchesFile` requires a
+  // positive match, so a record rule with no `fileGlobs` matches NOTHING (that
+  // asymmetry is what stops a hand-edited record from silently widening its own
+  // scope). Stripping `fileGlobs` off a record rule would therefore make it fire
+  // on zero files, and Stage 4 would report `no-matches` for every record rule
+  // ever verified — a silent, total inversion of this function's contract.
+  //
+  // So: legacy rules keep the shipped strip byte-for-byte, and record rules get
+  // an explicit match-everything glob plus their exclusions dropped. `**\/*`
+  // compiles to `^(?:[^/]+/)*[^/]*$` under the record dialect, matching every
+  // repo-relative path including root-level ones. `examples` and `requires` are
+  // deliberately left intact: this strip removes SCOPE, and neither of those is
+  // scope — dropping `examples` would also re-classify the rule as legacy
+  // mid-run, and dropping only `examples` while `requires` remained would
+  // manufacture exactly the torn shape `assertNoTornRecordRules` rejects.
+  const ruleNoScope: CompiledRule = isRecordPathRule(rule)
+    ? { ...rule, fileGlobs: ['**/*'], excludeGlobs: undefined }
+    : { ...rule, fileGlobs: undefined };
 
   if (rule.engine === 'regex' || !rule.engine) {
     return applyRulesToAdditions(ctx, [ruleNoScope], [...additions]);
@@ -515,7 +555,7 @@ export async function verifyAgainstCodebase(
   const candidateDebtLines: string[] = [];
 
   for (const violation of violations) {
-    const classification = classifyFile(violation.file, rule.fileGlobs, baseline);
+    const classification = classifyFile(violation.file, rule, baseline);
     if (classification === 'baseline') {
       baselineMatchSet.add(violation.file);
     } else {

--- a/packages/core/src/stage4-verifier.ts
+++ b/packages/core/src/stage4-verifier.ts
@@ -52,7 +52,11 @@ import {
   applyRulesToAdditions,
   fileMatchesGlobs,
 } from './rule-engine.js';
-import { isRecordPathRule, ruleAppliesToFile } from './spine/record-runtime.js';
+import {
+  isRecordPathRule,
+  ruleAppliesToFile,
+  type RuleScopeFields,
+} from './spine/record-runtime.js';
 
 // ─── Types ──────────────────────────────────────────
 
@@ -312,12 +316,12 @@ export function parseStage4BaselineDirectives(content: string): string[] {
  */
 function classifyFile(
   filePath: string,
-  rule: Pick<CompiledRule, 'fileGlobs' | 'excludeGlobs' | 'examples'>,
+  rule: RuleScopeFields,
   baseline: Stage4Baseline,
 ): 'in-scope' | 'baseline' {
   const ruleFileGlobs = rule.fileGlobs;
   // File is outside the rule's declared scope → baseline (out-of-scope).
-  if (!ruleAppliesToFile(rule as CompiledRule, filePath)) return 'baseline';
+  if (!ruleAppliesToFile(rule, filePath)) return 'baseline';
   // File matches rule scope (or rule has no scope). Now check baseline overrides.
   //
   // Subtract rule-declared scope from the baseline first (CR mmnto-ai/totem#1766 R3).

--- a/packages/core/src/sys/glob.ts
+++ b/packages/core/src/sys/glob.ts
@@ -40,7 +40,15 @@ const NO_OPTIONAL_SYNTAX = new Set<OptionalSyntax>();
 const CLASSIFIER_OPTIONAL_SYNTAX = new Set<OptionalSyntax>(['brace-alternation', 'question']);
 const classifierCache = new Map<string, RegExp>();
 
-class BoundedRegexCache implements GlobCache {
+/**
+ * LRU-bounded `string → RegExp` cache. Nothing about it is glob-specific — the
+ * key is any source string and the value its compiled expression — so it is
+ * exported for the other compile-once-evaluate-many sites in the engine (Prop
+ * 310's `requires.pattern`, `spine/record-runtime.ts`). Reusing this rather than
+ * a bare `Map` keeps the shipped idiom AND the bound: an unbounded map keyed by
+ * rule content grows with every distinct pattern the process ever sees.
+ */
+export class BoundedRegexCache implements GlobCache {
   private readonly entries = new Map<string, RegExp>();
 
   constructor(private readonly capacity: number) {}

--- a/packages/core/src/sys/glob.ts
+++ b/packages/core/src/sys/glob.ts
@@ -84,6 +84,48 @@ const PATH_CLASSIFIER_PROFILE: GlobProfileOptions = Object.freeze({
   cache: classifierCache,
 });
 
+/**
+ * Prop 310 § Design 7 — the NORMATIVE record-grammar dialect, as a third profile
+ * over the same tokenizer rather than a second matcher (the file's own design:
+ * "profiles are option records over this one tokenizer and compiler"; a parallel
+ * implementation would be Tenet 20's prohibited mirror of glob semantics).
+ *
+ * Each option below IS a spec clause, not a preference:
+ *   - `barePatternMatchesBasename: false` — § Design 7 "No silent promotion": a
+ *     glob means what it says, so `*.ts` is ROOT-LEVEL and tree-wide is written
+ *     `**\/*.ts`. The rule-engine profile's basename prefix is exactly the
+ *     promotion the grammar kills.
+ *   - `starActivation: 'all'` — every `*` is a wildcard. The rule-engine profile's
+ *     bounded legacy shapes silently demote unrecognized stars to LITERALS; the
+ *     record dialect admits `*` and `**` and nothing else, so there is no
+ *     unrecognized shape to demote.
+ *   - `optionalSyntax` empty — braces are OUT of the dialect (§ Design 7's brace
+ *     ruling) and `?` is banned regex syntax. Both are already parse errors, so
+ *     this is defence in depth against a hand-edited manifest.
+ *   - `crossSegmentWildcard: '.*'` — a TRAILING `**` (`packages/**`) matches the
+ *     whole subtree. A `**\/` SEGMENT compiles to `(?:[^/]+/)*` via the shared
+ *     `globstar-segments` token, so `**\/*.ts` is tree-wide INCLUDING the root.
+ *   - `normalizePatternSeparators: false` — record globs are `/`-only (a backslash
+ *     is a parse error), so there is nothing to normalize on the PATTERN side.
+ *     The PATH side is normalized by `matchGlob` for every profile, which is
+ *     § Design 7's "matchers normalize host separators before evaluation".
+ *
+ * Matching is case-SENSITIVE (no `i` flag anywhere in this file) against
+ * repo-relative path names, per § Design 7's Windows-semantics paragraph.
+ *
+ * Its own cache instance is mandatory: the caches are keyed by glob STRING only,
+ * so sharing one with another profile would serve a `*.ts` regex compiled under
+ * the opposite promotion rule.
+ */
+const RECORD_DIALECT_PROFILE: GlobProfileOptions = Object.freeze({
+  normalizePatternSeparators: false,
+  barePatternMatchesBasename: false,
+  optionalSyntax: NO_OPTIONAL_SYNTAX,
+  starActivation: 'all',
+  crossSegmentWildcard: '.*',
+  cache: new BoundedRegexCache(RULE_ENGINE_CACHE_CAPACITY),
+});
+
 function escapeRegexLiteral(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -318,6 +360,19 @@ export function matchesGlob(filePath: string, glob: string): boolean {
 /** Match a path with the anchored path-classifier compatibility profile. */
 export function matchesPathGlob(filePath: string, glob: string): boolean {
   return matchGlob(filePath, glob, PATH_CLASSIFIER_PROFILE);
+}
+
+/**
+ * Match a repo-relative path against ONE glob under the Prop 310 § Design 7
+ * normative dialect. Single-glob only: the two-array scope rule
+ * (`positiveMatch && !excludeMatch`) is record-grammar SEMANTICS and lives with
+ * the record runtime (`spine/record-runtime.ts`), not in the dialect mechanics.
+ *
+ * Reachable only for rules that carry a Prop 310 compiled home; every legacy
+ * rule keeps `matchesGlob`'s shipped behaviour byte-for-byte.
+ */
+export function matchesRecordGlob(filePath: string, glob: string): boolean {
+  return matchGlob(filePath, glob, RECORD_DIALECT_PROFILE);
 }
 
 /**


### PR DESCRIPTION
## What

Slice 2 of the Prop 310 V1 record-grammar build: **compiled homes, total lowering, and runtime evaluation** — the record path now runs end-to-end from a parsed `.rule.yaml` to live `totem lint` verdicts. Slice 1 (the parser) merged as mmnto-ai/totem#2660; slice 3 (intake front-end + envelope derivation + manifest attestation) follows.

- **`spine/record-lower.ts`** — `compileRuleRecord(parsed, {ruleId, now})`: identity is an INPUT (the ADR-112 producer mints at intake; this function asserts well-formed and never hashes `dslSource`), tree-form payload wrapped into the NapiConfig the engine consumes (operator ruling 2026-08-21: `target.rule` is the rule TREE; the wrapper's `language` derives from the resolved `target.language`, so the record never carries a duplicate language home), engine gates fail loud per § Design 12 (safe-regex2 on `target.pattern` AND `requires.pattern`; ast-grep validated under EXACTLY the declared registry-resolved language, retiring try-each-glob-Lang on the record path), record globs pass VERBATIM (`sanitizeFileGlobs` never runs on records), verbatim carries for the § Design 12 set.
- **`spine/record-runtime.ts` + `rule-engine.ts` + `regex-safety/apply-rules-bounded.ts`** — the § Design 7 two-array scope (`positiveMatch && !excludeMatch`) and § Design 8 `requires` two-pass (fires iff target matches ∧ pattern absent in declared scope; evaluated as part of the match predicate), wired through BOTH regex dispatchers and all three AST branches via one shared predicate; legacy rules route to the byte-identical shipped expression.
- **`compiler-schema.ts`** — additive-optional homes: `excludeGlobs`, `requires`, `examples`, `language`, `verificationShadow` (verbatim, never evaluated — Amendment R4 gate), `recoveryHint`, `curation`. The mined corpus re-validates byte-identical (guarded by test against the real `.totem/compiled-rules.json`).
- **`sys/glob.ts`** — the § Design 7 dialect as a third profile over the shared tokenizer; both shipped profiles byte-unchanged (pinned).
- **Certification seams** — the windtunnel regex path now reads the same post-image content as its AST path; Stage 4 single-homed onto the shared scope predicate, including a dialect-aware fix to its scope-strip (details below).
- **91 slice-2 core tests + 3 CLI staged-mode tests**; both spec exemplars lower and live-evaluate against their own `bad`/`good` through the real engines.

## Review of record

Opus build-leg against the ruled design; **full falsification pass + scoped re-arm** (both with corpus-scale empirical sweeps — the re-pointed legacy non-regression sweep ran 10,670 (rule, path) pairs through the SHIPPING dispatcher with the real RegexEvaluator: 0 divergences, now pinned permanently at 4,850 assertions in CI); a convergence round executing the re-arm's findings. Owner gates (build, core + CLI suites, format, full-branch totem lint, eslint) re-run independently after every round. The convergence round was mechanical execution of reviewed findings plus one documented judgment (the Stage 4 strip cure, reviewed directly by the dispatching seat); no fourth falsification pass was armed — stated here as the discretion it is.

Commit stack (nothing amended): `77a24911` build → `1b46740` falsification cures → `6e79303a` convergence.

## Findings cured along the way (the interesting ones)

1. **The shipping regex path never ran the new runtime.** `totem lint` uses `applyRulesToAdditionsBounded` exclusively — the initial build wired only `applyRulesToAdditions`, so record `excludeGlobs`/`requires` were inert and record globs rode legacy promotion (silent scope WIDENING). Both dispatchers now share the predicate; a CLI staged-mode test pins that the reader actually reaches the bounded regex gate.
2. **Staged fail-open.** `requires: {scope: file}` read the worktree while the violation sat staged — a pre-commit gate passing on deleted context. Both dispatchers now take staged readers (sync param on the sync path, async `readStrategy` on the bounded path); a caller-supplied reader's throw propagates loudly.
3. **Stage 4's scope-strip inverts for records.** The verifier expresses "fires everywhere" as `fileGlobs: undefined` — include-all on the legacy matcher, match-NOTHING on the record dialect — so every record rule verified would have silently classed `untested-against-codebase`. Cure: dialect-aware unscoping (`['**/*']` + exclusions dropped for records; legacy strip byte-for-byte). Sole strip site (swept).
4. **Language⇄glob gap.** `language: typescript` + `fileGlobs: ["**/*.js"]` lowered clean and then either inertly failed per-file or silently FIRED under the wrong grammar. Cured by the lowering floor below.

## Applied rulings — your override window

- **Language⇄glob consistency floor:** for ast-grep targets, every `fileGlobs` entry must end in a registered extension resolving to the declared `language`; extension-less globs reject. Note `.tsx` resolves to the distinct `tsx` grammar, so `.ts`+`.tsx` is TWO records — § Design 6's own "a multi-language ast-grep rule is N records", typed `construct-gap` if the R14 trial finds it bites (it should count this: it doubles the modal React-codebase rule).
- **`requires.scope: line` rejected on ast-grep targets** at lowering: an ast locus is a SPAN whose natural unit is the reserved-unimplemented `block`; the alternative was a silently formatting-dependent start-line reading (verified: same semantics, multi-line fires / one-line silent). `line` stays valid on regex; `file` on both.
- **Deviation D1 (build-leg, confirmed by falsification review):** compiled homes for `recoveryHint` + `curation` — § Design 12's totality clause ("no construct is accepted at parse and dropped at compile") binds them; § Design 1's intake-seam enumeration is closed and contains neither.

## Named forward items

- **Certification-seam readers and Stage 4 are cured in-slice** (were deferral candidates; ruled in since slice 3 routes record rules through exactly those seams).
- **The ast-grep record surface is JS/TS-family-only today** (`registeredExtensions()` = the 8 JS/TS extensions) — the R14 trial cannot express another language until a pack registers one. Corpus cost zero (all 268 ast-grep corpus rules in-family); named for the trial rather than discovered at it.
- **§ Design 7 conformance note owed to the spec** (rides the open strategy thread on the § Design 7 character set): an extension-less glob is dialect-clean but cannot carry an ast-grep record.
- The compiled `language` field is now formally redundant with the globs (derivable) — kept as the Tenet-20 couple form (authored + fail-loud coupling check), a version bump could drop it.
- `requires: {scope: file}` staged reads on the two `applyRulesToAdditions` certification callers use pre-resolved post-image readers; the sync-path param is additive with all four shipped callers unchanged (verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
