### PR TITLE
spike(spine-adopt): the E24 apparatus slice — K3b pair fields · explicit error:null · T5 header at the scored 20 · records[].inlineFilePath required · manifest.scorerSha256 (43c8667c) · A12: INV 2 referent re-keyed + the specimens baseline re-homed (the next apparatus pin)

### DIFF
--- a/.github/workflows/spine-spike-linux.yml
+++ b/.github/workflows/spine-spike-linux.yml
@@ -12,9 +12,12 @@
 # too, so an edit to the workflow exercises itself.)
 #
 # TWO LEGS, one matrix (mmnto-ai/totem-strategy#1154 § 5 K7, ruled 2026-08-30):
-#   - `specimens` — the original arm, unchanged: shipped runtime re-derived on
-#     Linux, the OPA differential, the SMT floor + binding probe, the wazero probe,
-#     the K-controls; uploads `spine-spike-linux-artifacts`.
+#   - `specimens` — the original arm: shipped runtime re-derived on Linux, the
+#     OPA differential, the SMT floor + binding probe, the wazero probe, the
+#     K-controls; uploads `spine-spike-linux-artifacts`. Since the run of record
+#     landed at the top-level artifact tree, its INV 2 committed referent is the
+#     re-homed baseline `spikes/spine-adopt/artifacts/specimens/chains/` (A12,
+#     mmnto-ai/totem#2704 — the E24 slice).
 #   - `seed20` — the R14 seed-20 seam on Linux, in the apparatus's own order
 #     (control-only build FIRST so the seed manifest measures `repinned` from arm B,
 #     then `all` → `differential` → the Go arm → `controls`); uploads

--- a/spikes/spine-adopt/artifacts/specimens/chains/r0123456789abcdef_d_file.json
+++ b/spikes/spine-adopt/artifacts/specimens/chains/r0123456789abcdef_d_file.json
@@ -1,0 +1,120 @@
+{
+  "generatedBy": "spikes/spine-adopt/src/build-wasm.mts",
+  "contract": "rego/LOWERING.md § Lowering 1 — sha256(record yaml) → sha256(lowered .rego + fact schema) → sha256(bundle.wasm); Prop 310 Amendment R2 source→IR→artifact",
+  "specimen": "d-file",
+  "ruleId": "0123456789abcdef",
+  "package": "totem.spike.r0123456789abcdef_d_file",
+  "entrypoint": "totem/spike/r0123456789abcdef_d_file/result",
+  "recordSha256": "048f8da56316438929144ad60e5650ece885f44bf26172d1727a1f4ab14ed239",
+  "recordFile": "records/d-requires-file.rule.yaml",
+  "regoSha256": "3525bdd8ec94033d51117dad49e69dca531570c529e85d98cc75887b5623392a",
+  "regoComposition": {
+    "note": "sha256 over the three component digests, labelled and newline-joined in this exact order. Component digests are published so the composite is auditable without re-deriving it.",
+    "order": [
+      "policy.rego",
+      "globs.json",
+      "factSchemaLine"
+    ],
+    "components": {
+      "policy.rego": "dcbcd77a041737297322928b74b650911c6eda6b4552bec20c70df5188382085",
+      "globs.json": "e28b298ed0a8d93c6eb9c0e00c0af87cd39d070c642be98b7e0f6aa038fcf5c9",
+      "factSchemaLine": "3e9643cd65a2335b0b1de3c508e9cadf229ecdd3a29d7519ba33409ed1c3e58f"
+    },
+    "factSchemaLine": "input = { file, fileText: string|null, lines: [string], astMatches: [{lineNumber, lineText, startLineText, startPrecedingLineText}] }",
+    "preimage": "policy.rego:dcbcd77a041737297322928b74b650911c6eda6b4552bec20c70df5188382085\nglobs.json:e28b298ed0a8d93c6eb9c0e00c0af87cd39d070c642be98b7e0f6aa038fcf5c9\nfactSchemaLine:3e9643cd65a2335b0b1de3c508e9cadf229ecdd3a29d7519ba33409ed1c3e58f\n"
+  },
+  "wasmSha256": "07b771da11130e61082f28d41f209e7f44335db10c370b0ff4f33acdf2692aad",
+  "bundleTarballSha256": "f7537894fa9ecfd5a32ab9a7dcfac7047f87746499d5dc91f1f8d6f89851ec6b",
+  "manifest": {
+    "revision": "",
+    "roots": [
+      ""
+    ],
+    "wasm": [
+      {
+        "entrypoint": "totem/spike/r0123456789abcdef_d_file/result",
+        "module": "/policy.wasm"
+      }
+    ],
+    "rego_version": 1
+  },
+  "determinism": {
+    "buildCount": 2,
+    "wasmIdentical": true,
+    "tarballIdentical": true,
+    "wasmSha256": [
+      "07b771da11130e61082f28d41f209e7f44335db10c370b0ff4f33acdf2692aad",
+      "07b771da11130e61082f28d41f209e7f44335db10c370b0ff4f33acdf2692aad"
+    ],
+    "bundleTarballSha256": [
+      "f7537894fa9ecfd5a32ab9a7dcfac7047f87746499d5dc91f1f8d6f89851ec6b",
+      "f7537894fa9ecfd5a32ab9a7dcfac7047f87746499d5dc91f1f8d6f89851ec6b"
+    ]
+  },
+  "manifestSha256": "15b853c2fe8f9f4de2a2f9525ad671042d401846b9dacb09c2d5bb16a10705ec",
+  "entrypointManifest": {
+    "note": "The ENTRYPOINT/IMPORT manifest — the fourth member of the bound set (spec § Actuator slice 3). Distinct from the `manifest` key above, which is the OPA BUNDLE `.manifest` member. Read from the module itself by the same census code path as artifacts/opa-abi-census.json.",
+    "contract": "spec § Actuator slice 3 — manifestSha256 = sha256 of the canonical JSON of {entrypoints[], imports[], builtins{}}",
+    "manifest": {
+      "entrypoints": [
+        "totem/spike/r0123456789abcdef_d_file/result"
+      ],
+      "imports": [
+        "env.memory:memory",
+        "env.opa_abort:function",
+        "env.opa_builtin0:function",
+        "env.opa_builtin1:function",
+        "env.opa_builtin2:function",
+        "env.opa_builtin3:function",
+        "env.opa_builtin4:function"
+      ],
+      "builtins": {}
+    },
+    "canonicalPreimage": "{\"builtins\":{},\"entrypoints\":[\"totem/spike/r0123456789abcdef_d_file/result\"],\"imports\":[\"env.memory:memory\",\"env.opa_abort:function\",\"env.opa_builtin0:function\",\"env.opa_builtin1:function\",\"env.opa_builtin2:function\",\"env.opa_builtin3:function\",\"env.opa_builtin4:function\"]}"
+  },
+  "certified": true,
+  "certification": {
+    "contract": "spec § Actuator slice — \"certification evaluates EVERY emitted entrypoint against a schema-valid sentinel FactBundle BEFORE artifact publication\"",
+    "sentinel": {
+      "file": "certify/sentinel.ts",
+      "fileText": "",
+      "lines": [],
+      "astMatches": []
+    },
+    "sentinelSha256": "bb5b7fff8ba0d974fd8a977280340b13cb9321e9dc59f749f88706899945a6f0",
+    "onlyExportedResultPath": {
+      "ok": true,
+      "detail": "exactly one entrypoint, and it is the canonical `totem/spike/r0123456789abcdef_d_file/result` (`<pkg>/result` derived from the package name, and the expected entrypoint agrees)"
+    },
+    "evaluatedEntrypoints": [
+      "totem/spike/r0123456789abcdef_d_file/result"
+    ],
+    "classifications": [
+      {
+        "entrypoint": "totem/spike/r0123456789abcdef_d_file/result",
+        "status": "PASS",
+        "reason": null,
+        "detail": "defined object with exactly `violations` + `events` (0 violations, 0 events)"
+      }
+    ],
+    "hosts": {
+      "wasmtime": {
+        "abiVersion": "1.3 (1.2+ compatible)",
+        "verdict": "PASS"
+      },
+      "regorus": {
+        "role": "reference differential (LOWERING.md § Host contract) — not a certification gate",
+        "ok": true,
+        "error": null
+      }
+    },
+    "boundSet": [
+      "source: recordSha256",
+      "IR: regoSha256 (lowered .rego + globs + fact schema)",
+      "guarded policy: regoComposition.components[\"policy.rego\"]",
+      "entrypoint/import manifest: manifestSha256",
+      "final Wasm: wasmSha256"
+    ]
+  },
+  "publishedBy": "spikes/spine-adopt/src/certify.mts (certification PASS)"
+}

--- a/spikes/spine-adopt/artifacts/specimens/chains/r0123456789abcdef_d_line.json
+++ b/spikes/spine-adopt/artifacts/specimens/chains/r0123456789abcdef_d_line.json
@@ -1,0 +1,120 @@
+{
+  "generatedBy": "spikes/spine-adopt/src/build-wasm.mts",
+  "contract": "rego/LOWERING.md § Lowering 1 — sha256(record yaml) → sha256(lowered .rego + fact schema) → sha256(bundle.wasm); Prop 310 Amendment R2 source→IR→artifact",
+  "specimen": "d-line",
+  "ruleId": "0123456789abcdef",
+  "package": "totem.spike.r0123456789abcdef_d_line",
+  "entrypoint": "totem/spike/r0123456789abcdef_d_line/result",
+  "recordSha256": "76e5e1725e0c0fa0c4baee22304351bd2f05119018f53887068f2b47c67d4449",
+  "recordFile": "records/d-requires-line.rule.yaml",
+  "regoSha256": "cf5d25f929b85c0dadb0a56def1932c436084b9957e547758f444cf76bf0f8bb",
+  "regoComposition": {
+    "note": "sha256 over the three component digests, labelled and newline-joined in this exact order. Component digests are published so the composite is auditable without re-deriving it.",
+    "order": [
+      "policy.rego",
+      "globs.json",
+      "factSchemaLine"
+    ],
+    "components": {
+      "policy.rego": "264ef7932ae142ff405b6ff21c8e669f75c1fad0d85f67a35795890a12f7c109",
+      "globs.json": "573d33f195009cd4aedfd130b4f3c434163b2b1e8ff0bd9564292125bdac3fa5",
+      "factSchemaLine": "3e9643cd65a2335b0b1de3c508e9cadf229ecdd3a29d7519ba33409ed1c3e58f"
+    },
+    "factSchemaLine": "input = { file, fileText: string|null, lines: [string], astMatches: [{lineNumber, lineText, startLineText, startPrecedingLineText}] }",
+    "preimage": "policy.rego:264ef7932ae142ff405b6ff21c8e669f75c1fad0d85f67a35795890a12f7c109\nglobs.json:573d33f195009cd4aedfd130b4f3c434163b2b1e8ff0bd9564292125bdac3fa5\nfactSchemaLine:3e9643cd65a2335b0b1de3c508e9cadf229ecdd3a29d7519ba33409ed1c3e58f\n"
+  },
+  "wasmSha256": "ea46fa323435ea077774bce967c4683af46024d129d0263b5a18dc6fd4d20e10",
+  "bundleTarballSha256": "7432111105ae10f226fd436a0c39815363f0033126897fb5f0450a70a466113f",
+  "manifest": {
+    "revision": "",
+    "roots": [
+      ""
+    ],
+    "wasm": [
+      {
+        "entrypoint": "totem/spike/r0123456789abcdef_d_line/result",
+        "module": "/policy.wasm"
+      }
+    ],
+    "rego_version": 1
+  },
+  "determinism": {
+    "buildCount": 2,
+    "wasmIdentical": true,
+    "tarballIdentical": true,
+    "wasmSha256": [
+      "ea46fa323435ea077774bce967c4683af46024d129d0263b5a18dc6fd4d20e10",
+      "ea46fa323435ea077774bce967c4683af46024d129d0263b5a18dc6fd4d20e10"
+    ],
+    "bundleTarballSha256": [
+      "7432111105ae10f226fd436a0c39815363f0033126897fb5f0450a70a466113f",
+      "7432111105ae10f226fd436a0c39815363f0033126897fb5f0450a70a466113f"
+    ]
+  },
+  "manifestSha256": "21368409551a7f6424d5cd1512da006ba3982ae6bf118eb6de1bec25916f7ecc",
+  "entrypointManifest": {
+    "note": "The ENTRYPOINT/IMPORT manifest — the fourth member of the bound set (spec § Actuator slice 3). Distinct from the `manifest` key above, which is the OPA BUNDLE `.manifest` member. Read from the module itself by the same census code path as artifacts/opa-abi-census.json.",
+    "contract": "spec § Actuator slice 3 — manifestSha256 = sha256 of the canonical JSON of {entrypoints[], imports[], builtins{}}",
+    "manifest": {
+      "entrypoints": [
+        "totem/spike/r0123456789abcdef_d_line/result"
+      ],
+      "imports": [
+        "env.memory:memory",
+        "env.opa_abort:function",
+        "env.opa_builtin0:function",
+        "env.opa_builtin1:function",
+        "env.opa_builtin2:function",
+        "env.opa_builtin3:function",
+        "env.opa_builtin4:function"
+      ],
+      "builtins": {}
+    },
+    "canonicalPreimage": "{\"builtins\":{},\"entrypoints\":[\"totem/spike/r0123456789abcdef_d_line/result\"],\"imports\":[\"env.memory:memory\",\"env.opa_abort:function\",\"env.opa_builtin0:function\",\"env.opa_builtin1:function\",\"env.opa_builtin2:function\",\"env.opa_builtin3:function\",\"env.opa_builtin4:function\"]}"
+  },
+  "certified": true,
+  "certification": {
+    "contract": "spec § Actuator slice — \"certification evaluates EVERY emitted entrypoint against a schema-valid sentinel FactBundle BEFORE artifact publication\"",
+    "sentinel": {
+      "file": "certify/sentinel.ts",
+      "fileText": "",
+      "lines": [],
+      "astMatches": []
+    },
+    "sentinelSha256": "bb5b7fff8ba0d974fd8a977280340b13cb9321e9dc59f749f88706899945a6f0",
+    "onlyExportedResultPath": {
+      "ok": true,
+      "detail": "exactly one entrypoint, and it is the canonical `totem/spike/r0123456789abcdef_d_line/result` (`<pkg>/result` derived from the package name, and the expected entrypoint agrees)"
+    },
+    "evaluatedEntrypoints": [
+      "totem/spike/r0123456789abcdef_d_line/result"
+    ],
+    "classifications": [
+      {
+        "entrypoint": "totem/spike/r0123456789abcdef_d_line/result",
+        "status": "PASS",
+        "reason": null,
+        "detail": "defined object with exactly `violations` + `events` (0 violations, 0 events)"
+      }
+    ],
+    "hosts": {
+      "wasmtime": {
+        "abiVersion": "1.3 (1.2+ compatible)",
+        "verdict": "PASS"
+      },
+      "regorus": {
+        "role": "reference differential (LOWERING.md § Host contract) — not a certification gate",
+        "ok": true,
+        "error": null
+      }
+    },
+    "boundSet": [
+      "source: recordSha256",
+      "IR: regoSha256 (lowered .rego + globs + fact schema)",
+      "guarded policy: regoComposition.components[\"policy.rego\"]",
+      "entrypoint/import manifest: manifestSha256",
+      "final Wasm: wasmSha256"
+    ]
+  },
+  "publishedBy": "spikes/spine-adopt/src/certify.mts (certification PASS)"
+}

