### PR TITLE
fix(hooks): session-context's latest-journal pick checks the lexical-newest against the newest write and names the drift — a seat whose names leave the NNNN counter no longer gets a stale entry injected as latest (mmnto-ai/totem#2828)

### DIFF
--- a/.claude/hooks/lib/select-latest-journal.mjs
+++ b/.claude/hooks/lib/select-latest-journal.mjs
@@ -1,0 +1,85 @@
+// [totem] bespoke helper for .claude/hooks/session-context.mjs — the latest-journal
+// pick (mmnto-ai/totem#2828). Pure: takes the journal directory's entries and a
+// stat function, returns the pick and its evidence; the hook renders the banner
+// line and the selection-manifest reasons from it, so the algorithm is testable
+// without spawning the hook.
+//
+// Policy. The signoff skill's `<model>-NNNN-<slug>.md` counter is what makes a
+// lexical sort the recency policy. A seat whose names leave the counter (an HHMM
+// clock prefix — seen 2026-09-06/07) breaks that premise silently, so the lexical
+// pick is checked against the newest WRITE: these files are per-clone and
+// untracked, so mtime is the write instant (the clone/worktree reset that makes
+// mtime unsafe for mail cutoffs, mmnto-ai/totem-strategy#813, never reaches an
+// untracked directory). When the two disagree the newer write is served and the
+// drift is reported. Ties keep the lexical pick.
+//
+// Resilience. A candidate whose stat fails (a dangling symlink, a file removed
+// between readdir and stat, a permission error) is skipped for the mtime
+// comparison and reported by name — one unreadable sibling must never drop the
+// whole journal context (bot round 1 on mmnto-ai/totem#2831). When the lexical
+// pick itself cannot be stat'ed the newest READABLE write is served and the
+// reason says so; that is not naming drift. When nothing can be stat'ed the
+// lexical pick stands and the hook's own read of it decides.
+//
+// @param {string[]} entries directory entries (any extension; `.md` is filtered here)
+// @param {(file: string) => number} statMtimeMs returns mtimeMs for a basename; may throw
+// @returns {null | {
+//   files: string[]; lexicalLatest: string; mtimeLatest: string; latest: string;
+//   drift: boolean; reason: 'lexical' | 'newest-write' | 'lexical-unreadable';
+//   statFailures: Array<{ file: string; message: string }>;
+// }}
+export function selectLatestJournal(entries, statMtimeMs) {
+  const files = [...entries].filter((f) => f.endsWith('.md')).sort().reverse();
+  if (files.length === 0) return null;
+  const lexicalLatest = files[0];
+  let mtimeLatest = null;
+  let newestMtimeMs = -Infinity;
+  const statFailures = [];
+  for (const file of files) {
+    let mtimeMs;
+    try {
+      mtimeMs = statMtimeMs(file);
+    } catch (err) {
+      statFailures.push({ file, message: err && err.message ? err.message : String(err) });
+      continue;
+    }
+    if (typeof mtimeMs === 'number' && Number.isFinite(mtimeMs) && mtimeMs > newestMtimeMs) {
+      newestMtimeMs = mtimeMs;
+      mtimeLatest = file;
+    }
+  }
+  const lexicalUnreadable = statFailures.some((s) => s.file === lexicalLatest);
+  if (mtimeLatest === null) {
+    // Nothing could be stat'ed: the lexical pick stands, the failures are reported.
+    return {
+      files,
+      lexicalLatest,
+      mtimeLatest: lexicalLatest,
+      latest: lexicalLatest,
+      drift: false,
+      reason: 'lexical',
+      statFailures,
+    };
+  }
+  if (lexicalUnreadable) {
+    return {
+      files,
+      lexicalLatest,
+      mtimeLatest,
+      latest: mtimeLatest,
+      drift: false,
+      reason: 'lexical-unreadable',
+      statFailures,
+    };
+  }
+  const drift = mtimeLatest !== lexicalLatest;
+  return {
+    files,
+    lexicalLatest,
+    mtimeLatest,
+    latest: drift ? mtimeLatest : lexicalLatest,
+    drift,
+    reason: drift ? 'newest-write' : 'lexical',
+    statFailures,
+  };
+}

