### PR TITLE
ci(spine-spike-linux): a seed20 leg for K7 — record_set matrix (specimens unchanged; seed20 runs the control-only build first, then all → differential → Go → controls) uploading spine-spike-linux-seed20-artifacts; workflow-only, apparatus pin 57f9af5a unchanged

### DIFF
--- a/.github/workflows/spine-spike-linux.yml
+++ b/.github/workflows/spine-spike-linux.yml
@@ -8,7 +8,24 @@
 # seed-20 apparatus lands on `r14/seed20-target-apparatus` — so the trigger follows
 # the SPIKE DIRECTORY on any branch instead of one branch name. A push that touches
 # nothing under `spikes/spine-adopt/**` still does not run it, so `main` and the
-# repo's CI are perturbed no more than before.
+# repo's CI are perturbed no more than before. (This file is in its own path filter
+# too, so an edit to the workflow exercises itself.)
+#
+# TWO LEGS, one matrix (mmnto-ai/totem-strategy#1154 § 5 K7, ruled 2026-08-30):
+#   - `specimens` — the original arm, unchanged: shipped runtime re-derived on
+#     Linux, the OPA differential, the SMT floor + binding probe, the wazero probe,
+#     the K-controls; uploads `spine-spike-linux-artifacts`.
+#   - `seed20` — the R14 seed-20 seam on Linux, in the apparatus's own order
+#     (control-only build FIRST so the seed manifest measures `repinned` from arm B,
+#     then `all` → `differential` → the Go arm → `controls`); uploads
+#     `spine-spike-linux-seed20-artifacts`. Its `artifacts/chains/**` are what the
+#     owner copies to `artifacts/k7-rebuild/chains/` at the run of record, so K7
+#     (`src/controls.mts`) corroborates T6 on the SAME chains across hosts — the
+#     specimens leg's chains overlap a seed run on one package only. K7 compares
+#     `regoSha256` / `wasmSha256` per chain, which are content digests independent
+#     of the commit, so any Linux run of the identical apparatus source + frozen
+#     seed qualifies; the run of record cites the run id it copied from. No
+#     apparatus code moves; the apparatus pin (`57f9af5a`) is unchanged.
 #
 # Tool provisioning reads the URL + sha256 straight out of
 # `spikes/spine-adopt/toolchain.lock` so the lock stays the single source of
@@ -17,7 +34,9 @@ name: Spine Spike (Linux)
 
 on:
   push:
