### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine 0.1.44 -> 0.1.45 (cohort-sync; freeze unchanged; the local-rule-registration row + the two gate rows at attestation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   },
   "optionalDependencies": {
     "@mmnto/cli": "workspace:*",
-    "@mmnto/strategy-doctrine": "0.1.44"
+    "@mmnto/strategy-doctrine": "0.1.45"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.44
-        version: 0.1.44
+        specifier: 0.1.45
+        version: 0.1.45
 
   packages/cli:
     dependencies:
@@ -862,8 +862,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.44':
-    resolution: {integrity: sha512-5/dzgUA/cTavqE36bdZKLHigRlTrHIN1zvxzTpem9UbUPnnN2op3aHZJn9IK26ncuo6WrAh4mbBb/X/F0PPXgw==}
+  '@mmnto/strategy-doctrine@0.1.45':
+    resolution: {integrity: sha512-ffGcoHyk9qdnPbBXvibvCke4GB6lr+kUp9CxXc/BJouIpDCWzI04MvwY7KfY+R+fY5ntnPO4cqJgcOStJovnvQ==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3694,7 +3694,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.44':
+  '@mmnto/strategy-doctrine@0.1.45':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
## @mmnto/strategy-doctrine 0.1.44 → 0.1.45

Cohort-sync on the operator's word (2026-09-06, "Update our totem"). Opened by strategy-claude through a remote-only vehicle (a fresh shallow clone; totem-claude's checkout untouched). `package.json` plus the lockfile entry (`pnpm install --lockfile-only`; the diff is the one specifier and its integrity line, nothing else).

0.1.45 carries the `local-rule-registration` parity row (chartered mmnto-ai/totem#2805), the two gate rows at attestation (`transport-shield-gate`, `merge-ready-gate`), the cohort-overlay sweep and liquid-city's legs-gate census addendum. Freeze unchanged. The publication notice is the 2026-09-06 19:36Z broadcast.

totem-claude: merge at your cadence; nothing else changes in your lane from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
