### PR TITLE
fix(scripts): sync-labels.ps1 gives every canonical a create+edit pair — an edit-only canonical ended the armed run on a repo that never carried it (mmnto-ai/totem#2837)

### DIFF
--- a/packages/cli/src/commands/sync-labels-forms.test.ts
+++ b/packages/cli/src/commands/sync-labels-forms.test.ts
@@ -42,7 +42,7 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { parse as parseYaml } from 'yaml';
 
-import { parseLabelCanon } from '@mmnto/totem';
+import { normalizeLabelColor, parseLabelCanon } from '@mmnto/totem';
 
 /** packages/cli/src/commands → the repo root. */
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
@@ -223,6 +223,29 @@ describe.skipIf(!REPO_FILES_PRESENT)('issue forms', () => {
     // Untouched by mmnto-ai/totem#2792: still the front-matter markdown template it was.
     expect(fs.readFileSync(ONBOARDING_PATH, 'utf8').startsWith('---')).toBe(true);
   });
+
+  it("every canonical's create line carries exactly the colour and description of its edit twin", () => {
+    // The canon readers regex only the `edit` lines; the `create` twin is
+    // invisible to them, so a later change to one line of a pair would leave a
+    // fresh repository initialised with metadata the canon does not carry
+    // (Greptile P2 on mmnto-ai/totem#2839). Read from the script TEXT, not the
+    // rendered dry run, so a console code page cannot transliterate the compare.
+    const script = fs.readFileSync(SCRIPT_PATH, 'utf8');
+    const createRe = /gh label create "([^"]+)" --color "([^"]+)" --description "([^"]*)"/g;
+    const creates = new Map<string, { color: string; description: string }>();
+    for (const match of script.matchAll(createRe)) {
+      creates.set(match[1]!, { color: normalizeLabelColor(match[2]), description: match[3]! });
+    }
+    const canon = realCanon();
+    expect(canon.labels.length).toBeGreaterThan(0);
+    expect(creates.size).toBe(canon.labels.length);
+    for (const label of canon.labels) {
+      expect(creates.get(label.name), `create twin for ${label.name}`).toEqual({
+        color: normalizeLabelColor(label.color),
+        description: label.description,
+      });
+    }
+  });
 });
 
 // ─── The pwsh dry run ────────────────────────────────────
