### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine to 0.1.39 — freeze unchanged; distributes the harness-permissions-baseline parity row

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "optionalDependencies": {
     "@mmnto/cli": "workspace:*",
-    "@mmnto/strategy-doctrine": "0.1.38"
+    "@mmnto/strategy-doctrine": "0.1.39"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.38
-        version: 0.1.38
+        specifier: 0.1.39
+        version: 0.1.39
 
   packages/cli:
     dependencies:
@@ -862,8 +862,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.38':
-    resolution: {integrity: sha512-Cigq+u9ka5Gir2+UiiQDPk1IMBzLWb6EeiX9PodCVGRsONbcAtaOSxT8GqtSjCWoQznbNXCPyGM36xAxNCbHAA==}
+  '@mmnto/strategy-doctrine@0.1.39':
+    resolution: {integrity: sha512-hS8x5CyBONc/zeMEJKxRi0FGTiwBlq85ENsnpAnXekS5Rta7YrPWVmxLHJgfXfdyE14ylDzEhRb5TgWbl17aZg==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3694,7 +3694,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.38':
+  '@mmnto/strategy-doctrine@0.1.39':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
## `@mmnto/strategy-doctrine` 0.1.38 → 0.1.39 — freeze unchanged; distributes the harness-permissions-baseline parity row

Operator-directed this session ("update our strategy-doctrine"). The published tarballs were diffed before the bump:

- **The payload:** `parity-manifest.yaml` gains the **harness-permissions-baseline** row (mmnto-ai/totem-strategy#1157 charter; operator direction 2026-08-29) — the positive allow/ask/identity floor for Claude host seats, WC-7 registered for the classifier-order question; `canonical-source: null` until mmnto-ai/totem#2695 ships the distributed block + reader (this row's expected-value is the canonical until then).
- **Freeze unchanged:** the `freeze.json` entry (rule-compilation, parked 2026-05-17) is byte-identical — content-hash `4e4d2c85…` the same in both versions; `cohort-overlay.md` likewise. Only `parity-manifest.yaml`'s content-hash moved (strategy `f285f0a4` → `f57e997e`).
- **Verified at 0.1.39 in this branch's worktree:** `pnpm install` clean; `totem doctor` **11 passed · 5 warnings · 0 failures** (the warnings pre-existing and sense-only). Diff is exactly `package.json` (one line) + `pnpm-lock.yaml` (specifier/version/integrity).
- **No changeset**, per the bump precedent (mmnto-ai/totem#2689, mmnto-ai/totem#2684): an internal consumption pin.

**Sequencing (the seed-20 loop):** this merges BEFORE the next apparatus pin is cut, or after the next run pin — never between the two (the scorer's B-1 containment diff between `manifest.runCommit` and the run pin is repo-wide; a deps commit inside that window would refuse the run pin). The E24 apparatus slice (`r14/seed20-apparatus-slice3`) is not yet open; merging this first keeps the window clean.

Related: mmnto-ai/totem-strategy#1157 · mmnto-ai/totem#2695 · mmnto-ai/totem-strategy#1163.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BoXoT6Ecn1tpyVmk2nYRM
