### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine 0.1.42 → 0.1.44 in one hop — freeze unchanged; distributes the 0.1.43 + 0.1.44 batches (legs-gate census adopted cohort-wide, the enforce knob + reach clauses, agents-skills REQUIRED; the vocabulary row's structured expected-option-sets + grammar pin, the label-canon origin-keyed disclosure)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   },
   "optionalDependencies": {
     "@mmnto/cli": "workspace:*",
-    "@mmnto/strategy-doctrine": "0.1.42"
+    "@mmnto/strategy-doctrine": "0.1.44"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.42
-        version: 0.1.42
+        specifier: 0.1.44
+        version: 0.1.44
 
   packages/cli:
     dependencies:
@@ -862,8 +862,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.42':
-    resolution: {integrity: sha512-X87A/ATxEeQaGXbpWedI5A5y4onZIKw0qH5XQQJIJ4ModYcjzTWM6mYUAWRT9QjjPqiGV5JeQtFNp2fLFyO/MQ==}
+  '@mmnto/strategy-doctrine@0.1.44':
+    resolution: {integrity: sha512-5/dzgUA/cTavqE36bdZKLHigRlTrHIN1zvxzTpem9UbUPnnN2op3aHZJn9IK26ncuo6WrAh4mbBb/X/F0PPXgw==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3694,7 +3694,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.42':
+  '@mmnto/strategy-doctrine@0.1.44':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
## Bump `@mmnto/strategy-doctrine` 0.1.42 → 0.1.44 in one hop — freeze unchanged; distributes the 0.1.43 and 0.1.44 batches

## Mechanical Root Cause

The doctrine floor moved twice before this repo's next pins-only PR opened: 0.1.43 was cut 2026-09-05 (strategy tag `strategy-doctrine-v0.1.43` at `37e73d4d`, publish run 33998758299, PATCH; batches mmnto-ai/totem-strategy#1235, mmnto-ai/totem-strategy#1239, mmnto-ai/totem-strategy#1240; cut mmnto-ai/totem-strategy#1237) and 0.1.44 on 2026-09-06 (tag `strategy-doctrine-v0.1.44` at `26f6bcbe`, run 34009899295, PATCH; batch mmnto-ai/totem-strategy#1250; cut mmnto-ai/totem-strategy#1251). The 0.1.44 broadcast (2026-09-06T03:52Z) supersedes the 0.1.43 bump owed from the 2026-09-05T23:33Z broadcast: bump straight to 0.1.44, one hop. The cohort-pin read on this repo stays at 0.1.42 until this merges. Nothing published by this repo pins the doctrine package — it is a root `optionalDependencies` entry — so this bump moves only this repo's own freeze, parity and orient reads. Per the carryforward it lands ahead of the open Version Packages PR mmnto-ai/totem#2798 (2.2.0).

## Fix Applied

One line in the root `package.json` (`optionalDependencies` `@mmnto/strategy-doctrine` `0.1.42` → `0.1.44`) and the resulting `pnpm-lock.yaml` delta. The same two-file shape as mmnto-ai/totem#2764 (0.1.42), mmnto-ai/totem#2749 (0.1.41) and mmnto-ai/totem#2721 (0.1.40). The lockfile carries the 0.1.44 entry with its integrity hash and `node_modules` resolves 0.1.44 — checked explicitly, because a failed restricted-registry fetch drops an optional dependency silently (mmnto-ai/totem#630).

**Installed-pack diff (0.1.42 in the resident vs 0.1.44 in this branch's worktree; six files, four differ):**

- `freeze.json` — **byte-identical** (`cmp`): the `rule-compilation` hold since 2026-05-17; the local mirror `.totem/freeze.json` needs no change.
- `cohort-overlay.md` — one paragraph (2 diff lines), the § 5 gate clause: the per-arm knob `hooks.legsOwed.enforce` (`block` arms the gate at every tier, `advisory` softens every tier including the CI step; mmnto-ai/totem#2771), the CI arm's reach (`pull_request` only; a `push` trigger is not a firing arm), and the arm's one exemption — the release train identified by its diff through `tools/release-train-shape.sh` (mmnto-ai/totem#2779 / mmnto-ai/totem#2780).
- `parity-manifest.yaml` — 169 diff lines across four rows plus the header. (0.1.44) The header contract for the OPTIONAL `expected-option-sets` field and the `gh-project-vocabulary` row carrying it (Status: seven options; Priority: four) with the pinned prose grammar of `expected-value-or-derivation` as the fallback — the contract the detector shipped in mmnto-ai/totem#2797 reads first; the `gh-issue-label-canon` row's origin-keyed local-read note (local only when the origin slug is exactly `mmnto-ai/totem`, else the contents fetch with the blob sha disclosed). (0.1.43) The `agents-skills` row now lists the four active repos as consumers and REQUIRES `.agents/skills/<name>/SKILL.md` there (absence = adoption owed), with the mechanism gap disclosed — `totem init` writes `.claude/skills/` only until mmnto-ai/totem#2788 — and the doctor's cohort-permits-absence scoping flagged as mmnto-ai/totem#2789; the `legs-gate` row's census reads ADOPTED on all four active repos (totem = arm (a): the `legs gate` step in the lint workflow, tracked deposits, 14 globs, `Totem Lint` required on main — mmnto-ai/totem#2772, the release-train check placed before the gate step by mmnto-ai/totem#2780), detection (a) reworded to the `check-ignore` mechanism rather than the literal re-include line, `last-attested` 2026-09-05.
- `strategy-doctrine.lock` — version, published instant, the two content hashes and `last-published-sha` (`7cf1b6a9` → `26f6bcbe`).

**What the new content does to this repo's gates: nothing new.** `totem doctor --strict` on this branch exits 0 and still gates nothing (the manifest declares no `blocking: true` contracts). The `legs-gate` row stays honest-absent until the doctor carries a workflow reader (mmnto-ai/totem#2697); this repo's CI arm is already live. The `agents-skills` REQUIRED reading and the `.agents` twin writer are separate slices (mmnto-ai/totem#2789, mmnto-ai/totem#2788), not this bump.

## Verification

In the branch worktree on `cdfd4fde` + this change: `pnpm install` (lockfile moved, 0.1.44 resolved, `node_modules/@mmnto/strategy-doctrine/package.json` reads 0.1.44); `pnpm build` 6/6; `pnpm test` 12/12 tasks (cli 173 files, 4697 passed, 20 skipped); `totem doctor --strict` exit 0; `totem doctor --parity` with `TOTEM_STRATEGY_ROOT` set: `@mmnto/strategy-doctrine pin current — installed 0.1.44 ≥ cohort floor 0.1.44`, `packaged freeze.json intact — sha256:4e4d2c85…`, lock matches the local strategy canonical at `26f6bcbe`, and the mmnto-ai/totem#2797 detector now reads the structured field — `gh-project-vocabulary: PASS — mmnto-ai/projects/1: Status 7/7, Priority 4/4 option sets equal the canon (canon: expected-option-sets)` (on main at 0.1.42 the same row reads the prose); `totem lint --base main` — no lint-target changes; `prettier --check .` clean; ESLint 0 errors (8 pre-existing unused-directive warnings, untouched files); the pre-push hook: lockfile-sync PASS, claim-discipline PASS, legs not owed (2 changed files, none of the 14 globs). No changeset: no published package changes, the same as the three prior bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XowHnjJZbWHTgMjGqyCuJF
