### PR TITLE
chore(lessons): postmerge extraction for #2668 (Prop 310 slice 3)

### DIFF
--- a/.totem/lessons/lesson-07bf3ce5.md
+++ b/.totem/lessons/lesson-07bf3ce5.md
@@ -1,0 +1,7 @@
+## Lesson — When a manifest gains a new attested file class, every
+
+**Tags:** manifest, attestation, freshness, single-homing, tenet-20, trap
+
+When a manifest gains a new attested file class, every WRITER and every FRESHNESS / no-op decision path must consult ONE predicate for that class. Prop 310 slice 3 added `records_hash` to `compile-manifest.json` and wired all six `writeCompileManifest` callers plus the `--refresh-manifest` freshness test — but the ordinary `totem compile` no-op path derived `manifestStale` from `input_hash` alone, so a tracked record-only edit was never rewritten and `verify-manifest` then hard-FAILed (CodeRabbit Major, outside the diff, mmnto-ai/totem#2668). Cure shape: a single exported predicate (`isRecordsAttestationFresh(existingHash, totemDir, cwd)`) shared by the verifier, the refresh path, and the no-op path, with a regression row "tracked record-only change ⇒ manifest rewritten, rules file byte-identical" and its negative control "nothing changed ⇒ manifest byte-identical". Sweep with `grep` for every site that decides "is the manifest fresh?", not only the sites that write it.
+
+**Source:** mcp (added at 2026-08-22T05:59:32.040Z)

--- a/.totem/lessons/lesson-1011661f.md
+++ b/.totem/lessons/lesson-1011661f.md
@@ -1,0 +1,7 @@
+## Lesson — Validate a repo-relative file reference LEXICALLY
+
+**Tags:** path-validation, windows, cross-platform, security, ledger, trap
+
+Validate a repo-relative file reference LEXICALLY before resolving it, and never let a machine-specific path reach a tracked artifact. On Prop 310 slice 3 (mmnto-ai/totem#2668) the first `record:` reference check was `path.resolve` + `path.relative` containment only; the falsification leg showed it accepts backslash separators, a drive-letter absolute that lands inside the root, `//`, leading `./`, and case-variant directory names on win32 while rejecting the same strings on linux — a platform-dependent verdict — and the accepted reference was written verbatim into the git-tracked `authoring-ledger.ndjson`. Cure: a closed rule table over the TEXT (`separator`, `absolute-path`, `drive-letter`, `unc-path`, `empty-segment`, `current-segment`, `parent-segment`, case-sensitive `records-dir-prefix`, `suffix`, `is-the-records-dir`) run before any resolution, an exhaustiveness guard asserting every rule has a negative fixture, the table driven through the shipping entry point, and containment kept as the second line of defence with `relative === '..' || relative.startsWith('..' + path.sep)` (a bare `startsWith('..')` false-rejects `..hidden/`).
+
+**Source:** mcp (added at 2026-08-22T05:59:37.688Z)

--- a/.totem/lessons/lesson-24b3936e.md
+++ b/.totem/lessons/lesson-24b3936e.md
@@ -1,0 +1,7 @@
+## Lesson — When a test asserts that a sanitizer removed an AUTHORED
+
+**Tags:** testing, terminal, sanitization, ansi, environment-dependent, trap
+
+When a test asserts that a sanitizer removed an AUTHORED terminal escape from CLI output, the injected needle must be a sequence the CLI's own colouring never emits. The bot-round-1 test on mmnto-ai/totem#2668 injected `ESC[31m` and asserted the raw stderr did not contain it — but `ui`'s `errorColor('FAIL')` emits exactly `ESC[31m` whenever colours are enabled, so the row passed in the build-leg's colour-off environment and failed at the owner gate with colours on, for a reason unrelated to the sanitizer. Chalk/ui emit only SGR sequences (`ESC[…m`); use an erase/cursor CSI such as `ESC[2J` as the authored needle, build it with `String.fromCharCode(27)` (never a raw or `\x1b` literal in source), capture RAW output (a `stripAnsi`'d capture makes the assertion vacuous), and verify the row under `FORCE_COLOR=0`, `FORCE_COLOR=1`, and the default environment before calling it green.
+
+**Source:** mcp (added at 2026-08-22T05:59:27.049Z)

--- a/.totem/lessons/lesson-623479e8.md
+++ b/.totem/lessons/lesson-623479e8.md
@@ -1,0 +1,7 @@
+## Lesson — a ruling's record is never aligned to the build.
+
+**Tags:** provenance, spec, falsification-leg, operator-ruling, trap, process
+
+A cure charter that names a spec's wording must carve out the verbatim RULED quote. On Prop 310 slice 3 (mmnto-ai/totem#2668) the falsification leg's MIN-1 cure said "say git-tracked in the spec's OQ-3 wording"; the build-leg applied it to the operator's RULED blockquote as well as to the build's own failure-mode rows, and the scoped re-arm flagged it MATERIAL: after the edit no artifact could show whether the operator ruled the narrow form or the build narrowed it. Rule: a ruling's record is never aligned to the build. When the build deviates from ruled text, restore the quote byte-for-byte (diff against the commit that recorded it) and append a dated build note BENEATH it naming the deviation and flagging it for operator confirmation; the build's own sections (failure modes, data model) may carry the corrected wording. When chartering a cure that touches a spec, enumerate which passages are the build's and which are the ruling's.
+
+**Source:** mcp (added at 2026-08-22T05:59:23.008Z)

--- a/.totem/lessons/lesson-68e71ddf.md
+++ b/.totem/lessons/lesson-68e71ddf.md
@@ -1,0 +1,6 @@
+## Lesson — Attest git-tracked files over raw disk
+
+**Tags:** git, manifest, dx
+**Scope:** packages/core/src/compile-manifest.ts
+
+Scoping manifest attestation to git-tracked files rather than raw disk files prevents untracked local drafts from blocking unrelated upstream pushes.

--- a/.totem/lessons/lesson-6fa3cc32.md
+++ b/.totem/lessons/lesson-6fa3cc32.md
@@ -1,0 +1,6 @@
+## Lesson — Track record changes in manifest freshness
+
+**Tags:** manifest, build-system, caching
+**Scope:** packages/cli/src/commands/compile.ts
+
+Manifest freshness checks must account for tracked record file changes even when main compilable inputs are unchanged, preventing stale hashes during incremental compiles.

--- a/.totem/lessons/lesson-d842c38b.md
+++ b/.totem/lessons/lesson-d842c38b.md
@@ -1,0 +1,7 @@
+## Lesson — {pattern:'log.error($$$ARGS)'}
+
+**Tags:** ast-grep, constraints, metavariable, engine-semantics, trap, r14
+
+In `@ast-grep/napi` (measured at 0.42.0), a `constraints:` entry on a MULTI meta-variable (`$$$NAME`) is silently inert: the rule matches exactly as the bare pattern would, with no error or warning — `{rule:{pattern:'log.error($$$ARGS)'}, constraints:{ARGS:{not:{regex:'Totem Error'}}}}` fires on `log.error('Totem Error', msg)` just like the unconstrained pattern. Only single meta-variables (`$FIRST`, `$SRC`) are constrained, and changing the pattern to bind one (`log.error($FIRST, $$$REST)`) changes the arity it matches. Measured in the R14 round (mmnto-ai/totem-strategy#288) — the construct the translator had named as the missing one for two rules would not have expressed the intent even if V1 had grafted it; the intent IS expressible as tree-form `all:` + `not:`/`regex:` or `has: {field: arguments, …}`. Never assume a constraint on `$$$` does anything without a probe; fail-loud candidate tracked as mmnto-ai/totem#2667.
+
+**Source:** mcp (added at 2026-08-22T05:59:42.952Z)


### PR DESCRIPTION
Postmerge lesson extraction for Prop 310 slice 3 (mmnto-ai/totem#2668, merged `180e0d5b`): 2 diff-extracted lessons (`totem lesson extract 2668`, from the CodeRabbit round — manifest freshness across every no-op path; git-tracked attestation scope) + 5 session-level classes added via `add_lesson` (ruled-text provenance: a cure never edits a RULED quote; colour-independent sanitizer assertions; one freshness predicate for every manifest writer and no-op path; lexical-before-resolution validation of repo-relative references with no machine path in a tracked artifact; `@ast-grep/napi` `constraints:` on `$$$` is silently inert — the R14 round's measurement, tracked as mmnto-ai/totem#2667).

Extraction-only — the `rule-compilation` freeze is untouched (index-only lessons are freeze-exempt per the freeze entry's scope ruling). No compile, no manifest mutation, no compiled-rules change; the `verify-manifest` check will WARN-downgrade the lesson-only staleness under the freeze exactly as it did for mmnto-ai/totem#2664.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
