### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine to 0.1.38 (freeze + overlay unchanged; distributes the ci-workflows parity rows)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "optionalDependencies": {
     "@mmnto/cli": "workspace:*",
-    "@mmnto/strategy-doctrine": "0.1.37"
+    "@mmnto/strategy-doctrine": "0.1.38"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.37
-        version: 0.1.37
+        specifier: 0.1.38
+        version: 0.1.38
 
   packages/cli:
     dependencies:
@@ -862,8 +862,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.37':
-    resolution: {integrity: sha512-gfyOtLjZ9BQzWdVJSbxFT1Ne83Irqe+cU442iJ00swnK6xjDXOc93Sk++zvgA9aK84GEhWihRbrWYkQLqfaWPg==}
+  '@mmnto/strategy-doctrine@0.1.38':
+    resolution: {integrity: sha512-Cigq+u9ka5Gir2+UiiQDPk1IMBzLWb6EeiX9PodCVGRsONbcAtaOSxT8GqtSjCWoQznbNXCPyGM36xAxNCbHAA==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3694,7 +3694,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.37':
+  '@mmnto/strategy-doctrine@0.1.38':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
## What

Cohort doctrine snapshot upkeep: `@mmnto/strategy-doctrine` `0.1.37` → `0.1.38` (root devDependency pin + lockfile; nothing else). The repo-root package is private, so no changeset. Published by mmnto-ai/totem-strategy#1152 (tag `strategy-doctrine-v0.1.38` @ `f285f0a4`, OIDC run 33230806574); strategy-claude's 2026-08-29T03:13Z notice; parity reads pin-behind until this lands.

## What the snapshot delta is (verified by content diff of the two published tarballs, not the version number)

- **`freeze.json` — byte-identical.** The `rule-compilation` freeze rides through unchanged; `verify-manifest`'s freeze consult resolves against `cohort@0.1.38` exactly as before (gate output below).
- **`cohort-overlay.md` — byte-identical.** (The § 5c merge-authority doctrine from mmnto-ai/totem-strategy#1151 rides the always-injected surfaces, not this package.)
- **`parity-manifest.yaml` — three new attestation rows** (declared, not sensed; the doctor has no TS-config or workflow reader yet):
  - `review-lanes` (dimension `bot-review-configs`, ruled 2026-08-27): canonical source is this repo's `totem.config.ts#review.lanes`; expected `['anthropic:claude-sonnet-5', 'gemini:gemini-3.5-flash']` — **matches** the current config verbatim.
  - `ci-action-pins` (dimension `ci-workflows`, ruled 2026-08-29): every `uses:` SHA-pinned with a `# v<version>` comment + dependabot `github-actions` ecosystem present — **satisfied on main** as of #2687 (`22456532`; 49/49, incl. the `dtolnay/rust-toolchain@… # v1` fold).
  - `ci-workflow-head-isolation` (`ci-workflows`): consumers `[totem-status]` only — cohort-permits-absence here (no `pull_request_target` workflow beyond `cla.yml`, which is out of the row's stated scope).
- `strategy-doctrine.lock` / `package.json` — version + published-at + content-hash regenerated alongside.

## Gates (in the branch worktree, snapshot consumers exercised)

- `totem verify-manifest` — `PASS — Manifest accepted under freeze: lesson staleness warned (not blocked); 485 rules, output hash matches.` (freeze consult resolves via the 0.1.38 snapshot)
- `totem doctor --strict` — exit 0; freeze row shows `cohort channel ok (@mmnto/strategy-doctrine@0.1.38)`; parity rows SKIP as before.
- `totem orient` — the parked/frozen block renders both freeze sources, cohort @ `strategy-doctrine 0.1.38`.
- `pnpm install` lockfile-clean (integrity `sha512-Cigq+u9k…`); `totem lint` PASS; prettier clean; no source, test, or template change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vw98oJ3HfnAgKmS1BKydy8
