### PR TITLE
chore(lessons): eight lessons from mmnto-ai/totem#2821 and mmnto-ai/totem#2827 — the bootstrap lesson's drafted bypass clause corrected to the fail-closed ruling; compile untouched under the freeze

### DIFF
--- a/.totem/lessons/lesson-190cd3ce.md
+++ b/.totem/lessons/lesson-190cd3ce.md
@@ -1,0 +1,6 @@
+## Lesson — Avoid fail-closed hooks during bootstrap
+
+**Tags:** claude-code, dx, bootstrap
+**Scope:** .claude/hooks/gate-wrapper.cjs
+
+Strict pre-tool hooks that fail closed when local dependencies are missing can block the very package installation commands (e.g., `pnpm install`) needed to bootstrap the repository. Give the hook a fallback resolution path (a CLI on PATH evaluating the same gate) so the gate stays evaluable during bootstrap; an applicable gate that cannot be evaluated still fails closed, and the block message must name exits that are not themselves gated.

--- a/.totem/lessons/lesson-32768a05.md
+++ b/.totem/lessons/lesson-32768a05.md
@@ -1,0 +1,6 @@
+## Lesson — Assert exact counts in sync tests
+
+**Tags:** testing, vitest, automation
+**Scope:** packages/cli/src/commands/**/*.test.ts
+
+When testing synchronization scripts, assert the exact set and count of expected mutations derived from the source of truth rather than using weak lower-bound checks. This prevents undetected drift and ensures unauthorized or missing changes are caught immediately.

--- a/.totem/lessons/lesson-38485b0c.md
+++ b/.totem/lessons/lesson-38485b0c.md
@@ -1,0 +1,6 @@
+## Lesson — Keep parser-targeted lines unrefactored
+
+**Tags:** parsing, regex, tooling
+**Scope:** scripts/**/*.ps1
+
+When external tools parse source code files using rigid line-by-line regex, avoid refactoring those lines into loops or helper functions. Keeping the literal, repetitive line shapes intact prevents breaking AST-less parsers that rely on static patterns.

--- a/.totem/lessons/lesson-392a410e.md
+++ b/.totem/lessons/lesson-392a410e.md
@@ -1,0 +1,6 @@
+## Lesson — Use CJS extension for hook scripts
+
+**Tags:** claude-code, node, esm
+**Scope:** .claude/hooks/**/*
+
+Claude Code executes hook scripts using plain `node`, which will fail if the repository uses ESM (`"type": "module"`) and the hook uses CommonJS. Using the `.cjs` extension ensures the script is always executed correctly regardless of the package type.

--- a/.totem/lessons/lesson-48b587fa.md
+++ b/.totem/lessons/lesson-48b587fa.md
@@ -1,0 +1,6 @@
+## Lesson — Shadow executables for dry runs
+
+**Tags:** powershell, testing, dry-run
+**Scope:** scripts/**/*.ps1
+
+In PowerShell scripts, you can implement a safe dry-run (`-WhatIf`) mode by defining a script-scoped function that shadows an external executable (like `gh`). This intercepts and prints commands instead of executing them, without needing to modify the literal command invocations.

--- a/.totem/lessons/lesson-58f33ed6.md
+++ b/.totem/lessons/lesson-58f33ed6.md
@@ -1,0 +1,6 @@
+## Lesson — Avoid environment variable configuration overrides
+
+**Tags:** security, configuration
+**Scope:** .claude/hooks/gate-wrapper.cjs
+
+Relying on environment variables for security-sensitive configurations can lead to silent fail-open vulnerabilities if the environment is manipulated. Bake configurations directly into the invocation arguments to ensure environment immunity.

--- a/.totem/lessons/lesson-6704b2df.md
+++ b/.totem/lessons/lesson-6704b2df.md
@@ -1,0 +1,6 @@
+## Lesson — Check exit status of suppressed commands
+
+**Tags:** powershell, ci-cd, error-handling
+**Scope:** scripts/**/*.ps1
+
+When suppressing stderr (e.g., `2>$null`) to ignore expected errors like resource-already-exists, you must explicitly check the command's exit status or `$LASTEXITCODE`. Otherwise, critical failures like authentication or permission issues will fail silently and report false success.

--- a/.totem/lessons/lesson-ae52bf7c.md
+++ b/.totem/lessons/lesson-ae52bf7c.md
@@ -1,0 +1,6 @@
+## Lesson — Verify PowerShell hook envelope names
+
+**Tags:** claude-code, powershell, testing
+**Scope:** .claude/hooks/gate-wrapper.cjs
+
+The exact payload structure and tool name (e.g., `PowerShell`) for pre-tool hooks should be verified through active observation rather than assumed, as mismatches can cause hooks to silently bypass enforcement.


### PR DESCRIPTION
## Summary

Post-merge lesson extraction for the two merges of 2026-09-07: mmnto-ai/totem#2821 (transport-shield installed on totem) and mmnto-ai/totem#2827 (six issue forms bound to the label canon; `sync-labels.ps1` grows the `disposition:` namespace, `-WhatIf`, and the auth preflight). Eight lessons, written by `totem lesson extract 2821 2827 --yes` at `beaa9886`.

One drafted clause corrected by hand before commit. `lesson-190cd3ce` (fail-closed hooks during bootstrap) proposed "allow bootstrap commands to bypass enforcement". The fail-closed ruling on mmnto-ai/totem#2799 and the mmnto-ai/totem#2822 ask both reject an exemption, so the lesson now says: give the hook a fallback resolution path (a CLI on PATH evaluating the same gate), an applicable gate that cannot be evaluated still fails closed, and the block message must name exits that are not themselves gated.

## What this PR does not do

- No `totem lesson compile` (rule-compilation is under the standing freeze since 2026-05-17; lesson-only manifest staleness warns under the freeze by design).
- No changeset: no package is touched.

## Verification

- The eight files are the extract's output plus the one clause edit above; `git diff --stat` is eight additions under `.totem/lessons/`.
- Push gate: `totem lint`, `format:check`, `verify-manifest` (lesson-only drift warns under the freeze) on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfjHkyuEtTWahKf1eXpQeQ
