### PR TITLE
spike(spine-adopt): the A13.1 + A14 apparatus slice — INV 2's seed20 × committed-seed20 byte-equality referent LIVE on the top-level arm (charter v1.4 § 7 E25) · the control run's arm-B disclosure renders n/a (A14) — the next apparatus pin; MERGE HELD behind the 0e01112d cure run pin

### DIFF
--- a/spikes/spine-adopt/src/certify-verify.mts
+++ b/spikes/spine-adopt/src/certify-verify.mts
@@ -326,7 +326,11 @@ function main(): void {
   //     a LIVE certifier-drift sensor on the arm the E23 replay itself takes:
   //     the TOP-LEVEL arm. A `seed20` run publishing under a named
   //     `SPIKE_ARTIFACTS_SUBDIR` (a § S8 K-control arm — K4's swap) is not that
-  //     arm and is SKIPPED by name; its chains are that control's to compare.
+  //     arm and is SKIPPED by name. Nothing else compares that arm's chains
+  //     either (K4 reads facts, verdicts and the differential report, never a
+  //     chain; the swap moves example bundles, not chain inputs, so at a run pin
+  //     they are byte-identical to the run of record's) — the skip is scope, not
+  //     delegation, and the sensor of record is the top-level arm's.
   //     The cost is the ruling's intended behaviour: a charter-sanctioned K3
   //     re-pin changes the run of record, so it REFUSES at this seam until the
   //     run of record is re-cut — the same class `control` already carries under
@@ -427,6 +431,18 @@ function main(): void {
         ? ''
         : ' — re-run `npm run all` for this record set before certifying'),
   );
+  // (T13's twin for the ARTIFACT SET — leg G6 on the A13.1 fold) A13.1's arm
+  // selection below reads `SPIKE_ARTIFACTS_SUBDIR` — the environment — while the
+  // manifest records the set the run was DECLARED into (`artifactsSubdir`, inside
+  // `runManifestSha256`'s preimage). The same discipline applies: the two must
+  // agree, and a disagreement is a FAILED check, never a skip.
+  const manifestArtifactsSubdir =
+    (manifest as { artifactsSubdir?: string | null }).artifactsSubdir ?? null;
+  checks.check(
+    "INV 2 — the manifest's `artifactsSubdir` and `SPIKE_ARTIFACTS_SUBDIR` AGREE (the artifact set on disk and this process are the same run)",
+    manifestArtifactsSubdir === ARTIFACTS_SUBDIR,
+    `manifest.artifactsSubdir=${JSON.stringify(manifestArtifactsSubdir)}, SPIKE_ARTIFACTS_SUBDIR=${JSON.stringify(ARTIFACTS_SUBDIR)}`,
+  );
   // (§ S5, as re-keyed by A12 above and extended by A13.1) The comparison has a
   // referent for `specimens` — the whole committed set, when HEAD's committed
   // baseline IS the specimens set — for `control`, where it is ONE chain: against
