### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine to 0.1.37 (freeze unchanged; distributes the § 5 design rung)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "optionalDependencies": {
     "@mmnto/cli": "workspace:*",
-    "@mmnto/strategy-doctrine": "0.1.36"
+    "@mmnto/strategy-doctrine": "0.1.37"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.36
-        version: 0.1.36
+        specifier: 0.1.37
+        version: 0.1.37
 
   packages/cli:
     dependencies:
@@ -862,8 +862,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.36':
-    resolution: {integrity: sha512-EK6RE8QcJZ7WEo7G4KxlGBTkbDKUj8kjUXC9pUEOCVdD89eqoMPE87QP4FMRDJwfc+prr0/YoHQbty3Wv0dLdA==}
+  '@mmnto/strategy-doctrine@0.1.37':
+    resolution: {integrity: sha512-gfyOtLjZ9BQzWdVJSbxFT1Ne83Irqe+cU442iJ00swnK6xjDXOc93Sk++zvgA9aK84GEhWihRbrWYkQLqfaWPg==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3694,7 +3694,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.36':
+  '@mmnto/strategy-doctrine@0.1.37':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
## What

Cohort doctrine snapshot upkeep: `@mmnto/strategy-doctrine` `0.1.36` → `0.1.37` (root devDependency pin + lockfile; nothing else). The repo-root package is private, so no changeset.

## What the snapshot delta is (verified by content diff, not the version number)

- **`freeze.json` — byte-identical.** The `rule-compilation` freeze entry rides through unchanged; `verify-manifest`'s freeze consult resolves against `cohort@0.1.37` exactly as before (gate output below).
- **`cohort-overlay.md` — § 5 (the review-leg contract) gains the design rung** (operator-ruled 2026-08-23, admission delta 2026-08-24): between a falsification leg's return and the fold, the seat clusters the leg's refutations by cause and folds ONE SHAPE per class rather than N local patches — structure and behaviour in separate commits; a design-rung fold is semantics-rewiring class wherever it changes contract/spec/code text; clustering bot-specified mechanical remedies into a shape voids the mechanical-remedy exemption. Canonical: `mmnto-ai/totem-strategy:doctrine/model-tiering.md` § The design rung (landed there as `d596955`, PR mmnto-ai/totem-strategy#1116). This binds this repo's seats' fold rounds from this bump forward.
- `strategy-doctrine.lock` — regenerated alongside.

## Gates (in the branch worktree, snapshot consumers exercised)

- `totem verify-manifest` — `PASS — Manifest accepted under freeze: lesson staleness warned (not blocked); 485 rules, output hash matches.` (freeze downgrade resolves via the 0.1.37 snapshot)
- `totem doctor --strict` — clean (`--strict (armed): currently gates nothing`; lesson-federation rows SKIP honest-absent as before)
- `totem orient` — the parked/frozen block still renders both freeze sources
- `pnpm install` lockfile-clean; no source, test, or template change.