--- a/spikes/spine-adopt/artifacts/specimens/chains/r0123456789abcdef_e.json
+++ b/spikes/spine-adopt/artifacts/specimens/chains/r0123456789abcdef_e.json
@@ -1,0 +1,120 @@
+{
+  "generatedBy": "spikes/spine-adopt/src/build-wasm.mts",
+  "contract": "rego/LOWERING.md § Lowering 1 — sha256(record yaml) → sha256(lowered .rego + fact schema) → sha256(bundle.wasm); Prop 310 Amendment R2 source→IR→artifact",
+  "specimen": "e",
+  "ruleId": "0123456789abcdef",
+  "package": "totem.spike.r0123456789abcdef_e",
+  "entrypoint": "totem/spike/r0123456789abcdef_e/result",
+  "recordSha256": "d42a48e025863d320a214ee5c1c577e437b8cf4b068f2d5572ac8f8bbcf12ee8",
+  "recordFile": "records/e-exception-excludeglobs.rule.yaml",
+  "regoSha256": "9f2bbf2bfc222ee9b91b0929a9df0edf53efdc3fc3eee66c032855f0a61e2de2",
+  "regoComposition": {
+    "note": "sha256 over the three component digests, labelled and newline-joined in this exact order. Component digests are published so the composite is auditable without re-deriving it.",
+    "order": [
+      "policy.rego",
+      "globs.json",
+      "factSchemaLine"
+    ],
+    "components": {
+      "policy.rego": "50cd2f2d98d6239e2d9c3546d088f22bd05bdb49495c06ce3636ace67cd79739",
+      "globs.json": "d9fe4718ea5ac3350c721aa9add0cd94ce3b65c5e4f44994a10b5788bccf539b",
+      "factSchemaLine": "3e9643cd65a2335b0b1de3c508e9cadf229ecdd3a29d7519ba33409ed1c3e58f"
+    },
+    "factSchemaLine": "input = { file, fileText: string|null, lines: [string], astMatches: [{lineNumber, lineText, startLineText, startPrecedingLineText}] }",
+    "preimage": "policy.rego:50cd2f2d98d6239e2d9c3546d088f22bd05bdb49495c06ce3636ace67cd79739\nglobs.json:d9fe4718ea5ac3350c721aa9add0cd94ce3b65c5e4f44994a10b5788bccf539b\nfactSchemaLine:3e9643cd65a2335b0b1de3c508e9cadf229ecdd3a29d7519ba33409ed1c3e58f\n"
+  },
+  "wasmSha256": "b81f809552a233b376eabd252c94dd4db5de85e22e940206ab01a657c1144bd9",
+  "bundleTarballSha256": "0c734aa1f6745cc413034b3ecd0b6cc1995ca128f4c39fa9704de5f1f0793eaa",
+  "manifest": {
+    "revision": "",
+    "roots": [
+      ""
+    ],
+    "wasm": [
+      {
+        "entrypoint": "totem/spike/r0123456789abcdef_e/result",
+        "module": "/policy.wasm"
+      }
+    ],
+    "rego_version": 1
+  },
+  "determinism": {
+    "buildCount": 2,
+    "wasmIdentical": true,
+    "tarballIdentical": true,
+    "wasmSha256": [
+      "b81f809552a233b376eabd252c94dd4db5de85e22e940206ab01a657c1144bd9",
+      "b81f809552a233b376eabd252c94dd4db5de85e22e940206ab01a657c1144bd9"
+    ],
+    "bundleTarballSha256": [
+      "0c734aa1f6745cc413034b3ecd0b6cc1995ca128f4c39fa9704de5f1f0793eaa",
+      "0c734aa1f6745cc413034b3ecd0b6cc1995ca128f4c39fa9704de5f1f0793eaa"
+    ]
+  },
+  "manifestSha256": "9d75a0488d8057d16c80be39e81cda8c9d215d86f6c48f05400fdfb92e29d0d8",
+  "entrypointManifest": {
+    "note": "The ENTRYPOINT/IMPORT manifest — the fourth member of the bound set (spec § Actuator slice 3). Distinct from the `manifest` key above, which is the OPA BUNDLE `.manifest` member. Read from the module itself by the same census code path as artifacts/opa-abi-census.json.",
+    "contract": "spec § Actuator slice 3 — manifestSha256 = sha256 of the canonical JSON of {entrypoints[], imports[], builtins{}}",
+    "manifest": {
+      "entrypoints": [
+        "totem/spike/r0123456789abcdef_e/result"
+      ],
+      "imports": [
+        "env.memory:memory",
+        "env.opa_abort:function",
+        "env.opa_builtin0:function",
+        "env.opa_builtin1:function",
+        "env.opa_builtin2:function",
+        "env.opa_builtin3:function",
+        "env.opa_builtin4:function"
+      ],
+      "builtins": {}
+    },
+    "canonicalPreimage": "{\"builtins\":{},\"entrypoints\":[\"totem/spike/r0123456789abcdef_e/result\"],\"imports\":[\"env.memory:memory\",\"env.opa_abort:function\",\"env.opa_builtin0:function\",\"env.opa_builtin1:function\",\"env.opa_builtin2:function\",\"env.opa_builtin3:function\",\"env.opa_builtin4:function\"]}"
+  },
+  "certified": true,
+  "certification": {
+    "contract": "spec § Actuator slice — \"certification evaluates EVERY emitted entrypoint against a schema-valid sentinel FactBundle BEFORE artifact publication\"",
+    "sentinel": {
+      "file": "certify/sentinel.ts",
+      "fileText": "",
+      "lines": [],
+      "astMatches": []
+    },
+    "sentinelSha256": "bb5b7fff8ba0d974fd8a977280340b13cb9321e9dc59f749f88706899945a6f0",
+    "onlyExportedResultPath": {
+      "ok": true,
+      "detail": "exactly one entrypoint, and it is the canonical `totem/spike/r0123456789abcdef_e/result` (`<pkg>/result` derived from the package name, and the expected entrypoint agrees)"
+    },
+    "evaluatedEntrypoints": [
+      "totem/spike/r0123456789abcdef_e/result"
+    ],
+    "classifications": [
+      {
+        "entrypoint": "totem/spike/r0123456789abcdef_e/result",
+        "status": "PASS",
+        "reason": null,
+        "detail": "defined object with exactly `violations` + `events` (0 violations, 0 events)"
+      }
+    ],
+    "hosts": {
+      "wasmtime": {
+        "abiVersion": "1.3 (1.2+ compatible)",
+        "verdict": "PASS"
+      },
+      "regorus": {
+        "role": "reference differential (LOWERING.md § Host contract) — not a certification gate",
+        "ok": true,
+        "error": null
+      }
+    },
+    "boundSet": [
+      "source: recordSha256",
+      "IR: regoSha256 (lowered .rego + globs + fact schema)",
+      "guarded policy: regoComposition.components[\"policy.rego\"]",
+      "entrypoint/import manifest: manifestSha256",
+      "final Wasm: wasmSha256"
+    ]
+  },
+  "publishedBy": "spikes/spine-adopt/src/certify.mts (certification PASS)"
+}