--- a/.claude/hooks/session-context.mjs
+++ b/.claude/hooks/session-context.mjs
@@ -24,6 +24,7 @@ import {
 } from 'node:fs';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
+import { selectLatestJournal } from './lib/select-latest-journal.mjs';
 
 // ─── totem-status sidecar refresh — GH snapshot + obligation store ───
 // (mmnto-ai/totem-status#127: C3 tracked in mmnto-ai/totem#2556, slice-two
@@ -463,27 +464,24 @@ async function buildStaticContext(gitRoot, branch, ticket, records) {
       // mmnto-ai/totem-strategy#813, never reaches an untracked directory).
       // When the two disagree the newer write is served and the drift is
       // named on the banner and in the manifest reason; when they agree
-      // nothing changes. Ties keep the lexical pick.
-      const files = readdirSync(journalDir)
-        .filter((f) => f.endsWith('.md'))
-        .sort()
-        .reverse();
-      if (files.length > 0) {
-        const lexicalLatest = files[0];
-        let mtimeLatest = lexicalLatest;
-        let newestMtimeMs = -Infinity;
-        for (const f of files) {
-          const mtimeMs = statSync(join(journalDir, f)).mtimeMs;
-          if (mtimeMs > newestMtimeMs) {
-            newestMtimeMs = mtimeMs;
-            mtimeLatest = f;
-          }
+      // nothing changes. Ties keep the lexical pick. The algorithm lives in
+      // ./lib/select-latest-journal.mjs so it is unit-tested without spawning
+      // this hook; a sibling whose stat fails is skipped and named there, never
+      // allowed to drop the whole journal block (bot round 1, mmnto-ai/totem#2831).
+      const pick = selectLatestJournal(readdirSync(journalDir), (f) => statSync(join(journalDir, f)).mtimeMs);
+      if (pick) {
+        const { files, lexicalLatest, mtimeLatest, latest, statFailures } = pick;
+        const journalDrift = pick.drift;
+        for (const failure of statFailures) {
+          process.stderr.write(
+            `[session-context] could not stat journal ${failure.file}: ${failure.message} — skipped for the newest-write check\n`,
+          );
         }
-        const journalDrift = mtimeLatest !== lexicalLatest;
-        const latest = journalDrift ? mtimeLatest : lexicalLatest;
         const recencyPolicy = journalDrift
           ? `recency-policy: newest write (${mtimeLatest}); the lexical-newest ${lexicalLatest} is older on disk — names have left the <model>-NNNN counter (mmnto-ai/totem#2828)`
-          : 'recency-policy: latest journal';
+          : pick.reason === 'lexical-unreadable'
+            ? `recency-policy: newest readable write (${latest}); the lexical-newest ${lexicalLatest} could not be stat'ed (see the stderr line)`
+            : 'recency-policy: latest journal';
         if (journalDrift) {
           lines.push(
             `⚠ journal naming drift: the lexical-newest ${lexicalLatest} is older on disk than ${mtimeLatest} — a name has left the <model>-NNNN counter convention (signoff skill step 2); serving the newer write (mmnto-ai/totem#2828)`,

--- a/.claude/hooks/session-context.mjs
+++ b/.claude/hooks/session-context.mjs
@@ -450,12 +450,45 @@ async function buildStaticContext(gitRoot, branch, ticket, records) {
 
   if (journalDir) {
     try {
+      // The signoff skill's filename convention (`<model>-NNNN-<slug>.md`, a
+      // per-seat session counter) is what makes a lexical sort the recency
+      // policy. A seat whose names leave the counter breaks that premise
+      // silently — on 2026-09-06/07 this seat stamped seven journals with an
+      // HHMM clock prefix, `claude-2315-…` out-sorted the later `claude-0132-…`
+      // signoff, four names collided with June counters, and the manifest
+      // attested the wrong pick as `selected` (mmnto-ai/totem#2828). So the
+      // lexical pick is checked against the newest WRITE: these files are
+      // per-clone and untracked, so mtime is the write instant (the
+      // clone/worktree reset that makes mtime unsafe for mail cutoffs,
+      // mmnto-ai/totem-strategy#813, never reaches an untracked directory).
+      // When the two disagree the newer write is served and the drift is
+      // named on the banner and in the manifest reason; when they agree
+      // nothing changes. Ties keep the lexical pick.
       const files = readdirSync(journalDir)
         .filter((f) => f.endsWith('.md'))
         .sort()
         .reverse();
       if (files.length > 0) {
-        const latest = files[0];
+        const lexicalLatest = files[0];
+        let mtimeLatest = lexicalLatest;
+        let newestMtimeMs = -Infinity;
+        for (const f of files) {
+          const mtimeMs = statSync(join(journalDir, f)).mtimeMs;
+          if (mtimeMs > newestMtimeMs) {
+            newestMtimeMs = mtimeMs;
+            mtimeLatest = f;
+          }
+        }
+        const journalDrift = mtimeLatest !== lexicalLatest;
+        const latest = journalDrift ? mtimeLatest : lexicalLatest;
+        const recencyPolicy = journalDrift
+          ? `recency-policy: newest write (${mtimeLatest}); the lexical-newest ${lexicalLatest} is older on disk — names have left the <model>-NNNN counter (mmnto-ai/totem#2828)`
+          : 'recency-policy: latest journal';
+        if (journalDrift) {
+          lines.push(
+            `⚠ journal naming drift: the lexical-newest ${lexicalLatest} is older on disk than ${mtimeLatest} — a name has left the <model>-NNNN counter convention (signoff skill step 2); serving the newer write (mmnto-ai/totem#2828)`,
+          );
+        }
         lines.push(`Latest journal (${journalSourceLabel}): ${latest}`);
         const content = readFileSync(join(journalDir, latest), 'utf-8');
         // Cap was 20 — far below the size of a normal journal entry
@@ -486,17 +519,20 @@ async function buildStaticContext(gitRoot, branch, ticket, records) {
           content,
           disposition: journalTruncated ? 'truncated' : 'selected',
           reason: journalTruncated
-            ? `recency-policy: latest journal; display-cap ${JOURNAL_DISPLAY_LINE_CAP} lines`
-            : 'recency-policy: latest journal, no display-cap cut (the global char slice may still apply — see finalTruncation)',
+            ? `${recencyPolicy}; display-cap ${JOURNAL_DISPLAY_LINE_CAP} lines`
+            : `${recencyPolicy}, no display-cap cut (the global char slice may still apply — see finalTruncation)`,
           ...(journalTruncated && {
             deliveredBytes: Buffer.byteLength(journalLines.join('\n'), 'utf-8'),
           }),
         });
-        for (const f of files.slice(1)) {
+        for (const f of files) {
+          if (f === latest) continue;
           records.push({
             id: `journal/${f}`,
             disposition: 'excluded',
-            reason: 'recency-policy: only latest journal injected',
+            reason: journalDrift
+              ? 'recency-policy: only the newest write injected (naming drift — see the served record)'
+              : 'recency-policy: only latest journal injected',
           });
         }
       }

--- a/packages/cli/src/commands/init.test.ts
+++ b/packages/cli/src/commands/init.test.ts
@@ -3882,6 +3882,17 @@ describe('bespoke .claude/hooks/session-context.mjs stays in lockstep with the t
     // It is the first of two; the stale banner outlived the second registration.
     expect(bespoke()).not.toContain('sole SessionStart entry');
   });
+
+  it('checks the lexical-newest journal against the newest write and names the drift (mmnto-ai/totem#2828)', () => {
+    // The journal read used to serve files[0] of a lexical sort with no
+    // other signal; a seat whose names left the <model>-NNNN counter got a
+    // stale entry injected as "latest". The sensor line and the per-record
+    // manifest reason are the two surfaces a drift now shows on.
+    const source = bespoke();
+    expect(source).toContain('journal naming drift: the lexical-newest');
+    expect(source).toContain('recency-policy: newest write (');
+    expect(source).toContain('only the newest write injected (naming drift');
+  });
 });
 
 describe('Distributed skill constants match source-of-truth (mmnto-ai/totem#1890)', () => {

--- a/packages/cli/src/commands/session-context-journal-select.test.ts
+++ b/packages/cli/src/commands/session-context-journal-select.test.ts
@@ -1,0 +1,148 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// The latest-journal pick of the bespoke SessionStart hook
+// (.claude/hooks/session-context.mjs) lives in .claude/hooks/lib/select-latest-journal.mjs
+// so the algorithm is exercised here without spawning the hook (mmnto-ai/totem#2828;
+// bot round 1 on mmnto-ai/totem#2831 asked for executed behaviour, not source-text
+// locks alone — those stay in init.test.ts). The module is plain ESM JavaScript at the
+// repo root, outside the package's TypeScript program, so it is loaded by URL.
+
+type StatFailure = { file: string; message: string };
+type Pick = {
+  files: string[];
+  lexicalLatest: string;
+  mtimeLatest: string;
+  latest: string;
+  drift: boolean;
+  reason: 'lexical' | 'newest-write' | 'lexical-unreadable';
+  statFailures: StatFailure[];
+};
+type SelectLatestJournal = (
+  entries: string[],
+  statMtimeMs: (file: string) => number,
+) => Pick | null;
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+const helperPath = path.join(repoRoot, '.claude', 'hooks', 'lib', 'select-latest-journal.mjs');
+
+let selectLatestJournal: SelectLatestJournal;
+
+beforeAll(async () => {
+  const mod = (await import(pathToFileURL(helperPath).href)) as {
+    selectLatestJournal: SelectLatestJournal;
+  };
+  selectLatestJournal = mod.selectLatestJournal;
+});
+
+/** A stat function over a fixed mtime table; a missing key throws like fs would. */
+function statOf(table: Record<string, number>): (file: string) => number {
+  return (file) => {
+    if (!(file in table)) {
+      throw new Error(`ENOENT: no such file or directory, stat '${file}'`);
+    }
+    return table[file]!;
+  };
+}
+
+const T1 = 1_000;
+const T2 = 2_000;
+const T3 = 3_000;
+
+describe('selectLatestJournal — the recency policy behind the hook', () => {
+  it('a conforming directory (counter order == write order) serves the lexical-newest with no drift', () => {
+    const pick = selectLatestJournal(
+      ['claude-0001-a.md', 'claude-0002-b.md', 'claude-0003-c.md'],
+      statOf({
+        'claude-0001-a.md': T1,
+        'claude-0002-b.md': T2,
+        'claude-0003-c.md': T3,
+      }),
+    );
+    expect(pick).not.toBeNull();
+    expect(pick!.latest).toBe('claude-0003-c.md');
+    expect(pick!.lexicalLatest).toBe('claude-0003-c.md');
+    expect(pick!.drift).toBe(false);
+    expect(pick!.reason).toBe('lexical');
+    expect(pick!.statFailures).toEqual([]);
+  });
+
+  it('a clock-named file that out-sorts a later write is naming drift: the newer write is served and named', () => {
+    // The 2026-09-07 incident shape: `claude-2315-…` (a 23:15 clock stamp) out-sorted the
+    // 01:33 signoff `claude-0132-…`; the pre-fix hook served the stale file silently.
+    const pick = selectLatestJournal(
+      ['claude-0001-first.md', 'claude-2315-clock-named.md', 'claude-0100-newest-write.md'],
+      statOf({
+        'claude-0001-first.md': T1,
+        'claude-2315-clock-named.md': T2,
+        'claude-0100-newest-write.md': T3,
+      }),
+    );
+    expect(pick!.lexicalLatest).toBe('claude-2315-clock-named.md');
+    expect(pick!.mtimeLatest).toBe('claude-0100-newest-write.md');
+    expect(pick!.latest).toBe('claude-0100-newest-write.md');
+    expect(pick!.drift).toBe(true);
+    expect(pick!.reason).toBe('newest-write');
+  });
+
+  it('an mtime tie keeps the lexical pick (no drift reported)', () => {
+    const pick = selectLatestJournal(
+      ['claude-0001-a.md', 'claude-0002-b.md'],
+      statOf({
+        'claude-0001-a.md': T2,
+        'claude-0002-b.md': T2,
+      }),
+    );
+    expect(pick!.latest).toBe('claude-0002-b.md');
+    expect(pick!.drift).toBe(false);
+  });
+
+  it('a sibling whose stat throws is skipped and reported — it never drops the pick', () => {
+    // The GCA / Greptile / CodeRabbit round-1 finding: pre-fix, one dangling entry threw
+    // inside the hook's outer try and the whole journal block was lost.
+    const pick = selectLatestJournal(
+      ['claude-0001-a.md', 'claude-0002-dangling.md', 'claude-0003-c.md'],
+      statOf({ 'claude-0001-a.md': T1, 'claude-0003-c.md': T3 }),
+    );
+    expect(pick!.latest).toBe('claude-0003-c.md');
+    expect(pick!.drift).toBe(false);
+    expect(pick!.reason).toBe('lexical');
+    expect(pick!.statFailures).toHaveLength(1);
+    expect(pick!.statFailures[0]!.file).toBe('claude-0002-dangling.md');
+    expect(pick!.statFailures[0]!.message).toContain('ENOENT');
+  });
+
+  it('when the lexical-newest itself cannot be stat-ed, the newest readable write is served and the reason says so, not drift', () => {
+    const pick = selectLatestJournal(
+      ['claude-0001-a.md', 'claude-0002-b.md', 'claude-0003-gone.md'],
+      statOf({
+        'claude-0001-a.md': T1,
+        'claude-0002-b.md': T2,
+      }),
+    );
+    expect(pick!.lexicalLatest).toBe('claude-0003-gone.md');
+    expect(pick!.latest).toBe('claude-0002-b.md');
+    expect(pick!.drift).toBe(false);
+    expect(pick!.reason).toBe('lexical-unreadable');
+    expect(pick!.statFailures.map((s) => s.file)).toEqual(['claude-0003-gone.md']);
+  });
+
+  it('when nothing can be stat-ed the lexical pick stands with every failure reported', () => {
+    const pick = selectLatestJournal(['claude-0001-a.md', 'claude-0002-b.md'], statOf({}));
+    expect(pick!.latest).toBe('claude-0002-b.md');
+    expect(pick!.reason).toBe('lexical');
+    expect(pick!.drift).toBe(false);
+    expect(pick!.statFailures).toHaveLength(2);
+  });
+
+  it('filters non-markdown entries and returns null for an empty directory', () => {
+    expect(selectLatestJournal(['legacy', 'notes.txt'], statOf({}))).toBeNull();
+    const pick = selectLatestJournal(
+      ['legacy', 'claude-0001-a.md'],
+      statOf({ 'claude-0001-a.md': T1 }),
+    );
+    expect(pick!.files).toEqual(['claude-0001-a.md']);
+    expect(pick!.latest).toBe('claude-0001-a.md');
+  });
+});

--- a/packages/cli/src/commands/session-context-journal-select.test.ts
+++ b/packages/cli/src/commands/session-context-journal-select.test.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+
 import { beforeAll, describe, expect, it } from 'vitest';
 
 // The latest-journal pick of the bespoke SessionStart hook


### PR DESCRIPTION
## What

The SessionStart hook's "latest journal" pick no longer trusts the filename sort alone: it checks the lexical-newest journal against the newest write, serves the newer write when they disagree, and names the drift on the banner and in the selection manifest. Serves mmnto-ai/totem#2828.

## How

`.claude/hooks/session-context.mjs` sorted `readdirSync(journalDir)` lexically and served `files[0]`. That is correct under the signoff skill's `<model>-NNNN-<slug>.md` counter convention and silently wrong the moment a seat's names leave it. On 2026-09-06/07 this seat stamped seven journals with an HHMM clock prefix; a 23:15 milestone out-sorted the 01:33 signoff, four names collided with June counters, the hook injected the superseded carryforward at signon, and the selection manifest attested that pick as `selected` with every sibling `excluded`.

Now every candidate is `stat`ed once. These are per-clone untracked files, so mtime is the write instant; the clone and worktree reset that makes mtime unsafe for mail cutoffs (mmnto-ai/totem-strategy#813) never reaches an untracked directory. When the mtime-newest file differs from the lexical-newest, the newer write is served, one warning line names both files and the convention, the served record's manifest `reason` says which policy chose it, and the excluded records say why. Ties and conforming directories behave exactly as before. The seat's seven drifted names were renamed back onto the counter (`claude-0233` through `claude-0239`) the same morning, so on this repo the sensor is now quiet.

## Verification

Fixture in the branch worktree, three journals under the seat's orchestration path, mtimes set by `touch`: `claude-0001-first.md` (2026-09-01), `claude-2315-clock-named.md` (2026-09-06 23:15), `claude-0100-newest-write.md` (2026-09-07 01:00).

| Hook | Served | Drift line |
| --- | --- | --- |
| pre-fix (origin/main copy) | `claude-2315-clock-named.md` | none |
| this branch | `claude-0100-newest-write.md` | printed, naming both files and the convention |

The manifest row for the branch run carries `recency-policy: newest write (claude-0100-newest-write.md); the lexical-newest claude-2315-clock-named.md is older on disk …` on the served record and `only the newest write injected (naming drift — see the served record)` on the excluded ones. The same fixture renamed onto the counter (`0001`, `0002`, `0003` in write order) serves `claude-0003-third.md` with no drift line.

Tests: one string lock added to the existing `init.test.ts` lockstep block for this bespoke hook (the file has no other harness): it asserts the drift-sensor line is present, so it fails on the pre-fix hook. The four existing locks (sidecar verbs, stamps, breadcrumb, banner) are untouched and pass.

## Review leg (doctrine/model-tiering § Review legs)

Not owed by the push gate's derivation (`.claude/hooks/**` is not in `hooks.legsOwed.globs`). The falsifier above is the fixture comparison, run on both copies of the hook.

## Not in this PR

- The MCP extractor's Layer 1 read of strategy's journals (`packages/mcp/src/state-extractors.ts`) rests on the same premise. strategy-claude's names still follow the counter, so it is unaffected today; its substrate-fallback sibling is mmnto-ai/totem#1955.
- No change to the filename convention itself; the counter stays canonical (signoff skill step 2).

## Related

mmnto-ai/totem#2828 (this defect), mmnto-ai/totem#1955 (substrate sort tiebreak), mmnto-ai/totem#2468 (selection manifests), mmnto-ai/totem#1993 (the display cap on the same read).

<!-- totem-context: intended close — the D1 atom's bare-prose closing line -->
Closes mmnto-ai/totem#2828
<!-- totem-context: intended close — the D1 atom's totem-close marker for the line above -->
<!-- totem-close: #2828 -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfjHkyuEtTWahKf1eXpQeQ
