### PR TITLE
chore(lessons): postmerge extraction for #2660 + #2663

### DIFF
--- a/.totem/lessons/lesson-02091878.md
+++ b/.totem/lessons/lesson-02091878.md
@@ -1,0 +1,6 @@
+## Lesson — Validate dynamic regex patterns at runtime
+
+**Tags:** security, regex
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Dynamic regex patterns must be validated using safety gates (like `safe-regex2`) at runtime boundaries before evaluation. This prevents Regular Expression Denial of Service (ReDoS) from hand-edited or untrusted rule manifests.

--- a/.totem/lessons/lesson-04ded3cd.md
+++ b/.totem/lessons/lesson-04ded3cd.md
@@ -1,0 +1,6 @@
+## Lesson — Guard file readers against path traversal
+
+**Tags:** security, fs
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+When resolving repository file paths dynamically, validate that the resolved path remains within the project root using `path.relative`. Treat escaping paths (absolute or starting with `..`) as unreadable to prevent directory traversal vulnerabilities.

--- a/.totem/lessons/lesson-08763111.md
+++ b/.totem/lessons/lesson-08763111.md
@@ -1,0 +1,6 @@
+## Lesson — Guard recursive YAML with ancestor tracking
+
+**Tags:** yaml, algorithms, validation
+**Scope:** packages/core/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+When scanning parsed YAML payloads for forbidden keys, use an ancestor-only stack (WeakSet) rather than a visit-once log to detect true cycles while permitting legal shared anchors (DAGs).

--- a/.totem/lessons/lesson-169e5c75.md
+++ b/.totem/lessons/lesson-169e5c75.md
@@ -1,0 +1,6 @@
+## Lesson — Evaluate staged files using index content
+
+**Tags:** git, cli
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Reading from the worktree during pre-commit or staged-file checks can lead to false passes on deleted or modified context. Use dedicated staged readers that query the Git index rather than the worktree to ensure evaluated bytes match what is actually being committed.

--- a/.totem/lessons/lesson-2549e510.md
+++ b/.totem/lessons/lesson-2549e510.md
@@ -1,0 +1,6 @@
+## Lesson — Use own-property checks for key validation
+
+**Tags:** security, typescript
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Relying on `table[key] === undefined` to verify key disposition is vulnerable to prototype pollution from inherited properties like `constructor` or `toString`. Use `Object.hasOwn` to ensure only own-properties are evaluated.

