### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine to 0.1.42 — freeze unchanged; distributes the legs-gate parity row (attestation; totem = neither arm, adoption owed), the gate clause's two-arm rendering (overlay § 5) and Project 2's gh-project-vocabulary adoption

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   },
   "optionalDependencies": {
     "@mmnto/cli": "workspace:*",
-    "@mmnto/strategy-doctrine": "0.1.41"
+    "@mmnto/strategy-doctrine": "0.1.42"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.41
-        version: 0.1.41
+        specifier: 0.1.42
+        version: 0.1.42
 
   packages/cli:
     dependencies:
@@ -862,8 +862,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.41':
-    resolution: {integrity: sha512-koSKhRIkreVpoI7hMvpQkBfGEIQvDFUJowLNKV/M/7rTxVZZ1vuvTpzUql/zR1S3QXnDBqfahaiUCs+3k4z/Wg==}
+  '@mmnto/strategy-doctrine@0.1.42':
+    resolution: {integrity: sha512-X87A/ATxEeQaGXbpWedI5A5y4onZIKw0qH5XQQJIJ4ModYcjzTWM6mYUAWRT9QjjPqiGV5JeQtFNp2fLFyO/MQ==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3694,7 +3694,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.41':
+  '@mmnto/strategy-doctrine@0.1.42':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
## Bump `@mmnto/strategy-doctrine` 0.1.41 → 0.1.42 — freeze unchanged; distributes the legs-gate parity row, the gate clause's two-arm rendering (overlay § 5) and Project 2's vocabulary adoption

## Mechanical Root Cause

The doctrine floor moved: 0.1.42 was cut today (strategy tag `strategy-doctrine-v0.1.42` at `7cf1b6a9`, OIDC publish run 33909829256, PATCH; content from the 0.1.42 batch mmnto-ai/totem-strategy#1221, released by mmnto-ai/totem-strategy#1223). The cohort-pin read on this repo stays at 0.1.41 until this merges. Nothing published by this repo pins the doctrine package — it is a root `optionalDependencies` entry — so this bump moves only this repo's own freeze, parity and orient reads. The 2.0.0 cut (mmnto-ai/totem#2762 → `594c4a8b`) shipped with the pin at 0.1.41 by the operator's sequence (cut, then pin); strategy-claude's dispatch of 19:12Z states nothing in 2.0.0 needs 0.1.42.

## Fix Applied

One line in the root `package.json` (`optionalDependencies` `@mmnto/strategy-doctrine` `0.1.41` → `0.1.42`) and the resulting `pnpm-lock.yaml` delta. The same two-file shape as mmnto-ai/totem#2749 (0.1.41), mmnto-ai/totem#2721 (0.1.40) and mmnto-ai/totem#2709 (0.1.39). The lockfile carries the 0.1.42 entry with its integrity hash and `node_modules` resolves 0.1.42 — checked explicitly, because a failed restricted-registry fetch drops an optional dependency silently (mmnto-ai/totem#630).

**Installed-pack diff (0.1.41 in the resident vs 0.1.42 in this branch's worktree; six files, four differ):**

- `freeze.json` — **byte-identical** (the `rule-compilation` hold since 2026-05-17; the local mirror `.totem/freeze.json` needs no change).
- `cohort-overlay.md` — two lines. The § 5 heading gains `CI arm 2026-09-03`; the gate paragraph replaces "From the `@mmnto/cli` cut that ships the mechanism — unreleased at this rendering" with "Since `@mmnto/cli` 1.123.0" and now renders enforcement as two arms over the same evidence, a repo adopting one, with each arm's reach disclosed (the strict tier blocks the push; the CI arm turns a pull request's check red where the workflow triggers, and branch protection decides whether red blocks).
- `parity-manifest.yaml` — 42 lines. One new row, `legs-gate` (dimension enforcement; tractability mechanical, manifestation attestation until the doctor carries a workflow reader, mmnto-ai/totem#2697; tracking mmnto-ai/totem#2698). Its census of 2026-09-04 reads **totem = neither arm** (its own `tools/pre-push` at tier standard, advisory) — **adoption owed**, which the row itself says reads as owed, never as a deviation ruling. The `gh-project-vocabulary` row's Project 2 note moves from "undecided at this writing" to adopted 2026-09-03, both projects read conforming on 2026-09-04.
- `strategy-doctrine.lock` — version, published instant, content hash and last-published SHA (`8e4da160` → `7cf1b6a9`).

**What the new row does to this repo's gates: nothing yet.** `totem doctor --strict` on this branch renders `legs-gate: SKIP [honest-absent] — enforcement (mechanical) — drift detection not yet implemented for this sub-class`, and `--strict` currently gates nothing (the manifest declares no `blocking: true` contracts). Adopting one arm here (a `totem legs gate` step in the lint workflow plus tracked deposits plus `hooks.legsOwed.globs`, or hooks tier strict) is the carryforward's legs-required adoption slice, on the operator's word — a separate PR, not this bump.

## Verification

In the branch worktree on `594c4a8b` + this change: `pnpm install` (lockfile moved, 0.1.42 resolved); `pnpm build` 6/6; `totem doctor --strict` exit 0 (its one WARN, `knowledge-search-access`, is the worktree's missing `.mcp.json`, not the pin); `totem lint --base main` — no lint-target changes; `prettier --check .` clean; ESLint 3/3; `pnpm test` 12/12 tasks (cli 4611 passed, 20 skipped). No changeset: no published package changes, the same as the three prior bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LM7M3MuvwsqbdEMauLq891
