### PR TITLE
chore(lessons): supersede the mmnto-ai/totem#391-era single-pool + filePath-partition lesson — empty by construction since mmnto-ai/totem#431, deleted by mmnto-ai/totem#2750; the continue-not-break clause kept (mmnto-ai/totem#2754; freeze specimen class)

### DIFF
--- a/.totem/lessons.md
+++ b/.totem/lessons.md
@@ -1392,9 +1392,9 @@ Use the `--recurse-submodules` flag with `git ls-files` to ensure that files loc
 
 ## Lesson — When injecting vectordb lessons into orchestrator prompts
 
-**Tags:** vectordb, spec, lessons, architecture, pattern
+**Tags:** vectordb, spec, lessons, architecture, pattern, superseded
 
-When injecting vectordb lessons into orchestrator prompts (like `totem spec`), use a single broadened search pool (e.g., 20 results) and partition by filePath rather than running multiple redundant searches. The `lessons.md` filePath convention is the reliable partition key. Use `continue` not `break` in character budget loops so oversized items are skipped but smaller ones still fit.
+SUPERSEDED (mmnto-ai/totem#2735, merged as mmnto-ai/totem#2750; specimen edit mmnto-ai/totem#2754). The original text taught a single broadened spec-typed search pool partitioned by `filePath`, with the `lessons.md` path as the partition key. Since mmnto-ai/totem#431 lessons live in `.totem/lessons/` under content type `lesson`, so that partition was empty by construction for every run and mmnto-ai/totem#2750 deleted it. When injecting vectordb lessons into orchestrator prompts (like `totem spec`), retrieve them through the one core helper `searchLessons` (`typeFilter: 'lesson'`, exported from `@mmnto/totem`) — never by partitioning a broadened pool of another content type. Still true: use `continue` not `break` in character budget loops so oversized items are skipped but smaller ones still fit.
 
 ## Lesson — Changesets interactive CLI (pnpm changeset) crashes when
 


### PR DESCRIPTION
Closes #2754 <!-- totem-close: #2754 -->

**The specimen.** `.totem/lessons.md:1393` ("When injecting vectordb lessons into orchestrator prompts") taught the mmnto-ai/totem#391-era single broadened spec-typed pool partitioned by `filePath`. Since mmnto-ai/totem#431 lessons live in `.totem/lessons/` under content type `lesson`, so that partition was empty by construction for every run; mmnto-ai/totem#2750 deleted it and routes every lesson retrieval through `searchLessons` (`typeFilter: 'lesson'`, exported from `@mmnto/totem`). Because mmnto-ai/totem#2750 also delivers lessons to `spec` / `shield` / `triage` prompts under a HARD CONSTRAINTS header, the old text told an agent to re-introduce the measured defect.

**The edit (one entry, narrow).** The body now opens `SUPERSEDED (…)`, states the construction fact and the current mechanism, and keeps the still-true clause (`continue` not `break` in character budget loops). Tag `superseded` added. Heading unchanged, so the compiled rule `1e9417ca76e7a183` — which enforces only the surviving clause (a regex over `if (… budget|limit|max … ) break`) — keeps its link and is untouched.

**Freeze posture.** The rule-compilation freeze (since 2026-05-17) stands; this is the adjudicated specimen class (mmnto-ai/totem#2343 precedent: narrow hand-edit + the no-LLM re-seal), on the operator's per-specimen word of 2026-09-03. `totem lesson compile --refresh-manifest`: `Manifest already fresh — no changes` (no rule changed; lesson-input staleness remains the freeze's accrued WARN, as `verify-manifest` reports on main today).

**Gate.** prettier clean on the file; `pnpm lint` green; `totem lint` (post-commit, branch scope) PASS with 1 advisory warning (the absolute-claim regex on the word "never" inside the lesson body); full `pnpm test --force` with `GIT_CONFIG_GLOBAL` + `GIT_CONFIG_SYSTEM` masked (probe: `init.defaultBranch` unset): 12/12 tasks, every package green, exit 0.

**Owed after merge.** `totem sync` in the resident, then confirm the designing query (`totem spec 2735`'s topic) no longer surfaces the superseded text at rank 1 — the issue's acceptance line.

No falsification leg: a four-line lesson edit whose two source claims (`searchLessons` exported from core; `partitionLessons` gone) were verified by grep at `3e82124f`; the diff matches no `hooks.legsOwed.globs` entry. Bots: none invoked (operator-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015M6AwdHorDacnmh4MQQgn5
