### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine to 0.1.40 — freeze unchanged; distributes the merge-verb ruling on the harness-permissions-baseline row, the bot-review-trigger-guard and naming-display-form rows, and the overlay's naming display-form mandate

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "optionalDependencies": {
     "@mmnto/cli": "workspace:*",
-    "@mmnto/strategy-doctrine": "0.1.39"
+    "@mmnto/strategy-doctrine": "0.1.40"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.39
-        version: 0.1.39
+        specifier: 0.1.40
+        version: 0.1.40
 
   packages/cli:
     dependencies:
@@ -862,8 +862,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.39':
-    resolution: {integrity: sha512-hS8x5CyBONc/zeMEJKxRi0FGTiwBlq85ENsnpAnXekS5Rta7YrPWVmxLHJgfXfdyE14ylDzEhRb5TgWbl17aZg==}
+  '@mmnto/strategy-doctrine@0.1.40':
+    resolution: {integrity: sha512-Qfkx0XiDRz9e54m0GZ4rbF7E5+a/oHKMExA8rA54CSiKZqL+SXYdGIjPq3vfo6jhl1lzufFpZZ1xw9XsRqBdwg==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3694,7 +3694,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.39':
+  '@mmnto/strategy-doctrine@0.1.40':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
## Bump `@mmnto/strategy-doctrine` 0.1.39 → 0.1.40 — freeze unchanged; the pin bump the 2026-09-01T16:51Z cohort broadcast asked for, in this lane after the cure run pin

## Mechanical Root Cause

The doctrine floor moved: `@mmnto/strategy-doctrine` 0.1.40 was cut on the operator's word (strategy tag `strategy-doctrine-v0.1.40` at `55be8821`, OIDC publish run 33534162724; mmnto-ai/totem-strategy#1179 + mmnto-ai/totem-strategy#1181), classified in advance as patch-class, contract-bearing by content, choreography = the pin bump only. The cohort-pin sensor reads totem at 0.1.39 < 0.1.40 until this merges.

## Fix Applied

One line in the root `package.json` (`optionalDependencies` `@mmnto/strategy-doctrine` `0.1.39` → `0.1.40`) and the resulting `pnpm-lock.yaml` delta (6 +/−). The same two-file shape as mmnto-ai/totem#2709 (0.1.39).

**Tarball-diffed before the bump (0.1.39 vs 0.1.40, from the registry):**
- `freeze.json` — **byte-identical** (the `rule-compilation` hold, since 2026-05-17, three do-nots; the local mirror `.totem/freeze.json` needs no change).
- `parity-manifest.yaml` — the `harness-permissions-baseline` row now carries the 2026-08-30 merge-verb ruling (mmnto-ai/totem-strategy#1157: `gh pr merge` in `allow`, both tool shapes; the word in chat is the verb; a project-scope `ask`/`deny` shadowing it is drift, sensed); two rows added at the attestation rung — `bot-review-trigger-guard` (the trigger discipline as a managed PreToolUse hook, mmnto-ai/totem#2713) and `naming-display-form` (ecl § 6.3).
- `cohort-overlay.md` — one § 1 mandate bullet: the naming display form.
- `strategy-doctrine.lock`, `package.json` version.

## Out of Scope

- Any doctrine rendering in this repo (the overlay reaches `mmnto-ai/totem` through the package; nothing to hand-author here).
- The `bot-review-trigger-guard` hook itself (mmnto-ai/totem#2713) and the naming verb/sensor (mmnto-ai/totem-strategy#1155) — separate work.

## Tests Added/Updated

- [x] `totem doctor` at the bump: **11 passed · 5 sense-only warnings · 0 failures** (the warnings are the estate and seat-identity sensors, report-only — the worktree's gitignored `.totem/orchestration/`, as at mmnto-ai/totem#2709).
- [x] Gates: `pnpm format:check` clean · `pnpm -r build` green · `pnpm lint` 3/3 · `totem lint` PASS (385 rules, 0 violations on the 2 changed files) · no close keyword.
- [ ] N/A — a pin bump; the package's own doctor renders the new rows under existing logic (no field added or removed).

## Related Tickets

Related (none closed): mmnto-ai/totem-strategy#1179 · mmnto-ai/totem-strategy#1181 · mmnto-ai/totem-strategy#1157 · mmnto-ai/totem#2713 · mmnto-ai/totem#2709 (the previous bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JSpME1vv1iZXz6Vg9gUc6j