--- a/spikes/spine-adopt/artifacts/specimens/chains/r2d962603591aa928.json
+++ b/spikes/spine-adopt/artifacts/specimens/chains/r2d962603591aa928.json
@@ -1,0 +1,120 @@
+{
+  "generatedBy": "spikes/spine-adopt/src/build-wasm.mts",
+  "contract": "rego/LOWERING.md § Lowering 1 — sha256(record yaml) → sha256(lowered .rego + fact schema) → sha256(bundle.wasm); Prop 310 Amendment R2 source→IR→artifact",
+  "specimen": "b",
+  "ruleId": "2d962603591aa928",
+  "package": "totem.spike.r2d962603591aa928",
+  "entrypoint": "totem/spike/r2d962603591aa928/result",
+  "recordSha256": "40bd79d7c970e21edced9b9ef90bedbec66e1fbf6d98d8c10e3dd6f6f19dbd19",
+  "recordFile": "records/b-astgrep-flat-empty-catch.rule.yaml",
+  "regoSha256": "634fc78f98b73f867c4bcf3fb2898ba7dc6acffd161c4cd1619dff8017f4c48b",
+  "regoComposition": {
+    "note": "sha256 over the three component digests, labelled and newline-joined in this exact order. Component digests are published so the composite is auditable without re-deriving it.",
+    "order": [
+      "policy.rego",
+      "globs.json",
+      "factSchemaLine"
+    ],
+    "components": {
+      "policy.rego": "a84403a07362e8cbd04226c9dc6cce0dca18b9a0d64281a23ce77cfd8010d681",
+      "globs.json": "17f9ced87f5bca2eaf7eb80bfe5c5e3c4f14608ec21090119f8a17e502ee6110",
+      "factSchemaLine": "3e9643cd65a2335b0b1de3c508e9cadf229ecdd3a29d7519ba33409ed1c3e58f"
+    },
+    "factSchemaLine": "input = { file, fileText: string|null, lines: [string], astMatches: [{lineNumber, lineText, startLineText, startPrecedingLineText}] }",
+    "preimage": "policy.rego:a84403a07362e8cbd04226c9dc6cce0dca18b9a0d64281a23ce77cfd8010d681\nglobs.json:17f9ced87f5bca2eaf7eb80bfe5c5e3c4f14608ec21090119f8a17e502ee6110\nfactSchemaLine:3e9643cd65a2335b0b1de3c508e9cadf229ecdd3a29d7519ba33409ed1c3e58f\n"
+  },
+  "wasmSha256": "761f95f29e6e4272e0b4e51e1a8812116f0618a04d0d7b69e9c4dcacc28c0f2c",
+  "bundleTarballSha256": "fbc9560131d3be79df8feefaeba334a0b5ba7a2c0d7ac726d8ba63b4d9490698",
+  "manifest": {
+    "revision": "",
+    "roots": [
+      ""
+    ],
+    "wasm": [
+      {
+        "entrypoint": "totem/spike/r2d962603591aa928/result",
+        "module": "/policy.wasm"
+      }
+    ],
+    "rego_version": 1
+  },
+  "determinism": {
+    "buildCount": 2,
+    "wasmIdentical": true,
+    "tarballIdentical": true,
+    "wasmSha256": [
+      "761f95f29e6e4272e0b4e51e1a8812116f0618a04d0d7b69e9c4dcacc28c0f2c",
+      "761f95f29e6e4272e0b4e51e1a8812116f0618a04d0d7b69e9c4dcacc28c0f2c"
+    ],
+    "bundleTarballSha256": [
+      "fbc9560131d3be79df8feefaeba334a0b5ba7a2c0d7ac726d8ba63b4d9490698",
+      "fbc9560131d3be79df8feefaeba334a0b5ba7a2c0d7ac726d8ba63b4d9490698"
+    ]
+  },
+  "manifestSha256": "084b4852e2180feb456be6d45be05ba5a705cd4cf86748f5995b7d19616d83a7",
+  "entrypointManifest": {
+    "note": "The ENTRYPOINT/IMPORT manifest — the fourth member of the bound set (spec § Actuator slice 3). Distinct from the `manifest` key above, which is the OPA BUNDLE `.manifest` member. Read from the module itself by the same census code path as artifacts/opa-abi-census.json.",
+    "contract": "spec § Actuator slice 3 — manifestSha256 = sha256 of the canonical JSON of {entrypoints[], imports[], builtins{}}",
+    "manifest": {
+      "entrypoints": [
+        "totem/spike/r2d962603591aa928/result"
+      ],
+      "imports": [
+        "env.memory:memory",
+        "env.opa_abort:function",
+        "env.opa_builtin0:function",
+        "env.opa_builtin1:function",
+        "env.opa_builtin2:function",
+        "env.opa_builtin3:function",
+        "env.opa_builtin4:function"
+      ],
+      "builtins": {}
+    },
+    "canonicalPreimage": "{\"builtins\":{},\"entrypoints\":[\"totem/spike/r2d962603591aa928/result\"],\"imports\":[\"env.memory:memory\",\"env.opa_abort:function\",\"env.opa_builtin0:function\",\"env.opa_builtin1:function\",\"env.opa_builtin2:function\",\"env.opa_builtin3:function\",\"env.opa_builtin4:function\"]}"
+  },
+  "certified": true,
+  "certification": {
+    "contract": "spec § Actuator slice — \"certification evaluates EVERY emitted entrypoint against a schema-valid sentinel FactBundle BEFORE artifact publication\"",
+    "sentinel": {
+      "file": "certify/sentinel.ts",
+      "fileText": "",
+      "lines": [],
+      "astMatches": []
+    },
+    "sentinelSha256": "bb5b7fff8ba0d974fd8a977280340b13cb9321e9dc59f749f88706899945a6f0",
+    "onlyExportedResultPath": {
+      "ok": true,
+      "detail": "exactly one entrypoint, and it is the canonical `totem/spike/r2d962603591aa928/result` (`<pkg>/result` derived from the package name, and the expected entrypoint agrees)"
+    },
+    "evaluatedEntrypoints": [
+      "totem/spike/r2d962603591aa928/result"
+    ],
+    "classifications": [
+      {
+        "entrypoint": "totem/spike/r2d962603591aa928/result",
+        "status": "PASS",
+        "reason": null,
+        "detail": "defined object with exactly `violations` + `events` (0 violations, 0 events)"
+      }
+    ],
+    "hosts": {
+      "wasmtime": {
+        "abiVersion": "1.3 (1.2+ compatible)",
+        "verdict": "PASS"
+      },
+      "regorus": {
+        "role": "reference differential (LOWERING.md § Host contract) — not a certification gate",
+        "ok": true,
+        "error": null
+      }
+    },
+    "boundSet": [
+      "source: recordSha256",
+      "IR: regoSha256 (lowered .rego + globs + fact schema)",
+      "guarded policy: regoComposition.components[\"policy.rego\"]",
+      "entrypoint/import manifest: manifestSha256",
+      "final Wasm: wasmSha256"
+    ]
+  },
+  "publishedBy": "spikes/spine-adopt/src/certify.mts (certification PASS)"
+}

--- a/spikes/spine-adopt/artifacts/specimens/chains/r61dcb058bd1df15d.json
+++ b/spikes/spine-adopt/artifacts/specimens/chains/r61dcb058bd1df15d.json
@@ -1,0 +1,120 @@
+{
+  "generatedBy": "spikes/spine-adopt/src/build-wasm.mts",
+  "contract": "rego/LOWERING.md § Lowering 1 — sha256(record yaml) → sha256(lowered .rego + fact schema) → sha256(bundle.wasm); Prop 310 Amendment R2 source→IR→artifact",
+  "specimen": "a",
+  "ruleId": "61dcb058bd1df15d",
+  "package": "totem.spike.r61dcb058bd1df15d",
+  "entrypoint": "totem/spike/r61dcb058bd1df15d/result",
+  "recordSha256": "24be123733cda7a3a5a345d2fedb0633607344fdc375af587a8a7e31f2f345ad",
+  "recordFile": "records/a-regex-lessons-rm-guard.rule.yaml",
+  "regoSha256": "12c788f645b3369a52dbfae52f17f744f21e524016b62d4b72d4ec777c1f2abc",
+  "regoComposition": {
+    "note": "sha256 over the three component digests, labelled and newline-joined in this exact order. Component digests are published so the composite is auditable without re-deriving it.",
+    "order": [
+      "policy.rego",
+      "globs.json",
+      "factSchemaLine"
+    ],
+    "components": {
+      "policy.rego": "77942137614cd9016fc286a88c8db112f238b810196b49758ec30c0dd1b34829",
+      "globs.json": "abd916ad074c8ec20febec397002b3d1084fb3528c39630bcb5449028d4dd645",
+      "factSchemaLine": "3e9643cd65a2335b0b1de3c508e9cadf229ecdd3a29d7519ba33409ed1c3e58f"
+    },
+    "factSchemaLine": "input = { file, fileText: string|null, lines: [string], astMatches: [{lineNumber, lineText, startLineText, startPrecedingLineText}] }",
+    "preimage": "policy.rego:77942137614cd9016fc286a88c8db112f238b810196b49758ec30c0dd1b34829\nglobs.json:abd916ad074c8ec20febec397002b3d1084fb3528c39630bcb5449028d4dd645\nfactSchemaLine:3e9643cd65a2335b0b1de3c508e9cadf229ecdd3a29d7519ba33409ed1c3e58f\n"
+  },
+  "wasmSha256": "757f8118a34de759cb541c3a2cfe37b2ecb2414cdb43e2138daabc3d76539a48",
+  "bundleTarballSha256": "1c97f06193df25da6a2eada3952dfcb4671b28f271bd1140440139281b3c69aa",
+  "manifest": {
+    "revision": "",
+    "roots": [
+      ""
+    ],
+    "wasm": [
+      {
+        "entrypoint": "totem/spike/r61dcb058bd1df15d/result",
+        "module": "/policy.wasm"
+      }
+    ],
+    "rego_version": 1
+  },
+  "determinism": {
+    "buildCount": 2,
+    "wasmIdentical": true,
+    "tarballIdentical": true,
+    "wasmSha256": [
+      "757f8118a34de759cb541c3a2cfe37b2ecb2414cdb43e2138daabc3d76539a48",
+      "757f8118a34de759cb541c3a2cfe37b2ecb2414cdb43e2138daabc3d76539a48"
+    ],
+    "bundleTarballSha256": [
+      "1c97f06193df25da6a2eada3952dfcb4671b28f271bd1140440139281b3c69aa",
+      "1c97f06193df25da6a2eada3952dfcb4671b28f271bd1140440139281b3c69aa"
+    ]
+  },
+  "manifestSha256": "d5a3b732780f60232dde8f6f7e81e0eff5269fe1b2781a652cf5900c7c7c5616",
+  "entrypointManifest": {
+    "note": "The ENTRYPOINT/IMPORT manifest — the fourth member of the bound set (spec § Actuator slice 3). Distinct from the `manifest` key above, which is the OPA BUNDLE `.manifest` member. Read from the module itself by the same census code path as artifacts/opa-abi-census.json.",
+    "contract": "spec § Actuator slice 3 — manifestSha256 = sha256 of the canonical JSON of {entrypoints[], imports[], builtins{}}",
+    "manifest": {
+      "entrypoints": [
+        "totem/spike/r61dcb058bd1df15d/result"
+      ],
+      "imports": [
+        "env.memory:memory",
+        "env.opa_abort:function",
+        "env.opa_builtin0:function",
+        "env.opa_builtin1:function",
+        "env.opa_builtin2:function",
+        "env.opa_builtin3:function",
+        "env.opa_builtin4:function"
+      ],
+      "builtins": {}
+    },
+    "canonicalPreimage": "{\"builtins\":{},\"entrypoints\":[\"totem/spike/r61dcb058bd1df15d/result\"],\"imports\":[\"env.memory:memory\",\"env.opa_abort:function\",\"env.opa_builtin0:function\",\"env.opa_builtin1:function\",\"env.opa_builtin2:function\",\"env.opa_builtin3:function\",\"env.opa_builtin4:function\"]}"
+  },
+  "certified": true,
+  "certification": {
+    "contract": "spec § Actuator slice — \"certification evaluates EVERY emitted entrypoint against a schema-valid sentinel FactBundle BEFORE artifact publication\"",
+    "sentinel": {
+      "file": "certify/sentinel.ts",
+      "fileText": "",
+      "lines": [],
+      "astMatches": []
+    },
+    "sentinelSha256": "bb5b7fff8ba0d974fd8a977280340b13cb9321e9dc59f749f88706899945a6f0",
+    "onlyExportedResultPath": {
+      "ok": true,
+      "detail": "exactly one entrypoint, and it is the canonical `totem/spike/r61dcb058bd1df15d/result` (`<pkg>/result` derived from the package name, and the expected entrypoint agrees)"
+    },
+    "evaluatedEntrypoints": [
+      "totem/spike/r61dcb058bd1df15d/result"
+    ],
+    "classifications": [
+      {
+        "entrypoint": "totem/spike/r61dcb058bd1df15d/result",
+        "status": "PASS",
+        "reason": null,
+        "detail": "defined object with exactly `violations` + `events` (0 violations, 0 events)"
+      }
+    ],
+    "hosts": {
+      "wasmtime": {
+        "abiVersion": "1.3 (1.2+ compatible)",
+        "verdict": "PASS"
+      },
+      "regorus": {
+        "role": "reference differential (LOWERING.md § Host contract) — not a certification gate",
+        "ok": true,
+        "error": null
+      }
+    },
+    "boundSet": [
+      "source: recordSha256",
+      "IR: regoSha256 (lowered .rego + globs + fact schema)",
+      "guarded policy: regoComposition.components[\"policy.rego\"]",
+      "entrypoint/import manifest: manifestSha256",
+      "final Wasm: wasmSha256"
+    ]
+  },
+  "publishedBy": "spikes/spine-adopt/src/certify.mts (certification PASS)"
+}