--- a/.totem/lessons/lesson-4dae05d1.md
+++ b/.totem/lessons/lesson-4dae05d1.md
@@ -1,0 +1,7 @@
+## Lesson — When two scope dialects share one runtime, every dispatch
+
+**Tags:** rule-engine, dispatch, scope-dialect, trap, shipping-path, prop-310
+
+When two scope dialects share one runtime, every dispatch AND every scope-transform site must be dialect-aware, and the tested dispatcher must be the SHIPPING dispatcher. Two incidents from the Prop 310 slice-2 build (PR mmnto-ai/totem#2663): (1) the new record-dialect runtime was wired into `applyRulesToAdditions` and fully tested there — but `totem lint`'s regex path runs `applyRulesToAdditionsBounded` exclusively, so the entire new runtime was inert on the product path and record globs silently rode legacy promotion (scope WIDENING); a corpus-scale sweep on the non-shipping dispatcher had certified "no regression" while exercising code the product never runs. (2) Stage 4's scope-strip expressed "fires everywhere" as `fileGlobs: undefined` — include-all under the legacy matcher, match-NOTHING under the record dialect (which requires a positive match by design) — silently inverting verification for every record rule. Cures: single-home the scope predicate and route every dispatcher and every consumer (windtunnel, stage4) through it; express "unscoped" per-dialect explicitly (`['**/*']` for the positive-match dialect); pin the shipping-path wiring with an end-to-end test through the REAL entry point (`run-compiled-rules` staged mode), because "the reader existed but never reached the path" survives every unit test of the dispatcher itself.
+
+**Source:** mcp (added at 2026-08-22T02:01:38.935Z)

--- a/.totem/lessons/lesson-78b1c137.md
+++ b/.totem/lessons/lesson-78b1c137.md
@@ -1,0 +1,6 @@
+## Lesson — Ban do-nothing values in schemas
+
+**Tags:** validation, schema
+**Scope:** packages/core/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Strictly rejecting empty arrays (like `excludeGlobs: []`) and empty exemplars prevents silent rule degradation and ensures every authored key carries active configuration.

--- a/.totem/lessons/lesson-9403c5e9.md
+++ b/.totem/lessons/lesson-9403c5e9.md
@@ -1,0 +1,6 @@
+## Lesson — Cache regexes in hot evaluation loops
+
+**Tags:** performance, regex
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Compiling RegExp instances repeatedly inside hot loops like `requiresContextPresent` introduces significant CPU overhead. Re-use or cache compiled patterns using a bounded cache to maintain performance.

--- a/.totem/lessons/lesson-a7534623.md
+++ b/.totem/lessons/lesson-a7534623.md
@@ -1,0 +1,6 @@
+## Lesson — Reject prototype keys in parsed payloads
+
+**Tags:** security, yaml, validation
+**Scope:** packages/core/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+YAML parsers can materialize `__proto__`, `constructor`, and `prototype` as own enumerable keys; using `Object.assign` on such payloads silently drops these keys and reparents the destination's prototype, causing structural corruption.

--- a/.totem/lessons/lesson-d7900a89.md
+++ b/.totem/lessons/lesson-d7900a89.md
@@ -1,0 +1,7 @@
+## Lesson — A compiled rule can be a DEAD MATCHER: syntactically valid
+
+**Tags:** ast-grep, compiled-rules, dead-matcher, trap, r14-trial, validation
+
+A compiled rule can be a DEAD MATCHER: syntactically valid, compile-green, and structurally unable to ever match. `validateAstGrepPattern` proves PARSEABILITY, not MATCHABILITY — an ast-grep bare-brace object pattern with a LEADING `$$$` metavariable (`{ $$$BEFORE, key: $VAL, $$$AFTER }`) parses as a statement block rather than an object literal and matches zero object nodes, ever. Two of the 485 shipped corpus rules carry this exact shape (`d940b2c9ffe92e99`, and `1a7080ebf6162de3`'s payload), probe-verified during the R14 seed-20 translation: 0/7 candidate snippets matched, while controls (`const $X = {...same...}` and the literal braces) both matched, isolating the cause to the bare-brace + leading-`$$$` form. Detection requires a firing probe (run the pattern against a snippet it MUST match), not a validator. When auditing or authoring compound ast-grep rules: anchor bare object patterns to a surrounding node (assignment, call argument) or probe-verify at authoring time; a wind-tunnel bad-example differential (fires-on-bad) catches this class mechanically — which is exactly what Prop 310's mandatory `examples` exists to force.
+
+**Source:** mcp (added at 2026-08-22T02:01:32.416Z)

--- a/.totem/lessons/lesson-e6dc0f07.md
+++ b/.totem/lessons/lesson-e6dc0f07.md
@@ -1,0 +1,6 @@
+## Lesson — Enforce all-or-none validation for metadata groups
+
+**Tags:** validation, zod, architecture
+**Scope:** packages/core/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+To prevent incomplete process state, groups of related optional metadata fields should be validated all-or-none together rather than allowing arbitrary partial subsets.

--- a/.totem/lessons/lesson-f1b7eb21.md
+++ b/.totem/lessons/lesson-f1b7eb21.md
@@ -1,0 +1,6 @@
+## Lesson — Reject line-scoped requirements on AST targets
+
+**Tags:** ast, validation
+**Scope:** packages/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+AST nodes represent multi-line spans whose natural boundaries do not map cleanly to line-scoped requirements, making line-level checks highly formatting-dependent. Enforce a runtime fail-loud guard or lowering-time rejection when line-scoped requirements are configured for AST-based rules.


### PR DESCRIPTION
Postmerge lesson extraction for the two Prop 310 record-grammar slices (mmnto-ai/totem#2660, mmnto-ai/totem#2663): 10 diff-extracted lessons + 2 session-level classes (dead-matcher; two-dialect shipping-path) added via add_lesson. Extraction-only — the rule-compilation freeze is untouched (index-only lessons are freeze-exempt per the freeze entry's scope ruling). No compile, no manifest mutation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)