-    paths: [spikes/spine-adopt/**]
+    paths:
+      - spikes/spine-adopt/**
+      - .github/workflows/spine-spike-linux.yml
   workflow_dispatch:
 
 concurrency:
@@ -29,8 +48,12 @@ permissions:
 
 jobs:
   linux:
-    name: spine-adopt harnesses on ubuntu-latest
+    name: spine-adopt harnesses on ubuntu-latest (${{ matrix.record_set }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        record_set: [specimens, seed20]
     env:
       TOOLS_DIR: ${{ github.workspace }}/spikes/spine-adopt/tools
     steps:
@@ -113,6 +136,10 @@ jobs:
           ./z3-5.1.0-x64-glibc-2.39/bin/z3 --version
           ./cvc5-Linux-x86_64-static/bin/cvc5 --version | head -1
 
+      # ═══════════════════════════════════════════════════════════════════════
+      # specimens leg — the original arm, step for step
+      # ═══════════════════════════════════════════════════════════════════════
+
       # ── (a) OPA Rego→Wasm verdict differential ─────────────────────────────
       # `all` FIRST (census → verify-records → facts → shipped-verdicts) so the
       # shipped runtime, fact bundles, and reference verdicts are all re-derived
@@ -131,11 +158,13 @@ jobs:
       # all three hosts, including the Go/wazero arm, which is why setup-go above
       # must stay ahead of this step.
       - name: Spike 1 — shipped runtime re-derived on Linux
+        if: matrix.record_set == 'specimens'
         working-directory: spikes/spine-adopt
         env:
           SPIKE_OPA_BIN: ${{ env.TOOLS_DIR }}/opa_linux_amd64_static
         run: npm run all
       - name: Spike 1 — OPA differential
+        if: matrix.record_set == 'specimens'
         working-directory: spikes/spine-adopt
         env:
           SPIKE_OPA_BIN: ${{ env.TOOLS_DIR }}/opa_linux_amd64_static
@@ -145,6 +174,7 @@ jobs:
       # This is the deliverable floor and MUST pass; the native binding is a
       # separate, explicitly non-fatal step below.
       - name: Spike 2 — SMT obligations (pinned CLI arm)
+        if: matrix.record_set == 'specimens'
         working-directory: spikes/spine-adopt/smt
         env:
           SPIKE_Z3_BIN: ${{ env.TOOLS_DIR }}/z3-5.1.0-x64-glibc-2.39/bin/z3
@@ -156,6 +186,7 @@ jobs:
       # (spec § Failure modes, "z3-sys/cvc5 build fails" => recorded build-matrix
       # row, not a spike failure). The CLI floor above already passed.
       - name: Spike 2 — z3 binding arm (non-fatal build-matrix probe)
+        if: matrix.record_set == 'specimens'
         id: binding
         continue-on-error: true
         working-directory: spikes/spine-adopt/smt
@@ -171,7 +202,7 @@ jobs:
           cargo run --features binding-z3 2>&1 | tee artifacts/binding-z3-linux.log
 
       - name: Record the binding arm's outcome as an artifact row
-        if: always()
+        if: always() && matrix.record_set == 'specimens'
         working-directory: spikes/spine-adopt/smt
         run: |
           mkdir -p artifacts
@@ -187,6 +218,7 @@ jobs:
       # Runs AFTER the differential: it reads that run's lowering-rejects.json,
       # opa-verdicts.json and the rego/*/policy.wasm artifacts.
       - name: Enrichment — wazero probe
+        if: matrix.record_set == 'specimens'
         working-directory: spikes/spine-adopt/wazero-probe
         run: |
           go test ./...
@@ -200,16 +232,74 @@ jobs:
       # Linux arm means `controls.json` is deposited on BOTH platforms from one
       # edit, the way `certify` already is.
       - name: Enrichment — K-controls
+        if: matrix.record_set == 'specimens'
         working-directory: spikes/spine-adopt
         env:
           SPIKE_OPA_BIN: ${{ env.TOOLS_DIR }}/opa_linux_amd64_static
         run: npm run controls
 
+      # ═══════════════════════════════════════════════════════════════════════
+      # seed20 leg — the R14 seed-20 seam, in the apparatus's own order (spec
+      # `.totem/specs/seed20-apparatus-slice2.md` § S5 / § Verification; the
+      # controls-at-the-pin sequence of mmnto-ai/totem#2702). Its chains are
+      # K7's input at the run of record.
+      # ═══════════════════════════════════════════════════════════════════════
+
+      # Control-only build FIRST (K3 arm B): one specimen record under
+      # `SPIKE_CONTROL_RECORD`, output under `artifacts/k3-control/` (the default
+      # subdir for the control set), so the seed manifest below measures
+      # `k3Capture.repinned` FROM this build rather than reporting it unmeasured.
+      # `SPIKE_RECORD_SET` is deliberately unset here: the control set is selected
+      # by the control-record flag alone.
+      - name: Seed-20 — control-only build FIRST (K3 arm B)
+        if: matrix.record_set == 'seed20'
+        working-directory: spikes/spine-adopt
+        env:
+          SPIKE_OPA_BIN: ${{ env.TOOLS_DIR }}/opa_linux_amd64_static
+          SPIKE_CONTROL_RECORD: records/c-supp-astgrep-compound-failopen-catch.rule.yaml
+        run: npm run manifest && npm run lower && npm run build-wasm && npm run certify
+
+      - name: Seed-20 — shipped runtime re-derived on Linux
+        if: matrix.record_set == 'seed20'
+        working-directory: spikes/spine-adopt
+        env:
+          SPIKE_OPA_BIN: ${{ env.TOOLS_DIR }}/opa_linux_amd64_static
+          SPIKE_RECORD_SET: seed20
+        run: npm run all
+
+      - name: Seed-20 — OPA differential
+        if: matrix.record_set == 'seed20'
+        working-directory: spikes/spine-adopt
+        env:
+          SPIKE_OPA_BIN: ${{ env.TOOLS_DIR }}/opa_linux_amd64_static
+          SPIKE_RECORD_SET: seed20
+        run: npm run differential
+
+      - name: Seed-20 — wazero probe
+        if: matrix.record_set == 'seed20'
+        working-directory: spikes/spine-adopt/wazero-probe
+        env:
+          SPIKE_RECORD_SET: seed20
+        run: |
+          go test ./...
+          go run .
+
+      - name: Seed-20 — K-controls
+        if: matrix.record_set == 'seed20'
+        working-directory: spikes/spine-adopt
+        env:
+          SPIKE_OPA_BIN: ${{ env.TOOLS_DIR }}/opa_linux_amd64_static
+          SPIKE_RECORD_SET: seed20
+        run: npm run controls
+
+      # One upload per leg, under distinct names: `spine-spike-linux-artifacts`
+      # (specimens, the name every prior run used) and
+      # `spine-spike-linux-seed20-artifacts` (the K7 source).
       - name: Upload spike artifacts
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: spine-spike-linux-artifacts
+          name: ${{ matrix.record_set == 'seed20' && 'spine-spike-linux-seed20-artifacts' || 'spine-spike-linux-artifacts' }}
           if-no-files-found: error
           path: |
             spikes/spine-adopt/artifacts/**


### PR DESCRIPTION
## K7 on Linux — a `seed20` leg for `Spine Spike (Linux)` (workflow-only; no apparatus code; pin `57f9af5a` unchanged)

Operator's word (2026-08-30, direct), on strategy's recommendation from the mmnto-ai/totem#2702 disclosure: the Linux arm ran the **specimens** set only, so its uploaded chains overlap a seed-20 run on one package and K7 (`src/controls.mts`, "rebuilt on another host with identical `regoSha256` AND `wasmSha256`") could not be measured at the pin — nor at the run of record — without a same-set Linux run. This PR adds that run.

### What changes (one file: `.github/workflows/spine-spike-linux.yml`)

- **A `record_set` matrix — `specimens` · `seed20`, `fail-fast: false`.** The specimens leg is the original arm step for step, gated by `if: matrix.record_set == 'specimens'`; its artifact keeps the name every prior run used (`spine-spike-linux-artifacts`). Setup (checkout, pnpm, node, the pinned rust toolchain, go, install, build, the sha256-verified tool provisioning) is shared, not duplicated. All action SHA pins are untouched.
- **The `seed20` leg runs the apparatus's own seam order** — the one mmnto-ai/totem#2702 executed on Windows: control-only build FIRST (`SPIKE_CONTROL_RECORD`, `SPIKE_RECORD_SET` deliberately unset, so the seed manifest measures `k3Capture.repinned` from arm B) → `SPIKE_RECORD_SET=seed20 npm run all` → `npm run differential` → the Go arm (`go test ./...` + `go run .`) → `npm run controls`. It uploads `spine-spike-linux-seed20-artifacts` (`artifacts/**` + `**/artifacts/**`, `if-no-files-found: error`).
- **The workflow file joins its own path filter** (`on.push.paths`), so an edit to the workflow exercises itself; the `spikes/spine-adopt/**` scope is unchanged otherwise.
- Job name becomes `spine-adopt harnesses on ubuntu-latest (<record_set>)`. Not a required status check (the `main-required-checks` ruleset requires D1, the three Build & Lint legs and Totem Lint only — verified), so the rename gates nothing.

### How K7 uses it (at the run of record — not this PR)

`k7()` compares, per chain filename, `regoSha256` and `wasmSha256` — content digests independent of the commit — against the run's own `artifacts/chains/`. The owner copies the `seed20` leg's `artifacts/chains/**` to `artifacts/k7-rebuild/chains/` and re-runs `controls`, so K7 carries a measured row instead of `null`. Any Linux run of the identical apparatus source + frozen seed qualifies; the run of record names the run id it copied from. A divergence there is a **totem finding** about the toolchain (K7 is non-refusing by charter), never a refusal.

### Gates

- The workflow is dispatched on this branch (`gh workflow run … --ref ci/spine-spike-linux-seed20-k7`): both legs must go green, and the `seed20` leg's artifact must contain the 21 seed chains. The run link is posted below when it completes.
- Repo gates on the push: pre-push `totem lint` (branch scope). No package source changes; no changeset (CI only).

Related: mmnto-ai/totem#2702 (controls at the pin — disclosure 1), mmnto-ai/totem#2699 (the apparatus pin), mmnto-ai/totem-strategy#1154 (§ 5 K7, § 2 G9), mmnto-ai/totem-strategy#1160 (the scorer: `--k7-chains`, default `artifacts/k7-rebuild/chains/`).
