### PR TITLE
chore(agents): falsification-leg — findings numbered (F1, F2, …) and ranked BLOCKING · MATERIAL · MINOR (one line; canonical = strategy de3f067)

### DIFF
--- a/.claude/agents/falsification-leg.md
+++ b/.claude/agents/falsification-leg.md
@@ -15,4 +15,4 @@ Rules:
 - Git reads only: `git show` / `git diff` / `git log`. Never `checkout` / `switch` / `restore` / `stash` — workspace-state verbs are mutations under the no-mutation rule (incident 2026-08-01: a leg's detached checkouts left the primary tree on `main`; the dispatching seat had to re-derive its own tree state).
 - Drafted tests/controls/fixtures: check assertion STRENGTH against the verbatim source contract clause, not merely that checks pass (Invariant 2 — a weaker-than-contract assertion can pass and look verified).
 - Every finding cites its primary source (file:line, issue, contract clause). A finding you cannot ground is a question — label it as one.
-- Return findings ranked by severity, each as a typed deposit: claim · primary source quoted · assertion strength · verdict.
+- Return findings numbered (`F1`, `F2`, …) and ranked BLOCKING · MATERIAL · MINOR (model-tiering § Typed deposits — the ids let the seat's deposit under § The gate name what it folded), each as a typed deposit: claim · primary source quoted · assertion strength · verdict.


### PR DESCRIPTION
One line in `.claude/agents/falsification-leg.md`: the leg now returns findings **numbered** (`F1`, `F2`, …) and ranked BLOCKING · MATERIAL · MINOR, so the dispatching seat's deposit under model-tiering § The gate can name exactly which findings it folded — the `findings[].id` field the `totem legs deposit` schema carries (mmnto-ai/totem#2698, shipped in mmnto-ai/totem#2745).

**Canonical source:** `mmnto-ai/totem-strategy:.claude/agents/falsification-leg.md` at de3f067 (PR mmnto-ai/totem-strategy#1205, the § The gate clause). This copy otherwise stays byte-identical to the canonical one modulo the cross-repo path prefix it already carries.

**Vehicle:** announced to the host seat by ECL mail 2026-09-03T19:32Z before any write; branch + commit created through the GitHub contents API (no local checkout write); no changeset — the agent file is repo config, not a published source. Merge is the host seat's on the operator's word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqD2ySHPdcuCcYdfC9bntH