--- a/spikes/spine-adopt/artifacts/specimens/chains/r87aff037d7de47a7.json
+++ b/spikes/spine-adopt/artifacts/specimens/chains/r87aff037d7de47a7.json
@@ -1,0 +1,120 @@
+{
+  "generatedBy": "spikes/spine-adopt/src/build-wasm.mts",
+  "contract": "rego/LOWERING.md § Lowering 1 — sha256(record yaml) → sha256(lowered .rego + fact schema) → sha256(bundle.wasm); Prop 310 Amendment R2 source→IR→artifact",
+  "specimen": "c-supp",
+  "ruleId": "87aff037d7de47a7",
+  "package": "totem.spike.r87aff037d7de47a7",
+  "entrypoint": "totem/spike/r87aff037d7de47a7/result",
+  "recordSha256": "27ba70dd4820e67fc528c9c660f632f78586bc85608b4d783dc62897a8e7171d",
+  "recordFile": "records/c-supp-astgrep-compound-failopen-catch.rule.yaml",
+  "regoSha256": "e3d32564de9c7463a8ce70033a9b7378cbd306ebc68a4de19b05172000c42ca8",
+  "regoComposition": {
+    "note": "sha256 over the three component digests, labelled and newline-joined in this exact order. Component digests are published so the composite is auditable without re-deriving it.",
+    "order": [
+      "policy.rego",
+      "globs.json",
+      "factSchemaLine"
+    ],
+    "components": {
+      "policy.rego": "528c8d80ce148a404c2a6ff97fcb6df5b889eeeab83228618b5c455932ee48db",
+      "globs.json": "3288f10c51e1163046fec34c952242ec14cc6e64a2a58497ae2d80f4b66937a7",
+      "factSchemaLine": "3e9643cd65a2335b0b1de3c508e9cadf229ecdd3a29d7519ba33409ed1c3e58f"
+    },
+    "factSchemaLine": "input = { file, fileText: string|null, lines: [string], astMatches: [{lineNumber, lineText, startLineText, startPrecedingLineText}] }",
+    "preimage": "policy.rego:528c8d80ce148a404c2a6ff97fcb6df5b889eeeab83228618b5c455932ee48db\nglobs.json:3288f10c51e1163046fec34c952242ec14cc6e64a2a58497ae2d80f4b66937a7\nfactSchemaLine:3e9643cd65a2335b0b1de3c508e9cadf229ecdd3a29d7519ba33409ed1c3e58f\n"
+  },
+  "wasmSha256": "f1c2c73119b1f5e6dd2098b0662844a4c79e7eaafdcdb4fee68921b5c83418ec",
+  "bundleTarballSha256": "db5eb1a9d2f8d3d628d00b854630fcdc143ac3f30fac87f4035cc668fdddab38",
+  "manifest": {
+    "revision": "",
+    "roots": [
+      ""
+    ],
+    "wasm": [
+      {
+        "entrypoint": "totem/spike/r87aff037d7de47a7/result",
+        "module": "/policy.wasm"
+      }
+    ],
+    "rego_version": 1
+  },
+  "determinism": {
+    "buildCount": 2,
+    "wasmIdentical": true,
+    "tarballIdentical": true,
+    "wasmSha256": [
+      "f1c2c73119b1f5e6dd2098b0662844a4c79e7eaafdcdb4fee68921b5c83418ec",
+      "f1c2c73119b1f5e6dd2098b0662844a4c79e7eaafdcdb4fee68921b5c83418ec"
+    ],
+    "bundleTarballSha256": [
+      "db5eb1a9d2f8d3d628d00b854630fcdc143ac3f30fac87f4035cc668fdddab38",
+      "db5eb1a9d2f8d3d628d00b854630fcdc143ac3f30fac87f4035cc668fdddab38"
+    ]
+  },
+  "manifestSha256": "d3fcc0b58295aeb494b75769283efe7eb4c4a165308913b23111e19e8c7b37c8",
+  "entrypointManifest": {
+    "note": "The ENTRYPOINT/IMPORT manifest — the fourth member of the bound set (spec § Actuator slice 3). Distinct from the `manifest` key above, which is the OPA BUNDLE `.manifest` member. Read from the module itself by the same census code path as artifacts/opa-abi-census.json.",
+    "contract": "spec § Actuator slice 3 — manifestSha256 = sha256 of the canonical JSON of {entrypoints[], imports[], builtins{}}",
+    "manifest": {
+      "entrypoints": [
+        "totem/spike/r87aff037d7de47a7/result"
+      ],
+      "imports": [
+        "env.memory:memory",
+        "env.opa_abort:function",
+        "env.opa_builtin0:function",
+        "env.opa_builtin1:function",
+        "env.opa_builtin2:function",
+        "env.opa_builtin3:function",
+        "env.opa_builtin4:function"
+      ],
+      "builtins": {}
+    },
+    "canonicalPreimage": "{\"builtins\":{},\"entrypoints\":[\"totem/spike/r87aff037d7de47a7/result\"],\"imports\":[\"env.memory:memory\",\"env.opa_abort:function\",\"env.opa_builtin0:function\",\"env.opa_builtin1:function\",\"env.opa_builtin2:function\",\"env.opa_builtin3:function\",\"env.opa_builtin4:function\"]}"
+  },
+  "certified": true,
+  "certification": {
+    "contract": "spec § Actuator slice — \"certification evaluates EVERY emitted entrypoint against a schema-valid sentinel FactBundle BEFORE artifact publication\"",
+    "sentinel": {
+      "file": "certify/sentinel.ts",
+      "fileText": "",
+      "lines": [],
+      "astMatches": []
+    },
+    "sentinelSha256": "bb5b7fff8ba0d974fd8a977280340b13cb9321e9dc59f749f88706899945a6f0",
+    "onlyExportedResultPath": {
+      "ok": true,
+      "detail": "exactly one entrypoint, and it is the canonical `totem/spike/r87aff037d7de47a7/result` (`<pkg>/result` derived from the package name, and the expected entrypoint agrees)"
+    },
+    "evaluatedEntrypoints": [
+      "totem/spike/r87aff037d7de47a7/result"
+    ],
+    "classifications": [
+      {
+        "entrypoint": "totem/spike/r87aff037d7de47a7/result",
+        "status": "PASS",
+        "reason": null,
+        "detail": "defined object with exactly `violations` + `events` (0 violations, 0 events)"
+      }
+    ],
+    "hosts": {
+      "wasmtime": {
+        "abiVersion": "1.3 (1.2+ compatible)",
+        "verdict": "PASS"
+      },
+      "regorus": {
+        "role": "reference differential (LOWERING.md § Host contract) — not a certification gate",
+        "ok": true,
+        "error": null
+      }
+    },
+    "boundSet": [
+      "source: recordSha256",
+      "IR: regoSha256 (lowered .rego + globs + fact schema)",
+      "guarded policy: regoComposition.components[\"policy.rego\"]",
+      "entrypoint/import manifest: manifestSha256",
+      "final Wasm: wasmSha256"
+    ]
+  },
+  "publishedBy": "spikes/spine-adopt/src/certify.mts (certification PASS)"
+}

--- a/spikes/spine-adopt/artifacts/specimens/chains/rd0815b6769304e26.json
+++ b/spikes/spine-adopt/artifacts/specimens/chains/rd0815b6769304e26.json
@@ -1,0 +1,120 @@
+{
+  "generatedBy": "spikes/spine-adopt/src/build-wasm.mts",
+  "contract": "rego/LOWERING.md § Lowering 1 — sha256(record yaml) → sha256(lowered .rego + fact schema) → sha256(bundle.wasm); Prop 310 Amendment R2 source→IR→artifact",
+  "specimen": "c",
+  "ruleId": "d0815b6769304e26",
+  "package": "totem.spike.rd0815b6769304e26",
+  "entrypoint": "totem/spike/rd0815b6769304e26/result",
+  "recordSha256": "99c2deb2827c2f85785cd79d2322fa5a013af67a37d5cdecc4f49ded284aad44",
+  "recordFile": "records/c-astgrep-compound-spawn-shell.rule.yaml",
+  "regoSha256": "92b130e5b1d55064db19944322e3fcf9ac6e98a0274d0f03f1007d684a2c062a",
+  "regoComposition": {
+    "note": "sha256 over the three component digests, labelled and newline-joined in this exact order. Component digests are published so the composite is auditable without re-deriving it.",
+    "order": [
+      "policy.rego",
+      "globs.json",
+      "factSchemaLine"
+    ],
+    "components": {
+      "policy.rego": "2b9c56249bf510a48aac842344145908a8ea570b310f8232dfab5cbe05e97d94",
+      "globs.json": "d7f6019db06252129c43581dd13e5b72b0423253d45b6409e7ea101acc5b2ce2",
+      "factSchemaLine": "3e9643cd65a2335b0b1de3c508e9cadf229ecdd3a29d7519ba33409ed1c3e58f"
+    },
+    "factSchemaLine": "input = { file, fileText: string|null, lines: [string], astMatches: [{lineNumber, lineText, startLineText, startPrecedingLineText}] }",
+    "preimage": "policy.rego:2b9c56249bf510a48aac842344145908a8ea570b310f8232dfab5cbe05e97d94\nglobs.json:d7f6019db06252129c43581dd13e5b72b0423253d45b6409e7ea101acc5b2ce2\nfactSchemaLine:3e9643cd65a2335b0b1de3c508e9cadf229ecdd3a29d7519ba33409ed1c3e58f\n"
+  },
+  "wasmSha256": "5aa898a084d8214dd3e7f3efc67cec1202c3ddd4743fa8f375a4042c6bf890fc",
+  "bundleTarballSha256": "7c85694cc7fddd47045e1a98546aa915d9425f3b76423678382aa3e0a39ec8ff",
+  "manifest": {
+    "revision": "",
+    "roots": [
+      ""
+    ],
+    "wasm": [
+      {
+        "entrypoint": "totem/spike/rd0815b6769304e26/result",
+        "module": "/policy.wasm"
+      }
+    ],
+    "rego_version": 1
+  },
+  "determinism": {
+    "buildCount": 2,
+    "wasmIdentical": true,
+    "tarballIdentical": true,
+    "wasmSha256": [
+      "5aa898a084d8214dd3e7f3efc67cec1202c3ddd4743fa8f375a4042c6bf890fc",
+      "5aa898a084d8214dd3e7f3efc67cec1202c3ddd4743fa8f375a4042c6bf890fc"
+    ],
+    "bundleTarballSha256": [
+      "7c85694cc7fddd47045e1a98546aa915d9425f3b76423678382aa3e0a39ec8ff",
+      "7c85694cc7fddd47045e1a98546aa915d9425f3b76423678382aa3e0a39ec8ff"
+    ]
+  },
+  "manifestSha256": "70b6c0bb0a917147af8d87a27cda02626384870f7e28869a688c2c3c6492a8f8",
+  "entrypointManifest": {
+    "note": "The ENTRYPOINT/IMPORT manifest — the fourth member of the bound set (spec § Actuator slice 3). Distinct from the `manifest` key above, which is the OPA BUNDLE `.manifest` member. Read from the module itself by the same census code path as artifacts/opa-abi-census.json.",
+    "contract": "spec § Actuator slice 3 — manifestSha256 = sha256 of the canonical JSON of {entrypoints[], imports[], builtins{}}",
+    "manifest": {
+      "entrypoints": [
+        "totem/spike/rd0815b6769304e26/result"
+      ],
+      "imports": [
+        "env.memory:memory",
+        "env.opa_abort:function",
+        "env.opa_builtin0:function",
+        "env.opa_builtin1:function",
+        "env.opa_builtin2:function",
+        "env.opa_builtin3:function",
+        "env.opa_builtin4:function"
+      ],
+      "builtins": {}
+    },
+    "canonicalPreimage": "{\"builtins\":{},\"entrypoints\":[\"totem/spike/rd0815b6769304e26/result\"],\"imports\":[\"env.memory:memory\",\"env.opa_abort:function\",\"env.opa_builtin0:function\",\"env.opa_builtin1:function\",\"env.opa_builtin2:function\",\"env.opa_builtin3:function\",\"env.opa_builtin4:function\"]}"
+  },
+  "certified": true,
+  "certification": {
+    "contract": "spec § Actuator slice — \"certification evaluates EVERY emitted entrypoint against a schema-valid sentinel FactBundle BEFORE artifact publication\"",
+    "sentinel": {
+      "file": "certify/sentinel.ts",
+      "fileText": "",
+      "lines": [],
+      "astMatches": []
+    },
+    "sentinelSha256": "bb5b7fff8ba0d974fd8a977280340b13cb9321e9dc59f749f88706899945a6f0",
+    "onlyExportedResultPath": {
+      "ok": true,
+      "detail": "exactly one entrypoint, and it is the canonical `totem/spike/rd0815b6769304e26/result` (`<pkg>/result` derived from the package name, and the expected entrypoint agrees)"
+    },
+    "evaluatedEntrypoints": [
+      "totem/spike/rd0815b6769304e26/result"
+    ],
+    "classifications": [
+      {
+        "entrypoint": "totem/spike/rd0815b6769304e26/result",
+        "status": "PASS",
+        "reason": null,
+        "detail": "defined object with exactly `violations` + `events` (0 violations, 0 events)"
+      }
+    ],
+    "hosts": {
+      "wasmtime": {
+        "abiVersion": "1.3 (1.2+ compatible)",
+        "verdict": "PASS"
+      },
+      "regorus": {
+        "role": "reference differential (LOWERING.md § Host contract) — not a certification gate",
+        "ok": true,
+        "error": null
+      }
+    },
+    "boundSet": [
+      "source: recordSha256",
+      "IR: regoSha256 (lowered .rego + globs + fact schema)",
+      "guarded policy: regoComposition.components[\"policy.rego\"]",
+      "entrypoint/import manifest: manifestSha256",
+      "final Wasm: wasmSha256"
+    ]
+  },
+  "publishedBy": "spikes/spine-adopt/src/certify.mts (certification PASS)"
+}

