### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine 0.1.45 -> 0.1.46 (cohort-sync; freeze entry identical between the two packs; carries the gh-issue-label-canon parity row made canonical beside mmnto-ai/totem#2827)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   },
   "optionalDependencies": {
     "@mmnto/cli": "workspace:*",
-    "@mmnto/strategy-doctrine": "0.1.45"
+    "@mmnto/strategy-doctrine": "0.1.46"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.45
-        version: 0.1.45
+        specifier: 0.1.46
+        version: 0.1.46
 
   packages/cli:
     dependencies:
@@ -862,8 +862,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.45':
-    resolution: {integrity: sha512-ffGcoHyk9qdnPbBXvibvCke4GB6lr+kUp9CxXc/BJouIpDCWzI04MvwY7KfY+R+fY5ntnPO4cqJgcOStJovnvQ==}
+  '@mmnto/strategy-doctrine@0.1.46':
+    resolution: {integrity: sha512-JeXS3eQW6tNex83vMsfAVOSpvDyZroomDE1KFO1xKAnMwNd7pcVw/CTT7+UEei0B2H+atMY2WgtxC9OP7tN12w==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3694,7 +3694,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.45':
+  '@mmnto/strategy-doctrine@0.1.46':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
## What

Bumps totem's `@mmnto/strategy-doctrine` pin from 0.1.45 to 0.1.46, the cohort-sync that follows strategy-claude's cut (mmnto-ai/totem-strategy#1281, tag `strategy-doctrine-v0.1.46`, publish run success 2026-09-07 ~18:04Z). Strategy and totem-status already sit at 0.1.46; liquid-city's bump was mailed to its seat.

## How

`package.json` optionalDependencies pin and the two `pnpm-lock.yaml` entries (specifier/version and the resolution block with the new integrity), the same two-file shape as mmnto-ai/totem#2806. `pnpm install` ran with the registry token present and the pack materialised at 0.1.46 (the mmnto-ai/totem#630 silent-drop class is what `verify-lockfile-sync` guards; the entry is present, not vanished).

What 0.1.46 carries: the `gh-issue-label-canon` parity row made canonical beside mmnto-ai/totem#2827 (mmnto-ai/totem-strategy#1279) — the `disposition:` namespace, six names, create plus edit.

## Verification

- `diff` of the 0.1.45 pack's `freeze.json` (resident `node_modules`) against the 0.1.46 pack's: **empty**. The freeze entry did not move, so the local mirror `.totem/freeze.json` is not re-synced in this PR.
- Disclosed, not folded: the mirror's `tracking` line lacks the suffix the registry entry gained in August ("replacement/lift target: the record grammar, ADR-103 Amendment 2026-08-19 + Proposal 310"); its `_note`, `scope: local` and "CI-visible mirror" reason are the mirror's deliberate local framing. Pre-existing since before 0.1.45; the sensor for this class is mmnto-ai/totem#2352.
- Push gate on the branch: `totem lint`, `verify-lockfile-sync`, claim-discipline, legs gate.
- Tests: none added; a pin bump has no test seam beyond the lockfile-sync gate.

## Review leg (doctrine/model-tiering § Review legs)

Not owed: a two-file dependency pin with no code path.

## Not in this PR

- The mirror's `tracking` suffix re-sync (above).
- Any change to the freeze itself; the hold is unchanged and active.

## Related

mmnto-ai/totem-strategy#1279 (the parity row), mmnto-ai/totem-strategy#1281 (the 0.1.46 cut), mmnto-ai/totem#2806 (the 0.1.45 bump, same shape), mmnto-ai/totem#2792 (batch one, closed on the pair of receipts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfjHkyuEtTWahKf1eXpQeQ
