### PR TITLE
chore(lessons): sixteen lessons from mmnto-ai/totem#2839, mmnto-ai/totem#2843, mmnto-ai/totem#2844 and mmnto-ai/totem#2852, plus the uncommitted mail-mark lesson banked by MCP on 2026-09-08 — the label-migration lesson hand-edited to the cause mmnto-ai/totem#2849 corrected; compile untouched under the freeze

### DIFF
--- a/.totem/lessons/lesson-0636650a.md
+++ b/.totem/lessons/lesson-0636650a.md
@@ -1,0 +1,6 @@
+## Lesson — Automate fixture receipt generation
+
+**Tags:** testing, automation
+**Scope:** packages/core/src/**/*.test.ts, !**/*.spec.*
+
+Generate and verify fixture metadata (like SHA256 hashes and timestamps) programmatically to prevent manual transcription errors that lead to mismatched test states.

--- a/.totem/lessons/lesson-296c72de.md
+++ b/.totem/lessons/lesson-296c72de.md
@@ -1,0 +1,7 @@
+## Lesson — totem mail mark does not resolve the bare filename
+
+**Tags:** mail, ecl, trap, cli
+
+`totem mail mark` does not resolve the bare filename that `totem mail` displays — it opens the argument relative to cwd and fails ENOENT (mmnto-ai/totem#2527 still open as of cli 2.2.1). Mark by the full `filePath` from `totem mail --json`, then re-poll to confirm clean. Also still true on 2.2.1: `mail send` derives a filename whose subject-kebab truncates before the sender seat short — rename the outbox file to carry `-<seat>` after every send.
+
+**Source:** mcp (added at 2026-09-08T20:48:58.436Z)

--- a/.totem/lessons/lesson-2c52e6d6.md
+++ b/.totem/lessons/lesson-2c52e6d6.md
@@ -1,0 +1,6 @@
+## Lesson — Verify label absence before deletion
+
+**Tags:** github-api, automation, data-safety
+**Scope:** scripts/sync-labels.ps1
+
+When migrating GitHub labels, verify that no issue or PR still carries the legacy label before executing the destructive delete, and read that verification from the issues and pulls endpoints rather than the search index, which lags behind writes and can report a stale count (mmnto-ai/totem#2849 corrected the run that blamed a 1000-issue cap). A label delete strips PRs as well as issues, so a migration that moved issues only still loses the PRs' label.

--- a/.totem/lessons/lesson-48728335.md
+++ b/.totem/lessons/lesson-48728335.md
@@ -1,0 +1,6 @@
+## Lesson — Guard dictionary lookups against prototype pollution
+
+**Tags:** typescript, security
+**Scope:** packages/core/src/orchestration-resolver.ts
+
+Direct lookups on plain JavaScript objects can accidentally resolve inherited prototype properties like toString or constructor. Restricting lookups to own properties or using null-prototype objects prevents unexpected resolution failures.

--- a/.totem/lessons/lesson-7e38c567.md
+++ b/.totem/lessons/lesson-7e38c567.md
@@ -1,0 +1,6 @@
+## Lesson — Ignore code blocks when parsing severity
+
+**Tags:** parsing, markdown, security
+**Scope:** packages/core/src/merge-ready.ts
+
+When parsing bot comments for severity markers, strip code blocks and fenced spans first to prevent false positives from quoted source code or docstrings.

--- a/.totem/lessons/lesson-7e74e505.md
+++ b/.totem/lessons/lesson-7e74e505.md
@@ -1,0 +1,6 @@
+## Lesson — Sanitize shell comments
+
+**Tags:** cli, shell, security
+**Scope:** packages/cli/**/*.ts, !**/*.test.*
+
+CLI wrappers projecting shell commands must blank out comments, arithmetic expansions, and join backslash-newline continuations to prevent bypasses or misparsed arguments.

--- a/.totem/lessons/lesson-83be51da.md
+++ b/.totem/lessons/lesson-83be51da.md
@@ -1,0 +1,6 @@
+## Lesson — Verify multiple indicators for bot detection
+
+**Tags:** github-api, security, bot-detection
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Relying solely on login names to identify GitHub bots can allow App integrations to be misclassified as human. Check the GraphQL `typename`, the `[bot]` suffix, and explicit identity lists to ensure robust bot detection.

--- a/.totem/lessons/lesson-97b202c1.md
+++ b/.totem/lessons/lesson-97b202c1.md
@@ -1,0 +1,6 @@
+## Lesson — REST pagination merges arrays automatically
+
+**Tags:** github-cli, rest-api, pagination
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+When using `gh api --paginate` on REST endpoints, the GitHub CLI automatically merges paginated results into a single JSON array. Do not use `--slurp` or attempt manual page-array flattening, as this will corrupt the parsed output.

--- a/.totem/lessons/lesson-995164f8.md
+++ b/.totem/lessons/lesson-995164f8.md
@@ -1,0 +1,6 @@
+## Lesson — Avoid action wrappers for CLI preconditions
+
+**Tags:** cli, commander, error-handling
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+Running CLI tool checks or preconditions inside Commander action wrappers can bypass the subcommand's internal runner. This prevents the command from returning structured JSON error payloads when a dependency is missing.

--- a/.totem/lessons/lesson-9a0e6466.md
+++ b/.totem/lessons/lesson-9a0e6466.md
@@ -1,0 +1,6 @@
+## Lesson — Prefer execution allowlists over denylists
+
+**Tags:** testing, mocking, security
+**Scope:** packages/cli/src/**/*.ts, !**/*.test.*, !**/*.spec.*
+
+When mocking or spying on shell executions to prevent mutations during dry runs, use an allowlist of exact permitted shapes. Denylists are fragile and can let unexpected mutating command variants escape assertion.

