### PR TITLE
spike(spine-adopt): the E26 cure apparatus pin — SEED_RECORD_PIN → the cure record pin 78e7f196 (0e01112d re-authored, one hunk) · the six sites (E26 (ii)'s five + manifest.scorerSha256 → scorer v4, ruled (A)) · K1's third row = the cure's positive control — the pin the 0e01112d cure run executes at

### DIFF
--- a/spikes/spine-adopt/seed/PIN.md
+++ b/spikes/spine-adopt/seed/PIN.md
@@ -3,10 +3,16 @@
 Charter: mmnto-ai/totem-strategy#1154 (`operations/310-seed20-target-preregistration.md`).
 Spec: `.totem/specs/seed20-apparatus.md` § "Hard constraints" 5.
 
-**Pin:** `2a7135762b6aedc9cd3099ab3f42e029ee34092e` (branch `r14/seed-20-translation`).
+**Pin:** `78e7f196b93caf0df68a3baba561cce66279563c` — the **cure record pin** (charter v1.5
+§ 7 E26; branch `r14/seed-20-translation`, annotated tag `seed20-cure/0e01112d`, both durable).
+It is the child of the run of record's pin `2a7135762b6aedc9cd3099ab3f42e029ee34092e` (the pin
+of `f6efe85d`'s verdict, (B) 14/15, which stands) and differs from it in exactly one file:
+`r14-0e01112d-bare-new-error.rule.yaml`, whose `target.pattern` `\bnew\s+(?!Totem)Error\(`
+became `\bnew\s+Error\(` — the inert lookahead removed, every other byte identical (one hunk on
+the pattern line; semantic preservation: strategy-codex's E26 (iii) deposit, 0 findings).
 
 The 22 files below are **byte-identical copies** of `.totem/rules/r14-*.rule.yaml` at that
-commit, obtained with `git show 2a7135762b6aedc9cd3099ab3f42e029ee34092e:<path>` and verified
+commit, obtained with `git show 78e7f196b93caf0df68a3baba561cce66279563c:<path>` and verified
 by comparing `git hash-object` of each copy against `git rev-parse <pin>:<path>` (all 22 blob
 oids equal). `.totem/rules/r14-translation-notes.md` is at the pin too and is deliberately NOT
 copied — it is prose, not a record, and the apparatus loads records only.
@@ -33,7 +39,7 @@ has no `r14/seed-20-translation` history).
 | file                                                     | sha256                                                             | blob oid                                   | bytes |
 | -------------------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------ | ----- |
 | `r14-0167a783-dynamic-import-utility-layer.rule.yaml`    | `07516f5d50e45afd7d9de0151cfb8b81c562121e5f517e8d2e69cfe3b88a2301` | `24ff5cd9dc23f9288334f1efeaa447b30c8b8223` | 629   |
-| `r14-0e01112d-bare-new-error.rule.yaml`                  | `a289e29fffdea60d6d330f1a62cd7a8363ab61418fa2724a7275e84d1d6ba8e5` | `560f3aa3009c73f66c01e6f49db4d81e277f3138` | 493   |
+| `r14-0e01112d-bare-new-error.rule.yaml`                  | `26e997b34a3ba5a0d7dd61014d2996942b545748763f418a5bd9d8f8409362dc` | `927cf76c96a56390f7475b13b41c8da6223cbb3a` | 484   |
 | `r14-1a7080eb-inline-secrets-agent-config.rule.yaml`     | `02f84fb59f1181a07ee2d54d450efbfc36e787a6213a7baf9b78fd785e05e33d` | `6186a141e8dda259fc9ddb1099b19368a0c5953c` | 685   |
 | `r14-49dd9e4f-llm-character-counting.rule.yaml`          | `16464d624f16481377718b409413bd96c0c3bf4e692c6f1161ec1d905c6e5912` | `c1a402d3d1727686573423a70da995f47a664cf6` | 556   |
 | `r14-54140f59-bare-issue-number-refs.rule.yaml`          | `b382417d9f84c7f2da7c30ac1e8ee6c05849f319b01e2794fa78f0a75a04618c` | `04d70b358d35587880124f3ba04143dbba487818` | 508   |
@@ -62,8 +68,12 @@ readable. They score nothing.
 
 - `1a7080eb` declares `language: json`, which the shipped `compileRuleRecord` does not register
   → a `shipped-compile` reject row. No bundle, no chain.
-- `0e01112d` carries a negative lookahead (`(?!Totem)`) → a `target-lowering` reject row, class
-  `lookaround` (§ Lowering 4 forbids an approximation). No bundle, no chain.
+- `0e01112d` at this (cure) pin carries `\bnew\s+Error\(` — the negative lookahead `(?!Totem)` it
+  carried at `2a713576` is gone (E26) → it classifies `word-boundary`, produces NO reject row, and
+  lowers: a bundle and a chain (K7 21 → 22, T5 scored packages 20 → 21, both declared). At the run
+  of record's pin it was a `target-lowering` reject row, class `lookaround` — no bundle, no chain —
+  and that row stays the run of record's K1 third row, PASS at `f6efe85d`; here K1's third row is
+  the cure's positive control (`src/controls.mts`).
 - `5da43ea6` carries a literal backtick inside a character class. It lowers: the § Lowering 3
   self-assert tests raw-string SYNTAX, not the byte (`.totem/specs/seed20-apparatus.md` § G6).
 - `87aff037` is the only seed record with a corpus fixture

--- a/spikes/spine-adopt/seed/probe-pairs.json
+++ b/spikes/spine-adopt/seed/probe-pairs.json
@@ -1,7 +1,7 @@
 {
   "generatedBy": "spikes/spine-adopt/src/lib/record-sets.mts generatedSeedProbes()",
   "contract": "spec `.totem/specs/seed20-apparatus-slice2.md` § S1 — the PINNED EXPECTATION for the G2 probe generator. This repo has no TS test runner; a committed artifact the generator is re-derived against IS the test. `src/verify-records.mts` asserts generatedSeedProbes() deep-equals `pairs` below, so a change to either rule shows up as a failed check instead of as a silently different probe set.",
-  "recordPin": "2a7135762b6aedc9cd3099ab3f42e029ee34092e",
+  "recordPin": "78e7f196b93caf0df68a3baba561cce66279563c",
   "rule": "matching probe = every `**/` -> `k3b/` then every `*` -> `probe`; twin = that probe with the glob's LAST LITERAL character (right-to-left; `*` and `/` are not literals) replaced by `_`, or by `-` when it is already `_`.",
   "globCount": 33,
   "pairs": [

--- a/spikes/spine-adopt/seed/records/r14-0e01112d-bare-new-error.rule.yaml
+++ b/spikes/spine-adopt/seed/records/r14-0e01112d-bare-new-error.rule.yaml
@@ -5,7 +5,7 @@ message: 'When wrapping external errors or providing fallbacks,'
 
 target:
   type: regex
-  pattern: '\bnew\s+(?!Totem)Error\('
+  pattern: '\bnew\s+Error\('
   scope:
     fileGlobs:
       - '**/*.ts'

--- a/spikes/spine-adopt/src/controls.mts
+++ b/spikes/spine-adopt/src/controls.mts
@@ -206,7 +206,13 @@ function compareChains(current: unknown, target: unknown) {
 // ─── The rows ────────────────────────────────────────────────────────────────
 
 function k1(recordSet: RecordSetId, lowering: Artifact): ControlRow {
-  const evidence = [{ artifact: 'lowering-rejects.json', path: 'rejects[]' }];
+  const evidence = [
+    { artifact: 'lowering-rejects.json', path: 'rejects[]' },
+    // (E26) The cure's positive control reads the LOWERED side too — on the seed
+    // set only; the specimens arm never opens `lowered[]` and must not claim to
+    // (leg F3: evidence is a provenance row, and it names only what was read).
+    ...(recordSet === 'seed20' ? [{ artifact: 'lowering-rejects.json', path: 'lowered[]' }] : []),
+  ];
   if (lowering === null) {
     return {
       id: 'K1',
@@ -232,21 +238,39 @@ function k1(recordSet: RecordSetId, lowering: Artifact): ControlRow {
     census('bddfbd2ec1c75eaf', 'lookaround'),
     census('80192e6ac2a1dd3c', 'backreference'),
   ];
-  // The seed's own inert-lookahead seam: the third row the charter adds, because
-  // the two census rows alone could still pass a lowerer that "provably-inert"-ed
-  // a lookahead away. Seed-set only — the specimens set has no such record.
+  // The seed's own third row (§ 5 K1). At the run of record's pin `2a713576` this
+  // was the inert-lookahead seam — `0e01112d` had to REJECT as `lookaround`, because
+  // the two census rows alone could still pass a lowerer that "provably-inert"-ed a
+  // lookahead away; that proof stands, PASS at `f6efe85d`. At THIS apparatus pin
+  // (charter v1.5 § 7 E26 — the cure record pin `78e7f196`, `SEED_RECORD_PIN`) the
+  // record's pattern carries no lookahead, and the row is declared as the cure's
+  // POSITIVE control: `0e01112d` produces NO reject row, its target literal
+  // classifies `word-boundary`, and it LOWERS — decidable from
+  // `lowering-rejects.json`'s `rejects[]` and `lowered[]` alone (the `lowered[]` row
+  // carries the class per pattern). Seed-set only — the specimens set has no such
+  // record.
   if (recordSet === 'seed20') {
-    const own = rejects.find(
+    const ownReject = rejects.find(
       (r) => typeof r.recordId === 'string' && r.recordId.startsWith('0e01112d'),
     );
+    const lowered = (lowering.lowered ?? []) as Artifact[];
+    const ownLowered = lowered.find((l) => l.seedEntry === '0e01112d');
+    const target = ((ownLowered?.patterns ?? []) as Artifact[]).find((p) => p.role === 'target');
     rows.push({
       id: '0e01112d',
-      source: 'record reject row',
-      present: own !== undefined,
-      stage: own?.stage ?? null,
-      class: own?.class ?? null,
-      expectedClass: 'lookaround',
-      ok: own !== undefined && own.stage === 'target-lowering' && own.class === 'lookaround',
+      source: 'record lowered row (E26 cure — positive control)',
+      present: ownLowered !== undefined,
+      rejectRow: ownReject !== undefined,
+      rejectStage: ownReject?.stage ?? null,
+      rejectClass: ownReject?.class ?? null,
+      class: target?.class ?? null,
+      lowered: target?.lowered ?? null,
+      expectedClass: 'word-boundary',
+      ok:
+        ownReject === undefined &&
+        ownLowered !== undefined &&
+        target?.class === 'word-boundary' &&
+        target?.lowered === true,
     });
   }
   const missing = rows.filter((r) => !r.ok);
@@ -256,8 +280,21 @@ function k1(recordSet: RecordSetId, lowering: Artifact): ControlRow {
     ok: missing.length === 0,
     detail:
       missing.length === 0
-        ? `${rows.length} classifier reject row(s) present with the class named${recordSet === 'seed20' ? '' : ' (the seed`s own `0e01112d` row is seed-only and is not part of this set)'}`
-        : `MISSING or MISCLASSED: ${missing.map((r) => `${r.id} (class=${String(r.class)}, expected ${r.expectedClass})`).join('; ')}`,
+        ? recordSet === 'seed20'
+          ? `${rows.filter((r) => r.source === 'census-evidence').length} classifier reject row(s) present with the class named; the seed's own \`0e01112d\` LOWERS as \`word-boundary\` with no reject row (the E26 cure's positive control)`
+          : `${rows.length} classifier reject row(s) present with the class named (the seed\`s own \`0e01112d\` row is seed-only and is not part of this set)`
+        : `MISSING or MISCLASSED: ${missing
+            .map(
+              (r) =>
+                `${r.id} (class=${String(r.class)}, expected ${r.expectedClass}${
+                  r.rejectRow === true
+                    ? `; a reject row is present at ${String(r.rejectStage)}/${String(r.rejectClass)} where none is expected`
+                    : r.rejectRow === false && r.present === false
+                      ? '; the record is ABSENT from both `rejects[]` and `lowered[]` — neither lowered nor refused'
+                      : ''
+                })`,
+            )
+            .join('; ')}`,
     rows,
     evidence,
   };

--- a/spikes/spine-adopt/src/lib/record-sets.mts
+++ b/spikes/spine-adopt/src/lib/record-sets.mts
@@ -8,8 +8,11 @@
 //                          so every committed artifact, check and Go test holds
 //                          unchanged.
 //   `seed20`               the frozen R14 seed: the 22 `.totem/rules/r14-*.rule.yaml`
-//                          at pin `2a7135762b6aedc9cd3099ab3f42e029ee34092e`, copied
-//                          byte-identically under `seed/records/` (see `seed/PIN.md`).
+//                          at the CURE record pin `78e7f196b93caf0df68a3baba561cce66279563c`
+//                          (charter v1.5 § 7 E26: `0e01112d` re-authored, one hunk on
+//                          its pattern line; a child of the run of record's pin
+//                          `2a713576`), copied byte-identically under `seed/records/`
+//                          (see `seed/PIN.md`).
 //
 // Selected by `SPIKE_RECORD_SET`. NOTHING here decides a verdict: the loader emits
 // rows, and the § Lowering 4 / shipped-compile gates emit reject ROWS
@@ -59,8 +62,17 @@ export const K3_CAPTURE_CHAIN = path.join(SEED_CONTROLS_DIR, 'k3', 'k3-target.ch
 /** The package the K3 captures belong to — the seed's `87aff037` record. */
 export const K3_CAPTURE_PACKAGE = 'r87aff037d7de47a7';
 
-/** The frozen commit the `seed/records/` copies were taken from (`seed/PIN.md`). */
-export const SEED_RECORD_PIN = '2a7135762b6aedc9cd3099ab3f42e029ee34092e';
+/**
+ * The frozen commit the `seed/records/` copies were taken from (`seed/PIN.md`).
+ *
+ * The CURE record pin (charter v1.5 § 7 E26): a child of the run of record's pin
+ * `2a7135762b6aedc9cd3099ab3f42e029ee34092e` on the `r14/seed-20-translation`
+ * lineage, also reachable by the annotated tag `seed20-cure/0e01112d`, carrying
+ * exactly one change — `0e01112d`'s `target.pattern` with its inert lookahead
+ * removed (`\bnew\s+(?!Totem)Error\(` → `\bnew\s+Error\(`). Every other record
+ * byte-identical to the run of record's.
+ */
+export const SEED_RECORD_PIN = '78e7f196b93caf0df68a3baba561cce66279563c';
 
 /**
  * A loaded record row. `Specimen` unchanged, plus the three fields the seed set

--- a/spikes/spine-adopt/src/manifest.mts
+++ b/spikes/spine-adopt/src/manifest.mts
@@ -524,7 +524,18 @@ function main(): void {
     // binding fact is its sha256 in the run manifest" was never realized until
     // here. A scorer re-freeze is a new value HERE and therefore a new apparatus
     // pin — the coupling is the point.
-    scorerSha256: '43c8667c5a5ea4947b01b88b2269c816131717b54e768580361a843b664c96c9',
+    //
+    // (E26 — the cure apparatus pin) Scorer v4, the scorer of record for the
+    // `0e01112d` cure run: the bytes at strategy main `264535d`
+    // (mmnto-ai/totem-strategy#1178, merged UNFROZEN — the freeze is the scorer's
+    // mail of 2026-09-01T05:03Z, E24's rule, this value verbatim), the SIXTH site
+    // of the cure apparatus pin (ruled (A) 2026-09-01T05:36Z — E26 (iv) binds the
+    // cure run's manifest to v4's sha; (ii)'s five-site list omitted this one — the
+    // E26 erratum naming it is owed strategy-side before the cure run's score). v2
+    // `43c8667c…` stays the run of record's witness at `f6efe85d` (its committed
+    // manifests, which no byte here touches); v3 `70979e54…` stays that run's
+    // scorer of record, strategy-side.
+    scorerSha256: '0b95fc03ac34ec82611d5f191d8551e3891e80a31a434a4170d231cb1782e579',
     // T17 — a FACT about the run, not a gate: `trackedPaths` below is the tree at
     // `runCommit`, and this says whether the tree the run actually read matched it.
     //


### PR DESCRIPTION
## The E26 cure apparatus pin — `SEED_RECORD_PIN` → the cure record pin `78e7f196` (`0e01112d` re-authored: the inert lookahead removed, one hunk), E26 (ii)'s five sites plus the ruled sixth (`manifest.scorerSha256` → scorer v4) and nothing else; K1's third row becomes the cure's POSITIVE control — the pin the `0e01112d` cure run executes at

Charter of record: v1.5 § 7 E26 (mmnto-ai/totem-strategy, merged `92fccafb`; main `264535d`), sequenced by the scorer's 04:08Z / 05:03Z / 05:17Z dispatches and started on the operator's direct word in-session ("start the cure loop"). The `0e01112d` routing row of the verdict of record (mmnto-ai/totem-strategy#1138 comment 5488028522: **re-authoring**) executed at the record layer, disclosed; semantic preservation: strategy-codex's E26 (iii) deposit (comment 5489216656, 05:11Z — ten minutes before the record pin was authored; 0 findings; the structural proof both directions, six probes, a 7,949-input sweep with 0 mismatches V8 ↔ V8 ↔ OPA 1.20.0). **What does not move:** the verdict of record (B) 14/15 and `f6efe85d`'s artifacts; scorer v3 as their scorer of record; nothing installs or publishes.

**Sequencing:** this pin is a descendant of `main` at `f6efe85d`, which does **not** carry A13.1 — mmnto-ai/totem#2717 (the A13.1 + A14 slice) stays held open until the cure run pin is mailed (E26: "the cure loop precedes the A13.1 slice's merge"). After this merges: controls at the pin (one PR) → the full `seed20` cure run → the cure run pin (one PR) → the scorer under v4 cure mode → the blind replay → the figure beside 14/15 (E27) → only then mmnto-ai/totem#2717.

**One commit, `42b8e82dff58cbe778fe1ad57398788cd4372733`** (six files; squashed locally through the five-site candidate `f9237f1d`, the sixth-site amend `7a5fdb89`, and three legs' folds — nothing was pushed before this shape).

**The sixth site — ruled (A) by the charter's author, 2026-09-01T05:36Z, reported to the operator in-session.** E26 (ii) lists five sites and says "its diff is exactly those files"; E26 (iv) says "the cure run's manifest carries [v4's sha] as `scorerSha256`" — and that sha is a constant in `manifest.mts` (the E24 slice's rule: the freeze-time sha verbatim; a re-freeze is a new apparatus pin by construction), and scorer v4 refuses any `spikes/spine-adopt` source delta between the apparatus pin and the run pin (`score.mjs:1694-1704`), so the site can live only in this commit. At the five-site candidate the seam's manifest carried v2's `43c8667c…`, and v4's `scorerLineage` (`score.mjs:114-126`) would have rendered the E24 two-witness note "a post-run revision re-scoring the SAME artifacts" — false for the cure, a new run under its scorer of record. I mailed the contradiction with both resolutions costed (05:34Z); strategy ruled **(A)** — the only direction that writes no false row; (B) refused. **Owed edges that are strategy's, not this commit's:** (1) E26 (ii)'s list is amended in place with a dated marker by strategy's erratum PR — open as mmnto-ai/totem-strategy#1180 (v1.6; head `83bc79f`), merging on the operator's word before the cure run's score; neither this pin nor the cure run waits on it — until it lands, the charter text a reader dereferences at main still forbids a sixth site; the erratum should name `controls.mts`'s site as `k1()` and `record-sets.mts`'s as the constant plus its header comment; (2) "the scorer verifies [the diff] from the evidence clone" has no mechanical form in v4 (no site-list constant; only the apparatus-pin→run-pin source-delta gate) — strategy's 05:53Z correction says the same: the bus verifies the six files against this PR's diff before the merge word, recorded on the verdict issue; (3) nothing in this repo binds `manifest.scorerSha256` to the freeze mail — a well-formed wrong sha would pass every gate here; the guard belongs scorer-side.

## Mechanical Root Cause

The one live miss of the trial: `0e01112d`'s `target.pattern` `\bnew\s+(?!Totem)Error\(` classifies `lookaround`, which § Lowering 4 refuses (no approximation), so the record never lowered. The lookahead is inert — after `\s+` the next character must be `E` for `Error\(` to match, so `(?!Totem)` can never fail at that position (`L(\bnew\s+(?!Totem)Error\() = L(\bnew\s+Error\()`); dropping it is semantics-preserving. The cure is at the RECORD layer, on the operator's word: the apparatus stays byte-identical in its lowerer (K6's bound regions untouched), and the frozen record is REPLACED by the re-authored one — no twin, since the rule has one record and the frozen one cannot pass.

## Fix Applied

**The cure record pin (step 1, already on `origin`):** `78e7f196b93caf0df68a3baba561cce66279563c`, sole parent `2a7135762b6aedc9cd3099ab3f42e029ee34092e` (the run of record's pin), on the durable `r14/seed-20-translation` branch AND the annotated tag `seed20-cure/0e01112d` (tag object `990c2316…`). Exactly one file: `.totem/rules/r14-0e01112d-bare-new-error.rule.yaml` blob `560f3aa3…` (493 B, sha256 `a289e29f…`) → blob `927cf76c96a56390f7475b13b41c8da6223cbb3a` (484 B, sha256 `26e997b34a3ba5a0d7dd61014d2996942b545748763f418a5bd9d8f8409362dc`) — the 9 bytes `(?!Totem)` removed at offset 144, applied to the blob's bytes; one hunk, one line; 2,742 tracked paths, one modified, none added or removed; the 21 other seed blobs identical to `2a713576`'s (leg-verified). (The translation lineage's compile manifest carries no `records_hash` — identical to `2a713576`'s state; the manifest-only `--refresh-manifest` re-seal sits on the sibling branch `r14/cure-manifest-refresh-78e7f196` @ `01dd42a4`, exactly as `200404bf` did after `2a713576`; the freeze's do-not list read first; nothing recompiles.)

**This PR — the cure apparatus pin, six sites:**

| site | change |
|---|---|
| `src/lib/record-sets.mts` | `SEED_RECORD_PIN` → `78e7f196b93caf0df68a3baba561cce66279563c`, and the file's header comment (which asserted `2a713576` as a fact about the loaded set — a sub-file second site, named for the erratum) |
| `seed/records/r14-0e01112d-bare-new-error.rule.yaml` | = the pin's blob bytes, `927cf76c…` (484 B) |
| `seed/PIN.md` | the head pin (the cure pin, its parent, the tag, the one-file delta); the "obtained with `git show <pin>`" prose; the file's row (sha256 · blob oid · bytes → `26e997b3…` · `927cf76c…` · 484; all 22 rows re-verified by the leg); the "Known apparatus outcomes" paragraph — "No bundle, no chain" is false at the cure: it classifies `word-boundary`, produces no reject row, and lowers (K7 21 → 22, T5 20 → 21, declared) |
| `seed/probe-pairs.json` | `recordPin` → the cure pin; `pairs` unchanged (the cure moves no glob; `verify-records` still deep-equals the generator — leg-executed) |
| `src/controls.mts` (`k1()`) | K1's third row for `seed20` declared as the cure's POSITIVE control: NO reject row for `0e01112d`, a `lowered[]` row present (keyed `seedEntry`, the only key a lowered row carries), its `target` pattern class `word-boundary` and `lowered: true` — decidable from `lowering-rejects.json`'s `rejects[]` and `lowered[]` alone. Stronger on the lowered side than v4's own cure arm (v4 checks only that a `lowered[]` row exists; this row also asserts `lowered: true`); v4's classifier arm is independent — it re-derives the class from the record bytes, so the two arms are not nested. The MISSING branch names a stray reject row by stage/class and the absent-from-both state; `evidence[]` gains `lowered[]` on the seed set only; the census count derived by source. The lookaround seam's proof stays the run of record's K1 third row, PASS at `f6efe85d`; the run of record's state (a `target-lowering`/`lookaround` reject row, no lowered row) now FAILS this row, as it must. `specimens` behaviour byte-identical (witnessed). |
| `src/manifest.mts` (the sixth site, ruled (A)) | `scorerSha256` → `0b95fc03ac34ec82611d5f191d8551e3891e80a31a434a4170d231cb1782e579` — scorer v4, the cure run's scorer of record: the bytes at strategy main `264535d` (mmnto-ai/totem-strategy#1178, merged UNFROZEN — the freeze is the scorer's 05:03Z mail, E24's rule; byte-exact three ways, leg-verified). v2 `43c8667c…` stays the run of record's witness at `f6efe85d`; v3 `70979e54…` its scorer of record, strategy-side. |

K6's bound regions (`rule-record.ts`, `record-lower.ts`, `LOWERING.md`, `toolchain.lock [opa]`, the `lower.mts` symbols) untouched — the seam measures 10/11 with only the pre-ruled `packageSuffix` delta, identical to the run of record. No workflow change. Not a published package — no changeset.

**Declared beside E26 (vii)'s two counts (K7 21 → 22, T5 20 → 21):** the apparatus's **K3b row count moves 56 → 60** at this pin — `0e01112d`'s four globs are now reachable as `(package, glob)` rows; the distinct-glob set the charter fixes at 29 is unchanged (`0e01112d`'s four are already among `49dd9e4f`'s). Pre-declared to strategy in the pin mail so the cure run's controls don't surface it as an undeclared (vii) delta.

## Out of Scope

- The controls-at-the-pin and the cure run of record (the next two PRs, E6's three-commit shape; the seed run's own artifacts are NOT committed here — restored after every seam).
- Scorer v4 (strategy's) and the E26 erratum (strategy's, owed before the score).
- A13.1 + A14 (mmnto-ai/totem#2717) — held behind the cure run pin by E26.

## Tests Added/Updated

- [x] The verification IS the apparatus's own seam at `42b8e82d`, CI's exact order including the wazero arm: control-only build FIRST (manifest 30/30 · lower 21/21 · build-wasm 18/18 · certify 81/81 · certify-verify 55/55) → `SPIKE_RECORD_SET=seed20 all` (manifest 32/32 · census 22/22 · **verify-records 115/115 — the SEED PIN row is the BYTE COMPARISON at `78e7f196…`, 22 pairs, never the skip** · facts 161/161 · shipped-verdicts 102/102) → `differential` (lower 193/193 · t5-sweep 86/86 · build-wasm 144/144 · certify 145/145 · certify-verify 133/133 · compare 30/30) → wazero `go test ./... && go run .` rc=0 → **controls 10 PASS · 0 FAIL · 0 NOT MEASURED**. Every stage rc=0; zero FAIL rows. The same seam ran at each earlier shape (`f9237f1d`, `7a5fdb89`, the folds, `0e8e8192`) with identical counts (leg-diffed: the logs differ only in `runCommit` strings, two manifest digests and timings).
- [x] **Durable witnesses** — the emitted artifacts copied OUT of the tree before the restore (the run-log does not print `scorerSha256`): the seed `manifest.json` (sha256 `b82e1831…`) records `scorerSha256 0b95fc03ac34ec82611d5f191d8551e3891e80a31a434a4170d231cb1782e579` · `runCommit 42b8e82dff58cbe778fe1ad57398788cd4372733` · `recordPin 78e7f196b93caf0df68a3baba561cce66279563c` · 22 records (its `runManifestSha256` recomputes, leg-verified at the previous shape); the `k3-control` manifest the same v4 sha at the same `runCommit`; `controls.json` K1 `ok: true` with evidence `rejects[]` + `lowered[]`, 10 PASS; `lowering-rejects.json` **3 rejects / 22 lowered**, `0e01112d` `{target, word-boundary, lowered: true}`, **no reject row**; `records-verification.json` the SEED PIN comparison row; `t5-sweep.json` 21 scored packages; and the specimens arm's `controls.json` (K1 `ok: true`, evidence `rejects[]` only, 2 rows, the pre-slice detail verbatim). Held in the session's scratchpad for the legs; not committed (apparatus-only PR).
- [x] **The declared outcomes, measured:** K1 PASS — "2 classifier reject row(s) present with the class named; the seed's own `0e01112d` LOWERS as `word-boundary` with no reject row (the E26 cure's positive control)"; **22 chains**; **T5 21 scored packages**; `trackedPathsAtRecordPin` 2,742; K3b 60 rows (above); K6 10/11; K7 read the committed `k7-rebuild/` (21, non-refusing — the cure run pin's own Linux run supplies 22).
- [x] Falsification legs (below).

### Falsification legs (three; every finding folded or carried as a named edge; convergence declared by leg 3)

- **Leg 1 on the five-site candidate `f9237f1d`:** **F1 BLOCKING** — the `scorerSha256` contradiction (E26 (ii) vs (iv)); the leg established from `score.mjs:1694-1704` that the site could live only in the apparatus pin → resolved by the (A) ruling and the sixth site. **F2** `record-sets.mts` moves a header comment as well as the constant → named for the erratum. **F3** K1's `evidence[]` claimed `lowered[]` on `specimens` where it is never read → seed-only. **F4** the seed PASS detail hard-coded `2` → derived. **F5** the absent-from-both state's detail was thin → named. **F6/F7** notes (K3b's row-vs-distinct count; which leg's `records-verification.json` (vii) reads — the local seam's, where the pin resolves; CI's shallow checkout skips by name). NOT FALSIFIED: the five sites exactly; every `PIN.md` row (22/22) re-derived; the cure pin's parent, refs, blob, byte counts; the 21 other blobs identical; `probe-pairs.json` deep-equal to the generator (executed); K1's five states with `ok` correct in each and the run-of-record state now FAILING; `seedEntry` the right key (a lowered row has no `recordId`); `specimens` byte-identical; the (iii) deposit pre-dates the record pin by ten minutes; the base carries no A13.1; no close keyword; no machine path.
- **Leg 2 on the sixth-site delta `f9237f1d..7a5fdb89`:** S1 clean — the sha byte-exact vs the freeze mail and the raw blob at strategy main (64/64). **T1 MATERIAL** the body's evidence line cited the run-log for a field it never prints → the durable witnesses above. **T2 MATERIAL** E26 (ii) at main still forbids a sixth site until strategy's erratum lands → owed edge. **T3 MATERIAL** "the scorer verifies the diff" has no mechanical form in v4 → owed edge / conduct row. **T5/T6** "frozen" beside a commit whose subject says UNFROZEN → the comment names the mail as the freeze. **T7** a well-formed wrong sha would pass → owed edge (scorer-side guard). **T8 MATERIAL** the commit message attributed six sites to a clause naming five → corrected. NOT FALSIFIED: one file, one constant; every dated/numbered claim in the comment; no consumer of `scorerSha256` in the apparatus; row counts identical across the five- and six-site runs; every cited sha resolves.
- **Leg 3 on the fold `7a5fdb89..0e8e8192`, with the convergence question:** "**No BLOCKING and no code-level MATERIAL remains against E26 (i)/(ii)/(iv) or the 05:36Z ruling. The pin is ready to be presented for merge without a fourth leg.**" Residuals folded into `42b8e82d`: **V1** (this body overstated v4's cure arm → reworded, table row above), **V2** (the comment stated the erratum as fact → owed), **V3** (v3 is not a totem-side witness → reworded), **V5** (`rows.length - 1` → derived by source); **V4** (K3b 56 → 60, declared above and in the pin mail), **V6** (the 05:36Z ruling's "the run-log shows `scorerSha256`" is unsatisfiable as worded — the run-log never prints the field; the durable manifest witness is the stronger artifact, named back to its author in the pin mail), **V7** (erratum naming, above). NOT FALSIFIED: the fold exactly F3/F4/F5 + T5/T6; `evidence` still an array the scorer accepts ("Recorded, never required"; K1 has no row key, so only `ok`/`refusing` reconcile); the MISSING clause fires only on the positive-control row in the absent-from-both state; the specimens K1 row byte-identical to `f6efe85d`'s (typo included); every witness claim; `runManifestSha256` recomputed; the commit message's shas and attribution.

### Gates

At `42b8e82d`: repo-wide `pnpm format:check` clean · `pnpm -r build` green · `pnpm lint` (turbo ESLint, 3/3) green · full-branch `totem lint` PASS (385 rules, 0 violations on the 6 changed files) · no close keyword in the commit. The Linux legs at this PR's head: the seed20 leg's SEED PIN row will SKIP by name (`pin-commit-not-present-locally` — a shallow checkout; an `ok` row, unchanged behaviour), so the byte comparison of record is this seam's and the cure run's, where the pin resolves; its K7 reads its own rebuild.

### Then the loop

Bots: operator-invoked; disposition here. Merge on the operator's word → the merged commit is the **cure apparatus pin** (the cure run's `--apparatus-pin`; `8f64e4b9` is not passed), mailed to strategy-claude full 40-hex with the owed edges named (the E26 erratum and its site naming; the manual site-list check; the scorer-side `scorerSha256` guard; K3b 56 → 60; V6).

## Related Tickets

Related (none closed): mmnto-ai/totem#2704 · mmnto-ai/totem#2717 (held) · mmnto-ai/totem-strategy#1138 · mmnto-ai/totem-strategy#1177 (E26) · mmnto-ai/totem-strategy#1178 (v4) · mmnto-ai/totem#2712 (the run pin) · mmnto-ai/totem#2710 (the previous apparatus pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSpME1vv1iZXz6Vg9gUc6j
