### PR TITLE
fix(release): the OIDC verify step polls every package until a 10-min visibility deadline (floor + ceiling pinned by test, outer cap 13 min); v0 repoint rides the publish verdict, not the verify verdict (mmnto-ai/totem#2748)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
 
       - run: pnpm test
 
+      # Root tool test: pins the verify-oidc visibility budget against the
+      # release workflow's outer timeout-minutes cap (mmnto-ai/totem#2748).
+      - run: pnpm test:verify-oidc
+
       - name: Wind Tunnel (rule fixture tests)
         run: node packages/cli/dist/index.js test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,14 +76,16 @@ jobs:
       # trusted publisher misconfigured. See tools/verify-oidc-provenance.mjs.
       # Visibility budget (mmnto-ai/totem#2748). npm makes a just-published
       # package readable minutes after publish, per package: 2 min 20 s after
-      # the old ~25 s budget gave up on the 1.123.0 cut, 6 min 57 s after the
-      # merge on the 1.124.0 cut. The script polls every still-pending package
-      # once per round, so:
+      # the old budget gave up on the 1.123.0 cut (5 attempts separated by
+      # 4 × 5 s sleeps — about 20 s of waiting; the step ran 21 s), and
+      # 6 min 57 s after the merge on the 1.124.0 cut. The script polls every
+      # still-pending package once per round, so:
       #   FLOOR   — 10 min (VISIBILITY_DEADLINE_MS): a package that stays
       #             invisible is polled for at least that long.
-      #   CEILING — worstCaseMs(4) = 10 min + 4 × 20 s ≈ 11 min 20 s for the
-      #             four published packages (one spawn timeout each in the
-      #             final round).
+      #   CEILING — worstCaseMs(4) = 10 min + 15 s + 4 × 20 s ≈ 11 min 35 s
+      #             for the four published packages: the deadline, plus the
+      #             one poll interval the final round can start past it, plus
+      #             one spawn timeout per package pending in that round.
       # timeout-minutes: 13 is the OUTER cap and must stay ≥ that ceiling;
       # tools/verify-oidc-provenance.test.mjs pins the relation, so lowering
       # this without lowering the script's budget fails CI.
@@ -100,7 +102,10 @@ jobs:
       # on the 1.123.0 and 1.124.0 cuts a propagation-lag verify failure left
       # v0 behind (mmnto-ai/totem#2748); the 1.91.0 cut hit the same class from
       # the other side (mmnto-ai/totem#2314). !cancelled() rather than always()
-      # so a cancelled run never repoints tags.
+      # so a cancelled run never repoints tags. This also lets v0 advance after
+      # a genuine provenance-regression failure, which is accepted: action.yml
+      # runs the CLI unpinned, so v0 pins only the composite action source,
+      # never the suspect package.
       - name: Push release tags
         if: ${{ !cancelled() && steps.publish.outputs.published == 'true' }}
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,20 +74,35 @@ jobs:
       # Fails the release loud (Tenet 4) if OIDC silently regressed to token
       # auth — e.g. NPM_TOKEN re-added, `registry-url` re-written into .npmrc,
       # trusted publisher misconfigured. See tools/verify-oidc-provenance.mjs.
-      # timeout-minutes caps the verify step at the YAML layer; the script's
-      # MAX_ATTEMPTS × SPAWN_TIMEOUT_MS + RETRY_DELAY_MS arithmetic bounds it
-      # to ~2 min/package (8 min worst case across 4 packages), but encoding
-      # the cap in the workflow makes the contract explicit rather than
-      # implicit in script constants.
+      # Visibility budget (mmnto-ai/totem#2748). npm makes a just-published
+      # package readable minutes after publish, per package: 2 min 20 s after
+      # the old ~25 s budget gave up on the 1.123.0 cut, 6 min 57 s after the
+      # merge on the 1.124.0 cut. The script polls every still-pending package
+      # once per round, so:
+      #   FLOOR   — 10 min (VISIBILITY_DEADLINE_MS): a package that stays
+      #             invisible is polled for at least that long.
+      #   CEILING — worstCaseMs(4) = 10 min + 4 × 20 s ≈ 11 min 20 s for the
+      #             four published packages (one spawn timeout each in the
+      #             final round).
+      # timeout-minutes: 13 is the OUTER cap and must stay ≥ that ceiling;
+      # tools/verify-oidc-provenance.test.mjs pins the relation, so lowering
+      # this without lowering the script's budget fails CI.
       - name: Verify OIDC provenance on published packages
         if: steps.publish.outputs.published == 'true'
-        timeout-minutes: 4
+        timeout-minutes: 13
         run: node tools/verify-oidc-provenance.mjs
         env:
           PUBLISHED_PACKAGES: ${{ steps.publish.outputs.published_packages }}
 
+      # The floating v0 repoint rides the PUBLISH verdict, not the verify
+      # verdict. A verify failure still fails the job (loud, Tenet 4), but the
+      # tags the publish already created get pushed instead of being stranded:
+      # on the 1.123.0 and 1.124.0 cuts a propagation-lag verify failure left
+      # v0 behind (mmnto-ai/totem#2748); the 1.91.0 cut hit the same class from
+      # the other side (mmnto-ai/totem#2314). !cancelled() rather than always()
+      # so a cancelled run never repoints tags.
       - name: Push release tags
-        if: steps.publish.outputs.published == 'true'
+        if: ${{ !cancelled() && steps.publish.outputs.published == 'true' }}
         run: |
           git push origin --tags --force
           git tag -f v0

--- a/.totem/specs/2748.md
+++ b/.totem/specs/2748.md
@@ -1,0 +1,79 @@
+### Problem Statement
+
+The OIDC provenance verification step (`tools/verify-oidc-provenance.mjs`) has an effective retry budget of only ~25 seconds against a ~2.5 minute npm registry propagation delay, causing false-positive workflow failures. Furthermore, the `Push release tags` workflow step is coupled to the verification step's success, preventing the floating `v0` release tag from being updated even when the publish step succeeds.
+
+### Architectural Context
+
+- **Lesson — npm OIDC trusted publishing prerequisites**: Emphasizes that OIDC trusted publishing requires correct permissions and environment. The verification gate must remain robust but should not produce false-positive failures due to propagation delays.
+- **Lesson — Alpha-pilot publish exemption from Sigstore gating**: Highlights that while security gates are critical, operational flow and release propagation must be modeled accurately to avoid artificial blockages.
+
+### Files to Examine
+
+- `tools/verify-oidc-provenance.mjs` — Contains the retry constants (`MAX_ATTEMPTS`, `RETRY_DELAY_MS`) and the sequential package verification logic.
+- `.github/workflows/release.yml` — Defines the workflow execution steps, dependencies, and conditions for OIDC verification and tag pushing.
+- `tools/verify-oidc-provenance.test.mjs` — The test suite for the verification logic where retry behavior and error aggregation must be validated.
+
+### Technical Approach & Contracts
+
+1. **Extend the Visibility Budget**:
+   - Replace the fixed attempt count in `tools/verify-oidc-provenance.mjs` with a deadline-driven poller: `POLL_INTERVAL_MS = 15_000` (poll every 15 seconds) and `VISIBILITY_DEADLINE_MS = 10 * 60_000` (a 10-minute floor — a package that stays invisible is polled for at least that long from the start of polling). 10 minutes covers the measured 6 min 57 s propagation with margin.
+   - Poll round-robin across all packages: every still-pending spec is fetched once per round, and a spec that resolves is never fetched again, so one slow package cannot hide the others.
+   - The ceiling is `worstCaseMs(pendingCount) = VISIBILITY_DEADLINE_MS + pendingCount * SPAWN_TIMEOUT_MS` — the deadline plus one 20-second spawn timeout per package still pending in the final round (≈ 11 min 20 s for the four published packages).
+   - Set the workflow's outer step cap to `timeout-minutes: 13`, which must stay ≥ the ceiling; the test pins that relation.
+2. **Batch Verification Execution**:
+   - Refactor `tools/verify-oidc-provenance.mjs` to run the verification process over all targeted packages before throwing an error.
+   - Instead of immediately exiting the process on the first 404/miss, collect package verification failures into an array, log all specific failures at the end, and exit with a non-zero exit code if the array is non-empty.
+3. **Decouple the Release Tag Updates**:
+   - Modify the `Push release tags` job or step within `.github/workflows/release.yml` to evaluate based on whether the publishing step successfully completed, regardless of whether the OIDC verification step failed or succeeded.
+   - Use a conditional expression such as `if: always() && steps.publish.outputs.published == 'true'` (or the appropriate job-level equivalent depending on workflow topology) to ensure the floating tags are repointed.
+
+### Edge Cases & Traps
+
+- **Workflow Cancellation**: Using `always()` in GitHub Actions can cause steps to run even when a workflow run is manually cancelled. Ensure the condition strictly checks that the publishing steps completed successfully and that the runner was not cancelled (e.g., using `!cancelled()`).
+- **Cumulative Step Timeouts**: Increasing retry counts must not exceed the job's overall timeout configuration. Ensure that the total possible run duration of `tools/verify-oidc-provenance.mjs` fits comfortably within the GitHub Actions runner step-level `timeout-minutes` threshold.
+- **Unintended Execution of Tag Repointing**: If the publishing step is skipped or fails to publish packages, the floating tags must never be repointed. The conditional logic must tightly couple to the exact output indicating a successful publish.
+
+### Implementation Tasks
+
+- [ ] **Task 1: Restructure Verification Script Polling and Budget Constants**
+  - Open `tools/verify-oidc-provenance.mjs` and replace `MAX_ATTEMPTS` / `RETRY_DELAY_MS` with `POLL_INTERVAL_MS = 15_000`, `VISIBILITY_DEADLINE_MS = 10 * 60_000`, `SPAWN_TIMEOUT_MS = 20_000` and `worstCaseMs = (pendingCount) => VISIBILITY_DEADLINE_MS + pendingCount * SPAWN_TIMEOUT_MS`, driving a round-robin poller over all packages.
+  - Update the commentary above the constants to document the floor (10 minutes of polling for a package that stays invisible), the ceiling (`worstCaseMs(n)` = deadline + pending × 20 s), and that the workflow's `timeout-minutes: 13` is the outer cap that must stay ≥ the ceiling.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `asserts_visibility_deadline_covers_measured_propagation` that validates the configured deadline against the measured propagation datum.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 2: Refactor Verification Logic to Aggregate Package Failures**
+  - Modify `tools/verify-oidc-provenance.mjs` to execute verification against every package in the cohort, gathering all verification errors into a collection.
+  - Log failures for all failing packages and exit the process with code `1` only after all packages have been evaluated.
+    > TEST DIRECTIVE: Before implementing, write a failing test named `verifies_all_packages_and_reports_aggregated_failures` that mocks a failure on the first package and ensures subsequent packages are still processed.
+  - write test → verify fails → implement → verify passes → lint
+
+- [ ] **Task 3: Decouple the Push Release Tags Step**
+  - Open `.github/workflows/release.yml`.
+  - Update the condition for the `Push release tags` step to use `if: always() && steps.publish.outputs.published == 'true'` (or equivalent context) so it runs even if the OIDC verification step fails.
+  - verify fails (via mock/local dry-run schema validation if possible) → implement → verify passes → lint
+
+### Execution Flow (structural constraint)
+
+```dot
+digraph workflow {
+  spec -> write_test -> verify_fails -> implement -> verify_passes -> lint -> next_task
+  verify_fails -> implement [label="RED only"]
+  verify_passes -> lint [label="GREEN required"]
+  lint -> next_task [label="0 violations"]
+  lint -> implement [label="violations found — fix first"]
+}
+```
+
+### Verification (MANDATORY — do not skip)
+
+Every implementation MUST end with these steps:
+
+1. `totem lint` — deterministic rule check (zero LLM, ~2s). Fixes any violations.
+2. `totem review` — supplementary AI lanes over the diff (~18s, advisory). Address critical findings; your team's review discipline decides the review of record.
+3. If using MCP, call `verify_execution` to confirm compliance before declaring the task done.
+
+### Test Plan
+
+- **Verification Script Visibility Budget Test**: Verify that the configured visibility deadline is greater than or equal to 7 × 60 000 ms.
+- **Batch Error Collection Test**: Simulate verification failures across multiple packages and ensure the script registers and reports all of them before exiting.
+- **Workflow Semantic Check**: Validate `.github/workflows/release.yml` syntactically to ensure the GHA conditional logic is valid and decoupled.

--- a/.totem/specs/2748.md
+++ b/.totem/specs/2748.md
@@ -1,6 +1,6 @@
 ### Problem Statement
 
-The OIDC provenance verification step (`tools/verify-oidc-provenance.mjs`) has an effective retry budget of only ~25 seconds against a ~2.5 minute npm registry propagation delay, causing false-positive workflow failures. Furthermore, the `Push release tags` workflow step is coupled to the verification step's success, preventing the floating `v0` release tag from being updated even when the publish step succeeds.
+The OIDC provenance verification step (`tools/verify-oidc-provenance.mjs`) has a retry budget of only 5 attempts separated by 4 × 5 s sleeps — about 20 seconds of waiting, and the step itself ran 21 seconds — against an npm registry propagation delay of minutes, causing false-positive workflow failures. Furthermore, the `Push release tags` workflow step is coupled to the verification step's success, preventing the floating `v0` release tag from being updated even when the publish step succeeds.
 
 ### Architectural Context
 
@@ -18,7 +18,7 @@ The OIDC provenance verification step (`tools/verify-oidc-provenance.mjs`) has a
 1. **Extend the Visibility Budget**:
    - Replace the fixed attempt count in `tools/verify-oidc-provenance.mjs` with a deadline-driven poller: `POLL_INTERVAL_MS = 15_000` (poll every 15 seconds) and `VISIBILITY_DEADLINE_MS = 10 * 60_000` (a 10-minute floor — a package that stays invisible is polled for at least that long from the start of polling). 10 minutes covers the measured 6 min 57 s propagation with margin.
    - Poll round-robin across all packages: every still-pending spec is fetched once per round, and a spec that resolves is never fetched again, so one slow package cannot hide the others.
-   - The ceiling is `worstCaseMs(pendingCount) = VISIBILITY_DEADLINE_MS + pendingCount * SPAWN_TIMEOUT_MS` — the deadline plus one 20-second spawn timeout per package still pending in the final round (≈ 11 min 20 s for the four published packages).
+   - The ceiling is `worstCaseMs(pendingCount) = VISIBILITY_DEADLINE_MS + POLL_INTERVAL_MS + pendingCount * SPAWN_TIMEOUT_MS` — the deadline, plus the one 15-second poll interval the final round can start past it (the deadline is checked after a round and before the sleep), plus one 20-second spawn timeout per package still pending in that round (≈ 11 min 35 s for the four published packages).
    - Set the workflow's outer step cap to `timeout-minutes: 13`, which must stay ≥ the ceiling; the test pins that relation.
 2. **Batch Verification Execution**:
    - Refactor `tools/verify-oidc-provenance.mjs` to run the verification process over all targeted packages before throwing an error.
@@ -49,7 +49,7 @@ The OIDC provenance verification step (`tools/verify-oidc-provenance.mjs`) has a
 
 - [ ] **Task 3: Decouple the Push Release Tags Step**
   - Open `.github/workflows/release.yml`.
-  - Update the condition for the `Push release tags` step to use `if: always() && steps.publish.outputs.published == 'true'` (or equivalent context) so it runs even if the OIDC verification step fails.
+  - Update the condition for the `Push release tags` step to use `if: ${{ !cancelled() && steps.publish.outputs.published == 'true' }}` so it runs even if the OIDC verification step fails, while a cancelled run never repoints tags.
   - verify fails (via mock/local dry-run schema validation if possible) → implement → verify passes → lint
 
 ### Execution Flow (structural constraint)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "test:docs": "node tools/docs-transforms.test.cjs",
     "test:augment-headers": "node tools/augment-cohort-changelog-headers.test.mjs",
     "test:cut-sensor": "node --test tools/vp-pr-cut-sensor.test.mjs",
+    "test:verify-oidc": "node --test tools/verify-oidc-provenance.test.mjs",
     "test:autoclose-adapters": "node --test tools/autoclose-adapters.test.mjs"
   },
   "devDependencies": {

--- a/tools/verify-oidc-provenance.mjs
+++ b/tools/verify-oidc-provenance.mjs
@@ -23,10 +23,10 @@
  * just-published package readable on a lag that is minutes, not seconds, and
  * the lag is per-package inside a single publish. Two measured data from that
  * issue: on the 1.123.0 cut npm made `@mmnto/totem` visible 2 min 20 s AFTER
- * this step had already given up (its budget then was 5 attempts × 5 s ≈ 25 s
- * of effective polling); on the 1.124.0 cut the same package was visible
- * 6 min 57 s after the merge, with a per-package spread inside that one
- * publish of 0:56 → 6:57.
+ * this step had already given up (its budget then was 5 attempts separated by
+ * 4 × 5 s sleeps — about 20 s of waiting; the step itself ran 21 s); on the
+ * 1.124.0 cut the same package was visible 6 min 57 s after the merge, with a
+ * per-package spread inside that one publish of 0:56 → 6:57.
  *
  * So the script polls rather than retries per package: `pollUntilVisible`
  * walks every still-pending spec once per round, then sleeps
@@ -35,11 +35,17 @@
  *
  *   FLOOR   — VISIBILITY_DEADLINE_MS (10 min). A package that stays invisible
  *             is polled for AT LEAST this long from the start of polling.
- *             10 min is the 6 min 57 s datum plus margin.
- *   CEILING — worstCaseMs(n) = VISIBILITY_DEADLINE_MS + n × SPAWN_TIMEOUT_MS:
- *             the deadline plus one spawn timeout for each of the n packages
- *             still pending in the final round (a wedged registry can burn a
- *             full spawn timeout per package in that round).
+ *             The 1.124.0 datum is 6 min 57 s measured from the merge but
+ *             5 min 45 s measured from this step's start, and the poller's
+ *             clock starts at the step — so the deadline bounds the step's
+ *             clock, with margin over both figures.
+ *   CEILING — worstCaseMs(n) = VISIBILITY_DEADLINE_MS + POLL_INTERVAL_MS
+ *             + n × SPAWN_TIMEOUT_MS. The deadline is checked AFTER a round
+ *             and BEFORE the sleep, so the final round can start up to one
+ *             POLL_INTERVAL_MS past the deadline; that round can then burn a
+ *             full SPAWN_TIMEOUT_MS on each of the n packages still pending,
+ *             because a spawnSync timeout is reported as `{ ok: false }` —
+ *             the package stays pending — rather than aborting the run.
  *
  * The release workflow's `timeout-minutes` on this step is the OUTER cap and
  * must stay ≥ the ceiling for the number of published packages;
@@ -56,9 +62,13 @@ export const VISIBILITY_DEADLINE_MS = 10 * 60_000;
 // Bound the per-call npm view to defend against a wedged registry/network
 // (otherwise the CI step could hang up to the job-level timeout).
 export const SPAWN_TIMEOUT_MS = 20_000;
-/** CEILING: the deadline plus one spawn timeout per package still pending in the final round. */
+/**
+ * CEILING: the deadline, plus the one poll interval the final round can start
+ * past it (the deadline is checked after a round and before the sleep), plus
+ * one spawn timeout per package still pending in that final round.
+ */
 export const worstCaseMs = (pendingCount) =>
-  VISIBILITY_DEADLINE_MS + pendingCount * SPAWN_TIMEOUT_MS;
+  VISIBILITY_DEADLINE_MS + POLL_INTERVAL_MS + pendingCount * SPAWN_TIMEOUT_MS;
 
 // On Windows, `npm` is a `.cmd` shim, and Node ≥ 20 refuses to spawnSync
 // .bat/.cmd files without shell: true (EINVAL). The workflow runs on
@@ -74,17 +84,26 @@ const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 // fetchNpmView throws on hard failures (spawn, JSON parse) — those aren't
 // recoverable by polling, so a "loud crash" via thrown Error is the right
-// shape (.gemini/styleguide.md § 120 cause-chain rule). For soft failures
-// (registry returned non-zero status, often propagation lag), returns
-// `{ ok: false, err }` so the poller can keep the spec pending.
-const fetchNpmView = (spec) => {
-  const result = spawnSync('npm', ['view', spec, '--json'], {
+// shape (.gemini/styleguide.md § 9 "Error Handling & Logging Conventions",
+// the "Error cause chains (ES2022)" bullet). For soft failures the poller can
+// ride out, returns `{ ok: false, err }` so the spec stays pending: a
+// non-zero npm view status (usually propagation lag), and a spawnSync
+// timeout — which arrives as `result.error` with `code: 'ETIMEDOUT'`
+// (measured on Node 24.16.0). Throwing on the timeout would let ONE wedged
+// `npm view` abort the whole poll, which is exactly the "one slow package
+// hides the others" failure mmnto-ai/totem#2748 removes. `spawn` is a
+// parameter so the test can drive both arms without spawning npm.
+export const fetchNpmView = (spec, spawn = spawnSync) => {
+  const result = spawn('npm', ['view', spec, '--json'], {
     encoding: 'utf-8',
     stdio: ['pipe', 'pipe', 'pipe'],
     timeout: SPAWN_TIMEOUT_MS,
     ...SPAWN_OPTS_BASE,
   });
   if (result.error) {
+    if (result.error.code === 'ETIMEDOUT') {
+      return { ok: false, err: `npm view timed out after ${SPAWN_TIMEOUT_MS}ms` };
+    }
     throw new Error('[Totem Error] verify-oidc: npm view spawn failed', {
       cause: result.error,
     });
@@ -214,8 +233,15 @@ export const assertProvenance = (spec, data) => {
   return true;
 };
 
-export const main = async () => {
-  const published = (process.env.PUBLISHED_PACKAGES ?? '')
+/**
+ * `exit` and `env` are parameters (not `process.exit` / `process.env` reached
+ * for inline) so the fail-loud arm below is reachable from a test — it is
+ * conditional now, and an untested exit path is how a gate goes quietly
+ * green. `fetch`/`sleep`/`now` are forwarded to `pollUntilVisible` only when
+ * given, so the shipped call `main()` runs on the poller's real defaults.
+ */
+export const main = async ({ fetch, sleep, now, exit = process.exit, env = process.env } = {}) => {
+  const published = (env.PUBLISHED_PACKAGES ?? '')
     .split('\n')
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
@@ -227,7 +253,12 @@ export const main = async () => {
 
   console.log(`[verify-oidc] Verifying ${published.length} package(s): ${published.join(', ')}`);
 
-  const { resolved, missing } = await pollUntilVisible(published);
+  const pollOptions = {};
+  if (fetch !== undefined) pollOptions.fetch = fetch;
+  if (sleep !== undefined) pollOptions.sleep = sleep;
+  if (now !== undefined) pollOptions.now = now;
+
+  const { resolved, missing } = await pollUntilVisible(published, pollOptions);
 
   const failed = [];
   for (const [spec, data] of resolved) {
@@ -253,7 +284,10 @@ export const main = async () => {
   }
 
   if (missing.size > 0 || failed.length > 0) {
-    process.exit(1);
+    exit(1);
+    // `process.exit` never returns; an injected `exit` might, and falling
+    // through would print the all-verified line over a failure.
+    return;
   }
 
   console.log(

--- a/tools/verify-oidc-provenance.mjs
+++ b/tools/verify-oidc-provenance.mjs
@@ -19,18 +19,46 @@
  * (e.g., if a future change re-introduces `NPM_TOKEN` or `registry-url` and
  * OIDC negotiation falls back unnoticed).
  *
- * The npm registry has read-replica lag of a few seconds after `npm publish`
- * returns, so each `npm view` is retried up to MAX_ATTEMPTS times with
- * RETRY_DELAY_MS between attempts. After publish-oidc finishes, registry
- * convergence is typically <10s.
+ * VISIBILITY BUDGET (mmnto-ai/totem#2748). The npm registry makes a
+ * just-published package readable on a lag that is minutes, not seconds, and
+ * the lag is per-package inside a single publish. Two measured data from that
+ * issue: on the 1.123.0 cut npm made `@mmnto/totem` visible 2 min 20 s AFTER
+ * this step had already given up (its budget then was 5 attempts × 5 s ≈ 25 s
+ * of effective polling); on the 1.124.0 cut the same package was visible
+ * 6 min 57 s after the merge, with a per-package spread inside that one
+ * publish of 0:56 → 6:57.
+ *
+ * So the script polls rather than retries per package: `pollUntilVisible`
+ * walks every still-pending spec once per round, then sleeps
+ * POLL_INTERVAL_MS, and a spec resolved in an earlier round is never fetched
+ * again. One slow package therefore cannot hide the others.
+ *
+ *   FLOOR   — VISIBILITY_DEADLINE_MS (10 min). A package that stays invisible
+ *             is polled for AT LEAST this long from the start of polling.
+ *             10 min is the 6 min 57 s datum plus margin.
+ *   CEILING — worstCaseMs(n) = VISIBILITY_DEADLINE_MS + n × SPAWN_TIMEOUT_MS:
+ *             the deadline plus one spawn timeout for each of the n packages
+ *             still pending in the final round (a wedged registry can burn a
+ *             full spawn timeout per package in that round).
+ *
+ * The release workflow's `timeout-minutes` on this step is the OUTER cap and
+ * must stay ≥ the ceiling for the number of published packages;
+ * `tools/verify-oidc-provenance.test.mjs` pins that relation so lowering one
+ * without the other fails CI.
  */
 import { spawnSync } from 'node:child_process';
+import { pathToFileURL } from 'node:url';
 
-const MAX_ATTEMPTS = 5;
-const RETRY_DELAY_MS = 5000;
+/** How long to wait between polling rounds. */
+export const POLL_INTERVAL_MS = 15_000;
+/** FLOOR: a package that stays invisible is polled for at least this long. */
+export const VISIBILITY_DEADLINE_MS = 10 * 60_000;
 // Bound the per-call npm view to defend against a wedged registry/network
 // (otherwise the CI step could hang up to the job-level timeout).
-const SPAWN_TIMEOUT_MS = 20_000;
+export const SPAWN_TIMEOUT_MS = 20_000;
+/** CEILING: the deadline plus one spawn timeout per package still pending in the final round. */
+export const worstCaseMs = (pendingCount) =>
+  VISIBILITY_DEADLINE_MS + pendingCount * SPAWN_TIMEOUT_MS;
 
 // On Windows, `npm` is a `.cmd` shim, and Node ≥ 20 refuses to spawnSync
 // .bat/.cmd files without shell: true (EINVAL). The workflow runs on
@@ -42,13 +70,13 @@ const EXPECTED_NPM_USER_EMAIL = 'npm-oidc-no-reply@github.com';
 const EXPECTED_NPM_USER_NAME = 'GitHub Actions';
 const EXPECTED_PROVENANCE_PREDICATE = 'https://slsa.dev/provenance/v1';
 
-const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 // fetchNpmView throws on hard failures (spawn, JSON parse) — those aren't
-// recoverable by retry, so a "loud crash" via thrown Error is the right
+// recoverable by polling, so a "loud crash" via thrown Error is the right
 // shape (.gemini/styleguide.md § 120 cause-chain rule). For soft failures
 // (registry returned non-zero status, often propagation lag), returns
-// `{ ok: false, err }` so the caller's retry loop can drive backoff.
+// `{ ok: false, err }` so the poller can keep the spec pending.
 const fetchNpmView = (spec) => {
   const result = spawnSync('npm', ['view', spec, '--json'], {
     encoding: 'utf-8',
@@ -73,35 +101,68 @@ const fetchNpmView = (spec) => {
   }
 };
 
-const fetchWithRetry = async (spec) => {
-  let lastErr = null;
-  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
-    const result = fetchNpmView(spec);
-    if (result.ok) return result.data;
-    lastErr = result.err;
-    if (attempt < MAX_ATTEMPTS) {
-      console.log(
-        `[verify-oidc] ${spec} not yet visible on registry (attempt ${attempt}/${MAX_ATTEMPTS}); retrying in ${RETRY_DELAY_MS}ms`,
-      );
-      await sleep(RETRY_DELAY_MS);
+/**
+ * Round-robin poller: every still-pending spec is fetched once per round, in
+ * input order, until nothing is pending or the deadline has passed. The first
+ * round runs immediately (no initial sleep). A spec that resolves is removed
+ * from the pending set and never fetched again.
+ *
+ * Returns `{ resolved, missing }` — `resolved` is a `Map<spec, data>`,
+ * `missing` a `Map<spec, lastErr>` of the specs still pending at return.
+ * A `fetch` that THROWS propagates unchanged (hard failures stay loud).
+ */
+export const pollUntilVisible = async (
+  specs,
+  {
+    fetch = fetchNpmView,
+    sleep = defaultSleep,
+    now = Date.now,
+    deadlineMs = VISIBILITY_DEADLINE_MS,
+    intervalMs = POLL_INTERVAL_MS,
+  } = {},
+) => {
+  const start = now();
+  const resolved = new Map();
+  const missing = new Map();
+  let pending = [...specs];
+
+  const elapsedSeconds = () => Math.round((now() - start) / 1000);
+
+  for (;;) {
+    const stillPending = [];
+    for (const spec of pending) {
+      const result = fetch(spec);
+      if (result.ok) {
+        resolved.set(spec, result.data);
+        missing.delete(spec);
+        console.log(`[verify-oidc] ${spec} visible after ${elapsedSeconds()}s`);
+      } else {
+        missing.set(spec, result.err);
+        stillPending.push(spec);
+      }
     }
+    pending = stillPending;
+
+    if (pending.length === 0) return { resolved, missing };
+    if (now() - start >= deadlineMs) return { resolved, missing };
+
+    console.log(
+      `[verify-oidc] ${pending.length} package(s) not yet visible after ${elapsedSeconds()}s (${pending.join(', ')}); next poll in ${intervalMs}ms`,
+    );
+    await sleep(intervalMs);
   }
-  console.error(`[verify-oidc] Failed to fetch ${spec} after ${MAX_ATTEMPTS} attempts:`, lastErr);
-  throw new Error(`[Totem Error] verify-oidc: registry fetch exhausted retries for ${spec}`, {
-    cause: lastErr,
-  });
 };
 
 // `npm view --json` returns `_npmUser` as a `<name> <<email>>` string
 // (e.g., `"GitHub Actions <npm-oidc-no-reply@github.com>"`), not an object.
-const parseNpmUser = (raw) => {
+export const parseNpmUser = (raw) => {
   if (typeof raw !== 'string') return { name: null, email: null };
   const match = raw.match(/^(.+)\s+<(.+)>$/);
   if (!match) return { name: raw.trim(), email: null };
   return { name: match[1].trim(), email: match[2].trim() };
 };
 
-const assertProvenance = (spec, data) => {
+export const assertProvenance = (spec, data) => {
   const failures = [];
 
   const npmUser = parseNpmUser(data._npmUser);
@@ -153,7 +214,7 @@ const assertProvenance = (spec, data) => {
   return true;
 };
 
-const main = async () => {
+export const main = async () => {
   const published = (process.env.PUBLISHED_PACKAGES ?? '')
     .split('\n')
     .map((line) => line.trim())
@@ -166,16 +227,32 @@ const main = async () => {
 
   console.log(`[verify-oidc] Verifying ${published.length} package(s): ${published.join(', ')}`);
 
+  const { resolved, missing } = await pollUntilVisible(published);
+
   const failed = [];
-  for (const spec of published) {
-    const data = await fetchWithRetry(spec);
+  for (const [spec, data] of resolved) {
     if (!assertProvenance(spec, data)) failed.push(spec);
+  }
+
+  if (missing.size > 0) {
+    console.error(
+      `[verify-oidc] ${missing.size} package(s) never became visible within ${VISIBILITY_DEADLINE_MS / 1000}s:`,
+    );
+    for (const [spec, lastErr] of missing) {
+      console.error(`  - ${spec} (${lastErr})`);
+    }
+    console.error(
+      '[verify-oidc] A miss here is registry propagation, not a provenance verdict — the publish may be complete; check with npm view. Observed propagation for one package: ~7 min (mmnto-ai/totem#2748).',
+    );
   }
 
   if (failed.length > 0) {
     console.error(
       `[verify-oidc] ${failed.length} package(s) failed provenance check: ${failed.join(', ')}`,
     );
+  }
+
+  if (missing.size > 0 || failed.length > 0) {
     process.exit(1);
   }
 
@@ -184,12 +261,15 @@ const main = async () => {
   );
 };
 
+// Only run main() when executed directly (not when imported by tests).
 // Bare `main()` would leave the hard-throw paths as unhandled rejections.
 // Node 24's default `--unhandled-rejections=throw` makes that exit non-zero
 // today, but a future flag flip or wrapper that downgrades unhandled
 // rejections to warnings would silently let the workflow pass green on a
 // real provenance regression. Make the intent explicit.
-main().catch((err) => {
-  console.error('[verify-oidc] Fatal:', err);
-  process.exit(1);
-});
+if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((err) => {
+    console.error('[verify-oidc] Fatal:', err);
+    process.exit(1);
+  });
+}

--- a/tools/verify-oidc-provenance.test.mjs
+++ b/tools/verify-oidc-provenance.test.mjs
@@ -4,10 +4,12 @@
  * Run: node --test tools/verify-oidc-provenance.test.mjs (root script test:verify-oidc).
  *
  * No npm is ever spawned here: `fetch`, `sleep`, `now`, `exit`, `env` and the
- * spawner itself are injected, and the clock is fake — it advances inside the
- * injected `sleep` AND inside the injected `fetch`, so elapsed time and
- * attempt count are not collinear and a fixed-attempt poller cannot satisfy a
- * deadline assertion by count alone.
+ * spawner itself are injected, and the clock is fake. Two fixture choices do
+ * work: charging the clock inside `fetch` makes it reflect the poll's real
+ * cost rather than its sleeps alone, and `sleep: (ms) => clock.advance(ms)`
+ * advances by the value the poller ASKED for, so a poller that sleeps some
+ * other amount fails. Neither of those is what kills a fixed-attempt poller —
+ * the deadline assertion is.
  */
 
 import assert from 'node:assert/strict';
@@ -144,8 +146,12 @@ const runThreeSpecPoll = () => {
 /** Sentinel thrown by the injected `exit` so `main` stops where process.exit would. */
 const EXIT_SENTINEL = Symbol('process.exit');
 
-/** Drives `main` with an injected clock, exit and env; captures both streams. */
-const runMain = async ({ publishedPackages, fetch }) => {
+/**
+ * Drives `main` with an injected clock, exit and env; captures both streams.
+ * `throwOnExit: false` records the code and lets `main` keep running, which
+ * is how the `return` guarding the fall-through past `exit(1)` gets observed.
+ */
+const runMain = async ({ publishedPackages, fetch, throwOnExit = true }) => {
   const clock = fakeClock();
   const exitCodes = [];
   const stdout = [];
@@ -161,7 +167,7 @@ const runMain = async ({ publishedPackages, fetch }) => {
       now: clock.now,
       exit: (code) => {
         exitCodes.push(code);
-        throw EXIT_SENTINEL;
+        if (throwOnExit) throw EXIT_SENTINEL;
       },
       env: { PUBLISHED_PACKAGES: publishedPackages },
     });
@@ -207,9 +213,12 @@ test('a persistently invisible package is polled until the deadline, not a fixed
     clock.now() >= deadlineMs,
     `poller returned at t=${clock.now()}ms, before the deadline ${deadlineMs}ms`,
   );
+  // Loose on purpose: the clock-vs-deadline assertion above is the
+  // contract-bearing one. A tight deadline/interval count would false-red the
+  // moment the fixture's per-fetch cost grows.
   assert.ok(
-    calls >= Math.floor(deadlineMs / intervalMs),
-    `only ${calls} fetch call(s); expected >= ${Math.floor(deadlineMs / intervalMs)} (deadline / interval)`,
+    calls >= Math.floor(deadlineMs / (intervalMs * 2)),
+    `only ${calls} fetch call(s); expected >= ${Math.floor(deadlineMs / (intervalMs * 2))}`,
   );
   assert.equal(missing.get(SPEC_B), 'E404');
 });
@@ -309,15 +318,32 @@ test("the workflow's outer cap covers the ceiling for every published package", 
     `timeout-minutes: ${timeoutMinutes} (${timeoutMinutes * 60_000}ms) is below the ceiling worstCaseMs(${publishedCount}) = ${worstCaseMs(publishedCount)}ms`,
   );
 
-  // The floor is stated twice — beside the constant and in the workflow
+  // The budget is stated twice — beside the constants and in the workflow
   // comment. Pin the workflow copy so a constant change without the prose
-  // fails CI rather than leaving a stale minute count in the release lane.
+  // fails CI rather than leaving stale arithmetic in the release lane. Each
+  // pin is anchored to ITS OWN line: matching anywhere in the block would let
+  // the CEILING line's "11 min 35 s" satisfy a floor pin for 11 min.
+  const comment = releaseStepComment('Verify OIDC provenance on published packages');
+
+  const floorLine = comment.find((line) => /FLOOR/.test(line));
+  assert.ok(floorLine, "the verify step's comment block has no FLOOR line");
   const floorMinutes = `${VISIBILITY_DEADLINE_MS / 60_000} min`;
   assert.ok(
-    releaseStepComment('Verify OIDC provenance on published packages')
-      .join('\n')
-      .includes(floorMinutes),
-    `the verify step's comment block does not state the floor as ${JSON.stringify(floorMinutes)}`,
+    floorLine.includes(floorMinutes),
+    `the FLOOR line must state ${JSON.stringify(floorMinutes)}; got: ${floorLine.trim()}`,
+  );
+
+  const ceilingLine = comment.find((line) => /CEILING/.test(line));
+  assert.ok(ceilingLine, "the verify step's comment block has no CEILING line");
+  const intervalSeconds = `${POLL_INTERVAL_MS / 1000} s`;
+  const spawnSeconds = `${SPAWN_TIMEOUT_MS / 1000} s`;
+  assert.ok(
+    ceilingLine.includes(intervalSeconds),
+    `the CEILING line must state the poll interval as ${JSON.stringify(intervalSeconds)}; got: ${ceilingLine.trim()}`,
+  );
+  assert.ok(
+    ceilingLine.includes(spawnSeconds),
+    `the CEILING line must state the spawn timeout as ${JSON.stringify(spawnSeconds)}; got: ${ceilingLine.trim()}`,
   );
 });
 
@@ -355,14 +381,18 @@ test('assertProvenance accepts an OIDC-shaped record and rejects a token-auth on
 test('main exits 1 when a package never becomes visible, exits 1 on a token-auth record, and does not exit when every package verifies', async () => {
   const published = `${SPEC_A}\n${SPEC_B}`;
 
+  // Non-throwing exit: `main` runs on past `exit(1)`, so the `return` that
+  // guards the fall-through is what keeps the all-verified line off stdout.
   const miss = await runMain({
     publishedPackages: published,
     fetch: (spec) =>
       spec === SPEC_A ? { ok: true, data: OIDC_RECORD } : { ok: false, err: 'E404' },
+    throwOnExit: false,
   });
   assert.deepEqual(miss.exitCodes, [1], 'a package that never becomes visible must exit 1');
   assert.match(miss.stderr, /never became visible/);
   assert.match(miss.stderr, /registry propagation, not a provenance verdict/);
+  assert.doesNotMatch(miss.stdout, /All \d+ package\(s\) verified/);
 
   const tokenAuth = await runMain({
     publishedPackages: published,
@@ -377,6 +407,40 @@ test('main exits 1 when a package never becomes visible, exits 1 on a token-auth
   });
   assert.deepEqual(allVerified.exitCodes, [], 'a clean run must not exit');
   assert.match(allVerified.stdout, /All 2 package\(s\) verified/);
+});
+
+test('worstCaseMs is a tight upper bound on the poller wall time', async () => {
+  // Worst case: every package burns a full spawn timeout, every round, and
+  // none ever resolves. Bounding from BOTH sides is the point — an
+  // upper-bound-only assertion is satisfied by any overstated formula, so an
+  // understated one (dropping the final interval, say) has to fail too.
+  for (const n of [1, 2, 4, 8]) {
+    const specs = Array.from({ length: n }, (_unused, i) => `@mmnto/pkg-${i}@1.0.0`);
+    const clock = fakeClock();
+
+    await withSilencedConsole(() =>
+      pollUntilVisible(specs, {
+        fetch: () => {
+          clock.advance(SPAWN_TIMEOUT_MS);
+          return { ok: false, err: 'E404' };
+        },
+        sleep: async (ms) => clock.advance(ms),
+        now: clock.now,
+      }),
+    );
+
+    const elapsed = clock.now();
+    const ceiling = worstCaseMs(n);
+    const understated = ceiling - POLL_INTERVAL_MS - n * SPAWN_TIMEOUT_MS;
+    assert.ok(
+      elapsed <= ceiling,
+      `n=${n}: the poll ran ${elapsed}ms, past the ceiling worstCaseMs(${n}) = ${ceiling}ms`,
+    );
+    assert.ok(
+      elapsed > understated,
+      `n=${n}: the poll ran ${elapsed}ms, which a ceiling of ${understated}ms would already cover — worstCaseMs(${n}) = ${ceiling}ms overstates`,
+    );
+  }
 });
 
 test('a timed-out npm view keeps the package pending; a spawn failure still throws', () => {

--- a/tools/verify-oidc-provenance.test.mjs
+++ b/tools/verify-oidc-provenance.test.mjs
@@ -1,0 +1,268 @@
+/**
+ * Tests for the OIDC provenance verifier's visibility budget and the release
+ * workflow contract that caps it (mmnto-ai/totem#2748).
+ * Run: node --test tools/verify-oidc-provenance.test.mjs (root script test:verify-oidc).
+ *
+ * No npm is ever spawned here: `fetch`, `sleep` and `now` are injected, and
+ * the clock is fake — `sleep` advances it by the poll interval.
+ */
+
+import assert from 'node:assert/strict';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import {
+  assertProvenance,
+  POLL_INTERVAL_MS,
+  pollUntilVisible,
+  VISIBILITY_DEADLINE_MS,
+  worstCaseMs,
+} from './verify-oidc-provenance.mjs';
+
+const repoRoot = fileURLToPath(new URL('../', import.meta.url));
+const readRepoFile = (...rel) => readFileSync(join(repoRoot, ...rel), 'utf-8');
+
+/** Fake clock: `now()` reads it, `advance()` moves it. Nothing here sleeps for real. */
+const fakeClock = () => {
+  let t = 0;
+  return {
+    now: () => t,
+    advance: (ms) => {
+      t += ms;
+    },
+  };
+};
+
+/** The poller logs one line per round; keep the test output readable. */
+const withSilencedConsole = async (fn) => {
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = () => {};
+  console.error = () => {};
+  try {
+    return await fn();
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+};
+
+/**
+ * Reads the block of lines belonging to one `- name: <stepName>` step in
+ * .github/workflows/release.yml (up to the next `- name:`/`- uses:`/`- run:`).
+ */
+const releaseStepLines = (stepName) => {
+  const lines = readRepoFile('.github', 'workflows', 'release.yml').split(/\r?\n/);
+  const start = lines.findIndex((line) => line.includes(`name: ${stepName}`));
+  assert.notEqual(start, -1, `release.yml has no step named ${JSON.stringify(stepName)}`);
+  const block = [];
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^\s*-\s+(name|uses|run):/.test(lines[i])) break;
+    block.push(lines[i]);
+  }
+  return block;
+};
+
+const SPEC_A = '@mmnto/cli@1.124.0';
+const SPEC_B = '@mmnto/totem@1.124.0';
+const SPEC_C = '@mmnto/mcp@1.124.0';
+
+/**
+ * One shared three-package poll: A visible in round 1, B in round 3, C never.
+ * T3 and T4 both read its call log, so it runs once and is memoised.
+ */
+let threeSpecRun = null;
+const runThreeSpecPoll = () => {
+  threeSpecRun ??= withSilencedConsole(async () => {
+    const clock = fakeClock();
+    const callLog = [];
+    let round = 1;
+    const fetch = (spec) => {
+      callLog.push({ round, spec });
+      if (spec === SPEC_A) return { ok: true, data: { spec: SPEC_A } };
+      if (spec === SPEC_B && round >= 3) return { ok: true, data: { spec: SPEC_B } };
+      return { ok: false, err: `E404 ${spec}` };
+    };
+    const sleep = async () => {
+      round += 1;
+      clock.advance(POLL_INTERVAL_MS);
+    };
+    const { resolved, missing } = await pollUntilVisible([SPEC_A, SPEC_B, SPEC_C], {
+      fetch,
+      sleep,
+      now: clock.now,
+    });
+    return { resolved, missing, callLog };
+  });
+  return threeSpecRun;
+};
+
+test('deadline covers the measured 7-minute propagation', () => {
+  assert.ok(
+    VISIBILITY_DEADLINE_MS >= 7 * 60_000,
+    `VISIBILITY_DEADLINE_MS = ${VISIBILITY_DEADLINE_MS}ms, expected >= ${7 * 60_000}ms (mmnto-ai/totem#2748 measured 6m57s)`,
+  );
+});
+
+test('a persistently invisible package is polled until the deadline, not a fixed attempt count', async () => {
+  const clock = fakeClock();
+  const deadlineMs = VISIBILITY_DEADLINE_MS;
+  const intervalMs = POLL_INTERVAL_MS;
+  let calls = 0;
+
+  const { resolved, missing } = await withSilencedConsole(() =>
+    pollUntilVisible([SPEC_B], {
+      fetch: () => {
+        calls += 1;
+        return { ok: false, err: 'E404' };
+      },
+      sleep: async () => clock.advance(intervalMs),
+      now: clock.now,
+      deadlineMs,
+      intervalMs,
+    }),
+  );
+
+  assert.equal(resolved.size, 0);
+  assert.ok(
+    clock.now() >= deadlineMs,
+    `poller returned at t=${clock.now()}ms, before the deadline ${deadlineMs}ms`,
+  );
+  assert.ok(
+    calls >= Math.floor(deadlineMs / intervalMs),
+    `only ${calls} fetch call(s); expected >= ${Math.floor(deadlineMs / intervalMs)} (deadline / interval)`,
+  );
+  assert.equal(missing.get(SPEC_B), 'E404');
+});
+
+test('all packages are polled before failing; one slow package does not hide the others', async () => {
+  const { resolved, missing, callLog } = await runThreeSpecPoll();
+
+  assert.deepEqual([...resolved.keys()], [SPEC_A, SPEC_B]);
+  assert.deepEqual(resolved.get(SPEC_A), { spec: SPEC_A });
+  assert.deepEqual(resolved.get(SPEC_B), { spec: SPEC_B });
+  assert.deepEqual([...missing.keys()], [SPEC_C]);
+  assert.equal(missing.get(SPEC_C), `E404 ${SPEC_C}`);
+
+  // Every round fetches exactly the specs still pending when it starts, in
+  // input order: A drops out after round 1, B after round 3, C never — so
+  // rounds 4..N (the deadline decides N) poll C alone.
+  const byRound = new Map();
+  for (const { round, spec } of callLog) {
+    if (!byRound.has(round)) byRound.set(round, []);
+    byRound.get(round).push(spec);
+  }
+  const rounds = [...byRound.keys()];
+  assert.deepEqual(
+    rounds,
+    Array.from({ length: rounds.length }, (_unused, i) => i + 1),
+    'rounds must be contiguous from 1',
+  );
+  assert.ok(rounds.length >= 3, `only ${rounds.length} round(s); B resolves in round 3`);
+  assert.deepEqual(byRound.get(1), [SPEC_A, SPEC_B, SPEC_C]);
+  assert.deepEqual(byRound.get(2), [SPEC_B, SPEC_C]);
+  assert.deepEqual(byRound.get(3), [SPEC_B, SPEC_C]);
+  for (const round of rounds.slice(3)) {
+    assert.deepEqual(byRound.get(round), [SPEC_C], `round ${round} must poll only ${SPEC_C}`);
+  }
+});
+
+test('a resolved package is not fetched again', async () => {
+  const { callLog } = await runThreeSpecPoll();
+  assert.equal(
+    callLog.filter((call) => call.spec === SPEC_A).length,
+    1,
+    `${SPEC_A} resolved in round 1 and must never be fetched again`,
+  );
+});
+
+test('a throwing fetch propagates (hard failures stay loud)', async () => {
+  await assert.rejects(
+    () =>
+      withSilencedConsole(() =>
+        pollUntilVisible([SPEC_A], {
+          fetch: () => {
+            throw new Error('[Totem Error] verify-oidc: npm view spawn failed');
+          },
+          sleep: async () => {},
+          now: () => 0,
+        }),
+      ),
+    /npm view spawn failed/,
+  );
+});
+
+test("the workflow's outer cap covers the ceiling for every published package", () => {
+  const block = releaseStepLines('Verify OIDC provenance on published packages');
+  const timeoutLine = block.find((line) => /^\s*timeout-minutes:\s*\d+\s*$/.test(line));
+  assert.ok(timeoutLine, 'the verify step has no timeout-minutes');
+  const timeoutMinutes = Number(timeoutLine.match(/timeout-minutes:\s*(\d+)/)[1]);
+
+  const packagesDir = join(repoRoot, 'packages');
+  const publishedCount = readdirSync(packagesDir)
+    .map((name) => join(packagesDir, name, 'package.json'))
+    .filter((manifest) => {
+      try {
+        return statSync(manifest).isFile();
+      } catch {
+        return false;
+      }
+    })
+    .filter((manifest) => JSON.parse(readFileSync(manifest, 'utf-8')).private !== true).length;
+
+  assert.ok(publishedCount >= 1, 'no publishable packages found under packages/');
+  assert.ok(
+    timeoutMinutes * 60_000 >= worstCaseMs(publishedCount),
+    `timeout-minutes: ${timeoutMinutes} (${timeoutMinutes * 60_000}ms) is below the ceiling worstCaseMs(${publishedCount}) = ${worstCaseMs(publishedCount)}ms`,
+  );
+});
+
+test('the tag push rides the publish verdict, not the verify verdict', () => {
+  const block = releaseStepLines('Push release tags');
+  const ifLine = block.find((line) => /^\s*if:/.test(line));
+  assert.ok(ifLine, 'the Push release tags step has no if: condition');
+  assert.match(ifLine, /!cancelled\(\)/);
+  assert.ok(
+    ifLine.includes("steps.publish.outputs.published == 'true'"),
+    `the tag push must gate on the publish output; got: ${ifLine.trim()}`,
+  );
+  assert.ok(
+    !ifLine.includes('steps.verify'),
+    `the tag push must not gate on the verify step; got: ${ifLine.trim()}`,
+  );
+  assert.ok(
+    !ifLine.includes('success()'),
+    `success() would re-couple the tag push to every prior step; got: ${ifLine.trim()}`,
+  );
+});
+
+test('assertProvenance accepts an OIDC-shaped record and rejects a token-auth one', () => {
+  const oidc = {
+    _npmUser: 'GitHub Actions <npm-oidc-no-reply@github.com>',
+    dist: {
+      attestations: {
+        url: 'https://registry.npmjs.org/-/npm/v1/attestations/@mmnto%2fcli@1.124.0',
+        provenance: { predicateType: 'https://slsa.dev/provenance/v1' },
+      },
+      signatures: [{ keyid: 'SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA', sig: 'MEUCIQ' }],
+    },
+  };
+  const tokenAuth = {
+    _npmUser: 'someone <dev@example.com>',
+    dist: { signatures: oidc.dist.signatures },
+  };
+
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = () => {};
+  console.error = () => {};
+  try {
+    assert.equal(assertProvenance(SPEC_A, oidc), true);
+    assert.equal(assertProvenance(SPEC_A, tokenAuth), false);
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+});

--- a/tools/verify-oidc-provenance.test.mjs
+++ b/tools/verify-oidc-provenance.test.mjs
@@ -3,8 +3,11 @@
  * workflow contract that caps it (mmnto-ai/totem#2748).
  * Run: node --test tools/verify-oidc-provenance.test.mjs (root script test:verify-oidc).
  *
- * No npm is ever spawned here: `fetch`, `sleep` and `now` are injected, and
- * the clock is fake — `sleep` advances it by the poll interval.
+ * No npm is ever spawned here: `fetch`, `sleep`, `now`, `exit`, `env` and the
+ * spawner itself are injected, and the clock is fake — it advances inside the
+ * injected `sleep` AND inside the injected `fetch`, so elapsed time and
+ * attempt count are not collinear and a fixed-attempt poller cannot satisfy a
+ * deadline assertion by count alone.
  */
 
 import assert from 'node:assert/strict';
@@ -15,8 +18,11 @@ import { fileURLToPath } from 'node:url';
 
 import {
   assertProvenance,
+  fetchNpmView,
+  main,
   POLL_INTERVAL_MS,
   pollUntilVisible,
+  SPAWN_TIMEOUT_MS,
   VISIBILITY_DEADLINE_MS,
   worstCaseMs,
 } from './verify-oidc-provenance.mjs';
@@ -49,29 +55,64 @@ const withSilencedConsole = async (fn) => {
   }
 };
 
-/**
- * Reads the block of lines belonging to one `- name: <stepName>` step in
- * .github/workflows/release.yml (up to the next `- name:`/`- uses:`/`- run:`).
- */
-const releaseStepLines = (stepName) => {
-  const lines = readRepoFile('.github', 'workflows', 'release.yml').split(/\r?\n/);
+const releaseYamlLines = () => readRepoFile('.github', 'workflows', 'release.yml').split(/\r?\n/);
+
+const releaseStepIndex = (lines, stepName) => {
   const start = lines.findIndex((line) => line.includes(`name: ${stepName}`));
   assert.notEqual(start, -1, `release.yml has no step named ${JSON.stringify(stepName)}`);
+  return start;
+};
+
+/**
+ * The lines belonging to one `- name: <stepName>` step in release.yml (up to
+ * the next `- name:`/`- uses:`/`- run:`).
+ */
+const releaseStepLines = (stepName) => {
+  const lines = releaseYamlLines();
   const block = [];
-  for (let i = start + 1; i < lines.length; i++) {
+  for (let i = releaseStepIndex(lines, stepName) + 1; i < lines.length; i++) {
     if (/^\s*-\s+(name|uses|run):/.test(lines[i])) break;
     block.push(lines[i]);
   }
   return block;
 };
 
+/** The contiguous `#` comment block directly above a step. */
+const releaseStepComment = (stepName) => {
+  const lines = releaseYamlLines();
+  const comment = [];
+  for (let i = releaseStepIndex(lines, stepName) - 1; i >= 0; i--) {
+    if (!/^\s*#/.test(lines[i])) break;
+    comment.unshift(lines[i]);
+  }
+  return comment;
+};
+
 const SPEC_A = '@mmnto/cli@1.124.0';
 const SPEC_B = '@mmnto/totem@1.124.0';
 const SPEC_C = '@mmnto/mcp@1.124.0';
 
+const OIDC_RECORD = {
+  _npmUser: 'GitHub Actions <npm-oidc-no-reply@github.com>',
+  dist: {
+    attestations: {
+      url: 'https://registry.npmjs.org/-/npm/v1/attestations/@mmnto%2fcli@1.124.0',
+      provenance: { predicateType: 'https://slsa.dev/provenance/v1' },
+    },
+    signatures: [{ keyid: 'SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA', sig: 'MEUCIQ' }],
+  },
+};
+
+/** The same record with a human publisher and no attestations — token auth. */
+const TOKEN_AUTH_RECORD = {
+  _npmUser: 'someone <dev@example.com>',
+  dist: { signatures: OIDC_RECORD.dist.signatures },
+};
+
 /**
  * One shared three-package poll: A visible in round 1, B in round 3, C never.
- * T3 and T4 both read its call log, so it runs once and is memoised.
+ * T3 and T4 both read its call log, so it runs once and is memoised. The
+ * poller is called on its shipped defaults (no deadlineMs/intervalMs).
  */
 let threeSpecRun = null;
 const runThreeSpecPoll = () => {
@@ -81,22 +122,56 @@ const runThreeSpecPoll = () => {
     let round = 1;
     const fetch = (spec) => {
       callLog.push({ round, spec });
+      clock.advance(500);
       if (spec === SPEC_A) return { ok: true, data: { spec: SPEC_A } };
       if (spec === SPEC_B && round >= 3) return { ok: true, data: { spec: SPEC_B } };
       return { ok: false, err: `E404 ${spec}` };
     };
-    const sleep = async () => {
+    const sleep = async (ms) => {
       round += 1;
-      clock.advance(POLL_INTERVAL_MS);
+      clock.advance(ms);
     };
     const { resolved, missing } = await pollUntilVisible([SPEC_A, SPEC_B, SPEC_C], {
       fetch,
       sleep,
       now: clock.now,
     });
-    return { resolved, missing, callLog };
+    return { resolved, missing, callLog, clock };
   });
   return threeSpecRun;
+};
+
+/** Sentinel thrown by the injected `exit` so `main` stops where process.exit would. */
+const EXIT_SENTINEL = Symbol('process.exit');
+
+/** Drives `main` with an injected clock, exit and env; captures both streams. */
+const runMain = async ({ publishedPackages, fetch }) => {
+  const clock = fakeClock();
+  const exitCodes = [];
+  const stdout = [];
+  const stderr = [];
+  const originalLog = console.log;
+  const originalError = console.error;
+  console.log = (...args) => stdout.push(args.map(String).join(' '));
+  console.error = (...args) => stderr.push(args.map(String).join(' '));
+  try {
+    await main({
+      fetch,
+      sleep: async (ms) => clock.advance(ms),
+      now: clock.now,
+      exit: (code) => {
+        exitCodes.push(code);
+        throw EXIT_SENTINEL;
+      },
+      env: { PUBLISHED_PACKAGES: publishedPackages },
+    });
+  } catch (err) {
+    if (err !== EXIT_SENTINEL) throw err;
+  } finally {
+    console.log = originalLog;
+    console.error = originalError;
+  }
+  return { exitCodes, stdout: stdout.join('\n'), stderr: stderr.join('\n') };
 };
 
 test('deadline covers the measured 7-minute propagation', () => {
@@ -108,6 +183,9 @@ test('deadline covers the measured 7-minute propagation', () => {
 
 test('a persistently invisible package is polled until the deadline, not a fixed attempt count', async () => {
   const clock = fakeClock();
+  // Local mirrors of the shipped defaults, for the assertions only: the
+  // poller below is called WITHOUT deadlineMs/intervalMs, so what runs is the
+  // default budget the release workflow actually gets.
   const deadlineMs = VISIBILITY_DEADLINE_MS;
   const intervalMs = POLL_INTERVAL_MS;
   let calls = 0;
@@ -116,12 +194,11 @@ test('a persistently invisible package is polled until the deadline, not a fixed
     pollUntilVisible([SPEC_B], {
       fetch: () => {
         calls += 1;
+        clock.advance(500);
         return { ok: false, err: 'E404' };
       },
-      sleep: async () => clock.advance(intervalMs),
+      sleep: async (ms) => clock.advance(ms),
       now: clock.now,
-      deadlineMs,
-      intervalMs,
     }),
   );
 
@@ -138,13 +215,20 @@ test('a persistently invisible package is polled until the deadline, not a fixed
 });
 
 test('all packages are polled before failing; one slow package does not hide the others', async () => {
-  const { resolved, missing, callLog } = await runThreeSpecPoll();
+  const { resolved, missing, callLog, clock } = await runThreeSpecPoll();
 
   assert.deepEqual([...resolved.keys()], [SPEC_A, SPEC_B]);
   assert.deepEqual(resolved.get(SPEC_A), { spec: SPEC_A });
   assert.deepEqual(resolved.get(SPEC_B), { spec: SPEC_B });
   assert.deepEqual([...missing.keys()], [SPEC_C]);
   assert.equal(missing.get(SPEC_C), `E404 ${SPEC_C}`);
+
+  // C never resolves, so a poll on the shipped defaults runs to the default
+  // deadline — the constant the workflow ships is what this exercises.
+  assert.ok(
+    clock.now() >= VISIBILITY_DEADLINE_MS,
+    `poll returned at t=${clock.now()}ms, before the default deadline ${VISIBILITY_DEADLINE_MS}ms`,
+  );
 
   // Every round fetches exactly the specs still pending when it starts, in
   // input order: A drops out after round 1, B after round 3, C never — so
@@ -196,6 +280,13 @@ test('a throwing fetch propagates (hard failures stay loud)', async () => {
 
 test("the workflow's outer cap covers the ceiling for every published package", () => {
   const block = releaseStepLines('Verify OIDC provenance on published packages');
+
+  // The cap must sit on the step that actually runs the poller.
+  assert.ok(
+    block.some((line) => line.includes('run: node tools/verify-oidc-provenance.mjs')),
+    'the located step does not run tools/verify-oidc-provenance.mjs',
+  );
+
   const timeoutLine = block.find((line) => /^\s*timeout-minutes:\s*\d+\s*$/.test(line));
   assert.ok(timeoutLine, 'the verify step has no timeout-minutes');
   const timeoutMinutes = Number(timeoutLine.match(/timeout-minutes:\s*(\d+)/)[1]);
@@ -217,17 +308,26 @@ test("the workflow's outer cap covers the ceiling for every published package", 
     timeoutMinutes * 60_000 >= worstCaseMs(publishedCount),
     `timeout-minutes: ${timeoutMinutes} (${timeoutMinutes * 60_000}ms) is below the ceiling worstCaseMs(${publishedCount}) = ${worstCaseMs(publishedCount)}ms`,
   );
+
+  // The floor is stated twice — beside the constant and in the workflow
+  // comment. Pin the workflow copy so a constant change without the prose
+  // fails CI rather than leaving a stale minute count in the release lane.
+  const floorMinutes = `${VISIBILITY_DEADLINE_MS / 60_000} min`;
+  assert.ok(
+    releaseStepComment('Verify OIDC provenance on published packages')
+      .join('\n')
+      .includes(floorMinutes),
+    `the verify step's comment block does not state the floor as ${JSON.stringify(floorMinutes)}`,
+  );
 });
 
 test('the tag push rides the publish verdict, not the verify verdict', () => {
   const block = releaseStepLines('Push release tags');
   const ifLine = block.find((line) => /^\s*if:/.test(line));
   assert.ok(ifLine, 'the Push release tags step has no if: condition');
-  assert.match(ifLine, /!cancelled\(\)/);
-  assert.ok(
-    ifLine.includes("steps.publish.outputs.published == 'true'"),
-    `the tag push must gate on the publish output; got: ${ifLine.trim()}`,
-  );
+  // Conjunction, not disjunction: an `||` mutant would still contain both
+  // operands as substrings, so match the whole relation.
+  assert.match(ifLine, /!cancelled\(\)\s*&&\s*steps\.publish\.outputs\.published\s*==\s*'true'/);
   assert.ok(
     !ifLine.includes('steps.verify'),
     `the tag push must not gate on the verify step; got: ${ifLine.trim()}`,
@@ -239,30 +339,52 @@ test('the tag push rides the publish verdict, not the verify verdict', () => {
 });
 
 test('assertProvenance accepts an OIDC-shaped record and rejects a token-auth one', () => {
-  const oidc = {
-    _npmUser: 'GitHub Actions <npm-oidc-no-reply@github.com>',
-    dist: {
-      attestations: {
-        url: 'https://registry.npmjs.org/-/npm/v1/attestations/@mmnto%2fcli@1.124.0',
-        provenance: { predicateType: 'https://slsa.dev/provenance/v1' },
-      },
-      signatures: [{ keyid: 'SHA256:jl3bwswu80PjjokCgh0o2w5c2U4LhQAE57gj9cz1kzA', sig: 'MEUCIQ' }],
-    },
-  };
-  const tokenAuth = {
-    _npmUser: 'someone <dev@example.com>',
-    dist: { signatures: oidc.dist.signatures },
-  };
-
   const originalLog = console.log;
   const originalError = console.error;
   console.log = () => {};
   console.error = () => {};
   try {
-    assert.equal(assertProvenance(SPEC_A, oidc), true);
-    assert.equal(assertProvenance(SPEC_A, tokenAuth), false);
+    assert.equal(assertProvenance(SPEC_A, OIDC_RECORD), true);
+    assert.equal(assertProvenance(SPEC_A, TOKEN_AUTH_RECORD), false);
   } finally {
     console.log = originalLog;
     console.error = originalError;
   }
+});
+
+test('main exits 1 when a package never becomes visible, exits 1 on a token-auth record, and does not exit when every package verifies', async () => {
+  const published = `${SPEC_A}\n${SPEC_B}`;
+
+  const miss = await runMain({
+    publishedPackages: published,
+    fetch: (spec) =>
+      spec === SPEC_A ? { ok: true, data: OIDC_RECORD } : { ok: false, err: 'E404' },
+  });
+  assert.deepEqual(miss.exitCodes, [1], 'a package that never becomes visible must exit 1');
+  assert.match(miss.stderr, /never became visible/);
+  assert.match(miss.stderr, /registry propagation, not a provenance verdict/);
+
+  const tokenAuth = await runMain({
+    publishedPackages: published,
+    fetch: (spec) => ({ ok: true, data: spec === SPEC_A ? OIDC_RECORD : TOKEN_AUTH_RECORD }),
+  });
+  assert.deepEqual(tokenAuth.exitCodes, [1], 'a token-auth record must exit 1');
+  assert.match(tokenAuth.stderr, /failed provenance check/);
+
+  const allVerified = await runMain({
+    publishedPackages: published,
+    fetch: () => ({ ok: true, data: OIDC_RECORD }),
+  });
+  assert.deepEqual(allVerified.exitCodes, [], 'a clean run must not exit');
+  assert.match(allVerified.stdout, /All 2 package\(s\) verified/);
+});
+
+test('a timed-out npm view keeps the package pending; a spawn failure still throws', () => {
+  const timedOut = () => ({ error: Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' }) });
+  const result = fetchNpmView(SPEC_A, timedOut);
+  assert.equal(result.ok, false);
+  assert.equal(result.err, `npm view timed out after ${SPAWN_TIMEOUT_MS}ms`);
+
+  const enoent = () => ({ error: Object.assign(new Error('nope'), { code: 'ENOENT' }) });
+  assert.throws(() => fetchNpmView(SPEC_A, enoent), /npm view spawn failed/);
 });


### PR DESCRIPTION
Closes #2748 <!-- totem-close: #2748 -->

**The break.** The release workflow's OIDC-provenance verify step gave a just-published package five `npm view` attempts separated by 5 s sleeps — about 20 s of waiting (the step ran 21 s) — against a registry that made `@mmnto/totem` visible 2 min 20 s after the step had given up on the 1.123.0 cut and 5 min 45 s after the step started (6 min 57 s after the merge) on the 1.124.0 cut, with a per-package spread inside one publish of 0:56 to 6:57. Both cuts went RED after a complete publish, and because `Push release tags` ran after the verify step, the floating `v0` action-pin tag was left behind both times.

**Cure 1 — an honest visibility budget.** `tools/verify-oidc-provenance.mjs` now polls every still-pending package once per round (15 s apart) until a 10-minute deadline, so one slow package cannot hide the others; a resolved package is never fetched again; misses are collected and reported together with a line saying a miss is registry propagation, not a provenance verdict. A `spawnSync` timeout (`ETIMEDOUT`) keeps the package pending instead of aborting the poll; any other spawn failure still throws. Floor = 10 min for a package that stays invisible; ceiling = `worstCaseMs(n) = deadline + one poll interval + n × spawn timeout` (≈ 11 min 35 s for the four packages); the workflow's `timeout-minutes: 13` is the outer cap, and the test pins the cap ≥ the ceiling, the floor and ceiling prose to the constants, and the ceiling formula from both sides by simulation.

**Cure 2 — `v0` rides the publish verdict.** `Push release tags` now runs on `!cancelled() && steps.publish.outputs.published == 'true'`: a verify failure still fails the job, but the tags the publish already created are pushed. Disclosed tradeoff: `v0` also advances after a genuine provenance-regression failure; accepted because `action.yml` runs the CLI unpinned, so `v0` pins only the composite action source.

**Tests.** `tools/verify-oidc-provenance.test.mjs` (11 cases, `node --test`, no npm spawn; wired as `pnpm test:verify-oidc` in the CI `build` job on all three OSes): deadline ≥ the measured 7 min; a persistently invisible package polled to the deadline on the shipped defaults; all packages polled before failing; no re-fetch; hard failures propagate; a timed-out view stays pending; `main` exits 1 on a miss and on a token-auth record and not when all verify (fail-loud fall-through observed); the workflow cap covers the ceiling for every published package, the cap is pinned to the step that runs the poller, and the FLOOR/CEILING comment lines state the constants; the tag-push condition is the conjunction. Mutation checks that all bite: cap 13 → 4; FLOOR prose 10 → 9 min; `&&` → `||`; `worstCaseMs` reverted to the pre-fold formula; deadline 10 → 11 min with the workflow untouched.

**Review of record.** Owner-verified diff at each commit. Falsification leg over the slice (`fbe3b294`): 0 BLOCKING · 5 MATERIAL · 8 MINOR — all five material folded in `6212b322` (the ceiling omitted one interval; the default deadline was never exercised on the shipped call path; `main`'s fail-loud arm untested and newly conditional; the tag-push regex admitted `||`; a spawn timeout aborted the whole poll). Re-armed leg scoped to that fold: 0 · 2 · 8 — both material folded in `2054b0c3` (the floor-prose pin collided with the ceiling line's substring; the ceiling was pinned only downward); the ladder terminates there (test-only fold). Declined/noted: the release lane's concurrency window widens from ~4 to ~13 min on the slow path (no `cancel-in-progress`; publish is version-idempotent); the "6 min 57 s" figure is the issue's truncated delta (6:57.7); the T7 regex is order-sensitive by design.

**Gate.** `pnpm -r build`; prettier check repo-wide; `pnpm lint`; `totem lint` (post-commit, branch scope) PASS 0 errors; the full `pnpm test` with `GIT_CONFIG_GLOBAL` + `GIT_CONFIG_SYSTEM` masked (`init.defaultBranch` unset → `master`, the runners' default) and `TEMP`/`TMP` on a fresh empty directory: 12/12 tasks, every package green. Environmental note for the next seat on this workstation: with the real `%TEMP%` (hundreds of thousands of files) two `estate-scan.test.ts` cases time out at 30 s under full-suite load, reproducibly on an unmodified base; not this change.

**No changeset:** no published package changes (tools + workflow only). Bots: none invoked (operator-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015M6AwdHorDacnmh4MQQgn5
