### PR TITLE
chore(deps): bump @mmnto/strategy-doctrine 0.1.46 -> 0.1.47 (cohort-sync; freeze entry identical; carries the node-engine-floor parity row at the attestation rung, the plugins seat-scoping erratum, and the cohort-overlay § 5 model-of-record clause; mmnto-ai/totem-strategy#1291)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   },
   "optionalDependencies": {
     "@mmnto/cli": "workspace:*",
-    "@mmnto/strategy-doctrine": "0.1.46"
+    "@mmnto/strategy-doctrine": "0.1.47"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,8 +46,8 @@ importers:
         specifier: workspace:*
         version: link:packages/cli
       '@mmnto/strategy-doctrine':
-        specifier: 0.1.46
-        version: 0.1.46
+        specifier: 0.1.47
+        version: 0.1.47
 
   packages/cli:
     dependencies:
@@ -862,8 +862,8 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mmnto/strategy-doctrine@0.1.46':
-    resolution: {integrity: sha512-JeXS3eQW6tNex83vMsfAVOSpvDyZroomDE1KFO1xKAnMwNd7pcVw/CTT7+UEei0B2H+atMY2WgtxC9OP7tN12w==}
+  '@mmnto/strategy-doctrine@0.1.47':
+    resolution: {integrity: sha512-KH9exqazdq5Ip3yrhpxhroPsY8idtO2LWCHfwTCBQVIbmzkFoRos6lXHHthW2CiQqVxnUtHxoIJ5n8/7E9qsFg==}
 
   '@modelcontextprotocol/sdk@1.27.1':
     resolution: {integrity: sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==}
@@ -3694,7 +3694,7 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mmnto/strategy-doctrine@0.1.46':
+  '@mmnto/strategy-doctrine@0.1.47':
     optional: true
 
   '@modelcontextprotocol/sdk@1.27.1(zod@3.25.76)':


### PR DESCRIPTION
## Cohort pin bump: `@mmnto/strategy-doctrine` 0.1.46 → 0.1.47

The bump strategy-claude's 2026-09-08T18:14Z dispatch named as this seat's lane, after mmnto-ai/totem-strategy#1294 merged (a8f138d0) and published 0.1.47 (npm `latest`, verified 18:1xZ by strategy and again here). Same shape as mmnto-ai/totem#2832: `package.json` and `pnpm-lock.yaml` only.

### What rides in 0.1.47 (diffed between the two installed trees)

- **`parity-manifest.yaml`** — the new `node-engine-floor` row (dimension `toolchain-version`; canonical source `mmnto-ai/totem:packages/cli/package.json#engines.node`; `manifestation: attestation`, `last-attested: 2026-09-08`; tracking issue mmnto-ai/totem#2842). It rides the attestation rung until totem's doctor carries the workflow reader, so `totem doctor` senses nothing new from it yet; totem's thirteen `setup-node` steps already run 24. The plugins-dimension seat-scoping comment retires its "no plugin layer" gloss (erratum; the ruling's ground is Tenet 16 alone).
- **`cohort-overlay.md` § 5** — a declared `model:` on a review leg is a request; where a runtime record exists, the model of record is its attestation (the doctrine side of mmnto-ai/totem#2845).
- **`strategy-doctrine.lock`** — the 0.1.47 content hashes and publish sha.
- **`freeze.json`** — byte-identical to 0.1.46: the rule-compilation freeze this repo honours is unchanged.

### Verification

- Installed in an npm-authed shell (`npm whoami` → the operator's login), the mmnto-ai/totem-strategy#630 class: `grep -c "strategy-doctrine@" pnpm-lock.yaml` → 2; `node_modules/@mmnto/strategy-doctrine/package.json` → `0.1.47`.
- Full workspace build + test on the bumped tree: 12/12 turbo tasks green (`pnpm build` then `pnpm test`, exit 0).

Reply to strategy-claude with the merge sha follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKX3XdibxYeiV3AwETsykH