@@ -486,10 +502,14 @@ function main(): void {
     // — a re-pin or a certifier delta — never a skip, and the seam stops here
     // (`certify` = `certify.mts && certify-verify.mts`; nothing after it runs).
     // The escape is the charter's E6 loop, not a flag: `certify.mts` has already
-    // published the new chains beside this refusal, so the owner commits them as
-    // a NEW run of record (the artifacts-only commit over the pin) and re-runs
-    // the seam at that commit, where this check reads its own bytes back. Same
-    // path `control` takes under A12; there is deliberately no dev seam here.
+    // published the new chains beside this refusal, so the owner commits them
+    // over the pin (an artifacts-only commit — not yet a run of record; the
+    // reports beside them are the previous run's) and re-cuts the run at that
+    // commit, where this check reads its own bytes back. Same path `control`
+    // takes under A12. There is no dev seam on THIS arm: a run under a named
+    // `SPIKE_ARTIFACTS_SUBDIR` is a different artifact set (recorded in its own
+    // manifest as `artifactsSubdir`, and never the run of record), not this one
+    // exempted.
     checks.eq(
       `INV 2 (A13.1) — the published seed-20 chain set is exactly the committed run of record's chain set at HEAD (referent: \`${committedChainsDir}\`, the committed \`recordSet: ${JSON.stringify(committedRecordSet)}\` baseline; every chain is held byte-equal below)`,
       chainFiles,
@@ -498,10 +518,17 @@ function main(): void {
   } else if (manifestRecordSet === 'seed20' && ARTIFACTS_SUBDIR !== null) {
     // (A13.1's scope) A `seed20` run publishing under a named subdir is a § S8
     // K-control arm (K4's swap, or another named set): not the arm the E23 replay
-    // takes, and its chains are that control's to compare. The top-level committed
-    // chains are named, never compared against a sub-arm's published set.
+    // takes. The skip is SCOPE, not delegation — no control compares a sub-arm's
+    // chains (K4 reads facts, verdicts and the differential report), and at a run
+    // pin they are byte-identical to the run of record's because the swap moves
+    // example bundles, not chain inputs. The top-level committed chains are
+    // named, never compared against a sub-arm's published set.
     checks.check(
-      `INV 2 — SKIPPED with the named reason \`seed20-under-named-subdir\`: this run publishes its ${chainFiles.length} chain(s) under \`artifacts/${ARTIFACTS_SUBDIR}/\` (a § S8 K-control arm), not the top-level arm the E23 replay takes, so the committed-vs-published half (A13.1, mmnto-ai/totem#2704) is not run on this arm — \`${committedChainsDir}\` at HEAD holds ${committedNames.length} chain(s) from the committed \`${String(committedRecordSet)}\` baseline; the per-chain claims that need no referent still run`,
+      `INV 2 — SKIPPED with the named reason \`seed20-under-named-subdir\`: this run publishes its ${chainFiles.length} chain(s) under \`artifacts/${ARTIFACTS_SUBDIR}/\` (a § S8 K-control arm), not the top-level arm the E23 replay takes, so the committed-vs-published half (A13.1, mmnto-ai/totem#2704) is not run on this arm and no control compares these chains either — \`${committedChainsDir}\` at HEAD holds ${committedNames.length} chain(s) ${
+        committedManifestPresent
+          ? `from the committed \`recordSet: ${JSON.stringify(committedRecordSet)}\` baseline`
+          : '(`artifacts/manifest.json` is ABSENT at HEAD — pre-manifest history)'
+      }; the per-chain claims that need no referent still run`,
       true,
       `published: ${chainFiles.length} under \`artifacts/${ARTIFACTS_SUBDIR}/chains\`; committed at HEAD under \`${committedChainsDir}\`: ${committedNames.length}`,
     );
@@ -620,7 +647,16 @@ function main(): void {
       mode: cmp?.mode ?? null,
       modeReason:
         cmp === null
-          ? `no committed referent for this run — \`artifacts/manifest.json\` at HEAD records \`recordSet: ${JSON.stringify(committedRecordSet)}\` and the selected referent dir \`${committedChainsDir}\` does not apply on \`${String(manifestRecordSet)}\`, so the committed-vs-published half of INV 2 is skipped for this chain`
+          ? manifestRecordSet === 'seed20' && ARTIFACTS_SUBDIR !== null
+            ? // (leg G2 on the A13.1 fold) The per-chain narration must agree with
+              // the header row above: on a sub-arm the referent APPLIES to `seed20`
+              // — it is the arm, not the record set, that is out of scope.
+              `skipped with the named reason \`seed20-under-named-subdir\` — this run publishes under \`artifacts/${ARTIFACTS_SUBDIR}/\`, not the top-level arm the E23 replay takes, so the committed-vs-published half of INV 2 (A13.1) is not run for this chain; \`${committedChainsDir}\` at HEAD is the top-level arm's referent`
+            : `no committed referent for this run — \`artifacts/manifest.json\` at HEAD ${
+                committedManifestPresent
+                  ? `records \`recordSet: ${JSON.stringify(committedRecordSet)}\``
+                  : 'is ABSENT (pre-manifest history)'
+              } and the selected referent dir \`${committedChainsDir}\` does not apply on \`${String(manifestRecordSet)}\`, so the committed-vs-published half of INV 2 is skipped for this chain`
           : cmp.mode === 'drift-detection'
             ? `the committed chain carries \`${POST_SLICE_MARKER}\` — the slice is committed, so the claim is byte-EQUALITY`
             : `the committed chain has no \`${POST_SLICE_MARKER}\` — a pre-slice baseline, so the claim is the additive extension`,
@@ -936,7 +972,18 @@ function main(): void {
       method:
         "BIDIRECTIONAL, chosen per chain from the COMMITTED file's own shape, so the invariant survives its own commit. `pre-commit` (the committed chain carries no `manifestSha256`): two independent claims — (a) a BYTE claim, the published file starts with the committed file's bytes up to its closing brace, so the extension is appended and nothing was re-serialised; (b) a STRUCTURAL claim, every pre-slice key holds an identical value and the added key set is exactly the extension's. `drift-detection` (the committed chain already carries `manifestSha256`): the published chain must be BYTE-EQUAL to it, and no key may be added, changed or removed — certification is deterministic, so any difference is drift. In both modes the named hashes are checked unchanged and the manifest hash is RE-DERIVED from the module.",
       modeMarker: `the presence of \`${POST_SLICE_MARKER}\` in the committed chain`,
-      preSliceSource: `git show HEAD:${committedChainsDir}/<name>.json`,
+      // (leg G7) Named only when it was READ: on an arm whose committed-vs-published
+      // half is skipped, no referent was consulted and none is claimed here.
+      preSliceSource: committedChainsApply
+        ? `git show HEAD:${committedChainsDir}/<name>.json`
+        : null,
+      preSliceSourceSkipped: committedChainsApply
+        ? null
+        : manifestRecordSet === 'seed20' && ARTIFACTS_SUBDIR !== null
+          ? 'seed20-under-named-subdir'
+          : manifestRecordSet === 'seed20'
+            ? 'no-seed20-referent-at-HEAD'
+            : 'no-specimens-referent-at-HEAD',
       expectedAddedKeys: EXPECTED_ADDED_KEYS,
       modesRun,
       rows: preservation,

--- a/spikes/spine-adopt/src/certify-verify.mts
+++ b/spikes/spine-adopt/src/certify-verify.mts
@@ -503,7 +503,7 @@ function main(): void {
     checks.check(
       `INV 2 — SKIPPED with the named reason \`seed20-under-named-subdir\`: this run publishes its ${chainFiles.length} chain(s) under \`artifacts/${ARTIFACTS_SUBDIR}/\` (a § S8 K-control arm), not the top-level arm the E23 replay takes, so the committed-vs-published half (A13.1, mmnto-ai/totem#2704) is not run on this arm — \`${committedChainsDir}\` at HEAD holds ${committedNames.length} chain(s) from the committed \`${String(committedRecordSet)}\` baseline; the per-chain claims that need no referent still run`,
       true,
-      `published under: ${CHAINS_DIR}; committed at HEAD under \`${committedChainsDir}\`: ${committedNames.length}`,
+      `published: ${chainFiles.length} under \`artifacts/${ARTIFACTS_SUBDIR}/chains\`; committed at HEAD under \`${committedChainsDir}\`: ${committedNames.length}`,
     );
   } else {
     // A `seed20` run whose committed baseline is NOT a seed run: the specimens

--- a/spikes/spine-adopt/src/certify-verify.mts
+++ b/spikes/spine-adopt/src/certify-verify.mts
@@ -314,7 +314,17 @@ function main(): void {
   //     the record bytes are unchanged (chains carry no run identity; a
   //     charter-sanctioned K3 re-pin re-captures its targets first, § 5 K3); a
   //     `specimens` run reads the re-homed baseline under `artifacts/specimens/`
-  //     (below), and only SKIPS, by name, where that home is not committed.
+  //     (below), and only SKIPS, by name, where that home is not committed; and
+  //     (A13.1, charter v1.4 § 7 E25 — EXTEND) a `seed20` run's referent is the
+  //     committed run of record itself, `HEAD:…artifacts/chains/`: the 21 chains
+  //     carry no run identity, so a re-execution at any commit whose committed
+  //     manifest records `recordSet: 'seed20'` regenerates the same bytes, and
+  //     committed-vs-published byte-equality is a LIVE certifier-drift sensor on
+  //     the arm the E23 replay itself takes. The cost is the ruling's intended
+  //     behaviour: a charter-sanctioned K3 re-pin changes the run of record, so
+  //     it REFUSES at this seam until the run of record is re-cut — the same
+  //     class `control` already carries under A12 — rather than measuring drift
+  //     on every arm but the one that matters.
   //   - ABSENT committed manifest (pre-manifest history): treated as the
   //     specimens-baseline era. Absence is established by `ls-tree` — a no-match
   //     pathspec exits 0 with empty stdout — NEVER by a failed `git show`: `gitShow`
@@ -411,19 +421,25 @@ function main(): void {
         ? ''
         : ' — re-run `npm run all` for this record set before certifying'),
   );
-  // (§ S5, as re-keyed by A12 above) The comparison has a referent for `specimens`
-  // — the whole committed set, when HEAD's committed baseline IS the specimens set
-  // — and for `control`, where it is ONE chain: against the specimens baseline, the
-  // committed specimen chain (a control-only rebuild of a committed specimen record
-  // IS K3 arm B); against a committed run of record, the run's own committed
-  // `k3-control/` build. `seed20` never has a committed referent here, and a
-  // `specimens` run over a committed run of record has none either.
+  // (§ S5, as re-keyed by A12 above and extended by A13.1) The comparison has a
+  // referent for `specimens` — the whole committed set, when HEAD's committed
+  // baseline IS the specimens set — for `control`, where it is ONE chain: against
+  // the specimens baseline, the committed specimen chain (a control-only rebuild
+  // of a committed specimen record IS K3 arm B); against a committed run of
+  // record, the run's own committed `k3-control/` build — and (A13.1) for
+  // `seed20`, where it is the whole committed run of record when HEAD's committed
+  // baseline IS a seed run: the top-level chains, byte for byte. A `seed20` run
+  // over the specimens-baseline era (or an absent committed manifest) has no
+  // referent, and a `specimens` run over a committed run of record has none
+  // either unless the re-homed baseline is committed.
   const committedChainsApply =
     manifestRecordSet === 'control'
       ? true
       : manifestRecordSet === 'specimens'
         ? specimensHomeCommitted || committedRecordSet === 'specimens'
-        : false;
+        : manifestRecordSet === 'seed20'
+          ? committedIsRunOfRecord
+          : false;
   if (manifestRecordSet === 'specimens' && !committedChainsApply) {
     // Reachable only before the re-homed baseline is committed AND when the
     // top-level committed baseline is not the specimens set (a committed run of
@@ -450,9 +466,24 @@ function main(): void {
       },
       { published: expected, missingFromCommitted: [] },
     );
+  } else if (manifestRecordSet === 'seed20' && committedChainsApply) {
+    // (A13.1) The committed run of record IS the referent: the published seed-20
+    // chain set must be exactly the committed top-level set, and each chain is
+    // then held BYTE-EQUAL in the per-chain loop below (`drift-detection`, the
+    // committed chains carry `manifestSha256`). A mismatch here is a FAILED check
+    // — a re-pin or a certifier delta — never a skip; the cure is to re-cut the
+    // run of record, by the charter's E6 loop, not to loosen the seam.
+    checks.eq(
+      `INV 2 (A13.1) — the published seed-20 chain set is exactly the committed run of record's chain set at HEAD (referent: \`${committedChainsDir}\`, the committed \`recordSet: ${JSON.stringify(committedRecordSet)}\` baseline; every chain is held byte-equal below)`,
+      chainFiles,
+      committedNames,
+    );
   } else {
+    // A `seed20` run whose committed baseline is NOT a seed run: the specimens
+    // era, or an absent committed manifest. The top-level chains at HEAD are then
+    // a different record set's, never a referent for these — named, not compared.
     checks.check(
-      `INV 2 — SKIPPED with the named reason \`committed-half-not-run-on-seed20\`: the ${chainFiles.length} published chain(s) belong to record set \`${String(manifestRecordSet)}\` (the manifest's); the committed-vs-published half is not run on this arm — \`${committedChainsDir}\` at HEAD holds ${committedNames.length} chain(s) from the committed \`${String(committedRecordSet)}\` baseline, a live byte-equality referent when that baseline is itself a seed run (deposited as a candidate extension, not built here: A13 on mmnto-ai/totem#2704)`,
+      `INV 2 — SKIPPED with the named reason \`no-seed20-referent-at-HEAD\`: the ${chainFiles.length} published chain(s) belong to record set \`${String(manifestRecordSet)}\` (the manifest's) but \`artifacts/manifest.json\` at HEAD records \`recordSet: ${JSON.stringify(committedRecordSet)}\`, so \`${committedChainsDir}\` at HEAD (${committedNames.length} chain(s)) is not a committed run of record and the committed-vs-published half is not run on this arm (A13.1 applies only over a committed seed run; mmnto-ai/totem#2704); the per-chain claims that need no referent still run`,
       true,
       `published: ${chainFiles.length}; committed at HEAD: ${committedNames.length}`,
     );

--- a/spikes/spine-adopt/src/certify-verify.mts
+++ b/spikes/spine-adopt/src/certify-verify.mts
@@ -52,6 +52,7 @@ import * as path from 'node:path';
 import { activeRecordSet, loadRecordSet } from './lib/record-sets.mts';
 import {
   ARTIFACTS_DIR,
+  ARTIFACTS_SUBDIR,
   CHAINS_DIR,
   Checks,
   readRunManifest,
@@ -317,14 +318,19 @@ function main(): void {
   //     (below), and only SKIPS, by name, where that home is not committed; and
   //     (A13.1, charter v1.4 § 7 E25 — EXTEND) a `seed20` run's referent is the
   //     committed run of record itself, `HEAD:…artifacts/chains/`: the 21 chains
-  //     carry no run identity, so a re-execution at any commit whose committed
-  //     manifest records `recordSet: 'seed20'` regenerates the same bytes, and
-  //     committed-vs-published byte-equality is a LIVE certifier-drift sensor on
-  //     the arm the E23 replay itself takes. The cost is the ruling's intended
-  //     behaviour: a charter-sanctioned K3 re-pin changes the run of record, so
-  //     it REFUSES at this seam until the run of record is re-cut — the same
-  //     class `control` already carries under A12 — rather than measuring drift
-  //     on every arm but the one that matters.
+  //     carry no run identity, so — while the chain-producing source (the
+  //     lowerer, the certifier, the record bytes, the pinned toolchain) is
+  //     unchanged, which is exactly what this sensor measures — a re-execution
+  //     at any commit whose committed manifest records `recordSet: 'seed20'`
+  //     regenerates the same bytes, and committed-vs-published byte-equality is
+  //     a LIVE certifier-drift sensor on the arm the E23 replay itself takes:
+  //     the TOP-LEVEL arm. A `seed20` run publishing under a named
+  //     `SPIKE_ARTIFACTS_SUBDIR` (a § S8 K-control arm — K4's swap) is not that
+  //     arm and is SKIPPED by name; its chains are that control's to compare.
+  //     The cost is the ruling's intended behaviour: a charter-sanctioned K3
+  //     re-pin changes the run of record, so it REFUSES at this seam until the
+  //     run of record is re-cut — the same class `control` already carries under
+  //     A12 — rather than measuring drift on every arm but the one that matters.
   //   - ABSENT committed manifest (pre-manifest history): treated as the
   //     specimens-baseline era. Absence is established by `ls-tree` — a no-match
   //     pathspec exits 0 with empty stdout — NEVER by a failed `git show`: `gitShow`
@@ -427,18 +433,24 @@ function main(): void {
   // the specimens baseline, the committed specimen chain (a control-only rebuild
   // of a committed specimen record IS K3 arm B); against a committed run of
   // record, the run's own committed `k3-control/` build — and (A13.1) for
-  // `seed20`, where it is the whole committed run of record when HEAD's committed
-  // baseline IS a seed run: the top-level chains, byte for byte. A `seed20` run
-  // over the specimens-baseline era (or an absent committed manifest) has no
-  // referent, and a `specimens` run over a committed run of record has none
-  // either unless the re-homed baseline is committed.
+  // `seed20` ON THE TOP-LEVEL ARM, where it is the whole committed run of record
+  // when HEAD's committed baseline IS a seed run: the top-level chains, byte for
+  // byte. Two things narrow the ruled clause (`committedChainsApply = true when
+  // committedRecordSet === 'seed20'`), both disclosed: the MANIFEST's set must be
+  // `seed20` too (a `specimens` run over a committed seed baseline would otherwise
+  // compare specimen chains against seed chains), and `SPIKE_ARTIFACTS_SUBDIR`
+  // must be unset — a `seed20` run under a named subdir is a § S8 K-control arm
+  // (K4's swap), not the arm the E23 replay takes. A `seed20` run over the
+  // specimens-baseline era (or an absent committed manifest) has no referent, and
+  // a `specimens` run over a committed run of record has none either unless the
+  // re-homed baseline is committed.
   const committedChainsApply =
     manifestRecordSet === 'control'
       ? true
       : manifestRecordSet === 'specimens'
         ? specimensHomeCommitted || committedRecordSet === 'specimens'
         : manifestRecordSet === 'seed20'
-          ? committedIsRunOfRecord
+          ? committedIsRunOfRecord && ARTIFACTS_SUBDIR === null
           : false;
   if (manifestRecordSet === 'specimens' && !committedChainsApply) {
     // Reachable only before the re-homed baseline is committed AND when the
@@ -471,19 +483,38 @@ function main(): void {
     // chain set must be exactly the committed top-level set, and each chain is
     // then held BYTE-EQUAL in the per-chain loop below (`drift-detection`, the
     // committed chains carry `manifestSha256`). A mismatch here is a FAILED check
-    // — a re-pin or a certifier delta — never a skip; the cure is to re-cut the
-    // run of record, by the charter's E6 loop, not to loosen the seam.
+    // — a re-pin or a certifier delta — never a skip, and the seam stops here
+    // (`certify` = `certify.mts && certify-verify.mts`; nothing after it runs).
+    // The escape is the charter's E6 loop, not a flag: `certify.mts` has already
+    // published the new chains beside this refusal, so the owner commits them as
+    // a NEW run of record (the artifacts-only commit over the pin) and re-runs
+    // the seam at that commit, where this check reads its own bytes back. Same
+    // path `control` takes under A12; there is deliberately no dev seam here.
     checks.eq(
       `INV 2 (A13.1) — the published seed-20 chain set is exactly the committed run of record's chain set at HEAD (referent: \`${committedChainsDir}\`, the committed \`recordSet: ${JSON.stringify(committedRecordSet)}\` baseline; every chain is held byte-equal below)`,
       chainFiles,
       committedNames,
+    );
+  } else if (manifestRecordSet === 'seed20' && ARTIFACTS_SUBDIR !== null) {
+    // (A13.1's scope) A `seed20` run publishing under a named subdir is a § S8
+    // K-control arm (K4's swap, or another named set): not the arm the E23 replay
+    // takes, and its chains are that control's to compare. The top-level committed
+    // chains are named, never compared against a sub-arm's published set.
+    checks.check(
+      `INV 2 — SKIPPED with the named reason \`seed20-under-named-subdir\`: this run publishes its ${chainFiles.length} chain(s) under \`artifacts/${ARTIFACTS_SUBDIR}/\` (a § S8 K-control arm), not the top-level arm the E23 replay takes, so the committed-vs-published half (A13.1, mmnto-ai/totem#2704) is not run on this arm — \`${committedChainsDir}\` at HEAD holds ${committedNames.length} chain(s) from the committed \`${String(committedRecordSet)}\` baseline; the per-chain claims that need no referent still run`,
+      true,
+      `published under: ${CHAINS_DIR}; committed at HEAD under \`${committedChainsDir}\`: ${committedNames.length}`,
     );
   } else {
     // A `seed20` run whose committed baseline is NOT a seed run: the specimens
     // era, or an absent committed manifest. The top-level chains at HEAD are then
     // a different record set's, never a referent for these — named, not compared.
     checks.check(
-      `INV 2 — SKIPPED with the named reason \`no-seed20-referent-at-HEAD\`: the ${chainFiles.length} published chain(s) belong to record set \`${String(manifestRecordSet)}\` (the manifest's) but \`artifacts/manifest.json\` at HEAD records \`recordSet: ${JSON.stringify(committedRecordSet)}\`, so \`${committedChainsDir}\` at HEAD (${committedNames.length} chain(s)) is not a committed run of record and the committed-vs-published half is not run on this arm (A13.1 applies only over a committed seed run; mmnto-ai/totem#2704); the per-chain claims that need no referent still run`,
+      `INV 2 — SKIPPED with the named reason \`no-seed20-referent-at-HEAD\`: the ${chainFiles.length} published chain(s) belong to record set \`${String(manifestRecordSet)}\` (the manifest's) but ${
+        committedManifestPresent
+          ? `\`artifacts/manifest.json\` at HEAD records \`recordSet: ${JSON.stringify(committedRecordSet)}\``
+          : '`artifacts/manifest.json` is ABSENT at HEAD (pre-manifest history)'
+      }, so \`${committedChainsDir}\` at HEAD (${committedNames.length} chain(s)) is not a committed run of record and the committed-vs-published half is not run on this arm (A13.1 applies only over a committed seed run; mmnto-ai/totem#2704); the per-chain claims that need no referent still run`,
       true,
       `published: ${chainFiles.length}; committed at HEAD: ${committedNames.length}`,
     );

--- a/spikes/spine-adopt/src/certify-verify.mts
+++ b/spikes/spine-adopt/src/certify-verify.mts
@@ -432,16 +432,20 @@ function main(): void {
         : ' — re-run `npm run all` for this record set before certifying'),
   );
   // (T13's twin for the ARTIFACT SET — leg G6 on the A13.1 fold) A13.1's arm
-  // selection below reads `SPIKE_ARTIFACTS_SUBDIR` — the environment — while the
-  // manifest records the set the run was DECLARED into (`artifactsSubdir`, inside
-  // `runManifestSha256`'s preimage). The same discipline applies: the two must
-  // agree, and a disagreement is a FAILED check, never a skip.
+  // selection below reads `ARTIFACTS_SUBDIR` — derived from the environment
+  // (`SPIKE_ARTIFACTS_SUBDIR`, or the `k3-control` default under
+  // `SPIKE_CONTROL_RECORD`) — while the manifest records the set the run was
+  // DECLARED into (`artifactsSubdir`, inside `runManifestSha256`'s preimage). A
+  // weaker twin than T13's (leg J2): the manifest is read from the directory this
+  // constant names, so a disagreement needs a manifest moved across artifact
+  // roots — but it is still a FAILED check, never a skip, so the arm selection is
+  // bound to the set the manifest declares rather than to the process alone.
   const manifestArtifactsSubdir =
     (manifest as { artifactsSubdir?: string | null }).artifactsSubdir ?? null;
   checks.check(
-    "INV 2 — the manifest's `artifactsSubdir` and `SPIKE_ARTIFACTS_SUBDIR` AGREE (the artifact set on disk and this process are the same run)",
+    "INV 2 — the manifest's `artifactsSubdir` and this process's `ARTIFACTS_SUBDIR` AGREE (A13.1's arm selection is bound to the set the manifest declares)",
     manifestArtifactsSubdir === ARTIFACTS_SUBDIR,
-    `manifest.artifactsSubdir=${JSON.stringify(manifestArtifactsSubdir)}, SPIKE_ARTIFACTS_SUBDIR=${JSON.stringify(ARTIFACTS_SUBDIR)}`,
+    `manifest.artifactsSubdir=${JSON.stringify(manifestArtifactsSubdir)}, ARTIFACTS_SUBDIR=${JSON.stringify(ARTIFACTS_SUBDIR)} (from SPIKE_ARTIFACTS_SUBDIR, or the k3-control default under SPIKE_CONTROL_RECORD)`,
   );
   // (§ S5, as re-keyed by A12 above and extended by A13.1) The comparison has a
   // referent for `specimens` — the whole committed set, when HEAD's committed
@@ -468,13 +472,23 @@ function main(): void {
         : manifestRecordSet === 'seed20'
           ? committedIsRunOfRecord && ARTIFACTS_SUBDIR === null
           : false;
+  // (leg J5) The named skip reason is derived ONCE and used by the header row, the
+  // per-chain `modeReason` and `preSliceSourceSkipped`, so the three layers of the
+  // artifact cannot name different reasons for the same state.
+  const inv2SkipReason: string | null = committedChainsApply
+    ? null
+    : manifestRecordSet === 'specimens'
+      ? 'no-specimens-referent-at-HEAD'
+      : manifestRecordSet === 'seed20' && ARTIFACTS_SUBDIR !== null
+        ? 'seed20-under-named-subdir'
+        : 'no-seed20-referent-at-HEAD';
   if (manifestRecordSet === 'specimens' && !committedChainsApply) {
     // Reachable only before the re-homed baseline is committed AND when the
     // top-level committed baseline is not the specimens set (a committed run of
     // record, or an unknown/future committed set — named below either way, never
     // compared against the wrong referent).
     checks.check(
-      `INV 2 — SKIPPED with the named reason \`no-specimens-referent-at-HEAD\`: \`${SPECIMENS_HOME}\` is not committed and \`artifacts/manifest.json\` at HEAD records \`recordSet: ${JSON.stringify(committedRecordSet)}\`, so the ${chainFiles.length} published specimen chain(s) have no committed referent (A12, mmnto-ai/totem#2704); the per-chain claims that need none still run`,
+      `INV 2 — SKIPPED with the named reason \`${inv2SkipReason}\`: \`${SPECIMENS_HOME}\` is not committed and \`artifacts/manifest.json\` at HEAD records \`recordSet: ${JSON.stringify(committedRecordSet)}\`, so the ${chainFiles.length} published specimen chain(s) have no committed referent (A12, mmnto-ai/totem#2704); the per-chain claims that need none still run`,
       true,
       `published: ${chainFiles.length}; committed at HEAD under \`${committedChainsDir}\`: ${committedNames.length}`,
     );
@@ -503,9 +517,11 @@ function main(): void {
     // (`certify` = `certify.mts && certify-verify.mts`; nothing after it runs).
     // The escape is the charter's E6 loop, not a flag: `certify.mts` has already
     // published the new chains beside this refusal, so the owner commits them
-    // over the pin (an artifacts-only commit — not yet a run of record; the
-    // reports beside them are the previous run's) and re-cuts the run at that
-    // commit, where this check reads its own bytes back. Same path `control`
+    // over the pin (an artifacts-only commit — not yet a run of record: the
+    // certification report is this run's, but the host verdicts, the
+    // differential report and `controls.json` beside it are the previous run's,
+    // since the seam stopped at `certify`) and re-cuts the run at that commit,
+    // where this check reads its own bytes back. Same path `control`
     // takes under A12. There is no dev seam on THIS arm: a run under a named
     // `SPIKE_ARTIFACTS_SUBDIR` is a different artifact set (recorded in its own
     // manifest as `artifactsSubdir`, and never the run of record), not this one
@@ -518,13 +534,20 @@ function main(): void {
   } else if (manifestRecordSet === 'seed20' && ARTIFACTS_SUBDIR !== null) {
     // (A13.1's scope) A `seed20` run publishing under a named subdir is a § S8
     // K-control arm (K4's swap, or another named set): not the arm the E23 replay
-    // takes. The skip is SCOPE, not delegation — no control compares a sub-arm's
-    // chains (K4 reads facts, verdicts and the differential report), and at a run
-    // pin they are byte-identical to the run of record's because the swap moves
-    // example bundles, not chain inputs. The top-level committed chains are
-    // named, never compared against a sub-arm's published set.
+    // takes. The skip is SCOPE, not delegation. For K4 specifically, no control
+    // compares its chains (K4 reads facts, verdicts and the differential report),
+    // and at a run pin they are byte-identical to the run of record's because the
+    // swap moves example bundles, not chain inputs; another named set is its own
+    // control's to read (K7's rebuild home and the K3 control home ARE read by
+    // their controls — leg J3), so the row says only what holds for the arm it
+    // is on. The top-level committed chains are named, never compared against a
+    // sub-arm's published set.
     checks.check(
-      `INV 2 — SKIPPED with the named reason \`seed20-under-named-subdir\`: this run publishes its ${chainFiles.length} chain(s) under \`artifacts/${ARTIFACTS_SUBDIR}/\` (a § S8 K-control arm), not the top-level arm the E23 replay takes, so the committed-vs-published half (A13.1, mmnto-ai/totem#2704) is not run on this arm and no control compares these chains either — \`${committedChainsDir}\` at HEAD holds ${committedNames.length} chain(s) ${
+      `INV 2 — SKIPPED with the named reason \`${inv2SkipReason}\`: this run publishes its ${chainFiles.length} chain(s) under \`artifacts/${ARTIFACTS_SUBDIR}/\` (a § S8 K-control arm), not the top-level arm the E23 replay takes, so the committed-vs-published half (A13.1, mmnto-ai/totem#2704) is not run on this arm${
+        ARTIFACTS_SUBDIR === 'k4-swap'
+          ? " — and K4 compares none of this arm's chains (it reads facts, verdicts and the differential report)"
+          : " — what this arm's chains are compared against is its own control's to say"
+      } — \`${committedChainsDir}\` at HEAD holds ${committedNames.length} chain(s) ${
         committedManifestPresent
           ? `from the committed \`recordSet: ${JSON.stringify(committedRecordSet)}\` baseline`
           : '(`artifacts/manifest.json` is ABSENT at HEAD — pre-manifest history)'
@@ -537,7 +560,7 @@ function main(): void {
     // era, or an absent committed manifest. The top-level chains at HEAD are then
     // a different record set's, never a referent for these — named, not compared.
     checks.check(
-      `INV 2 — SKIPPED with the named reason \`no-seed20-referent-at-HEAD\`: the ${chainFiles.length} published chain(s) belong to record set \`${String(manifestRecordSet)}\` (the manifest's) but ${
+      `INV 2 — SKIPPED with the named reason \`${inv2SkipReason}\`: the ${chainFiles.length} published chain(s) belong to record set \`${String(manifestRecordSet)}\` (the manifest's) but ${
         committedManifestPresent
           ? `\`artifacts/manifest.json\` at HEAD records \`recordSet: ${JSON.stringify(committedRecordSet)}\``
           : '`artifacts/manifest.json` is ABSENT at HEAD (pre-manifest history)'
@@ -650,8 +673,14 @@ function main(): void {
           ? manifestRecordSet === 'seed20' && ARTIFACTS_SUBDIR !== null
             ? // (leg G2 on the A13.1 fold) The per-chain narration must agree with
               // the header row above: on a sub-arm the referent APPLIES to `seed20`
-              // — it is the arm, not the record set, that is out of scope.
-              `skipped with the named reason \`seed20-under-named-subdir\` — this run publishes under \`artifacts/${ARTIFACTS_SUBDIR}/\`, not the top-level arm the E23 replay takes, so the committed-vs-published half of INV 2 (A13.1) is not run for this chain; \`${committedChainsDir}\` at HEAD is the top-level arm's referent`
+              // — it is the arm, not the record set, that is out of scope. The
+              // closing clause is claimed only over a committed run of record (leg
+              // J4): at any other HEAD the top-level arm's own row denies a referent.
+              `skipped with the named reason \`${inv2SkipReason}\` — this run publishes under \`artifacts/${ARTIFACTS_SUBDIR}/\`, not the top-level arm the E23 replay takes, so the committed-vs-published half of INV 2 (A13.1) is not run for this chain${
+                committedIsRunOfRecord
+                  ? `; \`${committedChainsDir}\` at HEAD is the top-level arm's referent`
+                  : `; \`artifacts/manifest.json\` at HEAD is not a committed run of record, so the top-level arm has no referent here either`
+              }`
             : `no committed referent for this run — \`artifacts/manifest.json\` at HEAD ${
                 committedManifestPresent
                   ? `records \`recordSet: ${JSON.stringify(committedRecordSet)}\``
@@ -977,13 +1006,7 @@ function main(): void {
       preSliceSource: committedChainsApply
         ? `git show HEAD:${committedChainsDir}/<name>.json`
         : null,
-      preSliceSourceSkipped: committedChainsApply
-        ? null
-        : manifestRecordSet === 'seed20' && ARTIFACTS_SUBDIR !== null
-          ? 'seed20-under-named-subdir'
-          : manifestRecordSet === 'seed20'
-            ? 'no-seed20-referent-at-HEAD'
-            : 'no-specimens-referent-at-HEAD',
+      preSliceSourceSkipped: inv2SkipReason,
       expectedAddedKeys: EXPECTED_ADDED_KEYS,
       modesRun,
       rows: preservation,

--- a/spikes/spine-adopt/src/manifest.mts
+++ b/spikes/spine-adopt/src/manifest.mts
@@ -412,13 +412,25 @@ function main(): void {
   // run's `repinned`. Arm B is PRESENT only when the control build's OWN manifest
   // beside those bytes says `recordSet: 'control'` AND its `runCommit` equals this
   // run's HEAD. Anything else is arm B ABSENT, disclosed by name.
+  //
+  // (A14, mmnto-ai/totem#2704) On the CONTROL run this process IS arm B. The home it
+  // would inspect is the one it is about to write into, so anything found there is
+  // the PREVIOUS control build's — the one being replaced — and a disclosure read
+  // from it is stale and self-referential (the controls-at-the-pin commit recorded
+  // "STALE … runCommit=69b85544…" in `k3-control/manifest-checks.json` beside a
+  // `k3-control/manifest.json` that said `8f64e4b9…`; and a leftover build at the
+  // SAME HEAD would have been measured against itself and published as this run's
+  // `repinned`). Arm B is therefore NOT inspected on this set: `repinned` stays
+  // `null` with `repinnedFrom: null`, and the row says why by name. The seed run
+  // measures it — that is the § 6 order (control-only build FIRST).
+  const thisRunIsArmB = recordSet === 'control';
   const k3ControlRel = 'artifacts/k3-control';
   const k3ControlHome = path.join(SPIKE_ROOT, 'artifacts', 'k3-control');
   const armBPolicyAt = path.join(k3ControlHome, 'lowered', K3_CAPTURE_PACKAGE, 'policy.rego');
   const armBChainAt = path.join(k3ControlHome, 'chains', `${K3_CAPTURE_PACKAGE}.json`);
   const armBManifestAt = path.join(k3ControlHome, 'manifest.json');
   let armBManifest: Record<string, unknown> | null = null;
-  if (fs.existsSync(armBManifestAt)) {
+  if (!thisRunIsArmB && fs.existsSync(armBManifestAt)) {
     try {
       armBManifest = JSON.parse(fs.readFileSync(armBManifestAt, 'utf-8')) as Record<
         string,
@@ -431,20 +443,23 @@ function main(): void {
     }
   }
   const armBBound =
+    !thisRunIsArmB &&
     armBManifest !== null &&
     armBManifest.recordSet === 'control' &&
     armBManifest.runCommit === head.out;
-  const armBBindingDetail = !fs.existsSync(k3ControlHome)
-    ? `no control-only build present: \`${k3ControlRel}/\` does not exist`
-    : armBManifest === null
-      ? `no control-only build present: \`${k3ControlRel}/manifest.json\` is absent or unparseable`
-      : armBBound
-        ? `bound to this run: \`${k3ControlRel}/manifest.json\` carries recordSet=control runCommit=${head.out}`
-        : `STALE control-only build — \`${k3ControlRel}/manifest.json\` carries recordSet=${JSON.stringify(
-            armBManifest.recordSet ?? null,
-          )} runCommit=${JSON.stringify(
-            armBManifest.runCommit ?? null,
-          )}; arm B requires recordSet 'control' at THIS run's HEAD ${head.out}`;
+  const armBBindingDetail = thisRunIsArmB
+    ? 'n/a — this run IS the control-only build (arm B); the seed run measures it'
+    : !fs.existsSync(k3ControlHome)
+      ? `no control-only build present: \`${k3ControlRel}/\` does not exist`
+      : armBManifest === null
+        ? `no control-only build present: \`${k3ControlRel}/manifest.json\` is absent or unparseable`
+        : armBBound
+          ? `bound to this run: \`${k3ControlRel}/manifest.json\` carries recordSet=control runCommit=${head.out}`
+          : `STALE control-only build — \`${k3ControlRel}/manifest.json\` carries recordSet=${JSON.stringify(
+              armBManifest.recordSet ?? null,
+            )} runCommit=${JSON.stringify(
+              armBManifest.runCommit ?? null,
+            )}; arm B requires recordSet 'control' at THIS run's HEAD ${head.out}`;
   const armBRebuilt =
     armBBound && fs.existsSync(armBPolicyAt) && fs.existsSync(armBChainAt)
       ? {
@@ -889,14 +904,18 @@ function main(): void {
     }`,
     true,
     k3Repinned === null
-      ? // (fold 3 J2) The detail NAMES why arm B is absent: no build, or a build bound
-        // to another run. "Absent" and "stale" are different states and a reader must
-        // not have to guess which one produced the `null`.
-        `${armBBindingDetail}${
-          armBBound
-            ? ` — but \`${k3ControlRel}/lowered/${K3_CAPTURE_PACKAGE}/policy.rego\` and/or its chain are absent`
-            : ''
-        } — run the § S5 seam with SPIKE_CONTROL_RECORD set at this HEAD; the disposition is \`controls.json\` K3 arm B's`
+      ? thisRunIsArmB
+        ? // (A14) This run IS arm B: nothing to inspect, nothing to instruct — the
+          // seed run that follows measures this build, and the disposition is its.
+          armBBindingDetail
+        : // (fold 3 J2) The detail NAMES why arm B is absent: no build, or a build
+          // bound to another run. "Absent" and "stale" are different states and a
+          // reader must not have to guess which one produced the `null`.
+          `${armBBindingDetail}${
+            armBBound
+              ? ` — but \`${k3ControlRel}/lowered/${K3_CAPTURE_PACKAGE}/policy.rego\` and/or its chain are absent`
+              : ''
+          } — run the § S5 seam with SPIKE_CONTROL_RECORD set at this HEAD; the disposition is \`controls.json\` K3 arm B's`
       : k3Repinned
         ? `policy.rego ${armBRebuilt!.policyRegoSha256} (pin ${k3Pins.policyRegoSha256}); code ${armBRebuilt!.policyRegoCodeSha256} (pin ${k3Pins.policyRegoCodeSha256}); chain ${armBRebuilt!.chainSha256} (pin ${k3Pins.chainSha256}) — ${armBBindingDetail}`
         : `the control-only build reproduces the pinned policy.rego, its § 5 code-only digest AND the pinned chain byte-for-byte — ${armBBindingDetail}`,

--- a/spikes/spine-adopt/src/manifest.mts
+++ b/spikes/spine-adopt/src/manifest.mts
@@ -889,13 +889,19 @@ function main(): void {
     K3_CAPTURE_POLICY_CODE_SHA256,
   );
   // (fold 2 H2) DISCLOSING, never refusing. `repinned` is now a real predicate over
-  // K3 arm B, and each of its three outcomes is a legitimate state of a run: the
+  // K3 arm B, and each of its outcomes is a legitimate state of a run: the
   // control-only build was not present (`null`), it reproduced the pinned target
-  // (`false`), or the target moved (`true`). Whether a `true` is acceptable is the
-  // DISPOSITION, and the disposition lives in `controls.json` K3 — a manifest that
-  // exited 1 on it would be deciding a question that is not the apparatus's.
+  // (`false`), the target moved (`true`) — or (A14) this run IS arm B and the home
+  // was not inspected (`null`, named as such in the detail). Whether a `true` is
+  // acceptable is the DISPOSITION, and the disposition lives in `controls.json` K3
+  // — a manifest that exited 1 on it would be deciding a question that is not the
+  // apparatus's.
   checks.check(
-    `K3 CAPTURE — \`repinned\` MEASURED from arm B (the control-only build under \`${k3ControlRel}/\`): ${
+    `K3 CAPTURE — \`repinned\` ${
+      thisRunIsArmB
+        ? 'from arm B (this run IS arm B — not inspected)'
+        : `MEASURED from arm B (the control-only build under \`${k3ControlRel}/\`)`
+    }: ${
       k3Repinned === null
         ? 'NOT MEASURED (null)'
         : k3Repinned


### PR DESCRIPTION
## The A13.1 + A14 apparatus slice — INV 2's seed20 × committed-seed20 byte-equality referent goes LIVE on the top-level arm (A13.1 EXTEND, charter v1.4 § 7 E25), and the control run's arm-B disclosure stops inspecting the home it is about to overwrite (A14) — the next apparatus pin. **MERGE HELD** behind the `0e01112d` cure run pin (the scorer's 04:08Z re-sequencing)

Operator-greenlit direct in-session (2026-09-01 ~03:5xZ: "Greenlight the A13.1 + A14 apparatus slice"; the same word relayed by the scorer's 03:50Z dispatch). Ruling of record: charter v1.4 § 7 E25 at mmnto-ai/totem-strategy main (mmnto-ai/totem-strategy#1174; A13.1 EXTEND · A13.2 NOT ADOPTED · A14 rides this slice). Design record: mmnto-ai/totem#2704 comments 5471310105 (A13) and 5471646264 (A14). **The new apparatus pin requires nothing of the run of record**: `f6efe85d` stands scored under scorer v3; no re-run, no re-score, no re-pin.

**Sequencing (the scorer's 04:08Z dispatch, correcting its 03:50Z):** the `0e01112d` cure loop (charter v1.5 § 7 E26) PRECEDES this slice's merge. With A13.1 on `main`, the cure run — which publishes **22** chains against the run of record's committed **21** — is refused by this very sensor (`INV 2 — <name>: a committed chain exists at HEAD` fails for the new chain; the `INV 2 (A13.1)` set row fails 22 ≠ 21; `finish()` throws inside `all`): E25's own "a record change is a re-cut" class, applied to the cure. No carve-out in a fail-closed control. So: **build, bots and review proceed here; the merge waits for the cure run pin to be mailed** (and for the operator's word).

Five commits: `9d0d1200` the slice · `6191a3df` the leg-1 fold (F1–F5) · `577c31bf` one detail line made repo-relative · `8c2cfc17` the leg-2 fold (G1–G7) · `642f288e` the leg-3 fold (J1–J6). The A13.1 predicate is unchanged since `6191a3df`.

## Mechanical Root Cause

- **A13.1.** At every run pin the committed `artifacts/manifest.json` records `recordSet: 'seed20'` and the committed top-level `artifacts/chains/` are the run of record's 21 chains, which carry no run identity — so, while the chain-producing source is unchanged (exactly what the sensor measures), a `seed20` re-execution regenerates the same bytes and committed-vs-published byte-equality is a live certifier-drift sensor on the arm the E23 replay itself takes. `certify-verify.mts` left that half un-run on `seed20` (`committedChainsApply` was `false` there; the row said so by name). The A12 re-key had extended the referent to `control` and `specimens` only.
- **A14.** `manifest.mts` reads the arm-B home (`artifacts/k3-control/manifest.json`) before writing its own manifest. On the **control** run — which IS arm B — that read returns the PREVIOUS control build's manifest (the one this run is replacing), so the K3 CAPTURE disclosure described the build being replaced (`STALE … runCommit=69b85544…` beside a `k3-control/manifest.json` that said `8f64e4b9…`, the controls-at-the-pin commit). A leftover build at the SAME HEAD would have gone further: measured against itself and published as this run's `repinned`.

## Fix Applied

| item | cure | where |
|---|---|---|
| **A13.1 EXTEND** | `committedChainsApply = true` on `seed20` when the committed manifest at HEAD records `recordSet: 'seed20'` (`committedIsRunOfRecord`) **and `ARTIFACTS_SUBDIR` is null**; referent the top-level chains. A new `checks.eq` — `INV 2 (A13.1)` — requires the published seed-20 chain set to equal the committed set (a FAILED check, never a skip); each chain is then held byte-equal in the existing per-chain `drift-detection` loop. A `seed20` run under a named subdir (a § S8 K-control arm — K4's swap) is SKIPPED by name (`seed20-under-named-subdir`); the reason is derived ONCE (`inv2SkipReason`) and used by the header row, every per-chain `modeReason`, and `preSliceSourceSkipped` (`preSliceSource` is `null` on any arm whose referent was not read). The skip is **scope, not delegation**: for K4 the row states that K4 compares none of that arm's chains (it reads facts, verdicts and the differential report; at a run pin they are byte-identical to the run of record's because the swap moves example bundles, not chain inputs); for any other named set the row defers to that arm's own control. Over a non-seed committed baseline (specimens era / absent manifest) it is SKIPPED with `no-seed20-referent-at-HEAD`. **Two disclosed narrowings of the ruled clause's literal text** (`committedChainsApply = true when committedRecordSet === 'seed20'`): the MANIFEST's set must be `seed20` too (a `specimens` run over a committed seed baseline would otherwise compare specimen chains against seed chains), and the subdir must be unset (the ruling's "the arm the E23 replay itself takes" is the top-level arm; leg F1). Because that second conjunct is derived from the environment, an agreement row — T13's weaker twin, stated as such — requires the manifest's `artifactsSubdir` to equal the process's `ARTIFACTS_SUBDIR` (a FAILED check, never a skip; leg G6/J2). The cost E25 rules intended is now the behaviour: a charter-sanctioned K3 re-pin — or a record change, as the cure loop shows — REFUSES at this seam until the run of record is re-cut; the escape is the E6 loop (`certify.mts` has already published the new chains beside the refusal → commit them over the pin, an artifacts-only commit → re-cut the run at that commit), no dev seam on this arm. | `certify-verify.mts` (the referent comment, `committedChainsApply`, `inv2SkipReason`, the seed20 branches, the agreement row, `modeReason`, `preSliceSource`) |
| **A14** | `thisRunIsArmB = recordSet === 'control'`: the `k3-control/` home is not inspected on that set; `armBBound` is false; `armBBindingDetail` renders exactly `n/a — this run IS the control-only build (arm B); the seed run measures it` (byte-identical to the greenlight dispatch's text — leg-verified); `repinned: null` / `repinnedFrom: null` unchanged; the disclosing row's title no longer claims a measurement on that set (`from arm B (this run IS arm B — not inspected)`) and carries no "run the § S5 seam" instruction. One rendering branch, no gate change (the `seed20`-only FAIL gate is untouched). | `manifest.mts` (the arm-B read + detail, the K3 CAPTURE row) |

No chain-emission byte changes (K6 10/11 identical, the one disclosed `packageSuffix` delta pre-ruled benign). The spike is not a published package — no changeset. No workflow change. The committed artifacts under `artifacts/k4-swap/` and `artifacts/k3-control/` at this branch's HEAD still carry the pre-slice strings — the cures are in the writers and land in the tree at the next controls-at-the-pin run, as every apparatus pin's do (leg J8).

## Out of Scope

- **A13.2** — NOT ADOPTED by E25 (the top-level `fixtures[]` is the single home; scorer v4 deletes the per-record read). The apparatus emits nothing new.
- The `0e01112d` re-authoring cure — its own loop on its own pins, sequenced BEFORE this merge (above); its charter arrives by mail on its merge.
- Any run of record, controls-at-the-pin, or artifact rewrite — E25 closed the loop on `f6efe85d`; this pin is the apparatus for the next trial and the drift sensor going forward.

## Tests Added/Updated

- [x] The verification IS the apparatus's own seam, run at the branch HEAD `642f288e` (a clean tree; the clean-tree gate holds on `seed20`/`control`):
  - **Seed-20 seam in the charter's order:** control-only build FIRST (manifest · lower · build-wasm · certify; `certify-verify` 56/56) → `SPIKE_RECORD_SET=seed20 all` → `differential`: every stage rc=0; `certify-verify` **256/256** incl. the `INV 2 (A13.1)` set row PASS, the `artifactsSubdir … AGREE` row PASS, and **21 chains byte-equal** under `drift-detection` (the committed run of record's chains regenerate identically at the new pin); `compare` 30/30. At the slice commit `9d0d1200` the same seam was also run through `controls`: **K1–K8 8 PASS · 0 FAIL · 2 NOT MEASURED** (K5/K5b's opa-wazero half — the wazero probe is not run locally; both are measured on the Linux leg), K7 21/21 identical.
  - **The K4 sub-arm at `642f288e`** (leg F1's closure): `SPIKE_SWAP_EXAMPLES=87aff037-fail-open-catch-ban SPIKE_ARTIFACTS_SUBDIR=k4-swap SPIKE_RECORD_SET=seed20 all && differential` rc=0; `certify-verify` 130/130; its `certification-invariants.json` (a committed-class artifact at a run of record) carries the header row, all 21 per-chain `modeReason`s and `preSliceSourceSkipped` naming the one reason `seed20-under-named-subdir`, `preSliceSource: null`, and no machine path.
  - **Specimens leg at `642f288e`** (measured, not derived — leg J7): `all` + `differential` rc=0, `certify-verify` 116/116 (the +1 is the agreement row, `null === null`), the re-homed baseline row PASS, `compare` 28/28.
  - **A14 on the run's own artifacts** (observed on the control build's outputs before the tree was restored; the run-log line `K3 arm B repinned=null (NOT MEASURED) — n/a — this run IS the control-only build (arm B); the seed run measures it` is the durable stdout witness): `k3-control/manifest-checks.json`'s K3 CAPTURE row — title `… \`repinned\` from arm B (this run IS arm B — not inspected): NOT MEASURED (null)`, detail byte-exact `n/a — this run IS the control-only build (arm B); the seed run measures it`; `k3-control/manifest.json` — `recordSet control · runCommit <HEAD> · repinned null · repinnedFrom null`.
  - **The negative arms — A13.1 REFUSES, never skips** (at `9d0d1200` and after every fold, last at `642f288e` with the exit captured: `neg5 rc=1`): one published chain's `publishedBy` mutated → `certify-verify` rc=1, two FAIL rows (`DRIFT at byte 5459`; `changed=["publishedBy"]`); one seed-20 chain deleted → rc=1, the `INV 2 (A13.1)` set row FAILS (`expected [21 committed], got [20 published]`). Tree restored from git after each (0 dirty entries).
- [x] Falsification legs (below).

### Falsification legs (three, each dispatched before this PR opened; every finding folded; convergence declared by leg 3)

- **Leg 1 on the slice `9d0d1200` — F1 MATERIAL · F2–F7 MINOR** (folded in `6191a3df` + `577c31bf`): **F1** A13.1 also fired on a `seed20` run under a named `SPIKE_ARTIFACTS_SUBDIR` (the § S8 K4 swap arm runs `certify-verify` too), an arm the ruling's "the arm the E23 replay itself takes" did not scope; benign at this pin (21/21 byte-identical across `chains` ≡ `k4-swap/chains` ≡ `k7-rebuild/chains`) but unexercised and undisclosed → the subdir conjunct; the K4 arm re-executed. **F2** the K3 CAPTURE title claimed "MEASURED from arm B" on the control set. **F3** the "three outcomes" doc for `repinned: null` gains A14's fourth. **F4** the "re-cut" cure sentence read as circular → the escape path named. **F5** the absent-manifest skip wording. **F6/F7** narration. Verified clean: the A14 text byte-identical to the dispatch's; every arm-B predicate consumer enumerated (`seed20`/`specimens` reduce to the pre-slice expression); `checks.eq` argument order; no order desync; the renamed skip reason has zero consumers incl. `score.mjs`; no close keyword (D1); 255 = 129 + 6 × 21.
- **Leg 2 on `9d0d1200..577c31bf` — G1–G2 MATERIAL · G3–G7 MINOR** (folded in `8c2cfc17`): **G1** the skip's justification "its chains are that control's to compare" was false — no control compares a K4 arm's chains → scope, not delegation. **G2** the untouched per-chain `modeReason` on a sub-arm said the top-level referent "does not apply on `seed20`" — the negation of A13.1 inside a committed-class artifact → a sub-arm branch. **G3** F5 on the new row. **G4** "deliberately no dev seam" beside the subdir branch → scoped. **G5** "a NEW run of record" → "an artifacts-only commit, not yet a run of record". **G6** the env-derived conjunct against T13's manifest discipline → the agreement row. **G7** `preSliceSource` named a referent never read → `null` + `preSliceSourceSkipped`. Verified clean: the six `seed20` states each landing on one true row; `control`/`specimens` unchanged except the intended title; no absolute path; the escape-path sentence true of the code (`certify.mts` publishes before `certify-verify.mts` runs).
- **Leg 3 on `577c31bf..8c2cfc17`, with the convergence question — no BLOCKING/MATERIAL; J1–J7 MINOR** (folded in `642f288e`; J7 run): **J1** the agreement row labelled a derived value with the env-var name (unset on the control arm, where the `k3-control` default applies) → labels `ARTIFACTS_SUBDIR` and names the default. **J2** "the same discipline applies" overstated the twin → stated as the weaker twin (the manifest is read from the directory the constant names). **J3** "no control compares these chains" was a universal false for `k7-rebuild`/`k3-control` subdirs → claimed only for `k4-swap`. **J4** the sub-arm `modeReason`'s referent clause was false at a HEAD that is not a run of record → gated on `committedIsRunOfRecord`. **J5** the skip name was written twice → `inv2SkipReason`, derived once. **J6** the escape-path parenthetical → says which reports are stale. **J7** the specimens leg re-measured at HEAD. **J8** (observation) the committed K4/K3 artifacts at this HEAD still carry the pre-slice strings — stated above. Verified clean: the G6 row cannot FAIL on either Linux leg (`artifactsSubdir` is written on every set, `null` when unset; CI sets `SPIKE_ARTIFACTS_SUBDIR` nowhere); every emitted skip name agrees with `preSliceSourceSkipped` state by state; the +1 row on each arm is the agreement row and nothing else moved (`git diff` adds exactly one `checks.check`; `committedChainsApply` untouched); no `preSliceSource` consumer anywhere in `mmnto-ai/totem-strategy@main`; K6 unaffected. **Leg 3's H5 answer, verbatim:** "No BLOCKING/MATERIAL remains against A13.1's letter … or against the A14 deposit … residuals are MINOR" — no fourth leg.

### Gates

At `642f288e`: repo-wide `pnpm format:check` clean · `pnpm -r build` green · `pnpm lint` (turbo ESLint, 3/3) green · full-branch `totem lint` PASS (385 rules, 0 violations on the 2 changed files) · every seam green (above) · no close keyword in any branch commit. The Linux legs (`seed20` + `specimens`) at this PR's head are the real gate: the seed20 leg runs the A13.1 sensor over the committed run of record and K7 against its own rebuild (`SPIKE_ARTIFACTS_SUBDIR` is set nowhere in the workflow, so CI exercises the top-level arm; the agreement row reads `null === null` there).

### Then the loop

Bots: operator-invoked; disposition here. **Merge: HELD** until (a) the `0e01112d` cure run pin is mailed by the scorer (the 04:08Z re-sequencing — the cure's apparatus pin must be cut from a `main` that does not yet carry A13.1) and (b) the operator's merge word. The merged commit is then the **new apparatus pin**, mailed to strategy-claude with its sha; it requires nothing of the run of record.

## Related Tickets

Related (none closed): mmnto-ai/totem#2704 (the running findings issue; A13.1 + A14 cured at this pin, A13.2 not adopted) · mmnto-ai/totem-strategy#1138 · mmnto-ai/totem-strategy#1174 · mmnto-ai/totem#2710 (the previous pin) · mmnto-ai/totem#2712 (the run pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSpME1vv1iZXz6Vg9gUc6j
