### PR TITLE
chore(lessons): eight lessons from mmnto-ai/totem#2830, mmnto-ai/totem#2831 and mmnto-ai/totem#2834 — compile untouched under the freeze

### DIFF
--- a/.totem/lessons/lesson-0a96089e.md
+++ b/.totem/lessons/lesson-0a96089e.md
@@ -1,0 +1,6 @@
+## Lesson — Isolate filesystem operations in batch loops
+
+**Tags:** node, fs, error-handling
+**Scope:** .claude/hooks/**/*.mjs
+
+Synchronous filesystem operations like statSync inside a batch processing loop must be wrapped in individual try/catch blocks to prevent a single unreadable or deleted file from aborting the entire operation.

--- a/.totem/lessons/lesson-41b216aa.md
+++ b/.totem/lessons/lesson-41b216aa.md
@@ -1,0 +1,6 @@
+## Lesson — Test runtime behavior over source-text locks
+
+**Tags:** testing
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Asserting on the presence of source-code strings in a hook does not validate runtime execution; critical invariants (like file selection and tie-breaks) must be verified with behavioral unit tests using mock fixtures.

--- a/.totem/lessons/lesson-5b766e0d.md
+++ b/.totem/lessons/lesson-5b766e0d.md
@@ -1,0 +1,6 @@
+## Lesson — Fallback to PATH for local CLI wrappers
+
+**Tags:** cli, bootstrap, node
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+CLI wrappers that only probe repo-local `node_modules` can block bootstrap commands on fresh clones. Fall back to resolving the CLI from the system `PATH` while maintaining local-first precedence to prevent self-blocking bootstrap loops.

--- a/.totem/lessons/lesson-d8e09388.md
+++ b/.totem/lessons/lesson-d8e09388.md
@@ -1,0 +1,6 @@
+## Lesson — Avoid regex-based filename semantic checks
+
+**Tags:** naming-conventions, file-system
+**Scope:** .claude/hooks/**/*.mjs
+
+Filename patterns cannot reliably distinguish sequence counters from clock stamps when both share the same digit format (e.g., four digits). Comparing lexical order against file modification time (mtime) provides a deterministic way to detect naming drift without fragile regex matching.

--- a/.totem/lessons/lesson-db060fa9.md
+++ b/.totem/lessons/lesson-db060fa9.md
@@ -1,0 +1,6 @@
+## Lesson — Document wrapper contracts in agent prompts
+
+**Tags:** ai, dx, configuration
+**Scope:** packages/cli/src/commands/init-templates.ts
+
+When changing a wrapper's execution contract, update embedded agent instructions and bump the template version so that existing installations re-render and receive the updated recovery guidance.

--- a/.totem/lessons/lesson-deb7dcdc.md
+++ b/.totem/lessons/lesson-deb7dcdc.md
@@ -1,0 +1,6 @@
+## Lesson — Isolate closing keywords from issue references
+
+**Tags:** github, automation, regex
+**Scope:** .github/pull_request_template.md
+
+GitHub's parser can trigger accidental issue closures even when prose negates the closing keyword. PR templates must describe closing syntax using placeholders and keep keywords strictly separated from references to prevent triggering autoclose guards.

--- a/.totem/lessons/lesson-f5772c10.md
+++ b/.totem/lessons/lesson-f5772c10.md
@@ -1,0 +1,6 @@
+## Lesson — Provide ungated recovery paths for fail-closed gates
+
+**Tags:** security, ux, cli
+**Scope:** packages/cli/src/commands/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+When a security gate fails closed due to a missing CLI, the error message must explicitly guide the user to ungated recovery paths (like an external terminal) to avoid trapping them in a blocked state.

--- a/.totem/lessons/lesson-f9a997fc.md
+++ b/.totem/lessons/lesson-f9a997fc.md
@@ -1,0 +1,6 @@
+## Lesson — Avoid H1 headings in PR templates
+
+**Tags:** github, markdown, documentation
+**Scope:** .github/pull_request_template.md
+
+GitHub pull request titles act as the effective top-level H1 header, making an H1 inside the template body redundant. Starting the template with H2 headings prevents rendering a double title on the pull request page.


### PR DESCRIPTION
## What

Post-merge lesson extraction for the three merges of 2026-09-07 20:2xZ: mmnto-ai/totem#2830 (the PR template), mmnto-ai/totem#2831 (the session-start hook's journal-drift sensor) and mmnto-ai/totem#2834 (the gate wrapper's PATH-resolution arm). Eight lessons, written by `totem lesson extract 2830 2831 2834 --yes` at `61e3ec0f`.

## How

Each lesson restates either a finding the bot round folded (per-candidate stat handling in batch loops; behavioural tests over source-text locks; the PATH fallback with local-first precedence; ungated recovery paths for a fail-closed gate; the agent-prompt contract with a version bump; keyword-and-ref separation in the close guidance) or a decline the bots confirmed (filename regexes cannot separate a counter from a clock; no H1 in a PR body). Read in full and kept as drafted; no hand edits this time.

## Verification

- Eight additions under `.totem/lessons/`; `git diff --stat` matches the extract's output.
- Push gate: `totem lint` (lesson files are filtered by the ignore patterns), claim-discipline, legs gate (not owed), `format:check`.
- No `totem lesson compile` (the rule-compilation freeze stands); lesson-only manifest staleness warns by design.
- Tests: none; lessons are corpus, not code.

## Review leg (doctrine/model-tiering § Review legs)

Not owed: corpus files, no code path.

## Not in this PR

- No changeset (no package touched).
- The lessons from mmnto-ai/totem#2829 and mmnto-ai/totem#2832 are not extracted: one was itself a lessons PR, the other a two-file pin bump.

## Related

mmnto-ai/totem#2830, mmnto-ai/totem#2831, mmnto-ai/totem#2834 (the sources); mmnto-ai/totem#2829 (the previous lessons PR of the day).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfjHkyuEtTWahKf1eXpQeQ