--- a/spikes/spine-adopt/src/certify-verify.mts
+++ b/spikes/spine-adopt/src/certify-verify.mts
@@ -315,16 +315,23 @@ function main(): void {
   //     charter-sanctioned K3 re-pin re-captures its targets first, § 5 K3); a
   //     `specimens` run reads the re-homed baseline under `artifacts/specimens/`
   //     (below), and only SKIPS, by name, where that home is not committed.
-  //   - absent/unreadable committed manifest: treated as the specimens-baseline
-  //     era, so a broken referent fails loudly below rather than skipping silently.
+  //   - ABSENT committed manifest (pre-manifest history): treated as the
+  //     specimens-baseline era. A committed manifest that exists but does not PARSE
+  //     is a different thing — the authoritative artifact is malformed — and it
+  //     THROWS with the cause (bot round on mmnto-ai/totem#2710: a swallowed parse
+  //     error would select a referent instead of naming the broken artifact, and
+  //     with the re-homed baseline below a `specimens` run would then pass over it).
   const committedManifestText = gitShow('spikes/spine-adopt/artifacts/manifest.json');
   let committedRecordSet: string | null = null;
   if (committedManifestText !== null) {
     try {
       const parsed = JSON.parse(committedManifestText) as { recordSet?: unknown };
       committedRecordSet = typeof parsed.recordSet === 'string' ? parsed.recordSet : null;
-    } catch {
-      committedRecordSet = null;
+    } catch (err) {
+      throw new Error(
+        '[Totem Error] the committed `spikes/spine-adopt/artifacts/manifest.json` at HEAD is not valid JSON — INV 2 cannot select its committed referent from a malformed authoritative artifact',
+        { cause: err },
+      );
     }
   }
   const committedIsRunOfRecord = committedRecordSet === 'seed20';
@@ -335,29 +342,36 @@ function main(): void {
   // FULL drift-detection at every commit — including run pins — instead of
   // skipping.
   const SPECIMENS_HOME = 'spikes/spine-adopt/artifacts/specimens/chains';
-  const specimensHomeList = spawnSync(
-    'git',
-    ['ls-tree', '-r', '--name-only', 'HEAD', '--', SPECIMENS_HOME],
-    { cwd: REPO_ROOT, encoding: 'utf-8' },
-  );
-  const specimensHomeCommitted = (specimensHomeList.stdout ?? '').trim().length > 0;
+  // (bot round on mmnto-ai/totem#2710) Both `ls-tree` listings check git's exit
+  // status: a pathspec that matches nothing exits 0 with empty stdout (the honest
+  // "not committed"), so a NON-ZERO status is a real git fault — and reading empty
+  // stdout as "not committed" there would turn a broken referent lookup into a named
+  // skip. `gitShow` above already refuses on status; these two do the same.
+  const lsTreeAtHead = (repoRelDir: string): string[] => {
+    const r = spawnSync('git', ['ls-tree', '-r', '--name-only', 'HEAD', '--', repoRelDir], {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+    });
+    if (r.status !== 0) {
+      throw new Error(
+        `[Totem Error] \`git ls-tree -r --name-only HEAD -- ${repoRelDir}\` exited ${String(r.status)} in ${REPO_ROOT}: ${(r.stderr ?? '').trim()} — the committed referent cannot be established, so INV 2 must not skip`,
+      );
+    }
+    return (r.stdout ?? '')
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .map((l) => path.posix.basename(l))
+      .sort();
+  };
+  const specimensHomeCommitted = lsTreeAtHead(SPECIMENS_HOME).length > 0;
   const committedChainsDir =
     manifest.recordSet === 'control' && committedIsRunOfRecord
       ? 'spikes/spine-adopt/artifacts/k3-control/chains'
       : manifest.recordSet === 'specimens' && specimensHomeCommitted
         ? SPECIMENS_HOME
         : 'spikes/spine-adopt/artifacts/chains';
-  const committedList = spawnSync(
-    'git',
-    ['ls-tree', '-r', '--name-only', 'HEAD', '--', committedChainsDir],
-    { cwd: REPO_ROOT, encoding: 'utf-8' },
-  );
-  const committedNames = (committedList.stdout ?? '')
-    .split('\n')
-    .map((l) => l.trim())
-    .filter(Boolean)
-    .map((l) => path.posix.basename(l))
-    .sort();
+  const committedNames = lsTreeAtHead(committedChainsDir);
   // The committed referent is chosen above (A12): the re-homed specimens baseline
   // for a `specimens` run, the committed control build for a `control` run over a
   // committed run of record, the top-level chains otherwise. Where no referent

--- a/spikes/spine-adopt/src/certify-verify.mts
+++ b/spikes/spine-adopt/src/certify-verify.mts
@@ -18,9 +18,11 @@
 // committed chain's bytes up to its closing brace. That is only possible because
 // `publishChain` appends — a re-ordering serializer would fail here, loudly.
 //
-// The pre-slice chains are read with `git show HEAD:…`, so the comparison is
-// against the COMMITTED artifact rather than against whatever the working tree
-// happens to hold after this run overwrote it.
+// The referent chains are read with `git show HEAD:<referent dir>/…` — the dir
+// selected per run below (A12): the re-homed specimens baseline, the committed
+// control build, or the top-level chains — so the comparison is against the
+// COMMITTED artifact rather than against whatever the working tree happens to
+// hold after this run overwrote it.
 //
 // TEMPORAL VALIDITY — INV 2 is BIDIRECTIONAL, and has to be. Read one way only,
 // the additive-extension check self-invalidates the moment this slice commits:
@@ -308,10 +310,11 @@ function main(): void {
   //     its one chain, both against `HEAD:…artifacts/chains/`.
   //   - committed `recordSet: 'seed20'` (a committed run of record): a `control`
   //     run's referent is the run's own committed control build,
-  //     `HEAD:…artifacts/k3-control/chains/` (byte-equal by construction — chains
-  //     carry no run identity); a `specimens` run has NO committed referent and
-  //     SKIPS the committed half by name, keeping every per-chain claim that needs
-  //     none.
+  //     `HEAD:…artifacts/k3-control/chains/` — byte-equal while the producer and
+  //     the record bytes are unchanged (chains carry no run identity; a
+  //     charter-sanctioned K3 re-pin re-captures its targets first, § 5 K3); a
+  //     `specimens` run reads the re-homed baseline under `artifacts/specimens/`
+  //     (below), and only SKIPS, by name, where that home is not committed.
   //   - absent/unreadable committed manifest: treated as the specimens-baseline
   //     era, so a broken referent fails loudly below rather than skipping silently.
   const committedManifestText = gitShow('spikes/spine-adopt/artifacts/manifest.json');
@@ -325,10 +328,25 @@ function main(): void {
     }
   }
   const committedIsRunOfRecord = committedRecordSet === 'seed20';
+  // (A12 cure, the F2 fold) The SPECIMENS BASELINE THAT SURVIVES a committed run
+  // of record — A12's option (i): the seven pre-slice chains re-homed byte-exactly
+  // (from `69b85544`, the last commit whose top-level tree was the baseline) under
+  // a tree no run rewrites. When it is committed at HEAD, the specimens leg keeps
+  // FULL drift-detection at every commit — including run pins — instead of
+  // skipping.
+  const SPECIMENS_HOME = 'spikes/spine-adopt/artifacts/specimens/chains';
+  const specimensHomeList = spawnSync(
+    'git',
+    ['ls-tree', '-r', '--name-only', 'HEAD', '--', SPECIMENS_HOME],
+    { cwd: REPO_ROOT, encoding: 'utf-8' },
+  );
+  const specimensHomeCommitted = (specimensHomeList.stdout ?? '').trim().length > 0;
   const committedChainsDir =
     manifest.recordSet === 'control' && committedIsRunOfRecord
       ? 'spikes/spine-adopt/artifacts/k3-control/chains'
-      : 'spikes/spine-adopt/artifacts/chains';
+      : manifest.recordSet === 'specimens' && specimensHomeCommitted
+        ? SPECIMENS_HOME
+        : 'spikes/spine-adopt/artifacts/chains';
   const committedList = spawnSync(
     'git',
     ['ls-tree', '-r', '--name-only', 'HEAD', '--', committedChainsDir],
@@ -340,10 +358,11 @@ function main(): void {
     .filter(Boolean)
     .map((l) => path.posix.basename(l))
     .sort();
-  // The committed chains ARE the seven-specimen baseline: the comparison against
-  // them is a claim about THAT set and has no referent for any other. On another
-  // record set the whole committed-vs-published half of INV 2 is SKIPPED with a
-  // named reason, and the per-chain claims that do not need a committed referent —
+  // The committed referent is chosen above (A12): the re-homed specimens baseline
+  // for a `specimens` run, the committed control build for a `control` run over a
+  // committed run of record, the top-level chains otherwise. Where no referent
+  // applies the committed-vs-published half of INV 2 is SKIPPED with a named
+  // reason, and the per-chain claims that do not need a committed referent —
   // (d) the manifest re-derivation, (e) the five-member binding, (f) the guarded
   // result path — still run on every published chain.
   //
@@ -378,17 +397,21 @@ function main(): void {
     manifestRecordSet === 'control'
       ? true
       : manifestRecordSet === 'specimens'
-        ? !committedIsRunOfRecord
+        ? specimensHomeCommitted || committedRecordSet === 'specimens'
         : false;
-  if (manifestRecordSet === 'specimens' && committedIsRunOfRecord) {
+  if (manifestRecordSet === 'specimens' && !committedChainsApply) {
+    // Reachable only before the re-homed baseline is committed AND when the
+    // top-level committed baseline is not the specimens set (a committed run of
+    // record, or an unknown/future committed set — named below either way, never
+    // compared against the wrong referent).
     checks.check(
-      `INV 2 — SKIPPED with the named reason \`committed-baseline-is-a-run-of-record\`: \`artifacts/manifest.json\` at HEAD records \`recordSet: 'seed20'\`, so the ${chainFiles.length} published specimen chain(s) have no committed referent (A12, mmnto-ai/totem#2704); the per-chain claims that need none still run`,
+      `INV 2 — SKIPPED with the named reason \`no-specimens-referent-at-HEAD\`: \`${SPECIMENS_HOME}\` is not committed and \`artifacts/manifest.json\` at HEAD records \`recordSet: ${JSON.stringify(committedRecordSet)}\`, so the ${chainFiles.length} published specimen chain(s) have no committed referent (A12, mmnto-ai/totem#2704); the per-chain claims that need none still run`,
       true,
       `published: ${chainFiles.length}; committed at HEAD under \`${committedChainsDir}\`: ${committedNames.length}`,
     );
   } else if (manifestRecordSet === 'specimens') {
     checks.eq(
-      'INV 2 — the published chain set is exactly the pre-slice committed chain set',
+      `INV 2 — the published chain set is exactly the committed specimens baseline (referent: \`${committedChainsDir}\`)`,
       chainFiles,
       committedNames,
     );
@@ -404,7 +427,7 @@ function main(): void {
     );
   } else {
     checks.check(
-      `INV 2 — SKIPPED with the named reason \`committed-chains-are-not-this-run's-referent\`: the ${chainFiles.length} published chain(s) belong to record set \`${String(manifestRecordSet)}\` (the manifest's), which never has a committed referent; \`${committedChainsDir}\` at HEAD holds ${committedNames.length} chain(s) from the committed \`${String(committedRecordSet)}\` baseline`,
+      `INV 2 — SKIPPED with the named reason \`committed-half-not-run-on-seed20\`: the ${chainFiles.length} published chain(s) belong to record set \`${String(manifestRecordSet)}\` (the manifest's); the committed-vs-published half is not run on this arm — \`${committedChainsDir}\` at HEAD holds ${committedNames.length} chain(s) from the committed \`${String(committedRecordSet)}\` baseline, a live byte-equality referent when that baseline is itself a seed run (deposited as a candidate extension, not built here: A13 on mmnto-ai/totem#2704)`,
       true,
       `published: ${chainFiles.length}; committed at HEAD: ${committedNames.length}`,
     );
@@ -414,9 +437,7 @@ function main(): void {
   const modesRun: Record<string, ChainMode> = {};
   for (const name of chainFiles) {
     const currentText = fs.readFileSync(path.join(CHAINS_DIR, name), 'utf-8');
-    const committedText = committedChainsApply
-      ? gitShow(`${committedChainsDir}/${name}`)
-      : null;
+    const committedText = committedChainsApply ? gitShow(`${committedChainsDir}/${name}`) : null;
     if (committedChainsApply && committedText === null) {
       checks.check(`INV 2 — ${name}: a committed chain exists at HEAD`, false, 'git show failed');
       continue;
@@ -512,7 +533,7 @@ function main(): void {
       mode: cmp?.mode ?? null,
       modeReason:
         cmp === null
-          ? `no committed referent — the manifest's record set is \`${String(manifestRecordSet)}\`, so the committed-vs-published half of INV 2 is skipped for this chain`
+          ? `no committed referent for this run — \`artifacts/manifest.json\` at HEAD records \`recordSet: ${JSON.stringify(committedRecordSet)}\` and the selected referent dir \`${committedChainsDir}\` does not apply on \`${String(manifestRecordSet)}\`, so the committed-vs-published half of INV 2 is skipped for this chain`
           : cmp.mode === 'drift-detection'
             ? `the committed chain carries \`${POST_SLICE_MARKER}\` — the slice is committed, so the claim is byte-EQUALITY`
             : `the committed chain has no \`${POST_SLICE_MARKER}\` — a pre-slice baseline, so the claim is the additive extension`,
@@ -828,7 +849,7 @@ function main(): void {
       method:
         "BIDIRECTIONAL, chosen per chain from the COMMITTED file's own shape, so the invariant survives its own commit. `pre-commit` (the committed chain carries no `manifestSha256`): two independent claims — (a) a BYTE claim, the published file starts with the committed file's bytes up to its closing brace, so the extension is appended and nothing was re-serialised; (b) a STRUCTURAL claim, every pre-slice key holds an identical value and the added key set is exactly the extension's. `drift-detection` (the committed chain already carries `manifestSha256`): the published chain must be BYTE-EQUAL to it, and no key may be added, changed or removed — certification is deterministic, so any difference is drift. In both modes the named hashes are checked unchanged and the manifest hash is RE-DERIVED from the module.",
       modeMarker: `the presence of \`${POST_SLICE_MARKER}\` in the committed chain`,
-      preSliceSource: 'git show HEAD:spikes/spine-adopt/artifacts/chains/<name>.json',
+      preSliceSource: `git show HEAD:${committedChainsDir}/<name>.json`,
       expectedAddedKeys: EXPECTED_ADDED_KEYS,
       modesRun,
       rows: preservation,

--- a/spikes/spine-adopt/src/certify-verify.mts
+++ b/spikes/spine-adopt/src/certify-verify.mts
@@ -289,14 +289,49 @@ function main(): void {
     [],
   );
 
-  // ── INVARIANT 2: chain preservation vs the COMMITTED pre-slice chains ──
+  // ── INVARIANT 2: chain preservation vs the COMMITTED referent chains ──
   const chainFiles = fs
     .readdirSync(CHAINS_DIR)
     .filter((f) => f.endsWith('.json'))
     .sort();
+  // (A12, mmnto-ai/totem#2704 — the E24 slice) The committed referent is KEYED ON
+  // WHAT HEAD ACTUALLY COMMITS, not assumed to be the seven-specimen baseline
+  // forever. The first run of record committed the seed-20 run's own artifacts (the
+  // scorer's three-commit binding rewrites the top-level tree), and this check —
+  // reading `HEAD:…artifacts/chains/` as the specimens baseline unconditionally —
+  // failed every later `specimens` and `control` run AT the run pin: both Linux
+  // legs red, and a seam unable to re-execute at the commit containing its own
+  // evidence. The committed run manifest says what HEAD's artifact tree IS, and the
+  // referent follows it:
+  //   - committed `recordSet: 'specimens'` (the pre-run baseline): the original
+  //     behavior, byte for byte — `specimens` compares the whole set, `control`
+  //     its one chain, both against `HEAD:…artifacts/chains/`.
+  //   - committed `recordSet: 'seed20'` (a committed run of record): a `control`
+  //     run's referent is the run's own committed control build,
+  //     `HEAD:…artifacts/k3-control/chains/` (byte-equal by construction — chains
+  //     carry no run identity); a `specimens` run has NO committed referent and
+  //     SKIPS the committed half by name, keeping every per-chain claim that needs
+  //     none.
+  //   - absent/unreadable committed manifest: treated as the specimens-baseline
+  //     era, so a broken referent fails loudly below rather than skipping silently.
+  const committedManifestText = gitShow('spikes/spine-adopt/artifacts/manifest.json');
+  let committedRecordSet: string | null = null;
+  if (committedManifestText !== null) {
+    try {
+      const parsed = JSON.parse(committedManifestText) as { recordSet?: unknown };
+      committedRecordSet = typeof parsed.recordSet === 'string' ? parsed.recordSet : null;
+    } catch {
+      committedRecordSet = null;
+    }
+  }
+  const committedIsRunOfRecord = committedRecordSet === 'seed20';
+  const committedChainsDir =
+    manifest.recordSet === 'control' && committedIsRunOfRecord
+      ? 'spikes/spine-adopt/artifacts/k3-control/chains'
+      : 'spikes/spine-adopt/artifacts/chains';
   const committedList = spawnSync(
     'git',
-    ['ls-tree', '-r', '--name-only', 'HEAD', '--', 'spikes/spine-adopt/artifacts/chains'],
+    ['ls-tree', '-r', '--name-only', 'HEAD', '--', committedChainsDir],
     { cwd: REPO_ROOT, encoding: 'utf-8' },
   );
   const committedNames = (committedList.stdout ?? '')
@@ -332,14 +367,26 @@ function main(): void {
         ? ''
         : ' — re-run `npm run all` for this record set before certifying'),
   );
-  // (§ S5) The committed chains are the SPECIMENS baseline, so the comparison has a
-  // referent for `specimens` — where the published set is the whole committed set —
-  // and for `control`, where it is ONE of them: a control-only rebuild of a specimen
-  // record whose chain is already committed IS K3 arm B, and restricting the set
-  // comparison to the loaded packages is what lets that one chain be compared
-  // without pretending the other six went missing. Only `seed20` has no referent.
-  const committedChainsApply = manifestRecordSet !== 'seed20';
-  if (manifestRecordSet === 'specimens') {
+  // (§ S5, as re-keyed by A12 above) The comparison has a referent for `specimens`
+  // — the whole committed set, when HEAD's committed baseline IS the specimens set
+  // — and for `control`, where it is ONE chain: against the specimens baseline, the
+  // committed specimen chain (a control-only rebuild of a committed specimen record
+  // IS K3 arm B); against a committed run of record, the run's own committed
+  // `k3-control/` build. `seed20` never has a committed referent here, and a
+  // `specimens` run over a committed run of record has none either.
+  const committedChainsApply =
+    manifestRecordSet === 'control'
+      ? true
+      : manifestRecordSet === 'specimens'
+        ? !committedIsRunOfRecord
+        : false;
+  if (manifestRecordSet === 'specimens' && committedIsRunOfRecord) {
+    checks.check(
+      `INV 2 — SKIPPED with the named reason \`committed-baseline-is-a-run-of-record\`: \`artifacts/manifest.json\` at HEAD records \`recordSet: 'seed20'\`, so the ${chainFiles.length} published specimen chain(s) have no committed referent (A12, mmnto-ai/totem#2704); the per-chain claims that need none still run`,
+      true,
+      `published: ${chainFiles.length}; committed at HEAD under \`${committedChainsDir}\`: ${committedNames.length}`,
+    );
+  } else if (manifestRecordSet === 'specimens') {
     checks.eq(
       'INV 2 — the published chain set is exactly the pre-slice committed chain set',
       chainFiles,
@@ -348,7 +395,7 @@ function main(): void {
   } else if (manifestRecordSet === 'control') {
     const expected = loadRecordSet('control').map((r) => `r${r.ruleId}.json`);
     checks.eq(
-      `INV 2 (K3 arm B) — the control-only run published exactly the ${expected.length} chain(s) its record set names, and each has a committed counterpart at HEAD`,
+      `INV 2 (K3 arm B) — the control-only run published exactly the ${expected.length} chain(s) its record set names, and each has a committed counterpart at HEAD (referent: \`${committedChainsDir}\`)`,
       {
         published: chainFiles,
         missingFromCommitted: expected.filter((n) => !committedNames.includes(n)),
@@ -357,7 +404,7 @@ function main(): void {
     );
   } else {
     checks.check(
-      `INV 2 — SKIPPED with the named reason \`committed-chains-are-the-specimens-baseline\`: the ${chainFiles.length} published chain(s) belong to record set \`${String(manifestRecordSet)}\` (the manifest's), and \`artifacts/chains/\` at HEAD holds the ${committedNames.length} seven-specimen certificates`,
+      `INV 2 — SKIPPED with the named reason \`committed-chains-are-not-this-run's-referent\`: the ${chainFiles.length} published chain(s) belong to record set \`${String(manifestRecordSet)}\` (the manifest's), which never has a committed referent; \`${committedChainsDir}\` at HEAD holds ${committedNames.length} chain(s) from the committed \`${String(committedRecordSet)}\` baseline`,
       true,
       `published: ${chainFiles.length}; committed at HEAD: ${committedNames.length}`,
     );
@@ -368,7 +415,7 @@ function main(): void {
   for (const name of chainFiles) {
     const currentText = fs.readFileSync(path.join(CHAINS_DIR, name), 'utf-8');
     const committedText = committedChainsApply
-      ? gitShow(`spikes/spine-adopt/artifacts/chains/${name}`)
+      ? gitShow(`${committedChainsDir}/${name}`)
       : null;
     if (committedChainsApply && committedText === null) {
       checks.check(`INV 2 — ${name}: a committed chain exists at HEAD`, false, 'git show failed');

--- a/spikes/spine-adopt/src/certify-verify.mts
+++ b/spikes/spine-adopt/src/certify-verify.mts
@@ -316,12 +316,45 @@ function main(): void {
   //     `specimens` run reads the re-homed baseline under `artifacts/specimens/`
   //     (below), and only SKIPS, by name, where that home is not committed.
   //   - ABSENT committed manifest (pre-manifest history): treated as the
-  //     specimens-baseline era. A committed manifest that exists but does not PARSE
-  //     is a different thing — the authoritative artifact is malformed — and it
-  //     THROWS with the cause (bot round on mmnto-ai/totem#2710: a swallowed parse
-  //     error would select a referent instead of naming the broken artifact, and
-  //     with the re-homed baseline below a `specimens` run would then pass over it).
-  const committedManifestText = gitShow('spikes/spine-adopt/artifacts/manifest.json');
+  //     specimens-baseline era. Absence is established by `ls-tree` — a no-match
+  //     pathspec exits 0 with empty stdout — NEVER by a failed `git show`: `gitShow`
+  //     returns `null` on every non-zero status, which cannot tell "path absent"
+  //     from "repository/HEAD broken", and a git fault collapsed into the absence
+  //     fallback would select a referent or publish a named skip (bot round on
+  //     mmnto-ai/totem#2710, Greptile's residual). A committed manifest that exists
+  //     but does not PARSE is a third thing — the authoritative artifact is
+  //     malformed — and THROWS with the cause.
+  //
+  // (bot round on mmnto-ai/totem#2710) Every HEAD listing this block relies on checks
+  // git's exit status: a pathspec that matches nothing exits 0 with empty stdout
+  // (the honest "not committed"), so a NON-ZERO status is a real git fault, and
+  // reading empty stdout as "not committed" there would turn a broken lookup into a
+  // named skip with `ok: true`.
+  const lsTreeAtHead = (repoRelPath: string): string[] => {
+    const r = spawnSync('git', ['ls-tree', '-r', '--name-only', 'HEAD', '--', repoRelPath], {
+      cwd: REPO_ROOT,
+      encoding: 'utf-8',
+    });
+    if (r.status !== 0) {
+      throw new Error(
+        `[Totem Error] \`git ls-tree -r --name-only HEAD -- ${repoRelPath}\` exited ${String(r.status)} in ${REPO_ROOT}: ${(r.stderr ?? '').trim()} — the committed referent cannot be established, so INV 2 must not skip`,
+      );
+    }
+    return (r.stdout ?? '')
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .map((l) => path.posix.basename(l))
+      .sort();
+  };
+  const COMMITTED_MANIFEST = 'spikes/spine-adopt/artifacts/manifest.json';
+  const committedManifestPresent = lsTreeAtHead(COMMITTED_MANIFEST).length > 0;
+  const committedManifestText = committedManifestPresent ? gitShow(COMMITTED_MANIFEST) : null;
+  if (committedManifestPresent && committedManifestText === null) {
+    throw new Error(
+      `[Totem Error] \`git show HEAD:${COMMITTED_MANIFEST}\` failed although \`ls-tree\` lists the path at HEAD — a repository fault, not an absent manifest; INV 2 cannot select its committed referent`,
+    );
+  }
   let committedRecordSet: string | null = null;
   if (committedManifestText !== null) {
     try {
@@ -342,28 +375,6 @@ function main(): void {
   // FULL drift-detection at every commit — including run pins — instead of
   // skipping.
   const SPECIMENS_HOME = 'spikes/spine-adopt/artifacts/specimens/chains';
-  // (bot round on mmnto-ai/totem#2710) Both `ls-tree` listings check git's exit
-  // status: a pathspec that matches nothing exits 0 with empty stdout (the honest
-  // "not committed"), so a NON-ZERO status is a real git fault — and reading empty
-  // stdout as "not committed" there would turn a broken referent lookup into a named
-  // skip. `gitShow` above already refuses on status; these two do the same.
-  const lsTreeAtHead = (repoRelDir: string): string[] => {
-    const r = spawnSync('git', ['ls-tree', '-r', '--name-only', 'HEAD', '--', repoRelDir], {
-      cwd: REPO_ROOT,
-      encoding: 'utf-8',
-    });
-    if (r.status !== 0) {
-      throw new Error(
-        `[Totem Error] \`git ls-tree -r --name-only HEAD -- ${repoRelDir}\` exited ${String(r.status)} in ${REPO_ROOT}: ${(r.stderr ?? '').trim()} — the committed referent cannot be established, so INV 2 must not skip`,
-      );
-    }
-    return (r.stdout ?? '')
-      .split('\n')
-      .map((l) => l.trim())
-      .filter(Boolean)
-      .map((l) => path.posix.basename(l))
-      .sort();
-  };
   const specimensHomeCommitted = lsTreeAtHead(SPECIMENS_HOME).length > 0;
   const committedChainsDir =
     manifest.recordSet === 'control' && committedIsRunOfRecord

--- a/spikes/spine-adopt/src/controls.mts
+++ b/spikes/spine-adopt/src/controls.mts
@@ -26,6 +26,7 @@ import * as path from 'node:path';
 import { K3_CAPTURE_SHA256, spikeFileDigest } from './lib/baseline-pins.mts';
 import {
   activeRecordSet,
+  generatedSeedProbes,
   K3_CAPTURE_CHAIN,
   K3_CAPTURE_PACKAGE,
   K8_FIXTURES,
@@ -596,6 +597,14 @@ function k3b(recordSet: RecordSetId, lowering: Artifact): ControlRow {
       evidence,
     };
   }
+  // (the E24 slice) § 7 E6 fixes the K3b row at `{ glob, ok, matchingProbe,
+  // nonMatchingProbe }` ON BOTH SIDES — the reconciled fields are the E2 generated
+  // pair for the glob, the same generator the scorer runs independently; the sweep
+  // counts below ride as extra fields (E6's own words). Joined from the ONE
+  // generator (`generatedSeedProbes`, also published as
+  // `manifest.probeGeneration.pairs[]`) so the two artifacts cannot disagree.
+  // The first execution refused 58 K3b rows on exactly these absent fields.
+  const pairByGlob = new Map(generatedSeedProbes().map((p) => [p.glob, p]));
   const rows: Artifact[] = [];
   for (const l of (lowering.lowered ?? []) as Artifact[]) {
     const suffix = String(l.package).replace(/^totem\.spike\./, '');
@@ -616,9 +625,15 @@ function k3b(recordSet: RecordSetId, lowering: Artifact): ControlRow {
       byGlob.set(p.glob, acc);
     }
     for (const [glob, acc] of byGlob) {
+      const pair = pairByGlob.get(glob);
       rows.push({
         pkg: l.package,
         glob,
+        // § 7 E6's reconciled fields — present-as-null for a glob outside the
+        // generator's distinct-glob table (a state the `ok` conjunct would already
+        // report as blind, since such a glob can have no generated probe).
+        matchingProbe: pair ? pair.probe : null,
+        nonMatchingProbe: pair ? pair.twin : null,
         matching: acc.matching,
         nonMatching: acc.nonMatching,
         scopeDivergences: acc.disagree,

--- a/spikes/spine-adopt/src/controls.mts
+++ b/spikes/spine-adopt/src/controls.mts
@@ -629,15 +629,22 @@ function k3b(recordSet: RecordSetId, lowering: Artifact): ControlRow {
       rows.push({
         pkg: l.package,
         glob,
-        // § 7 E6's reconciled fields — present-as-null for a glob outside the
-        // generator's distinct-glob table (a state the `ok` conjunct would already
-        // report as blind, since such a glob can have no generated probe).
+        // § 7 E6's reconciled fields. A glob OUTSIDE the generator's distinct-glob
+        // table gets `null` — and `ok: false` below, asserted rather than assumed:
+        // the sweep counts alone cannot catch it (frozen/inline probes can satisfy
+        // >=1/>=1 for such a glob), and the premise that every reachable glob is in
+        // the table holds today only because every loaded record's globs — the K5
+        // control record included, a byte copy of a specimen record — happen to lie
+        // in the seed census the generator derives from. The scorer joins K3b rows
+        // by `glob` and reads these two fields as verdict fields, so a silent null
+        // here would re-open the exact refusal class this slice cures (F4, the
+        // slice's falsification leg).
         matchingProbe: pair ? pair.probe : null,
         nonMatchingProbe: pair ? pair.twin : null,
         matching: acc.matching,
         nonMatching: acc.nonMatching,
         scopeDivergences: acc.disagree,
-        ok: acc.matching >= 1 && acc.nonMatching >= 1,
+        ok: acc.matching >= 1 && acc.nonMatching >= 1 && pair !== undefined,
       });
     }
   }
@@ -651,7 +658,7 @@ function k3b(recordSet: RecordSetId, lowering: Artifact): ControlRow {
         ? 'NOT MEASURED — no lowered package published a globs.json'
         : blind.length === 0
           ? `${rows.length} reachable glob(s), each with >=1 matching AND >=1 non-matching probe`
-          : `BLIND globs: ${blind.map((r) => `${r.pkg}/${r.glob} (${r.matching}/${r.nonMatching})`).join('; ')}`,
+          : `BLIND globs: ${blind.map((r) => `${r.pkg}/${r.glob} (${r.matching}/${r.nonMatching}${r.matchingProbe === null ? '; NO GENERATED PAIR' : ''})`).join('; ')}`,
     rows,
     evidence,
   };

--- a/spikes/spine-adopt/src/manifest.mts
+++ b/spikes/spine-adopt/src/manifest.mts
@@ -256,8 +256,10 @@ function main(): void {
     // an absent key. The first execution's probePaths ×1 refusal traced here: the
     // field lived only in apparatus source (`src/lib/record-sets.mts`), so the
     // scorer's E2 R1 inline category was silently EMPTY. Every current row carries
-    // one (`Specimen.inlineFilePath: string`); the `?? null` is the declared shape
-    // for a future record without one, not a tolerated absence.
+    // one — `Specimen.inlineFilePath` is typed `string`, required, so today the
+    // `?? null` cannot fire; a future record WITHOUT one must change that type to
+    // `string | null` (the explicit-null shape), and emptiness is gated by this
+    // stage's own check below (F5 fold), never tolerated.
     inlineFilePath: r.inlineFilePath ?? null,
   });
   const records = rows.filter((r) => !r.control).map(rowDigest);
@@ -705,6 +707,20 @@ function main(): void {
     records.every((r) => /^[0-9a-f]{16}$/.test(r.ruleId)) &&
       (recordSet !== 'seed20' || records.every((r) => /^[0-9a-f]{8}$/.test(r.seedEntry ?? ''))),
     `${records.length} record(s)`,
+  );
+  // (the E24 slice, F5 fold) The (b) ruling's OTHER half, gated at the PUBLISHER:
+  // an empty or whitespace-only `inlineFilePath` would pass the type, publish, and
+  // refuse days later at score time (the scorer discards `''` from the E2 R1
+  // union, which would silently re-empty the inline category through the gate
+  // itself). Failing here moves that failure to the run that authored it.
+  checks.check(
+    "every scored record's `inlineFilePath` is a NON-EMPTY string or an explicit null (the scorer's (b) ruling, both halves)",
+    records.every(
+      (r) =>
+        r.inlineFilePath === null ||
+        (typeof r.inlineFilePath === 'string' && r.inlineFilePath.trim().length > 0),
+    ),
+    `${records.length} record(s); ${records.filter((r) => r.inlineFilePath !== null).length} with an inline path`,
   );
   checks.check(
     'the tracked-path sweep set is non-empty and published beside the manifest',

--- a/spikes/spine-adopt/src/manifest.mts
+++ b/spikes/spine-adopt/src/manifest.mts
@@ -256,11 +256,13 @@ function main(): void {
     // an absent key. The first execution's probePaths ×1 refusal traced here: the
     // field lived only in apparatus source (`src/lib/record-sets.mts`), so the
     // scorer's E2 R1 inline category was silently EMPTY. Every current row carries
-    // one — `Specimen.inlineFilePath` is typed `string`, required, so today the
-    // `?? null` cannot fire; a future record WITHOUT one must change that type to
-    // `string | null` (the explicit-null shape), and emptiness is gated by this
-    // stage's own check below (F5 fold), never tolerated.
-    inlineFilePath: r.inlineFilePath ?? null,
+    // one — `Specimen.inlineFilePath` is typed `string`, required — so it is
+    // published verbatim, with no defensive fallback (a `?? null` here would be
+    // dead code masking the type — F5 + the bot round on mmnto-ai/totem#2710); a
+    // future record WITHOUT one changes that type to `string | null` and publishes
+    // the explicit `null` from the type, and emptiness is gated by this stage's
+    // own check below, never tolerated.
+    inlineFilePath: r.inlineFilePath,
   });
   const records = rows.filter((r) => !r.control).map(rowDigest);
   const controlRecords = rows
@@ -768,7 +770,14 @@ function main(): void {
     checks.eq(
       `every seed record's \`inlineFilePath\` and \`fixture.file\` is in the published probe set (${seedScoped.length} scored record(s))`,
       [
-        ...seedScoped.map((r) => r.inlineFilePath),
+        // (bot round on mmnto-ai/totem#2710) The published contract admits an
+        // explicit `null` for a record with no inline path (the scorer's (b)
+        // ruling); the coverage claim is over the PATHS, so a `null` — impossible
+        // by today's `string` type, legal by contract — must not enter the
+        // membership test and fail publication.
+        ...seedScoped
+          .map((r) => r.inlineFilePath as string | null)
+          .filter((p): p is string => typeof p === 'string'),
         ...seedScoped.flatMap((r) => (r.fixture ? [r.fixture.file] : [])),
       ].filter((p) => !probePaths.includes(p)),
       [],

--- a/spikes/spine-adopt/src/manifest.mts
+++ b/spikes/spine-adopt/src/manifest.mts
@@ -250,6 +250,15 @@ function main(): void {
     sha256: sha256(fs.readFileSync(r.recordFile)),
     seedEntry: r.seedEntry,
     ruleId: r.ruleId,
+    // (the E24 slice; the scorer's (b) ruling, 2026-08-30) REQUIRED on every scored
+    // row: the in-scope virtual path the record's inline `examples[]` are served at
+    // — a NON-EMPTY string, or an EXPLICIT `null` for a record that has none, never
+    // an absent key. The first execution's probePaths ×1 refusal traced here: the
+    // field lived only in apparatus source (`src/lib/record-sets.mts`), so the
+    // scorer's E2 R1 inline category was silently EMPTY. Every current row carries
+    // one (`Specimen.inlineFilePath: string`); the `?? null` is the declared shape
+    // for a future record without one, not a tolerated absence.
+    inlineFilePath: r.inlineFilePath ?? null,
   });
   const records = rows.filter((r) => !r.control).map(rowDigest);
   const controlRecords = rows
@@ -503,6 +512,15 @@ function main(): void {
       'spec `.totem/specs/seed20-apparatus.md` § G5 — the run manifest. Every later artifact embeds `runManifestSha256` (named for the OPA `manifestSha256` collision; see src/lib/spike-env.mts).',
     recordSet,
     runCommit: head.out,
+    // (the E24 slice) § 5's binding fact, realized apparatus-side: the sha256 of
+    // the FROZEN `score.mjs` this run binds — the scorer's freeze mail of
+    // 2026-08-30T20:40Z (strategy main `a2cb78a`, charter v1.3 § 7 E24; verified
+    // against `operations/310-seed20-target/score.mjs` at that commit before this
+    // slice was cut). The run pin at `0daf8c96` carried NO scorer key — § 5's "the
+    // binding fact is its sha256 in the run manifest" was never realized until
+    // here. A scorer re-freeze is a new value HERE and therefore a new apparatus
+    // pin — the coupling is the point.
+    scorerSha256: '43c8667c5a5ea4947b01b88b2269c816131717b54e768580361a843b664c96c9',
     // T17 — a FACT about the run, not a gate: `trackedPaths` below is the tree at
     // `runCommit`, and this says whether the tree the run actually read matched it.
     //

--- a/spikes/spine-adopt/src/shipped-verdicts.mts
+++ b/spikes/spine-adopt/src/shipped-verdicts.mts
@@ -76,13 +76,17 @@ interface VerdictRow {
   armsCoincide: boolean;
   armsAgree: boolean;
   /**
-   * Present ONLY on the G8 malformed-facts control (K5b). The shipped dispatchers
-   * are fed `lines[]` verbatim; a non-string member is exactly the malformation the
-   * control exists to push through every arm, so this row carries the host-style
-   * ERROR instead of a verdict — never a clean zero, and never a missing row (the
-   * wazero probe holds every arm to the same row count).
+   * A non-null string ONLY on the G8 malformed-facts control (K5b). The shipped
+   * dispatchers are fed `lines[]` verbatim; a non-string member is exactly the
+   * malformation the control exists to push through every arm, so that row carries
+   * the host-style ERROR instead of a verdict — never a clean zero, and never a
+   * missing row (the wazero probe holds every arm to the same row count).
+   *
+   * (the E24 slice) EXPLICIT `null` on every other row, never an absent key:
+   * § 5 K5's letter is `error: null`, the scorer reads absent-as-undefined ≠ null
+   * and fails toward flagging — the first execution's K5 ×2 refusal class.
    */
-  error?: string;
+  error: string | null;
 }
 
 /**
@@ -397,6 +401,9 @@ async function main(): Promise<void> {
         arms,
         armsCoincide,
         armsAgree,
+        // (the E24 slice) § 5 K5's letter — explicit on every verdict row, never an
+        // absent key.
+        error: null,
       });
     }
 

--- a/spikes/spine-adopt/src/shipped-verdicts.mts
+++ b/spikes/spine-adopt/src/shipped-verdicts.mts
@@ -83,8 +83,10 @@ interface VerdictRow {
    * missing row (the wazero probe holds every arm to the same row count).
    *
    * (the E24 slice) EXPLICIT `null` on every other row, never an absent key:
-   * § 5 K5's letter is `error: null`, the scorer reads absent-as-undefined ≠ null
-   * and fails toward flagging — the first execution's K5 ×2 refusal class.
+   * § 5 K5's letter is `error: null`, and the scorer REFUSES on the K5 control
+   * rows when the key is absent (its `K5_EXPECTED` is `{fired: true, matchCount:
+   * 1, error: null}`, read as absent-as-undefined ≠ null) — the first execution's
+   * K5 ×2 refusal class.
    */
   error: string | null;
 }

--- a/spikes/spine-adopt/src/t5-sweep.mts
+++ b/spikes/spine-adopt/src/t5-sweep.mts
@@ -428,7 +428,7 @@ async function main(): Promise<void> {
     // (fold 1 F7 + the E24 slice) A K-CONTROL package is not swept — and not
     // LISTED. T5 is a per-record conjunct over the SCORED records; the K5 control
     // is not one of them and is exercised by K5, in its own row. Sweeping it would
-    // put a 23rd `rows[]` entry in a deposit the scorer reads as the corpus — and
+    // put a control's entry in a deposit the scorer reads as the scored corpus — and
     // § 7 E5 fixes the HEADER at the scored set too ("the records that reach target
     // lowering — 20 on this seed"): the first execution's T5 ×2 refusal class was
     // this package listed in `packages[]`/`policies` beside its own skip entry.

--- a/spikes/spine-adopt/src/t5-sweep.mts
+++ b/spikes/spine-adopt/src/t5-sweep.mts
@@ -425,6 +425,20 @@ async function main(): Promise<void> {
       );
     }
 
+    // (fold 1 F7 + the E24 slice) A K-CONTROL package is not swept — and not
+    // LISTED. T5 is a per-record conjunct over the SCORED records; the K5 control
+    // is not one of them and is exercised by K5, in its own row. Sweeping it would
+    // put a 23rd `rows[]` entry in a deposit the scorer reads as the corpus — and
+    // § 7 E5 fixes the HEADER at the scored set too ("the records that reach target
+    // lowering — 20 on this seed"): the first execution's T5 ×2 refusal class was
+    // this package listed in `packages[]`/`policies` beside its own skip entry.
+    // Named in `controlPackagesSkipped` ONLY — never silently dropped, never
+    // double-listed.
+    if (row.control === true) {
+      controlPackagesSkipped.push(row.package);
+      continue;
+    }
+
     const policyRegoSha256 = sha256(fs.readFileSync(policyAt));
     const wrapperSha256 = sha256(wrapperText);
     headerPackages.push({
@@ -445,18 +459,6 @@ async function main(): Promise<void> {
       seedEntry: row.seedEntry ?? null,
       control: row.control === true,
     };
-
-    // (fold 1 F7) A K-CONTROL package is not swept.
-    //
-    // T5 is a per-record conjunct over the SCORED records; the K5 control is not one
-    // of them and is exercised by K5, in its own row. Sweeping it would put a
-    // 23rd `rows[]` entry in a deposit the scorer reads as the corpus, and the entry
-    // would be a control's scope answering a question nobody asked of it. Named in
-    // the header, never silently dropped.
-    if (row.control === true) {
-      controlPackagesSkipped.push(row.package);
-      continue;
-    }
 
     const treeSweep = sweepPackage(
       checks,


### PR DESCRIPTION
## The E24 apparatus slice — the first execution's four deposit-shape classes cured, `scorerSha256` bound, and the A12 HEAD-keying cured (specimens baseline re-homed) — the next apparatus pin

Operator-greenlit route (2026-08-30 ~20:28Z in the strategy session, relayed 20:30Z; taken directly in-session ~20:50Z), scope as restated once in the scorer's 20:40Z freeze mail. Charter of record: v1.3 § 7 E24 at mmnto-ai/totem-strategy main `a2cb78a`. Scorer of record: `score.mjs` frozen at **`43c8667c5a5ea4947b01b88b2269c816131717b54e768580361a843b664c96c9`** (re-derived at that commit before the slice was cut, and independently by the falsification leg).

### The six items (two commits: `31bab7f1` the slice, `4d03c5c1` the falsification-leg fold)

| # | item | cure | where |
|---|---|---|---|
| 1 | **K3b ×58** — E6 fixes the row at `{glob, ok, matchingProbe, nonMatchingProbe}` "on both sides" | the generated pair joined per glob from the ONE generator (`generatedSeedProbes`, also published as `manifest.probeGeneration.pairs[]`); counts ride as extra fields; `ok` now also requires the pair to EXIST (leg F4 — the sweep counts cannot catch a missing pair; a missing one is a BLIND row naming "NO GENERATED PAIR") | `controls.mts` |
| 2 | **K5 ×2** — § 5 K5's letter `error: null` | `VerdictRow.error: string \| null`, explicit on every row; the K5b malformed-facts control keeps its non-empty string; `isErrorRow` unchanged; the Go decoder already reads `*string` | `shipped-verdicts.mts` |
| 3 | **T5 header ×2** — E5's "the records that reach target lowering — 20 on this seed" | the K-control package is skipped BEFORE the header pushes: named in `controlPackagesSkipped` only, never double-listed; `packages`/`policies` 21 → 20 | `t5-sweep.mts` |
| 4 | **`records[].inlineFilePath`** — the (b) ruling: REQUIRED, non-empty string or explicit `null` | published on every scored row from the loaded row; the second half (non-empty) gated at the PUBLISHER by a new manifest FAIL check (leg F5); the E2 R1 inline category becomes evidence-derivable (the class-5 root cause) | `manifest.mts` |
| 5 | **`manifest.scorerSha256`** — § 5's binding fact, never realized before | the freeze-time sha verbatim; a re-freeze is a new apparatus pin by construction | `manifest.mts` |
| 6 | **A12 (mmnto-ai/totem#2704)** — two HEAD-keyed checks made a committed run of record un-runnable at its own pin | INV 2's committed referent keyed on what HEAD commits: a `control` run over a committed run of record reads `HEAD:…artifacts/k3-control/chains/`; the **specimens baseline is RE-HOMED** — the seven pre-slice chains committed byte-exactly (verified against `69b85544`) under `artifacts/specimens/chains/`, so the specimens leg keeps FULL committed-vs-published drift detection at every commit including run pins (A12 option (i), the charter's "a specimens baseline that survives a committed run of record" — leg F2); the specimens-baseline era behavior byte-for-byte otherwise; the arm-B binding (`manifest.mts:874`) needs no change — the seam's control-build-first order binds it at any HEAD once the control build can pass | `certify-verify.mts`, `artifacts/specimens/chains/*` (7), workflow comment |

No chain-emission byte changes. The spike is not a published package — no changeset. Workflow: comment only.

### Verification — the full seam at THIS branch's HEAD, a run-of-record-shaped commit (the A12 acceptance)

Per-stage rc captured directly, `4d03c5c1`, 21:16:44Z → 21:17:53Z: control-only build FIRST (manifest · lower · build-wasm · certify) → `SPIKE_RECORD_SET=seed20 all` → `differential` → Go arm → `controls` → **the slice's deposit-shape gate** (`slice-assert`: K3b fields present and equal to `probeGeneration.pairs[]` per glob; every verdict row has the `error` key, the two K5 rows `null`; header 20/20 with the control only in `controlPackagesSkipped`; `inlineFilePath` on all 22 rows, `.github/workflows/ci.yml` claimed by `be74c55c`, the E2 R1 union now covers `probePaths[]` from the manifest alone; `scorerSha256` == the freeze; `k3Capture.repinned: false` from arm B; controls **10 PASS · 0 FAIL · 0 NOT MEASURED**) → restore → the **specimens** leg (all · differential · Go · controls) → restore. **14/14 rc=0, 0 assertion failures, tree clean after both restores.** The specimens leg's INV 2 now reads `referent: artifacts/specimens/chains` and reports every chain "bytes identical" (drift-detection live again); the control build's INV 2 reads `referent: artifacts/k3-control/chains`. The same seam run at the pre-fold commit `fa1e34a2` was equally green. At `main` today (a committed run of record) both Linux legs are red; **this push should turn both green** — the first CI-green commit since the run pin.

### Falsification leg (dispatched on the slice diff; deposit folded in `4d03c5c1`)

- **Folded:** F1 prettier (the only red file in `prettier --check .`) · F2 the specimens baseline re-homed (the charter's letter was not met by a named skip) · F3 the seed20 skip row's self-contradicting text ("never has a committed referent" beside the referent it named) · F4 the false "ok would catch it" claim → pair presence asserted, premise stated · F5 the (b) ruling's non-empty half gated publisher-side; the `?? null` comment corrected · F6 a–g (stale § S5 paragraph; hardcoded `preSliceSource` provenance; per-chain `modeReason` blamed the record set; the "23rd rows[] entry" ordinal; K5 "fails toward flagging" → "refuses"; "byte-equal by construction" softened to the verified claim).
- **Deposited, not built (out of the greenlit scope):** F3's seed20 × committed-seed20 drift-detection extension, and the `fixtureFile` tolerate-absent twin of class 5 — **A13 on mmnto-ai/totem#2704**, proposed to the scorer with the run pin.
- **Verified clean by the leg, independently:** `scorerSha256` byte-exact vs `a2cb78a`; the referent state table (control × specimens-baseline = the old behavior byte-for-byte; absent/unreadable committed manifest fails loudly); every consumer of the changed shapes (`isErrorRow`, `compare.mts`, the Go `*string` decoder, the `runManifestSha256` preimage on both sides, the manifest-checks reader); the arm-B trace.

### Gates

Repo-wide `pnpm run format:check` clean · `pnpm -r build` green · full-branch `totem lint` PASS · both seams green (above). ESLint does not cover `spikes/**` (workspace = `packages/*`; the files carried pre-existing `any`s at `69b85544`) — unchanged by this slice.

### Then the loop (each step on the operator's word; the scorer's E24 sequence)

The merged commit is the **new apparatus pin** → mailed to strategy-claude → **controls at the pin** (one PR: `controls.json` · `manifest-checks.json` · `k3-control/` · `k4-swap/`, the seed run's own artifacts NOT committed) → **the run of record** (one unsplit seam from the pin, artifacts committed whole incl. `manifest.json`, `scorerSha256` binding `43c8667c…`) → the **new run pin** mailed with the K7 run id → the scorer's two clones (evidence at the run pin, replay at `manifest.runCommit` per E23, control-only build first) → `scoring.{json,md}` → codex blind replay → the verdict on mmnto-ai/totem-strategy#1138. **Sequencing:** nothing else lands on `main` between the run's `runCommit` and its run pin (B-1 is repo-wide); mmnto-ai/totem#2709 was merged first for exactly that reason and this branch is rebased on it.

Related: mmnto-ai/totem-strategy#1138 · mmnto-ai/totem-strategy#1162 · mmnto-ai/totem-strategy#1165 · mmnto-ai/totem#2704 · mmnto-ai/totem#2705 · mmnto-ai/totem#2709.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017BoXoT6Ecn1tpyVmk2nYRM
