### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine to 0.1.41 — freeze unchanged; distributes the review-leg GATE clause (overlay § 5) and the gh-project-vocabulary + gh-issue-label-canon parity rows

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,6 @@
   },
   "optionalDependencies": {
     "@mmnto/cli": "workspace:*",
-    "@mmnto/strategy-doctrine": "0.1.40"
+    "@mmnto/strategy-doctrine": "0.1.41"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.40
-        version: 0.1.40
+        specifier: 0.1.41
+        version: 0.1.41
 
   packages/cli:
     dependencies:
@@ -862,8 +862,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.40':
-    resolution: {integrity: sha512-Qfkx0XiDRz9e54m0GZ4rbF7E5+a/oHKMExA8rA54CSiKZqL+SXYdGIjPq3vfo6jhl1lzufFpZZ1xw9XsRqBdwg==}
+  '@mmnto/strategy-doctrine@0.1.41':
+    resolution: {integrity: sha512-koSKhRIkreVpoI7hMvpQkBfGEIQvDFUJowLNKV/M/7rTxVZZ1vuvTpzUql/zR1S3QXnDBqfahaiUCs+3k4z/Wg==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3694,7 +3694,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.40':
+  '@mmnto/strategy-doctrine@0.1.41':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
## Bump `@mmnto/strategy-doctrine` 0.1.40 → 0.1.41 — freeze unchanged; distributes the review-leg GATE clause (overlay § 5) and the two board/label parity rows

## Mechanical Root Cause

The doctrine floor moved: `@mmnto/strategy-doctrine` 0.1.41 was cut on the operator's word (strategy tag `strategy-doctrine-v0.1.41` at `8e4da160`; content from mmnto-ai/totem-strategy#1205, the § The gate clause, and mmnto-ai/totem-strategy#1208, the issue-disposition pre-registration's two parity rows). The cohort-pin sensor reads totem at 0.1.40 < 0.1.41 until this merges. The mechanism the clause describes — `totem legs deposit` / `gate` and the strict pre-push arm — shipped in this repo as mmnto-ai/totem#2745 and is published in `@mmnto/cli` 1.123.0 (mmnto-ai/totem#2746 → `19e08f56`); the clause's own "unreleased at this rendering" note predates that cut. Nothing published by this repo pins the doctrine package; this bump moves only this repo's own freeze, parity and orient reads.

## Fix Applied

One line in the root `package.json` (`optionalDependencies` `@mmnto/strategy-doctrine` `0.1.40` → `0.1.41`) and the resulting `pnpm-lock.yaml` delta. The same two-file shape as mmnto-ai/totem#2721 (0.1.40) and mmnto-ai/totem#2709 (0.1.39).

**Tarball-diffed before the bump (0.1.40 vs 0.1.41, both packed from the registry):**

- `freeze.json` — **byte-identical** (the `rule-compilation` hold, since 2026-05-17, three do-nots; the local mirror `.totem/freeze.json` needs no change).
- `cohort-overlay.md` — § 5 "The review-leg contract" heading gains `gate 2026-08-29`, and one new paragraph, **The gate (operator-ruled 2026-08-29; mechanism mmnto-ai/totem#2698)**: the floor is a gate, not a duty — a legs-owed push (path globs, default set by the design record; each repo adds its own contract classes) carries the leg's deposit at `<totemDir>/artifacts/legs/<sha>.json`, ancestor-or-equal of the pushed head, or the strict pre-push arm blocks.
- `parity-manifest.yaml` — two rows added at the `orientation` dimension, both `manifestation: capability-probe`, `senses: present`, tracking mmnto-ai/totem-strategy#472: **`gh-project-vocabulary`** (Status / Priority option sets on every project a cohort repo's `orient.projectNumber` binds — extend-never-override; Project 2 is the live divergence, its disposition the operator's word) and **`gh-issue-label-canon`** (the `scripts/sync-labels.ps1` sets as the canonical label namespaces; census 2026-09-03: totem carries 18 extras, strategy 3). Neither row has a detector in `totem doctor --parity` yet — the detectors are the issue-disposition charter's totem-lane requests, which arrive on the operator's word (mmnto-ai/totem-strategy#1208); until then the rows render but are not sensed.
- `strategy-doctrine.lock`, `package.json` version.

## Out of Scope

- The two parity detectors (`gh-project-vocabulary`, `gh-issue-label-canon`) — separate slices, on the word above.
- Any doctrine rendering in this repo (the overlay reaches `mmnto-ai/totem` through the package; nothing to hand-author here).
- The mmnto-ai/totem#2747 agent-file one-liner (strategy-claude's PR) — independent.

## Tests Added/Updated

- [x] `totem doctor` at the bump in the branch worktree: **11 passed · 5 sense-only warnings · 0 failures** — the Freeze row now reads `cohort@0.1.41; cohort channel ok (@mmnto/strategy-doctrine@0.1.41)`; the warnings are the same estate / seat-identity / strategy-root sensors as mmnto-ai/totem#2721 (report-only; the worktree has no gitignored `.totem/orchestration/` and no sibling strategy checkout).
- [x] Gates: `pnpm format:check` clean · `pnpm -r build` green · `pnpm lint` 3/3 · `totem lint` PASS (385 rules, 0 violations) · no close keyword · not legs-owed (no contract-class path in the diff).
- [x] Installed version verified after the add: `node_modules/@mmnto/strategy-doctrine/package.json` → `0.1.41`, lockfile entry `@mmnto/strategy-doctrine@0.1.41` (the mmnto-ai/totem-strategy#630 silent-exclusion shape was hit ONCE on this seat before the registry token was renewed — `pnpm add` exited 0 with no change; the renewed token resolved it; the trap stands as filed).
- [ ] N/A — a pin bump; the package's own doctor renders the new rows under existing logic (no field added or removed).

## Related Tickets

Related (none closed): mmnto-ai/totem-strategy#1205 · mmnto-ai/totem-strategy#1208 · mmnto-ai/totem-strategy#472 · mmnto-ai/totem-strategy#630 · mmnto-ai/totem#2698 · mmnto-ai/totem#2745 · mmnto-ai/totem#2721 (the previous bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015M6AwdHorDacnmh4MQQgn5