@@ -236,15 +259,23 @@ describe.skipIf(!REPO_FILES_PRESENT)('issue forms', () => {
 function makeGhStub(): { dir: string; logPath: string } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-gh-stub-'));
   const logPath = path.join(dir, 'gh-calls.log');
-  // The stub logs every call and exits 0, with four opt-in modes read from the
-  // child's environment:
-  //   TOTEM_GH_STUB_ISSUES          — `issue list` answers with one issue, #7,
-  //                                   so the merge phase has something to relabel
-  //   TOTEM_GH_STUB_FAIL_ISSUE_LIST — `issue list` exits 1 (a failed READ)
-  //   TOTEM_GH_STUB_FAIL_ISSUE_EDIT — `issue edit` exits 1 (a failed relabel —
-  //                                   the totem-status incident, mmnto-ai/totem#2837)
-  //   TOTEM_GH_STUB_FAIL            — `label edit` exits 1 — the failure path of
-  //                                   the mutation tally (Greptile P1 on mmnto-ai/totem#2827)
+  // The stub logs every call and exits 0, with opt-in modes read from the
+  // child's environment. The script's two `issue list` reads differ only by
+  // their cap — `--limit 1000` migrates, `--limit 1 --json` rechecks — and the
+  // stub keys on that token so each read can be answered on its own:
+  //   TOTEM_GH_STUB_ISSUES            — the migration read answers with one
+  //                                     issue, #7, so the merge phase relabels
+  //   TOTEM_GH_STUB_ISSUES_REMAIN     — the recheck read still answers #7 (an
+  //                                     issue past the cap; Greptile P1 on
+  //                                     mmnto-ai/totem#2839)
+  //   TOTEM_GH_STUB_FAIL_ISSUE_LIST   — `issue list` exits 1 (a failed READ)
+  //   TOTEM_GH_STUB_FAIL_ISSUE_EDIT   — `issue edit` exits 1 (a failed relabel —
+  //                                     the totem-status incident, mmnto-ai/totem#2837)
+  //   TOTEM_GH_STUB_FAIL_LABEL_DELETE — `label delete` exits 1
+  //   TOTEM_GH_STUB_LABEL_PRESENT     — `label list` answers non-empty (the
+  //                                     deleted label is still there)
+  //   TOTEM_GH_STUB_FAIL              — `label edit` exits 1 — the failure path of
+  //                                     the mutation tally (Greptile P1 on mmnto-ai/totem#2827)
   if (process.platform === 'win32') {
     fs.writeFileSync(
       path.join(dir, 'gh.cmd'),
@@ -252,9 +283,17 @@ function makeGhStub(): { dir: string; logPath: string } {
         '@echo off',
         `>>"${logPath}" echo %*`,
         'if "%TOTEM_GH_STUB_ISSUES%"=="" goto :after_issues',
-        'echo %* | findstr /C:"issue list" >nul',
+        'echo %* | findstr /C:"--limit 1000" >nul',
         'if %errorlevel%==0 echo 7',
         ':after_issues',
+        'if "%TOTEM_GH_STUB_ISSUES_REMAIN%"=="" goto :after_remain',
+        'echo %* | findstr /C:"--limit 1 --json" >nul',
+        'if %errorlevel%==0 echo 7',
+        ':after_remain',
+        'if "%TOTEM_GH_STUB_LABEL_PRESENT%"=="" goto :after_present',
+        'echo %* | findstr /C:"label list" >nul',
+        'if %errorlevel%==0 echo present',
+        ':after_present',
         'if "%TOTEM_GH_STUB_FAIL_ISSUE_LIST%"=="" goto :after_list_fail',
         'echo %* | findstr /C:"issue list" >nul',
         'if %errorlevel%==0 exit /b 1',
@@ -263,6 +302,10 @@ function makeGhStub(): { dir: string; logPath: string } {
         'echo %* | findstr /C:"issue edit" >nul',
         'if %errorlevel%==0 exit /b 1',
         ':after_edit_fail',
+        'if "%TOTEM_GH_STUB_FAIL_LABEL_DELETE%"=="" goto :after_delete_fail',
+        'echo %* | findstr /C:"label delete" >nul',
+        'if %errorlevel%==0 exit /b 1',
+        ':after_delete_fail',
         'if "%TOTEM_GH_STUB_FAIL%"=="" exit /b 0',
         'echo %* | findstr /C:"label edit" >nul',
         'if %errorlevel%==0 exit /b 1',
@@ -279,13 +322,22 @@ function makeGhStub(): { dir: string; logPath: string } {
         '#!/bin/sh',
         `printf '%s\\n' "$*" >> "${logPath}"`,
         'if [ -n "$TOTEM_GH_STUB_ISSUES" ]; then',
-        '  case "$*" in *"issue list"*) echo 7 ;; esac',
+        '  case "$*" in *"--limit 1000"*) echo 7 ;; esac',
+        'fi',
+        'if [ -n "$TOTEM_GH_STUB_ISSUES_REMAIN" ]; then',
+        '  case "$*" in *"--limit 1 --json"*) echo 7 ;; esac',
+        'fi',
+        'if [ -n "$TOTEM_GH_STUB_LABEL_PRESENT" ]; then',
+        '  case "$*" in *"label list"*) echo present ;; esac',
         'fi',
         'if [ -n "$TOTEM_GH_STUB_FAIL_ISSUE_LIST" ]; then',
         '  case "$*" in *"issue list"*) exit 1 ;; esac',
         'fi',
         'if [ -n "$TOTEM_GH_STUB_FAIL_ISSUE_EDIT" ]; then',
         '  case "$*" in *"issue edit"*) exit 1 ;; esac',
+        'fi',
+        'if [ -n "$TOTEM_GH_STUB_FAIL_LABEL_DELETE" ]; then',
+        '  case "$*" in *"label delete"*) exit 1 ;; esac',
         'fi',
         'if [ -n "$TOTEM_GH_STUB_FAIL" ]; then',
         '  case "$*" in *"label edit"*) exit 1 ;; esac',
@@ -505,6 +557,86 @@ describe.skipIf(!PWSH_PRESENT)('scripts/sync-labels.ps1 dry run', () => {
       const calls = loggedCalls(stub.logPath);
       expect(calls.filter((call) => call.startsWith('issue edit '))).toHaveLength(0);
       expect(calls.filter((call) => call.startsWith('label delete '))).toHaveLength(0);
+    } finally {
+      fs.rmSync(stub.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('an issue past the read cap keeps the old label — the delete waits until no issue carries it', () => {
+    // The migration read is `--limit 1000`; a label on more issues than that
+    // lists a subset (Greptile P1 on mmnto-ai/totem#2839). The stub relabels
+    // #7 and then answers the limit-1 recheck with #7 again: the script must
+    // keep every legacy label, delete nothing, name the cap, and exit non-zero.
+    const stub = makeGhStub();
+    try {
+      const run = runScript(['-Repo', 'example/stub'], stub.dir, {
+        TOTEM_GH_STUB_ISSUES: '1',
+        TOTEM_GH_STUB_ISSUES_REMAIN: '1',
+      });
+      expect(run.error).toBeUndefined();
+      expect(run.status, run.stdout).toBe(1);
+      expect(run.stdout).not.toContain('sync complete');
+      const merges = realCanon().merges.length;
+      const kept = run.stdout
+        .split(/\r?\n/)
+        .filter((line) => line.includes('issues still carry it after the relabel pass')).length;
+      expect(kept).toBe(merges);
+      const calls = loggedCalls(stub.logPath);
+      expect(calls.filter((call) => /^issue edit 7 --add-label /.test(call))).toHaveLength(merges);
+      expect(calls.filter((call) => /^issue list .* --limit 1 --json/.test(call))).toHaveLength(
+        merges,
+      );
+      expect(calls.filter((call) => call.startsWith('label delete '))).toHaveLength(0);
+    } finally {
+      fs.rmSync(stub.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a failed delete of an already-absent label is a no-op — the run still converges', () => {
+    // `label delete` exits 1 on a name that was retired on an earlier run; the
+    // read-back finds nothing, so the failure is benign and the run completes.
+    const stub = makeGhStub();
+    try {
+      const run = runScript(['-Repo', 'example/stub'], stub.dir, {
+        TOTEM_GH_STUB_ISSUES: '1',
+        TOTEM_GH_STUB_FAIL_LABEL_DELETE: '1',
+      });
+      expect(run.error).toBeUndefined();
+      expect(run.status, run.stdout).toBe(0);
+      expect(run.stdout).toContain('sync complete');
+      const merges = realCanon().merges.length;
+      const calls = loggedCalls(stub.logPath);
+      expect(calls.filter((call) => call.startsWith('label delete '))).toHaveLength(merges);
+      expect(calls.filter((call) => call.startsWith('label list '))).toHaveLength(merges);
+    } finally {
+      fs.rmSync(stub.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a failed delete of a label that remains fails the run — convergence is never reported over a leftover', () => {
+    // `label delete` exits 1 and the read-back still finds the name (CodeRabbit
+    // on mmnto-ai/totem#2839): the failure is tallied, the run exits non-zero
+    // and never prints "sync complete".
+    const stub = makeGhStub();
+    try {
+      const run = runScript(['-Repo', 'example/stub'], stub.dir, {
+        TOTEM_GH_STUB_ISSUES: '1',
+        TOTEM_GH_STUB_FAIL_LABEL_DELETE: '1',
+        TOTEM_GH_STUB_LABEL_PRESENT: '1',
+      });
+      expect(run.error).toBeUndefined();
+      expect(run.status, run.stdout).toBe(1);
+      expect(run.stdout).not.toContain('sync complete');
+      const merges = realCanon().merges.length;
+      const still = run.stdout
+        .split(/\r?\n/)
+        .filter((line) =>
+          /\[Error\] gh label delete '.+' failed and the label is still present/.test(line),
+        ).length;
+      expect(still).toBe(merges);
+      const calls = loggedCalls(stub.logPath);
+      expect(calls.filter((call) => call.startsWith('label delete '))).toHaveLength(merges);
+      expect(calls.filter((call) => call.startsWith('label list '))).toHaveLength(merges);
     } finally {
       fs.rmSync(stub.dir, { recursive: true, force: true });
     }

--- a/packages/cli/src/commands/sync-labels-forms.test.ts
+++ b/packages/cli/src/commands/sync-labels-forms.test.ts
@@ -306,11 +306,29 @@ describe.skipIf(!PWSH_PRESENT)('scripts/sync-labels.ps1 dry run', () => {
         .split(/\r?\n/)
         .filter((line) => line.startsWith('[WhatIf] gh label'));
       // One line per would-be call, derived from the canon rather than pinned:
-      // an `edit` per canonical label, a `create` per disposition label, and a
-      // `delete` per Merge-Label retirement.
+      // a `create` AND an `edit` per canonical label (mmnto-ai/totem#2837 — an
+      // `edit`-only canonical exits the run on a repo that never carried it),
+      // and a `delete` per Merge-Label retirement.
       const canon = realCanon();
-      const creates = canon.labels.filter((label) => label.name.startsWith('disposition: ')).length;
+      const creates = canon.labels.length;
       expect(labelLines.length).toBe(canon.labels.length + creates + canon.merges.length);
+      // Every canonical's `create` line immediately precedes its `edit` line.
+      // Keyed on the name alone: the shadow re-quotes only an argument carrying
+      // whitespace, and a description's em-dash is transliterated by the child
+      // console's code page, so the colour and description are the count's
+      // business (above), not this adjacency's.
+      const q = (text: string) => (/\s/.test(text) ? `"${text}"` : text);
+      for (const label of canon.labels) {
+        const createAt = labelLines.findIndex((line) =>
+          line.startsWith(`[WhatIf] gh label create ${q(label.name)} --color `),
+        );
+        expect(createAt, `create line for ${label.name}`).toBeGreaterThanOrEqual(0);
+        expect(labelLines[createAt + 1], `edit line follows create for ${label.name}`).toMatch(
+          new RegExp(
+            `^\\[WhatIf\\] gh label edit ${q(label.name).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')} --color `,
+          ),
+        );
+      }
       // The shadow replaces the executable, so the stub on PATH never ran: no
       // log file at all. This is the "-WhatIf touches nothing" invariant.
       expect(fs.existsSync(stub.logPath)).toBe(false);

--- a/packages/cli/src/commands/sync-labels-forms.test.ts
+++ b/packages/cli/src/commands/sync-labels-forms.test.ts
@@ -18,12 +18,15 @@
  *      The scope derivation reads ONLY names starting with `scope: `, so the
  *      `disposition: ` namespace can never leak into the dropdown.
  *
- * The last two cases spawn `pwsh` against the real script. The first proves the
+ * The remaining cases spawn `pwsh` against the real script. The first proves the
  * `-WhatIf` shadow prints every `gh` call and executes none (a stub `gh` sits on
  * PATH and must stay untouched); the second proves the shadow does NOT leak into
- * a normal run — the same stub, no `-WhatIf`, must receive the whole canon. Both
- * run against `-Repo example/stub`; neither can reach GitHub, because `gh` on the
- * child's PATH is a log-appending stub.
+ * a normal run — the same stub, no `-WhatIf`, must receive the whole canon; the
+ * rest drive the stub's failure modes (a refused `label edit`, a refused
+ * `issue edit`, a failed `issue list`) to pin the mutation tally and the gated
+ * delete in `Merge-Label` (mmnto-ai/totem#2837). Every one runs against
+ * `-Repo example/stub`; none can reach GitHub, because `gh` on the child's PATH
+ * is a log-appending stub.
  *
  * Every case skips when the repo-root files are absent (a packaged install
  * carries neither the script nor `.github/`), and the spawning ones skip when
@@ -233,15 +236,33 @@ describe.skipIf(!REPO_FILES_PRESENT)('issue forms', () => {
 function makeGhStub(): { dir: string; logPath: string } {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'totem-gh-stub-'));
   const logPath = path.join(dir, 'gh-calls.log');
-  // With TOTEM_GH_STUB_FAIL set in the child's environment the stub still logs
-  // every call but exits 1 on `label edit` — the failure path of the script's
-  // mutation tally (Greptile P1 on mmnto-ai/totem#2827).
+  // The stub logs every call and exits 0, with four opt-in modes read from the
+  // child's environment:
+  //   TOTEM_GH_STUB_ISSUES          — `issue list` answers with one issue, #7,
+  //                                   so the merge phase has something to relabel
+  //   TOTEM_GH_STUB_FAIL_ISSUE_LIST — `issue list` exits 1 (a failed READ)
+  //   TOTEM_GH_STUB_FAIL_ISSUE_EDIT — `issue edit` exits 1 (a failed relabel —
+  //                                   the totem-status incident, mmnto-ai/totem#2837)
+  //   TOTEM_GH_STUB_FAIL            — `label edit` exits 1 — the failure path of
+  //                                   the mutation tally (Greptile P1 on mmnto-ai/totem#2827)
   if (process.platform === 'win32') {
     fs.writeFileSync(
       path.join(dir, 'gh.cmd'),
       [
         '@echo off',
         `>>"${logPath}" echo %*`,
+        'if "%TOTEM_GH_STUB_ISSUES%"=="" goto :after_issues',
+        'echo %* | findstr /C:"issue list" >nul',
+        'if %errorlevel%==0 echo 7',
+        ':after_issues',
+        'if "%TOTEM_GH_STUB_FAIL_ISSUE_LIST%"=="" goto :after_list_fail',
+        'echo %* | findstr /C:"issue list" >nul',
+        'if %errorlevel%==0 exit /b 1',
+        ':after_list_fail',
+        'if "%TOTEM_GH_STUB_FAIL_ISSUE_EDIT%"=="" goto :after_edit_fail',
+        'echo %* | findstr /C:"issue edit" >nul',
+        'if %errorlevel%==0 exit /b 1',
+        ':after_edit_fail',
         'if "%TOTEM_GH_STUB_FAIL%"=="" exit /b 0',
         'echo %* | findstr /C:"label edit" >nul',
         'if %errorlevel%==0 exit /b 1',
@@ -257,6 +278,15 @@ function makeGhStub(): { dir: string; logPath: string } {
       [
         '#!/bin/sh',
         `printf '%s\\n' "$*" >> "${logPath}"`,
+        'if [ -n "$TOTEM_GH_STUB_ISSUES" ]; then',
+        '  case "$*" in *"issue list"*) echo 7 ;; esac',
+        'fi',
+        'if [ -n "$TOTEM_GH_STUB_FAIL_ISSUE_LIST" ]; then',
+        '  case "$*" in *"issue list"*) exit 1 ;; esac',
+        'fi',
+        'if [ -n "$TOTEM_GH_STUB_FAIL_ISSUE_EDIT" ]; then',
+        '  case "$*" in *"issue edit"*) exit 1 ;; esac',
+        'fi',
         'if [ -n "$TOTEM_GH_STUB_FAIL" ]; then',
         '  case "$*" in *"label edit"*) exit 1 ;; esac',
         'fi',
@@ -362,16 +392,13 @@ describe.skipIf(!PWSH_PRESENT)('scripts/sync-labels.ps1 dry run', () => {
         .labels.map((label) => label.name)
         .sort();
       expect(edited).toEqual(expectedEdited);
+      // ...and created, by name, exactly once — every namespace, not only the
+      // dispositions (mmnto-ai/totem#2837).
       const created = calls
-        .map((call) => /^label create "?(disposition: [a-z-]+)"?/.exec(call)?.[1])
+        .map((call) => /^label create "?(.+?)"? --color /.exec(call)?.[1])
         .filter((name): name is string => name !== undefined)
         .sort();
-      const expectedCreated = realCanon()
-        .labels.map((label) => label.name)
-        .filter((name) => name.startsWith('disposition: '))
-        .sort();
-      expect(expectedCreated).toHaveLength(6);
-      expect(created).toEqual(expectedCreated);
+      expect(created).toEqual(expectedEdited);
     } finally {
       fs.rmSync(stub.dir, { recursive: true, force: true });
     }
@@ -393,6 +420,91 @@ describe.skipIf(!PWSH_PRESENT)('scripts/sync-labels.ps1 dry run', () => {
         .split(/\r?\n/)
         .filter((line) => line.includes('[Error] gh label edit')).length;
       expect(tallied).toBe(realCanon().labels.length);
+    } finally {
+      fs.rmSync(stub.dir, { recursive: true, force: true });
+    }
+  });
+
+  /** The stub's call log, one trimmed line per `gh` invocation. */
+  function loggedCalls(logPath: string): string[] {
+    return fs
+      .readFileSync(logPath, 'utf8')
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+  }
+
+  it('a converged relabel retires the old label — every merge deletes once the issue carries the new name', () => {
+    // The positive control for the gate below: the stub lists issue #7 under
+    // every legacy label and accepts every `issue edit`, so every `Merge-Label`
+    // relabels #7 and then deletes the legacy name.
+    const stub = makeGhStub();
+    try {
+      const run = runScript(['-Repo', 'example/stub'], stub.dir, { TOTEM_GH_STUB_ISSUES: '1' });
+      expect(run.error).toBeUndefined();
+      expect(run.status, run.stdout).toBe(0);
+      expect(run.stdout).toContain('sync complete');
+      const calls = loggedCalls(stub.logPath);
+      const merges = realCanon().merges.length;
+      expect(merges).toBeGreaterThan(0);
+      expect(calls.filter((call) => /^issue edit 7 --add-label /.test(call))).toHaveLength(merges);
+      expect(calls.filter((call) => call.startsWith('label delete '))).toHaveLength(merges);
+    } finally {
+      fs.rmSync(stub.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a failed relabel keeps the old label — the delete is gated on every issue carrying the new name', () => {
+    // The totem-status incident (2026-09-08, mmnto-ai/totem#2837): every
+    // `issue edit --add-label "type: bug"` had failed and the delete still ran,
+    // so `bug` left its issues with no replacement. The stub lists issue #7
+    // under every legacy label and refuses every `issue edit`: the script must
+    // name each kept label, delete nothing, and exit non-zero.
+    const stub = makeGhStub();
+    try {
+      const run = runScript(['-Repo', 'example/stub'], stub.dir, {
+        TOTEM_GH_STUB_ISSUES: '1',
+        TOTEM_GH_STUB_FAIL_ISSUE_EDIT: '1',
+      });
+      expect(run.error).toBeUndefined();
+      expect(run.status, run.stdout).toBe(1);
+      expect(run.stdout).not.toContain('sync complete');
+      const merges = realCanon().merges.length;
+      const kept = run.stdout
+        .split(/\r?\n/)
+        .filter((line) => line.includes("[Error] keeping '")).length;
+      expect(kept).toBe(merges);
+      const calls = loggedCalls(stub.logPath);
+      expect(calls.filter((call) => /^issue edit 7 --add-label /.test(call))).toHaveLength(merges);
+      expect(calls.filter((call) => call.startsWith('label delete '))).toHaveLength(0);
+    } finally {
+      fs.rmSync(stub.dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a failed issue list keeps the old label — a read failure is not an empty list', () => {
+    // `gh issue list` exits 1 (auth, rate limit, network): the script must not
+    // read that as "no issue carries the label" and delete it. Nothing is
+    // relabelled, nothing is deleted, the read failure counts against
+    // convergence, and the run exits non-zero.
+    const stub = makeGhStub();
+    try {
+      const run = runScript(['-Repo', 'example/stub'], stub.dir, {
+        TOTEM_GH_STUB_FAIL_ISSUE_LIST: '1',
+      });
+      expect(run.error).toBeUndefined();
+      expect(run.status, run.stdout).toBe(1);
+      expect(run.stdout).not.toContain('sync complete');
+      const merges = realCanon().merges.length;
+      const kept = run.stdout
+        .split(/\r?\n/)
+        .filter((line) =>
+          /\[Error\] gh issue list '.+' failed \(exit 1\) -- keeping '/.test(line),
+        ).length;
+      expect(kept).toBe(merges);
+      const calls = loggedCalls(stub.logPath);
+      expect(calls.filter((call) => call.startsWith('issue edit '))).toHaveLength(0);
+      expect(calls.filter((call) => call.startsWith('label delete '))).toHaveLength(0);
     } finally {
       fs.rmSync(stub.dir, { recursive: true, force: true });
     }

--- a/scripts/sync-labels.ps1
+++ b/scripts/sync-labels.ps1
@@ -75,16 +75,36 @@ Write-Host "Syncing labels for repository: $Repo" -ForegroundColor Magenta
 function Merge-Label {
     param($OldName, $NewName)
     Write-Host "Merging '$OldName' into '$NewName'..." -ForegroundColor Cyan
-    # Get issues with the old label
+    # Get issues with the old label. A label the repo never carried lists as
+    # empty with exit 0; a non-zero exit is a failed READ (auth, rate limit,
+    # network), and deleting on one would strip the old label from every issue
+    # that carries it with no replacement -- so the read failure keeps the label
+    # and counts against convergence.
     $issues = gh issue list --label $OldName --repo $Repo --state all --limit 1000 --json number --jq '.[].number' | Out-String
+    if ($LASTEXITCODE -ne 0) {
+        $script:Failures.Add("issue list $OldName")
+        Write-Host "[Error] gh issue list '$OldName' failed (exit $LASTEXITCODE) -- keeping '$OldName'" -ForegroundColor Red
+        return
+    }
     $issueNumbers = $issues -split '\s+' | Where-Object { $_ -ne '' }
-    
+
+    $failuresBefore = $script:Failures.Count
     foreach ($num in $issueNumbers) {
         Write-Host "  Updating issue #$num"
         gh issue edit $num --add-label $NewName --remove-label $OldName --repo $Repo
     }
-    
-    # Try deleting the old label
+
+    # The delete is gated on every relabel above having succeeded. On totem-status
+    # (2026-09-08, mmnto-ai/totem#2837) every `issue edit` had failed on an absent
+    # canonical and the delete still ran: `bug`, `enhancement` and `documentation`
+    # left their issues with no replacement, repaired by hand.
+    $relabelFailures = $script:Failures.Count - $failuresBefore
+    if ($relabelFailures -gt 0) {
+        Write-Host "[Error] keeping '$OldName': $relabelFailures relabel(s) into '$NewName' failed" -ForegroundColor Red
+        return
+    }
+
+    # Every issue that carried the old label now carries the new one: retire it
     gh label delete $OldName --yes --repo $Repo 2>$null
 }
 

--- a/scripts/sync-labels.ps1
+++ b/scripts/sync-labels.ps1
@@ -90,36 +90,58 @@ function Merge-Label {
 
 Write-Host "Updating canonical labels..." -ForegroundColor Yellow
 
+# Two lines per canonical label, every namespace (mmnto-ai/totem#2837): `create`
+# makes it exist (an error on an existing label is suppressed and never tallied),
+# `edit` converges its colour and description on every run AND is the line both
+# canon parsers read -- a `create` line is invisible to them. An `edit`-only
+# canonical fails loud on a repo that never carried it (the shadow tallies a
+# non-zero `label edit`), which ended the run before any merge on liquid-city.
+
 # Tiers (Replaces Priorities)
+gh label create "tier-1" --color "d73a4a" --description "Immediate priority - next 1-2 PRs" --repo $Repo 2>$null
 gh label edit "tier-1" --color "d73a4a" --description "Immediate priority - next 1-2 PRs" --repo $Repo 2>$null
+gh label create "tier-2" --color "fbca04" --description "Next release cycle" --repo $Repo 2>$null
 gh label edit "tier-2" --color "fbca04" --description "Next release cycle" --repo $Repo 2>$null
+gh label create "tier-3" --color "0e8a16" --description "Phase 4 / long-term architecture" --repo $Repo 2>$null
 gh label edit "tier-3" --color "0e8a16" --description "Phase 4 / long-term architecture" --repo $Repo 2>$null
 
 # Types
+gh label create "type: bug" --color "d73a4a" --description "Something is not working" --repo $Repo 2>$null
 gh label edit "type: bug" --color "d73a4a" --description "Something is not working" --repo $Repo 2>$null
+gh label create "type: feature" --color "a59758" --description "New feature or request" --repo $Repo 2>$null
 gh label edit "type: feature" --color "a59758" --description "New feature or request" --repo $Repo 2>$null
+gh label create "type: chore" --color "b1d3e7" --description "Maintenance, refactoring, or CI/CD" --repo $Repo 2>$null
 gh label edit "type: chore" --color "b1d3e7" --description "Maintenance, refactoring, or CI/CD" --repo $Repo 2>$null
+gh label create "type: epic" --color "041b3f" --description "Large, multi-issue initiatives" --repo $Repo 2>$null
 gh label edit "type: epic" --color "041b3f" --description "Large, multi-issue initiatives" --repo $Repo 2>$null
+gh label create "type: docs" --color "0075ca" --description "Improvements to documentation" --repo $Repo 2>$null
 gh label edit "type: docs" --color "0075ca" --description "Improvements to documentation" --repo $Repo 2>$null
+gh label create "type: security" --color "ff0000" --description "Security vulnerabilities or hardening" --repo $Repo 2>$null
 gh label edit "type: security" --color "ff0000" --description "Security vulnerabilities or hardening" --repo $Repo 2>$null
 
 # Scopes / Domains
+gh label create "scope: cli" --color "de89ff" --description "Issues related to the CLI package" --repo $Repo 2>$null
 gh label edit "scope: cli" --color "de89ff" --description "Issues related to the CLI package" --repo $Repo 2>$null
+gh label create "scope: core" --color "de89ff" --description "Issues related to the Core engine package" --repo $Repo 2>$null
 gh label edit "scope: core" --color "de89ff" --description "Issues related to the Core engine package" --repo $Repo 2>$null
+gh label create "scope: mcp" --color "de89ff" --description "Issues related to the MCP server package" --repo $Repo 2>$null
 gh label edit "scope: mcp" --color "de89ff" --description "Issues related to the MCP server package" --repo $Repo 2>$null
+gh label create "scope: ci" --color "32c597" --description "GitHub Actions, Turbo, or build pipelines" --repo $Repo 2>$null
 gh label edit "scope: ci" --color "32c597" --description "GitHub Actions, Turbo, or build pipelines" --repo $Repo 2>$null
+gh label create "domain: architecture" --color "1edb45" --description "System design and structural decisions" --repo $Repo 2>$null
 gh label edit "domain: architecture" --color "1edb45" --description "System design and structural decisions" --repo $Repo 2>$null
+gh label create "domain: ux" --color "1edb45" --description "Terminal UI, CLI output, and user experience" --repo $Repo 2>$null
 gh label edit "domain: ux" --color "1edb45" --description "Terminal UI, CLI output, and user experience" --repo $Repo 2>$null
+gh label create "domain: strategy" --color "1edb45" --description "Product and execution strategy decisions" --repo $Repo 2>$null
 gh label edit "domain: strategy" --color "1edb45" --description "Product and execution strategy decisions" --repo $Repo 2>$null
 
 # Status / Meta
+gh label create "status: blocked" --color "dda26d" --description "Blocked by external dependency" --repo $Repo 2>$null
 gh label edit "status: blocked" --color "dda26d" --description "Blocked by external dependency" --repo $Repo 2>$null
+gh label create "status: investigation" --color "cfd3d7" --description "Research or spike" --repo $Repo 2>$null
 gh label edit "status: investigation" --color "cfd3d7" --description "Research or spike" --repo $Repo 2>$null
 
 # Dispositions (issue pre-registration; the six fixed outcomes)
-# Two lines per label: `create` makes it exist (an error on an existing label is
-# suppressed), `edit` converges its colour and description on every run AND is
-# the line both canon parsers read -- a `create` line is invisible to them.
 gh label create "disposition: premise-changed" --color "6f42c1" --description "UPDATE — the premise moved; a human rewrites or rules; stays open" --repo $Repo 2>$null
 gh label edit "disposition: premise-changed" --color "6f42c1" --description "UPDATE — the premise moved; a human rewrites or rules; stays open" --repo $Repo 2>$null
 gh label create "disposition: horizon" --color "6f42c1" --description "HOLD (Horizon) — premise valid, not now; open, label only, no card" --repo $Repo 2>$null

--- a/scripts/sync-labels.ps1
+++ b/scripts/sync-labels.ps1
@@ -104,8 +104,41 @@ function Merge-Label {
         return
     }
 
-    # Every issue that carried the old label now carries the new one: retire it
+    # The migration read is capped (--limit 1000): a label on more issues than the
+    # cap lists a subset, and deleting after relabelling only that subset strips
+    # the rest (Greptile P1 on mmnto-ai/totem#2839). One more read, limit 1, asks
+    # whether ANY issue still carries the old label; a remainder or a failed read
+    # keeps the label, and the next run continues the migration.
+    $remaining = gh issue list --label $OldName --repo $Repo --state all --limit 1 --json number --jq '.[].number' | Out-String
+    if ($LASTEXITCODE -ne 0) {
+        $script:Failures.Add("issue list $OldName (recheck)")
+        Write-Host "[Error] gh issue list '$OldName' recheck failed (exit $LASTEXITCODE) -- keeping '$OldName'" -ForegroundColor Red
+        return
+    }
+    if (@($remaining -split '\s+' | Where-Object { $_ -ne '' }).Count -gt 0) {
+        $script:Failures.Add("issue list $OldName (issues remain past the 1000-issue read cap)")
+        Write-Host "[Error] keeping '$OldName': issues still carry it after the relabel pass (the read is capped at 1000) -- re-run to continue the migration" -ForegroundColor Red
+        return
+    }
+
+    # Every issue that carried the old label now carries the new one: retire it.
+    # `label delete` fails on an already-retired name by design (2>$null, never
+    # tallied), so a failure is VERIFIED rather than assumed benign: the exact
+    # name is read back -- absent is a no-op, present or unreadable means the
+    # taxonomy did not converge (CodeRabbit on mmnto-ai/totem#2839).
     gh label delete $OldName --yes --repo $Repo 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        $present = gh label list --repo $Repo --search $OldName --limit 100 --json name --jq ".[] | select(.name == `"$OldName`") | .name" | Out-String
+        if ($LASTEXITCODE -ne 0) {
+            $script:Failures.Add("label delete $OldName (unverified)")
+            Write-Host "[Error] gh label delete '$OldName' failed and the label could not be read back -- keeping '$OldName'" -ForegroundColor Red
+            return
+        }
+        if ($present.Trim().Length -gt 0) {
+            $script:Failures.Add("label delete $OldName")
+            Write-Host "[Error] gh label delete '$OldName' failed and the label is still present" -ForegroundColor Red
+        }
+    }
 }
 
 Write-Host "Updating canonical labels..." -ForegroundColor Yellow


### PR DESCRIPTION
## What

`scripts/sync-labels.ps1` was unsafe on any repo that never carried the label taxonomy, in two ways seen live on 2026-09-08. (1) Only the six `disposition:` names had a `gh label create` + `gh label edit` pair; the other 18 canonicals were `edit`-only, and the shadow `gh` tallies a non-zero `label edit` as a convergence failure, so liquid-city's dry run showed the armed run would edit the three tiers, reach `type: bug` and exit before any merge. (2) totem-status's armed run went further: every `gh issue edit --add-label "type: bug"` failed on the absent canonical and `Merge-Label` deleted `bug`, `enhancement` and `documentation` anyway, leaving their issues with no replacement (repaired by hand within the minute). This PR gives every canonical the pair and gates the delete on the relabel, serving mmnto-ai/totem#2837 (scope recorded on the issue).

## How

Root causes: the `create` twin was added for the disposition namespace only (mmnto-ai/totem#2792) and the other five namespaces were assumed present, which held on totem and strategy and on no other repo; and `Merge-Label` deleted the legacy name unconditionally after its relabel loop.

- **Create pairs.** A `gh label create` line is inserted immediately before each of the 18 `gh label edit` lines with identical arguments (18 insertions, no other line moved), and the two-lines-per-label comment moves up to cover every namespace. The `create` line is expected-fail on an existing label and the shadow already exempts it from the tally; the `edit` line keeps carrying the convergence and stays the only line the two canon readers regex (`packages/core/src/parity-label-canon.ts`, strategy's `tools/gh-parity-twins.cjs`), so the derived canon is unchanged at 24. A create-if-missing helper was not used: the readers forbid refactoring the literal lines.
- **Gated delete.** `Merge-Label` records the mutation tally before its relabel loop and, when any `issue edit` failed, keeps the old label and prints one line naming the count. A non-zero exit from `gh issue list` is treated as a failed READ, not an empty list: the label is kept and the failure is tallied. Probed before choosing this: listing by a label the repo never carried returns an empty list with exit 0, so the gate cannot fire on a fresh repo's absent legacy names.
- **Recheck past the read cap** (Greptile P1, bot round). The migration read is `--limit 1000`; a label on more issues than that lists a subset. After the relabel pass one more read, limit 1, asks whether any issue still carries the label; a remainder keeps the label, names the cap and counts against convergence, and the next run continues the migration.
- **Verified delete** (CodeRabbit, bot round). `gh label delete` fails on an already-retired name by design and was never tallied, so a delete that failed for any other reason left the label under "sync complete". On a non-zero delete the exact name is read back through `gh label list --search` filtered to equality: absent is a no-op, present or unreadable is tallied.

## Verification

- `pnpm build`: 6 successful, 6 total.
- `sync-labels-forms.test.ts`: 17 passed. `parity-label-canon.test.ts`: 27 passed (the canon still derives exactly 24).
- `pnpm format:check`: all matched files use Prettier code style. `eslint` on the changed test: clean. `totem lint`: PASS, 0 errors.
- Tests, and why each fails on the pre-fix code:
  - The `-WhatIf` dry run expects a `create` per canonical (70 rendered calls, from 52) and checks each canonical's `create` line immediately precedes its `edit` line. Pre-fix: `expected 52 to be 70`, verified by stashing the script.
  - The normal run expects every canonical created, not only the six dispositions. Pre-fix: 6 of 24.
  - "a failed relabel keeps the old label": the stub lists issue #7 under every legacy label and refuses every `issue edit`; asserts one kept line per merge, zero `label delete` calls, exit 1. Pre-fix: 22 deletes ran (the totem-status shape), verified by stashing the script.
  - "a failed issue list keeps the old label": the stub exits 1 on `issue list`; asserts nothing relabelled or deleted, one read-failure line per merge, exit 1. Pre-fix: 22 deletes ran.
  - "an issue past the read cap keeps the old label": the stub answers the migration read with #7 and the limit-1 recheck with #7 again; asserts 22 relabels, 22 rechecks, zero deletes, exit 1. Pre-fold: 22 deletes ran.
  - "a failed delete of a label that remains fails the run": `label delete` exits 1 and `label list` still answers; asserts one still-present line per merge, exit 1, no "sync complete". Pre-fold: exit 0 with "sync complete".
  - Positive controls, so the gates cannot over-fire: "a converged relabel retires the old label" (one delete per merge, exit 0) and "a failed delete of an already-absent label is a no-op" (22 deletes attempted, 22 read-backs empty, exit 0).
  - "every canonical's create line carries exactly the colour and description of its edit twin" is a drift guard read from the script text (Greptile P2); it passes on this branch and fails the moment one line of a pair is edited alone.
- Not run here: an armed run against a taxonomy-less repo. status-claude's held re-run and lc-claude's armed run are the live verification and follow the merge.

## Review leg (doctrine/model-tiering § Review legs)

Not owed for the create pairs (18 insertions of one line shape mirroring the existing disposition pattern). The `Merge-Label` changes are PowerShell control flow with two positive controls and four negative controls executed against the real script; the operator's bot round (Gemini no findings; Greptile P1 + P2; CodeRabbit one major, all folded) stands as the review of record.

## Not in this PR

- The heading-truncation defect in `generateLessonHeading` (mmnto-ai/totem#2838), filed from the same mail batch.
- lc's conventional-commit vocabulary beside `type: *` (lc's operator's ruling).
- A sensed create-if-missing form the canon readers could tolerate (the readers' contract forbids it today).
- Re-applying the labels totem-status lost (done by hand on that seat before this PR existed).
- Paginating the migration read past 1000 in one run: the recheck makes the cap safe and a re-run continues; a paginated loop is a follow-up if a cohort repo ever carries a legacy label on more than a thousand issues.

## Related

Closes mmnto-ai/totem#2837
<!-- totem-close: #2837 -->

See mmnto-ai/totem#2827 (the label canon made canonical), mmnto-ai/totem#2792 (the issue forms and the disposition pairs), mmnto-ai/totem-strategy#472 (the charter's § 4b lane; the canon refresh after rung 5 waits on this merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HcDXuhkVZmqZkwXzQ66wCY