--- a/.totem/lessons/lesson-a9918708.md
+++ b/.totem/lessons/lesson-a9918708.md
@@ -1,0 +1,6 @@
+## Lesson — GraphQL bot logins lack bot suffixes
+
+**Tags:** github-api, graphql, authentication
+**Scope:** packages/core/src/bot-identity.ts
+
+Unlike REST APIs, GitHub's GraphQL API does not append the `[bot]` suffix to bot logins, requiring an exact login lookup list alongside loose pattern matching.

--- a/.totem/lessons/lesson-b3637cbf.md
+++ b/.totem/lessons/lesson-b3637cbf.md
@@ -1,0 +1,6 @@
+## Lesson — Scrub ambient Git environment variables
+
+**Tags:** git, testing, subprocess
+**Scope:** packages/core/src/sys/git.ts
+
+Ambient Git environment variables like GIT_DIR can leak into spawned subprocesses and corrupt local repository resolution. Scrubbing these variables from the environment before running Git commands ensures deterministic behavior.

--- a/.totem/lessons/lesson-b8b0239c.md
+++ b/.totem/lessons/lesson-b8b0239c.md
@@ -1,0 +1,6 @@
+## Lesson — Verify CLI deletions
+
+**Tags:** cli, automation, error-handling
+**Scope:** scripts/sync-labels.ps1
+
+Command-line deletions can fail for reasons other than the resource already being absent. Verifying the deletion by querying the resource's existence prevents false-positive convergence reports when a delete command fails silently.

--- a/.totem/lessons/lesson-dc9ff85c.md
+++ b/.totem/lessons/lesson-dc9ff85c.md
@@ -1,0 +1,6 @@
+## Lesson — Pair label creation with edits
+
+**Tags:** github-api, automation, idempotency
+**Scope:** scripts/sync-labels.ps1
+
+Running metadata edits on non-existent GitHub labels causes synchronization failures on fresh repositories. Preceding every edit command with an expected-fail creation command ensures idempotency across all environments.

--- a/.totem/lessons/lesson-df854a67.md
+++ b/.totem/lessons/lesson-df854a67.md
@@ -1,0 +1,6 @@
+## Lesson — Lock head SHA during pagination
+
+**Tags:** github-api, graphql, concurrency
+**Scope:** packages/core/src/merge-ready.ts
+
+When paginating through API responses for a PR, verify the head SHA on every page against the initial read to prevent evaluating a moving target if a new commit is pushed mid-read.

--- a/.totem/lessons/lesson-e3d92402.md
+++ b/.totem/lessons/lesson-e3d92402.md
@@ -1,0 +1,6 @@
+## Lesson — Key repository maps on Git origin
+
+**Tags:** git, worktrees, orchestration
+**Scope:** packages/core/src/orchestration-resolver.ts
+
+Keying repository maps on directory basenames fails in Git worktrees or renamed clones. Parsing the remote origin URL instead provides a stable repository identifier across different checkouts.


### PR DESCRIPTION
## What

Post-merge lesson extraction for the four substantive merges of 2026-09-08: mmnto-ai/totem#2839 (sync-labels: every canonical a create+edit pair), mmnto-ai/totem#2843 (signon derives the seat first; the cohort map keyed on the git origin), mmnto-ai/totem#2844 (the merge-ready gate) and mmnto-ai/totem#2852 (`totem resolve-threads`). Fifteen lessons written by `totem lesson extract 2839 2843 2844 2852 --yes` at `9ce020bb` (3 + 3 + 5 + 4), plus one lesson banked by MCP `add_lesson` on 2026-09-08 that had never been committed (`lesson-296c72de`, the mail-mark path nuance; mmnto-ai/totem#2527 is still OPEN, so its claim stands as dated).

## How

Each lesson restates a finding the bot rounds folded or a leg confirmed: prototype-safe map lookups and origin-keyed repository maps (mmnto-ai/totem#2843); code-block stripping before severity parsing, the head-SHA lock across pages, shell-comment projection, GraphQL logins without the `[bot]` suffix and the multi-indicator bot test (mmnto-ai/totem#2844); the `gh api --paginate` array shape, Commander action wrappers bypassing the runner, execution allowlists in dry-run mocks (mmnto-ai/totem#2852); create-before-edit pairs and deletion verification (mmnto-ai/totem#2839). Read in full. **One hand edit, disclosed:** `lesson-2c52e6d6` (verify label absence before deletion) was drafted with the cause the round blamed — a 1000-issue search cap — which mmnto-ai/totem#2849 later corrected to a lagging search index; the lesson now names the corrected cause and the PR-stripping datum from the same issue. The other fifteen are kept as drafted.

## Verification

- Sixteen additions under `.totem/lessons/`; `git diff --stat` matches the extract's output plus the one MCP file.
- Push gate: `totem lint` (lesson files are filtered by the ignore patterns), claim-discipline, legs gate (not owed), `format:check` (clean).
- No `totem lesson compile` (the rule-compilation freeze of 2026-05-17 stands); lesson-only manifest staleness warns by design.
- Tests: none; lessons are corpus, not code.

## Review leg (doctrine/model-tiering § Review legs)

Not owed: corpus files, no code path.

## Not in this PR

- No changeset (no package touched).
- mmnto-ai/totem#2848 (the strategy-doctrine pin bump, two files) is not extracted — a pin bump, per the standing convention.
- mmnto-ai/totem#2850 (Version Packages) is not a source.

## Related

mmnto-ai/totem#2839, mmnto-ai/totem#2843, mmnto-ai/totem#2844, mmnto-ai/totem#2852 (the sources); mmnto-ai/totem#2836 (the previous lessons PR); mmnto-ai/totem#2849 (the corrected cause in the hand-edited lesson).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UEFs7GcBowjFEjbEKSGC8r
